### PR TITLE
#2460: emit RT_FLOW SESSION_CLOSE so userspace NetFlow/IPFIX session-close export fires

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12205,3 +12205,53 @@ top.
   pkg/config/dual_ast_differential_test.go,
   pkg/dataplane/userspace/flow_wire_coerce_test.go,
   test/incus/xpf-test.conf, docs/feature-gaps.md, _Log.md
+- **Timestamp**: 2026-06-23
+- **Action**: #2460 (P1) — emit RT_FLOW SESSION_CLOSE on the raw
+  dataplane-event channel so NetFlow v9 / IPFIX session-close export fires
+  in userspace AF_XDP mode. Root cause: the userspace dataplane emitted a
+  session close ONLY as the minimal type-2 MSG_SESSION_CLOSE HA
+  session-sync delta (SessionDeltaInfo channel → handleEventStreamDelta),
+  never as an RT_FLOW SESSION_CLOSE EventRecord on the raw channel
+  (SetOnRawDataplaneEvent → eventReader.ProcessRawEvent) the flow
+  exporters consume — so flowExportCallback/ipfixExportCallback
+  early-returned on rec.Type != "SESSION_CLOSE" and never ran. Field
+  comparison: the type-2 delta is minimal (AF/proto/ports/IPs/ownerRG/
+  flags/zone-ids) and carries NO byte/packet counters, NAT tuple, or
+  duration, so Option B (build the record from the delta) was infeasible →
+  Option A (enrich the wire). Added MSG_SESSION_CLOSE_RT_FLOW (type 14)
+  carrying the canonical 136-byte dataplane.Event payload with the
+  event-type byte = RT_FLOW SESSION_CLOSE (2), emitted ADDITIVELY at the
+  single close-drain SSOT (flush_session_deltas) as a 1:1 pair with the
+  unchanged type-2 HA delta (no double-emit; HA session sync untouched).
+  Go side routes type 14 through the existing
+  decodeDataplaneEventPayload/ProcessRawEvent path (which already decodes a
+  136-byte SESSION_CLOSE fully). Record carries the real 5-tuple, NAT
+  tuple, zones, protocol; byte/packet counters + duration are 0 because the
+  AF_XDP forwarding path keeps no per-session accounting — deferred to
+  #2501 (P2), documented honestly in code + docs + tests (assert == 0, not
+  non-zero). Wire parity: Rust encode_session_close_rt_flow byte layout is
+  byte-identical to the Go logging.DecodeRawEventRecord/logEvent reads
+  (offsets/endianness pinned by tests on both sides); frame-type constant
+  14 pinned in Rust (test_event_frame_type_values_are_stable) AND Go
+  (TestEventFrameTypeSessionCloseConstant). Tests (fail-on-revert proven by
+  reverting the event-type byte and the Go dispatch case): Rust codec v4/v6
+  layout + frame-type stability + emit pairing (exactly one type-2 + one
+  type-14 per close) + Open-delta no-op; Go end-to-end through the real
+  NetFlow+IPFIX flowexport callbacks (exactly one SESSION_CLOSE record,
+  correct tuple, counters 0) + negative (POLICY_DENY does not hit the
+  close gate) + full frame-routing through the EventStream socket. All Rust
+  (2626) + Go (daemon/logging/flowexport/userspace) tests green; new tests
+  5x stable; protocol_wire_v1.json contract test unaffected (event-stream
+  binary protocol, not the JSON control protocol).
+- **File(s)**: userspace-dp/src/event_stream/codec.rs,
+  userspace-dp/src/event_stream/codec_tests.rs,
+  userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/event_stream/tests.rs,
+  userspace-dp/src/event_stream/README.md,
+  userspace-dp/src/afxdp/session_delta.rs,
+  pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/eventstream.go,
+  pkg/dataplane/userspace/eventstream_test.go,
+  pkg/dataplane/userspace/flow.go,
+  pkg/daemon/daemon_flowexport_session_close_test.go,
+  pkg/flowexport/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -12255,3 +12255,28 @@ top.
   pkg/dataplane/userspace/flow.go,
   pkg/daemon/daemon_flowexport_session_close_test.go,
   pkg/flowexport/README.md, _Log.md
+- **Timestamp**: 2026-06-23
+- **Action**: #2460 (PR #2502) review folds (4): (1) codec.rs doc comment
+  no longer claims the SESSION_CLOSE RT_FLOW record carries "owner RG" —
+  owner_rg_id is intentionally NOT written (it overlaps the [56:64]
+  session-packets slot the Go decoder reads for a close); carried on the
+  type-2 HA delta instead. (2) byte[54] reworded from "inert" to: the Go
+  decoder DOES map it to EventRecord.Action and logs it for SESSION_CLOSE,
+  but a close has no action semantics so it is intentionally 0 (harmless,
+  not unread). (3) corrected the "created drives ElapsedTime" claim in
+  codec.rs + both READMEs + flow.go: the exporters derive flow duration
+  from the packet count (estimateSessionDuration(SessionPkts)), NOT the
+  `created`/ElapsedTime field, so duration is 0 today only because the
+  counters are 0 (#2501). (4) strengthened the daemon end-to-end test to
+  match its "reaches BOTH NetFlow + IPFIX callbacks" claim: it now binds
+  real UDP collectors and asserts BOTH real exporters export >= 1 flow
+  record (Stats.flows, which counts data records not templates) AND two
+  distinct SESSION_CLOSE-gated fanout callbacks each fire exactly once with
+  the correct tuple. Fail-on-revert proven (dropping either fanout
+  registration drops its count to 0). All Rust (build clean, codec +
+  session_close tests) + Go (daemon, dataplane/userspace) green; new
+  daemon tests 5x stable; gofmt clean.
+- **File(s)**: userspace-dp/src/event_stream/codec.rs,
+  userspace-dp/src/event_stream/README.md, pkg/flowexport/README.md,
+  pkg/dataplane/userspace/flow.go,
+  pkg/daemon/daemon_flowexport_session_close_test.go, _Log.md

--- a/pkg/daemon/daemon_flowexport_session_close_test.go
+++ b/pkg/daemon/daemon_flowexport_session_close_test.go
@@ -1,0 +1,181 @@
+package daemon
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// buildSessionCloseRawEventV4 builds the canonical 136-byte dataplane.Event
+// RT_FLOW payload for a SESSION_CLOSE, byte-for-byte mirroring the Rust
+// EventFrame::encode_session_close_rt_flow encoder
+// (userspace-dp/src/event_stream/codec.rs). This is the #2460 cross-language
+// wire-parity anchor: the offsets/endianness here MUST match the Rust
+// encoder, and the resulting bytes MUST decode to a Type=="SESSION_CLOSE"
+// EventRecord via logging.DecodeRawEventRecord / EventReader.ProcessRawEvent.
+//
+// Volume counters (offsets 56/64/112/120) and the created stamp (offset 108)
+// are intentionally 0 — the userspace dataplane does not yet maintain
+// per-session byte/packet accounting (tracked in #2501).
+func buildSessionCloseRawEventV4(
+	proto uint8,
+	srcIP, dstIP [4]byte,
+	srcPort, dstPort uint16,
+	natSrcIP [4]byte,
+	natSrcPort uint16,
+	ingressZone, egressZone uint16,
+) []byte {
+	buf := make([]byte, int(unsafe.Sizeof(dataplane.Event{})))
+	// [8:12] src ip, [24:28] dst ip (16-byte slots, v4 left-aligned).
+	copy(buf[8:12], srcIP[:])
+	copy(buf[24:28], dstIP[:])
+	// [40:42] src port, [42:44] dst port — BIG-endian.
+	binary.BigEndian.PutUint16(buf[40:42], srcPort)
+	binary.BigEndian.PutUint16(buf[42:44], dstPort)
+	// [48:50] ingress zone, [50:52] egress zone — little-endian.
+	binary.LittleEndian.PutUint16(buf[48:50], ingressZone)
+	binary.LittleEndian.PutUint16(buf[50:52], egressZone)
+	// [52] event type = SESSION_CLOSE (2); [53] protocol; [55] addr family.
+	buf[52] = dataplane.EventTypeSessionClose
+	buf[53] = proto
+	buf[55] = dataplane.AFInet
+	// [72:76] nat src ip, [104:106] nat src port (BIG-endian).
+	copy(buf[72:76], natSrcIP[:])
+	binary.BigEndian.PutUint16(buf[104:106], natSrcPort)
+	return buf
+}
+
+// TestSessionCloseRawEventDrivesFlowExport is the #2460 end-to-end (P1)
+// assertion: a userspace SESSION_CLOSE RT_FLOW event delivered on the raw
+// dataplane-event channel (exactly the path SetOnRawDataplaneEvent ->
+// eventReader.ProcessRawEvent uses for the EventFrameTypeSessionClose frame)
+// produces exactly one Type=="SESSION_CLOSE" EventRecord that reaches BOTH
+// the NetFlow v9 and IPFIX flow-export callbacks, carrying the correct
+// 5-tuple. Volume counters are 0 (P2/#2501).
+//
+// Fail-on-revert: without the helper emitting the type-14 SESSION_CLOSE
+// frame, no SESSION_CLOSE EventRecord is ever produced in userspace mode, so
+// the flowExportCallback / ipfixExportCallback early-return on
+// rec.Type != "SESSION_CLOSE" and never fire — exactly the #2460 defect.
+func TestSessionCloseRawEventDrivesFlowExport(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+
+	// rate=1 so ShouldExport always admits the close (deterministic).
+	if !d.reconcileFlowExporters(ipfixSamplingConfig("127.0.0.1", 1)) {
+		t.Fatal("flow + ipfix exporters must start")
+	}
+	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+		t.Fatal("v9 exporter must be live")
+	}
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+		t.Fatal("ipfix exporter must be live")
+	}
+
+	// Spy callback gating identically to the real flow-export callbacks.
+	// Registered AFTER the two real callbacks so all three see the record.
+	var sessionCloses []logging.EventRecord
+	d.eventReader.AddCallback(func(rec logging.EventRecord, _ []byte) {
+		if rec.Type != "SESSION_CLOSE" {
+			return
+		}
+		sessionCloses = append(sessionCloses, rec)
+	})
+
+	payload := buildSessionCloseRawEventV4(
+		6, // TCP
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		12345, 443,
+		[4]byte{172, 16, 80, 8}, 40000,
+		2, 3, // trust -> untrust
+	)
+
+	if !d.eventReader.ProcessRawEvent(payload) {
+		t.Fatal("ProcessRawEvent rejected a valid SESSION_CLOSE payload")
+	}
+
+	if len(sessionCloses) != 1 {
+		t.Fatalf("expected exactly one SESSION_CLOSE record, got %d", len(sessionCloses))
+	}
+	rec := sessionCloses[0]
+	if rec.Type != "SESSION_CLOSE" {
+		t.Fatalf("Type = %q, want SESSION_CLOSE", rec.Type)
+	}
+	if rec.SrcAddr != "10.0.1.102:12345" {
+		t.Fatalf("SrcAddr = %q, want 10.0.1.102:12345", rec.SrcAddr)
+	}
+	if rec.DstAddr != "172.16.80.200:443" {
+		t.Fatalf("DstAddr = %q, want 172.16.80.200:443", rec.DstAddr)
+	}
+	if rec.Protocol != "TCP" {
+		t.Fatalf("Protocol = %q, want TCP", rec.Protocol)
+	}
+	if rec.NATSrcAddr != "172.16.80.8:40000" {
+		t.Fatalf("NATSrcAddr = %q, want 172.16.80.8:40000", rec.NATSrcAddr)
+	}
+	if rec.InZone != 2 || rec.OutZone != 3 {
+		t.Fatalf("zones = (%d,%d), want (2,3)", rec.InZone, rec.OutZone)
+	}
+	// #2501: volume counters are 0 until per-session accounting lands. This
+	// is asserted explicitly (NOT non-zero) — the P1 fix wires the record
+	// through; the P2 follow-up populates the volume.
+	if rec.SessionPkts != 0 || rec.SessionBytes != 0 {
+		t.Fatalf("counters = (%d,%d), want (0,0) pending #2501",
+			rec.SessionPkts, rec.SessionBytes)
+	}
+	if rec.RevSessionPkts != 0 || rec.RevSessionBytes != 0 {
+		t.Fatalf("rev counters = (%d,%d), want (0,0) pending #2501",
+			rec.RevSessionPkts, rec.RevSessionBytes)
+	}
+}
+
+// TestNonSessionCloseRawEventDoesNotDriveFlowExport is the negative half of
+// the fail-on-revert proof: a NON-close RT_FLOW event (policy deny) on the
+// same raw channel must NOT reach the session-close export gate. If a future
+// change broadened the gate (or mislabeled the close), this catches it.
+func TestNonSessionCloseRawEventDoesNotDriveFlowExport(t *testing.T) {
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+	if !d.reconcileFlowExporters(ipfixSamplingConfig("127.0.0.1", 1)) {
+		t.Fatal("exporters must start")
+	}
+
+	var sessionCloses int
+	d.eventReader.AddCallback(func(rec logging.EventRecord, _ []byte) {
+		if rec.Type == "SESSION_CLOSE" {
+			sessionCloses++
+		}
+	})
+
+	// A POLICY_DENY raw event (event-type byte 3, not 2).
+	payload := buildSessionCloseRawEventV4(
+		6,
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		12345, 443,
+		[4]byte{}, 0,
+		2, 3,
+	)
+	payload[52] = dataplane.EventTypePolicyDeny
+
+	if !d.eventReader.ProcessRawEvent(payload) {
+		t.Fatal("ProcessRawEvent rejected a valid POLICY_DENY payload")
+	}
+	if sessionCloses != 0 {
+		t.Fatalf("a POLICY_DENY must not produce a SESSION_CLOSE record, got %d", sessionCloses)
+	}
+}
+
+// TestEventFrameTypeSessionCloseConstant pins the Go frame-type constant so a
+// drift from the Rust MSG_SESSION_CLOSE_RT_FLOW (14) is caught at unit level.
+func TestEventFrameTypeSessionCloseConstant(t *testing.T) {
+	if dpuserspace.EventFrameTypeSessionClose != 14 {
+		t.Fatalf("EventFrameTypeSessionClose = %d, want 14 (must match Rust MSG_SESSION_CLOSE_RT_FLOW)",
+			dpuserspace.EventFrameTypeSessionClose)
+	}
+}

--- a/pkg/daemon/daemon_flowexport_session_close_test.go
+++ b/pkg/daemon/daemon_flowexport_session_close_test.go
@@ -2,9 +2,12 @@ package daemon
 
 import (
 	"encoding/binary"
+	"net"
 	"testing"
+	"time"
 	"unsafe"
 
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/logging"
@@ -49,25 +52,91 @@ func buildSessionCloseRawEventV4(
 	return buf
 }
 
+// flowIPFIXConfigPorts builds a sampling config with the v9 and IPFIX
+// collectors bound to caller-chosen ports (so a test can bind a real UDP
+// listener for each and observe the transmitted datagram). rate=1 so
+// ShouldExport always admits the close.
+func flowIPFIXConfigPorts(addr string, v9Port, ipfixPort int) *config.Config {
+	cfg := flowSamplingConfig(addr, 1)
+	fam := cfg.ForwardingOptions.Sampling.Instances["s"].FamilyInet
+	fam.FlowServers[0].Port = v9Port
+	fam.FlowServers[0].Version = config.FlowServerVersion9
+	fam.FlowServers = append(fam.FlowServers, &config.FlowServer{
+		Address: addr, Port: ipfixPort, Version: config.FlowServerVersionIPFIX,
+	})
+	cfg.Services.FlowMonitoring.VersionIPFIX = &config.NetFlowIPFIXConfig{
+		Templates: map[string]*config.NetFlowIPFIXTemplate{"t": {Name: "t"}},
+	}
+	return cfg
+}
+
+// listenUDP binds a UDP socket on 127.0.0.1:0 and returns it plus its port.
+func listenUDP(t *testing.T) (*net.UDPConn, int) {
+	t.Helper()
+	pc, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	return pc, pc.LocalAddr().(*net.UDPAddr).Port
+}
+
+// waitFlows polls an exporter's Stats() until it reports at least one
+// EXPORTED FLOW RECORD (not a template — Stats.flows increments only in
+// sendRecords, never in sendTemplates), or the 3s deadline elapses. The
+// v9/IPFIX exporters flush queued records on a 100ms ticker started by
+// reconcile, so a SESSION_CLOSE admitted by ShouldExport becomes an
+// exported flow well within the deadline. A non-zero flow count is
+// close-specific: it proves the SESSION_CLOSE-derived FlowRecord reached
+// the real exporter and was transmitted, distinct from the unconditional
+// startup template datagram.
+func waitFlows(t *testing.T, stats func() (uint64, uint64)) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if flows, _ := stats(); flows >= 1 {
+			return flows
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	flows, _ := stats()
+	return flows
+}
+
 // TestSessionCloseRawEventDrivesFlowExport is the #2460 end-to-end (P1)
 // assertion: a userspace SESSION_CLOSE RT_FLOW event delivered on the raw
 // dataplane-event channel (exactly the path SetOnRawDataplaneEvent ->
 // eventReader.ProcessRawEvent uses for the EventFrameTypeSessionClose frame)
 // produces exactly one Type=="SESSION_CLOSE" EventRecord that reaches BOTH
 // the NetFlow v9 and IPFIX flow-export callbacks, carrying the correct
-// 5-tuple. Volume counters are 0 (P2/#2501).
+// 5-tuple. It proves "both callbacks" two ways:
+//
+//  1. The two REAL exporters (flowExportCallback / ipfixExportCallback,
+//     registered by reconcile) are bound to real UDP collectors and each
+//     transmits a datagram for the admitted close — proving the record
+//     truly reaches both production export paths, not just a spy.
+//  2. Two distinct fanout callbacks gating identically on
+//     rec.Type=="SESSION_CLOSE" (standing in for the NetFlow and IPFIX
+//     consumers) BOTH fire exactly once with the correct tuple — the
+//     deterministic content assertion the datagram-receipt cannot give.
+//
+// Volume counters are 0 (P2/#2501), asserted explicitly.
 //
 // Fail-on-revert: without the helper emitting the type-14 SESSION_CLOSE
 // frame, no SESSION_CLOSE EventRecord is ever produced in userspace mode, so
 // the flowExportCallback / ipfixExportCallback early-return on
 // rec.Type != "SESSION_CLOSE" and never fire — exactly the #2460 defect.
+// Dropping EITHER fanout callback registration drops its fire count to 0.
 func TestSessionCloseRawEventDrivesFlowExport(t *testing.T) {
+	v9Coll, v9Port := listenUDP(t)
+	t.Cleanup(func() { v9Coll.Close() })
+	ipfixColl, ipfixPort := listenUDP(t)
+	t.Cleanup(func() { ipfixColl.Close() })
+
 	d := newFlowTestDaemon()
 	t.Cleanup(d.stopFlowExporter)
 	t.Cleanup(d.stopIPFIXExporter)
 
-	// rate=1 so ShouldExport always admits the close (deterministic).
-	if !d.reconcileFlowExporters(ipfixSamplingConfig("127.0.0.1", 1)) {
+	if !d.reconcileFlowExporters(flowIPFIXConfigPorts("127.0.0.1", v9Port, ipfixPort)) {
 		t.Fatal("flow + ipfix exporters must start")
 	}
 	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
@@ -76,15 +145,29 @@ func TestSessionCloseRawEventDrivesFlowExport(t *testing.T) {
 	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
 		t.Fatal("ipfix exporter must be live")
 	}
+	// The two real export callbacks are registered exactly once.
+	if n := d.eventReader.CallbackCount(); n != 2 {
+		t.Fatalf("expected 2 real export callbacks (v9 + ipfix), got %d", n)
+	}
 
-	// Spy callback gating identically to the real flow-export callbacks.
-	// Registered AFTER the two real callbacks so all three see the record.
-	var sessionCloses []logging.EventRecord
+	// Two distinct fanout callbacks standing in for the NetFlow and IPFIX
+	// SESSION_CLOSE consumers — registered AFTER the two real callbacks so
+	// all four see the record. Dropping either makes its count 0
+	// (fail-on-revert for the "both callbacks" claim).
+	var netflowFires, ipfixFires int
+	var seen logging.EventRecord
 	d.eventReader.AddCallback(func(rec logging.EventRecord, _ []byte) {
 		if rec.Type != "SESSION_CLOSE" {
 			return
 		}
-		sessionCloses = append(sessionCloses, rec)
+		netflowFires++
+		seen = rec
+	})
+	d.eventReader.AddCallback(func(rec logging.EventRecord, _ []byte) {
+		if rec.Type != "SESSION_CLOSE" {
+			return
+		}
+		ipfixFires++
 	})
 
 	payload := buildSessionCloseRawEventV4(
@@ -99,10 +182,26 @@ func TestSessionCloseRawEventDrivesFlowExport(t *testing.T) {
 		t.Fatal("ProcessRawEvent rejected a valid SESSION_CLOSE payload")
 	}
 
-	if len(sessionCloses) != 1 {
-		t.Fatalf("expected exactly one SESSION_CLOSE record, got %d", len(sessionCloses))
+	// Both SESSION_CLOSE-gated consumers fire exactly once.
+	if netflowFires != 1 {
+		t.Fatalf("NetFlow SESSION_CLOSE callback fired %d times, want 1", netflowFires)
 	}
-	rec := sessionCloses[0]
+	if ipfixFires != 1 {
+		t.Fatalf("IPFIX SESSION_CLOSE callback fired %d times, want 1", ipfixFires)
+	}
+
+	// Both REAL exporters export a flow record for the close — proving the
+	// SESSION_CLOSE-derived FlowRecord reaches both production export paths
+	// (Stats.flows counts data records, not templates).
+	if got := waitFlows(t, d.flowExporter.Stats); got < 1 {
+		t.Fatalf("NetFlow v9 exporter exported %d flows after the SESSION_CLOSE, want >= 1", got)
+	}
+	if got := waitFlows(t, d.ipfixExporter.Stats); got < 1 {
+		t.Fatalf("IPFIX exporter exported %d flows after the SESSION_CLOSE, want >= 1", got)
+	}
+
+	// Record content (the deterministic boundary assertion).
+	rec := seen
 	if rec.Type != "SESSION_CLOSE" {
 		t.Fatalf("Type = %q, want SESSION_CLOSE", rec.Type)
 	}

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -66,18 +66,20 @@ type EventStream struct {
 	drainCompleteCh chan uint64
 
 	// Stats.
-	FramesRead        atomic.Uint64
-	FramesWritten     atomic.Uint64
-	DecodeErrors      atomic.Uint64
-	SeqGaps           atomic.Uint64
-	PolicyDenyEvents  atomic.Uint64
-	ScreenDropEvents  atomic.Uint64
-	ScreenAlarmEvents atomic.Uint64 // screen event with action=PERMIT (#2298)
-	FilterLogEvents   atomic.Uint64
-	PolicyDenyDrops   atomic.Uint64
-	ScreenDropDrops   atomic.Uint64
-	FilterLogDrops    atomic.Uint64
-	UnknownFrameDrops atomic.Uint64
+	FramesRead         atomic.Uint64
+	FramesWritten      atomic.Uint64
+	DecodeErrors       atomic.Uint64
+	SeqGaps            atomic.Uint64
+	PolicyDenyEvents   atomic.Uint64
+	ScreenDropEvents   atomic.Uint64
+	ScreenAlarmEvents  atomic.Uint64 // screen event with action=PERMIT (#2298)
+	FilterLogEvents    atomic.Uint64
+	SessionCloseEvents atomic.Uint64 // #2460: RT_FLOW SESSION_CLOSE frames
+	PolicyDenyDrops    atomic.Uint64
+	ScreenDropDrops    atomic.Uint64
+	FilterLogDrops     atomic.Uint64
+	SessionCloseDrops  atomic.Uint64 // #2460
+	UnknownFrameDrops  atomic.Uint64
 }
 
 // NewEventStream creates an EventStream for the given Unix socket path.
@@ -402,7 +404,8 @@ func (es *EventStream) readLoop(ctx context.Context) {
 			// the connection alive to prevent read-deadline disconnect.
 			continue
 
-		case EventFrameTypePolicyDeny, EventFrameTypeScreenDrop, EventFrameTypeFilterLog:
+		case EventFrameTypePolicyDeny, EventFrameTypeScreenDrop, EventFrameTypeFilterLog,
+			EventFrameTypeSessionClose:
 			if !dataplaneEventPayloadMatchesFrame(typ, payload) {
 				es.DecodeErrors.Add(1)
 				es.recordDataplaneEventDrop(typ)
@@ -599,7 +602,8 @@ func (es *EventStream) flushPendingCallbackFrames() {
 			if !onFullResync() {
 				return
 			}
-		case EventFrameTypePolicyDeny, EventFrameTypeScreenDrop, EventFrameTypeFilterLog:
+		case EventFrameTypePolicyDeny, EventFrameTypeScreenDrop, EventFrameTypeFilterLog,
+			EventFrameTypeSessionClose:
 			onRawDataplaneEvent, onDataplaneEvent := es.dataplaneCallbacks()
 			if onRawDataplaneEvent == nil && onDataplaneEvent == nil {
 				return
@@ -646,6 +650,8 @@ func (es *EventStream) recordDataplaneEvent(typ, action uint8) {
 		}
 	case EventFrameTypeFilterLog:
 		es.FilterLogEvents.Add(1)
+	case EventFrameTypeSessionClose:
+		es.SessionCloseEvents.Add(1)
 	}
 }
 
@@ -657,6 +663,8 @@ func (es *EventStream) recordDataplaneEventDrop(typ uint8) {
 		es.ScreenDropDrops.Add(1)
 	case EventFrameTypeFilterLog:
 		es.FilterLogDrops.Add(1)
+	case EventFrameTypeSessionClose:
+		es.SessionCloseDrops.Add(1)
 	default:
 		es.UnknownFrameDrops.Add(1)
 	}
@@ -926,8 +934,9 @@ func decodeSessionCloseEvent(payload []byte) (SessionDeltaInfo, bool) {
 }
 
 // decodeDataplaneEventPayload decodes the canonical dataplane.Event RT_FLOW
-// payload. Userspace-dp carries these bytes over event-stream frame types 11-13,
-// but the payload itself is the same shape consumed by pkg/logging/ringbuf.go.
+// payload. Userspace-dp carries these bytes over event-stream frame types 11-14
+// (#2460 added the SESSION_CLOSE frame), but the payload itself is the same
+// shape consumed by pkg/logging/ringbuf.go.
 func decodeDataplaneEventPayload(payload []byte) (logging.EventRecord, bool) {
 	return logging.DecodeRawEventRecord(payload)
 }
@@ -944,6 +953,8 @@ func dataplaneEventPayloadMatchesFrame(typ uint8, payload []byte) bool {
 		want = dataplane.EventTypeScreenDrop
 	case EventFrameTypeFilterLog:
 		want = dataplane.EventTypeFilterLog
+	case EventFrameTypeSessionClose:
+		want = dataplane.EventTypeSessionClose
 	default:
 		return false
 	}

--- a/pkg/dataplane/userspace/eventstream_test.go
+++ b/pkg/dataplane/userspace/eventstream_test.go
@@ -770,6 +770,104 @@ func TestEventStreamDataplaneEventRawCallbackPreferred(t *testing.T) {
 	}
 }
 
+// TestEventStreamSessionCloseRTFlowRoutesToRawCallback proves the #2460
+// EventFrameTypeSessionClose (type 14) frame is accepted by the event-stream
+// frame dispatcher and routed to the raw dataplane-event callback (the path
+// the daemon wires to eventReader.ProcessRawEvent so the NetFlow/IPFIX
+// session-close exporters fire). It further feeds the decoded payload through
+// a real EventReader and asserts a single Type=="SESSION_CLOSE" record with
+// the correct tuple results — closing the helper-emit -> Go-decode loop.
+//
+// Fail-on-revert: drop EventFrameTypeSessionClose from the dispatcher switch
+// (the type-14 case) and the frame is treated as unknown and dropped, so the
+// raw callback never fires.
+func TestEventStreamSessionCloseRTFlowRoutesToRawCallback(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test-events.sock")
+
+	es := NewEventStream(sockPath)
+	reader := logging.NewEventReader(nil, logging.NewEventBuffer(8))
+	rawSeen := make(chan logging.EventRecord, 4)
+	es.SetOnRawDataplaneEvent(func(_ uint64, payload []byte) {
+		if !reader.ProcessRawEvent(payload) {
+			return
+		}
+		rec, ok := logging.DecodeRawEventRecord(payload)
+		if ok {
+			rawSeen <- rec
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	es.Start(ctx)
+	defer es.Close()
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	var conn net.Conn
+	for conn == nil {
+		var err error
+		conn, err = net.Dial("unix", sockPath)
+		if err == nil {
+			break
+		}
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("dial: %v", err)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	defer conn.Close()
+	for !es.IsConnected() {
+		select {
+		case <-waitCtx.Done():
+			t.Fatal("event stream did not become connected")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// 136-byte dataplane.Event payload, EventType = SESSION_CLOSE (2),
+	// mirroring the Rust encode_session_close_rt_flow layout.
+	payload := buildTypedDataplaneEventV4Payload(
+		dataplane.EventTypeSessionClose,
+		dataplane.ActionDeny, // inert for a close
+		6,                    // TCP
+		12345, 443,
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		[4]byte{172, 16, 80, 8},
+		40000,
+		2, 3,
+		0, 0, 0, 0,
+		0, // close reason none
+		0,
+	)
+	if err := writeFrame(conn, EventFrameTypeSessionClose, 11, payload); err != nil {
+		t.Fatalf("write session-close frame: %v", err)
+	}
+
+	select {
+	case rec := <-rawSeen:
+		if rec.Type != "SESSION_CLOSE" {
+			t.Fatalf("Type = %q, want SESSION_CLOSE", rec.Type)
+		}
+		if rec.SrcAddr != "10.0.1.102:12345" || rec.DstAddr != "172.16.80.200:443" {
+			t.Fatalf("tuple = %s -> %s, want 10.0.1.102:12345 -> 172.16.80.200:443",
+				rec.SrcAddr, rec.DstAddr)
+		}
+		if rec.SessionPkts != 0 || rec.SessionBytes != 0 {
+			t.Fatalf("counters = (%d,%d), want (0,0) pending #2501",
+				rec.SessionPkts, rec.SessionBytes)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("session-close RT_FLOW frame did not reach the raw callback")
+	}
+
+	if got := es.SessionCloseEvents.Load(); got != 1 {
+		t.Fatalf("SessionCloseEvents = %d, want 1", got)
+	}
+}
+
 func TestEventStreamRawDataplaneEventsFeedSyslogFanout(t *testing.T) {
 	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
@@ -1628,10 +1726,10 @@ func TestEventSocketPathRemoved(t *testing.T) {
 // "alarm != drop" and "alarm is counted" assertions below would fail.
 func TestRecordDataplaneEventScreenAlarmNotDrop(t *testing.T) {
 	cases := []struct {
-		name        string
-		action      uint8
-		wantDrop    uint64
-		wantAlarm   uint64
+		name      string
+		action    uint8
+		wantDrop  uint64
+		wantAlarm uint64
 	}{
 		{"permit_alarm", dataplane.ActionPermit, 0, 1},
 		{"deny_drop", dataplane.ActionDeny, 1, 0},

--- a/pkg/dataplane/userspace/flow.go
+++ b/pkg/dataplane/userspace/flow.go
@@ -179,8 +179,9 @@ func buildAppCatalogSnapshot(cfg *config.Config) []AppCatalogEntrySnapshot {
 // logging.EventRecord{Type:"SESSION_CLOSE"} via eventReader.ProcessRawEvent,
 // which fires the NetFlow/IPFIX flowExportCallback / ipfixExportCallback
 // (daemon_flowexport.go). The record carries the real 5-tuple, NAT tuple,
-// zones, and protocol; byte/packet volume counters and session duration are
-// reported as 0 pending the userspace per-session accounting work in #2501.
+// zones, and protocol; byte/packet volume counters are 0 pending the
+// userspace per-session accounting work in #2501 (and since the exported
+// duration is estimated from the packet count, it is 0 until then too).
 func buildFlowExportSnapshot(cfg *config.Config) *FlowExportSnapshot {
 	if cfg == nil || cfg.Services.FlowMonitoring == nil {
 		return nil

--- a/pkg/dataplane/userspace/flow.go
+++ b/pkg/dataplane/userspace/flow.go
@@ -162,15 +162,25 @@ func buildAppCatalogSnapshot(cfg *config.Config) []AppCatalogEntrySnapshot {
 
 // buildFlowExportSnapshot constructs the FlowExportSnapshot wire field.
 //
-// #2130: the userspace dataplane does NOT emit flow records — flow export
-// is owned entirely by the Go control plane (pkg/flowexport), driven by
-// SESSION_CLOSE events. The Rust FlowExporter that once consumed this
+// #2130: the userspace dataplane does NOT build/format the NetFlow/IPFIX
+// flow records itself — flow export is owned entirely by the Go control
+// plane (pkg/flowexport). The Rust FlowExporter that once consumed this
 // snapshot was dead code (never wired into the forwarding path) and was
 // removed; the helper now deserializes this field and ignores it. The
 // field (and this builder) are retained as a documented-reserved wire
 // contract so the #1977 decode-safety coercion tests
 // (flow_wire_coerce_test.go, protocol/tests.rs) keep guarding the path and
 // no cross-language wire break is introduced.
+//
+// #2460: the session-close records that drive flow export ARE now produced
+// in userspace mode. On every session close the helper emits a SESSION_CLOSE
+// RT_FLOW frame (EventFrameTypeSessionClose, type 14) on the raw
+// dataplane-event channel; the daemon decodes it into a
+// logging.EventRecord{Type:"SESSION_CLOSE"} via eventReader.ProcessRawEvent,
+// which fires the NetFlow/IPFIX flowExportCallback / ipfixExportCallback
+// (daemon_flowexport.go). The record carries the real 5-tuple, NAT tuple,
+// zones, and protocol; byte/packet volume counters and session duration are
+// reported as 0 pending the userspace per-session accounting work in #2501.
 func buildFlowExportSnapshot(cfg *config.Config) *FlowExportSnapshot {
 	if cfg == nil || cfg.Services.FlowMonitoring == nil {
 		return nil

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -2039,6 +2039,15 @@ const (
 	EventFrameTypePolicyDeny uint8 = 11 // helper → daemon (RT_FLOW policy deny)
 	EventFrameTypeScreenDrop uint8 = 12 // helper → daemon (RT_FLOW screen drop)
 	EventFrameTypeFilterLog  uint8 = 13 // helper → daemon (RT_FLOW filter log)
+	// #2460: RT_FLOW SESSION_CLOSE on the raw dataplane-event channel,
+	// carrying the canonical 136-byte dataplane.Event payload with the
+	// event-type byte = dataplane.EventTypeSessionClose (2). Routed through
+	// the same decodeDataplaneEventPayload → eventReader.ProcessRawEvent
+	// path as the deny/screen/filter frames so the NetFlow/IPFIX
+	// session-close exporters fire. ADDITIVE to the minimal type-2
+	// EventTypeSessionClose HA session-sync delta — both are produced per
+	// close; the HA sync path is unchanged.
+	EventFrameTypeSessionClose uint8 = 14 // helper → daemon (RT_FLOW session close)
 )
 
 // Session event flag bits in the Flags byte of SessionOpen/Update/Close payloads.

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -30,9 +30,12 @@ it into a `Type:"SESSION_CLOSE"` `EventRecord` via
 HA delta is unchanged and emitted as a 1:1 pair with the type-14 frame —
 the RT_FLOW frame is additive, not a replacement, so HA session sync is
 unaffected. The record carries the real 5-tuple, NAT translated tuple,
-zones, and protocol; the byte/packet volume counters and session duration
-are reported as 0 because the AF_XDP forwarding path does not yet maintain
-per-session accounting — that is the follow-up tracked in **#2501**.
+zones, and protocol; the byte/packet volume counters are 0 because the
+AF_XDP forwarding path does not yet maintain per-session accounting — that
+is the follow-up tracked in **#2501**. The exported flow duration is
+derived from the packet count (`estimateSessionDuration(SessionPkts)`),
+not the close record's `created`/`ElapsedTime` field, so it is also 0
+until #2501 populates the counters.
 
 ## File layout
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -6,13 +6,33 @@ session sampling. Wired off `pkg/logging.EventReader` SESSION_CLOSE
 events in `pkg/daemon/daemon_flowexport.go`, not the conntrack GC
 delete callback. No per-packet sampling path.
 
-Flow export is **entirely control-plane**. The userspace dataplane
-(`userspace-dp`) does NOT emit flow records — it never has. Flow records
-are assembled in this package from SESSION_CLOSE events. The Rust
-dataplane carried a dead `FlowExporter` and a write-only
+Flow record *assembly* is **entirely control-plane**: the userspace
+dataplane does NOT build/format NetFlow/IPFIX records — flow records are
+assembled in this package from SESSION_CLOSE `logging.EventRecord`s. The
+Rust dataplane carried a dead `FlowExporter` and a write-only
 `flow_export_config` field that emitted nothing; both were removed in
 #2130. (The Go→Rust `flow_export` snapshot wire field is retained as
 reserved/ignored to preserve the #1977 decode-safety tests.)
+
+**#2460 — the SESSION_CLOSE events ARE now produced in userspace mode.**
+Before #2460, the userspace dataplane emitted a session close ONLY as a
+minimal `MSG_SESSION_CLOSE` (type 2) HA session-sync delta on the
+SessionDeltaInfo channel (`handleEventStreamDelta`), never as an RT_FLOW
+`SESSION_CLOSE` event on the raw dataplane-event channel that these
+exporters consume — so the NetFlow/IPFIX session-close callbacks never
+fired and userspace session-close export was silently non-functional
+(per-packet deny/screen/filter RT_FLOW export already worked). The helper
+now emits, on every session close, an ADDITIONAL RT_FLOW SESSION_CLOSE
+frame (`EventFrameTypeSessionClose`, type 14) carrying the canonical
+136-byte `dataplane.Event` payload on the raw channel. The daemon decodes
+it into a `Type:"SESSION_CLOSE"` `EventRecord` via
+`eventReader.ProcessRawEvent`, which fires the callbacks below. The type-2
+HA delta is unchanged and emitted as a 1:1 pair with the type-14 frame —
+the RT_FLOW frame is additive, not a replacement, so HA session sync is
+unaffected. The record carries the real 5-tuple, NAT translated tuple,
+zones, and protocol; the byte/packet volume counters and session duration
+are reported as 0 because the AF_XDP forwarding path does not yet maintain
+per-session accounting — that is the follow-up tracked in **#2501**.
 
 ## File layout
 

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -143,6 +143,17 @@ pub(super) fn flush_session_deltas(
         // Push to event stream (new path) alongside existing RPC fallback.
         if let Some(es) = event_stream {
             es.push_delta(delta, zone_name_to_id);
+            // #2460: a Close delta also emits a SEPARATE RT_FLOW
+            // SESSION_CLOSE frame (type 14) on the raw dataplane-event
+            // channel. `push_delta` above already sent the type-2 HA
+            // session-sync close delta unchanged; this is ADDITIVE and
+            // feeds the Go NetFlow/IPFIX session-close exporters, which only
+            // fire on a `Type == "SESSION_CLOSE"` EventRecord (never
+            // produced in userspace mode before this). The two frames are a
+            // 1:1 pair per close — no double-counting on the HA channel.
+            if delta.kind == SessionDeltaKind::Close {
+                es.emit_session_close_rt_flow(delta);
+            }
         }
         if let Ok(mut recent) = recent_session_deltas.lock() {
             push_recent_session_delta(&mut recent, info);

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -31,8 +31,11 @@ periodic ACK from the daemon.
   NetFlow v9 / IPFIX session-close exporters in userspace mode (they only
   fire on a `Type == "SESSION_CLOSE"` record; before #2460 none was
   produced). It carries the real 5-tuple, NAT tuple, zones, and protocol;
-  byte/packet counters and the session-creation stamp (→ duration) are 0
-  pending the per-session accounting follow-up #2501. Unlike the deny/
+  the byte/packet counters and the session-creation stamp are 0 pending the
+  per-session accounting follow-up #2501. The exporter-reported flow
+  duration is derived from the packet count today
+  (`estimateSessionDuration(SessionPkts)`), not the `created` stamp, so it
+  is 0 while the counters are 0. Unlike the deny/
   screen/filter frames, the close frame is NOT rate-limited (a dropped
   close loses one flow-export record; it is bounded by session churn, not
   attacker-controlled), so it is sent with the lossy `try_send` path

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -15,13 +15,28 @@ periodic ACK from the daemon.
   `MSG_SESSION_UPDATE`, `MSG_ACK`, `MSG_PAUSE`, `MSG_RESUME`,
   `MSG_DRAIN_REQUEST`, `MSG_DRAIN_COMPLETE`, `MSG_FULL_RESYNC`,
   `MSG_KEEPALIVE` (1..10), plus RT_FLOW dataplane telemetry frames
-  `MSG_POLICY_DENY`, `MSG_SCREEN_DROP`, and `MSG_FILTER_LOG` (11..13).
+  `MSG_POLICY_DENY`, `MSG_SCREEN_DROP`, and `MSG_FILTER_LOG` (11..13),
+  and (#2460) `MSG_SESSION_CLOSE_RT_FLOW` (14).
   The telemetry frame payload is not a userspace-specific schema: it is
   the same 136-byte `dataplane.Event` layout consumed by the Go ringbuf
   logger, including AF values 2/10 and big-endian L4 ports. Userspace
   telemetry may also populate the non-session metadata slots used by
   the Go adapter for action, rule ID, term ID, reason, owner RG,
   ingress ifindex, and application ID.
+  `MSG_SESSION_CLOSE_RT_FLOW` (14) carries that same 136-byte payload
+  with the event-type byte set to RT_FLOW SESSION_CLOSE (2). It is
+  emitted once per session close (via `emit_session_close_rt_flow`,
+  paired 1:1 with — and ADDITIVE to — the unchanged minimal type-2
+  `MSG_SESSION_CLOSE` HA session-sync delta), and is what drives the Go
+  NetFlow v9 / IPFIX session-close exporters in userspace mode (they only
+  fire on a `Type == "SESSION_CLOSE"` record; before #2460 none was
+  produced). It carries the real 5-tuple, NAT tuple, zones, and protocol;
+  byte/packet counters and the session-creation stamp (→ duration) are 0
+  pending the per-session accounting follow-up #2501. Unlike the deny/
+  screen/filter frames, the close frame is NOT rate-limited (a dropped
+  close loses one flow-export record; it is bounded by session churn, not
+  attacker-controlled), so it is sent with the lossy `try_send` path
+  directly rather than through the `producer.rs` rate limiter.
   `MSG_FILTER_LOG` intentionally reuses the RT_FLOW `reason` byte as
   a filter-log source discriminator (`pbr`, `input`, `output`,
   `cached-output`, or `lo0`). Close events still interpret that byte as

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -391,15 +391,24 @@ impl EventFrame {
     /// (`daemon_flowexport.go`).
     ///
     /// Fields populated from the close: the real forward 5-tuple, the NAT
-    /// translated tuple (when present), ingress/egress zone IDs, protocol,
-    /// owner RG, and the close-reason byte. The byte/packet counters
-    /// (offsets 56/64/112/120) and the session-creation timestamp (offset
-    /// 108, which drives `ElapsedTime`) are written as 0: the userspace
-    /// AF_XDP forwarding path does not yet maintain per-session byte/packet
-    /// accounting nor a wall-clock creation stamp. That accounting is the
-    /// follow-up tracked in #2501; until it lands these stay 0 (so the flow
-    /// record carries an accurate tuple but a zero volume/duration, never a
-    /// silently-missing record).
+    /// translated tuple (when present), ingress/egress zone IDs, and
+    /// protocol. `owner_rg_id` is accepted for symmetry with the other
+    /// frame encoders but is intentionally NOT written into this payload —
+    /// for a SESSION_CLOSE the Go decoder reads the [56:64] slot (where the
+    /// deny/screen/filter frames carry owner RG) as the session-packets
+    /// counter, so writing owner RG there would corrupt the counter. Owner
+    /// RG is carried for session sync on the type-2 HA close delta instead.
+    ///
+    /// The byte/packet counters (offsets 56/64/112/120) and the
+    /// session-creation timestamp (offset 108) are written as 0: the
+    /// userspace AF_XDP forwarding path does not yet maintain per-session
+    /// byte/packet accounting nor a wall-clock creation stamp. That
+    /// accounting is the follow-up tracked in #2501; until it lands these
+    /// stay 0, so the flow record carries an accurate tuple but zero volume.
+    /// The exporters' duration is derived from the packet count today
+    /// (`estimateSessionDuration(SessionPkts)` in pkg/flowexport), NOT from
+    /// the `created` stamp — so with 0 packets the reported duration is also
+    /// 0 (and will become real once #2501 populates the counters).
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn encode_session_close_rt_flow(
         seq: u64,
@@ -421,9 +430,12 @@ impl EventFrame {
         let base = FRAME_HEADER_SIZE;
         let wire_af = rt_flow_addr_family(addr_family, src_ip);
 
-        // [0:8] timestamp_ns — 0 (the Go side stamps time.Now() when it
-        // cannot derive a wire timestamp; ElapsedTime is gated on `created`,
-        // offset 108, which is 0 — see #2501).
+        // [0:8] timestamp_ns — 0 (the Go side stamps time.Now() when the
+        // wire timestamp is 0, which is the record's EndTime). The flow
+        // exporters compute the flow StartTime by subtracting a packet-count
+        // estimate (estimateSessionDuration(SessionPkts)), not from the
+        // `created` stamp at offset 108 — so duration is 0 until #2501
+        // populates the counters.
         // [8:24] src ip, [24:40] dst ip (16-byte slots, v4 left-aligned).
         write_ip_16(&mut buf, base + 8, src_ip);
         write_ip_16(&mut buf, base + 24, dst_ip);
@@ -438,8 +450,12 @@ impl EventFrame {
         // [52] event type, [53] protocol, [54] action, [55] address family.
         buf[base + 52] = RT_FLOW_EVENT_SESSION_CLOSE;
         buf[base + 53] = protocol;
-        // action is not meaningful for a close; 0 (deny encoding) is inert —
-        // the flowexport callbacks do not read it for SESSION_CLOSE.
+        // [54] action: the Go decoder DOES map this byte to
+        // EventRecord.Action (and logs it for SESSION_CLOSE), but a session
+        // close has no permit/deny/reject action semantics, so it is
+        // intentionally 0. The flow exporters do not branch on it for a
+        // close; only the syslog/event line carries it (as "deny", the 0
+        // encoding) — harmless for a close record.
         buf[base + 54] = 0;
         buf[base + 55] = wire_af;
         // [56:64] session_packets, [64:72] session_bytes — 0 (#2501).
@@ -449,7 +465,8 @@ impl EventFrame {
         // [104:106] nat src port, [106:108] nat dst port — BIG-endian.
         buf[base + 104..base + 106].copy_from_slice(&nat_src_port.to_be_bytes());
         buf[base + 106..base + 108].copy_from_slice(&nat_dst_port.to_be_bytes());
-        // [108:112] created — 0 (#2501; ElapsedTime stays 0).
+        // [108:112] created — 0 (#2501). Note the exporters ignore this
+        // field for duration; duration tracks the packet count (see above).
         // [112:120] rev packets, [120:128] rev bytes — 0 (#2501).
         // [128:132] ingress ifindex — 0 (per-close ifindex not threaded).
         // [132:134] application id — 0.

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -35,14 +35,37 @@ pub(crate) const MSG_SCREEN_DROP: u8 = 12;
 #[allow(dead_code)]
 pub(crate) const MSG_FILTER_LOG: u8 = 13;
 
+// #2460: RT_FLOW SESSION_CLOSE on the raw dataplane-event channel. This
+// frame carries the canonical 136-byte `dataplane.Event` payload (the same
+// shape the Go `logging.DecodeRawEventRecord` / `ProcessRawEvent` parser
+// consumes for the deny/screen/filter frames above) with the event-type
+// byte set to RT_FLOW SESSION_CLOSE (2). It is what drives the Go
+// NetFlow/IPFIX session-close exporters in userspace mode. It is ADDITIVE
+// to — and entirely separate from — the minimal `MSG_SESSION_CLOSE` (type
+// 2) HA session-sync delta below; the two are emitted as a pair from one
+// close, never substituting for each other.
+pub(crate) const MSG_SESSION_CLOSE_RT_FLOW: u8 = 14;
+
 #[allow(dead_code)]
 pub(crate) const SECURITY_EVENT_PAYLOAD_SIZE: usize = 136;
 
 const RT_FLOW_AF_INET: u8 = 2;
 const RT_FLOW_AF_INET6: u8 = 10;
+// #2460: SESSION_CLOSE event-type byte. Must equal the Go
+// `eventTypeSessionClose` (pkg/logging/ringbuf.go) and
+// `dataplane.EventTypeSessionClose` (pkg/dataplane/types.go) value of 2,
+// so `eventTypeName(data[52])` resolves to the literal "SESSION_CLOSE" the
+// flowexport callbacks gate on.
+const RT_FLOW_EVENT_SESSION_CLOSE: u8 = 2;
 const RT_FLOW_EVENT_POLICY_DENY: u8 = 3;
 const RT_FLOW_EVENT_SCREEN_DROP: u8 = 4;
 const RT_FLOW_EVENT_FILTER_LOG: u8 = 6;
+// #2460: SESSION_CLOSE reason byte. The HA close delta carries no
+// idle/FIN/RST/age discriminator, so the RT_FLOW close reports "none" (0).
+// A real close-reason (and the byte/packet counters + session duration this
+// frame currently reports as 0) is the per-session accounting work tracked
+// in #2501.
+const RT_FLOW_CLOSE_REASON_NONE: u8 = 0;
 // DENY/PERMIT are wire-format documentation pinned by codec_tests;
 // like REJECT below they have no non-test reader (#1826: exposed when
 // the stale module-level allow was removed).
@@ -350,6 +373,105 @@ impl EventFrame {
         EventFrame {
             data: buf,
             len: pos as u16,
+            seq,
+        }
+    }
+
+    /// #2460: Encode an RT_FLOW SESSION_CLOSE (type 14) frame.
+    ///
+    /// Unlike `encode_session_close` (the minimal type-2 HA session-sync
+    /// delta), this frame carries the canonical 136-byte `dataplane.Event`
+    /// payload — byte-identical to the layout written by
+    /// `encode_dataplane_event` and parsed by the Go
+    /// `logging.DecodeRawEventRecord` / `EventReader.logEvent`
+    /// (`pkg/logging/ringbuf.go`). With the event-type byte set to
+    /// `RT_FLOW_EVENT_SESSION_CLOSE` (2), the Go side resolves it to a
+    /// `Type == "SESSION_CLOSE"` `EventRecord`, which is exactly what the
+    /// NetFlow v9 / IPFIX session-close exporters gate on
+    /// (`daemon_flowexport.go`).
+    ///
+    /// Fields populated from the close: the real forward 5-tuple, the NAT
+    /// translated tuple (when present), ingress/egress zone IDs, protocol,
+    /// owner RG, and the close-reason byte. The byte/packet counters
+    /// (offsets 56/64/112/120) and the session-creation timestamp (offset
+    /// 108, which drives `ElapsedTime`) are written as 0: the userspace
+    /// AF_XDP forwarding path does not yet maintain per-session byte/packet
+    /// accounting nor a wall-clock creation stamp. That accounting is the
+    /// follow-up tracked in #2501; until it lands these stay 0 (so the flow
+    /// record carries an accurate tuple but a zero volume/duration, never a
+    /// silently-missing record).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn encode_session_close_rt_flow(
+        seq: u64,
+        addr_family: u8,
+        protocol: u8,
+        src_ip: IpAddr,
+        dst_ip: IpAddr,
+        src_port: u16,
+        dst_port: u16,
+        nat_src_ip: Option<IpAddr>,
+        nat_dst_ip: Option<IpAddr>,
+        nat_src_port: u16,
+        nat_dst_port: u16,
+        ingress_zone_id: u16,
+        egress_zone_id: u16,
+        owner_rg_id: i16,
+    ) -> Self {
+        let mut buf = [0u8; 256];
+        let base = FRAME_HEADER_SIZE;
+        let wire_af = rt_flow_addr_family(addr_family, src_ip);
+
+        // [0:8] timestamp_ns — 0 (the Go side stamps time.Now() when it
+        // cannot derive a wire timestamp; ElapsedTime is gated on `created`,
+        // offset 108, which is 0 — see #2501).
+        // [8:24] src ip, [24:40] dst ip (16-byte slots, v4 left-aligned).
+        write_ip_16(&mut buf, base + 8, src_ip);
+        write_ip_16(&mut buf, base + 24, dst_ip);
+        // [40:42] src port, [42:44] dst port — BIG-endian (matches the Go
+        // `binary.BigEndian` reads in logEvent/DecodeRawEventRecord).
+        buf[base + 40..base + 42].copy_from_slice(&src_port.to_be_bytes());
+        buf[base + 42..base + 44].copy_from_slice(&dst_port.to_be_bytes());
+        // [44:48] policy_id — unused for SESSION_CLOSE.
+        // [48:50] ingress zone, [50:52] egress zone — little-endian.
+        buf[base + 48..base + 50].copy_from_slice(&ingress_zone_id.to_le_bytes());
+        buf[base + 50..base + 52].copy_from_slice(&egress_zone_id.to_le_bytes());
+        // [52] event type, [53] protocol, [54] action, [55] address family.
+        buf[base + 52] = RT_FLOW_EVENT_SESSION_CLOSE;
+        buf[base + 53] = protocol;
+        // action is not meaningful for a close; 0 (deny encoding) is inert —
+        // the flowexport callbacks do not read it for SESSION_CLOSE.
+        buf[base + 54] = 0;
+        buf[base + 55] = wire_af;
+        // [56:64] session_packets, [64:72] session_bytes — 0 (#2501).
+        // [72:88] nat src ip, [88:104] nat dst ip.
+        write_ip_opt_16(&mut buf, base + 72, nat_src_ip);
+        write_ip_opt_16(&mut buf, base + 88, nat_dst_ip);
+        // [104:106] nat src port, [106:108] nat dst port — BIG-endian.
+        buf[base + 104..base + 106].copy_from_slice(&nat_src_port.to_be_bytes());
+        buf[base + 106..base + 108].copy_from_slice(&nat_dst_port.to_be_bytes());
+        // [108:112] created — 0 (#2501; ElapsedTime stays 0).
+        // [112:120] rev packets, [120:128] rev bytes — 0 (#2501).
+        // [128:132] ingress ifindex — 0 (per-close ifindex not threaded).
+        // [132:134] application id — 0.
+        // owner_rg_id rides the [64:66] slot the deny/screen/filter frames
+        // use, but for SESSION_CLOSE the Go side reads [56:64] as the
+        // session-packets counter, so owner_rg_id is intentionally NOT
+        // written here (it would corrupt the counter slot). The HA close
+        // delta (type 2) already carries owner_rg_id for session sync.
+        let _ = owner_rg_id;
+        // [134] close reason.
+        buf[base + 134] = RT_FLOW_CLOSE_REASON_NONE;
+
+        write_header(
+            &mut buf,
+            SECURITY_EVENT_PAYLOAD_SIZE as u32,
+            MSG_SESSION_CLOSE_RT_FLOW,
+            seq,
+        );
+
+        EventFrame {
+            data: buf,
+            len: (FRAME_HEADER_SIZE + SECURITY_EVENT_PAYLOAD_SIZE) as u16,
             seq,
         }
     }

--- a/userspace-dp/src/event_stream/codec_tests.rs
+++ b/userspace-dp/src/event_stream/codec_tests.rs
@@ -239,6 +239,102 @@ fn test_event_frame_type_values_are_stable() {
     assert_eq!(MSG_POLICY_DENY, 11);
     assert_eq!(MSG_SCREEN_DROP, 12);
     assert_eq!(MSG_FILTER_LOG, 13);
+    // #2460: the RT_FLOW SESSION_CLOSE frame type. Must match the Go
+    // EventFrameTypeSessionClose (pkg/dataplane/userspace/protocol.go).
+    assert_eq!(MSG_SESSION_CLOSE_RT_FLOW, 14);
+}
+
+#[test]
+fn test_encode_session_close_rt_flow_v4_wire_layout() {
+    // #2460 fail-on-revert: the RT_FLOW SESSION_CLOSE frame must carry the
+    // canonical 136-byte dataplane.Event payload with the SESSION_CLOSE
+    // event-type byte at offset 52 and the real 5-tuple/NAT/zones at the
+    // exact byte offsets the Go logging.DecodeRawEventRecord parser reads.
+    // If the encoder drops the SESSION_CLOSE event-type byte (or the type-14
+    // emit is reverted), the Go side never sees a Type=="SESSION_CLOSE"
+    // record and the NetFlow/IPFIX exporters never fire.
+    let frame = EventFrame::encode_session_close_rt_flow(
+        99,
+        libc::AF_INET as u8,
+        6, // TCP
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 102)),
+        IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+        12345,
+        443,
+        Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+        None,
+        40000,
+        0,
+        TEST_TRUST_ZONE_ID,
+        TEST_UNTRUST_ZONE_ID,
+        1,
+    );
+
+    assert_eq!(frame.data[4], MSG_SESSION_CLOSE_RT_FLOW);
+    assert_eq!(frame.seq, 99);
+    // Payload length in the header must be the canonical 136 bytes.
+    assert_eq!(
+        u32::from_le_bytes(frame.data[0..4].try_into().unwrap()),
+        SECURITY_EVENT_PAYLOAD_SIZE as u32
+    );
+    assert_eq!(frame.len as usize, FRAME_HEADER_SIZE + SECURITY_EVENT_PAYLOAD_SIZE);
+
+    let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
+    // src/dst IP (16-byte slots, v4 left-aligned).
+    assert_eq!(&p[8..12], &[10, 0, 1, 102]);
+    assert_eq!(&p[24..28], &[172, 16, 80, 200]);
+    // ports — BIG-endian.
+    assert_eq!(u16::from_be_bytes([p[40], p[41]]), 12345);
+    assert_eq!(u16::from_be_bytes([p[42], p[43]]), 443);
+    // zones — little-endian.
+    assert_eq!(u16::from_le_bytes([p[48], p[49]]), TEST_TRUST_ZONE_ID);
+    assert_eq!(u16::from_le_bytes([p[50], p[51]]), TEST_UNTRUST_ZONE_ID);
+    // event type = SESSION_CLOSE (2); protocol; address family (RT_FLOW v4).
+    assert_eq!(p[52], RT_FLOW_EVENT_SESSION_CLOSE);
+    assert_eq!(p[52], 2, "must equal the Go eventTypeSessionClose value");
+    assert_eq!(p[53], 6);
+    assert_eq!(p[55], RT_FLOW_AF_INET);
+    // NAT translated source IP/port.
+    assert_eq!(&p[72..76], &[172, 16, 80, 8]);
+    assert_eq!(u16::from_be_bytes([p[104], p[105]]), 40000);
+    // #2501: counters and created stamp are 0 until per-session accounting
+    // lands. Asserting they are 0 keeps the honest-zero contract explicit.
+    assert_eq!(u64::from_le_bytes(p[56..64].try_into().unwrap()), 0); // pkts
+    assert_eq!(u64::from_le_bytes(p[64..72].try_into().unwrap()), 0); // bytes
+    assert_eq!(u32::from_le_bytes(p[108..112].try_into().unwrap()), 0); // created
+    assert_eq!(u64::from_le_bytes(p[112..120].try_into().unwrap()), 0); // rev pkts
+    assert_eq!(u64::from_le_bytes(p[120..128].try_into().unwrap()), 0); // rev bytes
+    // close reason — none (the delta carries no idle/FIN/RST discriminator).
+    assert_eq!(p[134], RT_FLOW_CLOSE_REASON_NONE);
+}
+
+#[test]
+fn test_encode_session_close_rt_flow_v6() {
+    let frame = EventFrame::encode_session_close_rt_flow(
+        100,
+        libc::AF_INET6 as u8,
+        17, // UDP
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x559, 0x8585, 0xbf01, 0, 0, 0, 0x102)),
+        IpAddr::V6(Ipv6Addr::new(0x2001, 0x559, 0x8585, 0x80, 0, 0, 0, 0x200)),
+        5353,
+        53,
+        None,
+        None,
+        0,
+        0,
+        TEST_TRUST_ZONE_ID,
+        TEST_UNTRUST_ZONE_ID,
+        0,
+    );
+    let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
+    assert_eq!(p[52], RT_FLOW_EVENT_SESSION_CLOSE);
+    assert_eq!(p[55], RT_FLOW_AF_INET6);
+    assert_eq!(p[53], 17);
+    // full 16-byte v6 src address occupies [8..24].
+    assert_eq!(
+        &p[8..24],
+        &Ipv6Addr::new(0x2001, 0x559, 0x8585, 0xbf01, 0, 0, 0, 0x102).octets()
+    );
 }
 
 #[test]

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -384,6 +384,44 @@ impl EventStreamWorkerHandle {
         let frame = self.encode_delta_frame(delta, zone_name_to_id);
         self.send_frame_lossless(frame)
     }
+
+    /// #2460: emit a SESSION_CLOSE RT_FLOW frame (type 14) for a Close delta
+    /// on the raw dataplane-event channel.
+    ///
+    /// This is ADDITIVE to — and must be called ALONGSIDE, never instead of
+    /// — `push_delta`, which carries the unchanged type-2 HA session-sync
+    /// close delta. The RT_FLOW frame drives the Go NetFlow/IPFIX
+    /// session-close exporters (`pkg/daemon/daemon_flowexport.go`), which
+    /// only run on a `Type == "SESSION_CLOSE"` `logging.EventRecord` — a
+    /// record userspace mode never produced before this. The caller
+    /// (`flush_session_deltas`) gates on `delta.kind == Close`, but the
+    /// guard is repeated here so a future caller cannot misuse it on an Open
+    /// delta. Best-effort (`try_send`): a dropped close frame loses only one
+    /// flow-export record, never the HA close delta (a separate frame).
+    pub(crate) fn emit_session_close_rt_flow(&self, delta: &SessionDelta) {
+        if delta.kind != SessionDeltaKind::Close {
+            return;
+        }
+        let nat = &delta.decision.nat;
+        let seq = self.next_seq();
+        let frame = EventFrame::encode_session_close_rt_flow(
+            seq,
+            delta.key.addr_family,
+            delta.key.protocol,
+            delta.key.src_ip,
+            delta.key.dst_ip,
+            delta.key.src_port,
+            delta.key.dst_port,
+            nat.rewrite_src,
+            nat.rewrite_dst,
+            nat.rewrite_src_port.unwrap_or(0),
+            nat.rewrite_dst_port.unwrap_or(0),
+            delta.metadata.ingress_zone,
+            delta.metadata.egress_zone,
+            delta.metadata.owner_rg_id as i16,
+        );
+        self.try_send(frame);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -47,6 +47,119 @@ fn test_dataplane_event(kind: DataplaneEventKind, ingress_zone_id: u16) -> Datap
     }
 }
 
+// #2460: build a forward Close SessionDelta for the RT_FLOW close-emit
+// pairing tests.
+#[cfg(test)]
+fn test_close_delta(kind: crate::session::SessionDeltaKind) -> crate::session::SessionDelta {
+    use crate::afxdp::{ForwardingDisposition, ForwardingResolution};
+    use crate::nat::NatDecision;
+    use crate::session::{
+        SessionDecision, SessionDelta, SessionKey, SessionMetadata, SessionOrigin,
+    };
+    SessionDelta {
+        kind,
+        key: SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: 6,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 1, 102)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200)),
+            src_port: 12345,
+            dst_port: 443,
+        },
+        decision: SessionDecision {
+            resolution: ForwardingResolution {
+                disposition: ForwardingDisposition::ForwardCandidate,
+                local_ifindex: 2,
+                egress_ifindex: 3,
+                tx_ifindex: 3,
+                tunnel_endpoint_id: 0,
+                next_hop: None,
+                neighbor_mac: None,
+                src_mac: None,
+                tx_vlan_id: 0,
+            },
+            nat: NatDecision {
+                rewrite_src: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                rewrite_dst: None,
+                rewrite_src_port: Some(40000),
+                rewrite_dst_port: None,
+                nat64: false,
+                nptv6: false,
+            },
+        },
+        metadata: SessionMetadata {
+            ingress_zone: 1,
+            egress_zone: 2,
+            owner_rg_id: 0,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+        },
+        origin: SessionOrigin::ForwardFlow,
+        fabric_redirect_sync: false,
+    }
+}
+
+#[test]
+fn test_emit_session_close_rt_flow_pairs_with_ha_delta() {
+    // #2460 no-double-emit contract: a single close emits exactly ONE type-2
+    // HA session-sync close delta (push_delta, unchanged) AND exactly ONE
+    // type-14 RT_FLOW SESSION_CLOSE frame (emit_session_close_rt_flow). The
+    // two are a 1:1 pair — the RT_FLOW frame is additive, it does not
+    // duplicate or replace the HA delta.
+    let (handle, rx) = test_worker_handle(
+        8,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let zone_map = FxHashMap::default();
+    let delta = test_close_delta(crate::session::SessionDeltaKind::Close);
+
+    // Mirror flush_session_deltas: the HA delta then the RT_FLOW frame.
+    handle.push_delta(&delta, &zone_map);
+    handle.emit_session_close_rt_flow(&delta);
+
+    let frames: Vec<EventFrame> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert_eq!(frames.len(), 2, "expected exactly one HA delta + one RT_FLOW frame");
+
+    let ha = frames.iter().filter(|f| f.data[4] == codec::MSG_SESSION_CLOSE).count();
+    let rt = frames
+        .iter()
+        .filter(|f| f.data[4] == codec::MSG_SESSION_CLOSE_RT_FLOW)
+        .count();
+    assert_eq!(ha, 1, "exactly one type-2 HA close delta");
+    assert_eq!(rt, 1, "exactly one type-14 RT_FLOW close frame");
+
+    // The RT_FLOW frame carries the SESSION_CLOSE event-type byte and tuple.
+    let rt_frame = frames
+        .iter()
+        .find(|f| f.data[4] == codec::MSG_SESSION_CLOSE_RT_FLOW)
+        .unwrap();
+    let p = &rt_frame.data[FRAME_HEADER_SIZE..rt_frame.len as usize];
+    assert_eq!(p[52], 2, "RT_FLOW event type must be SESSION_CLOSE (2)");
+    assert_eq!(&p[8..12], &[10, 0, 1, 102]);
+    assert_eq!(&p[24..28], &[172, 16, 80, 200]);
+}
+
+#[test]
+fn test_emit_session_close_rt_flow_ignores_open_delta() {
+    // #2460: the RT_FLOW close emit is gated on Close — calling it for an
+    // Open delta is a no-op (guards against a future caller misusing it and
+    // injecting a bogus SESSION_CLOSE for an opening session).
+    let (handle, rx) = test_worker_handle(
+        8,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let delta = test_close_delta(crate::session::SessionDeltaKind::Open);
+    handle.emit_session_close_rt_flow(&delta);
+    assert!(rx.try_recv().is_err(), "Open delta must emit no RT_FLOW close frame");
+}
+
 #[test]
 fn test_sequence_monotonicity() {
     let shared = Arc::new(EventStreamShared::new());


### PR DESCRIPTION
## Summary

Closes #2460 (HIGH, codex review-034 finding 1). In userspace AF_XDP mode, NetFlow v9 / IPFIX **session-close** export never fired. The userspace dataplane emitted a session close ONLY as the minimal type-2 `MSG_SESSION_CLOSE` HA session-sync delta on the SessionDeltaInfo channel (`handleEventStreamDelta`), never as an RT_FLOW `SESSION_CLOSE` event on the **raw** dataplane-event channel (`SetOnRawDataplaneEvent` → `eventReader.ProcessRawEvent`) that the flow exporters consume — so `flowExportCallback`/`ipfixExportCallback` (`daemon_flowexport.go`) early-returned on `rec.Type != "SESSION_CLOSE"` and never ran. Per-packet RT_FLOW (deny/screen/filter) export already worked; only session-close records were missing.

This is the **P1** wiring fix. The byte/packet volume counters and session duration are reported as **0** because the AF_XDP forwarding path does not yet maintain per-session accounting — that build-half is split out as **#2501** (filed by the coordinator). This PR ships the wiring so every other close field flows, and the record is produced honestly (accurate tuple, zero volume) rather than silently missing.

## Field comparison + fork resolution (B vs A)

I first determined exactly what the existing type-2 delta carries vs what a `SESSION_CLOSE` `EventRecord` needs:

| Field needed by SESSION_CLOSE record | In type-2 MSG_SESSION_CLOSE delta? |
|---|---|
| 5-tuple (AF, proto, src/dst IP+port) | ✅ yes |
| owner RG, fabric flags, zone IDs | ✅ yes |
| NAT translated tuple | ❌ no |
| byte/packet counters (fwd+rev) | ❌ no |
| created/last → duration | ❌ no |

Because the delta is **minimal** (no counters, NAT tuple, or timestamps), **Option B** (build the record daemon-side from the delta) is infeasible → **Option A (enrich the wire)**. Further investigation found the counters do not exist *anywhere* in the userspace dataplane: `publish_conntrack.rs` writes `fwd_bytes/fwd_packets/rev_*` as `0` and **no forwarding-path code ever increments them** (the eBPF conntrack counters were a retired-datapath artifact). Hence the P1/P2 split: P1 wires the record through with everything that IS available; P2 (#2501) adds the accounting.

## Implementation (Option A — additive wire frame)

- New frame type **`MSG_SESSION_CLOSE_RT_FLOW` = 14** (Rust) / **`EventFrameTypeSessionClose` = 14** (Go), carrying the **canonical 136-byte `dataplane.Event` payload** with the event-type byte = RT_FLOW `SESSION_CLOSE` (2).
- Helper emits it once per close at the single close-drain SSOT (`flush_session_deltas`), via `emit_session_close_rt_flow`, **ADDITIVELY** — `push_delta` still sends the unchanged type-2 HA delta right before it.
- Go accepts type-14 and routes it through the **existing** `decodeDataplaneEventPayload` → `eventReader.ProcessRawEvent` path (which already fully decodes a 136-byte SESSION_CLOSE into a `Type:"SESSION_CLOSE"` `EventRecord`), so the existing NetFlow/IPFIX callbacks fire with no change to them.

## No double-emit / HA unaffected

The type-2 HA session-sync delta is **unchanged** and emitted as a **1:1 pair** with the type-14 RT_FLOW frame — both derived from the same `SessionDelta`, the RT_FLOW frame is *additional*, never a replacement. HA session sync (`handleEventStreamDelta` → `queueUserspaceSessionDeltas`) is untouched. Asserted by `test_emit_session_close_rt_flow_pairs_with_ha_delta`: exactly one type-2 + one type-14 frame per close; an Open delta emits zero type-14 frames.

## Wire parity (#1961 class)

The Rust `encode_session_close_rt_flow` byte layout is **byte-identical** to the Go `logging.DecodeRawEventRecord` / `EventReader.logEvent` reads — same offsets and endianness: IPs at [8:24]/[24:40] (16-byte slots, v4 left-aligned), L4 ports BIG-endian at [40:44] & NAT ports at [104:108], zones LE at [48:52], event-type/proto/AF at [52]/[53]/[55], counters LE at [56:72] & [112:128] (= 0), created LE at [108:112] (= 0), close reason at [134]. The frame-type constant **14** is pinned on both sides (`test_event_frame_type_values_are_stable` + `TestEventFrameTypeSessionCloseConstant`) so a one-sided drift is caught at unit level. No `protocol_wire_v1.json` change: that fixture covers the JSON **control** protocol, not the binary event-stream protocol; its cross-language contract test is unaffected and still green.

## Tests (fail-on-revert proven)

- **Rust codec**: v4 + v6 wire-layout assertions at the exact Go offsets; reverting the SESSION_CLOSE event-type byte → both fail (verified). Frame-type-14 stability pin.
- **Rust emit**: the 1:1 pairing test + Open-delta no-op guard.
- **Go end-to-end** (`pkg/daemon`): drives a SESSION_CLOSE raw event through the REAL reconciled NetFlow v9 + IPFIX flow-export callbacks → asserts exactly one SESSION_CLOSE record with the correct 5-tuple/NAT/zones reaches them, **counters == 0** (pending #2501, asserted explicitly, not non-zero). Negative test: a POLICY_DENY raw event does NOT hit the close gate.
- **Go frame-routing**: feeds a type-14 frame through the EventStream socket → asserts it reaches the raw callback + `SessionCloseEvents == 1`; reverting the type-14 dispatcher case → frame becomes an unknown drop and the callback never fires (verified).

## Validation

- `cargo build --release` clean; full Rust suite **2626 passed / 0 failed**; new Rust tests 5× stable.
- `go test ./pkg/daemon/ ./pkg/logging/ ./pkg/flowexport/ ./pkg/dataplane/userspace/` all green; new Go tests 5× stable. `gofmt` clean, `go vet` clean, `go build ./...` clean.

## Docs

`pkg/flowexport/README.md` (SESSION_CLOSE events ARE now produced in userspace mode; volume/duration 0 pending #2501), `userspace-dp/src/event_stream/README.md` (type-14 frame), and the `flow.go` #2130 comment all corrected.

Refs #2501 (per-session byte/packet/duration accounting — the P2 build-half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
