### PR TITLE
flowexport: honor per-flow-server NetFlow/IPFIX template binding (#2461)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,43 @@
 # Action Log
 
+## 2026-06-23 — #2461 flowexport per-flow-server template binding
+
+- **Timestamp**: 2026-06-23 PDT
+- **Action**: Correctness fix (HIGH, codex review-034 finding 2).
+  Per-flow-server NetFlow v9 / IPFIX template references were parsed and
+  stored (`FlowServer.Version9Template` / `VersionIPFIXTemplate`) but never
+  used: `BuildExportConfig` / `BuildIPFIXExportConfig` built ONE export
+  config from the FIRST Go-map-iteration template and broadcast it to every
+  collector, so a collector silently received a template (timeouts /
+  `flow-dir` extension) it never requested and the choice flipped across
+  process restarts. Fix: new `ResolveV9TemplateGroups` /
+  `ResolveIPFIXTemplateGroups` group collectors by referenced template and
+  emit one `*ExportConfig` per `(template, source-address)` group, each
+  carrying its template's parameters, sorted deterministically (template
+  name asc, address asc). All groups of a family share one `sampleCounter`
+  (now a pointer) so 1-in-N sampling stays global. The daemon
+  (`reconcileFlowExporters`) now runs N exporters per family (one per group)
+  — `flowExporters`/`ipfixExporters` slices, the atomic bundle carries the
+  group set, the once-registered callback decides `ShouldExport` on
+  `groups[0]` and fans out. A flow-server referencing an UNDEFINED template
+  is hard-rejected at commit by `validateFlowServerTemplateReferencesStrict`
+  (strict commit / commit-check, lenient warn on load/peer-sync per #1960;
+  the resolver drops an undefined-template group on the lenient path). The
+  single-template / no-reference DEFAULT case is unchanged (inherits the
+  lone template; `BuildExportConfig` singular returns the aggregate group).
+- **File(s)**: pkg/flowexport/manager.go (resolver + grouping + shared
+  counter), pkg/flowexport/template_group_test.go (new — fail-on-revert
+  binding, determinism, shared-counter, no-regression default),
+  pkg/config/compiler.go (lenient flag + dispatch),
+  pkg/config/compiler_validate_strict.go (new strict gate),
+  pkg/config/flowserver_template_ref_test.go (new — strict/lenient gate),
+  pkg/config/parser_ast_test.go (define template so existing fixture passes
+  the new gate), pkg/daemon/daemon.go + daemon_flow.go + daemon_flowexport.go
+  (N-exporters-per-family wiring), pkg/daemon test updates, README.md.
+- **Validation**: `go build ./...`, `go test ./pkg/flowexport/ ./pkg/config/
+  ./pkg/daemon/` green, `go vet` clean, gofmt clean; binding + determinism
+  + shared-counter tests pass `-race -count=5`.
+
 ## 2026-06-23 — #2374 AF_XDP bringup fill-ring partial-prime recovery
 
 - **Timestamp**: 2026-06-23 PDT

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -334,6 +334,25 @@ type compileOpts struct {
 	// loaded config is no worse than before the gate. Same doctrine as
 	// lenientRoutingExportRef.
 	lenientFirewallRefs bool
+	// lenientFlowServerTemplateRef (#2461) downgrades the per-flow-server
+	// NetFlow v9 / IPFIX template cross-reference gate
+	// (validateFlowServerTemplateReferencesStrict) from a hard compile
+	// error to a cfg.Warnings entry. A flow-server `version9 { template
+	// <name> }` / `version-ipfix { template <name> }` (or the flat
+	// `version9-template` / `version-ipfix-template`) reference that names
+	// no defined `services flow-monitoring` template was previously
+	// unvalidated: the live exporter ignored the reference and silently
+	// used the first map-iteration template, so a collector received a
+	// template (timeouts / export-extensions) it never requested and the
+	// choice flipped nondeterministically across restarts. The strict
+	// commit / commit-check path hard-rejects so the typo is operator-
+	// visible; the tolerant load / peer-sync paths warn so an already-
+	// persisted or peer-synced config carrying a dangling reference still
+	// BOOTS (#1960 fail-closed-on-load class) — the resolver drops a group
+	// whose template is undefined, so a leniently-loaded config exports
+	// nothing for that collector rather than the wrong template. Same
+	// doctrine as lenientLogProfileStreamRef.
+	lenientFlowServerTemplateRef bool
 	// lenientApplicationSetMembers (#2217 Finding B) downgrades the
 	// application-set member cross-reference gate
 	// (validateApplicationSetMembersStrict) from a hard compile error to a
@@ -463,6 +482,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFilterActions:               true,
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
+		lenientFlowServerTemplateRef:       true,
 		lenientApplicationSetMembers:       true,
 		lenientRibGroupRefs:                true,
 		lenientDHCPStaticBindings:          true,
@@ -560,6 +580,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFilterActions:               true,
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
+		lenientFlowServerTemplateRef:       true,
 		lenientApplicationSetMembers:       true,
 		lenientRibGroupRefs:                true,
 		lenientDHCPStaticBindings:          true,
@@ -1216,6 +1237,28 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFirewallRefs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("firewall routing-instance reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2461: per-flow-server NetFlow v9 / IPFIX template cross-reference. A
+	// flow-server `version9 { template <name> }` / `version-ipfix { template
+	// <name> }` (or the flat `version9-template` / `version-ipfix-template`)
+	// naming a template not defined under `services flow-monitoring`
+	// compiled cleanly; the live exporter ignored the reference and used the
+	// first map-iteration template, so the collector silently received a
+	// template (timeouts / export-extensions) it never requested and the
+	// choice flipped across restarts. Strict on commit / commit-check (hard
+	// reject so the typo is operator-visible); lenient on load / peer-sync
+	// (warn so an already-persisted or peer-synced config still boots —
+	// #1960; the resolver drops a group with an undefined template, exporting
+	// nothing for that collector rather than the wrong template). Mirrors
+	// validateLogProfileStreamReferencesStrict.
+	if err := validateFlowServerTemplateReferencesStrict(cfg); err != nil {
+		if opts.lenientFlowServerTemplateRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("flow-server template reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -379,6 +379,95 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateFlowServerTemplateReferencesStrict hard-rejects a per-flow-server
+// NetFlow v9 / IPFIX template reference (`version9 { template <name> }`,
+// `version9-template <name>`, `version-ipfix { template <name> }`, or
+// `version-ipfix-template <name>`) that names no template defined under the
+// matching `services flow-monitoring` version stanza (#2461).
+//
+// Without this gate the live exporter (pkg/flowexport) ignored the per-server
+// reference entirely and built one export config from the FIRST Go-map-
+// iteration template, broadcasting it to every collector of that version. A
+// collector that asked for a specific template silently received whichever
+// template the map happened to yield first, and that choice flipped across
+// process restarts (map order is not an operator contract). A reference to a
+// template that does not exist at all is the clearest form of the same defect:
+// the operator's intent (timeouts / export-extensions) is simply dropped.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientFlowServerTemplateRef) so an already-persisted or
+// peer-synced config carrying the typo still boots (#1960 fail-closed-on-load
+// class). The resolver (ResolveV9TemplateGroups / ResolveIPFIXTemplateGroups)
+// drops a group whose referenced template is undefined, so a leniently-loaded
+// bad config exports nothing for that collector rather than the wrong
+// template. Commit / commit-check stay strict so the operator's next edit
+// fails loudly. Mirrors validateLogProfileStreamReferencesStrict.
+func validateFlowServerTemplateReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	fm := cfg.Services.FlowMonitoring
+	if cfg.ForwardingOptions.Sampling == nil {
+		return nil
+	}
+
+	v9Defined := map[string]bool{}
+	ipfixDefined := map[string]bool{}
+	if fm != nil {
+		if fm.Version9 != nil {
+			for name := range fm.Version9.Templates {
+				v9Defined[name] = true
+			}
+		}
+		if fm.VersionIPFIX != nil {
+			for name := range fm.VersionIPFIX.Templates {
+				ipfixDefined[name] = true
+			}
+		}
+	}
+
+	// Walk the sampling instances in a deterministic key order so the
+	// first-error commit-check message is stable across runs (the instance
+	// map is unordered).
+	instNames := make([]string, 0, len(cfg.ForwardingOptions.Sampling.Instances))
+	for name := range cfg.ForwardingOptions.Sampling.Instances {
+		instNames = append(instNames, name)
+	}
+	sort.Strings(instNames)
+
+	for _, instName := range instNames {
+		inst := cfg.ForwardingOptions.Sampling.Instances[instName]
+		if inst == nil {
+			continue
+		}
+		for _, fam := range []*SamplingFamily{inst.FamilyInet, inst.FamilyInet6} {
+			if fam == nil {
+				continue
+			}
+			for _, fs := range fam.FlowServers {
+				if fs == nil {
+					continue
+				}
+				if fs.Version9Template != "" && !v9Defined[fs.Version9Template] {
+					return fmt.Errorf("forwarding-options sampling instance %q "+
+						"flow-server %s references undefined version9 template %q "+
+						"(define it under services flow-monitoring version9, or fix "+
+						"the template name — the collector would otherwise receive "+
+						"an arbitrary template)", instName, fs.Address, fs.Version9Template)
+				}
+				if fs.VersionIPFIXTemplate != "" && !ipfixDefined[fs.VersionIPFIXTemplate] {
+					return fmt.Errorf("forwarding-options sampling instance %q "+
+						"flow-server %s references undefined version-ipfix template "+
+						"%q (define it under services flow-monitoring version-ipfix, "+
+						"or fix the template name — the collector would otherwise "+
+						"receive an arbitrary template)", instName, fs.Address, fs.VersionIPFIXTemplate)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // routingRedistProtocolTokens is the set of bare protocol keywords that an
 // OSPF/OSPFv3/BGP/IS-IS `export` (or a RIP `redistribute`) accepts in lieu
 // of a named policy-statement. resolveRedistribute (pkg/frr/policy_render.go)

--- a/pkg/config/flowserver_template_ref_test.go
+++ b/pkg/config/flowserver_template_ref_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2461 — per-flow-server NetFlow v9 / IPFIX template cross-reference gate.
+//
+// A flow-server `version9 { template <name> }` (or the flat
+// `version9-template <name>`) / `version-ipfix { template <name> }`
+// reference to a template not defined under `services flow-monitoring` must
+// be hard-rejected on commit / commit-check (the live exporter would
+// otherwise silently use an arbitrary template), but downgraded to a warning
+// on the tolerant load / peer-sync path so an already-persisted config still
+// boots (#1960).
+
+func flowMonV9OnlyDefinedSet() []string {
+	return []string{
+		"set services flow-monitoring version9 template good-tmpl flow-active-timeout 60",
+	}
+}
+
+// TestFlowServerDanglingV9TemplateRejected: a flow-server referencing an
+// undefined v9 template is hard-rejected at commit.
+func TestFlowServerDanglingV9TemplateRejected(t *testing.T) {
+	cmds := append(flowMonV9OnlyDefinedSet(),
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 version9 template missing-tmpl",
+	)
+	tree := buildTreeFromSet(t, cmds)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a flow-server referencing an undefined version9 template; expected rejection")
+	}
+	for _, want := range []string{"10.0.0.1", "missing-tmpl", "version9"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestFlowServerDanglingIPFIXTemplateRejected: same for IPFIX.
+func TestFlowServerDanglingIPFIXTemplateRejected(t *testing.T) {
+	cmds := []string{
+		"set services flow-monitoring version-ipfix template good-tmpl flow-active-timeout 60",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.2 version-ipfix template nope-tmpl",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a flow-server referencing an undefined version-ipfix template; expected rejection")
+	}
+	for _, want := range []string{"10.0.0.2", "nope-tmpl", "version-ipfix"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestFlowServerDefinedTemplateAccepted: a flow-server referencing a DEFINED
+// template compiles cleanly (no over-gate).
+func TestFlowServerDefinedTemplateAccepted(t *testing.T) {
+	cmds := append(flowMonV9OnlyDefinedSet(),
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 version9 template good-tmpl",
+	)
+	tree := buildTreeFromSet(t, cmds)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a flow-server referencing a DEFINED template: %v", err)
+	}
+}
+
+// TestFlowServerNoTemplateRefAccepted: a flow-server with no per-server
+// template reference compiles cleanly (the common single-template case).
+func TestFlowServerNoTemplateRefAccepted(t *testing.T) {
+	cmds := append(flowMonV9OnlyDefinedSet(),
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055",
+	)
+	tree := buildTreeFromSet(t, cmds)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a flow-server with no template reference: %v", err)
+	}
+}
+
+// TestFlowServerDanglingTemplateLenientWarns: on the tolerant load /
+// peer-sync path the dangling reference is downgraded to a warning so the
+// config still boots (#1960).
+func TestFlowServerDanglingTemplateLenientWarns(t *testing.T) {
+	cmds := append(flowMonV9OnlyDefinedSet(),
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 version9 template missing-tmpl",
+	)
+	tree := buildTreeFromSet(t, cmds)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must NOT hard-reject a dangling flow-server template ref: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "flow-server template reference") && strings.Contains(w, "missing-tmpl") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("lenient compile must emit a downgraded warning for the dangling ref; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -2189,7 +2189,19 @@ func TestEventOptions(t *testing.T) {
 }
 
 func TestInlineJflowSourceAddress(t *testing.T) {
-	input := `forwarding-options {
+	// services flow-monitoring defines ipv4-template so the per-flow-server
+	// template reference resolves (#2461 strict gate); the test's purpose
+	// is the inline-jflow source-address parse + the template-ref field.
+	input := `services {
+    flow-monitoring {
+        version9 {
+            template ipv4-template {
+                flow-active-timeout 60;
+            }
+        }
+    }
+}
+forwarding-options {
     sampling {
         instance jflow-inst {
             input {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -164,10 +164,13 @@ type Daemon struct {
 	// otherwise cached flow routes stay pinned to pre-failover paths.
 	// Mutated only in actuateRouteOverlayLocked under applySem.
 	pendingFIBBump bool
-	flowExporter   *flowexport.Exporter
+	// #2461: one exporter per per-flow-server template group, so a
+	// collector receives the template it referenced (was a single exporter
+	// using the first map-iteration template for every collector).
+	flowExporters  []*flowexport.Exporter
 	flowCancel     context.CancelFunc
 	flowWg         sync.WaitGroup
-	ipfixExporter  *flowexport.IPFIXExporter
+	ipfixExporters []*flowexport.IPFIXExporter
 	ipfixCancel    context.CancelFunc
 	ipfixWg        sync.WaitGroup
 	// #2075 flowexport reconcile state. The bundle pointers carry the

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -150,10 +150,10 @@ func (d *Daemon) stopFlowExporter() {
 		d.flowCancel()
 	}
 	d.flowWg.Wait()
-	if d.flowExporter != nil {
-		d.flowExporter.Close()
-		d.flowExporter = nil
+	for _, exp := range d.flowExporters {
+		exp.Close()
 	}
+	d.flowExporters = nil
 	d.flowCancel = nil
 	d.flowBundle.Store(&exporterBundle{})
 }
@@ -166,10 +166,10 @@ func (d *Daemon) stopIPFIXExporter() {
 		d.ipfixCancel()
 	}
 	d.ipfixWg.Wait()
-	if d.ipfixExporter != nil {
-		d.ipfixExporter.Close()
-		d.ipfixExporter = nil
+	for _, exp := range d.ipfixExporters {
+		exp.Close()
 	}
+	d.ipfixExporters = nil
 	d.ipfixCancel = nil
 	d.ipfixBundlePtr.Store(&ipfixBundle{})
 }

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -44,32 +44,66 @@ import (
 	"github.com/psaab/xpf/pkg/logging"
 )
 
-// exporterBundle is the immutable (exporter, resolved-config) pair the
-// NetFlow v9 session-close callback reads via d.flowBundle. A nil exp
-// means "no v9 exporter configured".
-type exporterBundle struct {
+// v9Group is one running NetFlow v9 template-group exporter and its
+// resolved config (#2461). One flow-server template => one group => one
+// exporter, so a collector receives exactly the template it referenced.
+type v9Group struct {
 	exp *flowexport.Exporter
 	ec  *flowexport.ExportConfig
 }
 
-// ipfixBundle is the IPFIX equivalent of exporterBundle.
-type ipfixBundle struct {
+// ipfixGroup is the IPFIX equivalent of v9Group.
+type ipfixGroup struct {
 	exp *flowexport.IPFIXExporter
 	ec  *flowexport.ExportConfig
 }
 
-// flowExportConfigHash hashes the resolved *ExportConfig (Collectors,
-// timeouts, SamplingZones, SamplingRate, V9TemplateOpts). The
-// unexported atomic.Uint64 sampleCounter is invisible to json.Marshal,
-// and Go marshals map[uint16]SamplingDir keys in sorted numeric order,
-// so the encoding is deterministic. A nil ec hashes to a distinct
-// sentinel so "configured -> removed" registers as a real change.
-func flowExportConfigHash(ec *flowexport.ExportConfig) [32]byte {
-	if ec == nil {
+// exporterBundle is the immutable per-family set of NetFlow v9 template-
+// group exporters the session-close callback reads via d.flowBundle. An
+// empty groups slice means "no v9 exporter configured". The groups share
+// one ExportConfig.sampleCounter, so the callback evaluates ShouldExport
+// (the shared 1-in-N counter + sampling zones) EXACTLY ONCE and fans the
+// record out to every group (#2461).
+type exporterBundle struct {
+	groups []v9Group
+}
+
+// ipfixBundle is the IPFIX equivalent of exporterBundle.
+type ipfixBundle struct {
+	groups []ipfixGroup
+}
+
+// firstExp returns the first running v9 group exporter, or nil when no v9
+// exporter is configured. A test/inspection convenience over b.groups.
+func (b *exporterBundle) firstExp() *flowexport.Exporter {
+	if b == nil || len(b.groups) == 0 {
+		return nil
+	}
+	return b.groups[0].exp
+}
+
+// firstExp returns the first running IPFIX group exporter, or nil.
+func (b *ipfixBundle) firstExp() *flowexport.IPFIXExporter {
+	if b == nil || len(b.groups) == 0 {
+		return nil
+	}
+	return b.groups[0].exp
+}
+
+// flowExportConfigHash hashes the resolved per-family template groups
+// ([]*ExportConfig: Collectors, TemplateName, timeouts, SamplingZones,
+// SamplingRate, V9TemplateOpts). The unexported atomic.Uint64 sampleCounter
+// is invisible to json.Marshal, and Go marshals map[uint16]SamplingDir keys
+// in sorted numeric order, so the encoding is deterministic — provided the
+// resolver returns the groups in a stable order (it sorts by template name;
+// #2461). An empty slice hashes to a distinct sentinel so "configured ->
+// removed" registers as a real change.
+func flowExportConfigHash(ecs []*flowexport.ExportConfig) [32]byte {
+	if len(ecs) == 0 {
 		// Distinct, stable sentinel for the unconfigured state.
 		return sha256.Sum256([]byte("flowexport:nil"))
 	}
-	data, err := json.Marshal(ec)
+	data, err := json.Marshal(ecs)
 	if err != nil {
 		// Marshal of plain structs cannot realistically fail; fall back
 		// to a zero hash (forces re-apply) rather than silently skip.
@@ -78,29 +112,37 @@ func flowExportConfigHash(ec *flowexport.ExportConfig) [32]byte {
 	return sha256.Sum256(data)
 }
 
-// buildFlowExportConfig resolves the NetFlow v9 export config from the
-// committed config, filling per-zone sampling directions. Returns nil
-// when flow export is not configured.
-func (d *Daemon) buildFlowExportConfig(cfg *config.Config) *flowexport.ExportConfig {
-	ec := flowexport.BuildExportConfig(&cfg.Services, &cfg.ForwardingOptions)
-	if ec == nil {
+// buildFlowExportConfigs resolves the NetFlow v9 export config from the
+// committed config into one ExportConfig per per-flow-server template group
+// (#2461), filling per-zone sampling directions on each. Returns nil when
+// flow export is not configured.
+func (d *Daemon) buildFlowExportConfigs(cfg *config.Config) []*flowexport.ExportConfig {
+	ecs := flowexport.ResolveV9TemplateGroups(&cfg.Services, &cfg.ForwardingOptions)
+	if len(ecs) == 0 {
 		return nil
 	}
 	zoneIDs := buildZoneIDs(cfg)
-	ec.SamplingZones = flowexport.BuildSamplingZones(cfg, zoneIDs)
-	return ec
+	zones := flowexport.BuildSamplingZones(cfg, zoneIDs)
+	for _, ec := range ecs {
+		ec.SamplingZones = zones
+	}
+	return ecs
 }
 
-// buildIPFIXExportConfig resolves the IPFIX export config from the
-// committed config. Returns nil when IPFIX export is not configured.
-func (d *Daemon) buildIPFIXExportConfig(cfg *config.Config) *flowexport.ExportConfig {
-	ec := flowexport.BuildIPFIXExportConfig(&cfg.Services, &cfg.ForwardingOptions)
-	if ec == nil {
+// buildIPFIXExportConfigs resolves the IPFIX export config from the
+// committed config into one ExportConfig per template group. Returns nil
+// when IPFIX export is not configured.
+func (d *Daemon) buildIPFIXExportConfigs(cfg *config.Config) []*flowexport.ExportConfig {
+	ecs := flowexport.ResolveIPFIXTemplateGroups(&cfg.Services, &cfg.ForwardingOptions)
+	if len(ecs) == 0 {
 		return nil
 	}
 	zoneIDs := buildZoneIDs(cfg)
-	ec.SamplingZones = flowexport.BuildSamplingZones(cfg, zoneIDs)
-	return ec
+	zones := flowexport.BuildSamplingZones(cfg, zoneIDs)
+	for _, ec := range ecs {
+		ec.SamplingZones = zones
+	}
+	return ecs
 }
 
 // reconcileFlowExporters reconciles BOTH the NetFlow v9 and IPFIX
@@ -121,33 +163,34 @@ func (d *Daemon) reconcileFlowExporters(cfg *config.Config) bool {
 	return v9 || ipfix
 }
 
-// reconcileV9Exporter reconciles only the NetFlow v9 exporter.
+// reconcileV9Exporter reconciles the NetFlow v9 template-group exporters
+// (one per per-flow-server template, #2461).
 func (d *Daemon) reconcileV9Exporter(cfg *config.Config) bool {
 	d.flowReconMu.Lock()
 	defer d.flowReconMu.Unlock()
 
-	ec := d.buildFlowExportConfig(cfg)
-	h := flowExportConfigHash(ec)
+	ecs := d.buildFlowExportConfigs(cfg)
+	h := flowExportConfigHash(ecs)
 	if d.flowHashSet && h == d.flowHash {
-		return false // gated: healthy exporter keeps running
+		return false // gated: healthy exporters keep running
 	}
 
-	wasRunning := d.flowExporter != nil
+	wasRunning := len(d.flowExporters) > 0
 
-	// Stop the old exporter (if any). The session-close callback reads
+	// Stop the old exporters (if any). The session-close callback reads
 	// the bundle lock-free; we publish the new bundle as one atomic
-	// pointer, so a concurrent read sees either the old or new pair.
+	// pointer, so a concurrent read sees either the old or new set.
 	if d.flowCancel != nil {
 		d.flowCancel()
 		d.flowWg.Wait()
-		if d.flowExporter != nil {
-			d.flowExporter.Close()
+		for _, exp := range d.flowExporters {
+			exp.Close()
 		}
-		d.flowExporter = nil
+		d.flowExporters = nil
 		d.flowCancel = nil
 	}
 
-	if ec == nil {
+	if len(ecs) == 0 {
 		d.flowBundle.Store(&exporterBundle{})
 		d.flowHash, d.flowHashSet = h, true
 		if !wasRunning {
@@ -159,70 +202,81 @@ func (d *Daemon) reconcileV9Exporter(cfg *config.Config) bool {
 		return true
 	}
 
-	exp, err := flowexport.NewExporter(ec)
-	if err != nil {
-		slog.Warn("failed to create flow exporter", "err", err)
-		// Do NOT record the hash on a create failure: NewExporter ->
-		// dialCollectors can fail transiently (a pinned source-address
-		// bind before the source interface is up, transient collector
-		// DNS). Leaving flowHashSet false means the NEXT commit (even an
-		// identical one) retries instead of being hash-gated into a
-		// permanently-dead exporter. NewExporter is cheap, so the retry
-		// is safe; the gate re-arms on the first successful start.
-		d.flowBundle.Store(&exporterBundle{})
-		d.flowHashSet = false
-		return true
+	flowCtx, cancel := context.WithCancel(d.daemonCtx)
+	groups := make([]v9Group, 0, len(ecs))
+	exps := make([]*flowexport.Exporter, 0, len(ecs))
+	for _, ec := range ecs {
+		exp, err := flowexport.NewExporter(ec)
+		if err != nil {
+			slog.Warn("failed to create flow exporter", "template", ec.TemplateName, "err", err)
+			// Roll back the group exporters started so far and do NOT
+			// record the hash: NewExporter -> dialCollectors can fail
+			// transiently (a pinned source-address bind before the source
+			// interface is up, transient collector DNS). Leaving
+			// flowHashSet false means the NEXT commit (even an identical
+			// one) retries instead of being hash-gated into a permanently-
+			// dead family. NewExporter is cheap, so the retry is safe; the
+			// gate re-arms on the first fully-successful start.
+			cancel()
+			for _, e := range exps {
+				e.Close()
+			}
+			d.flowBundle.Store(&exporterBundle{})
+			d.flowHashSet = false
+			return true
+		}
+		exps = append(exps, exp)
+		groups = append(groups, v9Group{exp: exp, ec: ec})
 	}
 
-	flowCtx, cancel := context.WithCancel(d.daemonCtx)
-	d.flowExporter = exp
+	d.flowExporters = exps
 	d.flowCancel = cancel
-	d.flowBundle.Store(&exporterBundle{exp: exp, ec: ec})
+	d.flowBundle.Store(&exporterBundle{groups: groups})
 
 	d.flowCBOnce.Do(func() {
 		d.eventReader.AddCallback(d.flowExportCallback)
 	})
 
-	d.flowWg.Add(1)
-	go func() {
-		defer d.flowWg.Done()
-		exp.Run(flowCtx)
-	}()
+	for _, exp := range exps {
+		d.flowWg.Add(1)
+		go func(e *flowexport.Exporter) {
+			defer d.flowWg.Done()
+			e.Run(flowCtx)
+		}(exp)
+	}
 
 	d.flowHash, d.flowHashSet = h, true
 	slog.Info("NetFlow v9 exporter reconciled",
-		"collectors", len(ec.Collectors),
-		"active_timeout", ec.FlowActiveTimeout,
-		"inactive_timeout", ec.FlowInactiveTimeout,
-		"sampling_zones", len(ec.SamplingZones),
-		"sampling_rate", ec.SamplingRate)
+		"template_groups", len(ecs),
+		"sampling_zones", len(ecs[0].SamplingZones),
+		"sampling_rate", ecs[0].SamplingRate)
 	return true
 }
 
-// reconcileIPFIXExporter reconciles only the IPFIX exporter.
+// reconcileIPFIXExporter reconciles the IPFIX template-group exporters.
 func (d *Daemon) reconcileIPFIXExporter(cfg *config.Config) bool {
 	d.ipfixReconMu.Lock()
 	defer d.ipfixReconMu.Unlock()
 
-	ec := d.buildIPFIXExportConfig(cfg)
-	h := flowExportConfigHash(ec)
+	ecs := d.buildIPFIXExportConfigs(cfg)
+	h := flowExportConfigHash(ecs)
 	if d.ipfixHashSet && h == d.ipfixHash {
 		return false
 	}
 
-	wasRunning := d.ipfixExporter != nil
+	wasRunning := len(d.ipfixExporters) > 0
 
 	if d.ipfixCancel != nil {
 		d.ipfixCancel()
 		d.ipfixWg.Wait()
-		if d.ipfixExporter != nil {
-			d.ipfixExporter.Close()
+		for _, exp := range d.ipfixExporters {
+			exp.Close()
 		}
-		d.ipfixExporter = nil
+		d.ipfixExporters = nil
 		d.ipfixCancel = nil
 	}
 
-	if ec == nil {
+	if len(ecs) == 0 {
 		d.ipfixBundlePtr.Store(&ipfixBundle{})
 		d.ipfixHash, d.ipfixHashSet = h, true
 		if !wasRunning {
@@ -232,55 +286,69 @@ func (d *Daemon) reconcileIPFIXExporter(cfg *config.Config) bool {
 		return true
 	}
 
-	exp, err := flowexport.NewIPFIXExporter(ec)
-	if err != nil {
-		slog.Warn("failed to create IPFIX exporter", "err", err)
-		// Do NOT record the hash on a create failure (see the v9 path):
-		// leaving ipfixHashSet false lets the next commit retry instead
-		// of being gated into a permanently-dead exporter.
-		d.ipfixBundlePtr.Store(&ipfixBundle{})
-		d.ipfixHashSet = false
-		return true
+	ipfixCtx, cancel := context.WithCancel(d.daemonCtx)
+	groups := make([]ipfixGroup, 0, len(ecs))
+	exps := make([]*flowexport.IPFIXExporter, 0, len(ecs))
+	for _, ec := range ecs {
+		exp, err := flowexport.NewIPFIXExporter(ec)
+		if err != nil {
+			slog.Warn("failed to create IPFIX exporter", "template", ec.TemplateName, "err", err)
+			// Roll back and do NOT record the hash (see the v9 path).
+			cancel()
+			for _, e := range exps {
+				e.Close()
+			}
+			d.ipfixBundlePtr.Store(&ipfixBundle{})
+			d.ipfixHashSet = false
+			return true
+		}
+		exps = append(exps, exp)
+		groups = append(groups, ipfixGroup{exp: exp, ec: ec})
 	}
 
-	ipfixCtx, cancel := context.WithCancel(d.daemonCtx)
-	d.ipfixExporter = exp
+	d.ipfixExporters = exps
 	d.ipfixCancel = cancel
-	d.ipfixBundlePtr.Store(&ipfixBundle{exp: exp, ec: ec})
+	d.ipfixBundlePtr.Store(&ipfixBundle{groups: groups})
 
 	d.ipfixCBOnce.Do(func() {
 		d.eventReader.AddCallback(d.ipfixExportCallback)
 	})
 
-	d.ipfixWg.Add(1)
-	go func() {
-		defer d.ipfixWg.Done()
-		exp.Run(ipfixCtx)
-	}()
+	for _, exp := range exps {
+		d.ipfixWg.Add(1)
+		go func(e *flowexport.IPFIXExporter) {
+			defer d.ipfixWg.Done()
+			e.Run(ipfixCtx)
+		}(exp)
+	}
 
 	d.ipfixHash, d.ipfixHashSet = h, true
 	slog.Info("IPFIX exporter reconciled",
-		"collectors", len(ec.Collectors),
-		"active_timeout", ec.FlowActiveTimeout,
-		"inactive_timeout", ec.FlowInactiveTimeout,
-		"sampling_zones", len(ec.SamplingZones),
-		"sampling_rate", ec.SamplingRate)
+		"template_groups", len(ecs),
+		"sampling_zones", len(ecs[0].SamplingZones),
+		"sampling_rate", ecs[0].SamplingRate)
 	return true
 }
 
 // flowExportCallback is the single, stable NetFlow v9 session-close
 // handler registered on the EventReader exactly once. It reads the live
-// (exporter, config) pair lock-free from the atomic bundle, so reconcile
-// can swap the exporter without ever touching the callback list.
+// set of template-group exporters lock-free from the atomic bundle, so
+// reconcile can swap the exporters without ever touching the callback list.
+//
+// #2461: the family's groups share one ShouldExport state (the 1-in-N
+// counter + sampling zones), so the sampling decision is made EXACTLY ONCE
+// (on groups[0]) and the record is fanned out to every group — each group
+// encodes with the template its collectors referenced. Deciding per group
+// would over-increment the shared counter and corrupt the 1-in-N cadence.
 func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
 	if rec.Type != "SESSION_CLOSE" {
 		return
 	}
 	b := d.flowBundle.Load()
-	if b == nil || b.exp == nil || b.ec == nil {
+	if b == nil || len(b.groups) == 0 {
 		return
 	}
-	if !b.ec.ShouldExport(rec.InZone, rec.OutZone) {
+	if !b.groups[0].ec.ShouldExport(rec.InZone, rec.OutZone) {
 		return
 	}
 	sd := flowexport.SessionCloseData{
@@ -289,7 +357,9 @@ func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
 		Protocol: parseProtocol(rec.Protocol),
 	}
 	sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
-	b.exp.ExportSessionClose(rec, sd)
+	for _, g := range b.groups {
+		g.exp.ExportSessionClose(rec, sd)
+	}
 }
 
 // ipfixExportCallback is the IPFIX equivalent of flowExportCallback.
@@ -298,10 +368,10 @@ func (d *Daemon) ipfixExportCallback(rec logging.EventRecord, raw []byte) {
 		return
 	}
 	b := d.ipfixBundlePtr.Load()
-	if b == nil || b.exp == nil || b.ec == nil {
+	if b == nil || len(b.groups) == 0 {
 		return
 	}
-	if !b.ec.ShouldExport(rec.InZone, rec.OutZone) {
+	if !b.groups[0].ec.ShouldExport(rec.InZone, rec.OutZone) {
 		return
 	}
 	sd := flowexport.SessionCloseData{
@@ -310,5 +380,7 @@ func (d *Daemon) ipfixExportCallback(rec logging.EventRecord, raw []byte) {
 		Protocol: parseProtocol(rec.Protocol),
 	}
 	sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
-	b.exp.ExportSessionClose(rec, sd)
+	for _, g := range b.groups {
+		g.exp.ExportSessionClose(rec, sd)
+	}
 }

--- a/pkg/daemon/daemon_flowexport_reconcile_test.go
+++ b/pkg/daemon/daemon_flowexport_reconcile_test.go
@@ -99,7 +99,7 @@ func TestReconcileFlowExporterAddAfterBoot(t *testing.T) {
 	if d.reconcileFlowExporters(&config.Config{}) {
 		t.Fatal("empty config should not start an exporter")
 	}
-	if b := d.flowBundle.Load(); b != nil && b.exp != nil {
+	if b := d.flowBundle.Load(); b != nil && b.firstExp() != nil {
 		t.Fatal("no exporter should exist for empty config")
 	}
 
@@ -107,10 +107,10 @@ func TestReconcileFlowExporterAddAfterBoot(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("adding flow export must start the exporter")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("exporter must be live after add-after-boot")
 	}
-	if d.flowExporter == nil {
+	if len(d.flowExporters) == 0 {
 		t.Fatal("d.flowExporter must be set after add-after-boot")
 	}
 }
@@ -124,7 +124,7 @@ func TestReconcileFlowExporterRemoveAfterBoot(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("initial config must start exporter")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("exporter must be live")
 	}
 
@@ -132,10 +132,10 @@ func TestReconcileFlowExporterRemoveAfterBoot(t *testing.T) {
 	if !d.reconcileFlowExporters(&config.Config{}) {
 		t.Fatal("removing flow export must reconcile (stop exporter)")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp != nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() != nil {
 		t.Fatal("exporter must be stopped after removal")
 	}
-	if d.flowExporter != nil {
+	if len(d.flowExporters) > 0 {
 		t.Fatal("d.flowExporter must be nil after removal")
 	}
 }
@@ -151,7 +151,7 @@ func TestReconcileFlowExporterHashGate(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("initial config must start exporter")
 	}
-	first := d.flowBundle.Load().exp
+	first := d.flowBundle.Load().firstExp()
 	if first == nil {
 		t.Fatal("exporter must be live")
 	}
@@ -160,7 +160,7 @@ func TestReconcileFlowExporterHashGate(t *testing.T) {
 	if d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("identical config must be hash-gated (no restart)")
 	}
-	if got := d.flowBundle.Load().exp; got != first {
+	if got := d.flowBundle.Load().firstExp(); got != first {
 		t.Fatal("hash-gated reconcile must keep the SAME exporter instance")
 	}
 
@@ -168,7 +168,7 @@ func TestReconcileFlowExporterHashGate(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.2", 100)) {
 		t.Fatal("changed collector must re-apply")
 	}
-	if got := d.flowBundle.Load().exp; got == first {
+	if got := d.flowBundle.Load().firstExp(); got == first {
 		t.Fatal("a real config change must swap to a new exporter instance")
 	}
 	// A sampling-rate change also re-applies.
@@ -211,11 +211,11 @@ func TestReconcileV9IPFIXIndependence(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("v9 config must start")
 	}
-	v9 := d.flowBundle.Load().exp
+	v9 := d.flowBundle.Load().firstExp()
 	if v9 == nil {
 		t.Fatal("v9 exporter must be live")
 	}
-	if b := d.ipfixBundlePtr.Load(); b != nil && b.exp != nil {
+	if b := d.ipfixBundlePtr.Load(); b != nil && b.firstExp() != nil {
 		t.Fatal("IPFIX must not be configured yet")
 	}
 
@@ -223,11 +223,11 @@ func TestReconcileV9IPFIXIndependence(t *testing.T) {
 	if !d.reconcileFlowExporters(ipfixSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("adding IPFIX must reconcile")
 	}
-	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("IPFIX exporter must be live after add")
 	}
 	// v9 untouched (same instance).
-	if got := d.flowBundle.Load().exp; got != v9 {
+	if got := d.flowBundle.Load().firstExp(); got != v9 {
 		t.Fatal("adding IPFIX must NOT bounce the running v9 exporter")
 	}
 }
@@ -254,7 +254,7 @@ func TestReconcileFlowExporterRetriesAfterCreateFailure(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfigSrc("127.0.0.1", "192.0.2.250", 100)) {
 		t.Fatal("a create-failing reconcile should still report a change")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp != nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() != nil {
 		t.Fatal("no exporter should be live after a create failure")
 	}
 	if d.flowHashSet {
@@ -266,7 +266,7 @@ func TestReconcileFlowExporterRetriesAfterCreateFailure(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("a working config after a create failure must start the exporter")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("exporter must recover on the next working commit")
 	}
 }
@@ -296,7 +296,7 @@ func TestApplyConfigLockedReconcilesFlowExporters(t *testing.T) {
 		t.Fatalf("applyConfigLocked: %v", err)
 	}
 
-	if d.flowExporter == nil {
+	if len(d.flowExporters) == 0 {
 		t.Fatal("applyConfigLocked did not reconcile the flow exporter: " +
 			"a committed forwarding-options sampling stanza left the NetFlow " +
 			"exporter unstarted (missing reconcileFlowExporters wiring)")
@@ -334,10 +334,10 @@ func TestReconcileIPFIXOnlyDoesNotStartV9(t *testing.T) {
 	if !d.reconcileFlowExporters(ipfixOnlySamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("an IPFIX-only config must reconcile (the IPFIX exporter starts)")
 	}
-	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("IPFIX exporter must be live for an IPFIX-only config")
 	}
-	if b := d.flowBundle.Load(); b != nil && b.exp != nil {
+	if b := d.flowBundle.Load(); b != nil && b.firstExp() != nil {
 		t.Fatal("#2129: no v9 exporter may start without a `version9` stanza " +
 			"— an IPFIX-only operator must not get an unrequested v9 stream")
 	}
@@ -376,10 +376,10 @@ func TestReconcileBothVersionsUnboundServerNoDoubleExport(t *testing.T) {
 	if !d.reconcileFlowExporters(bothVersionsUnboundConfig("127.0.0.1", 100)) {
 		t.Fatal("both-versions config must reconcile (the IPFIX exporter starts)")
 	}
-	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("#2136: unbound server under both versions must run the IPFIX exporter")
 	}
-	if b := d.flowBundle.Load(); b != nil && b.exp != nil {
+	if b := d.flowBundle.Load(); b != nil && b.firstExp() != nil {
 		t.Fatal("#2136: an UNBOUND collector under both versions must NOT also " +
 			"start the v9 exporter — that is the double-export bug")
 	}
@@ -406,7 +406,7 @@ func TestReconcileV9RequiresVersion9Stanza(t *testing.T) {
 		t.Fatal("#2129: sampling without any flow-monitoring stanza must " +
 			"NOT start a v9 exporter (no change to reconcile)")
 	}
-	if b := d.flowBundle.Load(); b != nil && b.exp != nil {
+	if b := d.flowBundle.Load(); b != nil && b.firstExp() != nil {
 		t.Fatal("#2129: no v9 exporter may start without a `version9` stanza")
 	}
 
@@ -414,7 +414,7 @@ func TestReconcileV9RequiresVersion9Stanza(t *testing.T) {
 	if !d.reconcileFlowExporters(flowSamplingConfig("127.0.0.1", 100)) {
 		t.Fatal("adding version9 must start the v9 exporter")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("v9 exporter must be live once version9 is configured")
 	}
 }

--- a/pkg/daemon/daemon_flowexport_session_close_test.go
+++ b/pkg/daemon/daemon_flowexport_session_close_test.go
@@ -139,10 +139,10 @@ func TestSessionCloseRawEventDrivesFlowExport(t *testing.T) {
 	if !d.reconcileFlowExporters(flowIPFIXConfigPorts("127.0.0.1", v9Port, ipfixPort)) {
 		t.Fatal("flow + ipfix exporters must start")
 	}
-	if b := d.flowBundle.Load(); b == nil || b.exp == nil {
+	if b := d.flowBundle.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("v9 exporter must be live")
 	}
-	if b := d.ipfixBundlePtr.Load(); b == nil || b.exp == nil {
+	if b := d.ipfixBundlePtr.Load(); b == nil || b.firstExp() == nil {
 		t.Fatal("ipfix exporter must be live")
 	}
 	// The two real export callbacks are registered exactly once.
@@ -193,10 +193,10 @@ func TestSessionCloseRawEventDrivesFlowExport(t *testing.T) {
 	// Both REAL exporters export a flow record for the close — proving the
 	// SESSION_CLOSE-derived FlowRecord reaches both production export paths
 	// (Stats.flows counts data records, not templates).
-	if got := waitFlows(t, d.flowExporter.Stats); got < 1 {
+	if got := waitFlows(t, d.flowBundle.Load().firstExp().Stats); got < 1 {
 		t.Fatalf("NetFlow v9 exporter exported %d flows after the SESSION_CLOSE, want >= 1", got)
 	}
-	if got := waitFlows(t, d.ipfixExporter.Stats); got < 1 {
+	if got := waitFlows(t, d.ipfixBundlePtr.Load().firstExp().Stats); got < 1 {
 		t.Fatalf("IPFIX exporter exported %d flows after the SESSION_CLOSE, want >= 1", got)
 	}
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -152,11 +152,15 @@ The resolver now groups collectors by the template they referenced and
 emits one `*ExportConfig` per group:
 
 - **`ResolveV9TemplateGroups` / `ResolveIPFIXTemplateGroups`** (`manager.go`)
-  return `[]*ExportConfig`, one per `(template, source-address)` group.
-  Each group carries the timeouts / `V9TemplateOpts` of the template its
-  collectors referenced. A collector that referenced no template lands in
-  the default (`TemplateName == ""`) group, which inherits the lone
-  template's parameters when exactly one is configured (the common
+  return `[]*ExportConfig`, one per referenced template. The group key is
+  `(version, template_name)`; **source-address is a deterministic sort
+  tiebreak, NOT part of the grouping key** — collectors that share a
+  template but pin different source-addresses share ONE group and each
+  still receives its own source-pinned UDP connection (via
+  `dialCollectors`). Each group carries the timeouts / `V9TemplateOpts` of
+  the template its collectors referenced. A collector that referenced no
+  template lands in the default (`TemplateName == ""`) group, which inherits
+  the lone template's parameters when exactly one is configured (the common
   single-template case — unchanged) and otherwise the built-in defaults.
 - **Determinism.** Groups are sorted by template name and each group's
   collectors by address, so process restarts produce identical exporter

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -79,7 +79,13 @@ IPFIX:
 - `IPFIXExporter.ExportSessionClose(rec, evt)` — emit one record.
 
 Shared:
-- `ExportConfig` — `manager.go`. Resolved per-collector config.
+- `ExportConfig` — `manager.go`. Resolved per-template-group config: the
+  collectors that referenced one template, that template's timeouts /
+  field options, plus the family-shared sampling state (#2461 — see
+  "Per-flow-server template binding" below).
+- `ResolveV9TemplateGroups(...) []*ExportConfig` /
+  `ResolveIPFIXTemplateGroups(...)` — `manager.go`. The per-template-group
+  resolvers the daemon uses (#2461).
 - `BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig` — `manager.go`.
   Returns nil (no v9 exporter) unless BOTH `forwarding-options sampling`
   has a flow-server AND `services flow-monitoring version9` is configured
@@ -130,6 +136,53 @@ Resolution order for one flow-server (`resolveFlowServerVersion`):
    datagram stream rather than the pre-#2136 double-export. To send v9 to
    such a collector, pin it explicitly with a per-server `version9`
    selector.
+
+## Per-flow-server template binding (#2461)
+
+After #2136 routes each flow-server to the right *version*, #2461 routes
+it to the right *template*. Junos binds each flow-server to one template
+under its version; before #2461 the resolver ignored that reference
+entirely — it built ONE export config from the FIRST Go-map-iteration
+template and broadcast it (timeouts, `flow-dir` export-extension) to every
+collector of the version. A collector that asked for a specific template
+silently received whichever the map yielded first, and that choice flipped
+across process restarts (map order is not an operator contract).
+
+The resolver now groups collectors by the template they referenced and
+emits one `*ExportConfig` per group:
+
+- **`ResolveV9TemplateGroups` / `ResolveIPFIXTemplateGroups`** (`manager.go`)
+  return `[]*ExportConfig`, one per `(template, source-address)` group.
+  Each group carries the timeouts / `V9TemplateOpts` of the template its
+  collectors referenced. A collector that referenced no template lands in
+  the default (`TemplateName == ""`) group, which inherits the lone
+  template's parameters when exactly one is configured (the common
+  single-template case — unchanged) and otherwise the built-in defaults.
+- **Determinism.** Groups are sorted by template name and each group's
+  collectors by address, so process restarts produce identical exporter
+  wiring — the map-iteration nondeterminism is gone.
+- **Validation.** A flow-server referencing an UNDEFINED template is
+  hard-rejected at commit / commit-check by
+  `validateFlowServerTemplateReferencesStrict` (`pkg/config`). The tolerant
+  load / peer-sync path downgrades it to a warning (#1960) and the resolver
+  DROPS that group, so a leniently-loaded bad config exports nothing for
+  that collector rather than the wrong template.
+- **Shared sampling.** 1-in-N sampling is a forwarding-options-instance
+  property, not a per-template one, so all groups of a family share ONE
+  `sampleCounter` (a pointer). The daemon evaluates `ShouldExport` exactly
+  once per SESSION_CLOSE and fans the record out to every group.
+- `BuildExportConfig` / `BuildIPFIXExportConfig` (singular) are retained
+  for single-aggregate callers and now return the first resolved group.
+
+### Daemon wiring (one exporter per group)
+
+`reconcileFlowExporters` now starts **N exporters per family** — one per
+template group — instead of a single exporter. `d.flowExporters` /
+`d.ipfixExporters` are slices; the atomic `flowBundle` / `ipfixBundlePtr`
+carry the group set; the once-registered session-close callback makes the
+shared sampling decision on `groups[0]` and exports to every group. The
+per-family config-hash gate, transient-create-failure retry (no hash
+recorded), and shutdown teardown all operate over the slice.
 
 ## Callers
 

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -42,7 +42,11 @@ type SamplingDir struct {
 // from the FIRST Go-map-iteration template and broadcast to every
 // collector, so a per-flow-server template reference was silently ignored
 // and the chosen template flipped across restarts. The resolver now emits
-// one ExportConfig per (template, source-address) group (see
+// one ExportConfig per referenced template — the group key is
+// (version, template_name); source-address is a deterministic sort
+// tiebreak, NOT part of the key, so collectors that share a template but
+// pin different source-addresses land in ONE group and each still gets its
+// own source-pinned UDP connection from dialCollectors (see
 // ResolveV9TemplateGroups / ResolveIPFIXTemplateGroups). The daemon runs
 // one exporter per group; the groups of a family share one sampleCounter
 // (pointer below) so 1-in-N sampling stays global across the family rather
@@ -176,7 +180,9 @@ func collectVersionCollectors(fo *config.ForwardingOptionsConfig, version string
 }
 
 // dedupeCollectors removes duplicate collector destinations (same
-// address + source-address) in-place, preserving first-seen order.
+// address + source-address + referenced template — see collectorKey)
+// in-place, preserving first-seen order. This is the dedup key, NOT the
+// grouping key: grouping is by template name alone (groupCollectorsByTemplate).
 func dedupeCollectors(collectors []CollectorConfig) []CollectorConfig {
 	seen := make(map[string]bool)
 	deduped := collectors[:0]

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -17,7 +17,9 @@ package flowexport
 
 import (
 	"net"
+	"sort"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -30,22 +32,50 @@ type SamplingDir struct {
 	Output bool
 }
 
-// ExportConfig holds the resolved NetFlow export configuration.
+// ExportConfig holds the resolved NetFlow export configuration for a
+// single template group: the collectors that referenced one template (or
+// the default-template collectors that referenced none), the timeouts and
+// v9 field options resolved from THAT template, plus the family-wide
+// sampling state.
+//
+// #2461: before this change a single ExportConfig was built per family
+// from the FIRST Go-map-iteration template and broadcast to every
+// collector, so a per-flow-server template reference was silently ignored
+// and the chosen template flipped across restarts. The resolver now emits
+// one ExportConfig per (template, source-address) group (see
+// ResolveV9TemplateGroups / ResolveIPFIXTemplateGroups). The daemon runs
+// one exporter per group; the groups of a family share one sampleCounter
+// (pointer below) so 1-in-N sampling stays global across the family rather
+// than restarting the modulo cadence per template.
 type ExportConfig struct {
 	Collectors          []CollectorConfig
+	TemplateName        string // referenced template ("" = default group)
 	FlowActiveTimeout   time.Duration
 	FlowInactiveTimeout time.Duration
 	TemplateRefreshRate time.Duration
 	SamplingZones       map[uint16]SamplingDir // zone ID -> sampling directions
 	SamplingRate        int                    // 1-in-N sampling (0 = export all)
 	V9TemplateOpts      V9TemplateOptions      // optional v9 template field control
-	sampleCounter       atomic.Uint64          // monotonic counter for 1-in-N
+	// sampleCounter is the monotonic 1-in-N counter. It is a POINTER so all
+	// ExportConfig groups of one family share a single counter (the
+	// sampling rate is a forwarding-options-instance property, not a
+	// per-template one). A nil pointer is lazily allocated on first use so
+	// a hand-built ExportConfig (tests, the singular Build* helpers) still
+	// samples correctly. json.Marshal skips the unexported field, so the
+	// reconcile config-hash is unaffected.
+	sampleCounter *atomic.Uint64
+	counterOnce   sync.Once
 }
 
 // CollectorConfig defines a single NetFlow collector destination.
 type CollectorConfig struct {
 	Address       string // "host:port"
 	SourceAddress string // local bind address (empty = auto)
+	// Template is the per-flow-server template the collector referenced
+	// ("" = none → default group). It is the grouping key for #2461 and is
+	// NOT serialized into the dialed connection; it only steers which
+	// ExportConfig (template context) the collector is placed under.
+	Template string `json:"-"`
 }
 
 // resolveFlowServerVersion returns the export protocol a single
@@ -130,9 +160,14 @@ func collectVersionCollectors(fo *config.ForwardingOptionsConfig, version string
 				if srcAddr == "" {
 					srcAddr = fam.InlineJflowSourceAddress
 				}
+				tmpl := fs.Version9Template
+				if version == config.FlowServerVersionIPFIX {
+					tmpl = fs.VersionIPFIXTemplate
+				}
 				collectors = append(collectors, CollectorConfig{
 					Address:       addr,
 					SourceAddress: srcAddr,
+					Template:      tmpl,
 				})
 			}
 		}
@@ -155,87 +190,187 @@ func dedupeCollectors(collectors []CollectorConfig) []CollectorConfig {
 	return deduped
 }
 
-// BuildExportConfig resolves config types into an ExportConfig.
-// Returns nil if no flow export is configured.
-func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
+// templateContext is the resolved per-template export parameters (the
+// timeouts and the v9 field options) carried into every ExportConfig built
+// for the collectors that referenced that template. #2461.
+type templateContext struct {
+	activeTimeout   time.Duration
+	inactiveTimeout time.Duration
+	refreshRate     time.Duration
+	v9opts          V9TemplateOptions
+}
+
+// defaultTemplateContext is the timeout/refresh fallback used for a
+// collector that referenced no template and when a referenced template
+// name has no matching definition that overrides a field.
+func defaultTemplateContext() templateContext {
+	return templateContext{
+		activeTimeout:   60 * time.Second,
+		inactiveTimeout: 15 * time.Second,
+		refreshRate:     60 * time.Second,
+	}
+}
+
+// v9TemplateContext resolves one NetFlow v9 template definition into a
+// templateContext. A zero/absent field keeps the default.
+func v9TemplateContext(tmpl *config.NetFlowV9Template) templateContext {
+	tc := defaultTemplateContext()
+	if tmpl == nil {
+		return tc
+	}
+	if tmpl.FlowActiveTimeout > 0 {
+		tc.activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
+	}
+	if tmpl.FlowInactiveTimeout > 0 {
+		tc.inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
+	}
+	if tmpl.TemplateRefreshRate > 0 {
+		tc.refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
+	}
+	for _, ext := range tmpl.ExportExtensions {
+		if ext == "flow-dir" {
+			tc.v9opts.IncludeFlowDir = true
+		}
+	}
+	return tc
+}
+
+// ipfixTemplateContext resolves one IPFIX template definition into a
+// templateContext (IPFIX has no v9 field options).
+func ipfixTemplateContext(tmpl *config.NetFlowIPFIXTemplate) templateContext {
+	tc := defaultTemplateContext()
+	if tmpl == nil {
+		return tc
+	}
+	if tmpl.FlowActiveTimeout > 0 {
+		tc.activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
+	}
+	if tmpl.FlowInactiveTimeout > 0 {
+		tc.inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
+	}
+	if tmpl.TemplateRefreshRate > 0 {
+		tc.refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
+	}
+	return tc
+}
+
+// samplingRate returns the global 1-in-N sampling rate (the first sampling
+// instance's input rate), shared by every template group of both families.
+func samplingRate(fo *config.ForwardingOptionsConfig) int {
+	for _, inst := range fo.Sampling.Instances {
+		if inst.InputRate > 0 {
+			return inst.InputRate
+		}
+	}
+	return 0
+}
+
+// groupCollectorsByTemplate partitions the deduplicated collector list into
+// one slice per referenced template name, returning the group keys sorted
+// deterministically. The empty-string key holds collectors that referenced
+// no template (the default group). Determinism (#2461): the group order and
+// the per-group collector order are stable across process restarts, killing
+// the Go-map-iteration nondeterminism that let a collector silently flip
+// between templates.
+func groupCollectorsByTemplate(collectors []CollectorConfig) ([]string, map[string][]CollectorConfig) {
+	groups := make(map[string][]CollectorConfig)
+	for _, c := range collectors {
+		groups[c.Template] = append(groups[c.Template], c)
+	}
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		cs := groups[k]
+		sort.Slice(cs, func(i, j int) bool {
+			if cs[i].Address != cs[j].Address {
+				return cs[i].Address < cs[j].Address
+			}
+			return cs[i].SourceAddress < cs[j].SourceAddress
+		})
+		groups[k] = cs
+	}
+	return keys, groups
+}
+
+// ResolveV9TemplateGroups resolves the NetFlow v9 export configuration into
+// one ExportConfig per referenced template (#2461). Each group carries the
+// timeouts / field options of the template its collectors actually
+// referenced, instead of broadcasting the first map-iteration template to
+// every collector. A collector referencing no template lands in the default
+// group, which uses the lone configured template's parameters when there is
+// exactly one (the common single-template case, unchanged behavior), else
+// the built-in defaults. A collector referencing a template that is not
+// defined is DROPPED (the strict commit-time gate
+// validateFlowServerTemplateReferencesStrict rejects it on commit; this is
+// the lenient-load backstop — export nothing for that collector rather than
+// the wrong template). All groups share one sampleCounter so 1-in-N
+// sampling stays global. Returns nil when no v9 export is configured.
+func ResolveV9TemplateGroups(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) []*ExportConfig {
 	if fo == nil || fo.Sampling == nil || len(fo.Sampling.Instances) == 0 {
 		return nil
 	}
 	// #2129: a NetFlow v9 exporter must only start when `services
-	// flow-monitoring version9` is configured. This mirrors the
-	// VersionIPFIX guard in BuildIPFIXExportConfig below. Without it an
-	// IPFIX-only operator (or one with sampling+flow-server but no
-	// flow-monitoring stanza at all) received an unrequested v9 datagram
-	// stream at the collector. NOTE: this fixes only the *unrequested* v9
-	// stream; a flow-server configured with BOTH version9 and
-	// version-ipfix still double-exports to one collector (each version
-	// passes its own gate) — that per-flow-server version-binding fix is
-	// deferred to a follow-up.
+	// flow-monitoring version9` is configured.
 	if svc == nil || svc.FlowMonitoring == nil || svc.FlowMonitoring.Version9 == nil {
 		return nil
 	}
 
-	// Collect template timeouts from services config
-	activeTimeout := 60 * time.Second
-	inactiveTimeout := 15 * time.Second
-	refreshRate := 60 * time.Second
-
-	// The guard above guarantees svc.FlowMonitoring.Version9 != nil.
-	var v9opts V9TemplateOptions
-	for _, tmpl := range svc.FlowMonitoring.Version9.Templates {
-		if tmpl.FlowActiveTimeout > 0 {
-			activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
-		}
-		if tmpl.FlowInactiveTimeout > 0 {
-			inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
-		}
-		if tmpl.TemplateRefreshRate > 0 {
-			refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
-		}
-		for _, ext := range tmpl.ExportExtensions {
-			switch ext {
-			case "flow-dir":
-				v9opts.IncludeFlowDir = true
-			}
-		}
-		break // use first template
-	}
-
-	ec := &ExportConfig{
-		FlowActiveTimeout:   activeTimeout,
-		FlowInactiveTimeout: inactiveTimeout,
-		TemplateRefreshRate: refreshRate,
-		V9TemplateOpts:      v9opts,
-	}
-
-	// Use the first sampling instance's input rate as the global sampling rate
-	for _, inst := range fo.Sampling.Instances {
-		if inst.InputRate > 0 {
-			ec.SamplingRate = inst.InputRate
-			break
-		}
-	}
-
-	// Collect only the flow-servers bound to NetFlow v9. A server is
-	// bound to v9 by an explicit per-server selector, or — when it has
-	// no per-server selector — by inheriting v9 only if IPFIX is not
-	// also configured (IPFIX wins the unbound precedence). This is the
-	// #2136 per-flow-server version binding: it skips servers resolved
-	// to IPFIX so a collector configured under both versions receives
-	// exactly one datagram stream, not two.
 	hasIPFIX := svc.FlowMonitoring.VersionIPFIX != nil
-	ec.Collectors = collectVersionCollectors(fo, config.FlowServerVersion9, true, hasIPFIX)
-
-	if len(ec.Collectors) == 0 {
+	// #2136 per-flow-server version binding: collect only the flow-servers
+	// bound to NetFlow v9 so a collector under both versions gets one stream.
+	collectors := collectVersionCollectors(fo, config.FlowServerVersion9, true, hasIPFIX)
+	if len(collectors) == 0 {
 		return nil
 	}
 
-	return ec
+	defined := svc.FlowMonitoring.Version9.Templates
+	// defaultCtx: when exactly one template is defined, an unreferenced
+	// collector inherits it (preserves the pre-#2461 single-template case);
+	// with zero or multiple templates it uses the built-in defaults.
+	defaultCtx := defaultTemplateContext()
+	if len(defined) == 1 {
+		for _, tmpl := range defined {
+			defaultCtx = v9TemplateContext(tmpl)
+		}
+	}
+
+	rate := samplingRate(fo)
+	shared := &atomic.Uint64{}
+	keys, groups := groupCollectorsByTemplate(collectors)
+
+	var out []*ExportConfig
+	for _, name := range keys {
+		ctx := defaultCtx
+		if name != "" {
+			tmpl, ok := defined[name]
+			if !ok {
+				// Undefined reference: drop (the strict gate rejects on
+				// commit; lenient load exports nothing for these collectors).
+				continue
+			}
+			ctx = v9TemplateContext(tmpl)
+		}
+		out = append(out, &ExportConfig{
+			Collectors:          groups[name],
+			TemplateName:        name,
+			FlowActiveTimeout:   ctx.activeTimeout,
+			FlowInactiveTimeout: ctx.inactiveTimeout,
+			TemplateRefreshRate: ctx.refreshRate,
+			V9TemplateOpts:      ctx.v9opts,
+			SamplingRate:        rate,
+			sampleCounter:       shared,
+		})
+	}
+	return out
 }
 
-// BuildIPFIXExportConfig resolves IPFIX config into an ExportConfig.
-// Falls back to v9 collectors/sampling if no IPFIX-specific overrides.
-func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
+// ResolveIPFIXTemplateGroups is the IPFIX equivalent of
+// ResolveV9TemplateGroups (#2461). Returns nil when no IPFIX export is
+// configured.
+func ResolveIPFIXTemplateGroups(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) []*ExportConfig {
 	if fo == nil || fo.Sampling == nil || len(fo.Sampling.Instances) == 0 {
 		return nil
 	}
@@ -243,50 +378,68 @@ func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOpt
 		return nil
 	}
 
-	activeTimeout := 60 * time.Second
-	inactiveTimeout := 15 * time.Second
-	refreshRate := 60 * time.Second
-
-	for _, tmpl := range svc.FlowMonitoring.VersionIPFIX.Templates {
-		if tmpl.FlowActiveTimeout > 0 {
-			activeTimeout = time.Duration(tmpl.FlowActiveTimeout) * time.Second
-		}
-		if tmpl.FlowInactiveTimeout > 0 {
-			inactiveTimeout = time.Duration(tmpl.FlowInactiveTimeout) * time.Second
-		}
-		if tmpl.TemplateRefreshRate > 0 {
-			refreshRate = time.Duration(tmpl.TemplateRefreshRate) * time.Second
-		}
-		break // use first template
-	}
-
-	ec := &ExportConfig{
-		FlowActiveTimeout:   activeTimeout,
-		FlowInactiveTimeout: inactiveTimeout,
-		TemplateRefreshRate: refreshRate,
-	}
-
-	// Same sampling rate as v9 (shared forwarding-options sampling).
-	for _, inst := range fo.Sampling.Instances {
-		if inst.InputRate > 0 {
-			ec.SamplingRate = inst.InputRate
-			break
-		}
-	}
-
-	// Collect only the flow-servers bound to IPFIX (#2136). A server is
-	// bound to IPFIX by an explicit per-server selector, or — when it
-	// has no per-server selector — by inheriting IPFIX (which wins the
-	// unbound precedence whenever IPFIX is configured). The v9 builder
-	// skips exactly these servers, so no collector is double-exported.
 	hasV9 := svc.FlowMonitoring.Version9 != nil
-	ec.Collectors = collectVersionCollectors(fo, config.FlowServerVersionIPFIX, hasV9, true)
-
-	if len(ec.Collectors) == 0 {
+	collectors := collectVersionCollectors(fo, config.FlowServerVersionIPFIX, hasV9, true)
+	if len(collectors) == 0 {
 		return nil
 	}
 
-	return ec
+	defined := svc.FlowMonitoring.VersionIPFIX.Templates
+	defaultCtx := defaultTemplateContext()
+	if len(defined) == 1 {
+		for _, tmpl := range defined {
+			defaultCtx = ipfixTemplateContext(tmpl)
+		}
+	}
+
+	rate := samplingRate(fo)
+	shared := &atomic.Uint64{}
+	keys, groups := groupCollectorsByTemplate(collectors)
+
+	var out []*ExportConfig
+	for _, name := range keys {
+		ctx := defaultCtx
+		if name != "" {
+			tmpl, ok := defined[name]
+			if !ok {
+				continue
+			}
+			ctx = ipfixTemplateContext(tmpl)
+		}
+		out = append(out, &ExportConfig{
+			Collectors:          groups[name],
+			TemplateName:        name,
+			FlowActiveTimeout:   ctx.activeTimeout,
+			FlowInactiveTimeout: ctx.inactiveTimeout,
+			TemplateRefreshRate: ctx.refreshRate,
+			SamplingRate:        rate,
+			sampleCounter:       shared,
+		})
+	}
+	return out
+}
+
+// BuildExportConfig resolves config types into a single NetFlow v9
+// ExportConfig. It returns the FIRST template group (deterministically the
+// default/empty-template group, else the lowest template name) and is
+// retained for callers that want a single aggregate config; the daemon uses
+// ResolveV9TemplateGroups so each collector gets its referenced template
+// (#2461). Returns nil if no flow export is configured.
+func BuildExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
+	groups := ResolveV9TemplateGroups(svc, fo)
+	if len(groups) == 0 {
+		return nil
+	}
+	return groups[0]
+}
+
+// BuildIPFIXExportConfig is the IPFIX equivalent of BuildExportConfig.
+func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOptionsConfig) *ExportConfig {
+	groups := ResolveIPFIXTemplateGroups(svc, fo)
+	if len(groups) == 0 {
+		return nil
+	}
+	return groups[0]
 }
 
 // BuildSamplingZones builds a map of zone ID to sampling direction flags.
@@ -345,10 +498,22 @@ func (ec *ExportConfig) ShouldExport(inZone, outZone uint16) bool {
 	}
 	// Apply 1-in-N sampling rate
 	if ec.SamplingRate > 1 {
-		n := ec.sampleCounter.Add(1)
+		n := ec.counter().Add(1)
 		return n%uint64(ec.SamplingRate) == 0
 	}
 	return true
+}
+
+// counter returns the shared 1-in-N counter, lazily allocating a private
+// one for a hand-built ExportConfig that the resolver did not wire. The
+// sync.Once converges a concurrent first-call race on a single counter.
+func (ec *ExportConfig) counter() *atomic.Uint64 {
+	ec.counterOnce.Do(func() {
+		if ec.sampleCounter == nil {
+			ec.sampleCounter = &atomic.Uint64{}
+		}
+	})
+	return ec.sampleCounter
 }
 
 // parseIfaceRef splits "eth0.0" into ("eth0", 0).
@@ -413,5 +578,5 @@ func estimateSessionDuration(pkts uint64, proto uint8) time.Duration {
 }
 
 func collectorKey(c CollectorConfig) string {
-	return c.Address + "\x00" + c.SourceAddress
+	return c.Address + "\x00" + c.SourceAddress + "\x00" + c.Template
 }

--- a/pkg/flowexport/template_group_test.go
+++ b/pkg/flowexport/template_group_test.go
@@ -1,0 +1,284 @@
+package flowexport
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2461 — per-flow-server template binding.
+//
+// Before #2461 BuildExportConfig / BuildIPFIXExportConfig built ONE export
+// config from the FIRST Go-map-iteration template and broadcast it to every
+// collector, silently ignoring the per-flow-server `version9 { template ... }`
+// / `version-ipfix { template ... }` reference. These tests assert the
+// resolver now emits one ExportConfig per referenced template, so each
+// collector's exporter carries the template (timeouts / export-extensions) it
+// actually requested, in a deterministic order.
+
+// twoTemplateV9Svc defines two distinct NetFlow v9 templates with
+// observably different parameters (timeouts + the flow-dir extension).
+func twoTemplateV9Svc() *config.ServicesConfig {
+	return &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			Version9: &config.NetFlowV9Config{
+				Templates: map[string]*config.NetFlowV9Template{
+					"fast": {
+						Name:                "fast",
+						FlowActiveTimeout:   30,
+						FlowInactiveTimeout: 10,
+						TemplateRefreshRate: 20,
+						ExportExtensions:    []string{"flow-dir"},
+					},
+					"slow": {
+						Name:                "slow",
+						FlowActiveTimeout:   300,
+						FlowInactiveTimeout: 90,
+						TemplateRefreshRate: 120,
+						// no flow-dir
+					},
+				},
+			},
+		},
+	}
+}
+
+// twoTemplateIPFIXSvc is the IPFIX equivalent.
+func twoTemplateIPFIXSvc() *config.ServicesConfig {
+	return &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			VersionIPFIX: &config.NetFlowIPFIXConfig{
+				Templates: map[string]*config.NetFlowIPFIXTemplate{
+					"fast": {Name: "fast", FlowActiveTimeout: 30, TemplateRefreshRate: 20},
+					"slow": {Name: "slow", FlowActiveTimeout: 300, TemplateRefreshRate: 120},
+				},
+			},
+		},
+	}
+}
+
+// twoCollectorV9 returns sampling with two collectors referencing two
+// distinct v9 templates.
+func twoCollectorV9() *config.ForwardingOptionsConfig {
+	return samplingFO(
+		&config.FlowServer{Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "fast"},
+		&config.FlowServer{Address: "10.0.0.2", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "slow"},
+	)
+}
+
+// findGroupForCollector returns the ExportConfig group whose collector list
+// contains the given address, or nil.
+func findGroupForCollector(groups []*ExportConfig, addr string) *ExportConfig {
+	for _, ec := range groups {
+		for _, c := range ec.Collectors {
+			if c.Address == addr {
+				return ec
+			}
+		}
+	}
+	return nil
+}
+
+// TestV9PerServerTemplateBinding is the headline #2461 fail-on-revert test:
+// two collectors referencing two different templates each get an export
+// config carrying the template they referenced. Restore the old `break //
+// use first template` and a single config (the first map entry) is broadcast
+// to BOTH collectors — this test fails because the two groups would collapse
+// or carry identical (first-map-entry) parameters.
+func TestV9PerServerTemplateBinding(t *testing.T) {
+	groups := ResolveV9TemplateGroups(twoTemplateV9Svc(), twoCollectorV9())
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 template groups, got %d", len(groups))
+	}
+
+	fast := findGroupForCollector(groups, "10.0.0.1:2055")
+	slow := findGroupForCollector(groups, "10.0.0.2:2055")
+	if fast == nil || slow == nil {
+		t.Fatalf("both collectors must be present: fast=%v slow=%v", fast, slow)
+	}
+
+	// The 10.0.0.1 collector requested "fast": 30/10/20s, flow-dir ON.
+	if fast.TemplateName != "fast" {
+		t.Errorf("collector 10.0.0.1 group TemplateName = %q, want fast", fast.TemplateName)
+	}
+	if fast.FlowActiveTimeout != 30*time.Second {
+		t.Errorf("fast FlowActiveTimeout = %v, want 30s", fast.FlowActiveTimeout)
+	}
+	if fast.FlowInactiveTimeout != 10*time.Second {
+		t.Errorf("fast FlowInactiveTimeout = %v, want 10s", fast.FlowInactiveTimeout)
+	}
+	if fast.TemplateRefreshRate != 20*time.Second {
+		t.Errorf("fast TemplateRefreshRate = %v, want 20s", fast.TemplateRefreshRate)
+	}
+	if !fast.V9TemplateOpts.IncludeFlowDir {
+		t.Error("fast template requested flow-dir; IncludeFlowDir must be true")
+	}
+
+	// The 10.0.0.2 collector requested "slow": 300/90/120s, flow-dir OFF.
+	if slow.TemplateName != "slow" {
+		t.Errorf("collector 10.0.0.2 group TemplateName = %q, want slow", slow.TemplateName)
+	}
+	if slow.FlowActiveTimeout != 300*time.Second {
+		t.Errorf("slow FlowActiveTimeout = %v, want 300s", slow.FlowActiveTimeout)
+	}
+	if slow.FlowInactiveTimeout != 90*time.Second {
+		t.Errorf("slow FlowInactiveTimeout = %v, want 90s", slow.FlowInactiveTimeout)
+	}
+	if slow.TemplateRefreshRate != 120*time.Second {
+		t.Errorf("slow TemplateRefreshRate = %v, want 120s", slow.TemplateRefreshRate)
+	}
+	if slow.V9TemplateOpts.IncludeFlowDir {
+		t.Error("slow template did NOT request flow-dir; IncludeFlowDir must be false")
+	}
+
+	// Each group has exactly its one collector (no cross-contamination).
+	if len(fast.Collectors) != 1 || len(slow.Collectors) != 1 {
+		t.Fatalf("each group must hold exactly its referenced collector: fast=%d slow=%d",
+			len(fast.Collectors), len(slow.Collectors))
+	}
+}
+
+// TestIPFIXPerServerTemplateBinding mirrors the v9 test for IPFIX.
+func TestIPFIXPerServerTemplateBinding(t *testing.T) {
+	fo := samplingFO(
+		&config.FlowServer{Address: "10.0.0.1", Port: 4739, Version: config.FlowServerVersionIPFIX, VersionIPFIXTemplate: "fast"},
+		&config.FlowServer{Address: "10.0.0.2", Port: 4739, Version: config.FlowServerVersionIPFIX, VersionIPFIXTemplate: "slow"},
+	)
+	groups := ResolveIPFIXTemplateGroups(twoTemplateIPFIXSvc(), fo)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 template groups, got %d", len(groups))
+	}
+
+	fast := findGroupForCollector(groups, "10.0.0.1:4739")
+	slow := findGroupForCollector(groups, "10.0.0.2:4739")
+	if fast == nil || slow == nil {
+		t.Fatalf("both collectors must be present: fast=%v slow=%v", fast, slow)
+	}
+	if fast.TemplateName != "fast" || fast.FlowActiveTimeout != 30*time.Second || fast.TemplateRefreshRate != 20*time.Second {
+		t.Errorf("fast group mis-resolved: name=%q active=%v refresh=%v",
+			fast.TemplateName, fast.FlowActiveTimeout, fast.TemplateRefreshRate)
+	}
+	if slow.TemplateName != "slow" || slow.FlowActiveTimeout != 300*time.Second || slow.TemplateRefreshRate != 120*time.Second {
+		t.Errorf("slow group mis-resolved: name=%q active=%v refresh=%v",
+			slow.TemplateName, slow.FlowActiveTimeout, slow.TemplateRefreshRate)
+	}
+}
+
+// TestSingleTemplateNoReferenceUnchanged is the no-regression guard: a
+// single configured template with collectors that reference none must yield
+// exactly one default group carrying that template's parameters — the common
+// pre-#2461 single-template case. (Anti-over-gate concern from the issue.)
+func TestSingleTemplateNoReferenceUnchanged(t *testing.T) {
+	svc := &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			Version9: &config.NetFlowV9Config{
+				Templates: map[string]*config.NetFlowV9Template{
+					"only": {Name: "only", FlowActiveTimeout: 45, ExportExtensions: []string{"flow-dir"}},
+				},
+			},
+		},
+	}
+	fo := samplingFO(
+		&config.FlowServer{Address: "10.0.0.1", Port: 2055},
+		&config.FlowServer{Address: "10.0.0.2", Port: 2055},
+	)
+	groups := ResolveV9TemplateGroups(svc, fo)
+	if len(groups) != 1 {
+		t.Fatalf("a single template with no per-server reference must yield ONE group, got %d", len(groups))
+	}
+	g := groups[0]
+	if g.TemplateName != "" {
+		t.Errorf("default group TemplateName = %q, want empty", g.TemplateName)
+	}
+	if len(g.Collectors) != 2 {
+		t.Errorf("default group must hold both unreferenced collectors, got %d", len(g.Collectors))
+	}
+	// Unreferenced collectors inherit the lone template's parameters.
+	if g.FlowActiveTimeout != 45*time.Second {
+		t.Errorf("default group FlowActiveTimeout = %v, want 45s (the lone template)", g.FlowActiveTimeout)
+	}
+	if !g.V9TemplateOpts.IncludeFlowDir {
+		t.Error("default group must inherit the lone template's flow-dir extension")
+	}
+	// BuildExportConfig (singular) returns this same group — backward compat.
+	if ec := BuildExportConfig(svc, fo); ec == nil || len(ec.Collectors) != 2 {
+		t.Errorf("BuildExportConfig must still return the aggregate single-group config")
+	}
+}
+
+// TestTemplateGroupsAreDeterministic proves the grouping is stable across
+// repeated resolves — group order (by template name) and per-group collector
+// order (by address) are identical every time, killing the map-iteration
+// nondeterminism (#2461). Restore Go-map iteration order and this flakes.
+func TestTemplateGroupsAreDeterministic(t *testing.T) {
+	// Three collectors across two templates, addresses intentionally out of
+	// sorted order so a stable sort is observable.
+	svc := twoTemplateV9Svc()
+	fo := samplingFO(
+		&config.FlowServer{Address: "10.0.0.9", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "slow"},
+		&config.FlowServer{Address: "10.0.0.3", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "fast"},
+		&config.FlowServer{Address: "10.0.0.7", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "fast"},
+	)
+
+	var prev []string
+	for i := 0; i < 20; i++ {
+		groups := ResolveV9TemplateGroups(svc, fo)
+		var order []string
+		for _, ec := range groups {
+			order = append(order, ec.TemplateName)
+			for _, c := range ec.Collectors {
+				order = append(order, c.Address)
+			}
+		}
+		if prev == nil {
+			prev = order
+			continue
+		}
+		if len(order) != len(prev) {
+			t.Fatalf("resolve %d produced a different shape: %v vs %v", i, order, prev)
+		}
+		for j := range order {
+			if order[j] != prev[j] {
+				t.Fatalf("resolve %d nondeterministic at %d: %v vs %v", i, j, order, prev)
+			}
+		}
+	}
+	// Expected stable order: group "fast" (10.0.0.3, 10.0.0.7) then "slow"
+	// (10.0.0.9) — template name asc, address asc.
+	want := []string{"fast", "10.0.0.3:2055", "10.0.0.7:2055", "slow", "10.0.0.9:2055"}
+	if len(prev) != len(want) {
+		t.Fatalf("order shape = %v, want %v", prev, want)
+	}
+	for i := range want {
+		if prev[i] != want[i] {
+			t.Fatalf("deterministic order = %v, want %v", prev, want)
+		}
+	}
+}
+
+// TestSharedSamplingCounterAcrossGroups proves all groups of a family share
+// one 1-in-N counter: with rate 2 and one record offered per group, the
+// shared counter advances across groups rather than each group counting from
+// zero (which would corrupt the global cadence). The resolver wires the same
+// *atomic.Uint64 into every group.
+func TestSharedSamplingCounterAcrossGroups(t *testing.T) {
+	groups := ResolveV9TemplateGroups(twoTemplateV9Svc(), twoCollectorV9())
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d", len(groups))
+	}
+	// Rate 2 was set by samplingFO (InputRate 100); override to 2 for clarity.
+	for _, g := range groups {
+		g.SamplingRate = 2
+	}
+	// First call on group 0: counter 1 -> 1%2 != 0 -> false.
+	if groups[0].ShouldExport(0, 0) {
+		t.Fatal("first sampled call must be dropped (1%2 != 0)")
+	}
+	// Next call on group 1 must see the SHARED counter at 2 -> true,
+	// not a fresh per-group counter at 1 (which would drop).
+	if !groups[1].ShouldExport(0, 0) {
+		t.Fatal("second call on the OTHER group must see the shared counter (2%2 == 0); " +
+			"a per-group counter would wrongly drop it")
+	}
+}


### PR DESCRIPTION
Closes #2461

## Problem

Per-flow-server NetFlow v9 / IPFIX template bindings (`version9 { template
<name> }` / `version-ipfix { template <name> }`, and the flat
`version9-template` / `version-ipfix-template`) were parsed into
`FlowServer.Version9Template` / `VersionIPFIXTemplate` but never used to
select the template per collector. `BuildExportConfig` /
`BuildIPFIXExportConfig` built ONE export config from the FIRST
Go-map-iteration template (`break // use first template`) and broadcast it
to every collector of the version. A collector that referenced a specific
template silently received whichever the map yielded first, and that choice
flipped across process restarts (map order is not an operator contract) — so
the template's timeouts and the `flow-dir` export-extension could differ from
what the operator requested. HIGH (codex review-034 finding 2).

## Fix

**Grouping key — `(version, template_name)`.** New `ResolveV9TemplateGroups`
/ `ResolveIPFIXTemplateGroups` (`pkg/flowexport/manager.go`) take the
version-bound collectors (the existing #2136 `collectVersionCollectors`
set), group them by the template each referenced, and emit one
`*ExportConfig` per group carrying that template's timeouts /
`V9TemplateOpts`. **source-address is NOT part of the grouping key** — it is
a deterministic sort tiebreak only. Collectors that share a template but pin
different source-addresses land in ONE group and each still gets its own
source-pinned UDP connection (via `dialCollectors`).

**Validation of template refs.** A flow-server referencing an undefined
template is hard-rejected at commit / commit-check by the new
`validateFlowServerTemplateReferencesStrict` (`pkg/config`). It is downgraded
to a `cfg.Warnings` entry on the tolerant load / peer-sync paths
(`lenientFlowServerTemplateRef`) so an already-persisted or peer-synced
config still boots (#1960); on that lenient path the resolver DROPS the
undefined-template group, so the collector exports nothing for that
collector rather than the wrong template. Same doctrine as
`validateLogProfileStreamReferencesStrict`.

**Determinism.** Groups are sorted by template name and each group's
collectors by address, so process restarts produce identical exporter wiring
— the map-iteration nondeterminism is gone.

**No regression for the default case.** A collector that references no
template lands in the default (`TemplateName == ""`) group, which inherits
the lone template's parameters when exactly one is configured (the common
single-template case, bit-identical to before) and otherwise the built-in
defaults. `BuildExportConfig` / `BuildIPFIXExportConfig` (singular) are
retained for single-aggregate callers and return the first resolved group.

## Why the daemon changed (blast radius)

One-exporter-per-group requires the daemon to start and reconcile **N
exporters per family** instead of one. `reconcileFlowExporters`
(`pkg/daemon/daemon_flowexport.go`) now builds every group's exporter
(rolling back the partial set and NOT recording the config hash if any
`NewExporter` fails — preserving the transient-create-failure retry),
tracks them in `flowExporters` / `ipfixExporters` slices
(`daemon.go`), publishes the group set through the atomic `flowBundle` /
`ipfixBundlePtr`, and tears them all down at shutdown (`daemon_flow.go`).

1-in-N sampling is a forwarding-options-instance property, not a per-template
one, so all groups of a family **share one `sampleCounter`** (now a
`*atomic.Uint64`). The once-registered session-close callback evaluates
`ShouldExport` exactly once (on `groups[0]`) and fans the record out to every
group, so the global sampling cadence is not over-incremented and each
collector is encoded with the template it referenced.

> Note: `samplingRate()` returns the first map-entry sampling instance's
> input-rate, which is nondeterministic when more than one sampling instance
> is configured. That is the SEPARATE already-filed issue #2462 (multiple
> sampling instances flattened) and is intentionally out of scope here — it
> will be fixed in this same file by #2462.

## Tests (fail-on-revert)

- `TestV9PerServerTemplateBinding` / `TestIPFIXPerServerTemplateBinding` —
  two collectors referencing two templates (distinct timeouts +
  `flow-dir` on/off); each group carries its own referenced template.
  Restoring `break // use first template` collapses both collectors onto the
  first map entry and these fail.
- `TestSingleTemplateNoReferenceUnchanged` — single template, no per-server
  reference → one default group with both collectors inheriting the lone
  template (anti-over-gate / no-regression guard); `BuildExportConfig`
  singular still returns the aggregate.
- `TestTemplateGroupsAreDeterministic` — 20 repeated resolves produce an
  identical group + collector order (template asc, address asc).
- `TestSharedSamplingCounterAcrossGroups` — the groups share one 1-in-N
  counter.
- `pkg/config/flowserver_template_ref_test.go` — undefined v9 / IPFIX ref
  hard-rejected at commit; defined ref + no-ref accepted; dangling ref
  downgraded to a warning on the lenient path.

## Validation

`go build ./...`; `go test ./pkg/flowexport/ ./pkg/config/ ./pkg/daemon/`
green; `go vet` clean; `gofmt` clean. Binding + determinism + shared-counter
tests pass `-race -count=5`. Go-only change (no Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
