### PR TITLE
flowexport: isolate sampling instances as first-class policies (#2462)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12318,3 +12318,32 @@ top.
   userspace-dp/src/event_stream/README.md, pkg/flowexport/README.md,
   pkg/dataplane/userspace/flow.go,
   pkg/daemon/daemon_flowexport_session_close_test.go, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2462 — sampling-instance isolation: each `forwarding-options
+  sampling instance` is now a first-class export policy with its OWN
+  collectors, OWN 1-in-N rate, and OWN sampleCounter, composing with #2461's
+  per-template grouping (grouping key gains instance identity:
+  (instance, version, template)). Killed the merged-collector walk
+  (collectVersionCollectors → per-instance collectInstanceVersionCollectors)
+  and the first-nonzero-map-order global rate (samplingRate → per-instance
+  inst.InputRate + sortedInstanceNames for restart-stable ordering). Flow→
+  instance attribution is by address family (ServesInet/ServesInet6 +
+  ServesFamily) — the only per-flow selector available (interface sampling is
+  a plain boolean; no per-interface sampling-instance selector exists). The
+  daemon callback walks contiguous per-instance group runs, applies the
+  family gate + single per-instance sampling decision, then fans to that
+  instance's groups (was: decide once on groups[0], fan to all). Added
+  validateSamplingInstanceConflictsStrict: two instances claiming the SAME
+  (version, family) are genuinely ambiguous → hard-reject on commit, warn on
+  lenient load/peer-sync (#1960, lenientSamplingInstanceConflicts). Supported:
+  single instance (no regression), instances split by family or by export
+  version. Rejected: two instances same (version,family). Fail-on-revert
+  proven for per-instance rate/counter and the strict reject. Tests run
+  -race -count=5 green; build/vet clean.
+- **File(s)**: pkg/flowexport/manager.go,
+  pkg/flowexport/instance_isolation_test.go,
+  pkg/daemon/daemon_flowexport.go, pkg/config/compiler.go,
+  pkg/config/compiler_validate_strict.go,
+  pkg/config/sampling_instance_conflict_test.go,
+  pkg/flowexport/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -12347,3 +12347,23 @@ top.
   pkg/config/compiler_validate_strict.go,
   pkg/config/sampling_instance_conflict_test.go,
   pkg/flowexport/README.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2462 review folds (PR #2504). (1-2) fixed two manager.go
+  comments referencing a non-existent ShouldExportFamily method → ServesFamily
+  (the actual method). (3) corrected the v9OnlySvc test-helper comment to match
+  the empty-template-map reality (instance-isolation tests use no-template
+  flow-servers → default group with built-in defaults; template resolution is
+  covered by template_group_test.go). (4) closed the daemon-level coverage gap
+  on the per-instance fanout walk: new
+  TestSessionCloseMultiInstanceFamilyIsolation wires two v9 instances (alpha
+  inet rate 1, bravo inet6 rate 1) through the REAL reconcile + callback path,
+  feeds an IPv4 SESSION_CLOSE, and asserts it reaches ONLY alpha's exporter and
+  NEVER bravo's (no-cross-export). Fail-on-revert proven: reverting the
+  callback to the pre-#2462 global groups[0]-decide-fan-to-all behavior makes
+  bravo wrongly export the v4 flow (count 0→1) and the test fails. Observable
+  seam = per-group Exporter.Stats() flow count (same seam the existing #2460
+  daemon flowexport tests use). Build/vet/gofmt clean; -race -count=5 green.
+- **File(s)**: pkg/flowexport/manager.go,
+  pkg/flowexport/instance_isolation_test.go,
+  pkg/daemon/daemon_flowexport_session_close_test.go, _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -353,6 +353,22 @@ type compileOpts struct {
 	// nothing for that collector rather than the wrong template. Same
 	// doctrine as lenientLogProfileStreamRef.
 	lenientFlowServerTemplateRef bool
+	// lenientSamplingInstanceConflicts (#2462) downgrades the
+	// multi-sampling-instance conflict gate
+	// (validateSamplingInstanceConflictsStrict) from a hard compile error to
+	// a cfg.Warnings entry. Two `forwarding-options sampling instance` blocks
+	// that each export the SAME (export-version, address-family) pair are
+	// genuinely ambiguous — there is no per-interface sampling-instance
+	// selector, so a flow of that family cannot be attributed to one instance
+	// — and were previously silently flattened into one global policy (one
+	// map-order-dependent rate, one merged collector set; flows from instance
+	// A reaching instance B's collectors). The strict commit / commit-check
+	// path hard-rejects so the operator sees it; the tolerant load / peer-sync
+	// paths warn so an already-persisted or peer-synced config still BOOTS
+	// (#1960) — the resolver still emits both instances' independent
+	// ExportConfigs, so eligible flows duplicate to both instances rather than
+	// bricking the load. Same doctrine as lenientFlowServerTemplateRef.
+	lenientSamplingInstanceConflicts bool
 	// lenientApplicationSetMembers (#2217 Finding B) downgrades the
 	// application-set member cross-reference gate
 	// (validateApplicationSetMembersStrict) from a hard compile error to a
@@ -483,6 +499,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
 		lenientFlowServerTemplateRef:       true,
+		lenientSamplingInstanceConflicts:   true,
 		lenientApplicationSetMembers:       true,
 		lenientRibGroupRefs:                true,
 		lenientDHCPStaticBindings:          true,
@@ -581,6 +598,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientNPTv6:                       true,
 		lenientFirewallRefs:                true,
 		lenientFlowServerTemplateRef:       true,
+		lenientSamplingInstanceConflicts:   true,
 		lenientApplicationSetMembers:       true,
 		lenientRibGroupRefs:                true,
 		lenientDHCPStaticBindings:          true,
@@ -1259,6 +1277,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFlowServerTemplateRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("flow-server template reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2462: multi-sampling-instance conflict. Two `forwarding-options
+	// sampling instance` blocks that each export the same (export-version,
+	// address-family) pair are genuinely ambiguous — there is no per-interface
+	// sampling-instance selector, so the runtime cannot attribute a flow of
+	// that family to one instance — and were previously silently flattened
+	// into one global policy (first-nonzero map-order rate, merged collectors;
+	// flows crossing from one instance's policy to another's collectors).
+	// Strict on commit / commit-check (hard reject so the operator sees it);
+	// lenient on load / peer-sync (warn so an already-persisted or peer-synced
+	// config still boots — #1960; the resolver emits both instances'
+	// independent ExportConfigs, duplicating eligible flows rather than
+	// bricking). Mirrors validateFlowServerTemplateReferencesStrict.
+	if err := validateSamplingInstanceConflictsStrict(cfg); err != nil {
+		if opts.lenientSamplingInstanceConflicts {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("sampling instance conflict (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -468,6 +468,146 @@ func validateFlowServerTemplateReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// flowServerExportVersion mirrors flowexport.resolveFlowServerVersion: it
+// returns the export protocol a single flow-server binds to, given the
+// per-server selector and which global `services flow-monitoring` version
+// stanzas are configured. It is duplicated here (not imported) because
+// pkg/config must not depend on pkg/flowexport. Returns "" when the server
+// resolves to no configured version. Keep in sync with
+// pkg/flowexport.resolveFlowServerVersion.
+func flowServerExportVersion(fs *FlowServer, hasV9, hasIPFIX bool) string {
+	switch fs.Version {
+	case FlowServerVersion9:
+		if hasV9 {
+			return FlowServerVersion9
+		}
+		return ""
+	case FlowServerVersionIPFIX:
+		if hasIPFIX {
+			return FlowServerVersionIPFIX
+		}
+		return ""
+	}
+	switch {
+	case hasIPFIX:
+		return FlowServerVersionIPFIX
+	case hasV9:
+		return FlowServerVersion9
+	default:
+		return ""
+	}
+}
+
+// validateSamplingInstanceConflictsStrict hard-rejects an unsupported
+// multi-sampling-instance configuration (#2462).
+//
+// The defect: multiple `forwarding-options sampling instance` blocks were
+// silently flattened into one global export policy — one rate (the first
+// nonzero InputRate in Go map order), one merged collector set, one zone
+// eligibility map. Flows from instance A could export to instance B's
+// collectors and the effective rate depended on map-iteration order.
+//
+// The fix makes each instance a first-class export policy: its own rate, its
+// own 1-in-N counter, its own collectors. A flow is attributed to an instance
+// by ADDRESS FAMILY (the only per-flow selector available — the interface
+// `family inet { sampling { input; } }` stanza is a plain boolean; there is
+// NO per-interface sampling-instance selector in the config model, so two
+// instances serving the SAME family for the SAME export version are genuinely
+// ambiguous: the runtime cannot tell which instance a given IPv4 (or IPv6)
+// flow belongs to). Rather than guess (the flatten-and-hope behavior this
+// issue reports), that combination is rejected.
+//
+// Supported: a single instance (any rate / families / collectors — the common
+// case, unchanged); multiple instances disambiguated by family (e.g. instance
+// A serves inet, instance B serves inet6) and/or by export version (an inet
+// instance bound to version9 vs an inet instance bound to version-ipfix —
+// distinct datagram streams, the flow is duplicated to both intentionally,
+// same as today's single-instance dual-version behavior).
+//
+// Rejected: two or more instances each configuring a flow-server that
+// resolves to the SAME (export-version, address-family) pair.
+//
+// Strict on commit / commit-check (hard reject so the operator sees it);
+// lenient on load / peer-sync (the call site downgrades to a warning via
+// opts.lenientSamplingInstanceConflicts so an already-persisted or
+// peer-synced config still boots — #1960; the resolver still emits both
+// instances' independent ExportConfigs, so a leniently-loaded conflicting
+// config duplicates eligible flows to both instances rather than bricking).
+func validateSamplingInstanceConflictsStrict(cfg *Config) error {
+	if cfg == nil || cfg.ForwardingOptions.Sampling == nil {
+		return nil
+	}
+	insts := cfg.ForwardingOptions.Sampling.Instances
+	if len(insts) < 2 {
+		return nil // single instance is always unambiguous
+	}
+	fm := cfg.Services.FlowMonitoring
+	hasV9 := fm != nil && fm.Version9 != nil
+	hasIPFIX := fm != nil && fm.VersionIPFIX != nil
+
+	// Deterministic instance order so the first-conflict message is stable.
+	names := make([]string, 0, len(insts))
+	for name := range insts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// claim key "<version>\x00<family>" -> first instance that claimed it.
+	claimed := map[string]string{}
+	for _, name := range names {
+		inst := insts[name]
+		if inst == nil {
+			continue
+		}
+		fams := []struct {
+			fam    *SamplingFamily
+			family string
+		}{
+			{inst.FamilyInet, "inet"},
+			{inst.FamilyInet6, "inet6"},
+		}
+		// Collect THIS instance's distinct (version, family) claims, so the
+		// same instance binding two collectors to the same (version, family)
+		// does not self-conflict.
+		selfClaims := map[string]bool{}
+		for _, fe := range fams {
+			if fe.fam == nil {
+				continue
+			}
+			for _, fs := range fe.fam.FlowServers {
+				if fs == nil {
+					continue
+				}
+				ver := flowServerExportVersion(fs, hasV9, hasIPFIX)
+				if ver == "" {
+					continue // resolves to no configured version; exports nothing
+				}
+				selfClaims[ver+"\x00"+fe.family] = true
+			}
+		}
+		// Deterministic order over this instance's claims.
+		keys := make([]string, 0, len(selfClaims))
+		for k := range selfClaims {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if owner, ok := claimed[key]; ok {
+				parts := strings.SplitN(key, "\x00", 2)
+				return fmt.Errorf("forwarding-options sampling instances %q and %q "+
+					"both export %s family %s flows: the runtime cannot attribute a "+
+					"flow to one instance (there is no per-interface sampling-instance "+
+					"selector — eligibility is per address family), so the two would "+
+					"silently merge. Use a single instance for this version/family, or "+
+					"separate the instances by family or export version",
+					owner, name, parts[0], parts[1])
+			}
+			claimed[key] = name
+		}
+	}
+	return nil
+}
+
 // routingRedistProtocolTokens is the set of bare protocol keywords that an
 // OSPF/OSPFv3/BGP/IS-IS `export` (or a RIP `redistribute`) accepts in lieu
 // of a named policy-statement. resolveRedistribute (pkg/frr/policy_render.go)

--- a/pkg/config/sampling_instance_conflict_test.go
+++ b/pkg/config/sampling_instance_conflict_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2462 — multi-sampling-instance conflict gate.
+//
+// Multiple `forwarding-options sampling instance` blocks that each export the
+// SAME (export-version, address-family) pair are genuinely ambiguous: there is
+// no per-interface sampling-instance selector, so the runtime cannot attribute
+// a flow of that family to one instance. The compiler previously flattened
+// them silently. The strict commit / commit-check path now hard-rejects;
+// the tolerant load / peer-sync path downgrades to a warning (#1960).
+
+// TestTwoInstancesSameFamilyVersionRejected: two instances both exporting
+// inet flows under the (single) configured version are rejected at commit.
+func TestTwoInstancesSameFamilyVersionRejected(t *testing.T) {
+	cmds := []string{
+		"set services flow-monitoring version9 template t flow-active-timeout 60",
+		"set forwarding-options sampling instance alpha input rate 100",
+		"set forwarding-options sampling instance alpha family inet output flow-server 10.0.0.1 version9 template t",
+		"set forwarding-options sampling instance bravo input rate 200",
+		"set forwarding-options sampling instance bravo family inet output flow-server 10.0.0.2 version9 template t",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted two sampling instances both exporting inet/version9; expected rejection")
+	}
+	for _, want := range []string{"alpha", "bravo", "inet"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// TestTwoInstancesDifferentFamilyAccepted: instances disambiguated by family
+// (alpha inet, bravo inet6) compile cleanly — the supported multi-instance
+// case (family is the per-flow attribution selector).
+func TestTwoInstancesDifferentFamilyAccepted(t *testing.T) {
+	cmds := []string{
+		"set services flow-monitoring version9 template t flow-active-timeout 60",
+		"set forwarding-options sampling instance alpha family inet output flow-server 10.0.0.1 port 2055",
+		"set forwarding-options sampling instance bravo family inet6 output flow-server 2001:db8::2 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected two family-disjoint sampling instances: %v", err)
+	}
+}
+
+// TestTwoInstancesDifferentVersionAccepted: instances disambiguated by export
+// version (alpha inet/version9, bravo inet/version-ipfix) compile cleanly —
+// distinct datagram streams, not a merge.
+func TestTwoInstancesDifferentVersionAccepted(t *testing.T) {
+	cmds := []string{
+		"set services flow-monitoring version9 template t9 flow-active-timeout 60",
+		"set services flow-monitoring version-ipfix template ti flow-active-timeout 60",
+		"set forwarding-options sampling instance alpha family inet output flow-server 10.0.0.1 version9 template t9",
+		"set forwarding-options sampling instance bravo family inet output flow-server 10.0.0.2 version-ipfix template ti",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected two version-disjoint sampling instances: %v", err)
+	}
+}
+
+// TestSingleInstanceMultiFamilyAccepted: ONE instance serving both families is
+// fine (the common single-instance case is never gated — anti-over-gate).
+func TestSingleInstanceMultiFamilyAccepted(t *testing.T) {
+	cmds := []string{
+		"set services flow-monitoring version9 template t flow-active-timeout 60",
+		"set forwarding-options sampling instance s family inet output flow-server 10.0.0.1 port 2055",
+		"set forwarding-options sampling instance s family inet6 output flow-server 2001:db8::1 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a single multi-family instance: %v", err)
+	}
+}
+
+// TestConflictingInstancesLenientWarns: on the tolerant load / peer-sync path
+// the conflict is downgraded to a warning so an already-persisted or
+// peer-synced config still boots (#1960).
+func TestConflictingInstancesLenientWarns(t *testing.T) {
+	cmds := []string{
+		"set services flow-monitoring version9 template t flow-active-timeout 60",
+		"set forwarding-options sampling instance alpha family inet output flow-server 10.0.0.1 port 2055",
+		"set forwarding-options sampling instance bravo family inet output flow-server 10.0.0.2 port 2055",
+	}
+	tree := buildTreeFromSet(t, cmds)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must NOT hard-reject conflicting sampling instances: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "sampling instance conflict") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("lenient compile must emit a downgraded warning for the conflict; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -335,11 +335,20 @@ func (d *Daemon) reconcileIPFIXExporter(cfg *config.Config) bool {
 // set of template-group exporters lock-free from the atomic bundle, so
 // reconcile can swap the exporters without ever touching the callback list.
 //
-// #2461: the family's groups share one ShouldExport state (the 1-in-N
-// counter + sampling zones), so the sampling decision is made EXACTLY ONCE
-// (on groups[0]) and the record is fanned out to every group — each group
-// encodes with the template its collectors referenced. Deciding per group
-// would over-increment the shared counter and corrupt the 1-in-N cadence.
+// #2461: the template groups of ONE instance share one ShouldExport state
+// (the 1-in-N counter + sampling zones), so the sampling decision is made
+// EXACTLY ONCE per instance and fanned to that instance's groups — each
+// group encodes with the template its collectors referenced. Deciding per
+// template group would over-increment the shared counter and corrupt 1-in-N.
+//
+// #2462: sampling instances are independent export policies. A flow is
+// attributed to an instance by address family (ServesFamily) and then
+// sampled at THAT instance's own rate via THAT instance's own counter, so a
+// flow eligible for instance A exports only to A's collectors at A's rate and
+// never crosses to instance B. The per-instance decision is made once
+// (groupedByInstance walks contiguous same-instance runs — the resolver
+// emits an instance's groups consecutively) so the shared per-instance
+// counter advances exactly once per eligible flow.
 func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
 	if rec.Type != "SESSION_CLOSE" {
 		return
@@ -348,17 +357,30 @@ func (d *Daemon) flowExportCallback(rec logging.EventRecord, raw []byte) {
 	if b == nil || len(b.groups) == 0 {
 		return
 	}
-	if !b.groups[0].ec.ShouldExport(rec.InZone, rec.OutZone) {
-		return
-	}
 	sd := flowexport.SessionCloseData{
 		SrcPort:  parseSrcPort(rec.SrcAddr),
 		DstPort:  parseSrcPort(rec.DstAddr),
 		Protocol: parseProtocol(rec.Protocol),
 	}
 	sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
-	for _, g := range b.groups {
-		g.exp.ExportSessionClose(rec, sd)
+
+	i := 0
+	for i < len(b.groups) {
+		inst := b.groups[i].ec.InstanceName
+		// First group of this instance carries the shared per-instance state.
+		lead := b.groups[i].ec
+		// Determine the contiguous run of groups for this instance.
+		j := i
+		for j < len(b.groups) && b.groups[j].ec.InstanceName == inst {
+			j++
+		}
+		// Family attribution then the single per-instance sampling decision.
+		if lead.ServesFamily(sd.IsIPv6) && lead.ShouldExport(rec.InZone, rec.OutZone) {
+			for k := i; k < j; k++ {
+				b.groups[k].exp.ExportSessionClose(rec, sd)
+			}
+		}
+		i = j
 	}
 }
 
@@ -371,16 +393,26 @@ func (d *Daemon) ipfixExportCallback(rec logging.EventRecord, raw []byte) {
 	if b == nil || len(b.groups) == 0 {
 		return
 	}
-	if !b.groups[0].ec.ShouldExport(rec.InZone, rec.OutZone) {
-		return
-	}
 	sd := flowexport.SessionCloseData{
 		SrcPort:  parseSrcPort(rec.SrcAddr),
 		DstPort:  parseSrcPort(rec.DstAddr),
 		Protocol: parseProtocol(rec.Protocol),
 	}
 	sd.SrcIP, sd.DstIP, sd.IsIPv6 = parseAddrPair(rec.SrcAddr, rec.DstAddr)
-	for _, g := range b.groups {
-		g.exp.ExportSessionClose(rec, sd)
+
+	i := 0
+	for i < len(b.groups) {
+		inst := b.groups[i].ec.InstanceName
+		lead := b.groups[i].ec
+		j := i
+		for j < len(b.groups) && b.groups[j].ec.InstanceName == inst {
+			j++
+		}
+		if lead.ServesFamily(sd.IsIPv6) && lead.ShouldExport(rec.InZone, rec.OutZone) {
+			for k := i; k < j; k++ {
+				b.groups[k].exp.ExportSessionClose(rec, sd)
+			}
+		}
+		i = j
 	}
 }

--- a/pkg/daemon/daemon_flowexport_session_close_test.go
+++ b/pkg/daemon/daemon_flowexport_session_close_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/flowexport"
 	"github.com/psaab/xpf/pkg/logging"
 )
 
@@ -267,6 +268,148 @@ func TestNonSessionCloseRawEventDoesNotDriveFlowExport(t *testing.T) {
 	}
 	if sessionCloses != 0 {
 		t.Fatalf("a POLICY_DENY must not produce a SESSION_CLOSE record, got %d", sessionCloses)
+	}
+}
+
+// twoInstanceV9Config builds a config with TWO NetFlow v9 sampling instances
+// disambiguated by address family (#2462): "alpha" serves inet (IPv4) with its
+// own collector, "bravo" serves inet6 (IPv6) with its own collector. Both at
+// rate 1 so ShouldExport always admits. Each flow-server is pinned to version9
+// so both land in the v9 bundle (exercising the per-instance fanout walk in
+// flowExportCallback). The two collectors bind different ports so the test can
+// observe each exporter's Stats independently.
+func twoInstanceV9Config(addr string, alphaPort, bravoPort int) *config.Config {
+	cfg := &config.Config{}
+	cfg.ForwardingOptions.Sampling = &config.SamplingConfig{
+		Instances: map[string]*config.SamplingInstance{
+			"alpha": {
+				Name:      "alpha",
+				InputRate: 1,
+				FamilyInet: &config.SamplingFamily{
+					FlowServers: []*config.FlowServer{
+						{Address: addr, Port: alphaPort, Version: config.FlowServerVersion9},
+					},
+				},
+			},
+			"bravo": {
+				Name:      "bravo",
+				InputRate: 1,
+				FamilyInet6: &config.SamplingFamily{
+					FlowServers: []*config.FlowServer{
+						{Address: addr, Port: bravoPort, Version: config.FlowServerVersion9},
+					},
+				},
+			},
+		},
+	}
+	cfg.Services.FlowMonitoring = &config.FlowMonitoringConfig{
+		Version9: &config.NetFlowV9Config{
+			Templates: map[string]*config.NetFlowV9Template{},
+		},
+	}
+	return cfg
+}
+
+// groupStatsForInstance returns the summed exported-flow count across all
+// template groups of the named instance in the live v9 bundle.
+func groupStatsForInstance(b *exporterBundle, inst string) uint64 {
+	var total uint64
+	for _, g := range b.groups {
+		if g.ec.InstanceName == inst {
+			flows, _ := g.exp.Stats()
+			total += flows
+		}
+	}
+	return total
+}
+
+// waitInstanceFlows polls until the named instance's exporter(s) report at
+// least one exported flow record, or the 3s deadline elapses.
+func waitInstanceFlows(t *testing.T, b *exporterBundle, inst string) uint64 {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if n := groupStatsForInstance(b, inst); n >= 1 {
+			return n
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return groupStatsForInstance(b, inst)
+}
+
+// TestSessionCloseMultiInstanceFamilyIsolation is the #2462 daemon-level
+// fail-on-revert test for the per-instance fanout walk in flowExportCallback
+// (and its IPFIX twin). Two v9 sampling instances are wired through the REAL
+// reconcile + callback path: "alpha" (inet, rate 1) and "bravo" (inet6, rate
+// 1). An IPv4 SESSION_CLOSE is fed on the raw dataplane-event channel and must
+// reach ONLY alpha's exporter (its family) and NEVER bravo's — the
+// no-cross-export guarantee. The callback makes ONE sampling decision per
+// instance and fans only to that instance's groups.
+//
+// Fail-on-revert: reverting the callback to the pre-#2462 global decision —
+// one ShouldExport on groups[0] then export to EVERY group regardless of
+// family/instance — makes the IPv4 flow wrongly reach bravo (inet6), so
+// bravo's exported-flow count goes from 0 to >= 1 and this test fails.
+func TestSessionCloseMultiInstanceFamilyIsolation(t *testing.T) {
+	alphaColl, alphaPort := listenUDP(t)
+	t.Cleanup(func() { alphaColl.Close() })
+	bravoColl, bravoPort := listenUDP(t)
+	t.Cleanup(func() { bravoColl.Close() })
+
+	d := newFlowTestDaemon()
+	t.Cleanup(d.stopFlowExporter)
+	t.Cleanup(d.stopIPFIXExporter)
+
+	if !d.reconcileFlowExporters(twoInstanceV9Config("127.0.0.1", alphaPort, bravoPort)) {
+		t.Fatal("two-instance v9 reconcile must start exporters")
+	}
+	b := d.flowBundle.Load()
+	if b == nil || len(b.groups) != 2 {
+		t.Fatalf("expected two v9 groups (alpha + bravo), got %v", b)
+	}
+	// Verify the per-instance family scoping the callback relies on.
+	var alphaEC, bravoEC *flowexport.ExportConfig
+	for _, g := range b.groups {
+		switch g.ec.InstanceName {
+		case "alpha":
+			alphaEC = g.ec
+		case "bravo":
+			bravoEC = g.ec
+		}
+	}
+	if alphaEC == nil || bravoEC == nil {
+		t.Fatalf("both instances must resolve to a group: alpha=%v bravo=%v", alphaEC, bravoEC)
+	}
+	if !alphaEC.ServesFamily(false) || alphaEC.ServesFamily(true) {
+		t.Errorf("alpha must serve v4 only: v4=%v v6=%v", alphaEC.ServesFamily(false), alphaEC.ServesFamily(true))
+	}
+	if bravoEC.ServesFamily(false) || !bravoEC.ServesFamily(true) {
+		t.Errorf("bravo must serve v6 only: v4=%v v6=%v", bravoEC.ServesFamily(false), bravoEC.ServesFamily(true))
+	}
+
+	// Feed an IPv4 SESSION_CLOSE. Only alpha (inet) must export it.
+	payload := buildSessionCloseRawEventV4(
+		6, // TCP
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		12345, 443,
+		[4]byte{172, 16, 80, 8}, 40000,
+		2, 3, // trust -> untrust
+	)
+	if !d.eventReader.ProcessRawEvent(payload) {
+		t.Fatal("ProcessRawEvent rejected a valid SESSION_CLOSE payload")
+	}
+
+	// alpha (the IPv4 instance) must export the flow.
+	if got := waitInstanceFlows(t, b, "alpha"); got < 1 {
+		t.Fatalf("alpha (inet) must export the IPv4 SESSION_CLOSE, got %d flows", got)
+	}
+	// bravo (inet6) must NEVER receive the IPv4 flow. Give the 100ms flush
+	// ticker margin to (incorrectly) transmit before asserting zero — under
+	// the pre-#2462 global-fanout behavior bravo would have exported by now.
+	time.Sleep(300 * time.Millisecond)
+	if got := groupStatsForInstance(b, "bravo"); got != 0 {
+		t.Fatalf("bravo (inet6) must NOT export an IPv4 flow (#2462 isolation); got %d "+
+			"— the callback wrongly fanned a v4 record to the inet6 instance", got)
 	}
 }
 

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -171,22 +171,77 @@ emits one `*ExportConfig` per group:
   load / peer-sync path downgrades it to a warning (#1960) and the resolver
   DROPS that group, so a leniently-loaded bad config exports nothing for
   that collector rather than the wrong template.
-- **Shared sampling.** 1-in-N sampling is a forwarding-options-instance
-  property, not a per-template one, so all groups of a family share ONE
-  `sampleCounter` (a pointer). The daemon evaluates `ShouldExport` exactly
-  once per SESSION_CLOSE and fans the record out to every group.
+- **Per-instance sampling.** 1-in-N sampling is a sampling-INSTANCE
+  property (#2462). The template groups of ONE instance share that
+  instance's `sampleCounter` (a pointer); two different instances each get
+  their own counter. The daemon evaluates `ShouldExport` exactly once per
+  instance per SESSION_CLOSE and fans the record out to that instance's
+  groups.
 - `BuildExportConfig` / `BuildIPFIXExportConfig` (singular) are retained
   for single-aggregate callers and now return the first resolved group.
 
-### Daemon wiring (one exporter per group)
+## Multi-sampling-instance isolation (#2462)
 
-`reconcileFlowExporters` now starts **N exporters per family** — one per
-template group — instead of a single exporter. `d.flowExporters` /
-`d.ipfixExporters` are slices; the atomic `flowBundle` / `ipfixBundlePtr`
-carry the group set; the once-registered session-close callback makes the
-shared sampling decision on `groups[0]` and exports to every group. The
-per-family config-hash gate, transient-create-failure retry (no hash
-recorded), and shutdown teardown all operate over the slice.
+`forwarding-options` can define several `sampling instance <name>` blocks,
+each with its own input rate, families, and flow-servers. Before #2462 the
+resolver flattened EVERY instance into one global export policy:
+`collectVersionCollectors` merged all instances' flow-servers into one
+collector set, `samplingRate()` returned the first-nonzero `InputRate` in
+Go map order, and one `sampleCounter` was shared by the whole family. Flows
+from instance A exported to instance B's collectors and the effective rate
+depended on map-iteration order.
+
+The resolver now treats each instance as a first-class export policy. The
+grouping key is `(instance, version, template)`:
+
+- **Own collectors.** `collectInstanceVersionCollectors` walks ONE
+  instance's flow-servers, so instance A's collectors never receive
+  instance B's flows.
+- **Own rate.** Each instance's `ExportConfig.SamplingRate` is its own
+  `InputRate` — the first-nonzero map-order global rate is gone.
+- **Own 1-in-N counter.** Each instance gets a distinct `sampleCounter`, so
+  1-in-N is independent per instance (and still shared across that
+  instance's template groups, the #2461 invariant scoped to one instance).
+- **Attribution by family.** The only per-flow instance selector available
+  is the address family: the interface `family inet { sampling { input; } }`
+  stanza is a plain boolean and there is **no per-interface
+  sampling-instance selector** in the config model. So `ServesInet` /
+  `ServesInet6` record which families an instance configured a collector
+  for, and `ExportConfig.ServesFamily(isIPv6)` gates a record — an
+  inet-only instance never exports an IPv6 flow. The daemon callback walks
+  the contiguous per-instance run of groups, applies the family gate + the
+  single per-instance sampling decision, then fans to that instance's
+  groups.
+- **Determinism.** Instances are resolved in lexical name order
+  (`sortedInstanceNames`), so restarts produce identical wiring.
+
+### Supported vs rejected matrix
+
+| Configuration | Result |
+|---|---|
+| Single sampling instance (any rate / families / collectors) | **Supported** — unchanged from pre-#2462 (the common case) |
+| Two instances, different families (A: inet, B: inet6) | **Supported** — attributed by flow family |
+| Two instances, different export versions (A: version9, B: version-ipfix) on the same family | **Supported** — distinct datagram streams |
+| Two instances both exporting the same `(version, family)` pair | **Rejected at commit** — no per-flow instance selector exists, so the runtime cannot attribute a flow to one instance |
+
+The reject is `validateSamplingInstanceConflictsStrict` (`pkg/config`):
+strict on commit / commit-check (hard reject so the operator sees it),
+lenient on load / peer-sync (downgraded to a warning via
+`opts.lenientSamplingInstanceConflicts` so an already-persisted or
+peer-synced config still boots — #1960; the resolver still emits both
+instances' independent `ExportConfig`s, duplicating eligible flows to both
+rather than bricking the load).
+
+### Daemon wiring (one exporter per (instance, template) group)
+
+`reconcileFlowExporters` starts **N exporters per family** — one per
+`(instance, template)` group — instead of a single exporter.
+`d.flowExporters` / `d.ipfixExporters` are slices; the atomic `flowBundle`
+/ `ipfixBundlePtr` carry the group set; the once-registered session-close
+callback walks each contiguous per-instance run, applies the family gate +
+the single per-instance sampling decision, and exports to that instance's
+groups. The per-family config-hash gate, transient-create-failure retry (no
+hash recorded), and shutdown teardown all operate over the slice.
 
 ## Callers
 
@@ -211,7 +266,9 @@ bundle atomically. The callback calls `Exporter.ExportSessionClose()`
 `logging.EventReader` SESSION_CLOSE event. The resolved `*ExportConfig`
 is shared by pointer everywhere — in the bundle, by the callback's
 `ShouldExport`, AND inside the exporter — so there is exactly ONE live
-1-in-N `sampleCounter` (`atomic.Uint64`) per family. `ExportConfig` is
+1-in-N `sampleCounter` (`atomic.Uint64`) per sampling INSTANCE (#2462;
+shared across that instance's template groups, distinct between
+instances). `ExportConfig` is
 never copied by value: doing so would fork the atomic counter (a go-vet
 "copies lock value" failure) and silently re-seed the modulo cadence the
 moment any caller sampled off the copy (#2224).

--- a/pkg/flowexport/instance_isolation_test.go
+++ b/pkg/flowexport/instance_isolation_test.go
@@ -48,8 +48,11 @@ func twoInstanceV9() *config.ForwardingOptionsConfig {
 	}
 }
 
-// v9OnlySvc is a v9-only global stanza with a single template (so unreferenced
-// collectors inherit it, the common case).
+// v9OnlySvc is a v9-only global stanza with NO templates defined. The
+// instance-isolation tests use flow-servers that reference no template, so the
+// resolver places them in the default ("") group with the built-in timeout
+// defaults — these tests assert per-instance collector/rate/counter isolation,
+// not template resolution (that is covered by template_group_test.go).
 func v9OnlySvc() *config.ServicesConfig {
 	return &config.ServicesConfig{
 		FlowMonitoring: &config.FlowMonitoringConfig{

--- a/pkg/flowexport/instance_isolation_test.go
+++ b/pkg/flowexport/instance_isolation_test.go
@@ -1,0 +1,302 @@
+package flowexport
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2462 — sampling-instance identity is a first-class runtime object.
+//
+// Before #2462 the resolver merged EVERY sampling instance into one global
+// export policy: collectVersionCollectors walked all instances into one
+// collector slice, samplingRate() returned the first-nonzero InputRate in Go
+// map order, and one sampleCounter was shared by the whole family. Flows from
+// instance A exported to instance B's collectors and the effective rate
+// depended on map iteration order. These tests assert each instance resolves
+// to its OWN ExportConfig(s) — own collectors, own rate, own 1-in-N counter —
+// and that instances are isolated and deterministically ordered.
+
+// twoInstanceV9 builds two sampling instances with DIFFERENT rates and
+// DIFFERENT collectors, disambiguated by address family (instance "alpha"
+// serves inet, instance "bravo" serves inet6) so the combination is supported
+// (family is the per-flow attribution selector).
+func twoInstanceV9() *config.ForwardingOptionsConfig {
+	return &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"alpha": {
+					Name:      "alpha",
+					InputRate: 2,
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersion9},
+						},
+					},
+				},
+				"bravo": {
+					Name:      "bravo",
+					InputRate: 3,
+					FamilyInet6: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.2", Port: 2055, Version: config.FlowServerVersion9},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// v9OnlySvc is a v9-only global stanza with a single template (so unreferenced
+// collectors inherit it, the common case).
+func v9OnlySvc() *config.ServicesConfig {
+	return &config.ServicesConfig{
+		FlowMonitoring: &config.FlowMonitoringConfig{
+			Version9: &config.NetFlowV9Config{
+				Templates: map[string]*config.NetFlowV9Template{},
+			},
+		},
+	}
+}
+
+// TestInstanceIsolation is the headline #2462 fail-on-revert test: two
+// instances with different rates and different collectors resolve to TWO
+// independent ExportConfigs, each carrying ONLY its own collector, its own
+// rate, and its own (distinct) sampleCounter. Restore the merged-collector /
+// first-nonzero-rate behavior and the collectors cross over and the rates
+// collapse, failing the assertions below.
+func TestInstanceIsolation(t *testing.T) {
+	groups := ResolveV9TemplateGroups(v9OnlySvc(), twoInstanceV9())
+	if len(groups) != 2 {
+		t.Fatalf("two instances must yield two independent ExportConfigs, got %d", len(groups))
+	}
+
+	var alpha, bravo *ExportConfig
+	for _, ec := range groups {
+		switch ec.InstanceName {
+		case "alpha":
+			alpha = ec
+		case "bravo":
+			bravo = ec
+		}
+	}
+	if alpha == nil || bravo == nil {
+		t.Fatalf("both instances must resolve: alpha=%v bravo=%v", alpha, bravo)
+	}
+
+	// Each instance holds ONLY its own collector — no cross-contamination.
+	if len(alpha.Collectors) != 1 || alpha.Collectors[0].Address != "10.0.0.1:2055" {
+		t.Errorf("alpha collectors = %v, want only 10.0.0.1:2055", collectorAddrs(alpha))
+	}
+	if len(bravo.Collectors) != 1 || bravo.Collectors[0].Address != "10.0.0.2:2055" {
+		t.Errorf("bravo collectors = %v, want only 10.0.0.2:2055", collectorAddrs(bravo))
+	}
+
+	// Each instance keeps its OWN rate (not the first-map-entry global rate).
+	if alpha.SamplingRate != 2 {
+		t.Errorf("alpha SamplingRate = %d, want 2 (its own InputRate)", alpha.SamplingRate)
+	}
+	if bravo.SamplingRate != 3 {
+		t.Errorf("bravo SamplingRate = %d, want 3 (its own InputRate)", bravo.SamplingRate)
+	}
+
+	// Each instance has its OWN family scope.
+	if !alpha.ServesInet || alpha.ServesInet6 {
+		t.Errorf("alpha must serve inet only: inet=%v inet6=%v", alpha.ServesInet, alpha.ServesInet6)
+	}
+	if bravo.ServesInet || !bravo.ServesInet6 {
+		t.Errorf("bravo must serve inet6 only: inet=%v inet6=%v", bravo.ServesInet, bravo.ServesInet6)
+	}
+
+	// The 1-in-N counters are INDEPENDENT (distinct pointers): advancing
+	// alpha's counter must not move bravo's cadence.
+	if alpha.counter() == bravo.counter() {
+		t.Fatal("each instance must own a distinct sampleCounter; a shared counter " +
+			"is the merged-policy defect this fix removes")
+	}
+}
+
+// TestInstanceCounterIndependence proves 1-in-N is per-instance: with alpha at
+// rate 2 and bravo at rate 3, alpha's modulo cadence is unaffected by bravo's
+// sampling and vice versa. A shared counter (the old behavior) would interleave
+// the two cadences and change which calls export.
+func TestInstanceCounterIndependence(t *testing.T) {
+	groups := ResolveV9TemplateGroups(v9OnlySvc(), twoInstanceV9())
+	var alpha, bravo *ExportConfig
+	for _, ec := range groups {
+		switch ec.InstanceName {
+		case "alpha":
+			alpha = ec
+		case "bravo":
+			bravo = ec
+		}
+	}
+	if alpha == nil || bravo == nil {
+		t.Fatalf("both instances must resolve")
+	}
+
+	// Drive bravo several times; this must NOT perturb alpha's own counter.
+	for i := 0; i < 5; i++ {
+		bravo.ShouldExport(0, 0)
+	}
+	// alpha rate 2: first call -> counter 1 -> 1%2 != 0 -> drop; second -> 2%2 == 0 -> export.
+	if alpha.ShouldExport(0, 0) {
+		t.Fatal("alpha first call must drop (1%2 != 0); bravo's sampling must not advance alpha's counter")
+	}
+	if !alpha.ShouldExport(0, 0) {
+		t.Fatal("alpha second call must export (2%2 == 0)")
+	}
+}
+
+// TestInstanceTemplateGroupsShareInstanceCounter proves the per-INSTANCE
+// counter is still shared across that instance's template groups (the #2461
+// invariant, now scoped to one instance): two collectors in one instance
+// referencing two templates share one counter, but a second instance gets its
+// own.
+func TestInstanceTemplateGroupsShareInstanceCounter(t *testing.T) {
+	svc := twoTemplateV9Svc()
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"alpha": {
+					Name:      "alpha",
+					InputRate: 2,
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "fast"},
+							{Address: "10.0.0.2", Port: 2055, Version: config.FlowServerVersion9, Version9Template: "slow"},
+						},
+					},
+				},
+				"bravo": {
+					Name:      "bravo",
+					InputRate: 2,
+					FamilyInet6: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.3", Port: 2055, Version: config.FlowServerVersion9},
+						},
+					},
+				},
+			},
+		},
+	}
+	groups := ResolveV9TemplateGroups(svc, fo)
+	if len(groups) != 3 {
+		t.Fatalf("alpha (2 templates) + bravo (1) must yield 3 groups, got %d", len(groups))
+	}
+
+	// Collect alpha's two template groups and bravo's group.
+	var alphaGroups []*ExportConfig
+	var bravoGroup *ExportConfig
+	for _, ec := range groups {
+		if ec.InstanceName == "alpha" {
+			alphaGroups = append(alphaGroups, ec)
+		} else if ec.InstanceName == "bravo" {
+			bravoGroup = ec
+		}
+	}
+	if len(alphaGroups) != 2 || bravoGroup == nil {
+		t.Fatalf("want 2 alpha groups + 1 bravo group, got alpha=%d bravo=%v", len(alphaGroups), bravoGroup)
+	}
+	// alpha's two template groups share ONE counter.
+	if alphaGroups[0].counter() != alphaGroups[1].counter() {
+		t.Error("alpha's template groups must share the instance counter (#2461 within instance)")
+	}
+	// bravo's counter is distinct from alpha's.
+	if bravoGroup.counter() == alphaGroups[0].counter() {
+		t.Error("bravo must own a counter distinct from alpha (#2462)")
+	}
+}
+
+// TestInstanceResolutionDeterministic proves resolving the same multi-instance
+// config repeatedly yields identical instance ordering and per-instance
+// collector ordering. Restore Go-map iteration order over instances and this
+// flakes (the determinism half of #2462).
+func TestInstanceResolutionDeterministic(t *testing.T) {
+	fo := twoInstanceV9()
+	var prev []string
+	for i := 0; i < 50; i++ {
+		groups := ResolveV9TemplateGroups(v9OnlySvc(), fo)
+		var order []string
+		for _, ec := range groups {
+			order = append(order, ec.InstanceName)
+			for _, c := range ec.Collectors {
+				order = append(order, c.Address)
+			}
+		}
+		if prev == nil {
+			prev = order
+			continue
+		}
+		if len(order) != len(prev) {
+			t.Fatalf("resolve %d shape changed: %v vs %v", i, order, prev)
+		}
+		for j := range order {
+			if order[j] != prev[j] {
+				t.Fatalf("resolve %d nondeterministic at %d: %v vs %v", i, j, order, prev)
+			}
+		}
+	}
+	// Expected stable order: alpha before bravo (lexical instance order).
+	want := []string{"alpha", "10.0.0.1:2055", "bravo", "10.0.0.2:2055"}
+	if len(prev) != len(want) {
+		t.Fatalf("order = %v, want %v", prev, want)
+	}
+	for i := range want {
+		if prev[i] != want[i] {
+			t.Fatalf("deterministic order = %v, want %v", prev, want)
+		}
+	}
+}
+
+// TestSingleInstanceNoRegression is the anti-over-gate guard: a single
+// instance must resolve exactly as before (one group, its collectors, its
+// rate), the common case the issue stresses must be unaffected.
+func TestSingleInstanceNoRegression(t *testing.T) {
+	fo := samplingFO(
+		&config.FlowServer{Address: "10.0.0.1", Port: 2055, Version: config.FlowServerVersion9},
+		&config.FlowServer{Address: "10.0.0.2", Port: 2055, Version: config.FlowServerVersion9},
+	)
+	groups := ResolveV9TemplateGroups(v9OnlySvc(), fo)
+	if len(groups) != 1 {
+		t.Fatalf("single instance must yield ONE group, got %d", len(groups))
+	}
+	g := groups[0]
+	if g.InstanceName != "s" {
+		t.Errorf("InstanceName = %q, want s", g.InstanceName)
+	}
+	if g.SamplingRate != 100 {
+		t.Errorf("SamplingRate = %d, want 100 (samplingFO InputRate)", g.SamplingRate)
+	}
+	if len(g.Collectors) != 2 {
+		t.Errorf("single instance group must hold both collectors, got %d", len(g.Collectors))
+	}
+	// samplingFO configures FamilyInet only.
+	if !g.ServesInet || g.ServesInet6 {
+		t.Errorf("samplingFO is inet-only: inet=%v inet6=%v", g.ServesInet, g.ServesInet6)
+	}
+	if !g.ServesFamily(false) || g.ServesFamily(true) {
+		t.Error("inet-only instance must serve v4 but not v6 flows")
+	}
+}
+
+// TestServesFamilyAttribution proves the per-family attribution: an inet-only
+// instance does not claim IPv6 flows, an inet6-only instance does not claim
+// IPv4 flows. This is the control-plane mechanism that keeps two
+// family-disjoint instances isolated.
+func TestServesFamilyAttribution(t *testing.T) {
+	groups := ResolveV9TemplateGroups(v9OnlySvc(), twoInstanceV9())
+	for _, ec := range groups {
+		switch ec.InstanceName {
+		case "alpha": // inet only
+			if !ec.ServesFamily(false) || ec.ServesFamily(true) {
+				t.Errorf("alpha (inet) must serve v4 only: v4=%v v6=%v", ec.ServesFamily(false), ec.ServesFamily(true))
+			}
+		case "bravo": // inet6 only
+			if ec.ServesFamily(false) || !ec.ServesFamily(true) {
+				t.Errorf("bravo (inet6) must serve v6 only: v4=%v v6=%v", ec.ServesFamily(false), ec.ServesFamily(true))
+			}
+		}
+	}
+}

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -35,7 +35,7 @@ type SamplingDir struct {
 // ExportConfig holds the resolved NetFlow export configuration for a
 // single template group: the collectors that referenced one template (or
 // the default-template collectors that referenced none), the timeouts and
-// v9 field options resolved from THAT template, plus the family-wide
+// v9 field options resolved from THAT template, plus the per-instance
 // sampling state.
 //
 // #2461: before this change a single ExportConfig was built per family
@@ -43,30 +43,51 @@ type SamplingDir struct {
 // collector, so a per-flow-server template reference was silently ignored
 // and the chosen template flipped across restarts. The resolver now emits
 // one ExportConfig per referenced template — the group key is
-// (version, template_name); source-address is a deterministic sort
-// tiebreak, NOT part of the key, so collectors that share a template but
-// pin different source-addresses land in ONE group and each still gets its
-// own source-pinned UDP connection from dialCollectors (see
-// ResolveV9TemplateGroups / ResolveIPFIXTemplateGroups). The daemon runs
-// one exporter per group; the groups of a family share one sampleCounter
-// (pointer below) so 1-in-N sampling stays global across the family rather
-// than restarting the modulo cadence per template.
+// (instance, version, template_name); source-address is a deterministic
+// sort tiebreak, NOT part of the key, so collectors that share a template
+// but pin different source-addresses land in ONE group and each still gets
+// its own source-pinned UDP connection from dialCollectors (see
+// ResolveV9TemplateGroups / ResolveIPFIXTemplateGroups).
+//
+// #2462: sampling-instance identity is now first-class. Each sampling
+// instance resolves to its OWN ExportConfig(s) carrying its OWN InputRate
+// and its OWN sampleCounter, so a flow eligible for instance A exports ONLY
+// to instance A's collectors at instance A's rate (1-in-N is independent
+// per instance) and NEVER crosses to instance B. The template groups of one
+// instance share that instance's sampleCounter (pointer below) so 1-in-N
+// stays a single cadence across the instance's templates, but two instances
+// never share a counter. Attribution to an instance is by address family:
+// ServesInet / ServesInet6 record which families the instance configured a
+// collector for, and ShouldExportFamily gates a record so an IPv6 flow is
+// not exported by an instance that configured only inet collectors. Two
+// instances claiming the SAME (version, family) are genuinely ambiguous (no
+// per-interface instance selector exists to attribute a flow) and are
+// rejected at commit — see validateSamplingInstanceConflictsStrict.
 type ExportConfig struct {
 	Collectors          []CollectorConfig
+	InstanceName        string // sampling instance this config belongs to (#2462)
 	TemplateName        string // referenced template ("" = default group)
 	FlowActiveTimeout   time.Duration
 	FlowInactiveTimeout time.Duration
 	TemplateRefreshRate time.Duration
 	SamplingZones       map[uint16]SamplingDir // zone ID -> sampling directions
 	SamplingRate        int                    // 1-in-N sampling (0 = export all)
-	V9TemplateOpts      V9TemplateOptions      // optional v9 template field control
+	// ServesInet / ServesInet6 record which address families this instance
+	// configured a flow-server for (#2462). ShouldExportFamily uses them to
+	// attribute a flow to the right instance: an instance with only inet
+	// collectors must not export an IPv6 flow. An instance that configured
+	// neither (no flow-servers for this version) produces no ExportConfig at
+	// all, so both true-everywhere defaults are never observed.
+	ServesInet     bool
+	ServesInet6    bool
+	V9TemplateOpts V9TemplateOptions // optional v9 template field control
 	// sampleCounter is the monotonic 1-in-N counter. It is a POINTER so all
-	// ExportConfig groups of one family share a single counter (the
-	// sampling rate is a forwarding-options-instance property, not a
-	// per-template one). A nil pointer is lazily allocated on first use so
-	// a hand-built ExportConfig (tests, the singular Build* helpers) still
-	// samples correctly. json.Marshal skips the unexported field, so the
-	// reconcile config-hash is unaffected.
+	// ExportConfig template groups of one INSTANCE share a single counter
+	// (the sampling rate is a per-instance property; #2462). Two different
+	// instances each get their own counter. A nil pointer is lazily
+	// allocated on first use so a hand-built ExportConfig (tests, the
+	// singular Build* helpers) still samples correctly. json.Marshal skips
+	// the unexported field, so the reconcile config-hash is unaffected.
 	sampleCounter *atomic.Uint64
 	counterOnce   sync.Once
 }
@@ -131,52 +152,67 @@ func resolveFlowServerVersion(fs *config.FlowServer, hasV9, hasIPFIX bool) strin
 	}
 }
 
-// collectVersionCollectors walks every sampling family's flow-servers
-// and returns the deduplicated collector set for the requested export
-// version, skipping flow-servers resolved to the other version. This is
-// the per-flow-server version binding that prevents double-export
-// (#2136): the v9 builder calls it with version=version9, the IPFIX
-// builder with version=version-ipfix, and a server appears in at most
-// one of the two sets.
-func collectVersionCollectors(fo *config.ForwardingOptionsConfig, version string, hasV9, hasIPFIX bool) []CollectorConfig {
-	var collectors []CollectorConfig
-	for _, inst := range fo.Sampling.Instances {
-		families := []*config.SamplingFamily{inst.FamilyInet, inst.FamilyInet6}
-		for _, fam := range families {
-			if fam == nil {
+// collectInstanceVersionCollectors walks ONE sampling instance's
+// flow-servers and returns the deduplicated collector set for the requested
+// export version, skipping flow-servers resolved to the other version. It
+// also reports which address families (inet / inet6) the instance
+// configured a collector for under this version, so the caller can scope the
+// resulting ExportConfig to those families (#2462 attribution). This is the
+// per-flow-server version binding that prevents double-export (#2136): the
+// v9 resolver calls it with version=version9, the IPFIX resolver with
+// version=version-ipfix, and a server appears in at most one of the two
+// sets.
+//
+// #2462: this is now per-INSTANCE (was a global walk over every instance,
+// which merged distinct instances into one collector set — the defect).
+func collectInstanceVersionCollectors(inst *config.SamplingInstance, version string, hasV9, hasIPFIX bool) (collectors []CollectorConfig, servesInet, servesInet6 bool) {
+	families := []struct {
+		fam  *config.SamplingFamily
+		isV6 bool
+	}{
+		{inst.FamilyInet, false},
+		{inst.FamilyInet6, true},
+	}
+	for _, fe := range families {
+		fam := fe.fam
+		if fam == nil {
+			continue
+		}
+		for _, fs := range fam.FlowServers {
+			if resolveFlowServerVersion(fs, hasV9, hasIPFIX) != version {
 				continue
 			}
-			for _, fs := range fam.FlowServers {
-				if resolveFlowServerVersion(fs, hasV9, hasIPFIX) != version {
-					continue
-				}
-				addr := fs.Address
-				if fs.Port > 0 {
-					// net.JoinHostPort brackets an IPv6 literal
-					// ([2001:db8::9]:4739) so net.ResolveUDPAddr /
-					// net.Dial in transport.go can parse it. A plain
-					// "%s:%d" leaves an IPv6 address unbracketed
-					// (2001:db8::9:4739), which they cannot parse, so
-					// IPv6 flow collectors never dial (#2183).
-					addr = net.JoinHostPort(fs.Address, strconv.Itoa(fs.Port))
-				}
-				srcAddr := fam.SourceAddress
-				if srcAddr == "" {
-					srcAddr = fam.InlineJflowSourceAddress
-				}
-				tmpl := fs.Version9Template
-				if version == config.FlowServerVersionIPFIX {
-					tmpl = fs.VersionIPFIXTemplate
-				}
-				collectors = append(collectors, CollectorConfig{
-					Address:       addr,
-					SourceAddress: srcAddr,
-					Template:      tmpl,
-				})
+			addr := fs.Address
+			if fs.Port > 0 {
+				// net.JoinHostPort brackets an IPv6 literal
+				// ([2001:db8::9]:4739) so net.ResolveUDPAddr /
+				// net.Dial in transport.go can parse it. A plain
+				// "%s:%d" leaves an IPv6 address unbracketed
+				// (2001:db8::9:4739), which they cannot parse, so
+				// IPv6 flow collectors never dial (#2183).
+				addr = net.JoinHostPort(fs.Address, strconv.Itoa(fs.Port))
+			}
+			srcAddr := fam.SourceAddress
+			if srcAddr == "" {
+				srcAddr = fam.InlineJflowSourceAddress
+			}
+			tmpl := fs.Version9Template
+			if version == config.FlowServerVersionIPFIX {
+				tmpl = fs.VersionIPFIXTemplate
+			}
+			collectors = append(collectors, CollectorConfig{
+				Address:       addr,
+				SourceAddress: srcAddr,
+				Template:      tmpl,
+			})
+			if fe.isV6 {
+				servesInet6 = true
+			} else {
+				servesInet = true
 			}
 		}
 	}
-	return dedupeCollectors(collectors)
+	return dedupeCollectors(collectors), servesInet, servesInet6
 }
 
 // dedupeCollectors removes duplicate collector destinations (same
@@ -260,15 +296,18 @@ func ipfixTemplateContext(tmpl *config.NetFlowIPFIXTemplate) templateContext {
 	return tc
 }
 
-// samplingRate returns the global 1-in-N sampling rate (the first sampling
-// instance's input rate), shared by every template group of both families.
-func samplingRate(fo *config.ForwardingOptionsConfig) int {
-	for _, inst := range fo.Sampling.Instances {
-		if inst.InputRate > 0 {
-			return inst.InputRate
-		}
+// sortedInstanceNames returns the sampling-instance names in deterministic
+// (lexical) order so the resolved exporter wiring is restart-stable (#2462).
+// Killing the Go-map-iteration order is half of the determinism fix; the
+// other half is per-instance rate selection (no more first-nonzero
+// map-order-dependent global rate).
+func sortedInstanceNames(fo *config.ForwardingOptionsConfig) []string {
+	names := make([]string, 0, len(fo.Sampling.Instances))
+	for name := range fo.Sampling.Instances {
+		names = append(names, name)
 	}
-	return 0
+	sort.Strings(names)
+	return names
 }
 
 // groupCollectorsByTemplate partitions the deduplicated collector list into
@@ -325,13 +364,6 @@ func ResolveV9TemplateGroups(svc *config.ServicesConfig, fo *config.ForwardingOp
 	}
 
 	hasIPFIX := svc.FlowMonitoring.VersionIPFIX != nil
-	// #2136 per-flow-server version binding: collect only the flow-servers
-	// bound to NetFlow v9 so a collector under both versions gets one stream.
-	collectors := collectVersionCollectors(fo, config.FlowServerVersion9, true, hasIPFIX)
-	if len(collectors) == 0 {
-		return nil
-	}
-
 	defined := svc.FlowMonitoring.Version9.Templates
 	// defaultCtx: when exactly one template is defined, an unreferenced
 	// collector inherits it (preserves the pre-#2461 single-template case);
@@ -343,32 +375,48 @@ func ResolveV9TemplateGroups(svc *config.ServicesConfig, fo *config.ForwardingOp
 		}
 	}
 
-	rate := samplingRate(fo)
-	shared := &atomic.Uint64{}
-	keys, groups := groupCollectorsByTemplate(collectors)
-
 	var out []*ExportConfig
-	for _, name := range keys {
-		ctx := defaultCtx
-		if name != "" {
-			tmpl, ok := defined[name]
-			if !ok {
-				// Undefined reference: drop (the strict gate rejects on
-				// commit; lenient load exports nothing for these collectors).
-				continue
-			}
-			ctx = v9TemplateContext(tmpl)
+	// #2462: iterate instances in deterministic order; each instance is an
+	// independent export policy (own collectors, own rate, own counter).
+	for _, instName := range sortedInstanceNames(fo) {
+		inst := fo.Sampling.Instances[instName]
+		if inst == nil {
+			continue
 		}
-		out = append(out, &ExportConfig{
-			Collectors:          groups[name],
-			TemplateName:        name,
-			FlowActiveTimeout:   ctx.activeTimeout,
-			FlowInactiveTimeout: ctx.inactiveTimeout,
-			TemplateRefreshRate: ctx.refreshRate,
-			V9TemplateOpts:      ctx.v9opts,
-			SamplingRate:        rate,
-			sampleCounter:       shared,
-		})
+		// #2136 per-flow-server version binding: collect only THIS instance's
+		// flow-servers bound to NetFlow v9.
+		collectors, servesInet, servesInet6 := collectInstanceVersionCollectors(inst, config.FlowServerVersion9, true, hasIPFIX)
+		if len(collectors) == 0 {
+			continue
+		}
+		rate := inst.InputRate
+		shared := &atomic.Uint64{} // per-INSTANCE counter (#2462)
+		keys, groups := groupCollectorsByTemplate(collectors)
+		for _, name := range keys {
+			ctx := defaultCtx
+			if name != "" {
+				tmpl, ok := defined[name]
+				if !ok {
+					// Undefined reference: drop (the strict gate rejects on
+					// commit; lenient load exports nothing for these collectors).
+					continue
+				}
+				ctx = v9TemplateContext(tmpl)
+			}
+			out = append(out, &ExportConfig{
+				Collectors:          groups[name],
+				InstanceName:        instName,
+				TemplateName:        name,
+				FlowActiveTimeout:   ctx.activeTimeout,
+				FlowInactiveTimeout: ctx.inactiveTimeout,
+				TemplateRefreshRate: ctx.refreshRate,
+				V9TemplateOpts:      ctx.v9opts,
+				SamplingRate:        rate,
+				ServesInet:          servesInet,
+				ServesInet6:         servesInet6,
+				sampleCounter:       shared,
+			})
+		}
 	}
 	return out
 }
@@ -385,11 +433,6 @@ func ResolveIPFIXTemplateGroups(svc *config.ServicesConfig, fo *config.Forwardin
 	}
 
 	hasV9 := svc.FlowMonitoring.Version9 != nil
-	collectors := collectVersionCollectors(fo, config.FlowServerVersionIPFIX, hasV9, true)
-	if len(collectors) == 0 {
-		return nil
-	}
-
 	defined := svc.FlowMonitoring.VersionIPFIX.Templates
 	defaultCtx := defaultTemplateContext()
 	if len(defined) == 1 {
@@ -398,29 +441,41 @@ func ResolveIPFIXTemplateGroups(svc *config.ServicesConfig, fo *config.Forwardin
 		}
 	}
 
-	rate := samplingRate(fo)
-	shared := &atomic.Uint64{}
-	keys, groups := groupCollectorsByTemplate(collectors)
-
 	var out []*ExportConfig
-	for _, name := range keys {
-		ctx := defaultCtx
-		if name != "" {
-			tmpl, ok := defined[name]
-			if !ok {
-				continue
-			}
-			ctx = ipfixTemplateContext(tmpl)
+	for _, instName := range sortedInstanceNames(fo) {
+		inst := fo.Sampling.Instances[instName]
+		if inst == nil {
+			continue
 		}
-		out = append(out, &ExportConfig{
-			Collectors:          groups[name],
-			TemplateName:        name,
-			FlowActiveTimeout:   ctx.activeTimeout,
-			FlowInactiveTimeout: ctx.inactiveTimeout,
-			TemplateRefreshRate: ctx.refreshRate,
-			SamplingRate:        rate,
-			sampleCounter:       shared,
-		})
+		collectors, servesInet, servesInet6 := collectInstanceVersionCollectors(inst, config.FlowServerVersionIPFIX, hasV9, true)
+		if len(collectors) == 0 {
+			continue
+		}
+		rate := inst.InputRate
+		shared := &atomic.Uint64{} // per-INSTANCE counter (#2462)
+		keys, groups := groupCollectorsByTemplate(collectors)
+		for _, name := range keys {
+			ctx := defaultCtx
+			if name != "" {
+				tmpl, ok := defined[name]
+				if !ok {
+					continue
+				}
+				ctx = ipfixTemplateContext(tmpl)
+			}
+			out = append(out, &ExportConfig{
+				Collectors:          groups[name],
+				InstanceName:        instName,
+				TemplateName:        name,
+				FlowActiveTimeout:   ctx.activeTimeout,
+				FlowInactiveTimeout: ctx.inactiveTimeout,
+				TemplateRefreshRate: ctx.refreshRate,
+				SamplingRate:        rate,
+				ServesInet:          servesInet,
+				ServesInet6:         servesInet6,
+				sampleCounter:       shared,
+			})
+		}
 	}
 	return out
 }
@@ -508,6 +563,20 @@ func (ec *ExportConfig) ShouldExport(inZone, outZone uint16) bool {
 		return n%uint64(ec.SamplingRate) == 0
 	}
 	return true
+}
+
+// ServesFamily reports whether this instance's ExportConfig should handle a
+// flow of the given address family (#2462). An instance that configured only
+// inet collectors must not export an IPv6 flow (and vice versa) — that is the
+// control-plane attribution that keeps two family-disjoint instances
+// isolated. An ExportConfig is only ever built for a version the instance has
+// at least one collector for, so at least one of ServesInet / ServesInet6 is
+// always true here.
+func (ec *ExportConfig) ServesFamily(isIPv6 bool) bool {
+	if isIPv6 {
+		return ec.ServesInet6
+	}
+	return ec.ServesInet
 }
 
 // counter returns the shared 1-in-N counter, lazily allocating a private

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -58,7 +58,7 @@ type SamplingDir struct {
 // stays a single cadence across the instance's templates, but two instances
 // never share a counter. Attribution to an instance is by address family:
 // ServesInet / ServesInet6 record which families the instance configured a
-// collector for, and ShouldExportFamily gates a record so an IPv6 flow is
+// collector for, and ServesFamily gates a record so an IPv6 flow is
 // not exported by an instance that configured only inet collectors. Two
 // instances claiming the SAME (version, family) are genuinely ambiguous (no
 // per-interface instance selector exists to attribute a flow) and are
@@ -73,7 +73,7 @@ type ExportConfig struct {
 	SamplingZones       map[uint16]SamplingDir // zone ID -> sampling directions
 	SamplingRate        int                    // 1-in-N sampling (0 = export all)
 	// ServesInet / ServesInet6 record which address families this instance
-	// configured a flow-server for (#2462). ShouldExportFamily uses them to
+	// configured a flow-server for (#2462). ServesFamily uses them to
 	// attribute a flow to the right instance: an instance with only inet
 	// collectors must not export an IPv6 flow. An instance that configured
 	// neither (no flow-servers for this version) produces no ExportConfig at


### PR DESCRIPTION
Closes #2462

## Problem

Multiple `forwarding-options sampling instance` blocks collapsed into ONE
global export policy. In `pkg/flowexport/manager.go`:

- `collectVersionCollectors` merged every instance's flow-servers into one
  collector slice.
- `samplingRate()` returned the FIRST nonzero `InputRate` in Go map order
  (nondeterministic — exactly the Copilot finding on #2461).
- One `sampleCounter` was shared by the whole family.

Result: flows from instance A could export to instance B's collectors, and
the effective rate depended on map iteration order — bad telemetry under
normal operation, worse during incident response. MEDIUM, codex review-034
finding 3.

## Fix: instance identity is first-class, composing with #2461

#2461 grouped collectors by `(version, template)` into per-group
`ExportConfig`s with a shared per-family counter. #2462 extends that
grouping key with instance identity → `(instance, version, template)`:

- **Own collectors** — `collectVersionCollectors` becomes the per-instance
  `collectInstanceVersionCollectors`; instance A's collectors never receive
  instance B's flows.
- **Own rate** — each `ExportConfig.SamplingRate` is that instance's own
  `InputRate`. The first-nonzero map-order global rate is removed.
- **Own 1-in-N counter** — each instance gets a distinct `sampleCounter`,
  still shared across that instance's template groups (the #2461 invariant,
  scoped to one instance).
- **Determinism** — instances resolve in lexical name order
  (`sortedInstanceNames`); restarts produce identical wiring.

### Flow → instance attribution (the key design point)

The only per-flow instance selector available is the **address family**:
the interface `family inet { sampling { input; } }` stanza is a plain
boolean and there is **no per-interface sampling-instance selector** in the
config model. So attribution is by family — `ServesInet` / `ServesInet6` +
`ExportConfig.ServesFamily(isIPv6)` gate a record so an inet-only instance
never exports an IPv6 flow. The daemon callback walks the contiguous
per-instance run of groups, applies the family gate + the single
per-instance sampling decision, then fans to that instance's groups.

No dataplane change was required — attribution is fully control-plane
resolvable (family of the flow vs. the instance's configured family).

### Supported vs rejected matrix

| Configuration | Result |
|---|---|
| Single sampling instance (any rate / families / collectors) | **Supported** — unchanged from pre-#2462 (the common case) |
| Two instances, different families (A inet, B inet6) | **Supported** — attributed by flow family |
| Two instances, different export versions (A version9, B version-ipfix) on the same family | **Supported** — distinct datagram streams |
| Two instances both exporting the same `(version, family)` pair | **Rejected at commit** — no per-flow instance selector exists to attribute a flow |

The reject is `validateSamplingInstanceConflictsStrict` (`pkg/config`):
strict on commit / commit-check (hard reject so the typo is operator
visible), lenient on load / peer-sync (downgraded to a warning via
`opts.lenientSamplingInstanceConflicts` so an already-persisted or
peer-synced config still boots — #1960; the resolver still emits both
instances' independent `ExportConfig`s, duplicating eligible flows rather
than bricking the load). Mirrors `validateFlowServerTemplateReferencesStrict`.

## Single-instance no-regression

A single instance resolves bit-for-bit as before — one group, its
collectors, its rate, its counter. Guarded by
`TestSingleInstanceNoRegression`. The conflict gate only fires for >= 2
instances, never for the common case (anti-over-gate).

## Tests (fail-on-revert)

`pkg/flowexport/instance_isolation_test.go`:
- `TestInstanceIsolation` — two instances: own collectors, own rates,
  distinct counters.
- `TestInstanceCounterIndependence` — 1-in-N is per-instance (driving B's
  counter never perturbs A's cadence).
- `TestInstanceTemplateGroupsShareInstanceCounter` — counter shared within
  an instance, distinct between instances.
- `TestInstanceResolutionDeterministic` — 50x identical instance/collector
  ordering.
- `TestSingleInstanceNoRegression`, `TestServesFamilyAttribution`.

`pkg/config/sampling_instance_conflict_test.go`:
- reject same-(version,family); accept family-disjoint, version-disjoint,
  single multi-family; lenient warns.

Fail-on-revert verified: restoring first-nonzero rate / shared counter
fails the isolation tests; removing the strict call accepts the
conflicting config.

## Validation

- `go build ./...` clean
- `go test -race -count=5 ./pkg/flowexport/ ./pkg/config/ ./pkg/daemon/` green
- `gofmt -l` clean on touched files, `go vet` clean
- docs: `pkg/flowexport/README.md` (isolation section + supported/rejected
  matrix), `_Log.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi