### PR TITLE
dhcpserver: chown HA DHCP memfile pre-seed to the Kea user (#2450)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12367,3 +12367,24 @@ top.
 - **File(s)**: pkg/flowexport/manager.go,
   pkg/flowexport/instance_isolation_test.go,
   pkg/daemon/daemon_flowexport_session_close_test.go, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2450 (HIGH, agy review-033 finding 2) — chown the HA DHCP
+  memfile pre-seed to the Kea runtime user. On takeover the standby pre-seeds
+  /var/lib/kea/kea-leases{4,6}.csv as ROOT 0640 with no chown; distro Kea runs
+  as unprivileged _kea (Debian/Ubuntu) or kea (RHEL) and opens the memfile RW
+  at startup, so a root-owned file → Kea EACCES → fails to start → DHCP outage
+  on failover. Fix: resolveKeaOwner() looks up _kea then kea via os/user
+  (cached behind sync.Once), and writeMemfileAtomic installs the file via
+  fsatomic.WithOwner so the chown rides the temp fd and the FINAL renamed inode
+  is _kea-owned atomically (no post-rename root window, no orphaned root temp).
+  Covers BOTH families. Robustness: absent Kea user → one warning, write
+  without owner, takeover NOT aborted. Seams: keaOwnerLookup (fake uid/gid) +
+  writeMemfileFile (owner recorder) so tests run unprivileged. Fail-on-revert
+  proven (drop the owner → chown assertions fail). Build/vet/gofmt clean;
+  go test ./pkg/dhcpserver/ green. The pre-existing pkg/fsatomic canary failure
+  (dataplane/proxyarp.go direct os.WriteFile) is unrelated — present on clean
+  origin/master.
+- **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/dhcpserver.go,
+  pkg/dhcpserver/test_seams.go, pkg/dhcpserver/lease_sync_test.go,
+  pkg/dhcpserver/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -12388,3 +12388,22 @@ top.
 - **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/dhcpserver.go,
   pkg/dhcpserver/test_seams.go, pkg/dhcpserver/lease_sync_test.go,
   pkg/dhcpserver/README.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2450 PR #2518 review folds (Copilot, 3 nits — code verdicted
+  MERGE-READY). (1) Fixed the resolveKeaOwner doc comment that named a
+  non-existent "keaOwnerCache" / "cached on first success" → now names
+  keaOwnerOnce (sync.Once) + describes once-per-process caching. (2+3) Moved
+  the absent-Kea-user warning OUT of writeMemfileAtomic (which warned on EVERY
+  pre-seed → twice per takeover for v4+v6, and again every takeover) INTO the
+  keaOwnerOnce closure in resolveKeaOwner, so it fires exactly once per process
+  on lookup failure; writeMemfileAtomic is now silent on ok=false (still writes
+  without owner + returns nil — takeover never aborts). Updated the
+  writeMemfileAtomic comment + README to accurately say "one warning is logged
+  (once per process)". Strengthened TestPreSeedMemfile_NoKeaUser_WarnsAndSucceeds
+  to pre-seed BOTH families and assert exactly ONE warning across both (catches
+  the per-call regression — verified the reverted per-call warn fails it).
+  Build/vet/gofmt clean; go test ./pkg/dhcpserver/ green; targeted tests
+  -count=5 green.
+- **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/lease_sync_test.go,
+  pkg/dhcpserver/README.md, _Log.md

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -494,9 +494,11 @@ This package owns the KEA side of #2239 cross-chassis DHCP-server lease sync
   chown rides on the `fsatomic` temp fd (`fsatomic.WithOwner` fchowns BEFORE
   the rename), so the FINAL renamed inode is _kea-owned atomically — no
   post-rename root-owned window and no orphaned root-owned temp. Best-effort
-  when the Kea user is absent (dev host / Kea not installed): one warning, write
-  without the owner override, **takeover is never aborted**. Both the v4 and v6
-  memfiles are covered.
+  when the Kea user is absent (dev host / Kea not installed): one warning is
+  logged (once per process, in the cached owner resolution — not per pre-seed,
+  so an absent-user takeover does not warn twice for v4+v6 or again on every
+  later takeover), the file is written without the owner override, and
+  **takeover is never aborted**. Both the v4 and v6 memfiles are covered.
   The v6 WRITE side (memfile pre-seed AND `lease6-add`) encodes the lease kind
   SYMMETRICALLY with the read side: `stringToKeaLeaseType` is the exact total
   inverse of the read path's `keaLeaseTypeToString`, so IA_NA / IA_TA / IA_PD

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -484,7 +484,19 @@ This package owns the KEA side of #2239 cross-chassis DHCP-server lease sync
   memfile CSV (canonical header) BEFORE Kea start so it loads the in-use
   bindings at boot and can never hand an in-use address to a different client
   even in the pre-`lease-add` window (the duplicate-allocation-window closer).
-  Durable (`fsatomic.WriteFileDurable`).
+  Durable (`fsatomic.WriteFileDurable`). **Chowned to the Kea runtime user
+  (#2450):** xpfd runs as root but distro Kea runs unprivileged (`_kea` on
+  Debian/Ubuntu, `kea` on RHEL-family) and opens its memfile lease DB for
+  READ+WRITE at startup; a root-owned 0640 pre-seed would be unreadable by Kea
+  → it fails to start (EACCES) on the node that just took over → DHCP outage at
+  failover. The pre-seed therefore resolves the Kea user once (cached) and
+  installs the file already owned by it (0640 + owner=_kea ⇒ owner RW). The
+  chown rides on the `fsatomic` temp fd (`fsatomic.WithOwner` fchowns BEFORE
+  the rename), so the FINAL renamed inode is _kea-owned atomically — no
+  post-rename root-owned window and no orphaned root-owned temp. Best-effort
+  when the Kea user is absent (dev host / Kea not installed): one warning, write
+  without the owner override, **takeover is never aborted**. Both the v4 and v6
+  memfiles are covered.
   The v6 WRITE side (memfile pre-seed AND `lease6-add`) encodes the lease kind
   SYMMETRICALLY with the read side: `stringToKeaLeaseType` is the exact total
   inverse of the read path's `keaLeaseTypeToString`, so IA_NA / IA_TA / IA_PD

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -165,6 +165,19 @@ type Manager struct {
 	ctrlSocket6 string
 	leaseFile4  string
 	leaseFile6  string
+
+	// Kea runtime-user resolution for the memfile pre-seed (#2450). The
+	// pre-seeded lease memfile must be chowned to the unprivileged Kea user
+	// (_kea / kea) so Kea can open it RW on takeover; otherwise it fails to
+	// start (EACCES) and DHCP goes dark. keaOwnerLookup is a test seam (nil
+	// selects the real os/user lookup); the resolution is cached behind
+	// keaOwnerOnce so the takeover path does not read /etc/passwd per
+	// pre-seed.
+	keaOwnerOnce   sync.Once
+	keaOwnerLookup func() (uid, gid int, ok bool)
+	keaOwnerUID    int
+	keaOwnerGID    int
+	keaOwnerOK     bool
 }
 
 // SetLeaseSyncEnabled toggles emission of the Kea control-socket + lease_cmds

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -607,13 +608,13 @@ func (m *Manager) controlSocket(family int) string {
 // takeover the held peer set is the authoritative serving state, and Kea's own
 // LFC will compact going forward.
 func (m *Manager) PreSeedMemfile4(leases []SyncLease, now time.Time) error {
-	return writeMemfile4(m.leaseFile(4), leases, now)
+	return m.writeMemfile4(m.leaseFile(4), leases, now)
 }
 
 // PreSeedMemfile6 writes the held peer v6 leases into the Kea v6 memfile CSV
 // before Kea start (#2239 Q3). See PreSeedMemfile4.
 func (m *Manager) PreSeedMemfile6(leases []SyncLease, now time.Time) error {
-	return writeMemfile6(m.leaseFile(6), leases, now)
+	return m.writeMemfile6(m.leaseFile(6), leases, now)
 }
 
 // keaMemfileHeader4 is Kea's canonical DHCPv4 memfile CSV header (Kea 2.x/3.x).
@@ -629,7 +630,7 @@ func boolCSV(b bool) string {
 	return "0"
 }
 
-func writeMemfile4(path string, leases []SyncLease, now time.Time) error {
+func (m *Manager) writeMemfile4(path string, leases []SyncLease, now time.Time) error {
 	var b strings.Builder
 	b.WriteString(keaMemfileHeader4)
 	b.WriteByte('\n')
@@ -650,10 +651,10 @@ func writeMemfile4(path string, leases []SyncLease, now time.Time) error {
 			boolCSV(l.FQDNFwd), boolCSV(l.FQDNRev), csvField(l.Hostname),
 			keaStateDefault)
 	}
-	return writeMemfileAtomic(path, b.String())
+	return m.writeMemfileAtomic(path, b.String())
 }
 
-func writeMemfile6(path string, leases []SyncLease, now time.Time) error {
+func (m *Manager) writeMemfile6(path string, leases []SyncLease, now time.Time) error {
 	var b strings.Builder
 	b.WriteString(keaMemfileHeader6)
 	b.WriteByte('\n')
@@ -691,19 +692,113 @@ func writeMemfile6(path string, leases []SyncLease, now time.Time) error {
 			boolCSV(l.FQDNFwd), boolCSV(l.FQDNRev), csvField(l.Hostname),
 			keaStateDefault)
 	}
-	return writeMemfileAtomic(path, b.String())
+	return m.writeMemfileAtomic(path, b.String())
 }
 
 // writeMemfileAtomic writes the rendered memfile durably so a Kea start cannot
 // read a torn pre-seed. Pre-seed runs on the takeover path (not a hot path) so
 // the fsync cost is acceptable, and durability matters: the pre-seed exists to
 // survive a crash-failover, the worst case being a torn file Kea then rejects.
-func writeMemfileAtomic(path, content string) error {
+//
+// OWNERSHIP (#2450, HIGH): xpfd runs as root, but distro Kea (`kea-dhcp4`/
+// `kea-dhcp6`) runs as the unprivileged `_kea` (Debian/Ubuntu) or `kea`
+// (RHEL-family) user and opens its memfile lease DB for READ+WRITE at startup.
+// A root-owned 0640 file is unreadable/unwritable by that user, so Kea fails to
+// start (EACCES) on the node that just took over — a DHCP outage at the worst
+// possible moment. We therefore install the file already owned by the resolved
+// Kea runtime user (0640 + owner=_kea ⇒ owner can RW). The chown rides on the
+// fsatomic temp fd (fsatomic.WithOwner does fchown BEFORE the rename), so the
+// FINAL visible inode at `path` is _kea-owned atomically — there is no
+// post-rename window where the renamed-into-place file is root-owned, and no
+// orphaned root-owned temp survives the rename.
+//
+// ROBUSTNESS: when NEITHER Kea user exists (a dev host, or Kea simply not
+// installed) the takeover must NOT abort — chown is best-effort. We log one
+// warning and write the file without an owner override; the write itself still
+// succeeds. The daemon is root, so when the user DOES exist the chown cannot
+// fail for lack of privilege.
+func (m *Manager) writeMemfileAtomic(path, content string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("create %s: %w", dir, err)
 	}
-	return fsatomic.WriteFileDurable(path, []byte(content), 0640)
+	uid, gid, ok := m.resolveKeaOwner()
+	if !ok {
+		m.warnf("dhcpserver: no %s/%s runtime user found; pre-seeding Kea memfile %s "+
+			"as root — Kea may be unable to open it (EACCES) if it runs unprivileged",
+			keaPrimaryUser, keaFallbackUser, path)
+	}
+	return writeMemfileFile(path, []byte(content), 0640, uid, gid, ok)
+}
+
+// writeMemfileFile installs the pre-seeded memfile. It is a package var so a
+// test can record the resolved owner (uid/gid + whether the chown is applied)
+// and the final path without needing root to perform a real fchown. Production
+// rides the chown on the fsatomic temp fd via WithOwner, so the FINAL renamed
+// inode is _kea-owned atomically (no post-rename root-owned window).
+var writeMemfileFile = func(path string, data []byte, perm os.FileMode, uid, gid int, applyOwner bool) error {
+	var opts []fsatomic.Option
+	if applyOwner {
+		opts = append(opts, fsatomic.WithOwner(uid, gid))
+	}
+	return fsatomic.WriteFileDurable(path, data, perm, opts...)
+}
+
+// Kea runtime user names, in resolution order. Debian/Ubuntu (the appliance
+// base) package Kea to run as `_kea`; the RHEL-family packaging uses `kea`.
+const (
+	keaPrimaryUser  = "_kea"
+	keaFallbackUser = "kea"
+)
+
+// resolveKeaOwner returns the uid/gid the Kea memfile must be owned by so the
+// unprivileged Kea process can open it RW, and ok=false when neither candidate
+// user exists (chown then becomes best-effort — see writeMemfileAtomic). The
+// lookup is cached on first success so the takeover path does not hit
+// /etc/passwd per pre-seed. The resolver and the cache are seam-injectable for
+// tests (keaOwnerLookup / keaOwnerCache).
+func (m *Manager) resolveKeaOwner() (uid, gid int, ok bool) {
+	m.keaOwnerOnce.Do(func() {
+		lookup := m.keaOwnerLookup
+		if lookup == nil {
+			lookup = lookupKeaOwner
+		}
+		m.keaOwnerUID, m.keaOwnerGID, m.keaOwnerOK = lookup()
+	})
+	return m.keaOwnerUID, m.keaOwnerGID, m.keaOwnerOK
+}
+
+// lookupKeaOwner resolves the first existing Kea runtime user (_kea, then kea)
+// to its numeric uid/gid via the OS user database. It returns ok=false when
+// neither exists.
+func lookupKeaOwner() (uid, gid int, ok bool) {
+	for _, name := range []string{keaPrimaryUser, keaFallbackUser} {
+		u, err := user.Lookup(name)
+		if err != nil {
+			continue
+		}
+		ui, err := strconv.Atoi(u.Uid)
+		if err != nil {
+			continue
+		}
+		gi, err := strconv.Atoi(u.Gid)
+		if err != nil {
+			continue
+		}
+		return ui, gi, true
+	}
+	return 0, 0, false
+}
+
+// warnf routes a pre-seed warning through the manager's warn sink (the test
+// seam, default slog.Warn) using printf-style formatting so the message is one
+// human-readable line rather than slog key/value pairs.
+func (m *Manager) warnf(format string, args ...any) {
+	if m.warn != nil {
+		m.warn(fmt.Sprintf(format, args...))
+		return
+	}
+	slog.Warn(fmt.Sprintf(format, args...))
 }
 
 // csvField escapes a memfile CSV field. Kea memfile values (addresses,

--- a/pkg/dhcpserver/lease_sync.go
+++ b/pkg/dhcpserver/lease_sync.go
@@ -713,21 +713,18 @@ func (m *Manager) writeMemfile6(path string, leases []SyncLease, now time.Time) 
 // orphaned root-owned temp survives the rename.
 //
 // ROBUSTNESS: when NEITHER Kea user exists (a dev host, or Kea simply not
-// installed) the takeover must NOT abort — chown is best-effort. We log one
-// warning and write the file without an owner override; the write itself still
-// succeeds. The daemon is root, so when the user DOES exist the chown cannot
-// fail for lack of privilege.
+// installed) the takeover must NOT abort — chown is best-effort. The file is
+// written without an owner override and the write itself still succeeds; one
+// warning is logged (once per process, in resolveKeaOwner's cached lookup —
+// not per pre-seed) so an absent-user takeover does not warn twice for v4+v6
+// or again on every subsequent takeover. The daemon is root, so when the user
+// DOES exist the chown cannot fail for lack of privilege.
 func (m *Manager) writeMemfileAtomic(path, content string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("create %s: %w", dir, err)
 	}
 	uid, gid, ok := m.resolveKeaOwner()
-	if !ok {
-		m.warnf("dhcpserver: no %s/%s runtime user found; pre-seeding Kea memfile %s "+
-			"as root — Kea may be unable to open it (EACCES) if it runs unprivileged",
-			keaPrimaryUser, keaFallbackUser, path)
-	}
 	return writeMemfileFile(path, []byte(content), 0640, uid, gid, ok)
 }
 
@@ -754,9 +751,13 @@ const (
 // resolveKeaOwner returns the uid/gid the Kea memfile must be owned by so the
 // unprivileged Kea process can open it RW, and ok=false when neither candidate
 // user exists (chown then becomes best-effort — see writeMemfileAtomic). The
-// lookup is cached on first success so the takeover path does not hit
-// /etc/passwd per pre-seed. The resolver and the cache are seam-injectable for
-// tests (keaOwnerLookup / keaOwnerCache).
+// lookup runs exactly once per process (cached behind keaOwnerOnce, a
+// sync.Once) so the takeover path does not hit /etc/passwd per pre-seed. The
+// resolver is seam-injectable for tests (keaOwnerLookup; nil selects the real
+// os/user lookup). When the lookup FAILS, the absent-user warning is emitted
+// HERE — inside the once-guarded closure — so it fires exactly once per
+// process rather than on every pre-seed (an operator who installs the Kea
+// package mid-process restarts xpfd anyway, which re-runs the lookup).
 func (m *Manager) resolveKeaOwner() (uid, gid int, ok bool) {
 	m.keaOwnerOnce.Do(func() {
 		lookup := m.keaOwnerLookup
@@ -764,6 +765,11 @@ func (m *Manager) resolveKeaOwner() (uid, gid int, ok bool) {
 			lookup = lookupKeaOwner
 		}
 		m.keaOwnerUID, m.keaOwnerGID, m.keaOwnerOK = lookup()
+		if !m.keaOwnerOK {
+			m.warnf("dhcpserver: no %s/%s runtime user found; pre-seeding Kea "+
+				"memfiles as root — Kea may be unable to open them (EACCES) if it "+
+				"runs unprivileged", keaPrimaryUser, keaFallbackUser)
+		}
 	})
 	return m.keaOwnerUID, m.keaOwnerGID, m.keaOwnerOK
 }

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -711,32 +711,44 @@ func TestPreSeedMemfile_ChownsToKeaUser(t *testing.T) {
 }
 
 // Test (#2450 robustness): when NEITHER Kea user resolves (dev host / Kea not
-// installed), the pre-seed must NOT abort the takeover — it logs a warning,
-// writes the file without an owner override, and returns nil. Aborting here
-// would turn a missing-package condition into a failed failover.
+// installed), the pre-seed must NOT abort the takeover — it writes the file
+// without an owner override and returns nil. Aborting here would turn a
+// missing-package condition into a failed failover.
+//
+// The warning is emitted ONCE PER PROCESS from the cached owner resolution,
+// NOT per pre-seed: this test pre-seeds BOTH families and asserts exactly one
+// warning across the two pre-seeds (a stronger assertion than per-call — if
+// the warning regresses back into writeMemfileAtomic it fires twice here and
+// this fails).
 func TestPreSeedMemfile_NoKeaUser_WarnsAndSucceeds(t *testing.T) {
 	localNow := time.Unix(1_700_000_000, 0)
 	dir := t.TempDir()
 	memfile4 := filepath.Join(dir, "kea-leases4.csv")
+	memfile6 := filepath.Join(dir, "kea-leases6.csv")
 
 	calls, restore := installMemfileRecorder(t)
 	defer restore()
 
 	var warnings []string
 	m := New()
-	m.SetLeaseSyncSeamsForTesting(nil, "", "", memfile4, "")
+	m.SetLeaseSyncSeamsForTesting(nil, "", "", memfile4, memfile6)
 	m.SetWarnForTesting(func(msg string, _ ...any) { warnings = append(warnings, msg) })
 	m.SetKeaOwnerLookupForTesting(func() (int, int, bool) { return 0, 0, false })
 
-	in := []SyncLease{
+	if err := m.PreSeedMemfile4([]SyncLease{
 		{Family: 4, Address: "10.0.61.7", HWAddress: "aa:bb:cc:dd:ee:07",
 			SubnetID: 3, Remaining: 600, State: keaStateDefault},
-	}
-	if err := m.PreSeedMemfile4(in, localNow); err != nil {
+	}, localNow); err != nil {
 		t.Fatalf("PreSeedMemfile4 must not abort when Kea user absent: %v", err)
 	}
+	if err := m.PreSeedMemfile6([]SyncLease{
+		{Family: 6, Address: "2001:db8::7", DUID: "00:09", IAID: 9,
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 600, State: keaStateDefault},
+	}, localNow); err != nil {
+		t.Fatalf("PreSeedMemfile6 must not abort when Kea user absent: %v", err)
+	}
 
-	// The file was still written (takeover not aborted) and is parseable.
+	// The v4 file was still written (takeover not aborted) and is parseable.
 	got, err := parseActiveLeases4(memfile4, localNow)
 	if err != nil {
 		t.Fatalf("parseActiveLeases4 on pre-seeded file: %v", err)
@@ -744,13 +756,18 @@ func TestPreSeedMemfile_NoKeaUser_WarnsAndSucceeds(t *testing.T) {
 	if len(got) != 1 || got[0].Address != "10.0.61.7" {
 		t.Fatalf("pre-seeded memfile = %+v, want the one lease", got)
 	}
-	// No owner override requested.
-	if len(*calls) != 1 || (*calls)[0].applyOwner {
-		t.Fatalf("writeMemfileFile calls = %+v, want one call with applyOwner=false", *calls)
+	// Both families written, neither with an owner override.
+	if len(*calls) != 2 {
+		t.Fatalf("writeMemfileFile called %d times, want 2 (v4+v6)", len(*calls))
 	}
-	// A clear warning fired.
+	for _, c := range *calls {
+		if c.applyOwner {
+			t.Errorf("path %s: applyOwner=true, want no owner override when Kea user absent", c.path)
+		}
+	}
+	// Exactly ONE warning across both pre-seeds (once per process).
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "_kea") {
-		t.Errorf("warnings = %v, want one mentioning the missing Kea user", warnings)
+		t.Errorf("warnings = %v, want exactly one mentioning the missing Kea user", warnings)
 	}
 }
 

--- a/pkg/dhcpserver/lease_sync_test.go
+++ b/pkg/dhcpserver/lease_sync_test.go
@@ -621,3 +621,156 @@ func TestKeaLeaseTypeInverseTotality(t *testing.T) {
 		t.Errorf("keaLeaseTypeToString(99) ok=true, want false")
 	}
 }
+
+// ownerCall records one writeMemfileFile invocation so the chown-on-pre-seed
+// tests (#2450) can assert the resolved Kea owner reached the writer with the
+// correct final path — without needing root to perform a real fchown.
+type ownerCall struct {
+	path       string
+	uid, gid   int
+	applyOwner bool
+}
+
+// installMemfileRecorder swaps the package writeMemfileFile var for a recorder
+// that captures the owner decision AND still writes the file (plainly, no
+// chown) so any read-back in the test works. It returns the captured calls
+// slice (append-only) and a restore func.
+func installMemfileRecorder(t *testing.T) (*[]ownerCall, func()) {
+	t.Helper()
+	var calls []ownerCall
+	prev := writeMemfileFile
+	writeMemfileFile = func(path string, data []byte, perm os.FileMode, uid, gid int, applyOwner bool) error {
+		calls = append(calls, ownerCall{path: path, uid: uid, gid: gid, applyOwner: applyOwner})
+		// Write without a chown so the recorder works unprivileged; the
+		// production install path's atomic-owner behavior is exercised by
+		// fsatomic's own WithOwner tests.
+		return os.WriteFile(path, data, perm)
+	}
+	return &calls, func() { writeMemfileFile = prev }
+}
+
+// Test (#2450, HIGH): the memfile pre-seed must chown the file to the resolved
+// Kea runtime user so unprivileged Kea can open it RW on takeover; otherwise
+// Kea fails to start (EACCES) and DHCP goes dark at failover. The fake resolver
+// returns a known uid/gid (no real _kea user needed) and the recorder asserts
+// WithOwner was requested with exactly that uid/gid on the FINAL memfile path,
+// for BOTH families.
+//
+// Fail-on-revert: deleting the chown in writeMemfileAtomic (so it writes
+// without the resolved owner) makes applyOwner=false / uid/gid=0 here, failing
+// the assertions.
+func TestPreSeedMemfile_ChownsToKeaUser(t *testing.T) {
+	const wantUID, wantGID = 14242, 14243
+	localNow := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile4 := filepath.Join(dir, "kea-leases4.csv")
+	memfile6 := filepath.Join(dir, "kea-leases6.csv")
+
+	calls, restore := installMemfileRecorder(t)
+	defer restore()
+
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", "", memfile4, memfile6)
+	m.SetKeaOwnerLookupForTesting(func() (int, int, bool) { return wantUID, wantGID, true })
+
+	if err := m.PreSeedMemfile4([]SyncLease{
+		{Family: 4, Address: "10.0.61.42", HWAddress: "aa:bb:cc:dd:ee:42",
+			SubnetID: 3, Remaining: 900, State: keaStateDefault},
+	}, localNow); err != nil {
+		t.Fatalf("PreSeedMemfile4: %v", err)
+	}
+	if err := m.PreSeedMemfile6([]SyncLease{
+		{Family: 6, Address: "2001:db8::1", DUID: "00:01", IAID: 7,
+			LeaseType: "IA_NA", SubnetID: 1, Remaining: 1200, State: keaStateDefault},
+	}, localNow); err != nil {
+		t.Fatalf("PreSeedMemfile6: %v", err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("writeMemfileFile called %d times, want 2 (v4+v6)", len(*calls))
+	}
+	wantPaths := map[string]bool{memfile4: false, memfile6: false}
+	for _, c := range *calls {
+		if !c.applyOwner {
+			t.Errorf("path %s: applyOwner=false, want chown to Kea user", c.path)
+		}
+		if c.uid != wantUID || c.gid != wantGID {
+			t.Errorf("path %s: owner = %d:%d, want %d:%d", c.path, c.uid, c.gid, wantUID, wantGID)
+		}
+		if _, ok := wantPaths[c.path]; !ok {
+			t.Errorf("unexpected pre-seed path %q", c.path)
+			continue
+		}
+		wantPaths[c.path] = true
+	}
+	for p, seen := range wantPaths {
+		if !seen {
+			t.Errorf("no pre-seed write to %s", p)
+		}
+	}
+}
+
+// Test (#2450 robustness): when NEITHER Kea user resolves (dev host / Kea not
+// installed), the pre-seed must NOT abort the takeover — it logs a warning,
+// writes the file without an owner override, and returns nil. Aborting here
+// would turn a missing-package condition into a failed failover.
+func TestPreSeedMemfile_NoKeaUser_WarnsAndSucceeds(t *testing.T) {
+	localNow := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	memfile4 := filepath.Join(dir, "kea-leases4.csv")
+
+	calls, restore := installMemfileRecorder(t)
+	defer restore()
+
+	var warnings []string
+	m := New()
+	m.SetLeaseSyncSeamsForTesting(nil, "", "", memfile4, "")
+	m.SetWarnForTesting(func(msg string, _ ...any) { warnings = append(warnings, msg) })
+	m.SetKeaOwnerLookupForTesting(func() (int, int, bool) { return 0, 0, false })
+
+	in := []SyncLease{
+		{Family: 4, Address: "10.0.61.7", HWAddress: "aa:bb:cc:dd:ee:07",
+			SubnetID: 3, Remaining: 600, State: keaStateDefault},
+	}
+	if err := m.PreSeedMemfile4(in, localNow); err != nil {
+		t.Fatalf("PreSeedMemfile4 must not abort when Kea user absent: %v", err)
+	}
+
+	// The file was still written (takeover not aborted) and is parseable.
+	got, err := parseActiveLeases4(memfile4, localNow)
+	if err != nil {
+		t.Fatalf("parseActiveLeases4 on pre-seeded file: %v", err)
+	}
+	if len(got) != 1 || got[0].Address != "10.0.61.7" {
+		t.Fatalf("pre-seeded memfile = %+v, want the one lease", got)
+	}
+	// No owner override requested.
+	if len(*calls) != 1 || (*calls)[0].applyOwner {
+		t.Fatalf("writeMemfileFile calls = %+v, want one call with applyOwner=false", *calls)
+	}
+	// A clear warning fired.
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "_kea") {
+		t.Errorf("warnings = %v, want one mentioning the missing Kea user", warnings)
+	}
+}
+
+// Test (#2450): the Kea owner resolution is cached behind sync.Once — the
+// takeover path may pre-seed both families (and re-seed on retry) without
+// re-reading the user database each time.
+func TestResolveKeaOwner_CachedOnce(t *testing.T) {
+	m := New()
+	var lookups int
+	m.SetKeaOwnerLookupForTesting(func() (int, int, bool) {
+		lookups++
+		return 991, 992, true
+	})
+	for i := 0; i < 3; i++ {
+		uid, gid, ok := m.resolveKeaOwner()
+		if !ok || uid != 991 || gid != 992 {
+			t.Fatalf("resolveKeaOwner() = %d:%d ok=%v, want 991:992 true", uid, gid, ok)
+		}
+	}
+	if lookups != 1 {
+		t.Errorf("user lookup ran %d times, want 1 (cached)", lookups)
+	}
+}

--- a/pkg/dhcpserver/test_seams.go
+++ b/pkg/dhcpserver/test_seams.go
@@ -59,6 +59,15 @@ func (m *Manager) SetWarnForTesting(fn func(msg string, args ...any)) {
 	m.warn = fn
 }
 
+// SetKeaOwnerLookupForTesting injects the Kea runtime-user resolver used by
+// the memfile pre-seed chown (#2450). A test passes a fake that returns a
+// known uid/gid (so the pre-seed chowns to it without a real _kea user) or
+// ok=false (to exercise the absent-user best-effort fallback). Must be called
+// before the first pre-seed (the resolution is cached behind a sync.Once).
+func (m *Manager) SetKeaOwnerLookupForTesting(fn func() (uid, gid int, ok bool)) {
+	m.keaOwnerLookup = fn
+}
+
 // NewDDNSManagerForTesting builds a DDNSManager with injectable state +
 // lease paths, clock, and a per-Reconcile updater factory (#1387 inc-2).
 // It is used by OTHER packages' tests (e.g. pkg/daemon) to drive the


### PR DESCRIPTION
Closes #2450

## Problem (HIGH — agy review-033 finding 2, HA failover DHCP outage)

On HA takeover the promoting node pre-seeds the Kea lease memfiles
(`/var/lib/kea/kea-leases{4,6}.csv`) so Kea loads the in-use bindings at
boot and cannot hand out a duplicate address in the pre-`lease-add`
window. xpfd runs as **root** and wrote those files via
`fsatomic.WriteFileDurable(path, ..., 0640)` with **no ownership override**.

Distro Kea does **not** run as root — Debian/Ubuntu (the appliance base)
package `kea-dhcp4`/`kea-dhcp6` to run as the unprivileged `_kea` user
(RHEL-family uses `kea`), and Kea opens its memfile lease DB for
**READ+WRITE** at startup. A root-owned `0640` file is unreadable/
unwritable by that user, so **Kea fails to start (EACCES) on the node that
just took over → DHCP outage at failover**.

## Fix

- **chown to the Kea user.** Resolve the runtime user once (`_kea`, then
  `kea`, via `os/user`, cached behind `sync.Once`) and install the
  pre-seed already owned by it. Mode stays `0640` (owner `_kea` can RW).
- **post-rename ordering is correct.** The chown rides on the `fsatomic`
  temp fd — `fsatomic.WithOwner` fchowns **before** the rename — so the
  **final renamed inode** at the memfile path is `_kea`-owned atomically.
  No post-rename window where the visible file is root-owned, and no
  orphaned root-owned temp survives the rename.
- **both families covered.** v4 and v6 memfiles both go through the same
  install path.
- **absent-user fallback (no takeover abort).** When neither `_kea` nor
  `kea` exists (dev host / Kea not installed), the chown is best-effort:
  log one warning, write without an owner override, return nil. The
  takeover is never aborted — turning a missing-package condition into a
  failed failover would be strictly worse. The daemon is root, so when
  the user **does** exist the chown cannot fail for lack of privilege.

## Tests (fail-on-revert)

`writeMemfile{4,6}`/`writeMemfileAtomic` become `Manager` methods; the
user resolver (`keaOwnerLookup`) and the file install (`writeMemfileFile`
package var) are seam-injectable so the tests run **unprivileged**.

- `TestPreSeedMemfile_ChownsToKeaUser` — both families installed with
  `WithOwner` = the resolved uid/gid on the **final** memfile path.
- `TestPreSeedMemfile_NoKeaUser_WarnsAndSucceeds` — absent-user path
  warns, writes a parseable file, returns nil (takeover not aborted), no
  owner override requested.
- `TestResolveKeaOwner_CachedOnce` — `sync.Once` cache (one lookup across
  repeated pre-seeds).

Fail-on-revert verified: dropping the owner wiring (`applyOwner=false`)
makes the chown assertions fail.

## Validation

- `go build ./...` — clean
- `go vet ./pkg/dhcpserver/` — clean
- `gofmt -l` on touched files — clean
- `go test ./pkg/dhcpserver/` — green

Note: the pre-existing `pkg/fsatomic` canary failure
(`dataplane/proxyarp.go` direct `os.WriteFile`) is unrelated to this
change — it is present on clean `origin/master`.

## Docs

`pkg/dhcpserver/README.md` documents the ownership contract (atomic chown
via the temp fd, both families, best-effort absent-user fallback); `_Log.md`
records the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
