### PR TITLE
#2505: fail closed on unresolvable firewall-filter protocol (fix fail-wide)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12407,3 +12407,40 @@ top.
   -count=5 green.
 - **File(s)**: pkg/dhcpserver/lease_sync.go, pkg/dhcpserver/lease_sync_test.go,
   pkg/dhcpserver/README.md, _Log.md
+
+- **Timestamp**: 2026-06-23
+- **Action**: #2505 (HIGH, codex review-036 finding 1) — fix fail-wide
+  firewall-filter protocol parser. The Rust filter compiler carried a stale
+  local `parse_protocol` recognizing only tcp/udp/icmp/icmpv6/gre/ospf/ipip +
+  bare numeric (no trim/lowercase) and `filter_map`-DROPPED everything else.
+  Named protocols the Go commit gate accepts (esp/ah/sctp/vrrp/igmp/pim/egp +
+  junos-* aliases) and mixed-case/whitespace tokens were silently dropped → the
+  term's protocol list went empty → `protocol_match_enabled=false` → the term
+  matched ALL protocols. `from protocol esp; then discard` discarded all
+  traffic (fail-wide). FIX: (1) deleted the local parser; resolve every token
+  via the shared, normalizing `ip_proto::proto_number`; (2) added the junos-*
+  aliases the Go gate accepts to `proto_number` (gate↔dataplane parity — filter
+  tokens reach the snapshot verbatim, no Go-side alias resolution); (3) made
+  `parse_filter_state*`/`parse_term` fallible — a NON-EMPTY list with any
+  unresolvable token returns `SnapshotIntegrityError::UnrepresentableFilterProtocol`,
+  propagated via `?` through `build_forwarding_state_*` to the reconcile
+  preflight (`build_reconcile_forwarding`) which aborts BEFORE teardown/publish
+  (post-#2484), keeping the prior good filter state. An EMPTY input list stays
+  "no constraint" (match-any). Tests: 6 Rust filter tests (named protocols
+  scoped, GRE/whitespace normalization, junos aliases, unresolvable→Err,
+  empty→unconstrained, esp-discard Go→Rust fixture) + extended proto_number
+  resolver test for the full gate set. Fail-on-revert PROVEN: simulating the
+  stale parser flips all protocol_2505 tests to FAILED (term becomes match-all).
+  Build release clean; filter+ip_proto+policy tests 150/150 5x; full suite green
+  (one pre-existing flaky worker_queue concurrency test, untouched code, passes
+  3/3 isolated); Go appid/config parity tests green.
+- **File(s)**: userspace-dp/src/ip_proto.rs, userspace-dp/src/policy.rs,
+  userspace-dp/src/filter/compiler.rs, userspace-dp/src/filter/mod.rs,
+  userspace-dp/src/afxdp/forwarding_build/mod.rs, userspace-dp/src/filter/README.md,
+  userspace-dp/src/filter/tests.rs, userspace-dp/src/nat/tests.rs,
+  userspace-dp/src/filter/engine/cache_sensitive.rs,
+  userspace-dp/src/afxdp/flow_cache_tests.rs,
+  userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs,
+  userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs,
+  userspace-dp/src/afxdp/frame/tests.rs, userspace-dp/src/afxdp/tests.rs, _Log.md

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -671,7 +671,7 @@ fn from_forward_decision_skips_cache_for_dscp_matched_output_filter() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     let entry = FlowCacheEntry::from_forward_decision(
         &flow,
@@ -723,7 +723,7 @@ fn from_forward_decision_skips_cache_for_dscp_matched_input_filter() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     let entry = FlowCacheEntry::from_forward_decision(
         &flow,
@@ -775,7 +775,7 @@ fn from_forward_decision_skips_cache_for_per_packet_l4_input_filter() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     let entry = FlowCacheEntry::from_forward_decision(
         &flow,
@@ -823,7 +823,7 @@ fn from_forward_decision_skips_cache_for_per_packet_l4_output_filter() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     let entry = FlowCacheEntry::from_forward_decision(
         &flow,
@@ -915,7 +915,7 @@ fn dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     // Step 4: drive FlowCacheEntry::from_forward_decision and
     // confirm the gate at flow_cache.rs:297-309 declined
@@ -977,7 +977,7 @@ fn dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     // Step 4: same gate, different lookup —
     // interface_output_filter_has_dscp_match consults

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -260,7 +260,11 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         let (slot_map, _slots_to_zero) = ColdPathSlotMap::build(prev_map, &pairs);
         state.cold_path_slot_map = std::sync::Arc::new(slot_map);
     }
-    // Build filter state from snapshot
+    // Build filter state from snapshot. #2505: this is fallible — an
+    // unresolvable `from protocol` token raises a SnapshotIntegrityError that
+    // propagates here, aborting the reconcile preflight (before teardown /
+    // publish) so the prior good filter state stays live rather than
+    // installing a fail-wide match-all term.
     state.filter_state = crate::filter::parse_filter_state_with_three_color_preserving(
         &snapshot.filters,
         &snapshot.policers,
@@ -269,7 +273,7 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         &snapshot.flow.lo0_filter_input_v4,
         &snapshot.flow.lo0_filter_input_v6,
         previous.map(|state| &state.filter_state),
-    );
+    )?;
     state.cos = build_cos_state(snapshot);
     let has_cos_interfaces = !state.cos.interfaces.is_empty();
     state.tx_selection_enabled_v4 = has_cos_interfaces

--- a/userspace-dp/src/afxdp/frame/tests.rs
+++ b/userspace-dp/src/afxdp/frame/tests.rs
@@ -2449,7 +2449,7 @@ fn build_live_forward_request_meters_non_l4_metadata_flow() {
         }],
         "policed",
         "",
-    );
+    ).expect("filter state compiles");
     let mut forwarding = ForwardingState {
         filter_state,
         tx_selection_enabled_v4: true,
@@ -2578,7 +2578,7 @@ fn build_live_forward_request_marks_empty_cos_selection_resolved() {
         }],
         "policed",
         "",
-    );
+    ).expect("filter state compiles");
     let forwarding = ForwardingState {
         filter_state,
         tx_selection_enabled_v4: true,
@@ -2679,7 +2679,7 @@ fn build_live_forward_request_emits_output_filter_log_event() {
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
     let mut forwarding = ForwardingState {
         filter_state,
         tx_selection_enabled_v4: true,

--- a/userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs
@@ -274,7 +274,7 @@ mod tests {
             }],
             "",
             "",
-        );
+        ).expect("filter state compiles");
         let forwarding = ForwardingState {
             filter_state,
             tx_selection_enabled_v4: true,

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -290,7 +290,7 @@ mod tests {
             }],
             "",
             "",
-        );
+        ).expect("filter state compiles");
         let mut forwarding = ForwardingState {
             filter_state,
             tx_selection_enabled_v4: true,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -1526,7 +1526,7 @@ fn build_output_filter_state(
         }],
         "",
         "",
-    )
+    ).expect("filter state compiles")
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/dispatch_tests.rs
@@ -1244,7 +1244,7 @@ fn forwarding_for_ptb_with_output_term(
         }],
         "",
         "",
-    );
+    ).expect("filter state compiles");
     forwarding.tx_selection_enabled_v4 = true;
     forwarding
 }

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -18,6 +18,28 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   matcher, DSCP bitmap). Three-color policer snapshots are sorted by
   name for deterministic iteration and compiled into name-derived
   stable runtime IDs before terms are linked.
+  - **Protocol resolution (#2505)** uses the SHARED, normalizing
+    resolver `crate::ip_proto::proto_number` (trim + lowercase + the
+    full `appid.ProtocolNumber` acceptance set — tcp/udp/icmp/icmpv6/
+    gre/ospf/ipip/esp/ah/sctp/vrrp/igmp/pim/egp + the specific
+    `junos-*` aliases + bare numeric). It does NOT carry a local
+    protocol table. A `from protocol` token reaches the snapshot
+    VERBATIM (Go's `compileFilterFrom` does no alias resolution), so
+    the resolver must accept exactly what the Go filter commit gate
+    (`filterProtocolResolvable`) accepts or a gate-passing filter would
+    lose its protocol constraint in the dataplane.
+  - **Fail closed, not fail wide (#2505):** an EMPTY protocol list
+    means "no constraint" (`protocol_match_enabled = false`, match-any,
+    preserved). A NON-EMPTY list with any UNRESOLVABLE token raises
+    `SnapshotIntegrityError::UnrepresentableFilterProtocol`, which
+    propagates up through `build_forwarding_state_*` to the reconcile
+    preflight (`build_reconcile_forwarding`) and aborts the reconcile
+    BEFORE teardown/publish (post-#2484), keeping the prior good filter
+    state live. Silently dropping the token (the pre-fix `filter_map`)
+    collapsed the list to empty and disabled the match, so a `from
+    protocol esp; then discard` term matched EVERY protocol — a
+    fail-wide security bug. The Go gate is the primary defense; this is
+    the helper-boundary backstop against version/snapshot drift.
 - `engine.rs` — per-term evaluation, first-match-wins. It carries the
   matched `then policer ...` name in the filter result. Routing-instance
   evaluation can also return log/action/filter/term metadata so AF_XDP

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -103,6 +103,7 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 parse_term(
                     t,
                     term_idx as u32,
+                    &snap.family,
                     &snap.name,
                     &state.three_color_policer_by_name,
                 )
@@ -357,6 +358,7 @@ fn qualify_filter_key(family: &str, filter_name: &str) -> String {
 fn parse_term(
     snap: &FirewallTermSnapshot,
     id: u32,
+    filter_family: &str,
     filter_name: &str,
     three_color_policers: &rustc_hash::FxHashMap<String, Arc<ThreeColorPolicerRuntime>>,
 ) -> Result<FilterTerm, SnapshotIntegrityError> {
@@ -406,6 +408,7 @@ fn parse_term(
             Some(n) => protocols.push(n),
             None => {
                 return Err(SnapshotIntegrityError::UnrepresentableFilterProtocol {
+                    family: filter_family.to_string(),
                     filter: filter_name.to_string(),
                     term: snap.name.clone(),
                     token: token.clone(),

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -5,13 +5,19 @@
 use super::*;
 
 /// Build the complete FilterState from snapshot data.
+///
+/// #2505: returns `Err(SnapshotIntegrityError)` when a filter term carries a
+/// NON-EMPTY `from protocol` list with a token `ip_proto::proto_number` cannot
+/// resolve. Silently dropping it (the pre-fix `filter_map`) was a fail-WIDE
+/// security bug — an all-dropped list disabled the protocol match so the term
+/// matched every protocol.
 pub(crate) fn parse_filter_state(
     filters: &[FirewallFilterSnapshot],
     policers: &[PolicerSnapshot],
     interfaces: &[crate::InterfaceSnapshot],
     lo0_filter_v4: &str,
     lo0_filter_v6: &str,
-) -> FilterState {
+) -> Result<FilterState, SnapshotIntegrityError> {
     parse_filter_state_with_three_color(
         filters,
         policers,
@@ -31,7 +37,7 @@ pub(crate) fn parse_filter_state_with_three_color(
     interfaces: &[crate::InterfaceSnapshot],
     lo0_filter_v4: &str,
     lo0_filter_v6: &str,
-) -> FilterState {
+) -> Result<FilterState, SnapshotIntegrityError> {
     parse_filter_state_with_three_color_preserving(
         filters,
         policers,
@@ -53,7 +59,7 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
     lo0_filter_v4: &str,
     lo0_filter_v6: &str,
     previous: Option<&FilterState>,
-) -> FilterState {
+) -> Result<FilterState, SnapshotIntegrityError> {
     let mut state = FilterState::default();
 
     // Parse legacy token-bucket policers.
@@ -93,8 +99,15 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
             .terms
             .iter()
             .enumerate()
-            .map(|(term_idx, t)| parse_term(t, term_idx as u32, &state.three_color_policer_by_name))
-            .collect::<Vec<_>>();
+            .map(|(term_idx, t)| {
+                parse_term(
+                    t,
+                    term_idx as u32,
+                    &snap.name,
+                    &state.three_color_policer_by_name,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         let filter = Filter {
             id: filter_idx as u32,
             name: snap.name.clone(),
@@ -242,7 +255,7 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
     };
     state.lo0_filter_v6_fast = state.filters.get(&state.lo0_filter_v6).cloned();
 
-    state
+    Ok(state)
 }
 
 fn parse_three_color_policer(
@@ -344,8 +357,9 @@ fn qualify_filter_key(family: &str, filter_name: &str) -> String {
 fn parse_term(
     snap: &FirewallTermSnapshot,
     id: u32,
+    filter_name: &str,
     three_color_policers: &rustc_hash::FxHashMap<String, Arc<ThreeColorPolicerRuntime>>,
-) -> FilterTerm {
+) -> Result<FilterTerm, SnapshotIntegrityError> {
     let mut source_v4 = Vec::new();
     let mut source_v6 = Vec::new();
     for addr in &snap.source_addresses {
@@ -366,11 +380,39 @@ fn parse_term(
     // engine/matching.rs).
     let source_addr_constrained = snap.source_addresses.iter().any(|a| addr_is_real(a));
     let dest_addr_constrained = snap.destination_addresses.iter().any(|a| addr_is_real(a));
-    let protocols: Vec<u8> = snap
-        .protocols
-        .iter()
-        .filter_map(|p| parse_protocol(p))
-        .collect();
+    // #2505: resolve every `from protocol` token via the SHARED, normalizing
+    // resolver `ip_proto::proto_number` (trim + lowercase + the full
+    // appid.ProtocolNumber acceptance set: esp/ah/sctp/vrrp/igmp/pim/egp +
+    // the junos-* aliases), NOT the stale local parser this function used to
+    // carry (tcp/udp/icmp/icmpv6/gre/ospf/ipip + bare numeric, no
+    // normalization). An EMPTY input list is the legitimate "no protocol
+    // constraint" case -> empty `protocols` -> `protocol_match_enabled` false
+    // (match-any, preserved below). A NON-EMPTY list with any UNRESOLVABLE
+    // token is a snapshot-integrity error: silently dropping it (the pre-fix
+    // `filter_map`) collapses the list to empty and disables the protocol
+    // match, so a `from protocol esp; then discard` term would match EVERY
+    // protocol (fail-WIDE). Fail closed by rejecting the whole snapshot — the
+    // reconcile preflight keeps the previous good filter state.
+    let mut protocols: Vec<u8> = Vec::with_capacity(snap.protocols.len());
+    for token in &snap.protocols {
+        // An empty / whitespace-only entry is a placeholder, never a real
+        // constraint (the Go side only emits `protocols` when `term.Protocol
+        // != ""`); treat it as "no protocol" rather than an integrity error,
+        // mirroring the pre-fix `parse_protocol("")` -> None drop.
+        if token.trim().is_empty() {
+            continue;
+        }
+        match proto_number(token) {
+            Some(n) => protocols.push(n),
+            None => {
+                return Err(SnapshotIntegrityError::UnrepresentableFilterProtocol {
+                    filter: filter_name.to_string(),
+                    term: snap.name.clone(),
+                    token: token.clone(),
+                });
+            }
+        }
+    }
     let source_ports: Vec<PortRange> = snap
         .source_ports
         .iter()
@@ -417,7 +459,7 @@ fn parse_term(
     };
     let dscp_rewrite = snap.dscp_rewrite.map(|value| value & 0x3f);
 
-    FilterTerm {
+    Ok(FilterTerm {
         id,
         name: snap.name.clone(),
         source_v4,
@@ -452,7 +494,7 @@ fn parse_term(
         forwarding_class: Arc::<str>::from(snap.forwarding_class.as_str()),
         dscp_rewrite,
         counter: Arc::new(FilterTermCounter::default()),
-    }
+    })
 }
 
 /// #2400: whether an address entry imposes a real scope. `parse_address` drops
@@ -491,20 +533,6 @@ fn parse_address(prefix: &str, out_v4: &mut Vec<PrefixV4>, out_v6: &mut Vec<Pref
                 ));
             }
         }
-    }
-}
-
-fn parse_protocol(protocol: &str) -> Option<u8> {
-    match protocol {
-        "" => None,
-        "tcp" => Some(PROTO_TCP),
-        "udp" => Some(PROTO_UDP),
-        "icmp" => Some(PROTO_ICMP),
-        "icmpv6" => Some(PROTO_ICMPV6),
-        "gre" => Some(PROTO_GRE),
-        "89" | "ospf" => Some(PROTO_OSPF),
-        "4" | "ipip" => Some(PROTO_IPIP),
-        _ => protocol.parse::<u8>().ok(),
     }
 }
 

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -324,7 +324,8 @@ mod cache_sensitive_2400_tests {
             &[],
             "",
             "",
-        );
+        )
+        .expect("filter state compiles");
         state
             .filters
             .get("inet:f")

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -24,11 +24,16 @@ use std::sync::{Arc, Mutex};
 
 use crate::ip_proto::proto_number;
 use crate::policy::SnapshotIntegrityError;
-// #2505: the production code resolves all protocol tokens through
-// `proto_number`; the bare `PROTO_*` consts are now only referenced by the
-// filter unit tests (asserting a term resolved to the right IANA number), so
-// re-export them under `super::*` for tests only — exposing them
-// unconditionally would warn as unused in the non-test build.
+// #2505: filter compilation resolves all protocol tokens through
+// `proto_number`, so this module's *compiler* no longer needs the bare
+// `PROTO_*` consts. Production code that DOES reference them imports them
+// directly where used — e.g. `engine/matching.rs` imports `PROTO_TCP`,
+// `PROTO_ICMP`, `PROTO_ICMPV6` from `crate::ip_proto` for per-packet match
+// classification. The `#[cfg(test)]` import below re-exports the consts via
+// `super::*` ONLY for the filter unit tests in this module (asserting a term
+// resolved to the right IANA number); a module-level non-test re-export would
+// warn as unused because nothing under `mod.rs`/`compiler.rs` references them
+// outside tests anymore.
 #[cfg(test)]
 use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP, PROTO_UDP};
 

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -22,9 +22,15 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::ip_proto::{
-    PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6, PROTO_IPIP, PROTO_OSPF, PROTO_TCP, PROTO_UDP,
-};
+use crate::ip_proto::proto_number;
+use crate::policy::SnapshotIntegrityError;
+// #2505: the production code resolves all protocol tokens through
+// `proto_number`; the bare `PROTO_*` consts are now only referenced by the
+// filter unit tests (asserting a term resolved to the right IANA number), so
+// re-export them under `super::*` for tests only — exposing them
+// unconditionally would warn as unused in the non-test build.
+#[cfg(test)]
+use crate::ip_proto::{PROTO_ICMP, PROTO_ICMPV6, PROTO_TCP, PROTO_UDP};
 
 /// Result of evaluating a filter term.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -9,7 +9,7 @@ fn make_filter_state(
     filters: &[FirewallFilterSnapshot],
     policers: &[PolicerSnapshot],
 ) -> FilterState {
-    parse_filter_state(filters, policers, &[], "", "")
+    parse_filter_state(filters, policers, &[], "", "").expect("filter state compiles")
 }
 
 fn make_filter_state_with_three_color(
@@ -17,13 +17,14 @@ fn make_filter_state_with_three_color(
     three_color_policers: &[ThreeColorPolicerSnapshot],
 ) -> FilterState {
     parse_filter_state_with_three_color(filters, &[], three_color_policers, &[], "", "")
+        .expect("filter state compiles")
 }
 
 fn make_filter_state_with_interfaces(
     filters: &[FirewallFilterSnapshot],
     interfaces: &[crate::InterfaceSnapshot],
 ) -> FilterState {
-    parse_filter_state(filters, &[], interfaces, "", "")
+    parse_filter_state(filters, &[], interfaces, "", "").expect("filter state compiles")
 }
 
 #[test]
@@ -608,7 +609,7 @@ fn equivalent_snapshot_refresh_preserves_three_color_state_and_counters() {
         "",
         "",
         Some(&state),
-    );
+    ).expect("filter state compiles");
     assert!(
         std::sync::Arc::ptr_eq(
             &state.three_color_policers[0],
@@ -694,7 +695,7 @@ fn three_color_adding_lower_sorted_policer_does_not_reset_existing_runtime() {
         "",
         "",
         Some(&state),
-    );
+    ).expect("filter state compiles");
     let previous_runtime = state
         .three_color_policer_by_name
         .get("stable-pol")
@@ -763,7 +764,7 @@ fn three_color_compatible_refresh_observes_old_runtime_mutations_after_rebuild()
         "",
         "",
         Some(&state),
-    );
+    ).expect("filter state compiles");
     assert!(std::sync::Arc::ptr_eq(
         &state.three_color_policers[0],
         &refreshed.three_color_policers[0]
@@ -859,7 +860,7 @@ fn changed_snapshot_shape_resets_three_color_runtime_state() {
         "",
         "",
         Some(&state),
-    );
+    ).expect("filter state compiles");
     let refreshed_filter = refreshed.filters.get("inet:policed").unwrap();
     let second = evaluate_filter_ref_tx_selection_runtime_counted(
         refreshed_filter,
@@ -1404,7 +1405,7 @@ fn interface_filter_assignment() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
     // v4 filter on ifindex 5
     let result = evaluate_interface_filter(
         &state,
@@ -1491,7 +1492,7 @@ fn parse_filter_state_prequalifies_interface_and_lo0_filter_keys() {
         &ifaces,
         "protect-re",
         "protect-re-v6",
-    );
+    ).expect("filter state compiles");
     assert_eq!(
         state.iface_filter_v4.get(&7).map(String::as_str),
         Some("inet:ingress-v4")
@@ -1535,7 +1536,7 @@ fn accept_only_output_filter_does_not_need_tx_eval() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     assert!(!interface_output_filter_needs_tx_eval(&state, 7, false));
     assert!(!filter_state_has_output_tx_selection(&state, false));
@@ -1574,7 +1575,7 @@ fn interface_filter_routing_instance_counted_returns_matching_override() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     assert!(interface_filter_affects_route_lookup(&state, 11, true));
     let routing_instance = evaluate_interface_filter_routing_instance_counted(
@@ -1622,7 +1623,7 @@ fn interface_output_filter_counted_records_term_hits() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
     let result = evaluate_interface_output_filter_counted(
         &state,
         7,
@@ -1671,7 +1672,7 @@ fn interface_output_filter_without_count_does_not_record_term_hits() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
     let result = evaluate_interface_output_filter_counted(
         &state,
         7,
@@ -1720,7 +1721,7 @@ fn lo0_filter_evaluation() {
         &[],
         "protect-RE",
         "",
-    );
+    ).expect("filter state compiles");
     // SSH should pass lo0 filter
     let result = evaluate_lo0_filter(
         &state,
@@ -1961,7 +1962,7 @@ fn input_dscp_filter_families_changed_detects_three_color_shape_change() {
         std::slice::from_ref(&iface),
         "",
         "",
-    );
+    ).expect("filter state compiles");
     let new = parse_filter_state_with_three_color_preserving(
         &filters,
         &[],
@@ -1970,7 +1971,7 @@ fn input_dscp_filter_families_changed_detects_three_color_shape_change() {
         "",
         "",
         Some(&old),
-    );
+    ).expect("filter state compiles");
 
     assert!(
         !std::sync::Arc::ptr_eq(
@@ -2288,7 +2289,7 @@ fn evaluate_lo0_filter_ipv6_path() {
         &[],
         "",
         "protect-RE-v6",
-    );
+    ).expect("filter state compiles");
     let accepted = evaluate_lo0_filter(
         &state,
         true,
@@ -2339,7 +2340,7 @@ fn evaluate_interface_filter_ipv6_input_path() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
     let result = evaluate_interface_filter(
         &state,
         9,
@@ -2482,7 +2483,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     // A packet that matches the routing-instance term must short-circuit to
     // the default (route-lookup wins) and must NOT increment that term's
@@ -2566,7 +2567,7 @@ fn interface_filter_tx_selection_wrappers_dispatch_and_default() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     let input = evaluate_interface_filter_tx_selection_counted(
         &state,
@@ -2685,7 +2686,7 @@ fn thin_accessor_predicates() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
 
     // TX-selection accessor reads the TX-selection set, NOT the DSCP set:
     // true on the TX-only ifindex, false on the DSCP-only ifindex.
@@ -2735,7 +2736,7 @@ fn cached_and_runtime_tx_selection_agree_on_plain_term() {
         &ifaces,
         "",
         "",
-    );
+    ).expect("filter state compiles");
     let filter = state.iface_filter_v4_fast.get(&30).expect("input filter");
     let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
     let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
@@ -3229,7 +3230,7 @@ fn per_packet_match_marks_filter_cache_sensitive() {
         filter_input_v4: "pp".into(),
         ..Default::default()
     }];
-    let state = parse_filter_state(&filters, &[], &interfaces, "", "");
+    let state = parse_filter_state(&filters, &[], &interfaces, "", "").expect("filter state compiles");
     assert!(
         state.iface_filter_v4_has_per_packet_l4_match.contains(&7),
         "interface input filter with a tcp-flags term must be marked per-packet-L4 cache-sensitive"
@@ -3986,5 +3987,225 @@ fn term_2400_partial_malformed_address_keeps_valid_scope() {
         in_valid.action,
         FilterAction::Discard,
         "the surviving valid prefix must still match (partial-malformed != all-malformed)"
+    );
+}
+
+// =====================================================================
+// #2505: firewall-filter protocol resolution uses the SHARED, normalizing
+// resolver (ip_proto::proto_number) and fails CLOSED on an unresolvable
+// token in a non-empty list. The pre-fix local parse_protocol recognized
+// only tcp/udp/icmp/icmpv6/gre/ospf/ipip + bare numeric and silently
+// dropped everything else; an all-dropped list disabled the protocol match
+// so a `from protocol esp; then discard` term matched EVERY protocol
+// (fail-WIDE).
+// =====================================================================
+
+// Build a single-term `discard` filter scoped to one `from protocol` token,
+// returning the compiled FilterState result (Ok or the integrity Err).
+fn filter_for_protocol(token: &str) -> Result<FilterState, SnapshotIntegrityError> {
+    parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "f".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "scoped".into(),
+                protocols: vec![token.into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[],
+        "",
+        "",
+    )
+}
+
+// Assert a token resolves to a protocol-SCOPED term: the term discards ITS
+// protocol and ACCEPTS (no match) a different one — proving the protocol
+// match is enabled and not a fail-wide match-all.
+fn assert_scoped_to(token: &str, want_proto: u8) {
+    let state = filter_for_protocol(token)
+        .unwrap_or_else(|e| panic!("token {token:?} should resolve, got {e}"));
+    let term = state
+        .filters
+        .get("inet:f")
+        .expect("filter compiled")
+        .terms
+        .first()
+        .expect("one term");
+    assert!(
+        term.protocol_match_enabled,
+        "token {token:?} must enable the protocol match (else the term is fail-wide match-all)"
+    );
+
+    // The scoped protocol is discarded.
+    let hit = evaluate_filter(
+        &state,
+        "inet:f",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        want_proto,
+        0,
+        0,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        hit.action,
+        FilterAction::Discard,
+        "token {token:?} (proto {want_proto}) must be discarded by its own term"
+    );
+
+    // A DIFFERENT protocol must NOT match (proves it is not match-all).
+    let other = if want_proto == PROTO_TCP {
+        PROTO_UDP
+    } else {
+        PROTO_TCP
+    };
+    let miss = evaluate_filter(
+        &state,
+        "inet:f",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        other,
+        0,
+        0,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        miss.action,
+        FilterAction::Accept,
+        "token {token:?} term must NOT match a different protocol ({other}) — that would be fail-wide"
+    );
+}
+
+#[test]
+fn protocol_2505_named_protocols_resolve_scoped() {
+    // The protocols the Go commit gate accepts but the stale local parser
+    // dropped. Each must resolve to its IANA number AND produce a scoped term.
+    assert_scoped_to("esp", 50);
+    assert_scoped_to("ah", 51);
+    assert_scoped_to("sctp", 132);
+    assert_scoped_to("vrrp", 112);
+    assert_scoped_to("igmp", 2);
+    assert_scoped_to("pim", 103);
+    assert_scoped_to("egp", 8);
+}
+
+#[test]
+fn protocol_2505_normalization_uppercase_and_whitespace() {
+    // The stale local parser did not trim/lowercase. The shared resolver does,
+    // matching the Go gate's strings.TrimSpace + ToLower.
+    assert_scoped_to("GRE", 47);
+    assert_scoped_to(" icmp ", PROTO_ICMP);
+    assert_scoped_to("Esp", 50);
+}
+
+#[test]
+fn protocol_2505_junos_aliases_resolve() {
+    // Gate<->dataplane parity: filterProtocolResolvable accepts these junos-*
+    // aliases and they reach the snapshot VERBATIM (compileFilterFrom does no
+    // alias resolution), so proto_number must resolve them too.
+    assert_scoped_to("junos-tcp-any", PROTO_TCP);
+    assert_scoped_to("junos-udp-any", PROTO_UDP);
+    assert_scoped_to("junos-ping", PROTO_ICMP);
+    assert_scoped_to("junos-gre", 47);
+    assert_scoped_to("junos-ospf", 89);
+    assert_scoped_to("junos-ip-in-ip", 4);
+}
+
+#[test]
+fn protocol_2505_unresolvable_fails_closed_not_match_all() {
+    // A non-empty list with an unresolvable token must reject the whole
+    // snapshot (fail closed), NOT silently drop it into an empty match-all
+    // term.
+    let err = filter_for_protocol("bogusproto")
+        .expect_err("an unresolvable protocol token must fail the build closed");
+    match err {
+        SnapshotIntegrityError::UnrepresentableFilterProtocol {
+            filter,
+            term,
+            token,
+        } => {
+            assert_eq!(filter, "f");
+            assert_eq!(term, "scoped");
+            assert_eq!(token, "bogusproto");
+        }
+        other => panic!("expected UnrepresentableFilterProtocol, got {other:?}"),
+    }
+}
+
+#[test]
+fn protocol_2505_empty_list_is_unconstrained() {
+    // An EMPTY input protocol list legitimately means "no protocol
+    // constraint" — protocol_match_enabled=false, NOT an error.
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "f".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "any-proto".into(),
+                protocols: vec![],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[],
+        "",
+        "",
+    )
+    .expect("empty protocol list is not an error");
+    let term = state
+        .filters
+        .get("inet:f")
+        .expect("filter compiled")
+        .terms
+        .first()
+        .expect("one term");
+    assert!(
+        !term.protocol_match_enabled,
+        "an empty protocol list must leave the protocol match disabled (match-any constraint)"
+    );
+}
+
+// Go->Rust fixture: the exact #2505 reproduction — `from protocol esp; then
+// discard` must discard ONLY ESP, not all protocols. This is the fail-on-
+// revert canary: restoring the stale local parse_protocol (which drops esp)
+// turns the term into a match-all and BOTH of these asserts flip.
+#[test]
+fn protocol_2505_esp_discard_fixture_scopes_only_esp() {
+    let state = filter_for_protocol("esp").expect("esp resolves");
+    // ESP (proto 50) is discarded.
+    let esp = evaluate_filter(
+        &state,
+        "inet:f",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        50,
+        0,
+        0,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(esp.action, FilterAction::Discard, "ESP must be discarded");
+    // TCP is NOT discarded — the bug made this Discard (match-all).
+    let tcp = evaluate_filter(
+        &state,
+        "inet:f",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        12345,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        tcp.action,
+        FilterAction::Accept,
+        "TCP must NOT be discarded by a `from protocol esp` term — fail-wide regression (#2505)"
     );
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -4125,11 +4125,65 @@ fn protocol_2505_unresolvable_fails_closed_not_match_all() {
         .expect_err("an unresolvable protocol token must fail the build closed");
     match err {
         SnapshotIntegrityError::UnrepresentableFilterProtocol {
+            family,
             filter,
             term,
             token,
         } => {
+            assert_eq!(family, "inet");
             assert_eq!(filter, "f");
+            assert_eq!(term, "scoped");
+            assert_eq!(token, "bogusproto");
+        }
+        other => panic!("expected UnrepresentableFilterProtocol, got {other:?}"),
+    }
+}
+
+#[test]
+fn protocol_2505_error_names_the_family_for_reused_filter_names() {
+    // Filter names can be reused across families. When the inet6 copy carries
+    // the unresolvable token, the diagnostic must name family inet6 (not just
+    // the ambiguous filter name) so the operator can find the offending filter.
+    let bad_term = || FirewallTermSnapshot {
+        name: "scoped".into(),
+        protocols: vec!["bogusproto".into()],
+        action: "discard".into(),
+        ..Default::default()
+    };
+    let good_term = || FirewallTermSnapshot {
+        name: "ok".into(),
+        protocols: vec!["tcp".into()],
+        action: "discard".into(),
+        ..Default::default()
+    };
+    let err = parse_filter_state(
+        &[
+            FirewallFilterSnapshot {
+                name: "dup".into(),
+                family: "inet".into(),
+                terms: vec![good_term()],
+            },
+            FirewallFilterSnapshot {
+                name: "dup".into(),
+                family: "inet6".into(),
+                terms: vec![bad_term()],
+            },
+        ],
+        &[],
+        &[],
+        "",
+        "",
+    )
+    .expect_err("the inet6 filter's unresolvable token must fail the build closed");
+    match err {
+        SnapshotIntegrityError::UnrepresentableFilterProtocol {
+            family,
+            filter,
+            term,
+            token,
+        } => {
+            assert_eq!(family, "inet6", "the error must name the inet6 family");
+            assert_eq!(filter, "dup");
             assert_eq!(term, "scoped");
             assert_eq!(token, "bogusproto");
         }

--- a/userspace-dp/src/ip_proto.rs
+++ b/userspace-dp/src/ip_proto.rs
@@ -32,13 +32,22 @@ pub(crate) const PROTO_SCTP: u8 = 132;
 /// mirrors the Go SSOT `appid.ProtocolNumber` (the table the commit-time gate
 /// validates against) so the two views agree on the accepted set.
 ///
-/// `junos-*` aliases are NOT handled here: the Go compiler resolves an
-/// `application junos-foo` to its numeric protocol before building the
-/// snapshot, so the wire `protocol` is already a bare name or number. Returns
-/// `None` for an unrecognized token; the DNAT commit gate
-/// (validateDestinationNATProtocolStrict, #2396) rejects an unresolvable DNAT
-/// protocol so an inert rule never reaches the wire, and the dataplane drops
-/// any that slip through a tolerant load.
+/// The specific `junos-*` protocol aliases the Go SSOT resolves
+/// (`appid.ProtocolNumber`) are handled here too (#2505): a firewall
+/// filter's `from protocol <token>` reaches the wire VERBATIM from the
+/// parser (`compileFilterFrom` assigns `term.Protocol = nodeVal` with no
+/// alias resolution), so a config `from protocol junos-gre` arrives as the
+/// literal alias string. The Go filter commit gate
+/// (`filterProtocolResolvable`, #2175/#2505) accepts exactly the
+/// `appid.ProtocolNumber` set, so this resolver must accept the same aliases
+/// or a gate-passing filter would silently lose its protocol constraint in
+/// the dataplane (the #2505 fail-wide bug). An UNKNOWN `junos-foobar` is NOT
+/// accepted (consistent with the gate, which rejects it). Returns `None` for
+/// an unrecognized token; the DNAT commit gate
+/// (validateDestinationNATProtocolStrict, #2396) and the filter commit gate
+/// reject an unresolvable protocol so an inert rule never reaches the wire,
+/// and the dataplane fails closed (rejecting the snapshot) on any that slip
+/// through a tolerant load.
 ///
 /// #2396 (Copilot fold): the token is trimmed and lower-cased before matching.
 /// DNAT `match protocol` and an `application`'s `protocol` reach the wire
@@ -49,13 +58,13 @@ pub(crate) const PROTO_SCTP: u8 = 132;
 /// validating, so the two views agree on the accepted set after normalization.
 pub(crate) fn proto_number(name: &str) -> Option<u8> {
     match name.trim().to_ascii_lowercase().as_str() {
-        "tcp" => Some(PROTO_TCP),
-        "udp" => Some(PROTO_UDP),
-        "icmp" => Some(PROTO_ICMP),
-        "icmp6" | "icmpv6" => Some(PROTO_ICMPV6),
-        "gre" => Some(PROTO_GRE),
-        "ospf" => Some(PROTO_OSPF),
-        "ipip" => Some(PROTO_IPIP),
+        "tcp" | "junos-tcp-any" => Some(PROTO_TCP),
+        "udp" | "junos-udp-any" => Some(PROTO_UDP),
+        "icmp" | "junos-icmp-all" | "junos-ping" => Some(PROTO_ICMP),
+        "icmp6" | "icmpv6" | "junos-icmp6-all" | "junos-pingv6" => Some(PROTO_ICMPV6),
+        "gre" | "junos-gre" => Some(PROTO_GRE),
+        "ospf" | "junos-ospf" => Some(PROTO_OSPF),
+        "ipip" | "junos-ip-in-ip" | "junos-ipip" => Some(PROTO_IPIP),
         "egp" => Some(PROTO_EGP),
         "igmp" => Some(PROTO_IGMP),
         "pim" => Some(PROTO_PIM),

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -4582,6 +4582,40 @@ fn proto_number_resolver_matches_known_tokens() {
     assert_eq!(proto_number("256"), None);
 }
 
+/// #2505: the shared resolver must cover the FULL appid.ProtocolNumber
+/// acceptance set — the named protocols and the specific junos-* aliases the
+/// Go filter commit gate (filterProtocolResolvable) accepts. A firewall
+/// filter `from protocol <token>` reaches the snapshot VERBATIM, so any token
+/// the gate passes must resolve here or the filter loses its protocol
+/// constraint (the #2505 fail-wide bug).
+#[test]
+fn proto_number_resolves_full_gate_acceptance_set() {
+    use crate::ip_proto::proto_number;
+    // Named protocols the stale local filter parser dropped.
+    assert_eq!(proto_number("esp"), Some(50));
+    assert_eq!(proto_number("ah"), Some(51));
+    assert_eq!(proto_number("sctp"), Some(132));
+    assert_eq!(proto_number("vrrp"), Some(112));
+    assert_eq!(proto_number("igmp"), Some(2));
+    assert_eq!(proto_number("pim"), Some(103));
+    assert_eq!(proto_number("egp"), Some(8));
+    assert_eq!(proto_number("ipip"), Some(4));
+    assert_eq!(proto_number("ospf"), Some(89));
+    // junos-* aliases (mirror appid.ProtocolNumber / catalog.go).
+    assert_eq!(proto_number("junos-tcp-any"), Some(PROTO_TCP));
+    assert_eq!(proto_number("junos-udp-any"), Some(PROTO_UDP));
+    assert_eq!(proto_number("junos-icmp-all"), Some(PROTO_ICMP));
+    assert_eq!(proto_number("junos-ping"), Some(PROTO_ICMP));
+    assert_eq!(proto_number("junos-icmp6-all"), Some(PROTO_ICMPV6));
+    assert_eq!(proto_number("junos-pingv6"), Some(PROTO_ICMPV6));
+    assert_eq!(proto_number("junos-gre"), Some(PROTO_GRE));
+    assert_eq!(proto_number("junos-ospf"), Some(89));
+    assert_eq!(proto_number("junos-ip-in-ip"), Some(4));
+    assert_eq!(proto_number("junos-ipip"), Some(4));
+    // An UNKNOWN junos-* alias is NOT accepted (consistent with the gate).
+    assert_eq!(proto_number("junos-foobar"), None);
+}
+
 /// #2396 (Copilot fold, item 1): the resolver normalizes (trim + lower-case)
 /// so a mixed-case or whitespace-padded protocol token from the verbatim
 /// parser path resolves to the SAME number as the canonical lower-case token —

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -86,7 +86,13 @@ pub(crate) enum SnapshotIntegrityError {
     /// gate-passing config never reaches this arm in normal operation — it
     /// guards against version/snapshot drift. An EMPTY input protocol list is
     /// the legitimate "no protocol constraint" case and is NOT an error.
+    ///
+    /// `family` (inet / inet6) is carried alongside the filter name because
+    /// filter names can be REUSED across families — without it the fail-closed
+    /// diagnostic could not tell the operator WHICH `family <f> filter <name>`
+    /// failed.
     UnrepresentableFilterProtocol {
+        family: String,
         filter: String,
         term: String,
         token: String,
@@ -130,13 +136,14 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 first_rule, second_rule, direction
             ),
             Self::UnrepresentableFilterProtocol {
+                family,
                 filter,
                 term,
                 token,
             } => write!(
                 f,
-                "firewall filter {:?} term {:?} has an unresolvable protocol token {:?} — refusing to fail wide by dropping it (which would make the term match every protocol)",
-                filter, term, token
+                "firewall family {:?} filter {:?} term {:?} has an unresolvable protocol token {:?} — refusing to fail wide by dropping it (which would make the term match every protocol)",
+                family, filter, term, token
             ),
         }
     }

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -69,6 +69,28 @@ pub(crate) enum SnapshotIntegrityError {
         second_rule: String,
         direction: &'static str,
     },
+    /// #2505: a firewall-filter term carried a NON-EMPTY `from protocol` list
+    /// with at least one token that `ip_proto::proto_number` cannot resolve.
+    /// The pre-fix compiler used a stale local `parse_protocol` (recognizing
+    /// only tcp/udp/icmp/icmpv6/gre/ospf/ipip + bare numeric, no
+    /// trim/lowercase) and `filter_map`-dropped anything else. A named
+    /// protocol the Go commit gate accepts (esp/ah/sctp/vrrp/igmp/pim/egp +
+    /// the junos-* aliases) — or a mixed-case / whitespace token the Go gate
+    /// normalizes — was silently dropped. When ALL tokens drop, the term's
+    /// protocol list collapses to empty, `protocol_match_enabled` becomes
+    /// false, and the term matches EVERY protocol: a `from protocol esp; then
+    /// discard` term that should drop only ESP instead discards ALL traffic
+    /// (fail-WIDE). Rejecting the whole snapshot (the preflight keeps the
+    /// previous good state) is the fail-closed backstop; the Go gate
+    /// (`filterProtocolResolvable`, #2175/#2505) is the primary defense, so a
+    /// gate-passing config never reaches this arm in normal operation — it
+    /// guards against version/snapshot drift. An EMPTY input protocol list is
+    /// the legitimate "no protocol constraint" case and is NOT an error.
+    UnrepresentableFilterProtocol {
+        filter: String,
+        term: String,
+        token: String,
+    },
 }
 
 impl std::fmt::Display for SnapshotIntegrityError {
@@ -106,6 +128,15 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "nptv6 rules {:?} and {:?} have overlapping {} prefixes — refusing nondeterministic first-match resolution",
                 first_rule, second_rule, direction
+            ),
+            Self::UnrepresentableFilterProtocol {
+                filter,
+                term,
+                token,
+            } => write!(
+                f,
+                "firewall filter {:?} term {:?} has an unresolvable protocol token {:?} — refusing to fail wide by dropping it (which would make the term match every protocol)",
+                filter, term, token
             ),
         }
     }


### PR DESCRIPTION
Closes #2505

## Problem (HIGH, codex review-036 finding 1 — fail-wide security parity)

The Rust firewall-filter compiler carried a **stale local `parse_protocol`** that
recognized only `tcp/udp/icmp/icmpv6/gre/ospf/ipip` + bare numeric, did **not**
trim/lowercase, and `filter_map`-**dropped** any token it could not parse.

Named protocols the Go commit gate (`filterProtocolResolvable`) accepts —
`esp`, `ah`, `sctp`, `vrrp`, `igmp`, `pim`, `egp`, plus the `junos-*` aliases —
and mixed-case / whitespace tokens the Go gate normalizes were silently dropped.
When **every** token in a term's `from protocol` list dropped, the list collapsed
to empty, `protocol_match_enabled` became `false`, and the term matched **every**
protocol:

```
set firewall family inet filter f term esp-only from protocol esp
set firewall family inet filter f term esp-only then discard
```

committed cleanly but in the dataplane `esp` dropped → protocols empty →
`protocol_match_enabled=false` → the `discard` matched **all** traffic
(**fail-wide**).

## Fix

1. **Delete the stale local parser.** Resolve every protocol token through the
   shared, normalizing `crate::ip_proto::proto_number` (trim + lowercase + the
   full `appid.ProtocolNumber` acceptance set).

2. **Fail closed on an unresolvable token.** `parse_term` and the public
   `parse_filter_state*` functions now return
   `Result<FilterState, SnapshotIntegrityError>`. A **non-empty** protocol list
   with any unresolvable token raises the new
   `SnapshotIntegrityError::UnrepresentableFilterProtocol{filter, term, token}`,
   propagated via `?` through `build_forwarding_state_with_policy_counters_and_previous`
   to the reconcile preflight (`build_reconcile_forwarding`). Post-#2484 that
   preflight aborts the reconcile **before** teardown/publish, keeping the prior
   good filter state live rather than installing a fail-wide match-all term. An
   **empty** input list stays "no constraint" (`protocol_match_enabled=false`,
   match-any), and an empty/whitespace placeholder token is skipped (not an
   error).

3. **Gate↔dataplane parity.** Added the specific `junos-*` aliases the Go gate
   accepts (`junos-tcp-any`, `junos-ping`, `junos-gre`, `junos-ip-in-ip`, ...) to
   `proto_number`. A filter's `from protocol` token reaches the snapshot
   **verbatim** (Go's `compileFilterFrom` does no alias resolution), so the
   resolver must accept exactly what the gate accepts. An unknown `junos-foobar`
   is still rejected, consistent with the gate. No token the commit gate passes
   can reach the fail-closed path in normal operation — fail-closed is the
   backstop against future drift.

## Blast radius (16 files)

- **Production (5):** `ip_proto.rs` (junos aliases + doc), `policy.rs` (new error
  variant), `filter/compiler.rs` (core fix), `filter/mod.rs` (imports),
  `afxdp/forwarding_build/mod.rs` (`?` propagation).
- **Doc (2):** `filter/README.md`, `_Log.md`.
- **Test content (2):** `filter/tests.rs` (6 new tests), `nat/tests.rs` (extended
  resolver test).
- **Mechanical ripple (7):** `filter/engine/cache_sensitive.rs`,
  `afxdp/flow_cache_tests.rs`, `afxdp/tx/dispatch/dispatch_tests.rs`,
  `afxdp/poll_descriptor/{reject_reply,cookie_reply}.rs`, `afxdp/frame/tests.rs`,
  `afxdp/tests.rs` — test call sites add `.expect("filter state compiles")` on
  the now-`Result` return. No behavior change.

## Validation

- `cargo build --release` clean (0 errors).
- Filter + ip_proto + policy tests: **150/150**, 5× consecutive.
- New `protocol_2505_*` tests (6) green; extended `proto_number` resolver test green.
- **Fail-on-revert proven:** simulating the stale parser (drop `esp`) flips all
  `protocol_2505` tests to FAILED — the `esp` term becomes match-all.
- Full Rust suite green (one pre-existing flaky `worker_queue` concurrency test,
  untouched code, passes 3/3 isolated).
- Go parity tests green: `go test ./pkg/appid/ ./pkg/config/ -run "ProtocolNumber|FilterProtocol"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
