### PR TITLE
userspace-dp: synthesize active reply for filter then-reject (#2521)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12570,3 +12570,36 @@ top.
   source-path SESSION_OPEN/CLOSE wrongly suppressed → test fails; restored →
   pass). go build ./... ; go test pkg/{logging,daemon,dataplane/userspace}
   green; gofmt/vet clean (pre-existing syslog.go drift untouched).
+
+## 2026-06-24 — #2521 filter `then reject` active-reply synthesis
+
+- **Timestamp**: 2026-06-24
+- **Action**: Make firewall-filter `then reject` synthesize an active reply
+  (TCP RST / ICMP unreachable) on the input + lo0 paths instead of a silent
+  drop, reusing policy reject's machinery; add `filter_reject_sent` counter.
+- **File(s)**:
+  - userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs — factor shared
+    `enqueue_reject_reply(... source)` with `RejectReplySource{Policy,Filter}`;
+    thin `enqueue_policy_reject_reply` / new `enqueue_filter_reject_reply`
+    wrappers; filter-reject unit tests (TCP RST + ICMP unreachable + counter).
+  - userspace-dp/src/afxdp/poll_descriptor/mod.rs — wire
+    `enqueue_filter_reject_reply` at the new-flow input filter,
+    DSCP/L4-sensitive session-hit re-eval, and both lo0 local-delivery sites;
+    capture lo0 action via `FilterAction` instead of bool.
+  - userspace-dp/src/afxdp/poll_descriptor/filter.rs — `apply_lo0_filter_action`
+    returns `FilterAction` (was bool) so caller can distinguish Reject/Discard.
+  - userspace-dp/src/afxdp/event_emit.rs — `filter_action_to_rt_flow` maps
+    Reject→REJECT (was DENY); test updated + discard-as-deny test added.
+  - filter_reject_sent counter chain: afxdp/mod.rs (BatchCounters + flush),
+    afxdp/umem/mod.rs (live atomic + ctor), umem/snapshot.rs, worker/mod.rs
+    (snapshot), coordinator/refresh_bindings.rs (copy + zero),
+    protocol/binding.rs (wire DTO), pkg/dataplane/userspace/protocol.go (Go DTO).
+  - userspace-dp/tests/fixtures/protocol_wire_v1.json — regenerated (new key).
+  - userspace-dp/src/filter/tests.rs — reject-distinct-from-discard compile test.
+  - userspace-dp/src/filter/README.md, docs/feature-gaps.md — document the
+    synthesis, classification parity, #2472 compose note, output-filter gap.
+- **Validation**: cargo build --release clean; targeted suites (filter,
+  reject_reply, poll_descriptor, event_emit, wire_invariant) 5/5 green;
+  fail-on-revert PROVEN twice (RejectReplySource::Filter→Policy fails the
+  counter test; compiler reject→Discard fails reject_action_compiles_distinct);
+  `then discard` still silent (no reply) confirmed; go build ./pkg/dataplane/userspace OK.

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -389,6 +389,17 @@ xpf has a broad chassis cluster implementation with redundancy groups, RETH (VRR
 
 xpf has firewall filters with source/dest addresses, prefix-lists (with except), DSCP, protocol, dest/source ports, ICMP type/code, TCP flags, fragment match, actions (accept/reject/discard), routing-instance, log, count, forwarding-class, loss-priority, DSCP rewrite, and IPv6 traffic-class matching.
 
+Filter `then reject` is now an **active** reject on the input and lo0
+(host-bound) paths (#2521): it synthesizes a TCP RST (TCP) or ICMP/ICMPv6
+admin-prohibited unreachable (otherwise) using the SAME machinery as policy
+reject (`poll_descriptor/reject_reply.rs`), runs the generated reply through
+#2238 output-filter/CoS/DSCP classification, and counts it on
+`filter_reject_sent`. `then discard` stays a silent drop. Previously filter
+reject collapsed to a silent drop (fail-closed parity gap). REMAINING GAP:
+output-firewall-filter `then reject` realized on the TX/CoS path still
+collapses to a silent drop (the TX site lacks the descriptor context for
+reply synthesis) — tracked as a #2521 follow-up.
+
 `from protocol <name>` resolution is centralized (#2175) on the same
 `appid.ProtocolNumber` source of truth used by security-policy applications
 (#2124), so every protocol a policy accepts a firewall filter accepts too: the

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1681,7 +1681,13 @@ type BindingStatus struct {
 	SYNCookieBypass              uint64 `json:"syn_cookie_bypass,omitempty"`
 	// #2089: policy `reject` action — RST/ICMP-unreachable replies sent,
 	// and replies suppressed due to TX-frame budget exhaustion.
-	PolicyRejectSent             uint64 `json:"policy_reject_sent,omitempty"`
+	PolicyRejectSent uint64 `json:"policy_reject_sent,omitempty"`
+	// #2521: firewall-filter `then reject` — RST/ICMP-unreachable replies
+	// sent (mirrors PolicyRejectSent). The suppression legs (budget,
+	// output-filter, parse-error) are shared with policy reject because both
+	// run the same synthesis + #2238 classification path. omitempty + Rust
+	// serde `default` keep cross-version wire safety.
+	FilterRejectSent             uint64 `json:"filter_reject_sent,omitempty"`
 	PolicyRejectReplyBudgetDrops uint64 `json:"policy_reject_reply_budget_drops,omitempty"`
 	// #2238: locally-generated replies (Time Exceeded, policy-reject
 	// RST/ICMP-unreachable, SYN-cookie SYN-ACK/ACK-RST) are now classified by

--- a/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
+++ b/userspace-dp/src/afxdp/coordinator/refresh_bindings.rs
@@ -115,6 +115,7 @@ fn copy_live_snapshot(binding: &mut BindingStatus, snap: BindingLiveSnapshot) {
     binding.syn_cookie_ack_invalid = snap.syn_cookie_ack_invalid;
     binding.syn_cookie_bypass = snap.syn_cookie_bypass;
     binding.policy_reject_sent = snap.policy_reject_sent;
+    binding.filter_reject_sent = snap.filter_reject_sent;
     binding.policy_reject_reply_budget_drops = snap.policy_reject_reply_budget_drops;
     binding.time_exceeded_output_filter_drops = snap.time_exceeded_output_filter_drops;
     binding.policy_reject_output_filter_drops = snap.policy_reject_output_filter_drops;
@@ -304,6 +305,7 @@ fn zero_unbound_slot(binding: &mut BindingStatus) {
     binding.syn_cookie_ack_invalid = 0;
     binding.syn_cookie_bypass = 0;
     binding.policy_reject_sent = 0;
+    binding.filter_reject_sent = 0;
     binding.policy_reject_reply_budget_drops = 0;
     binding.time_exceeded_output_filter_drops = 0;
     binding.policy_reject_output_filter_drops = 0;

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -305,10 +305,13 @@ fn filter_action_to_rt_flow(action: FilterAction) -> u8 {
     match action {
         FilterAction::Accept => RT_FLOW_ACTION_PERMIT,
         FilterAction::Discard => RT_FLOW_ACTION_DENY,
-        // Userspace filter reject is currently fail-closed as a terminal
-        // drop. Until per-path reject packet synthesis is wired, RT_FLOW
-        // must report deny rather than claiming an ICMP/RST reject happened.
-        FilterAction::Reject => RT_FLOW_ACTION_DENY,
+        // #2521: filter `then reject` now synthesizes an active reply (TCP
+        // RST / ICMP unreachable) via the same path as policy reject
+        // (poll_descriptor enqueue_filter_reject_reply), so RT_FLOW reports
+        // reject — matching the wire behavior and Junos, like
+        // policy_action_to_rt_flow above. `discard` stays a silent drop →
+        // deny.
+        FilterAction::Reject => RT_FLOW_ACTION_REJECT,
     }
 }
 
@@ -657,8 +660,13 @@ mod tests {
         assert_eq!(handle.dataplane_event_stats().filter_log.sent, 1);
     }
 
+    /// #2521: filter `then reject` now synthesizes an active reply (the
+    /// dataplane enqueues a TCP RST / ICMP unreachable), so the RT_FLOW filter
+    /// log reports REJECT — matching policy reject and Junos. (Pre-#2521 this
+    /// asserted DENY because no reply was generated.) `discard` still maps to
+    /// DENY (`filter_log_event_emit_discard_as_deny`).
     #[test]
-    fn filter_log_event_emit_fails_closed_reject_as_deny() {
+    fn filter_log_event_emit_reject_reports_reject() {
         let (handle, rx) = unlimited_handle();
         let flow = test_flow();
 
@@ -681,10 +689,40 @@ mod tests {
             .decode_dataplane_event()
             .expect("filter event payload");
         assert_eq!(event.kind, DataplaneEventKind::FilterLog);
-        assert_eq!(event.action, RT_FLOW_ACTION_DENY);
+        assert_eq!(event.action, RT_FLOW_ACTION_REJECT);
         assert_eq!(event.filter_id, 23);
         assert_eq!(event.term_id, 6);
         assert_eq!(event.reason, FilterLogSource::Lo0.wire_reason());
+        assert_eq!(handle.dataplane_event_stats().filter_log.sent, 1);
+    }
+
+    /// #2521: `then discard` stays a silent drop → RT_FLOW DENY (the
+    /// distinction from reject above).
+    #[test]
+    fn filter_log_event_emit_discard_as_deny() {
+        let (handle, rx) = unlimited_handle();
+        let flow = test_flow();
+
+        emit_filter_log_event(
+            Some(&handle),
+            &flow,
+            test_meta(),
+            7,
+            0,
+            23,
+            6,
+            FilterAction::Discard,
+            FilterLogSource::Lo0,
+            789,
+        );
+
+        let event = rx
+            .try_recv()
+            .expect("filter event frame")
+            .decode_dataplane_event()
+            .expect("filter event payload");
+        assert_eq!(event.kind, DataplaneEventKind::FilterLog);
+        assert_eq!(event.action, RT_FLOW_ACTION_DENY);
         assert_eq!(handle.dataplane_event_stats().filter_log.sent, 1);
     }
 }

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -294,8 +294,10 @@ fn policy_action_to_rt_flow(action: PolicyAction) -> u8 {
         // #2089: the policy-deny path now synthesizes a TCP RST / ICMP
         // unreachable for `reject` (poll_descriptor reject_reply), so the
         // RT_FLOW action reports reject, matching the wire behavior and
-        // Junos. (Filter reject — filter_action_to_rt_flow below — is
-        // still a silent drop and stays mapped to deny.)
+        // Junos. (#2521: filter reject — filter_action_to_rt_flow below —
+        // now ALSO synthesizes an active reject reply (RST/ICMP) and maps
+        // to RT_FLOW_ACTION_REJECT, same as policy reject; filter DISCARD
+        // remains the silent-drop → deny case.)
         PolicyAction::Reject => RT_FLOW_ACTION_REJECT,
     }
 }

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -464,6 +464,15 @@ pub(in crate::afxdp) struct BatchCounters {
     // counts replies suppressed because the TX-frame budget was exhausted
     // (the packet is still dropped — fail-closed).
     policy_reject_sent: u64,
+    // #2521: firewall-filter `then reject` reply synthesis. Counts the
+    // RST/ICMP-unreachable replies enqueued for a filter (not policy)
+    // reject; mirrors `policy_reject_sent`. The budget-exhaustion,
+    // output-filter, and parse-error drop legs are SHARED with policy
+    // reject (`policy_reject_reply_budget_drops`,
+    // `policy_reject_output_filter_drops`,
+    // `generated_reply_classify_parse_errors`) because both run the same
+    // synthesis + #2238 output-classification path.
+    filter_reject_sent: u64,
     policy_reject_reply_budget_drops: u64,
     // #2238: locally-generated reply output-classification drops. A reply
     // (Time Exceeded, policy-reject RST/ICMP-unreachable, SYN-cookie
@@ -616,6 +625,11 @@ impl BatchCounters {
             live.policy_reject_sent
                 .fetch_add(self.policy_reject_sent, Ordering::Relaxed);
             self.policy_reject_sent = 0;
+        }
+        if self.filter_reject_sent != 0 {
+            live.filter_reject_sent
+                .fetch_add(self.filter_reject_sent, Ordering::Relaxed);
+            self.filter_reject_sent = 0;
         }
         if self.policy_reject_reply_budget_drops != 0 {
             live.policy_reject_reply_budget_drops

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -304,6 +304,13 @@ fn emit_cached_output_filter_log_tail(
     );
 }
 
+/// Evaluate the lo0 (host-bound) firewall filter and emit any matched filter
+/// log. Returns the matched terminal `FilterAction` (#2521): the caller maps
+/// `Accept` → deliver, `Discard` → silent drop, `Reject` → silent drop PLUS a
+/// synthesized active reply (TCP RST / ICMP unreachable). Previously this
+/// returned a bare `bool` (drop vs deliver), collapsing `Reject` into a silent
+/// `Discard` — the parity gap #2521 closes for control-plane / host-bound
+/// filters.
 #[cold]
 #[inline(never)]
 pub(super) fn apply_lo0_filter_action(
@@ -314,9 +321,9 @@ pub(super) fn apply_lo0_filter_action(
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
     now_ns: u64,
-) -> bool {
+) -> crate::filter::FilterAction {
     let Some(flow) = flow else {
-        return false;
+        return crate::filter::FilterAction::Accept;
     };
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
     let result = crate::filter::evaluate_lo0_filter_counted(
@@ -350,5 +357,5 @@ pub(super) fn apply_lo0_filter_action(
             now_ns,
         );
     }
-    !matches!(result.action, crate::filter::FilterAction::Accept)
+    result.action
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -36,7 +36,7 @@ use crate::policy::evaluate_policy_result_with_len;
 
 use cookie_reply::{SynCookieReply, enqueue_syn_cookie_reply};
 use nat_exception::{record_source_nat_failure, source_nat_decision_for_flow};
-use reject_reply::enqueue_policy_reject_reply;
+use reject_reply::{enqueue_filter_reject_reply, enqueue_policy_reject_reply};
 
 use filter::{
     apply_lo0_filter_action, emit_input_filter_log_match,
@@ -442,13 +442,33 @@ pub(super) fn poll_binding_process_descriptor(
                                 );
                             }
                             if input_filter_eval.action != crate::filter::FilterAction::Accept {
+                                // #2521: a filter `then reject` synthesizes a
+                                // TCP RST / ICMP unreachable back toward the
+                                // source (same machinery as policy reject);
+                                // `discard` stays a silent drop. The reply is
+                                // enqueued before the recycle, while flow /
+                                // packet_frame are in scope.
+                                if input_filter_eval.action
+                                    == crate::filter::FilterAction::Reject
+                                {
+                                    enqueue_filter_reject_reply(
+                                        &mut binding.tx_pipeline,
+                                        worker_ctx.forwarding,
+                                        binding.ifindex,
+                                        packet_frame,
+                                        meta,
+                                        flow,
+                                        telemetry.counters,
+                                    );
+                                }
                                 binding.scratch.scratch_recycle.push(desc.addr);
                                 continue;
                             }
                         }
-                        if resolved.decision.resolution.disposition
+                        let lo0_action = if resolved.decision.resolution.disposition
                             == ForwardingDisposition::LocalDelivery
-                            && apply_lo0_filter_action(
+                        {
+                            apply_lo0_filter_action(
                                 worker_ctx.forwarding,
                                 crate::afxdp::frame::term_match_extra_from_frame(
                                     packet_frame,
@@ -460,7 +480,25 @@ pub(super) fn poll_binding_process_descriptor(
                                 Some(resolved.metadata.ingress_zone),
                                 now_ns,
                             )
-                        {
+                        } else {
+                            crate::filter::FilterAction::Accept
+                        };
+                        if lo0_action != crate::filter::FilterAction::Accept {
+                            // #2521: a lo0 `then reject` synthesizes a TCP RST /
+                            // ICMP unreachable toward the source before the
+                            // host-bound session is torn down; `discard` stays
+                            // a silent drop.
+                            if lo0_action == crate::filter::FilterAction::Reject {
+                                enqueue_filter_reject_reply(
+                                    &mut binding.tx_pipeline,
+                                    worker_ctx.forwarding,
+                                    binding.ifindex,
+                                    packet_frame,
+                                    meta,
+                                    flow,
+                                    telemetry.counters,
+                                );
+                            }
                             delete_terminal_filtered_session(
                                 sessions,
                                 binding.bpf_maps.session_map_fd,
@@ -813,6 +851,20 @@ pub(super) fn poll_binding_process_descriptor(
                                     now_ns,
                                 );
                             }
+                            // #2521: filter `then reject` synthesizes an active
+                            // reply (TCP RST / ICMP unreachable) like policy
+                            // reject; `discard` remains a silent drop.
+                            if input_filter_eval.action == crate::filter::FilterAction::Reject {
+                                enqueue_filter_reject_reply(
+                                    &mut binding.tx_pipeline,
+                                    worker_ctx.forwarding,
+                                    binding.ifindex,
+                                    packet_frame,
+                                    meta,
+                                    flow,
+                                    telemetry.counters,
+                                );
+                            }
                             binding.scratch.scratch_recycle.push(desc.addr);
                             continue;
                         }
@@ -1105,8 +1157,10 @@ pub(super) fn poll_binding_process_descriptor(
                         } else {
                             false
                         };
-                        if resolution.disposition == ForwardingDisposition::LocalDelivery
-                            && apply_lo0_filter_action(
+                        let lo0_action = if resolution.disposition
+                            == ForwardingDisposition::LocalDelivery
+                        {
+                            apply_lo0_filter_action(
                                 worker_ctx.forwarding,
                                 crate::afxdp::frame::term_match_extra_from_frame(
                                     packet_frame,
@@ -1118,7 +1172,24 @@ pub(super) fn poll_binding_process_descriptor(
                                 ingress_zone_override,
                                 now_ns,
                             )
-                        {
+                        } else {
+                            crate::filter::FilterAction::Accept
+                        };
+                        if lo0_action != crate::filter::FilterAction::Accept {
+                            // #2521: lo0 `then reject` synthesizes an active
+                            // reply (TCP RST / ICMP unreachable); `discard`
+                            // stays a silent drop.
+                            if lo0_action == crate::filter::FilterAction::Reject {
+                                enqueue_filter_reject_reply(
+                                    &mut binding.tx_pipeline,
+                                    worker_ctx.forwarding,
+                                    binding.ifindex,
+                                    packet_frame,
+                                    meta,
+                                    flow,
+                                    telemetry.counters,
+                                );
+                            }
                             telemetry.dbg.local += 1;
                             telemetry.dbg.policy_deny += 1;
                             binding.scratch.scratch_recycle.push(desc.addr);

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -19,6 +19,20 @@ use super::worker::WorkerTxPipeline;
 use super::*;
 use crate::afxdp::icmp::build_reject_icmp_unreachable;
 
+/// Which `reject` source a synthesized reply is attributed to. Selects the
+/// per-source counters so a policy `then reject` and a firewall-filter `then
+/// reject` are independently observable, while both flow through the SAME
+/// reply-synthesis + output-classification machinery (#2521). The
+/// budget-exhaustion / output-filter-drop / parse-error legs are shared with
+/// policy reject so #2472's future per-reason rate limiter (which hooks the
+/// shared generated-reply path) covers filter reject automatically — there is
+/// no parallel, un-limitable emit path.
+#[derive(Clone, Copy)]
+pub(super) enum RejectReplySource {
+    Policy,
+    Filter,
+}
+
 #[cold]
 #[inline(never)]
 pub(super) fn enqueue_policy_reject_reply(
@@ -29,6 +43,62 @@ pub(super) fn enqueue_policy_reject_reply(
     meta: UserspaceDpMeta,
     flow: &SessionFlow,
     counters: &mut BatchCounters,
+) -> bool {
+    enqueue_reject_reply(
+        tx_pipeline,
+        forwarding,
+        ingress_ifindex,
+        packet_frame,
+        meta,
+        flow,
+        counters,
+        RejectReplySource::Policy,
+    )
+}
+
+/// #2521: firewall-filter `then reject` now synthesizes the SAME active
+/// reply as policy `reject` (TCP RST for TCP, ICMP/ICMPv6 admin-prohibited
+/// unreachable otherwise) instead of the historical silent drop. Reuses the
+/// exact synthesis + #2238 output-classification path via the shared
+/// `enqueue_reject_reply`; only the success counter differs
+/// (`filter_reject_sent` vs `policy_reject_sent`). Budget, output-filter, and
+/// parse-error drops share policy reject's counters and its fail-closed
+/// behavior (the caller still drops the packet on a `false` return).
+#[cold]
+#[inline(never)]
+pub(super) fn enqueue_filter_reject_reply(
+    tx_pipeline: &mut WorkerTxPipeline,
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    flow: &SessionFlow,
+    counters: &mut BatchCounters,
+) -> bool {
+    enqueue_reject_reply(
+        tx_pipeline,
+        forwarding,
+        ingress_ifindex,
+        packet_frame,
+        meta,
+        flow,
+        counters,
+        RejectReplySource::Filter,
+    )
+}
+
+#[cold]
+#[inline(never)]
+#[allow(clippy::too_many_arguments)]
+fn enqueue_reject_reply(
+    tx_pipeline: &mut WorkerTxPipeline,
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    flow: &SessionFlow,
+    counters: &mut BatchCounters,
+    source: RejectReplySource,
 ) -> bool {
     if !syn_cookie_reply_budget_available(tx_pipeline) {
         counters.touched = true;
@@ -83,7 +153,10 @@ pub(super) fn enqueue_policy_reject_reply(
         enqueue_ns: 0,
     });
     counters.touched = true;
-    counters.policy_reject_sent += 1;
+    match source {
+        RejectReplySource::Policy => counters.policy_reject_sent += 1,
+        RejectReplySource::Filter => counters.filter_reject_sent += 1,
+    }
     true
 }
 
@@ -328,6 +401,130 @@ mod tests {
         assert_eq!(counters.policy_reject_output_filter_drops, 1);
         assert_eq!(counters.generated_reply_classify_parse_errors, 0);
         assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #2521: a firewall-filter `then reject` on a TCP flow synthesizes a TCP
+    /// RST (not a silent drop) and increments `filter_reject_sent` — NOT
+    /// `policy_reject_sent`. Fail-on-revert: if the call site reverts to a
+    /// silent recycle (no synthesis), `pending_tx_local` stays empty and
+    /// `filter_reject_sent` stays 0; if it routes through the policy counter,
+    /// the per-source counter assertion fails.
+    #[test]
+    fn filter_reject_tcp_enqueues_rst_filter_counter() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        let (frame, meta, flow) = tcp_v4_syn();
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let forwarding = ForwardingState::default();
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_filter_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(sent, "filter TCP reject must enqueue a RST");
+        assert_eq!(
+            counters.filter_reject_sent, 1,
+            "filter reject must bump filter_reject_sent"
+        );
+        assert_eq!(
+            counters.policy_reject_sent, 0,
+            "filter reject must NOT bump policy_reject_sent"
+        );
+        let req = pipeline
+            .pending_tx_local
+            .pop_front()
+            .expect("filter reject RST request");
+        assert_eq!(req.egress_ifindex, 5);
+        // Reflected RST: dst MAC is the inbound src MAC; RST flag set.
+        assert_eq!(&req.bytes[0..6], &[0x36, 0xe4, 0x2b, 0xd5, 0x39, 0xe6]);
+        let tcp_flags = req.bytes[14 + 20 + 13];
+        assert_ne!(tcp_flags & 0x04, 0, "RST flag must be set");
+    }
+
+    /// #2521: a firewall-filter `then reject` on a NON-TCP (ICMP) flow
+    /// synthesizes an ICMP unreachable and increments `filter_reject_sent`.
+    #[test]
+    fn filter_reject_non_tcp_enqueues_icmp_unreachable() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        let client = std::net::Ipv4Addr::new(10, 0, 61, 102);
+        let server = std::net::Ipv4Addr::new(1, 1, 1, 1);
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        frame.extend_from_slice(&[0x36, 0xe4, 0x2b, 0xd5, 0x39, 0xe6]);
+        frame.extend_from_slice(&0x0800u16.to_be_bytes());
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x40, 0x00, 64, PROTO_ICMP, 0, 0,
+        ]);
+        frame.extend_from_slice(&client.octets());
+        frame.extend_from_slice(&server.octets());
+        frame.extend_from_slice(&[8, 0, 0, 0, 0x12, 0x34, 0, 1]); // ICMP echo
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: 5,
+            l3_offset: 14,
+            l4_offset: 34,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_ICMP,
+            pkt_len: (frame.len() - 14) as u16,
+            ..UserspaceDpMeta::default()
+        };
+        let flow = SessionFlow {
+            src_ip: std::net::IpAddr::V4(client),
+            dst_ip: std::net::IpAddr::V4(server),
+            forward_key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_ICMP,
+                src_ip: std::net::IpAddr::V4(client),
+                dst_ip: std::net::IpAddr::V4(server),
+                src_port: 0x1234,
+                dst_port: 0,
+            },
+        };
+        // build_reject_icmp_unreachable needs an egress with a v4 primary on
+        // the reply's egress interface (the inbound ingress ifindex).
+        let mut forwarding = ForwardingState::default();
+        forwarding.egress.insert(
+            5,
+            EgressInterface {
+                bind_ifindex: 5,
+                vlan_id: 0,
+                mtu: 1500,
+                src_mac: [0x02, 0xbf, 0x72, 0x00, 0x61, 0x01],
+                zone_id: 0,
+                redundancy_group: 0,
+                primary_v4: Some(std::net::Ipv4Addr::new(10, 0, 61, 1)),
+                primary_v6: None,
+            },
+        );
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_filter_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(sent, "filter non-TCP reject must enqueue an ICMP unreachable");
+        assert_eq!(counters.filter_reject_sent, 1);
+        assert_eq!(counters.policy_reject_sent, 0);
+        let req = pipeline
+            .pending_tx_local
+            .pop_front()
+            .expect("filter reject ICMP request");
+        // ICMP unreachable: type 3 at the L4 offset of the reply.
+        assert_eq!(req.bytes[14 + 20], 3, "ICMP type must be Destination Unreachable");
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/umem/mod.rs
+++ b/userspace-dp/src/afxdp/umem/mod.rs
@@ -372,8 +372,13 @@ pub(in crate::afxdp) struct BindingLiveState {
     pub(super) syn_cookie_bypass: AtomicU64,
     /// #2089: policy-`reject` RST/ICMP-unreachable replies enqueued.
     pub(super) policy_reject_sent: AtomicU64,
+    /// #2521: firewall-filter `then reject` RST/ICMP-unreachable replies
+    /// enqueued. Mirrors `policy_reject_sent`; the suppression legs
+    /// (budget / output-filter / parse-error) are shared with policy reject.
+    pub(super) filter_reject_sent: AtomicU64,
     /// #2089: policy-`reject` replies suppressed due to TX-frame budget
-    /// exhaustion (the packet is still dropped — fail-closed).
+    /// exhaustion (the packet is still dropped — fail-closed). Shared with
+    /// filter reject (#2521).
     pub(super) policy_reject_reply_budget_drops: AtomicU64,
     /// #2238: locally-generated replies dropped by an OUTPUT firewall filter
     /// terminal `discard`/`reject` (or three-color policer) on the egress
@@ -792,6 +797,7 @@ impl BindingLiveState {
             syn_cookie_ack_invalid: AtomicU64::new(0),
             syn_cookie_bypass: AtomicU64::new(0),
             policy_reject_sent: AtomicU64::new(0),
+            filter_reject_sent: AtomicU64::new(0),
             policy_reject_reply_budget_drops: AtomicU64::new(0),
             time_exceeded_output_filter_drops: AtomicU64::new(0),
             policy_reject_output_filter_drops: AtomicU64::new(0),

--- a/userspace-dp/src/afxdp/umem/snapshot.rs
+++ b/userspace-dp/src/afxdp/umem/snapshot.rs
@@ -93,6 +93,7 @@ impl BindingLiveState {
             syn_cookie_ack_invalid: self.syn_cookie_ack_invalid.load(Ordering::Relaxed),
             syn_cookie_bypass: self.syn_cookie_bypass.load(Ordering::Relaxed),
             policy_reject_sent: self.policy_reject_sent.load(Ordering::Relaxed),
+            filter_reject_sent: self.filter_reject_sent.load(Ordering::Relaxed),
             policy_reject_reply_budget_drops: self
                 .policy_reject_reply_budget_drops
                 .load(Ordering::Relaxed),

--- a/userspace-dp/src/afxdp/worker/mod.rs
+++ b/userspace-dp/src/afxdp/worker/mod.rs
@@ -1324,7 +1324,11 @@ pub(crate) struct BindingLiveSnapshot {
     pub(crate) syn_cookie_bypass: u64,
     /// #2089: policy-`reject` RST/ICMP-unreachable replies enqueued.
     pub(crate) policy_reject_sent: u64,
-    /// #2089: policy-`reject` replies suppressed by TX-frame budget.
+    /// #2521: firewall-filter `then reject` RST/ICMP-unreachable replies
+    /// enqueued. Mirrors `policy_reject_sent`.
+    pub(crate) filter_reject_sent: u64,
+    /// #2089: policy-`reject` replies suppressed by TX-frame budget (shared
+    /// with filter reject, #2521).
     pub(crate) policy_reject_reply_budget_drops: u64,
     /// #2238: locally-generated replies dropped by an OUTPUT firewall filter
     /// (terminal discard/reject or three-color policer) on the egress

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -389,3 +389,42 @@ a per-interface `has_<X>_match` set — the flow-cache never holds
 a lo0 decision in the first place. This is noted here so future
 readers do not repeat the v1 plan investigation that mistook lo0
 for a missing cache-sensitive gate.
+
+### `then reject` synthesizes an active reply (#2521)
+
+`FilterAction::Reject` (`then reject`) no longer realizes as a silent
+drop. It now synthesizes and transmits an active reject reply — a TCP
+RST for TCP, an ICMP/ICMPv6 administratively-prohibited Destination
+Unreachable otherwise — using the **same** machinery as policy
+`reject`. `FilterAction::Discard` (`then discard`) is unchanged: still
+a silent drop, no reply.
+
+The synthesis is the shared `enqueue_reject_reply` in
+`poll_descriptor/reject_reply.rs`; `enqueue_policy_reject_reply` and
+`enqueue_filter_reject_reply` are thin wrappers over it that differ
+only in the success counter (`policy_reject_sent` vs
+`filter_reject_sent`). Filter reject is wired at every input/lo0
+filter drop site in `poll_descriptor/mod.rs` that previously recycled
+the descriptor on a terminal action: the new-flow input filter, the
+DSCP/L4-sensitive session-hit re-evaluation, and both lo0 local-delivery
+paths. `apply_lo0_filter_action` returns the matched `FilterAction`
+(not a bare drop `bool`) so the caller can tell `Reject` from
+`Discard`.
+
+Because the generated reply runs through the SAME path as policy
+reject, it inherits the #2238 output-filter / CoS / DSCP
+classification (`classify_generated_reply`, keyed on the reply's OWN
+egress tuple) and the SYN-cookie TX-frame budget gate — and a future
+per-reason generated-reply rate limiter (#2472) covers filter reject
+automatically (no parallel, un-limitable emit path). Budget exhaustion,
+output-filter drops, and parse-error drops share policy reject's
+counters and its fail-closed behavior (the caller still drops the
+packet when synthesis returns `false`). The RT_FLOW filter-log action
+maps `Reject → reject` (matching policy reject and Junos), `Discard →
+deny`.
+
+**Scope:** output-firewall-filter `then reject` realized on the
+TX/CoS path (`tx/cos_classify.rs`) still collapses `Reject` to a
+silent drop. That site lacks the descriptor/packet context the
+reflected-reply synthesis needs, so wiring it would be a divergent
+path — tracked as a follow-up, not part of #2521.

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -115,6 +115,66 @@ fn basic_accept_discard() {
     assert_eq!(result.action, FilterAction::Accept);
 }
 
+/// #2521: `then reject` compiles to `FilterAction::Reject` and stays DISTINCT
+/// from `then discard` (`FilterAction::Discard`). The dataplane uses this
+/// distinction to synthesize an active reply for reject while keeping discard a
+/// silent drop. Fail-on-revert: if the compiler collapses `reject` to
+/// `Discard` (the historical silent-drop behavior), this asserts fail.
+#[test]
+fn reject_action_compiles_distinct_from_discard() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "reject-filter".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "reject-ssh".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["22".into()],
+                    action: "reject".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "discard-telnet".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["23".into()],
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+    );
+    let reject = evaluate_filter(
+        &state,
+        "inet:reject-filter",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 2)),
+        PROTO_TCP,
+        12345,
+        22,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        reject.action,
+        FilterAction::Reject,
+        "`then reject` must compile to FilterAction::Reject, not collapse to Discard"
+    );
+    let discard = evaluate_filter(
+        &state,
+        "inet:reject-filter",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 2)),
+        PROTO_TCP,
+        12345,
+        23,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(discard.action, FilterAction::Discard);
+}
+
 #[test]
 fn interface_filter_log_match_returns_filter_and_term_identity() {
     let state = make_filter_state_with_interfaces(

--- a/userspace-dp/src/protocol/binding.rs
+++ b/userspace-dp/src/protocol/binding.rs
@@ -431,6 +431,12 @@ pub(crate) struct BindingStatus {
     pub syn_cookie_bypass: u64,
     #[serde(rename = "policy_reject_sent", default)]
     pub policy_reject_sent: u64,
+    // #2521: firewall-filter `then reject` RST/ICMP-unreachable replies
+    // enqueued (mirrors policy_reject_sent). `default` keeps cross-version
+    // wire safety — an older helper omits the field and Go/Rust read 0
+    // (#1961-class contract).
+    #[serde(rename = "filter_reject_sent", default)]
+    pub filter_reject_sent: u64,
     #[serde(rename = "policy_reject_reply_budget_drops", default)]
     pub policy_reject_reply_budget_drops: u64,
     // #2238: locally-generated replies dropped by an output firewall filter

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -79,6 +79,7 @@
     "exception_packets": 0,
     "fabric_redirect_unsendable_drops": 0,
     "fib_gen_mismatches": 0,
+    "filter_reject_sent": 0,
     "flow_cache_capacity": 0,
     "flow_cache_collision_evictions": 0,
     "flow_cache_evictions": 0,


### PR DESCRIPTION
Closes #2521

## Problem
Firewall-filter `then reject` compiled to `FilterAction::Reject` but the dataplane realized it as a **silent drop** — no ICMP unreachable / TCP RST — unlike policy `reject`, which synthesizes and transmits an active reply. The same `reject` keyword behaved differently between policies and firewall filters (a fail-closed feature/parity gap; codex review-037 finding 037-02).

## Fix — reuse, don't diverge
`poll_descriptor/reject_reply.rs` now factors the synthesis + output-classification body into a shared `enqueue_reject_reply(..., source)` taking a `RejectReplySource{Policy,Filter}` selector. `enqueue_policy_reject_reply` and the new `enqueue_filter_reject_reply` are thin wrappers that differ **only** in the success counter (`policy_reject_sent` vs `filter_reject_sent`). Both:
- build a TCP RST for TCP, an ICMP/ICMPv6 admin-prohibited Destination Unreachable otherwise;
- run the generated reply through the **#2238 output-filter / CoS / DSCP classification** (`classify_generated_reply`, keyed on the reply's own egress tuple);
- gate on the SYN-cookie TX-frame budget;
- fail closed on budget / output-filter / parse-error (caller still drops the packet), sharing policy reject's drop counters.

Filter reject is wired at every input/lo0 filter drop site in `poll_descriptor/mod.rs` that previously recycled the descriptor on a terminal action: the new-flow input filter, the DSCP/L4-sensitive session-hit re-evaluation, and **both** lo0 (host-bound, control-plane-meaningful) local-delivery paths. `apply_lo0_filter_action` now returns the matched `FilterAction` (was a bare drop `bool`) so the caller can tell `Reject` from `Discard`. `then discard` is unchanged — still a silent drop.

## Classification parity decision
The issue asked for the generated reply to be classified the same way policy-reject's reply is. Policy reject **already** classifies its generated reply through output-filter / CoS / DSCP (#2238, `classify_generated_reply`). Filter reject routes through the **identical** path — no duplicate-and-diverge. (There was no policy-reject classification gap to match-and-defer.)

## Compose with #2472 (not built here)
Routing filter reject through the shared generated-reply path means #2472's future per-reason rate limiter — which hooks that shared path — covers filter reject **automatically**. No parallel, un-limitable emit path is created here. Rate-limiting itself is **not** implemented in this PR.

## Telemetry
- New `filter_reject_sent` counter mirroring `policy_reject_sent`, threaded through the full chain: `BatchCounters` (+ flush), `BindingLiveState` atomic (+ ctor), snapshot, worker snapshot, `refresh_bindings` copy/zero, Rust + Go wire DTOs. `serde default` / `omitempty` keep cross-version wire safety. `protocol_wire_v1.json` regenerated.
- `filter_action_to_rt_flow` now maps `Reject → REJECT` (was DENY), matching policy reject and Junos now that synthesis happens; `Discard` stays DENY.

## Scope (follow-up, not this PR)
Output-firewall-filter `then reject` realized on the **TX/CoS path** (`tx/cos_classify.rs`) still collapses `Reject` to a silent drop. That site lacks the descriptor/packet context the reflected-reply synthesis needs, so wiring it would be a divergent path — documented as a follow-up in `filter/README.md` and `docs/feature-gaps.md`.

## Validation
- `cargo build --release` clean (no new warnings); `go build ./pkg/dataplane/userspace` OK; gofmt/vet clean.
- Targeted suites (`filter`, `reject_reply`, `poll_descriptor`, `event_emit`, `wire_invariant`) **5/5 green**.
- **Fail-on-revert proven twice**:
  - reverting the filter wrapper's `RejectReplySource::Filter → Policy` fails the filter-reject counter tests;
  - reverting the compiler's `"reject" => Reject` to `Discard` fails `reject_action_compiles_distinct_from_discard`.
- `then discard` confirmed to remain a silent drop (no reply enqueued; RT_FLOW DENY).
- The pre-existing flaky `concurrent_recovery_processes_each_command_exactly_once` (unrelated concurrency timing test) passes in isolation 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi