### PR TITLE
config: warn that firewall-filter then loss-priority is inert (#2507)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12603,3 +12603,26 @@ top.
   fail-on-revert PROVEN twice (RejectReplySource::Filter→Policy fails the
   counter test; compiler reject→Discard fails reject_action_compiles_distinct);
   `then discard` still silent (no reply) confirmed; go build ./pkg/dataplane/userspace OK.
+
+## #2507 — firewall-filter `then loss-priority` accepted-but-inert warning (2026-06-24)
+- **Action**: Add commit WARNING for firewall-filter `then loss-priority`
+  (parsed/stored but no snapshot field, no dataplane consumer → silent QoS
+  no-op). Determined the WARN path (not wire path): grep of userspace-dp shows
+  the only packet "color" is the three-color policer's internally-metered color
+  consumed by `treatment_for`; `apply_term_three_color_policer` hardcodes
+  `PacketColor::Green` and color-aware mode is fail-closed per the filter
+  README — there is NO per-packet loss-priority consumer to wire into. Honest
+  scoped fix = warn, mark feature partial (same principle as #2486 ipsec-vpn).
+- **File(s)**:
+  - pkg/config/compiler_validate_warn.go — `validateFilterLossPriorityWarnings`
+    (WARN-only, once per filter/term, sorted-deterministic, both inet/inet6),
+    wired into ValidateConfig; added `sort` import.
+  - pkg/config/compiler_filter_loss_priority_2507_test.go — new tests
+    (warns-inert, commit-succeeds/no-reject, no-false-positive).
+  - docs/feature-gaps.md — new "Filter loss-priority action" PARTIAL row +
+    paragraph; summary counts 2|0|0|2 → 2|1|0|3, TOTAL 18→19 / 137→138.
+  - userspace-dp/src/filter/README.md — document the inert + commit-warning.
+- **Validation**: go build ./... OK; go test ./pkg/config/ ./pkg/dataplane/userspace/
+  PASS; gofmt clean; go vet ./pkg/config/ clean; fail-on-revert PROVEN
+  (removing the validateFilterLossPriorityWarnings call → warning absent →
+  TestFilterLossPriorityWarnsInert fails). No Rust code changed (README only).

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -33,14 +33,14 @@ Last updated: 2026-05-24
 | Routing Enhancements | 10 | 3 | 0 | 13 |
 | VPN Enhancements | 9 | 0 | 0 | 9 |
 | HA Enhancements | 0 | 2 | 0 | 2 |
-| Firewall Filter Enhancements | 2 | 0 | 0 | 2 |
+| Firewall Filter Enhancements | 2 | 1 | 0 | 3 |
 | QoS / Class of Service | 2 | 4 | 0 | 6 |
 | Multi-Tenancy | 4 | 0 | 0 | 4 |
 | Management & Automation | 12 | 2 | 0 | 14 |
 | Interface Enhancements | 1 | 1 | 0 | 2 |
 | System Enhancements | 5 | 0 | 0 | 5 |
 | Miscellaneous | 6 | 0 | 0 | 6 |
-| **TOTAL** | **119** | **18** | **0** | **137** |
+| **TOTAL** | **119** | **19** | **0** | **138** |
 
 **Implementation status key:**
 - **Fully Missing**: No config parsing or runtime support
@@ -387,7 +387,7 @@ xpf has a broad chassis cluster implementation with redundancy groups, RETH (VRR
 
 ## 17. Firewall Filter Enhancements
 
-xpf has firewall filters with source/dest addresses, prefix-lists (with except), DSCP, protocol, dest/source ports, ICMP type/code, TCP flags, fragment match, actions (accept/reject/discard), routing-instance, log, count, forwarding-class, loss-priority, DSCP rewrite, and IPv6 traffic-class matching.
+xpf has firewall filters with source/dest addresses, prefix-lists (with except), DSCP, protocol, dest/source ports, ICMP type/code, TCP flags, fragment match, actions (accept/reject/discard), routing-instance, log, count, forwarding-class, loss-priority (parse-only/inert — see below), DSCP rewrite, and IPv6 traffic-class matching.
 
 Filter `then reject` is now an **active** reject on the input and lo0
 (host-bound) paths (#2521): it synthesizes a TCP RST (TCP) or ICMP/ICMPv6
@@ -510,8 +510,26 @@ fail-OPEN for a `discard`/`reject` term (traffic the operator meant to drop via
 `except` is no longer dropped). Splitting into two terms is the operator
 workaround; the structured mixed case is a documented follow-up.
 
+**Firewall-filter `then loss-priority` is PARTIAL (parse-only, inert-with-warning, #2507).**
+`then loss-priority <low|medium-low|medium-high|high>` is parsed and stored on
+the term (`config.FirewallFilterTerm.LossPriority`) but is NOT carried on the
+snapshot wire (`FirewallTermSnapshot` has no loss-priority field) and the
+userspace dataplane has no per-packet loss-priority consumer: the three-color
+policer always meters at `PacketColor::Green` (`apply_term_three_color_policer`)
+and color-aware mode stays fail-closed until inherited packet color is carried
+through trusted metadata (`userspace-dp/src/filter/README.md`). So the action
+commits but does nothing. To avoid a silent QoS no-op, the commit now emits a
+WARN-only message naming the family/filter/term
+(`validateFilterLossPriorityWarnings`, `pkg/config/compiler_validate_warn.go`),
+mirroring the existing CoS classifier/rewrite loss-priority warnings. It is a
+warning, never a reject — loss-priority is valid Junos and a hard reject would
+brick a config that was previously accepted. Wiring an actual per-packet
+loss-priority action onto the egress CoS/drop-profile path is the follow-up;
+until then the action is documented as inert.
+
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
+| **Filter loss-priority action** | `firewall filter ... term ... then loss-priority <level>` | Mark a packet's packet-loss-priority for downstream drop-profile / congestion behavior | Low | Partial (#2507): parsed and stored, but NOT wired to the snapshot wire and inert in the userspace dataplane (no per-packet loss-priority consumer; three-color policer meters at green only). Commit emits a WARN naming the filter/term that the action is accepted-but-inert. |
 | **Policer (Rate Limiting)** | `firewall policer ... bandwidth-limit N burst-size-limit N` | Token-bucket rate limiter applied to filter terms or interfaces. Single-rate two-color, three-color policers. | High | Partial for #1373: legacy eBPF/~~DPDK~~ (DPDK retired #1525) token-bucket policer support existed; userspace supports the admitted filter path and the color-blind `then discard` three-color slice. #1375 is closed; unsupported color-aware/non-drop behavior and broader Junos parity remain production/future parity work, not active #1373 source-removal blockers. |
 | **Three-Color Policer** | `firewall three-color-policer ...` | RFC 2697/2698 metering with green/yellow/red marking based on CIR/CBS/EBS or CIR/PIR | Medium | Legacy eBPF/~~DPDK~~ (DPDK retired #1525) done; userspace AF_XDP supports color-blind `then discard` with compatible snapshot continuity. #1375 is closed; remaining color-aware/non-drop action parity plus integration, failover, and performance hardening are production/future parity work, not active #1373 source-removal blockers. |
 | **Interface Policer** | `firewall policer ... logical-interface-policer` | Aggregate rate limiting across all protocol families on a logical interface | Low | Missing |

--- a/pkg/config/compiler_filter_loss_priority_2507_test.go
+++ b/pkg/config/compiler_filter_loss_priority_2507_test.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// compileSetLinesT compiles a list of `set ...` lines into a *Config using the
+// flat-set path (ParseSetCommand + SetPath), per the project rule never to feed
+// multiple set lines through NewParser (it merges newlines as whitespace).
+func compileSetLinesT(t *testing.T, lines []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile error: %v", err)
+	}
+	return cfg
+}
+
+// TestFilterLossPriorityWarnsInert proves #2507: a firewall-filter term with
+// `then loss-priority <level>` commits successfully (loss-priority is valid
+// Junos), but emits a commit WARNING that the action is accepted-but-inert in
+// the userspace dataplane, naming the family/filter/term.
+//
+// Fail-on-revert: deleting the validateFilterLossPriorityWarnings call (or the
+// per-term append) removes the warning and this test fails.
+func TestFilterLossPriorityWarnsInert(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set firewall family inet filter mark term mark-high then loss-priority high",
+		"set firewall family inet filter mark term mark-high then accept",
+	})
+
+	warnings := ValidateConfig(cfg)
+
+	var got string
+	for _, w := range warnings {
+		if strings.Contains(w, "loss-priority") && strings.Contains(w, "filter") {
+			got = w
+			break
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected a firewall-filter loss-priority inert warning, got warnings: %v", warnings)
+	}
+	for _, want := range []string{"inet", "mark", "mark-high", "high", "inert"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning %q missing substring %q", got, want)
+		}
+	}
+}
+
+// TestFilterLossPriorityCommitSucceeds confirms the warning does NOT fail-close
+// the commit: loss-priority is valid Junos and must be accepted (warn, never
+// reject) so an existing config is never bricked. CompileConfig already
+// succeeded in compileSetLinesT; here we additionally assert the strict
+// commit-check action validator does not reject the term.
+func TestFilterLossPriorityCommitSucceeds(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set system dataplane-type userspace",
+		"set firewall family inet filter mark term mark-high then loss-priority high",
+		"set firewall family inet filter mark term mark-high then accept",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("loss-priority must commit (warn, not reject): %v", err)
+	}
+	if err := SchemaValidate(tree, cfg); err != nil {
+		t.Fatalf("SchemaValidate rejected a valid loss-priority filter: %v", err)
+	}
+	// Sanity: the term actually carries the parsed loss-priority.
+	f := cfg.Firewall.FiltersInet["mark"]
+	if f == nil || len(f.Terms) == 0 || f.Terms[0].LossPriority != "high" {
+		t.Fatalf("expected term to store LossPriority=high, got %+v", f)
+	}
+}
+
+// TestFilterLossPriorityNoFalsePositive confirms a filter WITHOUT loss-priority
+// emits no such warning (the warn loop is gated on the action being present).
+func TestFilterLossPriorityNoFalsePositive(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set firewall family inet filter plain term t1 then accept",
+	})
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "loss-priority") && strings.Contains(w, "filter") {
+			t.Fatalf("unexpected loss-priority warning for a filter with no loss-priority action: %q", w)
+		}
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 )
 
@@ -734,6 +735,60 @@ func ValidateConfig(cfg *Config) []string {
 	// against increment 1 cannot brick a boot (plan §4.5 / §7 Q-C).
 	warnings = append(warnings, validateDDNSBackendWarnings(cfg)...)
 
+	// #2507: firewall-filter `then loss-priority <low|...|high>` is parsed and
+	// stored on the term (FirewallFilterTerm.LossPriority) but is never wired
+	// onto the wire (no FirewallTermSnapshot field) and the userspace dataplane
+	// has no per-packet loss-priority consumer — the three-color policer always
+	// meters at PacketColor::Green and color-aware mode stays fail-closed until
+	// inherited packet color is carried through trusted metadata (see
+	// userspace-dp/src/filter/README.md). So the action commits and silently
+	// does nothing. Mirror the CoS classifier/rewrite loss-priority warning
+	// above: WARN-only (loss-priority is valid Junos — never fail the commit),
+	// once per filter/term, naming the filter and term so the operator knows
+	// the QoS action is inert. Same principle as #2486 (ipsec-vpn): never
+	// silently accept config the dataplane cannot enforce.
+	warnings = append(warnings, validateFilterLossPriorityWarnings(cfg)...)
+
+	return warnings
+}
+
+// validateFilterLossPriorityWarnings emits a WARN-only commit-time message for
+// each firewall-filter term carrying `then loss-priority`. The action is parsed
+// and stored but has no runtime consumer in the userspace dataplane (#2507), so
+// it is accepted-but-inert. It is never an error: loss-priority is valid Junos
+// and a hard reject would brick a boot on a previously-inert committed value.
+func validateFilterLossPriorityWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var warnings []string
+	emit := func(family string, filters map[string]*FirewallFilter) {
+		// Stable order: iterate by sorted filter name so warnings are
+		// deterministic across commits (map iteration is randomized).
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil || term.LossPriority == "" {
+					continue
+				}
+				warnings = append(warnings, fmt.Sprintf(
+					"firewall family %s filter %q term %q `then loss-priority %s` is "+
+						"accepted for compatibility but is inert in the userspace "+
+						"dataplane (no per-packet loss-priority action is enforced)",
+					family, name, term.Name, term.LossPriority))
+			}
+		}
+	}
+	emit("inet", cfg.Firewall.FiltersInet)
+	emit("inet6", cfg.Firewall.FiltersInet6)
 	return warnings
 }
 

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -131,6 +131,14 @@ Remaining limitations:
   fail-closed until downstream loss-priority behavior is wired. Color-aware
   mode also stays fail-closed until inherited packet color is carried through
   trusted metadata.
+- Firewall-filter `then loss-priority <level>` (#2507) is likewise NOT wired:
+  it carries no `FirewallTermSnapshot` field and there is no per-packet
+  loss-priority consumer here (`apply_term_three_color_policer` always meters at
+  `PacketColor::Green`). The Go control plane emits a commit WARNING that the
+  action is accepted-but-inert (`validateFilterLossPriorityWarnings` in
+  `pkg/config/compiler_validate_warn.go`) rather than silently committing a
+  QoS no-op. Wiring a real per-packet loss-priority action onto the egress
+  CoS/drop-profile path is a follow-up.
 - Traffic-level integration, failover, and performance evidence remain
   production-hardening follow-ups for #1375, not active feature-gap blockers.
 


### PR DESCRIPTION
## Summary
Firewall-filter `then loss-priority <low|medium-low|medium-high|high>` was parsed and stored on the term but never reached the userspace dataplane and emitted **no commit warning** — it committed and silently did nothing (codex review-036 finding 3, MEDIUM, #2507).

## Consumer-exists determination (the design fork)
**No runtime consumer exists → WARN path is correct.** Grep evidence:
- `FirewallTermSnapshot` (`pkg/dataplane/userspace/protocol.go`) carries `ForwardingClass` + `DSCPRewrite` but **no** loss-priority field; `filters.go` copies `ForwardingClass`, not `LossPriority`.
- The only "color" in `userspace-dp` is the three-color policer's **internally-metered** color consumed by `treatment_for` within the policer. `apply_term_three_color_policer` (`userspace-dp/src/filter/engine/policer.rs`) hardcodes `runtime.meter(..., PacketColor::Green)` and `apply_cached_three_color_policers` likewise — the incoming color is never an inherited per-packet loss priority.
- `userspace-dp/src/filter/README.md`: loss-priority propagation and color-aware mode stay **fail-closed until inherited packet color is carried through trusted metadata**.

So a filter `then loss-priority` value is read **nowhere** on the CoS/queue/shaper path. Wiring a snapshot field would terminate in a no-op. Honest scoped fix = warn + mark partial (same principle as #2486 ipsec-vpn: don't silently accept config the dataplane can't enforce).

## Chosen path: commit WARNING
`validateFilterLossPriorityWarnings` (`pkg/config/compiler_validate_warn.go`) emits a **WARN-only** message naming family/filter/term that the action is accepted-but-inert, mirroring the existing CoS classifier/rewrite loss-priority warnings in the same file. **Never a reject** — loss-priority is valid Junos and a hard reject would brick a previously-accepted config. Sorted-deterministic iteration; both `inet` + `inet6`.

## Tests (fail-on-revert)
- `TestFilterLossPriorityWarnsInert` — warning emitted, names inet/filter/term/level/inert. **Fail-on-revert PROVEN**: removing the `validateFilterLossPriorityWarnings` call drops the warning → test fails.
- `TestFilterLossPriorityCommitSucceeds` — `CompileConfig` + `SchemaValidate` both succeed (warn, not reject); term still stores `LossPriority=high`.
- `TestFilterLossPriorityNoFalsePositive` — filter without loss-priority emits no such warning.

## Docs
- `docs/feature-gaps.md`: new "Filter loss-priority action" PARTIAL row + paragraph; counts 2|0|0|2 → 2|1|0|3, TOTAL 18→19 / 137→138.
- `userspace-dp/src/filter/README.md`: records the inert state + commit warning (README only, no Rust code changed).

## Validation
`go build ./...`; `go test ./pkg/config/ ./pkg/dataplane/userspace/`; `gofmt` clean; `go vet ./pkg/config/` — all green.

Closes #2507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi