### PR TITLE
config: warn that pre-id-default-policy then-log is inert (#2509)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12626,3 +12626,26 @@ top.
   PASS; gofmt clean; go vet ./pkg/config/ clean; fail-on-revert PROVEN
   (removing the validateFilterLossPriorityWarnings call → warning absent →
   TestFilterLossPriorityWarnsInert fails). No Rust code changed (README only).
+
+## 2026-06-24 — #2509 pre-id-default-policy then-log accepted-but-inert warning
+
+- **Timestamp**: 2026-06-24 PDT
+- **Action**: WARN-INERT fix for #2509. Determined (from source) that the
+  userspace dataplane has NO pre-identification session-admit path: the only
+  reader of PreIDDefaultPolicy.LogSessionInit/LogSessionClose was the retired
+  eBPF compiler (pkg/dataplane/compiler.go → FlowConfigValue.AppFlags). Unlike
+  per-policy #2508 (which stamps the admitting policy's log flags onto session
+  metadata at install), there is no session admitted "before app-id resolves"
+  to stamp onto — app-id is best-effort labeling of already-admitted sessions.
+  So WIRE would dead-end in a no-op. Chose WARN-INERT, mirroring #2507 filter
+  loss-priority + the CoS loss-priority warnings: commit succeeds with a
+  WARNING that the action is accepted-but-inert; never a reject (valid Junos).
+- **File(s)**: pkg/config/compiler_validate_warn.go (validatePreIDDefaultPolicyLogWarnings
+  + ValidateConfig wiring), pkg/config/compiler_preid_default_policy_log_2509_test.go
+  (4 tests: warns-inert both-modes, init-only-warns, commit-succeeds-no-fail-close,
+  no-log-no-warning), docs/feature-gaps.md (PARTIAL note + table row).
+- **Validation**: go build ./... OK; go test ./pkg/config/ ./pkg/dataplane/userspace/
+  ./pkg/logging/ PASS; gofmt clean; go vet ./pkg/config/ clean; fail-on-revert
+  PROVEN (removing the validatePreIDDefaultPolicyLogWarnings call → warning
+  absent → TestPreIDDefaultPolicyLogWarnsInert + InitOnlyWarns fail). No Rust
+  changed.

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -527,9 +527,31 @@ brick a config that was previously accepted. Wiring an actual per-packet
 loss-priority action onto the egress CoS/drop-profile path is the follow-up;
 until then the action is documented as inert.
 
+**`security pre-id-default-policy then log` is PARTIAL (parse-only, inert-with-warning, #2509).**
+`security pre-id-default-policy then log session-init/session-close` is parsed
+and stored on `config.PreIDDefaultPolicy.LogSessionInit/LogSessionClose` but has
+NO consumer in the userspace dataplane after the eBPF retirement (#1373/#1476).
+The only reader was the retired eBPF compiler (`pkg/dataplane/compiler.go`,
+which mapped the bits to `FlowConfigValue.AppFlags`). Unlike the per-policy
+#2508 path — where the admitting policy's log flags are stamped onto session
+metadata at install and gate RT_FLOW emission — the userspace runtime has no
+pre-identification session-admit path: app-id is best-effort labeling of
+already-admitted sessions, not a "default policy admits the session before
+app-id resolves, then re-evaluate" pipeline. There is therefore no session to
+stamp the pre-id log mode onto, and no field is wired to the dataplane (wiring
+one would dead-end in a no-op). To avoid a silent logging no-op, the commit now
+emits a WARN-only message naming the configured mode(s)
+(`validatePreIDDefaultPolicyLogWarnings`, `pkg/config/compiler_validate_warn.go`),
+mirroring the #2507 filter loss-priority / CoS loss-priority warnings. It is a
+warning, never a reject — pre-id-default-policy is valid Junos and a hard reject
+would brick a config that was previously accepted. Adding a real
+pre-identification session-admit + re-evaluation pipeline is the prerequisite
+follow-up before this logging signal can be produced.
+
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
 | **Filter loss-priority action** | `firewall filter ... term ... then loss-priority <level>` | Mark a packet's packet-loss-priority for downstream drop-profile / congestion behavior | Low | Partial (#2507): parsed and stored, but NOT wired to the snapshot wire and inert in the userspace dataplane (no per-packet loss-priority consumer; three-color policer meters at green only). Commit emits a WARN naming the filter/term that the action is accepted-but-inert. |
+| **Pre-ID default-policy logging** | `security pre-id-default-policy then log session-init session-close` | Log sessions admitted under the pre-identification default policy (before app-id resolves) | Medium | Partial (#2509): parsed and stored, but NOT wired to the dataplane and inert in userspace — there is no pre-identification session-admit path (no session to stamp the log mode onto, unlike per-policy #2508). Commit emits a WARN that the action is accepted-but-inert. |
 | **Policer (Rate Limiting)** | `firewall policer ... bandwidth-limit N burst-size-limit N` | Token-bucket rate limiter applied to filter terms or interfaces. Single-rate two-color, three-color policers. | High | Partial for #1373: legacy eBPF/~~DPDK~~ (DPDK retired #1525) token-bucket policer support existed; userspace supports the admitted filter path and the color-blind `then discard` three-color slice. #1375 is closed; unsupported color-aware/non-drop behavior and broader Junos parity remain production/future parity work, not active #1373 source-removal blockers. |
 | **Three-Color Policer** | `firewall three-color-policer ...` | RFC 2697/2698 metering with green/yellow/red marking based on CIR/CBS/EBS or CIR/PIR | Medium | Legacy eBPF/~~DPDK~~ (DPDK retired #1525) done; userspace AF_XDP supports color-blind `then discard` with compatible snapshot continuity. #1375 is closed; remaining color-aware/non-drop action parity plus integration, failover, and performance hardening are production/future parity work, not active #1373 source-removal blockers. |
 | **Interface Policer** | `firewall policer ... logical-interface-policer` | Aggregate rate limiting across all protocol families on a logical interface | Low | Missing |

--- a/pkg/config/compiler_preid_default_policy_log_2509_test.go
+++ b/pkg/config/compiler_preid_default_policy_log_2509_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPreIDDefaultPolicyLogWarnsInert proves #2509: a
+// `security pre-id-default-policy then log session-init/session-close` stanza
+// commits successfully (pre-id-default-policy is valid Junos) but emits a
+// commit WARNING that the logging action is accepted-but-inert in the
+// userspace dataplane (no pre-identification session-admit path exists to
+// stamp the log mode onto, unlike the per-policy #2508 path).
+//
+// Fail-on-revert: deleting the validatePreIDDefaultPolicyLogWarnings call (or
+// the append) removes the warning and this test fails.
+func TestPreIDDefaultPolicyLogWarnsInert(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set security pre-id-default-policy then log session-init",
+		"set security pre-id-default-policy then log session-close",
+	})
+
+	warnings := ValidateConfig(cfg)
+
+	var got string
+	for _, w := range warnings {
+		if strings.Contains(w, "pre-id-default-policy") && strings.Contains(w, "inert") {
+			got = w
+			break
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected a pre-id-default-policy log inert warning, got warnings: %v", warnings)
+	}
+	for _, want := range []string{"session-init", "session-close", "inert", "userspace"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning %q missing substring %q", got, want)
+		}
+	}
+}
+
+// TestPreIDDefaultPolicyLogInitOnlyWarns confirms the warning names only the
+// configured mode (session-init alone), mirroring the #2508 per-policy log
+// matrix where init-only and close-only are distinct.
+func TestPreIDDefaultPolicyLogInitOnlyWarns(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set security pre-id-default-policy then log session-init",
+	})
+
+	var got string
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "pre-id-default-policy") && strings.Contains(w, "inert") {
+			got = w
+			break
+		}
+	}
+	if got == "" {
+		t.Fatalf("expected an init-only pre-id-default-policy warning")
+	}
+	if !strings.Contains(got, "session-init") {
+		t.Errorf("init-only warning %q missing session-init", got)
+	}
+	if strings.Contains(got, "session-close") {
+		t.Errorf("init-only warning %q wrongly mentions session-close", got)
+	}
+}
+
+// TestPreIDDefaultPolicyLogCommitSucceeds confirms the warning does NOT
+// fail-close the commit: pre-id-default-policy then log is valid Junos and must
+// be accepted (warn, never reject) so an existing config is never bricked.
+// CompileConfig already succeeded in compileSetLinesT; here we additionally
+// assert the strict commit-check validator does not reject the stanza, and
+// that the flags are actually stored.
+func TestPreIDDefaultPolicyLogCommitSucceeds(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set system dataplane-type userspace",
+		"set security pre-id-default-policy then log session-init",
+		"set security pre-id-default-policy then log session-close",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("pre-id-default-policy log must commit (warn, not reject): %v", err)
+	}
+	if err := SchemaValidate(tree, cfg); err != nil {
+		t.Fatalf("SchemaValidate rejected a valid pre-id-default-policy log stanza: %v", err)
+	}
+	p := cfg.Security.PreIDDefaultPolicy
+	if p == nil || !p.LogSessionInit || !p.LogSessionClose {
+		t.Fatalf("expected PreIDDefaultPolicy to store both log flags, got %+v", p)
+	}
+}
+
+// TestPreIDDefaultPolicyNoLogNoWarning confirms a pre-id-default-policy stanza
+// with no `then log` (or no stanza at all) emits no such warning — the warn is
+// gated on the log flags being present.
+func TestPreIDDefaultPolicyNoLogNoWarning(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set security policies default-policy deny-all",
+	})
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "pre-id-default-policy") {
+			t.Fatalf("unexpected pre-id-default-policy warning when no then-log is configured: %q", w)
+		}
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -749,7 +749,56 @@ func ValidateConfig(cfg *Config) []string {
 	// silently accept config the dataplane cannot enforce.
 	warnings = append(warnings, validateFilterLossPriorityWarnings(cfg)...)
 
+	// #2509: `security pre-id-default-policy then log session-init/session-close`
+	// is parsed and stored on PreIDDefaultPolicy.LogSessionInit/LogSessionClose
+	// but has NO consumer in the userspace dataplane after the eBPF retirement
+	// (#1373/#1476). The only reader was the retired eBPF compiler
+	// (pkg/dataplane/compiler.go, which mapped the bits to FlowConfigValue.
+	// AppFlags). The userspace runtime has no pre-identification session-admit
+	// path: app-id is best-effort labeling of already-admitted sessions, not a
+	// "default policy admits the session before app-id resolves, then
+	// re-evaluate" pipeline, so there is no session to stamp the pre-id log
+	// mode onto (unlike the per-policy #2508 path, which stamps the admitting
+	// policy's log flags at install). The stanza therefore commits and is
+	// silently inert. Mirror the #2507 filter loss-priority / CoS
+	// loss-priority warnings: WARN-only (pre-id-default-policy is valid Junos —
+	// never fail the commit; a hard reject would brick a boot on a
+	// previously-inert committed value), naming the inert action so the
+	// operator knows the logging signal is not produced.
+	warnings = append(warnings, validatePreIDDefaultPolicyLogWarnings(cfg)...)
+
 	return warnings
+}
+
+// validatePreIDDefaultPolicyLogWarnings emits a WARN-only commit-time message
+// when `security pre-id-default-policy then log session-init/session-close` is
+// configured. The flags are parsed and stored but have no runtime consumer in
+// the userspace dataplane (#2509) — there is no pre-identification
+// session-admit path to stamp the log mode onto — so the logging action is
+// accepted-but-inert. It is never an error: pre-id-default-policy is valid
+// Junos and a hard reject would brick a boot on a previously-inert committed
+// value.
+func validatePreIDDefaultPolicyLogWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	p := cfg.Security.PreIDDefaultPolicy
+	if p == nil || (!p.LogSessionInit && !p.LogSessionClose) {
+		return nil
+	}
+	var modes []string
+	if p.LogSessionInit {
+		modes = append(modes, "session-init")
+	}
+	if p.LogSessionClose {
+		modes = append(modes, "session-close")
+	}
+	return []string{fmt.Sprintf(
+		"security pre-id-default-policy `then log %s` is accepted for "+
+			"compatibility but is inert in the userspace dataplane (no "+
+			"pre-identification session-admit path exists to emit the "+
+			"RT_FLOW session log)",
+		strings.Join(modes, "/"))}
 }
 
 // validateFilterLossPriorityWarnings emits a WARN-only commit-time message for


### PR DESCRIPTION
## Summary

Fixes #2509 (MEDIUM, codex review-036 finding 5): `security
pre-id-default-policy then log session-init/session-close` was parsed and
stored on `PreIDDefaultPolicy.LogSessionInit/LogSessionClose` but had no
consumer in the userspace dataplane after the eBPF retirement — it committed
and was silently inert (the PRE-ID sibling of the per-policy #2508 finding).

## Determination: WARN-INERT, not WIRE

I verified against source on the PR base (origin/master, includes #2508):

- The **only** reader of `PreIDDefaultPolicy.Log*` is the **retired eBPF
  compiler** `pkg/dataplane/compiler.go:1088` (maps the bits to
  `FlowConfigValue.AppFlags`). Per CLAUDE.md, that file is not the enforcement
  path. The userspace adapter (`pkg/dataplane/userspace/`) and `userspace-dp/`
  never read these flags.
- `grep` for `pre-id` / `pre_id` / `pre-identif` / `app-id-pending` across
  `userspace-dp/src/` and `pkg/dataplane/userspace/` returns **no consumer**.
  The only `default_policy` in userspace is the zone-pair firewall default
  action (permit/deny fallback) — a different concept.
- **There is no pre-identification session-admit path.** App-id in userspace is
  best-effort labeling of *already-admitted* sessions
  (`pkg/dataplane/userspace/flow.go:142`), not a "default policy admits the
  session before app-id resolves, then re-evaluate" pipeline. #2508 works
  because it stamps the *admitting policy's* log flags onto session metadata at
  install; there is no analogous pre-id-admitted session to stamp the pre-id
  default policy's log mode onto.

Therefore wiring `PreIDDefaultPolicy.Log*` to the dataplane would dead-end in a
no-op. Per the prompt's "prefer the smaller correct fix; do NOT wire a field
that dead-ends in a no-op", this is the **WARN-INERT** fork.

## Change

- `validatePreIDDefaultPolicyLogWarnings` (`pkg/config/compiler_validate_warn.go`)
  emits a WARN-only commit message naming the configured mode(s) when
  pre-id-default-policy then-log is set, wired into `ValidateConfig`. Mirrors the
  #2507 filter loss-priority and CoS loss-priority warnings. **Never a reject** —
  pre-id-default-policy is valid Junos; a hard reject would brick a boot on a
  previously-inert committed value.
- `docs/feature-gaps.md`: PARTIAL note + table row (parse-only / inert-with-warning;
  the missing pre-id pipeline is the prerequisite follow-up).

No new wire field, so no #1961 wire-parity work and no Rust change.

## Tests (fail-on-revert)

`pkg/config/compiler_preid_default_policy_log_2509_test.go`, folded into the
#2507/#2508 warn-matrix style:
- `TestPreIDDefaultPolicyLogWarnsInert` — both modes → warning naming
  session-init/session-close + inert + userspace.
- `TestPreIDDefaultPolicyLogInitOnlyWarns` — init-only → warning names
  session-init and NOT session-close.
- `TestPreIDDefaultPolicyLogCommitSucceeds` — no fail-close: CompileConfig +
  SchemaValidate accept, both flags stored.
- `TestPreIDDefaultPolicyNoLogNoWarning` — no then-log → no such warning.

Fail-on-revert PROVEN: removing the `validatePreIDDefaultPolicyLogWarnings` call
drops the warning → WarnsInert + InitOnlyWarns fail.

## Validation

`go build ./...` clean; `go test ./pkg/config/ ./pkg/dataplane/userspace/
./pkg/logging/` all green; gofmt clean; `go vet ./pkg/config/` clean.

Closes #2509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi