### PR TITLE
config/bgp: gate group address-family flags by neighbor IP version (#2454)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12865,3 +12865,28 @@ top.
   next emission makes term 1 terminating in FRR, term 2 never runs →
   TestGeneratePolicyOptions_MultiTermOnMatchNext fails (the terminating-term
   guard still passes). No Rust changed.
+
+## 2026-06-24 — #2454 BGP group address-family flags gated by neighbor address version
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fix #2454 (MED, agy review-033 finding 15). BGP group-level
+  `family inet`/`family inet6` flags were copied to EVERY neighbor in the
+  group regardless of the neighbor's IP version. A dual-stack group set both
+  FamilyInet and FamilyInet6 on a bare IPv4 neighbor → renderer emitted
+  `neighbor <ipv4> activate` under `address-family ipv6 unicast`, invalid
+  without RFC 5549 extended-nexthop (no such knob in the config model) →
+  broke the peer's AF activation.
+- **Fix**: In compiler_protocols.go, parse the neighbor address
+  (`net.ParseIP`) when inheriting group family flags; an IPv4 address gets
+  only FamilyInet, an IPv6 address only FamilyInet6. Unparseable address
+  (hostname/template) preserves pre-#2454 behavior (inherits both, no crash).
+  Per-neighbor explicit `family` clause stays operator-authoritative.
+- **File(s)**: pkg/config/compiler_protocols.go (gate),
+  pkg/config/parser_routing_test.go (3 new fail-on-revert tests +
+  corrected TestBGPGroupExportFamily / TestBGPPrefixLimitSetSyntax which
+  encoded the bug), pkg/frr/frr_test.go (end-to-end compile→render
+  fail-on-revert test), pkg/frr/README.md (gate doc), _Log.md.
+- **Validation**: go build ./... OK; go test ./pkg/config/ ./pkg/frr/ PASS;
+  gofmt clean; go vet clean. Fail-on-revert PROVEN — neutralizing the gate
+  makes the IPv4 neighbor appear under `address-family ipv6 unicast` and the
+  new tests fail. Go-only, no Rust touched.

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -348,6 +348,31 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 				case "neighbor":
 					nAddr := nodeVal(child)
 					if nAddr != "" {
+						// Gate group-level address-family flags by the
+						// neighbor's own address version (#2454). A
+						// dual-stack group (family inet AND inet6) must NOT
+						// activate a bare IPv4 neighbor under
+						// `address-family ipv6 unicast` (and vice versa):
+						// without RFC 5549 extended-nexthop (which this
+						// config model has no knob for) activating an IPv4
+						// address for IPv6 unicast is invalid and breaks the
+						// peer's AF activation. So an IPv4-addressed neighbor
+						// inherits only the group's inet flag, an
+						// IPv6-addressed neighbor only inet6.
+						//
+						// An address that does not parse (a hostname/peer-
+						// group template or a malformed value) is left to
+						// inherit BOTH group flags unchanged — preserving
+						// pre-#2454 behavior for the non-literal-IP case
+						// rather than silently dropping a family.
+						inheritInet, inheritInet6 := familyInet, familyInet6
+						if ip := net.ParseIP(nAddr); ip != nil {
+							if ip.To4() != nil {
+								inheritInet6 = false
+							} else {
+								inheritInet = false
+							}
+						}
 						neighbor := &BGPNeighbor{
 							Address:          nAddr,
 							PeerAS:           peerAS,
@@ -355,8 +380,8 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 							MultihopTTL:      groupMultihop,
 							Export:           groupExport,
 							Import:           groupImport,
-							FamilyInet:       familyInet,
-							FamilyInet6:      familyInet6,
+							FamilyInet:       inheritInet,
+							FamilyInet6:      inheritInet6,
 							GroupName:        groupInst.name,
 							AuthPassword:     Secret(groupAuthKey),
 							BFD:              groupBFD,

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -948,8 +948,13 @@ func TestBGPGroupExportFamily(t *testing.T) {
 	if !n.FamilyInet {
 		t.Error("neighbor should have FamilyInet=true")
 	}
-	if !n.FamilyInet6 {
-		t.Error("neighbor should have FamilyInet6=true")
+	// #2454: a bare IPv4 neighbor in a dual-stack group inherits ONLY the
+	// inet family. Inheriting FamilyInet6 made the renderer emit
+	// `neighbor 10.1.0.1 activate` under `address-family ipv6 unicast`,
+	// which is invalid without RFC 5549 extended-nexthop. This assertion is
+	// a fail-on-revert anchor for the address-version gate.
+	if n.FamilyInet6 {
+		t.Error("IPv4 neighbor must NOT inherit group FamilyInet6 (#2454)")
 	}
 	if len(n.Export) != 1 || n.Export[0] != "my-export-policy" {
 		t.Errorf("neighbor export = %v, want [my-export-policy]", n.Export)
@@ -1927,8 +1932,12 @@ func TestBGPPrefixLimitSetSyntax(t *testing.T) {
 	if !n.FamilyInet {
 		t.Error("FamilyInet should be true")
 	}
-	if !n.FamilyInet6 {
-		t.Error("FamilyInet6 should be true")
+	// #2454: 10.0.0.2 is an IPv4 address, so it must NOT inherit the group's
+	// inet6 family flag (that would activate it under ipv6 unicast, invalid
+	// without RFC 5549). The inherited PrefixLimitInet6 below stays populated
+	// but is inert because FamilyInet6 is false.
+	if n.FamilyInet6 {
+		t.Error("IPv4 neighbor must NOT inherit group FamilyInet6 (#2454)")
 	}
 	if n.PrefixLimitInet != 1000 {
 		t.Errorf("PrefixLimitInet = %d, want 1000", n.PrefixLimitInet)
@@ -3469,5 +3478,149 @@ func TestPolicyTermMultiProtocolSeparateSetCommands(t *testing.T) {
 	}
 	if ps.Terms[0].Action != "accept" {
 		t.Errorf("action = %q, want accept", ps.Terms[0].Action)
+	}
+}
+
+// TestBGPGroupFamilyGatedByNeighborAddressVersion is the fail-on-revert guard
+// for #2454: group-level address-family flags must be gated by each neighbor's
+// own address version when inherited. A dual-stack group (family inet AND
+// family inet6) must NOT mark a bare IPv4 neighbor FamilyInet6 (which made the
+// renderer emit `neighbor <ipv4> activate` under `address-family ipv6 unicast`
+// — invalid without RFC 5549 extended-nexthop), nor a bare IPv6 neighbor
+// FamilyInet. Revert the address-version gate in compiler_protocols.go and the
+// FamilyInet6/FamilyInet assertions below flip and fail.
+func TestBGPGroupFamilyGatedByNeighborAddressVersion(t *testing.T) {
+	tree := &ConfigTree{}
+	setCommands := []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group dual peer-as 65002",
+		"set protocols bgp group dual family inet unicast",
+		"set protocols bgp group dual family inet6 unicast",
+		"set protocols bgp group dual neighbor 10.0.0.2",
+		"set protocols bgp group dual neighbor 2001:db8::2",
+	}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.BGP == nil {
+		t.Fatal("BGP config is nil")
+	}
+	var v4, v6 *BGPNeighbor
+	for _, n := range cfg.Protocols.BGP.Neighbors {
+		switch n.Address {
+		case "10.0.0.2":
+			v4 = n
+		case "2001:db8::2":
+			v6 = n
+		}
+	}
+	if v4 == nil {
+		t.Fatal("missing IPv4 neighbor 10.0.0.2")
+	}
+	if v6 == nil {
+		t.Fatal("missing IPv6 neighbor 2001:db8::2")
+	}
+
+	// IPv4 neighbor inherits ONLY the group's inet flag.
+	if !v4.FamilyInet {
+		t.Error("IPv4 neighbor should inherit group FamilyInet")
+	}
+	if v4.FamilyInet6 {
+		t.Error("IPv4 neighbor must NOT inherit group FamilyInet6 (#2454: invalid v6-unicast activation of an IPv4 address)")
+	}
+
+	// IPv6 neighbor inherits ONLY the group's inet6 flag.
+	if !v6.FamilyInet6 {
+		t.Error("IPv6 neighbor should inherit group FamilyInet6")
+	}
+	if v6.FamilyInet {
+		t.Error("IPv6 neighbor must NOT inherit group FamilyInet (#2454: invalid v4-unicast activation of an IPv6 address)")
+	}
+}
+
+// TestBGPGroupFamilyV4OnlyNoOverGate guards against over-gating: a v4-only
+// group with an IPv4 neighbor must still keep the v4 family so the renderer
+// activates it under ipv4-unicast — the no-over-gate regression check from
+// #2454 (agy-10 was refuted: FRR default ipv4-unicast covers a family-less
+// neighbor, but an explicit family inet group must still surface FamilyInet).
+func TestBGPGroupFamilyV4OnlyNoOverGate(t *testing.T) {
+	tree := &ConfigTree{}
+	setCommands := []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group up peer-as 65002",
+		"set protocols bgp group up family inet unicast",
+		"set protocols bgp group up neighbor 10.0.0.2",
+	}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.BGP == nil || len(cfg.Protocols.BGP.Neighbors) != 1 {
+		t.Fatalf("expected 1 BGP neighbor, got %+v", cfg.Protocols.BGP)
+	}
+	n := cfg.Protocols.BGP.Neighbors[0]
+	if !n.FamilyInet {
+		t.Error("v4-only group: IPv4 neighbor must keep FamilyInet (no over-gate)")
+	}
+	if n.FamilyInet6 {
+		t.Error("v4-only group: IPv4 neighbor must not have FamilyInet6")
+	}
+}
+
+// TestBGPGroupFamilyUnparseableAddressInheritsBoth documents the edge-case
+// choice from #2454: a neighbor whose address is not a literal IP (a hostname
+// or peer-group template) cannot be classified by version, so it preserves the
+// pre-#2454 behavior of inheriting BOTH group family flags rather than silently
+// dropping a family. The compiler must NOT crash on the unparseable address.
+func TestBGPGroupFamilyUnparseableAddressInheritsBoth(t *testing.T) {
+	tree := &ConfigTree{}
+	setCommands := []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group dual peer-as 65002",
+		"set protocols bgp group dual family inet unicast",
+		"set protocols bgp group dual family inet6 unicast",
+		"set protocols bgp group dual neighbor peer.example.com",
+	}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.BGP == nil || len(cfg.Protocols.BGP.Neighbors) != 1 {
+		t.Fatalf("expected 1 BGP neighbor, got %+v", cfg.Protocols.BGP)
+	}
+	n := cfg.Protocols.BGP.Neighbors[0]
+	if n.Address != "peer.example.com" {
+		t.Fatalf("unexpected neighbor address %q", n.Address)
+	}
+	if !n.FamilyInet || !n.FamilyInet6 {
+		t.Errorf("unparseable address should inherit BOTH group families, got inet=%v inet6=%v", n.FamilyInet, n.FamilyInet6)
 	}
 }

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -174,6 +174,27 @@ move or rename the markers — they're literal strings.
   advertisement and defeating the operator's filter (the #2473 leak, inbound
   side). The referenced route-map is the same block `generatePolicyOptions`
   already emits for the policy-statement.
+- **Group address-family flags are gated by neighbor address version
+  (#2454).** When `compiler_protocols.go` copies a BGP group's `family inet`
+  / `family inet6` flags down to each neighbor, it parses the neighbor's
+  address (`net.ParseIP`) and inherits ONLY the matching family: an
+  IPv4-addressed neighbor gets `FamilyInet` (never `FamilyInet6`), an
+  IPv6-addressed neighbor gets `FamilyInet6` (never `FamilyInet`). Before
+  this gate, a dual-stack group (`family inet` AND `family inet6`) marked
+  BOTH flags on every neighbor regardless of its IP version, so the render's
+  `inet4Neighbors`/`inet6Neighbors` partition put a bare IPv4 neighbor into
+  the ipv6 set and emitted `neighbor <ipv4> activate` under
+  `address-family ipv6 unicast`. Activating an IPv4 address for IPv6 unicast
+  is invalid without RFC 5549 extended-nexthop (this config model has no
+  such knob), and FRR rejects/ignores the activation — breaking the peer's
+  AF setup. Edge cases: an address that is not a literal IP (a hostname or
+  peer-group template) cannot be classified, so it preserves the prior
+  behavior of inheriting BOTH group flags (no silent family drop, no crash);
+  a per-neighbor explicit `family` clause is operator-authoritative and is
+  applied as-is after the inherited flags. The gate does not over-restrict:
+  an IPv4 neighbor in a v4-only or family-less group still establishes — FRR
+  default `bgp default ipv4-unicast` auto-activates it, and an explicit
+  `family inet` group still surfaces `FamilyInet`.
 - **`resolveRedistribute` never emits an invalid `redistribute <name>`
   line (#2223).** FRR's `redistribute` requires a source-protocol token
   (`connected`/`static`/`ospf`/`bgp`/`rip`/`isis`/`kernel`); a bare

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -1237,6 +1237,89 @@ func TestBGPAddressFamily(t *testing.T) {
 	}
 }
 
+// TestBGPDualStackGroupActivatesByAddressVersion is the end-to-end fail-on-
+// revert guard for #2454: a dual-stack BGP group (family inet AND inet6) with
+// one IPv4 and one IPv6 neighbor, compiled from config then rendered to FRR,
+// must activate the IPv4 neighbor ONLY under address-family ipv4 unicast and
+// the IPv6 neighbor ONLY under ipv6 unicast. Before the compiler address-
+// version gate, the IPv4 neighbor was activated under ipv6 unicast too —
+// invalid without RFC 5549 extended-nexthop, which breaks AF activation.
+func TestBGPDualStackGroupActivatesByAddressVersion(t *testing.T) {
+	tree := &config.ConfigTree{}
+	setCommands := []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group dual peer-as 65002",
+		"set protocols bgp group dual family inet unicast",
+		"set protocols bgp group dual family inet6 unicast",
+		"set protocols bgp group dual neighbor 10.0.0.2",
+		"set protocols bgp group dual neighbor 2001:db8::2",
+	}
+	for _, cmd := range setCommands {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+
+	m := New()
+	got := m.generateProtocols(nil, nil, cfg.Protocols.BGP, nil, nil, "", 0, nil)
+
+	// Walk the rendered output tracking which address-family block each
+	// `activate` line falls in.
+	var af string
+	sawV4inV4, sawV6inV6, v4inV6, v6inV4 := false, false, false, false
+	for _, line := range strings.Split(got, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "address-family ipv4"):
+			af = "v4"
+		case strings.HasPrefix(trimmed, "address-family ipv6"):
+			af = "v6"
+		case trimmed == "exit-address-family":
+			af = ""
+		}
+		if !strings.HasSuffix(trimmed, " activate") {
+			continue
+		}
+		switch {
+		case strings.Contains(trimmed, "10.0.0.2"):
+			if af == "v4" {
+				sawV4inV4 = true
+			}
+			if af == "v6" {
+				v4inV6 = true
+			}
+		case strings.Contains(trimmed, "2001:db8::2"):
+			if af == "v6" {
+				sawV6inV6 = true
+			}
+			if af == "v4" {
+				v6inV4 = true
+			}
+		}
+	}
+
+	if !sawV4inV4 {
+		t.Error("IPv4 neighbor 10.0.0.2 must be activated under address-family ipv4 unicast")
+	}
+	if !sawV6inV6 {
+		t.Error("IPv6 neighbor 2001:db8::2 must be activated under address-family ipv6 unicast")
+	}
+	if v4inV6 {
+		t.Errorf("#2454: IPv4 neighbor 10.0.0.2 must NOT be activated under address-family ipv6 unicast\n%s", got)
+	}
+	if v6inV4 {
+		t.Errorf("IPv6 neighbor 2001:db8::2 must NOT be activated under address-family ipv4 unicast\n%s", got)
+	}
+}
+
 func TestGenerateProtocols_ECMPMaxPaths(t *testing.T) {
 	m := New()
 	bgp := &config.BGPConfig{


### PR DESCRIPTION
Closes #2454 (MED, agy review-033 finding 15).

## The bug
BGP group-level address-family flags (`family inet` / `family inet6`) were copied onto **every** neighbor in the group, ignoring each neighbor’s own address version. A dual-stack group (`family inet` AND `family inet6`) set both `FamilyInet` and `FamilyInet6` on a bare IPv4 neighbor. The FRR renderer partitions neighbors into `inet4Neighbors`/`inet6Neighbors` on those flags, so the IPv4 neighbor landed in the IPv6 set and was emitted as:

```
address-family ipv6 unicast
 neighbor <ipv4-addr> activate
```

Activating a bare IPv4 address for IPv6 unicast is invalid without RFC 5549 extended-nexthop (this config model has **no** such knob); FRR rejects/ignores it and the peer’s address-family activation breaks.

## The fix
`pkg/config/compiler_protocols.go`: when inheriting group family flags onto a neighbor, parse the neighbor address with `net.ParseIP` and inherit **only the matching family** — an IPv4 address gets `FamilyInet` (never `FamilyInet6`), an IPv6 address gets `FamilyInet6` (never `FamilyInet`). The fix is in the compiler, composes with the existing #2473/#2490 export/import AF placement in the renderer (renderer unchanged).

### Edge cases
- **Unparseable address** (hostname / peer-group template / malformed): cannot be classified by version, so it preserves pre-fix behavior — inherits BOTH group flags rather than silently dropping a family. The compiler never crashes.
- **RFC 5549 / extended-nexthop**: grep confirms the config model has no such knob, so the plain address-version gate is correct — a v4 neighbor never activates v6-unicast.
- **No over-gate**: an IPv4 neighbor in a v4-only or family-less group still establishes — FRR default `bgp default ipv4-unicast` auto-activates a family-less v4 neighbor, and an explicit `family inet` group still surfaces `FamilyInet` (agy-10 refuted).
- **Per-neighbor explicit `family`** clause stays operator-authoritative, applied as-is after the inherited flags.

## Tests (fail-on-revert)
- `TestBGPGroupFamilyGatedByNeighborAddressVersion` (compiler): dual-stack group, one v4 + one v6 neighbor → v4 gets inet-only, v6 gets inet6-only.
- `TestBGPDualStackGroupActivatesByAddressVersion` (frr, end-to-end compile→render): v4 neighbor activated ONLY under ipv4-unicast, v6 ONLY under ipv6-unicast.
- `TestBGPGroupFamilyV4OnlyNoOverGate`: v4-only group keeps `FamilyInet`.
- `TestBGPGroupFamilyUnparseableAddressInheritsBoth`: hostname inherits both, no crash.
- Two existing tests (`TestBGPGroupExportFamily`, `TestBGPPrefixLimitSetSyntax`) asserted the buggy `FamilyInet6=true` on an IPv4 neighbor — corrected to the gated behavior and annotated as fail-on-revert anchors.

**Fail-on-revert proven**: neutralizing the gate makes the IPv4 neighbor appear under `address-family ipv6 unicast` and the new tests fail.

## Validation
`go build ./...` OK; `go test ./pkg/config/ ./pkg/frr/` PASS; `gofmt` + `go vet` clean. Go-only, no Rust touched. `pkg/frr/README.md` documents the gate, edge cases, and the no-over-gate guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi