### PR TITLE
Add OSPFv3 interface BFD support (parity with OSPFv2)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12927,3 +12927,14 @@ top.
 - **Fix**: Read the VIP from the map VALUE — iterate `unit.VRRPGroups` values and `net.ParseCIDR` each `vg.VirtualAddresses` entry, adding the VIP subnet as a connected prefix. Do NOT parse the key. Test rewritten to the real compiler key shape (`"<CIDR>_grp<id>_grp1"` style `2001:559:8585:50::8/64_grp1`) with `VirtualAddresses` populated as a CIDR.
 - **File(s)**: pkg/daemon/daemon_run.go (read VirtualAddresses values, not keys), pkg/daemon/ipv6_static_nexthop_test.go (production key shape + VIP-as-value), pkg/frr/README.md (correct the VRRP-VIP doc), _Log.md.
 - **Validation**: go build ./... OK; go test ./pkg/daemon/ ./pkg/frr/ PASS; gofmt clean; go vet clean. Fail-on-revert PROVEN two ways: (1) neutralizing the VirtualAddresses scan → VIP-subnet test resolves "" → fails; (2) reintroducing the OLD key-parse code against the REAL key shape → also resolves "" → fails (confirms the test now exercises a production path the old code could not satisfy). Primary link-local resolve/disambiguation untouched (reviewer-confirmed correct).
+
+## 2026-06-24 — #2474 OSPFv3 BFD parity
+- **Timestamp**: 2026-06-24
+- **Action**: Add BFD (bfd-liveness-detection) support to OSPFv3 interfaces, mirroring OSPFv2.
+- **File(s)**: pkg/config/types_routing.go (OSPFv3Interface +BFD/BFDInterval/BFDMultiplier),
+  pkg/config/compiler_protocols.go (ospf3 interface loop parses bfd-liveness-detection,
+  both AST shapes via shared compileProtocols), pkg/frr/policy_render.go (emit
+  `ipv6 ospf6 bfd` / `ipv6 ospf6 bfd profile <name>` with FRR profile dedup),
+  pkg/config/schema_routing.go (ospf3 interface bfd-liveness-detection leaf, global +
+  routing-instance), pkg/config/parser_routing_test.go + pkg/frr/frr_test.go (tests),
+  docs/feature-gaps.md (note OSPFv3 BFD done).

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -331,7 +331,7 @@ xpf has static routes, generate/aggregate routes, ECMP, VRFs, GRE tunnels, IPIP 
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
-| **BFD** | `protocols ospf area ... interface ... bfd-liveness-detection ...` | Bidirectional Forwarding Detection for sub-second failure detection on routing adjacencies. FRR supports BFD natively. | High | **Done** -- OSPF BFD with interval/multiplier via FRR profiles, IS-IS BFD support with optional interval/multiplier, BGP BFD multiplier configurable. |
+| **BFD** | `protocols ospf area ... interface ... bfd-liveness-detection ...` | Bidirectional Forwarding Detection for sub-second failure detection on routing adjacencies. FRR supports BFD natively. | High | **Done** -- OSPF (v2) and OSPFv3 (`protocols ospf3 area ... interface ... bfd-liveness-detection`, renders `ipv6 ospf6 bfd`, #2474) BFD with interval/multiplier via FRR profiles, IS-IS BFD support with optional interval/multiplier, BGP BFD multiplier configurable. |
 | **BGP Import Policy** | `protocols bgp ... import <policy>` | Inbound route filtering on a BGP peer (`route-map ... in`). | Medium | **Done (#2490)** — `Import []string` parsed at global/group/neighbor scope (symmetric to `export`), rendered `neighbor <X> route-map <name> in` per neighbor/AF (`bgpEffectiveImport` + `lastNonEmpty`, most-specific-wins). Import has NO redistribute equivalent, so a ref MUST be a defined policy-statement: an undefined/bare-token ref is rejected at commit (lenient-warn on load/peer-sync) and SKIPPED at render (`isDefinedPolicyStatement` guard), never emitting a dangling `route-map in` (the #2473 permit-all leak, inbound side). The same `isDefinedPolicyStatement` guard was added to BOTH `route-map out` emit sites (#2539) so a per-neighbor export — newly parseable as of #2490 — cannot leak permit-all OUTBOUND on the lenient path either. Before #2490 the `import` clause parsed to nothing — a silent no-op. |
 | **Graceful Restart** | `routing-options graceful-restart` | Non-stop routing during control plane restart. Keep forwarding while protocols reconverge. FRR supports GR. | Medium | Missing (FRR has GR but xpf doesn't configure it) |
 | **Aggregate Routes** | `routing-options aggregate route ...` | Aggregate (summary) routes with policy control, different from generate routes in contributing route behavior | Medium | Partial (generate routes implemented but aggregate semantics differ) |
@@ -789,7 +789,8 @@ evidence, not as active eBPF source-removal blockers.
   blockers.
 
 ### BFD (Tier 1) -- DONE
-- OSPF BFD with interval/multiplier via FRR profiles
+- OSPF (v2) BFD with interval/multiplier via FRR profiles
+- OSPFv3 BFD with interval/multiplier via FRR profiles (renders `ipv6 ospf6 bfd`, #2474)
 - IS-IS BFD support with optional interval/multiplier
 - BGP BFD multiplier configurable (was hardcoded to 3)
 

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -535,6 +535,24 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 								iface.Cost = n
 							}
 						}
+					case "bfd-liveness-detection":
+						iface.BFD = true
+						for _, bc := range prop.Children {
+							switch bc.Name() {
+							case "minimum-interval":
+								if v := nodeVal(bc); v != "" {
+									if n, err := strconv.Atoi(v); err == nil {
+										iface.BFDInterval = n
+									}
+								}
+							case "multiplier":
+								if v := nodeVal(bc); v != "" {
+									if n, err := strconv.Atoi(v); err == nil {
+										iface.BFDMultiplier = n
+									}
+								}
+							}
+						}
 					}
 				}
 				area.Interfaces = append(area.Interfaces, iface)

--- a/pkg/config/parser_routing_test.go
+++ b/pkg/config/parser_routing_test.go
@@ -1185,6 +1185,92 @@ func TestOSPFBFDSetSyntax(t *testing.T) {
 	}
 }
 
+// TestOSPFv3BFDHierarchical verifies the hierarchical AST shape carries
+// bfd-liveness-detection (minimum-interval + multiplier) into the compiled
+// OSPFv3Interface (#2474 — OSPFv3 BFD parity with OSPFv2).
+func TestOSPFv3BFDHierarchical(t *testing.T) {
+	input := `
+protocols {
+    ospf3 {
+        router-id 10.0.0.1;
+        area 0.0.0.0 {
+            interface trust0 {
+                cost 5;
+                bfd-liveness-detection {
+                    minimum-interval 250;
+                    multiplier 4;
+                }
+            }
+        }
+    }
+}
+`
+	parser := NewParser(input)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ospf3 := cfg.Protocols.OSPFv3
+	if ospf3 == nil {
+		t.Fatal("OSPFv3 config is nil")
+	}
+	if len(ospf3.Areas) != 1 || len(ospf3.Areas[0].Interfaces) != 1 {
+		t.Fatalf("unexpected area/interface count: %+v", ospf3.Areas)
+	}
+	iface := ospf3.Areas[0].Interfaces[0]
+	if !iface.BFD {
+		t.Error("OSPFv3 interface BFD should be true")
+	}
+	if iface.BFDInterval != 250 {
+		t.Errorf("OSPFv3 BFDInterval: got %d, want 250", iface.BFDInterval)
+	}
+	if iface.BFDMultiplier != 4 {
+		t.Errorf("OSPFv3 BFDMultiplier: got %d, want 4", iface.BFDMultiplier)
+	}
+}
+
+// TestOSPFv3BFDSetSyntax verifies the flat-set AST shape (ParseSetCommand +
+// SetPath) carries bfd-liveness-detection into the compiled OSPFv3Interface.
+func TestOSPFv3BFDSetSyntax(t *testing.T) {
+	cmds := []string{
+		"set protocols ospf3 area 0.0.0.0 interface trust0 cost 5",
+		"set protocols ospf3 area 0.0.0.0 interface trust0 bfd-liveness-detection minimum-interval 300",
+		"set protocols ospf3 area 0.0.0.0 interface trust0 bfd-liveness-detection multiplier 3",
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ospf3 := cfg.Protocols.OSPFv3
+	if ospf3 == nil {
+		t.Fatal("OSPFv3 config is nil")
+	}
+	iface := ospf3.Areas[0].Interfaces[0]
+	if !iface.BFD {
+		t.Error("OSPFv3 interface BFD should be true")
+	}
+	if iface.BFDInterval != 300 {
+		t.Errorf("OSPFv3 BFDInterval: got %d, want 300", iface.BFDInterval)
+	}
+	if iface.BFDMultiplier != 3 {
+		t.Errorf("OSPFv3 BFDMultiplier: got %d, want 3", iface.BFDMultiplier)
+	}
+}
+
 func TestBGPBFDSetSyntax(t *testing.T) {
 	cmds := []string{"set protocols bgp local-as 65001", "set protocols bgp group external peer-as 65002", "set protocols bgp group external bfd-liveness-detection minimum-interval 200", "set protocols bgp group external neighbor 10.0.2.1", "set protocols bgp group external neighbor 10.0.3.1 bfd-liveness-detection minimum-interval 100"}
 	tree := &ConfigTree{}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -154,6 +154,10 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 				"passive": {desc: "Passive interface", children: nil},
 				"cost":    {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+				"bfd-liveness-detection": {desc: "BFD liveness detection", children: map[string]*schemaNode{
+					"minimum-interval": {desc: "Minimum interval", args: 1, placeholder: "<milliseconds>", children: nil},
+					"multiplier":       {desc: "Multiplier", args: 1, placeholder: "<multiplier>", children: nil},
+				}},
 			}},
 		}},
 	}},
@@ -462,6 +466,10 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 				"interface": {desc: "Interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: map[string]*schemaNode{
 					"passive": {desc: "Passive interface", children: nil},
 					"cost":    {desc: "Interface cost", args: 1, placeholder: "<cost>", children: nil},
+					"bfd-liveness-detection": {desc: "BFD liveness detection", children: map[string]*schemaNode{
+						"minimum-interval": {desc: "Minimum interval", args: 1, placeholder: "<milliseconds>", children: nil},
+						"multiplier":       {desc: "Multiplier", args: 1, placeholder: "<multiplier>", children: nil},
+					}},
 				}},
 			}},
 		}},

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -164,9 +164,12 @@ type OSPFv3Area struct {
 
 // OSPFv3Interface defines an interface participating in OSPFv3.
 type OSPFv3Interface struct {
-	Name    string
-	Passive bool
-	Cost    int
+	Name          string
+	Passive       bool
+	Cost          int
+	BFD           bool // enable BFD on this interface
+	BFDInterval   int  // BFD minimum-interval in ms (0 = default)
+	BFDMultiplier int  // BFD detect-multiplier (0 = default)
 }
 
 // RIPConfig holds RIP routing configuration.

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -2807,6 +2807,63 @@ func TestGenerateProtocols_OSPFv3VRF(t *testing.T) {
 	}
 }
 
+// TestGenerateProtocols_OSPFv3BFD verifies an OSPFv3 interface with BFD renders
+// the FRR 10.6 ospf6d interface command `ipv6 ospf6 bfd` (bare, no profile) and
+// does NOT emit the OSPFv2 `ip ospf bfd` form (#2474).
+func TestGenerateProtocols_OSPFv3BFD(t *testing.T) {
+	m := New()
+	ospfv3 := &config.OSPFv3Config{
+		RouterID: "10.0.0.1",
+		Areas: []*config.OSPFv3Area{
+			{
+				ID: "0.0.0.0",
+				Interfaces: []*config.OSPFv3Interface{
+					{Name: "trust0", BFD: true},
+				},
+			},
+		},
+	}
+	got := m.generateProtocols(nil, ospfv3, nil, nil, nil, "", 0, nil)
+	if !strings.Contains(got, "interface trust0\n") {
+		t.Errorf("missing interface block in:\n%s", got)
+	}
+	if !strings.Contains(got, " ipv6 ospf6 bfd\n") {
+		t.Errorf("missing 'ipv6 ospf6 bfd' in:\n%s", got)
+	}
+	if strings.Contains(got, "ip ospf bfd") {
+		t.Errorf("must NOT emit OSPFv2 'ip ospf bfd' for an OSPFv3 interface in:\n%s", got)
+	}
+}
+
+// TestGenerateProtocols_OSPFv3BFDProfile verifies that an OSPFv3 interface with
+// a custom interval/multiplier renders a BFD profile reference plus the profile
+// definition, mirroring the OSPFv2 structure but with the ospf6 keyword (#2474).
+func TestGenerateProtocols_OSPFv3BFDProfile(t *testing.T) {
+	m := New()
+	ospfv3 := &config.OSPFv3Config{
+		RouterID: "10.0.0.1",
+		Areas: []*config.OSPFv3Area{
+			{
+				ID: "0.0.0.0",
+				Interfaces: []*config.OSPFv3Interface{
+					{Name: "trust0", BFD: true, BFDInterval: 300, BFDMultiplier: 3},
+				},
+			},
+		},
+	}
+	got := m.generateProtocols(nil, ospfv3, nil, nil, nil, "", 0, nil)
+	profile := bfdProfileName(300, 3)
+	if !strings.Contains(got, " ipv6 ospf6 bfd profile "+profile+"\n") {
+		t.Errorf("missing 'ipv6 ospf6 bfd profile %s' in:\n%s", profile, got)
+	}
+	if !strings.Contains(got, "profile "+profile+"\n") {
+		t.Errorf("missing BFD profile definition %q in:\n%s", profile, got)
+	}
+	if strings.Contains(got, "ip ospf bfd") {
+		t.Errorf("must NOT emit OSPFv2 'ip ospf bfd' for an OSPFv3 interface in:\n%s", got)
+	}
+}
+
 func TestGeneratePolicyOptionsCommunityListAndMetricType(t *testing.T) {
 	m := &Manager{frrConf: "/dev/null"}
 	po := &config.PolicyOptionsConfig{

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -357,13 +357,22 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 		b.WriteString("exit\n!\n")
 		for _, area := range ospfv3.Areas {
 			for _, iface := range area.Interfaces {
-				if iface.Cost > 0 || iface.Passive {
+				if iface.Cost > 0 || iface.Passive || iface.BFD {
 					fmt.Fprintf(&b, "interface %s\n", iface.Name)
 					if iface.Passive {
 						b.WriteString(" ipv6 ospf6 passive\n")
 					}
 					if iface.Cost > 0 {
 						fmt.Fprintf(&b, " ipv6 ospf6 cost %d\n", iface.Cost)
+					}
+					if iface.BFD {
+						if iface.BFDInterval > 0 || iface.BFDMultiplier > 0 {
+							profile := bfdProfileName(iface.BFDInterval, iface.BFDMultiplier)
+							bfdProfiles[profile] = bfdProfile{iface.BFDInterval, iface.BFDMultiplier}
+							fmt.Fprintf(&b, " ipv6 ospf6 bfd profile %s\n", profile)
+						} else {
+							b.WriteString(" ipv6 ospf6 bfd\n")
+						}
 					}
 					b.WriteString("exit\n!\n")
 				}


### PR DESCRIPTION
Closes #2474

## Problem
OSPFv3 (IPv6) interfaces could not be configured with BFD, while OSPFv2 had full `bfd-liveness-detection` support. `OSPFv3Interface` carried only `Name`/`Passive`/`Cost`, the ospf3 interface compiler loop handled only `passive`/`cost`, and the FRR renderer emitted no BFD line for ospf6 interfaces — so `protocols ospf3 area ... interface ... bfd-liveness-detection` was silently dropped.

## Change (mirrors the OSPFv2 path exactly)
- **types_routing.go**: `OSPFv3Interface` gains `BFD`/`BFDInterval`/`BFDMultiplier`.
- **compiler_protocols.go**: the shared `compileProtocols` ospf3 interface loop parses `bfd-liveness-detection` → `minimum-interval`/`multiplier`, handling both AST shapes (hierarchical + flat-set). One edit covers global and routing-instance protocols (single shared compiler).
- **policy_render.go**: emit FRR 10.6 ospf6d `ipv6 ospf6 bfd` (bare) or `ipv6 ospf6 bfd profile <name>` (custom interval/multiplier), reusing the existing `bfdProfile` dedup. This is the `ospf6` keyword, **not** OSPFv2's `ip ospf bfd`.
- **schema_routing.go**: add the `bfd-liveness-detection` typed leaf under the ospf3 interface path in **both** the global and routing-instance schemas (set-completion + commit validation).
- **docs/feature-gaps.md**: record OSPFv3 BFD as done.

## FRR syntax emitted
```
interface trust0
 ipv6 ospf6 bfd
exit
```
With custom interval/multiplier:
```
interface trust0
 ipv6 ospf6 bfd profile xpf-300-3
exit
...
bfd
 profile xpf-300-3
  detect-multiplier 3
  receive-interval 300
  transmit-interval 300
 exit
exit
```

## Validation
- New `pkg/config` tests cover **both** AST shapes (hierarchical parser + `ParseSetCommand`+`SetPath` flat-set) and assert the compiled `OSPFv3Interface` carries BFD/Interval/Multiplier.
- New `pkg/frr` tests assert the OSPFv3 BFD interface renders `ipv6 ospf6 bfd` (and the profile form) and **never** emits the OSPFv2 `ip ospf bfd` form.
- **Fail-on-revert proven**: reverting only the compiler+render logic (type fields kept) makes the new tests fail at runtime; restoring passes.
- `go build ./...` and `go test ./pkg/config/... ./pkg/frr/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)