### PR TITLE
frr: bind DHCP IPv4 default route to its interface (#2547)

### DIFF
--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -106,6 +106,15 @@ move or rename the markers — they're literal strings.
 - In cluster mode the package emits a blackhole default at admin distance
   250 so traffic to the active fabric peer survives a brief
   active/active overlap.
+- **DHCP default routes bind the originating interface for BOTH families
+  (#2547).** `renderDHCPDefaults` (admin distance 200) emits `ip route
+  0.0.0.0/0 <gw> <iface> 200` / `ipv6 route ::/0 <gw> <iface> 200` whenever
+  the lease records an interface (`DHCPRoute.Interface != ""`, populated by
+  `collectDHCPRoutes` in `pkg/daemon/daemon_flow.go` for v4 and v6 alike),
+  falling back to the gateway-only form when it is empty. The IPv4 branch
+  previously dropped the interface — an unintended asymmetry that left the
+  kernel unable to pick the correct egress in multi-WAN / shared-gateway-IP
+  deployments (default-route conflicts / blackholing).
 - **Export references are validated at commit (#2144).** A dynamic-protocol
   `export` (OSPF/OSPFv3/BGP/IS-IS), a RIP `redistribute`, a BGP
   group/neighbor `export`, and a `routing-options forwarding-table export`

--- a/pkg/frr/config_render.go
+++ b/pkg/frr/config_render.go
@@ -189,7 +189,10 @@ func renderGenerateRoutes(b *strings.Builder, fc *FullConfig) {
 // renderDHCPDefaults emits DHCP-learned default routes at admin distance 200.
 // Suppressed when an explicit static default route exists for the same
 // address family so the management interface's DHCP gateway doesn't compete
-// with configured routes.
+// with configured routes. Both families bind the route to the originating
+// interface when the lease records one (dr.Interface != ""), so that in
+// multi-WAN / shared-gateway-IP deployments the kernel can pick the correct
+// egress instead of leaving an ambiguous gateway-only default.
 func renderDHCPDefaults(b *strings.Builder, fc *FullConfig) {
 	if len(fc.DHCPRoutes) == 0 {
 		return
@@ -223,7 +226,11 @@ func renderDHCPDefaults(b *strings.Builder, fc *FullConfig) {
 				fmt.Fprintf(b, "ipv6 route ::/0 %s 200\n", dr.Gateway)
 			}
 		} else {
-			fmt.Fprintf(b, "ip route 0.0.0.0/0 %s 200\n", dr.Gateway)
+			if dr.Interface != "" {
+				fmt.Fprintf(b, "ip route 0.0.0.0/0 %s %s 200\n", dr.Gateway, dr.Interface)
+			} else {
+				fmt.Fprintf(b, "ip route 0.0.0.0/0 %s 200\n", dr.Gateway)
+			}
 		}
 		wrote = true
 	}

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -4044,6 +4044,52 @@ func TestDHCPRoutesIPv6SuppressedByStaticDefault(t *testing.T) {
 	}
 }
 
+// TestDHCPRoutesIPv4BindInterface verifies that a DHCP-learned IPv4 default
+// route binds to the originating interface when the lease records one,
+// mirroring the IPv6 branch. In multi-WAN / shared-gateway-IP deployments an
+// unbound `ip route 0.0.0.0/0 <gw> 200` leaves the kernel unable to pick the
+// correct egress (#2547). This assertion FAILS against master, which emitted
+// the gateway-only form.
+func TestDHCPRoutesIPv4BindInterface(t *testing.T) {
+	m := New()
+	m.frrConf = filepath.Join(t.TempDir(), "frr.conf")
+	os.WriteFile(m.frrConf, []byte(""), 0644)
+
+	fc := &FullConfig{
+		DHCPRoutes: []DHCPRoute{
+			{Gateway: "10.0.100.1", Interface: "ge-0-0-3"},
+		},
+	}
+	_ = m.ApplyFull(fc)
+	data, _ := os.ReadFile(m.frrConf)
+	got := string(data)
+
+	if !strings.Contains(got, "ip route 0.0.0.0/0 10.0.100.1 ge-0-0-3 200\n") {
+		t.Errorf("DHCP IPv4 default route should bind the originating interface, got:\n%s", got)
+	}
+}
+
+// TestDHCPRoutesIPv4NoInterfaceUnbound verifies backward compatibility: a DHCP
+// IPv4 lease without a recorded interface still renders the gateway-only form.
+func TestDHCPRoutesIPv4NoInterfaceUnbound(t *testing.T) {
+	m := New()
+	m.frrConf = filepath.Join(t.TempDir(), "frr.conf")
+	os.WriteFile(m.frrConf, []byte(""), 0644)
+
+	fc := &FullConfig{
+		DHCPRoutes: []DHCPRoute{
+			{Gateway: "10.0.100.1"},
+		},
+	}
+	_ = m.ApplyFull(fc)
+	data, _ := os.ReadFile(m.frrConf)
+	got := string(data)
+
+	if !strings.Contains(got, "ip route 0.0.0.0/0 10.0.100.1 200\n") {
+		t.Errorf("DHCP IPv4 default without interface should render gateway-only form, got:\n%s", got)
+	}
+}
+
 func TestPerInstanceInet6StaticRoutes(t *testing.T) {
 	m := New()
 	m.frrConf = t.TempDir() + "/frr.conf"


### PR DESCRIPTION
Closes #2547

## Problem
`renderDHCPDefaults` (`pkg/frr/config_render.go`) bound DHCP-learned IPv6
default routes to the originating interface (`ipv6 route ::/0 <gw> <iface> 200`)
but the IPv4 branch dropped the interface (`ip route 0.0.0.0/0 <gw> 200`) — an
unintended asymmetry. `collectDHCPRoutes` (`pkg/daemon/daemon_flow.go`)
populates `DHCPRoute.Interface` from `lease.Interface` for BOTH families, so the
IPv4 interface was already available and simply unused.

In multi-WAN / shared-gateway-IP deployments an unbound IPv4 default route
leaves the kernel unable to pick the correct egress, causing default-route
conflicts / blackholing.

## Fix
Mirror the IPv6 branch exactly. When `dr.Interface != ""`, emit
`ip route 0.0.0.0/0 <gw> <iface> 200` (the v4 analog of the already-shipped
IPv6 interface-nexthop form — valid FRR 10.6 static-route syntax: gateway +
interface nexthop + admin distance). Otherwise keep the gateway-only form for
backward compatibility.

## Tests
- `TestDHCPRoutesIPv4BindInterface` — asserts the interface-bound form. Proven
  fail-on-revert: against the prior gateway-only code this test FAILS (got
  `ip route 0.0.0.0/0 10.0.100.1 200`, want the `ge-0-0-3` bound form).
- `TestDHCPRoutesIPv4NoInterfaceUnbound` — backward-compat: empty interface
  still renders the gateway-only form.
- Existing IPv6 and static-default suppression cases remain green.
- `GOCACHE=/dev/shm/cache GOTMPDIR=/dev/shm go test ./pkg/frr/...` → `ok`.

## Docs
Updated the `renderDHCPDefaults` doc comment and `pkg/frr/README.md` to record
that DHCP default routes now bind the originating interface for both families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)