### PR TITLE
rpm: evaluate test pass/fail once per cycle (#2527)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12951,3 +12951,12 @@ top.
   _BGPBFDPeersSingleBlock): count==2 on master-emulation, ==1 after fix.
   **File(s)**: pkg/frr/policy_render.go, pkg/frr/manager.go,
   pkg/frr/frr_test.go, pkg/frr/README.md, _Log.md
+
+- **Timestamp**: 2026-06-24
+  **Action**: #2527 — RPM test transitions now evaluate once per cycle
+  (per-test aggregate) instead of per probe, so transient mid-cycle loss
+  can no longer flap ip-monitoring static-route preference. Added a
+  probeFn test seam + runProbe wrapper; new per-cycle transition tests
+  (fail-on-revert proven: master fires [fail pass fail]=3, fixed fires 1).
+  **File(s)**: pkg/rpm/rpm.go, pkg/rpm/transition_cycle_test.go,
+  docs/multi-wan.md, _Log.md

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -359,3 +359,16 @@ routing, and only on double fault).
 - Failover actuation is a differential frr-reload + one snapshot push
   per debounce window; detection time (probe interval × threshold)
   dominates end-to-end failover latency.
+- **Per-cycle transition evaluation (#2527).** An RPM test's pass/fail
+  status is a per-test aggregate, evaluated once across the whole probe
+  set (`probe-count` probes per cycle), Junos ip-monitoring style. The
+  successive-loss threshold is applied during the cycle but the test
+  transitions **at most once per cycle** — the sensor edge that drives
+  static-route preference fires after the full cycle completes, never
+  per probe. A single transient mid-cycle success therefore cannot flip
+  the test fail→pass→fail and flap the route tables within one cycle;
+  the consecutive-loss counter still carries across cycle boundaries, so
+  a `threshold` larger than `probe-count` trips on the cycle where the
+  running run finally crosses the bar. Coarser per-probe
+  `ping_probe_failed` events still fire per lost probe (eventengine
+  signal only; they do not actuate routes).

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -147,6 +147,12 @@ type Manager struct {
 	// icmpListen is the injectable raw-socket seam for the ICMP echo
 	// prober. nil = realICMPListen.
 	icmpListen icmpListenFunc
+
+	// probeFn, when non-nil, replaces executeProbe — the injectable
+	// seam for unit-testing the per-cycle pass/fail transition logic
+	// with a scripted probe-result sequence (#2527). It is set once
+	// before the manager runs and never mutated concurrently.
+	probeFn func(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error)
 }
 
 // SetEventCallback registers a callback for RPM events.
@@ -367,6 +373,26 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 	probeLimit := test.ProbeLimit // 0 = unlimited
 	setupWarned := false
 
+	// The per-test pass/fail status is a per-cycle aggregate, like
+	// Junos RPM/ip-monitoring: the successive-loss threshold is
+	// evaluated across the WHOLE probe set and the test transitions AT
+	// MOST once per cycle — never per probe. Capture the pre-cycle
+	// status ONCE; evolve `status` locally through the cycle (so the
+	// cross-cycle consecutive-failure counter r.SuccFail keeps its
+	// meaning); publish r.LastStatus and fire the transition only after
+	// the loop. Firing inside the loop let a single transient mid-cycle
+	// success flip fail->pass->fail and flap static-route preference in
+	// services ip-monitoring (#2527).
+	m.mu.Lock()
+	r0 := m.results[key]
+	if r0 == nil {
+		m.mu.Unlock()
+		return
+	}
+	prevStatus := r0.LastStatus
+	m.mu.Unlock()
+	status := prevStatus
+
 	for i := 0; i < probeCount; i++ {
 		if i > 0 {
 			select {
@@ -376,7 +402,7 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 			}
 		}
 
-		rtt, err := m.executeProbe(ctx, test, key)
+		rtt, err := m.runProbe(ctx, test, key)
 
 		// ErrProbeSetup = environment/capability failure (raw socket
 		// open denied, marshal, probe pin not installed #1895): the
@@ -405,23 +431,23 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 		}
 		r.TotalSent++
 		r.LastProbeAt = time.Now()
-		prevStatus := r.LastStatus
 		if err != nil {
 			failures++
 			r.SuccFail++
+			// Successive-loss trip: once `threshold` consecutive
+			// probes are lost the test is failed. r.SuccFail carries
+			// across cycles, so a fail run spanning a cycle boundary
+			// still trips. The status is only PUBLISHED after the loop.
 			if r.SuccFail >= threshold {
-				r.LastStatus = "fail"
+				status = "fail"
 			}
 			// Check probe-limit: stop test cycle when reached
 			hitLimit := probeLimit > 0 && r.SuccFail >= probeLimit
 			m.mu.Unlock()
-			// Fire probe-level failure event
+			// Probe-level failure event stays per-probe — it is an
+			// eventengine signal and does not drive ip-monitoring
+			// routes (which key off fireTransition only).
 			m.fireEvent("ping_probe_failed", probeName, test.Name)
-			// Fire test-level failure on transition
-			if r.SuccFail == threshold && prevStatus != "fail" {
-				m.fireEvent("ping_test_failed", probeName, test.Name)
-				m.fireTransition(probeName, test.Name, "fail")
-			}
 			if hitLimit {
 				break
 			}
@@ -454,12 +480,29 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 			}
 			r.LastRTT = rtt
 			r.SuccFail = 0
-			r.LastStatus = "pass"
+			// A success clears the successive-loss run. The status is
+			// only PUBLISHED after the loop.
+			status = "pass"
 			m.mu.Unlock()
-			if prevStatus != "pass" {
-				m.fireTransition(probeName, test.Name, "pass")
-			}
 		}
+	}
+
+	// Publish the per-cycle status decision: compare the aggregate
+	// end-of-cycle status to the pre-cycle status and fire AT MOST one
+	// transition. This is the single ip-monitoring sensor edge per test
+	// cycle (#2527). A below-threshold cycle that never reached "fail"
+	// and saw no success leaves `status == prevStatus` (e.g. the
+	// initial "unknown" state holds), so no spurious transition fires.
+	if status != prevStatus {
+		m.mu.Lock()
+		if r := m.results[key]; r != nil {
+			r.LastStatus = status
+		}
+		m.mu.Unlock()
+		if status == "fail" {
+			m.fireEvent("ping_test_failed", probeName, test.Name)
+		}
+		m.fireTransition(probeName, test.Name, status)
 	}
 
 	// Fire test completed if all probes passed
@@ -506,6 +549,15 @@ func (m *Manager) pinInstallError(test *config.RPMTest, key string) error {
 		return fmt.Errorf("%w: no probe pin slot assigned for next-hop test", ErrProbeSetup)
 	}
 	return nil
+}
+
+// runProbe dispatches a single probe through the test seam when one is
+// installed, otherwise the real executeProbe path.
+func (m *Manager) runProbe(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error) {
+	if m.probeFn != nil {
+		return m.probeFn(ctx, test, key)
+	}
+	return m.executeProbe(ctx, test, key)
 }
 
 func (m *Manager) executeProbe(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error) {

--- a/pkg/rpm/transition_cycle_test.go
+++ b/pkg/rpm/transition_cycle_test.go
@@ -1,0 +1,168 @@
+package rpm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// scriptedProber returns a probeFn that yields the next result from
+// seq on each call: false = lost probe (error), true = received. Once
+// seq is exhausted it repeats the last element (so a short script can
+// drive a longer probe-count without panicking).
+func scriptedProber(seq []bool) func(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error) {
+	var mu sync.Mutex
+	i := 0
+	return func(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		ok := seq[len(seq)-1]
+		if i < len(seq) {
+			ok = seq[i]
+		}
+		i++
+		if ok {
+			return time.Millisecond, nil
+		}
+		return 0, fmt.Errorf("scripted loss")
+	}
+}
+
+// newTestManager builds a Manager with the test prober seam and a
+// transition recorder. It seeds a single result under key "p/t" with
+// the given starting status, mirroring Apply's initialization.
+func newTestManager(t *testing.T, startStatus string, seq []bool) (*Manager, *[]string) {
+	t.Helper()
+	m := New()
+	m.probeFn = scriptedProber(seq)
+	m.results["p/t"] = &ProbeResult{
+		ProbeName:  "p",
+		TestName:   "t",
+		LastStatus: startStatus,
+	}
+	var mu sync.Mutex
+	var transitions []string
+	m.SetTransitionCallback(func(tr Transition) {
+		mu.Lock()
+		defer mu.Unlock()
+		transitions = append(transitions, tr.Status)
+	})
+	return m, &transitions
+}
+
+// TestRunSingleTestOneTransitionPerCycle is the core #2527 regression:
+// a fail,fail,pass,fail,fail cycle (probeCount=5, threshold=2) must fire
+// EXACTLY ONE transition (to "fail") — not three. Against the pre-fix
+// per-probe firing this asserts 3 transitions and FAILS.
+func TestRunSingleTestOneTransitionPerCycle(t *testing.T) {
+	seq := []bool{false, false, true, false, false}
+	m, transitions := newTestManager(t, "pass", seq)
+
+	m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 5, 0, 2)
+
+	if len(*transitions) != 1 {
+		t.Fatalf("expected exactly 1 transition per cycle, got %d: %v",
+			len(*transitions), *transitions)
+	}
+	if (*transitions)[0] != "fail" {
+		t.Fatalf("expected the single transition to be \"fail\", got %q", (*transitions)[0])
+	}
+	if got := m.results["p/t"].LastStatus; got != "fail" {
+		t.Fatalf("expected LastStatus=fail after the cycle, got %q", got)
+	}
+}
+
+// TestRunSingleTestTransientLossBelowThreshold: a mostly-pass cycle with
+// a single transient loss below threshold must fire NO transition (the
+// test was already passing and never crosses the successive-loss bar).
+func TestRunSingleTestTransientLossBelowThreshold(t *testing.T) {
+	seq := []bool{true, true, false, true, true}
+	m, transitions := newTestManager(t, "pass", seq)
+
+	m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 5, 0, 2)
+
+	if len(*transitions) != 0 {
+		t.Fatalf("expected no transition for transient sub-threshold loss, got %d: %v",
+			len(*transitions), *transitions)
+	}
+	if got := m.results["p/t"].LastStatus; got != "pass" {
+		t.Fatalf("expected LastStatus to stay pass, got %q", got)
+	}
+}
+
+// TestRunSingleTestRecovery: a fully-passing cycle following a failed
+// state fires exactly one "pass" transition.
+func TestRunSingleTestRecovery(t *testing.T) {
+	seq := []bool{true, true, true, true, true}
+	m, transitions := newTestManager(t, "fail", seq)
+	// Simulate carry-over from a prior failed cycle.
+	m.results["p/t"].SuccFail = 4
+
+	m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 5, 0, 2)
+
+	if len(*transitions) != 1 || (*transitions)[0] != "pass" {
+		t.Fatalf("expected exactly 1 \"pass\" transition on recovery, got %v", *transitions)
+	}
+	if got := m.results["p/t"].SuccFail; got != 0 {
+		t.Fatalf("expected SuccFail reset to 0 on recovery, got %d", got)
+	}
+}
+
+// TestRunSingleTestProbeCountOne preserves the degenerate single-probe
+// behavior across the relevant cases.
+func TestRunSingleTestProbeCountOne(t *testing.T) {
+	t.Run("single-pass-fires-pass-from-unknown", func(t *testing.T) {
+		m, transitions := newTestManager(t, "unknown", []bool{true})
+		m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 1, 0, 1)
+		if len(*transitions) != 1 || (*transitions)[0] != "pass" {
+			t.Fatalf("expected one pass transition, got %v", *transitions)
+		}
+	})
+
+	t.Run("single-fail-threshold-1-fires-fail", func(t *testing.T) {
+		m, transitions := newTestManager(t, "pass", []bool{false})
+		m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 1, 0, 1)
+		if len(*transitions) != 1 || (*transitions)[0] != "fail" {
+			t.Fatalf("expected one fail transition, got %v", *transitions)
+		}
+	})
+
+	t.Run("single-fail-below-threshold-holds", func(t *testing.T) {
+		// threshold 3, one fail: must NOT transition and must hold the
+		// initial unknown state — a single lost probe is not a failure.
+		m, transitions := newTestManager(t, "unknown", []bool{false})
+		m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 1, 0, 3)
+		if len(*transitions) != 0 {
+			t.Fatalf("expected no transition below threshold, got %v", *transitions)
+		}
+		if got := m.results["p/t"].LastStatus; got != "unknown" {
+			t.Fatalf("expected status to hold unknown, got %q", got)
+		}
+	})
+}
+
+// TestRunSingleTestCrossCycleSuccessiveLoss verifies the successive-loss
+// counter still accumulates ACROSS cycles when threshold > probeCount,
+// firing a single fail once the consecutive run finally crosses the bar.
+func TestRunSingleTestCrossCycleSuccessiveLoss(t *testing.T) {
+	// probeCount=2, threshold=3: one cycle of two losses cannot trip
+	// (2 < 3); the second cycle's first loss makes it 3 and trips once.
+	m, transitions := newTestManager(t, "pass", []bool{false})
+
+	m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 2, 0, 3)
+	if len(*transitions) != 0 {
+		t.Fatalf("cycle 1: 2<3 successive losses must not trip, got %v", *transitions)
+	}
+	if got := m.results["p/t"].SuccFail; got != 2 {
+		t.Fatalf("cycle 1: expected SuccFail=2 carried, got %d", got)
+	}
+
+	m.runSingleTest(context.Background(), "p", &config.RPMTest{Name: "t"}, "p/t", 2, 0, 3)
+	if len(*transitions) != 1 || (*transitions)[0] != "fail" {
+		t.Fatalf("cycle 2: expected exactly one fail once run reaches 3, got %v", *transitions)
+	}
+}


### PR DESCRIPTION
Closes #2527

## Problem
`runSingleTest` evaluated the successive-loss threshold and fired
`fireTransition` pass/fail callbacks **inside** the per-probe loop. A
single test cycle (`probe-count` probes) could flap status multiple times
on transient loss: with `probe-count=5` / `successive-loss=2` a
`fail,fail,pass,fail,fail` cycle fired **three** transitions (fail, pass,
fail). `services ip-monitoring` drives static-route preference off these
transitions, so route tables flapped mid-cycle.

## Junos basis
Junos RPM/ip-monitoring evaluates the threshold across the probe **set**
(per-test aggregate) and transitions **once** per evaluation — not per
probe.

## Fix
Capture the pre-cycle status once; evolve `status` locally through the
cycle (the cross-cycle consecutive-failure counter `r.SuccFail` keeps its
meaning, so a fail run spanning a cycle boundary and a `threshold` larger
than `probe-count` still trip); publish `r.LastStatus` and fire **at most
one** transition after the loop. A below-threshold cycle that saw no
success leaves `status` unchanged (the initial `unknown` state holds), so
no spurious transition fires. Per-probe `ping_probe_failed` events still
fire per lost probe (eventengine signal only; they do not drive routes).

Added a `probeFn` injection seam + `runProbe` wrapper so the per-cycle
transition logic is unit-testable with a scripted probe-result sequence.

## Validation
- `pkg/rpm/transition_cycle_test.go`: exactly one transition for the
  issue's `fail,fail,pass,fail,fail` cycle; no spurious fail on
  sub-threshold transient loss; one pass on recovery; preserved
  `probe-count==1` behavior; cross-cycle successive-loss accumulation
  when `threshold > probe-count`.
- **Fail-on-revert proven:** against master's per-probe logic the core
  test reports `[fail pass fail]` (3 transitions); the fixed code
  reports 1.
- `go test -race ./pkg/rpm/...` green; `go build ./...` green.
- `docs/multi-wan.md` documents the per-cycle transition semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)