### PR TITLE
Reject malformed RPM source-address at commit (#2492)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12960,3 +12960,16 @@ top.
   (fail-on-revert proven: master fires [fail pass fail]=3, fixed fires 1).
   **File(s)**: pkg/rpm/rpm.go, pkg/rpm/transition_cycle_test.go,
   docs/multi-wan.md, _Log.md
+
+- **Timestamp**: 2026-06-24
+  **Action**: #2492 — reject malformed RPM source-address at commit +
+  defensive runtime guard. Added validateRPMSourceAddressStrict (parse
+  + IP-literal-target family-compat) gated by lenientRPMSourceAddress
+  (strict-reject on commit, warn on tolerant load/peer-sync per #1960).
+  probeDialer now returns (*net.Dialer, error): a non-empty unparseable
+  source returns ErrProbeSetup instead of wildcard-binding TCPAddr{IP:nil};
+  empty source stays the default bind. Fail-on-revert proven (strict
+  tests fail with the gate neutralized = master behavior).
+  **File(s)**: pkg/config/compiler.go, pkg/config/compiler_services.go,
+  pkg/config/compiler_rpm_source_2492_test.go, pkg/rpm/rpm.go,
+  pkg/rpm/probe_dialer_2492_test.go, docs/multi-wan.md, _Log.md

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -51,6 +51,22 @@ set services rpm probe WAN test wan-a thresholds successive-loss 3
   two uplinks" the natural dual-WAN pattern. Limits: at most 50 pinned
   tests; the pinned test needs an IP-literal target of the same family
   and a `destination-interface`.
+- `source-address` selects the probe's source IP (the dialer's
+  `LocalAddr`). It is validated at commit (#2492): a non-empty but
+  unparseable `source-address` is **rejected** on the strict commit /
+  commit-check path — a malformed value would otherwise `net.ParseIP`
+  to nil and silently degrade the tcp-ping/http-get probe to a
+  wildcard/kernel-chosen source bind, so the probe would measure the
+  **default** uplink instead of the source-specific path and publish
+  PASS/FAIL for the wrong uplink. When the target is an IP literal the
+  `source-address` family must match it (a v6 source cannot bind a v4
+  target connection); a hostname target skips the family check (its
+  family is unknown until DNS resolves). An **empty** `source-address`
+  is legitimate — it means "default source". On the tolerant load /
+  peer-sync path the same malformed value is downgraded to a warning so
+  a persisted/peer-synced config still boots (#1960 no-brick); the
+  runtime dialer guard then returns the same setup error, so the test
+  holds state (below) rather than measuring the wrong path.
 - Probe config re-applies on commit, gated on the rendered RPM stanza
   hash — unrelated commits never reset probe state.
 - **Environment errors never move routes**: a probe-socket setup

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -471,6 +471,24 @@ type compileOpts struct {
 	// leniently-loaded bad config is inert. Same doctrine as
 	// lenientPolicyZoneRefs / lenientNATHostMask.
 	lenientDestNATAddresses bool
+	// lenientRPMSourceAddress (#2492) downgrades the RPM test
+	// source-address gate (validateRPMSourceAddressStrict) from a hard
+	// compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects an RPM test whose `source-address`
+	// is non-empty but unparseable, or whose source address-family does
+	// not match an IP-literal target. A malformed source silently turns
+	// the tcp-ping/http-get probe dialer into a wildcard/kernel-chosen
+	// source bind (net.ParseIP -> nil -> TCPAddr{IP:nil}), so the probe
+	// measures the DEFAULT uplink instead of the pinned source path and
+	// publishes PASS/FAIL for the wrong path — and RPM feeds
+	// event-options / ip-monitoring failover. The tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config carrying a bad source still BOOTS (#1960
+	// no-brick); the runtime probeDialer guard returns ErrProbeSetup for
+	// the same malformed source, so the leniently-loaded test HOLDS
+	// state rather than actuating routes off a wildcard measurement.
+	// Same doctrine as lenientDestNATAddresses / lenientNATHostMask.
+	lenientRPMSourceAddress bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -520,6 +538,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientWireguardPeers:              true,
 		lenientPolicyZoneRefs:              true,
 		lenientDestNATAddresses:            true,
+		lenientRPMSourceAddress:            true,
 	})
 }
 
@@ -620,6 +639,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientWireguardPeers:              true,
 		lenientPolicyZoneRefs:              true,
 		lenientDestNATAddresses:            true,
+		lenientRPMSourceAddress:            true,
 	})
 }
 
@@ -1391,6 +1411,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRibGroupRefs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("rib-group import-rib reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2492: RPM test source-address gate. A malformed `source-address`
+	// (non-empty but unparseable) silently degrades the tcp-ping/http-get
+	// probe dialer to a wildcard/kernel-chosen source bind, so the probe
+	// measures the DEFAULT uplink instead of the pinned source path —
+	// publishing PASS/FAIL for the wrong path while RPM feeds
+	// event-options / ip-monitoring failover. A v6 source with a v4
+	// IP-literal target (or vice-versa) is likewise unpinnable. Strict on
+	// commit / commit-check (hard reject so the typo is operator-visible);
+	// lenient on load / peer-sync (warn — #1960; the runtime probeDialer
+	// guard returns ErrProbeSetup for the same malformed source, so the
+	// leniently-loaded test HOLDS state instead of actuating routes off a
+	// wildcard measurement). Hostname targets skip the family check
+	// (the target family is unknown until DNS resolves). Mirrors
+	// validateRibGroupImportRibReferencesStrict.
+	if err := validateRPMSourceAddressStrict(cfg); err != nil {
+		if opts.lenientRPMSourceAddress {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("rpm source-address (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_rpm_source_2492_test.go
+++ b/pkg/config/compiler_rpm_source_2492_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRPMSourceAddressMalformedStrictRejects pins the #2492 commit-time
+// gate: a non-empty but unparseable source-address is hard-rejected on
+// the strict path (commit / commit-check). This FAILS against master,
+// which accepts the malformed source and silently degrades the
+// tcp-ping/http-get probe to a wildcard source bind.
+func TestRPMSourceAddressMalformedStrictRejects(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{"out-of-range octet", "10.0.0.999"},
+		{"not an ip", "not-an-ip"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := []string{
+				"set services rpm probe P test t probe-type tcp-ping",
+				"set services rpm probe P test t target 1.1.1.1",
+				"set services rpm probe P test t source-address " + tc.src,
+			}
+			tree := buildTree(t, lines)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted malformed source-address %q; want strict reject", tc.src)
+			}
+			if !strings.Contains(err.Error(), "source-address: invalid IP address") {
+				t.Fatalf("err = %v, want substring %q", err, "source-address: invalid IP address")
+			}
+		})
+	}
+}
+
+// TestRPMSourceAddressMalformedLenientWarns pins the no-brick contract
+// (#1960 doctrine): the same malformed source-address that the strict
+// path rejects is TOLERATED on the lenient load / peer-sync path —
+// downgraded to a warning so an already-persisted or peer-synced config
+// still boots.
+func TestRPMSourceAddressMalformedLenientWarns(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type tcp-ping",
+		"set services rpm probe P test t target 1.1.1.1",
+		"set services rpm probe P test t source-address 10.0.0.999",
+	}
+	tree := buildTree(t, lines)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on malformed source (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "rpm source-address") {
+		t.Fatalf("expected a downgraded rpm source-address warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestRPMSourceAddressFamilyMismatch covers layer 2: a v6 source with a
+// v4 IP-literal target (and vice-versa) is unpinnable and rejected
+// strict; a hostname target's family is unknown at commit time so the
+// family check is skipped (accepted).
+func TestRPMSourceAddressFamilyMismatch(t *testing.T) {
+	t.Run("v6 source v4 literal target rejected", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type tcp-ping",
+			"set services rpm probe P test t target 1.1.1.1",
+			"set services rpm probe P test t source-address 2001:db8::1",
+		}
+		tree := buildTree(t, lines)
+		_, err := CompileConfig(tree)
+		if err == nil || !strings.Contains(err.Error(), "address family does not match") {
+			t.Fatalf("err = %v, want family-mismatch rejection", err)
+		}
+	})
+
+	t.Run("v4 source v6 literal target rejected", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type tcp-ping",
+			"set services rpm probe P test t target 2001:db8::2",
+			"set services rpm probe P test t source-address 10.0.0.1",
+		}
+		tree := buildTree(t, lines)
+		_, err := CompileConfig(tree)
+		if err == nil || !strings.Contains(err.Error(), "address family does not match") {
+			t.Fatalf("err = %v, want family-mismatch rejection", err)
+		}
+	})
+
+	t.Run("hostname target accepted (family unknown)", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type tcp-ping",
+			"set services rpm probe P test t target example.com",
+			"set services rpm probe P test t source-address 2001:db8::1",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("hostname target with v6 source must be accepted (family unknown): %v", err)
+		}
+	})
+}
+
+// TestRPMSourceAddressValidAndEmptyAccepted confirms the legitimate
+// cases: an empty source-address (default bind) and a parseable
+// same-family source both compile cleanly on the strict path.
+func TestRPMSourceAddressValidAndEmptyAccepted(t *testing.T) {
+	t.Run("empty source-address (default bind) accepted", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type tcp-ping",
+			"set services rpm probe P test t target 1.1.1.1",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("empty source-address must be accepted (means default source): %v", err)
+		}
+	})
+
+	t.Run("valid same-family source accepted", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type tcp-ping",
+			"set services rpm probe P test t target 1.1.1.1",
+			"set services rpm probe P test t source-address 10.0.0.5",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("valid v4 source + v4 target must be accepted: %v", err)
+		}
+	})
+}
+
+func hasWarningSubstr(warnings []string, sub string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -75,6 +75,53 @@ func validateRPMTest(probeName string, test *RPMTest) error {
 	return nil
 }
 
+// validateRPMSourceAddressStrict rejects a malformed RPM test
+// `source-address` (#2492). A non-empty but unparseable value silently
+// turns the tcp-ping/http-get probe dialer into a wildcard/kernel-chosen
+// source bind (net.ParseIP -> nil -> net.TCPAddr{IP:nil}), so the probe
+// measures the DEFAULT uplink instead of the source-specific path the
+// operator pinned. Because RPM feeds event-options / ip-monitoring
+// failover, that publishes PASS for the wrong uplink (or FAILs a healthy
+// source-specific path). The ICMP path already surfaces a bad source via
+// its real listen error; tcp-ping/http-get had no such backstop.
+//
+// When the target is an IP literal, the source must share its address
+// family: a v6 source can never bind a v4 destination connection (and
+// vice-versa). For a hostname target the family is unknown until DNS
+// resolves, so the family check is skipped — only the parse check
+// applies. An EMPTY source-address is legitimate (default source bind)
+// and is never rejected.
+func validateRPMSourceAddressStrict(cfg *Config) error {
+	if cfg == nil || cfg.Services.RPM == nil {
+		return nil
+	}
+	for _, probe := range cfg.Services.RPM.Probes {
+		if probe == nil {
+			continue
+		}
+		for _, test := range probe.Tests {
+			if test == nil || test.SourceAddress == "" {
+				continue
+			}
+			src := net.ParseIP(test.SourceAddress)
+			if src == nil {
+				return fmt.Errorf("services rpm probe %q test %q source-address: invalid IP address %q",
+					probe.Name, test.Name, test.SourceAddress)
+			}
+			// Family compatibility only applies to an IP-literal target;
+			// a hostname target's family is unknown at commit time.
+			if target := net.ParseIP(test.Target); target != nil {
+				if (src.To4() == nil) != (target.To4() == nil) {
+					return fmt.Errorf(
+						"services rpm probe %q test %q: source-address %q address family does not match target %q",
+						probe.Name, test.Name, test.SourceAddress, test.Target)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // validateRPMProbePinsStrict enforces the probe-pin band invariants
 // (#1827 PR-1a): at most ProbeTableCount next-hop-pinned tests (one
 // reserved kernel table each), and no routing-instance table ID may

--- a/pkg/rpm/probe_dialer_2492_test.go
+++ b/pkg/rpm/probe_dialer_2492_test.go
@@ -1,0 +1,61 @@
+package rpm
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestProbeDialerMalformedSourceReturnsSetupError pins the #2492 runtime
+// guard: a NON-EMPTY but unparseable source-address must return an
+// ErrProbeSetup-wrapped error rather than proceeding with a
+// net.TCPAddr{IP:nil} wildcard bind. ErrProbeSetup makes runSingleTest
+// hold the test's state (no counter, no status flip, no Transition), so
+// ip-monitoring never actuates routes off a wrong-path measurement.
+func TestProbeDialerMalformedSourceReturnsSetupError(t *testing.T) {
+	for _, src := range []string{"not-an-ip", "10.0.0.999", "2001:db8::g"} {
+		d, err := probeDialer(5*time.Second, src, probeSockOpts{})
+		if err == nil {
+			t.Fatalf("probeDialer(%q) returned nil error; want ErrProbeSetup (would wildcard-bind)", src)
+		}
+		if !errors.Is(err, ErrProbeSetup) {
+			t.Fatalf("probeDialer(%q) err = %v, want ErrProbeSetup", src, err)
+		}
+		if d != nil {
+			t.Fatalf("probeDialer(%q) returned non-nil dialer with error", src)
+		}
+	}
+}
+
+// TestProbeDialerEmptySourceIsDefaultBind confirms an EMPTY
+// source-address stays legitimate: it means "default source", so the
+// dialer is returned with no LocalAddr and no error.
+func TestProbeDialerEmptySourceIsDefaultBind(t *testing.T) {
+	d, err := probeDialer(5*time.Second, "", probeSockOpts{})
+	if err != nil {
+		t.Fatalf("probeDialer(\"\") err = %v, want nil (empty = default source)", err)
+	}
+	if d == nil {
+		t.Fatal("probeDialer(\"\") returned nil dialer")
+	}
+	if d.LocalAddr != nil {
+		t.Fatalf("probeDialer(\"\") LocalAddr = %v, want nil (kernel default source)", d.LocalAddr)
+	}
+}
+
+// TestProbeDialerValidSourceBinds confirms a parseable source-address is
+// carried through to the dialer's LocalAddr.
+func TestProbeDialerValidSourceBinds(t *testing.T) {
+	d, err := probeDialer(5*time.Second, "10.0.0.5", probeSockOpts{})
+	if err != nil {
+		t.Fatalf("probeDialer valid source err = %v, want nil", err)
+	}
+	ta, ok := d.LocalAddr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("LocalAddr type = %T, want *net.TCPAddr", d.LocalAddr)
+	}
+	if !ta.IP.Equal(net.ParseIP("10.0.0.5")) {
+		t.Fatalf("LocalAddr IP = %v, want 10.0.0.5", ta.IP)
+	}
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -22,10 +22,28 @@ import (
 // optional source address, SO_BINDTODEVICE (destination-interface, or
 // the "vrf-"+instance VRF device fallback), and SO_MARK for
 // next-hop-pinned tests (#1827).
-func probeDialer(timeout time.Duration, sourceAddr string, opts probeSockOpts) *net.Dialer {
+//
+// A NON-EMPTY but unparseable source-address is a setup error, not a
+// path signal (#2492): net.ParseIP returns nil, and a TCPAddr{IP:nil}
+// silently degrades to a wildcard/kernel-chosen source bind — the probe
+// would then measure the DEFAULT uplink instead of the source-specific
+// path the operator pinned, publishing PASS/FAIL for the wrong path.
+// The commit-time validator (validateRPMSourceAddressStrict) rejects
+// this on the strict path, but a leniently-loaded or externally-built
+// config can still reach here, so guard defensively and surface
+// ErrProbeSetup. The ICMP path already fails closed via its real
+// listen error; tcp-ping/http-get had no such backstop. An EMPTY
+// source-address stays legitimate (means "default source"): only a
+// non-empty value that will not parse is the error.
+func probeDialer(timeout time.Duration, sourceAddr string, opts probeSockOpts) (*net.Dialer, error) {
 	d := &net.Dialer{Timeout: timeout}
 	if sourceAddr != "" {
-		d.LocalAddr = &net.TCPAddr{IP: net.ParseIP(sourceAddr)}
+		ip := net.ParseIP(sourceAddr)
+		if ip == nil {
+			return nil, fmt.Errorf("%w: invalid source-address %q (would bind wildcard source)",
+				ErrProbeSetup, sourceAddr)
+		}
+		d.LocalAddr = &net.TCPAddr{IP: ip}
 	}
 	if opts.BindDevice != "" || opts.Mark != 0 {
 		d.Control = func(network, address string, c syscall.RawConn) error {
@@ -62,7 +80,7 @@ func probeDialer(timeout time.Duration, sourceAddr string, opts probeSockOpts) *
 			return err
 		}
 	}
-	return d
+	return d, nil
 }
 
 // vrfDeviceName returns the VRF device name for a routing instance.
@@ -580,7 +598,10 @@ func (m *Manager) executeProbe(ctx context.Context, test *config.RPMTest, key st
 func (m *Manager) probeTCP(ctx context.Context, test *config.RPMTest, opts probeSockOpts) (time.Duration, error) {
 	port := test.EffectiveDestinationPort()
 	addr := net.JoinHostPort(test.Target, fmt.Sprintf("%d", port))
-	dialer := probeDialer(5*time.Second, test.SourceAddress, opts)
+	dialer, err := probeDialer(5*time.Second, test.SourceAddress, opts)
+	if err != nil {
+		return 0, err
+	}
 
 	start := time.Now()
 	conn, err := dialer.DialContext(ctx, "tcp", addr)
@@ -603,7 +624,10 @@ func (m *Manager) probeHTTP(ctx context.Context, test *config.RPMTest, opts prob
 		url = "http://" + target
 	}
 
-	dialer := probeDialer(10*time.Second, test.SourceAddress, opts)
+	dialer, err := probeDialer(10*time.Second, test.SourceAddress, opts)
+	if err != nil {
+		return 0, err
+	}
 	transport := &http.Transport{
 		DialContext: dialer.DialContext,
 	}


### PR DESCRIPTION
Closes #2492

## Problem
A malformed RPM test `source-address` was accepted at commit and silently turned tcp-ping/http-get probes into **wildcard-source binds**. `probeDialer` built `&net.TCPAddr{IP: net.ParseIP(sourceAddr)}` with no nil check, so an unparseable source produced `TCPAddr{IP:nil}` — a kernel-chosen/wildcard source. The probe then measured the **default** uplink instead of the source-specific path the operator pinned. Since RPM feeds event-options / ip-monitoring failover, a typo'd source made a probe publish PASS for the wrong uplink (or FAIL a healthy source-specific path). The ICMP path already surfaced a bad source via its real listen error; tcp-ping/http-get had no backstop.

## Fix (3 layers)
1. **Commit-reject** (`validateRPMSourceAddressStrict`): a non-empty but unparseable `source-address` is hard-rejected on the strict commit / commit-check path. Per the #1960 strict-vs-lenient doctrine, the tolerant load / peer-sync path (`CompileConfigLenient` / `CompileConfigForNodeLenient`) downgrades it to a `cfg.Warnings` entry via a new `lenientRPMSourceAddress` opt — an already-persisted or peer-synced config never bricks on restart. Wired as a gated post-compile validator next to `validateRibGroupImportRibReferencesStrict`.
2. **Family compatibility**: when the target is an IP literal, the source address-family must match it (v6 source cannot bind a v4 target connection, and vice-versa). A hostname target's family is unknown at commit time, so the family check is skipped there.
3. **Runtime guard**: `probeDialer` now returns `(*net.Dialer, error)`. A non-empty source that `net.ParseIP` cannot parse returns an `ErrProbeSetup`-wrapped error instead of wildcard-binding. `ErrProbeSetup` makes `runSingleTest` hold the test's state (no counter, no status flip, no Transition), so a leniently-loaded bad config cannot actuate routes off a wrong-path measurement. An **empty** source-address stays legitimate ("default source") on every path.

## Validation
- **pkg/config**: strict compile rejects `10.0.0.999` / `not-an-ip` and a v6-source/v4-literal-target mismatch; lenient compile tolerates the same malformed source with a warning; hostname target + any source and empty source both accepted.
- **Fail-on-revert proven**: with the strict gate neutralized (master behavior) the strict-reject and family-mismatch tests fail because the malformed source is accepted.
- **pkg/rpm**: `probeDialer` returns `ErrProbeSetup` for a non-empty malformed source (nil dialer), default-binds on empty source, carries a valid source through to `LocalAddr`.
- `go test ./pkg/config/... ./pkg/rpm/...` and `go vet` green; gofmt clean.
- `docs/multi-wan.md` documents the new source-address validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)