### PR TITLE
Reject hostname target on a scoped RPM test at commit (#2493)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12973,3 +12973,18 @@ top.
   **File(s)**: pkg/config/compiler.go, pkg/config/compiler_services.go,
   pkg/config/compiler_rpm_source_2492_test.go, pkg/rpm/rpm.go,
   pkg/rpm/probe_dialer_2492_test.go, docs/multi-wan.md, _Log.md
+
+- **Timestamp**: 2026-06-24
+  **Action**: #2493 — reject hostname target on a SCOPED RPM test at commit
+  (DNS escapes the configured VRF/device scope); add resolver seam +
+  runtime hold-state guard. New `(*RPMTest).IsScoped()` SSOT predicate
+  (routing-instance/destination-interface/next-hop), strict validator
+  `validateRPMScopedHostnameStrict` (strict reject / lenient warn, #2492
+  mirror), `rpm.Manager.resolveTarget` injectable resolver seam,
+  `scopedHostnameError` executeProbe guard (ErrProbeSetup hold-state).
+  Deferred full VRF-aware resolver documented in docs/multi-wan.md.
+  **File(s)**: pkg/config/types_system.go, pkg/config/compiler.go,
+  pkg/config/compiler_services.go,
+  pkg/config/compiler_rpm_scoped_hostname_2493_test.go, pkg/rpm/rpm.go,
+  pkg/rpm/icmp.go, pkg/rpm/scoped_hostname_2493_test.go, docs/multi-wan.md,
+  _Log.md

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -67,6 +67,33 @@ set services rpm probe WAN test wan-a thresholds successive-loss 3
   a persisted/peer-synced config still boots (#1960 no-brick); the
   runtime dialer guard then returns the same setup error, so the test
   holds state (below) rather than measuring the wrong path.
+- **Scoped tests require an IP-literal target (#2493).** A *scoped*
+  test — one with `routing-instance`, `destination-interface`, or
+  `next-hop` set — binds its probe **data** socket to a specific VRF /
+  egress device (`SO_BINDTODEVICE`) or path (`SO_MARK`). Hostname
+  resolution, however, runs through the process-default resolver /
+  table / source: the bind is applied in the per-connection `Control`
+  hook, which fires **after** name resolution, so DNS escapes the
+  configured scope. With split-horizon / per-WAN DNS that turns
+  path-health into a resolver-context test (false PASS/FAIL feeding
+  ip-monitoring failover). Therefore a **hostname target on a scoped
+  test is rejected at commit** (strict commit / commit-check;
+  `validateRPMScopedHostnameStrict`). An **IP-literal** target on a
+  scoped test is fine (no resolution), and a **hostname on an
+  *unscoped*** (default-context) test is fine (it resolves in the same
+  context it probes — today's behavior, no regression). On the tolerant
+  load / peer-sync path the rejection is downgraded to a warning so a
+  persisted/peer-synced config still boots (#1960 no-brick); the runtime
+  prober then returns the probe-setup error for the same combination, so
+  a leniently-loaded scoped-hostname test **holds state** rather than
+  actuating routes off a mis-scoped measurement.
+  - *Deferred:* a **VRF-aware resolver** — binding the DNS socket to the
+    scope device and using the routing-instance's resolv context — would
+    let a scoped hostname resolve in-context and lift this restriction.
+    That is a larger feature (per-instance resolver wiring); the
+    injectable `Manager.resolveTarget` seam (`pkg/rpm`) is the slot where
+    it drops in. Until then the safe increment is the commit reject
+    above. Tracked as the #2493 follow-up.
 - Probe config re-applies on commit, gated on the rendered RPM stanza
   hash — unrelated commits never reset probe state.
 - **Environment errors never move routes**: a probe-socket setup

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -489,6 +489,20 @@ type compileOpts struct {
 	// state rather than actuating routes off a wildcard measurement.
 	// Same doctrine as lenientDestNATAddresses / lenientNATHostMask.
 	lenientRPMSourceAddress bool
+	// lenientRPMScopedHostname (#2493) downgrades the scoped-hostname RPM
+	// gate (validateRPMScopedHostnameStrict) from a hard compile error to
+	// a cfg.Warnings entry. A scoped test (routing-instance /
+	// destination-interface / next-hop) binds its DATA socket to a
+	// specific VRF/egress device, but hostname resolution escapes that
+	// scope through the process-default resolver (the bind is applied
+	// AFTER name resolution), so the probe measures resolver context
+	// instead of path health — a false PASS/FAIL into ip-monitoring
+	// failover. Strict on commit / commit-check (hard reject); lenient on
+	// load / peer-sync (warn — #1960 no-brick; the runtime executeProbe
+	// guard returns ErrProbeSetup for the same combination, so the
+	// leniently-loaded test HOLDS state rather than actuating off a
+	// mis-scoped measurement). Same doctrine as lenientRPMSourceAddress.
+	lenientRPMScopedHostname bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -539,6 +553,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyZoneRefs:              true,
 		lenientDestNATAddresses:            true,
 		lenientRPMSourceAddress:            true,
+		lenientRPMScopedHostname:           true,
 	})
 }
 
@@ -640,6 +655,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyZoneRefs:              true,
 		lenientDestNATAddresses:            true,
 		lenientRPMSourceAddress:            true,
+		lenientRPMScopedHostname:           true,
 	})
 }
 
@@ -1434,6 +1450,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRPMSourceAddress {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("rpm source-address (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2493: scoped RPM hostname gate. A scoped test (routing-instance /
+	// destination-interface / next-hop) binds its probe DATA socket to a
+	// specific VRF/egress device, but hostname resolution escapes that
+	// scope through the process-default resolver (the SO_BINDTODEVICE bind
+	// is applied per-connection, AFTER name resolution). With split-horizon
+	// DNS the probe then measures resolver context, not path health, and
+	// publishes a false PASS/FAIL into ip-monitoring failover. IP-literal
+	// targets (no resolution) and hostname targets on UNSCOPED tests are
+	// unaffected. Strict on commit / commit-check (hard reject so the
+	// operator must use an IP literal); lenient on load / peer-sync (warn —
+	// #1960; the runtime executeProbe guard returns ErrProbeSetup for the
+	// same combination, so the leniently-loaded test HOLDS state instead of
+	// actuating off a mis-scoped measurement). The full VRF-aware resolver
+	// is deferred (docs/multi-wan.md).
+	if err := validateRPMScopedHostnameStrict(cfg); err != nil {
+		if opts.lenientRPMScopedHostname {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("rpm scoped hostname (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_rpm_scoped_hostname_2493_test.go
+++ b/pkg/config/compiler_rpm_scoped_hostname_2493_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRPMScopedHostnameStrictRejects pins the #2493 commit-time gate: a
+// HOSTNAME target on a SCOPED test (routing-instance, destination-interface,
+// or next-hop) is hard-rejected on the strict path (commit / commit-check).
+// DNS resolution is not VRF/device-scoped — the SO_BINDTODEVICE bind is
+// applied per-connection, AFTER name resolution — so the probe would
+// resolve out-of-context and measure resolver health, not path health.
+//
+// This FAILS against master, which accepts the scoped hostname and silently
+// leaks the DNS lookup out of the configured scope.
+func TestRPMScopedHostnameStrictRejects(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope string // the scoping set-line tail
+	}{
+		{"routing-instance", "set services rpm probe P test t routing-instance ISP-B"},
+		{"destination-interface", "set services rpm probe P test t destination-interface ge-0/0/1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := []string{
+				"set services rpm probe P test t probe-type icmp-ping",
+				"set services rpm probe P test t target example.com",
+				tc.scope,
+			}
+			tree := buildTree(t, lines)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted scoped hostname target; want strict reject")
+			}
+			if !strings.Contains(err.Error(), "hostname on a scoped test") {
+				t.Fatalf("err = %v, want substring %q", err, "hostname on a scoped test")
+			}
+		})
+	}
+}
+
+// TestRPMScopedHostnameNextHopRejected covers the next-hop-pinned scope.
+// (validateRPMTest already rejects a hostname under next-hop because the
+// pin route needs an IP-literal target; this confirms the scoped-hostname
+// gate also treats next-hop as scoped, so the two gates agree.)
+func TestRPMScopedHostnameNextHopRejected(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target example.com",
+		"set services rpm probe P test t destination-interface ge-0/0/1",
+		"set services rpm probe P test t next-hop 10.0.0.1",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("CompileConfig accepted scoped+next-hop hostname target; want reject")
+	}
+}
+
+// TestRPMScopedHostnameLenientWarns pins the no-brick contract (#1960
+// doctrine): the same scoped hostname that the strict path rejects is
+// TOLERATED on the lenient load / peer-sync path — downgraded to a warning
+// so an already-persisted or peer-synced config still boots. The runtime
+// executeProbe guard then holds the test's state.
+func TestRPMScopedHostnameLenientWarns(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target example.com",
+		"set services rpm probe P test t routing-instance ISP-B",
+	}
+	tree := buildTree(t, lines)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on scoped hostname (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "rpm scoped hostname") {
+		t.Fatalf("expected a downgraded rpm scoped-hostname warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestRPMScopedIPLiteralAccepted confirms an IP-literal target on a scoped
+// test is accepted (no resolution, no leak) — the legitimate scoped-probe
+// shape used for multi-WAN path health.
+func TestRPMScopedIPLiteralAccepted(t *testing.T) {
+	t.Run("routing-instance + IP literal accepted", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type icmp-ping",
+			"set services rpm probe P test t target 8.8.8.8",
+			"set services rpm probe P test t routing-instance ISP-B",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("scoped IP-literal target must be accepted: %v", err)
+		}
+	})
+
+	t.Run("destination-interface + IPv6 literal accepted", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t probe-type icmp-ping",
+			"set services rpm probe P test t target 2001:db8::1",
+			"set services rpm probe P test t destination-interface ge-0/0/1",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("scoped IPv6-literal target must be accepted: %v", err)
+		}
+	})
+}
+
+// TestRPMUnscopedHostnameAccepted confirms NO regression: a hostname target
+// on an UNSCOPED (default-context) test resolves in the same context it
+// probes, so it stays accepted (today's behavior).
+func TestRPMUnscopedHostnameAccepted(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target example.com",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("unscoped hostname target must be accepted (no regression): %v", err)
+	}
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -122,6 +122,59 @@ func validateRPMSourceAddressStrict(cfg *Config) error {
 	return nil
 }
 
+// validateRPMScopedHostnameStrict rejects a HOSTNAME target on a SCOPED
+// RPM test (#2493). A scoped test (routing-instance, destination-interface,
+// or next-hop pin) binds its probe DATA socket to a specific VRF / egress
+// device (SO_BINDTODEVICE) or path (SO_MARK), but hostname resolution runs
+// through the process-default resolver / table / source: the bind is
+// applied in the per-connection Control hook, which fires AFTER name
+// resolution. With split-horizon / per-WAN DNS the probe then measures
+// resolver context, not path health, and can publish a false PASS/FAIL
+// into event-options / ip-monitoring failover.
+//
+// An IP-literal target needs no resolution and is unaffected. A hostname
+// on an UNSCOPED (default-context) test resolves in the same context it
+// probes and is allowed (today's behavior, no regression). The full fix —
+// a VRF-aware resolver binding the DNS socket to the scope device and
+// using the instance's resolv context — is a larger feature, deferred and
+// recorded in docs/multi-wan.md; until then the safe, shippable increment
+// is to refuse the silently-wrong combination at commit so an operator
+// cannot configure a scoped hostname probe that lies about path health.
+//
+// Strict on commit / commit-check (hard reject so the typo is
+// operator-visible); lenient on load / peer-sync (warn — #1960 no-brick;
+// the runtime executeProbe guard returns ErrProbeSetup for the same
+// combination, so a leniently-loaded test HOLDS state instead of actuating
+// routes off a mis-scoped measurement). Mirrors
+// validateRPMSourceAddressStrict.
+func validateRPMScopedHostnameStrict(cfg *Config) error {
+	if cfg == nil || cfg.Services.RPM == nil {
+		return nil
+	}
+	for _, probe := range cfg.Services.RPM.Probes {
+		if probe == nil {
+			continue
+		}
+		for _, test := range probe.Tests {
+			if test == nil || !test.IsScoped() {
+				continue
+			}
+			// Empty target is caught by validateRPMTest; an IP-literal
+			// target needs no DNS, so neither leaks the scope.
+			if test.Target == "" || net.ParseIP(test.Target) != nil {
+				continue
+			}
+			return fmt.Errorf(
+				"services rpm probe %q test %q: target %q is a hostname on a scoped test "+
+					"(routing-instance/destination-interface/next-hop); DNS is not VRF/device-scoped, "+
+					"so the probe would resolve out-of-context and measure resolver health instead of "+
+					"path health — use an IP-literal target",
+				probe.Name, test.Name, test.Target)
+		}
+	}
+	return nil
+}
+
 // validateRPMProbePinsStrict enforces the probe-pin band invariants
 // (#1827 PR-1a): at most ProbeTableCount next-hop-pinned tests (one
 // reserved kernel table each), and no routing-instance table ID may

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -585,6 +585,23 @@ type RPMTest struct {
 	DestPort             int    // for tcp-ping
 }
 
+// IsScoped reports whether the test's probe DATA socket is bound to a
+// specific VRF / egress device / next-hop path — i.e. probeOpts would set
+// SO_BINDTODEVICE (from destination-interface, or the routing-instance VRF
+// device) or SO_MARK (from a next-hop pin). A scoped test measures a
+// SPECIFIC path, so a hostname target must resolve in that path's context;
+// the process-default resolver does not, since name resolution happens
+// before the per-connection bind (#2493). Kept here as the single source
+// of truth so the commit-time gate (validateRPMScopedHostnameStrict) and
+// the runtime guard (rpm.Manager.executeProbe) agree on what "scoped"
+// means.
+func (t *RPMTest) IsScoped() bool {
+	if t == nil {
+		return false
+	}
+	return t.DestinationInterface != "" || t.RoutingInstance != "" || t.NextHop != ""
+}
+
 func (t *RPMTest) EffectiveProbeType() string {
 	if t == nil || t.ProbeType == "" {
 		return DefaultRPMProbeType
@@ -830,7 +847,7 @@ type FirewallFilterTerm struct {
 	// hard-rejects any term carrying an entry here at commit; the tolerant
 	// load path downgrades it to a warning (#1960 no-brick). Populated by
 	// compileFilterThen.
-	UnknownActions    []string
+	UnknownActions []string
 	// RejectMessageType is the optional message-type after `then reject`
 	// (e.g. tcp-reset, administratively-prohibited, port-unreachable). Junos
 	// accepts `then reject <message-type>` and the term acts as a plain reject;
@@ -841,15 +858,15 @@ type FirewallFilterTerm struct {
 	// NextTerm records `then next term` / `then next-term` — an explicit
 	// fall-through to the next term (a no-op terminating-wise; Action stays "").
 	// It is a recognized, valid construct, not an unknown action.
-	NextTerm          bool
-	RoutingInstance   string          // routing-instance name (policy-based routing)
-	Log               bool
-	Count             string           // counter name
-	ForwardingClass   string           // forwarding-class name
-	LossPriority      string           // loss-priority (low, medium-low, medium-high, high)
-	DSCPRewrite       string           // then dscp <value> — rewrite DSCP/traffic-class
-	Policer           string           // then policer <name> — reference to policer definition
-	FlexMatch         *FlexMatchConfig // flexible-match-range configuration
+	NextTerm        bool
+	RoutingInstance string // routing-instance name (policy-based routing)
+	Log             bool
+	Count           string           // counter name
+	ForwardingClass string           // forwarding-class name
+	LossPriority    string           // loss-priority (low, medium-low, medium-high, high)
+	DSCPRewrite     string           // then dscp <value> — rewrite DSCP/traffic-class
+	Policer         string           // then policer <name> — reference to policer definition
+	FlexMatch       *FlexMatchConfig // flexible-match-range configuration
 }
 
 // FlexMatchConfig defines a flexible byte-offset match condition.

--- a/pkg/rpm/icmp.go
+++ b/pkg/rpm/icmp.go
@@ -108,7 +108,11 @@ var ErrProbeSetup = errors.New("probe setup failed")
 // probeICMP sends one ICMP (or ICMPv6) echo request to the test target
 // and waits for the matching reply. Returns the measured RTT.
 func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest, opts probeSockOpts) (time.Duration, error) {
-	dst, err := resolveProbeTarget(test.Target)
+	resolve := m.resolveTarget
+	if resolve == nil {
+		resolve = resolveProbeTarget
+	}
+	dst, err := resolve(test.Target)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -171,6 +171,20 @@ type Manager struct {
 	// with a scripted probe-result sequence (#2527). It is set once
 	// before the manager runs and never mutated concurrently.
 	probeFn func(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error)
+
+	// resolveTarget is the injectable hostname-resolution seam (#2493).
+	// nil = resolveProbeTarget (process-default resolver via
+	// net.ResolveIPAddr). The default resolver is NOT VRF/device-scoped,
+	// so a SCOPED test (routing-instance / destination-interface /
+	// next-hop) against a hostname would resolve out-of-context. The
+	// scoped-hostname combination is rejected at commit
+	// (validateRPMScopedHostnameStrict) and held via ErrProbeSetup in
+	// executeProbe before any resolution runs, so this seam is consulted
+	// only for unscoped / IP-literal probes today. It exists so a future
+	// VRF-aware resolver can be slotted in (and so a test can assert the
+	// guard short-circuits a scoped hostname before the default resolver
+	// is reached).
+	resolveTarget func(target string) (net.IP, error)
 }
 
 // SetEventCallback registers a callback for RPM events.
@@ -569,6 +583,32 @@ func (m *Manager) pinInstallError(test *config.RPMTest, key string) error {
 	return nil
 }
 
+// scopedHostnameError holds a VRF/device-scoped test whose target is a
+// hostname (#2493). The probe DATA socket is bound to a specific VRF /
+// egress device (SO_BINDTODEVICE) or path (SO_MARK), but DNS resolution
+// runs through the process-default resolver / table / source — the bind is
+// applied in the per-connection Control hook, which fires AFTER name
+// resolution — so a scoped probe against a hostname resolves
+// out-of-context and measures resolver health rather than the scoped
+// path. The commit-time validator (validateRPMScopedHostnameStrict)
+// rejects this combination on the strict path; a leniently-loaded or
+// peer-synced config can still reach here, so hold state via ErrProbeSetup
+// (the probe loop holds, exactly like a failed source bind) instead of
+// actuating ip-monitoring failover off a mis-scoped measurement. Returns
+// nil for IP-literal targets (no resolution) and unscoped tests (resolve
+// in the same context they probe). A future VRF-aware resolver would lift
+// this guard.
+func scopedHostnameError(test *config.RPMTest) error {
+	if test == nil || !test.IsScoped() {
+		return nil
+	}
+	if test.Target == "" || net.ParseIP(test.Target) != nil {
+		return nil
+	}
+	return fmt.Errorf("%w: scoped RPM test target %q is a hostname; DNS is not VRF/device-scoped "+
+		"(resolves out-of-context) — use an IP-literal target", ErrProbeSetup, test.Target)
+}
+
 // runProbe dispatches a single probe through the test seam when one is
 // installed, otherwise the real executeProbe path.
 func (m *Manager) runProbe(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error) {
@@ -579,6 +619,9 @@ func (m *Manager) runProbe(ctx context.Context, test *config.RPMTest, key string
 }
 
 func (m *Manager) executeProbe(ctx context.Context, test *config.RPMTest, key string) (time.Duration, error) {
+	if err := scopedHostnameError(test); err != nil {
+		return 0, err
+	}
 	if err := m.pinInstallError(test, key); err != nil {
 		return 0, err
 	}

--- a/pkg/rpm/scoped_hostname_2493_test.go
+++ b/pkg/rpm/scoped_hostname_2493_test.go
@@ -1,0 +1,107 @@
+// scoped_hostname_2493_test.go — #2493: a VRF/device-scoped RPM test
+// (routing-instance / destination-interface / next-hop) against a HOSTNAME
+// must NOT probe. DNS resolution runs through the process-default resolver,
+// which is not bound to the test's scope (the SO_BINDTODEVICE bind is
+// applied per-connection, AFTER name resolution), so a scoped hostname
+// probe measures resolver context, not path health. The commit gate
+// rejects this; a leniently-loaded config still reaches the prober, so it
+// holds state via ErrProbeSetup before any resolution runs.
+package rpm
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestScopedHostnameHoldsStateAndSkipsResolver asserts the runtime guard:
+// a scoped hostname probe returns ErrProbeSetup, opens NO socket, and never
+// falls through to the (process-default) resolver seam.
+func TestScopedHostnameHoldsStateAndSkipsResolver(t *testing.T) {
+	scoped := []struct {
+		name string
+		test *config.RPMTest
+	}{
+		{"routing-instance", &config.RPMTest{Name: "t", Target: "wan-a.example.com", RoutingInstance: "ISP-B"}},
+		{"destination-interface", &config.RPMTest{Name: "t", Target: "wan-a.example.com", DestinationInterface: "ge-0/0/1"}},
+	}
+	for _, tc := range scoped {
+		t.Run(tc.name, func(t *testing.T) {
+			var listens, resolves atomic.Int32
+			m, conn := newFakeManager(nil)
+			inner := m.icmpListen
+			m.icmpListen = func(network, laddr string, opts probeSockOpts) (net.PacketConn, error) {
+				listens.Add(1)
+				return inner(network, laddr, opts)
+			}
+			m.resolveTarget = func(target string) (net.IP, error) {
+				resolves.Add(1)
+				return net.ParseIP("203.0.113.1"), nil
+			}
+
+			_, err := m.executeProbe(context.Background(), tc.test, "WAN/t")
+			if !errors.Is(err, ErrProbeSetup) {
+				t.Fatalf("scoped hostname not classified ErrProbeSetup: %v", err)
+			}
+			if n := resolves.Load(); n != 0 {
+				t.Fatalf("scoped hostname consulted the default resolver %d times, want 0 "+
+					"(DNS would escape the configured scope)", n)
+			}
+			if n := listens.Load(); n != 0 {
+				t.Fatalf("scoped hostname opened %d sockets, want 0", n)
+			}
+			if len(conn.sent) != 0 {
+				t.Fatalf("scoped hostname sent %d packets, want 0", len(conn.sent))
+			}
+		})
+	}
+}
+
+// TestUnscopedHostnameUsesResolver is the contrast case: an UNSCOPED
+// hostname probe is NOT held — it resolves through the seam (in the same
+// default context it probes) and sends.
+func TestUnscopedHostnameUsesResolver(t *testing.T) {
+	var resolves atomic.Int32
+	target := net.ParseIP("203.0.113.5")
+	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
+		return []fakeReply{echoReply(t, b, false, false, target)}
+	})
+	m.resolveTarget = func(name string) (net.IP, error) {
+		resolves.Add(1)
+		return target, nil
+	}
+
+	test := &config.RPMTest{Name: "t", Target: "host.example.com"} // no scope
+	if _, err := m.executeProbe(context.Background(), test, "WAN/t"); err != nil {
+		t.Fatalf("unscoped hostname probe must run: %v", err)
+	}
+	if resolves.Load() != 1 {
+		t.Fatalf("unscoped hostname did not consult the resolver seam: calls=%d", resolves.Load())
+	}
+	if len(conn.sent) != 1 {
+		t.Fatalf("unscoped hostname did not send: sent=%d", len(conn.sent))
+	}
+}
+
+// TestScopedIPLiteralProbes confirms a scoped IP-literal target is NOT held
+// by the scoped-hostname guard — the legitimate multi-WAN scoped-probe
+// shape probes normally. (The real resolveProbeTarget short-circuits an IP
+// literal via net.ParseIP without any DNS lookup, so no scope is escaped.)
+func TestScopedIPLiteralProbes(t *testing.T) {
+	target := net.ParseIP("192.0.2.10")
+	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
+		return []fakeReply{echoReply(t, b, false, false, target)}
+	})
+
+	test := &config.RPMTest{Name: "t", Target: "192.0.2.10", DestinationInterface: "ge-0/0/1"}
+	if _, err := m.executeProbe(context.Background(), test, "WAN/t"); err != nil {
+		t.Fatalf("scoped IP-literal probe must run: %v", err)
+	}
+	if len(conn.sent) != 1 {
+		t.Fatalf("scoped IP-literal did not send: sent=%d", len(conn.sent))
+	}
+}


### PR DESCRIPTION
Closes #2493

## Problem
RPM hostname resolution is **not** scoped to the configured
`routing-instance` / `destination-interface` / `next-hop` pin — only the
probe **data** socket is VRF/device-bound. `SO_BINDTODEVICE` is applied
in the per-connection `Control` hook, which fires **after** name
resolution, so a scoped test against a **hostname** resolves DNS via the
process-default resolver / table / source. With split-horizon or per-WAN
DNS this turns path-health into a resolver-context test and publishes a
false PASS/FAIL into event-options / ip-monitoring failover. IP-literal
targets are unaffected (no resolution); only hostname targets on scoped
tests leak.

## Approach (issue's primary recommendation — bounded fix, defer full resolver)
Refuse the silently-wrong combination at commit. A VRF-aware resolver
(binding the DNS socket to the scope device + the instance's resolv
context) is a larger feature, recorded as a deferred follow-up.

- **`(*RPMTest).IsScoped()`** (`pkg/config/types_system.go`) is the SSOT
  predicate — `DestinationInterface` / `RoutingInstance` / `NextHop` set
  — matching exactly the conditions under which `probeOpts` binds the
  data socket. Both the commit gate and the runtime guard consult it.
- **`validateRPMScopedHostnameStrict`** rejects a hostname target on a
  scoped test; IP-literal-on-scoped and hostname-on-unscoped are accepted
  (no regression). Wired in `compileExpanded` with a new
  `lenientRPMScopedHostname` opt set true **only** in the two `Lenient`
  constructors — strict commit/commit-check hard-rejects, tolerant
  load/peer-sync downgrades to `cfg.Warnings` (#1960 no-brick). Mirrors
  the #2492 source-address strict/lenient wiring exactly.
- **Resolver seam + runtime guard**: `rpm.Manager.resolveTarget`
  (injectable; default `resolveProbeTarget`) is the slot a future
  VRF-aware resolver drops into and the assertion point that a scoped
  probe doesn't fall through to the default resolver. `scopedHostnameError`
  guards `executeProbe` before any resolution/socket open — a
  leniently-loaded scoped-hostname test returns `ErrProbeSetup` and
  **holds state** instead of actuating off a mis-scoped measurement.

## Tests (fail-on-revert verified against master)
- `pkg/config`: scoped hostname **rejected** strict / **warned** lenient;
  scoped IP-literal **accepted**; unscoped hostname **accepted**. The
  strict-reject and lenient-warn tests **FAIL on master** (which accepts
  the scoped hostname and emits no warning).
- `pkg/rpm`: scoped hostname → `ErrProbeSetup`, no socket, resolver seam
  never consulted; unscoped hostname → seam consulted + sends; scoped
  IP-literal → probes normally.

## Docs
`docs/multi-wan.md` documents the scoped-hostname restriction and the
deferred VRF-aware resolver follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)