### PR TITLE
rpm: preserve IPv6 link-local zone in ICMP probe (#2494)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -12988,3 +12988,17 @@ top.
   pkg/config/compiler_rpm_scoped_hostname_2493_test.go, pkg/rpm/rpm.go,
   pkg/rpm/icmp.go, pkg/rpm/scoped_hostname_2493_test.go, docs/multi-wan.md,
   _Log.md
+
+- **Timestamp**: 2026-06-24
+  **Action**: #2494 — preserve IPv6 link-local zone in RPM ICMP probe;
+  default zone from destination-interface; reject bare link-local at
+  commit (strict/lenient #1960 mirror). resolveProbeTarget +
+  resolveTarget seam now return *net.IPAddr; probeICMP sends
+  &net.IPAddr{IP,Zone}; validateRPMLinkLocalZoneStrict +
+  lenientRPMLinkLocalZone opt. Fail-on-revert proven (4 rpm + 2 config
+  tests). gofmt+vet+test green.
+  **File(s)**: pkg/rpm/icmp.go, pkg/rpm/rpm.go, pkg/rpm/icmp_test.go,
+  pkg/rpm/scoped_hostname_2493_test.go, pkg/rpm/icmp_linklocal_2494_test.go,
+  pkg/config/compiler.go, pkg/config/compiler_services.go,
+  pkg/config/compiler_rpm_linklocal_zone_2494_test.go, docs/multi-wan.md,
+  _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -13002,3 +13002,14 @@ top.
   pkg/config/compiler.go, pkg/config/compiler_services.go,
   pkg/config/compiler_rpm_linklocal_zone_2494_test.go, docs/multi-wan.md,
   _Log.md
+
+- **Timestamp**: 2026-06-24
+  **Action**: #2494 fold (hostile-reviewer nit) — link-local zone-default
+  now derives from destination-interface specifically
+  (routing.ResolveProbeInterface), NOT opts.BindDevice, so a
+  routing-instance-only bare link-local (lenient load) HOLDS with
+  ErrProbeSetup instead of sending to a "vrf-<ri>" non-link zone (counted
+  as path loss). Preserves #1960 hold-state doctrine. Added
+  fail-on-revert test TestProbeICMPLinkLocalRoutingInstanceOnlyHeld.
+  **File(s)**: pkg/rpm/icmp.go, pkg/rpm/icmp_linklocal_2494_test.go,
+  _Log.md

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -94,6 +94,32 @@ set services rpm probe WAN test wan-a thresholds successive-loss 3
     injectable `Manager.resolveTarget` seam (`pkg/rpm`) is the slot where
     it drops in. Until then the safe increment is the commit reject
     above. Tracked as the #2493 follow-up.
+- **IPv6 link-local targets need a scope (#2494).** A link-local target
+  (`fe80::/10`) is unprobeable without an egress link: the kernel cannot
+  pick the link, so the ICMP echo goes nowhere. The scope can come from
+  an explicit `%zone` on the literal (`target fe80::1%ge-0/0/3`) or be
+  derived from the test's `destination-interface` — both resolve to the
+  same kernel interface name the probe data socket binds via
+  `SO_BINDTODEVICE`. A **bare link-local with neither a `%zone` nor a
+  `destination-interface` is rejected at commit**
+  (`validateRPMLinkLocalZoneStrict`); a link-local **with** either is
+  accepted. The send path preserves the zone into the ICMP destination
+  (`net.IPAddr{IP, Zone}`) so the echo leaves the right link; a bare
+  `fe80::1` with a `destination-interface` defaults its zone to that
+  device. Global IPv6 and IPv4 targets are unaffected. On the tolerant
+  load / peer-sync path the rejection is downgraded to a warning (#1960
+  no-brick); the runtime prober then returns the probe-setup error for
+  the same scopeless link-local, so it **holds state** rather than
+  actuating off a dead probe.
+  - *Honoring an explicit `%zone`:* the zone string is normalized for the
+    Junos slash form (`ge-0/0/3` → `ge-0-0-3`) but is **not** run through
+    the RETH-member translation that `destination-interface` gets — for a
+    RETH base name use `destination-interface` (fully resolved through the
+    RETH map) rather than a raw `%zone`.
+  - *Reply-match:* the echo-reply match compares the peer **IP** only, not
+    the zone (id/seq already disambiguate the exchange, and the kernel may
+    not populate the reply's zone). The send-side zone is the correctness
+    fix; the reply-match stays zone-agnostic by design.
 - Probe config re-applies on commit, gated on the rendered RPM stanza
   hash — unrelated commits never reset probe state.
 - **Environment errors never move routes**: a probe-socket setup

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -503,6 +503,18 @@ type compileOpts struct {
 	// leniently-loaded test HOLDS state rather than actuating off a
 	// mis-scoped measurement). Same doctrine as lenientRPMSourceAddress.
 	lenientRPMScopedHostname bool
+	// lenientRPMLinkLocalZone (#2494) downgrades the bare-link-local RPM
+	// target gate (validateRPMLinkLocalZoneStrict) from a hard compile
+	// error to a cfg.Warnings entry. An IPv6 link-local target with no
+	// `%zone` and no destination-interface has no egress-link scope, so
+	// the kernel cannot pick the link and the probe is dead. Strict on
+	// commit / commit-check (hard reject so the gap is operator-visible);
+	// lenient on load / peer-sync (warn — #1960 no-brick; the runtime
+	// probeICMP guard returns ErrProbeSetup for the same scopeless
+	// link-local, so the leniently-loaded test HOLDS state rather than
+	// actuating off a dead measurement). Same doctrine as
+	// lenientRPMScopedHostname.
+	lenientRPMLinkLocalZone bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -554,6 +566,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientDestNATAddresses:            true,
 		lenientRPMSourceAddress:            true,
 		lenientRPMScopedHostname:           true,
+		lenientRPMLinkLocalZone:            true,
 	})
 }
 
@@ -656,6 +669,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientDestNATAddresses:            true,
 		lenientRPMSourceAddress:            true,
 		lenientRPMScopedHostname:           true,
+		lenientRPMLinkLocalZone:            true,
 	})
 }
 
@@ -1473,6 +1487,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRPMScopedHostname {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("rpm scoped hostname (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2494: IPv6 link-local RPM target zone gate. A link-local target
+	// (fe80::/10) needs an egress-link scope — an explicit `%zone` on the
+	// literal or a destination-interface — or the kernel cannot pick the
+	// link and the ICMP echo is dead. A bare link-local with neither is
+	// refused so the operator sees the gap at commit instead of a silently
+	// dead probe driving ip-monitoring failover. Strict on commit /
+	// commit-check (hard reject); lenient on load / peer-sync (warn —
+	// #1960; the runtime probeICMP guard returns ErrProbeSetup for the
+	// same scopeless link-local, so the leniently-loaded test HOLDS state
+	// instead of actuating off a dead measurement).
+	if err := validateRPMLinkLocalZoneStrict(cfg); err != nil {
+		if opts.lenientRPMLinkLocalZone {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("rpm link-local zone (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_rpm_linklocal_zone_2494_test.go
+++ b/pkg/config/compiler_rpm_linklocal_zone_2494_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRPMLinkLocalNoScopeStrictRejects pins the #2494 commit-time gate: an
+// IPv6 link-local target (fe80::/10) with NO scope — neither an explicit
+// %zone on the literal nor a destination-interface — is hard-rejected on
+// the strict path. A link-local address is unprobeable without an egress
+// link; the kernel cannot pick one, so the ICMP echo goes nowhere.
+//
+// This FAILS against master, which accepts the scopeless link-local and
+// silently runs a dead probe into ip-monitoring failover.
+func TestRPMLinkLocalNoScopeStrictRejects(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target fe80::1",
+	}
+	tree := buildTree(t, lines)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted a scopeless link-local target; want strict reject")
+	}
+	if !strings.Contains(err.Error(), "link-local") {
+		t.Fatalf("err = %v, want substring %q", err, "link-local")
+	}
+}
+
+// TestRPMLinkLocalWithDestInterfaceAccepted confirms a link-local target
+// scoped by a destination-interface is accepted — the zone is derivable
+// from the egress device, so the probe can pick the link.
+func TestRPMLinkLocalWithDestInterfaceAccepted(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target fe80::1",
+		"set services rpm probe P test t destination-interface ge-0/0/3",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("link-local + destination-interface must be accepted: %v", err)
+	}
+}
+
+// TestRPMLinkLocalWithExplicitZoneAccepted confirms a link-local literal
+// carrying an explicit %zone is accepted with no destination-interface.
+func TestRPMLinkLocalWithExplicitZoneAccepted(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target fe80::1%ge-0/0/3",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("link-local with explicit %%zone must be accepted: %v", err)
+	}
+}
+
+// TestRPMLinkLocalNoScopeLenientWarns pins the no-brick contract (#1960
+// doctrine): the same scopeless link-local the strict path rejects is
+// TOLERATED on the lenient load / peer-sync path — downgraded to a warning
+// so an already-persisted or peer-synced config still boots. The runtime
+// probeICMP guard then holds the test's state with ErrProbeSetup.
+func TestRPMLinkLocalNoScopeLenientWarns(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target fe80::1",
+	}
+	tree := buildTree(t, lines)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on scopeless link-local (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "rpm link-local zone") {
+		t.Fatalf("expected a downgraded rpm link-local-zone warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestRPMGlobalV6TargetUnaffected confirms a non-link-local IPv6 target is
+// not touched by the link-local gate (no regression).
+func TestRPMGlobalV6TargetUnaffected(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type icmp-ping",
+		"set services rpm probe P test t target 2001:db8::10",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("global IPv6 target must be unaffected: %v", err)
+	}
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -175,6 +175,65 @@ func validateRPMScopedHostnameStrict(cfg *Config) error {
 	return nil
 }
 
+// validateRPMLinkLocalZoneStrict rejects an IPv6 link-local RPM target
+// that carries no scope (#2494). A link-local destination (fe80::/10) is
+// meaningless without a zone: the kernel cannot pick the egress link, so
+// the ICMP echo goes to the wrong link or fails outright. The scope can
+// come from an explicit `%zone` on the target literal (fe80::1%ge-0/0/3)
+// or be derived from the test's destination-interface (the same egress
+// device the probe data socket binds via SO_BINDTODEVICE). A bare
+// link-local with NEITHER is unprobeable and is refused so the operator
+// sees the gap at commit instead of a silently-dead probe feeding
+// ip-monitoring failover.
+//
+// Only IP-literal targets are checked: net.ParseIP rejects a zoned
+// literal so the zone is split off by hand first (no DNS at commit). A
+// hostname resolving to a link-local cannot be caught here (resolution is
+// runtime); a scoped hostname is already refused by
+// validateRPMScopedHostnameStrict, and an unscoped hostname that resolves
+// to a link-local would fail at runtime with ErrProbeSetup (the same
+// missing-zone error in probeICMP). routing-instance / next-hop scopes do
+// NOT supply a link scope (a VRF master device / fwmark route is not an
+// egress link for fe80::), so only destination-interface satisfies the
+// requirement. Strict on commit / commit-check (hard reject so the gap is
+// operator-visible); lenient on load / peer-sync (warn — #1960 no-brick;
+// the runtime probeICMP guard returns ErrProbeSetup for the same bare
+// link-local, so a leniently-loaded test HOLDS state instead of actuating
+// routes off a dead measurement). Mirrors validateRPMScopedHostnameStrict.
+func validateRPMLinkLocalZoneStrict(cfg *Config) error {
+	if cfg == nil || cfg.Services.RPM == nil {
+		return nil
+	}
+	for _, probe := range cfg.Services.RPM.Probes {
+		if probe == nil {
+			continue
+		}
+		for _, test := range probe.Tests {
+			if test == nil || test.Target == "" {
+				continue
+			}
+			host := test.Target
+			zone := ""
+			if i := strings.IndexByte(host, '%'); i >= 0 {
+				zone = host[i+1:]
+				host = host[:i]
+			}
+			ip := net.ParseIP(host)
+			if ip == nil || ip.To4() != nil || !ip.IsLinkLocalUnicast() {
+				continue // not an IPv6 link-local literal
+			}
+			if zone == "" && test.DestinationInterface == "" {
+				return fmt.Errorf(
+					"services rpm probe %q test %q: target %q is an IPv6 link-local address "+
+						"with no scope — add an explicit %%zone (fe80::1%%ge-0/0/3) or a "+
+						"destination-interface so the probe can pick the egress link",
+					probe.Name, test.Name, test.Target)
+			}
+		}
+	}
+	return nil
+}
+
 // validateRPMProbePinsStrict enforces the probe-pin band invariants
 // (#1827 PR-1a): at most ProbeTableCount next-hop-pinned tests (one
 // reserved kernel table each), and no routing-instance table ID may

--- a/pkg/rpm/icmp.go
+++ b/pkg/rpm/icmp.go
@@ -112,11 +112,35 @@ func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest, opts prob
 	if resolve == nil {
 		resolve = resolveProbeTarget
 	}
-	dst, err := resolve(test.Target)
+	dstAddr, err := resolve(test.Target)
 	if err != nil {
 		return 0, err
 	}
+	dst := dstAddr.IP
+	zone := dstAddr.Zone
 	isV6 := dst.To4() == nil
+
+	// #2494: an IPv6 link-local target must carry a scope (zone) or the
+	// kernel cannot pick the egress link — the echo goes to the wrong
+	// link or fails. Honor an explicit `%zone` from the target literal
+	// (normalize Junos slash form to the kernel name); otherwise default
+	// the zone to the resolved egress device the data socket binds via
+	// SO_BINDTODEVICE (opts.BindDevice — already the kernel ifname). The
+	// commit-time gate (validateRPMLinkLocalZoneStrict) rejects a bare
+	// link-local with neither a zone nor a destination-interface, so by
+	// the time a probe runs one of the two is present (or the test was
+	// loaded leniently and HOLDS via the same missing-zone error below).
+	if isV6 && dst.IsLinkLocalUnicast() {
+		if zone != "" {
+			zone = config.LinuxIfName(zone)
+		} else {
+			zone = opts.BindDevice
+		}
+		if zone == "" {
+			return 0, fmt.Errorf("%w: icmp link-local target %s needs a zone "+
+				"(%%zone or destination-interface)", ErrProbeSetup, dst)
+		}
+	}
 
 	network := "ip4:icmp"
 	proto := icmpProtocolIPv4
@@ -155,7 +179,10 @@ func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest, opts prob
 	}
 
 	start := time.Now()
-	if _, err := conn.WriteTo(wire, &net.IPAddr{IP: dst}); err != nil {
+	// Carry the zone so a link-local destination is scoped to the right
+	// egress link (#2494). For global addresses zone is "" and this is
+	// the same &net.IPAddr{IP: dst} as before.
+	if _, err := conn.WriteTo(wire, &net.IPAddr{IP: dst, Zone: zone}); err != nil {
 		return 0, fmt.Errorf("icmp send: %w", err)
 	}
 
@@ -188,6 +215,11 @@ func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest, opts prob
 		if !ok || echo.ID != id || echo.Seq != seq {
 			continue
 		}
+		// Reply-match compares the peer IP only, not the zone (#2494):
+		// the kernel may or may not populate the reply's IPAddr.Zone, and
+		// id/seq already disambiguate this exchange. The send-side zone is
+		// the correctness fix (the echo leaves the right link); the
+		// reply-match stays zone-agnostic by design.
 		if peerIP, ok := peer.(*net.IPAddr); ok && !peerIP.IP.Equal(dst) {
 			continue
 		}
@@ -195,17 +227,23 @@ func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest, opts prob
 	}
 }
 
-// resolveProbeTarget parses or resolves the test target into an IP.
-func resolveProbeTarget(target string) (net.IP, error) {
+// resolveProbeTarget parses or resolves the test target into an address,
+// preserving the IPv6 link-local zone (#2494). net.ParseIP rejects a
+// zoned literal (`fe80::1%ge-0-0-3`), so a zoned target falls through to
+// net.ResolveIPAddr, which parses the scope id into IPAddr.Zone — the
+// zone must survive to the send path so a link-local echo is steered to
+// the right link. A plain IP literal short-circuits ParseIP (no DNS, no
+// zone); a hostname resolves through net.ResolveIPAddr.
+func resolveProbeTarget(target string) (*net.IPAddr, error) {
 	if target == "" {
 		return nil, fmt.Errorf("no target specified")
 	}
 	if ip := net.ParseIP(target); ip != nil {
-		return ip, nil
+		return &net.IPAddr{IP: ip}, nil
 	}
 	addr, err := net.ResolveIPAddr("ip", target)
 	if err != nil {
 		return nil, fmt.Errorf("resolve target %q: %w", target, err)
 	}
-	return addr.IP, nil
+	return addr, nil
 }

--- a/pkg/rpm/icmp.go
+++ b/pkg/rpm/icmp.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/routing"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -124,21 +125,32 @@ func (m *Manager) probeICMP(ctx context.Context, test *config.RPMTest, opts prob
 	// kernel cannot pick the egress link — the echo goes to the wrong
 	// link or fails. Honor an explicit `%zone` from the target literal
 	// (normalize Junos slash form to the kernel name); otherwise default
-	// the zone to the resolved egress device the data socket binds via
-	// SO_BINDTODEVICE (opts.BindDevice — already the kernel ifname). The
-	// commit-time gate (validateRPMLinkLocalZoneStrict) rejects a bare
-	// link-local with neither a zone nor a destination-interface, so by
-	// the time a probe runs one of the two is present (or the test was
-	// loaded leniently and HOLDS via the same missing-zone error below).
+	// the zone to the egress device derived from destination-interface
+	// (the same routing.ResolveProbeInterface mapping probeOpts uses for
+	// SO_BINDTODEVICE — RETH → physical member, slashes → dashes). NOTE:
+	// we deliberately do NOT fall back to opts.BindDevice here — that can
+	// hold the routing-instance VRF device ("vrf-<ri>") from probeOpts,
+	// which is NOT an egress link for fe80:: . A routing-instance-only
+	// link-local (no destination-interface, no %zone) is rejected by the
+	// strict commit gate (validateRPMLinkLocalZoneStrict), but can still
+	// reach here on the lenient load / peer-sync path; defaulting it to
+	// "vrf-<ri>" would let it SEND (counted as path loss) instead of
+	// HOLDING state, breaking the #1960 hold-state doctrine. Only a real
+	// destination-interface satisfies the link-local scope; with neither
+	// we fail closed with ErrProbeSetup so the test HOLDS.
 	if isV6 && dst.IsLinkLocalUnicast() {
 		if zone != "" {
 			zone = config.LinuxIfName(zone)
 		} else {
-			zone = opts.BindDevice
+			m.mu.RLock()
+			rethMap := m.rethMap
+			m.mu.RUnlock()
+			zone = routing.ResolveProbeInterface(test.DestinationInterface, rethMap)
 		}
 		if zone == "" {
 			return 0, fmt.Errorf("%w: icmp link-local target %s needs a zone "+
-				"(%%zone or destination-interface)", ErrProbeSetup, dst)
+				"(%%zone or destination-interface; a routing-instance VRF is not an egress link)",
+				ErrProbeSetup, dst)
 		}
 	}
 

--- a/pkg/rpm/icmp_linklocal_2494_test.go
+++ b/pkg/rpm/icmp_linklocal_2494_test.go
@@ -1,0 +1,122 @@
+package rpm
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestResolveProbeTargetPreservesZone proves resolveProbeTarget keeps the
+// IPv6 link-local zone (#2494). net.ParseIP rejects a zoned literal, so a
+// `fe80::1%ge-0-0-3` target must round-trip through net.ResolveIPAddr,
+// which populates IPAddr.Zone. Before #2494 the resolver returned a bare
+// net.IP and the zone was dropped — this test fails on master.
+func TestResolveProbeTargetPreservesZone(t *testing.T) {
+	addr, err := resolveProbeTarget("fe80::1%ge-0-0-3")
+	if err != nil {
+		t.Fatalf("resolveProbeTarget: %v", err)
+	}
+	if addr.Zone != "ge-0-0-3" {
+		t.Fatalf("zone = %q, want ge-0-0-3 (link-local scope dropped)", addr.Zone)
+	}
+	if !addr.IP.IsLinkLocalUnicast() {
+		t.Fatalf("IP = %v, want a link-local address", addr.IP)
+	}
+
+	// A plain global literal carries no zone.
+	g, err := resolveProbeTarget("2001:db8::10")
+	if err != nil {
+		t.Fatalf("resolveProbeTarget global: %v", err)
+	}
+	if g.Zone != "" {
+		t.Fatalf("global zone = %q, want empty", g.Zone)
+	}
+}
+
+// TestProbeICMPLinkLocalSendsWithExplicitZone confirms the send path
+// builds an &net.IPAddr carrying the explicit zone from the target
+// literal. This is the core correctness fix: the echo leaves the right
+// link. Fails on master (send used &net.IPAddr{IP: dst} with no Zone).
+func TestProbeICMPLinkLocalSendsWithExplicitZone(t *testing.T) {
+	target := net.ParseIP("fe80::1")
+	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
+		return []fakeReply{echoReply(t, b, true, false, target)}
+	})
+	test := &config.RPMTest{Name: "t", Target: "fe80::1%ge-0-0-3"}
+	if _, err := m.probeICMP(context.Background(), test, probeSockOpts{}); err != nil {
+		t.Fatalf("probeICMP link-local: %v", err)
+	}
+	if len(conn.sentAddr) != 1 {
+		t.Fatalf("sent %d packets, want 1", len(conn.sentAddr))
+	}
+	dst, ok := conn.sentAddr[0].(*net.IPAddr)
+	if !ok {
+		t.Fatalf("send addr type = %T, want *net.IPAddr", conn.sentAddr[0])
+	}
+	if dst.Zone != "ge-0-0-3" {
+		t.Fatalf("send zone = %q, want ge-0-0-3", dst.Zone)
+	}
+}
+
+// TestProbeICMPLinkLocalDefaultsZoneToBindDevice confirms a bare
+// link-local target with no %zone defaults the send zone to the resolved
+// egress device (opts.BindDevice — the same kernel ifname the data socket
+// binds via SO_BINDTODEVICE), derived from destination-interface.
+func TestProbeICMPLinkLocalDefaultsZoneToBindDevice(t *testing.T) {
+	target := net.ParseIP("fe80::1")
+	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
+		return []fakeReply{echoReply(t, b, true, false, target)}
+	})
+	test := &config.RPMTest{Name: "t", Target: "fe80::1", DestinationInterface: "ge-0/0/3"}
+	// opts.BindDevice mirrors what probeOpts derives from
+	// destination-interface (kernel ifname, slashes->dashes).
+	opts := probeSockOpts{BindDevice: "ge-0-0-3"}
+	if _, err := m.probeICMP(context.Background(), test, opts); err != nil {
+		t.Fatalf("probeICMP link-local default zone: %v", err)
+	}
+	dst, ok := conn.sentAddr[0].(*net.IPAddr)
+	if !ok {
+		t.Fatalf("send addr type = %T, want *net.IPAddr", conn.sentAddr[0])
+	}
+	if dst.Zone != "ge-0-0-3" {
+		t.Fatalf("send zone = %q, want ge-0-0-3 (defaulted from BindDevice)", dst.Zone)
+	}
+}
+
+// TestProbeICMPLinkLocalNoZoneHeld confirms a bare link-local with no
+// %zone and no resolvable egress device is HELD with ErrProbeSetup rather
+// than sent to the wrong link.
+func TestProbeICMPLinkLocalNoZoneHeld(t *testing.T) {
+	m, conn := newFakeManager(nil)
+	test := &config.RPMTest{Name: "t", Target: "fe80::1"}
+	_, err := m.probeICMP(context.Background(), test, probeSockOpts{})
+	if err == nil {
+		t.Fatal("probeICMP link-local with no zone returned nil error, want ErrProbeSetup")
+	}
+	if !errors.Is(err, ErrProbeSetup) {
+		t.Fatalf("err = %v, want ErrProbeSetup", err)
+	}
+	if len(conn.sent) != 0 {
+		t.Fatalf("sent %d packets, want 0 (must not probe an unscoped link-local)", len(conn.sent))
+	}
+}
+
+// TestProbeICMPGlobalV6NoZone confirms a global IPv6 target still sends
+// with an empty zone (the link-local handling does not touch it).
+func TestProbeICMPGlobalV6NoZone(t *testing.T) {
+	target := net.ParseIP("2001:db8::10")
+	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
+		return []fakeReply{echoReply(t, b, true, false, target)}
+	})
+	test := &config.RPMTest{Name: "t", Target: "2001:db8::10"}
+	if _, err := m.probeICMP(context.Background(), test, probeSockOpts{BindDevice: "ge-0-0-3"}); err != nil {
+		t.Fatalf("probeICMP global v6: %v", err)
+	}
+	dst := conn.sentAddr[0].(*net.IPAddr)
+	if dst.Zone != "" {
+		t.Fatalf("global v6 send zone = %q, want empty", dst.Zone)
+	}
+}

--- a/pkg/rpm/icmp_linklocal_2494_test.go
+++ b/pkg/rpm/icmp_linklocal_2494_test.go
@@ -61,20 +61,22 @@ func TestProbeICMPLinkLocalSendsWithExplicitZone(t *testing.T) {
 	}
 }
 
-// TestProbeICMPLinkLocalDefaultsZoneToBindDevice confirms a bare
-// link-local target with no %zone defaults the send zone to the resolved
-// egress device (opts.BindDevice — the same kernel ifname the data socket
-// binds via SO_BINDTODEVICE), derived from destination-interface.
-func TestProbeICMPLinkLocalDefaultsZoneToBindDevice(t *testing.T) {
+// TestProbeICMPLinkLocalDefaultsZoneToDestInterface confirms a bare
+// link-local target with no %zone defaults the send zone to the egress
+// device derived from destination-interface (via
+// routing.ResolveProbeInterface: slashes->dashes, RETH->member) — the
+// same kernel ifname the data socket binds via SO_BINDTODEVICE. The zone
+// is taken from destination-interface specifically, NOT from
+// opts.BindDevice (which may carry the routing-instance VRF fallback).
+func TestProbeICMPLinkLocalDefaultsZoneToDestInterface(t *testing.T) {
 	target := net.ParseIP("fe80::1")
 	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
 		return []fakeReply{echoReply(t, b, true, false, target)}
 	})
 	test := &config.RPMTest{Name: "t", Target: "fe80::1", DestinationInterface: "ge-0/0/3"}
-	// opts.BindDevice mirrors what probeOpts derives from
-	// destination-interface (kernel ifname, slashes->dashes).
-	opts := probeSockOpts{BindDevice: "ge-0-0-3"}
-	if _, err := m.probeICMP(context.Background(), test, opts); err != nil {
+	// Pass NO BindDevice in opts — the zone must come from
+	// destination-interface, not from opts.BindDevice.
+	if _, err := m.probeICMP(context.Background(), test, probeSockOpts{}); err != nil {
 		t.Fatalf("probeICMP link-local default zone: %v", err)
 	}
 	dst, ok := conn.sentAddr[0].(*net.IPAddr)
@@ -82,7 +84,33 @@ func TestProbeICMPLinkLocalDefaultsZoneToBindDevice(t *testing.T) {
 		t.Fatalf("send addr type = %T, want *net.IPAddr", conn.sentAddr[0])
 	}
 	if dst.Zone != "ge-0-0-3" {
-		t.Fatalf("send zone = %q, want ge-0-0-3 (defaulted from BindDevice)", dst.Zone)
+		t.Fatalf("send zone = %q, want ge-0-0-3 (derived from destination-interface)", dst.Zone)
+	}
+}
+
+// TestProbeICMPLinkLocalRoutingInstanceOnlyHeld is the hostile-reviewer
+// case (#2494 fold): a routing-instance-only link-local test (no %zone,
+// no destination-interface) is rejected by the strict commit gate but can
+// reach the runtime on the lenient load / peer-sync path. probeOpts would
+// set opts.BindDevice = "vrf-<ri>" for it, but a VRF device is NOT an
+// egress link for fe80:: . The prober must HOLD with ErrProbeSetup (and
+// send nothing), NOT send to the VRF "zone" and count the failure as path
+// loss — that would defeat the #1960 hold-state doctrine for this combo.
+func TestProbeICMPLinkLocalRoutingInstanceOnlyHeld(t *testing.T) {
+	m, conn := newFakeManager(nil)
+	test := &config.RPMTest{Name: "t", Target: "fe80::1", RoutingInstance: "ISP-B"}
+	// opts mirrors what probeOpts derives for a routing-instance-only test:
+	// BindDevice = vrfDeviceName("ISP-B") = "vrf-ISP-B".
+	opts := probeSockOpts{BindDevice: "vrf-ISP-B"}
+	_, err := m.probeICMP(context.Background(), test, opts)
+	if err == nil {
+		t.Fatal("probeICMP routing-instance-only link-local returned nil error, want ErrProbeSetup")
+	}
+	if !errors.Is(err, ErrProbeSetup) {
+		t.Fatalf("err = %v, want ErrProbeSetup (must HOLD, not send to a VRF zone as path loss)", err)
+	}
+	if len(conn.sent) != 0 {
+		t.Fatalf("sent %d packets, want 0 (a VRF is not an egress link for fe80::)", len(conn.sent))
 	}
 }
 

--- a/pkg/rpm/icmp_test.go
+++ b/pkg/rpm/icmp_test.go
@@ -25,6 +25,7 @@ type fakeICMPConn struct {
 	replies  chan fakeReply
 	respond  func(b []byte, dst net.Addr) []fakeReply
 	sent     [][]byte
+	sentAddr []net.Addr // destination passed to each WriteTo (#2494 zone check)
 	opts     probeSockOpts
 	network  string
 	// failFast makes ReadFrom return an immediate timeout when no
@@ -42,6 +43,7 @@ func (f *fakeICMPConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	cp := append([]byte(nil), b...)
 	f.mu.Lock()
 	f.sent = append(f.sent, cp)
+	f.sentAddr = append(f.sentAddr, addr)
 	f.mu.Unlock()
 	if f.respond != nil {
 		for _, r := range f.respond(cp, addr) {

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -183,8 +183,9 @@ type Manager struct {
 	// only for unscoped / IP-literal probes today. It exists so a future
 	// VRF-aware resolver can be slotted in (and so a test can assert the
 	// guard short-circuits a scoped hostname before the default resolver
-	// is reached).
-	resolveTarget func(target string) (net.IP, error)
+	// is reached). Returns *net.IPAddr so the IPv6 link-local zone is
+	// preserved through to the send path (#2494).
+	resolveTarget func(target string) (*net.IPAddr, error)
 }
 
 // SetEventCallback registers a callback for RPM events.

--- a/pkg/rpm/scoped_hostname_2493_test.go
+++ b/pkg/rpm/scoped_hostname_2493_test.go
@@ -38,9 +38,9 @@ func TestScopedHostnameHoldsStateAndSkipsResolver(t *testing.T) {
 				listens.Add(1)
 				return inner(network, laddr, opts)
 			}
-			m.resolveTarget = func(target string) (net.IP, error) {
+			m.resolveTarget = func(target string) (*net.IPAddr, error) {
 				resolves.Add(1)
-				return net.ParseIP("203.0.113.1"), nil
+				return &net.IPAddr{IP: net.ParseIP("203.0.113.1")}, nil
 			}
 
 			_, err := m.executeProbe(context.Background(), tc.test, "WAN/t")
@@ -70,9 +70,9 @@ func TestUnscopedHostnameUsesResolver(t *testing.T) {
 	m, conn := newFakeManager(func(b []byte, _ net.Addr) []fakeReply {
 		return []fakeReply{echoReply(t, b, false, false, target)}
 	})
-	m.resolveTarget = func(name string) (net.IP, error) {
+	m.resolveTarget = func(name string) (*net.IPAddr, error) {
 		resolves.Add(1)
-		return target, nil
+		return &net.IPAddr{IP: target}, nil
 	}
 
 	test := &config.RPMTest{Name: "t", Target: "host.example.com"} // no scope


### PR DESCRIPTION
Closes #2494.

## Problem
The RPM ICMP prober discarded the IPv6 link-local scope. `resolveProbeTarget` returned a bare `net.IP` and the send path built `&net.IPAddr{IP: dst}` with no `Zone`, so a `fe80::...%if` target (or a bare link-local with `destination-interface`) could not be probed — the kernel had no egress link and the echo went nowhere / to the wrong link. Link-local next-hop liveness checks silently failed, feeding a dead PASS/FAIL into `services ip-monitoring` failover.

## Fix
1. **Preserve the zone** — `resolveProbeTarget` + the `Manager.resolveTarget` seam now return `*net.IPAddr`. A zoned literal (`fe80::1%ge-0-0-3`) round-trips through `net.ResolveIPAddr` (which parses the scope id); the send path builds `&net.IPAddr{IP: dst, Zone: zone}`.
2. **Default the zone** — a bare link-local target defaults its zone to `opts.BindDevice` (the resolved kernel ifname the data socket binds via `SO_BINDTODEVICE`, derived from `destination-interface` through `routing.ResolveProbeInterface`). An explicit `%zone` is honored (normalized for Junos slash form). A scopeless link-local that slips past commit is held at runtime with `ErrProbeSetup`.
3. **Reject bare link-local at commit** — `validateRPMLinkLocalZoneStrict` refuses an IPv6 link-local IP-literal with neither `%zone` nor `destination-interface`. Mirrors the #1960 strict/lenient pattern exactly like #2492/#2493 (`lenientRPMLinkLocalZone` true only in the two Lenient constructors, gated in `compileExpanded`). Complementary IP-literal case to #2493's hostname reject.

The reply-match stays zone-agnostic (peer IP only; id/seq disambiguate, kernel may not populate the reply zone). The send-side zone is the correctness gain.

## Socket scope: kernel ifname vs display name
The zone uses the **kernel** interface name — the same value the data socket binds via `SO_BINDTODEVICE`. The default path reuses `opts.BindDevice` (already resolved through `routing.ResolveProbeInterface`: RETH→physical member, slashes→dashes, `.0` unit stripped). An explicit `%zone` is normalized only for the slash form (`config.LinuxIfName`); RETH-member translation is not applied to a raw `%zone` (documented — use `destination-interface` for RETH).

## Tests (fail-on-revert verified)
4 rpm + 2 config tests FAIL on master behavior, PASS with the fix:
- `pkg/rpm`: zone preserved by resolveProbeTarget; send carries zone (explicit + defaulted-from-BindDevice); bare link-local held with `ErrProbeSetup` (sends nothing); global IPv6 unaffected.
- `pkg/config`: bare link-local rejected strict / warned lenient; link-local with destination-interface or explicit `%zone` accepted; global IPv6 unaffected.

`gofmt` + `go vet` + `go test ./pkg/rpm/... ./pkg/config/...` green.

## Docs
`docs/multi-wan.md` documents link-local RPM target support + the zone/destination-interface requirement, the explicit-`%zone` RETH limitation, and the zone-agnostic reply-match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)