### PR TITLE
rpm: fix http-get scheme detection for h-prefixed hosts (#2495)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -13013,3 +13013,18 @@ top.
   fail-on-revert test TestProbeICMPLinkLocalRoutingInstanceOnlyHeld.
   **File(s)**: pkg/rpm/icmp.go, pkg/rpm/icmp_linklocal_2494_test.go,
   _Log.md
+
+- **Timestamp**: 2026-06-24
+  **Action**: #2495 — replace http-get URL scheme first-char heuristic
+  (`url[0] != 'h'`) with proper scheme detection. Extracted
+  `canonicalizeHTTPTarget(target) (string, error)` in pkg/rpm: schemeless
+  targets (no `://`, incl. bare host:port and h-prefixed hosts) get
+  `http://` prepended; explicit http/https accepted; any other scheme
+  (ftp/gopher) rejected. Added commit-time `validateRPMHTTPGetSchemeStrict`
+  + `lenientRPMHTTPGetScheme` gate (strict reject / tolerant warn, #1960
+  doctrine) mirroring #2494. Tests prove fail-on-revert on h-prefixed bare
+  host. Doc note in docs/multi-wan.md.
+  **File(s)**: pkg/rpm/rpm.go, pkg/rpm/http_scheme_2495_test.go,
+  pkg/config/compiler.go, pkg/config/compiler_services.go,
+  pkg/config/compiler_rpm_http_scheme_2495_test.go, docs/multi-wan.md,
+  _Log.md

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -120,6 +120,23 @@ set services rpm probe WAN test wan-a thresholds successive-loss 3
     the zone (id/seq already disambiguate the exchange, and the kernel may
     not populate the reply's zone). The send-side zone is the correctness
     fix; the reply-match stays zone-agnostic by design.
+- **http-get targets are http/https only (#2495).** An `http-get` test's
+  `target` may be a bare hostname, IP literal, or `host:port` (the prober
+  prepends the default `http://`), or it may carry an explicit `http://`
+  or `https://` scheme. A scheme is detected by the `://` separator, so a
+  bare `host:port` is correctly treated as schemeless — never mistaken for
+  a scheme. The previous canonicalizer used a first-character heuristic
+  (prefix `http://` only when the target did **not** start with `h`), which
+  wrongly assumed any `h`-leading bare host (`host.example.com`, `h2.lan`)
+  was already schemed; the resulting schemeless URL was rejected by the
+  HTTP client before a packet was sent, so a healthy `h`-host probe never
+  ran. A target carrying any other scheme (`ftp://`, `gopher://`) is
+  **rejected at commit** (`validateRPMHTTPGetSchemeStrict`) — only http and
+  https are meaningful for an http-get probe. On the tolerant load /
+  peer-sync path the rejection is downgraded to a warning (#1960 no-brick);
+  the runtime `canonicalizeHTTPTarget` guard returns the same error for the
+  bad scheme, so the test **holds state** rather than actuating off a probe
+  that can never run.
 - Probe config re-applies on commit, gated on the rendered RPM stanza
   hash — unrelated commits never reset probe state.
 - **Environment errors never move routes**: a probe-socket setup

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -515,6 +515,19 @@ type compileOpts struct {
 	// actuating off a dead measurement). Same doctrine as
 	// lenientRPMScopedHostname.
 	lenientRPMLinkLocalZone bool
+	// lenientRPMHTTPGetScheme (#2495) downgrades the http-get target
+	// scheme gate (validateRPMHTTPGetSchemeStrict) from a hard compile
+	// error to a cfg.Warnings entry. An http-get target that carries a
+	// scheme other than http/https (ftp://, gopher://, …) makes
+	// http.NewRequestWithContext error before a packet is sent, so the
+	// probe never runs and publishes a permanent FAIL into event-options
+	// / ip-monitoring failover. Strict on commit / commit-check (hard
+	// reject so the bad scheme is operator-visible); lenient on load /
+	// peer-sync (warn — #1960 no-brick; the runtime canonicalizeHTTPTarget
+	// guard returns the same error for the bad scheme, so the
+	// leniently-loaded test HOLDS state rather than actuating off a probe
+	// that can never run). Same doctrine as lenientRPMLinkLocalZone.
+	lenientRPMHTTPGetScheme bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -567,6 +580,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRPMSourceAddress:            true,
 		lenientRPMScopedHostname:           true,
 		lenientRPMLinkLocalZone:            true,
+		lenientRPMHTTPGetScheme:            true,
 	})
 }
 
@@ -670,6 +684,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRPMSourceAddress:            true,
 		lenientRPMScopedHostname:           true,
 		lenientRPMLinkLocalZone:            true,
+		lenientRPMHTTPGetScheme:            true,
 	})
 }
 
@@ -1506,6 +1521,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRPMLinkLocalZone {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("rpm link-local zone (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2495: http-get target scheme gate. An http-get target that carries
+	// a scheme other than http/https (ftp://, gopher://, …) makes
+	// http.NewRequestWithContext error before a packet is sent, so the
+	// probe never runs and publishes a permanent FAIL into event-options /
+	// ip-monitoring failover. A schemeless target (bare host / IP /
+	// host:port) is fine — the runtime prepends http://. Strict on commit /
+	// commit-check (hard reject so the bad scheme is operator-visible);
+	// lenient on load / peer-sync (warn — #1960; the runtime
+	// canonicalizeHTTPTarget guard returns the same error, so the
+	// leniently-loaded test HOLDS state instead of actuating off a probe
+	// that can never run).
+	if err := validateRPMHTTPGetSchemeStrict(cfg); err != nil {
+		if opts.lenientRPMHTTPGetScheme {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("rpm http-get scheme (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_rpm_http_scheme_2495_test.go
+++ b/pkg/config/compiler_rpm_http_scheme_2495_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRPMHTTPGetSchemeStrictRejects pins the #2495 commit-time gate: an
+// http-get target carrying a scheme other than http/https (ftp://,
+// gopher://) is hard-rejected on the strict path (commit / commit-check).
+// Such a scheme makes http.NewRequestWithContext error before any packet
+// is sent, so the probe never runs and publishes a permanent FAIL into
+// event-options / ip-monitoring failover.
+//
+// This FAILS against master, which has no scheme gate and silently
+// accepts the unprobeable target.
+func TestRPMHTTPGetSchemeStrictRejects(t *testing.T) {
+	cases := []struct {
+		name   string
+		target string
+		scheme string
+	}{
+		{"ftp", "ftp://host.example.com/health", "ftp"},
+		{"gopher", "gopher://h.example.com", "gopher"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := []string{
+				"set services rpm probe P test t probe-type http-get",
+				"set services rpm probe P test t target " + tc.target,
+			}
+			tree := buildTree(t, lines)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted http-get target %q with scheme %q; want strict reject",
+					tc.target, tc.scheme)
+			}
+			if !strings.Contains(err.Error(), "unsupported scheme") {
+				t.Fatalf("err = %v, want substring %q", err, "unsupported scheme")
+			}
+		})
+	}
+}
+
+// TestRPMHTTPGetSchemeLenientWarns pins the no-brick contract (#1960
+// doctrine): the bad scheme the strict path rejects is TOLERATED on the
+// lenient load / peer-sync path — downgraded to a warning so an
+// already-persisted or peer-synced config still boots. The runtime
+// canonicalizeHTTPTarget guard then returns the same error and the test
+// holds state.
+func TestRPMHTTPGetSchemeLenientWarns(t *testing.T) {
+	lines := []string{
+		"set services rpm probe P test t probe-type http-get",
+		"set services rpm probe P test t target ftp://host.example.com",
+	}
+	tree := buildTree(t, lines)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on bad http-get scheme (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "rpm http-get scheme") {
+		t.Fatalf("expected a downgraded rpm http-get-scheme warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestRPMHTTPGetSchemeAccepts confirms NO regression and the bug-fix
+// coverage: bare hostnames (including h-prefixed ones, the #2495 bug),
+// host:port, and explicit http:// / https:// targets are all accepted.
+func TestRPMHTTPGetSchemeAccepts(t *testing.T) {
+	targets := []string{
+		"server.example.com",      // bare host, non-'h'
+		"host.example.com",        // bare host starting with 'h' — the bug
+		"h2.lan",                  // bare h-prefixed host
+		"host.example.com:8080",   // bare host:port (must not parse "host..." as scheme)
+		"http://host.example.com", // explicit http
+		"https://h.example.com",   // explicit https
+		"203.0.113.5",             // bare IPv4 literal
+	}
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			lines := []string{
+				"set services rpm probe P test t probe-type http-get",
+				"set services rpm probe P test t target " + target,
+			}
+			tree := buildTree(t, lines)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("http-get target %q must be accepted: %v", target, err)
+			}
+		})
+	}
+}
+
+// TestRPMHTTPGetSchemeOnlyAppliesToHTTPGet confirms the scheme gate is
+// scoped to http-get tests: an icmp-ping/tcp-ping test is never inspected
+// for a URL scheme (its target is a host/IP, never a URL).
+func TestRPMHTTPGetSchemeOnlyAppliesToHTTPGet(t *testing.T) {
+	// A non-http-get test with an IP-literal target is accepted as today.
+	lines := []string{
+		"set services rpm probe P test t probe-type tcp-ping",
+		"set services rpm probe P test t target 8.8.8.8",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("tcp-ping test must be unaffected by the http-get scheme gate: %v", err)
+	}
+}

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -228,6 +229,64 @@ func validateRPMLinkLocalZoneStrict(cfg *Config) error {
 						"with no scope — add an explicit %%zone (fe80::1%%ge-0/0/3) or a "+
 						"destination-interface so the probe can pick the egress link",
 					probe.Name, test.Name, test.Target)
+			}
+		}
+	}
+	return nil
+}
+
+// validateRPMHTTPGetSchemeStrict rejects an http-get RPM test whose
+// target carries an unsupported URL scheme (#2495). The runtime probe
+// canonicalizes a schemeless target (bare hostname / IP / host:port) by
+// prepending "http://", and accepts an explicit "http://" or "https://"
+// target as-is; any other scheme (ftp://, gopher://, …) is meaningless
+// for an http-get probe and makes http.NewRequestWithContext error
+// before a packet is sent — the probe never runs and publishes a
+// permanent FAIL into event-options / ip-monitoring failover. A scheme
+// is only present when the target contains the "://" separator; a bare
+// "host:port" (no "://") is NOT a scheme and is left for the runtime to
+// prefix with http://. Only the literal target is inspected (no DNS at
+// commit).
+//
+// Strict on commit / commit-check (hard reject so the operator sees the
+// bad scheme immediately); lenient on load / peer-sync (warn — #1960
+// no-brick; the runtime canonicalizeHTTPTarget guard returns the same
+// error for the bad scheme, so a leniently-loaded test HOLDS state
+// instead of actuating routes off a probe that can never run). Mirrors
+// validateRPMLinkLocalZoneStrict.
+func validateRPMHTTPGetSchemeStrict(cfg *Config) error {
+	if cfg == nil || cfg.Services.RPM == nil {
+		return nil
+	}
+	for _, probe := range cfg.Services.RPM.Probes {
+		if probe == nil {
+			continue
+		}
+		for _, test := range probe.Tests {
+			if test == nil || test.Target == "" {
+				continue
+			}
+			if test.EffectiveProbeType() != "http-get" {
+				continue
+			}
+			// A scheme is present only with the "://" separator; a bare
+			// host:port is schemeless (the runtime prepends http://).
+			if !strings.Contains(test.Target, "://") {
+				continue
+			}
+			u, err := url.Parse(test.Target)
+			if err != nil {
+				return fmt.Errorf("services rpm probe %q test %q: invalid http-get target URL %q: %w",
+					probe.Name, test.Name, test.Target, err)
+			}
+			switch u.Scheme {
+			case "http", "https":
+				// supported
+			default:
+				return fmt.Errorf(
+					"services rpm probe %q test %q: http-get target %q uses unsupported scheme %q "+
+						"(only http and https are valid for an http-get probe)",
+					probe.Name, test.Name, test.Target, u.Scheme)
 			}
 		}
 	}

--- a/pkg/rpm/http_scheme_2495_test.go
+++ b/pkg/rpm/http_scheme_2495_test.go
@@ -1,0 +1,71 @@
+package rpm
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCanonicalizeHTTPTarget pins the #2495 fix: the http-get target
+// canonicalizer must prepend "http://" to every schemeless target —
+// including a bare hostname that STARTS WITH 'h' (host.example.com,
+// h2.lan), which the old first-char heuristic (`url[0] != 'h'`) wrongly
+// assumed was already schemed, leaving a schemeless URL that
+// http.NewRequestWithContext rejects before any packet is sent. An
+// already-schemed http://... / https://... target is returned unchanged;
+// any other scheme (ftp://, gopher://) is rejected.
+//
+// The "host.example.com" / "h2.lan" cases FAIL against master: the old
+// heuristic skips the "http://" prefix for any 'h'-leading target, so
+// canonicalization returns the bare host and the probe errors out.
+func TestCanonicalizeHTTPTarget(t *testing.T) {
+	ok := []struct {
+		target string
+		want   string
+	}{
+		// bare host NOT starting with 'h' — worked before and after
+		{"server.example.com", "http://server.example.com"},
+		// bare host STARTING with 'h' — THE BUG (#2495)
+		{"host.example.com", "http://host.example.com"},
+		{"h2.lan", "http://h2.lan"},
+		// bare host:port — must NOT be mistaken for a scheme
+		{"host.example.com:8080", "http://host.example.com:8080"},
+		{"server.example.com:443", "http://server.example.com:443"},
+		// bare IP literal
+		{"203.0.113.5", "http://203.0.113.5"},
+		// already schemed — returned unchanged
+		{"http://host.example.com", "http://host.example.com"},
+		{"https://h.example.com/health", "https://h.example.com/health"},
+		{"http://server.example.com:8080/x", "http://server.example.com:8080/x"},
+	}
+	for _, tc := range ok {
+		t.Run("ok/"+tc.target, func(t *testing.T) {
+			got, err := canonicalizeHTTPTarget(tc.target)
+			if err != nil {
+				t.Fatalf("canonicalizeHTTPTarget(%q) unexpected error: %v", tc.target, err)
+			}
+			if got != tc.want {
+				t.Fatalf("canonicalizeHTTPTarget(%q) = %q, want %q", tc.target, got, tc.want)
+			}
+		})
+	}
+
+	bad := []struct {
+		target string
+		substr string
+	}{
+		{"", "no target"},
+		{"ftp://host.example.com", "unsupported"},
+		{"gopher://h.example.com", "unsupported"},
+	}
+	for _, tc := range bad {
+		t.Run("bad/"+tc.target, func(t *testing.T) {
+			_, err := canonicalizeHTTPTarget(tc.target)
+			if err == nil {
+				t.Fatalf("canonicalizeHTTPTarget(%q) = nil error, want rejection", tc.target)
+			}
+			if !strings.Contains(err.Error(), tc.substr) {
+				t.Fatalf("canonicalizeHTTPTarget(%q) err = %v, want substring %q", tc.target, err, tc.substr)
+			}
+		})
+	}
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -657,15 +659,47 @@ func (m *Manager) probeTCP(ctx context.Context, test *config.RPMTest, opts probe
 	return rtt, nil
 }
 
-func (m *Manager) probeHTTP(ctx context.Context, test *config.RPMTest, opts probeSockOpts) (time.Duration, error) {
-	target := test.Target
+// canonicalizeHTTPTarget turns an http-get probe target into a fully
+// schemed URL suitable for http.NewRequestWithContext.
+//
+// A bare hostname, IP literal, or host:port (no "://" separator) gets
+// the default "http://" scheme prepended. This replaces the fragile
+// first-char heuristic (`url[0] != 'h'`) that decided whether a scheme
+// was already present by looking at the first byte: a bare hostname
+// starting with 'h' (host.example.com, h2.lan) was wrongly assumed to
+// be already-schemed, so no prefix was added and the schemeless URL was
+// rejected by http.NewRequestWithContext before any packet was sent —
+// a healthy h-host probe never ran (#2495). The "://" containment test
+// is the correct scheme detector: a bare "host:port" has no "://", so
+// it is treated as schemeless (url.Parse would otherwise mistake "host"
+// for a scheme).
+//
+// A target that already carries a scheme must be http or https; any
+// other scheme (ftp://, gopher://, …) is rejected, since only http and
+// https make sense for an http-get probe.
+func canonicalizeHTTPTarget(target string) (string, error) {
 	if target == "" {
-		return 0, fmt.Errorf("no target specified")
+		return "", fmt.Errorf("no target specified")
 	}
-	// If target doesn't look like a URL, make it one
-	url := target
-	if len(url) > 0 && url[0] != 'h' {
-		url = "http://" + target
+	if !strings.Contains(target, "://") {
+		return "http://" + target, nil
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return "", fmt.Errorf("invalid http-get target URL %q: %w", target, err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return target, nil
+	default:
+		return "", fmt.Errorf("unsupported http-get target scheme %q (want http or https): %q", u.Scheme, target)
+	}
+}
+
+func (m *Manager) probeHTTP(ctx context.Context, test *config.RPMTest, opts probeSockOpts) (time.Duration, error) {
+	url, err := canonicalizeHTTPTarget(test.Target)
+	if err != nil {
+		return 0, err
 	}
 
 	dialer, err := probeDialer(10*time.Second, test.SourceAddress, opts)


### PR DESCRIPTION
Closes #2495

## Problem
The RPM `http-get` probe canonicalized its target with a first-character
heuristic — `if url[0] != 'h' { url = "http://" + target }`. A bare
hostname that starts with `h` (`host.example.com`, `h2.lan`) was assumed
already-schemed, so no prefix was added, and the schemeless URL was
rejected by `http.NewRequestWithContext` before any packet was sent. The
probe fails closed (errors, never mis-routes), but a healthy `h`-host
probe could never run — publishing a permanent FAIL into event-options /
ip-monitoring failover. The heuristic was also over-broad the other way:
any `h...` string was assumed already-schemed.

## Fix
**Runtime canonicalization** — extracted into a testable helper
`canonicalizeHTTPTarget(target) (string, error)` in `pkg/rpm`:
- No `://` separator ⇒ schemeless (bare host, IP literal, `host:port`) ⇒
  prepend `http://`. The `://` test is the correct scheme detector: a
  bare `host:port` has no `://`, so `url.Parse` never mistakes `host` for
  a scheme.
- Already-schemed ⇒ must be `http`/`https`; any other scheme (`ftp://`,
  `gopher://`) is rejected.

`probeHTTP` now calls the helper and surfaces the error.

**Commit-time validator** — `validateRPMHTTPGetSchemeStrict` wired through
the `lenientRPMHTTPGetScheme` compile option, mirroring the
#2492/#2493/#2494 strict/lenient structure: strict on commit /
commit-check (hard reject a non-http(s) scheme), lenient on load /
peer-sync (downgrade to a warning so an already-persisted / peer-synced
config still boots — #1960 no-brick; the runtime guard returns the same
error so the test holds state). Bare hostnames are not inspected, so the
gate only fires on an explicit unsupported scheme.

## host:port and ftp:// handling
- `host:8080` / `host.example.com:8080` — no `://` ⇒ schemeless ⇒
  `http://host:8080`. NOT mistaken for a scheme.
- `ftp://...` / `gopher://...` — rejected at commit (validator) and at
  runtime (canonicalizer).

## Validator placement
Added the commit-time validator (preferred operator experience) **and**
the runtime canonicalization fix — both reject non-http(s) schemes.

## Tests / fail-on-revert
- `pkg/rpm`: helper across bare host (non-`h` and `h`-prefixed),
  `host:port`, IPv4 literal, explicit http/https; rejects ftp/gopher and
  empty target. The `host.example.com` / `h2.lan` / `host:port` cases
  **FAIL against the old first-char heuristic** (proven by temporarily
  restoring it: `canonicalizeHTTPTarget("host.example.com") =
  "host.example.com", want "http://host.example.com"`).
- `pkg/config`: strict-reject ftp/gopher, lenient-warn, acceptance of all
  schemeless/http/https shapes, and gate scoped to http-get tests only.

## Docs
`docs/multi-wan.md` — sibling note alongside the #2492/#2493/#2494 RPM
target gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)