### PR TITLE
config: validate rpm routing-instance at commit (#2496)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -13028,3 +13028,7 @@ top.
   pkg/config/compiler.go, pkg/config/compiler_services.go,
   pkg/config/compiler_rpm_http_scheme_2495_test.go, docs/multi-wan.md,
   _Log.md
+
+## 2026-06-24 — #2496 RPM routing-instance strict cross-reference validator
+- **Action**: Add validateRPMRoutingInstanceStrict — reject RPM test routing-instance that names no configured instance; lenient warn on load/peer-sync (#1960). Mirrors validateIPMonitoringStrict preferred-route RI check.
+- **Files**: pkg/config/compiler_services.go (validator), pkg/config/compiler.go (lenientRPMRoutingInstance opt + gate), pkg/config/compiler_rpm_routing_instance_2496_test.go (new), pkg/config/compiler_rpm_scoped_hostname_2493_test.go + parser_ast_test.go (configure RI in pre-existing tests), docs/multi-wan.md (#2496 bullet).

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -137,6 +137,20 @@ set services rpm probe WAN test wan-a thresholds successive-loss 3
   the runtime `canonicalizeHTTPTarget` guard returns the same error for the
   bad scheme, so the test **holds state** rather than actuating off a probe
   that can never run.
+- **`routing-instance` must name a configured instance (#2496).** When a
+  test sets `routing-instance <name>`, the runtime binds the probe data
+  socket to that instance's VRF device (`vrf-<name>`) via
+  `SO_BINDTODEVICE`. A typo'd / nonexistent instance has no such kernel
+  device, so the bind fails `ENODEV`: the probe never sends a packet and
+  the test **holds its state forever** (no PASS, no FAIL), starving any
+  ip-monitoring / event-options policy keyed off it of a failover signal.
+  A non-empty `routing-instance` that does not match a configured instance
+  is therefore **rejected at commit** (`validateRPMRoutingInstanceStrict`,
+  mirroring the ip-monitoring preferred-route `routing-instance` check in
+  `validateIPMonitoringStrict`). An empty `routing-instance` is the default
+  (master) context and is always accepted. On the tolerant load / peer-sync
+  path the rejection is downgraded to a warning (#1960 no-brick); the
+  runtime VRF bind returns the same `ENODEV`, so the test holds state.
 - Probe config re-applies on commit, gated on the rendered RPM stanza
   hash — unrelated commits never reset probe state.
 - **Environment errors never move routes**: a probe-socket setup

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -528,6 +528,21 @@ type compileOpts struct {
 	// leniently-loaded test HOLDS state rather than actuating off a probe
 	// that can never run). Same doctrine as lenientRPMLinkLocalZone.
 	lenientRPMHTTPGetScheme bool
+	// lenientRPMRoutingInstance (#2496) downgrades the RPM test
+	// routing-instance cross-reference gate
+	// (validateRPMRoutingInstanceStrict) from a hard compile error to a
+	// cfg.Warnings entry. An RPM test whose `routing-instance` names a
+	// nonexistent instance makes the runtime bind the probe DATA socket to
+	// a synthesized vrf-<name> device (SO_BINDTODEVICE) that does not exist
+	// → ENODEV → the probe never sends a packet and the test HOLDS its
+	// state forever (no PASS, no FAIL), starving any event-options /
+	// ip-monitoring policy keyed off it of a failover signal. Strict on
+	// commit / commit-check (hard reject so the typo is operator-visible);
+	// lenient on load / peer-sync (warn — #1960 no-brick; the runtime bind
+	// returns ENODEV for the same nonexistent instance, so the leniently-
+	// loaded test HOLDS state rather than actuating off a dead measurement).
+	// Same doctrine as lenientRPMHTTPGetScheme.
+	lenientRPMRoutingInstance bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -581,6 +596,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRPMScopedHostname:           true,
 		lenientRPMLinkLocalZone:            true,
 		lenientRPMHTTPGetScheme:            true,
+		lenientRPMRoutingInstance:          true,
 	})
 }
 
@@ -685,6 +701,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRPMScopedHostname:           true,
 		lenientRPMLinkLocalZone:            true,
 		lenientRPMHTTPGetScheme:            true,
+		lenientRPMRoutingInstance:          true,
 	})
 }
 
@@ -1541,6 +1558,28 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRPMHTTPGetScheme {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("rpm http-get scheme (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2496: RPM test routing-instance cross-reference gate. A test whose
+	// `routing-instance` names a nonexistent instance makes the runtime
+	// bind the probe DATA socket to a synthesized vrf-<name> device
+	// (SO_BINDTODEVICE) that does not exist → ENODEV → the probe never runs
+	// and the test HOLDS its state forever, starving any event-options /
+	// ip-monitoring policy keyed off it of a failover signal. An empty
+	// routing-instance is the default (master) context and is accepted.
+	// Strict on commit / commit-check (hard reject so the typo is
+	// operator-visible); lenient on load / peer-sync (warn — #1960; the
+	// runtime bind returns ENODEV for the same nonexistent instance, so the
+	// leniently-loaded test HOLDS state instead of actuating off a dead
+	// measurement). Mirrors the ip-monitoring preferred-route
+	// routing-instance check in validateIPMonitoringStrict.
+	if err := validateRPMRoutingInstanceStrict(cfg); err != nil {
+		if opts.lenientRPMRoutingInstance {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("rpm routing-instance (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_rpm_routing_instance_2496_test.go
+++ b/pkg/config/compiler_rpm_routing_instance_2496_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRPMRoutingInstanceStrictRejects pins the #2496 commit-time gate: an
+// RPM test whose `routing-instance` names a nonexistent / typo'd instance
+// is hard-rejected on the strict path (commit / commit-check). The runtime
+// would bind the probe DATA socket to a synthesized vrf-<name> device
+// (SO_BINDTODEVICE) that does not exist -> ENODEV -> the probe never sends
+// a packet and the test silently HOLDS its state forever, starving any
+// event-options / ip-monitoring policy keyed off it of a failover signal.
+//
+// The target is an IP literal so the scoped-hostname gate (#2493), which
+// runs earlier and would also reject a hostname on a scoped test, does not
+// fire first — this isolates the routing-instance cross-reference check.
+//
+// This FAILS against master, which has no routing-instance cross-reference
+// gate and silently accepts the unprobeable test.
+func TestRPMRoutingInstanceStrictRejects(t *testing.T) {
+	lines := []string{
+		"set routing-instances ISP-B instance-type forwarding",
+		"set services rpm probe P test t routing-instance ISP-TYPO",
+		"set services rpm probe P test t target 8.8.8.8",
+	}
+	tree := buildTree(t, lines)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted an RPM test referencing a nonexistent routing-instance; want strict reject")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want substring %q", err, "does not exist")
+	}
+}
+
+// TestRPMRoutingInstanceLenientWarns pins the no-brick contract (#1960
+// doctrine): the nonexistent-instance the strict path rejects is TOLERATED
+// on the lenient load / peer-sync path — downgraded to a warning so an
+// already-persisted or peer-synced config still boots. The runtime VRF
+// bind then returns ENODEV and the test holds state.
+func TestRPMRoutingInstanceLenientWarns(t *testing.T) {
+	lines := []string{
+		"set routing-instances ISP-B instance-type forwarding",
+		"set services rpm probe P test t routing-instance ISP-TYPO",
+		"set services rpm probe P test t target 8.8.8.8",
+	}
+	tree := buildTree(t, lines)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on a bad rpm routing-instance (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "rpm routing-instance") {
+		t.Fatalf("expected a downgraded rpm routing-instance warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestRPMRoutingInstanceConfiguredAccepted confirms NO regression: an RPM
+// test whose routing-instance names a CONFIGURED instance is accepted, and
+// a test with an EMPTY routing-instance (default/master context — not
+// scoped to any VRF device) is likewise accepted.
+func TestRPMRoutingInstanceConfiguredAccepted(t *testing.T) {
+	t.Run("configured instance accepted", func(t *testing.T) {
+		lines := []string{
+			"set routing-instances ISP-B instance-type forwarding",
+			"set services rpm probe P test t routing-instance ISP-B",
+			"set services rpm probe P test t target 8.8.8.8",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("RPM test naming a configured routing-instance must be accepted: %v", err)
+		}
+	})
+
+	t.Run("empty routing-instance (default context) accepted", func(t *testing.T) {
+		lines := []string{
+			"set services rpm probe P test t target 8.8.8.8",
+		}
+		tree := buildTree(t, lines)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("RPM test with no routing-instance (default context) must be accepted: %v", err)
+		}
+	})
+}

--- a/pkg/config/compiler_rpm_scoped_hostname_2493_test.go
+++ b/pkg/config/compiler_rpm_scoped_hostname_2493_test.go
@@ -85,6 +85,7 @@ func TestRPMScopedHostnameLenientWarns(t *testing.T) {
 func TestRPMScopedIPLiteralAccepted(t *testing.T) {
 	t.Run("routing-instance + IP literal accepted", func(t *testing.T) {
 		lines := []string{
+			"set routing-instances ISP-B instance-type forwarding",
 			"set services rpm probe P test t probe-type icmp-ping",
 			"set services rpm probe P test t target 8.8.8.8",
 			"set services rpm probe P test t routing-instance ISP-B",

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -293,6 +293,59 @@ func validateRPMHTTPGetSchemeStrict(cfg *Config) error {
 	return nil
 }
 
+// validateRPMRoutingInstanceStrict rejects an RPM test whose
+// `routing-instance` does not name a CONFIGURED routing instance (#2496).
+// The runtime binds the probe DATA socket to the instance's VRF device
+// via SO_BINDTODEVICE — vrfDeviceName(ri) synthesizes "vrf-<name>"
+// (pkg/rpm/rpm.go). A typo'd / nonexistent instance has no such kernel
+// device, so the bind fails with ENODEV: the probe never sends a packet
+// and the test silently HOLDS its state forever (never PASS, never FAIL),
+// so any event-options / ip-monitoring policy keyed off it gets no
+// failover signal. It fails safe (no false PASS), but the candidate
+// config should have been rejected at commit so the operator sees the
+// typo rather than a permanently dead probe.
+//
+// An EMPTY routing-instance means the default (master) context and is NOT
+// scoped to a VRF device — it is always accepted. Only a non-empty name
+// that does not match a configured instance is the error. The configured-
+// instance enumeration mirrors validateIPMonitoringStrict's preferred-route
+// routing-instance check exactly (same cfg.RoutingInstances source, same
+// empty-is-default handling, same "does not exist" error shape).
+//
+// Strict on commit / commit-check (hard reject so the typo is
+// operator-visible); lenient on load / peer-sync (warn — #1960 no-brick;
+// the runtime bind returns ENODEV for the same nonexistent instance, so a
+// leniently-loaded test HOLDS state instead of actuating routes off a dead
+// measurement). Mirrors validateRPMHTTPGetSchemeStrict.
+func validateRPMRoutingInstanceStrict(cfg *Config) error {
+	if cfg == nil || cfg.Services.RPM == nil {
+		return nil
+	}
+	instances := make(map[string]*RoutingInstanceConfig)
+	for _, ri := range cfg.RoutingInstances {
+		if ri != nil {
+			instances[ri.Name] = ri
+		}
+	}
+	for _, probe := range cfg.Services.RPM.Probes {
+		if probe == nil {
+			continue
+		}
+		for _, test := range probe.Tests {
+			if test == nil || test.RoutingInstance == "" {
+				continue
+			}
+			if _, ok := instances[test.RoutingInstance]; !ok {
+				return fmt.Errorf(
+					"services rpm probe %q test %q: routing-instance %q does not exist "+
+						"(the probe would bind a nonexistent vrf-%s device and never run)",
+					probe.Name, test.Name, test.RoutingInstance, test.RoutingInstance)
+			}
+		}
+	}
+	return nil
+}
+
 // validateRPMProbePinsStrict enforces the probe-pin band invariants
 // (#1827 PR-1a): at most ProbeTableCount next-hop-pinned tests (one
 // reserved kernel table each), and no routing-instance table ID may

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -884,7 +884,12 @@ func TestFormatSet(t *testing.T) {
 }
 
 func TestRPMConfig(t *testing.T) {
-	input := `services {
+	input := `routing-instances {
+    att-vr {
+        instance-type forwarding;
+    }
+}
+services {
     rpm {
         probe isp-comcast {
             test icmp-check {


### PR DESCRIPTION
Closes #2496

## Problem
`validateRPMTest` never cross-checked an RPM test's `routing-instance`
against the configured routing instances. A typo'd / nonexistent instance
committed cleanly, then every probe in that test bound a synthesized
`vrf-<name>` device (`vrfDeviceName`, `pkg/rpm/rpm.go`) via
`SO_BINDTODEVICE` → ENODEV. The probe never sent a packet and the test
silently **held its state forever** (no PASS, no FAIL), starving any
event-options / ip-monitoring policy keyed off it of a failover signal. It
fails safe (no false PASS), but the candidate config should have been
rejected so the operator saw the typo.

## Fix
Add `validateRPMRoutingInstanceStrict`: for each RPM test with a non-empty
`routing-instance`, confirm it names a configured instance. The
enumeration **mirrors the ip-monitoring preferred-route `routing-instance`
check in `validateIPMonitoringStrict` exactly** — same `cfg.RoutingInstances`
source, same empty-is-default-context handling (empty = master, never
rejected), same "does not exist" error shape.

Wired with the #1960 strict/lenient pattern (as #2492-2495): a new
`lenientRPMRoutingInstance` opt set true only in `CompileConfigLenient` /
`CompileConfigForNodeLenient`, gated in `compileExpanded` (strict → hard
reject; lenient → `cfg.Warnings` so a persisted/peer-synced config still
boots — the runtime VRF bind returns the same ENODEV → test holds state).

## Tests
`pkg/config`: nonexistent instance REJECTED strict / WARNED lenient;
configured instance ACCEPTED; empty routing-instance ACCEPTED. IP-literal
targets keep the #2493 scoped-hostname gate (runs earlier) from firing
first. **Fail-on-revert verified**: reverting the production change makes
`TestRPMRoutingInstanceStrictRejects` fail (master has no such check). Two
pre-existing tests that referenced an unconfigured instance now define it.
`docs/multi-wan.md` gains a #2496 bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)