### PR TITLE
vrrp: set SOCK_CLOEXEC on AF_PACKET receiver socket (#2476)

### DIFF
--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -167,6 +167,13 @@ load/peer-sync compile paths.
   VLAN sub-interfaces (the kernel's raw IP doesn't reliably receive
   multicast on VLANs).
 - IPv6: separate raw socket; hop limit set to 255 per RFC.
+- The AF_PACKET capture fd is created `SOCK_RAW|SOCK_CLOEXEC` so it is set
+  close-on-exec atomically at creation (#2476). A raw `unix.Socket` does NOT
+  inherit CLOEXEC the way Go `net` sockets do, so without this the raw VRRP
+  capture fd would leak into every child the daemon execs (frr-reload.py,
+  swanctl, dhcp helpers) — an fd leak and a security boundary (a child could
+  read raw VRRP frames). The OR-into-type form avoids the fork race a separate
+  `fcntl(FD_CLOEXEC)` would open.
 
 ### Receiver goroutine model
 

--- a/pkg/vrrp/afpacket_cloexec_test.go
+++ b/pkg/vrrp/afpacket_cloexec_test.go
@@ -1,0 +1,72 @@
+package vrrp
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestAfPacketReceiverSocketTypeCloexec asserts that openAfPacketReceiver
+// passes SOCK_CLOEXEC (OR'd into the socket type) at the socket(2) call site.
+// This is the close-on-exec guarantee for the raw VRRP capture fd: without it
+// the fd leaks to every child the daemon execs (frr-reload.py, swanctl, dhcp
+// helpers), both an fd leak and a security boundary (a child could read raw
+// VRRP frames). The check intercepts the socket(2) entry point via the
+// afPacketSocket seam, so it captures the EXACT flags the call site uses and
+// runs deterministically without CAP_NET_RAW.
+//
+// Fail-on-revert: reverting the call site to plain unix.SOCK_RAW makes the
+// captured type lack SOCK_CLOEXEC and this test fails.
+func TestAfPacketReceiverSocketTypeCloexec(t *testing.T) {
+	var gotType int
+	called := false
+	orig := afPacketSocket
+	afPacketSocket = func(domain, typ, proto int) (int, error) {
+		gotType = typ
+		called = true
+		// Return an error so openAfPacketReceiver bails out before it tries
+		// to bind/setsockopt on a fd we did not actually open. We only need
+		// the captured type flags.
+		return -1, unix.EPERM
+	}
+	defer func() { afPacketSocket = orig }()
+
+	// ifindex value is irrelevant — the stub returns before bind.
+	if _, err := openAfPacketReceiver(1); err == nil {
+		t.Fatal("expected openAfPacketReceiver to surface the stub error")
+	}
+	if !called {
+		t.Fatal("afPacketSocket seam was not invoked")
+	}
+	if gotType&unix.SOCK_CLOEXEC == 0 {
+		t.Fatalf("AF_PACKET socket type %#x missing SOCK_CLOEXEC", gotType)
+	}
+	if gotType&unix.SOCK_RAW == 0 {
+		t.Fatalf("AF_PACKET socket type %#x missing SOCK_RAW", gotType)
+	}
+}
+
+// TestAfPacketReceiverRealFDCloexec opens a real AF_PACKET socket (requires
+// CAP_NET_RAW/root) and verifies the kernel actually set FD_CLOEXEC on it.
+// Skips gracefully when the test process lacks the capability. This is the
+// end-to-end confirmation that the atomic SOCK_CLOEXEC in the type argument
+// reaches the fd, complementing the deterministic seam test above.
+func TestAfPacketReceiverRealFDCloexec(t *testing.T) {
+	fd, err := openAfPacketReceiver(1) // ifindex 1 == lo
+	if err != nil {
+		if errors.Is(err, unix.EPERM) || errors.Is(err, unix.EACCES) {
+			t.Skipf("no CAP_NET_RAW for AF_PACKET socket: %v", err)
+		}
+		t.Fatalf("openAfPacketReceiver: %v", err)
+	}
+	defer unix.Close(fd)
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatalf("AF_PACKET receiver fd lacks FD_CLOEXEC (F_GETFD=%#x)", flags)
+	}
+}

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -667,15 +667,28 @@ func openPerInterfaceSocket(ifName string, iface *net.Interface, isVLAN bool) (*
 	return rawConn, conn, nil
 }
 
-// openAfPacketReceiver opens an AF_PACKET SOCK_DGRAM socket bound to the
+// afPacketSocket is the socket(2) entry point used by openAfPacketReceiver.
+// It is a package var so tests can intercept the call and assert the type
+// flags (notably SOCK_CLOEXEC) without needing CAP_NET_RAW.
+var afPacketSocket = unix.Socket
+
+// openAfPacketReceiver opens an AF_PACKET SOCK_RAW socket bound to the
 // given interface for receiving VRRP packets. This is used on VLAN sub-
 // interfaces where raw IP sockets don't reliably receive multicast.
-// SOCK_DGRAM strips the Ethernet header — received data starts at the IP header.
+// SOCK_RAW keeps the Ethernet header — the cBPF VLAN filter and the Go
+// parser both expect data starting at the L2 header.
 func openAfPacketReceiver(ifIndex int) (int, error) {
 	// Use ETH_P_ALL (same as tcpdump) — VLAN sub-interface + multicast
 	// delivery is unreliable with ETH_P_IP protocol filtering.
 	proto := htons(unix.ETH_P_ALL)
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(proto))
+	// SOCK_CLOEXEC is OR'd into the type so the raw packet-capture fd is set
+	// close-on-exec ATOMICALLY at creation. A raw unix.Socket does NOT get
+	// CLOEXEC by default (unlike Go net sockets), so without this the fd would
+	// be inherited by every child the daemon execs (frr-reload.py, swanctl,
+	// dhcp helpers) — an fd leak and a security boundary issue (a child could
+	// read raw VRRP frames off the capture socket). The atomic OR-into-type
+	// avoids the fork race of a separate post-creation fcntl(FD_CLOEXEC).
+	fd, err := afPacketSocket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_CLOEXEC, int(proto))
 	if err != nil {
 		return -1, fmt.Errorf("af_packet socket: %w", err)
 	}


### PR DESCRIPTION
Closes #2476

## Problem
`openAfPacketReceiver` in `pkg/vrrp/manager.go` created the AF_PACKET VRRP
capture socket with a bare `unix.Socket(AF_PACKET, SOCK_RAW, ...)`. Raw sockets
opened via `unix.Socket` do **not** get close-on-exec by default (unlike Go
net-stack sockets), so the raw packet-capture fd was inherited by every child
the daemon execs — `frr-reload.py`, `swanctl`, dhcp helpers. That is an fd leak
plus a minor security boundary: an exec'd child could read raw VRRP frames off
the capture socket.

## Fix
OR `SOCK_CLOEXEC` into the socket type: `unix.SOCK_RAW|unix.SOCK_CLOEXEC`.
Setting CLOEXEC in the type argument applies it **atomically at creation**,
avoiding the fork-race window a separate post-creation `fcntl(FD_CLOEXEC)`
would leave open. The flag is transparent to the data path (socket still
opens/binds/receives adverts identically).

## Sibling raw-socket audit
This is the **only** raw `unix.Socket`/`syscall.Socket` site in `pkg/vrrp`. The
per-instance IPv4/IPv6 sockets go through `net.ListenPacket` / `x/net/ipv4`,
which the Go runtime already opens close-on-exec — no gap. (Other raw-socket
sites exist elsewhere in the daemon — `pkg/cluster/garp.go`, `pkg/lldp`,
`pkg/daemon/daemon_ha_fabric.go`, `pkg/dataplane/userspace/process.go` — but
#2476 scopes this to the VRRP receiver; those are out of scope here.)

## Testing
`pkg/vrrp/afpacket_cloexec_test.go`:
- **Seam test (deterministic, no privilege):** a `afPacketSocket` function-var
  seam captures the exact type flags passed at the call site and asserts
  `SOCK_CLOEXEC|SOCK_RAW` are both present. **Fail-on-revert proven** — stripping
  `SOCK_CLOEXEC` yields captured type `0x3` and the test fails.
- **Real-fd test:** opens a live AF_PACKET fd and checks `F_GETFD` has
  `FD_CLOEXEC`; skips gracefully without `CAP_NET_RAW` (the CI/dev user).

`go test ./pkg/vrrp/...` passes; gofmt clean. `pkg/vrrp/README.md` Sockets
section updated to document the CLOEXEC posture.

> VRRP code — parent runs `make test-failover` as the merge gate. SOCK_CLOEXEC
> only affects fd inheritance, not advert/failover behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)