### PR TITLE
Recover poisoned shared-session locks on HA failover (#2402)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -13049,3 +13049,7 @@ top.
 - **Timestamp**: 2026-06-24
   - **Action**: #2377 — fix VRRP sendGARP gateway-probe target on /25+ subnets. Factored target computation into network-free helper `gatewayProbeTarget(ipNet) (net.IP, bool)` computing network+1 from masked CIDR; skip on /31//32. v4-only bug (v6 path has no .1 assumption). Added fail-on-revert table test + sendGARP-seam tests. Updated README + sendGARP docs.
   - **File(s)**: pkg/vrrp/instance.go, pkg/vrrp/instance_garp_probe_target_test.go, pkg/vrrp/README.md
+
+- **Timestamp**: 2026-06-24
+  - **Action**: #2402 — HA session promotion swallowed a poisoned shared-sessions lock and dropped ALL sessions on failover. Replaced poison-swallowing `.lock().map(..).unwrap_or_default()` / `if let Ok` / `.lock().ok()` / `match .lock() { Err=>return }` patterns across shared_ops.rs with poison-RECOVERING `lock_shared_recover` (into_inner + clear_poison + counter + sparse journald line), mirroring nat/allocator + worker_queue::lock_recover. Fixed prewarm + demote + publish + remove + 3 lookups + republish + owner-RG index helpers. Added fail-on-revert test (poison synced mutex, assert reverse companion still synthesized/published). Updated afxdp/README poison-policy section.
+  - **File(s)**: userspace-dp/src/afxdp/shared_ops.rs, userspace-dp/src/afxdp/ha_tests.rs, userspace-dp/src/afxdp/README.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -284,6 +284,42 @@ helpers. Before #1807 a single poisoned queue made the worker
 permanently deaf (poison read as "no commands") while producers
 silently dropped or, for the tunnel drain-wait, spun to timeout.
 
+## Shared-session map poison policy (#2402)
+
+The HA promotion/demotion path reads and mutates three shared-session
+maps (`Mutex<FastMap<SessionKey, SyncedSessionEntry>>` — synced, NAT, and
+forward-wire) plus their owner-RG indexes. A worker panic while holding
+one of these mutexes (contained by the #925 supervisor) poisons it, and
+the map still holds every committed insert.
+
+The old access patterns SWALLOWED that poison and lost the data:
+
+- `prewarm_reverse_synced_sessions_for_owner_rgs` used
+  `shared_sessions.lock().map(|s| { … }).unwrap_or_default()`. On a
+  poisoned lock the `.map` closure was skipped and `unwrap_or_default()`
+  substituted EMPTY `(forward_entries, reverse_entries)` — so RG
+  activation proceeded as if there were **no sessions to promote** and
+  silently dropped every active synced session at the exact moment of
+  failover (the #2402 bug).
+- `demote_shared_owner_rgs`, `publish_shared_session`,
+  `remove_shared_session`, the `lookup_shared_*` helpers,
+  `republish_bpf_session_entries_for_owner_rgs`, and the owner-RG index
+  maintenance helpers used `if let Ok(..)` / `.lock().ok()` /
+  `match .lock() { Err(_) => return }`, each of which silently SKIPPED its
+  work (a missed demotion, a dropped publish/remove, a spurious lookup
+  miss) on poison.
+
+`shared_ops::lock_shared_recover` replaces all of them with poison
+RECOVERY — `into_inner()` to keep the committed map, `clear_poison()` to
+restore the fast path, and a bump of `SHARED_SESSION_POISON_RECOVERIES`
+plus a sparse journald line so operators see the underlying worker panic.
+This mirrors the worker-command-queue policy above (`worker_queue.rs`,
+#1807): a contained panic must never void failover — promotion/demotion
+proceeds with the existing session data. The unrelated `mode`-mutex
+status reads in `state_writer.rs` / `slowpath.rs` keep
+`.lock().map(..).unwrap_or_default()` deliberately (a momentary
+default-mode status read is harmless and not on the session path).
+
 ## Hot-path constants
 
 - `RX_BATCH_SIZE = 64`

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -461,6 +461,118 @@ fn update_ha_state_demotion_recovers_from_poisoned_worker_command_mutex() {
     );
 }
 
+#[test]
+fn prewarm_recovers_from_poisoned_shared_session_mutex() {
+    // #2402 regression: the activation prewarm path acquired the shared
+    // session mutex with `.lock().map(..).unwrap_or_default()`. If a
+    // worker thread had panicked while holding that lock, `lock()` returns
+    // Err, the `.map(..)` closure is SKIPPED, and `unwrap_or_default()`
+    // substitutes EMPTY (forward_entries, reverse_entries) — so RG
+    // activation proceeded as if there were NO sessions to promote and
+    // silently dropped every active synced session at the moment of
+    // failover. The fix recovers the poisoned guard
+    // (`lock_shared_recover` / `into_inner`) and promotes the EXISTING
+    // sessions. This test populates a shared session, poisons the mutex,
+    // runs prewarm, and asserts the reverse companion is still
+    // synthesized + published (with the old code it would be absent).
+    let mut coordinator = Coordinator::new();
+    coordinator.forwarding = test_forwarding_state_split_rgs();
+    let worker_commands = Arc::new(Mutex::new(VecDeque::new()));
+
+    let entry = SyncedSessionEntry {
+        key: test_key(),
+        decision: test_decision(),
+        metadata: test_metadata(),
+        origin: SessionOrigin::SyncImport,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+        generation: 0,
+    };
+    publish_shared_session(
+        &coordinator.sessions.synced,
+        &coordinator.sessions.nat,
+        &coordinator.sessions.forward_wire,
+        &coordinator.sessions.owner_rg_indexes,
+        &entry,
+    );
+    refresh_reverse_prewarm_owner_rg_indexes(
+        &coordinator
+            .sessions
+            .owner_rg_indexes
+            .reverse_prewarm_sessions,
+        &coordinator.forwarding,
+        coordinator.dynamic_neighbors_ref(),
+        None,
+        Some(&entry),
+    );
+
+    // Poison the shared session mutex deterministically: a thread panics
+    // while holding the lock, and join() observes the panic.
+    let to_poison = coordinator.sessions.synced.clone();
+    let poisoner = std::thread::spawn(move || {
+        let _guard = to_poison.lock().expect("lock before poisoning");
+        panic!("poison shared session mutex");
+    })
+    .join();
+    assert!(poisoner.is_err(), "poisoning thread must panic");
+    assert!(
+        coordinator.sessions.synced.lock().is_err(),
+        "shared session mutex must be poisoned"
+    );
+
+    let recoveries_before =
+        super::shared_ops::SHARED_SESSION_POISON_RECOVERIES.load(Ordering::Relaxed);
+
+    let ha_state = BTreeMap::from([(1, active_ha_runtime(1_000)), (2, active_ha_runtime(1_000))]);
+    prewarm_reverse_synced_sessions_for_owner_rgs(
+        &coordinator.sessions.synced,
+        &coordinator.sessions.nat,
+        &coordinator.sessions.forward_wire,
+        &coordinator.sessions.owner_rg_indexes,
+        std::slice::from_ref(&worker_commands),
+        -1,
+        &coordinator.forwarding,
+        &ha_state,
+        coordinator.dynamic_neighbors_ref(),
+        &[1, 2],
+        1_000,
+    );
+
+    // The poisoned guard was recovered, not swallowed.
+    assert!(
+        super::shared_ops::SHARED_SESSION_POISON_RECOVERIES.load(Ordering::Relaxed)
+            > recoveries_before,
+        "prewarm must recover (count) the poisoned shared session lock"
+    );
+
+    // Fail-on-revert: with the old `.unwrap_or_default()`, the poisoned
+    // lock yields empty entries and the reverse companion is NEVER
+    // published — this lookup returns None and the assert fails.
+    let reverse_key = reverse_session_key(&entry.key, entry.decision.nat);
+    let reverse = coordinator
+        .sessions
+        .synced
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&reverse_key)
+        .cloned()
+        .expect("reverse companion must survive a poisoned shared lock");
+    assert!(reverse.metadata.is_reverse);
+
+    // The worker also received the reverse UpsertSynced (promotion was not
+    // silently dropped).
+    let commands = worker_commands
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+        commands.iter().any(|command| matches!(
+            command,
+            WorkerCommand::UpsertSynced(session) if session.metadata.is_reverse
+        )),
+        "worker must receive the recovered reverse UpsertSynced"
+    );
+}
+
 // --- #2170 install-generation guard (helper-side belt-and-suspenders) -----
 
 fn synced_entry_with_generation(generation: u64) -> SyncedSessionEntry {

--- a/userspace-dp/src/afxdp/shared_ops.rs
+++ b/userspace-dp/src/afxdp/shared_ops.rs
@@ -1,5 +1,46 @@
 use super::*;
 use std::sync::atomic::AtomicU64;
+use std::sync::MutexGuard;
+
+/// #2402: total shared-session / owner-RG-index mutex poison recoveries
+/// across every site in this module (HA promotion prewarm, demotion,
+/// publish, remove, lookups, owner-RG index maintenance). Each recovery
+/// means a worker thread panicked while holding one of the shared-session
+/// mutexes; the map still holds every committed insert, so the HA
+/// promotion/demotion path proceeds with the EXISTING sessions instead of
+/// silently treating the table as empty (which dropped all synced sessions
+/// at failover — the #2402 bug). Mirrors the worker-command-queue policy
+/// (`worker_queue::lock_recover`, #1807). Each recovery also emits a sparse
+/// journald line so operators see that a worker panicked (the root cause);
+/// the counter is kept for tests and future status wiring.
+pub(crate) static SHARED_SESSION_POISON_RECOVERIES: AtomicU64 = AtomicU64::new(0);
+
+/// Lock a shared-session (or owner-RG index) mutex, RECOVERING and
+/// clearing poison instead of swallowing it.
+///
+/// Policy (#2402, mirrors `worker_queue::lock_recover` #1807): a panic
+/// that poisoned the mutex already happened and was contained (#925
+/// worker supervisor). The guarded map still holds the committed prefix
+/// of every completed insert, so the correct recovery is to keep using
+/// that data — NOT to skip the operation (`if let Ok`) or substitute an
+/// empty table (`.lock().map(..).unwrap_or_default()`). On the HA
+/// promotion path the latter silently dropped every active synced session
+/// at the exact moment of failover. `clear_poison` restores the fast
+/// unpoisoned path for subsequent locks so the Poisoned arm stays cold.
+#[inline]
+pub(super) fn lock_shared_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    match m.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            m.clear_poison();
+            SHARED_SESSION_POISON_RECOVERIES.fetch_add(1, Ordering::Relaxed);
+            eprintln!(
+                "xpf-ha: shared session mutex poisoned by a prior worker panic; recovering existing sessions and clearing poison"
+            );
+            poisoned.into_inner()
+        }
+    }
+}
 
 /// #1760 W3': cumulative count of shared-map NAT reverse-key displacement
 /// events — a `publish_shared_session` insert into `shared_nat_sessions`
@@ -130,7 +171,8 @@ pub(super) fn demote_shared_owner_rgs(
         return;
     }
     let mut demoted_entries = Vec::new();
-    if let Ok(mut sessions) = shared_sessions.lock() {
+    {
+        let mut sessions = lock_shared_recover(shared_sessions);
         for key in owner_rg_session_keys(&shared_owner_rg_indexes.sessions, owner_rgs) {
             if let Some(entry) = sessions.get_mut(&key) {
                 let previous = entry.clone();
@@ -148,14 +190,16 @@ pub(super) fn demote_shared_owner_rgs(
             Some(&entry),
         );
     }
-    if let Ok(mut sessions) = shared_nat_sessions.lock() {
+    {
+        let mut sessions = lock_shared_recover(shared_nat_sessions);
         for key in owner_rg_session_keys(&shared_owner_rg_indexes.nat_sessions, owner_rgs) {
             if let Some(entry) = sessions.get_mut(&key) {
                 entry.origin = SessionOrigin::SyncImport;
             }
         }
     }
-    if let Ok(mut sessions) = shared_forward_wire_sessions.lock() {
+    {
+        let mut sessions = lock_shared_recover(shared_forward_wire_sessions);
         for key in owner_rg_session_keys(&shared_owner_rg_indexes.forward_wire_sessions, owner_rgs)
         {
             if let Some(entry) = sessions.get_mut(&key) {
@@ -219,46 +263,51 @@ pub(super) fn prewarm_reverse_synced_sessions_for_owner_rgs(
             candidate_keys.push(key);
         }
     }
-    let (forward_entries, reverse_entries) = shared_sessions
-        .lock()
-        .map(|sessions| {
-            let mut forward_entries = Vec::new();
-            let mut reverse_entries = Vec::new();
-            for key in candidate_keys {
-                let Some(entry) = sessions.get(&key) else {
-                    continue;
-                };
-                if entry.metadata.is_reverse {
-                    continue;
-                }
-                let allow_reverse_prewarm = entry.origin.is_peer_synced()
-                    || matches!(entry.origin, SessionOrigin::SharedPromote);
-                let Some(reverse) = synthesized_synced_reverse_entry(
-                    forwarding,
-                    ha_state,
-                    dynamic_neighbors,
-                    entry,
-                    now_secs,
-                ) else {
-                    // Collect forward entry even if reverse can't be synthesized,
-                    // as long as the forward session belongs to an activated RG.
-                    if owner_rg_set.contains(&entry.metadata.owner_rg_id) {
-                        forward_entries.push(entry.clone());
-                    }
-                    continue;
-                };
-                if owner_rg_set.contains(&entry.metadata.owner_rg_id)
-                    || owner_rg_set.contains(&reverse.metadata.owner_rg_id)
-                {
+    // #2402: acquire the shared-session guard with poison RECOVERY. The
+    // prior `.lock().map(..).unwrap_or_default()` swallowed a poisoned
+    // lock into EMPTY (forward_entries, reverse_entries) — so if a worker
+    // had panicked while holding this mutex, RG activation proceeded as if
+    // there were NO sessions to promote and silently dropped every active
+    // synced session at the exact moment of failover. Recover the existing
+    // map and compute from it instead.
+    let (forward_entries, reverse_entries) = {
+        let sessions = lock_shared_recover(shared_sessions);
+        let mut forward_entries = Vec::new();
+        let mut reverse_entries = Vec::new();
+        for key in candidate_keys {
+            let Some(entry) = sessions.get(&key) else {
+                continue;
+            };
+            if entry.metadata.is_reverse {
+                continue;
+            }
+            let allow_reverse_prewarm = entry.origin.is_peer_synced()
+                || matches!(entry.origin, SessionOrigin::SharedPromote);
+            let Some(reverse) = synthesized_synced_reverse_entry(
+                forwarding,
+                ha_state,
+                dynamic_neighbors,
+                entry,
+                now_secs,
+            ) else {
+                // Collect forward entry even if reverse can't be synthesized,
+                // as long as the forward session belongs to an activated RG.
+                if owner_rg_set.contains(&entry.metadata.owner_rg_id) {
                     forward_entries.push(entry.clone());
-                    if allow_reverse_prewarm {
-                        reverse_entries.push(reverse);
-                    }
+                }
+                continue;
+            };
+            if owner_rg_set.contains(&entry.metadata.owner_rg_id)
+                || owner_rg_set.contains(&reverse.metadata.owner_rg_id)
+            {
+                forward_entries.push(entry.clone());
+                if allow_reverse_prewarm {
+                    reverse_entries.push(reverse);
                 }
             }
-            (forward_entries, reverse_entries)
-        })
-        .unwrap_or_default();
+        }
+        (forward_entries, reverse_entries)
+    };
     if forward_entries.is_empty() && reverse_entries.is_empty() {
         return;
     }
@@ -366,10 +415,9 @@ pub(super) fn republish_bpf_session_entries_for_owner_rgs(
     // Collect entries under the lock, then release before BPF syscalls
     // to avoid blocking concurrent session insert/remove/lookup.
     let entries: Vec<_> = {
-        let sessions = match shared_sessions.lock() {
-            Ok(s) => s,
-            Err(_) => return 0,
-        };
+        // #2402: recover a poisoned lock instead of returning 0 — a prior
+        // worker panic must not void the activation BPF-map republish.
+        let sessions = lock_shared_recover(shared_sessions);
         keys.iter()
             .filter_map(|key| {
                 sessions
@@ -404,30 +452,25 @@ pub(super) fn lookup_shared_session(
     shared_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     key: &SessionKey,
 ) -> Option<SyncedSessionEntry> {
-    shared_sessions
-        .lock()
-        .ok()
-        .and_then(|sessions| sessions.get(key).cloned())
+    // #2402: recover poison so a prior worker panic does not turn every
+    // shared-session lookup into a spurious miss.
+    lock_shared_recover(shared_sessions).get(key).cloned()
 }
 
 pub(super) fn lookup_shared_forward_nat_match(
     shared_nat_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     reply_key: &SessionKey,
 ) -> Option<SyncedSessionEntry> {
-    shared_nat_sessions
-        .lock()
-        .ok()
-        .and_then(|sessions| sessions.get(reply_key).cloned())
+    // #2402: recover poison (see lookup_shared_session).
+    lock_shared_recover(shared_nat_sessions).get(reply_key).cloned()
 }
 
 pub(super) fn lookup_shared_forward_wire_match(
     shared_forward_wire_sessions: &Arc<Mutex<FastMap<SessionKey, SyncedSessionEntry>>>,
     wire_key: &SessionKey,
 ) -> Option<SyncedSessionEntry> {
-    shared_forward_wire_sessions
-        .lock()
-        .ok()
-        .and_then(|sessions| sessions.get(wire_key).cloned())
+    // #2402: recover poison (see lookup_shared_session).
+    lock_shared_recover(shared_forward_wire_sessions).get(wire_key).cloned()
 }
 
 #[derive(Clone, Debug)]
@@ -793,7 +836,10 @@ pub(super) fn publish_shared_session(
     shared_owner_rg_indexes: &SharedSessionOwnerRgIndexes,
     entry: &SyncedSessionEntry,
 ) {
-    if let Ok(mut sessions) = shared_sessions.lock() {
+    {
+        // #2402: recover poison so a peer-sync / promote publish is never
+        // silently dropped because a worker panicked under this lock.
+        let mut sessions = lock_shared_recover(shared_sessions);
         let previous_owner_rg = sessions
             .insert(entry.key.clone(), entry.clone())
             .map(|existing| existing.metadata.owner_rg_id);
@@ -804,9 +850,8 @@ pub(super) fn publish_shared_session(
             entry.metadata.owner_rg_id,
         );
     }
-    if !entry.metadata.is_reverse
-        && let Ok(mut sessions) = shared_nat_sessions.lock()
-    {
+    if !entry.metadata.is_reverse {
+        let mut sessions = lock_shared_recover(shared_nat_sessions);
         let reverse_wire = reverse_session_key(&entry.key, entry.decision.nat);
         let displaced = sessions.insert(reverse_wire.clone(), entry.clone());
         record_shared_nat_displacement(displaced.as_ref(), entry);
@@ -830,9 +875,8 @@ pub(super) fn publish_shared_session(
             );
         }
     }
-    if !entry.metadata.is_reverse
-        && let Ok(mut sessions) = shared_forward_wire_sessions.lock()
-    {
+    if !entry.metadata.is_reverse {
+        let mut sessions = lock_shared_recover(shared_forward_wire_sessions);
         let wire_key = forward_wire_key(&entry.key, entry.decision.nat);
         if wire_key != entry.key {
             let previous_owner_rg = sessions
@@ -855,17 +899,18 @@ pub(super) fn remove_shared_session(
     shared_owner_rg_indexes: &SharedSessionOwnerRgIndexes,
     key: &SessionKey,
 ) {
-    if let Ok(mut sessions) = shared_sessions.lock()
-        && let Some(entry) = sessions.remove(key)
-    {
+    // #2402: recover poison so a delete-sync removal is never silently
+    // skipped (leaving a stale entry that would mis-route after failover)
+    // because a worker panicked under the shared-session lock.
+    let mut sessions = lock_shared_recover(shared_sessions);
+    if let Some(entry) = sessions.remove(key) {
         remove_owner_rg_index_entry(
             &shared_owner_rg_indexes.sessions,
             entry.metadata.owner_rg_id,
             key,
         );
-        if !entry.metadata.is_reverse
-            && let Ok(mut nat_sessions) = shared_nat_sessions.lock()
-        {
+        if !entry.metadata.is_reverse {
+            let mut nat_sessions = lock_shared_recover(shared_nat_sessions);
             let reverse_wire = reverse_session_key(&entry.key, entry.decision.nat);
             if let Some(removed) = nat_sessions.remove(&reverse_wire) {
                 remove_owner_rg_index_entry(
@@ -884,7 +929,9 @@ pub(super) fn remove_shared_session(
                     &reverse_canonical,
                 );
             }
-            if let Ok(mut forward_wire_sessions) = shared_forward_wire_sessions.lock() {
+            {
+                let mut forward_wire_sessions =
+                    lock_shared_recover(shared_forward_wire_sessions);
                 let wire_key = forward_wire_key(&entry.key, entry.decision.nat);
                 if wire_key != entry.key
                     && let Some(removed) = forward_wire_sessions.remove(&wire_key)
@@ -905,7 +952,10 @@ pub(super) fn owner_rg_session_keys(
     owner_rgs: &[i32],
 ) -> Vec<SessionKey> {
     let mut keys = FastSet::default();
-    if let Ok(index) = index.lock() {
+    {
+        // #2402: recover poison so the owner-RG index is not silently
+        // emptied (which hides every session from promotion/demotion).
+        let index = lock_shared_recover(index);
         for owner_rg_id in owner_rgs {
             if let Some(entries) = index.get(owner_rg_id) {
                 keys.extend(entries.iter().cloned());
@@ -920,9 +970,9 @@ pub(super) fn owner_rg_session_keys_serialized(
     index: &Arc<Mutex<OwnerRgSessionIndex>>,
     owner_rgs: &[i32],
 ) -> Vec<SessionKey> {
-    let Ok(_sessions) = sessions.lock() else {
-        return Vec::new();
-    };
+    // #2402: hold the shared-session lock (recovering poison) to serialize
+    // against concurrent insert/remove while the index is read.
+    let _sessions = lock_shared_recover(sessions);
     owner_rg_session_keys(index, owner_rgs)
 }
 
@@ -937,9 +987,9 @@ pub(super) fn refresh_reverse_prewarm_owner_rg_indexes(
         .map(|entry| reverse_prewarm_owner_rg_candidates(forwarding, dynamic_neighbors, entry));
     let next_owner_rgs = next_entry
         .map(|entry| reverse_prewarm_owner_rg_candidates(forwarding, dynamic_neighbors, entry));
-    let Ok(mut index) = index.lock() else {
-        return;
-    };
+    // #2402: recover poison so reverse-prewarm index maintenance is not
+    // skipped after a prior worker panic.
+    let mut index = lock_shared_recover(index);
     if let Some(previous_entry) = previous_entry {
         for owner_rg_id in previous_owner_rgs.unwrap_or_default() {
             remove_owner_rg_index_entry_locked(&mut index, owner_rg_id, &previous_entry.key);
@@ -996,12 +1046,12 @@ fn update_owner_rg_index(
     if owner_rg_id <= 0 {
         return;
     }
-    if let Ok(mut index) = index.lock() {
-        index
-            .entry(owner_rg_id)
-            .or_insert_with(FastSet::default)
-            .insert(key.clone());
-    }
+    // #2402: recover poison (owner-RG index maintenance).
+    let mut index = lock_shared_recover(index);
+    index
+        .entry(owner_rg_id)
+        .or_insert_with(FastSet::default)
+        .insert(key.clone());
 }
 
 fn remove_owner_rg_index_entry(
@@ -1012,9 +1062,9 @@ fn remove_owner_rg_index_entry(
     if owner_rg_id <= 0 {
         return;
     }
-    if let Ok(mut index) = index.lock() {
-        remove_owner_rg_index_entry_locked(&mut index, owner_rg_id, key);
-    }
+    // #2402: recover poison (owner-RG index maintenance).
+    let mut index = lock_shared_recover(index);
+    remove_owner_rg_index_entry_locked(&mut index, owner_rg_id, key);
 }
 
 fn remove_owner_rg_index_entry_locked(


### PR DESCRIPTION
Closes #2402

## Problem
On HA failover the shared-session promotion path acquired the
shared-sessions mutex with `.lock().map(..).unwrap_or_default()`. If a
worker thread had panicked earlier while holding that lock, the mutex is
POISONED → `lock()` returns `Err` → the `.map(..)` closure is skipped →
`unwrap_or_default()` yields EMPTY vectors → the coordinator proceeds as
if there were NO sessions to promote and **silently drops every active
synced session** at the exact moment hitless failover is needed.

`prewarm_reverse_synced_sessions_for_owner_rgs` was the data-dropping
site; `demote_shared_owner_rgs` and the sibling
publish/remove/lookup/republish/owner-RG-index helpers used `if let Ok`,
`.lock().ok()`, or `match .lock() { Err(_) => return }`, each silently
skipping its work on poison (missed demotion, dropped publish/remove,
spurious lookup miss).

## Fix
Replace all of them with a single poison-RECOVERING helper
`shared_ops::lock_shared_recover` — `into_inner()` to keep the committed
map, `clear_poison()` to restore the fast path, a `SHARED_SESSION_POISON_RECOVERIES`
bump, and one sparse journald line so operators see the worker panic.
Mirrors `nat/allocator.rs` (`.lock().unwrap_or_else(|e| e.into_inner())`)
and `worker_queue::lock_recover` (#1807). Promotion/demotion now proceeds
with the EXISTING session data.

Sites fixed (all in `shared_ops.rs`): `prewarm_reverse_synced_sessions_for_owner_rgs`,
`demote_shared_owner_rgs`, `publish_shared_session`, `remove_shared_session`,
`lookup_shared_session`, `lookup_shared_forward_nat_match`,
`lookup_shared_forward_wire_match`, `republish_bpf_session_entries_for_owner_rgs`,
`owner_rg_session_keys`, `owner_rg_session_keys_serialized`,
`refresh_reverse_prewarm_owner_rg_indexes`, `update_owner_rg_index`,
`remove_owner_rg_index_entry`.

The unrelated `mode`-mutex status reads in `state_writer.rs` / `slowpath.rs`
keep `.unwrap_or_default()` deliberately (momentary default-mode status
read, not on the session path).

## Tests
- `prewarm_recovers_from_poisoned_shared_session_mutex`: publishes a
  shared session, poisons the synced mutex via a panicking thread, runs
  the prewarm path, asserts the reverse companion is still synthesized +
  published and the recovery counter advanced.
- **Fail-on-revert proven**: restoring the swallow forms makes the test
  FAIL — the poisoned lock yields empty entries and the reverse companion
  is never published (`prewarm must recover the poisoned shared session lock`).
- Full suite: **2658 passed, 0 failed**.

## Docs
Added a "Shared-session map poison policy (#2402)" section to
`userspace-dp/src/afxdp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)