### PR TITLE
appid: protocol-only custom apps match in tuple fallback (#2548)

### DIFF
--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -24,8 +24,16 @@ and resolves session display names from the dataplane's assigned `app_id`.
   the matched `app_id` on each new session.
 - `ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, dstPort uint16, appID uint16) string` —
   `runtime.go`. Lookup order: dataplane `app_id` (authoritative from
-  BPF) → exact `(proto, dstPort)` match → narrow built-in fallback
-  (`junos-http`, `junos-ssh`, …). When AppID is **enabled** in
+  BPF) → user-configured app tuple match (`resolveTupleFallback` →
+  `matchTuple`) → narrow built-in fallback (`junos-http`, `junos-ssh`,
+  …). Tuple matching requires the configured protocol to match; if the
+  app also sets a `destination-port` (single or `lo-hi` range), the port
+  must match too. A **protocol-only** custom app — one with a `protocol`
+  but no `destination-port`, e.g. a user-defined GRE/ESP/AH application —
+  matches on protocol alone (#2548; before that fix `matchTuple`
+  rejected an empty port, so protocol-only apps never matched and their
+  sessions reported `UNKNOWN`). An app with neither protocol nor port is
+  never a match-all. When AppID is **enabled** in
   `services.application-identification` and the dataplane has not
   assigned an `app_id` for the session (`appID == 0`), the function
   returns `UNKNOWN` rather than guessing from port heuristics. Used

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -151,8 +151,16 @@ func matchTuple(proto uint8, dstPort uint16, appProto, appPort string) bool {
 	if pn, ok := protocolNumber(appProto); !ok || pn != proto {
 		return false
 	}
+	// #2548: a custom application configured with a protocol but no
+	// destination-port is PROTOCOL-ONLY (e.g. user-defined GRE/ESP/AH). The
+	// protocol match above is the whole constraint, so it matches here instead
+	// of being rejected — previously this returned false, so a protocol-only
+	// app could never tuple-match and its sessions reported UNKNOWN. The
+	// appProto=="" guard above still rejects an unconstrained app from
+	// match-all; a port-only/port-ranged app (appPort != "") below still
+	// requires BOTH the protocol and the port to match (unchanged).
 	if appPort == "" {
-		return false
+		return true
 	}
 	if strings.Contains(appPort, "-") {
 		parts := strings.SplitN(appPort, "-", 2)

--- a/pkg/appid/runtime_test.go
+++ b/pkg/appid/runtime_test.go
@@ -159,6 +159,76 @@ func TestResolveSessionNameFallbackWhenDisabled(t *testing.T) {
 	}
 }
 
+// TestMatchTupleProtocolOnly is the #2548 fail-on-revert guard. A custom app
+// configured with a protocol but NO destination-port (e.g. user-defined
+// GRE/ESP/AH) must tuple-match on protocol alone. Before the fix, matchTuple
+// returned false on appPort=="", so the protocol-only app never matched and
+// its sessions reported UNKNOWN. Reverting the empty-appPort short-circuit to
+// `return false` fails the protocol-only-matches assertion below.
+func TestMatchTupleProtocolOnly(t *testing.T) {
+	const greProto = 47
+
+	// Protocol-only app matches a session of its protocol regardless of port.
+	if !matchTuple(greProto, 0, "gre", "") {
+		t.Error("protocol-only GRE app must match a GRE session (proto match alone) — got no match")
+	}
+	if !matchTuple(greProto, 1234, "gre", "") {
+		t.Error("protocol-only GRE app must match regardless of dstPort — got no match")
+	}
+	// Protocol-only app does NOT match a different protocol.
+	if matchTuple(6 /*tcp*/, 0, "gre", "") {
+		t.Error("protocol-only GRE app must NOT match a TCP session")
+	}
+	// Numeric protocol token, protocol-only.
+	if !matchTuple(greProto, 0, "47", "") {
+		t.Error("protocol-only numeric-protocol app must match its protocol")
+	}
+	// Port-based app still requires BOTH protocol AND port — no regression.
+	if !matchTuple(6, 8443, "tcp", "8443") {
+		t.Error("port-based app must match on protocol+port")
+	}
+	if matchTuple(6, 9999, "tcp", "8443") {
+		t.Error("port-based app must NOT match on protocol-match/port-mismatch")
+	}
+	if matchTuple(17 /*udp*/, 8443, "tcp", "8443") {
+		t.Error("port-based app must NOT match on port-match/protocol-mismatch")
+	}
+	// Port-range app unchanged.
+	if !matchTuple(6, 8444, "tcp", "8443-8445") {
+		t.Error("port-range app must match a dstPort inside the range")
+	}
+	if matchTuple(6, 8500, "tcp", "8443-8445") {
+		t.Error("port-range app must NOT match a dstPort outside the range")
+	}
+	// Empty appProto must NOT match-all.
+	if matchTuple(47, 0, "", "") {
+		t.Error("app with empty protocol must NOT match-all")
+	}
+}
+
+// TestResolveSessionNameProtocolOnlyApp proves the protocol-only fix flows
+// through resolveTupleFallback so the session reports the configured app name
+// rather than UNKNOWN. (#2548)
+func TestResolveSessionNameProtocolOnlyApp(t *testing.T) {
+	cfg := &config.Config{
+		Applications: config.ApplicationsConfig{
+			Applications: map[string]*config.Application{
+				"custom-gre": {Name: "custom-gre", Protocol: "gre"},
+			},
+		},
+	}
+
+	// AppID disabled → tuple fallback. A GRE session (proto 47) names the app.
+	got := ResolveSessionName(nil, cfg, 47, 0, 0)
+	if got != "custom-gre" {
+		t.Fatalf("ResolveSessionName(GRE) = %q, want custom-gre (protocol-only app)", got)
+	}
+	// A non-GRE session must not pick up the protocol-only GRE app.
+	if got := ResolveSessionName(nil, cfg, 6, 80, 0); got == "custom-gre" {
+		t.Fatalf("ResolveSessionName(TCP/80) = %q, must not match protocol-only GRE app", got)
+	}
+}
+
 func TestSessionMatchesUnknown(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Services.ApplicationIdentification = true


### PR DESCRIPTION
Closes #2548

## Problem
`appid.matchTuple` returned `false` whenever the configured application had no
`destination-port` (`if appPort == "" { return false }`). A **protocol-only**
custom app — one defined with a `protocol` but no `destination-port`, e.g. a
user-defined GRE/ESP/AH application — could therefore never tuple-match.
`resolveTupleFallback` / `ResolveSessionName` skipped it, so matching sessions
reported `UNKNOWN` instead of the configured application name.

## Fix
In `matchTuple`, after the protocol match, an empty `appPort` is treated as
PROTOCOL-ONLY and returns `true` — the protocol match is the whole constraint.
Preserved invariants:

- `appProto == ""` → still `false` (an unconstrained app must not match-all).
- `appPort != ""` → require BOTH protocol AND port to match (single port or
  `lo-hi` range), unchanged.
- protocol mismatch → `false`, unchanged.

Rule: protocol must match; if a port is configured the port must also match; if
no port is configured a protocol match alone suffices.

## Validation
- `TestMatchTupleProtocolOnly` — protocol-only match, different-protocol
  non-match, numeric-protocol token, port-based protocol+port match, the
  protocol-match/port-mismatch and port-match/protocol-mismatch non-matches,
  port-range match/non-match, and the empty-protocol no-match-all guard.
- `TestResolveSessionNameProtocolOnlyApp` — a protocol-only GRE app resolves a
  GRE session to its name (not `UNKNOWN`) and does not pick up a non-GRE session.
- **Fail-on-revert proven**: reverting the empty-`appPort` short-circuit to
  `return false` fails the protocol-only assertions
  (`ResolveSessionName(GRE)` → `""` / `UNKNOWN`).
- `go test ./pkg/appid/...` passes.
- README lookup-order updated to document protocol-only tuple matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi