### PR TITLE
lldp: reject truncated mandatory TLVs instead of caching empty keys

### DIFF
--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -68,3 +68,11 @@ Standard library + `golang.org/x/sys/unix`. No internal `pkg/*` imports.
   `Neighbors()` snapshot.
 - The neighbor map is RWMutex-guarded. `Neighbors()` returns a copy, not
   a reference, so callers can iterate without holding the lock.
+- `ParseTLVs` counts a mandatory TLV (Chassis ID, Port ID, TTL) as
+  present only once its value parsed into a valid identifier — a non-empty
+  Chassis/Port ID, a full 2-byte TTL. A truncated mandatory TLV (subtype
+  byte alone, a MAC-subtype Chassis ID short of its 6-byte address, or a
+  TTL under 2 bytes) leaves the corresponding flag unset, so the frame is
+  rejected rather than cached under an empty `ifname//` key with TTL 0
+  (#2551). A valid 2-byte TTL of 0 is a legitimate shutdown advert and is
+  still accepted (the gate is "the TLV parsed", not "TTL != 0").

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -573,7 +573,11 @@ func encodeTTL(seconds int) []byte {
 }
 
 // ParseTLVs parses LLDP TLVs from raw payload (after Ethernet header).
-// Returns nil if mandatory TLVs (Chassis ID, Port ID, TTL) are missing.
+// Returns nil if any mandatory TLV (Chassis ID, Port ID, TTL) is missing OR
+// truncated: a mandatory TLV is only counted present once its value parsed
+// into a valid identifier (non-empty Chassis/Port ID, a 2-byte TTL). A
+// truncated mandatory TLV would otherwise be accepted with an empty key and
+// poison the neighbor cache as "ifname//" with TTL 0 (#2551).
 func ParseTLVs(data []byte) *Neighbor {
 	n := &Neighbor{}
 	hasChassis, hasPort, hasTTL := false, false, false
@@ -594,24 +598,39 @@ func ParseTLVs(data []byte) *Neighbor {
 		case tlvEnd:
 			goto done
 		case tlvChassisID:
-			if len(value) >= 2 && value[0] == chassisSubtypeMACAddr && len(value) >= 7 {
-				n.ChassisID = net.HardwareAddr(value[1:7]).String()
+			// Mark the Chassis ID present ONLY when the value is long enough
+			// to yield a real identifier. A subtype byte alone (len < 2) or a
+			// MAC-subtype value short of the 6-byte address (len < 7) is a
+			// truncated TLV: leaving hasChassis false makes the terminal check
+			// reject the frame rather than caching it under an empty key
+			// (#2551).
+			if len(value) >= 2 && value[0] == chassisSubtypeMACAddr {
+				if len(value) >= 7 {
+					n.ChassisID = net.HardwareAddr(value[1:7]).String()
+					hasChassis = true
+				}
+				// MAC subtype with len 2..6 is truncated for its own subtype —
+				// do not accept it.
 			} else if len(value) >= 2 {
 				n.ChassisID = string(value[1:])
+				hasChassis = true
 			}
-			hasChassis = true
 		case tlvPortID:
-			if len(value) >= 2 && value[0] == portSubtypeIfName {
+			// Same gating as Chassis ID: a subtype byte with no identifier
+			// (len < 2) is truncated, so leave hasPort false (#2551).
+			if len(value) >= 2 {
 				n.PortID = string(value[1:])
-			} else if len(value) >= 2 {
-				n.PortID = string(value[1:])
+				hasPort = true
 			}
-			hasPort = true
 		case tlvTTL:
+			// hasTTL gates on the 2-byte PARSE succeeding, not on a non-zero
+			// value: a valid 2-byte TTL of 0 is a legitimate shutdown advert
+			// (RFC IEEE 802.1AB) and must be accepted; only a TLV shorter than
+			// 2 bytes is truncated and leaves hasTTL false (#2551).
 			if len(value) >= 2 {
 				n.TTL = int(binary.BigEndian.Uint16(value[:2]))
+				hasTTL = true
 			}
-			hasTTL = true
 		case tlvSystemName:
 			n.SystemName = string(value)
 		case tlvSystemDesc:

--- a/pkg/lldp/lldp_test.go
+++ b/pkg/lldp/lldp_test.go
@@ -210,6 +210,108 @@ func TestParseTLVs_Empty(t *testing.T) {
 	}
 }
 
+// rawTLV builds a single TLV with an explicit (possibly short) value so a
+// truncated mandatory TLV can be constructed directly. tlvLen is the 9-bit
+// length field written to the header; value is the body that follows it.
+func rawTLV(tlvType int, value []byte) []byte {
+	header := uint16(tlvType&0x7f)<<9 | uint16(len(value)&0x1ff)
+	out := make([]byte, 2+len(value))
+	binary.BigEndian.PutUint16(out[:2], header)
+	copy(out[2:], value)
+	return out
+}
+
+// TestParseTLVs_TruncatedMandatory asserts that a mandatory TLV whose value is
+// too short to yield a valid identifier is treated as absent, so the frame is
+// rejected rather than cached under an empty key (#2551). Before the fix each
+// hasX flag was set unconditionally, so these frames were ACCEPTED with empty
+// ChassisID/PortID (or TTL 0) — these subtests FAIL on the pre-#2551 code,
+// proving fail-on-revert.
+func TestParseTLVs_TruncatedMandatory(t *testing.T) {
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	goodChassis := mustEncodeTLV(tlvChassisID, encodeChassisID(mac))
+	goodPort := mustEncodeTLV(tlvPortID, encodePortID("trust0"))
+	goodTTL := mustEncodeTLV(tlvTTL, encodeTTL(120))
+	end := mustEncodeTLV(tlvEnd, nil)
+
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{
+			// Chassis ID = subtype byte only (len 1), no identifier.
+			name: "chassis-id-len-1",
+			data: concat(rawTLV(tlvChassisID, []byte{chassisSubtypeMACAddr}), goodPort, goodTTL, end),
+		},
+		{
+			// Chassis ID = empty value (len 0).
+			name: "chassis-id-len-0",
+			data: concat(rawTLV(tlvChassisID, nil), goodPort, goodTTL, end),
+		},
+		{
+			// Chassis ID MAC subtype but value short of the 6-byte address
+			// (subtype + 4 of 6 MAC bytes = len 5, < 7).
+			name: "chassis-id-mac-subtype-truncated",
+			data: concat(rawTLV(tlvChassisID, []byte{chassisSubtypeMACAddr, 0xaa, 0xbb, 0xcc, 0xdd}), goodPort, goodTTL, end),
+		},
+		{
+			// Port ID = subtype byte only, no identifier.
+			name: "port-id-len-1",
+			data: concat(goodChassis, rawTLV(tlvPortID, []byte{portSubtypeIfName}), goodTTL, end),
+		},
+		{
+			// TTL value is 1 byte, can't form the 2-byte hold time.
+			name: "ttl-len-1",
+			data: concat(goodChassis, goodPort, rawTLV(tlvTTL, []byte{0x05}), end),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := ParseTLVs(tc.data)
+			if n != nil {
+				t.Errorf("expected nil for truncated mandatory TLV, got neighbor "+
+					"chassis=%q port=%q ttl=%d", n.ChassisID, n.PortID, n.TTL)
+			}
+		})
+	}
+}
+
+// TestParseTLVs_ValidShutdownTTL asserts that a well-formed advert carrying a
+// 2-byte TTL of 0 (a legitimate LLDP shutdown frame) is still accepted: the
+// hasTTL gate is "the 2-byte value parsed", not "TTL != 0". A truncated TTL
+// (covered above) is rejected; a parsed 0 is not.
+func TestParseTLVs_ValidShutdownTTL(t *testing.T) {
+	mac := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	data := concat(
+		mustEncodeTLV(tlvChassisID, encodeChassisID(mac)),
+		mustEncodeTLV(tlvPortID, encodePortID("trust0")),
+		mustEncodeTLV(tlvTTL, encodeTTL(0)),
+		mustEncodeTLV(tlvEnd, nil),
+	)
+	n := ParseTLVs(data)
+	if n == nil {
+		t.Fatal("expected a neighbor for a valid 2-byte TTL=0 shutdown advert, got nil")
+	}
+	if n.TTL != 0 {
+		t.Errorf("TTL: got %d, want 0", n.TTL)
+	}
+	if n.ChassisID != mac.String() {
+		t.Errorf("chassis ID: got %s, want %s", n.ChassisID, mac.String())
+	}
+	if n.PortID != "trust0" {
+		t.Errorf("port ID: got %s, want trust0", n.PortID)
+	}
+}
+
+func concat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
 func TestNeighborTable(t *testing.T) {
 	m := New()
 


### PR DESCRIPTION
Closes #2551

## Problem
`lldp.ParseTLVs` set `hasChassis`/`hasPort`/`hasTTL = true` unconditionally
after each mandatory-TLV case, even when the TLV value was too short to yield a
valid identifier. A truncated Chassis-ID or Port-ID left the identifier `""` but
still marked the TLV present, so the terminal
`if !hasChassis || !hasPort || !hasTTL { return nil }` guard passed and the
malformed advert was accepted. `rxLoop` then cached it under the key
`ge-0-0-0//` with TTL 0, poisoning/churning the neighbor cache on every receipt
of a crafted or corrupt frame.

## Fix
Gate each presence flag on the value actually parsing into a valid identifier:

- **`hasChassis`** only when a Chassis ID decoded non-empty. A subtype-byte-only
  value (`len < 2`) or a MAC-subtype value short of its 6-byte address
  (`len < 7`) is truncated for its subtype and is NOT accepted. (The old code
  mis-decoded the MAC-subtype-truncated case as a string built from the subtype
  byte.)
- **`hasPort`** only when a Port ID decoded non-empty.
- **`hasTTL`** only when the 2-byte hold time parsed. The gate is "the 2-byte
  value parsed", not "TTL != 0": a valid 2-byte TTL of 0 is a legitimate LLDP
  shutdown advert and is still accepted; only a TTL TLV shorter than 2 bytes
  leaves `hasTTL` false.

A frame with any truncated mandatory TLV now leaves the corresponding flag
false, so the terminal check returns nil (frame rejected, not cached).
Well-formed frames — including a TTL=0 shutdown advert — are unaffected.

## Tests
- `TestParseTLVs_TruncatedMandatory`: truncated chassis-id (len 0/1),
  MAC-subtype chassis-id short of 6 bytes, truncated port-id, 1-byte TTL — each
  asserts `ParseTLVs` returns nil.
- `TestParseTLVs_ValidShutdownTTL`: a 2-byte TTL=0 advert is still accepted.
- **Fail-on-revert proven**: all five truncated subtests FAIL on the pre-fix
  source (they were accepted with empty/partial keys, e.g.
  `chassis="" port="trust0" ttl=120`).
- `go test ./pkg/lldp/...` and `go vet` pass; `gofmt` clean.

## Docs
`pkg/lldp/README.md` documents the per-flag gating and the
parsed-0-vs-truncated TTL distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi