### PR TITLE
flowexport: strict parse of sampling-interface unit suffix (#2463)

### DIFF
--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -289,6 +289,19 @@ moment any caller sampled off the copy (#2224).
 - Two batches are maintained inside `flowBatch` (`v4` and `v6`, split
   by family, not by zone — `transport.go`). Both flush on a 100 ms
   ticker or on shutdown.
+- `BuildSamplingZones` resolves a zone's interface references
+  (`parseIfaceRef`, `manager.go`) into (physical-name, unit) pairs to
+  decide which zones have sampling enabled. The unit suffix is parsed
+  strictly (#2463): a bare reference with no dot is the implicit unit 0
+  (a legitimate config form), but a reference WITH a dot must carry a
+  clean unsigned decimal unit after the FINAL dot — `strconv.Atoi`, no
+  sign, space, empty suffix, or trailing junk. A malformed reference
+  (`ge-0/0/0.1abc2`, `ge-0/0/0.foo`, `ge-0/0/0.-1`, `ge-0/0/0.`) is
+  WARNED once and SKIPPED, not silently coerced. The previous
+  digit-accumulation scan accepted them all — `1abc2` became unit 12,
+  `foo` and an empty suffix became unit 0, `-1` became unit 1 — so
+  sampling could be enabled on the wrong unit or silently on unit 0,
+  diverging from the operator's interface list.
 - `ExportSessionClose` builds the flow record synchronously from the
   event-reader callback. The export goroutine (started in `Run(ctx)`)
   is what actually transmits and refreshes templates; record assembly

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -219,18 +219,86 @@ func TestParseIfaceRef(t *testing.T) {
 		ref      string
 		wantName string
 		wantUnit int
+		wantOK   bool
 	}{
-		{"eth0.0", "eth0", 0},
-		{"trust0.5", "trust0", 5},
-		{"enp6s0", "enp6s0", 0},
-		{"ge-0/0/0.100", "ge-0/0/0", 100},
+		// Valid references.
+		{"eth0.0", "eth0", 0, true},
+		{"trust0.5", "trust0", 5, true},
+		{"ge-0/0/0.100", "ge-0/0/0", 100, true},
+		// Bare name (no dot) — legitimate config form, implicit unit 0.
+		{"enp6s0", "enp6s0", 0, true},
+		{"ge-0/0/0", "ge-0/0/0", 0, true},
+		// Malformed unit suffixes — strict parse rejects (#2463). The old
+		// digit-accumulation scan accepted all of these with a wrong/zero
+		// unit (1abc2->12, foo->0, -1->1).
+		{"ge-0/0/0.1abc2", "ge-0/0/0", 0, false},
+		{"ge-0/0/0.foo", "ge-0/0/0", 0, false},
+		{"ge-0/0/0.-1", "ge-0/0/0", 0, false},
+		{"ge-0/0/0.+1", "ge-0/0/0", 0, false},
+		{"ge-0/0/0. 1", "ge-0/0/0", 0, false},
+		{"ge-0/0/0.", "ge-0/0/0", 0, false},
+		{"ge-0/0/0.12x", "ge-0/0/0", 0, false},
 	}
 	for _, tt := range tests {
-		name, unit := parseIfaceRef(tt.ref)
-		if name != tt.wantName || unit != tt.wantUnit {
-			t.Errorf("parseIfaceRef(%q) = (%q, %d), want (%q, %d)",
-				tt.ref, name, unit, tt.wantName, tt.wantUnit)
+		name, unit, ok := parseIfaceRef(tt.ref)
+		if name != tt.wantName || unit != tt.wantUnit || ok != tt.wantOK {
+			t.Errorf("parseIfaceRef(%q) = (%q, %d, %v), want (%q, %d, %v)",
+				tt.ref, name, unit, ok, tt.wantName, tt.wantUnit, tt.wantOK)
 		}
+	}
+}
+
+// TestBuildSamplingZonesMalformedRefSkipped is the #2463 fail-on-revert
+// guard at the caller layer: a zone whose only interface reference has a
+// malformed unit suffix must NOT enable sampling on a bogus (digit-scan)
+// unit — BuildSamplingZones warns and skips it, so the zone is absent from
+// the result. A second zone with a valid reference still enables sampling
+// on the correct unit.
+//
+// On master parseIfaceRef("ge-0/0/0.1abc2") returns unit 12; if the config
+// happened to define unit 12 sampling it would silently be enabled, and a
+// "foo"/"" suffix falls back to unit 0 — both divergences this test pins
+// against.
+func TestBuildSamplingZonesMalformedRefSkipped(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				// Malformed unit suffix: digit-scan would parse unit 12.
+				"bad": {Interfaces: []string{"ge-0/0/0.1abc2"}},
+				// Valid reference on unit 0.
+				"good": {Interfaces: []string{"ge-0/0/1.0"}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/0": {
+					Units: map[int]*config.InterfaceUnit{
+						// Unit 12 has sampling enabled — the digit-scan
+						// mis-parse would wrongly turn this on for "bad".
+						12: {SamplingInput: true, SamplingOutput: true},
+					},
+				},
+				"ge-0/0/1": {
+					Units: map[int]*config.InterfaceUnit{
+						0: {SamplingInput: true},
+					},
+				},
+			},
+		},
+	}
+
+	zoneIDs := map[string]uint16{"bad": 1, "good": 2}
+	sz := BuildSamplingZones(cfg, zoneIDs)
+
+	// "bad" (id=1) must NOT enable sampling — the malformed ref is skipped,
+	// so the bogus unit-12 sampling config is never consulted.
+	if d, ok := sz[1]; ok {
+		t.Errorf("bad zone: malformed sampling-interface ref must be skipped, "+
+			"got %+v (digit-scan mis-parse enabled the wrong unit)", d)
+	}
+	// "good" (id=2) enables input sampling on the correct unit 0.
+	if d, ok := sz[2]; !ok || !d.Input || d.Output {
+		t.Errorf("good zone: got %+v (ok=%v), want Input=true Output=false", sz[2], ok)
 	}
 }
 

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -16,9 +16,11 @@
 package flowexport
 
 import (
+	"log/slog"
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -515,7 +517,16 @@ func BuildSamplingZones(cfg *config.Config, zoneIDs map[string]uint16) map[uint1
 		}
 		var dir SamplingDir
 		for _, ifaceRef := range zone.Interfaces {
-			physName, unitNum := parseIfaceRef(ifaceRef)
+			physName, unitNum, ok := parseIfaceRef(ifaceRef)
+			if !ok {
+				// A malformed unit suffix (non-numeric, signed, empty, or
+				// trailing junk) used to be silently coerced to the wrong
+				// unit (or unit 0). Warn once and skip rather than enable
+				// sampling on a bogus unit (#2463).
+				slog.Warn("flowexport: skipping malformed sampling-interface reference",
+					"zone", zoneName, "interface", ifaceRef)
+				continue
+			}
 			ifCfg, ok := cfg.Interfaces.Interfaces[physName]
 			if !ok {
 				continue
@@ -591,20 +602,40 @@ func (ec *ExportConfig) counter() *atomic.Uint64 {
 	return ec.sampleCounter
 }
 
-// parseIfaceRef splits "eth0.0" into ("eth0", 0).
-func parseIfaceRef(ref string) (string, int) {
-	for i := len(ref) - 1; i >= 0; i-- {
-		if ref[i] == '.' {
-			unitNum := 0
-			for _, c := range ref[i+1:] {
-				if c >= '0' && c <= '9' {
-					unitNum = unitNum*10 + int(c-'0')
-				}
-			}
-			return ref[:i], unitNum
-		}
+// parseIfaceRef splits an interface reference into its physical name and
+// logical unit, returning ok=false for a malformed unit suffix.
+//
+// A bare reference with no dot (e.g. "ge-0/0/0", "enp6s0") is a legitimate
+// config form and maps to the implicit unit 0 — the parser stores zone
+// interface tokens verbatim and a unit-less reference is valid Junos
+// grammar, so it returns (ref, 0, true).
+//
+// A reference WITH a dot splits on the FINAL dot and the suffix after it
+// must be a clean decimal unit number parsed by strconv.Atoi. Anything
+// strconv.Atoi rejects — a non-numeric suffix ("foo"), trailing junk
+// ("1abc2"), an empty suffix ("ge-0/0/0."), a sign or leading/trailing
+// space ("-1", " 1") — returns ok=false so the caller can warn and skip
+// rather than silently sample the wrong unit. The previous
+// digit-accumulation scan accepted all of these: "1abc2" became unit 12,
+// "foo" became unit 0, "-1" became unit 1.
+func parseIfaceRef(ref string) (name string, unit int, ok bool) {
+	dot := strings.LastIndexByte(ref, '.')
+	if dot < 0 {
+		// No unit suffix — implicit unit 0 (valid bare-name form).
+		return ref, 0, true
 	}
-	return ref, 0
+	suffix := ref[dot+1:]
+	// Reject an empty suffix and any leading sign or space up front:
+	// strconv.Atoi would accept "+1"/"-1" and return a signed value, but a
+	// Junos unit number is an unsigned decimal with no sign or whitespace.
+	if suffix == "" || suffix[0] < '0' || suffix[0] > '9' {
+		return ref[:dot], 0, false
+	}
+	u, err := strconv.Atoi(suffix)
+	if err != nil || u < 0 {
+		return ref[:dot], 0, false
+	}
+	return ref[:dot], u, true
 }
 
 // FlowRecord holds the data for a single flow, shared by the NetFlow v9


### PR DESCRIPTION
Closes #2463.

## Problem
`parseIfaceRef` extracted the logical unit by accumulating EVERY decimal digit in the post-dot substring and ignoring non-digit characters, so a malformed sampling-interface reference was silently accepted with a wrong or zero unit:

- `ge-0/0/0.1abc2` -> unit 12 (trailing junk merged into the number)
- `ge-0/0/0.foo` -> unit 0 (no digits -> silent unit-0 fallback)
- `ge-0/0/0.-1` -> unit 1 (sign dropped)

`BuildSamplingZones` trusts the parsed `(name, unit)` to decide whether a zone interface has flow sampling enabled, so a typo'd reference enabled sampling on the wrong unit (or silently on unit 0) and flow-export coverage diverged from the operator's interface list with no diagnostic.

## Fix
- Parse the suffix strictly: split on the FINAL dot, require a clean unsigned decimal unit via `strconv.Atoi`. Reject non-numeric suffix, trailing junk, empty suffix, negative value, or a leading sign/space (a digit-first guard rejects `+1`/`-1`/`" 1"` that `strconv.Atoi` would otherwise accept).
- Signature changes to `(name string, unit int, ok bool)` so callers can distinguish malformed from valid.
- `BuildSamplingZones` now `slog.Warn`s once (config-resolve time, not per-packet) and SKIPS a malformed reference instead of enabling sampling on a bogus unit. One bad reference does not fail the whole resolve.

## Bare-name (no-dot) semantics
A reference with NO dot (`ge-0/0/0`, `enp6s0`) is a legitimate config form — the parser stores zone interface tokens verbatim and a unit-less reference is valid Junos grammar (`pkg/config/parser_routing_test.go` records a bare `enp7s0` zone interface). It maps to implicit unit 0 and returns `ok=true`. Only a reference that DOES carry a dot is held to the strict decimal rule.

## Validation
- `pkg/flowexport` table tests: valid refs, both bare forms, every malformed case (`1abc2`, `foo`, `-1`, `+1`, `" 1"`, empty suffix, `12x`).
- `BuildSamplingZones` test: a malformed ref is WARNED + SKIPPED (bogus unit-12 sampling config never consulted) while a valid sibling enables sampling on the correct unit.
- Fail-on-revert confirmed: against the master digit-scan logic the parseIfaceRef table and the BuildSamplingZones skip test both fail.
- `go test ./pkg/flowexport` and `go vet ./pkg/flowexport` pass.
- README updated to document the strict parsing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi