### PR TITLE
logging: drop action= from standard SESSION_CLOSE RT_FLOW line (#2513)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,32 @@
 # Action Log
 
+## 2026-06-24 — #2513 fix: SESSION_CLOSE standard RT_FLOW line rendered `action=deny`
+
+- **Timestamp**: 2026-06-24
+- **Action**: A session close is a termination event, not a forwarding
+  decision, so userspace-dp writes the wire action byte as 0 for a close.
+  Byte 0 maps to "deny" via `actionName`, so the standard (plain)
+  `formatSyslogMsg` SESSION_CLOSE branch rendered `action=deny` — misleading
+  incident response into reading normal termination as a drop. Removed the
+  `action=` field from the standard SESSION_CLOSE line (the structured
+  RT_FLOW_SESSION_CLOSE line never carried one and reports a close
+  `reason="..."` instead, matching Junos). Change is keyed on
+  `Type == "SESSION_CLOSE"`, so POLICY_DENY / SCREEN_DROP / FILTER_LOG (the
+  genuine deny/reject paths) still render `action`. Wire encoding and the
+  `actionName` mapping are unchanged; only the misleading codec.rs comment
+  was corrected.
+- **File(s)**: pkg/logging/ringbuf.go (omit action= for the SESSION_CLOSE
+  standard branch), pkg/logging/session_close_format_test.go (golden tests,
+  new), userspace-dp/src/event_stream/codec.rs (comment only — the "harmless"
+  note now records that both close formatters omit action),
+  pkg/logging/README.md (SESSION_CLOSE line-format gotcha), _Log.md.
+- **Validation**: `go test ./pkg/logging/...` PASS; gofmt clean. Rust:
+  `cargo test --release --bin xpf-userspace-dp event_stream::codec` 17/17 PASS
+  (comment-only). Fail-on-revert PROVEN: restoring the `action=%s`/`rec.Action`
+  args to the standard SESSION_CLOSE branch makes TestStandardSessionCloseOmits
+  Action red (line shows `action=deny` again). TestStandardNonCloseStillRenders
+  Action confirms the change is event-type-scoped, not action==0 global.
+
 ## 2026-06-24 — #2403 fix: route-map next-hop emitted v4-only `set ip next-hop` for IPv6
 
 - **Timestamp**: 2026-06-24

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -146,6 +146,21 @@ if `Handle` runs the re-entrancy guard before the client check.
   `DecodeRawEventRecord` already honored the wire stamp — under helper
   backlog or reconnect that drifted from the decision instant. Keep the two
   paths on the single `eventTimeFromWire` SSOT.
+- **SESSION_CLOSE log lines carry no `action` (#2513).** A session close
+  is a termination event, not a forwarding decision, so it has no
+  permit/deny/reject action — the userspace-dp producer writes the wire
+  action byte as 0 for a close
+  (`encode_session_close_rt_flow`). Byte 0 maps to "deny" via
+  `actionName`, so the standard (plain) formatter used to render
+  `RT_FLOW SESSION_CLOSE ... action=deny ...`, which misread as a drop.
+  Both close renderers now omit action: the standard line
+  (`formatSyslogMsg`, keyed on `Type == "SESSION_CLOSE"`) drops the
+  `action=` field and keeps `proto/policy/zone/pkts/bytes`; the structured
+  line (`formatStructuredMsg` `RT_FLOW_SESSION_CLOSE`) never carried one and
+  reports a close `reason="..."` (e.g. "TCP FIN", "idle Timeout") matching
+  Junos. The omission is scoped to the close event type only — POLICY_DENY,
+  SCREEN_DROP, and FILTER_LOG (the genuine deny/reject paths) still render
+  `action`. Golden coverage: `session_close_format_test.go`.
 - `pkg/dataplane/userspace/eventstream_test.go` owns the deterministic
   local syslog harness for userspace RT_FLOW policy-deny, screen-drop, and
   filter-log frames. It sends raw event-stream frames through

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -839,8 +839,17 @@ func formatSyslogMsg(rec EventRecord) string {
 			rec.Type, rec.ScreenCheck, rec.SrcAddr, rec.DstAddr, rec.Protocol, rec.Action, inZone)
 	}
 	if rec.Type == "SESSION_CLOSE" {
-		return fmt.Sprintf("RT_FLOW %s src=%s dst=%s proto=%s action=%s policy=%d zone=%s->%s pkts=%d bytes=%d",
-			rec.Type, rec.SrcAddr, rec.DstAddr, rec.Protocol, rec.Action,
+		// A session close is not a forwarding decision, so it carries no
+		// permit/deny/reject action (the wire action byte is intentionally 0
+		// for closes; see userspace-dp encode_session_close_rt_flow). Rendering
+		// the 0 byte via actionName would print action=deny and mislead
+		// incident response into reading normal session termination as a drop
+		// (#2513). Omit action entirely — like the structured RT_FLOW_SESSION_
+		// CLOSE line, which carries a close reason instead. The close reason is
+		// surfaced on the structured line; the standard line keeps the volume
+		// counters operators use here.
+		return fmt.Sprintf("RT_FLOW %s src=%s dst=%s proto=%s policy=%d zone=%s->%s pkts=%d bytes=%d",
+			rec.Type, rec.SrcAddr, rec.DstAddr, rec.Protocol,
 			rec.PolicyID, inZone, outZone, rec.SessionPkts, rec.SessionBytes)
 	}
 	if rec.Type == "FILTER_LOG" {

--- a/pkg/logging/session_close_format_test.go
+++ b/pkg/logging/session_close_format_test.go
@@ -1,0 +1,121 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+// sessionCloseRecord builds an EventRecord that mirrors what decodeUserspaceEvent
+// produces for a SESSION_CLOSE frame: the wire action byte is 0 (a close carries
+// no permit/deny/reject decision), which actionName maps to "deny".
+func sessionCloseRecord() EventRecord {
+	return EventRecord{
+		Type:            "SESSION_CLOSE",
+		SrcAddr:         "10.0.1.5:51000",
+		DstAddr:         "10.0.2.7:443",
+		Protocol:        "TCP",
+		Action:          actionName(0), // wire action 0 -> "deny" before #2513
+		PolicyID:        7,
+		InZone:          1,
+		OutZone:         2,
+		InZoneName:      "trust",
+		OutZoneName:     "untrust",
+		SessionPkts:     12,
+		SessionBytes:    3456,
+		RevSessionPkts:  10,
+		RevSessionBytes: 2048,
+		ElapsedTime:     42,
+		CloseReason:     "TCP FIN",
+		SessionID:       99,
+		PolicyName:      "allow-web",
+		AppName:         "junos-https",
+		IngressIface:    "ge-0-0-0",
+	}
+}
+
+// TestStandardSessionCloseOmitsAction is the #2513 golden test for the plain
+// RT_FLOW SESSION_CLOSE line. A session close is not a forwarding decision, so
+// the standard formatter must NOT render the wire action byte (which is 0 and
+// decodes to "deny"). Reverting the formatter change reintroduces "action=deny"
+// here and turns this test red (fail-on-revert).
+func TestStandardSessionCloseOmitsAction(t *testing.T) {
+	rec := sessionCloseRecord()
+
+	// Guard: confirm the input record really does carry the misleading value,
+	// so this test would actually catch a regression in the formatter.
+	if rec.Action != "deny" {
+		t.Fatalf("precondition: wire action 0 should map to %q, got %q",
+			"deny", rec.Action)
+	}
+
+	got := formatSyslogMsg(rec)
+
+	const want = "RT_FLOW SESSION_CLOSE src=10.0.1.5:51000 dst=10.0.2.7:443 " +
+		"proto=TCP policy=7 zone=trust->untrust pkts=12 bytes=3456"
+	if got != want {
+		t.Errorf("standard SESSION_CLOSE line mismatch:\n got: %s\nwant: %s", got, want)
+	}
+
+	if strings.Contains(got, "action=") {
+		t.Errorf("standard SESSION_CLOSE line must omit action= (close is not a "+
+			"deny decision, #2513); got: %s", got)
+	}
+	if strings.Contains(got, "deny") {
+		t.Errorf("standard SESSION_CLOSE line must not contain \"deny\" (#2513); got: %s", got)
+	}
+}
+
+// TestStructuredSessionCloseUnchanged pins the structured RT_FLOW_SESSION_CLOSE
+// line: it already omits action and carries a close reason instead. This guards
+// against the #2513 fix accidentally altering the structured output.
+func TestStructuredSessionCloseUnchanged(t *testing.T) {
+	rec := sessionCloseRecord()
+
+	got := formatStructuredMsg(rec, 6) // protocol-id 6 = TCP
+
+	if strings.Contains(got, "action=") {
+		t.Errorf("structured SESSION_CLOSE line must not contain action=; got: %s", got)
+	}
+	if !strings.Contains(got, "RT_FLOW_SESSION_CLOSE") {
+		t.Errorf("structured line missing RT_FLOW_SESSION_CLOSE tag; got: %s", got)
+	}
+	if !strings.Contains(got, `reason="TCP FIN"`) {
+		t.Errorf("structured SESSION_CLOSE line must carry the close reason; got: %s", got)
+	}
+	// Spot-check the rest of the contract is intact (tuple, zones, counters).
+	for _, want := range []string{
+		`source-address="10.0.1.5" source-port="51000"`,
+		`destination-address="10.0.2.7" destination-port="443"`,
+		`protocol-id="6"`,
+		`policy-name="allow-web"`,
+		`source-zone-name="trust" destination-zone-name="untrust"`,
+		`packets-from-client="12" bytes-from-client="3456"`,
+		`packets-from-server="10" bytes-from-server="2048"`,
+		`elapsed-time="42"`,
+		`application="junos-https"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("structured SESSION_CLOSE line missing %q; got: %s", want, got)
+		}
+	}
+}
+
+// TestStandardNonCloseStillRendersAction confirms the #2513 change is keyed on
+// event type == SESSION_CLOSE, not on action == 0 globally: a POLICY_DENY (the
+// genuine deny path) still renders action=deny in the standard formatter.
+func TestStandardNonCloseStillRendersAction(t *testing.T) {
+	rec := EventRecord{
+		Type:        "POLICY_DENY",
+		SrcAddr:     "10.0.1.5:51000",
+		DstAddr:     "10.0.2.7:443",
+		Protocol:    "TCP",
+		Action:      actionName(actionDeny),
+		PolicyID:    7,
+		InZoneName:  "trust",
+		OutZoneName: "untrust",
+	}
+	got := formatSyslogMsg(rec)
+	if !strings.Contains(got, "action=deny") {
+		t.Errorf("POLICY_DENY standard line must still render action=deny; got: %s", got)
+	}
+}

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -503,12 +503,13 @@ impl EventFrame {
         // [52] event type, [53] protocol, [54] action, [55] address family.
         buf[base + 52] = RT_FLOW_EVENT_SESSION_CLOSE;
         buf[base + 53] = protocol;
-        // [54] action: the Go decoder DOES map this byte to
-        // EventRecord.Action (and logs it for SESSION_CLOSE), but a session
-        // close has no permit/deny/reject action semantics, so it is
-        // intentionally 0. The flow exporters do not branch on it for a
-        // close; only the syslog/event line carries it (as "deny", the 0
-        // encoding) — harmless for a close record.
+        // [54] action: a session close has no permit/deny/reject action
+        // semantics, so this byte is intentionally 0. The Go decoder maps it
+        // into EventRecord.Action, but the flow exporters do not branch on it
+        // for a close, and as of #2513 the syslog/event renderers omit action
+        // for SESSION_CLOSE entirely (the standard line dropped its `action=`
+        // field; the structured line never carried one). Do NOT rely on the 0
+        // rendering as a value — both close formatters skip it.
         buf[base + 54] = 0;
         buf[base + 55] = wire_af;
         // [56:64] session_packets, [64:72] session_bytes — 0 (#2501).


### PR DESCRIPTION
Closes #2513 (codex review-036 finding 9, LOW — operator clarity).

## Defect
Standard (plain) `SESSION_CLOSE` RT_FLOW log lines rendered `action=deny`. A session close is not a deny decision; this misleads incident response into reading ordinary session termination as a drop.

Chain: userspace-dp writes the wire action byte as `0` for a close (`encode_session_close_rt_flow`); Go's `actionName` maps `0` -> `"deny"` (`actionDeny = 0`); the standard formatter (`formatSyslogMsg`, `pkg/logging/ringbuf.go`) printed `action=%s` with that value. The structured `RT_FLOW_SESSION_CLOSE` line already omits action, so only the standard/plain line was affected.

## Fix and the omit-vs-placeholder decision
**Omit `action` entirely** from the standard SESSION_CLOSE branch (no placeholder).

Rationale: Junos `RT_FLOW_SESSION_CLOSE` lines carry a close **reason** ("TCP FIN", "idle Timeout", "response received"), not an action — a close is a termination event, not a forwarding decision. The structured formatter already omits action and reports `reason="..."`. Omitting (rather than mapping `0`->`close`/`none`) makes the standard line agree with the structured line: neither implies a forwarding decision for a close. The standard line is a `key=value` log, not a fixed-column contract, so dropping one field needs no placeholder. The standard line keeps `proto`/`policy`/`zone`/`pkts`/`bytes` that operators read here.

## Scope (event-type keyed, NOT action==0 global)
The change is keyed on `rec.Type == "SESSION_CLOSE"` in `formatSyslogMsg`. POLICY_DENY, SCREEN_DROP, and FILTER_LOG (the genuine deny/reject paths) still render `action=`. SESSION_OPEN carries wire action `1` (permit) and is unaffected. No other event type legitimately carries action byte `0` through this branch — only the close path writes `0`, and only the close branch was changed. `TestStandardNonCloseStillRendersAction` pins that POLICY_DENY still shows `action=deny`.

## Wire format unchanged
The on-wire action byte and the `actionName` mapping are NOT changed (wire format is a contract). The only Rust edit is a comment correction in `codec.rs` — the prior comment called the `0`->"deny" rendering "harmless"; it now records that both close formatters omit action.

## Tests (golden, fail-on-revert)
New `pkg/logging/session_close_format_test.go`:
- `TestStandardSessionCloseOmitsAction` — asserts the standard line no longer contains `action=`/`deny` and matches the exact expected string.
- `TestStructuredSessionCloseUnchanged` — asserts the structured line has no `action=` and still carries `reason="TCP FIN"` plus the tuple/zone/counter contract.
- `TestStandardNonCloseStillRendersAction` — POLICY_DENY still renders `action=deny` (proves event-type scoping).

**Fail-on-revert proven:** restoring `action=%s`/`rec.Action` to the close branch makes `TestStandardSessionCloseOmitsAction` red (line shows `action=deny` again).

## Validation
- `go test ./pkg/logging/...` PASS; gofmt clean.
- `cargo test --release --bin xpf-userspace-dp event_stream::codec` 17/17 PASS (comment-only Rust change).
- Docs: `pkg/logging/README.md` gotcha for the SESSION_CLOSE line format; `_Log.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi