### PR TITLE
dhcprelay: forward DHCPNAK server responses to clients

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,39 @@
 # Action Log
 
+## 2026-06-24 — #2606 fix: DHCP relay silently dropped DHCPNAK server responses
+
+- **Timestamp**: 2026-06-24
+- **Action**: #2606 (agy review-041 finding 041-06) — `handleServerResponses`
+  in pkg/dhcprelay/relay.go accepted only `DHCPOFFER`/`DHCPACK` server replies
+  and `continue`'d on everything else, silently dropping `DHCPNAK`. Per RFC
+  2131 §4.3.2 a server sends NAK to reject a client REQUEST; the client must
+  receive it to abandon negotiation and restart with DISCOVER. Dropping it at
+  the relay made clients hang until their retransmission timeout. FIX: (1)
+  added `dhcpv4.MessageTypeNak` to the accepted server-response set (switch
+  over msgType). (2) Added a NAK-first branch in `deliverReply` that FORCE-
+  broadcasts the NAK to 255.255.255.255:68 ahead of the #2076 destination
+  matrix. Rationale: a NAK carries no binding (yiaddr==0) so there is no
+  address to raw-L2/UDP unicast to, and force-broadcasting prevents a server
+  that erroneously echoes a stale ciaddr from steering the matrix into a UDP
+  unicast to an address the client does not own. New counter
+  `RepliesBroadcastNak` (atomic + RelayStats field + `show ... dhcp-relay`
+  column in pkg/cli/cli_show_services.go) records the NAK-broadcast reason.
+  giaddr/xid/chaddr handling is unchanged (the existing reply path zeroes
+  giaddr for the last hop and copies the rest verbatim). Tests:
+  TestDeliverReply_Nak_AlwaysBroadcast (flag-clear, flag-set, and stale-ciaddr
+  defense-in-depth cases — all broadcast, never L2, never ciaddr-unicast) and
+  TestHandleServerResponses_NakForwarded (end-to-end: a NAK fed through the
+  server conn IS written to the client conn at broadcast). Validation: gofmt
+  -w clean, go vet ./pkg/dhcprelay/... clean (pre-existing cli.go:441
+  unreachable-code vet note is unrelated), go test ./pkg/dhcprelay/...
+  ./pkg/cli/... PASS. Fail-on-revert PROVEN: removing MessageTypeNak from the
+  accepted set makes TestHandleServerResponses_NakForwarded red (0 writes,
+  want 1). Live relay verify is lab-bound; the unit tests are the gate. Doc:
+  pkg/dhcprelay/README.md (relayed-types table + reply matrix + NAK section +
+  counter list).
+- **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/delivery_test.go,
+  pkg/cli/cli_show_services.go, pkg/dhcprelay/README.md, _Log.md
+
 ## 2026-06-24 — #2593 fix: SESSION_OPEN standard RT_FLOW line rendered `action=deny`
 
 - **Timestamp**: 2026-06-24

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -326,14 +326,15 @@ func (c *CLI) showDHCPRelay() error {
 			// alert on: it means the raw-L2 path failed (CAP_NET_RAW,
 			// driver, or MTU) and the relay degraded to broadcast.
 			fmt.Println("\nReply delivery (#2076):")
-			fmt.Printf("  %-16s %-10s %-10s %-10s %-10s %-10s %s\n",
+			fmt.Printf("  %-16s %-10s %-10s %-10s %-10s %-10s %-12s %s\n",
 				"Interface", "L2-unicast", "ciaddr", "bcast-flag", "bcast-fwd",
-				"no-target", "L2-fallback")
+				"no-target", "L2-fallback", "nak-bcast")
 			for _, s := range stats {
-				fmt.Printf("  %-16s %-10d %-10d %-10d %-10d %-10d %d\n",
+				fmt.Printf("  %-16s %-10d %-10d %-10d %-10d %-10d %-12d %d\n",
 					s.Interface, s.RepliesL2Unicast, s.RepliesUnicastCiaddr,
 					s.RepliesBroadcastFlag1, s.RepliesBroadcastForced,
-					s.RepliesBroadcastNoTarget, s.RepliesBroadcastL2Fallback)
+					s.RepliesBroadcastNoTarget, s.RepliesBroadcastL2Fallback,
+					s.RepliesBroadcastNak)
 			}
 		}
 	}

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -38,7 +38,7 @@ carries server-bound options, per RFC 2131 §3.4:
 | `INFORM` | yes (#2153) | client already holds an address, asks only for supplemental parameters (DNS/domain/NTP) |
 | `DECLINE` | no | broadcast by the client on address conflict (RFC 2131 §4.4); not relayed (out of scope for #2153) |
 | `RELEASE` | no | unicast by the client to its bound server; no relay-agent obligation |
-| server reply types (`OFFER`/`ACK`/`NAK`) | n/a | not client-originated; the client→server gate never sees them. The reverse server→client path (`handleServerResponses`) forwards `OFFER` and `ACK` only — see the reply matrix below |
+| server reply types (`OFFER`/`ACK`/`NAK`) | n/a | not client-originated; the client→server gate never sees them. The reverse server→client path (`handleServerResponses`) forwards `OFFER`, `ACK`, and `NAK` (#2606) — see the reply matrix below |
 
 The `INFORM` reply (a server-issued `ACK` with no `yiaddr` but a real
 `ciaddr`) is delivered by the matrix below via the "flag clear, `yiaddr==0`,
@@ -47,17 +47,29 @@ its address.
 
 ## Reply delivery model (#2076)
 
-Server replies (OFFER/ACK) are delivered to clients honoring the RFC 2131
+Server replies (OFFER/ACK/NAK) are delivered to clients honoring the RFC 2131
 §4.1 broadcast flag:
 
 | Condition | Delivery |
 |-----------|----------|
+| message type `DHCPNAK` (#2606) | **always broadcast** `255.255.255.255:68` (RFC 2131 §4.3.2; checked first, ignores the flag/yiaddr/ciaddr) |
 | `overrides always-broadcast` set | broadcast `255.255.255.255:68` (operator override wins) |
 | broadcast flag **set** | broadcast `255.255.255.255:68` |
 | flag **clear**, real `yiaddr` | **raw-L2 unicast** to `chaddr` + `yiaddr` |
 | flag **clear**, `yiaddr==0`, real `ciaddr` | UDP-unicast to `ciaddr` (client already owns the IP) |
 | flag **clear**, no `yiaddr`/`ciaddr` | broadcast (nothing routable) |
 | raw-L2 path unavailable/fails | broadcast fallback (always works) |
+
+**DHCPNAK (#2606).** A server sends `DHCPNAK` to reject a client's `REQUEST`
+(e.g. the requested address is already leased, or the client moved subnets).
+On receiving it the client immediately abandons negotiation and restarts with
+a fresh `DISCOVER`. Before #2606 `handleServerResponses` accepted only
+`OFFER`/`ACK`, so NAKs were silently dropped and clients hung until their
+retransmission timeout. The NAK is now forwarded, and it is **force-broadcast**
+ahead of the matrix above: a NAK carries no binding (`yiaddr==0`), the client
+has no usable address, and broadcasting also prevents a server that
+erroneously echoes a stale `ciaddr` from steering the NAK into a UDP unicast to
+an address the client does not own.
 
 **Why raw L2 (`l2send_linux.go`).** A client in SELECTING/REQUESTING that
 clears the broadcast flag has **not yet configured** the offered address,
@@ -88,7 +100,7 @@ RFC 768).
 - **Counters.** `Stats()` exposes a per-reason breakdown
   (`RepliesL2Unicast`, `RepliesUnicastCiaddr`, `RepliesBroadcastFlag1`,
   `RepliesBroadcastForced`, `RepliesBroadcastNoTarget`,
-  `RepliesBroadcastL2Fallback`). **`RepliesBroadcastL2Fallback` is the one
+  `RepliesBroadcastL2Fallback`, `RepliesBroadcastNak`). **`RepliesBroadcastL2Fallback` is the one
   to alert on** — it means the raw-L2 path failed (CAP_NET_RAW, driver, or
   MTU) and the relay degraded to broadcast. `show ... dhcp-relay` prints
   this breakdown.

--- a/pkg/dhcprelay/delivery_test.go
+++ b/pkg/dhcprelay/delivery_test.go
@@ -363,6 +363,143 @@ func TestDeliverReply_ExactlyOneSend_NoDoubleDeliver(t *testing.T) {
 	}
 }
 
+// newNak builds a BOOTREPLY DHCPNAK. Per RFC 2131 a NAK carries no binding,
+// so yiaddr/ciaddr are zero; broadcast controls whether the client set the
+// flag. A stale ciaddr is accepted to exercise the force-broadcast guard.
+func newNak(t *testing.T, broadcast bool, ciaddr net.IP, chaddr net.HardwareAddr) *dhcpv4.DHCPv4 {
+	t.Helper()
+	pkt, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	pkt.OpCode = dhcpv4.OpcodeBootReply
+	pkt.HWType = iana.HWTypeEthernet
+	pkt.ClientHWAddr = chaddr
+	pkt.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeNak))
+	if broadcast {
+		pkt.SetBroadcast()
+	}
+	pkt.YourIPAddr = net.IPv4zero
+	if ciaddr != nil {
+		pkt.ClientIPAddr = ciaddr
+	} else {
+		pkt.ClientIPAddr = net.IPv4zero
+	}
+	return pkt
+}
+
+// TestDeliverReply_Nak_AlwaysBroadcast proves a DHCPNAK is force-broadcast to
+// the client (RFC 2131 §4.3.2) regardless of the broadcast flag, never
+// unicast — even when the server erroneously echoes a stale ciaddr that would
+// otherwise drive the matrix to a UDP unicast. It must also never take the
+// raw-L2 path (yiaddr is zero, so there is no address to unicast to).
+func TestDeliverReply_Nak_AlwaysBroadcast(t *testing.T) {
+	cases := []struct {
+		name      string
+		broadcast bool
+		ciaddr    net.IP
+	}{
+		{"flag_clear_no_ciaddr", false, nil},
+		{"flag_set_no_ciaddr", true, nil},
+		// Defense-in-depth: a NAK MUST NOT be unicast even if the server
+		// (incorrectly) leaves a stale ciaddr in the reply.
+		{"flag_clear_stale_ciaddr", false, testCiaddr},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+			client := newFakeConn()
+			defer client.Close()
+			fl2 := &fakeL2{}
+
+			pkt := newNak(t, tc.broadcast, tc.ciaddr, testChaddr)
+			if !deliverReply(ir, client, fl2, testGiaddr, pkt, pkt.ToBytes()) {
+				t.Fatal("deliverReply returned false (NAK not delivered)")
+			}
+
+			if fl2.callCount() != 0 {
+				t.Errorf("NAK must NOT use raw-L2 unicast, got %d calls", fl2.callCount())
+			}
+			if ir.repliesBroadcastNak.Load() != 1 {
+				t.Errorf("repliesBroadcastNak = %d, want 1", ir.repliesBroadcastNak.Load())
+			}
+			if ir.repliesUnicastCiaddr.Load() != 0 {
+				t.Errorf("NAK must NOT unicast to ciaddr, got %d", ir.repliesUnicastCiaddr.Load())
+			}
+
+			client.mu.Lock()
+			writes := append([]fakeWrite(nil), client.writes...)
+			client.mu.Unlock()
+			if len(writes) != 1 {
+				t.Fatalf("expected 1 client UDP write, got %d", len(writes))
+			}
+			got := writes[0].addr.(*net.UDPAddr)
+			if !got.IP.Equal(net.IPv4bcast) || got.Port != clientPort {
+				t.Errorf("NAK dst = %v, want broadcast %v:%d", got, net.IPv4bcast, clientPort)
+			}
+		})
+	}
+}
+
+// TestHandleServerResponses_NakForwarded is the fail-on-revert gate for #2606:
+// a DHCPNAK server reply MUST be forwarded to the client (broadcast), not
+// silently dropped. Removing dhcpv4.MessageTypeNak from the accepted set in
+// handleServerResponses makes this test red (the NAK is never written to the
+// client conn).
+func TestHandleServerResponses_NakForwarded(t *testing.T) {
+	nak := newNak(t, false, nil, testChaddr)
+	nak.GatewayIPAddr = testGiaddr // server echoes giaddr; relay must zero it
+	serverConn := newFakeConn()
+	serverConn.mu.Lock()
+	serverConn.pending = [][]byte{nak.ToBytes()}
+	serverConn.mu.Unlock()
+	clientConn := newFakeConn()
+	defer clientConn.Close()
+	fl2 := &fakeL2{}
+	ir := &interfaceRelay{ifaceName: "ge-0-0-0"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		handleServerResponses(ctx, serverConn, clientConn, ir, fl2, testGiaddr)
+		close(done)
+	}()
+
+	// Wait for the client-direction write (the NAK must reach the client).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		clientConn.mu.Lock()
+		n := len(clientConn.writes)
+		clientConn.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	clientConn.mu.Lock()
+	writes := append([]fakeWrite(nil), clientConn.writes...)
+	clientConn.mu.Unlock()
+	if len(writes) != 1 {
+		t.Fatalf("DHCPNAK not forwarded to client: got %d writes, want 1", len(writes))
+	}
+	dst := writes[0].addr.(*net.UDPAddr)
+	if !dst.IP.Equal(net.IPv4bcast) || dst.Port != clientPort {
+		t.Errorf("NAK forwarded to %v, want broadcast %v:%d", dst, net.IPv4bcast, clientPort)
+	}
+	if fl2.callCount() != 0 {
+		t.Errorf("NAK must not use raw-L2, got %d calls", fl2.callCount())
+	}
+	if ir.repliesForwarded.Load() != 1 {
+		t.Errorf("repliesForwarded = %d, want 1", ir.repliesForwarded.Load())
+	}
+
+	cancel()
+	serverConn.Close()
+	<-done
+}
+
 // TestHandleServerResponses_L2SourceIsSavedGiaddr proves the end-to-end path:
 // handleServerResponses zeroes pkt.GatewayIPAddr before sending, yet the L2
 // frame's source IP is the SAVED giaddr passed by runRelay (#2076 §7.2 / SMR-F4)

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -72,6 +72,7 @@ type RelayStats struct {
 	RepliesBroadcastForced     uint64 // overrides always-broadcast
 	RepliesBroadcastNoTarget   uint64 // no routable target (yiaddr==0,ciaddr==0)
 	RepliesBroadcastL2Fallback uint64 // raw-L2 path failed → degraded
+	RepliesBroadcastNak        uint64 // DHCPNAK force-broadcast (RFC 2131 §4.3.2)
 }
 
 // l2Replier is the raw-L2 unicast seam. *l2Sender implements it in production;
@@ -135,6 +136,7 @@ type interfaceRelay struct {
 	repliesBroadcastForced     atomic.Uint64
 	repliesBroadcastNoTarget   atomic.Uint64
 	repliesBroadcastL2Fallback atomic.Uint64
+	repliesBroadcastNak        atomic.Uint64
 }
 
 // packetConnFactory creates a UDP packet connection with the relay's required
@@ -487,6 +489,7 @@ func (m *Manager) Stats() []RelayStats {
 			RepliesBroadcastForced:     ir.repliesBroadcastForced.Load(),
 			RepliesBroadcastNoTarget:   ir.repliesBroadcastNoTarget.Load(),
 			RepliesBroadcastL2Fallback: ir.repliesBroadcastL2Fallback.Load(),
+			RepliesBroadcastNak:        ir.repliesBroadcastNak.Load(),
 		})
 	}
 	return stats
@@ -895,7 +898,13 @@ func handleServerResponses(ctx context.Context, serverConn, clientConn net.Packe
 		}
 
 		msgType := pkt.MessageType()
-		if msgType != dhcpv4.MessageTypeOffer && msgType != dhcpv4.MessageTypeAck {
+		switch msgType {
+		case dhcpv4.MessageTypeOffer, dhcpv4.MessageTypeAck, dhcpv4.MessageTypeNak:
+			// Forward to the client. NAK rejects the client's request
+			// (RFC 2131 §4.3.2); dropping it makes the client hang until
+			// its retransmission timeout instead of restarting with a
+			// fresh DISCOVER.
+		default:
 			continue
 		}
 
@@ -931,6 +940,17 @@ func deliverReply(ir *interfaceRelay, clientConn net.PacketConn, l2 l2Replier,
 	ciaddrReal := ciaddr != nil && !ciaddr.Equal(net.IPv4zero)
 
 	switch {
+	case pkt.MessageType() == dhcpv4.MessageTypeNak:
+		// A DHCPNAK rejects the client's request: it carries no binding,
+		// so yiaddr (and ciaddr) are zero and the client has no usable
+		// address. RFC 2131 §4.3.2 requires the relay to broadcast the
+		// NAK on the client's subnet regardless of the broadcast flag.
+		// Force broadcast here so a server that erroneously echoes a
+		// stale ciaddr cannot trick the matrix into a unicast to an
+		// address the client does not own.
+		ir.repliesBroadcastNak.Add(1)
+		return broadcastReply(ir, clientConn, replyData)
+
 	case ir.alwaysBroadcast:
 		ir.repliesBroadcastForced.Add(1)
 		return broadcastReply(ir, clientConn, replyData)


### PR DESCRIPTION
Closes #2606 (agy review-041 finding 041-06).

## Problem
`handleServerResponses` (pkg/dhcprelay/relay.go) accepted only `DHCPOFFER`
and `DHCPACK` server replies and `continue`'d on everything else, silently
dropping `DHCPNAK`. Per RFC 2131 §4.3.2 a server sends DHCPNAK to reject a
client's REQUEST (requested address already leased, off-subnet after a
network move, etc.); on receiving it the client immediately abandons lease
negotiation and restarts with a fresh DISCOVER. Dropping the NAK at the relay
leaves the client hung until its retransmission timeout — the standard DHCP
rejection path is broken behind the relay.

## Fix
- Add `dhcpv4.MessageTypeNak` to the accepted server-response set in
  `handleServerResponses`.
- Deliver the NAK via a dedicated **force-broadcast** branch placed ahead of
  the #2076 reply-destination matrix.

### NAK destination decision: always broadcast (not the existing matrix path)
A DHCPNAK carries no binding, so `yiaddr == 0`. The #2076 matrix would
otherwise fall through to "no yiaddr/ciaddr → broadcast" in the normal case,
which is already correct — but adding to the set alone was NOT sufficient to
be safe: a server that erroneously echoes a stale `ciaddr` in the NAK would
hit the "flag clear, yiaddr==0, real ciaddr → UDP-unicast to ciaddr" row and
send the NAK to an address the client does not own. So a NAK-first branch that
unconditionally broadcasts to `255.255.255.255:68` is added, matching
RFC 2131 §4.3.2 (broadcast on the client's subnet regardless of the broadcast
flag). This also guarantees the NAK never takes the raw-L2 unicast path (there
is no yiaddr to address the frame to). giaddr/xid/chaddr handling is unchanged:
the existing reply path zeroes giaddr for the last hop and copies the rest
verbatim.

A `RepliesBroadcastNak` counter (atomic + `RelayStats` field +
`show ... dhcp-relay` column) records the NAK-broadcast reason alongside the
other reply-delivery reasons.

## Validation
- `go test ./pkg/dhcprelay/... ./pkg/cli/...` — PASS; gofmt + go vet clean
  (the pre-existing `cli.go:441` unreachable-code vet note is unrelated).
- `TestDeliverReply_Nak_AlwaysBroadcast` — flag-clear, flag-set, and
  stale-ciaddr defense-in-depth cases: all broadcast, never L2, never
  ciaddr-unicast.
- **Fail-on-revert**: `TestHandleServerResponses_NakForwarded` feeds a NAK
  through the server conn and asserts it is written to the client conn at
  broadcast. Removing `MessageTypeNak` from the accepted set makes it red
  (0 writes, want 1) — verified by temp-revert.
- Live relay verification (real DHCP server issuing a NAK behind the relay) is
  lab-bound; the unit tests are the gate.

Doc: pkg/dhcprelay/README.md updated (relayed-types table, reply matrix, NAK
section, counter list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi