### PR TITLE
snmp: enforce SNMPv3 USM timeliness window + persist engineBoots (#2610)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,32 @@
 # Action Log
 
+## 2026-06-24 — #2610 fix: SNMPv3 USM timeliness/replay protection + engineBoots persistence
+
+- **Timestamp**: 2026-06-24
+- **Action**: #2610 (codex review-041 finding 041-07) — SNMPv3 authenticated
+  requests were accepted on HMAC validation alone; the RFC 3414 §3.2 USM
+  timeliness window was never enforced, so an on-path attacker could replay a
+  captured authenticated PDU. Additionally `engineBoots` reset to 1 every
+  daemon start and `engineTime` was raw process uptime, breaking strict
+  managers and aiding cross-restart replay. FIX: (1) `checkTimeliness` in
+  pkg/snmp/agent.go enforces §3.2 step 7 as the authoritative engine — reject
+  if our boots == 2^31-1, or req boots != our boots, or |our time - req time|
+  > 150s; called after `verifyAuth` in handleV3Packet (pkg/snmp/v3.go). A
+  rejected request gets an authenticated `usmStatsNotInTimeWindows`
+  (1.3.6.1.6.3.15.1.1.2.0) Report PDU carrying our current boots/time so a
+  manager can resync (`buildV3TimelinessReport`). (2) engineBoots is now
+  loaded/incremented/persisted at agent construction to
+  /var/lib/xpf/snmp-engineboots via fsatomic.WriteFileDurable
+  (`loadAndIncrementEngineBoots`); first boot = 1, each restart increments;
+  corrupt/ceiling resets to 1. Path injectable via `NewAgentWithBootsPath`
+  (test seam). Discovery handshake (empty userName →
+  usmStatsUnknownEngineIDs) unchanged. Tests: replay (stale/future/wrong-boots)
+  rejected, in-window/boundary accepted, boots 1→2→3 across simulated restart,
+  first-boot/corrupt handling, discovery still works. fail-on-revert verified
+  (disabling the check turns all replay tests into served responses).
+- **File(s)**: pkg/snmp/agent.go, pkg/snmp/v3.go, pkg/snmp/v3_timeliness_test.go,
+  pkg/snmp/README.md, _Log.md
+
 ## 2026-06-24 — #2606 fix: DHCP relay silently dropped DHCPNAK server responses
 
 - **Timestamp**: 2026-06-24

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -23,6 +23,50 @@ struct; SET requests (`pduSetRequest`, 0xa3) are gated on it:
 SNMPv3 SET requests are uniformly refused with `notWritable` (the USM users
 in this config carry no read-write authorization).
 
+## SNMPv3 USM timeliness and replay protection (RFC 3414 §3.2)
+
+Authenticating a request proves the sender holds the user's key; it does
+**not** prove the message is fresh. Without a timeliness check an on-path
+attacker can replay a captured authenticated PDU verbatim. The agent enforces
+the RFC 3414 §3.2 timeliness window as the authoritative engine:
+
+- After `verifyAuth` succeeds, `checkTimeliness(reqBoots, reqTime)` compares the
+  request's `msgAuthoritativeEngineBoots`/`msgAuthoritativeEngineTime` against
+  the agent's own `engineBoots`/`engineTime()`. A request is in the window only
+  when our boots counter is below the RFC ceiling (`2147483647`), the request's
+  boots equals ours, and the request's time is within ±150 seconds of ours.
+- A request outside the window gets an **authenticated** Report PDU carrying
+  `usmStatsNotInTimeWindows` (`1.3.6.1.6.3.15.1.1.2.0`) plus the agent's current
+  boots/time, never a data response. A manager whose cached boots/time drifted
+  (the legitimate case, e.g. after our restart bumped boots) reads the report
+  and resynchronizes; a replay simply gets nothing useful.
+- The engineID discovery handshake (empty `userName` →
+  `usmStatsUnknownEngineIDs`, `1.3.6.1.6.3.15.1.1.4.0`) is unaffected: a manager
+  still learns our engineID and current boots/time before its first
+  authenticated request, so a freshly-discovered, timely request is accepted.
+
+### engineBoots persistence
+
+`engineBoots` is loaded, incremented, and persisted once at agent construction
+so `(engineBoots, engineTime)` is monotonic across daemon restarts, as RFC 3414
+requires of an authoritative engine:
+
+- State file: `/var/lib/xpf/snmp-engineboots` (a single decimal integer). The
+  path is injectable via `NewAgentWithBootsPath` — the test seam used to assert
+  the load/increment/persist cycle without touching real state.
+- First boot (file missing): `engineBoots` starts at `1` and the file is
+  created. Each subsequent start reads the prior value, increments it, and
+  persists the new value (1 → 2 → 3 …). `engineTime()` then counts from *this*
+  boot (`startTime`), so the pair advances monotonically.
+- A corrupt/unreadable counter or a value at the RFC ceiling restarts the count
+  at `1` rather than wedging the agent — the timeliness check is the replay
+  backstop, so a lost counter degrades resynchronization, not security. A write
+  failure is logged and ignored; the agent serves with the in-memory boots for
+  this run and only cross-restart monotonicity is lost until the next write.
+- The persist uses `fsatomic.WriteFileDurable` (fsync-on-write); the directory
+  is created with `fsatomic.MkdirAllDurable`. This is slow-path (once per start),
+  so per-write durability is affordable.
+
 ## Live reconfigure (commit-time reconcile)
 
 The agent is created once at daemon startup and keeps serving on UDP/161.

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -7,10 +7,14 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/fsatomic"
 )
 
 // SNMP v2c PDU types.
@@ -43,7 +47,28 @@ const (
 	snmpVersion2c = 1 // version field: 0 = v1, 1 = v2c
 
 	maxPacketSize = 4096
+
+	// usmTimeWindow is the RFC 3414 §3.2 timeliness window in seconds: an
+	// authenticated request whose msgAuthoritativeEngineTime differs from
+	// the authoritative engine's own time by more than this is rejected as
+	// outside the time window (and is therefore not replayable beyond it).
+	usmTimeWindow = 150
+
+	// engineBootsMax is the RFC 3414 ceiling for msgAuthoritativeEngineBoots
+	// (2^31 - 1). When our boots counter reaches it, the engine ID must be
+	// reconfigured; until then every authenticated request is rejected as
+	// not-in-time-window per §3.2.
+	engineBootsMax = 2147483647
 )
+
+// defaultEngineBootsPath is the on-disk location of the persisted SNMPv3
+// engineBoots counter. It is loaded and incremented once at agent
+// construction so (engineBoots, engineTime) is monotonic across daemon
+// restarts per RFC 3414 — a manager that caches our authoritative boots/time
+// keeps working over a restart, and a request captured before a restart no
+// longer validates (the boots value advanced). /var/lib/xpf is the persistent
+// runtime-state root shared with the other xpf subsystems.
+const defaultEngineBootsPath = "/var/lib/xpf/snmp-engineboots"
 
 // tagCounter32 is the ASN.1 application tag for Counter32.
 const tagCounter32 = 0x41
@@ -132,6 +157,12 @@ type Agent struct {
 	engineBoots int    // SNMPv3 engine boots counter (immutable after initEngine)
 	lastPacket  []byte // raw packet for v3 auth verification
 
+	// engineBootsPath is the persistence seam for the engineBoots counter
+	// (RFC 3414 monotonicity across restarts). Empty means the default
+	// path; tests inject a temp file to assert the load/increment/persist
+	// cycle. Set before initEngine runs (NewAgent / NewAgentWithBootsPath).
+	engineBootsPath string
+
 	// cfgMu guards the live authorization/identity configuration (cfg) and
 	// the derived USM user table (v3Users). The request-serving goroutine
 	// reads both under RLock; UpdateConfig swaps both under Lock so a commit
@@ -144,11 +175,26 @@ type Agent struct {
 	v3Users map[string]*usmUser // SNMPv3 USM users (keyed by name)
 }
 
-// NewAgent creates a new SNMP agent with the given configuration.
+// NewAgent creates a new SNMP agent with the given configuration. The
+// SNMPv3 engineBoots counter is loaded from defaultEngineBootsPath,
+// incremented, and persisted so (engineBoots, engineTime) advances
+// monotonically across daemon restarts (RFC 3414).
 func NewAgent(cfg *config.SNMPConfig) *Agent {
+	return NewAgentWithBootsPath(cfg, defaultEngineBootsPath)
+}
+
+// NewAgentWithBootsPath is NewAgent with an explicit engineBoots persistence
+// path. It is the seam used by tests to drive the load/increment/persist
+// cycle against a temp file; production code uses NewAgent. An empty path
+// falls back to defaultEngineBootsPath.
+func NewAgentWithBootsPath(cfg *config.SNMPConfig, bootsPath string) *Agent {
+	if bootsPath == "" {
+		bootsPath = defaultEngineBootsPath
+	}
 	a := &Agent{
-		cfg:       cfg,
-		startTime: time.Now(),
+		cfg:             cfg,
+		startTime:       time.Now(),
+		engineBootsPath: bootsPath,
 	}
 	a.initEngine()
 	a.initV3Users()
@@ -209,12 +255,76 @@ func (a *Agent) initEngine() {
 	// RFC 3411 format: enterprise(4) + text(3) = 0x80 | len, enterprise OID, format byte, text.
 	// Simplified: use 0x80 0x00 0x00 0x00 0x01 (enterprise=1) + 0x04 (text) + hostname bytes.
 	a.engineID = append([]byte{0x80, 0x00, 0x01, 0x86, 0xa3, 0x04}, []byte(hostname)...)
-	a.engineBoots = 1
+	a.engineBoots = a.loadAndIncrementEngineBoots()
+}
+
+// loadAndIncrementEngineBoots reads the persisted engineBoots counter, returns
+// it incremented by one, and writes the new value back so the next start
+// advances again. On first boot (file missing) it starts at 1. engineTime then
+// counts from THIS boot (a.startTime), so (engineBoots, engineTime) is the
+// monotonically-advancing authoritative pair RFC 3414 requires for replay
+// protection across restarts.
+//
+// A read/parse failure or a value at/over the RFC ceiling restarts the count
+// at 1 rather than refusing to serve — the timeliness check (which rejects a
+// stale boots/time on its own) is the replay backstop, and a corrupt counter
+// must not wedge the agent. A write failure is logged and ignored: the agent
+// still serves with the in-memory boots for this run; only cross-restart
+// monotonicity is lost until the next successful write.
+func (a *Agent) loadAndIncrementEngineBoots() int {
+	prev := 0
+	if data, err := os.ReadFile(a.engineBootsPath); err == nil {
+		if n, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil && n > 0 && n < engineBootsMax {
+			prev = n
+		} else {
+			slog.Warn("SNMP: engineBoots state unreadable, restarting count", "path", a.engineBootsPath)
+		}
+	} else if !os.IsNotExist(err) {
+		slog.Warn("SNMP: engineBoots state read error, restarting count", "path", a.engineBootsPath, "err", err)
+	}
+
+	boots := prev + 1
+	if boots < 1 || boots >= engineBootsMax {
+		boots = 1
+	}
+
+	if err := fsatomic.MkdirAllDurable(filepath.Dir(a.engineBootsPath), 0o755); err != nil {
+		slog.Warn("SNMP: engineBoots state dir create failed", "path", a.engineBootsPath, "err", err)
+	}
+	if err := fsatomic.WriteFileDurable(a.engineBootsPath, []byte(strconv.Itoa(boots)+"\n"), 0o644); err != nil {
+		slog.Warn("SNMP: engineBoots state persist failed", "path", a.engineBootsPath, "err", err)
+	}
+	return boots
 }
 
 // engineTime returns the number of seconds since agent start.
 func (a *Agent) engineTime() int {
 	return int(time.Since(a.startTime).Seconds())
+}
+
+// checkTimeliness applies the RFC 3414 §3.2 timeliness window for the agent
+// acting as the authoritative engine. It compares an incoming authenticated
+// request's msgAuthoritativeEngineBoots/Time against the agent's own clock and
+// returns true when the request is within the window (and may be accepted).
+//
+// Per §3.2 step 7, the request is NOT in the time window if our boots counter
+// has reached the ceiling, if the request's boots differs from ours, or if the
+// request's time differs from ours by more than usmTimeWindow seconds. A
+// replayed request fails the time test once usmTimeWindow has elapsed (or fails
+// the boots test immediately after a restart bumped our boots), which is the
+// replay protection the bare HMAC check lacked.
+func (a *Agent) checkTimeliness(reqBoots, reqTime int) bool {
+	if a.engineBoots >= engineBootsMax {
+		return false
+	}
+	if reqBoots != a.engineBoots {
+		return false
+	}
+	diff := a.engineTime() - reqTime
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= usmTimeWindow
 }
 
 // SetIfDataFn sets the callback for retrieving interface data.

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -196,12 +196,12 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		slog.Debug("SNMPv3: failed to decode engineID")
 		return nil
 	}
-	_, usmRest, err = berDecodeInteger(usmRest) // engineBoots
+	reqBoots, usmRest, err := berDecodeInteger(usmRest) // engineBoots
 	if err != nil {
 		slog.Debug("SNMPv3: failed to decode engineBoots")
 		return nil
 	}
-	_, usmRest, err = berDecodeInteger(usmRest) // engineTime
+	reqTime, usmRest, err := berDecodeInteger(usmRest) // engineTime
 	if err != nil {
 		slog.Debug("SNMPv3: failed to decode engineTime")
 		return nil
@@ -246,6 +246,20 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		if !a.verifyAuth(user, authParams) {
 			slog.Debug("SNMPv3: authentication failed", "user", userName)
 			return nil
+		}
+
+		// USM timeliness window (RFC 3414 §3.2). Authentication proves the
+		// sender holds the key; the time window proves the message is fresh.
+		// Without it an on-path attacker can replay a captured authenticated
+		// PDU. As the authoritative engine we check the request's boots/time
+		// against our own clock and reply with usmStatsNotInTimeWindows on a
+		// stale/future/wrong-boots request, which also lets a manager whose
+		// cached boots/time drifted (e.g. across our restart) resynchronize.
+		if !a.checkTimeliness(reqBoots, reqTime) {
+			slog.Debug("SNMPv3: not in time window",
+				"user", userName, "req_boots", reqBoots, "req_time", reqTime,
+				"our_boots", a.engineBoots, "our_time", a.engineTime())
+			return a.buildV3TimelinessReport(msgID, msgFlags, user)
 		}
 	}
 
@@ -770,6 +784,79 @@ func (a *Agent) buildV3Discovery(msgID int) []byte {
 	msgBody = append(msgBody, usmOctet...)
 	msgBody = append(msgBody, scopedPDU...)
 	return berEncodeTLV(tagSequence, msgBody)
+}
+
+// usmStatsNotInTimeWindows is the RFC 3414 §3.2 / §5 report OID
+// (1.3.6.1.6.3.15.1.1.2.0) the authoritative engine returns when an
+// authenticated request falls outside the timeliness window.
+var usmStatsNotInTimeWindows = []int{1, 3, 6, 1, 6, 3, 15, 1, 1, 2, 0}
+
+// buildV3TimelinessReport builds an authenticated Report PDU carrying
+// usmStatsNotInTimeWindows and the agent's CURRENT engineBoots/engineTime, so a
+// manager whose cached authoritative boots/time is stale (the legitimate
+// not-in-time-window case, e.g. after our restart bumped engineBoots) can
+// resynchronize and retry. The report is authenticated (RFC 3414 §3.2 requires
+// the not-in-time-window report be sent at the request's security level) but
+// never encrypted — it carries no MIB data. A replayed request gets this report
+// instead of a data response, so the replay yields nothing useful.
+func (a *Agent) buildV3TimelinessReport(msgID int, reqFlags byte, user *usmUser) []byte {
+	reportPDU := a.buildReportPDU(usmStatsNotInTimeWindows)
+
+	scopedBody := berEncodeTLV(tagOctetString, a.engineID)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...) // contextName
+	scopedBody = append(scopedBody, reportPDU...)
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	// Reports are sent authNoPriv (no encryption) regardless of the request's
+	// priv flag — they carry no sensitive MIB data.
+	respFlags := reqFlags & msgFlagAuth
+
+	truncLen := authTruncLen(user.authProto)
+	var authPlaceholder []byte
+	if respFlags&msgFlagAuth != 0 && user.authKey != nil {
+		authPlaceholder = make([]byte, truncLen)
+	}
+
+	usmFields := berEncodeTLV(tagOctetString, a.engineID)
+	usmFields = append(usmFields, berEncodeIntegerTLV(a.engineBoots)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(a.engineTime())...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte(user.name))...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, authPlaceholder)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // privParams
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(msgID)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{respFlags | msgFlagReport})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	wholeMsg := berEncodeTLV(tagSequence, msgBody)
+
+	if respFlags&msgFlagAuth != 0 && user.authKey != nil {
+		if authMAC := computeAuth(user, wholeMsg); authMAC != nil {
+			insertAuthMAC(wholeMsg, authMAC, truncLen)
+		}
+	}
+	return wholeMsg
+}
+
+// buildReportPDU encodes a Report PDU (tag 0xa8) with a single varbind whose
+// OID is the supplied usmStats counter and whose value is Counter32(0). The
+// varbind value is informational — the OID identifies the error to the manager.
+func (a *Agent) buildReportPDU(statsOID []int) []byte {
+	vb := berEncodeTLV(tagObjectIdentifier, berEncodeOID(statsOID))
+	vb = append(vb, berEncodeTLV(tagCounter32, berEncodeCounter32(0))...)
+	vbList := berEncodeTLV(tagSequence, berEncodeTLV(tagSequence, vb))
+	pduBody := berEncodeIntegerTLV(0) // request-id
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, vbList...)
+	return berEncodeTLV(0xa8, pduBody) // Report PDU tag
 }
 
 // buildV3Response builds an authenticated (and optionally encrypted) SNMPv3 response.

--- a/pkg/snmp/v3_timeliness_test.go
+++ b/pkg/snmp/v3_timeliness_test.go
@@ -1,0 +1,316 @@
+package snmp
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// nowMinus returns a time secs seconds in the past, so an Agent.startTime set
+// to it makes engineTime() return approximately secs.
+func nowMinus(secs int) time.Time {
+	return time.Now().Add(-time.Duration(secs) * time.Second)
+}
+
+// buildV3TimedRequest builds a complete SNMPv3 authNoPriv GetRequest carrying
+// the given msgAuthoritativeEngineBoots/Time, signed with authKey. It returns
+// the on-wire bytes. The PDU is an empty GetRequest (the agent serves it and
+// returns a GetResponse on acceptance, or a Report on a timeliness failure).
+func buildV3TimedRequest(t *testing.T, authProto, userName string, engineID, authKey []byte, boots, tm int) []byte {
+	t.Helper()
+	hashFn, _ := authHashFunc(authProto)
+	if hashFn == nil {
+		t.Fatalf("unknown auth proto %q", authProto)
+	}
+	truncLen := authTruncLen(authProto)
+
+	authPlaceholder := make([]byte, truncLen)
+	usmFields := berEncodeTLV(tagOctetString, engineID)
+	usmFields = append(usmFields, berEncodeIntegerTLV(boots)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(tm)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte(userName))...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, authPlaceholder)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // privParams
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(7)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagAuth})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	// scopedPDU: contextEngineID, contextName, empty GetRequest PDU.
+	scopedBody := berEncodeTLV(tagOctetString, engineID)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...)
+	// GetRequest PDU body: request-id, error-status, error-index, empty vblist.
+	pduBody := berEncodeIntegerTLV(99)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeTLV(tagSequence, nil)...)
+	scopedBody = append(scopedBody, berEncodeTLV(pduGetRequest, pduBody)...)
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	wholeMsg := berEncodeTLV(tagSequence, msgBody)
+
+	start, end, ok := usmAuthParamsRange(wholeMsg)
+	if !ok || end-start != truncLen {
+		t.Fatalf("usmAuthParamsRange failed on built request (ok=%v len=%d)", ok, end-start)
+	}
+	mac := hmac.New(hashFn, authKey)
+	mac.Write(wholeMsg)
+	computed := mac.Sum(nil)[:truncLen]
+	copy(wholeMsg[start:end], computed)
+	return wholeMsg
+}
+
+// newTimelinessAgent builds an agent with a single authNoPriv user, a fixed
+// engineID, a controlled engineBoots, and a startTime offset so engineTime()
+// returns approximately wantTime. It returns the agent, engineID, and authKey.
+func newTimelinessAgent(t *testing.T, boots, wantTime int) (*Agent, []byte, []byte) {
+	t.Helper()
+	engineID := []byte{0x80, 0x00, 0x1f, 0x88, 0x80, 0xDE, 0xAD, 0xBE, 0xEF}
+	authProto := "sha"
+	hashFn, hashLen := authHashFunc(authProto)
+	authKey := passwordToKey("timeliness-pw-123456", engineID, hashFn, hashLen)
+
+	a := &Agent{
+		engineID:    engineID,
+		engineBoots: boots,
+		v3Users:     map[string]*usmUser{},
+		// startTime in the past so engineTime() ~= wantTime.
+		startTime: nowMinus(wantTime),
+	}
+	a.v3Users["tuser"] = &usmUser{name: "tuser", authProto: authProto, authKey: authKey}
+	return a, engineID, authKey
+}
+
+// classifyV3Response reports whether a response is a Report PDU carrying the
+// usmStatsNotInTimeWindows OID ("report"), an ordinary GetResponse
+// ("response"), or something else ("other"/"nil").
+func classifyV3Response(t *testing.T, resp []byte) string {
+	t.Helper()
+	if resp == nil {
+		return "nil"
+	}
+	if bytes.Contains(resp, berEncodeOID(usmStatsNotInTimeWindows)) {
+		return "report"
+	}
+	// A GetResponse PDU tag (0xa2) appears in the scopedPDU.
+	if bytes.IndexByte(resp, byte(pduGetResponse)) >= 0 {
+		return "response"
+	}
+	return "other"
+}
+
+// TestTimeliness_InWindowAccepted verifies that an authenticated request with
+// the correct boots and a timestamp inside the ±150s window is accepted and
+// produces a data GetResponse (not a timeliness report).
+func TestTimeliness_InWindowAccepted(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 5, 1000)
+	// Request time within 150s of our time (~1000).
+	pkt := buildV3TimedRequest(t, "sha", "tuser", engineID, authKey, 5, 1050)
+	a.lastPacket = pkt
+
+	// handleV3Packet consumes the message body after the version integer; mirror
+	// handlePacket's decode of the outer SEQUENCE + version.
+	resp := driveV3(t, a, pkt)
+	if got := classifyV3Response(t, resp); got != "response" {
+		t.Fatalf("in-window request: got %q response, want a data GetResponse", got)
+	}
+}
+
+// TestTimeliness_StaleRejected is the core replay test: a captured request
+// whose engineTime is far outside the window (a replay long after capture) is
+// rejected with usmStatsNotInTimeWindows, NOT served. fail-on-revert: removing
+// the checkTimeliness call makes this request classify as "response".
+func TestTimeliness_StaleRejected(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 5, 1000)
+	// Replay: the captured request's time is 151s behind our clock.
+	pkt := buildV3TimedRequest(t, "sha", "tuser", engineID, authKey, 5, 849)
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if got := classifyV3Response(t, resp); got != "report" {
+		t.Fatalf("stale replay: got %q, want a usmStatsNotInTimeWindows report (replay must be rejected)", got)
+	}
+}
+
+// TestTimeliness_FutureRejected covers a request whose engineTime is far in the
+// future (clock skew / crafted) — also outside the window.
+func TestTimeliness_FutureRejected(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 5, 1000)
+	pkt := buildV3TimedRequest(t, "sha", "tuser", engineID, authKey, 5, 1200) // +200s
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if got := classifyV3Response(t, resp); got != "report" {
+		t.Fatalf("future request: got %q, want a not-in-time-window report", got)
+	}
+}
+
+// TestTimeliness_WrongBootsRejected covers the post-restart replay vector: the
+// captured request carries the pre-restart boots value, which no longer matches
+// our (incremented) boots, so it is rejected even if the time happens to align.
+func TestTimeliness_WrongBootsRejected(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 6, 1000)                    // we are now boots=6
+	pkt := buildV3TimedRequest(t, "sha", "tuser", engineID, authKey, 5, 1000) // captured at boots=5
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if got := classifyV3Response(t, resp); got != "report" {
+		t.Fatalf("wrong-boots request: got %q, want a not-in-time-window report", got)
+	}
+}
+
+// TestTimeliness_Boundary checks the exact ±150s boundary: 150s is in-window,
+// 151s is out.
+func TestTimeliness_Boundary(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 3, 5000)
+
+	in := buildV3TimedRequest(t, "sha", "tuser", engineID, authKey, 3, 5000-usmTimeWindow)
+	a.lastPacket = in
+	if got := classifyV3Response(t, driveV3(t, a, in)); got != "response" {
+		t.Fatalf("at -150s boundary: got %q, want accepted response", got)
+	}
+
+	out := buildV3TimedRequest(t, "sha", "tuser", engineID, authKey, 3, 5000-usmTimeWindow-1)
+	a.lastPacket = out
+	if got := classifyV3Response(t, driveV3(t, a, out)); got != "report" {
+		t.Fatalf("at -151s boundary: got %q, want rejected report", got)
+	}
+}
+
+// TestTimeliness_DiscoveryStillWorks verifies the engineID discovery handshake
+// (empty userName) is unaffected by the timeliness gate and still returns a
+// usmStatsUnknownEngineIDs report so a manager can learn our boots/time.
+func TestTimeliness_DiscoveryStillWorks(t *testing.T) {
+	a, _, _ := newTimelinessAgent(t, 4, 100)
+	// Discovery probe: empty userName, no auth.
+	usmFields := berEncodeTLV(tagOctetString, nil) // unknown engineID
+	usmFields = append(usmFields, berEncodeIntegerTLV(0)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(0)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // empty userName
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...)
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(1)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagReport})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	scopedBody := berEncodeTLV(tagOctetString, nil)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...)
+	scopedBody = append(scopedBody, berEncodeTLV(pduGetRequest, nil)...)
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	pkt := berEncodeTLV(tagSequence, msgBody)
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if resp == nil {
+		t.Fatal("discovery probe returned nil; handshake broken")
+	}
+	unknownEngineIDs := berEncodeOID([]int{1, 3, 6, 1, 6, 3, 15, 1, 1, 4, 0})
+	if !bytes.Contains(resp, unknownEngineIDs) {
+		t.Fatal("discovery response missing usmStatsUnknownEngineIDs report")
+	}
+}
+
+// driveV3 strips the outer SEQUENCE + version (as handlePacket does) and calls
+// handleV3Packet, the unit under test.
+func driveV3(t *testing.T, a *Agent, pkt []byte) []byte {
+	t.Helper()
+	tag, msgBody, err := berDecodeHeader(pkt)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("driveV3: outer SEQUENCE decode failed: %v", err)
+	}
+	_, rest, err := berDecodeInteger(msgBody) // version
+	if err != nil {
+		t.Fatalf("driveV3: version decode failed: %v", err)
+	}
+	return a.handleV3Packet(rest)
+}
+
+// --- engineBoots persistence tests ---
+
+// TestEngineBootsPersistAcrossRestart asserts the persisted counter advances
+// 1 -> 2 -> 3 across successive agent constructions sharing one state file,
+// rather than resetting to 1 each start. fail-on-revert: hard-coding
+// engineBoots = 1 in initEngine makes the second/third assertions fail.
+func TestEngineBootsPersistAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snmp-engineboots")
+
+	for i, want := range []int{1, 2, 3} {
+		a := NewAgentWithBootsPath(nil, path)
+		if a.engineBoots != want {
+			t.Fatalf("restart %d: engineBoots = %d, want %d", i, a.engineBoots, want)
+		}
+		// The persisted file must hold the value we just used.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("restart %d: read state: %v", i, err)
+		}
+		got, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			t.Fatalf("restart %d: parse state %q: %v", i, data, err)
+		}
+		if got != want {
+			t.Fatalf("restart %d: persisted boots = %d, want %d", i, got, want)
+		}
+	}
+}
+
+// TestEngineBootsFirstBootMissingFile confirms a missing state file yields
+// boots = 1 (first boot) and creates the file.
+func TestEngineBootsFirstBootMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "snmp-engineboots")
+
+	a := NewAgentWithBootsPath(nil, path)
+	if a.engineBoots != 1 {
+		t.Fatalf("first boot: engineBoots = %d, want 1", a.engineBoots)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("first boot: state file not created: %v", err)
+	}
+}
+
+// TestEngineBootsCorruptResets confirms an unparseable counter restarts at 1
+// rather than wedging the agent (the timeliness check remains the replay
+// backstop).
+func TestEngineBootsCorruptResets(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snmp-engineboots")
+	if err := os.WriteFile(path, []byte("not-a-number"), 0o644); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+	a := NewAgentWithBootsPath(nil, path)
+	if a.engineBoots != 1 {
+		t.Fatalf("corrupt state: engineBoots = %d, want 1", a.engineBoots)
+	}
+}
+
+// TestCheckTimeliness_CeilingRejects confirms a boots counter at the RFC
+// ceiling rejects every authenticated request (RFC 3414 §3.2).
+func TestCheckTimeliness_CeilingRejects(t *testing.T) {
+	a := &Agent{engineBoots: engineBootsMax, startTime: nowMinus(100)}
+	if a.checkTimeliness(engineBootsMax, 100) {
+		t.Fatal("at engineBoots ceiling, checkTimeliness must reject all requests")
+	}
+}


### PR DESCRIPTION
Closes #2610

## Problem

SNMPv3 authenticated requests were accepted on HMAC validation alone.
`handleV3Packet` decoded `msgAuthoritativeEngineBoots`/`Time` then discarded
them — the RFC 3414 §3.2 USM timeliness window was never enforced, so an on-path
attacker could **replay a captured authenticated PDU verbatim**. Separately,
`engineBoots` reset to `1` on every daemon start and `engineTime` was raw
process uptime, which breaks strict managers that track authoritative engine
boots/time and aids cross-restart replay.

Provenance: codex review-041 finding 041-07. Severity: HIGH (security model gap).

## Fix

### 1. USM timeliness window (the replay fix) — `pkg/snmp/v3.go`, `agent.go`

After `verifyAuth` succeeds, `checkTimeliness(reqBoots, reqTime)` enforces
RFC 3414 §3.2 step 7 as the **authoritative** engine: reject if our
`engineBoots == 2147483647` (RFC ceiling), OR the request's boots != our boots,
OR `|our engineTime - request engineTime| > 150s`.

A request outside the window gets an **authenticated** Report PDU carrying
`usmStatsNotInTimeWindows` (`1.3.6.1.6.3.15.1.1.2.0`) plus the agent's current
boots/time (`buildV3TimelinessReport`) — never a data response. A manager whose
cached boots/time drifted (the legitimate case, e.g. across our restart) reads
the report and resynchronizes; a replay gets nothing useful. Reports are sent
authNoPriv (no encryption — no MIB data). The engineID discovery handshake
(empty `userName` → `usmStatsUnknownEngineIDs`) is unchanged, so a
freshly-discovered timely request is still accepted.

### 2. engineBoots persistence — `pkg/snmp/agent.go`

Loaded, incremented, and persisted once at agent construction so
`(engineBoots, engineTime)` is monotonic across restarts.

- **State file**: `/var/lib/xpf/snmp-engineboots` (single decimal int), written
  via `fsatomic.WriteFileDurable` (fsync-on-write, slow path), dir via
  `fsatomic.MkdirAllDurable`. Path injectable via `NewAgentWithBootsPath` (test
  seam); `NewAgent` keeps its signature.
- **First boot** (file missing): starts at `1`, creates the file. Each restart
  reads the prior value and increments (1 → 2 → 3 …); `engineTime()` counts from
  this boot.
- **Corrupt/unreadable/ceiling**: restarts the count at `1` rather than wedging
  the agent — the timeliness check is the replay backstop, so a lost counter
  degrades resynchronization, not security. A write failure is logged + ignored
  (in-memory boots used for this run).

## Validation

`go test ./pkg/snmp/...` green; `gofmt` + `go vet` clean on changed files.

New tests (`pkg/snmp/v3_timeliness_test.go`):
- replay rejected → `usmStatsNotInTimeWindows`: stale (−151s), future (+200s),
  and wrong-boots (post-restart) vectors
- in-window (+50s) and exact ±150s boundary accepted (data response)
- boots ceiling rejects all
- engineBoots persists 1 → 2 → 3 across simulated restarts; first-boot=1;
  corrupt resets to 1
- discovery handshake still returns `usmStatsUnknownEngineIDs`

**fail-on-revert proof**: neutralizing the `checkTimeliness` branch turns every
replay test ("should reject") into a served data response (red), while the
in-window/boundary-accept assertions stay green.

Docs: `pkg/snmp/README.md` (timeliness window + engineBoots persistence
sections), `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi