### PR TITLE
filter: report terminal verdict in fall-through RT_FLOW log action (#2616/#2618/#2619)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,37 @@
 # Action Log
 
+## 2026-06-24 — #2616/#2618/#2619 fix: firewall-filter fall-through log metadata
+
+- **Timestamp**: 2026-06-24
+- **Action**: codex review-040 findings 040-01/040-03/040-05. One coherent
+  filter-evaluator log-metadata fix across the post-#2544 fall-through machinery.
+  - #2616: a fall-through `then { log; next term; }` term recorded its Accept
+    PLACEHOLDER action into `log_match`; a later terminal `discard`/`reject`
+    left the RT_FLOW log saying permit. FIX: `normalize_log_match_action` stamps
+    the accumulated `log_match.action` with the FINAL `acc.action` before every
+    evaluator returns (main v4/v6, non-routing v4/v6, log-only helper,
+    routing-instance evaluators).
+  - #2618: the log-only helper `evaluate_filter_ref_log_match` returned on the
+    FIRST matched logging fall-through term, diverging from the full evaluator's
+    latest-matched semantics. FIX: rewrite it to accumulate latest-matched +
+    normalize action to the terminal verdict.
+  - #2619: the PBR routing-instance evaluator dropped fall-through `then log`
+    metadata for terms ahead of the routing-instance term. FIX: added
+    `log_match: Option<FilterLogMatch>` to `FilterRoutingInstanceResult`,
+    accumulate latest-matched logging term (fall-through + the RI term itself),
+    normalize to the RI term's verdict; forwarding/mod.rs PBR emit now uses the
+    accumulated `log_match` instead of only the RI term's own log.
+  - Siblings #2617 (emit timing miss vs cache-hit), #2620 (counter double-count
+    across split passes), #2621 (fc/dscp/policer modifiers dropped pre-RI) are
+    DISTINCT code paths (poll_descriptor emit / counter side-effects /
+    TX-selection) — left for follow-up, not bundled.
+- **File(s)**: userspace-dp/src/filter/engine/eval.rs,
+  userspace-dp/src/filter/mod.rs, userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md
+- **Validation**: cargo build --release green; 6 new regression tests pass;
+  fail-on-revert proven for all three fixes; full suite 2709 pass / 1 known
+  flake (worker_queue concurrent_recovery, passes in isolation).
+
 ## 2026-06-24 — #2606 fix: DHCP relay silently dropped DHCPNAK server responses
 
 - **Timestamp**: 2026-06-24

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1119,7 +1119,12 @@ pub(super) fn ingress_route_table_override(
         extra,
         meta.pkt_len as u64,
     )?;
-    if routing_result.log {
+    // #2619: emit the accumulated log_match — it captures fall-through
+    // `then { log; next term; }` terms ahead of the routing-instance term that
+    // the PBR path previously dropped, AND the routing-instance term's own log
+    // (latest matched wins). Its action is already normalized to the verdict the
+    // packet receives (#2616). Falls back to nothing when no matched term logged.
+    if let Some(log_match) = routing_result.log_match {
         let ingress_zone_id = ingress_zone_override
             .filter(|id| forwarding.zone_id_to_name.contains_key(id))
             .or_else(|| forwarding.ifindex_to_zone_id.get(&ingress_ifindex).copied())
@@ -1136,9 +1141,9 @@ pub(super) fn ingress_route_table_override(
             meta,
             ingress_zone_id,
             0,
-            routing_result.filter_id,
-            routing_result.term_id,
-            routing_result.action,
+            log_match.filter_id,
+            log_match.term_id,
+            log_match.action,
             FilterLogSource::Pbr,
             // #2520: AppID via the hot-path app_catalog.lookup.
             resolve_flow_app_id(&forwarding.app_catalog, flow),

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -44,9 +44,14 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   matched `then policer ...` name in the filter result. Routing-instance
   evaluation can also return log/action/filter/term metadata so AF_XDP
   can emit PBR RT_FLOW filter-log events without re-evaluating the term
-  or allocating on the packet path. No-count helper evaluation returns the
-  first logged non-PBR input or lo0 match while skipping routing-instance
-  terms to avoid double-emitting PBR logs. TX-selection evaluation meters
+  or allocating on the packet path. The routing-instance result also
+  carries an accumulated `log_match` (#2619) so a fall-through
+  `then { log; next term; }` term ahead of the routing-instance term is
+  not dropped from the PBR RT_FLOW path. The no-count log-only helper
+  (`evaluate_filter_ref_log_match`) accumulates the LATEST matched logging
+  term — sharing the full evaluator's semantics (#2618) instead of
+  returning on the first one — while still skipping routing-instance terms
+  so PBR logs are emitted only on the PBR path. TX-selection evaluation meters
   three-color policers, carries output filter-log identity through live
   forwarding and cached flow-cache hits, and preserves terminal
   `discard`/`reject` actions so output filters cannot log deny while
@@ -89,6 +94,21 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   each carry `then count` the cached rebuild path records only the last
   (a pre-existing structural limit; the uncached full-eval path counts
   every term).
+
+  **Fall-through log action follows the terminal verdict (#2616).** A
+  matched fall-through logging term records its identity
+  (`filter_id`/`term_id`) into the accumulated `log_match`, but its
+  `action` field holds the Accept PLACEHOLDER the compiler assigns an
+  empty/`next term` action — NOT the verdict the packet receives. Every
+  evaluator entry point (`evaluate_filter_ref_counted_v4/v6`, the
+  `_non_routing_` variants, the routing-instance evaluators, and the
+  log-only helper) now normalizes the stored `log_match.action` to the
+  FINAL terminal action before returning. A `then { log; next term; }`
+  term ahead of a terminal `discard`/`reject` therefore logs DENY, not
+  permit — the RT_FLOW record no longer lies about the action while the
+  dataplane denies the packet. For a terminating logging term
+  `term.action` already equals the final verdict, so normalization is a
+  no-op there.
 - `policer.rs` — token-bucket implementation plus the #1375 RFC
   2697/2698 three-color meter core. Token math is integer-only:
   the legacy token bucket keeps its bits/sec constructor contract, and

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -128,10 +128,28 @@ fn evaluate_filter_ref_counted_v4(
         merge_matched_modifiers(&mut acc, filter, term);
         if !term.continue_term {
             acc.action = term.action;
+            normalize_log_match_action(&mut acc);
             return acc;
         }
     }
+    normalize_log_match_action(&mut acc);
     acc
+}
+
+/// #2616: the RT_FLOW log action must report the verdict the packet actually
+/// received, not the placeholder Accept a fall-through (`then { log; next term; }`)
+/// logging term carries in its `action` field. The accumulated `log_match`
+/// tracks the latest matched logging term's identity (filter_id/term_id), but
+/// its action is the term's own — which is the Accept placeholder for a
+/// fall-through term. Before the result leaves the evaluator, rewrite the
+/// log_match action to the final `acc.action` so a `log; next term` ahead of a
+/// terminal `discard`/`reject` logs DENY, not permit. For a terminating logging
+/// term `term.action == acc.action` already, so this is a no-op there.
+#[inline]
+fn normalize_log_match_action(acc: &mut FilterResult) {
+    if let Some(lm) = acc.log_match.as_mut() {
+        lm.action = acc.action;
+    }
 }
 
 /// #2544: merge a matched term's modifiers into the running result. Used by both
@@ -141,7 +159,9 @@ fn evaluate_filter_ref_counted_v4(
 /// term wins for each scalar modifier (Junos applies modifiers as terms are
 /// traversed); `log` is OR'd so any matched term with `then log` lights it. The
 /// log_match diagnostic tracks the latest matched logging term. The action is
-/// NOT set here — the caller sets it only for a terminating term.
+/// NOT set here — the caller sets it only for a terminating term, and
+/// `normalize_log_match_action` (#2616) rewrites the stored log_match action to
+/// the final verdict before the result is returned.
 #[inline]
 fn merge_matched_modifiers(acc: &mut FilterResult, filter: &Filter, term: &FilterTerm) {
     if term.dscp_rewrite.is_some() {
@@ -191,9 +211,11 @@ fn evaluate_filter_ref_counted_v6(
         merge_matched_modifiers(&mut acc, filter, term);
         if !term.continue_term {
             acc.action = term.action;
+            normalize_log_match_action(&mut acc);
             return acc;
         }
     }
+    normalize_log_match_action(&mut acc);
     acc
 }
 
@@ -271,9 +293,11 @@ fn evaluate_filter_ref_non_routing_counted_v4(
         acc.routing_instance = String::new();
         if !term.continue_term {
             acc.action = term.action;
+            normalize_log_match_action(&mut acc);
             return acc;
         }
     }
+    normalize_log_match_action(&mut acc);
     acc
 }
 
@@ -307,9 +331,11 @@ fn evaluate_filter_ref_non_routing_counted_v6(
         acc.routing_instance = String::new();
         if !term.continue_term {
             acc.action = term.action;
+            normalize_log_match_action(&mut acc);
             return acc;
         }
     }
+    normalize_log_match_action(&mut acc);
     acc
 }
 
@@ -334,6 +360,7 @@ fn evaluate_filter_ref_routing_instance_counted_v4<'a>(
     extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> Option<FilterRoutingInstanceResult<'a>> {
+    let mut acc_log: Option<FilterLogMatch> = None;
     for term in &filter.terms {
         if !term_matches_v4(
             term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
@@ -349,17 +376,35 @@ fn evaluate_filter_ref_routing_instance_counted_v4<'a>(
         // TERMINATING term without a routing-instance still halts (returns None
         // via the `?` below): once a packet is accepted/discarded there is no
         // routing-instance override to find.
+        // #2619: capture a fall-through `then log` term's log_match before we
+        // continue past it — the PBR path previously dropped these. Latest
+        // matched logging term wins, mirroring the full evaluator.
         if term.continue_term {
+            if let Some(lm) = filter_log_match(filter, term) {
+                acc_log = Some(lm);
+            }
             continue;
         }
         let routing_instance =
             (!term.routing_instance.is_empty()).then_some(term.routing_instance.as_str())?;
+        // The routing-instance term itself may also carry `then log`; latest
+        // matched wins so it supersedes any earlier fall-through log.
+        if let Some(lm) = filter_log_match(filter, term) {
+            acc_log = Some(lm);
+        }
+        // #2616: the routing-instance term is terminating on the PBR path; stamp
+        // its action onto the accumulated log_match so a fall-through log ahead
+        // of it reports the verdict the packet actually receives.
+        if let Some(lm) = acc_log.as_mut() {
+            lm.action = term.action;
+        }
         return Some(FilterRoutingInstanceResult {
             routing_instance,
             log: term.log,
             action: term.action,
             filter_id: filter.id,
             term_id: term.id,
+            log_match: acc_log,
         });
     }
     None
@@ -377,6 +422,7 @@ fn evaluate_filter_ref_routing_instance_counted_v6<'a>(
     extra: TermMatchExtra,
     packet_bytes: u64,
 ) -> Option<FilterRoutingInstanceResult<'a>> {
+    let mut acc_log: Option<FilterLogMatch> = None;
     for term in &filter.terms {
         if !term_matches_v6(
             term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
@@ -387,17 +433,29 @@ fn evaluate_filter_ref_routing_instance_counted_v6<'a>(
             record_filter_counter(&term.counter, packet_bytes);
         }
         // #2544: see the v4 variant — a matched fall-through term keeps scanning.
+        // #2619: capture its log_match before continuing (latest wins).
         if term.continue_term {
+            if let Some(lm) = filter_log_match(filter, term) {
+                acc_log = Some(lm);
+            }
             continue;
         }
         let routing_instance =
             (!term.routing_instance.is_empty()).then_some(term.routing_instance.as_str())?;
+        if let Some(lm) = filter_log_match(filter, term) {
+            acc_log = Some(lm);
+        }
+        // #2616: stamp the routing-instance term's verdict onto the log_match.
+        if let Some(lm) = acc_log.as_mut() {
+            lm.action = term.action;
+        }
         return Some(FilterRoutingInstanceResult {
             routing_instance,
             log: term.log,
             action: term.action,
             filter_id: filter.id,
             term_id: term.id,
+            log_match: acc_log,
         });
     }
     None
@@ -685,11 +743,21 @@ fn evaluate_filter_ref_log_match(
     }
     // #2544: a matched fall-through term (`then next term` / modifier-only) with
     // `then log` fires its log even though evaluation continues to later terms.
-    // Walk terms: a matched logging fall-through term emits its log_match; a
-    // matched fall-through term without `log` is skipped (keep scanning for a
-    // later logging/terminating term); the first matched TERMINATING term ends
-    // the scan and emits its log_match (None when it has no `log`), matching the
-    // first-match-wins behavior for terminating terms.
+    // #2618: this log-only helper must share the FULL evaluator's
+    // latest-matched-logging-term semantics — it previously returned on the
+    // FIRST matched logging fall-through term, so two `log; next term` terms made
+    // the cached input-filter log point at a different term than live evaluation.
+    // Walk all terms: a matched logging fall-through term records its log_match
+    // and keeps scanning (latest wins); a matched fall-through term without `log`
+    // is skipped; the first matched TERMINATING term ends the scan, recording its
+    // own log_match (when it has `log`) and resolving the final verdict.
+    //
+    // #2616: the recorded log action must follow the FINAL verdict, not the
+    // Accept placeholder a fall-through logging term carries — track the terminal
+    // action and stamp it onto the accumulated log_match before returning so a
+    // `log; next term` ahead of a terminal discard/reject logs DENY, not permit.
+    let mut acc_log: Option<FilterLogMatch> = None;
+    let mut final_action = FilterAction::Accept;
     for term in &filter.terms {
         if !term_matches(
             term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
@@ -697,17 +765,28 @@ fn evaluate_filter_ref_log_match(
             continue;
         }
         if term.continue_term {
-            if term.log {
-                return filter_log_match(filter, term);
+            if let Some(lm) = filter_log_match(filter, term) {
+                acc_log = Some(lm);
             }
             continue;
         }
         if skip_routing_instance && !term.routing_instance.is_empty() {
-            return None;
+            // The route-lookup-affecting PBR term is handled by the
+            // routing-instance evaluator; its log is not emitted on this path.
+            // Any earlier fall-through log_match still carries the verdict the
+            // packet receives here (default Accept on the non-PBR path).
+            break;
         }
-        return filter_log_match(filter, term);
+        final_action = term.action;
+        if let Some(lm) = filter_log_match(filter, term) {
+            acc_log = Some(lm);
+        }
+        break;
     }
-    None
+    if let Some(lm) = acc_log.as_mut() {
+        lm.action = final_action;
+    }
+    acc_log
 }
 
 /// Evaluate the per-interface output filter for a given address family.

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -655,6 +655,16 @@ pub(crate) struct FilterRoutingInstanceResult<'a> {
     pub(crate) action: FilterAction,
     pub(crate) filter_id: u32,
     pub(crate) term_id: u32,
+    // #2619: the latest-matched logging term seen while scanning for the
+    // routing-instance term — INCLUDING fall-through `then { log; next term; }`
+    // terms ahead of the routing-instance term, whose log metadata the PBR path
+    // previously dropped. `None` when no matched term carried `then log`. The
+    // action is normalized to the verdict the packet receives on the PBR path
+    // (#2616): the routing-instance term itself terminates with its own action,
+    // so a fall-through log ahead of it logs that terminal action. The legacy
+    // `log`/`action`/`filter_id`/`term_id` fields above describe ONLY the
+    // routing-instance term; emitters now prefer `log_match`.
+    pub(crate) log_match: Option<FilterLogMatch>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -5124,3 +5124,344 @@ fn fallthrough_tx_selection_applies_forwarding_class_then_discards() {
     let filter = state.filters.get("inet:tx-ft").expect("filter");
     assert_eq!(filter.terms[0].counter.packets.load(Ordering::Relaxed), 1);
 }
+
+// ---------------------------------------------------------------------------
+// #2616: a fall-through `then { log; next term; }` term followed by a terminal
+// discard/reject must report the FINAL verdict (deny) in its RT_FLOW log action,
+// not the Accept placeholder the fall-through term carries. Pre-fix the
+// log_match action was term.action (Accept) — the event lied "permit" while the
+// packet was denied. These FAIL on master (assert Discard/Reject, master
+// returns Accept on log_match.action) and pass with normalize_log_match_action.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallthrough_log_action_follows_terminal_discard() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "lt".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "log-first".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: String::new(),
+                    next_term: true,
+                    log: true,
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "deny-web".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:lt",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(r.action, FilterAction::Discard);
+    let lm = r.log_match.expect("fall-through log term must emit a log_match");
+    // Identity is the fall-through logging term (term 0), but the action must be
+    // the terminal verdict, NOT the Accept placeholder.
+    assert_eq!(lm.term_id, 0);
+    assert_eq!(
+        lm.action,
+        FilterAction::Discard,
+        "RT_FLOW log action must follow the terminal verdict (#2616)"
+    );
+}
+
+#[test]
+fn fallthrough_log_action_follows_terminal_reject() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "lr".into(),
+            family: "inet6".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "log-first".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: String::new(),
+                    next_term: true,
+                    log: true,
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "reject-web".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "reject".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet6:lr",
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        IpAddr::V6("2001:db8::2".parse().unwrap()),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(r.action, FilterAction::Reject);
+    let lm = r.log_match.expect("fall-through log term must emit a log_match");
+    assert_eq!(
+        lm.action,
+        FilterAction::Reject,
+        "RT_FLOW log action must follow the terminal reject (#2616)"
+    );
+}
+
+#[test]
+fn fallthrough_log_action_terminating_log_term_unchanged() {
+    // Regression guard: a terminating logging term still reports its OWN action
+    // (here Accept) — normalization is a no-op because term.action == acc.action.
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "la".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "log-accept".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["443".into()],
+                action: "accept".into(),
+                log: true,
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    let r = evaluate_filter(
+        &state,
+        "inet:la",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(r.action, FilterAction::Accept);
+    assert_eq!(r.log_match.expect("log_match").action, FilterAction::Accept);
+}
+
+// ---------------------------------------------------------------------------
+// #2618: the log-only helper (evaluate_interface_filter_log_match) must share
+// the full evaluator's latest-matched-logging-term semantics. With two matched
+// `then { log; next term; }` terms, both the full evaluator and the log-only
+// helper must point at the SECOND term, and (with a terminal discard) both must
+// report the terminal action. Pre-fix the log-only helper returned the FIRST
+// term and the placeholder Accept.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn log_only_helper_matches_full_evaluator_latest_term_and_action() {
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "two-log".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "log-a".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: String::new(),
+                    next_term: true,
+                    log: true,
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "log-b".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: String::new(),
+                    next_term: true,
+                    log: true,
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "deny-web".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["443".into()],
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 7,
+            filter_input_v4: "two-log".into(),
+            ..Default::default()
+        }],
+    );
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10));
+    let dst = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20));
+
+    let full = evaluate_interface_filter_counted(
+        &state,
+        7,
+        false,
+        src,
+        dst,
+        PROTO_TCP,
+        49152,
+        443,
+        0,
+        TermMatchExtra::default(),
+        0,
+    );
+    let full_lm = full.log_match.expect("full evaluator log_match");
+
+    let log_only = evaluate_interface_filter_log_match(
+        &state,
+        7,
+        false,
+        src,
+        dst,
+        PROTO_TCP,
+        49152,
+        443,
+        0,
+        TermMatchExtra::default(),
+        true,
+    )
+    .expect("log-only helper log_match");
+
+    // Latest-matched: term 1 (log-b), not the first matched logging term.
+    assert_eq!(full_lm.term_id, 1);
+    assert_eq!(log_only.term_id, full_lm.term_id);
+    assert_eq!(log_only.filter_id, full_lm.filter_id);
+    // Both report the terminal verdict (discard), not the placeholder Accept.
+    assert_eq!(full.action, FilterAction::Discard);
+    assert_eq!(full_lm.action, FilterAction::Discard);
+    assert_eq!(log_only.action, FilterAction::Discard);
+}
+
+// ---------------------------------------------------------------------------
+// #2619: the PBR (routing-instance) evaluator must preserve a fall-through
+// `then { log; next term; }` term's log metadata seen BEFORE the
+// routing-instance term. Pre-fix FilterRoutingInstanceResult carried only the
+// routing-instance term's log; the earlier fall-through log was dropped.
+// The accumulated log_match.action is normalized to the routing-instance term's
+// own action (the verdict the packet receives on the PBR path, #2616).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pbr_evaluator_preserves_fallthrough_log_before_routing_instance() {
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "pbr-log".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "audit-pbr".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: String::new(),
+                    next_term: true,
+                    log: true,
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "steer-blue".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "accept".into(),
+                    routing_instance: "blue".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 12,
+            filter_input_v4: "pbr-log".into(),
+            ..Default::default()
+        }],
+    );
+    let result = evaluate_interface_filter_routing_instance_event_counted(
+        &state,
+        12,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        1400,
+    )
+    .expect("routing-instance override");
+    assert_eq!(result.routing_instance, "blue");
+    let lm = result
+        .log_match
+        .expect("fall-through log before routing-instance must be preserved (#2619)");
+    // Identity is the fall-through audit term (term 0).
+    assert_eq!(lm.term_id, 0);
+    // Action follows the routing-instance term's verdict (Accept here).
+    assert_eq!(lm.action, FilterAction::Accept);
+}
+
+#[test]
+fn pbr_evaluator_log_on_routing_instance_term_itself() {
+    // The routing-instance term carries `then log` directly (no fall-through
+    // term ahead). log_match must point at it (latest matched wins).
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "pbr-self-log".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "steer-and-log".into(),
+                protocols: vec!["tcp".into()],
+                destination_ports: vec!["5201".into()],
+                action: "accept".into(),
+                log: true,
+                routing_instance: "green".into(),
+                ..Default::default()
+            }],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 13,
+            filter_input_v4: "pbr-self-log".into(),
+            ..Default::default()
+        }],
+    );
+    let result = evaluate_interface_filter_routing_instance_event_counted(
+        &state,
+        13,
+        false,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        1400,
+    )
+    .expect("routing-instance override");
+    assert_eq!(result.routing_instance, "green");
+    let lm = result.log_match.expect("routing-instance term log");
+    assert_eq!(lm.term_id, 0);
+    assert_eq!(lm.action, FilterAction::Accept);
+}


### PR DESCRIPTION
## Summary

After #2544 added firewall-filter fall-through (`then next term`) support, the RT_FLOW log metadata for a matched fall-through logging term captured that term's **placeholder Accept** action instead of the **terminal** action the packet actually received. `term { log; next term; }` ahead of `then discard`/`then reject` produced an event reporting *permit* while the dataplane *denied* the packet — an observability/security lie on a firewall appliance.

This is **one coherent fix** across the post-#2544 fall-through log machinery (the same evaluator), closing three codex review-040 findings.

## Root fix: log action follows the terminal verdict

A fall-through logging term records its identity (`filter_id`/`term_id`) into the accumulated `log_match`, but `filter_log_match` stamps `action: term.action` — the **Accept placeholder** the compiler assigns an empty/`next term` action. The terminal verdict is only known when a later term (or the implicit default) terminates. The fix adds `normalize_log_match_action`, called before **every** evaluator returns, which rewrites the stored `log_match.action` to the final `acc.action`. For a terminating logging term `term.action` already equals the verdict, so it is a no-op there.

## Per-sibling assessment (#2617–#2621)

| Issue | Finding | Disposition |
|-------|---------|-------------|
| **#2616** (040-01) | fall-through log records placeholder Accept, not terminal action | **Fixed here** — `normalize_log_match_action` across main v4/v6, non-routing v4/v6, log-only helper, routing-instance evaluators |
| **#2618** (040-03) | log-only helper returns FIRST fall-through log term vs full evaluator's LATEST | **Fixed here** — same evaluator; rewrote `evaluate_filter_ref_log_match` to accumulate latest-matched + normalize the terminal action |
| **#2619** (040-05) | PBR routing-instance evaluator drops fall-through `then log` metadata | **Fixed here** — same evaluator; added `log_match` to `FilterRoutingInstanceResult`, accumulate + normalize, AF_XDP PBR emit uses it |
| **#2617** (040-02) | accepted input-filter `then log` emitted only on cache-hit, not on session-miss packet | **Distinct follow-up** — emit *timing* on the poll_descriptor session-miss path (`mod.rs` ~837-864), not the evaluator. Different concern, would bloat scope |
| **#2620** (040-06) | PBR session-miss double-counts pre-PBR fall-through `then count` | **Distinct follow-up** — counter *side-effects* run across two evaluator passes (non-PBR precheck + PBR). Architectural unification of the split, not log metadata |
| **#2621** (040-07) | fc/DSCP/policer modifiers before a routing-instance term dropped | **Distinct follow-up** — TX-selection / modifier accumulation across the split precheck/PBR/TX passes. CoS correctness, large architectural change |

The three distinct siblings live in genuinely different code paths and were not force-bundled.

## Validation

- `cargo build --release` green
- 6 new regression tests (fall-through log action follows terminal discard/reject; terminating log term unchanged; log-only helper agrees with full evaluator on latest-matched term + terminal action; PBR preserves fall-through log ahead of routing-instance term; PBR logs the routing-instance term's own log)
- **Fail-on-revert proven** for all three fixes independently
- Full userspace-dp suite: 2709 pass / 1 known flake (`worker_queue concurrent_recovery`, passes in isolation)

Closes #2616
Closes #2618
Closes #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi