### PR TITLE
snmp: honor SNMPv3 scopedPDU contextName, fail closed on non-default context

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,18 @@
 # Action Log
 
+## 2026-06-24 — #2611 fix: honor SNMPv3 scopedPDU contextName (empty-view gate)
+
+- **Timestamp**: 2026-06-24
+- **Action**: SNMPv3 scopedPDU `contextName` was decoded then discarded;
+  Get/GetNext/GetBulk served the default MIB regardless of context and the
+  response always carried an empty contextName. Now capture `contextName`,
+  gate the PDU handlers (non-default context → noSuchInstance for Get,
+  endOfMibView for GetNext/GetBulk; SET still notWritable), and echo the
+  requested contextName in the response scopedPDU. Default (empty) context is
+  unchanged. Added `pkg/snmp/v3_context_test.go` (default served, non-default
+  empty-view no-leak, contextName echo, fail-on-revert).
+- **File(s)**: pkg/snmp/v3.go, pkg/snmp/v3_context_test.go, pkg/snmp/README.md
+
 ## 2026-06-24 — #2616/#2618/#2619 fix: firewall-filter fall-through log metadata
 
 - **Timestamp**: 2026-06-24

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -23,6 +23,32 @@ struct; SET requests (`pduSetRequest`, 0xa3) are gated on it:
 SNMPv3 SET requests are uniformly refused with `notWritable` (the USM users
 in this config carry no read-write authorization).
 
+## SNMPv3 contexts (RFC 3412 §4.1, RFC 3413 §3)
+
+The agent serves a single MIB view in the **default context** (empty
+`contextName`). It does NOT model per-VRF / per-routing-instance context
+views. The scopedPDU `contextEngineID` and `contextName` are decoded and the
+`contextName` is honored when dispatching the request:
+
+- **Default context** (empty `contextName`): served exactly as before —
+  Get / GetNext / GetBulk return the real MIB objects. No behavior change.
+- **Non-default context** (any non-empty `contextName`): there is no MIB view
+  for that context, so per RFC 3413 the request yields no matching objects.
+  Rather than leaking default-context data (an information-exposure /
+  operator-confusion bug, #2611), the agent returns the **empty-view**
+  exceptions: `noSuchInstance` for every Get varbind and `endOfMibView` for
+  every GetNext / GetBulk varbind. SET is refused with `notWritable` as in any
+  context. This is fail-closed: a manager addressing an unknown context never
+  receives default-context values.
+- The response **echoes the requested `contextName`** back in the scopedPDU
+  (empty for the default context), so the manager sees the response is bound to
+  the context it addressed. `contextEngineID` in the response is our own engine
+  ID (we are the authoritative engine).
+
+This is the empty-view route (RFC 3413), chosen over an `authorizationError` /
+`snmpUnknownContexts` report because it is the standard, simplest result for a
+single-context agent and needs no new error-counter MIB objects.
+
 ## SNMPv3 USM timeliness and replay protection (RFC 3414 §3.2)
 
 Authenticating a request proves the sender holds the user's key; it does

--- a/pkg/snmp/v3.go
+++ b/pkg/snmp/v3.go
@@ -298,17 +298,35 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		slog.Debug("SNMPv3: failed to decode contextEngineID")
 		return nil
 	}
-	_, scopedRest, err = berDecodeOctetString(scopedRest) // contextName
+	contextName, scopedRest, err := berDecodeOctetString(scopedRest) // contextName
 	if err != nil {
 		slog.Debug("SNMPv3: failed to decode contextName")
 		return nil
 	}
+
+	// Context gating (RFC 3412 §4.1, RFC 3413 §3). This agent serves a single
+	// MIB view in the default context (empty contextName). It does NOT model
+	// per-VRF/routing-instance context views, so a request naming a non-default
+	// context must NOT be answered with default-context data — that would be an
+	// information-exposure / operator-confusion bug (#2611). Per RFC 3413, an
+	// unknown context yields no matching MIB objects: Get/GetNext/GetBulk return
+	// the empty-view exceptions (noSuchInstance / endOfMibView) for every
+	// varbind, and Set is refused. The requested contextName is echoed back in
+	// the response so the manager sees which context it addressed. The empty
+	// (default) context continues to be served exactly as before.
+	defaultContext := len(contextName) == 0
+	echoContext := contextName
 
 	// Decode PDU.
 	pduTag, pduBody, err := berDecodeHeader(scopedRest)
 	if err != nil {
 		slog.Debug("SNMPv3: failed to decode PDU")
 		return nil
+	}
+
+	if !defaultContext {
+		slog.Debug("SNMPv3: non-default context not served, returning empty view",
+			"user", userName, "context", string(contextName))
 	}
 
 	var respVarbinds []varbind
@@ -322,6 +340,10 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 			return nil
 		}
 		for _, oid := range oids {
+			if !defaultContext {
+				respVarbinds = append(respVarbinds, varbind{oid: oid, tag: tagNoSuchInstance})
+				continue
+			}
 			val, valTag := a.getOIDValue(oid)
 			if val == nil {
 				respVarbinds = append(respVarbinds, varbind{oid: oid, tag: tagNoSuchInstance})
@@ -337,6 +359,10 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 			return nil
 		}
 		for _, oid := range oids {
+			if !defaultContext {
+				respVarbinds = append(respVarbinds, varbind{oid: oid, tag: tagEndOfMibView})
+				continue
+			}
 			nextOID := a.findNextOID(oid)
 			if nextOID == nil {
 				respVarbinds = append(respVarbinds, varbind{oid: oid, tag: tagEndOfMibView})
@@ -361,6 +387,15 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		}
 		if maxRepetitions > 100 {
 			maxRepetitions = 100
+		}
+		if !defaultContext {
+			// Non-default context: no MIB view exists, so every requested OID
+			// yields endOfMibView. One varbind per OID matches what a manager
+			// expects from an empty view and avoids walking the default MIB.
+			for _, oid := range oids {
+				respVarbinds = append(respVarbinds, varbind{oid: oid, tag: tagEndOfMibView})
+			}
+			break
 		}
 		for i := 0; i < nonRepeaters && i < len(oids); i++ {
 			nextOID := a.findNextOID(oids[i])
@@ -402,14 +437,14 @@ func (a *Agent) handleV3Packet(msgBody []byte) []byte {
 		if len(oids) > 0 {
 			errIdx = 1
 		}
-		return a.buildV3Response(msgID, msgFlags, user, requestID, errNotWritable, errIdx, respVarbinds)
+		return a.buildV3Response(msgID, msgFlags, user, echoContext, requestID, errNotWritable, errIdx, respVarbinds)
 
 	default:
 		slog.Debug("SNMPv3: unsupported PDU type", "type", pduTag)
 		return nil
 	}
 
-	return a.buildV3Response(msgID, msgFlags, user, requestID, errNoError, 0, respVarbinds)
+	return a.buildV3Response(msgID, msgFlags, user, echoContext, requestID, errNoError, 0, respVarbinds)
 }
 
 // verifyAuth checks the HMAC authentication of a v3 message.
@@ -859,9 +894,15 @@ func (a *Agent) buildReportPDU(statsOID []int) []byte {
 	return berEncodeTLV(0xa8, pduBody) // Report PDU tag
 }
 
-// buildV3Response builds an authenticated (and optionally encrypted) SNMPv3 response.
+// buildV3Response builds an authenticated (and optionally encrypted) SNMPv3
+// response. contextName is the contextName echoed back into the scopedPDU; it
+// is the value decoded from the request (empty for the default context), so the
+// manager sees the response is bound to the context it addressed (RFC 3412
+// §4.1). The agent serves data only in the default (empty) context — non-default
+// contexts are gated to an empty view by the caller — but the response still
+// echoes the requested contextName.
 func (a *Agent) buildV3Response(msgID int, reqFlags byte, user *usmUser,
-	requestID, errorStatus, errorIndex int, vbs []varbind) []byte {
+	contextName []byte, requestID, errorStatus, errorIndex int, vbs []varbind) []byte {
 
 	// Build varbind list.
 	var vbListBytes []byte
@@ -884,9 +925,10 @@ func (a *Agent) buildV3Response(msgID int, reqFlags byte, user *usmUser,
 	pduBody = append(pduBody, vbListEncoded...)
 	responsePDU := berEncodeTLV(pduGetResponse, pduBody)
 
-	// Build scopedPDU.
+	// Build scopedPDU. contextEngineID is our engineID (we are the authoritative
+	// engine); contextName echoes the requested context (empty = default).
 	scopedBody := berEncodeTLV(tagOctetString, a.engineID)
-	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, nil)...) // contextName
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, contextName)...) // contextName
 	scopedBody = append(scopedBody, responsePDU...)
 	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
 

--- a/pkg/snmp/v3_context_test.go
+++ b/pkg/snmp/v3_context_test.go
@@ -1,0 +1,191 @@
+package snmp
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"testing"
+)
+
+// buildV3ContextRequest builds a complete SNMPv3 authNoPriv GetRequest for a
+// single OID, carrying the supplied scopedPDU contextName. boots/tm are set to
+// the agent's values so the request passes the timeliness window; the focus is
+// the context gate, not timeliness. The PDU is a GetRequest for oid so the
+// default-context path returns a real data varbind and the non-default path can
+// be asserted to return an empty-view exception instead.
+func buildV3ContextRequest(t *testing.T, authProto, userName string, engineID, authKey []byte, boots, tm int, contextName []byte, oid []int) []byte {
+	return buildV3ContextRequestPDU(t, authProto, userName, engineID, authKey, boots, tm, contextName, oid, pduGetRequest)
+}
+
+// buildV3ContextRequestPDU is buildV3ContextRequest with a selectable PDU tag.
+func buildV3ContextRequestPDU(t *testing.T, authProto, userName string, engineID, authKey []byte, boots, tm int, contextName []byte, oid []int, pduTag byte) []byte {
+	t.Helper()
+	hashFn, _ := authHashFunc(authProto)
+	if hashFn == nil {
+		t.Fatalf("unknown auth proto %q", authProto)
+	}
+	truncLen := authTruncLen(authProto)
+
+	authPlaceholder := make([]byte, truncLen)
+	usmFields := berEncodeTLV(tagOctetString, engineID)
+	usmFields = append(usmFields, berEncodeIntegerTLV(boots)...)
+	usmFields = append(usmFields, berEncodeIntegerTLV(tm)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, []byte(userName))...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, authPlaceholder)...)
+	usmFields = append(usmFields, berEncodeTLV(tagOctetString, nil)...) // privParams
+	usmOctet := berEncodeTLV(tagOctetString, berEncodeTLV(tagSequence, usmFields))
+
+	hdr := berEncodeIntegerTLV(11)
+	hdr = append(hdr, berEncodeIntegerTLV(maxPacketSize)...)
+	hdr = append(hdr, berEncodeTLV(tagOctetString, []byte{msgFlagAuth})...)
+	hdr = append(hdr, berEncodeIntegerTLV(usmSecurityModel)...)
+	hdrSeq := berEncodeTLV(tagSequence, hdr)
+
+	// scopedPDU: contextEngineID, contextName, GetRequest PDU for one OID.
+	scopedBody := berEncodeTLV(tagOctetString, engineID)
+	scopedBody = append(scopedBody, berEncodeTLV(tagOctetString, contextName)...)
+	vb := berEncodeTLV(tagObjectIdentifier, berEncodeOID(oid))
+	vb = append(vb, berEncodeTLV(tagNull, nil)...)
+	vbList := berEncodeTLV(tagSequence, berEncodeTLV(tagSequence, vb))
+	pduBody := berEncodeIntegerTLV(77)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, berEncodeIntegerTLV(0)...)
+	pduBody = append(pduBody, vbList...)
+	scopedBody = append(scopedBody, berEncodeTLV(pduTag, pduBody)...)
+	scopedPDU := berEncodeTLV(tagSequence, scopedBody)
+
+	msgBody := berEncodeIntegerTLV(snmpVersion3)
+	msgBody = append(msgBody, hdrSeq...)
+	msgBody = append(msgBody, usmOctet...)
+	msgBody = append(msgBody, scopedPDU...)
+	wholeMsg := berEncodeTLV(tagSequence, msgBody)
+
+	start, end, ok := usmAuthParamsRange(wholeMsg)
+	if !ok || end-start != truncLen {
+		t.Fatalf("usmAuthParamsRange failed on built request (ok=%v len=%d)", ok, end-start)
+	}
+	mac := hmac.New(hashFn, authKey)
+	mac.Write(wholeMsg)
+	computed := mac.Sum(nil)[:truncLen]
+	copy(wholeMsg[start:end], computed)
+	return wholeMsg
+}
+
+// scopedContextName decodes the contextName field out of a v3 GetResponse so a
+// test can assert the agent echoes the requested context. It walks: outer
+// SEQUENCE -> version -> msgGlobalData SEQUENCE -> msgSecurityParameters OCTET
+// STRING -> scopedPDU SEQUENCE -> contextEngineID, contextName.
+func scopedContextName(t *testing.T, resp []byte) []byte {
+	t.Helper()
+	tag, msgBody, err := berDecodeHeader(resp)
+	if err != nil || tag != tagSequence {
+		t.Fatalf("resp: outer SEQUENCE decode failed: %v", err)
+	}
+	_, rest, err := berDecodeInteger(msgBody) // version
+	if err != nil {
+		t.Fatalf("resp: version decode failed: %v", err)
+	}
+	hdrLen := berEncodedLen(rest) // msgGlobalData SEQUENCE
+	if hdrLen <= 0 || hdrLen >= len(rest) {
+		t.Fatalf("resp: msgGlobalData length error")
+	}
+	afterHdr := rest[hdrLen:]
+	_, afterSec, err := berDecodeOctetString(afterHdr) // msgSecurityParameters
+	if err != nil {
+		t.Fatalf("resp: msgSecurityParameters decode failed: %v", err)
+	}
+	tag, scopedBody, err := berDecodeHeader(afterSec) // scopedPDU SEQUENCE
+	if err != nil || tag != tagSequence {
+		t.Fatalf("resp: scopedPDU not a SEQUENCE (tag=0x%02x err=%v)", tag, err)
+	}
+	_, ctxRest, err := berDecodeOctetString(scopedBody) // contextEngineID
+	if err != nil {
+		t.Fatalf("resp: contextEngineID decode failed: %v", err)
+	}
+	ctxName, _, err := berDecodeOctetString(ctxRest) // contextName
+	if err != nil {
+		t.Fatalf("resp: contextName decode failed: %v", err)
+	}
+	return ctxName
+}
+
+// TestV3DefaultContextServed verifies that a GetRequest with an EMPTY (default)
+// contextName still returns the real MIB value for sysDescr — i.e. the context
+// gate does not regress the default context.
+func TestV3DefaultContextServed(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 5, 1000)
+	pkt := buildV3ContextRequest(t, "sha", "tuser", engineID, authKey, 5, 1000, nil, oidSysDescr)
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if resp == nil {
+		t.Fatal("default-context request: got nil response")
+	}
+	// The default sysDescr value must appear in the response.
+	if !bytes.Contains(resp, []byte("xpf stateful firewall")) {
+		t.Fatal("default-context request: response missing sysDescr value")
+	}
+	if got := scopedContextName(t, resp); len(got) != 0 {
+		t.Fatalf("default-context request: response contextName = %q, want empty", got)
+	}
+}
+
+// TestV3NonDefaultContextEmptyView is the core context-gate test. A GetRequest
+// for a NON-DEFAULT context ("vrf-red") must NOT be served default-context data:
+// the sysDescr value must be absent and the varbind must be a noSuchInstance
+// exception. fail-on-revert: removing the `if !defaultContext` gate in the
+// GetRequest branch makes this request return the sysDescr value -> red.
+func TestV3NonDefaultContextEmptyView(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 5, 1000)
+	ctx := []byte("vrf-red")
+	pkt := buildV3ContextRequest(t, "sha", "tuser", engineID, authKey, 5, 1000, ctx, oidSysDescr)
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if resp == nil {
+		t.Fatal("non-default-context request: got nil response (should be empty-view, not dropped)")
+	}
+	// Must NOT leak the default-context sysDescr value.
+	if bytes.Contains(resp, []byte("xpf stateful firewall")) {
+		t.Fatal("non-default-context request: response leaked default-context sysDescr value")
+	}
+	// Varbind must be a noSuchInstance exception (tag 0x81).
+	if !bytes.Contains(resp, []byte{tagNoSuchInstance, 0x00}) {
+		t.Fatal("non-default-context request: response missing noSuchInstance exception")
+	}
+	// The requested contextName must be echoed back.
+	if got := scopedContextName(t, resp); !bytes.Equal(got, ctx) {
+		t.Fatalf("non-default-context request: response contextName = %q, want %q", got, ctx)
+	}
+}
+
+// TestV3NonDefaultContextGetNextEndOfMib verifies the GetNext branch returns
+// endOfMibView (not default-context data) for a non-default context.
+// fail-on-revert: removing the GetNext-branch gate makes this leak the first
+// MIB OID's value.
+func TestV3NonDefaultContextGetNextEndOfMib(t *testing.T) {
+	a, engineID, authKey := newTimelinessAgent(t, 5, 1000)
+	ctx := []byte("vrf-blue")
+	// GetNext on sysDescr would normally return sysObjectID's value.
+	pkt := buildV3ContextRequestNext(t, "sha", "tuser", engineID, authKey, 5, 1000, ctx, oidSysDescr)
+	a.lastPacket = pkt
+
+	resp := driveV3(t, a, pkt)
+	if resp == nil {
+		t.Fatal("non-default-context GetNext: got nil response")
+	}
+	if bytes.Contains(resp, []byte("xpf stateful firewall")) {
+		t.Fatal("non-default-context GetNext: leaked default-context data")
+	}
+	if !bytes.Contains(resp, []byte{tagEndOfMibView, 0x00}) {
+		t.Fatal("non-default-context GetNext: missing endOfMibView exception")
+	}
+	if got := scopedContextName(t, resp); !bytes.Equal(got, ctx) {
+		t.Fatalf("non-default-context GetNext: contextName = %q, want %q", got, ctx)
+	}
+}
+
+// buildV3ContextRequestNext is buildV3ContextRequest with a GetNext PDU tag.
+func buildV3ContextRequestNext(t *testing.T, authProto, userName string, engineID, authKey []byte, boots, tm int, contextName []byte, oid []int) []byte {
+	t.Helper()
+	return buildV3ContextRequestPDU(t, authProto, userName, engineID, authKey, boots, tm, contextName, oid, pduGetNextRequest)
+}


### PR DESCRIPTION
## Problem (#2611, codex review-041 finding 041-08)

The SNMPv3 scopedPDU `contextEngineID` and `contextName` were decoded in
`handleV3Packet` and then discarded. Get/GetNext/GetBulk/Set were serviced
against the default MIB regardless of the requested context, and every response
carried an empty `contextName`. A request for a **non-default context** (the way
managers address per-VRF / routing-instance views) was answered with
**default-context data** — an operator-confusion and information-exposure gap.

## Fix — empty-view route (fail-closed)

This agent serves a single MIB view in the **default (empty) context** and does
not model per-VRF/routing-instance context views.

**Chosen response: empty view (RFC 3413 §3 / RFC 3412 §4.1).** An unknown
context yields "no matching MIB objects", so:

- **Default context** (empty `contextName`): served exactly as before — no
  behavior change, no regression.
- **Non-default context** (any non-empty `contextName`): gated **before** the
  MIB lookup so no default-context value is read or returned —
  - Get → `noSuchInstance` for every varbind
  - GetNext / GetBulk → `endOfMibView` for every varbind
  - Set → `notWritable` (unchanged)
- The response scopedPDU now **echoes the requested `contextName`** (empty for
  the default context) instead of a hard-coded empty string, so the manager sees
  the response is bound to the context it addressed. `contextEngineID` in the
  response is our own engine ID (we are the authoritative engine).

### RFC basis / why empty-view, not a report

Per RFC 3413 §3 and RFC 3412 §4.1 an unknown context has no instances, which
maps directly to the `noSuchInstance` / `endOfMibView` exceptions. This was
preferred over an `authorizationError` or an `snmpUnknownContexts` Report
because it is the standard and simplest result for a single-context agent and
adds no new error-counter MIB objects. The key property is fail-closed: a
manager addressing an unknown context never receives default-context values.

## Validation

New `pkg/snmp/v3_context_test.go`:
- (a) default-context GetRequest still returns the real `sysDescr` value and
  echoes an empty `contextName` (no regression);
- (b) non-default-context GetRequest returns `noSuchInstance` and the response
  does **not** contain the default `sysDescr` value, echoing the requested
  `contextName`;
- (c) non-default GetNext returns `endOfMibView` with no default data.

**fail-on-revert proven:** removing the Get-branch context gate makes test (b)
leak the `sysDescr` value → red.

`go test ./pkg/snmp/...` green (including #2610's USM timeliness tests); `gofmt`
and `go vet` clean. README updated with the context-handling contract.

Closes #2611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi