### PR TITLE
userspace-dp: persist MQFQ V_min cadence counter across drain calls

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,43 @@
 # Action Log
 
+## 2026-06-24 — #2624 fix: MQFQ V_min cadence persists across drain calls
+
+- **Timestamp**: 2026-06-24
+- **Action**: agy review-041 finding 041-01 (LOW, performance). The MQFQ
+  cross-worker V_min sync cadence (`V_MIN_READ_CADENCE = 8`, gating the
+  expensive `participating_v_min_snapshot` peer-slot scan) was defeated
+  because `v_min_pop_count` was a `let mut = 0u32` re-initialized at the
+  top of BOTH `drain_exact_*_to_scratch_flow_fair` fns. Each drain's
+  first pop hit `pop_count == 1`, bypassing the cadence gate and running
+  a full peer-slot Acquire-load scan on every drain call — under
+  low/medium load (many small drains) the scan ran continuously,
+  generating cross-core cache-line ping-pong.
+  - FIX: moved the counter to `VMinQueueState::v_min_pop_count` (persists
+    across drain calls). The cadence is now counted over POPS THAT
+    ACTUALLY PROCEED: a throttled drain breaks WITHOUT advancing the
+    counter (`candidate = persisted+1`; persist only after the gate
+    passes), so the next drain re-checks at the same cadence position —
+    this preserves the #941 hard-cap retry semantics
+    (`vmin_prepared_drain_arms_hard_cap_after_repeated_throttle` stays
+    green). Both flow-fair drains share the one counter; single-writer
+    (owning worker), no atomics — same model as `consecutive_v_min_skips`.
+  - TEST: `vmin_cadence_persists_across_small_drain_calls` drives 17
+    one-pop drains with a participating peer (within lag → gate passes
+    each pop) and asserts the snapshot ran exactly 3 times (pops 1, 8,
+    16) via a new `#[cfg(test)]` `SharedCoSQueueVtimeFloor::snapshot_calls`
+    counter. Fail-on-revert: restoring the per-call `let mut = 0u32`
+    makes it 17 snapshots → red (proven both directions).
+  - Validation: `cargo build --release` green; full
+    `cargo test --release --bin xpf-userspace-dp` 2710 passed, only the
+    known `concurrent_recovery_processes_each_command_exactly_once` flake
+    failed (passes in isolation).
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/drain.rs,
+  userspace-dp/src/afxdp/types/cos.rs,
+  userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs,
+  userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs,
+  userspace-dp/src/afxdp/cos/builders.rs (+ test struct-literal sites),
+  userspace-dp/src/afxdp/cos/README.md, docs/fairness-regimes.md
+
 ## 2026-06-24 — #2616/#2618/#2619 fix: firewall-filter fall-through log metadata
 
 - **Timestamp**: 2026-06-24

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1001,7 +1001,14 @@ the sweep exit `2`; they do not produce a false-green fairness verdict.
   early-broke because the queue's virtual time ran more than
   LAG_THRESHOLD ahead of the slowest participating peer worker's V_min
   (#917/#943). Non-zero under load confirms the cross-worker brake is
-  engaged.
+  engaged. The expensive peer-slot V_min scan that backs this brake is
+  throttled by a per-queue cadence (`V_MIN_READ_CADENCE = 8`): it runs on
+  the first proceeding pop and every 8th pop thereafter. That cadence
+  counter (`VMinQueueState::v_min_pop_count`) PERSISTS across the many
+  small drain calls a queue takes under low/medium load (#2624); a
+  per-call reset would re-arm the full scan on every drain and defeat the
+  cadence, raising cross-core coherency traffic without changing the
+  throttle decision.
 - **`xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
   counter (#1831): V_MIN_CONSECUTIVE_SKIP_HARD_CAP escape-hatch
   activations — after that many back-to-back throttle decisions the

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -92,6 +92,24 @@ mod.rs for further file-level breakdown.
   binding is the same worker that owns the queue's
   `FlowFairState`; therefore `observed_bps` updates and reads do not
   need atomic synchronization.
+- **V_min cadence persists across drain calls (#2624).** The
+  cross-worker V_min sync (`cos_queue_v_min_continue` → the expensive
+  `participating_v_min_snapshot` Acquire-load scan of every peer
+  worker's slot) is rate-limited to the first proceeding pop and every
+  `V_MIN_READ_CADENCE`-th pop thereafter. The cadence counter
+  (`VMinQueueState::v_min_pop_count`) lives on the per-queue runtime, NOT
+  as a `let mut = 0` local re-initialized at the top of each
+  `drain_exact_*_to_scratch_flow_fair` call: under low/medium load the
+  queue is drained in many small batches, so a per-call reset re-armed
+  the mandatory first-pop full scan on EVERY drain, generating continuous
+  cross-core cache-line ping-pong and defeating the cadence. It is
+  counted over POPS THAT ACTUALLY PROCEED — a throttled drain breaks
+  WITHOUT advancing it, so the next drain re-checks at the same cadence
+  position (preserving the #941 hard-cap retry semantics). Both flow-fair
+  drains (Local + Prepared) for a queue run on that queue's single owner
+  worker and share the one counter, so it is a plain `u32` with no
+  atomics — the same single-writer model as the sibling
+  `consecutive_v_min_skips` / `v_min_suspended_remaining` fields.
 - Prepared CoS items may carry frames from another binding in the same
   shared-UMEM group. Queue overflow, capacity rejection, local
   demotion, cross-binding copy, and runtime reset must thread the

--- a/userspace-dp/src/afxdp/cos/builders.rs
+++ b/userspace-dp/src/afxdp/cos/builders.rs
@@ -230,6 +230,7 @@ pub(in crate::afxdp) fn build_cos_interface_runtime(
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
@@ -1260,3 +1260,89 @@ fn vmin_local_hard_cap_suspension_carries_into_prepared_drain() {
         "Prepared drain must consume exactly one queue-level suspension slot",
     );
 }
+
+/// #2624: the V_min cadence (`participating_v_min_snapshot`, the
+/// expensive Acquire-load peer-slot scan) must be honored ACROSS many
+/// small drain calls — not re-armed on the first pop of every call.
+///
+/// `v_min_pop_count` persists on `queue.v_min`, so popping one item per
+/// drain call across 17 calls runs the snapshot only at pops 1, 8, 16
+/// (3 times), not once per call. fail-on-revert: restoring the old
+/// per-call `let mut v_min_pop_count = 0u32;` re-arms the mandatory
+/// first-pop snapshot every call → 17 snapshots → assertion fails.
+#[test]
+fn vmin_cadence_persists_across_small_drain_calls() {
+    let umem = MmapArea::new(2 * 1024 * 1024).expect("umem");
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    let floor = attach_test_vtime_floor(queue, 4, 1);
+    // A peer participates with a HIGH v_min and the local queue_vtime
+    // sits at 0, so the lag check always passes (continue == true) and
+    // every cadence pop reaches the snapshot — isolating the cadence
+    // counter, not the throttle decision.
+    floor.slots[0].publish(u64::MAX - 1);
+    test_flow_fair_state_mut(queue).queue_vtime = 0;
+
+    const PKT: usize = 1500;
+    const CALLS: usize = 17;
+    // One free TX frame and a budget of exactly one packet per call →
+    // each drain pops exactly one item, modelling the many-small-drains
+    // regime under low/medium load where the defect bites.
+    let mut scratch: Vec<(u64, TxRequest)> = Vec::new();
+    for _ in 0..CALLS {
+        cos_queue_push_back(queue, test_cos_item(PKT));
+    }
+
+    for call in 0..CALLS {
+        scratch.clear();
+        let mut free_tx: VecDeque<u64> = VecDeque::new();
+        // Distinct UMEM offset per call so the frame copy succeeds.
+        free_tx.push_back((call as u64) * 2048);
+        let _ = drain_exact_local_items_to_scratch_flow_fair(
+            queue,
+            &mut free_tx,
+            &mut scratch,
+            &umem,
+            PKT as u64,
+            PKT as u64,
+            None,
+        );
+        assert_eq!(
+            scratch.len(),
+            1,
+            "each small drain call should pop exactly one item (call {call})",
+        );
+    }
+
+    // Persistent counter advanced once per pop across all calls.
+    assert_eq!(
+        queue.v_min.v_min_pop_count, CALLS as u32,
+        "v_min_pop_count must persist and count every pop across drain calls",
+    );
+    // Snapshot ran only at pops 1, 8, 16 — three times, NOT once per call.
+    let snapshots = floor
+        .snapshot_calls
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert_eq!(
+        snapshots, 3,
+        "V_min snapshot must run at the cadence (pops 1, 8, 16) across {CALLS} small \
+         drains, not once per call; got {snapshots}",
+    );
+}

--- a/userspace-dp/src/afxdp/cos/queue_service/drain.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/drain.rs
@@ -185,24 +185,35 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
     let suspended = cos_queue_v_min_consume_suspension(queue);
     let mut remaining_root = root_budget;
     let mut remaining_secondary = secondary_budget;
-    let mut v_min_pop_count = 0u32;
     while scratch_local_tx.len() < TX_BATCH_SIZE {
         if free_tx_frames.is_empty() {
             break;
         }
-        // #917 Phase 4: V_min check on drain-batch start (pop_count
-        // transitions 0→1) and every K=8 pops thereafter. Throttle
-        // = early break out of this queue's drain. The fast worker
-        // moves on to next runnable queue (or exits the drain
-        // entirely if all queues throttle); revisits this queue
-        // next round when V_min has likely advanced.
+        // #917 Phase 4: V_min check on the first pop (pop_count == 1)
+        // and every K=8 pops thereafter. Throttle = early break out of
+        // this queue's drain. The fast worker moves on to next runnable
+        // queue (or exits the drain entirely if all queues throttle);
+        // revisits this queue next round when V_min has likely advanced.
+        //
+        // #2624: `v_min_pop_count` PERSISTS on the per-queue runtime
+        // (owner-worker single-writer) across drain calls. The cadence
+        // is counted over POPS THAT ACTUALLY PROCEED, not over drain
+        // invocations: a throttled drain breaks WITHOUT advancing the
+        // counter, so the next drain re-checks at the same cadence
+        // position (preserving the #941 hard-cap retry semantics). Only
+        // a pop that passes the gate advances the counter — so the
+        // mandatory first-pop snapshot fires once and the K=8 cadence
+        // then holds across the many small successful drains under
+        // low/medium load, instead of re-arming the full peer-slot scan
+        // on every drain invocation.
         //
         // #941 Work item D: skip the V_min check entirely when this
         // drain is suspended (hard-cap previously armed).
-        v_min_pop_count = v_min_pop_count.saturating_add(1);
-        if !suspended && !cos_queue_v_min_continue(queue, v_min_pop_count) {
+        let candidate_pop_count = queue.v_min.v_min_pop_count.wrapping_add(1);
+        if !suspended && !cos_queue_v_min_continue(queue, candidate_pop_count) {
             break;
         }
+        queue.v_min.v_min_pop_count = candidate_pop_count;
         // #1229 v7: cap-aware front/pop. target_bps was sampled
         // once at drain-batch start; same value used for every
         // pop in the batch so the eligible-set is stable.
@@ -455,17 +466,26 @@ pub(in crate::afxdp) fn drain_exact_prepared_items_to_scratch_flow_fair(
     // pops at pop_count=1, 8, 16, ... all see the same suspension
     // state. See `cos_queue_v_min_consume_suspension` doc.
     let suspended = cos_queue_v_min_consume_suspension(queue);
-    let mut v_min_pop_count = 0u32;
 
     while scratch_prepared_tx.len() < TX_BATCH_SIZE {
         // #942: V_min check on the Prepared flow-fair drain path,
-        // mirroring the Local-flow wiring. Same K=8 cadence with
-        // mandatory check at pop_count==1 (drain-batch start).
+        // mirroring the Local-flow wiring. Same K=8 cadence with a
+        // mandatory check on the first pop (pop_count == 1).
         // Skipped entirely when the drain is suspended (#941 hard-cap).
-        v_min_pop_count = v_min_pop_count.saturating_add(1);
-        if !suspended && !cos_queue_v_min_continue(queue, v_min_pop_count) {
+        //
+        // #2624: shares the SAME persistent `queue.v_min.v_min_pop_count`
+        // as the Local flow-fair drain — both run on the queue's single
+        // owner worker, so the cadence is honored across BOTH entry
+        // points and across the many small drain calls (no per-call
+        // reset that re-ran the full peer-slot scan every drain). A
+        // throttled drain breaks WITHOUT advancing the counter; only a
+        // pop that passes the gate advances it (see the Local-flow
+        // comment for the full rationale).
+        let candidate_pop_count = queue.v_min.v_min_pop_count.wrapping_add(1);
+        if !suspended && !cos_queue_v_min_continue(queue, candidate_pop_count) {
             break;
         }
+        queue.v_min.v_min_pop_count = candidate_pop_count;
         // #1763 Lever A — fused select+pop (Prepared cap-aware arm).
         // Budget break abandons without popping (1 scan); commit reuses
         // `bucket` (no re-scan). See the Local arm for the invariant.

--- a/userspace-dp/src/afxdp/cos/queue_service/tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/tests.rs
@@ -2202,6 +2202,7 @@ fn restore_cos_local_items_marks_queue_runnable_after_retry() {
             v_min_suspended_remaining: 0,
             v_min_hard_cap_overrides_scratch: 0,
             v_min_throttles_scratch: 0,
+            v_min_pop_count: 0,
         },
         telemetry: crate::afxdp::types::CoSQueueTelemetry {
             drop_counters: CoSQueueDropCounters::default(),
@@ -2272,6 +2273,7 @@ fn restore_cos_prepared_items_marks_queue_runnable_after_retry() {
             v_min_suspended_remaining: 0,
             v_min_hard_cap_overrides_scratch: 0,
             v_min_throttles_scratch: 0,
+            v_min_pop_count: 0,
         },
         telemetry: crate::afxdp::types::CoSQueueTelemetry {
             drop_counters: CoSQueueDropCounters::default(),

--- a/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
+++ b/userspace-dp/src/afxdp/cos/tx_completion_tests.rs
@@ -550,6 +550,7 @@ fn normalize_cos_queue_state_repairs_nonempty_unparked_queue_to_runnable() {
             v_min_suspended_remaining: 0,
             v_min_hard_cap_overrides_scratch: 0,
             v_min_throttles_scratch: 0,
+            v_min_pop_count: 0,
         },
         telemetry: crate::afxdp::types::CoSQueueTelemetry {
             drop_counters: CoSQueueDropCounters::default(),

--- a/userspace-dp/src/afxdp/types/cos.rs
+++ b/userspace-dp/src/afxdp/types/cos.rs
@@ -1125,6 +1125,31 @@ pub(in crate::afxdp) struct VMinQueueState {
     /// (working-as-designed fairness brake) and the hard-cap
     /// override path (escape hatch when the brake is too tight).
     pub(in crate::afxdp) v_min_throttles_scratch: u32,
+    /// #2624: persistent V_min cadence pop counter. The cross-worker
+    /// V_min sync (`cos_queue_v_min_continue` → the expensive
+    /// `participating_v_min_snapshot` Acquire-load scan of every peer
+    /// worker's slot) is rate-limited to the first pop and every
+    /// `V_MIN_READ_CADENCE`-th pop thereafter. This counter MUST persist
+    /// across `drain_exact_*_to_scratch_flow_fair` invocations: under
+    /// low/medium load the queue is drained in many small batches, so a
+    /// per-call `let mut = 0` re-armed the mandatory `pop_count == 1`
+    /// first-pop snapshot on EVERY drain call, defeating the cadence and
+    /// generating continuous cross-core coherency traffic.
+    ///
+    /// Single-writer, no atomics: each `CoSQueueRuntime` instance is
+    /// owned and drained by exactly one worker thread (`worker_id`), the
+    /// same single-writer model the sibling `consecutive_v_min_skips` /
+    /// `v_min_suspended_remaining` fields already rely on. Both
+    /// flow-fair drain fns (Local + Prepared) for a given queue run on
+    /// that one owner worker and share this counter, so the cadence is
+    /// counted across BOTH drain entry points for the queue.
+    ///
+    /// Incremented with `wrapping_add` so the cadence stays live even
+    /// after ~4 billion pops (saturating would freeze at a value that is
+    /// neither 1 nor a multiple of the cadence and silently disable all
+    /// further sync); a single wrap-to-0 just re-runs the snapshot once
+    /// (0 is a multiple of the cadence), which is harmless.
+    pub(in crate::afxdp) v_min_pop_count: u32,
 }
 
 pub(in crate::afxdp) struct CoSQueueTelemetry {

--- a/userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs
+++ b/userspace-dp/src/afxdp/types/shared_cos_lease/vtime.rs
@@ -117,6 +117,14 @@ pub(in crate::afxdp) struct SharedCoSQueueVtimeFloor {
     /// One slot per worker. Index by the worker's
     /// 0-based id.
     pub(in crate::afxdp) slots: Box<[PaddedVtimeSlot]>,
+    /// #2624 test seam: counts how many times the expensive
+    /// `participating_v_min_snapshot` peer-slot scan actually ran.
+    /// This is the exact cost the V_MIN_READ_CADENCE filter throttles,
+    /// so tests assert the cadence (1st pop, then every Kth) is honored
+    /// ACROSS drain calls by reading this counter. Test-only; no
+    /// hot-path cost in release builds.
+    #[cfg(test)]
+    pub(in crate::afxdp) snapshot_calls: std::sync::atomic::AtomicU64,
 }
 
 impl SharedCoSQueueVtimeFloor {
@@ -125,7 +133,11 @@ impl SharedCoSQueueVtimeFloor {
             .map(|_| PaddedVtimeSlot::not_participating())
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        Self { slots }
+        Self {
+            slots,
+            #[cfg(test)]
+            snapshot_calls: std::sync::atomic::AtomicU64::new(0),
+        }
     }
 
     /// Single-pass snapshot of the participating peers' V_min
@@ -159,6 +171,9 @@ impl SharedCoSQueueVtimeFloor {
         &self,
         worker_id: u32,
     ) -> (u32, Option<u64>) {
+        #[cfg(test)]
+        self.snapshot_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let mut participating = 0u32;
         let mut v_min = u64::MAX;
         for (idx, slot) in self.slots.iter().enumerate() {

--- a/userspace-dp/src/afxdp/worker/cos/tests.rs
+++ b/userspace-dp/src/afxdp/worker/cos/tests.rs
@@ -242,6 +242,7 @@ fn build_worker_cos_statuses_aggregates_runtime_by_interface_and_queue() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters,
@@ -420,6 +421,7 @@ fn build_worker_cos_statuses_sums_owner_profile_without_breaking_hist_invariant(
                 v_min_suspended_remaining: 0,
                 v_min_hard_cap_overrides_scratch: 0,
                 v_min_throttles_scratch: 0,
+                v_min_pop_count: 0,
             },
             telemetry: crate::afxdp::types::CoSQueueTelemetry {
                 drop_counters: CoSQueueDropCounters::default(),
@@ -663,6 +665,7 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -710,6 +713,7 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -757,6 +761,7 @@ fn build_worker_cos_statuses_owner_profile_only_surfaces_on_unambiguous_owner_lo
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -958,6 +963,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -1005,6 +1011,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_exact_
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -1165,6 +1172,7 @@ fn build_worker_cos_statuses_owner_profile_stays_zero_for_ambiguous_multi_interf
                 v_min_suspended_remaining: 0,
                 v_min_hard_cap_overrides_scratch: 0,
                 v_min_throttles_scratch: 0,
+                v_min_pop_count: 0,
             },
             telemetry: crate::afxdp::types::CoSQueueTelemetry {
                 drop_counters: CoSQueueDropCounters::default(),
@@ -1375,6 +1383,7 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -1422,6 +1431,7 @@ fn build_worker_cos_statuses_surfaces_distinct_per_queue_drain_telemetry() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),
@@ -2471,6 +2481,7 @@ fn active_flow_buckets_peak_is_max_not_sum_across_workers() {
                     v_min_suspended_remaining: 0,
                     v_min_hard_cap_overrides_scratch: 0,
                     v_min_throttles_scratch: 0,
+                    v_min_pop_count: 0,
                 },
                 telemetry: crate::afxdp::types::CoSQueueTelemetry {
                     drop_counters: CoSQueueDropCounters::default(),


### PR DESCRIPTION
Closes #2624

## Defect (LOW, performance — agy review-041 finding 041-01)

The MQFQ cross-worker V_min sync uses a cadence filter (`V_MIN_READ_CADENCE = 8`): the expensive `participating_v_min_snapshot` — an Acquire-load scan of every peer worker's aligned slot — should run only on the first proceeding pop and every 8th pop thereafter. But `v_min_pop_count` was a `let mut = 0u32` re-initialized at the top of **both** `drain_exact_*_to_scratch_flow_fair` functions (`drain.rs` ~188 and ~458). On the first loop iteration of every drain it incremented to 1, hitting the mandatory `pop_count == 1` path in `cos_queue_v_min_continue`, so the full peer-slot scan ran on **every** drain call. Under low/medium load the queue is drained in many small invocations, so the cadence was effectively disabled — continuous Acquire loads whose peers' Release stores invalidate those cache lines across cores, raising cross-core coherency traffic and jitter for no benefit (the throttle decision is unchanged).

## Fix — where the persistent counter now lives

Moved the counter onto the per-queue runtime as **`VMinQueueState::v_min_pop_count`** (`userspace-dp/src/afxdp/types/cos.rs`), a sibling of the existing `consecutive_v_min_skips` / `v_min_suspended_remaining` per-queue drain state. It persists across drain calls so the mandatory first-pop snapshot fires once and the K=8 cadence holds across the many small drains.

The cadence is counted over **pops that actually proceed**, not over drain invocations: each iteration computes `candidate = persisted + 1`, runs the gate with `candidate`, and persists it **only after the gate passes**. A throttled drain breaks **without** advancing the counter, so the next drain re-checks at the same cadence position. This preserves the #941 hard-cap retry semantics — a queue that throttles `HARD_CAP-1` times in a row still arms suspension on the next call (`vmin_prepared_drain_arms_hard_cap_after_repeated_throttle` stays green). Both flow-fair drains (Local + Prepared) for a queue share the one counter.

`wrapping_add` (not `saturating_add`) so the cadence stays live past ~4 billion pops; a single wrap-to-0 re-runs the snapshot once (0 is a multiple of the cadence) — harmless.

## Ownership / race analysis

No new allocation, no atomics. Each `CoSQueueRuntime` instance is owned and drained by exactly **one** worker thread (`worker_id`) — the same single-writer model the sibling `VMinQueueState` fields already rely on. Both `drain_exact_local_items_to_scratch_flow_fair` and `drain_exact_prepared_items_to_scratch_flow_fair` for a given queue run on that one owner worker, so a plain `u32` field is correct: there is no cross-thread write to this counter. (The peer-slot *values* it gates remain atomic `PaddedVtimeSlot`s with Acquire/Release ordering, unchanged.)

## Cadence-honored-across-calls test

`vmin_cadence_persists_across_small_drain_calls` (`v_min_tests.rs`): a participating peer publishes a high V_min and the local `queue_vtime` is 0 so the lag check always passes (gate returns true → every cadence pop reaches the snapshot, isolating the cadence counter from the throttle decision). It drives **17 one-pop drains** (budget = one packet per call → exactly one pop per call, modelling the many-small-drains regime) and asserts the snapshot ran **exactly 3 times** (pops 1, 8, 16), not once per call. The count is read via a new `#[cfg(test)]` `SharedCoSQueueVtimeFloor::snapshot_calls` seam (no release-build cost) incremented at the top of `participating_v_min_snapshot`.

**Fail-on-revert proof:** restoring the per-call `let mut v_min_pop_count = 0u32;` in the Local drain makes the test report 17 snapshots → red (`left: 0, right: 17` on the persistence assertion). Verified both directions; the fix restores green.

## Validation

- `cargo build --release` green.
- Full `cargo test --release --bin xpf-userspace-dp`: **2710 passed**; only the known `concurrent_recovery_processes_each_command_exactly_once` flake failed and passes in isolation (re-ran: ok).
- Docs updated: `userspace-dp/src/afxdp/cos/README.md` (cadence-persistence invariant + ownership note) and `docs/fairness-regimes.md` (V_min throttle counter section).

The parent will run a CoS per-class smoke on the loss userspace cluster to confirm fairness is intact (this change is fairness-neutral by construction — it only reduces redundant peer-slot scans, not the throttle decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi