### PR TITLE
frr: render regex community members as expanded community-lists (#2643)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,24 @@
 # Action Log
 
+## 2026-06-24 — #2643 fix: FRR community-lists with regex members render `expanded`
+
+- **Timestamp**: 2026-06-24
+- **Action**: agy review-044 finding 044-02 (HIGH). `generatePolicyOptions`
+  always rendered named BGP community members as
+  `bgp community-list standard`. FRR standard community-lists reject
+  regex/wildcard members (`65000:*`, `.*`) at config load, failing the
+  whole `frr-reload` of the managed section. FIX: detect regex
+  metacharacters (`communityMemberIsRegex`, chars `* . + ? ^ $ [ ] ( ) | \`)
+  per member; if ANY member of a definition is regex, render the WHOLE
+  definition as `bgp community-list expanded <name>` (FRR forbids the same
+  name being both standard and expanded). Literal-only definitions stay
+  `standard`. Added render test (standard/expanded/mixed +
+  fail-on-revert: no regex on a standard line, no name as both kinds).
+- **File(s)**: pkg/frr/policy_render.go, pkg/frr/frr_test.go,
+  pkg/frr/README.md, _Log.md
+- **Validation**: `go test ./pkg/frr/...` green; gofmt clean; go vet clean;
+  fail-on-revert proven (force-standard → FRR-invalid assertions fire).
+
 ## 2026-06-24 — #2624 fix: MQFQ V_min cadence persists across drain calls
 
 - **Timestamp**: 2026-06-24

--- a/_Log.md
+++ b/_Log.md
@@ -19,6 +19,25 @@
 - **Validation**: `go test ./pkg/frr/...` green; gofmt clean; go vet clean;
   fail-on-revert proven (force-standard → FRR-invalid assertions fire).
 
+## 2026-06-24 — #2643 review fold: add POSIX-ERE braces `{` `}` to regex set
+
+- **Timestamp**: 2026-06-24
+- **Action**: hostile-review false-negative fold. `communityRegexChars`
+  omitted the POSIX-ERE interval/bound braces `{` `}`. A Junos community
+  member is a free-form verbatim slot (no value validation), so a valid
+  bound member like `65000:1{2,3}` carries no other metachar and was
+  routed to a `standard` list → FRR rejects the brace → the #2643 bug
+  persists for that input. FIX: add `{` `}` to `communityRegexChars`
+  (→ `*.+?^$[]()|\{}`). Added a `BOUND` test case (`65000:1{2,3}` → must
+  render expanded) + brace-specific fail-on-revert. Added a README
+  caveat: expanded-list members match UNANCHORED, so a literal folded
+  into a MIXED expanded list substring-matches (only affects mixed
+  lists; literal-only stays standard/anchored).
+- **File(s)**: pkg/frr/policy_render.go, pkg/frr/frr_test.go,
+  pkg/frr/README.md, _Log.md
+- **Validation**: `go test ./pkg/frr/...` green; gofmt clean; go vet clean;
+  brace fail-on-revert proven (drop `{}` → BOUND renders standard → red).
+
 ## 2026-06-24 — #2624 fix: MQFQ V_min cadence persists across drain calls
 
 - **Timestamp**: 2026-06-24

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -251,6 +251,29 @@ move or rename the markers — they're literal strings.
   warned to add a `from protocol <proto>` (or use a bare protocol token).
   This is the load-bearing invariant: a single unresolvable export can never
   poison the entire managed-section reload.
+- **Community-lists: `standard` vs `expanded` is per-DEFINITION (#2643).**
+  An FRR `standard` community-list accepts ONLY literal community values
+  (`ASN:VALUE`, or a well-known name such as `no-export` /
+  `no-advertise` / `internet` / `local-AS`); it REJECTS any POSIX-regex /
+  wildcard member (`65000:*`, `.*`, `65001:1..`) at config load, and a
+  single rejected line fails the whole `frr-reload` of the managed
+  section, leaving the routing daemon stale/unconfigured for the entire
+  commit. An `expanded` community-list accepts a POSIX regex per member.
+  `generatePolicyOptions` therefore inspects every member of a named
+  community definition: a member containing any of
+  `* . + ? ^ $ [ ] ( ) | \` (`communityMemberIsRegex`) is regex; a plain
+  `digits:digits` or well-known name is literal. If ANY member is regex,
+  the WHOLE definition renders as `bgp community-list expanded <name> …`;
+  otherwise it stays `bgp community-list standard <name> …`. FRR forbids
+  the same list NAME from being declared both standard and expanded, so a
+  MIXED literal+regex definition CANNOT be split across the two kinds —
+  it is rendered entirely as `expanded` (a literal like `65000:100` is a
+  valid regex that matches itself, so it is safe in an expanded list).
+  Members are written as-is (the wildcard `65000:*` becomes the FRR regex
+  verbatim, matching Junos intent); FRR matches community regexes
+  unanchored, which is the desired wildcard behavior. This is the same
+  fail-closed-the-whole-reload class as the route-filter `ge`/`le`
+  bounds above (#1880).
 - `vtysh -c` is run synchronously in batch mode for state queries. There
   is no streaming; long output is buffered.
 - All `vtysh` and `frr-reload.py` shell-outs route through the

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -261,19 +261,23 @@ move or rename the markers — they're literal strings.
   commit. An `expanded` community-list accepts a POSIX regex per member.
   `generatePolicyOptions` therefore inspects every member of a named
   community definition: a member containing any of
-  `* . + ? ^ $ [ ] ( ) | \` (`communityMemberIsRegex`) is regex; a plain
-  `digits:digits` or well-known name is literal. If ANY member is regex,
-  the WHOLE definition renders as `bgp community-list expanded <name> …`;
-  otherwise it stays `bgp community-list standard <name> …`. FRR forbids
-  the same list NAME from being declared both standard and expanded, so a
-  MIXED literal+regex definition CANNOT be split across the two kinds —
-  it is rendered entirely as `expanded` (a literal like `65000:100` is a
-  valid regex that matches itself, so it is safe in an expanded list).
-  Members are written as-is (the wildcard `65000:*` becomes the FRR regex
-  verbatim, matching Junos intent); FRR matches community regexes
-  unanchored, which is the desired wildcard behavior. This is the same
-  fail-closed-the-whole-reload class as the route-filter `ge`/`le`
-  bounds above (#1880).
+  `* . + ? ^ $ [ ] ( ) | \ { }` (`communityMemberIsRegex` —
+  the braces cover POSIX-ERE interval bounds like `65000:1{2,3}`) is
+  regex; a plain `digits:digits` or well-known name is literal. If ANY
+  member is regex, the WHOLE definition renders as
+  `bgp community-list expanded <name> …`; otherwise it stays
+  `bgp community-list standard <name> …`. FRR forbids the same list NAME
+  from being declared both standard and expanded, so a MIXED
+  literal+regex definition CANNOT be split across the two kinds — it is
+  rendered entirely as `expanded`. Members are written as-is (the
+  wildcard `65000:*` becomes the FRR regex verbatim, matching Junos
+  intent). NUANCE: FRR matches expanded community-list members
+  UNANCHORED, so a literal value folded into an expanded list (the MIXED
+  case) matches as a substring — `65000:100` would also match
+  `65000:1000` / `165000:100`. This only affects MIXED definitions
+  (uncommon); a literal-only definition stays `standard` (anchored exact
+  match) and is unaffected. This is the same fail-closed-the-whole-reload
+  class as the route-filter `ge`/`le` bounds above (#1880).
 - `vtysh -c` is run synchronously in batch mode for state queries. There
   is no streaming; long output is buffered.
 - All `vtysh` and `frr-reload.py` shell-outs route through the

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -3069,6 +3069,14 @@ func TestGeneratePolicyOptionsCommunityExpandedVsStandard(t *testing.T) {
 				Name:    "MIXED",
 				Members: []string{"65000:100", "65001:.*"},
 			},
+			// POSIX-ERE interval/bound braces are regex too — the member
+			// carries none of `* . + ? ^ $ [ ]`, so it relies on `{` `}`
+			// being in communityRegexChars to route to an expanded list
+			// (#2643 follow-up false-negative).
+			"BOUND": {
+				Name:    "BOUND",
+				Members: []string{"65000:1{2,3}"},
+			},
 		},
 	}
 
@@ -3085,6 +3093,8 @@ func TestGeneratePolicyOptionsCommunityExpandedVsStandard(t *testing.T) {
 		// same list name cannot be both kinds in FRR.
 		"bgp community-list expanded MIXED permit 65000:100",
 		"bgp community-list expanded MIXED permit 65001:.*",
+		// Brace-bound member must render expanded, not standard.
+		"bgp community-list expanded BOUND permit 65000:1{2,3}",
 	}
 	for _, want := range wantLines {
 		if !strings.Contains(got, want) {
@@ -3115,6 +3125,9 @@ func TestGeneratePolicyOptionsCommunityExpandedVsStandard(t *testing.T) {
 	}
 	if strings.Contains(got, "bgp community-list standard WILD ") {
 		t.Errorf("WILD list must NOT appear as standard:\n%s", got)
+	}
+	if strings.Contains(got, "bgp community-list standard BOUND ") {
+		t.Errorf("BOUND (brace-bound regex) list must NOT appear as standard:\n%s", got)
 	}
 }
 

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -3043,6 +3043,81 @@ func TestGeneratePolicyOptionsCommunityListAndMetricType(t *testing.T) {
 	}
 }
 
+// TestGeneratePolicyOptionsCommunityExpandedVsStandard pins the #2643
+// fix: a community definition with a regex/wildcard member must render as
+// an FRR `expanded` community-list (which accepts POSIX regex), NOT
+// `standard` (which rejects regex at config load and fails the whole
+// frr-reload). A literal-only definition stays `standard`, and a MIXED
+// definition (any regex member) renders the WHOLE list as `expanded`
+// because FRR forbids the same name being both standard and expanded.
+func TestGeneratePolicyOptionsCommunityExpandedVsStandard(t *testing.T) {
+	m := &Manager{frrConf: "/dev/null"}
+	po := &config.PolicyOptionsConfig{
+		Communities: map[string]*config.CommunityDef{
+			// Literal-only -> standard.
+			"LIT-ONLY": {
+				Name:    "LIT-ONLY",
+				Members: []string{"65000:100", "no-export"},
+			},
+			// Wildcard member -> expanded (whole list).
+			"WILD": {
+				Name:    "WILD",
+				Members: []string{"65000:*"},
+			},
+			// Mixed literal + regex -> whole list expanded.
+			"MIXED": {
+				Name:    "MIXED",
+				Members: []string{"65000:100", "65001:.*"},
+			},
+		},
+	}
+
+	got := m.generatePolicyOptions(po)
+
+	wantLines := []string{
+		// Literal-only definition keeps standard.
+		"bgp community-list standard LIT-ONLY permit 65000:100",
+		"bgp community-list standard LIT-ONLY permit no-export",
+		// Wildcard member renders the member as-is into an expanded list.
+		"bgp community-list expanded WILD permit 65000:*",
+		// Mixed definition: BOTH members go into the expanded list — the
+		// literal member must NOT regress to a standard line, since the
+		// same list name cannot be both kinds in FRR.
+		"bgp community-list expanded MIXED permit 65000:100",
+		"bgp community-list expanded MIXED permit 65001:.*",
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+
+	// fail-on-revert: forcing a wildcard/regex member onto a standard
+	// list is exactly the FRR-invalid config that fails the reload. No
+	// standard community-list line may carry a regex metacharacter, and
+	// no name may appear as both standard and expanded.
+	for _, line := range strings.Split(got, "\n") {
+		if !strings.HasPrefix(line, "bgp community-list standard ") {
+			continue
+		}
+		// fields: bgp community-list standard <name> permit <member>
+		fields := strings.Fields(line)
+		if len(fields) != 6 {
+			t.Fatalf("unexpected standard community-list line shape: %q", line)
+		}
+		member := fields[5]
+		if strings.ContainsAny(member, communityRegexChars) {
+			t.Errorf("FRR-invalid: regex member %q on a standard community-list line: %q", member, line)
+		}
+	}
+	if strings.Contains(got, "bgp community-list standard MIXED ") {
+		t.Errorf("MIXED list must NOT appear as standard (would collide with its expanded form):\n%s", got)
+	}
+	if strings.Contains(got, "bgp community-list standard WILD ") {
+		t.Errorf("WILD list must NOT appear as standard:\n%s", got)
+	}
+}
+
 func TestGenerateProtocols_BGPDampening(t *testing.T) {
 	m := New()
 	bgp := &config.BGPConfig{

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -1035,8 +1035,12 @@ func partitionRouteFiltersByFamily(rfs []*config.RouteFilter) (v4, v6 []indexedR
 // member means it cannot be a plain literal ASN:VALUE (or well-known
 // name) and therefore requires an FRR `expanded` community-list (POSIX
 // regex) rather than a `standard` one. A standard list rejects any of
-// these at config load, failing the whole frr-reload (#2643).
-const communityRegexChars = `*.+?^$[]()|\`
+// these at config load, failing the whole frr-reload (#2643). The set
+// includes the POSIX-ERE interval/bound braces `{` `}` — a Junos
+// community member is a free-form verbatim string slot (no value
+// validation; the compiler copies it straight through), so a legitimate
+// bound operator like `65000:1{2,3}` must route to an expanded list too.
+const communityRegexChars = `*.+?^$[]()|\{}`
 
 // communityMemberIsRegex reports whether a Junos community member value
 // contains regex / wildcard metacharacters and must be rendered into an

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -1031,6 +1031,22 @@ func partitionRouteFiltersByFamily(rfs []*config.RouteFilter) (v4, v6 []indexedR
 	return v4, v6
 }
 
+// communityRegexChars are the characters whose presence in a community
+// member means it cannot be a plain literal ASN:VALUE (or well-known
+// name) and therefore requires an FRR `expanded` community-list (POSIX
+// regex) rather than a `standard` one. A standard list rejects any of
+// these at config load, failing the whole frr-reload (#2643).
+const communityRegexChars = `*.+?^$[]()|\`
+
+// communityMemberIsRegex reports whether a Junos community member value
+// contains regex / wildcard metacharacters and must be rendered into an
+// FRR `expanded` community-list. A plain `ASN:VALUE` (digits:digits) or a
+// well-known name ("no-export", "no-advertise", "internet", "local-AS")
+// contains none of these and stays a `standard` member.
+func communityMemberIsRegex(member string) bool {
+	return strings.ContainsAny(member, communityRegexChars)
+}
+
 // generatePolicyOptions emits FRR prefix-list / route-map / community-list /
 // as-path-access-list config from the typed Junos policy-options.
 func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig) string {
@@ -1064,8 +1080,25 @@ func (m *Manager) generatePolicyOptions(po *config.PolicyOptionsConfig) string {
 	sort.Strings(commNames)
 	for _, name := range commNames {
 		cd := po.Communities[name]
+		// FRR standard community-lists only accept literal community
+		// values (ASN:VALUE or well-known names); they REJECT regex /
+		// wildcard members (e.g. "65000:*", ".*") at config load, which
+		// fails the whole frr-reload of the managed section. An expanded
+		// community-list accepts a POSIX regex per member. FRR does NOT
+		// allow the same list NAME to be both standard and expanded, so
+		// the decision is per-DEFINITION: if ANY member is a regex/
+		// wildcard, the ENTIRE definition is rendered as `expanded`
+		// (literal members are valid regexes that match themselves);
+		// otherwise it stays `standard` (#2643).
+		listKind := "standard"
 		for _, member := range cd.Members {
-			fmt.Fprintf(&b, "bgp community-list standard %s permit %s\n", name, member)
+			if communityMemberIsRegex(member) {
+				listKind = "expanded"
+				break
+			}
+		}
+		for _, member := range cd.Members {
+			fmt.Fprintf(&b, "bgp community-list %s %s permit %s\n", listKind, name, member)
 		}
 	}
 	if len(po.Communities) > 0 {


### PR DESCRIPTION
Closes #2643

## Defect (HIGH — FRR config load failure)
`generatePolicyOptions` (`pkg/frr/policy_render.go`) always rendered named
BGP community members as `bgp community-list standard <name> permit <member>`.
FRR standard community-lists accept **only** literal community values
(`ASN:VALUE` or a well-known name like `no-export`); they **reject** regex /
wildcard members (`65000:*`, `.*`, `65001:1..`) at config load. A single
rejected line fails the entire `frr-reload` of the managed section, leaving
the routing daemon stale/unconfigured for the whole commit. (agy review-044
finding 044-02.)

## Fix
Classify each member with `communityMemberIsRegex` — true when it contains any
of `* . + ? ^ $ [ ] ( ) | \`. A plain `digits:digits` or well-known name has
none of these and is literal.

### standard-vs-expanded decision (per-DEFINITION)
- If **no** member of a named community is regex → `bgp community-list standard`.
- If **any** member is regex → the **whole** definition renders as
  `bgp community-list expanded <name>`.

### Why the whole list, including mixed definitions
FRR forbids the same list **name** from being declared both `standard` and
`expanded` (a name owns exactly one kind). So a definition that mixes literal
and regex members **cannot** be split across the two kinds — it is rendered
entirely as `expanded`. This is safe: a literal like `65000:100` is a valid
POSIX regex that matches itself, so it functions correctly inside an expanded
list. We do **not** split one name across both types.

### Member rendering / anchoring
Members are written **verbatim** — the Junos wildcard `65000:*` becomes the FRR
regex `65000:*` as-is. FRR matches community regexes **unanchored**, which is
exactly the Junos wildcard intent, so no anchoring is added.

This is the same fail-closed-the-whole-reload class as the route-filter
`ge`/`le` bounds handling (#1880).

## Validation
- New render test `TestGeneratePolicyOptionsCommunityExpandedVsStandard`:
  literal-only → `standard`; wildcard → `expanded`; mixed literal+regex →
  whole list `expanded`. Asserts FRR-validity: no `standard` community-list
  line carries a regex metacharacter, and no name appears as both kinds.
- **fail-on-revert proven**: forcing `standard` rendering for a wildcard
  member turns the test red (FRR-invalid-line + both-kinds assertions fire).
- `go test ./pkg/frr/...` green; `gofmt -w` + `go vet` clean.
- `pkg/frr/README.md` documents the community-list standard-vs-expanded rule;
  `_Log.md` updated.

Note: the parent will run an frr-active smoke to confirm FRR loads the
generated `expanded` community-list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi