### PR TITLE
dhcpserver: assign Kea subnet_id over a reload-stable order (#2668)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,22 @@
 # Action Log
 
+## 2026-06-24 — #2668 stable Kea subnet_id assignment
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed Kea `subnet_id` being assigned over the randomized Go
+  map iteration of `Groups`, which shifted IDs on every config regeneration
+  and remapped active memfile leases onto the wrong subnet. Added
+  `stableGroups` (sort groups by name) and `stablePools` (sort pools by
+  subnet then name); both `generateKea4Config` and `generateKea6Config` now
+  iterate the deterministic order, and the `interfaces-config` collection
+  loops use the sorted group order too. Stability level: sorted-by-name
+  (fixes the randomization; add/remove may still shift later IDs — justified
+  in the README). Added `TestKeaSubnetIDStableAcrossRegenerations` (3-group
+  multi-pool config, 50 regens, golden subnet→id map, v4+v6) — proven
+  fail-on-revert (5/5 red with the map-range restored).
+- **File(s)**: pkg/dhcpserver/dhcpserver.go, pkg/dhcpserver/dhcpserver_test.go,
+  pkg/dhcpserver/README.md, _Log.md
+
 ## 2026-06-24 — #2648 fold: refused-add records NO ownership (review MAJOR-1)
 
 - **Timestamp**: 2026-06-24

--- a/pkg/dhcpserver/README.md
+++ b/pkg/dhcpserver/README.md
@@ -113,6 +113,41 @@ subtree with an IPv6 `fixed-address`.)
   separate companion gap, #2239.) ISC Kea handles static reservations
   entirely in the config file, independent of its HA hook.
 
+## Stable subnet IDs — #2668
+
+`generateKea4Config`/`generateKea6Config` assign each rendered subnet a Kea
+`subnet_id` (the `id` field of `subnet4`/`subnet6`). Kea binds memfile leases
+(`kea-leases4.csv`/`kea-leases6.csv`) to a subnet by the `subnet_id` COLUMN,
+so the ID a subnet receives MUST be stable across config regenerations
+(commit / reload) — a shifted ID remaps live leases onto the wrong
+subnet/pool and corrupts diagnostics, lease-sync, and DDNS (which keys
+desired records by SubnetID, #2663).
+
+The IDs are assigned over a DETERMINISTIC order:
+
+- **Groups** are sorted by name (`stableGroups`). The config holds groups in
+  a Go map, whose iteration order is RANDOMIZED — ranging it directly was the
+  #2668 bug: the same subnet could get a different `subnet_id` on every
+  regeneration of an UNCHANGED config.
+- **Pools** within a group are sorted by subnet, then name (`stablePools`),
+  so a pool keeps its `subnet_id` even if it is reordered within the group's
+  config list. The subnet string is the natural key Kea binds a lease to.
+- The `interfaces-config.interfaces` list is collected over the same sorted
+  group order, so it is deterministic too.
+
+Stability level: SORTED-BY-NAME (not a persisted name→id map). This removes
+the randomization — the actual reported defect — so an unchanged config
+always renders identical `subnet_id`s. The weaker guarantee is that
+INSERTING a group/pool whose sort key lands in the middle shifts the IDs of
+all later subnets (a persistent name→id store would avoid that). Add/remove
+is a deliberate operator config change, not the per-reload churn #2668 is
+about, and a persisted ID map adds a new on-disk state file plus its own
+HA-sync and stale-entry-GC concerns; the regression guard
+(`TestKeaSubnetIDStableAcrossRegenerations`) pins the sorted ordering and is
+the failure mode that bit production. If add/remove lease-remapping becomes a
+concern, layering a persistent map on top of this stable order is the next
+increment.
+
 ## Expired-lease reclamation — #1387 (stale-lease-cleanup slice / Path S)
 
 The "stale lease cleanup" half of #1387. Kea keeps an expired / released /
@@ -466,7 +501,8 @@ What increment 2 ships (the feasible, CI-testable slice):
   ONLY its own MASTER-RG leases — the two nodes' input sets are disjoint by RG
   ownership, so dueling writers are impossible. The gate reads
   `snapshotRethMasterState` ONLY (the same source the Kea manager uses), never
-  the map-order-assigned, per-render-unstable `subnet_id`. A BACKUP-for-all
+  the `subnet_id` (which is now reload-stable per #2668, but the gate still
+  reads RG master state, not the ID). A BACKUP-for-all
   node STOPS WRITING — it does NOT withdraw valid records (the peer MASTER
   owns them; deletion is lease-state / config-removal driven only). The
   async-takeover ordering (Kea `ApplyAsync` may lag the DDNS nudge) is benign:

--- a/pkg/dhcpserver/dhcpserver.go
+++ b/pkg/dhcpserver/dhcpserver.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -714,6 +715,48 @@ func keaExpiredLeasesMap(c *config.DHCPExpiredLeasesConfig) map[string]any {
 	return m
 }
 
+// stableGroups returns the DHCP server groups in a DETERMINISTIC,
+// reload-stable order (#2668). The config holds groups in a Go map whose
+// iteration order is randomized, so assigning Kea subnet_id over a direct
+// map range produced a different ID for the same subnet on every config
+// regeneration. Sorting by the group name (the map key) gives the same
+// subnet the same subnet_id across reloads of an unchanged config, which is
+// what Kea needs to keep memfile leases bound to the right subnet. The map
+// key is mirrored into DHCPServerGroup.Name by the compiler, but we sort on
+// the authoritative map key so a (hypothetical) name/key mismatch cannot
+// reintroduce nondeterminism.
+func stableGroups(groups map[string]*config.DHCPServerGroup) []*config.DHCPServerGroup {
+	names := make([]string, 0, len(groups))
+	for name := range groups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]*config.DHCPServerGroup, 0, len(names))
+	for _, name := range names {
+		out = append(out, groups[name])
+	}
+	return out
+}
+
+// stablePools returns a group's pools in a deterministic order (#2668).
+// Pools already arrive as a config-declared slice (stable across reloads of
+// an unchanged config), but sorting by the pool subnet (then name) hardens
+// the subnet_id assignment against a pool being reordered within a group:
+// the subnet string is the natural key Kea uses to bind a lease, so a pool
+// keeps its subnet_id even if its position in the group's list shifts. It
+// returns a fresh slice — the caller's config is not mutated.
+func stablePools(pools []*config.DHCPPool) []*config.DHCPPool {
+	out := make([]*config.DHCPPool, len(pools))
+	copy(out, pools)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Subnet != out[j].Subnet {
+			return out[i].Subnet < out[j].Subnet
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
 func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 	type keaPool struct {
 		Pool string `json:"pool"`
@@ -741,8 +784,16 @@ func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 
 	var subnets []keaSubnet4
 	subnetID := 1
-	for _, group := range cfg.DHCPLocalServer.Groups {
-		for _, pool := range group.Pools {
+	// #2668: assign Kea subnet_id over a DETERMINISTIC, reload-stable order.
+	// Ranging the Groups map directly used Go's randomized map-iteration
+	// order, so every config regeneration (commit / reload) could hand the
+	// same subnet a DIFFERENT subnet_id. Kea binds memfile leases
+	// (kea-leases4.csv) to subnets by the subnet_id column, so a shifted ID
+	// remaps live leases onto the wrong subnet. Iterate group names sorted
+	// lexically and pools sorted by their subnet so the SAME logical subnet
+	// always gets the SAME subnet_id across reloads of an unchanged config.
+	for _, group := range stableGroups(cfg.DHCPLocalServer.Groups) {
+		for _, pool := range stablePools(group.Pools) {
 			sub := keaSubnet4{
 				ID:     subnetID,
 				Subnet: pool.Subnet,
@@ -798,9 +849,10 @@ func (m *Manager) generateKea4Config(cfg *config.DHCPServerConfig) error {
 		}
 	}
 
-	// Collect interfaces
+	// Collect interfaces. Sorted group order (#2668) also keeps this list
+	// deterministic across reloads.
 	var ifaces []string
-	for _, group := range cfg.DHCPLocalServer.Groups {
+	for _, group := range stableGroups(cfg.DHCPLocalServer.Groups) {
 		ifaces = append(ifaces, group.Interfaces...)
 	}
 
@@ -855,8 +907,12 @@ func (m *Manager) generateKea6Config(cfg *config.DHCPServerConfig) error {
 
 	var subnets []keaSubnet6
 	subnetID := 1
-	for _, group := range cfg.DHCPv6LocalServer.Groups {
-		for _, pool := range group.Pools {
+	// #2668: same reload-stable subnet_id ordering as the v4 path. Kea binds
+	// kea-leases6.csv leases by subnet_id, so the randomized map-iteration
+	// order had to be replaced by a deterministic sort to keep active leases
+	// pinned to their subnet across reloads.
+	for _, group := range stableGroups(cfg.DHCPv6LocalServer.Groups) {
+		for _, pool := range stablePools(group.Pools) {
 			sub := keaSubnet6{
 				ID:     subnetID,
 				Subnet: pool.Subnet,
@@ -914,8 +970,9 @@ func (m *Manager) generateKea6Config(cfg *config.DHCPServerConfig) error {
 		}
 	}
 
+	// Sorted group order (#2668) keeps this list deterministic across reloads.
 	var ifaces []string
-	for _, group := range cfg.DHCPv6LocalServer.Groups {
+	for _, group := range stableGroups(cfg.DHCPv6LocalServer.Groups) {
 		ifaces = append(ifaces, group.Interfaces...)
 	}
 

--- a/pkg/dhcpserver/dhcpserver_test.go
+++ b/pkg/dhcpserver/dhcpserver_test.go
@@ -1055,3 +1055,145 @@ func TestApplyAsyncConcurrentProducersHighestGenWins(t *testing.T) {
 		t.Fatalf("lastAppliedGen = %d, want %d", last, pend.gen)
 	}
 }
+
+// multiGroupV4Config builds a 3-group / multi-pool DHCPv4 config whose
+// stable (sorted) subnet_id assignment is known. Group names are chosen so
+// lexical order (alpha, mid, zeta) differs from any natural map-insert order.
+func multiGroupV4Config() *config.DHCPServerConfig {
+	return &config.DHCPServerConfig{
+		DHCPLocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{
+				"zeta": {Name: "zeta", Interfaces: []string{"ge-0-0-2"}, Pools: []*config.DHCPPool{
+					{Name: "z0", Subnet: "10.0.3.0/24", RangeLow: "10.0.3.10", RangeHigh: "10.0.3.20"},
+				}},
+				"alpha": {Name: "alpha", Interfaces: []string{"ge-0-0-0"}, Pools: []*config.DHCPPool{
+					// Declared out of subnet order to exercise stablePools.
+					{Name: "a1", Subnet: "10.0.1.128/25", RangeLow: "10.0.1.130", RangeHigh: "10.0.1.140"},
+					{Name: "a0", Subnet: "10.0.1.0/25", RangeLow: "10.0.1.10", RangeHigh: "10.0.1.20"},
+				}},
+				"mid": {Name: "mid", Interfaces: []string{"ge-0-0-1"}, Pools: []*config.DHCPPool{
+					{Name: "m0", Subnet: "10.0.2.0/24", RangeLow: "10.0.2.10", RangeHigh: "10.0.2.20"},
+				}},
+			},
+		},
+	}
+}
+
+func multiGroupV6Config() *config.DHCPServerConfig {
+	return &config.DHCPServerConfig{
+		DHCPv6LocalServer: &config.DHCPLocalServerConfig{
+			Groups: map[string]*config.DHCPServerGroup{
+				"zeta": {Name: "zeta", Interfaces: []string{"ge-0-0-2"}, Pools: []*config.DHCPPool{
+					{Name: "z0", Subnet: "2001:db8:3::/64", RangeLow: "2001:db8:3::10", RangeHigh: "2001:db8:3::20"},
+				}},
+				"alpha": {Name: "alpha", Interfaces: []string{"ge-0-0-0"}, Pools: []*config.DHCPPool{
+					{Name: "a1", Subnet: "2001:db8:1:8000::/65", RangeLow: "2001:db8:1:8000::10", RangeHigh: "2001:db8:1:8000::20"},
+					{Name: "a0", Subnet: "2001:db8:1::/65", RangeLow: "2001:db8:1::10", RangeHigh: "2001:db8:1::20"},
+				}},
+				"mid": {Name: "mid", Interfaces: []string{"ge-0-0-1"}, Pools: []*config.DHCPPool{
+					{Name: "m0", Subnet: "2001:db8:2::/64", RangeLow: "2001:db8:2::10", RangeHigh: "2001:db8:2::20"},
+				}},
+			},
+		},
+	}
+}
+
+// subnetIDMap reads the rendered Kea conf and returns subnet -> id.
+func subnetIDMap(t *testing.T, path, family string) map[string]int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	type sub struct {
+		ID     int    `json:"id"`
+		Subnet string `json:"subnet"`
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatal(err)
+	}
+	var inner struct {
+		Subnet4 []sub `json:"subnet4"`
+		Subnet6 []sub `json:"subnet6"`
+	}
+	if err := json.Unmarshal(out["Dhcp"+family], &inner); err != nil {
+		t.Fatal(err)
+	}
+	subs := inner.Subnet4
+	if family == "6" {
+		subs = inner.Subnet6
+	}
+	res := make(map[string]int, len(subs))
+	for _, s := range subs {
+		if prev, dup := res[s.Subnet]; dup {
+			t.Fatalf("duplicate subnet %s (ids %d and %d)", s.Subnet, prev, s.ID)
+		}
+		res[s.Subnet] = s.ID
+	}
+	return res
+}
+
+// TestKeaSubnetIDStableAcrossRegenerations is the #2668 regression guard.
+// Kea binds memfile leases to subnets by the subnet_id column, so the SAME
+// subnet MUST receive the SAME subnet_id on every config regeneration. The
+// assignment used to range the randomized Groups map, so reverting to that
+// makes this test flaky (a wrong mapping eventually appears across the N
+// regenerations); the sorted assignment never does. The expected mapping is
+// the golden sorted order: groups by name (alpha, mid, zeta), pools by
+// subnet within each group.
+func TestKeaSubnetIDStableAcrossRegenerations(t *testing.T) {
+	// Golden expected subnet_id, derived from the deterministic order:
+	//   alpha/10.0.1.0/25=1, alpha/10.0.1.128/25=2, mid/10.0.2.0/24=3,
+	//   zeta/10.0.3.0/24=4.
+	wantV4 := map[string]int{
+		"10.0.1.0/25":   1,
+		"10.0.1.128/25": 2,
+		"10.0.2.0/24":   3,
+		"10.0.3.0/24":   4,
+	}
+	// NOTE: stablePools sorts by the literal subnet STRING, and
+	// "2001:db8:1:8000::/65" < "2001:db8:1::/65" lexically ('8' (0x38) <
+	// ':' (0x3a) at the 4th hextet), so the 8000 half-subnet gets id 1.
+	// The exact ordering does not matter for correctness — only that it is
+	// STABLE — but the golden pins it so an accidental reorder is caught.
+	wantV6 := map[string]int{
+		"2001:db8:1:8000::/65": 1,
+		"2001:db8:1::/65":      2,
+		"2001:db8:2::/64":      3,
+		"2001:db8:3::/64":      4,
+	}
+
+	const regens = 50 // enough to surface map-order randomization on revert
+	for i := 0; i < regens; i++ {
+		mv4, _ := testManager(t, map[string]bool{}, "")
+		if err := mv4.generateKea4Config(multiGroupV4Config()); err != nil {
+			t.Fatalf("generateKea4Config[%d]: %v", i, err)
+		}
+		got := subnetIDMap(t, mv4.confPath4, "4")
+		if !mapsEqualSI(got, wantV4) {
+			t.Fatalf("v4 regen %d: subnet_id mapping %v != golden %v", i, got, wantV4)
+		}
+
+		mv6, _ := testManager(t, map[string]bool{}, "")
+		if err := mv6.generateKea6Config(multiGroupV6Config()); err != nil {
+			t.Fatalf("generateKea6Config[%d]: %v", i, err)
+		}
+		got6 := subnetIDMap(t, mv6.confPath6, "6")
+		if !mapsEqualSI(got6, wantV6) {
+			t.Fatalf("v6 regen %d: subnet_id mapping %v != golden %v", i, got6, wantV6)
+		}
+	}
+}
+
+func mapsEqualSI(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #2668

## Problem
`generateKea4Config` / `generateKea6Config` assigned each subnet a Kea
`subnet_id` sequentially while ranging the `Groups` **Go map**. Map
iteration order is randomized, so every config regeneration (commit /
reload) could hand the same subnet a different `subnet_id`. Kea binds
memfile leases (`kea-leases4.csv` / `kea-leases6.csv`) to a subnet by the
`subnet_id` column, so a shifted ID remaps live leases onto the wrong
subnet/pool — IP conflicts, lease-sync failures, wrong diagnostics, and
broken DDNS (which keys desired records by SubnetID, #2663).

## Fix
Iterate a deterministic order:
- `stableGroups` sorts groups by name (the authoritative map key).
- `stablePools` sorts a group's pools by subnet then name, so a pool keeps
  its `subnet_id` even if reordered in the group's config list (it copies
  before sorting — the caller's config is not mutated).
- Both the **v4 and v6** render paths use the sorted order, and the
  `interfaces-config` collection loops do too so that list is deterministic.

## Stability level — sorted-by-name (not a persistent name→id map)
This removes the randomization (the actual defect), so an **unchanged**
config always renders identical `subnet_id`s. Inserting a group/pool whose
sort key lands mid-list still shifts later IDs — a persistent name→id store
would avoid that, but it is a deliberate operator config change rather than
the per-reload churn #2668 is about, and a persisted map adds a new on-disk
state file plus its own HA-sync and stale-GC concerns. The README documents
the trade-off and the next increment if add/remove remapping becomes a
concern. Sorted-by-name is the floor that fixes the reported bug.

## Coverage
- v4 path ✅ + v6 path ✅.

## Validation
- New `TestKeaSubnetIDStableAcrossRegenerations`: 3-group multi-pool config
  (group names ordered so lexical order differs from insert order; one
  group's pools declared out of subnet order), regenerated **50×** for both
  families, asserting the subnet→id map matches a **golden sorted order**
  every time.
- **Fail-on-revert proven**: restoring the direct map-range makes the test
  fail **5/5** runs.
- `go test ./pkg/dhcpserver/...` green, `gofmt` clean, `go vet` clean.
- Docs: `pkg/dhcpserver/README.md` gets a "Stable subnet IDs — #2668"
  section + corrects the stale "per-render-unstable subnet_id" DDNS note;
  `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi