### PR TITLE
userspace-dp: flush drained session deltas even with no bindings (#2669)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,38 @@
 # Action Log
 
+## 2026-06-24 — #2669 fix: drained session deltas never discarded when bindings empty
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed a HIGH silent session-sync desync. The worker loop drains
+  the per-worker session-delta ring unconditionally (`drain_deltas` pops
+  permanently), but `flush_session_deltas` was gated behind
+  `if let Some(binding) = bindings.first()` at all three drain sites. When
+  `bindings` is empty (XSK sockets admin-down/unconfigured during a
+  reload/transaction while the table still ages entries out), the deltas were
+  drained and then silently discarded — closed/expired sessions never left the
+  shared conntrack/session tables, no `DeleteSynced` reached the HA peer, and
+  no SESSION_CLOSE reached the event stream. Read `flush_session_deltas` to
+  split binding-INDEPENDENT work (shared-table removal, BPF deletes,
+  peer-worker delete replication, recent-deltas buffer, event stream) from the
+  single binding-DEPENDENT step (`BindingLiveState::push_session_delta`).
+  PREFERRED-split fix: `flush_session_deltas` now takes
+  `live: Option<&BindingLiveState>` and flushes every binding-independent
+  consumer unconditionally, gating only the RPC fallback push. Added a
+  `flush_drained_session_deltas!` worker-loop macro that uses
+  `bindings.first()` identity+live+fd when present, else a synthesized
+  labels-only `BindingIdentity` + `None` live + loop-cached (`-1`) map fds (the
+  live session-map delete becomes a harmless EBADF no-op — that map belongs to
+  the absent binding). Applied at ALL THREE sites; composes with the #2442
+  resync `drain_and_flush_all!` (now routes through the new macro, so its drain
+  no longer discards either). Added a fail-on-revert test exercising the
+  `live = None` path: asserts the Close reaches the shared table (cleared), the
+  HA peer queue (`DeleteSynced`), and the recent-deltas buffer; reverting to a
+  binding-gated flush turns it red (proven).
+- **File(s)**: userspace-dp/src/afxdp/session_delta.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  docs/session-sync-architecture.md, _Log.md
+
 ## 2026-06-24 — #2648 fold: refused-add records NO ownership (review MAJOR-1)
 
 - **Timestamp**: 2026-06-24

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -366,6 +366,43 @@ resync is entirely worker-local — it re-uses the same per-worker delta ring an
 incremental sync (the control-socket contention rules in CLAUDE.md). It runs at
 most once per worker poll tick and only when an overflow actually occurred.
 
+### Drained deltas reach binding-independent consumers even with no binding (#2669)
+
+The worker loop drains the delta ring **unconditionally** (`drain_deltas`
+pops entries off permanently) and then calls `flush_session_deltas` to apply
+them. A drain cycle can coincide with an **empty `bindings` slice** — the XSK
+sockets are admin-down or unconfigured during a reload/transaction while the
+session table is still aging entries out. `flush_session_deltas` does much
+more than push into a per-binding queue:
+
+- **binding-INDEPENDENT** (must always run): remove the closed session from
+  the shared session / NAT / forward-wire / owner-RG tables, delete the BPF
+  conntrack + live-session entries, replicate a `DeleteSynced` command to the
+  peer-worker queues (the HA delete-sync path), append to the recent-deltas
+  RPC buffer, and emit to the event stream (HA type-2 session-sync delta plus
+  the RT_FLOW SESSION_CLOSE/SESSION_CREATE frames).
+- **binding-DEPENDENT** (the only step that needs a binding): the per-binding
+  RPC fallback push, `BindingLiveState::push_session_delta` — there is no
+  interface-local RPC queue to push into when no binding exists.
+
+Pre-#2669 the **entire** flush was gated behind `if let Some(binding) =
+bindings.first()`, so when `bindings` was empty the deltas were drained off
+the ring and then silently discarded: closed/expired sessions never left the
+shared conntrack/session tables, no `DeleteSynced` reached the HA peer, and no
+SESSION_CLOSE reached the event stream — a permanent session-state leak and HA
+desync. The fix makes `flush_session_deltas` take `live: Option<&BindingLiveState>`
+and flush every binding-independent consumer unconditionally, gating **only**
+`push_session_delta` on a binding. When no binding exists the worker loop
+synthesizes a labels-only `BindingIdentity` (interface `""`, ifindex `-1`) and
+falls back to the loop-cached map fds (which are `-1`, making the live
+session-map delete a harmless `EBADF` no-op — that live map belongs to the
+absent binding; the shared tables, HA replication, and event stream are the
+consumers that matter). This is applied at **all three** drain sites (the
+#2442 resync `drain_and_flush_all!` macro, the exported-sequences branch, and
+the steady-state else branch) via the shared `flush_drained_session_deltas!`
+macro. The invariant: **a drained delta MUST be flushed to its
+binding-independent consumers — never popped-and-discarded.**
+
 ## Clock Synchronization
 
 At connection setup, both sides exchange monotonic timestamps with `ClockSync`.

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -34,9 +34,22 @@ pub(super) fn purge_queued_flows_for_closed_deltas(
     }
 }
 
+// #2669: `live` is `Option` because a drain cycle can coincide with an
+// empty `bindings` slice (XSK sockets admin-down / unconfigured during a
+// reload or transaction while the session table is still aging entries
+// out). The drained deltas MUST still reach every binding-independent
+// consumer — the shared session/conntrack tables, the peer-worker command
+// queues, the HA delete replication, the recent-deltas RPC buffer, and the
+// event stream — so they are flushed unconditionally below. Only the
+// per-binding RPC fallback push (`live.push_session_delta`) is gated on a
+// binding existing: with no binding there is no interface-local RPC queue
+// to push into. Previously the entire flush was skipped when `bindings`
+// was empty, but the deltas were still drained off the ring — silently
+// discarding session-close/expire events and desynchronizing peers,
+// sibling workers, and CLI/gRPC visibility.
 pub(super) fn flush_session_deltas(
     ident: &BindingIdentity,
-    live: &BindingLiveState,
+    live: Option<&BindingLiveState>,
     session_map_fd: c_int,
     conntrack_v4_fd: c_int,
     conntrack_v6_fd: c_int,
@@ -139,7 +152,12 @@ pub(super) fn flush_session_deltas(
                 || delta.decision.resolution.disposition == ForwardingDisposition::FabricRedirect,
             fabric_ingress: delta.metadata.fabric_ingress,
         };
-        live.push_session_delta(info.clone());
+        // #2669: per-binding RPC fallback push is the ONLY binding-dependent
+        // step. Skipped when no binding exists; every consumer below is
+        // binding-independent and runs regardless.
+        if let Some(live) = live {
+            live.push_session_delta(info.clone());
+        }
         // Push to event stream (new path) alongside existing RPC fallback.
         if let Some(es) = event_stream {
             es.push_delta(delta, zone_name_to_id);

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -4719,3 +4719,117 @@ fn upsert_local_entries_stay_out_of_owner_rg_bulk_export() {
         "peer-synced-origin local-tunnel entries must not bulk-export"
     );
 }
+
+/// #2669: a drained Close delta must reach its binding-INDEPENDENT
+/// consumers (shared session/conntrack tables, HA peer-worker delete
+/// replication, recent-deltas RPC buffer, event stream) even when the
+/// worker has NO bindings — i.e. `flush_session_deltas` is invoked with
+/// `live = None`. The pre-fix code drained the delta off the ring and then
+/// skipped the whole flush when `bindings.first()` was `None`, silently
+/// discarding the close. This test exercises the `live = None` path
+/// directly: reverting the fix (re-gating the flush on a binding, or
+/// passing `&binding.live` only) makes none of these consumers observe the
+/// delete, so the assertions go red — fail-on-revert.
+#[test]
+fn flush_session_deltas_without_binding_reaches_global_consumers() {
+    let key = test_key();
+    let decision = test_decision();
+    let metadata = test_metadata();
+
+    // Seed the shared session table so the Close delete has something to
+    // remove (the binding-independent shared-table consumer).
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let shared_entry = SyncedSessionEntry {
+        key: key.clone(),
+        decision,
+        metadata: metadata.clone(),
+        origin: SessionOrigin::ForwardFlow,
+        protocol: PROTO_TCP,
+        tcp_flags: 0x10,
+        generation: 0,
+    };
+    publish_shared_session(
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &shared_entry,
+    );
+    assert!(
+        !shared_sessions.lock().expect("shared sessions").is_empty(),
+        "precondition: shared session seeded"
+    );
+
+    // One peer-worker command queue — the HA delete-replication sink.
+    let peer_queue: Arc<Mutex<VecDeque<WorkerCommand>>> =
+        Arc::new(Mutex::new(VecDeque::new()));
+    let peer_worker_commands = vec![peer_queue.clone()];
+    let recent_session_deltas = Arc::new(Mutex::new(VecDeque::new()));
+    let forwarding = ForwardingState::default();
+
+    let delta = SessionDelta {
+        kind: SessionDeltaKind::Close,
+        key: key.clone(),
+        decision,
+        metadata,
+        origin: SessionOrigin::ForwardFlow,
+        fabric_redirect_sync: false,
+        created_ns: 0,
+        last_seen_ns: 0,
+    };
+
+    // Synthesize a binding identity with labels only — exactly what the
+    // worker loop does when `bindings` is empty — and flush with NO live
+    // RPC queue and the fd-less (-1) map fds.
+    let ident = BindingIdentity {
+        slot: 0,
+        queue_id: 0,
+        worker_id: 0,
+        interface: Arc::<str>::from(""),
+        ifindex: -1,
+    };
+    flush_session_deltas(
+        &ident,
+        None,
+        -1,
+        -1,
+        -1,
+        &[delta],
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &recent_session_deltas,
+        &peer_worker_commands,
+        &None,
+        &forwarding,
+    );
+
+    // Binding-independent consumer 1: shared session table cleared.
+    assert!(
+        shared_sessions.lock().expect("shared sessions").is_empty(),
+        "Close delta must remove the shared session even with no binding"
+    );
+    // Binding-independent consumer 2: HA peer-worker delete replication.
+    let replicated: Vec<_> = peer_queue
+        .lock()
+        .expect("peer queue")
+        .iter()
+        .cloned()
+        .collect();
+    assert!(
+        replicated
+            .iter()
+            .any(|cmd| matches!(cmd, WorkerCommand::DeleteSynced(k) if *k == key)),
+        "Close delta must replicate a DeleteSynced to the HA peer even with no binding"
+    );
+    // Binding-independent consumer 3: recent-deltas RPC buffer.
+    let recent = recent_session_deltas.lock().expect("recent deltas");
+    assert!(
+        recent.iter().any(|info| info.event == "close"),
+        "Close delta must reach the recent-deltas buffer even with no binding"
+    );
+}

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -122,6 +122,71 @@ pub(crate) fn worker_loop(
     let mut idle_iters = 0u32;
     let mut poll_start = 0usize;
     let mut shared_recycles = Vec::with_capacity((RX_BATCH_SIZE as usize).saturating_mul(2));
+    // #2669: flush a freshly-drained delta batch to its consumers. Used at
+    // all three drain sites (resync macro, exported-sequences branch, else
+    // branch). The drain that produced `$deltas` already popped them off the
+    // ring PERMANENTLY, so this flush MUST run regardless of whether a binding
+    // exists — otherwise the deltas are silently discarded and HA peers,
+    // sibling workers, the shared conntrack/session tables, and CLI/gRPC
+    // visibility diverge (the original bug). When a binding exists we use its
+    // identity + live RPC queue + per-binding session-map fd, exactly as
+    // before. When `bindings` is empty we synthesize a binding identity
+    // (labels only — no XSK), pass `None` for the per-binding RPC queue, and
+    // fall back to the loop-cached map fds (which are `-1`, making the live
+    // session-map delete a harmless EBADF no-op — that map belongs to the
+    // absent binding; the shared tables, HA replication, and event stream are
+    // the consumers that actually matter here).
+    macro_rules! flush_drained_session_deltas {
+        ($deltas:expr) => {{
+            let deltas_ref: &[SessionDelta] = $deltas;
+            match bindings.first() {
+                Some(binding) => {
+                    let ident = binding.identity();
+                    flush_session_deltas(
+                        &ident,
+                        Some(&binding.live),
+                        binding.bpf_maps.session_map_fd,
+                        conntrack_v4_fd,
+                        conntrack_v6_fd,
+                        deltas_ref,
+                        &shared_sessions,
+                        &shared_nat_sessions,
+                        &shared_forward_wire_sessions,
+                        &shared_owner_rg_indexes,
+                        &recent_session_deltas,
+                        &peer_worker_commands,
+                        &event_stream,
+                        forwarding.as_ref(),
+                    );
+                }
+                None => {
+                    let ident = BindingIdentity {
+                        slot: 0,
+                        queue_id: 0,
+                        worker_id,
+                        interface: Arc::<str>::from(""),
+                        ifindex: -1,
+                    };
+                    flush_session_deltas(
+                        &ident,
+                        None,
+                        session_map_fd,
+                        conntrack_v4_fd,
+                        conntrack_v6_fd,
+                        deltas_ref,
+                        &shared_sessions,
+                        &shared_nat_sessions,
+                        &shared_forward_wire_sessions,
+                        &shared_owner_rg_indexes,
+                        &recent_session_deltas,
+                        &peer_worker_commands,
+                        &event_stream,
+                        forwarding.as_ref(),
+                    );
+                }
+            }
+        }};
+    }
     // Debug: periodic summary counters
     let mut dbg_last_report_ns = monotonic_nanos();
     // #1776: the per-interval cfg(debug-log) dbg_* counters are
@@ -796,25 +861,14 @@ pub(crate) fn worker_loop(
                             &mut shared_recycles,
                             &deltas,
                         );
-                        if let Some(binding) = bindings.first() {
-                            let ident = binding.identity();
-                            flush_session_deltas(
-                                &ident,
-                                &binding.live,
-                                binding.bpf_maps.session_map_fd,
-                                conntrack_v4_fd,
-                                conntrack_v6_fd,
-                                &deltas,
-                                &shared_sessions,
-                                &shared_nat_sessions,
-                                &shared_forward_wire_sessions,
-                                &shared_owner_rg_indexes,
-                                &recent_session_deltas,
-                                &peer_worker_commands,
-                                &event_stream,
-                                forwarding.as_ref(),
-                            );
-                        }
+                        // #2669: flush UNCONDITIONALLY. The binding-independent
+                        // consumers (shared session/conntrack tables, HA peer,
+                        // peer-worker commands, recent-deltas RPC buffer, event
+                        // stream) must receive every drained delta even when no
+                        // binding exists; only the per-binding RPC fallback push
+                        // is gated on a binding. Gating the whole flush would
+                        // drain-then-discard, silently desyncing HA/conntrack.
+                        flush_drained_session_deltas!(&deltas);
                     }
                 };
             }
@@ -848,25 +902,8 @@ pub(crate) fn worker_loop(
                     &mut shared_recycles,
                     &deltas,
                 );
-                if let Some(binding) = bindings.first() {
-                    let ident = binding.identity();
-                    flush_session_deltas(
-                        &ident,
-                        &binding.live,
-                        binding.bpf_maps.session_map_fd,
-                        conntrack_v4_fd,
-                        conntrack_v6_fd,
-                        &deltas,
-                        &shared_sessions,
-                        &shared_nat_sessions,
-                        &shared_forward_wire_sessions,
-                        &shared_owner_rg_indexes,
-                        &recent_session_deltas,
-                        &peer_worker_commands,
-                        &event_stream,
-                        forwarding.as_ref(),
-                    );
-                }
+                // #2669: flush unconditionally — see flush_drained_session_deltas!.
+                flush_drained_session_deltas!(&deltas);
             }
             if let Some(sequence) = exported_sequences.iter().copied().max() {
                 session_export_ack.store(sequence, Ordering::Release);
@@ -879,25 +916,8 @@ pub(crate) fn worker_loop(
                 &mut shared_recycles,
                 &deltas,
             );
-            if let Some(binding) = bindings.first() {
-                let ident = binding.identity();
-                flush_session_deltas(
-                    &ident,
-                    &binding.live,
-                    binding.bpf_maps.session_map_fd,
-                    conntrack_v4_fd,
-                    conntrack_v6_fd,
-                    &deltas,
-                    &shared_sessions,
-                    &shared_nat_sessions,
-                    &shared_forward_wire_sessions,
-                    &shared_owner_rg_indexes,
-                    &recent_session_deltas,
-                    &peer_worker_commands,
-                    &event_stream,
-                    forwarding.as_ref(),
-                );
-            }
+            // #2669: flush unconditionally — see flush_drained_session_deltas!.
+            flush_drained_session_deltas!(&deltas);
         }
         // Debug: periodic summary report
         {


### PR DESCRIPTION
Closes #2669

## Defect (HIGH — silent session-sync desync)

The worker loop drains the per-worker session-delta ring **unconditionally**
(`drain_deltas(256)` pops entries off permanently), but `flush_session_deltas`
was gated behind `if let Some(binding) = bindings.first()` at all three drain
sites in `userspace-dp/src/afxdp/worker/loop_body/mod.rs`:

- the #2442 resync `drain_and_flush_all!` macro,
- the exported-sequences branch,
- the steady-state else branch.

When `bindings` is empty — XSK sockets admin-down/unconfigured during a
reload/transaction while the session table is still aging entries out — the
deltas were drained off the ring and then **silently discarded**. Closed/expired
sessions never left the shared conntrack/session tables, no `DeleteSynced`
reached the HA peer, no SESSION_CLOSE reached the event stream, and the
recent-deltas RPC buffer never saw the close — a permanent session-state leak
+ HA desync whenever a drain cycle coincided with empty bindings.

## Split decision: PREFERRED split (not don't-drain)

I read `flush_session_deltas` (`userspace-dp/src/afxdp/session_delta.rs`) to
determine what actually needs a binding:

- **binding-INDEPENDENT** (must always run): shared session/NAT/forward-wire/
  owner-RG table removal, BPF conntrack + live-session deletes, `DeleteSynced`
  replication to the peer-worker queues (HA delete-sync), recent-deltas RPC
  buffer append, event-stream emit (HA type-2 delta + RT_FLOW SESSION_CLOSE/
  SESSION_CREATE).
- **binding-DEPENDENT** (the only step): `BindingLiveState::push_session_delta`,
  the per-binding RPC fallback — no interface-local queue exists with no binding.

The deltas are needed by binding-independent consumers (HA peer / conntrack /
event stream), so the **PREFERRED split** is correct: don't strand HA sync
behind XSK readiness. `flush_session_deltas` now takes
`live: Option<&BindingLiveState>`, flushes every binding-independent consumer
unconditionally, and gates only the RPC fallback push.

A new worker-loop macro `flush_drained_session_deltas!` drives all three sites:
when a binding exists it uses that binding's identity + live queue + per-binding
session-map fd (behavior-identical to before); when empty it synthesizes a
labels-only `BindingIdentity` (interface `""`, ifindex `-1`), passes `None` for
the RPC queue, and falls back to the loop-cached map fds (which are `-1`, making
the live session-map delete a harmless `EBADF` no-op — that live map belongs to
the absent binding; the shared tables / HA replication / event stream are the
consumers that matter).

## Composition with #2442

The #2442 resync `drain_and_flush_all!` macro previously had the same
bindings-gated discard. It now routes its drain through
`flush_drained_session_deltas!`, so the chunked resync drain no longer discards
either. The #2442 loss-signal/resync remains the backstop for genuine ring
overflow; this fix prevents a *different* loss path (drain-then-skip-flush).

**Invariant:** a drained delta MUST be flushed to its binding-independent
consumers — never popped-and-discarded.

## Validation

- `cargo build --release` clean (pre-existing warnings only).
- `cargo test --release --bin xpf-userspace-dp`: **2718 passed, 0 failed**
  (2 ignored).
- **fail-on-revert test** `flush_session_deltas_without_binding_reaches_global_consumers`
  exercises the `live = None` path directly: asserts the Close reaches the
  shared table (cleared), the HA peer queue (`DeleteSynced`), and the
  recent-deltas buffer. Temporarily restoring the binding-gated flush
  (`let Some(_) = live else { return };`) turns it red — verified, then reverted.
- Docs: `docs/session-sync-architecture.md` updated with the
  binding-independent-flush contract; `_Log.md` entry added.

The parent will run `make test-failover` (MANDATORY session-sync gate) before merge.