### PR TITLE
dhcpserver/ddns: own the forward when reverse PTR add fails (#2661)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,40 @@
 # Action Log
 
+## 2026-06-24 — #2661 fix: forward A/AAAA orphaned when reverse PTR update fails
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed a HIGH stale-state bug in the RFC 2136 DDNS backend.
+  `UpsertLease` published the forward A/AAAA first, then the reverse PTR;
+  if the forward SUCCEEDED but the PTR add returned a non-skippable error
+  (SERVFAIL/timeout), it returned a plain error so `upsertLocked` recorded
+  NO ownership — leaving the forward RR LIVE in DNS but untracked, hence
+  orphaned (no later release could withdraw it). Chose RECORD-OWNERSHIP
+  over compensating-delete (the reconcile loop re-runs UpsertLease every
+  cycle, so recording ownership + retrying the PTR converges; the forward
+  stays, the PTR eventually publishes). Added `errDDNSPTRPending` (wraps
+  the cause): `UpsertLease` returns it on a non-skippable PTR failure after
+  a forward success; `upsertLocked` classifies it like a partial success —
+  records ownership with a new `ownedRecord.PTRPending` flag, counts a new
+  `PTRDeferred` counter, logs a WARN, and does NOT fail the pass. The
+  reconcile Pass-1 match branch leaves a PTR-pending record OWNED (never
+  deletes the live forward) but does not mark it settled, so Pass 2 re-runs
+  the idempotent forward re-add and re-attempts the PTR until it lands. A
+  NOTAUTH/REFUSED PTR stays a permanent counted skip (owned, not pending →
+  no retry churn). Surfaced `PTRDeferred` in the CLI/gRPC `show ...
+  dynamic-dns` counters and the Prometheus skipped-total (`ptr-deferred`).
+  Also hardened the stateful fake DNS server so an error rcode override
+  SUPPRESSES the in-memory apply (a real server does not apply a SERVFAILed
+  update), which the PTR-retry test depends on.
+- **File(s)**: pkg/dhcpserver/ddns_rfc2136.go, pkg/dhcpserver/ddns.go,
+  pkg/dhcpserver/ddns_state.go, pkg/dhcpserver/ddns_rfc2136_test.go,
+  pkg/dhcpserver/ddns_manager_inc2_test.go, pkg/api/metrics_system.go,
+  pkg/cli/cli_show_services.go, pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+- **Validation**: `go test -race ./pkg/dhcpserver/...` green; build +
+  go test ./pkg/api ./pkg/cli ./pkg/grpcapi green; gofmt clean; go vet
+  clean on touched files (cli.go:441 unreachable-code is pre-existing on
+  master). fail-on-revert verified: reverting UpsertLease to the plain
+  error turns the new manager + updater tests red (orphaned forward).
+
 ## 2026-06-24 — #2639 fix: Phase-2 dh-group silently dropped the group<N> spelling
 
 - **Timestamp**: 2026-06-24

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -63,6 +63,8 @@ func (c *xpfCollector) collectDDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.SkippedConflict), "conflict")
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSSkippedTotal, prometheus.CounterValue,
 		float64(st.SkippedPTRNotAuth), "ptr-notauth")
+	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSSkippedTotal, prometheus.CounterValue,
+		float64(st.PTRDeferred), "ptr-deferred")
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSOwnedRecords, prometheus.GaugeValue,
 		float64(st.OwnedRecords))
 	var lastTs float64

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -495,6 +495,7 @@ func (c *CLI) showDHCPDynamicDNS(detail bool) error {
 	fmt.Printf("    Reconciles: ok=%d fail=%d\n", st.ReconcileOK, st.ReconcileFail)
 	fmt.Printf("    Skipped:    no-name=%d no-backend=%d conflict=%d ptr-notauth=%d\n",
 		st.SkippedNoName, st.SkippedNoBackend, st.SkippedConflict, st.SkippedPTRNotAuth)
+	fmt.Printf("    PTR deferred: %d (forward published, reverse PTR retry pending)\n", st.PTRDeferred)
 	fmt.Printf("    Owned records: %d\n", st.OwnedRecords)
 	if !st.LastReconcile.IsZero() {
 		fmt.Printf("    Last reconcile: %s (%d leases)\n",

--- a/pkg/dhcpserver/ddns.go
+++ b/pkg/dhcpserver/ddns.go
@@ -93,6 +93,11 @@ type DDNSStats struct {
 	// SkippedConflict counts adds skipped under conflict-policy skip-existing
 	// because the exact RR already existed at the server (plan §4.1).
 	SkippedConflict uint64
+	// PTRDeferred counts upserts where the forward A/AAAA published but the
+	// reverse PTR add failed with a non-skippable (transient) error: ownership
+	// is recorded for the live forward (never orphaned) and the PTR is retried
+	// on the next reconcile (#2661).
+	PTRDeferred uint64
 	// ReconcileOK / ReconcileFail count whole reconcile passes by outcome
 	// (a pass is "fail" when at least one record op errored this cycle).
 	ReconcileOK    uint64
@@ -145,6 +150,7 @@ type DDNSManager struct {
 	skippedNoBackend  atomic.Uint64 // upsert/delete skipped: no live backend wired
 	skippedPTRNotAuth atomic.Uint64 // reverse-zone PTR skipped (NOTAUTH/REFUSED)
 	skippedConflict   atomic.Uint64 // add skipped: exact RR already exists
+	ptrDeferred       atomic.Uint64 // forward published, PTR add failed (retry next cycle)
 	reconcileOK       atomic.Uint64 // reconcile passes with no record-op error
 	reconcileFail     atomic.Uint64 // reconcile passes with >=1 record-op error
 
@@ -426,7 +432,14 @@ func (m *DDNSManager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, l
 		key := ownedRecordKey(owned.Identity, owned.Address)
 		d, stillWanted := want[key]
 		if stillWanted && recordsEqual(owned, d.ow) {
-			d.seen = true // unchanged; no add needed below
+			// The published forward/reverse tuple is unchanged. If the owned
+			// record still owes its reverse PTR (#2661 partial success), leave it
+			// owned (do NOT delete the live forward) but do NOT mark it settled —
+			// fall through so Pass 2 re-runs the upsert and re-attempts the PTR
+			// (the forward re-add is an idempotent no-op).
+			if !owned.PTRPending {
+				d.seen = true // fully published; no add needed below
+			}
 			continue
 		}
 		// Fail-safe (#1387 MAJOR-4): if this owned record's family had an
@@ -527,6 +540,26 @@ func (m *DDNSManager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow o
 			// fail the reconcile pass.
 			return nil
 		}
+		if errors.Is(err, errDDNSPTRPending) {
+			// PARTIAL SUCCESS (#2661): the forward A/AAAA is LIVE in DNS but the
+			// reverse PTR add failed with a non-skippable (transient) error. We
+			// MUST record ownership of the forward so it is tracked + cleanable —
+			// recording NO ownership here (the pre-#2661 behavior) would orphan a
+			// live forward record. Record ownership with PTRPending set so the
+			// next reconcile re-runs UpsertLease (an idempotent forward re-add)
+			// and re-attempts the still-missing PTR. The PTR failure is counted
+			// and logged so it is observable; the reconcile pass is NOT failed
+			// (the forward succeeded and the PTR retry converges on its own), the
+			// same non-fatal treatment as a NOTAUTH skip.
+			m.ptrDeferred.Add(1)
+			slog.Warn("ddns: forward published but reverse PTR add failed; "+
+				"recording ownership with PTR pending for retry next cycle",
+				"fqdn", rec.FQDN, "ptr", rec.PTRName, "err", err)
+			ow.PTRPending = true
+			m.upsertOK.Add(1)
+			m.state.put(ow)
+			return nil
+		}
 		m.upsertFail.Add(1)
 		return err
 	}
@@ -535,6 +568,8 @@ func (m *DDNSManager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow o
 		return nil
 	}
 	m.upsertOK.Add(1)
+	// A fully-successful upsert settles any prior pending-PTR state.
+	ow.PTRPending = false
 	m.state.put(ow)
 	return nil
 }
@@ -643,6 +678,7 @@ func (m *DDNSManager) Stats() DDNSStats {
 		SkippedNoBackend:  m.skippedNoBackend.Load(),
 		SkippedPTRNotAuth: m.skippedPTRNotAuth.Load(),
 		SkippedConflict:   m.skippedConflict.Load(),
+		PTRDeferred:       m.ptrDeferred.Load(),
 		ReconcileOK:       m.reconcileOK.Load(),
 		ReconcileFail:     m.reconcileFail.Load(),
 		OwnedRecords:      n,

--- a/pkg/dhcpserver/ddns_manager_inc2_test.go
+++ b/pkg/dhcpserver/ddns_manager_inc2_test.go
@@ -3,6 +3,7 @@ package dhcpserver
 import (
 	"context"
 	"net"
+	"net/netip"
 	"path/filepath"
 	"testing"
 	"time"
@@ -550,6 +551,186 @@ func TestManagerSkipExistingFreshNameFullLifecycle(t *testing.T) {
 	if srv.zoneHas(a) {
 		t.Errorf("owned A not deleted after expiry")
 	}
+}
+
+// TestManagerForwardPublishedPTRFailsRecordsOwnership is the #2661 regression
+// at the MANAGER level (the layer reconcileOnceLocked drives). The forward A
+// add succeeds but the reverse PTR add returns a NON-skippable error (SERVFAIL).
+// Pre-#2661 the manager recorded NO ownership while the forward was already
+// live in DNS → the forward was ORPHANED (live but untracked, never cleanable).
+// Post-fix the manager records ownership of the live forward with PTRPending so
+// it is tracked + cleanable, and a later release deletes it.
+//
+// fail-on-revert: restoring UpsertLease to return a plain error (no pending
+// sentinel) / upsertLocked to record no ownership on that error re-creates the
+// orphan: cycle 1 OwnedRecords=0 while the A is live, and cycle 2 issues no
+// delete → the A survives in the zone with no owner → this test goes red.
+func TestManagerForwardPublishedPTRFailsRecordsOwnership(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	// The reverse zone always SERVFAILs (a non-skippable, transient error —
+	// NOT NOTAUTH/REFUSED, which is the permanent counted-skip case).
+	srv.setRcode("1.0.10.in-addr.arpa.", dns.RcodeServerFailure)
+
+	m := prodManagerTo(t, srv)
+	cfg := ddnsCfg(srv.addrUDP)
+
+	// Cycle 1: an active v4 lease. Forward A publishes; reverse PTR SERVFAILs.
+	writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.1.5,aa:bb,01:02:03,3600,1900000000,1,laptop,0
+`)
+	writeCSV(t, m.leasePath6, "address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state\n")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 1 must not fail the pass on a PTR-only failure: %v", err)
+	}
+	// The forward A is LIVE in the zone...
+	liveA := &dns.A{Hdr: dns.RR_Header{Name: "laptop.example.com.", Rrtype: dns.TypeA}, A: net.ParseIP("10.0.1.5")}
+	if !srv.zoneHas(liveA) {
+		t.Fatalf("forward A was not published")
+	}
+	// ...and it MUST be owned (tracked + cleanable), not orphaned.
+	if got := m.Stats().OwnedRecords; got != 1 {
+		t.Fatalf("#2661: forward published but NOT owned (orphaned); OwnedRecords=%d want 1 (owned=%v)",
+			got, ownedFQDNs(m))
+	}
+	if got := m.Stats().PTRDeferred; got != 1 {
+		t.Errorf("PTRDeferred = %d, want 1 (the PTR failure must be counted)", got)
+	}
+	// The owned record must be marked PTR-pending so the PTR is retried.
+	if !ownedPTRPending(m, "laptop.example.com") {
+		t.Errorf("owned record not marked PTRPending; the PTR will never be retried")
+	}
+
+	// Cycle 2: PTR zone recovers. The forward re-add is an idempotent no-op and
+	// the still-missing PTR publishes; the record settles (PTRPending cleared).
+	srv.clearRcode("1.0.10.in-addr.arpa.")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 2 (PTR retry): %v", err)
+	}
+	livePTR := &dns.PTR{
+		Hdr: dns.RR_Header{Name: reversePTRName(netip.MustParseAddr("10.0.1.5")) + ".", Rrtype: dns.TypePTR},
+		Ptr: "laptop.example.com.",
+	}
+	if !srv.zoneHas(livePTR) {
+		t.Errorf("reverse PTR was not published on the retry cycle")
+	}
+	if ownedPTRPending(m, "laptop.example.com") {
+		t.Errorf("PTRPending not cleared after a successful PTR retry")
+	}
+
+	// Cycle 3: lease gone — the (now fully-owned) forward is deleted, never
+	// orphaned. This is the no-orphan proof: a release withdraws the forward.
+	writeCSV(t, m.leasePath4, "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state\n")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 3 (release): %v", err)
+	}
+	if srv.zoneHas(liveA) {
+		t.Fatalf("#2661: the forward A was NOT withdrawn on release — it was orphaned")
+	}
+	if m.Stats().OwnedRecords != 0 {
+		t.Errorf("OwnedRecords = %d after release, want 0", m.Stats().OwnedRecords)
+	}
+}
+
+// TestManagerPTRPendingReleaseWithoutRetryStillCleansForward proves the forward
+// is cleanable even if the PTR NEVER recovers: a record stuck PTR-pending is
+// still owned, so when the lease expires the release withdraws the forward
+// (#2661 — the forward is tracked + cleanable regardless of the PTR outcome).
+func TestManagerPTRPendingReleaseWithoutRetryStillCleansForward(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	srv.setRcode("1.0.10.in-addr.arpa.", dns.RcodeServerFailure)
+
+	m := prodManagerTo(t, srv)
+	cfg := ddnsCfg(srv.addrUDP)
+
+	writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.1.5,aa:bb,01:02:03,3600,1900000000,1,laptop,0
+`)
+	writeCSV(t, m.leasePath6, "address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state\n")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	liveA := &dns.A{Hdr: dns.RR_Header{Name: "laptop.example.com.", Rrtype: dns.TypeA}, A: net.ParseIP("10.0.1.5")}
+	if !srv.zoneHas(liveA) || m.Stats().OwnedRecords != 1 {
+		t.Fatalf("forward not owned after PTR failure")
+	}
+
+	// Lease gone while still PTR-pending (PTR zone still broken): the forward
+	// must still be withdrawn (it is OWNED — that is the whole point of #2661).
+	// DeleteLease deletes the forward FIRST, then the PTR; the PTR delete to the
+	// still-broken zone surfaces an error so the reconcile pass reports it and
+	// keeps the ownership entry for a later retry, but the forward A is GONE
+	// from the zone — never orphaned. (Re-deleting an already-gone forward on a
+	// later cycle is an idempotent NXRRSET no-op.)
+	writeCSV(t, m.leasePath4, "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state\n")
+	_ = m.Reconcile(context.Background(), cfg) // PTR-delete error is expected/non-fatal here
+	if srv.zoneHas(liveA) {
+		t.Fatalf("#2661: a PTR-pending forward was NOT cleaned on release — orphaned")
+	}
+	// The forward is withdrawn from DNS; ownership lingers only because the PTR
+	// delete to the broken zone could not complete. Once the PTR zone recovers
+	// the entry clears. Prove no orphan + eventual cleanup: recover the zone.
+	srv.clearRcode("1.0.10.in-addr.arpa.")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 3 (cleanup after PTR zone recovery): %v", err)
+	}
+	if m.Stats().OwnedRecords != 0 {
+		t.Errorf("OwnedRecords = %d after PTR-zone recovery, want 0", m.Stats().OwnedRecords)
+	}
+}
+
+// TestManagerPTRNotAuthOwnedNotPending guards the no-regression case: a NOTAUTH
+// reverse zone (permanently not ours) is a counted SKIP — the forward is owned
+// but NOT marked PTR-pending (there is nothing to retry), so steady state does
+// not churn re-attempting an UPDATE the server will always refuse.
+func TestManagerPTRNotAuthOwnedNotPending(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	srv.setRcode("1.0.10.in-addr.arpa.", dns.RcodeNotAuth)
+
+	m := prodManagerTo(t, srv)
+	cfg := ddnsCfg(srv.addrUDP)
+	writeCSV(t, m.leasePath4, `address,hwaddr,client_id,valid_lifetime,expire,subnet_id,hostname,state
+10.0.1.5,aa:bb,01:02:03,3600,1900000000,1,laptop,0
+`)
+	writeCSV(t, m.leasePath6, "address,duid,valid_lifetime,expire,subnet_id,iaid,hostname,state\n")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 1: %v", err)
+	}
+	if m.Stats().OwnedRecords != 1 {
+		t.Fatalf("forward not owned after a NOTAUTH PTR skip")
+	}
+	if m.Stats().SkippedPTRNotAuth != 1 {
+		t.Errorf("SkippedPTRNotAuth = %d, want 1", m.Stats().SkippedPTRNotAuth)
+	}
+	if m.Stats().PTRDeferred != 0 {
+		t.Errorf("PTRDeferred = %d, want 0 (NOTAUTH is a permanent skip, not a retry)", m.Stats().PTRDeferred)
+	}
+	if ownedPTRPending(m, "laptop.example.com") {
+		t.Errorf("NOTAUTH-skip record must NOT be PTRPending (nothing to retry)")
+	}
+	// Steady state: a second cycle does not re-upsert (no churn) — the record
+	// is settled, not pending.
+	after := m.Stats().UpsertOK
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile 2: %v", err)
+	}
+	if got := m.Stats().UpsertOK; got != after {
+		t.Errorf("NOTAUTH-skip record churned a re-upsert: %d -> %d (want flat)", after, got)
+	}
+}
+
+// ownedPTRPending reports whether the owned record for fqdn is PTR-pending.
+func ownedPTRPending(m *DDNSManager, fqdn string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, r := range m.state.records {
+		if r.FQDN == fqdn {
+			return r.PTRPending
+		}
+	}
+	return false
 }
 
 func TestOwnedRecordViews(t *testing.T) {

--- a/pkg/dhcpserver/ddns_rfc2136.go
+++ b/pkg/dhcpserver/ddns_rfc2136.go
@@ -70,6 +70,22 @@ const defaultDDNSTimeout = 5 * time.Second
 // running on a refused forward and signals the manager not to put().
 var errDDNSConflictRefused = errors.New("ddns: replace-owned add refused (name owned by another party)")
 
+// errDDNSPTRPending is the sentinel UpsertLease returns when the forward
+// A/AAAA add SUCCEEDED but the reverse PTR add failed with a NON-skippable
+// error (timeout, SERVFAIL, etc.). The forward RR is already LIVE in DNS, so
+// the manager (upsertLocked) MUST record ownership of it — otherwise the
+// forward is orphaned: live in the authoritative zone but absent from the
+// ownership store, so no later release can withdraw it (#2661, the exact
+// stale-record class #1387 set out to prevent). It is a PARTIAL success:
+// ownership IS recorded (the forward is tracked + cleanable) but with the
+// PTRPending flag set so the NEXT reconcile re-attempts the PTR (the forward
+// re-add is an idempotent no-op; only the still-missing PTR is published).
+// The wrapped cause carries the underlying PTR error so the manager can log
+// and count it. Distinct from errDDNSConflictRefused (which records NO
+// ownership) and from a NOTAUTH/REFUSED skip (which records ownership with no
+// pending retry, because that reverse zone is permanently not ours).
+var errDDNSPTRPending = errors.New("ddns: forward published but reverse PTR add failed (pending retry)")
+
 // dnsExchanger is the seam the backend uses to talk to the authoritative
 // server. *dns.Client satisfies it; tests inject a recorder so the wire
 // adds/deletes can be asserted without a real socket (though the test
@@ -334,7 +350,15 @@ func (u *rfc2136Updater) UpsertLease(ctx context.Context, rec LeaseDNSRecord) er
 				}
 				return nil
 			}
-			return fmt.Errorf("ddns: reverse upsert PTR %s: %w", rec.PTRName, err)
+			// The forward A/AAAA is already LIVE in DNS but the reverse PTR add
+			// failed with a non-skippable (transient) error. Returning a plain
+			// error here would make the manager record NO ownership, ORPHANING
+			// the live forward (#2661). Instead, return the errDDNSPTRPending
+			// sentinel wrapping the cause: the manager records ownership of the
+			// forward (so it is tracked + cleanable) with PTRPending set, and the
+			// next reconcile re-runs UpsertLease — the forward re-add is an
+			// idempotent no-op and only the still-missing PTR is published.
+			return fmt.Errorf("ddns: reverse upsert PTR %s: %w: %w", rec.PTRName, err, errDDNSPTRPending)
 		}
 	}
 	return nil

--- a/pkg/dhcpserver/ddns_rfc2136_test.go
+++ b/pkg/dhcpserver/ddns_rfc2136_test.go
@@ -149,7 +149,14 @@ func (s *fakeDNSServer) handle(w dns.ResponseWriter, r *dns.Msg) {
 	tcpDelay := s.tcpReplyDelay
 	statefulRcode := 0
 	statefulSet := false
-	if s.stateful {
+	// A real authoritative server that answers an error rcode (SERVFAIL,
+	// NOTAUTH, REFUSED, ...) does NOT apply the update. An explicit error
+	// override therefore SUPPRESSES the stateful apply, so a re-attempt of a
+	// failed update sees the record as still-absent (the #2661 PTR-retry path
+	// depends on this: a PTR that SERVFAILed must not silently land in the
+	// zone, or the retry's name-not-in-use prerequisite would falsely collide).
+	overrideIsError := hasOverride && override != dns.RcodeSuccess
+	if s.stateful && !overrideIsError {
 		statefulRcode = s.evalStatefulLocked(r)
 		statefulSet = true
 	}
@@ -564,6 +571,33 @@ func TestRFC2136PTRNotAuthIsCountedSkipNotFatal(t *testing.T) {
 	}
 	if ptr != 1 {
 		t.Errorf("ptr-notauth skip counter = %d, want 1", ptr)
+	}
+}
+
+// TestRFC2136ForwardPublishedPTRFailReturnsPendingSentinel proves the #2661
+// updater contract: when the forward A publishes but the reverse PTR add fails
+// with a NON-skippable error (SERVFAIL — not NOTAUTH/REFUSED), UpsertLease
+// returns the errDDNSPTRPending sentinel (so the manager records ownership of
+// the live forward instead of orphaning it). The forward A is on the wire.
+func TestRFC2136ForwardPublishedPTRFailReturnsPendingSentinel(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	srv.setRcode("1.0.10.in-addr.arpa.", dns.RcodeServerFailure)
+	var ptr, conf int
+	u := testUpdater(t, srv, &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com"}, &ptr, &conf)
+
+	err := u.UpsertLease(context.Background(), recV4("laptop.example.com", "10.0.1.5", 300))
+	if !errors.Is(err, errDDNSPTRPending) {
+		t.Fatalf("a non-skippable PTR failure after a forward success must return the "+
+			"PTR-pending sentinel (#2661); got %v", err)
+	}
+	// The non-skippable PTR error is NOT counted as a NOTAUTH skip.
+	if ptr != 0 {
+		t.Errorf("ptr-notauth skip counter = %d, want 0 (SERVFAIL is not a NOTAUTH skip)", ptr)
+	}
+	// The forward A is live (the orphan-risk record the manager must now own).
+	if !srv.zoneHas(&dns.A{Hdr: dns.RR_Header{Name: "laptop.example.com.", Rrtype: dns.TypeA}, A: net.ParseIP("10.0.1.5")}) {
+		t.Errorf("forward A was not published")
 	}
 }
 

--- a/pkg/dhcpserver/ddns_state.go
+++ b/pkg/dhcpserver/ddns_state.go
@@ -53,6 +53,16 @@ type ownedRecord struct {
 	// an absent value degrades to the no-DHCID path on delete (safe — the
 	// exact-RR delete still only removes the firewall's own tuple).
 	ClientID string `json:"client_id,omitempty"`
+	// PTRPending marks an ownership record whose forward A/AAAA was published
+	// but whose reverse PTR add failed with a non-skippable (transient) error
+	// (#2661). Ownership is still recorded so the live forward is tracked +
+	// cleanable (never orphaned), and this flag tells the reconciler the PTR
+	// is still owed: a record with PTRPending=true is NOT considered settled,
+	// so the next reconcile re-runs UpsertLease (an idempotent forward re-add)
+	// to re-attempt the PTR. Cleared once the PTR finally publishes. Omitted
+	// from the JSON when false; an absent value (older stores, fully-published
+	// records) degrades to "settled", the safe default.
+	PTRPending bool `json:"ptr_pending,omitempty"`
 }
 
 // ownedRecordKey is the in-memory map key for an owned record: a lease's

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -243,6 +243,7 @@ func (s *Server) showDHCPDynamicDNS(cfg *config.Config, buf *strings.Builder, de
 	fmt.Fprintf(buf, "    Reconciles: ok=%d fail=%d\n", st.ReconcileOK, st.ReconcileFail)
 	fmt.Fprintf(buf, "    Skipped:    no-name=%d no-backend=%d conflict=%d ptr-notauth=%d\n",
 		st.SkippedNoName, st.SkippedNoBackend, st.SkippedConflict, st.SkippedPTRNotAuth)
+	fmt.Fprintf(buf, "    PTR deferred: %d (forward published, reverse PTR retry pending)\n", st.PTRDeferred)
 	fmt.Fprintf(buf, "    Owned records: %d\n", st.OwnedRecords)
 	if !st.LastReconcile.IsZero() {
 		fmt.Fprintf(buf, "    Last reconcile: %s (%d leases)\n",


### PR DESCRIPTION
## Summary

Closes #2661. Fixes a HIGH stale-state bug in the RFC 2136 DDNS backend: a forward A/AAAA could be left ORPHANED in the authoritative zone when the reverse PTR update failed after the forward succeeded.

`UpsertLease` publishes the forward A/AAAA first, then the reverse PTR. When the forward SUCCEEDED but the PTR add returned a non-skippable error (SERVFAIL/timeout/etc.), `UpsertLease` returned a plain error, so the manager (`upsertLocked`) recorded **no ownership** — while the forward RR was already **live in DNS**. With no ownership entry and no compensating delete, the forward was orphaned: present in the zone but invisible to the never-delete-non-owned reconciler, so no later release could ever withdraw it. That is exactly the stale-authoritative-record class #1387 set out to prevent.

## Decision: RECORD-OWNERSHIP (vs compensating-delete)

xpf created the forward, so xpf must own and eventually clean it. The reconcile loop re-runs `UpsertLease` every cycle for every still-active lease, and the forward re-add is an idempotent no-op. So **record ownership of the forward + retry the PTR** converges: the forward stays tracked and cleanable, and the PTR eventually publishes when the reverse zone recovers.

This is strictly better than a compensating delete here, which would tear down a healthy forward on a transient reverse-zone blip and lose the lease's forward record until the next cycle. The reconcile loop's idempotent re-invocation is precisely the condition the issue says favors record-ownership.

## Implementation

- `errDDNSPTRPending` sentinel (wraps the cause). `UpsertLease` returns it on a non-skippable PTR failure after a forward success, instead of a plain error.
- `upsertLocked` classifies the sentinel as a **partial success**: records ownership with a new `ownedRecord.PTRPending` flag, counts a new `PTRDeferred` counter, logs a WARN, and does **not** fail the pass (same non-fatal treatment as a NOTAUTH skip — the forward is up and the PTR retry self-converges).
- `reconcileOnceLocked` Pass 1 leaves a `PTRPending` record **owned** (never deletes the live forward) but does not mark it settled, so Pass 2 re-runs the upsert and re-attempts the PTR. A fully-successful upsert clears `PTRPending`.
- A NOTAUTH/REFUSED reverse zone stays a **permanent counted skip**: owned, NOT pending → steady state does not churn an UPDATE the server will always refuse. (No regression to the #1387 Q6 behavior.)
- `PTRDeferred` surfaced in the CLI/gRPC `show ... dynamic-dns` counters and the Prometheus dhcp-ddns skipped-total (`ptr-deferred` label).

## No-orphan proof (either path)

A PTR-pending record is **owned**, so a later release withdraws the forward even if the PTR never recovers: `DeleteLease` removes the forward first; a PTR-delete error to a still-broken zone only lingers the ownership entry for an idempotent retry — the forward is already gone from DNS.

## Tests (through `reconcileOnceLocked` — the layer the #2648/#2660 lesson says surfaces the breach)

- `TestManagerForwardPublishedPTRFailsRecordsOwnership`: forward A live + PTR SERVFAIL → owned with `PTRPending` + `PTRDeferred=1`; PTR zone recovers → PTR publishes, pending cleared; lease gone → forward withdrawn (no orphan).
- `TestManagerPTRPendingReleaseWithoutRetryStillCleansForward`: forward cleaned on release even while the PTR is still broken.
- `TestManagerPTRNotAuthOwnedNotPending`: NOTAUTH stays a skip (owned, not pending, no re-upsert churn).
- `TestRFC2136ForwardPublishedPTRFailReturnsPendingSentinel`: updater contract — a non-skippable PTR failure after a forward success returns the pending sentinel with the forward A on the wire.
- Hardened the stateful fake DNS server so an error rcode override **suppresses** the in-memory apply (a real server does not apply a SERVFAILed update) — the PTR-retry path depends on the failed PTR being genuinely absent.

**fail-on-revert:** reverting `UpsertLease` to the plain error (no pending sentinel) turns the new manager + updater tests red — cycle 1 fails the pass and records no ownership while the A is live (the orphan).

## Validation

- `go test -race ./pkg/dhcpserver/...` green
- build + `go test ./pkg/api ./pkg/cli ./pkg/grpcapi` green
- gofmt clean; go vet clean on touched files (`cli.go:441` unreachable-code is pre-existing on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi