### PR TITLE
cos: advance V_min cadence counter only on a confirmed pop (#2646)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,39 @@
 # Action Log
 
+## 2026-06-24 — #2646 fix: V_min cadence counter advanced before a confirmed pop
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed a CoS-drain cadence-accuracy bug (residual of #2624).
+  In both `drain_exact_*_to_scratch_flow_fair` fns the cadence counter
+  `queue.v_min.v_min_pop_count = candidate_pop_count` was committed right
+  after the V_min gate but BEFORE the code knew a packet could actually
+  pop. A subsequent post-gate budget-miss or mirror-reserve-miss break
+  exited WITHOUT popping, yet the cadence counter had already advanced —
+  contradicting #2624's "counts POPS THAT ACTUALLY PROCEED" contract and
+  letting a head packet larger than the remaining budget burn cadence
+  positions (skipping mandatory/cadence peer snapshots and counting
+  phantom pops) in the low-budget bursty regime. Moved the commit to
+  immediately AFTER `cos_queue_pop_known_bucket` confirms the pop (the
+  normal pop site and the mirror-reserve-empty-scratch pop site in the
+  Local fn; the single pop site in the Prepared fn). The gate
+  (`cos_queue_v_min_continue`) still runs at `candidate_pop_count` to
+  drive throttle / hard-cap accounting — its throttle-break is unchanged
+  (it breaks before the commit, as in #2624), so the #941 hard-cap retry
+  semantics are preserved; only the post-gate pre-pop breaks now also
+  skip the advance.
+- **File(s)**: userspace-dp/src/afxdp/cos/queue_service/drain.rs,
+  userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs,
+  userspace-dp/src/afxdp/cos/README.md, docs/fairness-regimes.md
+- **Validation**: `cargo test --release --bin xpf-userspace-dp` green
+  (2720 passed, 0 failed). Added `vmin_local_drain_budget_miss_does_not_
+  advance_cadence` + `vmin_prepared_drain_budget_miss_does_not_advance_
+  cadence`: gate passes (peer publishes high v_min, local vtime 0) but
+  budget one byte short → no pop, `v_min_pop_count` stays 0; adequate
+  budget → pop, counter == 1. fail-on-revert: re-introducing the commit
+  above the budget break made the Local test report counter 1 vs 0 → red.
+  #2624's `vmin_cadence_persists_across_small_drain_calls` and #941's
+  `vmin_prepared_drain_arms_hard_cap_after_repeated_throttle` still green.
+
 ## 2026-06-24 — #2639 fix: Phase-2 dh-group silently dropped the group<N> spelling
 
 - **Timestamp**: 2026-06-24

--- a/docs/fairness-regimes.md
+++ b/docs/fairness-regimes.md
@@ -1008,7 +1008,16 @@ the sweep exit `2`; they do not produce a false-green fairness verdict.
   small drain calls a queue takes under low/medium load (#2624); a
   per-call reset would re-arm the full scan on every drain and defeat the
   cadence, raising cross-core coherency traffic without changing the
-  throttle decision.
+  throttle decision. The counter advances ONLY over a CONFIRMED pop
+  (#2646): the commit is deferred past the gate to after the head item is
+  actually removed from its bucket, so a post-gate budget-miss or
+  mirror-reserve-miss break (head packet larger than the remaining
+  root/secondary budget) breaks WITHOUT advancing the cadence — it no
+  longer burns a cadence position while draining zero bytes, which would
+  otherwise skip a mandatory/cadence peer snapshot and count a phantom pop
+  in exactly the low-budget bursty regime this brake serves. The
+  gate-throttle (hard-cap) path is unchanged; only the post-gate pre-pop
+  breaks now also skip the advance.
 - **`xpf_userspace_binding_v_min_throttle_hard_cap_overrides_total{binding_slot=..., queue_id=..., worker_id=..., iface=...}`**
   counter (#1831): V_MIN_CONSECUTIVE_SKIP_HARD_CAP escape-hatch
   activations — after that many back-to-back throttle decisions the

--- a/userspace-dp/src/afxdp/cos/README.md
+++ b/userspace-dp/src/afxdp/cos/README.md
@@ -105,10 +105,24 @@ mod.rs for further file-level breakdown.
   cross-core cache-line ping-pong and defeating the cadence. It is
   counted over POPS THAT ACTUALLY PROCEED — a throttled drain breaks
   WITHOUT advancing it, so the next drain re-checks at the same cadence
-  position (preserving the #941 hard-cap retry semantics). Both flow-fair
-  drains (Local + Prepared) for a queue run on that queue's single owner
-  worker and share the one counter, so it is a plain `u32` with no
-  atomics — the same single-writer model as the sibling
+  position (preserving the #941 hard-cap retry semantics). The counter
+  advances ONLY on a CONFIRMED pop (#2646): the commit
+  (`v_min_pop_count = candidate_pop_count`) is deferred past the gate
+  to the point where the peek succeeds, the root/secondary budget and
+  mirror-reserve checks pass, and `cos_queue_pop_known_bucket` actually
+  removes the item. The gate (`cos_queue_v_min_continue`) is still
+  evaluated at `candidate_pop_count` to drive the throttle / hard-cap
+  accounting, but every POST-GATE no-pop exit (empty peek, wrong-variant
+  head, budget miss, mirror-reserve miss, or a pop that returns None) now
+  breaks without advancing the counter — so a head packet larger than the
+  remaining budget no longer burns a cadence position while draining zero
+  bytes (which would otherwise skip a mandatory/cadence peer snapshot and
+  count a phantom pop in the bursty low-budget regime CoS targets). The
+  gate-throttle path is unchanged (it breaks before the commit, as in
+  #2624), so the #941 hard-cap retry semantics are unaffected. Both
+  flow-fair drains (Local + Prepared) for a queue run on that queue's
+  single owner worker and share the one counter, so it is a plain `u32`
+  with no atomics — the same single-writer model as the sibling
   `consecutive_v_min_skips` / `v_min_suspended_remaining` fields.
 - Prepared CoS items may carry frames from another binding in the same
   shared-UMEM group. Queue overflow, capacity rejection, local

--- a/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
+++ b/userspace-dp/src/afxdp/cos/queue_ops/v_min_tests.rs
@@ -1346,3 +1346,174 @@ fn vmin_cadence_persists_across_small_drain_calls() {
          drains, not once per call; got {snapshots}",
     );
 }
+
+/// #2646 (Local flow-fair): the V_min cadence counter
+/// (`v_min_pop_count`) must advance only on a pop that ACTUALLY
+/// PROCEEDS. When the gate (`cos_queue_v_min_continue`) PASSES but the
+/// budget check fails (head packet larger than the remaining root/
+/// secondary budget), the drain breaks WITHOUT popping — and the
+/// counter must NOT advance, so the cadence position is preserved for
+/// the next real pop. A subsequent drain with adequate budget pops the
+/// same head and advances the counter exactly once.
+///
+/// fail-on-revert: moving the `queue.v_min.v_min_pop_count =
+/// candidate_pop_count` commit back ABOVE the budget break (the pre-
+/// #2646 placement) makes the budget-miss drain advance the counter →
+/// the first assertion (`== 0`) goes red.
+#[test]
+fn vmin_local_drain_budget_miss_does_not_advance_cadence() {
+    let umem = MmapArea::new(2 * 1024 * 1024).expect("umem");
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    let floor = attach_test_vtime_floor(queue, 4, 1);
+    // Gate PASSES: a peer participates with a high v_min and the local
+    // queue_vtime sits at 0, so the lag check always returns continue ==
+    // true. This isolates the post-gate budget break from the gate-
+    // throttle path.
+    floor.slots[0].publish(u64::MAX - 1);
+    test_flow_fair_state_mut(queue).queue_vtime = 0;
+
+    const PKT: usize = 1500;
+    cos_queue_push_back(queue, test_cos_item(PKT));
+    assert_eq!(queue.v_min.v_min_pop_count, 0, "counter starts at 0");
+
+    // Drain with a root budget SMALLER than the head packet. The gate
+    // passes, the peek succeeds, but the budget check (remaining_root <
+    // len) breaks WITHOUT popping.
+    let mut scratch: Vec<(u64, TxRequest)> = Vec::new();
+    let mut free_tx: VecDeque<u64> = VecDeque::new();
+    free_tx.push_back(0);
+    let _ = drain_exact_local_items_to_scratch_flow_fair(
+        queue,
+        &mut free_tx,
+        &mut scratch,
+        &umem,
+        (PKT as u64) - 1, // root budget one byte short
+        u64::MAX,
+        None,
+    );
+    assert!(scratch.is_empty(), "budget miss must not pop");
+    assert_eq!(
+        queue.v_min.v_min_pop_count, 0,
+        "a post-gate budget miss must NOT advance the V_min cadence counter",
+    );
+
+    // Now drain with adequate budget — the head pops and the counter
+    // advances exactly once.
+    let mut free_tx2: VecDeque<u64> = VecDeque::new();
+    free_tx2.push_back(0);
+    let _ = drain_exact_local_items_to_scratch_flow_fair(
+        queue,
+        &mut free_tx2,
+        &mut scratch,
+        &umem,
+        PKT as u64,
+        u64::MAX,
+        None,
+    );
+    assert_eq!(scratch.len(), 1, "adequate budget must pop the head");
+    assert_eq!(
+        queue.v_min.v_min_pop_count, 1,
+        "a confirmed pop must advance the V_min cadence counter exactly once",
+    );
+}
+
+/// #2646 (Prepared flow-fair): same contract as the Local case above —
+/// a post-gate budget miss must NOT burn a cadence position. The gate
+/// passes, the budget check fails, the drain breaks without popping,
+/// and `v_min_pop_count` stays put; the next adequate-budget drain pops
+/// and advances it once.
+///
+/// fail-on-revert: restoring the commit above the budget break makes
+/// the first (`== 0`) assertion red.
+#[test]
+fn vmin_prepared_drain_budget_miss_does_not_advance_cadence() {
+    let mut umem = MmapArea::new(2 * 1024 * 1024).expect("umem");
+    let mut root = test_cos_runtime_with_queues(
+        10_000_000_000 / 8,
+        vec![CoSQueueConfig {
+            queue_id: 0,
+            forwarding_class: "iperf-c".into(),
+            priority: 5,
+            transmit_rate_bytes: 10_000_000_000 / 8,
+            guarantee_enabled: true,
+            exact: true,
+            surplus_sharing: false,
+            equal_flow_enforcement: false,
+            equal_flow_target_policy: EqualFlowTargetPolicy::Slowest,
+            surplus_weight: 1,
+            buffer_bytes: COS_MIN_BURST_BYTES,
+            dscp_rewrite: None,
+            codel_target_ns: 0,
+        }],
+    );
+    let queue = &mut root.queues[0];
+    let floor = attach_test_vtime_floor(queue, 4, 1);
+    // Gate PASSES (see the Local test for the rationale).
+    floor.slots[0].publish(u64::MAX - 1);
+    test_flow_fair_state_mut(queue).queue_vtime = 0;
+
+    const PKT: usize = 1500;
+    let packet = vec![0u8; PKT];
+    let prepared = test_prepared_item_in_umem(&mut umem, 0, &packet, libc::AF_INET as u8);
+    cos_queue_push_back(queue, prepared);
+    assert_eq!(queue.v_min.v_min_pop_count, 0, "counter starts at 0");
+
+    // Budget one byte short of the head — gate passes, budget breaks.
+    let mut scratch: Vec<PreparedTxRequest> = Vec::new();
+    let mut free_tx: VecDeque<u64> = VecDeque::new();
+    let mut pending_fill: VecDeque<u64> = VecDeque::new();
+    let _ = drain_exact_prepared_items_to_scratch_flow_fair(
+        queue,
+        &mut scratch,
+        &umem,
+        &mut free_tx,
+        &mut pending_fill,
+        0,
+        &mut Vec::new(),
+        (PKT as u64) - 1,
+        u64::MAX,
+        None,
+    );
+    assert!(scratch.is_empty(), "budget miss must not pop");
+    assert_eq!(
+        queue.v_min.v_min_pop_count, 0,
+        "a post-gate budget miss must NOT advance the V_min cadence counter (Prepared)",
+    );
+
+    // Adequate budget — head pops, counter advances once.
+    let _ = drain_exact_prepared_items_to_scratch_flow_fair(
+        queue,
+        &mut scratch,
+        &umem,
+        &mut free_tx,
+        &mut pending_fill,
+        0,
+        &mut Vec::new(),
+        PKT as u64,
+        u64::MAX,
+        None,
+    );
+    assert_eq!(scratch.len(), 1, "adequate budget must pop the head (Prepared)");
+    assert_eq!(
+        queue.v_min.v_min_pop_count, 1,
+        "a confirmed pop must advance the V_min cadence counter exactly once (Prepared)",
+    );
+}

--- a/userspace-dp/src/afxdp/cos/queue_service/drain.rs
+++ b/userspace-dp/src/afxdp/cos/queue_service/drain.rs
@@ -207,13 +207,28 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
         // low/medium load, instead of re-arming the full peer-slot scan
         // on every drain invocation.
         //
+        // #2646: the `v_min_pop_count` commit is deferred to the point
+        // where a pop is CONFIRMED (after peek + budget + mirror-reserve
+        // all pass and `cos_queue_pop_known_bucket` actually removes the
+        // item). The gate (`cos_queue_v_min_continue`) is still
+        // evaluated here at `candidate_pop_count` — it must run to drive
+        // the throttle / hard-cap accounting (`consecutive_v_min_skips`,
+        // suspension arming) — but a POST-GATE no-pop exit (empty peek,
+        // budget miss, mirror-reserve miss, or a pop that returns None)
+        // now breaks WITHOUT advancing the counter. This honors the
+        // #2624 "counts pops that actually proceed" contract: a head
+        // packet larger than the remaining budget no longer burns a
+        // cadence position while draining zero bytes, so the next drain
+        // re-checks at the same position when budget returns. The gate-
+        // throttle path is unchanged (it breaks before the commit, same
+        // as #2624) so the #941 hard-cap retry semantics are preserved.
+        //
         // #941 Work item D: skip the V_min check entirely when this
         // drain is suspended (hard-cap previously armed).
         let candidate_pop_count = queue.v_min.v_min_pop_count.wrapping_add(1);
         if !suspended && !cos_queue_v_min_continue(queue, candidate_pop_count) {
             break;
         }
-        queue.v_min.v_min_pop_count = candidate_pop_count;
         // #1229 v7: cap-aware front/pop. target_bps was sampled
         // once at drain-batch start; same value used for every
         // pop in the batch so the eligible-set is stable.
@@ -244,6 +259,10 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
                 else {
                     break;
                 };
+                // #2646: a real pop occurred (the head is removed and
+                // accounted as a mirror-reserve drop) — advance the
+                // cadence counter now that the pop is confirmed.
+                queue.v_min.v_min_pop_count = candidate_pop_count;
                 cos_queue_clear_orphan_snapshot_after_drop(queue);
                 return ExactCoSScratchBuild::MirrorTxFrameReserve { dropped_bytes: len };
             }
@@ -254,6 +273,11 @@ pub(in crate::afxdp) fn drain_exact_local_items_to_scratch_flow_fair(
         else {
             break;
         };
+        // #2646: the pop is confirmed (item removed from the bucket) —
+        // advance the cadence counter now. A budget/mirror/peek/None
+        // break above exited without reaching here, so it did not burn
+        // a cadence position.
+        queue.v_min.v_min_pop_count = candidate_pop_count;
         remaining_root = remaining_root.saturating_sub(len);
         remaining_secondary = remaining_secondary.saturating_sub(len);
 
@@ -481,11 +505,20 @@ pub(in crate::afxdp) fn drain_exact_prepared_items_to_scratch_flow_fair(
         // throttled drain breaks WITHOUT advancing the counter; only a
         // pop that passes the gate advances it (see the Local-flow
         // comment for the full rationale).
+        //
+        // #2646: as in the Local flow-fair drain, the `v_min_pop_count`
+        // commit is deferred until the pop is CONFIRMED (after peek +
+        // budget pass and `cos_queue_pop_known_bucket` removes the
+        // item). The gate still runs here to drive throttle / hard-cap
+        // accounting, but a post-gate no-pop exit (empty peek, Local at
+        // head, budget miss, or a pop that returns None) breaks WITHOUT
+        // advancing the counter — honoring the #2624 "counts pops that
+        // actually proceed" contract while leaving the gate-throttle
+        // (#941 hard-cap) path unchanged.
         let candidate_pop_count = queue.v_min.v_min_pop_count.wrapping_add(1);
         if !suspended && !cos_queue_v_min_continue(queue, candidate_pop_count) {
             break;
         }
-        queue.v_min.v_min_pop_count = candidate_pop_count;
         // #1763 Lever A — fused select+pop (Prepared cap-aware arm).
         // Budget break abandons without popping (1 scan); commit reuses
         // `bucket` (no re-scan). See the Local arm for the invariant.
@@ -504,6 +537,11 @@ pub(in crate::afxdp) fn drain_exact_prepared_items_to_scratch_flow_fair(
         else {
             break;
         };
+        // #2646: the pop is confirmed (item removed from the bucket) —
+        // advance the cadence counter now. A budget/peek/Local-head/None
+        // break above exited without reaching here, so it did not burn
+        // a cadence position.
+        queue.v_min.v_min_pop_count = candidate_pop_count;
         remaining_root = remaining_root.saturating_sub(len);
         remaining_secondary = remaining_secondary.saturating_sub(len);
 


### PR DESCRIPTION
Closes #2646

## Problem (residual of #2624)

In both `drain_exact_*_to_scratch_flow_fair` fns the cadence counter
`queue.v_min.v_min_pop_count = candidate_pop_count` was committed
immediately after the V_min gate but BEFORE the code knew a packet could
actually pop. A subsequent **post-gate** no-pop break exited WITHOUT
popping, yet the cadence counter had already advanced — contradicting
#2624's contract that the counter counts "POPS THAT ACTUALLY PROCEED".

Under shaping / shared-root pressure a head packet larger than the
remaining root/secondary budget repeatedly advanced V_min cadence while
draining zero bytes — skipping a mandatory/cadence peer snapshot when
budget returned and counting phantom pops in hard-cap accounting.

## Fix

Defer the `v_min_pop_count` commit past the gate to the point where the
pop is **confirmed** — after the peek succeeds, the root/secondary budget
and mirror-reserve checks pass, and `cos_queue_pop_known_bucket` actually
removes the item.

Breaks that now SKIP the advance (post-gate, pre-pop):
- empty peek
- wrong-variant head (Prepared-in-Local / Local-in-Prepared)
- **budget miss** (`remaining_root < len || remaining_secondary < len`)
- **mirror-reserve miss** (non-empty scratch)
- `cos_queue_pop_known_bucket` returns `None`

Commit sites (confirmed pops):
- **Local fn**: the normal pop site **and** the mirror-reserve-with-empty-
  scratch pop (which removes the head and returns `MirrorTxFrameReserve`).
- **Prepared fn**: its single pop site.

Both `drain_exact_*_to_scratch_flow_fair` fns are fixed.

## How #2624 / #941 are preserved

The gate (`cos_queue_v_min_continue`) is **still evaluated** at
`candidate_pop_count` to drive throttle / hard-cap accounting
(`consecutive_v_min_skips`, suspension arming). The **gate-throttle break
is unchanged** — it breaks BEFORE the commit, exactly as in #2624 — so a
throttled drain still does not advance the counter, and the #941 hard-cap
retry semantics (which count consecutive *gate-throttle* skips, not budget
misses) are unaffected. Only the post-gate pre-pop breaks now also skip
the advance.

## Validation

`cargo test --release --bin xpf-userspace-dp` green (2720 passed,
0 failed).

New tests:
- `vmin_local_drain_budget_miss_does_not_advance_cadence`
- `vmin_prepared_drain_budget_miss_does_not_advance_cadence`

Both drive the gate to PASS (a peer publishes a high `v_min`, local
`queue_vtime` = 0) then feed a root budget one byte short of the head
packet → the drain breaks at the budget check without popping and
`v_min_pop_count` stays 0; a follow-up drain with adequate budget pops the
head and advances the counter to exactly 1.

**fail-on-revert:** re-introducing the commit above the budget break makes
the Local budget-miss test report the counter as `1` vs the expected `0`
(red) — verified.

Regression-pinned: #2624's `vmin_cadence_persists_across_small_drain_calls`
and #941's `vmin_prepared_drain_arms_hard_cap_after_repeated_throttle`
remain green.

Docs: `userspace-dp/src/afxdp/cos/README.md` and `docs/fairness-regimes.md`
updated (counter advances only on a confirmed pop).

Note: the parent may run a CoS smoke on the loss userspace cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi