### PR TITLE
#2587: read all values from multi-value routing-protocol leaves

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,25 @@
 # Action Log
 
+## 2026-06-24 — #2587 fix: routing-protocol export/import + community members dropped all but first bracketed value
+
+- **Timestamp**: 2026-06-24
+- **Action**: Routed six multi-value-leaf compiler readers through the
+  shared `firewallMatchValues` SSOT (Keys[1:] + child leaves) so a
+  bracketed list `[ a b c ]` (and a hierarchical block) keeps ALL
+  values on BOTH AST shapes. Affected leaves (all already `multi:true`
+  in `schema_routing.go`): OSPF `export`, BGP `export`/`import`, OSPFv3
+  `export`, IS-IS `export` (`compiler_protocols.go`), policy-options
+  community `members` (`compiler_routing.go`). The already-correct BGP
+  group/neighbor export/import readers (#2490) were left unchanged. Added
+  `protocols_multileaf_2587_test.go` with 10 fail-on-revert cases (flat-set
+  via ParseSetCommand+SetPath AND hierarchical block per reader) — all 10
+  FAIL on the pre-fix readers, pass after. Updated docs/config-schema.md
+  multi-value reader list. Gates: go build ./... clean, go test
+  ./pkg/config/... + ./pkg/frr/... green, gofmt clean.
+- **File(s)**: pkg/config/compiler_protocols.go,
+  pkg/config/compiler_routing.go,
+  pkg/config/protocols_multileaf_2587_test.go, docs/config-schema.md.
+
 ## 2026-06-24 — #2630 review fold: mark flat-set collapse FIXED in pkg/frr/README.md
 
 - **Timestamp**: 2026-06-24

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -120,6 +120,23 @@ covered by `TestSystemDomainSearchBracketList{FlatSet,Hierarchical}` and
 `TestSystemNameServer{BracketListFlatSet,BlockListHierarchical}` in
 `pkg/config/system_multileaf_test.go`.
 
+The routing-protocol export/import readers and the policy-options community
+`members` reader were brought onto the contract in #2587. The schema leaves
+were already `multi:true` (`schema_routing.go`: `protocols ospf export`,
+`protocols ospf3 export`, `protocols bgp export`/`import`, `protocols isis
+export`, `policy-options community <name> members`), but the compilers
+(`compileProtocols`, `compiler_protocols.go`; `compilePolicyOptions`,
+`compiler_routing.go`) read only `child.Keys[1]` with no children iteration,
+so `protocols ospf export [ connected static ]` redistributed only
+`connected` and `community c1 members [ 65000:1 65000:2 ]` truncated to the
+first member. All six now route through `firewallMatchValues`. The
+already-correct BGP **group**/**neighbor** export/import readers
+(`compiler_protocols.go`, #2490) read `Keys[1:]` directly and were left
+unchanged. Fail-on-revert covered by the `TestOSPFExport*`,
+`TestBGPExportImport*`, `TestOSPFv3Export*`, `TestISISExport*`, and
+`TestCommunityMembers*` cases in
+`pkg/config/protocols_multileaf_2587_test.go`.
+
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 
 The dual-AST contract above covers a single leaf carrying a bracketed list

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -68,9 +68,11 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 			case "passive":
 				proto.OSPF.PassiveDefault = true
 			case "export":
-				if len(child.Keys) >= 2 {
-					proto.OSPF.Export = append(proto.OSPF.Export, child.Keys[1])
-				}
+				// Multi-value leaf (#2587): `export [ p1 p2 ]` collapses onto
+				// child.Keys[1:] (flat-set) or child.Children (hierarchical
+				// block). Read ALL values via the firewallMatchValues SSOT;
+				// reading only Keys[1] dropped every policy past the first.
+				proto.OSPF.Export = append(proto.OSPF.Export, firewallMatchValues(child)...)
 			}
 		}
 
@@ -238,13 +240,11 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 					}
 				}
 			case "export":
-				if len(child.Keys) >= 2 {
-					proto.BGP.Export = append(proto.BGP.Export, child.Keys[1])
-				}
+				// Multi-value leaf (#2587): accumulate ALL policies across
+				// both AST shapes via the firewallMatchValues SSOT.
+				proto.BGP.Export = append(proto.BGP.Export, firewallMatchValues(child)...)
 			case "import":
-				if len(child.Keys) >= 2 {
-					proto.BGP.Import = append(proto.BGP.Import, child.Keys[1])
-				}
+				proto.BGP.Import = append(proto.BGP.Import, firewallMatchValues(child)...)
 			}
 		}
 
@@ -514,9 +514,9 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 					proto.OSPFv3.RouterID = child.Keys[1]
 				}
 			case "export":
-				if len(child.Keys) >= 2 {
-					proto.OSPFv3.Export = append(proto.OSPFv3.Export, child.Keys[1])
-				}
+				// Multi-value leaf (#2587): accumulate ALL policies across
+				// both AST shapes via the firewallMatchValues SSOT.
+				proto.OSPFv3.Export = append(proto.OSPFv3.Export, firewallMatchValues(child)...)
 			}
 		}
 
@@ -622,9 +622,9 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 					proto.ISIS.Level = child.Keys[1]
 				}
 			case "export":
-				if len(child.Keys) >= 2 {
-					proto.ISIS.Export = append(proto.ISIS.Export, child.Keys[1])
-				}
+				// Multi-value leaf (#2587): accumulate ALL policies across
+				// both AST shapes via the firewallMatchValues SSOT.
+				proto.ISIS.Export = append(proto.ISIS.Export, firewallMatchValues(child)...)
 			case "authentication-key":
 				if v := nodeVal(child); v != "" {
 					proto.ISIS.AuthKey = Secret(v)

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -374,14 +374,17 @@ func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {
 		}
 		for _, entry := range inst.node.Children {
 			if entry.Name() == "members" {
-				if v := nodeVal(entry); v != "" {
-					cd.Members = append(cd.Members, v)
-				}
+				// Multi-value leaf (#2587): `members [ c1 c2 ]` (and a
+				// hierarchical block) collapses onto entry.Keys[1:] and/or
+				// entry.Children. Read ALL via the firewallMatchValues SSOT;
+				// the prior nodeVal-only read kept just the first community.
+				cd.Members = append(cd.Members, firewallMatchValues(entry)...)
 			}
 		}
-		// Handle flat set syntax: keys like ["members", "65000:100"]
+		// Handle flat set syntax where `members` collapses onto the community
+		// instance node itself: Keys like ["members", "65000:100", ...].
 		if len(inst.node.Keys) > 1 && inst.node.Keys[0] == "members" {
-			cd.Members = append(cd.Members, inst.node.Keys[1])
+			cd.Members = append(cd.Members, inst.node.Keys[1:]...)
 		}
 	}
 

--- a/pkg/config/protocols_multileaf_2587_test.go
+++ b/pkg/config/protocols_multileaf_2587_test.go
@@ -1,0 +1,230 @@
+package config
+
+import "testing"
+
+// #2587: a set of routing-protocol compilers read a `multi: true` export /
+// import / members leaf via only child.Keys[1] (no Keys[1:] slice, no
+// child.Children iteration). A bracketed list `[ a b c ]` collapses onto a
+// single leaf's Keys in BOTH AST shapes (#2419), so those readers silently
+// kept only the FIRST value — `protocols ospf export [ connected static ]`
+// redistributed only `connected`; `community c1 members [ 65000:1 65000:2 ]`
+// truncated.
+//
+// The fix routes each reader through the shared firewallMatchValues SSOT
+// (Keys[1:] + each child leaf). The schema leaves were already marked
+// multi:true (schema_routing.go), so only the compiler readers changed.
+//
+// These are fail-on-revert guards: each asserts ALL N values survive on BOTH
+// the flat-set bracket-list shape (via ParseSetCommand + SetPath, the
+// CLAUDE.md-mandated harness for flat-set) and the hierarchical block shape.
+// Reverting any reader to the single-Keys[1] form drops the trailing values
+// and fails the len/element assertions. The dual-AST differential harness
+// alone misses this class because both shapes collapse identically (#2585) —
+// dedicated assertions are required.
+
+// --- OSPF export ---
+
+func TestOSPFExportMultiValueFlatSet(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set protocols ospf export [ connected static bgp ]",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.OSPF == nil {
+		t.Fatalf("OSPF config nil")
+	}
+	got := cfg.Protocols.OSPF.Export
+	want := []string{"connected", "static", "bgp"}
+	if !equalStrs(got, want) {
+		t.Errorf("OSPF.Export = %v, want %v (trailing policies dropped without firewallMatchValues)", got, want)
+	}
+}
+
+func TestOSPFExportMultiValueHierarchical(t *testing.T) {
+	src := `protocols {
+    ospf {
+        export [ connected static bgp ];
+    }
+}`
+	cfg := mustCompile(t, src)
+	if cfg.Protocols.OSPF == nil {
+		t.Fatalf("OSPF config nil")
+	}
+	got := cfg.Protocols.OSPF.Export
+	want := []string{"connected", "static", "bgp"}
+	if !equalStrs(got, want) {
+		t.Errorf("OSPF.Export = %v, want %v", got, want)
+	}
+}
+
+// --- BGP export + import ---
+
+func TestBGPExportImportMultiValueFlatSet(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set protocols bgp export [ connected static ospf ]",
+		"set protocols bgp import [ imp1 imp2 ]",
+		"set policy-options policy-statement imp1 term t then accept",
+		"set policy-options policy-statement imp2 term t then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.BGP == nil {
+		t.Fatalf("BGP config nil")
+	}
+	if got, want := cfg.Protocols.BGP.Export, []string{"connected", "static", "ospf"}; !equalStrs(got, want) {
+		t.Errorf("BGP.Export = %v, want %v", got, want)
+	}
+	if got, want := cfg.Protocols.BGP.Import, []string{"imp1", "imp2"}; !equalStrs(got, want) {
+		t.Errorf("BGP.Import = %v, want %v", got, want)
+	}
+}
+
+func TestBGPExportImportMultiValueHierarchical(t *testing.T) {
+	src := `protocols {
+    bgp {
+        export [ connected static ospf ];
+        import [ imp1 imp2 ];
+    }
+}
+policy-options {
+    policy-statement imp1 { term t { then accept; } }
+    policy-statement imp2 { term t { then accept; } }
+}`
+	cfg := mustCompile(t, src)
+	if cfg.Protocols.BGP == nil {
+		t.Fatalf("BGP config nil")
+	}
+	if got, want := cfg.Protocols.BGP.Export, []string{"connected", "static", "ospf"}; !equalStrs(got, want) {
+		t.Errorf("BGP.Export = %v, want %v", got, want)
+	}
+	if got, want := cfg.Protocols.BGP.Import, []string{"imp1", "imp2"}; !equalStrs(got, want) {
+		t.Errorf("BGP.Import = %v, want %v", got, want)
+	}
+}
+
+// --- OSPFv3 export ---
+
+func TestOSPFv3ExportMultiValueFlatSet(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set protocols ospf3 export [ connected static ]",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.OSPFv3 == nil {
+		t.Fatalf("OSPFv3 config nil")
+	}
+	got := cfg.Protocols.OSPFv3.Export
+	want := []string{"connected", "static"}
+	if !equalStrs(got, want) {
+		t.Errorf("OSPFv3.Export = %v, want %v", got, want)
+	}
+}
+
+func TestOSPFv3ExportMultiValueHierarchical(t *testing.T) {
+	src := `protocols {
+    ospf3 {
+        export [ connected static ];
+    }
+}`
+	cfg := mustCompile(t, src)
+	if cfg.Protocols.OSPFv3 == nil {
+		t.Fatalf("OSPFv3 config nil")
+	}
+	got := cfg.Protocols.OSPFv3.Export
+	want := []string{"connected", "static"}
+	if !equalStrs(got, want) {
+		t.Errorf("OSPFv3.Export = %v, want %v", got, want)
+	}
+}
+
+// --- IS-IS export ---
+
+func TestISISExportMultiValueFlatSet(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set protocols isis export [ connected static bgp ]",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.Protocols.ISIS == nil {
+		t.Fatalf("ISIS config nil")
+	}
+	got := cfg.Protocols.ISIS.Export
+	want := []string{"connected", "static", "bgp"}
+	if !equalStrs(got, want) {
+		t.Errorf("ISIS.Export = %v, want %v", got, want)
+	}
+}
+
+func TestISISExportMultiValueHierarchical(t *testing.T) {
+	src := `protocols {
+    isis {
+        export [ connected static bgp ];
+    }
+}`
+	cfg := mustCompile(t, src)
+	if cfg.Protocols.ISIS == nil {
+		t.Fatalf("ISIS config nil")
+	}
+	got := cfg.Protocols.ISIS.Export
+	want := []string{"connected", "static", "bgp"}
+	if !equalStrs(got, want) {
+		t.Errorf("ISIS.Export = %v, want %v", got, want)
+	}
+}
+
+// --- policy-options community members ---
+
+func TestCommunityMembersMultiValueFlatSet(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options community c1 members [ 65000:1 65000:2 65000:3 ]",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	cd := cfg.PolicyOptions.Communities["c1"]
+	if cd == nil {
+		t.Fatalf("community c1 not compiled")
+	}
+	got := cd.Members
+	want := []string{"65000:1", "65000:2", "65000:3"}
+	if !equalStrs(got, want) {
+		t.Errorf("community c1 Members = %v, want %v (trailing members dropped without firewallMatchValues)", got, want)
+	}
+}
+
+func TestCommunityMembersMultiValueHierarchical(t *testing.T) {
+	src := `policy-options {
+    community c1 {
+        members [ 65000:1 65000:2 65000:3 ];
+    }
+}`
+	cfg := mustCompile(t, src)
+	cd := cfg.PolicyOptions.Communities["c1"]
+	if cd == nil {
+		t.Fatalf("community c1 not compiled")
+	}
+	got := cd.Members
+	want := []string{"65000:1", "65000:2", "65000:3"}
+	if !equalStrs(got, want) {
+		t.Errorf("community c1 Members = %v, want %v", got, want)
+	}
+}
+
+// mustCompile parses a hierarchical config source and compiles it, failing the
+// test on any parse or compile error.
+func mustCompile(t *testing.T, src string) *Config {
+	t.Helper()
+	tree, perrs := NewParser(src).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg
+}


### PR DESCRIPTION
Closes #2587

## Problem

Six routing-protocol / policy-options compilers read a `multi: true` value leaf via only `child.Keys[1]` with **no** child-node iteration. A bracketed list `[ a b c ]` collapses onto a single leaf's `Keys` in BOTH AST shapes (#2419), and a hierarchical block carries values as child leaves — so these readers silently kept only the **first** value.

Symptom: `protocols ospf export [ connected static ]` redistributed only `connected`; `community c1 members [ 65000:1 65000:2 ]` truncated to the first member → wrong route policy. Latent on master.

## Per-reader changes

All six routed through the shared `firewallMatchValues` SSOT (the #2545/#2585 helper — accumulates `Keys[1:]` plus every child leaf):

| Leaf | File | Was |
|------|------|-----|
| `protocols ospf export` | compiler_protocols.go | `Keys[1]` only |
| `protocols bgp export` / `import` | compiler_protocols.go | `Keys[1]` only |
| `protocols ospf3 export` | compiler_protocols.go | `Keys[1]` only |
| `protocols isis export` | compiler_protocols.go | `Keys[1]` only |
| `policy-options community members` | compiler_routing.go | `nodeVal`/`Keys[1]` only |

The already-correct BGP **group**/**neighbor** export/import readers (#2490, which read `Keys[1:]` directly) were left unchanged and used as the reference pattern.

## Schema half

Already done — every affected leaf was already `multi: true` in `schema_routing.go` (verified). Only the compiler readers needed the fix; no schema change in this PR.

## Tests (fail-on-revert)

`pkg/config/protocols_multileaf_2587_test.go` adds **10** cases: for each of OSPF export / BGP export+import / OSPFv3 export / IS-IS export / community members, both the **flat-set bracket list** (via `ParseSetCommand` + `tree.SetPath`, the CLAUDE.md-mandated flat-set harness) and the **hierarchical block** must yield all N values. Proven fail-on-revert: all 10 FAIL against the pre-fix readers (only the first value survives), pass after. The dual-AST differential harness alone misses this class because both shapes collapse identically (#2585), so dedicated assertions are required. No `multi:true`-guard enumeration test added — noted as a possible follow-up to avoid over-engineering.

## Docs

`docs/config-schema.md` multi-value-leaf reader list updated to record the six readers brought onto the contract. `_Log.md` updated.

## Gates

- `go build ./...` clean
- `go test ./pkg/config/...` green
- `go test ./pkg/frr/...` green
- `gofmt` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi