### PR TITLE
#2689: route policy-term from community/prefix-list through firewallMatchValues

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,26 @@
 # Action Log
 
+## 2026-06-24 — #2689 fix: policy-term `from community` / `from prefix-list` dropped all but first bracketed value
+
+- **Timestamp**: 2026-06-24
+- **Action**: Routed the two policy-statement match readers (`from
+  community`, `from prefix-list`) in `parsePolicyTermChildren` through
+  the shared `firewallMatchValues` SSOT (Keys[1:] + child leaves) so a
+  bracketed list `from community [ c1 c2 ]` / `from prefix-list [ p1 p2 ]`
+  keeps ALL values on BOTH AST shapes. Both leaves were already
+  `multi:true` in `schema_routing.go`; the readers previously used
+  `nodeVal(fc)` = Keys[1] only, truncating to the first list entry. Same
+  class as #2587 (PR #2687) and #2630 (PR #2685). Composes with #2642's
+  repeated-sibling append (bracket values + a sibling statement both
+  accumulate). Added `policy_from_multileaf_2689_test.go` with 6
+  fail-on-revert cases (flat-set bracket, hierarchical block, and
+  bracket+sibling composition per reader) — all 6 fail on the old reader,
+  pass on the fix. `go build ./...` clean; `go test ./pkg/config/...
+  ./pkg/frr/...` green (frr cartesian render unchanged downstream).
+- **File(s)**: pkg/config/compiler_routing.go,
+  pkg/config/policy_from_multileaf_2689_test.go, docs/config-schema.md,
+  _Log.md
+
 ## 2026-06-24 — #2587 fix: routing-protocol export/import + community members dropped all but first bracketed value
 
 - **Timestamp**: 2026-06-24

--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,7 @@
 # Action Log
 
+## 2026-06-24 — #2689 review fold: `from as-path` bracket-collapse (sibling reader, same function) — routed through firewallMatchValues + 3 fail-on-revert tests; children-path only (brackets never reach the inline-keys path). Files: pkg/config/compiler_routing.go, pkg/config/policy_from_multileaf_2689_test.go, docs/config-schema.md, _Log.md
+
 ## 2026-06-24 — #2689 fix: policy-term `from community` / `from prefix-list` dropped all but first bracketed value
 
 - **Timestamp**: 2026-06-24

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -137,18 +137,20 @@ unchanged. Fail-on-revert covered by the `TestOSPFExport*`,
 `TestCommunityMembers*` cases in
 `pkg/config/protocols_multileaf_2587_test.go`.
 
-The policy-statement `from community` and `from prefix-list` match readers were
-the same class and were brought onto the contract in #2689. Both leaves are
-`multi:true` (`schema_routing.go`: `policy-options policy-statement <name> term
-<name> from prefix-list`/`community`), but `parsePolicyTermChildren`
+The policy-statement `from community`, `from prefix-list`, and `from as-path`
+match readers were the same class and were brought onto the contract in #2689
+(`as-path` folded in during review). All three leaves are `multi:true`
+(`schema_routing.go`: `policy-options policy-statement <name> term <name> from
+prefix-list`/`community`/`as-path`), but `parsePolicyTermChildren`
 (`compiler_routing.go`) read only `nodeVal(fc)` = `child.Keys[1]`, so
-`from community [ c1 c2 ]` matched only `c1` and `from prefix-list [ p1 p2 ]`
-matched only `p1`. Both now route through `firewallMatchValues`. This composes
-with the #2642 repeated-sibling append below — a term carrying BOTH a bracket
-list AND a separate `from community c3` sibling keeps every value
-(`[c1 c2 c3]`). Fail-on-revert covered by `TestPolicyFromCommunity*` and
-`TestPolicyFromPrefixList*` in
-`pkg/config/policy_from_multileaf_2689_test.go`.
+`from community [ c1 c2 ]` matched only `c1`, `from prefix-list [ p1 p2 ]`
+matched only `p1`, and `from as-path [ a1 a2 ]` matched only `a1` (the dropped
+as-path was silently absent from the `policy_render.go` cartesian OR product).
+All three now route through `firewallMatchValues`. This composes with the #2642
+repeated-sibling append below — a term carrying BOTH a bracket list AND a
+separate `from community c3` sibling keeps every value (`[c1 c2 c3]`).
+Fail-on-revert covered by `TestPolicyFromCommunity*`, `TestPolicyFromPrefixList*`,
+and `TestPolicyFromASPath*` in `pkg/config/policy_from_multileaf_2689_test.go`.
 
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -137,6 +137,19 @@ unchanged. Fail-on-revert covered by the `TestOSPFExport*`,
 `TestCommunityMembers*` cases in
 `pkg/config/protocols_multileaf_2587_test.go`.
 
+The policy-statement `from community` and `from prefix-list` match readers were
+the same class and were brought onto the contract in #2689. Both leaves are
+`multi:true` (`schema_routing.go`: `policy-options policy-statement <name> term
+<name> from prefix-list`/`community`), but `parsePolicyTermChildren`
+(`compiler_routing.go`) read only `nodeVal(fc)` = `child.Keys[1]`, so
+`from community [ c1 c2 ]` matched only `c1` and `from prefix-list [ p1 p2 ]`
+matched only `p1`. Both now route through `firewallMatchValues`. This composes
+with the #2642 repeated-sibling append below — a term carrying BOTH a bracket
+list AND a separate `from community c3` sibling keeps every value
+(`[c1 c2 c3]`). Fail-on-revert covered by `TestPolicyFromCommunity*` and
+`TestPolicyFromPrefixList*` in
+`pkg/config/policy_from_multileaf_2689_test.go`.
+
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 
 The dual-AST contract above covers a single leaf carrying a bracketed list

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -639,10 +639,12 @@ func parsePolicyTermChildren(term *PolicyTerm, children []*Node) {
 					// nodeVal-only read kept just the first list entry (#2689).
 					term.FromCommunity = append(term.FromCommunity, firewallMatchValues(fc)...)
 				case "as-path":
-					// Repeated `as-path` siblings match ANY (#2642).
-					if v := nodeVal(fc); v != "" {
-						term.FromASPath = append(term.FromASPath, v)
-					}
+					// Repeated `as-path` siblings match ANY (#2642). A bracketed
+					// list `as-path [ a1 a2 ]` ALSO collapses onto one leaf's
+					// Keys[1:] / Children in BOTH AST shapes (#2419), so read
+					// every value via the firewallMatchValues SSOT — the prior
+					// nodeVal-only read kept just the first list entry (#2689).
+					term.FromASPath = append(term.FromASPath, firewallMatchValues(fc)...)
 				}
 			}
 		case "then":

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -590,10 +590,12 @@ func parsePolicyTermChildren(term *PolicyTerm, children []*Node) {
 				case "prefix-list":
 					// Junos allows repeated `prefix-list` siblings in one
 					// term (match ANY). Accumulate so multiple statements are
-					// all kept, not just the last (#2642).
-					if v := nodeVal(fc); v != "" {
-						term.PrefixList = append(term.PrefixList, v)
-					}
+					// all kept, not just the last (#2642). A bracketed list
+					// `prefix-list [ p1 p2 ]` ALSO collapses onto one leaf's
+					// Keys[1:] / Children in BOTH AST shapes (#2419), so read
+					// every value via the firewallMatchValues SSOT — the prior
+					// nodeVal-only read kept just the first list entry (#2689).
+					term.PrefixList = append(term.PrefixList, firewallMatchValues(fc)...)
 				case "route-filter":
 					if len(fc.Keys) >= 3 {
 						rf := &RouteFilter{
@@ -630,10 +632,12 @@ func parsePolicyTermChildren(term *PolicyTerm, children []*Node) {
 					}
 				case "community":
 					// Repeated `community` siblings match ANY (#2642) — keep
-					// every one, not just the last.
-					if v := nodeVal(fc); v != "" {
-						term.FromCommunity = append(term.FromCommunity, v)
-					}
+					// every one, not just the last. A bracketed list
+					// `community [ c1 c2 ]` ALSO collapses onto one leaf's
+					// Keys[1:] / Children in BOTH AST shapes (#2419), so read
+					// every value via the firewallMatchValues SSOT — the prior
+					// nodeVal-only read kept just the first list entry (#2689).
+					term.FromCommunity = append(term.FromCommunity, firewallMatchValues(fc)...)
 				case "as-path":
 					// Repeated `as-path` siblings match ANY (#2642).
 					if v := nodeVal(fc); v != "" {

--- a/pkg/config/policy_from_multileaf_2689_test.go
+++ b/pkg/config/policy_from_multileaf_2689_test.go
@@ -133,3 +133,55 @@ func TestPolicyFromPrefixListBracketPlusSibling_2689(t *testing.T) {
 		t.Errorf("PrefixList = %v, want %v (bracket+sibling composition)", term.PrefixList, want)
 	}
 }
+
+// --- from as-path (review fold: sibling reader in the same function) ---
+
+func TestPolicyFromASPathBracketFlatSet_2689(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options policy-statement P term T from as-path [ a1 a2 ]",
+		"set policy-options policy-statement P term T then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"a1", "a2"}
+	if !equalStrs(term.FromASPath, want) {
+		t.Errorf("FromASPath = %v, want %v (trailing as-path dropped without firewallMatchValues)", term.FromASPath, want)
+	}
+}
+
+func TestPolicyFromASPathBracketHierarchical_2689(t *testing.T) {
+	src := `policy-options {
+    policy-statement P {
+        term T {
+            from {
+                as-path [ a1 a2 ];
+            }
+            then accept;
+        }
+    }
+}`
+	cfg := mustCompile(t, src)
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"a1", "a2"}
+	if !equalStrs(term.FromASPath, want) {
+		t.Errorf("FromASPath = %v, want %v", term.FromASPath, want)
+	}
+}
+
+func TestPolicyFromASPathBracketPlusSibling_2689(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options policy-statement P term T from as-path [ a1 a2 ]",
+		"set policy-options policy-statement P term T from as-path a3",
+		"set policy-options policy-statement P term T then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"a1", "a2", "a3"}
+	if !equalStrs(term.FromASPath, want) {
+		t.Errorf("FromASPath = %v, want %v (bracket+sibling composition)", term.FromASPath, want)
+	}
+}

--- a/pkg/config/policy_from_multileaf_2689_test.go
+++ b/pkg/config/policy_from_multileaf_2689_test.go
@@ -1,0 +1,135 @@
+package config
+
+import "testing"
+
+// #2689: the policy-statement `from community` and `from prefix-list` match
+// readers in parsePolicyTermChildren read a `multi: true` leaf via only
+// nodeVal(fc) = child.Keys[1] (no Keys[1:] slice, no child.Children
+// iteration). A bracketed list `[ c1 c2 ]` collapses onto a single leaf's
+// Keys in BOTH AST shapes (#2419), so those readers silently kept only the
+// FIRST value — `from community [ c1 c2 ]` matched only c1, and
+// `from prefix-list [ p1 p2 ]` matched only p1.
+//
+// This is the same class fixed for the protocol export/import/community-members
+// readers in #2587 (PR #2687) and #2630 (PR #2685). The fix routes both
+// readers through the shared firewallMatchValues SSOT (Keys[1:] + each child
+// leaf). The schema leaves were already multi:true (schema_routing.go ~105/107),
+// so only the compiler readers changed.
+//
+// #2642 added the []string OR/cartesian model for these from-* fields by
+// accumulating repeated SIBLING statements; it did NOT cover the bracket-list
+// collapse for these two readers. The fix below COMPOSES with #2642: a term
+// carrying BOTH a bracket list AND a repeated sibling must keep every value.
+//
+// These are fail-on-revert guards: each asserts ALL values survive on BOTH the
+// flat-set bracket-list shape (via ParseSetCommand + SetPath, the
+// CLAUDE.md-mandated harness for flat-set) and the hierarchical block shape.
+// Reverting either reader to the single-nodeVal form drops the trailing values
+// and fails the len/element assertions.
+
+// --- from community ---
+
+func TestPolicyFromCommunityBracketFlatSet_2689(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options policy-statement P term T from community [ c1 c2 ]",
+		"set policy-options policy-statement P term T then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"c1", "c2"}
+	if !equalStrs(term.FromCommunity, want) {
+		t.Errorf("FromCommunity = %v, want %v (trailing community dropped without firewallMatchValues)", term.FromCommunity, want)
+	}
+}
+
+func TestPolicyFromCommunityBracketHierarchical_2689(t *testing.T) {
+	src := `policy-options {
+    policy-statement P {
+        term T {
+            from {
+                community [ c1 c2 ];
+            }
+            then accept;
+        }
+    }
+}`
+	cfg := mustCompile(t, src)
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"c1", "c2"}
+	if !equalStrs(term.FromCommunity, want) {
+		t.Errorf("FromCommunity = %v, want %v", term.FromCommunity, want)
+	}
+}
+
+// Composition with #2642's repeated-sibling append: a bracket list plus a
+// separate `from community c3` statement must yield [c1 c2 c3] — the bracket
+// values accumulate, then the sibling appends, neither overwriting the other.
+func TestPolicyFromCommunityBracketPlusSibling_2689(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options policy-statement P term T from community [ c1 c2 ]",
+		"set policy-options policy-statement P term T from community c3",
+		"set policy-options policy-statement P term T then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"c1", "c2", "c3"}
+	if !equalStrs(term.FromCommunity, want) {
+		t.Errorf("FromCommunity = %v, want %v (bracket+sibling composition)", term.FromCommunity, want)
+	}
+}
+
+// --- from prefix-list ---
+
+func TestPolicyFromPrefixListBracketFlatSet_2689(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options policy-statement P term T from prefix-list [ p1 p2 ]",
+		"set policy-options policy-statement P term T then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"p1", "p2"}
+	if !equalStrs(term.PrefixList, want) {
+		t.Errorf("PrefixList = %v, want %v (trailing prefix-list dropped without firewallMatchValues)", term.PrefixList, want)
+	}
+}
+
+func TestPolicyFromPrefixListBracketHierarchical_2689(t *testing.T) {
+	src := `policy-options {
+    policy-statement P {
+        term T {
+            from {
+                prefix-list [ p1 p2 ];
+            }
+            then accept;
+        }
+    }
+}`
+	cfg := mustCompile(t, src)
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"p1", "p2"}
+	if !equalStrs(term.PrefixList, want) {
+		t.Errorf("PrefixList = %v, want %v", term.PrefixList, want)
+	}
+}
+
+func TestPolicyFromPrefixListBracketPlusSibling_2689(t *testing.T) {
+	cfg, err := compileSet(t, []string{
+		"set policy-options policy-statement P term T from prefix-list [ p1 p2 ]",
+		"set policy-options policy-statement P term T from prefix-list p3",
+		"set policy-options policy-statement P term T then accept",
+	})
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := cfg.PolicyOptions.PolicyStatements["P"].Terms[0]
+	want := []string{"p1", "p2", "p3"}
+	if !equalStrs(term.PrefixList, want) {
+		t.Errorf("PrefixList = %v, want %v (bracket+sibling composition)", term.PrefixList, want)
+	}
+}


### PR DESCRIPTION
Closes #2689

## What changed

The policy-statement `from community` and `from prefix-list` match readers in
`parsePolicyTermChildren` (`pkg/config/compiler_routing.go`) read a `multi: true`
leaf via only `nodeVal(fc)` = `child.Keys[1]` — no `Keys[1:]` slice, no
`child.Children` iteration. A bracketed list `[ c1 c2 ]` collapses onto a single
leaf's Keys in BOTH AST shapes (#2419), so the readers silently kept only the
FIRST value:

- `from community [ c1 c2 ]` matched only `c1`
- `from prefix-list [ p1 p2 ]` matched only `p1`

This is the exact same class fixed for the routing-protocol export/import and
community-members readers in **#2587 (PR #2687)** and **#2630 (PR #2685)**. The
fix routes both readers through the shared `firewallMatchValues` SSOT
(`Keys[1:]` + each child leaf), mirroring #2587's community-members fix. The
schema leaves were already `multi:true` (`schema_routing.go` ~105/107), so only
the compiler readers changed.

## #2642 composition

#2642 added the `[]string` OR/cartesian model for these from-* fields by
accumulating repeated SIBLING statements; it did NOT cover the bracket-list
collapse for these two readers. The fix composes with #2642: a term carrying
BOTH a bracket list AND a separate `from community c3` sibling keeps every value
(`[c1 c2 c3]`) — bracket values accumulate via `firewallMatchValues`, then the
sibling statement appends. The FRR cartesian render (`policy_render.go`) is
downstream and unchanged; it already consumes the `[]string` fields.

## Tests (fail-on-revert)

`pkg/config/policy_from_multileaf_2689_test.go` adds 6 cases for BOTH readers:

- flat-set bracket (`set ... from community [ c1 c2 ]` via `ParseSetCommand` + `SetPath`) → `[c1 c2]`
- hierarchical block (`from { community [ c1 c2 ]; }`) → `[c1 c2]`
- bracket + #2642 sibling (`[ c1 c2 ]` + `from community c3`) → `[c1 c2 c3]`

Proven fail-on-revert: temporarily restoring the old `nodeVal` reader makes all
6 fail (bracket truncates to first value; sibling-only composition keeps
`[c1 c3]` dropping the bracket's `c2`). All pass on the fix.

## Gates

- `gofmt` clean on touched files
- `GOCACHE=... go build ./...` clean
- `go test ./pkg/config/... ./pkg/frr/...` green (frr cartesian render unchanged downstream)
- `docs/config-schema.md` multi-value reader list extended with the #2689 readers; `_Log.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi