### PR TITLE
io_uring slow-path write error handling: no double-TX on partial (#2477) + no tight-spin on permanent error (#2478)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,5 +1,41 @@
 # Action Log
 
+## 2026-06-24 — #2477 + #2478: io_uring slow-path write error handling (one PR, two commits)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Two coupled io_uring write error-handling fixes sharing the
+  slow-path write helper.
+  - **#2477** (TUN double-transmission): `write_all`/`write_all_to_fd` now
+    return a `WriteError { NothingWritten(_) | Transferred(_) }` instead of a
+    bare `String`. `safe_to_retry()` is true only for `NothingWritten`
+    (submit-queue full, kernel completion error, zero-byte completion —
+    nothing on the fd). A packet-fd partial write, and an ambiguous reap
+    submit/wait error (SQE may be in flight), are `Transferred` (drop, never
+    re-send). The slow-path caller's `io_uring().or_else(|_| sync)` is
+    replaced by `write_packet_io_uring_or_sync` → `decide_sync_fallback`,
+    which falls back to the synchronous TUN write ONLY when
+    `safe_to_retry()`. Previously ANY io_uring error — including a partial
+    that already placed a truncated frame on the TUN — re-sent the whole
+    packet, yielding a truncated frame + a duplicate full frame.
+  - **#2478** (tight-spin on permanent error): `reap_matching` now calls
+    `is_permanent(errno)` (EBADF/EINVAL/EFAULT/ENXIO/EBADFD/ENODEV/
+    EOPNOTSUPP/EPERM) on the catch-all submit/wait error arm and returns
+    immediately rather than re-spinning to the `MAX_WAIT_RETRIES` (4096)
+    ceiling at 100% CPU; transient errors yield (`yield_now`) before
+    retrying.
+  - State writer (`state_writer.rs`) collapses the new `WriteError` to a
+    `String` (positioned byte-stream write, no sync fallback — retry-safety
+    classification is irrelevant there).
+- **File(s)**: userspace-dp/src/io_uring_write.rs,
+  userspace-dp/src/slowpath.rs, userspace-dp/src/state_writer.rs, _Log.md
+- **Validation**: `cargo build --release` clean (no new warnings in touched
+  files); `cargo test --release --bin xpf-userspace-dp` slowpath::/
+  io_uring_write::/state_writer:: all green. Fail-on-revert verified for
+  both: reverting `decide_sync_fallback` to sync-on-any-error makes
+  `partial_iouring_write_does_not_sync_fallback` RED; removing the
+  `is_permanent` fast-fail makes `permanent_error_returns_without_spinning`
+  RED (wait_calls hits the 4096 ceiling).
+
 ## 2026-06-24 — #2689 review fold: `from as-path` bracket-collapse (sibling reader, same function) — routed through firewallMatchValues + 3 fail-on-revert tests; children-path only (brackets never reach the inline-keys path). Files: pkg/config/compiler_routing.go, pkg/config/policy_from_multileaf_2689_test.go, docs/config-schema.md, _Log.md
 
 ## 2026-06-24 — #2689 fix: policy-term `from community` / `from prefix-list` dropped all but first bracketed value

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -40,6 +40,19 @@
 //!   * Because the function only returns after the matching CQE is reaped, the
 //!     caller's buffer provably outlives every kernel reference to it, closing
 //!     the UAF window.
+//!
+//! Error classification (two further defects, fixed together):
+//!
+//!   * #2477 — retry safety. On failure [`write_all`] returns a [`WriteError`]
+//!     that tells the caller whether a synchronous retry from offset 0 is safe.
+//!     `NothingWritten` (submit-queue full, a kernel completion error, a
+//!     zero-byte completion) put nothing on the fd → safe to sync-retry.
+//!     `Transferred` (a packet-fd partial write, or an ambiguous submit/wait
+//!     error where the SQE may be in flight) means bytes are — or may be —
+//!     already on the device → the caller MUST drop, never re-send. The TUN slow
+//!     path uses this so its io_uring→sync fallback cannot double-transmit a
+//!     packet; the state writer (a true byte stream, no sync fallback) ignores
+//!     it.
 
 use io_uring::{IoUring, opcode, types};
 use std::io;
@@ -81,6 +94,50 @@ pub(crate) trait RingPort {
 pub(crate) enum WriteOutcome {
     /// All `data.len()` bytes were written.
     Done,
+}
+
+/// Failure of [`write_all`] / [`write_all_to_fd`], carrying enough state for the
+/// caller to decide whether a synchronous retry is safe.
+///
+/// The distinction matters for a packet-oriented fd (the TUN slow path, #2477):
+/// a synchronous fallback must NEVER re-send a packet whose bytes the io_uring
+/// path already placed on the device, or the TUN sees a truncated frame followed
+/// by a duplicate full frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum WriteError {
+    /// Nothing was transferred — the io_uring path failed before (or while)
+    /// putting any bytes on the fd (submit-queue full, the kernel completion
+    /// reported an error, or a zero-byte completion). A synchronous retry from
+    /// offset 0 is safe: no bytes are on the device yet.
+    NothingWritten(String),
+    /// Bytes were (or may have been) transferred and a retry would corrupt the
+    /// stream. Two cases:
+    ///   * a packet-fd short write — `0 < n < len` bytes are already on the TUN
+    ///     as a truncated frame; re-sending the whole packet would duplicate it;
+    ///   * an ambiguous submit/wait error after the SQE was submitted — the
+    ///     write may be in flight, so a retry could double-transmit.
+    /// The caller MUST drop the packet, never fall back to a synchronous write.
+    Transferred(String),
+}
+
+impl WriteError {
+    /// True when a synchronous retry from offset 0 is safe (nothing is on the
+    /// fd yet). Only [`WriteError::NothingWritten`] qualifies.
+    pub(crate) fn safe_to_retry(&self) -> bool {
+        matches!(self, WriteError::NothingWritten(_))
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        match self {
+            WriteError::NothingWritten(m) | WriteError::Transferred(m) => m,
+        }
+    }
+}
+
+impl std::fmt::Display for WriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.message())
+    }
 }
 
 /// `RingPort` adapter over a real `io_uring::IoUring`.
@@ -130,13 +187,18 @@ impl RingPort for IoUringPort<'_> {
 ///
 /// Returns once every byte is written AND every SQE this call submitted has
 /// been reaped, so `data` may be dropped safely on return.
+///
+/// On failure the [`WriteError`] reports whether a synchronous retry is safe —
+/// see [`WriteError::safe_to_retry`] / #2477. The state writer ignores this
+/// (it has no sync fallback); the TUN slow path uses it to avoid double-sending
+/// a packet whose bytes are already on the device.
 pub(crate) fn write_all_to_fd(
     ring: &mut IoUring,
     fd: i32,
     data: &[u8],
     positioned: bool,
     label: &str,
-) -> Result<(), String> {
+) -> Result<(), WriteError> {
     let mut port = IoUringPort { ring, fd };
     write_all(&mut port, data, positioned, label).map(|_| ())
 }
@@ -163,7 +225,7 @@ pub(crate) fn write_all(
     data: &[u8],
     positioned: bool,
     label: &str,
-) -> Result<WriteOutcome, String> {
+) -> Result<WriteOutcome, WriteError> {
     let mut offset = 0usize;
     // Distinct tag per submission. Start at 1 so a zero `user_data` (the value
     // an uninitialised / pre-existing CQE would carry) is never a valid match.
@@ -172,35 +234,51 @@ pub(crate) fn write_all(
     while offset < data.len() {
         let chunk = &data[offset..];
         let file_offset = if positioned { Some(offset as u64) } else { None };
-        port.push_write(tag, chunk, file_offset)?;
+        // A push failure means the SQE was never submitted — nothing is on the
+        // fd, so a synchronous retry from offset 0 is safe (#2477). For a packet
+        // fd this is always the first (only) chunk, so `offset == 0` and a
+        // retry-from-0 is sound.
+        port.push_write(tag, chunk, file_offset)
+            .map_err(WriteError::NothingWritten)?;
 
         // Submit + reap exactly the completion for THIS submission. The
         // closure below loops on the wait so an EINTR (or any wait error) does
-        // not leave the SQE outstanding.
-        let res = reap_matching(port, tag, label)?;
+        // not leave the SQE outstanding. A reap error is AMBIGUOUS: the SQE was
+        // already submitted, so the write may be in flight and a retry could
+        // double-transmit on a packet fd — classify it as `Transferred` (drop,
+        // never sync-retry).
+        let res = reap_matching(port, tag, label).map_err(WriteError::Transferred)?;
 
         if res < 0 {
-            return Err(format!(
+            // The kernel completion reported a write error: nothing was placed
+            // on the fd, so a synchronous retry from offset 0 is safe.
+            return Err(WriteError::NothingWritten(format!(
                 "{label} io_uring write failed: {}",
                 io::Error::from_raw_os_error(-res)
-            ));
+            )));
         }
         if res == 0 {
-            return Err(format!("{label} io_uring short write: 0"));
+            // Zero bytes transferred — safe to retry synchronously.
+            return Err(WriteError::NothingWritten(format!(
+                "{label} io_uring short write: 0"
+            )));
         }
         let n = res as usize;
         // A non-positioned (stream-mode) write targets a packet-oriented fd:
         // the TUN slow path (#2407). One submission is one L3 packet. A short
         // CQE count must NOT resubmit the remainder — re-writing `data[n..]`
         // would inject the leftover bytes as a SECOND, malformed packet. Treat
-        // a partial as an unsendable packet and drop it (Err); the caller
-        // counts the drop. Positioned writes (a regular file — the state
-        // writer) are a true byte stream and DO resume from `offset + n`.
+        // a partial as an unsendable packet and drop it (Err) — and because
+        // `0 < n < len` bytes are ALREADY on the TUN, classify it as
+        // `Transferred` so the caller does NOT fall back to a synchronous write
+        // (which would re-send the whole packet → truncated frame + duplicate,
+        // #2477). Positioned writes (a regular file — the state writer) are a
+        // true byte stream and DO resume from `offset + n`.
         if !positioned && n < data.len() {
-            return Err(format!(
+            return Err(WriteError::Transferred(format!(
                 "{label} io_uring short write on packet fd: wrote {n} of {} bytes (packet dropped)",
                 data.len()
-            ));
+            )));
         }
         offset += n;
         // Advance the tag so the next submission's CQE cannot be confused with
@@ -469,8 +547,19 @@ mod tests {
         let mut ring = FakeRing::new(vec![Ok(()), Ok(())], vec![2, 2]);
         let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
         assert!(
-            err.contains("short write on packet fd"),
+            err.message().contains("short write on packet fd"),
             "partial packet write must be a drop, got: {err}"
+        );
+        // #2477: a packet-fd partial write put bytes on the TUN, so it MUST
+        // classify as `Transferred` (NOT safe to retry) — otherwise the
+        // slow-path caller would sync-retry and re-send the whole packet.
+        assert!(
+            matches!(err, WriteError::Transferred(_)),
+            "a packet-fd partial write must be Transferred, got: {err:?}"
+        );
+        assert!(
+            !err.safe_to_retry(),
+            "a packet-fd partial write must NOT be safe to sync-retry (#2477)"
         );
         assert_eq!(
             ring.push_calls, 1,
@@ -591,7 +680,13 @@ mod tests {
     fn negative_result_is_error() {
         let mut ring = FakeRing::new(vec![Ok(())], vec![-libc::EIO]);
         let err = write_all(&mut ring, &[0u8; 4], false, "test").unwrap_err();
-        assert!(err.contains("io_uring write failed"), "got: {err}");
+        assert!(err.message().contains("io_uring write failed"), "got: {err}");
+        // The kernel completion errored — nothing reached the fd, so a
+        // synchronous retry from offset 0 is safe (#2477).
+        assert!(
+            err.safe_to_retry(),
+            "a kernel completion error transferred nothing; sync-retry must be safe"
+        );
     }
 
     /// res == 0 is a short write and must be an error, not an infinite loop.
@@ -599,7 +694,9 @@ mod tests {
     fn zero_result_is_short_write_error() {
         let mut ring = FakeRing::new(vec![Ok(())], vec![0]);
         let err = write_all(&mut ring, &[0u8; 4], false, "test").unwrap_err();
-        assert!(err.contains("short write"), "got: {err}");
+        assert!(err.message().contains("short write"), "got: {err}");
+        // Zero bytes transferred — safe to retry synchronously (#2477).
+        assert!(err.safe_to_retry(), "a zero-byte completion must be safe to retry");
     }
 
     /// Several EINTRs in a row still converge — the loop keeps waiting.

--- a/userspace-dp/src/io_uring_write.rs
+++ b/userspace-dp/src/io_uring_write.rs
@@ -53,6 +53,12 @@
 //!     path uses this so its io_uring→sync fallback cannot double-transmit a
 //!     packet; the state writer (a true byte stream, no sync fallback) ignores
 //!     it.
+//!   * #2478 — permanent-error fast-fail. [`reap_matching`] no longer
+//!     re-spins the submit/wait on a PERMANENT OS error (a bad/closed ring fd,
+//!     EINVAL, EFAULT, …) — those return the same error forever and would burn a
+//!     full core through the `MAX_WAIT_RETRIES` ceiling. [`is_permanent`]
+//!     classifies the errno; permanent errors return immediately, transient ones
+//!     (EINTR/EAGAIN) retry after a `yield_now`.
 
 use io_uring::{IoUring, opcode, types};
 use std::io;
@@ -291,10 +297,38 @@ pub(crate) fn write_all(
     Ok(WriteOutcome::Done)
 }
 
+/// True when `err` is a PERMANENT OS failure that a retry cannot recover from
+/// (a bad/closed ring fd, an invalid argument, a faulting buffer). Retrying
+/// these would just re-spin at 100% CPU through the `MAX_WAIT_RETRIES` ceiling
+/// (#2478), so [`reap_matching`] returns immediately on them. EINTR/EAGAIN (and
+/// any unrecognised errno) are treated as TRANSIENT and retried.
+fn is_permanent(err: &io::Error) -> bool {
+    match err.raw_os_error() {
+        Some(e) => matches!(
+            e,
+            libc::EBADF        // ring fd closed / never valid
+                | libc::EINVAL     // malformed submission / unsupported op
+                | libc::EFAULT     // buffer/iovec points at unmapped memory
+                | libc::ENXIO      // device/ring gone
+                | libc::EBADFD     // ring in a bad state
+                | libc::ENODEV     // backing device removed
+                | libc::EOPNOTSUPP // op not supported by the ring
+                | libc::EPERM      // not permitted — no point retrying
+        ),
+        // No errno (e.g. a non-OS io::Error) — treat as transient and let the
+        // retry ceiling bound it rather than wedging on a misclassification.
+        None => false,
+    }
+}
+
 /// Submit the queued SQE and reap the completion whose `user_data == want`,
 /// retrying the wait on `EINTR`/error so the in-flight SQE is never abandoned.
 /// Stale completions (a different `user_data`, e.g. a leftover from a prior
 /// interrupted call) are drained and discarded rather than mis-attributed.
+///
+/// A PERMANENT submit/wait error (bad ring fd, EINVAL, EFAULT, …) returns
+/// immediately instead of re-spinning through `MAX_WAIT_RETRIES` at 100% CPU
+/// (#2478); a TRANSIENT error yields the core before retrying.
 fn reap_matching(port: &mut dyn RingPort, want: u64, label: &str) -> Result<i32, String> {
     // First, drain any already-ready stale completions so a leftover CQE from a
     // previously interrupted submission can never be returned as ours. At this
@@ -326,9 +360,23 @@ fn reap_matching(port: &mut dyn RingPort, want: u64, label: &str) -> Result<i32,
                 continue;
             }
             Err(err) => {
-                // Any other wait error: the SQE may still be in flight. Keep
-                // waiting for it to drain rather than returning and leaving the
-                // ring desynchronised for the next write.
+                // A PERMANENT error (bad/closed ring fd, EINVAL, EFAULT, …)
+                // returns the SAME error on every retry. Looping on it just
+                // burns a full core through the MAX_WAIT_RETRIES ceiling without
+                // making progress (#2478) — fail fast instead. The caller drops
+                // the packet; leaving the ring "desynchronised" is moot when the
+                // ring fd itself is dead.
+                if is_permanent(&err) {
+                    return Err(format!(
+                        "{label} io_uring permanent submit/wait error: {err}"
+                    ));
+                }
+                // A TRANSIENT wait error (e.g. EAGAIN): the SQE may still be in
+                // flight. Keep waiting for it to drain rather than returning and
+                // leaving the ring desynchronised for the next write — but yield
+                // the core first so a burst of transient failures does not
+                // tight-spin at 100% CPU before the ceiling.
+                std::thread::yield_now();
                 waits += 1;
                 if waits >= MAX_WAIT_RETRIES {
                     return Err(format!("{label} io_uring submit/wait: {err}"));
@@ -406,6 +454,14 @@ mod tests {
         /// alongside the real CQE and the REAP-LOOP user_data match is what must
         /// skip it. `None` for a given wait injects nothing.
         stale_on_wait: VecDeque<Option<Completion>>,
+        /// Number of `submit_and_wait_one` calls — the spin counter for #2478.
+        /// A permanent error must return after exactly ONE wait, not loop to the
+        /// `MAX_WAIT_RETRIES` ceiling.
+        wait_calls: usize,
+        /// When set, every wait beyond the scripted `wait_script` returns this
+        /// errno (instead of materialising a completion). Models a ring fd that
+        /// keeps returning the SAME error — the #2478 tight-spin condition.
+        repeat_err: Option<i32>,
     }
 
     impl FakeRing {
@@ -419,7 +475,16 @@ mod tests {
                 real_tags: std::collections::HashSet::new(),
                 accepted_bytes: 0,
                 stale_on_wait: VecDeque::new(),
+                wait_calls: 0,
+                repeat_err: None,
             }
+        }
+
+        /// Make every wait past the script return `errno` forever (no
+        /// completion). Used to drive the #2478 permanent/transient spin tests.
+        fn with_repeat_err(mut self, errno: i32) -> Self {
+            self.repeat_err = Some(errno);
+            self
         }
 
         fn with_stale(mut self, stale: Vec<Completion>) -> Self {
@@ -476,6 +541,7 @@ mod tests {
         }
 
         fn submit_and_wait_one(&mut self) -> io::Result<()> {
+            self.wait_calls += 1;
             match self.wait_script.pop_front() {
                 Some(Ok(())) => {
                     self.materialise_on_successful_wait();
@@ -483,8 +549,13 @@ mod tests {
                 }
                 Some(Err(e)) => Err(e),
                 None => {
-                    // No more script: behave as a successful wait that
-                    // materialises an in-flight completion if any, else Ok.
+                    // Script exhausted: if a repeating errno was configured, keep
+                    // returning it (no completion) so the caller's retry loop is
+                    // exercised (#2478). Otherwise behave as a successful wait
+                    // that materialises an in-flight completion if any, else Ok.
+                    if let Some(errno) = self.repeat_err {
+                        return Err(io::Error::from_raw_os_error(errno));
+                    }
                     self.materialise_on_successful_wait();
                     Ok(())
                 }
@@ -715,5 +786,96 @@ mod tests {
         let out = write_all(&mut ring, &[0u8; 6], true, "state").unwrap();
         assert_eq!(out, WriteOutcome::Done);
         assert_eq!(ring.push_calls, 2);
+    }
+
+    fn os_err(errno: i32) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(errno))
+    }
+
+    /// #2478 errno classification: the permanent set returns from the retry
+    /// loop, the transient set keeps retrying.
+    #[test]
+    fn is_permanent_classifies_errnos() {
+        for e in [
+            libc::EBADF,
+            libc::EINVAL,
+            libc::EFAULT,
+            libc::ENXIO,
+            libc::EBADFD,
+            libc::ENODEV,
+            libc::EOPNOTSUPP,
+            libc::EPERM,
+        ] {
+            assert!(
+                is_permanent(&io::Error::from_raw_os_error(e)),
+                "errno {e} must be permanent"
+            );
+        }
+        for e in [libc::EINTR, libc::EAGAIN] {
+            assert!(
+                !is_permanent(&io::Error::from_raw_os_error(e)),
+                "errno {e} must be transient"
+            );
+        }
+        // A non-OS io::Error has no errno — treated as transient (bounded by the
+        // retry ceiling) rather than misclassified as permanent.
+        assert!(!is_permanent(&io::Error::new(io::ErrorKind::Other, "no errno")));
+    }
+
+    /// #2478 fail-on-revert: a PERMANENT submit/wait error (EBADF) must return
+    /// after exactly ONE `submit_and_wait_one` call — never tight-spin up to the
+    /// MAX_WAIT_RETRIES (4096) ceiling at 100% CPU.
+    ///
+    /// `repeat_err` makes every wait return EBADF forever. With the old
+    /// unconditional-retry arm, `wait_calls` would reach 4096 before the ceiling
+    /// gives up (the assert `== 1` fails). With the fix, `is_permanent(EBADF)`
+    /// returns immediately on the first wait.
+    #[test]
+    fn permanent_error_returns_without_spinning() {
+        let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EBADF);
+        let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
+        assert!(
+            err.message().contains("permanent submit/wait error"),
+            "got: {err}"
+        );
+        // The single load-bearing assertion: ONE wait, not 4096.
+        assert_eq!(
+            ring.wait_calls, 1,
+            "a permanent error must fail fast after one wait, not spin to the ceiling"
+        );
+        // A permanent submit/wait error is ambiguous about the SQE, so it is
+        // `Transferred` (no sync-retry) — consistent with the #2477 contract.
+        assert!(matches!(err, WriteError::Transferred(_)));
+    }
+
+    /// #2478 complement: a TRANSIENT error (EAGAIN) is NOT permanent, so the loop
+    /// keeps retrying and DOES reach the MAX_WAIT_RETRIES ceiling rather than
+    /// returning on the first wait. This proves the classification actually
+    /// gates the behaviour (and that transient errors are not fast-failed).
+    #[test]
+    fn transient_error_retries_to_ceiling() {
+        let mut ring = FakeRing::new(vec![], vec![]).with_repeat_err(libc::EAGAIN);
+        let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
+        assert!(err.message().contains("submit/wait"), "got: {err}");
+        // It looped to the ceiling (4096) rather than bailing on wait #1.
+        assert!(
+            ring.wait_calls >= 4096,
+            "a transient error must keep retrying to the ceiling, got {} waits",
+            ring.wait_calls
+        );
+    }
+
+    /// A single EINTR followed by a permanent EBADF returns on the permanent
+    /// error — EINTR retried (wait #1), EBADF fast-failed (wait #2). Confirms the
+    /// permanent check sits on the catch-all arm, not the EINTR arm.
+    #[test]
+    fn eintr_then_permanent_returns_promptly() {
+        let mut ring = FakeRing::new(vec![os_err(libc::EINTR)], vec![]).with_repeat_err(libc::EBADF);
+        let err = write_all(&mut ring, &[0u8; 4], false, "slow-path").unwrap_err();
+        assert!(err.message().contains("permanent submit/wait error"), "got: {err}");
+        assert_eq!(
+            ring.wait_calls, 2,
+            "EINTR retries once, then the permanent EBADF fast-fails — two waits total"
+        );
     }
 }

--- a/userspace-dp/src/slowpath.rs
+++ b/userspace-dp/src/slowpath.rs
@@ -383,8 +383,9 @@ fn slow_path_worker(name: &str, mtu: i32, rx: Receiver<PacketRequest>, status: A
     while let Ok(req) = rx.recv() {
         status.queued_packets.fetch_sub(1, Ordering::Relaxed);
         let result = match &mut mode {
-            WriteMode::IoUring(ring) => write_packet_io_uring(ring, tun.as_raw_fd(), &req.bytes)
-                .or_else(|_| write_packet_sync(tun.as_raw_fd(), &req.bytes)),
+            WriteMode::IoUring(ring) => {
+                write_packet_io_uring_or_sync(ring, tun.as_raw_fd(), &req.bytes)
+            }
             WriteMode::SyncFallback => write_packet_sync(tun.as_raw_fd(), &req.bytes),
         };
         match result {
@@ -466,13 +467,59 @@ where
     }
 }
 
-fn write_packet_io_uring(ring: &mut IoUring, fd: i32, bytes: &[u8]) -> Result<(), String> {
+fn write_packet_io_uring(
+    ring: &mut IoUring,
+    fd: i32,
+    bytes: &[u8],
+) -> Result<(), crate::io_uring_write::WriteError> {
     // Stream write to the TUN device (no file offset). The shared loop retries
     // the wait on EINTR rather than abandoning an in-flight SQE, matches the
     // completion by user_data so a stale CQE cannot corrupt the offset, and
     // returns only after the matching CQE is reaped so `bytes` outlives every
     // kernel reference (#2297).
     crate::io_uring_write::write_all_to_fd(ring, fd, bytes, false, "slow-path")
+}
+
+/// Write one packet to the TUN via io_uring, falling back to a synchronous
+/// `write()` ONLY when the io_uring attempt put nothing on the device (#2477).
+///
+/// A naive `io_uring().or_else(sync)` re-sends the whole packet on ANY io_uring
+/// error — including a partial write that already placed bytes on the
+/// packet-oriented TUN. The fallback then injects the full frame again, so the
+/// TUN sees a truncated frame followed by a duplicate full frame (parser errors
+/// / duplicate delivery to local BGP/OSPF listeners). The synchronous fallback
+/// is therefore gated on [`crate::io_uring_write::WriteError::safe_to_retry`]:
+/// only a failure that transferred nothing (submit-queue full, a kernel
+/// completion error, a zero-byte completion) may retry. A partial transfer — or
+/// an ambiguous submit/wait error where the SQE may be in flight — drops the
+/// packet instead.
+fn write_packet_io_uring_or_sync(ring: &mut IoUring, fd: i32, bytes: &[u8]) -> Result<(), String> {
+    decide_sync_fallback(write_packet_io_uring(ring, fd, bytes), || {
+        write_packet_sync(fd, bytes)
+    })
+}
+
+/// The #2477 fallback DECISION, factored out so it is unit-testable without a
+/// live io_uring ring or TUN fd. Given the io_uring write `result` and a
+/// `sync_fallback` thunk, only invokes the synchronous fallback when the
+/// io_uring failure transferred NOTHING (`safe_to_retry`). A partial transfer —
+/// or an ambiguous in-flight error — drops the packet so the whole frame is
+/// never re-sent on top of bytes already on the TUN.
+fn decide_sync_fallback<F>(
+    result: Result<(), crate::io_uring_write::WriteError>,
+    sync_fallback: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) if err.safe_to_retry() => sync_fallback(),
+        // Bytes are (or may be) already on the TUN — re-sending would
+        // double-transmit / corrupt the device. Drop the packet (the caller
+        // counts it as a write error + drop).
+        Err(err) => Err(err.to_string()),
+    }
 }
 
 pub(crate) fn open_tun(name: &str) -> Result<(std::fs::File, String), String> {
@@ -1034,5 +1081,91 @@ mod tests {
         // SAFETY: we just wrote the `mtu` arm, so reading it back is defined.
         assert_eq!(unsafe { ifr.ifru.mtu }, 9000);
         assert_eq!(ifr.name_string(), "xpf-usp0");
+    }
+
+    use crate::io_uring_write::WriteError;
+    use std::cell::Cell;
+
+    /// #2477 fail-on-revert: a PARTIAL io_uring write (`WriteError::Transferred`)
+    /// already placed bytes on the packet-oriented TUN. The fallback decision
+    /// MUST NOT invoke the synchronous write — doing so re-sends the whole frame
+    /// on top of the truncated one (truncated + duplicate delivery).
+    ///
+    /// The sync-fallback thunk records whether it ran. With the old behaviour
+    /// (`io_uring().or_else(|_| sync)` — i.e. sync on ANY error), the thunk would
+    /// fire for this partial and the assertions below fail.
+    #[test]
+    fn partial_iouring_write_does_not_sync_fallback() {
+        let sync_ran = Cell::new(false);
+        let res = decide_sync_fallback(
+            Err(WriteError::Transferred(
+                "slow-path io_uring short write on packet fd: wrote 40 of 1400 bytes".to_string(),
+            )),
+            || {
+                sync_ran.set(true);
+                Ok(())
+            },
+        );
+        assert!(
+            !sync_ran.get(),
+            "a partial io_uring write must NOT sync-retry — re-sending the whole \
+             packet on top of the bytes already on the TUN double-transmits (#2477)"
+        );
+        assert!(
+            res.is_err(),
+            "the partial packet must be DROPPED (Err), not silently succeeded"
+        );
+    }
+
+    /// #2477 fail-on-revert: an ambiguous reap error where the SQE may be in
+    /// flight is also `Transferred` — never sync-retry (could double-transmit).
+    #[test]
+    fn ambiguous_reap_error_does_not_sync_fallback() {
+        let sync_ran = Cell::new(false);
+        let res = decide_sync_fallback(
+            Err(WriteError::Transferred(
+                "slow-path io_uring submit/wait: some wait error".to_string(),
+            )),
+            || {
+                sync_ran.set(true);
+                Ok(())
+            },
+        );
+        assert!(!sync_ran.get(), "an in-flight-ambiguous error must not sync-retry");
+        assert!(res.is_err());
+    }
+
+    /// Complement: a ZERO-byte io_uring failure (`WriteError::NothingWritten`)
+    /// put nothing on the TUN, so the synchronous fallback MUST run — the packet
+    /// is still deliverable and dropping it would be a regression.
+    #[test]
+    fn zero_byte_iouring_failure_does_sync_fallback() {
+        let sync_ran = Cell::new(false);
+        let res = decide_sync_fallback(
+            Err(WriteError::NothingWritten(
+                "slow-path io_uring write failed: Input/output error".to_string(),
+            )),
+            || {
+                sync_ran.set(true);
+                Ok(())
+            },
+        );
+        assert!(
+            sync_ran.get(),
+            "a zero-byte io_uring failure transferred nothing — sync-retry MUST run"
+        );
+        assert!(res.is_ok(), "the sync fallback succeeded, so the result is Ok");
+    }
+
+    /// The happy path: a successful io_uring write never touches the sync path.
+    #[test]
+    fn successful_iouring_write_skips_sync_fallback() {
+        let sync_ran = Cell::new(false);
+        let res = decide_sync_fallback(Ok(()), || {
+            sync_ran.set(true);
+            Ok(())
+        });
+        assert!(!sync_ran.get(), "a successful io_uring write must not sync-retry");
+        assert!(res.is_ok());
     }
 }

--- a/userspace-dp/src/state_writer.rs
+++ b/userspace-dp/src/state_writer.rs
@@ -214,7 +214,11 @@ fn write_all_with_ring(ring: &mut IoUring, fd: i32, data: &[u8]) -> Result<(), S
     // by user_data so a stale CQE cannot corrupt the file offset, and returns
     // only after the matching CQE is reaped so `data` outlives every kernel
     // reference (#2297).
+    // The state writer is a positioned (byte-stream) write with no synchronous
+    // fallback, so it does not consume the `WriteError` retry-safety
+    // classification (#2477) — collapse it to the error message.
     crate::io_uring_write::write_all_to_fd(ring, fd, data, true, "state")
+        .map_err(|e| e.to_string())
 }
 
 fn temporary_path(path: &str) -> PathBuf {


### PR DESCRIPTION
Closes #2477
Closes #2478

Two coupled io_uring write error-handling bugs sharing the slow-path write
helper (`userspace-dp/src/io_uring_write.rs` + the TUN slow-path caller in
`slowpath.rs`), fixed with a single error-classification approach. Two
logical commits.

## #2477 — TUN double-transmission on io_uring->sync fallback (MEDIUM, correctness)

The slow-path TUN write fell back from io_uring to a synchronous write on
ANY io_uring error: `write_packet_io_uring(...).or_else(|_| sync)`. That
includes a PARTIAL io_uring write, which on a packet-oriented TUN has
already injected a truncated L3 frame. The synchronous fallback then
re-sent the WHOLE packet from offset 0 -> truncated frame + duplicate full
frame (parser errors / duplicate delivery to local BGP/OSPF listeners).
#2407 handled the within-one-write path but not this io_uring->sync
FALLBACK double-write.

**Transferred-bytes representation:** `write_all` / `write_all_to_fd` now
return `Result<_, WriteError>` (was `Result<_, String>`), where

- `WriteError::NothingWritten(_)` — submit-queue-full push error, a kernel
  completion error (negative res), or a zero-byte completion. Nothing
  reached the fd, so `safe_to_retry()` is **true**.
- `WriteError::Transferred(_)` — a packet-fd short write (`0 < n < len`,
  bytes already on the TUN) **or** an ambiguous reap submit/wait error
  (the SQE may be in flight). A retry could double-transmit, so
  `safe_to_retry()` is **false**.

The slow-path caller replaces `.or_else(|_| sync)` with
`write_packet_io_uring_or_sync` -> `decide_sync_fallback`, which runs the
synchronous TUN write ONLY when `safe_to_retry()`; otherwise it drops the
packet (counted as a write error + drop). `decide_sync_fallback` is a pure
decision over `WriteError` + a sync thunk, unit-testable without a live
ring/TUN. The state writer (positioned byte stream, no sync fallback)
collapses `WriteError` to a `String`.

**Fail-on-revert tests (how no-double-write is proven):**
`slowpath::partial_iouring_write_does_not_sync_fallback` passes a
`WriteError::Transferred` and a sync thunk that records whether it ran; it
asserts the thunk did NOT run and the result is Err (drop). Reverting
`decide_sync_fallback` to the old sync-on-any-error behaviour makes the
thunk fire -> RED (verified). The complement
`zero_byte_iouring_failure_does_sync_fallback` asserts a `NothingWritten`
failure DOES fall back.

## #2478 — reap_matching tight-spins on permanent errors (MEDIUM, CPU)

`reap_matching` retried submit/wait on ANY non-EINTR error with no yield,
up to the `MAX_WAIT_RETRIES` (4096) ceiling. A permanent failure (EBADF /
EINVAL / EFAULT, …) returns the same error every call, so the worker spun
through 4096 immediate failures at 100% CPU.

Added `is_permanent(errno)` (EBADF/EINVAL/EFAULT/ENXIO/EBADFD/ENODEV/
EOPNOTSUPP/EPERM permanent; EINTR/EAGAIN and no-errno transient). The
catch-all error arm returns immediately on a permanent error; a transient
error yields the core (`std::thread::yield_now()`) before retrying. The
EINTR arm is unchanged.

**Fail-on-revert tests:** `permanent_error_returns_without_spinning` uses
the FakeRing seam (new `wait_calls` counter + `with_repeat_err(EBADF)`)
and asserts `wait_calls == 1`, not 4096. Removing the `is_permanent`
fast-fail makes it hit the ceiling -> RED (verified).
`transient_error_retries_to_ceiling` asserts EAGAIN still loops to 4096
(classification actually gates behaviour); `eintr_then_permanent_returns_promptly`
confirms the check is on the catch-all arm, not the EINTR arm.

## Gates
- `cargo build --release` clean — no new warnings in the touched files.
- `cargo test --release --bin xpf-userspace-dp` green: slowpath:: (21),
  io_uring_write:: (15), state_writer:: (4).
- Fail-on-revert verified RED for the load-bearing test of each bug.
- Module contract doc updated (io_uring_write.rs header + inline rationale);
  `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
