### PR TITLE
#2691 P1b: ScopeKey + per-scope policy + per-RG HA gate + source binding

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14014,3 +14014,50 @@ top.
   only full-suite failure is the pre-existing `pkg/fsatomic` canary flagging
   `pkg/dataplane/proxyarp.go` (untouched by this PR). `make test-failover`
   deferred to the parent (no cluster access); the HA gate is call-through-only.
+
+---
+
+## 2026-06-24 — #2691 Phase P1b: ScopeKey + per-scope policy + per-RG HA gate + source binding
+
+- **Timestamp**: 2026-06-24
+- **Action**: Implement #2691 P1b (closes #2663, #2664, #2665) on the P1a
+  pkg/ddns spine — the load-bearing ScopeKey primitive, independent v4/v6
+  policy, the per-RG HA writer gate, and RFC 2136 source/VRF binding.
+- **ScopeKey (#2663/#2664, plan §5.4)**: added `ScopeKey
+  {Family,Interface,Unit,RoutingInstance,RGOwner,PolicyID}` +
+  `Family`/`familyOf` to `pkg/ddns/state.go`. Ownership records carry a
+  `*ScopeKey` (pointer → JSON-omitted for the zero/global scope) and are keyed
+  by `{scope,identity,address}`. The ZERO scope reproduces the pre-P1b
+  `identity|address` key byte-for-byte → pre-P1b stores load with NO migration
+  (plan §11 Q7). `scopeOf()`/`withScope()` helpers; `get`/`delete`/`put`/`all`
+  + `loadDDNSState` made scope-aware.
+- **Independent v4/v6 policy (#2663)**: `Reconcile` → `ReconcileScoped`
+  resolves a policy + backend PER FAMILY (`reconcileEnv.pol[2]/updater[2]`)
+  from `DHCPServerConfig.DynamicDNS` (v4) + new `.DynamicDNSv6` (v6). Compiler
+  routes v4→DynamicDNS, v6→DynamicDNSv6 (no more field-merge). Single-family
+  backward compat: the other family inherits the single block at reconcile.
+- **Per-RG HA gate (#2664)**: `ReconcileOptions{Gate,Resolver}` →
+  `reconcileOnceLocked` tags each lease's scope + applies the gate
+  (stop-writing-never-withdraw for a gated-out scope; fail-closed on
+  unattributable when RG-owned pools exist). Daemon `ddnsReconcileOptions`
+  builds the resolver (lease addr → pool-subnet CIDR → group → interface → RG)
+  + gate (master[RGOwner]); `reconcileDDNSOnce` calls `ReconcileScoped`. Added
+  the partial-demotion DDNS nudge in `clearRethServicesForRG`.
+- **Source/VRF binding (#2665)**: new `pkg/ddns/backend_bind.go` builds a
+  custom `net.Dialer` (one Control hook: `unix.Bind` source IP +
+  `SO_BINDTODEVICE` interface/VRF, works for UDP-first + TCP-retry).
+  `newRFC2136Updater` installs it; invalid source-address → hard ctor error →
+  family falls back to no-op. New config leaves source-address /
+  destination-interface / routing-instance (schema + compiler + types).
+- **File(s)**: [Write] pkg/ddns/backend_bind.go, pkg/ddns/scope_test.go,
+  pkg/ddns/backend_bind_test.go, pkg/daemon/daemon_ddns_scope_test.go;
+  [Edit] pkg/ddns/{state,manager,backend_rfc2136,README}.go|md,
+  pkg/ddns/{manager_test,durability_test}.go,
+  pkg/config/{types_system,compiler_services,schema_system}.go,
+  pkg/config/compiler_dhcp_ddns_test.go,
+  pkg/daemon/{daemon_ddns,daemon_ha}.go, docs/config-schema.md, _Log.md.
+- **Validation**: `go build ./...` clean; `gofmt`/`go vet` clean on touched
+  files; `go test ./pkg/ddns/ ./pkg/config/ ./pkg/dhcpserver/ ./pkg/daemon/`
+  all green; `go test -race ./pkg/ddns/` green. `make test-failover` is
+  MANDATORY (HA gate change) and DEFERRED to the parent (no cluster access);
+  the gate is reasoned + unit-tested (partial-demotion + fail-on-revert).

--- a/_Log.md
+++ b/_Log.md
@@ -14061,3 +14061,44 @@ top.
   all green; `go test -race ./pkg/ddns/` green. `make test-failover` is
   MANDATORY (HA gate change) and DEFERRED to the parent (no cluster access);
   the gate is reasoned + unit-tested (partial-demotion + fail-on-revert).
+
+---
+
+## 2026-06-24 — #2691 P1b review fold (#2664 MAJOR + MINOR)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Address PR #2697 review (MERGE-NEEDS-MAJOR): one HA-correctness
+  MAJOR + one MINOR.
+- **MAJOR — partial-demotion withdrawal blackhole (#2664/§5.6)**: Pass 1
+  protected an owned record from withdrawal ONLY via `gatedScope`, which is
+  populated solely from leases in the CURRENT parsed set. On a STEADY-STATE
+  partial demotion the demoted RG's group is dropped from the narrowed Kea
+  config and its leases age out of the memfile → they vanish from the parsed
+  set → gatedScope never learns the demoted RG's prefix → Pass 1 saw the owned
+  record as expired and WITHDREW it (the exact blackhole the gate exists to
+  prevent). FIX (`pkg/ddns/manager.go` Pass 1): protect whenever the gate
+  rejects the OWNED record's stored scope —
+  `gatedScope[...] || !env.scopeAdmits(owned.scopeOf())` — re-consulting the
+  SAME gate the publish path uses so publish + withdraw agree. Standalone (nil
+  gate) admits all → guard inert → turn-off/expiry/reassign withdrawal
+  unaffected; disabled-family records are in mastered scopes → still withdrawn.
+- **MINOR — non-deterministic overlapping-pool attribution**:
+  `buildLeaseSubnetRGMap` appended in Go map-iteration order (randomized) and
+  `rgForLeaseAddress` first-matched, so two overlapping cross-RG pools could
+  flip the attributed RG between passes (gate flap). FIX
+  (`pkg/daemon/daemon_ddns.go`): sort the subnet→RG slice MOST-SPECIFIC-FIRST
+  (longest prefix wins) with a stable CIDR/RG tie-break.
+- **Tests**: `TestPerRGGatePartialDemotionSteadyState`
+  (`pkg/ddns/scope_test.go`) — Phase 2 DROPS the demoted RG's lease from the
+  source, asserts NOT withdrawn + still owned + kept RG keeps publishing;
+  VERIFIED RED on the pre-fix guard (withdrew rg2host) and GREEN with the fix
+  (fail-on-revert). `TestDDNSOverlappingPoolAttributionDeterministic`
+  (`pkg/daemon/daemon_ddns_scope_test.go`) — 50 rebuilds, overlap address
+  always attributes to the more-specific RG.
+- **File(s)**: [Edit] pkg/ddns/manager.go, pkg/ddns/scope_test.go,
+  pkg/daemon/daemon_ddns.go, pkg/daemon/daemon_ddns_scope_test.go,
+  pkg/ddns/README.md, _Log.md.
+- **Validation**: `go build ./...` clean; gofmt/vet clean on touched files;
+  `go test ./pkg/{ddns,config,dhcpserver,daemon}` green; `-race ./pkg/ddns`
+  green. `make test-failover` still MANDATORY — the parent re-runs it on the
+  folded head.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -609,6 +609,50 @@ reserved for whole-dataplane selection where a rewrite shim
   empty-tree-compiles-non-nil trap). Regression coverage:
   `pkg/config/compiler_dhcp_ddns_test.go` (dual-AST equality, absent-default,
   TSIG redaction, enum/ttl accept+reject).
+- **#2691 P1b (DDNS ScopeKey + independent v4/v6 policy + source binding):**
+  three additions to the `dynamic-dns` subtree above.
+  - **#2663 — independent v4/v6 policy.** The v4 (`dhcp-local-server`) and v6
+    (`dhcpv6-local-server`) blocks now compile to SEPARATE fields —
+    `DHCPServerConfig.DynamicDNS` (v4) and `DHCPServerConfig.DynamicDNSv6`
+    (v6) — instead of one field-merged struct. Each family keeps its OWN
+    `domain` / `update-server` / `tsig-*` / `ttl` / `conflict-policy` /
+    source-binding, so v4 leases and v6 leases can target different zones /
+    servers / TSIG keys, and a v4 conflict or v4 turn-off never affects v6.
+    Backward compatibility: a config that sets the block under only ONE family
+    still works — the engine (`ReconcileScoped`) INHERITS that single policy for
+    the other family at reconcile time, so committed single-block configs are
+    byte-for-byte unchanged; the moment BOTH families set their own block they
+    are fully independent. The pre-P1b field-merge (`mergeDHCPDynamicDNS`) is
+    retained only as a defensive same-family-block-seen-twice no-op.
+  - **#2665 — source / interface / VRF binding** (three new free-form
+    `args:1` leaves on the `dynamic-dns` subtree, per family):
+    - `source-address <ip>` — bind the RFC 2136 UPDATE socket's source IP.
+    - `destination-interface <if>` — pin egress to an interface
+      (`SO_BINDTODEVICE`).
+    - `routing-instance <name>` — egress from a routing-instance / VRF (binds
+      to the VRF master device, which shares the routing-instance name).
+    They are free-form (an IP / interface / instance name is not rejected at the
+    typed-schema layer) and FAIL-OPEN at runtime: an invalid `source-address`
+    makes the live backend fall back to no-op for that family (logged + counted),
+    never a hard commit brick — matching the existing `update-server` / `tsig-*`
+    posture. The live rfc2136 backend (`pkg/ddns/backend_bind.go`) builds a
+    custom `net.Dialer` (a single `Control` hook does `unix.Bind` for the source
+    IP and `SO_BINDTODEVICE` for the interface/VRF, so the bind works for both
+    the UDP-first and the TCP-retry exchange); a config with no binding leaves
+    the default transport unchanged. `destination-interface` wins over
+    `routing-instance` for `SO_BINDTODEVICE` (the more specific pin).
+  - **ScopeKey (#2663/#2664).** Ownership records now carry a `ScopeKey`
+    `{Family, Interface, Unit, RoutingInstance, RGOwner, PolicyID}`
+    (`pkg/ddns/state.go`) and are keyed by `{ScopeKey, identity, address}`. The
+    ZERO scope reproduces the pre-P1b `identity|address` key byte-for-byte, so a
+    pre-P1b ownership store loads with no migration (the `scope` JSON field is a
+    pointer, omitted for the global lease scope). This is the load-bearing
+    primitive the per-RG HA gate and (future) Surface-A router publish build on.
+  Regression coverage: `pkg/config/compiler_dhcp_ddns_test.go`
+  (independent-policy, single-family-applies-to-both, source-binding-leaves),
+  `pkg/ddns/scope_test.go` (ScopeKey distinctness + pre-P1b round-trip +
+  independent v4/v6 + per-RG gate), `pkg/ddns/backend_bind_test.go` (dial
+  config), `pkg/daemon/daemon_ddns_scope_test.go` (per-RG resolver + gate).
 - **#2243 (DHCP-server static / fixed / reserved host bindings):** added a
   `static-binding <mac>` named-instance subtree under `services
   dhcp-local-server group <g> pool <p>` AND `services dhcpv6-local-server

--- a/pkg/config/compiler_dhcp_ddns_test.go
+++ b/pkg/config/compiler_dhcp_ddns_test.go
@@ -16,6 +16,13 @@ func ddnsOf(t *testing.T, cfg *Config) *DHCPDynamicDNSConfig {
 	return cfg.System.DHCPServer.DynamicDNS
 }
 
+// ddnsV6Of returns the IPv6-family DDNS policy (#2691 P1b / #2663: v4 and v6
+// now compile to independent fields instead of one field-merged struct).
+func ddnsV6Of(t *testing.T, cfg *Config) *DHCPDynamicDNSConfig {
+	t.Helper()
+	return cfg.System.DHCPServer.DynamicDNSv6
+}
+
 func TestDHCPDDNSHierarchicalAndFlatSetCompileEqually(t *testing.T) {
 	// Dual-AST equality: the hierarchical block and the flat-set spelling
 	// must compile to the same typed DHCPDynamicDNSConfig (plan §5 inv 5).
@@ -116,75 +123,80 @@ func TestDHCPDDNSV6BlockCompiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CompileConfig: %v", err)
 	}
-	d := ddnsOf(t, cfg)
+	// #2691 P1b / #2663: a v6-only block now compiles to the INDEPENDENT
+	// DynamicDNSv6 field (not field-merged into DynamicDNS). The v4 field stays
+	// nil (no v4 DDNS configured).
+	d := ddnsV6Of(t, cfg)
 	if d == nil || !d.Enabled || d.Domain != "v6.example.com" {
-		t.Fatalf("v6 dynamic-dns not compiled: %+v", d)
+		t.Fatalf("v6 dynamic-dns not compiled into DynamicDNSv6: %+v", d)
+	}
+	if ddnsOf(t, cfg) != nil {
+		t.Fatalf("v6-only block must leave the v4 DynamicDNS field nil, got %+v", ddnsOf(t, cfg))
 	}
 }
 
-// TestDHCPDDNSDualFamilyMergesFieldByField proves the Copilot/Codex MAJOR
-// fix: when BOTH dhcp-local-server AND dhcpv6-local-server carry a
-// dynamic-dns block, the compiler MERGES them field-by-field instead of
-// whole-struct overwrite. A partial second-family block (e.g. only domain
-// under v6) must NOT clear the first family's Enabled/server/ttl. Against
-// the pre-fix `dhcp.DynamicDNS = compileDHCPDynamicDNS(...)` overwrite, the
-// v6 block (Enabled=false, no server, no ttl) replaced the v4 block and
-// DDNS was silently disabled with its settings dropped — so this test
-// fails pre-fix.
-func TestDHCPDDNSDualFamilyMergesFieldByField(t *testing.T) {
-	// v4 compiles first (dst): enable + update-server + ttl. v6 compiles
-	// second (src): only domain. Merge must keep all v4 fields + gain domain.
+// TestDHCPDDNSDualFamilyIndependentPolicy proves the #2691 P1b / #2663 fix:
+// when BOTH dhcp-local-server AND dhcpv6-local-server carry a dynamic-dns
+// block, the two families compile to INDEPENDENT policies (DynamicDNS vs
+// DynamicDNSv6) — NOT one field-merged struct. A v4 block and a v6 block keep
+// their OWN domain / server / ttl, so an operator can direct v4 leases to one
+// zone/server and v6 leases to another. This is the deliberate behaviour change
+// from the pre-P1b field-merge (under which a v6 `domain` silently filled an
+// empty v4 field and a single struct could not represent two servers).
+func TestDHCPDDNSDualFamilyIndependentPolicy(t *testing.T) {
 	cfg, err := CompileConfig(buildTree(t, []string{
 		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns domain v4.example.com",
 		"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
 		"set system services dhcp-local-server dynamic-dns ttl 600",
-		"set system services dhcpv6-local-server dynamic-dns domain corp.example.com",
+		"set system services dhcpv6-local-server dynamic-dns enable",
+		"set system services dhcpv6-local-server dynamic-dns domain v6.example.com",
+		"set system services dhcpv6-local-server dynamic-dns update-server 2001:db8::53",
+		"set system services dhcpv6-local-server dynamic-dns ttl 1200",
 	}))
 	if err != nil {
 		t.Fatalf("CompileConfig: %v", err)
 	}
-	d := ddnsOf(t, cfg)
-	if d == nil {
-		t.Fatal("dual-family DDNS compiled to nil")
+	v4 := ddnsOf(t, cfg)
+	v6 := ddnsV6Of(t, cfg)
+	if v4 == nil || v6 == nil {
+		t.Fatalf("both families must compile to a policy: v4=%+v v6=%+v", v4, v6)
 	}
-	if !d.Enabled {
-		t.Fatal("partial v6 block cleared v4 Enabled (whole-struct overwrite bug)")
+	// v4 keeps ITS settings; v6 keeps ITS settings — independent, never merged.
+	if v4.Domain != "v4.example.com" || v4.UpdateServer != "192.0.2.53" || v4.TTLSeconds != 600 {
+		t.Fatalf("v4 policy not independent: %+v", v4)
 	}
-	if d.UpdateServer != "192.0.2.53" {
-		t.Fatalf("v4 update-server lost on merge: %q", d.UpdateServer)
+	if v6.Domain != "v6.example.com" || v6.UpdateServer != "2001:db8::53" || v6.TTLSeconds != 1200 {
+		t.Fatalf("v6 policy not independent: %+v", v6)
 	}
-	if d.TTLSeconds != 600 {
-		t.Fatalf("v4 ttl lost on merge: %d", d.TTLSeconds)
-	}
-	if d.Domain != "corp.example.com" {
-		t.Fatalf("v6 domain not merged in: %q", d.Domain)
+	// The cardinal #2663 assertion: a v6 field never bled into the v4 struct.
+	if v4.Domain == v6.Domain || v4.UpdateServer == v6.UpdateServer {
+		t.Fatalf("v4 and v6 policies were merged (not independent): v4=%+v v6=%+v", v4, v6)
 	}
 }
 
-// TestDHCPDDNSDualFamilyEnableLatchesEitherOrder proves the Enabled latch is
-// order-robust: enabling DDNS in EITHER family enables it, and a partial
-// block in the other family cannot flip it off — regardless of which family
-// is the partial one.
-func TestDHCPDDNSDualFamilyEnableLatchesEitherOrder(t *testing.T) {
-	// v4 partial (only domain), v6 enables. Latch must hold (v6 is src; the
-	// merge ORs Enabled so dst v4 ends up Enabled too).
+// TestDHCPDDNSSingleFamilyAppliesToBoth proves backward compatibility (#2691
+// P1b / plan §5.9): a pre-P1b config that set the dynamic-dns block under only
+// ONE family still works — the engine inherits that single policy for the other
+// family at reconcile time (ReconcileScoped). At the COMPILE layer the v4 block
+// lands in DynamicDNS and DynamicDNSv6 stays nil; the inheritance is a runtime
+// (engine) concern, asserted in pkg/ddns. Here we only prove the v4 block
+// compiles into the v4 field and the v6 field is nil (no silent v6 struct).
+func TestDHCPDDNSSingleFamilyAppliesToBoth(t *testing.T) {
 	cfg, err := CompileConfig(buildTree(t, []string{
+		"set system services dhcp-local-server dynamic-dns enable",
 		"set system services dhcp-local-server dynamic-dns domain corp.example.com",
-		"set system services dhcpv6-local-server dynamic-dns enable",
-		"set system services dhcpv6-local-server dynamic-dns update-server 2001:db8::53",
+		"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
 	}))
 	if err != nil {
 		t.Fatalf("CompileConfig: %v", err)
 	}
-	d := ddnsOf(t, cfg)
-	if d == nil || !d.Enabled {
-		t.Fatalf("enable in v6 did not latch when v4 was the partial block: %+v", d)
+	v4 := ddnsOf(t, cfg)
+	if v4 == nil || !v4.Enabled || v4.Domain != "corp.example.com" {
+		t.Fatalf("v4 block not compiled: %+v", v4)
 	}
-	if d.Domain != "corp.example.com" {
-		t.Fatalf("v4 domain lost: %q", d.Domain)
-	}
-	if d.UpdateServer != "2001:db8::53" {
-		t.Fatalf("v6 update-server not merged: %q", d.UpdateServer)
+	if ddnsV6Of(t, cfg) != nil {
+		t.Fatalf("v4-only block must leave DynamicDNSv6 nil (engine inherits at reconcile), got %+v", ddnsV6Of(t, cfg))
 	}
 }
 
@@ -219,6 +231,41 @@ func TestDHCPDDNSSchemaAcceptsValidLeaves(t *testing.T) {
 	})
 	if err := SchemaValidate(tree, nil); err != nil {
 		t.Fatalf("SchemaValidate rejected valid DDNS leaves: %v", err)
+	}
+}
+
+// TestDHCPDDNSSourceBindingLeaves proves the #2691 P1b / #2665 source-binding
+// leaves (source-address / destination-interface / routing-instance) pass
+// schema validation AND compile onto the typed policy.
+func TestDHCPDDNSSourceBindingLeaves(t *testing.T) {
+	lines := []string{
+		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns domain example.com",
+		"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+		"set system services dhcp-local-server dynamic-dns source-address 10.0.0.9",
+		"set system services dhcp-local-server dynamic-dns destination-interface ge-0/0/2.50",
+		"set system services dhcp-local-server dynamic-dns routing-instance VRF-WAN",
+	}
+	tree := buildTree(t, lines)
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("SchemaValidate rejected source-binding leaves: %v", err)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	d := ddnsOf(t, cfg)
+	if d == nil {
+		t.Fatal("source-binding block compiled to nil")
+	}
+	if d.SourceAddress != "10.0.0.9" {
+		t.Fatalf("source-address not compiled: %q", d.SourceAddress)
+	}
+	if d.DestinationInterface != "ge-0/0/2.50" {
+		t.Fatalf("destination-interface not compiled: %q", d.DestinationInterface)
+	}
+	if d.RoutingInstance != "VRF-WAN" {
+		t.Fatalf("routing-instance not compiled: %q", d.RoutingInstance)
 	}
 }
 

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -346,18 +346,24 @@ func compileDHCPLocalServer(node *Node, dhcp *DHCPServerConfig, isV6 bool) error
 		dhcp.DHCPLocalServer = lsc
 	}
 
-	// #1387: the dynamic-dns block is a server-level policy shared by all
-	// pools of the family. It can appear under dhcp-local-server and/or
-	// dhcpv6-local-server; the typed model carries a single
-	// DHCPDynamicDNSConfig (the reconciler walks both families' leases).
-	// When BOTH families carry a block we MERGE field-by-field rather than
-	// whole-struct overwrite: a partial second block (e.g. only `domain`
-	// under v6) must NOT clear the v4 block's Enabled/server/ttl. A field
-	// set in either block wins; presence-only `enable` latches on (once any
-	// family enables DDNS it stays enabled). See mergeDHCPDynamicDNS.
+	// #1387 + #2691 P1b (#2663 independent v4/v6 policy): the dynamic-dns block
+	// is a server-level policy for THIS family. It can appear under
+	// dhcp-local-server (v4) and/or dhcpv6-local-server (v6); each family's
+	// block now compiles into its OWN typed field — DynamicDNS (v4) /
+	// DynamicDNSv6 (v6) — so the two families keep INDEPENDENT
+	// domain/server/TSIG/TTL/conflict-policy/source-binding. This replaces the
+	// pre-P1b field-MERGE (mergeDHCPDynamicDNS), under which a v6 `domain`
+	// silently filled an empty v4 field and a single shared struct could not
+	// represent two different servers. mergeDHCPDynamicDNS is retained ONLY for
+	// the degenerate same-family-block-seen-twice case (compileDHCPLocalServer
+	// runs once per family, so it is effectively a defensive no-op now).
 	if ddnsNode := node.FindChild("dynamic-dns"); ddnsNode != nil {
 		if ddns := compileDHCPDynamicDNS(ddnsNode); ddns != nil {
-			dhcp.DynamicDNS = mergeDHCPDynamicDNS(dhcp.DynamicDNS, ddns)
+			if isV6 {
+				dhcp.DynamicDNSv6 = mergeDHCPDynamicDNS(dhcp.DynamicDNSv6, ddns)
+			} else {
+				dhcp.DynamicDNS = mergeDHCPDynamicDNS(dhcp.DynamicDNS, ddns)
+			}
 		}
 	}
 
@@ -485,6 +491,15 @@ func mergeDHCPDynamicDNS(dst, src *DHCPDynamicDNSConfig) *DHCPDynamicDNSConfig {
 	if dst.TSIGSecret == "" {
 		dst.TSIGSecret = src.TSIGSecret
 	}
+	if dst.SourceAddress == "" {
+		dst.SourceAddress = src.SourceAddress
+	}
+	if dst.DestinationInterface == "" {
+		dst.DestinationInterface = src.DestinationInterface
+	}
+	if dst.RoutingInstance == "" {
+		dst.RoutingInstance = src.RoutingInstance
+	}
 	if dst.TTLSeconds == 0 {
 		dst.TTLSeconds = src.TTLSeconds
 	}
@@ -505,6 +520,10 @@ var dhcpDDNSStringProps = map[string]bool{
 	"tsig-key":        true,
 	"tsig-algorithm":  true,
 	"tsig-secret":     true,
+	// #2691 P1b / #2665 source-binding leaves (per-family transport scoping).
+	"source-address":        true,
+	"destination-interface": true,
+	"routing-instance":      true,
 }
 
 // compileDHCPDynamicDNS converts a parsed `dynamic-dns` subtree into a
@@ -563,6 +582,9 @@ func compileDHCPDynamicDNS(node *Node) *DHCPDynamicDNSConfig {
 	d.TSIGKeyName = props["tsig-key"]
 	d.TSIGAlgorithm = props["tsig-algorithm"]
 	d.TSIGSecret = Secret(props["tsig-secret"])
+	d.SourceAddress = props["source-address"]
+	d.DestinationInterface = props["destination-interface"]
+	d.RoutingInstance = props["routing-instance"]
 	if v := props["ttl"]; v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			d.TTLSeconds = n
@@ -574,7 +596,8 @@ func compileDHCPDynamicDNS(node *Node) *DHCPDynamicDNSConfig {
 	if !d.Enabled && d.Domain == "" && d.HostnameSource == "" &&
 		d.ConflictPolicy == "" && d.Backend == "" && d.UpdateServer == "" &&
 		d.TSIGKeyName == "" && d.TSIGAlgorithm == "" && d.TSIGSecret == "" &&
-		d.TTLSeconds == 0 {
+		d.SourceAddress == "" && d.DestinationInterface == "" &&
+		d.RoutingInstance == "" && d.TTLSeconds == 0 {
 		return nil
 	}
 	return d

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -626,6 +626,31 @@ func dhcpDynamicDNSSchema() *schemaNode {
 			placeholder: "<secret>",
 			children:    nil,
 		},
+		// #2691 P1b / #2665: source/VRF binding for the RFC 2136 UPDATE
+		// transport (multi-WAN / VRF parity). All three are free-form leaves
+		// (an IP literal / interface name / routing-instance name) — the live
+		// backend builds a custom net.Dialer (LocalAddr + SO_BINDTODEVICE / VRF
+		// bind) from them; an unusable value is fail-open at runtime (logged,
+		// the update falls back to the default table), never a hard commit
+		// brick — matching the existing update-server / tsig-* leaves.
+		"source-address": {
+			desc:        "Source address to bind the RFC 2136 UPDATE socket to (#2665)",
+			args:        1,
+			placeholder: "<ip>",
+			children:    nil,
+		},
+		"destination-interface": {
+			desc:        "Egress interface to pin the RFC 2136 UPDATE to (SO_BINDTODEVICE, #2665)",
+			args:        1,
+			placeholder: "<interface>",
+			children:    nil,
+		},
+		"routing-instance": {
+			desc:        "Routing instance / VRF the RFC 2136 UPDATE egresses from (#2665)",
+			args:        1,
+			placeholder: "<instance>",
+			children:    nil,
+		},
 	}}
 }
 

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -899,10 +899,26 @@ type PrefixListRef struct {
 type DHCPServerConfig struct {
 	DHCPLocalServer   *DHCPLocalServerConfig
 	DHCPv6LocalServer *DHCPLocalServerConfig
-	// DynamicDNS is the opt-in DHCP DDNS policy (#1387 increment 1).
-	// nil == disabled == today's behaviour byte-for-byte; the dataplane
-	// (Kea render, daemon wiring) ignores a nil block entirely.
+	// DynamicDNS is the opt-in DHCP DDNS policy (#1387 increment 1). It is the
+	// IPv4-family (dhcp-local-server) policy. nil == disabled == today's
+	// behaviour byte-for-byte; the dataplane (Kea render, daemon wiring)
+	// ignores a nil block entirely.
+	//
+	// #2691 P1b / #2663: this is now the v4 policy ONLY. The v6 policy lives in
+	// DynamicDNSv6 and is INDEPENDENT (separate domain / server / TSIG / TTL /
+	// conflict-policy / source-binding). The two families are no longer
+	// field-merged into one struct — a v4-family block and a v6-family block
+	// keep their own settings. Backward compatibility: a config that sets the
+	// stanza under only ONE family compiles to that family's field with the
+	// other nil (so the single-family case is byte-for-byte unchanged), and a
+	// config that set BOTH under the pre-P1b field-merge model now keeps them
+	// distinct (the documented behaviour change in §5.8).
 	DynamicDNS *DHCPDynamicDNSConfig
+	// DynamicDNSv6 is the opt-in IPv6-family (dhcpv6-local-server) DDNS policy
+	// (#2691 P1b / #2663), independent of the v4 DynamicDNS policy above. nil
+	// == no v6 DDNS policy. When a config sets the stanza under only
+	// dhcpv6-local-server, DynamicDNS is nil and this carries the v6 policy.
+	DynamicDNSv6 *DHCPDynamicDNSConfig
 }
 
 // DHCPDynamicDNSConfig is the opt-in dynamic-DNS policy for the DHCP
@@ -960,6 +976,28 @@ type DHCPDynamicDNSConfig struct {
 	TSIGKeyName   string
 	TSIGAlgorithm string
 	TSIGSecret    Secret
+	// SourceAddress / DestinationInterface / RoutingInstance scope the RFC
+	// 2136 UPDATE TRANSPORT (#2691 P1b / #2665). In a multi-WAN / VRF
+	// deployment a DNS UPDATE must egress from the right source IP, the right
+	// interface, and/or the right routing-instance (VRF) or it is dropped by
+	// source-IP-keyed ACLs or sent to the wrong upstream. The live rfc2136
+	// backend builds its transport with a custom net.Dialer:
+	//   - SourceAddress       → Dialer.LocalAddr (bind the UDP/TCP socket's
+	//     source IP). Must be a bare IP literal (v4 or v6); the port is chosen
+	//     by the kernel.
+	//   - DestinationInterface → Dialer.Control → SO_BINDTODEVICE (pin egress
+	//     to a specific interface; covers the no-source-route / policy-route
+	//     case).
+	//   - RoutingInstance     → Dialer.Control → SO_BINDTODEVICE on the VRF
+	//     master device (Linux binds a socket into a VRF by binding to the vrf
+	//     device). xpf names a routing-instance and the VRF device shares that
+	//     name (pkg/routing), so the bind target is the routing-instance name.
+	// All three are optional; empty means "default table / kernel source
+	// selection" (today's behaviour). They are per-family (v4 vs v6 may bind
+	// different sources), which is why they live on this per-family struct.
+	SourceAddress        string
+	DestinationInterface string
+	RoutingInstance      string
 }
 
 // String redacts TSIGSecret so a %v/%s/slog format of a

--- a/pkg/daemon/daemon_ddns.go
+++ b/pkg/daemon/daemon_ddns.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -252,6 +253,25 @@ func (d *Daemon) buildLeaseSubnetRGMap(cfg *config.Config) []leaseSubnetRG {
 	}
 	collect(cfg.System.DHCPServer.DHCPLocalServer)
 	collect(cfg.System.DHCPServer.DHCPv6LocalServer)
+	// Deterministic attribution (#2664 review MINOR): the source iterates Go
+	// maps (ls.Groups) in RANDOMIZED order, so a first-match resolver over an
+	// unsorted slice would attribute an address that falls in two OVERLAPPING
+	// pool subnets owned by DIFFERENT RGs non-deterministically — the gate would
+	// then FLAP between passes for that address. Sort MOST-SPECIFIC FIRST (longer
+	// prefix wins), with a stable tie-break (CIDR string, then RG) for
+	// equal-length prefixes, so rgForLeaseAddress's first-match is both
+	// longest-prefix-correct AND stable across reconciles.
+	sort.Slice(out, func(i, j int) bool {
+		oi, _ := out[i].net.Mask.Size()
+		oj, _ := out[j].net.Mask.Size()
+		if oi != oj {
+			return oi > oj // longer prefix (more specific) first
+		}
+		if si, sj := out[i].net.String(), out[j].net.String(); si != sj {
+			return si < sj
+		}
+		return out[i].rg < out[j].rg
+	})
 	return out
 }
 

--- a/pkg/daemon/daemon_ddns.go
+++ b/pkg/daemon/daemon_ddns.go
@@ -3,10 +3,13 @@ package daemon
 import (
 	"context"
 	"log/slog"
+	"net"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcpserver"
 )
 
@@ -119,18 +122,181 @@ func (d *Daemon) reconcileDDNSOnce(ctx context.Context) {
 		return
 	}
 	if !d.ddnsWriterGateOpen() {
-		// BACKUP for all RGs: stop emitting. No withdraw (plan R3).
+		// BACKUP for all RGs: cheap short-circuit — stop emitting entirely. No
+		// withdraw (plan R3). This is the node-level fast path; the per-scope
+		// gate below makes the publish decision PER RG so a node MASTER for one
+		// RG and BACKUP for another publishes only its own RG's leases (#2664).
 		slog.Debug("ddns: skipping reconcile — node is not MASTER for any RG")
 		return
 	}
 	rctx, cancel := context.WithTimeout(ctx, ddnsReconcileTimeout)
 	defer cancel()
-	if err := d.ddns.Reconcile(rctx, &cfg.System.DHCPServer); err != nil {
+	// #2691 P1b / #2664: drive the SCOPED reconcile with a per-RG writer gate +
+	// a lease→RG resolver. Standalone (no cluster) passes nil gate/resolver
+	// (every scope writable — today's behaviour). In a cluster the resolver
+	// attributes each lease to its owning RG (by stable pool-subnet CIDR
+	// membership, NOT the per-render-unstable Kea subnet_id) and the gate admits
+	// a scope IFF this node is MASTER for that RG — FAIL-CLOSED for an
+	// unattributable lease (an address in no known master-owned subnet is not
+	// published, but its owned record is never withdrawn either).
+	opts := d.ddnsReconcileOptions(cfg)
+	if err := d.ddns.ReconcileScoped(rctx, &cfg.System.DHCPServer, opts); err != nil {
 		// Fail-open for DHCP (plan risk R9): a DNS failure is logged +
 		// counted (by the manager) and retried next cycle; it NEVER
 		// propagates to the Kea apply path or to commit.
 		slog.Warn("ddns: reconcile pass had errors (retrying next cycle)", "err", err)
 	}
+}
+
+// ddnsReconcileOptions builds the per-scope HA wiring for one reconcile pass
+// (#2691 P1b / #2664). Standalone (no cluster) returns the zero options (nil
+// gate + resolver) so the engine treats every scope as writable — byte-for-byte
+// today's behaviour. In a cluster it builds:
+//
+//   - a lease→RG RESOLVER from the committed DHCP config: an address is mapped
+//     to its pool subnet (stable CIDR membership) → group → interface →
+//     redundancy-group. This is the SAME RG attribution the Kea master-filter
+//     uses (rethInterfacesForRG), but keyed on the lease ADDRESS, not on the
+//     Kea subnet_id (which is map-order-assigned and unstable per render, plan
+//     §6 fork 2). A lease whose address falls in no known pool subnet is
+//     UNATTRIBUTABLE → ok=false → fail-closed (not published).
+//   - a per-RG GATE: a scope is writable IFF this node is MASTER for
+//     scope.RGOwner. RGOwner 0 (a lease in a non-RETH / non-HA pool) is admitted
+//     when the node is the writer at all (the node-level short-circuit already
+//     ran): such a pool is not HA-owned, so there is no peer to double-write.
+func (d *Daemon) ddnsReconcileOptions(cfg *config.Config) ddns.ReconcileOptions {
+	if d.cluster == nil || cfg == nil {
+		return ddns.ReconcileOptions{}
+	}
+	subnetRG := d.buildLeaseSubnetRGMap(cfg)
+	master := d.snapshotRethMasterState()
+
+	// anyRGOwnedPool reports whether the config has ANY redundancy-group-owned
+	// pool at all. When it does NOT, the cluster has no HA-owned DHCP scope, so
+	// an unattributable lease is just a standalone-style pool (no peer
+	// double-write hazard) and is admitted as RG 0; the per-RG gate is moot.
+	anyRGOwnedPool := false
+	for _, s := range subnetRG {
+		if s.rg > 0 {
+			anyRGOwnedPool = true
+			break
+		}
+	}
+
+	resolver := func(l ddns.Lease) (ddns.ScopeKey, bool) {
+		rg, ok := rgForLeaseAddress(l.Address, subnetRG)
+		if !ok {
+			// Unattributable: an address in no known pool subnet.
+			//
+			//   - If there ARE RG-owned pools, an address that falls in NONE of
+			//     them is ambiguous w.r.t. HA ownership — FAIL-CLOSED (#2664 /
+			//     plan §5.6: uncertain RG ownership → do not write). This is the
+			//     split-brain guard: a stale memfile row for a subnet we no
+			//     longer serve must not be republished from here.
+			//   - If there are NO RG-owned pools, the cluster has no HA-owned
+			//     DHCP scope (e.g. a non-RETH DHCP group in a cluster used for
+			//     other HA services). There is no peer to double-write, so admit
+			//     as RG 0 — the node-level writer gate already authorized the
+			//     pass.
+			if anyRGOwnedPool {
+				return ddns.ScopeKey{Family: ddns.Family(l.Family)}, false
+			}
+			return ddns.ScopeKey{Family: ddns.Family(l.Family), RGOwner: 0}, true
+		}
+		return ddns.ScopeKey{Family: ddns.Family(l.Family), RGOwner: rg}, true
+	}
+	gate := func(s ddns.ScopeKey) bool {
+		if s.RGOwner == 0 {
+			// Non-RG-owned pool (no RETH / no HA attribution): not a
+			// double-write hazard. The node-level writer gate already gated
+			// the whole pass, so admit.
+			return true
+		}
+		return master[s.RGOwner]
+	}
+	return ddns.ReconcileOptions{Gate: gate, Resolver: resolver}
+}
+
+// leaseSubnetRG pairs a parsed pool subnet (CIDR) with the redundancy group
+// that owns the interfaces of the group the pool belongs to (#2664).
+type leaseSubnetRG struct {
+	net *net.IPNet
+	rg  int
+}
+
+// buildLeaseSubnetRGMap walks the committed DHCP config and pairs each pool
+// subnet with its owning redundancy group, by mapping group → interfaces →
+// redundancy-group (#2664). A group whose interfaces are not RETH / not
+// RG-owned yields rg 0 (a non-HA pool: admitted by the gate as a non-double-
+// write hazard). This is the lease→RG attribution source for the resolver; it
+// is rebuilt per reconcile so a commit takes effect on the next pass.
+func (d *Daemon) buildLeaseSubnetRGMap(cfg *config.Config) []leaseSubnetRG {
+	var out []leaseSubnetRG
+	collect := func(ls *config.DHCPLocalServerConfig) {
+		if ls == nil {
+			return
+		}
+		for _, g := range ls.Groups {
+			rg := rgForInterfaces(cfg, g.Interfaces)
+			for _, p := range g.Pools {
+				if p.Subnet == "" {
+					continue
+				}
+				_, ipnet, err := net.ParseCIDR(p.Subnet)
+				if err != nil || ipnet == nil {
+					continue
+				}
+				out = append(out, leaseSubnetRG{net: ipnet, rg: rg})
+			}
+		}
+	}
+	collect(cfg.System.DHCPServer.DHCPLocalServer)
+	collect(cfg.System.DHCPServer.DHCPv6LocalServer)
+	return out
+}
+
+// rgForInterfaces returns the redundancy group that owns the given DHCP-group
+// interfaces (#2664). An interface that is a RETH member maps to its
+// RedundancyGroup; the first RG-owned interface wins (a DHCP group binds to one
+// HA-owned segment in practice). Returns 0 when no interface is RG-owned (a
+// non-HA pool).
+func rgForInterfaces(cfg *config.Config, ifaces []string) int {
+	if cfg == nil {
+		return 0
+	}
+	for _, name := range ifaces {
+		// The configured interface name may be the RETH logical name (reth0.0)
+		// or a unit form; match against the config's interface table by the
+		// base interface name.
+		base := name
+		if i := strings.IndexByte(base, '.'); i >= 0 {
+			base = base[:i]
+		}
+		if ifc, ok := cfg.Interfaces.Interfaces[base]; ok {
+			if ifc.RedundancyGroup > 0 {
+				return ifc.RedundancyGroup
+			}
+		}
+	}
+	return 0
+}
+
+// rgForLeaseAddress maps a lease address to its owning redundancy group via the
+// pool-subnet→RG map (#2664). It is the stable, render-independent attribution
+// the per-RG gate keys on (CIDR membership, NOT the Kea subnet_id). Returns
+// ok=false when the address parses but falls in no known pool subnet
+// (unattributable → fail-closed at the caller) or does not parse.
+func rgForLeaseAddress(addr string, subnetRG []leaseSubnetRG) (int, bool) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return 0, false
+	}
+	for _, s := range subnetRG {
+		if s.net.Contains(ip) {
+			return s.rg, true
+		}
+	}
+	return 0, false
 }
 
 // ddnsWriterGateOpen reports whether this node should publish DDNS now

--- a/pkg/daemon/daemon_ddns_scope_test.go
+++ b/pkg/daemon/daemon_ddns_scope_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/ddns"
+)
+
+// #2691 P1b / #2664 daemon-level per-RG DDNS writer gate tests. They exercise
+// ddnsReconcileOptions: the lease→RG resolver (by stable pool-subnet CIDR) and
+// the per-RG gate (master[RGOwner]). These prove a node MASTER for one RG but
+// not another publishes only its own RG's leases — the partial-demotion
+// correctness the issue calls out.
+
+// scopeClusterDaemon builds a two-RG cluster daemon with RG-owned DHCP pools:
+//   - reth0 (RG1) carries the 10.0.1.0/24 pool (group g1).
+//   - reth1 (RG2) carries the 10.0.2.0/24 pool (group g2).
+func scopeClusterDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	store := testStoreWithSetConfig(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set chassis cluster redundancy-group 2 node 0 priority 200",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set interfaces reth0 unit 0 family inet address 10.0.1.1/24",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set interfaces reth1 redundant-ether-options redundancy-group 2",
+		"set interfaces reth1 unit 0 family inet address 10.0.2.1/24",
+		"set interfaces ge-0/0/1 gigether-options redundant-parent reth1",
+		"set system services dhcp-local-server group g1 interface reth0.0",
+		"set system services dhcp-local-server group g1 pool p1 address-range low 10.0.1.10 high 10.0.1.200",
+		"set system services dhcp-local-server group g1 pool p1 subnet 10.0.1.0/24",
+		"set system services dhcp-local-server group g2 interface reth1.0",
+		"set system services dhcp-local-server group g2 pool p2 address-range low 10.0.2.10 high 10.0.2.200",
+		"set system services dhcp-local-server group g2 pool p2 subnet 10.0.2.0/24",
+		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns domain example.com",
+		"set system services dhcp-local-server dynamic-dns backend rfc2136",
+		"set system services dhcp-local-server dynamic-dns update-server 192.0.2.53",
+	})
+	d := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(0, 1),
+		store:    store,
+	}
+	return d
+}
+
+func TestDDNSReconcileOptionsResolvesLeaseToRG(t *testing.T) {
+	d := scopeClusterDaemon(t)
+	cfg := d.store.ActiveConfig()
+	opts := d.ddnsReconcileOptions(cfg)
+	if opts.Resolver == nil || opts.Gate == nil {
+		t.Fatal("cluster daemon must produce a non-nil per-RG gate + resolver")
+	}
+
+	// A 10.0.1.x lease attributes to RG1; a 10.0.2.x lease to RG2.
+	s1, ok1 := opts.Resolver(ddns.Lease{Family: 4, Address: "10.0.1.50"})
+	if !ok1 || s1.RGOwner != 1 {
+		t.Fatalf("10.0.1.50 must attribute to RG1, got rg=%d ok=%v", s1.RGOwner, ok1)
+	}
+	s2, ok2 := opts.Resolver(ddns.Lease{Family: 4, Address: "10.0.2.50"})
+	if !ok2 || s2.RGOwner != 2 {
+		t.Fatalf("10.0.2.50 must attribute to RG2, got rg=%d ok=%v", s2.RGOwner, ok2)
+	}
+	// An address in NO known pool subnet, with RG-owned pools present, is
+	// fail-closed (ok=false).
+	if _, ok := opts.Resolver(ddns.Lease{Family: 4, Address: "10.9.9.9"}); ok {
+		t.Fatal("an address in no known pool subnet must be unattributable (fail-closed) when RG-owned pools exist")
+	}
+}
+
+func TestDDNSReconcileGatePartialMaster(t *testing.T) {
+	d := scopeClusterDaemon(t)
+	// Node is MASTER for RG1, BACKUP for RG2.
+	d.getOrCreateRGState(1).SetCluster(true)
+	d.getOrCreateRGState(2).SetCluster(false)
+
+	cfg := d.store.ActiveConfig()
+	opts := d.ddnsReconcileOptions(cfg)
+
+	// The gate admits RG1's scope, rejects RG2's scope — the #2664 invariant:
+	// publish only the RG you own.
+	if !opts.Gate(ddns.ScopeKey{Family: ddns.FamilyV4, RGOwner: 1}) {
+		t.Fatal("node MASTER for RG1 must admit RG1's scope")
+	}
+	if opts.Gate(ddns.ScopeKey{Family: ddns.FamilyV4, RGOwner: 2}) {
+		t.Fatal("node BACKUP for RG2 must REJECT RG2's scope (no double-write)")
+	}
+}
+
+func TestDDNSReconcileGateStandaloneNilOpts(t *testing.T) {
+	// A standalone daemon (no cluster) produces zero options — every scope
+	// writable, byte-for-byte today's behaviour.
+	d := &Daemon{rgStates: make(map[int]*rgStateMachine)}
+	opts := d.ddnsReconcileOptions(nil)
+	if opts.Gate != nil || opts.Resolver != nil {
+		t.Fatal("standalone daemon must produce nil gate + resolver (all scopes writable)")
+	}
+}

--- a/pkg/daemon/daemon_ddns_scope_test.go
+++ b/pkg/daemon/daemon_ddns_scope_test.go
@@ -100,3 +100,55 @@ func TestDDNSReconcileGateStandaloneNilOpts(t *testing.T) {
 		t.Fatal("standalone daemon must produce nil gate + resolver (all scopes writable)")
 	}
 }
+
+// TestDDNSOverlappingPoolAttributionDeterministic proves the #2664 review MINOR
+// fix: when two pools with OVERLAPPING subnets belong to DIFFERENT RGs, an
+// address in the overlap attributes to the MOST-SPECIFIC (longest-prefix) pool,
+// DETERMINISTICALLY across rebuilds — not the random first map-iteration match
+// (which would flap the gate between passes). Here RG1 owns 10.0.0.0/16 and RG2
+// owns the more-specific 10.0.2.0/24; 10.0.2.50 must always attribute to RG2.
+func TestDDNSOverlappingPoolAttributionDeterministic(t *testing.T) {
+	store := testStoreWithSetConfig(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set chassis cluster redundancy-group 2 node 0 priority 200",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set interfaces reth0 unit 0 family inet address 10.0.0.1/16",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set interfaces reth1 redundant-ether-options redundancy-group 2",
+		"set interfaces reth1 unit 0 family inet address 10.0.2.1/24",
+		"set interfaces ge-0/0/1 gigether-options redundant-parent reth1",
+		// RG1's broad pool (10.0.0.0/16) and RG2's specific pool (10.0.2.0/24).
+		"set system services dhcp-local-server group g1 interface reth0.0",
+		"set system services dhcp-local-server group g1 pool p1 address-range low 10.0.0.10 high 10.0.255.250",
+		"set system services dhcp-local-server group g1 pool p1 subnet 10.0.0.0/16",
+		"set system services dhcp-local-server group g2 interface reth1.0",
+		"set system services dhcp-local-server group g2 pool p2 address-range low 10.0.2.10 high 10.0.2.250",
+		"set system services dhcp-local-server group g2 pool p2 subnet 10.0.2.0/24",
+		"set system services dhcp-local-server dynamic-dns enable",
+		"set system services dhcp-local-server dynamic-dns domain example.com",
+	})
+	d := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(0, 1),
+		store:    store,
+	}
+	cfg := d.store.ActiveConfig()
+
+	// Rebuild many times: Go map iteration over ls.Groups is randomized, so an
+	// unsorted first-match would attribute non-deterministically. The sorted
+	// (longest-prefix-first) build must yield RG2 EVERY time for 10.0.2.50.
+	for i := 0; i < 50; i++ {
+		opts := d.ddnsReconcileOptions(cfg)
+		s, ok := opts.Resolver(ddns.Lease{Family: 4, Address: "10.0.2.50"})
+		if !ok || s.RGOwner != 2 {
+			t.Fatalf("iter %d: 10.0.2.50 in the overlap must attribute to the more-specific RG2, got rg=%d ok=%v", i, s.RGOwner, ok)
+		}
+		// An address in RG1's broad pool but OUTSIDE RG2's specific pool stays RG1.
+		s1, ok1 := opts.Resolver(ddns.Lease{Family: 4, Address: "10.0.5.50"})
+		if !ok1 || s1.RGOwner != 1 {
+			t.Fatalf("iter %d: 10.0.5.50 (only in RG1's pool) must attribute to RG1, got rg=%d ok=%v", i, s1.RGOwner, ok1)
+		}
+	}
+}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1058,6 +1058,18 @@ func (d *Daemon) clearRethServicesForRG(rgID int) {
 			slog.Info("vrrp: DHCP server stop enqueued (BACKUP)", "rg", rgID)
 		}
 	}
+	// #2691 P1b / #2664: nudge the DDNS reconcile loop after a (partial)
+	// demotion. This closes the documented "no DDNS nudge on partial demotion"
+	// gap: when this node loses RG `rgID` but stays MASTER for another RG, the
+	// per-RG writer gate now CLOSES for rgID's scopes — but only a reconcile
+	// pass acts on it, so without this nudge the demoted RG's records would keep
+	// being re-asserted until the next 30s tick. The nudged pass STOPS
+	// publishing rgID's leases (the gate is closed for that RG) and does NOT
+	// withdraw them (stop-writing, never withdraw — the peer that became MASTER
+	// for rgID refreshes them; a withdraw race would blackhole, plan §5.6). The
+	// nudge is benign if it races the async Kea re-apply: a too-early pass sees
+	// the unchanged store and only the gate state matters for the demoted RG.
+	d.nudgeDDNSReconcile()
 }
 
 // filterDHCPConfigForMasterRGs returns a DHCP config containing only groups

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -81,3 +81,43 @@ no change in those packages:
 
 The HA writer gate (`ddnsWriterGateOpen`) stays in `pkg/daemon/daemon_ddns.go`
 (it reads cluster RG state); P1a did not move or change it.
+
+## Phase P1b — ScopeKey, per-family policy, per-RG HA gate, source binding
+
+P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
+
+- **ScopeKey (`state.go`, #2663/#2664, plan §5.4)** — the unifying ownership
+  primitive `{Family, Interface, Unit, RoutingInstance, RGOwner, PolicyID}`.
+  Ownership records are now keyed by `{ScopeKey, identity, address}`. The ZERO
+  scope reproduces the pre-P1b `identity|address` key byte-for-byte (the `scope`
+  JSON field is a `*ScopeKey`, omitted for the global lease scope), so a pre-P1b
+  store loads with **no migration**. Two scopes for the same name+address (a v4
+  vs v6 publish, or an RG0-owned vs RG1-owned publish) are DISTINCT entries.
+- **Independent v4/v6 policy (#2663)** — `Reconcile` →
+  `ReconcileScoped` resolves an INDEPENDENT policy + backend PER FAMILY
+  (`reconcileEnv.pol[2]`/`updater[2]`) from `DHCPServerConfig.DynamicDNS` (v4)
+  and `.DynamicDNSv6` (v6). A v4 conflict, a v4 backend error, or a v4 turn-off
+  never affects v6. Single-block backward compat: if only one family's block is
+  set, the other inherits it at reconcile time.
+- **Per-RG HA writer gate (#2664)** — `ReconcileScoped` takes a
+  `ScopeGate`/`ScopeResolver` (built in `pkg/daemon/daemon_ddns.go`
+  `ddnsReconcileOptions`). The resolver attributes each lease to its owning RG
+  by STABLE pool-subnet CIDR membership (not the per-render-unstable Kea
+  subnet_id); the gate admits a scope IFF this node is MASTER for its RG. A
+  gated-out scope is **stop-writing, never-withdraw**: its owned records are left
+  untouched (the peer MASTER for that RG refreshes them — a withdraw would
+  blackhole, plan §5.6). Unattributable leases FAIL-CLOSED when RG-owned pools
+  exist. The daemon also nudges DDNS on a partial demotion
+  (`clearRethServicesForRG`) so the gate change takes effect within one pass.
+- **Source / VRF binding (#2665, `backend_bind.go`)** — the per-family
+  `source-address` / `destination-interface` / `routing-instance` leaves build a
+  custom `net.Dialer` (one `Control` hook: `unix.Bind` for the source IP +
+  `SO_BINDTODEVICE` for the interface/VRF, working for both the UDP-first and
+  TCP-retry exchange). Fail-open at runtime; an invalid source-address falls the
+  family back to no-op.
+
+**HA correctness:** the per-RG gate change MUST pass `make test-failover` (the
+project rule for any gate / HA-path change). P1b adds the gate + the
+partial-demotion nudge; reason about split-brain (uncertain RG → fail-closed)
+and partial demotion (lose one RG, keep another → publish only the kept RG,
+withdraw nothing) in `scope_test.go` / `daemon_ddns_scope_test.go`.

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -106,8 +106,15 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   subnet_id); the gate admits a scope IFF this node is MASTER for its RG. A
   gated-out scope is **stop-writing, never-withdraw**: its owned records are left
   untouched (the peer MASTER for that RG refreshes them — a withdraw would
-  blackhole, plan §5.6). Unattributable leases FAIL-CLOSED when RG-owned pools
-  exist. The daemon also nudges DDNS on a partial demotion
+  blackhole, plan §5.6). Pass 1 protects an owned record by re-consulting the
+  SAME gate on the record's STORED scope (`env.scopeAdmits(owned.scopeOf())`),
+  NOT only via the current-lease-derived `gatedScope` set — so a STEADY-STATE
+  partial demotion, where the demoted RG's leases have aged out of the parsed
+  set, still does not withdraw the demoted RG's records (#2664 review MAJOR;
+  `TestPerRGGatePartialDemotionSteadyState`). Unattributable leases FAIL-CLOSED
+  when RG-owned pools exist. Pool→RG attribution is sorted MOST-SPECIFIC-FIRST so
+  overlapping cross-RG pools attribute deterministically across passes (the gate
+  cannot flap). The daemon also nudges DDNS on a partial demotion
   (`clearRethServicesForRG`) so the gate change takes effect within one pass.
 - **Source / VRF binding (#2665, `backend_bind.go`)** — the per-family
   `source-address` / `destination-interface` / `routing-instance` leaves build a

--- a/pkg/ddns/backend_bind.go
+++ b/pkg/ddns/backend_bind.go
@@ -1,0 +1,139 @@
+package ddns
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// backend_bind.go: source / interface / VRF binding for the RFC 2136 UPDATE
+// transport (#2691 P1b / #2665, plan §5.7). In a multi-WAN or VRF deployment a
+// DNS UPDATE must egress from a specific source IP, a specific interface,
+// and/or a specific routing-instance (VRF) — otherwise it leaves via the
+// default table / kernel-chosen source and is dropped by source-IP-keyed ACLs
+// (authoritative servers commonly ACL on source IP in addition to TSIG) or
+// sent to the wrong upstream.
+//
+// The binding is built into the *dns.Client's transport via a custom
+// net.Dialer:
+//   - source-address       → Dialer.LocalAddr (bind the socket's source IP).
+//   - destination-interface → Dialer.Control → SO_BINDTODEVICE (pin egress).
+//   - routing-instance     → Dialer.Control → SO_BINDTODEVICE on the VRF
+//     master device (Linux binds a socket into a VRF by binding to the vrf
+//     device, which shares the routing-instance name — pkg/routing). When both
+//     a destination-interface and a routing-instance are set, the
+//     destination-interface wins for SO_BINDTODEVICE (the more specific pin);
+//     a VRF-only config binds to the VRF device.
+//
+// FAIL-OPEN at runtime: a malformed source-address is rejected at construction
+// (the manager falls back to a no-op for that family and counts it, never a
+// crash); a SO_BINDTODEVICE failure surfaces as a dial error on the exchange,
+// which the reconciler logs + retries next cycle (it never wedges DHCP). This
+// matches the existing update-server / TSIG fail-open posture.
+
+// bindConfig is the resolved source/interface/VRF binding for one family's
+// backend (#2665). The zero value (all empty) means "no binding — default
+// table / kernel source selection", today's behaviour byte-for-byte.
+type bindConfig struct {
+	sourceAddr  netip.Addr // bound source IP; zero ⇒ none
+	bindDevice  string     // SO_BINDTODEVICE target (dest-interface or VRF dev)
+	routingInst string     // routing-instance name (informational / VRF dev)
+}
+
+// resolveBindConfig builds a bindConfig from a DDNS policy's source-binding
+// leaves (#2665). An empty config yields the zero bindConfig (no binding). A
+// non-empty source-address that does not parse is a hard error so the manager
+// falls back to no-op for that family (and counts it) rather than emitting
+// UPDATEs from the wrong source.
+func resolveBindConfig(c *config.DHCPDynamicDNSConfig) (bindConfig, error) {
+	if c == nil {
+		return bindConfig{}, nil
+	}
+	var b bindConfig
+	if c.SourceAddress != "" {
+		a, err := netip.ParseAddr(c.SourceAddress)
+		if err != nil {
+			return bindConfig{}, fmt.Errorf("ddns: invalid source-address %q: %w", c.SourceAddress, err)
+		}
+		b.sourceAddr = a.Unmap()
+	}
+	// destination-interface is the more specific SO_BINDTODEVICE pin; a VRF
+	// (routing-instance) binds to its VRF master device, which shares the
+	// routing-instance name. Prefer the explicit destination-interface.
+	b.routingInst = c.RoutingInstance
+	switch {
+	case c.DestinationInterface != "":
+		b.bindDevice = c.DestinationInterface
+	case c.RoutingInstance != "":
+		b.bindDevice = c.RoutingInstance
+	}
+	return b, nil
+}
+
+// isSet reports whether the bindConfig requests any binding.
+func (b bindConfig) isSet() bool {
+	return b.sourceAddr.IsValid() || b.bindDevice != ""
+}
+
+// dialer builds the net.Dialer the *dns.Client uses for both the UDP-first and
+// the TCP-retry exchange, applying the source-address bind AND the
+// interface/VRF SO_BINDTODEVICE in a SINGLE Dialer.Control hook.
+//
+// Both binds are done in Control (not via Dialer.LocalAddr) deliberately: the
+// SAME dialer is reused for a "udp" dial (the primary path) and a "tcp" dial
+// (the truncation retry, see exchange()), and net.Dialer.LocalAddr is
+// network-typed (a *net.UDPAddr LocalAddr makes a "tcp" dial fail with an
+// address-type mismatch). Binding the source IP with unix.Bind inside Control —
+// where the socket fd is already open but not yet connected — works for BOTH
+// networks with no type coupling. Port 0 lets the kernel pick the source port.
+//
+// Returns nil when no binding is requested (the *dns.Client then uses its
+// default dialer — today's behaviour byte-for-byte).
+func (b bindConfig) dialer(timeout time.Duration) *net.Dialer {
+	if !b.isSet() {
+		return nil
+	}
+	src := b.sourceAddr
+	dev := b.bindDevice
+	return &net.Dialer{
+		Timeout: timeout,
+		Control: func(_, _ string, c syscall.RawConn) error {
+			var serr error
+			if err := c.Control(func(fd uintptr) {
+				if dev != "" {
+					// SO_BINDTODEVICE pins egress to the named device; for a VRF
+					// the device is the VRF master (Linux's VRF socket-binding
+					// model), matching pkg/grpcapi's VRF-bind pattern.
+					if e := unix.SetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_BINDTODEVICE, dev); e != nil {
+						serr = e
+						return
+					}
+				}
+				if src.IsValid() {
+					// Bind the source IP (ephemeral port). unix.Bind on the raw fd
+					// before connect sets the socket's local address for both UDP
+					// and TCP.
+					var sa unix.Sockaddr
+					if src.Is4() {
+						sa = &unix.SockaddrInet4{Addr: src.As4()}
+					} else {
+						sa = &unix.SockaddrInet6{Addr: src.As16()}
+					}
+					if e := unix.Bind(int(fd), sa); e != nil {
+						serr = e
+						return
+					}
+				}
+			}); err != nil {
+				return err
+			}
+			return serr
+		},
+	}
+}

--- a/pkg/ddns/backend_bind_test.go
+++ b/pkg/ddns/backend_bind_test.go
@@ -1,0 +1,137 @@
+package ddns
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2691 P1b / #2665 source-binding tests: the resolved bindConfig + the custom
+// net.Dialer the rfc2136 backend uses. The socket bind itself is a kernel
+// operation exercised on the cluster; here we assert the DIAL CONFIGURATION
+// (the unit the issue's fix-direction names) — LocalAddr/Control are wired iff
+// a binding is configured, an invalid source-address is rejected, and the
+// rfc2136 backend installs the custom dialer.
+
+func TestResolveBindConfigEmptyIsNoBinding(t *testing.T) {
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{})
+	if err != nil {
+		t.Fatalf("empty config: %v", err)
+	}
+	if b.isSet() {
+		t.Fatal("empty source-binding config must request NO binding")
+	}
+	if d := b.dialer(time.Second); d != nil {
+		t.Fatal("no-binding config must yield a nil dialer (default transport)")
+	}
+}
+
+func TestResolveBindConfigSourceAddress(t *testing.T) {
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "10.0.0.9"})
+	if err != nil {
+		t.Fatalf("source-address: %v", err)
+	}
+	if !b.sourceAddr.IsValid() || b.sourceAddr.String() != "10.0.0.9" {
+		t.Fatalf("source-address not resolved: %v", b.sourceAddr)
+	}
+	if !b.isSet() {
+		t.Fatal("a source-address must request a binding")
+	}
+	if d := b.dialer(time.Second); d == nil || d.Control == nil {
+		t.Fatal("a source-address must produce a dialer with a Control hook (source bind)")
+	}
+}
+
+func TestResolveBindConfigInvalidSourceAddressRejected(t *testing.T) {
+	if _, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{SourceAddress: "not-an-ip"}); err == nil {
+		t.Fatal("an invalid source-address must be rejected (the manager then falls back to no-op + counts it)")
+	}
+}
+
+func TestResolveBindConfigDestInterfaceWinsOverVRF(t *testing.T) {
+	// destination-interface is the more specific SO_BINDTODEVICE pin; when both
+	// it and a routing-instance are set, the destination-interface wins.
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{
+		DestinationInterface: "ge-0-0-2",
+		RoutingInstance:      "VRF-WAN",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if b.bindDevice != "ge-0-0-2" {
+		t.Fatalf("destination-interface must win for SO_BINDTODEVICE, got %q", b.bindDevice)
+	}
+	if b.routingInst != "VRF-WAN" {
+		t.Fatalf("routing-instance must be recorded, got %q", b.routingInst)
+	}
+}
+
+func TestResolveBindConfigVRFOnlyBindsVRFDevice(t *testing.T) {
+	b, err := resolveBindConfig(&config.DHCPDynamicDNSConfig{RoutingInstance: "VRF-WAN"})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// A VRF binds to its VRF master device, which shares the routing-instance
+	// name (Linux's VRF socket-binding model).
+	if b.bindDevice != "VRF-WAN" {
+		t.Fatalf("a VRF-only config must bind to the VRF device, got %q", b.bindDevice)
+	}
+}
+
+// TestNewRFC2136UpdaterInstallsCustomDialer proves the rfc2136 backend installs
+// the source-binding dialer on its production *dns.Client when a binding is
+// configured (and leaves the default dialer when none is). The client seam is
+// nil here so newRFC2136Updater builds the real *dns.Client.
+func TestNewRFC2136UpdaterInstallsCustomDialer(t *testing.T) {
+	pol := policyFromConfig(&config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+	})
+	// With a binding configured → custom dialer installed.
+	withBind := &config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+		SourceAddress: "10.0.0.9",
+	}
+	u, err := newRFC2136Updater(pol, withBind, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newRFC2136Updater (with bind): %v", err)
+	}
+	cl, ok := u.client.(*dns.Client)
+	if !ok {
+		t.Fatalf("expected production *dns.Client, got %T", u.client)
+	}
+	if cl.Dialer == nil || cl.Dialer.Control == nil {
+		t.Fatal("a configured source-address must install a custom dialer on the *dns.Client")
+	}
+
+	// With NO binding → default dialer (today's behaviour).
+	noBind := &config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+	}
+	u2, err := newRFC2136Updater(pol, noBind, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newRFC2136Updater (no bind): %v", err)
+	}
+	cl2 := u2.client.(*dns.Client)
+	if cl2.Dialer != nil {
+		t.Fatal("no source-binding must leave the *dns.Client's default dialer (nil)")
+	}
+}
+
+// TestNewRFC2136UpdaterInvalidSourceAddressErrors proves an invalid
+// source-address is surfaced from the constructor so the manager falls back to
+// no-op for that family rather than emitting UPDATEs from the wrong source.
+func TestNewRFC2136UpdaterInvalidSourceAddressErrors(t *testing.T) {
+	pol := policyFromConfig(&config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+	})
+	bad := &config.DHCPDynamicDNSConfig{
+		Enabled: true, Domain: "example.com", UpdateServer: "192.0.2.53:53",
+		SourceAddress: "garbage",
+	}
+	if _, err := newRFC2136Updater(pol, bad, nil, nil, nil); err == nil {
+		t.Fatal("an invalid source-address must fail newRFC2136Updater")
+	}
+}

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -217,11 +217,26 @@ func newRFC2136Updater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig, client dn
 		u.tsigAlgo = algo
 		u.tsigSecret = c.TSIGSecret.Reveal()
 	}
+	// #2691 P1b / #2665: resolve the source / interface / VRF binding. An
+	// invalid source-address is a hard error (the caller falls back to no-op +
+	// counts it) so a misconfigured bind never emits UPDATEs from the wrong
+	// source.
+	bind, err := resolveBindConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	if u.client == nil {
-		u.client = &dns.Client{
+		cl := &dns.Client{
 			Timeout:    u.timeout,
 			TsigSecret: u.tsigSecretMap(),
 		}
+		// Apply the custom dialer (source-address LocalAddr + interface/VRF
+		// SO_BINDTODEVICE) when any binding is requested; otherwise leave the
+		// *dns.Client's default dialer (today's behaviour byte-for-byte).
+		if d := bind.dialer(u.timeout); d != nil {
+			cl.Dialer = d
+		}
+		u.client = cl
 	}
 	return u, nil
 }

--- a/pkg/ddns/durability_test.go
+++ b/pkg/ddns/durability_test.go
@@ -32,7 +32,7 @@ func readDurableOwnership(t *testing.T, path string) map[string]ownedRecord {
 	}
 	out := map[string]ownedRecord{}
 	for _, r := range f.Records {
-		out[ownedRecordKey(r.Identity, r.Address)] = r
+		out[ownedRecordKey(r.scopeOf(), r.Identity, r.Address)] = r
 	}
 	return out
 }
@@ -150,7 +150,7 @@ func TestUpsertCrashAfterAddBeforeEndOfPassSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load durable state: %v", err)
 	}
-	if _, ok := fresh.get("mac:aabb", "10.0.1.50"); !ok {
+	if _, ok := fresh.get(ScopeKey{}, "mac:aabb", "10.0.1.50"); !ok {
 		t.Fatalf("orphan: fresh manager has no durable ownership for the live RR; records=%v", fresh.records)
 	}
 }
@@ -175,7 +175,7 @@ func TestUpsertRefusedAddRemovesIntent(t *testing.T) {
 		t.Fatalf("refused add should record no successful upsert, got %v", up.upserts)
 	}
 	// Neither in-memory nor durable ownership may claim the refused name.
-	if _, ok := m.state.get("mac:aabb", "10.0.1.50"); ok {
+	if _, ok := m.state.get(ScopeKey{}, "mac:aabb", "10.0.1.50"); ok {
 		t.Fatalf("phantom in-memory ownership survived a refused add")
 	}
 	durable := readDurableOwnership(t, m.state.path)
@@ -206,7 +206,7 @@ func TestUpsertPreAddSaveFailureSuppressesPublish(t *testing.T) {
 	if len(up.upserts) != 0 {
 		t.Fatalf("publish must be suppressed when ownership cannot be durably recorded; got %v", up.upserts)
 	}
-	if _, ok := m.state.get("mac:aabb", "10.0.1.50"); ok {
+	if _, ok := m.state.get(ScopeKey{}, "mac:aabb", "10.0.1.50"); ok {
 		t.Fatalf("in-memory ownership left after a suppressed publish")
 	}
 }

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -756,7 +756,24 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, env *reconcileEnv, le
 		// peer and blackhole (plan §5.6 / risk R3). This is the load-bearing
 		// #2664 invariant: a node that loses one RG must not delete that RG's
 		// records.
-		if gatedScope[owned.scopeOf().scopePrefix()] {
+		//
+		// The gate is consulted DIRECTLY on the owned record's stored scope
+		// (env.scopeAdmits), NOT only via gatedScope — which is populated solely
+		// from leases present in THIS cycle's parsed set. On a STEADY-STATE
+		// partial demotion the demoted RG's group is dropped from the narrowed
+		// Kea config (filterDHCPConfigForMasterRGs) and its leases age out of the
+		// memfile, so those leases vanish from the parsed set and gatedScope
+		// never learns the demoted RG's prefix. Without re-asking the gate here,
+		// Pass 1 would then see the demoted RG's owned record as "not wanted, not
+		// gated, not untrusted, not disabled" and WITHDRAW it — the exact §5.6
+		// blackhole the per-RG gate exists to prevent. Re-evaluating the SAME
+		// gate the publish path consults keeps publish and withdraw in agreement:
+		// a scope this node does not master is neither published nor withdrawn.
+		// Standalone (nil gate) admits every scope ⇒ this guard is inert and
+		// turn-off / expiry / reassignment withdrawal still works; a disabled
+		// family's owned records are in scopes this node DOES master, so the gate
+		// admits them and they are still withdrawn (turn-off cleanup unaffected).
+		if gatedScope[owned.scopeOf().scopePrefix()] || !env.scopeAdmits(owned.scopeOf()) {
 			if stillWanted {
 				d.seen = true
 			}

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -33,10 +33,20 @@ import (
 //   - Prometheus emission through pkg/api (the xpf_dhcp_ddns_* counters
 //     are exported from Stats()).
 //
+// SHIPPED in #2691 P1b (this phase):
+//   - ScopeKey on ownership records + per-family INDEPENDENT v4/v6 policy
+//     (#2663): ReconcileScoped resolves a policy + backend PER FAMILY;
+//   - per-RG HA writer gate (#2664): a ScopeGate/ScopeResolver gates the
+//     publish decision PER redundancy-group (stop-writing-never-withdraw on a
+//     partial demotion), wired from pkg/daemon (ddnsReconcileOptions);
+//   - source / interface / VRF binding for the RFC 2136 update socket (#2665,
+//     backend_bind.go).
+//
 // STILL DEFERRED:
 //   - the Kea D2 backend (reserved enum; not in the image — bake.py);
-//   - per-scope / per-RG policy, source binding, and router/interface
-//     address publish (the #2691 world-class redesign, phases P1-P3).
+//   - router/interface-address publish (Surface A) + the HTTP provider
+//     backends (dyndns2/Cloudflare/Route53/generic) — the #2691 world-class
+//     redesign phases P2-P3.
 //
 // When DynamicDNS is nil or disabled the manager does nothing except a
 // one-time withdraw of any previously-owned records (turn-off cleanup) —
@@ -69,6 +79,11 @@ type LeaseParser func(path string, family int, now time.Time) ([]Lease, error)
 // reconciler consumes. It is derived from config.DHCPDynamicDNSConfig at
 // reconcile time so the reconciler never holds a stale captured cfg
 // (plan §5 invariant 1).
+//
+// #2691 P1b — one ddnsPolicy is resolved PER FAMILY (#2663 independent v4/v6
+// policy). The v4 and v6 lease sets are now reconciled with their OWN policy +
+// own backend, so a v4 conflict, a v4 backend failure, or a v4 turn-off can
+// never affect v6 publishing (and vice-versa).
 type ddnsPolicy struct {
 	enabled        bool
 	domain         string
@@ -76,6 +91,46 @@ type ddnsPolicy struct {
 	hostnameSource string
 	conflictPolicy string
 	backend        string
+}
+
+// ScopeGate decides whether THIS node may publish records for a given scope
+// (#2691 P1b / #2664 the per-RG HA writer gate). It returns true when the
+// scope is writable from here: standalone always true; in a cluster, true IFF
+// the local node is the MASTER for scope.RGOwner. A nil gate (the standalone
+// Reconcile entry point and existing tests) means "every scope is writable".
+//
+// FAIL-CLOSED CONTRACT (#2664): the daemon's gate returns FALSE for any scope
+// whose RG ownership is uncertain (a lease whose address falls in no
+// master-owned subnet, or whose RG cannot be attributed). A scope the gate
+// rejects is NOT published — but it is also NOT withdrawn (stop-writing, never
+// withdraw: the peer that became MASTER for that RG refreshes the record; a
+// withdraw race would blackhole, plan §5.6 / risk R3). The reconciler enforces
+// this by treating a gated-out OWNED record exactly like an untrusted family:
+// it is left in the store, never deleted, and never re-published from here.
+type ScopeGate func(ScopeKey) bool
+
+// ScopeResolver attributes a lease to the redundancy group (and, in later
+// phases, the interface/unit/routing-instance) that OWNS it (#2691 P1b). The
+// daemon supplies it from the committed DHCP config: a lease address is mapped
+// to its pool subnet → group → interface → redundancy-group (stable CIDR
+// membership, NOT the per-render-unstable Kea subnet_id, plan §6 fork 2). It
+// returns the scope's RG owner and ok=false when the lease cannot be attributed
+// to any known scope — which the gate then treats as fail-closed (not
+// published). A nil resolver (standalone / tests) yields the zero scope for the
+// family (RGOwner 0), which a nil gate always admits.
+type ScopeResolver func(l Lease) (ScopeKey, bool)
+
+// ReconcileOptions carries the HA scope wiring for one reconcile pass (#2691
+// P1b). All fields are optional; the zero value is the standalone behaviour
+// (every scope writable, leases keyed by family only). The daemon populates
+// Gate + Resolver so the per-RG writer gate and per-family/per-RG ownership
+// scoping take effect.
+type ReconcileOptions struct {
+	// Gate is the per-scope HA writer gate (#2664). Nil ⇒ all scopes writable.
+	Gate ScopeGate
+	// Resolver attributes each lease to its owning scope (RG etc., #2664). Nil
+	// ⇒ leases get the zero scope for their family (standalone Surface B).
+	Resolver ScopeResolver
 }
 
 // policyFromConfig resolves a typed config block into a runtime policy,
@@ -332,83 +387,193 @@ func (m *Manager) ownerWatermark(identity, address string) string {
 // one-time cleanup of any previously-owned records when the feature is
 // turned OFF (so disabling DDNS withdraws its records).
 func (m *Manager) Reconcile(ctx context.Context, cfg *config.DHCPServerConfig) error {
-	var ddns *config.DHCPDynamicDNSConfig
-	if cfg != nil {
-		ddns = cfg.DynamicDNS
+	return m.ReconcileScoped(ctx, cfg, ReconcileOptions{})
+}
+
+// reconcileEnv is the per-pass, per-family resolved environment the reconcile
+// algorithm + the upsert/delete helpers consume (#2691 P1b). It carries each
+// family's INDEPENDENT policy + backend (#2663), plus the HA scope gate +
+// resolver (#2664). The helpers select the family slice by a record's Family.
+type reconcileEnv struct {
+	pol     [2]ddnsPolicy // [0]=v4, [1]=v6
+	updater [2]DNSUpdater // [0]=v4, [1]=v6 (resolve-per-Reconcile per family)
+	gate    ScopeGate     // per-scope HA writer gate (#2664); nil ⇒ all writable
+	res     ScopeResolver // lease→scope attribution (#2664); nil ⇒ zero scope
+}
+
+// famIdx maps an engine family int (4/6) to the [2] env slot.
+func famIdx(family int) int {
+	if family == 6 {
+		return 1
 	}
-	pol := policyFromConfig(ddns)
-	m.lastPolicy.Store(&pol)
+	return 0
+}
+
+// updaterFor returns the resolved backend for a record's family.
+func (e *reconcileEnv) updaterFor(family int) DNSUpdater { return e.updater[famIdx(family)] }
+
+// polFor returns the resolved policy for a family.
+func (e *reconcileEnv) polFor(family int) ddnsPolicy { return e.pol[famIdx(family)] }
+
+// scopeAdmits reports whether THIS node may publish records for a scope under
+// the gate (#2664). A nil gate admits everything (standalone). Fail-closed is
+// the daemon's gate's responsibility (it returns false for an uncertain RG).
+func (e *reconcileEnv) scopeAdmits(s ScopeKey) bool {
+	if e.gate == nil {
+		return true
+	}
+	return e.gate(s)
+}
+
+// scopeFor attributes a lease to its owning scope (#2664). With no resolver
+// (standalone / tests) the scope is just the family — the zero-scope global
+// lease path, byte-for-byte the pre-P1b ownership key. The resolver's ok=false
+// (lease attributable to no known scope) returns the family-only scope with
+// admit=false so the caller fail-closes (does not publish), without losing the
+// family tag that keeps v4/v6 ownership independent.
+func (e *reconcileEnv) scopeFor(l Lease) (scope ScopeKey, admit bool) {
+	if e.res == nil {
+		// Standalone / no-resolver: the ZERO scope for BOTH families — the
+		// global lease key, byte-for-byte the pre-P1b "identity|address"
+		// ownership key (no migration, no churn). A v4 and a v6 record never
+		// collide on this key because their ADDRESSES differ (an address is
+		// either v4 or v6), so the family need not be folded into the key here;
+		// per-family POLICY independence (#2663) is delivered by the per-family
+		// policy + backend resolution, not by the ownership key. The record's
+		// own Family field stays authoritative for the wire op.
+		return ScopeKey{}, e.scopeAdmits(ScopeKey{})
+	}
+	s, ok := e.res(l)
+	if !ok {
+		// Unattributable lease: fail-closed (#2664). Use a non-zero family-only
+		// scope so the gated-out record cannot alias a real global-scope entry;
+		// it is dropped (admit=false), so it is never stored anyway.
+		return ScopeKey{Family: familyOf(l.Family)}, false
+	}
+	return s, e.scopeAdmits(s)
+}
+
+// ReconcileScoped is the per-family / per-scope reconcile entry point (#2691
+// P1b). It resolves an INDEPENDENT policy + backend for the v4 and the v6
+// family (#2663), tags every desired record with its ScopeKey (#2664), and
+// applies the per-scope HA writer gate (opts.Gate / opts.Resolver). Reconcile
+// is the nil-options (standalone, all-scopes-writable) wrapper.
+func (m *Manager) ReconcileScoped(ctx context.Context, cfg *config.DHCPServerConfig, opts ReconcileOptions) error {
+	var ddns4, ddns6 *config.DHCPDynamicDNSConfig
+	if cfg != nil {
+		ddns4 = cfg.DynamicDNS
+		ddns6 = cfg.DynamicDNSv6
+	}
+	// BACKWARD COMPATIBILITY (#2663 + plan §5.9): a pre-P1b config carried a
+	// SINGLE dynamic-dns block under ONE family that applied to BOTH families
+	// (the reconciler walked both lease sets with one policy). To keep those
+	// committed configs working byte-for-byte, when only ONE family's block is
+	// present the OTHER family INHERITS it. The moment BOTH families set their
+	// own block they are fully INDEPENDENT (the #2663 fix). This preserves the
+	// single-family case AND delivers per-family independence for the two-block
+	// case, with no silent loss of v6 publishing for existing single-block
+	// configs.
+	if ddns4 == nil && ddns6 != nil {
+		ddns4 = ddns6
+	} else if ddns6 == nil && ddns4 != nil {
+		ddns6 = ddns4
+	}
+	pol4 := policyFromConfig(ddns4)
+	pol6 := policyFromConfig(ddns6)
+	// lastPolicy surfaces an aggregate for Stats(): enabled if EITHER family is
+	// enabled; backend is the v4 backend when v4 is configured, else v6's.
+	agg := pol4
+	if !agg.enabled {
+		agg = pol6
+	}
+	if ddns4 == nil && ddns6 != nil {
+		agg = pol6
+	}
+	m.lastPolicy.Store(&agg)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Resolve the live backend from the policy resolved THIS cycle (plan §6
-	// fork 1: resolve-per-Reconcile). A nil factory keeps the static updater
-	// (tests inject a fixed fakeUpdater). A factory error (bad TSIG /
-	// unusable policy) falls back to the no-op so reconcile never wedges and
-	// a malformed backend cannot crash the loop — it is logged + counted as
-	// a no-backend cycle. This MUST run even when disabled so a turn-off
-	// resolves the live backend that published the records and can withdraw
-	// them (else the static nop would silently no-op the withdraw).
-	if m.newUpdater != nil {
-		up, err := m.newUpdater(pol, ddns)
-		if err != nil {
-			slog.Warn("ddns: cannot build DNS-update backend; staying no-op this cycle", "err", err)
-			up = nopUpdater{}
-		}
-		// Do NOT replace a LIVE updater with a nop while owned records still
-		// need withdrawing. The whole-stanza removal (DynamicDNS=nil) resolves
-		// the factory to a nopUpdater (no update-server/TSIG left to build the
-		// live backend from), and the !pol.enabled branch below would then run
-		// withdrawAllLocked THROUGH the nop — dropping ownership entries while
-		// sending no real DNS delete, orphaning the records this firewall
-		// published. Keep the existing live updater for THIS withdraw cycle so
-		// the backend that published the records also withdraws them; the swap
-		// to nop happens on the next cycle once nothing is owned. (Disable via
-		// Enabled=false while keeping the backend config still resolves a live
-		// updater here, so that path is unaffected.)
-		if isNopUpdater(up) && !isNopUpdater(m.updater) && len(m.state.records) > 0 {
-			slog.Debug("ddns: keeping live updater this cycle to withdraw owned records " +
-				"before swapping to no-op")
-		} else {
-			m.updater = up
-		}
+	env := reconcileEnv{
+		pol:     [2]ddnsPolicy{pol4, pol6},
+		updater: [2]DNSUpdater{m.updater, m.updater},
+		gate:    opts.Gate,
+		res:     opts.Resolver,
 	}
 
-	if !pol.enabled {
-		err := m.withdrawAllLocked(ctx)
-		m.recordReconcilePass(err)
-		return err
+	// Resolve each family's live backend from THIS cycle's policy (plan §6
+	// fork 1: resolve-per-Reconcile, now PER FAMILY — #2663). A nil factory
+	// keeps the static updater (tests inject a fixed fakeUpdater). A factory
+	// error (bad TSIG / unusable policy) for one family falls back to that
+	// family's no-op WITHOUT affecting the other family — independence (#2663).
+	if m.newUpdater != nil {
+		env.updater[0] = m.resolveFamilyUpdater(pol4, ddns4)
+		env.updater[1] = m.resolveFamilyUpdater(pol6, ddns6)
+		// Keep the LIVE-updater-for-withdraw guard, now per family: if a family
+		// resolved to nop but still owns records (turn-off), keep the prior live
+		// updater for THIS withdraw cycle so the backend that published also
+		// withdraws (else the nop silently drops ownership, orphaning the live
+		// RR — the same hazard the single-family path guards, plan §4.2).
+		if isNopUpdater(env.updater[0]) && !isNopUpdater(m.updater) && m.familyOwnsRecords(4) {
+			env.updater[0] = m.updater
+			slog.Debug("ddns: keeping live v4 updater this cycle to withdraw owned records")
+		}
+		if isNopUpdater(env.updater[1]) && !isNopUpdater(m.updater) && m.familyOwnsRecords(6) {
+			env.updater[1] = m.updater
+			slog.Debug("ddns: keeping live v6 updater this cycle to withdraw owned records")
+		}
+		// Track a single representative live updater for the next-cycle
+		// withdraw guard (m.updater is the "last live backend seen" anchor).
+		if !isNopUpdater(env.updater[0]) {
+			m.updater = env.updater[0]
+		} else if !isNopUpdater(env.updater[1]) {
+			m.updater = env.updater[1]
+		}
 	}
 
 	now := m.now()
-	leases4, err4 := m.parseLeases(m.leasePath4, 4, now)
-	if err4 != nil {
-		slog.Warn("ddns: parse v4 leases failed; suppressing v4 deletes this cycle", "err", err4)
-	}
-	leases6, err6 := m.parseLeases(m.leasePath6, 6, now)
-	if err6 != nil {
-		slog.Warn("ddns: parse v6 leases failed; suppressing v6 deletes this cycle", "err", err6)
-	}
-	leases := append(leases4, leases6...)
-
-	// Fail-safe: when a family's lease CSV cannot be read/parsed, its lease
-	// set is unreliable (nil/partial) and EVERY owned record of that family
-	// would look expired -> eligible for deletion. We must never delete owned
-	// records on the basis of an unreadable source of truth, so mark that
-	// family as untrusted and the reconciler skips its destructive diff this
-	// cycle. The error is surfaced to the caller so the loop logs/counts it.
 	untrusted := map[int]bool{}
-	if err4 != nil {
-		untrusted[4] = true
+	var leases []Lease
+	var err4, err6 error
+
+	// Per-family enable: a disabled family withdraws ITS OWN records only
+	// (#2663 independence — disabling v4 must not touch v6). A family that is
+	// enabled feeds its leases into the shared desired set.
+	if pol4.enabled {
+		l4, e4 := m.parseLeases(m.leasePath4, 4, now)
+		err4 = e4
+		if e4 != nil {
+			slog.Warn("ddns: parse v4 leases failed; suppressing v4 deletes this cycle", "err", e4)
+			untrusted[4] = true
+		}
+		leases = append(leases, l4...)
+	} else {
+		// v4 disabled: withdraw v4-owned records through the resolved v4
+		// updater. Leaving v4 out of `leases` would make Pass 1 try to delete
+		// every v4 record anyway, but routing the withdraw explicitly keeps the
+		// family-scoped semantics clear and uses the v4 backend.
+		untrusted[4] = false
 	}
-	if err6 != nil {
-		untrusted[6] = true
+	if pol6.enabled {
+		l6, e6 := m.parseLeases(m.leasePath6, 6, now)
+		err6 = e6
+		if e6 != nil {
+			slog.Warn("ddns: parse v6 leases failed; suppressing v6 deletes this cycle", "err", e6)
+			untrusted[6] = true
+		}
+		leases = append(leases, l6...)
+	} else {
+		untrusted[6] = false
 	}
-	recErr := m.reconcileOnceLocked(ctx, pol, leases, untrusted)
-	// A reconcile pass "fails" when any record op errored OR a family's lease
-	// CSV was unreadable (its destructive diff was suppressed — an incomplete
-	// pass). Surface the first error to the loop for logging.
+
+	// disabledFamilies tells the reconciler to WITHDRAW (delete-owned) a
+	// family's records rather than skip them: a family that is not enabled has
+	// no desired set, so Pass 1 deletes its owned records (turn-off cleanup),
+	// while an ENABLED family with an unreadable CSV is untrusted (skip the
+	// destructive diff). The two must not be conflated.
+	disabled := map[int]bool{4: !pol4.enabled, 6: !pol6.enabled}
+
+	recErr := m.reconcileOnceLocked(ctx, &env, leases, untrusted, disabled)
 	passErr := recErr
 	if passErr == nil {
 		if err4 != nil {
@@ -419,6 +584,29 @@ func (m *Manager) Reconcile(ctx context.Context, cfg *config.DHCPServerConfig) e
 	}
 	m.recordReconcilePass(passErr)
 	return passErr
+}
+
+// resolveFamilyUpdater resolves one family's backend from its policy + config,
+// falling back to the no-op (logged, counted) on a factory error so one
+// family's malformed backend cannot wedge the loop or affect the other family.
+func (m *Manager) resolveFamilyUpdater(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig) DNSUpdater {
+	up, err := m.newUpdater(pol, c)
+	if err != nil {
+		slog.Warn("ddns: cannot build DNS-update backend; staying no-op this cycle for this family", "err", err)
+		return nopUpdater{}
+	}
+	return up
+}
+
+// familyOwnsRecords reports whether the ownership store holds any record of the
+// given family — used to keep a live updater for a turn-off withdraw cycle.
+func (m *Manager) familyOwnsRecords(family int) bool {
+	for _, r := range m.state.records {
+		if r.Family == family {
+			return true
+		}
+	}
+	return false
 }
 
 // parseLeases reads a family's active leases via the injected LeaseParser
@@ -455,13 +643,22 @@ func (m *Manager) recordReconcilePass(err error) {
 // destructive diff (deletes) for an untrusted family so a transient
 // malformed lease file can never mass-delete that family's owned records.
 // A nil map means all families are trusted.
-func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, leases []Lease, untrusted map[int]bool) error {
-	source := hostnameSourceFor(&pol)
+func (m *Manager) reconcileOnceLocked(ctx context.Context, env *reconcileEnv, leases []Lease, untrusted, disabled map[int]bool) error {
 	blockedIdentity := map[string]struct{}{}
 	blockedAddress := map[string]struct{}{}
 	blockedFQDN := map[string]struct{}{}
 
-	// desired[key] = the record we want owned for that identity+address.
+	// gatedScope[scopePrefix] = true marks a scope this node may NOT publish
+	// for (the per-RG HA writer gate is CLOSED for it, #2664). An owned record
+	// in a gated scope is treated EXACTLY like an untrusted family in Pass 1:
+	// it is NEVER deleted (stop-writing, never withdraw — the peer MASTER for
+	// that RG refreshes it; a withdraw race would blackhole, plan §5.6) and
+	// never re-published from here. Tracked by scope-prefix so the Pass-1
+	// owned-record loop can ask "is this record's scope gated?" without a
+	// resolver (the owned record carries its scope).
+	gatedScope := map[string]bool{}
+
+	// desired[key] = the record we want owned for that scope+identity+address.
 	type desired struct {
 		rec  LeaseDNSRecord
 		ow   ownedRecord
@@ -470,11 +667,24 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, lease
 	want := map[string]*desired{}
 	// Reassignment (a new client taking over an address a different client
 	// held) is cleaned by the owned-state delete pass below, NOT a separate
-	// tracker: the old owner's (identity,address) key is no longer in `want`
-	// (the new client has a different identity), so Pass 1 deletes the old
-	// owned record before Pass 2 adds the new one (delete-before-add on a
+	// tracker: the old owner's (scope,identity,address) key is no longer in
+	// `want` (the new client has a different identity), so Pass 1 deletes the
+	// old owned record before Pass 2 adds the new one (delete-before-add on a
 	// shared address; a failed delete blocks the add via the blocked maps).
 	for _, l := range leases {
+		pol := env.polFor(l.Family)
+		source := hostnameSourceFor(&pol)
+		// Resolve the lease's scope + the per-RG HA gate decision (#2664). A
+		// gated-out scope is recorded so Pass 1 protects its owned records from
+		// deletion, and the desired record is NOT added (stop-writing).
+		scope, admit := env.scopeFor(l)
+		if !admit {
+			gatedScope[scope.scopePrefix()] = true
+			slog.Debug("ddns: scope not writable from this node (per-RG gate closed); "+
+				"not publishing, not withdrawing",
+				"address", l.Address, "rg", scope.RGOwner, "family", l.Family)
+			continue
+		}
 		fqdn, err := deriveFQDN(l.HostName, l.ClientFQDN, l.Identity, pol.domain, source)
 		if err != nil {
 			m.skippedNoName.Add(1)
@@ -510,8 +720,8 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, lease
 			TTL:         rec.TTL,
 			OwnerID:     m.ownerWatermark(identity, l.Address),
 			ClientID:    l.Identity,
-		}
-		want[ownedRecordKey(identity, l.Address)] = &desired{rec: rec, ow: ow}
+		}.withScope(scope)
+		want[ownedRecordKey(scope, identity, l.Address)] = &desired{rec: rec, ow: ow}
 	}
 
 	var firstErr error
@@ -526,7 +736,7 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, lease
 	// moved, name changed). Cleaning before adding is what makes
 	// reassignment safe (delete the old owner first).
 	for _, owned := range m.state.all() {
-		key := ownedRecordKey(owned.Identity, owned.Address)
+		key := ownedRecordKey(owned.scopeOf(), owned.Identity, owned.Address)
 		d, stillWanted := want[key]
 		if stillWanted && recordsEqual(owned, d.ow) {
 			// The published forward/reverse tuple is unchanged. If the owned
@@ -539,12 +749,28 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, lease
 			}
 			continue
 		}
+		// HA per-RG gate (#2664): if this owned record's scope is gated CLOSED
+		// from this node (we are not the MASTER for its RG), STOP WRITING but
+		// NEVER WITHDRAW — leave it in the store untouched. The peer that is
+		// MASTER for that RG owns the refresh; a withdraw here would race the
+		// peer and blackhole (plan §5.6 / risk R3). This is the load-bearing
+		// #2664 invariant: a node that loses one RG must not delete that RG's
+		// records.
+		if gatedScope[owned.scopeOf().scopePrefix()] {
+			if stillWanted {
+				d.seen = true
+			}
+			continue
+		}
 		// Fail-safe (#1387 MAJOR-4): if this owned record's family had an
 		// unreadable/partial lease CSV this cycle, its "expired" appearance
 		// is untrustworthy — skip the delete entirely. Mark the record as
 		// seen so the add pass does not re-publish it either; leave the
-		// ownership entry intact for a later, trustworthy reconcile.
-		if untrusted[owned.Family] {
+		// ownership entry intact for a later, trustworthy reconcile. A DISABLED
+		// family (disabled[family]) is NOT untrusted — it has no desired set on
+		// purpose, so its owned records SHOULD be withdrawn (turn-off cleanup),
+		// so disabled does not protect from delete here.
+		if untrusted[owned.Family] && !disabled[owned.Family] {
 			if stillWanted {
 				d.seen = true
 			}
@@ -553,7 +779,7 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, lease
 		// Owned but not wanted (expired/released) OR wanted differently
 		// (the desired pass below re-adds the new form). Delete only the
 		// EXACT owned tuple — never anything not in the store.
-		if err := m.deleteOwnedLocked(ctx, owned); err != nil {
+		if err := m.deleteOwnedLocked(ctx, env.updaterFor(owned.Family), owned); err != nil {
 			noteErr(err)
 			blockedIdentity[owned.Identity] = struct{}{}
 			blockedAddress[owned.Address] = struct{}{}
@@ -579,7 +805,7 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, pol ddnsPolicy, lease
 		if _, blocked := blockedFQDN[d.ow.FQDN]; blocked {
 			continue
 		}
-		if err := m.upsertLocked(ctx, d.rec, d.ow); err != nil {
+		if err := m.upsertLocked(ctx, env.updaterFor(d.ow.Family), d.rec, d.ow); err != nil {
 			noteErr(err)
 			continue
 		}
@@ -613,7 +839,7 @@ func (m *Manager) withdrawAllLocked(ctx context.Context) error {
 	}
 	var firstErr error
 	for _, r := range owned {
-		if err := m.deleteOwnedLocked(ctx, r); err != nil && firstErr == nil {
+		if err := m.deleteOwnedLocked(ctx, m.updater, r); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -657,13 +883,13 @@ func (m *Manager) withdrawAllLocked(ctx context.Context) error {
 // actually fires). Deleting an intent for a RR that was never created is
 // safe: the #2648 DHCID-match / exact-RR delete prerequisite fails on a
 // non-existent RR, so the wire delete is a harmless no-op.
-func (m *Manager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow ownedRecord) error {
-	if isNopUpdater(m.updater) {
+func (m *Manager) upsertLocked(ctx context.Context, updater DNSUpdater, rec LeaseDNSRecord, ow ownedRecord) error {
+	if isNopUpdater(updater) {
 		// No live backend: nothing is published, so record NO ownership and
 		// do not write-ahead an intent (an intent for a record nopUpdater
 		// never wrote would be phantom). Count the skip and return success so
 		// the reconcile does not wedge.
-		if err := m.updater.UpsertLease(ctx, rec); err != nil {
+		if err := updater.UpsertLease(ctx, rec); err != nil {
 			m.upsertFail.Add(1)
 			return err
 		}
@@ -683,14 +909,14 @@ func (m *Manager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow owned
 		// in-memory intent back so the store matches what is durable, surface
 		// the failure as "record not safely owned", and let the next
 		// reconcile retry.
-		m.state.delete(intent.Identity, intent.Address)
+		m.state.delete(intent.scopeOf(), intent.Identity, intent.Address)
 		m.upsertFail.Add(1)
 		slog.Warn("ddns: cannot durably record ownership before add; skipping publish",
 			"fqdn", rec.FQDN, "err", err)
 		return err
 	}
 
-	if err := m.updater.UpsertLease(ctx, rec); err != nil {
+	if err := updater.UpsertLease(ctx, rec); err != nil {
 		// ORDER MATTERS (#2676): check errDDNSPTRPending BEFORE
 		// errDDNSConflictRefused. errDDNSPTRPending is returned ONLY after the
 		// forward A/AAAA add SUCCEEDED, so its presence proves the forward is
@@ -727,7 +953,7 @@ func (m *Manager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow owned
 			// REMOVE the pre-written intent (no phantom ownership) and persist the
 			// removal. Count it as a conflict skip already done by the backend; do
 			// not fail the reconcile pass.
-			m.state.delete(intent.Identity, intent.Address)
+			m.state.delete(intent.scopeOf(), intent.Identity, intent.Address)
 			if serr := m.state.save(); serr != nil {
 				// The intent is removed in memory but the removal is not durable.
 				// Surface it so the pass is marked failed and retried; a stale
@@ -745,7 +971,7 @@ func (m *Manager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow owned
 		// (no-op) delete against a non-existent RR forever. A save failure here
 		// is non-fatal beyond the add error already returned: a stale durable
 		// intent's delete is a harmless no-op and self-heals on the next save.
-		m.state.delete(intent.Identity, intent.Address)
+		m.state.delete(intent.scopeOf(), intent.Identity, intent.Address)
 		if serr := m.state.save(); serr != nil {
 			slog.Warn("ddns: cannot persist removal of failed-add intent",
 				"fqdn", rec.FQDN, "err", serr)
@@ -773,7 +999,7 @@ func (m *Manager) upsertLocked(ctx context.Context, rec LeaseDNSRecord, ow owned
 // deletes it, removing the ownership entry on success. This is the sole
 // delete authority — it never constructs a delete from anything but the
 // store, so a record xpf did not create can never be deleted.
-func (m *Manager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) error {
+func (m *Manager) deleteOwnedLocked(ctx context.Context, updater DNSUpdater, owned ownedRecord) error {
 	rec, err := buildLeaseRecord(owned.FQDN, owned.Address, owned.TTL)
 	if err != nil {
 		// The stored address no longer parses (should not happen): drop
@@ -781,7 +1007,7 @@ func (m *Manager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) erro
 		// guessed name.
 		slog.Warn("ddns: owned record has unparseable address; dropping entry",
 			"address", owned.Address, "err", err)
-		m.state.delete(owned.Identity, owned.Address)
+		m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
 		return nil
 	}
 	// Force the stored forward type / PTR name (re-derived above should
@@ -792,11 +1018,11 @@ func (m *Manager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) erro
 	// backend recomputes the same RFC 4701 DHCID — the delete prerequisite
 	// then proves xpf owns the record before removing it.
 	rec.ClientID = owned.ClientID
-	if err := m.updater.DeleteLease(ctx, rec); err != nil {
+	if err := updater.DeleteLease(ctx, rec); err != nil {
 		m.deleteFail.Add(1)
 		return err
 	}
-	if isNopUpdater(m.updater) {
+	if isNopUpdater(updater) {
 		// No live backend: the delete was a logged no-op. Still drop the
 		// ownership entry. For increment 1 this is CORRECT: nopUpdater never
 		// published anything, so there is nothing in DNS to orphan by
@@ -807,11 +1033,11 @@ func (m *Manager) deleteOwnedLocked(ctx context.Context, owned ownedRecord) erro
 		// increment-2 concern; there is NO logic change for inc-1, where the
 		// store can only ever hold records nopUpdater "wrote" (i.e. none).
 		m.skippedNoBackend.Add(1)
-		m.state.delete(owned.Identity, owned.Address)
+		m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
 		return nil
 	}
 	m.deleteOK.Add(1)
-	m.state.delete(owned.Identity, owned.Address)
+	m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
 	return nil
 }
 
@@ -898,14 +1124,21 @@ func (m *Manager) DDNSLeasePaths() (leasePath4, leasePath6 string) {
 }
 
 // OwnedForTesting reports whether the ownership store holds a record for the
-// given identity+address. Test-only accessor for cross-package tests (the
-// pkg/dhcpserver real-parser→engine integration tests) that previously reached
-// into the unexported state store directly (#2691 P1a). Not for production use.
+// given identity+address IN ANY SCOPE. Test-only accessor for cross-package
+// tests (the pkg/dhcpserver real-parser→engine integration tests) that
+// previously reached into the unexported state store directly (#2691 P1a). It
+// matches scope-agnostically (#2691 P1b) so the existing seam callers — which
+// publish on the zero/global lease scope — keep working unchanged. Not for
+// production use.
 func (m *Manager) OwnedForTesting(identity, address string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	_, ok := m.state.get(identity, address)
-	return ok
+	for _, r := range m.state.records {
+		if r.Identity == identity && r.Address == address {
+			return true
+		}
+	}
+	return false
 }
 
 // OwnedKeysForTesting returns the identity|address keys of every owned record,

--- a/pkg/ddns/manager_test.go
+++ b/pkg/ddns/manager_test.go
@@ -107,7 +107,15 @@ func runReconcile(t *testing.T, m *Manager, pol ddnsPolicy, leases []Lease) erro
 	t.Helper()
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.reconcileOnceLocked(context.Background(), pol, leases, nil)
+	// #2691 P1b: reconcileOnceLocked now takes a per-family env (the same policy
+	// is applied to both families here) + the disabled map. The updater is the
+	// manager's single test updater for both families; nil gate/resolver ⇒ all
+	// scopes writable (the standalone / zero-scope path these tests assert on).
+	env := &reconcileEnv{
+		pol:     [2]ddnsPolicy{pol, pol},
+		updater: [2]DNSUpdater{m.updater, m.updater},
+	}
+	return m.reconcileOnceLocked(context.Background(), env, leases, nil, nil)
 }
 
 // writeCSV writes a file (used by the state-store tests to seed an on-disk
@@ -392,7 +400,7 @@ func TestReconcileDeleteFailureBlocksReplacementUpsert(t *testing.T) {
 	if m.deleteFail.Load() != 1 {
 		t.Fatalf("deleteFail = %d, want 1", m.deleteFail.Load())
 	}
-	if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+	if _, ok := m.state.get(ScopeKey{}, "mac:aa", "10.0.0.10"); !ok {
 		t.Fatal("old ownership entry dropped after failed delete")
 	}
 
@@ -409,7 +417,7 @@ func TestReconcileDeleteFailureBlocksReplacementUpsert(t *testing.T) {
 	if got := up.upsertNames(); !equalStr(got, []string{"host-b.example.com=10.0.0.10"}) {
 		t.Fatalf("replacement upserts = %v", got)
 	}
-	if _, ok := m.state.get("mac:aa", "10.0.0.10"); ok {
+	if _, ok := m.state.get(ScopeKey{}, "mac:aa", "10.0.0.10"); ok {
 		t.Fatal("old ownership entry still present after successful retry")
 	}
 }
@@ -571,7 +579,7 @@ func TestNilUpdaterIsNopNotPanic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("withdraw with no backend errored: %v", err)
 	}
-	if _, ok := m.state.get("mac:bb", "10.0.0.20"); ok {
+	if _, ok := m.state.get(ScopeKey{}, "mac:bb", "10.0.0.20"); ok {
 		t.Fatal("withdraw did not drop the owned entry under no-backend mode")
 	}
 }
@@ -657,11 +665,11 @@ func TestReconcileParseErrorSuppressesFamilyDeletes(t *testing.T) {
 		}
 	}
 	// The v4 owned record is still in the store.
-	if _, ok := m.state.get("mac:aa", "10.0.0.10"); !ok {
+	if _, ok := m.state.get(ScopeKey{}, "mac:aa", "10.0.0.10"); !ok {
 		t.Fatal("v4 owned record dropped after a v4 parse error (mass-delete bug)")
 	}
 	// The healthy v6 owned record is also still present (active this cycle).
-	if _, ok := m.state.get("duid:00:01/7", "2001:db8::5"); !ok {
+	if _, ok := m.state.get(ScopeKey{}, "duid:00:01/7", "2001:db8::5"); !ok {
 		t.Fatal("healthy v6 owned record lost while v4 was untrusted")
 	}
 }
@@ -683,7 +691,7 @@ func TestStateStorePersistsAndReloads(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r, ok := s2.get("mac:aa", "10.0.0.10"); !ok || r.FQDN != "h.example.com" {
+	if r, ok := s2.get(ScopeKey{}, "mac:aa", "10.0.0.10"); !ok || r.FQDN != "h.example.com" {
 		t.Fatalf("reload lost record: %+v ok=%v", r, ok)
 	}
 }
@@ -733,7 +741,7 @@ func TestStateStoreUnsupportedVersionFailsOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version-0 store must load, got error: %v", err)
 	}
-	if _, ok := s0.get("mac:bb", "10.0.0.20"); !ok {
+	if _, ok := s0.get(ScopeKey{}, "mac:bb", "10.0.0.20"); !ok {
 		t.Fatal("version-0 store should load its records")
 	}
 }

--- a/pkg/ddns/scope_test.go
+++ b/pkg/ddns/scope_test.go
@@ -1,0 +1,297 @@
+package ddns
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2691 P1b scope tests: ScopeKey ownership-key independence, per-family
+// independent policy (#2663), and the per-RG HA writer gate (#2664). All drive
+// the engine through ReconcileScoped with a fakeUpdater (no network/DNS).
+
+// scopeManager builds a manager wired to a per-family fake lease source + a
+// fakeUpdater for BOTH families (the same updater records all ops). The updater
+// factory returns the recording updater whenever a family is enabled, so the
+// per-family backend resolution is exercised end to end.
+func scopeManager(t *testing.T, up DNSUpdater, v4, v6 []Lease) *Manager {
+	t.Helper()
+	dir := t.TempDir()
+	src := &fakeLeaseSource{v4: v4, v6: v6}
+	m := newManagerForTesting(
+		src.parser(),
+		up,
+		filepath.Join(dir, "state.json"),
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		func() time.Time { return time.Unix(1_700_000_000, 0) },
+	)
+	// Resolve to the recording updater whenever the family is enabled.
+	m.newUpdater = func(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig) (DNSUpdater, error) {
+		if !pol.enabled || c == nil {
+			return nopUpdater{}, nil
+		}
+		return up, nil
+	}
+	return m
+}
+
+// scopeRecOf counts how many owned records carry the given RGOwner.
+func ownedByRG(m *Manager, rg int) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, r := range m.state.records {
+		if r.scopeOf().RGOwner == rg {
+			n++
+		}
+	}
+	return n
+}
+
+// TestScopeKeyDistinctForDifferentScopes proves the ScopeKey primitive: two
+// owned records with the SAME identity+address but DIFFERENT scopes (different
+// RG owner, or different family) are DISTINCT entries that never collide
+// (#2663/#2664 — the unifying requirement). Against a flat identity|address key
+// (the pre-P1b shape) the second put would OVERWRITE the first.
+func TestScopeKeyDistinctForDifferentScopes(t *testing.T) {
+	s := &ddnsState{path: "", records: map[string]ownedRecord{}}
+
+	base := ownedRecord{Identity: "mac:aa", Address: "10.0.1.5", FQDN: "h.example.com",
+		ForwardType: "A", Family: 4, TTL: 300}
+
+	// Same identity+address under two different RG scopes.
+	rg1 := base.withScope(ScopeKey{Family: FamilyV4, RGOwner: 1})
+	rg2 := base.withScope(ScopeKey{Family: FamilyV4, RGOwner: 2})
+	s.put(rg1)
+	s.put(rg2)
+	if len(s.records) != 2 {
+		t.Fatalf("two different-RG scopes must be distinct owned entries, got %d", len(s.records))
+	}
+	if _, ok := s.get(ScopeKey{Family: FamilyV4, RGOwner: 1}, "mac:aa", "10.0.1.5"); !ok {
+		t.Fatal("RG1-scoped record not retrievable by its scope")
+	}
+	if _, ok := s.get(ScopeKey{Family: FamilyV4, RGOwner: 2}, "mac:aa", "10.0.1.5"); !ok {
+		t.Fatal("RG2-scoped record not retrievable by its scope")
+	}
+
+	// The ZERO scope yields the pre-P1b "identity|address" key, distinct from
+	// the RG-scoped keys.
+	if got := ownedRecordKey(ScopeKey{}, "mac:aa", "10.0.1.5"); got != "mac:aa|10.0.1.5" {
+		t.Fatalf("zero-scope key must be the pre-P1b form, got %q", got)
+	}
+	if ownedRecordKey(ScopeKey{RGOwner: 1}, "mac:aa", "10.0.1.5") == ownedRecordKey(ScopeKey{}, "mac:aa", "10.0.1.5") {
+		t.Fatal("a non-zero scope must not collide with the zero/global key")
+	}
+}
+
+// TestScopeKeyZeroRoundTripsPreP1bStore proves a pre-P1b ownership record (no
+// "scope" JSON key) loads as the zero/global scope and is keyed exactly as
+// before — no migration, no churn (plan §11 Q7).
+func TestScopeKeyZeroRoundTripsPreP1bStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+	// A pre-P1b store: records with NO "scope" field.
+	writeCSV(t, path, `{"version":1,"records":[
+	  {"family":4,"identity":"mac:aa","subnet_id":"1","address":"10.0.1.5",
+	   "fqdn":"h.example.com","forward_type":"A","ptr_name":"5.1.0.10.in-addr.arpa","ttl":300,"owner_id":"x"}
+	]}`)
+	st, err := loadDDNSState(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if _, ok := st.records["mac:aa|10.0.1.5"]; !ok {
+		t.Fatalf("pre-P1b record not keyed by the global identity|address form: %v", keysOf(st))
+	}
+	r := st.records["mac:aa|10.0.1.5"]
+	if r.Scope != nil {
+		t.Fatalf("pre-P1b record must decode to a nil (zero) scope, got %+v", r.Scope)
+	}
+}
+
+func keysOf(s *ddnsState) []string {
+	out := make([]string, 0, len(s.records))
+	for k := range s.records {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestIndependentV4V6Policy proves #2663: the v4 and v6 families reconcile with
+// INDEPENDENT policies + backends. A v4-scoped publish and a v6-scoped publish
+// for the same host are independent; a disabled/failed v4 family does not block
+// v6 publishing. Here both families are enabled with different domains, and both
+// publish their own records.
+func TestIndependentV4V6Policy(t *testing.T) {
+	up := newFakeUpdater()
+	v4 := []Lease{{Family: 4, Address: "10.0.1.5", Identity: "mac:aa", HostName: "host", SubnetID: "1"}}
+	v6 := []Lease{{Family: 6, Address: "2001:db8::5", Identity: "duid:00:01", HostName: "host", SubnetID: "1"}}
+	m := scopeManager(t, up, v4, v6)
+
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS:   &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "v4.example.com", TTLSeconds: 300},
+		DynamicDNSv6: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "v6.example.com", TTLSeconds: 300},
+	}
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	names := up.upsertNames()
+	var sawV4, sawV6 bool
+	for _, n := range names {
+		switch n {
+		case "host.v4.example.com=10.0.1.5":
+			sawV4 = true
+		case "host.v6.example.com=2001:db8::5":
+			sawV6 = true
+		}
+	}
+	if !sawV4 {
+		t.Errorf("v4 lease must publish under its OWN domain v4.example.com; upserts=%v", names)
+	}
+	if !sawV6 {
+		t.Errorf("v6 lease must publish under its OWN domain v6.example.com; upserts=%v", names)
+	}
+}
+
+// TestV4DisableLeavesV6Untouched proves #2663 independence on the disable path:
+// turning v4 OFF withdraws v4 records but must NOT touch v6 records.
+func TestV4DisableLeavesV6Untouched(t *testing.T) {
+	up := newFakeUpdater()
+	v4 := []Lease{{Family: 4, Address: "10.0.1.5", Identity: "mac:aa", HostName: "h4", SubnetID: "1"}}
+	v6 := []Lease{{Family: 6, Address: "2001:db8::5", Identity: "duid:00:01", HostName: "h6", SubnetID: "1"}}
+	m := scopeManager(t, up, v4, v6)
+
+	both := &config.DHCPServerConfig{
+		DynamicDNS:   &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+		DynamicDNSv6: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+	}
+	if err := m.Reconcile(context.Background(), both); err != nil {
+		t.Fatalf("reconcile both: %v", err)
+	}
+	if len(m.state.records) != 2 {
+		t.Fatalf("both families should own a record, got %d", len(m.state.records))
+	}
+
+	// Disable v4 only (v6 stays enabled).
+	up.deletes = nil
+	v4Off := &config.DHCPServerConfig{
+		DynamicDNS:   &config.DHCPDynamicDNSConfig{Enabled: false, Domain: "example.com", TTLSeconds: 300},
+		DynamicDNSv6: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+	}
+	if err := m.Reconcile(context.Background(), v4Off); err != nil {
+		t.Fatalf("reconcile v4-off: %v", err)
+	}
+	// v4 record withdrawn, v6 retained.
+	for _, d := range up.deletes {
+		if d.Addr.Is6() {
+			t.Fatalf("v6 record deleted when only v4 was disabled: %s", d.FQDN)
+		}
+	}
+	if _, ok := m.state.get(ScopeKey{}, "duid:00:01", "2001:db8::5"); !ok {
+		t.Fatal("v6 owned record lost when only v4 was disabled (independence broken)")
+	}
+	if _, ok := m.state.get(ScopeKey{}, "mac:aa", "10.0.1.5"); ok {
+		t.Fatal("v4 owned record must be withdrawn when v4 is disabled")
+	}
+}
+
+// TestPerRGGatePublishesOwnedRGOnly proves the #2664 per-RG HA writer gate: a
+// node that is MASTER for RG1 but NOT RG2 publishes RG1's leases, does NOT
+// publish RG2's leases, and does NOT withdraw RG2's previously-owned records
+// (stop-writing, never withdraw). This is the partial-demotion invariant.
+//
+// Fail-on-revert: with the pre-#2664 node-level gate (publish-everything-when-
+// master-for-any-RG), RG2's lease WOULD be published from this node — the
+// `sawRG2Upsert` assertion below catches that regression.
+func TestPerRGGatePublishesOwnedRGOnly(t *testing.T) {
+	up := newFakeUpdater()
+	// Two leases in two different RG-owned subnets.
+	rg1Lease := Lease{Family: 4, Address: "10.0.1.5", Identity: "mac:11", HostName: "rg1host", SubnetID: "1"}
+	rg2Lease := Lease{Family: 4, Address: "10.0.2.5", Identity: "mac:22", HostName: "rg2host", SubnetID: "2"}
+	m := scopeManager(t, up, []Lease{rg1Lease, rg2Lease}, nil)
+
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+	}
+
+	// Resolver: 10.0.1.0/24 → RG1, 10.0.2.0/24 → RG2.
+	resolver := func(l Lease) (ScopeKey, bool) {
+		switch l.Address {
+		case "10.0.1.5":
+			return ScopeKey{Family: FamilyV4, RGOwner: 1}, true
+		case "10.0.2.5":
+			return ScopeKey{Family: FamilyV4, RGOwner: 2}, true
+		}
+		return ScopeKey{}, false
+	}
+	// Phase 1: node is MASTER for BOTH RGs → both publish + owned.
+	gateBoth := func(s ScopeKey) bool { return true }
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: gateBoth, Resolver: resolver}); err != nil {
+		t.Fatalf("reconcile (master for both): %v", err)
+	}
+	if ownedByRG(m, 1) != 1 || ownedByRG(m, 2) != 1 {
+		t.Fatalf("both RGs should be owned: rg1=%d rg2=%d", ownedByRG(m, 1), ownedByRG(m, 2))
+	}
+
+	// Phase 2: PARTIAL DEMOTION — node loses RG2, keeps RG1. The gate now
+	// CLOSES for RG2. RG2's lease is still in the (stale) memfile.
+	up.upserts = nil
+	up.deletes = nil
+	gateRG1Only := func(s ScopeKey) bool { return s.RGOwner == 1 }
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: gateRG1Only, Resolver: resolver}); err != nil {
+		t.Fatalf("reconcile (master for RG1 only): %v", err)
+	}
+
+	// RG2 must NOT be published from this node (the #2664 double-write fix).
+	for _, u := range up.upserts {
+		if u.FQDN == "rg2host.example.com" {
+			t.Fatalf("RG2 lease published from a node that is NOT MASTER for RG2 (double-writer): %s", u.FQDN)
+		}
+	}
+	// RG2 must NOT be withdrawn (stop-writing, never withdraw — the peer that
+	// became MASTER for RG2 refreshes it; a withdraw would blackhole).
+	for _, d := range up.deletes {
+		if d.FQDN == "rg2host.example.com" {
+			t.Fatalf("RG2 record WITHDRAWN on partial demotion (blackhole risk): %s", d.FQDN)
+		}
+	}
+	// RG2's owned record is PRESERVED in the store (still owned, just not
+	// touched from here).
+	if ownedByRG(m, 2) != 1 {
+		t.Fatalf("RG2 owned record must be preserved on partial demotion, got %d", ownedByRG(m, 2))
+	}
+	// RG1 is still owned + serviced.
+	if ownedByRG(m, 1) != 1 {
+		t.Fatalf("RG1 owned record must remain, got %d", ownedByRG(m, 1))
+	}
+}
+
+// TestPerRGGateFailClosedUnattributable proves the fail-closed contract
+// (#2664): a lease the gate rejects (admit=false) is NOT published and NOT
+// stored. The resolver returns ok=false → the engine drops it.
+func TestPerRGGateFailClosedUnattributable(t *testing.T) {
+	up := newFakeUpdater()
+	lease := Lease{Family: 4, Address: "10.9.9.9", Identity: "mac:99", HostName: "ghost", SubnetID: "9"}
+	m := scopeManager(t, up, []Lease{lease}, nil)
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+	}
+	resolver := func(l Lease) (ScopeKey, bool) { return ScopeKey{}, false } // never attributable
+	gate := func(s ScopeKey) bool { return true }
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: gate, Resolver: resolver}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(up.upserts) != 0 {
+		t.Fatalf("an unattributable (fail-closed) lease must not be published, got %v", up.upsertNames())
+	}
+	if len(m.state.records) != 0 {
+		t.Fatalf("an unattributable lease must not be recorded as owned, got %d", len(m.state.records))
+	}
+}

--- a/pkg/ddns/scope_test.go
+++ b/pkg/ddns/scope_test.go
@@ -40,6 +40,32 @@ func scopeManager(t *testing.T, up DNSUpdater, v4, v6 []Lease) *Manager {
 	return m
 }
 
+// scopeManagerSrc is scopeManager but also returns the mutable lease source so
+// a test can change the parsed lease set between reconcile passes (modeling a
+// steady-state partial demotion where the demoted RG's leases AGE OUT of the
+// memfile, not merely linger in a stale one).
+func scopeManagerSrc(t *testing.T, up DNSUpdater, v4, v6 []Lease) (*Manager, *fakeLeaseSource) {
+	t.Helper()
+	dir := t.TempDir()
+	src := &fakeLeaseSource{v4: v4, v6: v6}
+	m := newManagerForTesting(
+		src.parser(),
+		up,
+		filepath.Join(dir, "state.json"),
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		func() time.Time { return time.Unix(1_700_000_000, 0) },
+	)
+	m.newUpdater = func(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig) (DNSUpdater, error) {
+		if !pol.enabled || c == nil {
+			return nopUpdater{}, nil
+		}
+		return up, nil
+	}
+	return m, src
+}
+
 // scopeRecOf counts how many owned records carry the given RGOwner.
 func ownedByRG(m *Manager, rg int) int {
 	m.mu.Lock()
@@ -293,5 +319,84 @@ func TestPerRGGateFailClosedUnattributable(t *testing.T) {
 	}
 	if len(m.state.records) != 0 {
 		t.Fatalf("an unattributable lease must not be recorded as owned, got %d", len(m.state.records))
+	}
+}
+
+// TestPerRGGatePartialDemotionSteadyState is the load-bearing #2664
+// fail-on-revert test (review MAJOR): on a STEADY-STATE partial demotion the
+// demoted RG's lease is GONE from the parsed set (its group was dropped from
+// the narrowed Kea config and the lease aged out of the memfile), NOT merely
+// lingering in a stale memfile. The demoted RG's owned record must STILL NOT be
+// withdrawn (stop-writing-never-withdraw, §5.6 — the peer that became MASTER for
+// that RG refreshes it; a withdraw would blackhole), while the kept RG keeps
+// publishing normally.
+//
+// This goes RED on the pre-fix HEAD (Pass 1 protected an owned record ONLY via
+// gatedScope, which is populated solely from CURRENT leases — so a demoted RG
+// whose lease is gone is seen as "expired" and WITHDRAWN) and GREEN with the
+// direct-gate guard (protect whenever the gate rejects the owned scope). It is a
+// reconcile-layer test: it asserts on the durable ownership store + the wire
+// delete calls, not on an updater-in-isolation.
+func TestPerRGGatePartialDemotionSteadyState(t *testing.T) {
+	up := newFakeUpdater()
+	rg1Lease := Lease{Family: 4, Address: "10.0.1.5", Identity: "mac:11", HostName: "rg1host", SubnetID: "1"}
+	rg2Lease := Lease{Family: 4, Address: "10.0.2.5", Identity: "mac:22", HostName: "rg2host", SubnetID: "2"}
+	m, src := scopeManagerSrc(t, up, []Lease{rg1Lease, rg2Lease}, nil)
+
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{Enabled: true, Domain: "example.com", TTLSeconds: 300},
+	}
+	resolver := func(l Lease) (ScopeKey, bool) {
+		switch l.Address {
+		case "10.0.1.5":
+			return ScopeKey{Family: FamilyV4, RGOwner: 1}, true
+		case "10.0.2.5":
+			return ScopeKey{Family: FamilyV4, RGOwner: 2}, true
+		}
+		return ScopeKey{}, false
+	}
+
+	// Phase 1: MASTER for BOTH RGs → both published + owned.
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: func(ScopeKey) bool { return true }, Resolver: resolver}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	if ownedByRG(m, 1) != 1 || ownedByRG(m, 2) != 1 {
+		t.Fatalf("phase 1: both RGs should be owned: rg1=%d rg2=%d", ownedByRG(m, 1), ownedByRG(m, 2))
+	}
+
+	// Phase 2: STEADY-STATE partial demotion. The node lost RG2; the narrowed
+	// Kea config dropped RG2's group and RG2's lease AGED OUT of the memfile —
+	// so it is GONE from the parsed set (the critical difference from the
+	// transient-window test). The gate is closed for RG2.
+	src.v4 = []Lease{rg1Lease} // RG2's lease is NO LONGER present
+	up.upserts = nil
+	up.deletes = nil
+	gateRG1Only := func(s ScopeKey) bool { return s.RGOwner == 1 }
+	if err := m.ReconcileScoped(context.Background(), cfg,
+		ReconcileOptions{Gate: gateRG1Only, Resolver: resolver}); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	// THE ASSERTION (RED pre-fix): RG2's record must NOT be withdrawn even
+	// though no current lease references it — the gate rejects RG2's scope, so
+	// this node neither publishes nor withdraws it.
+	for _, d := range up.deletes {
+		if d.FQDN == "rg2host.example.com" {
+			t.Fatalf("STEADY-STATE partial demotion WITHDREW the demoted RG's record (§5.6 blackhole): %s", d.FQDN)
+		}
+	}
+	if ownedByRG(m, 2) != 1 {
+		t.Fatalf("RG2 owned record must be PRESERVED on steady-state partial demotion, got %d", ownedByRG(m, 2))
+	}
+	// And it must not have been republished from this node either.
+	for _, u := range up.upserts {
+		if u.FQDN == "rg2host.example.com" {
+			t.Fatalf("RG2 republished from a non-master node: %s", u.FQDN)
+		}
+	}
+	// RG1 stays owned + serviced (its lease is still present + the gate admits).
+	if ownedByRG(m, 1) != 1 {
+		t.Fatalf("RG1 owned record must remain, got %d", ownedByRG(m, 1))
 	}
 }

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/fsatomic"
 )
@@ -43,6 +44,84 @@ const defaultDDNSStatePath = "/var/lib/xpf/dhcp-ddns-state.json"
 // defaultDDNSTTL is the record TTL when the operator does not set one.
 const defaultDDNSTTL = 300
 
+// Family is the address family a scope/record applies to (#2691 P1b,
+// plan §5.4). It is the FIRST and load-bearing ScopeKey axis: v4 and v6
+// ownership/policy are INDEPENDENT (#2663), so a v4 conflict can never block
+// a v6 publish, and the two families may target different domains / servers /
+// TSIG keys / TTLs. The integer values mirror the engine's existing 4/6
+// convention (ownedRecord.Family) so the scope and the record agree.
+type Family int
+
+const (
+	// FamilyV4 is the IPv4 (A / in-addr.arpa) family.
+	FamilyV4 Family = 4
+	// FamilyV6 is the IPv6 (AAAA / ip6.arpa) family.
+	FamilyV6 Family = 6
+)
+
+// familyOf maps the engine's int family (4/6) to a Family. Any other value
+// (should not happen for a built record) maps to FamilyV4 as the safe
+// default — the field is informational on the scope key, the record's own
+// ForwardType/Address remain authoritative for the wire op.
+func familyOf(f int) Family {
+	if f == 6 {
+		return FamilyV6
+	}
+	return FamilyV4
+}
+
+// ScopeKey is the unifying ownership/scope primitive (#2691 P1b, plan §5.4).
+// It replaces the flat identity|address ownership key with a structured scope
+// so the SAME firewall can independently own records across families,
+// interfaces, routing-instances, and HA redundancy groups without collision:
+//
+//   - Family         — inet | inet6 (#2663: independent v4/v6 policy + ownership).
+//   - Interface      — the bound interface (e.g. ge-0-0-2.50); "" = a global
+//     lease policy not bound to a specific interface (today's Surface B).
+//   - Unit           — the logical unit (sub-interface) the scope applies to.
+//   - RoutingInstance — the VRF / routing-instance the update egresses from
+//     (#2665 source binding selects the transport from this).
+//   - RGOwner        — the redundancy-group id that owns this scope (#2664:
+//     the per-RG HA writer gate keys on this; 0 = unscoped / standalone).
+//   - PolicyID       — which provider/profile applies (P2/P3 catalog; "" today).
+//
+// ScopeKey is a comparable struct so it is usable directly as a map key. The
+// zero value (FamilyV4-via-familyOf, all-empty) is the BACKWARD-COMPATIBLE
+// global lease scope: an ownership record written before P1b (no scope fields
+// on disk) decodes to a zero ScopeKey, and ownedRecordKey(zeroScope, id, addr)
+// reproduces the EXACT pre-P1b "identity|address" key — so an old store loads
+// and reconciles with no migration (plan §11 Q7: fail-open-to-existing).
+type ScopeKey struct {
+	Family          Family
+	Interface       string
+	Unit            int
+	RoutingInstance string
+	RGOwner         int
+	PolicyID        string
+}
+
+// scopePrefix is the stable, deterministic textual encoding of a ScopeKey for
+// the in-memory map key + the on-disk JSON sort order. The ZERO scope encodes
+// to the EMPTY string, so ownedRecordKey(zeroScope, id, addr) == the pre-P1b
+// "id|addr" key byte-for-byte: a pre-P1b store (no scope fields) loads and is
+// reconciled identically (no migration, no churn). A NON-zero scope prefixes
+// the key with its fields so two scopes for the same name+address never
+// collide (the #2663 / #2664 requirement: a v4-scoped and a v6-scoped publish,
+// or an RG0-owned and RG1-owned publish, of the same host are distinct owned
+// records).
+func (s ScopeKey) scopePrefix() string {
+	if s == (ScopeKey{}) {
+		return ""
+	}
+	// Fixed field order; the family int (4/6) keeps it human-readable. The
+	// terminating "#" separates the scope prefix from the identity|address
+	// suffix so a scope value containing '|' cannot alias an identity.
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "f%d/if=%s/u=%d/ri=%s/rg=%d/pid=%s#",
+		int(s.Family), s.Interface, s.Unit, s.RoutingInstance, s.RGOwner, s.PolicyID)
+	return sb.String()
+}
+
 // ownedRecord is the exact record set this firewall published for one
 // owner identity. A delete re-derives precisely these fields; a mismatch
 // (address moved, name changed) means the desired and owned differ and
@@ -78,13 +157,52 @@ type ownedRecord struct {
 	// from the JSON when false; an absent value (older stores, fully-published
 	// records) degrades to "settled", the safe default.
 	PTRPending bool `json:"ptr_pending,omitempty"`
+	// Scope is the ScopeKey this record belongs to (#2691 P1b, plan §5.4). It
+	// is the per-family / per-interface / per-RG / per-routing-instance scope
+	// the record was published under, so two scopes for the same name+address
+	// (a v4 and a v6 publish, or an RG0-owned and RG1-owned publish) are
+	// distinct owned entries. It is a POINTER so the JSON OMITS it entirely for
+	// the zero (global lease) scope: a pre-P1b store has no "scope" key, which
+	// decodes to a nil pointer, and a P1b global-scope record writes none
+	// either — so the on-disk shape is unchanged for the existing Surface-B
+	// path and there is no migration (plan §11 Q7: fail-open-to-existing). The
+	// in-memory key uses scopeOf(r) which treats nil as the zero ScopeKey,
+	// reproducing the pre-P1b "identity|address" key byte-for-byte.
+	Scope *ScopeKey `json:"scope,omitempty"`
 }
 
-// ownedRecordKey is the in-memory map key for an owned record: a lease's
-// stable identity plus its address, so the same client moving to a new
-// address is a distinct entry (cleanup of the old address is explicit).
-func ownedRecordKey(identity, address string) string {
-	return identity + "|" + address
+// scopeOf returns the record's scope as a value, treating a nil pointer (the
+// zero/global lease scope, and every pre-P1b record) as the zero ScopeKey.
+func (r ownedRecord) scopeOf() ScopeKey {
+	if r.Scope == nil {
+		return ScopeKey{}
+	}
+	return *r.Scope
+}
+
+// withScope returns r with its Scope set: a NON-zero scope is stored as a
+// pointer; the zero scope clears it to nil so the JSON stays pre-P1b-clean and
+// the in-memory key stays the global "identity|address" form.
+func (r ownedRecord) withScope(s ScopeKey) ownedRecord {
+	if s == (ScopeKey{}) {
+		r.Scope = nil
+		return r
+	}
+	sc := s
+	r.Scope = &sc
+	return r
+}
+
+// ownedRecordKey is the in-memory map key for an owned record: the record's
+// SCOPE (#2691 P1b) plus a lease's stable identity plus its address, so the
+// same client moving to a new address is a distinct entry (cleanup of the old
+// address is explicit), AND the same identity+address published under two
+// different scopes (e.g. a v4 vs v6 family, or an RG0 vs RG1 owner) are
+// distinct entries that never collide. The ZERO scope yields the EXACT
+// pre-P1b "identity|address" key (scopePrefix() == ""), so a pre-P1b store
+// loads and reconciles unchanged.
+func ownedRecordKey(scope ScopeKey, identity, address string) string {
+	return scope.scopePrefix() + identity + "|" + address
 }
 
 // ddnsState is the in-memory + on-disk ownership store. records is keyed
@@ -143,7 +261,7 @@ func loadDDNSState(path string) (*ddnsState, error) {
 			path, f.Version, ddnsStateVersion)
 	}
 	for _, r := range f.Records {
-		s.records[ownedRecordKey(r.Identity, r.Address)] = r
+		s.records[ownedRecordKey(r.scopeOf(), r.Identity, r.Address)] = r
 	}
 	return s, nil
 }
@@ -176,20 +294,22 @@ func (s *ddnsState) save() error {
 	return fsatomic.WriteFileDurable(s.path, data, 0o600)
 }
 
-// put records ownership of a published record.
+// put records ownership of a published record, keyed by its scope (#2691
+// P1b) + identity + address.
 func (s *ddnsState) put(r ownedRecord) {
-	s.records[ownedRecordKey(r.Identity, r.Address)] = r
+	s.records[ownedRecordKey(r.scopeOf(), r.Identity, r.Address)] = r
 }
 
-// get returns the owned record for identity+address, if any.
-func (s *ddnsState) get(identity, address string) (ownedRecord, bool) {
-	r, ok := s.records[ownedRecordKey(identity, address)]
+// get returns the owned record for scope+identity+address, if any.
+func (s *ddnsState) get(scope ScopeKey, identity, address string) (ownedRecord, bool) {
+	r, ok := s.records[ownedRecordKey(scope, identity, address)]
 	return r, ok
 }
 
-// delete removes an ownership entry (after a successful DNS delete).
-func (s *ddnsState) delete(identity, address string) {
-	delete(s.records, ownedRecordKey(identity, address))
+// delete removes an ownership entry (after a successful DNS delete), keyed by
+// its scope + identity + address.
+func (s *ddnsState) delete(scope ScopeKey, identity, address string) {
+	delete(s.records, ownedRecordKey(scope, identity, address))
 }
 
 // all returns a stable-ordered copy of every owned record.
@@ -199,8 +319,8 @@ func (s *ddnsState) all() []ownedRecord {
 		out = append(out, r)
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return ownedRecordKey(out[i].Identity, out[i].Address) <
-			ownedRecordKey(out[j].Identity, out[j].Address)
+		return ownedRecordKey(out[i].scopeOf(), out[i].Identity, out[i].Address) <
+			ownedRecordKey(out[j].scopeOf(), out[j].Identity, out[j].Address)
 	})
 	return out
 }


### PR DESCRIPTION
Phase P1b of #2691 — ScopeKey + per-scope policy + per-RG HA gate + source binding.
Closes #2663
Closes #2664
Closes #2665
Refs #2691

Built on the P1a `pkg/ddns` spine. Preserves the P0/P1a ownership model
(never-delete-non-owned, DHCID-match, write-ahead durability #2662, the
two sentinels, the mass-delete fail-safe) — ScopeKey EXTENDS the record,
the existing semantics are unchanged.

## ScopeKey — the unifying primitive (#2663/#2664, plan §5.4)

```go
type ScopeKey struct {
    Family          Family // inet | inet6   (#2663 independent v4/v6)
    Interface       string // "" = global lease policy (today's Surface B)
    Unit            int
    RoutingInstance string // VRF / routing-instance (#2665)
    RGOwner         int    // redundancy-group that owns this scope (#2664)
    PolicyID        string // provider/profile (P2/P3 catalog; "" today)
}
```

Ownership records are keyed by `{ScopeKey, identity, address}`. The **zero
scope reproduces the pre-P1b `identity|address` key byte-for-byte** — the
`scope` JSON field is a `*ScopeKey`, omitted for the global lease scope, so a
pre-P1b ownership store loads with **no migration** (plan §11 Q7:
fail-open-to-existing). Two scopes for the same name+address (a v4 vs v6
publish, or an RG0-owned vs RG1-owned publish) are **distinct** entries that
never collide.

## #2663 — per-interface + independent IPv4/IPv6 policy

`Reconcile` → `ReconcileScoped` resolves an **independent policy + backend per
family** (`reconcileEnv.pol[2]`/`updater[2]`) from
`DHCPServerConfig.DynamicDNS` (v4) and the new `.DynamicDNSv6` (v6). The
compiler routes the v4 / v6 blocks to their own fields instead of
field-merging them (`mergeDHCPDynamicDNS` retained only as a defensive
same-family no-op). A v4 conflict, a v4 backend error, or a v4 turn-off never
affects v6. **Backward compat:** a single-family block is inherited for the
other family at reconcile time, so committed single-block configs are
byte-for-byte unchanged; the moment both families set their own block they are
fully independent. (Per plan §4.2 this is independent *policy* — the wire path
was already v4/v6-independent; no over-claim of wire-level dual-stack.)

## #2664 — per-RG HA writer gate (HA-critical)

`ReconcileScoped` takes a `ScopeGate` + `ScopeResolver`, wired from the daemon
(`ddnsReconcileOptions`):

- **Resolver:** lease address → pool-subnet **CIDR membership** → group →
  interface → redundancy-group. Stable, render-independent (NOT the
  map-order-unstable Kea subnet_id, plan §6 fork 2).
- **Gate:** a scope is writable IFF this node is MASTER for `scope.RGOwner`.

**Split-brain / partial-demotion reasoning:**

- *Partial demotion* (node loses RG1, keeps RG2): the gate **closes** for RG1's
  scopes. The node **stops publishing** RG1's leases but **does NOT withdraw**
  them — its owned RG1 records are left untouched (the peer that became MASTER
  for RG1 refreshes them; a withdraw race would blackhole, plan §5.6 / risk R3).
  RG2 keeps publishing normally. This is the load-bearing #2664 invariant.
- *Split-brain / uncertain ownership:* an unattributable lease (address in no
  known pool subnet) **fails closed** when RG-owned pools exist — not published,
  never withdrawn. When there are NO RG-owned pools at all (a non-HA DHCP group
  in a cluster) the lease is admitted as RG 0 (no peer to double-write).
- *Single-writer-per-scope preserved:* the lease *input* sets stay disjoint via
  the existing MASTER-filtered Kea memfile; the per-scope gate now makes the
  *publish* decision disjoint too — no double-writer on the same authoritative
  records.

The daemon also **nudges DDNS on a partial demotion** (`clearRethServicesForRG`)
so the gate change takes effect within one pass — closing the documented
"no DDNS nudge on partial demotion" gap.

## #2665 — source / VRF binding

New per-family `source-address` / `destination-interface` / `routing-instance`
leaves (schema + compiler + types). The live rfc2136 backend
(`pkg/ddns/backend_bind.go`) builds a custom `net.Dialer` with a single
`Control` hook: `unix.Bind` for the source IP + `SO_BINDTODEVICE` for the
interface / VRF (binds to the VRF master device, which shares the
routing-instance name). Done in `Control` (not `LocalAddr`) so the SAME dialer
works for the UDP-first and the TCP-retry exchange. `destination-interface`
wins over `routing-instance` for the device pin. Fail-open: an invalid
source-address fails the backend constructor so the family falls back to no-op
(logged + counted) rather than emitting UPDATEs from the wrong source; no
binding leaves the default transport unchanged.

## Tests (fail-on-revert, reconcile-layer for ownership)

- `pkg/ddns/scope_test.go` — ScopeKey distinctness (two scopes, same
  name+address, don't collide); pre-P1b store round-trips to the zero scope;
  independent v4/v6 publish + v4-disable-leaves-v6-untouched; **per-RG gate
  partial-demotion** (publishes owned RG only, does NOT publish or withdraw the
  lost RG — **fail-on-revert**: the pre-#2664 node-level gate would publish the
  lost RG, which `sawRG2Upsert`/`deletes` assertions catch); fail-closed
  unattributable.
- `pkg/ddns/backend_bind_test.go` — dial config (LocalAddr/Control wired iff
  bound; invalid source rejected; dest-iface wins over VRF; rfc2136 installs the
  dialer).
- `pkg/daemon/daemon_ddns_scope_test.go` — per-RG resolver (lease→RG by CIDR) +
  gate (master[RGOwner]); standalone yields nil options.
- `pkg/config/compiler_dhcp_ddns_test.go` — independent v4/v6 policy,
  single-family-applies-to-both, source-binding leaves (flat-set via
  ParseSetCommand+SetPath).

## Gates

- `go build ./...` clean; `go vet` + `gofmt` clean on touched files.
- `go test ./pkg/{ddns,config,dhcpserver,daemon,grpcapi,cli,api}` green;
  `go test -race ./pkg/ddns/` green.
- **`make test-failover` is MANDATORY and was NOT run here (no cluster
  access).** This PR changes the HA writer gate (#2664) + adds the
  partial-demotion nudge, so **the parent MUST run `make test-failover`
  before merge.** The gate change is reasoned above and unit-tested
  (partial-demotion + fail-on-revert + fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
