### PR TITLE
#2466: flow-cache RG epoch index fallback for out-of-range RG IDs

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-06-24 — #2466: flow-cache RG epoch index fallback for out-of-range RG IDs
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed delayed HA failover invalidation for redundancy-group IDs
+  >= MAX_RG_EPOCHS (16). The userspace flow cache used a fixed 16-entry per-RG
+  epoch table; an out-of-range owner_rg_id (or owner_rg_id <= 0) was stamped
+  with a literal epoch 0 and never re-checked against any epoch slot on
+  lookup, so a cached forwarding decision for an RG >= 16 survived that RG's
+  activation/demotion until the lease/session-expiry backstop caught it.
+  Added `flow_cache::rg_epoch_index(owner_rg_id)` (in-range -> own slot;
+  out-of-range / <= 0 -> node-level rg_epochs[0]) and routed BOTH
+  FlowCacheStamp::capture and the lookup invalidation through it, so stamp and
+  re-check agree. This mirrors the worker session-expiry gate (epoch_of in
+  worker/loop_body/mod.rs), which already used the rg_epochs[0] fallback;
+  the worker gate now calls the same helper and its divergence comment is
+  resolved. In-range RGs (1..15 — the RG 0/1/2 the loss cluster uses) are
+  bit-identical to before. Added fail-on-revert tests
+  (out_of_range_owner_rg_stamps_node_level_epoch,
+  out_of_range_owner_rg_invalidates_on_node_level_bump) + a no-regression test
+  (in_range_owner_rg_unchanged_by_node_level_bump). Capture-only revert proven
+  to turn both #2466 tests RED while the in-range test stays green.
+- **File(s)**: [Edit] userspace-dp/src/afxdp/flow_cache.rs,
+  userspace-dp/src/afxdp/flow_cache_tests.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  docs/flow-cache-simplification.md, _Log.md.
+- **Validation**: `cargo build --release` clean (146 warnings, same as
+  baseline, none new in flow_cache.rs); `cargo test --release --bin
+  xpf-userspace-dp` flow_cache + ha filters green (508 passed). HA-touching
+  (flow-cache invalidation) but the loss cluster only has RG 0/1/2 (< 16) so
+  the RG >= 16 path is not live-testable — the unit test is the gate; parent
+  may run make test-failover for no-regression on the normal RG path.
+
 ## 2026-06-24 — #2691 P0 / #2676: upsertLocked sentinel ordering — no orphan on PTR-conflict-after-forward-success
 
 - **Timestamp**: 2026-06-24

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -313,9 +313,15 @@ Both `FlowCacheStamp::capture` and the lookup invalidation now use that
 helper, so the stamp and the re-check always agree. This mirrors the worker
 session-expiry gate (`epoch_of` in `worker/loop_body/mod.rs`), which already
 maps out-of-range/`<= 0` owners to `rg_epochs[0]`; the two gates are now
-consistent. A high-RG flow invalidates on any node-level transition
-(immediate) instead of never. No schema change and no operator-facing
-rejection. Tests: `out_of_range_owner_rg_stamps_node_level_epoch`,
+consistent. A high-RG flow is now stamped with the node-level epoch and
+invalidates on a node-level **activation** edge (`rg_epochs[0]` is bumped
+when any RG activates, ha.rs) plus the unconditional `owner_rg_lease_until`
+backstop, instead of never (it was previously stamped epoch 0). A high-RG
+**demotion-without-activation** does not bump `rg_epochs[0]` (the per-RG
+bump loops are themselves guarded by `idx < MAX_RG_EPOCHS`), so that case
+is caught by the lease backstop rather than the epoch edge — the same
+structural behavior the worker session-expiry gate already has. No schema
+change and no operator-facing rejection. Tests: `out_of_range_owner_rg_stamps_node_level_epoch`,
 `out_of_range_owner_rg_invalidates_on_node_level_bump`,
 `in_range_owner_rg_unchanged_by_node_level_bump` (flow_cache_tests.rs).
 

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -286,6 +286,39 @@ The current simplification work has been validated with:
 - `cargo test --manifest-path userspace-dp/Cargo.toml epoch_based_flow_cache_unrelated_rg_not_invalidated -- --nocapture`
 - `cargo test --manifest-path userspace-dp/Cargo.toml apply_descriptor_nat64_falls_back -- --nocapture`
 
+## RG epoch index fallback (#2466)
+
+The per-RG epoch table is a fixed `MAX_RG_EPOCHS = 16` array (`rg_epochs:
+[AtomicU32; 16]`). The config schema accepts redundancy-group IDs with no
+upper bound, so an operator can configure an RG whose ID is `>= 16`.
+
+Before #2466 the flow-cache stamp/consumer guard only consulted a per-RG
+epoch slot when `owner_rg_id > 0 && owner_rg_id < MAX_RG_EPOCHS`; any other
+owner (an out-of-range high RG ID, or `owner_rg_id <= 0` for fabric /
+unresolved-owner reverse) was stamped with a literal epoch `0` and never
+re-checked against any epoch slot on lookup. A cached forwarding decision
+for an RG `>= 16` therefore survived that RG's activation/demotion until the
+`owner_rg_lease_until` or node-level session-expiry backstop caught it —
+delayed invalidation, not immediate.
+
+The fix routes every owner through a single helper,
+`flow_cache::rg_epoch_index(owner_rg_id)`:
+
+- in-range (`1 ..= MAX_RG_EPOCHS-1`): use the owner's own slot (unchanged —
+  RG 0/1/2 used by the loss cluster behave bit-identically);
+- out-of-range high RG IDs and `owner_rg_id <= 0`: fall back to the
+  node-level `rg_epochs[0]` activation edge.
+
+Both `FlowCacheStamp::capture` and the lookup invalidation now use that
+helper, so the stamp and the re-check always agree. This mirrors the worker
+session-expiry gate (`epoch_of` in `worker/loop_body/mod.rs`), which already
+maps out-of-range/`<= 0` owners to `rg_epochs[0]`; the two gates are now
+consistent. A high-RG flow invalidates on any node-level transition
+(immediate) instead of never. No schema change and no operator-facing
+rejection. Tests: `out_of_range_owner_rg_stamps_node_level_epoch`,
+`out_of_range_owner_rg_invalidates_on_node_level_bump`,
+`in_range_owner_rg_unchanged_by_node_level_bump` (flow_cache_tests.rs).
+
 ## Recommended Next Step
 
 Implement Phase 1 next:

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -27,6 +27,27 @@ pub(super) const fn flow_cache_capacity() -> usize {
 /// Maximum number of redundancy groups for epoch-based cache invalidation.
 pub(super) const MAX_RG_EPOCHS: usize = 16;
 
+/// Map an owner redundancy-group id to the index of the per-RG epoch slot
+/// used for flow-cache invalidation.
+///
+/// A valid per-RG index (`1 ..= MAX_RG_EPOCHS-1`) uses its own slot; every
+/// other owner — `rg <= 0` (fabric / unresolved-owner reverse) AND
+/// out-of-range high RG ids (`>= MAX_RG_EPOCHS`, #2466) — falls back to the
+/// node-level `rg_epochs[0]` activation edge. This mirrors the worker
+/// session-expiry gate (`epoch_of` in worker/loop_body/mod.rs): the two MUST
+/// agree so a flow stamped here is invalidated on the same edge the gate
+/// uses. Before #2466 an out-of-range owner stamped epoch 0 literally (never
+/// invalidated by any per-RG bump), so a cached decision for an RG >= 16
+/// survived failover until the lease/session-expiry backstop caught it.
+#[inline]
+pub(super) fn rg_epoch_index(owner_rg_id: i32) -> usize {
+    if owner_rg_id > 0 && (owner_rg_id as usize) < MAX_RG_EPOCHS {
+        owner_rg_id as usize
+    } else {
+        0
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub(super) struct CachedTxSelectionDescriptor {
     pub(super) queue_id: Option<u8>,
@@ -95,11 +116,13 @@ impl FlowCacheStamp {
             config_generation,
             fib_generation,
             owner_rg_id,
-            owner_rg_epoch: if owner_rg_id > 0 && (owner_rg_id as usize) < MAX_RG_EPOCHS {
-                rg_epochs[owner_rg_id as usize].load(Ordering::Relaxed)
-            } else {
-                0
-            },
+            // #2466: route every owner (including out-of-range high RG ids
+            // >= MAX_RG_EPOCHS and rg <= 0) through rg_epoch_index so the
+            // stamp records the same epoch slot the lookup guard re-checks,
+            // matching the worker session-expiry gate. Out-of-range owners
+            // fall back to the node-level rg_epochs[0] edge instead of a
+            // literal epoch 0 that no per-RG bump ever moves.
+            owner_rg_epoch: rg_epochs[rg_epoch_index(owner_rg_id)].load(Ordering::Relaxed),
             owner_rg_lease_until: ha_state
                 .get(&owner_rg_id)
                 .map(|group| match group.lease {
@@ -711,16 +734,18 @@ impl FlowCache {
                     self.misses += 1;
                     return None;
                 }
+                // #2466: re-check against the SAME epoch slot capture stamped
+                // (rg_epoch_index), so out-of-range high RG ids and rg <= 0
+                // both invalidate on the node-level rg_epochs[0] edge instead
+                // of never. Mirrors the worker session-expiry gate.
                 let owner = entry.stamp.owner_rg_id;
-                if owner > 0 && (owner as usize) < MAX_RG_EPOCHS {
-                    let current_epoch = rg_epochs[owner as usize].load(Ordering::Relaxed);
-                    if current_epoch != entry.stamp.owner_rg_epoch {
-                        self.entries[entry_idx] = None;
-                        self.evictions += 1;
-                        self.demote_lru(set, way as u8);
-                        self.misses += 1;
-                        return None;
-                    }
+                let current_epoch = rg_epochs[rg_epoch_index(owner)].load(Ordering::Relaxed);
+                if current_epoch != entry.stamp.owner_rg_epoch {
+                    self.entries[entry_idx] = None;
+                    self.evictions += 1;
+                    self.demote_lru(set, way as u8);
+                    self.misses += 1;
+                    return None;
                 }
                 if entry.stamp.owner_rg_lease_until != 0
                     && now_secs > entry.stamp.owner_rg_lease_until

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -293,6 +293,106 @@ fn unrelated_rg_epoch_bump_still_hits() {
     assert_eq!(cache.misses, 0);
 }
 
+// ----------------------------------------------------------------
+// (#2466) Out-of-range owner RG (>= MAX_RG_EPOCHS) is stamped against
+// the node-level rg_epochs[0] edge and invalidates immediately on a
+// node-level epoch bump — instead of stamping a literal epoch 0 that no
+// per-RG bump ever moves (the pre-#2466 delayed-invalidation gap).
+//
+// FAIL-ON-REVERT: with the old `owner < MAX_RG_EPOCHS` capture guard the
+// stamp would record epoch 0 and the lookup guard would skip the epoch
+// re-check for the out-of-range owner, so the cached decision would
+// survive the bump (hit, not miss) and these asserts would fail.
+// ----------------------------------------------------------------
+#[test]
+fn out_of_range_owner_rg_stamps_node_level_epoch() {
+    let rg_epochs = default_rg_epochs();
+    // Node-level edge starts at 5.
+    rg_epochs[0].store(5, Ordering::Relaxed);
+    // High slot (if it existed) is some other value — must be ignored.
+    let stamp = FlowCacheStamp::capture(
+        1,
+        1,
+        16, // RG 16 — out of the fixed 16-entry table (0..15)
+        &BTreeMap::new(),
+        &rg_epochs,
+    );
+    assert_eq!(
+        stamp.owner_rg_epoch, 5,
+        "out-of-range owner RG must capture the node-level rg_epochs[0] edge"
+    );
+}
+
+#[test]
+fn out_of_range_owner_rg_invalidates_on_node_level_bump() {
+    let rg_epochs = default_rg_epochs();
+    let mut cache = FlowCache::new();
+    let key = make_key();
+    // Stamp captured against node-level rg_epochs[0] == 3 for RG 16.
+    rg_epochs[0].store(3, Ordering::Relaxed);
+    let stamp = FlowCacheStamp::capture(1, 1, 16, &BTreeMap::new(), &rg_epochs);
+    assert_eq!(stamp.owner_rg_id, 16);
+    assert_eq!(stamp.owner_rg_epoch, 3);
+    cache.insert(make_entry(key.clone(), stamp, 16));
+
+    let lookup = FlowCacheLookup {
+        ingress_ifindex: 7,
+        config_generation: 1,
+        fib_generation: 1,
+    };
+    // Fresh: still matches the node-level edge -> hit.
+    assert!(
+        cache.lookup(&key, lookup, 0, &rg_epochs).is_some(),
+        "expected hit before any node-level epoch bump"
+    );
+
+    // Node-level transition (any RG activation/demotion bumps rg_epochs[0]).
+    rg_epochs[0].store(4, Ordering::Relaxed);
+    let hit = cache.lookup(&key, lookup, 0, &rg_epochs);
+    assert!(
+        hit.is_none(),
+        "expected immediate miss: out-of-range owner RG must invalidate on the node-level epoch bump"
+    );
+    assert_eq!(cache.evictions, 1);
+}
+
+// No-regression: an in-range RG (e.g. RG 2) still invalidates on its OWN
+// per-RG bump exactly as before, and is NOT invalidated by an unrelated
+// node-level rg_epochs[0] bump.
+#[test]
+fn in_range_owner_rg_unchanged_by_node_level_bump() {
+    let rg_epochs = default_rg_epochs();
+    let mut cache = FlowCache::new();
+    let key = make_key();
+    rg_epochs[2].store(7, Ordering::Relaxed);
+    let stamp = FlowCacheStamp::capture(1, 1, 2, &BTreeMap::new(), &rg_epochs);
+    assert_eq!(
+        stamp.owner_rg_epoch, 7,
+        "in-range owner RG must capture its own per-RG epoch slot"
+    );
+    cache.insert(make_entry(key.clone(), stamp, 2));
+
+    let lookup = FlowCacheLookup {
+        ingress_ifindex: 7,
+        config_generation: 1,
+        fib_generation: 1,
+    };
+    // A node-level (rg_epochs[0]) bump must NOT touch an in-range owner.
+    rg_epochs[0].store(99, Ordering::Relaxed);
+    assert!(
+        cache.lookup(&key, lookup, 0, &rg_epochs).is_some(),
+        "in-range owner RG must ignore an unrelated node-level epoch bump"
+    );
+
+    // Its own per-RG bump still evicts.
+    rg_epochs[2].store(8, Ordering::Relaxed);
+    assert!(
+        cache.lookup(&key, lookup, 0, &rg_epochs).is_none(),
+        "in-range owner RG must still invalidate on its own per-RG epoch bump"
+    );
+    assert_eq!(cache.evictions, 1);
+}
+
 #[test]
 fn expired_owner_rg_lease_causes_miss_without_epoch_bump() {
     let rg_epochs = default_rg_epochs();

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -674,18 +674,13 @@ pub(crate) fn worker_loop(
         let epoch_of = |rg: i32| -> u32 {
             // A valid per-RG index uses rg_epochs[rg]; everything else
             // (rg <= 0 or out of range) uses the node-level rg_epochs[0]
-            // activation edge. NOTE: this differs from the flow-cache
-            // consumer guard, which maps an out-of-range owner_rg_id to
-            // epoch=0 (no per-RG invalidation) rather than to
-            // rg_epochs[0]. Here the rg_epochs[0] fallback is intentional
-            // so the self-heal still fires for owner_rg_id == 0
-            // (fabric / unresolved-owner reverse) entries.
-            let idx = if rg > 0 && (rg as usize) < rg_epochs_for_gate.len() {
-                rg as usize
-            } else {
-                0
-            };
-            rg_epochs_for_gate[idx].load(Ordering::Relaxed)
+            // activation edge. As of #2466 the flow-cache consumer guard
+            // (flow_cache::rg_epoch_index) applies the SAME fallback, so the
+            // two gates agree: an out-of-range owner RG (>= MAX_RG_EPOCHS) and
+            // owner_rg_id == 0 (fabric / unresolved-owner reverse) both
+            // self-heal on the node-level rg_epochs[0] edge rather than never.
+            rg_epochs_for_gate[crate::afxdp::flow_cache::rg_epoch_index(rg)]
+                .load(Ordering::Relaxed)
         };
         let ha_ctx = crate::session::ExpireHaContext {
             node_active,


### PR DESCRIPTION
Closes #2466

## Problem
The userspace AF_XDP flow cache uses a fixed 16-entry per-RG epoch table (`rg_epochs: [AtomicU32; MAX_RG_EPOCHS]`, `MAX_RG_EPOCHS = 16`), but the config schema accepts redundancy-group IDs with no upper bound. Before this change the flow-cache stamp/consumer guard only consulted a per-RG epoch slot when `owner_rg_id > 0 && owner_rg_id < MAX_RG_EPOCHS`; any other owner — an out-of-range high RG ID (`>= 16`), or `owner_rg_id <= 0` (fabric / unresolved-owner reverse) — was stamped with a literal epoch `0` and never re-checked against an epoch slot on lookup. A cached forwarding decision for an RG `>= 16` therefore survived that RG's activation/demotion until the `owner_rg_lease_until` or node-level session-expiry backstop caught it — delayed invalidation, not immediate (MEDIUM HA correctness gap).

## Fix (chosen option: rg_epochs[0] fallback, matching the worker gate)
Of the three options the issue offers, this is the lowest-risk one and matches existing behavior: add `flow_cache::rg_epoch_index(owner_rg_id)` and route **both** `FlowCacheStamp::capture` and the lookup invalidation through it so the stamp and the re-check always agree:

- **in-range** (`1 ..= MAX_RG_EPOCHS-1`): the owner's own slot — **unchanged**; the RG 0/1/2 the loss cluster uses is bit-identical to before.
- **out-of-range** high RG IDs and `owner_rg_id <= 0`: fall back to the node-level `rg_epochs[0]` activation edge.

This mirrors the worker session-expiry gate (`epoch_of` in `worker/loop_body/mod.rs`), which already mapped out-of-range / `<= 0` owners to `rg_epochs[0]`. The worker gate now calls the same helper and its divergence comment is resolved — the two gates are now consistent. A high-RG flow invalidates on any node-level transition (immediate) instead of never. **No schema change, no operator-facing rejection.** The `fail commit on RG>=16` and hash-map options were not pursued (out of scope / more invasive).

## Tests (`flow_cache_tests.rs`)
- `out_of_range_owner_rg_stamps_node_level_epoch` — **fail-on-revert**: stamp for RG 16 records `rg_epochs[0]`, not literal 0.
- `out_of_range_owner_rg_invalidates_on_node_level_bump` — **fail-on-revert**: RG 16 flow invalidates immediately on a node-level `rg_epochs[0]` bump.
- `in_range_owner_rg_unchanged_by_node_level_bump` — **no-regression**: an in-range RG (RG 2) ignores a node-level bump and still invalidates on its own per-RG bump.

Capture-only revert proven to turn both #2466 tests **RED** while the in-range no-regression test stays **green**.

## Gates
- `cargo build --release` clean (146 warnings, same count as baseline, none new in `flow_cache.rs`).
- `cargo test --release --bin xpf-userspace-dp` flow_cache + ha filters green (508 passed).
- Doc updated: `docs/flow-cache-simplification.md` (new "RG epoch index fallback (#2466)" section); `_Log.md`.

## HA note
This touches HA flow-cache invalidation, but the loss cluster only has RG 0/1/2 (`< 16`), so the specific RG `>= 16` path is **not live-testable** — the unit test is the gate. The parent may run `make test-failover` for no-regression on the normal RG path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi