### PR TITLE
Fix #2517: GRE MSS clamp survives a transient egress-map miss (share #2300 SSOT)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-06-24 — #2517: GRE MSS clamp survives a transient egress-map miss
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed a transient silent loss of a configured GRE outbound TCP
+  MSS clamp and unified it with the WireGuard path. `native_gre_inner_mtu`
+  resolved the outer/transport MTU with its own egress-lookup chain ending in
+  `unwrap_or_default()` → 0 on an egress-map miss, which made
+  `native_gre_tcp_mss` return 0 and silently DISABLE the clamp during
+  re-reconciliation / interface bringup (until the next reconcile re-populated
+  the egress map). The sibling WG MSS clamp resolves the SAME chain via
+  `tunnel_outer_mtu` (the #2300 SSOT) with `.filter(|m| *m > 0)
+  .unwrap_or(1500)`. Routed `native_gre_inner_mtu`'s outer-MTU resolution
+  through `tunnel_outer_mtu` so both tunnel MSS paths read ONE resolver and
+  cannot drift: a GRE egress miss now falls back to the 1500 underlay MTU and
+  the GRE overhead is still subtracted after, so the clamp stays live. Dropped
+  the now-redundant `.cloned()` and the dead `if transport_mtu == 0` guard
+  (`tunnel_outer_mtu` never returns 0). Added a fail-on-revert test
+  (native_gre_inner_mtu_falls_back_to_1500_on_egress_miss — clears egress,
+  asserts inner MTU 1456 + MSS 1416, not 0) proven to turn RED under the old
+  `unwrap_or_default()`, plus a no-regression test
+  (native_gre_inner_mtu_uses_real_egress_mtu_when_present). Gates: cargo build
+  --release clean (no new forwarding/mod.rs warnings); filtered tests (gre /
+  mss / tunnel / forwarding) green.
+- **File(s)**: [Edit] userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/tunnel_tests.rs, docs/wireguard-interop.md, _Log.md.
+
 ## 2026-06-24 — #2466: flow-cache RG epoch index fallback for out-of-range RG IDs
 
 - **Timestamp**: 2026-06-24

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -83,7 +83,7 @@ SYN MSS clamp (#2299, `tunnel_tcp_mss`), the encap MTU guards
 and share `native_gre_inner_mtu` / `wg::mss::wg_inner_mtu` /
 `TunnelKind`.
 
-### Outer MTU SSOT (#2300 / #2680)
+### Outer MTU SSOT (#2300 / #2680 / #2517)
 There is now ONE outer-MTU model. The transit-egress encap
 (`frame/wg.rs`) and the control-thread egress (`coordinator/wg_control.rs`)
 both gate the OUTER encapped datagram against the REAL underlay-egress
@@ -92,6 +92,20 @@ resolved underlay MTU at spawn (`Coordinator::resolve_wg_outer_mtu`
 route-looks-up the peer endpoint in the endpoint's transport table).
 `WG_DEFAULT_OUTER_MTU` (1500) is now ONLY the last-resort fallback for an
 unconfigured/unroutable endpoint.
+
+**#2517 (GRE inner-MTU shares the same fallback).** The native-GRE
+inner-MTU resolver `native_gre_inner_mtu` now resolves its outer/transport
+MTU through the SAME `tunnel_outer_mtu` SSOT helper the WG MSS clamp uses,
+instead of an independent egress-lookup chain. The two paths had drifted on
+the miss case: `tunnel_outer_mtu` falls back to 1500 (`.filter(|m| *m > 0)
+.unwrap_or(1500)`), but `native_gre_inner_mtu` used `unwrap_or_default()` →
+0, which made `native_gre_tcp_mss` return 0 and silently DISABLE a
+configured GRE outbound TCP MSS clamp during a transient egress-map miss
+(re-reconciliation / interface bringup) — the clamp came back only on the
+next reconcile. After #2517 a GRE egress-map miss falls back to the 1500
+underlay MTU and `native_gre_tcp_mss` keeps computing a real clamp, exactly
+like the WG path. Both tunnel MSS-clamp paths now read one resolver and
+cannot drift again.
 
 **#2680 (transit-egress site).** The `frame/wg.rs` guard previously read
 the MTU of `decision.resolution.egress_ifindex`, which for a tunnel-resolved

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -751,26 +751,20 @@ pub(super) fn native_gre_inner_mtu(
     let Some(endpoint) = forwarding
         .tunnel_endpoints
         .get(&decision.resolution.tunnel_endpoint_id)
-        .cloned()
     else {
         return 0;
     };
-    let transport_ifindex = resolve_ingress_logical_ifindex(
-        forwarding,
-        decision.resolution.tx_ifindex,
-        decision.resolution.tx_vlan_id,
-    )
-    .unwrap_or(decision.resolution.tx_ifindex);
-    let transport_mtu = forwarding
-        .egress
-        .get(&transport_ifindex)
-        .or_else(|| forwarding.egress.get(&decision.resolution.egress_ifindex))
-        .or_else(|| forwarding.egress.get(&endpoint.logical_ifindex))
-        .map(|egress| egress.mtu)
-        .unwrap_or_default();
-    if transport_mtu == 0 {
-        return 0;
-    }
+    // #2517: resolve the outer/transport MTU through the SAME #2300 SSOT
+    // helper the WireGuard MSS clamp uses (`tunnel_outer_mtu`) so the two
+    // tunnel MSS paths cannot drift. That helper falls back to the
+    // standard 1500 underlay MTU when EVERY egress lookup misses (a
+    // transient egress-map miss during re-reconciliation / interface
+    // bringup) instead of the old `unwrap_or_default()` → 0, which made
+    // `native_gre_tcp_mss` return 0 and silently DISABLE a configured GRE
+    // outbound TCP MSS clamp until the next reconcile. `tunnel_outer_mtu`
+    // also filters out an explicitly-zero stored egress MTU, so it never
+    // returns 0; `transport_mtu` here is therefore always >= 1500.
+    let transport_mtu = tunnel_outer_mtu(forwarding, decision, endpoint);
     let outer_ip_header_len = match endpoint.outer_family {
         libc::AF_INET => 20usize,
         libc::AF_INET6 => 40usize,
@@ -810,11 +804,14 @@ pub(super) fn native_gre_tcp_mss(
 
 /// Resolve the real outer-link (transport) MTU for a tunnel endpoint —
 /// the egress interface the OUTER encapped datagram leaves on, NOT the
-/// tunnel device. Same resolution chain as `native_gre_inner_mtu`
-/// (#2300 SSOT): transport ifindex → stored resolution egress →
-/// endpoint logical ifindex; `unwrap_or(1500)` only when every lookup
-/// misses. Used by the WireGuard MSS clamp (#2299) so the advertised
-/// inner MSS matches the encap MTU guard.
+/// tunnel device. This is the #2300 SSOT resolver shared by BOTH tunnel
+/// MSS-clamp paths: the WireGuard clamp (#2299) and the native-GRE
+/// clamp (`native_gre_inner_mtu`, #2517). Resolution chain: transport
+/// ifindex → stored resolution egress → endpoint logical ifindex;
+/// `unwrap_or(1500)` only when every lookup misses (a transient
+/// egress-map miss must NOT zero the clamp). The `.filter(|m| *m > 0)`
+/// also coerces an explicitly-zero stored egress MTU to the 1500
+/// fallback, so this helper never returns 0.
 pub(super) fn tunnel_outer_mtu(
     forwarding: &ForwardingState,
     decision: &SessionDecision,

--- a/userspace-dp/src/afxdp/tunnel_tests.rs
+++ b/userspace-dp/src/afxdp/tunnel_tests.rs
@@ -828,6 +828,90 @@ fn tunnel_tcp_mss_wireguard_uses_wg_overhead_not_gre() {
     );
 }
 
+// --- #2517 GRE MSS clamp survives a transient egress-map miss ---------
+
+#[test]
+fn native_gre_inner_mtu_falls_back_to_1500_on_egress_miss() {
+    // Reproduce the transient egress-map miss (re-reconciliation /
+    // interface bringup): a valid GRE endpoint but NO egress entry for
+    // the transport / resolution-egress / endpoint-logical ifindex.
+    // Pre-#2517 `native_gre_inner_mtu` did `unwrap_or_default()` → 0, so
+    // `native_gre_tcp_mss` returned 0 and silently DISABLED a configured
+    // GRE outbound TCP MSS clamp. After #2517 it shares the
+    // `tunnel_outer_mtu` SSOT (1500 fallback) → a REAL clamp.
+    let mut state = gre1881_state();
+    state.egress.clear(); // every egress lookup now misses
+    let decision = SessionDecision {
+        resolution: gre_encap_resolution(),
+        nat: NatDecision::default(),
+    };
+
+    // Endpoint is IPv6-outer (40), no key (gre 4): inner MTU =
+    // 1500 - 40 - 4 = 1456. Fail-on-revert: with unwrap_or_default()
+    // this was 0.
+    let inner_mtu = native_gre_inner_mtu(&state, &decision);
+    assert_eq!(
+        inner_mtu, 1456,
+        "GRE inner MTU on an egress miss must fall back to the 1500 \
+         underlay (1500 - 40 outer IPv6 - 4 GRE), NOT 0 (pre-#2517 \
+         unwrap_or_default disabled the clamp)"
+    );
+
+    // The configured MSS clamp must therefore be non-zero. Inner IPv4
+    // (20) + TCP (20): MSS = 1456 - 40 = 1416.
+    let mss = native_gre_tcp_mss(&state, &decision, libc::AF_INET as u8);
+    assert_eq!(
+        mss, 1416,
+        "native_gre_tcp_mss on an egress miss must compute a real clamp \
+         from the 1500 fallback (1456 - 20 IP - 20 TCP); pre-#2517 it \
+         returned 0 and the clamp was silently disabled"
+    );
+    assert_ne!(mss, 0, "the GRE clamp must NOT be disabled on a map miss");
+
+    // It must match what the WG-sibling SSOT resolver yields for the same
+    // miss — proving the two tunnel paths can no longer drift.
+    let endpoint = state.tunnel_endpoints.get(&1).expect("fixture endpoint");
+    assert_eq!(
+        tunnel_outer_mtu(&state, &decision, endpoint),
+        1500,
+        "tunnel_outer_mtu (the shared #2300 SSOT) falls back to 1500 on \
+         the same miss — native_gre_inner_mtu now reads this exact value"
+    );
+}
+
+#[test]
+fn native_gre_inner_mtu_uses_real_egress_mtu_when_present() {
+    // No-regression: when the egress entry IS present the clamp must use
+    // the real resolved MTU exactly as before the #2517 fallback change.
+    // The gre1881 fixture egress for reth0.80 is 1500.
+    let state = gre1881_state();
+    let decision = SessionDecision {
+        resolution: gre_encap_resolution(),
+        nat: NatDecision::default(),
+    };
+
+    let inner_mtu = native_gre_inner_mtu(&state, &decision);
+    assert_eq!(
+        inner_mtu, 1456,
+        "with the egress present the GRE inner MTU is the real underlay \
+         1500 - 40 - 4 = 1456 (unchanged by #2517)"
+    );
+
+    // And the present-egress path equals the SSOT-resolved outer MTU minus
+    // the GRE overhead — i.e. #2517 did not alter the hit path.
+    let endpoint = state.tunnel_endpoints.get(&1).expect("fixture endpoint");
+    let outer = tunnel_outer_mtu(&state, &decision, endpoint);
+    assert_eq!(outer, 1500, "fixture present-egress outer MTU is 1500");
+    assert_eq!(
+        inner_mtu,
+        outer - 40 - 4,
+        "present-egress GRE inner MTU == outer MTU - outer IPv6 - GRE"
+    );
+
+    let mss = native_gre_tcp_mss(&state, &decision, libc::AF_INET as u8);
+    assert_eq!(mss, 1416, "present-egress GRE clamp unchanged");
+}
+
 #[test]
 fn tunnel_tcp_mss_gre_unchanged_for_gre_endpoint() {
     // Fail-on-revert guard: a GRE endpoint must keep the exact GRE


### PR DESCRIPTION
Closes #2517

## Problem
`native_gre_inner_mtu` resolved the outer/transport MTU with its own egress-lookup chain ending in `unwrap_or_default()` → **0** on an egress-map miss. That made `native_gre_tcp_mss` return 0 and **silently disable** a configured GRE outbound TCP MSS clamp during a transient egress-map miss (re-reconciliation / interface bringup) — the clamp only came back on the next reconcile.

The sibling WireGuard MSS clamp (`tunnel_outer_mtu`, the #2300 SSOT, #2299/#2300) resolves the **identical** chain but with `.filter(|m| *m > 0).unwrap_or(1500)`. The two tunnel MSS paths had drifted on the miss case.

## Fix (SSOT-unify, not minimal patch)
Routed `native_gre_inner_mtu`'s outer-MTU resolution through `tunnel_outer_mtu` so **both** tunnel MSS paths read ONE resolver and cannot drift again. A GRE egress miss now falls back to the standard **1500** underlay MTU; the GRE overhead (outer IP + 4/8 GRE) is still subtracted after the fallback, so the clamp stays live.

`tunnel_outer_mtu` also coerces an explicitly-zero stored egress MTU to 1500, so it never returns 0 — the now-dead `if transport_mtu == 0 { return 0 }` guard and the redundant `.cloned()` on the endpoint lookup were removed.

**Why SSOT-unify over the minimal `unwrap_or(1500)` patch:** the two functions already had a bit-identical resolution chain; calling the existing helper is a small refactor (`native_gre_inner_mtu` already fetched the endpoint, which is the only extra arg `tunnel_outer_mtu` needs) and structurally prevents the drift that caused this bug.

## Tests (`tunnel_tests.rs`)
- **Fail-on-revert** — `native_gre_inner_mtu_falls_back_to_1500_on_egress_miss`: clears the egress map, asserts inner MTU **1456** (1500 − 40 IPv6 − 4 GRE) and MSS **1416** (1456 − 20 IP − 20 TCP), and cross-checks `tunnel_outer_mtu` returns the same 1500. **Proven RED** under the old `unwrap_or_default()` (inner MTU 0, clamp disabled).
- **No-regression** — `native_gre_inner_mtu_uses_real_egress_mtu_when_present`: the present-egress hit path is unchanged (1456 / 1416).

## Docs
`docs/wireguard-interop.md` "Outer MTU SSOT" section records the #2517 unification (GRE inner-MTU now shares the WG 1500 fallback).

## Gates
- `cargo build --release` clean — no new `forwarding/mod.rs` warnings.
- `cargo test --release --bin xpf-userspace-dp` filtered on gre / mss / tunnel / forwarding — all green (224 + 173 passing in the relevant filters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi