### PR TITLE
vrrp: re-match addr events by name when a sub-interface ifindex changes (#2707)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14134,3 +14134,32 @@ top.
   `go test ./pkg/{ddns,config,dhcpserver,daemon}` green; `-race ./pkg/ddns`
   green. `make test-failover` still MANDATORY — the parent re-runs it on the
   folded head.
+
+## 2026-06-24 — #2707 VRRP addr-watch ifindex robustness (fix/2707-vrrp-addrwatch-ifindex)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Make the VRRP source-address watcher robust to a sub-interface
+  (VLAN/GRE/WireGuard) being deleted and recreated with a NEW ifindex. The
+  watcher matched address events only by the cached `vi.iface.Index`, so after
+  a recreate (config change, driver restart, link-cycle recovery) every address
+  event on the new ifindex was silently dropped until the ~2s reconcile noticed
+  the drift — leaving the instance on a stale source/socket for that window.
+- **Fix**: `reresolveAddrFor` keeps the syscall-free fast path (match by cached
+  ifindex -> `reresolveLocalAddrs`). On a cached-ifindex MISS it resolves the
+  event ifindex -> current link NAME (one syscall, only on a miss) via a new
+  `resolveLinkName` seam (`netlinkLinkName` = `netlink.LinkByIndex`), re-matches
+  instances by their STABLE configured name, and on an ifindex drift triggers
+  the immediate-reconcile lever (`onEventDrop`, wired to `triggerReconcile` in
+  the daemon). UpdateInstances then rebinds the drifted instance to the new
+  ifindex and re-resolves the source — event-driven, not ~2s-deferred. We do
+  NOT mutate `vi.iface` here (it would race the run-loop reads in
+  sendPacket/sendPacketIPv6); the reconcile owns the rebind.
+- **File(s)**: pkg/vrrp/addrwatch.go (reresolveAddrFor + netlinkLinkName),
+  pkg/vrrp/manager.go (resolveLinkName seam + NewManager default),
+  pkg/vrrp/addrwatch_test.go (RecreatedLinkNewIfindexSchedulesReconcile
+  fail-on-revert + UnchangedIfindexUsesFastPath guard), _Log.md.
+- **Validation**: `go build ./...` clean; gofmt/vet clean on touched files;
+  `go test -race ./pkg/vrrp/...` green; fail-on-revert proven (reverting to the
+  cached-only match makes the recreated-link test time out RED). HA-touching ->
+  `make test-failover` MANDATORY before merge (parent runs it; not attempted
+  here).

--- a/docs/vrrp-failover-next-feature.md
+++ b/docs/vrrp-failover-next-feature.md
@@ -18,6 +18,14 @@ cause transient packet loss or sticky incorrect state during repeated failover:
   changes.
 - IPv6 VRRP source address selection is not fully deterministic in all
   multi-address edge cases.
+- The source-address watcher (#2528) matched netlink address events by the
+  instance's cached `vi.iface.Index`. RESOLVED (#2707): when a VLAN/GRE/
+  WireGuard sub-interface is deleted and recreated with a NEW ifindex (config
+  change, driver restart, link-cycle recovery), the watcher now resolves the
+  event ifindex back to its stable link name on a cached-ifindex miss,
+  re-matches the instance by name, and triggers an immediate reconcile so the
+  instance rebinds to the new ifindex without waiting for the ~2s periodic
+  reconcile. The common unchanged-ifindex path stays syscall-free.
 
 ## Goals
 

--- a/pkg/vrrp/addrwatch.go
+++ b/pkg/vrrp/addrwatch.go
@@ -92,12 +92,82 @@ func (m *Manager) clearAddrWatcherLatch() {
 // per-instance lock is needed and no lock-order inversion with m.mu exists
 // (instances never take m.mu). Filtering by ifindex ensures churn on an
 // interface no VRRP instance uses is ignored.
+//
+// Recreated-link robustness (#2707): the fast path matches on the cached
+// vi.iface.Index. When a VLAN/GRE/WireGuard sub-interface is deleted and
+// recreated (config change, driver restart, link-cycle recovery) the kernel
+// assigns a NEW ifindex, so an address event on the recreated link no longer
+// matches any cached ifindex and would be silently dropped until the ~2s
+// UpdateInstances reconcile noticed the drift — leaving the instance
+// advertising from a stale source (or off a stale socket) for that whole
+// window. On a cached-ifindex MISS we therefore resolve the event ifindex back
+// to its current link NAME (a single syscall, ONLY on a miss — the common
+// unchanged-ifindex path stays syscall-free) and re-match instances by their
+// STABLE configured interface name. A match whose cached ifindex differs is a
+// recreated link: re-resolving its source against the stale vi.iface would
+// query the wrong/absent ifindex (net.Interface.Addrs filters by Index), so
+// instead we trigger an immediate reconcile (onEventDrop) which rebuilds the
+// instance with a fresh socket bound to the new ifindex AND a fresh source —
+// the same restart UpdateInstances would do, but event-driven rather than
+// ~2s-deferred. Mutating vi.iface here would race the run-loop reads in
+// sendPacket/sendPacketIPv6, so we deliberately do not; the reconcile owns the
+// rebind.
 func (m *Manager) reresolveAddrFor(ifindex int) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
+	matched := false
 	for _, vi := range m.instances {
 		if vi.iface != nil && vi.iface.Index == ifindex {
 			vi.reresolveLocalAddrs()
+			matched = true
 		}
 	}
+	if matched {
+		m.mu.RUnlock()
+		return
+	}
+
+	// Cached-ifindex miss: the event may be for a recreated link whose name
+	// still matches a configured instance but whose ifindex drifted. Resolve
+	// the event ifindex -> current name and re-match by the stable name.
+	resolve := m.resolveLinkName
+	onDrop := m.onEventDrop
+	m.mu.RUnlock()
+	if resolve == nil {
+		return
+	}
+	name, err := resolve(ifindex)
+	if err != nil || name == "" {
+		return // ifindex gone (pure delete) or unresolvable — nothing to rebind
+	}
+
+	m.mu.RLock()
+	driftDetected := false
+	for _, vi := range m.instances {
+		if vi.iface != nil && vi.cfg.Interface == name && vi.iface.Index != ifindex {
+			driftDetected = true
+			slog.Info("vrrp: address event on recreated link, scheduling reconcile",
+				"key", vi.key(), "interface", name,
+				"old_ifindex", vi.iface.Index, "new_ifindex", ifindex)
+		}
+	}
+	m.mu.RUnlock()
+
+	if driftDetected && onDrop != nil {
+		// Reuse the immediate-reconcile lever (the daemon wires onEventDrop to
+		// schedule a reconcile pass). UpdateInstances then rebinds the drifted
+		// instance to the new ifindex and re-resolves the source.
+		onDrop()
+	}
+}
+
+// netlinkLinkName is the production resolveLinkName seam (#2707): map a kernel
+// ifindex to its current link name. Returns an error if the ifindex no longer
+// exists (a pure delete with no recreate) — the caller treats that as "nothing
+// to rebind".
+func netlinkLinkName(ifindex int) (string, error) {
+	link, err := netlink.LinkByIndex(ifindex)
+	if err != nil {
+		return "", err
+	}
+	return link.Attrs().Name, nil
 }

--- a/pkg/vrrp/addrwatch_test.go
+++ b/pkg/vrrp/addrwatch_test.go
@@ -3,6 +3,7 @@ package vrrp
 import (
 	"errors"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -224,6 +225,145 @@ func TestAddrWatcher_IgnoresUnrelatedInterface(t *testing.T) {
 	// event, so its source must be the ORIGINAL, not the renumbered 10.0.61.2.
 	if got := viB.getLocalIP(); got == nil || got.String() != "10.0.61.1" {
 		t.Fatalf("viB localIP = %v, want unchanged 10.0.61.1 (no event for its ifindex)", got)
+	}
+}
+
+// TestAddrWatcher_RecreatedLinkNewIfindexSchedulesReconcile is the #2707
+// fail-on-revert gate. A VLAN/GRE/WireGuard sub-interface is deleted and
+// recreated, so the kernel assigns a NEW ifindex while the configured NAME is
+// stable. An address event arrives on the NEW ifindex. The cached vi.iface.Index
+// no longer matches, so the pre-#2707 cached-ifindex-only match dropped the
+// event entirely and the instance waited up to ~2s for the reconcile to notice
+// the drift. The fix resolves the event ifindex -> name, re-matches by the
+// stable name, and triggers the immediate-reconcile lever (onEventDrop).
+//
+// Revert proof: with the old reresolveAddrFor (match only on cached ifindex),
+// the ifindex-77 event matches nothing, onEventDrop never fires, and this test
+// times out RED.
+func TestAddrWatcher_RecreatedLinkNewIfindexSchedulesReconcile(t *testing.T) {
+	m := NewManager()
+	defer stopManagerForTest(m)
+
+	updates := make(chan chan<- netlink.AddrUpdate, 1)
+	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error {
+		updates <- ch
+		return nil
+	}
+	// The recreated link's NEW ifindex (77) resolves back to the SAME name the
+	// instance is configured with. This is the only syscall the watcher makes,
+	// and only on a cached-ifindex miss.
+	m.resolveLinkName = func(ifindex int) (string, error) {
+		if ifindex == 77 {
+			return "reth0.50", nil
+		}
+		return "", errors.New("test: no such ifindex")
+	}
+	reconciled := make(chan struct{}, 4)
+	m.SetOnEventDrop(func() { reconciled <- struct{}{} })
+
+	// Instance was built when the link had ifindex 42 (the pre-recreate value).
+	cur := []net.Addr{ipnetAddr(t, "172.16.50.8/24")}
+	vi := newInstance(Instance{Interface: "reth0.50", GroupID: 1, Priority: 200},
+		&net.Interface{Name: "reth0.50", Index: 42}, m.eventCh, m.onEventDrop)
+	vi.addrsFn = func() ([]net.Addr, error) { return cur, nil }
+	vi.reresolveLocalAddrs()
+
+	m.mu.Lock()
+	m.instances[instanceKey{iface: "reth0.50", groupID: 1}] = vi
+	m.ensureAddrWatcherLocked()
+	m.mu.Unlock()
+
+	var ch chan<- netlink.AddrUpdate
+	select {
+	case ch = <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("addr watcher never subscribed")
+	}
+
+	// Address comes up on the RECREATED link — new ifindex 77, same name.
+	ch <- netlink.AddrUpdate{
+		LinkIndex:   77,
+		NewAddr:     true,
+		LinkAddress: net.IPNet{IP: net.ParseIP("172.16.50.8"), Mask: net.CIDRMask(24, 32)},
+	}
+
+	select {
+	case <-reconciled:
+		// Immediate reconcile scheduled — the rebind happens event-driven, not
+		// after the ~2s periodic reconcile.
+	case <-time.After(2 * time.Second):
+		t.Fatal("recreated-link addr event (new ifindex, same name) did not schedule a reconcile")
+	}
+}
+
+// TestAddrWatcher_UnchangedIfindexUsesFastPath asserts the common case is
+// unchanged: when the event ifindex still matches the cached vi.iface.Index the
+// source is re-resolved IN PLACE (reresolveLocalAddrs) and NO reconcile is
+// scheduled and NO link-name syscall is made. This guards the #2707 fix from
+// regressing into a reconcile (or a syscall) on every routine address event.
+func TestAddrWatcher_UnchangedIfindexUsesFastPath(t *testing.T) {
+	m := NewManager()
+	defer stopManagerForTest(m)
+
+	updates := make(chan chan<- netlink.AddrUpdate, 1)
+	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error {
+		updates <- ch
+		return nil
+	}
+	var nameResolves int32
+	m.resolveLinkName = func(ifindex int) (string, error) {
+		atomic.AddInt32(&nameResolves, 1)
+		return "reth0.50", nil
+	}
+	reconciled := make(chan struct{}, 4)
+	m.SetOnEventDrop(func() { reconciled <- struct{}{} })
+
+	cur := []net.Addr{ipnetAddr(t, "172.16.50.8/24")}
+	vi := newInstance(Instance{Interface: "reth0.50", GroupID: 1, Priority: 200},
+		&net.Interface{Name: "reth0.50", Index: 42}, m.eventCh, m.onEventDrop)
+	vi.addrsFn = func() ([]net.Addr, error) { return cur, nil }
+	vi.reresolveLocalAddrs()
+
+	m.mu.Lock()
+	m.instances[instanceKey{iface: "reth0.50", groupID: 1}] = vi
+	m.ensureAddrWatcherLocked()
+	m.mu.Unlock()
+
+	var ch chan<- netlink.AddrUpdate
+	select {
+	case ch = <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("addr watcher never subscribed")
+	}
+
+	// Renumber + event on the SAME (cached) ifindex 42.
+	cur = []net.Addr{ipnetAddr(t, "172.16.50.9/24")}
+	ch <- netlink.AddrUpdate{
+		LinkIndex:   42,
+		NewAddr:     true,
+		LinkAddress: net.IPNet{IP: net.ParseIP("172.16.50.9"), Mask: net.CIDRMask(24, 32)},
+	}
+
+	// Fast path re-resolves in place.
+	deadline := time.After(2 * time.Second)
+	for {
+		if got := vi.getLocalIP(); got != nil && got.String() == "172.16.50.9" {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("localIP = %v, want 172.16.50.9 (fast-path reresolve)", vi.getLocalIP())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	// No reconcile and no link-name syscall on the fast path.
+	select {
+	case <-reconciled:
+		t.Fatal("unchanged-ifindex event must NOT schedule a reconcile")
+	case <-time.After(150 * time.Millisecond):
+	}
+	if n := atomic.LoadInt32(&nameResolves); n != 0 {
+		t.Fatalf("resolveLinkName called %d times on the fast path, want 0 (no syscall on a cached-ifindex hit)", n)
 	}
 }
 

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -59,6 +59,19 @@ type Manager struct {
 	addrWatcherStarts  int  // guarded by mu — observability/test seam
 	subscribeAddrs     func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error
 
+	// resolveLinkName maps a kernel ifindex to its current link NAME. The
+	// addr-watcher (#2707) calls it ONLY on a cached-ifindex miss — when an
+	// address event arrives for an ifindex no instance is bound to. A
+	// VLAN/GRE/WireGuard link that is deleted+recreated (config change, driver
+	// restart, link-cycle recovery) gets a NEW ifindex, so the cached
+	// vi.iface.Index no longer matches and every subsequent address event on
+	// the recreated link would be ignored until the ~2s reconcile noticed the
+	// drift. Resolving the event ifindex back to a name lets us re-match the
+	// instance by its STABLE configured name and trigger an immediate
+	// reconcile. Defaults to a netlink.LinkByIndex wrapper; injectable so unit
+	// tests need no real netlink.
+	resolveLinkName func(ifindex int) (string, error)
+
 	// Injectable instance-lifecycle seams (#2156). Unit tests must not
 	// require real raw sockets or a live run() goroutine to exercise the
 	// build-before-teardown ordering in UpdateInstances. Production
@@ -91,6 +104,7 @@ func NewManager() *Manager {
 		linkState:          netlinkLinkState,
 		subscribeLinks:     netlink.LinkSubscribe,
 		subscribeAddrs:     netlink.AddrSubscribe,
+		resolveLinkName:    netlinkLinkName,
 		resolveIface:       net.InterfaceByName,
 		openInstanceSocket: func(vi *vrrpInstance) error { return vi.openSocket() },
 		runInstance:        func(vi *vrrpInstance) { go vi.run() },


### PR DESCRIPTION
Closes #2707

## The bug (MEDIUM, HA)

The VRRP source-address watcher (#2528) filtered netlink address events by the
instance's cached `vi.iface.Index` (`reresolveAddrFor`, `pkg/vrrp/addrwatch.go`).
When a VLAN sub-interface / GRE / WireGuard tunnel link is deleted and recreated
(config change, driver restart, link-cycle recovery) the kernel assigns a **new
ifindex**, so `vi.iface.Index == ifindex` no longer matches and **every**
subsequent address event on the recreated link was silently dropped until the
~2s `UpdateInstances` reconcile noticed the drift (the #2294 mitigation, which
only *bounds* the gap). For that whole window the instance kept advertising from
a stale source / off a stale socket — the same RETH-style split-brain the
addr-watcher exists to close, re-opened on the recreate path.

## Fix — match approach

`reresolveAddrFor` now:

1. **Fast path (unchanged, syscall-free):** match by cached `vi.iface.Index` →
   `reresolveLocalAddrs()`. The common unchanged-ifindex case takes no extra
   syscall.
2. **On a cached-ifindex MISS:** resolve the event ifindex → current link **name**
   (one syscall, *only* on a miss) via a new `resolveLinkName` seam
   (`netlinkLinkName` = `netlink.LinkByIndex`), then re-match instances by their
   **stable configured interface name** (`vi.cfg.Interface`). An instance whose
   name matches but whose cached ifindex differs is a recreated link → trigger
   the established immediate-reconcile lever (`onEventDrop`, wired to the daemon's
   `triggerReconcile`). `UpdateInstances` then rebinds the drifted instance to the
   new ifindex and re-resolves the source — **event-driven, not ~2s-deferred**.

## Locking / race safety

`vi.iface` is **not** mutated in the watcher. It is read by the run-loop
`sendPacket`/`sendPacketIPv6` goroutine, so mutating it under the manager
RLock would be a data race. Re-resolving the source against the stale `vi.iface`
also can't work — `net.Interface.Addrs()` filters by `Index`, so it would query
the wrong/absent ifindex. The reconcile (which builds a *fresh* instance with a
fresh socket + fresh source) is the correct, already-race-clean place to do the
rebind. The manager lock is dropped before calling `onEventDrop` to avoid holding
the RLock across the daemon callback.

## Tests (fail-on-revert)

- `TestAddrWatcher_RecreatedLinkNewIfindexSchedulesReconcile` — delivers an
  address event on a **new** ifindex whose name still matches a configured
  instance and asserts an immediate reconcile is scheduled. **Proven RED on
  revert**: reverting `reresolveAddrFor` to the cached-only match makes it time
  out (event matches nothing → `onEventDrop` never fires).
- `TestAddrWatcher_UnchangedIfindexUsesFastPath` — guards the common case:
  unchanged ifindex re-resolves in place with **no reconcile and no link-name
  syscall**.

## Gates

- `go build ./...` clean
- `gofmt`/`go vet` clean on touched files (`pkg/vrrp/vrrp.go` shows in
  `gofmt -l` but is **pre-existing dirty on origin/master** and untouched here)
- `go test -race ./pkg/vrrp/...` green

## For the parent — test-failover MANDATORY

This is HA-touching (VRRP). Per CLAUDE.md, **`make test-failover` must pass
before merge** (not run in this agent — no cluster access). Please run it on the
folded head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi