### PR TITLE
forwarding-build: validate classifier/rewrite classes and interface MTU (#2704, #2706)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14134,3 +14134,38 @@ top.
   `go test ./pkg/{ddns,config,dhcpserver,daemon}` green; `-race ./pkg/ddns`
   green. `make test-failover` still MANDATORY — the parent re-runs it on the
   folded head.
+
+## 2026-06-24 — #2704 + #2706 forwarding-build validation siblings (one PR)
+
+- **Timestamp**: 2026-06-24
+- **Action**: #2704 — apply the #2696/#2409 scheduler-map skip+warn pattern to
+  the DSCP classifier, 802.1p classifier, and DSCP rewrite emitters so an
+  entry referencing an undefined forwarding-class (a non-fatal commit warning)
+  is SKIPPED with a slog.Warn instead of crossing the wire to be silently
+  dropped / no-op'd by the Rust drift backstop. Go warn NOT promoted to a hard
+  error (out of scope). #2706 — add an `InterfaceMtu` validated newtype
+  (mirroring VlanId/TunnelTtl/QueueId) decoded at the egress-interface build
+  site; a NEGATIVE snapshot MTU now fails the snapshot closed
+  (`InterfaceMtuInvalid`) instead of `iface.mtu.max(0) as usize` collapsing it
+  to 0 — which the egress MTU guard treats as "unknown; forward", silently
+  disabling PTB/drop enforcement. 0 (the legitimate Go "unknown MTU" sentinel,
+  omitempty-dropped when the link can't be resolved) stays permissive (=0),
+  avoiding the #2696 over-rejection dual-risk.
+- **File(s)**: [Edit] pkg/dataplane/userspace/cos.go,
+  pkg/dataplane/userspace/manager_test.go,
+  userspace-dp/src/afxdp/forwarding_build/validated.rs,
+  userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/policy.rs, _Log.md. Docs: behavior documented inline per the
+  established fail-closed-family convention (VlanId/TunnelTtl/QueueId and the
+  #2409 scheduler-map skip are all self-documenting in code; no separate md
+  registry exists for this family).
+- **Validation**: GOCACHE go build ./... clean; gofmt + go vet clean on touched
+  Go; go test ./pkg/dataplane/userspace/... green (incl. new
+  TestBuildClassOfServiceSnapshotSkipsUndefinedClassifierAndRewriteClass).
+  cargo build --release clean; cargo test --release --bin xpf-userspace-dp
+  forwarding_build green (68/0) incl. new interface_negative_mtu_fails_closed +
+  interface_mtu_positive_and_zero_build_exactly. Fail-on-revert: removing the
+  Go filter lets the undefined-class entry cross the wire (surviving-entry
+  asserts go red); restoring `.max(0) as usize` collapses -1→0 (expect_err goes
+  red).

--- a/pkg/dataplane/userspace/cos.go
+++ b/pkg/dataplane/userspace/cos.go
@@ -53,6 +53,20 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 				if entry == nil {
 					continue
 				}
+				// #2704: an undefined forwarding-class ref in a DSCP
+				// classifier is only a non-fatal commit-time warning
+				// (compiler_validate_warn.go). Mirror the #2696/#2409
+				// scheduler-map skip+warn so the loss is no longer SILENT
+				// (the Rust side already drops unresolvable classifier
+				// entries; filtering here keeps the drop visible and the
+				// helper drift-backstop a true never-fires guard).
+				if _, ok := cos.ForwardingClasses[entry.ForwardingClass]; !ok {
+					slog.Warn("cos dscp-classifier references undefined forwarding-class; skipping entry (classifier partially absent)",
+						"classifier", classifier.Name,
+						"forwarding_class", entry.ForwardingClass,
+					)
+					continue
+				}
 				classifierSnap.Entries = append(classifierSnap.Entries, CoSDSCPClassifierEntrySnapshot{
 					ForwardingClass: entry.ForwardingClass,
 					LossPriority:    entry.LossPriority,
@@ -80,6 +94,14 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 				if entry == nil {
 					continue
 				}
+				// #2704: same skip+warn for 802.1p classifier entries.
+				if _, ok := cos.ForwardingClasses[entry.ForwardingClass]; !ok {
+					slog.Warn("cos ieee-802.1 classifier references undefined forwarding-class; skipping entry (classifier partially absent)",
+						"classifier", classifier.Name,
+						"forwarding_class", entry.ForwardingClass,
+					)
+					continue
+				}
 				classifierSnap.Entries = append(classifierSnap.Entries, CoSIEEE8021ClassifierEntrySnapshot{
 					ForwardingClass: entry.ForwardingClass,
 					LossPriority:    entry.LossPriority,
@@ -105,6 +127,18 @@ func buildClassOfServiceSnapshot(cfg *config.Config) *ClassOfServiceSnapshot {
 			rewriteSnap := CoSDSCPRewriteRuleSnapshot{Name: rewriteRule.Name}
 			for _, entry := range rewriteRule.Entries {
 				if entry == nil {
+					continue
+				}
+				// #2704: same skip+warn for DSCP rewrite entries. Without
+				// this an undefined-class rewrite crossed the wire and the
+				// Rust side only materialized rewrite for classes the
+				// interface actually carries, so the rewrite was silently
+				// no-op for the undefined class.
+				if _, ok := cos.ForwardingClasses[entry.ForwardingClass]; !ok {
+					slog.Warn("cos dscp rewrite-rule references undefined forwarding-class; skipping entry (rewrite absent for class)",
+						"rewrite_rule", rewriteRule.Name,
+						"forwarding_class", entry.ForwardingClass,
+					)
 					continue
 				}
 				rewriteSnap.Entries = append(rewriteSnap.Entries, CoSDSCPRewriteRuleEntrySnapshot{

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -4797,6 +4797,90 @@ func TestBuildClassOfServiceSnapshotSkipsUndefinedSchedulerMapClass(t *testing.T
 	}
 }
 
+// #2704: a DSCP classifier, 802.1p classifier, or DSCP rewrite-rule entry
+// referencing a forwarding-class that is not defined in
+// `class-of-service forwarding-classes` is only a NON-FATAL warning at commit
+// (compiler_validate_warn.go). The emitter must SKIP such an entry (mirroring
+// the scheduler-map skip) so the classifier/rewrite loss is no longer SILENT —
+// the pre-fix emitter carried the entry unfiltered and the Rust side then
+// silently dropped/no-op'd it. fail-on-revert: removing the filter lets the
+// undefined-class entry cross the wire and the surviving-entry asserts go red.
+func TestBuildClassOfServiceSnapshotSkipsUndefinedClassifierAndRewriteClass(t *testing.T) {
+	cfg := &config.Config{
+		ClassOfService: &config.ClassOfServiceConfig{
+			ForwardingClasses: map[string]*config.CoSForwardingClass{
+				"best-effort": {Name: "best-effort", Queue: 0},
+			},
+			DSCPClassifiers: map[string]*config.CoSDSCPClassifier{
+				"dscp-cl": {
+					Name: "dscp-cl",
+					Entries: []*config.CoSDSCPClassifierEntry{
+						{ForwardingClass: "best-effort", DSCPValues: []uint8{0}},
+						// undefined class — warning-only at commit, must be skipped
+						{ForwardingClass: "voice", DSCPValues: []uint8{46}},
+					},
+				},
+			},
+			IEEE8021Classifiers: map[string]*config.CoSIEEE8021Classifier{
+				"pcp-cl": {
+					Name: "pcp-cl",
+					Entries: []*config.CoSIEEE8021ClassifierEntry{
+						{ForwardingClass: "best-effort", CodePoints: []uint8{0}},
+						{ForwardingClass: "voice", CodePoints: []uint8{5}},
+					},
+				},
+			},
+			DSCPRewriteRules: map[string]*config.CoSDSCPRewriteRule{
+				"rw": {
+					Name: "rw",
+					Entries: []*config.CoSDSCPRewriteRuleEntry{
+						{ForwardingClass: "best-effort", DSCPValue: 0},
+						{ForwardingClass: "voice", DSCPValue: 46},
+					},
+				},
+			},
+		},
+	}
+
+	snap := buildClassOfServiceSnapshot(cfg)
+	if snap == nil {
+		t.Fatal("expected non-nil class-of-service snapshot")
+	}
+
+	if len(snap.DSCPClassifiers) != 1 {
+		t.Fatalf("DSCPClassifiers len = %d, want 1", len(snap.DSCPClassifiers))
+	}
+	dscpEntries := snap.DSCPClassifiers[0].Entries
+	if len(dscpEntries) != 1 {
+		t.Fatalf("dscp classifier entries = %d, want 1 (undefined-class entry must be skipped)", len(dscpEntries))
+	}
+	if dscpEntries[0].ForwardingClass != "best-effort" {
+		t.Fatalf("dscp surviving class = %q, want best-effort", dscpEntries[0].ForwardingClass)
+	}
+
+	if len(snap.IEEE8021Classifiers) != 1 {
+		t.Fatalf("IEEE8021Classifiers len = %d, want 1", len(snap.IEEE8021Classifiers))
+	}
+	pcpEntries := snap.IEEE8021Classifiers[0].Entries
+	if len(pcpEntries) != 1 {
+		t.Fatalf("802.1p classifier entries = %d, want 1 (undefined-class entry must be skipped)", len(pcpEntries))
+	}
+	if pcpEntries[0].ForwardingClass != "best-effort" {
+		t.Fatalf("802.1p surviving class = %q, want best-effort", pcpEntries[0].ForwardingClass)
+	}
+
+	if len(snap.DSCPRewriteRules) != 1 {
+		t.Fatalf("DSCPRewriteRules len = %d, want 1", len(snap.DSCPRewriteRules))
+	}
+	rwEntries := snap.DSCPRewriteRules[0].Entries
+	if len(rwEntries) != 1 {
+		t.Fatalf("rewrite entries = %d, want 1 (undefined-class entry must be skipped)", len(rwEntries))
+	}
+	if rwEntries[0].ForwardingClass != "best-effort" {
+		t.Fatalf("rewrite surviving class = %q, want best-effort", rwEntries[0].ForwardingClass)
+	}
+}
+
 // #1746: the equal-flow target policy reaches the scheduler snapshot,
 // and an UNSET policy keeps the serialized snapshot byte-identical to
 // the pre-#1746 wire (omitempty) — the byte-unchanged-default proof.

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -166,6 +166,13 @@ pub(super) fn populate_egress(
         // (> 65535) fails the snapshot closed rather than wrapping to a
         // different VLAN (a different L2 domain).
         let vlan_id = super::validated::VlanId::try_from_snapshot(iface.vlan_id, &iface.name)?.get();
+        // #2706: validate the MTU ONCE here instead of narrowing it with an
+        // unchecked `iface.mtu.max(0) as usize`. A NEGATIVE value fails the
+        // snapshot closed rather than collapsing to 0 — which the egress MTU
+        // guard treats as "unknown; forward", silently disabling PTB/drop
+        // enforcement. 0 (the legitimate "unknown MTU" sentinel) stays
+        // permissive.
+        let mtu = super::validated::InterfaceMtu::try_from_snapshot(iface.mtu, &iface.name)?.get();
         let ingress_key = (bind_ifindex, vlan_id);
         if iface.parent_ifindex > 0 {
             state
@@ -206,7 +213,7 @@ pub(super) fn populate_egress(
             EgressInterface {
                 bind_ifindex,
                 vlan_id,
-                mtu: iface.mtu.max(0) as usize,
+                mtu,
                 src_mac,
                 zone_id,
                 redundancy_group: iface.redundancy_group,

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1211,6 +1211,69 @@ fn interface_vlan_id_in_range_builds_exactly() {
     assert_eq!(state.egress.get(&31).expect("egress 31").vlan_id, 0);
 }
 
+/// #2706: a NEGATIVE interface MTU fails the snapshot CLOSED via
+/// `InterfaceMtuInvalid`. fail-on-revert: restoring `iface.mtu.max(0) as
+/// usize` silently collapses -1 → 0, the egress MTU guard then treats 0 as
+/// "unknown; forward" (PTB/drop enforcement disabled), the build succeeds,
+/// and this `expect_err` goes red.
+#[test]
+fn interface_negative_mtu_fails_closed() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0/0/2".into(),
+            ifindex: 40,
+            mtu: -1, // collapses to 0 (enforcement off) under the old `.max(0)` cast
+            hardware_addr: "02:00:00:00:00:40".into(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let err = try_build_forwarding_state_with_policy_counters(
+        &snapshot,
+        &crate::policy::PolicyCounterStore::default(),
+    )
+    .expect_err("a negative interface MTU must fail closed, not collapse to 0 (enforcement off)");
+    match err {
+        crate::policy::SnapshotIntegrityError::InterfaceMtuInvalid { interface, mtu } => {
+            assert_eq!(interface, "ge-0/0/2");
+            assert_eq!(mtu, -1);
+        }
+        other => panic!("expected InterfaceMtuInvalid, got {other:?}"),
+    }
+}
+
+/// #2706 anti-over-reject: a positive MTU builds through unchanged, and the
+/// legitimate 0 "unknown MTU" sentinel is preserved as 0 (the permissive
+/// "forward; MTU unknown" case the egress guard relies on) — byte-identical
+/// to the old `.max(0) as usize`. This guards against the #2696
+/// over-rejection dual-risk (rejecting a legit 0 would break deploy-boot of
+/// any interface whose link MTU could not be resolved).
+#[test]
+fn interface_mtu_positive_and_zero_build_exactly() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![
+            InterfaceSnapshot {
+                name: "ge-0/0/3".into(),
+                ifindex: 41,
+                mtu: 9000, // jumbo — passes through unchanged
+                hardware_addr: "02:00:00:00:00:41".into(),
+                ..Default::default()
+            },
+            InterfaceSnapshot {
+                name: "ge-0/0/4".into(),
+                ifindex: 42,
+                mtu: 0, // legitimate "unknown MTU" sentinel → stays 0 (permissive)
+                hardware_addr: "02:00:00:00:00:42".into(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert_eq!(state.egress.get(&41).expect("egress 41").mtu, 9000);
+    assert_eq!(state.egress.get(&42).expect("egress 42").mtu, 0);
+}
+
 /// #2410: a tunnel TTL > 255 fails the snapshot CLOSED via
 /// `TunnelTtlOutOfRange`. fail-on-revert: restoring
 /// `endpoint.ttl.max(0) as u8` wraps 256 → 0 (a blackholed tunnel) and

--- a/userspace-dp/src/afxdp/forwarding_build/validated.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/validated.rs
@@ -104,3 +104,48 @@ impl QueueId {
         self.0
     }
 }
+
+/// A validated egress interface MTU.
+///
+/// #2706: the pre-fix code narrowed the snapshot `mtu` with
+/// `iface.mtu.max(0) as usize`, so a NEGATIVE (malformed / version-drifted)
+/// value silently collapsed to `0`. The egress MTU guard
+/// (`forwarded_egress_mtu_decision`) treats `mtu == 0` as "unknown; forward"
+/// (fail-open: never invent an MTU smaller than the link), so a negative MTU
+/// silently DISABLED PTB / drop enforcement instead of failing the snapshot.
+///
+/// `0` is the LEGITIMATE "unknown MTU" sentinel the Go control plane emits
+/// (an interface whose link could not be resolved — `buildLinkSnapshot`
+/// returns mtu 0, dropped on the wire by `json:"mtu,omitempty"` and decoded
+/// back to 0). That permissive case is preserved unchanged: `0` maps to
+/// `InterfaceMtu(0)`. Only a NEGATIVE value (which a healthy Go path never
+/// produces — netlink MTUs are non-negative) is REJECTED, consistent with the
+/// #2410/#2696 fail-closed boundary: rejecting the whole snapshot keeps the
+/// previous live forwarding state rather than installing an interface with MTU
+/// enforcement silently switched off.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::afxdp) struct InterfaceMtu(usize);
+
+impl InterfaceMtu {
+    /// Decode an interface snapshot `mtu` (an `i32`). `0` (and only 0) is the
+    /// legitimate "unknown, forward permissively" sentinel and maps to
+    /// `InterfaceMtu(0)`. A NEGATIVE value is REJECTED (the pre-fix `.max(0)`
+    /// silently turned it into the permissive 0, disabling egress MTU
+    /// enforcement). A positive value passes through unchanged.
+    pub(in crate::afxdp) fn try_from_snapshot(
+        mtu: i32,
+        interface: &str,
+    ) -> Result<Self, SnapshotIntegrityError> {
+        usize::try_from(mtu).map(Self).map_err(|_| {
+            SnapshotIntegrityError::InterfaceMtuInvalid {
+                interface: interface.to_string(),
+                mtu,
+            }
+        })
+    }
+
+    #[inline]
+    pub(in crate::afxdp) fn get(self) -> usize {
+        self.0
+    }
+}

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -143,6 +143,17 @@ pub(crate) enum SnapshotIntegrityError {
     /// a partial CoS table. An EMPTY class name is the legitimate "unnamed /
     /// placeholder" case and is NOT an error (skipped as before).
     CosQueueIdOutOfRange { forwarding_class: String, queue: i32 },
+    /// #2706: an interface snapshot's `mtu` is NEGATIVE. The pre-fix code
+    /// narrowed it with `iface.mtu.max(0) as usize`, so a negative value
+    /// silently collapsed to 0 — and the egress MTU guard
+    /// (`forwarded_egress_mtu_decision`) treats mtu 0 as "unknown; forward"
+    /// (fail-open), so a negative MTU silently DISABLED PTB / drop enforcement
+    /// on that interface. A healthy Go control plane never emits a negative MTU
+    /// (netlink MTUs are non-negative; 0 is the legitimate "unknown" sentinel
+    /// preserved as permissive). Fail the snapshot closed on a negative value
+    /// rather than installing an interface with MTU enforcement off, consistent
+    /// with the #2410/#2696 fail-closed family.
+    InterfaceMtuInvalid { interface: String, mtu: i32 },
     /// #2409: an interface address snapshot's `address` string did not parse as
     /// an `IpNet` CIDR. The pre-fix code `continue`d past it, so the connected
     /// route / local-address / interface-NAT material for that address silently
@@ -233,6 +244,11 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "cos forwarding-class {:?} has queue {} outside the 0..=255 range — refusing to silently drop the class (which would unmap every classifier/scheduler entry referencing it)",
                 forwarding_class, queue
+            ),
+            Self::InterfaceMtuInvalid { interface, mtu } => write!(
+                f,
+                "interface {:?} has a negative mtu {} — refusing to narrow it with an unchecked .max(0) cast that would collapse it to 0 (which the egress MTU guard treats as \"unknown; forward\", silently disabling PTB/drop enforcement)",
+                interface, mtu
             ),
             Self::InterfaceAddressUnparseable { interface, address } => write!(
                 f,


### PR DESCRIPTION
Two forwarding-build validation siblings of #2696. Both fix config that commits with a non-fatal warning but installs with material forwarding behavior silently absent.

## #2704 — undefined forwarding-class in DSCP/802.1p classifiers + DSCP rewrite (Go emitter)

An undefined forwarding-class reference is a commit-time **WARNING** (not error) for DSCP classifiers, 802.1p classifiers, and DSCP rewrite (`compiler_validate_warn.go`). The #2696/#2409 skip+warn guard was applied only to **scheduler-map** entries; these three emitters carried entries **unfiltered**, so the Rust side silently dropped unresolvable classifier entries / only materialized rewrite for classes the interface actually carries — a committed (warned) config installed with its classifier/rewrite **materially absent**, no hard failure.

Fix: mirror the scheduler-map skip+warn for all three emitters in `cos.go` — skip an entry whose `ForwardingClass` is not in `cos.ForwardingClasses` with an `slog.Warn` naming the dropped classifier/rewrite + class. The Go warn is **not** promoted to a hard error (operator-facing behavior change, out of scope). The Rust drift backstop is left as-is — it now fires only on a version/snapshot-drifted helper.

## #2706 — interface MTU not validated; negative collapses to 0 and disables egress MTU enforcement (Rust)

`forwarding_build` narrowed the snapshot MTU with `iface.mtu.max(0) as usize`, so a negative (malformed / version-drifted) value silently became `0` — and the egress MTU guard (`forwarded_egress_mtu_decision`) treats `mtu == 0` as "unknown; forward" (fail-open), so a negative MTU **silently disabled PTB/drop enforcement** on that interface.

Fix: add an `InterfaceMtu` validated newtype (mirrors `VlanId`/`TunnelTtl`/`QueueId`), decoded once at the egress-interface build site, that fails the snapshot closed (`InterfaceMtuInvalid`) on a negative value — same error type / `?` propagation / prior-state-retained-on-Err precedent.

**0-vs-negative decision (for deploy-boot):** `0` is the **legitimate** "unknown MTU" sentinel the Go control plane emits — `buildLinkSnapshot` returns mtu 0 when the link can't be resolved, dropped on the wire by `json:"mtu,omitempty"` and decoded back to 0. It is **preserved as the permissive 0** (unchanged egress-guard behavior), avoiding the #2696 over-rejection dual-risk. A healthy Go path never emits a negative MTU (netlink MTUs are non-negative), so only a drifted/corrupt snapshot is rejected.

## Tests (fail-on-revert)

- `TestBuildClassOfServiceSnapshotSkipsUndefinedClassifierAndRewriteClass` (Go) — the undefined-class entry is skipped for all three emitters, the valid entry survives. Remove the filter → bad entry crosses the wire → red.
- `interface_negative_mtu_fails_closed` + `interface_mtu_positive_and_zero_build_exactly` (Rust) — a negative MTU fails closed; a positive MTU and the legit `0` sentinel build unchanged. Restore `.max(0) as usize` → -1 silently 0 → `expect_err` red.

## Gates

- `go build ./...` clean; gofmt + go vet clean on touched Go; `go test ./pkg/dataplane/userspace/...` green.
- `cargo build --release` clean; `cargo test --release --bin xpf-userspace-dp forwarding_build` green.

Closes #2704
Closes #2706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi