### PR TITLE
tunnels: fix WG outer source + GRE/WG outer TTL=0 blackhole (#2701, #2703)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-24 — #2701 review fold: end-to-end call-site test for the WG outer source
+
+- **Timestamp**: 2026-06-24
+- **Action**: Added two end-to-end `wg_encap_frame` tests that assert on the
+  EMITTED outer-IP source bytes of a real built frame, closing the
+  test-coverage gap flagged in review: the original
+  `outer_source_uses_physical_egress_not_tunnel_logical` test called the
+  `outer_physical_egress_ifindex` helper directly and stayed GREEN when ONLY
+  the production call-site source lookup (wg.rs) was reverted to the logical
+  `decision.resolution.egress_ifindex`. The new tests build an ESTABLISHED
+  WgEngine (real Noise IKpsk2 handshake so `try_encap` succeeds) over the
+  shared #2680 fixture, with the peer endpoint routed to the physical egress
+  (ifindex 12), and assert the built frame's outer source == the physical WAN
+  primary (172.16.80.8 v4 / 2001:559:8585:80::8 v6), NOT the tunnel-logical
+  address (10.123.0.1 / fd00:dead::1). Verified fail-on-revert at the CALL
+  SITE: reverting wg.rs's source lookup to the logical egress_ifindex turns
+  BOTH new tests RED (the helper tests stay green, confirming they alone were
+  insufficient); restoring → all green.
+- **File(s)**: `userspace-dp/src/afxdp/frame/wg.rs` (two end-to-end tests +
+  engine/inner-frame test helpers), `_Log.md`.
+- **Validation**: `cargo build --release` clean; `cargo test --release --bin
+  xpf-userspace-dp` wg_frame (11/11) + frame:: + tunnel_ttl (293 total) green.
+  Call-site fail-on-revert confirmed manually (both new tests RED on revert).
+
 ## 2026-06-24 — #2701 + #2703: tunnel outer-IP-header bugs (WG outer source, GRE/WG outer TTL)
 
 - **Timestamp**: 2026-06-24

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-06-24 — #2701 + #2703: tunnel outer-IP-header bugs (WG outer source, GRE/WG outer TTL)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed two coupled outer-IP-header transit bugs in ONE PR.
+  - **#2701 (WG outer SOURCE)**: the #2680/#2683 MTU fix re-resolved the
+    PHYSICAL underlay egress for the outer-MTU guard but the outer IP SOURCE
+    was still read from `decision.resolution.egress_ifindex` (the LOGICAL WG
+    tunnel ifindex) — `None`-drop when the logical iface had no WAN primary,
+    or a tunnel-address source otherwise. Factored the MTU helper's
+    physical-egress resolution into `outer_physical_egress_ifindex` and used
+    it for BOTH the MTU guard (`outer_physical_egress_mtu` now wraps it) AND
+    the outer-source `primary_v4`/`primary_v6` lookup. Outer UDP now sources
+    from the physical WAN primary.
+  - **#2703 (outer TTL=0 sentinel)**: tunnel `TTL=0` means "default 64"
+    (Go config + netlink `pkg/routing/tunnel.go:686-688`), but the AF_XDP
+    snapshot passed `tunnel.TTL` raw → Rust frame builders wrote outer TTL 0
+    → blackhole. Applied the 0→64 default Go-side in
+    `pkg/dataplane/userspace/tunnels.go` (SSOT, mirrors netlink); explicit
+    non-zero preserved. Fail-closed backstop: `TunnelTtl::try_from_snapshot`
+    now maps NEGATIVE → default 64 (was 0); >255 still fails CLOSED.
+- **File(s)**: `userspace-dp/src/afxdp/frame/wg.rs` (helper refactor + outer
+  source + 2 tests), `pkg/dataplane/userspace/tunnels.go` (0→64 default),
+  `pkg/dataplane/userspace/tunnels_test.go` (TTL default/preserve test),
+  `userspace-dp/src/afxdp/forwarding_build/validated.rs` (negative→default),
+  `userspace-dp/src/afxdp/forwarding_build/tests.rs` (negative-TTL test),
+  `docs/wireguard-interop.md` (#2701/#2703 notes), `_Log.md`.
+- **Validation**: `go build ./...`, `go test ./pkg/dataplane/userspace/...`,
+  gofmt, go vet clean; `cargo build --release` clean; `cargo test --release
+  --bin xpf-userspace-dp` wg_frame (9/9) + tunnel_ttl (3/3) + gre/frame
+  filters green. WG/GRE transit is lab-bound on the loss cluster (no WG
+  tunnel) — unit tests are the gate.
+
 ## 2026-06-24 — #2702: BGP group/neighbor export/import bracket-list truncation
 
 - **Timestamp**: 2026-06-24

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -130,6 +130,34 @@ from `wgDefaultOuterMTU` minus the family overhead. The pre-#2300 code
 ignored `tc.MTU` entirely and always derived from 1500, so a
 lowered-underlay deployment could not set a smaller wgN MTU.
 
+**#2701 (transit-egress OUTER SOURCE).** The #2680 MTU fix resolved the
+physical underlay egress for the MTU guard but left the OUTER IP SOURCE
+still read from `decision.resolution.egress_ifindex` (the LOGICAL tunnel
+ifindex). When the logical WG interface carries no WAN primary the
+`primary_v4?`/`primary_v6?` lookup returned `None` → dropped transit; when
+it carried a tunnel address the outer UDP was sourced from that tunnel
+address (breaking source-dependent policy/NAT/upstream anti-spoofing). The
+MTU helper is now factored into `outer_physical_egress_ifindex` (returns the
+physical underlay ifindex via the same route-to-selected-peer lookup), used
+for BOTH the MTU guard (`outer_physical_egress_mtu` wraps it) AND the outer
+source primary. So the outer UDP is always sourced from the physical WAN
+primary, not the tunnel-logical address. Same conservative fallback: an
+unresolvable outer falls back to `egress_ifindex` (no worse than pre-#2701).
+
+**#2703 (outer TTL default).** A tunnel TTL of `0` is the "use the default
+64" sentinel in the Go config (`schema_interfaces.go`, `types_routing.go`),
+and the netlink GRE path applies it (`pkg/routing/tunnel.go: if ttl == 0 {
+ttl = 64 }`). The AF_XDP transit path passed `tunnel.TTL` raw into the
+snapshot, and the Rust frame builders (`frame/wg.rs`, `gre.rs`) write the
+snapshot TTL straight into the outer IP header — so a default-config tunnel
+emitted outer TTL/hop-limit 0 → deterministic first-hop blackhole. The 0→64
+default is now applied Go-side in `pkg/dataplane/userspace/tunnels.go` (the
+SSOT, mirroring the netlink precedent) before the value reaches the
+snapshot; an explicit non-zero TTL is preserved. As a fail-closed backstop,
+`TunnelTtl::try_from_snapshot` now maps a NEGATIVE snapshot TTL (corrupt /
+mixed-version) to the documented default 64 rather than 0 (an out-of-range
+value > 255 still fails the snapshot CLOSED via `TunnelTtlOutOfRange`).
+
 Residual / follow-up: the per-peer LEARNED-endpoint roam case still uses
 the spawn-time outer MTU on the control thread (the transit-egress path
 already reads the real per-packet egress MTU); the Go default cannot see

--- a/pkg/dataplane/userspace/tunnels.go
+++ b/pkg/dataplane/userspace/tunnels.go
@@ -82,6 +82,19 @@ func buildTunnelEndpointSnapshots(cfg *config.Config, interfaces []InterfaceSnap
 				transportTable = tunnel.RoutingInstance + ".inet.0"
 			}
 		}
+		// #2703: a tunnel TTL of 0 is the "use the default 64" sentinel
+		// (pkg/config/schema_interfaces.go, types_routing.go). The netlink
+		// kernel-tunnel path applies that default
+		// (pkg/routing/tunnel.go: `if ttl == 0 { ttl = 64 }`); the AF_XDP
+		// transit path must mirror it BEFORE the value reaches the snapshot,
+		// else the Rust frame builders write outer TTL/hop-limit 0 and every
+		// default-config GRE/IPIP/WG outer packet is dropped at the first hop
+		// (a deterministic blackhole that looks like underlay loss). An
+		// explicitly-configured non-zero TTL is preserved unchanged.
+		ttl := tunnel.TTL
+		if ttl == 0 {
+			ttl = 64
+		}
 		redundancyGroup := iface.RedundancyGroup
 		if redundancyGroup <= 0 {
 			if src := net.ParseIP(tunnel.Source); src != nil {
@@ -116,7 +129,7 @@ func buildTunnelEndpointSnapshots(cfg *config.Config, interfaces []InterfaceSnap
 			Source:          tunnel.Source,
 			Destination:     tunnel.Destination,
 			Key:             tunnel.Key,
-			TTL:             tunnel.TTL,
+			TTL:             ttl,
 			TransportTable:  transportTable,
 		}
 		if isWireguard {

--- a/pkg/dataplane/userspace/tunnels_test.go
+++ b/pkg/dataplane/userspace/tunnels_test.go
@@ -49,6 +49,53 @@ func TestBuildTunnelEndpointSnapshotsDropsRemovedWireguard(t *testing.T) {
 	}
 }
 
+// #2703: a tunnel TTL of 0 is the "use the default 64" sentinel. The
+// AF_XDP snapshot emitter must apply that default (mirroring the netlink
+// path in pkg/routing/tunnel.go) BEFORE the value reaches the Rust frame
+// builders, which write the snapshot TTL straight into the outer IP
+// header. Leaving it 0 emits outer TTL/hop-limit 0 → first-hop blackhole.
+// An explicitly-configured non-zero TTL must be preserved unchanged.
+func TestBuildTunnelEndpointSnapshotsTTLDefault(t *testing.T) {
+	mkCfg := func(ttl int) *config.Config {
+		cfg := &config.Config{}
+		cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+			"gr-0/0/0": {
+				Name: "gr-0/0/0",
+				Tunnel: &config.TunnelConfig{
+					Name:        "gr-0/0/0",
+					Mode:        "gre",
+					Source:      "172.16.50.8",
+					Destination: "172.16.50.9",
+					TTL:         ttl,
+				},
+			},
+		}
+		return cfg
+	}
+	interfaces := []InterfaceSnapshot{
+		{Name: "gr-0/0/0", LinuxName: "gr0", Ifindex: 50},
+	}
+
+	// TTL unset (0) → defaulted to 64. Fail-on-revert: raw passthrough
+	// keeps 0 here, which the Rust builder writes as outer TTL 0 (blackhole).
+	eps := buildTunnelEndpointSnapshots(mkCfg(0), interfaces)
+	if len(eps) != 1 {
+		t.Fatalf("TTL=0 endpoints = %+v, want exactly one", eps)
+	}
+	if eps[0].TTL != 64 {
+		t.Fatalf("TTL=0 (sentinel) must default to 64, got %d", eps[0].TTL)
+	}
+
+	// Explicit non-zero TTL is preserved (the default must not override it).
+	eps = buildTunnelEndpointSnapshots(mkCfg(32), interfaces)
+	if len(eps) != 1 {
+		t.Fatalf("TTL=32 endpoints = %+v, want exactly one", eps)
+	}
+	if eps[0].TTL != 32 {
+		t.Fatalf("explicit TTL=32 must be preserved, got %d", eps[0].TTL)
+	}
+}
+
 // #1910 r2 Codex High: an interface-level WireGuard tunnel with
 // multiple units is ONE persistent TUN with ONE listen port. Now that
 // TunnelNameMap resolves every unit ref of an interface-level wg to
@@ -337,7 +384,7 @@ func TestEmitTunnelEndpointNamesMatchesBuilder(t *testing.T) {
 			cfg: cfgWith(map[string]*config.InterfaceConfig{
 				"gr-2/0/0": mkIface("gr-2/0/0", nil, map[int]*config.InterfaceUnit{
 					0: {Number: 0, Tunnel: greComplete()},
-					1: {Number: 1}, // no tunnel — not emitted
+					1: {Number: 1},                          // no tunnel — not emitted
 					2: {Number: 2, Tunnel: greIncomplete()}, // dropped
 				}),
 			}),

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1327,6 +1327,34 @@ fn tunnel_ttl_in_range_builds_exactly() {
     assert_eq!(state.tunnel_endpoints.get(&10).expect("endpoint").ttl, 255);
 }
 
+/// #2703: a NEGATIVE tunnel TTL (a corrupt / mixed-version snapshot
+/// field) maps to the documented default 64, NOT 0. fail-on-revert:
+/// restoring `TunnelTtl(0)` for negatives writes outer TTL 0 and
+/// blackholes the tunnel — the exact failure the Go-side 0→64 default
+/// guards against — making this assertion red.
+#[test]
+fn tunnel_ttl_negative_maps_to_default_not_zero() {
+    let snapshot = ConfigSnapshot {
+        tunnel_endpoints: vec![crate::protocol::snapshot::TunnelEndpointSnapshot {
+            id: 11,
+            interface: "gr-0/0/0".into(),
+            ifindex: 52,
+            mode: "gre".into(),
+            source: "203.0.113.1".into(),
+            destination: "198.51.100.1".into(),
+            ttl: -1, // corrupt / mixed-version: must NOT become 0
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert_eq!(
+        state.tunnel_endpoints.get(&11).expect("endpoint").ttl,
+        64,
+        "a negative snapshot TTL must map to the default 64, not 0 (blackhole)"
+    );
+}
+
 /// #2410: a CoS forwarding-class queue id outside 0..=255 fails the
 /// snapshot CLOSED via `CosQueueIdOutOfRange`. fail-on-revert: restoring
 /// the `filter_map` range check silently DROPS the class, the build

--- a/userspace-dp/src/afxdp/forwarding_build/validated.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/validated.rs
@@ -55,16 +55,26 @@ impl VlanId {
 pub(in crate::afxdp) struct TunnelTtl(u8);
 
 impl TunnelTtl {
-    /// Decode a tunnel-endpoint snapshot `ttl` (an `i32`). A NEGATIVE
-    /// value maps to `TunnelTtl(0)` (the pre-fix `.max(0)` behavior); a
-    /// value > `u8::MAX` is REJECTED (the pre-fix cast wrapped it,
-    /// 256→0).
+    /// The documented default outer TTL when a tunnel carries no explicit
+    /// value. Mirrors the Go contract (`0` = "use the default 64",
+    /// `pkg/config/schema_interfaces.go` / `types_routing.go`) and the
+    /// netlink path (`pkg/routing/tunnel.go: if ttl == 0 { ttl = 64 }`).
+    pub(in crate::afxdp) const DEFAULT_TTL: u8 = 64;
+
+    /// Decode a tunnel-endpoint snapshot `ttl` (an `i32`). A value > `u8::MAX`
+    /// is REJECTED (the pre-fix cast wrapped it, 256→0). A NEGATIVE value is a
+    /// corrupt / mixed-version snapshot field — map it to the documented
+    /// default `DEFAULT_TTL` rather than `0` (#2703): coercing to 0 would write
+    /// outer TTL 0 and blackhole the tunnel, the exact failure the Go-side
+    /// 0→64 default in `pkg/dataplane/userspace/tunnels.go` exists to prevent.
+    /// The well-behaved Go emitter never sends 0 (it applies the default
+    /// before the snapshot), so this is a fail-closed backstop only.
     pub(in crate::afxdp) fn try_from_snapshot(
         ttl: i32,
         tunnel_id: u16,
     ) -> Result<Self, SnapshotIntegrityError> {
         if ttl < 0 {
-            return Ok(Self(0));
+            return Ok(Self(Self::DEFAULT_TTL));
         }
         u8::try_from(ttl)
             .map(Self)

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -41,18 +41,21 @@ fn wg_encapped_size(inner_len: usize, outer_v6: bool) -> usize {
     wg_record_len + outer_ip_len + 8
 }
 
-/// The PHYSICAL underlay egress MTU the OUTER (WG/UDP) datagram must fit,
-/// for a tunnel-resolved encap decision (#2680).
+/// Resolve the PHYSICAL underlay egress ifindex the OUTER (WG/UDP) datagram
+/// actually leaves on, for a tunnel-resolved encap decision (#2680/#2701).
 ///
-/// The MTU guard in `wg_encap_frame` compares the full OUTER encapped size
-/// against an interface MTU. The interface it must compare against is the
-/// PHYSICAL underlay egress — the interface the outer WG/UDP datagram
-/// actually leaves on — NOT `decision.resolution.egress_ifindex`, which for
-/// a tunnel-resolved flow is the tunnel LOGICAL ifindex (the WG interface,
-/// MTU ~1420, used for zone/policy/CoS). Gating the outer size against the
-/// logical MTU is apples-to-oranges and silently drops inner packets whose
-/// outer datagram fits the 1500-byte underlay (broken PMTUD / tunnel
-/// transit).
+/// The interface that matters here is the PHYSICAL underlay egress — the one
+/// the outer WG/UDP datagram leaves on — NOT
+/// `decision.resolution.egress_ifindex`, which for a tunnel-resolved flow is
+/// the tunnel LOGICAL ifindex (the WG interface, MTU ~1420, address a tunnel
+/// address, used for zone/policy/CoS). BOTH the outer-MTU guard AND the outer
+/// IP SOURCE address must follow this SAME physical egress:
+///   - #2680: gating the outer size against the LOGICAL MTU is
+///     apples-to-oranges and silently drops inner packets whose outer datagram
+///     fits the 1500-byte underlay (broken PMTUD / tunnel transit).
+///   - #2701: sourcing the outer IP from the LOGICAL ifindex reads a tunnel
+///     address (or, when the logical WG iface carries no primary, `None` →
+///     drop). The outer UDP must be sourced from the physical WAN primary.
 ///
 /// For WireGuard the outer destination is the SELECTED peer endpoint
 /// (`engine.peer_for_dest` LPM), NOT the endpoint-level `destination` (which
@@ -65,23 +68,19 @@ fn wg_encapped_size(inner_len: usize, outer_v6: bool) -> usize {
 /// zeroed endpoint destination, cannot be reused here — it always NoRoutes
 /// for WG.)
 ///
-/// Fallbacks (conservative): if the outer route cannot be resolved (no FIB
-/// entry / non-positive egress) fall back to the resolution's own
-/// `egress_ifindex` MTU, then to 1500. This never makes the guard tighter
-/// than the pre-#2680 logical-MTU behaviour for the unresolvable case — it
-/// only widens it to the underlay when the outer resolves, which is the
-/// correct comparison.
-///
-/// The inner packet's own logical/PMTUD MTU is a SEPARATE concern handled
-/// by the WG inner-MTU clamp / post-transform PMTUD on the TX dispatcher
-/// (#2299/#2330/#2457); this helper is strictly outer-size-vs-physical-MTU.
+/// Fallback (conservative): if the outer route cannot be resolved (no FIB
+/// entry / non-positive egress / the resolved egress is itself a tunnel
+/// interface) fall back to the resolution's own `egress_ifindex` (the LOGICAL
+/// ifindex). For the MTU guard this never makes it tighter than the pre-#2680
+/// logical-MTU behaviour; for the source it preserves the pre-#2701 lookup,
+/// so an unresolvable outer is no worse than before.
 #[inline]
-fn outer_physical_egress_mtu(
+fn outer_physical_egress_ifindex(
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     endpoint: &TunnelEndpoint,
     outer_dst: IpAddr,
-) -> usize {
+) -> i32 {
     let outer = match outer_dst {
         IpAddr::V4(ip) => lookup_forwarding_resolution_v4(
             forwarding,
@@ -100,14 +99,33 @@ fn outer_physical_egress_mtu(
             false,
         ),
     };
-    let physical_ifindex = if outer.egress_ifindex > 0
+    if outer.egress_ifindex > 0
         && outer.disposition != ForwardingDisposition::NoRoute
         && !forwarding.tunnel_interfaces.contains(&outer.egress_ifindex)
     {
         outer.egress_ifindex
     } else {
         decision.resolution.egress_ifindex
-    };
+    }
+}
+
+/// The PHYSICAL underlay egress MTU the OUTER (WG/UDP) datagram must fit
+/// (#2680). Thin wrapper over `outer_physical_egress_ifindex` so the MTU
+/// guard and the outer-source lookup resolve the SAME physical egress.
+///
+/// The inner packet's own logical/PMTUD MTU is a SEPARATE concern handled
+/// by the WG inner-MTU clamp / post-transform PMTUD on the TX dispatcher
+/// (#2299/#2330/#2457); this helper is strictly outer-size-vs-physical-MTU.
+/// Final fallback (egress row missing / MTU 0) is 1500.
+#[inline]
+fn outer_physical_egress_mtu(
+    decision: &SessionDecision,
+    forwarding: &ForwardingState,
+    endpoint: &TunnelEndpoint,
+    outer_dst: IpAddr,
+) -> usize {
+    let physical_ifindex =
+        outer_physical_egress_ifindex(decision, forwarding, endpoint, outer_dst);
     forwarding
         .egress
         .get(&physical_ifindex)
@@ -236,7 +254,16 @@ pub(super) fn wg_encap_frame(
 
     // Source IP/port: the firewall egress primary address + WG listen
     // port; destination: the peer endpoint.
-    let egress = forwarding.egress.get(&decision.resolution.egress_ifindex);
+    //
+    // #2701: the outer IP SOURCE must be the PHYSICAL underlay egress
+    // primary, resolved via the route to the SELECTED peer endpoint — the
+    // SAME egress the #2680 MTU guard uses — NOT
+    // `decision.resolution.egress_ifindex` (the tunnel LOGICAL ifindex,
+    // whose primary is a tunnel address or absent → wrong source / None
+    // drop). Both follow `outer_physical_egress_ifindex`.
+    let physical_egress_ifindex =
+        outer_physical_egress_ifindex(decision, forwarding, endpoint, peer_endpoint.ip());
+    let egress = forwarding.egress.get(&physical_egress_ifindex);
     let src_port = endpoint.wg_listen_port;
     let dst_port = peer_endpoint.port();
 
@@ -469,6 +496,58 @@ mod wg_frame_tests {
         assert_eq!(
             outer_physical_egress_mtu(&decision, &state, endpoint, unrouted),
             1420
+        );
+    }
+
+    // === #2701: the OUTER IP SOURCE follows the PHYSICAL underlay egress,
+    // not the tunnel LOGICAL ifindex. ===
+
+    #[test]
+    fn outer_source_uses_physical_egress_not_tunnel_logical() {
+        // The WG endpoint's logical interface (wg0.0, ifindex 400) carries a
+        // TUNNEL address (10.123.0.1) and no WAN primary; the outer transport
+        // egresses on reth0.80 (ifindex 12, primary 172.16.80.8) via the route
+        // to the peer endpoint. The outer source must be the PHYSICAL WAN
+        // primary, NOT the logical tunnel address (or None).
+        let state = build_forwarding_state(&wg_outer_mtu_snapshot());
+        let endpoint = state.tunnel_endpoints.get(&1).expect("wg endpoint present");
+        let decision = wg_tunnel_decision(400, 1);
+
+        // Sanity: the logical iface's primary really is the tunnel address —
+        // sourcing from it (the bug) would leak a tunnel source / fail policy.
+        assert_eq!(
+            state.egress.get(&400).and_then(|e| e.primary_v4),
+            Some(std::net::Ipv4Addr::new(10, 123, 0, 1)),
+            "logical wg0.0 primary is the tunnel address (the wrong source)"
+        );
+
+        // The fix: resolve the physical egress (reth0.80, ifindex 12) and read
+        // its WAN primary. Reverting to `decision.resolution.egress_ifindex`
+        // (400) would read the tunnel address → this fails red.
+        let physical =
+            outer_physical_egress_ifindex(&decision, &state, endpoint, WG_PEER_OUTER_DST);
+        assert_eq!(physical, 12, "outer source must follow the PHYSICAL egress");
+        assert_eq!(
+            state.egress.get(&physical).and_then(|e| e.primary_v4),
+            Some(std::net::Ipv4Addr::new(172, 16, 80, 8)),
+            "outer source must be the PHYSICAL WAN primary (172.16.80.8), \
+             not the tunnel-logical address"
+        );
+    }
+
+    #[test]
+    fn outer_source_falls_back_to_logical_when_outer_unresolvable() {
+        // Conservative fallback parity with the MTU helper: an unresolvable
+        // outer destination falls back to the resolution's own egress_ifindex
+        // (the logical), so the source is no worse than the pre-#2701 lookup.
+        let state = build_forwarding_state(&wg_outer_mtu_snapshot());
+        let endpoint = state.tunnel_endpoints.get(&1).expect("wg endpoint present");
+        let decision = wg_tunnel_decision(400, 1);
+        let unrouted = IpAddr::V4(std::net::Ipv4Addr::new(198, 51, 100, 9));
+        assert_eq!(
+            outer_physical_egress_ifindex(&decision, &state, endpoint, unrouted),
+            400,
+            "unresolvable outer falls back to the logical egress_ifindex"
         );
     }
 

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -551,6 +551,286 @@ mod wg_frame_tests {
         );
     }
 
+    // === #2701 END-TO-END: `wg_encap_frame` writes the PHYSICAL WAN primary
+    // into the BUILT outer IP header — the call-site guard, not just the
+    // helper. ===
+    //
+    // The helper tests above prove `outer_physical_egress_ifindex` resolves
+    // the physical egress, but they do NOT call `wg_encap_frame`: reverting
+    // ONLY the call-site source lookup (back to
+    // `forwarding.egress.get(&decision.resolution.egress_ifindex)`) leaves
+    // them green. These tests close that gap by asserting on the emitted
+    // outer-IP source bytes of a real built frame, for BOTH outer families.
+
+    use crate::afxdp::wg::session::{SessionRole, WgSession};
+    use crate::afxdp::wg::{WgEngine, WgEngineConfig, WgPeerConfig};
+    use std::sync::Arc;
+
+    fn wg_keypair() -> ([u8; 32], [u8; 32]) {
+        let kp = snow::Builder::new(crate::afxdp::wg::WG_NOISE_PATTERN.parse().unwrap())
+            .generate_keypair()
+            .unwrap();
+        let mut priv_k = [0u8; 32];
+        let mut pub_k = [0u8; 32];
+        priv_k.copy_from_slice(&kp.private);
+        pub_k.copy_from_slice(&kp.public);
+        (priv_k, pub_k)
+    }
+
+    /// Build an ESTABLISHED initiator engine whose single peer's endpoint is
+    /// `peer_ep` (the real outer hop, so `peer_for_dest` returns a concrete
+    /// destination that the FIB route resolves to the physical egress) and
+    /// whose AllowedIPs cover `peer_cidr` (so the inner dst LPM-selects it).
+    /// `try_encap` succeeds because a real Noise IKpsk2 handshake is driven.
+    fn established_initiator_engine(
+        peer_ep: std::net::SocketAddr,
+        peer_cidr: &str,
+    ) -> WgEngine {
+        let (init_priv, init_pub) = wg_keypair();
+        let (resp_priv, resp_pub) = wg_keypair();
+
+        let init_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: init_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: resp_pub,
+                endpoint: Some(peer_ep),
+                persistent_keepalive: 0,
+                allowed_ips: vec![peer_cidr.parse().unwrap()],
+                preshared_key: [0u8; 32],
+            }],
+        });
+        let resp_engine = WgEngine::new(WgEngineConfig {
+            local_private_key: resp_priv,
+            listen_port: 51820,
+            peers: vec![WgPeerConfig {
+                pubkey: init_pub,
+                endpoint: None,
+                persistent_keepalive: 0,
+                allowed_ips: vec!["0.0.0.0/0".parse().unwrap()],
+                preshared_key: [0u8; 32],
+            }],
+        });
+
+        let mut init_hs = init_engine.build_initiator_handshake(&resp_pub).unwrap();
+        let mut resp_hs = resp_engine.build_responder_handshake().unwrap();
+        let mut buf = [0u8; 1024];
+        let mut sink = [0u8; 1024];
+        let n1 = init_hs.write_message(&[], &mut buf).unwrap();
+        resp_hs.read_message(&buf[..n1], &mut sink).unwrap();
+        let n2 = resp_hs.write_message(&[], &mut buf).unwrap();
+        init_hs.read_message(&buf[..n2], &mut sink).unwrap();
+        let init_xport = init_hs.into_stateless_transport_mode().unwrap();
+        let now = crate::afxdp::wg::counters::monotonic_now_ns();
+        init_engine
+            .install_session(
+                &resp_pub,
+                Arc::new(WgSession::new_with_role(
+                    init_xport,
+                    0xaaaa_0001u32,
+                    0xbbbb_0001u32,
+                    resp_pub,
+                    SessionRole::Initiator,
+                    now,
+                )),
+            )
+            .unwrap();
+        init_engine
+    }
+
+    /// A tunnel-resolved decision with the LOGICAL egress_ifindex (400, the
+    /// `wg0.0` tunnel iface — its primary is the tunnel address 10.123.0.1)
+    /// and both MACs resolved so `wg_encap_frame` builds rather than dropping
+    /// on a missing neighbor.
+    fn wg_encap_decision() -> SessionDecision {
+        let mut d = wg_tunnel_decision(400, 1);
+        d.resolution.disposition = ForwardingDisposition::ForwardCandidate;
+        d.resolution.neighbor_mac = Some([0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+        d.resolution.src_mac = Some([0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]);
+        d
+    }
+
+    /// Minimal L2/IPv4/UDP inner frame with dst in the WG peer's AllowedIPs
+    /// (10.123.0.0/24) so `peer_for_dest` selects the established peer.
+    fn inner_v4_frame() -> Vec<u8> {
+        let src_ip = std::net::Ipv4Addr::new(10, 0, 61, 50);
+        let dst_ip = std::net::Ipv4Addr::new(10, 123, 0, 9);
+        let payload = [0xabu8; 32];
+        let total_len = (20 + 8 + payload.len()) as u16;
+        let mut frame = Vec::new();
+        // eth
+        frame.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+        frame.extend_from_slice(&[0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]);
+        frame.extend_from_slice(&[0x08, 0x00]);
+        // ipv4
+        frame.extend_from_slice(&[
+            0x45, 0x00,
+            (total_len >> 8) as u8, total_len as u8,
+            0x00, 0x01, 0x00, 0x00,
+            64, PROTO_UDP, 0x00, 0x00,
+        ]);
+        frame.extend_from_slice(&src_ip.octets());
+        frame.extend_from_slice(&dst_ip.octets());
+        // udp
+        frame.extend_from_slice(&4000u16.to_be_bytes());
+        frame.extend_from_slice(&5000u16.to_be_bytes());
+        frame.extend_from_slice(&((8 + payload.len()) as u16).to_be_bytes());
+        frame.extend_from_slice(&0u16.to_be_bytes());
+        frame.extend_from_slice(&payload);
+        let ip_sum = crate::afxdp::frame::checksum::checksum16(&frame[14..34]);
+        frame[24] = (ip_sum >> 8) as u8;
+        frame[25] = ip_sum as u8;
+        frame
+    }
+
+    fn inner_v4_meta() -> ForwardPacketMeta {
+        ForwardPacketMeta {
+            l3_offset: 14,
+            l4_offset: 34,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_UDP,
+            ..ForwardPacketMeta::default()
+        }
+    }
+
+    #[test]
+    fn wg_encap_frame_sources_outer_from_physical_wan_primary_v4() {
+        // Build the real forwarding state from the shared #2680 fixture:
+        // reth0.80 (ifindex 12, primary 172.16.80.8) is the physical egress
+        // via the route to the peer endpoint (203.0.113.7); wg0.0
+        // (ifindex 400, primary 10.123.0.1) is the LOGICAL tunnel iface.
+        let mut state = build_forwarding_state(&wg_outer_mtu_snapshot());
+        // Swap in an ESTABLISHED engine (the snapshot one has no session, so
+        // try_encap would NoSession) whose peer endpoint == the fixture route
+        // target so the FIB resolves to the physical egress (ifindex 12).
+        let peer_ep: std::net::SocketAddr = "203.0.113.7:51820".parse().unwrap();
+        state
+            .wg_engines
+            .insert(1, Arc::new(established_initiator_engine(peer_ep, "10.123.0.0/24")));
+
+        let decision = wg_encap_decision();
+        let frame = inner_v4_frame();
+        let out = wg_encap_frame(&frame, inner_v4_meta(), &decision, &state)
+            .expect("wg_encap_frame must build (established session, routed peer)");
+
+        // Outer layout: eth(14) + IPv4(20). The IPv4 source is at bytes
+        // 14+12 ..= 14+15. The fix sources it from the PHYSICAL WAN primary
+        // (172.16.80.8). Reverting the call-site source lookup to the LOGICAL
+        // egress_ifindex (400) would write the tunnel address 10.123.0.1 → red.
+        let outer_src = &out[26..30];
+        assert_eq!(
+            outer_src,
+            &[172, 16, 80, 8],
+            "outer IPv4 source must be the PHYSICAL WAN primary (172.16.80.8), \
+             not the tunnel-logical address (10.123.0.1) — call-site #2701 guard"
+        );
+        // Sanity: it is NOT the logical tunnel address.
+        assert_ne!(outer_src, &[10, 123, 0, 1], "outer source must not be the tunnel addr");
+        // And the destination is the peer endpoint (203.0.113.7).
+        assert_eq!(&out[30..34], &[203, 0, 113, 7], "outer dst is the peer endpoint");
+    }
+
+    /// Minimal L2/IPv6/UDP inner frame with dst in `fd00:123::/64` so
+    /// `peer_for_dest` selects the v6-endpoint peer.
+    fn inner_v6_frame() -> Vec<u8> {
+        let src_ip: std::net::Ipv6Addr = "fd00:61::50".parse().unwrap();
+        let dst_ip: std::net::Ipv6Addr = "fd00:123::9".parse().unwrap();
+        let payload = [0xabu8; 32];
+        let payload_len = (8 + payload.len()) as u16; // UDP header + data
+        let mut frame = Vec::new();
+        // eth
+        frame.extend_from_slice(&[0x00, 0x11, 0x22, 0x33, 0x44, 0x55]);
+        frame.extend_from_slice(&[0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]);
+        frame.extend_from_slice(&[0x86, 0xdd]);
+        // ipv6: version/tc/flow, payload len, next header (UDP), hop limit
+        frame.extend_from_slice(&[0x60, 0x00, 0x00, 0x00]);
+        frame.extend_from_slice(&payload_len.to_be_bytes());
+        frame.push(PROTO_UDP);
+        frame.push(64);
+        frame.extend_from_slice(&src_ip.octets());
+        frame.extend_from_slice(&dst_ip.octets());
+        // udp
+        frame.extend_from_slice(&4000u16.to_be_bytes());
+        frame.extend_from_slice(&5000u16.to_be_bytes());
+        frame.extend_from_slice(&payload_len.to_be_bytes());
+        frame.extend_from_slice(&0u16.to_be_bytes());
+        frame.extend_from_slice(&payload);
+        frame
+    }
+
+    fn inner_v6_meta() -> ForwardPacketMeta {
+        ForwardPacketMeta {
+            l3_offset: 14,
+            l4_offset: 54,
+            addr_family: libc::AF_INET6 as u8,
+            protocol: PROTO_UDP,
+            ..ForwardPacketMeta::default()
+        }
+    }
+
+    #[test]
+    fn wg_encap_frame_sources_outer_from_physical_wan_primary_v6() {
+        // Clone the shared fixture and extend it with an IPv6 WAN primary on
+        // reth0.80 + a v6 route to a v6 peer endpoint, so the outer family is
+        // IPv6 and the physical egress (ifindex 12) carries a v6 primary
+        // (2001:559:8585:80::8) distinct from the logical wg0.0 v6 address.
+        let mut snap = wg_outer_mtu_snapshot();
+        // reth0.80 gets the WAN v6 primary; wg0.0 gets a tunnel v6 address.
+        snap.interfaces[0].addresses.push(crate::InterfaceAddressSnapshot {
+            family: "inet6".to_string(),
+            address: "2001:559:8585:80::8/64".to_string(),
+            scope: 0,
+        });
+        snap.interfaces[1].addresses.push(crate::InterfaceAddressSnapshot {
+            family: "inet6".to_string(),
+            address: "fd00:dead::1/64".to_string(),
+            scope: 0,
+        });
+        // v6 route to the peer endpoint prefix, egressing reth0.80.
+        snap.routes.push(crate::RouteSnapshot {
+            table: "inet6.0".to_string(),
+            family: "inet6".to_string(),
+            destination: "2001:db8:113::/48".to_string(),
+            next_hops: vec!["2001:559:8585:80::1@reth0.80".to_string()],
+            discard: false,
+            next_table: String::new(),
+        });
+        // The WG endpoint's transport table follows the v6 outer family.
+        snap.tunnel_endpoints[0].outer_family = "inet6".to_string();
+        snap.tunnel_endpoints[0].transport_table = "inet6.0".to_string();
+        snap.tunnel_endpoints[0].source = "2001:559:8585:80::8".to_string();
+        snap.tunnel_endpoints[0].destination = "2001:db8:113::7".to_string();
+        snap.tunnel_endpoints[0].wg_peers[0].wg_allowed_ips = vec!["fd00:123::/64".to_string()];
+        snap.tunnel_endpoints[0].wg_peers[0].wg_endpoint = "[2001:db8:113::7]:51820".to_string();
+
+        let mut state = build_forwarding_state(&snap);
+        let peer_ep: std::net::SocketAddr = "[2001:db8:113::7]:51820".parse().unwrap();
+        state
+            .wg_engines
+            .insert(1, Arc::new(established_initiator_engine(peer_ep, "fd00:123::/64")));
+
+        let decision = wg_encap_decision();
+        let frame = inner_v6_frame();
+        let out = wg_encap_frame(&frame, inner_v6_meta(), &decision, &state)
+            .expect("wg_encap_frame must build a v6 outer (established session, routed peer)");
+
+        // Outer layout: eth(14) + IPv6(40). The IPv6 source is at bytes
+        // 14+8 ..= 14+23, i.e. out[22..38]. It must be the PHYSICAL WAN v6
+        // primary. Reverting the call-site lookup to the LOGICAL ifindex (400)
+        // would write the tunnel v6 address (fd00:dead::1) → red.
+        let expected: std::net::Ipv6Addr = "2001:559:8585:80::8".parse().unwrap();
+        let tunnel_addr: std::net::Ipv6Addr = "fd00:dead::1".parse().unwrap();
+        assert_eq!(
+            &out[22..38],
+            &expected.octets(),
+            "outer IPv6 source must be the PHYSICAL WAN v6 primary, not the tunnel-logical address"
+        );
+        assert_ne!(&out[22..38], &tunnel_addr.octets());
+        // Destination is the v6 peer endpoint.
+        let dst: std::net::Ipv6Addr = "2001:db8:113::7".parse().unwrap();
+        assert_eq!(&out[38..54], &dst.octets(), "outer v6 dst is the peer endpoint");
+    }
+
     #[test]
     fn wg_mtu_guard_drops_oversize_inner() {
         // At a 1500-byte v4 outer MTU the largest inner that fits is


### PR DESCRIPTION
Closes #2701
Closes #2703

Two coupled outer-IP-header transit bugs, both in the tunnel frame builders, fixed in one PR.

## #2701 — WG transit outer SOURCE from logical tunnel ifindex
The #2680/#2683 work re-resolved the PHYSICAL underlay egress for the outer-MTU guard but the outer IP SOURCE was still read from `decision.resolution.egress_ifindex` (the LOGICAL WG tunnel ifindex). When the logical WG interface carries no WAN primary the `primary_v4?`/`primary_v6?` lookup returned `None` → dropped transit; otherwise it sourced the outer UDP from a tunnel address (breaking source-dependent policy/NAT/upstream anti-spoofing).

**Fix:** factored the MTU helper's physical-egress resolution into a shared `outer_physical_egress_ifindex` (route-looks-up the SELECTED peer endpoint in the endpoint's transport table) and use it for BOTH the MTU guard (`outer_physical_egress_mtu` now wraps it) AND the outer-source `primary_v4`/`primary_v6` lookup. Outer UDP is now sourced from the physical WAN primary. Conservative fallback unchanged: an unresolvable outer falls back to `egress_ifindex`.

## #2703 — tunnel TTL=0 sentinel not honored (outer TTL 0 blackhole)
Tunnel `TTL=0` means "use the default 64" in the Go config, and the netlink GRE path applies it (`pkg/routing/tunnel.go:686-688`). The AF_XDP transit path passed `tunnel.TTL` raw into the snapshot and the Rust frame builders write it straight into the outer IP header → a default-config tunnel emitted outer TTL 0 → deterministic first-hop blackhole.

**Fix:** apply the 0→64 default Go-side in `pkg/dataplane/userspace/tunnels.go` (the SSOT, mirroring the netlink precedent) before the value reaches the snapshot; an explicit non-zero TTL is preserved. Fail-closed backstop: `TunnelTtl::try_from_snapshot` now maps a NEGATIVE snapshot TTL to the documented default 64 rather than 0 (a value > 255 still fails the snapshot CLOSED via `TunnelTtlOutOfRange`).

## Tests (fail-on-revert)
- `outer_source_uses_physical_egress_not_tunnel_logical` — outer source resolves to the physical WAN primary (172.16.80.8); reverting to the logical ifindex reads the tunnel address (10.123.0.1) → red. Plus `outer_source_falls_back_to_logical_when_outer_unresolvable`.
- `TestBuildTunnelEndpointSnapshotsTTLDefault` (Go) — TTL=0 → 64, explicit TTL=32 preserved; raw passthrough keeps 0 → red.
- `tunnel_ttl_negative_maps_to_default_not_zero` (Rust) — negative → 64, not 0.

## Gates
- `go build ./...`, `go test ./pkg/dataplane/userspace/...`, gofmt, go vet — clean.
- `cargo build --release` — clean. `cargo test --release --bin xpf-userspace-dp`: wg_frame (9/9), tunnel_ttl (3/3), gre/frame filters — green.

## Note
WG/GRE transit is lab-bound on the loss cluster (no WG tunnel configured there); the unit tests are the gate for these fixes. A deploy-boot no-regression run is fine but won't exercise the transit encap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi