### PR TITLE
#2467: widen event-stream session ifindex/owner-RG wire fields i16 -> i32

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14272,3 +14272,41 @@ top.
   failed.
 - **File(s)**: userspace-dp/src/state_writer.rs, userspace-dp/src/FEATURES.md,
   _Log.md.
+
+## #2467 — event-stream session-event ifindex widened i16 → i32 (wire change)
+
+- **Timestamp**: 2026-06-24
+- **Action**: The userspace session-event binary wire encoded three identity
+  fields (OwnerRGID, EgressIfindex, TXIfindex) as signed 16-bit, while the Go
+  side stored them as full `int`. Linux ifindexes are a full `int` and wrap
+  negative past 32767 on long-running systems with interface churn, so a high
+  ifindex truncated/sign-flipped over the wire. Widened all three open-frame
+  fields and the close-frame OwnerRGID from i16 to i32 on the wire (LE, matching
+  the existing LittleEndian convention). This is a #1961-class WIRE change: the
+  Rust encoder (event_stream/codec.rs) and Go decoder
+  (pkg/dataplane/userspace/eventstream.go) stay byte-compatible.
+- **Layout impact**: the open frame's fixed header grew 24 → 30 bytes (+6); all
+  downstream offsets (TunnelEndpoint, TXVLAN, Flags, zone IDs, Disposition, the
+  IP block start at 24 → 30) shifted +6 on BOTH sides. The close frame's
+  OwnerRGID slot grew 2 → 4 bytes; trailing Flags + zone-id offsets shifted +2.
+  Both encoder offsets, both decoder offsets, the length/min-length guards, and
+  the codec_tests.rs + eventstream_test.go payload builders/readers updated.
+- **Tests**: Rust test_encode_session_open_high_ifindex_v4 (egress 70000, tx
+  65536, owner 40000 — all > i16/u16 limits) + test_encode_session_close_high_
+  owner_rg_v4 pin the i32 wire encode. Go TestDecodeSessionEventHighIfindex +
+  TestDecodeSessionCloseEventHighOwnerRG round-trip the high values through the
+  decoder. Fail-on-revert PROVEN: reverting the Go EgressIfindex read to i16
+  yielded `EgressIfindex = 4464` (70000 & 0xFFFF) RED; restored → GREEN.
+- **Not in scope**: the 136-byte RT_FLOW dataplane.Event payload (frame types
+  11-15) keeps its own owner_rg_id i16 slot at [64:66] and ingress_ifindex i32
+  at [128:132] — a separate layout, unchanged. The protocol_wire_v1.json
+  control-protocol fixture is JSON serde (i32 numbers), unaffected; its
+  wire_invariant_default_specimens test still passes (no regen).
+- **Gates**: cargo build --release clean; cargo test event_stream::codec → 19
+  passed/0 failed; go build ./... clean; go test ./pkg/dataplane/userspace/...
+  ok; gofmt + go vet clean.
+- **File(s)**: userspace-dp/src/event_stream/codec.rs,
+  userspace-dp/src/event_stream/codec_tests.rs,
+  pkg/dataplane/userspace/eventstream.go,
+  pkg/dataplane/userspace/eventstream_test.go, docs/session-sync-design.md,
+  _Log.md.

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -500,19 +500,19 @@ SessionOpen and SessionUpdate share the same payload:
   [4:6]   DstPort (uint16 LE)
   [6:8]   NATSrcPort (uint16 LE)
   [8:10]  NATDstPort (uint16 LE)
-  [10:12] OwnerRGID (int16 LE)
-  [12:14] EgressIfindex (int16 LE)
-  [14:16] TXIfindex (int16 LE)
-  [16:18] TunnelEndpointID (uint16 LE)
-  [18:20] TXVLANID (uint16 LE)
-  [20]    Flags (bit0=FabricRedirect, bit1=FabricIngress, bit2=IsReverse)
-  [21]    IngressZoneID (uint8)
-  [22]    EgressZoneID (uint8)
-  [23]    Disposition (uint8: 0=Accept, 1=LocalDelivery, 2=Reject, ...)
-  [24:28] SrcIP (4 bytes for v4, first 4 of 16 for v6)
-  [28:32] DstIP
-  [32:36] NATSrcIP
-  [36:40] NATDstIP
+  [10:14] OwnerRGID (int32 LE)       — #2467: widened from int16
+  [14:18] EgressIfindex (int32 LE)   — #2467: widened from int16
+  [18:22] TXIfindex (int32 LE)       — #2467: widened from int16
+  [22:24] TunnelEndpointID (uint16 LE)
+  [24:26] TXVLANID (uint16 LE)
+  [26]    Flags (bit0=FabricRedirect, bit1=FabricIngress, bit2=IsReverse)
+  [27]    IngressZoneID (uint8)
+  [28]    EgressZoneID (uint8)
+  [29]    Disposition (uint8: 0=Accept, 1=LocalDelivery, 2=Reject, ...)
+  [30:34] SrcIP (4 bytes for v4, first 4 of 16 for v6)
+  [34:38] DstIP
+  [38:42] NATSrcIP
+  [42:46] NATDstIP
   For IPv6: addresses are 16 bytes each (payload is larger)
   After addresses:
   [N:N+6]  NeighborMAC (6 bytes, zero if unresolved)
@@ -529,9 +529,21 @@ SessionClose payload is minimal:
   [4:6]   DstPort
   [6:10]  SrcIP (4 or 16 bytes)
   [10:14] DstIP (4 or 16 bytes)
-  [N:N+2] OwnerRGID (int16 LE)
-  [N+2]   Flags (bit0=FabricRedirect, bit1=FabricIngress)
+  [N:N+4] OwnerRGID (int32 LE)       — #2467: widened from int16
+  [N+4]   Flags (bit0=FabricRedirect, bit1=FabricIngress)
+  [N+5]   IngressZoneID (uint8)      — #919/#922
+  [N+6]   EgressZoneID (uint8)       — #919/#922
 ```
+
+> **#2467 (breaking wire change):** the three identity fields in the open
+> frame (`OwnerRGID`, `EgressIfindex`, `TXIfindex`) and the close frame's
+> `OwnerRGID` were widened from signed 16-bit to signed 32-bit. Linux
+> ifindexes are a full `int` and wrap negative past 32767 on long-running
+> systems with interface churn. The event-stream frame is unversioned and
+> fixed-layout, so this is NOT a rolling-upgrade-compatible change: the Rust
+> encoder (`event_stream/codec.rs`) and the Go decoder
+> (`pkg/dataplane/userspace/eventstream.go`) must be deployed together. They
+> always are — `xpfd` and the `userspace-dp` helper ship as one binary set.
 
 ### Flow Control
 

--- a/pkg/dataplane/userspace/eventstream.go
+++ b/pkg/dataplane/userspace/eventstream.go
@@ -755,7 +755,7 @@ func (es *EventStream) writeFrame(typ uint8, seq uint64, payload []byte) error {
 // decodeSessionEvent decodes a SessionOpen or SessionUpdate binary payload
 // into a SessionDeltaInfo.
 //
-// Wire layout (v4, 56 bytes):
+// Wire layout (v4, 62 bytes):
 //
 //	[0]     AddrFamily (4=v4, 6=v6)
 //	[1]     Protocol
@@ -763,19 +763,25 @@ func (es *EventStream) writeFrame(typ uint8, seq uint64, payload []byte) error {
 //	[4:6]   DstPort (uint16 LE)
 //	[6:8]   NATSrcPort (uint16 LE)
 //	[8:10]  NATDstPort (uint16 LE)
-//	[10:12] OwnerRGID (int16 LE)
-//	[12:14] EgressIfindex (int16 LE)
-//	[14:16] TXIfindex (int16 LE)
-//	[16:18] TunnelEndpointID (uint16 LE)
-//	[18:20] TXVLANID (uint16 LE)
-//	[20]    Flags
-//	[21]    IngressZoneID
-//	[22]    EgressZoneID
-//	[23]    Disposition
-//	[24..]  IPs (4 bytes each for v4, 16 each for v6): src, dst, nat_src, nat_dst
+//	[10:14] OwnerRGID (int32 LE)      — #2467: widened from int16
+//	[14:18] EgressIfindex (int32 LE)  — #2467: widened from int16
+//	[18:22] TXIfindex (int32 LE)      — #2467: widened from int16
+//	[22:24] TunnelEndpointID (uint16 LE)
+//	[24:26] TXVLANID (uint16 LE)
+//	[26]    Flags
+//	[27]    IngressZoneID
+//	[28]    EgressZoneID
+//	[29]    Disposition
+//	[30..]  IPs (4 bytes each for v4, 16 each for v6): src, dst, nat_src, nat_dst
 //	[N..]   NeighborMAC (6 bytes)
 //	[N+6..] SrcMAC (6 bytes)
 //	[N+12..]NextHop (4 or 16 bytes)
+//
+// #2467: the three identity fields at [10:22] were widened from signed
+// 16-bit to signed 32-bit. Linux ifindexes are a full `int`; with the old
+// i16 encoding an ifindex above 32767 wrapped negative. This is a breaking
+// wire-format change — the Rust encoder (event_stream/codec.rs) and this
+// decoder must be deployed together (they always are: one binary set).
 //
 // wireAFToDataplane maps the 1-byte wire encoding (4 = IPv4, 6 = IPv6
 // — chosen by the Rust codec to match the protocol number; see
@@ -793,7 +799,9 @@ func wireAFToDataplane(wire uint8) uint8 {
 }
 
 func decodeSessionEvent(payload []byte) (SessionDeltaInfo, bool) {
-	if len(payload) < 24 {
+	// #2467: fixed header is 30 bytes (was 24) after widening the three
+	// identity fields at [10:22] from int16 to int32.
+	if len(payload) < 30 {
 		return SessionDeltaInfo{}, false
 	}
 
@@ -808,13 +816,13 @@ func decodeSessionEvent(payload []byte) (SessionDeltaInfo, bool) {
 		return SessionDeltaInfo{}, false
 	}
 
-	// Fixed header (24 bytes) + 4*addrSize + 6+6 + addrSize = 24 + 5*addrSize + 12
-	minLen := 24 + 5*addrSize + 12
+	// Fixed header (30 bytes) + 4*addrSize + 6+6 + addrSize = 30 + 5*addrSize + 12
+	minLen := 30 + 5*addrSize + 12
 	if len(payload) < minLen {
 		return SessionDeltaInfo{}, false
 	}
 
-	flags := payload[20]
+	flags := payload[26]
 
 	// #919/#922: normalise the wire AF (4/6) to the dataplane AF
 	// constants (2/10) consumed by daemon_ha_userspace.go's switch.
@@ -824,34 +832,35 @@ func decodeSessionEvent(payload []byte) (SessionDeltaInfo, bool) {
 	}
 
 	d := SessionDeltaInfo{
-		AddrFamily:       dpAF,
-		Protocol:         payload[1],
-		SrcPort:          binary.LittleEndian.Uint16(payload[2:4]),
-		DstPort:          binary.LittleEndian.Uint16(payload[4:6]),
-		NATSrcPort:       binary.LittleEndian.Uint16(payload[6:8]),
-		NATDstPort:       binary.LittleEndian.Uint16(payload[8:10]),
-		OwnerRGID:        int(int16(binary.LittleEndian.Uint16(payload[10:12]))),
-		EgressIfindex:    int(int16(binary.LittleEndian.Uint16(payload[12:14]))),
-		TXIfindex:        int(int16(binary.LittleEndian.Uint16(payload[14:16]))),
-		TunnelEndpointID: binary.LittleEndian.Uint16(payload[16:18]),
-		TXVLANID:         binary.LittleEndian.Uint16(payload[18:20]),
-		// #919/#922: bytes [21]/[22] are u8 ingress/egress zone IDs
-		// written by the Rust codec at event_stream/codec.rs:144-156.
-		// Promote to uint16 for symmetry with SessionSyncRequest.
-		IngressZoneID:  uint16(payload[21]),
-		EgressZoneID:   uint16(payload[22]),
+		AddrFamily: dpAF,
+		Protocol:   payload[1],
+		SrcPort:    binary.LittleEndian.Uint16(payload[2:4]),
+		DstPort:    binary.LittleEndian.Uint16(payload[4:6]),
+		NATSrcPort: binary.LittleEndian.Uint16(payload[6:8]),
+		NATDstPort: binary.LittleEndian.Uint16(payload[8:10]),
+		// #2467: int32 LE (was int16) — ifindexes are a full Linux int.
+		OwnerRGID:        int(int32(binary.LittleEndian.Uint32(payload[10:14]))),
+		EgressIfindex:    int(int32(binary.LittleEndian.Uint32(payload[14:18]))),
+		TXIfindex:        int(int32(binary.LittleEndian.Uint32(payload[18:22]))),
+		TunnelEndpointID: binary.LittleEndian.Uint16(payload[22:24]),
+		TXVLANID:         binary.LittleEndian.Uint16(payload[24:26]),
+		// #919/#922: bytes [27]/[28] are u8 ingress/egress zone IDs
+		// written by the Rust codec. Promote to uint16 for symmetry with
+		// SessionSyncRequest. (#2467: offsets shifted +6 by the int32 widen.)
+		IngressZoneID:  uint16(payload[27]),
+		EgressZoneID:   uint16(payload[28]),
 		FabricRedirect: flags&SessionEventFlagFabricRedirect != 0,
 		FabricIngress:  flags&SessionEventFlagFabricIngress != 0,
 	}
 
 	// Disposition mapping: 0=Accept, 1=LocalDelivery
-	switch payload[23] {
+	switch payload[29] {
 	case 1:
 		d.Disposition = "local_delivery"
 	}
 
-	// IP addresses start at offset 24.
-	off := 24
+	// IP addresses start at offset 30 (#2467: was 24).
+	off := 30
 	d.SrcIP = formatIP(payload[off:off+addrSize], af)
 	off += addrSize
 	d.DstIP = formatIP(payload[off:off+addrSize], af)
@@ -883,8 +892,10 @@ func decodeSessionEvent(payload []byte) (SessionDeltaInfo, bool) {
 //	[4:6]   DstPort
 //	[6..]   SrcIP (4 or 16 bytes)
 //	[N..]   DstIP (4 or 16 bytes)
-//	[M:M+2] OwnerRGID (int16 LE)
-//	[M+2]   Flags
+//	[M:M+4] OwnerRGID (int32 LE)  — #2467: widened from int16
+//	[M+4]   Flags
+//	[M+5]   IngressZoneID (#919/#922)
+//	[M+6]   EgressZoneID (#919/#922)
 func decodeSessionCloseEvent(payload []byte) (SessionDeltaInfo, bool) {
 	if len(payload) < 6 {
 		return SessionDeltaInfo{}, false
@@ -901,10 +912,10 @@ func decodeSessionCloseEvent(payload []byte) (SessionDeltaInfo, bool) {
 		return SessionDeltaInfo{}, false
 	}
 
-	// Legacy minimum: 6 (fixed) + 2*addrSize + 2 (OwnerRGID) + 1 (Flags).
-	// New helpers append +2 (ZoneIDs); accept both for rolling upgrade.
-	legacyMin := 6 + 2*addrSize + 3
-	if len(payload) < legacyMin {
+	// Minimum: 6 (fixed) + 2*addrSize + 4 (OwnerRGID int32, #2467) + 1 (Flags).
+	// Helpers append +2 (ZoneIDs) after that; accept both lengths.
+	minLen := 6 + 2*addrSize + 5
+	if len(payload) < minLen {
 		return SessionDeltaInfo{}, false
 	}
 
@@ -925,8 +936,9 @@ func decodeSessionCloseEvent(payload []byte) (SessionDeltaInfo, bool) {
 	off += addrSize
 	d.DstIP = formatIP(payload[off:off+addrSize], af)
 	off += addrSize
-	d.OwnerRGID = int(int16(binary.LittleEndian.Uint16(payload[off : off+2])))
-	off += 2
+	// #2467: int32 LE (was int16).
+	d.OwnerRGID = int(int32(binary.LittleEndian.Uint32(payload[off : off+4])))
+	off += 4
 	flags := payload[off]
 	off++
 	d.FabricRedirect = flags&SessionEventFlagFabricRedirect != 0

--- a/pkg/dataplane/userspace/eventstream_test.go
+++ b/pkg/dataplane/userspace/eventstream_test.go
@@ -25,38 +25,39 @@ func buildSessionOpenV4Payload(
 	srcIP, dstIP [4]byte,
 	natSrcIP, natDstIP [4]byte,
 	natSrcPort, natDstPort uint16,
-	ownerRG int16,
-	egressIfindex, txIfindex int16,
+	ownerRG int32,
+	egressIfindex, txIfindex int32,
 	tunnelEndpoint, txVLAN uint16,
 	flags uint8,
 	ingressZone, egressZone, disposition uint8,
 	neighborMAC, srcMAC [6]byte,
 	nextHop [4]byte,
 ) []byte {
-	// 24 fixed + 4*4 IPs + 6+6 MACs + 4 NextHop = 56 bytes
-	buf := make([]byte, 56)
+	// #2467: 30 fixed + 4*4 IPs + 6+6 MACs + 4 NextHop = 62 bytes
+	// (the three identity fields at [10:22] are int32, not int16).
+	buf := make([]byte, 62)
 	buf[0] = 4 // AddrFamily
 	buf[1] = proto
 	binary.LittleEndian.PutUint16(buf[2:4], srcPort)
 	binary.LittleEndian.PutUint16(buf[4:6], dstPort)
 	binary.LittleEndian.PutUint16(buf[6:8], natSrcPort)
 	binary.LittleEndian.PutUint16(buf[8:10], natDstPort)
-	binary.LittleEndian.PutUint16(buf[10:12], uint16(ownerRG))
-	binary.LittleEndian.PutUint16(buf[12:14], uint16(egressIfindex))
-	binary.LittleEndian.PutUint16(buf[14:16], uint16(txIfindex))
-	binary.LittleEndian.PutUint16(buf[16:18], tunnelEndpoint)
-	binary.LittleEndian.PutUint16(buf[18:20], txVLAN)
-	buf[20] = flags
-	buf[21] = ingressZone
-	buf[22] = egressZone
-	buf[23] = disposition
-	copy(buf[24:28], srcIP[:])
-	copy(buf[28:32], dstIP[:])
-	copy(buf[32:36], natSrcIP[:])
-	copy(buf[36:40], natDstIP[:])
-	copy(buf[40:46], neighborMAC[:])
-	copy(buf[46:52], srcMAC[:])
-	copy(buf[52:56], nextHop[:])
+	binary.LittleEndian.PutUint32(buf[10:14], uint32(ownerRG))
+	binary.LittleEndian.PutUint32(buf[14:18], uint32(egressIfindex))
+	binary.LittleEndian.PutUint32(buf[18:22], uint32(txIfindex))
+	binary.LittleEndian.PutUint16(buf[22:24], tunnelEndpoint)
+	binary.LittleEndian.PutUint16(buf[24:26], txVLAN)
+	buf[26] = flags
+	buf[27] = ingressZone
+	buf[28] = egressZone
+	buf[29] = disposition
+	copy(buf[30:34], srcIP[:])
+	copy(buf[34:38], dstIP[:])
+	copy(buf[38:42], natSrcIP[:])
+	copy(buf[42:46], natDstIP[:])
+	copy(buf[46:52], neighborMAC[:])
+	copy(buf[52:58], srcMAC[:])
+	copy(buf[58:62], nextHop[:])
 	return buf
 }
 
@@ -66,22 +67,22 @@ func buildSessionCloseV4Payload(
 	proto uint8,
 	srcPort, dstPort uint16,
 	srcIP, dstIP [4]byte,
-	ownerRG int16,
+	ownerRG int32,
 	flags uint8,
 	ingressZoneID, egressZoneID uint8,
 ) []byte {
-	// 6 + 4+4 + 2 + 1 + 2 = 19 bytes
-	buf := make([]byte, 19)
+	// #2467: 6 + 4+4 + 4 (OwnerRGID int32) + 1 + 2 = 21 bytes
+	buf := make([]byte, 21)
 	buf[0] = 4 // AddrFamily
 	buf[1] = proto
 	binary.LittleEndian.PutUint16(buf[2:4], srcPort)
 	binary.LittleEndian.PutUint16(buf[4:6], dstPort)
 	copy(buf[6:10], srcIP[:])
 	copy(buf[10:14], dstIP[:])
-	binary.LittleEndian.PutUint16(buf[14:16], uint16(ownerRG))
-	buf[16] = flags
-	buf[17] = ingressZoneID
-	buf[18] = egressZoneID
+	binary.LittleEndian.PutUint32(buf[14:18], uint32(ownerRG))
+	buf[18] = flags
+	buf[19] = ingressZoneID
+	buf[20] = egressZoneID
 	return buf
 }
 
@@ -326,14 +327,93 @@ func TestDecodeSessionCloseEventV4(t *testing.T) {
 	}
 }
 
+// TestDecodeSessionEventHighIfindex is the #2467 fail-on-revert guard. Linux
+// ifindexes are a full `int` and exceed 32767 on long-running systems with
+// interface churn. The wire fields used to be int16, so an ifindex of 70000
+// truncated and decoded as a negative number. The builder writes the value via
+// the now-int32 PutUint32 path; with a revert to int16 these high values would
+// wrap negative and the assertions below fail RED.
+func TestDecodeSessionEventHighIfindex(t *testing.T) {
+	const (
+		hiOwnerRG = int32(40000) // > int16 max (32767)
+		hiEgress  = int32(70000) // > uint16 max (65535)
+		hiTX      = int32(65536) // exactly uint16 max + 1 (would be 0 as int16)
+	)
+	payload := buildSessionOpenV4Payload(
+		6,
+		12345, 443,
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		[4]byte{}, [4]byte{},
+		0, 0,
+		hiOwnerRG,
+		hiEgress, hiTX,
+		0, 80,
+		0,
+		1, 2, 0,
+		[6]byte{}, [6]byte{}, [4]byte{},
+	)
+
+	d, ok := decodeSessionEvent(payload)
+	if !ok {
+		t.Fatal("decodeSessionEvent returned false")
+	}
+	if d.OwnerRGID != int(hiOwnerRG) {
+		t.Fatalf("OwnerRGID = %d, want %d (must not wrap negative)", d.OwnerRGID, hiOwnerRG)
+	}
+	if d.EgressIfindex != int(hiEgress) {
+		t.Fatalf("EgressIfindex = %d, want %d (must not wrap negative)", d.EgressIfindex, hiEgress)
+	}
+	if d.TXIfindex != int(hiTX) {
+		t.Fatalf("TXIfindex = %d, want %d (must not wrap)", d.TXIfindex, hiTX)
+	}
+	// Downstream fields must still decode correctly after the +6-byte shift.
+	if d.TXVLANID != 80 {
+		t.Fatalf("TXVLANID = %d, want 80", d.TXVLANID)
+	}
+	if d.IngressZoneID != 1 || d.EgressZoneID != 2 {
+		t.Fatalf("ZoneIDs = (%d,%d), want (1,2)", d.IngressZoneID, d.EgressZoneID)
+	}
+}
+
+// TestDecodeSessionCloseEventHighOwnerRG is the #2467 close-side fail-on-revert
+// guard: the close frame's owner RG must survive past int16 too.
+func TestDecodeSessionCloseEventHighOwnerRG(t *testing.T) {
+	const hiOwnerRG = int32(40000) // > int16 max
+	payload := buildSessionCloseV4Payload(
+		6,
+		12345, 443,
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		hiOwnerRG,
+		SessionEventFlagFabricRedirect,
+		3, 4,
+	)
+
+	d, ok := decodeSessionCloseEvent(payload)
+	if !ok {
+		t.Fatal("decodeSessionCloseEvent returned false")
+	}
+	if d.OwnerRGID != int(hiOwnerRG) {
+		t.Fatalf("OwnerRGID = %d, want %d (must not wrap negative)", d.OwnerRGID, hiOwnerRG)
+	}
+	if d.IngressZoneID != 3 || d.EgressZoneID != 4 {
+		t.Fatalf("ZoneIDs = (%d,%d), want (3,4)", d.IngressZoneID, d.EgressZoneID)
+	}
+	if !d.FabricRedirect {
+		t.Fatal("FabricRedirect should be true")
+	}
+}
+
 func TestDecodeSessionEventRejectsTruncated(t *testing.T) {
-	// Too short for v4 (need 56 bytes minimum).
+	// Too short for v4 (#2467: need 62 bytes minimum, 30-byte fixed header).
 	_, ok := decodeSessionEvent([]byte{4, 6, 0, 0})
 	if ok {
 		t.Fatal("should reject truncated v4 payload")
 	}
-	// Invalid address family.
-	_, ok = decodeSessionEvent([]byte{99, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+	// Invalid address family (long enough to pass the length gate so the AF
+	// switch is what rejects it).
+	badAF := make([]byte, 64)
+	badAF[0] = 99
+	_, ok = decodeSessionEvent(badAF)
 	if ok {
 		t.Fatal("should reject unknown address family")
 	}

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -259,28 +259,32 @@ impl EventFrame {
         buf[pos..pos + 2].copy_from_slice(&nat.rewrite_dst_port.unwrap_or(0).to_le_bytes());
         pos += 2;
 
-        // [10:12] OwnerRGID i16 LE
-        buf[pos..pos + 2].copy_from_slice(&(metadata.owner_rg_id as i16).to_le_bytes());
-        pos += 2;
+        // [10:14] OwnerRGID i32 LE
+        // #2467: widened from i16 to i32. Linux ifindexes (the sibling fields
+        // below) are a full `int` and wrap negative past 32767 on long-running
+        // systems with interface churn; owner_rg_id is widened with them to
+        // keep the record's three identity ints a uniform 32-bit width.
+        buf[pos..pos + 4].copy_from_slice(&(metadata.owner_rg_id as i32).to_le_bytes());
+        pos += 4;
 
-        // [12:14] EgressIfindex i16 LE
-        buf[pos..pos + 2]
-            .copy_from_slice(&(decision.resolution.egress_ifindex as i16).to_le_bytes());
-        pos += 2;
+        // [14:18] EgressIfindex i32 LE (#2467)
+        buf[pos..pos + 4]
+            .copy_from_slice(&(decision.resolution.egress_ifindex as i32).to_le_bytes());
+        pos += 4;
 
-        // [14:16] TXIfindex i16 LE
-        buf[pos..pos + 2].copy_from_slice(&(decision.resolution.tx_ifindex as i16).to_le_bytes());
-        pos += 2;
+        // [18:22] TXIfindex i32 LE (#2467)
+        buf[pos..pos + 4].copy_from_slice(&(decision.resolution.tx_ifindex as i32).to_le_bytes());
+        pos += 4;
 
-        // [16:18] TunnelEndpointID u16 LE
+        // [22:24] TunnelEndpointID u16 LE
         buf[pos..pos + 2].copy_from_slice(&decision.resolution.tunnel_endpoint_id.to_le_bytes());
         pos += 2;
 
-        // [18:20] TXVLANID u16 LE
+        // [24:26] TXVLANID u16 LE
         buf[pos..pos + 2].copy_from_slice(&decision.resolution.tx_vlan_id.to_le_bytes());
         pos += 2;
 
-        // [20] Flags
+        // [26] Flags
         let mut flags: u8 = 0;
         if fabric_redirect_sync
             || decision.resolution.disposition == ForwardingDisposition::FabricRedirect
@@ -296,7 +300,7 @@ impl EventFrame {
         buf[pos] = flags;
         pos += 1;
 
-        // [21] IngressZoneID u8
+        // [27] IngressZoneID u8
         // #919/#922: SessionMetadata.ingress_zone is now u16 directly;
         // no name→id round-trip. Wire format remains u8 — assert this
         // at debug time. forwarding_build.rs:80 enforces zone IDs
@@ -311,7 +315,7 @@ impl EventFrame {
         buf[pos] = ingress_id;
         pos += 1;
 
-        // [22] EgressZoneID u8
+        // [28] EgressZoneID u8
         debug_assert!(
             metadata.egress_zone < 256,
             "zone id {} exceeds wire u8 capacity",
@@ -321,7 +325,7 @@ impl EventFrame {
         buf[pos] = egress_id;
         pos += 1;
 
-        // [23] Disposition u8
+        // [29] Disposition u8
         buf[pos] = encode_disposition(decision.resolution.disposition);
         pos += 1;
 
@@ -395,9 +399,9 @@ impl EventFrame {
         pos = write_ip(&mut buf, pos, key.src_ip, is_v6);
         pos = write_ip(&mut buf, pos, key.dst_ip, is_v6);
 
-        // OwnerRGID i16 LE
-        buf[pos..pos + 2].copy_from_slice(&(owner_rg_id as i16).to_le_bytes());
-        pos += 2;
+        // OwnerRGID i32 LE (#2467: widened from i16, see encode_session_open).
+        buf[pos..pos + 4].copy_from_slice(&owner_rg_id.to_le_bytes());
+        pos += 4;
 
         // Flags
         buf[pos] = close_flags;

--- a/userspace-dp/src/event_stream/codec_tests.rs
+++ b/userspace-dp/src/event_stream/codec_tests.rs
@@ -546,13 +546,14 @@ fn test_encode_session_open_v4() {
     assert_eq!(u16::from_le_bytes([p[4], p[5]]), 80); // DstPort
     assert_eq!(u16::from_le_bytes([p[6], p[7]]), 40000); // NATSrcPort
     assert_eq!(u16::from_le_bytes([p[8], p[9]]), 0); // NATDstPort
-    assert_eq!(i16::from_le_bytes([p[10], p[11]]), 0); // OwnerRGID
-    assert_eq!(i16::from_le_bytes([p[12], p[13]]), 3); // EgressIfindex
-    assert_eq!(i16::from_le_bytes([p[14], p[15]]), 3); // TXIfindex
-    assert_eq!(p[20], 0); // Flags (no fabric redirect, no fabric ingress)
-    assert_eq!(p[21], TEST_TRUST_ZONE_ID as u8); // IngressZoneID
-    assert_eq!(p[22], TEST_UNTRUST_ZONE_ID as u8); // EgressZoneID
-    assert_eq!(p[23], DISP_FORWARD_CANDIDATE); // Disposition
+    // #2467: OwnerRGID/EgressIfindex/TXIfindex are i32 LE at [10:14]/[14:18]/[18:22].
+    assert_eq!(i32::from_le_bytes([p[10], p[11], p[12], p[13]]), 0); // OwnerRGID
+    assert_eq!(i32::from_le_bytes([p[14], p[15], p[16], p[17]]), 3); // EgressIfindex
+    assert_eq!(i32::from_le_bytes([p[18], p[19], p[20], p[21]]), 3); // TXIfindex
+    assert_eq!(p[26], 0); // Flags (no fabric redirect, no fabric ingress)
+    assert_eq!(p[27], TEST_TRUST_ZONE_ID as u8); // IngressZoneID
+    assert_eq!(p[28], TEST_UNTRUST_ZONE_ID as u8); // EgressZoneID
+    assert_eq!(p[29], DISP_FORWARD_CANDIDATE); // Disposition
 }
 
 #[test]
@@ -597,13 +598,63 @@ fn test_encode_session_close_v4() {
     assert_eq!(u16::from_le_bytes([p[2], p[3]]), 12345); // SrcPort
     assert_eq!(u16::from_le_bytes([p[4], p[5]]), 80); // DstPort
     // p[6..10] SrcIP, p[10..14] DstIP
-    // p[14..16] OwnerRGID
-    assert_eq!(i16::from_le_bytes([p[14], p[15]]), 1);
-    // p[16] Flags
-    assert_eq!(p[16], FLAG_FABRIC_REDIRECT);
-    // #919/#922: p[17] IngressZoneID, p[18] EgressZoneID
-    assert_eq!(p[17], TEST_TRUST_ZONE_ID as u8);
-    assert_eq!(p[18], TEST_UNTRUST_ZONE_ID as u8);
+    // #2467: p[14..18] OwnerRGID (i32 LE, was i16 at [14..16]).
+    assert_eq!(i32::from_le_bytes([p[14], p[15], p[16], p[17]]), 1);
+    // p[18] Flags
+    assert_eq!(p[18], FLAG_FABRIC_REDIRECT);
+    // #919/#922: p[19] IngressZoneID, p[20] EgressZoneID
+    assert_eq!(p[19], TEST_TRUST_ZONE_ID as u8);
+    assert_eq!(p[20], TEST_UNTRUST_ZONE_ID as u8);
+}
+
+// #2467: high (>32767) ifindexes must survive the wire encode. With the old
+// i16 encoding, an ifindex of 70000 truncated to (70000 & 0xFFFF) = 4464 and,
+// once reinterpreted as i16 on decode, sign-extended to a negative value. This
+// test pins the i32 encode of the session-open identity fields so a revert to
+// i16 (which would write only 2 bytes) fails RED. The full cross-language
+// round-trip (Rust encode -> Go decode -> value preserved) is exercised by the
+// Go TestDecodeSessionEvent*HighIfindex tests in pkg/dataplane/userspace.
+#[test]
+fn test_encode_session_open_high_ifindex_v4() {
+    let zones = test_zone_map();
+    let mut decision = test_decision();
+    decision.resolution.egress_ifindex = 70000; // > i16::MAX
+    decision.resolution.tx_ifindex = 65536; // > u16::MAX (would be 0 as i16)
+    let mut metadata = test_metadata();
+    metadata.owner_rg_id = 40000; // > i16::MAX
+
+    let frame =
+        EventFrame::encode_session_open(1, &test_key_v4(), &decision, &metadata, &zones, false);
+    let p = &frame.data[FRAME_HEADER_SIZE..];
+
+    // i32 LE reads recover the exact values; an i16 encode could not.
+    assert_eq!(i32::from_le_bytes([p[10], p[11], p[12], p[13]]), 40000); // OwnerRGID
+    assert_eq!(i32::from_le_bytes([p[14], p[15], p[16], p[17]]), 70000); // EgressIfindex
+    assert_eq!(i32::from_le_bytes([p[18], p[19], p[20], p[21]]), 65536); // TXIfindex
+    // Downstream fields must still land at their shifted offsets.
+    assert_eq!(p[27], TEST_TRUST_ZONE_ID as u8); // IngressZoneID
+    assert_eq!(p[28], TEST_UNTRUST_ZONE_ID as u8); // EgressZoneID
+    assert_eq!(p[29], DISP_FORWARD_CANDIDATE); // Disposition
+}
+
+// #2467: session-close owner RG must also survive the i32 widen. The encoder
+// accepts owner_rg_id as i32; this pins the 4-byte LE wire encoding.
+#[test]
+fn test_encode_session_close_high_owner_rg_v4() {
+    let frame = EventFrame::encode_session_close(
+        2,
+        &test_key_v4(),
+        40000, // owner_rg_id > i16::MAX
+        FLAG_FABRIC_REDIRECT,
+        TEST_TRUST_ZONE_ID,
+        TEST_UNTRUST_ZONE_ID,
+    );
+    let p = &frame.data[FRAME_HEADER_SIZE..];
+    // p[6..10] SrcIP, p[10..14] DstIP, p[14..18] OwnerRGID i32 LE.
+    assert_eq!(i32::from_le_bytes([p[14], p[15], p[16], p[17]]), 40000);
+    assert_eq!(p[18], FLAG_FABRIC_REDIRECT); // Flags
+    assert_eq!(p[19], TEST_TRUST_ZONE_ID as u8); // IngressZoneID
+    assert_eq!(p[20], TEST_UNTRUST_ZONE_ID as u8); // EgressZoneID
 }
 
 #[test]


### PR DESCRIPTION
Closes #2467

## The bug

The userspace session-event binary wire protocol encoded three identity fields as **signed 16-bit**, while the Go side stored them as a full `int`:

- session-open frame (type 1): `OwnerRGID`, `EgressIfindex`, `TXIfindex`
- session-close frame (type 2): `OwnerRGID`

Linux ifindexes are a full `int` and exceed 32767 on long-running systems with interface churn. With the old i16 encoding an ifindex of 70000 truncated to `70000 & 0xFFFF = 4464` and, reinterpreted as i16 on decode, could sign-extend negative. Observability (HA session sync owner-RG, egress/tx ifindex on the synced delta) silently corrupted.

## The fix — which fields, i32 vs u32, why

Widened the four fields from i16 to **i32** on the wire (LE, matching the existing `LittleEndian` convention).

- **i32, not u32:** the Go decode target is `int`, and the existing encode used signed (`as i16` / `int16(...)`). i32 round-trips into Go's `int` with the same signedness. ifindex is positive in practice so u32 would also be defensible, but i32 keeps the Go `int` decode and the historical signedness consistent across all three fields and the shared record.
- `owner_rg_id` is small but is widened with the ifindexes so the record's three identity ints share a uniform 32-bit width.

## Wire-format change (#1961 class) — both-sides offsets updated

The event-stream frame is a **fixed-layout, unversioned** struct, so widening 3 open-frame fields from 2→4 bytes each:

- grows the open-frame fixed header **24 → 30 bytes** and shifts every downstream offset **+6** (TunnelEndpoint, TXVLAN, Flags, ingress/egress zone IDs, Disposition, and the IP block start 24 → 30).
- grows the close-frame OwnerRGID slot 2 → 4 bytes, shifting its trailing Flags + zone-id bytes **+2**.

Updated on **both sides** — Rust encoder (`event_stream/codec.rs`) and Go decoder (`pkg/dataplane/userspace/eventstream.go`): every offset, the record length, the length/min-length guards, and the `codec_tests.rs` + `eventstream_test.go` payload builders/readers. Verified the full record layout end-to-end (open: through NextHop; close: through zone IDs).

**Unversioned → must be deployed together.** This is NOT rolling-upgrade compatible. `xpfd` and the `userspace-dp` helper ship as one binary set and are always deployed together, so the breaking change is safe.

### Out of scope (unchanged)
- The 136-byte RT_FLOW `dataplane.Event` payload (frame types 11-15) keeps its own `owner_rg_id` i16 at `[64:66]` and `ingress_ifindex` i32 at `[128:132]` — a separate layout.
- `protocol_wire_v1.json` is the JSON serde control-protocol fixture (i32 numbers), unaffected by the binary wire width. Its `wire_invariant_default_specimens` test still passes — **no fixture regen needed**.

## Tests (fail-on-revert)

- **Rust** `test_encode_session_open_high_ifindex_v4` (egress 70000, tx 65536, owner 40000 — all past i16/u16 limits) + `test_encode_session_close_high_owner_rg_v4` pin the i32 wire encode and downstream offsets.
- **Go** `TestDecodeSessionEventHighIfindex` + `TestDecodeSessionCloseEventHighOwnerRG` round-trip the high values (covers both create and close). No-regression open/close v4 tests cover the normal small-ifindex case.
- **Fail-on-revert proven:** temporarily reverting the Go `EgressIfindex` read to i16 produced `EgressIfindex = 4464` (70000 & 0xFFFF) — RED; restored to i32 — GREEN.

## Gates

- `cargo build --release` clean
- `cargo test --release --bin xpf-userspace-dp event_stream::codec` → 19 passed / 0 failed
- `go build ./...` clean
- `go test ./pkg/dataplane/... ./pkg/cluster/...` ok
- `gofmt` + `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi