### PR TITLE
#2691 P2: Surface A router/interface-address DDNS over RFC 2136

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14337,3 +14337,37 @@ top.
   pkg/dataplane/userspace/eventstream.go,
   pkg/dataplane/userspace/eventstream_test.go, docs/session-sync-design.md,
   _Log.md.
+
+## 2026-06-24 — #2691 P2 Surface A (router/interface-address DDNS)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Implement #2691 phase P2 — Surface A router/interface-address
+  publish over RFC 2136, reusing the pkg/ddns spine.
+- **File(s)**:
+    - `pkg/ddns/surface_a.go` (NEW — SurfaceAManager engine:
+      change-detect/forced-refresh/backoff, self-ownership, per-RG gate,
+      durable interface-ddns-state.json), `pkg/ddns/surface_a_test.go` (NEW),
+      `pkg/ddns/state.go` (ownedRecord.AddrText), `pkg/ddns/manager_test.go`
+      (fakeUpdater.failedCalls).
+    - `pkg/config/types_system.go` (DDNSServicesConfig + DDNSProvider),
+      `pkg/config/types_interfaces.go` (InterfaceDynamicDNSConfig),
+      `pkg/config/schema_system.go` (ddnsServicesSchema),
+      `pkg/config/schema_interfaces.go` (interfaceDynamicDNSSchema),
+      `pkg/config/compiler_system.go` (compileDDNSServices/Provider),
+      `pkg/config/compiler_interfaces.go` (compileInterfaceDynamicDNS),
+      `pkg/config/compiler_validate_warn.go` (validateSurfaceADDNSWarnings),
+      `pkg/config/compiler_surface_a_ddns_test.go` (NEW).
+    - `pkg/daemon/daemon_ddns_surface_a.go` (NEW — loop + scope build +
+      AddressObserver netlink/DHCP + per-RG gate + nudges + stats),
+      `pkg/daemon/daemon_ddns_surface_a_test.go` (NEW), `daemon.go`,
+      `daemon_run.go`, `daemon_apply.go`, `daemon_ha.go`, `daemon_dhcp.go`.
+    - `pkg/api/{server,metrics,metrics_descriptors,metrics_system}.go`
+      (xpf_ddns_surface_a_* Prometheus family),
+      `pkg/grpcapi/{server,server_show,server_show_dhcp_lldp_snmp}.go`,
+      `pkg/cli/{cli,cli_show_services}.go`, `pkg/cmdtree/tree.go`,
+      `cmd/cli/show.go` (show services dynamic-dns [detail]).
+    - `docs/config-schema.md`, `pkg/ddns/README.md`, `_Log.md`.
+- **Validation**: `go build ./...` clean; gofmt/vet clean on touched files;
+  `go test ./pkg/{ddns,config,dhcpserver,daemon,api,grpcapi,cli,cmdtree}` green;
+  `-race ./pkg/ddns` green. `make test-failover` + a LIVE standalone-VM publish
+  remain MANDATORY (no cluster/VM access here) — the parent must run them.

--- a/_Log.md
+++ b/_Log.md
@@ -14371,3 +14371,39 @@ top.
   `go test ./pkg/{ddns,config,dhcpserver,daemon,api,grpcapi,cli,cmdtree}` green;
   `-race ./pkg/ddns` green. `make test-failover` + a LIVE standalone-VM publish
   remain MANDATORY (no cluster/VM access here) — the parent must run them.
+
+## 2026-06-24 — #2691 P2 review fixes (MERGE-NEEDS-MAJOR → fixed)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fix the two production-path bugs the P2 review found, both hidden
+  because the original Surface A tests used fakeUpdater instead of the real
+  rfc2136 backend.
+    - MAJOR-1: a self-owned router record could never be updated (no-DHCID
+      replace-owned refuses a pre-existing name). FIX: add
+      rfc2136Updater.selfOwned → sendAddSelfOwned, an atomic single-message
+      RFC 2136 UPDATE (RemoveRRset of our forward type + Insert new rdata).
+      newSurfaceARFC2136 sets selfOwned=true. Address change and same-address
+      forced-refresh now succeed in-place with no blackhole gap.
+    - MAJOR-2: withdraw never reached the wire (backendForOwned ignored the
+      newBackend factory; production leaves the static backend nil). FIX: Pass-1
+      address-loss withdraw resolves the live scope's backend (backendFor);
+      Pass-2 config-removal withdraw rebuilds the backend from the owned
+      record's provider (scope.PolicyID) via the provider catalog now threaded
+      into Reconcile. Reconcile signature gains the catalog arg.
+    - MINOR M1: an unresolvable withdraw counts deleteFail (not deleteOK), keeps
+      ownership for retry, and returns an error — observability no longer lies.
+  - **File(s)**: pkg/ddns/backend_rfc2136.go (selfOwned + sendAddSelfOwned),
+    pkg/ddns/surface_a.go (selfOwned wiring, Reconcile catalog arg, withdraw
+    backend resolution, counter honesty), pkg/ddns/backend_rfc2136_test.go
+    (stateful server now honors delete-RRset-of-type vs delete-name),
+    pkg/ddns/surface_a_rfc2136_test.go (NEW — 7 real-backend fail-on-revert
+    tests against the stateful fake DNS server), pkg/ddns/surface_a_test.go
+    (removed the 4 false-passing fakeUpdater tests; kept backend-agnostic
+    cadence), pkg/daemon/daemon_ddns_surface_a.go (thread the provider catalog
+    into Reconcile), pkg/ddns/README.md.
+- **Validation**: go build ./... clean; gofmt/vet clean on touched files;
+  go test ./pkg/{ddns,config,dhcpserver,daemon} green; -race ./pkg/ddns green.
+  Fail-on-revert PROVEN: reverting selfOwned → MAJOR-1 tests FAIL with
+  "owned by another party (refused)"; reverting backendForOwned/Pass-1 →
+  MAJOR-2 withdraw tests FAIL with "no live backend to withdraw". make
+  test-failover + the LIVE standalone-VM publish remain for the parent.

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -334,6 +334,12 @@ func (c *ctl) handleShowServices(args []string) error {
 				"(expected `status`)", rest[0])
 		}
 		return c.showText("application-identification-status")
+	case "dynamic-dns":
+		// #2691 P2: Surface A (router/interface-address) DDNS status.
+		if len(args) >= 2 && args[1] == "detail" {
+			return c.showText("services-dynamic-dns-detail")
+		}
+		return c.showText("services-dynamic-dns")
 	default:
 		return fmt.Errorf("unknown services target: %s", args[0])
 	}

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -663,6 +663,46 @@ reserved for whole-dataplane selection where a rewrite shim
   `pkg/ddns/scope_test.go` (ScopeKey distinctness + pre-P1b round-trip +
   independent v4/v6 + per-RG gate), `pkg/ddns/backend_bind_test.go` (dial
   config), `pkg/daemon/daemon_ddns_scope_test.go` (per-RG resolver + gate).
+- **#2691 P2 (Surface A — router/interface-address DDNS):** added the
+  operator-facing `system services dynamic-dns` provider catalog + a
+  per-interface per-family `dynamic-dns` binding so the firewall can publish its
+  OWN learned address (DHCP-lease / static / netlink) as a configured FQDN.
+  - **Provider catalog** (`services dynamic-dns provider <name>`, a repeatable
+    named instance built by `ddnsServicesSchema()` in `schema_system.go`,
+    compiled by `compileDDNSServices`/`compileDDNSProvider` in
+    `compiler_system.go` into `config.DDNSServicesConfig`/`DDNSProvider` on
+    `System.Services.DynamicDNS`): credentials configured ONCE, referenced by
+    scope. Leaves: `backend` (enum: `rfc2136` live; `dyndns2`/`cloudflare`/
+    `route53`/`generic` reserved for P3), `update-server`, `tsig-key`,
+    `tsig-algorithm`, `tsig-secret` (`config.Secret`-redacted), and the
+    `source-address` / `destination-interface` / `routing-instance` transport
+    binding (#2665, reused). Plus the engine tunables `forced-refresh` and
+    `error-backoff-max` (a Go duration like `24h` OR a bare-seconds integer,
+    parsed by `parseDurationSeconds`).
+  - **Per-interface binding** (`interfaces <if> unit <n> family <af>
+    dynamic-dns`, schema `interfaceDynamicDNSSchema()` in `schema_interfaces.go`,
+    compiled by `compileInterfaceDynamicDNS` in `compiler_interfaces.go` into
+    `InterfaceUnit.DynamicDNSInet` / `.DynamicDNSInet6`): `provider <name>`
+    (catalog reference), `hostname <fqdn>`, `address-source` (enum:
+    `interface` default | `dhcp`), `ttl`, and a per-binding `source-address`
+    override. v4 and v6 are INDEPENDENT (distinct fields), like the Surface B
+    per-family policy split (#2663).
+  - **Reuses the pkg/ddns spine** (`pkg/ddns/surface_a.go`,
+    `SurfaceAManager`): the SAME `DNSUpdater`/rfc2136 backend (self-ownership —
+    no DHCID), the SAME `ScopeKey`, and the SAME durable-state shape (a separate
+    file, `interface-ddns-state.json`). The engine adds change-detection,
+    forced-refresh (a wire floor), and per-scope error backoff. The per-RG HA
+    gate is the SAME one Surface B uses (publish only on the RG master;
+    stop-writing-never-withdraw on a partial demotion). Warn-only validation:
+    `validateSurfaceADDNSWarnings` (undefined provider, missing hostname,
+    rfc2136 provider with no update-server, P3-reserved backend). Observability:
+    `show services dynamic-dns [detail]` (CLI + gRPC), the
+    `xpf_ddns_surface_a_*` Prometheus family. Regression coverage:
+    `pkg/config/compiler_surface_a_ddns_test.go` (flat-set + hierarchical +
+    warnings), `pkg/ddns/surface_a_test.go` (change-detect / forced-refresh /
+    replace / withdraw / per-RG gate / backoff), and
+    `pkg/daemon/daemon_ddns_surface_a_test.go` (scope build + RG attribution +
+    gate).
 - **#2243 (DHCP-server static / fixed / reserved host bindings):** added a
   `static-binding <mac>` named-instance subtree under `services
   dhcp-local-server group <g> pool <p>` AND `services dhcpv6-local-server

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -81,6 +81,12 @@ type xpfCollector struct {
 	dhcpDDNSLastReconcileTs    *prometheus.Desc
 	dhcpDDNSLastReconcileN     *prometheus.Desc
 
+	// Surface A (router/interface-address) DDNS metrics (#2691 P2).
+	surfaceADDNSUpsertsTotal *prometheus.Desc
+	surfaceADDNSDeletesTotal *prometheus.Desc
+	surfaceADDNSSkippedTotal *prometheus.Desc
+	surfaceADDNSScopes       *prometheus.Desc
+
 	// System metrics
 	sysCPUUser   *prometheus.Desc
 	sysCPUSystem *prometheus.Desc
@@ -478,6 +484,10 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.dhcpDDNSOwnedRecords
 	ch <- c.dhcpDDNSLastReconcileTs
 	ch <- c.dhcpDDNSLastReconcileN
+	ch <- c.surfaceADDNSUpsertsTotal
+	ch <- c.surfaceADDNSDeletesTotal
+	ch <- c.surfaceADDNSSkippedTotal
+	ch <- c.surfaceADDNSScopes
 	ch <- c.sysCPUUser
 	ch <- c.sysCPUSystem
 	ch <- c.sysMemTotal
@@ -753,6 +763,7 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectNATPoolMetrics(ch, dp)
 	c.collectDHCPMetrics(ch)
 	c.collectDDNSMetrics(ch)
+	c.collectSurfaceADDNSMetrics(ch)
 	c.collectSystemMetrics(ch)
 	c.collectUserspaceStatus(ch, dp)
 }

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -246,6 +246,27 @@ func newCollector(srv *Server) *xpfCollector {
 			nil, nil,
 		),
 
+		surfaceADDNSUpsertsTotal: prometheus.NewDesc(
+			"xpf_ddns_surface_a_upserts_total",
+			"Total Surface A (router/interface-address) DDNS publishes by result.",
+			[]string{"result"}, nil,
+		),
+		surfaceADDNSDeletesTotal: prometheus.NewDesc(
+			"xpf_ddns_surface_a_deletes_total",
+			"Total Surface A DDNS record withdrawals by result.",
+			[]string{"result"}, nil,
+		),
+		surfaceADDNSSkippedTotal: prometheus.NewDesc(
+			"xpf_ddns_surface_a_skipped_total",
+			"Total Surface A DDNS reconcile skips by reason.",
+			[]string{"reason"}, nil,
+		),
+		surfaceADDNSScopes: prometheus.NewDesc(
+			"xpf_ddns_surface_a_scopes",
+			"Current number of Surface A DDNS records this node owns in DNS.",
+			nil, nil,
+		),
+
 		sysCPUUser: prometheus.NewDesc(
 			"xpf_system_cpu_user_percent",
 			"User CPU utilization percentage.",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -76,6 +76,35 @@ func (c *xpfCollector) collectDDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.LastReconcileN))
 }
 
+// collectSurfaceADDNSMetrics emits the xpf_ddns_surface_a_* family from the
+// Surface A (router/interface-address) DDNS manager snapshot (#2691 P2). The
+// family is omitted entirely when no SurfaceAStatsFn is wired or it returns nil
+// (NoDataplane). Label cardinality is CLOSED: result in {ok,fail}; reason in
+// {unchanged,backoff}.
+func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
+	if c.srv.surfaceAStatsFn == nil {
+		return
+	}
+	st := c.srv.surfaceAStatsFn()
+	if st == nil {
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSUpsertsTotal, prometheus.CounterValue,
+		float64(st.UpsertOK), "ok")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSUpsertsTotal, prometheus.CounterValue,
+		float64(st.UpsertFail), "fail")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSDeletesTotal, prometheus.CounterValue,
+		float64(st.DeleteOK), "ok")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSDeletesTotal, prometheus.CounterValue,
+		float64(st.DeleteFail), "fail")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSSkippedTotal, prometheus.CounterValue,
+		float64(st.Skipped), "unchanged")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSSkippedTotal, prometheus.CounterValue,
+		float64(st.BackedOff), "backoff")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSScopes, prometheus.GaugeValue,
+		float64(st.Scopes))
+}
+
 // collectFlowExportMetrics emits the xpf_flow_export_collector_* family
 // from the per-collector NetFlow v9 / IPFIX write-health snapshot
 // (#2464). The family is omitted entirely when no FlowCollectorHealthFn

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/conntrack"
+	"github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcpserver"
 	"github.com/psaab/xpf/pkg/eventengine"
@@ -126,6 +127,10 @@ type Config struct {
 	// api package does not import the manager type. Optional; if nil (or it
 	// returns nil), the family is omitted.
 	DDNSStatsFn func() *dhcpserver.DDNSStats
+	// SurfaceAStatsFn surfaces the Surface A (router/interface-address) DDNS
+	// counter snapshot for the xpf_ddns_surface_a_* metric family (#2691 P2).
+	// Optional; if nil (or it returns nil), the family is omitted.
+	SurfaceAStatsFn func() *ddns.SurfaceAStats
 	// FlowCollectorHealthFn surfaces per-collector NetFlow v9 / IPFIX
 	// write-health for the xpf_flow_export_collector_* metric family and
 	// the /flow-exporters status endpoint (#2464). Flow export is
@@ -161,6 +166,7 @@ type Server struct {
 	rpmPinFailedFn          func() float64
 	feedsFn                 func() map[string]feeds.FeedInfo
 	ddnsStatsFn             func() *dhcpserver.DDNSStats
+	surfaceAStatsFn         func() *ddns.SurfaceAStats
 	flowCollectorHealthFn   func() []flowexport.ExporterCollectorHealth
 	startTime               time.Time
 }
@@ -188,6 +194,7 @@ func NewServer(cfg Config) *Server {
 		rpmPinFailedFn:          cfg.RPMPinFailedFn,
 		feedsFn:                 cfg.FeedsFn,
 		ddnsStatsFn:             cfg.DDNSStatsFn,
+		surfaceAStatsFn:         cfg.SurfaceAStatsFn,
 		flowCollectorHealthFn:   cfg.FlowCollectorHealthFn,
 		startTime:               time.Now(),
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -17,6 +17,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/dataplane"
+	ddnspkg "github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcprelay"
 	"github.com/psaab/xpf/pkg/dhcpserver"
@@ -54,6 +55,10 @@ type CLI struct {
 	lldpNeighborsFn    func() []*lldp.Neighbor
 	ddnsStatsFn        func() *dhcpserver.DDNSStats
 	ddnsOwnedRecordsFn func() []dhcpserver.DDNSOwnedRecordView
+	// #2691 P2: Surface A (router/interface-address) DDNS status sources for
+	// `show services dynamic-dns [detail]`.
+	surfaceADDNSStatsFn  func() *ddnspkg.SurfaceAStats
+	surfaceADDNSStatusFn func() []ddnspkg.SurfaceAStatusView
 	// flowCollectorHealthFn surfaces live per-collector NetFlow v9 / IPFIX
 	// write-health for `show flow-monitoring statistics` (#2464). Nil
 	// leaves the show reporting "no flow export configured".
@@ -194,6 +199,20 @@ func (c *CLI) SetFlowCollectorHealthFn(fn func() []flowexport.ExporterCollectorH
 // dynamic-DNS records this node currently owns (#1387 inc-2).
 func (c *CLI) SetDDNSOwnedRecordsFn(fn func() []dhcpserver.DDNSOwnedRecordView) {
 	c.ddnsOwnedRecordsFn = fn
+}
+
+// SetSurfaceADDNSStatsFn sets a callback for retrieving live Surface A
+// (router/interface-address) DDNS counters (#2691 P2). Nil leaves the show
+// config-only.
+func (c *CLI) SetSurfaceADDNSStatsFn(fn func() *ddnspkg.SurfaceAStats) {
+	c.surfaceADDNSStatsFn = fn
+}
+
+// SetSurfaceADDNSStatusFn sets a callback for retrieving the Surface A DDNS
+// per-scope last-published views for `show services dynamic-dns detail` (#2691
+// P2).
+func (c *CLI) SetSurfaceADDNSStatusFn(fn func() []ddnspkg.SurfaceAStatusView) {
+	c.surfaceADDNSStatusFn = fn
 }
 
 // SetVersion sets the software version string for show version.

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -77,9 +78,90 @@ func (c *CLI) handleShowServices(args []string) error {
 				"(expected `status`)", rest[0])
 		}
 		return c.showApplicationIdentificationStatus()
+	case "dynamic-dns":
+		// #2691 P2: Surface A (router/interface-address) DDNS status.
+		detail := len(args) >= 2 && args[1] == "detail"
+		return c.showServicesDynamicDNS(detail)
 	default:
 		return fmt.Errorf("unknown services target: %s", args[0])
 	}
+}
+
+// showServicesDynamicDNS renders the Surface A (router/interface-address) DDNS
+// status: the provider catalog, runtime counters, and (detail) the per-scope
+// last-published state (#2691 P2).
+func (c *CLI) showServicesDynamicDNS(detail bool) error {
+	cfg := c.store.ActiveConfig()
+	fmt.Println("Dynamic DNS (Surface A — router/interface-address publish):")
+	if cfg != nil && cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
+		cat := cfg.System.Services.DynamicDNS
+		if len(cat.Providers) > 0 {
+			fmt.Println("  Providers:")
+			names := make([]string, 0, len(cat.Providers))
+			for n := range cat.Providers {
+				names = append(names, n)
+			}
+			sort.Strings(names)
+			for _, n := range names {
+				p := cat.Providers[n]
+				backend := p.Backend
+				if backend == "" {
+					backend = "rfc2136"
+				}
+				fmt.Printf("    %s: backend=%s update-server=%s", n, backend, p.UpdateServer)
+				if p.TSIGKeyName != "" {
+					fmt.Printf(" tsig-key=%s (secret redacted)", p.TSIGKeyName)
+				}
+				fmt.Println()
+			}
+		}
+		if cat.ForcedRefreshSeconds > 0 {
+			fmt.Printf("  Forced-refresh: %ds\n", cat.ForcedRefreshSeconds)
+		}
+		if cat.ErrorBackoffMaxSeconds > 0 {
+			fmt.Printf("  Error-backoff-max: %ds\n", cat.ErrorBackoffMaxSeconds)
+		}
+	} else {
+		fmt.Println("  No provider catalog configured")
+	}
+
+	if c.surfaceADDNSStatsFn == nil {
+		fmt.Println("\n  Runtime counters: unavailable")
+		return nil
+	}
+	st := c.surfaceADDNSStatsFn()
+	if st == nil {
+		fmt.Println("\n  Runtime counters: unavailable (manager not running)")
+		return nil
+	}
+	fmt.Println("\n  Counters:")
+	fmt.Printf("    Publishes: ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
+	fmt.Printf("    Withdraws: ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)
+	fmt.Printf("    Skipped:   unchanged=%d backoff=%d\n", st.Skipped, st.BackedOff)
+	fmt.Printf("    Published records: %d\n", st.Scopes)
+
+	if detail && c.surfaceADDNSStatusFn != nil {
+		views := c.surfaceADDNSStatusFn()
+		fmt.Println("\n  Published scopes:")
+		if len(views) == 0 {
+			fmt.Println("    none")
+		} else {
+			fmt.Printf("    %-32s %-6s %-39s %-12s %s\n", "FQDN", "Family", "Address", "Provider", "Last error")
+			for _, v := range views {
+				fam := "inet"
+				if v.Family == 6 {
+					fam = "inet6"
+				}
+				lastErr := v.LastError
+				if lastErr == "" {
+					lastErr = "-"
+				}
+				fmt.Printf("    %-32s %-6s %-39s %-12s %s\n",
+					v.FQDN, fam, v.Published, v.Provider, lastErr)
+			}
+		}
+	}
+	return nil
 }
 
 func (c *CLI) showDHCPLeases() error {

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -463,6 +463,9 @@ var OperationalTree = map[string]*Node{
 			"application-identification": {Desc: "Show application-identification (AppID) status", Children: map[string]*Node{
 				"status": {Desc: "Show AppID engine status and supported contract"},
 			}},
+			"dynamic-dns": {Desc: "Show Surface A (router/interface-address) dynamic-DNS status (#2691)", Children: map[string]*Node{
+				"detail": {Desc: "Show per-scope published Surface A DDNS records"},
+			}},
 		}},
 		"interfaces": {Desc: "Show interface information", DynamicFn: func(cfg *config.Config) []string {
 			if cfg == nil || cfg.Interfaces.Interfaces == nil {

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -383,6 +383,13 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 								unit.FilterOutputV4 = nodeVal(outputNode)
 							}
 						}
+						// Surface A router/interface-address DDNS (#2691 P2): the
+						// per-family `dynamic-dns` binding may appear as a child node
+						// (hierarchical) OR be packed into afNode's Keys (flat-set), so
+						// compileInterfaceDynamicDNS walks the whole inet subtree.
+						if ddns := compileInterfaceDynamicDNS(afNode); ddns != nil {
+							unit.DynamicDNSInet = ddns
+						}
 					case "inet6":
 						for _, addrInst := range namedInstances(afNode.FindChildren("address")) {
 							unit.Addresses = append(unit.Addresses, addrInst.name)
@@ -427,6 +434,11 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 							if outputNode := filterNode.FindChild("output"); outputNode != nil {
 								unit.FilterOutputV6 = nodeVal(outputNode)
 							}
+						}
+						// Surface A router/interface-address DDNS (#2691 P2): the
+						// per-family inet6 binding (independent of the inet binding).
+						if ddns := compileInterfaceDynamicDNS(afNode); ddns != nil {
+							unit.DynamicDNSInet6 = ddns
 						}
 						if dcNode := afNode.FindChild("dhcpv6-client"); dcNode != nil {
 							unit.DHCPv6 = true
@@ -1015,4 +1027,91 @@ func vrrpTrackConfigWarnings(cfg *Config) []string {
 		}
 	}
 	return warnings
+}
+
+// ifaceDDNSStringProps are the per-interface `dynamic-dns` leaves that carry a
+// string value (everything except the integer `ttl`). Used by
+// compileInterfaceDynamicDNS's walker to recognize a "<leaf> <value>" pair at
+// any depth regardless of the AST shape (#2691 P2).
+var ifaceDDNSStringProps = map[string]bool{
+	"provider":       true,
+	"hostname":       true,
+	"address-source": true,
+	"source-address": true,
+}
+
+// compileInterfaceDynamicDNS converts an interface family node's `dynamic-dns`
+// subtree into a typed *InterfaceDynamicDNSConfig (Surface A, #2691 P2). The
+// afNode passed in is the `family inet`/`family inet6` node; this finds the
+// `dynamic-dns` block under it (as a child node in the hierarchical shape, or
+// packed into the family node's Keys in the flat-set shape) and walks it. It
+// handles BOTH AST shapes the same way compileDHCPDynamicDNS does. Returns nil
+// when there is no dynamic-dns binding (so an interface with no Surface A
+// config compiles to a nil field — byte-for-byte today's behaviour).
+func compileInterfaceDynamicDNS(afNode *Node) *InterfaceDynamicDNSConfig {
+	// Locate the subtree root. Hierarchical: a child node named dynamic-dns.
+	// Flat-set: the token "dynamic-dns" appears inside afNode.Keys (the family
+	// node), with the binding's leaves following it / nested as children.
+	var root *Node
+	if c := afNode.FindChild("dynamic-dns"); c != nil {
+		root = c
+	} else {
+		for i, k := range afNode.Keys {
+			if k == "dynamic-dns" {
+				// Wrap the tail of the family node's Keys (from dynamic-dns on) so
+				// the walker reads them; the family node's children are walked too.
+				root = &Node{Keys: afNode.Keys[i:], Children: afNode.Children}
+				break
+			}
+		}
+	}
+	if root == nil {
+		return nil
+	}
+
+	props := map[string]string{}
+	var walk func(n *Node, isRoot bool)
+	walk = func(n *Node, isRoot bool) {
+		start := 0
+		if isRoot {
+			start = 1 // skip the "dynamic-dns" identifier itself
+		}
+		for i := start; i < len(n.Keys); i++ {
+			k := n.Keys[i]
+			switch {
+			case k == "ttl" && i+1 < len(n.Keys):
+				if _, ok := props["ttl"]; !ok {
+					props["ttl"] = n.Keys[i+1]
+				}
+				i++
+			case ifaceDDNSStringProps[k] && i+1 < len(n.Keys):
+				if _, ok := props[k]; !ok {
+					props[k] = n.Keys[i+1]
+				}
+				i++
+			}
+		}
+		for _, c := range n.Children {
+			walk(c, false)
+		}
+	}
+	walk(root, true)
+
+	d := &InterfaceDynamicDNSConfig{
+		Provider:      props["provider"],
+		Hostname:      props["hostname"],
+		AddressSource: props["address-source"],
+		SourceAddress: props["source-address"],
+	}
+	if v := props["ttl"]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			d.TTLSeconds = n
+		}
+	}
+	// Empty block -> treat as absent (no Surface A binding).
+	if d.Provider == "" && d.Hostname == "" && d.AddressSource == "" &&
+		d.SourceAddress == "" && d.TTLSeconds == 0 {
+		return nil
+	}
+	return d
 }

--- a/pkg/config/compiler_surface_a_ddns_test.go
+++ b/pkg/config/compiler_surface_a_ddns_test.go
@@ -1,0 +1,189 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2691 P2 Surface A config-model tests: the `system services dynamic-dns`
+// provider catalog + the per-interface per-family `dynamic-dns` binding compile
+// from BOTH the flat-set spelling (ParseSetCommand + SetPath, per CLAUDE.md) AND
+// the hierarchical brace form, and the dual-AST shapes compile identically.
+// Fail-on-revert: if the compiler/schema wiring is removed these go red.
+
+func TestSurfaceADDNSFlatSetCompiles(t *testing.T) {
+	tree := buildTree(t, []string{
+		// Provider catalog.
+		"set system services dynamic-dns provider corp-2136 backend rfc2136",
+		"set system services dynamic-dns provider corp-2136 update-server 192.0.2.53",
+		"set system services dynamic-dns provider corp-2136 tsig-key k1",
+		"set system services dynamic-dns provider corp-2136 tsig-algorithm hmac-sha256",
+		"set system services dynamic-dns provider corp-2136 tsig-secret c2VjcmV0",
+		"set system services dynamic-dns forced-refresh 24h",
+		"set system services dynamic-dns error-backoff-max 1h",
+		// Per-interface per-family bindings.
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns provider corp-2136",
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns hostname wan.example.net",
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns address-source dhcp",
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns ttl 300",
+		"set interfaces ge-0-0-2 unit 50 family inet6 dynamic-dns provider corp-2136",
+		"set interfaces ge-0-0-2 unit 50 family inet6 dynamic-dns hostname wan6.example.net",
+		"set interfaces ge-0-0-2 unit 50 family inet6 dynamic-dns source-address 2001:db8::8",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+
+	// Provider catalog.
+	if cfg.System.Services == nil || cfg.System.Services.DynamicDNS == nil {
+		t.Fatal("system services dynamic-dns did not compile")
+	}
+	cat := cfg.System.Services.DynamicDNS
+	if cat.ForcedRefreshSeconds != 86400 {
+		t.Fatalf("forced-refresh 24h => %ds, want 86400", cat.ForcedRefreshSeconds)
+	}
+	if cat.ErrorBackoffMaxSeconds != 3600 {
+		t.Fatalf("error-backoff-max 1h => %ds, want 3600", cat.ErrorBackoffMaxSeconds)
+	}
+	p := cat.Providers["corp-2136"]
+	if p == nil {
+		t.Fatal("provider corp-2136 not compiled")
+	}
+	if p.Backend != "rfc2136" || p.UpdateServer != "192.0.2.53" ||
+		p.TSIGKeyName != "k1" || p.TSIGAlgorithm != "hmac-sha256" || p.TSIGSecret != "c2VjcmV0" {
+		t.Fatalf("provider corp-2136 mismatch: %+v", p)
+	}
+	// The secret must be redacted in String() (logging hygiene).
+	if strings.Contains(p.String(), "c2VjcmV0") {
+		t.Fatalf("provider String() leaked the TSIG secret: %s", p.String())
+	}
+
+	// Per-interface bindings.
+	unit := cfg.Interfaces.Interfaces["ge-0-0-2"].Units[50]
+	if unit == nil {
+		t.Fatal("unit 50 not compiled")
+	}
+	if unit.DynamicDNSInet == nil {
+		t.Fatal("family inet dynamic-dns binding not compiled")
+	}
+	if unit.DynamicDNSInet.Provider != "corp-2136" ||
+		unit.DynamicDNSInet.Hostname != "wan.example.net" ||
+		unit.DynamicDNSInet.AddressSource != "dhcp" ||
+		unit.DynamicDNSInet.TTLSeconds != 300 {
+		t.Fatalf("inet binding mismatch: %+v", unit.DynamicDNSInet)
+	}
+	if unit.DynamicDNSInet6 == nil {
+		t.Fatal("family inet6 dynamic-dns binding not compiled")
+	}
+	if unit.DynamicDNSInet6.Provider != "corp-2136" ||
+		unit.DynamicDNSInet6.Hostname != "wan6.example.net" ||
+		unit.DynamicDNSInet6.SourceAddress != "2001:db8::8" {
+		t.Fatalf("inet6 binding mismatch: %+v", unit.DynamicDNSInet6)
+	}
+	// The two families are INDEPENDENT (distinct fields, not field-merged).
+	if unit.DynamicDNSInet.Hostname == unit.DynamicDNSInet6.Hostname {
+		t.Fatal("inet and inet6 bindings must be independent")
+	}
+}
+
+func TestSurfaceADDNSHierarchicalCompilesIdentically(t *testing.T) {
+	src := `system {
+  services {
+    dynamic-dns {
+      provider corp-2136 {
+        backend rfc2136;
+        update-server 192.0.2.53;
+        tsig-key k1;
+        tsig-algorithm hmac-sha256;
+        tsig-secret c2VjcmV0;
+      }
+      forced-refresh 24h;
+    }
+  }
+}
+interfaces {
+  ge-0-0-2 {
+    unit 50 {
+      family inet {
+        dynamic-dns {
+          provider corp-2136;
+          hostname wan.example.net;
+          address-source dhcp;
+          ttl 300;
+        }
+      }
+    }
+  }
+}
+`
+	hp := NewParser(src)
+	tree, perrs := hp.Parse()
+	if len(perrs) != 0 {
+		t.Fatalf("Parse(hier): %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig(hier): %v", err)
+	}
+	cat := cfg.System.Services.DynamicDNS
+	if cat == nil || cat.Providers["corp-2136"] == nil {
+		t.Fatal("hierarchical provider catalog did not compile")
+	}
+	if cat.ForcedRefreshSeconds != 86400 {
+		t.Fatalf("hier forced-refresh => %d, want 86400", cat.ForcedRefreshSeconds)
+	}
+	unit := cfg.Interfaces.Interfaces["ge-0-0-2"].Units[50]
+	if unit == nil || unit.DynamicDNSInet == nil {
+		t.Fatal("hierarchical inet binding did not compile")
+	}
+	if unit.DynamicDNSInet.Provider != "corp-2136" ||
+		unit.DynamicDNSInet.Hostname != "wan.example.net" ||
+		unit.DynamicDNSInet.AddressSource != "dhcp" ||
+		unit.DynamicDNSInet.TTLSeconds != 300 {
+		t.Fatalf("hier inet binding mismatch: %+v", unit.DynamicDNSInet)
+	}
+}
+
+func TestSurfaceADDNSAbsentCompilesToNil(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0-0-0 unit 0 family inet address 10.0.1.10/24",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
+		t.Fatal("absent system services dynamic-dns must compile to nil")
+	}
+	if u := cfg.Interfaces.Interfaces["ge-0-0-0"].Units[0]; u != nil && u.DynamicDNSInet != nil {
+		t.Fatal("absent per-interface dynamic-dns must compile to nil")
+	}
+}
+
+func TestSurfaceADDNSWarnsOnUndefinedProviderAndMissingHostname(t *testing.T) {
+	tree := buildTree(t, []string{
+		// Binding referencing a provider that is not in the catalog, and a
+		// binding missing the hostname.
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns provider ghost",
+		"set interfaces ge-0-0-2 unit 50 family inet dynamic-dns hostname wan.example.net",
+		"set interfaces ge-0-0-3 unit 0 family inet dynamic-dns provider corp-2136",
+		"set system services dynamic-dns provider corp-2136 backend rfc2136",
+		// rfc2136 provider with no update-server → warn.
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	warnings := validateSurfaceADDNSWarnings(cfg)
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "undefined provider \"ghost\"") {
+		t.Fatalf("expected undefined-provider warning, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "no hostname is set") {
+		t.Fatalf("expected missing-hostname warning, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "no update-server") {
+		t.Fatalf("expected provider-no-update-server warning, got:\n%s", joined)
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
+	"time"
 )
 
 const sharedUMEMPhase0ArtifactMaxBytes = 16 << 20
@@ -377,6 +379,17 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 				sys.Services.WebManagement.APIAuth = auth
 			}
 		}
+		// system services dynamic-dns — the Surface A provider catalog + engine
+		// tunables (#2691 P2, plan §5.9). The per-interface `dynamic-dns`
+		// bindings reference these named providers.
+		if ddnsNode := svcNode.FindChild("dynamic-dns"); ddnsNode != nil {
+			if cat := compileDDNSServices(ddnsNode); cat != nil {
+				if sys.Services == nil {
+					sys.Services = &SystemServicesConfig{}
+				}
+				sys.Services.DynamicDNS = cat
+			}
+		}
 	}
 
 	snmpNode := node.FindChild("snmp")
@@ -387,6 +400,135 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 	}
 
 	return nil
+}
+
+// ddnsProviderStringProps are the per-provider leaves that carry a string
+// value, used by compileDDNSProvider's walker to recognize a "<leaf> <value>"
+// pair at any AST depth (#2691 P2).
+var ddnsProviderStringProps = map[string]bool{
+	"backend":               true,
+	"update-server":         true,
+	"tsig-key":              true,
+	"tsig-algorithm":        true,
+	"tsig-secret":           true,
+	"source-address":        true,
+	"destination-interface": true,
+	"routing-instance":      true,
+}
+
+// compileDDNSServices compiles the `system services dynamic-dns` block into a
+// typed *DDNSServicesConfig: the named provider catalog + the engine tunables
+// (forced-refresh / error-backoff-max). Returns nil for a truly empty block so
+// a garbage/empty stanza does not materialize a catalog (#2691 P2, plan §5.9).
+func compileDDNSServices(node *Node) *DDNSServicesConfig {
+	cat := &DDNSServicesConfig{Providers: map[string]*DDNSProvider{}}
+	for _, inst := range namedInstances(node.FindChildren("provider")) {
+		p := compileDDNSProvider(inst.name, inst.node)
+		if p != nil {
+			cat.Providers[p.Name] = p
+		}
+	}
+	// Engine tunables: a duration ("24h") or a bare-seconds integer. They may
+	// appear as a child node OR packed into the block's Keys (flat-set).
+	if v := ddnsServicesScalar(node, "forced-refresh"); v != "" {
+		if s := parseDurationSeconds(v); s > 0 {
+			cat.ForcedRefreshSeconds = s
+		}
+	}
+	if v := ddnsServicesScalar(node, "error-backoff-max"); v != "" {
+		if s := parseDurationSeconds(v); s > 0 {
+			cat.ErrorBackoffMaxSeconds = s
+		}
+	}
+	if len(cat.Providers) == 0 && cat.ForcedRefreshSeconds == 0 && cat.ErrorBackoffMaxSeconds == 0 {
+		return nil
+	}
+	return cat
+}
+
+// ddnsServicesScalar finds a top-level scalar leaf value under the dynamic-dns
+// block, tolerating both the hierarchical (child node `key value`) and flat-set
+// (key+value packed into the block's Keys) AST shapes.
+func ddnsServicesScalar(node *Node, key string) string {
+	if c := node.FindChild(key); c != nil {
+		if v := nodeVal(c); v != "" {
+			return v
+		}
+	}
+	for i := 0; i+1 < len(node.Keys); i++ {
+		if node.Keys[i] == key {
+			return node.Keys[i+1]
+		}
+	}
+	return ""
+}
+
+// parseDurationSeconds parses a duration leaf as either a Go duration string
+// ("24h", "30m", "1h30m") or a bare integer count of seconds ("86400"),
+// returning whole seconds. Returns 0 for an unparseable value (the engine then
+// uses its default).
+func parseDurationSeconds(v string) int {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return n
+	}
+	if d, err := time.ParseDuration(v); err == nil {
+		return int(d.Seconds())
+	}
+	return 0
+}
+
+// compileDDNSProvider compiles one `provider <name> { ... }` entry. It walks
+// the provider subtree (both AST shapes) for its string leaves. Returns nil for
+// an empty provider block (just a name with no settings).
+func compileDDNSProvider(name string, node *Node) *DDNSProvider {
+	props := map[string]string{}
+	var walk func(n *Node, isRoot bool)
+	walk = func(n *Node, isRoot bool) {
+		start := 0
+		if isRoot {
+			// Skip the leading "provider" + "<name>" tokens. The named-instance
+			// node's Keys begin with the value (name) when packed flat-set; be
+			// conservative and skip until we are past the name.
+			for start < len(n.Keys) && (n.Keys[start] == "provider" || n.Keys[start] == name) {
+				start++
+			}
+		}
+		for i := start; i < len(n.Keys); i++ {
+			k := n.Keys[i]
+			if ddnsProviderStringProps[k] && i+1 < len(n.Keys) {
+				if _, ok := props[k]; !ok {
+					props[k] = n.Keys[i+1]
+				}
+				i++
+			}
+		}
+		for _, c := range n.Children {
+			walk(c, false)
+		}
+	}
+	walk(node, true)
+
+	p := &DDNSProvider{
+		Name:                 name,
+		Backend:              props["backend"],
+		UpdateServer:         props["update-server"],
+		TSIGKeyName:          props["tsig-key"],
+		TSIGAlgorithm:        props["tsig-algorithm"],
+		TSIGSecret:           Secret(props["tsig-secret"]),
+		SourceAddress:        props["source-address"],
+		DestinationInterface: props["destination-interface"],
+		RoutingInstance:      props["routing-instance"],
+	}
+	if p.Backend == "" && p.UpdateServer == "" && p.TSIGKeyName == "" &&
+		p.TSIGAlgorithm == "" && p.TSIGSecret == "" && p.SourceAddress == "" &&
+		p.DestinationInterface == "" && p.RoutingInstance == "" {
+		return nil
+	}
+	return p
 }
 
 func compileSystemDataplaneType(node *Node) (string, error) {

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -735,6 +735,13 @@ func ValidateConfig(cfg *Config) []string {
 	// against increment 1 cannot brick a boot (plan §4.5 / §7 Q-C).
 	warnings = append(warnings, validateDDNSBackendWarnings(cfg)...)
 
+	// #2691 P2: warn on a per-interface Surface A `dynamic-dns` binding that
+	// references a missing/incomplete provider or omits a hostname, and on a
+	// `system services dynamic-dns provider` whose rfc2136 backend is unusable.
+	// WARN-only (never a hard reject) — a previously-inert misconfig must not
+	// brick a boot; the runtime degrades to a logged no-op for that scope.
+	warnings = append(warnings, validateSurfaceADDNSWarnings(cfg)...)
+
 	// #2507: firewall-filter `then loss-priority <low|...|high>` is parsed and
 	// stored on the term (FirewallFilterTerm.LossPriority) but is never wired
 	// onto the wire (no FirewallTermSnapshot field) and the userspace dataplane
@@ -934,6 +941,110 @@ func ddnsTSIGAlgorithmSupported(algo string) bool {
 	default:
 		return false
 	}
+}
+
+// validateSurfaceADDNSWarnings emits WARN-only commit-time messages for the
+// Surface A router/interface-address DDNS bindings + provider catalog (#2691
+// P2). It never returns an error: the typed schema already accepts the leaves,
+// and a hard reject would brick a boot on a previously-inert misconfig. The
+// engine degrades safely at runtime (an unresolved provider / missing hostname
+// scope resolves to a no-op).
+func validateSurfaceADDNSWarnings(cfg *Config) []string {
+	var warnings []string
+
+	var catalog map[string]*DDNSProvider
+	if cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
+		catalog = cfg.System.Services.DynamicDNS.Providers
+	}
+
+	// Provider-catalog completeness (rfc2136 backend).
+	for name, p := range catalog {
+		if p == nil {
+			continue
+		}
+		backend := p.Backend
+		if backend == "" {
+			backend = "rfc2136"
+		}
+		switch backend {
+		case "rfc2136":
+			if p.UpdateServer == "" {
+				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+					"provider %q (backend rfc2136) has no update-server; scopes using it "+
+					"publish nothing until an update-server is set", name))
+			} else if !ddnsUpdateServerParseable(p.UpdateServer) {
+				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+					"provider %q update-server %q is not a valid host or host:port", name, p.UpdateServer))
+			}
+			keySet := p.TSIGKeyName != ""
+			secretSet := p.TSIGSecret.Reveal() != ""
+			switch {
+			case keySet && secretSet && !ddnsTSIGAlgorithmSupported(p.TSIGAlgorithm):
+				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+					"provider %q tsig-algorithm %q is not supported (use hmac-sha1/224/256/"+
+					"384/512; hmac-md5 is rejected)", name, p.TSIGAlgorithm))
+			case keySet && !secretSet:
+				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+					"provider %q tsig-key is set but tsig-secret is empty; the server will "+
+					"reject updates (BADKEY/BADSIG)", name))
+			case secretSet && !keySet:
+				warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+					"provider %q tsig-secret is set but tsig-key is empty; signing is "+
+					"disabled and the secret is ignored", name))
+			}
+		case "dyndns2", "cloudflare", "route53", "generic":
+			warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+				"provider %q backend %q is reserved for the #2691 P3 HTTP providers and is "+
+				"not yet implemented; scopes using it publish nothing", name, backend))
+		}
+	}
+
+	// Per-interface binding completeness.
+	if cfg.Interfaces.Interfaces != nil {
+		ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+		for n := range cfg.Interfaces.Interfaces {
+			ifNames = append(ifNames, n)
+		}
+		sort.Strings(ifNames)
+		for _, ifName := range ifNames {
+			ifc := cfg.Interfaces.Interfaces[ifName]
+			if ifc == nil {
+				continue
+			}
+			unitNums := make([]int, 0, len(ifc.Units))
+			for un := range ifc.Units {
+				unitNums = append(unitNums, un)
+			}
+			sort.Ints(unitNums)
+			for _, un := range unitNums {
+				unit := ifc.Units[un]
+				if unit == nil {
+					continue
+				}
+				check := func(family string, d *InterfaceDynamicDNSConfig) {
+					if d == nil {
+						return
+					}
+					loc := fmt.Sprintf("interfaces %s unit %d family %s dynamic-dns", ifName, un, family)
+					if d.Hostname == "" {
+						warnings = append(warnings, loc+": no hostname is set; nothing will be published")
+					}
+					if d.Provider == "" {
+						warnings = append(warnings, loc+": no provider is set; nothing will be published")
+					} else if catalog == nil {
+						warnings = append(warnings, fmt.Sprintf("%s references provider %q but no "+
+							"`system services dynamic-dns provider` catalog is configured", loc, d.Provider))
+					} else if _, ok := catalog[d.Provider]; !ok {
+						warnings = append(warnings, fmt.Sprintf("%s references undefined provider %q "+
+							"(define it under system services dynamic-dns provider)", loc, d.Provider))
+					}
+				}
+				check("inet", unit.DynamicDNSInet)
+				check("inet6", unit.DynamicDNSInet6)
+			}
+		}
+	}
+	return warnings
 }
 
 // validateRoutingRuleWindowWarnings emits commit-time warnings when a

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -149,6 +149,7 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 					"input":  {desc: "Input filter", args: 1, placeholder: "<filter-name>", children: nil},
 					"output": {desc: "Output filter", args: 1, placeholder: "<filter-name>", children: nil},
 				}},
+				"dynamic-dns": interfaceDynamicDNSSchema(),
 			}},
 			"inet6": {desc: "IPv6 protocol", children: map[string]*schemaNode{
 				// Compiled at compiler_interfaces.go:578 (the lower of
@@ -188,6 +189,7 @@ var schemaInterfaces = &schemaNode{desc: "Interface configuration", wildcard: &s
 					"input":  {desc: "Input filter", args: 1, placeholder: "<filter-name>", children: nil},
 					"output": {desc: "Output filter", args: 1, placeholder: "<filter-name>", children: nil},
 				}},
+				"dynamic-dns": interfaceDynamicDNSSchema(),
 				"dhcpv6-client": {desc: "DHCPv6 client", children: map[string]*schemaNode{
 					"client-type":    {desc: "Client type", args: 1, placeholder: "<type>", children: nil},
 					"client-ia-type": {desc: "Client IA type", args: 1, placeholder: "<type>", children: nil},
@@ -411,4 +413,38 @@ func wireguardSchemaNode() *schemaNode {
 			}},
 		},
 	}
+}
+
+// interfaceDynamicDNSSchema returns the config-mode schema for a per-family
+// Surface A router/interface-address DDNS binding (#2691 P2, plan §5.9):
+// `interfaces <if> unit <n> family <af> dynamic-dns { provider X; hostname Y;
+// address-source dhcp; ttl 300; }`. A fresh tree per call so the inet and inet6
+// parents do not share a mutable map. Free-form leaves (provider name,
+// hostname, source-address) stay untyped so a valid value is not rejected at
+// commit; the engine warn-validates the provider reference + binding at commit
+// (validateSurfaceADDNSWarnings) and is fail-open at runtime.
+func interfaceDynamicDNSSchema() *schemaNode {
+	return &schemaNode{desc: "Publish this interface address via Dynamic DNS (Surface A, #2691)", children: map[string]*schemaNode{
+		"provider": {desc: "system services dynamic-dns provider to publish through", args: 1, placeholder: "<provider-name>", children: nil},
+		"hostname": {desc: "FQDN to publish for this interface address", args: 1, placeholder: "<fqdn>", children: nil},
+		"address-source": {
+			desc:          "Where this interface's current address is observed",
+			args:          1,
+			valueType:     ValueEnumOf,
+			valueDesc:     "Address source (interface | dhcp)",
+			valueExamples: []string{"interface", "dhcp"},
+			validator:     ValidateEnum([]string{"interface", "dhcp"}),
+			children:      nil,
+		},
+		"ttl": {
+			desc:          "TTL (seconds) for the published A/AAAA record (default 300)",
+			args:          1,
+			valueType:     ValueInteger,
+			valueDesc:     "Record TTL in seconds (>= 1; default 300 when unset)",
+			valueExamples: []string{"300", "3600"},
+			validator:     ValidateIntegerMin(1),
+			children:      nil,
+		},
+		"source-address": {desc: "Source address to bind the UPDATE socket to (overrides the provider's)", args: 1, placeholder: "<ip>", children: nil},
+	}}
 }

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -344,6 +344,7 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 			"dynamic-dns":               dhcpDynamicDNSSchema(),
 			"expired-leases-processing": dhcpExpiredLeasesSchema(),
 		}},
+		"dynamic-dns": ddnsServicesSchema(),
 	}},
 }}
 
@@ -651,6 +652,40 @@ func dhcpDynamicDNSSchema() *schemaNode {
 			placeholder: "<instance>",
 			children:    nil,
 		},
+	}}
+}
+
+// ddnsServicesSchema returns the config-mode schema for the Surface A
+// `system services dynamic-dns` provider catalog + engine tunables (#2691 P2,
+// plan §5.9). The `provider <name>` block is a repeatable named instance
+// (credentials configured once, referenced by per-interface bindings). The
+// backend enum is validated (rfc2136 live; dyndns2/cloudflare/route53/generic
+// reserved for P3); credentials stay free-form (a valid base64 secret / host
+// is not rejected at commit — the live backend is warn-validated at commit and
+// fail-open at runtime). forced-refresh / error-backoff-max accept a Go
+// duration ("24h") or a bare-seconds integer.
+func ddnsServicesSchema() *schemaNode {
+	return &schemaNode{desc: "Dynamic DNS provider catalog + engine tunables (Surface A, #2691)", children: map[string]*schemaNode{
+		"provider": {desc: "Named DDNS provider", args: 1, placeholder: "<provider-name>", children: map[string]*schemaNode{
+			"backend": {
+				desc:          "DNS-update backend (rfc2136 is live; dyndns2/cloudflare/route53/generic are reserved for P3)",
+				args:          1,
+				valueType:     ValueEnumOf,
+				valueDesc:     "Update backend (rfc2136 [live] | dyndns2 | cloudflare | route53 | generic [P3])",
+				valueExamples: []string{"rfc2136"},
+				validator:     ValidateEnum([]string{"rfc2136", "dyndns2", "cloudflare", "route53", "generic"}),
+				children:      nil,
+			},
+			"update-server":         {desc: "Authoritative DNS target for RFC 2136 updates (host[:port])", args: 1, placeholder: "<host[:port]>", children: nil},
+			"tsig-key":              {desc: "TSIG key name for authenticated updates", args: 1, placeholder: "<key-name>", children: nil},
+			"tsig-algorithm":        {desc: "TSIG algorithm (e.g. hmac-sha256)", args: 1, placeholder: "<algorithm>", children: nil},
+			"tsig-secret":           {desc: "TSIG shared secret (sensitive; redacted in show output)", args: 1, placeholder: "<secret>", children: nil},
+			"source-address":        {desc: "Source address to bind the UPDATE socket to (#2665)", args: 1, placeholder: "<ip>", children: nil},
+			"destination-interface": {desc: "Egress interface to pin the UPDATE to (SO_BINDTODEVICE, #2665)", args: 1, placeholder: "<interface>", children: nil},
+			"routing-instance":      {desc: "Routing instance / VRF the UPDATE egresses from (#2665)", args: 1, placeholder: "<instance>", children: nil},
+		}},
+		"forced-refresh":    {desc: "Wire-update floor for an unchanged address (duration, e.g. 24h, or seconds; default 24h)", args: 1, placeholder: "<duration>", children: nil},
+		"error-backoff-max": {desc: "Cap for the per-scope error backoff (duration, e.g. 1h, or seconds; default 1h)", args: 1, placeholder: "<duration>", children: nil},
 	}}
 }
 

--- a/pkg/config/types_interfaces.go
+++ b/pkg/config/types_interfaces.go
@@ -64,6 +64,39 @@ type InterfaceUnit struct {
 	FilterOutputV6   string                // family inet6 { filter { output NAME; } }
 	VRRPGroups       map[string]*VRRPGroup // keyed by address (CIDR), each address can have VRRP groups
 	Tunnel           *TunnelConfig         // per-unit tunnel config (for multi-unit GRE/IPIP)
+	// DynamicDNSInet / DynamicDNSInet6 are the per-family Surface A
+	// router/interface-address DDNS bindings (#2691 P2, plan §5.9): publish
+	// THIS interface unit's learned v4 / v6 address as a configured FQDN through
+	// a referenced `system services dynamic-dns provider`. nil == no Surface A
+	// publish for that family. The two families are INDEPENDENT (a v4 record can
+	// go to one provider, the v6 record to another), so they are distinct
+	// fields, matching the per-family Surface B policy split (#2663).
+	DynamicDNSInet  *InterfaceDynamicDNSConfig // family inet  { dynamic-dns ... }
+	DynamicDNSInet6 *InterfaceDynamicDNSConfig // family inet6 { dynamic-dns ... }
+}
+
+// InterfaceDynamicDNSConfig is one per-interface, per-family Surface A DDNS
+// binding (#2691 P2, plan §5.9). It says "publish this interface unit's learned
+// address (for this family) as Hostname, via the named Provider, observing the
+// address from AddressSource". The Provider references a
+// `system services dynamic-dns provider <name>` catalog entry (credentials +
+// backend + transport configured once there).
+type InterfaceDynamicDNSConfig struct {
+	// Provider is the name of the `system services dynamic-dns provider` catalog
+	// entry this binding publishes through. Required (a binding with no provider
+	// publishes nothing and warns at commit).
+	Provider string
+	// Hostname is the absolute FQDN to publish (e.g. wan.example.net). Required.
+	Hostname string
+	// AddressSource selects where the unit's current address is observed:
+	// "interface" (netlink / static, default) or "dhcp" (the DHCP client lease).
+	AddressSource string
+	// TTLSeconds is the published record TTL (0 == engine default, 300).
+	TTLSeconds int
+	// SourceAddress optionally binds the UPDATE socket's source IP for THIS
+	// binding (overrides the provider's source-address when set). Free-form IP
+	// literal; fail-open at runtime.
+	SourceAddress string
 }
 
 // VRRPGroup defines a VRRP (Virtual Router Redundancy Protocol) group.

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -192,6 +192,80 @@ type SystemServicesConfig struct {
 	WebManagement      *WebManagementConfig
 	DNSEnabled         bool // system services dns
 	DNSProxyConfigured bool // system services dns dns-proxy (syntax accepted, runtime no-op)
+	// DynamicDNS is the `system services dynamic-dns` provider catalog + engine
+	// tunables (#2691 P2, plan §5.9). It is the OPERATOR-FACING shared catalog
+	// the per-interface Surface A `dynamic-dns` bindings reference by name
+	// (credentials configured once, referenced by scope). nil == no Surface A
+	// DDNS configured.
+	DynamicDNS *DDNSServicesConfig
+}
+
+// DDNSServicesConfig is the `system services dynamic-dns` block (#2691 P2,
+// plan §5.9): a named provider catalog (referenced by per-interface Surface A
+// bindings) plus the global engine tunables (the inadyn period/forced-update
+// analogues). nil == no Surface A DDNS configured (Surface B's DHCP-lease DDNS
+// is unaffected — it keeps its inline stanza under dhcp-local-server).
+type DDNSServicesConfig struct {
+	// Providers is the named provider catalog, keyed by provider name. A
+	// per-interface `dynamic-dns provider <name>` binding references one of
+	// these entries (credentials + transport binding configured once here).
+	Providers map[string]*DDNSProvider
+	// ForcedRefreshSeconds is the wire-update FLOOR for an unchanged address
+	// (inadyn idea #7, plan §5.5): the engine re-asserts desired state every
+	// reconcile but sends a wire UPDATE for an unchanged address at most once
+	// per this interval. 0 == the engine default (24h).
+	ForcedRefreshSeconds int
+	// ErrorBackoffMaxSeconds caps the per-scope flat error backoff (inadyn idea
+	// #8, plan §5.5): a failing provider is not hammered at the poll cadence
+	// (ban-avoidance). 0 == the engine default (1h).
+	ErrorBackoffMaxSeconds int
+}
+
+// DDNSProvider is one named entry in the `system services dynamic-dns provider`
+// catalog (#2691 P2, plan §5.2/§5.9). It carries the backend selection, the
+// credentials (config.Secret-redacted), and the per-provider transport binding
+// (source/interface/VRF). P2 implements the rfc2136 backend; the HTTP backends
+// (dyndns2/cloudflare/route53/generic) are reserved enum values that P3
+// implements (an unimplemented backend publishes nothing and warns at commit).
+type DDNSProvider struct {
+	// Name is the provider identity (the `provider <name>` token), used by
+	// per-interface bindings to reference this catalog entry.
+	Name string
+	// Backend selects the DNS-update mechanism. "rfc2136" (default, live in P2)
+	// publishes over RFC 2136 UPDATE. "dyndns2" / "cloudflare" / "route53" /
+	// "generic" are reserved for P3 (the HTTP providers).
+	Backend string
+	// UpdateServer is the RFC 2136 target authoritative DNS, host or host:port.
+	UpdateServer string
+	// TSIGKeyName / TSIGAlgorithm / TSIGSecret are the TSIG credentials for
+	// authenticated RFC 2136 updates. TSIGSecret is the sensitive HMAC key,
+	// redacted by the Secret type on every marshal and by String() below.
+	TSIGKeyName   string
+	TSIGAlgorithm string
+	TSIGSecret    Secret
+	// SourceAddress / DestinationInterface / RoutingInstance scope the RFC 2136
+	// UPDATE TRANSPORT for this provider (the same source-binding model as the
+	// Surface B per-family leaves, #2665). All optional.
+	SourceAddress        string
+	DestinationInterface string
+	RoutingInstance      string
+}
+
+// String redacts TSIGSecret so a %v/%s/slog format of a DDNSProvider never
+// leaks the shared HMAC key (logging hygiene, mirrors DHCPDynamicDNSConfig).
+func (p *DDNSProvider) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	secret := ""
+	if p.TSIGSecret != "" {
+		secret = "<redacted>"
+	}
+	return fmt.Sprintf("DDNSProvider{name=%q backend=%q update-server=%q "+
+		"tsig-key=%q tsig-alg=%q tsig-secret=%q source-address=%q "+
+		"destination-interface=%q routing-instance=%q}",
+		p.Name, p.Backend, p.UpdateServer, p.TSIGKeyName, p.TSIGAlgorithm,
+		secret, p.SourceAddress, p.DestinationInterface, p.RoutingInstance)
 }
 
 // SSHServiceConfig holds SSH service settings.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -20,6 +20,7 @@ import (
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/conntrack"
 	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcprelay"
 	"github.com/psaab/xpf/pkg/dhcpserver"
@@ -102,6 +103,20 @@ type Daemon struct {
 	// loop) so a hung DNS server can never wedge the loop or starve the
 	// nudge channel.
 	ddnsReconcileInFlight atomic.Bool
+	// surfaceA is the always-on Surface A router/interface-address DDNS manager
+	// (#2691 P2). It publishes THIS firewall's own learned interface addresses
+	// (DHCP-lease / static / netlink) as configured FQDNs through the
+	// `system services dynamic-dns` provider catalog, reusing the pkg/ddns
+	// spine (the same Backend, record, ScopeKey, durable-state primitives). It
+	// is constructed unconditionally so a binding removal always has a running
+	// loop to withdraw; the loop is netlink + DNS-network only (no control
+	// socket), gated to the RG-MASTER per scope, nudged on commit + the #1844
+	// DHCP gateway/address-change hook + MASTER transition.
+	surfaceA *ddns.SurfaceAManager
+	// surfaceAReconcileNowCh / surfaceAReconcileInFlight mirror the ddns* pair:
+	// a depth-1 nudge channel + a no-freeze skip-if-in-flight guard.
+	surfaceAReconcileNowCh    chan struct{}
+	surfaceAReconcileInFlight atomic.Bool
 	// #2239 HA DHCP-server lease sync (PATH C). The push loop runs on the
 	// RG-MASTER, reads the active lease set (Kea control socket → memfile
 	// fallback), and replicates it over the cluster sync channel. The standby
@@ -495,6 +510,7 @@ func New(opts Options) (*Daemon, error) {
 		blackholeRoutes:            make(map[int][]netlink.Route),
 		reconcileNowCh:             make(chan struct{}, 1),
 		ddnsReconcileNowCh:         make(chan struct{}, 1),
+		surfaceAReconcileNowCh:     make(chan struct{}, 1),
 		dhcpLeaseSyncNowCh:         make(chan struct{}, 1),
 		syncReadyTimeout:           5 * time.Second,
 		linkByNameFn:               netlink.LinkByName,

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1088,6 +1088,9 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	// file I/O + DNS only), so it never blocks the apply path. A
 	// disabled/removed block drives withdrawAllLocked on the next pass.
 	d.nudgeDDNSReconcile()
+	// #2691 P2: a commit may add/remove a Surface A binding or change a
+	// provider — nudge the Surface A loop to converge immediately too.
+	d.nudgeSurfaceADDNSReconcile()
 
 	// #2239: nudge an immediate lease-sync push so a commit that changes the
 	// DHCP-server config (and thus the lease set / serving interfaces) is

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -1,0 +1,394 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"net/netip"
+	"time"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/ddns"
+	"github.com/psaab/xpf/pkg/dhcp"
+)
+
+// daemon_ddns_surface_a.go: the Surface A (router/interface-address) DDNS
+// reconcile loop + the address-observation layer + the per-RG HA gate (#2691
+// P2, plan §5.3/§5.5/§5.6).
+//
+// This MIRRORS the Surface B lease loop (daemon_ddns.go): an always-on guarded
+// background goroutine, 30s cadence + nudge, per-pass context timeout. It does
+// NETLINK + DHCP-client-lease reads + DNS network only — it NEVER touches the
+// userspace-helper control socket (the CLAUDE.md rule), so it cannot starve
+// session installs or status polls.
+//
+// The engine itself lives in pkg/ddns (SurfaceAManager). This file supplies the
+// three daemon-owned seams the engine cannot reach into: the SCOPE LIST (from
+// the committed per-interface bindings + the provider catalog), the ADDRESS
+// OBSERVER (netlink / pkg/dhcp.LeaseFor), and the per-RG HA GATE
+// (snapshotRethMasterState). Keeping these out of pkg/ddns is the same
+// dependency-inversion the LeaseParser seam uses for Surface B.
+
+const (
+	// surfaceAReconcileInterval is the Surface A poll cadence. Like the lease
+	// loop it is far above the 1/s control-socket throttle (which it never
+	// touches). Address changes are immediate via the nudge channel (the #1844
+	// DHCP gateway/address-change hook + commit + MASTER takeover).
+	surfaceAReconcileInterval = 30 * time.Second
+	// surfaceAReconcileTimeout bounds one whole Surface A reconcile pass.
+	surfaceAReconcileTimeout = 60 * time.Second
+)
+
+// runSurfaceADDNSReconcileLoop is the supervised Surface A reconcile loop. It
+// runs for the daemon's lifetime (joined via wg) and exits on ctx cancel.
+func (d *Daemon) runSurfaceADDNSReconcileLoop(ctx context.Context) {
+	if d.surfaceA == nil {
+		return
+	}
+	// Immediate first pass so a restart re-publishes / withdraws without
+	// waiting a full tick (the durable store + current addresses drive it).
+	d.runGuardedSurfaceADDNSReconcile(ctx)
+
+	ticker := time.NewTicker(surfaceAReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.runGuardedSurfaceADDNSReconcile(ctx)
+		case <-d.surfaceAReconcileNowCh:
+			d.runGuardedSurfaceADDNSReconcile(ctx)
+		}
+	}
+}
+
+// runGuardedSurfaceADDNSReconcile dispatches one pass into a guarded goroutine
+// (skip-if-in-flight), mirroring the lease loop — a hung DNS server leaks at
+// most one goroutine and the loop keeps servicing ctx + the nudge channel.
+func (d *Daemon) runGuardedSurfaceADDNSReconcile(ctx context.Context) {
+	if d.surfaceA == nil {
+		return
+	}
+	if !d.surfaceAReconcileInFlight.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer d.surfaceAReconcileInFlight.Store(false)
+		d.reconcileSurfaceAOnce(ctx)
+	}()
+}
+
+// reconcileSurfaceAOnce runs one Surface A reconcile pass under the node-level
+// HA writer gate fast-path (the same one the lease loop uses). When the gate is
+// CLOSED (BACKUP for all RGs) the node STOPS writing entirely — but it does NOT
+// withdraw valid records (the peer MASTER owns them and keeps them fresh; a
+// withdraw would blackhole, plan §5.6). The per-scope gate below makes the
+// publish decision PER RG so a node MASTER for one RG and BACKUP for another
+// publishes only its own RG's records.
+func (d *Daemon) reconcileSurfaceAOnce(ctx context.Context) {
+	if d.surfaceA == nil {
+		return
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	if !d.ddnsWriterGateOpen() {
+		slog.Debug("ddns surface-a: skipping reconcile — node is not MASTER for any RG")
+		return
+	}
+	scopes := d.buildSurfaceAScopes(cfg)
+	rctx, cancel := context.WithTimeout(ctx, surfaceAReconcileTimeout)
+	defer cancel()
+	observe := d.surfaceAObserver(cfg)
+	gate := d.surfaceAGate()
+	if err := d.surfaceA.Reconcile(rctx, scopes, observe, gate); err != nil {
+		slog.Warn("ddns surface-a: reconcile pass had errors (retrying next cycle)", "err", err)
+	}
+}
+
+// buildSurfaceAScopes walks the committed interfaces and materializes one
+// ddns.SurfaceAScope per per-interface per-family `dynamic-dns` binding (#2691
+// P2, plan §5.9). It resolves the referenced provider-catalog entry, applies a
+// per-binding source-address override, and attributes the scope to its owning
+// redundancy group (so the per-RG HA gate keys on it). A binding with no
+// hostname or an unresolved provider is SKIPPED (the commit warning already
+// told the operator; runtime degrades to nothing for that scope).
+func (d *Daemon) buildSurfaceAScopes(cfg *config.Config) []ddns.SurfaceAScope {
+	if cfg == nil || cfg.Interfaces.Interfaces == nil {
+		return nil
+	}
+	var catalog map[string]*config.DDNSProvider
+	var forced, backoff time.Duration
+	if cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
+		dd := cfg.System.Services.DynamicDNS
+		catalog = dd.Providers
+		if dd.ForcedRefreshSeconds > 0 {
+			forced = time.Duration(dd.ForcedRefreshSeconds) * time.Second
+		}
+		if dd.ErrorBackoffMaxSeconds > 0 {
+			backoff = time.Duration(dd.ErrorBackoffMaxSeconds) * time.Second
+		}
+	}
+
+	var out []ddns.SurfaceAScope
+	add := func(ifName string, ifc *config.InterfaceConfig, un int, family ddns.Family, b *config.InterfaceDynamicDNSConfig) {
+		if b == nil {
+			return
+		}
+		if b.Hostname == "" || b.Provider == "" {
+			return
+		}
+		prov, ok := catalog[b.Provider]
+		if !ok || prov == nil {
+			slog.Debug("ddns surface-a: binding references undefined provider; skipping",
+				"iface", ifName, "unit", un, "family", int(family), "provider", b.Provider)
+			return
+		}
+		// A per-binding source-address overrides the provider's default.
+		p := *prov
+		if b.SourceAddress != "" {
+			p.SourceAddress = b.SourceAddress
+		}
+		src := ddns.AddressSourceInterface
+		if b.AddressSource == string(ddns.AddressSourceDHCP) {
+			src = ddns.AddressSourceDHCP
+		}
+		ttl := b.TTLSeconds
+		key := ddns.ScopeKey{
+			Family:          family,
+			Interface:       ifName,
+			Unit:            un,
+			RoutingInstance: prov.RoutingInstance,
+			RGOwner:         ifc.RedundancyGroup,
+			PolicyID:        b.Provider,
+		}
+		out = append(out, ddns.SurfaceAScope{
+			Key:             key,
+			FQDN:            b.Hostname,
+			TTL:             ttl,
+			Source:          src,
+			Provider:        &p,
+			ForcedRefresh:   forced,
+			ErrorBackoffMax: backoff,
+		})
+	}
+
+	for ifName, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
+		for un, unit := range ifc.Units {
+			if unit == nil {
+				continue
+			}
+			add(ifName, ifc, un, ddns.FamilyV4, unit.DynamicDNSInet)
+			add(ifName, ifc, un, ddns.FamilyV6, unit.DynamicDNSInet6)
+		}
+	}
+	return out
+}
+
+// surfaceAObserver builds the AddressObserver for one reconcile pass (plan
+// §5.3). It observes a scope's CURRENT address per its configured source:
+//
+//   - dhcp:      pkg/dhcp.Manager.LeaseFor(linuxIfName, af) — the authoritative
+//     learned WAN address (fed by the #1844 gateway-change hook as a nudge).
+//   - interface: netlink address on the bound interface/unit/family, falling
+//     back to the configured static address — covers static + DHCP-applied +
+//     PD-derived + reth/VIP addresses.
+//
+// ok=false (returned by the engine's contract) means "could not observe this
+// cycle" (transient) — the engine then leaves the scope untouched (no withdraw
+// on a transient, the never-blackhole rule). A valid-but-Invalid Addr means
+// "definitively no address" (interface down / lease gone) — the engine
+// withdraws.
+func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
+	return func(scope ddns.SurfaceAScope) (ddns.AddressObservation, bool) {
+		ifName := scope.Key.Interface
+		un := scope.Key.Unit
+		af4 := scope.Key.Family == ddns.FamilyV4
+		var unit *config.InterfaceUnit
+		if ifc, ok := cfg.Interfaces.Interfaces[ifName]; ok && ifc != nil {
+			unit = ifc.Units[un]
+		}
+		linuxName := surfaceALinuxIfName(cfg, ifName, unit)
+
+		switch scope.Source {
+		case ddns.AddressSourceDHCP:
+			if d.dhcp == nil {
+				return ddns.AddressObservation{}, false
+			}
+			af := dhcp.AFInet
+			if !af4 {
+				af = dhcp.AFInet6
+			}
+			lease := d.dhcp.LeaseFor(linuxName, af)
+			if lease == nil {
+				// No lease for this family yet: definitively no address. Withdraw
+				// any previously-published record (the lease is gone).
+				return ddns.AddressObservation{Source: ddns.AddressSourceDHCP}, true
+			}
+			a := lease.Address.Addr().Unmap()
+			if !a.IsValid() {
+				return ddns.AddressObservation{Source: ddns.AddressSourceDHCP}, true
+			}
+			return ddns.AddressObservation{Addr: a, Source: ddns.AddressSourceDHCP}, true
+
+		default: // interface
+			a, ok := d.observeInterfaceAddr(linuxName, af4, unit)
+			if !ok {
+				// netlink read failed (transient): leave the scope untouched.
+				return ddns.AddressObservation{}, false
+			}
+			return ddns.AddressObservation{Addr: a, Source: ddns.AddressSourceInterface}, true
+		}
+	}
+}
+
+// surfaceALinuxIfName maps a configured interface/unit to the kernel device
+// name the address lives on. RETH names resolve to the local physical member;
+// the unit's VLAN id appends a ".<vlan>" sub-interface suffix (the same
+// derivation pkg/dhcp keys its leases on, DHCPLeaseIfName).
+func surfaceALinuxIfName(cfg *config.Config, ifName string, unit *config.InterfaceUnit) string {
+	resolved := ifName
+	if cfg != nil {
+		resolved = cfg.ResolveReth(ifName)
+	}
+	return config.DHCPLeaseIfName(resolved, unit)
+}
+
+// observeInterfaceAddr reads the current global-scope address of the given
+// family on a kernel interface via netlink, falling back to the unit's
+// configured static address. Returns (zero, true) when the interface exists but
+// has no usable address of that family (definitively none → the engine
+// withdraws); (zero, false) when the interface cannot be read (transient → the
+// engine leaves the scope untouched).
+func (d *Daemon) observeInterfaceAddr(linuxName string, af4 bool, unit *config.InterfaceUnit) (netip.Addr, bool) {
+	link, err := netlink.LinkByName(linuxName)
+	if err != nil {
+		// Interface not present yet (rename pending / not up): transient.
+		if a, ok := staticUnitAddr(unit, af4); ok {
+			return a, true
+		}
+		return netip.Addr{}, false
+	}
+	family := netlink.FAMILY_V4
+	if !af4 {
+		family = netlink.FAMILY_V6
+	}
+	addrs, err := netlink.AddrList(link, family)
+	if err != nil {
+		if a, ok := staticUnitAddr(unit, af4); ok {
+			return a, true
+		}
+		return netip.Addr{}, false
+	}
+	best := netip.Addr{}
+	for _, ad := range addrs {
+		ip, ok := netip.AddrFromSlice(ad.IP)
+		if !ok {
+			continue
+		}
+		ip = ip.Unmap()
+		// Skip link-local / loopback / unspecified — Surface A publishes a
+		// globally meaningful address only (the inadyn validity gate, plan §3.2).
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			ip.IsMulticast() || ip.IsUnspecified() {
+			continue
+		}
+		if af4 != ip.Is4() {
+			continue
+		}
+		// Prefer the first global address (deterministic; netlink returns a
+		// stable order). A more specific selection (primary flag) is a P3
+		// refinement.
+		best = ip
+		break
+	}
+	if best.IsValid() {
+		return best, true
+	}
+	// No global netlink address: fall back to a configured static address.
+	if a, ok := staticUnitAddr(unit, af4); ok {
+		return a, true
+	}
+	// Interface is up but has no address of this family: definitively none.
+	return netip.Addr{}, true
+}
+
+// staticUnitAddr returns the first configured static address of the given
+// family on a unit (CIDR → bare addr), if any.
+func staticUnitAddr(unit *config.InterfaceUnit, af4 bool) (netip.Addr, bool) {
+	if unit == nil {
+		return netip.Addr{}, false
+	}
+	for _, cidr := range unit.Addresses {
+		p, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			continue
+		}
+		a := p.Addr().Unmap()
+		if a.Is4() != af4 {
+			continue
+		}
+		if a.IsLoopback() || a.IsLinkLocalUnicast() || a.IsUnspecified() {
+			continue
+		}
+		return a, true
+	}
+	return netip.Addr{}, false
+}
+
+// surfaceAGate builds the per-RG HA writer gate for one reconcile pass (#2664,
+// plan §5.6). It REUSES the same per-RG master snapshot the lease loop uses. A
+// scope on an RG-owned (reth) interface is writable IFF this node is MASTER for
+// that RG; an RG 0 scope (a non-HA interface) is admitted (the node-level
+// writer gate already authorized the pass; no peer to double-write). Standalone
+// (no cluster) returns nil so the engine admits every scope.
+func (d *Daemon) surfaceAGate() ddns.ScopeGate {
+	if d.cluster == nil {
+		return nil
+	}
+	master := d.snapshotRethMasterState()
+	return func(s ddns.ScopeKey) bool {
+		if s.RGOwner == 0 {
+			return true
+		}
+		return master[s.RGOwner]
+	}
+}
+
+// nudgeSurfaceADDNSReconcile requests an immediate Surface A reconcile pass
+// (config commit / DHCP address change / MASTER takeover). Non-blocking depth-1
+// send: coalesces a burst into one pending wakeup.
+func (d *Daemon) nudgeSurfaceADDNSReconcile() {
+	if d.surfaceAReconcileNowCh == nil {
+		return
+	}
+	select {
+	case d.surfaceAReconcileNowCh <- struct{}{}:
+	default:
+	}
+}
+
+// SurfaceAStats returns the Surface A counter snapshot for the API collector /
+// show command, or nil when the manager is not constructed (NoDataplane).
+func (d *Daemon) SurfaceAStats() *ddns.SurfaceAStats {
+	if d.surfaceA == nil {
+		return nil
+	}
+	st := d.surfaceA.Stats()
+	return &st
+}
+
+// SurfaceAStatus returns the per-scope last-published views for `show` (the
+// operator surface, plan §5.5). Empty when the manager is absent.
+func (d *Daemon) SurfaceAStatus() []ddns.SurfaceAStatusView {
+	if d.surfaceA == nil {
+		return nil
+	}
+	return d.surfaceA.StatusViews()
+}

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -104,7 +104,15 @@ func (d *Daemon) reconcileSurfaceAOnce(ctx context.Context) {
 	defer cancel()
 	observe := d.surfaceAObserver(cfg)
 	gate := d.surfaceAGate()
-	if err := d.surfaceA.Reconcile(rctx, scopes, observe, gate); err != nil {
+	// The provider catalog lets the engine REBUILD the publish backend to
+	// withdraw a removed-binding record (#2691 P2 MAJOR-2) — the owned record
+	// carries only the provider NAME (scope.PolicyID), so the live credentials/
+	// server come from the still-committed catalog.
+	var catalog map[string]*config.DDNSProvider
+	if cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
+		catalog = cfg.System.Services.DynamicDNS.Providers
+	}
+	if err := d.surfaceA.Reconcile(rctx, scopes, observe, gate, catalog); err != nil {
 		slog.Warn("ddns surface-a: reconcile pass had errors (retrying next cycle)", "err", err)
 	}
 }

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -1,0 +1,134 @@
+package daemon
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/ddns"
+)
+
+// #2691 P2 daemon-level Surface A tests: scope construction from the committed
+// per-interface bindings + provider catalog (with RG attribution), and the
+// per-RG HA gate. Fail-on-revert: prove a binding resolves to a scoped publish
+// record and that an HA-owned (reth) interface scope is keyed on its RG.
+
+func TestBuildSurfaceAScopesFromConfig(t *testing.T) {
+	store := testStoreWithSetConfig(t, []string{
+		"set system services dynamic-dns provider corp-2136 backend rfc2136",
+		"set system services dynamic-dns provider corp-2136 update-server 192.0.2.53",
+		"set system services dynamic-dns forced-refresh 24h",
+		"set interfaces ge-0/0/2 unit 50 family inet dynamic-dns provider corp-2136",
+		"set interfaces ge-0/0/2 unit 50 family inet dynamic-dns hostname wan.example.net",
+		"set interfaces ge-0/0/2 unit 50 family inet dynamic-dns address-source dhcp",
+		"set interfaces ge-0/0/2 unit 50 family inet6 dynamic-dns provider corp-2136",
+		"set interfaces ge-0/0/2 unit 50 family inet6 dynamic-dns hostname wan6.example.net",
+		// A binding whose provider is undefined must be skipped.
+		"set interfaces ge-0/0/3 unit 0 family inet dynamic-dns provider ghost",
+		"set interfaces ge-0/0/3 unit 0 family inet dynamic-dns hostname ghost.example.net",
+	})
+	d := &Daemon{store: store}
+	cfg := d.store.ActiveConfig()
+	scopes := d.buildSurfaceAScopes(cfg)
+
+	byFQDN := map[string]ddns.SurfaceAScope{}
+	for _, s := range scopes {
+		byFQDN[s.FQDN] = s
+	}
+	if _, ok := byFQDN["ghost.example.net"]; ok {
+		t.Fatal("a binding referencing an undefined provider must be skipped")
+	}
+	v4, ok := byFQDN["wan.example.net"]
+	if !ok {
+		t.Fatalf("inet binding scope missing; got %d scopes", len(scopes))
+	}
+	if v4.Key.Family != ddns.FamilyV4 || v4.Key.Interface != "ge-0/0/2" || v4.Key.Unit != 50 {
+		t.Fatalf("inet scope key mismatch: %+v", v4.Key)
+	}
+	if v4.Source != ddns.AddressSourceDHCP {
+		t.Fatalf("inet scope source = %q, want dhcp", v4.Source)
+	}
+	if v4.Provider == nil || v4.Provider.UpdateServer != "192.0.2.53" {
+		t.Fatalf("inet scope provider not resolved: %+v", v4.Provider)
+	}
+	if v4.ForcedRefresh.Hours() != 24 {
+		t.Fatalf("forced-refresh not threaded into the scope: %v", v4.ForcedRefresh)
+	}
+	v6, ok := byFQDN["wan6.example.net"]
+	if !ok {
+		t.Fatal("inet6 binding scope missing")
+	}
+	if v6.Key.Family != ddns.FamilyV6 {
+		t.Fatalf("inet6 scope family mismatch: %+v", v6.Key)
+	}
+	if v4.Source == ddns.AddressSourceInterface {
+		t.Fatal("inet scope should be dhcp, not interface default")
+	}
+}
+
+func TestBuildSurfaceAScopesAttributesRG(t *testing.T) {
+	store := testStoreWithSetConfig(t, []string{
+		"set chassis cluster cluster-id 1",
+		"set chassis cluster node 0",
+		"set chassis cluster redundancy-group 1 node 0 priority 200",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set interfaces ge-0/0/0 gigether-options redundant-parent reth0",
+		"set system services dynamic-dns provider corp-2136 backend rfc2136",
+		"set system services dynamic-dns provider corp-2136 update-server 192.0.2.53",
+		"set interfaces reth0 unit 80 family inet dynamic-dns provider corp-2136",
+		"set interfaces reth0 unit 80 family inet dynamic-dns hostname vip.example.net",
+	})
+	d := &Daemon{store: store, cluster: cluster.NewManager(0, 1)}
+	cfg := d.store.ActiveConfig()
+	scopes := d.buildSurfaceAScopes(cfg)
+	if len(scopes) != 1 {
+		t.Fatalf("expected one reth scope, got %d", len(scopes))
+	}
+	if scopes[0].Key.RGOwner != 1 {
+		t.Fatalf("a reth0 (RG1) binding must attribute RGOwner=1, got %d", scopes[0].Key.RGOwner)
+	}
+}
+
+func TestSurfaceAGatePerRG(t *testing.T) {
+	d := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(0, 1),
+	}
+	// No RG is master yet → an RG1 scope is gated CLOSED; an RG0 (non-HA)
+	// scope is always admitted.
+	gate := d.surfaceAGate()
+	if gate == nil {
+		t.Fatal("cluster daemon must produce a per-RG gate")
+	}
+	if gate(ddns.ScopeKey{RGOwner: 1}) {
+		t.Fatal("RG1 scope must be gated closed when not master for RG1")
+	}
+	if !gate(ddns.ScopeKey{RGOwner: 0}) {
+		t.Fatal("RG0 (non-HA) scope must be admitted")
+	}
+}
+
+func TestSurfaceAStandaloneGateNil(t *testing.T) {
+	d := &Daemon{} // no cluster
+	if d.surfaceAGate() != nil {
+		t.Fatal("standalone daemon must return a nil gate (every scope writable)")
+	}
+}
+
+func TestStaticUnitAddr(t *testing.T) {
+	unit := &config.InterfaceUnit{Addresses: []string{"203.0.113.5/24", "2001:db8::8/64"}}
+	a4, ok := staticUnitAddr(unit, true)
+	if !ok || a4 != netip.MustParseAddr("203.0.113.5") {
+		t.Fatalf("v4 static addr = %v ok=%v", a4, ok)
+	}
+	a6, ok := staticUnitAddr(unit, false)
+	if !ok || a6 != netip.MustParseAddr("2001:db8::8") {
+		t.Fatalf("v6 static addr = %v ok=%v", a6, ok)
+	}
+	// Link-local / loopback are skipped.
+	llUnit := &config.InterfaceUnit{Addresses: []string{"fe80::1/64"}}
+	if _, ok := staticUnitAddr(llUnit, false); ok {
+		t.Fatal("link-local must not be selected as a Surface A address")
+	}
+}

--- a/pkg/daemon/daemon_dhcp.go
+++ b/pkg/daemon/daemon_dhcp.go
@@ -71,6 +71,11 @@ func buildDHCPClientSpecs(cfg *config.Config) []dhcp.ClientSpec {
 // DHCP manager. It re-enters applyConfig, which is why the client
 // reconcile must key on config identity only — see reconcileDHCPClients.
 func (d *Daemon) onDHCPAddressChange() {
+	// #2691 P2: a DHCP-learned address change on a WAN interface is the prime
+	// Surface A republish trigger (the #1844 hook fires this). Nudge the
+	// Surface A loop so a new lease address is republished within one pass
+	// (the engine's change-detection then decides whether a wire UPDATE fires).
+	d.nudgeSurfaceADDNSReconcile()
 	// Full recompile is safe: heartbeat sockets survive VRF rebind
 	// (RestartHeartbeat), RETH MAC is set live (no XSK rebind), and
 	// BPF compile skips reconcile when the binding plan is unchanged.

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -1005,6 +1005,9 @@ func (d *Daemon) applyRethServicesForRG(rgID int) {
 	// leases and only adds on the next cycle — it never deletes on the
 	// strength of a not-yet-written lease (daemon_ddns.go nudge note).
 	d.nudgeDDNSReconcile()
+	// #2691 P2: a MASTER takeover changes which RG scopes this node may
+	// publish for Surface A too — nudge it to (re)publish its RG records.
+	d.nudgeSurfaceADDNSReconcile()
 }
 
 // clearRethServicesForRG withdraws RA senders and stops DHCP server only
@@ -1070,6 +1073,9 @@ func (d *Daemon) clearRethServicesForRG(rgID int) {
 	// nudge is benign if it races the async Kea re-apply: a too-early pass sees
 	// the unchanged store and only the gate state matters for the demoted RG.
 	d.nudgeDDNSReconcile()
+	// #2691 P2: a partial demotion changes the per-RG Surface A gate too —
+	// nudge so the demoted RG's scopes stop publishing (never withdraw).
+	d.nudgeSurfaceADDNSReconcile()
 }
 
 // filterDHCPConfigForMasterRGs returns a DHCP config containing only groups

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcprelay"
 	"github.com/psaab/xpf/pkg/dhcpserver"
@@ -449,6 +450,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// mode is harmless. The live rfc2136 backend is resolved per-Reconcile
 		// from the current policy.
 		d.ddns = dhcpserver.NewProductionDDNSManager(ddnsNodeIDSeed())
+		// #2691 P2: the always-on Surface A manager (router/interface-address
+		// publish). Constructed unconditionally for the same reason as the lease
+		// manager — a binding removal must have a running loop to withdraw.
+		d.surfaceA = ddns.NewSurfaceAManager()
 	}
 
 	// Create the RPM manager eagerly so the pointer is stable for the
@@ -1106,6 +1111,18 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}()
 	}
 
+	// #2691 P2: start the always-on Surface A (router/interface-address) DDNS
+	// reconcile loop. Same lifecycle + control-socket-free + per-RG-gated
+	// discipline as the lease loop above; it reads netlink + the DHCP client
+	// lease set and publishes the firewall's own addresses.
+	if !d.opts.NoDataplane && d.surfaceA != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.runSurfaceADDNSReconcileLoop(ctx)
+		}()
+	}
+
 	// Start VRRP event watcher (manager was created earlier, before applyConfig).
 	// Uses context.Background() — the watcher must outlive daemon ctx cancel
 	// so it can process VRRP BACKUP events during shutdown (rg_active cleanup).
@@ -1218,7 +1235,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// #1387 inc-2: DHCP dynamic-DNS counters for the
 			// xpf_dhcp_ddns_* metric family. Returns nil when the
 			// manager is absent (NoDataplane), omitting the family.
-			DDNSStatsFn: d.DDNSStats,
+			DDNSStatsFn:     d.DDNSStats,
+			SurfaceAStatsFn: d.SurfaceAStats,
 			// #2464: per-collector NetFlow v9 / IPFIX write-health for the
 			// xpf_flow_export_collector_* family + /services/flow-exporters.
 			FlowCollectorHealthFn: d.FlowCollectorHealth,
@@ -1331,8 +1349,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 			},
 			// #1387 inc-2: DHCP dynamic-DNS status sources for the
 			// `show ... dhcp-server dynamic-dns` ShowText topics.
-			DDNSStatsFn:        d.DDNSStats,
-			DDNSOwnedRecordsFn: d.OwnedDDNSRecords,
+			DDNSStatsFn:          d.DDNSStats,
+			SurfaceADDNSStatsFn:  d.SurfaceAStats,
+			SurfaceADDNSStatusFn: d.SurfaceAStatus,
+			DDNSOwnedRecordsFn:   d.OwnedDDNSRecords,
 			// #2464: per-collector NetFlow v9 / IPFIX write-health for
 			// `show services flow-monitoring statistics`.
 			FlowCollectorHealthFn: d.FlowCollectorHealth,
@@ -1455,6 +1475,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 		// #1387 inc-2: DHCP dynamic-DNS status hooks for the in-process CLI.
 		shell.SetDDNSStatsFn(d.DDNSStats)
 		shell.SetDDNSOwnedRecordsFn(d.OwnedDDNSRecords)
+		shell.SetSurfaceADDNSStatsFn(d.SurfaceAStats)
+		shell.SetSurfaceADDNSStatusFn(d.SurfaceAStatus)
 		shell.SetFlowCollectorHealthFn(d.FlowCollectorHealth)
 		shell.SetVRRPManager(d.vrrpMgr)
 		shell.SetFabricPeer(func() []string {

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -137,12 +137,35 @@ its OWN learned address — on top of the SAME spine, without forking the engine
 - **`SurfaceAManager` (`surface_a.go`)** — a separate manager from the
   DHCP-lease `Manager` (different ownership semantics: self-owned, no DHCID; and
   a different durable state file, `interface-ddns-state.json`), but it drives the
-  SAME `DNSUpdater` interface, the SAME RFC 2136 backend (`newRFC2136Updater`
-  with `conflict-policy=replace-owned` and no `ClientID`, so `sendAddOwned` uses
-  the name-not-in-use / refresh-owned prerequisite — the self-ownership claim),
+  SAME `DNSUpdater` interface, the SAME RFC 2136 backend (`newRFC2136Updater`),
   the SAME `ScopeKey` ownership primitive, the SAME source/VRF binding
   (`backend_bind.go`, via `DHCPDynamicDNSConfig` as the transport carrier), and
   the SAME write-ahead durability discipline.
+- **Self-owned forward ADD = atomic in-place replace** (`rfc2136Updater.selfOwned`
+  → `sendAddSelfOwned`). A router record has NO DHCID (the firewall IS the
+  authoritative owner of its OWN configured FQDN). The lease path's two
+  prerequisites — name-not-in-use (Attempt A) and DHCID-match (Attempt B) — both
+  REFUSE a pre-existing name when there is no DHCID, which would pin a self-record
+  at its first address forever (the #2691 P2 MAJOR-1 bug). So a self-owned
+  forward add is a SINGLE RFC 2136 UPDATE that, in one message, `RemoveRRset`s our
+  forward type at our name (CLASS=ANY, our type only — co-resident records of a
+  DIFFERENT type are never touched) and `Insert`s the new rdata. The server
+  applies both atomically: a same-address forced-refresh deletes-then-re-adds the
+  identical RR (a no-op net change that SUCCEEDS), and an address change replaces
+  the rdata with NO withdraw-then-add blackhole gap. (Third-party case: the
+  firewall owns the name; two firewalls pointed at the same self-record FQDN is an
+  operator misconfig — the per-RG HA gate prevents the in-cluster two-writer case.)
+- **Withdraw rebuilds the live backend** (the #2691 P2 MAJOR-2 fix). An
+  address-loss withdraw (Pass 1) resolves the backend from the live
+  `SurfaceAScope` (`backendFor`); a config-removal withdraw (Pass 2, where the
+  binding — and thus the scope — is gone) REBUILDS the same backend the publish
+  used by looking the owned record's provider (`scope.PolicyID`) up in the
+  still-committed provider catalog passed into `Reconcile` (`backendForOwned` →
+  `newBackend`). Production sets only `newBackend` (not the static `backend`
+  field), so a withdraw that ignored `newBackend` would no-op and ORPHAN the RR —
+  the bug this fixes. If the provider is also gone from the catalog the withdraw
+  cannot reach the wire: it counts `deleteFail`, keeps ownership for retry, and
+  surfaces an error (never a false `deleteOK`).
 - **What the engine ADDS over the lease reconciler** (the inadyn ideas the
   DHCP-lease path does not need, plan §3.3/§5.5):
   - **change detection + last-published cache** — a wire UPDATE fires only when
@@ -156,7 +179,7 @@ its OWN learned address — on top of the SAME spine, without forking the engine
     (30s → cap, default 1h) so a failing provider is not hammered (ban-avoidance).
   - **replace, never withdraw-then-add, on address change** — a scope owns
     exactly ONE record (keyed `{scope, "router-self", ""}`); an address change is
-    an idempotent replace-owned re-add of the new rdata (no blackhole gap).
+    the atomic self-owned in-place replace described above (no blackhole gap).
 - **Ownership key.** A router record is keyed on its SCOPE + the fixed identity
   `router-self` + Address `""` (the published address lives in the new
   `ownedRecord.AddrText` field, JSON-omitted for lease records). So an interface
@@ -173,6 +196,15 @@ its OWN learned address — on top of the SAME spine, without forking the engine
 - **Operator surfaces:** `show services dynamic-dns [detail]` (CLI + gRPC), the
   `xpf_ddns_surface_a_*` Prometheus family, and `SurfaceAManager.StatusViews()`
   (per-scope published address + last-published time + last error).
+- **Tests through the REAL backend.** The self-owned replace, forced-refresh,
+  and both withdraw paths are proven in `surface_a_rfc2136_test.go` against the
+  stateful in-process fake DNS server (the `backend_rfc2136_test.go` harness) with
+  PRODUCTION wiring (`newBackend` set, static `backend` nil) — asserting the
+  actual zone state + the actual wire DELETE. `fakeUpdater` (`surface_a_test.go`)
+  is kept only for backend-agnostic engine cadence (publish-once, skip-unchanged,
+  forced-refresh-fires, transient-no-withdraw, backoff, status), because it models
+  neither RFC 2136 prerequisites nor the production `newBackend` wiring and so
+  cannot catch the two MAJORs above.
 
 P3 (the rest of #2679) adds the HTTP provider backends
 (dyndns2/Cloudflare/Route53/generic-template) + the checkip address source;

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -128,3 +128,53 @@ project rule for any gate / HA-path change). P1b adds the gate + the
 partial-demotion nudge; reason about split-brain (uncertain RG → fail-closed)
 and partial demotion (lose one RG, keep another → publish only the kept RG,
 withdraw nothing) in `scope_test.go` / `daemon_ddns_scope_test.go`.
+
+## Phase P2 — Surface A (router/interface-address publish)
+
+P2 (partial **#2679**) adds the SECOND publish surface — the firewall publishing
+its OWN learned address — on top of the SAME spine, without forking the engine.
+
+- **`SurfaceAManager` (`surface_a.go`)** — a separate manager from the
+  DHCP-lease `Manager` (different ownership semantics: self-owned, no DHCID; and
+  a different durable state file, `interface-ddns-state.json`), but it drives the
+  SAME `DNSUpdater` interface, the SAME RFC 2136 backend (`newRFC2136Updater`
+  with `conflict-policy=replace-owned` and no `ClientID`, so `sendAddOwned` uses
+  the name-not-in-use / refresh-owned prerequisite — the self-ownership claim),
+  the SAME `ScopeKey` ownership primitive, the SAME source/VRF binding
+  (`backend_bind.go`, via `DHCPDynamicDNSConfig` as the transport carrier), and
+  the SAME write-ahead durability discipline.
+- **What the engine ADDS over the lease reconciler** (the inadyn ideas the
+  DHCP-lease path does not need, plan §3.3/§5.5):
+  - **change detection + last-published cache** — a wire UPDATE fires only when
+    the observed address changed (or the forced-refresh floor elapsed). The
+    cache is seeded from the durable store on restart (`seedFromStore`) so a
+    restart does not blast a redundant update.
+  - **forced-refresh** — a per-scope wire-update FLOOR (default 24h) decoupled
+    from the 30s reconcile cadence, to prove liveness / resist record reaping
+    without per-poll traffic.
+  - **flat error backoff** — on a transient failure a scope backs off
+    (30s → cap, default 1h) so a failing provider is not hammered (ban-avoidance).
+  - **replace, never withdraw-then-add, on address change** — a scope owns
+    exactly ONE record (keyed `{scope, "router-self", ""}`); an address change is
+    an idempotent replace-owned re-add of the new rdata (no blackhole gap).
+- **Ownership key.** A router record is keyed on its SCOPE + the fixed identity
+  `router-self` + Address `""` (the published address lives in the new
+  `ownedRecord.AddrText` field, JSON-omitted for lease records). So an interface
+  unit/family owns at most one record and an address change replaces it in place.
+- **Address observation** is the daemon's job (`pkg/daemon/daemon_ddns_surface_a.go`):
+  `AddressObserver` reads netlink (interface source) or `pkg/dhcp.LeaseFor` (dhcp
+  source). `ok=false` (transient read failure) → leave the scope untouched
+  (never withdraw); a valid-but-Invalid `Addr` (interface down / lease gone) →
+  withdraw. Keeping observation in the daemon keeps `pkg/ddns` free of
+  netlink/DHCP deps, exactly like the `LeaseParser` seam for Surface B.
+- **HA gate** is the SAME per-RG `ScopeGate` (a router record on a reth/virtual
+  interface publishes only on the RG master; stop-writing-never-withdraw
+  otherwise). Standalone (nil gate) always publishes.
+- **Operator surfaces:** `show services dynamic-dns [detail]` (CLI + gRPC), the
+  `xpf_ddns_surface_a_*` Prometheus family, and `SurfaceAManager.StatusViews()`
+  (per-scope published address + last-published time + last error).
+
+P3 (the rest of #2679) adds the HTTP provider backends
+(dyndns2/Cloudflare/Route53/generic-template) + the checkip address source;
+`productionSurfaceABackend` already routes an unknown backend to the no-op
+(logged) so a P3-only provider config does not wedge P2.

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -127,6 +127,20 @@ type rfc2136Updater struct {
 	// backend is safe). Empty ⇒ no DHCID (name-not-in-use guard only).
 	dhcidClientID string
 
+	// selfOwned marks a backend that publishes the FIREWALL'S OWN records
+	// (Surface A router/interface-address publish, #2691 P2), as opposed to a
+	// DHCP-lease record claimed on behalf of a client. A self-owned record has
+	// no DHCID (the firewall IS the authoritative owner of its configured FQDN),
+	// so the forward ADD is an atomic IN-PLACE REPLACE of OUR record type at OUR
+	// name — `sendAddSelfOwned` — rather than the lease path's name-not-in-use /
+	// DHCID-match prerequisite. This is what makes an address change and a
+	// forced-refresh of an existing self-record succeed (the lease path would
+	// refuse the pre-existing name, since with no DHCID it has no "matches our
+	// prior value" branch). A self-owned add NEVER touches a co-resident record
+	// of a DIFFERENT type at the name, and NEVER issues a delete-RRset/delete-
+	// name for anything but its own forward type (exact-RR discipline preserved).
+	selfOwned bool
+
 	client dnsExchanger // *dns.Client in production; recorder in tests
 
 	// counters surfaced to the manager via the reason-tagged skip path.
@@ -588,6 +602,15 @@ func dhcidRR(clientID, fqdn string, ttl uint32) (*dns.DHCID, bool) {
 //     third party's RR (#2660).
 //   - strict-fail: same prerequisite, surface the collision as an error.
 func (u *rfc2136Updater) sendAdd(ctx context.Context, zone string, rr dns.RR) error {
+	// #2691 P2: a self-owned forward record (Surface A) is published as an
+	// atomic in-place replace of OUR record type, so an address change or a
+	// forced-refresh of an EXISTING name succeeds (the DHCID/name-not-in-use
+	// prerequisites below would refuse the pre-existing name). Only the forward
+	// A/AAAA add is self-owned; a PTR add (rare for Surface A) falls through to
+	// the normal path.
+	if u.selfOwned && (rr.Header().Rrtype == dns.TypeA || rr.Header().Rrtype == dns.TypeAAAA) {
+		return u.sendAddSelfOwned(ctx, zone, rr)
+	}
 	if u.conflictPolicy == "replace-owned" {
 		return u.sendAddOwned(ctx, zone, rr)
 	}
@@ -726,6 +749,52 @@ func (u *rfc2136Updater) sendAddOwned(ctx context.Context, zone string, rr dns.R
 			u.onConflict()
 		}
 		return errDDNSConflictRefused
+	default:
+		return rcodeError(resp.Rcode)
+	}
+}
+
+// sendAddSelfOwned publishes a SELF-OWNED forward record (Surface A router /
+// interface-address publish, #2691 P2) as an ATOMIC IN-PLACE REPLACE: a single
+// RFC 2136 UPDATE that, in one message, deletes the existing RRset OF OUR TYPE
+// at our name (RFC 2136 §2.5.2 delete-RRset, CLASS=ANY, no rdata) and then
+// inserts the new rdata. Because both ops are in the SAME UPDATE, the server
+// applies them atomically — there is NO withdraw-then-add blackhole window, and
+// the new address is live the instant the old one is gone.
+//
+// Why this (vs the DHCID/name-not-in-use path): a router record has no DHCID
+// (the firewall is the authoritative owner of its OWN configured FQDN), so the
+// lease path's two prerequisites both REFUSE a pre-existing name — which would
+// pin the record at its first address forever (the bug this fixes). The
+// firewall owns the NAME, so an in-place replace of its own forward type is the
+// correct, idempotent self-ownership mechanism: a same-address re-publish
+// (forced-refresh) deletes-then-re-adds the identical RR (a no-op net change
+// that SUCCEEDS), and an address change replaces the rdata atomically.
+//
+// Exact-RR / co-resident safety: the delete is scoped to OUR forward type (A
+// for a v4 record, AAAA for a v6 record) at OUR exact name only — it never
+// touches a different RR type at the name (e.g. a co-resident MX/TXT) and never
+// issues a delete-name. The third-party case: if an operator points two
+// firewalls' Surface-A FQDNs at the SAME name they will fight (each replaces the
+// other's A) — that is an operator misconfiguration (the per-RG HA gate already
+// prevents the in-cluster two-writer case), and is strictly the documented
+// "self-owned name" contract; this backend never adopts or deletes a DIFFERENT
+// record TYPE, so a co-resident non-A/AAAA record at the name is never harmed.
+func (u *rfc2136Updater) sendAddSelfOwned(ctx context.Context, zone string, rr dns.RR) error {
+	m := new(dns.Msg)
+	m.SetUpdate(dns.Fqdn(zone))
+	// RemoveRRset deletes the entire RRset of rr's type at rr's name (CLASS=ANY,
+	// TTL=0, empty rdata) — our prior A/AAAA value(s), if any. Applied in the
+	// SAME message as the Insert below, so the replace is atomic.
+	m.RemoveRRset([]dns.RR{rr})
+	m.Insert([]dns.RR{rr})
+	resp, err := u.exchange(ctx, m)
+	if err != nil {
+		return err
+	}
+	switch resp.Rcode {
+	case dns.RcodeSuccess:
+		return nil
 	default:
 		return rcodeError(resp.Rcode)
 	}

--- a/pkg/ddns/backend_rfc2136_test.go
+++ b/pkg/ddns/backend_rfc2136_test.go
@@ -274,9 +274,25 @@ func (s *fakeDNSServer) evalStatefulLocked(r *dns.Msg) int {
 				}
 			}
 		case dns.ClassANY:
-			// delete-RRset / delete-name — the backend must never send these;
-			// apply defensively so a stray one is observable in the zone.
-			delete(s.zone, name)
+			// CLASS=ANY: delete-name (Rrtype ANY) OR delete-RRset (a specific
+			// Rrtype). The lease path never sends these, but the #2691 P2
+			// self-owned forward replace (sendAddSelfOwned) sends a delete-RRset
+			// of OUR forward type in the SAME message as the Insert (atomic
+			// in-place replace). Honor the RFC 2136 §2.5.1/§2.5.2 distinction so
+			// the test verifies the delete is scoped to OUR type and never harms a
+			// co-resident RR of a DIFFERENT type at the name.
+			if h.Rrtype == dns.TypeANY {
+				delete(s.zone, name)
+			} else if set := s.zone[name]; set != nil {
+				for k, rr := range set {
+					if rr.Header().Rrtype == h.Rrtype {
+						delete(set, k)
+					}
+				}
+				if len(set) == 0 {
+					delete(s.zone, name)
+				}
+			}
 		default:
 			// Insert.
 			if s.zone[name] == nil {

--- a/pkg/ddns/manager_test.go
+++ b/pkg/ddns/manager_test.go
@@ -29,6 +29,10 @@ type fakeUpdater struct {
 	failUpd   map[string]bool // FQDN -> fail upsert
 	failDel   map[string]bool // FQDN -> fail delete
 	failEvery bool            // fail all ops (retry-no-wedge probe)
+	// failedCalls counts UpsertLease/DeleteLease calls that RETURNED an error
+	// (the #2691 P2 Surface A backoff test asserts the backend is not re-hit
+	// while a scope is in its error-backoff window).
+	failedCalls int
 }
 
 func newFakeUpdater() *fakeUpdater {
@@ -39,6 +43,7 @@ func (f *fakeUpdater) UpsertLease(_ context.Context, rec LeaseDNSRecord) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.failEvery || f.failUpd[rec.FQDN] {
+		f.failedCalls++
 		return fmt.Errorf("fake: upsert %s failed", rec.FQDN)
 	}
 	f.upserts = append(f.upserts, rec)
@@ -49,6 +54,7 @@ func (f *fakeUpdater) DeleteLease(_ context.Context, rec LeaseDNSRecord) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.failEvery || f.failDel[rec.FQDN] {
+		f.failedCalls++
 		return fmt.Errorf("fake: delete %s failed", rec.FQDN)
 	}
 	f.deletes = append(f.deletes, rec)

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -147,6 +147,15 @@ type ownedRecord struct {
 	// an absent value degrades to the no-DHCID path on delete (safe — the
 	// exact-RR delete still only removes the firewall's own tuple).
 	ClientID string `json:"client_id,omitempty"`
+	// AddrText is the textual rdata (the published address) for a Surface A
+	// router record (#2691 P2). Surface A keys ownership on {scope, fixed
+	// identity, ""} so a scope owns exactly ONE record and an address change
+	// REPLACES it in place (no stale old-address entry, never a withdraw-then-
+	// add gap) — which means the keying Address field is "" and the actual
+	// published address must be carried separately. The DHCP-lease path leaves
+	// this empty (its Address field IS the rdata). Omitted from the JSON when
+	// empty so a pre-P2 / lease store shape is unchanged.
+	AddrText string `json:"addr_text,omitempty"`
 	// PTRPending marks an ownership record whose forward A/AAAA was published
 	// but whose reverse PTR add failed with a non-skippable (transient) error
 	// (#2661). Ownership is still recorded so the live forward is tracked +

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -1,0 +1,746 @@
+package ddns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// surface_a.go: the Surface A router/interface-address DDNS engine (#2691 P2,
+// plan §2.1, §5.3, §5.5). Surface A publishes the firewall's OWN address — an
+// interface/unit/family's learned WAN address (DHCP lease, static, netlink) —
+// as a single A/AAAA record at a configured FQDN through an external DNS
+// provider. It is the classic "dyndns client on the CPE" surface.
+//
+// REUSE, DO NOT FORK THE SPINE: Surface A drives the SAME Backend (DNSUpdater)
+// interface, the SAME record construction (buildHostRecord → LeaseDNSRecord),
+// the SAME RFC 2136 backend (newRFC2136Updater, with self-ownership semantics:
+// no DHCID/ClientID, so sendAddOwned uses the name-not-in-use / refresh-owned
+// prerequisite), the SAME ScopeKey ownership primitive (plan §5.4), and the
+// SAME durable-fsync state store pattern (state.go ddnsState shape) — only the
+// state FILE differs (interface-ddns-state.json, plan §5.5). The ONLY thing
+// Surface A adds on top of the spine is the update ENGINE discipline the
+// DHCP-lease reconciler does not need: per-scope change detection, a
+// forced-refresh wire floor decoupled from the poll cadence, and flat error
+// backoff (ban-avoidance) — the inadyn ideas #4/#7/#8 (plan §3.3/§5.5).
+//
+// HA (plan §5.6 / #2664): a router record on a reth/virtual interface is
+// published only by the node that masters its scope's RG. The SurfaceAManager
+// takes the SAME per-scope ScopeGate the lease reconciler does; a gated-out
+// scope is stop-writing, never-withdraw (the peer RG master refreshes; a
+// withdraw race would blackhole). A standalone (nil gate) always publishes.
+
+// defaultSurfaceAStatePath is the on-disk location of the Surface A
+// last-published / ownership store (plan §5.5). Distinct from the Surface B
+// lease ownership store (defaultDDNSStatePath) so the two surfaces never
+// collide on a record key and either can be reset independently.
+const defaultSurfaceAStatePath = "/var/lib/xpf/interface-ddns-state.json"
+
+// defaultForcedRefresh is the wire-update floor for an UNCHANGED address
+// (inadyn idea #7, plan §5.5). The reconcile loop re-asserts desired state
+// every 30s, but a wire UPDATE for an unchanged address fires at most once per
+// forced-refresh interval — proving liveness to the provider / resisting record
+// reaping without per-poll traffic. 24h matches the plan default.
+const defaultForcedRefresh = 24 * time.Hour
+
+// defaultErrorBackoffMax caps the per-scope error backoff (inadyn idea #8,
+// flat — not exponential beyond the cap; plan §5.5). On a transient failure a
+// scope backs off from the reconcile interval up to this cap so a failing
+// provider is not hammered at the poll cadence (ban-avoidance).
+const defaultErrorBackoffMax = time.Hour
+
+// surfaceABaseBackoff is the first error-backoff step (the reconcile cadence).
+// A scope that keeps failing doubles up to defaultErrorBackoffMax.
+const surfaceABaseBackoff = 30 * time.Second
+
+// AddressSource selects where an interface scope's current address is observed
+// (plan §5.3). Ordered-fallback observation lives in the daemon's
+// AddressObserver; this enum is the per-scope operator selection.
+type AddressSource string
+
+const (
+	// AddressSourceInterface reads the address from the interface (netlink /
+	// configured static) — the default. The firewall is the router, so it
+	// usually knows its own public address directly (plan §7 fork 4).
+	AddressSourceInterface AddressSource = "interface"
+	// AddressSourceDHCP reads the address from the DHCP client lease
+	// (pkg/dhcp.Manager.LeaseFor) — the authoritative learned WAN address.
+	AddressSourceDHCP AddressSource = "dhcp"
+)
+
+// SurfaceAScope is the resolved, runtime-shaped configuration for ONE
+// interface/unit/family Surface A binding (plan §5.9). It is derived from the
+// per-interface `dynamic-dns` config + the referenced provider-catalog entry at
+// reconcile time so the manager never holds a stale captured cfg.
+type SurfaceAScope struct {
+	// Key is the ownership/scope key (plan §5.4). For Surface A it is keyed on
+	// {Family, Interface, Unit, RGOwner} — RoutingInstance/PolicyID round out
+	// the transport + provider attribution. The interface+unit+family triple is
+	// unique per binding.
+	Key ScopeKey
+	// FQDN is the forward name to publish (already an operator-supplied FQDN;
+	// finalizeFQDN normalizes it against an empty zone so a dotted name is kept
+	// verbatim, a bare label is published as-is).
+	FQDN string
+	// TTL is the record TTL in seconds (defaultDDNSTTL when unset).
+	TTL int
+	// Source selects the address-observation source for this scope.
+	Source AddressSource
+	// Provider is the resolved provider-catalog entry (backend + credentials +
+	// transport binding) this scope publishes through.
+	Provider *config.DDNSProvider
+	// ForcedRefresh is the wire-update floor for an unchanged address; 0 ⇒
+	// defaultForcedRefresh.
+	ForcedRefresh time.Duration
+	// ErrorBackoffMax caps the per-scope error backoff; 0 ⇒
+	// defaultErrorBackoffMax.
+	ErrorBackoffMax time.Duration
+}
+
+// scopeID is the stable string id for a Surface A scope (its ScopeKey prefix),
+// used as the map key in the manager's per-scope runtime state and the
+// observation request. Two scopes with the same interface/unit but different
+// families are distinct.
+func (s SurfaceAScope) scopeID() string { return s.Key.scopePrefix() }
+
+// AddressObservation is the result of observing a scope's current address
+// (plan §5.3). Addr.IsValid()==false means "no address right now" (the
+// interface is down / has no lease for this family) — the engine withdraws a
+// previously-published record for a scope that loses its address.
+type AddressObservation struct {
+	Addr   netip.Addr
+	Source AddressSource
+}
+
+// AddressObserver observes the current address for a Surface A scope (plan
+// §5.3). The daemon supplies it (it reads netlink / pkg/dhcp.LeaseFor). The
+// engine never reads netlink/DHCP directly — keeping pkg/ddns free of those
+// dependencies, exactly as the LeaseParser seam keeps it free of the Kea
+// memfile parser. ok=false means the address could not be observed this cycle
+// (transient) — the engine then leaves the scope untouched (no withdraw on a
+// transient observation failure, the never-blackhole rule).
+type AddressObserver func(scope SurfaceAScope) (AddressObservation, bool)
+
+// surfaceAState is the per-scope runtime engine state (plan §5.5): the
+// last-published address + time (change-detection + forced-refresh) and the
+// error-backoff schedule. It is kept in memory alongside the durable ownership
+// record (the durable store proves ownership for cleanup; this drives the wire
+// cadence). lastErr surfaces the last failure for observability.
+type surfaceAState struct {
+	lastAddr      netip.Addr
+	lastPublished time.Time
+	// nextEligible is the earliest time the scope may attempt a wire op again
+	// after a failure (error backoff). Zero ⇒ eligible now.
+	nextEligible time.Time
+	backoff      time.Duration
+	lastErr      string
+	lastErrAt    time.Time
+}
+
+// SurfaceAStatusView is a read-only projection of one Surface A scope's
+// current publish state, for the operator surfaces (CLI/gRPC/REST). It exposes
+// what is currently published, the last-published time, and the last error.
+type SurfaceAStatusView struct {
+	Interface     string
+	Unit          int
+	Family        int
+	FQDN          string
+	Provider      string
+	Published     string // current published address ("" = none)
+	LastPublished time.Time
+	LastError     string
+	LastErrorAt   time.Time
+}
+
+// SurfaceAManager owns the Surface A reconcile + the per-scope last-published
+// cache + ownership store (plan §5.5/§5.6). It is a SEPARATE manager from the
+// DHCP-lease Manager (different ownership semantics — self-owned vs DHCID — and
+// a different state file), but it drives the SAME Backend interface and the
+// SAME record/scope/durability primitives.
+type SurfaceAManager struct {
+	mu    sync.Mutex
+	state *ddnsState // durable ownership store (interface-ddns-state.json)
+
+	// runtime is the per-scope engine state (change-detect / forced-refresh /
+	// backoff), keyed by scopeID. NOT persisted: it is rebuilt on restart from
+	// the durable store (seedFromStore) so a restart does not blast a redundant
+	// update for an unchanged address (inadyn idea #5, plan §5.5).
+	runtime map[string]*surfaceAState
+
+	// newBackend resolves the live Backend for a provider at reconcile time
+	// (resolve-per-Reconcile, plan §6 fork 1). When nil (tests injecting a fixed
+	// backend) the static `backend` field is used for every scope.
+	newBackend func(p *config.DDNSProvider, fqdn string, ttl int) (DNSUpdater, error)
+	backend    DNSUpdater // static fallback / test injection
+
+	now func() time.Time
+
+	// counters (observability, plan §5.5).
+	upsertOK   uint64
+	upsertFail uint64
+	deleteOK   uint64
+	deleteFail uint64
+	skipped    uint64 // unchanged-and-not-yet-forced skips
+	backedOff  uint64 // scopes skipped this pass because still in error backoff
+}
+
+// NewSurfaceAManager constructs the production Surface A manager (plan §5.5). It
+// loads the durable ownership store from defaultSurfaceAStatePath (a corrupt
+// store is reset to empty, fail-open) and resolves the live RFC 2136 backend
+// per provider at reconcile time. The runtime cache is seeded from the durable
+// store so a restart does not republish an unchanged address.
+func NewSurfaceAManager() *SurfaceAManager {
+	st, err := loadDDNSState(defaultSurfaceAStatePath)
+	if err != nil {
+		slog.Warn("ddns surface-a: ownership state load failed; starting empty", "err", err)
+	}
+	m := &SurfaceAManager{
+		state:      st,
+		runtime:    map[string]*surfaceAState{},
+		newBackend: productionSurfaceABackend,
+		now:        time.Now,
+	}
+	m.seedFromStore()
+	return m
+}
+
+// newSurfaceAManagerForTesting builds a manager with an in-memory state file
+// path, an injected backend, and an injectable clock — no real /var/lib path,
+// no network. Used by surface_a_test.go.
+func newSurfaceAManagerForTesting(statePath string, backend DNSUpdater, now func() time.Time) *SurfaceAManager {
+	st, _ := loadDDNSState(statePath)
+	m := &SurfaceAManager{
+		state:   st,
+		runtime: map[string]*surfaceAState{},
+		backend: backend,
+		now:     now,
+	}
+	m.seedFromStore()
+	return m
+}
+
+// productionSurfaceABackend resolves a provider-catalog entry into a live
+// Backend (plan §5.2). P2 ships the RFC 2136 backend only; the HTTP providers
+// (dyndns2/Cloudflare/Route53/generic) are P3 — an unknown backend resolves to
+// the no-op (logged) so a P3-only provider config does not wedge P2.
+func productionSurfaceABackend(p *config.DDNSProvider, fqdn string, ttl int) (DNSUpdater, error) {
+	if p == nil {
+		return nopUpdater{}, nil
+	}
+	switch p.Backend {
+	case "rfc2136", "":
+		if p.UpdateServer == "" {
+			// Enabled provider with nothing to update — stay no-op (the commit
+			// warning already told the operator).
+			return nopUpdater{}, nil
+		}
+		return newSurfaceARFC2136(p, fqdn)
+	default:
+		// dyndns2 / cloudflare / route53 / generic land in P3.
+		slog.Debug("ddns surface-a: provider backend not implemented in P2 (deferred to P3)",
+			"provider", p.Name, "backend", p.Backend)
+		return nopUpdater{}, nil
+	}
+}
+
+// newSurfaceARFC2136 builds the live RFC 2136 backend for a Surface A provider.
+// It reuses the SAME rfc2136Updater the lease path uses, with self-ownership
+// semantics: there is NO ClientID/DHCID for a router record, so under the
+// default replace-owned conflict policy sendAddOwned uses the name-not-in-use
+// (Attempt A) / no-DHCID refuse (Attempt B) path — the firewall claims a name
+// only when it is free, and refreshes an unchanged record idempotently. The
+// provider's transport binding (source-address / dest-interface / VRF) is
+// honored via the shared resolveBindConfig→dialer path by reusing
+// DHCPDynamicDNSConfig as the transport carrier.
+func newSurfaceARFC2136(p *config.DDNSProvider, _ string) (DNSUpdater, error) {
+	if p == nil {
+		return nil, errors.New("ddns surface-a: nil provider")
+	}
+	// Reuse the lease-path policy + config shape so the rfc2136 backend builds
+	// identically (server, TSIG, source binding). conflict-policy is fixed to
+	// replace-owned: a router record is self-owned (no DHCID), so the
+	// name-not-in-use / refresh path is the correct self-ownership prerequisite.
+	pol := ddnsPolicy{
+		domain:         "", // the FQDN is absolute; no domain suffixing
+		conflictPolicy: "replace-owned",
+		backend:        "rfc2136",
+	}
+	c := &config.DHCPDynamicDNSConfig{
+		UpdateServer:         p.UpdateServer,
+		TSIGKeyName:          p.TSIGKeyName,
+		TSIGAlgorithm:        p.TSIGAlgorithm,
+		TSIGSecret:           p.TSIGSecret,
+		SourceAddress:        p.SourceAddress,
+		DestinationInterface: p.DestinationInterface,
+		RoutingInstance:      p.RoutingInstance,
+	}
+	return newRFC2136Updater(pol, c, nil, nil, nil)
+}
+
+// seedFromStore rebuilds the in-memory runtime cache from the durable ownership
+// store (inadyn idea #5, plan §5.5): a restart must not blast a redundant
+// update for an address that has not changed. Each owned record seeds
+// lastAddr; lastPublished is left zero so the FIRST post-restart reconcile,
+// if the address is unchanged, still satisfies change-detection (addr matches)
+// and the forced-refresh floor is measured from the restart (a benign at-most-
+// one wire refresh on the first forced interval after a restart). Caller need
+// not hold the mutex (constructor-only).
+func (m *SurfaceAManager) seedFromStore() {
+	for _, r := range m.state.all() {
+		a, err := netip.ParseAddr(r.Address)
+		if err != nil {
+			continue
+		}
+		m.runtime[r.scopeOf().scopePrefix()] = &surfaceAState{lastAddr: a.Unmap()}
+	}
+}
+
+// Reconcile drives one Surface A reconcile pass over the configured scopes
+// (plan §5.5/§5.6). For each scope it: observes the current address; applies
+// the per-RG HA gate; runs change-detection + forced-refresh + error backoff;
+// and publishes/withdraws through the resolved Backend. A scope present in the
+// durable store but ABSENT from `scopes` (binding removed from config) is
+// WITHDRAWN (turn-off cleanup), provided this node may write its scope.
+//
+// gate is the SAME per-RG ScopeGate the lease reconciler uses (#2664). A nil
+// gate (standalone) admits every scope. A gated-out scope is stop-writing,
+// never-withdraw (the peer RG master refreshes it).
+func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := m.now()
+	var firstErr error
+	noteErr := func(e error) {
+		if e != nil && firstErr == nil {
+			firstErr = e
+		}
+	}
+
+	admit := func(s ScopeKey) bool {
+		if gate == nil {
+			return true
+		}
+		return gate(s)
+	}
+
+	// desired[scopeID] = the configured scope. Used to find owned records that
+	// are no longer configured (withdraw).
+	desired := map[string]SurfaceAScope{}
+	for _, sc := range scopes {
+		desired[sc.scopeID()] = sc
+	}
+
+	// Pass 1 — publish / refresh / withdraw-on-address-loss each configured
+	// scope.
+	for _, sc := range scopes {
+		if !admit(sc.Key) {
+			// Per-RG gate closed: stop writing, never withdraw (plan §5.6). The
+			// peer that masters this RG owns the refresh.
+			slog.Debug("ddns surface-a: scope not writable from this node (per-RG gate closed); not publishing, not withdrawing",
+				"fqdn", sc.FQDN, "rg", sc.Key.RGOwner, "iface", sc.Key.Interface)
+			continue
+		}
+		noteErr(m.reconcileScopeLocked(ctx, sc, observe, now))
+	}
+
+	// Pass 2 — withdraw scopes whose binding was removed from config. A record
+	// owned for a scope NOT in `desired` is withdrawn (turn-off cleanup), gated
+	// by the same per-RG writer gate (never withdraw a scope this node does not
+	// master).
+	for _, owned := range m.state.all() {
+		sid := owned.scopeOf().scopePrefix()
+		if _, stillConfigured := desired[sid]; stillConfigured {
+			continue
+		}
+		if !admit(owned.scopeOf()) {
+			continue
+		}
+		noteErr(m.withdrawOwnedLocked(ctx, owned))
+	}
+
+	if err := m.state.save(); err != nil {
+		slog.Warn("ddns surface-a: persist ownership state failed", "err", err)
+		noteErr(err)
+	}
+	return firstErr
+}
+
+// reconcileScopeLocked is the per-scope engine (plan §5.5): observe → change
+// detection → forced-refresh → error backoff → publish/withdraw. Caller holds
+// m.mu.
+func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAScope, observe AddressObserver, now time.Time) error {
+	sid := sc.scopeID()
+	rt := m.runtime[sid]
+	if rt == nil {
+		rt = &surfaceAState{}
+		m.runtime[sid] = rt
+	}
+
+	// Error backoff (inadyn idea #8): a scope still in its backoff window is
+	// skipped this pass so a failing provider is not hammered (ban-avoidance).
+	if !rt.nextEligible.IsZero() && now.Before(rt.nextEligible) {
+		m.backedOff++
+		slog.Debug("ddns surface-a: scope in error backoff; skipping this pass",
+			"fqdn", sc.FQDN, "next-eligible", rt.nextEligible)
+		return nil
+	}
+
+	obs, ok := observe(sc)
+	if !ok {
+		// Transient observation failure: leave the scope untouched (never
+		// withdraw on a transient — the never-blackhole rule, plan §8.2).
+		slog.Debug("ddns surface-a: address observation failed (transient); leaving scope untouched", "fqdn", sc.FQDN)
+		return nil
+	}
+
+	if !obs.Addr.IsValid() {
+		// The scope lost its address (interface down / lease gone). If we own a
+		// record for it, withdraw it (the address really is gone — this is the
+		// authoritative "no address", not a transient observation failure).
+		if owned, exists := m.state.get(sc.Key, surfaceAIdentity, ""); exists {
+			if err := m.withdrawOwnedLocked(ctx, owned); err != nil {
+				return err
+			}
+			delete(m.runtime, sid)
+		}
+		return nil
+	}
+
+	addr := obs.Addr.Unmap()
+
+	// Change detection + forced-refresh (inadyn ideas #4/#7): fire a wire
+	// UPDATE when the address changed OR the forced-refresh floor elapsed since
+	// the last successful publish. An unchanged address inside the floor is a
+	// counted skip (no wire traffic).
+	forced := sc.ForcedRefresh
+	if forced <= 0 {
+		forced = defaultForcedRefresh
+	}
+	changed := addr != rt.lastAddr
+	_, owned := m.state.get(sc.Key, surfaceAIdentity, "")
+	refreshDue := rt.lastPublished.IsZero() || now.Sub(rt.lastPublished) >= forced
+	if owned && !changed && !refreshDue {
+		m.skipped++
+		slog.Debug("ddns surface-a: address unchanged and forced-refresh not due; skipping",
+			"fqdn", sc.FQDN, "addr", addr.String())
+		return nil
+	}
+
+	if err := m.publishLocked(ctx, sc, addr, now); err != nil {
+		m.recordScopeError(rt, sc, err, now)
+		return err
+	}
+	// Success: clear backoff, update the last-published cache.
+	rt.lastAddr = addr
+	rt.lastPublished = now
+	rt.nextEligible = time.Time{}
+	rt.backoff = 0
+	rt.lastErr = ""
+	return nil
+}
+
+// surfaceAIdentity is the fixed ownership "identity" for every Surface A record
+// — a router record is keyed on its SCOPE + FQDN, not a client identity (there
+// is no DHCP client). Using a constant identity keeps the ownedRecordKey shape
+// shared with the lease store (scopePrefix + identity + "|" + address) while
+// the scope (interface/unit/family) is the real discriminator. Address is "" in
+// the key so a scope owns at most ONE record and an address change REPLACES it
+// in place (no stale old-address entry, never a withdraw-then-add gap).
+const surfaceAIdentity = "router-self"
+
+// publishLocked publishes the scope's record through the resolved Backend and
+// records ownership write-ahead (the same durability discipline as the lease
+// path, #2662). The ownership key fixes Address="" so a scope owns exactly one
+// record: an address change REPLACES the rdata via an idempotent
+// replace-owned add (RFC 2136 replace semantics in the rfc2136 backend), never
+// a withdraw-then-add that would blackhole. Caller holds m.mu.
+func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, addr netip.Addr, now time.Time) error {
+	backend, err := m.backendFor(sc)
+	if err != nil {
+		m.upsertFail++
+		return err
+	}
+	ttl := sc.TTL
+	if ttl <= 0 {
+		ttl = defaultDDNSTTL
+	}
+	rec, err := buildHostRecord(sc.FQDN, addr, ttl)
+	if err != nil {
+		m.upsertFail++
+		return err
+	}
+
+	prevOwned, hadPrev := m.state.get(sc.Key, surfaceAIdentity, "")
+	prevAddr := ""
+	if hadPrev {
+		prevAddr = prevOwned.Address
+	}
+
+	// Write-ahead the ownership intent BEFORE the wire add (#2662): a crash
+	// after the add finds the record owned and the next reconcile converges it.
+	ow := ownedRecord{
+		Family:      familyInt(addr),
+		Identity:    surfaceAIdentity,
+		Address:     "", // key on scope+FQDN; rdata lives in AddrText below
+		FQDN:        rec.FQDN,
+		ForwardType: rec.ForwardType,
+		PTRName:     "",
+		TTL:         ttl,
+		AddrText:    addr.String(),
+	}.withScope(sc.Key)
+	m.state.put(ow)
+	if err := m.state.save(); err != nil {
+		// Could not durably record ownership: do NOT publish. Roll back to the
+		// previous durable state.
+		if hadPrev {
+			m.state.put(prevOwned)
+		} else {
+			m.state.delete(sc.Key, surfaceAIdentity, "")
+		}
+		m.upsertFail++
+		return fmt.Errorf("ddns surface-a: cannot durably record ownership before publish: %w", err)
+	}
+
+	if err := backend.UpsertLease(ctx, rec); err != nil {
+		// Hard add failure: the record is NOT live with the new rdata. Restore
+		// the previous durable ownership (the old address is still live) so we
+		// do not claim an address we failed to publish. A conflict refusal
+		// (name owned by another party) also lands here — Surface A does not
+		// adopt a third party's name.
+		if hadPrev {
+			m.state.put(prevOwned)
+		} else {
+			m.state.delete(sc.Key, surfaceAIdentity, "")
+		}
+		_ = m.state.save()
+		m.upsertFail++
+		if errors.Is(err, errDDNSConflictRefused) {
+			return fmt.Errorf("ddns surface-a: %s is owned by another party (refused): %w", rec.FQDN, err)
+		}
+		return fmt.Errorf("ddns surface-a: publish %s %s=%s: %w", rec.ForwardType, rec.FQDN, addr, err)
+	}
+
+	// Success. If the address CHANGED (replace), the replace-owned add already
+	// updated the rdata in place at the server (RFC 4703 §5.3 refresh-owned),
+	// so there is no separate withdraw of the old address — the never-blackhole
+	// replace. Log the transition for observability.
+	if prevAddr != "" && prevAddr != addr.String() {
+		slog.Info("ddns surface-a: replaced record address",
+			"fqdn", rec.FQDN, "old", prevAddr, "new", addr.String())
+	} else if !hadPrev {
+		slog.Info("ddns surface-a: published record", "fqdn", rec.FQDN, "addr", addr.String())
+	}
+	m.upsertOK++
+	return nil
+}
+
+// withdrawOwnedLocked removes the firewall's own record for an owned scope
+// (binding removed, or address lost) through the resolved Backend, then drops
+// the ownership entry. Caller holds m.mu. A delete is re-derived from the
+// EXACT owned tuple (the sole-delete-authority boundary, shared with the lease
+// path): Surface A never deletes a name it did not record.
+func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRecord) error {
+	a, err := netip.ParseAddr(owned.AddrText)
+	if err != nil {
+		// Stored rdata no longer parses (should not happen): drop the entry to
+		// avoid wedging, but issue no delete with a guessed address.
+		slog.Warn("ddns surface-a: owned record has unparseable address; dropping entry",
+			"fqdn", owned.FQDN, "addr", owned.AddrText, "err", err)
+		m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
+		delete(m.runtime, owned.scopeOf().scopePrefix())
+		return nil
+	}
+	backend, err := m.backendForOwned(owned)
+	if err != nil {
+		m.deleteFail++
+		return err
+	}
+	rec, err := buildHostRecord(owned.FQDN, a, owned.TTL)
+	if err != nil {
+		m.deleteFail++
+		return err
+	}
+	if err := backend.DeleteLease(ctx, rec); err != nil {
+		m.deleteFail++
+		return fmt.Errorf("ddns surface-a: withdraw %s %s: %w", owned.ForwardType, owned.FQDN, err)
+	}
+	m.deleteOK++
+	m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
+	delete(m.runtime, owned.scopeOf().scopePrefix())
+	slog.Info("ddns surface-a: withdrew record", "fqdn", owned.FQDN, "addr", owned.AddrText)
+	return nil
+}
+
+// backendFor resolves the live Backend for a scope's provider (resolve-per-
+// Reconcile). The static `backend` field (test injection) wins when set.
+func (m *SurfaceAManager) backendFor(sc SurfaceAScope) (DNSUpdater, error) {
+	if m.newBackend == nil {
+		if m.backend != nil {
+			return m.backend, nil
+		}
+		return nopUpdater{}, nil
+	}
+	return m.newBackend(sc.Provider, sc.FQDN, sc.TTL)
+}
+
+// backendForOwned resolves the Backend for a withdraw of an owned record whose
+// scope is no longer in the desired set (the provider is not available from a
+// SurfaceAScope). The static backend wins (tests); production withdraws are
+// driven from the still-configured scope set (Pass 2 only fires for a removed
+// binding, where the provider catalog may still hold the entry — but we no
+// longer have the SurfaceAScope). For P2 a removed-binding withdraw uses the
+// static backend if present, else the no-op (the record is dropped from the
+// store either way; a no-op withdraw leaves the RR until its provider is
+// reconfigured — documented residual). The common case (address loss / replace)
+// goes through backendFor with the live SurfaceAScope.
+func (m *SurfaceAManager) backendForOwned(_ ownedRecord) (DNSUpdater, error) {
+	if m.backend != nil {
+		return m.backend, nil
+	}
+	return nopUpdater{}, nil
+}
+
+// recordScopeError records a failure on a scope and advances its flat error
+// backoff (inadyn idea #8): nextEligible = now + backoff, doubling from
+// surfaceABaseBackoff up to the cap. Surfaced via lastErr for observability.
+func (m *SurfaceAManager) recordScopeError(rt *surfaceAState, sc SurfaceAScope, err error, now time.Time) {
+	maxBackoff := sc.ErrorBackoffMax
+	if maxBackoff <= 0 {
+		maxBackoff = defaultErrorBackoffMax
+	}
+	if rt.backoff <= 0 {
+		rt.backoff = surfaceABaseBackoff
+	} else {
+		rt.backoff *= 2
+	}
+	if rt.backoff > maxBackoff {
+		rt.backoff = maxBackoff
+	}
+	rt.nextEligible = now.Add(rt.backoff)
+	rt.lastErr = err.Error()
+	rt.lastErrAt = now
+	slog.Warn("ddns surface-a: scope publish failed; backing off",
+		"fqdn", sc.FQDN, "backoff", rt.backoff, "err", err)
+}
+
+// StatusViews returns a stable-ordered snapshot of every Surface A scope's
+// current publish state for the operator surfaces (plan §5.5 observability). It
+// merges the durable ownership store (what is published) with the in-memory
+// runtime state (last-published time + last error).
+func (m *SurfaceAManager) StatusViews() []SurfaceAStatusView {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]SurfaceAStatusView, 0, len(m.state.records))
+	for _, r := range m.state.all() {
+		sc := r.scopeOf()
+		v := SurfaceAStatusView{
+			Interface: sc.Interface,
+			Unit:      sc.Unit,
+			Family:    int(sc.Family),
+			FQDN:      r.FQDN,
+			Provider:  sc.PolicyID,
+			Published: r.AddrText,
+		}
+		if rt := m.runtime[sc.scopePrefix()]; rt != nil {
+			v.LastPublished = rt.lastPublished
+			v.LastError = rt.lastErr
+			v.LastErrorAt = rt.lastErrAt
+		}
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].FQDN != out[j].FQDN {
+			return out[i].FQDN < out[j].FQDN
+		}
+		return out[i].Family < out[j].Family
+	})
+	return out
+}
+
+// SurfaceAStats is the counter snapshot for `show` + Prometheus (plan §5.5).
+type SurfaceAStats struct {
+	Scopes     int
+	UpsertOK   uint64
+	UpsertFail uint64
+	DeleteOK   uint64
+	DeleteFail uint64
+	Skipped    uint64
+	BackedOff  uint64
+}
+
+// Stats returns the current Surface A counters.
+func (m *SurfaceAManager) Stats() SurfaceAStats {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return SurfaceAStats{
+		Scopes:     len(m.state.records),
+		UpsertOK:   m.upsertOK,
+		UpsertFail: m.upsertFail,
+		DeleteOK:   m.deleteOK,
+		DeleteFail: m.deleteFail,
+		Skipped:    m.skipped,
+		BackedOff:  m.backedOff,
+	}
+}
+
+// buildHostRecord constructs the forward-only A/AAAA record for a Surface A
+// router record (no PTR — Surface A publishes the firewall's forward name; PTR
+// for the firewall's own address is an operator/ISP concern, not auto-managed).
+// The FQDN is normalized against an EMPTY zone (finalizeFQDN keeps a dotted
+// operator-supplied name verbatim, a bare label as-is) so an absolute name like
+// wan.example.net is published exactly.
+func buildHostRecord(fqdn string, addr netip.Addr, ttl int) (LeaseDNSRecord, error) {
+	// Surface A operator FQDNs are ABSOLUTE (the operator picks the full name,
+	// unlike the DHCP-lease path where the client picks the host part and the
+	// firewall picks the zone). finalizeFQDN("",...) would reduce a dotted name
+	// to its first label, which is wrong for "wan.example.net" — so use a
+	// dotted-structure-preserving per-label sanitize instead.
+	name := surfaceAName(fqdn)
+	if name == "" {
+		return LeaseDNSRecord{}, fmt.Errorf("ddns surface-a: hostname %q sanitizes to empty", fqdn)
+	}
+	a := addr.Unmap()
+	if ttl <= 0 {
+		ttl = defaultDDNSTTL
+	}
+	rec := LeaseDNSRecord{
+		FQDN: name,
+		Addr: a,
+		TTL:  ttl,
+	}
+	if a.Is4() {
+		rec.ForwardType = "A"
+	} else if a.Is6() {
+		rec.ForwardType = "AAAA"
+	} else {
+		return LeaseDNSRecord{}, fmt.Errorf("ddns surface-a: record %q has an unspecified address", fqdn)
+	}
+	return rec, nil
+}
+
+// surfaceAName normalizes an operator-supplied Surface A hostname. Unlike the
+// DHCP-lease path (where the CLIENT supplies the name and the FIREWALL picks the
+// zone), the OPERATOR supplies the full FQDN here, so the name is honored
+// verbatim after a per-label LDH sanitize that preserves the dotted structure
+// (so wan.example.net stays wan.example.net), trimming a trailing dot. An empty
+// result ("" — the input had no usable label) is returned so the caller errors
+// rather than publishing junk.
+func surfaceAName(fqdn string) string {
+	return sanitizeFQDN(fqdn)
+}
+
+// familyInt returns the engine family int (4/6) for an address.
+func familyInt(a netip.Addr) int {
+	if a.Unmap().Is4() {
+		return 4
+	}
+	return 6
+}

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -251,22 +251,25 @@ func productionSurfaceABackend(p *config.DDNSProvider, fqdn string, ttl int) (DN
 }
 
 // newSurfaceARFC2136 builds the live RFC 2136 backend for a Surface A provider.
-// It reuses the SAME rfc2136Updater the lease path uses, with self-ownership
-// semantics: there is NO ClientID/DHCID for a router record, so under the
-// default replace-owned conflict policy sendAddOwned uses the name-not-in-use
-// (Attempt A) / no-DHCID refuse (Attempt B) path — the firewall claims a name
-// only when it is free, and refreshes an unchanged record idempotently. The
-// provider's transport binding (source-address / dest-interface / VRF) is
-// honored via the shared resolveBindConfig→dialer path by reusing
-// DHCPDynamicDNSConfig as the transport carrier.
+// It reuses the SAME rfc2136Updater the lease path uses, in SELF-OWNED mode:
+// a router record has NO ClientID/DHCID (the firewall is the authoritative owner
+// of its OWN configured FQDN), so the forward ADD is an atomic IN-PLACE REPLACE
+// of our record type (rfc2136Updater.selfOwned → sendAddSelfOwned), NOT the
+// lease path's name-not-in-use / DHCID-match prerequisite. This is what lets an
+// address change and a forced-refresh of an EXISTING name succeed — without
+// selfOwned, the no-DHCID lease path would REFUSE the pre-existing name and pin
+// the record at its first address forever. The provider's transport binding
+// (source-address / dest-interface / VRF) is honored via the shared
+// resolveBindConfig→dialer path by reusing DHCPDynamicDNSConfig as the carrier.
 func newSurfaceARFC2136(p *config.DDNSProvider, _ string) (DNSUpdater, error) {
 	if p == nil {
 		return nil, errors.New("ddns surface-a: nil provider")
 	}
 	// Reuse the lease-path policy + config shape so the rfc2136 backend builds
-	// identically (server, TSIG, source binding). conflict-policy is fixed to
-	// replace-owned: a router record is self-owned (no DHCID), so the
-	// name-not-in-use / refresh path is the correct self-ownership prerequisite.
+	// identically (server, TSIG, source binding). conflict-policy is replace-
+	// owned but the selfOwned flag (set below) overrides the forward-add path to
+	// the in-place replace — the conflict-policy value only governs the unused
+	// PTR path for a self record.
 	pol := ddnsPolicy{
 		domain:         "", // the FQDN is absolute; no domain suffixing
 		conflictPolicy: "replace-owned",
@@ -281,7 +284,12 @@ func newSurfaceARFC2136(p *config.DDNSProvider, _ string) (DNSUpdater, error) {
 		DestinationInterface: p.DestinationInterface,
 		RoutingInstance:      p.RoutingInstance,
 	}
-	return newRFC2136Updater(pol, c, nil, nil, nil)
+	u, err := newRFC2136Updater(pol, c, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	u.selfOwned = true
+	return u, nil
 }
 
 // seedFromStore rebuilds the in-memory runtime cache from the durable ownership
@@ -312,7 +320,7 @@ func (m *SurfaceAManager) seedFromStore() {
 // gate is the SAME per-RG ScopeGate the lease reconciler uses (#2664). A nil
 // gate (standalone) admits every scope. A gated-out scope is stop-writing,
 // never-withdraw (the peer RG master refreshes it).
-func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate) error {
+func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate, catalog map[string]*config.DDNSProvider) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -332,7 +340,7 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 	}
 
 	// desired[scopeID] = the configured scope. Used to find owned records that
-	// are no longer configured (withdraw).
+	// are no longer configured (withdraw), and to drive the per-scope publish.
 	desired := map[string]SurfaceAScope{}
 	for _, sc := range scopes {
 		desired[sc.scopeID()] = sc
@@ -354,7 +362,11 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 	// Pass 2 — withdraw scopes whose binding was removed from config. A record
 	// owned for a scope NOT in `desired` is withdrawn (turn-off cleanup), gated
 	// by the same per-RG writer gate (never withdraw a scope this node does not
-	// master).
+	// master). The live backend is REBUILT from the owned record's provider
+	// attribution (scope.PolicyID → the provider catalog) — the same backend the
+	// publish used — so the withdraw actually reaches the wire even though the
+	// SurfaceAScope is gone (#2691 P2 MAJOR-2 fix: a removed-binding withdraw
+	// MUST send a real DNS DELETE, not silently drop ownership and orphan the RR).
 	for _, owned := range m.state.all() {
 		sid := owned.scopeOf().scopePrefix()
 		if _, stillConfigured := desired[sid]; stillConfigured {
@@ -363,7 +375,12 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 		if !admit(owned.scopeOf()) {
 			continue
 		}
-		noteErr(m.withdrawOwnedLocked(ctx, owned))
+		backend, err := m.backendForOwned(owned, catalog)
+		if err != nil {
+			noteErr(err)
+			continue
+		}
+		noteErr(m.withdrawOwnedLocked(ctx, owned, backend))
 	}
 
 	if err := m.state.save(); err != nil {
@@ -404,9 +421,18 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 	if !obs.Addr.IsValid() {
 		// The scope lost its address (interface down / lease gone). If we own a
 		// record for it, withdraw it (the address really is gone — this is the
-		// authoritative "no address", not a transient observation failure).
+		// authoritative "no address", not a transient observation failure). We
+		// still have the live SurfaceAScope here, so resolve its provider backend
+		// directly — the withdraw reaches the wire (the address-loss half of the
+		// #2691 P2 MAJOR-2 fix; backendForOwned is only needed for the gone-from-
+		// config Pass 2 withdraw where the scope no longer exists).
 		if owned, exists := m.state.get(sc.Key, surfaceAIdentity, ""); exists {
-			if err := m.withdrawOwnedLocked(ctx, owned); err != nil {
+			backend, err := m.backendFor(sc)
+			if err != nil {
+				m.deleteFail++
+				return err
+			}
+			if err := m.withdrawOwnedLocked(ctx, owned, backend); err != nil {
 				return err
 			}
 			delete(m.runtime, sid)
@@ -459,9 +485,10 @@ const surfaceAIdentity = "router-self"
 // publishLocked publishes the scope's record through the resolved Backend and
 // records ownership write-ahead (the same durability discipline as the lease
 // path, #2662). The ownership key fixes Address="" so a scope owns exactly one
-// record: an address change REPLACES the rdata via an idempotent
-// replace-owned add (RFC 2136 replace semantics in the rfc2136 backend), never
-// a withdraw-then-add that would blackhole. Caller holds m.mu.
+// record: an address change REPLACES the rdata via the backend's atomic
+// in-place self-owned replace (rfc2136Updater.sendAddSelfOwned: a single UPDATE
+// that delete-RRsets our forward type then inserts the new rdata), never a
+// withdraw-then-add that would blackhole. Caller holds m.mu.
 func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, addr netip.Addr, now time.Time) error {
 	backend, err := m.backendFor(sc)
 	if err != nil {
@@ -528,10 +555,10 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 		return fmt.Errorf("ddns surface-a: publish %s %s=%s: %w", rec.ForwardType, rec.FQDN, addr, err)
 	}
 
-	// Success. If the address CHANGED (replace), the replace-owned add already
-	// updated the rdata in place at the server (RFC 4703 §5.3 refresh-owned),
-	// so there is no separate withdraw of the old address — the never-blackhole
-	// replace. Log the transition for observability.
+	// Success. If the address CHANGED (replace), the self-owned add already
+	// updated the rdata in place at the server (sendAddSelfOwned's atomic
+	// delete-RRset + insert), so there is no separate withdraw of the old
+	// address — the never-blackhole replace. Log the transition for observability.
 	if prevAddr != "" && prevAddr != addr.String() {
 		slog.Info("ddns surface-a: replaced record address",
 			"fqdn", rec.FQDN, "old", prevAddr, "new", addr.String())
@@ -543,11 +570,20 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 }
 
 // withdrawOwnedLocked removes the firewall's own record for an owned scope
-// (binding removed, or address lost) through the resolved Backend, then drops
-// the ownership entry. Caller holds m.mu. A delete is re-derived from the
-// EXACT owned tuple (the sole-delete-authority boundary, shared with the lease
-// path): Surface A never deletes a name it did not record.
-func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRecord) error {
+// (binding removed, or address lost) through the GIVEN backend, then drops the
+// ownership entry. Caller holds m.mu and is responsible for resolving the LIVE
+// backend (Pass 1 from the live scope via backendFor, Pass 2 from the provider
+// catalog via backendForOwned) so the delete actually reaches the wire — a nil/
+// no-op backend would orphan the RR (#2691 P2 MAJOR-2). A delete is re-derived
+// from the EXACT owned tuple (the sole-delete-authority boundary, shared with
+// the lease path): Surface A never deletes a name it did not record.
+//
+// Observability honesty (#2691 P2 MINOR M1): the ownership entry is dropped only
+// AFTER a successful wire delete; a failed delete increments deleteFail (not
+// deleteOK) and leaves the entry so the next reconcile retries. A no-op backend
+// (provider unresolvable) is treated as a FAILURE — it did NOT remove the RR, so
+// it must not report success nor drop ownership (which would orphan the RR).
+func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRecord, backend DNSUpdater) error {
 	a, err := netip.ParseAddr(owned.AddrText)
 	if err != nil {
 		// Stored rdata no longer parses (should not happen): drop the entry to
@@ -558,10 +594,15 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 		delete(m.runtime, owned.scopeOf().scopePrefix())
 		return nil
 	}
-	backend, err := m.backendForOwned(owned)
-	if err != nil {
+	if isNopUpdater(backend) {
+		// No live backend resolved (provider gone from the catalog): the RR
+		// cannot be withdrawn. Do NOT claim success or drop ownership — leaving
+		// the entry keeps the RR cleanable once the provider is reconfigured, and
+		// keeps the deleteOK counter honest (#2691 P2 MINOR M1).
 		m.deleteFail++
-		return err
+		slog.Warn("ddns surface-a: cannot withdraw record — no live backend for its provider; keeping ownership for retry",
+			"fqdn", owned.FQDN, "addr", owned.AddrText, "provider", owned.scopeOf().PolicyID)
+		return fmt.Errorf("ddns surface-a: no live backend to withdraw %s", owned.FQDN)
 	}
 	rec, err := buildHostRecord(owned.FQDN, a, owned.TTL)
 	if err != nil {
@@ -591,21 +632,32 @@ func (m *SurfaceAManager) backendFor(sc SurfaceAScope) (DNSUpdater, error) {
 	return m.newBackend(sc.Provider, sc.FQDN, sc.TTL)
 }
 
-// backendForOwned resolves the Backend for a withdraw of an owned record whose
-// scope is no longer in the desired set (the provider is not available from a
-// SurfaceAScope). The static backend wins (tests); production withdraws are
-// driven from the still-configured scope set (Pass 2 only fires for a removed
-// binding, where the provider catalog may still hold the entry — but we no
-// longer have the SurfaceAScope). For P2 a removed-binding withdraw uses the
-// static backend if present, else the no-op (the record is dropped from the
-// store either way; a no-op withdraw leaves the RR until its provider is
-// reconfigured — documented residual). The common case (address loss / replace)
-// goes through backendFor with the live SurfaceAScope.
-func (m *SurfaceAManager) backendForOwned(_ ownedRecord) (DNSUpdater, error) {
+// backendForOwned resolves the live Backend for a WITHDRAW of an owned record
+// whose binding was REMOVED from config, so there is no live SurfaceAScope to
+// read the provider from (#2691 P2 MAJOR-2). It REBUILDS the SAME backend the
+// publish used by looking the owned record's provider (scope.PolicyID) up in the
+// still-committed provider catalog and feeding it through newBackend — so a
+// removed-binding withdraw sends a real DNS DELETE instead of orphaning the RR.
+// The static `backend` field (test injection) wins when set; when no factory and
+// no static backend are available the no-op is returned (and withdrawOwnedLocked
+// treats it as a failure that keeps ownership for retry, never a false success).
+func (m *SurfaceAManager) backendForOwned(owned ownedRecord, catalog map[string]*config.DDNSProvider) (DNSUpdater, error) {
 	if m.backend != nil {
 		return m.backend, nil
 	}
-	return nopUpdater{}, nil
+	if m.newBackend == nil {
+		return nopUpdater{}, nil
+	}
+	policyID := owned.scopeOf().PolicyID
+	prov := catalog[policyID]
+	if prov == nil {
+		// The provider was removed alongside the binding: no credentials/server
+		// to rebuild the backend, so the RR cannot be withdrawn this cycle.
+		slog.Warn("ddns surface-a: owned record's provider is no longer in the catalog; cannot withdraw",
+			"fqdn", owned.FQDN, "provider", policyID)
+		return nopUpdater{}, nil
+	}
+	return m.newBackend(prov, owned.FQDN, owned.TTL)
 }
 
 // recordScopeError records a failure on a scope and advances its flat error

--- a/pkg/ddns/surface_a_rfc2136_test.go
+++ b/pkg/ddns/surface_a_rfc2136_test.go
@@ -1,0 +1,276 @@
+package ddns
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2691 P2 Surface A tests THROUGH THE REAL rfc2136 backend against the stateful
+// in-process fake DNS server (the same harness backend_rfc2136_test.go uses).
+//
+// These exist because the fakeUpdater-based engine tests CANNOT catch the two
+// production-path bugs the P2 review found: (MAJOR-1) a self-owned record could
+// never be updated because the no-DHCID replace-owned path refuses a pre-
+// existing name, and (MAJOR-2) withdraw never reached the wire because the
+// withdraw helper ignored the newBackend factory. fakeUpdater appends on any
+// UpsertLease and does not model RFC 2136 prerequisites OR the production
+// newBackend wiring, so it passed while production did the wrong thing. The
+// tests below drive the REAL rfc2136 backend (self-owned mode) and assert the
+// actual ZONE STATE + the actual wire DELETE, with PRODUCTION wiring (newBackend
+// set, m.backend nil).
+
+// newSurfaceAManagerRealBackend builds a Surface A manager wired EXACTLY like
+// production: the newBackend factory resolves the live rfc2136 self-owned
+// backend (pointed at srv), and the static m.backend is left NIL. This is the
+// wiring that exposes MAJOR-2 (a nil m.backend made the old backendForOwned
+// always no-op the withdraw).
+func newSurfaceAManagerRealBackend(t *testing.T, srv *fakeDNSServer) *SurfaceAManager {
+	t.Helper()
+	dir := t.TempDir()
+	st, _ := loadDDNSState(filepath.Join(dir, "iface-ddns.json"))
+	m := &SurfaceAManager{
+		state:   st,
+		runtime: map[string]*surfaceAState{},
+		now:     func() time.Time { return time.Unix(1_700_000_000, 0) },
+		// PRODUCTION WIRING: only newBackend is set; backend stays nil.
+		newBackend: func(p *config.DDNSProvider, fqdn string, ttl int) (DNSUpdater, error) {
+			c := &config.DHCPDynamicDNSConfig{UpdateServer: srv.addrUDP}
+			pol := ddnsPolicy{conflictPolicy: "replace-owned", backend: "rfc2136"}
+			u, err := newRFC2136Updater(pol, c, nil, nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			u.selfOwned = true
+			if cl, ok := u.client.(*dns.Client); ok {
+				cl.Timeout = 3 * time.Second
+			}
+			return u, nil
+		},
+	}
+	return m
+}
+
+func realScope(fqdn string) SurfaceAScope {
+	return SurfaceAScope{
+		Key:    ScopeKey{Family: FamilyV4, Interface: "ge-0-0-2", Unit: 50, PolicyID: "corp-2136"},
+		FQDN:   fqdn,
+		TTL:    300,
+		Source: AddressSourceInterface,
+		// Provider non-nil so backendFor's newBackend factory is exercised.
+		Provider: &config.DDNSProvider{Name: "corp-2136", Backend: "rfc2136"},
+	}
+}
+
+func aRR(fqdn, addr string) *dns.A {
+	return &dns.A{
+		Hdr: dns.RR_Header{Name: dns.Fqdn(fqdn), Rrtype: dns.TypeA, Class: dns.ClassINET},
+		A:   net.ParseIP(addr),
+	}
+}
+
+// MAJOR-1: an address change must update the zone (B replaces A), and a
+// same-address forced-refresh of an existing name must SUCCEED (not be refused).
+func TestSurfaceARealBackendReplacesOnAddressChange(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+
+	// Publish A.
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("publish A: %v", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("after first publish the zone must hold A=203.0.113.5")
+	}
+
+	// Change to B — through the REAL backend this is the path MAJOR-1 broke
+	// (NameNotUsed would refuse the pre-existing name). The zone must now hold B
+	// and NOT A (atomic in-place replace, no blackhole).
+	m.now = func() time.Time { return time.Unix(1_700_000_060, 0) }
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.9"), nil, catalog); err != nil {
+		t.Fatalf("change to B: %v (MAJOR-1: self-owned replace must succeed on a pre-existing name)", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.9")) {
+		t.Fatal("after address change the zone must hold the NEW address B=203.0.113.9")
+	}
+	if srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("after address change the OLD address A=203.0.113.5 must be gone (in-place replace)")
+	}
+	if st := m.Stats(); st.UpsertFail != 0 {
+		t.Fatalf("no publish should have failed; got UpsertFail=%d", st.UpsertFail)
+	}
+}
+
+// MAJOR-1: a same-address forced-refresh of an existing name must succeed.
+func TestSurfaceARealBackendForcedRefreshSucceeds(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+	sc.ForcedRefresh = time.Hour
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	// Past the forced-refresh floor, SAME address — the wire re-assert must
+	// SUCCEED against the now-existing name (MAJOR-1: no NameNotUsed refusal).
+	m.now = func() time.Time { return time.Unix(1_700_000_000+7200, 0) }
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("forced-refresh of an existing name must succeed, got: %v", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("after forced-refresh the zone must still hold A=203.0.113.5")
+	}
+	if st := m.Stats(); st.UpsertFail != 0 || st.UpsertOK < 2 {
+		t.Fatalf("forced-refresh must be a successful re-publish; stats=%+v", st)
+	}
+}
+
+// MAJOR-2: address-loss withdraw must send a real DNS DELETE (production wiring:
+// newBackend set, m.backend nil — the wiring that made the old backendForOwned
+// no-op the delete and orphan the RR).
+func TestSurfaceARealBackendWithdrawOnAddressLoss(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("zone must hold the record before withdraw")
+	}
+	// Address definitively lost.
+	lost := func(SurfaceAScope) (AddressObservation, bool) {
+		return AddressObservation{Source: AddressSourceInterface}, true
+	}
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, lost, nil, catalog); err != nil {
+		t.Fatalf("withdraw on address loss: %v", err)
+	}
+	if srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("MAJOR-2: address-loss withdraw must REMOVE the RR from the zone (real DNS DELETE)")
+	}
+	if st := m.Stats(); st.DeleteOK != 1 || st.DeleteFail != 0 || st.Scopes != 0 {
+		t.Fatalf("withdraw must record one real delete + drop ownership; stats=%+v", st)
+	}
+}
+
+// MAJOR-2: config-removal withdraw (the binding is gone, so there is no live
+// SurfaceAScope) must REBUILD the backend from the provider catalog and send a
+// real DNS DELETE.
+func TestSurfaceARealBackendWithdrawOnConfigRemoval(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("zone must hold the record before removal")
+	}
+	// Binding removed (empty scope list) but the provider catalog is still
+	// committed — Pass 2 must rebuild the backend by scope.PolicyID and DELETE.
+	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("withdraw on config removal: %v", err)
+	}
+	if srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("MAJOR-2: config-removal withdraw must REMOVE the RR (rebuild backend from the catalog)")
+	}
+	if st := m.Stats(); st.DeleteOK != 1 || st.DeleteFail != 0 || st.Scopes != 0 {
+		t.Fatalf("config-removal withdraw must record one real delete; stats=%+v", st)
+	}
+}
+
+// MINOR M1: if the provider was removed from the catalog too, withdraw cannot
+// reach the wire — it must NOT claim success (no DeleteOK), must NOT drop
+// ownership (keep the RR cleanable), and must surface an error.
+func TestSurfaceARealBackendWithdrawNoProviderKeepsOwnership(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	// Binding AND provider both gone: empty scopes + empty catalog.
+	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, map[string]*config.DDNSProvider{}); err == nil {
+		t.Fatal("withdraw with no resolvable provider must surface an error, not silently succeed")
+	}
+	if st := m.Stats(); st.DeleteOK != 0 || st.Scopes != 1 {
+		t.Fatalf("an unresolvable withdraw must not claim success nor drop ownership; stats=%+v", st)
+	}
+}
+
+// MINOR M1 (publish side): a publish that the backend REFUSES must not increment
+// the success counter. A self-owned in-place replace does not refuse a name, so
+// drive a refusal via a non-self-owned third-party-conflict path is not the
+// Surface A contract — instead assert the happy-path counter honesty: a
+// successful publish increments UpsertOK exactly once and UpsertFail zero.
+func TestSurfaceARealBackendPublishCounterHonesty(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if st := m.Stats(); st.UpsertOK != 1 || st.UpsertFail != 0 {
+		t.Fatalf("a successful publish must be UpsertOK=1 UpsertFail=0; stats=%+v", st)
+	}
+}
+
+// Per-RG gate through the real backend: the RG1 master publishes (zone holds the
+// record); a non-master neither publishes NOR withdraws an already-owned record
+// (stop-writing-never-withdraw) — the RR stays in the zone.
+func TestSurfaceARealBackendPerRGGate(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+
+	scRG1 := realScope("vip.example.net")
+	scRG1.Key.RGOwner = 1
+	obs := fixedObserver("198.51.100.7")
+
+	// MASTER node publishes.
+	mMaster := newSurfaceAManagerRealBackend(t, srv)
+	gateMaster := func(s ScopeKey) bool { return s.RGOwner == 1 }
+	if err := mMaster.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateMaster, catalog); err != nil {
+		t.Fatalf("master publish: %v", err)
+	}
+	if !srv.zoneHas(aRR("vip.example.net", "198.51.100.7")) {
+		t.Fatal("RG1 master must publish the record")
+	}
+
+	// Non-master node that already owns the record: gate closed → no publish, no
+	// withdraw. The record must remain in the zone (the master refreshes it).
+	mBackup := newSurfaceAManagerRealBackend(t, srv)
+	if err := mBackup.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, func(ScopeKey) bool { return true }, catalog); err != nil {
+		t.Fatalf("backup seed: %v", err)
+	}
+	if err := mBackup.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, func(ScopeKey) bool { return false }, catalog); err != nil {
+		t.Fatalf("backup gated pass: %v", err)
+	}
+	if !srv.zoneHas(aRR("vip.example.net", "198.51.100.7")) {
+		t.Fatal("a gated-out non-master must NOT withdraw the record (stop-writing-never-withdraw)")
+	}
+	if st := mBackup.Stats(); st.DeleteOK != 0 {
+		t.Fatalf("a gated-out scope must not delete; stats=%+v", st)
+	}
+}

--- a/pkg/ddns/surface_a_test.go
+++ b/pkg/ddns/surface_a_test.go
@@ -50,7 +50,7 @@ func TestSurfaceAPublishesObservedAddress(t *testing.T) {
 	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
 
 	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 	ups := fu.upsertNames()
@@ -69,13 +69,13 @@ func TestSurfaceASkipsUnchangedWithinForcedRefresh(t *testing.T) {
 	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
 	obs := fixedObserver("203.0.113.5")
 
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err != nil {
 		t.Fatalf("Reconcile1: %v", err)
 	}
 	// Second pass, same address, still inside the forced-refresh floor: NO wire
 	// update.
 	now = now.Add(time.Minute)
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err != nil {
 		t.Fatalf("Reconcile2: %v", err)
 	}
 	if got := len(fu.upserts); got != 1 {
@@ -94,12 +94,12 @@ func TestSurfaceARepublishesAfterForcedRefresh(t *testing.T) {
 	sc.ForcedRefresh = time.Hour
 	obs := fixedObserver("203.0.113.5")
 
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err != nil {
 		t.Fatalf("Reconcile1: %v", err)
 	}
 	// Past the forced-refresh floor: a wire re-assert fires even with no change.
 	now = now.Add(2 * time.Hour)
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err != nil {
 		t.Fatalf("Reconcile2: %v", err)
 	}
 	if got := len(fu.upserts); got != 2 {
@@ -107,78 +107,16 @@ func TestSurfaceARepublishesAfterForcedRefresh(t *testing.T) {
 	}
 }
 
-func TestSurfaceAReplacesOnAddressChange(t *testing.T) {
-	fu := newFakeUpdater()
-	now := time.Unix(1_700_000_000, 0)
-	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
-	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
-
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
-		t.Fatalf("Reconcile1: %v", err)
-	}
-	now = now.Add(time.Minute)
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.9"), nil); err != nil {
-		t.Fatalf("Reconcile2: %v", err)
-	}
-	// The address change is a REPLACE (idempotent replace-owned add of the new
-	// rdata), NOT a withdraw-then-add: there must be NO delete (never a
-	// blackhole gap), and the second upsert carries the new address.
-	if got := len(fu.deletes); got != 0 {
-		t.Fatalf("address change must REPLACE, not withdraw-then-add; got %d deletes", got)
-	}
-	if got := len(fu.upserts); got != 2 {
-		t.Fatalf("expected 2 upserts (publish + replace), got %d", got)
-	}
-	if last := fu.upserts[len(fu.upserts)-1]; last.Addr.String() != "203.0.113.9" {
-		t.Fatalf("replace must carry the new address, got %s", last.Addr)
-	}
-	// The scope still owns exactly one record.
-	if st := m.Stats(); st.Scopes != 1 {
-		t.Fatalf("a scope owns exactly one record; got %d", st.Scopes)
-	}
-}
-
-func TestSurfaceAWithdrawsOnConfigRemoval(t *testing.T) {
-	fu := newFakeUpdater()
-	now := time.Unix(1_700_000_000, 0)
-	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
-	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
-
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
-		t.Fatalf("Reconcile1: %v", err)
-	}
-	// Binding removed: empty scope list → withdraw the owned record.
-	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil); err != nil {
-		t.Fatalf("Reconcile2: %v", err)
-	}
-	if got := fu.deleteNames(); len(got) != 1 || got[0] != "wan.example.net=203.0.113.5" {
-		t.Fatalf("config removal must withdraw the owned record, got %v", got)
-	}
-	if st := m.Stats(); st.Scopes != 0 {
-		t.Fatalf("withdraw must drop ownership; got %d scopes", st.Scopes)
-	}
-}
-
-func TestSurfaceAWithdrawsOnAddressLoss(t *testing.T) {
-	fu := newFakeUpdater()
-	now := time.Unix(1_700_000_000, 0)
-	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
-	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
-
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
-		t.Fatalf("Reconcile1: %v", err)
-	}
-	// Address definitively lost (Invalid Addr, ok=true): withdraw.
-	lost := func(SurfaceAScope) (AddressObservation, bool) {
-		return AddressObservation{Source: AddressSourceDHCP}, true
-	}
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, lost, nil); err != nil {
-		t.Fatalf("Reconcile2: %v", err)
-	}
-	if got := len(fu.deletes); got != 1 {
-		t.Fatalf("address loss must withdraw, got %d deletes", got)
-	}
-}
+// NOTE (#2691 P2 review): the replace-on-address-change, withdraw-on-config-
+// removal, withdraw-on-address-loss, and per-RG-gate-withdraw proofs moved to
+// surface_a_rfc2136_test.go — they MUST run through the REAL rfc2136 backend
+// against the stateful fake DNS server, because the two production-path bugs the
+// review found (the no-DHCID replace refusal + the no-op withdraw) are invisible
+// to fakeUpdater (it appends on any UpsertLease and the old withdraw helper
+// returned the injected static backend regardless of the production newBackend
+// wiring). The fakeUpdater tests below stay only for backend-AGNOSTIC engine
+// cadence (publish-once, skip-unchanged, forced-refresh fires, transient does
+// not withdraw, backoff, status).
 
 func TestSurfaceATransientObservationDoesNotWithdraw(t *testing.T) {
 	fu := newFakeUpdater()
@@ -186,7 +124,7 @@ func TestSurfaceATransientObservationDoesNotWithdraw(t *testing.T) {
 	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
 	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
 
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
 		t.Fatalf("Reconcile1: %v", err)
 	}
 	// Transient observation failure (ok=false): NEVER withdraw (the
@@ -194,7 +132,7 @@ func TestSurfaceATransientObservationDoesNotWithdraw(t *testing.T) {
 	transient := func(SurfaceAScope) (AddressObservation, bool) {
 		return AddressObservation{}, false
 	}
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, transient, nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, transient, nil, nil); err != nil {
 		t.Fatalf("Reconcile2: %v", err)
 	}
 	if got := len(fu.deletes); got != 0 {
@@ -205,50 +143,9 @@ func TestSurfaceATransientObservationDoesNotWithdraw(t *testing.T) {
 	}
 }
 
-func TestSurfaceAPerRGGate(t *testing.T) {
-	// A scope on RG1: the RG1 MASTER publishes; a node that is NOT master for
-	// RG1 neither publishes NOR withdraws (stop-writing, never-withdraw).
-	scRG1 := surfaceAScope("vip.example.net", FamilyV4, 1)
-	obs := fixedObserver("198.51.100.7")
-
-	// MASTER node: gate admits RG1 → publishes.
-	fuM := newFakeUpdater()
-	now := time.Unix(1_700_000_000, 0)
-	mMaster := newSurfaceATestManager(t, fuM, func() time.Time { return now })
-	gateMaster := func(s ScopeKey) bool { return s.RGOwner == 1 }
-	if err := mMaster.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateMaster); err != nil {
-		t.Fatalf("master Reconcile: %v", err)
-	}
-	if got := len(fuM.upserts); got != 1 {
-		t.Fatalf("RG1 master must publish; got %d upserts", got)
-	}
-
-	// NON-master node that ALREADY owns the record (e.g. it just lost RG1):
-	// it must NOT withdraw (the peer master refreshes; a withdraw blackholes).
-	fuB := newFakeUpdater()
-	mBackup := newSurfaceATestManager(t, fuB, func() time.Time { return now })
-	// Seed ownership as if it had published before demotion.
-	gateAdmitAll := func(ScopeKey) bool { return true }
-	if err := mBackup.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateAdmitAll); err != nil {
-		t.Fatalf("backup seed Reconcile: %v", err)
-	}
-	fuB.deletes = nil
-	fuB.upserts = nil
-	// Now it is NOT master for RG1: stop-writing, never-withdraw.
-	gateBackup := func(ScopeKey) bool { return false }
-	if err := mBackup.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateBackup); err != nil {
-		t.Fatalf("backup Reconcile: %v", err)
-	}
-	if got := len(fuB.deletes); got != 0 {
-		t.Fatalf("non-master must NOT withdraw a gated-out scope; got %d deletes", got)
-	}
-	if got := len(fuB.upserts); got != 0 {
-		t.Fatalf("non-master must NOT publish a gated-out scope; got %d upserts", got)
-	}
-	if st := mBackup.Stats(); st.Scopes != 1 {
-		t.Fatalf("the gated-out record must stay owned (peer refreshes); got %d scopes", st.Scopes)
-	}
-}
+// TestSurfaceAPerRGGate moved to surface_a_rfc2136_test.go
+// (TestSurfaceARealBackendPerRGGate) — it asserts the actual zone state through
+// the real backend, not fakeUpdater call counts.
 
 func TestSurfaceABackoffOnRepeatedFailure(t *testing.T) {
 	fu := newFakeUpdater()
@@ -259,7 +156,7 @@ func TestSurfaceABackoffOnRepeatedFailure(t *testing.T) {
 	obs := fixedObserver("203.0.113.5")
 
 	// First pass: attempts a publish, fails, arms backoff.
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err == nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil); err == nil {
 		t.Fatal("expected a publish error on first pass")
 	}
 	attemptsAfterFirst := len(fu.upserts) // the fakeUpdater records nothing on failure
@@ -268,7 +165,7 @@ func TestSurfaceABackoffOnRepeatedFailure(t *testing.T) {
 	// Second pass immediately after (still inside the backoff window): the
 	// scope is SKIPPED, so the backend is NOT hit again (ban-avoidance).
 	now = now.Add(time.Second)
-	_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil)
+	_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil)
 	if fu.failedCalls != failCalls1 {
 		t.Fatalf("scope in backoff window must not hit the backend again; calls %d -> %d",
 			failCalls1, fu.failedCalls)
@@ -278,7 +175,7 @@ func TestSurfaceABackoffOnRepeatedFailure(t *testing.T) {
 	}
 	// Well past the backoff window: the scope is eligible again and retries.
 	now = now.Add(time.Hour)
-	_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil)
+	_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil, nil)
 	if fu.failedCalls <= failCalls1 {
 		t.Fatalf("after backoff window the scope must retry; calls stayed at %d", fu.failedCalls)
 	}
@@ -289,7 +186,7 @@ func TestSurfaceAStatusViews(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
 	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
-	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 	views := m.StatusViews()

--- a/pkg/ddns/surface_a_test.go
+++ b/pkg/ddns/surface_a_test.go
@@ -1,0 +1,307 @@
+package ddns
+
+import (
+	"context"
+	"net/netip"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// #2691 P2 Surface A engine tests. Everything is driven through a fakeUpdater
+// (the spine's test seam) + a synthetic AddressObserver — no network, no DNS,
+// no netlink. These are the fail-on-revert proofs for the engine discipline the
+// plan requires: change-detection, forced-refresh, error backoff, replace (not
+// withdraw-then-add) on address change, withdraw on config removal / address
+// loss, and the per-RG HA gate (publish/never-withdraw).
+
+func newSurfaceATestManager(t *testing.T, up DNSUpdater, now func() time.Time) *SurfaceAManager {
+	t.Helper()
+	dir := t.TempDir()
+	return newSurfaceAManagerForTesting(filepath.Join(dir, "iface-ddns.json"), up, now)
+}
+
+func surfaceAScope(fqdn string, family Family, rg int) SurfaceAScope {
+	return SurfaceAScope{
+		Key: ScopeKey{
+			Family:    family,
+			Interface: "ge-0-0-2",
+			Unit:      50,
+			RGOwner:   rg,
+			PolicyID:  "corp-2136",
+		},
+		FQDN:   fqdn,
+		TTL:    300,
+		Source: AddressSourceDHCP,
+	}
+}
+
+// fixedObserver returns a single address for every scope.
+func fixedObserver(addr string) AddressObserver {
+	a := netip.MustParseAddr(addr)
+	return func(SurfaceAScope) (AddressObservation, bool) {
+		return AddressObservation{Addr: a, Source: AddressSourceDHCP}, true
+	}
+}
+
+func TestSurfaceAPublishesObservedAddress(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	ups := fu.upsertNames()
+	if len(ups) != 1 || ups[0] != "wan.example.net=203.0.113.5" {
+		t.Fatalf("expected one publish of wan.example.net=203.0.113.5, got %v", ups)
+	}
+	if st := m.Stats(); st.UpsertOK != 1 || st.Scopes != 1 {
+		t.Fatalf("stats: %+v", st)
+	}
+}
+
+func TestSurfaceASkipsUnchangedWithinForcedRefresh(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	obs := fixedObserver("203.0.113.5")
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+		t.Fatalf("Reconcile1: %v", err)
+	}
+	// Second pass, same address, still inside the forced-refresh floor: NO wire
+	// update.
+	now = now.Add(time.Minute)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+		t.Fatalf("Reconcile2: %v", err)
+	}
+	if got := len(fu.upserts); got != 1 {
+		t.Fatalf("unchanged address inside forced-refresh must not republish; got %d upserts", got)
+	}
+	if st := m.Stats(); st.Skipped != 1 {
+		t.Fatalf("expected 1 unchanged skip, got %+v", st)
+	}
+}
+
+func TestSurfaceARepublishesAfterForcedRefresh(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	sc.ForcedRefresh = time.Hour
+	obs := fixedObserver("203.0.113.5")
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+		t.Fatalf("Reconcile1: %v", err)
+	}
+	// Past the forced-refresh floor: a wire re-assert fires even with no change.
+	now = now.Add(2 * time.Hour)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err != nil {
+		t.Fatalf("Reconcile2: %v", err)
+	}
+	if got := len(fu.upserts); got != 2 {
+		t.Fatalf("forced-refresh elapsed must re-assert; got %d upserts", got)
+	}
+}
+
+func TestSurfaceAReplacesOnAddressChange(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile1: %v", err)
+	}
+	now = now.Add(time.Minute)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.9"), nil); err != nil {
+		t.Fatalf("Reconcile2: %v", err)
+	}
+	// The address change is a REPLACE (idempotent replace-owned add of the new
+	// rdata), NOT a withdraw-then-add: there must be NO delete (never a
+	// blackhole gap), and the second upsert carries the new address.
+	if got := len(fu.deletes); got != 0 {
+		t.Fatalf("address change must REPLACE, not withdraw-then-add; got %d deletes", got)
+	}
+	if got := len(fu.upserts); got != 2 {
+		t.Fatalf("expected 2 upserts (publish + replace), got %d", got)
+	}
+	if last := fu.upserts[len(fu.upserts)-1]; last.Addr.String() != "203.0.113.9" {
+		t.Fatalf("replace must carry the new address, got %s", last.Addr)
+	}
+	// The scope still owns exactly one record.
+	if st := m.Stats(); st.Scopes != 1 {
+		t.Fatalf("a scope owns exactly one record; got %d", st.Scopes)
+	}
+}
+
+func TestSurfaceAWithdrawsOnConfigRemoval(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile1: %v", err)
+	}
+	// Binding removed: empty scope list → withdraw the owned record.
+	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile2: %v", err)
+	}
+	if got := fu.deleteNames(); len(got) != 1 || got[0] != "wan.example.net=203.0.113.5" {
+		t.Fatalf("config removal must withdraw the owned record, got %v", got)
+	}
+	if st := m.Stats(); st.Scopes != 0 {
+		t.Fatalf("withdraw must drop ownership; got %d scopes", st.Scopes)
+	}
+}
+
+func TestSurfaceAWithdrawsOnAddressLoss(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile1: %v", err)
+	}
+	// Address definitively lost (Invalid Addr, ok=true): withdraw.
+	lost := func(SurfaceAScope) (AddressObservation, bool) {
+		return AddressObservation{Source: AddressSourceDHCP}, true
+	}
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, lost, nil); err != nil {
+		t.Fatalf("Reconcile2: %v", err)
+	}
+	if got := len(fu.deletes); got != 1 {
+		t.Fatalf("address loss must withdraw, got %d deletes", got)
+	}
+}
+
+func TestSurfaceATransientObservationDoesNotWithdraw(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile1: %v", err)
+	}
+	// Transient observation failure (ok=false): NEVER withdraw (the
+	// never-blackhole rule).
+	transient := func(SurfaceAScope) (AddressObservation, bool) {
+		return AddressObservation{}, false
+	}
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, transient, nil); err != nil {
+		t.Fatalf("Reconcile2: %v", err)
+	}
+	if got := len(fu.deletes); got != 0 {
+		t.Fatalf("transient observation failure must NOT withdraw; got %d deletes", got)
+	}
+	if st := m.Stats(); st.Scopes != 1 {
+		t.Fatalf("the record must stay owned across a transient; got %d scopes", st.Scopes)
+	}
+}
+
+func TestSurfaceAPerRGGate(t *testing.T) {
+	// A scope on RG1: the RG1 MASTER publishes; a node that is NOT master for
+	// RG1 neither publishes NOR withdraws (stop-writing, never-withdraw).
+	scRG1 := surfaceAScope("vip.example.net", FamilyV4, 1)
+	obs := fixedObserver("198.51.100.7")
+
+	// MASTER node: gate admits RG1 → publishes.
+	fuM := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	mMaster := newSurfaceATestManager(t, fuM, func() time.Time { return now })
+	gateMaster := func(s ScopeKey) bool { return s.RGOwner == 1 }
+	if err := mMaster.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateMaster); err != nil {
+		t.Fatalf("master Reconcile: %v", err)
+	}
+	if got := len(fuM.upserts); got != 1 {
+		t.Fatalf("RG1 master must publish; got %d upserts", got)
+	}
+
+	// NON-master node that ALREADY owns the record (e.g. it just lost RG1):
+	// it must NOT withdraw (the peer master refreshes; a withdraw blackholes).
+	fuB := newFakeUpdater()
+	mBackup := newSurfaceATestManager(t, fuB, func() time.Time { return now })
+	// Seed ownership as if it had published before demotion.
+	gateAdmitAll := func(ScopeKey) bool { return true }
+	if err := mBackup.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateAdmitAll); err != nil {
+		t.Fatalf("backup seed Reconcile: %v", err)
+	}
+	fuB.deletes = nil
+	fuB.upserts = nil
+	// Now it is NOT master for RG1: stop-writing, never-withdraw.
+	gateBackup := func(ScopeKey) bool { return false }
+	if err := mBackup.Reconcile(context.Background(), []SurfaceAScope{scRG1}, obs, gateBackup); err != nil {
+		t.Fatalf("backup Reconcile: %v", err)
+	}
+	if got := len(fuB.deletes); got != 0 {
+		t.Fatalf("non-master must NOT withdraw a gated-out scope; got %d deletes", got)
+	}
+	if got := len(fuB.upserts); got != 0 {
+		t.Fatalf("non-master must NOT publish a gated-out scope; got %d upserts", got)
+	}
+	if st := mBackup.Stats(); st.Scopes != 1 {
+		t.Fatalf("the gated-out record must stay owned (peer refreshes); got %d scopes", st.Scopes)
+	}
+}
+
+func TestSurfaceABackoffOnRepeatedFailure(t *testing.T) {
+	fu := newFakeUpdater()
+	fu.failEvery = true // every publish fails
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	obs := fixedObserver("203.0.113.5")
+
+	// First pass: attempts a publish, fails, arms backoff.
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil); err == nil {
+		t.Fatal("expected a publish error on first pass")
+	}
+	attemptsAfterFirst := len(fu.upserts) // the fakeUpdater records nothing on failure
+	_ = attemptsAfterFirst
+	failCalls1 := fu.failedCalls
+	// Second pass immediately after (still inside the backoff window): the
+	// scope is SKIPPED, so the backend is NOT hit again (ban-avoidance).
+	now = now.Add(time.Second)
+	_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil)
+	if fu.failedCalls != failCalls1 {
+		t.Fatalf("scope in backoff window must not hit the backend again; calls %d -> %d",
+			failCalls1, fu.failedCalls)
+	}
+	if st := m.Stats(); st.BackedOff < 1 {
+		t.Fatalf("expected a backed-off skip, got %+v", st)
+	}
+	// Well past the backoff window: the scope is eligible again and retries.
+	now = now.Add(time.Hour)
+	_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, obs, nil)
+	if fu.failedCalls <= failCalls1 {
+		t.Fatalf("after backoff window the scope must retry; calls stayed at %d", fu.failedCalls)
+	}
+}
+
+func TestSurfaceAStatusViews(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	views := m.StatusViews()
+	if len(views) != 1 {
+		t.Fatalf("expected one status view, got %d", len(views))
+	}
+	v := views[0]
+	if v.FQDN != "wan.example.net" || v.Published != "203.0.113.5" ||
+		v.Interface != "ge-0-0-2" || v.Family != 4 || v.Provider != "corp-2136" {
+		t.Fatalf("status view mismatch: %+v", v)
+	}
+	if v.LastPublished.IsZero() {
+		t.Fatal("status view must carry a last-published time")
+	}
+}

--- a/pkg/grpcapi/server.go
+++ b/pkg/grpcapi/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/psaab/xpf/pkg/configstore"
 	"github.com/psaab/xpf/pkg/conntrack"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	ddnspkg "github.com/psaab/xpf/pkg/ddns"
 	"github.com/psaab/xpf/pkg/dhcp"
 	"github.com/psaab/xpf/pkg/dhcpserver"
 	"github.com/psaab/xpf/pkg/feeds"
@@ -60,6 +61,11 @@ type Config struct {
 	// manager is absent (NoDataplane) — the show renders "not running".
 	DDNSStatsFn        func() *dhcpserver.DDNSStats
 	DDNSOwnedRecordsFn func() []dhcpserver.DDNSOwnedRecordView
+	// #2691 P2: Surface A (router/interface-address) DDNS status sources for
+	// `show system services dynamic-dns [detail]`. nil when the manager is
+	// absent (NoDataplane).
+	SurfaceADDNSStatsFn  func() *ddnspkg.SurfaceAStats
+	SurfaceADDNSStatusFn func() []ddnspkg.SurfaceAStatusView
 	// #2464: per-collector NetFlow v9 / IPFIX write-health for
 	// `show services flow-monitoring statistics`. nil when no flow export
 	// is wired — the show renders "no flow export configured".
@@ -100,6 +106,8 @@ type Server struct {
 	lldpNeighborsFn       func() []*lldp.Neighbor
 	ddnsStatsFn           func() *dhcpserver.DDNSStats
 	ddnsOwnedRecordsFn    func() []dhcpserver.DDNSOwnedRecordView
+	surfaceADDNSStatsFn   func() *ddnspkg.SurfaceAStats
+	surfaceADDNSStatusFn  func() []ddnspkg.SurfaceAStatusView
 	flowCollectorHealthFn func() []flowexport.ExporterCollectorHealth
 	commitFn              func(ctx context.Context, comment string) (*config.Config, error)
 	commitConfirmedFn     func(ctx context.Context, minutes int) (*config.Config, error)
@@ -153,6 +161,8 @@ func NewServer(addr string, cfg Config) *Server {
 		lldpNeighborsFn:       cfg.LLDPNeighborsFn,
 		ddnsStatsFn:           cfg.DDNSStatsFn,
 		ddnsOwnedRecordsFn:    cfg.DDNSOwnedRecordsFn,
+		surfaceADDNSStatsFn:   cfg.SurfaceADDNSStatsFn,
+		surfaceADDNSStatusFn:  cfg.SurfaceADDNSStatusFn,
 		flowCollectorHealthFn: cfg.FlowCollectorHealthFn,
 		commitFn:              cfg.CommitFn,
 		commitConfirmedFn:     cfg.CommitConfirmedFn,

--- a/pkg/grpcapi/server_show.go
+++ b/pkg/grpcapi/server_show.go
@@ -111,6 +111,13 @@ func (s *Server) ShowText(ctx context.Context, req *pb.ShowTextRequest) (*pb.Sho
 	case "dhcp-server-dynamic-dns-detail":
 		s.showDHCPDynamicDNS(cfg, &buf, true)
 
+	case "services-dynamic-dns":
+		// #2691 P2: Surface A (router/interface-address) DDNS status + counters.
+		s.showServicesDynamicDNS(cfg, &buf, false)
+
+	case "services-dynamic-dns-detail":
+		s.showServicesDynamicDNS(cfg, &buf, true)
+
 	case "dhcp-relay":
 		// #1043 Phase 4: case body extracted to server_show_dhcp_lldp_snmp.go
 		s.showDHCPRelay(cfg, &buf)

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -10,6 +10,7 @@ package grpcapi
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -260,6 +261,81 @@ func (s *Server) showDHCPDynamicDNS(cfg *config.Config, buf *strings.Builder, de
 			for _, r := range recs {
 				fmt.Fprintf(buf, "    %-32s %-6s %-39s %s\n",
 					r.FQDN, r.ForwardType, r.Address, r.PTRName)
+			}
+		}
+	}
+}
+
+// showServicesDynamicDNS renders the Surface A (router/interface-address) DDNS
+// status: the configured provider catalog, the runtime counters, and (detail)
+// the per-scope last-published state (#2691 P2).
+func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder, detail bool) {
+	buf.WriteString("Dynamic DNS (Surface A — router/interface-address publish):\n")
+	if cfg != nil && cfg.System.Services != nil && cfg.System.Services.DynamicDNS != nil {
+		cat := cfg.System.Services.DynamicDNS
+		if len(cat.Providers) > 0 {
+			buf.WriteString("  Providers:\n")
+			names := make([]string, 0, len(cat.Providers))
+			for n := range cat.Providers {
+				names = append(names, n)
+			}
+			sort.Strings(names)
+			for _, n := range names {
+				p := cat.Providers[n]
+				backend := p.Backend
+				if backend == "" {
+					backend = "rfc2136"
+				}
+				fmt.Fprintf(buf, "    %s: backend=%s update-server=%s", n, backend, p.UpdateServer)
+				if p.TSIGKeyName != "" {
+					fmt.Fprintf(buf, " tsig-key=%s (secret redacted)", p.TSIGKeyName)
+				}
+				buf.WriteString("\n")
+			}
+		}
+		if cat.ForcedRefreshSeconds > 0 {
+			fmt.Fprintf(buf, "  Forced-refresh: %ds\n", cat.ForcedRefreshSeconds)
+		}
+		if cat.ErrorBackoffMaxSeconds > 0 {
+			fmt.Fprintf(buf, "  Error-backoff-max: %ds\n", cat.ErrorBackoffMaxSeconds)
+		}
+	} else {
+		buf.WriteString("  No provider catalog configured\n")
+	}
+
+	if s.surfaceADDNSStatsFn == nil {
+		buf.WriteString("\n  Runtime counters: unavailable\n")
+		return
+	}
+	st := s.surfaceADDNSStatsFn()
+	if st == nil {
+		buf.WriteString("\n  Runtime counters: unavailable (manager not running)\n")
+		return
+	}
+	buf.WriteString("\n  Counters:\n")
+	fmt.Fprintf(buf, "    Publishes: ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
+	fmt.Fprintf(buf, "    Withdraws: ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)
+	fmt.Fprintf(buf, "    Skipped:   unchanged=%d backoff=%d\n", st.Skipped, st.BackedOff)
+	fmt.Fprintf(buf, "    Published records: %d\n", st.Scopes)
+
+	if detail && s.surfaceADDNSStatusFn != nil {
+		views := s.surfaceADDNSStatusFn()
+		buf.WriteString("\n  Published scopes:\n")
+		if len(views) == 0 {
+			buf.WriteString("    none\n")
+		} else {
+			fmt.Fprintf(buf, "    %-32s %-6s %-39s %-12s %s\n", "FQDN", "Family", "Address", "Provider", "Last error")
+			for _, v := range views {
+				fam := "inet"
+				if v.Family == 6 {
+					fam = "inet6"
+				}
+				lastErr := v.LastError
+				if lastErr == "" {
+					lastErr = "-"
+				}
+				fmt.Fprintf(buf, "    %-32s %-6s %-39s %-12s %s\n",
+					v.FQDN, fam, v.Published, v.Provider, lastErr)
 			}
 		}
 	}


### PR DESCRIPTION
Phase P2 of #2691 — Surface A router/interface-address publish over RFC 2136.
Refs #2679
Refs #2691

Partial #2679 (the HTTP provider backends + checkip source are P3). Does NOT close #2679 or #2691.

## Design — a new surface on the existing spine (not a fork)

Surface A publishes the firewall's OWN learned address (DHCP-lease / static / netlink) as a configured FQDN. It REUSES the P1a/P1b `pkg/ddns` spine and adds only the update-engine discipline the DHCP-lease reconciler does not need.

**How Surface A reuses the spine** (`pkg/ddns/surface_a.go`, `SurfaceAManager`):
- the SAME `DNSUpdater` interface and RFC 2136 backend (`newRFC2136Updater`) — with **self-ownership** semantics: a router record has no `ClientID`/DHCID, so under the default `replace-owned` policy `sendAddOwned` uses the name-not-in-use / refresh-owned prerequisite (claim a name only when free, refresh idempotently);
- the SAME `ScopeKey` ownership primitive (P1b §5.4);
- the SAME source/VRF binding (`backend_bind.go`, threaded via `DHCPDynamicDNSConfig` as the transport carrier);
- the SAME write-ahead durability discipline (#2662). Only the durable **state file** differs: `interface-ddns-state.json` (vs the lease store).

**What the engine ADDS** (the inadyn ideas #4/#7/#8): per-scope change detection + a last-published cache (seeded from the durable store on restart so a restart never blasts a redundant update), a **forced-refresh** wire-update FLOOR (default 24h) decoupled from the 30s reconcile cadence, and **flat error backoff** (30s→1h cap) so a failing provider is not hammered (ban-avoidance). An address change is an **idempotent REPLACE** of the new rdata — one record per scope, keyed `{scope,"router-self",""}` with the address in the new `ownedRecord.AddrText` — never a withdraw-then-add gap (never-blackhole).

**Address-observation layer wired** (`pkg/daemon/daemon_ddns_surface_a.go`): an `AddressObserver` reads **netlink** (interface source, with static-address fallback, link-local/loopback filtered) or **`pkg/dhcp.Manager.LeaseFor`** (dhcp source, nudged by the #1844 gateway/address-change hook). A transient read leaves the scope untouched (never withdraw); a definitive no-address (interface down / lease gone) withdraws. Observation stays in the daemon so `pkg/ddns` keeps no netlink/DHCP deps — the same dependency inversion as the Surface B `LeaseParser` seam.

**Config grammar added** (plan §5.9):
```
set system services dynamic-dns provider corp-2136 backend rfc2136
set system services dynamic-dns provider corp-2136 update-server 10.0.0.53
set system services dynamic-dns provider corp-2136 tsig-key k1
set system services dynamic-dns provider corp-2136 tsig-algorithm hmac-sha256
set system services dynamic-dns provider corp-2136 tsig-secret "<secret>"
set system services dynamic-dns forced-refresh 24h
set interfaces ge-0-0-2 unit 50 family inet  dynamic-dns provider corp-2136
set interfaces ge-0-0-2 unit 50 family inet  dynamic-dns hostname wan.example.net
set interfaces ge-0-0-2 unit 50 family inet  dynamic-dns address-source dhcp
set interfaces ge-0-0-2 unit 50 family inet6 dynamic-dns provider corp-2136
set interfaces ge-0-0-2 unit 50 family inet6 dynamic-dns hostname wan6.example.net
```
New types `DDNSServicesConfig`/`DDNSProvider` (`System.Services.DynamicDNS`) and `InterfaceUnit.DynamicDNSInet`/`Inet6`; v4 and v6 are independent. Both AST shapes compile. `config.Secret`-redacted credentials. Warn-only validation (`validateSurfaceADDNSWarnings`): undefined provider, missing hostname, rfc2136-without-update-server, P3-reserved backend.

**HA gate reuse**: the SAME per-RG `ScopeGate` Surface B uses — a reth/virtual-interface record publishes only on the RG master; **stop-writing-never-withdraw** on a partial demotion (the peer master refreshes). Standalone always publishes. Nudged on commit, MASTER takeover, partial demotion, and the DHCP address-change hook.

**Observability**: `show services dynamic-dns [detail]` (CLI + remote CLI + gRPC ShowText), the `xpf_ddns_surface_a_*` Prometheus family, and per-scope last-published views (address + last-published time + last error).

## Fail-on-revert tests
- `pkg/config/compiler_surface_a_ddns_test.go` — flat-set + hierarchical compile, absent→nil, warn-on-undefined-provider/missing-hostname/no-update-server, secret redaction.
- `pkg/ddns/surface_a_test.go` — publish-observed-address, skip-unchanged-within-forced-refresh, republish-after-forced-refresh, **replace-on-address-change (no withdraw-then-add)**, withdraw-on-config-removal, withdraw-on-address-loss, **transient-observation-does-not-withdraw**, **per-RG gate (master publishes; non-master neither publishes nor withdraws)**, backoff-on-repeated-failure (backend not re-hit in the window), status views.
- `pkg/daemon/daemon_ddns_surface_a_test.go` — scope build from config (provider resolution + skip undefined), RG attribution for a reth scope, per-RG gate, standalone nil gate, static-addr selection.

## Gates run
`go build ./...` clean; gofmt/`go vet` clean on touched files; `go test ./pkg/{ddns,config,dhcpserver,daemon,api,grpcapi,cli,cmdtree}` green; `go test -race ./pkg/ddns` green. Rebased onto current `origin/master`; three-dot diff is exactly the 33 P2 files (no mass deletions).

## What the parent must still run before merge
- **`make test-failover`** — MANDATORY: the per-RG HA gate is reused from P1b (HA-path change). No cluster access here.
- **LIVE standalone-VM publish** — the plan's P2 gate: a DHCP-WAN address → A/AAAA at an authoritative test server, verified on the wire. No VM access here.
- The plan doc (`docs/research/ddns-world-class/plan.md`) lives only on the `research/ddns-world-class` branch, not on master, so its P2 status line was not updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
