### PR TITLE
screen: invalidate SYN-cookie validated cache on zone profile change (#2446)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-06-24 — #2446: SYN-cookie validated-ACK cache survives zone profile changes
+
+- **Timestamp**: 2026-06-24
+- **Action**: Added a per-zone SYN-cookie profile generation to the
+  validated-ACK cache key. The cache was keyed by `(zone_id, 4-tuple)`
+  and cleared only on a master-key change, so a SYN-cookie-relevant
+  profile edit (disable/re-enable, syn-flood-threshold change,
+  zone→profile rebind) with a stable master key let a tuple validated
+  under the old profile bypass the new profile's SYN-flood counter until
+  TTL expiry. Fix: `SynCookieValidatedKey` now carries `profile_gen`;
+  `ScreenState.update_profiles` bumps a per-zone generation whenever the
+  SYN-cookie signature `(syn_cookie, syn_flood_threshold)` changes (or
+  the zone gains/loses a profile); insert stamps the current generation
+  and `take_valid` compares it (stale gen = miss → re-validate under the
+  new profile). Master-key clear retained as defense in depth. Unrelated
+  profile edits do not bump the generation (no re-validation churn).
+- **File(s)**: userspace-dp/src/screen/syncookie.rs,
+  userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/tests.rs,
+  docs/syn-cookie-flood-protection.md
+- **Validation**: `cargo build --release` clean (no new screen/
+  warnings); `cargo test --release --bin xpf-userspace-dp screen::`
+  123/0. New tests: invalidated_on_profile_change,
+  invalidated_on_disable_reenable, hit_within_same_generation (no
+  regression), generation_is_keyed (unit). Fail-on-revert proven —
+  disabling the gen bump turns the two invalidation tests RED
+  (SynCookieBypass instead of Pass).
+
 ## 2026-06-24 — #2702: BGP group/neighbor export/import bracket-list truncation
 
 - **Timestamp**: 2026-06-24

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -130,7 +130,24 @@ accepts a valid cookie ACK even when it has not locally observed the flood
 threshold; ACKs outside the transmitted-epoch window are prefiltered before
 SipHash, and plausible standby ACKs are rate-limited per zone per second.
 Invalid ACKs outside a local active flood window remain ordinary session-miss
-traffic instead of being counted as cookie failures. If that secret material is
+traffic instead of being counted as cookie failures.
+
+The validated-client cache is keyed by `(zone_id, profile_generation, 4-tuple)`
+(#2446). Each zone carries a SYN-cookie profile generation that is bumped
+whenever a SYN-cookie-relevant profile field changes — the `syn-cookie`
+enable/disable toggle or the `syn-flood` threshold, plus the zone gaining or
+losing a profile (how a zone→profile rebinding manifests). The current
+generation is stamped into an entry on insert and compared on consume: an entry
+from an older generation is treated as a cache miss and the connection is
+re-validated under the new profile, so the new profile's SYN-flood counter sees
+it. This closes the window where a master-key-stable profile edit let a tuple
+validated under the old profile bypass the new profile's flood gate until the
+cache TTL expired. The master-key-rotation clear (`set_hash_keys`) remains as
+defense in depth, and unrelated profile edits (e.g. stateless screens,
+scan/sweep thresholds) do NOT bump the generation, so they cause no
+re-validation churn.
+
+If that secret material is
 absent, userspace
 omits the key and fails closed instead of minting predictable cookies; config
 validation also warns and userspace capability admission refuses active

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -98,6 +98,19 @@ pub(crate) struct ScreenState {
     syn_cookie_standby_ack_counters: FxHashMap<String, RateCounter>,
     syn_cookie_codec: Option<SynCookieCodec>,
     syn_cookie_validated: SynCookieValidatedCache,
+    /// #2446: per-zone SYN-cookie profile generation. Bumped in
+    /// `update_profiles` whenever a zone's SYN-cookie-relevant profile fields
+    /// (`syn_cookie` enable, `syn_flood_threshold`) change — including the
+    /// zone gaining or losing a profile, which is how a zone→profile
+    /// rebinding manifests. The current generation is stamped into a
+    /// validated-cache entry on insert and compared on consume, so a tuple
+    /// validated under an old profile is treated as a cache miss after the
+    /// profile changes and is re-validated under the new profile (its
+    /// SYN-flood counter then sees the connection). Keyed by zone name to
+    /// match `profiles`; the cache is keyed by `zone_id`, but both the insert
+    /// and consume sites carry the zone name, so the name→gen lookup happens
+    /// there.
+    syn_cookie_profile_gen: FxHashMap<String, u64>,
     syn_cookie_last_full_epoch: u64,
     #[cfg(test)]
     syn_cookie_full_epoch_override: Option<u64>,
@@ -118,6 +131,7 @@ impl ScreenState {
             syn_cookie_standby_ack_counters: FxHashMap::default(),
             syn_cookie_codec: None,
             syn_cookie_validated: SynCookieValidatedCache::default(),
+            syn_cookie_profile_gen: FxHashMap::default(),
             syn_cookie_last_full_epoch: 0,
             #[cfg(test)]
             syn_cookie_full_epoch_override: None,
@@ -137,6 +151,13 @@ impl ScreenState {
             .retain(|k, _| profiles.contains_key(k));
         self.syn_cookie_standby_ack_counters
             .retain(|k, _| profiles.contains_key(k));
+        // #2446: drop generation tracking for zones that lost their profile.
+        // If such a zone is reconfigured later, the absence (gen 0 vs. a
+        // freshly bumped gen) makes the next change a bump as well — but the
+        // master-key clear plus the per-entry TTL already bound any window,
+        // and a removed zone has no live cache consumers of its old gen.
+        self.syn_cookie_profile_gen
+            .retain(|k, _| profiles.contains_key(k));
         for zone in profiles.keys() {
             self.icmp_counters.entry(zone.clone()).or_default();
             self.udp_counters.entry(zone.clone()).or_default();
@@ -147,8 +168,40 @@ impl ScreenState {
             self.syn_cookie_standby_ack_counters
                 .entry(zone.clone())
                 .or_default();
+            // #2446: bump the per-zone SYN-cookie profile generation when a
+            // SYN-cookie-relevant field changes (or the zone newly gains a
+            // profile). Only `syn_cookie` (enable/disable) and
+            // `syn_flood_threshold` (the gate that consumes a validated-cache
+            // entry) affect whether a cached validation may legitimately
+            // bypass the SYN-flood counter, so unrelated profile edits
+            // (e.g. teardrop, port-scan) do NOT churn the validated cache.
+            let new_sig = Self::syn_cookie_profile_signature(&profiles[zone]);
+            let old_sig = self.profiles.get(zone).map(Self::syn_cookie_profile_signature);
+            if old_sig != Some(new_sig) {
+                let zone_gen = self.syn_cookie_profile_gen.entry(zone.clone()).or_insert(0);
+                *zone_gen = zone_gen.wrapping_add(1);
+            }
         }
         self.profiles = profiles;
+    }
+
+    /// #2446: the SYN-cookie-relevant slice of a zone profile. Two profiles
+    /// with the same signature are interchangeable for the validated-ACK
+    /// cache: a tuple validated under one may bypass the SYN-flood counter
+    /// under the other without changing the security posture. Any change here
+    /// bumps the zone's profile generation and invalidates its cached
+    /// validations. `(syn_cookie, syn_flood_threshold)` — NOT the stateless
+    /// screens, scan/sweep, or other flood thresholds, which never gate the
+    /// validated cache.
+    fn syn_cookie_profile_signature(profile: &ScreenProfile) -> (bool, u32) {
+        (profile.syn_cookie, profile.syn_flood_threshold)
+    }
+
+    /// #2446: current SYN-cookie profile generation for a zone (0 if the zone
+    /// has no profile or has never been configured). Stamped into validated-
+    /// cache entries on insert and compared on consume.
+    fn syn_cookie_profile_gen(&self, zone: &str) -> u64 {
+        self.syn_cookie_profile_gen.get(zone).copied().unwrap_or(0)
     }
 
     /// Publish the cluster-wide SYN-cookie master key into this worker's screen
@@ -302,9 +355,11 @@ impl ScreenState {
         if syn_flood_threshold > 0 && pkt.protocol == PROTO_TCP {
             let tf = pkt.tcp_flags;
             if is_initial_syn(tf) {
+                let profile_gen = self.syn_cookie_profile_gen(zone);
                 let syn_cookie_validated = syn_cookie
                     && self.syn_cookie_validated.take_valid(
                         zone_id,
+                        profile_gen,
                         SynCookieTuple::from_packet(pkt),
                         now_secs,
                     );
@@ -550,7 +605,9 @@ impl ScreenState {
             .validate_isn(tuple, zone_id, current_epoch, cookie_isn)
             .is_some()
         {
-            self.syn_cookie_validated.insert(zone_id, tuple, now_secs);
+            let profile_gen = self.syn_cookie_profile_gen(zone);
+            self.syn_cookie_validated
+                .insert(zone_id, profile_gen, tuple, now_secs);
             SynCookieAckVerdict::Validated
         } else if locally_active {
             SynCookieAckVerdict::Invalid

--- a/userspace-dp/src/screen/syncookie.rs
+++ b/userspace-dp/src/screen/syncookie.rs
@@ -9,7 +9,11 @@
 //! - `SipHash24` (private MAC primitive)
 //! - `SynCookieValidatedCache` (4-way set-associative recent-validated
 //!   cookie cache so the ACK+SYN bypass path doesn't re-validate per
-//!   packet)
+//!   packet). Keyed by `(zone_id, profile_gen, 4-tuple)` (#2446): the
+//!   per-zone SYN-cookie profile generation is stamped on insert and
+//!   compared on consume, so a tuple validated under an old profile is a
+//!   miss after the zone's SYN-cookie profile changes (the new profile's
+//!   SYN-flood counter then re-sees the connection).
 
 use std::net::IpAddr;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -375,6 +379,15 @@ impl SipHash24 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct SynCookieValidatedKey {
     zone_id: u16,
+    /// Per-zone SYN-cookie profile generation captured at validation time
+    /// (#2446). A cached entry is only consumable while the zone's current
+    /// generation still matches: a SYN-cookie-relevant profile change
+    /// (disable/re-enable, syn-flood-threshold change, zone→profile
+    /// rebinding) bumps the generation, so a tuple validated under the old
+    /// profile is treated as a miss and re-validated under the new profile —
+    /// the new profile's SYN-flood counter then sees the connection. The
+    /// master-key-change `set_hash_keys` clear remains as defense in depth.
+    profile_gen: u64,
     tuple: SynCookieTuple,
 }
 
@@ -428,11 +441,21 @@ impl SynCookieValidatedCache {
         }
     }
 
-    pub(super) fn insert(&mut self, zone_id: u16, tuple: SynCookieTuple, now_secs: u64) {
+    pub(super) fn insert(
+        &mut self,
+        zone_id: u16,
+        profile_gen: u64,
+        tuple: SynCookieTuple,
+        now_secs: u64,
+    ) {
         if self.sets.is_empty() {
             return;
         }
-        let key = SynCookieValidatedKey { zone_id, tuple };
+        let key = SynCookieValidatedKey {
+            zone_id,
+            profile_gen,
+            tuple,
+        };
         let set_index = self.set_index(&key);
         self.clock = self.clock.wrapping_add(1);
         let set = &mut self.sets[set_index];
@@ -477,13 +500,18 @@ impl SynCookieValidatedCache {
     pub(super) fn take_valid(
         &mut self,
         zone_id: u16,
+        profile_gen: u64,
         tuple: SynCookieTuple,
         now_secs: u64,
     ) -> bool {
         if self.sets.is_empty() {
             return false;
         }
-        let key = SynCookieValidatedKey { zone_id, tuple };
+        let key = SynCookieValidatedKey {
+            zone_id,
+            profile_gen,
+            tuple,
+        };
         let set_index = self.set_index(&key);
         let set = &mut self.sets[set_index];
         let mut valid = false;
@@ -530,6 +558,7 @@ impl SynCookieValidatedCache {
     fn key_hash(&self, key: &SynCookieValidatedKey) -> u64 {
         let mut sip = SipHash24::new(self.hash_keys[0], self.hash_keys[1]);
         sip.write_u16(key.zone_id);
+        sip.write_u64(key.profile_gen);
         sip.write_ip(key.tuple.src_ip);
         sip.write_ip(key.tuple.dst_ip);
         sip.write_u16(key.tuple.src_port);
@@ -548,10 +577,19 @@ impl SynCookieValidatedCache {
     }
 
     #[cfg(test)]
-    pub(super) fn debug_set_index(&self, zone_id: u16, tuple: SynCookieTuple) -> Option<usize> {
+    pub(super) fn debug_set_index(
+        &self,
+        zone_id: u16,
+        profile_gen: u64,
+        tuple: SynCookieTuple,
+    ) -> Option<usize> {
         if self.sets.is_empty() {
             return None;
         }
-        Some(self.set_index(&SynCookieValidatedKey { zone_id, tuple }))
+        Some(self.set_index(&SynCookieValidatedKey {
+            zone_id,
+            profile_gen,
+            tuple,
+        }))
     }
 }

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -2106,21 +2106,21 @@ fn syn_cookie_validated_cache_is_bounded() {
     let mut tuple = syn_cookie_tuple();
     for port in 40000..40032 {
         tuple.src_port = port;
-        cache.insert(7, tuple, 100);
+        cache.insert(7, 0, tuple, 100);
     }
 
     assert_eq!(cache.len(), 4);
     let mut evicted = syn_cookie_tuple();
     evicted.src_port = 40000;
-    assert!(!cache.take_valid(7, evicted, 100));
+    assert!(!cache.take_valid(7, 0, evicted, 100));
     evicted.src_port = 40027;
-    assert!(!cache.take_valid(7, evicted, 100));
+    assert!(!cache.take_valid(7, 0, evicted, 100));
 
     let mut retained = syn_cookie_tuple();
     retained.src_port = 40028;
-    assert!(cache.take_valid(7, retained, 100));
+    assert!(cache.take_valid(7, 0, retained, 100));
     retained.src_port = 40031;
-    assert!(cache.take_valid(7, retained, 100));
+    assert!(cache.take_valid(7, 0, retained, 100));
 }
 
 #[test]
@@ -2133,7 +2133,7 @@ fn syn_cookie_validated_cache_index_is_keyed() {
     let mut tuple = syn_cookie_tuple();
     let differs = (0..1024).any(|offset| {
         tuple.src_port = 30000 + offset;
-        left.debug_set_index(7, tuple) != right.debug_set_index(7, tuple)
+        left.debug_set_index(7, 0, tuple) != right.debug_set_index(7, 0, tuple)
     });
 
     assert!(
@@ -2217,6 +2217,193 @@ fn syn_cookie_master_key_rotation_clears_validated_cache() {
     assert_eq!(state.syn_cookie_validated_len(), 0);
 }
 
+// #2446: helper — drive a zone through a SYN-flood crossing into cookie
+// mode, then validate a returning ACK so a validated-cache entry is
+// installed for `tuple`. Returns the validated SYN-cookie 4-tuple.
+fn install_validated_syn_cookie_entry(state: &mut ScreenState, zone: &str, zone_id: u16) {
+    let syn = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        49152,
+        443,
+        TCP_SYN,
+    );
+    // First SYN passes (counter at threshold-1), second crosses the
+    // threshold and mints a challenge.
+    assert_eq!(
+        state.check_packet_with_zone_id(zone, zone_id, &syn, 128),
+        ScreenVerdict::Pass
+    );
+    let challenge = match state.check_packet_with_zone_id(zone, zone_id, &syn, 128) {
+        ScreenVerdict::SynCookieChallenge(challenge) => challenge,
+        other => panic!("expected SYN-cookie challenge, got {other:?}"),
+    };
+    let mut ack = syn.clone();
+    ack.tcp_flags = TCP_ACK;
+    ack.tcp_ack = challenge.cookie_isn.wrapping_add(1);
+    assert_eq!(
+        state.validate_syn_cookie_ack_on_session_miss(zone, zone_id, &ack, 128),
+        SynCookieAckVerdict::Validated
+    );
+    assert_eq!(state.syn_cookie_validated_len(), 1);
+}
+
+// #2446 fail-on-revert: a tuple validated under one SYN-cookie profile
+// generation must NOT be consumable as a hit after the zone's
+// SYN-cookie-relevant profile changes (same master key). Without the
+// per-zone profile generation in the cache key (or without the gen bump
+// in `update_profiles`) the validated entry is consumed as a hit and
+// bypasses the NEW profile's SYN-flood counter — RED.
+#[test]
+fn syn_cookie_validated_cache_invalidated_on_profile_change() {
+    let mut profile = ScreenProfile::default();
+    profile.syn_flood_threshold = 1;
+    profile.syn_cookie = true;
+    let mut state = make_state("trust", profile);
+    state.update_syn_cookie_master_key(Some(syn_cookie_key()));
+
+    install_validated_syn_cookie_entry(&mut state, "trust", 7);
+
+    // Change a SYN-cookie-relevant field (the SYN-flood threshold) while
+    // the master key stays stable. This bumps the zone's profile
+    // generation, so the cached validation is from an older generation.
+    let mut changed = ScreenProfile::default();
+    changed.syn_flood_threshold = 5; // was 1
+    changed.syn_cookie = true;
+    let mut profiles = FxHashMap::default();
+    profiles.insert("trust".to_string(), changed);
+    state.update_profiles(profiles);
+
+    // The same SYN that produced the validated ACK now arrives. Under the
+    // bug it would be a validated-cache HIT (SynCookieBypass) and skip the
+    // new profile's SYN-flood counter. With the fix it is a MISS, so the
+    // packet is counted as a normal SYN under the new threshold (Pass at
+    // count 1, below the new threshold of 5).
+    let syn = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        49152,
+        443,
+        TCP_SYN,
+    );
+    // Within the entry's TTL (insert at 128, 64s TTL → expires 192) so the
+    // only reason this is a MISS is the bumped generation, not expiry.
+    assert_eq!(
+        state.check_packet_with_zone_id("trust", 7, &syn, 150),
+        ScreenVerdict::Pass,
+        "validated entry from the old profile generation must NOT bypass \
+         the new profile's SYN-flood counter"
+    );
+}
+
+// #2446: disable then re-enable SYN-cookie on a zone (master key stable)
+// invalidates a validation that occurred before the toggle.
+#[test]
+fn syn_cookie_validated_cache_invalidated_on_disable_reenable() {
+    let mut profile = ScreenProfile::default();
+    profile.syn_flood_threshold = 1;
+    profile.syn_cookie = true;
+    let mut state = make_state("trust", profile.clone());
+    state.update_syn_cookie_master_key(Some(syn_cookie_key()));
+
+    install_validated_syn_cookie_entry(&mut state, "trust", 7);
+
+    // Disable syn_cookie (gen bump), then re-enable it (gen bump again):
+    // two SYN-cookie-relevant changes, so the pre-toggle validation is
+    // stale.
+    let mut disabled = profile.clone();
+    disabled.syn_cookie = false;
+    let mut profiles = FxHashMap::default();
+    profiles.insert("trust".to_string(), disabled);
+    state.update_profiles(profiles);
+
+    let mut profiles = FxHashMap::default();
+    profiles.insert("trust".to_string(), profile);
+    state.update_profiles(profiles);
+
+    let syn = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        49152,
+        443,
+        TCP_SYN,
+    );
+    // Within the entry's TTL (insert at 128, 64s TTL → expires 192) so the
+    // only reason this is not a HIT is the stale generation. A stale HIT
+    // would return SynCookieBypass and skip the SYN-flood counter; with the
+    // fix it is a MISS, counted as the first SYN under threshold 1 → Pass.
+    assert_eq!(
+        state.check_packet_with_zone_id("trust", 7, &syn, 150),
+        ScreenVerdict::Pass,
+        "re-enabled cookie mode must NOT honour a stale pre-disable \
+         validation (a stale HIT would return SynCookieBypass)"
+    );
+}
+
+// #2446 no-regression: within the SAME profile generation a validated
+// tuple is still a hit (the cache works normally). An UNRELATED profile
+// edit (a stateless screen toggle) does NOT bump the generation, so the
+// validation survives.
+#[test]
+fn syn_cookie_validated_cache_hit_within_same_generation() {
+    let mut profile = ScreenProfile::default();
+    profile.syn_flood_threshold = 1;
+    profile.syn_cookie = true;
+    let mut state = make_state("trust", profile.clone());
+    state.update_syn_cookie_master_key(Some(syn_cookie_key()));
+
+    install_validated_syn_cookie_entry(&mut state, "trust", 7);
+
+    // An unrelated profile change (enable the teardrop screen) leaves the
+    // SYN-cookie signature unchanged, so the generation is stable and the
+    // validation remains consumable.
+    let mut unrelated = profile;
+    unrelated.teardrop = true;
+    let mut profiles = FxHashMap::default();
+    profiles.insert("trust".to_string(), unrelated);
+    state.update_profiles(profiles);
+
+    // The matching SYN is a validated-cache HIT → SynCookieBypass (it does
+    // NOT count toward the SYN-flood threshold), proving the cache still
+    // works normally within a generation.
+    let syn = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)),
+        IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)),
+        49152,
+        443,
+        TCP_SYN,
+    );
+    // Within the entry's TTL (insert at 128, 64s TTL → expires 192).
+    assert_eq!(
+        state.check_packet_with_zone_id("trust", 7, &syn, 150),
+        ScreenVerdict::SynCookieBypass,
+        "an unrelated profile edit must not invalidate a validated entry"
+    );
+    // Consumed exactly once.
+    assert_eq!(state.syn_cookie_validated_len(), 0);
+}
+
+// #2446 unit-level: the cache treats two generations as distinct keys —
+// an entry inserted under gen N is a miss when consumed under gen N+1,
+// and a hit when consumed under gen N.
+#[test]
+fn syn_cookie_validated_cache_generation_is_keyed() {
+    let mut cache = SynCookieValidatedCache::new(64, 64);
+    let tuple = syn_cookie_tuple();
+
+    cache.insert(7, 1, tuple, 100);
+    assert!(
+        !cache.take_valid(7, 2, tuple, 100),
+        "an entry from a stale generation must be a miss under the new gen"
+    );
+
+    cache.insert(7, 1, tuple, 100);
+    assert!(
+        cache.take_valid(7, 1, tuple, 100),
+        "an entry consumed under its own generation must still be a hit"
+    );
+}
+
 #[test]
 fn update_profiles_prepopulates_syn_cookie_active_state() {
     let mut profile = ScreenProfile::default();
@@ -2241,11 +2428,11 @@ fn syn_cookie_validated_cache_refresh_extends_ttl() {
     let tuple_refreshed = syn_cookie_tuple();
     let mut tuple_old = syn_cookie_tuple();
     tuple_old.src_port += 1;
-    cache.insert(7, tuple_refreshed, 100);
-    cache.insert(7, tuple_old, 100);
-    cache.insert(7, tuple_refreshed, 109);
-    assert!(!cache.take_valid(7, tuple_old, 110));
-    assert!(cache.take_valid(7, tuple_refreshed, 110));
+    cache.insert(7, 0, tuple_refreshed, 100);
+    cache.insert(7, 0, tuple_old, 100);
+    cache.insert(7, 0, tuple_refreshed, 109);
+    assert!(!cache.take_valid(7, 0, tuple_old, 110));
+    assert!(cache.take_valid(7, 0, tuple_refreshed, 110));
 }
 
 #[test]
@@ -2253,15 +2440,15 @@ fn syn_cookie_validated_cache_expires_on_ttl_boundary() {
     let mut cache = SynCookieValidatedCache::new(4, SynCookieCodec::EPOCH_SECS);
     let tuple = syn_cookie_tuple();
 
-    cache.insert(7, tuple, 128);
+    cache.insert(7, 0, tuple, 128);
     assert!(
-        cache.take_valid(7, tuple, 191),
+        cache.take_valid(7, 0, tuple, 191),
         "entry should remain valid until just before the 64s TTL boundary"
     );
 
-    cache.insert(7, tuple, 128);
+    cache.insert(7, 0, tuple, 128);
     assert!(
-        !cache.take_valid(7, tuple, 192),
+        !cache.take_valid(7, 0, tuple, 192),
         "entry expires at insertion time + one cookie epoch"
     );
 }


### PR DESCRIPTION
Closes #2446

## Problem
The SYN-cookie validated-ACK cache (`SynCookieValidatedCache`) was keyed by
`(zone_id, 4-tuple)` and cleared only when the SYN-cookie master HASH key
changed (`set_hash_keys`). If a zone's SYN-cookie-relevant profile changed while
the master key stayed stable, a tuple validated under the OLD profile could be
consumed under the NEW profile until the cache TTL expired — bypassing the new
profile's SYN-flood counter. (codex review-033 finding 033-06, MEDIUM.)

## Fix — profile generation in the cache key
- `SynCookieValidatedKey` gains a `profile_gen: u64` (also folded into the
  set-association hash so generations occupy distinct keys).
- `ScreenState` tracks a per-zone SYN-cookie profile generation
  (`syn_cookie_profile_gen`, keyed by zone name to match `profiles`).
- `update_profiles` bumps a zone's generation whenever its SYN-cookie
  **signature** changes.

### Which profile changes bump the generation
The signature is `(syn_cookie, syn_flood_threshold)` — the only two fields that
gate whether a validated entry may legitimately bypass the SYN-flood counter:
- `syn_cookie` enable/disable (and disable→re-enable = two bumps)
- `syn_flood_threshold` change
- the zone **gaining or losing** a profile — this is how a zone→profile
  rebinding manifests (old signature `None` vs. new, or vice versa)

Unrelated edits (stateless screens, scan/sweep, ICMP/UDP flood thresholds) do
**not** bump the generation → no needless re-validation churn. Correctness-first:
over-invalidation is safe; under-invalidation was the bug.

### Insert / consume
`insert` stamps the zone's current generation into the entry; `take_valid`
carries the zone's current generation and an entry from an older generation is a
**miss** — the connection is re-validated under the new profile and the new
profile's SYN-flood counter sees it. The master-key-change clear is preserved as
defense in depth.

A stale-generation entry hashes to a different set than the current-generation
key, so it is never consumed and ages out by TTL/LRU (bounded over-retention,
no correctness impact).

## Tests
- **fail-on-revert** `syn_cookie_validated_cache_invalidated_on_profile_change`
  and `..._on_disable_reenable`: a tuple validated under generation N, then a
  SYN-cookie-relevant profile change (gen N→N+1), is a MISS on consume **within
  TTL** (returns `Pass` under the new threshold) rather than a HIT bypassing the
  new counter (`SynCookieBypass`). Verified RED with the gen bump disabled (both
  return `SynCookieBypass`).
- **no-regression** `syn_cookie_validated_cache_hit_within_same_generation`: an
  unrelated profile edit (enable teardrop) leaves the generation stable, so the
  validation is still consumed as a hit (`SynCookieBypass`).
- **unit** `syn_cookie_validated_cache_generation_is_keyed`: the cache treats two
  generations as distinct keys.
- All pre-existing direct-cache tests updated for the new `profile_gen` argument.

## Gates
- `cargo build --release` clean — no new warnings in `screen/`.
- `cargo test --release --bin xpf-userspace-dp screen::` → 123 passed, 0 failed.

## Docs
- `docs/syn-cookie-flood-protection.md` — validated-client cache section now
  documents the `(zone_id, profile_gen, 4-tuple)` key and which profile changes
  bump the generation.
- `userspace-dp/src/screen/syncookie.rs` module header updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi