### PR TITLE
Fix #2719: align stale pkg/daemon event-stream test fixture with #2467 wire widen

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-06-24 — #2719 fix: stale pkg/daemon event-stream test fixture (post-#2467 wire widen)
+
+- **Timestamp**: 2026-06-24
+- **Action**: Fixed a red-on-master regression. #2467/PR#2716 widened the
+  session-event wire (open-frame header 24→30 bytes: OwnerRGID/EgressIfindex/
+  TXIfindex int16→int32; close-frame OwnerRGID 2→4) in
+  pkg/dataplane/userspace, but missed the pkg/daemon test fixture
+  `buildSessionOpenFrameV4PayloadForWiringTest`, which still hand-built a
+  56-byte v4 payload at the OLD 24-byte-header layout (IPs at offset 24).
+  Under the widened decoder the v4 minimum is 62 bytes, so the fixture frame
+  was rejected by `decodeSessionEvent` (DecodeErrors++, no callback, no ACK)
+  → `TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync`
+  blocked on `read ack frame: i/o timeout`. ROOT CAUSE = stale TEST FIXTURE,
+  not a production bug: the daemon consumer (`SetOnEvent` in
+  daemon_ha_userspace.go) receives a pre-decoded SessionDeltaInfo from the
+  correctly-widened pkg/dataplane/userspace decoder — it never parses raw
+  bytes at fixed offsets. Rewrote the fixture to the new 62-byte v4 layout
+  (i32 identity fields at [10:22], IPs at offset 30) and seeded the three
+  identity fields with 40000 (> int16 max 32767) so the full daemon wire+ack
+  path round-trips a high ifindex per the #2467 intent. The #2467
+  fail-on-revert decode guard already lives on the correct side
+  (`TestDecodeSessionEventHighIfindex`, pkg/dataplane/userspace).
+- **Validation**: regression test GREEN 3x (was a 2s i/o timeout — confirmed
+  not flaky); `go build ./...` clean; `go test ./pkg/daemon/...` and
+  `go test ./pkg/dataplane/userspace/...` green; gofmt clean; go vet clean.
+- **Process note**: event-stream wire changes must gate on
+  `go test ./pkg/daemon/...`, not just `./pkg/dataplane/userspace/...` — the
+  fixture lives in the daemon package.
+- **File(s)**: `pkg/daemon/userspace_sync_test.go`, `_Log.md`.
+
 ## 2026-06-24 — #2701 review fold: end-to-end call-site test for the WG outer source
 
 - **Timestamp**: 2026-06-24

--- a/pkg/daemon/userspace_sync_test.go
+++ b/pkg/daemon/userspace_sync_test.go
@@ -24,14 +24,38 @@ const maxEventFramePayloadForWiringTest = 1 << 20
 
 func (p fixedEventStreamProvider) EventStream() *dpuserspace.EventStream { return p.es }
 
+// buildSessionOpenFrameV4PayloadForWiringTest builds a v4 SessionOpen payload
+// in the #2467 widened wire layout consumed by
+// pkg/dataplane/userspace.decodeSessionEvent:
+//
+//	[0]     AddrFamily (4)
+//	[1]     Protocol
+//	[2:4]   SrcPort        [4:6]   DstPort
+//	[6:8]   NATSrcPort     [8:10]  NATDstPort
+//	[10:14] OwnerRGID (int32 LE)      — #2467: widened from int16
+//	[14:18] EgressIfindex (int32 LE)  — #2467: widened from int16
+//	[18:22] TXIfindex (int32 LE)      — #2467: widened from int16
+//	[22:24] TunnelEndpointID  [24:26] TXVLANID
+//	[26] Flags [27] IngressZone [28] EgressZone [29] Disposition
+//	[30..]  src/dst/nat_src/nat_dst IPs (4 bytes each, v4)
+//	[N..]   NeighborMAC(6) SrcMAC(6) NextHop(4)
+//
+// Total v4 size: 30 + 4*4 + 6 + 6 + 4 = 62 bytes. The three identity
+// fields are seeded with 40000 (> int16 max 32767) so the full daemon
+// wire+ack path round-trips a high ifindex per the #2467 intent — a
+// revert to the old 24-byte/int16 layout makes this payload undersized
+// (decodeSessionEvent rejects it, no ACK is sent, the test times out).
 func buildSessionOpenFrameV4PayloadForWiringTest() []byte {
-	buf := make([]byte, 56)
+	buf := make([]byte, 62)
 	buf[0] = 4
 	buf[1] = 6
 	binary.LittleEndian.PutUint16(buf[2:4], 12345)
 	binary.LittleEndian.PutUint16(buf[4:6], 443)
-	copy(buf[24:28], []byte{10, 0, 1, 2})
-	copy(buf[28:32], []byte{172, 16, 0, 1})
+	binary.LittleEndian.PutUint32(buf[10:14], 40000) // OwnerRGID (>int16)
+	binary.LittleEndian.PutUint32(buf[14:18], 40001) // EgressIfindex
+	binary.LittleEndian.PutUint32(buf[18:22], 40002) // TXIfindex
+	copy(buf[30:34], []byte{10, 0, 1, 2})            // SrcIP
+	copy(buf[34:38], []byte{172, 16, 0, 1})          // DstIP
 	return buf
 }
 


### PR DESCRIPTION
Closes #2719

## Root cause: stale TEST FIXTURE (not a production bug)

#2467/PR#2716 widened the session-event wire in `pkg/dataplane/userspace`
(open-frame header 24→30 bytes — `OwnerRGID`/`EgressIfindex`/`TXIfindex`
int16→int32; close-frame `OwnerRGID` 2→4) but missed the **pkg/daemon test
fixture** `buildSessionOpenFrameV4PayloadForWiringTest`, which still
hand-built a 56-byte v4 payload at the OLD 24-byte-header layout (IPs at
offset 24).

Under the widened decoder the v4 minimum payload is **62 bytes**, so the
fixture frame was rejected by `decodeSessionEvent` (`DecodeErrors++`, no
callback dispatched, no ACK emitted). The regression-guard test
`TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync`
then blocked on `read ack frame: ... i/o timeout`.

**Evidence this is a fixture bug, not production:** the daemon event consumer
(`SetOnEvent` in `daemon_ha_userspace.go:535`) receives a *pre-decoded*
`SessionDeltaInfo` from the correctly-widened `pkg/dataplane/userspace`
decoder — it never parses raw frame bytes at fixed offsets. The production HA
session-sync-over-event-stream path has been correct since #2467; only the
daemon-side fixture was left at the old layout. **Severity: low (test-only).**

## The fix

Rewrite the fixture to the new 62-byte v4 layout established by #2467 in
`pkg/dataplane/userspace/eventstream.go` (`decodeSessionEvent` offsets):
int32 identity fields at `[10:22]`, IPs at offset 30. The three identity
fields are seeded with **40000 (> int16 max 32767)** so the full daemon
wire+ack path round-trips a high ifindex per the #2467 intent — a revert to
the old 24-byte/int16 layout makes this payload undersized and the test times
out again. The #2467 fail-on-revert *decode* guard already lives on the
correct side (`TestDecodeSessionEventHighIfindex`, `pkg/dataplane/userspace`).

## Validation

- `TestWireUserspaceEventStreamCallbacksStandaloneWiresSessionAndFullResync`
  GREEN **3x** (was a 2s i/o timeout — confirmed not flaky)
- `go build ./...` clean
- `go test ./pkg/daemon/...` green
- `go test ./pkg/dataplane/userspace/...` green (the already-correct side
  is unaffected)
- `gofmt` clean, `go vet` clean

## Process note

Event-stream wire changes must gate on `go test ./pkg/daemon/...`, not just
`./pkg/dataplane/userspace/...` — the wire fixture lives in the daemon
package, so a userspace-only test run would not have caught #2467's miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi