### PR TITLE
#2652: flow cache — enable NPTv6 fast-path caching, keep NAT64 excluded

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14492,3 +14492,27 @@ top.
   "owned by another party (refused)"; reverting backendForOwned/Pass-1 →
   MAJOR-2 withdraw tests FAIL with "no live backend to withdraw". make
   test-failover + the LIVE standalone-VM publish remain for the parent.
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2652 — flow cache: enable NPTv6 fast-path caching; keep NAT64
+  excluded (version-changing). NPTv6 is a same-family IPv6 address byte-rewrite
+  that is checksum-neutral by RFC 6296 (adjustment baked into the address
+  upstream in src/nptv6.rs), so the descriptor IPv6 arm reproduces the slow
+  path byte-for-byte: write address, l4_csum_delta==0 → no L4 csum touch
+  (matches apply_nat_ipv6 skip_l4_csum). NAT64 rebuilds the IP header to a
+  different version/size (build_nat64_*_frame allocates a new frame) — cannot
+  be expressed by the in-place RewriteDescriptor; stays excluded.
+  Changes: should_cache drops !nptv6 (keeps !nat64); from_forward_decision
+  propagates nptv6; orchestrator early-returns only for rd.nat64 + a v4-guard
+  for a nptv6 descriptor with non-v6 ether_type.
+  Tests: nptv6_is_cacheable, nat64_not_cacheable (renamed),
+  pin_nptv6_descriptor_matches_generic_byte_for_byte (byte-identical
+  fast-vs-slow + L4 csum unchanged), pin_descriptor_nat64_decline_frame_untouched.
+  Fail-on-revert PROVEN for both should_cache and orchestrator changes.
+  Gates: cargo build --release clean; cargo test --release --bin
+  xpf-userspace-dp 2768 passed / 0 failed.
+  **File(s)**: userspace-dp/src/afxdp/flow_cache.rs,
+  userspace-dp/src/afxdp/frame/rewrite/mod.rs,
+  userspace-dp/src/afxdp/flow_cache_tests.rs,
+  userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs,
+  docs/flow-cache-simplification.md

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -250,7 +250,8 @@ Add focused tests for:
 2. cache hit, cross-binding transmit
 3. stale HA validation forcing miss/fallthrough
 4. stale RG epoch forcing miss
-5. non-cacheable NAT64/NPTv6 decisions staying uncached
+5. non-cacheable NAT64 decisions staying uncached (NPTv6 is now
+   cacheable — see "NPTv6 fast-path caching (#2652)" below)
 
 Expected benefit:
 
@@ -324,6 +325,54 @@ structural behavior the worker session-expiry gate already has. No schema
 change and no operator-facing rejection. Tests: `out_of_range_owner_rg_stamps_node_level_epoch`,
 `out_of_range_owner_rg_invalidates_on_node_level_bump`,
 `in_range_owner_rg_unchanged_by_node_level_bump` (flow_cache_tests.rs).
+
+## NPTv6 fast-path caching (#2652)
+
+Before #2652 `FlowCacheEntry::should_cache` excluded BOTH `decision.nat.nat64`
+and `decision.nat.nptv6`, so every NPTv6- and NAT64-translated packet missed
+the flow cache and re-ran the full session-lookup + policy-eval slow path on
+every packet. #2652 splits these two cases on the actual dataplane mechanics:
+
+- **NPTv6 (RFC 6296) is now cacheable.** At the dataplane an NPTv6 decision is
+  nothing more than a same-family IPv6 address byte-rewrite of one side
+  (`rewrite_dst` for inbound, `rewrite_src` for outbound). The RFC 6296
+  checksum-neutral adjustment word is computed entirely upstream in
+  `src/nptv6.rs` (`translate_inbound`/`translate_outbound` via `adjust_word`),
+  so the `Ipv6Addr` handed to the worker in `NatDecision` already preserves
+  the L4 ones-complement sum. The slow path (`apply_nat_ipv6`) writes that
+  address and SKIPS the L4 checksum adjust (`skip_l4_csum = nat.nptv6`); the
+  descriptor fast path carries `l4_csum_delta == 0` (`compute_l4_csum_delta`
+  short-circuits on `nat.nptv6`) so the IPv6 arm
+  (`apply_rewrite_descriptor_ipv6`) ALSO leaves the L4 checksum untouched.
+  The two paths are therefore byte-identical. The orchestrator
+  (`frame/rewrite/mod.rs`) no longer early-returns for `rd.nptv6`; it keeps a
+  defense-in-depth fall-back only when a `nptv6` descriptor carries a non-v6
+  `ether_type` (NPTv6 is IPv6-only). `should_cache` drops the
+  `!decision.nat.nptv6` clause and `from_forward_decision` propagates
+  `nptv6: decision.nat.nptv6` into the descriptor.
+
+- **NAT64 stays excluded (correct).** NAT64 is a version-changing translation:
+  the IPv6 40-byte header is rebuilt as an IPv4 20-byte header (or vice versa),
+  the frame length changes, and fragment-header handling differs. It is
+  produced by `build_nat64_*_frame`, which ALLOCATES a fresh frame of a
+  different size — there is no in-place rewrite the byte-write
+  `RewriteDescriptor` could carry. The orchestrator still early-returns
+  `None` for `rd.nat64`, and `should_cache` keeps `!decision.nat.nat64`.
+
+Validation:
+
+- `nptv6_is_cacheable`, `nat64_not_cacheable` (flow_cache_tests.rs) — the
+  admission split; fail-on-revert if the `!nptv6` exclusion is reinstated.
+- `pin_nptv6_descriptor_matches_generic_byte_for_byte`
+  (frame/prop_tests/rewrite.rs) — proves the descriptor fast path output is
+  byte-identical to the generic slow path for an NPTv6 dst rewrite, with the
+  L4 checksum unchanged (checksum-neutral). Fail-on-revert: reinstating the
+  `rd.nptv6` decline makes `apply_rewrite_descriptor` return `None` and the
+  `.expect(...)` panics.
+- `pin_descriptor_nat64_decline_frame_untouched` — NAT64 (and a `nptv6`
+  descriptor with a v4 `ether_type`) still decline before any byte is written.
+- `descriptor_generic_differential` (unmasked) — existing same-family parity
+  unaffected.
 
 ## Recommended Next Step
 

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -263,10 +263,23 @@ impl FlowCacheEntry {
         // truth for cacheability (see `packet_eligible`); PSH+ACK data segments
         // remain cacheable because `is_ack_only` ignores PSH/URG, so
         // steady-state data and UDP still fast-path.
+        //
+        // #2652: NPTv6 (RFC 6296 stateless prefix translation) IS cacheable.
+        // It is a same-family IPv6 address byte-rewrite that is checksum-neutral
+        // by design, so the descriptor fast path (`apply_rewrite_descriptor` →
+        // `apply_rewrite_descriptor_ipv6`) reproduces it byte-for-byte: it
+        // writes the new IPv6 address(es) and, because `compute_l4_csum_delta`
+        // returns 0 for nptv6, leaves the L4 checksum untouched — exactly what
+        // the slow-path `apply_nat_ipv6` does (`skip_l4_csum = nat.nptv6`).
+        //
+        // NAT64 stays EXCLUDED. It is a version-changing translation (IPv6 40B
+        // header <-> IPv4 20B header, fragment-header handling) built by
+        // `build_nat64_*_frame` which allocates a fresh frame of a different
+        // size. The in-place `RewriteDescriptor` byte-write fast path cannot
+        // express a header rebuild, so NAT64 must remain on the generic path.
         Self::packet_eligible(meta)
             && matches!(meta.protocol, PROTO_TCP | PROTO_UDP)
             && !decision.nat.nat64
-            && !decision.nat.nptv6
             && decision.resolution.disposition.is_cacheable()
     }
 
@@ -413,7 +426,11 @@ impl FlowCacheEntry {
                     Some(&flow.forward_key),
                 ),
                 nat64: false,
-                nptv6: false,
+                // #2652: carry the NPTv6 flag so the descriptor fast path
+                // routes through the IPv6 arm with a zero L4 csum delta
+                // (checksum-neutral). NAT64 is never cached (gated out in
+                // `should_cache`), so its flag stays false here.
+                nptv6: decision.nat.nptv6,
                 apply_nat_on_fabric,
             },
             decision,

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -488,25 +488,49 @@ fn forward_candidate_is_cacheable() {
 }
 
 // ----------------------------------------------------------------
-// (g-extra) NAT64 and NPTv6 decisions are not cacheable
+// (g-extra) NAT64 stays non-cacheable; NPTv6 IS cacheable (#2652)
 // ----------------------------------------------------------------
 #[test]
-fn nat64_and_nptv6_not_cacheable() {
+fn nat64_not_cacheable() {
     let meta = make_meta(PROTO_TCP);
 
+    // NAT64 is a version-changing translation (header rebuild) the in-place
+    // descriptor fast path cannot express — it must stay on the generic path.
     let mut nat64_decision = make_decision(ForwardingDisposition::ForwardCandidate);
     nat64_decision.nat.nat64 = true;
     assert!(
         !FlowCacheEntry::should_cache(meta, nat64_decision),
         "NAT64 should not be cacheable",
     );
+}
+
+#[test]
+fn nptv6_is_cacheable() {
+    // #2652: NPTv6 is a same-family IPv6 prefix rewrite that is
+    // checksum-neutral by RFC 6296, so the descriptor fast path reproduces it
+    // byte-for-byte. It MUST now be admitted to the flow cache. Use a v6 meta
+    // so the eligibility predicate (UDP / established-TCP) and the v6 family
+    // match the NPTv6 dst rewrite below.
+    let meta = UserspaceDpMeta {
+        protocol: PROTO_TCP,
+        addr_family: libc::AF_INET6 as u8,
+        ingress_ifindex: 7,
+        tcp_flags: 0x10, // ACK only
+        ..Default::default()
+    };
 
     let mut nptv6_decision = make_decision(ForwardingDisposition::ForwardCandidate);
     nptv6_decision.nat.nptv6 = true;
+    nptv6_decision.nat.rewrite_dst = Some(IpAddr::V6(std::net::Ipv6Addr::new(
+        0xfd00, 0, 0, 0, 0, 0, 0, 0x1234,
+    )));
     assert!(
-        !FlowCacheEntry::should_cache(meta, nptv6_decision),
-        "NPTv6 should not be cacheable",
+        FlowCacheEntry::should_cache(meta, nptv6_decision),
+        "NPTv6 should be cacheable (#2652)",
     );
+
+    // Fail-on-revert guard: if the `!decision.nat.nptv6` exclusion is
+    // reinstated in `should_cache`, this assertion flips to false.
 }
 
 // ----------------------------------------------------------------

--- a/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
+++ b/userspace-dp/src/afxdp/frame/prop_tests/rewrite.rs
@@ -381,31 +381,136 @@ fn pin_descriptor_port_mismatch_declines() {
     assert_eq!(&after[pkt.l3..], &pkt.frame[pkt.l3..]);
 }
 
-/// (c) NAT64/NPTv6 descriptors decline BEFORE the eth prep
-/// (rewrite/mod.rs:52) — frame fully untouched, including L2. The
-/// flow cache never builds such descriptors (`should_cache` gates at
-/// flow_cache.rs:223-224); this pins the defense-in-depth check.
+/// (c) NAT64 descriptors decline BEFORE the eth prep (rewrite/mod.rs)
+/// — frame fully untouched, including L2. The flow cache never builds a
+/// NAT64 descriptor (`should_cache` gates `!decision.nat.nat64`); this
+/// pins the defense-in-depth check.
+///
+/// #2652: NPTv6 is no longer in this decline set — it is now applied by
+/// the descriptor fast path (proved byte-identical to the generic path
+/// in `pin_nptv6_descriptor_matches_generic_byte_for_byte`). A
+/// descriptor flagged `nptv6` with a non-v6 ether_type still declines
+/// (the defense-in-depth v4 guard), which is also pinned below.
 #[test]
-fn pin_descriptor_nat64_nptv6_decline_frame_untouched() {
+fn pin_descriptor_nat64_decline_frame_untouched() {
     let pkt = pin_packet(false, PROTO_TCP, 64, Vec::new());
     let desc = XdpDesc {
         addr: DIFF_ADDR as u64,
         len: pkt.frame.len() as u32,
         options: 0,
     };
-    for (nat64, nptv6) in [(true, false), (false, true)] {
+    // NAT64: always declines, frame untouched.
+    {
         let area = area_with_frame(&pkt.frame);
         let mut rd = make_descriptor(&pkt, NatDecision::default(), 0);
-        rd.nat64 = nat64;
-        rd.nptv6 = nptv6;
+        rd.nat64 = true;
         assert!(apply_rewrite_descriptor(&area, desc, pkt.meta, &rd, None).is_none());
         let after = area.slice(DIFF_ADDR, pkt.frame.len()).unwrap();
         assert_eq!(
             after,
             &pkt.frame[..],
-            "nat64/nptv6 decline happens before any byte is written"
+            "nat64 decline happens before any byte is written"
         );
     }
+    // NPTv6 on a v4-typed descriptor: defense-in-depth decline, frame
+    // untouched (NPTv6 is IPv6-only; the v4 ether_type is inconsistent).
+    {
+        let area = area_with_frame(&pkt.frame);
+        let mut rd = make_descriptor(&pkt, NatDecision::default(), 0);
+        rd.nptv6 = true; // ether_type stays 0x0800 (this is a v4 pin packet)
+        assert!(apply_rewrite_descriptor(&area, desc, pkt.meta, &rd, None).is_none());
+        let after = area.slice(DIFF_ADDR, pkt.frame.len()).unwrap();
+        assert_eq!(
+            after,
+            &pkt.frame[..],
+            "nptv6 on a non-v6 descriptor declines before any byte is written"
+        );
+    }
+}
+
+/// #2652 — NPTv6 descriptor fast path is BYTE-IDENTICAL to the generic
+/// slow path. NPTv6 (RFC 6296) is a same-family IPv6 dst-prefix rewrite
+/// that is checksum-neutral by design: the generic `apply_nat_ipv6`
+/// writes the new address and SKIPS the L4 checksum adjust
+/// (`skip_l4_csum = nat.nptv6`); the descriptor carries `l4_csum_delta
+/// == 0` (`compute_l4_csum_delta` short-circuits on `nat.nptv6`) so the
+/// fast path's IPv6 arm also leaves the L4 checksum untouched.
+///
+/// This is the fail-on-revert proof: with the descriptor `nptv6` flag
+/// honored (orchestrator no longer early-returns for `rd.nptv6`), the
+/// two outputs match byte-for-byte. Reinstating the `rd.nptv6` decline
+/// makes `fast` `None` and the `.expect(...)` panics.
+#[test]
+fn pin_nptv6_descriptor_matches_generic_byte_for_byte() {
+    // Valid IPv6 TCP packet (no VLAN), pure-ACK eligible.
+    let pkt = pin_packet(true, PROTO_TCP, 64, Vec::new());
+    // NPTv6: dst prefix translation only (the upstream compiler folds the
+    // RFC 6296 adjustment word into the rewritten address, so the
+    // dataplane simply writes it and leaves the L4 checksum alone).
+    let mut new_dst = match pkt.dst_ip {
+        IpAddr::V6(a) => a.octets(),
+        _ => unreachable!("v6 pin packet"),
+    };
+    // Replace the /48 prefix; checksum-neutrality is a property of the
+    // address bytes the compiler chose, but the DATAPLANE behavior under
+    // test (write address, skip L4 csum) is identical for any new dst —
+    // both paths skip the L4 csum, so they agree regardless.
+    new_dst[0] = 0xfd;
+    new_dst[1] = 0x00;
+    new_dst[2] = 0x00;
+    let nptv6_nat = NatDecision {
+        rewrite_dst: Some(IpAddr::V6(std::net::Ipv6Addr::from(new_dst))),
+        nptv6: true,
+        ..NatDecision::default()
+    };
+
+    let desc = XdpDesc {
+        addr: DIFF_ADDR as u64,
+        len: pkt.frame.len() as u32,
+        options: 0,
+    };
+
+    // Capture the input L4 checksum (TCP csum at rel_l4 + 16).
+    let l4_csum_off = pkt.l3 + pkt.rel_l4 + 16;
+    let in_l4_csum =
+        u16::from_be_bytes([pkt.frame[l4_csum_off], pkt.frame[l4_csum_off + 1]]);
+
+    // Generic slow path.
+    let area_g = area_with_frame(&pkt.frame);
+    let decision = make_decision(&pkt, nptv6_nat, 0);
+    let generic = rewrite_forwarded_frame_in_place(&area_g, desc, pkt.meta, &decision, false, None)
+        .expect("generic NPTv6 rewrite must succeed");
+
+    // Descriptor fast path — descriptor built exactly as the flow cache does,
+    // including the nptv6 flag (#2652) and the zero L4 csum delta.
+    let area_d = area_with_frame(&pkt.frame);
+    let mut rd = make_descriptor(&pkt, nptv6_nat, 0);
+    rd.nptv6 = true;
+    assert_eq!(
+        rd.l4_csum_delta, 0,
+        "NPTv6 descriptor must carry a zero L4 csum delta (checksum-neutral)"
+    );
+    let fast = apply_rewrite_descriptor(&area_d, desc, pkt.meta, &rd, None)
+        .expect("descriptor NPTv6 rewrite must succeed (#2652) — fail-on-revert");
+
+    assert_eq!(generic, fast, "InPlaceRewriteResult (offset/len/l2) must agree");
+
+    let out_g = area_g.slice(generic.offset as usize, generic.len as usize).unwrap();
+    let out_d = area_d.slice(fast.offset as usize, fast.len as usize).unwrap();
+    assert_eq!(out_g, out_d, "NPTv6 fast path must be byte-identical to generic");
+
+    // Confirm the actual NPTv6 semantics on the shared output: dst address
+    // rewritten, L4 checksum UNCHANGED (checksum-neutral).
+    let out_l3 = 14usize; // no VLAN
+    let out_dst = &out_g[out_l3 + 24..out_l3 + 40];
+    assert_eq!(out_dst, &new_dst, "NPTv6 must rewrite the IPv6 dst address");
+    let out_l4_csum_off = out_l3 + pkt.rel_l4 + 16;
+    let out_l4_csum =
+        u16::from_be_bytes([out_g[out_l4_csum_off], out_g[out_l4_csum_off + 1]]);
+    assert_eq!(
+        out_l4_csum, in_l4_csum,
+        "NPTv6 is checksum-neutral — the L4 checksum must be untouched"
+    );
 }
 
 /// (d) #1838 (D3) FIXED pin: the generic v6 NAT path threads the

--- a/userspace-dp/src/afxdp/frame/rewrite/mod.rs
+++ b/userspace-dp/src/afxdp/frame/rewrite/mod.rs
@@ -42,8 +42,13 @@ use crate::afxdp::{MmapArea, RewriteDescriptor, UserspaceDpMeta, XdpDesc};
 ///
 /// **Scope**: IPv4/IPv6 TCP and UDP only (flow cache gates on
 /// ACK-only TCP + UDP). Does NOT handle: ICMP identifier repair,
-/// NAT64 (header-size change), NPTv6 (checksum-neutral — address
-/// rewrite differs).
+/// NAT64 (header-size change — always falls back to the generic frame
+/// builder). NPTv6 IS handled (#2652): it is a same-family IPv6 address
+/// byte-rewrite that is checksum-neutral by RFC 6296, so the IPv6 arm
+/// reproduces the slow path exactly — it writes the new address(es) and,
+/// because the descriptor's `l4_csum_delta` is 0 for NPTv6
+/// (`compute_l4_csum_delta` short-circuits on `nat.nptv6`), it leaves the
+/// L4 checksum untouched, matching `apply_nat_ipv6`'s `skip_l4_csum`.
 #[inline]
 pub(in crate::afxdp) fn apply_rewrite_descriptor(
     area: &MmapArea,
@@ -52,8 +57,16 @@ pub(in crate::afxdp) fn apply_rewrite_descriptor(
     rd: &RewriteDescriptor,
     expected_ports: Option<(u16, u16)>,
 ) -> Option<InPlaceRewriteResult> {
-    // NAT64 and NPTv6 use the generic path — they need special handling.
-    if rd.nat64 || rd.nptv6 {
+    // NAT64 is a version-changing translation (IPv6 40B <-> IPv4 20B header
+    // rebuild, fragment handling) built by the generic NAT64 frame builder —
+    // the in-place descriptor byte-write path cannot express it, so fall back.
+    if rd.nat64 {
+        return None;
+    }
+    // #2652 defense-in-depth: NPTv6 is IPv6-only. A descriptor flagged nptv6
+    // with a non-v6 ether_type is a malformed/inconsistent cache entry; fall
+    // back to the generic path rather than misapply a v4 rewrite.
+    if rd.nptv6 && rd.ether_type != 0x86dd {
         return None;
     }
 


### PR DESCRIPTION
Closes #2652 — partial scope by design: NPTv6 is enabled; NAT64 stays excluded with a documented reason (it cannot be expressed by the in-place RewriteDescriptor fast path).

## Problem
`FlowCacheEntry::should_cache` excluded BOTH NPTv6 and NAT64, so every translated packet missed the flow cache and re-ran the full session-lookup + policy-eval slow path on every packet instead of fast-pathing through a cached `RewriteDescriptor`.

## What I enabled, and why

### NPTv6 — now cacheable
NPTv6 (RFC 6296) at the dataplane is a same-family IPv6 address byte-rewrite of one side (`rewrite_dst` inbound / `rewrite_src` outbound). The checksum-neutral adjustment word is computed entirely **upstream** in `src/nptv6.rs` (`translate_inbound`/`translate_outbound` via `adjust_word`), so the `Ipv6Addr` handed to the worker in `NatDecision` already preserves the L4 ones-complement sum — there is **no per-packet adjustment at the dataplane**.

- Slow path `apply_nat_ipv6`: writes the new address, **skips** the L4 checksum adjust (`skip_l4_csum = nat.nptv6`).
- Fast path: `compute_l4_csum_delta` already returns `0` for nptv6, and the IPv6 arm only touches the L4 checksum `if rd.l4_csum_delta != 0` → it also leaves the checksum untouched.

The two paths are therefore **byte-identical**. The only blockers were the `should_cache` exclusion, the hardcoded `nptv6: false` in the descriptor builder, and the `rd.nptv6` early-return in the orchestrator.

### NAT64 — stays excluded (the exclusion is correct)
NAT64 is a **version-changing** translation: the IPv6 40-byte header is rebuilt as an IPv4 20-byte header (or vice versa), the frame length changes, and fragment-header handling differs. It is produced by `build_nat64_*_frame`, which **allocates a fresh frame of a different size**. There is no in-place rewrite the byte-write `RewriteDescriptor` could carry, so `apply_rewrite_descriptor` keeps its `rd.nat64` early-return and `should_cache` keeps `!decision.nat.nat64`.

## Changes
- `should_cache`: drops `!decision.nat.nptv6` (keeps `!decision.nat.nat64`).
- `from_forward_decision`: propagates `nptv6: decision.nat.nptv6` into the descriptor.
- `apply_rewrite_descriptor`: early-returns only for `rd.nat64`; NPTv6 flows into the IPv6 arm. Defense-in-depth fall-back kept for a `nptv6` descriptor carrying a non-v6 `ether_type`.

## Byte-identical fast-vs-slow test (fail-on-revert)
- `pin_nptv6_descriptor_matches_generic_byte_for_byte` (frame/prop_tests/rewrite.rs): runs the generic slow path and the descriptor fast path on the same IPv6 TCP packet with an NPTv6 dst rewrite and asserts the output frames are **byte-identical**, the dst address **is** rewritten, and the L4 checksum is **unchanged** (checksum-neutral). Reinstating the `rd.nptv6` decline makes the fast path return `None` → the test panics.
- `nptv6_is_cacheable` / `nat64_not_cacheable` (flow_cache_tests.rs): the admission split. Reinstating `!nptv6` in `should_cache` flips `nptv6_is_cacheable` red.
- `pin_descriptor_nat64_decline_frame_untouched`: NAT64, and a `nptv6` descriptor with a v4 ether_type, still decline before any byte is written.
- `descriptor_generic_differential` (unmasked): existing same-family parity unaffected.

Both fail-on-revert directions were verified by temporarily reverting each change and confirming the corresponding test turns red.

## Gates
- `cargo build --release` — clean (pre-existing warnings only).
- `cargo test --release --bin xpf-userspace-dp` — **2768 passed / 0 failed**.

## Docs
`docs/flow-cache-simplification.md`: new "NPTv6 fast-path caching (#2652)" section + corrected the NAT64/NPTv6 wording in the Phase 4 test list.

## Note for reviewer / parent
This is a dataplane fast-path change. A deploy-boot + iperf on the NPTv6 (and NAT64, to confirm no regression) path is worth running for no-regression validation before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi