### PR TITLE
ddns: fix lease-path no-backend orphan, shared-DHCID teardown, PTR-pending visibility (#2699/#2700/#2708)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-06-25 — #2699 / #2700 / #2708 DDNS spine re-verify + fix (one PR)
+
+- **Timestamp**: 2026-06-25
+- **Action**: Re-verified three pre-#2691-redesign DDNS spine bugs against
+  current master (966dea4b8, all of #2691 P0-P3 merged). All THREE still
+  genuine on the lease (Surface B) path — the P2/P3 fail-closed work landed on
+  the Surface A (`SurfaceAManager`) path only. Fixed all three in one PR with
+  reconcile-layer fail-on-revert tests driving the real rfc2136 backend against
+  the in-process stateful fake DNS server (per the P2 lesson: no fakeUpdater
+  bypass for an ownership/orphan correctness test).
+  - **#2699** — `deleteOwnedLocked` dropped ownership through `nopUpdater` after
+    a restart / backend removal, orphaning the live RR. Fix: keep ownership,
+    count `deleteFail`, return new sentinel `errDDNSNoBackendToWithdraw`
+    (swallowed by `reconcileOnceLocked` / `withdrawAllLocked` so a legit
+    disabled-with-no-backend pass is not failed). Mirrors the Surface A
+    `withdrawOwnedLocked` precedent. (The pre-#2691 inc-1 invariant — "nop never
+    published, nothing to orphan" — no longer holds: a live backend publishes,
+    and ownership is recorded ONLY by a live backend.)
+  - **#2700** — shared RFC 4701 DHCID (digest folds client-id||FQDN, NOT the
+    address) deleted on a partial dual-stack teardown left the surviving family
+    unprotected + leaked. Fix: `Manager.dhcidSharedWithOther` scans the store;
+    `LeaseDNSRecord.KeepForwardDHCID` threads through `DeleteLease` →
+    `sendRemoveForward(..., keepDHCID)`, which removes only the A/AAAA and
+    leaves the shared DHCID (DHCID-match prereq still sent). DHCID removed only
+    with the last family's record.
+  - **#2708** — `PTRPending` persisted but not surfaced. Fix:
+    `OwnedRecordView.PTRPending` + copy in `OwnedRecordViews`; new
+    `Stats.PTRPendingNow` current gauge (distinct from cumulative
+    `PTRDeferred`); CLI + gRPC detail `Pending` column; Prometheus
+    `xpf_dhcp_ddns_ptr_pending` gauge.
+- **File(s)**: pkg/ddns/manager.go, pkg/ddns/backend.go,
+  pkg/ddns/backend_rfc2136.go, pkg/ddns/manager_test.go,
+  pkg/ddns/spine_fixes_test.go (new), pkg/cli/cli_show_services.go,
+  pkg/grpcapi/server_show_dhcp_lldp_snmp.go, pkg/api/metrics.go,
+  pkg/api/metrics_descriptors.go, pkg/api/metrics_system.go, pkg/ddns/README.md
+- **Validation**: go build ./... clean; go test ./pkg/ddns/... ./pkg/dhcpserver/...
+  ./pkg/daemon/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/api/... green;
+  -race ./pkg/ddns green; gofmt clean; all three new tests proven fail-on-revert.
+
 ## 2026-06-24 — #2719 fix: stale pkg/daemon event-stream test fixture (post-#2467 wire widen)
 
 - **Timestamp**: 2026-06-24

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -78,6 +78,7 @@ type xpfCollector struct {
 	dhcpDDNSReconcileRunsTotal *prometheus.Desc
 	dhcpDDNSSkippedTotal       *prometheus.Desc
 	dhcpDDNSOwnedRecords       *prometheus.Desc
+	dhcpDDNSPTRPending         *prometheus.Desc
 	dhcpDDNSLastReconcileTs    *prometheus.Desc
 	dhcpDDNSLastReconcileN     *prometheus.Desc
 
@@ -482,6 +483,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.dhcpDDNSReconcileRunsTotal
 	ch <- c.dhcpDDNSSkippedTotal
 	ch <- c.dhcpDDNSOwnedRecords
+	ch <- c.dhcpDDNSPTRPending
 	ch <- c.dhcpDDNSLastReconcileTs
 	ch <- c.dhcpDDNSLastReconcileN
 	ch <- c.surfaceADDNSUpsertsTotal

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -235,6 +235,13 @@ func newCollector(srv *Server) *xpfCollector {
 			"Current number of DHCP dynamic-DNS records this node owns in DNS.",
 			nil, nil,
 		),
+		dhcpDDNSPTRPending: prometheus.NewDesc(
+			"xpf_dhcp_ddns_ptr_pending",
+			"Current number of owned DHCP dynamic-DNS records whose forward "+
+				"A/AAAA is published but whose reverse PTR is still owed "+
+				"(distinct from the cumulative ptr-deferred counter; #2708).",
+			nil, nil,
+		),
 		dhcpDDNSLastReconcileTs: prometheus.NewDesc(
 			"xpf_dhcp_ddns_last_reconcile_timestamp_seconds",
 			"Unix timestamp of the last DHCP dynamic-DNS reconcile pass.",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -67,6 +67,8 @@ func (c *xpfCollector) collectDDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.PTRDeferred), "ptr-deferred")
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSOwnedRecords, prometheus.GaugeValue,
 		float64(st.OwnedRecords))
+	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSPTRPending, prometheus.GaugeValue,
+		float64(st.PTRPendingNow))
 	var lastTs float64
 	if !st.LastReconcile.IsZero() {
 		lastTs = float64(st.LastReconcile.Unix())

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -577,7 +577,8 @@ func (c *CLI) showDHCPDynamicDNS(detail bool) error {
 	fmt.Printf("    Reconciles: ok=%d fail=%d\n", st.ReconcileOK, st.ReconcileFail)
 	fmt.Printf("    Skipped:    no-name=%d no-backend=%d conflict=%d ptr-notauth=%d\n",
 		st.SkippedNoName, st.SkippedNoBackend, st.SkippedConflict, st.SkippedPTRNotAuth)
-	fmt.Printf("    PTR deferred: %d (forward published, reverse PTR retry pending)\n", st.PTRDeferred)
+	fmt.Printf("    PTR deferred: %d total (lifetime), %d pending now\n",
+		st.PTRDeferred, st.PTRPendingNow)
 	fmt.Printf("    Owned records: %d\n", st.OwnedRecords)
 	if !st.LastReconcile.IsZero() {
 		fmt.Printf("    Last reconcile: %s (%d leases)\n",
@@ -590,10 +591,14 @@ func (c *CLI) showDHCPDynamicDNS(detail bool) error {
 		if len(recs) == 0 {
 			fmt.Println("    none")
 		} else {
-			fmt.Printf("    %-32s %-6s %-39s %s\n", "FQDN", "Type", "Address", "PTR")
+			fmt.Printf("    %-32s %-6s %-39s %-26s %s\n", "FQDN", "Type", "Address", "PTR", "Pending")
 			for _, r := range recs {
-				fmt.Printf("    %-32s %-6s %-39s %s\n",
-					r.FQDN, r.ForwardType, r.Address, r.PTRName)
+				pending := "-"
+				if r.PTRPending {
+					pending = "PTR"
+				}
+				fmt.Printf("    %-32s %-6s %-39s %-26s %s\n",
+					r.FQDN, r.ForwardType, r.Address, r.PTRName, pending)
 			}
 		}
 	}

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -15,10 +15,10 @@ moved with its assertions intact.
 
 | File | Contents |
 |------|----------|
-| `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `Stats`, `OwnedRecordView(s)`, the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
+| `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `dhcidSharedWithOther` (#2700 shared-DHCID guard), `Stats` (incl. `PTRPendingNow`, #2708), `OwnedRecordView(s)`, the `errDDNSNoBackendToWithdraw` keep-ownership sentinel (#2699), the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
 | `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. |
 | `backend.go` | `DNSUpdater` interface, `LeaseDNSRecord`, `nopUpdater`, the record + reverse-PTR-name helpers — moved from `dhcpserver/ddns_dns.go`. |
-| `backend_rfc2136.go` | The LIVE RFC 2136 backend (`rfc2136Updater`): exact-RR adds/deletes, TSIG, RFC 4701 DHCID + RFC 4703 replace-owned two-attempt, the `errDDNSConflictRefused` / `errDDNSPTRPending` sentinels — moved from `dhcpserver/ddns_rfc2136.go`. |
+| `backend_rfc2136.go` | The LIVE RFC 2136 backend (`rfc2136Updater`): exact-RR adds/deletes, TSIG, RFC 4701 DHCID + RFC 4703 replace-owned two-attempt, the `errDDNSConflictRefused` / `errDDNSPTRPending` sentinels — moved from `dhcpserver/ddns_rfc2136.go`. `sendRemoveForward(..., keepDHCID)` keeps a shared DHCID on a partial dual-stack teardown (#2700); `dnsCanonicalFQDN` mirrors the DHCID FQDN canonicalization. |
 | `hostname.go` | Deterministic hostname → DNS-label normalization (pure) — moved from `dhcpserver/ddns_hostname.go`. |
 | `surface_a.go` | Surface A router/interface-address publish engine (`SurfaceAManager`): change-detection, forced-refresh wire floor, per-scope error backoff, per-RG HA gate, the backend factory `productionSurfaceABackend` (#2691 P2/P3). |
 | `backend_http.go` | Shared HTTP-backend discipline (#2691 P3): hardened `http.Client` (TLS-verified, bounded timeout), capped body read, `classifyHTTPStatus`, `queryEscape`, the `errHTTPAuth`/`errHTTPRateLimited` verdicts. |
@@ -110,10 +110,46 @@ no change in those packages:
   is never orphaned.
 - **Mass-delete fail-safe** — a family whose `LeaseParser` errors is marked
   untrusted and its destructive diff is skipped.
+- **No-backend withdraw keeps ownership (#2699)** — `deleteOwnedLocked` no
+  longer drops the ownership entry when only the `nopUpdater` is wired. A record
+  in the store was published by a real backend (the nop upsert path records no
+  ownership), so forgetting it while the live RR persists would ORPHAN it (after
+  a restart with DDNS disabled / no `update-server`, or a backend removal).
+  Instead the no-op delete counts `deleteFail`, returns
+  `errDDNSNoBackendToWithdraw`, and KEEPS ownership; a later reconcile with a
+  live backend withdraws it for real. `reconcileOnceLocked` / `withdrawAllLocked`
+  swallow the sentinel so a legitimate disabled-with-no-backend pass is not
+  marked failed. Mirrors the Surface A `withdrawOwnedLocked` precedent.
+- **Shared-DHCID partial dual-stack teardown (#2700)** — the RFC 4701 DHCID
+  digest folds in `client-identity || FQDN` only (NOT the address), so a
+  dual-stack client (an A + an AAAA under one FQDN, same client id) shares ONE
+  DHCID. `deleteOwnedLocked` scans the store (`dhcidSharedWithOther`); when a
+  sibling family still owns the same FQDN+ClientID it sets
+  `LeaseDNSRecord.KeepForwardDHCID`, and `sendRemoveForward` then deletes only
+  the A/AAAA and LEAVES the shared DHCID (the DHCID-match prerequisite is still
+  sent, so the delete stays ownership-guarded). The DHCID is removed only with
+  the LAST family's record, so a fully-released name leaves no orphan DHCID and
+  a survivor is never left unprotected (no hijack window, no wire leak).
 - **No secret in any error string** (TSIG secret revealed only at construction).
 
 The HA writer gate (`ddnsWriterGateOpen`) stays in `pkg/daemon/daemon_ddns.go`
 (it reads cluster RG state); P1a did not move or change it.
+
+## Observability — PTR-pending (#2708)
+
+A record can be HALF-PUBLISHED: the forward A/AAAA is live but the reverse PTR
+add failed with a non-skippable error (`ownedRecord.PTRPending=true`, #2661).
+This condition is surfaced per record and as a current gauge so an operator can
+identify the broken record and watch it recover:
+
+- `OwnedRecordView.PTRPending` — exposed on every owned record (CLI + gRPC
+  `show ... dynamic-dns detail` print a `Pending` column).
+- `Stats.PTRPendingNow` — the CURRENT count of records pending a PTR, distinct
+  from the cumulative lifetime `PTRDeferred` (which only ever increases). It
+  falls back to 0 once every PTR finally publishes.
+- Prometheus `xpf_dhcp_ddns_ptr_pending` (gauge) — current pending count, beside
+  the existing `xpf_dhcp_ddns_skipped_total{reason="ptr-deferred"}` lifetime
+  counter.
 
 ## Phase P1b — ScopeKey, per-family policy, per-RG HA gate, source binding
 

--- a/pkg/ddns/backend.go
+++ b/pkg/ddns/backend.go
@@ -40,6 +40,20 @@ type LeaseDNSRecord struct {
 	// pre-existing third-party RR). NOT part of the published forward/reverse
 	// RR set; carried alongside it only to derive the ownership marker.
 	ClientID string
+	// KeepForwardDHCID, when true on a DeleteLease, tells the replace-owned
+	// RFC 2136 backend to delete the forward A/AAAA but NOT the shared RFC 4701
+	// DHCID — because ANOTHER owned record still shares this FQDN+ClientID
+	// (a dual-stack client whose A and AAAA carry one DHCID). Deleting the
+	// shared DHCID on a partial dual-stack teardown would (1) leave the
+	// surviving family's record DHCID-unprotected (a hijack window, RFC 4703)
+	// and (2) make the eventual delete of the surviving record fail its
+	// DHCID-match prerequisite — leaking it on the wire (#2700). The DHCID-match
+	// PREREQUISITE is still sent (the delete stays ownership-guarded); only the
+	// DHCID's removal from the zone is suppressed. The manager (deleteOwnedLocked)
+	// sets this from a scan of the ownership store. Ignored on UpsertLease and by
+	// non-replace-owned / no-DHCID delete paths. Defaults false (delete the
+	// DHCID with the last record under the name — the pre-#2700 behaviour).
+	KeepForwardDHCID bool
 }
 
 // DNSUpdater is the pluggable DNS-update backend (plan §4.4). The

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -428,7 +428,12 @@ func (u *rfc2136Updater) DeleteLease(ctx context.Context, rec LeaseDNSRecord) er
 		return err
 	}
 	zone := u.resolveForwardZone(rec.FQDN)
-	if err := u.sendRemoveForward(ctx, zone, forwardRR); err != nil {
+	// rec.KeepForwardDHCID (#2700): another owned record still shares this
+	// FQDN+ClientID (a dual-stack client's surviving family), so delete the
+	// forward A/AAAA but keep the shared DHCID — the surviving record stays
+	// DHCID-protected and its later delete still satisfies the DHCID-match
+	// prerequisite.
+	if err := u.sendRemoveForward(ctx, zone, forwardRR, rec.KeepForwardDHCID); err != nil {
 		return fmt.Errorf("ddns: forward delete %s %s: %w", rec.ForwardType, rec.FQDN, err)
 	}
 	if rec.PTRName != "" {
@@ -533,6 +538,15 @@ func dhcidIdentifierType(clientID string) int {
 
 // dhcidDigestTypeSHA256 is the RFC 4701 §3.4 digest type code for SHA-256.
 const dhcidDigestTypeSHA256 = 0x01
+
+// dnsCanonicalFQDN returns the canonical (lowercased, trailing-dot) form of a
+// name, matching exactly how dhcidRR canonicalizes the FQDN before folding it
+// into the DHCID digest. The manager (dhcidSharedWithOther, #2700) uses it to
+// decide whether two owned records would compute the SAME DHCID, so this must
+// stay in lockstep with dhcidRR's `dns.CanonicalName(dns.Fqdn(fqdn))`.
+func dnsCanonicalFQDN(fqdn string) string {
+	return dns.CanonicalName(dns.Fqdn(fqdn))
+}
 
 // dhcidRR builds the RFC 4701 DHCID resource record that proves xpf owns a
 // forward name. The RDATA is: 2-byte identifier-type || 1-byte digest-type
@@ -834,7 +848,18 @@ func (u *rfc2136Updater) sendRemove(ctx context.Context, zone string, rr dns.RR)
 // release. Without a client identity (no DHCID was ever written) the delete is
 // the plain exact-RR delete — still only the firewall's own (name,type,rdata)
 // tuple, never a delete-RRset.
-func (u *rfc2136Updater) sendRemoveForward(ctx context.Context, zone string, rr dns.RR) error {
+//
+// keepDHCID (#2700): when ANOTHER owned record still shares this FQDN+ClientID
+// (a dual-stack client whose A and AAAA carry the SAME shared DHCID), the DHCID
+// must SURVIVE this delete so the remaining family's record stays
+// DHCID-protected (RFC 4703) and its eventual delete still satisfies the
+// DHCID-match prerequisite. In that case the DHCID-match PREREQUISITE is still
+// sent (the delete stays ownership-guarded — xpf removes the A/AAAA only when
+// the on-wire DHCID proves xpf created it) but the DHCID itself is OMITTED from
+// the Remove section, so only the specific A/AAAA is removed. When this is the
+// LAST owned record under the name (keepDHCID=false) the DHCID is removed with
+// it (the pre-#2700 behaviour), so a fully-released name leaves no orphan DHCID.
+func (u *rfc2136Updater) sendRemoveForward(ctx context.Context, zone string, rr dns.RR, keepDHCID bool) error {
 	if u.conflictPolicy != "replace-owned" {
 		return u.sendRemove(ctx, zone, rr)
 	}
@@ -850,7 +875,13 @@ func (u *rfc2136Updater) sendRemoveForward(ctx context.Context, zone string, rr 
 	// CLASS=NONE in place, which would otherwise corrupt the value-dependent
 	// Used() prerequisite that proves we own the record.
 	m.Used([]dns.RR{dns.Copy(dhcid)}) // prerequisite: our exact DHCID must exist
-	m.Remove([]dns.RR{rr, dhcid})
+	if keepDHCID {
+		// A sibling family's record still shares this DHCID (#2700): remove only
+		// the A/AAAA, leave the shared DHCID so the survivor stays protected.
+		m.Remove([]dns.RR{rr})
+	} else {
+		m.Remove([]dns.RR{rr, dhcid})
+	}
 	resp, err := u.exchange(ctx, m)
 	if err != nil {
 		return err

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -13,6 +13,20 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// errDDNSNoBackendToWithdraw is returned by deleteOwnedLocked when an owned
+// record must be withdrawn but only the no-op backend is wired (#2699). The
+// wire RR was NOT removed and ownership is DELIBERATELY KEPT (so the record
+// stays cleanable once a real backend is reconfigured), so the delete is
+// reported as a failure rather than a silent ownership drop. reconcileOnceLocked
+// treats it like any other delete error (the record is left in the store, its
+// identity/address/FQDN are blocked from re-add this cycle, and a later
+// reconcile retries) — but it is NOT a wire-level error, so it does not fail
+// the whole reconcile pass: a turn-off / restart with no backend resolves to
+// nop legitimately, and wedging the pass on it would be noise. The next
+// reconcile that resolves a live backend (or the next-cycle withdraw guard
+// supplying the prior live updater) performs the real withdraw.
+var errDDNSNoBackendToWithdraw = errors.New("ddns: no live backend to withdraw owned record (ownership kept for retry)")
+
 // manager.go (moved verbatim from pkg/dhcpserver/ddns.go in #2691 P1a): the
 // DHCP dynamic-DNS manager + reconciler core (#1387, per
 // docs/research/1387-dhcp-ddns/plan.md). This is the config-driven policy,
@@ -182,8 +196,17 @@ type Stats struct {
 	// PTRDeferred counts upserts where the forward A/AAAA published but the
 	// reverse PTR add failed with a non-skippable (transient) error: ownership
 	// is recorded for the live forward (never orphaned) and the PTR is retried
-	// on the next reconcile (#2661).
+	// on the next reconcile (#2661). It is a CUMULATIVE lifetime counter (every
+	// deferral ever), NOT the count of records CURRENTLY pending — use
+	// PTRPendingNow for the current gauge (#2708).
 	PTRDeferred uint64
+	// PTRPendingNow is the CURRENT count of owned records whose forward A/AAAA
+	// is published but whose reverse PTR is still owed (ownedRecord.PTRPending,
+	// #2708). Distinct from the cumulative PTRDeferred: this falls back to 0
+	// once every pending PTR finally publishes, so it is the live "how many
+	// records are half-published right now" gauge an operator watches for
+	// recovery. Surfaced in `show ... dynamic-dns` and Prometheus.
+	PTRPendingNow int
 	// ReconcileOK / ReconcileFail count whole reconcile passes by outcome
 	// (a pass is "fail" when at least one record op errored this cycle).
 	ReconcileOK    uint64
@@ -609,6 +632,36 @@ func (m *Manager) familyOwnsRecords(family int) bool {
 	return false
 }
 
+// dhcidSharedWithOther reports whether ANOTHER owned record (a different store
+// key) shares the SAME RFC 4701 DHCID as `owned` — i.e. the same non-empty
+// ClientID and the same canonical FQDN (#2700). The DHCID digest is
+// SHA-256(client-identity || canonical-FQDN-in-wire-form) and folds in NEITHER
+// the address NOR the family, so a dual-stack client (an A and an AAAA under
+// one FQDN, same client identity) produces ONE shared DHCID across both
+// records. When such a sibling exists, deleting one family's A/AAAA must keep
+// the shared DHCID on the wire so the surviving family's record stays
+// DHCID-protected and its eventual delete still satisfies the DHCID-match
+// prerequisite — otherwise the survivor is left unprotected (a hijack window)
+// and then leaks on the wire (its delete prereq fails). Records with an empty
+// ClientID never wrote a DHCID (the delete takes the plain exact-RR path), so
+// they are never siblings. Caller holds m.mu.
+func (m *Manager) dhcidSharedWithOther(owned ownedRecord) bool {
+	if owned.ClientID == "" {
+		return false
+	}
+	ownedKey := ownedRecordKey(owned.scopeOf(), owned.Identity, owned.Address)
+	ownedFQDN := dnsCanonicalFQDN(owned.FQDN)
+	for k, r := range m.state.records {
+		if k == ownedKey {
+			continue
+		}
+		if r.ClientID == owned.ClientID && dnsCanonicalFQDN(r.FQDN) == ownedFQDN {
+			return true
+		}
+	}
+	return false
+}
+
 // parseLeases reads a family's active leases via the injected LeaseParser
 // (#2691 P1a). A nil parser (the spine constructed without a Kea-memfile
 // parser) yields an empty, trusted lease set — identical to a healthy memfile
@@ -797,7 +850,15 @@ func (m *Manager) reconcileOnceLocked(ctx context.Context, env *reconcileEnv, le
 		// (the desired pass below re-adds the new form). Delete only the
 		// EXACT owned tuple — never anything not in the store.
 		if err := m.deleteOwnedLocked(ctx, env.updaterFor(owned.Family), owned); err != nil {
-			noteErr(err)
+			// errDDNSNoBackendToWithdraw is a "kept ownership, no backend"
+			// non-failure (#2699): the record stays owned + cleanable, but no
+			// wire op was attempted, so it must NOT fail the reconcile pass (a
+			// legitimate turn-off / restart with no backend resolves to nop).
+			// Still BLOCK a re-add of the same tuple this cycle — the record is
+			// still considered live/owned, not expired.
+			if !errors.Is(err, errDDNSNoBackendToWithdraw) {
+				noteErr(err)
+			}
 			blockedIdentity[owned.Identity] = struct{}{}
 			blockedAddress[owned.Address] = struct{}{}
 			blockedFQDN[owned.FQDN] = struct{}{}
@@ -856,7 +917,13 @@ func (m *Manager) withdrawAllLocked(ctx context.Context) error {
 	}
 	var firstErr error
 	for _, r := range owned {
-		if err := m.deleteOwnedLocked(ctx, m.updater, r); err != nil && firstErr == nil {
+		// errDDNSNoBackendToWithdraw (#2699) keeps ownership and is not a wire
+		// failure: a withdraw-all with no live backend (DDNS disabled before a
+		// real backend was ever resolved, or a restart that has not yet built
+		// one) legitimately resolves to nop. Do NOT surface it — the records are
+		// kept and a later reconcile with a live backend withdraws them.
+		if err := m.deleteOwnedLocked(ctx, m.updater, r); err != nil &&
+			!errors.Is(err, errDDNSNoBackendToWithdraw) && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -1035,23 +1102,47 @@ func (m *Manager) deleteOwnedLocked(ctx context.Context, updater DNSUpdater, own
 	// backend recomputes the same RFC 4701 DHCID — the delete prerequisite
 	// then proves xpf owns the record before removing it.
 	rec.ClientID = owned.ClientID
+	// #2700: if ANOTHER owned record still shares this record's FQDN + ClientID
+	// (a dual-stack client whose A and AAAA carry the SAME shared DHCID — the
+	// DHCID digest folds in client-identity||FQDN, NOT the address, so both
+	// families produce one DHCID), keep the shared DHCID on the wire so the
+	// surviving family's record stays DHCID-protected (RFC 4703) and its later
+	// delete still satisfies the DHCID-match prerequisite. Only when THIS is the
+	// last owned record under the name is the DHCID removed with it.
+	rec.KeepForwardDHCID = m.dhcidSharedWithOther(owned)
 	if err := updater.DeleteLease(ctx, rec); err != nil {
 		m.deleteFail.Add(1)
 		return err
 	}
 	if isNopUpdater(updater) {
-		// No live backend: the delete was a logged no-op. Still drop the
-		// ownership entry. For increment 1 this is CORRECT: nopUpdater never
-		// published anything, so there is nothing in DNS to orphan by
-		// forgetting ownership. CAVEAT (increment 2+): if a real backend is
-		// ever wired, publishes records, and is later removed (a downgrade
-		// back to no-backend), dropping ownership here would orphan those
-		// previously-published records in DNS. Handling that downgrade is an
-		// increment-2 concern; there is NO logic change for inc-1, where the
-		// store can only ever hold records nopUpdater "wrote" (i.e. none).
+		// No live backend: the delete was a logged no-op — the wire RR (if any)
+		// was NOT removed. KEEP the ownership entry so the record stays
+		// cleanable once a real backend is reconfigured; do NOT drop it (#2699).
+		//
+		// The pre-#2699 path dropped ownership here, justified by the inc-1
+		// invariant "nopUpdater never published, so there is nothing to orphan."
+		// That invariant no longer holds: a real RFC 2136 backend now publishes
+		// records (inc-2), and ownership can ONLY be recorded by a live backend
+		// (upsertLocked's nop branch records NO ownership and write-aheads no
+		// intent — manager.go upsertLocked). So any owned entry reaching this
+		// path was published by a real backend; if the backend is later removed
+		// (DDNS disabled / update-server cleared) OR the process restarts before
+		// it resolves a live backend, dropping ownership would ORPHAN the live
+		// A/AAAA/PTR/DHCID in the authoritative zone — xpf would forget the only
+		// record that lets it ever clean them (the stale-record / split-ownership
+		// class #1387 exists to prevent). Instead, treat the no-op delete as a
+		// FAILURE (count deleteFail, surface the error) and KEEP ownership: a
+		// later reconcile that resolves a live backend (the same family's backend
+		// re-appears, or the next-cycle withdraw guard supplies the prior live
+		// updater) withdraws it for real. This mirrors the Surface A precedent
+		// (SurfaceAManager.withdrawOwnedLocked, surface_a.go) which already treats
+		// a no-op backend as a delete failure rather than dropping ownership.
 		m.skippedNoBackend.Add(1)
-		m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
-		return nil
+		m.deleteFail.Add(1)
+		slog.Warn("ddns: cannot withdraw record — no live backend wired; "+
+			"keeping ownership for retry (record stays cleanable)",
+			"fqdn", owned.FQDN, "address", owned.Address, "type", owned.ForwardType)
+		return errDDNSNoBackendToWithdraw
 	}
 	m.deleteOK.Add(1)
 	m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
@@ -1079,6 +1170,11 @@ type OwnedRecordView struct {
 	Address     string
 	PTRName     string
 	TTL         int
+	// PTRPending is true when the forward A/AAAA is published but the reverse
+	// PTR is still owed (a non-skippable PTR add failure, #2661). It surfaces
+	// the half-published condition per record so an operator can distinguish a
+	// settled record from one whose PTR is missing and watch it recover (#2708).
+	PTRPending bool
 }
 
 // OwnedRecordViews returns a stable-ordered snapshot of the records this
@@ -1096,6 +1192,7 @@ func (m *Manager) OwnedRecordViews() []OwnedRecordView {
 			Address:     r.Address,
 			PTRName:     r.PTRName,
 			TTL:         r.TTL,
+			PTRPending:  r.PTRPending,
 		})
 	}
 	return out
@@ -1105,6 +1202,12 @@ func (m *Manager) OwnedRecordViews() []OwnedRecordView {
 func (m *Manager) Stats() Stats {
 	m.mu.Lock()
 	n := len(m.state.records)
+	pendingNow := 0
+	for _, r := range m.state.records {
+		if r.PTRPending {
+			pendingNow++
+		}
+	}
 	m.mu.Unlock()
 
 	st := Stats{
@@ -1117,6 +1220,7 @@ func (m *Manager) Stats() Stats {
 		SkippedPTRNotAuth: m.skippedPTRNotAuth.Load(),
 		SkippedConflict:   m.skippedConflict.Load(),
 		PTRDeferred:       m.ptrDeferred.Load(),
+		PTRPendingNow:     pendingNow,
 		ReconcileOK:       m.reconcileOK.Load(),
 		ReconcileFail:     m.reconcileFail.Load(),
 		OwnedRecords:      n,

--- a/pkg/ddns/manager_test.go
+++ b/pkg/ddns/manager_test.go
@@ -571,9 +571,12 @@ func TestNilUpdaterIsNopNotPanic(t *testing.T) {
 		t.Fatalf("no-backend upsert counted as upsertOK = %d", m.upsertOK.Load())
 	}
 
-	// Withdraw path: disabling DDNS while owned state exists must also be a
-	// safe no-op. Seed a stale owned record (as if a prior backend wrote it),
-	// then run the disabled (withdraw-all) reconcile.
+	// Withdraw path: disabling DDNS while owned state exists must be a safe
+	// no-op on the wire, but it must NOT drop ownership through the no-op
+	// backend (#2699). A record reaching the store was published by a real
+	// backend (the nop upsert path records no ownership), so forgetting it
+	// while the live RR persists would orphan it. The withdraw-all keeps the
+	// entry so a later reconcile with a real backend can clean it.
 	m.mu.Lock()
 	m.state.put(ownedRecord{
 		Family: 4, Identity: "mac:bb", Address: "10.0.0.20",
@@ -583,10 +586,16 @@ func TestNilUpdaterIsNopNotPanic(t *testing.T) {
 	err := m.withdrawAllLocked(context.Background())
 	m.mu.Unlock()
 	if err != nil {
+		// withdrawAllLocked swallows errDDNSNoBackendToWithdraw (it is the
+		// legitimate disabled-with-no-backend case), so no error is surfaced.
 		t.Fatalf("withdraw with no backend errored: %v", err)
 	}
-	if _, ok := m.state.get(ScopeKey{}, "mac:bb", "10.0.0.20"); ok {
-		t.Fatal("withdraw did not drop the owned entry under no-backend mode")
+	if _, ok := m.state.get(ScopeKey{}, "mac:bb", "10.0.0.20"); !ok {
+		t.Fatal("#2699 regression: no-backend withdraw DROPPED ownership; " +
+			"the live RR is now orphaned (unrecoverable)")
+	}
+	if m.deleteFail.Load() == 0 {
+		t.Fatal("#2699: no-backend withdraw should count a deleteFail (delete owed but no backend)")
 	}
 }
 

--- a/pkg/ddns/spine_fixes_test.go
+++ b/pkg/ddns/spine_fixes_test.go
@@ -1,0 +1,287 @@
+package ddns
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// spine_fixes_test.go — fail-on-revert regressions for the DDNS spine bugs
+// re-verified against current master after the #2691 P0-P3 redesign:
+//
+//   - #2699: deleteOwnedLocked must NOT drop ownership through the no-op
+//     backend after a restart / backend removal (orphaning the live RR).
+//   - #2700: a partial dual-stack teardown must KEEP the shared RFC 4701
+//     DHCID so the surviving family's record stays protected and its later
+//     delete still satisfies the DHCID-match prerequisite.
+//   - #2708: PTRPending must be exposed per owned record (view + current
+//     gauge), not just the cumulative PTRDeferred lifetime counter.
+//
+// The teardown tests drive the REAL rfc2136 backend against the in-process
+// stateful fake DNS server (the #2691 P2 lesson: a fakeUpdater that bypasses
+// the ownership/wire logic cannot prove an orphan/hijack bug). Reverting any
+// of the three fixes makes the matching test fail.
+
+// dualStackLease pairs a v4 + a v6 lease under the SAME host-name and the SAME
+// client identity — a dual-stack DHCP client. With one FQDN + one client
+// identity, the RFC 4701 DHCID digest (SHA-256(clientID||FQDN), address NOT
+// folded in) is IDENTICAL for both records: the shared-DHCID condition #2700
+// is about.
+func dualStackLease(identity string) (v4, v6 []Lease) {
+	v4 = []Lease{{Family: 4, Address: "10.0.1.5", Identity: identity, SubnetID: "1", HostName: "laptop"}}
+	v6 = []Lease{{Family: 6, Address: "2001:db8::5", Identity: identity, SubnetID: "1", HostName: "laptop"}}
+	return v4, v6
+}
+
+// dhcidForName builds the DHCID RR the backend would publish for (identity,
+// fqdn) so a test can assert its presence/absence in the stateful zone.
+func dhcidForName(t *testing.T, identity, fqdn string) *dns.DHCID {
+	t.Helper()
+	d, ok := dhcidRR(identity, fqdn, 300)
+	if !ok {
+		t.Fatalf("dhcidRR(%q,%q) returned ok=false", identity, fqdn)
+	}
+	return d
+}
+
+// TestPartialDualStackTeardownKeepsSharedDHCID is the #2700 fail-on-revert
+// regression. A dual-stack client publishes an A and an AAAA under one FQDN
+// sharing one DHCID. Releasing only the v4 lease must delete the A but KEEP the
+// shared DHCID (so the surviving AAAA stays ownership-protected); releasing the
+// v6 lease afterwards must then delete the AAAA AND the now-unshared DHCID.
+//
+// Pre-fix (sendRemoveForward always Remove([]dns.RR{rr, dhcid})): the v4
+// release deletes the shared DHCID, so the surviving AAAA's later delete fails
+// its DHCID-match prerequisite (NXRRSET) and the AAAA is LEAKED on the wire.
+func TestPartialDualStackTeardownKeepsSharedDHCID(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m, src := prodManagerTo(t, srv)
+	cfg := ddnsCfg(srv.addrUDP)
+	// Independent v4 + v6 blocks (#2663) so both families publish under
+	// replace-owned with a DHCID; reuse the same cfg for both.
+	cfg.DynamicDNSv6 = cfg.DynamicDNS
+
+	const identity = "cid:01:02:03"
+	const fqdn = "laptop.example.com"
+	v4, v6 := dualStackLease(identity)
+
+	// Cycle 1: both families active → A, AAAA, and the shared DHCID published.
+	src.v4, src.v6 = v4, v6
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("publish reconcile: %v", err)
+	}
+	dhcid := dhcidForName(t, identity, fqdn)
+	if !srv.zoneHas(dhcid) {
+		t.Fatal("setup: shared DHCID was not published")
+	}
+	aRR := recV4ID(fqdn, "10.0.1.5", identity, 300)
+	if m.Stats().OwnedRecords != 2 {
+		t.Fatalf("want 2 owned records (A+AAAA), got %d", m.Stats().OwnedRecords)
+	}
+	_ = aRR
+
+	// Cycle 2: v4 lease released, v6 still active. The A is withdrawn but the
+	// shared DHCID MUST survive (the AAAA still needs it).
+	src.v4 = nil
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("partial-teardown reconcile: %v", err)
+	}
+	if !srv.zoneHas(dhcid) {
+		t.Fatal("#2700 regression: shared DHCID was deleted on partial dual-stack " +
+			"teardown — the surviving AAAA is now unprotected and will leak")
+	}
+	// The A must be gone; the AAAA must remain.
+	if hasA := zoneHasType(srv, dns.Fqdn(fqdn), dns.TypeA); hasA {
+		t.Fatal("v4 A record was not withdrawn on lease release")
+	}
+	if hasAAAA := zoneHasType(srv, dns.Fqdn(fqdn), dns.TypeAAAA); !hasAAAA {
+		t.Fatal("surviving v6 AAAA was wrongly removed on the v4 teardown")
+	}
+
+	// Cycle 3: v6 lease released too → the AAAA must be deleted, AND the
+	// (now-unshared) DHCID removed with it, leaving no orphan.
+	src.v6 = nil
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("final-teardown reconcile: %v", err)
+	}
+	if zoneHasType(srv, dns.Fqdn(fqdn), dns.TypeAAAA) {
+		t.Fatal("#2700: surviving AAAA leaked — its delete failed the DHCID-match prereq")
+	}
+	if srv.zoneHas(dhcid) {
+		t.Fatal("#2700: DHCID orphaned after the last family released")
+	}
+	if m.Stats().OwnedRecords != 0 {
+		t.Fatalf("want 0 owned records after full teardown, got %d", m.Stats().OwnedRecords)
+	}
+}
+
+// zoneHasType reports whether the stateful zone holds any RR of rrtype at name.
+func zoneHasType(s *fakeDNSServer, name string, rrtype uint16) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set := s.zone[dns.CanonicalName(name)]
+	for _, rr := range set {
+		if rr.Header().Rrtype == rrtype {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRestartNoBackendKeepsOwnershipNotOrphan is the #2699 fail-on-revert
+// regression at the RECONCILE layer. A real backend publishes a record (so
+// ownership is persisted to the store). A FRESH manager is then constructed
+// from that persisted store (a daemon restart) with a config that resolves to
+// the no-op backend (DDNS disabled / update-server removed). Reconcile must
+// KEEP the ownership entry (the live RR stays cleanable), NOT drop it.
+//
+// Pre-fix (deleteOwnedLocked dropped ownership on isNopUpdater): the restart
+// reconcile no-ops the delete but deletes ownership, orphaning the live RR.
+func TestRestartNoBackendKeepsOwnershipNotOrphan(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	lease4 := filepath.Join(dir, "leases4.csv")
+	lease6 := filepath.Join(dir, "leases6.csv")
+	clock := func() time.Time { return time.Unix(1_700_000_000, 0) }
+
+	// --- Process 1: publish via a live backend, persisting ownership. ---
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	src1 := &fakeLeaseSource{}
+	m1 := newManagerForTesting(src1.parser(), nopUpdater{}, statePath, lease4, lease6, "node0", clock)
+	m1.newUpdater = func(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig) (DNSUpdater, error) {
+		if pol.backend != "rfc2136" || c == nil || c.UpdateServer == "" {
+			return nopUpdater{}, nil
+		}
+		c.UpdateServer = srv.addrUDP
+		return newRFC2136Updater(pol, c, nil,
+			func() { m1.skippedPTRNotAuth.Add(1) },
+			func() { m1.skippedConflict.Add(1) })
+	}
+	src1.v4 = laptopCIDLease()
+	if err := m1.Reconcile(context.Background(), ddnsCfg(srv.addrUDP)); err != nil {
+		t.Fatalf("process-1 publish reconcile: %v", err)
+	}
+	if m1.Stats().OwnedRecords != 1 {
+		t.Fatalf("process-1: want 1 owned record, got %d", m1.Stats().OwnedRecords)
+	}
+
+	// --- Process 2: fresh manager loads the persisted store; the config now
+	// resolves to the no-op backend (DDNS disabled). ---
+	src2 := &fakeLeaseSource{} // no leases this process (lease gone too)
+	m2 := newManagerForTesting(src2.parser(), nopUpdater{}, statePath, lease4, lease6, "node0", clock)
+	if m2.Stats().OwnedRecords != 1 {
+		t.Fatalf("process-2: persisted store should load 1 owned record, got %d", m2.Stats().OwnedRecords)
+	}
+	m2.newUpdater = func(_ ddnsPolicy, _ *config.DHCPDynamicDNSConfig) (DNSUpdater, error) {
+		// No backend resolvable after restart (config removed / no update-server).
+		return nopUpdater{}, nil
+	}
+
+	// DDNS disabled → withdraw path runs through the resolved no-op backend.
+	disabled := &config.DHCPServerConfig{DynamicDNS: &config.DHCPDynamicDNSConfig{Enabled: false}}
+	if err := m2.Reconcile(context.Background(), disabled); err != nil {
+		t.Fatalf("process-2 disabled reconcile errored: %v", err)
+	}
+	if got := m2.Stats().OwnedRecords; got != 1 {
+		t.Fatalf("#2699 regression: restart-with-no-backend DROPPED ownership "+
+			"(OwnedRecords=%d, want 1); the live RR is orphaned and unrecoverable", got)
+	}
+	if m2.Stats().DeleteFail == 0 {
+		t.Fatal("#2699: no-backend withdraw should count a deleteFail (delete owed, no backend)")
+	}
+	// And the RR is still live on the wire (never withdrawn through the nop).
+	if !srv.zoneHas(dhcidForName(t, "cid:01:02:03", "laptop.example.com")) {
+		t.Fatal("setup: published DHCID missing from zone")
+	}
+
+	// --- Process 3: a live backend re-appears → the kept ownership is now
+	// withdrawn for real (proves "kept for retry" actually converges). ---
+	src3 := &fakeLeaseSource{}
+	m3 := newManagerForTesting(src3.parser(), nopUpdater{}, statePath, lease4, lease6, "node0", clock)
+	m3.newUpdater = func(pol ddnsPolicy, c *config.DHCPDynamicDNSConfig) (DNSUpdater, error) {
+		if pol.backend != "rfc2136" || c == nil || c.UpdateServer == "" {
+			return nopUpdater{}, nil
+		}
+		c.UpdateServer = srv.addrUDP
+		return newRFC2136Updater(pol, c, nil,
+			func() { m3.skippedPTRNotAuth.Add(1) },
+			func() { m3.skippedConflict.Add(1) })
+	}
+	// Live backend present but DDNS now disabled (turn-off) → withdraw-all
+	// through the live backend resolved for the family.
+	disabledLive := &config.DHCPServerConfig{DynamicDNS: &config.DHCPDynamicDNSConfig{
+		Enabled: false, Backend: "rfc2136", UpdateServer: srv.addrUDP,
+	}}
+	if err := m3.Reconcile(context.Background(), disabledLive); err != nil {
+		t.Fatalf("process-3 withdraw reconcile: %v", err)
+	}
+	if got := m3.Stats().OwnedRecords; got != 0 {
+		t.Fatalf("process-3: live backend re-appeared but ownership not withdrawn (OwnedRecords=%d)", got)
+	}
+	if zoneHasType(srv, dns.Fqdn("laptop.example.com"), dns.TypeA) {
+		t.Fatal("process-3: the live RR was not actually withdrawn from the zone")
+	}
+}
+
+// TestPTRPendingExposedPerRecord is the #2708 fail-on-revert regression. A
+// reverse PTR add that fails with a non-skippable (SERVFAIL) error leaves the
+// forward owned with PTRPending=true. That condition must be visible per record
+// (OwnedRecordViews) and as a CURRENT gauge (Stats.PTRPendingNow), distinct
+// from the cumulative PTRDeferred. A later successful reconcile clears it.
+//
+// Pre-fix: OwnedRecordView omitted PTRPending and Stats had no current gauge —
+// a half-published record was indistinguishable from a settled one.
+func TestPTRPendingExposedPerRecord(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	// Reverse zone SERVFAILs → the PTR add fails with a non-skippable error,
+	// so the forward is owned with PTRPending set.
+	srv.setRcode("1.0.10.in-addr.arpa.", dns.RcodeServerFailure)
+	m, src := prodManagerTo(t, srv)
+	cfg := ddnsCfg(srv.addrUDP)
+	src.v4 = laptopMacLease()
+
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("reconcile (forward ok, PTR deferred): %v", err)
+	}
+
+	// The owned-record view must EXPOSE the pending flag (#2708).
+	views := m.OwnedRecordViews()
+	if len(views) != 1 {
+		t.Fatalf("want 1 owned record view, got %d", len(views))
+	}
+	if !views[0].PTRPending {
+		t.Fatal("#2708 regression: OwnedRecordView does not expose PTRPending " +
+			"(a half-published record is invisible to operators)")
+	}
+
+	// The CURRENT gauge must read 1, distinct from the lifetime counter.
+	st := m.Stats()
+	if st.PTRPendingNow != 1 {
+		t.Fatalf("#2708 regression: PTRPendingNow = %d, want 1 (current pending gauge)", st.PTRPendingNow)
+	}
+	if st.PTRDeferred == 0 {
+		t.Fatal("PTRDeferred (lifetime) should also be >0")
+	}
+
+	// Recovery: reverse zone heals → the next reconcile publishes the PTR and
+	// clears the pending flag. PTRPendingNow falls back to 0; PTRDeferred (a
+	// lifetime counter) stays put — that distinction is the #2708 point.
+	srv.clearRcode("1.0.10.in-addr.arpa.")
+	if err := m.Reconcile(context.Background(), cfg); err != nil {
+		t.Fatalf("recovery reconcile: %v", err)
+	}
+	views = m.OwnedRecordViews()
+	if len(views) == 1 && views[0].PTRPending {
+		t.Fatal("#2708: PTRPending not cleared after the PTR finally published")
+	}
+	if got := m.Stats().PTRPendingNow; got != 0 {
+		t.Fatalf("#2708: PTRPendingNow = %d after recovery, want 0", got)
+	}
+}

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -244,7 +244,8 @@ func (s *Server) showDHCPDynamicDNS(cfg *config.Config, buf *strings.Builder, de
 	fmt.Fprintf(buf, "    Reconciles: ok=%d fail=%d\n", st.ReconcileOK, st.ReconcileFail)
 	fmt.Fprintf(buf, "    Skipped:    no-name=%d no-backend=%d conflict=%d ptr-notauth=%d\n",
 		st.SkippedNoName, st.SkippedNoBackend, st.SkippedConflict, st.SkippedPTRNotAuth)
-	fmt.Fprintf(buf, "    PTR deferred: %d (forward published, reverse PTR retry pending)\n", st.PTRDeferred)
+	fmt.Fprintf(buf, "    PTR deferred: %d total (lifetime), %d pending now\n",
+		st.PTRDeferred, st.PTRPendingNow)
 	fmt.Fprintf(buf, "    Owned records: %d\n", st.OwnedRecords)
 	if !st.LastReconcile.IsZero() {
 		fmt.Fprintf(buf, "    Last reconcile: %s (%d leases)\n",
@@ -257,10 +258,14 @@ func (s *Server) showDHCPDynamicDNS(cfg *config.Config, buf *strings.Builder, de
 		if len(recs) == 0 {
 			buf.WriteString("    none\n")
 		} else {
-			fmt.Fprintf(buf, "    %-32s %-6s %-39s %s\n", "FQDN", "Type", "Address", "PTR")
+			fmt.Fprintf(buf, "    %-32s %-6s %-39s %-26s %s\n", "FQDN", "Type", "Address", "PTR", "Pending")
 			for _, r := range recs {
-				fmt.Fprintf(buf, "    %-32s %-6s %-39s %s\n",
-					r.FQDN, r.ForwardType, r.Address, r.PTRName)
+				pending := "-"
+				if r.PTRPending {
+					pending = "PTR"
+				}
+				fmt.Fprintf(buf, "    %-32s %-6s %-39s %-26s %s\n",
+					r.FQDN, r.ForwardType, r.Address, r.PTRName, pending)
 			}
 		}
 	}


### PR DESCRIPTION
Re-verified three DDNS spine bugs filed before the #2691 P0-P3 redesign against
current master (966dea4b8). The P2/P3 fail-closed work landed on the Surface A
(`SurfaceAManager`) path only; **all three are STILL genuine on the DHCP-lease
(Surface B) path**, so they are fixed together (coupled files).

## #2699 — GENUINE-AND-FIXED

`Manager.deleteOwnedLocked` dropped the ownership entry when only the
`nopUpdater` is wired, orphaning the live RFC 2136 record after a restart with
DDNS disabled / no `update-server`, or a backend removal.

- The pre-#2691 inc-1 justification ("nop never published, so nothing to
  orphan") no longer holds: a real backend now publishes, and ownership is
  recorded ONLY by a live backend (`upsertLocked`'s nop branch records none and
  write-aheads no intent). So any owned entry reaching the nop-delete path was
  published by a real backend.
- **Fix**: keep ownership, count `deleteFail`, return new sentinel
  `errDDNSNoBackendToWithdraw`. `reconcileOnceLocked` / `withdrawAllLocked`
  swallow the sentinel (a legitimate disabled-with-no-backend pass is not marked
  failed) but still block a same-cycle re-add. A later reconcile with a live
  backend withdraws for real. Mirrors the Surface A `withdrawOwnedLocked`
  precedent (which P2 already made keep-ownership-on-no-op).

## #2700 — GENUINE-AND-FIXED

The RFC 4701 DHCID digest folds `client-identity || FQDN` only (NOT the
address — `dhcidRR`, `backend_rfc2136.go`), so a dual-stack client (an A and an
AAAA under one FQDN, one client id) shares ONE DHCID. `sendRemoveForward` always
did `Remove([]dns.RR{rr, dhcid})`, deleting the shared DHCID with a single
A/AAAA. ScopeKey makes ownership per-family, but the DHCID is one shared wire RR
under the FQDN — the per-family keying does not address this.

- **Impact**: a partial teardown (one family released) left the survivor
  DHCID-unprotected (hijack window, RFC 4703), then leaked it (its later delete
  failed the DHCID-match prereq).
- **Fix**: `Manager.dhcidSharedWithOther` scans the store; a new
  `LeaseDNSRecord.KeepForwardDHCID` threads through `DeleteLease` →
  `sendRemoveForward(..., keepDHCID)`, which removes only the A/AAAA and LEAVES
  the shared DHCID (the DHCID-match prerequisite is still sent, so the delete
  stays ownership-guarded). The DHCID is removed only with the LAST family's
  record, so a fully-released name leaves no orphan DHCID.

## #2708 — GENUINE-AND-FIXED

`PTRPending` was persisted but invisible: `OwnedRecordView` omitted it and
`Stats` had only the cumulative `PTRDeferred`. P2/P3 added Surface A
observability but did not surface lease-path PTR-pending.

- **Fix**: `OwnedRecordView.PTRPending` (+ copy in `OwnedRecordViews`); new
  CURRENT `Stats.PTRPendingNow` gauge distinct from the lifetime `PTRDeferred`;
  a `Pending` column in CLI + gRPC `show ... dynamic-dns detail`; Prometheus
  `xpf_dhcp_ddns_ptr_pending` gauge.

## Fail-on-revert tests (`pkg/ddns/spine_fixes_test.go`)

Reconcile-layer regressions driving the REAL `rfc2136Updater` against the
in-process stateful fake DNS server (no `fakeUpdater` bypass — the #2691 P2
lesson). Each was confirmed to FAIL when its fix is reverted:

- `TestPartialDualStackTeardownKeepsSharedDHCID` (#2700) — publish A+AAAA one
  FQDN; release v4 → A gone, **shared DHCID + AAAA survive**; release v6 → AAAA
  and now-unshared DHCID both removed.
- `TestRestartNoBackendKeepsOwnershipNotOrphan` (#2699) — publish via live
  backend, fresh manager loads persisted store with config resolving to nop →
  **ownership retained, deleteFail counted, RR still live**; a third process
  with a live backend withdraws for real.
- `TestPTRPendingExposedPerRecord` (#2708) — force a SERVFAIL PTR → view +
  `PTRPendingNow` expose pending; recovery clears it while `PTRDeferred`
  (lifetime) stays.

The pre-existing no-backend test in `manager_test.go` is updated to assert
ownership is RETAINED (the #2699 contract change).

## Gates

- `go build ./...` clean
- `go test ./pkg/ddns/... ./pkg/dhcpserver/... ./pkg/daemon/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/api/...` green
- `go test -race ./pkg/ddns` green
- `gofmt` clean; `go vet` clean (the `pkg/cli/cli.go` unreachable-code note is pre-existing, untouched)

Closes #2699
Closes #2700
Closes #2708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
