### PR TITLE
#2519: allowlist writeProxyResponderSysctl in fsatomic canary

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-06-25 — #2519: allowlist writeProxyResponderSysctl in fsatomic canary
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed RED-on-master `TestNoDirectOsWriteFile` (the #1916
+  receiver-aware direct-`os.WriteFile` canary). It flagged
+  `pkg/dataplane/proxyarp.go:95` `writeProxyResponderSysctl`, which writes
+  `[]byte("1")` to the procfs `net.ipv4.conf.<if>.proxy_arp` /
+  `net.ipv6.conf.<if>.proxy_ndp` knob. procfs has no rename(2), so the
+  fsatomic atomic-rename writers are impossible by construction — this is a
+  legitimate BestEffortKernelKnob write, exactly like the already-allowlisted
+  slow-path procfs/sysfs entries. Added the narrow receiver-aware allowlist
+  entry `"dataplane::writeProxyResponderSysctl": "procfs proxy_arp /
+  proxy_ndp knob"` mirroring the existing `dataplane::ensureVLANSubInterface`
+  shape. The entry is keyed to this one function only — the canary still
+  catches any genuine non-allowlisted direct `os.WriteFile`.
+- **File(s)**: pkg/fsatomic/canary_test.go, _Log.md
+- **Validation**: confirmed RED on master (proxyarp.go:95 violation) → GREEN
+  with the entry; `go build ./...` clean; `go test ./pkg/fsatomic/...` and
+  `go test ./pkg/dataplane/...` green; gofmt clean; `go vet` clean.
+
 ## 2026-06-25 — #2364: seed node-local hot-path hashes (algorithmic-complexity hardening)
 
 - **Timestamp**: 2026-06-25

--- a/pkg/fsatomic/canary_test.go
+++ b/pkg/fsatomic/canary_test.go
@@ -46,6 +46,7 @@ var allowedFunctions = map[string]string{
 	// pkg/dataplane — RPS/RFS/XPS + accept_ra sysfs/procfs knobs.
 	"dataplane::CompileResult.tuneInterfaceBuffers": "sysfs RPS/RFS/XPS knobs",
 	"dataplane::ensureVLANSubInterface":             "procfs accept_ra knob",
+	"dataplane::writeProxyResponderSysctl":          "procfs proxy_arp / proxy_ndp knob",
 	// pkg/dataplane/userspace — socket-buffer sysctls.
 	"dataplane/userspace::tuneSocketBuffers": "procfs socket-buffer sysctls",
 	// pkg/networkd — slow-path rp_filter restore (procfs).


### PR DESCRIPTION
Closes #2519

## Problem
`TestNoDirectOsWriteFile` (the #1916 receiver-aware direct-`os.WriteFile` canary) was RED on master. It flagged `pkg/dataplane/proxyarp.go:95` `writeProxyResponderSysctl`, which writes `[]byte("1")` to the procfs proxy responder knob:
- `net.ipv4.conf.<if>.proxy_arp`
- `net.ipv6.conf.<if>.proxy_ndp`

## Fix
Added one narrow receiver-aware allowlist entry to `pkg/fsatomic/canary_test.go`:

```go
"dataplane::writeProxyResponderSysctl": "procfs proxy_arp / proxy_ndp knob",
```

**Justification (procfs no-rename BestEffortKernelKnob):** procfs has no `rename(2)`, so the fsatomic atomic-rename writers (`WriteFileDurable` / `WriteFileAtomic`) are impossible by construction. This is a legitimate `BestEffortKernelKnob` write — identical in class to the already-allowlisted slow-path procfs/sysfs knob writers (e.g. `dataplane::ensureVLANSubInterface` accept_ra). The entry format mirrors the existing entries exactly; no new mechanism was introduced.

**Canary still catches genuine violations:** the key is specific to this single plain function (`dataplane::writeProxyResponderSysctl`). It is not a package- or file-level blanket exemption — any other non-allowlisted direct `os.WriteFile` under `pkg/` is still flagged. Confirmed RED on master (the exact `proxyarp.go:95` violation) → GREEN with the entry.

## Validation
- `go test ./pkg/fsatomic/...` — green, `TestNoDirectOsWriteFile` now PASSES (scanned 423 files)
- `go build ./...` — clean
- `go test ./pkg/dataplane/...` — green
- `gofmt` clean, `go vet` clean