### PR TITLE
observability: surface Surface A DDNS no-backend skips; fix MSS docstring (#2726)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14674,3 +14674,28 @@ top.
   **File(s)**: pkg/config/compiler_routing.go,
   pkg/config/compiler_prefix_list_merge_2641_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2726 — surface Surface A DDNS SkippedNoBackend on all three
+  operator surfaces (Prometheus / CLI / gRPC) + correct stale
+  tunnel_tcp_mss docstring (post-#2715). (a) Mirrored the lease-path
+  no-backend surfacing: added the
+  xpf_ddns_surface_a_skipped_total{reason="no-backend"} series in
+  collectSurfaceADDNSMetrics (descriptor already had the reason label,
+  closed-cardinality — only the comment's reason set updated); added
+  no-backend to the CLI + gRPC "Skipped:" formatted lines. No proto
+  change (both render formatted strings). New fail-on-revert test drives
+  collectSurfaceADDNSMetrics directly and asserts the no-backend series.
+  (b) Doc-only: rewrote the tunnel_tcp_mss docstring to describe the
+  ACTUAL behavior — the WG MSS clamp uses tunnel_outer_mtu
+  (tx_ifindex→egress→logical, 1500 floor), NOT the #2715 route-resolved
+  encap-guard path — and note it is safe (route-resolved WG endpoints
+  NoRoute on this AF_XDP builder; clamp errs smaller, can't reintroduce
+  encap_mtu_drops).
+  Gates: gofmt clean; go build ./... clean; go test ./pkg/api/...
+  ./pkg/cli/... ./pkg/grpcapi/... ./pkg/ddns/... green; cargo build
+  --release clean (doc-only).
+  **File(s)**: pkg/api/metrics_system.go,
+  pkg/api/metrics_surface_a_ddns_test.go, pkg/cli/cli_show_services.go,
+  pkg/grpcapi/server_show_dhcp_lldp_snmp.go,
+  userspace-dp/src/afxdp/forwarding/mod.rs, _Log.md

--- a/pkg/api/metrics_surface_a_ddns_test.go
+++ b/pkg/api/metrics_surface_a_ddns_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/psaab/xpf/pkg/ddns"
+)
+
+// TestSurfaceADDNSSkippedNoBackendMetric pins #2726 (a): the Surface A
+// (router/interface-address) DDNS skip counter must surface the
+// no-backend reason as a third series on
+// xpf_ddns_surface_a_skipped_total{reason="no-backend"}, mirroring the
+// lease-path xpf_dhcp_ddns_skipped_total{reason="no-backend"}. P3 added
+// SurfaceAStats.SkippedNoBackend + its increment but the operator
+// surfaces only showed unchanged/backoff.
+//
+// The emitter is driven directly (collectSurfaceADDNSMetrics runs behind
+// the full dataplane-loaded gate in Collect(); this isolates the one
+// emitter under test without standing up a loaded DP + config store).
+//
+// FAIL-ON-REVERT: without the no-backend emitter line the
+// {reason="no-backend"} series is never produced and the lookup misses
+// → the test fails.
+func TestSurfaceADDNSSkippedNoBackendMetric(t *testing.T) {
+	s := &Server{
+		surfaceAStatsFn: func() *ddns.SurfaceAStats {
+			return &ddns.SurfaceAStats{
+				Scopes:           2,
+				UpsertOK:         7,
+				DeleteOK:         1,
+				Skipped:          4,
+				BackedOff:        2,
+				SkippedNoBackend: 5,
+			}
+		},
+	}
+	c := newCollector(s)
+
+	ch := make(chan prometheus.Metric, 64)
+	c.collectSurfaceADDNSMetrics(ch)
+	close(ch)
+
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+
+	reasonValue := func(name, reason string) (float64, bool) {
+		for _, m := range metrics {
+			if descName(m.Desc()) != name {
+				continue
+			}
+			var dm dto.Metric
+			if err := m.Write(&dm); err != nil {
+				t.Fatalf("metric Write: %v", err)
+			}
+			for _, lp := range dm.GetLabel() {
+				if lp.GetName() == "reason" && lp.GetValue() == reason {
+					if ctr := dm.GetCounter(); ctr != nil {
+						return ctr.GetValue(), true
+					}
+				}
+			}
+		}
+		return 0, false
+	}
+
+	if v, ok := reasonValue("xpf_ddns_surface_a_skipped_total", "no-backend"); !ok || v != 5 {
+		t.Errorf("surface_a skipped no-backend = %v (ok=%v), want 5", v, ok)
+	}
+	// The pre-existing reasons must still be emitted alongside it.
+	if v, ok := reasonValue("xpf_ddns_surface_a_skipped_total", "unchanged"); !ok || v != 4 {
+		t.Errorf("surface_a skipped unchanged = %v (ok=%v), want 4", v, ok)
+	}
+	if v, ok := reasonValue("xpf_ddns_surface_a_skipped_total", "backoff"); !ok || v != 2 {
+		t.Errorf("surface_a skipped backoff = %v (ok=%v), want 2", v, ok)
+	}
+}

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -82,7 +82,7 @@ func (c *xpfCollector) collectDDNSMetrics(ch chan<- prometheus.Metric) {
 // Surface A (router/interface-address) DDNS manager snapshot (#2691 P2). The
 // family is omitted entirely when no SurfaceAStatsFn is wired or it returns nil
 // (NoDataplane). Label cardinality is CLOSED: result in {ok,fail}; reason in
-// {unchanged,backoff}.
+// {unchanged,backoff,no-backend}.
 func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
 	if c.srv.surfaceAStatsFn == nil {
 		return
@@ -103,6 +103,8 @@ func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.Skipped), "unchanged")
 	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSSkippedTotal, prometheus.CounterValue,
 		float64(st.BackedOff), "backoff")
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSSkippedTotal, prometheus.CounterValue,
+		float64(st.SkippedNoBackend), "no-backend")
 	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSScopes, prometheus.GaugeValue,
 		float64(st.Scopes))
 }

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -137,7 +137,7 @@ func (c *CLI) showServicesDynamicDNS(detail bool) error {
 	fmt.Println("\n  Counters:")
 	fmt.Printf("    Publishes: ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
 	fmt.Printf("    Withdraws: ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)
-	fmt.Printf("    Skipped:   unchanged=%d backoff=%d\n", st.Skipped, st.BackedOff)
+	fmt.Printf("    Skipped:   unchanged=%d backoff=%d no-backend=%d\n", st.Skipped, st.BackedOff, st.SkippedNoBackend)
 	fmt.Printf("    Published records: %d\n", st.Scopes)
 
 	if detail && c.surfaceADDNSStatusFn != nil {

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -320,7 +320,7 @@ func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder
 	buf.WriteString("\n  Counters:\n")
 	fmt.Fprintf(buf, "    Publishes: ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
 	fmt.Fprintf(buf, "    Withdraws: ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)
-	fmt.Fprintf(buf, "    Skipped:   unchanged=%d backoff=%d\n", st.Skipped, st.BackedOff)
+	fmt.Fprintf(buf, "    Skipped:   unchanged=%d backoff=%d no-backend=%d\n", st.Skipped, st.BackedOff, st.SkippedNoBackend)
 	fmt.Fprintf(buf, "    Published records: %d\n", st.Scopes)
 
 	if detail && s.surfaceADDNSStatusFn != nil {

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -841,7 +841,19 @@ pub(super) fn tunnel_outer_mtu(
 /// A SYN clamped with the GRE value lets the peer send full-MSS data
 /// segments that the WG encap MTU guard then silently drops
 /// (`encap_mtu_drops`). Route WG-bound SYNs through `wg::mss::wg_tcp_mss`
-/// instead, derived from the SAME outer MTU the encap guard reads.
+/// instead, derived from `tunnel_outer_mtu` (resolve the transport
+/// `tx_ifindex`/`tx_vlan` → egress, falling back to `egress_ifindex`
+/// then the endpoint's `logical_ifindex`, with a 1500 floor).
+///
+/// NOTE (#2715): this is NOT the same path the encap MTU guard now
+/// reads. Post-#2715 the encap guard route-resolves the physical egress
+/// via the peer endpoint address; the MSS clamp still uses the
+/// `tunnel_outer_mtu` (tx_ifindex→egress→logical) chain above. That
+/// divergence is safe here, not a live bug: a route-resolved WG endpoint
+/// returns NoRoute on this AF_XDP builder (no synthetic egress to read),
+/// and the clamp errs toward a SMALLER MSS, so it can never advertise an
+/// MSS larger than the encap guard tolerates — it cannot reintroduce
+/// `encap_mtu_drops`.
 ///
 /// Non-WG endpoints (and the plain-forward path, `tunnel_endpoint_id ==
 /// 0`) keep the GRE formula bit-for-bit. No new branch on the


### PR DESCRIPTION
Closes #2726

Two LOW observability/doc items from the #2691 integration audit.

## (a) Surface A `SkippedNoBackend` not surfaced (Go: Prometheus + CLI + gRPC)

P3 added `SurfaceAStats.SkippedNoBackend` (plus its increment in `surface_a.go`) but the three operator surfaces only showed `unchanged`/`backoff`. Mirrored the lease-path (Surface B) `no-backend` surfacing pattern on all three:

- **Prometheus** (`pkg/api/metrics_system.go`): emit the third series `xpf_ddns_surface_a_skipped_total{reason="no-backend"}`, matching the lease-path `xpf_dhcp_ddns_skipped_total{reason="no-backend"}` label convention. The `surfaceADDNSSkippedTotal` descriptor already declares the closed-cardinality `reason` label, so **no descriptor change** — only the collect-function doc comment's reason set is updated.
- **CLI** (`pkg/cli/cli_show_services.go`): add `no-backend=%d` to the `Skipped:` line.
- **gRPC** (`pkg/grpcapi/server_show_dhcp_lldp_snmp.go`): same in the gRPC-rendered output.

**No proto change needed** — both the CLI and gRPC surfaces render formatted strings, not proto message fields. `SurfaceAStats.SkippedNoBackend` is already populated from `m.skippedNoBackend` (incremented in `surface_a.go`), so the surfaces show real data.

New fail-on-revert test `pkg/api/metrics_surface_a_ddns_test.go` drives `collectSurfaceADDNSMetrics` directly (the emitter runs behind the full dataplane-loaded gate in `Collect()`; driving it directly isolates the one emitter without standing up a loaded DP + config store) and asserts the `no-backend` series is present with the right value alongside `unchanged`/`backoff`.

## (b) Stale `tunnel_tcp_mss` docstring (`userspace-dp/src/afxdp/forwarding/mod.rs`)

The docstring claimed the WG MSS clamp derives from "the SAME outer MTU the encap guard reads." Stale post-#2715: the encap guard now route-resolves the physical egress via the peer endpoint, while the MSS clamp still uses `tunnel_outer_mtu` (`tx_ifindex`->egress->logical, 1500 floor). Corrected the docstring to describe the actual chain and note the divergence is **safe** — a route-resolved WG endpoint `NoRoute`s on this AF_XDP builder, and the clamp errs toward a smaller MSS, so it can never advertise an MSS larger than the encap guard tolerates (cannot reintroduce `encap_mtu_drops`). Doc-only; no Rust code change.

## Gates
- `gofmt` clean
- `go build ./...` clean
- `go test ./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/ddns/...` green
- `cargo build --release` clean (doc-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi