### PR TITLE
userspace: return error on address-book content-ID collision instead of panicking (#2514)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14674,3 +14674,28 @@ top.
   **File(s)**: pkg/config/compiler_routing.go,
   pkg/config/compiler_prefix_list_merge_2641_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2514 — address-book content-ID collision now returns a typed
+  error instead of panicking the daemon. Replaced the `probe > 256`
+  `panic(...)` in `buildAddressBookTableWithFeeds` with a returned
+  `*AddressBookIDCollisionError`. The linear-probe bound now scales with the
+  bucket count (`addressBookProbeLimit`, default `len(buckets)+8`) so a
+  forward probe is pigeonhole-guaranteed to find a free u32 slot for any
+  realistic config — the error is the genuine fail-safe, never a routine
+  path. Threaded the error up through `buildPolicySnapshots*` and the
+  `buildSnapshot*` chain: `ApplyConfig` (manager.go) now fails closed and
+  rejects the config (prior dataplane state retained); the scheduler-only
+  republish (`UpdatePolicyScheduleState`) logs and keeps the last snapshot;
+  the best-effort `UserspaceBoundLinuxInterfaces` degrades to nil. Added two
+  package-var seams (`addressBookContentHash64`, `addressBookProbeLimit`) so a
+  fail-on-revert test can force the exhaustion branch. New tests assert
+  error-not-panic (recover-guarded), snapshot-build propagation, and benign
+  64-book happy path. Gates: gofmt clean; go build ./... clean; go vet +
+  go test ./pkg/dataplane/userspace/... ./pkg/config/... ./pkg/daemon/...
+  green. Fail-on-revert verified (restoring the panic fails the test).
+  **File(s)**: pkg/dataplane/userspace/policies.go,
+  pkg/dataplane/userspace/builder.go, pkg/dataplane/userspace/manager.go,
+  pkg/dataplane/userspace/interfaces.go,
+  pkg/dataplane/userspace/address_book_collision_2514_test.go,
+  + mechanical 3rd-return-value updates across userspace *_test.go, _Log.md

--- a/pkg/dataplane/userspace/address_book_collision_2514_test.go
+++ b/pkg/dataplane/userspace/address_book_collision_2514_test.go
@@ -1,0 +1,184 @@
+// #2514: the address-book content-ID assignment must NOT panic the daemon
+// when a folded-hash collision cannot be resolved within the probe window.
+// Config-shaped input feeding the commit/apply path must fail closed with a
+// returned error so the offending config is rejected and the prior dataplane
+// state is retained — never crash a security appliance.
+//
+// These tests are fail-on-revert: the old code panicked at probe > 256, so if
+// the panic is restored, withInjectedAddressBookCollision recovers it and
+// fails the test, and the error-not-panic assertions below fail too.
+package userspace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// forceAddressBookCollision installs hash + probe-limit seams that drive every
+// distinct content bucket onto the same folded primary slot with a probe
+// window too small to ever find a free slot, so the (otherwise unreachable)
+// collision-exhaustion branch fires deterministically. It returns a restore
+// func. recover() is wired so a reintroduced panic surfaces as a test failure
+// rather than crashing the test binary.
+func forceAddressBookCollision(t *testing.T) (restore func()) {
+	t.Helper()
+	origHash := addressBookContentHash64
+	origLimit := addressBookProbeLimit
+	// Constant hash: every bucket maps to the same primary id and the same
+	// folded base, so every bucket after the first collides on the same
+	// slot. Low 32 bits non-zero so the id != 0 reservation does not move
+	// the slot around.
+	addressBookContentHash64 = func([]byte) uint64 { return 0x1234 }
+	// Probe window of 1: the first colliding bucket takes folded+1, the
+	// next colliding bucket finds folded+1 already used and exhausts the
+	// single-step window → AddressBookIDCollisionError.
+	addressBookProbeLimit = func(int) int { return 1 }
+	return func() {
+		addressBookContentHash64 = origHash
+		addressBookProbeLimit = origLimit
+	}
+}
+
+// collidingBookCfg builds a config with n address-book entries that all have
+// DISTINCT content (so they form n separate content buckets), which under the
+// injected constant hash all collide on the same folded slot.
+func collidingBookCfg(n int) *config.Config {
+	addrs := make(map[string]*config.Address, n)
+	for i := 0; i < n; i++ {
+		// Distinct /32 per entry → distinct canonical content → distinct
+		// bucket. names lexicographically ordered for determinism.
+		name := string(rune('a'+i/26)) + string(rune('a'+i%26))
+		addrs[name] = &config.Address{
+			Name:  name,
+			Value: cidrForIndex(i),
+		}
+	}
+	return &config.Config{
+		Security: config.SecurityConfig{
+			AddressBook: &config.AddressBook{Addresses: addrs},
+		},
+	}
+}
+
+func cidrForIndex(i int) string {
+	// 10.<a>.<b>.<c>/32 — unique per i for the small counts used here.
+	a := (i >> 16) & 0xff
+	b := (i >> 8) & 0xff
+	c := i & 0xff
+	return itoa(10) + "." + itoa(a) + "." + itoa(b) + "." + itoa(c) + "/32"
+}
+
+func itoa(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [3]byte
+	pos := len(buf)
+	for v > 0 {
+		pos--
+		buf[pos] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[pos:])
+}
+
+// TestAddressBookCollisionReturnsErrorNotPanic is the core #2514 assertion:
+// the builder returns an AddressBookIDCollisionError instead of panicking when
+// the probe window is exhausted. Wrapped in a recover so a reintroduced panic
+// fails the test loudly rather than aborting the binary.
+func TestAddressBookCollisionReturnsErrorNotPanic(t *testing.T) {
+	defer forceAddressBookCollision(t)()
+
+	var (
+		err  error
+		pan  any
+		done bool
+	)
+	func() {
+		defer func() { pan = recover(); done = true }()
+		_, _, err = buildAddressBookTable(collidingBookCfg(3))
+	}()
+
+	if !done {
+		t.Fatal("builder did not complete")
+	}
+	if pan != nil {
+		t.Fatalf("builder PANICKED on content-ID collision (regression of #2514): %v", pan)
+	}
+	if err == nil {
+		t.Fatal("expected AddressBookIDCollisionError, got nil error")
+	}
+	var collErr *AddressBookIDCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("expected *AddressBookIDCollisionError, got %T: %v", err, err)
+	}
+	if collErr.BucketCount != 3 {
+		t.Fatalf("BucketCount = %d, want 3", collErr.BucketCount)
+	}
+}
+
+// TestAddressBookCollisionPropagatesToSnapshotBuild proves the error threads
+// up the snapshot builder (the apply path), so ApplyConfig rejects the config
+// and retains the prior dataplane state (fail-closed) rather than panicking.
+func TestAddressBookCollisionPropagatesToSnapshotBuild(t *testing.T) {
+	defer forceAddressBookCollision(t)()
+
+	cfg := collidingBookCfg(3)
+	// A policy referencing a book exercises both the policy builder and
+	// the address-book builder error paths inside buildSnapshot.
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Policies: []*config.Policy{
+				{
+					Name: "p1",
+					Match: config.PolicyMatch{
+						SourceAddresses:      []string{"aa"},
+						DestinationAddresses: []string{"any"},
+						Applications:         []string{"any"},
+					},
+					Action: config.PolicyPermit,
+				},
+			},
+		},
+	}
+
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	if err == nil {
+		t.Fatal("expected snapshot build to fail with collision error, got nil")
+	}
+	if snap != nil {
+		t.Fatalf("expected nil snapshot on error, got %+v", snap)
+	}
+	var collErr *AddressBookIDCollisionError
+	if !errors.As(err, &collErr) {
+		t.Fatalf("expected wrapped *AddressBookIDCollisionError, got %T: %v", err, err)
+	}
+}
+
+// TestAddressBookProbeResolvesWithoutErrorNormally guards the happy path: with
+// the real seams, a benign multi-book config builds with no error (the probe
+// bound scales with bucket count and is never reached for real FNV hashes).
+func TestAddressBookProbeResolvesWithoutErrorNormally(t *testing.T) {
+	books, _, err := buildAddressBookTable(collidingBookCfg(64))
+	if err != nil {
+		t.Fatalf("benign 64-book config returned an error: %v", err)
+	}
+	if len(books) != 64 {
+		t.Fatalf("expected 64 unique book rows, got %d", len(books))
+	}
+	// Every assigned ID must be unique and non-zero.
+	seen := make(map[uint32]struct{}, len(books))
+	for _, b := range books {
+		if b.ID == 0 {
+			t.Fatalf("book %q got reserved ID 0", b.Name)
+		}
+		if _, dup := seen[b.ID]; dup {
+			t.Fatalf("duplicate ID %d assigned", b.ID)
+		}
+		seen[b.ID] = struct{}{}
+	}
+}

--- a/pkg/dataplane/userspace/address_book_test.go
+++ b/pkg/dataplane/userspace/address_book_test.go
@@ -30,8 +30,8 @@ func TestAddressBookIDStability(t *testing.T) {
 		"alpha": "10.0.0.0/24",
 		"beta":  "192.168.0.0/16",
 	})
-	a, _ := buildAddressBookTable(cfg)
-	b, _ := buildAddressBookTable(cfg)
+	a, _, _ := buildAddressBookTable(cfg)
+	b, _, _ := buildAddressBookTable(cfg)
 	if len(a) != len(b) || len(a) != 2 {
 		t.Fatalf("expected 2 books in each build, got %d / %d", len(a), len(b))
 	}
@@ -58,7 +58,7 @@ func TestAddressBookIDDeterministicAcrossMapOrder(t *testing.T) {
 	var first []AddressBookSnapshot
 	for i := 0; i < 5; i++ {
 		cfg := newBookCfg(contents)
-		books, _ := buildAddressBookTable(cfg)
+		books, _, _ := buildAddressBookTable(cfg)
 		if i == 0 {
 			first = books
 			continue
@@ -81,12 +81,12 @@ func TestAddressBookContentDedup(t *testing.T) {
 	// Two books with identical content collapse to ONE row with ONE
 	// id. The diagnostic name is the lexicographically smallest.
 	cfg := newBookCfg(map[string]string{
-		"zeta":    "10.0.0.0/24",
-		"alpha":   "10.0.0.0/24",
-		"middle":  "10.0.0.0/24",
-		"unique":  "192.168.0.0/16",
+		"zeta":   "10.0.0.0/24",
+		"alpha":  "10.0.0.0/24",
+		"middle": "10.0.0.0/24",
+		"unique": "192.168.0.0/16",
 	})
-	books, nameToID := buildAddressBookTable(cfg)
+	books, nameToID, _ := buildAddressBookTable(cfg)
 	if len(books) != 2 {
 		t.Fatalf("expected 2 unique rows (one for 10.0.0.0/24, one for 192.168), got %d", len(books))
 	}
@@ -117,7 +117,7 @@ func TestAddressBookContainingBareIPNormalizesToSlash32Or128(t *testing.T) {
 		"host1": "10.0.0.1",
 		"host2": "2001:db8::1",
 	})
-	books, _ := buildAddressBookTable(cfg)
+	books, _, _ := buildAddressBookTable(cfg)
 	if len(books) != 2 {
 		t.Fatalf("expected 2 books, got %d", len(books))
 	}
@@ -154,7 +154,7 @@ func TestAddressBookDedupsCIDRSetByContent(t *testing.T) {
 			},
 		},
 	}
-	books, nameToID := buildAddressBookTable(cfg)
+	books, nameToID, _ := buildAddressBookTable(cfg)
 	if len(books) != 1 {
 		t.Fatalf("expected 1 deduped row, got %d (members: %+v)", len(books), books)
 	}
@@ -165,7 +165,7 @@ func TestAddressBookDedupsCIDRSetByContent(t *testing.T) {
 
 func TestAddressBookContainingAnyNormalizesToZeroSlash(t *testing.T) {
 	cfg := newBookCfg(map[string]string{"world": "any"})
-	books, _ := buildAddressBookTable(cfg)
+	books, _, _ := buildAddressBookTable(cfg)
 	if len(books) != 1 {
 		t.Fatalf("expected 1 book, got %d", len(books))
 	}
@@ -191,7 +191,7 @@ func TestClassifyPolicyAddresses(t *testing.T) {
 		"corp-net": "10.0.0.0/8",
 		"vpn-net":  "192.168.0.0/16",
 	})
-	_, nameToID := buildAddressBookTable(cfg)
+	_, nameToID, _ := buildAddressBookTable(cfg)
 	// Mix: 2 named books + 1 literal CIDR + 1 "any" + 1 unknown name.
 	bookIDs, literals := classifyPolicyAddresses(cfg, nameToID, []string{
 		"corp-net", "192.168.5.5/32", "any", "vpn-net", "unknown-book",
@@ -246,7 +246,7 @@ func TestPolicyBuildEmitsBookIDsAndLiterals(t *testing.T) {
 			},
 		},
 	}
-	snaps := buildPolicySnapshots(cfg)
+	snaps, _ := buildPolicySnapshots(cfg)
 	if len(snaps) != 1 {
 		t.Fatalf("expected 1 rule, got %d", len(snaps))
 	}

--- a/pkg/dataplane/userspace/app_catalog_test.go
+++ b/pkg/dataplane/userspace/app_catalog_test.go
@@ -23,7 +23,7 @@ func appCatalogTestConfig() *config.Config {
 
 func TestBuildSnapshotShipsAppCatalog_M5(t *testing.T) {
 	cfg := appCatalogTestConfig()
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.AppCatalog) == 0 {
 		t.Fatal("snapshot AppCatalog is empty; catalog never ships to Rust (#2008 M5)")
 	}
@@ -44,7 +44,7 @@ func TestBuildSnapshotShipsAppCatalog_M5(t *testing.T) {
 
 func TestAppCatalogSnapshotJSONRoundTrip_M5(t *testing.T) {
 	cfg := appCatalogTestConfig()
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 
 	data, err := json.Marshal(snap)
 	if err != nil {
@@ -80,7 +80,7 @@ func TestAppCatalogSnapshotJSONRoundTrip_M5(t *testing.T) {
 // and a new Rust helper sees an empty catalog (every session keeps app_id 0).
 func TestAppCatalogOmittedWhenEmpty_M5(t *testing.T) {
 	cfg := &config.Config{} // no applications referenced, AppID off
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.AppCatalog) != 0 {
 		t.Fatalf("expected empty AppCatalog for bare config, got %+v", snap.AppCatalog)
 	}

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -10,11 +10,11 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
-func buildSnapshot(cfg *config.Config, ucfg config.UserspaceConfig, generation uint64, fibGeneration uint32) *ConfigSnapshot {
+func buildSnapshot(cfg *config.Config, ucfg config.UserspaceConfig, generation uint64, fibGeneration uint32) (*ConfigSnapshot, error) {
 	return buildSnapshotWithSchedulerState(cfg, ucfg, generation, fibGeneration, nil, nil, nil)
 }
 
-func buildSnapshotWithSchedulerState(cfg *config.Config, ucfg config.UserspaceConfig, generation uint64, fibGeneration uint32, activeState map[string]bool, routeOverlay []config.RouteOverlayEntry, feedOverlay map[string][]string) *ConfigSnapshot {
+func buildSnapshotWithSchedulerState(cfg *config.Config, ucfg config.UserspaceConfig, generation uint64, fibGeneration uint32, activeState map[string]bool, routeOverlay []config.RouteOverlayEntry, feedOverlay map[string][]string) (*ConfigSnapshot, error) {
 	return buildSnapshotWithSchedulerStateAndNATCounters(cfg, ucfg, generation, fibGeneration, activeState, routeOverlay, feedOverlay, nil)
 }
 
@@ -26,7 +26,7 @@ func buildSnapshotWithSchedulerState(cfg *config.Config, ucfg config.UserspaceCo
 // stable key-derived counter ID, #2255); a nil map leaves every CounterID at 0
 // ("no counter"), reproducing pre-#2218 wire shape for callers that do not have
 // a compile result (tests, partial syncs).
-func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg config.UserspaceConfig, generation uint64, fibGeneration uint32, activeState map[string]bool, routeOverlay []config.RouteOverlayEntry, feedOverlay map[string][]string, natCounterIDs map[string]uint32) *ConfigSnapshot {
+func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg config.UserspaceConfig, generation uint64, fibGeneration uint32, activeState map[string]bool, routeOverlay []config.RouteOverlayEntry, feedOverlay map[string][]string, natCounterIDs map[string]uint32) (*ConfigSnapshot, error) {
 	if cfg == nil {
 		return &ConfigSnapshot{
 			Version:       ProtocolVersion,
@@ -36,10 +36,24 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 			Capabilities:  deriveUserspaceCapabilities(nil),
 			MapPins:       userspaceMapPins(),
 			Userspace:     ucfg,
-		}
+		}, nil
 	}
 	policyCount := len(cfg.Security.Policies)
 	interfaces := buildInterfaceSnapshots(cfg)
+	// #2514: the address-book content-ID assignment and the policy
+	// snapshot builder (which consumes the same nameToID map) can return
+	// an AddressBookIDCollisionError on an unresolvable folded-hash
+	// collision. Surface it as a build error so the apply path rejects the
+	// config and retains the prior dataplane state (fail-closed) — a
+	// config-shaped input must never panic the daemon.
+	policies, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeState, feedOverlay)
+	if err != nil {
+		return nil, err
+	}
+	addressBooks, _, err := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+	if err != nil {
+		return nil, err
+	}
 	return &ConfigSnapshot{
 		Version:            ProtocolVersion,
 		Generation:         generation,
@@ -56,7 +70,7 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 		Routes:             buildRouteSnapshots(cfg, interfaces, routeOverlay),
 		Flow:               buildFlowSnapshot(cfg),
 		DefaultPolicy:      policyActionString(cfg.Security.DefaultPolicy),
-		Policies:           buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeState, feedOverlay),
+		Policies:           policies,
 		SourceNAT:          buildSourceNATSnapshots(cfg, natCounterIDs),
 		StaticNAT:          buildStaticNATSnapshots(cfg, natCounterIDs),
 		DestinationNAT:     buildDestinationNATSnapshots(cfg, natCounterIDs),
@@ -70,12 +84,9 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 		ClassOfService:     buildClassOfServiceSnapshot(cfg),
 		FlowExport:         buildFlowExportSnapshot(cfg),
 		MirrorConfigs:      buildMirrorConfigSnapshotsFailClosed(cfg, interfaces),
-		AddressBooks: func() []AddressBookSnapshot {
-			books, _ := buildAddressBookTableWithFeeds(cfg, feedOverlay)
-			return books
-		}(),
-		AppCatalog: buildAppCatalogSnapshot(cfg),
-		Config:     cfg,
+		AddressBooks:       addressBooks,
+		AppCatalog:         buildAppCatalogSnapshot(cfg),
+		Config:             cfg,
 		Summary: SnapshotSummary{
 			HostName:       cfg.System.HostName,
 			DataplaneType:  cfg.System.DataplaneType,
@@ -85,7 +96,7 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 			SchedulerCount: len(cfg.Schedulers),
 			HAEnabled:      cfg.Chassis.Cluster != nil,
 		},
-	}
+	}, nil
 }
 
 // snapshotContentHash computes a SHA-256 hash over the stable content of a

--- a/pkg/dataplane/userspace/feed_enforcement_test.go
+++ b/pkg/dataplane/userspace/feed_enforcement_test.go
@@ -85,7 +85,7 @@ func TestFeedOverlayEmitsBookRowAndPopulatesNameToID(t *testing.T) {
 		"bad-actors": {"198.51.100.0/24", "2001:db8:bad::/48"},
 	}
 
-	books, nameToID := buildAddressBookTableWithFeeds(cfg, overlay)
+	books, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
 
 	row := findBookByName(books, "bad-actors")
 	if row == nil {
@@ -105,7 +105,7 @@ func TestFeedOverlayEmitsBookRowAndPopulatesNameToID(t *testing.T) {
 	// NON-TAUTOLOGICAL guard: with no overlay the name is unknown — the table
 	// is empty and nameToID has no entry. Proves the row/ID come from the
 	// overlay, not from anywhere else.
-	booksNoOverlay, nameToIDNoOverlay := buildAddressBookTableWithFeeds(cfg, nil)
+	booksNoOverlay, nameToIDNoOverlay, _ := buildAddressBookTableWithFeeds(cfg, nil)
 	if findBookByName(booksNoOverlay, "bad-actors") != nil {
 		t.Fatalf("without the overlay, bad-actors must NOT emit a book row (tautology check)")
 	}
@@ -123,13 +123,13 @@ func TestFeedBackedPolicyRoutesAsBookReference(t *testing.T) {
 		"bad-actors": {"198.51.100.0/24"},
 	}
 
-	_, nameToID := buildAddressBookTableWithFeeds(cfg, overlay)
+	_, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
 	wantID := nameToID["bad-actors"]
 	if wantID == 0 {
 		t.Fatalf("precondition: feed name must have an ID")
 	}
 
-	snaps := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	snaps, _ := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
 	if len(snaps) != 1 {
 		t.Fatalf("expected 1 policy rule, got %d", len(snaps))
 	}
@@ -144,7 +144,7 @@ func TestFeedBackedPolicyRoutesAsBookReference(t *testing.T) {
 	// NON-TAUTOLOGICAL: without the overlay the SAME token IS a no-match
 	// literal (the pre-#2049 broken behaviour). This proves the difference is
 	// the overlay.
-	snapsNoOverlay := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, nil)
+	snapsNoOverlay, _ := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, nil)
 	if len(snapsNoOverlay) != 1 {
 		t.Fatalf("expected 1 rule without overlay, got %d", len(snapsNoOverlay))
 	}
@@ -163,12 +163,12 @@ func TestFeedBackedPolicyDestinationRoutesAsBookReference(t *testing.T) {
 	overlay := map[string][]string{
 		"blocklist": {"203.0.113.0/24", "2001:db8:dead::/48"},
 	}
-	_, nameToID := buildAddressBookTableWithFeeds(cfg, overlay)
+	_, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
 	wantID := nameToID["blocklist"]
 	if wantID == 0 {
 		t.Fatalf("precondition: feed name must have an ID")
 	}
-	snaps := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	snaps, _ := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
 	if !containsID(snaps[0].DestinationBookIDs, wantID) {
 		t.Fatalf("feed-backed destination must be a book reference; DestinationBookIDs=%v want %d", snaps[0].DestinationBookIDs, wantID)
 	}
@@ -184,7 +184,7 @@ func TestEmptyFeedSnapshotYieldsNoPrefixes(t *testing.T) {
 	overlay := map[string][]string{
 		"bad-actors": {}, // bound but empty (no snapshot yet)
 	}
-	books, nameToID := buildAddressBookTableWithFeeds(cfg, overlay)
+	books, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
 	row := findBookByName(books, "bad-actors")
 	if row != nil {
 		if len(row.PrefixesV4) != 0 || len(row.PrefixesV6) != 0 {
@@ -196,7 +196,7 @@ func TestEmptyFeedSnapshotYieldsNoPrefixes(t *testing.T) {
 	if _, ok := nameToID["bad-actors"]; !ok {
 		t.Fatalf("empty feed-backed name must still be in nameToID (book reference to an empty set)")
 	}
-	snaps := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
+	snaps, _ := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, overlay)
 	if len(snaps) != 1 {
 		t.Fatalf("policy must still build with an empty feed; got %d rules", len(snaps))
 	}
@@ -215,8 +215,8 @@ func TestFeedContentChangeReshapesPublishedSnapshot(t *testing.T) {
 	overlayP1 := map[string][]string{"bad-actors": {"198.51.100.0/24"}}
 	overlayP2 := map[string][]string{"bad-actors": {"203.0.113.0/24"}}
 
-	s1 := buildSnapshotWithSchedulerState(cfg, ucfg, 1, 0, nil, nil, overlayP1)
-	s2 := buildSnapshotWithSchedulerState(cfg, ucfg, 1, 0, nil, nil, overlayP2)
+	s1, _ := buildSnapshotWithSchedulerState(cfg, ucfg, 1, 0, nil, nil, overlayP1)
+	s2, _ := buildSnapshotWithSchedulerState(cfg, ucfg, 1, 0, nil, nil, overlayP2)
 
 	// The published address-book row follows the new content.
 	row1 := findBookByName(s1.AddressBooks, "bad-actors")
@@ -243,7 +243,7 @@ func TestFeedContentChangeReshapesPublishedSnapshot(t *testing.T) {
 
 	// Conversely: identical overlay content yields an identical hash (the skip
 	// is correct — no wasted round-trip).
-	s1b := buildSnapshotWithSchedulerState(cfg, ucfg, 9, 7, nil, nil, overlayP1)
+	s1b, _ := buildSnapshotWithSchedulerState(cfg, ucfg, 9, 7, nil, nil, overlayP1)
 	h1b, _ := snapshotContentHash(s1b)
 	if h1 != h1b {
 		t.Fatalf("identical feed content must yield identical content hash; %x != %x", h1, h1b)
@@ -264,7 +264,7 @@ func TestFeedOverlayMergesWithStaticBook(t *testing.T) {
 		},
 	}
 	overlay := map[string][]string{"mixed": {"198.51.100.0/24"}}
-	books, _ := buildAddressBookTableWithFeeds(cfg, overlay)
+	books, _, _ := buildAddressBookTableWithFeeds(cfg, overlay)
 	row := findBookByName(books, "mixed")
 	if row == nil {
 		t.Fatalf("mixed book row missing")
@@ -301,7 +301,7 @@ func TestLegacyAdapterForwardsFeedSnapshots(t *testing.T) {
 	// stored overlay emits the feed-backed book row. Mirrors the daemon path
 	// where the next Compile/Apply consumes the cached overlay.
 	cfg := feedPolicyCfg("bad-actors", "any")
-	books, nameToID := buildAddressBookTableWithFeeds(cfg, m.feedSnapshotOverlay())
+	books, nameToID, _ := buildAddressBookTableWithFeeds(cfg, m.feedSnapshotOverlay())
 	if findBookByName(books, "bad-actors") == nil {
 		t.Fatalf("feed overlay forwarded through the adapter must enforce a book row")
 	}
@@ -404,7 +404,7 @@ func TestSchedulerRepublishRetainsFeedEnforcement(t *testing.T) {
 	if len(snap.Policies) != 1 {
 		t.Fatalf("expected 1 republished policy rule, got %d", len(snap.Policies))
 	}
-	_, nameToID := buildAddressBookTableWithFeeds(cfg, overlay)
+	_, nameToID, _ := buildAddressBookTableWithFeeds(cfg, overlay)
 	wantID := nameToID["bad-actors"]
 	if wantID == 0 {
 		t.Fatalf("precondition: feed name must have an ID")

--- a/pkg/dataplane/userspace/flow_wire_coerce_test.go
+++ b/pkg/dataplane/userspace/flow_wire_coerce_test.go
@@ -151,7 +151,7 @@ func TestFullSnapshotMarshalsInRange_1977(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.Flow.TCPMSSGreIn = 70000
 	cfg.Security.Flow.TCPSession = &config.TCPSessionConfig{EstablishedTimeout: math.MaxInt64}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if _, err := json.Marshal(&ControlRequest{Type: "apply_snapshot", Snapshot: snap}); err != nil {
 		t.Fatalf("marshal: %v", err)
 	}

--- a/pkg/dataplane/userspace/interfaces.go
+++ b/pkg/dataplane/userspace/interfaces.go
@@ -91,8 +91,13 @@ func UserspaceBoundLinuxInterfaces(cfg *config.Config) []string {
 	// allowlist is by Linux name (what `ethtool` consumes), so ifindex
 	// lookups are unnecessary here. We reuse the shared filter via the
 	// real builder to stay in lock-step with binding logic.
-	snap := buildSnapshot(cfg, ucfg, 0, 0)
-	if snap == nil {
+	// #2514: buildSnapshot can return an error (e.g. an unresolvable
+	// address-book content-ID collision). This is a best-effort allowlist
+	// derivation, so on error we degrade to nil rather than propagating —
+	// the real apply path (ApplyConfig) surfaces the same error to the
+	// operator and rejects the commit.
+	snap, err := buildSnapshot(cfg, ucfg, 0, 0)
+	if err != nil || snap == nil {
 		return nil
 	}
 	seen := make(map[string]struct{})

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -518,7 +518,15 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 	// #1827: include the cached ip-monitoring route overlay so a full
 	// apply (operator commit) while a policy is FAILED preserves the
 	// injected route instead of reverting traffic to the dead uplink.
-	snap := buildSnapshotWithSchedulerStateAndNATCounters(cfg, ucfg, m.bumpGeneration(), m.readFIBGeneration(), activeState, m.routeOverlaySnapshot(), m.feedSnapshotOverlay(), result.NATCounterIDs)
+	// #2514: a config-shaped input (e.g. address-book content-ID
+	// collision) must reject the apply with an error rather than panic
+	// the daemon. buildSnapshot* returns the error up here; ApplyConfig
+	// fails closed and the previously published snapshot / dataplane state
+	// is retained (m.lastSnapshot is not advanced on the error path).
+	snap, err := buildSnapshotWithSchedulerStateAndNATCounters(cfg, ucfg, m.bumpGeneration(), m.readFIBGeneration(), activeState, m.routeOverlaySnapshot(), m.feedSnapshotOverlay(), result.NATCounterIDs)
+	if err != nil {
+		return nil, fmt.Errorf("userspace: build config snapshot: %w", err)
+	}
 	// #1620: stamp the cold-path sample mask onto the snapshot. The
 	// daemon called SetColdPathSampleMask once at startup with the
 	// validated CLI flag value (or nil for "use default"). A nil
@@ -729,11 +737,24 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	// rather than feedSnapshotOverlay() (which re-locks m.mu and would
 	// deadlock). Matches how the full snapshot build reads the overlay.
 	feedOverlay := cloneFeedOverlay(m.feedOverlay)
-	next.Policies = buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeCopy, feedOverlay)
+	// #2514: an unresolvable address-book content-ID collision must not
+	// panic the daemon. Abort the scheduler-only republish and retain the
+	// last published snapshot (fail-closed) — the next full apply will
+	// surface the same error to the operator at commit time.
+	policies, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeCopy, feedOverlay)
+	if err != nil {
+		slog.Warn("userspace: skipping policy-scheduler republish; retaining prior snapshot", "err", err)
+		return
+	}
+	next.Policies = policies
 	// #1606: refresh the address-book table alongside the policies
 	// so book IDs cited in the new policies always resolve on the
 	// dataplane side.
-	books, _ := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+	books, _, err := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+	if err != nil {
+		slog.Warn("userspace: skipping policy-scheduler republish; retaining prior snapshot", "err", err)
+		return
+	}
 	next.AddressBooks = books
 
 	publishSnap := next

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2080,7 +2080,7 @@ func TestBuildSnapshotSummary(t *testing.T) {
 		},
 	}
 
-	snap := buildSnapshot(cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 11, 5)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 11, 5)
 	if snap.Generation != 11 {
 		t.Fatalf("Generation = %d, want 11", snap.Generation)
 	}
@@ -2707,7 +2707,7 @@ func TestBuildSnapshotIncludesThreeColorPolicerSchema(t *testing.T) {
 		},
 	}
 
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if !snap.Capabilities.ForwardingSupported {
 		t.Fatalf("ForwardingSupported = false, want three-color policers admitted. Reasons: %+v", snap.Capabilities.UnsupportedReasons)
 	}
@@ -2804,7 +2804,7 @@ func TestBuildSnapshotIncludesMirrorConfigsFromRealInterfaceSnapshot(t *testing.
 		},
 	}
 
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	var loIfindex int
 	for _, iface := range snap.Interfaces {
 		if iface.Name == "lo" {
@@ -3358,7 +3358,7 @@ func TestUserspaceSupportsSimpleZonePolicies(t *testing.T) {
 	if !userspaceSupportsSecurityPolicies(cfg) {
 		t.Fatal("userspaceSupportsSecurityPolicies = false, want true")
 	}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if snap.DefaultPolicy != "deny" || len(snap.Policies) != 1 || snap.Policies[0].Action != "permit" {
 		t.Fatalf("unexpected policy snapshot: %+v", snap.Policies)
 	}
@@ -3399,7 +3399,7 @@ func TestUserspaceSupportsAddressBookPolicyMatches(t *testing.T) {
 	if !userspaceSupportsSecurityPolicies(cfg) {
 		t.Fatal("userspaceSupportsSecurityPolicies = false, want true with resolvable address-book entries")
 	}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 {
 		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
 	}
@@ -3464,7 +3464,7 @@ func TestUserspaceSupportsNamedApplicationPolicyMatches(t *testing.T) {
 	if !userspaceSupportsSecurityPolicies(cfg) {
 		t.Fatal("userspaceSupportsSecurityPolicies = false, want true with resolvable application-set")
 	}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 {
 		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
 	}
@@ -3521,7 +3521,7 @@ func TestBuildSnapshotIncludesUnitInterfaces(t *testing.T) {
 		"wan": {Name: "wan", Interfaces: []string{"reth0.50"}},
 	}
 
-	snap := buildSnapshot(cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 2, RingEntries: 2048}, 1, 0)
 	got := map[string]InterfaceSnapshot{}
 	for _, iface := range snap.Interfaces {
 		got[iface.Name] = iface
@@ -3635,7 +3635,7 @@ func TestBuildPolicySnapshotsIncludesGlobalPolicies(t *testing.T) {
 		},
 		Action: config.PolicyDeny,
 	}}
-	snap := buildPolicySnapshots(cfg)
+	snap, _ := buildPolicySnapshots(cfg)
 	if len(snap) != 2 {
 		t.Fatalf("len(snap) = %d, want 2", len(snap))
 	}
@@ -3677,7 +3677,7 @@ func TestBuildPolicySnapshotsRoundTripsSchedulerInactiveAndRuleID(t *testing.T) 
 		Action: config.PolicyDeny,
 	}}
 
-	unseeded := buildPolicySnapshots(cfg)
+	unseeded, _ := buildPolicySnapshots(cfg)
 	if len(unseeded) != 2 {
 		t.Fatalf("len(unseeded) = %d, want 2", len(unseeded))
 	}
@@ -3687,7 +3687,7 @@ func TestBuildPolicySnapshotsRoundTripsSchedulerInactiveAndRuleID(t *testing.T) 
 		}
 	}
 
-	snap := buildPolicySnapshotsWithSchedulerState(cfg, map[string]bool{
+	snap, _ := buildPolicySnapshotsWithSchedulerState(cfg, map[string]bool{
 		"workhours": false,
 		"always":    true,
 	})
@@ -3791,7 +3791,7 @@ func TestUpdatePolicyScheduleStatePublishesUserspaceSnapshot(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
 
 	m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
@@ -3889,7 +3889,7 @@ func TestUpdatePolicyScheduleStateRefusesOldHelperForScheduledPolicies(t *testin
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	m.lastSnapshot.Policies[0].Inactive = false
 
 	m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
@@ -3942,7 +3942,7 @@ func TestUpdatePolicyScheduleStateWithoutHelperDoesNotMutateSnapshot(t *testing.
 
 	m := New()
 	m.generation = 7
-	m.lastSnapshot = buildSnapshot(cfg, config.UserspaceConfig{}, 7, 0)
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{}, 7, 0)
 	m.lastSnapshot.Policies[0].Inactive = false
 
 	m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
@@ -4125,13 +4125,13 @@ func TestBuildScreenSnapshotsMarksSynCookieMode(t *testing.T) {
 	if !snaps[0].SYNCookie {
 		t.Fatalf("SYNCookie = false, want true: %+v", snaps[0])
 	}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.SYNCookieMasterKey) != 32 {
 		t.Fatalf("SYNCookieMasterKey len = %d, want 32", len(snap.SYNCookieMasterKey))
 	}
 	cfg.System.RootAuthentication = nil
 	cfg.System.MasterPassword = "juniper-prf1"
-	snap = buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ = buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if snap.SYNCookieMasterKey != "" {
 		t.Fatalf("SYNCookieMasterKey without root secret = %q, want empty", snap.SYNCookieMasterKey)
 	}
@@ -5819,8 +5819,8 @@ func TestSnapshotContentHashIgnoresVolatileFields(t *testing.T) {
 	cfg.Security.Zones = map[string]*config.ZoneConfig{
 		"trust": {Name: "trust"},
 	}
-	snap1 := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 1, 10)
-	snap2 := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 99, 50)
+	snap1, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 1, 10)
+	snap2, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1}, 99, 50)
 
 	h1, ok1 := snapshotContentHash(snap1)
 	h2, ok2 := snapshotContentHash(snap2)
@@ -5843,8 +5843,8 @@ func TestSnapshotContentHashDiffersOnForwardingChange(t *testing.T) {
 		"untrust": {Name: "untrust"},
 	}
 
-	snap1 := buildSnapshot(cfg1, config.UserspaceConfig{Workers: 1}, 1, 1)
-	snap2 := buildSnapshot(cfg2, config.UserspaceConfig{Workers: 1}, 1, 1)
+	snap1, _ := buildSnapshot(cfg1, config.UserspaceConfig{Workers: 1}, 1, 1)
+	snap2, _ := buildSnapshot(cfg2, config.UserspaceConfig{Workers: 1}, 1, 1)
 
 	h1, ok1 := snapshotContentHash(snap1)
 	h2, ok2 := snapshotContentHash(snap2)

--- a/pkg/dataplane/userspace/nested_app_set_policy_test.go
+++ b/pkg/dataplane/userspace/nested_app_set_policy_test.go
@@ -47,7 +47,7 @@ func TestNestedApplicationSetPolicyMatch(t *testing.T) {
 		t.Fatalf("CompileConfig: %v", err)
 	}
 
-	snaps := buildPolicySnapshots(cfg)
+	snaps, _ := buildPolicySnapshots(cfg)
 	if len(snaps) != 1 {
 		t.Fatalf("expected 1 policy rule snapshot, got %d", len(snaps))
 	}

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -22,11 +22,68 @@ import (
 // by both appid.ProtocolNumber and userspace-dp parse_protocol.
 const unsupportedApplicationSentinel = "__unsupported__"
 
-func buildPolicySnapshots(cfg *config.Config) []PolicyRuleSnapshot {
+// addressBookProbeLimit bounds the deterministic linear probe used to resolve
+// a folded-hash collision when assigning a u32 address-book content ID. The
+// folded FNV hash gives a starting slot; on a collision we walk forward by one
+// slot at a time. The walk is bounded by the number of buckets actually being
+// assigned plus a small fixed margin, NOT by a magic constant: with N distinct
+// content buckets, at most N-1 prior IDs are taken, so a probe sequence of
+// length N is guaranteed to land on a free slot in the 2^32 ID space (which is
+// astronomically larger than any realistic N). Exceeding the bound therefore
+// signals a builder logic error, not a credible accidental collision — and even
+// then we return an error rather than panicking the daemon (#2514).
+const addressBookProbeMargin = 8
+
+// addressBookProbeLimit returns the maximum number of linear-probe steps
+// allowed when resolving a folded-hash content-ID collision for nBuckets
+// distinct content buckets. With at most nBuckets-1 IDs already taken, a
+// forward probe of nBuckets steps is guaranteed to reach a free slot in the
+// 2^32 space, so in production this bound is never reached — the
+// AddressBookIDCollisionError it guards is the fail-safe, not a routine path.
+// It is a package var so the #2514 fail-on-revert test can shrink the bound to
+// deterministically drive the collision-exhaustion branch (proving it returns
+// an error rather than panicking). Production code never reassigns it.
+var addressBookProbeLimit = func(nBuckets int) int {
+	return nBuckets + addressBookProbeMargin
+}
+
+// AddressBookIDCollisionError reports that the deterministic content-ID probe
+// could not assign a unique u32 ID to every address-book content bucket. It is
+// returned (never panicked) up the snapshot-build / apply path so a commit or
+// apply rejects the offending config and the prior dataplane state is retained
+// (fail-closed). FNV is not collision-resistant, so this is the defined
+// failure mode for the (astronomically unlikely) case of unresolvable folded
+// collisions among the configured address-book content buckets.
+type AddressBookIDCollisionError struct {
+	// BucketCount is the number of distinct content buckets being assigned.
+	BucketCount int
+	// Probes is the number of probe steps attempted before giving up.
+	Probes int
+}
+
+func (e *AddressBookIDCollisionError) Error() string {
+	return fmt.Sprintf(
+		"address-book content-ID collision could not be resolved within %d probes (bucket count = %d); reject config, retain prior dataplane state",
+		e.Probes, e.BucketCount)
+}
+
+// addressBookContentHash64 derives the FNV-1a/64 hash of an address-book
+// content bucket's canonical bytes. It is a package var (not an inline call)
+// solely so the #2514 fail-on-revert test can inject a degenerate hash that
+// forces every bucket into the same folded-ID probe sequence — exercising the
+// collision-exhaustion path that must return an AddressBookIDCollisionError
+// instead of panicking. Production code never reassigns it.
+var addressBookContentHash64 = func(canon []byte) uint64 {
+	h := fnv.New64a()
+	h.Write(canon)
+	return h.Sum64()
+}
+
+func buildPolicySnapshots(cfg *config.Config) ([]PolicyRuleSnapshot, error) {
 	return buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, nil, nil)
 }
 
-func buildPolicySnapshotsWithSchedulerState(cfg *config.Config, activeState map[string]bool) []PolicyRuleSnapshot {
+func buildPolicySnapshotsWithSchedulerState(cfg *config.Config, activeState map[string]bool) ([]PolicyRuleSnapshot, error) {
 	return buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeState, nil)
 }
 
@@ -36,11 +93,14 @@ func buildPolicySnapshotsWithSchedulerState(cfg *config.Config, activeState map[
 // feed-backed address-name resolves through nameToID to a SourceBookIDs /
 // DestinationBookIDs reference (instead of falling through to a no-match
 // literal), so the helper enforces the feed prefixes.
-func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeState map[string]bool, feedOverlay map[string][]string) []PolicyRuleSnapshot {
+func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeState map[string]bool, feedOverlay map[string][]string) ([]PolicyRuleSnapshot, error) {
 	if cfg == nil || (len(cfg.Security.Policies) == 0 && len(cfg.Security.GlobalPolicies) == 0) {
-		return nil
+		return nil, nil
 	}
-	_, nameToID := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+	_, nameToID, err := buildAddressBookTableWithFeeds(cfg, feedOverlay)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]PolicyRuleSnapshot, 0)
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
@@ -70,7 +130,7 @@ func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeSt
 		out = append(out, snap)
 		globalRuleIndex += userspacePolicyRuleExpansionCount(cfg, pol.Match.Applications)
 	}
-	return out
+	return out, nil
 }
 
 func buildOneRuleSnapshot(
@@ -196,7 +256,7 @@ func classifyPolicyAddresses(cfg *config.Config, nameToID map[string]uint32, add
 // canonical bytes (not by hash), and the bucket sort key is
 // (hash64, canonical_bytes) so collision-resolution is fully
 // deterministic across HA peers.
-func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[string]uint32) {
+func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[string]uint32, error) {
 	return buildAddressBookTableWithFeeds(cfg, nil)
 }
 
@@ -229,13 +289,13 @@ func buildAddressBookTable(cfg *config.Config) ([]AddressBookSnapshot, map[strin
 // When the static AddressBook is nil but a feed overlay is present, the table
 // is still built from the overlay alone (the pre-#2049 early-return only fired
 // because there were no static books to enumerate).
-func buildAddressBookTableWithFeeds(cfg *config.Config, feedOverlay map[string][]string) ([]AddressBookSnapshot, map[string]uint32) {
+func buildAddressBookTableWithFeeds(cfg *config.Config, feedOverlay map[string][]string) ([]AddressBookSnapshot, map[string]uint32, error) {
 	if cfg == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	ab := cfg.Security.AddressBook
 	if ab == nil && len(feedOverlay) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Collect all unique names: static Addresses + AddressSets ∪ feed-overlay
@@ -292,9 +352,7 @@ func buildAddressBookTableWithFeeds(cfg *config.Config, feedOverlay map[string][
 		key := string(canon)
 		b, exists := contentToBucket[key]
 		if !exists {
-			h := fnv.New64a()
-			h.Write(canon)
-			b = &bucket{canonical: canon, hash64: h.Sum64(), v4: v4, v6: v6}
+			b = &bucket{canonical: canon, hash64: addressBookContentHash64(canon), v4: v4, v6: v6}
 			contentToBucket[key] = b
 		}
 		b.names = append(b.names, name) // already in sorted-name order
@@ -324,26 +382,33 @@ func buildAddressBookTableWithFeeds(cfg *config.Config, feedOverlay map[string][
 			id = 1
 		}
 		if _, dup := used[id]; dup {
-			// Linear probe (deterministic given bucket sort).
+			// Linear probe (deterministic given bucket sort). The
+			// walk is bounded by the number of buckets being
+			// assigned plus a small margin: with N buckets at most
+			// N-1 IDs are already taken, so a free slot is reached
+			// within N probes in the 2^32 ID space. Exceeding the
+			// bound returns an AddressBookIDCollisionError (#2514)
+			// — config-shaped input must never panic a security
+			// appliance. The caller rejects the config and retains
+			// the prior dataplane state (fail-closed).
 			folded := uint32(b.hash64 ^ (b.hash64 >> 32))
-			probe := uint32(1)
-			for {
-				cand := folded + probe
+			probeLimit := addressBookProbeLimit(len(buckets))
+			resolved := false
+			for probe := 1; probe <= probeLimit; probe++ {
+				cand := folded + uint32(probe)
 				if cand == 0 {
 					cand = 1
 				}
 				if _, dup := used[cand]; !dup {
 					id = cand
+					resolved = true
 					break
 				}
-				probe++
-				if probe > 256 {
-					// Hard-fail by panic — would indicate
-					// astronomically-unlikely 256 simultaneous
-					// collisions in a 2^32 ID space.
-					panic(fmt.Sprintf(
-						"address-book content hash collision could not be resolved within 256 probes (bucket count = %d)",
-						len(buckets)))
+			}
+			if !resolved {
+				return nil, nil, &AddressBookIDCollisionError{
+					BucketCount: len(buckets),
+					Probes:      probeLimit,
 				}
 			}
 		}
@@ -363,7 +428,7 @@ func buildAddressBookTableWithFeeds(cfg *config.Config, feedOverlay map[string][
 			nameToID[n] = id
 		}
 	}
-	return out, nameToID
+	return out, nameToID, nil
 }
 
 // splitFeedPrefixesByFamily classifies feed-backed CIDR strings into v4 and

--- a/pkg/dataplane/userspace/policy_match_excluded_test.go
+++ b/pkg/dataplane/userspace/policy_match_excluded_test.go
@@ -42,7 +42,7 @@ func TestPolicySnapshotCarriesExcludedFlags(t *testing.T) {
 			},
 		},
 	}
-	snaps := buildPolicySnapshots(cfg)
+	snaps, _ := buildPolicySnapshots(cfg)
 	if len(snaps) != 2 {
 		t.Fatalf("expected 2 rules, got %d", len(snaps))
 	}

--- a/pkg/dataplane/userspace/protocol_failopen_2124_test.go
+++ b/pkg/dataplane/userspace/protocol_failopen_2124_test.go
@@ -106,7 +106,7 @@ func TestBuildOneRuleSnapshotEmitsUnsupportedSentinel(t *testing.T) {
 	// sentinel term (so Rust fails the whole snapshot closed), NEVER nil (which
 	// Rust would read as genuine match-any — the publish-window fail-open).
 	cfg := twoZonePolicyCfg(&config.Application{Name: "weird", Protocol: "definitely-not-a-proto"}, "weird")
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	if len(snap.Policies) != 1 {
 		t.Fatalf("len(Policies) = %d, want 1", len(snap.Policies))
 	}
@@ -123,7 +123,7 @@ func TestBuildOneRuleSnapshotNoSentinelForSupportedApp(t *testing.T) {
 	// A supported named protocol must NOT trigger the sentinel; the rule carries
 	// a normal canonicalized term.
 	cfg := twoZonePolicyCfg(&config.Application{Name: "esp-only", Protocol: "esp"}, "esp-only")
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 	terms := snap.Policies[0].ApplicationTerms
 	if len(terms) != 1 || terms[0].Protocol != "50" {
 		t.Fatalf("ApplicationTerms = %+v, want one esp term canonicalized to \"50\"", terms)

--- a/pkg/dataplane/userspace/protocol_null_collections_2214_test.go
+++ b/pkg/dataplane/userspace/protocol_null_collections_2214_test.go
@@ -133,7 +133,7 @@ func TestSnapshotWireNoNullCollections2214(t *testing.T) {
 	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
 		"EMPTY": {Name: "EMPTY"},
 	}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
 
 	if len(snap.NAT64) != 1 {
 		t.Fatalf("snap.NAT64 = %d, want 1", len(snap.NAT64))

--- a/pkg/dataplane/userspace/route_overlay_test.go
+++ b/pkg/dataplane/userspace/route_overlay_test.go
@@ -98,8 +98,8 @@ func TestRouteOverlayWholeEntryReplacement(t *testing.T) {
 // would be a failover-doesn't-happen bug).
 func TestRouteOverlayContentHashDelta(t *testing.T) {
 	cfg := overlayTestConfig()
-	base := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil, nil, nil)
-	withOverlay := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil,
+	base, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil, nil, nil)
+	withOverlay, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil,
 		[]config.RouteOverlayEntry{{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "p"}}, nil)
 
 	h1, ok1 := snapshotContentHash(base)
@@ -112,7 +112,7 @@ func TestRouteOverlayContentHashDelta(t *testing.T) {
 	}
 
 	// Same overlay again ⇒ identical hash (duplicate-publish basis).
-	again := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 2, 7, nil,
+	again, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 2, 7, nil,
 		[]config.RouteOverlayEntry{{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "p"}}, nil)
 	h3, _ := snapshotContentHash(again)
 	if h2 != h3 {
@@ -173,7 +173,7 @@ func TestPublishRouteOverlaySnapshot(t *testing.T) {
 	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
 	m.cfg.ControlSocket = controlSock
 	m.generation = 7
-	m.lastSnapshot = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
 	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
 		m.lastSnapshotHash = h
 	}
@@ -252,7 +252,7 @@ func TestPublishRouteOverlaySnapshot(t *testing.T) {
 	// Full-apply preservation (AGY r2-2): the cached overlay feeds the
 	// full snapshot build, so an operator commit while a policy is
 	// FAILED keeps the injected route.
-	snap := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
+	snap, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
 	kept := false
 	for _, r := range snap.Routes {
 		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" &&

--- a/pkg/dataplane/userspace/wire_uint8list_test.go
+++ b/pkg/dataplane/userspace/wire_uint8list_test.go
@@ -169,7 +169,7 @@ func TestBuildSnapshotFromFullConfigDecodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	snap := buildSnapshot(cfg, config.UserspaceConfig{Workers: 4, RingEntries: 1024}, 3, 3)
+	snap, _ := buildSnapshot(cfg, config.UserspaceConfig{Workers: 4, RingEntries: 1024}, 3, 3)
 	buf, err := json.Marshal(&ControlRequest{Type: "apply_snapshot", Snapshot: snap})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)


### PR DESCRIPTION
Closes #2514

## Problem
`buildAddressBookTableWithFeeds` (`pkg/dataplane/userspace/policies.go`) derived a u32 content ID from a folded FNV64 hash and, after 256 linear-probe collisions, **panicked the process**. This builder runs on the commit/apply path, so config-shaped input could crash the daemon rather than rejecting the config and holding last-known-good — the wrong failure mode for a router/security appliance (HIGH).

## Fix: panic → typed error, threaded to the apply rejection
- `buildAddressBookTable` / `buildAddressBookTableWithFeeds` now return `(snapshot, nameToID, error)` and return a typed `*AddressBookIDCollisionError` instead of panicking.
- The probe bound is now `addressBookProbeLimit(nBuckets)` (default `len(buckets)+8`) rather than a magic 256. With at most N-1 IDs already taken, a forward probe of N+margin steps is pigeonhole-guaranteed to reach a free slot in the 2^32 space for any realistic config — so the error is the genuine fail-safe, never a routine path, but it is **returned, never panicked**.
- The error threads up `buildPolicySnapshots*` and the `buildSnapshot*` chain:
  - **`ApplyConfig`** (the operator commit/apply path) wraps and returns the error; `m.lastSnapshot` is **not** advanced, so the prior dataplane state is retained (fail-closed) and the config is rejected — matching the established `SnapshotIntegrityError` / compile-error pattern.
  - **`UpdatePolicyScheduleState`** (scheduler-only republish) logs and keeps the last published snapshot.
  - **`UserspaceBoundLinuxInterfaces`** (best-effort allowlist) degrades to nil.

## How the error reaches the operator
`ApplyConfig` already returns `(result, err)`. On collision it now returns `fmt.Errorf("userspace: build config snapshot: %w", err)`, so the commit/apply fails with a clear message and the previously published snapshot remains live.

## Tests (fail-on-revert)
`pkg/dataplane/userspace/address_book_collision_2514_test.go`, using two package-var seams (`addressBookContentHash64`, `addressBookProbeLimit`) to force the exhaustion branch deterministically:
- `TestAddressBookCollisionReturnsErrorNotPanic` — recover-guarded; asserts `*AddressBookIDCollisionError`, not a panic. **Verified: restoring the old panic makes this test fail.**
- `TestAddressBookCollisionPropagatesToSnapshotBuild` — error wraps up through `buildSnapshot`; snapshot is nil (fail-closed).
- `TestAddressBookProbeResolvesWithoutErrorNormally` — benign 64-book config builds with unique non-zero IDs, no error.

## Gates
- `gofmt` clean, `go build ./...` clean, `go vet` clean
- `go test ./pkg/dataplane/userspace/... ./pkg/config/... ./pkg/daemon/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi