### PR TITLE
ra: run the NDP bind retry off the manager mutex (#2453)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14742,3 +14742,34 @@ top.
   pkg/api/metrics_surface_a_ddns_test.go, pkg/cli/cli_show_services.go,
   pkg/grpcapi/server_show_dhcp_lldp_snmp.go,
   userspace-dp/src/afxdp/forwarding/mod.rs, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2453 — move the RA sender NDP bind retry OUT of the manager
+  mutex critical section. `Manager.startLocked` (under `m.mu`) called
+  `sender.start()`, which opened the NDP conn synchronously: `ensureLinkLocal`
+  + `listen()`'s 10×200ms (~2s) bind retry while a settling/RETH link-local
+  appears. The whole retry ran under `m.mu`, so any concurrent RA manager op —
+  a VRRP-failover `Withdraw` or an `Apply` on a DIFFERENT interface — stalled up
+  to ~2s on `m.mu.Lock()`. Fix (approach b): `start()` now just launches the
+  owner goroutine and returns; the socket open moved to `openConn()`, run in the
+  owner goroutine BEFORE its main loop, with no lock held. The bind retry sleep
+  is now interruptible by `stopCh` (a mid-retry withdraw aborts promptly).
+  `startLocked`'s `m.mu` hold is reduced to the `InterfaceByName` check + the
+  `m.senders` bookkeeping. Race-safety: `s.conn` remains owner-only;
+  `finishShutdown` tolerates a nil conn (open failed or stop landed mid-retry) →
+  no goodbye, `goodbyeEmitted` stays false → the manager's release-time
+  standalone-goodbye backstop still fires for an owed graceful withdraw; `start()`
+  no longer returns a listen error (open is async — every `Apply` call site only
+  `slog.Warn`s it anyway); `srcAddr` is now owner-written / `Status`-read so it
+  got its own `srcMu` guard (`getSrcAddr`/`setSrcAddr`). Tests (race-on):
+  `TestT2453_SlowBindDoesNotStallOtherManagerOps` (fail-on-revert — a gated bind
+  on "lo" must not stall `WithdrawInterfaces` on another interface + `Status`;
+  verified RED when `start()` is reverted to synchronous open under `m.mu`),
+  `TestT2453_NormalStartStillBindsAndSends` (no-regression bind+burst),
+  `TestT2453_WithdrawDuringSlowBindEmitsGoodbye` (conn==nil safety + standalone
+  goodbye backstop). Gates: gofmt clean; go build ./... clean; go vet
+  ./pkg/ra/... clean; go test -race ./pkg/ra/... green; go test
+  ./pkg/daemon/... ./pkg/cluster/... green. HA-adjacent (RA Withdraw on VRRP
+  failover) → parent may run make test-failover for no-regression.
+  **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/serialize_test.go,
+  pkg/ra/README.md, _Log.md

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -96,13 +96,14 @@ after HA failover. To make that **structural**, not flag-defended:
   lands after is harmless (no supersession existed at the act moment). The only
   unlock inside `releaseDrain` is for the blocking standalone-goodbye send; the
   loop re-acquires and re-evaluates fresh state before touching the replacement.
-  NOTE: `onProvenClose` calls `startLocked`, which does blocking setup
-  (`InterfaceByName`, link-local add, `ndp.Listen` with retry) UNDER `m.mu` —
-  this can hold the manager mutex for up to ~2s and is pre-existing (plain
-  `Apply` also calls `startLocked` under `m.mu`). It is a known cost, not a
-  correctness issue; the tombstone (held) is what provides mutual exclusion, so
-  moving the start just after the unlock is possible but was left as-is to avoid
-  reintroducing a check-then-act.
+  NOTE: `onProvenClose` calls `startLocked` under `m.mu`. As of #2453 that is
+  cheap: `startLocked` only does the synchronous `InterfaceByName` check and the
+  `m.senders` bookkeeping, then launches the owner goroutine and returns. The
+  socket open — `ensureLinkLocal` + the `ndp.Listen` bind RETRY that sleeps up
+  to ~2s while a settling/RETH link-local appears — now runs in the owner
+  goroutine's `openConn()` BEFORE its main loop, NOT under `m.mu` (see "Bind
+  retry runs unlocked" below). The tombstone (held) still provides mutual
+  exclusion for the start.
 - **Draining tombstone — one live conn per interface, including replaces.**
   Every transition that removes OR replaces a sender installs a
   per-interface DRAINING tombstone under the manager mutex BEFORE releasing
@@ -206,7 +207,30 @@ best-effort).
   DOWN/UP from inside the RA manager would un-reconcile VIPs / stable LLAs
   and race the AF_XDP dataplane rebind. An interface with no usable 6-byte
   MAC degrades to a soft-logged warning (the caller only `slog.Warn`s the
-  error); the explicit `source-link-local` config and the `start()` retry
-  loop are the recovery path.
+  error); the explicit `source-link-local` config and the `listen()` retry
+  loop (now in the owner goroutine, see below) are the recovery path.
+- **Bind retry runs UNLOCKED, in the owner goroutine (#2453).** `start()` no
+  longer opens the NDP conn synchronously. It just launches `run()` and returns,
+  so `Manager.startLocked` holds `m.mu` only for the cheap `InterfaceByName`
+  check plus the `m.senders` bookkeeping. The socket open — `ensureLinkLocal`
+  plus the `ndp.Listen` bind retry, which sleeps up to ~2s (10 × 200 ms) while a
+  settling/RETH link-local appears — runs in the owner goroutine's `openConn()`
+  before its main loop, with NO lock held. Before this, a slow/settling
+  link-local on one interface stalled EVERY other RA manager op (a VRRP-failover
+  `Withdraw`, or an `Apply` on a different interface) for up to ~2s, because they
+  all contend `m.mu`. The bind retry is now interruptible by `stopCh`: a withdraw
+  signalled mid-retry aborts the sleep instead of running the full ~2s.
+  Consequences for the single-owner / #2033 invariants: `s.conn` is still opened,
+  used, and closed solely by the owner goroutine. If the bind ultimately fails
+  (or a stop lands before/during the retry) `openConn` returns false and `run`
+  goes straight to `finishShutdown`, which tolerates a nil conn — no goodbye is
+  written and `goodbyeEmitted` stays false, so the manager's release-time
+  backstop (`sendOneGoodbye` on a FRESH conn) still emits a standalone goodbye if
+  a graceful withdraw owed one. `start()` therefore never returns a listen error
+  (the open is async); the only caller cost is that an unreachable interface is
+  logged by the owner instead of surfaced as an `Apply` error — and every `Apply`
+  call site already only `slog.Warn`s that error. `srcAddr` is now written by the
+  owner goroutine and read by `Status` under `m.mu`, so it carries its own
+  `srcMu` guard (`getSrcAddr`/`setSrcAddr`).
 - Per RFC 5798, `AdvertiseInterval` is stored in milliseconds but goes
   on the wire in centiseconds. Don't double-convert.

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -47,10 +47,10 @@ var claimWaitTimeout = 5 * time.Second
 //   - the goodbye decision reads sender.goodbyeEmitted only AFTER <-stopped
 //     (happens-before), never on the timeout path.
 type drainEntry struct {
-	sender        *sender                   // draining sender; nil for a standalone-only claim
-	cfg           *config.RAInterfaceConfig // config for a standalone goodbye, if owed
-	goodbyeWanted bool                      // a graceful Withdraw targeted this interface
-	goodbyeClaimed bool                     // the owner has taken responsibility to emit it
+	sender         *sender                   // draining sender; nil for a standalone-only claim
+	cfg            *config.RAInterfaceConfig // config for a standalone goodbye, if owed
+	goodbyeWanted  bool                      // a graceful Withdraw targeted this interface
+	goodbyeClaimed bool                      // the owner has taken responsibility to emit it
 }
 
 // Manager manages per-interface RA sender goroutines.
@@ -275,7 +275,7 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	// replace — tombstone + stop old, defer the start), or already-draining /
 	// new (deferred or started directly).
 	var firstErr error
-	var deferred []*config.RAInterfaceConfig // already-draining when we held the lock
+	var deferred []*config.RAInterfaceConfig  // already-draining when we held the lock
 	var toRestart []*config.RAInterfaceConfig // changed config: old stopped, start after join
 	for name, cfg := range desired {
 		existing, ok := m.senders[name]
@@ -492,6 +492,7 @@ func (m *Manager) WithdrawInterfaces(names []string) {
 //     owner's release path (releaseDrain / Apply restart) emits the standalone
 //     if owed — claim-once via goodbyeClaimed guarantees no double-send even if
 //     several Withdraws flip the same entry.
+//
 // Callers must hold m.mu.
 func (m *Manager) claimGracefulLocked(names []string) []ownedDrain {
 	var owned []ownedDrain
@@ -714,7 +715,7 @@ func (m *Manager) Status() []SenderInfo {
 	for _, s := range m.senders {
 		info := SenderInfo{
 			Interface:   s.cfg.Interface,
-			SrcAddr:     s.srcAddr.String(),
+			SrcAddr:     s.getSrcAddr().String(),
 			Lifetime:    s.cfg.DefaultLifetime,
 			MaxInterval: s.cfg.MaxAdvInterval,
 			MinInterval: s.cfg.MinAdvInterval,

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -108,9 +108,16 @@ var ensureLinkLocalFn = ensureLinkLocal
 // lifetime-0 goodbye as its FINAL action in finishShutdown — guaranteeing no
 // lifetime>0 RA follows the goodbye on the wire.
 type sender struct {
-	cfg     *config.RAInterfaceConfig
-	iface   *net.Interface
-	conn    ndpConn
+	cfg   *config.RAInterfaceConfig
+	iface *net.Interface
+	conn  ndpConn
+
+	// srcAddr is the bound link-local source address. Since openConn now runs
+	// in the owner goroutine (#2453), the owner WRITES srcAddr without m.mu
+	// while Manager.Status READS it under m.mu — so it must carry its own
+	// guard. srcMu is that guard; use getSrcAddr/setSrcAddr, never the field
+	// directly off-goroutine.
+	srcMu   sync.Mutex
 	srcAddr netip.Addr
 
 	mode     atomic.Int32 // shutdownMode; set BEFORE close(stopCh)
@@ -142,20 +149,60 @@ func newSender(cfg *config.RAInterfaceConfig, iface *net.Interface) *sender {
 	}
 }
 
-// start opens the NDP connection and launches the sender goroutine.
-// Ensures a link-local address exists (RETH interfaces suppress auto
-// link-local via addr_gen_mode=1, so we add one explicitly with NODAD).
+// start launches the sender goroutine. It does NOT open the NDP connection
+// itself — the socket open (ensureLinkLocal + the link-local bind RETRY, which
+// sleeps up to ~2s while a settling/RETH link-local appears) is performed by
+// the owner goroutine in openConn() BEFORE it enters its main loop (#2453).
+//
+// Why the open moved off this path: start() is called from
+// Manager.startLocked while the manager mutex m.mu is held. Doing the
+// multi-second bind retry under m.mu serialized every other RA manager op
+// (a VRRP-failover Withdraw, or an Apply on a DIFFERENT interface) behind the
+// retry — control-plane latency up to ~2s. Launching the goroutine and
+// returning immediately keeps the m.mu critical section to just the
+// s.senders bookkeeping; the bind retry runs fully UNLOCKED.
+//
+// start() therefore never returns a listen/bind error (the open is async); the
+// only error it can return is a programming-level one, and there are none here.
+// A bind that ultimately fails is logged by openConn and the owner exits
+// cleanly (closing s.stopped) so the manager's join/release path still
+// completes. s.conn is opened, used, and closed solely by the owner goroutine,
+// preserving the single-owner contract (#2033).
 func (s *sender) start() error {
+	go s.run()
+	return nil
+}
+
+// openConn performs the (potentially slow) NDP socket open for the owner
+// goroutine: ensure a link-local exists, then bind with the bounded retry. It
+// is INTERRUPTIBLE by stopCh — a withdraw/clear signalled while the bind is
+// still retrying aborts promptly instead of blocking up to ~2s. It returns
+// false if no connection was opened (bind failed after all retries, or a stop
+// was signalled mid-retry); in that case the owner must go straight to
+// finishShutdown without a live conn.
+//
+// On success s.conn / s.srcAddr are set (owner-only writes), the all-routers
+// group is joined, and the RS-only ICMPv6 filter is installed.
+func (s *sender) openConn() bool {
+	// A stop signalled before we even begin: do not open a conn.
+	select {
+	case <-s.stopCh:
+		return false
+	default:
+	}
+
 	if err := ensureLinkLocalFn(s.iface); err != nil {
 		slog.Warn("ra: failed to ensure link-local", "interface", s.iface.Name, "err", err)
 	}
 
 	conn, srcAddr, err := s.listen()
 	if err != nil {
-		return err
+		slog.Warn("ra: failed to open NDP connection (giving up after retries)",
+			"interface", s.cfg.Interface, "err", err)
+		return false
 	}
 	s.conn = conn
-	s.srcAddr = srcAddr
+	s.setSrcAddr(srcAddr)
 
 	// Join all-routers multicast to receive Router Solicitations.
 	allRouters := netip.MustParseAddr("ff02::2")
@@ -171,9 +218,7 @@ func (s *sender) start() error {
 		slog.Warn("ra: failed to set ICMPv6 filter",
 			"interface", s.cfg.Interface, "err", err)
 	}
-
-	go s.run()
-	return nil
+	return true
 }
 
 // sendGoodbyeStandalone is the WithdrawOnce goodbye-only entry point. It opens
@@ -190,10 +235,24 @@ func (s *sender) sendGoodbyeStandalone() error {
 		return err
 	}
 	s.conn = conn
-	s.srcAddr = srcAddr
+	s.setSrcAddr(srcAddr)
 	defer s.conn.Close()
 	s.sendGoodbyeRA()
 	return nil
+}
+
+// getSrcAddr / setSrcAddr guard the bound source address against the
+// owner-writes / Status-reads race (#2453). See the srcMu field comment.
+func (s *sender) getSrcAddr() netip.Addr {
+	s.srcMu.Lock()
+	defer s.srcMu.Unlock()
+	return s.srcAddr
+}
+
+func (s *sender) setSrcAddr(a netip.Addr) {
+	s.srcMu.Lock()
+	s.srcAddr = a
+	s.srcMu.Unlock()
 }
 
 // listen opens the NDP connection with the configured bind address, retrying
@@ -212,8 +271,19 @@ func (s *sender) listen() (ndpConn, netip.Addr, error) {
 		if err == nil {
 			return conn, srcAddr, nil
 		}
-		// Re-read interface (link-local may appear after addr add).
-		time.Sleep(200 * time.Millisecond)
+		// Re-read interface (link-local may appear after addr add). The sleep is
+		// interruptible by stopCh (#2453): a withdraw/clear signalled while the
+		// bind is still retrying aborts the retry promptly rather than running
+		// the full ~2s. Since this loop now runs in the owner goroutine
+		// (unlocked), the abort frees nothing held by the manager — it just lets
+		// the owner reach finishShutdown sooner.
+		t := time.NewTimer(200 * time.Millisecond)
+		select {
+		case <-s.stopCh:
+			t.Stop()
+			return nil, netip.Addr{}, err
+		case <-t.C:
+		}
 		if iface, e := net.InterfaceByName(s.iface.Name); e == nil {
 			s.iface = iface
 		}
@@ -278,6 +348,25 @@ func (s *sender) draining() bool { return s.mode.Load() != int32(modeNone) }
 // closes the connection.
 func (s *sender) run() {
 	defer close(s.stopped)
+
+	// Open the NDP conn (ensureLinkLocal + the bounded, interruptible bind
+	// retry) HERE, in the owner goroutine, not under the manager mutex (#2453).
+	// If it fails (bind gave up, or a stop was signalled mid-retry) there is no
+	// conn to emit on: go straight to finishShutdown, which tolerates a nil conn
+	// (no goodbye is written, goodbyeEmitted stays false → the manager's
+	// release-time backstop emits a standalone goodbye if one was owed).
+	if !s.openConn() {
+		s.finishShutdown()
+		return
+	}
+
+	// A stop may have been signalled while the conn was opening. Honor it before
+	// emitting the startup burst (burstInterruptible also short-circuits, but
+	// this avoids even the first burst RA after a withdraw).
+	if s.draining() {
+		s.finishShutdown()
+		return
+	}
 
 	// Interruptible startup burst so a withdraw during startup cannot leave a
 	// normal RA after the goodbye.
@@ -346,6 +435,15 @@ func (s *sender) run() {
 // graceful upgrade that landed before the owner woke. The conn is closed AFTER
 // the goodbye, which also unblocks the detached rsReceiver's ReadFrom (I10).
 func (s *sender) finishShutdown() {
+	// No conn was ever opened (openConn failed or a stop landed mid bind-retry).
+	// There is nothing to emit on and nothing to close. Leave goodbyeEmitted=
+	// false so the manager's release-time backstop (sendOneGoodbye on a FRESH
+	// conn) still emits a standalone goodbye if a graceful withdraw owed one
+	// (#2453). This mirrors the conn==nil tail below; we return early so the
+	// graceful branch never dereferences a nil conn.
+	if s.conn == nil {
+		return
+	}
 	if shutdownMode(s.mode.Load()) == modeGraceful {
 		// Record the fact for the manager's post-join owes-a-goodbye check, but
 		// ONLY if the goodbye actually went out. On a write failure (interface

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -198,7 +198,7 @@ func (errClosed) Timeout() bool { return false }
 // testCfg returns a minimal RA config for an interface.
 func testCfg(iface string) *config.RAInterfaceConfig {
 	return &config.RAInterfaceConfig{
-		Interface:      iface,
+		Interface:       iface,
 		DefaultLifetime: 1800,
 		MaxAdvInterval:  600,
 		MinAdvInterval:  200,
@@ -211,8 +211,8 @@ func testCfg(iface string) *config.RAInterfaceConfig {
 // fakeListen is the test harness wiring listenFn + ensureLinkLocalFn to fakes.
 type fakeListen struct {
 	mu       sync.Mutex
-	conns    map[string]*fakeConn   // most-recent conn per interface
-	allConns map[string][]*fakeConn // EVERY conn ever opened per interface
+	conns    map[string]*fakeConn           // most-recent conn per interface
+	allConns map[string][]*fakeConn         // EVERY conn ever opened per interface
 	prehooks map[string]func(time.Duration) // installed at conn-creation time
 	live     int32
 	liveMu   sync.Mutex
@@ -857,8 +857,8 @@ func TestT7_GracefulUpgradesHard(t *testing.T) {
 		assertGoodbyeIsLast(t, fc.snapshot())
 	}
 
-	run("t7a", modeHard, modeGraceful)     // hard then graceful -> graceful wins
-	run("t7b", modeGraceful, modeHard)     // graceful then hard -> no downgrade
+	run("t7a", modeHard, modeGraceful) // hard then graceful -> graceful wins
+	run("t7b", modeGraceful, modeHard) // graceful then hard -> no downgrade
 }
 
 // T9 — startup burst preserved: a fresh start records exactly
@@ -1197,7 +1197,7 @@ func TestT7c_WithdrawAfterDeadHardSenderEmitsStandaloneGoodbye(t *testing.T) {
 
 	total, conns := fl.goodbyeStats("lo")
 	if conns == 0 {
-		t.Fatalf("no goodbye emitted for the withdrawn interface; a dead hard "+
+		t.Fatalf("no goodbye emitted for the withdrawn interface; a dead hard " +
 			"sender must get a STANDALONE goodbye (#2033 MAJOR 2 dead-sender)")
 	}
 	if conns != 1 || total != goodbyeCount {
@@ -1285,7 +1285,7 @@ func TestT2b_WithdrawDuringRestartWindowEmitsGoodbye(t *testing.T) {
 	// (the restart was aborted).
 	total, conns := fl.goodbyeStats("lo")
 	if conns == 0 {
-		t.Fatalf("no goodbye emitted for the interface withdrawn during the "+
+		t.Fatalf("no goodbye emitted for the interface withdrawn during the " +
 			"restart window (#2033 NEW MAJOR)")
 	}
 	if conns != 1 || total != goodbyeCount {
@@ -1296,7 +1296,7 @@ func TestT2b_WithdrawDuringRestartWindowEmitsGoodbye(t *testing.T) {
 	_, live := m.senders["lo"]
 	m.mu.Unlock()
 	if live {
-		t.Fatal("a replacement sender was started despite the graceful Withdraw "+
+		t.Fatal("a replacement sender was started despite the graceful Withdraw " +
 			"aborting the restart")
 	}
 }
@@ -1515,7 +1515,7 @@ func TestRace3_ApplyDuringStandaloneEmitDefersNoClobber(t *testing.T) {
 		_, live := m.senders["lo"]
 		m.mu.Unlock()
 		if live {
-			t.Fatal("Apply started a live sender DURING the standalone emit "+
+			t.Fatal("Apply started a live sender DURING the standalone emit " +
 				"(clobber; tombstone did not block it) — #2033 race 3")
 		}
 		if lc := fl.liveCount(); lc > 1 {
@@ -1615,7 +1615,7 @@ func TestRace2_TimeoutDoesNotEmitWhileOwnerCouldBeLive(t *testing.T) {
 	_, stillDraining := m.draining["lo"]
 	m.mu.Unlock()
 	if !stillDraining {
-		t.Fatal("releaseDrain removed the tombstone after a timeout; it must be "+
+		t.Fatal("releaseDrain removed the tombstone after a timeout; it must be " +
 			"LEFT HELD (owner may still hold a live conn) — #2033 round-4")
 	}
 
@@ -1712,7 +1712,7 @@ func TestRestartTimeoutNoGoodbyeNoReplacement(t *testing.T) {
 	_, live := m.senders["lo"]
 	m.mu.Unlock()
 	if live {
-		t.Fatal("restart timeout started a replacement sender while the old conn "+
+		t.Fatal("restart timeout started a replacement sender while the old conn " +
 			"may be live — #2033 round-4 MAJOR 2 (≤1-conn)")
 	}
 	if lc := fl.liveCount(); lc > 1 {
@@ -1898,8 +1898,8 @@ func TestRound5_WithdrawDuringRestartDecisionNoReplacementGoodbyeEmitted(t *test
 	// the never-start-after-supersede property, which holds on every interleave.)
 	_ = startCalled
 	if startedDespiteSupersede {
-		t.Fatal("replacement started despite a newer Withdraw superseding the "+
-			"restart at the act moment — stale cached decision across the unlock "+
+		t.Fatal("replacement started despite a newer Withdraw superseding the " +
+			"restart at the act moment — stale cached decision across the unlock " +
 			"— #2033 round-5")
 	}
 }
@@ -2142,12 +2142,264 @@ func TestRound5_ClearDuringRestartDecisionNoReplacement(t *testing.T) {
 	_ = startCalled
 	_ = cfg
 	if startedDespiteSupersede {
-		t.Fatal("restart started a replacement after a newer Clear advanced the "+
+		t.Fatal("restart started a replacement after a newer Clear advanced the " +
 			"epoch at the act moment (stale cached decision) — #2033 round-5")
 	}
 	total, conns := fl.goodbyeStats("lo")
 	if conns != 0 || total != 0 {
 		t.Fatalf("a Clear/restart race emitted a goodbye (%d conns / %d writes); "+
 			"expected 0", conns, total)
+	}
+}
+
+// installGatedListen wires listenFn + ensureLinkLocalFn so that a bind for the
+// named "slow" interface BLOCKS until release is closed (simulating the
+// link-local-settling bind retry that runs up to ~2s), while every other
+// interface binds instantly. It returns release (close to unblock the slow
+// bind) and a getConn accessor. It restores the originals on cleanup.
+//
+// This is the #2453 seam: with the fix the slow bind happens in the sender's
+// OWN goroutine (no m.mu held), so a concurrent manager op on a DIFFERENT
+// interface is unaffected. With the bug (bind under m.mu in startLocked) the
+// slow bind stalls every other manager op.
+func installGatedListen(t *testing.T, slow string) (release func(), liveCount func() int32) {
+	t.Helper()
+	origListen := listenFn
+	origEnsure := ensureLinkLocalFn
+
+	gate := make(chan struct{})
+	var once sync.Once
+	var live int32
+	var liveMu sync.Mutex
+
+	ensureLinkLocalFn = func(*net.Interface) error { return nil }
+	listenFn = func(iface *net.Interface, _ ndp.Addr) (ndpConn, netip.Addr, error) {
+		if iface.Name == slow {
+			<-gate // block the slow interface's bind until released
+		}
+		fc := newFakeConn()
+		fc.liveCounter = &live
+		fc.liveMu = &liveMu
+		liveMu.Lock()
+		live++
+		liveMu.Unlock()
+		return fc, netip.MustParseAddr("fe80::1"), nil
+	}
+
+	release = func() { once.Do(func() { close(gate) }) }
+	liveCount = func() int32 {
+		liveMu.Lock()
+		defer liveMu.Unlock()
+		return live
+	}
+
+	t.Cleanup(func() {
+		// Unblock any owner still parked in the gate, then wait for every conn
+		// opened through this listenFn to be closed by its owner goroutine BEFORE
+		// restoring the package globals. Restoring listenFn while a leaked owner
+		// is still reading/calling it is the data race the race detector flags;
+		// joining on liveCount==0 closes that window deterministically.
+		release()
+		for i := 0; i < 500; i++ {
+			if liveCount() == 0 {
+				break
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+		listenFn = origListen
+		ensureLinkLocalFn = origEnsure
+	})
+	return release, liveCount
+}
+
+// TestT2453_SlowBindDoesNotStallOtherManagerOps is the #2453 fail-on-revert
+// concurrency proof: a sender whose bind is slow (stuck in the listen retry)
+// MUST NOT hold the manager mutex m.mu, so concurrent manager operations that
+// only need m.mu briefly complete promptly instead of waiting for the bind.
+//
+// The probes are operations that take m.mu and return WITHOUT joining the
+// gated sender (so they isolate "is m.mu held across the bind?" from "does a
+// same-interface withdraw legitimately wait for the owner to exit?"):
+//   - WithdrawInterfaces(["ge-0-0-9"]) — a DIFFERENT interface (the motivating
+//     VRRP-failover-on-another-RG case): finds no sender/tombstone, takes
+//     m.mu, does nothing, returns. With the bug it blocks on m.mu.Lock()
+//     behind startLocked's in-flight listen().
+//   - Status() — takes m.mu, reads, returns.
+//
+// Fail-on-revert: restore the conn-open to run synchronously under m.mu in
+// startLocked (the pre-#2453 behavior) and BOTH probes block on m.mu.Lock()
+// until the gated bind releases, so the assertions below time out and the test
+// FAILS.
+func TestT2453_SlowBindDoesNotStallOtherManagerOps(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	release, liveCount := installGatedListen(t, "lo")
+
+	m := New()
+
+	// Apply on "lo" starts a sender whose bind is GATED (blocks in listen). With
+	// the fix Apply itself returns promptly (the bind runs in the owner
+	// goroutine, NOT under m.mu); run it in the background so the gated bind is
+	// in flight while we contend the lock.
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}) }()
+
+	// Give the gated bind a moment to be in flight (the owner goroutine is parked
+	// in listenFn on <-gate).
+	time.Sleep(50 * time.Millisecond)
+
+	// Probe: concurrent manager ops on a DIFFERENT interface + a Status read.
+	// They must NOT be serialized behind the in-flight bind on "lo". With the
+	// bug they block on m.mu.Lock() until release.
+	probeDone := make(chan struct{}, 1)
+	start := time.Now()
+	go func() {
+		m.WithdrawInterfaces([]string{"ge-0-0-9"})
+		_ = m.Status()
+		probeDone <- struct{}{}
+	}()
+
+	select {
+	case <-probeDone:
+		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Fatalf("concurrent manager ops took %v while another interface's "+
+				"bind was in flight — m.mu was held across the bind retry (#2453)", elapsed)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("concurrent manager ops blocked >500ms behind an in-flight bind " +
+			"on another interface — startLocked is holding m.mu across listen() (#2453)")
+	}
+
+	// Apply (startLocked) itself must also have returned promptly under the fix.
+	select {
+	case <-applyDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Apply blocked behind the in-flight bind — startLocked held " +
+			"m.mu across listen() (#2453)")
+	}
+
+	// Release the gated bind and drain to a known state so the gated owner
+	// goroutine exits before cleanup (cleanup also joins on liveCount==0).
+	release()
+	_ = m.Clear()
+	for i := 0; i < 500; i++ {
+		if liveCount() == 0 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestT2453_NormalStartStillBindsAndSends is the no-regression companion: with
+// the conn-open moved into the owner goroutine, a normal start must still open
+// the conn and emit its startup burst (proving the async open is wired and the
+// owner reaches its send loop).
+func TestT2453_NormalStartStillBindsAndSends(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	getConn, liveCount := installFakeListen(t)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	fc := waitConn(t, getConn, "lo")
+	// Startup burst is startupBurstCount normal (lifetime>0) RAs.
+	waitWrites(t, fc, startupBurstCount)
+	for _, w := range fc.snapshot() {
+		if w.lifetime == 0 {
+			t.Fatalf("normal start emitted a lifetime-0 (goodbye) RA in its burst")
+		}
+	}
+	if lc := liveCount(); lc != 1 {
+		t.Fatalf("expected exactly 1 live conn after a normal start, got %d", lc)
+	}
+
+	// Clean teardown leaves no live conns.
+	if err := m.Withdraw(); err != nil {
+		t.Fatalf("Withdraw: %v", err)
+	}
+	if lc := liveCount(); lc != 0 {
+		t.Fatalf("leaked %d live conns after Withdraw", lc)
+	}
+}
+
+// TestT2453_WithdrawDuringSlowBindEmitsGoodbye proves the conn==nil safety in
+// finishShutdown: if a graceful Withdraw arrives while the bind is still
+// retrying (so the owner never opens a conn), the manager's release-time
+// backstop still emits exactly one standalone goodbye on a FRESH conn — the
+// route is withdrawn, not silently dropped, and the owner never dereferences a
+// nil conn (which would panic).
+func TestT2453_WithdrawDuringSlowBindEmitsGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+
+	origListen := listenFn
+	origEnsure := ensureLinkLocalFn
+	t.Cleanup(func() { listenFn = origListen; ensureLinkLocalFn = origEnsure })
+
+	var mu sync.Mutex
+	allConns := map[string][]*fakeConn{}
+	// The owner's bind never succeeds while gate is open; the standalone backstop
+	// (sendOneGoodbye -> sender.listen) is allowed through once standalone=true.
+	gate := make(chan struct{})
+	var standalone atomic.Bool
+
+	ensureLinkLocalFn = func(*net.Interface) error { return nil }
+	listenFn = func(iface *net.Interface, _ ndp.Addr) (ndpConn, netip.Addr, error) {
+		if !standalone.Load() {
+			// Owner's bind: block until the test releases (then it returns an
+			// error so the owner gives up without a conn).
+			<-gate
+			return nil, netip.Addr{}, errors.New("bind aborted")
+		}
+		fc := newFakeConn()
+		mu.Lock()
+		allConns[iface.Name] = append(allConns[iface.Name], fc)
+		mu.Unlock()
+		return fc, netip.MustParseAddr("fe80::1"), nil
+	}
+
+	m := New()
+	applyDone := make(chan error, 1)
+	go func() { applyDone <- m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}) }()
+	time.Sleep(50 * time.Millisecond) // let the owner park in the gated bind
+
+	// Graceful Withdraw while the bind is still in flight: flips goodbyeWanted,
+	// signals stop (the owner's listen retry aborts via stopCh), then the release
+	// path joins the dead owner (goodbyeEmitted=false, no conn) and emits a
+	// standalone goodbye on a fresh conn.
+	standalone.Store(true) // allow the backstop's fresh-conn bind to succeed
+	close(gate)            // unblock the owner's bind so it gives up promptly
+
+	if err := m.Withdraw(); err != nil {
+		t.Fatalf("Withdraw: %v", err)
+	}
+	<-applyDone
+
+	mu.Lock()
+	conns := append([]*fakeConn(nil), allConns["lo"]...)
+	mu.Unlock()
+	total, connsWithGoodbye := 0, 0
+	for _, c := range conns {
+		n := 0
+		for _, w := range c.snapshot() {
+			if w.lifetime == 0 {
+				n++
+			}
+		}
+		if n > 0 {
+			connsWithGoodbye++
+			total += n
+		}
+	}
+	if connsWithGoodbye != 1 || total != goodbyeCount {
+		t.Fatalf("expected exactly one standalone goodbye (1 conn, %d writes) for "+
+			"a withdraw during a slow bind; got %d conns, %d writes",
+			goodbyeCount, connsWithGoodbye, total)
 	}
 }


### PR DESCRIPTION
Closes #2453

## Problem
`Manager.startLocked` ran the RA sender's socket-open path while holding the manager mutex `m.mu`. `sender.start()` opened the NDP connection synchronously: `ensureLinkLocal` + `listen()`'s 10x200ms (~2s) bind retry while a settling/RETH link-local settles. Because `startLocked` is always invoked under `m.mu` (`ra.go:308/334/382`), the whole multi-second retry ran under the lock — so any concurrent RA manager op (a VRRP-failover `Withdraw`, or an `Apply` on a DIFFERENT interface) stalled up to ~2s on `m.mu.Lock()`. MEDIUM, HA-adjacent (the failover withdraw path is exactly the motivating case).

## Fix (approach b: open in the owner goroutine)
`start()` now just launches `run()` and returns, so `startLocked` holds `m.mu` only for the cheap `InterfaceByName` check + the `m.senders` bookkeeping. The socket open moved into a new `openConn()` run by the owner goroutine BEFORE its main loop, with **no lock held**. The bind-retry sleep is now interruptible by `stopCh` (a mid-retry withdraw aborts promptly instead of running the full ~2s).

### Re-lock / cancel race-safety (the #2033 single-owner + ≤1-live-conn invariants hold)
- `s.conn` is still opened, used, and closed **solely by the owner goroutine** — single-owner contract unchanged.
- **Cancel during bind:** if the bind ultimately fails, or a stop lands before/during the retry, `openConn` returns false and `run` goes straight to `finishShutdown`, which now tolerates a **nil conn**: no goodbye is written, `goodbyeEmitted` stays false → the manager's release-time backstop (`sendOneGoodbye` on a FRESH conn) still emits a standalone goodbye if a graceful withdraw owed one. The owner never dereferences a nil conn.
- **No double-start / no torn map:** `startLocked` still mutates `m.senders` under `m.mu`; a same-interface withdraw goes through the existing tombstone/`releaseDrain` discipline and joins the owner via `<-s.stopped` (the join legitimately waits for the owner, but it does NOT hold `m.mu`, so other interfaces are unaffected).
- `start()` no longer returns a listen error (open is async); every `Apply` call site already only `slog.Warn`'d it.
- `srcAddr` is now owner-written / `Status`-read, so it got its own `srcMu` guard (`getSrcAddr`/`setSrcAddr`).

## Tests (race detector ON — this is a concurrency fix)
- **`TestT2453_SlowBindDoesNotStallOtherManagerOps`** — fail-on-revert concurrency proof. A gated bind on one interface must not stall `WithdrawInterfaces` on a DIFFERENT interface + `Status`. **Verified RED** when `start()` is reverted to the synchronous open under `m.mu` (the probe times out at >500ms).
- **`TestT2453_NormalStartStillBindsAndSends`** — no-regression: a normal start still binds and emits its startup burst, exactly one live conn.
- **`TestT2453_WithdrawDuringSlowBindEmitsGoodbye`** — conn==nil safety: a graceful withdraw arriving while the bind is still retrying still yields exactly one standalone goodbye via the backstop (no panic, route not silently dropped).

## Gates
- `gofmt` clean; `go build ./...` clean; `go vet ./pkg/ra/...` clean
- `go test -race ./pkg/ra/...` green (race ON)
- `go test ./pkg/daemon/... ./pkg/cluster/...` green
- README (`pkg/ra/README.md`) updated — the stale "known cost, left as-is" note is now resolved; `_Log.md` updated.

## Note for reviewers
HA-adjacent (RA Withdraw fires on VRRP failover). Recommend running `make test-failover` on the loss userspace cluster for no-regression before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi