### PR TITLE
userspace-dp: fix three coupled Rust FIB route-snapshot defects (#2388/#2389/#2390)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14674,3 +14674,47 @@ top.
   **File(s)**: pkg/config/compiler_routing.go,
   pkg/config/compiler_prefix_list_merge_2641_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25T00:00Z
+  **Action**: #2388/#2389/#2390 — three coupled Rust FIB route-snapshot
+  correctness fixes (one PR). (#2388) connected routes are now table-scoped
+  in the Rust FIB: each ConnectedRouteV4/V6 carries its routing-table name
+  (derived from the new InterfaceSnapshot.routing_instance wire field), and
+  the lookup filters connected candidates by the resolving table — no more
+  cross-VRF connected-route leak. (#2389) ECMP static routes retain ALL
+  next-hops (RouteEntry.next_hops: Vec<RouteNextHop>); select_route_next_hop
+  prefers a candidate with a resolved neighbor (dead-first-NH no longer
+  blackholes) then distributes by a fixed-seed dst-IP hash; neighbor-warm
+  loop warms every NH. Per-flow (5-tuple) ECMP spread deferred — flow hash
+  not plumbed into the resolution layer. (#2390) StaticRoute.Preference is
+  serialized (RouteSnapshot.preference wire field) and used as the secondary
+  sort key (prefix-len desc, then preference asc) so same-prefix routes
+  tie-break by operator preference, not insertion order. Wire: added
+  routing_instance (InterfaceSnapshot) + preference (RouteSnapshot) — both
+  additive/serde-default both sides; regenerated protocol_wire_v1.json.
+  Tests: 3 fail-on-revert Rust tests (forwarding/tests.rs) + 3 Go tests
+  (routes_fib_metadata_test.go), all verified RED on revert.
+  Gates: cargo build --release clean; cargo test --release green
+  (2781 passed; the lone intermittent worker_queue concurrency test is a
+  pre-existing flake, passes in isolation); go build ./... + go vet +
+  gofmt clean; go test ./pkg/dataplane/userspace/... green.
+  **File(s)**: pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/routes.go,
+  pkg/dataplane/userspace/interfaces.go,
+  pkg/dataplane/userspace/routes_fib_metadata_test.go,
+  userspace-dp/src/protocol/snapshot.rs,
+  userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding_build/fib.rs,
+  userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/forwarding_build/mod.rs,
+  userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  userspace-dp/src/afxdp/coordinator/mod.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs,
+  userspace-dp/src/afxdp/ha_tests.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  userspace-dp/src/afxdp/test_fixtures.rs, userspace-dp/src/afxdp/tests.rs,
+  userspace-dp/src/afxdp/frame/wg.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json, _Log.md

--- a/pkg/dataplane/userspace/interfaces.go
+++ b/pkg/dataplane/userspace/interfaces.go
@@ -131,6 +131,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 		return nil
 	}
 	zoneByInterface := buildInterfaceZoneMap(cfg)
+	ifaceRoutingInstance := buildInterfaceRoutingInstances(cfg)
 	usedSyntheticIfindexes := make(map[int]struct{})
 	// Build RETH RG lookup: physical member → RETH's RedundancyGroup.
 	// Physical members have RedundantParent set but RedundancyGroup=0;
@@ -166,6 +167,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 		out = append(out, InterfaceSnapshot{
 			Name:            name,
 			Zone:            zoneByInterface[name],
+			RoutingInstance: ifaceRoutingInstance[name],
 			LinuxName:       linuxName,
 			ParentLinuxName: "",
 			Ifindex:         ifindex,
@@ -228,6 +230,7 @@ func buildInterfaceSnapshots(cfg *config.Config) []InterfaceSnapshot {
 			out = append(out, InterfaceSnapshot{
 				Name:                      unitName,
 				Zone:                      zoneByInterface[unitName],
+				RoutingInstance:           ifaceRoutingInstance[unitName],
 				LinuxName:                 linuxUnit,
 				ParentLinuxName:           parentLinux,
 				Ifindex:                   ifindex,

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -163,8 +163,17 @@ type ZoneSnapshot struct {
 }
 
 type InterfaceSnapshot struct {
-	Name                      string                     `json:"name"`
-	Zone                      string                     `json:"zone,omitempty"`
+	Name string `json:"name"`
+	Zone string `json:"zone,omitempty"`
+	// RoutingInstance is the bare routing-instance name this interface
+	// belongs to ("" = the default instance). The Rust dataplane derives
+	// the connected-route table (<ri>.inet.0 / <ri>.inet6.0, or
+	// inet.0/inet6.0 for the default instance) from it so connected routes
+	// rebuilt from interface addresses are table-scoped and do not leak
+	// across VRF boundaries (#2388). Additive: an old Rust helper that does
+	// not know the field treats every interface as the default instance
+	// (the pre-#2388 global behavior); an old Go binary omits it.
+	RoutingInstance           string                     `json:"routing_instance,omitempty"`
 	LinuxName                 string                     `json:"linux_name,omitempty"`
 	ParentLinuxName           string                     `json:"parent_linux_name,omitempty"`
 	Ifindex                   int                        `json:"ifindex,omitempty"`
@@ -705,6 +714,17 @@ type RouteSnapshot struct {
 	NextHops    []string `json:"next_hops,omitempty"`
 	Discard     bool     `json:"discard"`
 	NextTable   string   `json:"next_table,omitempty"`
+	// Preference is the Junos route preference (administrative distance;
+	// lower = more preferred, default 5). The Rust FIB tie-breaks two
+	// same-prefix routes in a table by preference BEFORE insertion order
+	// (#2390); without it, two competing same-prefix statics selected by
+	// insertion order, ignoring operator intent. Additive: an old Rust
+	// helper ignores it (insertion-order tie-break, the pre-#2390 behavior)
+	// and an old Go binary omits it (Rust sees 0, the most-preferred value,
+	// which for the common single-route-per-prefix case is a no-op). 0 is a
+	// legitimate value (it deserializes back to 0 under serde default), so
+	// omitempty only suppresses the wire byte for an explicit preference 0.
+	Preference int `json:"preference,omitempty"`
 }
 
 type NeighborSnapshot struct {

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -42,6 +42,7 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 				Destination: route.Destination,
 				Discard:     route.Discard,
 				NextTable:   route.NextTable,
+				Preference:  route.Preference,
 			}
 			for _, nh := range route.NextHops {
 				switch {
@@ -234,6 +235,33 @@ func buildInterfaceRouteTables(cfg *config.Config) (map[string]string, map[strin
 		}
 	}
 	return v4, v6
+}
+
+// buildInterfaceRoutingInstances maps each interface (config name, e.g.
+// "ge-0-0-1.80") to the routing-instance it belongs to. The default
+// instance is the empty string. This mirrors buildInterfaceRouteTables'
+// membership lookup, but carries the bare instance NAME so the Rust
+// dataplane can scope its rebuilt-from-interface connected routes to the
+// owning routing table (#2388): without it, the Rust connected store is
+// global and a per-table (VRF / next-table) FIB lookup can match a
+// connected prefix owned by a different routing-instance.
+func buildInterfaceRoutingInstances(cfg *config.Config) map[string]string {
+	out := make(map[string]string)
+	if cfg == nil {
+		return out
+	}
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil || ri.Name == "" {
+			continue
+		}
+		for _, ifname := range ri.Interfaces {
+			if ifname == "" {
+				continue
+			}
+			out[ifname] = ri.Name
+		}
+	}
+	return out
 }
 
 func connectedPrefixesForInterface(iface InterfaceSnapshot) ([]string, []string) {

--- a/pkg/dataplane/userspace/routes_fib_metadata_test.go
+++ b/pkg/dataplane/userspace/routes_fib_metadata_test.go
@@ -1,0 +1,90 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestRouteSnapshotCarriesPreference verifies #2390: StaticRoute.Preference
+// is serialized into the RouteSnapshot so the Rust FIB can tie-break
+// same-prefix routes by preference instead of insertion order. Before the
+// fix the field was dropped at this boundary.
+func TestRouteSnapshotCarriesPreference(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "203.0.113.0/24", Preference: 50, NextHops: []config.NextHopEntry{{Address: "172.16.50.1"}}},
+		{Destination: "198.51.100.0/24", Preference: 5, NextHops: []config.NextHopEntry{{Address: "172.16.50.2"}}},
+	}
+	routes := buildRouteSnapshots(cfg, nil, nil)
+
+	got := map[string]int{}
+	for _, r := range routes {
+		got[r.Destination] = r.Preference
+	}
+	if got["203.0.113.0/24"] != 50 {
+		t.Fatalf("preference 50 dropped: route 203.0.113.0/24 has preference %d", got["203.0.113.0/24"])
+	}
+	if got["198.51.100.0/24"] != 5 {
+		t.Fatalf("preference 5 dropped: route 198.51.100.0/24 has preference %d", got["198.51.100.0/24"])
+	}
+}
+
+// TestRouteSnapshotRetainsAllECMPNextHops verifies #2389: an ECMP static
+// route with multiple next-hops serializes EVERY next-hop (the Rust FIB
+// retains and distributes across them). The Go side always emitted all
+// next-hops; this pins that contract so a future refactor cannot collapse
+// the slice and silently disable multipath downstream.
+func TestRouteSnapshotRetainsAllECMPNextHops(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "203.0.113.0/24", NextHops: []config.NextHopEntry{
+			{Address: "172.16.50.1"},
+			{Address: "172.16.50.2", Interface: "ge-0/0/2"},
+		}},
+	}
+	routes := buildRouteSnapshots(cfg, nil, nil)
+
+	var found *RouteSnapshot
+	for i := range routes {
+		if routes[i].Destination == "203.0.113.0/24" {
+			found = &routes[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("ECMP route not in snapshot")
+	}
+	if len(found.NextHops) != 2 {
+		t.Fatalf("ECMP next-hops collapsed: got %d want 2 (%v)", len(found.NextHops), found.NextHops)
+	}
+	if found.NextHops[0] != "172.16.50.1" || found.NextHops[1] != "172.16.50.2@ge-0/0/2" {
+		t.Fatalf("ECMP next-hop encoding wrong: %v", found.NextHops)
+	}
+}
+
+// TestBuildInterfaceRoutingInstances verifies #2388: each interface is
+// mapped to the bare routing-instance it belongs to, so the InterfaceSnapshot
+// carries the data the Rust dataplane needs to table-scope connected routes.
+func TestBuildInterfaceRoutingInstances(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "tenant-a", Interfaces: []string{"ge-0/0/1.80"}},
+		{Name: "tenant-b", Interfaces: []string{"ge-0/0/1.90", "ge-0/0/3"}},
+	}
+	m := buildInterfaceRoutingInstances(cfg)
+
+	if m["ge-0/0/1.80"] != "tenant-a" {
+		t.Fatalf("ge-0/0/1.80 routing-instance = %q, want tenant-a", m["ge-0/0/1.80"])
+	}
+	if m["ge-0/0/1.90"] != "tenant-b" {
+		t.Fatalf("ge-0/0/1.90 routing-instance = %q, want tenant-b", m["ge-0/0/1.90"])
+	}
+	if m["ge-0/0/3"] != "tenant-b" {
+		t.Fatalf("ge-0/0/3 routing-instance = %q, want tenant-b", m["ge-0/0/3"])
+	}
+	// An interface not in any routing-instance is the default ("").
+	if _, ok := m["fxp0"]; ok {
+		t.Fatalf("unmapped interface fxp0 should be absent (default instance), got %q", m["fxp0"])
+	}
+}

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -706,23 +706,30 @@ impl Coordinator {
         // endpoints are also explicitly out of warm scope per the plan
         // (AGY plan r1 #3); their underlay next-hops, if relevant, appear
         // as ordinary (tunnel_endpoint_id == 0) routes.
+        // #2389: warm EVERY equal-cost next-hop's neighbor (not just the
+        // first), so a multipath route's alternate paths are pre-resolved
+        // and selectable on the hot path.
         for routes in snapshot.routes_v4.values() {
             for route in routes {
-                if route.tunnel_endpoint_id != 0 {
-                    continue;
-                }
-                if let Some(hop) = route.next_hop {
-                    enqueue(route.ifindex, IpAddr::V4(hop));
+                for nh in &route.next_hops {
+                    if nh.tunnel_endpoint_id != 0 {
+                        continue;
+                    }
+                    if let Some(hop) = nh.next_hop {
+                        enqueue(nh.ifindex, IpAddr::V4(hop));
+                    }
                 }
             }
         }
         for routes in snapshot.routes_v6.values() {
             for route in routes {
-                if route.tunnel_endpoint_id != 0 {
-                    continue;
-                }
-                if let Some(hop) = route.next_hop {
-                    enqueue(route.ifindex, IpAddr::V6(hop));
+                for nh in &route.next_hops {
+                    if nh.tunnel_endpoint_id != 0 {
+                        continue;
+                    }
+                    if let Some(hop) = nh.next_hop {
+                        enqueue(nh.ifindex, IpAddr::V6(hop));
+                    }
                 }
             }
         }

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1700,14 +1700,15 @@ fn warm_test_coordinator(rg_id: i32) -> (Coordinator, Receiver<WarmItem>) {
     );
     coord.forwarding.routes_v4.insert(
         "inet.0".to_string(),
-        vec![RouteEntryV4 {
-            prefix: PrefixV4::from_net("0.0.0.0/0".parse().unwrap()),
-            ifindex: egress_ifindex,
-            tunnel_endpoint_id: 0,
-            next_hop: Some(Ipv4Addr::new(172, 16, 80, 1)),
-            discard: false,
-            next_table: String::new(),
-        }],
+        vec![RouteEntryV4::single(
+            PrefixV4::from_net("0.0.0.0/0".parse().unwrap()),
+            egress_ifindex,
+            0,
+            Some(Ipv4Addr::new(172, 16, 80, 1)),
+            false,
+            String::new(),
+            5,
+        )],
     );
     (coord, rx)
 }
@@ -1764,7 +1765,7 @@ fn queue_warm_pass_skips_tunnel_routes() {
     // of warm scope. The warmer must skip it rather than gate it on the
     // wrong RG.
     let (mut coord, rx) = warm_test_coordinator(0);
-    coord.forwarding.routes_v4.get_mut("inet.0").unwrap()[0].tunnel_endpoint_id = 7;
+    coord.forwarding.routes_v4.get_mut("inet.0").unwrap()[0].next_hops[0].tunnel_endpoint_id = 7;
     coord.queue_warm_pass(false);
     assert!(rx.try_recv().is_err(), "tunnel route must not be warmed");
 }
@@ -1773,7 +1774,7 @@ fn queue_warm_pass_skips_tunnel_routes() {
 fn queue_warm_pass_skips_invalid_addresses() {
     let (mut coord, rx) = warm_test_coordinator(0);
     // Replace the route's next-hop with a multicast address.
-    coord.forwarding.routes_v4.get_mut("inet.0").unwrap()[0].next_hop =
+    coord.forwarding.routes_v4.get_mut("inet.0").unwrap()[0].next_hops[0].next_hop =
         Some(Ipv4Addr::new(224, 0, 0, 1));
     coord.queue_warm_pass(false);
     assert!(rx.try_recv().is_err(), "multicast next-hop must be filtered");
@@ -1785,14 +1786,15 @@ fn queue_warm_pass_dedups_within_one_call() {
     // Two routes with the SAME (ifindex, next-hop) in different tables.
     coord.forwarding.routes_v4.insert(
         "vrf-a.inet.0".to_string(),
-        vec![RouteEntryV4 {
-            prefix: PrefixV4::from_net("0.0.0.0/0".parse().unwrap()),
-            ifindex: 80,
-            tunnel_endpoint_id: 0,
-            next_hop: Some(Ipv4Addr::new(172, 16, 80, 1)),
-            discard: false,
-            next_table: String::new(),
-        }],
+        vec![RouteEntryV4::single(
+            PrefixV4::from_net("0.0.0.0/0".parse().unwrap()),
+            80,
+            0,
+            Some(Ipv4Addr::new(172, 16, 80, 1)),
+            false,
+            String::new(),
+            5,
+        )],
     );
     coord.queue_warm_pass(false);
     assert!(rx.try_recv().is_ok(), "first item expected");
@@ -1846,14 +1848,15 @@ fn queue_warm_pass_noop_without_worker_queue() {
         .store(Arc::new(BTreeMap::from([(0i32, warm_active_ha_runtime(now_secs))])));
     coord.forwarding.routes_v4.insert(
         "inet.0".to_string(),
-        vec![RouteEntryV4 {
-            prefix: PrefixV4::from_net("0.0.0.0/0".parse().unwrap()),
-            ifindex: 80,
-            tunnel_endpoint_id: 0,
-            next_hop: Some(Ipv4Addr::new(172, 16, 80, 1)),
-            discard: false,
-            next_table: String::new(),
-        }],
+        vec![RouteEntryV4::single(
+            PrefixV4::from_net("0.0.0.0/0".parse().unwrap()),
+            80,
+            0,
+            Some(Ipv4Addr::new(172, 16, 80, 1)),
+            false,
+            String::new(),
+            5,
+        )],
     );
     coord.queue_warm_pass(false); // must not panic
 }

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -27,6 +27,48 @@ slow-path-injected.
 - `MAX_NEXT_TABLE_DEPTH = 8` — bounded recursion across `next-table`
   chains to keep a misconfigured loop from running forever.
 
+## FIB route model
+
+Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
+(`protocol/snapshot.rs`) and is built into per-table FIBs by
+`forwarding_build/fib.rs`. Three correctness rules govern selection:
+
+- **Connected routes are table-scoped (#2388).** Connected prefixes are
+  rebuilt from interface addresses into the global `connected_v[46]`
+  vectors, but each entry carries its routing-table name
+  (`ConnectedRouteV4::table`), derived from the interface's
+  `routing_instance` (`""` = default → `inet.0`/`inet6.0`; a named
+  instance → `<ri>.inet.0`/`<ri>.inet6.0`). The lookup filters connected
+  candidates on the resolving table, so a per-VRF / `next-table` lookup
+  never matches another routing-instance's connected prefix. (Gateway →
+  egress inference at build time, `infer_connected_route_target_*`,
+  stays global — that resolves "which interface reaches this gateway IP",
+  not a destination egress.)
+- **ECMP: all next-hops retained, dead ones skipped (#2389).** A static
+  route keeps EVERY configured next-hop (`RouteEntryV4::next_hops:
+  Vec<RouteNextHopV4>`). `select_route_next_hop` prefers a candidate with
+  a resolved neighbor (so a dead first next-hop no longer blackholes a
+  route with a healthy alternate), then distributes across the live
+  candidates by a fixed-seed hash of the destination IP (`ecmp_hash_*`).
+  Distribution is per-DESTINATION today — the 5-tuple flow hash is not
+  plumbed into the resolution layer; true per-flow ECMP spread is a
+  localized follow-up enabled by the retained candidate vector. The
+  legacy `RouteEntryV4::{ifindex,next_hop,tunnel_endpoint_id}` accessors
+  return the FIRST candidate for non-multipath call sites.
+- **Preference tie-break before insertion order (#2390).**
+  `RouteSnapshot.preference` (Junos admin distance; lower = more
+  preferred, default 5) is carried on the wire and used as the secondary
+  sort key in `sort_routes` (descending prefix length, then ascending
+  preference). Two same-prefix routes in a table select by operator
+  preference, not insertion order; same-prefix/same-preference routes
+  keep insertion order (stable sort).
+
+All three wire fields (`routing_instance`, `next_hops`, `preference`)
+are additive: an old Rust helper ignores them (pre-fix behavior) and an
+old Go binary omits them (serde defaults: default instance, empty
+next-hops, preference 0). The wire specimen lives in
+`tests/fixtures/protocol_wire_v1.json`.
+
 ## Where it sits
 
 - Reads the live snapshot Arcs (FIB, NAT, neighbor table) supplied

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1383,10 +1383,15 @@ pub(super) fn lookup_forwarding_resolution_v4(
         .routes_v4
         .get(table)
         .and_then(|routes| routes.iter().find(|entry| entry.prefix.contains(ip)));
+    // #2388: connected routes are table-scoped — only consider a connected
+    // prefix that belongs to the table being resolved, so a per-VRF /
+    // next-table lookup never matches another routing-instance's connected
+    // prefix. The vec is sorted longest-prefix-first, so the first matching
+    // in-table entry is the most specific.
     let connected_match = state
         .connected_v4
         .iter()
-        .find(|entry| entry.prefix.contains(ip));
+        .find(|entry| entry.table == table && entry.prefix.contains(ip));
     match choose_v4_route(static_match, connected_match) {
         Some(ResolvedRouteV4::Connected {
             ifindex,
@@ -1423,27 +1428,22 @@ pub(super) fn lookup_forwarding_resolution_v4(
             populate_egress_resolution(state, ifindex, &mut resolution);
             resolution
         }
-        Some(ResolvedRouteV4::Static {
-            ifindex,
-            tunnel_endpoint_id,
-            next_hop,
-            discard,
-            next_table,
-        }) => {
-            if discard {
+        Some(ResolvedRouteV4::Static(route)) => {
+            if route.discard {
                 return ForwardingResolution {
                     disposition: ForwardingDisposition::DiscardRoute,
                     local_ifindex: 0,
-                    egress_ifindex: ifindex,
-                    tx_ifindex: ifindex,
-                    tunnel_endpoint_id,
-                    next_hop: next_hop.map(IpAddr::V4),
+                    egress_ifindex: 0,
+                    tx_ifindex: 0,
+                    tunnel_endpoint_id: 0,
+                    next_hop: None,
                     neighbor_mac: None,
                     src_mac: None,
                     tx_vlan_id: 0,
                 };
             }
-            if let Some(next_table_name) = next_table {
+            if !route.next_table.is_empty() {
+                let next_table_name = route.next_table.as_str();
                 if next_table_name == table {
                     return ForwardingResolution {
                         disposition: ForwardingDisposition::NextTableUnsupported,
@@ -1457,6 +1457,8 @@ pub(super) fn lookup_forwarding_resolution_v4(
                         tx_vlan_id: 0,
                     };
                 }
+                // Clone needed: the recursive call borrows `state` again.
+                let next_table_name = route.next_table.clone();
                 return lookup_forwarding_resolution_v4(
                     state,
                     dynamic_neighbors,
@@ -1466,6 +1468,18 @@ pub(super) fn lookup_forwarding_resolution_v4(
                     allow_tunnels,
                 );
             }
+            // #2389: select one equal-cost next-hop, skipping a dead one.
+            let ip_hash = ecmp_hash_v4(ip);
+            let selected = select_route_next_hop(&route.next_hops, ip_hash, |nh| {
+                let target = nh.next_hop.unwrap_or(ip);
+                nh.ifindex > 0
+                    && lookup_neighbor_entry(state, dynamic_neighbors, nh.ifindex, IpAddr::V4(target))
+                        .is_some()
+            });
+            let (next_hop, ifindex, tunnel_endpoint_id) = match selected {
+                Some(nh) => (nh.next_hop, nh.ifindex, nh.tunnel_endpoint_id),
+                None => (None, 0, 0),
+            };
             if tunnel_endpoint_id != 0 {
                 return if allow_tunnels {
                     resolve_tunnel_forwarding_resolution(
@@ -1531,10 +1545,11 @@ pub(super) fn lookup_forwarding_resolution_v6(
         .routes_v6
         .get(table)
         .and_then(|routes| routes.iter().find(|entry| entry.prefix.contains(ip)));
+    // #2388: connected routes are table-scoped (see the v4 lookup).
     let connected_match = state
         .connected_v6
         .iter()
-        .find(|entry| entry.prefix.contains(ip));
+        .find(|entry| entry.table == table && entry.prefix.contains(ip));
     match choose_v6_route(static_match, connected_match) {
         Some(ResolvedRouteV6::Connected {
             ifindex,
@@ -1571,27 +1586,22 @@ pub(super) fn lookup_forwarding_resolution_v6(
             populate_egress_resolution(state, ifindex, &mut resolution);
             resolution
         }
-        Some(ResolvedRouteV6::Static {
-            ifindex,
-            tunnel_endpoint_id,
-            next_hop,
-            discard,
-            next_table,
-        }) => {
-            if discard {
+        Some(ResolvedRouteV6::Static(route)) => {
+            if route.discard {
                 return ForwardingResolution {
                     disposition: ForwardingDisposition::DiscardRoute,
                     local_ifindex: 0,
-                    egress_ifindex: ifindex,
-                    tx_ifindex: ifindex,
-                    tunnel_endpoint_id,
-                    next_hop: next_hop.map(IpAddr::V6),
+                    egress_ifindex: 0,
+                    tx_ifindex: 0,
+                    tunnel_endpoint_id: 0,
+                    next_hop: None,
                     neighbor_mac: None,
                     src_mac: None,
                     tx_vlan_id: 0,
                 };
             }
-            if let Some(next_table_name) = next_table {
+            if !route.next_table.is_empty() {
+                let next_table_name = route.next_table.as_str();
                 if next_table_name == table {
                     return ForwardingResolution {
                         disposition: ForwardingDisposition::NextTableUnsupported,
@@ -1605,6 +1615,7 @@ pub(super) fn lookup_forwarding_resolution_v6(
                         tx_vlan_id: 0,
                     };
                 }
+                let next_table_name = route.next_table.clone();
                 return lookup_forwarding_resolution_v6(
                     state,
                     dynamic_neighbors,
@@ -1614,6 +1625,18 @@ pub(super) fn lookup_forwarding_resolution_v6(
                     allow_tunnels,
                 );
             }
+            // #2389: select one equal-cost next-hop, skipping a dead one.
+            let ip_hash = ecmp_hash_v6(ip);
+            let selected = select_route_next_hop(&route.next_hops, ip_hash, |nh| {
+                let target = nh.next_hop.unwrap_or(ip);
+                nh.ifindex > 0
+                    && lookup_neighbor_entry(state, dynamic_neighbors, nh.ifindex, IpAddr::V6(target))
+                        .is_some()
+            });
+            let (next_hop, ifindex, tunnel_endpoint_id) = match selected {
+                Some(nh) => (nh.next_hop, nh.ifindex, nh.tunnel_endpoint_id),
+                None => (None, 0, 0),
+            };
             if tunnel_endpoint_id != 0 {
                 return if allow_tunnels {
                     resolve_tunnel_forwarding_resolution(
@@ -1825,38 +1848,26 @@ pub(super) fn parse_neighbor_entries(output: &str) -> Vec<(IpAddr, NeighborEntry
     out
 }
 
-enum ResolvedRouteV4 {
+enum ResolvedRouteV4<'a> {
     Connected {
         ifindex: i32,
         tunnel_endpoint_id: u16,
     },
-    Static {
-        ifindex: i32,
-        tunnel_endpoint_id: u16,
-        next_hop: Option<Ipv4Addr>,
-        discard: bool,
-        next_table: Option<String>,
-    },
+    Static(&'a RouteEntryV4),
 }
 
-enum ResolvedRouteV6 {
+enum ResolvedRouteV6<'a> {
     Connected {
         ifindex: i32,
         tunnel_endpoint_id: u16,
     },
-    Static {
-        ifindex: i32,
-        tunnel_endpoint_id: u16,
-        next_hop: Option<Ipv6Addr>,
-        discard: bool,
-        next_table: Option<String>,
-    },
+    Static(&'a RouteEntryV6),
 }
 
-fn choose_v4_route(
-    static_match: Option<&RouteEntryV4>,
-    connected_match: Option<&ConnectedRouteV4>,
-) -> Option<ResolvedRouteV4> {
+fn choose_v4_route<'a>(
+    static_match: Option<&'a RouteEntryV4>,
+    connected_match: Option<&'a ConnectedRouteV4>,
+) -> Option<ResolvedRouteV4<'a>> {
     match (static_match, connected_match) {
         (Some(route), Some(conn)) if conn.prefix.prefix_len() >= route.prefix.prefix_len() => {
             Some(ResolvedRouteV4::Connected {
@@ -1864,17 +1875,7 @@ fn choose_v4_route(
                 tunnel_endpoint_id: conn.tunnel_endpoint_id,
             })
         }
-        (Some(route), _) => Some(ResolvedRouteV4::Static {
-            ifindex: route.ifindex,
-            tunnel_endpoint_id: route.tunnel_endpoint_id,
-            next_hop: route.next_hop,
-            discard: route.discard,
-            next_table: if route.next_table.is_empty() {
-                None
-            } else {
-                Some(route.next_table.clone())
-            },
-        }),
+        (Some(route), _) => Some(ResolvedRouteV4::Static(route)),
         (None, Some(conn)) => Some(ResolvedRouteV4::Connected {
             ifindex: conn.ifindex,
             tunnel_endpoint_id: conn.tunnel_endpoint_id,
@@ -1883,10 +1884,10 @@ fn choose_v4_route(
     }
 }
 
-fn choose_v6_route(
-    static_match: Option<&RouteEntryV6>,
-    connected_match: Option<&ConnectedRouteV6>,
-) -> Option<ResolvedRouteV6> {
+fn choose_v6_route<'a>(
+    static_match: Option<&'a RouteEntryV6>,
+    connected_match: Option<&'a ConnectedRouteV6>,
+) -> Option<ResolvedRouteV6<'a>> {
     match (static_match, connected_match) {
         (Some(route), Some(conn)) if conn.prefix.prefix_len() >= route.prefix.prefix_len() => {
             Some(ResolvedRouteV6::Connected {
@@ -1894,22 +1895,62 @@ fn choose_v6_route(
                 tunnel_endpoint_id: conn.tunnel_endpoint_id,
             })
         }
-        (Some(route), _) => Some(ResolvedRouteV6::Static {
-            ifindex: route.ifindex,
-            tunnel_endpoint_id: route.tunnel_endpoint_id,
-            next_hop: route.next_hop,
-            discard: route.discard,
-            next_table: if route.next_table.is_empty() {
-                None
-            } else {
-                Some(route.next_table.clone())
-            },
-        }),
+        (Some(route), _) => Some(ResolvedRouteV6::Static(route)),
         (None, Some(conn)) => Some(ResolvedRouteV6::Connected {
             ifindex: conn.ifindex,
             tunnel_endpoint_id: conn.tunnel_endpoint_id,
         }),
         (None, None) => None,
+    }
+}
+
+/// #2389: select one equal-cost next-hop candidate for a forwarding
+/// static route. Prefers a candidate whose neighbor is resolved (skips a
+/// dead/unresolved first next-hop — the load-bearing correctness fix); if
+/// several resolve, distributes deterministically by destination IP; if
+/// none resolve, falls back to the same dst-hashed pick so the kernel
+/// slow-path can drive ARP/NDP. `ip` is hashed for the spread.
+///
+/// Distribution is per-DESTINATION (the only flow identity available at
+/// this resolution layer — the 5-tuple flow hash is not plumbed here).
+/// True per-flow ECMP spread would require threading the session flow
+/// hash into the forwarding-resolution path; tracked as a follow-up. The
+/// retained candidate vector makes that a localized change.
+/// Deterministic per-destination ECMP spread key. A fixed-seed splitmix64
+/// finalizer over the address bytes — stable across reloads and workers so
+/// every worker maps the same destination to the same equal-cost path
+/// (a flow's packets never split across paths). Not a security hash.
+fn ecmp_hash_bytes(seed: u64) -> u64 {
+    let mut z = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+fn ecmp_hash_v4(ip: Ipv4Addr) -> u64 {
+    ecmp_hash_bytes(u32::from(ip) as u64)
+}
+
+fn ecmp_hash_v6(ip: Ipv6Addr) -> u64 {
+    let bits = u128::from(ip);
+    ecmp_hash_bytes((bits as u64) ^ ((bits >> 64) as u64))
+}
+
+fn select_route_next_hop<'a, T: Copy>(
+    candidates: &'a [T],
+    ip_hash: u64,
+    is_live: impl Fn(&T) -> bool,
+) -> Option<&'a T> {
+    if candidates.is_empty() {
+        return None;
+    }
+    let live: usize = candidates.iter().filter(|c| is_live(c)).count();
+    let pool_len = if live > 0 { live } else { candidates.len() };
+    let pick = (ip_hash % pool_len as u64) as usize;
+    if live > 0 {
+        candidates.iter().filter(|c| is_live(c)).nth(pick)
+    } else {
+        candidates.get(pick)
     }
 }
 

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2409,3 +2409,290 @@ fn is_ipsec_traffic_rejects_non_ipsec() {
         "GRE (proto 47) is not IPsec passthrough"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2388 / #2389 / #2390 — Rust FIB route-snapshot correctness regressions.
+// Each test FAILS if the corresponding fix is reverted.
+// ---------------------------------------------------------------------------
+
+/// #2388: connected routes must be table-scoped. Two routing-instances own
+/// the SAME connected prefix (10.0.0.0/24) on different interfaces. A
+/// lookup in tenant-b's table must resolve to tenant-b's interface, never
+/// leak to tenant-a's connected route. Revert (drop the `entry.table ==
+/// table` filter in the connected scan) → the global scan returns
+/// tenant-a's interface (pushed first) → egress mismatch → RED.
+#[test]
+fn connected_routes_are_table_scoped_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![
+            crate::ZoneSnapshot {
+                name: "za".to_string(),
+                id: TEST_TRUST_ZONE_ID,
+            },
+            crate::ZoneSnapshot {
+                name: "zb".to_string(),
+                id: TEST_UNTRUST_ZONE_ID,
+            },
+        ],
+        interfaces: vec![
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1.80".to_string(),
+                zone: "za".to_string(),
+                routing_instance: "tenant-a".to_string(),
+                linux_name: "ge-0-0-1.80".to_string(),
+                ifindex: 101,
+                hardware_addr: "02:00:00:00:00:a1".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "10.0.0.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1.90".to_string(),
+                zone: "zb".to_string(),
+                routing_instance: "tenant-b".to_string(),
+                linux_name: "ge-0-0-1.90".to_string(),
+                ifindex: 202,
+                hardware_addr: "02:00:00:00:00:b2".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "10.0.0.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+
+    // A lookup directed into tenant-b's table for a host in the overlapping
+    // prefix must egress tenant-b's interface (202), never tenant-a's (101).
+    let resolved = lookup_forwarding_resolution_v4(
+        &state,
+        None,
+        Ipv4Addr::new(10, 0, 0, 42),
+        "tenant-b.inet.0",
+        0,
+        true,
+    );
+    assert_eq!(
+        resolved.egress_ifindex, 202,
+        "tenant-b lookup must resolve tenant-b's connected interface, not tenant-a's (cross-VRF leak)",
+    );
+
+    // And the mirror: tenant-a's table resolves tenant-a's interface.
+    let resolved_a = lookup_forwarding_resolution_v4(
+        &state,
+        None,
+        Ipv4Addr::new(10, 0, 0, 42),
+        "tenant-a.inet.0",
+        0,
+        true,
+    );
+    assert_eq!(resolved_a.egress_ifindex, 101);
+}
+
+/// #2389: a static route with two next-hops must retain BOTH in the FIB
+/// (equal-cost), and a dead first next-hop must fall back to a live
+/// alternate. Revert the build to `next_hops.first()` → only one candidate
+/// retained → len 1 → RED; revert the selection → a dead NH[0] blackholes.
+#[test]
+fn ecmp_static_route_retains_all_next_hops_and_skips_dead() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![crate::ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+        }],
+        interfaces: vec![
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1".to_string(),
+                zone: "wan".to_string(),
+                linux_name: "ge-0-0-1".to_string(),
+                ifindex: 11,
+                hardware_addr: "02:00:00:00:00:11".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "192.0.2.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/2".to_string(),
+                zone: "wan".to_string(),
+                linux_name: "ge-0-0-2".to_string(),
+                ifindex: 22,
+                hardware_addr: "02:00:00:00:00:22".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "192.0.3.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+        ],
+        routes: vec![crate::RouteSnapshot {
+            table: "inet.0".to_string(),
+            family: "inet".to_string(),
+            destination: "203.0.113.0/24".to_string(),
+            // Two equal-cost next-hops, each via a distinct interface.
+            next_hops: vec![
+                "192.0.2.2@ge-0/0/1".to_string(),
+                "192.0.3.2@ge-0/0/2".to_string(),
+            ],
+            discard: false,
+            next_table: String::new(),
+            preference: 5,
+        }],
+        // Only the SECOND next-hop's neighbor is resolved; the first is dead.
+        neighbors: vec![crate::NeighborSnapshot {
+            interface: "ge-0-0-2".to_string(),
+            ifindex: 22,
+            family: "inet".to_string(),
+            ip: "192.0.3.2".to_string(),
+            mac: "00:11:22:33:44:66".to_string(),
+            state: "reachable".to_string(),
+            router: true,
+            link_local: false,
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+
+    // Build retains BOTH next-hops (not just the first).
+    let route = &state.routes_v4.get("inet.0").expect("table")[0];
+    assert_eq!(
+        route.next_hops.len(),
+        2,
+        "ECMP route must retain all next-hops, not collapse to the first",
+    );
+
+    // Selection skips the dead first next-hop and forwards via the live
+    // second (egress ge-0/0/2 = ifindex 22), producing a ForwardCandidate
+    // rather than a MissingNeighbor blackhole on NH[0].
+    let resolved = lookup_forwarding_resolution_v4(
+        &state,
+        None,
+        Ipv4Addr::new(203, 0, 113, 5),
+        "inet.0",
+        0,
+        true,
+    );
+    assert_eq!(
+        resolved.disposition,
+        ForwardingDisposition::ForwardCandidate,
+        "live alternate next-hop must forward despite a dead first next-hop",
+    );
+    assert_eq!(
+        resolved.egress_ifindex, 22,
+        "must egress the live next-hop's interface",
+    );
+}
+
+/// #2390: two same-prefix static routes with different preference must
+/// select the lower-preference one regardless of insertion order. The
+/// worse route is inserted FIRST. Revert (sort by prefix length only) →
+/// insertion order wins → the worse next-hop is selected → RED.
+#[test]
+fn same_prefix_routes_tie_break_by_preference_not_insertion_order() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![crate::ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+        }],
+        interfaces: vec![
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1".to_string(),
+                zone: "wan".to_string(),
+                linux_name: "ge-0-0-1".to_string(),
+                ifindex: 11,
+                hardware_addr: "02:00:00:00:00:11".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "192.0.2.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/2".to_string(),
+                zone: "wan".to_string(),
+                linux_name: "ge-0-0-2".to_string(),
+                ifindex: 22,
+                hardware_addr: "02:00:00:00:00:22".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "192.0.3.1/24".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+        ],
+        routes: vec![
+            // WORSE route first (higher preference = less preferred).
+            crate::RouteSnapshot {
+                table: "inet.0".to_string(),
+                family: "inet".to_string(),
+                destination: "203.0.113.0/24".to_string(),
+                next_hops: vec!["192.0.2.2@ge-0/0/1".to_string()],
+                discard: false,
+                next_table: String::new(),
+                preference: 50,
+            },
+            // BETTER route second (lower preference).
+            crate::RouteSnapshot {
+                table: "inet.0".to_string(),
+                family: "inet".to_string(),
+                destination: "203.0.113.0/24".to_string(),
+                next_hops: vec!["192.0.3.2@ge-0/0/2".to_string()],
+                discard: false,
+                next_table: String::new(),
+                preference: 5,
+            },
+        ],
+        neighbors: vec![
+            crate::NeighborSnapshot {
+                interface: "ge-0-0-1".to_string(),
+                ifindex: 11,
+                family: "inet".to_string(),
+                ip: "192.0.2.2".to_string(),
+                mac: "00:11:22:33:44:55".to_string(),
+                state: "reachable".to_string(),
+                router: true,
+                link_local: false,
+            },
+            crate::NeighborSnapshot {
+                interface: "ge-0-0-2".to_string(),
+                ifindex: 22,
+                family: "inet".to_string(),
+                ip: "192.0.3.2".to_string(),
+                mac: "00:11:22:33:44:66".to_string(),
+                state: "reachable".to_string(),
+                router: true,
+                link_local: false,
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+
+    let resolved = lookup_forwarding_resolution_v4(
+        &state,
+        None,
+        Ipv4Addr::new(203, 0, 113, 5),
+        "inet.0",
+        0,
+        true,
+    );
+    assert_eq!(
+        resolved.disposition,
+        ForwardingDisposition::ForwardCandidate
+    );
+    assert_eq!(
+        resolved.egress_ifindex, 22,
+        "lower-preference route (pref 5, ge-0/0/2) must win over the higher-preference route (pref 50, ge-0/0/1) inserted first",
+    );
+}

--- a/userspace-dp/src/afxdp/forwarding_build/fib.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/fib.rs
@@ -13,7 +13,7 @@
 //!   [`IfaceIndex`] and the populated `state.neighbors` map.
 //!
 //! Also hosts the route-target resolution helpers
-//! ([`resolve_route_target_v4`] etc.) re-exported by
+//! ([`resolve_route_next_hops_v4`] etc.) re-exported by
 //! `forwarding_build/mod.rs` as `pub(in crate::afxdp)` for the
 //! other afxdp siblings that consume them via `use
 //! self::forwarding_build::*;` in `afxdp/mod.rs`.
@@ -41,7 +41,7 @@ pub(super) fn populate_routes(
 ) {
     for route in &snapshot.routes {
         if let Ok(prefix) = route.destination.parse::<Ipv4Net>() {
-            let (next_hop, ifindex, tunnel_endpoint_id) = resolve_route_target_v4(
+            let next_hops = resolve_route_next_hops_v4(
                 route,
                 &iface_ctx.name_to_ifindex,
                 &iface_ctx.linux_to_ifindex,
@@ -54,16 +54,15 @@ pub(super) fn populate_routes(
                 .or_default()
                 .push(RouteEntryV4 {
                     prefix: PrefixV4::from_net(prefix),
-                    ifindex,
-                    tunnel_endpoint_id,
-                    next_hop,
+                    next_hops,
                     discard: route.discard,
                     next_table: route.next_table.clone(),
+                    preference: route.preference,
                 });
             continue;
         }
         if let Ok(prefix) = route.destination.parse::<Ipv6Net>() {
-            let (next_hop, ifindex, tunnel_endpoint_id) = resolve_route_target_v6(
+            let next_hops = resolve_route_next_hops_v6(
                 route,
                 &iface_ctx.name_to_ifindex,
                 &iface_ctx.linux_to_ifindex,
@@ -76,22 +75,37 @@ pub(super) fn populate_routes(
                 .or_default()
                 .push(RouteEntryV6 {
                     prefix: PrefixV6::from_net(prefix),
-                    ifindex,
-                    tunnel_endpoint_id,
-                    next_hop,
+                    next_hops,
                     discard: route.discard,
                     next_table: route.next_table.clone(),
+                    preference: route.preference,
                 });
         }
     }
 }
 
 pub(super) fn sort_routes(state: &mut ForwardingState) {
+    // #2390: order each table by descending prefix length (longest-match
+    // first), then ASCENDING preference (lower = more preferred per Junos),
+    // so `routes.iter().find(prefix.contains)` returns the most-specific
+    // and, among same-prefix routes, the operator-preferred one — NOT the
+    // insertion-order first. `sort_by` is stable, so same-prefix /
+    // same-preference routes keep their relative (insertion) order.
     for routes in state.routes_v4.values_mut() {
-        routes.sort_by(|a, b| b.prefix.prefix_len().cmp(&a.prefix.prefix_len()));
+        routes.sort_by(|a, b| {
+            b.prefix
+                .prefix_len()
+                .cmp(&a.prefix.prefix_len())
+                .then(a.preference.cmp(&b.preference))
+        });
     }
     for routes in state.routes_v6.values_mut() {
-        routes.sort_by(|a, b| b.prefix.prefix_len().cmp(&a.prefix.prefix_len()));
+        routes.sort_by(|a, b| {
+            b.prefix
+                .prefix_len()
+                .cmp(&a.prefix.prefix_len())
+                .then(a.preference.cmp(&b.preference))
+        });
     }
 }
 
@@ -149,58 +163,83 @@ pub(super) fn populate_fabrics(
     }
 }
 
-pub(in crate::afxdp) fn resolve_route_target_v4(
+/// #2389: resolve EVERY configured next-hop of a static route into a
+/// `RouteNextHopV4` candidate. A discard / next-table route has no
+/// forwarding next-hop (returns empty). Each candidate resolves its egress
+/// ifindex from an explicit `@interface` spec, else by inferring the
+/// connected interface that contains the gateway IP — scoped to the
+/// route's own table (#2388) so a gateway is never resolved against
+/// another routing-instance's connected prefix. Candidates whose interface
+/// fails to resolve are still retained with ifindex 0 (matching the
+/// pre-#2389 single-next-hop fallback, which kept next_hop with ifindex 0).
+pub(in crate::afxdp) fn resolve_route_next_hops_v4(
     route: &RouteSnapshot,
     names: &BTreeMap<String, i32>,
     linux_names: &BTreeMap<String, i32>,
     state: &ForwardingState,
-) -> (Option<Ipv4Addr>, i32, u16) {
+) -> Vec<RouteNextHopV4> {
     if route.discard || !route.next_table.is_empty() {
-        return (None, 0, 0);
+        return Vec::new();
     }
-    let Some((next_hop, interface)) = route
+    route
         .next_hops
-        .first()
-        .map(|nh| parse_route_next_hop(nh.as_str()))
-    else {
-        return (None, 0, 0);
-    };
-    let target = interface
-        .as_deref()
-        .and_then(|name| resolve_ifindex(name, names, linux_names))
-        .map(|ifindex| {
-            (
+        .iter()
+        .map(|nh| {
+            let (next_hop, interface) = parse_route_next_hop(nh.as_str());
+            let (ifindex, tunnel_endpoint_id) = resolve_next_hop_target_v4(
+                next_hop,
+                interface.as_deref(),
+                names,
+                linux_names,
+                state,
+            );
+            RouteNextHopV4 {
+                next_hop,
                 ifindex,
-                state
-                    .tunnel_endpoint_by_ifindex
-                    .get(&ifindex)
-                    .copied()
-                    .unwrap_or(0),
-            )
+                tunnel_endpoint_id,
+            }
         })
-        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v4(state, ip)));
-    let (ifindex, tunnel_endpoint_id) = target.unwrap_or((0, 0));
-    (next_hop, ifindex, tunnel_endpoint_id)
+        .collect()
 }
 
-pub(in crate::afxdp) fn resolve_route_target_v6(
+pub(in crate::afxdp) fn resolve_route_next_hops_v6(
     route: &RouteSnapshot,
     names: &BTreeMap<String, i32>,
     linux_names: &BTreeMap<String, i32>,
     state: &ForwardingState,
-) -> (Option<Ipv6Addr>, i32, u16) {
+) -> Vec<RouteNextHopV6> {
     if route.discard || !route.next_table.is_empty() {
-        return (None, 0, 0);
+        return Vec::new();
     }
-    let Some((next_hop, interface)) = route
+    route
         .next_hops
-        .first()
-        .map(|nh| parse_route_next_hop_v6(nh.as_str()))
-    else {
-        return (None, 0, 0);
-    };
-    let target = interface
-        .as_deref()
+        .iter()
+        .map(|nh| {
+            let (next_hop, interface) = parse_route_next_hop_v6(nh.as_str());
+            let (ifindex, tunnel_endpoint_id) = resolve_next_hop_target_v6(
+                next_hop,
+                interface.as_deref(),
+                names,
+                linux_names,
+                state,
+            );
+            RouteNextHopV6 {
+                next_hop,
+                ifindex,
+                tunnel_endpoint_id,
+            }
+        })
+        .collect()
+}
+
+fn resolve_next_hop_target_v4(
+    next_hop: Option<Ipv4Addr>,
+    interface: Option<&str>,
+    names: &BTreeMap<String, i32>,
+    linux_names: &BTreeMap<String, i32>,
+    state: &ForwardingState,
+) -> (i32, u16) {
+    interface
         .and_then(|name| resolve_ifindex(name, names, linux_names))
         .map(|ifindex| {
             (
@@ -212,9 +251,31 @@ pub(in crate::afxdp) fn resolve_route_target_v6(
                     .unwrap_or(0),
             )
         })
-        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v6(state, ip)));
-    let (ifindex, tunnel_endpoint_id) = target.unwrap_or((0, 0));
-    (next_hop, ifindex, tunnel_endpoint_id)
+        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v4(state, ip)))
+        .unwrap_or((0, 0))
+}
+
+fn resolve_next_hop_target_v6(
+    next_hop: Option<Ipv6Addr>,
+    interface: Option<&str>,
+    names: &BTreeMap<String, i32>,
+    linux_names: &BTreeMap<String, i32>,
+    state: &ForwardingState,
+) -> (i32, u16) {
+    interface
+        .and_then(|name| resolve_ifindex(name, names, linux_names))
+        .map(|ifindex| {
+            (
+                ifindex,
+                state
+                    .tunnel_endpoint_by_ifindex
+                    .get(&ifindex)
+                    .copied()
+                    .unwrap_or(0),
+            )
+        })
+        .or_else(|| next_hop.and_then(|ip| infer_connected_route_target_v6(state, ip)))
+        .unwrap_or((0, 0))
 }
 
 pub(in crate::afxdp) fn parse_route_next_hop(spec: &str) -> (Option<Ipv4Addr>, Option<String>) {
@@ -270,6 +331,13 @@ pub(in crate::afxdp) fn infer_connected_route_target_v4(
     state: &ForwardingState,
     ip: Ipv4Addr,
 ) -> Option<(i32, u16)> {
+    // Gateway -> egress-interface inference at FIB-build time: "which
+    // interface can reach this next-hop gateway IP". This is a global
+    // connected-prefix match and is intentionally NOT table-scoped — a
+    // route's configured gateway resolves to whatever connected interface
+    // contains it. The #2388 cross-VRF leak is a LOOKUP-time concern
+    // (which connected prefix a destination egresses on) and is fixed at
+    // the lookup site by filtering connected_v4 on the resolving table.
     state
         .connected_v4
         .iter()

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -96,6 +96,14 @@ pub(super) fn populate_interfaces(
             .get(&iface.ifindex)
             .copied()
             .unwrap_or(0);
+        // #2388: canonical connected-route table names for this interface's
+        // routing-instance. "" (default instance) → inet.0 / inet6.0; a
+        // named instance → "<ri>.inet.0" / "<ri>.inet6.0". The lookup
+        // filters connected routes by the canonical table it is resolving
+        // in, so a per-VRF / next-table lookup never matches a connected
+        // prefix owned by a different routing-instance.
+        let (connected_table_v4, connected_table_v6) =
+            connected_route_tables(&iface.routing_instance);
         for addr in &iface.addresses {
             // #2409: fail CLOSED on an unparseable interface address rather
             // than silently `continue`-ing past it. The pre-fix skip lost the
@@ -121,6 +129,7 @@ pub(super) fn populate_interfaces(
                         prefix: PrefixV4::from_net(v4),
                         ifindex: iface.ifindex,
                         tunnel_endpoint_id,
+                        table: connected_table_v4.clone(),
                     });
                 }
                 IpNet::V6(v6) => {
@@ -133,6 +142,7 @@ pub(super) fn populate_interfaces(
                         prefix: PrefixV6::from_net(v6),
                         ifindex: iface.ifindex,
                         tunnel_endpoint_id,
+                        table: connected_table_v6.clone(),
                     });
                 }
             }
@@ -223,6 +233,23 @@ pub(super) fn populate_egress(
         );
     }
     Ok(())
+}
+
+/// #2388: canonical (v4, v6) connected-route table names for a routing
+/// instance. The empty instance name is the default instance
+/// (inet.0 / inet6.0); a named instance maps to "<ri>.inet.0" /
+/// "<ri>.inet6.0". These match the names the lookup canonicalizes the
+/// queried table to (`canonical_route_table`), so a connected entry is
+/// only matched when the lookup is resolving in the owning table.
+pub(in crate::afxdp) fn connected_route_tables(routing_instance: &str) -> (String, String) {
+    if routing_instance.is_empty() {
+        ("inet.0".to_string(), "inet6.0".to_string())
+    } else {
+        (
+            format!("{routing_instance}.inet.0"),
+            format!("{routing_instance}.inet6.0"),
+        )
+    }
 }
 
 pub(in crate::afxdp) fn pick_interface_v4(iface: &InterfaceSnapshot) -> Option<Ipv4Addr> {

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -43,7 +43,7 @@ mod tests;
 // `use self::forwarding_build::*;` in `afxdp/mod.rs`.
 pub(in crate::afxdp) use fib::{
     infer_connected_route_target_v4, infer_connected_route_target_v6, parse_route_next_hop,
-    parse_route_next_hop_v6, resolve_ifindex, resolve_route_target_v4, resolve_route_target_v6,
+    parse_route_next_hop_v6, resolve_ifindex, resolve_route_next_hops_v4, resolve_route_next_hops_v6,
 };
 pub(in crate::afxdp) use interfaces::{pick_interface_v4, pick_interface_v6};
 // #1866: WG row-identity hydration shared with the coordinator's

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -794,6 +794,7 @@ mod wg_frame_tests {
             next_hops: vec!["2001:559:8585:80::1@reth0.80".to_string()],
             discard: false,
             next_table: String::new(),
+            preference: 0,
         });
         // The WG endpoint's transport table follows the v6 outer family.
         snap.tunnel_endpoints[0].outer_family = "inet6".to_string();

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -165,6 +165,7 @@ fn test_forwarding_state_with_fabric() -> ForwardingState {
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(10, 0, 61, 0), 24).unwrap()),
         ifindex: 6,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (6, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -840,6 +840,7 @@ mod tests {
             prefix: crate::prefix::PrefixV4::from_net(cidr.parse().expect("cidr")),
             ifindex: ICMP_IFINDEX,
             tunnel_endpoint_id: 0,
+            table: "inet.0".to_string(),
         });
         state
     }

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -372,6 +372,7 @@ fn ptb_suppressed_for_v4_directed_broadcast_dst() {
         prefix: crate::prefix::PrefixV4::from_net("10.0.1.0/24".parse().expect("cidr")),
         ifindex: PTB_IFINDEX,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     assert!(
         ptb_reply_suppressed(&frame, meta, l3, &fwd),
@@ -400,6 +401,7 @@ fn ptb_still_generated_for_unicast_in_connected_subnet() {
         prefix: crate::prefix::PrefixV4::from_net("10.0.1.0/24".parse().expect("cidr")),
         ifindex: PTB_IFINDEX,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     assert!(
         !ptb_reply_suppressed(&frame, meta, l3, &fwd),

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -86,6 +86,7 @@ fn test_forwarding_state() -> ForwardingState {
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(10, 0, 61, 0), 24).unwrap()),
         ifindex: 6,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (6, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102))),
@@ -439,6 +440,7 @@ fn resolve_flow_session_decision_promotes_stale_fabric_shared_hit_to_local_owner
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
@@ -1316,6 +1318,7 @@ fn resolve_flow_session_decision_promotes_translated_shared_hit_on_active_fabric
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
@@ -1414,6 +1417,7 @@ fn resolve_flow_session_decision_promotes_local_synced_translated_hit_on_active_
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
@@ -1499,6 +1503,7 @@ fn resolve_flow_session_decision_keeps_translated_shared_hit_transient_on_inacti
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
@@ -1582,6 +1587,7 @@ fn resolve_flow_session_decision_keeps_translated_shared_hit_transient_on_inacti
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
@@ -1664,6 +1670,7 @@ fn resolve_flow_session_decision_keeps_local_synced_translated_hit_transient_on_
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),
@@ -3734,6 +3741,7 @@ fn synced_session_hit_recomputes_local_resolution_after_failover() {
         prefix: PrefixV4::from_net(Ipv4Net::new(Ipv4Addr::new(172, 16, 80, 0), 24).unwrap()),
         ifindex: 12,
         tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
     });
     forwarding.neighbors.insert(
         (12, IpAddr::V4(Ipv4Addr::new(172, 16, 80, 200))),

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -40,6 +40,7 @@ pub(super) fn forwarding_snapshot(include_neighbor: bool) -> ConfigSnapshot {
                 next_hops: vec!["172.16.50.1@ge-0/0/0.50".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
             RouteSnapshot {
                 table: "inet6.0".to_string(),
@@ -48,6 +49,7 @@ pub(super) fn forwarding_snapshot(include_neighbor: bool) -> ConfigSnapshot {
                 next_hops: vec!["2001:559:8585:50::1@ge-0/0/0.50".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
         ],
         neighbors: if include_neighbor {
@@ -159,6 +161,7 @@ pub(super) fn native_gre_snapshot(include_neighbor: bool) -> ConfigSnapshot {
                 next_hops: vec!["2001:559:8585:80::1@reth0.80".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
             RouteSnapshot {
                 table: "sfmix.inet.0".to_string(),
@@ -167,6 +170,7 @@ pub(super) fn native_gre_snapshot(include_neighbor: bool) -> ConfigSnapshot {
                 next_hops: vec!["10.255.192.41".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
         ],
         neighbors: if include_neighbor {
@@ -276,6 +280,7 @@ pub(super) fn wg_outer_mtu_snapshot() -> ConfigSnapshot {
             next_hops: vec!["172.16.80.1@reth0.80".to_string()],
             discard: false,
             next_table: String::new(),
+            preference: 0,
         }],
         ..Default::default()
     }
@@ -360,6 +365,7 @@ pub(super) fn forwarding_snapshot_with_next_table(include_neighbor: bool) -> Con
                 next_hops: vec![],
                 discard: false,
                 next_table: "blue.inet.0".to_string(),
+                preference: 0,
             },
             RouteSnapshot {
                 table: "blue.inet.0".to_string(),
@@ -368,6 +374,7 @@ pub(super) fn forwarding_snapshot_with_next_table(include_neighbor: bool) -> Con
                 next_hops: vec!["172.16.50.1@ge-0/0/0.50".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
             RouteSnapshot {
                 table: "inet6.0".to_string(),
@@ -376,6 +383,7 @@ pub(super) fn forwarding_snapshot_with_next_table(include_neighbor: bool) -> Con
                 next_hops: vec![],
                 discard: false,
                 next_table: "blue.inet6.0".to_string(),
+                preference: 0,
             },
             RouteSnapshot {
                 table: "blue.inet6.0".to_string(),
@@ -384,6 +392,7 @@ pub(super) fn forwarding_snapshot_with_next_table(include_neighbor: bool) -> Con
                 next_hops: vec!["2001:559:8585:50::1@ge-0/0/0.50".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
         ],
         neighbors: if include_neighbor {
@@ -425,6 +434,7 @@ pub(super) fn forwarding_snapshot_with_next_table_loop() -> ConfigSnapshot {
             next_hops: vec![],
             discard: false,
             next_table: "inet.0".to_string(),
+            preference: 0,
         }],
         ..Default::default()
     }
@@ -496,6 +506,7 @@ pub(super) fn nat_snapshot() -> ConfigSnapshot {
                 next_hops: vec!["172.16.80.1@reth0.80".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
             RouteSnapshot {
                 table: "inet6.0".to_string(),
@@ -504,6 +515,7 @@ pub(super) fn nat_snapshot() -> ConfigSnapshot {
                 next_hops: vec!["2001:559:8585:80::1@reth0.80".to_string()],
                 discard: false,
                 next_table: String::new(),
+                preference: 0,
             },
         ],
         source_nat_rules: vec![
@@ -728,6 +740,7 @@ pub(super) fn static_nat_snapshot() -> ConfigSnapshot {
             next_hops: vec!["203.0.113.254@ge-0/0/1".to_string()],
             discard: false,
             next_table: String::new(),
+            preference: 0,
         }],
         static_nat_rules: vec![StaticNATRuleSnapshot {
             counter_id: 0,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -4198,6 +4198,7 @@ fn poll_descriptor_input_filter_log_path_emits_rt_flow_event() {
         next_hops: vec!["172.16.80.200@reth0.80".to_string()],
         discard: false,
         next_table: String::new(),
+        preference: 0,
     }];
     snapshot.filters = vec![FirewallFilterSnapshot {
         name: "log-input".to_string(),
@@ -7107,6 +7108,7 @@ fn txn_tunnel_marked_missing_neighbor_not_buffered() {
         next_hops: vec!["@gr-0/0/0.0".to_string()],
         discard: false,
         next_table: String::new(),
+        preference: 0,
     });
     // No neighbors: the tunnel's OUTER destination (203.0.113.9 via the
     // 172.16.80.1 default gateway) is unresolved -> MissingNeighbor
@@ -8689,6 +8691,7 @@ fn inbound_nptv6_snapshot(policy: PolicyRuleSnapshot) -> ConfigSnapshot {
         next_hops: vec!["fd35:1940:27:100::102@reth1.0".to_string()],
         discard: false,
         next_table: String::new(),
+        preference: 0,
     });
     snapshot.neighbors.push(NeighborSnapshot {
         interface: "reth1.0".to_string(),

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -140,38 +140,159 @@ pub(in crate::afxdp) struct MirrorRuntimeConfig {
     pub(in crate::afxdp) rate: u32,
 }
 
+/// One resolved equal-cost next-hop candidate for a static route (#2389).
+/// A route with multiple configured next-hops retains every resolved
+/// candidate so the lookup can distribute flows across them and skip a
+/// dead candidate. `next_hop == None` with a non-zero `ifindex` is an
+/// interface-only ("via <if>") candidate.
 #[derive(Clone, Copy, Debug)]
-pub(in crate::afxdp) struct ConnectedRouteV4 {
-    pub(in crate::afxdp) prefix: PrefixV4,
+pub(in crate::afxdp) struct RouteNextHopV4 {
+    pub(in crate::afxdp) next_hop: Option<Ipv4Addr>,
     pub(in crate::afxdp) ifindex: i32,
     pub(in crate::afxdp) tunnel_endpoint_id: u16,
 }
 
 #[derive(Clone, Copy, Debug)]
+pub(in crate::afxdp) struct RouteNextHopV6 {
+    pub(in crate::afxdp) next_hop: Option<Ipv6Addr>,
+    pub(in crate::afxdp) ifindex: i32,
+    pub(in crate::afxdp) tunnel_endpoint_id: u16,
+}
+
+#[derive(Clone, Debug)]
+pub(in crate::afxdp) struct ConnectedRouteV4 {
+    pub(in crate::afxdp) prefix: PrefixV4,
+    pub(in crate::afxdp) ifindex: i32,
+    pub(in crate::afxdp) tunnel_endpoint_id: u16,
+    /// #2388: canonical routing-table name this connected route belongs to
+    /// (e.g. "inet.0" or "tenant-a.inet.0"). The lookup filters connected
+    /// routes by table so a per-VRF / next-table lookup never matches a
+    /// connected prefix owned by a different routing-instance. The
+    /// connected vec holds one entry per interface address, so the
+    /// per-packet linear scan plus a string compare stays cheap.
+    pub(in crate::afxdp) table: String,
+}
+
+#[derive(Clone, Debug)]
 pub(in crate::afxdp) struct ConnectedRouteV6 {
     pub(in crate::afxdp) prefix: PrefixV6,
     pub(in crate::afxdp) ifindex: i32,
     pub(in crate::afxdp) tunnel_endpoint_id: u16,
+    /// #2388: canonical routing-table name. See `ConnectedRouteV4::table`.
+    pub(in crate::afxdp) table: String,
 }
 
 #[derive(Clone, Debug)]
 pub(in crate::afxdp) struct RouteEntryV4 {
     pub(in crate::afxdp) prefix: PrefixV4,
-    pub(in crate::afxdp) ifindex: i32,
-    pub(in crate::afxdp) tunnel_endpoint_id: u16,
-    pub(in crate::afxdp) next_hop: Option<Ipv4Addr>,
+    /// #2389: all resolved equal-cost next-hops. Always non-empty for a
+    /// forwarding (non-discard, non-next-table) route; built from the full
+    /// `RouteSnapshot.next_hops` vector. The legacy single `next_hop` /
+    /// `ifindex` / `tunnel_endpoint_id` accessors below select the FIRST
+    /// candidate so existing call sites are unchanged; the multipath
+    /// selector reads the whole slice.
+    pub(in crate::afxdp) next_hops: Vec<RouteNextHopV4>,
     pub(in crate::afxdp) discard: bool,
     pub(in crate::afxdp) next_table: String,
+    /// #2390: Junos route preference (admin distance; lower = preferred).
+    pub(in crate::afxdp) preference: i32,
 }
 
 #[derive(Clone, Debug)]
 pub(in crate::afxdp) struct RouteEntryV6 {
     pub(in crate::afxdp) prefix: PrefixV6,
-    pub(in crate::afxdp) ifindex: i32,
-    pub(in crate::afxdp) tunnel_endpoint_id: u16,
-    pub(in crate::afxdp) next_hop: Option<Ipv6Addr>,
+    /// #2389: all resolved equal-cost next-hops. See `RouteEntryV4`.
+    pub(in crate::afxdp) next_hops: Vec<RouteNextHopV6>,
     pub(in crate::afxdp) discard: bool,
     pub(in crate::afxdp) next_table: String,
+    /// #2390: Junos route preference (admin distance; lower = preferred).
+    pub(in crate::afxdp) preference: i32,
+}
+
+impl RouteEntryV4 {
+    /// First (primary) next-hop ifindex, or 0 if the route has no resolved
+    /// next-hop (discard / next-table). Preserves the pre-#2389 single
+    /// next-hop accessor for call sites that do not multipath-select.
+    pub(in crate::afxdp) fn ifindex(&self) -> i32 {
+        self.next_hops.first().map(|nh| nh.ifindex).unwrap_or(0)
+    }
+    pub(in crate::afxdp) fn tunnel_endpoint_id(&self) -> u16 {
+        self.next_hops
+            .first()
+            .map(|nh| nh.tunnel_endpoint_id)
+            .unwrap_or(0)
+    }
+    pub(in crate::afxdp) fn next_hop(&self) -> Option<Ipv4Addr> {
+        self.next_hops.first().and_then(|nh| nh.next_hop)
+    }
+}
+
+impl RouteEntryV6 {
+    pub(in crate::afxdp) fn ifindex(&self) -> i32 {
+        self.next_hops.first().map(|nh| nh.ifindex).unwrap_or(0)
+    }
+    pub(in crate::afxdp) fn tunnel_endpoint_id(&self) -> u16 {
+        self.next_hops
+            .first()
+            .map(|nh| nh.tunnel_endpoint_id)
+            .unwrap_or(0)
+    }
+    pub(in crate::afxdp) fn next_hop(&self) -> Option<Ipv6Addr> {
+        self.next_hops.first().and_then(|nh| nh.next_hop)
+    }
+}
+
+#[cfg(test)]
+impl RouteEntryV4 {
+    /// Test-only single-next-hop constructor preserving the pre-#2389
+    /// `{ ifindex, tunnel_endpoint_id, next_hop }` shape so existing FIB
+    /// tests read straightforwardly.
+    pub(in crate::afxdp) fn single(
+        prefix: PrefixV4,
+        ifindex: i32,
+        tunnel_endpoint_id: u16,
+        next_hop: Option<Ipv4Addr>,
+        discard: bool,
+        next_table: String,
+        preference: i32,
+    ) -> Self {
+        RouteEntryV4 {
+            prefix,
+            next_hops: vec![RouteNextHopV4 {
+                next_hop,
+                ifindex,
+                tunnel_endpoint_id,
+            }],
+            discard,
+            next_table,
+            preference,
+        }
+    }
+}
+
+#[cfg(test)]
+impl RouteEntryV6 {
+    pub(in crate::afxdp) fn single(
+        prefix: PrefixV6,
+        ifindex: i32,
+        tunnel_endpoint_id: u16,
+        next_hop: Option<Ipv6Addr>,
+        discard: bool,
+        next_table: String,
+        preference: i32,
+    ) -> Self {
+        RouteEntryV6 {
+            prefix,
+            next_hops: vec![RouteNextHopV6 {
+                next_hop,
+                ifindex,
+                tunnel_endpoint_id,
+            }],
+            discard,
+            next_table,
+            preference,
+        }
+    }
 }
 
 #[allow(dead_code)]

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -39,6 +39,14 @@ pub(crate) struct InterfaceSnapshot {
     pub name: String,
     #[serde(default)]
     pub zone: String,
+    /// Bare routing-instance name this interface belongs to ("" = the
+    /// default instance). Used to scope connected routes rebuilt from
+    /// interface addresses to the owning routing table (#2388). Additive
+    /// via serde default: absent on snapshots from an old Go binary, in
+    /// which case the interface is treated as the default instance (the
+    /// pre-#2388 global behavior).
+    #[serde(rename = "routing_instance", default)]
+    pub routing_instance: String,
     #[serde(rename = "linux_name", default)]
     pub linux_name: String,
     #[serde(rename = "parent_linux_name", default)]
@@ -131,6 +139,15 @@ pub(crate) struct RouteSnapshot {
     pub discard: bool,
     #[serde(rename = "next_table", default)]
     pub next_table: String,
+    /// Junos route preference (administrative distance; lower = more
+    /// preferred, default 5). The FIB tie-breaks two same-prefix routes in
+    /// a table by ascending preference BEFORE insertion order (#2390).
+    /// serde default 0 keeps wire parity with an old Go binary that omits
+    /// the field (0 is the most-preferred value; for the common
+    /// single-route-per-prefix case the tie-break never fires, so behavior
+    /// is unchanged).
+    #[serde(default)]
+    pub preference: i32,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -632,6 +632,7 @@
     "parent_ifindex": 0,
     "parent_linux_name": "",
     "redundancy_group": 0,
+    "routing_instance": "",
     "rx_queues": 0,
     "tunnel": false,
     "unit_count": 0,
@@ -884,6 +885,7 @@
     "family": "",
     "next_hops": [],
     "next_table": "",
+    "preference": 0,
     "table": ""
   },
   "screen_profile_snapshot": {


### PR DESCRIPTION
Closes #2388
Closes #2389
Closes #2390

Three correctness bugs at the Go->Rust route-snapshot boundary, all in the shared route-snapshot serialization and the Rust FIB build/lookup. Shipped as one PR because they share `RouteSnapshot` / `InterfaceSnapshot` / the FIB route types.

## #2388 — connected routes not table-scoped (cross-VRF leak)
Connected prefixes are rebuilt globally from interface addresses, and the lookup scanned them with **no table filter** while static routes were table-scoped. Overlapping connected prefixes across routing-instances could leak across the VRF boundary on a per-VRF / `next-table` lookup.

**Fix:** carry each interface's routing-instance on the wire (`InterfaceSnapshot.routing_instance`), tag every `ConnectedRouteV4/V6` with its canonical table (`<ri>.inet.0`/`inet6.0`, default `inet.0`/`inet6.0`), and filter the connected scan by the resolving table in `lookup_forwarding_resolution_v4/v6`. Gateway→egress inference at FIB-build time stays global on purpose (it answers "which interface reaches this gateway IP", not a destination egress).

## #2389 — ECMP static routes collapsed to the first next-hop
The build kept only `next_hops.first()`: no equal-cost distribution, and a **dead first next-hop blackholed** a route with a healthy alternate.

**Fix:** `RouteEntryV4/V6` now hold `next_hops: Vec<RouteNextHop*>` (every resolved candidate). `select_route_next_hop` prefers a candidate whose neighbor is resolved (dead-NH fallback), then distributes by a fixed-seed hash of the destination IP; the neighbor-warm loop warms every next-hop. **Dead-NH fallback is IN.** Distribution is per-DESTINATION — the 5-tuple flow hash is not plumbed into the resolution layer, so true per-flow ECMP spread is a localized follow-up the retained candidate vector enables (noted in the module README). Legacy single-next-hop accessors return the first candidate.

## #2390 — static route preference (admin distance) dropped
`StaticRoute.Preference` was dropped at the boundary, so two same-prefix routes selected by insertion order.

**Fix:** serialize `RouteSnapshot.preference` (Junos: lower = more preferred, default 5) and use it as the secondary sort key in `sort_routes` (prefix length desc, then preference asc, stable). Same-prefix/same-preference routes keep insertion order.

## Wire format
Added `routing_instance` (InterfaceSnapshot) and `preference` (RouteSnapshot). Both **additive and matched on both sides** (#1961 class): old Rust ignores them (pre-fix behavior), old Go omits them (serde defaults: default instance, preference 0). `protocol_wire_v1.json` regenerated.

## Tests (fail-on-revert)
- Rust (`forwarding/tests.rs`): connected table-scope no-leak; ECMP retains all next-hops + skips a dead first; same-prefix preference tie-break beats insertion order. Each verified RED on revert.
- Go (`routes_fib_metadata_test.go`): preference passthrough, all ECMP next-hops serialized, interface→routing-instance map.

## Gates
- `cargo build --release` clean; `cargo test --release --bin xpf-userspace-dp` green (one pre-existing `worker_queue` concurrency flake, passes in isolation, not in this diff).
- `go build ./...` + `go vet` + `gofmt` clean; `go test ./pkg/dataplane/userspace/...` green.

## Deploy note
Dataplane forwarding change — needs a deploy-boot + iperf no-regression on the cluster, and ideally a VRF/ECMP scenario (lab-bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi