### PR TITLE
#2733: clear the NAT'd reverse companion at val.ReverseKey

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-06-25 — #2733: clear the NAT'd reverse companion at val.ReverseKey
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed a session-map leak on operator session-clear. The
+  filtered clear (CLI `clearFilteredSessions` and gRPC `ClearSessions`)
+  deleted the dual-entry reverse companion at a NAIVE src/dst 5-tuple swap
+  of the forward key. But the companion is INSTALLED keyed on
+  `val.ReverseKey` — the TRANSLATED tuple for NAT'd sessions
+  (`session_store.go` PutClusterSynced* + `manager_ha.go`, gated by
+  `val.IsReverse == 0 && val.ReverseKey.Protocol != 0`). For a NAT'd
+  session the naive swap != val.ReverseKey, so the clear removed the
+  forward entry and LEAKED the real reverse companion. Replaced the naive
+  swap with `val.ReverseKey` (from the iteration value), skipping the
+  reverse delete when `val.ReverseKey.Protocol == 0` (no companion). Both
+  V4 and V6, both call sites. Non-NAT sessions are unchanged
+  (val.ReverseKey == the naive swap). The #2730 error-aggregation
+  (addExceptNotFound) is retained — a benign not-found (already-GC'd
+  companion) still does not inflate Failures. The SNAT DNAT-companion
+  delete was already correct (keyed on val.NATSrcIP/NATSrcPort, matching
+  the install in session_store.go), so it needed no change.
+- **File(s)**: pkg/cli/cli_clear.go, pkg/grpcapi/server_sessions.go,
+  pkg/cli/cli_clear_reversekey_test.go,
+  pkg/grpcapi/clear_sessions_reversekey_test.go,
+  pkg/cli/cli_clear_errors_test.go, pkg/grpcapi/clear_sessions_errors_test.go,
+  _Log.md
+- **Validation**: new fail-on-revert tests assert the clear deletes
+  val.ReverseKey (the translated tuple) and NOT the naive swap — reverting
+  to the naive swap turns them RED (verified: leaks 203.0.113.5, deletes
+  10.0.1.10 instead). Non-NAT no-regression + no-companion-skip tests
+  added. Updated the two existing #2468 reverse-delete-error tests to
+  populate val.ReverseKey so a reverse delete is actually issued.
+  `go build ./...` clean; `go test ./pkg/cli/... ./pkg/grpcapi/...
+  ./pkg/dataplane/...` green; gofmt clean; go vet clean (cli.go:460
+  unreachable-code warning is pre-existing on master, unrelated).
+
 ## 2026-06-25 — #2519: allowlist writeProxyResponderSysctl in fsatomic canary
 
 - **Timestamp**: 2026-06-25

--- a/pkg/cli/cli_clear.go
+++ b/pkg/cli/cli_clear.go
@@ -201,13 +201,17 @@ func (c *CLI) clearFilteredSessions(f sessionFilter) error {
 			return true
 		}
 		v4Keys = append(v4Keys, key)
-		v4RevKeys = append(v4RevKeys, dataplane.SessionKey{
-			Protocol: key.Protocol,
-			SrcIP:    key.DstIP,
-			DstIP:    key.SrcIP,
-			SrcPort:  key.DstPort,
-			DstPort:  key.SrcPort,
-		})
+		// The reverse companion is installed keyed on val.ReverseKey
+		// (the TRANSLATED tuple for NAT'd sessions — session_store.go
+		// PutClusterSyncedV4 / manager_ha.go), NOT a naive src/dst swap
+		// of the forward key. For a non-NAT session the two coincide;
+		// for a NAT'd session a naive swap would leave the real reverse
+		// entry behind (#2733). A zero ReverseKey (Protocol==0) means no
+		// reverse companion was installed (the needsReverse gate), so
+		// skip it.
+		if val.ReverseKey.Protocol != 0 {
+			v4RevKeys = append(v4RevKeys, val.ReverseKey)
+		}
 		if val.Flags&dataplane.SessFlagSNAT != 0 &&
 			val.Flags&dataplane.SessFlagStaticNAT == 0 {
 			snatDNATKeys = append(snatDNATKeys, dataplane.DNATKey{
@@ -244,13 +248,11 @@ func (c *CLI) clearFilteredSessions(f sessionFilter) error {
 			return true
 		}
 		v6Keys = append(v6Keys, key)
-		v6RevKeys = append(v6RevKeys, dataplane.SessionKeyV6{
-			Protocol: key.Protocol,
-			SrcIP:    key.DstIP,
-			DstIP:    key.SrcIP,
-			SrcPort:  key.DstPort,
-			DstPort:  key.SrcPort,
-		})
+		// Reverse companion at the TRANSLATED tuple val.ReverseKey, not a
+		// naive swap (see V4 above, #2733). Zero ReverseKey => no companion.
+		if val.ReverseKey.Protocol != 0 {
+			v6RevKeys = append(v6RevKeys, val.ReverseKey)
+		}
 		if val.Flags&dataplane.SessFlagSNAT != 0 &&
 			val.Flags&dataplane.SessFlagStaticNAT == 0 {
 			snatDNATKeysV6 = append(snatDNATKeysV6, dataplane.DNATKeyV6{

--- a/pkg/cli/cli_clear_errors_test.go
+++ b/pkg/cli/cli_clear_errors_test.go
@@ -64,10 +64,16 @@ func (d *clearFaultCLIDP) DeleteDNATEntry(dataplane.DNATKey) error      { return
 func (d *clearFaultCLIDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error  { return nil }
 func (d *clearFaultCLIDP) ClearAllSessions() (int, int, error)          { return 0, 0, nil }
 
-// one matching TCP session (proto-only filter), optionally SNAT.
+// one matching TCP session (proto-only filter), optionally SNAT. A
+// reverse companion (val.ReverseKey) is always populated with a tuple
+// distinct from the forward key so the clear issues a reverse delete the
+// mock routes to revDelErr (#2733: the clear now keys the reverse delete
+// on val.ReverseKey, skipping it entirely when ReverseKey.Protocol == 0).
 func seedV4(snat bool) map[dataplane.SessionKey]dataplane.SessionValue {
 	key := dataplane.SessionKey{Protocol: 6, SrcPort: 0x3930} // network-order, irrelevant to proto filter
-	val := dataplane.SessionValue{}
+	val := dataplane.SessionValue{
+		ReverseKey: dataplane.SessionKey{Protocol: 6, SrcPort: 0x0050, DstPort: 0x3930},
+	}
 	if snat {
 		val.Flags = dataplane.SessFlagSNAT
 	}

--- a/pkg/cli/cli_clear_reversekey_test.go
+++ b/pkg/cli/cli_clear_reversekey_test.go
@@ -1,0 +1,216 @@
+// #2733: a NAT'd session's reverse companion is installed keyed on the
+// TRANSLATED tuple (val.ReverseKey), not the naive src/dst swap of the
+// forward key. The session clear MUST delete val.ReverseKey, otherwise a
+// NAT'd-session clear removes only the forward entry and leaks the real
+// reverse companion. These tests record the exact keys DeleteSession is
+// called with and assert val.ReverseKey is deleted (and the naive swap is
+// not). Fail-on-revert: restoring the naive-swap key construction deletes
+// the wrong key and the leak assertion goes RED.
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// recordingClearCLIDP records every key passed to DeleteSession /
+// DeleteSessionV6 so a test can assert which reverse-companion key the
+// clear targeted. It embeds *dataplane.Manager to satisfy cliRuntime;
+// only the session methods are overridden.
+type recordingClearCLIDP struct {
+	*dataplane.Manager
+
+	v4Sessions map[dataplane.SessionKey]dataplane.SessionValue
+	v6Sessions map[dataplane.SessionKeyV6]dataplane.SessionValueV6
+
+	deletedV4 []dataplane.SessionKey
+	deletedV6 []dataplane.SessionKeyV6
+
+	// missingV4 keys report not-found on delete, modelling the dataplane
+	// returning ErrKeyNotExist for a key that does not exist (e.g. the
+	// naive swap of a NAT'd session). A delete of any other key succeeds.
+	missingV4 map[dataplane.SessionKey]bool
+}
+
+func (d *recordingClearCLIDP) IsLoaded() bool { return true }
+
+func (d *recordingClearCLIDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for k, v := range d.v4Sessions {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *recordingClearCLIDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for k, v := range d.v6Sessions {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *recordingClearCLIDP) DeleteSession(key dataplane.SessionKey) error {
+	d.deletedV4 = append(d.deletedV4, key)
+	if d.missingV4[key] {
+		return ebpf.ErrKeyNotExist
+	}
+	return nil
+}
+
+func (d *recordingClearCLIDP) DeleteSessionV6(key dataplane.SessionKeyV6) error {
+	d.deletedV6 = append(d.deletedV6, key)
+	return nil
+}
+
+func (d *recordingClearCLIDP) DeleteDNATEntry(dataplane.DNATKey) error     { return nil }
+func (d *recordingClearCLIDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error { return nil }
+func (d *recordingClearCLIDP) ClearAllSessions() (int, int, error)         { return 0, 0, nil }
+
+func newRecordingCLI(t *testing.T, dp cliRuntime) *CLI {
+	t.Helper()
+	return &CLI{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    dp,
+	}
+}
+
+func containsV4(keys []dataplane.SessionKey, want dataplane.SessionKey) bool {
+	for _, k := range keys {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+// A NAT'd (SNAT) session: forward key and val.ReverseKey are the TRUE
+// dual-entry pair. The naive src/dst swap of the forward key is a
+// DIFFERENT, non-existent tuple. The clear must delete val.ReverseKey and
+// must NOT delete the naive swap. Reverting the fix (naive-swap key) makes
+// this RED: val.ReverseKey is left behind (leak) and the naive swap is
+// deleted instead.
+func TestClearFilteredSessionsDeletesTranslatedReverseKey(t *testing.T) {
+	// Forward: 10.0.1.10:1000 -> 8.8.8.8:443  (host-order ports shown,
+	// stored network-order; exact byte values are irrelevant to a
+	// protocol-only filter — only key identity matters).
+	fwd := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 1, 10},
+		DstIP:    [4]byte{8, 8, 8, 8},
+		SrcPort:  0x03e8, // 1000
+		DstPort:  0x01bb, // 443
+	}
+	// TRANSLATED reverse companion (SNAT public src 203.0.113.5:50000):
+	// 8.8.8.8:443 -> 203.0.113.5:50000. This is val.ReverseKey.
+	translatedRev := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{8, 8, 8, 8},
+		DstIP:    [4]byte{203, 0, 113, 5},
+		SrcPort:  0x01bb,
+		DstPort:  0xc350, // 50000
+	}
+	// The naive src/dst swap of the forward key — the WRONG key the buggy
+	// clear computed. It must never be deleted (and does not exist).
+	naiveSwap := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    fwd.DstIP,
+		DstIP:    fwd.SrcIP,
+		SrcPort:  fwd.DstPort,
+		DstPort:  fwd.SrcPort,
+	}
+
+	val := dataplane.SessionValue{
+		Flags:      dataplane.SessFlagSNAT,
+		ReverseKey: translatedRev,
+	}
+
+	dp := &recordingClearCLIDP{
+		Manager:    dataplane.New(),
+		v4Sessions: map[dataplane.SessionKey]dataplane.SessionValue{fwd: val},
+		missingV4:  map[dataplane.SessionKey]bool{naiveSwap: true},
+	}
+	c := newRecordingCLI(t, dp)
+	if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+		t.Fatalf("handleClearSecurity error = %v", err)
+	}
+
+	if !containsV4(dp.deletedV4, fwd) {
+		t.Fatalf("forward key not deleted; deleted=%v", dp.deletedV4)
+	}
+	if !containsV4(dp.deletedV4, translatedRev) {
+		t.Fatalf("translated reverse companion (val.ReverseKey) NOT deleted — leak (#2733); deleted=%v", dp.deletedV4)
+	}
+	if containsV4(dp.deletedV4, naiveSwap) {
+		t.Fatalf("naive src/dst swap was deleted — wrong key (#2733); deleted=%v", dp.deletedV4)
+	}
+}
+
+// Non-NAT no-regression: for a plain session val.ReverseKey IS the naive
+// src/dst swap, so the same companion is deleted as before. Behavior
+// unchanged by the fix.
+func TestClearFilteredSessionsNonNATReverseUnchanged(t *testing.T) {
+	fwd := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 1, 10},
+		DstIP:    [4]byte{10, 0, 2, 20},
+		SrcPort:  0x03e8,
+		DstPort:  0x01bb,
+	}
+	// Non-NAT: ReverseKey == naive swap of the forward tuple.
+	rev := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    fwd.DstIP,
+		DstIP:    fwd.SrcIP,
+		SrcPort:  fwd.DstPort,
+		DstPort:  fwd.SrcPort,
+	}
+	val := dataplane.SessionValue{ReverseKey: rev}
+
+	dp := &recordingClearCLIDP{
+		Manager:    dataplane.New(),
+		v4Sessions: map[dataplane.SessionKey]dataplane.SessionValue{fwd: val},
+	}
+	c := newRecordingCLI(t, dp)
+	if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+		t.Fatalf("handleClearSecurity error = %v", err)
+	}
+	if !containsV4(dp.deletedV4, fwd) {
+		t.Fatalf("forward key not deleted; deleted=%v", dp.deletedV4)
+	}
+	if !containsV4(dp.deletedV4, rev) {
+		t.Fatalf("non-NAT reverse companion not deleted; deleted=%v", dp.deletedV4)
+	}
+}
+
+// A session with no reverse companion (val.ReverseKey.Protocol == 0, the
+// needsReverse gate) must NOT trigger a reverse delete at all — only the
+// forward entry is removed. Reverting to the naive-swap construction would
+// fabricate a bogus reverse key and issue a spurious delete.
+func TestClearFilteredSessionsNoReverseCompanionSkipsReverseDelete(t *testing.T) {
+	fwd := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 1, 10},
+		DstIP:    [4]byte{10, 0, 2, 20},
+		SrcPort:  0x03e8,
+		DstPort:  0x01bb,
+	}
+	val := dataplane.SessionValue{} // ReverseKey zero-valued -> Protocol==0
+
+	dp := &recordingClearCLIDP{
+		Manager:    dataplane.New(),
+		v4Sessions: map[dataplane.SessionKey]dataplane.SessionValue{fwd: val},
+	}
+	c := newRecordingCLI(t, dp)
+	if err := c.handleClearSecurity([]string{"flow", "session", "protocol", "tcp"}); err != nil {
+		t.Fatalf("handleClearSecurity error = %v", err)
+	}
+	if len(dp.deletedV4) != 1 || dp.deletedV4[0] != fwd {
+		t.Fatalf("expected only the forward key deleted, got %v", dp.deletedV4)
+	}
+}

--- a/pkg/grpcapi/clear_sessions_errors_test.go
+++ b/pkg/grpcapi/clear_sessions_errors_test.go
@@ -60,10 +60,16 @@ func (d *clearFaultGRPCDP) DeleteDNATEntry(dataplane.DNATKey) error      { retur
 func (d *clearFaultGRPCDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error  { return nil }
 
 func seedGRPCV4(snat bool) map[dataplane.SessionKey]dataplane.SessionValue {
-	// Distinct src/dst ports so the naive-swap reverse key differs from
-	// the forward key (the mock distinguishes them by key membership).
+	// Distinct src/dst ports so the reverse companion key differs from
+	// the forward key (the mock distinguishes them by key membership). A
+	// reverse companion (val.ReverseKey) is always populated so the clear
+	// issues a reverse delete the mock routes to revDelErr (#2733: the
+	// clear keys the reverse delete on val.ReverseKey and skips it when
+	// ReverseKey.Protocol == 0).
 	key := dataplane.SessionKey{Protocol: 6, SrcPort: 0x3930, DstPort: 0x0050}
-	val := dataplane.SessionValue{}
+	val := dataplane.SessionValue{
+		ReverseKey: dataplane.SessionKey{Protocol: 6, SrcPort: 0x0050, DstPort: 0x3930},
+	}
 	if snat {
 		val.Flags = dataplane.SessFlagSNAT
 	}

--- a/pkg/grpcapi/clear_sessions_reversekey_test.go
+++ b/pkg/grpcapi/clear_sessions_reversekey_test.go
@@ -1,0 +1,167 @@
+// #2733: the gRPC ClearSessions RPC must delete a NAT'd session's reverse
+// companion at the TRANSLATED tuple (val.ReverseKey), not the naive
+// src/dst swap of the forward key. These tests record the exact keys
+// DeleteSession is called with. Fail-on-revert: restoring the naive-swap
+// key construction leaks val.ReverseKey and the assertion goes RED.
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+type recordingClearGRPCDP struct {
+	*dataplane.Manager
+
+	v4Sessions map[dataplane.SessionKey]dataplane.SessionValue
+
+	deletedV4 []dataplane.SessionKey
+	missingV4 map[dataplane.SessionKey]bool
+}
+
+func (d *recordingClearGRPCDP) IsLoaded() bool { return true }
+
+func (d *recordingClearGRPCDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for k, v := range d.v4Sessions {
+		if !fn(k, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *recordingClearGRPCDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *recordingClearGRPCDP) DeleteSession(key dataplane.SessionKey) error {
+	d.deletedV4 = append(d.deletedV4, key)
+	if d.missingV4[key] {
+		return ebpf.ErrKeyNotExist
+	}
+	return nil
+}
+
+func (d *recordingClearGRPCDP) DeleteSessionV6(dataplane.SessionKeyV6) error { return nil }
+func (d *recordingClearGRPCDP) DeleteDNATEntry(dataplane.DNATKey) error      { return nil }
+func (d *recordingClearGRPCDP) DeleteDNATEntryV6(dataplane.DNATKeyV6) error  { return nil }
+
+func recContainsV4(keys []dataplane.SessionKey, want dataplane.SessionKey) bool {
+	for _, k := range keys {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestClearSessionsRPCDeletesTranslatedReverseKey(t *testing.T) {
+	fwd := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 1, 10},
+		DstIP:    [4]byte{8, 8, 8, 8},
+		SrcPort:  0x03e8,
+		DstPort:  0x01bb,
+	}
+	translatedRev := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{8, 8, 8, 8},
+		DstIP:    [4]byte{203, 0, 113, 5},
+		SrcPort:  0x01bb,
+		DstPort:  0xc350,
+	}
+	naiveSwap := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    fwd.DstIP,
+		DstIP:    fwd.SrcIP,
+		SrcPort:  fwd.DstPort,
+		DstPort:  fwd.SrcPort,
+	}
+	val := dataplane.SessionValue{
+		Flags:      dataplane.SessFlagSNAT,
+		ReverseKey: translatedRev,
+	}
+
+	dp := &recordingClearGRPCDP{
+		Manager:    dataplane.New(),
+		v4Sessions: map[dataplane.SessionKey]dataplane.SessionValue{fwd: val},
+		missingV4:  map[dataplane.SessionKey]bool{naiveSwap: true},
+	}
+	s := newClearServer(t, dp)
+	resp, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{Protocol: "tcp"})
+	if err != nil {
+		t.Fatalf("ClearSessions RPC error: %v", err)
+	}
+	if !recContainsV4(dp.deletedV4, fwd) {
+		t.Fatalf("forward key not deleted; deleted=%v", dp.deletedV4)
+	}
+	if !recContainsV4(dp.deletedV4, translatedRev) {
+		t.Fatalf("translated reverse companion (val.ReverseKey) NOT deleted — leak (#2733); deleted=%v", dp.deletedV4)
+	}
+	if recContainsV4(dp.deletedV4, naiveSwap) {
+		t.Fatalf("naive src/dst swap deleted — wrong key (#2733); deleted=%v", dp.deletedV4)
+	}
+	if resp.Failures != 0 {
+		t.Fatalf("Failures=%d summary=%q, want 0", resp.Failures, resp.FailureSummary)
+	}
+	if resp.Ipv4Cleared != 1 {
+		t.Fatalf("Ipv4Cleared=%d, want 1", resp.Ipv4Cleared)
+	}
+}
+
+func TestClearSessionsRPCNonNATReverseUnchanged(t *testing.T) {
+	fwd := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 1, 10},
+		DstIP:    [4]byte{10, 0, 2, 20},
+		SrcPort:  0x03e8,
+		DstPort:  0x01bb,
+	}
+	rev := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    fwd.DstIP,
+		DstIP:    fwd.SrcIP,
+		SrcPort:  fwd.DstPort,
+		DstPort:  fwd.SrcPort,
+	}
+	val := dataplane.SessionValue{ReverseKey: rev}
+
+	dp := &recordingClearGRPCDP{
+		Manager:    dataplane.New(),
+		v4Sessions: map[dataplane.SessionKey]dataplane.SessionValue{fwd: val},
+	}
+	s := newClearServer(t, dp)
+	if _, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{Protocol: "tcp"}); err != nil {
+		t.Fatalf("ClearSessions RPC error: %v", err)
+	}
+	if !recContainsV4(dp.deletedV4, fwd) || !recContainsV4(dp.deletedV4, rev) {
+		t.Fatalf("non-NAT forward/reverse not both deleted; deleted=%v", dp.deletedV4)
+	}
+}
+
+func TestClearSessionsRPCNoReverseCompanionSkipsReverseDelete(t *testing.T) {
+	fwd := dataplane.SessionKey{
+		Protocol: 6,
+		SrcIP:    [4]byte{10, 0, 1, 10},
+		DstIP:    [4]byte{10, 0, 2, 20},
+		SrcPort:  0x03e8,
+		DstPort:  0x01bb,
+	}
+	val := dataplane.SessionValue{} // ReverseKey zero -> Protocol==0
+
+	dp := &recordingClearGRPCDP{
+		Manager:    dataplane.New(),
+		v4Sessions: map[dataplane.SessionKey]dataplane.SessionValue{fwd: val},
+	}
+	s := newClearServer(t, dp)
+	if _, err := s.ClearSessions(context.Background(), &pb.ClearSessionsRequest{Protocol: "tcp"}); err != nil {
+		t.Fatalf("ClearSessions RPC error: %v", err)
+	}
+	if len(dp.deletedV4) != 1 || dp.deletedV4[0] != fwd {
+		t.Fatalf("expected only forward key deleted, got %v", dp.deletedV4)
+	}
+}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -798,13 +798,16 @@ func (s *Server) ClearSessions(ctx context.Context, req *pb.ClearSessionsRequest
 			return true
 		}
 		v4Keys = append(v4Keys, key)
-		v4RevKeys = append(v4RevKeys, dataplane.SessionKey{
-			Protocol: key.Protocol,
-			SrcIP:    key.DstIP,
-			DstIP:    key.SrcIP,
-			SrcPort:  key.DstPort,
-			DstPort:  key.SrcPort,
-		})
+		// The reverse companion is installed keyed on val.ReverseKey
+		// (the TRANSLATED tuple for NAT'd sessions — session_store.go
+		// PutClusterSyncedV4 / manager_ha.go), NOT a naive src/dst swap
+		// of the forward key. For a non-NAT session the two coincide;
+		// for a NAT'd session a naive swap would leave the real reverse
+		// entry behind (#2733). A zero ReverseKey (Protocol==0) means no
+		// reverse companion was installed (the needsReverse gate).
+		if val.ReverseKey.Protocol != 0 {
+			v4RevKeys = append(v4RevKeys, val.ReverseKey)
+		}
 		if val.Flags&dataplane.SessFlagSNAT != 0 &&
 			val.Flags&dataplane.SessFlagStaticNAT == 0 {
 			snatDNATKeys = append(snatDNATKeys, dataplane.DNATKey{
@@ -840,13 +843,11 @@ func (s *Server) ClearSessions(ctx context.Context, req *pb.ClearSessionsRequest
 			return true
 		}
 		v6Keys = append(v6Keys, key)
-		v6RevKeys = append(v6RevKeys, dataplane.SessionKeyV6{
-			Protocol: key.Protocol,
-			SrcIP:    key.DstIP,
-			DstIP:    key.SrcIP,
-			SrcPort:  key.DstPort,
-			DstPort:  key.SrcPort,
-		})
+		// Reverse companion at the TRANSLATED tuple val.ReverseKey, not a
+		// naive swap (see V4 above, #2733). Zero ReverseKey => no companion.
+		if val.ReverseKey.Protocol != 0 {
+			v6RevKeys = append(v6RevKeys, val.ReverseKey)
+		}
 		if val.Flags&dataplane.SessFlagSNAT != 0 &&
 			val.Flags&dataplane.SessFlagStaticNAT == 0 {
 			snatDNATKeysV6 = append(snatDNATKeysV6, dataplane.DNATKeyV6{


### PR DESCRIPTION
Closes #2733

## Problem

Operator session-clear leaked the dual-entry **reverse companion** for NAT'd sessions. The filtered clear (CLI `clearFilteredSessions` and gRPC `ClearSessions`) computed the reverse-delete key as a **naive src/dst 5-tuple swap** of the forward key. But the reverse companion is **installed** keyed on `val.ReverseKey` — the **TRANSLATED** tuple for NAT'd sessions (`session_store.go` `PutClusterSynced{V4,V6}` + `manager_ha.go`), gated by `val.IsReverse == 0 && val.ReverseKey.Protocol != 0`.

For a NAT'd session the naive swap != `val.ReverseKey`, so the clear deleted the forward entry but **left the real reverse companion behind** — a session-map leak. Non-NAT sessions were unaffected (swap == `val.ReverseKey`).

## Fix

Replace the naive swap with `val.ReverseKey` taken from the iteration value (the clear already has the `SessionValue` in hand). Skip the reverse delete when `val.ReverseKey.Protocol == 0` (no companion installed — the `needsReverse` install gate) instead of fabricating a bogus key. Applied to both V4 and V6 in both call sites.

- **Non-NAT no-regression:** `val.ReverseKey` == the naive swap, so the same companion is deleted — behavior unchanged.
- **#2730 error-aggregation retained:** `addExceptNotFound` stays — a benign not-found (already-GC'd companion) still does not inflate `Failures`.
- **DNAT companion:** already correct — keyed on `val.NATSrcIP/NATSrcPort`, matching the `SetDNATEntry` install in `session_store.go`. No change needed.

## Tests

New fail-on-revert tests record the exact keys `DeleteSession` is called with and assert the clear deletes `val.ReverseKey` (translated tuple) and NOT the naive swap — reverting to the naive swap turns them RED (verified: leaks `203.0.113.5`, deletes `10.0.1.10` instead). Added non-NAT no-regression and no-companion-skip cases. Updated the two existing #2468 reverse-delete-error tests to populate `val.ReverseKey` so a reverse delete is actually issued under the new key derivation.

## Validation

- `go build ./...` clean
- `go test ./pkg/cli/... ./pkg/grpcapi/... ./pkg/dataplane/...` green
- gofmt clean; `go vet` clean (the `cli.go:460` unreachable-code warning is pre-existing on master, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi