### PR TITLE
cos: reject out-of-range DSCP/PCP code-points instead of aliasing

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-25 — #2447: reject out-of-range CoS DSCP/PCP code-points instead of aliasing
+
+- **Timestamp**: 2026-06-25
+- **Action**: CoS classifier/rewrite code-points are now domain-validated at
+  commit (DSCP 0..63, PCP 0..7) with a clear operator error, instead of being
+  silently dropped at the Go parse layer and masked `dscp & 0x3f` / clamped
+  `pcp.min(7)` into a DIFFERENT traffic class by the Rust builder (110→46,
+  9→7). Go: `expandCoSCodePointToken` / `collectCoS8021CodePoints` /
+  `collectCoSDSCPRewriteCodePoint` now return errors propagated through
+  `compileClassOfService` (primary, operator-facing). Rust:
+  `build_cos_dscp_queue_table` / `build_cos_ieee8021_queue_table` removed the
+  mask/clamp and fail the snapshot CLOSED
+  (`SnapshotIntegrityError::CosDscpCodePointOutOfRange` /
+  `CosIeee8021CodePointOutOfRange`) as a drift backstop (#2410/#2696/#2713
+  posture). Runtime packet-field masking in `tx/cos_classify.rs` retained
+  (legit: bounds the physically-limited wire field, table now built from
+  validated indices only).
+- **File(s)**: pkg/config/compiler_class_of_service.go,
+  pkg/config/parser_class_of_service_test.go,
+  userspace-dp/src/policy.rs,
+  userspace-dp/src/afxdp/forwarding_build/cos.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  docs/config-schema.md
+
 ## 2026-06-25 — #2519: allowlist writeProxyResponderSysctl in fsatomic canary
 
 - **Timestamp**: 2026-06-25

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1495,3 +1495,36 @@ remote CLI, gRPC, and REST (previously local-CLI-only) via
 (no response field). This makes `show | display set` output — including the
 `deactivate <path>` lines above — round-trippable through every service
 surface.
+
+### #2447 — class-of-service DSCP/802.1p code-points are domain-validated at commit
+
+`class-of-service` classifier (and DSCP rewrite-rule) code-points are now
+range-checked at commit, not silently aliased into a different traffic class.
+
+- **DSCP** (`classifiers dscp ...`, `rewrite-rules dscp ...`) — domain `0..63`
+  (the 6-bit DiffServ field). A symbolic alias (`be`, `ef`, `af11`, `cs6`, …)
+  resolves through `coSDSCPValues`; a numeric token outside `0..63` is a
+  **commit error** (`compileClassOfService`, `expandCoSCodePointToken` in
+  `pkg/config/compiler_class_of_service.go`).
+- **802.1p / IEEE 802.1** (`classifiers ieee-802.1 ...`) — domain `0..7` (the
+  3-bit PCP field). A numeric token outside `0..7` is a **commit error**
+  (`collectCoS8021CodePoints`).
+
+Before #2447 these were **silently dropped** at the Go parse layer (no commit
+error) and, on a version/snapshot-drifted helper, the dataplane builder masked
+`dscp & 0x3f` / clamped `pcp.min(7)` — so a configured DSCP 110 installed a
+classifier for DSCP 46 (a DIFFERENT class) and PCP 9 installed one for PCP 7,
+with no failure surfaced. A non-numeric, non-alias token (a typo) is still
+skipped (not an error), preserving Junos-compatibility for unknown spellings.
+
+The Rust forwarding-build is the second trust boundary: an out-of-range
+code-point reaching `build_cos_dscp_queue_table` / `build_cos_ieee8021_queue_table`
+fails the snapshot CLOSED (`SnapshotIntegrityError::CosDscpCodePointOutOfRange`
+/ `CosIeee8021CodePointOutOfRange`) — the apply preflight keeps the previous
+live CoS state rather than building a classifier for the wrong class. This is
+the same fail-closed posture as #2410/#2696/#2713 (queue id, scheduler-map
+class, interface MTU). Runtime packet-field masking is retained where it
+belongs: `resolve_cos_dscp_classifier_queue_id` / `resolve_cos_ieee8021_classifier_queue_id`
+(`tx/cos_classify.rs`) still mask the LIVE packet's DSCP/PCP to index the
+fixed-size table — the table is now built only from validated indices, so the
+mask just bounds the physically-limited wire field, it no longer aliases config.

--- a/pkg/config/compiler_class_of_service.go
+++ b/pkg/config/compiler_class_of_service.go
@@ -138,7 +138,10 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					if lossPriority == "" {
 						lossPriority = nodeVal(lpNode)
 					}
-					codePoints := collectCoSDSCPCodePoints(lpNode)
+					codePoints, err := collectCoSDSCPCodePoints(lpNode)
+					if err != nil {
+						return fmt.Errorf("class-of-service classifiers dscp %q: %w", classifier.Name, err)
+					}
 					if len(codePoints) == 0 {
 						continue
 					}
@@ -171,7 +174,10 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					if lossPriority == "" {
 						lossPriority = nodeVal(lpNode)
 					}
-					codePoints := collectCoS8021CodePoints(lpNode)
+					codePoints, err := collectCoS8021CodePoints(lpNode)
+					if err != nil {
+						return fmt.Errorf("class-of-service classifiers ieee-802.1 %q: %w", classifier.Name, err)
+					}
 					if len(codePoints) == 0 {
 						continue
 					}
@@ -207,7 +213,10 @@ func compileClassOfService(node *Node, cos *ClassOfServiceConfig) error {
 					if lossPriority == "" {
 						lossPriority = nodeVal(lpNode)
 					}
-					codePoint, ok := collectCoSDSCPRewriteCodePoint(lpNode)
+					codePoint, ok, err := collectCoSDSCPRewriteCodePoint(lpNode)
+					if err != nil {
+						return fmt.Errorf("class-of-service rewrite-rules dscp %q: %w", rewriteRule.Name, err)
+					}
 					if !ok {
 						continue
 					}
@@ -514,21 +523,28 @@ func parseCoSTransmitRate(node *Node) (uint64, bool) {
 	return rate, exact
 }
 
-func collectCoSDSCPCodePoints(node *Node) []uint8 {
+func collectCoSDSCPCodePoints(node *Node) ([]uint8, error) {
 	var values []uint8
 	seen := make(map[uint8]struct{})
-	add := func(raw string) {
-		for _, value := range expandCoSCodePointToken(raw) {
+	add := func(raw string) error {
+		expanded, err := expandCoSCodePointToken(raw)
+		if err != nil {
+			return err
+		}
+		for _, value := range expanded {
 			if _, ok := seen[value]; ok {
 				continue
 			}
 			seen[value] = struct{}{}
 			values = append(values, value)
 		}
+		return nil
 	}
 	for _, child := range node.FindChildren("code-points") {
 		for _, raw := range child.Keys[1:] {
-			add(raw)
+			if err := add(raw); err != nil {
+				return nil, err
+			}
 		}
 	}
 	// Inline leaf spelling (#1809): "loss-priority low code-points ef;"
@@ -537,36 +553,53 @@ func collectCoSDSCPCodePoints(node *Node) []uint8 {
 	for i := 2; i < len(node.Keys); i++ {
 		if node.Keys[i] == "code-points" {
 			for _, raw := range node.Keys[i+1:] {
-				add(raw)
+				if err := add(raw); err != nil {
+					return nil, err
+				}
 			}
 			break
 		}
 	}
-	return values
+	return values, nil
 }
 
-func collectCoS8021CodePoints(node *Node) []uint8 {
+func collectCoS8021CodePoints(node *Node) ([]uint8, error) {
 	var values []uint8
 	seen := make(map[uint8]struct{})
-	add := func(raw string) {
+	// #2447: an 802.1p code-point is the 3-bit PCP field, domain 0..7. A
+	// numeric token outside that range is REJECTED at commit rather than
+	// silently dropped (pre-fix) or clamped to 7 by the dataplane builder —
+	// a clamp would install the classifier for a DIFFERENT traffic class.
+	add := func(raw string) error {
 		raw = strings.TrimSpace(strings.ToLower(raw))
 		if raw == "" {
-			return
+			return nil
 		}
 		v, err := strconv.Atoi(raw)
-		if err != nil || v < 0 || v > 7 {
-			return
+		if err != nil {
+			// Non-numeric token: 802.1p has no symbolic aliases (unlike
+			// DSCP). Preserve the pre-fix skip for anything that is not a
+			// number so we do not reject Junos-compatibility spellings.
+			return nil
+		}
+		if v < 0 || v > 7 {
+			return fmt.Errorf(
+				"class-of-service ieee-802.1 classifier code-point %d is out of range (must be 0..7)",
+				v)
 		}
 		value := uint8(v)
 		if _, ok := seen[value]; ok {
-			return
+			return nil
 		}
 		seen[value] = struct{}{}
 		values = append(values, value)
+		return nil
 	}
 	for _, child := range node.FindChildren("code-points") {
 		for _, raw := range child.Keys[1:] {
-			add(raw)
+			if err := add(raw); err != nil {
+				return nil, err
+			}
 		}
 	}
 	// Inline leaf spelling (#1809): "loss-priority low code-points 3;"
@@ -575,45 +608,72 @@ func collectCoS8021CodePoints(node *Node) []uint8 {
 	for i := 2; i < len(node.Keys); i++ {
 		if node.Keys[i] == "code-points" {
 			for _, raw := range node.Keys[i+1:] {
-				add(raw)
+				if err := add(raw); err != nil {
+					return nil, err
+				}
 			}
 			break
 		}
 	}
-	return values
+	return values, nil
 }
 
-func collectCoSDSCPRewriteCodePoint(node *Node) (uint8, bool) {
+func collectCoSDSCPRewriteCodePoint(node *Node) (uint8, bool, error) {
 	for _, child := range node.FindChildren("code-point") {
 		if len(child.Keys) < 2 {
 			continue
 		}
-		if values := expandCoSCodePointToken(child.Keys[1]); len(values) > 0 {
-			return values[0], true
+		values, err := expandCoSCodePointToken(child.Keys[1])
+		if err != nil {
+			return 0, false, err
+		}
+		if len(values) > 0 {
+			return values[0], true, nil
 		}
 	}
 	for _, child := range node.FindChildren("code-points") {
 		for _, raw := range child.Keys[1:] {
-			if values := expandCoSCodePointToken(raw); len(values) > 0 {
-				return values[0], true
+			values, err := expandCoSCodePointToken(raw)
+			if err != nil {
+				return 0, false, err
+			}
+			if len(values) > 0 {
+				return values[0], true, nil
 			}
 		}
 	}
-	return 0, false
+	return 0, false, nil
 }
 
-func expandCoSCodePointToken(raw string) []uint8 {
+// expandCoSCodePointToken resolves a DSCP code-point token (a symbolic
+// alias such as `ef`/`af11`/`cs6` or a numeric value) to its 0..63 DSCP
+// value(s).
+//
+// #2447: a NUMERIC token outside the 6-bit DSCP domain (0..63) is an
+// out-of-range error, REJECTED at commit. The pre-fix code silently
+// returned nil (dropping the entry), and the dataplane builder masked
+// `dscp & 0x3f` — so a configured DSCP 110 silently installed a
+// classifier for DSCP 46, a DIFFERENT traffic class, with no commit
+// error. A non-numeric, non-alias token (a typo) is NOT an error here —
+// it returns no values (the entry is skipped), preserving the pre-fix
+// Junos-compatibility behavior for unknown symbolic spellings.
+func expandCoSCodePointToken(raw string) ([]uint8, error) {
 	raw = strings.TrimSpace(strings.ToLower(raw))
 	if raw == "" {
-		return nil
+		return nil, nil
 	}
 	if value, ok := coSDSCPValues[raw]; ok {
-		return []uint8{value}
+		return []uint8{value}, nil
 	}
-	if v, err := strconv.Atoi(raw); err == nil && v >= 0 && v <= 63 {
-		return []uint8{uint8(v)}
+	if v, err := strconv.Atoi(raw); err == nil {
+		if v < 0 || v > 63 {
+			return nil, fmt.Errorf(
+				"class-of-service dscp code-point %d is out of range (must be 0..63)",
+				v)
+		}
+		return []uint8{uint8(v)}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 var coSDSCPValues = map[string]uint8{

--- a/pkg/config/parser_class_of_service_test.go
+++ b/pkg/config/parser_class_of_service_test.go
@@ -1466,3 +1466,143 @@ func TestCompileClassOfServiceRejectsThreeFCsOnOneQueue(t *testing.T) {
 		t.Errorf("error must reference queue 5, got: %s", err.Error())
 	}
 }
+
+// TestCompileClassOfServiceRejectsOutOfRangeDSCPCodePoint proves the #2447
+// fix: a DSCP code-point outside the 6-bit domain (0..63) is REJECTED at
+// commit with a clear operator error, rather than being silently dropped at
+// the Go parse layer (pre-fix) or masked `dscp & 0x3f` into a different
+// traffic class by the dataplane builder (110 → 46).
+//
+// Fail-on-revert: restore the pre-fix `v >= 0 && v <= 63` silent-skip in
+// expandCoSCodePointToken (returning nil instead of an error) and this test
+// goes RED — the bad config compiles and the classifier installs with the
+// out-of-range entry dropped (no commit error).
+func TestCompileClassOfServiceRejectsOutOfRangeDSCPCodePoint(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service classifiers dscp wan-classifier forwarding-class best-effort loss-priority low code-points 110",
+		"set system dataplane-type userspace",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected compile to reject DSCP code-point 110, got nil error")
+	}
+	if !strings.Contains(err.Error(), "110") || !strings.Contains(err.Error(), "0..63") {
+		t.Errorf("error must name the out-of-range value 110 and the 0..63 range, got: %s", err.Error())
+	}
+}
+
+// TestCompileClassOfServiceRejectsOutOfRangePCPCodePoint proves the #2447
+// fix for the 802.1p path: a code-point outside the 3-bit PCP domain (0..7)
+// is REJECTED at commit rather than silently dropped (pre-fix) or clamped
+// `pcp.min(7)` into a different traffic class by the dataplane builder (9 → 7).
+func TestCompileClassOfServiceRejectsOutOfRangePCPCodePoint(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service classifiers ieee-802.1 wan-pcp forwarding-class best-effort loss-priority low code-points 9",
+		"set system dataplane-type userspace",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected compile to reject 802.1p code-point 9, got nil error")
+	}
+	if !strings.Contains(err.Error(), "9") || !strings.Contains(err.Error(), "0..7") {
+		t.Errorf("error must name the out-of-range value 9 and the 0..7 range, got: %s", err.Error())
+	}
+}
+
+// TestCompileClassOfServiceRejectsOutOfRangeRewriteCodePoint proves a DSCP
+// rewrite-rule code-point > 63 is rejected (same domain, same builder hazard).
+func TestCompileClassOfServiceRejectsOutOfRangeRewriteCodePoint(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service rewrite-rules dscp wan-rewrite forwarding-class best-effort loss-priority low code-point 200",
+		"set system dataplane-type userspace",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected compile to reject rewrite code-point 200, got nil error")
+	}
+	if !strings.Contains(err.Error(), "200") || !strings.Contains(err.Error(), "0..63") {
+		t.Errorf("error must name the out-of-range value 200 and the 0..63 range, got: %s", err.Error())
+	}
+}
+
+// TestCompileClassOfServiceAcceptsBoundaryCodePoints confirms the valid
+// domain still compiles unchanged: DSCP 63 (max) and PCP 7 (max), plus the
+// `ef` alias (46), all build a classifier entry with the expected value.
+func TestCompileClassOfServiceAcceptsBoundaryCodePoints(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set class-of-service forwarding-classes queue 0 best-effort",
+		"set class-of-service classifiers dscp wan-classifier forwarding-class best-effort loss-priority low code-points 63",
+		"set class-of-service classifiers dscp wan-classifier forwarding-class best-effort loss-priority high code-points ef",
+		"set class-of-service classifiers ieee-802.1 wan-pcp forwarding-class best-effort loss-priority low code-points 7",
+		"set system dataplane-type userspace",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile of in-range boundary code-points: %v", err)
+	}
+	dscp := cfg.ClassOfService.DSCPClassifiers["wan-classifier"]
+	if dscp == nil {
+		t.Fatal("expected wan-classifier")
+	}
+	var sawDSCP63, sawDSCP46 bool
+	for _, e := range dscp.Entries {
+		for _, v := range e.DSCPValues {
+			if v == 63 {
+				sawDSCP63 = true
+			}
+			if v == 46 {
+				sawDSCP46 = true
+			}
+		}
+	}
+	if !sawDSCP63 || !sawDSCP46 {
+		t.Fatalf("expected DSCP 63 and 46 (ef) entries, got %#v", dscp.Entries)
+	}
+	pcp := cfg.ClassOfService.IEEE8021Classifiers["wan-pcp"]
+	if pcp == nil || len(pcp.Entries) != 1 || len(pcp.Entries[0].CodePoints) != 1 || pcp.Entries[0].CodePoints[0] != 7 {
+		t.Fatalf("expected wan-pcp code-point 7, got %#v", pcp)
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding_build/cos.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/cos.rs
@@ -32,35 +32,61 @@ pub(super) struct ClassifierTables<'a> {
 fn build_cos_dscp_queue_table(
     classifier_name: &str,
     classifiers: &FastMap<String, CoSDSCPClassifierConfig>,
-) -> [u8; 64] {
+) -> Result<[u8; 64], crate::policy::SnapshotIntegrityError> {
     let mut table = [u8::MAX; 64];
     if classifier_name.is_empty() {
-        return table;
+        return Ok(table);
     }
     if let Some(classifier) = classifiers.get(classifier_name) {
         for (&dscp, &queue_id) in &classifier.queue_by_dscp {
-            let idx = usize::from(dscp & 0x3f);
-            table[idx] = queue_id;
+            // #2447: a code-point outside the 6-bit DSCP domain fails the
+            // snapshot CLOSED. The pre-fix `dscp & 0x3f` masked an
+            // out-of-range value into a valid index, silently installing the
+            // classifier for a DIFFERENT traffic class (110 → 46). The Go
+            // commit gate rejects these first; this guards version/snapshot
+            // drift. An in-range value indexes the table unchanged.
+            let idx = usize::from(dscp);
+            let Some(slot) = table.get_mut(idx) else {
+                return Err(
+                    crate::policy::SnapshotIntegrityError::CosDscpCodePointOutOfRange {
+                        classifier: classifier_name.to_string(),
+                        dscp,
+                    },
+                );
+            };
+            *slot = queue_id;
         }
     }
-    table
+    Ok(table)
 }
 
 fn build_cos_ieee8021_queue_table(
     classifier_name: &str,
     classifiers: &FastMap<String, CoSIEEE8021ClassifierConfig>,
-) -> [u8; 8] {
+) -> Result<[u8; 8], crate::policy::SnapshotIntegrityError> {
     let mut table = [u8::MAX; 8];
     if classifier_name.is_empty() {
-        return table;
+        return Ok(table);
     }
     if let Some(classifier) = classifiers.get(classifier_name) {
         for (&pcp, &queue_id) in &classifier.queue_by_pcp {
-            let idx = usize::from(pcp.min(7));
-            table[idx] = queue_id;
+            // #2447: a code-point outside the 3-bit PCP domain fails the
+            // snapshot CLOSED. The pre-fix `pcp.min(7)` clamped an
+            // out-of-range value into a valid index, silently installing the
+            // classifier for a DIFFERENT traffic class (9 → 7).
+            let idx = usize::from(pcp);
+            let Some(slot) = table.get_mut(idx) else {
+                return Err(
+                    crate::policy::SnapshotIntegrityError::CosIeee8021CodePointOutOfRange {
+                        classifier: classifier_name.to_string(),
+                        pcp,
+                    },
+                );
+            };
+            *slot = queue_id;
         }
     }
-    table
+    Ok(table)
 }
 
 /// Default burst size when interface or scheduler did not specify
@@ -409,9 +435,11 @@ pub(super) fn build_cos_iface_config(
         return Ok(None);
     }
     let dscp_queue_by_dscp =
-        build_cos_dscp_queue_table(&iface.cos_dscp_classifier, &tables.dscp_classifiers);
-    let ieee8021_queue_by_pcp =
-        build_cos_ieee8021_queue_table(&iface.cos_ieee8021_classifier, &tables.ieee8021_classifiers);
+        build_cos_dscp_queue_table(&iface.cos_dscp_classifier, &tables.dscp_classifiers)?;
+    let ieee8021_queue_by_pcp = build_cos_ieee8021_queue_table(
+        &iface.cos_ieee8021_classifier,
+        &tables.ieee8021_classifiers,
+    )?;
 
     if queues.is_empty() {
         queues.push(CoSQueueConfig {

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1436,6 +1436,142 @@ fn cos_forwarding_class_in_range_queue_builds_and_empty_name_skipped() {
     assert_eq!(cfg.queue_by_forwarding_class.get("voice").copied(), Some(5));
 }
 
+/// #2447: a DSCP classifier code-point outside the 6-bit DSCP domain
+/// (0..=63) fails the snapshot CLOSED via `CosDscpCodePointOutOfRange`. The
+/// pre-fix builder masked the index `dscp & 0x3f`, so 110 silently built the
+/// classifier for DSCP 46 — a DIFFERENT traffic class. fail-on-revert:
+/// restore `usize::from(dscp & 0x3f)` and `table[idx] = queue_id` and the
+/// build succeeds (installing the aliased entry), making this `expect_err`
+/// red.
+#[test]
+fn cos_dscp_classifier_out_of_range_code_point_fails_closed() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 80,
+            cos_shaping_rate_bytes_per_sec: 1,
+            cos_dscp_classifier: "wan".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+                name: "wan".into(),
+                entries: vec![CoSDSCPClassifierEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    loss_priority: "low".into(),
+                    dscp_values: vec![110], // > 63 — pre-fix masked to 46
+                }],
+            }],
+            ieee8021_classifiers: vec![],
+            dscp_rewrite_rules: vec![],
+            schedulers: vec![],
+            scheduler_maps: vec![],
+        }),
+        ..Default::default()
+    };
+    let err = super::cos::build_cos_state(&snapshot)
+        .expect_err("an out-of-range DSCP code-point must fail closed, not alias into queue 46");
+    match err {
+        crate::policy::SnapshotIntegrityError::CosDscpCodePointOutOfRange { classifier, dscp } => {
+            assert_eq!(classifier, "wan");
+            assert_eq!(dscp, 110);
+        }
+        other => panic!("expected CosDscpCodePointOutOfRange, got {other:?}"),
+    }
+}
+
+/// #2447: an 802.1p classifier code-point outside the 3-bit PCP domain
+/// (0..=7) fails closed via `CosIeee8021CodePointOutOfRange` (pre-fix
+/// `pcp.min(7)` clamped 9 into queue 7).
+#[test]
+fn cos_ieee8021_classifier_out_of_range_code_point_fails_closed() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 81,
+            cos_shaping_rate_bytes_per_sec: 1,
+            cos_ieee8021_classifier: "wan-pcp".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            dscp_classifiers: vec![],
+            ieee8021_classifiers: vec![CoSIEEE8021ClassifierSnapshot {
+                name: "wan-pcp".into(),
+                entries: vec![CoSIEEE8021ClassifierEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    loss_priority: "low".into(),
+                    code_points: vec![9], // > 7 — pre-fix clamped to 7
+                }],
+            }],
+            dscp_rewrite_rules: vec![],
+            schedulers: vec![],
+            scheduler_maps: vec![],
+        }),
+        ..Default::default()
+    };
+    let err = super::cos::build_cos_state(&snapshot)
+        .expect_err("an out-of-range PCP code-point must fail closed, not clamp into queue 7");
+    match err {
+        crate::policy::SnapshotIntegrityError::CosIeee8021CodePointOutOfRange { classifier, pcp } => {
+            assert_eq!(classifier, "wan-pcp");
+            assert_eq!(pcp, 9);
+        }
+        other => panic!("expected CosIeee8021CodePointOutOfRange, got {other:?}"),
+    }
+}
+
+/// #2447 anti-over-reject: in-range boundary code-points (DSCP 63, PCP 7)
+/// still build the classifier table at the expected indices.
+#[test]
+fn cos_classifier_in_range_boundary_code_points_build() {
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            ifindex: 82,
+            cos_shaping_rate_bytes_per_sec: 1,
+            cos_dscp_classifier: "wan".into(),
+            cos_ieee8021_classifier: "wan-pcp".into(),
+            ..Default::default()
+        }],
+        class_of_service: Some(ClassOfServiceSnapshot {
+            forwarding_classes: vec![CoSForwardingClassSnapshot {
+                name: "best-effort".into(),
+                queue: 0,
+            }],
+            dscp_classifiers: vec![CoSDSCPClassifierSnapshot {
+                name: "wan".into(),
+                entries: vec![CoSDSCPClassifierEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    loss_priority: "low".into(),
+                    dscp_values: vec![63], // max in-range
+                }],
+            }],
+            ieee8021_classifiers: vec![CoSIEEE8021ClassifierSnapshot {
+                name: "wan-pcp".into(),
+                entries: vec![CoSIEEE8021ClassifierEntrySnapshot {
+                    forwarding_class: "best-effort".into(),
+                    loss_priority: "low".into(),
+                    code_points: vec![7], // max in-range
+                }],
+            }],
+            dscp_rewrite_rules: vec![],
+            schedulers: vec![],
+            scheduler_maps: vec![],
+        }),
+        ..Default::default()
+    };
+    let state = super::cos::build_cos_state(&snapshot)
+        .expect("in-range boundary code-points must build");
+    let iface = state.interfaces.get(&82).expect("iface 82 cos");
+    assert_eq!(iface.dscp_queue_by_dscp[63], 0, "DSCP 63 must map to queue 0");
+    assert_eq!(iface.ieee8021_queue_by_pcp[7], 0, "PCP 7 must map to queue 0");
+}
+
 /// #2409: an interface address that does not parse as an `IpNet` fails the
 /// snapshot CLOSED via `InterfaceAddressUnparseable`. fail-on-revert:
 /// restoring the `else { continue; }` silently drops the address (losing

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -174,6 +174,22 @@ pub(crate) enum SnapshotIntegrityError {
         scheduler_map: String,
         forwarding_class: String,
     },
+    /// #2447: a CoS DSCP classifier entry carried a code-point outside the
+    /// 6-bit DSCP domain (0..=63). The pre-fix builder masked the index with
+    /// `dscp & 0x3f`, so a value of 110 silently installed the classifier for
+    /// DSCP 46 — a DIFFERENT traffic class — with no apply failure. The Go
+    /// commit-time gate (`expandCoSCodePointToken`, #2447) is the primary
+    /// defense; this is the helper-boundary backstop against version/snapshot
+    /// drift, consistent with the #2410/#2696/#2713 fail-closed family. Fail
+    /// the snapshot closed (the preflight keeps the previous live CoS state)
+    /// rather than building a classifier for a different class than configured.
+    CosDscpCodePointOutOfRange { classifier: String, dscp: u8 },
+    /// #2447: a CoS IEEE 802.1p classifier entry carried a code-point outside
+    /// the 3-bit PCP domain (0..=7). The pre-fix builder clamped the index with
+    /// `pcp.min(7)`, so a value of 9 silently installed the classifier for PCP
+    /// 7 — a DIFFERENT traffic class — with no apply failure. Same fail-closed
+    /// rationale as `CosDscpCodePointOutOfRange`.
+    CosIeee8021CodePointOutOfRange { classifier: String, pcp: u8 },
 }
 
 impl std::fmt::Display for SnapshotIntegrityError {
@@ -262,6 +278,16 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "cos scheduler-map {:?} references forwarding-class {:?} that is not in the class-to-queue table — refusing to partially install the scheduler (some queues silently missing)",
                 scheduler_map, forwarding_class
+            ),
+            Self::CosDscpCodePointOutOfRange { classifier, dscp } => write!(
+                f,
+                "cos dscp classifier {:?} has code-point {} outside the 0..=63 DSCP range — refusing to mask it with & 0x3f (which would install the classifier for a different traffic class)",
+                classifier, dscp
+            ),
+            Self::CosIeee8021CodePointOutOfRange { classifier, pcp } => write!(
+                f,
+                "cos ieee-802.1 classifier {:?} has code-point {} outside the 0..=7 PCP range — refusing to clamp it with .min(7) (which would install the classifier for a different traffic class)",
+                classifier, pcp
             ),
         }
     }


### PR DESCRIPTION
Closes #2447

## The bug
The CoS classifier table builders silently ALIASED out-of-domain code-points into valid queues at build time:
- DSCP masked `dscp & 0x3f` (`build_cos_dscp_queue_table`) → 110 installed a classifier for DSCP 46
- PCP clamped `pcp.min(7)` (`build_cos_ieee8021_queue_table`) → 9 installed one for PCP 7

A configured out-of-range code-point installed a classifier for a **different traffic class with no commit error**. The Go parse layer compounded this by silently **dropping** out-of-range numeric tokens (no warn, no error) before they ever reached the typed config.

## The fix — posture (commit-reject primary + Rust fail-closed backstop)
Mirrors the established #2410/#2696/#2713 CoS posture: Go commit-time gate is the primary operator-facing defense, the Rust forwarding-build snapshot boundary is the fail-closed drift backstop. Justification: the issue states the value should be **rejected** ("with no commit error" is the bug), so unlike #2704 (which kept undefined-class as a warn) this promotes to a hard commit error per the issue directive.

**Go (primary, operator-facing error)** — `pkg/config/compiler_class_of_service.go`:
`expandCoSCodePointToken` (DSCP 0..63), `collectCoS8021CodePoints` (PCP 0..7) and `collectCoSDSCPRewriteCodePoint` now return an error for a numeric token outside its domain, propagated through `compileClassOfService` → commit is REJECTED with a message naming the bad value and the valid range. A symbolic DSCP alias (`be`/`ef`/`af11`/`cs6`/…) still resolves; a non-numeric, non-alias token (a typo) is still skipped, not promoted to an error (preserves Junos-compat for unknown spellings).

**Rust (drift backstop, fail-closed)** — `userspace-dp/src/afxdp/forwarding_build/cos.rs` + `policy.rs`:
the two builders drop the mask/clamp and fail the snapshot CLOSED via new `SnapshotIntegrityError::CosDscpCodePointOutOfRange` / `CosIeee8021CodePointOutOfRange` when a code-point would index outside the fixed-size table. The apply preflight keeps the previous live CoS state rather than building a classifier for the wrong class. A gate-passing config never reaches this arm — it guards version/snapshot drift. Runtime packet-field masking in `tx/cos_classify.rs` (`resolve_cos_dscp_classifier_queue_id` / `resolve_cos_ieee8021_classifier_queue_id`) is **retained**: the table is now built only from validated indices, so masking the LIVE packet's DSCP/PCP just bounds the physically-limited wire field into the table — it no longer aliases config.

## Tests (fail-on-revert)
- **Go**: rejects DSCP 110 / PCP 9 / rewrite 200 at commit; accepts boundary 63 / 7 / `ef`. Verified: restoring the `v >= 0 && v <= 63` silent-skip → DSCP test RED (bad config compiles, no error).
- **Rust**: `cos_dscp_classifier_out_of_range_code_point_fails_closed` / `cos_ieee8021_classifier_out_of_range_code_point_fails_closed` expect the snapshot error; `cos_classifier_in_range_boundary_code_points_build` confirms 63/7 build at the expected table indices. Verified: restoring `& 0x3f` / `.min(7)` → both fail-closed tests RED.

## Gates
- `go build ./...` clean; gofmt + go vet clean on touched Go
- `go test ./pkg/config/...` and `./pkg/dataplane/userspace/...` green
- `cargo build --release` clean; `cargo test --release --bin xpf-userspace-dp forwarding_build` / `cos` green

Docs: `docs/config-schema.md` gains a #2447 section (DSCP 0..63 / PCP 0..7 commit-validated domains + the two-trust-boundary posture). `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)