### PR TITLE
#2596: strip trailing dot before the 253-octet hostname cap

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-06-25 — #2596: strip trailing dot before the 253-octet hostname cap
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed an ordering bug in `isPlausibleHostname`
+  (`pkg/config/compiler_ipsec.go`). The `len(s) > 253` presentation-form
+  length cap ran BEFORE the single trailing-dot strip (added by #2455), so
+  a maximal 253-char FQDN written in absolute form (254 bytes including the
+  root `.`) was wrongly rejected. Per RFC 1035 §3.1 the trailing root dot
+  does not count toward the 253-char presentation limit. Moved the strip to
+  precede the cap; the cap now applies to the stripped name. All other
+  validation (empty-label, hyphen, label-length, contains-a-dot) is
+  preserved. Added `TestIsUsableIPsecEndpointMaxLength` — a fail-on-revert
+  boundary table (253-char valid, 253-char+dot valid, 254-char invalid,
+  254-char+dot invalid, empty, bare-dot). Verified RED on revert (the
+  253-char+trailing-dot case returns false instead of true), GREEN after
+  restore.
+- **File(s)**: pkg/config/compiler_ipsec.go,
+  pkg/config/compiler_ipsec_gateway_ref_test.go, _Log.md
+
 ## 2026-06-25 — #2733: clear the NAT'd reverse companion at val.ReverseKey
 
 - **Timestamp**: 2026-06-25

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -496,10 +496,7 @@ func IsUsableIPsecEndpoint(s string) bool {
 // a proper `security ike gateway <name> { address <ip>; }` (or
 // `dynamic { hostname <fqdn>; }`) instead.
 func isPlausibleHostname(s string) bool {
-	if len(s) == 0 || len(s) > 253 {
-		return false
-	}
-	if !strings.Contains(s, ".") {
+	if len(s) == 0 {
 		return false
 	}
 	// A single trailing dot is the absolute-root marker of a fully
@@ -510,11 +507,23 @@ func isPlausibleHostname(s string) bool {
 	// has a leading/interior empty label is NOT made valid by this: after
 	// stripping one trailing dot the scan still rejects "", a trailing
 	// dot, or any "..".
+	//
+	// The strip MUST precede the 253-octet presentation cap: RFC 1035 §3.1
+	// counts only the labels (max 253 chars), and the absolute-root dot
+	// does not consume part of that budget. A maximal 253-char FQDN written
+	// in absolute form is 254 bytes including the trailing "." and is valid
+	// (#2596) — capping the raw byte length first wrongly rejected it.
 	if strings.HasSuffix(s, ".") {
 		s = s[:len(s)-1]
 		if len(s) == 0 {
 			return false // name was just "."
 		}
+	}
+	if len(s) > 253 {
+		return false
+	}
+	if !strings.Contains(s, ".") {
+		return false
 	}
 	labelLen := 0
 	for i := 0; i < len(s); i++ {

--- a/pkg/config/compiler_ipsec_gateway_ref_test.go
+++ b/pkg/config/compiler_ipsec_gateway_ref_test.go
@@ -201,3 +201,71 @@ func TestIsUsableIPsecEndpoint(t *testing.T) {
 		}
 	}
 }
+
+// TestIsUsableIPsecEndpointMaxLength pins the 253-octet presentation-form
+// length boundary and its interaction with the absolute-root trailing dot
+// (#2596). RFC 1035 §3.1 caps the presentation name at 253 characters
+// (excluding the trailing root dot); a maximal 253-char FQDN written in
+// absolute form is 254 bytes including the "." and must be accepted. The
+// pre-#2596 code applied the byte-length cap BEFORE stripping the trailing
+// dot, so the 254-byte absolute form was wrongly rejected. This test goes
+// RED if the strip-then-cap ordering is reverted.
+func TestIsUsableIPsecEndpointMaxLength(t *testing.T) {
+	// makeName builds a dotted multi-label hostname of exactly n characters
+	// (n >= 1). Labels are kept at <=63 chars so each label is individually
+	// valid; the total length is what we are pinning here.
+	makeName := func(n int) string {
+		var b strings.Builder
+		for b.Len() < n {
+			if b.Len() > 0 {
+				b.WriteByte('.')
+				if b.Len() == n {
+					break
+				}
+			}
+			// Fill this label up to 63 chars or until we hit n.
+			label := 0
+			for b.Len() < n && label < 63 {
+				b.WriteByte('a')
+				label++
+			}
+		}
+		return b.String()
+	}
+
+	name253 := makeName(253)
+	if len(name253) != 253 {
+		t.Fatalf("makeName(253) produced len %d, want 253", len(name253))
+	}
+	name254 := makeName(254)
+	if len(name254) != 254 {
+		t.Fatalf("makeName(254) produced len %d, want 254", len(name254))
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		// 253-char relative FQDN: at the cap, valid.
+		{"253-char", name253, true},
+		// 253-char name with a trailing root dot: 254 bytes on the wire,
+		// but only 253 presentation chars => valid (#2596). This is the
+		// case the pre-fix ordering wrongly rejected.
+		{"253-char+trailing-dot", name253 + ".", true},
+		// 254-char relative FQDN: one over the cap, invalid.
+		{"254-char", name254, false},
+		// 254-char name with a trailing dot: after stripping the dot the
+		// stripped name is still 254 chars => over the cap, invalid.
+		{"254-char+trailing-dot", name254 + ".", false},
+		// Edge cases around the strip itself.
+		{"empty", "", false},
+		{"bare-dot", ".", false},
+	}
+	for _, c := range cases {
+		if got := IsUsableIPsecEndpoint(c.in); got != c.want {
+			t.Errorf("%s: IsUsableIPsecEndpoint(len=%d) = %v, want %v",
+				c.name, len(c.in), got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2596

## Summary
`isPlausibleHostname` (`pkg/config/compiler_ipsec.go`) applied its
`len(s) > 253` presentation-length cap BEFORE stripping the single
trailing root dot that #2455 added. A maximal 253-character FQDN in
absolute form is 254 bytes including the terminal `.`, so the byte-length
check rejected it even though RFC 1035 §3.1 counts only the labels (max
253 chars) and does not charge the absolute-root dot against that budget.

Fix: move the trailing-dot strip ahead of the length cap so the cap
measures the stripped presentation name. All other checks (empty-name,
bare-`.`, contains-a-dot Rule A, per-label scan) run in the same order on
the stripped string — this only widens acceptance for the previously
over-rejected maximal absolute FQDN; nothing else is newly accepted.

## Fail-on-revert proof
Added `TestIsUsableIPsecEndpointMaxLength` (boundary table: 253-char
valid; 253-char + trailing dot / 254 bytes valid; 254-char invalid;
254-char + trailing dot invalid; empty; bare-dot). With the ordering
reverted:

```
compiler_ipsec_gateway_ref_test.go:267: 253-char+trailing-dot: IsUsableIPsecEndpoint(len=254) = false, want true
--- FAIL: TestIsUsableIPsecEndpointMaxLength
```
Restoring the fix returns the package to green.

## Docs
No module-doc change needed: the function's own doc comment already
states the 253-char cap and the trailing-dot relaxation; the public
contract only widens to accept a previously-rejected valid corner. The
inline comment was updated to pin the strip-then-cap ordering rationale.

## Gates
- `GOCACHE=/dev/shm/gocache-2596 go build ./...` — clean
- `gofmt -l` on both touched files — clean
- `go vet ./pkg/config/` — clean
- `go test ./pkg/config/` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi