### PR TITLE
flowexport: keep IPFIX sequence across template refresh (#2609)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14893,3 +14893,17 @@ top.
   failover) → parent may run make test-failover for no-regression.
   **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/serialize_test.go,
   pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2609 — IPFIX template-refresh header no longer resets
+  SequenceNumber to 0. Per RFC 7011 §3.1/§10.3.2 the IPFIX sequence is the
+  cumulative data-record count; a template-only Message carries the current
+  value WITHOUT advancing it. sendTemplates() now reads e.seq under e.mu
+  (no increment) instead of hardcoding 0 (NetFlow v9, which counts export
+  packets, is unaffected and correctly keeps its template-send increment).
+  Added fail-on-revert TestIPFIXTemplateRefreshPreservesSequenceNumber
+  (loopback UDP collector; proven RED on revert, GREEN restored). Gates:
+  go build ./... OK; gofmt clean; go vet ./pkg/flowexport/... clean;
+  go test ./pkg/flowexport/... ok.
+  **File(s)**: pkg/flowexport/ipfix.go,
+  pkg/flowexport/ipfix_seqnum_test.go, pkg/flowexport/README.md, _Log.md

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -127,6 +127,26 @@ The package is split by responsibility (#1988):
   earlier in the loop before returning — no descriptor leak on partial
   failure.
 
+## Header sequence number — v9 vs IPFIX (#2609)
+
+The two protocols define the header sequence number differently, and the
+exporters MUST NOT share the same rule:
+
+- **NetFlow v9 (RFC 3954)** — the header `SeqNumber` counts **export
+  packets**. Every datagram, *including* a template-only refresh,
+  advances the counter. `Exporter.sendTemplates()` therefore reads and
+  post-increments `e.seq` exactly like a data send.
+- **IPFIX / NetFlow v10 (RFC 7011 §3.1, §10.3.2)** — the header
+  `SequenceNumber` is the **cumulative count of Data Records** sent in
+  all prior Messages for this Observation Domain (the sequence of the
+  *next* Data Record). A Message that carries only (Options) Template
+  Sets contains no Data Records, so `IPFIXExporter.sendTemplates()`
+  carries the **current** cumulative value WITHOUT advancing it. Emitting
+  a hardcoded `0` on every periodic refresh (the pre-#2609 bug) rewound
+  the header sequence, which loss/sequence-tracking collectors (pmacct,
+  Elastiflow) read as packet loss or an exporter restart. Pinned by
+  `TestIPFIXTemplateRefreshPreservesSequenceNumber` (fail-on-revert).
+
 ## Per-collector write-health (#2464)
 
 Flow export is forensics/compliance data; a collector going unreachable

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -479,12 +479,25 @@ func (e *IPFIXExporter) Close() {
 }
 
 func (e *IPFIXExporter) sendTemplates() {
+	// RFC 7011 §3.1 / §10.3.2: the IPFIX Sequence Number is the cumulative
+	// count of Data Records sent in all prior Messages for this Observation
+	// Domain (the value of the NEXT Data Record's sequence). A Message that
+	// carries only (Options) Template Sets contains no Data Records, so it
+	// MUST NOT advance the counter — but it MUST carry the current cumulative
+	// value, not 0. Emitting 0 on every periodic template refresh rewinds the
+	// header sequence, which loss/sequence-tracking collectors (pmacct,
+	// Elastiflow) read as packet loss or an exporter restart (#2609). Read
+	// e.seq under e.mu WITHOUT incrementing it (no data records are sent).
+	e.mu.Lock()
+	seq := e.seq
+	e.mu.Unlock()
+
 	now := time.Now()
 	hdr := ipfixHeader{
 		Version:        10,
 		Length:         uint16(16 + len(e.templateSet)),
 		ExportTime:     uint32(now.Unix()),
-		SequenceNumber: 0, // template-only messages use seq=0 per convention
+		SequenceNumber: seq,
 		ObservationID:  e.sourceID,
 	}
 

--- a/pkg/flowexport/ipfix_seqnum_test.go
+++ b/pkg/flowexport/ipfix_seqnum_test.go
@@ -1,0 +1,142 @@
+package flowexport
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestIPFIXTemplateRefreshPreservesSequenceNumber is the #2609 fail-on-revert
+// guard. RFC 7011 §3.1 / §10.3.2: the IPFIX header Sequence Number is the
+// cumulative count of Data Records sent in all prior Messages for this
+// Observation Domain (i.e. the sequence of the NEXT Data Record). A Message
+// carrying only Template Sets contains no Data Records, so it MUST NOT advance
+// the counter — but it MUST carry the CURRENT cumulative value, not 0.
+//
+// The pre-fix code hardcoded SequenceNumber: 0 in sendTemplates(). After data
+// records had been exported, a periodic template refresh rewound the header
+// sequence to 0, which loss/sequence-tracking collectors read as packet loss
+// or an exporter restart.
+//
+// This test exercises the real wire path: it stands up a loopback UDP
+// collector, sends a data batch (advancing the counter), triggers a template
+// refresh, then sends more data, and parses the captured header sequence
+// numbers off the wire. It asserts:
+//   - template-refresh header carries the current cumulative data-record count
+//     (NOT 0) once records have been sent
+//   - the template refresh does NOT advance the counter (no data records)
+//   - the subsequent data send resumes exactly where the prior data left off
+//
+// Revert the fix (SequenceNumber: 0 in sendTemplates) and the refresh-after-
+// data assertion goes red: the captured template header reads 0 instead of the
+// cumulative count.
+func TestIPFIXTemplateRefreshPreservesSequenceNumber(t *testing.T) {
+	// Loopback UDP collector to capture the exact bytes hitting the wire.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	defer pc.Close()
+	collectorAddr := pc.LocalAddr().String()
+
+	ec := &ExportConfig{
+		Collectors: []CollectorConfig{{Address: collectorAddr}},
+	}
+	e, err := NewIPFIXExporter(ec)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	defer e.Close()
+
+	// seqOf parses the IPFIX header (RFC 7011 §3.1) off a captured packet and
+	// returns (version, sequenceNumber). The header is 16 bytes; the sequence
+	// number is at offset 8..12, big-endian.
+	readPkt := func() []byte {
+		buf := make([]byte, 2048)
+		if err := pc.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		n, _, err := pc.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("ReadFrom (collector got no packet): %v", err)
+		}
+		if n < 16 {
+			t.Fatalf("short IPFIX packet: %d bytes", n)
+		}
+		return buf[:n]
+	}
+	seqOf := func(pkt []byte) (version, setID uint16, seq uint32) {
+		version = binary.BigEndian.Uint16(pkt[0:2])
+		seq = binary.BigEndian.Uint32(pkt[8:12])
+		// First set ID after the 16-byte header (2 = template set, >=256 data).
+		setID = binary.BigEndian.Uint16(pkt[16:18])
+		return version, setID, seq
+	}
+
+	mkRecords := func(n int) []FlowRecord {
+		recs := make([]FlowRecord, n)
+		for i := range recs {
+			recs[i] = FlowRecord{
+				SrcIP:     net.IPv4(10, 0, 0, 1),
+				DstIP:     net.IPv4(10, 0, 0, 2),
+				SrcPort:   1000 + uint16(i),
+				DstPort:   80,
+				Protocol:  6,
+				StartTime: time.Now(),
+				EndTime:   time.Now(),
+			}
+		}
+		return recs
+	}
+
+	// 1) Send a first data batch of 3 records. First data packet's header
+	//    sequence is 0 (no prior data records); the counter then advances to 3.
+	e.sendRecords(mkRecords(3))
+	_, setID, seq := seqOf(readPkt())
+	if setID < 256 {
+		t.Fatalf("expected a data set (set ID >= 256), got set ID %d", setID)
+	}
+	if seq != 0 {
+		t.Fatalf("first data packet sequence = %d, want 0 (no prior data records)", seq)
+	}
+
+	// 2) Trigger a template refresh. RFC 7011: the template-only Message
+	//    carries the CURRENT cumulative data-record count (3), and does NOT
+	//    advance the counter (it has no data records).
+	e.sendTemplates()
+	ver, setID, seq := seqOf(readPkt())
+	if ver != 10 {
+		t.Fatalf("template packet version = %d, want 10 (IPFIX)", ver)
+	}
+	if setID != ipfixSetIDTemplate {
+		t.Fatalf("expected a template set (set ID %d), got set ID %d", ipfixSetIDTemplate, setID)
+	}
+	if seq != 3 {
+		t.Fatalf("template-refresh header sequence = %d, want 3 "+
+			"(RFC 7011 §3.1: cumulative data-record count, NOT reset to 0) (#2609)", seq)
+	}
+
+	// 3) Send 2 more data records. The data sequence MUST resume at 3 (the
+	//    template refresh did not consume or reset the counter); the counter
+	//    then advances to 5.
+	e.sendRecords(mkRecords(2))
+	_, setID, seq = seqOf(readPkt())
+	if setID < 256 {
+		t.Fatalf("expected a data set (set ID >= 256), got set ID %d", setID)
+	}
+	if seq != 3 {
+		t.Fatalf("post-refresh data packet sequence = %d, want 3 "+
+			"(template refresh must not advance or reset the data-record counter) (#2609)", seq)
+	}
+
+	// The exporter's running counter is now 5 (3 + 2), proving the template
+	// refresh contributed 0 to the cumulative data-record count.
+	e.mu.Lock()
+	finalSeq := e.seq
+	e.mu.Unlock()
+	if finalSeq != 5 {
+		t.Fatalf("final cumulative seq = %d, want 5 (3 + 2 data records; "+
+			"template refresh must count 0)", finalSeq)
+	}
+}


### PR DESCRIPTION
## Summary

- IPFIX `sendTemplates()` hardcoded `SequenceNumber: 0`. After data records had been exported, every periodic template refresh rewound the header sequence to 0.
- Loss/sequence-tracking collectors (pmacct, Elastiflow) read that rewind as packet loss or an exporter restart — false telemetry-integrity events.
- Fix: `sendTemplates()` now reads `e.seq` under `e.mu` and writes the **current cumulative** value WITHOUT incrementing it (a template-only Message carries zero Data Records).
- NetFlow v9 is intentionally unchanged.

## RFC basis

- **IPFIX / NetFlow v10 — RFC 7011 §3.1, §10.3.2**: the header Sequence Number is the cumulative count of **Data Records** sent in all prior Messages for the Observation Domain (the sequence of the *next* Data Record). A Message carrying only (Options) Template Sets contains no Data Records → it MUST NOT advance the counter, and it MUST carry the current cumulative value, not 0.
- **NetFlow v9 — RFC 3954**: the header sequence counts **export packets**, so its template send legitimately advances the counter (`e.seq++` kept). This is why the fix is IPFIX-only.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l` clean on touched files
- [x] `go vet ./pkg/flowexport/...` clean
- [x] `go test ./pkg/flowexport/...` ok
- [x] Added `TestIPFIXTemplateRefreshPreservesSequenceNumber` — loopback UDP collector captures real wire bytes: send 3 data records (counter→3), template refresh, send 2 more. Asserts refresh header = 3 (not 0), post-refresh data resumes at 3, final cumulative = 5 (refresh counted 0).

### Fail-on-revert proof

Reverting the fix (`SequenceNumber: 0` in `sendTemplates`):

```
--- FAIL: TestIPFIXTemplateRefreshPreservesSequenceNumber (0.00s)
    ipfix_seqnum_test.go:116: template-refresh header sequence = 0, want 3
        (RFC 7011 §3.1: cumulative data-record count, NOT reset to 0) (#2609)
```

GREEN after restore.

## Docs

- `pkg/flowexport/README.md`: new "Header sequence number — v9 vs IPFIX (#2609)" subsection documenting the divergent rule and the fail-on-revert pin.

## Refs

Closes #2609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi