### PR TITLE
config: type the five untyped router-advertisement leaves (#2497)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14927,3 +14927,23 @@ top.
   GOCACHE go build ./... clean; go test ./pkg/dhcprelay/... ./pkg/daemon/...
   green; gofmt clean; go vet clean. HA-adjacent (relay follows VRRP master
   state) → parent may run make test-failover for no-regression.
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2497 — type the five untyped router-advertisement config
+  leaves so commit rejects garbage instead of the RA sender silently
+  skipping / mis-advertising it at runtime.
+- **File(s)**: pkg/config/schema_validators.go (new ValidateIPv6Address +
+  ValidatePREF64CIDR), pkg/config/schema_routing.go (wire keyValidator on
+  prefix/nat-prefix/nat64prefix, ValidateEnum on preference,
+  ValidateIPv6Address on dns-server-address, link-mtu floor 1->1280,
+  nat lifetime child typed integer),
+  pkg/config/schema_validate_2497_test.go (new regression suite),
+  docs/config-schema.md, _Log.md
+- **Validation**: fail-on-revert proven — stashing the two schema files
+  turns all 12 *_RejectsBad assertions RED (AcceptsValid stay green,
+  correctly fix-independent), restored identical and green. Gates:
+  GOCACHE go build ./... clean; go vet ./pkg/config/... clean; gofmt clean;
+  go test ./pkg/config/... ./pkg/cmdtree/... green. The one pkg/ra failure
+  (TestT2a_ChangedConfigApplyNeverTwoLiveConns) is a pre-existing NDP-socket
+  bind flake on origin/master — confirmed failing with my changes stashed,
+  and this PR touches zero pkg/ra code.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -278,7 +278,8 @@ Rules:
 - **Validators live in `pkg/config/schema_validators.go`** and are stateless
   string-checkers reusing the compiler's parsers. Add a generic one
   (`ValidateInteger(min,max)`, `ValidateEnum([...])`, the IP family
-  validators `ValidateIPAddress` / `ValidateIPv4CIDR` / `ValidateIPv6CIDR`)
+  validators `ValidateIPAddress` / `ValidateIPv6Address` /
+  `ValidateIPv4CIDR` / `ValidateIPv6CIDR` / `ValidatePREF64CIDR`)
   or a bespoke `ValidateX(raw string, cfg *Config) error`. **cfg is always
   nil in production** — both call sites run the gate BEFORE compile
   (`configstore.compileTree` / `compileTreeLenient`), so a validator must
@@ -526,8 +527,9 @@ reserved for whole-dataplane selection where a rewrite shim
     compiler reads (the subtree was previously unreachable by the walker).
   - `protocols router-advertisement interface` — typed the
     second-denominated leaves (`max/min-advertisement-interval`,
-    `default-lifetime`, `link-mtu` via `ValidateIntegerMin(1)`) and
-    declared the remaining compiler-consumed structural children
+    `default-lifetime`, `link-mtu`; the latter was tightened from
+    `ValidateIntegerMin(1)` to `ValidateIntegerMin(1280)` in #2497, see
+    below) and declared the remaining compiler-consumed structural children
     (managed/other-stateful-configuration, dns-server-address, prefix
     flags). The per-`prefix` `valid-lifetime` / `preferred-lifetime` leaves
     are typed as non-negative integers (`ValidateIntegerMin(0)`): the
@@ -542,6 +544,36 @@ reserved for whole-dataplane selection where a rewrite shim
     fails at commit; `allow-duplicates` is an explicit presence-only flag.
   Pure schema hardening — no runtime behavior change. Regression coverage:
   `pkg/config/schema_validate_2008_test.go`.
+- **#2497 (router-advertisement string/identity leaves):** #2008 typed
+  only the RA integer leaves; the five string/identity leaves below were
+  still accepted untyped and then silently skipped or mis-advertised by
+  the RA sender (`pkg/ra/sender.go buildRA`). Wired at commit:
+  - `prefix` — the prefix value is the named-instance identity arg, so it
+    uses `keyValidator: ValidateIPv6CIDR` (not the typed-leaf `validator`,
+    which would mis-treat the on-link/autonomous flag children as
+    modifiers). A typo'd or IPv4 prefix previously committed and the
+    sender's `netip.ParsePrefix` error path logged-and-skipped it, so
+    hosts got no PrefixInformation option and SLAAC silently broke.
+  - `nat-prefix` / `nat64prefix` — `keyValidator: ValidatePREF64CIDR`,
+    which reuses `ValidateIPv6CIDR` and then enforces the RFC 8781 §4
+    PREF64 length set `{32,40,48,56,64,96}` (the only lengths the 3-bit
+    PLC wire field encodes). The `lifetime` child is now
+    `ValidateIntegerMin(0)` (was an Atoi-on-error-zero leaf).
+  - `preference` — `ValueEnumOf` + `ValidateEnum(high|medium|low)`. A
+    typo fell through the sender's `switch` default and silently
+    advertised Medium, perturbing host default-router selection.
+  - `dns-server-address` — `ValueIPAddress` + `ValidateIPv6Address` (a
+    new validator: bare IPv6 literal, IPv4 rejected). The RDNSS option
+    (RFC 8106) is IPv6-only; the sender skipped unparseable strings but
+    did NOT family-gate, so a valid IPv4 literal reached the wire.
+  - `link-mtu` — floor raised to `ValidateIntegerMin(1280)` (RFC 8200 §5
+    IPv6 minimum link MTU); a smaller value was advertised verbatim and
+    blackholes hosts that honor it.
+  Pure schema hardening — no runtime behavior change (the sender's
+  parse-and-skip / default paths are now unreachable for committed
+  configs). New validators `ValidateIPv6Address` / `ValidatePREF64CIDR`
+  live in `schema_validators.go`. Regression coverage:
+  `pkg/config/schema_validate_2497_test.go`.
 - **#2008 H7 (security log profile):** declared the `security log
   profile <name>` stanza — `stream-name` (`ValueHintStreamName`
   completion), `default-profile` (presence flag), and

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -305,37 +305,79 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			"default-lifetime": {desc: "Router lifetime advertised to hosts (seconds)", args: 1, placeholder: "<seconds>",
 				valueType: ValueInteger, valueDesc: "router lifetime in seconds",
 				valueExamples: []string{"1800", "9000"}, validator: ValidateIntegerMin(1), children: nil},
+			// #2497: link-mtu is advertised verbatim via ndp.NewMTU. RFC 8200
+			// §5 sets the IPv6 minimum link MTU at 1280 bytes; a smaller value
+			// (1-1279) committed today reaches the wire and blackholes hosts
+			// that honor it. Floor the leaf at the IPv6 minimum.
 			"link-mtu": {desc: "Link MTU option advertised to hosts", args: 1, placeholder: "<mtu>",
-				valueType: ValueInteger, valueDesc: "advertised link MTU",
-				valueExamples: []string{"1280", "1500"}, validator: ValidateIntegerMin(1), children: nil},
-			"dns-server-address": {desc: "RDNSS DNS server address advertised to hosts", args: 1, multi: true, placeholder: "<address>", children: nil},
-			"preference":         {desc: "Default router preference (high|medium|low)", args: 1, placeholder: "<preference>", children: nil},
-			"prefix": {desc: "Advertised on-link prefix", args: 1, placeholder: "<prefix>", children: map[string]*schemaNode{ // prefix <prefix/len>
-				"on-link":       {desc: "Set the on-link (L) flag (default)", children: nil},
-				"autonomous":    {desc: "Set the autonomous (A) flag (default)", children: nil},
-				"no-onlink":     {desc: "Clear the on-link (L) flag", children: nil},
-				"no-autonomous": {desc: "Clear the autonomous (A) flag", children: nil},
-				// Prefix lifetimes compile with a bare strconv.Atoi
-				// (compiler_protocols.go) and treat 0 as "use the SLAAC
-				// default" (types_routing.go RAPrefix; pkg/ra sender clamps
-				// <=0 to defaultValid/PreferredLifetime). Type them as
-				// non-negative integers so the gate rejects garbage (e.g.
-				// `valid-lifetime abc`, which previously stayed at 0 and
-				// silently fell back to the default) while still accepting
-				// an explicit 0.
-				"valid-lifetime": {desc: "Prefix valid lifetime in seconds (0 = SLAAC default)", args: 1, placeholder: "<seconds>",
-					valueType: ValueInteger, valueDesc: "prefix valid lifetime in seconds",
-					valueExamples: []string{"0", "86400", "2592000"}, validator: ValidateIntegerMin(0), children: nil},
-				"preferred-lifetime": {desc: "Prefix preferred lifetime in seconds (0 = SLAAC default)", args: 1, placeholder: "<seconds>",
-					valueType: ValueInteger, valueDesc: "prefix preferred lifetime in seconds",
-					valueExamples: []string{"0", "604800", "86400"}, validator: ValidateIntegerMin(0), children: nil},
-			}},
-			"nat-prefix": {desc: "NAT prefix", args: 1, placeholder: "<prefix>", children: map[string]*schemaNode{
-				"lifetime": {desc: "Lifetime", args: 1, placeholder: "<seconds>", children: nil},
-			}},
-			"nat64prefix": {desc: "NAT64 prefix", args: 1, placeholder: "<prefix>", children: map[string]*schemaNode{
-				"lifetime": {desc: "Lifetime", args: 1, placeholder: "<seconds>", children: nil},
-			}},
+				valueType: ValueInteger, valueDesc: "advertised link MTU (RFC 8200 §5 minimum 1280)",
+				valueExamples: []string{"1280", "1500"}, validator: ValidateIntegerMin(1280), children: nil},
+			// #2497: each address is appended to an RFC 8106 RecursiveDNSServer
+			// (RDNSS) option, which is IPv6-only. The runtime skips an
+			// unparseable string but does NOT family-gate, so a bare IPv4
+			// literal was advertised on the wire. Validate as a bare IPv6
+			// literal at commit.
+			"dns-server-address": {desc: "RDNSS DNS server address advertised to hosts", args: 1, multi: true, placeholder: "<address>",
+				valueType: ValueIPAddress, valueDesc: "RDNSS server (IPv6 literal, RFC 8106)",
+				valueExamples: []string{"2001:db8::53"}, validator: ValidateIPv6Address, children: nil},
+			// #2497: a preference typo (case drift, "mdeium") falls through the
+			// RA sender's switch default and silently advertises Medium,
+			// perturbing host default-router selection on a multi-router LAN.
+			// Constrain to the three RFC 4191 router-selection preferences.
+			"preference": {desc: "Default router preference (high|medium|low)", args: 1, placeholder: "<preference>",
+				valueType: ValueEnumOf, valueDesc: "router selection preference",
+				valueExamples: []string{"high", "medium", "low"}, validator: ValidateEnum([]string{"high", "medium", "low"}), children: nil},
+			// #2497: the prefix value is the named-instance identity arg. A
+			// typo'd prefix committed today; the RA sender's netip.ParsePrefix
+			// error path logs and skips it, so hosts on the link get no PIO and
+			// SLAAC silently breaks. Validate it as an IPv6 CIDR at commit.
+			"prefix": {desc: "Advertised on-link prefix", args: 1, placeholder: "<prefix>",
+				keyValueType: ValueCIDR, keyValueDesc: "IPv6 prefix with length (e.g. 2001:db8::/64)",
+				keyValueExamples: []string{"2001:db8::/64"}, keyValidator: ValidateIPv6CIDR,
+				children: map[string]*schemaNode{ // prefix <prefix/len>
+					"on-link":       {desc: "Set the on-link (L) flag (default)", children: nil},
+					"autonomous":    {desc: "Set the autonomous (A) flag (default)", children: nil},
+					"no-onlink":     {desc: "Clear the on-link (L) flag", children: nil},
+					"no-autonomous": {desc: "Clear the autonomous (A) flag", children: nil},
+					// Prefix lifetimes compile with a bare strconv.Atoi
+					// (compiler_protocols.go) and treat 0 as "use the SLAAC
+					// default" (types_routing.go RAPrefix; pkg/ra sender clamps
+					// <=0 to defaultValid/PreferredLifetime). Type them as
+					// non-negative integers so the gate rejects garbage (e.g.
+					// `valid-lifetime abc`, which previously stayed at 0 and
+					// silently fell back to the default) while still accepting
+					// an explicit 0.
+					"valid-lifetime": {desc: "Prefix valid lifetime in seconds (0 = SLAAC default)", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "prefix valid lifetime in seconds",
+						valueExamples: []string{"0", "86400", "2592000"}, validator: ValidateIntegerMin(0), children: nil},
+					"preferred-lifetime": {desc: "Prefix preferred lifetime in seconds (0 = SLAAC default)", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "prefix preferred lifetime in seconds",
+						valueExamples: []string{"0", "604800", "86400"}, validator: ValidateIntegerMin(0), children: nil},
+				}},
+			// #2497: nat-prefix/nat64prefix feed an ndp.PREF64 option whose
+			// 3-bit PLC wire field can only encode the RFC 8781 §4 length set
+			// {32,40,48,56,64,96}. An out-of-set length committed today parses
+			// in netip.ParsePrefix, so the runtime accepts it and mis-encodes
+			// or omits the option. Validate as a PREF64-legal IPv6 CIDR at
+			// commit, and type the lifetime child as a non-negative integer so
+			// garbage no longer silently zeroes (which defaults to the router
+			// lifetime).
+			"nat-prefix": {desc: "NAT prefix", args: 1, placeholder: "<prefix>",
+				keyValueType: ValueCIDR, keyValueDesc: "NAT64 prefix (RFC 8781 length /32 /40 /48 /56 /64 /96)",
+				keyValueExamples: []string{"64:ff9b::/96"}, keyValidator: ValidatePREF64CIDR,
+				children: map[string]*schemaNode{
+					"lifetime": {desc: "Lifetime", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "PREF64 lifetime in seconds (0 = router lifetime)",
+						valueExamples: []string{"0", "1800"}, validator: ValidateIntegerMin(0), children: nil},
+				}},
+			"nat64prefix": {desc: "NAT64 prefix", args: 1, placeholder: "<prefix>",
+				keyValueType: ValueCIDR, keyValueDesc: "NAT64 prefix (RFC 8781 length /32 /40 /48 /56 /64 /96)",
+				keyValueExamples: []string{"64:ff9b::/96"}, keyValidator: ValidatePREF64CIDR,
+				children: map[string]*schemaNode{
+					"lifetime": {desc: "Lifetime", args: 1, placeholder: "<seconds>",
+						valueType: ValueInteger, valueDesc: "PREF64 lifetime in seconds (0 = router lifetime)",
+						valueExamples: []string{"0", "1800"}, validator: ValidateIntegerMin(0), children: nil},
+				}},
 		}},
 	}},
 	"lldp": {desc: "LLDP configuration", children: map[string]*schemaNode{

--- a/pkg/config/schema_validate_2497_test.go
+++ b/pkg/config/schema_validate_2497_test.go
@@ -1,0 +1,309 @@
+package config_test
+
+// Regression tests for #2497: five router-advertisement config leaves were
+// accepted untyped at commit and then silently skipped or mis-advertised by
+// the RA sender (pkg/ra/sender.go buildRA) at runtime. #2008 typed only the
+// integer interval/lifetime leaves; these string/identity leaves were left
+// untyped. Each "RejectsBad" case FAILS to error before the fix (the gate
+// has no validator) and errors after it; each "AcceptsValid" case guards
+// the spellings the compiler already accepts against a false-reject.
+//
+// Items covered (issue findings a-e):
+//   - (a) prefix             -> ValidateIPv6CIDR keyValidator
+//   - (b) nat-prefix/        -> ValidatePREF64CIDR keyValidator
+//         nat64prefix           (+ RFC 8781 length set, + lifetime integer)
+//   - (c) preference         -> ValidateEnum(high|medium|low)
+//   - (d) dns-server-address -> ValidateIPv6Address (IPv6 literal only)
+//   - (e) link-mtu           -> ValidateIntegerMin(1280) (RFC 8200 §5)
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- (a) prefix: must be a valid IPv6 CIDR ------------------------------
+
+func TestSchema2497_RAPrefix_RejectsBad(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            prefix 2001:db8::garbage/64;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for malformed RA prefix, got nil")
+	}
+	if !strings.Contains(err.Error(), "prefix") {
+		t.Fatalf("error should reference prefix: %v", err)
+	}
+}
+
+// A bare IP without a prefix length must be rejected: the RA sender uses
+// netip.ParsePrefix and skips the prefix entirely on error.
+func TestSchema2497_RAPrefix_RejectsMissingLength(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            prefix 2001:db8::1;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for RA prefix without /prefix-length, got nil")
+	}
+}
+
+// An IPv4 CIDR under prefix must be rejected (RA PIO is IPv6-only).
+func TestSchema2497_RAPrefix_RejectsIPv4(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            prefix 192.0.2.0/24;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for IPv4 RA prefix, got nil")
+	}
+}
+
+func TestSchema2497_RAPrefix_AcceptsValid(t *testing.T) {
+	if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            prefix 2001:db8:abcd::/64 {
+                autonomous;
+                on-link;
+            }
+        }
+    }
+}`); err != nil {
+		t.Fatalf("unexpected error for valid RA prefix: %v", err)
+	}
+}
+
+// --- (b) nat-prefix / nat64prefix: PREF64-legal IPv6 CIDR ---------------
+
+func TestSchema2497_RANAT64Prefix_RejectsBad(t *testing.T) {
+	for _, leaf := range []string{"nat-prefix", "nat64prefix"} {
+		err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            `+leaf+` not-a-prefix;
+        }
+    }
+}`)
+		if err == nil {
+			t.Fatalf("expected error for %s not-a-prefix, got nil", leaf)
+		}
+	}
+}
+
+// RFC 8781 §4 permits only /32 /40 /48 /56 /64 /96. A syntactically valid
+// IPv6 CIDR with an out-of-set length parses cleanly in netip.ParsePrefix
+// today and is then mis-encoded / omitted; the gate must reject it.
+func TestSchema2497_RANAT64Prefix_RejectsBadLength(t *testing.T) {
+	for _, leaf := range []string{"nat-prefix", "nat64prefix"} {
+		err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            `+leaf+` 64:ff9b::/60;
+        }
+    }
+}`)
+		if err == nil {
+			t.Fatalf("expected error for %s /60 (not in RFC 8781 set), got nil", leaf)
+		}
+		if !strings.Contains(err.Error(), "8781") && !strings.Contains(err.Error(), "/60") {
+			t.Fatalf("error should reference the PREF64 length rule: %v", err)
+		}
+	}
+}
+
+// The lifetime child was an Atoi-on-error-zero leaf; garbage must now fail.
+func TestSchema2497_RANAT64PrefixLifetime_RejectsBad(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            nat64prefix 64:ff9b::/96 {
+                lifetime abc;
+            }
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for nat64prefix lifetime abc, got nil")
+	}
+	if !strings.Contains(err.Error(), "lifetime") {
+		t.Fatalf("error should reference lifetime: %v", err)
+	}
+}
+
+func TestSchema2497_RANAT64Prefix_AcceptsValid(t *testing.T) {
+	for _, leaf := range []string{"nat-prefix", "nat64prefix"} {
+		for _, length := range []string{"32", "40", "48", "56", "64", "96"} {
+			cfg := `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            ` + leaf + ` 64:ff9b::/` + length + ` {
+                lifetime 1800;
+            }
+        }
+    }
+}`
+			if err := schemaCheck(t, cfg); err != nil {
+				t.Fatalf("unexpected error for %s /%s: %v", leaf, length, err)
+			}
+		}
+	}
+}
+
+// --- (c) preference: enum high|medium|low -------------------------------
+
+func TestSchema2497_RAPreference_RejectsBad(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            preference mdeium;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for preference mdeium, got nil")
+	}
+	if !strings.Contains(err.Error(), "mdeium") {
+		t.Fatalf("error should quote the bad preference: %v", err)
+	}
+}
+
+func TestSchema2497_RAPreference_AcceptsValid(t *testing.T) {
+	for _, p := range []string{"high", "medium", "low"} {
+		if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            preference `+p+`;
+        }
+    }
+}`); err != nil {
+			t.Fatalf("unexpected error for preference %s: %v", p, err)
+		}
+	}
+}
+
+// --- (d) dns-server-address: IPv6 literal only --------------------------
+
+// A valid IPv4 literal parses in netip.ParseAddr and was appended to the
+// IPv6-only RDNSS option on the wire — worse than a skip. The gate must
+// reject it.
+func TestSchema2497_RADNSServer_RejectsIPv4(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            dns-server-address 8.8.8.8;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for IPv4 RDNSS address, got nil")
+	}
+	if !strings.Contains(err.Error(), "8.8.8.8") {
+		t.Fatalf("error should quote the bad address: %v", err)
+	}
+}
+
+func TestSchema2497_RADNSServer_RejectsGarbage(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            dns-server-address not-an-address;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for garbage RDNSS address, got nil")
+	}
+}
+
+func TestSchema2497_RADNSServer_AcceptsValid(t *testing.T) {
+	if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            dns-server-address 2001:db8::53;
+        }
+    }
+}`); err != nil {
+		t.Fatalf("unexpected error for valid IPv6 RDNSS address: %v", err)
+	}
+}
+
+// --- (e) link-mtu: IPv6 minimum 1280 ------------------------------------
+
+// RFC 8200 §5 requires a minimum link MTU of 1280. A smaller value was
+// advertised verbatim and blackholes hosts that honor it.
+func TestSchema2497_RALinkMTU_RejectsBelowMinimum(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            link-mtu 576;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for link-mtu 576 (below IPv6 minimum 1280), got nil")
+	}
+	if !strings.Contains(err.Error(), "link-mtu") {
+		t.Fatalf("error should reference link-mtu: %v", err)
+	}
+}
+
+func TestSchema2497_RALinkMTU_AcceptsMinimumAndAbove(t *testing.T) {
+	for _, mtu := range []string{"1280", "1500", "9000"} {
+		if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            link-mtu `+mtu+`;
+        }
+    }
+}`); err != nil {
+			t.Fatalf("unexpected error for link-mtu %s: %v", mtu, err)
+		}
+	}
+}
+
+// --- flat-set parity ----------------------------------------------------
+
+// The #1319 gate runs against the tree expanded from set commands at commit
+// time; the flat-set shape must validate identically to the hierarchical one.
+func TestSchema2497_FlatSet_RAPreference_RejectsBad(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set protocols router-advertisement interface ge-0-0-0 preference bogus",
+	)
+	if err == nil {
+		t.Fatal("expected error for flat-set preference bogus, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("error should quote the bad preference: %v", err)
+	}
+}
+
+func TestSchema2497_FlatSet_RAPrefix_RejectsBad(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set protocols router-advertisement interface ge-0-0-0 prefix 192.0.2.0/24",
+	)
+	if err == nil {
+		t.Fatal("expected error for flat-set IPv4 RA prefix, got nil")
+	}
+}
+
+func TestSchema2497_FlatSet_RA_AcceptsValid(t *testing.T) {
+	if err := flatSchemaCheck(t,
+		"set protocols router-advertisement interface ge-0-0-0 prefix 2001:db8::/64 autonomous",
+		"set protocols router-advertisement interface ge-0-0-0 preference high",
+		"set protocols router-advertisement interface ge-0-0-0 dns-server-address 2001:db8::53",
+		"set protocols router-advertisement interface ge-0-0-0 nat64prefix 64:ff9b::/96 lifetime 1800",
+		"set protocols router-advertisement interface ge-0-0-0 link-mtu 1500",
+	); err != nil {
+		t.Fatalf("unexpected error for valid flat-set RA config: %v", err)
+	}
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -253,6 +253,63 @@ func ValidateIPAddress(raw string, _ *Config) error {
 	return nil
 }
 
+// ValidateIPv6Address accepts an IPv6 literal WITHOUT a prefix length and
+// rejects IPv4. Used for the RDNSS dns-server-address leaf (#2497): the RA
+// sender (pkg/ra/sender.go buildRA) feeds each address to netip.ParseAddr
+// and appends it to an RFC 8106 RecursiveDNSServer option, which is an
+// IPv6-only NDP option. The runtime skips an unparseable string but does
+// NOT family-gate, so a bare IPv4 literal (8.8.8.8) parses and is
+// advertised on the wire inside an IPv6 RDNSS option — a malformed RA.
+// The family rule mirrors the runtime's ip.To4()==nil classification.
+func ValidateIPv6Address(raw string, _ *Config) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("missing value (expected an IPv6 address, e.g. 2001:db8::1)")
+	}
+	ip := net.ParseIP(trimmed)
+	if ip == nil {
+		if _, _, err := net.ParseCIDR(trimmed); err == nil {
+			return fmt.Errorf("prefix length not allowed here (got %q; use a bare IPv6 address)", raw)
+		}
+		return fmt.Errorf("not a valid IP address (got %q)", raw)
+	}
+	if ip.To4() != nil {
+		return fmt.Errorf("not an IPv6 address (got %q; the RDNSS option is IPv6-only per RFC 8106)", raw)
+	}
+	return nil
+}
+
+// pref64PrefixLengths are the prefix lengths RFC 8781 §4 permits for a
+// PREF64 (NAT64 prefix) option: only these encode in the 3-bit PLC field.
+// A prefix of any other length cannot be advertised at all.
+var pref64PrefixLengths = map[int]struct{}{
+	32: {}, 40: {}, 48: {}, 56: {}, 64: {}, 96: {},
+}
+
+// ValidatePREF64CIDR accepts an IPv6 prefix usable in a PREF64 option:
+// a valid IPv6 CIDR (reusing ValidateIPv6CIDR's family + prefix rules)
+// whose prefix length is one of the RFC 8781 §4 set {32,40,48,56,64,96}.
+// Used for the router-advertisement nat-prefix/nat64prefix leaves (#2497):
+// the RA sender wraps the prefix in an ndp.PREF64 option whose wire PLC
+// field can only encode those six lengths. An out-of-set length committed
+// today reaches netip.ParsePrefix cleanly, so the runtime accepts it and
+// then either omits the option or mis-encodes the length.
+func ValidatePREF64CIDR(raw string, cfg *Config) error {
+	if err := ValidateIPv6CIDR(raw, cfg); err != nil {
+		return err
+	}
+	_, ipnet, err := net.ParseCIDR(strings.TrimSpace(raw))
+	if err != nil {
+		// Unreachable: ValidateIPv6CIDR already parsed it.
+		return fmt.Errorf("not a valid address/prefix-length (got %q): %v", raw, err)
+	}
+	ones, _ := ipnet.Mask.Size()
+	if _, ok := pref64PrefixLengths[ones]; !ok {
+		return fmt.Errorf("invalid PREF64 prefix length /%d (got %q; RFC 8781 permits only /32, /40, /48, /56, /64, /96)", ones, raw)
+	}
+	return nil
+}
+
 // ValidateIPv4CIDR accepts an IPv4 address with an explicit prefix
 // length (e.g. 10.0.1.10/24). The prefix is REQUIRED: every runtime
 // consumer of configured interface addresses net.ParseCIDRs the string


### PR DESCRIPTION
Closes #2497

## Summary

Five `protocols router-advertisement` config leaves were accepted untyped
at commit and then silently skipped or mis-advertised by the RA sender
(`pkg/ra/sender.go buildRA`) at runtime. #2008's RA-typing pass typed only
the integer interval/lifetime leaves and left these string/identity leaves
untyped. This wires the existing #1319 commit-time gate onto each:

- **`prefix`** — `keyValidator: ValidateIPv6CIDR` (identity-arg slot, so
  keyValidator not the typed-leaf validator — the latter would mis-treat
  the on-link/autonomous flag children as modifiers). A typo'd/IPv4 prefix
  previously committed and the sender's `netip.ParsePrefix` error path
  logged-and-skipped it → no PrefixInformation option → SLAAC silently broke.
- **`nat-prefix` / `nat64prefix`** — new `ValidatePREF64CIDR` keyValidator:
  reuses `ValidateIPv6CIDR`, then enforces the RFC 8781 §4 PREF64 length set
  `{32,40,48,56,64,96}` (the only lengths the 3-bit PLC wire field encodes).
  The `lifetime` child is now `ValidateIntegerMin(0)` (was Atoi-on-error-zero).
- **`preference`** — `ValueEnumOf` + `ValidateEnum(high|medium|low)`. A typo
  fell through the sender's `switch` default → silently advertised Medium →
  perturbed host default-router selection.
- **`dns-server-address`** — `ValueIPAddress` + new `ValidateIPv6Address`
  (bare IPv6 literal; IPv4 rejected). The RDNSS option (RFC 8106) is
  IPv6-only; the sender skipped unparseable strings but did NOT family-gate,
  so a valid IPv4 literal reached the wire inside an IPv6 RDNSS option.
- **`link-mtu`** — floor raised `ValidateIntegerMin(1)` → `(1280)` (RFC 8200
  §5 IPv6 minimum link MTU); a smaller value was advertised verbatim and
  blackholes hosts that honor it.

Pure schema hardening — no runtime behavior change; the sender's
parse-and-skip / switch-default paths are now unreachable for committed
configs. New validators `ValidateIPv6Address` / `ValidatePREF64CIDR` in
`schema_validators.go`. Docs: `docs/config-schema.md` updated.

## Fail-on-revert proof

New suite `pkg/config/schema_validate_2497_test.go` (22 cases: hierarchical
+ flat-set, reject-bad + accept-valid for all five leaves). Stashing the two
schema files turned all 12 `*_RejectsBad` assertions RED while the
`AcceptsValid` cases stayed green (correctly fix-independent):

```
--- FAIL: TestSchema2497_RAPrefix_RejectsBad
--- FAIL: TestSchema2497_RAPrefix_RejectsMissingLength
--- FAIL: TestSchema2497_RAPrefix_RejectsIPv4
--- FAIL: TestSchema2497_RANAT64Prefix_RejectsBad
--- FAIL: TestSchema2497_RANAT64Prefix_RejectsBadLength
--- FAIL: TestSchema2497_RANAT64PrefixLifetime_RejectsBad
--- FAIL: TestSchema2497_RAPreference_RejectsBad
--- FAIL: TestSchema2497_RADNSServer_RejectsIPv4
--- FAIL: TestSchema2497_RADNSServer_RejectsGarbage
--- FAIL: TestSchema2497_RALinkMTU_RejectsBelowMinimum
--- FAIL: TestSchema2497_FlatSet_RAPreference_RejectsBad
--- FAIL: TestSchema2497_FlatSet_RAPrefix_RejectsBad
```

Files restored identical and green afterward.

## Gates (green)

- `go build ./...` — clean
- `go vet ./pkg/config/...` — clean
- `gofmt -l` on touched files — clean
- `go test ./pkg/config/... ./pkg/cmdtree/...` — green

Note: the one `pkg/ra` failure (`TestT2a_ChangedConfigApplyNeverTwoLiveConns`)
is a pre-existing NDP-socket bind flake on `origin/master` — confirmed
failing with this PR's changes stashed; this PR touches zero `pkg/ra` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi