### PR TITLE
userspace-dp: cap control-socket request read before allocation (#2523)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -14893,3 +14893,20 @@ top.
   failover) → parent may run make test-failover for no-regression.
   **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/serialize_test.go,
   pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2523 — cap control-socket request read before allocation.
+  Replaced the unbounded `read_line` in `handle_stream` with a
+  `take(MAX_CONTROL_REQUEST_BYTES + 1)`-bounded `read_until`; oversize
+  bodies (no terminating newline within the cap) are rejected before
+  decode, fail-closed, daemon stays alive. Added
+  `MAX_CONTROL_REQUEST_BYTES = 16 MiB` (headroom over the largest real
+  request, a full apply_snapshot). Both control + session sockets share
+  `handle_stream`, so one fix covers both. Read-side only — no wire
+  change (wire_invariant test green, no protocol_wire_v1.json regen).
+  Added fail-on-revert tests: oversize→rejected (RED on cap removal,
+  proven), max-size legit body→succeeds. Gates: cargo build --release
+  clean; server::tests 41/0.
+  **File(s)**: userspace-dp/src/protocol/control.rs,
+  userspace-dp/src/server/handlers/mod.rs,
+  userspace-dp/src/server/tests.rs, _Log.md

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -35,12 +35,24 @@ pub(crate) const INJECT_PACKET_TUPLE_PROTOCOL_VERSION: i32 = 1;
 ///
 /// Sizing: the largest legitimate request is `apply_snapshot`, which
 /// carries the entire compiled config (every zone, policy, address-book
-/// entry, NAT rule, filter, route, etc.). Even a pathologically large
-/// production config serializes to a few MB of JSON; 16 MiB gives roughly
-/// an order of magnitude of headroom over any realistic snapshot while
-/// still bounding a single request's read allocation to a fixed ceiling.
-/// A request larger than this is, by construction, malformed — reject it
-/// before allocating its body and keep the daemon alive (fail-closed).
+/// entry, NAT rule, filter, route, etc.). A hand-authored production
+/// config serializes to a few MB of JSON, so 16 MiB leaves ample margin
+/// for the policy/NAT/route dimension while still bounding a single
+/// request's read allocation to a fixed ceiling. A request larger than
+/// this is rejected before allocating its body, keeping the daemon alive
+/// (fail-closed: stale config retained, one log line, no crash).
+///
+/// Caveat — the dominant scaling dimension is NOT policy count but
+/// dynamic-feed-backed address books: `AddressBookSnapshot.prefixes_v4/v6`
+/// carry feed prefixes inline as CIDR text (see
+/// `buildAddressBookTableWithFeeds`, `pkg/dataplane/userspace/policies.go`),
+/// bounded only by a per-line scanner cap, not a total-entry cap. A very
+/// large threat-intel feed (hundreds of thousands of CIDRs) can push a
+/// *legitimate* snapshot past 16 MiB, in which case this cap rejects it
+/// at the control socket with no Go-side commit-time diagnostic. That is
+/// safe (fail-closed) but coarse; #2744 tracks a feed-dimension-aware cap
+/// plus a Go-side pre-flight size check that surfaces the limit as a
+/// config error instead of a silent control-socket rejection.
 pub(crate) const MAX_CONTROL_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -22,6 +22,27 @@ use super::snapshot::{ConfigSnapshot, FabricSnapshot, NeighborSnapshot, Userspac
 pub(crate) const CONFIG_SNAPSHOT_PROTOCOL_VERSION: i32 = 3;
 pub(crate) const INJECT_PACKET_TUPLE_PROTOCOL_VERSION: i32 = 1;
 
+/// Maximum accepted size, in bytes, of a single newline-delimited
+/// control-socket request body before it is decoded (#2523).
+///
+/// The control socket reads one JSON request per connection via a
+/// bounded `read_until`. Without a cap, a malformed or compromised local
+/// caller can stream a very large unterminated line and force the helper
+/// to grow its read buffer unbounded (bounded in time only by the 5 s
+/// read timeout, not in allocation). The accept loop reads the whole body
+/// into memory before any schema validation can run, so the cap must be
+/// enforced at the read, not at decode.
+///
+/// Sizing: the largest legitimate request is `apply_snapshot`, which
+/// carries the entire compiled config (every zone, policy, address-book
+/// entry, NAT rule, filter, route, etc.). Even a pathologically large
+/// production config serializes to a few MB of JSON; 16 MiB gives roughly
+/// an order of magnitude of headroom over any realistic snapshot while
+/// still bounding a single request's read allocation to a fixed ceiling.
+/// A request larger than this is, by construction, malformed — reject it
+/// before allocating its body and keep the daemon alive (fail-closed).
+pub(crate) const MAX_CONTROL_REQUEST_BYTES: usize = 16 * 1024 * 1024;
+
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub(crate) struct ControlRequest {
     #[serde(rename = "type")]

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -4,7 +4,7 @@
 // decomposed into per-verb files in this directory module. This
 // `mod.rs` retains only:
 //   - Stream timeout setup
-//   - BufReader / read_line / decode
+//   - BufReader / size-capped read_until / decode (#2523)
 //   - `state.lock()` critical section
 //   - `match request.request_type.as_str()` dispatch into per-verb
 //     handlers (substantive verbs) or inline bodies (trivial arms:
@@ -35,7 +35,7 @@ mod sync_session;
 
 use super::super::*;
 use super::helpers::{refresh_status, write_state};
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -54,17 +54,39 @@ pub(crate) fn handle_stream(
         .set_write_timeout(Some(Duration::from_secs(5)))
         .map_err(|e| format!("set write timeout: {e}"))?;
 
+    // Read one newline-delimited request body, capped at
+    // MAX_CONTROL_REQUEST_BYTES (#2523). A malformed or compromised local
+    // caller could otherwise stream a very large unterminated line and
+    // force the read buffer to grow unbounded — the 5 s read timeout
+    // bounds the worst case in time but not in allocation. `take` limits
+    // the reader to the cap + 1 byte, so the read can never allocate
+    // beyond that ceiling. The largest legitimate request is a body of up
+    // to MAX bytes plus its single terminating newline (the Go encoder
+    // always appends one), i.e. MAX+1 bytes ending in '\n'. If the read
+    // stops at the cap WITHOUT a terminating newline the body is, by
+    // construction, oversize: reject it before any decode and keep the
+    // daemon alive (fail-closed).
     let mut reader = BufReader::new(
         stream
             .try_clone()
-            .map_err(|e| format!("clone stream for read: {e}"))?,
+            .map_err(|e| format!("clone stream for read: {e}"))?
+            .take(MAX_CONTROL_REQUEST_BYTES as u64 + 1),
     );
-    let mut line = String::new();
-    reader
-        .read_line(&mut line)
+    let mut line: Vec<u8> = Vec::new();
+    let n = reader
+        .read_until(b'\n', &mut line)
         .map_err(|e| format!("read request: {e}"))?;
+    if n > MAX_CONTROL_REQUEST_BYTES && line.last() != Some(&b'\n') {
+        return Err(format!(
+            "control request exceeds maximum size of {MAX_CONTROL_REQUEST_BYTES} bytes; rejecting before decode"
+        ));
+    }
+    let body = match line.last() {
+        Some(&b'\n') => &line[..line.len() - 1],
+        _ => &line[..],
+    };
     let request: ControlRequest =
-        serde_json::from_str(line.trim_end()).map_err(|e| format!("decode request: {e}"))?;
+        serde_json::from_slice(body).map_err(|e| format!("decode request: {e}"))?;
 
     let mut response = ControlResponse {
         ok: true,

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -17,7 +17,7 @@ use crate::state_writer::StateWriter;
 use crate::{
     afxdp, BindingControlRequest, BindingStatus, ControlRequest, ControlResponse, ForwardingControlRequest,
     HAGroupStatus, HAStateUpdateRequest, ProcessStatus, QueueControlRequest, SessionSyncRequest,
-    UserspaceCapabilities,
+    UserspaceCapabilities, MAX_CONTROL_REQUEST_BYTES,
 };
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
@@ -76,6 +76,83 @@ fn req(request_type: &str) -> ControlRequest {
         request_type: request_type.to_string(),
         ..ControlRequest::default()
     }
+}
+
+/// Drive a RAW byte payload through `handle_stream` and return the
+/// handler's `Result<(), String>` directly. Unlike `run_request`, this
+/// does not assume the handler replies — an oversize/undecodable request
+/// is rejected before the reply is written, so the caller inspects the
+/// returned error string. The client half writes `payload` then shuts
+/// down the write side so a body WITHOUT a terminating newline still
+/// reaches EOF (the `take` cap, not the missing newline, must be what
+/// bounds the read).
+fn run_raw(state: Arc<Mutex<ServerState>>, payload: &[u8]) -> Result<(), String> {
+    use std::io::Write as _;
+    let state_file = unique_state_file("raw");
+    let (mut client, server) =
+        std::os::unix::net::UnixStream::pair().expect("control socket pair");
+    let running = Arc::new(AtomicBool::new(true));
+    let handle = {
+        let state_file = state_file.clone();
+        std::thread::spawn(move || handle_stream(server, &state_file, state, running))
+    };
+    client.write_all(payload).expect("write raw payload");
+    // Drop the write half so the handler sees EOF; an oversize body with
+    // no newline must still be bounded by the read cap, not block.
+    client
+        .shutdown(std::net::Shutdown::Write)
+        .expect("shutdown write");
+    // Drain any response the handler may write so it never blocks on a
+    // full socket buffer, then collect the handler result.
+    let mut sink = Vec::new();
+    let _ = std::io::Read::read_to_end(&mut client, &mut sink);
+    let result = handle.join().expect("handler thread");
+    let _ = std::fs::remove_file(&state_file);
+    result
+}
+
+// --- request byte cap (#2523) -------------------------------------------
+
+#[test]
+fn oversize_request_is_rejected_before_decode() {
+    // A body one byte past the cap with NO terminating newline. The cap
+    // must reject it before the (unbounded) decode allocation; the read
+    // itself is bounded to MAX+1 by the `take` in handle_stream.
+    let payload = vec![b'a'; MAX_CONTROL_REQUEST_BYTES + 1];
+    let err = run_raw(new_state(ProcessStatus::default()), &payload)
+        .expect_err("oversize request must be rejected");
+    assert!(
+        err.contains("exceeds maximum size"),
+        "expected oversize rejection, got: {err}"
+    );
+    // Fail-on-revert pin: if the cap is removed, `read_until` would slurp
+    // all MAX+1 'a' bytes and serde would fail with a DECODE error, not an
+    // "exceeds maximum size" error — so this assertion goes RED on revert.
+}
+
+#[test]
+fn max_size_legitimate_request_still_succeeds() {
+    // A real request padded with a large (but legal) field up to just
+    // under the cap, terminated by the single newline the Go encoder
+    // appends. The body is <= MAX bytes, so MAX+1 bytes on the wire ending
+    // in '\n' — the largest legitimate read. It must decode and succeed.
+    // Pad the request_type string so the serialized body approaches the
+    // cap without crossing it (leave generous slack for the JSON
+    // envelope). The body decodes as valid JSON and the dispatcher runs
+    // its catch-all arm — handle_stream completes with Ok(()), proving a
+    // max-size body is read, decoded, and handled rather than rejected.
+    let pad_len = MAX_CONTROL_REQUEST_BYTES - 4096;
+    let request = req(&"x".repeat(pad_len));
+    let mut payload = serde_json::to_vec(&request).expect("serialize");
+    assert!(
+        payload.len() <= MAX_CONTROL_REQUEST_BYTES,
+        "test payload {} must stay within the cap {}",
+        payload.len(),
+        MAX_CONTROL_REQUEST_BYTES
+    );
+    payload.push(b'\n');
+    run_raw(new_state(ProcessStatus::default()), &payload)
+        .expect("max-size legitimate request must succeed");
 }
 
 // --- dispatcher: ping / status / unknown --------------------------------


### PR DESCRIPTION
Closes #2523

## Summary
- The control socket reads one newline-delimited JSON request per connection in `handle_stream`. The read used an unbounded `read_line`: a malformed/compromised local caller could stream a large unterminated line and grow the helper's read buffer without bound. The 5 s read timeout bounds the worst case in time but not in allocation, and the body is read fully into memory before any schema validation, so a decode-time check cannot help.
- Both the main control socket and the session-sync socket route through `handle_stream`, so one fix covers both shared paths.
- Enforce the cap at the read: new `MAX_CONTROL_REQUEST_BYTES` + a `take(MAX + 1)`-bounded `read_until`. A read that stops at the cap WITHOUT a terminating newline is by construction oversize → rejected before any decode, fail-closed, daemon stays alive.

## Chosen cap + justification
`MAX_CONTROL_REQUEST_BYTES = 16 MiB` (`16 * 1024 * 1024`). The largest legitimate request is `apply_snapshot`, which carries the entire compiled config (zones, policies, address books, NAT rules, filters, routes). Even a pathological production config serializes to a few MB of JSON; 16 MiB leaves ~an order of magnitude of headroom while bounding a single request's read allocation to a fixed ceiling. A body of up to MAX bytes plus its single terminating newline (the Go encoder always appends one) = MAX+1 bytes ending in `\n` and still succeeds.

## Wire impact
Read-side only. The JSON wire shape is unchanged (the new constant is not a struct field), so no Go-side change and no `protocol_wire_v1.json` regeneration — the protocol wire-invariant test stays green. No separate control-request framing doc exists; the contract lives in the `handle_stream` module doc and the `MAX_CONTROL_REQUEST_BYTES` rustdoc, both updated here.

## Fail-on-revert proof
- `oversize_request_is_rejected_before_decode`: sends `MAX+1` bytes with no newline, asserts the `"exceeds maximum size"` rejection. Verified RED on revert — with the cap removed, `read_until` slurps the whole body and serde returns `decode request: expected value at line 1 column 1` instead, so the assertion fails. True fail-on-revert pin.
- `max_size_legitimate_request_still_succeeds`: body padded to just under the cap + one newline; asserts the handler completes.

## Test plan
- [x] `cargo build --release` clean (warnings pre-existing)
- [x] `cargo test --release --bin xpf-userspace-dp -- server::tests::` → 41/0
- [x] `protocol::tests::wire_invariant_default_specimens` green (no wire drift)
- [x] Fail-on-revert proven (cap removed → oversize test FAILS, restored → green)

## Refs
- #2523 (codex review-037 finding 037-04, LOW / local-only hardening)