### PR TITLE
appid: prefer port-based over protocol-only in tuple fallback (#2578)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,14 @@
+## 2026-06-25 — #2578: appid tuple fallback prefers port-based over protocol-only
+
+- **Timestamp**: 2026-06-25
+- **Action**: `resolveTupleFallback` iterated the applications map first-match
+  (non-deterministic). When both a port-based app (tcp/8443) and a protocol-only
+  app (tcp) match a session, the more-specific port-based app now wins
+  deterministically; ties break by name. Display-only label path (no
+  enforcement impact). Added a 256-iteration fail-on-revert test
+  (`TestResolveTupleFallbackPrefersPortOverProtocol`); doc note in README.
+- **File(s)**: pkg/appid/runtime.go, pkg/appid/runtime_test.go, pkg/appid/README.md
+
 ## 2026-06-25 — #2447: reject out-of-range CoS DSCP/PCP code-points instead of aliasing
 
 - **Timestamp**: 2026-06-25

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -33,7 +33,14 @@ and resolves session display names from the dataplane's assigned `app_id`.
   matches on protocol alone (#2548; before that fix `matchTuple`
   rejected an empty port, so protocol-only apps never matched and their
   sessions reported `UNKNOWN`). An app with neither protocol nor port is
-  never a match-all. When AppID is **enabled** in
+  never a match-all. When several configured apps match the same tuple,
+  `resolveTupleFallback` resolves deterministically by **specificity**: a
+  port-constrained app (`destination-port` set) wins over a protocol-only
+  app of the same protocol, with remaining ties broken by app name (#2578;
+  before that the map was iterated first-match, so a port-specific app
+  could non-deterministically lose to a protocol-only sibling). This is a
+  display-only label path — it does not affect policy enforcement, which
+  uses the dataplane-assigned `app_id`. When AppID is **enabled** in
   `services.application-identification` and the dataplane has not
   assigned an `app_id` for the session (`appID == 0`), the function
   returns `UNKNOWN` rather than guessing from port heuristics. Used

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -129,11 +129,28 @@ func sortedNames(names map[string]struct{}) []string {
 
 func resolveTupleFallback(proto uint8, dstPort uint16, cfg *config.Config) string {
 	if cfg != nil {
+		// #2578: cfg.Applications.Applications is a Go map; iterating it and
+		// returning the first match is non-deterministic. When BOTH a
+		// port-constrained app (e.g. tcp/8443) and a protocol-only app (tcp)
+		// match the same session, the more-specific port-based app must win,
+		// deterministically. Scan all matches, prefer a port-constrained app
+		// (DestinationPort != "") over a protocol-only one, and break ties by
+		// name so the result is stable regardless of map iteration order.
+		best := ""
+		bestPortBased := false
 		for name, app := range cfg.Applications.Applications {
 			if !matchTuple(proto, dstPort, app.Protocol, app.DestinationPort) {
 				continue
 			}
-			return name
+			portBased := app.DestinationPort != ""
+			if best == "" || (portBased && !bestPortBased) ||
+				(portBased == bestPortBased && name < best) {
+				best = name
+				bestPortBased = portBased
+			}
+		}
+		if best != "" {
+			return best
 		}
 	}
 	for name, ba := range builtinFallbacks {

--- a/pkg/appid/runtime_test.go
+++ b/pkg/appid/runtime_test.go
@@ -229,6 +229,39 @@ func TestResolveSessionNameProtocolOnlyApp(t *testing.T) {
 	}
 }
 
+// TestResolveTupleFallbackPrefersPortOverProtocol proves the #2578 specificity
+// ordering: when BOTH a port-based app (tcp/8443) and a protocol-only app (tcp)
+// match a session, the more-specific port-based app wins deterministically. The
+// matching-port session resolves to the port-based app; a non-matching-port TCP
+// session falls through to the protocol-only app. Reverting the specificity
+// sort in resolveTupleFallback (first-match map iteration) makes the matching-
+// port assertion flaky — it picks whichever app the Go map hits first.
+func TestResolveTupleFallbackPrefersPortOverProtocol(t *testing.T) {
+	cfg := &config.Config{
+		Applications: config.ApplicationsConfig{
+			Applications: map[string]*config.Application{
+				// Named so the port-based app sorts AFTER the protocol-only app
+				// alphabetically — a name-only tiebreak would pick the protocol
+				// app, so a passing test depends on the port>protocol rule.
+				"aaa-proto-only": {Name: "aaa-proto-only", Protocol: "tcp"},
+				"zzz-port-8443":  {Name: "zzz-port-8443", Protocol: "tcp", DestinationPort: "8443"},
+			},
+		},
+	}
+
+	// Run many times: map iteration order is randomized per-range, so a
+	// first-match implementation would intermittently return the protocol-only
+	// app. The specificity sort must make every iteration deterministic.
+	for i := 0; i < 256; i++ {
+		if got := resolveTupleFallback(6, 8443, cfg); got != "zzz-port-8443" {
+			t.Fatalf("iter %d: TCP/8443 = %q, want zzz-port-8443 (port-based beats protocol-only)", i, got)
+		}
+		if got := resolveTupleFallback(6, 9999, cfg); got != "aaa-proto-only" {
+			t.Fatalf("iter %d: TCP/9999 = %q, want aaa-proto-only (only the protocol-only app matches)", i, got)
+		}
+	}
+}
+
 func TestSessionMatchesUnknown(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Services.ApplicationIdentification = true


### PR DESCRIPTION
Closes #2578

## Summary
`resolveTupleFallback` (`pkg/appid/runtime.go`) iterated the
`cfg.Applications.Applications` map and returned the FIRST match. With
BOTH a port-constrained app (e.g. `tcp/8443`) and a protocol-only app
(`tcp`) matching the same session, the result was non-deterministic per
Go map iteration order — so the more-specific port-based app could
non-deterministically lose to the protocol-only sibling.

This change resolves deterministically by **specificity**: scan all
matching apps, prefer a port-constrained app (`DestinationPort != ""`)
over a protocol-only one of the same protocol, and break remaining ties
by app name.

DISPLAY-ONLY label path (`show security flow session` / `application`
filter); it does NOT affect policy enforcement, which uses the
dataplane-assigned `app_id`. Provenance: #2577 hostile review (angle 2),
follow-up to #2548/#2577.

## Fail-on-revert proof
Added `TestResolveTupleFallbackPrefersPortOverProtocol` — 256 iterations
(map order is randomized per range), asserting `TCP/8443` resolves to the
port-based app and `TCP/9999` to the protocol-only app. App names are
chosen so a name-only tiebreak would pick the protocol app, so a passing
test depends on the port>protocol rule.

Reverting the function body to the original first-match map iteration:

```
--- FAIL: TestResolveTupleFallbackPrefersPortOverProtocol (0.00s)
    runtime_test.go:257: iter 0: TCP/8443 = "aaa-proto-only", want zzz-port-8443 (port-based beats protocol-only)
FAIL    github.com/psaab/xpf/pkg/appid
```
Restored → `ok github.com/psaab/xpf/pkg/appid`.

## Gates
- `go build ./...` — ok
- `go vet ./pkg/appid/...` — ok
- `gofmt -l` touched files — clean
- `go test ./pkg/appid/... ./pkg/config/...` — ok

## Docs
- `pkg/appid/README.md` documents the specificity ordering + display-only
  scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi