### PR TITLE
nat: resolve match source-address-name for DNAT/SNAT source scoping (#2416)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15003,3 +15003,21 @@ top.
   (TestT2a_ChangedConfigApplyNeverTwoLiveConns) is a pre-existing NDP-socket
   bind flake on origin/master — confirmed failing with my changes stashed,
   and this PR touches zero pkg/ra code.
+
+## #2416 NAT match source-address-name resolution for DNAT/SNAT
+
+- **Timestamp**: 2026-06-25
+- **Action**: Resolve `match source-address-name <book-entry>` into concrete
+  source prefixes for DNAT and SNAT snapshots so the #2394 source constraint
+  enforces the named source scope (was published empty = fail-open match-any).
+  Fail-closed on an unknown name (raw token kept non-empty -> match-nothing);
+  added commit-time strict gate validateNATSourceAddressNameReferencesStrict
+  (lenient->warn on load/peer-sync). Added SNAT match parse + schema entry
+  (DNAT already had both). Fail-on-revert proven RED.
+- **File(s)**: pkg/dataplane/userspace/nat.go,
+  pkg/config/compiler_nat.go, pkg/config/compiler.go,
+  pkg/config/compiler_validate_strict.go, pkg/config/schema_security.go,
+  pkg/config/parser_security_test.go,
+  pkg/config/compiler_nat_source_address_name_2416_test.go,
+  pkg/dataplane/userspace/nat_source_address_name_2416_test.go,
+  docs/userspace-dnat-plan.md

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -374,6 +374,38 @@ Two robustness fixes (the DNAT sibling of #2398 SNAT):
    whose entries all fail to parse matches nothing rather than reverting to
    match-any. A mix of valid + garbage entries keeps the valid prefixes.
 
+### Address-book-name source scope (#2416)
+
+`match source-address` (#2394) takes literal prefixes; the sibling
+`match source-address-name <book-entry>` takes an **address-book reference**.
+The compiler parsed it into `NATMatch.SourceAddressName` but never resolved it
+into the source list `buildDestinationNATSnapshots` reads, so a name-scoped DNAT
+published an EMPTY `source_addresses` = `source_constrained == false` = match
+ANY source — the same fail-open as #2394 for the named variant. SNAT shared the
+gap (its match switch did not even parse the keyword, and the schema did not
+expose it).
+
+#2416 closes it:
+
+- `appendNATSourceAddressName` (`nat.go`) resolves the name via
+  `resolveUserspaceAddressBookEntry` — the same global-address-book expander the
+  security-policy snapshot path uses — and appends the concrete prefixes to the
+  rule's source list. Both `buildDestinationNATSnapshots` and
+  `buildSourceNATSnapshots` call it.
+- Fail-closed on an unknown / unresolvable name: the raw token is appended so
+  the source list stays non-empty (`source_constrained` stays true) while the
+  token fails `IpAddr`/`IpNet` parse and contributes no prefix — the rule
+  matches NOTHING, never collapsing back to match-any. This reuses the existing
+  #2394/#2398 all-malformed -> fail-closed Rust path; no wire change.
+- The SNAT match parser (`compiler_nat.go`) now reads `source-address-name`, and
+  the SNAT `match` schema (`schema_security.go`) exposes the keyword (DNAT
+  already did).
+- `validateNATSourceAddressNameReferencesStrict` (`compiler_validate_strict.go`)
+  hard-rejects an undefined reference at commit / commit-check so the typo is
+  operator-visible; the tolerant load / peer-sync path downgrades to a warning
+  (`lenientFirewallRefs`, #1960) and the dataplane backstop fails closed. Mirrors
+  the firewall prefix-list / policer reference gates.
+
 ## 11. Multiple destination-addresses (#2395)
 
 Junos DNAT `match destination-address [ A B C ]` publishes the SAME

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1398,6 +1398,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #2416: NAT `match source-address-name <book-entry>` cross-reference. A
+	// source / destination NAT rule naming an address-book entry not defined
+	// under `security address-book` compiled cleanly; the snapshot builder
+	// resolves the name to no prefixes and (per the fail-closed backstop) the
+	// rule matches NOTHING. That is safe but silent — the operator's intended
+	// source scoping is gone with no signal. Strict on commit / commit-check
+	// (hard reject so the typo is operator-visible); lenient on load / peer-sync
+	// (warn so an already-persisted or peer-synced config still boots — #1960;
+	// the dataplane then fails closed for the unresolved reference). Mirrors the
+	// firewall prefix-list gate above.
+	if err := validateNATSourceAddressNameReferencesStrict(cfg); err != nil {
+		if opts.lenientFirewallRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("NAT source-address-name reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	// #2217 Finding C: firewall-filter `then routing-instance <name>` (FBF)
 	// cross-reference. A term naming a routing-instance not defined under
 	// `routing-instances` compiled cleanly and the dataplane steered matched

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -993,6 +993,10 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 						if len(rule.Match.SourceAddresses) > 0 {
 							rule.Match.SourceAddress = rule.Match.SourceAddresses[0]
 						}
+					case "source-address-name":
+						// #2416: address-book reference; resolved to prefixes at
+						// snapshot-build time (appendNATSourceAddressName).
+						rule.Match.SourceAddressName = nodeVal(m)
 					case "destination-address":
 						// Support bracket lists: destination-address [ addr1 addr2 ... ]
 						if len(m.Keys) >= 2 {

--- a/pkg/config/compiler_nat_source_address_name_2416_test.go
+++ b/pkg/config/compiler_nat_source_address_name_2416_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2416: NAT `match source-address-name <book-entry>` is an address-book
+// reference. The compiler must (1) parse it into NATMatch.SourceAddressName for
+// both source and destination NAT, and (2) hard-reject at commit a rule whose
+// name is not defined under `security address-book`
+// (validateNATSourceAddressNameReferencesStrict) so the typo is operator-
+// visible instead of silently failing closed.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+func dnatSourceNameSet(matchName string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security address-book global address corp-a 198.51.100.0/24",
+		"set security address-book global address-set corp-net address corp-a",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match source-address-name " + matchName,
+		"set security nat destination rule-set rs1 rule r1 match destination-address 203.0.113.20",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	}
+}
+
+func snatSourceNameSet(matchName string) []string {
+	return []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security address-book global address corp-a 198.51.100.0/24",
+		"set security address-book global address-set corp-net address corp-a",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address-name " + matchName,
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+}
+
+func TestNATDNATSourceAddressNameParsed(t *testing.T) {
+	tree := buildTree(t, dnatSourceNameSet("corp-net"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("DNAT with a defined source-address-name must compile, got: %v", err)
+	}
+	if cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
+		t.Fatal("destination NAT rule-set missing after compile")
+	}
+	rule := cfg.Security.NAT.Destination.RuleSets[0].Rules[0]
+	if rule.Match.SourceAddressName != "corp-net" {
+		t.Fatalf("DNAT SourceAddressName = %q, want corp-net (parse dropped)", rule.Match.SourceAddressName)
+	}
+}
+
+func TestNATSNATSourceAddressNameParsed(t *testing.T) {
+	tree := buildTree(t, snatSourceNameSet("corp-net"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("SNAT with a defined source-address-name must compile, got: %v", err)
+	}
+	if len(cfg.Security.NAT.Source) == 0 {
+		t.Fatal("source NAT rule-set missing after compile")
+	}
+	rule := cfg.Security.NAT.Source[0].Rules[0]
+	if rule.Match.SourceAddressName != "corp-net" {
+		t.Fatalf("SNAT SourceAddressName = %q, want corp-net (parse dropped)", rule.Match.SourceAddressName)
+	}
+}
+
+func TestNATDNATUnknownSourceAddressNameRejected(t *testing.T) {
+	tree := buildTree(t, dnatSourceNameSet("does-not-exist"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a DNAT rule naming an undefined source-address-name must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "does-not-exist") {
+		t.Fatalf("error must name the rule + the undefined book entry, got: %v", err)
+	}
+}
+
+func TestNATSNATUnknownSourceAddressNameRejected(t *testing.T) {
+	tree := buildTree(t, snatSourceNameSet("does-not-exist"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a SNAT rule naming an undefined source-address-name must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "source") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "does-not-exist") {
+		t.Fatalf("error must name the rule + the undefined book entry, got: %v", err)
+	}
+}
+
+// The tolerant load / peer-sync path downgrades the undefined reference to a
+// warning so an already-persisted or peer-synced config still boots (#1960).
+func TestNATUnknownSourceAddressNameLenientWarns(t *testing.T) {
+	tree := buildTree(t, dnatSourceNameSet("does-not-exist"))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant path must not hard-reject an undefined source-address-name, got: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "source-address-name") && strings.Contains(w, "does-not-exist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant path must record a warning for the undefined reference, got warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2314,3 +2314,71 @@ func validatePrefixLengthRange(rf *RouteFilter) error {
 	}
 	return nil
 }
+
+// validateNATSourceAddressNameReferencesStrict hard-rejects a source or
+// destination NAT rule whose `match source-address-name <name>` names an
+// address-book entry not defined under `security address-book` (#2416).
+//
+// The name is resolved to concrete source prefixes at snapshot-build time
+// (appendNATSourceAddressName). A dangling reference contributes no prefix and
+// the rule fails closed (matches NOTHING) — safe, but silent: the operator's
+// intended source scoping vanishes with no signal. This gate makes the typo
+// operator-visible at commit, consistent with the firewall prefix-list and
+// policer reference gates.
+//
+// On the tolerant load / peer-sync paths the call site downgrades to a warning
+// (opts.lenientFirewallRefs) so an already-persisted or peer-synced config
+// still BOOTS (#1960); the dataplane then fails closed for the unresolved
+// reference. Rule-sets are walked source-first then destination, in slice
+// order, for a deterministic first error.
+func validateNATSourceAddressNameReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	ab := cfg.Security.AddressBook
+	defined := func(name string) bool {
+		if name == "" || ab == nil {
+			return false
+		}
+		if _, ok := ab.Addresses[name]; ok {
+			return true
+		}
+		_, ok := ab.AddressSets[name]
+		return ok
+	}
+	check := func(natType string, rs *NATRuleSet) error {
+		if rs == nil {
+			return nil
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil || rule.Match.SourceAddressName == "" {
+				continue
+			}
+			if defined(rule.Match.SourceAddressName) {
+				continue
+			}
+			return fmt.Errorf(
+				"%s NAT rule-set %q rule %q references undefined "+
+					"source-address-name %q (define `security address-book "+
+					"address %s` / `address-set %s`, or fix the name — the "+
+					"source scope would otherwise be silently lost and the "+
+					"rule would match no traffic)",
+				natType, rs.Name, rule.Name, rule.Match.SourceAddressName,
+				rule.Match.SourceAddressName, rule.Match.SourceAddressName)
+		}
+		return nil
+	}
+	for _, rs := range cfg.Security.NAT.Source {
+		if err := check("source", rs); err != nil {
+			return err
+		}
+	}
+	if cfg.Security.NAT.Destination != nil {
+		for _, rs := range cfg.Security.NAT.Destination.RuleSets {
+			if err := check("destination", rs); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -3884,7 +3884,10 @@ func TestDNATSourceAddressName(t *testing.T) {
 }
 
 func TestDNATSourceAddressNameSetSyntax(t *testing.T) {
-	lines := []string{"set security nat destination pool web1 address 10.0.30.100", "set security nat destination rule-set wan-dnat from zone untrust", "set security nat destination rule-set wan-dnat rule r1 match source-address-name mynet", "set security nat destination rule-set wan-dnat rule r1 match destination-address 50.0.0.1/32", "set security nat destination rule-set wan-dnat rule r1 match destination-port 443", "set security nat destination rule-set wan-dnat rule r1 then destination-nat pool web1"}
+	// #2416: the named entry must be defined in the address book or commit
+	// hard-rejects (validateNATSourceAddressNameReferencesStrict). Define
+	// `mynet` so this parse assertion still exercises the happy path.
+	lines := []string{"set security address-book global address mynet 192.0.2.0/24", "set security nat destination pool web1 address 10.0.30.100", "set security nat destination rule-set wan-dnat from zone untrust", "set security nat destination rule-set wan-dnat rule r1 match source-address-name mynet", "set security nat destination rule-set wan-dnat rule r1 match destination-address 50.0.0.1/32", "set security nat destination rule-set wan-dnat rule r1 match destination-port 443", "set security nat destination rule-set wan-dnat rule r1 then destination-nat pool web1"}
 	tree := &ConfigTree{}
 	for _, line := range lines {
 		cmd, err := ParseSetCommand(line)

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -87,6 +87,7 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				"rule": {desc: "Source NAT rule name", args: 1, placeholder: "<rule-name>", children: map[string]*schemaNode{
 					"match": {desc: "Match criteria", children: map[string]*schemaNode{
 						"source-address":      {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						"source-address-name": {desc: "Source address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
 						"destination-address": {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
 						"destination-port":    {desc: "Destination port to match", args: 1, multi: true, placeholder: "<port>", children: nil},
 						"application":         {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -24,6 +24,31 @@ func natCounterID(ids map[string]uint32, natType, ruleSet, rule string) uint32 {
 	return ids[dataplane.NATCounterKey(natType, ruleSet, rule)]
 }
 
+// appendNATSourceAddressName resolves a NAT rule's `match source-address-name
+// <book-entry>` into concrete source prefixes and appends them to the rule's
+// source list (#2416). It reuses resolveUserspaceAddressBookEntry — the same
+// global-address-book expander the security-policy snapshot path uses — so a
+// name-scoped NAT rule carries the entry's prefixes into the #2394 source
+// constraint instead of publishing an empty (match-any) source list.
+//
+// Fail-closed on an unknown / unresolvable name: the raw token is appended so
+// the source list stays NON-EMPTY (source_constrained stays true on the Rust
+// side) while the token itself fails IpAddr/IpNet parse and contributes no
+// prefix — the rule then matches NOTHING rather than collapsing to match-any.
+// This mirrors the policy path's behavior for an unresolved address reference
+// and is backstopped at commit by validateNATSourceAddressNameReferencesStrict.
+func appendNATSourceAddressName(cfg *config.Config, sourceAddrs []string, name string) []string {
+	if name == "" {
+		return sourceAddrs
+	}
+	if values, ok := resolveUserspaceAddressBookEntry(cfg, name); ok && len(values) > 0 {
+		return append(sourceAddrs, values...)
+	}
+	// Unknown / empty book entry: keep the constraint non-empty but
+	// unmatchable (fail-closed). The raw name cannot parse as an IP.
+	return append(sourceAddrs, name)
+}
+
 func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32) []SourceNATRuleSnapshot {
 	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
 		return nil
@@ -41,6 +66,10 @@ func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 			if len(sourceAddrs) == 0 && rule.Match.SourceAddress != "" {
 				sourceAddrs = append(sourceAddrs, rule.Match.SourceAddress)
 			}
+			// #2416: resolve `match source-address-name` for SNAT too — same
+			// builder gap as DNAT (the source list only carried literal
+			// prefixes). See appendNATSourceAddressName.
+			sourceAddrs = appendNATSourceAddressName(cfg, sourceAddrs, rule.Match.SourceAddressName)
 			destAddrs := append([]string(nil), rule.Match.DestinationAddresses...)
 			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
 				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
@@ -233,6 +262,22 @@ func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]u
 			if len(sourceAddrs) == 0 && rule.Match.SourceAddress != "" {
 				sourceAddrs = append(sourceAddrs, rule.Match.SourceAddress)
 			}
+			// #2416: `match source-address-name <book-entry>` scopes the DNAT
+			// the same way a literal `match source-address` does, but as an
+			// address-book reference. It was parsed into SourceAddressName yet
+			// never resolved into the source list the #2394 enforcement reads,
+			// so a name-scoped DNAT published an EMPTY source list = match any
+			// source = fail-open (a destination translation the operator scoped
+			// to a named source set fired for everyone). Resolve the name to its
+			// concrete prefixes via the same address-book expander the policy
+			// path uses and append them. On an unknown name we append the raw
+			// token: it cannot parse on the Rust side (IpAddr::parse fails) so it
+			// contributes no prefix, but it keeps the source list NON-EMPTY so
+			// source_constrained stays true and the rule matches NOTHING
+			// (fail-closed) instead of collapsing back to match-any. A commit-
+			// time strict gate (validateNATSourceAddressNameReferencesStrict)
+			// makes the typo operator-visible; this is the dataplane backstop.
+			sourceAddrs = appendNATSourceAddressName(cfg, sourceAddrs, rule.Match.SourceAddressName)
 
 			// Resolve application match to protocol+ports if specified.
 			type appTerm struct {

--- a/pkg/dataplane/userspace/nat_source_address_name_2416_test.go
+++ b/pkg/dataplane/userspace/nat_source_address_name_2416_test.go
@@ -1,0 +1,180 @@
+package userspace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2416: a NAT rule scoped by `match source-address-name <book-entry>` is an
+// address-book reference, not a literal prefix. The compiler parsed it into
+// NATMatch.SourceAddressName but the snapshot builder never resolved it into
+// the source list that the #2394 source-constraint enforcement reads, so a
+// name-scoped DNAT/SNAT published an EMPTY source list = match-any source =
+// fail-open. appendNATSourceAddressName resolves the name to its concrete
+// prefixes (reusing the policy-path address-book expander) and appends them.
+//
+// These tests construct the config at the struct level so they exercise the
+// snapshot builder directly. The compiler-side parse + commit-time reject are
+// covered in pkg/config (compiler_nat_source_address_name_2416_test.go).
+
+func addressBookForNAT() *config.AddressBook {
+	return &config.AddressBook{
+		Addresses: map[string]*config.Address{
+			"corp-a": {Name: "corp-a", Value: "198.51.100.0/24"},
+			"corp-b": {Name: "corp-b", Value: "203.0.113.7/32"},
+		},
+		AddressSets: map[string]*config.AddressSet{
+			"corp-net": {Name: "corp-net", Addresses: []string{"corp-a", "corp-b"}},
+		},
+	}
+}
+
+// TestBuildDestinationNATSnapshotsResolvesSourceAddressName is the core
+// fail-on-revert pin: a DNAT rule with `match source-address-name corp-net`
+// must publish the address-set's expanded prefixes in the snapshot source
+// list. Reverting appendNATSourceAddressName leaves SourceAddresses empty
+// (match-any = fail-open) and this test FAILS.
+func TestBuildDestinationNATSnapshotsResolvesSourceAddressName(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = addressBookForNAT()
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "scoped", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name: "name-scoped",
+					Match: config.NATMatch{
+						SourceAddressName:  "corp-net",
+						DestinationAddress: "203.0.113.20",
+						Protocol:           "tcp",
+						DestinationPort:    443,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	var got []string
+	for _, s := range snaps {
+		if s.Name == "name-scoped" {
+			got = s.SourceAddresses
+		}
+	}
+	// Address-set members expanded and sorted by the resolver.
+	want := []string{"198.51.100.0/24", "203.0.113.7/32"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("name-scoped DNAT SourceAddresses = %+v, want resolved book prefixes %+v "+
+			"(empty => source-address-name not resolved => fail-open #2416)", got, want)
+	}
+}
+
+// TestBuildDestinationNATSnapshotsSourceAddressNameAndLiteralUnion: a rule can
+// carry BOTH a literal `source-address` and a `source-address-name`; the
+// snapshot must union them (literals first, then resolved book prefixes).
+func TestBuildDestinationNATSnapshotsSourceAddressNameAndLiteralUnion(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = addressBookForNAT()
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "scoped", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name: "union",
+					Match: config.NATMatch{
+						SourceAddresses:    []string{"10.1.0.0/16"},
+						SourceAddressName:  "corp-a",
+						DestinationAddress: "203.0.113.21",
+						Protocol:           "tcp",
+						DestinationPort:    80,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	var got []string
+	for _, s := range snaps {
+		if s.Name == "union" {
+			got = s.SourceAddresses
+		}
+	}
+	want := []string{"10.1.0.0/16", "198.51.100.0/24"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("union DNAT SourceAddresses = %+v, want literal+resolved %+v", got, want)
+	}
+}
+
+// TestBuildDestinationNATSnapshotsUnknownSourceAddressNameFailsClosed: an
+// unresolvable book name keeps the source list NON-EMPTY (carries the raw
+// token), so source_constrained stays true on the Rust side and the rule
+// matches NOTHING — never collapses back to match-any (fail-open).
+func TestBuildDestinationNATSnapshotsUnknownSourceAddressNameFailsClosed(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = addressBookForNAT()
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "scoped", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name: "bad-name",
+					Match: config.NATMatch{
+						SourceAddressName:  "does-not-exist",
+						DestinationAddress: "203.0.113.22",
+						Protocol:           "tcp",
+						DestinationPort:    8080,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	var got []string
+	for _, s := range snaps {
+		if s.Name == "bad-name" {
+			got = s.SourceAddresses
+		}
+	}
+	if len(got) != 1 || got[0] != "does-not-exist" {
+		t.Fatalf("unknown source-address-name SourceAddresses = %+v, want [does-not-exist] "+
+			"(non-empty unparseable token => fail-closed match-nothing, NOT match-any)", got)
+	}
+}
+
+// TestBuildSourceNATSnapshotsResolvesSourceAddressName: SNAT shares the same
+// builder gap as DNAT. A source-NAT rule scoped by source-address-name must
+// carry the resolved prefixes too.
+func TestBuildSourceNATSnapshotsResolvesSourceAddressName(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = addressBookForNAT()
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{Name: "snat", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+			{
+				Name: "name-scoped-snat",
+				Match: config.NATMatch{
+					SourceAddressName: "corp-net",
+				},
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			},
+		}},
+	}
+
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	var got []string
+	for _, s := range snaps {
+		if s.Name == "name-scoped-snat" {
+			got = s.SourceAddresses
+		}
+	}
+	want := []string{"198.51.100.0/24", "203.0.113.7/32"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("name-scoped SNAT SourceAddresses = %+v, want resolved book prefixes %+v", got, want)
+	}
+}


### PR DESCRIPTION
Closes #2416

## Summary

- Junos NAT `match source-address-name <book-entry>` (the address-book reference variant of `match source-address`) was parsed into `NATMatch.SourceAddressName` but never resolved into the source list `buildDestinationNATSnapshots` reads, so a name-scoped DNAT published an EMPTY `source_addresses` = `source_constrained false` = match ANY source. A destination translation scoped to a named source set fired for everyone (fail-open, same class as #2394 for literal prefixes). SNAT shared the builder gap and additionally never parsed the keyword nor exposed it in the SNAT match schema.
- `appendNATSourceAddressName` resolves the name via `resolveUserspaceAddressBookEntry` (the same global-address-book expander the security-policy snapshot path uses) and appends the concrete prefixes to the rule's source list. Both DNAT and SNAT builders call it, so the existing #2394 end-to-end enforcement carries the named scope. No wire change.
- **Fail-closed on unknown name**: the raw token is appended so the source list stays non-empty (`source_constrained` true) while the token fails `IpAddr`/`IpNet` parse on the Rust side and contributes no prefix → the rule matches NOTHING, never collapsing to match-any. Reuses the existing #2394/#2398 all-malformed → fail-closed path; mirrors the policy fallback for an unresolved reference.
- SNAT match parser now reads `source-address-name`; SNAT match schema exposes the keyword (DNAT already had both).
- `validateNATSourceAddressNameReferencesStrict` hard-rejects an undefined reference at commit / commit-check (operator-visible typo); tolerant load / peer-sync downgrades to a warning (`lenientFirewallRefs`, #1960) with the dataplane backstop failing closed. Mirrors the firewall prefix-list / policer reference gates.

## Test plan

- [x] `pkg/dataplane/userspace`: name-scoped DNAT resolves the address-set prefixes; literal+named union carries both; unknown name keeps the non-empty unparseable token (fail-closed); SNAT resolves too.
- [x] `pkg/config`: source-address-name parses for DNAT and SNAT; undefined reference hard-rejected at commit; tolerant path warns.
- [x] `go build ./...`, `go vet ./pkg/config/ ./pkg/dataplane/userspace/`, `gofmt -l` — all clean.
- [x] `go test ./pkg/config/... ./pkg/dataplane/userspace/...` — green.

### Fail-on-revert proof

Reverting `appendNATSourceAddressName` to a no-op turns the userspace pins RED:

```
--- FAIL: TestBuildDestinationNATSnapshotsResolvesSourceAddressName
    name-scoped DNAT SourceAddresses = [], want resolved book prefixes [198.51.100.0/24 203.0.113.7/32]
--- FAIL: TestBuildDestinationNATSnapshotsSourceAddressNameAndLiteralUnion
--- FAIL: TestBuildDestinationNATSnapshotsUnknownSourceAddressNameFailsClosed
--- FAIL: TestBuildSourceNATSnapshotsResolvesSourceAddressName
```

Empty source list = the exact fail-open #2416 describes. Restored identical and green.

### Validation lanes not run

Cluster smoke / live NAT exercise (engineering-style table) NOT run — this is a compile-time config-resolution fix verified by unit tests and fail-on-revert; the PARENT drives review + any live validation.

## Refs

- #2416 (this), #2394 (literal source-address constraint, the sibling), #2398 (SNAT all-malformed fail-closed), #2506/#2401 (undefined-reference strict-gate pattern)