### PR TITLE
snmp: fail closed on corrupt/ceiling/unwritable engineBoots state (#2649)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15092,3 +15092,23 @@ top.
   pkg/config/compiler_nat_source_address_name_2416_test.go,
   pkg/dataplane/userspace/nat_source_address_name_2416_test.go,
   docs/userspace-dnat-plan.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2649 — SNMPv3 engineBoots fail-closed on corrupt/ceiling/
+  unwritable state. RFC 3414 §2.2 requires engineBoots monotonic; the prior
+  reset-to-1 on a corrupt/unreadable counter, a ceiling value, or a failed
+  durable write re-opened the timeliness replay window (same deterministic
+  engineID + low boots). Now pin engineBoots to the RFC ceiling
+  (engineBootsMax) in all those cases — checkTimeliness then rejects every
+  authenticated request (§3.2 step 7), forcing re-discovery, while the agent
+  still starts and answers discovery/report (no SNMP DoS — the owner's #2649
+  concern). First-boot missing file still legitimately starts at 1.
+  Replaced TestEngineBootsCorruptResets with three fail-on-revert tests
+  (corrupt fails closed, ceiling does not wrap, persist-failure fails closed)
+  and rebased TestV3SetRequest_NotWritable onto a writable temp boots path so
+  it still exercises the SET authz path. Fail-on-revert proven RED (restoring
+  boots=1 fails the corrupt + ceiling tests). Pre-existing pkg/ra
+  TestT2a_ChangedConfigApplyNeverTwoLiveConns failure is unrelated (fails on
+  clean origin/master, no snmp involvement).
+- **File(s)**: pkg/snmp/agent.go, pkg/snmp/v3_timeliness_test.go,
+  pkg/snmp/v3_set_test.go, pkg/snmp/README.md, _Log.md

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -131,11 +131,19 @@ requires of an authoritative engine:
   created. Each subsequent start reads the prior value, increments it, and
   persists the new value (1 → 2 → 3 …). `engineTime()` then counts from *this*
   boot (`startTime`), so the pair advances monotonically.
-- A corrupt/unreadable counter or a value at the RFC ceiling restarts the count
-  at `1` rather than wedging the agent — the timeliness check is the replay
-  backstop, so a lost counter degrades resynchronization, not security. A write
-  failure is logged and ignored; the agent serves with the in-memory boots for
-  this run and only cross-restart monotonicity is lost until the next write.
+- A corrupt/unreadable counter, a value already at the RFC ceiling, an
+  increment that would reach the ceiling, or a failed durable write all **fail
+  closed** by pinning `engineBoots` to the ceiling (`engineBootsMax`) rather
+  than restarting at `1` (#2649). RFC 3414 §2.2 requires `engineBoots` to be
+  monotonic for the authoritative engine; resetting to a low value while the
+  deterministic engineID is unchanged re-opens the replay window — a captured
+  authenticated request from a prior low-boots epoch could become timely again.
+  At the ceiling `checkTimeliness` rejects every authenticated request (§3.2
+  step 7), so managers must re-discover and the engineID must be reconfigured
+  to recover. The agent still starts and answers discovery/report (no SNMP
+  DoS), but no replayed low-boots packet is serveable while the counter is
+  corrupt, maxed, or unpersistable. First boot (missing file) still legitimately
+  starts at `1` — that is a genuinely new epoch, not a reuse of a low value.
 - The persist uses `fsatomic.WriteFileDurable` (fsync-on-write); the directory
   is created with `fsatomic.MkdirAllDurable`. This is slow-path (once per start),
   so per-write durability is affordable.

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -275,34 +275,53 @@ func (a *Agent) initEngine() {
 // monotonically-advancing authoritative pair RFC 3414 requires for replay
 // protection across restarts.
 //
-// A read/parse failure or a value at/over the RFC ceiling restarts the count
-// at 1 rather than refusing to serve — the timeliness check (which rejects a
-// stale boots/time on its own) is the replay backstop, and a corrupt counter
-// must not wedge the agent. A write failure is logged and ignored: the agent
-// still serves with the in-memory boots for this run; only cross-restart
-// monotonicity is lost until the next successful write.
+// RFC 3414 §2.2 requires engineBoots to be MONOTONIC for the authoritative
+// engine; it must never silently decrease while the engineID stays the same.
+// A reset back to a low value re-opens the replay window: a captured
+// authenticated request from a prior low-boots epoch can become timely again
+// (#2649). So a read/parse failure, a value already at/over the RFC ceiling,
+// an increment that would reach the ceiling, OR a failed durable write all
+// FAIL CLOSED by pinning engineBoots to the ceiling (engineBootsMax) rather
+// than restarting at 1. At the ceiling checkTimeliness rejects every
+// authenticated request (§3.2 step 7), which forces managers to re-discover —
+// the engineID must be reconfigured to recover. The agent still starts and
+// answers discovery/report (no SNMP DoS — the owner's #2649 concern), but no
+// replayed low-boots packet can pass while the counter is corrupt or maxed.
 func (a *Agent) loadAndIncrementEngineBoots() int {
 	prev := 0
+	corrupt := false
 	if data, err := os.ReadFile(a.engineBootsPath); err == nil {
 		if n, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil && n > 0 && n < engineBootsMax {
 			prev = n
 		} else {
-			slog.Warn("SNMP: engineBoots state unreadable, restarting count", "path", a.engineBootsPath)
+			slog.Warn("SNMP: engineBoots state unreadable, pinning to ceiling (fail-closed, re-discovery required)", "path", a.engineBootsPath)
+			corrupt = true
 		}
-	} else if !os.IsNotExist(err) {
-		slog.Warn("SNMP: engineBoots state read error, restarting count", "path", a.engineBootsPath, "err", err)
+	} else if os.IsNotExist(err) {
+		// First boot: no prior epoch exists, so boots=1 is genuinely new and
+		// not a reuse of a persisted low value. This is not a fail-open reset.
+	} else {
+		slog.Warn("SNMP: engineBoots state read error, pinning to ceiling (fail-closed, re-discovery required)", "path", a.engineBootsPath, "err", err)
+		corrupt = true
 	}
 
 	boots := prev + 1
-	if boots < 1 || boots >= engineBootsMax {
-		boots = 1
+	if corrupt || boots < 1 || boots >= engineBootsMax {
+		// Fail closed: a lost/corrupt counter or an exhausted counter pins to
+		// the ceiling so no low-boots replay is timely. Never restart at 1.
+		boots = engineBootsMax
 	}
 
 	if err := fsatomic.MkdirAllDurable(filepath.Dir(a.engineBootsPath), 0o755); err != nil {
-		slog.Warn("SNMP: engineBoots state dir create failed", "path", a.engineBootsPath, "err", err)
+		slog.Warn("SNMP: engineBoots state dir create failed, pinning to ceiling (fail-closed)", "path", a.engineBootsPath, "err", err)
+		boots = engineBootsMax
 	}
 	if err := fsatomic.WriteFileDurable(a.engineBootsPath, []byte(strconv.Itoa(boots)+"\n"), 0o644); err != nil {
-		slog.Warn("SNMP: engineBoots state persist failed", "path", a.engineBootsPath, "err", err)
+		// A boots value we cannot durably persist would be reused next start
+		// (the next read sees the stale lower value) → replay window. Fail
+		// closed for THIS run so the unpersisted epoch is never serveable.
+		slog.Warn("SNMP: engineBoots state persist failed, pinning to ceiling (fail-closed, re-discovery required)", "path", a.engineBootsPath, "err", err)
+		boots = engineBootsMax
 	}
 	return boots
 }

--- a/pkg/snmp/v3_set_test.go
+++ b/pkg/snmp/v3_set_test.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"crypto/hmac"
+	"path/filepath"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -156,11 +157,16 @@ func TestV3SetRequest_NotWritable(t *testing.T) {
 		authPro  = "sha"
 	)
 
-	a := NewAgent(&config.SNMPConfig{
+	// Use a writable temp boots path so engineBoots is a fresh 1 (matching the
+	// packet's engineBoots) and the timeliness gate passes — the default
+	// /var/lib/xpf path is unwritable under test and now fails closed by
+	// pinning to the ceiling (#2649), which is exercised separately.
+	bootsPath := filepath.Join(t.TempDir(), "snmp-engineboots")
+	a := NewAgentWithBootsPath(&config.SNMPConfig{
 		V3Users: map[string]*config.SNMPv3User{
 			userName: {Name: userName, AuthProtocol: authPro, AuthPassword: authPW},
 		},
-	})
+	}, bootsPath)
 
 	// Derive the localized auth key against the agent's engine ID so the
 	// packet authenticates against the live user table.

--- a/pkg/snmp/v3_timeliness_test.go
+++ b/pkg/snmp/v3_timeliness_test.go
@@ -291,18 +291,71 @@ func TestEngineBootsFirstBootMissingFile(t *testing.T) {
 	}
 }
 
-// TestEngineBootsCorruptResets confirms an unparseable counter restarts at 1
-// rather than wedging the agent (the timeliness check remains the replay
-// backstop).
-func TestEngineBootsCorruptResets(t *testing.T) {
+// TestEngineBootsCorruptFailsClosed confirms an unparseable counter does NOT
+// silently reset to a low, replayable value but pins engineBoots to the RFC
+// ceiling (#2649). RFC 3414 §2.2 requires engineBoots to be monotonic; a reset
+// to 1 with the same deterministic engineID re-opens the replay window for a
+// captured prior-epoch request. At the ceiling checkTimeliness rejects every
+// authenticated request, forcing re-discovery — fail closed, not fail open.
+//
+// fail-on-revert: restoring the old `boots = 1` reset makes both assertions
+// fail (engineBoots becomes 1, and checkTimeliness would no longer reject).
+func TestEngineBootsCorruptFailsClosed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "snmp-engineboots")
 	if err := os.WriteFile(path, []byte("not-a-number"), 0o644); err != nil {
 		t.Fatalf("seed corrupt file: %v", err)
 	}
 	a := NewAgentWithBootsPath(nil, path)
-	if a.engineBoots != 1 {
-		t.Fatalf("corrupt state: engineBoots = %d, want 1", a.engineBoots)
+	if a.engineBoots == 1 {
+		t.Fatal("corrupt state: engineBoots reset to 1 (fail-open replay window) — must pin to ceiling")
+	}
+	if a.engineBoots != engineBootsMax {
+		t.Fatalf("corrupt state: engineBoots = %d, want ceiling %d (fail-closed)", a.engineBoots, engineBootsMax)
+	}
+	// At the ceiling every authenticated request is rejected (§3.2 step 7),
+	// so no replayed prior-epoch packet can be timely.
+	if a.checkTimeliness(a.engineBoots, a.engineTime()) {
+		t.Fatal("corrupt state pinned to ceiling must reject all authenticated requests")
+	}
+}
+
+// TestEngineBootsCeilingDoesNotWrap confirms a persisted value at the ceiling
+// does NOT wrap back to 1 on the next start (which would re-open the replay
+// window) but stays pinned at the ceiling (#2649).
+//
+// fail-on-revert: the old `boots = 1` reset wraps a ceiling-valued file to 1.
+func TestEngineBootsCeilingDoesNotWrap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "snmp-engineboots")
+	if err := os.WriteFile(path, []byte(strconv.Itoa(engineBootsMax)+"\n"), 0o644); err != nil {
+		t.Fatalf("seed ceiling file: %v", err)
+	}
+	a := NewAgentWithBootsPath(nil, path)
+	if a.engineBoots != engineBootsMax {
+		t.Fatalf("ceiling state: engineBoots = %d, want ceiling %d (no wrap to 1)", a.engineBoots, engineBootsMax)
+	}
+}
+
+// TestEngineBootsPersistFailureFailsClosed confirms that when the boots value
+// cannot be durably persisted (unwritable state directory), the agent pins to
+// the ceiling for this run rather than serving with an unpersisted low value
+// that the next start would reuse as a stale (replayable) epoch (#2649).
+//
+// fail-on-revert: dropping the persist-failure ceiling pin makes engineBoots
+// stay at the low prev+1 value, failing this assertion.
+func TestEngineBootsPersistFailureFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	// Make the parent a regular file so MkdirAllDurable/WriteFileDurable under
+	// it cannot succeed, forcing the durable-write failure path.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	path := filepath.Join(blocker, "subdir", "snmp-engineboots")
+	a := NewAgentWithBootsPath(nil, path)
+	if a.engineBoots != engineBootsMax {
+		t.Fatalf("persist failure: engineBoots = %d, want ceiling %d (fail-closed)", a.engineBoots, engineBootsMax)
 	}
 }
 


### PR DESCRIPTION
Closes #2649

## Summary
The SNMPv3 authoritative engine's `engineBoots` counter must be MONOTONIC
per RFC 3414 §2.2. `loadAndIncrementEngineBoots` previously **reset to 1**
on a corrupt/unreadable state file, on a value at the RFC ceiling (wrap),
and silently ignored a failed durable write while still serving. Because
the engineID is deterministic (hostname-derived), a reset to a low boots
value re-opens the §3.2 timeliness replay window — a captured authenticated
request from an earlier low-boots epoch becomes timely again if its
`msgAuthoritativeEngineTime` lands within the 150s window of the new epoch.

This is codex review-043 finding 043-02, distinct from the already-fixed
#2610. Per the parent adjudication it is a **hardening** (persist-or-
escalate, not reset-to-1) — refuse-to-start would be an SNMP DoS.

## Fix (RFC 3414 basis)
In every fail case — unparseable/out-of-range counter, read error, a value
at/over the ceiling, an increment reaching the ceiling, a state-dir create
failure, or a durable-write failure — **pin `engineBoots` to `engineBootsMax`
(the RFC ceiling)** instead of restarting at 1. RFC 3414 §3.2 step 7 makes
`checkTimeliness` reject every authenticated request once boots is at the
ceiling, forcing managers to re-discover and requiring the engineID to be
reconfigured to recover. The agent still binds and answers discovery/report,
so there is **no SNMP DoS**. First boot (missing file) still legitimately
starts at 1 — a genuinely new epoch, not reuse of a persisted low value.

## Fail-on-revert proof
Replaced `TestEngineBootsCorruptResets` (which asserted the unsafe reset-to-1)
with three fail-on-revert tests:
- `TestEngineBootsCorruptFailsClosed` — corrupt counter pins to ceiling and
  `checkTimeliness` rejects all requests.
- `TestEngineBootsCeilingDoesNotWrap` — a ceiling-valued file does not wrap to 1.
- `TestEngineBootsPersistFailureFailsClosed` — an unwritable state dir pins to ceiling.

Restoring the old `boots = 1` reset turns both the corrupt and ceiling tests
RED (verified):
```
--- FAIL: TestEngineBootsCorruptFailsClosed
    engineBoots reset to 1 (fail-open replay window) — must pin to ceiling
--- FAIL: TestEngineBootsCeilingDoesNotWrap
    engineBoots = 1, want ceiling 2147483647 (no wrap to 1)
```
`TestV3SetRequest_NotWritable` was rebased onto a writable temp boots path so
it still exercises the SET authorization path (the default `/var/lib/xpf` path
is unwritable under test and now correctly fails closed).

## Gates
- `go build ./...` — clean
- `gofmt -l` touched .go files — clean
- `go vet ./pkg/snmp/ ./pkg/daemon/` — clean
- `go test ./pkg/snmp/ ./pkg/daemon/` — PASS
- README engineBoots-persistence contract updated.
- Unrelated pre-existing `pkg/ra` `TestT2a_ChangedConfigApplyNeverTwoLiveConns`
  failure confirmed RED on clean `origin/master` (no snmp involvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi