### PR TITLE
daemon: reconcile LLDP service on day-2 config commits (#2372)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15092,3 +15092,15 @@ top.
   pkg/config/compiler_nat_source_address_name_2416_test.go,
   pkg/dataplane/userspace/nat_source_address_name_2416_test.go,
   docs/userspace-dnat-plan.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2372 — reconcile the LLDP service on day-2 config commits
+  (was boot-only, requiring a daemon restart). Extracted the boot-time LLDP
+  start into `Daemon.reconcileLLDP` (single source of truth), wired it into
+  `applyConfigLocked` after the DHCP-relay reconcile, lazily instantiates the
+  manager on first enable and `Stop()`s it on disable/empty. Added
+  `lldp.Manager.Running()` accessor + a fail-on-revert daemon test
+  (lazy-create on day-2 enable; disable-stops-running under CAP_NET_RAW).
+  **File(s)**: pkg/daemon/daemon_apply.go, pkg/daemon/daemon_run.go,
+  pkg/daemon/daemon_lldp_reconcile_test.go, pkg/lldp/lldp.go,
+  pkg/lldp/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -15104,3 +15104,20 @@ top.
   **File(s)**: pkg/daemon/daemon_apply.go, pkg/daemon/daemon_run.go,
   pkg/daemon/daemon_lldp_reconcile_test.go, pkg/lldp/lldp.go,
   pkg/lldp/README.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2372 review fold — addressed hostile-review findings 3 + 6 on
+  PR #2748. (3) Data race on d.lldpMgr: construct the manager ONCE at boot
+  (unconditionally, mirroring d.dhcpRelay); reconcileLLDP now never reassigns
+  the pointer (only Apply/Stop), so the lock-free `show lldp neighbors`
+  handler reads can't race a day-2 commit. (6) Per-commit thrash: added a
+  reconcile-level diff-guard (effectiveLLDPConfig + lldpConfigEqual,
+  lldpApplied/lldpApplyInit on Daemon) so an unrelated commit no longer
+  Stop()/rebuilds the LLDP generation (which wipes the neighbor table + churns
+  sockets). Added lldp.Manager.ApplyCount() seam + two fail-on-revert tests
+  (manager-identity-stable; skips-unchanged-commit), both proven RED on revert.
+  go test -race ./pkg/daemon/ ./pkg/lldp/ green; disable-stops test PASS under
+  CAP_NET_RAW.
+  **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_apply.go,
+  pkg/daemon/daemon_run.go, pkg/daemon/daemon_lldp_reconcile_test.go,
+  pkg/lldp/lldp.go, pkg/lldp/README.md

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -209,6 +209,8 @@ type Daemon struct {
 	dhcpRelay                  *dhcprelay.Manager
 	snmpAgent                  *snmp.Agent
 	lldpMgr                    *lldp.Manager
+	lldpApplied                *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
+	lldpApplyInit              bool             // true once reconcileLLDP has run at least once
 	scheduler                  *scheduler.Scheduler
 	schedulerCancel            context.CancelFunc
 	policySchedulerConfigHash  [32]byte

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -18,6 +18,7 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/ipsec"
+	"github.com/psaab/xpf/pkg/lldp"
 	"github.com/psaab/xpf/pkg/routing"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
@@ -1202,6 +1203,15 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	// d.daemonCtx so the relay goroutines outlive this apply call.
 	d.reconcileDHCPRelay(cfg)
 
+	// 16d. Reconcile the LLDP service (#2372). Before this, LLDP was applied
+	// only at boot (daemon_run.go), so a day-2 commit that enabled, disabled,
+	// or changed `protocols lldp` (interface set, transmit-interval,
+	// hold-multiplier) was silently ignored until a daemon restart. reconcileLLDP
+	// lazily instantiates the manager on the first enable and Apply()s the new
+	// config; a disabled/empty stanza stops the running service. Bound to
+	// d.daemonCtx so the TX/RX goroutines outlive this apply call.
+	d.reconcileLLDP(cfg)
+
 	// 17. Update event-options policies (RPM-driven failover)
 	if d.eventEngine != nil {
 		d.eventEngine.Apply(cfg.EventOptions)
@@ -1370,6 +1380,61 @@ func (d *Daemon) reconcileDHCPRelay(cfg *config.Config) {
 		ctx = context.Background()
 	}
 	d.dhcpRelay.Apply(ctx, cfg.ForwardingOptions.DHCPRelay)
+}
+
+// reconcileLLDP re-applies the LLDP service config on every commit (#2372). It
+// is the single source of truth for LLDP lifecycle — daemon_run.go calls it at
+// boot, and applyConfigLocked calls it on every day-2 commit, so a change to
+// `protocols lldp` takes effect without a daemon restart.
+//
+// Unlike the DHCP relay Manager (always created at boot), the LLDP Manager is
+// instantiated lazily on the first commit that enables LLDP, so a daemon that
+// never runs LLDP never allocates the manager or its sockets. lldp.Manager.Apply
+// is itself reconcile-shaped: it Stop()s the current generation (closing every
+// per-interface socket and clearing the neighbor table) before starting the new
+// one, so calling it repeatedly is idempotent and a disabled/empty config stops
+// the running service.
+//
+// The manager is bound to d.daemonCtx (the daemon lifetime) — NOT a
+// request-scoped context — so the TX/RX/expiry goroutines survive past this
+// apply call and are torn down only at daemon stop (or the next reconcile that
+// disables LLDP).
+func (d *Daemon) reconcileLLDP(cfg *config.Config) {
+	enabled := cfg != nil && cfg.Protocols.LLDP != nil &&
+		!cfg.Protocols.LLDP.Disable && len(cfg.Protocols.LLDP.Interfaces) > 0
+
+	if !enabled {
+		// Nothing to run. Stop a manager that was started by an earlier commit;
+		// if LLDP was never enabled, d.lldpMgr is nil and this is a no-op (no
+		// manager is allocated just to immediately stop it).
+		if d.lldpMgr != nil {
+			d.lldpMgr.Stop()
+		}
+		return
+	}
+
+	if d.lldpMgr == nil {
+		d.lldpMgr = lldp.New()
+	}
+
+	var lldpIfaces []lldp.LLDPInterface
+	for _, iface := range cfg.Protocols.LLDP.Interfaces {
+		lldpIfaces = append(lldpIfaces, lldp.LLDPInterface{
+			Name:    iface.Name,
+			Disable: iface.Disable,
+		})
+	}
+
+	ctx := d.daemonCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	d.lldpMgr.Apply(ctx, &lldp.LLDPConfig{
+		Interfaces:     lldpIfaces,
+		Interval:       cfg.Protocols.LLDP.Interval,
+		HoldMultiplier: cfg.Protocols.LLDP.HoldMultiplier,
+		SystemName:     cfg.System.HostName,
+	})
 }
 
 func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, activeState map[string]bool, applyResult *dataplane.ApplyResult) {

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -1382,59 +1383,95 @@ func (d *Daemon) reconcileDHCPRelay(cfg *config.Config) {
 	d.dhcpRelay.Apply(ctx, cfg.ForwardingOptions.DHCPRelay)
 }
 
-// reconcileLLDP re-applies the LLDP service config on every commit (#2372). It
-// is the single source of truth for LLDP lifecycle — daemon_run.go calls it at
-// boot, and applyConfigLocked calls it on every day-2 commit, so a change to
-// `protocols lldp` takes effect without a daemon restart.
-//
-// Unlike the DHCP relay Manager (always created at boot), the LLDP Manager is
-// instantiated lazily on the first commit that enables LLDP, so a daemon that
-// never runs LLDP never allocates the manager or its sockets. lldp.Manager.Apply
-// is itself reconcile-shaped: it Stop()s the current generation (closing every
-// per-interface socket and clearing the neighbor table) before starting the new
-// one, so calling it repeatedly is idempotent and a disabled/empty config stops
-// the running service.
-//
-// The manager is bound to d.daemonCtx (the daemon lifetime) — NOT a
-// request-scoped context — so the TX/RX/expiry goroutines survive past this
-// apply call and are torn down only at daemon stop (or the next reconcile that
-// disables LLDP).
-func (d *Daemon) reconcileLLDP(cfg *config.Config) {
-	enabled := cfg != nil && cfg.Protocols.LLDP != nil &&
-		!cfg.Protocols.LLDP.Disable && len(cfg.Protocols.LLDP.Interfaces) > 0
-
-	if !enabled {
-		// Nothing to run. Stop a manager that was started by an earlier commit;
-		// if LLDP was never enabled, d.lldpMgr is nil and this is a no-op (no
-		// manager is allocated just to immediately stop it).
-		if d.lldpMgr != nil {
-			d.lldpMgr.Stop()
-		}
-		return
+// effectiveLLDPConfig translates the typed `protocols lldp` stanza into the
+// lldp.LLDPConfig the manager consumes, or returns nil when LLDP is disabled,
+// empty, or absent (the "stop the service" signal). It is the single mapping
+// used by both boot and the day-2 reconcile, so the diff-guard in reconcileLLDP
+// compares like-for-like.
+func effectiveLLDPConfig(cfg *config.Config) *lldp.LLDPConfig {
+	if cfg == nil || cfg.Protocols.LLDP == nil ||
+		cfg.Protocols.LLDP.Disable || len(cfg.Protocols.LLDP.Interfaces) == 0 {
+		return nil
 	}
-
-	if d.lldpMgr == nil {
-		d.lldpMgr = lldp.New()
-	}
-
-	var lldpIfaces []lldp.LLDPInterface
+	lldpIfaces := make([]lldp.LLDPInterface, 0, len(cfg.Protocols.LLDP.Interfaces))
 	for _, iface := range cfg.Protocols.LLDP.Interfaces {
 		lldpIfaces = append(lldpIfaces, lldp.LLDPInterface{
 			Name:    iface.Name,
 			Disable: iface.Disable,
 		})
 	}
+	return &lldp.LLDPConfig{
+		Interfaces:     lldpIfaces,
+		Interval:       cfg.Protocols.LLDP.Interval,
+		HoldMultiplier: cfg.Protocols.LLDP.HoldMultiplier,
+		SystemName:     cfg.System.HostName,
+	}
+}
+
+// reconcileLLDP re-applies the LLDP service config on every commit (#2372). It
+// is the single source of truth for LLDP lifecycle — daemon_run.go calls it at
+// boot, and applyConfigLocked calls it on every day-2 commit, so a change to
+// `protocols lldp` takes effect without a daemon restart.
+//
+// The manager itself is constructed exactly once at boot (daemon_run.go),
+// mirroring d.dhcpRelay. reconcileLLDP NEVER reassigns the d.lldpMgr pointer —
+// it only calls Apply()/Stop() on the already-constructed manager. This keeps
+// the lock-free d.lldpMgr reads on the `show lldp neighbors` handler goroutines
+// race-free against a concurrent commit (finding 3): the pointer is written
+// once, before any handler can run.
+//
+// Change-guarded (finding 6): lldp.Manager.Apply unconditionally Stop()s the
+// current generation — closing every per-interface socket, joining goroutines,
+// AND wiping the neighbor table — before rebuilding. Calling it on every commit
+// would blank `show lldp neighbors` and churn sockets on any unrelated day-2
+// commit (e.g. a firewall-policy change) while neighbors re-learn. So Apply (or
+// Stop) is invoked only when the effective LLDP config actually changed from the
+// last-applied one, matching the diff discipline of the adjacent
+// reconcileDHCPRelay (#2348). The first call (boot) always applies.
+//
+// The manager is bound to d.daemonCtx (the daemon lifetime) — NOT a
+// request-scoped context — so the TX/RX/expiry goroutines survive past this
+// apply call and are torn down only at daemon stop (or the next reconcile that
+// disables LLDP).
+func (d *Daemon) reconcileLLDP(cfg *config.Config) {
+	if d.lldpMgr == nil {
+		// Defensive: a test harness or a boot path that skipped the construct-
+		// once wiring leaves the manager nil. Nothing to reconcile.
+		return
+	}
+
+	want := effectiveLLDPConfig(cfg)
+
+	// Skip when the effective config is unchanged since the last reconcile, so
+	// an unrelated commit never bounces a healthy LLDP generation (sockets +
+	// neighbor table). The first reconcile (boot) always runs.
+	if d.lldpApplyInit && lldpConfigEqual(d.lldpApplied, want) {
+		return
+	}
+	d.lldpApplyInit = true
+	d.lldpApplied = want
+
+	if want == nil {
+		// Disabled / empty: stop the running service (idempotent if already
+		// stopped).
+		d.lldpMgr.Stop()
+		return
+	}
 
 	ctx := d.daemonCtx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	d.lldpMgr.Apply(ctx, &lldp.LLDPConfig{
-		Interfaces:     lldpIfaces,
-		Interval:       cfg.Protocols.LLDP.Interval,
-		HoldMultiplier: cfg.Protocols.LLDP.HoldMultiplier,
-		SystemName:     cfg.System.HostName,
-	})
+	d.lldpMgr.Apply(ctx, want)
+}
+
+// lldpConfigEqual reports whether two effective LLDP configs are equivalent for
+// reconcile purposes (both nil, or deeply equal). nil means "service stopped".
+func lldpConfigEqual(a, b *lldp.LLDPConfig) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return reflect.DeepEqual(a, b)
 }
 
 func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, activeState map[string]bool, applyResult *dataplane.ApplyResult) {

--- a/pkg/daemon/daemon_lldp_reconcile_test.go
+++ b/pkg/daemon/daemon_lldp_reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/lldp"
 )
 
 // lldpCfg builds a *config.Config with an LLDP stanza. disable toggles the
@@ -19,43 +20,129 @@ func lldpCfg(disable bool, ifaces ...string) *config.Config {
 	return cfg
 }
 
-// TestReconcileLLDPLazyCreateOnDay2Enable is the fail-on-revert pin for #2372.
+// bootDaemon returns a Daemon wired the way daemon_run.go wires it for LLDP:
+// the manager is constructed once at boot (unconditionally), so reconcileLLDP
+// never reassigns the pointer.
+func bootDaemon(ctx context.Context) *Daemon {
+	return &Daemon{daemonCtx: ctx, lldpMgr: lldp.New()}
+}
+
+// TestReconcileLLDPManagerIdentityStable is the fail-on-revert pin for #2372
+// finding 3 (data race on the d.lldpMgr pointer).
 //
-// The defect: LLDP was Apply()'d once at boot (daemon_run.go) and never from
-// the day-2 apply pipeline, so a commit that enabled `protocols lldp` after the
-// daemon booted with LLDP disabled (d.lldpMgr == nil) did nothing — the manager
-// was never instantiated post-boot. This test recreates that exact failure
-// mode: a daemon that booted with LLDP disabled (nil manager) receives a day-2
-// commit enabling LLDP, and the reconcile MUST lazily create the manager.
+// The manager is constructed exactly once at boot; reconcileLLDP must only ever
+// call Apply()/Stop() on it and NEVER reassign the pointer. The `show lldp
+// neighbors` gRPC/CLI handlers read d.lldpMgr lock-free on a handler goroutine,
+// so a day-2 reassignment (the lazy-create the first version did) would be a
+// data race on the pointer field per the Go memory model. This test asserts the
+// pointer identity is stable across the full lifecycle: a day-2 enable, a
+// reconfigure, and a disable.
 //
-// If the day-2 reconcile is reverted (LLDP start moves back to boot-only),
-// reconcileLLDP would no longer create the manager on a day-2 enable and
-// d.lldpMgr stays nil → this test goes RED.
+// If reconcileLLDP reverts to reassigning d.lldpMgr (e.g. lazy-create on
+// enable), the identity check goes RED.
+func TestReconcileLLDPManagerIdentityStable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := bootDaemon(ctx)
+	orig := d.lldpMgr
+	if orig == nil {
+		t.Fatal("boot wiring did not construct the LLDP manager")
+	}
+
+	// Boot reconcile with LLDP disabled.
+	d.reconcileLLDP(lldpCfg(true))
+	// Day-2 enable.
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic0"))
+	// Day-2 reconfigure (different interface set).
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic1"))
+	// Day-2 disable.
+	d.reconcileLLDP(lldpCfg(true))
+
+	if d.lldpMgr != orig {
+		t.Fatalf("reconcileLLDP reassigned the d.lldpMgr pointer; the handler "+
+			"read path would race a commit (#2372 finding 3). orig=%p now=%p",
+			orig, d.lldpMgr)
+	}
+	d.lldpMgr.Stop()
+}
+
+// TestReconcileLLDPSkipsUnchangedCommit is the fail-on-revert pin for #2372
+// finding 6 (per-commit thrash).
+//
+// lldp.Manager.Apply unconditionally Stop()s the running generation — closing
+// sockets, joining goroutines, AND wiping the neighbor table — before
+// rebuilding. So reconcileLLDP must call Apply only when the effective LLDP
+// config actually changed; an unrelated day-2 commit (with LLDP unchanged) must
+// NOT re-Apply, or `show lldp neighbors` blanks and sockets churn while
+// neighbors re-learn.
+//
+// The seam is lldp.Manager.ApplyCount(). A second commit with an identical LLDP
+// stanza must leave it unchanged. Reverting the diff-guard (calling Apply on
+// every commit) makes the unchanged-commit assertion RED.
+func TestReconcileLLDPSkipsUnchangedCommit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := bootDaemon(ctx)
+
+	// First commit enables LLDP — must Apply once.
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic0"))
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Fatalf("first enable: ApplyCount = %d, want 1", got)
+	}
+
+	// Second commit with an identical LLDP stanza (a fresh but equal config,
+	// modelling an unrelated day-2 commit) must be skipped — no re-Apply.
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic0"))
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Fatalf("unchanged commit re-Applied (per-commit thrash, #2372 "+
+			"finding 6): ApplyCount = %d, want 1", got)
+	}
+
+	// A genuine change (different interface) must re-Apply.
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic1"))
+	if got := d.lldpMgr.ApplyCount(); got != 2 {
+		t.Fatalf("changed commit did not re-Apply: ApplyCount = %d, want 2", got)
+	}
+
+	// Another unchanged commit (matching the last applied) must again skip.
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic1"))
+	if got := d.lldpMgr.ApplyCount(); got != 2 {
+		t.Fatalf("second unchanged commit re-Applied: ApplyCount = %d, want 2", got)
+	}
+
+	d.lldpMgr.Stop()
+}
+
+// TestReconcileLLDPLazyCreateOnDay2Enable verifies the day-2 enable still takes
+// effect with the construct-once wiring: a daemon that booted with LLDP
+// disabled (manager constructed but never Apply()'d) and then receives a commit
+// enabling LLDP must Apply the new config. This recreates the original #2372
+// failure mode (boot-only start) at the reconcile level.
 func TestReconcileLLDPLazyCreateOnDay2Enable(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Boot state: LLDP disabled, manager never created.
-	d := &Daemon{daemonCtx: ctx}
+	d := bootDaemon(ctx)
+
+	// Boot state: LLDP disabled — no Apply.
 	d.reconcileLLDP(lldpCfg(true))
-	if d.lldpMgr != nil {
-		t.Fatalf("reconcileLLDP allocated a manager for a disabled stanza; want nil")
+	if got := d.lldpMgr.ApplyCount(); got != 0 {
+		t.Fatalf("disabled boot Applied: ApplyCount = %d, want 0", got)
 	}
 
-	// Day-2 commit enables LLDP. The manager must be lazily instantiated, even
-	// though no interface socket can be opened in the test env (the interface
-	// lookup is a no-op skip without a real NIC + CAP_NET_RAW).
+	// Day-2 commit enables LLDP — must Apply (the boot-only defect would skip
+	// this because the day-2 reconcile would not run at all).
 	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic0"))
-	if d.lldpMgr == nil {
-		t.Fatalf("day-2 enable did not lazily create the LLDP manager; " +
-			"reconcile is not running on commit (the #2372 boot-only defect)")
+	if got := d.lldpMgr.ApplyCount(); got != 1 {
+		t.Fatalf("day-2 enable did not Apply (the #2372 boot-only defect): "+
+			"ApplyCount = %d, want 1", got)
 	}
-
-	// Clean up any goroutines the manager started.
 	d.lldpMgr.Stop()
 }
 
-// TestReconcileLLDPDisableStopsRunning verifies the inverse: a day-2 commit that
+// TestReconcileLLDPDisableStopsRunning verifies that a day-2 commit which
 // disables LLDP stops the running service. It needs a live generation, which
 // requires opening an AF_PACKET socket on the loopback interface (CAP_NET_RAW).
 // When that capability is absent (unprivileged CI), Apply() logs + skips the
@@ -65,11 +152,8 @@ func TestReconcileLLDPDisableStopsRunning(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	d := &Daemon{daemonCtx: ctx}
+	d := bootDaemon(ctx)
 	d.reconcileLLDP(lldpCfg(false, "lo"))
-	if d.lldpMgr == nil {
-		t.Fatal("enable on lo did not create the manager")
-	}
 	if !d.lldpMgr.Running() {
 		d.lldpMgr.Stop()
 		t.Skip("no live LLDP generation on lo (no CAP_NET_RAW); " +

--- a/pkg/daemon/daemon_lldp_reconcile_test.go
+++ b/pkg/daemon/daemon_lldp_reconcile_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// lldpCfg builds a *config.Config with an LLDP stanza. disable toggles the
+// global `protocols lldp disable`; ifaces names the enabled interfaces.
+func lldpCfg(disable bool, ifaces ...string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Protocols.LLDP = &config.LLDPConfig{Disable: disable}
+	for _, name := range ifaces {
+		cfg.Protocols.LLDP.Interfaces = append(cfg.Protocols.LLDP.Interfaces,
+			config.LLDPInterface{Name: name})
+	}
+	return cfg
+}
+
+// TestReconcileLLDPLazyCreateOnDay2Enable is the fail-on-revert pin for #2372.
+//
+// The defect: LLDP was Apply()'d once at boot (daemon_run.go) and never from
+// the day-2 apply pipeline, so a commit that enabled `protocols lldp` after the
+// daemon booted with LLDP disabled (d.lldpMgr == nil) did nothing — the manager
+// was never instantiated post-boot. This test recreates that exact failure
+// mode: a daemon that booted with LLDP disabled (nil manager) receives a day-2
+// commit enabling LLDP, and the reconcile MUST lazily create the manager.
+//
+// If the day-2 reconcile is reverted (LLDP start moves back to boot-only),
+// reconcileLLDP would no longer create the manager on a day-2 enable and
+// d.lldpMgr stays nil → this test goes RED.
+func TestReconcileLLDPLazyCreateOnDay2Enable(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Boot state: LLDP disabled, manager never created.
+	d := &Daemon{daemonCtx: ctx}
+	d.reconcileLLDP(lldpCfg(true))
+	if d.lldpMgr != nil {
+		t.Fatalf("reconcileLLDP allocated a manager for a disabled stanza; want nil")
+	}
+
+	// Day-2 commit enables LLDP. The manager must be lazily instantiated, even
+	// though no interface socket can be opened in the test env (the interface
+	// lookup is a no-op skip without a real NIC + CAP_NET_RAW).
+	d.reconcileLLDP(lldpCfg(false, "xpf-lldp-test-nic0"))
+	if d.lldpMgr == nil {
+		t.Fatalf("day-2 enable did not lazily create the LLDP manager; " +
+			"reconcile is not running on commit (the #2372 boot-only defect)")
+	}
+
+	// Clean up any goroutines the manager started.
+	d.lldpMgr.Stop()
+}
+
+// TestReconcileLLDPDisableStopsRunning verifies the inverse: a day-2 commit that
+// disables LLDP stops the running service. It needs a live generation, which
+// requires opening an AF_PACKET socket on the loopback interface (CAP_NET_RAW).
+// When that capability is absent (unprivileged CI), Apply() logs + skips the
+// interface so no session starts; the test then skips rather than asserting a
+// transition it could not establish.
+func TestReconcileLLDPDisableStopsRunning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := &Daemon{daemonCtx: ctx}
+	d.reconcileLLDP(lldpCfg(false, "lo"))
+	if d.lldpMgr == nil {
+		t.Fatal("enable on lo did not create the manager")
+	}
+	if !d.lldpMgr.Running() {
+		d.lldpMgr.Stop()
+		t.Skip("no live LLDP generation on lo (no CAP_NET_RAW); " +
+			"skipping the disable-stops-running transition")
+	}
+
+	// Day-2 disable must tear the running generation down.
+	d.reconcileLLDP(lldpCfg(true))
+	if d.lldpMgr.Running() {
+		d.lldpMgr.Stop()
+		t.Fatalf("day-2 disable did not stop the running LLDP service")
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -931,22 +931,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.reconcileRPM(cfg)
 	}
 
-	// Start LLDP if configured.
-	if cfg := d.store.ActiveConfig(); cfg != nil && cfg.Protocols.LLDP != nil && !cfg.Protocols.LLDP.Disable && len(cfg.Protocols.LLDP.Interfaces) > 0 {
-		d.lldpMgr = lldp.New()
-		var lldpIfaces []lldp.LLDPInterface
-		for _, iface := range cfg.Protocols.LLDP.Interfaces {
-			lldpIfaces = append(lldpIfaces, lldp.LLDPInterface{
-				Name:    iface.Name,
-				Disable: iface.Disable,
-			})
-		}
-		d.lldpMgr.Apply(ctx, &lldp.LLDPConfig{
-			Interfaces:     lldpIfaces,
-			Interval:       cfg.Protocols.LLDP.Interval,
-			HoldMultiplier: cfg.Protocols.LLDP.HoldMultiplier,
-			SystemName:     cfg.System.HostName,
-		})
+	// Start LLDP if configured. reconcileLLDP is the single source of truth
+	// for LLDP start/stop/reconfigure: it runs here at boot and again on every
+	// day-2 commit from applyConfigLocked (#2372), so a config change to
+	// `protocols lldp` takes effect without a daemon restart.
+	if cfg := d.store.ActiveConfig(); cfg != nil {
+		d.reconcileLLDP(cfg)
 	}
 
 	// Start event-options engine if configured.

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -931,10 +931,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.reconcileRPM(cfg)
 	}
 
-	// Start LLDP if configured. reconcileLLDP is the single source of truth
+	// Start LLDP if configured. The Manager is always created here (not gated
+	// on a non-nil/enabled LLDP config), mirroring d.dhcpRelay above: the
+	// d.lldpMgr pointer is then written exactly once, at boot, so the lock-free
+	// reads on the gRPC / CLI `show lldp neighbors` handler goroutines never
+	// race a day-2 commit (#2372 finding 3 — a lazy day-2 reassignment would be
+	// a data race on the pointer). reconcileLLDP is the single source of truth
 	// for LLDP start/stop/reconfigure: it runs here at boot and again on every
-	// day-2 commit from applyConfigLocked (#2372), so a config change to
-	// `protocols lldp` takes effect without a daemon restart.
+	// day-2 commit from applyConfigLocked, so a config change to `protocols
+	// lldp` takes effect without a daemon restart, and it only ever calls
+	// Apply()/Stop() on this already-constructed manager.
+	d.lldpMgr = lldp.New()
 	if cfg := d.store.ActiveConfig(); cfg != nil {
 		d.reconcileLLDP(cfg)
 	}

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -17,6 +17,8 @@ entries by TTL.
 - `Running()` — `lldp.go`. Reports whether a live generation has at least one
   active interface session. Used by the daemon's day-2 reconcile (#2372) and
   its tests to observe the start/stop transition.
+- `ApplyCount()` — `lldp.go`. Number of `Apply()` calls. Test seam for the
+  day-2 reconcile diff-guard (#2372) — an unrelated commit must not re-`Apply`.
 - `Neighbors()` — `lldp.go`. Snapshot consumed by `show lldp
   neighbors`.
 
@@ -71,12 +73,29 @@ Standard library + `golang.org/x/sys/unix`. No internal `pkg/*` imports.
 The daemon owns the manager and reconciles it on every commit, not just at
 boot. `Daemon.reconcileLLDP` (`pkg/daemon/daemon_apply.go`) is the single
 source of truth: `daemon_run.go` calls it at boot and `applyConfigLocked`
-calls it on every commit. It lazily instantiates the manager on the first
-commit that enables LLDP (so a daemon that never runs LLDP never allocates the
-sockets) and `Stop()`s it when a commit disables or empties the stanza. Because
-`Apply()` is reconcile-shaped (stop-then-start), an interface-set,
-`transmit-interval`, or `hold-multiplier` change takes effect on commit without
-a daemon restart.
+calls it on every commit. An interface-set, `transmit-interval`, or
+`hold-multiplier` change takes effect on commit without a daemon restart, and
+a disabled/empty stanza `Stop()`s the running service.
+
+Two properties keep this safe (#2372 review findings 3 + 6):
+
+- **Construct-once.** The `Manager` is created exactly once, at boot
+  (`daemon_run.go`, unconditionally — mirroring `dhcpRelay`), so the
+  `d.lldpMgr` pointer is written before any handler runs. `reconcileLLDP`
+  only ever calls `Apply()`/`Stop()` on it and NEVER reassigns the pointer.
+  The `show lldp neighbors` gRPC/CLI handlers read `d.lldpMgr` lock-free on a
+  handler goroutine, so a day-2 reassignment would be a data race on the
+  pointer field — construct-once eliminates the write entirely. (A daemon that
+  never enables LLDP allocates the manager but no sockets/goroutines.)
+- **Change-guarded.** `Apply()` unconditionally `Stop()`s the current
+  generation (closing every socket, joining goroutines, and wiping the
+  neighbor table) before rebuilding. So `reconcileLLDP` compares the new
+  effective LLDP config (`effectiveLLDPConfig`) against the last-applied one
+  and calls `Apply()`/`Stop()` only when it actually changed. An unrelated
+  day-2 commit (e.g. a firewall-policy change) therefore leaves a healthy LLDP
+  generation untouched — `show lldp neighbors` does not blank and sockets do
+  not churn. This matches the diff discipline of the adjacent
+  `reconcileDHCPRelay` (#2348).
 
 ## Gotchas
 

--- a/pkg/lldp/README.md
+++ b/pkg/lldp/README.md
@@ -10,8 +10,13 @@ entries by TTL.
 - `Neighbor` — `lldp.go`. Chassis ID, port ID, TTL, system name and
   description.
 - `New()` — `lldp.go`.
-- `Apply(ctx context.Context, cfg *LLDPConfig)` — `lldp.go`.
+- `Apply(ctx context.Context, cfg *LLDPConfig)` — `lldp.go`. Reconcile-shaped:
+  `Stop()`s the current generation before starting the new one, so calling it
+  repeatedly is idempotent. A nil/disabled/empty config stops the service.
 - `Stop()` — `lldp.go`.
+- `Running()` — `lldp.go`. Reports whether a live generation has at least one
+  active interface session. Used by the daemon's day-2 reconcile (#2372) and
+  its tests to observe the start/stop transition.
 - `Neighbors()` — `lldp.go`. Snapshot consumed by `show lldp
   neighbors`.
 
@@ -43,10 +48,12 @@ Standard library + `golang.org/x/sys/unix`. No internal `pkg/*` imports.
   `Stop()` close-to-unblock and the loop returns; otherwise (the context
   is still live, e.g. the interface flapped down — `ENETDOWN`) the loop
   **backs off `rxErrorBackoff` (1s) and retries** rather than exiting.
-  Nothing restarts `rxLoop` short of a daemon restart — LLDP is `Apply()`'d
-  once at startup — so a permanent exit on a transient flap would silently
-  kill neighbor discovery for the life of the process (the pre-`#2040`
-  behavior; the old timeout-poll loop survived flaps by continuing). The
+  Nothing restarts `rxLoop` within a generation — it lives only for the life
+  of the `Apply()` that started it (a config change re-`Apply()`s, which
+  `Stop()`s the old generation and starts a fresh one) — so a permanent exit
+  on a transient flap would silently kill neighbor discovery until the next
+  `protocols lldp` commit or a daemon restart (the pre-`#2040` behavior; the
+  old timeout-poll loop survived flaps by continuing). The
   backoff is interruptible: a concurrent `Stop()` cancels the context and
   the loop returns promptly instead of sleeping out the delay, and the
   closed fd makes any parked `Recvfrom` return so `Stop()` stays bounded.
@@ -58,6 +65,18 @@ Standard library + `golang.org/x/sys/unix`. No internal `pkg/*` imports.
   promptly with a parked RX goroutine, without `CAP_NET_RAW`.
 - A socket setup / `CAP_NET_RAW` failure now surfaces at `Apply()` time
   (logged once, interface skipped) instead of silently per-frame.
+
+## Day-2 reconcile (#2372)
+
+The daemon owns the manager and reconciles it on every commit, not just at
+boot. `Daemon.reconcileLLDP` (`pkg/daemon/daemon_apply.go`) is the single
+source of truth: `daemon_run.go` calls it at boot and `applyConfigLocked`
+calls it on every commit. It lazily instantiates the manager on the first
+commit that enables LLDP (so a daemon that never runs LLDP never allocates the
+sockets) and `Stop()`s it when a commit disables or empties the stanza. Because
+`Apply()` is reconcile-shaped (stop-then-start), an interface-set,
+`transmit-interval`, or `hold-multiplier` change takes effect on commit without
+a daemon restart.
 
 ## Gotchas
 

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -299,6 +299,22 @@ func (m *Manager) Stop() {
 	m.mu.Unlock()
 }
 
+// Running reports whether a live LLDP generation is active — i.e. Apply() has
+// started the TX/RX/expiry goroutines and Stop() has not since torn them down.
+// It lets the daemon's day-2 reconcile (and tests of it) observe the
+// start/stop transition without reaching into unexported fields. The result is
+// the m.sessions snapshot: Apply appends sessions under mu and Stop nils them
+// under mu, so a non-empty session set is the race-free witness that a
+// generation is live (cancel is set/cleared by the apply-serialized caller, but
+// sessions are the mu-guarded state). A generation with zero usable interfaces
+// (all InterfaceByName lookups failed) reports false — there is nothing running
+// to reconcile away.
+func (m *Manager) Running() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sessions) > 0
+}
+
 // Neighbors returns a sorted snapshot of all discovered neighbors.
 func (m *Manager) Neighbors() []*Neighbor {
 	m.mu.RLock()

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -90,6 +91,12 @@ type Manager struct {
 	// generation. Stop() closes each one to unblock the parked RX Recvfrom
 	// immediately, so shutdown does not wait out a read timeout. Guarded by mu.
 	sessions []*ifSession
+
+	// applyCount counts Apply() calls. It exists so the daemon's day-2 reconcile
+	// diff-guard (#2372) can be regression-tested — an unrelated commit must not
+	// re-Apply (which would Stop()/rebuild the generation and wipe the neighbor
+	// table). Atomic so a test reading it does not race a concurrent Apply.
+	applyCount atomic.Uint64
 }
 
 // ifSession owns the RX and TX AF_PACKET sockets for one interface for the life
@@ -193,6 +200,7 @@ func New() *Manager {
 
 // Apply starts LLDP on the configured interfaces.
 func (m *Manager) Apply(ctx context.Context, cfg *LLDPConfig) {
+	m.applyCount.Add(1)
 	m.Stop()
 
 	if cfg == nil || cfg.Disable || len(cfg.Interfaces) == 0 {
@@ -315,6 +323,13 @@ func (m *Manager) Running() bool {
 	return len(m.sessions) > 0
 }
 
+// ApplyCount returns the number of times Apply() has been called on this
+// manager. It exists for the day-2 reconcile diff-guard regression test
+// (#2372): an unrelated commit must leave this unchanged.
+func (m *Manager) ApplyCount() uint64 {
+	return m.applyCount.Load()
+}
+
 // Neighbors returns a sorted snapshot of all discovered neighbors.
 func (m *Manager) Neighbors() []*Neighbor {
 	m.mu.RLock()
@@ -377,9 +392,12 @@ func (m *Manager) sendFrame(sess *ifSession, ttl int, sysName, sysDesc string) {
 // non-shutdown) recv error before retrying. A persistent operational error
 // (e.g. an interface flapped down so recv keeps erroring) must not become a
 // tight busy-spin, but it also must not permanently kill the receiver — nothing
-// restarts rxLoop short of a daemon restart, because LLDP is Apply()'d once at
-// startup (daemon_run.go) and Stop()'d only at shutdown. A var so tests can
-// shrink it; production keeps the 1s default.
+// restarts rxLoop within a generation. rxLoop lives only for the life of the
+// Apply() that started it; the daemon re-Apply()s only on a `protocols lldp`
+// change (#2372 diff-guard), which Stop()s the old generation and starts a
+// fresh one. So a permanent exit on a transient flap would silently kill
+// discovery until the next LLDP config change or a daemon restart. A var so
+// tests can shrink it; production keeps the 1s default.
 var rxErrorBackoff = 1 * time.Second
 
 // rxLoop receives LLDP frames on the session's interface and updates the


### PR DESCRIPTION
Closes #2372

## Summary

- LLDP was `Apply()`'d once at daemon boot and never from the day-2 apply
  pipeline, so a commit changing `protocols lldp` (enable/disable, interface
  set, `transmit-interval`, `hold-multiplier`) was silently ignored until a
  daemon restart. If LLDP was disabled at boot, the manager was nil, so a
  day-2 enable did nothing at all.
- Extracted the boot-time start into `Daemon.reconcileLLDP`, the single
  source of truth for LLDP lifecycle, and call it from both `daemon_run.go`
  (boot) and `applyConfigLocked` (every commit), placed next to the existing
  day-2 service reconciles (DHCP relay, flow exporters, RPM).
- Manager is instantiated lazily on the first commit that enables LLDP (a
  daemon that never runs LLDP never allocates the manager or its AF_PACKET
  sockets) and `Stop()`'d when a commit disables/empties the stanza. Bound to
  `d.daemonCtx` so the TX/RX/expiry goroutines outlive the apply call.
  `lldp.Manager.Apply` is already reconcile-shaped (stop-then-start), so
  re-applying on commit is idempotent.
- Added `lldp.Manager.Running()` (witnessed by the mu-guarded session set) so
  the reconcile and its tests can observe the start/stop transition without
  reaching into unexported fields.

## Test plan

- [x] `pkg/daemon/daemon_lldp_reconcile_test.go`
  - `TestReconcileLLDPLazyCreateOnDay2Enable` — a day-2 enable on a daemon
    that booted with LLDP disabled (nil manager) must lazily create the
    manager. Recreates the exact #2372 failure mode.
  - `TestReconcileLLDPDisableStopsRunning` — a day-2 disable stops the running
    service (exercised under `CAP_NET_RAW` on `lo`; skips cleanly otherwise).
- [x] **Fail-on-revert proven**: stubbing `reconcileLLDP` to not lazily-create
  (mimicking boot-only) reproduces the defect and the test goes RED:
  `day-2 enable did not lazily create the LLDP manager`. Restored → GREEN.
- [x] `go build ./...`, `go vet ./pkg/daemon/ ./pkg/lldp/`, `gofmt -l` (touched
  files clean), `go test ./pkg/daemon/ ./pkg/lldp/` all pass.
- [x] `TestReconcileLLDPDisableStopsRunning` PASS under sudo (CAP_NET_RAW):
  `LLDP started interface=lo` then disable stops it.

## Docs

- `pkg/lldp/README.md` corrected from "Apply()'d once at startup" to the
  day-2 reconcile contract; added `Running()` to entry points and a "Day-2
  reconcile (#2372)" section.

## Refs

- #2372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi