### PR TITLE
flowexport: drop unpopulated NetFlow/IPFIX template fields (#2613)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15092,3 +15092,26 @@ top.
   pkg/config/compiler_nat_source_address_name_2416_test.go,
   pkg/dataplane/userspace/nat_source_address_name_2416_test.go,
   docs/userspace-dnat-plan.md
+
+## #2613 flowexport: drop unpopulated NetFlow/IPFIX template fields
+
+- **Timestamp**: 2026-06-25
+- **Action**: NetFlow v9 + IPFIX templates advertised SrcTos/ipClassOfService
+  (5), TCPFlags/tcpControlBits (6), Direction/flowDirection (61),
+  InputSNMP/ingressInterface (10) and OutputSNMP/egressInterface (14) but the
+  SESSION_CLOSE builder never populated FlowRecord.{TOS,TCPFlags,Direction,
+  InIf,OutIf} and there is no source for them — the fixed 136-byte RT_FLOW
+  close frame carries no DSCP/TOS/flags/direction/egress-ifindex and the Rust
+  encoder hardcodes ingress ifindex 0 on close frames. Collectors ingested
+  authoritative zeros. Dropped all five from both v9 templates and IPFIX v4/v6
+  templates + their record encoders + size consts (ipfixRecordSizeV4 69->57,
+  V6 117->105; v9 v4 64->52, v6 112->100). IncludeFlowDir/NoDir template split
+  collapsed (fieldDirection gone) -> single template per family; IncludeFlowDir
+  kept as an accepted no-op. Compiler now warns on export-extension flow-dir
+  (mirrors the app-id warn-not-lie precedent). Populate-via-wire-extension is a
+  tracked follow-up. fail-on-revert proven RED (3 tests fire on re-adding a
+  field) then restored GREEN.
+- **File(s)**: pkg/flowexport/netflow.go, pkg/flowexport/ipfix.go,
+  pkg/flowexport/exporter_test.go, pkg/flowexport/postnat_test.go,
+  pkg/flowexport/dropped_fields_test.go, pkg/config/compiler_validate_warn.go,
+  pkg/flowexport/README.md, _Log.md

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -519,9 +519,18 @@ func ValidateConfig(cfg *Config) []string {
 	if fm := cfg.Services.FlowMonitoring; fm != nil {
 		checkExtWarning := func(kind, name string, exts []string) {
 			for _, ext := range exts {
-				if ext == "app-id" {
+				switch ext {
+				case "app-id":
 					warnings = append(warnings, fmt.Sprintf(
 						"flow-monitoring %s template %s: export-extension app-id configured but application data is not available in flow records", kind, name))
+				case "flow-dir":
+					// #2613: flowDirection (IE 61) was dropped from the v9/IPFIX
+					// templates because the SESSION_CLOSE wire frame carries no
+					// per-flow direction — exporting it produced authoritative
+					// zeros at the collector. The extension is still accepted but
+					// no longer adds the field; warn rather than silently lie.
+					warnings = append(warnings, fmt.Sprintf(
+						"flow-monitoring %s template %s: export-extension flow-dir configured but flow-direction data is not available in flow records (the field is no longer exported)", kind, name))
 				}
 			}
 		}

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -83,9 +83,11 @@ RFC 8158) are appended LAST in every template:
 | postNATDestinationIPv6Address | 282 | ipv6Address | 16 | v6 |
 
 NetFlow v9 reuses the same IANA element type IDs in its template
-FlowSet. The IPv4 IPFIX record grows 57→69 bytes, the IPv6 record 81→117
-bytes; the NetFlow v9 record sizes derive from the template via
-`recordSize` (4-byte padded), so they grow automatically. An init-time
+FlowSet. With the #2613 drop (below) the IPv4 IPFIX record is 57 bytes
+(45 pre-NAT body + 12 post-NAT) and the IPv6 record is 105 bytes (69 +
+36); the NetFlow v9 record sizes derive from the template via
+`recordSize` (4-byte padded), so they track the template automatically.
+An init-time
 assertion in `ipfix.go` pins `ipfixRecordSizeV4/V6` to the sum of their
 template field lengths so a template/encoder length drift fails the
 process at startup (a mismatch would corrupt every record). Golden
@@ -104,6 +106,30 @@ independently, so an address-only or port-only translation reports the
 translated half and the pre-NAT other half. A collector distinguishes a
 NAT'd flow from a non-NAT'd flow by post != pre. Volume counters remain 0
 pending #2501.
+
+**#2613 — stop advertising fields the close path cannot populate.** The
+templates previously advertised `ipClassOfService`/SrcTos (5),
+`tcpControlBits`/TCPFlags (6), `flowDirection`/Direction (61),
+`ingressInterface`/InputSNMP (10) and `egressInterface`/OutputSNMP (14),
+but the SESSION_CLOSE builder (`ExportSessionClose`) never set
+`FlowRecord.{TOS,TCPFlags,Direction,InIf,OutIf}` — and there is nowhere
+to set them from. The dataplane→Go SESSION_CLOSE RT_FLOW frame is a fixed
+136-byte wire shape (`pkg/logging/ringbuf.go`) that carries no DSCP/TOS,
+no observed TCP flags, no per-flow direction and no egress ifindex, and
+the Rust encoder hardcodes the ingress-ifindex slot to 0 on close frames
+(`userspace-dp/.../codec.rs::encode_session_close_rt_flow`). So every one
+of those IEs reached collectors as an authoritative zero. The five fields
+are now removed from both NetFlow v9 templates and the IPFIX v4/v6
+templates (and their record encoders / size constants). Populating them
+for real needs a Rust↔Go wire-format extension (re-lay the 136-byte
+frame + conntrack-side TCP-flag/TOS stamping + egress-ifindex tracking),
+tracked in #2749. The `export-extension flow-dir` config knob is still
+accepted but no longer adds `flowDirection`; the compiler now warns when
+it is configured (`compiler_validate_warn.go`), mirroring the existing
+`app-id` warn-not-lie precedent. fail-on-revert pins live in
+`dropped_fields_test.go` (template-absence walk + record-layout golden
+that proves the bytes after `protocol` are the real counters, not a
+sentinel TOS/flags block).
 
 ## File layout
 

--- a/pkg/flowexport/dropped_fields_test.go
+++ b/pkg/flowexport/dropped_fields_test.go
@@ -1,0 +1,174 @@
+package flowexport
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// #2613: the NetFlow v9 and IPFIX templates no longer advertise
+// ipClassOfService/SrcTos (5), tcpControlBits/TCPFlags (6),
+// flowDirection/Direction (61), ingressInterface/InputSNMP (10) or
+// egressInterface/OutputSNMP (14). The SESSION_CLOSE wire frame carries no
+// real value for any of them, so advertising them made collectors ingest
+// authoritative zeros.
+//
+// These tests are fail-on-revert pins: re-adding any of the five IEs to a
+// template slice (and re-introducing the matching encoder write) shifts the
+// record layout and re-fails both the template-absence walk AND the
+// record-layout golden, which assert that the bytes immediately after the
+// protocol byte are the packet/byte counters (carrying the REAL values), not
+// a zero TOS/flags/direction/interface block.
+
+// --- IPFIX template-absence ------------------------------------------------
+
+// TestIPFIXTemplateDroppedFieldsAbsent walks the encoded IPFIX template set
+// and asserts none of the five dropped IEs appear. The element IDs are
+// asserted as literals (independent of the package constants) so a renamed or
+// removed constant cannot make the test agree with itself.
+func TestIPFIXTemplateDroppedFieldsAbsent(t *testing.T) {
+	dropped := map[uint16]string{
+		5:  "ipClassOfService",
+		6:  "tcpControlBits",
+		61: "flowDirection",
+		10: "ingressInterface",
+		14: "egressInterface",
+	}
+	for _, tmpl := range [][]ipfixField{ipfixTemplateV4, ipfixTemplateV6} {
+		for _, f := range tmpl {
+			if name, bad := dropped[f.elementID]; bad {
+				t.Errorf("dropped IPFIX IE %s (%d) still advertised in template", name, f.elementID)
+			}
+		}
+	}
+
+	// Also walk the encoded bytes (the wire the collector parses).
+	ts := encodeIPFIXTemplateSet()
+	off := 4 // skip set header
+	for off+4 <= len(ts) {
+		off += 2 // skip template ID
+		count := int(binary.BigEndian.Uint16(ts[off : off+2]))
+		off += 2
+		for i := 0; i < count && off+4 <= len(ts); i++ {
+			eid := binary.BigEndian.Uint16(ts[off : off+2])
+			if name, bad := dropped[eid]; bad {
+				t.Errorf("dropped IPFIX IE %s (%d) found in encoded template set", name, eid)
+			}
+			off += 4
+		}
+	}
+}
+
+// --- record-layout fail-on-revert ------------------------------------------
+
+// nonZeroRecord returns a FlowRecord whose dropped-field members are all set
+// to a sentinel non-zero value. If any of those fields were still encoded, the
+// golden offset checks below would read the sentinel instead of the real
+// counters — so the test proves the dropped fields are genuinely gone, not
+// merely zero.
+func nonZeroRecord(v6 bool) FlowRecord {
+	now := time.Unix(1_700_000_000, 0)
+	r := FlowRecord{
+		SrcPort: 40000, DstPort: 80, Protocol: 6,
+		TOS: 0xAB, TCPFlags: 0xCD, Direction: 0x01,
+		InIf: 0xDEADBEEF, OutIf: 0xFEEDFACE,
+		Packets: 0x1122334455667788, Bytes: 0x99AABBCCDDEEFF00,
+		StartTime: now, EndTime: now,
+		SrcMask: 24, DstMask: 32,
+	}
+	if v6 {
+		r.IsIPv6 = true
+		r.SrcIP = net.ParseIP("fd00::1")
+		r.DstIP = net.ParseIP("2001:db8::200")
+		r.NATSrcIP = r.SrcIP
+		r.NATDstIP = r.DstIP
+	} else {
+		r.SrcIP = net.IPv4(10, 0, 1, 100)
+		r.DstIP = net.IPv4(172, 16, 80, 200)
+		r.NATSrcIP = r.SrcIP
+		r.NATDstIP = r.DstIP
+	}
+	return r
+}
+
+// TestIPFIXRecordOmitsDroppedFields encodes a record with sentinel TOS/flags/
+// direction/interface values and asserts the byte immediately after the
+// protocol byte is the high byte of the 8-byte packet counter (0x11), NOT the
+// sentinel TOS (0xAB). Under the pre-#2613 layout the next byte was TOS.
+func TestIPFIXRecordOmitsDroppedFields(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		v6      bool
+		recSize int
+		// offset of the protocol byte within the data record body
+		protoOff int
+	}{
+		// v4 record body: src4 dst4 sport2 dport2 proto1 -> proto at body off 12
+		{"v4", false, ipfixRecordSizeV4, 12},
+		// v6 record body: src16 dst16 sport2 dport2 proto1 -> proto at body off 36
+		{"v6", true, ipfixRecordSizeV6, 36},
+	} {
+		ds := encodeIPFIXDataSet([]FlowRecord{nonZeroRecord(tc.v6)})
+		if got := len(ds); got != 4+tc.recSize {
+			t.Fatalf("%s: encoded len = %d, want %d", tc.name, got, 4+tc.recSize)
+		}
+		// 4-byte set header precedes the record body.
+		proto := ds[4+tc.protoOff]
+		if proto != 6 {
+			t.Fatalf("%s: protocol byte = 0x%02x, want 0x06", tc.name, proto)
+		}
+		// The byte after protocol must be the packet-counter high byte (0x11),
+		// proving no TOS (0xAB) / flags / direction were written there.
+		next := ds[4+tc.protoOff+1]
+		if next == 0xAB || next == 0xCD || next == 0x01 {
+			t.Errorf("%s: byte after protocol = 0x%02x — a dropped field (TOS/flags/dir) leaked", tc.name, next)
+		}
+		if next != 0x11 {
+			t.Errorf("%s: byte after protocol = 0x%02x, want 0x11 (packet-counter high byte)", tc.name, next)
+		}
+		// And the packet/byte counters (the REAL values) round-trip.
+		pktOff := 4 + tc.protoOff + 1
+		if pkts := binary.BigEndian.Uint64(ds[pktOff : pktOff+8]); pkts != 0x1122334455667788 {
+			t.Errorf("%s: packets = 0x%016x, want 0x1122334455667788", tc.name, pkts)
+		}
+	}
+}
+
+// TestNetflowRecordOmitsDroppedFields mirrors the IPFIX check for NetFlow v9.
+// The v9 record writes the 8-byte packet count right after the protocol byte
+// once SrcTos/TCPFlags/Direction are dropped.
+func TestNetflowRecordOmitsDroppedFields(t *testing.T) {
+	boot := time.Unix(1_700_000_000, 0)
+	opts := DefaultV9TemplateOptions()
+	for _, tc := range []struct {
+		name     string
+		v6       bool
+		fields   []templateField
+		protoOff int // protocol byte offset within the record body
+	}{
+		{"v4", false, netflowTemplateFieldsV4, 12},
+		{"v6", true, netflowTemplateFieldsV6, 36},
+	} {
+		fs := encodeDataFlowSet([]FlowRecord{nonZeroRecord(tc.v6)}, boot, opts)
+		recSize := recordSize(tc.fields)
+		if len(fs) != 4+recSize {
+			t.Fatalf("%s: flowset len = %d, want %d", tc.name, len(fs), 4+recSize)
+		}
+		proto := fs[4+tc.protoOff]
+		if proto != 6 {
+			t.Fatalf("%s: protocol byte = 0x%02x, want 0x06", tc.name, proto)
+		}
+		next := fs[4+tc.protoOff+1]
+		if next == 0xAB || next == 0xCD || next == 0x01 {
+			t.Errorf("%s: byte after protocol = 0x%02x — a dropped field leaked", tc.name, next)
+		}
+		if next != 0x11 {
+			t.Errorf("%s: byte after protocol = 0x%02x, want 0x11 (packet-counter high byte)", tc.name, next)
+		}
+		pktOff := 4 + tc.protoOff + 1
+		if pkts := binary.BigEndian.Uint64(fs[pktOff : pktOff+8]); pkts != 0x1122334455667788 {
+			t.Errorf("%s: packets = 0x%016x, want 0x1122334455667788", tc.name, pkts)
+		}
+	}
+}

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -601,78 +601,61 @@ func TestBuildIPFIXExportConfig_DistinctSourceAddressesAreNotDeduped(t *testing.
 	}
 }
 
-func TestV9TemplateFlowDirConditional(t *testing.T) {
-	// With flow-dir enabled, template should include fieldDirection
-	opts := V9TemplateOptions{IncludeFlowDir: true}
-	fieldsV4 := buildTemplateFieldsV4(opts)
-	hasDir := false
-	for _, f := range fieldsV4 {
-		if f.fieldType == fieldDirection {
-			hasDir = true
-		}
-	}
-	if !hasDir {
-		t.Error("expected fieldDirection in v4 template when IncludeFlowDir=true")
-	}
-
-	// Without flow-dir, template should NOT include fieldDirection
-	opts2 := V9TemplateOptions{IncludeFlowDir: false}
-	fieldsV4no := buildTemplateFieldsV4(opts2)
-	for _, f := range fieldsV4no {
-		if f.fieldType == fieldDirection {
-			t.Error("fieldDirection should not appear when IncludeFlowDir=false")
-		}
-	}
-
-	// Same check for v6
-	fieldsV6 := buildTemplateFieldsV6(opts)
-	hasDir = false
-	for _, f := range fieldsV6 {
-		if f.fieldType == fieldDirection {
-			hasDir = true
-		}
-	}
-	if !hasDir {
-		t.Error("expected fieldDirection in v6 template when IncludeFlowDir=true")
-	}
-
-	fieldsV6no := buildTemplateFieldsV6(opts2)
-	for _, f := range fieldsV6no {
-		if f.fieldType == fieldDirection {
-			t.Error("fieldDirection should not appear in v6 when IncludeFlowDir=false")
+// TestV9TemplateFlowDirAlwaysAbsent pins the #2613 contract: fieldDirection
+// (IE 61) is no longer advertised in the v9 templates regardless of the
+// IncludeFlowDir option, because the SESSION_CLOSE wire frame carries no
+// per-flow direction (it would always be 0 at the collector). The option is
+// retained as an accepted no-op.
+func TestV9TemplateFlowDirAlwaysAbsent(t *testing.T) {
+	for _, includeDir := range []bool{true, false} {
+		opts := V9TemplateOptions{IncludeFlowDir: includeDir}
+		for _, tc := range []struct {
+			name   string
+			fields []templateField
+		}{
+			{"v4", buildTemplateFieldsV4(opts)},
+			{"v6", buildTemplateFieldsV6(opts)},
+		} {
+			for _, f := range tc.fields {
+				if f.fieldType == fieldDirection {
+					t.Errorf("includeDir=%v %s: fieldDirection must not appear (#2613)",
+						includeDir, tc.name)
+				}
+			}
 		}
 	}
 }
 
-func TestV9TemplateEncodeWithoutFlowDir(t *testing.T) {
-	opts := V9TemplateOptions{IncludeFlowDir: false}
-	tmplFS := encodeTemplateFlowSet(opts)
-	if len(tmplFS) < 4 {
-		t.Fatalf("template flowset too short: %d bytes", len(tmplFS))
+// TestV9TemplateDroppedFieldsAbsent walks the encoded template FlowSet bytes
+// and asserts NONE of the #2613-dropped IEs (SrcTos/TCPFlags/Direction/
+// InputSNMP/OutputSNMP) are advertised. Re-adding any of them to the template
+// slices re-fails this test (fail-on-revert).
+func TestV9TemplateDroppedFieldsAbsent(t *testing.T) {
+	dropped := map[uint16]string{
+		fieldSrcTos:     "SrcTos",
+		fieldTCPFlags:   "TCPFlags",
+		fieldDirection:  "Direction",
+		fieldInputSNMP:  "InputSNMP",
+		fieldOutputSNMP: "OutputSNMP",
 	}
-
-	// FlowSet header: ID=0
-	setID := binary.BigEndian.Uint16(tmplFS[0:2])
-	if setID != 0 {
-		t.Errorf("flowset ID = %d, want 0", setID)
-	}
-
-	// Verify no fieldDirection (61) appears in the template field entries
-	// Skip flowset header (4), then parse template headers + fields
-	off := 4
-	for off < len(tmplFS) {
-		if off+4 > len(tmplFS) {
-			break
+	for _, includeDir := range []bool{true, false} {
+		tmplFS := encodeTemplateFlowSet(V9TemplateOptions{IncludeFlowDir: includeDir})
+		if setID := binary.BigEndian.Uint16(tmplFS[0:2]); setID != 0 {
+			t.Errorf("flowset ID = %d, want 0", setID)
 		}
-		off += 2 // skip template ID
-		fieldCount := int(binary.BigEndian.Uint16(tmplFS[off : off+2]))
-		off += 2
-		for i := 0; i < fieldCount; i++ {
-			ft := binary.BigEndian.Uint16(tmplFS[off : off+2])
-			if ft == fieldDirection {
-				t.Errorf("fieldDirection found in template when IncludeFlowDir=false")
+		off := 4
+		for off+4 <= len(tmplFS) {
+			off += 2 // skip template ID
+			fieldCount := int(binary.BigEndian.Uint16(tmplFS[off : off+2]))
+			off += 2
+			for i := 0; i < fieldCount && off+4 <= len(tmplFS); i++ {
+				ft := binary.BigEndian.Uint16(tmplFS[off : off+2])
+				if name, bad := dropped[ft]; bad {
+					t.Errorf("includeDir=%v: dropped IE %s (%d) found in v9 template",
+						includeDir, name, ft)
+				}
+				off += 4
 			}
-			off += 4
 		}
 	}
 }

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -16,20 +16,19 @@ const (
 	ipfixOctetDeltaCount          = 1
 	ipfixPacketDeltaCount         = 2
 	ipfixProtocolIdentifier       = 4
-	ipfixIpClassOfService         = 5
-	ipfixTcpControlBits           = 6
 	ipfixSourceTransportPort      = 7
 	ipfixSourceIPv4Address        = 8
 	ipfixDestinationTransportPort = 11
 	ipfixDestinationIPv4Address   = 12
-	ipfixIngressInterface         = 10
-	ipfixEgressInterface          = 14
 	ipfixSourceIPv6Address        = 27
 	ipfixDestinationIPv6Address   = 28
-	ipfixFlowDirection            = 61
-	ipfixApplicationId            = 95
 	ipfixFlowStartMilliseconds    = 152
 	ipfixFlowEndMilliseconds      = 153
+	// #2613: ipClassOfService (5), tcpControlBits (6), ingressInterface (10),
+	// egressInterface (14) and flowDirection (61) are no longer advertised —
+	// the SESSION_CLOSE wire frame carries no real value for any of them, so
+	// exporting them produced authoritative zeros at the collector.
+	// ipfixApplicationId (95) is reserved for a future app-id record field.
 	// RFC 5103 post-NAT (translated) tuple elements. IPv4 addresses 225/226
 	// (ipv4Address, 4B); transport ports 227/228 (unsigned16, 2B), which are
 	// family-agnostic and reused for IPv6. IPv6 addresses 281/282
@@ -62,6 +61,18 @@ type ipfixField struct {
 	length    uint16
 }
 
+// #2613: the IPFIX templates do NOT advertise ipClassOfService (5),
+// tcpControlBits (6), flowDirection (61), ingressInterface (10) or
+// egressInterface (14). The SESSION_CLOSE wire frame (the only flow source)
+// carries no DSCP/TOS, no observed TCP flags, no per-flow direction and no
+// egress ifindex, and the dataplane hardcodes the ingress ifindex slot to 0
+// on close frames (userspace-dp encode_session_close_rt_flow). Advertising
+// those IEs made every collector ingest authoritative zeros for
+// class-of-service, TCP flags, direction and interface attribution.
+// Populating them requires a Rust<->Go wire-format extension tracked
+// separately; until that exists the templates omit the fields rather than
+// export synthetic zeros.
+
 // ipfixTemplateV4 defines the IPv4 IPFIX template fields.
 var ipfixTemplateV4 = []ipfixField{
 	{ipfixSourceIPv4Address, 4},
@@ -69,11 +80,6 @@ var ipfixTemplateV4 = []ipfixField{
 	{ipfixSourceTransportPort, 2},
 	{ipfixDestinationTransportPort, 2},
 	{ipfixProtocolIdentifier, 1},
-	{ipfixIpClassOfService, 1},
-	{ipfixTcpControlBits, 2}, // IPFIX uses 2 bytes for TCP flags (RFC 7011)
-	{ipfixFlowDirection, 1},
-	{ipfixIngressInterface, 4},
-	{ipfixEgressInterface, 4},
 	{ipfixPacketDeltaCount, 8},
 	{ipfixOctetDeltaCount, 8},
 	{ipfixFlowStartMilliseconds, 8},
@@ -92,11 +98,6 @@ var ipfixTemplateV6 = []ipfixField{
 	{ipfixSourceTransportPort, 2},
 	{ipfixDestinationTransportPort, 2},
 	{ipfixProtocolIdentifier, 1},
-	{ipfixIpClassOfService, 1},
-	{ipfixTcpControlBits, 2},
-	{ipfixFlowDirection, 1},
-	{ipfixIngressInterface, 4},
-	{ipfixEgressInterface, 4},
 	{ipfixPacketDeltaCount, 8},
 	{ipfixOctetDeltaCount, 8},
 	{ipfixFlowStartMilliseconds, 8},
@@ -110,15 +111,17 @@ var ipfixTemplateV6 = []ipfixField{
 }
 
 // ipfixRecordSizeV4 is the byte size of a single IPv4 IPFIX data record.
-// pre-NAT 5-tuple + meta + counters + timestamps = 57; #2526 post-NAT tuple
-// (4+4+2+2) = 12 → 69.
-// 4+4+2+2+1+1+2+1+4+4+8+8+8+8 + 4+4+2+2 = 69
-const ipfixRecordSizeV4 = 69
+// #2613 dropped TOS(1)+TCPflags(2)+direction(1)+ingressIf(4)+egressIf(4)=12
+// from the former 69-byte record. pre-NAT body = 45; #2526 post-NAT tuple
+// (4+4+2+2) = 12 → 57.
+// 4+4+2+2+1+8+8+8+8 + 4+4+2+2 = 57
+const ipfixRecordSizeV4 = 57
 
 // ipfixRecordSizeV6 is the byte size of a single IPv6 IPFIX data record.
-// pre-NAT body = 81; #2526 post-NAT tuple (16+16+2+2) = 36 → 117.
-// 16+16+2+2+1+1+2+1+4+4+8+8+8+8 + 16+16+2+2 = 117
-const ipfixRecordSizeV6 = 117
+// #2613 dropped the same 12 unpopulated bytes from the former 117. pre-NAT
+// body = 69; #2526 post-NAT tuple (16+16+2+2) = 36 → 105.
+// 16+16+2+2+1+8+8+8+8 + 16+16+2+2 = 105
+const ipfixRecordSizeV6 = 105
 
 // ipfixRecordSizeV4 / V6 must equal the sum of their template field lengths.
 // A drift between the template (what the collector parses) and the encoder
@@ -265,16 +268,9 @@ func encodeIPFIXRecordV4(b []byte, off int, r FlowRecord) int {
 	off += 2
 	b[off] = r.Protocol
 	off++
-	b[off] = r.TOS
-	off++
-	binary.BigEndian.PutUint16(b[off:off+2], uint16(r.TCPFlags))
-	off += 2
-	b[off] = r.Direction
-	off++
-	binary.BigEndian.PutUint32(b[off:off+4], r.InIf)
-	off += 4
-	binary.BigEndian.PutUint32(b[off:off+4], r.OutIf)
-	off += 4
+	// #2613: ipClassOfService/tcpControlBits/flowDirection/ingress+egress
+	// interface are no longer in the template (no wire data) — go straight to
+	// the counters/timestamps the close frame actually carries.
 	binary.BigEndian.PutUint64(b[off:off+8], r.Packets)
 	off += 8
 	binary.BigEndian.PutUint64(b[off:off+8], r.Bytes)
@@ -322,16 +318,7 @@ func encodeIPFIXRecordV6(b []byte, off int, r FlowRecord) int {
 	off += 2
 	b[off] = r.Protocol
 	off++
-	b[off] = r.TOS
-	off++
-	binary.BigEndian.PutUint16(b[off:off+2], uint16(r.TCPFlags))
-	off += 2
-	b[off] = r.Direction
-	off++
-	binary.BigEndian.PutUint32(b[off:off+4], r.InIf)
-	off += 4
-	binary.BigEndian.PutUint32(b[off:off+4], r.OutIf)
-	off += 4
+	// #2613: dropped class-of-service/TCP flags/direction/interface fields.
 	binary.BigEndian.PutUint64(b[off:off+8], r.Packets)
 	off += 8
 	binary.BigEndian.PutUint64(b[off:off+8], r.Bytes)

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -64,11 +64,26 @@ type templateField struct {
 	fieldLen  uint16
 }
 
-// V9TemplateOptions controls which optional fields are included in v9 templates.
+// V9TemplateOptions controls which optional fields are included in v9
+// templates.
+//
+// #2613: IncludeFlowDir formerly toggled fieldDirection (IE 61) in the v9
+// templates. fieldDirection — together with SrcTos (5), TCPFlags (6),
+// InputSNMP (10) and OutputSNMP (14) — has been removed because the
+// SESSION_CLOSE wire frame carries no real value for any of them, so the
+// fields exported authoritative zeros to collectors. The option is retained
+// (still set by the `export-extension flow-dir` config knob, which the
+// schema already documents as "accepted; not applied") but no longer changes
+// the emitted template. It becomes load-bearing again only if a future
+// Rust<->Go wire-format extension threads real per-flow direction.
 type V9TemplateOptions struct {
-	IncludeFlowDir bool // include fieldDirection (export-extension flow-dir)
+	IncludeFlowDir bool // accepted; no longer changes the template (#2613)
 }
 
+// #2613: SrcTos/TCPFlags/Direction/InputSNMP/OutputSNMP dropped — no wire
+// data backs them on the SESSION_CLOSE path. The IncludeFlowDir/NoDir split
+// collapsed with fieldDirection's removal, so there is a single template per
+// address family.
 var (
 	netflowTemplateFieldsV4 = []templateField{
 		{fieldIPv4SrcAddr, 4},
@@ -76,33 +91,6 @@ var (
 		{fieldL4SrcPort, 2},
 		{fieldL4DstPort, 2},
 		{fieldProtocol, 1},
-		{fieldSrcTos, 1},
-		{fieldTCPFlags, 1},
-		{fieldDirection, 1},
-		{fieldInputSNMP, 4},
-		{fieldOutputSNMP, 4},
-		{fieldInPkts, 8},
-		{fieldInBytes, 8},
-		{fieldFirstSwitched, 4},
-		{fieldLastSwitched, 4},
-		{fieldSrcMask, 1},
-		{fieldDstMask, 1},
-		// #2526: post-NAT (translated) tuple, appended last.
-		{fieldPostNatSrcIPv4, 4},
-		{fieldPostNatDstIPv4, 4},
-		{fieldPostNapatSrcPort, 2},
-		{fieldPostNapatDstPort, 2},
-	}
-	netflowTemplateFieldsV4NoDir = []templateField{
-		{fieldIPv4SrcAddr, 4},
-		{fieldIPv4DstAddr, 4},
-		{fieldL4SrcPort, 2},
-		{fieldL4DstPort, 2},
-		{fieldProtocol, 1},
-		{fieldSrcTos, 1},
-		{fieldTCPFlags, 1},
-		{fieldInputSNMP, 4},
-		{fieldOutputSNMP, 4},
 		{fieldInPkts, 8},
 		{fieldInBytes, 8},
 		{fieldFirstSwitched, 4},
@@ -121,33 +109,6 @@ var (
 		{fieldL4SrcPort, 2},
 		{fieldL4DstPort, 2},
 		{fieldProtocol, 1},
-		{fieldSrcTos, 1},
-		{fieldTCPFlags, 1},
-		{fieldDirection, 1},
-		{fieldInputSNMP, 4},
-		{fieldOutputSNMP, 4},
-		{fieldInPkts, 8},
-		{fieldInBytes, 8},
-		{fieldFirstSwitched, 4},
-		{fieldLastSwitched, 4},
-		{fieldIPv6SrcMask, 1},
-		{fieldIPv6DstMask, 1},
-		// #2526: post-NAT (translated) tuple, appended last (v6 addrs 16B).
-		{fieldPostNatSrcIPv6, 16},
-		{fieldPostNatDstIPv6, 16},
-		{fieldPostNapatSrcPort, 2},
-		{fieldPostNapatDstPort, 2},
-	}
-	netflowTemplateFieldsV6NoDir = []templateField{
-		{fieldIPv6SrcAddr, 16},
-		{fieldIPv6DstAddr, 16},
-		{fieldL4SrcPort, 2},
-		{fieldL4DstPort, 2},
-		{fieldProtocol, 1},
-		{fieldSrcTos, 1},
-		{fieldTCPFlags, 1},
-		{fieldInputSNMP, 4},
-		{fieldOutputSNMP, 4},
 		{fieldInPkts, 8},
 		{fieldInBytes, 8},
 		{fieldFirstSwitched, 4},
@@ -167,20 +128,16 @@ func DefaultV9TemplateOptions() V9TemplateOptions {
 	return V9TemplateOptions{IncludeFlowDir: true}
 }
 
-// buildTemplateFieldsV4 returns the IPv4 template fields based on options.
-func buildTemplateFieldsV4(opts V9TemplateOptions) []templateField {
-	if opts.IncludeFlowDir {
-		return netflowTemplateFieldsV4
-	}
-	return netflowTemplateFieldsV4NoDir
+// buildTemplateFieldsV4 returns the IPv4 template fields. #2613: the option no
+// longer changes the field set (fieldDirection removed); the parameter is kept
+// for call-site stability and future re-introduction.
+func buildTemplateFieldsV4(_ V9TemplateOptions) []templateField {
+	return netflowTemplateFieldsV4
 }
 
-// buildTemplateFieldsV6 returns the IPv6 template fields based on options.
-func buildTemplateFieldsV6(opts V9TemplateOptions) []templateField {
-	if opts.IncludeFlowDir {
-		return netflowTemplateFieldsV6
-	}
-	return netflowTemplateFieldsV6NoDir
+// buildTemplateFieldsV6 returns the IPv6 template fields. See buildTemplateFieldsV4.
+func buildTemplateFieldsV6(_ V9TemplateOptions) []templateField {
+	return netflowTemplateFieldsV6
 }
 
 // recordSize computes the data record size from template fields, padded to 4 bytes.
@@ -297,30 +254,19 @@ func encodeDataFlowSetInto(b []byte, records []FlowRecord, bootTime time.Time,
 	binary.BigEndian.PutUint16(b[2:4], uint16(totalLen))
 	off := 4
 	isV6 := records[0].IsIPv6
-	includeFlowDir := fieldSetIncludesFlowDir(fields)
+	_ = fields // template field set is fixed per family (#2613)
 	for _, r := range records {
 		if isV6 {
-			off = encodeRecordV6(b, off, r, bootTime,
-				includeFlowDir, recSize)
+			off = encodeRecordV6(b, off, r, bootTime, recSize)
 		} else {
-			off = encodeRecordV4(b, off, r, bootTime,
-				includeFlowDir, recSize)
+			off = encodeRecordV4(b, off, r, bootTime, recSize)
 		}
 	}
 	clear(b[off:totalLen])
 }
 
-func fieldSetIncludesFlowDir(fields []templateField) bool {
-	for _, f := range fields {
-		if f.fieldType == fieldDirection {
-			return true
-		}
-	}
-	return false
-}
-
 func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time,
-	includeFlowDir bool, recSize int,
+	recSize int,
 ) int {
 	startOff := off
 	src4 := r.SrcIP.To4()
@@ -341,18 +287,8 @@ func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time,
 	off += 2
 	b[off] = r.Protocol
 	off++
-	b[off] = r.TOS
-	off++
-	b[off] = r.TCPFlags
-	off++
-	if includeFlowDir {
-		b[off] = r.Direction
-		off++
-	}
-	binary.BigEndian.PutUint32(b[off:off+4], r.InIf)
-	off += 4
-	binary.BigEndian.PutUint32(b[off:off+4], r.OutIf)
-	off += 4
+	// #2613: SrcTos/TCPFlags/Direction/InputSNMP/OutputSNMP are no longer in
+	// the template (no wire data backs them on the close path).
 	binary.BigEndian.PutUint64(b[off:off+8], r.Packets)
 	off += 8
 	binary.BigEndian.PutUint64(b[off:off+8], r.Bytes)
@@ -386,7 +322,7 @@ func encodeRecordV4(b []byte, off int, r FlowRecord, bootTime time.Time,
 }
 
 func encodeRecordV6(b []byte, off int, r FlowRecord, bootTime time.Time,
-	includeFlowDir bool, recSize int,
+	recSize int,
 ) int {
 	startOff := off
 	src16 := r.SrcIP.To16()
@@ -407,18 +343,7 @@ func encodeRecordV6(b []byte, off int, r FlowRecord, bootTime time.Time,
 	off += 2
 	b[off] = r.Protocol
 	off++
-	b[off] = r.TOS
-	off++
-	b[off] = r.TCPFlags
-	off++
-	if includeFlowDir {
-		b[off] = r.Direction
-		off++
-	}
-	binary.BigEndian.PutUint32(b[off:off+4], r.InIf)
-	off += 4
-	binary.BigEndian.PutUint32(b[off:off+4], r.OutIf)
-	off += 4
+	// #2613: dropped class-of-service/TCP flags/direction/interface fields.
 	binary.BigEndian.PutUint64(b[off:off+8], r.Packets)
 	off += 8
 	binary.BigEndian.PutUint64(b[off:off+8], r.Bytes)

--- a/pkg/flowexport/postnat_test.go
+++ b/pkg/flowexport/postnat_test.go
@@ -52,8 +52,8 @@ func TestIPFIXTemplateV4_PostNATFields(t *testing.T) {
 	if sum != ipfixRecordSizeV4 {
 		t.Fatalf("ipfixRecordSizeV4 = %d, want sum(template) = %d", ipfixRecordSizeV4, sum)
 	}
-	if ipfixRecordSizeV4 != 69 {
-		t.Fatalf("ipfixRecordSizeV4 = %d, want 69 (pre-NAT 57 + 12 post-NAT)", ipfixRecordSizeV4)
+	if ipfixRecordSizeV4 != 57 {
+		t.Fatalf("ipfixRecordSizeV4 = %d, want 57 (pre-NAT 45 + 12 post-NAT, #2613 dropped 12 unpopulated bytes)", ipfixRecordSizeV4)
 	}
 }
 
@@ -78,8 +78,8 @@ func TestIPFIXTemplateV6_PostNATFields(t *testing.T) {
 	if sum != ipfixRecordSizeV6 {
 		t.Fatalf("ipfixRecordSizeV6 = %d, want sum(template) = %d", ipfixRecordSizeV6, sum)
 	}
-	if ipfixRecordSizeV6 != 117 {
-		t.Fatalf("ipfixRecordSizeV6 = %d, want 117 (pre-NAT 81 + 36 post-NAT)", ipfixRecordSizeV6)
+	if ipfixRecordSizeV6 != 105 {
+		t.Fatalf("ipfixRecordSizeV6 = %d, want 105 (pre-NAT 69 + 36 post-NAT, #2613 dropped 12 unpopulated bytes)", ipfixRecordSizeV6)
 	}
 }
 
@@ -175,11 +175,12 @@ func TestNetflowTemplateV4_PostNATFields(t *testing.T) {
 			t.Fatalf("v9 v4 template post-NAT field %d = %+v, want %+v", i, got[i], want[i])
 		}
 	}
-	// Record size derives from the template; the post-NAT append must grow it
-	// by 12 bytes (4+4+2+2). The pre-NAT v4 body (with flow-dir) is 50 bytes,
-	// padded to 52; +12 post-NAT = 62, padded to 64.
-	if rs := recordSize(netflowTemplateFieldsV4); rs != 64 {
-		t.Fatalf("v9 v4 recordSize = %d, want 64 (50 pre-NAT body + 12 post-NAT, padded)", rs)
+	// Record size derives from the template; the post-NAT append grows it by
+	// 12 bytes (4+4+2+2). #2613 dropped 11 unpopulated body bytes
+	// (TOS1+TCPFlags1+Dir1+InputSNMP4+OutputSNMP4): the pre-NAT v4 body is now
+	// 39 bytes; +12 post-NAT = 51, padded to 52.
+	if rs := recordSize(netflowTemplateFieldsV4); rs != 52 {
+		t.Fatalf("v9 v4 recordSize = %d, want 52 (39 pre-NAT body + 12 post-NAT, padded; #2613)", rs)
 	}
 }
 
@@ -209,10 +210,10 @@ func TestNetflowTemplateV6_PostNATFields(t *testing.T) {
 			t.Fatalf("v9 v6 template post-NAT field %d = %+v, want %+v", i, got[i], want[i])
 		}
 	}
-	// v6 pre-NAT body (with flow-dir) is 74 bytes, padded to 76; +36 post-NAT
-	// = 110, padded to 112.
-	if rs := recordSize(netflowTemplateFieldsV6); rs != 112 {
-		t.Fatalf("v9 v6 recordSize = %d, want 112 (74 pre-NAT body + 36 post-NAT, padded)", rs)
+	// #2613 dropped the same 11 unpopulated body bytes: the pre-NAT v6 body is
+	// now 63 bytes; +36 post-NAT = 99, padded to 100.
+	if rs := recordSize(netflowTemplateFieldsV6); rs != 100 {
+		t.Fatalf("v9 v6 recordSize = %d, want 100 (63 pre-NAT body + 36 post-NAT, padded; #2613)", rs)
 	}
 }
 


### PR DESCRIPTION
Closes #2613

## Summary

- The NetFlow v9 and IPFIX templates advertised **SrcTos/ipClassOfService (IE 5)**, **TCPFlags/tcpControlBits (6)**, **Direction/flowDirection (61)**, **InputSNMP/ingressInterface (10)** and **OutputSNMP/egressInterface (14)**, but the SESSION_CLOSE builder (`ExportSessionClose`) never set `FlowRecord.{TOS,TCPFlags,Direction,InIf,OutIf}` — and there is **no source** for them. Collectors ingested authoritative zeros for class-of-service, TCP flags, direction and interface attribution.
- **Root cause (verified):** the dataplane→Go SESSION_CLOSE RT_FLOW frame is a **fixed 136-byte** wire shape (`pkg/logging/ringbuf.go`; final byte is the #2508 LogSyslog gate) that carries no DSCP/TOS, no observed TCP flags, no per-flow direction and no egress ifindex; the Rust encoder `encode_session_close_rt_flow` **hardcodes the ingress-ifindex slot to 0** on close frames. None of the five fields have real data without a cross-dataplane wire-format change.
- **Fix (DROP, per the issue's stated alternative):** removed all five fields from both v9 templates and the IPFIX v4/v6 templates + record encoders + size constants. `ipfixRecordSizeV4` 69→57, V6 117→105; v9 v4 64→52, v6 112→100 (derived via `recordSize`). Removing `fieldDirection` collapses the `IncludeFlowDir`/NoDir variants into one template per family; `IncludeFlowDir` is kept as an **accepted no-op** so config plumbing is unchanged.
- **Warn-not-lie:** the compiler now warns when `export-extension flow-dir` is configured (it no longer adds the field), mirroring the existing `app-id` precedent in the same helper.
- **Follow-up #2749** tracks populating the fields for real via a Rust↔Go SESSION_CLOSE wire-format extension.

A hostile design review (Codex/gpt-5.5) independently confirmed DROP over POPULATE for all five fields (no Go-side source exists) and the keep-`IncludeFlowDir`-as-no-op + warn disposition.

## Which fields

| Field | NetFlow v9 IE | IPFIX IE | Disposition |
|---|---|---|---|
| SrcTos / ipClassOfService | 5 | 5 | dropped |
| TCPFlags / tcpControlBits | 6 | 6 | dropped |
| Direction / flowDirection | 61 | 61 | dropped |
| InputSNMP / ingressInterface | 10 | 10 | dropped |
| OutputSNMP / egressInterface | 14 | 14 | dropped |

## Test plan

- [x] `pkg/flowexport/dropped_fields_test.go` — template-absence walk over the encoded v9 + IPFIX template bytes; record-layout golden encodes a record with **sentinel** non-zero TOS/flags/direction/interface and asserts the byte after `protocol` is the packet-counter high byte (0x11), not a leaked sentinel.
- [x] **fail-on-revert proven:** re-introducing IPFIX v4 TOS (template + encoder + size) fired `TestIPFIXTemplateDroppedFieldsAbsent`, `TestIPFIXRecordOmitsDroppedFields` and `TestIPFIXTemplateV4_PostNATFields` **RED**; reverting restores **GREEN**.
- [x] Updated `postnat_test.go` size assertions and replaced the obsolete v9 flow-dir-conditional tests with an always-absent contract test.
- [x] Gates: `go build ./...`, `go vet ./pkg/flowexport/... ./pkg/config/... ./pkg/daemon/...`, `gofmt -l` (clean), `go test ./pkg/flowexport/... ./pkg/config/... ./pkg/daemon/...` — all green.

Live-traffic validation not run (pure encoder/template change in the Go control plane; no dataplane/forwarding path touched).

## Deferred

- #2749 — populate TOS/TCPFlags/Direction/InIf/OutIf via a SESSION_CLOSE wire-format extension.

## Refs

- Closes #2613
- Refs #2749, #2526 (post-NAT tuple), #2508 (LogSyslog wire byte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi