### PR TITLE
userspace-dp: reject subnet-directed broadcast ICMP-error source (#2487)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15092,3 +15092,24 @@ top.
   pkg/config/compiler_nat_source_address_name_2416_test.go,
   pkg/dataplane/userspace/nat_source_address_name_2416_test.go,
   docs/userspace-dnat-plan.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2487 — extend ICMP-error source validation to subnet-directed
+  broadcast. `source_is_invalid_for_icmp_error` only caught the limited
+  broadcast (`255.255.255.255` via `is_broadcast()`); a directed-broadcast
+  SOURCE (all-ones host of a connected prefix) slipped through, so a locally
+  generated ICMP error addressed to that source went to the whole segment
+  (Smurf backscatter). Extracted `v4_addr_is_directed_broadcast` from
+  `dest_is_directed_broadcast` and added the SOURCE sibling
+  `src_is_directed_broadcast(&ForwardingState, packet)`; wired into the IPv4
+  arms of `can_generate_icmp_error_reply` (icmp.rs) and `ptb_reply_suppressed`
+  (icmp_ptb.rs), v4-only. Added 6 fail-on-revert tests (reject + PTB paths:
+  directed-broadcast src suppressed, unicast-in-subnet still allowed, /32
+  host all-ones-octet still allowed). RED-on-revert proven for the reject
+  path. README updated with the #2487 source-side paragraph. Read-side only,
+  no wire change.
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs,
+  userspace-dp/src/afxdp/frame/mod.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs,
+  userspace-dp/src/afxdp/README.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -231,6 +231,24 @@ sync.
   runs only when an ICMP error is about to be generated, never on the
   per-packet fast path. No new counter — a suppressed error folds into
   the existing fail-closed silent drop.
+  #2487: the SOURCE-side sibling of #2411. A locally generated ICMP error
+  is addressed TO the trigger packet's source, so a *subnet-directed
+  broadcast* SOURCE (the all-ones host of a connected prefix, e.g.
+  `10.0.1.255` for `10.0.1.0/24`) produces an error emitted to that
+  directed broadcast — delivered to every host on the segment
+  (Smurf-style amplification / backscatter). The limited-broadcast test
+  in `source_is_invalid_for_icmp_error` (`is_broadcast()`) only catches
+  `255.255.255.255`; a subnet-directed broadcast is a plain unicast to it
+  and needs the configured subnet MASK. The new shared
+  `src_is_directed_broadcast` predicate (`frame/inspect.rs`) reuses the
+  SAME `connected_v4` scan (extracted into the shared
+  `v4_addr_is_directed_broadcast` helper that `dest_is_directed_broadcast`
+  also now calls) and the SAME `/31`/`/32` prefix-length guards. The IPv4
+  arms of `can_generate_icmp_error_reply` and `ptb_reply_suppressed` call
+  it alongside the existing source check (v4-only — IPv6 has no
+  broadcast), so the reject, Time-Exceeded, and PTB paths apply ONE
+  bad-source set covering both the limited and directed broadcast. Same
+  cold-path scan, no new counter, fail-closed silent drop.
   #2472: AFTER the RFC suppression + output-classification gates, all three
   locally-generated error reasons (Time Exceeded, PTB/Frag-Needed, and
   policy/filter `reject`) now also pass through a per-reason token-bucket

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -626,16 +626,67 @@ pub(in crate::afxdp) fn dest_is_directed_broadcast(
         return true;
     };
     let dst = Ipv4Addr::new(dst[0], dst[1], dst[2], dst[3]);
-    // `directed_broadcast() == dst` already implies the prefix contains
-    // dst: a directed broadcast is `network | !mask`, so `dst & mask ==
-    // network` (the host bits are all-ones and masked off) — i.e.
-    // `contains(dst)` is necessarily true. The explicit `contains` check
-    // would be redundant, so only the broadcast-equality and the
-    // prefix-length guard remain.
+    v4_addr_is_directed_broadcast(forwarding, dst)
+}
+
+/// Shared connected-table directed-broadcast test for a single IPv4
+/// address, used by both the L3-DESTINATION gate
+/// ([`dest_is_directed_broadcast`]) and the L3-SOURCE gate
+/// ([`src_is_directed_broadcast`]). Returns `true` when `addr` is the
+/// all-ones host (subnet-directed broadcast) of any connected prefix.
+///
+/// `directed_broadcast() == addr` already implies the prefix contains
+/// `addr`: a directed broadcast is `network | !mask`, so `addr & mask ==
+/// network` (the host bits are all-ones and masked off) — i.e.
+/// `contains(addr)` is necessarily true. The explicit `contains` check
+/// would be redundant, so only the broadcast-equality and the
+/// prefix-length guard remain.
+///
+/// Prefixes shorter than /31 are the only ones with a meaningful
+/// directed broadcast: a /31 (RFC 3021) has no broadcast and a /32's
+/// host-all-ones value equals the host itself, so both are skipped to
+/// avoid mis-classifying a legitimate unicast to a /32 connected host.
+#[inline]
+fn v4_addr_is_directed_broadcast(forwarding: &ForwardingState, addr: Ipv4Addr) -> bool {
     forwarding
         .connected_v4
         .iter()
-        .any(|entry| entry.prefix.prefix_len() < 31 && entry.prefix.directed_broadcast() == dst)
+        .any(|entry| entry.prefix.prefix_len() < 31 && entry.prefix.directed_broadcast() == addr)
+}
+
+/// #2487: RFC 1812 §4.3.2.7 — a router MUST NOT originate an ICMP error
+/// in reply to a datagram whose IP SOURCE is a *directed* (subnet)
+/// broadcast, e.g. `10.0.1.255` for a connected `10.0.1.0/24`. A locally
+/// generated error is addressed TO the trigger's source, so a directed-
+/// broadcast source produces an error sent to that directed broadcast —
+/// delivered to every host on the segment (Smurf-style amplification /
+/// backscatter). This is the L3-SOURCE sibling of the merged #2411
+/// [`dest_is_directed_broadcast`] (L3 destination): the
+/// [`source_is_invalid_for_icmp_error`] limited-broadcast test
+/// (`is_broadcast()`) only catches `255.255.255.255`; a subnet-directed
+/// broadcast is a plain unicast address to that test and needs the
+/// configured subnet MASK from the connected-route table to recognize.
+///
+/// IPv4-only: IPv6 has no broadcast (the v6 caller never invokes this).
+/// `packet` is the L3 (IP-header-first) slice. Returns `true` when the
+/// source is the all-ones host address of a connected prefix and the
+/// ICMP error MUST be suppressed. A too-short slice fails closed
+/// (suppress). The connected table is reused from the forwarding path
+/// (no new infrastructure), scanned only on the cold error-generation
+/// path. The /31 and /32 prefix-length guards match
+/// [`dest_is_directed_broadcast`].
+#[inline]
+pub(in crate::afxdp) fn src_is_directed_broadcast(
+    forwarding: &ForwardingState,
+    packet: &[u8],
+) -> bool {
+    let Some(src) = packet.get(12..16) else {
+        // Fail closed: a source we cannot read must suppress the error
+        // rather than risk directed-broadcast backscatter.
+        return true;
+    };
+    let src = Ipv4Addr::new(src[0], src[1], src[2], src[3]);
+    v4_addr_is_directed_broadcast(forwarding, src)
 }
 
 /// #2367: RFC 1812 §4.3.2.7 / RFC 4443 §2.4(e) — a router MUST NOT

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -66,7 +66,8 @@ pub(in crate::afxdp) use inspect::{
     ipv4_is_non_first_fragment, ipv6_is_any_fragment, ipv6_is_non_first_fragment, is_any_fragment,
     is_non_first_fragment,
     l2_dst_is_group_or_broadcast, parse_session_flow, source_is_invalid_for_icmp_error,
-    term_match_extra_from_frame, term_match_extra_from_frame_fwd, term_match_extra_from_meta,
+    src_is_directed_broadcast, term_match_extra_from_frame, term_match_extra_from_frame_fwd,
+    term_match_extra_from_meta,
     try_parse_metadata,
 };
 

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -93,9 +93,15 @@ pub(super) fn can_generate_icmp_error_reply(
             // #2314 destination) so the PTB, reject, and Time Exceeded
             // paths agree on the disallowed source/destination sets.
             // #2411: also suppress for an IPv4 subnet-directed broadcast
-            // (all-ones host of a connected prefix) — invisible to the
-            // limited-broadcast test, needs the connected subnet mask.
+            // DESTINATION (all-ones host of a connected prefix) —
+            // invisible to the limited-broadcast test, needs the
+            // connected subnet mask.
+            // #2487: and the matching SOURCE check — a directed-broadcast
+            // SOURCE would send the generated error to that directed
+            // broadcast (Smurf backscatter); `source_is_invalid_for_icmp_error`
+            // only catches the limited broadcast (255.255.255.255).
             if source_is_invalid_for_icmp_error(meta.addr_family, packet)
+                || src_is_directed_broadcast(forwarding, packet)
                 || dest_is_multicast_or_broadcast(meta.addr_family, packet)
                 || dest_is_directed_broadcast(forwarding, packet)
             {
@@ -892,6 +898,72 @@ mod tests {
         assert!(
             can_generate_icmp_error_reply(&frame, meta, &fwd),
             "a /32 connected host must not be treated as a directed broadcast"
+        );
+    }
+
+    /// #2487: rewrite the IPv4 SOURCE of an `inbound_v4` frame (offset
+    /// depends on the L2 tag) and fix the IP-header checksum. Mirror of
+    /// `set_inbound_v4_dst` for the source-side directed-broadcast test.
+    fn set_inbound_v4_src(frame: &mut [u8], meta: UserspaceDpMeta, src: Ipv4Addr) {
+        let l3 = meta.l3_offset as usize;
+        frame[l3 + 12..l3 + 16].copy_from_slice(&src.octets());
+        frame[l3 + 10..l3 + 12].copy_from_slice(&[0, 0]);
+        let csum = checksum16(&frame[l3..l3 + 20]);
+        frame[l3 + 10..l3 + 12].copy_from_slice(&csum.to_be_bytes());
+    }
+
+    /// #2487: an IPv4 trigger whose SOURCE is a SUBNET-DIRECTED broadcast
+    /// (the all-ones host of a configured connected prefix, e.g.
+    /// 10.0.1.255 for 10.0.1.0/24) must suppress the locally generated
+    /// ICMP error (RFC 1812 §4.3.2.7). The error is addressed to the
+    /// trigger's source, so a directed-broadcast source would emit the
+    /// error to that directed broadcast (Smurf backscatter). This is the
+    /// source-side sibling of #2411 — the limited-broadcast test in
+    /// `source_is_invalid_for_icmp_error` (`is_broadcast()`) only catches
+    /// 255.255.255.255. FAILS (error generated) if the
+    /// `src_is_directed_broadcast` check is removed.
+    #[test]
+    fn reject_suppressed_for_v4_directed_broadcast_src() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_src(&mut frame, meta, Ipv4Addr::new(10, 0, 1, 255));
+        let fwd = forwarding_with_connected_v4("10.0.1.0/24");
+        assert!(
+            !can_generate_icmp_error_reply(&frame, meta, &fwd),
+            "IPv4 subnet-directed broadcast SOURCE must suppress the reply"
+        );
+        assert!(
+            build_reject_icmp_unreachable(&frame, meta, ICMP_IFINDEX, &fwd).is_none(),
+            "reject unreachable must not build for a directed-broadcast source"
+        );
+    }
+
+    /// #2487 anti-over-suppress: a normal unicast HOST source inside the
+    /// same connected subnet (10.0.1.42 in 10.0.1.0/24) must STILL
+    /// generate the error — only the all-ones host is the directed
+    /// broadcast.
+    #[test]
+    fn reject_still_allowed_for_unicast_src_in_connected_subnet() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_src(&mut frame, meta, Ipv4Addr::new(10, 0, 1, 42));
+        let fwd = forwarding_with_connected_v4("10.0.1.0/24");
+        assert!(
+            can_generate_icmp_error_reply(&frame, meta, &fwd),
+            "a unicast host source inside a connected subnet must allow the reply"
+        );
+    }
+
+    /// #2487 fail-on-revert guard for the prefix-length skip: a /32
+    /// connected host's `.255` octet is the host itself, NOT a directed
+    /// broadcast, so a normal unicast source to a /32 host must NOT be
+    /// suppressed (the `prefix_len() < 31` guard keeps it allowed).
+    #[test]
+    fn reject_still_allowed_for_v4_host_route_all_ones_octet_src() {
+        let (mut frame, meta) = inbound_v4(InL2::Untagged);
+        set_inbound_v4_src(&mut frame, meta, Ipv4Addr::new(10, 0, 1, 255));
+        let fwd = forwarding_with_connected_v4("10.0.1.255/32");
+        assert!(
+            can_generate_icmp_error_reply(&frame, meta, &fwd),
+            "a /32 connected host source must not be treated as a directed broadcast"
         );
     }
 

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -254,6 +254,17 @@ pub(in crate::afxdp) fn ptb_reply_suppressed(
     if source_is_invalid_for_icmp_error(meta.addr_family, packet) {
         return true;
     }
+    // #2487: never generate a PTB in reply to an IPv4 subnet-directed
+    // broadcast SOURCE (all-ones host of a connected prefix). The PTB is
+    // addressed to the trigger's source, so a directed-broadcast source
+    // would send the PTB to that directed broadcast (Smurf backscatter);
+    // `source_is_invalid_for_icmp_error` only catches the limited
+    // broadcast (255.255.255.255). v4-only — IPv6 has no broadcast and
+    // `src_is_directed_broadcast` reads the v4 source octets, so it is
+    // gated on AF_INET (matching the #2411 destination gate below).
+    if meta.addr_family as i32 == libc::AF_INET && src_is_directed_broadcast(forwarding, packet) {
+        return true;
+    }
     // #2314: never generate a PTB in reply to a datagram whose IP
     // destination was multicast or broadcast.
     if dest_is_multicast_or_broadcast(meta.addr_family, packet) {

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -409,6 +409,53 @@ fn ptb_still_generated_for_unicast_in_connected_subnet() {
     );
 }
 
+/// #2487: an oversized DF IPv4 datagram whose SOURCE is a SUBNET-DIRECTED
+/// broadcast (all-ones host of a connected prefix, e.g. 10.0.1.255 for
+/// 10.0.1.0/24) must NOT generate a PTB (RFC 1812 §4.3.2.7). The PTB is
+/// addressed to the trigger's source, so a directed-broadcast source
+/// would emit the PTB to that directed broadcast (Smurf backscatter). The
+/// limited-broadcast test in `source_is_invalid_for_icmp_error` only
+/// catches 255.255.255.255. Fails (PTB allowed) if the
+/// `src_is_directed_broadcast` check is removed.
+#[test]
+fn ptb_suppressed_for_v4_directed_broadcast_src() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_v4_src(&mut frame, l3, Ipv4Addr::new(10, 0, 1, 255));
+    let mut fwd = forwarding_with_egress(1400);
+    fwd.connected_v4.push(ConnectedRouteV4 {
+        prefix: crate::prefix::PrefixV4::from_net("10.0.1.0/24".parse().expect("cidr")),
+        ifindex: PTB_IFINDEX,
+        tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
+    });
+    assert!(
+        ptb_reply_suppressed(&frame, meta, l3, &fwd),
+        "IPv4 subnet-directed broadcast SOURCE must suppress the PTB"
+    );
+}
+
+/// #2487 anti-over-suppress: a normal unicast HOST source inside the same
+/// connected subnet must STILL generate the PTB; only the all-ones host
+/// is the directed broadcast.
+#[test]
+fn ptb_still_generated_for_unicast_src_in_connected_subnet() {
+    let (mut frame, meta) = inbound_v4_udp(1500, true);
+    let l3 = meta.l3_offset as usize;
+    set_v4_src(&mut frame, l3, Ipv4Addr::new(10, 0, 1, 42));
+    let mut fwd = forwarding_with_egress(1400);
+    fwd.connected_v4.push(ConnectedRouteV4 {
+        prefix: crate::prefix::PrefixV4::from_net("10.0.1.0/24".parse().expect("cidr")),
+        ifindex: PTB_IFINDEX,
+        tunnel_endpoint_id: 0,
+        table: "inet.0".to_string(),
+    });
+    assert!(
+        !ptb_reply_suppressed(&frame, meta, l3, &fwd),
+        "a unicast host source inside a connected subnet must NOT suppress the PTB"
+    );
+}
+
 /// #2314: an oversized IPv6 datagram destined to ff00::/8 multicast must
 /// NOT generate a Packet-Too-Big (RFC 4443 §2.4(e)).
 #[test]


### PR DESCRIPTION
Closes #2487

## Summary
`source_is_invalid_for_icmp_error` (the L3-SOURCE gate for locally generated ICMP errors) checked only `Ipv4Addr::is_broadcast()`, which is true ONLY for the limited broadcast `255.255.255.255`. A **subnet-directed broadcast** source — the all-ones host of a connected prefix, e.g. `10.0.1.255` for a connected `10.0.1.0/24` — is a plain unicast address to that test and slipped through. Because a locally generated ICMP error is addressed TO the trigger packet's source, a directed-broadcast source produces an error emitted to that directed broadcast, delivered to every host on the segment (Smurf-style amplification / backscatter). This is the SOURCE-side sibling of the merged #2411 (destination directed-broadcast suppression).

## RFC basis
RFC 1812 §4.3.2.7 / §5.3.7 — a router MUST NOT originate an ICMP error in reply to a datagram whose source does not uniquely identify a single host. A directed broadcast is not a single host.

## Fix
- Extracted the connected-prefix directed-broadcast match from `dest_is_directed_broadcast` into a shared `v4_addr_is_directed_broadcast` helper (`frame/inspect.rs`).
- Added the SOURCE predicate `src_is_directed_broadcast(&ForwardingState, packet)` that scans the SAME `connected_v4` rows with the SAME `/31` (RFC 3021, no broadcast) / `/32` (all-ones host == the host itself) prefix-length guards as #2411.
- Wired it into the IPv4 arms of `can_generate_icmp_error_reply` (icmp.rs) and `ptb_reply_suppressed` (icmp_ptb.rs) alongside the existing source check, v4-only (IPv6 has no broadcast). Reject, Time-Exceeded, and PTB paths now apply ONE bad-source set covering both the limited and the directed broadcast.
- Cold-path scan only (runs only when an error is about to be generated); no new counter — a suppressed error folds into the existing fail-closed silent drop.

Read-side validation only; no protocol-wire change. README updated with the #2487 source-side paragraph.

## Fail-on-revert proof
Six unit tests across the reject + PTB paths:
- `reject_suppressed_for_v4_directed_broadcast_src` / `ptb_suppressed_for_v4_directed_broadcast_src` — directed-broadcast source suppressed
- `reject_still_allowed_for_unicast_src_in_connected_subnet` / `ptb_still_generated_for_unicast_src_in_connected_subnet` — anti-over-suppress (normal host in subnet)
- `reject_still_allowed_for_v4_host_route_all_ones_octet_src` — /32 host all-ones octet NOT a directed broadcast

Temporarily removing the `src_is_directed_broadcast` call site in icmp.rs turned `reject_suppressed_for_v4_directed_broadcast_src` RED ("IPv4 subnet-directed broadcast SOURCE must suppress the reply"); restored to green.

## Gates
- `cargo build --release` — clean (pre-existing warnings only)
- New tests: all 6 pass; full suite green except the pre-existing `worker_queue::tests::concurrent_recovery_processes_each_command_exactly_once` parallelism flake (passes in isolation, unrelated to this read-side change).
- No protocol_wire test depends on this read-side predicate (no wire change).