### PR TITLE
config: reject malformed static-route destination + next-hop at commit (#2448)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15201,3 +15201,24 @@ top.
   all green. Doc: docs/config-schema.md #2448 subsection.
 - **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_routing.go,
   pkg/config/schema_validate_route_2448_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2448 review fold — fix over-rejection regression flagged in the
+  hostile review of PR #2752. Modeling `next-hop` as a typed value-leaf routed
+  its `interface <iface>` child through the presence-only modifier path, so a
+  PLAIN `next-hop <ip> interface <iface>` (the IPv6 link-local form the
+  compiler supports in both AST shapes) was rejected as
+  `unknown modifier "<iface>"`. Re-modeled next-hop as a CONTAINER with a
+  keyValidator (keyValueType/keyValueDesc/keyValueExamples/keyValidator =
+  ValidateStaticNextHop) so the gateway is still validated while the
+  `interface` child walks as a normal value-bearing child. Added
+  TestSchema2448_NextHop_AcceptsExplicitInterface covering the hierarchical
+  child form AND the flat inline form (both now PASS; rejected before the
+  fold), plus a negative that a malformed gateway WITH an interface is still
+  rejected. All 9 RejectsBad fail-on-revert cases still go RED when the two
+  keyValidators are stripped. Gates: go build ./..., gofmt -l clean, go vet
+  clean, go test ./pkg/config/... ./pkg/cmdtree/... ./pkg/frr/...
+  ./pkg/configstore/... all green. Doc: docs/config-schema.md next-hop
+  container/explicit-interface paragraph.
+- **File(s)**: pkg/config/schema_routing.go,
+  pkg/config/schema_validate_route_2448_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -15181,3 +15181,23 @@ top.
   clean origin/master, no snmp involvement).
 - **File(s)**: pkg/snmp/agent.go, pkg/snmp/v3_timeliness_test.go,
   pkg/snmp/v3_set_test.go, pkg/snmp/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2448 — type static-route destination + next-hop at commit so a
+  malformed CIDR or gateway is REJECTED instead of silently dropped by the
+  FRR renderer / Rust FIB builder (populate_routes soft-skips a non-v4/v6
+  destination; the next-hop resolver falls back to ifindex 0 / interface-only).
+  Added ValidateRouteDestination (family-agnostic CIDR, required prefix —
+  accepts 0.0.0.0/0 + ::/0) and ValidateStaticNextHop (IP / ip@interface /
+  bare interface name; rejects botched IP literals + bad-IP-before-@) +
+  plausibleInterfaceName helper. Wired via a new staticRouteNode() SSOT shared
+  by routing-options / per-rib / routing-instances static blocks; the node now
+  declares next-hop, qualified-next-hop, discard, reject, next-table,
+  preference children so no-next-hop and qualified forms still commit. Added
+  schema_validate_route_2448_test.go (hierarchical + flat-set, fail-on-revert
+  proven RED: stripping the two validators makes all 9 RejectsBad cases
+  silently accept). Gates: go build ./..., gofmt -l clean, go vet clean,
+  go test ./pkg/config/... ./pkg/cmdtree/... ./pkg/frr/... ./pkg/configstore/...
+  all green. Doc: docs/config-schema.md #2448 subsection.
+- **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_routing.go,
+  pkg/config/schema_validate_route_2448_test.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1573,19 +1573,33 @@ of installing silently and then vanishing from the dataplane.
   `::/0` parse via `net.ParseCIDR` and are accepted; a bare IP (no length), an
   out-of-range mask (`/99`), or outright garbage is a commit error. v4 and v6
   both pass because a static block holds either family.
-- **next-hop** — the `next-hop` value uses `validator: ValidateStaticNextHop`
-  (`valueType: ValueIPAddress`). Accepted: a bare IPv4/IPv6 address (the FRR
-  renderer emits it verbatim, the Rust FIB parses it), a bare interface name
-  (`ge-0-0-0.0`, `reth0.50`, `eth1` — a valid Junos interface next-hop that
-  FRR renders as an interface route), and the Rust-FIB `ip@interface` /
-  `@interface` spec (the Junos lexer rejects `@`, so this form reaches only a
-  programmatic caller, but the validator classifies it correctly: the IP part,
-  when present, must parse, else the spec silently degrades to interface-only).
-  Rejected: a botched IP literal (`1.2.3.999`, `2001:db8::garbage`), an
-  `ip@iface` whose IP part does not parse, and any value that is neither a
-  valid IP nor a plausible interface name (`[A-Za-z0-9._-]`, at least one ASCII
-  letter so a numeric-only dotted token cannot masquerade as a name).
-- **what is NOT rejected** — `discard` / `reject` / `next-table` /
+- **next-hop** — the `next-hop` gateway uses `keyValidator:
+  ValidateStaticNextHop` (`keyValueType: ValueIPAddress`). next-hop is modeled
+  as a CONTAINER node (like `qualified-next-hop`), NOT a typed value-leaf, so
+  the gateway is validated through the identity-arg keyValidator while the
+  optional `interface <iface>` CHILD still walks as a normal value-bearing
+  child. This matters: the compiler accepts an EXPLICIT egress interface on a
+  plain next-hop (for IPv6 link-local gateways) in BOTH the hierarchical
+  `next-hop fe80::50 { interface reth0.50; }` and the flat/inline
+  `next-hop fe80::50 interface reth0.50` shapes (compiler_routing.go). A
+  typed value-leaf would route the `interface` child through the presence-only
+  modifier path and reject the value token after `interface` as `unknown
+  modifier` — the #2448 over-rejection regression caught in review. Accepted
+  gateway values: a bare IPv4/IPv6 address (the FRR renderer emits it
+  verbatim, the Rust FIB parses it), a bare interface name (`ge-0-0-0.0`,
+  `reth0.50`, `eth1` — a valid Junos interface next-hop that FRR renders as an
+  interface route), and the Rust-FIB `ip@interface` / `@interface` spec (the
+  Junos lexer rejects `@`, so this form reaches only a programmatic caller,
+  but the validator classifies it correctly: the IP part, when present, must
+  parse, else the spec silently degrades to interface-only). Rejected: a
+  botched IP literal (`1.2.3.999`, `2001:db8::garbage`), an `ip@iface` whose
+  IP part does not parse, and any value that is neither a valid IP nor a
+  plausible interface name (`[A-Za-z0-9._-]`, at least one ASCII letter so a
+  numeric-only dotted token cannot masquerade as a name). The gateway is still
+  validated when an explicit `interface` is present — the keyValidator runs on
+  the gateway identity arg regardless of the child.
+- **what is NOT rejected** — a plain `next-hop <ip> interface <iface>` (the
+  link-local form above, both shapes); `discard` / `reject` / `next-table` /
   `qualified-next-hop ... interface ...` are declared children of the `route`
   node, so a no-next-hop blackhole/leak route and the link-local-IPv6
   qualified-next-hop form still commit. `preference` is likewise declared.

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1560,3 +1560,42 @@ belongs: `resolve_cos_dscp_classifier_queue_id` / `resolve_cos_ieee8021_classifi
 (`tx/cos_classify.rs`) still mask the LIVE packet's DSCP/PCP to index the
 fixed-size table — the table is now built only from validated indices, so the
 mask just bounds the physically-limited wire field, it no longer aliases config.
+
+### #2448 — static-route destination + next-hop typed at commit
+
+`routing-options static route <destination>` and its `next-hop <gateway>`
+child are now typed so a malformed prefix or gateway fails the commit instead
+of installing silently and then vanishing from the dataplane.
+
+- **destination** — the `route` identity arg uses `keyValidator:
+  ValidateRouteDestination` (`keyValueType: ValueCIDR`), a family-agnostic
+  CIDR with a REQUIRED `/prefix-length`. The default routes `0.0.0.0/0` and
+  `::/0` parse via `net.ParseCIDR` and are accepted; a bare IP (no length), an
+  out-of-range mask (`/99`), or outright garbage is a commit error. v4 and v6
+  both pass because a static block holds either family.
+- **next-hop** — the `next-hop` value uses `validator: ValidateStaticNextHop`
+  (`valueType: ValueIPAddress`). Accepted: a bare IPv4/IPv6 address (the FRR
+  renderer emits it verbatim, the Rust FIB parses it), a bare interface name
+  (`ge-0-0-0.0`, `reth0.50`, `eth1` — a valid Junos interface next-hop that
+  FRR renders as an interface route), and the Rust-FIB `ip@interface` /
+  `@interface` spec (the Junos lexer rejects `@`, so this form reaches only a
+  programmatic caller, but the validator classifies it correctly: the IP part,
+  when present, must parse, else the spec silently degrades to interface-only).
+  Rejected: a botched IP literal (`1.2.3.999`, `2001:db8::garbage`), an
+  `ip@iface` whose IP part does not parse, and any value that is neither a
+  valid IP nor a plausible interface name (`[A-Za-z0-9._-]`, at least one ASCII
+  letter so a numeric-only dotted token cannot masquerade as a name).
+- **what is NOT rejected** — `discard` / `reject` / `next-table` /
+  `qualified-next-hop ... interface ...` are declared children of the `route`
+  node, so a no-next-hop blackhole/leak route and the link-local-IPv6
+  qualified-next-hop form still commit. `preference` is likewise declared.
+
+Before #2448 both leaves were accepted untyped: the Rust FIB builder
+(`userspace-dp forwarding_build/fib.rs populate_routes`) soft-skips a
+destination that parses as neither v4 nor v6 (no error, no counter), and the
+next-hop resolver falls back to ifindex 0 / interface-only on an unparseable
+spec — so an operator typo committed cleanly and then either never installed
+or installed a blackhole, with no signal. The SSOT is `staticRouteNode()` in
+`schema_routing.go`, shared by the `routing-options`, per-`rib`, and
+`routing-instances` static blocks. Regression + fail-on-revert tests:
+`pkg/config/schema_validate_route_2448_test.go`.

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -47,15 +47,17 @@ func samplingFlowServerNode() *schemaNode {
 // routes block (#2448). It is a fresh node per call so each static block
 // (routing-options, per-rib, and the routing-instances mirrors) owns an
 // independent subtree. The destination identity arg is validated as a
-// family-agnostic CIDR (ValidateRouteDestination); the next-hop child value
-// is validated as an IP / ip@interface / interface-name
-// (ValidateStaticNextHop). Both were accepted untyped before #2448, so a
+// family-agnostic CIDR (ValidateRouteDestination); the next-hop gateway is
+// validated as an IP / ip@interface / interface-name (ValidateStaticNextHop)
+// via the next-hop CONTAINER's keyValidator — so the optional
+// `interface <iface>` child still walks as a value-bearing child in both AST
+// shapes (a typed value-leaf would mis-route it through the presence-only
+// modifier path). Both leaves were accepted untyped before #2448, so a
 // malformed destination or next-hop committed cleanly and then silently
 // failed to install in the FRR renderer and the Rust FIB builder. The
 // remaining children (qualified-next-hop, discard, reject, next-table,
-// preference) are declared so completion does not drop them and so the
-// next-hop sibling is recognized as a known child rather than an extra
-// identity token.
+// preference) are declared so completion does not drop them and so each is
+// recognized as a known child rather than an extra identity token.
 func staticRouteNode() *schemaNode {
 	return &schemaNode{
 		desc: "Static route", args: 1, placeholder: "<destination>",
@@ -63,9 +65,21 @@ func staticRouteNode() *schemaNode {
 		keyValueExamples: []string{"0.0.0.0/0", "10.0.0.0/24", "::/0"},
 		keyValidator:     ValidateRouteDestination,
 		children: map[string]*schemaNode{
+			// next-hop is a CONTAINER (keyValidator), NOT a typed value-leaf:
+			// the gateway is validated via the identity-arg keyValidator
+			// (ValidateStaticNextHop) so its optional `interface <iface>`
+			// child — which the compiler supports for IPv6 link-local
+			// gateways in BOTH the hierarchical
+			// `next-hop fe80::50 { interface reth0.50; }` and the flat/inline
+			// `next-hop fe80::50 interface reth0.50` shapes
+			// (compiler_routing.go) — walks as a normal value-bearing child.
+			// Modeling it as a typed value-leaf routed the `interface` child
+			// through the presence-only modifier path, so the value token
+			// after `interface` was rejected as `unknown modifier` (#2448
+			// over-rejection regression).
 			"next-hop": {desc: "Next-hop gateway (IP, ip@interface, or interface name)", args: 1, placeholder: "<gateway>",
-				valueType: ValueIPAddress, valueDesc: "next-hop IP address, ip@interface, or interface name",
-				valueExamples: []string{"192.168.1.1", "2001:db8::1"}, validator: ValidateStaticNextHop,
+				keyValueType: ValueIPAddress, keyValueDesc: "next-hop IP address, ip@interface, or interface name",
+				keyValueExamples: []string{"192.168.1.1", "2001:db8::1"}, keyValidator: ValidateStaticNextHop,
 				children: map[string]*schemaNode{
 					"interface": {desc: "Egress interface for this next-hop", args: 1, placeholder: "<interface-name>", children: nil},
 				}},

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -43,13 +43,52 @@ func samplingFlowServerNode() *schemaNode {
 	}
 }
 
+// staticRouteNode builds the typed `route <destination>` node for a static
+// routes block (#2448). It is a fresh node per call so each static block
+// (routing-options, per-rib, and the routing-instances mirrors) owns an
+// independent subtree. The destination identity arg is validated as a
+// family-agnostic CIDR (ValidateRouteDestination); the next-hop child value
+// is validated as an IP / ip@interface / interface-name
+// (ValidateStaticNextHop). Both were accepted untyped before #2448, so a
+// malformed destination or next-hop committed cleanly and then silently
+// failed to install in the FRR renderer and the Rust FIB builder. The
+// remaining children (qualified-next-hop, discard, reject, next-table,
+// preference) are declared so completion does not drop them and so the
+// next-hop sibling is recognized as a known child rather than an extra
+// identity token.
+func staticRouteNode() *schemaNode {
+	return &schemaNode{
+		desc: "Static route", args: 1, placeholder: "<destination>",
+		keyValueType: ValueCIDR, keyValueDesc: "Route destination prefix (CIDR, e.g. 10.0.0.0/24 or ::/0)",
+		keyValueExamples: []string{"0.0.0.0/0", "10.0.0.0/24", "::/0"},
+		keyValidator:     ValidateRouteDestination,
+		children: map[string]*schemaNode{
+			"next-hop": {desc: "Next-hop gateway (IP, ip@interface, or interface name)", args: 1, placeholder: "<gateway>",
+				valueType: ValueIPAddress, valueDesc: "next-hop IP address, ip@interface, or interface name",
+				valueExamples: []string{"192.168.1.1", "2001:db8::1"}, validator: ValidateStaticNextHop,
+				children: map[string]*schemaNode{
+					"interface": {desc: "Egress interface for this next-hop", args: 1, placeholder: "<interface-name>", children: nil},
+				}},
+			"qualified-next-hop": {desc: "Qualified next-hop", args: 1, placeholder: "<gateway>", children: map[string]*schemaNode{
+				"interface":  {desc: "Egress interface", args: 1, placeholder: "<interface-name>", children: nil},
+				"preference": {desc: "Preference", args: 1, placeholder: "<value>", children: nil},
+				"metric":     {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
+			}},
+			"discard":    {desc: "Discard (blackhole) route", children: nil},
+			"reject":     {desc: "Reject route (send ICMP unreachable)", children: nil},
+			"next-table": {desc: "Resolve in another routing table", args: 1, placeholder: "<table>", children: nil},
+			"preference": {desc: "Route preference (administrative distance)", args: 1, placeholder: "<value>", children: nil},
+		},
+	}
+}
+
 var schemaRoutingOptions = &schemaNode{desc: "Routing options", children: map[string]*schemaNode{
 	"static": {desc: "Static routes", children: map[string]*schemaNode{
-		"route": {desc: "Static route", args: 1, placeholder: "<destination>", children: nil},
+		"route": staticRouteNode(),
 	}},
 	"rib": {desc: "Routing information base", args: 1, placeholder: "<rib-name>", children: map[string]*schemaNode{
 		"static": {desc: "Static routes", children: map[string]*schemaNode{
-			"route": {desc: "Static route", args: 1, placeholder: "<destination>", children: nil},
+			"route": staticRouteNode(),
 		}},
 	}},
 	"autonomous-system": {desc: "Autonomous system number", args: 1, placeholder: "<as-number>", children: nil},
@@ -479,11 +518,11 @@ var schemaRoutingInstances = &schemaNode{desc: "Routing instance configuration",
 	// e.g. "instance-type virtual-router;" and "interface enp7s0;"
 	"routing-options": {desc: "Routing options", children: map[string]*schemaNode{
 		"static": {desc: "Static routes", children: map[string]*schemaNode{
-			"route": {desc: "Static route", args: 1, placeholder: "<destination>", children: nil},
+			"route": staticRouteNode(),
 		}},
 		"rib": {desc: "Routing information base", args: 1, placeholder: "<rib-name>", children: map[string]*schemaNode{
 			"static": {desc: "Static routes", children: map[string]*schemaNode{
-				"route": {desc: "Static route", args: 1, placeholder: "<destination>", children: nil},
+				"route": staticRouteNode(),
 			}},
 		}},
 		"interface-routes": {desc: "Interface routes", children: map[string]*schemaNode{

--- a/pkg/config/schema_validate_route_2448_test.go
+++ b/pkg/config/schema_validate_route_2448_test.go
@@ -171,6 +171,43 @@ func TestSchema2448_NextHop_AcceptsValidForms(t *testing.T) {
 	}
 }
 
+// A PLAIN next-hop with an explicit egress interface must commit. The
+// compiler (compiler_routing.go) supports this for IPv6 link-local
+// gateways in BOTH the hierarchical `next-hop fe80::50 { interface
+// reth0.50; }` and the flat/inline `next-hop fe80::50 interface reth0.50`
+// shapes. Modeling next-hop as a typed value-leaf REGRESSED this to
+// `unknown modifier "reth0.50"` (the interface value token was rejected);
+// the container model with a keyValidator restores it. Pinning both shapes
+// (the AcceptsValid masked the gap by only covering qualified-next-hop).
+func TestSchema2448_NextHop_AcceptsExplicitInterface(t *testing.T) {
+	// hierarchical: interface is a block child of next-hop.
+	if err := schemaCheck(t, `routing-options {
+    static {
+        route ::/0 {
+            next-hop fe80::50 {
+                interface reth0.50;
+            }
+        }
+    }
+}`); err != nil {
+		t.Fatalf("hierarchical next-hop <ip> interface <iface> should commit: %v", err)
+	}
+	// flat/inline: interface follows the gateway on one set line.
+	if err := flatSchemaCheck(t,
+		"set routing-options static route ::/0 next-hop fe80::50 interface reth0.50",
+	); err != nil {
+		t.Fatalf("flat-inline next-hop <ip> interface <iface> should commit: %v", err)
+	}
+	// The gateway is still validated even when an interface is present: a
+	// malformed gateway with an interface must be rejected (the keyValidator
+	// runs on the gateway identity arg, not bypassed by the child).
+	if err := flatSchemaCheck(t,
+		"set routing-options static route ::/0 next-hop 2001:db8::garbage interface reth0.50",
+	); err == nil {
+		t.Fatal("malformed gateway with interface should still be rejected, got nil")
+	}
+}
+
 // discard / next-table routes (no next-hop) and qualified-next-hop with a
 // link-local IPv6 + interface must all still commit.
 func TestSchema2448_Route_AcceptsDiscardAndQualified(t *testing.T) {

--- a/pkg/config/schema_validate_route_2448_test.go
+++ b/pkg/config/schema_validate_route_2448_test.go
@@ -1,0 +1,259 @@
+package config_test
+
+// Regression tests for #2448: a static-route `destination` prefix and a
+// next-hop value were accepted untyped at commit and then SILENTLY dropped
+// downstream — a malformed destination falls out of the Rust FIB builder's
+// parse loop (userspace-dp forwarding_build/fib.rs populate_routes) with no
+// error, and a malformed next-hop either becomes an interface-only route or
+// a next-hop with ifindex 0 (a blackhole). The FRR renderer
+// (pkg/frr/config_render.go) likewise emits whatever string it is given.
+// The operator committed the route successfully but it never installs.
+//
+// The fix types the `route` identity arg with ValidateRouteDestination
+// (family-agnostic CIDR) and the `next-hop` value with ValidateStaticNextHop
+// (IP / ip@interface / interface name). Each "RejectsBad" case FAILS to
+// error before the fix and errors after it; each "AcceptsValid" case guards
+// the spellings the compiler/renderer already accept against a false-reject.
+//
+// Fail-on-revert: temporarily strip keyValidator/validator from the route
+// schema node (or run with origin/master), and the RejectsBad cases stop
+// erroring — that is the pre-fix silent-accept behaviour these tests pin.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// --- destination: must be a valid CIDR ----------------------------------
+
+func TestSchema2448_RouteDestination_RejectsBadCIDR(t *testing.T) {
+	err := schemaCheck(t, `routing-options {
+    static {
+        route 10.0.0.0/99 {
+            next-hop 192.168.1.1;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for malformed route destination 10.0.0.0/99, got nil")
+	}
+	if !strings.Contains(err.Error(), "10.0.0.0/99") {
+		t.Fatalf("error should quote the bad destination: %v", err)
+	}
+}
+
+func TestSchema2448_RouteDestination_RejectsGarbage(t *testing.T) {
+	err := schemaCheck(t, `routing-options {
+    static {
+        route not-a-prefix {
+            next-hop 192.168.1.1;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for garbage route destination, got nil")
+	}
+}
+
+// A bare IP without a /prefix-length must be rejected: net.ParseCIDR fails
+// and the route is silently dropped by both the FRR renderer and the FIB.
+func TestSchema2448_RouteDestination_RejectsMissingLength(t *testing.T) {
+	err := schemaCheck(t, `routing-options {
+    static {
+        route 10.0.0.0 {
+            next-hop 192.168.1.1;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for route destination without /prefix-length, got nil")
+	}
+}
+
+// The default routes and IPv6 destinations must NOT be rejected.
+func TestSchema2448_RouteDestination_AcceptsValid(t *testing.T) {
+	for _, dest := range []string{"0.0.0.0/0", "10.0.0.0/24", "172.16.0.0/12", "::/0", "2001:db8::/32"} {
+		cfg := `routing-options {
+    static {
+        route ` + dest + ` {
+            next-hop ` + nextHopFor(dest) + `;
+        }
+    }
+}`
+		if err := schemaCheck(t, cfg); err != nil {
+			t.Fatalf("unexpected error for valid destination %s: %v", dest, err)
+		}
+	}
+}
+
+// nextHopFor picks a family-matched gateway so the AcceptsValid destination
+// cases also exercise a valid next-hop (a v4 route with a v6 next-hop is a
+// different concern than this test's subject).
+func nextHopFor(dest string) string {
+	if strings.Contains(dest, ":") {
+		return "2001:db8::1"
+	}
+	return "192.168.1.1"
+}
+
+// --- next-hop: IP / ip@interface / interface name -----------------------
+
+func TestSchema2448_NextHop_RejectsBadIP(t *testing.T) {
+	err := schemaCheck(t, `routing-options {
+    static {
+        route 10.0.0.0/24 {
+            next-hop 1.2.3.999;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for malformed next-hop 1.2.3.999, got nil")
+	}
+	if !strings.Contains(err.Error(), "1.2.3.999") {
+		t.Fatalf("error should quote the bad next-hop: %v", err)
+	}
+}
+
+func TestSchema2448_NextHop_RejectsBadV6(t *testing.T) {
+	err := schemaCheck(t, `routing-options {
+    static {
+        route ::/0 {
+            next-hop 2001:db8::garbage;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for malformed IPv6 next-hop, got nil")
+	}
+}
+
+// The ip@interface / @interface spec is a Rust-FIB-internal form
+// (forwarding_build/fib.rs split_once('@')); the Junos lexer rejects '@' as
+// an unexpected character, so it never reaches the config layer. The
+// validator still classifies it correctly for any programmatic caller —
+// covered by the unit test below rather than through the parser.
+func TestSchema2448_ValidateStaticNextHop_AtSpec(t *testing.T) {
+	// Bad IP before '@' must be rejected (would silently degrade to
+	// interface-only in the FIB); a valid ip@iface / @iface is accepted.
+	if err := config.ValidateStaticNextHop("notanip@eth0", nil); err == nil {
+		t.Fatal("expected error for notanip@eth0, got nil")
+	}
+	if err := config.ValidateStaticNextHop("10.0.0.1@ge-0-0-0.0", nil); err != nil {
+		t.Fatalf("unexpected error for 10.0.0.1@ge-0-0-0.0: %v", err)
+	}
+	if err := config.ValidateStaticNextHop("@reth0.50", nil); err != nil {
+		t.Fatalf("unexpected error for @reth0.50: %v", err)
+	}
+	if err := config.ValidateStaticNextHop("10.0.0.1@", nil); err == nil {
+		t.Fatal("expected error for trailing '@' with no interface, got nil")
+	}
+}
+
+func TestSchema2448_NextHop_AcceptsValidForms(t *testing.T) {
+	for _, nh := range []string{
+		"192.168.1.1", // bare IPv4
+		"2001:db8::1", // bare IPv6
+		"ge-0-0-0.0",  // bare interface name
+		"eth1",        // bare kernel name
+	} {
+		cfg := `routing-options {
+    static {
+        route 10.0.0.0/24 {
+            next-hop ` + nh + `;
+        }
+    }
+}`
+		if err := schemaCheck(t, cfg); err != nil {
+			t.Fatalf("unexpected error for valid next-hop %q: %v", nh, err)
+		}
+	}
+}
+
+// discard / next-table routes (no next-hop) and qualified-next-hop with a
+// link-local IPv6 + interface must all still commit.
+func TestSchema2448_Route_AcceptsDiscardAndQualified(t *testing.T) {
+	for name, cfg := range map[string]string{
+		"discard": `routing-options {
+    static {
+        route 192.168.99.0/24 {
+            discard;
+        }
+    }
+}`,
+		"next-table": `routing-options {
+    static {
+        route 0.0.0.0/0 {
+            next-table Comcast-GigabitPro.inet.0;
+        }
+    }
+}`,
+		"qualified-next-hop": `routing-options {
+    static {
+        route ::/0 {
+            qualified-next-hop fe80::2d0:f6ff:feda:c180 {
+                interface reth2.0;
+            }
+        }
+    }
+}`,
+	} {
+		if err := schemaCheck(t, cfg); err != nil {
+			t.Fatalf("unexpected error for %s route: %v", name, err)
+		}
+	}
+}
+
+// --- flat-set parity ----------------------------------------------------
+
+func TestSchema2448_FlatSet_RouteDestination_RejectsBad(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set routing-options static route 10.0.0.0/99 next-hop 192.168.1.1",
+	)
+	if err == nil {
+		t.Fatal("expected error for flat-set malformed destination, got nil")
+	}
+}
+
+func TestSchema2448_FlatSet_NextHop_RejectsBad(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set routing-options static route 10.0.0.0/24 next-hop 1.2.3.999",
+	)
+	if err == nil {
+		t.Fatal("expected error for flat-set malformed next-hop, got nil")
+	}
+}
+
+func TestSchema2448_FlatSet_Route_AcceptsValid(t *testing.T) {
+	if err := flatSchemaCheck(t,
+		"set routing-options static route 0.0.0.0/0 next-hop 192.168.1.1",
+		"set routing-options static route 10.10.0.0/16 next-hop 10.0.0.2",
+		"set routing-options static route 192.168.99.0/24 discard",
+		"set routing-options static route 172.16.0.0/12 next-hop 10.0.0.3",
+		"set routing-options static route 172.16.0.0/12 preference 100",
+		"set routing-options static route ::/0 next-hop 2001:db8::1",
+		"set routing-options static route ::/0 qualified-next-hop fe80::2d0:f6ff:feda:c180 interface reth2.0",
+	); err != nil {
+		t.Fatalf("unexpected error for valid flat-set static routes: %v", err)
+	}
+}
+
+// Routing-instances and per-rib mirrors carry the same typed route node.
+func TestSchema2448_RoutingInstances_RouteDestination_RejectsBad(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set routing-instances ATT routing-options static route 10.0.0.0/99 next-hop 192.168.1.1",
+	)
+	if err == nil {
+		t.Fatal("expected error for flat-set routing-instances malformed destination, got nil")
+	}
+}
+
+func TestSchema2448_Rib_NextHop_RejectsBad(t *testing.T) {
+	err := flatSchemaCheck(t,
+		"set routing-options rib inet6.0 static route ::/0 next-hop 2001:db8::garbage",
+	)
+	if err == nil {
+		t.Fatal("expected error for flat-set per-rib malformed next-hop, got nil")
+	}
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -437,6 +437,103 @@ func ValidateRouteFilterArg(raw string, _ *Config) error {
 	return nil
 }
 
+// ValidateRouteDestination accepts a static-route destination prefix: a
+// family-agnostic CIDR (v4 or v6) with an explicit /prefix-length. Used for
+// the `routing-options static route <destination>` identity arg (#2448):
+// the destination feeds net.ParseCIDR in the FRR renderer
+// (pkg/frr/config_render.go generateStaticRoute) and net/ipnet parse in the
+// Rust FIB builder (userspace-dp forwarding_build/fib.rs populate_routes).
+// A destination that parses as neither IPv4 nor IPv6 is SILENTLY dropped by
+// both consumers today — the route commits cleanly but never installs. The
+// default routes 0.0.0.0/0 and ::/0 parse via net.ParseCIDR and are
+// accepted; a bare IP without a length, or outright garbage, is rejected
+// with a targeted message. route is family-agnostic so both families pass.
+func ValidateRouteDestination(raw string, _ *Config) error {
+	// parseCIDRStrict requires a /prefix-length and upgrades the two common
+	// operator mistakes (bare IP, garbage) to targeted messages. The returned
+	// IP is discarded because both v4 and v6 destinations are valid here.
+	if _, err := parseCIDRStrict(raw, "10.0.0.0/24"); err != nil {
+		return fmt.Errorf("not a valid route destination (expected a CIDR, e.g. 10.0.0.0/24 or 2001:db8::/32): %v", err)
+	}
+	return nil
+}
+
+// ValidateStaticNextHop accepts a static-route next-hop VALUE: a bare IPv4
+// or IPv6 address, the Rust-FIB `ip@interface` / `@interface` spec, or a
+// bare interface name. It rejects values that are genuinely malformed —
+// neither a usable IP nor a plausible interface name — so an operator typo
+// fails loud at commit instead of installing a blackhole (#2448).
+//
+// Why each accepted form is real:
+//   - a bare IP (192.168.1.1, 2001:db8::1) is the common gateway form; the
+//     FRR renderer emits it verbatim (config_render.go) and the Rust FIB
+//     parses it (parse_route_next_hop[_v6]).
+//   - `ip@iface` / `@iface` is the Rust FIB interface-scoped form
+//     (forwarding_build/fib.rs split_once('@')); the IP part, when present,
+//     must itself parse, else the spec silently degrades to interface-only.
+//   - a bare interface name (ge-0-0-0.0, reth0.50, eth1) is a valid Junos
+//     next-hop and renders as an interface route in FRR (config_render.go
+//     `case ifName != ""`).
+//
+// The malformed cases rejected: a botched IP literal (1.2.3.999,
+// 2001:db8::garbage), an `ip@iface` whose IP part does not parse
+// (notanip@eth0 — silently becomes interface-only), and any value that is
+// neither a valid IP nor a syntactically plausible interface name. The
+// interface-name test requires at least one ASCII letter so a numeric-only
+// dotted value (a botched IPv4) cannot masquerade as an interface, and uses
+// the [A-Za-z0-9._-] charset interface names actually use — which excludes
+// ':' so a botched IPv6 literal is rejected rather than mistaken for a name.
+func ValidateStaticNextHop(raw string, _ *Config) error {
+	tok := strings.TrimSpace(raw)
+	if tok == "" {
+		return fmt.Errorf("missing next-hop (expected an IP address, e.g. 192.168.1.1 or 2001:db8::1, or an interface name)")
+	}
+	// Rust-FIB ip@interface / @interface spec.
+	if ipPart, ifPart, hasAt := strings.Cut(tok, "@"); hasAt {
+		if ifPart == "" {
+			return fmt.Errorf("malformed next-hop %q: missing interface name after '@'", raw)
+		}
+		if ipPart != "" && net.ParseIP(ipPart) == nil {
+			return fmt.Errorf("malformed next-hop %q: %q is not a valid IP address before '@interface'", raw, ipPart)
+		}
+		if !plausibleInterfaceName(ifPart) {
+			return fmt.Errorf("malformed next-hop %q: %q is not a valid interface name after '@'", raw, ifPart)
+		}
+		return nil
+	}
+	if net.ParseIP(tok) != nil {
+		return nil
+	}
+	if plausibleInterfaceName(tok) {
+		return nil
+	}
+	return fmt.Errorf("not a valid next-hop (got %q; expected an IP address, ip@interface, or an interface name)", raw)
+}
+
+// plausibleInterfaceName reports whether s is syntactically usable as a
+// next-hop interface name: the [A-Za-z0-9._-] charset that xpf/vSRX and
+// kernel interface names use, with at least one ASCII letter so a
+// numeric-only dotted token (a botched IPv4 like 1.2.3.999) cannot pass as
+// an interface name. ':' is excluded so a malformed IPv6 literal is not
+// mistaken for an interface name.
+func plausibleInterfaceName(s string) bool {
+	if s == "" {
+		return false
+	}
+	hasLetter := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+			hasLetter = true
+		case r >= '0' && r <= '9', r == '.', r == '-', r == '_':
+			// allowed non-letter
+		default:
+			return false
+		}
+	}
+	return hasLetter
+}
+
 // validateForwardingClassRef is the #1319 PR 3 tree-based
 // cross-reference validator for `firewall family inet/inet6 filter
 // <f> term <t> then forwarding-class <name>`. The dataplane resolves


### PR DESCRIPTION
Closes #2448

## Summary
- A static-route `destination` prefix and `next-hop` value were accepted untyped at commit and then **silently dropped** downstream: the Rust FIB builder (`userspace-dp forwarding_build/fib.rs populate_routes`) soft-skips a destination that parses as neither IPv4 nor IPv6 (no error/counter/log), and the next-hop resolver falls back to `(0,0)` for an unparseable spec — an `ip@iface` with a bad IP becomes interface-only, a bare unparseable value installs ifindex 0 (a blackhole). The FRR renderer emits whatever string it is given. The route committed cleanly but never installed.
- Type the two leaves at the #1319 commit-time schema gate, mirroring #2497 (RA leaves) and #2416 (NAT). New `staticRouteNode()` SSOT shared by the `routing-options`, per-`rib`, and `routing-instances` static blocks.

## What is rejected
- **destination** (`ValidateRouteDestination`, keyValidator, `ValueCIDR`): a bare IP without `/prefix-length`, an out-of-range mask (`/99`), outright garbage. Family-agnostic (v4 or v6).
- **next-hop** (`ValidateStaticNextHop`, validator, `ValueIPAddress`): a botched IP literal (`1.2.3.999`, `2001:db8::garbage`), an `ip@iface` whose IP part does not parse (the silent-degrade footgun), and any value that is neither a valid IP nor a plausible interface name (`[A-Za-z0-9._-]`, ≥1 ASCII letter).

## What is still accepted (no over-rejection)
- Default routes `0.0.0.0/0` and `::/0`, all valid v4/v6 prefixes.
- next-hop as a bare IP, a bare interface name (`ge-0-0-0.0`, `reth0.50`, `eth1`), or the Rust-FIB `ip@interface`/`@interface` spec (Junos lexer rejects `@`, so this form is programmatic-only; validated by a unit test).
- `discard` / `reject` / `next-table` (no-next-hop) and `qualified-next-hop <link-local-v6> interface <if>` routes — declared children of the `route` node.

## Test plan
- [x] `pkg/config/schema_validate_route_2448_test.go` — hierarchical + flat-set (`ParseSetCommand`+`SetPath`), routing-instances + per-rib mirrors, default/v6/discard/qualified accepted forms.
- [x] **Fail-on-revert proven RED**: stripping the two validators from `staticRouteNode()` makes all 9 RejectsBad cases silently accept (`got nil`); restored, all pass.
- [x] `go build ./...`, `gofmt -l` clean, `go vet ./pkg/config/...` clean.
- [x] `go test ./pkg/config/... ./pkg/cmdtree/... ./pkg/frr/... ./pkg/configstore/...` all green.

## Docs
- `docs/config-schema.md` #2448 subsection; `_Log.md`.

## Refs
- #2497 (RA leaf typing), #2416 (NAT validation) — same commit-time-gate class.
- Distinct from #2388/#2389/#2390 (ordering/scoping of VALID routes); this is acceptance of INVALID route elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi