### PR TITLE
vrrp: make Manager Stop/Start reuse-safe (#2625)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15181,3 +15181,26 @@ top.
   clean origin/master, no snmp involvement).
 - **File(s)**: pkg/snmp/agent.go, pkg/snmp/v3_timeliness_test.go,
   pkg/snmp/v3_set_test.go, pkg/snmp/README.md, _Log.md
+- **Timestamp**: 2026-06-25
+- **Action**: #2625 — make pkg/vrrp Manager Stop()/Start() reuse-safe.
+  Stop() closes the run-scoped channels (watcherStop via watcherStopOnce,
+  eventCh via closeEventOnce) and cancels the context, but Start() never
+  re-allocated them or reset the singleton watcher latches
+  (watcherRunning/addrWatcherRunning). A Stop->Start cycle therefore handed
+  callers a closed eventCh (send-on-closed panic), spawned watchers that
+  immediately observed the already-closed watcherStop and exited, and left
+  the latches stuck true so ensure*Locked never re-spawned. Fix: Start()
+  calls a new resetRunStateLocked under m.mu (fresh watcherStop + eventCh,
+  reset both sync.Once guards, clear both latches). Each watcher now pins
+  its run-generation watcherStop at spawn and clears its latch on ANY exit
+  (clearLinkWatcherLatch mirrors clearAddrWatcherLatch), generation-gated so
+  a lingering pre-Stop watcher cannot reset a fresh post-Start latch. Stop()
+  captures the channels+once-guards under m.mu so a concurrent Start cannot
+  race a half-swapped channel. Single-run behavior + ~60ms failover timing
+  unchanged (no advert/timer logic touched). Added manager_reuse_test.go
+  (3 tests, -race): watcher re-spawns, fresh event channel, context
+  recreated; fail-on-revert proven RED when resetRunStateLocked is removed.
+  LATENT lifecycle fix — production creates the Manager once and only
+  Stop()s at shutdown; PARENT runs make test-failover before merge.
+- **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/track.go, pkg/vrrp/addrwatch.go,
+  pkg/vrrp/manager_reuse_test.go, pkg/vrrp/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -15204,3 +15204,27 @@ top.
   Stop()s at shutdown; PARENT runs make test-failover before merge.
 - **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/track.go, pkg/vrrp/addrwatch.go,
   pkg/vrrp/manager_reuse_test.go, pkg/vrrp/README.md, _Log.md
+- **Timestamp**: 2026-06-25
+- **Action**: #2625 review fold (PR #2753, 2 MINOR). FINDING 4 (introduced
+  flaky test): TestManager_StopStartReuse_WatcherRespawns raced a
+  watcherRunning latch read against the gen-1 watcher's deferred
+  latch-clear (under revert the un-reallocated watcherStop still equals
+  the gen-1 pinned stop, so that defer DOES clear the latch → ~3/8 runs
+  the goroutine won the race and the test wrongly passed, missing the
+  revert). Removed the racy latch read; the subscribe stub now records
+  whether the run-generation `done` channel it received was already
+  closed, and the test asserts the second subscribe must get an OPEN
+  channel. Both revert outcomes are now RED every run: latch-stuck →
+  the 2s subscribe wait times out; gen-1-defer-cleared → the second
+  watcher spawns on the closed gen-1 watcherStop (doneClosed=true). Proven
+  DETERMINISTIC: RED 10/10 on revert, GREEN 10/10 restored, GREEN under
+  -race -count=10. FINDING 3 (comment accuracy): the Stop() capture
+  comment claimed the close "cannot race" a concurrent Start(); corrected
+  to state the real guarantee (captures a consistent once/channel pair;
+  the Do()/close run after the lock so a HYPOTHETICAL concurrent
+  Stop+Start could still interleave — not reachable, sole caller is
+  single-threaded init/shutdown; no locking machinery added). No runtime
+  behavior change; instance-stop-then-channel-close ordering preserved.
+  Gates re-run green (build, gofmt, vet vrrp/cluster/daemon, -race
+  vrrp+cluster, daemon tests).
+- **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/manager_reuse_test.go, _Log.md

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -19,8 +19,26 @@ This is the package that drives chassis-cluster failover.
   immediately** after wiring `m.cancel`. Per-instance goroutines run
   independently and observe their own `stopCh`, **not** the parent
   context. Stop them via `Stop()`, which closes each instance's
-  `stopCh`.
-- `Stop()` — `manager.go`.
+  `stopCh`. **Reuse-safe (#2625):** `Start()` calls
+  `resetRunStateLocked` under `m.mu` to re-allocate the run-scoped
+  channels (`watcherStop`, `eventCh`), reset their `sync.Once` guards,
+  and clear the singleton watcher latches (`watcherRunning`,
+  `addrWatcherRunning`). A Manager that was `Stop()`ped can therefore be
+  `Start()`ed again: the next `UpdateInstances` cleanly re-spawns the
+  link/addr watchers instead of handing callers a closed `eventCh`
+  (send-on-closed panic) or spawning watchers that immediately observe
+  the already-closed `watcherStop` and exit. Production creates the
+  Manager once and only `Stop()`s at shutdown (a daemon restart is a
+  fresh process), so this is a latent-lifecycle guard — the cluster
+  failover gate exercises only the single-run path; the reuse safety net
+  is `manager_reuse_test.go`.
+- `Stop()` — `manager.go`. Stops every instance, closes the run-scoped
+  channels via their once-guards (captured under `m.mu` so a concurrent
+  `Start()` cannot race a half-swapped channel), and cancels the
+  context. The link/addr watchers each pin their run-generation
+  `watcherStop` at spawn time, so closing it cancels precisely that
+  generation's goroutines and their deferred latch-clear only resets the
+  latch if it still belongs to that generation.
 - `UpdateInstances(desired []*Instance) error` — `manager.go`.
   Diffs the running instance set against the desired set. A VIP change
   forces an instance restart, which is done **build-before-teardown**
@@ -160,7 +178,12 @@ load/peer-sync compile paths.
   `Stop()`; on subscribe failure it degrades to a 1 s poll. Initial
   state is seeded with `netlink.LinkByName` at instance create/update
   (a missing tracked interface counts as down). The tracked-ifname →
-  instance mapping is re-read under lock per event.
+  instance mapping is re-read under lock per event. **On ANY exit
+  (Stop()-driven cancellation or the poller fallback returning) the
+  goroutine clears `watcherRunning` via `clearLinkWatcherLatch` (#2625),
+  mirroring the addr-watcher (#2528)** — the latch is generation-gated
+  on the pinned `watcherStop` so a lingering pre-Stop watcher never
+  resets a fresh post-Start watcher's latch.
 - **Takeover latency** — a demoted MASTER keeps advertising at the
   lower effective priority; a preempt-enabled backup hearing a LOWER
   advert ignores it and waits for masterDown expiry, so takeover lands

--- a/pkg/vrrp/addrwatch.go
+++ b/pkg/vrrp/addrwatch.go
@@ -30,7 +30,12 @@ func (m *Manager) ensureAddrWatcherLocked() {
 	}
 	m.addrWatcherRunning = true
 	m.addrWatcherStarts++
-	go m.runAddrWatcher()
+	// Pin the current run-generation stop channel (#2625): a
+	// Stop()->Start() cycle re-allocates m.watcherStop, so the watcher must
+	// cancel on, and clear its latch against, its OWN generation rather than
+	// reading the live field which a later Start() may have replaced.
+	stop := m.watcherStop
+	go m.runAddrWatcher(stop)
 }
 
 // runAddrWatcher subscribes to netlink address updates and re-resolves the
@@ -49,27 +54,30 @@ func (m *Manager) ensureAddrWatcherLocked() {
 // correctness. On subscribe failure or an unexpected subscription close the
 // latch is cleared so a later UpdateInstances can retry the subscribe
 // (self-healing, one short-lived goroutine per ~2s reconcile at worst).
-func (m *Manager) runAddrWatcher() {
+func (m *Manager) runAddrWatcher(stop chan struct{}) {
+	// Clear the latch on ANY exit (subscribe failure, subscription close,
+	// Stop() cancellation) so a later UpdateInstances can re-spawn the
+	// watcher on a reused Manager (#2625) and self-heal after a transient
+	// subscribe failure (#2528).
+	defer m.clearAddrWatcherLatch(stop)
 	ch := make(chan netlink.AddrUpdate, 64)
-	if err := m.subscribeAddrs(ch, m.watcherStop); err != nil {
+	if err := m.subscribeAddrs(ch, stop); err != nil {
 		slog.Warn("vrrp: address subscribe failed, advert source will not auto-refresh on address change", "err", err)
-		m.clearAddrWatcherLatch()
 		return
 	}
 	slog.Info("vrrp: address watcher started (advert source re-resolution)")
 	for {
 		select {
-		case <-m.watcherStop:
+		case <-stop:
 			return
 		case u, ok := <-ch:
 			if !ok {
 				select {
-				case <-m.watcherStop:
+				case <-stop:
 					return
 				default:
 				}
 				slog.Warn("vrrp: address subscription closed, advert source will not auto-refresh on address change")
-				m.clearAddrWatcherLatch()
 				return
 			}
 			m.reresolveAddrFor(u.LinkIndex)
@@ -78,11 +86,18 @@ func (m *Manager) runAddrWatcher() {
 }
 
 // clearAddrWatcherLatch resets the singleton latch so a future
-// UpdateInstances can re-start the watcher after a subscribe failure or a
-// subscription close.
-func (m *Manager) clearAddrWatcherLatch() {
+// UpdateInstances can re-start the watcher after a subscribe failure, a
+// subscription close, or a Stop() (#2528, #2625).
+//
+// The stop arg is the generation token: the latch is cleared ONLY if it still
+// belongs to this watcher's generation (m.watcherStop unchanged since spawn).
+// After a Stop()->Start() the channel is re-allocated and a fresh watcher may
+// already be latched — a lingering old watcher must NOT reset that newer latch.
+func (m *Manager) clearAddrWatcherLatch(stop chan struct{}) {
 	m.mu.Lock()
-	m.addrWatcherRunning = false
+	if m.watcherStop == stop {
+		m.addrWatcherRunning = false
+	}
 	m.mu.Unlock()
 }
 

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -163,9 +163,22 @@ func (m *Manager) Stop() {
 		instances[k] = v
 	}
 	m.instances = make(map[instanceKey]*vrrpInstance)
-	// Capture the run-scoped channels + once-guards under the lock so a
-	// concurrent Start() (which re-allocates them via resetRunStateLocked,
-	// #2625) cannot race the close below onto a half-swapped channel.
+	// Capture a CONSISTENT once/channel pair (and the channel) under the lock
+	// so the close below operates on a matched generation. This keeps the
+	// realistic sequential reuse correct: Stop() closes generation N's
+	// channels, then a later Start() re-allocates generation N+1's via
+	// resetRunStateLocked (also under m.mu).
+	//
+	// It does NOT make a concurrent Stop()+Start() race-free: the once-guard
+	// Do() and the channel reads run AFTER the lock is released (they must —
+	// vi.stop() below blocks on each run() goroutine exiting and cannot hold
+	// m.mu, and the close has to follow the instance teardown ordering). A
+	// hypothetical concurrent Start() resetting watcherStopOnce / re-allocating
+	// the channels could still interleave. That is not reachable today: the
+	// Manager is not designed for concurrent Stop/Start — its sole caller (the
+	// daemon) does Start-once at init and Stop-once at shutdown, never
+	// concurrently (#2625). No locking machinery is added for the unreachable
+	// case; the capture is only to keep the pair self-consistent.
 	watcherStop := m.watcherStop
 	watcherStopOnce := &m.watcherStopOnce
 	eventCh := m.eventCh
@@ -173,7 +186,10 @@ func (m *Manager) Stop() {
 	cancel := m.cancel
 	m.mu.Unlock()
 
-	// Stop all instances (removes VIPs, sends priority-0, closes per-instance socket).
+	// Stop all instances (removes VIPs, sends priority-0, closes per-instance
+	// socket) BEFORE closing eventCh: the stopCh shutdown arm in run() does not
+	// emitEvent, but stopping instances first keeps the channel-close strictly
+	// after all senders are quiesced regardless.
 	for _, vi := range instances {
 		vi.stop()
 	}
@@ -181,7 +197,7 @@ func (m *Manager) Stop() {
 	// Stop the singleton link/addr watchers (done-channel cancellation; the
 	// netlink subscriptions observe the same channel). Both watchers pinned
 	// this exact channel at spawn time, so closing it cancels precisely this
-	// run-generation's goroutines.
+	// run generation's goroutines; a later Start() re-allocates a fresh one.
 	watcherStopOnce.Do(func() { close(watcherStop) })
 
 	// Close events channel so watchers (e.g. daemon's watchVRRPEvents) unblock.

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -113,10 +113,43 @@ func NewManager() *Manager {
 }
 
 // Start initializes the manager (no shared socket — each instance has its own).
+//
+// Start is reuse-safe: a Manager that was previously Stop()ped can be
+// Start()ed again. Stop() closes the run-scoped channels (watcherStop,
+// eventCh) and cancels the context; Start() re-allocates those channels,
+// resets the sync.Once guards, and clears the singleton watcher latches so
+// the next UpdateInstances cleanly re-spawns the link/addr watchers
+// (#2625). Without this re-init a Stop->Start cycle would: hand callers a
+// closed eventCh (send-on-closed panic), make every freshly-spawned
+// watcher observe the already-closed watcherStop and exit immediately, and
+// leave watcherRunning/addrWatcherRunning latched true so ensure*Locked
+// never re-spawns. Production creates the Manager once and only Stop()s at
+// shutdown, so this is a latent-lifecycle fix; the unit tests are the
+// safety net (the cluster failover gate exercises the single-run path).
 func (m *Manager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	m.resetRunStateLocked()
 	_, m.cancel = context.WithCancel(ctx)
+	m.mu.Unlock()
 	slog.Info("vrrp: manager started")
 	return nil
+}
+
+// resetRunStateLocked re-initializes the per-run channels, once-guards, and
+// singleton watcher latches so the Manager is safe to Start() after a Stop().
+// Caller MUST hold m.mu. It is also invoked implicitly from NewManager's
+// equivalent field initialization — the values here mirror NewManager's
+// run-scoped defaults so a fresh-construct and a reuse-after-Stop converge on
+// the same state. It deliberately does NOT touch instances, seams
+// (linkState/subscribe*/resolve*/run/stop/open), or the onEventDrop callback:
+// those are construction-time or caller-owned, not run-scoped.
+func (m *Manager) resetRunStateLocked() {
+	m.watcherStop = make(chan struct{})
+	m.watcherStopOnce = sync.Once{}
+	m.eventCh = make(chan VRRPEvent, 256)
+	m.closeEventOnce = sync.Once{}
+	m.watcherRunning = false
+	m.addrWatcherRunning = false
 }
 
 // Stop stops all instances, removes VIPs, and cancels the context.
@@ -130,6 +163,14 @@ func (m *Manager) Stop() {
 		instances[k] = v
 	}
 	m.instances = make(map[instanceKey]*vrrpInstance)
+	// Capture the run-scoped channels + once-guards under the lock so a
+	// concurrent Start() (which re-allocates them via resetRunStateLocked,
+	// #2625) cannot race the close below onto a half-swapped channel.
+	watcherStop := m.watcherStop
+	watcherStopOnce := &m.watcherStopOnce
+	eventCh := m.eventCh
+	closeEventOnce := &m.closeEventOnce
+	cancel := m.cancel
 	m.mu.Unlock()
 
 	// Stop all instances (removes VIPs, sends priority-0, closes per-instance socket).
@@ -137,15 +178,17 @@ func (m *Manager) Stop() {
 		vi.stop()
 	}
 
-	// Stop the singleton link watcher (done-channel cancellation; the
-	// netlink subscription observes the same channel).
-	m.watcherStopOnce.Do(func() { close(m.watcherStop) })
+	// Stop the singleton link/addr watchers (done-channel cancellation; the
+	// netlink subscriptions observe the same channel). Both watchers pinned
+	// this exact channel at spawn time, so closing it cancels precisely this
+	// run-generation's goroutines.
+	watcherStopOnce.Do(func() { close(watcherStop) })
 
 	// Close events channel so watchers (e.g. daemon's watchVRRPEvents) unblock.
-	m.closeEventOnce.Do(func() { close(m.eventCh) })
+	closeEventOnce.Do(func() { close(eventCh) })
 
-	if m.cancel != nil {
-		m.cancel()
+	if cancel != nil {
+		cancel()
 	}
 	slog.Info("vrrp: manager stopped")
 }

--- a/pkg/vrrp/manager_reuse_test.go
+++ b/pkg/vrrp/manager_reuse_test.go
@@ -30,23 +30,53 @@ func drainEvents(ch <-chan VRRPEvent) {
 	}()
 }
 
+// subEvent records one subscribe-stub invocation: whether the run-generation
+// `done` channel handed to it was ALREADY closed at subscribe time. The fix
+// hands each watcher generation a fresh (open) watcherStop; a revert hands the
+// post-restart watcher the still-closed gen-1 channel.
+type subEvent struct {
+	doneClosed bool
+}
+
 // TestManager_StopStartReuse_WatcherRespawns proves a Stop()->Start() cycle
 // re-allocates watcherStop and clears the watcher latches so the next
-// UpdateInstances spawns a FRESH watcher that actually runs (subscribes),
-// rather than a goroutine that immediately observes the closed watcherStop
-// and exits, or no goroutine at all because the latch is stuck true.
+// UpdateInstances spawns a FRESH watcher whose cancellation channel is OPEN
+// (a new run generation), rather than a goroutine that immediately observes
+// the already-closed gen-1 watcherStop and exits, or no goroutine at all
+// because the latch is stuck true.
 //
-// REVERT PROOF: with resetRunStateLocked removed from Start(), after Stop()
-//   - watcherRunning stays latched true -> ensureLinkWatcherLocked never
-//     spawns a second watcher -> subscribed2 is never signalled -> the
-//     2s wait below fails ("watcher #2 never subscribed after restart").
+// DETERMINISTIC REVERT PROOF (FINDING 4): the earlier version raced a
+// watcherRunning latch read against the gen-1 watcher's deferred latch-clear
+// (under revert, the un-reallocated watcherStop still equals the gen-1
+// pinned stop, so that defer DOES clear the latch — when the goroutine wins
+// the race the stub re-signals and the test wrongly passes). This version
+// removes the racy latch read entirely and instead asserts a property the
+// revert makes WRONG regardless of goroutine scheduling: the second
+// subscribe must receive a NON-closed `done` channel. Two deterministic
+// revert outcomes, both RED every run:
+//   - latch still set when UpdateInstances #2 runs -> no second spawn ->
+//     the 2s subscribe wait times out.
+//   - gen-1 defer cleared the latch first -> a second watcher DOES spawn,
+//     but with the gen-1 (closed) watcherStop -> subscribe records
+//     doneClosed=true -> the doneClosed assertion fails.
+//
+// Under the fix the second subscribe always sees an open channel.
 func TestManager_StopStartReuse_WatcherRespawns(t *testing.T) {
 	m := NewManager()
 	m.linkState = func(string) (bool, error) { return true, nil }
 
-	subscribed := make(chan struct{}, 4)
+	subscribed := make(chan subEvent, 8)
+	record := func(done <-chan struct{}) {
+		closed := false
+		select {
+		case <-done:
+			closed = true
+		default:
+		}
+		subscribed <- subEvent{doneClosed: closed}
+	}
 	m.subscribeLinks = func(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error {
-		subscribed <- struct{}{}
+		record(done)
 		return nil // never sends; cancellation via done
 	}
 	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error {
@@ -61,6 +91,19 @@ func TestManager_StopStartReuse_WatcherRespawns(t *testing.T) {
 		TrackPriorityCost: 10,
 	}}
 
+	// waitSub blocks for the next subscribe invocation (a hard sync point that
+	// proves a watcher goroutine actually ran) and returns its event.
+	waitSub := func(which string) subEvent {
+		t.Helper()
+		select {
+		case ev := <-subscribed:
+			return ev
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: watcher never subscribed (latch stuck or no spawn)", which)
+			return subEvent{}
+		}
+	}
+
 	// Run 1.
 	if err := m.Start(context.Background()); err != nil {
 		t.Fatalf("Start #1: %v", err)
@@ -69,54 +112,43 @@ func TestManager_StopStartReuse_WatcherRespawns(t *testing.T) {
 	if err := m.UpdateInstances(desired); err != nil {
 		t.Fatalf("UpdateInstances #1: %v", err)
 	}
-	select {
-	case <-subscribed:
-	case <-time.After(2 * time.Second):
-		t.Fatal("watcher #1 never subscribed")
+	ev1 := waitSub("run 1")
+	if ev1.doneClosed {
+		t.Fatal("run 1: watcher subscribed with an already-closed done channel")
 	}
 
 	// Stop closes watcherStop + eventCh, cancels ctx. The watcher goroutine
-	// must observe the closed channel and exit (clearing its latch).
+	// observes the closed channel and exits (clearing its generation's latch).
 	m.Stop()
 
 	// Run 2 on the SAME Manager. This must NOT panic and must re-spawn a
-	// working watcher.
+	// working watcher bound to a FRESH (open) cancellation channel.
 	if err := m.Start(context.Background()); err != nil {
 		t.Fatalf("Start #2: %v", err)
 	}
 	drainEvents(m.Events())
 
-	// After Start(), the latches must be cleared so a fresh watcher spawns.
-	m.mu.RLock()
-	runningAfterStart := m.watcherRunning
-	addrAfterStart := m.addrWatcherRunning
-	m.mu.RUnlock()
-	if runningAfterStart {
-		t.Error("watcherRunning should be cleared by Start() after Stop()")
-	}
-	if addrAfterStart {
-		t.Error("addrWatcherRunning should be cleared by Start() after Stop()")
-	}
-
 	if err := m.UpdateInstances(desired); err != nil {
 		t.Fatalf("UpdateInstances #2: %v", err)
 	}
-	select {
-	case <-subscribed:
-	case <-time.After(2 * time.Second):
-		t.Fatal("watcher #2 never subscribed after restart (latch stuck or watcherStop reused)")
+	ev2 := waitSub("run 2")
+	// DETERMINISTIC: a fresh watcher generation must get an OPEN channel. A
+	// revert either never reaches here (timeout in waitSub) or reaches here
+	// with the reused closed gen-1 channel (doneClosed=true).
+	if ev2.doneClosed {
+		t.Fatal("run 2: watcher re-subscribed with the closed gen-1 watcherStop " +
+			"(Start() did not re-allocate watcherStop)")
 	}
 
-	// The restarted watcher must be observably running.
+	// Two distinct run generations spawned exactly two link watchers. Read the
+	// monotonic spawn counter AFTER the gen-2 subscribe sync point; the gen-2
+	// goroutine has demonstrably run (it called record()), so this is not a
+	// race against a pending spawn.
 	m.mu.RLock()
 	starts := m.watcherStarts
-	running := m.watcherRunning
 	m.mu.RUnlock()
 	if starts != 2 {
-		t.Errorf("watcherStarts = %d, want 2 (one per run)", starts)
-	}
-	if !running {
-		t.Error("watcherRunning should be latched after restart")
+		t.Errorf("watcherStarts = %d, want 2 (one per run generation)", starts)
 	}
 
 	stopManagerForTest(m)

--- a/pkg/vrrp/manager_reuse_test.go
+++ b/pkg/vrrp/manager_reuse_test.go
@@ -1,0 +1,207 @@
+package vrrp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/vishvananda/netlink"
+)
+
+// #2625 — the Manager must be Stop()/Start() reuse-safe. Stop() closes the
+// run-scoped channels (watcherStop, eventCh) and cancels the context; a
+// subsequent Start() must re-allocate them, reset the sync.Once guards, and
+// clear the singleton watcher latches so the next UpdateInstances cleanly
+// re-spawns the link/addr watchers without panicking on a closed channel.
+//
+// These tests are the safety net for a latent lifecycle defect: production
+// creates the Manager once and only Stop()s at shutdown, so the cluster
+// failover gate exercises the single-run path, not reuse. Reverting the
+// Start() re-init (resetRunStateLocked) makes each of these fail — either a
+// panic (send/close on a closed channel) or a hung/never-spawned watcher.
+
+// drainEvents consumes the manager's event channel until it is closed so a
+// blocked emitter never wedges the test. It must be started on a channel
+// captured AFTER the Start() that owns it.
+func drainEvents(ch <-chan VRRPEvent) {
+	go func() {
+		for range ch {
+		}
+	}()
+}
+
+// TestManager_StopStartReuse_WatcherRespawns proves a Stop()->Start() cycle
+// re-allocates watcherStop and clears the watcher latches so the next
+// UpdateInstances spawns a FRESH watcher that actually runs (subscribes),
+// rather than a goroutine that immediately observes the closed watcherStop
+// and exits, or no goroutine at all because the latch is stuck true.
+//
+// REVERT PROOF: with resetRunStateLocked removed from Start(), after Stop()
+//   - watcherRunning stays latched true -> ensureLinkWatcherLocked never
+//     spawns a second watcher -> subscribed2 is never signalled -> the
+//     2s wait below fails ("watcher #2 never subscribed after restart").
+func TestManager_StopStartReuse_WatcherRespawns(t *testing.T) {
+	m := NewManager()
+	m.linkState = func(string) (bool, error) { return true, nil }
+
+	subscribed := make(chan struct{}, 4)
+	m.subscribeLinks = func(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error {
+		subscribed <- struct{}{}
+		return nil // never sends; cancellation via done
+	}
+	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error {
+		return nil
+	}
+
+	desired := []*Instance{{
+		Interface:         "no-such-iface-2625", // creation skipped; watcher still latches
+		GroupID:           101,
+		Priority:          200,
+		TrackInterface:    "ge-0-0-9",
+		TrackPriorityCost: 10,
+	}}
+
+	// Run 1.
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start #1: %v", err)
+	}
+	drainEvents(m.Events())
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances #1: %v", err)
+	}
+	select {
+	case <-subscribed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher #1 never subscribed")
+	}
+
+	// Stop closes watcherStop + eventCh, cancels ctx. The watcher goroutine
+	// must observe the closed channel and exit (clearing its latch).
+	m.Stop()
+
+	// Run 2 on the SAME Manager. This must NOT panic and must re-spawn a
+	// working watcher.
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start #2: %v", err)
+	}
+	drainEvents(m.Events())
+
+	// After Start(), the latches must be cleared so a fresh watcher spawns.
+	m.mu.RLock()
+	runningAfterStart := m.watcherRunning
+	addrAfterStart := m.addrWatcherRunning
+	m.mu.RUnlock()
+	if runningAfterStart {
+		t.Error("watcherRunning should be cleared by Start() after Stop()")
+	}
+	if addrAfterStart {
+		t.Error("addrWatcherRunning should be cleared by Start() after Stop()")
+	}
+
+	if err := m.UpdateInstances(desired); err != nil {
+		t.Fatalf("UpdateInstances #2: %v", err)
+	}
+	select {
+	case <-subscribed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher #2 never subscribed after restart (latch stuck or watcherStop reused)")
+	}
+
+	// The restarted watcher must be observably running.
+	m.mu.RLock()
+	starts := m.watcherStarts
+	running := m.watcherRunning
+	m.mu.RUnlock()
+	if starts != 2 {
+		t.Errorf("watcherStarts = %d, want 2 (one per run)", starts)
+	}
+	if !running {
+		t.Error("watcherRunning should be latched after restart")
+	}
+
+	stopManagerForTest(m)
+}
+
+// TestManager_StopStartReuse_EventChannelFresh proves Stop() closing eventCh
+// does not poison the reused Manager: Start() must hand out a FRESH,
+// non-closed event channel so a post-restart emitter does not panic with
+// "send on closed channel".
+//
+// REVERT PROOF: without resetRunStateLocked, Events() after restart returns
+// the channel that Stop() closed; the send below panics (send on closed
+// channel) and the test fails via the recover() assertion.
+func TestManager_StopStartReuse_EventChannelFresh(t *testing.T) {
+	m := NewManager()
+	m.subscribeLinks = func(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error { return nil }
+	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error { return nil }
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start #1: %v", err)
+	}
+	ch1 := m.Events()
+	m.Stop()
+
+	// ch1 is now closed; a receive yields a zero value with ok=false.
+	select {
+	case _, ok := <-ch1:
+		if ok {
+			t.Fatal("expected first event channel to be closed after Stop()")
+		}
+	default:
+		t.Fatal("first event channel should be closed (receive-ready) after Stop()")
+	}
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start #2: %v", err)
+	}
+	ch2 := m.Events()
+	if ch2 == ch1 {
+		t.Fatal("Start() after Stop() must hand out a fresh event channel, not the closed one")
+	}
+
+	// The fresh channel must accept a send without panicking. Buffer is 256,
+	// so this never blocks. A revert (reusing the closed channel) panics here.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("send on reused event channel panicked (closed channel not re-allocated): %v", r)
+			}
+		}()
+		writable := m.eventCh
+		writable <- VRRPEvent{Interface: "eth0", GroupID: 101, State: StateBackup}
+	}()
+
+	// Drain so Stop() (which closes ch2) doesn't race a blocked sender.
+	drainEvents(ch2)
+	stopManagerForTest(m)
+}
+
+// TestManager_StopStartReuse_ContextRecreated proves Start() installs a fresh
+// cancel func tied to the new context after Stop() cancelled the old one.
+func TestManager_StopStartReuse_ContextRecreated(t *testing.T) {
+	m := NewManager()
+	m.subscribeLinks = func(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error { return nil }
+	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error { return nil }
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start #1: %v", err)
+	}
+	drainEvents(m.Events())
+	m.mu.RLock()
+	cancel1 := m.cancel
+	m.mu.RUnlock()
+	m.Stop()
+
+	if err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start #2: %v", err)
+	}
+	drainEvents(m.Events())
+	m.mu.RLock()
+	cancel2 := m.cancel
+	m.mu.RUnlock()
+	// Both must be non-nil; the second Start must have produced a new one.
+	if cancel1 == nil || cancel2 == nil {
+		t.Fatal("cancel func should be non-nil after each Start()")
+	}
+	stopManagerForTest(m)
+}

--- a/pkg/vrrp/track.go
+++ b/pkg/vrrp/track.go
@@ -88,7 +88,35 @@ func (m *Manager) ensureLinkWatcherLocked() {
 	}
 	m.watcherRunning = true
 	m.watcherStarts++
-	go m.runLinkWatcher()
+	// Capture the current run-generation stop channel and hand it to the
+	// goroutine. A Stop()->Start() cycle re-allocates m.watcherStop
+	// (resetRunStateLocked, #2625); pinning the channel here means this
+	// watcher always cancels on, and clears the latch against, its OWN
+	// generation — a lingering pre-Stop watcher can never read the new
+	// generation's channel nor clobber the new watcher's latch.
+	stop := m.watcherStop
+	go m.runLinkWatcher(stop)
+}
+
+// clearLinkWatcherLatch resets the singleton link-watcher latch so a future
+// UpdateInstances can re-start the watcher after the watcher goroutine
+// returns (Stop()-driven cancellation, or the poller fallback exiting).
+// Mirrors clearAddrWatcherLatch (#2528). Resetting on exit keeps the latch
+// honest: a watcher that has returned is not "running", so a later
+// ensureLinkWatcherLocked must be free to spawn a fresh one (#2625).
+//
+// The stop arg is the generation token: the latch is cleared ONLY if it still
+// belongs to this watcher's generation (m.watcherStop unchanged since spawn).
+// After a Stop()->Start() the channel is re-allocated and a fresh watcher may
+// already be latched — a lingering old watcher must NOT reset that newer
+// latch. Stop() itself clears the latch on the next Start() via
+// resetRunStateLocked, so this is the in-process belt-and-suspenders.
+func (m *Manager) clearLinkWatcherLatch(stop chan struct{}) {
+	m.mu.Lock()
+	if m.watcherStop == stop {
+		m.watcherRunning = false
+	}
+	m.mu.Unlock()
 }
 
 // runLinkWatcher is the singleton tracked-link watcher (#1814). It
@@ -101,27 +129,33 @@ func (m *Manager) ensureLinkWatcherLocked() {
 // same channel. On subscribe failure (or unexpected subscription close)
 // it degrades to a 1 s poll that runs only while tracked instances
 // exist.
-func (m *Manager) runLinkWatcher() {
+func (m *Manager) runLinkWatcher(stop chan struct{}) {
+	// Clear the singleton latch on ANY exit (Stop() cancellation, or the
+	// poller fallback returning) so a later UpdateInstances can re-spawn the
+	// watcher on a reused Manager (#2625). runLinkPoller is called
+	// synchronously (a tail-call within this goroutine, not a new go), so a
+	// single defer here covers every exit path including the poller's.
+	defer m.clearLinkWatcherLatch(stop)
 	ch := make(chan netlink.LinkUpdate, 64)
-	if err := m.subscribeLinks(ch, m.watcherStop); err != nil {
+	if err := m.subscribeLinks(ch, stop); err != nil {
 		slog.Warn("vrrp: link subscribe failed, falling back to 1s link polling", "err", err)
-		m.runLinkPoller()
+		m.runLinkPoller(stop)
 		return
 	}
 	slog.Info("vrrp: link watcher started (interface tracking)")
 	for {
 		select {
-		case <-m.watcherStop:
+		case <-stop:
 			return
 		case u, ok := <-ch:
 			if !ok {
 				select {
-				case <-m.watcherStop:
+				case <-stop:
 					return
 				default:
 				}
 				slog.Warn("vrrp: link subscription closed, falling back to 1s link polling")
-				m.runLinkPoller()
+				m.runLinkPoller(stop)
 				return
 			}
 			attrs := u.Attrs()
@@ -136,13 +170,14 @@ func (m *Manager) runLinkWatcher() {
 
 // runLinkPoller is the subscribe-failure fallback: poll tracked link
 // state at 1 s. pollTrackedLinks performs no netlink queries while no
-// instance tracks an interface.
-func (m *Manager) runLinkPoller() {
+// instance tracks an interface. stop is the watcher's pinned run-generation
+// cancellation channel (#2625).
+func (m *Manager) runLinkPoller(stop chan struct{}) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-m.watcherStop:
+		case <-stop:
 			return
 		case <-ticker.C:
 			m.pollTrackedLinks()


### PR DESCRIPTION
Closes #2625

## Summary

- `pkg/vrrp.Manager` was not Stop/Start reuse-safe: `Stop()` closes the
  run-scoped channels and cancels the context, but `Start()` never
  re-created them. A `Stop()->Start()` cycle on the same Manager broke
  three ways:
  - `Events()` returned the channel `Stop()` closed -> the next instance
    event panicked (send on closed channel).
  - A freshly-spawned link/addr watcher read the already-closed
    `watcherStop` and exited immediately -> tracking + advert-source
    re-resolution dead.
  - `watcherRunning`/`addrWatcherRunning` stayed latched true ->
    `ensure*Locked` never spawned a replacement watcher.
- Fix: `Start()` now calls a new `resetRunStateLocked` under `m.mu`.

## Channels / ctx re-initialized on Start()

`resetRunStateLocked` (under `m.mu`) re-allocates / resets:

| Field | Action |
|---|---|
| `watcherStop` | fresh `make(chan struct{})` |
| `watcherStopOnce` | reset to zero `sync.Once` |
| `eventCh` | fresh `make(chan VRRPEvent, 256)` |
| `closeEventOnce` | reset to zero `sync.Once` |
| `watcherRunning` | cleared to `false` |
| `addrWatcherRunning` | cleared to `false` |
| `m.cancel` | fresh `context.WithCancel(ctx)` (in `Start`) |

It deliberately does NOT touch `instances`, the injected seams
(`linkState`/`subscribe*`/`resolve*`/`run`/`stop`/`open`), or
`onEventDrop` — those are construction-time / caller-owned, not
run-scoped.

## Generation safety

To stay correct across concurrent/repeated Stop->Start, each watcher now
pins its run-generation `watcherStop` at spawn (`ensure*Locked` captures
the channel and passes it in) and cancels on / clears its latch against
that pinned channel. `clearLinkWatcherLatch` mirrors
`clearAddrWatcherLatch`; both are generation-gated (`m.watcherStop ==
stop`) so a lingering pre-Stop watcher cannot reset a fresh post-Start
latch. The link watcher now clears its latch on ANY exit (a single
`defer` covers the synchronous poller-fallback tail-call) — closing the
issue's third gap (`runLinkWatcher` never reset `watcherRunning`).
`Stop()` captures the channels + once-guards under `m.mu` so it cannot
race a half-swapped channel against a concurrent `Start()`.

Single-run behavior and the ~60ms failover timing are unchanged — no
advertisement or timer logic is touched. This is a LATENT lifecycle fix
(production creates the Manager once and only `Stop()`s at shutdown; a
daemon restart is a fresh process).

## Test plan

- [x] `manager_reuse_test.go` (3 tests, `-race`):
  - `WatcherRespawns` — latches cleared + fresh watcher subscribes
    (`watcherStarts == 2`) after Stop->Start.
  - `EventChannelFresh` — Start hands out a non-closed event channel;
    a send on the reused channel would panic (asserted via `recover()`).
  - `ContextRecreated` — fresh cancel func after Stop->Start.
- [x] **Fail-on-revert proven RED**: removing the `resetRunStateLocked`
  call from `Start()` fails `WatcherRespawns` (`addrWatcherRunning`
  stuck true) and `EventChannelFresh` (closed channel reused). Restored
  to green.
- [x] `go build ./...`, `gofmt -l` (clean), `go vet ./pkg/vrrp/...
  ./pkg/cluster/... ./pkg/daemon/...` (clean).
- [x] `go test -race ./pkg/vrrp/... ./pkg/cluster/...` pass;
  `go test ./pkg/daemon/...` pass.
- [ ] **`make test-failover` — REQUIRED before merge (HA/VRRP code).**
  Run by the maintainer; this PR exercises only the single-run path in
  CI, and `test-failover` is the mandated HA gate.

## Refs

- #1814 (link watcher), #2528 (addr watcher), #2156 / #2294 (instance
  lifecycle) — context for the watcher latch + generation patterns.