### PR TITLE
ddns: fail closed on corrupt/unknown-version ownership state (#2650)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15181,3 +15181,23 @@ top.
   clean origin/master, no snmp involvement).
 - **File(s)**: pkg/snmp/agent.go, pkg/snmp/v3_timeliness_test.go,
   pkg/snmp/v3_set_test.go, pkg/snmp/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2650 — DDNS ownership state corrupt/unknown-version load now
+  FAILS CLOSED instead of silently resetting to an empty store. `loadDDNSState`
+  returns classified sentinels (`errDDNSStateCorrupt` /
+  `errDDNSStateUnsupportedVersion`); a new `loadStateOrDegrade` helper sets
+  `Manager.degraded`, quarantines the bad file aside
+  (`<path>.corrupt-<UTC-stamp>`, never overwritten by a later save), and
+  `ReconcileScoped` refuses the whole pass (no publish, no withdraw, counted as
+  a reconcile failure) while degraded. The old behavior leaked previously-owned
+  records forever (cleanup authority lost) and could re-claim a peer-owned name.
+  Alarm surfaced in `show ... dynamic-dns` (CLI + gRPC) and the new
+  `xpf_dhcp_ddns_degraded` Prometheus gauge. Added fail-on-revert tests
+  (corrupt + unknown-version → degraded, no ops, quarantined; reverting to
+  fail-open goes RED, proven). go build/vet/gofmt + ddns/dhcpserver/api/cli/
+  grpcapi/daemon tests green.
+- **File(s)**: pkg/ddns/state.go, pkg/ddns/manager.go, pkg/ddns/manager_test.go,
+  pkg/ddns/README.md, pkg/api/metrics.go, pkg/api/metrics_descriptors.go,
+  pkg/api/metrics_system.go, pkg/cli/cli_show_services.go,
+  pkg/grpcapi/server_show_dhcp_lldp_snmp.go, _Log.md

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -79,6 +79,7 @@ type xpfCollector struct {
 	dhcpDDNSSkippedTotal       *prometheus.Desc
 	dhcpDDNSOwnedRecords       *prometheus.Desc
 	dhcpDDNSPTRPending         *prometheus.Desc
+	dhcpDDNSDegraded           *prometheus.Desc
 	dhcpDDNSLastReconcileTs    *prometheus.Desc
 	dhcpDDNSLastReconcileN     *prometheus.Desc
 
@@ -484,6 +485,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.dhcpDDNSSkippedTotal
 	ch <- c.dhcpDDNSOwnedRecords
 	ch <- c.dhcpDDNSPTRPending
+	ch <- c.dhcpDDNSDegraded
 	ch <- c.dhcpDDNSLastReconcileTs
 	ch <- c.dhcpDDNSLastReconcileN
 	ch <- c.surfaceADDNSUpsertsTotal

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -242,6 +242,14 @@ func newCollector(srv *Server) *xpfCollector {
 				"(distinct from the cumulative ptr-deferred counter; #2708).",
 			nil, nil,
 		),
+		dhcpDDNSDegraded: prometheus.NewDesc(
+			"xpf_dhcp_ddns_degraded",
+			"1 when the DHCP dynamic-DNS ownership state failed to load "+
+				"(corrupt / unsupported-version / unreadable) and the manager is "+
+				"FAILING CLOSED: publishing and withdrawals are suspended until the "+
+				"operator resolves the quarantined state file (#2650).",
+			nil, nil,
+		),
 		dhcpDDNSLastReconcileTs: prometheus.NewDesc(
 			"xpf_dhcp_ddns_last_reconcile_timestamp_seconds",
 			"Unix timestamp of the last DHCP dynamic-DNS reconcile pass.",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -69,6 +69,11 @@ func (c *xpfCollector) collectDDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.OwnedRecords))
 	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSPTRPending, prometheus.GaugeValue,
 		float64(st.PTRPendingNow))
+	var degraded float64
+	if st.Degraded {
+		degraded = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.dhcpDDNSDegraded, prometheus.GaugeValue, degraded)
 	var lastTs float64
 	if !st.LastReconcile.IsZero() {
 		lastTs = float64(st.LastReconcile.Unix())

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -571,6 +571,10 @@ func (c *CLI) showDHCPDynamicDNS(detail bool) error {
 		fmt.Println("\n  Runtime counters: unavailable (manager not running)")
 		return nil
 	}
+	if st.Degraded {
+		fmt.Printf("\n  ALARM: DDNS DEGRADED (fail-closed) — %s\n", st.DegradedReason)
+		fmt.Println("    Publishing and withdrawals are SUSPENDED until the ownership state is resolved.")
+	}
 	fmt.Println("\n  Counters:")
 	fmt.Printf("    Upserts:    ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
 	fmt.Printf("    Deletes:    ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -16,7 +16,7 @@ moved with its assertions intact.
 | File | Contents |
 |------|----------|
 | `manager.go` | `Manager` (the DDNS reconcile engine — moved from `dhcpserver/ddns.go`): `policyFromConfig`, `Reconcile`, `reconcileOnceLocked`, `upsertLocked`/`deleteOwnedLocked`, `withdrawAllLocked`, `ownerWatermark`, `dhcidSharedWithOther` (#2700 shared-DHCID guard), `Stats` (incl. `PTRPendingNow`, #2708), `OwnedRecordView(s)`, the `errDDNSNoBackendToWithdraw` keep-ownership sentinel (#2699), the write-ahead durability + never-delete-non-owned boundary. Also the `Lease` record + `LeaseParser` seam. |
-| `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. |
+| `state.go` | Ownership state store (`ownedRecord`, `ddnsState`, `loadDDNSState`, durable `save` via `fsatomic.WriteFileDurable`) — moved from `dhcpserver/ddns_state.go`. Also the fail-closed load classifiers `errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion` + `quarantineBadState` (#2650). |
 | `backend.go` | `DNSUpdater` interface, `LeaseDNSRecord`, `nopUpdater`, the record + reverse-PTR-name helpers — moved from `dhcpserver/ddns_dns.go`. |
 | `backend_rfc2136.go` | The LIVE RFC 2136 backend (`rfc2136Updater`): exact-RR adds/deletes, TSIG, RFC 4701 DHCID + RFC 4703 replace-owned two-attempt, the `errDDNSConflictRefused` / `errDDNSPTRPending` sentinels — moved from `dhcpserver/ddns_rfc2136.go`. `sendRemoveForward(..., keepDHCID)` keeps a shared DHCID on a partial dual-stack teardown (#2700); `dnsCanonicalFQDN` mirrors the DHCID FQDN canonicalization. |
 | `hostname.go` | Deterministic hostname → DNS-label normalization (pure) — moved from `dhcpserver/ddns_hostname.go`. |
@@ -130,6 +130,20 @@ no change in those packages:
   sent, so the delete stays ownership-guarded). The DHCID is removed only with
   the LAST family's record, so a fully-released name leaves no orphan DHCID and
   a survivor is never left unprotected (no hijack window, no wire leak).
+- **Unloadable ownership state fails CLOSED (#2650)** — a corrupt, unknown-
+  future-version, or unreadable state file is NOT silently reset to an empty
+  store. `loadDDNSState` returns the empty store plus a CLASSIFIED error
+  (`errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion`); `loadStateOrDegrade`
+  sets `Manager.degraded`, QUARANTINES a corrupt/unsupported file aside
+  (`<path>.corrupt-<UTC-stamp>` — preserved, never overwritten by a later
+  `save()`), and `ReconcileScoped` then refuses the WHOLE pass (no publish, no
+  withdraw, counted as a reconcile failure) until the operator resolves it. Fail
+  OPEN would forget every owned record (permanent stale-record leak — the cleanup
+  half of the feature is lost) AND let a later publish re-claim a name a PEER
+  owns, since the lost DHCID/ownership state can no longer veto it. The degraded
+  state is surfaced as a `show ... dynamic-dns` ALARM and the
+  `xpf_dhcp_ddns_degraded` Prometheus gauge so the lost cleanup authority is
+  never silent.
 - **No secret in any error string** (TSIG secret revealed only at construction).
 
 The HA writer gate (`ddnsWriterGateOpen`) stays in `pkg/daemon/daemon_ddns.go`

--- a/pkg/ddns/manager.go
+++ b/pkg/ddns/manager.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -214,6 +215,18 @@ type Stats struct {
 	OwnedRecords   int
 	LastReconcile  time.Time
 	LastReconcileN int // active leases seen on the last reconcile
+	// Degraded is the FAIL-CLOSED alarm (#2650): the ownership state file could
+	// not be loaded (corrupt JSON, an unsupported/future version, or an
+	// unreadable file), so the manager cannot prove what records it owns. While
+	// degraded the reconciler refuses BOTH to publish (it could overwrite a
+	// peer-owned record) AND to withdraw/delete (it has lost the ownership it
+	// would withdraw against). The operator must resolve the state file before
+	// DDNS resumes. Surfaced in `show ... dynamic-dns` and Prometheus so the lost
+	// cleanup authority is never silent.
+	Degraded bool
+	// DegradedReason is a human-readable explanation of Degraded (the load error
+	// plus the quarantine path of the bad file, if any). Empty when not degraded.
+	DegradedReason string
 }
 
 // Manager owns the DDNS reconcile loop and the ownership store. It is
@@ -223,6 +236,18 @@ type Manager struct {
 	mu      sync.Mutex
 	state   *ddnsState
 	updater DNSUpdater
+
+	// degraded fails the manager CLOSED when the ownership state file could not
+	// be loaded (#2650): corrupt JSON, an unsupported/future version, or an
+	// unreadable file. The loaded `state` is empty in this case, but it must NOT
+	// be acted upon — an empty store would forget every owned record (permanent
+	// stale-record leak) and let a publish re-claim a peer-owned name. While
+	// degraded, ReconcileScoped is a no-op-with-error: no publish, no withdraw,
+	// no save() (which would overwrite the on-disk file). Cleared only by a
+	// successful reload (operator resolves/removes the bad file and restarts, or
+	// the quarantine leaves a clean slate for a genuine first run). Guarded by mu.
+	degraded       bool
+	degradedReason string
 
 	// newUpdater resolves the live DNS-update backend from the policy +
 	// config resolved at the start of each Reconcile (plan §6 fork 1:
@@ -282,17 +307,55 @@ type Manager struct {
 	lastPolicy atomic.Pointer[ddnsPolicy]
 }
 
+// loadStateOrDegrade loads the ownership store and classifies a load failure
+// into the fail-closed degraded posture (#2650). It always returns a usable
+// (possibly empty) store so the manager is constructible — the daemon must still
+// start — but on a corrupt / unsupported-version / unreadable store it returns
+// degraded=true plus a reason, and the manager refuses every reconcile op until
+// the operator resolves the file. A corrupt / unsupported-version file is
+// QUARANTINED (renamed aside, timestamped) so the bad bytes are preserved for
+// inspection and a later save() cannot clobber the only forensic copy. An
+// unreadable file (permission / IO) is NOT quarantined — the bytes may be fine
+// and re-readable, so it would be wrong to move the file under a transient fault.
+func loadStateOrDegrade(path string, now func() time.Time) (st *ddnsState, degraded bool, reason string) {
+	st, err := loadDDNSState(path)
+	if err == nil {
+		return st, false, ""
+	}
+	classified := errors.Is(err, errDDNSStateCorrupt) || errors.Is(err, errDDNSStateUnsupportedVersion)
+	reason = err.Error()
+	if classified {
+		nowFn := now
+		if nowFn == nil {
+			nowFn = time.Now
+		}
+		if qp, qerr := quarantineBadState(path, nowFn()); qerr != nil {
+			slog.Error("ddns: FAILING CLOSED on unloadable ownership state; quarantine of the bad file also failed",
+				"err", err, "quarantine_err", qerr)
+			reason += " (quarantine failed: " + qerr.Error() + ")"
+		} else {
+			slog.Error("ddns: FAILING CLOSED on unloadable ownership state; bad file quarantined; "+
+				"publishing and withdrawals are SUSPENDED until the operator resolves it",
+				"err", err, "quarantine", qp)
+			reason += " (quarantined to " + qp + ")"
+		}
+	} else {
+		slog.Error("ddns: FAILING CLOSED on unreadable ownership state; publishing and withdrawals "+
+			"are SUSPENDED until the file is readable", "err", err)
+	}
+	return st, true, reason
+}
+
 // NewManager constructs a DDNS manager with the given lease parser, updater
 // backend, and node id. The ownership store is loaded from
-// defaultDDNSStatePath; a corrupt store is reset to empty (fail-open) and the
-// error logged. The parser is the LeaseParser seam (the Kea-memfile parser
-// lives in pkg/dhcpserver — #2691 P1a); a nil parser means the manager reads
-// no leases (every family trusted-empty).
+// defaultDDNSStatePath. A corrupt / unsupported-version / unreadable store puts
+// the manager into the FAIL-CLOSED degraded state (#2650): it is constructible
+// (the daemon still starts) but refuses to publish or withdraw any record until
+// the operator resolves the bad file (quarantined aside). The parser is the
+// LeaseParser seam (the Kea-memfile parser lives in pkg/dhcpserver — #2691 P1a);
+// a nil parser means the manager reads no leases (every family trusted-empty).
 func NewManager(parser LeaseParser, updater DNSUpdater, nodeID string) *Manager {
-	st, err := loadDDNSState(defaultDDNSStatePath)
-	if err != nil {
-		slog.Warn("ddns: ownership state load failed; starting empty", "err", err)
-	}
+	st, degraded, reason := loadStateOrDegrade(defaultDDNSStatePath, time.Now)
 	if updater == nil {
 		// Increment 1 defers the live backend: a nil updater becomes a
 		// logged no-op rather than a nil-pointer panic on first publish or
@@ -302,13 +365,15 @@ func NewManager(parser LeaseParser, updater DNSUpdater, nodeID string) *Manager 
 		updater = nopUpdater{}
 	}
 	return &Manager{
-		state:       st,
-		updater:     updater,
-		nodeID:      nodeID,
-		leaseParser: parser,
-		leasePath4:  "/var/lib/kea/kea-leases4.csv",
-		leasePath6:  "/var/lib/kea/kea-leases6.csv",
-		now:         time.Now,
+		state:          st,
+		degraded:       degraded,
+		degradedReason: reason,
+		updater:        updater,
+		nodeID:         nodeID,
+		leaseParser:    parser,
+		leasePath4:     "/var/lib/kea/kea-leases4.csv",
+		leasePath6:     "/var/lib/kea/kea-leases6.csv",
+		now:            time.Now,
 	}
 }
 
@@ -344,18 +409,20 @@ func NewProductionManager(parser LeaseParser, nodeID string) *Manager {
 // at statePath and injectable lease parser / paths / clock. Exported to other
 // packages' tests via pkg/dhcpserver's test seam.
 func newManagerForTesting(parser LeaseParser, updater DNSUpdater, statePath, leasePath4, leasePath6, nodeID string, now func() time.Time) *Manager {
-	st, _ := loadDDNSState(statePath)
+	st, degraded, reason := loadStateOrDegrade(statePath, now)
 	if updater == nil {
 		updater = nopUpdater{}
 	}
 	return &Manager{
-		state:       st,
-		updater:     updater,
-		nodeID:      nodeID,
-		leaseParser: parser,
-		leasePath4:  leasePath4,
-		leasePath6:  leasePath6,
-		now:         now,
+		state:          st,
+		degraded:       degraded,
+		degradedReason: reason,
+		updater:        updater,
+		nodeID:         nodeID,
+		leaseParser:    parser,
+		leasePath4:     leasePath4,
+		leasePath6:     leasePath6,
+		now:            now,
 	}
 }
 
@@ -516,6 +583,19 @@ func (m *Manager) ReconcileScoped(ctx context.Context, cfg *config.DHCPServerCon
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// FAIL CLOSED (#2650): the ownership state could not be loaded, so we cannot
+	// prove what records this firewall owns. Doing ANYTHING here is unsafe — a
+	// publish could overwrite a peer-owned name (lost DHCID veto) and a withdraw
+	// has no trustworthy owned set to delete against. Refuse the whole pass
+	// (counted as a reconcile failure for visibility) and DO NOT touch the state
+	// file. The empty in-memory store is never acted upon, so no save() runs and
+	// the quarantined bad file is preserved.
+	if m.degraded {
+		err := fmt.Errorf("ddns: reconcile suspended (state degraded): %s", m.degradedReason)
+		m.recordReconcilePass(err)
+		return err
+	}
 
 	env := reconcileEnv{
 		pol:     [2]ddnsPolicy{pol4, pol6},
@@ -1208,9 +1288,13 @@ func (m *Manager) Stats() Stats {
 			pendingNow++
 		}
 	}
+	degraded := m.degraded
+	degradedReason := m.degradedReason
 	m.mu.Unlock()
 
 	st := Stats{
+		Degraded:          degraded,
+		DegradedReason:    degradedReason,
 		UpsertOK:          m.upsertOK.Load(),
 		UpsertFail:        m.upsertFail.Load(),
 		DeleteOK:          m.deleteOK.Load(),

--- a/pkg/ddns/manager_test.go
+++ b/pkg/ddns/manager_test.go
@@ -2,6 +2,7 @@ package ddns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/netip"
 	"os"
@@ -711,7 +712,7 @@ func TestStateStorePersistsAndReloads(t *testing.T) {
 	}
 }
 
-func TestStateStoreCorruptResetsEmptyFailOpen(t *testing.T) {
+func TestStateStoreCorruptReturnsEmptyStoreClassifiedError(t *testing.T) {
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "state.json")
 	writeCSV(t, statePath, "{ this is not json")
@@ -719,19 +720,22 @@ func TestStateStoreCorruptResetsEmptyFailOpen(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for corrupt state")
 	}
+	// #2650: the error must be CLASSIFIED corrupt so the manager can fail closed.
+	if !errors.Is(err, errDDNSStateCorrupt) {
+		t.Fatalf("corrupt store error must wrap errDDNSStateCorrupt, got %v", err)
+	}
 	if s == nil || len(s.records) != 0 {
-		t.Fatalf("corrupt store must reset to empty, got %+v", s)
+		t.Fatalf("corrupt store must return an empty store, got %+v", s)
 	}
 }
 
-// TestStateStoreUnsupportedVersionFailsOpen proves the Copilot robustness
-// fix: a state file with an unknown (future) non-zero Version is treated
-// like a corrupt store — fail-open to an EMPTY store + surface an error (so
-// the caller warns), rather than silently decoding records that may carry a
-// different tuple shape into wrong-tuple deletes. No panic. Against the
-// pre-fix loader (which never checked Version) the records load and would be
-// trusted, so this test fails pre-fix.
-func TestStateStoreUnsupportedVersionFailsOpen(t *testing.T) {
+// TestStateStoreUnsupportedVersionClassifiedError proves a state file with an
+// unknown (future) non-zero Version returns an EMPTY store plus a CLASSIFIED
+// unsupported-version error (#2650) — never silently decoding records that may
+// carry a different tuple shape into wrong-tuple deletes, and never silently
+// trusting the empty store. No panic. Against the pre-#2691 loader (which never
+// checked Version) the records load and would be trusted, so this fails pre-fix.
+func TestStateStoreUnsupportedVersionClassifiedError(t *testing.T) {
 	dir := t.TempDir()
 	statePath := filepath.Join(dir, "state.json")
 	// A syntactically-valid state file from a FUTURE format version, with a
@@ -741,11 +745,14 @@ func TestStateStoreUnsupportedVersionFailsOpen(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for an unsupported state version")
 	}
+	if !errors.Is(err, errDDNSStateUnsupportedVersion) {
+		t.Fatalf("unsupported-version error must wrap errDDNSStateUnsupportedVersion, got %v", err)
+	}
 	if s == nil {
 		t.Fatal("loadDDNSState returned nil store on unsupported version (must be empty store)")
 	}
 	if len(s.records) != 0 {
-		t.Fatalf("unsupported version must reset to empty (no wrong-tuple records), got %d records", len(s.records))
+		t.Fatalf("unsupported version must return an empty store (no wrong-tuple records), got %d records", len(s.records))
 	}
 
 	// A version-0 (pre-versioning / zero-value) file is tolerated and its
@@ -758,6 +765,112 @@ func TestStateStoreUnsupportedVersionFailsOpen(t *testing.T) {
 	}
 	if _, ok := s0.get(ScopeKey{}, "mac:bb", "10.0.0.20"); !ok {
 		t.Fatal("version-0 store should load its records")
+	}
+}
+
+// TestCorruptStateFailsClosedRefusingAllOps is the #2650 fail-on-revert test:
+// a corrupt ownership state file must put the manager into the DEGRADED
+// (fail-closed) state — it refuses to publish AND to withdraw any record, never
+// silently resetting to an empty store and reconciling-from-empty (which would
+// leak previously-owned records and could overwrite a peer-owned name). It also
+// proves the bad file is quarantined (preserved, not overwritten) and the alarm
+// is surfaced in Stats. Reverting loadStateOrDegrade to the old fail-open path
+// (treat the empty store as trusted, no degraded flag) makes this test RED: the
+// reconcile would publish the lease and the assertions on no-ops + degraded fail.
+func TestCorruptStateFailsClosedRefusingAllOps(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	// A corrupt store left behind by a crash / disk fault.
+	writeCSV(t, statePath, "{ this is not valid json at all")
+
+	src := &fakeLeaseSource{v4: laptopMacLease()}
+	up := newFakeUpdater()
+	m := newManagerForTesting(
+		src.parser(),
+		up,
+		statePath,
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		func() time.Time { return time.Unix(1_700_000_000, 0) },
+	)
+
+	// Degraded must be set at construction, and surfaced in Stats.
+	if !m.degraded {
+		t.Fatal("manager must be DEGRADED after loading a corrupt state file")
+	}
+	if st := m.Stats(); !st.Degraded || st.DegradedReason == "" {
+		t.Fatalf("Stats must report Degraded with a reason, got %+v", st)
+	}
+
+	// The corrupt file must be quarantined aside (preserved for inspection),
+	// not left in place to be overwritten by a later save.
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt state file must be quarantined (renamed away); stat err=%v", err)
+	}
+	matches, _ := filepath.Glob(statePath + ".corrupt-*")
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one quarantined copy, found %v", matches)
+	}
+
+	// A reconcile with an ENABLED config + a live lease must FAIL CLOSED: no
+	// publish, no withdraw, an error returned, and the state file NOT recreated.
+	cfg := &config.DHCPServerConfig{
+		DynamicDNS: &config.DHCPDynamicDNSConfig{
+			Enabled:    true,
+			Domain:     "example.com",
+			TTLSeconds: 300,
+		},
+	}
+	err := m.Reconcile(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("reconcile must return an error while degraded (fail closed)")
+	}
+	if names := up.upsertNames(); len(names) != 0 {
+		t.Fatalf("degraded manager must NOT publish any record, got upserts %v", names)
+	}
+	if names := up.deleteNames(); len(names) != 0 {
+		t.Fatalf("degraded manager must NOT withdraw any record, got deletes %v", names)
+	}
+	// The reconcile must NOT have written a fresh (empty) state file — that
+	// would erase the only signal that ownership was lost.
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatal("degraded manager must not recreate the ownership state file")
+	}
+	// The pass is counted as a failure so an operator watching ReconcileFail /
+	// the degraded gauge sees the suspension.
+	if st := m.Stats(); st.ReconcileFail == 0 {
+		t.Fatal("a degraded reconcile must count as a reconcile failure")
+	}
+}
+
+// TestUnsupportedVersionStateFailsClosed proves the unknown-future-version path
+// also fails closed + quarantines (the sibling of the corrupt path, #2650).
+func TestUnsupportedVersionStateFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "state.json")
+	writeCSV(t, statePath, `{"version":99,"records":[{"family":4,"identity":"mac:aa","address":"10.0.0.10","fqdn":"h.example.com","forward_type":"A","ptr_name":"10.0.0.10.in-addr.arpa","ttl":300}]}`)
+
+	up := newFakeUpdater()
+	m := newManagerForTesting(
+		(&fakeLeaseSource{}).parser(),
+		up,
+		statePath,
+		filepath.Join(dir, "leases4.csv"),
+		filepath.Join(dir, "leases6.csv"),
+		"node0",
+		func() time.Time { return time.Unix(1_700_000_000, 0) },
+	)
+	if !m.degraded {
+		t.Fatal("unsupported-version state must put the manager into the degraded state")
+	}
+	// No record from the future-version file leaked into the in-memory store.
+	if len(m.state.records) != 0 {
+		t.Fatalf("unsupported-version records must not load, got %d", len(m.state.records))
+	}
+	matches, _ := filepath.Glob(statePath + ".corrupt-*")
+	if len(matches) != 1 {
+		t.Fatalf("unsupported-version file must be quarantined, found %v", matches)
 	}
 }
 

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -7,8 +7,24 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/psaab/xpf/pkg/fsatomic"
+)
+
+// errDDNSStateCorrupt / errDDNSStateUnsupportedVersion classify a load failure
+// of the ownership store so the manager can FAIL CLOSED rather than silently
+// reset to an empty store (#2650). A corrupt or unknown-future-version store is
+// the only authority for the records this firewall published; treating it as
+// empty would (a) forget what we own — leaking previously-published records into
+// authoritative DNS forever — and (b) let a later publish RE-CLAIM a name a peer
+// owns, since the lost DHCID ownership records can no longer prove or deny our
+// authorship. The reconciler refuses destructive AND additive ops while the load
+// is unresolved (see Manager.degraded). These wrap with %w so the caller uses
+// errors.Is to decide the degraded reason.
+var (
+	errDDNSStateCorrupt            = errors.New("ddns: ownership state file is corrupt")
+	errDDNSStateUnsupportedVersion = errors.New("ddns: ownership state file has an unsupported version")
 )
 
 // state.go (moved verbatim from pkg/dhcpserver/ddns_state.go in #2691 P1a):
@@ -236,11 +252,27 @@ type ddnsStateFile struct {
 
 const ddnsStateVersion = 1
 
-// loadDDNSState reads the ownership store from path. A missing file yields
-// an empty store (first run). A CORRUPT file is FAIL-OPEN per plan §5
-// invariant 4: log-and-reset to empty rather than wedge the reconciler —
-// the caller logs; this returns (emptyStore, err) so the caller can count
-// and warn without aborting.
+// loadDDNSState reads the ownership store from path. A missing file yields an
+// empty store (first run, error nil). A CORRUPT or UNKNOWN-VERSION file is
+// FAIL-CLOSED (#2650): the returned store is empty, but the returned error is
+// non-nil and classifiable (errors.Is errDDNSStateCorrupt /
+// errDDNSStateUnsupportedVersion) so the manager enters a DEGRADED state and
+// refuses to publish or withdraw any record until the operator resolves it.
+//
+// Why fail closed, not fail open: this store is the ONLY authority for the
+// records this firewall published and the DHCID ownership it can prove. Silently
+// resetting to empty both forgets what we own (the cleanup half of the feature is
+// lost — stale A/AAAA/PTR records leak into authoritative DNS forever) AND lets a
+// later publish overwrite a record a PEER owns, because the lost ownership/DHCID
+// state can no longer veto the re-claim. Returning the empty store keeps the
+// manager constructible (the daemon still starts), but the non-nil error gates
+// every reconcile op off until the state is trustworthy again.
+//
+// A read error other than not-exist (permission / IO) is also returned so the
+// manager degrades — an unreadable store is no more trustworthy than a corrupt
+// one — but it is NOT classified corrupt/unsupported (no quarantine: the bytes
+// may be fine and re-readable, so do not move the file out from under a transient
+// fault).
 func loadDDNSState(path string) (*ddnsState, error) {
 	s := &ddnsState{path: path, records: map[string]ownedRecord{}}
 	data, err := os.ReadFile(path)
@@ -252,27 +284,43 @@ func loadDDNSState(path string) (*ddnsState, error) {
 	}
 	var f ddnsStateFile
 	if err := json.Unmarshal(data, &f); err != nil {
-		// Corrupt store: keep the empty (fresh) store. The boundary is only
-		// weakened to "may leak previously-owned records" — those records
-		// stay in DNS until something authoritatively removes them (TTL only
-		// controls resolver CACHING, not removal), so the worst case is
-		// stale-but-present records, never "deletes unowned records".
-		return s, fmt.Errorf("parse ddns state %s (resetting to empty): %w", path, err)
+		// Corrupt store: return the empty store + a corrupt-classified error so
+		// the manager fails closed (refuses all record ops) and quarantines the
+		// bad file. We must NOT silently treat this as an empty trusted store:
+		// that would forget every owned record (permanent stale-record leak) and
+		// permit re-claiming a peer-owned name.
+		return s, fmt.Errorf("parse ddns state %s: %w: %v", path, errDDNSStateCorrupt, err)
 	}
-	// Version validation: an unknown (future / unsupported) non-zero version
-	// means a format we cannot safely decode — its records may carry a
-	// different tuple shape, so trusting them could drive WRONG-tuple
-	// deletes. Treat it like a corrupt store: fail-open to an empty store +
-	// surface the error so the caller warns. Version 0 is tolerated as a
-	// pre-versioning / zero-value store (the field was absent or defaulted).
+	// Version validation: an unknown (future / unsupported) non-zero version is a
+	// format we cannot safely decode — its records may carry a different tuple
+	// shape, so trusting them could drive WRONG-tuple deletes, and ignoring them
+	// loses ownership. Fail closed exactly like a corrupt store. Version 0 is
+	// tolerated as a pre-versioning / zero-value store (the field was absent or
+	// defaulted).
 	if f.Version != 0 && f.Version != ddnsStateVersion {
-		return s, fmt.Errorf("ddns state %s has unsupported version %d (want %d); resetting to empty",
-			path, f.Version, ddnsStateVersion)
+		return s, fmt.Errorf("ddns state %s has version %d (want %d): %w",
+			path, f.Version, ddnsStateVersion, errDDNSStateUnsupportedVersion)
 	}
 	for _, r := range f.Records {
 		s.records[ownedRecordKey(r.scopeOf(), r.Identity, r.Address)] = r
 	}
 	return s, nil
+}
+
+// quarantineBadState moves a corrupt / unknown-version ownership file aside to a
+// timestamped copy (path + ".corrupt-<RFC3339-ish>") so (a) the operator can
+// inspect it and (b) a later save() does NOT overwrite the only forensic copy of
+// the lost ownership records. It is best-effort: a quarantine failure is logged
+// by the caller and does not change the fail-closed posture. Returns the
+// quarantine path on success.
+func quarantineBadState(path string, now time.Time) (string, error) {
+	// Colons are filesystem-hostile; use a compact, sortable stamp.
+	stamp := now.UTC().Format("20060102T150405Z")
+	dst := fmt.Sprintf("%s.corrupt-%s", path, stamp)
+	if err := os.Rename(path, dst); err != nil {
+		return "", fmt.Errorf("quarantine ddns state %s -> %s: %w", path, dst, err)
+	}
+	return dst, nil
 }
 
 // save persists the store durably (fsync-on-write). Records are sorted by

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -238,6 +238,10 @@ func (s *Server) showDHCPDynamicDNS(cfg *config.Config, buf *strings.Builder, de
 		buf.WriteString("\n  Runtime counters: unavailable (manager not running)\n")
 		return
 	}
+	if st.Degraded {
+		fmt.Fprintf(buf, "\n  ALARM: DDNS DEGRADED (fail-closed) — %s\n", st.DegradedReason)
+		buf.WriteString("    Publishing and withdrawals are SUSPENDED until the ownership state is resolved.\n")
+	}
 	buf.WriteString("\n  Counters:\n")
 	fmt.Fprintf(buf, "    Upserts:    ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
 	fmt.Fprintf(buf, "    Deletes:    ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)


### PR DESCRIPTION
Closes #2650

## Summary
The DDNS ownership store is the only authority for the records this firewall published and the DHCID ownership it can prove. `loadDDNSState` previously treated a corrupt or unknown-future-version store as an empty store and the manager started anyway (**fail-open**), silently losing the cleanup half of the feature: previously-published A/AAAA/PTR records were never withdrawn (a permanent stale-record leak in authoritative DNS), and a later publish could re-claim a name a **peer** owns because the lost ownership/DHCID state could no longer veto it.

This makes the unloadable-state path **fail closed**, matching the #2691 DDNS fail-closed posture.

## Fail-closed semantics
- `loadDDNSState` returns the empty store plus a **classified** error (`errDDNSStateCorrupt` / `errDDNSStateUnsupportedVersion`), so a real failure is distinguishable from a clean first run.
- A new `loadStateOrDegrade` helper sets `Manager.degraded` and **quarantines** the bad file aside (`<path>.corrupt-<UTC-stamp>`) — the forensic copy is preserved and a later `save()` cannot overwrite it.
- While degraded, `ReconcileScoped` refuses the **whole** pass: **no publish, no withdraw, no save()**, counted as a reconcile failure. The empty in-memory store is never acted upon (the never-delete-non-owned boundary is also preserved).
- An unreadable (permission/IO) file also degrades but is **not** quarantined — the bytes may be fine and re-readable, so the file is not moved under a transient fault.
- **Operator visibility:** `show services dhcp dynamic-dns` (CLI + gRPC) prints an ALARM line; new `xpf_dhcp_ddns_degraded` Prometheus gauge (1 when degraded); `Stats.Degraded` + `Stats.DegradedReason`.

## Fail-on-revert proof
Added `TestCorruptStateFailsClosedRefusingAllOps` and `TestUnsupportedVersionStateFailsClosed`: each asserts the manager is degraded, leaks no records, quarantines the bad file, and (corrupt case) a subsequent enabled reconcile performs NO publish, NO withdraw, returns an error, does not recreate the state file, and counts a reconcile failure. Reverting `loadStateOrDegrade` to the old fail-open path was verified **RED**:
```
--- FAIL: TestCorruptStateFailsClosedRefusingAllOps
    manager_test.go: manager must be DEGRADED after loading a corrupt state file
--- FAIL: TestUnsupportedVersionStateFailsClosed
    manager_test.go: unsupported-version state must put the manager into the degraded state
```
Restored → green.

## Gates
- `go build ./...` — clean
- `gofmt -l` touched files — clean (`pkg/api/types.go` is pre-existing gofmt-dirty on origin/master, not in this diff)
- `go vet` — clean for touched packages (`pkg/cli/cli.go:460 unreachable` is pre-existing on origin/master, not this change)
- `go test ./pkg/ddns/... ./pkg/dhcpserver/... ./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/daemon/...` — all pass

Docs: `pkg/ddns/README.md` invariant + file-table updated; `_Log.md` appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi