### PR TITLE
ipsec: support responder-only / %any dynamic-IP gateway (#2404)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15343,3 +15343,16 @@ top.
   pkg/ddns/README.md, pkg/api/metrics.go, pkg/api/metrics_descriptors.go,
   pkg/api/metrics_system.go, pkg/cli/cli_show_services.go,
   pkg/grpcapi/server_show_dhcp_lldp_snmp.go, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2404 — IPsec responder-only / %any dynamic-IP gateway. Added
+  `IPsecGateway.ResponderOnly` flag set by `compileIKE`/`compileIPsec` when a
+  `dynamic` block carries no hostname; strict validator
+  (`validateIPsecGatewayReferencesStrict`) now accepts such a gateway;
+  swanctl render (`resolveRemoteAddr`) emits `remote_addrs = %any`. Wired the
+  `dynamic { hostname <fqdn> }` child into the #1319 setSchema (both gateway
+  copies). Added fail-on-revert tests (proved RED on revert, restored).
+  **File(s)**: pkg/config/types_security.go, pkg/config/compiler_ipsec.go,
+  pkg/config/schema_security.go, pkg/ipsec/policy.go,
+  pkg/config/parser_security_test.go, pkg/ipsec/ipsec_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -522,6 +522,21 @@ reserved for whole-dataplane selection where a rewrite shim
     UNTYPED: the swanctl renderer normalizes arbitrary algorithm spellings
     by string substitution, so an enum there would false-reject valid
     configs.
+  - **#2404 (responder-only / dynamic-IP peer):** the `security ike gateway
+    <g> dynamic` node now declares a `hostname <fqdn>` child (it was a
+    `children: nil` leaf in both the `ike` and `ipsec` stanza copies of the
+    gateway schema). The semantics: `dynamic hostname <fqdn>` is a peer with
+    a dynamic IP but a resolvable DNS name (renders `remote_addrs = <fqdn>`,
+    unchanged); a BARE `dynamic` block — no address, no hostname — marks a
+    responder-only peer that dials in from an unknown source address. The
+    compiler (`compileIKE` / `compileIPsec`) sets `IPsecGateway.ResponderOnly`
+    when the `dynamic` block resolves no hostname; the strict commit-time
+    validator (`validateIPsecGatewayReferencesStrict`) accepts such a gateway
+    instead of rejecting it as addressless; and the swanctl render
+    (`resolveRemoteAddr`, `pkg/ipsec/policy.go`) emits `remote_addrs = %any`
+    so strongSwan listens for the inbound IKE rather than skipping the
+    connection. `local-address` (or `external-interface`) still pins the
+    local endpoint as usual.
   - `security nat static rule-set rule match` — declared the
     `source-address` / `destination-address` children the static-NAT
     compiler reads (the subtree was previously unreachable by the walker).

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -157,7 +157,10 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 					}
 				}
 			case "dynamic":
-				// "dynamic hostname FQDN" or children
+				// "dynamic hostname FQDN" or children. A `dynamic` block
+				// with no hostname marks a responder-only / dynamic-IP peer
+				// (remote_addrs = %any) — see the IPsec-stanza copy below
+				// and resolveRemoteAddr (#2404).
 				if len(p.Keys) >= 3 && p.Keys[1] == "hostname" {
 					gw.DynamicHostname = p.Keys[2]
 				} else {
@@ -166,6 +169,9 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 							gw.DynamicHostname = c.Keys[1]
 						}
 					}
+				}
+				if gw.DynamicHostname == "" {
+					gw.ResponderOnly = true
 				}
 			}
 		}
@@ -333,6 +339,10 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 					}
 				}
 			case "dynamic":
+				// A `dynamic` block with no hostname marks a responder-only
+				// / dynamic-IP peer: the peer initiates from an unknown
+				// address, so the gateway carries no remote_addrs target and
+				// renders remote_addrs = %any (#2404).
 				if len(p.Keys) >= 3 && p.Keys[1] == "hostname" {
 					gw.DynamicHostname = p.Keys[2]
 				} else {
@@ -341,6 +351,9 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 							gw.DynamicHostname = nodeVal(c)
 						}
 					}
+				}
+				if gw.DynamicHostname == "" {
+					gw.ResponderOnly = true
 				}
 			}
 		}
@@ -443,12 +456,14 @@ func validateIPsecGatewayReferencesStrict(cfg *Config) error {
 			continue
 		}
 		if gw, ok := ipsec.Gateways[vpn.Gateway]; ok {
-			if gw.Address == "" && gw.DynamicHostname == "" {
+			if gw.Address == "" && gw.DynamicHostname == "" && !gw.ResponderOnly {
 				return fmt.Errorf("security ipsec vpn %s: ike gateway %q "+
 					"has no address or dynamic hostname; the tunnel would "+
 					"never establish", name, vpn.Gateway)
 			}
-			continue // resolves to a defined, addressed gateway
+			// A responder-only gateway (dynamic block, no address/hostname)
+			// legitimately omits remote_addrs and renders %any (#2404).
+			continue // resolves to a defined, addressed (or responder-only) gateway
 		}
 		if IsUsableIPsecEndpoint(vpn.Gateway) {
 			continue // legacy inline literal IP / dotted hostname

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -5078,3 +5078,94 @@ func TestAddressBookEmptyValueWarns(t *testing.T) {
 		})
 	}
 }
+
+// TestIPsecResponderOnlyGatewaySetSyntax is the #2404 fail-on-revert
+// guard for the config layer: a `security ike gateway G dynamic` block
+// with NO hostname (and no address) marks the gateway responder-only —
+// a dial-in peer with a dynamic source IP. The compiler must set
+// gw.ResponderOnly and the strict commit-time validator
+// (validateIPsecGatewayReferencesStrict, reached via CompileConfig) must
+// ACCEPT the referencing VPN.
+//
+// Counter-factual pin: before #2404 the parser left ResponderOnly false
+// and the strict validator rejected the VPN with "has no address or
+// dynamic hostname; the tunnel would never establish" — CompileConfig
+// returned a non-nil error. Reverting the fix makes CompileConfig fail
+// here.
+func TestIPsecResponderOnlyGatewaySetSyntax(t *testing.T) {
+	cmds := []string{
+		"set security ike proposal p1 authentication-method pre-shared-keys",
+		"set security ike proposal p1 encryption-algorithm aes-256-cbc",
+		"set security ike proposal p1 authentication-algorithm sha-256",
+		"set security ike proposal p1 dh-group group14",
+		"set security ike policy ike-pol proposals p1",
+		"set security ike policy ike-pol pre-shared-key ascii-text secret123",
+		"set security ike gateway dial-in ike-policy ike-pol",
+		"set security ike gateway dial-in local-address 198.51.100.1",
+		"set security ike gateway dial-in dynamic",
+		"set security ipsec vpn dyn ike gateway dial-in",
+		"set security ipsec vpn dyn bind-interface st0.0",
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+	// CompileConfig is the STRICT commit path
+	// (lenientIPsecGatewayRefs=false): it must accept the responder-only
+	// gateway, not reject it.
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected responder-only gateway: %v", err)
+	}
+	gw := cfg.Security.IPsec.Gateways["dial-in"]
+	if gw == nil {
+		t.Fatal("gateway dial-in not found")
+	}
+	if !gw.ResponderOnly {
+		t.Errorf("gateway ResponderOnly = false, want true (bare dynamic block)")
+	}
+	if gw.Address != "" || gw.DynamicHostname != "" {
+		t.Errorf("responder-only gateway should have no address/hostname, got addr=%q host=%q",
+			gw.Address, gw.DynamicHostname)
+	}
+}
+
+// TestIPsecDynamicHostnameNotResponderOnly pins that a `dynamic hostname
+// <fqdn>` block does NOT flip the responder-only flag — it still carries
+// a resolvable remote target (#2404).
+func TestIPsecDynamicHostnameNotResponderOnly(t *testing.T) {
+	cmds := []string{
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ike gateway gw1 dynamic hostname peer.example.com",
+	}
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%v): %v", path, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	gw := cfg.Security.IPsec.Gateways["gw1"]
+	if gw == nil {
+		t.Fatal("gateway gw1 not found")
+	}
+	if gw.DynamicHostname != "peer.example.com" {
+		t.Errorf("dynamic hostname = %q, want peer.example.com", gw.DynamicHostname)
+	}
+	if gw.ResponderOnly {
+		t.Errorf("dynamic-hostname gateway must NOT be responder-only")
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -359,7 +359,9 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			}},
 			"local-identity":  {desc: "Local IKE identity (type and value)", children: nil},
 			"remote-identity": {desc: "Remote IKE identity (type and value)", children: nil},
-			"dynamic":         {desc: "Dynamic peer (hostname <fqdn>)", children: nil},
+			"dynamic": {desc: "Dynamic peer (peer has a dynamic IP). With `hostname <fqdn>` the peer is DNS-resolved; a bare `dynamic` block marks a responder-only peer (remote_addrs = %any, #2404)", children: map[string]*schemaNode{
+				"hostname": {desc: "Dynamic peer FQDN (DNS-resolved)", args: 1, placeholder: "<fqdn>", children: nil},
+			}},
 		}},
 	}},
 	"ipsec": {desc: "IPsec configuration", children: map[string]*schemaNode{
@@ -413,7 +415,9 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			}},
 			"local-identity":  {desc: "Local IKE identity (type and value)", children: nil},
 			"remote-identity": {desc: "Remote IKE identity (type and value)", children: nil},
-			"dynamic":         {desc: "Dynamic peer (hostname <fqdn>)", children: nil},
+			"dynamic": {desc: "Dynamic peer (peer has a dynamic IP). With `hostname <fqdn>` the peer is DNS-resolved; a bare `dynamic` block marks a responder-only peer (remote_addrs = %any, #2404)", children: map[string]*schemaNode{
+				"hostname": {desc: "Dynamic peer FQDN (DNS-resolved)", args: 1, placeholder: "<fqdn>", children: nil},
+			}},
 		}},
 		"vpn": {desc: "IPsec VPN tunnel name", args: 1, placeholder: "<vpn-name>", children: map[string]*schemaNode{
 			"bind-interface":    {desc: "XFRM tunnel interface to bind", args: 1, placeholder: "<interface-name>", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -532,6 +532,7 @@ type IPsecGateway struct {
 	Name             string
 	Address          string // remote gateway IP
 	DynamicHostname  string // dynamic peer hostname (DNS-resolved)
+	ResponderOnly    bool   // dynamic peer with no fixed address/hostname: responder-only (remote_addrs = %any)
 	LocalAddress     string // local IP
 	IKEPolicy        string // IKE policy reference
 	ExternalIface    string // external-facing interface

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -1289,3 +1289,44 @@ func TestRenderConfig_GatewayNameNeverLeaks(t *testing.T) {
 		}
 	})
 }
+
+// TestGenerateConfig_ResponderOnlyGateway is the #2404 fail-on-revert
+// guard: a gateway carrying a `dynamic` block with no address and no
+// hostname is responder-only — the peer dials in from a dynamic source
+// address. The render MUST emit `remote_addrs = %any` so strongSwan
+// listens for the inbound IKE instead of skipping the connection.
+//
+// Counter-factual pin: before #2404, resolveRemoteAddr returned ok=false
+// for a gateway with neither Address nor DynamicHostname, so renderConfig
+// skipped the VPN entirely (no `dyn {` connection block, no
+// `remote_addrs = %any`). Reverting the ResponderOnly handling makes both
+// assertions below fail.
+func TestGenerateConfig_ResponderOnlyGateway(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		Gateways: map[string]*config.IPsecGateway{
+			"dial-in": {
+				Name:          "dial-in",
+				ResponderOnly: true,
+				LocalAddress:  "203.0.113.5",
+			},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"dyn": {
+				Gateway: "dial-in",
+				PSK:     "supersecret",
+			},
+		},
+		Proposals: map[string]*config.IPsecProposal{},
+	}
+	got := m.generateConfig(cfg)
+	if !strings.Contains(got, "dyn {") {
+		t.Fatalf("responder-only VPN should render a connection block:\n%s", got)
+	}
+	if !strings.Contains(got, "remote_addrs = %any") {
+		t.Fatalf("responder-only gateway must render remote_addrs = %%any:\n%s", got)
+	}
+	if !strings.Contains(got, "local_addrs = 203.0.113.5") {
+		t.Fatalf("responder-only gateway local_addrs missing:\n%s", got)
+	}
+}

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -249,7 +249,9 @@ func (m *Manager) renderConfig(ipsecCfg *config.IPsecConfig) (string, error) {
 // NAME never leaks into remote_addrs (#2074):
 //
 //   - defined gateway with an address / dynamic hostname -> remote = that
-//   - defined gateway with neither (addressless)         -> ok=false
+//   - defined gateway flagged responder-only (dynamic, no addr/host)
+//     -> remote = "%any" (strongSwan responds, never initiates) (#2404)
+//   - defined gateway with neither + not responder-only   -> ok=false
 //   - no gateway object, vpn.Gateway is a usable IP/host -> remote = it
 //   - no gateway object, vpn.Gateway empty               -> ok=true,
 //     remote="" (connection emitted with no remote_addrs line, as before)
@@ -268,11 +270,14 @@ func resolveRemoteAddr(ipsecCfg *config.IPsecConfig, vpn *config.IPsecVPN) (
 			remoteAddr = gw.Address
 		case gw.DynamicHostname != "":
 			remoteAddr = gw.DynamicHostname
+		case gw.ResponderOnly:
+			// Responder-only / dynamic-IP peer (#2404): the peer initiates
+			// from an unknown source address, so strongSwan listens with
+			// remote_addrs = %any and never initiates to this gateway.
+			remoteAddr = "%any"
 		default:
-			// Gateway exists but has nothing routable. Do NOT fall back
-			// to the object name. (Forecloses a future responder-only /
-			// %any peer that legitimately omits remote_addrs — no such
-			// concept exists in the parser today; revisit if added.)
+			// Gateway exists but has nothing routable and is not flagged
+			// responder-only. Do NOT fall back to the object name.
 			return "", localAddr, gw, false
 		}
 		if gw.LocalAddress != "" && localAddr == "" {


### PR DESCRIPTION
Closes #2404 (defect #1; defect #2 deferred — see Deferred below).

## Summary
- A responder-only / dynamic-IP IKE peer (dials in from an unknown source
  address) was unconfigurable: a gateway omitting both `address` and
  `dynamic hostname` was hard-rejected at commit
  (`validateIPsecGatewayReferencesStrict`: "has no address or dynamic
  hostname; the tunnel would never establish"), and the render path
  (`resolveRemoteAddr`) returned `ok=false` so the connection was skipped.
- New Junos-faithful idiom: `set security ike gateway <g> dynamic` with NO
  hostname marks the gateway **responder-only**. `dynamic hostname <fqdn>`
  is unchanged.
- `compileIKE` / `compileIPsec` set the new `IPsecGateway.ResponderOnly`
  flag when a `dynamic` block resolves no hostname; the strict validator
  accepts such a gateway; an addressless gateway with NO `dynamic` block
  stays rejected (still a misconfiguration).
- Render emits `remote_addrs = %any` for a responder-only gateway so
  strongSwan listens for inbound IKE and never initiates to the peer.
  `local_addrs` (from `local-address` / `external-interface`) still pins
  the local endpoint.
- `dynamic { hostname <fqdn> }` wired into the #1319 `setSchema` (both
  gateway copies) for completion / `?` help.

## swanctl semantics
strongSwan `remote_addrs = %any` makes the connection a pure responder:
it matches inbound IKE_SA_INIT from any source address and never
initiates. This is the canonical config for a hub accepting dial-in from
branches with dynamic public IPs. `local_addrs` is still emitted so the
responder binds the correct local IKE address.

## Fail-on-revert proof
Both core lines were independently reverted and the tests went RED, then
restored to GREEN (`go test -count=1`):

- Revert the `%any` render case → `TestGenerateConfig_ResponderOnlyGateway`
  FAILs (render produced empty `connections {}` — VPN skipped).
- Revert the validator `&& !gw.ResponderOnly` → `CompileConfig` rejects
  the responder-only gateway, `TestIPsecResponderOnlyGatewaySetSyntax`
  FAILs with "ike gateway \"dial-in\" has no address or dynamic hostname".
- `TestIPsecDynamicHostnameNotResponderOnly` pins that a `dynamic
  hostname <fqdn>` gateway is NOT flagged responder-only (discriminator
  guard).

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l` on touched files — clean
- [x] `go vet ./pkg/ipsec/... ./pkg/config/...` — clean
- [x] `go test -count=1 ./pkg/ipsec/... ./pkg/config/...` — pass
- [x] Existing `commit rejects addressless gateway` (no `dynamic` block)
      still passes — scope is correctly narrow.

## Deferred
- **#2404 defect #2** (dynamic-hostname gateway selects the wrong local
  address family on a dual-stack interface — `addressFamilyHint` returns
  0 for a hostname, `matchFamily` then returns the first unicast IP).
  This is a separate behavior fix (DNS family resolution or an operator
  family pin) and is intentionally NOT bundled here per scope discipline.
  Tracked under #2404; will follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi