### PR TITLE
control-sockets: force SOCK_CLOEXEC on all raw/datagram control sockets via pkg/linuxsock (#2608)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-25 — #2608: SOCK_CLOEXEC on all raw/datagram control sockets via pkg/linuxsock
+
+- **Timestamp**: 2026-06-25
+- **Action**: A raw `unix.Socket(2)` is not close-on-exec by default, so
+  every bare raw AF_PACKET/raw-ICMP/datagram fd leaked into the helpers
+  xpfd fork-execs (frr-reload.py, swanctl, DHCP helpers) — an fd leak and
+  a raw-frame security boundary (#2476 fixed only the VRRP receiver).
+  Added `pkg/linuxsock` SSOT factory `Socket()` that ORs `SOCK_CLOEXEC`
+  atomically into the type, and routed all 13 sibling sites through it
+  (cluster GARP/NDP x6, LLDP rx/tx, HA fabric ICMP probes x3, userspace
+  NAPI probes x4, DHCP-relay L2 send). Added `TestNoDirectUnixSocket`
+  go/ast canary (walks every production .go under pkg/, fails on a new
+  direct `unix.Socket(...)` call outside the allowlist) + factory unit
+  test (seam-captured type flags) + real-fd `F_GETFD` CLOEXEC assert.
+  Fail-on-revert proven for both the canary (reverted call site → RED)
+  and the factory test (dropped CLOEXEC → RED). Allowlist: linuxsock
+  itself + pkg/vrrp's pre-#2476 receiver (pinned by its own test).
+  go build/vet/gofmt clean; affected-package tests green (pre-existing
+  pkg/ra TestT2a flake unrelated, fails on clean origin/master too).
+- **File(s)**: pkg/linuxsock/linuxsock.go, pkg/linuxsock/linuxsock_test.go,
+  pkg/linuxsock/canary_test.go, pkg/linuxsock/README.md,
+  pkg/cluster/garp.go, pkg/lldp/lldp.go, pkg/dhcprelay/l2send_linux.go,
+  pkg/daemon/daemon_ha_fabric.go, pkg/dataplane/userspace/process.go,
+  docs/engineering-style.md, _Log.md
+
 ## 2026-06-25 — #2406 r2: dnat_table KEY port byte-order (host-order; fixes latent v4)
 
 - **Timestamp**: 2026-06-25

--- a/docs/engineering-style.md
+++ b/docs/engineering-style.md
@@ -446,6 +446,17 @@ they repeatedly bite:
     lock still held means a child inherited the fd (pre-#1875 raw
     holders only; `with-cluster.sh` runs cells with the lock fd
     closed, so killing a cell's tree releases instantly).
+- **Raw/datagram sockets go through `pkg/linuxsock` (#2608).** A raw
+  `unix.Socket(2)` is NOT close-on-exec by default (unlike Go `net`
+  sockets), so a bare raw `AF_PACKET`/raw-ICMP/datagram fd leaks into
+  every helper the daemon fork-execs (`frr-reload.py`, `swanctl`, DHCP
+  helpers) — an fd leak and a raw-frame security boundary. Use
+  `linuxsock.Socket(domain, typ, proto)` (ORs `SOCK_CLOEXEC` atomically
+  into the type), never `unix.Socket` directly. `pkg/linuxsock`'s
+  `TestNoDirectUnixSocket` canary scans every production `.go` under
+  `pkg/` and fails the suite on a new direct call site (the one
+  justified exception, `pkg/vrrp`'s pre-#2476 receiver, is allowlisted
+  and pinned by its own `afpacket_cloexec_test.go`).
 - **Always `source ~/.sshrc` before `git push`.** The user's SSH agent
   config lives there.
 - **172.16.80.200 is the iperf3 test endpoint.** Not 172.16.50.x.

--- a/pkg/cluster/garp.go
+++ b/pkg/cluster/garp.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/psaab/xpf/pkg/linuxsock"
 	"golang.org/x/sys/unix"
 )
 
@@ -32,7 +33,7 @@ func SendGratuitousARP(iface string, ip net.IP, count int) error {
 	reqPkt := buildGratuitousARP(ifi.HardwareAddr, ip4, 1) // ARP Request
 	repPkt := buildGratuitousARP(ifi.HardwareAddr, ip4, 2) // ARP Reply
 
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ARP)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ARP)))
 	if err != nil {
 		return fmt.Errorf("raw socket: %w", err)
 	}
@@ -121,7 +122,7 @@ func SendGratuitousARPBurst(iface string, ip net.IP, count int) error {
 	reqPkt := buildGratuitousARP(ifi.HardwareAddr, ip4, 1) // ARP Request
 	repPkt := buildGratuitousARP(ifi.HardwareAddr, ip4, 2) // ARP Reply
 
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ARP)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ARP)))
 	if err != nil {
 		return fmt.Errorf("raw socket: %w", err)
 	}
@@ -198,7 +199,7 @@ func SendARPProbe(iface string, senderIP, targetIP net.IP) error {
 // frame SendARPProbe emits (sender field at pkt[28:32]) without socket I/O,
 // proving the wiring passes the VIP and not the interface primary (#2152).
 var arpProbeSend = func(ifi *net.Interface, pkt []byte) error {
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ARP)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ARP)))
 	if err != nil {
 		return fmt.Errorf("raw socket: %w", err)
 	}
@@ -337,7 +338,7 @@ func SendGratuitousIPv6(iface string, ip net.IP, count int) error {
 
 	pkt := buildUnsolicitedNA(ifi.HardwareAddr, ip6)
 
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_IPV6)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_IPV6)))
 	if err != nil {
 		return fmt.Errorf("raw socket: %w", err)
 	}
@@ -386,7 +387,7 @@ func SendGratuitousIPv6Burst(iface string, ip net.IP, count int) error {
 
 	pkt := buildUnsolicitedNA(ifi.HardwareAddr, ip6)
 
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_IPV6)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_IPV6)))
 	if err != nil {
 		return fmt.Errorf("raw socket: %w", err)
 	}
@@ -531,7 +532,7 @@ func SendNDSolicitation(iface string, sourceIP, targetIP net.IP) error {
 
 	pkt := buildNDSolicitation(ifi.HardwareAddr, src6, target6)
 
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_IPV6)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_IPV6)))
 	if err != nil {
 		return fmt.Errorf("raw socket: %w", err)
 	}

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/linuxsock"
 )
 
 // ensureFabricIPVLAN creates an IPVLAN L2 interface on top of parent for
@@ -278,7 +279,7 @@ func (d *Daemon) probeFabricNeighbor(ctx context.Context, fabIface string, peerI
 // shelling out to ping. Non-blocking: sendto MSG_DONTWAIT.
 func sendICMPProbe(iface string, target net.IP) {
 	if target.To4() != nil {
-		fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_ICMP)
+		fd, err := linuxsock.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_ICMP)
 		if err != nil {
 			return
 		}
@@ -290,7 +291,7 @@ func sendICMPProbe(iface string, target net.IP) {
 		copy(sa.Addr[:], target.To4())
 		_ = unix.Sendto(fd, icmp[:], unix.MSG_DONTWAIT, sa)
 	} else {
-		fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_ICMPV6)
+		fd, err := linuxsock.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_ICMPV6)
 		if err != nil {
 			return
 		}
@@ -312,7 +313,7 @@ func sendICMPProbe(iface string, target net.IP) {
 // for discovering the fabric peer's MAC when IPv4 ARP fails (e.g. after
 // crash recovery with RETH MAC changes on IPVLAN overlays).
 func sendIPv6MulticastProbe(iface string, ifindex int) {
-	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_ICMPV6)
+	fd, err := linuxsock.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_ICMPV6)
 	if err != nil {
 		return
 	}

--- a/pkg/dataplane/userspace/process.go
+++ b/pkg/dataplane/userspace/process.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/linuxsock"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
@@ -772,7 +773,7 @@ func sendICMPProbeFromManager(iface string, target net.IP) {
 // queues, triggering NAPI on each queue for zero-copy fill ring processing.
 func sendICMPProbeWithID(iface string, target net.IP, id uint16) {
 	if target.To4() != nil {
-		fd, err := unix.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_ICMP)
+		fd, err := linuxsock.Socket(unix.AF_INET, unix.SOCK_RAW, unix.IPPROTO_ICMP)
 		if err != nil {
 			return
 		}
@@ -794,7 +795,7 @@ func sendICMPProbeWithID(iface string, target net.IP, id uint16) {
 		copy(sa.Addr[:], target.To4())
 		_ = unix.Sendto(fd, icmp[:], unix.MSG_DONTWAIT, sa)
 	} else {
-		fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_ICMPV6)
+		fd, err := linuxsock.Socket(unix.AF_INET6, unix.SOCK_RAW, unix.IPPROTO_ICMPV6)
 		if err != nil {
 			return
 		}
@@ -817,7 +818,7 @@ func sendICMPProbeWithID(iface string, target net.IP, id uint16) {
 // (src_ip, dst_ip, src_port, dst_port). Different ports → different queues.
 func sendUDPProbeForNAPI(iface string, target net.IP, port uint16) {
 	if target.To4() != nil {
-		fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
+		fd, err := linuxsock.Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
 		if err != nil {
 			return
 		}
@@ -827,7 +828,7 @@ func sendUDPProbeForNAPI(iface string, target net.IP, port uint16) {
 		copy(sa.Addr[:], target.To4())
 		_ = unix.Sendto(fd, []byte("napi"), unix.MSG_DONTWAIT, sa)
 	} else {
-		fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
+		fd, err := linuxsock.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
 		if err != nil {
 			return
 		}

--- a/pkg/dhcprelay/l2send_linux.go
+++ b/pkg/dhcprelay/l2send_linux.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/psaab/xpf/pkg/linuxsock"
 	"golang.org/x/sys/unix"
 )
 
@@ -53,7 +54,7 @@ func newL2Sender(ifaceName string) (*l2Sender, error) {
 	if err != nil {
 		return nil, fmt.Errorf("interface lookup: %w", err)
 	}
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htonsLocal(unix.ETH_P_IP)))
+	fd, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htonsLocal(unix.ETH_P_IP)))
 	if err != nil {
 		return nil, fmt.Errorf("raw socket: %w", err)
 	}

--- a/pkg/linuxsock/README.md
+++ b/pkg/linuxsock/README.md
@@ -1,0 +1,35 @@
+# pkg/linuxsock
+
+Single source of truth for raw/datagram socket creation in xpfd, so that
+`SOCK_CLOEXEC` is non-optional.
+
+## Why this package exists
+
+Go's `net` package sets `O_CLOEXEC` on every fd it creates. A raw
+`unix.Socket(2)` does **not** — the fd is left inheritable. xpfd fork-execs
+helpers constantly (`frr-reload.py`, `swanctl`, DHCP/script helpers), so any
+inheritable raw `AF_PACKET` / raw-ICMP / datagram fd leaks into those children:
+an fd leak **and** a security boundary issue (a child could read or inject raw
+frames on the interface).
+
+`#2476` fixed the VRRP receiver socket in isolation. `#2608` made the policy
+structural: every sibling raw/datagram socket creation site (cluster GARP/NDP
+bursts, LLDP rx/tx, HA fabric ICMP probes, userspace NAPI probes, DHCP-relay L2
+send) now routes through `linuxsock.Socket`, which ORs `unix.SOCK_CLOEXEC` into
+the type argument so the fd is created close-on-exec **atomically** at
+`socket(2)` time. The atomic OR-into-type is deliberate: a separate
+post-creation `fcntl(FD_CLOEXEC)` races a concurrent fork-exec between the two
+syscalls, and an inherited fd in that window is exactly the leak being closed.
+
+## Contract
+
+- All raw/datagram socket creation under `pkg/` goes through
+  `linuxsock.Socket(domain, typ, proto)`. Callers pass the **bare** type
+  (`unix.SOCK_RAW`, `unix.SOCK_DGRAM`) — never `SOCK_CLOEXEC` themselves, and
+  never `unix.Socket` directly.
+- `canary_test.go::TestNoDirectUnixSocket` walks every production `.go` file
+  under `pkg/` with `go/ast` and fails the suite on any direct `unix.Socket(...)`
+  call outside the allowlist. A new socket added the wrong way fails loudly.
+- Allowlist (justified direct callers): `linuxsock.Socket` itself (the wrapper),
+  and `pkg/vrrp::openAfPacketReceiver` (the pre-#2476 site, which already ORs
+  `SOCK_CLOEXEC` and is pinned by `pkg/vrrp/afpacket_cloexec_test.go`).

--- a/pkg/linuxsock/canary_test.go
+++ b/pkg/linuxsock/canary_test.go
@@ -1,0 +1,165 @@
+package linuxsock
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// allowedFunctions are the production functions permitted to keep a direct
+// unix.Socket(...) CALL, keyed RECEIVER-AWARE by `<pkg-relpath>::[RecvType.]func`
+// (mirrors the #1916 fsatomic canary key). Each entry must OR SOCK_CLOEXEC into
+// the type argument itself and carry its own fail-on-revert test.
+//
+// linuxsock.Socket is the SSOT factory: it is exempt because it IS the wrapper
+// that forces SOCK_CLOEXEC.
+//
+// pkg/vrrp::openAfPacketReceiver predates this package (#2476). It already ORs
+// SOCK_CLOEXEC into the type at its call site and is pinned by
+// pkg/vrrp/afpacket_cloexec_test.go, so it keeps a justified direct call via
+// the afPacketSocket seam. New raw/datagram sockets MUST use linuxsock.Socket.
+var allowedFunctions = map[string]string{
+	"linuxsock::Socket":          "the SSOT factory that forces SOCK_CLOEXEC",
+	"vrrp::openAfPacketReceiver": "pre-existing #2476 site; ORs SOCK_CLOEXEC + pinned by afpacket_cloexec_test.go",
+}
+
+// funcKey formats the receiver-aware allowlist key for a FuncDecl in the
+// package at pkgRel (mirrors pkg/fsatomic/canary_test.go).
+func funcKey(pkgRel string, fn *ast.FuncDecl) string {
+	if fn.Recv != nil && len(fn.Recv.List) > 0 {
+		recv := recvTypeName(fn.Recv.List[0].Type)
+		if recv != "" {
+			return pkgRel + "::" + recv + "." + fn.Name.Name
+		}
+	}
+	return pkgRel + "::" + fn.Name.Name
+}
+
+// recvTypeName extracts the receiver type name, stripping a leading '*'.
+func recvTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.StarExpr:
+		return recvTypeName(t.X)
+	case *ast.Ident:
+		return t.Name
+	case *ast.IndexExpr:
+		return recvTypeName(t.X)
+	case *ast.IndexListExpr:
+		return recvTypeName(t.X)
+	}
+	return ""
+}
+
+// pkgRelKey turns a file path under ../ (the pkg/ root) into the
+// package-relative key segment: "../cluster/garp.go" -> "cluster".
+func pkgRelKey(file string) string {
+	rel := filepath.ToSlash(file)
+	rel = strings.TrimPrefix(rel, "../")
+	return filepath.ToSlash(filepath.Dir(rel))
+}
+
+// TestNoDirectUnixSocket is the #2608 socket-factory canary. It walks EVERY
+// production (non-test) .go file under pkg/ with go/ast — not grep, so comments
+// may mention unix.Socket freely and import aliases of golang.org/x/sys/unix
+// are still caught — and flags any direct unix.Socket(...) CALL whose enclosing
+// function is not in allowedFunctions.
+//
+// This makes SOCK_CLOEXEC structural: a new raw/datagram socket added outside
+// linuxsock.Socket fails the suite loudly, so the fd-leak hardening (#2476/#2608)
+// cannot silently regress.
+func TestNoDirectUnixSocket(t *testing.T) {
+	var violations []string
+	scanned := 0
+
+	root := ".." // pkg/ (this test lives in pkg/linuxsock)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		scanned++
+
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", path, perr)
+		}
+
+		// Resolve the local identifier of the golang.org/x/sys/unix import,
+		// including aliases. A dot-import defeats the selector match — reject
+		// it outright.
+		unixName := ""
+		for _, imp := range f.Imports {
+			ip, _ := strconv.Unquote(imp.Path.Value)
+			if ip != "golang.org/x/sys/unix" {
+				continue
+			}
+			unixName = "unix"
+			if imp.Name != nil {
+				unixName = imp.Name.Name
+				if unixName == "." {
+					violations = append(violations,
+						fmt.Sprintf("%s: dot-import of unix defeats the Socket canary", path))
+				}
+			}
+		}
+		if unixName == "" || unixName == "_" || unixName == "." {
+			return nil
+		}
+
+		pkgRel := pkgRelKey(path)
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if _, allowed := allowedFunctions[funcKey(pkgRel, fn)]; allowed {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Socket" {
+					return true
+				}
+				ident, ok := sel.X.(*ast.Ident)
+				if !ok || ident.Name != unixName {
+					return true
+				}
+				violations = append(violations, fmt.Sprintf(
+					"%s: direct %s.Socket call in %s — use linuxsock.Socket so SOCK_CLOEXEC is forced (the raw fd is otherwise inherited by every fork-exec); see docs/engineering-style.md and #2476/#2608",
+					fset.Position(call.Pos()), unixName, funcKey(pkgRel, fn)))
+				return true
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	// Self-test guard: a walk bug that scans nothing would make this canary
+	// vacuously pass.
+	t.Logf("scanned %d production .go files under pkg/", scanned)
+	if scanned == 0 {
+		t.Fatal("canary scanned 0 files — the repo walk is broken")
+	}
+
+	for _, v := range violations {
+		t.Error(v)
+	}
+}

--- a/pkg/linuxsock/linuxsock.go
+++ b/pkg/linuxsock/linuxsock.go
@@ -1,0 +1,34 @@
+// Package linuxsock centralizes raw/datagram socket creation so that
+// close-on-exec is non-optional.
+//
+// Go's net package sets O_CLOEXEC on every fd it creates, but a raw
+// unix.Socket(2) does NOT — the fd is left inheritable. xpfd fork-execs
+// helpers constantly (frr-reload.py, swanctl, DHCP/script helpers), so any
+// inheritable raw AF_PACKET / raw-ICMP / datagram fd leaks into those children:
+// an fd leak and a security boundary issue (a child could read or inject raw
+// frames on the interface). #2476 fixed the VRRP receiver in isolation; this
+// package makes the policy structural for every sibling socket so a new direct
+// unix.Socket call site fails the canary test (see linuxsock_canary_test.go).
+//
+// The single Socket helper ORs unix.SOCK_CLOEXEC into the type argument so the
+// fd is created close-on-exec ATOMICALLY at socket(2) time. The atomic OR-into-
+// type is deliberate: a separate post-creation fcntl(FD_CLOEXEC) races a
+// concurrent fork-exec between the two syscalls, and an inherited fd in that
+// window is exactly the leak we are closing.
+package linuxsock
+
+import "golang.org/x/sys/unix"
+
+// socketFn is the socket(2) entry point. It is a package var so tests can
+// intercept the call and assert the type flags (notably SOCK_CLOEXEC) without
+// needing CAP_NET_RAW or a real socket. Production uses unix.Socket.
+var socketFn = unix.Socket
+
+// Socket creates a socket with SOCK_CLOEXEC forced into the type argument.
+//
+// Callers pass the bare type (e.g. unix.SOCK_RAW, unix.SOCK_DGRAM); they must
+// NOT pass SOCK_CLOEXEC themselves and must NOT call unix.Socket directly. The
+// returned fd is close-on-exec, so it is never inherited by an exec'd child.
+func Socket(domain, typ, proto int) (int, error) {
+	return socketFn(domain, typ|unix.SOCK_CLOEXEC, proto)
+}

--- a/pkg/linuxsock/linuxsock_test.go
+++ b/pkg/linuxsock/linuxsock_test.go
@@ -1,0 +1,67 @@
+package linuxsock
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestSocketForcesCloexec asserts the factory ORs SOCK_CLOEXEC into the type
+// argument at the socket(2) call site. It intercepts the socketFn seam so it
+// captures the EXACT flags the helper passes, without needing CAP_NET_RAW or a
+// real socket. Reverting the `typ|unix.SOCK_CLOEXEC` to a bare `typ` makes
+// gotType lack SOCK_CLOEXEC and this test fails (fail-on-revert).
+func TestSocketForcesCloexec(t *testing.T) {
+	orig := socketFn
+	defer func() { socketFn = orig }()
+
+	var gotType int
+	called := false
+	socketFn = func(domain, typ, proto int) (int, error) {
+		gotType = typ
+		called = true
+		return -1, unix.EPERM // do not actually create an fd
+	}
+
+	for _, tc := range []struct {
+		name string
+		typ  int
+	}{
+		{"raw", unix.SOCK_RAW},
+		{"dgram", unix.SOCK_DGRAM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called = false
+			gotType = 0
+			_, _ = Socket(unix.AF_INET, tc.typ, 0)
+			if !called {
+				t.Fatal("socketFn seam was not invoked")
+			}
+			if gotType&unix.SOCK_CLOEXEC == 0 {
+				t.Fatalf("socket type %#x missing SOCK_CLOEXEC", gotType)
+			}
+			if gotType&^unix.SOCK_CLOEXEC != tc.typ {
+				t.Fatalf("socket type %#x altered the base type %#x", gotType, tc.typ)
+			}
+		})
+	}
+}
+
+// TestSocketRealFDIsCloexec creates a real socket and asserts the kernel set
+// FD_CLOEXEC on it. SOCK_DGRAM/IPPROTO_UDP needs no privilege, so this runs
+// unprivileged; if the platform still rejects it (sandbox), skip cleanly.
+func TestSocketRealFDIsCloexec(t *testing.T) {
+	fd, err := Socket(unix.AF_INET, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
+	if err != nil {
+		t.Skipf("cannot create socket in this environment: %v", err)
+	}
+	defer unix.Close(fd)
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatalf("fd flags %#x missing FD_CLOEXEC", flags)
+	}
+}

--- a/pkg/lldp/lldp.go
+++ b/pkg/lldp/lldp.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/psaab/xpf/pkg/linuxsock"
 	"golang.org/x/sys/unix"
 )
 
@@ -125,7 +126,7 @@ var newIfSessionFn = newIfSession
 // newIfSession opens and binds the RX socket and opens the TX socket for one
 // interface. Both fds live for the Apply generation and are released by close().
 func newIfSession(iface *net.Interface) (*ifSession, error) {
-	rxFD, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(etherTypeLLDP)))
+	rxFD, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(etherTypeLLDP)))
 	if err != nil {
 		return nil, fmt.Errorf("lldp: rx socket: %w", err)
 	}
@@ -139,7 +140,7 @@ func newIfSession(iface *net.Interface) (*ifSession, error) {
 	// No SO_RCVTIMEO: recv blocks indefinitely and is unblocked by closing the
 	// fd in close(), not by a polling timeout.
 
-	txFD, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
+	txFD, err := linuxsock.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
 	if err != nil {
 		unix.Close(rxFD)
 		return nil, fmt.Errorf("lldp: tx socket: %w", err)


### PR DESCRIPTION
Closes #2608

## Summary

- A raw `unix.Socket(2)` is **not** close-on-exec by default (unlike Go `net` sockets, which set `O_CLOEXEC` on every fd). xpfd fork-execs helpers constantly (`frr-reload.py`, `swanctl`, DHCP/script helpers), so every bare raw `AF_PACKET`/raw-ICMP/datagram fd leaked into those children — an fd leak **and** a raw-frame security boundary. #2476 fixed only the VRRP receiver; this closes the still-leaking siblings structurally.
- New `pkg/linuxsock` SSOT factory `Socket(domain, typ, proto)` ORs `unix.SOCK_CLOEXEC` into the type atomically at `socket(2)` time (no fcntl race window).
- All 16 direct call sites across 5 packages migrated to `linuxsock.Socket`.
- `TestNoDirectUnixSocket` go/ast canary walks every production `.go` under `pkg/` and fails the suite on a new direct `unix.Socket(...)` call outside the allowlist — the hardening can't silently regress.

## (socket, missing-option) pairs fixed

All were missing `SOCK_CLOEXEC`:

| Site | Socket |
|---|---|
| `pkg/cluster/garp.go` ×6 | AF_PACKET SOCK_RAW — ARP / IPv6 NA bursts |
| `pkg/lldp/lldp.go` ×2 | AF_PACKET SOCK_RAW — LLDP rx / tx |
| `pkg/daemon/daemon_ha_fabric.go` ×3 | AF_INET/AF_INET6 SOCK_RAW — ICMP/ICMPv6 fabric probes |
| `pkg/dataplane/userspace/process.go` ×4 | AF_INET/AF_INET6 SOCK_RAW ICMP + SOCK_DGRAM UDP — NAPI probes |
| `pkg/dhcprelay/l2send_linux.go` ×1 | AF_PACKET SOCK_RAW — DHCP-reply L2 send |

Allowlisted (justified direct callers): `linuxsock.Socket` (the wrapper itself) and `pkg/vrrp::openAfPacketReceiver` (the pre-#2476 site — already ORs `SOCK_CLOEXEC`, pinned by `pkg/vrrp/afpacket_cloexec_test.go`).

## Test plan

- [x] `pkg/linuxsock` factory test: seam-captured type asserts `SOCK_CLOEXEC` OR'd; real-fd `F_GETFD` asserts kernel `FD_CLOEXEC` (unprivileged SOCK_DGRAM/UDP; skips cleanly if sandbox rejects).
- [x] `TestNoDirectUnixSocket` canary: passes on the migrated tree.
- [x] **Fail-on-revert (canary):** revert one call site → `unix.Socket` ⇒ RED with exact `file:line` + function. Restored.
- [x] **Fail-on-revert (factory):** drop the `typ|unix.SOCK_CLOEXEC` OR ⇒ both the seam test (`missing SOCK_CLOEXEC`) and the real-fd test (`missing FD_CLOEXEC`) go RED. Restored.

## Gates

- `go build ./...` — clean
- `gofmt -l` (touched) — clean
- `go vet` (affected packages) — clean
- `go test ./pkg/linuxsock/ ./pkg/cluster/ ./pkg/lldp/ ./pkg/dhcprelay/ ./pkg/daemon/... ./pkg/dataplane/...` — green
- Pre-existing unrelated flake: `pkg/ra TestT2a_ChangedConfigApplyNeverTwoLiveConns` fails on clean `origin/master` too (a `bind aborted` NDP-connect flake; not touched by this PR — no socket sites in `pkg/ra`).

## Refs

- #2608 (this), #2476 (VRRP receiver, established the policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi