### PR TITLE
cluster: count and surface GARP/NDP burst follow-up send errors (#2623)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-06-25 — #2623: GARP/NDP burst follow-up sends now count + surface errors
+
+- **Timestamp**: 2026-06-25
+- **Action**: The failover GARP / unsolicited-NA bursts
+  (`SendGratuitousARPBurst` / `SendGratuitousIPv6Burst`) sent the first
+  frame synchronously (error returned) but the background follow-up
+  goroutine ignored every send error (`unix.Sendto(...) //nolint:errcheck`)
+  while the log reported `total=count` — masking a real failover-reliability
+  degradation when a transient link/qdisc/socket error appears after the
+  first frame. Fix per issue prescription: count follow-up send failures,
+  bump an exported `burstSendErrors` atomic counter (accessor
+  `BurstSendErrors()`), log per-send at Debug (per CLAUDE.md logging rules —
+  no flood) and a single Warn after the burst if any frame failed. The loop
+  never aborts on a transient error. Extracted the two goroutine bodies into
+  `runARPBurstFollowups` / `runNABurstFollowups` and added a `burstSend`
+  package-var seam so a fail-on-revert test can inject a sender that succeeds
+  once then fails. Async-burst timing, non-blocking first send, and the
+  #2081/#2082 epoch/dampener storm-control gates (in pkg/vrrp) are unchanged.
+- **File(s)**: pkg/cluster/garp.go, pkg/cluster/garp_burst_errors_test.go,
+  pkg/cluster/README.md, _Log.md
+- **Validation**: go build ./...; gofmt -l clean; go vet; go test -race
+  ./pkg/cluster/... ./pkg/vrrp/... PASS. Fail-on-revert proven: reverting the
+  ARP helper to the error-ignoring form makes burstSendErrors delta=0 and
+  TestARPBurstFollowupsCountFailures goes RED. HA code — PARENT runs
+  make test-failover before merge.
+
 ## 2026-06-25 — #2412: GRE local-origin thread eventfd wake (kill 1ms busy-poll)
 
 - **Timestamp**: 2026-06-25

--- a/pkg/cluster/README.md
+++ b/pkg/cluster/README.md
@@ -67,7 +67,17 @@ locating any symbol below is now a matter of opening the named file.
   `InterfaceMonitorInfo`, `RethInfo`, `InterfacesInput`) —
   `status.go`.
 - `triggerGARP` (no-op/log hook today — native VRRP owns GARP),
-  plus the gratuitous-ARP burst sender — `garp.go`.
+  plus the gratuitous-ARP / unsolicited-NA burst senders — `garp.go`.
+  `SendGratuitousARPBurst` / `SendGratuitousIPv6Burst` send the first
+  frame synchronously (error returned to the caller) and the remaining
+  follow-up frames at 50ms intervals in a background goroutine. The
+  follow-up sends are the failover-convergence reliability mechanism, so
+  their send errors are NOT dropped: each failed follow-up frame bumps the
+  package-level `burstSendErrors` counter (exported via `BurstSendErrors()`
+  for observability) and is logged at Debug; a single Warn fires after the
+  burst if any frame failed. The loop never aborts on a transient error
+  (#2623). The burst remains non-blocking and the #2081/#2082 epoch +
+  dampener storm-control gates live in `pkg/vrrp`, untouched by this.
 - `SessionSync` — `sync.go`, `sync_conn.go`, `sync_bulk.go`, `runtime.go`. HA
   session replication. After #1518, `NewSessionSync`, `NewDualSessionSync`,
   and `SetRuntime` accept the narrow `clusterRuntime` (see `runtime.go`) —

--- a/pkg/cluster/garp.go
+++ b/pkg/cluster/garp.go
@@ -5,11 +5,35 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/linuxsock"
 	"golang.org/x/sys/unix"
 )
+
+// burstSendErrors counts gratuitous ARP / unsolicited NA follow-up frames
+// (the background-goroutine adverts that aid neighbor/switch convergence
+// during failover) that failed to send. The first frame of every burst is
+// sent synchronously and its error is returned to the caller; this counter
+// only accumulates the follow-up failures that the background goroutine
+// would otherwise drop on the floor. Exported via BurstSendErrors for
+// observability (#2623).
+var burstSendErrors atomic.Uint64
+
+// BurstSendErrors returns the cumulative number of failover GARP/NA burst
+// follow-up frames that failed to transmit. A non-zero, climbing value means
+// the failover-convergence adverts are being dropped after the first frame —
+// the logs that report the full burst count are not proof of delivery.
+func BurstSendErrors() uint64 { return burstSendErrors.Load() }
+
+// burstSend transmits one burst follow-up frame. It is a package var so tests
+// can inject a sender that succeeds once then fails, proving the follow-up
+// error handling (count + warn + counter) fires without intercepting the
+// synchronous first send. Production wraps unix.Sendto.
+var burstSend = func(fd int, pkt []byte, addr unix.Sockaddr) error {
+	return unix.Sendto(fd, pkt, 0, addr)
+}
 
 // SendGratuitousARP sends gratuitous ARP on the specified interface for the
 // given IP address. Sends both ARP Request and ARP Reply variants — some
@@ -147,21 +171,54 @@ func SendGratuitousARPBurst(iface string, ip net.IP, count int) error {
 	slog.Info("cluster: sent gratuitous ARP burst (1st pair)",
 		"interface", iface, "ip", ip4.String(), "total", count)
 
-	// Schedule remaining pairs in background.
+	// Schedule remaining pairs in background. Follow-up sends are the
+	// reliability mechanism for neighbor/switch convergence; a send error
+	// after the first frame means the burst that the log already reported
+	// as `total=count` did not fully go out. Count the failures, bump the
+	// exported counter, and warn ONCE after the loop (never per-iteration —
+	// per CLAUDE.md logging rules a per-send log here would flood). The
+	// loop never aborts: a transient error on one frame must not suppress
+	// the remaining adverts that may still reach the LAN.
 	if count > 1 {
-		go func() {
-			defer unix.Close(fd)
-			for i := 1; i < count; i++ {
-				time.Sleep(50 * time.Millisecond)
-				unix.Sendto(fd, reqPkt, 0, &addr) //nolint:errcheck
-				unix.Sendto(fd, repPkt, 0, &addr) //nolint:errcheck
-			}
-		}()
+		go runARPBurstFollowups(fd, iface, ip4.String(), reqPkt, repPkt, addr, count)
 	} else {
 		unix.Close(fd)
 	}
 
 	return nil
+}
+
+// runARPBurstFollowups sends the (count-1) follow-up GARP pairs at 50ms
+// intervals, then closes fd. Extracted from SendGratuitousARPBurst so the
+// follow-up error handling is unit-testable via the burstSend seam without a
+// raw socket. Each failed frame bumps burstSendErrors and is logged at Debug
+// (per-iteration logging at higher levels would flood — CLAUDE.md); a single
+// Warn fires after the loop if any frame failed. The loop never aborts so a
+// transient error does not suppress the remaining adverts.
+func runARPBurstFollowups(fd int, iface, ip string, reqPkt, repPkt []byte, addr unix.SockaddrLinklayer, count int) {
+	defer unix.Close(fd)
+	var failed int
+	for i := 1; i < count; i++ {
+		time.Sleep(50 * time.Millisecond)
+		if err := burstSend(fd, reqPkt, &addr); err != nil {
+			failed++
+			slog.Debug("cluster: GARP burst follow-up send failed",
+				"interface", iface, "ip", ip,
+				"frame", "request", "iter", i, "err", err)
+		}
+		if err := burstSend(fd, repPkt, &addr); err != nil {
+			failed++
+			slog.Debug("cluster: GARP burst follow-up send failed",
+				"interface", iface, "ip", ip,
+				"frame", "reply", "iter", i, "err", err)
+		}
+	}
+	if failed > 0 {
+		burstSendErrors.Add(uint64(failed))
+		slog.Warn("cluster: GARP burst follow-up sends failed",
+			"interface", iface, "ip", ip,
+			"failed", failed, "total_frames", (count-1)*2)
+	}
 }
 
 // SendARPProbe sends a standard ARP Request for targetIP with senderIP as
@@ -408,20 +465,44 @@ func SendGratuitousIPv6Burst(iface string, ip net.IP, count int) error {
 	slog.Info("cluster: sent unsolicited IPv6 NA burst (1st)",
 		"interface", iface, "ip", ip6.String(), "total", count)
 
-	// Schedule remaining NAs in background.
+	// Schedule remaining NAs in background. As with the GARP burst above,
+	// follow-up sends are the failover-convergence reliability mechanism;
+	// count failures, bump the exported counter, and warn ONCE after the
+	// loop (never per-iteration). The loop never aborts on a transient
+	// error so the remaining NAs still get a chance to reach the LAN.
 	if count > 1 {
-		go func() {
-			defer unix.Close(fd)
-			for i := 1; i < count; i++ {
-				time.Sleep(50 * time.Millisecond)
-				unix.Sendto(fd, pkt, 0, &addr) //nolint:errcheck
-			}
-		}()
+		go runNABurstFollowups(fd, iface, ip6.String(), pkt, addr, count)
 	} else {
 		unix.Close(fd)
 	}
 
 	return nil
+}
+
+// runNABurstFollowups sends the (count-1) follow-up unsolicited NAs at 50ms
+// intervals, then closes fd. Extracted from SendGratuitousIPv6Burst for the
+// same reason as runARPBurstFollowups: the follow-up error handling is
+// unit-testable via the burstSend seam. Each failed NA bumps burstSendErrors
+// and is logged at Debug; a single Warn fires after the loop if any failed.
+// The loop never aborts on a transient error.
+func runNABurstFollowups(fd int, iface, ip string, pkt []byte, addr unix.SockaddrLinklayer, count int) {
+	defer unix.Close(fd)
+	var failed int
+	for i := 1; i < count; i++ {
+		time.Sleep(50 * time.Millisecond)
+		if err := burstSend(fd, pkt, &addr); err != nil {
+			failed++
+			slog.Debug("cluster: NA burst follow-up send failed",
+				"interface", iface, "ip", ip,
+				"iter", i, "err", err)
+		}
+	}
+	if failed > 0 {
+		burstSendErrors.Add(uint64(failed))
+		slog.Warn("cluster: NA burst follow-up sends failed",
+			"interface", iface, "ip", ip,
+			"failed", failed, "total_frames", count-1)
+	}
 }
 
 // buildUnsolicitedNA constructs a raw Ethernet + IPv6 + ICMPv6 Neighbor

--- a/pkg/cluster/garp_burst_errors_test.go
+++ b/pkg/cluster/garp_burst_errors_test.go
@@ -1,0 +1,104 @@
+package cluster
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// withBurstSend swaps the burstSend seam for the duration of fn and restores
+// it, also resetting the burstSendErrors counter so each test sees a clean
+// baseline. It returns the counter delta observed during fn.
+func withBurstSend(t *testing.T, sender func(fd int, pkt []byte, addr unix.Sockaddr) error, fn func()) uint64 {
+	t.Helper()
+	orig := burstSend
+	before := burstSendErrors.Load()
+	burstSend = sender
+	defer func() { burstSend = orig }()
+	fn()
+	return burstSendErrors.Load() - before
+}
+
+// failAfterN returns a sender that succeeds for the first n calls then fails
+// for every subsequent call, recording how many frames it was asked to send.
+func failAfterN(n int, frames *int) func(int, []byte, unix.Sockaddr) error {
+	var mu sync.Mutex
+	calls := 0
+	return func(_ int, _ []byte, _ unix.Sockaddr) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		*frames = calls
+		if calls <= n {
+			return nil
+		}
+		return errors.New("injected send failure")
+	}
+}
+
+// TestARPBurstFollowupsCountFailures proves the GARP burst follow-up loop
+// counts per-frame send failures into burstSendErrors instead of dropping
+// them. With count=4 the loop sends (count-1)*2 = 6 follow-up frames; the
+// injected sender succeeds once then fails, so 5 frames fail.
+//
+// FAIL-ON-REVERT: if the //nolint:errcheck "ignore the error" behaviour is
+// restored (drop the burstSend result, never touch burstSendErrors), the
+// counter stays at 0 and this assertion goes RED.
+func TestARPBurstFollowupsCountFailures(t *testing.T) {
+	const count = 4
+	var frames int
+	delta := withBurstSend(t, failAfterN(1, &frames), func() {
+		// fd=-1: the helper's defer unix.Close(-1) returns EBADF, ignored.
+		runARPBurstFollowups(-1, "ge-0-0-2", "10.0.61.1", []byte{0x01}, []byte{0x02}, unix.SockaddrLinklayer{}, count)
+	})
+
+	wantFrames := (count - 1) * 2 // 6 follow-up frames attempted
+	if frames != wantFrames {
+		t.Fatalf("follow-up frames attempted = %d, want %d (loop must not abort on error)", frames, wantFrames)
+	}
+	wantFailed := uint64(wantFrames - 1) // first succeeds, rest fail
+	if delta != wantFailed {
+		t.Fatalf("burstSendErrors delta = %d, want %d (errors must be counted, not dropped)", delta, wantFailed)
+	}
+}
+
+// TestNABurstFollowupsCountFailures is the IPv6 unsolicited-NA equivalent.
+// count=4 -> (count-1) = 3 follow-up NAs; first succeeds, 2 fail.
+func TestNABurstFollowupsCountFailures(t *testing.T) {
+	const count = 4
+	var frames int
+	delta := withBurstSend(t, failAfterN(1, &frames), func() {
+		runNABurstFollowups(-1, "ge-0-0-2", "2001:559:8585:80::200", []byte{0x01}, unix.SockaddrLinklayer{}, count)
+	})
+
+	wantFrames := count - 1 // 3 follow-up NAs attempted
+	if frames != wantFrames {
+		t.Fatalf("follow-up NAs attempted = %d, want %d (loop must not abort on error)", frames, wantFrames)
+	}
+	wantFailed := uint64(wantFrames - 1) // first succeeds, rest fail
+	if delta != wantFailed {
+		t.Fatalf("burstSendErrors delta = %d, want %d (errors must be counted, not dropped)", delta, wantFailed)
+	}
+}
+
+// TestBurstFollowupsAllSucceedNoCount confirms the happy path leaves the
+// counter untouched — a clean failover must not report phantom send errors.
+func TestBurstFollowupsAllSucceedNoCount(t *testing.T) {
+	var frames int
+	delta := withBurstSend(t, failAfterN(1<<30, &frames), func() {
+		runARPBurstFollowups(-1, "ge-0-0-2", "10.0.61.1", []byte{0x01}, []byte{0x02}, unix.SockaddrLinklayer{}, 3)
+	})
+	if delta != 0 {
+		t.Fatalf("burstSendErrors delta = %d on all-success path, want 0", delta)
+	}
+}
+
+// TestBurstSendErrorsAccessor confirms the exported observability accessor
+// reflects the underlying atomic counter.
+func TestBurstSendErrorsAccessor(t *testing.T) {
+	if got, want := BurstSendErrors(), burstSendErrors.Load(); got != want {
+		t.Fatalf("BurstSendErrors() = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
Closes #2623

## Summary

- The failover GARP / unsolicited-NA bursts (`SendGratuitousARPBurst` /
  `SendGratuitousIPv6Burst`) send the first frame synchronously (error
  returned to the caller) but the background goroutine that emits the
  `(count-1)` follow-up frames at 50ms intervals ignored every send error
  (`unix.Sendto(...) //nolint:errcheck`) while the log reported
  `total=count`. A transient link/qdisc/socket error after the first
  frame silently dropped the convergence adverts while the logs claimed
  full delivery.
- Follow-up send failures are now counted into a package-level
  `burstSendErrors` atomic counter, exported via `BurstSendErrors()` for
  observability.
- Per-failed-send logging is at Debug (per CLAUDE.md logging rules — a
  per-send log at a higher level inside the burst loop would flood); a
  single Warn fires after the burst if any frame failed, with the failed
  count and total follow-up frame count.
- The loop never aborts on a transient error — a single failed frame must
  not suppress the remaining adverts that may still reach the LAN.

## Error-handling semantics

| Path | Behaviour |
|---|---|
| First (synchronous) frame fails | Error returned to caller (unchanged) |
| A follow-up frame fails | `burstSendErrors++`, Debug log, loop continues |
| Any follow-up failed | One Warn after the burst (`failed`, `total_frames`) |
| Clean burst | Counter untouched, no Warn |

The two goroutine bodies are extracted into `runARPBurstFollowups` /
`runNABurstFollowups`, and a `burstSend` package-var seam wraps
`unix.Sendto`, so the follow-up error handling is unit-testable without a
raw AF_PACKET socket or root.

**Unchanged:** async-burst timing, the synchronous non-blocking first
send, the critical-path `becomeMaster` ordering, and the #2081/#2082
epoch dedup + 500ms dampener storm-control gates (which live in
`pkg/vrrp`).

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l` clean on touched files
- [x] `go vet ./pkg/cluster/...`
- [x] `go test -race ./pkg/cluster/... ./pkg/vrrp/...` PASS
- [x] New fail-on-revert test (`garp_burst_errors_test.go`): injects a
      sender that succeeds once then fails; asserts the counter advances
      by the number of failed frames and the loop attempts every
      follow-up frame (no abort). Happy path asserts the counter stays 0.
- [x] **Fail-on-revert proven**: reverting the ARP helper to the
      error-ignoring form makes `burstSendErrors` delta = 0 and
      `TestARPBurstFollowupsCountFailures` goes RED; restored to GREEN.

## Note

This is HA/cluster code. `make test-failover` is required before merge
and is run by the integrator (PARENT), not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi