### PR TITLE
eventstream: render AppID on SESSION_CREATE + ingress ifindex on create/close (#2615)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15438,3 +15438,27 @@ top.
   pkg/config/schema_security.go, pkg/ipsec/policy.go,
   pkg/config/parser_security_test.go, pkg/ipsec/ipsec_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2615 — render AppID (create) + ingress ifindex (create+close)
+  into the RT_FLOW SESSION_CREATE/CLOSE eventstream frames. The
+  `[128:132]` ingress-ifindex and `[132:134]` application-id wire slots
+  already existed and the Go `pkg/logging/ringbuf.go` decoder already reads
+  them for every RT_FLOW frame, so this is a RENDER-ONLY fix — NO
+  wire-format change (no protocol_wire_v1.json regen). The create encoder
+  left both slots 0 (→ `application="UNKNOWN"` / `packet-incoming-interface=
+  "N/A"`); the close encoder carried AppID (#2520) but left the ifindex 0.
+  Threaded `forwarding.app_catalog.lookup(...)` (mirroring the #2520
+  close-side fix) + `ident.ifindex as u32` (kernel ifindex always positive,
+  loss-free; full-width u32, distinct from the i16 egress/TX #2467 bug) into
+  both `emit_session_create_rt_flow` and `emit_session_close_rt_flow`. Added
+  fail-on-revert tests on both the codec (wire-layout) and emit paths
+  (proved RED on revert — 4 tests fail when the slot writes are reverted —
+  then restored). Go contract tests (pkg/daemon eventstream + pkg/logging)
+  green.
+  **File(s)**: userspace-dp/src/event_stream/codec.rs,
+  userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/afxdp/session_delta.rs,
+  userspace-dp/src/event_stream/codec_tests.rs,
+  userspace-dp/src/event_stream/tests.rs,
+  userspace-dp/src/event_stream/README.md, _Log.md

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -179,7 +179,13 @@ pub(super) fn flush_session_deltas(
                     delta.key.src_port,
                     delta.key.dst_port,
                 );
-                es.emit_session_close_rt_flow(delta, app_id);
+                // #2615: thread the closing binding's ingress ifindex so the
+                // SESSION_CLOSE RT_FLOW record shows the admitting interface
+                // (`packet-incoming-interface`) instead of "N/A". `ident` is
+                // the binding draining this delta; its ifindex is the ingress
+                // interface. A kernel ifindex is always positive, so the
+                // i32 -> u32 cast is loss-free.
+                es.emit_session_close_rt_flow(delta, app_id, ident.ifindex as u32);
             }
             // #2508: a session admitted by a policy configured with
             // `then log session-init` emits an RT_FLOW SESSION_CREATE frame
@@ -190,7 +196,20 @@ pub(super) fn flush_session_deltas(
             // SESSION_CLOSE syslog record is gated on the Go side (via the
             // frame's gate byte) because flowexport still needs every close.
             if delta.kind == SessionDeltaKind::Open && delta.metadata.log_session_init {
-                es.emit_session_create_rt_flow(delta);
+                // #2615: resolve the AppID for the new 5-tuple with the SAME
+                // app_catalog.lookup the forwarding hot path runs (mirroring
+                // the #2520 close-side fix), so the SESSION_CREATE RT_FLOW
+                // record carries the application instead of UNKNOWN. 0 (no
+                // match) keeps the prior UNKNOWN rendering. The ingress
+                // ifindex comes from the admitting binding (`ident`); a kernel
+                // ifindex is always positive so the i32 -> u32 cast is
+                // loss-free.
+                let app_id = forwarding.app_catalog.lookup(
+                    delta.key.protocol,
+                    delta.key.src_port,
+                    delta.key.dst_port,
+                );
+                es.emit_session_create_rt_flow(delta, app_id, ident.ifindex as u32);
             }
         }
         if let Ok(mut recent) = recent_session_deltas.lock() {

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -41,12 +41,20 @@ periodic ACK from the daemon.
   (#2520) the cold-path RT_FLOW emitters also populate the `application id`
   slot (offset 132, little-endian u16) instead of hardcoding 0. The
   `emit_policy_deny_event` / `emit_filter_log_event` call sites and the
-  `emit_session_close_rt_flow` caller resolve the AppID with the SAME
+  `emit_session_close_rt_flow` (#2520) AND `emit_session_create_rt_flow`
+  (#2615) callers resolve the AppID with the SAME
   `app_catalog.lookup(protocol, src_port, dst_port)` the forwarding hot
   path runs when it stamps the conntrack entry on session create (see
   `afxdp::event_emit::resolve_flow_app_id`), so a policy-deny / filter-log /
-  session-close record shows `application=<name>` for a resolvable 5-tuple
-  instead of `application="UNKNOWN"`. 0 stays the UNKNOWN sentinel when the
+  session-create / session-close record shows `application=<name>` for a
+  resolvable 5-tuple instead of `application="UNKNOWN"`.
+  (#2615) the SESSION_CREATE and SESSION_CLOSE frames ALSO populate the
+  ingress ifindex slot (offset 128, little-endian u32) from the admitting
+  binding's `ident.ifindex`, so the Go decoder resolves
+  `packet-incoming-interface=<name>` instead of `"N/A"`. A kernel ifindex
+  is always positive, so the i32 -> u32 cast is loss-free, and this is a
+  full-width u32 slot distinct from the i16 egress/TX ifindex width bug
+  (#2467). 0 stays the UNKNOWN sentinel when the
   catalog has no match. The screen emitters (`emit_screen_drop_event` /
   `emit_screen_alarm_event`) deliberately keep 0: the screen parse-error
   fail-closed path (#2146) and the L4-less screen drops legitimately lack a
@@ -102,7 +110,13 @@ periodic ACK from the daemon.
   ONLY when the admitting policy requested `then log session-init`, carries
   the same 136-byte payload with the event-type byte set to SESSION_OPEN
   (1, rendered as RT_FLOW_SESSION_CREATE on the Go side), and always sets
-  the gate byte. (#2512) like the close frame, the create frame rides the
+  the gate byte. (#2615) the create frame now also threads the resolved
+  application id (offset 132) and the admitting binding's ingress ifindex
+  (offset 128), mirroring the close-side #2520/#2615 fix — so a logged
+  session-create no longer logs `application="UNKNOWN"` /
+  `packet-incoming-interface="N/A"` for a resolvable session. The volume
+  counters stay 0 (a create has no volume yet). (#2512) like the close
+  frame, the create frame rides the
   per-kind budget path under `DataplaneEventKind::SessionCreate` (counters
   `event_stream_session_create_{sent,dropped}`), not a bare `try_send`.
   `MSG_FILTER_LOG` intentionally reuses the RT_FLOW `reason` byte as

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -484,6 +484,7 @@ impl EventFrame {
         created_unix_secs: u32,
         close_unix_ns: u64,
         application_id: u16,
+        ingress_ifindex: u32,
     ) -> Self {
         let mut buf = [0u8; 256];
         let base = FRAME_HEADER_SIZE;
@@ -530,7 +531,12 @@ impl EventFrame {
         // StartTime; 0 means "unknown" and triggers the packet-count fallback.
         buf[base + 108..base + 112].copy_from_slice(&created_unix_secs.to_le_bytes());
         // [112:120] rev packets, [120:128] rev bytes — 0 (#2501).
-        // [128:132] ingress ifindex — 0 (per-close ifindex not threaded).
+        // [128:132] ingress ifindex — #2615: the closing binding's interface
+        // (LITTLE-endian u32, decoded by the Go side as
+        // `binary.LittleEndian.Uint32` -> resolved to the RT_FLOW
+        // `packet-incoming-interface`). 0 keeps the prior "N/A" rendering for
+        // a session whose ingress interface could not be resolved.
+        buf[base + 128..base + 132].copy_from_slice(&ingress_ifindex.to_le_bytes());
         // [132:134] application id — #2520: the AppID resolved for the closing
         // session's 5-tuple (the caller runs the same app_catalog.lookup the
         // forwarding hot path used to stamp the conntrack entry). 0 stays the
@@ -571,6 +577,14 @@ impl EventFrame {
     /// frame when the gate is open (no flowexport consumer of opens — there is
     /// nothing to keep unconditional). The Go logEvent path renders it as the
     /// RT_FLOW_SESSION_CREATE syslog record.
+    ///
+    /// #2615: the create frame now also threads the ingress ifindex (the
+    /// admitting binding's interface, written to [128:132]) and the resolved
+    /// application id ([132:134]). The Go decoder already reads BOTH slots for
+    /// every RT_FLOW frame (`pkg/logging/ringbuf.go`), so this is a
+    /// render-only fix — no wire-format change. A 0 in either slot keeps the
+    /// prior `packet-incoming-interface="N/A"` / `application="UNKNOWN"`
+    /// rendering for sessions whose interface/app could not be resolved.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn encode_session_create_rt_flow(
         seq: u64,
@@ -586,6 +600,8 @@ impl EventFrame {
         nat_dst_port: u16,
         ingress_zone_id: u16,
         egress_zone_id: u16,
+        ingress_ifindex: u32,
+        application_id: u16,
     ) -> Self {
         let mut buf = [0u8; 256];
         let base = FRAME_HEADER_SIZE;
@@ -620,8 +636,20 @@ impl EventFrame {
         // [104:106] nat src port, [106:108] nat dst port — BIG-endian.
         buf[base + 104..base + 106].copy_from_slice(&nat_src_port.to_be_bytes());
         buf[base + 106..base + 108].copy_from_slice(&nat_dst_port.to_be_bytes());
-        // [108:135] counters / ifindex / appid / close-reason all 0 for a
-        // create. [135] #2508 SYSLOG gate — always set (producer-gated).
+        // [108:112] created stamp, [112:128] rev counters — 0 (a create has
+        // no volume yet).
+        // [128:132] ingress ifindex — #2615: the admitting binding's
+        // interface (LITTLE-endian u32, decoded by the Go side as
+        // `binary.LittleEndian.Uint32` -> resolved to the RT_FLOW
+        // `packet-incoming-interface`). 0 keeps the prior "N/A" rendering.
+        buf[base + 128..base + 132].copy_from_slice(&ingress_ifindex.to_le_bytes());
+        // [132:134] application id — #2615: the AppID resolved for the new
+        // session's 5-tuple (caller runs the same app_catalog.lookup the
+        // forwarding hot path used to stamp the conntrack entry, mirroring the
+        // #2520 close-side fix). 0 stays the UNKNOWN sentinel.
+        buf[base + 132..base + 134].copy_from_slice(&application_id.to_le_bytes());
+        // [134] close reason — 0 (a create has none).
+        // [135] #2508 SYSLOG gate — always set (producer-gated).
         buf[base + 135] = RT_FLOW_LOG_SYSLOG;
 
         write_header(

--- a/userspace-dp/src/event_stream/codec_tests.rs
+++ b/userspace-dp/src/event_stream/codec_tests.rs
@@ -280,6 +280,7 @@ fn test_encode_session_close_rt_flow_v4_wire_layout() {
         1_700_000_000,   // #2465: created Unix seconds
         1_700_000_123_000_000_000, // #2465: close instant Unix ns
         7,               // #2520: application id
+        42,              // #2615: ingress ifindex
     );
 
     assert_eq!(frame.data[4], MSG_SESSION_CLOSE_RT_FLOW);
@@ -335,6 +336,12 @@ fn test_encode_session_close_rt_flow_v4_wire_layout() {
     // encoder to leave it 0 makes this assertion fail (and the close record
     // logs application="UNKNOWN").
     assert_eq!(u16::from_le_bytes([p[132], p[133]]), 7);
+    // #2615 fail-on-revert: the ingress ifindex rides the [128:132] slot
+    // (little-endian u32), the slot the Go DecodeRawEventRecord reads to
+    // resolve packet-incoming-interface. Reverting the encoder to leave it 0
+    // makes this assertion fail (and the close record logs
+    // packet-incoming-interface="N/A").
+    assert_eq!(u32::from_le_bytes(p[128..132].try_into().unwrap()), 42);
 }
 
 #[test]
@@ -358,6 +365,7 @@ fn test_encode_session_close_rt_flow_v6() {
         0,     // #2465: created Unix seconds (unknown → fallback)
         0,     // #2465: close instant Unix ns
         0,     // #2520: application id (unknown)
+        0,     // #2615: ingress ifindex (unknown)
     );
     let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
     assert_eq!(p[52], RT_FLOW_EVENT_SESSION_CLOSE);
@@ -397,6 +405,7 @@ fn test_session_close_rt_flow_log_gate_byte() {
             0, // #2465: created Unix seconds
             0, // #2465: close instant Unix ns
             0, // #2520: application id
+            0, // #2615: ingress ifindex
         )
     };
     let gated_off = mk(false);
@@ -435,6 +444,8 @@ fn test_session_create_rt_flow_wire_layout() {
         0,
         TEST_TRUST_ZONE_ID,
         TEST_UNTRUST_ZONE_ID,
+        77, // #2615: ingress ifindex
+        9,  // #2615: application id
     );
     assert_eq!(frame.data[4], MSG_SESSION_CREATE_RT_FLOW);
     let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
@@ -454,6 +465,15 @@ fn test_session_create_rt_flow_wire_layout() {
     // NAT source slot populated.
     assert_eq!(&p[72..76], &Ipv4Addr::new(172, 16, 80, 8).octets());
     assert_eq!(u16::from_be_bytes([p[104], p[105]]), 40000);
+    // #2615 fail-on-revert: the SESSION_CREATE frame now threads the ingress
+    // ifindex ([128:132], LE u32) and the resolved application id
+    // ([132:134], LE u16) — the same slots the Go DecodeRawEventRecord reads
+    // to resolve packet-incoming-interface and application=. Reverting the
+    // encoder to leave either slot 0 makes these assertions fail (and the
+    // create record logs packet-incoming-interface="N/A" / application=
+    // "UNKNOWN").
+    assert_eq!(u32::from_le_bytes(p[128..132].try_into().unwrap()), 77);
+    assert_eq!(u16::from_le_bytes([p[132], p[133]]), 9);
 }
 
 #[test]

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -475,7 +475,15 @@ impl EventStreamWorkerHandle {
     /// by the caller (`flush_session_deltas`) via the same `app_catalog.lookup`
     /// the forwarding hot path runs — #2520. 0 means UNKNOWN (no catalog
     /// match), the unchanged behavior.
-    pub(crate) fn emit_session_close_rt_flow(&self, delta: &SessionDelta, app_id: u16) {
+    /// `ingress_ifindex` is the closing binding's interface index (#2615); the
+    /// Go side resolves it to the RT_FLOW `packet-incoming-interface`. 0 keeps
+    /// the prior "N/A" rendering.
+    pub(crate) fn emit_session_close_rt_flow(
+        &self,
+        delta: &SessionDelta,
+        app_id: u16,
+        ingress_ifindex: u32,
+    ) {
         if delta.kind != SessionDeltaKind::Close {
             return;
         }
@@ -532,6 +540,10 @@ impl EventStreamWorkerHandle {
                     // slot so SESSION_CLOSE RT_FLOW records (and the
                     // NetFlow/IPFIX exporters) show the application.
                     app_id,
+                    // #2615: carry the closing binding's ingress ifindex in
+                    // the [128:132] wire slot so the record shows the
+                    // admitting interface instead of "N/A".
+                    ingress_ifindex,
                 )
             },
         );
@@ -544,7 +556,16 @@ impl EventStreamWorkerHandle {
     /// `delta.metadata.log_session_init` is set. The frame rides the same raw
     /// dataplane-event channel and is formatted as RT_FLOW_SESSION_CREATE by
     /// the Go logEvent path. Best-effort (`try_send`).
-    pub(crate) fn emit_session_create_rt_flow(&self, delta: &SessionDelta) {
+    /// #2615: `app_id` is the application resolved for the new session's
+    /// 5-tuple (caller runs the same `app_catalog.lookup` the close path uses,
+    /// mirroring #2520) and `ingress_ifindex` is the admitting binding's
+    /// interface index. 0 in either keeps the prior UNKNOWN / N/A rendering.
+    pub(crate) fn emit_session_create_rt_flow(
+        &self,
+        delta: &SessionDelta,
+        app_id: u16,
+        ingress_ifindex: u32,
+    ) {
         if delta.kind != SessionDeltaKind::Open {
             return;
         }
@@ -575,6 +596,12 @@ impl EventStreamWorkerHandle {
                     nat.rewrite_dst_port.unwrap_or(0),
                     delta.metadata.ingress_zone,
                     delta.metadata.egress_zone,
+                    // #2615: ingress ifindex ([128:132]) + resolved AppID
+                    // ([132:134]) so the SESSION_CREATE RT_FLOW record shows
+                    // the admitting interface and application instead of
+                    // N/A / UNKNOWN.
+                    ingress_ifindex,
+                    app_id,
                 )
             },
         );

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -3,7 +3,9 @@
 // LOC threshold. Loaded as a sibling submodule via
 // `#[path = "tests.rs"]` from mod.rs.
 
-use super::codec::{DataplaneEventKind, DataplaneEventPayload, MSG_FULL_RESYNC};
+use super::codec::{
+    DataplaneEventKind, DataplaneEventPayload, MSG_FULL_RESYNC, MSG_SESSION_CREATE_RT_FLOW,
+};
 use super::*;
 use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr};
@@ -123,7 +125,7 @@ fn test_emit_session_close_rt_flow_pairs_with_ha_delta() {
 
     // Mirror flush_session_deltas: the HA delta then the RT_FLOW frame.
     handle.push_delta(&delta, &zone_map);
-    handle.emit_session_close_rt_flow(&delta, 0);
+    handle.emit_session_close_rt_flow(&delta, 0, 0);
 
     let frames: Vec<EventFrame> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
     assert_eq!(frames.len(), 2, "expected exactly one HA delta + one RT_FLOW frame");
@@ -198,7 +200,7 @@ fn test_emit_session_close_rt_flow_carries_real_created_stamp() {
     delta.created_ns = now_mono.saturating_sub(60 * NS_PER_SEC);
     delta.last_seen_ns = now_mono;
 
-    handle.emit_session_close_rt_flow(&delta, 0);
+    handle.emit_session_close_rt_flow(&delta, 0, 0);
     let frame = rx.try_recv().expect("RT_FLOW close frame");
     let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
 
@@ -232,13 +234,22 @@ fn test_emit_session_close_rt_flow_carries_app_id() {
         },
     );
     let delta = test_close_delta(crate::session::SessionDeltaKind::Close);
-    handle.emit_session_close_rt_flow(&delta, 7);
+    handle.emit_session_close_rt_flow(&delta, 7, 42);
     let frame = rx.try_recv().expect("RT_FLOW close frame");
     let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
     assert_eq!(
         u16::from_le_bytes([p[132], p[133]]),
         7,
         "SESSION_CLOSE RT_FLOW must carry the resolved AppID, not UNKNOWN(0)"
+    );
+    // #2615 fail-on-revert: the ingress ifindex the caller threads
+    // (ident.ifindex) must ride the [128:132] slot so the close record renders
+    // packet-incoming-interface=<name> instead of N/A. Reverting the emit /
+    // encode path to leave the slot 0 makes this assertion fail.
+    assert_eq!(
+        u32::from_le_bytes(p[128..132].try_into().unwrap()),
+        42,
+        "SESSION_CLOSE RT_FLOW must carry the ingress ifindex, not N/A(0)"
     );
 }
 
@@ -255,7 +266,7 @@ fn test_emit_session_close_rt_flow_zero_created_stays_zero() {
         },
     );
     let delta = test_close_delta(crate::session::SessionDeltaKind::Close); // created_ns == 0
-    handle.emit_session_close_rt_flow(&delta, 0);
+    handle.emit_session_close_rt_flow(&delta, 0, 0);
     let frame = rx.try_recv().expect("RT_FLOW close frame");
     let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
     assert_eq!(u32::from_le_bytes(p[108..112].try_into().unwrap()), 0);
@@ -275,7 +286,7 @@ fn test_emit_session_close_rt_flow_ignores_open_delta() {
         },
     );
     let delta = test_close_delta(crate::session::SessionDeltaKind::Open);
-    handle.emit_session_close_rt_flow(&delta, 0);
+    handle.emit_session_close_rt_flow(&delta, 0, 0);
     assert!(rx.try_recv().is_err(), "Open delta must emit no RT_FLOW close frame");
 }
 
@@ -304,7 +315,7 @@ fn test_emit_session_close_rt_flow_accounts_under_session_close_kind() {
     // Emit 4 closes; the per-kind budget admits 1, the rest are queue-full.
     // (`_rx` is never drained, so the budget is never released.)
     for _ in 0..4 {
-        handle.emit_session_close_rt_flow(&delta, 0);
+        handle.emit_session_close_rt_flow(&delta, 0, 0);
     }
 
     let stats = handle.dataplane_event_stats();
@@ -340,7 +351,7 @@ fn test_emit_session_close_rt_flow_rate_limited_is_counted() {
     let delta = test_close_delta(crate::session::SessionDeltaKind::Close);
 
     for _ in 0..5 {
-        handle.emit_session_close_rt_flow(&delta, 0);
+        handle.emit_session_close_rt_flow(&delta, 0, 0);
     }
 
     let stats = handle.dataplane_event_stats();
@@ -370,7 +381,7 @@ fn test_emit_session_create_rt_flow_accounts_under_session_create_kind() {
     delta.metadata.log_session_init = true;
 
     for _ in 0..3 {
-        handle.emit_session_create_rt_flow(&delta);
+        handle.emit_session_create_rt_flow(&delta, 0, 0);
     }
 
     let stats = handle.dataplane_event_stats();
@@ -380,6 +391,39 @@ fn test_emit_session_create_rt_flow_accounts_under_session_create_kind() {
     // Must not steal the close kind's budget/counters.
     assert_eq!(stats.session_close.sent, 0);
     assert_eq!(stats.session_close.dropped, 0);
+}
+
+#[test]
+fn test_emit_session_create_rt_flow_carries_app_id_and_ifindex() {
+    // #2615 fail-on-revert: the SESSION_CREATE emit path must thread the
+    // resolved AppID ([132:134]) and the admitting binding's ingress ifindex
+    // ([128:132]) into the wire frame, mirroring the #2520 close-side AppID
+    // fix. Reverting emit_session_create_rt_flow / encode_session_create_rt_flow
+    // to leave either slot 0 makes the create record log application="UNKNOWN"
+    // / packet-incoming-interface="N/A" — and these assertions fail.
+    let (handle, rx) = test_worker_handle(
+        8,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let mut delta = test_close_delta(crate::session::SessionDeltaKind::Open);
+    delta.metadata.log_session_init = true;
+    handle.emit_session_create_rt_flow(&delta, 9, 77);
+    let frame = rx.try_recv().expect("RT_FLOW create frame");
+    assert_eq!(frame.data[4], MSG_SESSION_CREATE_RT_FLOW);
+    let p = &frame.data[FRAME_HEADER_SIZE..frame.len as usize];
+    assert_eq!(
+        u16::from_le_bytes([p[132], p[133]]),
+        9,
+        "SESSION_CREATE RT_FLOW must carry the resolved AppID, not UNKNOWN(0)"
+    );
+    assert_eq!(
+        u32::from_le_bytes(p[128..132].try_into().unwrap()),
+        77,
+        "SESSION_CREATE RT_FLOW must carry the ingress ifindex, not N/A(0)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #2615

## Summary

- The RT_FLOW SESSION_CREATE record logged `application="UNKNOWN"`, and both SESSION_CREATE and SESSION_CLOSE logged `packet-incoming-interface="N/A"`, even though the helper knew both values — leaving permitted-flow audit records incomplete (forensics + Junos/vSRX RT_FLOW parity).
- Per the issue's parent-triage scope correction: the SESSION_CLOSE **AppID** half was already fixed by #2520; this PR fixes the remaining genuine gaps on master — SESSION_CREATE AppID, and ingress ifindex for both create and close.
- `encode_session_create_rt_flow` now writes the ingress ifindex `[128:132]` (LE u32) + application id `[132:134]` (LE u16); `encode_session_close_rt_flow` now writes the ingress ifindex `[128:132]`.
- The `flush_session_deltas` caller resolves the AppID with the SAME `forwarding.app_catalog.lookup(protocol, src_port, dst_port)` the forwarding hot path runs (mirroring the #2520 close-side fix) and supplies the admitting binding's `ident.ifindex`.
- 0 in either slot keeps the prior UNKNOWN / N/A rendering for unresolvable sessions.

## Wire change: NO

This is a **render-only** fix. The 136-byte RT_FLOW SecurityEvent payload already reserves the ingress-ifindex slot at `[128:132]` and the application-id slot at `[132:134]`, and the Go consumer (`pkg/logging/ringbuf.go` — `IngressIfindex`/`AppID`) already decodes BOTH for every RT_FLOW frame. The create encoder simply left them 0; the close encoder carried AppID (#2520) but left the ifindex 0. No new field, no protocol bump, no `protocol_wire_v1.json` regen (that fixture pins the cold-path *status* protocol, not the RT_FLOW frame).

The ingress ifindex slot is a full-width LE u32; a kernel ifindex is always positive so the `i32 -> u32` cast is loss-free. This is **distinct** from the i16 egress/TX ifindex wrap bug (#2467, CLOSED), which lived on the separate type-2 HA session-delta path.

## Test plan

- [x] `cargo build` (userspace-dp) clean
- [x] `cargo test event_stream::` — 54 pass
- [x] **Fail-on-revert (proved RED, then restored):** reverting the three encoder slot writes turns 4 tests RED — `test_encode_session_close_rt_flow_v4_wire_layout`, `test_session_create_rt_flow_wire_layout`, `test_emit_session_close_rt_flow_carries_app_id`, `test_emit_session_create_rt_flow_carries_app_id_and_ifindex`.
- [x] `go build ./...` clean
- [x] `go vet ./pkg/logging/... ./pkg/daemon/...` clean
- [x] `go test ./pkg/logging/... ./pkg/daemon/...` (eventstream cross-package contract test) — green
- [ ] Live cluster smoke not run (render-only wire-slot fix; no forwarding-path change). The Go consumer decode path is exercised by the pkg/daemon/pkg/logging contract tests.

## Refs

- #2615 (this), #2520 (close-side AppID, done), #2467 (i16 egress/TX ifindex, distinct path, closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi