### PR TITLE
observability: fail session views on iterator error, not partial-as-OK (#2469)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15438,3 +15438,25 @@ top.
   pkg/config/schema_security.go, pkg/ipsec/policy.go,
   pkg/config/parser_security_test.go, pkg/ipsec/ipsec_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2469 — session-view surfaces must not publish a partial
+  scan as success on iterator error. REST (`/sessions`,
+  `/sessions/summary`, `/sessions/zone-pair`, interface-mode NAT pool
+  stats) now return HTTP 500 on an `IterateSessions`/`IterateSessionsV6`
+  error instead of HTTP 200 with a partial/zero body. Prometheus session
+  collector emits new `xpf_sessions_breakdown_scrape_ok` gauge (1=full,
+  0=truncated) and OMITS the ipv4/ipv6/snat/dnat breakdown gauges on
+  failure. gRPC `getSessionsLegacy` + `GetSessionSummary` now return
+  `codes.Internal` (matching the already-correct cursor path). CLI
+  top-talkers fails the command; NAT source/dest summaries print a
+  stderr warning via new `warnSessionScan` helper. Added fail-on-revert
+  tests across pkg/api, pkg/grpcapi, pkg/cli (proved RED on revert,
+  restored). Provenance: codex review-034 finding 5.
+  **File(s)**: pkg/api/sessions.go, pkg/api/nat.go,
+  pkg/api/metrics_sessions.go, pkg/api/metrics.go,
+  pkg/api/metrics_descriptors.go, pkg/api/sessions_iterator_error_test.go,
+  pkg/api/README.md, pkg/grpcapi/server_sessions.go,
+  pkg/grpcapi/sessions_iterator_error_test.go, pkg/cli/cli_show_flow.go,
+  pkg/cli/cli_show_nat.go, pkg/cli/sessions_iterator_error_test.go,
+  _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -72,6 +72,21 @@ under the daemon's errgroup. Nothing else imports this package.
   pair is shaper-side; the `drain_park_root_tokens` / `drain_park_queue_tokens`
   pair counts the per-batch drain-loop decision (see
   `docs/cos-validation-notes.md`).
+- Session-view read paths must NOT publish a partial scan as success
+  (#2469). A backend session-iterator error (e.g. helper restart
+  mid-scan) makes `IterateSessions`/`IterateSessionsV6` return non-nil.
+  The REST session handlers (`/sessions`, `/sessions/summary`,
+  `/sessions/zone-pair`, interface-mode NAT pool stats) return HTTP 500
+  on that error instead of an HTTP 200 with a partial/zero body. The
+  Prometheus session-breakdown collector emits
+  `xpf_sessions_breakdown_scrape_ok` (1 = full scan, 0 = truncated) and
+  OMITS the `xpf_sessions_{ipv4,ipv6,snat,dnat}` gauges when the scan
+  failed, so an alert fires rather than a graph silently dropping to
+  zero. The gRPC `GetSessions` (legacy + cursor) and `GetSessionSummary`
+  return `codes.Internal` on the same error. The contract is pinned by
+  `sessions_iterator_error_test.go` in this package and in `pkg/grpcapi`
+  / `pkg/cli` (CLI top-talkers fails the command; NAT summaries print a
+  stderr warning).
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -56,6 +56,7 @@ type xpfCollector struct {
 	sessionsIPv6        *prometheus.Desc
 	sessionsSNAT        *prometheus.Desc
 	sessionsDNAT        *prometheus.Desc
+	sessionScrapeOK     *prometheus.Desc
 	gcSweepDuration     *prometheus.Desc
 
 	// NAT pool utilization
@@ -468,6 +469,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.sessionsIPv6
 	ch <- c.sessionsSNAT
 	ch <- c.sessionsDNAT
+	ch <- c.sessionScrapeOK
 	ch <- c.gcSweepDuration
 	ch <- c.natPoolUsedPorts
 	ch <- c.natPoolTotalPorts

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -151,6 +151,13 @@ func newCollector(srv *Server) *xpfCollector {
 			"Current number of DNAT sessions.",
 			nil, nil,
 		),
+		sessionScrapeOK: prometheus.NewDesc(
+			"xpf_sessions_breakdown_scrape_ok",
+			"1 if the last session-breakdown scrape (ipv4/ipv6/snat/dnat gauges) "+
+				"enumerated the full session table; 0 if a backend iterator "+
+				"error truncated the scan (the breakdown gauges are then omitted).",
+			nil, nil,
+		),
 		gcSweepDuration: prometheus.NewDesc(
 			"xpf_gc_sweep_duration_seconds",
 			"Duration of the last GC sweep in seconds.",

--- a/pkg/api/metrics_sessions.go
+++ b/pkg/api/metrics_sessions.go
@@ -18,9 +18,15 @@ func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiR
 	ch <- prometheus.MustNewConstMetric(c.gcSweepDuration, prometheus.GaugeValue,
 		stats.LastSweepDuration.Seconds())
 
-	// Session breakdowns by type
+	// Session breakdowns by type. A backend iterator error (e.g. a
+	// helper restart mid-scrape) truncates the scan and would otherwise
+	// publish low/zero gauges as a healthy result, so Prometheus reads a
+	// wrong-but-confident picture (#2469). Instead, track the iteration
+	// outcome, EXPOSE it as xpf_sessions_breakdown_scrape_ok, and OMIT
+	// the breakdown gauges on failure so an alert on staleness/scrape_ok
+	// fires rather than a graph silently dropping to zero.
 	var ipv4, ipv6, snat, dnat int
-	_ = dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+	errV4 := dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse == 0 {
 			ipv4++
 			if val.Flags&dataplane.SessFlagSNAT != 0 {
@@ -32,7 +38,7 @@ func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiR
 		}
 		return true
 	})
-	_ = dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	errV6 := dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse == 0 {
 			ipv6++
 			if val.Flags&dataplane.SessFlagSNAT != 0 {
@@ -44,6 +50,11 @@ func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiR
 		}
 		return true
 	})
+	if errV4 != nil || errV6 != nil {
+		ch <- prometheus.MustNewConstMetric(c.sessionScrapeOK, prometheus.GaugeValue, 0)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.sessionScrapeOK, prometheus.GaugeValue, 1)
 	ch <- prometheus.MustNewConstMetric(c.sessionsIPv4, prometheus.GaugeValue, float64(ipv4))
 	ch <- prometheus.MustNewConstMetric(c.sessionsIPv6, prometheus.GaugeValue, float64(ipv6))
 	ch <- prometheus.MustNewConstMetric(c.sessionsSNAT, prometheus.GaugeValue, float64(snat))

--- a/pkg/api/nat.go
+++ b/pkg/api/nat.go
@@ -122,12 +122,18 @@ func (s *Server) natPoolStatsHandler(w http.ResponseWriter, _ *http.Request) {
 			if rule.Then.Interface {
 				used := 0
 				if s.dp != nil && s.dp.IsLoaded() {
-					_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+					// A partial scan under-counts interface-mode NAT
+					// usage; fail rather than report a healthy-but-low
+					// figure (#2469).
+					if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 						if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
 							used++
 						}
 						return true
-					})
+					}); err != nil {
+						writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
+						return
+					}
 				}
 				result = append(result, NATPoolStatsInfo{
 					Name:        fmt.Sprintf("%s->%s", rs.FromZone, rs.ToZone),

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -30,8 +30,10 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 	all := make([]SessionEntry, 0)
 	idx := 0
 
-	// IPv4 sessions
-	_ = s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	// IPv4 sessions. A backend iterator failure (e.g. helper restart
+	// mid-scan) must fail the request rather than returning HTTP 200 with
+	// a partial/zero session list as a healthy result (#2469).
+	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -48,10 +50,13 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		idx++
 		return true
-	})
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
+		return
+	}
 
 	// IPv6 sessions
-	_ = s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -68,7 +73,10 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		idx++
 		return true
-	})
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "iterate sessions_v6: "+err.Error())
+		return
+	}
 
 	writeOK(w, SessionListResponse{
 		Total:    idx,
@@ -86,7 +94,9 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, _ *http.Request) {
 
 	var summary SessionSummary
 
-	_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+	// A partial scan yields an under-count that looks like a healthy
+	// summary — fail the request instead of publishing it (#2469).
+	if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 		summary.TotalEntries++
 		if val.IsReverse == 0 {
 			summary.ForwardOnly++
@@ -102,9 +112,12 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 		return true
-	})
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
+		return
+	}
 
-	_ = s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if err := s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		summary.TotalEntries++
 		if val.IsReverse == 0 {
 			summary.ForwardOnly++
@@ -120,7 +133,10 @@ func (s *Server) sessionSummaryHandler(w http.ResponseWriter, _ *http.Request) {
 			}
 		}
 		return true
-	})
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "iterate sessions_v6: "+err.Error())
+		return
+	}
 
 	writeOK(w, summary)
 }
@@ -184,18 +200,26 @@ func (s *Server) sessionZonePairHandler(w http.ResponseWriter, _ *http.Request) 
 		zp.Total++
 	}
 
-	_ = s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	// A partial scan produces a misleading zone-pair breakdown — fail
+	// the request rather than serving an incomplete table as OK (#2469).
+	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse == 0 {
 			countSession(val.IngressZone, val.EgressZone, key.Protocol)
 		}
 		return true
-	})
-	_ = s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
+		return
+	}
+	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse == 0 {
 			countSession(val.IngressZone, val.EgressZone, key.Protocol)
 		}
 		return true
-	})
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "iterate sessions_v6: "+err.Error())
+		return
+	}
 
 	result := make([]ZonePairSessionSummary, 0, len(counts))
 	for _, zp := range counts {

--- a/pkg/api/sessions_iterator_error_test.go
+++ b/pkg/api/sessions_iterator_error_test.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/psaab/xpf/pkg/conntrack"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// errIterDP is an apiRuntimeDataPlane whose session iterators fail,
+// modelling a backend (helper) error mid-scan. It embeds a
+// *dataplane.Manager only to satisfy the methods the tests do not
+// exercise; the IsLoaded/IterateSessions overrides drive the read paths.
+type errIterDP struct {
+	*dataplane.Manager
+	iterErr error
+}
+
+func (d *errIterDP) IsLoaded() bool { return true }
+
+func (d *errIterDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return d.iterErr
+}
+
+func (d *errIterDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return d.iterErr
+}
+
+// TestRESTSessionViewsFailOnIteratorError asserts the #2469 contract:
+// when the session iterator errors, the REST session views must NOT
+// return HTTP 200 with a partial/zero body — they must surface a 5xx so
+// dashboards see a failure instead of a healthy-but-wrong picture.
+//
+// FAIL-ON-REVERT: reverting the `if err := ...; err != nil { writeError }`
+// guard back to `_ = s.dp.IterateSessions(...)` makes each handler fall
+// through to writeOK (HTTP 200), and every want-500 assertion below
+// flips red.
+func TestRESTSessionViewsFailOnIteratorError(t *testing.T) {
+	iterErr := errors.New("helper restart: session map closed")
+	s := &Server{
+		dp: &errIterDP{Manager: dataplane.New(), iterErr: iterErr},
+	}
+
+	cases := []struct {
+		name    string
+		handler func(*httptest.ResponseRecorder)
+	}{
+		{
+			name: "sessions list",
+			handler: func(rr *httptest.ResponseRecorder) {
+				s.sessionsHandler(rr, httptest.NewRequest("GET", "/api/v1/sessions", nil))
+			},
+		},
+		{
+			name: "sessions summary",
+			handler: func(rr *httptest.ResponseRecorder) {
+				s.sessionSummaryHandler(rr, httptest.NewRequest("GET", "/api/v1/sessions/summary", nil))
+			},
+		},
+		{
+			name: "sessions zone-pair",
+			handler: func(rr *httptest.ResponseRecorder) {
+				s.sessionZonePairHandler(rr, httptest.NewRequest("GET", "/api/v1/sessions/zone-pair", nil))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			tc.handler(rr)
+			if rr.Code != 500 {
+				t.Fatalf("%s: status = %d, want 500 on iterator error; body: %s",
+					tc.name, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func newSessionGaugeCollector() *xpfCollector {
+	gc := conntrack.NewGC(nil, time.Minute)
+	return &xpfCollector{
+		srv:                 &Server{gc: gc},
+		sessionsActive:      prometheus.NewDesc("xpf_sessions_active", "test", nil, nil),
+		sessionsEstablished: prometheus.NewDesc("xpf_sessions_established", "test", nil, nil),
+		sessionsIPv4:        prometheus.NewDesc("xpf_sessions_ipv4", "test", nil, nil),
+		sessionsIPv6:        prometheus.NewDesc("xpf_sessions_ipv6", "test", nil, nil),
+		sessionsSNAT:        prometheus.NewDesc("xpf_sessions_snat", "test", nil, nil),
+		sessionsDNAT:        prometheus.NewDesc("xpf_sessions_dnat", "test", nil, nil),
+		sessionScrapeOK:     prometheus.NewDesc("xpf_sessions_breakdown_scrape_ok", "test", nil, nil),
+		gcSweepDuration:     prometheus.NewDesc("xpf_gc_sweep_duration_seconds", "test", nil, nil),
+	}
+}
+
+func gaugeValue(t *testing.T, m prometheus.Metric) float64 {
+	t.Helper()
+	var pb dto.Metric
+	if err := m.Write(&pb); err != nil {
+		t.Fatalf("metric.Write: %v", err)
+	}
+	if pb.Gauge == nil {
+		t.Fatalf("metric is not a gauge: %s", m.Desc().String())
+	}
+	return pb.Gauge.GetValue()
+}
+
+// TestPrometheusSessionBreakdownFailOnIteratorError asserts the #2469
+// Prometheus contract: on iterator error the collector must NOT emit the
+// session-breakdown gauges (ipv4/ipv6/snat/dnat) as if they were a
+// healthy zero — it must instead emit xpf_sessions_breakdown_scrape_ok=0
+// and OMIT the breakdown gauges, so an alert fires rather than graphs
+// silently dropping to zero.
+//
+// FAIL-ON-REVERT: restoring `_ = dp.IterateSessions(...)` and the
+// unconditional gauge emission makes the collector emit the breakdown
+// descs with value 0 AND never emit scrape_ok=0 — both assertions flip.
+func TestPrometheusSessionBreakdownFailOnIteratorError(t *testing.T) {
+	c := newSessionGaugeCollector()
+	dp := &errIterDP{Manager: dataplane.New(), iterErr: errors.New("helper restart")}
+
+	ch := make(chan prometheus.Metric, 16)
+	c.collectSessionGauges(ch, dp)
+	close(ch)
+
+	sawScrapeOKZero := false
+	for m := range ch {
+		desc := m.Desc().String()
+		if strings.Contains(desc, "xpf_sessions_ipv4") ||
+			strings.Contains(desc, "xpf_sessions_ipv6") ||
+			strings.Contains(desc, "xpf_sessions_snat") ||
+			strings.Contains(desc, "xpf_sessions_dnat") {
+			t.Fatalf("breakdown gauge emitted on iterator error: %s", desc)
+		}
+		if strings.Contains(desc, "xpf_sessions_breakdown_scrape_ok") {
+			if v := gaugeValue(t, m); v != 0 {
+				t.Fatalf("scrape_ok = %v on iterator error, want 0", v)
+			}
+			sawScrapeOKZero = true
+		}
+	}
+	if !sawScrapeOKZero {
+		t.Fatal("xpf_sessions_breakdown_scrape_ok not emitted on iterator error; want value 0")
+	}
+}
+
+// TestPrometheusSessionBreakdownHealthyEmitsGauges is the positive
+// companion: a healthy (nil-error) scan must emit scrape_ok=1 AND the
+// breakdown gauges, proving the failure path is the only one that omits
+// them.
+func TestPrometheusSessionBreakdownHealthyEmitsGauges(t *testing.T) {
+	c := newSessionGaugeCollector()
+	// nil iterErr => both iterators succeed (and enumerate nothing).
+	dp := &errIterDP{Manager: dataplane.New(), iterErr: nil}
+
+	ch := make(chan prometheus.Metric, 16)
+	c.collectSessionGauges(ch, dp)
+	close(ch)
+
+	sawIPv4 := false
+	sawScrapeOKOne := false
+	for m := range ch {
+		desc := m.Desc().String()
+		if strings.Contains(desc, "xpf_sessions_ipv4") {
+			sawIPv4 = true
+		}
+		if strings.Contains(desc, "xpf_sessions_breakdown_scrape_ok") {
+			if v := gaugeValue(t, m); v != 1 {
+				t.Fatalf("scrape_ok = %v on healthy scan, want 1", v)
+			}
+			sawScrapeOKOne = true
+		}
+	}
+	if !sawIPv4 {
+		t.Fatal("breakdown gauge xpf_sessions_ipv4 not emitted on healthy scan")
+	}
+	if !sawScrapeOKOne {
+		t.Fatal("xpf_sessions_breakdown_scrape_ok=1 not emitted on healthy scan")
+	}
+}

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -731,7 +731,11 @@ func (c *CLI) showTopTalkers(f sessionFilter) error {
 	now := monotonicSeconds()
 	var entries []topTalkerEntry
 
-	_ = c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	// A backend iterator error (e.g. helper restart mid-scan) must fail
+	// the command rather than printing a truncated top-talkers list as if
+	// it were the full picture (#2469). The iteration runs before any
+	// output, so an early return leaves no partial table on screen.
+	if err := c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -766,9 +770,11 @@ func (c *CLI) showTopTalkers(f sessionFilter) error {
 			age:      age,
 		})
 		return true
-	})
+	}); err != nil {
+		return fmt.Errorf("iterate sessions: %w", err)
+	}
 
-	_ = c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if err := c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -803,7 +809,9 @@ func (c *CLI) showTopTalkers(f sessionFilter) error {
 			age:      age,
 		})
 		return true
-	})
+	}); err != nil {
+		return fmt.Errorf("iterate sessions_v6: %w", err)
+	}
 
 	if f.sortBy == "bytes" {
 		sort.Slice(entries, func(i, j int) bool {

--- a/pkg/cli/cli_show_nat.go
+++ b/pkg/cli/cli_show_nat.go
@@ -10,6 +10,22 @@ import (
 	"github.com/psaab/xpf/pkg/natshow"
 )
 
+// warnSessionScan prints a single operator warning to stderr when a
+// session enumeration used for a NAT/summary count was truncated by a
+// backend iterator error (e.g. a helper restart mid-scan). Without this
+// the CLI would print an under-count as if it were the full table —
+// the #2469 partial-as-success defect. nil errors are no-ops.
+func warnSessionScan(errs ...error) {
+	for _, err := range errs {
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"warning: session enumeration incomplete (counts below may be understated): %v\n",
+				err)
+			return
+		}
+	}
+}
+
 // handleShowNAT dispatches `show security nat ...` subcommands to the
 // per-NAT-mode presenters below.
 func (c *CLI) handleShowNAT(args []string) error {
@@ -118,7 +134,7 @@ func (c *CLI) showNATSource(cfg *config.Config, args []string) error {
 	}
 
 	snatCount := 0
-	_ = c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	errV4 := c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -127,7 +143,7 @@ func (c *CLI) showNATSource(cfg *config.Config, args []string) error {
 		}
 		return true
 	})
-	_ = c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	errV6 := c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse != 0 {
 			return true
 		}
@@ -136,6 +152,9 @@ func (c *CLI) showNATSource(cfg *config.Config, args []string) error {
 		}
 		return true
 	})
+	// A truncated scan (e.g. helper restart) under-counts; warn so the
+	// operator does not read the count as authoritative (#2469).
+	warnSessionScan(errV4, errV6)
 	fmt.Printf("Active SNAT sessions: %d\n", snatCount)
 
 	// Show NAT alloc fail counter
@@ -225,7 +244,7 @@ func (c *CLI) showNATSourceSummary(cfg *config.Config) error {
 			}
 		}
 		// Count SNAT sessions per zone pair
-		_ = c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+		errV4 := c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
 				totalSNAT++
 				if zoneByID != nil {
@@ -235,7 +254,7 @@ func (c *CLI) showNATSourceSummary(cfg *config.Config) error {
 			return true
 		})
 		// Count IPv6 SNAT sessions
-		_ = c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		errV6 := c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
 				totalSNAT++
 				if zoneByID != nil {
@@ -244,6 +263,9 @@ func (c *CLI) showNATSourceSummary(cfg *config.Config) error {
 			}
 			return true
 		})
+		// A truncated scan under-counts the per-pool/zone-pair session
+		// figures below; warn so they are not read as authoritative (#2469).
+		warnSessionScan(errV4, errV6)
 		for i := range pools {
 			if pools[i].isIface {
 				pools[i].used = rsSessions[pools[i].key]
@@ -536,7 +558,7 @@ func (c *CLI) showNATDestination(cfg *config.Config, args []string) error {
 	// Show summary of active DNAT sessions
 	if c.dp != nil && c.dp.IsLoaded() {
 		dnatCount := 0
-		_ = c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+		errV4 := c.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 			if val.IsReverse != 0 {
 				return true
 			}
@@ -545,7 +567,7 @@ func (c *CLI) showNATDestination(cfg *config.Config, args []string) error {
 			}
 			return true
 		})
-		_ = c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		errV6 := c.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 			if val.IsReverse != 0 {
 				return true
 			}
@@ -554,6 +576,7 @@ func (c *CLI) showNATDestination(cfg *config.Config, args []string) error {
 			}
 			return true
 		})
+		warnSessionScan(errV4, errV6)
 		fmt.Printf("Active DNAT sessions: %d\n", dnatCount)
 	}
 
@@ -600,20 +623,21 @@ func (c *CLI) showNATDestinationSummary(cfg *config.Config) error {
 		for name, id := range cr.ZoneIDs {
 			zoneByID[id] = name
 		}
-		_ = c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+		errV4 := c.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
 				totalDNAT++
 				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
 			}
 			return true
 		})
-		_ = c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+		errV6 := c.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagDNAT != 0 {
 				totalDNAT++
 				rsSessions[ruleSetKey{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
 			}
 			return true
 		})
+		warnSessionScan(errV4, errV6)
 	}
 
 	fmt.Printf("Total active translations: %d\n", totalDNAT)

--- a/pkg/cli/sessions_iterator_error_test.go
+++ b/pkg/cli/sessions_iterator_error_test.go
@@ -1,0 +1,156 @@
+// #2469: CLI session-derived views (top-talkers, NAT source/destination
+// summaries) must NOT print a truncated count as if it were the full
+// picture when the backend session iterator errors. Top-talkers fails
+// the command (its scan precedes any output); the NAT summaries print a
+// stderr WARNING alongside the (now-understated) count.
+//
+// FAIL-ON-REVERT: restoring `_ = c.dp.IterateSessions(...)` makes
+// showTopTalkers return nil (no error) and the NAT summaries print no
+// warning — the assertions below go RED.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// viewFaultCLIDP fails the session iterators to model a backend (helper)
+// error mid-scan. Embeds *dataplane.Manager for the unused surface.
+type viewFaultCLIDP struct {
+	*dataplane.Manager
+	iterErr   error
+	iterV6Err error
+}
+
+func (d *viewFaultCLIDP) IsLoaded() bool { return true }
+
+func (d *viewFaultCLIDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return d.iterErr
+}
+
+func (d *viewFaultCLIDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return d.iterV6Err
+}
+
+// LastApplyResult returns a non-nil (empty) ApplyResult so the
+// destination-NAT summary's `cr != nil`-gated session-count path is
+// reached (showNATDestinationSummary skips the scan otherwise).
+func (d *viewFaultCLIDP) LastApplyResult() *dataplane.ApplyResult {
+	return &dataplane.ApplyResult{}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("stderr close error = %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	return string(out)
+}
+
+func newViewCLI(t *testing.T, dp cliRuntime) *CLI {
+	t.Helper()
+	return &CLI{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    dp,
+	}
+}
+
+func TestShowTopTalkersFailsOnIteratorError(t *testing.T) {
+	dp := &viewFaultCLIDP{
+		Manager: dataplane.New(),
+		iterErr: fmt.Errorf("helper restart: session map closed"),
+	}
+	c := newViewCLI(t, dp)
+
+	var callErr error
+	out := captureStdout(t, func() {
+		callErr = c.showTopTalkers(sessionFilter{sortBy: "bytes"})
+	})
+	if callErr == nil {
+		t.Fatalf("showTopTalkers returned nil error on iterator failure; want error.\noutput:\n%s", out)
+	}
+	if !strings.Contains(callErr.Error(), "iterate sessions") {
+		t.Fatalf("error did not mention iterate sessions: %v", callErr)
+	}
+}
+
+func TestShowNATSummariesWarnOnIteratorError(t *testing.T) {
+	cfg := &config.Config{}
+	// One interface-mode source NAT rule-set so showNATSourceSummary
+	// reaches the SNAT-session count path, and one destination pool so
+	// showNATDestinationSummary reaches the DNAT-session count path.
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "trust-to-untrust",
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Rules: []*config.NATRule{
+				{Name: "r1", Then: config.NATThen{Interface: true}},
+			},
+		},
+	}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"dpool": {Address: "10.0.0.1"},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{
+				Name: "dns",
+				Rules: []*config.NATRule{
+					{Name: "dr1", Then: config.NATThen{PoolName: "dpool"}},
+				},
+			},
+		},
+	}
+
+	dp := &viewFaultCLIDP{
+		Manager: dataplane.New(),
+		iterErr: fmt.Errorf("helper restart: session map closed"),
+	}
+	c := newViewCLI(t, dp)
+
+	t.Run("source summary", func(t *testing.T) {
+		var callErr error
+		errOut := captureStderr(t, func() {
+			_ = captureStdout(t, func() { callErr = c.showNATSourceSummary(cfg) })
+		})
+		if callErr != nil {
+			t.Fatalf("showNATSourceSummary error = %v", callErr)
+		}
+		if !strings.Contains(errOut, "warning") || !strings.Contains(errOut, "incomplete") {
+			t.Fatalf("source summary did not warn on iterator error; stderr:\n%s", errOut)
+		}
+	})
+
+	t.Run("destination summary", func(t *testing.T) {
+		var callErr error
+		errOut := captureStderr(t, func() {
+			_ = captureStdout(t, func() { callErr = c.showNATDestinationSummary(cfg) })
+		})
+		if callErr != nil {
+			t.Fatalf("showNATDestinationSummary error = %v", callErr)
+		}
+		if !strings.Contains(errOut, "warning") || !strings.Contains(errOut, "incomplete") {
+			t.Fatalf("destination summary did not warn on iterator error; stderr:\n%s", errOut)
+		}
+	})
+}

--- a/pkg/grpcapi/server_sessions.go
+++ b/pkg/grpcapi/server_sessions.go
@@ -583,7 +583,10 @@ func (s *Server) getSessionsLegacy(ctx context.Context, req *pb.GetSessionsReque
 		haActive = s.cluster.IsLocalPrimary(0)
 	}
 
-	_ = s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	// A backend iterator error (e.g. helper restart mid-scan) must fail
+	// the RPC rather than returning a partial session list as success —
+	// matching the cursor path above (#2469).
+	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if !filter.matchV4(key, val) {
 			return true
 		}
@@ -605,9 +608,11 @@ func (s *Server) getSessionsLegacy(ctx context.Context, req *pb.GetSessionsReque
 		}
 		idx++
 		return true
-	})
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "v4 session iteration: %v", err)
+	}
 
-	_ = s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if !filter.matchV6(key, val) {
 			return true
 		}
@@ -628,7 +633,9 @@ func (s *Server) getSessionsLegacy(ctx context.Context, req *pb.GetSessionsReque
 		}
 		idx++
 		return true
-	})
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "v6 session iteration: %v", err)
+	}
 
 	resp := &pb.GetSessionsResponse{
 		Total:    int32(idx),
@@ -654,7 +661,9 @@ func (s *Server) GetSessionSummary(ctx context.Context, req *pb.GetSessionSummar
 		resp.NodeId = int32(s.cluster.NodeID())
 	}
 
-	_ = s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+	// A partial scan under-counts the summary; fail the RPC rather than
+	// returning a healthy-looking but incomplete summary (#2469).
+	if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 		resp.TotalEntries++
 		if val.IsReverse == 0 {
 			resp.ForwardOnly++
@@ -670,9 +679,11 @@ func (s *Server) GetSessionSummary(ctx context.Context, req *pb.GetSessionSummar
 			}
 		}
 		return true
-	})
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "v4 session iteration: %v", err)
+	}
 
-	_ = s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if err := s.dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		resp.TotalEntries++
 		if val.IsReverse == 0 {
 			resp.ForwardOnly++
@@ -688,7 +699,9 @@ func (s *Server) GetSessionSummary(ctx context.Context, req *pb.GetSessionSummar
 			}
 		}
 		return true
-	})
+	}); err != nil {
+		return nil, status.Errorf(codes.Internal, "v6 session iteration: %v", err)
+	}
 
 	// Fetch peer summary if requested and in cluster mode.
 	if req.GetIncludePeer() && s.cluster != nil && s.cluster.PeerAlive() {

--- a/pkg/grpcapi/sessions_iterator_error_test.go
+++ b/pkg/grpcapi/sessions_iterator_error_test.go
@@ -1,0 +1,84 @@
+// #2469: the gRPC session VIEW RPCs (GetSessions legacy path and
+// GetSessionSummary) must fail with codes.Internal when the backend
+// session iterator errors, rather than returning a partial/zero result
+// as a successful response. The cursor GetSessions path already did
+// this; these tests pin the legacy + summary paths.
+//
+// FAIL-ON-REVERT: restoring `_ = s.dp.IterateSessions(...)` in
+// getSessionsLegacy / GetSessionSummary makes both RPCs return a
+// non-error empty response and the want-Internal assertions go RED.
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// viewFaultGRPCDP fails the session iterators to model a backend
+// (helper) error mid-scan. It embeds *dataplane.Manager only for the
+// methods the view paths do not reach before the iterator error.
+type viewFaultGRPCDP struct {
+	*dataplane.Manager
+	iterErr   error
+	iterV6Err error
+}
+
+func (d *viewFaultGRPCDP) IsLoaded() bool { return true }
+
+func (d *viewFaultGRPCDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return d.iterErr
+}
+
+func (d *viewFaultGRPCDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return d.iterV6Err
+}
+
+func newViewServer(t *testing.T, dp grpcRuntime) *Server {
+	t.Helper()
+	return &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    dp,
+		// cluster nil -> standalone.
+	}
+}
+
+func TestGetSessionsLegacyFailsOnIteratorError(t *testing.T) {
+	dp := &viewFaultGRPCDP{
+		Manager: dataplane.New(),
+		iterErr: errors.New("helper restart: session map closed"),
+	}
+	s := newViewServer(t, dp)
+
+	// Legacy path: PageSize == 0 (no cursor pagination).
+	_, err := s.GetSessions(context.Background(), &pb.GetSessionsRequest{})
+	if err == nil {
+		t.Fatal("GetSessions returned nil error on iterator failure; want codes.Internal")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetSessions error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}
+
+func TestGetSessionSummaryFailsOnIteratorError(t *testing.T) {
+	dp := &viewFaultGRPCDP{
+		Manager: dataplane.New(),
+		iterErr: errors.New("helper restart: session map closed"),
+	}
+	s := newViewServer(t, dp)
+
+	_, err := s.GetSessionSummary(context.Background(), &pb.GetSessionSummaryRequest{})
+	if err == nil {
+		t.Fatal("GetSessionSummary returned nil error on iterator failure; want codes.Internal")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetSessionSummary error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}


### PR DESCRIPTION
Closes #2469

## Problem

The REST, gRPC, Prometheus, and CLI session read paths discarded
session-iterator errors and published the partial/zero result as a
**successful** response. During a helper restart or any backend
iterator error this produced a healthy-but-wrong picture:

- **Prometheus** scraped low/zero session-breakdown gauges as OK.
- **REST** returned HTTP 200 with an incomplete sessions list / summary
  / zone-pair table (and an under-counted interface-mode NAT pool stat).
- **gRPC** legacy `GetSessions` + `GetSessionSummary` returned a
  truncated set as success (the cursor `GetSessions` path was already
  correct).
- **CLI** `show ... top-talkers` and the NAT source/destination
  summaries printed an under-count as if it were the full table.

Provenance: codex review-034 finding 5.

## Which surfaces diverged / fix

Each surface already had the iterator error in hand and threw it away
(`_ = s.dp.IterateSessions(...)`). Per-surface handling, per the issue's
fix direction:

| Surface | Before | After |
|---|---|---|
| REST `/sessions`, `/sessions/summary`, `/sessions/zone-pair`, interface-mode NAT pool stats | HTTP 200 + partial body | **HTTP 500** on iterator error |
| Prometheus session breakdown | emits ipv4/ipv6/snat/dnat gauges even on error | emits new **`xpf_sessions_breakdown_scrape_ok`** (1=full, 0=truncated) and **OMITS** the breakdown gauges on failure |
| gRPC `getSessionsLegacy`, `GetSessionSummary` | nil-error truncated result | **`codes.Internal`** (matches cursor path) |
| CLI top-talkers | prints partial table | **fails the command** (scan precedes output) |
| CLI NAT source/dest summary | prints under-count | prints a **stderr warning** (`warnSessionScan`) |

View-layer only — the dataplane and its per-session counters are
untouched. (The separate per-session counter **tracking** gap is #2501;
this issue is strictly the four surfaces disagreeing / publishing
partial-as-success, which does not depend on #2501.)

The new Prometheus desc is registered in `Describe()` so the
checked-collector / descriptor-coverage canary stays green.

## Fail-on-revert proof

`sessions_iterator_error_test.go` added in `pkg/api`, `pkg/grpcapi`,
`pkg/cli`. With each surface's guard reverted to the old `_ =` discard:

```
--- FAIL: TestRESTSessionViewsFailOnIteratorError/sessions_list
    status = 200, want 500 ... {"success":true,"data":{...,"sessions":[]}}
--- FAIL: TestPrometheusSessionBreakdownFailOnIteratorError
    breakdown gauge emitted on iterator error: xpf_sessions_ipv4
--- FAIL: TestPrometheusSessionBreakdownHealthyEmitsGauges
    xpf_sessions_breakdown_scrape_ok=1 not emitted on healthy scan
--- FAIL: TestGetSessionSummaryFailsOnIteratorError
    returned nil error on iterator failure; want codes.Internal
--- FAIL: TestShowTopTalkersFailsOnIteratorError
    returned nil error on iterator failure; want error
--- FAIL: TestShowNATSummariesWarnOnIteratorError/source_summary
    did not warn on iterator error
```

All RED on revert, then restored. A positive Prometheus companion
asserts a healthy scan still emits `scrape_ok=1` plus the breakdown
gauges (so the failure path is the only one that omits them).

## Gates

- `go build ./...` — OK
- `gofmt -l` on touched files — clean
- `go vet ./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/...` — only the
  pre-existing `cli.go:460 unreachable code` warning (not in any
  touched file; present on origin/master)
- `go test ./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/...` — all pass
  (incl. the descriptor-coverage canary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi