### PR TITLE
userspace-dp: emit accepted input-filter `then log` on session-miss packet (#2617)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15438,3 +15438,17 @@ top.
   pkg/config/schema_security.go, pkg/ipsec/policy.go,
   pkg/config/parser_security_test.go, pkg/ipsec/ipsec_test.go,
   docs/config-schema.md, _Log.md
+
+## 2026-06-25 — #2617 accepted input-filter `then log` miss-packet emit
+- **Timestamp**: 2026-06-25
+- **Action**: Move the non-PBR input-filter `then log` emit to a single early
+  site at the accept fall-through in `poll_binding_process_descriptor`, so an
+  accepted term emits its RT_FLOW audit record on the session-miss (first)
+  packet across ALL accept exits (forward-candidate install-success and
+  install-refused, local-delivery). Removed the former per-install emit site
+  (would double-log an installed forward flow). Added fail-on-revert test
+  `poll_descriptor_input_filter_accept_log_emits_on_install_refused_miss`
+  (cap=0 → install refused → log must still emit; RED on revert with "Empty").
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/tests.rs,
+  docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md, _Log.md

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -49,10 +49,20 @@ Current implementation status after the 2026-05-19 closeout slice:
   `discard`/`reject` actions are terminal before route lookup and policy
   evaluation; logged terminal actions emit `source=input` with deny RT_FLOW
   action because this userspace path fails closed without synthesizing an
-  ICMP/RST reject packet yet. If the first permitted packet installs a
-  flow-cache entry,
-  the matched input log term and ingress-zone ID are stored in that entry and
-  cached hits re-emit `source=input` without rescanning filter terms.
+  ICMP/RST reject packet yet. A matched input filter `then log` term emits
+  `source=input` on the session-miss (first) packet itself, regardless of the
+  term's terminal action: the emit is a single early site at the accept
+  fall-through in `poll_descriptor`, so it fires exactly once per miss packet
+  across every accept exit — forward-candidate (whether or not the session
+  install succeeds), local-delivery, and the install-refused (max-sessions)
+  drop path. (#2617 closed the prior gap where an accepted `then log` fired
+  only inside the per-install success branch, so a local-delivery or
+  install-refused permitted flow lost its first — and, if short-lived or
+  cache-declined, only — audit record.) For a forward-candidate flow that
+  installs a flow-cache entry, the matched input log term and ingress-zone ID
+  are also stored in that entry and SUBSEQUENT cached hits re-emit
+  `source=input` without rescanning filter terms. The miss packet does not
+  take the cache-hit path, so the same packet is never double-logged.
 - Input/output filters with DSCP match terms are deliberately not
   flow-cached because DSCP is per-packet metadata outside the session cache
   key. Established session hits re-evaluate DSCP-sensitive input filters, and

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -842,17 +842,48 @@ pub(super) fn poll_binding_process_descriptor(
                             meta,
                             ingress_zone_override,
                         );
+                        // #2617: emit the matched input-filter `then log` event
+                        // on THIS (session-miss / first) packet, regardless of
+                        // the term's terminal action. Previously the emit fired
+                        // only inside the `action != Accept` branch below and at
+                        // the ForwardCandidate session-install success site
+                        // (~L1850); the install emit was removed in this fix in
+                        // favour of this single early site. The old layout left
+                        // two accept-path gaps:
+                        //
+                        //   - LocalDelivery (host-bound) accepted flows never
+                        //     reached the install emit, so an accepted `then log`
+                        //     never fired on the miss packet.
+                        //   - A ForwardCandidate flow whose session install was
+                        //     refused (max-sessions admission) dropped via
+                        //     `continue` BEFORE the install emit, losing the
+                        //     audit record entirely for a cache-declined /
+                        //     short-lived permitted flow.
+                        //
+                        // Emitting once here — before the action branch — gives
+                        // exactly-once miss-packet semantics across every accept
+                        // exit (forward, local-delivery, install-refused) and is
+                        // bit-identical to the non-accept path's prior immediate
+                        // emit. The log_match comes from the SAME counted
+                        // evaluation at ~L838, so emitting it does not re-count
+                        // the filter hit. The flow-cache descriptor populated
+                        // later (~L2615) stores the log via
+                        // evaluate_non_pbr_input_filter_log_only (the
+                        // non-counting variant) for cache-hit replay on
+                        // SUBSEQUENT packets; the miss packet does not take the
+                        // cache-hit path, so the same packet is never
+                        // double-logged.
+                        if let Some(cached_log) = input_filter_eval.cached_log {
+                            emit_input_filter_log_match(
+                                worker_ctx.forwarding,
+                                worker_ctx.event_stream,
+                                flow,
+                                meta,
+                                cached_log,
+                                now_ns,
+                            );
+                        }
                         if input_filter_eval.action != crate::filter::FilterAction::Accept {
-                            if let Some(cached_log) = input_filter_eval.cached_log {
-                                emit_input_filter_log_match(
-                                    worker_ctx.forwarding,
-                                    worker_ctx.event_stream,
-                                    flow,
-                                    meta,
-                                    cached_log,
-                                    now_ns,
-                                );
-                            }
                             // #2521: filter `then reject` synthesizes an active
                             // reply (TCP RST / ICMP unreachable) like policy
                             // reject; `discard` remains a silent drop.
@@ -1846,16 +1877,16 @@ pub(super) fn poll_binding_process_descriptor(
                                             worker_ctx.peer_worker_commands,
                                             &forward_entry,
                                         );
-                                        if let Some(cached_log) = input_filter_eval.cached_log {
-                                            emit_input_filter_log_match(
-                                                worker_ctx.forwarding,
-                                                worker_ctx.event_stream,
-                                                flow,
-                                                meta,
-                                                cached_log,
-                                                now_ns,
-                                            );
-                                        }
+                                        // #2617: the input-filter `then log`
+                                        // emit moved to the single early site at
+                                        // the accept fall-through (~L876), so it
+                                        // now fires once per miss packet across
+                                        // every accept exit (forward,
+                                        // local-delivery, install-refused). The
+                                        // former per-install emit here would
+                                        // double-log a successfully installed
+                                        // ForwardCandidate flow once the early
+                                        // site is in place.
                                     } else {
                                         // #1861: only reachable when
                                         // track_in_userspace == false (a true

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -4165,8 +4165,23 @@ fn poll_descriptor_policy_deny_path_emits_rt_flow_event() {
     assert!(telemetry.dbg.policy_deny >= 1);
 }
 
-#[test]
-fn poll_descriptor_input_filter_log_path_emits_rt_flow_event() {
+/// #2617 harness: drive a single LAN→WAN TCP-SYN session-miss packet through
+/// `poll_binding_process_descriptor` with an interface input filter whose term
+/// is `then { log; accept; }` matching dport 5201. Returns the worker event
+/// handle (for `filter_log.sent` stats) plus the decoded receiver so callers
+/// can assert the emitted RT_FLOW event.
+///
+/// `max_sessions` caps the worker session table BEFORE the poll: `Some(0)`
+/// forces the ForwardCandidate install to be REFUSED (admission cap), which
+/// exercises the cache-declined / short-lived permitted-flow path the #2617
+/// fix repairs — the accepted `then log` must still emit on the miss packet
+/// even though no session is installed.
+fn run_input_filter_accept_log_poll(
+    max_sessions: Option<usize>,
+) -> (
+    crate::event_stream::EventStreamWorkerHandle,
+    std::sync::mpsc::Receiver<crate::event_stream::codec::EventFrame>,
+) {
     let mut snapshot = policy_deny_snapshot();
     snapshot.default_policy = "permit".to_string();
     snapshot.policies.clear();
@@ -4303,6 +4318,9 @@ fn poll_descriptor_input_filter_log_path_emits_rt_flow_event() {
         cold_path_sample_mask: 0xff,
     };
     let mut sessions = SessionTable::new();
+    if let Some(cap) = max_sessions {
+        sessions.set_max_sessions_for_test(cap);
+    }
     let mut screen = ScreenState::new();
     let mut batch = BatchCounters::default();
     let mut dbg = DebugPollCounters::default();
@@ -4334,6 +4352,16 @@ fn poll_descriptor_input_filter_log_path_emits_rt_flow_event() {
         &mut telemetry,
     );
 
+    (event_handle, event_rx)
+}
+
+/// Assert the common shape of the emitted accepted input-filter `then log`
+/// RT_FLOW event (shared by the install-success and install-refused #2617
+/// tests).
+fn assert_input_filter_accept_log_event(
+    event_handle: &crate::event_stream::EventStreamWorkerHandle,
+    event_rx: &std::sync::mpsc::Receiver<crate::event_stream::codec::EventFrame>,
+) {
     let event = event_rx
         .try_recv()
         .expect("input filter-log event from poll descriptor")
@@ -4350,6 +4378,28 @@ fn poll_descriptor_input_filter_log_path_emits_rt_flow_event() {
     assert_eq!(event.ingress_zone_id, TEST_LAN_ZONE_ID);
     assert_eq!(event.egress_zone_id, 0);
     assert_eq!(event_handle.dataplane_event_stats().filter_log.sent, 1);
+}
+
+#[test]
+fn poll_descriptor_input_filter_log_path_emits_rt_flow_event() {
+    // Default session cap: the ForwardCandidate flow installs a session.
+    let (event_handle, event_rx) = run_input_filter_accept_log_poll(None);
+    assert_input_filter_accept_log_event(&event_handle, &event_rx);
+}
+
+#[test]
+fn poll_descriptor_input_filter_accept_log_emits_on_install_refused_miss() {
+    // #2617 fail-on-revert guard. With the session table capped at 0 the
+    // ForwardCandidate install is REFUSED (admission cap) and the miss
+    // packet is dropped via `continue` BEFORE the former per-install emit
+    // site. The accepted `then log` term must still emit its RT_FLOW audit
+    // record on this first/only packet, otherwise a cache-declined or
+    // short-lived permitted flow logs nothing at all. Before the fix moved
+    // the emit to the single early accept-fall-through site, this asserted
+    // `try_recv()` found NO event and `filter_log.sent == 0` — reverting the
+    // fix turns this test RED.
+    let (event_handle, event_rx) = run_input_filter_accept_log_poll(Some(0));
+    assert_input_filter_accept_log_event(&event_handle, &event_rx);
 }
 
 #[test]


### PR DESCRIPTION
Closes #2617

## Summary
- An accepted interface input-filter term (`then { log; accept; }`) did not emit its RT_FLOW audit record on the **session-miss (first) packet** for two accept exits, only on the per-install success branch.
- The accepted log was otherwise just **stored** in the flow-cache descriptor for cache-hit replay on subsequent packets — so a short-lived or cache-declined permitted flow could log late, or never.
- Fix: emit the matched `then log` event once at the **accept fall-through** in `poll_binding_process_descriptor`, before the terminal-action branch, and remove the now-redundant per-install emit site.

## Accept-path log semantics (after fix)
The emit is a single early site, giving **exactly-once miss-packet** semantics across every accept exit:

| Accept exit | Master (buggy) | This PR |
|---|---|---|
| ForwardCandidate, session install **succeeds** | emits (at ~L1850 install site) | emits once (early site) |
| ForwardCandidate, install **refused** (max-sessions) | **no emit** — `continue` drops before install site | emits once |
| LocalDelivery (host-bound) | **no emit** — never reaches install site | emits once |

- The log reuses the SAME counted filter evaluation, so the emit does **not re-count** the filter hit.
- The flow-cache descriptor still stores the log (via the non-counting `evaluate_non_pbr_input_filter_log_only`) for cache-hit replay on **subsequent** packets. The miss packet never takes the cache-hit path → **no double-log** of the same packet.
- Behavior bit-identical to the prior non-Accept (discard/reject) immediate-emit path.

## Test plan
- [x] `cargo build --release` clean.
- [x] Added fail-on-revert guard `poll_descriptor_input_filter_accept_log_emits_on_install_refused_miss` (caps the session table at 0 → install refused → asserts the accepted `then log` still emits one `source=input` event).
- [x] **Fail-on-revert proven**: reverting `mod.rs` to `origin/master` turns the new test RED (`input filter-log event from poll descriptor: Empty`, `filter_log.sent == 0`); the install-success test and the discard test stay green. Restored fix → all green.
- [x] Refactored the existing accept-log poll test into a shared parameterized harness (`run_input_filter_accept_log_poll` + `assert_input_filter_accept_log_event`).
- [x] Full `afxdp::tests` (156) green — no double-log regression in adjacent `filter_log.sent` assertions.
- [x] `filter` / `event_stream` / `flow_cache` / `protocol_wire` suites green (one unrelated timing flake `stalled_consumer_does_not_grow_backlog_unbounded_end_to_end` passes in isolation).
- No wire change.

## Docs
- Updated `docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md` to record the new contract: accepted `then log` emits on the miss packet across all accept exits, plus cache-hit replay for subsequent packets, no double-log.

## Refs
- #2617 (codex review-040 finding 040-02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi