### PR TITLE
userspace-dp: count pre-PBR fall-through term once on session-miss (#2620)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -2,28 +2,44 @@
 
 - **Timestamp**: 2026-06-25
 - **Action**: On the session-miss path a route-lookup-affecting interface
-  input filter runs two counted evaluators over the same terms: the
-  non-routing precheck (`evaluate_interface_filter_non_routing_counted`)
-  for the verdict, then the routing-instance evaluator
+  input filter runs the non-routing precheck
+  (`evaluate_interface_filter_non_routing_counted`) for the verdict and —
+  ONLY on the precheck's Accept verdict — the routing-instance evaluator
   (`evaluate_interface_filter_routing_instance_event_counted`, via
-  `ingress_route_table_override`). Both called `record_filter_counter` for
-  a matched `then { count X; next term; }` fall-through term ahead of the
-  `then routing-instance` term, double-counting that term on one miss
-  packet (codex review-040 finding 040-06). Fix: added a `count: bool`
-  parameter to `evaluate_interface_filter_non_routing_counted` and its
-  `evaluate_filter_ref_non_routing_counted_v4/v6` bodies; the miss-path
-  caller `evaluate_non_pbr_input_filter` sets it to
-  `!interface_filter_affects_route_lookup(...)`. When a PBR term exists the
-  routing evaluator owns the count (precheck `count=false`); with no PBR
-  term the routing evaluator never runs and the precheck owns it
-  (`count=true`, behavior unchanged). The routing-instance evaluator already
-  counts every matched term up to the terminating one even when it returns
-  None, so the single owner is complete on every miss exit. Added a
-  fail-on-revert regression replicating the two-evaluator miss sequence
-  (asserts exactly-once; proved RED at left:2/right:1 on revert, restored).
-  No wire change (`wire_invariant_default_specimens` green).
+  `ingress_route_table_override`). On a non-Accept verdict the poll path
+  `continue`s and the routing evaluator NEVER runs. Both called
+  `record_filter_counter` for a matched `then { count X; next term; }`
+  fall-through term ahead of the `then routing-instance` term, so on the
+  Accept exit that term was double-counted on one miss packet (codex
+  review-040 finding 040-06). Counter ownership is per-EXIT, not a static
+  property of the filter. Initial fix used a coarse `count: bool` gated on
+  `!interface_filter_affects_route_lookup(...)`, which introduced a NEW
+  under-count: a terminal `discard`/`reject` ahead of the routing-instance
+  term, and the DSCP/L4 session-HIT re-eval, both reach the precheck while
+  the routing evaluator never runs — the coarse gate dropped those counts
+  to zero. Corrected fix: a `NonRoutingCountPolicy` enum (`Always` |
+  `OnlyTerminalNonAccept`) on
+  `evaluate_interface_filter_non_routing_counted` +
+  `evaluate_filter_ref_non_routing_counted_v4/v6`.
+  `evaluate_non_pbr_input_filter` takes `routing_eval_follows` and derives
+  the policy as `OnlyTerminalNonAccept` only when
+  `routing_eval_follows && affects_route_lookup`, else `Always`. Under
+  `OnlyTerminalNonAccept` the precheck counts nothing on the Accept exit
+  (routing eval owns it) but replays the matched-term walk to count
+  up-to-and-including the terminal on a `discard`/`reject` (via the new
+  `count_matched_non_routing_terms_v4/v6` helpers, ptr-eq terminal stop).
+  Miss-path call site passes `routing_eval_follows=true`; session-hit
+  re-eval passes `false`. Exactly-once on all four exits: Accept+PBR (once,
+  routing eval), discard/reject-before-PBR (once, precheck), plain non-PBR
+  (once, precheck), DSCP/L4 session-hit (once per packet, precheck). Four
+  regression tests; proved RED-on-revert: double-count revert →
+  exactly-once test left:2/right:1; under-count revert → terminal-discard
+  test left:0/right:1. Restored, full filter+poll_descriptor suite 188/0,
+  no wire change (`wire_invariant_default_specimens` green).
 - **File(s)**: userspace-dp/src/filter/engine/eval.rs,
+  userspace-dp/src/filter/engine/mod.rs,
   userspace-dp/src/afxdp/poll_descriptor/filter.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
   userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
   _Log.md
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-06-25 — #2620: PBR session-miss counts pre-PBR fall-through term once
+
+- **Timestamp**: 2026-06-25
+- **Action**: On the session-miss path a route-lookup-affecting interface
+  input filter runs two counted evaluators over the same terms: the
+  non-routing precheck (`evaluate_interface_filter_non_routing_counted`)
+  for the verdict, then the routing-instance evaluator
+  (`evaluate_interface_filter_routing_instance_event_counted`, via
+  `ingress_route_table_override`). Both called `record_filter_counter` for
+  a matched `then { count X; next term; }` fall-through term ahead of the
+  `then routing-instance` term, double-counting that term on one miss
+  packet (codex review-040 finding 040-06). Fix: added a `count: bool`
+  parameter to `evaluate_interface_filter_non_routing_counted` and its
+  `evaluate_filter_ref_non_routing_counted_v4/v6` bodies; the miss-path
+  caller `evaluate_non_pbr_input_filter` sets it to
+  `!interface_filter_affects_route_lookup(...)`. When a PBR term exists the
+  routing evaluator owns the count (precheck `count=false`); with no PBR
+  term the routing evaluator never runs and the precheck owns it
+  (`count=true`, behavior unchanged). The routing-instance evaluator already
+  counts every matched term up to the terminating one even when it returns
+  None, so the single owner is complete on every miss exit. Added a
+  fail-on-revert regression replicating the two-evaluator miss sequence
+  (asserts exactly-once; proved RED at left:2/right:1 on revert, restored).
+  No wire change (`wire_invariant_default_specimens` green).
+- **File(s)**: userspace-dp/src/filter/engine/eval.rs,
+  userspace-dp/src/afxdp/poll_descriptor/filter.rs,
+  userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md,
+  _Log.md
+
 ## 2026-06-25 — #2623: GARP/NDP burst follow-up sends now count + surface errors
 
 - **Timestamp**: 2026-06-25

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -103,6 +103,20 @@ pub(super) fn evaluate_non_pbr_input_filter(
     )
     .unwrap_or(meta.ingress_ifindex as i32);
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
+    // #2620: suppress fall-through `then count` recording here when the filter
+    // is route-lookup-affecting (a routing-instance / PBR term exists). On the
+    // session-miss path this precheck is paired with
+    // `ingress_route_table_override`, which calls
+    // `evaluate_interface_filter_routing_instance_event_counted` over the SAME
+    // terms and records their counters. Counting in both evaluators
+    // double-counts every matched `then { count X; next term; }` ahead of the
+    // routing-instance term. When no PBR term exists the routing evaluator
+    // never runs, so this precheck owns the count (count = true, unchanged).
+    let count = !crate::filter::interface_filter_affects_route_lookup(
+        &forwarding.filter_state,
+        ingress_ifindex,
+        is_v6,
+    );
     let result = crate::filter::evaluate_interface_filter_non_routing_counted(
         &forwarding.filter_state,
         ingress_ifindex,
@@ -115,6 +129,7 @@ pub(super) fn evaluate_non_pbr_input_filter(
         meta.dscp,
         extra,
         meta.pkt_len as u64,
+        count,
     );
     let ingress_zone_id =
         filter_log_ingress_zone_id(forwarding, meta, ingress_zone_override, ingress_ifindex);

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -89,6 +89,7 @@ pub(super) fn evaluate_non_pbr_input_filter(
     flow: Option<&SessionFlow>,
     meta: UserspaceDpMeta,
     ingress_zone_override: Option<u16>,
+    routing_eval_follows: bool,
 ) -> NonPbrInputFilterEval {
     let Some(flow) = flow else {
         return NonPbrInputFilterEval {
@@ -103,20 +104,31 @@ pub(super) fn evaluate_non_pbr_input_filter(
     )
     .unwrap_or(meta.ingress_ifindex as i32);
     let is_v6 = matches!(flow.dst_ip, IpAddr::V6(_));
-    // #2620: suppress fall-through `then count` recording here when the filter
-    // is route-lookup-affecting (a routing-instance / PBR term exists). On the
-    // session-miss path this precheck is paired with
-    // `ingress_route_table_override`, which calls
-    // `evaluate_interface_filter_routing_instance_event_counted` over the SAME
-    // terms and records their counters. Counting in both evaluators
-    // double-counts every matched `then { count X; next term; }` ahead of the
-    // routing-instance term. When no PBR term exists the routing evaluator
-    // never runs, so this precheck owns the count (count = true, unchanged).
-    let count = !crate::filter::interface_filter_affects_route_lookup(
-        &forwarding.filter_state,
-        ingress_ifindex,
-        is_v6,
-    );
+    // #2620: pick the counter-ownership policy. `routing_eval_follows` is true
+    // ONLY on the session-MISS path, where the caller proceeds to
+    // `ingress_route_table_override` after an Accept verdict from this precheck.
+    // When that path is taken AND the filter is route-lookup-affecting, the
+    // routing-instance evaluator runs on the Accept/defer exit and counts the
+    // same terms — so this precheck must count only on the terminal
+    // discard/reject exit the routing evaluator can't reach (the poll path
+    // `continue`s on a non-Accept verdict, never calling the routing
+    // evaluator). `OnlyTerminalNonAccept` avoids BOTH the #2620 double-count
+    // (count in both evaluators on Accept) AND the under-count regression
+    // (count in neither on a discard/reject ahead of the routing-instance
+    // term). Otherwise — a non-PBR-affecting filter, or the session-HIT re-eval
+    // (`routing_eval_follows == false`, which never invokes the routing
+    // evaluator) — this evaluator is the SOLE per-packet counter: `Always`
+    // (pre-#2620 behavior).
+    let count_policy = if routing_eval_follows
+        && crate::filter::interface_filter_affects_route_lookup(
+            &forwarding.filter_state,
+            ingress_ifindex,
+            is_v6,
+        ) {
+        crate::filter::NonRoutingCountPolicy::OnlyTerminalNonAccept
+    } else {
+        crate::filter::NonRoutingCountPolicy::Always
+    };
     let result = crate::filter::evaluate_interface_filter_non_routing_counted(
         &forwarding.filter_state,
         ingress_ifindex,
@@ -129,7 +141,7 @@ pub(super) fn evaluate_non_pbr_input_filter(
         meta.dscp,
         extra,
         meta.pkt_len as u64,
-        count,
+        count_policy,
     );
     let ingress_zone_id =
         filter_log_ingress_zone_id(forwarding, meta, ingress_zone_override, ingress_ifindex);
@@ -220,12 +232,17 @@ pub(super) fn evaluate_dscp_sensitive_input_filter_on_session_hit(
         return None;
     }
     let extra = term_match_extra_from_frame(frame, meta);
+    // #2620: the session-HIT re-eval is the SOLE counter for this packet — it
+    // never calls `ingress_route_table_override`/the routing evaluator. Pass
+    // `routing_eval_follows = false` so it counts on every exit (per-packet,
+    // pre-#2620 behavior), even when the filter is route-lookup-affecting.
     Some(evaluate_non_pbr_input_filter(
         forwarding,
         extra,
         Some(flow),
         meta,
         ingress_zone_override,
+        false,
     ))
 }
 

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -835,12 +835,19 @@ pub(super) fn poll_binding_process_descriptor(
                             .as_ref()
                             .and_then(|d| d.rewrite_dst_port)
                             .unwrap_or(flow.forward_key.dst_port);
+                        // #2620: session-MISS path — an Accept verdict here
+                        // proceeds to ingress_route_table_override (the routing
+                        // evaluator), so pass routing_eval_follows = true. The
+                        // precheck then counts only on the terminal
+                        // discard/reject exit (the routing evaluator owns the
+                        // Accept/defer exit count).
                         let input_filter_eval = evaluate_non_pbr_input_filter(
                             worker_ctx.forwarding,
                             crate::afxdp::frame::term_match_extra_from_frame(packet_frame, meta),
                             Some(flow),
                             meta,
                             ingress_zone_override,
+                            true,
                         );
                         // #2617: emit the matched input-filter `then log` event
                         // on THIS (session-miss / first) packet, regardless of

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -109,6 +109,28 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   dataplane denies the packet. For a terminating logging term
   `term.action` already equals the final verdict, so normalization is a
   no-op there.
+
+  **PBR session-miss counts each fall-through term exactly once (#2620).**
+  When an interface input filter is route-lookup-affecting (it has a
+  `then routing-instance` term), the session-miss path runs TWO evaluators
+  over the same filter: the non-routing precheck
+  (`evaluate_interface_filter_non_routing_counted`) for the terminal
+  verdict, then the routing-instance evaluator
+  (`evaluate_interface_filter_routing_instance_event_counted`, via
+  `ingress_route_table_override`) for the route override. Both walk every
+  matched term, so a `then { count X; next term; }` fall-through term ahead
+  of the routing-instance term was counted TWICE on one miss packet. The
+  precheck now takes a `count: bool`; the miss-path caller
+  (`evaluate_non_pbr_input_filter`) sets it to
+  `!interface_filter_affects_route_lookup(...)`. When a routing-instance
+  term exists the routing evaluator owns the count, so the precheck passes
+  `count = false` and records nothing; with no PBR term the routing
+  evaluator never runs and the precheck owns the count (`count = true`,
+  unchanged). The routing-instance evaluator already counts every matched
+  term up to and including the terminating one — even when it ultimately
+  returns `None` (a non-PBR terminal `discard` ahead of any
+  routing-instance term) — so the single owner is complete on every
+  miss-path exit.
 - `policer.rs` — token-bucket implementation plus the #1375 RFC
   2697/2698 three-color meter core. Token math is integer-only:
   the legacy token bucket keeps its bits/sec constructor contract, and

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -112,25 +112,49 @@ Mirrors the BPF firewall-filter pipeline in userspace.
 
   **PBR session-miss counts each fall-through term exactly once (#2620).**
   When an interface input filter is route-lookup-affecting (it has a
-  `then routing-instance` term), the session-miss path runs TWO evaluators
-  over the same filter: the non-routing precheck
+  `then routing-instance` term), the session-miss path can run TWO
+  evaluators over the same filter: the non-routing precheck
   (`evaluate_interface_filter_non_routing_counted`) for the terminal
-  verdict, then the routing-instance evaluator
+  verdict, and — ONLY on the precheck's Accept verdict — the
+  routing-instance evaluator
   (`evaluate_interface_filter_routing_instance_event_counted`, via
-  `ingress_route_table_override`) for the route override. Both walk every
-  matched term, so a `then { count X; next term; }` fall-through term ahead
-  of the routing-instance term was counted TWICE on one miss packet. The
-  precheck now takes a `count: bool`; the miss-path caller
-  (`evaluate_non_pbr_input_filter`) sets it to
-  `!interface_filter_affects_route_lookup(...)`. When a routing-instance
-  term exists the routing evaluator owns the count, so the precheck passes
-  `count = false` and records nothing; with no PBR term the routing
-  evaluator never runs and the precheck owns the count (`count = true`,
-  unchanged). The routing-instance evaluator already counts every matched
-  term up to and including the terminating one — even when it ultimately
-  returns `None` (a non-PBR terminal `discard` ahead of any
-  routing-instance term) — so the single owner is complete on every
-  miss-path exit.
+  `ingress_route_table_override`) for the route override. On a NON-Accept
+  verdict (`discard`/`reject`) the poll path `continue`s and the routing
+  evaluator NEVER runs. Both evaluators walk every matched term, so without
+  care a `then { count X; next term; }` fall-through term ahead of the
+  routing-instance term was counted TWICE on the Accept exit. Counter
+  ownership is therefore per-EXIT, not a property of the filter:
+
+  - **Accept / defer exit** (fall-through to default, or a matched
+    routing-instance term): the routing evaluator runs and counts every
+    matched term up to and including the routing-instance term. The
+    precheck must NOT count.
+  - **Terminal `discard`/`reject` exit** (a non-Accept term matched, with
+    `then count` fall-through terms ahead of it): the routing evaluator
+    never runs, so the precheck is the sole counter and records each
+    matched `then count` term up to and including the terminating one.
+  - **Plain non-PBR filter** (no routing-instance term): the routing
+    evaluator returns early at the `affects_route_lookup` guard and counts
+    nothing, so the precheck owns the count on every exit.
+  - **DSCP/L4 session-HIT re-eval**
+    (`evaluate_dscp_sensitive_input_filter_on_session_hit`): this never
+    invokes the routing evaluator, so the precheck counts per packet on
+    every exit (pre-#2620 behavior).
+
+  The precheck takes a `count_policy: NonRoutingCountPolicy`:
+  `OnlyTerminalNonAccept` (count only on the terminal discard/reject exit —
+  the routing evaluator owns the Accept exit count) vs `Always` (precheck
+  is the sole counter, counts on every exit).
+  `evaluate_non_pbr_input_filter` derives it as `OnlyTerminalNonAccept`
+  when `routing_eval_follows && interface_filter_affects_route_lookup(...)`
+  else `Always`. The miss-path call site passes `routing_eval_follows =
+  true` (an Accept proceeds to `ingress_route_table_override`); the
+  session-hit re-eval passes `false`. This yields exactly one count per
+  matched `then count` term on all four exits — neither the double-count on
+  the Accept exit nor an under-count on the discard/reject or session-hit
+  exits. (The earlier coarse fix gated the precheck solely on
+  `affects_route_lookup`; that under-counted to zero on the discard/reject
+  and session-hit exits, where the routing evaluator is never the counter.)
 - `policer.rs` — token-bucket implementation plus the #1375 RFC
   2697/2698 three-color meter core. Token math is integer-only:
   the legacy token bucket keeps its bits/sec constructor contract, and

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -219,6 +219,38 @@ fn evaluate_filter_ref_counted_v6(
     acc
 }
 
+/// #2620: counter ownership policy for the non-routing input-filter evaluator.
+///
+/// The session-miss path runs this precheck for the verdict AND — only on its
+/// Accept/defer exit (`poll_descriptor/mod.rs` does `continue` on a non-Accept
+/// verdict, never reaching the routing evaluator) — the routing-instance
+/// evaluator (`evaluate_interface_filter_routing_instance_event_counted`, via
+/// `ingress_route_table_override`), which counts every matched term itself.
+/// So WHO owns the count depends on the per-packet exit, not just on whether
+/// the filter has a routing-instance term:
+///
+/// * `Always` — this precheck is the SOLE counter for the packet. Used when no
+///   routing-instance term exists in the filter (the routing evaluator returns
+///   early at the `affects_route_lookup` guard and counts nothing) AND on the
+///   DSCP/L4-sensitive SESSION-HIT re-eval path (`evaluate_dscp_sensitive_input_filter_on_session_hit`),
+///   which never invokes the routing evaluator. Counts every matched `then
+///   count` term on every exit — bit-identical to pre-#2620 behavior.
+/// * `OnlyTerminalNonAccept` — used on the session-MISS path when the filter IS
+///   route-lookup-affecting. The routing evaluator runs and counts on the
+///   Accept/defer exit, so this precheck must NOT count there (else the
+///   fall-through `then count` ahead of the routing-instance term double-counts,
+///   the #2620 bug). But on a terminal `discard`/`reject` exit BEFORE the
+///   routing-instance term the poll path `continue`s and the routing evaluator
+///   never runs — so this precheck IS the sole counter on that exit and must
+///   count every matched `then count` term up to and including the terminal one
+///   (else those terms under-count to zero, the regression the coarse boolean
+///   gate introduced).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NonRoutingCountPolicy {
+    Always,
+    OnlyTerminalNonAccept,
+}
+
 #[inline]
 fn evaluate_filter_ref_non_routing_counted(
     filter: &Filter,
@@ -230,7 +262,7 @@ fn evaluate_filter_ref_non_routing_counted(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
-    count: bool,
+    count_policy: NonRoutingCountPolicy,
 ) -> FilterResult {
     match (src_ip, dst_ip) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_non_routing_counted_v4(
@@ -243,7 +275,7 @@ fn evaluate_filter_ref_non_routing_counted(
             dscp,
             extra,
             packet_bytes,
-            count,
+            count_policy,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_non_routing_counted_v6(
             filter,
@@ -255,7 +287,7 @@ fn evaluate_filter_ref_non_routing_counted(
             dscp,
             extra,
             packet_bytes,
-            count,
+            count_policy,
         ),
         _ => FilterResult::default(),
     }
@@ -272,20 +304,22 @@ fn evaluate_filter_ref_non_routing_counted_v4(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
-    count: bool,
+    count_policy: NonRoutingCountPolicy,
 ) -> FilterResult {
     // #2544: accumulate fall-through modifiers (count/log/fc/dscp). A matched
     // term that points at a routing-instance defers to the routing-instance
     // evaluator (returns default here, unchanged); such a term is never a
     // fall-through (continue_term is false when routing_instance is set).
     //
-    // #2620: `count` is false on the session-miss path when the interface
-    // filter is route-lookup-affecting — the paired routing-instance evaluator
-    // (`ingress_route_table_override`) traverses the SAME terms and records
-    // their counters there, so counting here too would double-count every
-    // matched fall-through `then count` term ahead of the routing-instance
-    // term. With no PBR term the routing evaluator never runs, so this path
-    // owns counting and `count` is true (current behavior preserved).
+    // #2620: counting follows `count_policy` (see NonRoutingCountPolicy). Under
+    // `Always` every matched `then count` term records inline. Under
+    // `OnlyTerminalNonAccept` we do NOT count during the walk — the routing
+    // evaluator owns the count on the Accept/defer exit — and instead replay the
+    // count over the matched terms ONLY when this evaluator reaches a terminal
+    // `discard`/`reject` (the exit on which the poll path `continue`s and the
+    // routing evaluator never runs), so those fall-through counters are recorded
+    // exactly once and never drop to zero.
+    let always_count = count_policy == NonRoutingCountPolicy::Always;
     let mut acc = FilterResult::default();
     for term in &filter.terms {
         if !term_matches_v4(
@@ -296,7 +330,7 @@ fn evaluate_filter_ref_non_routing_counted_v4(
         if !term.routing_instance.is_empty() {
             return FilterResult::default();
         }
-        if count && term.has_count {
+        if always_count && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
         merge_matched_modifiers(&mut acc, filter, term);
@@ -305,12 +339,63 @@ fn evaluate_filter_ref_non_routing_counted_v4(
         acc.routing_instance = String::new();
         if !term.continue_term {
             acc.action = term.action;
+            if !always_count && term.action != FilterAction::Accept {
+                count_matched_non_routing_terms_v4(
+                    filter,
+                    src_ip,
+                    dst_ip,
+                    protocol,
+                    src_port,
+                    dst_port,
+                    dscp,
+                    extra,
+                    packet_bytes,
+                    term,
+                );
+            }
             normalize_log_match_action(&mut acc);
             return acc;
         }
     }
     normalize_log_match_action(&mut acc);
     acc
+}
+
+/// #2620: replay the matched-term walk under `OnlyTerminalNonAccept` once the
+/// caller has resolved that the verdict is a terminal `discard`/`reject`,
+/// recording each matched `then count` term up to AND INCLUDING `terminal`
+/// exactly once. The routing evaluator never runs on this exit, so this
+/// evaluator is the sole counter. Walk order is identical to the main loop so
+/// the recorded set matches.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn count_matched_non_routing_terms_v4(
+    filter: &Filter,
+    src_ip: Ipv4Addr,
+    dst_ip: Ipv4Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    extra: TermMatchExtra,
+    packet_bytes: u64,
+    terminal: &FilterTerm,
+) {
+    for term in &filter.terms {
+        if !term_matches_v4(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
+            continue;
+        }
+        // A routing-instance term would have made the main loop return default
+        // before reaching the terminal; it can never precede `terminal` here.
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        if std::ptr::eq(term, terminal) {
+            return;
+        }
+    }
 }
 
 #[inline]
@@ -324,11 +409,10 @@ fn evaluate_filter_ref_non_routing_counted_v6(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
-    count: bool,
+    count_policy: NonRoutingCountPolicy,
 ) -> FilterResult {
-    // #2544: see evaluate_filter_ref_non_routing_counted_v4.
-    // #2620: `count` gating mirrors the v4 variant — false on the PBR-affecting
-    // session-miss path so the routing-instance evaluator owns the count.
+    // #2544/#2620: see evaluate_filter_ref_non_routing_counted_v4.
+    let always_count = count_policy == NonRoutingCountPolicy::Always;
     let mut acc = FilterResult::default();
     for term in &filter.terms {
         if !term_matches_v6(
@@ -339,19 +423,63 @@ fn evaluate_filter_ref_non_routing_counted_v6(
         if !term.routing_instance.is_empty() {
             return FilterResult::default();
         }
-        if count && term.has_count {
+        if always_count && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
         merge_matched_modifiers(&mut acc, filter, term);
         acc.routing_instance = String::new();
         if !term.continue_term {
             acc.action = term.action;
+            if !always_count && term.action != FilterAction::Accept {
+                count_matched_non_routing_terms_v6(
+                    filter,
+                    src_ip,
+                    dst_ip,
+                    protocol,
+                    src_port,
+                    dst_port,
+                    dscp,
+                    extra,
+                    packet_bytes,
+                    term,
+                );
+            }
             normalize_log_match_action(&mut acc);
             return acc;
         }
     }
     normalize_log_match_action(&mut acc);
     acc
+}
+
+/// #2620: v6 counterpart of `count_matched_non_routing_terms_v4`.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn count_matched_non_routing_terms_v6(
+    filter: &Filter,
+    src_ip: Ipv6Addr,
+    dst_ip: Ipv6Addr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    dscp: u8,
+    extra: TermMatchExtra,
+    packet_bytes: u64,
+    terminal: &FilterTerm,
+) {
+    for term in &filter.terms {
+        if !term_matches_v6(
+            term, src_ip, dst_ip, protocol, src_port, dst_port, dscp, extra,
+        ) {
+            continue;
+        }
+        if term.has_count {
+            record_filter_counter(&term.counter, packet_bytes);
+        }
+        if std::ptr::eq(term, terminal) {
+            return;
+        }
+    }
 }
 
 #[inline]
@@ -600,17 +728,17 @@ pub(crate) fn evaluate_interface_filter_counted(
     )
 }
 
-/// Evaluate the per-interface input filter for the session-miss decision,
-/// deferring any routing-instance (PBR) term to the routing-instance evaluator.
+/// Evaluate the per-interface input filter for the session-miss / session-hit
+/// decision, deferring any routing-instance (PBR) term to the routing-instance
+/// evaluator. `count_policy` selects who owns the per-packet count — see
+/// [`NonRoutingCountPolicy`] (#2620). The caller picks:
 ///
-/// `count` controls whether matched fall-through `then count` terms record
-/// their counters here. On the session-miss path the caller passes
-/// `count = !interface_filter_affects_route_lookup(...)`: when the filter is
-/// route-lookup-affecting the paired `evaluate_interface_filter_routing_instance_event_counted`
-/// traverses the SAME terms and records their counters, so this evaluator must
-/// NOT count (else every fall-through `then count` ahead of the routing-instance
-/// term double-counts on one miss packet, #2620). When no PBR term exists the
-/// routing evaluator never runs and this path owns the count (`count = true`).
+/// * `OnlyTerminalNonAccept` on the session-MISS path when the filter is
+///   route-lookup-affecting (the routing evaluator runs on the Accept exit and
+///   counts there; this evaluator counts only on the terminal discard/reject
+///   exit the routing evaluator can't reach), and
+/// * `Always` otherwise — a plain non-PBR filter, or the DSCP/L4 session-HIT
+///   re-eval, where this evaluator is the SOLE counter.
 pub(crate) fn evaluate_interface_filter_non_routing_counted(
     state: &FilterState,
     ifindex: i32,
@@ -623,7 +751,7 @@ pub(crate) fn evaluate_interface_filter_non_routing_counted(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
-    count: bool,
+    count_policy: NonRoutingCountPolicy,
 ) -> FilterResult {
     let filter = if is_v6 {
         state.iface_filter_v6_fast.get(&ifindex).map(Arc::as_ref)
@@ -643,7 +771,7 @@ pub(crate) fn evaluate_interface_filter_non_routing_counted(
         dscp,
         extra,
         packet_bytes,
-        count,
+        count_policy,
     )
 }
 

--- a/userspace-dp/src/filter/engine/eval.rs
+++ b/userspace-dp/src/filter/engine/eval.rs
@@ -230,6 +230,7 @@ fn evaluate_filter_ref_non_routing_counted(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
+    count: bool,
 ) -> FilterResult {
     match (src_ip, dst_ip) {
         (IpAddr::V4(src), IpAddr::V4(dst)) => evaluate_filter_ref_non_routing_counted_v4(
@@ -242,6 +243,7 @@ fn evaluate_filter_ref_non_routing_counted(
             dscp,
             extra,
             packet_bytes,
+            count,
         ),
         (IpAddr::V6(src), IpAddr::V6(dst)) => evaluate_filter_ref_non_routing_counted_v6(
             filter,
@@ -253,6 +255,7 @@ fn evaluate_filter_ref_non_routing_counted(
             dscp,
             extra,
             packet_bytes,
+            count,
         ),
         _ => FilterResult::default(),
     }
@@ -269,11 +272,20 @@ fn evaluate_filter_ref_non_routing_counted_v4(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
+    count: bool,
 ) -> FilterResult {
     // #2544: accumulate fall-through modifiers (count/log/fc/dscp). A matched
     // term that points at a routing-instance defers to the routing-instance
     // evaluator (returns default here, unchanged); such a term is never a
     // fall-through (continue_term is false when routing_instance is set).
+    //
+    // #2620: `count` is false on the session-miss path when the interface
+    // filter is route-lookup-affecting — the paired routing-instance evaluator
+    // (`ingress_route_table_override`) traverses the SAME terms and records
+    // their counters there, so counting here too would double-count every
+    // matched fall-through `then count` term ahead of the routing-instance
+    // term. With no PBR term the routing evaluator never runs, so this path
+    // owns counting and `count` is true (current behavior preserved).
     let mut acc = FilterResult::default();
     for term in &filter.terms {
         if !term_matches_v4(
@@ -284,7 +296,7 @@ fn evaluate_filter_ref_non_routing_counted_v4(
         if !term.routing_instance.is_empty() {
             return FilterResult::default();
         }
-        if term.has_count {
+        if count && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
         merge_matched_modifiers(&mut acc, filter, term);
@@ -312,8 +324,11 @@ fn evaluate_filter_ref_non_routing_counted_v6(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
+    count: bool,
 ) -> FilterResult {
     // #2544: see evaluate_filter_ref_non_routing_counted_v4.
+    // #2620: `count` gating mirrors the v4 variant — false on the PBR-affecting
+    // session-miss path so the routing-instance evaluator owns the count.
     let mut acc = FilterResult::default();
     for term in &filter.terms {
         if !term_matches_v6(
@@ -324,7 +339,7 @@ fn evaluate_filter_ref_non_routing_counted_v6(
         if !term.routing_instance.is_empty() {
             return FilterResult::default();
         }
-        if term.has_count {
+        if count && term.has_count {
             record_filter_counter(&term.counter, packet_bytes);
         }
         merge_matched_modifiers(&mut acc, filter, term);
@@ -585,6 +600,17 @@ pub(crate) fn evaluate_interface_filter_counted(
     )
 }
 
+/// Evaluate the per-interface input filter for the session-miss decision,
+/// deferring any routing-instance (PBR) term to the routing-instance evaluator.
+///
+/// `count` controls whether matched fall-through `then count` terms record
+/// their counters here. On the session-miss path the caller passes
+/// `count = !interface_filter_affects_route_lookup(...)`: when the filter is
+/// route-lookup-affecting the paired `evaluate_interface_filter_routing_instance_event_counted`
+/// traverses the SAME terms and records their counters, so this evaluator must
+/// NOT count (else every fall-through `then count` ahead of the routing-instance
+/// term double-counts on one miss packet, #2620). When no PBR term exists the
+/// routing evaluator never runs and this path owns the count (`count = true`).
 pub(crate) fn evaluate_interface_filter_non_routing_counted(
     state: &FilterState,
     ifindex: i32,
@@ -597,6 +623,7 @@ pub(crate) fn evaluate_interface_filter_non_routing_counted(
     dscp: u8,
     extra: TermMatchExtra,
     packet_bytes: u64,
+    count: bool,
 ) -> FilterResult {
     let filter = if is_v6 {
         state.iface_filter_v6_fast.get(&ifindex).map(Arc::as_ref)
@@ -616,6 +643,7 @@ pub(crate) fn evaluate_interface_filter_non_routing_counted(
         dscp,
         extra,
         packet_bytes,
+        count,
     )
 }
 

--- a/userspace-dp/src/filter/engine/mod.rs
+++ b/userspace-dp/src/filter/engine/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use eval::{
     evaluate_interface_filter_routing_instance_counted,
     evaluate_interface_filter_routing_instance_event_counted, evaluate_interface_output_filter,
     evaluate_interface_output_filter_counted, evaluate_lo0_filter, evaluate_lo0_filter_counted,
-    evaluate_lo0_filter_log_match, interface_filter_affects_route_lookup,
+    evaluate_lo0_filter_log_match, interface_filter_affects_route_lookup, NonRoutingCountPolicy,
 };
 pub(crate) use policer::{
     apply_cached_three_color_policers, filter_state_has_input_three_color_policer,

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2605,7 +2605,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         0,
         TermMatchExtra::default(),
         1400,
-        true,
+        NonRoutingCountPolicy::Always,
     );
     assert_eq!(pbr.action, FilterAction::Accept);
     assert!(pbr.routing_instance.is_empty());
@@ -2626,7 +2626,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         0,
         TermMatchExtra::default(),
         500,
-        true,
+        NonRoutingCountPolicy::Always,
     );
     assert_eq!(plain.action, FilterAction::Discard);
     assert_eq!(filter.terms[1].counter.packets.load(Ordering::Relaxed), 1);
@@ -5469,22 +5469,45 @@ fn pbr_evaluator_log_on_routing_instance_term_itself() {
 }
 
 // ---------------------------------------------------------------------------
-// #2620: the PBR (routing-instance) session-miss path runs TWO evaluators over
-// the same interface filter — the non-routing precheck
-// (`evaluate_interface_filter_non_routing_counted`) for the verdict, then the
-// routing-instance evaluator (`evaluate_interface_filter_routing_instance_event_counted`,
-// via `ingress_route_table_override`) for the route override. Both traverse the
-// same terms, so a `then { count X; next term; }` fall-through term ahead of the
-// `then routing-instance` term was counted twice on one miss packet.
+// #2620: counting on the PBR session-miss path must be EXACTLY ONCE per matched
+// `then count` term, on every exit. The miss path runs TWO evaluators over the
+// same interface filter — the non-routing precheck
+// (`evaluate_interface_filter_non_routing_counted`) for the verdict, then, ONLY
+// when the precheck returns Accept, the routing-instance evaluator
+// (`evaluate_interface_filter_routing_instance_event_counted`, via
+// `ingress_route_table_override`). On a non-Accept verdict the poll path
+// `continue`s and the routing evaluator never runs.
 //
-// The fix gates counting in the precheck on `count`, which the miss-path caller
-// sets to `!interface_filter_affects_route_lookup(...)`: when a routing-instance
-// term exists the routing evaluator owns the count, so the precheck passes
-// `count = false`. This test reproduces the exact miss-path sequence and asserts
-// the fall-through counter increments EXACTLY ONCE. Counter-factual guard: if the
-// precheck counts unconditionally (revert the fix → pass `count = true` below),
-// the counter would read 2 and this test fails.
+// The precheck's counter ownership is selected by `NonRoutingCountPolicy`, which
+// `evaluate_non_pbr_input_filter` derives as
+// `OnlyTerminalNonAccept` when (routing_eval_follows && affects_route_lookup)
+// else `Always`. The helper below mirrors that derivation so the tests exercise
+// the SAME discriminator the dataplane uses.
+//
+// Cases covered:
+//   1. Accept + routing-instance term  → counted once (routing eval).
+//   2. terminal discard BEFORE the routing-instance term → counted once
+//      (precheck; the routing eval never runs — finding 1 regression guard).
+//   3. plain non-PBR filter            → counted once (precheck, Always).
+//   4. session-HIT DSCP/L4 + PBR-affecting → counted once per packet (Always),
+//      the routing evaluator is never invoked on that path (finding 3).
 // ---------------------------------------------------------------------------
+
+/// Mirror of `evaluate_non_pbr_input_filter`'s #2620 policy derivation so the
+/// tests pick the precheck count policy from the same discriminator as the
+/// dataplane.
+fn miss_path_count_policy(
+    state: &FilterState,
+    ifindex: i32,
+    is_v6: bool,
+    routing_eval_follows: bool,
+) -> NonRoutingCountPolicy {
+    if routing_eval_follows && interface_filter_affects_route_lookup(state, ifindex, is_v6) {
+        NonRoutingCountPolicy::OnlyTerminalNonAccept
+    } else {
+        NonRoutingCountPolicy::Always
+    }
+}
 
 #[test]
 fn pbr_miss_path_counts_fallthrough_term_exactly_once() {
@@ -5522,18 +5545,13 @@ fn pbr_miss_path_counts_fallthrough_term_exactly_once() {
     let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
     let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
 
-    // The interface filter carries a routing-instance term, so the miss path
-    // runs the routing-instance evaluator and the precheck must NOT count.
-    let affects_route_lookup =
-        interface_filter_affects_route_lookup(&state, 14, false);
-    assert!(
-        affects_route_lookup,
-        "filter with a routing-instance term must be route-lookup-affecting"
-    );
+    // Miss path, Accept verdict → routing evaluator follows. Policy resolves to
+    // OnlyTerminalNonAccept: the precheck must NOT count on the Accept exit.
+    let policy = miss_path_count_policy(&state, 14, false, true);
+    assert_eq!(policy, NonRoutingCountPolicy::OnlyTerminalNonAccept);
 
-    // Step 1 — non-routing precheck (verdict). count = !affects_route_lookup,
-    // exactly as evaluate_non_pbr_input_filter computes it (#2620). The
-    // fall-through term matches; with count=false it must record nothing.
+    // Step 1 — non-routing precheck (verdict). The fall-through term matches but
+    // the routing-instance term defers → default Accept; nothing counted here.
     let precheck = evaluate_interface_filter_non_routing_counted(
         &state,
         14,
@@ -5546,9 +5564,8 @@ fn pbr_miss_path_counts_fallthrough_term_exactly_once() {
         0,
         TermMatchExtra::default(),
         1400,
-        !affects_route_lookup,
+        policy,
     );
-    // The routing-instance term defers to the routing evaluator → default Accept.
     assert_eq!(precheck.action, FilterAction::Accept);
     assert!(precheck.routing_instance.is_empty());
 
@@ -5569,18 +5586,251 @@ fn pbr_miss_path_counts_fallthrough_term_exactly_once() {
     .expect("routing-instance override");
     assert_eq!(routing.routing_instance, "blue");
 
-    // The fall-through `then { count pre-pbr; next term; }` term was counted
-    // EXACTLY ONCE across the two miss-path evaluators (the routing evaluator),
-    // not twice. Pre-fix (precheck counts too) this reads 2.
+    // Counted EXACTLY ONCE (the routing evaluator), not twice. Pre-#2620 (the
+    // precheck also counts) this reads 2.
     let filter = state.iface_filter_v4_fast.get(&14).expect("input filter");
     assert_eq!(
         filter.terms[0].counter.packets.load(Ordering::Relaxed),
         1,
-        "pre-PBR fall-through count must increment exactly once on the miss path (#2620)"
+        "pre-PBR fall-through count must increment exactly once on the Accept miss path (#2620)"
     );
     assert_eq!(
         filter.terms[0].counter.bytes.load(Ordering::Relaxed),
         1400,
         "byte counter must reflect a single packet"
+    );
+}
+
+// #2620 finding 1: a terminal `discard`/`reject` term BEFORE the
+// routing-instance term ends evaluation at the precheck; the poll path
+// `continue`s and the routing evaluator NEVER runs. The earlier fall-through
+// `then count` term must be counted by the precheck (exactly once), not dropped
+// to zero. The coarse boolean gate (precheck count=false whenever the filter has
+// any routing-instance term) under-counted this exit. Counter-factual guard: a
+// gate that suppresses the count on this exit reads 0.
+#[test]
+fn pbr_miss_path_terminal_discard_before_routing_instance_counts_once() {
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "pbr-discard".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "count-then-fall".into(),
+                    // dport 5201 — matches the test packet; falls through.
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: String::new(),
+                    next_term: true,
+                    count: "pre-discard".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    // Terminal discard that matches the SAME packet, BEFORE the
+                    // routing-instance term below.
+                    name: "deny".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "discard".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    // Routing-instance term — makes the filter route-lookup-
+                    // affecting, but this packet never reaches it.
+                    name: "steer-blue".into(),
+                    protocols: vec!["udp".into()],
+                    destination_ports: vec!["53".into()],
+                    action: "accept".into(),
+                    routing_instance: "blue".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 15,
+            filter_input_v4: "pbr-discard".into(),
+            ..Default::default()
+        }],
+    );
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    // The filter IS route-lookup-affecting, and the miss path's routing eval
+    // would follow on an Accept — so the precheck uses OnlyTerminalNonAccept.
+    let policy = miss_path_count_policy(&state, 15, false, true);
+    assert_eq!(policy, NonRoutingCountPolicy::OnlyTerminalNonAccept);
+
+    let precheck = evaluate_interface_filter_non_routing_counted(
+        &state,
+        15,
+        false,
+        src,
+        dst,
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        1400,
+        policy,
+    );
+    // Terminal discard → non-Accept verdict. The poll path `continue`s here;
+    // ingress_route_table_override is NEVER called for this packet.
+    assert_eq!(precheck.action, FilterAction::Discard);
+
+    let filter = state.iface_filter_v4_fast.get(&15).expect("input filter");
+    assert_eq!(
+        filter.terms[0].counter.packets.load(Ordering::Relaxed),
+        1,
+        "pre-discard fall-through count must increment once on the terminal-discard exit (#2620 finding 1)"
+    );
+    assert_eq!(
+        filter.terms[0].counter.bytes.load(Ordering::Relaxed),
+        1400,
+        "byte counter must reflect a single packet"
+    );
+}
+
+// #2620: a plain non-PBR filter (no routing-instance term anywhere) — the
+// routing evaluator returns early at the affects_route_lookup guard and counts
+// nothing, so the precheck is the SOLE counter and the policy resolves to
+// Always. A matched fall-through `then count` term is counted once.
+#[test]
+fn non_pbr_miss_path_counts_fallthrough_term_once() {
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "plain".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "count-then-fall".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: String::new(),
+                    next_term: true,
+                    count: "hits".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "accept".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "accept".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 16,
+            filter_input_v4: "plain".into(),
+            ..Default::default()
+        }],
+    );
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    // No routing-instance term → not route-lookup-affecting → Always.
+    assert!(!interface_filter_affects_route_lookup(&state, 16, false));
+    let policy = miss_path_count_policy(&state, 16, false, true);
+    assert_eq!(policy, NonRoutingCountPolicy::Always);
+
+    let precheck = evaluate_interface_filter_non_routing_counted(
+        &state,
+        16,
+        false,
+        src,
+        dst,
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        1400,
+        policy,
+    );
+    assert_eq!(precheck.action, FilterAction::Accept);
+
+    let filter = state.iface_filter_v4_fast.get(&16).expect("input filter");
+    assert_eq!(
+        filter.terms[0].counter.packets.load(Ordering::Relaxed),
+        1,
+        "plain non-PBR fall-through count must increment once (precheck Always, #2620)"
+    );
+}
+
+// #2620 finding 3: on the session-HIT DSCP/L4 re-eval path the routing
+// evaluator is NEVER invoked (routing_eval_follows == false), so the precheck is
+// the SOLE counter even when the filter is route-lookup-affecting. The policy
+// resolves to Always so a matched fall-through `then count` term still counts
+// per packet (pre-#2620 behavior), not zero.
+#[test]
+fn pbr_session_hit_path_counts_fallthrough_term_per_packet() {
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "pbr-hit".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "count-then-fall".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: String::new(),
+                    next_term: true,
+                    count: "hit-count".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "steer-blue".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "accept".into(),
+                    routing_instance: "blue".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 17,
+            filter_input_v4: "pbr-hit".into(),
+            ..Default::default()
+        }],
+    );
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    // Route-lookup-affecting, BUT the session-hit path does not run the routing
+    // evaluator → routing_eval_follows = false → Always (sole counter).
+    assert!(interface_filter_affects_route_lookup(&state, 17, false));
+    let policy = miss_path_count_policy(&state, 17, false, false);
+    assert_eq!(policy, NonRoutingCountPolicy::Always);
+
+    // Two session-hit packets → two counts (per-packet, pre-#2620 behavior). A
+    // gate that suppresses the hit-path count for a PBR-affecting filter reads 0.
+    for _ in 0..2 {
+        let eval = evaluate_interface_filter_non_routing_counted(
+            &state,
+            17,
+            false,
+            src,
+            dst,
+            PROTO_TCP,
+            40000,
+            5201,
+            0,
+            TermMatchExtra::default(),
+            1400,
+            policy,
+        );
+        assert_eq!(eval.action, FilterAction::Accept);
+    }
+
+    let filter = state.iface_filter_v4_fast.get(&17).expect("input filter");
+    assert_eq!(
+        filter.terms[0].counter.packets.load(Ordering::Relaxed),
+        2,
+        "session-hit re-eval counts the fall-through term per packet (#2620 finding 3)"
     );
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -2605,6 +2605,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         0,
         TermMatchExtra::default(),
         1400,
+        true,
     );
     assert_eq!(pbr.action, FilterAction::Accept);
     assert!(pbr.routing_instance.is_empty());
@@ -2625,6 +2626,7 @@ fn interface_filter_non_routing_counted_defers_pbr_term() {
         0,
         TermMatchExtra::default(),
         500,
+        true,
     );
     assert_eq!(plain.action, FilterAction::Discard);
     assert_eq!(filter.terms[1].counter.packets.load(Ordering::Relaxed), 1);
@@ -5464,4 +5466,121 @@ fn pbr_evaluator_log_on_routing_instance_term_itself() {
     let lm = result.log_match.expect("routing-instance term log");
     assert_eq!(lm.term_id, 0);
     assert_eq!(lm.action, FilterAction::Accept);
+}
+
+// ---------------------------------------------------------------------------
+// #2620: the PBR (routing-instance) session-miss path runs TWO evaluators over
+// the same interface filter — the non-routing precheck
+// (`evaluate_interface_filter_non_routing_counted`) for the verdict, then the
+// routing-instance evaluator (`evaluate_interface_filter_routing_instance_event_counted`,
+// via `ingress_route_table_override`) for the route override. Both traverse the
+// same terms, so a `then { count X; next term; }` fall-through term ahead of the
+// `then routing-instance` term was counted twice on one miss packet.
+//
+// The fix gates counting in the precheck on `count`, which the miss-path caller
+// sets to `!interface_filter_affects_route_lookup(...)`: when a routing-instance
+// term exists the routing evaluator owns the count, so the precheck passes
+// `count = false`. This test reproduces the exact miss-path sequence and asserts
+// the fall-through counter increments EXACTLY ONCE. Counter-factual guard: if the
+// precheck counts unconditionally (revert the fix → pass `count = true` below),
+// the counter would read 2 and this test fails.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pbr_miss_path_counts_fallthrough_term_exactly_once() {
+    let state = make_filter_state_with_interfaces(
+        &[FirewallFilterSnapshot {
+            name: "pbr-count".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "count-before-pbr".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: String::new(),
+                    next_term: true,
+                    count: "pre-pbr".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "steer-blue".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["5201".into()],
+                    action: "accept".into(),
+                    routing_instance: "blue".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[crate::InterfaceSnapshot {
+            ifindex: 14,
+            filter_input_v4: "pbr-count".into(),
+            ..Default::default()
+        }],
+    );
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    // The interface filter carries a routing-instance term, so the miss path
+    // runs the routing-instance evaluator and the precheck must NOT count.
+    let affects_route_lookup =
+        interface_filter_affects_route_lookup(&state, 14, false);
+    assert!(
+        affects_route_lookup,
+        "filter with a routing-instance term must be route-lookup-affecting"
+    );
+
+    // Step 1 — non-routing precheck (verdict). count = !affects_route_lookup,
+    // exactly as evaluate_non_pbr_input_filter computes it (#2620). The
+    // fall-through term matches; with count=false it must record nothing.
+    let precheck = evaluate_interface_filter_non_routing_counted(
+        &state,
+        14,
+        false,
+        src,
+        dst,
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        1400,
+        !affects_route_lookup,
+    );
+    // The routing-instance term defers to the routing evaluator → default Accept.
+    assert_eq!(precheck.action, FilterAction::Accept);
+    assert!(precheck.routing_instance.is_empty());
+
+    // Step 2 — routing-instance evaluator (route override). It owns the count.
+    let routing = evaluate_interface_filter_routing_instance_event_counted(
+        &state,
+        14,
+        false,
+        src,
+        dst,
+        PROTO_TCP,
+        40000,
+        5201,
+        0,
+        TermMatchExtra::default(),
+        1400,
+    )
+    .expect("routing-instance override");
+    assert_eq!(routing.routing_instance, "blue");
+
+    // The fall-through `then { count pre-pbr; next term; }` term was counted
+    // EXACTLY ONCE across the two miss-path evaluators (the routing evaluator),
+    // not twice. Pre-fix (precheck counts too) this reads 2.
+    let filter = state.iface_filter_v4_fast.get(&14).expect("input filter");
+    assert_eq!(
+        filter.terms[0].counter.packets.load(Ordering::Relaxed),
+        1,
+        "pre-PBR fall-through count must increment exactly once on the miss path (#2620)"
+    );
+    assert_eq!(
+        filter.terms[0].counter.bytes.load(Ordering::Relaxed),
+        1400,
+        "byte counter must reflect a single packet"
+    );
 }


### PR DESCRIPTION
Closes #2620

## Summary

- On the session-miss path a route-lookup-affecting interface input filter ran TWO counted evaluators over the same terms: the non-routing precheck (`evaluate_interface_filter_non_routing_counted`) for the verdict, then the routing-instance evaluator (`evaluate_interface_filter_routing_instance_event_counted`, via `ingress_route_table_override`) for the route override. Both called `record_filter_counter`, so a `then { count X; next term; }` fall-through term ahead of `then routing-instance` was counted **twice** on one miss packet (codex review-040 finding 040-06) — PBR filter counters overcount by 2x.
- Fix: count the pre-PBR fall-through exactly once. Added a `count: bool` parameter to `evaluate_interface_filter_non_routing_counted` + `evaluate_filter_ref_non_routing_counted_v4/v6`. The miss-path caller `evaluate_non_pbr_input_filter` sets `count = !interface_filter_affects_route_lookup(...)`.
- When a routing-instance term exists, the routing evaluator owns the count → precheck `count=false`, records nothing. With no PBR term the routing evaluator never runs → precheck owns it (`count=true`, behavior unchanged).
- The routing-instance evaluator already counts every matched term up to and including the terminating one — even when it returns `None` (a non-PBR terminal `discard` ahead of any routing-instance term) — so the single owner is complete on every miss-path exit. Established (cache-hit) packets use the non-counting `_log_only` variant, so no under-count was introduced on the fast path.

## Which counter / which sites

- **Counter**: the matched fall-through term's `FilterTermCounter` (a `then count <name>` term ahead of the `then routing-instance` term, e.g. `pre-pbr`).
- **Two incrementing sites (pre-fix)**:
  - `evaluate_filter_ref_non_routing_counted_v4/v6` — `userspace-dp/src/filter/engine/eval.rs` (~L288/L328), reached via the precheck `evaluate_non_pbr_input_filter`.
  - `evaluate_filter_ref_routing_instance_counted_v4/v6` — `eval.rs` (~L371/L433), reached via `ingress_route_table_override`.
- **After fix**: only the routing-instance evaluator counts when a PBR term is present; the precheck's count is gated off.

## Test plan

- [x] Added `pbr_miss_path_counts_fallthrough_term_exactly_once` (`userspace-dp/src/filter/tests.rs`): replicates the miss-path two-evaluator sequence with `count pre-pbr; next term` ahead of `then routing-instance blue`; asserts the counter is **1**, not 2.
- [x] **Fail-on-revert proof**: flipping the count gate to always-true (pre-fix behavior) made the test fail at `left: 2, right: 1`. Restored; passes at 1.
- [x] `cargo build --release` — clean (pre-existing warnings only).
- [x] `cargo test --release --bin xpf-userspace-dp filter::` — 111 passed.
- [x] `cargo test --release --bin xpf-userspace-dp poll_descriptor` — 23 passed.
- [x] No wire change — `protocol::tests::wire_invariant_default_specimens` green.

## Docs

- `userspace-dp/src/filter/README.md` — documented the #2620 PBR session-miss single-count contract (count owner = routing-instance evaluator when a PBR term exists).

## Refs

- #2620 (codex review-040 finding 040-06). Related fall-through-term work: #2544, #2616, #2618, #2619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi