### PR TITLE
userspace-dp: gate reconcile teardown 500ms mlx5 quiesce on rebind (#2522)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15530,14 +15530,19 @@ top.
   there. `Coordinator::reconcile` now passes `will_rebind =
   snapshot.is_some()` into `tear_down`; the quiesce fires only when live
   workers were torn down AND a rebind follows. Added `reconcile_quiesce_count`
-  observability counter (bumped on each quiesce). The quiesce routes
-  through a `cfg(test)` `test_seam` that records the requested duration
-  and skips the real sleep so the new tests run fast. Three fail-on-revert
-  tests in coordinator/tests.rs: no-live-workers skip, no-snapshot skip
-  (THE pin — RED on revert: left=500 right=0), and live-workers+snapshot
-  fires (barrier preserved). Proved RED on revert, restored. EBUSY barrier
-  is unchanged on the rebind path. Provenance: codex review-037 finding
-  037-03.
+  — an INTERNAL / test counter (bumped on each quiesce), NOT wired to any
+  gRPC / Prometheus / status surface. Under `cfg(test)` the quiesce records
+  its requested duration on the PER-INSTANCE `Coordinator::last_quiesce_ms`
+  field (no process-global — each test reads its own coordinator, safe
+  under parallel `cargo test`) and skips the real sleep so the new tests
+  run fast. Three fail-on-revert tests in coordinator/tests.rs:
+  no-live-workers skip, no-snapshot skip (THE pin — RED on revert:
+  left=500 right=0), and live-workers+snapshot fires (barrier preserved).
+  Proved RED on revert, restored. EBUSY barrier is unchanged on the rebind
+  path. Review fold: M1 (replaced a process-global atomic seam with the
+  per-instance field — removed an introduced parallel-test flake), M2
+  (corrected counter wording to internal/test, not "observability").
+  Provenance: codex review-037 finding 037-03.
   **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/teardown.rs,
   userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
   userspace-dp/src/afxdp/coordinator/mod.rs,

--- a/_Log.md
+++ b/_Log.md
@@ -15521,3 +15521,24 @@ top.
   pkg/grpcapi/sessions_iterator_error_test.go, pkg/cli/cli_show_flow.go,
   pkg/cli/cli_show_nat.go, pkg/cli/sessions_iterator_error_test.go,
   _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2522 — gate the 500ms mlx5 zero-copy teardown quiesce on
+  `will_rebind` (a snapshot is being applied), not just `had_live_workers`.
+  A teardown with no following bind (the `no_snapshot` / shutdown path)
+  never rebinds the queues, so the 500ms quiesce was pure dead latency
+  there. `Coordinator::reconcile` now passes `will_rebind =
+  snapshot.is_some()` into `tear_down`; the quiesce fires only when live
+  workers were torn down AND a rebind follows. Added `reconcile_quiesce_count`
+  observability counter (bumped on each quiesce). The quiesce routes
+  through a `cfg(test)` `test_seam` that records the requested duration
+  and skips the real sleep so the new tests run fast. Three fail-on-revert
+  tests in coordinator/tests.rs: no-live-workers skip, no-snapshot skip
+  (THE pin — RED on revert: left=500 right=0), and live-workers+snapshot
+  fires (barrier preserved). Proved RED on revert, restored. EBUSY barrier
+  is unchanged on the rebind path. Provenance: codex review-037 finding
+  037-03.
+  **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/teardown.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
+  userspace-dp/src/afxdp/coordinator/mod.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs, _Log.md

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -210,10 +210,20 @@ pub struct Coordinator {
     pub(crate) reconcile_calls: u64,
     /// #2522: count of teardowns that paid the 500ms mlx5 zero-copy
     /// EBUSY quiesce. Bumped only when live workers were torn down AND a
-    /// rebind follows (snapshot-apply path). Surfaces the mlx5-specific
-    /// workaround so its frequency is observable; the `no_snapshot` /
-    /// shutdown teardown no longer pays (and no longer counts) it.
+    /// rebind follows (snapshot-apply path); the `no_snapshot` /
+    /// shutdown teardown no longer pays (and no longer counts) it. This
+    /// is an INTERNAL / test counter — it is read only by the #2522
+    /// regression tests and is NOT wired to any gRPC / Prometheus /
+    /// status surface. Wiring it into the status surface (a wire change)
+    /// is a possible follow-up.
     pub(crate) reconcile_quiesce_count: u64,
+    /// #2522 test seam (per-instance, NOT a process-global): under
+    /// `cfg(test)` `tear_down`'s quiesce records its requested duration
+    /// here and skips the real `thread::sleep`, so each test asserts
+    /// against its OWN coordinator with no cross-test race. Absent from
+    /// release builds.
+    #[cfg(test)]
+    pub(crate) last_quiesce_ms: u64,
     pub(crate) last_reconcile_stage: String,
     pub(crate) poll_mode: crate::PollMode,
     pub(crate) event_stream: Option<crate::event_stream::EventStreamSender>,
@@ -258,6 +268,8 @@ impl Coordinator {
             validation: ValidationState::default(),
             reconcile_calls: 0,
             reconcile_quiesce_count: 0,
+            #[cfg(test)]
+            last_quiesce_ms: 0,
             last_reconcile_stage: "idle".to_string(),
             poll_mode: crate::PollMode::BusyPoll,
             event_stream: None,

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -208,6 +208,12 @@ pub struct Coordinator {
     pub(crate) last_resolution: Arc<Mutex<Option<PacketResolution>>>,
     pub(crate) validation: ValidationState,
     pub(crate) reconcile_calls: u64,
+    /// #2522: count of teardowns that paid the 500ms mlx5 zero-copy
+    /// EBUSY quiesce. Bumped only when live workers were torn down AND a
+    /// rebind follows (snapshot-apply path). Surfaces the mlx5-specific
+    /// workaround so its frequency is observable; the `no_snapshot` /
+    /// shutdown teardown no longer pays (and no longer counts) it.
+    pub(crate) reconcile_quiesce_count: u64,
     pub(crate) last_reconcile_stage: String,
     pub(crate) poll_mode: crate::PollMode,
     pub(crate) event_stream: Option<crate::event_stream::EventStreamSender>,
@@ -251,6 +257,7 @@ impl Coordinator {
             last_resolution: Arc::new(Mutex::new(None)),
             validation: ValidationState::default(),
             reconcile_calls: 0,
+            reconcile_quiesce_count: 0,
             last_reconcile_stage: "idle".to_string(),
             poll_mode: crate::PollMode::BusyPoll,
             event_stream: None,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -22,9 +22,9 @@ pub(super) mod snapshot;
 pub(super) mod teardown;
 
 /// State preserved across `stop_inner(false)` that the later phases
-/// need to consume. Two fields only — `had_live_workers` lives
-/// entirely inside `teardown.rs` (it gates the 500ms mlx5 quiesce
-/// sleep, which is not needed outside teardown).
+/// need to consume. `had_live_workers` lives entirely inside
+/// `teardown.rs` (it gates the 500ms mlx5 quiesce sleep alongside the
+/// `will_rebind` flag, which is not needed outside teardown).
 pub(in crate::afxdp) struct PreservedReconcileState {
     pub(super) synced_sessions: Vec<SyncedSessionEntry>,
     pub(super) slow_path: Option<Arc<SlowPathReinjector>>,
@@ -70,7 +70,8 @@ impl Coordinator {
     ///
     /// Phases (preserved verbatim from pre-#1328 monolithic body):
     /// 1. Teardown: preserve synced sessions + healthy slow path,
-    ///    stop workers, 500ms quiesce if workers were live.
+    ///    stop workers, 500ms quiesce if workers were live AND a rebind
+    ///    follows (snapshot-apply path only — #2522).
     /// 2. Reset: zero per-binding counter fields.
     /// 3. Snapshot apply (only if `snapshot.is_some()`): install
     ///    validation/forwarding state, re-arm slow path, open BPF
@@ -171,7 +172,14 @@ impl Coordinator {
         } else {
             None
         };
-        let mut preserved = teardown::tear_down(self);
+        // #2522: only the snapshot-apply path rebinds the XSK on the
+        // (possibly) same queue set, so only it needs the mlx5 EBUSY
+        // quiesce. A `None`-snapshot teardown (config cleared / shutdown
+        // reconcile) returns at `no_snapshot` below without ever
+        // rebinding — pass `will_rebind = false` so it skips the 500ms
+        // stall.
+        let will_rebind = snapshot.is_some();
+        let mut preserved = teardown::tear_down(self, will_rebind);
         reset::reset_binding_counters(bindings);
         let Some(snapshot) = snapshot else {
             self.policy_counters.reconcile_rules(&[]);

--- a/userspace-dp/src/afxdp/coordinator/reconcile/teardown.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/teardown.rs
@@ -2,15 +2,70 @@
 //!
 //! Pure code motion from the head of the pre-#1328 monolithic
 //! `Coordinator::reconcile` body: preserve synced sessions + healthy
-//! slow-path, call `stop_inner(false)`, sleep 500ms if there were
+//! slow-path, call `stop_inner(false)`, then — only when a rebind will
+//! actually follow on the same queue set — sleep 500ms if there were
 //! live workers (mlx5 zero-copy queue teardown is not synchronously
 //! reusable; EBUSY guard for back-to-back snapshot refreshes).
+//!
+//! #2522: the quiesce is now gated on `will_rebind` (the reconcile is
+//! applying a snapshot) IN ADDITION to `had_live_workers`. A teardown
+//! that is not followed by a bind — the `no_snapshot` / shutdown path —
+//! never rebinds the queues, so the 500ms quiesce was pure dead
+//! latency there. Gating it on `will_rebind` removes that stall while
+//! keeping the EBUSY guard exactly where a back-to-back rebind needs
+//! it. `quiesce()` routes through a test seam so a unit test can prove
+//! the gate without paying the real 500ms.
 use super::PreservedReconcileState;
 use super::super::Coordinator;
-use std::thread;
 use std::time::Duration;
 
-pub(super) fn tear_down(coord: &mut Coordinator) -> PreservedReconcileState {
+/// The mlx5 zero-copy teardown quiesce. Real builds sleep; tests
+/// record the request and skip the sleep (see [`test_seam`]).
+const TEARDOWN_QUIESCE: Duration = Duration::from_millis(500);
+
+#[cfg(test)]
+pub(in crate::afxdp) mod test_seam {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    /// Total quiesce duration requested by `tear_down`, in
+    /// milliseconds. A test resets this to 0, drives a reconcile, and
+    /// asserts whether the gate fired. The real `thread::sleep` is
+    /// skipped under `cfg(test)` so the suite stays fast.
+    pub(in crate::afxdp) static QUIESCE_MS: AtomicU64 = AtomicU64::new(0);
+
+    pub(in crate::afxdp) fn reset() {
+        QUIESCE_MS.store(0, Ordering::Relaxed);
+    }
+
+    pub(in crate::afxdp) fn requested_ms() -> u64 {
+        QUIESCE_MS.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn record(d: Duration) {
+        QUIESCE_MS.fetch_add(d.as_millis() as u64, Ordering::Relaxed);
+    }
+}
+
+#[inline]
+fn quiesce(d: Duration) {
+    #[cfg(test)]
+    {
+        // Record the request; skip the real sleep so the suite is fast.
+        test_seam::record(d);
+    }
+    #[cfg(not(test))]
+    {
+        std::thread::sleep(d);
+    }
+}
+
+/// `will_rebind` is true when the reconcile is applying a snapshot and
+/// will therefore re-bind the XSK on (potentially) the same queue set
+/// — the only case where the mlx5 EBUSY quiesce is load-bearing. A
+/// teardown with no following bind (`no_snapshot` / shutdown) passes
+/// `false` and skips the quiesce.
+pub(super) fn tear_down(coord: &mut Coordinator, will_rebind: bool) -> PreservedReconcileState {
     let had_live_workers = !coord.workers.handles.is_empty();
     let synced_sessions = coord.snapshot_shared_session_entries();
     // #1873 R-D (AGY code r3): capture the tunnel-owner map and the
@@ -37,12 +92,16 @@ pub(super) fn tear_down(coord: &mut Coordinator) -> PreservedReconcileState {
         }
     });
     coord.stop_inner(false);
-    if had_live_workers {
+    if had_live_workers && will_rebind {
         // Zero-copy queue teardown is not synchronously reusable on
         // mlx5. A short quiesce avoids EBUSY when a later snapshot
         // refresh rebuilds the same queue set immediately after
-        // shutdown.
-        thread::sleep(Duration::from_millis(500));
+        // shutdown. #2522: skipped when no rebind follows (the
+        // `no_snapshot` / shutdown teardown), where it was pure dead
+        // latency. Counted in `reconcile_quiesce_count` for
+        // observability.
+        coord.reconcile_quiesce_count = coord.reconcile_quiesce_count.saturating_add(1);
+        quiesce(TEARDOWN_QUIESCE);
     }
     PreservedReconcileState {
         synced_sessions,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/teardown.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/teardown.rs
@@ -13,49 +13,35 @@
 //! never rebinds the queues, so the 500ms quiesce was pure dead
 //! latency there. Gating it on `will_rebind` removes that stall while
 //! keeping the EBUSY guard exactly where a back-to-back rebind needs
-//! it. `quiesce()` routes through a test seam so a unit test can prove
-//! the gate without paying the real 500ms.
+//! it. Under `cfg(test)` the quiesce is RECORDED on the per-instance
+//! `Coordinator::last_quiesce_ms` field and the real `thread::sleep`
+//! is skipped, so a unit test proves the gate against ITS OWN
+//! coordinator (no process-global state, no cross-test race) and the
+//! suite stays fast.
 use super::PreservedReconcileState;
 use super::super::Coordinator;
 use std::time::Duration;
 
 /// The mlx5 zero-copy teardown quiesce. Real builds sleep; tests
-/// record the request and skip the sleep (see [`test_seam`]).
+/// record the request on `Coordinator::last_quiesce_ms` and skip the
+/// sleep.
 const TEARDOWN_QUIESCE: Duration = Duration::from_millis(500);
 
-#[cfg(test)]
-pub(in crate::afxdp) mod test_seam {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::Duration;
-
-    /// Total quiesce duration requested by `tear_down`, in
-    /// milliseconds. A test resets this to 0, drives a reconcile, and
-    /// asserts whether the gate fired. The real `thread::sleep` is
-    /// skipped under `cfg(test)` so the suite stays fast.
-    pub(in crate::afxdp) static QUIESCE_MS: AtomicU64 = AtomicU64::new(0);
-
-    pub(in crate::afxdp) fn reset() {
-        QUIESCE_MS.store(0, Ordering::Relaxed);
-    }
-
-    pub(in crate::afxdp) fn requested_ms() -> u64 {
-        QUIESCE_MS.load(Ordering::Relaxed)
-    }
-
-    pub(super) fn record(d: Duration) {
-        QUIESCE_MS.fetch_add(d.as_millis() as u64, Ordering::Relaxed);
-    }
-}
-
+/// Apply the teardown quiesce. In a real build this sleeps; under
+/// `cfg(test)` it records the requested duration on the coordinator's
+/// own `last_quiesce_ms` field (per-instance — no shared global) and
+/// returns immediately so the suite is fast.
 #[inline]
-fn quiesce(d: Duration) {
+fn quiesce(coord: &mut Coordinator, d: Duration) {
     #[cfg(test)]
     {
-        // Record the request; skip the real sleep so the suite is fast.
-        test_seam::record(d);
+        coord.last_quiesce_ms = coord
+            .last_quiesce_ms
+            .saturating_add(d.as_millis() as u64);
     }
     #[cfg(not(test))]
     {
+        let _ = coord;
         std::thread::sleep(d);
     }
 }
@@ -98,10 +84,10 @@ pub(super) fn tear_down(coord: &mut Coordinator, will_rebind: bool) -> Preserved
         // refresh rebuilds the same queue set immediately after
         // shutdown. #2522: skipped when no rebind follows (the
         // `no_snapshot` / shutdown teardown), where it was pure dead
-        // latency. Counted in `reconcile_quiesce_count` for
-        // observability.
+        // latency. Counted in `reconcile_quiesce_count` (an internal /
+        // test counter — not wired to any status surface).
         coord.reconcile_quiesce_count = coord.reconcile_quiesce_count.saturating_add(1);
-        quiesce(TEARDOWN_QUIESCE);
+        quiesce(coord, TEARDOWN_QUIESCE);
     }
     PreservedReconcileState {
         synced_sessions,

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1663,25 +1663,24 @@ fn reconcile_with_none_snapshot_reaches_no_snapshot_early_exit() {
 // bind — the `no_snapshot` / shutdown path — never rebinds, so the
 // quiesce was pure dead latency there.
 //
-// The quiesce routes through `teardown::test_seam` under `cfg(test)`:
-// it RECORDS the requested duration in `QUIESCE_MS` and skips the real
-// `thread::sleep`, so these tests run fast while still proving the gate.
-// `reconcile_quiesce_count` mirrors the gate as an operator-visible
-// counter.
+// Under `cfg(test)` the quiesce records its requested duration on the
+// PER-INSTANCE `Coordinator::last_quiesce_ms` field and skips the real
+// `thread::sleep`. Each test reads its OWN coordinator's field — there
+// is NO process-global state, so the three tests are independent and
+// safe to run in parallel (the default `cargo test` mode).
+// `reconcile_quiesce_count` is an internal/test counter mirroring the
+// gate.
 // ---------------------------------------------------------------------------
-use crate::afxdp::coordinator::reconcile::teardown::test_seam as quiesce_seam;
 
 /// No live workers + no rebind: the quiesce never fires. (Sanity floor
 /// for the gate — the first conjunct alone is enough to skip.)
 #[test]
 fn teardown_quiesce_skipped_when_no_live_workers() {
-    quiesce_seam::reset();
     let mut coordinator = Coordinator::new();
     let mut bindings: Vec<BindingStatus> = Vec::new();
     coordinator.reconcile(None, &mut bindings, 64);
     assert_eq!(
-        quiesce_seam::requested_ms(),
-        0,
+        coordinator.last_quiesce_ms, 0,
         "no live workers => no mlx5 quiesce"
     );
     assert_eq!(coordinator.reconcile_quiesce_count, 0);
@@ -1694,13 +1693,12 @@ fn teardown_quiesce_skipped_when_no_live_workers() {
 ///
 /// Fail-on-revert: revert the fix (gate back to `if had_live_workers`,
 /// dropping the `&& will_rebind` conjunct) and this teardown sleeps the
-/// full 500ms again — `requested_ms()` becomes 500 and
+/// full 500ms again — `last_quiesce_ms` becomes 500 and
 /// `reconcile_quiesce_count` becomes 1, failing both assertions. The
 /// pre-fix code paid this stall on every live-worker config-clear /
 /// shutdown reconcile.
 #[test]
 fn teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers() {
-    quiesce_seam::reset();
     let mut coordinator = gre1881_coordinator_with_worker();
     assert!(
         !coordinator.workers.handles.is_empty(),
@@ -1717,8 +1715,7 @@ fn teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers() {
         "the seeded worker WAS torn down (proves had_live_workers held)"
     );
     assert_eq!(
-        quiesce_seam::requested_ms(),
-        0,
+        coordinator.last_quiesce_ms, 0,
         "#2522: a teardown with no following rebind must NOT pay the 500ms mlx5 quiesce"
     );
     assert_eq!(
@@ -1735,11 +1732,10 @@ fn teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers() {
 ///
 /// Fail-on-revert: if a future change drops the quiesce entirely (or
 /// gates it on `will_rebind` alone, losing the `had_live_workers`
-/// conjunct in a way that skips this case), `requested_ms()` stays 0
+/// conjunct in a way that skips this case), `last_quiesce_ms` stays 0
 /// and this assertion fails.
 #[test]
 fn teardown_quiesce_fires_when_live_workers_and_snapshot_rebinds() {
-    quiesce_seam::reset();
     let mut coordinator = gre1881_coordinator_with_worker();
     assert!(
         !coordinator.workers.handles.is_empty(),
@@ -1755,8 +1751,7 @@ fn teardown_quiesce_fires_when_live_workers_and_snapshot_rebinds() {
     let mut bindings: Vec<BindingStatus> = Vec::new();
     coordinator.reconcile(Some(&snap), &mut bindings, 64);
     assert_eq!(
-        quiesce_seam::requested_ms(),
-        500,
+        coordinator.last_quiesce_ms, 500,
         "#2522: live workers + a rebinding snapshot MUST still pay the mlx5 EBUSY quiesce"
     );
     assert_eq!(

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1657,6 +1657,115 @@ fn reconcile_with_none_snapshot_reaches_no_snapshot_early_exit() {
 }
 
 // ---------------------------------------------------------------------------
+// #2522: the mlx5 zero-copy teardown quiesce (500ms) is gated on BOTH
+// `had_live_workers` AND `will_rebind` (a snapshot is being applied, so
+// a rebind on the same queue set follows). A teardown with no following
+// bind — the `no_snapshot` / shutdown path — never rebinds, so the
+// quiesce was pure dead latency there.
+//
+// The quiesce routes through `teardown::test_seam` under `cfg(test)`:
+// it RECORDS the requested duration in `QUIESCE_MS` and skips the real
+// `thread::sleep`, so these tests run fast while still proving the gate.
+// `reconcile_quiesce_count` mirrors the gate as an operator-visible
+// counter.
+// ---------------------------------------------------------------------------
+use crate::afxdp::coordinator::reconcile::teardown::test_seam as quiesce_seam;
+
+/// No live workers + no rebind: the quiesce never fires. (Sanity floor
+/// for the gate — the first conjunct alone is enough to skip.)
+#[test]
+fn teardown_quiesce_skipped_when_no_live_workers() {
+    quiesce_seam::reset();
+    let mut coordinator = Coordinator::new();
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+    coordinator.reconcile(None, &mut bindings, 64);
+    assert_eq!(
+        quiesce_seam::requested_ms(),
+        0,
+        "no live workers => no mlx5 quiesce"
+    );
+    assert_eq!(coordinator.reconcile_quiesce_count, 0);
+}
+
+/// THE #2522 fail-on-revert pin: live workers WERE torn down, but the
+/// reconcile carries NO snapshot (`will_rebind == false`) — the
+/// `no_snapshot` early-exit follows with no rebind. The quiesce MUST be
+/// skipped.
+///
+/// Fail-on-revert: revert the fix (gate back to `if had_live_workers`,
+/// dropping the `&& will_rebind` conjunct) and this teardown sleeps the
+/// full 500ms again — `requested_ms()` becomes 500 and
+/// `reconcile_quiesce_count` becomes 1, failing both assertions. The
+/// pre-fix code paid this stall on every live-worker config-clear /
+/// shutdown reconcile.
+#[test]
+fn teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers() {
+    quiesce_seam::reset();
+    let mut coordinator = gre1881_coordinator_with_worker();
+    assert!(
+        !coordinator.workers.handles.is_empty(),
+        "precondition: a live worker handle is seeded (had_live_workers == true)"
+    );
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+    coordinator.reconcile(None, &mut bindings, 64);
+    assert_eq!(
+        coordinator.last_reconcile_stage, "no_snapshot",
+        "None snapshot reaches the no_snapshot early-exit"
+    );
+    assert!(
+        coordinator.workers.handles.is_empty(),
+        "the seeded worker WAS torn down (proves had_live_workers held)"
+    );
+    assert_eq!(
+        quiesce_seam::requested_ms(),
+        0,
+        "#2522: a teardown with no following rebind must NOT pay the 500ms mlx5 quiesce"
+    );
+    assert_eq!(
+        coordinator.reconcile_quiesce_count, 0,
+        "no quiesce event counted on the no-rebind teardown"
+    );
+}
+
+/// The other side of the gate: live workers AND a snapshot to apply
+/// (`will_rebind == true`) — the rebind on the same queue set follows,
+/// so the mlx5 EBUSY quiesce is load-bearing and MUST still fire. This
+/// is the barrier-preservation half: the fix narrows WHEN the quiesce
+/// runs, it does not remove the barrier from the path that needs it.
+///
+/// Fail-on-revert: if a future change drops the quiesce entirely (or
+/// gates it on `will_rebind` alone, losing the `had_live_workers`
+/// conjunct in a way that skips this case), `requested_ms()` stays 0
+/// and this assertion fails.
+#[test]
+fn teardown_quiesce_fires_when_live_workers_and_snapshot_rebinds() {
+    quiesce_seam::reset();
+    let mut coordinator = gre1881_coordinator_with_worker();
+    assert!(
+        !coordinator.workers.handles.is_empty(),
+        "precondition: had_live_workers == true"
+    );
+    // All-OK mandatory pins so the map-FD preflight + forwarding build
+    // pass and the reconcile REACHES `tear_down` (and the quiesce). The
+    // post-teardown bringup may not fully bind a real XSK in the unit
+    // env, but the quiesce already ran inside `tear_down` before any of
+    // that — which is exactly the EBUSY-guard placement under test.
+    let mut snap = fail_open_snapshot(1);
+    snap.map_pins.sessions = format!("{TEST_MAP_PIN_OK}sessions");
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    assert_eq!(
+        quiesce_seam::requested_ms(),
+        500,
+        "#2522: live workers + a rebinding snapshot MUST still pay the mlx5 EBUSY quiesce"
+    );
+    assert_eq!(
+        coordinator.reconcile_quiesce_count, 1,
+        "exactly one quiesce event counted for the rebinding teardown"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // #1636 option C: proactive neighbor warm tests.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #2522

## Summary
- The reconcile teardown unconditionally slept 500ms whenever live workers existed (`had_live_workers = !coord.workers.handles.is_empty()`), before the rebuild bind. Every config-clear / shutdown reconcile that had live workers paid a fixed half-second stall — but that teardown returns at the `no_snapshot` early-exit without ever rebinding the XSK, so there was no mlx5 zero-copy queue to wait out of EBUSY.
- `Coordinator::reconcile` now computes `will_rebind = snapshot.is_some()` and passes it into `tear_down`. The quiesce fires only when live workers were torn down **AND** a rebind follows.
- Added a `reconcile_quiesce_count` counter on `Coordinator`, bumped on each quiesce, making the mlx5 workaround observable in-process.
- The quiesce routes through a `cfg(test)` `test_seam` that records the requested duration and skips the real `thread::sleep`, so the regression tests run fast.

## Gating condition + why it's still correct
The 500ms quiesce is the mlx5 EBUSY guard: mlx5 zero-copy queue teardown is not synchronously reusable, so a back-to-back rebind of the **same queue set** immediately after `stop_inner` can return EBUSY. That hazard exists **only on the snapshot-apply path** (the path that rebinds). A `None`-snapshot teardown (config cleared / shutdown reconcile) returns at `no_snapshot` with no following bind. So the barrier is preserved exactly where a rebind needs it — `had_live_workers && will_rebind` — and skipped where it was pure dead latency. The fix narrows *when* the barrier runs; it does not remove it.

Scoped away from #2515 (the sibling no_snapshot `refresh_bindings` concern) — this PR touches only the unconditional-sleep gate.

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo test --release --bin xpf-userspace-dp reconcile` — 18 passed (incl. 3 new)
- [x] Three fail-on-revert tests in `coordinator/tests.rs`:
  - `teardown_quiesce_skipped_when_no_live_workers` — no workers → quiesce skipped (count 0)
  - `teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers` — **THE #2522 pin**: live workers torn down, no snapshot → quiesce SKIPPED
  - `teardown_quiesce_fires_when_live_workers_and_snapshot_rebinds` — live workers + snapshot → quiesce FIRES (500ms, count 1), proving the EBUSY barrier is preserved

## Fail-on-revert proof
Reverted the gate to `if had_live_workers` (dropping `&& will_rebind`):
```
test ...teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers ... FAILED
assertion `left == right` failed: #2522: a teardown with no following rebind must NOT pay the 500ms mlx5 quiesce
  (left=500, right=0)
test result: FAILED. 2 passed; 1 failed
```
The other two pass under the revert (the barrier-present and no-workers cases are unaffected). Restored the fix; all 3 green.

## Wire / docs
- No wire/protocol change. `reconcile_quiesce_count` is an in-process observability field; full status-surface wiring is a possible follow-up, not required for the fix.
- Behavior documented in source comments (`teardown.rs`, `reconcile/mod.rs`). The `docs/pr/1328-...` plan is left as-is (historical record of that PR's code-motion state).

Provenance: codex review-037 finding 037-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi