### PR TITLE
userspace-dp: bound single-shot ExportOwnerRGSessions delta-ring push (#2653)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15521,3 +15521,28 @@ top.
   pkg/grpcapi/sessions_iterator_error_test.go, pkg/cli/cli_show_flow.go,
   pkg/cli/cli_show_nat.go, pkg/cli/sessions_iterator_error_test.go,
   _Log.md
+
+## #2653 — single-shot ExportOwnerRGSessions unbounded delta-ring push
+
+- **Timestamp**: 2026-06-25
+- **Action**: Bound the single-shot `ExportOwnerRGSessions` command path with
+  the same #2442 chunked drain-as-you-export. The command handler
+  (`handle_export_owner_rg_sessions`) no longer emits open deltas inline (it
+  pushed up to DEFAULT_MAX_SESSIONS = 32x the 4096-slot ring in one shot,
+  overflowing it and dropping sessions 4097..N from the HA bulk snapshot).
+  It now records the requested owner RGs in
+  `WorkerCommandResults.export_owner_rgs`; the worker loop performs the chunked
+  export (collect candidates -> emit in 2048 chunks -> drain+flush between) and
+  acks only after the complete export drains. `export_forward_sessions_for_owner_rgs`
+  is now `#[cfg(test)]`-only.
+- **File(s)**: userspace-dp/src/afxdp/session_glue/commands/export_owner_rg_sessions.rs,
+  userspace-dp/src/afxdp/session_glue/mod.rs,
+  userspace-dp/src/afxdp/worker/loop_body/mod.rs,
+  userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/session_glue/tests.rs,
+  docs/session-sync-architecture.md
+- **Validation**: cargo build --release OK; new fail-on-revert test
+  `export_owner_rg_command_does_not_overflow_ring_unbounded` GREEN on fix,
+  RED-on-revert proven (inline emit -> "must NOT emit deltas inline" panics);
+  session_glue suite 79/79; resync test still green. test-failover pending
+  (PARENT runs before merge — HA path).

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -352,9 +352,26 @@ would climb without bound). The resync therefore **interleaves the drain**:
 Because the ring is empty before every chunk and a chunk is smaller than the
 cap, `push_delta` never overflows during a resync. The complete snapshot ships
 in chunks regardless of session count, and the loss latch is not spuriously
-re-armed by the export itself. (The single-shot `ExportOwnerRGSessions` command
-path keeps pushing the whole candidate set at once — its caller drains against a
-15 s export-ack budget — so only the worker-loop resync needs the chunked path.)
+re-armed by the export itself.
+
+**The single-shot `ExportOwnerRGSessions` command path uses the same chunked
+drain-as-you-export (#2653).** Pre-#2653 the command handler
+(`handle_export_owner_rg_sessions`) called `export_forward_sessions_for_owner_rgs`
+inline, pushing the whole owned-session set into the ring in one shot on the
+theory that the caller's 15 s export-ack drain would mop it up. But the overflow
+happens *inside* the emit, before any drain runs: with >4096 owned sessions the
+ring overflowed at delta 4097 and silently dropped sessions 4097..N, so the HA
+peer received an INCOMPLETE bulk snapshot on rejoin / RG transition (the
+command-path sibling of the #2442 worker-loop overflow). Since
+`apply_worker_commands` has no `BindingWorker`/flush access (it cannot drain the
+ring to the peer mid-export), the handler now only **records** the requested
+owner RGs in `WorkerCommandResults.export_owner_rgs`; the worker loop — which
+owns the binding + flush machinery — performs the identical chunked
+drain-as-you-export (collect candidates → emit in `RESYNC_EXPORT_CHUNK = 2048`
+chunks → drain+flush between chunks) and only advances `session_export_ack` once
+the complete export has drained to the peer. The unbounded
+`export_forward_sessions_for_owner_rgs` helper is now `#[cfg(test)]`-only (a
+candidate-selection fixture); both production paths are bounded.
 
 **Debounce / composition with the sync state machine.** The signal is a single
 bool cleared on read, so a burst that drops N deltas before the worker reads it

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -102,9 +102,11 @@ mod session_glue;
 // #2442: re-export the owner-RG export walk + its chunkable candidate collector
 // so the worker loop's loss-of-sync resync path and the session-module resync
 // test can reach them without naming the private `session_glue` module.
-pub(crate) use session_glue::{
-    export_forward_sessions_for_owner_rgs, forward_export_candidates_for_owner_rgs,
-};
+pub(crate) use session_glue::forward_export_candidates_for_owner_rgs;
+// #2653: the unbounded "emit all at once" helper is now a test-only fixture
+// (the production paths use the chunked drain-as-you-export in worker::loop_body).
+#[cfg(test)]
+pub(crate) use session_glue::export_forward_sessions_for_owner_rgs;
 #[path = "shared_ops.rs"]
 mod shared_ops;
 #[path = "shared_umem.rs"]

--- a/userspace-dp/src/afxdp/session_glue/commands/export_owner_rg_sessions.rs
+++ b/userspace-dp/src/afxdp/session_glue/commands/export_owner_rg_sessions.rs
@@ -1,20 +1,35 @@
 use super::super::*;
 
-/// Apply `WorkerCommand::ExportOwnerRGSessions`: walk the session
-/// table for the given owner RGs and push their sequence onto the
-/// exported-sequences accumulator.
+/// Apply `WorkerCommand::ExportOwnerRGSessions`: record the requested owner
+/// RGs for a chunked, drain-as-you-export re-emit by the worker loop, and
+/// push the command sequence onto the exported-sequences accumulator so the
+/// `session_export_ack` advances once the export has shipped.
 ///
-/// Lifted verbatim from `apply_worker_commands` at the
-/// `WorkerCommand::ExportOwnerRGSessions` match arm. Takes the
-/// narrow `&mut Vec<u64>` instead of `&mut WorkerCommandResults`
-/// because the dispatcher constructs the results struct after the
-/// loop (per #1346 plan v2).
+/// #2653: this handler used to call `export_forward_sessions_for_owner_rgs`
+/// inline, which pushed the ENTIRE owned-session set (up to
+/// `DEFAULT_MAX_SESSIONS` = 131072 = 32x the 4096-slot delta ring) into the
+/// ring in one shot. With no interleaved drain, the ring overflowed at delta
+/// 4097 and `push_delta` silently dropped sessions 4097..N, so the HA peer
+/// received an INCOMPLETE bulk snapshot on rejoin / RG transition.
+///
+/// `apply_worker_commands` has no `BindingWorker`/flush access, so it cannot
+/// drain the ring to the peer mid-export. The fix mirrors the #2442
+/// loss-of-sync resync: the handler only RECORDS the owner RGs here; the
+/// worker loop (`worker::loop_body`), which holds the binding + flush
+/// machinery, performs the same chunked drain-as-you-export (collect
+/// candidates -> emit in < cap chunks -> drain between chunks) so the complete
+/// snapshot ships without ever overflowing the ring. The sequence is acked
+/// only after that chunked export drains to empty.
 pub(in crate::afxdp::session_glue) fn handle_export_owner_rg_sessions(
-    sessions: &mut SessionTable,
     exported_sequences: &mut Vec<u64>,
+    export_owner_rgs: &mut Vec<i32>,
     sequence: u64,
     owner_rgs: Vec<i32>,
 ) {
-    export_forward_sessions_for_owner_rgs(sessions, &owner_rgs);
+    for rg in owner_rgs {
+        if !export_owner_rgs.contains(&rg) {
+            export_owner_rgs.push(rg);
+        }
+    }
     exported_sequences.push(sequence);
 }

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -240,6 +240,17 @@ fn should_bypass_unseeded_tunnel_ha(
 pub(super) struct WorkerCommandResults {
     pub cancelled_keys: Vec<SessionKey>,
     pub exported_sequences: Vec<u64>,
+    /// #2653: the union of owner RGs requested by every
+    /// `ExportOwnerRGSessions` command processed this tick. The command
+    /// handler NO LONGER emits the open deltas itself — doing so pushed the
+    /// entire owned-session set (up to `DEFAULT_MAX_SESSIONS` = 32x the 4096
+    /// delta ring) into the ring in one shot, overflowing it and silently
+    /// dropping sessions 4097..N from the HA bulk snapshot. Instead the
+    /// handler records the RGs here and the worker loop performs the same
+    /// chunked drain-as-you-export the #2442 loss-of-sync resync uses
+    /// (collect candidates -> emit in < cap chunks -> drain between chunks),
+    /// so the complete snapshot ships without overflowing the ring.
+    pub export_owner_rgs: Vec<i32>,
     pub shaped_tx_requests: Vec<TxRequest>,
     /// #941 Work item C: set when at least one
     /// `WorkerCommand::VacateAllSharedExactSlots` was processed.
@@ -495,11 +506,18 @@ pub(crate) fn forward_export_candidates_for_owner_rgs(
 
 // #2442: widened from `pub(in crate::afxdp::session_glue)` to `pub(crate)` so
 // the session-module resync test can re-emit owned forward sessions through the
-// same table-truth walk the `ExportOwnerRGSessions` command uses. The
-// command path pushes the entire candidate set at once (its caller drains
-// against a 15s export-ack budget); the worker-loop resync uses the chunked
-// `forward_export_candidates_for_owner_rgs` collector + interleaved drain
-// instead (see `worker::loop_body`).
+// same table-truth walk the `ExportOwnerRGSessions` command uses.
+//
+// #2653: this naive "emit the whole candidate set at once" helper is no longer
+// on the production path. BOTH the worker-loop loss-of-sync resync AND the
+// single-shot `ExportOwnerRGSessions` command now use the chunked
+// drain-as-you-export (collect via `forward_export_candidates_for_owner_rgs`
+// -> emit in < ring-cap chunks -> drain between chunks, see `worker::loop_body`)
+// so a worker owning more sessions than the 4096-slot ring never overflows it
+// mid-export. The unbounded helper is retained only as a test fixture that
+// drives the candidate-selection walk directly (forward yes, reverse /
+// peer-synced / transient-seed / fabric-ingress no), hence `#[cfg(test)]`.
+#[cfg(test)]
 pub(crate) fn export_forward_sessions_for_owner_rgs(
     sessions: &mut SessionTable,
     owner_rgs: &[i32],
@@ -534,6 +552,7 @@ pub(super) fn apply_worker_commands(
                 return WorkerCommandResults {
                     cancelled_keys: Vec::new(),
                     exported_sequences: Vec::new(),
+                    export_owner_rgs: Vec::new(),
                     shaped_tx_requests: Vec::new(),
                     vacate_all_shared_exact_slots: false,
                 };
@@ -544,6 +563,7 @@ pub(super) fn apply_worker_commands(
             return WorkerCommandResults {
                 cancelled_keys: Vec::new(),
                 exported_sequences: Vec::new(),
+                export_owner_rgs: Vec::new(),
                 shaped_tx_requests: Vec::new(),
                 vacate_all_shared_exact_slots: false,
             };
@@ -556,6 +576,7 @@ pub(super) fn apply_worker_commands(
     let now_secs = now_ns / 1_000_000_000;
     let mut cancelled_keys: Vec<SessionKey> = Vec::new();
     let mut exported_sequences = Vec::new();
+    let mut export_owner_rgs: Vec<i32> = Vec::new();
     let mut shaped_tx_requests = Vec::new();
     let mut vacate_all_shared_exact_slots = false;
     for cmd in pending {
@@ -590,8 +611,8 @@ pub(super) fn apply_worker_commands(
                 owner_rgs,
             } => {
                 commands::handle_export_owner_rg_sessions(
-                    sessions,
                     &mut exported_sequences,
+                    &mut export_owner_rgs,
                     sequence,
                     owner_rgs,
                 );
@@ -680,6 +701,7 @@ pub(super) fn apply_worker_commands(
     WorkerCommandResults {
         cancelled_keys,
         exported_sequences,
+        export_owner_rgs,
         shaped_tx_requests,
         vacate_all_shared_exact_slots,
     }

--- a/userspace-dp/src/afxdp/session_glue/mod.rs
+++ b/userspace-dp/src/afxdp/session_glue/mod.rs
@@ -467,13 +467,14 @@ pub(super) fn delete_terminal_filtered_session(
 
 /// #2442: the filter half of `export_forward_sessions_for_owner_rgs`. Walks the
 /// owner-RG index and returns the export candidates (forward, locally-owned,
-/// forwarding-disposition sessions) WITHOUT pushing any delta. The two
-/// callers re-emit at different cadences: the `ExportOwnerRGSessions` command
-/// path pushes the whole set in one go (its caller drains with a 15s
-/// export-ack budget), while the worker-loop loss-of-sync resync path
-/// (`worker::loop_body`) emits in ring-sized chunks, draining between chunks so
-/// a worker owning up to `DEFAULT_MAX_SESSIONS` (32× the delta ring) never
-/// re-overflows the ring it is trying to recover.
+/// forwarding-disposition sessions) WITHOUT pushing any delta. Both callers
+/// re-emit through the SAME `chunked_drain_as_you_export!` macro in
+/// `worker::loop_body` (#2653): the `ExportOwnerRGSessions` command path (now
+/// recorded in `WorkerCommandResults.export_owner_rgs`, not emitted inline) and
+/// the loss-of-sync resync path both emit in `RESYNC_EXPORT_CHUNK`-sized chunks,
+/// draining the ring to empty between chunks so a worker owning up to
+/// `DEFAULT_MAX_SESSIONS` (32× the delta ring) never re-overflows the ring it is
+/// trying to recover, and ship a complete snapshot.
 pub(crate) fn forward_export_candidates_for_owner_rgs(
     sessions: &SessionTable,
     owner_rgs: &[i32],

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -2120,6 +2120,136 @@ fn epoch_based_flow_cache_unrelated_rg_not_invalidated() {
     );
 }
 
+/// #2653: the single-shot `ExportOwnerRGSessions` command path must NOT push
+/// the entire owned-session set into the 4096-slot delta ring in one shot. A
+/// worker can own up to DEFAULT_MAX_SESSIONS (131072) = 32x the ring; the old
+/// `handle_export_owner_rg_sessions` called `export_forward_sessions_for_owner_rgs`
+/// inline, which emitted all N open deltas with no interleaved drain, overflowed
+/// the ring at delta 4097, and silently dropped sessions 4097..N from the HA
+/// bulk snapshot on rejoin / RG transition (the command-path sibling of the
+/// #2442 worker-loop overflow).
+///
+/// The fix makes the command handler RECORD the owner RGs (`export_owner_rgs`)
+/// instead of emitting; the worker loop performs the chunked drain-as-you-export.
+/// This test installs > ring-cap owned forward sessions, dispatches the command
+/// through `apply_worker_commands`, and asserts:
+///   (a) the command records the owner RG;
+///   (b) `apply_worker_commands` emits NOTHING inline and does NOT overflow the
+///       ring (delta_drops unchanged, no loss latch) — the bound is respected;
+///   (c) driving the recorded RGs through the chunked drain-as-you-export ships
+///       the COMPLETE snapshot (all N) with zero new drops.
+///
+/// FAIL-ON-REVERT: restoring the inline `export_forward_sessions_for_owner_rgs`
+/// call in `handle_export_owner_rg_sessions` overflows the ring INSIDE
+/// `apply_worker_commands` — (b) reds (delta_drops jumps by ~N-4096, the loss
+/// latch arms, and only 4096 deltas reach the inline drain).
+#[test]
+fn export_owner_rg_command_does_not_overflow_ring_unbounded() {
+    // Ring cap is MAX_SESSION_DELTAS (4096, private to session/mod.rs).
+    const RING_CAP: usize = 4096;
+    const RESYNC_EXPORT_CHUNK: usize = 2048; // mirror the worker loop
+    let n: usize = RING_CAP + 1000; // 5096 > cap to exercise the overflow hole
+
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    let mut sessions = SessionTable::new();
+    let mut keys: Vec<SessionKey> = Vec::with_capacity(n);
+    for i in 0..n {
+        let mut key = test_key();
+        // Unique forward keys (owner RG 1 from test_metadata): sweep src ip+port.
+        key.src_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 61, (i / 256) as u8));
+        key.src_port = ((i % 256) as u16) + 1000;
+        assert!(sessions.install_with_protocol(
+            key.clone(),
+            test_decision(),
+            test_metadata(),
+            1_000_000,
+            PROTO_TCP,
+            0x10,
+        ));
+        keys.push(key);
+    }
+    // The installs themselves overflowed the ring (n > cap) and latched loss;
+    // clear that pre-existing state so the assertions below measure ONLY what
+    // the export command does.
+    assert!(sessions.delta_drops() > 0, "installing > cap deltas overflows");
+    let _ = sessions.take_delta_loss();
+    while !sessions.drain_deltas(256).is_empty() {}
+    let drops_before_export = sessions.delta_drops();
+    assert!(!sessions.take_delta_loss(), "loss latch cleared before export");
+
+    commands
+        .lock()
+        .expect("commands lock")
+        .push_back(WorkerCommand::ExportOwnerRGSessions {
+            sequence: 42,
+            owner_rgs: vec![1],
+        });
+    let forwarding = test_forwarding_state_with_fabric();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::new());
+    let mut ha_state = BTreeMap::new();
+    ha_state.insert(1, active_ha_runtime(monotonic_nanos() / 1_000_000_000));
+    let results = apply_worker_commands(
+        &commands,
+        &mut sessions,
+        -1,
+        -1,
+        -1,
+        &forwarding,
+        &ha_state,
+        &dynamic_neighbors,
+    );
+
+    // (a) the command recorded the owner RG and sequence.
+    assert_eq!(results.exported_sequences, vec![42]);
+    assert_eq!(results.export_owner_rgs, vec![1]);
+
+    // (b) THE BOUND: apply_worker_commands must NOT push unbounded into the
+    // ring. It emits nothing inline and never overflows. The reverted inline
+    // export would have emitted all N here, overflowing the ring.
+    assert!(
+        !sessions.has_pending_deltas(),
+        "export command must NOT emit deltas inline (#2653) — the worker loop \
+         performs the chunked drain-as-you-export"
+    );
+    assert_eq!(
+        sessions.delta_drops(),
+        drops_before_export,
+        "export command must NOT overflow the ring (the #2653 unbounded bug)"
+    );
+    assert!(
+        !sessions.take_delta_loss(),
+        "export command must NOT latch a delta loss (no mid-export overflow)"
+    );
+
+    // (c) driving the recorded RGs through the chunked drain-as-you-export the
+    // worker loop runs ships the COMPLETE snapshot with zero new drops.
+    let owner_rgs = results.export_owner_rgs.clone();
+    let candidates = crate::afxdp::forward_export_candidates_for_owner_rgs(&sessions, &owner_rgs);
+    let mut exported = 0usize;
+    for chunk in candidates.chunks(RESYNC_EXPORT_CHUNK) {
+        for (key, decision, metadata, origin) in chunk.iter().cloned() {
+            sessions.emit_open_delta_with_origin(key, decision, metadata, origin, true);
+        }
+        loop {
+            let d = sessions.drain_deltas(256);
+            if d.is_empty() {
+                break;
+            }
+            exported += d.iter().filter(|x| x.kind == SessionDeltaKind::Open).count();
+        }
+    }
+    assert_eq!(
+        exported, n,
+        "chunked export ships the COMPLETE snapshot ({n}), not the ring cap"
+    );
+    assert_eq!(
+        sessions.delta_drops(),
+        drops_before_export,
+        "the chunked export drops nothing (drain-as-you-export never overflows)"
+    );
+    assert!(!sessions.take_delta_loss(), "no spurious re-arm after export");
+}
+
 #[test]
 fn apply_worker_commands_exports_owner_rg_forward_sessions_without_teardown() {
     let commands = Arc::new(Mutex::new(VecDeque::new()));
@@ -2169,6 +2299,13 @@ fn apply_worker_commands_exports_owner_rg_forward_sessions_without_teardown() {
 
     assert!(results.cancelled_keys.is_empty());
     assert_eq!(results.exported_sequences, vec![9]);
+    // #2653: the command handler records the owner RGs instead of emitting the
+    // deltas inline (the worker loop performs the chunked drain-as-you-export).
+    assert_eq!(results.export_owner_rgs, vec![1]);
+    assert!(
+        sessions.drain_deltas(16).is_empty(),
+        "apply_worker_commands no longer emits export deltas inline (#2653)"
+    );
     let hit = sessions
         .lookup(&key, 2_000_000, 0x10)
         .expect("exported forward hit");
@@ -2177,6 +2314,9 @@ fn apply_worker_commands_exports_owner_rg_forward_sessions_without_teardown() {
         hit.decision.resolution.disposition,
         ForwardingDisposition::ForwardCandidate
     );
+    // Drive the recorded RGs through the same candidate walk the worker loop
+    // chunked export uses: the forward session must republish as an Open delta.
+    export_forward_sessions_for_owner_rgs(&mut sessions, &results.export_owner_rgs);
     let deltas = sessions.drain_deltas(16);
     assert_eq!(deltas.len(), 1, "export should republish forward session");
     assert_eq!(deltas[0].kind, SessionDeltaKind::Open);
@@ -2229,6 +2369,10 @@ fn apply_worker_commands_does_not_export_missing_neighbor_seed_sessions() {
 
     assert!(results.cancelled_keys.is_empty());
     assert_eq!(results.exported_sequences, vec![10]);
+    assert_eq!(results.export_owner_rgs, vec![1]);
+    // Even when the worker loop drives the recorded RGs through the chunked
+    // export, a missing-neighbor seed session must NOT be republished.
+    export_forward_sessions_for_owner_rgs(&mut sessions, &results.export_owner_rgs);
     assert!(
         sessions.drain_deltas(16).is_empty(),
         "missing-neighbor seed sessions must not be exported as HA deltas"
@@ -3057,6 +3201,10 @@ fn export_owner_rg_sessions_skips_locally_demoted_entries() {
     );
 
     assert_eq!(results.exported_sequences, vec![11]);
+    assert_eq!(results.export_owner_rgs, vec![1]);
+    // Driving the recorded RGs through the chunked-export candidate walk must
+    // still emit nothing: the session was demoted out of owner RG 1's index.
+    export_forward_sessions_for_owner_rgs(&mut sessions, &results.export_owner_rgs);
     assert!(
         sessions.drain_deltas(16).is_empty(),
         "demoted local owner sessions must not be re-exported as fresh HA deltas"
@@ -3966,6 +4114,8 @@ fn apply_worker_commands_dispatch_order_pin_with_demote_dedup() {
 
     // ── (a) Exports preserved ───────────────────────────────────────────────
     assert_eq!(results.exported_sequences, vec![7u64]);
+    // #2653: the export owner RG is recorded for the worker-loop chunked export.
+    assert_eq!(results.export_owner_rgs, vec![5i32]);
 
     // ── (b) ShapedLocal pushed exactly once ────────────────────────────────
     assert_eq!(results.shaped_tx_requests.len(), 1);

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -586,6 +586,7 @@ pub(crate) fn worker_loop(
             WorkerCommandResults {
                 cancelled_keys: Vec::new(),
                 exported_sequences: Vec::new(),
+                export_owner_rgs: Vec::new(),
                 shaped_tx_requests: Vec::new(),
                 vacate_all_shared_exact_slots: false,
             }
@@ -593,6 +594,7 @@ pub(crate) fn worker_loop(
         let WorkerCommandResults {
             cancelled_keys,
             exported_sequences,
+            export_owner_rgs,
             shaped_tx_requests,
             vacate_all_shared_exact_slots,
         } = command_results;
@@ -839,49 +841,75 @@ pub(crate) fn worker_loop(
         // during a resync — the complete snapshot ships and the latch is not
         // spuriously re-armed. A genuinely new drop after the resync still
         // re-arms a fresh episode on a later cycle.
-        if sessions.take_delta_loss() {
-            // Emit at most this many open deltas before draining. Comfortably
-            // under MAX_SESSION_DELTAS (4096) so a freshly-emptied ring never
-            // overflows mid-chunk.
-            const RESYNC_EXPORT_CHUNK: usize = 2048;
-            // Flush whatever is queued in the ring to the peer (shared with the
-            // pre-export backlog drain and each chunk's post-emit drain).
-            macro_rules! drain_and_flush_all {
-                () => {
-                    while sessions.has_pending_deltas() {
-                        let deltas = sessions.drain_deltas(256);
-                        purge_queued_flows_for_closed_deltas(
-                            &mut bindings,
-                            &binding_lookup,
-                            &mut shared_recycles,
-                            &deltas,
-                        );
-                        // #2669: flush UNCONDITIONALLY. The binding-independent
-                        // consumers (shared session/conntrack tables, HA peer,
-                        // peer-worker commands, recent-deltas RPC buffer, event
-                        // stream) must receive every drained delta even when no
-                        // binding exists; only the per-binding RPC fallback push
-                        // is gated on a binding. Gating the whole flush would
-                        // drain-then-discard, silently desyncing HA/conntrack.
-                        flush_drained_session_deltas!(&deltas);
+        //
+        // Emit at most this many open deltas before draining. Comfortably
+        // under MAX_SESSION_DELTAS (4096) so a freshly-emptied ring never
+        // overflows mid-chunk. Shared by the #2442 loss-of-sync resync and the
+        // #2653 single-shot `ExportOwnerRGSessions` command path.
+        const RESYNC_EXPORT_CHUNK: usize = 2048;
+        // Flush whatever is queued in the ring to the peer (shared with the
+        // pre-export backlog drain and each chunk's post-emit drain).
+        macro_rules! drain_and_flush_all {
+            () => {
+                while sessions.has_pending_deltas() {
+                    let deltas = sessions.drain_deltas(256);
+                    purge_queued_flows_for_closed_deltas(
+                        &mut bindings,
+                        &binding_lookup,
+                        &mut shared_recycles,
+                        &deltas,
+                    );
+                    // #2669: flush UNCONDITIONALLY. The binding-independent
+                    // consumers (shared session/conntrack tables, HA peer,
+                    // peer-worker commands, recent-deltas RPC buffer, event
+                    // stream) must receive every drained delta even when no
+                    // binding exists; only the per-binding RPC fallback push
+                    // is gated on a binding. Gating the whole flush would
+                    // drain-then-discard, silently desyncing HA/conntrack.
+                    flush_drained_session_deltas!(&deltas);
+                }
+            };
+        }
+        // Chunked drain-as-you-export: collect the owned forward candidates
+        // for `$owner_rgs` once, then emit them in ring-sized chunks, draining
+        // and flushing each chunk to the peer before emitting the next. The
+        // ring is empty before every chunk and a chunk is < cap, so
+        // `push_delta` NEVER overflows during the export — the complete
+        // snapshot ships and the loss latch is not spuriously re-armed. A
+        // worker can own up to DEFAULT_MAX_SESSIONS (131072) forward sessions
+        // — 32x the 4096-slot delta ring — so a naive "emit all N then drain
+        // once" drops sessions 4097..N (the #2653 command-path bug, sibling of
+        // #2442's worker-loop bug).
+        macro_rules! chunked_drain_as_you_export {
+            ($owner_rgs:expr) => {{
+                let owner_rgs = $owner_rgs;
+                if !owner_rgs.is_empty() {
+                    let candidates = crate::afxdp::forward_export_candidates_for_owner_rgs(
+                        &sessions, &owner_rgs,
+                    );
+                    for chunk in candidates.chunks(RESYNC_EXPORT_CHUNK) {
+                        for (key, decision, metadata, origin) in chunk.iter().cloned() {
+                            sessions
+                                .emit_open_delta_with_origin(key, decision, metadata, origin, true);
+                        }
+                        // Ship this chunk and empty the ring before the next
+                        // chunk, so the next batch of emits cannot overflow.
+                        drain_and_flush_all!();
                     }
-                };
-            }
+                }
+            }};
+        }
+        if sessions.take_delta_loss() {
+            // #2442 loss-of-sync resync. If `push_delta` dropped any delta
+            // since the last drain, the in-worker session-delta ring
+            // overflowed and the downstream session-sync consumer missed
+            // HA-relevant open/close events — its view may have silently
+            // diverged from the table truth. Re-emit an open delta for every
+            // owned forward session so the peer re-derives a complete snapshot.
+            //
             // Drain the existing backlog so the ring starts empty.
             drain_and_flush_all!();
-            let owner_rgs = sessions.all_owner_rg_ids();
-            if !owner_rgs.is_empty() {
-                let candidates =
-                    crate::afxdp::forward_export_candidates_for_owner_rgs(&sessions, &owner_rgs);
-                for chunk in candidates.chunks(RESYNC_EXPORT_CHUNK) {
-                    for (key, decision, metadata, origin) in chunk.iter().cloned() {
-                        sessions.emit_open_delta_with_origin(key, decision, metadata, origin, true);
-                    }
-                    // Ship this chunk and empty the ring before the next chunk,
-                    // so the next batch of emits cannot overflow.
-                    drain_and_flush_all!();
-                }
-            }
+            chunked_drain_as_you_export!(sessions.all_owner_rg_ids());
             // The export drained to empty without overflowing, so any latch set
             // during this resync was a genuinely-new local drop, not the export
             // re-flooding itself. Clearing it here is unnecessary (drain-as-you-
@@ -889,17 +917,19 @@ pub(crate) fn worker_loop(
             // spurious re-arm regardless.
         }
         if !exported_sequences.is_empty() {
-            while sessions.has_pending_deltas() {
-                let deltas = sessions.drain_deltas(256);
-                purge_queued_flows_for_closed_deltas(
-                    &mut bindings,
-                    &binding_lookup,
-                    &mut shared_recycles,
-                    &deltas,
-                );
-                // #2669: flush unconditionally — see flush_drained_session_deltas!.
-                flush_drained_session_deltas!(&deltas);
-            }
+            // #2653 single-shot `ExportOwnerRGSessions` command path. The
+            // command handler (`handle_export_owner_rg_sessions`) no longer
+            // emits the open deltas itself — it only records the requested
+            // owner RGs in `export_owner_rgs`. We perform the SAME chunked
+            // drain-as-you-export here (where the binding + flush machinery
+            // lives), so a worker owning more sessions than the 4096-slot ring
+            // ships the COMPLETE bulk snapshot to the HA peer without dropping
+            // sessions 4097..N. Drain any pre-export backlog first so the ring
+            // starts empty, then export, then drain the final chunk's tail.
+            drain_and_flush_all!();
+            chunked_drain_as_you_export!(export_owner_rgs);
+            drain_and_flush_all!();
+            // Ack only after the complete export has drained to the peer.
             if let Some(sequence) = exported_sequences.iter().copied().max() {
                 session_export_ack.store(sequence, Ordering::Release);
             }


### PR DESCRIPTION
Closes #2653

## Problem

The single-shot HA command path (`handle_export_owner_rg_sessions` →
`export_forward_sessions_for_owner_rgs`) pushed the ENTIRE owned forward-session
set into the 4096-slot per-worker session-delta ring in one shot, with no
interleaved drain. A worker can own up to `DEFAULT_MAX_SESSIONS` (131072) forward
sessions — 32× the ring cap. On a full owner-RG export (HA peer rejoin / RG
transition), if the owning worker held >4096 forward sessions the emit overflowed
the ring at delta 4097 and `push_delta` silently dropped sessions 4097..N → the
peer received an **incomplete bulk snapshot**.

This is the command-path sibling of the #2442 worker-loop overflow (PR #2638),
which only bounded the loss-of-sync resync path and left this byte-identical.
Same overflow class, same #835/#913 unbounded-queue lineage.

## Fix — reuse the #2442 chunked drain-as-you-export

`apply_worker_commands` has no `BindingWorker`/flush access, so it cannot drain
the ring to the peer mid-export — chunking *inside* the handler is impossible.
So the handler now only **records** the requested owner RGs in
`WorkerCommandResults.export_owner_rgs`; the worker loop (which owns the binding +
flush machinery) performs the same chunked drain-as-you-export the #2442 resync
uses:

1. drain+flush the existing backlog so the ring starts empty;
2. collect the export candidates once (`forward_export_candidates_for_owner_rgs`);
3. emit in `RESYNC_EXPORT_CHUNK = 2048` chunks, draining+flushing each chunk to
   the peer **before** the next;
4. advance `session_export_ack` only after the complete export has drained.

The ring is empty before every chunk and a chunk is < cap, so `push_delta` never
overflows during the export — the **complete snapshot ships regardless of session
count**. The `drain_and_flush_all!` macro + `RESYNC_EXPORT_CHUNK` are hoisted and
shared via a new `chunked_drain_as_you_export!` macro. The unbounded
`export_forward_sessions_for_owner_rgs` helper is now `#[cfg(test)]`-only.

## Bound + overflow policy

- **Bound**: each emit batch is `RESYNC_EXPORT_CHUNK = 2048` (< the 4096 ring cap).
- **Overflow policy**: chunk + **drain-to-backpressure**, **no drops**, complete
  snapshot — the established #2442 policy. Never coalesce or drop a session that
  backs fabric-forwarding / failover. This is not a design fork: the issue
  specifies reusing the #2442 mechanism, which already settled the policy.

## Fail-on-revert proof

New test `export_owner_rg_command_does_not_overflow_ring_unbounded`: installs
>4096 owned forward sessions, dispatches `ExportOwnerRGSessions` through
`apply_worker_commands`, and asserts:
- (a) the command records the owner RG + sequence;
- (b) **the bound** — `apply_worker_commands` emits NOTHING inline and does NOT
  overflow the ring (`delta_drops` unchanged, no loss latch);
- (c) driving the recorded RGs through the chunked export ships the COMPLETE
  snapshot (all N) with zero new drops.

**RED-on-revert verified**: temporarily restoring the inline
`export_forward_sessions_for_owner_rgs(sessions, &owner_rgs)` at the dispatch arm
overflows the ring *inside* `apply_worker_commands` → assertion (b) panics with
"export command must NOT emit deltas inline (#2653)". Fix restored, test green.

## Validation

- `cargo build --release` clean.
- `session_glue` suite 79/79; #2442 resync test (`resync_ships_complete_snapshot_above_ring_cap_without_relatching`) still green.
- Two unrelated tests (`worker_queue::concurrent_recovery_processes_each_command_exactly_once`, `wg::engine::reconcile_peers_snapshot_is_atomic_under_concurrent_load`) flake under full-suite CPU contention; both pass in isolation — pre-existing timing flakes, untouched by this change.
- **HA path — `make test-failover` to be run by the reviewer before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi