### PR TITLE
config+userspace-dp: static NAT port / mapped-port forwarding (#2491)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-06-25 — #2491: static NAT port / mapped-port forwarding
+
+- **Timestamp**: 2026-06-25
+- **Action**: Added Junos static-NAT per-port forwarding so several
+  services can live behind one public IP. Grammar:
+  `match destination-port <port>` (typed ValueInteger 1..65535) +
+  `then static-nat prefix <ip> mapped-port <port>`. The inbound DNAT
+  rewrites the destination port to mapped-port; the reverse SNAT
+  un-translates the return packet's source port back to the external
+  match port. Go: `StaticNATRule.{MatchDestinationPort,MappedPort}`,
+  compiler parse (both flat-set Keys + hierarchical shapes), strict
+  commit-check range guard + "mapped-port requires match destination-port"
+  guard in `validateNATHostMaskStrict`. Snapshot wire: additive
+  `match_destination_port`/`mapped_port` u16 fields (Go omitempty + Rust
+  serde default, regenerated `protocol_wire_v1.json`). Rust dataplane:
+  `StaticNatTable` keyed by `(IpAddr, Option<u16>)` so a port-mapped rule
+  and a whole-address 1:1 rule coexist on one external IP (port-specific
+  entry wins, port-less is the fallback); `match_dnat_with_counter` /
+  `match_snat_with_counter` thread the packet port. Fail-closed: a
+  mapped-port with no match-port demotes to whole-address; an
+  out-of-range port clamps to 0 on the wire.
+- **File(s)**: pkg/config/types_security.go, pkg/config/compiler_nat.go,
+  pkg/config/schema_security.go, pkg/config/static_nat_mapped_port_2491_test.go,
+  pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/nat.go,
+  pkg/dataplane/userspace/static_nat_mapped_port_2491_test.go,
+  userspace-dp/src/protocol/nat.rs, userspace-dp/src/nat/static_nat.rs,
+  userspace-dp/src/nat/tests.rs, userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs,
+  userspace-dp/src/afxdp/tests.rs, userspace-dp/src/afxdp/test_fixtures.rs,
+  userspace-dp/tests/fixtures/protocol_wire_v1.json,
+  docs/config-schema.md, docs/feature-coverage.md,
+  docs/pr/2491-static-nat-port-fwd/plan.md, _Log.md
+
 ## 2026-06-25 — #2623: GARP/NDP burst follow-up sends now count + surface errors
 
 - **Timestamp**: 2026-06-25

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -540,6 +540,24 @@ reserved for whole-dataplane selection where a rewrite shim
   - `security nat static rule-set rule match` — declared the
     `source-address` / `destination-address` children the static-NAT
     compiler reads (the subtree was previously unreachable by the walker).
+    #2491 added `match destination-port` as a typed `ValueInteger`
+    (1..65535) leaf: it is the external (pre-translation) port a
+    port-mapped static-NAT rule matches on. The companion
+    `then static-nat prefix <ip> mapped-port <port>` carries the internal
+    (post-translation) port. `static-nat` deliberately stays a
+    `children: nil` free-form leaf (so `prefix <ip> mapped-port <port>`
+    collapses onto ONE leaf node and SetPath grouping is preserved); the
+    `mapped-port` token therefore bypasses the schema value validator and
+    is range-checked in the compiler (`validateNATHostMaskStrict`,
+    `compiler_nat.go`), which ALSO rejects a `mapped-port` with no
+    matching `match destination-port` (the reverse SNAT could not recover
+    the original port). The snapshot fields `match_destination_port` /
+    `mapped_port` (`StaticNATRuleSnapshot`, both Go `omitempty` + Rust
+    `#[serde(default)]`, default 0) are an additive, backward-compatible
+    wire change; a single external IP can host several per-port mappings
+    plus a port-less whole-address 1:1 rule (the dataplane keys the
+    static-NAT tables by `(IP, Option<port>)` and falls back to the
+    port-less entry).
   - `protocols router-advertisement interface` — typed the
     second-denominated leaves (`max/min-advertisement-interval`,
     `default-lifetime`, `link-mtu`; the latter was tightened from

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -12,8 +12,9 @@ the userspace dataplane admission boundary is in
   application matching (multi-term apps), global policies, filtered
   session clearing.
 - **NAT**: source (interface + pool, userspace-v2 address-persistent),
-  destination (with hit counters), static 1:1, NAT64, NPTv6 (RFC 6296
-  stateless prefix translation).
+  destination (with hit counters), static 1:1 (with optional
+  `match destination-port` + `mapped-port` per-port forwarding, #2491),
+  NAT64, NPTv6 (RFC 6296 stateless prefix translation).
 - **Dual-stack**: IPv4 + IPv6, DHCPv4/v6 clients, embedded Router
   Advertisement sender (replaces radvd), SLAAC.
 - **Screen/IDS**: 11 checks (land, SYN flood, ping of death, teardrop,
@@ -143,7 +144,7 @@ The exact admission boundary is documented in
 | Application matching | Yes |
 | Source NAT (interface + pool) | Interface and pool mode yes; userspace `address-persistent` uses a documented userspace-v2 seeded FxHash selector (#2349 replaced the prior SHA-256; see `docs/userspace-dataplane-gaps.md` for the authoritative algorithm/contract). Non-HA per-pool `persistent-nat` lease reuse and pool exhaustion counters are implemented in helper-local runtime state; HA/restart persistence and cross-backend new-flow parity remain outside the current contract |
 | Destination NAT | Yes |
-| Static NAT (1:1) | Yes |
+| Static NAT (1:1) | Yes; optional per-port forwarding (#2491) — `match destination-port <port>` + `then static-nat prefix <ip> mapped-port <port>` translates the destination port on the inbound DNAT and un-translates the source port on the reverse SNAT, so several services can share one external IP. A port-less rule is the whole-address 1:1 fallback; both can coexist on one external IP |
 | NAT64 (IPv6↔IPv4) | Yes; translates ICMP echo AND error messages (Destination-Unreachable, Time-Exceeded, Packet-Too-Big↔Fragmentation-Needed with MTU adjustment, Parameter-Problem) per RFC 7915 §4.2/§5.2, including the embedded quoted packet — so PMTUD and traceroute work across the boundary (#2219). Per-packet **fragment translation** is RFC 7915 §4/§5 compliant (#2488): v6→v4 derives the IPv4 MF/offset/Identification from the IPv6 Fragment Header (low 16 bits of its 32-bit id) instead of the `no-v6-frag-header` config; v4→v6 inserts an IPv6 Fragment Header (next-header 44) for a fragmented IPv4 input. The TCP/UDP checksum on a first fragment is adjusted incrementally for the pseudo-header address change (RFC 1624, the full payload is not present). **Limitation:** only first/atomic fragments translate — non-first fragments are dropped both directions because the round-robin SNAT pool + port-keyed sessions cannot consistently map a port-less fragment to its datagram, so end-to-end fragmented NAT64 needs a stateful fragment-id cache (separate follow-up) |
 | NPTv6 (RFC 6296) | Yes |
 | Screen/IDS (11 checks) | Yes; userspace SYN-cookie runtime is wired |

--- a/docs/pr/2491-static-nat-port-fwd/plan.md
+++ b/docs/pr/2491-static-nat-port-fwd/plan.md
@@ -1,0 +1,96 @@
+# #2491 — static NAT port / mapped-port forwarding
+
+## Gap
+
+`StaticNATRule` supports only whole-address 1:1 NAT. Junos static-NAT
+also supports translating the destination port on a 1:1 host:
+
+```
+set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32
+set security nat static rule-set rs1 rule r1 match destination-port 8080
+set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 80
+```
+
+This lets multiple services live behind one public IP. xpf parses
+`match destination-port` nowhere for static NAT, and `then static-nat
+prefix` ignores any trailing `mapped-port` token, so the capability is
+inexpressible.
+
+## Approach (minimal, mirrors DNAT which already has port translation)
+
+1. **Go types** (`pkg/config/types_security.go`): add to `StaticNATRule`
+   - `MatchDestinationPort int` (0 = any / no port match)
+   - `MappedPort int` (0 = no port translation)
+2. **Compiler** (`pkg/config/compiler_nat.go` `compileNATStatic`):
+   - parse `match destination-port`
+   - parse the trailing `mapped-port <port>` token on
+     `then static-nat prefix <ip> mapped-port <port>` (both flat-set
+     `Keys` and hierarchical `prefix { ... } mapped-port { ... }`).
+   - Fail-closed: a `mapped-port`/`destination-port` outside 1..65535 is
+     a commit-check error (SchemaValidate typed leaf).
+3. **Schema** (`pkg/config/schema_security.go`): add typed leaves
+   `match destination-port` and (under `then static-nat`) `prefix` +
+   `mapped-port`, with port validation (#1319 SSOT).
+4. **Snapshot wire** (`pkg/dataplane/userspace/protocol.go` +
+   `nat.go`): add `MatchDestinationPort uint16` + `MappedPort uint16`
+   to `StaticNATRuleSnapshot` (Go `omitempty`). Mirror on the Rust side
+   (`userspace-dp/src/protocol/nat.rs`, `#[serde(default)]`). Regenerate
+   `tests/fixtures/protocol_wire_v1.json`. Backward compatible (new
+   optional fields default 0).
+5. **Rust dataplane** (`userspace-dp/src/nat/static_nat.rs`):
+   - `StaticNatEntry` gains `match_dst_port: Option<u16>` (external
+     port the inbound packet must carry) and `mapped_port: Option<u16>`
+     (internal port to rewrite to).
+   - Key the DNAT map by `(external_ip, Option<u16> match-port)` and the
+     SNAT map by `(internal_ip, Option<u16> mapped-port)` so a single
+     external IP can host several per-port mappings AND a port-less 1:1
+     mapping. Lookup falls back: try the port-specific entry first, then
+     the port-less (any-port) entry.
+   - Forward (DNAT, inbound): `match_dnat_with_counter(dst_ip, dst_port,
+     zone)` → `rewrite_dst = internal_ip`, and if `mapped_port` set,
+     `rewrite_dst_port = mapped_port`.
+   - Reverse (SNAT, outbound return): `match_snat_with_counter(src_ip,
+     src_port, zone)` → `rewrite_src = external_ip`, and if `mapped_port`
+     set and the packet's src port == mapped_port, `rewrite_src_port =
+     match_dst_port` (the external port).
+   - `NatDecision` already carries `rewrite_src_port`/`rewrite_dst_port`
+     and `.reverse()` already mirrors them — no decision-type change.
+6. **Callers** thread the port:
+   - `poll_descriptor/mod.rs` inbound: pass `flow.forward_key.dst_port`.
+   - `nat_exception.rs` SNAT: pass `flow.forward_key.src_port`.
+
+## Alternatives rejected
+
+- *Fold into DNAT table*: would lose the static-NAT bidirectional
+  semantics (the reverse SNAT that rewrites the source back to the
+  external IP). Static NAT is its own table by design; extend it.
+- *Key DNAT by IP only, store a Vec of port-mappings per IP*: more
+  allocation + a linear scan; the (IP, Option<port>) composite key is
+  O(1) and matches the existing FxHashMap shape.
+
+## Files touched
+
+- pkg/config/types_security.go
+- pkg/config/compiler_nat.go
+- pkg/config/schema_security.go (+ schema_walk typed-leaf validation)
+- pkg/dataplane/userspace/protocol.go
+- pkg/dataplane/userspace/nat.go
+- userspace-dp/src/protocol/nat.rs
+- userspace-dp/src/nat/static_nat.rs
+- userspace-dp/src/afxdp/poll_descriptor/mod.rs
+- userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs
+- userspace-dp/tests/fixtures/protocol_wire_v1.json (regen)
+- docs/config-schema.md, docs/ (NAT)
+
+## Test strategy (fail-on-revert)
+
+- Go: flat-set `ParseSetCommand`+`SetPath` compiles a rule with
+  `match destination-port` + `then static-nat prefix … mapped-port …`;
+  assert `StaticNATRule.MatchDestinationPort`/`MappedPort`; assert the
+  snapshot carries them. Revert (drop the parse) → RED.
+- Go schema: invalid port (0, 70000) rejected by SchemaValidate.
+- Rust: `from_snapshots` builds the port-keyed entry; `match_dnat`
+  rewrites dst + dst_port on the matching port and MISSES a
+  non-matching port; `match_snat` un-translates the source port on the
+  return packet. Revert (drop the mapped-port rewrite) → RED.
+- Rust wire: protocol-wire fixture regenerated, round-trip green.

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -265,6 +265,40 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 					}
 				}
 			}
+			// #2491: port-mapped static NAT. The `mapped-port` token rides
+			// inside the children:nil static-nat leaf, so the schema's
+			// value-slot validator never sees it; range-check it here. An
+			// out-of-range port would truncate to a wrong u16 in the snapshot,
+			// so reject it. A `mapped-port` requires a matching `match
+			// destination-port`: without an external port to match, the port
+			// rewrite has no inbound trigger and the reverse SNAT cannot
+			// recover the original port.
+			if rule.MatchDestinationPort != 0 && (rule.MatchDestinationPort < 1 || rule.MatchDestinationPort > 65535) {
+				if err := emitSuffix(fmt.Sprintf(
+					"security nat static rule-set %q rule %q match destination-port %d is out of range (1-65535)",
+					rs.Name, rule.Name, rule.MatchDestinationPort),
+					" (ignored: port match dropped by dataplane until corrected)"); err != nil {
+					return nil, err
+				}
+			}
+			if rule.MappedPort != 0 {
+				if rule.MappedPort < 1 || rule.MappedPort > 65535 {
+					if err := emitSuffix(fmt.Sprintf(
+						"security nat static rule-set %q rule %q then static-nat mapped-port %d is out of range (1-65535)",
+						rs.Name, rule.Name, rule.MappedPort),
+						" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
+						return nil, err
+					}
+				}
+				if rule.MatchDestinationPort == 0 {
+					if err := emitSuffix(fmt.Sprintf(
+						"security nat static rule-set %q rule %q then static-nat mapped-port %d requires a matching `match destination-port`",
+						rs.Name, rule.Name, rule.MappedPort),
+						" (ignored: port translation dropped by dataplane until corrected)"); err != nil {
+						return nil, err
+					}
+				}
+			}
 		}
 	}
 
@@ -1303,6 +1337,26 @@ func parseDNATPortList(m *Node) []int {
 	return ports
 }
 
+// staticNATMappedPortFromKeys extracts the `mapped-port <port>` modifier
+// from a flat-set static-NAT leaf's collapsed Keys (#2491). The lexer
+// collapses `then static-nat prefix <ip> mapped-port <port>` onto one node
+// whose Keys are `["static-nat","prefix","<ip>","mapped-port","<port>"]`
+// because `static-nat` is a children:nil schema leaf. Returns 0 (no port
+// translation) when the keyword is absent or its value is non-numeric;
+// the schema does not yet range-check this in-leaf token, so the caller's
+// dataplane parse fails closed on an out-of-range value.
+func staticNATMappedPortFromKeys(keys []string) int {
+	for i := 0; i+1 < len(keys); i++ {
+		if keys[i] == "mapped-port" {
+			if p, err := strconv.Atoi(keys[i+1]); err == nil {
+				return p
+			}
+			return 0
+		}
+	}
+	return 0
+}
+
 func compileNATStatic(node *Node, sec *SecurityConfig) error {
 	for _, rsInst := range namedInstances(node.FindChildren("rule-set")) {
 		// Parse from zones (bracket lists produce multiple keys)
@@ -1329,6 +1383,14 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 						rule.Match = nodeVal(m)
 					case "source-address":
 						rule.SourceAddress = nodeVal(m)
+					case "destination-port":
+						// #2491: external (pre-translation) destination
+						// port the inbound packet must carry. Schema
+						// already range-checks 1..65535; tolerate a
+						// non-numeric value defensively (leave 0 = any).
+						if p, err := strconv.Atoi(nodeVal(m)); err == nil {
+							rule.MatchDestinationPort = p
+						}
 					}
 				}
 			}
@@ -1347,8 +1409,30 @@ func compileNATStatic(node *Node, sec *SecurityConfig) error {
 							rule.IsNPTv6 = true
 						} else if len(t.Keys) >= 3 && t.Keys[1] == "prefix" {
 							rule.Then = t.Keys[2]
+							// #2491: optional trailing `mapped-port <port>`.
+							// Flat-set collapses the whole `prefix <ip>
+							// mapped-port <port>` onto this one leaf's Keys
+							// (`static-nat` is a children:nil schema leaf), so
+							// scan for the keyword + value pair.
+							rule.MappedPort = staticNATMappedPortFromKeys(t.Keys)
 						} else if pn := t.FindChild("prefix"); pn != nil {
 							rule.Then = nodeVal(pn)
+							// #2491: `then static-nat prefix <ip> mapped-port
+							// <port>` collapses onto the `prefix` child's Keys
+							// (`["prefix","<ip>","mapped-port","<port>"]`)
+							// because `static-nat` is a children:nil schema
+							// leaf, so the modifier rides on the prefix leaf,
+							// not a sibling `mapped-port` node. Scan pn.Keys.
+							rule.MappedPort = staticNATMappedPortFromKeys(pn.Keys)
+							// Hierarchical shape `static-nat { prefix X;
+							// mapped-port P; }` carries it as a sibling child.
+							if rule.MappedPort == 0 {
+								if mp := t.FindChild("mapped-port"); mp != nil {
+									if p, err := strconv.Atoi(nodeVal(mp)); err == nil {
+										rule.MappedPort = p
+									}
+								}
+							}
 						} else if t.FindChild("inet") != nil || (len(t.Keys) >= 2 && t.Keys[1] == "inet") {
 							// static-nat { inet; } — NAT64 translation
 							rule.Then = "inet"

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -153,9 +153,23 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 					"match": {desc: "Match criteria", children: map[string]*schemaNode{
 						"destination-address": {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
 						"source-address":      {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						// #2491: external (pre-translation) destination port the
+						// inbound packet must carry for a port-mapped static-NAT
+						// rule (`then static-nat prefix <ip> mapped-port <port>`).
+						// Typed 1..65535 so a garbage or out-of-range port fails
+						// at commit instead of silently dropping the rule.
+						"destination-port": {desc: "Destination port to match", args: 1, valueType: ValueInteger, valueDesc: "TCP/UDP destination port (1-65535)", valueExamples: []string{"443", "8080"}, validator: ValidateInteger(1, 65535), placeholder: "<port>", children: nil},
 					}},
+					// #2491: `static-nat` stays a free-form leaf (children: nil)
+					// so `prefix <ip> [mapped-port <port>]`, `nptv6-prefix
+					// <prefix>`, and `inet` all collapse onto ONE leaf node and
+					// the compiler reads the tokens from Keys. Adding children
+					// here would split the mapped-port modifier off the prefix
+					// value and regress SetPath grouping (schema.go: children==
+					// nil is the replace-vs-container signal). The mapped-port
+					// range is validated in the compiler (compileNATStatic).
 					"then": {desc: "Static NAT action", children: map[string]*schemaNode{
-						"static-nat": {desc: "Static NAT translation (prefix|nptv6-prefix|inet)", children: nil},
+						"static-nat": {desc: "Static NAT translation (prefix [mapped-port <port>]|nptv6-prefix|inet)", children: nil},
 					}},
 				}},
 			}},

--- a/pkg/config/static_nat_mapped_port_2491_test.go
+++ b/pkg/config/static_nat_mapped_port_2491_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStaticNATMappedPortCompiles is the #2491 config half: a static-NAT rule
+// with `match destination-port` + `then static-nat prefix <ip> mapped-port
+// <port>` must compile both fields onto the StaticNATRule.
+//
+// Fail-on-revert: dropping the `destination-port` / `mapped-port` parse in
+// compileNATStatic (or the staticNATMappedPortFromKeys helper) leaves both
+// fields at 0 and this test goes RED.
+func TestStaticNATMappedPortCompiles(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+		"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 80",
+	})
+
+	if len(cfg.Security.NAT.Static) != 1 {
+		t.Fatalf("expected 1 static NAT rule-set, got %d", len(cfg.Security.NAT.Static))
+	}
+	rs := cfg.Security.NAT.Static[0]
+	if len(rs.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rs.Rules))
+	}
+	rule := rs.Rules[0]
+	if rule.Match != "203.0.113.1/32" {
+		t.Fatalf("Match = %q, want 203.0.113.1/32", rule.Match)
+	}
+	if rule.Then != "10.0.0.5/32" {
+		t.Fatalf("Then = %q, want 10.0.0.5/32", rule.Then)
+	}
+	if rule.MatchDestinationPort != 8080 {
+		t.Fatalf("MatchDestinationPort = %d, want 8080", rule.MatchDestinationPort)
+	}
+	if rule.MappedPort != 80 {
+		t.Fatalf("MappedPort = %d, want 80", rule.MappedPort)
+	}
+}
+
+// TestStaticNATWholeAddressNoPort confirms the legacy whole-address 1:1 rule
+// still compiles with zero ports (no port match, no port translation).
+func TestStaticNATWholeAddressNoPort(t *testing.T) {
+	cfg := compileSetLines(t, []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32",
+	})
+	rule := cfg.Security.NAT.Static[0].Rules[0]
+	if rule.MatchDestinationPort != 0 || rule.MappedPort != 0 {
+		t.Fatalf("whole-address rule must carry 0 ports, got match=%d mapped=%d",
+			rule.MatchDestinationPort, rule.MappedPort)
+	}
+}
+
+// TestStaticNATMappedPortOutOfRangeRejected is the fail-closed half: an
+// out-of-range mapped-port (the token rides inside the children:nil static-nat
+// leaf, bypassing the schema value validator) is rejected at strict
+// commit-check by validateNATHostMaskStrict.
+func TestStaticNATMappedPortOutOfRangeRejected(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+		"set security nat static rule-set rs1 rule r1 match destination-port 8080",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 70000",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	// Strict commit-check (run inside CompileConfig) must reject the
+	// out-of-range mapped-port. Reverting the range guard in
+	// validateNATHostMaskStrict makes CompileConfig succeed → RED.
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected CompileConfig to reject mapped-port 70000")
+	}
+	if !strings.Contains(err.Error(), "mapped-port") {
+		t.Fatalf("error must mention mapped-port, got %v", err)
+	}
+}
+
+// TestStaticNATMappedPortWithoutMatchPortRejected: a mapped-port with no
+// `match destination-port` has no inbound trigger and the reverse SNAT cannot
+// recover the original port, so strict commit-check rejects it.
+func TestStaticNATMappedPortWithoutMatchPortRejected(t *testing.T) {
+	tree := &ConfigTree{}
+	lines := []string{
+		"set security zones security-zone untrust",
+		"set security nat static rule-set rs1 from zone untrust",
+		"set security nat static rule-set rs1 rule r1 match destination-address 203.0.113.1/32",
+		"set security nat static rule-set rs1 rule r1 then static-nat prefix 10.0.0.5/32 mapped-port 80",
+	}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected CompileConfig to reject mapped-port without match destination-port")
+	}
+	if !strings.Contains(err.Error(), "requires a matching") {
+		t.Fatalf("error must explain the missing match destination-port, got %v", err)
+	}
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -379,6 +379,18 @@ type StaticNATRule struct {
 	SourceAddress string // source-address match (optional, e.g. "::/0" for NAT64)
 	Then          string // static-nat prefix (internal/private IP), or "inet" for NAT64
 	IsNPTv6       bool   // true if this is an nptv6-prefix rule (RFC 6296)
+	// MatchDestinationPort is the external (pre-translation) destination
+	// port the inbound packet must carry for this rule to apply (Junos
+	// `match destination-port`). 0 = match any port (whole-address 1:1,
+	// the legacy behaviour). #2491.
+	MatchDestinationPort int
+	// MappedPort is the internal (post-translation) destination port the
+	// 1:1 host receives (Junos `then static-nat prefix <ip> mapped-port
+	// <port>`). 0 = no port translation (whole-address 1:1). When set, the
+	// inbound DNAT rewrites the destination port to this value and the
+	// outbound return SNAT un-translates it back to MatchDestinationPort.
+	// #2491.
+	MappedPort int
 }
 
 // LimitSessionScreen configures per-IP session limiting.

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -161,6 +161,18 @@ func sourceNATPoolPortRange(pool *config.NATPool) (uint16, uint16, bool) {
 	return uint16(low), uint16(high), true
 }
 
+// clampPort coerces a compiler-stored port (int, 0 = unset) into the u16
+// wire slot. An out-of-range value is rejected at strict commit-check
+// (compiler_nat.go validateNATHostMaskStrict), but the lenient load/peer-sync
+// path can still carry one; clamp it to 0 ("no port translation") so a bad
+// value fails CLOSED on the wire instead of wrapping to a wrong u16. #2491.
+func clampPort(p int) uint16 {
+	if p < 1 || p > 65535 {
+		return 0
+	}
+	return uint16(p)
+}
+
 func buildStaticNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32) []StaticNATRuleSnapshot {
 	if cfg == nil || len(cfg.Security.NAT.Static) == 0 {
 		return nil
@@ -175,11 +187,13 @@ func buildStaticNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 				continue
 			}
 			out = append(out, StaticNATRuleSnapshot{
-				Name:       rule.Name,
-				FromZone:   rs.FromZone,
-				ExternalIP: rule.Match,
-				InternalIP: rule.Then,
-				CounterID:  natCounterID(natCounterIDs, dataplane.NATCounterTypeStatic, rs.Name, rule.Name),
+				Name:                 rule.Name,
+				FromZone:             rs.FromZone,
+				ExternalIP:           rule.Match,
+				InternalIP:           rule.Then,
+				MatchDestinationPort: clampPort(rule.MatchDestinationPort),
+				MappedPort:           clampPort(rule.MappedPort),
+				CounterID:            natCounterID(natCounterIDs, dataplane.NATCounterTypeStatic, rs.Name, rule.Name),
 			})
 		}
 	}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -415,6 +415,17 @@ type StaticNATRuleSnapshot struct {
 	FromZone   string `json:"from_zone,omitempty"`
 	ExternalIP string `json:"external_ip"`
 	InternalIP string `json:"internal_ip"`
+	// MatchDestinationPort is the external (pre-translation) destination port
+	// the inbound packet must carry for this port-mapped static-NAT rule
+	// (Junos `match destination-port`). 0 = match any port (whole-address
+	// 1:1, the legacy behaviour). #2491.
+	MatchDestinationPort uint16 `json:"match_destination_port,omitempty"`
+	// MappedPort is the internal (post-translation) destination port the 1:1
+	// host receives (Junos `then static-nat prefix <ip> mapped-port <port>`).
+	// 0 = no port translation. When set, the inbound DNAT rewrites the
+	// destination port to this value and the reverse-path SNAT un-translates
+	// it back to MatchDestinationPort. #2491.
+	MappedPort uint16 `json:"mapped_port,omitempty"`
 	// CounterID is the compiler-assigned per-rule translation hit counter ID
 	// (stable key-derived hash, non-zero; 0 means "no counter") for this static
 	// NAT rule (#2218; stable across reorder/removal, #2255).

--- a/pkg/dataplane/userspace/static_nat_mapped_port_2491_test.go
+++ b/pkg/dataplane/userspace/static_nat_mapped_port_2491_test.go
@@ -1,0 +1,60 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildStaticNATSnapshotCarriesMappedPort is the #2491 wire half: the Go
+// snapshot builder must carry MatchDestinationPort + MappedPort onto the
+// StaticNATRuleSnapshot so the Rust dataplane can do port-mapped static NAT.
+//
+// Fail-on-revert: dropping the two field assignments in buildStaticNATSnapshots
+// leaves both at 0 and this test goes RED.
+func TestBuildStaticNATSnapshotCarriesMappedPort(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{Name: "statnat", FromZone: "untrust", Rules: []*config.StaticNATRule{{
+			Name:                 "port-rule",
+			Match:                "203.0.113.1/32",
+			Then:                 "10.0.0.5/32",
+			MatchDestinationPort: 8080,
+			MappedPort:           80,
+		}}},
+	}
+
+	snaps := buildStaticNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 static NAT snapshot, got %d", len(snaps))
+	}
+	s := snaps[0]
+	if s.MatchDestinationPort != 8080 {
+		t.Fatalf("MatchDestinationPort = %d, want 8080", s.MatchDestinationPort)
+	}
+	if s.MappedPort != 80 {
+		t.Fatalf("MappedPort = %d, want 80", s.MappedPort)
+	}
+}
+
+// TestBuildStaticNATSnapshotClampsBadPort confirms an out-of-range port (which
+// can only reach the builder via the lenient load path; strict commit rejects
+// it) clamps to 0 ("no port translation") so it fails CLOSED on the wire
+// instead of wrapping to a wrong u16.
+func TestBuildStaticNATSnapshotClampsBadPort(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Static = []*config.StaticNATRuleSet{
+		{Name: "statnat", Rules: []*config.StaticNATRule{{
+			Name:                 "bad-port",
+			Match:                "203.0.113.1/32",
+			Then:                 "10.0.0.5/32",
+			MatchDestinationPort: 70000,
+			MappedPort:           -1,
+		}}},
+	}
+	s := buildStaticNATSnapshots(cfg, nil)[0]
+	if s.MatchDestinationPort != 0 || s.MappedPort != 0 {
+		t.Fatalf("out-of-range ports must clamp to 0, got match=%d mapped=%d",
+			s.MatchDestinationPort, s.MappedPort)
+	}
+}

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -703,10 +703,11 @@ pub(super) fn poll_binding_process_descriptor(
                             None
                         };
                         let static_dnat_decision = if dnat_decision.is_none() {
-                            worker_ctx
-                                .forwarding
-                                .static_nat
-                                .match_dnat_with_counter(resolution_target, ingress_zone_name)
+                            worker_ctx.forwarding.static_nat.match_dnat_with_counter(
+                                resolution_target,
+                                flow.forward_key.dst_port,
+                                ingress_zone_name,
+                            )
                         } else {
                             None
                         };

--- a/userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs
@@ -35,10 +35,11 @@ pub(super) fn source_nat_decision_for_flow(
     matched_counter: &mut Option<std::sync::Arc<crate::nat::NatRuleCounter>>,
 ) -> Result<NatDecision, SourceNatFailure> {
     *matched_counter = None;
-    if let Some((decision, counter)) = forwarding
-        .static_nat
-        .match_snat_with_counter(flow.src_ip, from_zone)
-    {
+    if let Some((decision, counter)) = forwarding.static_nat.match_snat_with_counter(
+        flow.src_ip,
+        flow.forward_key.src_port,
+        from_zone,
+    ) {
         *matched_counter = counter;
         return Ok(decision);
     }

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -748,6 +748,8 @@ pub(super) fn static_nat_snapshot() -> ConfigSnapshot {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         default_policy: "deny".to_string(),
         policies: vec![

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -943,6 +943,8 @@ fn static_nat_snat_matches_when_zone_is_empty() {
         from_zone: String::new(), // matches any zone
         external_ip: "203.0.113.10".to_string(),
         internal_ip: "192.168.1.10".to_string(),
+        match_destination_port: 0,
+        mapped_port: 0,
     }];
     let state = build_forwarding_state(&snapshot);
 
@@ -969,6 +971,8 @@ fn static_nat_takes_priority_over_interface_snat() {
         from_zone: String::new(),
         external_ip: "203.0.113.10".to_string(),
         internal_ip: "192.168.1.10".to_string(),
+        match_destination_port: 0,
+        mapped_port: 0,
     }];
     snapshot.source_nat_rules = vec![SourceNATRuleSnapshot {
         name: "interface-snat".to_string(),
@@ -1003,6 +1007,8 @@ fn static_nat_v6_dnat_and_snat() {
         from_zone: String::new(),
         external_ip: "2001:db8::10".to_string(),
         internal_ip: "fd00::10".to_string(),
+        match_destination_port: 0,
+        mapped_port: 0,
     }];
     // Add v6 addresses to interfaces
     snapshot.interfaces[0]

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -12,17 +12,32 @@ pub(crate) struct StaticNatEntry {
     pub(crate) external_ip: IpAddr,
     pub(crate) internal_ip: IpAddr,
     pub(crate) from_zone: String,
+    /// #2491: external (pre-translation) destination port the inbound packet
+    /// must carry for a port-mapped rule. `None` = whole-address 1:1 (match
+    /// any port, the legacy behaviour).
+    pub(crate) match_dst_port: Option<u16>,
+    /// #2491: internal (post-translation) destination port to rewrite to.
+    /// `None` = no port translation (whole-address 1:1).
+    pub(crate) mapped_port: Option<u16>,
     /// #2218: per-rule translation hit counter (None for counter_id 0).
     pub(crate) hit_counter: Option<Arc<NatRuleCounter>>,
 }
 
-/// Lookup table for static NAT -- indexed by IP for O(1) matching.
+/// Lookup table for static NAT -- indexed by (IP, Option<port>) for O(1)
+/// matching. #2491: a single external IP can host several per-port mappings
+/// (`mapped-port`) AND a port-less whole-address 1:1 mapping, so the key
+/// carries the matched port. The port-less entry uses `None` and is the
+/// fallback when no port-specific entry matches.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct StaticNatTable {
-    /// external_ip -> entry (for inbound DNAT)
-    dnat: FxHashMap<IpAddr, StaticNatEntry>,
-    /// internal_ip -> entry (for outbound SNAT)
-    snat: FxHashMap<IpAddr, StaticNatEntry>,
+    /// (external_ip, match-port) -> entry (for inbound DNAT). The match-port
+    /// is the external destination port (`Some` for a port-mapped rule,
+    /// `None` for a whole-address rule).
+    dnat: FxHashMap<(IpAddr, Option<u16>), StaticNatEntry>,
+    /// (internal_ip, mapped-port) -> entry (for outbound SNAT). The mapped-port
+    /// is the internal source port of the return packet (`Some` for a
+    /// port-mapped rule, `None` for a whole-address rule).
+    snat: FxHashMap<(IpAddr, Option<u16>), StaticNatEntry>,
 }
 
 /// Parse a static-NAT address that may carry a canonical host mask
@@ -71,14 +86,32 @@ impl StaticNatTable {
                 Some(ip) => ip,
                 None => continue,
             };
+            // #2491: a `mapped_port` without a `match_destination_port` has no
+            // inbound trigger (no external port to match) and the reverse SNAT
+            // cannot recover the original port, so fail CLOSED: drop the port
+            // translation and treat the rule as a whole-address 1:1. The Go
+            // compiler already rejects this at strict commit-check; this is the
+            // lenient-load / peer-sync backstop.
+            let (match_dst_port, mapped_port) = match (snap.match_destination_port, snap.mapped_port)
+            {
+                (0, _) => (None, None),
+                (m, 0) => (Some(m), None),
+                (m, p) => (Some(m), Some(p)),
+            };
             let entry = StaticNatEntry {
                 external_ip,
                 internal_ip,
                 from_zone: snap.from_zone.clone(),
+                match_dst_port,
+                mapped_port,
                 hit_counter: nat_counters.rule_counter(snap.counter_id),
             };
-            table.dnat.insert(external_ip, entry.clone());
-            table.snat.insert(internal_ip, entry);
+            // DNAT keyed by the external (pre-translation) destination port.
+            table.dnat.insert((external_ip, match_dst_port), entry.clone());
+            // SNAT keyed by the internal (post-translation) source port of the
+            // return packet, i.e. the mapped-port. A whole-address rule keys on
+            // `None`.
+            table.snat.insert((internal_ip, mapped_port), entry);
         }
         table
     }
@@ -88,20 +121,36 @@ impl StaticNatTable {
     /// Returns just the decision; existing callers/tests keep their
     /// `Option<NatDecision>` shape. The cold path uses
     /// [`match_dnat_with_counter`] (#2218) for the per-rule hit counter.
-    #[cfg_attr(not(test), allow(dead_code))]
+    ///
+    /// #2491: the test-only port-less wrapper looks up the whole-address
+    /// entry (port `0` exercises only the `None` fallback). The production
+    /// path uses [`match_dnat_with_counter`] with the packet's destination
+    /// port so a port-mapped rule can be matched.
+    #[cfg(test)]
     pub(crate) fn match_dnat(&self, dst_ip: IpAddr, ingress_zone: &str) -> Option<NatDecision> {
-        self.match_dnat_with_counter(dst_ip, ingress_zone)
+        self.match_dnat_with_counter(dst_ip, 0, ingress_zone)
             .map(|(decision, _)| decision)
     }
 
     /// #2218: as [`match_dnat`] but also returns the matched entry's
     /// per-rule hit counter (if any).
+    ///
+    /// #2491: `dst_port` is the inbound packet's destination port. A
+    /// port-mapped entry keyed on `Some(match_dst_port)` is tried first; on a
+    /// miss the whole-address entry keyed on `None` is the fallback. When the
+    /// matched entry carries a `mapped_port`, the decision rewrites the
+    /// destination port too.
     pub(crate) fn match_dnat_with_counter(
         &self,
         dst_ip: IpAddr,
+        dst_port: u16,
         ingress_zone: &str,
     ) -> Option<(NatDecision, Option<Arc<NatRuleCounter>>)> {
-        let entry = self.dnat.get(&dst_ip)?;
+        // Port-specific entry takes precedence over the whole-address entry.
+        let entry = self
+            .dnat
+            .get(&(dst_ip, Some(dst_port)))
+            .or_else(|| self.dnat.get(&(dst_ip, None)))?;
         if !entry.from_zone.is_empty() && entry.from_zone != ingress_zone {
             return None;
         }
@@ -109,6 +158,7 @@ impl StaticNatTable {
             NatDecision {
                 rewrite_src: None,
                 rewrite_dst: Some(entry.internal_ip),
+                rewrite_dst_port: entry.mapped_port,
                 ..NatDecision::default()
             },
             entry.hit_counter.clone(),
@@ -125,24 +175,43 @@ impl StaticNatTable {
     ///
     /// Returns just the decision; the cold path uses
     /// [`match_snat_with_counter`] (#2218) for the per-rule hit counter.
-    #[cfg_attr(not(test), allow(dead_code))]
+    ///
+    /// #2491: the test-only port-less wrapper looks up the whole-address
+    /// entry (port `0` exercises only the `None` fallback).
+    #[cfg(test)]
     pub(crate) fn match_snat(&self, src_ip: IpAddr, ingress_zone: &str) -> Option<NatDecision> {
-        self.match_snat_with_counter(src_ip, ingress_zone)
+        self.match_snat_with_counter(src_ip, 0, ingress_zone)
             .map(|(decision, _)| decision)
     }
 
     /// #2218: as [`match_snat`] but also returns the matched entry's
     /// per-rule hit counter (if any).
+    ///
+    /// #2491: `src_port` is the return packet's source port — for a
+    /// port-mapped flow this is the internal `mapped_port`. A port-specific
+    /// entry keyed on `Some(src_port)` is tried first; on a miss the
+    /// whole-address entry keyed on `None` is the fallback. When the matched
+    /// entry carries a `mapped_port`, the decision un-translates the source
+    /// port back to the external `match_dst_port`.
     pub(crate) fn match_snat_with_counter(
         &self,
         src_ip: IpAddr,
+        src_port: u16,
         _ingress_zone: &str,
     ) -> Option<(NatDecision, Option<Arc<NatRuleCounter>>)> {
-        let entry = self.snat.get(&src_ip)?;
+        let entry = self
+            .snat
+            .get(&(src_ip, Some(src_port)))
+            .or_else(|| self.snat.get(&(src_ip, None)))?;
+        // For a port-mapped rule, un-translate the source port back to the
+        // external (pre-translation) port; for a whole-address rule this is
+        // `None` (no port rewrite).
+        let rewrite_src_port = entry.mapped_port.and(entry.match_dst_port);
         Some((
             NatDecision {
                 rewrite_src: Some(entry.external_ip),
                 rewrite_dst: None,
+                rewrite_src_port,
                 ..NatDecision::default()
             },
             entry.hit_counter.clone(),
@@ -155,8 +224,11 @@ impl StaticNatTable {
         self.dnat.is_empty()
     }
 
-    /// Returns all external IPs (for local delivery recognition).
+    /// Returns all external IPs (for local delivery recognition). #2491: the
+    /// DNAT map is now keyed by `(IpAddr, Option<u16>)`; project the IP out.
+    /// A given external IP appears once per distinct port mapping, which is
+    /// fine for the consumers (they dedup or only test membership).
     pub(crate) fn external_ips(&self) -> impl Iterator<Item = &IpAddr> {
-        self.dnat.keys()
+        self.dnat.keys().map(|(ip, _)| ip)
     }
 }

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -550,6 +550,8 @@ fn static_nat_dnat_matches_external_ip_v4() {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -573,6 +575,8 @@ fn static_nat_snat_matches_internal_ip_v4() {
             from_zone: "trust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -596,6 +600,8 @@ fn static_nat_dnat_matches_external_ip_v6() {
             from_zone: "untrust".to_string(),
             external_ip: "2001:db8::1".to_string(),
             internal_ip: "fd00::1".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -619,6 +625,8 @@ fn static_nat_snat_matches_internal_ip_v6() {
             from_zone: "trust".to_string(),
             external_ip: "2001:db8::1".to_string(),
             internal_ip: "fd00::1".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -642,6 +650,8 @@ fn static_nat_zone_mismatch_returns_none_for_dnat() {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -669,6 +679,8 @@ fn static_nat_empty_zone_matches_any() {
             from_zone: String::new(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -698,6 +710,8 @@ fn static_nat_bidirectional_reverse() {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -739,6 +753,8 @@ fn static_nat_no_match_returns_none() {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -764,6 +780,8 @@ fn static_nat_invalid_ip_skipped() {
                 from_zone: String::new(),
                 external_ip: "not-an-ip".to_string(),
                 internal_ip: "192.168.1.10".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             },
             StaticNATRuleSnapshot {
                 counter_id: 0,
@@ -771,6 +789,8 @@ fn static_nat_invalid_ip_skipped() {
                 from_zone: String::new(),
                 external_ip: "203.0.113.10".to_string(),
                 internal_ip: "192.168.1.10".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             },
         ],
         &crate::nat::NatCounterStore::default(),
@@ -793,6 +813,8 @@ fn static_nat_external_ips_iterator() {
                 from_zone: String::new(),
                 external_ip: "203.0.113.10".to_string(),
                 internal_ip: "192.168.1.10".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             },
             StaticNATRuleSnapshot {
                 counter_id: 0,
@@ -800,6 +822,8 @@ fn static_nat_external_ips_iterator() {
                 from_zone: String::new(),
                 external_ip: "203.0.113.20".to_string(),
                 internal_ip: "192.168.1.20".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             },
         ],
         &crate::nat::NatCounterStore::default(),
@@ -827,6 +851,8 @@ fn static_nat_canonical_cidr_mask_v4_installs_entry() {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.5/32".to_string(),
             internal_ip: "10.0.0.5/32".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -864,6 +890,8 @@ fn static_nat_canonical_cidr_mask_v6_installs_entry() {
             from_zone: "untrust".to_string(),
             external_ip: "2001:db8::1/128".to_string(),
             internal_ip: "fd00::1/128".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
         }],
         &crate::nat::NatCounterStore::default(),
     );
@@ -899,6 +927,8 @@ fn static_nat_cidr_and_bare_coexist() {
                 from_zone: String::new(),
                 external_ip: "203.0.113.5/32".to_string(),
                 internal_ip: "10.0.0.5".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             },
             StaticNATRuleSnapshot {
                 counter_id: 0,
@@ -906,6 +936,8 @@ fn static_nat_cidr_and_bare_coexist() {
                 from_zone: String::new(),
                 external_ip: "203.0.113.6".to_string(),
                 internal_ip: "10.0.0.6/32".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             },
         ],
         &crate::nat::NatCounterStore::default(),
@@ -955,6 +987,8 @@ fn static_nat_non_host_mask_rejected() {
                 from_zone: String::new(),
                 external_ip: bad.to_string(),
                 internal_ip: "10.0.0.5".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
             }],
             &crate::nat::NatCounterStore::default(),
         );
@@ -964,6 +998,130 @@ fn static_nat_non_host_mask_rejected() {
             "non-host/garbage mask {bad:?} must be rejected, not installed"
         );
     }
+}
+
+// --- #2491 static-NAT port / mapped-port forwarding ---
+
+fn mapped_port_snapshot() -> StaticNATRuleSnapshot {
+    StaticNATRuleSnapshot {
+        counter_id: 0,
+        name: "port-map".to_string(),
+        from_zone: "untrust".to_string(),
+        external_ip: "203.0.113.1/32".to_string(),
+        internal_ip: "10.0.0.5/32".to_string(),
+        match_destination_port: 8080,
+        mapped_port: 80,
+    }
+}
+
+// Forward (inbound DNAT): a packet to the external IP on the matched external
+// port is translated to the internal IP AND the destination port is rewritten
+// to the mapped-port. A packet to the same IP on a DIFFERENT port misses (no
+// port-less fallback entry, so no translation).
+//
+// Fail-on-revert: dropping `rewrite_dst_port: entry.mapped_port` in
+// match_dnat_with_counter turns the rewrite_dst_port assertion RED.
+#[test]
+fn static_nat_mapped_port_dnat_rewrites_dst_port() {
+    let table =
+        StaticNatTable::from_snapshots(&[mapped_port_snapshot()], &crate::nat::NatCounterStore::default());
+    let ext: IpAddr = "203.0.113.1".parse().unwrap();
+    let int: IpAddr = "10.0.0.5".parse().unwrap();
+
+    let (decision, _) = table
+        .match_dnat_with_counter(ext, 8080, "untrust")
+        .expect("matched external port");
+    assert_eq!(decision.rewrite_dst, Some(int), "dst IP must be the internal host");
+    assert_eq!(decision.rewrite_dst_port, Some(80), "dst port must be the mapped-port");
+
+    // A non-matching external port must NOT translate (no whole-address
+    // fallback present).
+    assert!(
+        table.match_dnat_with_counter(ext, 9999, "untrust").is_none(),
+        "non-matching external port must miss"
+    );
+}
+
+// Reverse (outbound return SNAT): the return packet from the internal host's
+// mapped-port has its source IP rewritten back to the external IP AND its
+// source port un-translated back to the external (match) port.
+//
+// Fail-on-revert: dropping `rewrite_src_port` in match_snat_with_counter (or
+// keying snat on the internal IP without the mapped-port) turns the
+// rewrite_src_port assertion RED / the lookup miss.
+#[test]
+fn static_nat_mapped_port_snat_untranslates_src_port() {
+    let table =
+        StaticNatTable::from_snapshots(&[mapped_port_snapshot()], &crate::nat::NatCounterStore::default());
+    let ext: IpAddr = "203.0.113.1".parse().unwrap();
+    let int: IpAddr = "10.0.0.5".parse().unwrap();
+
+    let (decision, _) = table
+        .match_snat_with_counter(int, 80, "trust")
+        .expect("matched internal mapped-port");
+    assert_eq!(decision.rewrite_src, Some(ext), "src IP must be the external IP");
+    assert_eq!(
+        decision.rewrite_src_port,
+        Some(8080),
+        "src port must be un-translated to the external match port"
+    );
+}
+
+// A whole-address rule and a port-mapped rule can coexist on the SAME external
+// IP: the port-mapped entry wins on its exact port; everything else falls back
+// to the whole-address mapping (no port rewrite).
+#[test]
+fn static_nat_port_mapped_and_whole_address_coexist() {
+    let table = StaticNatTable::from_snapshots(
+        &[
+            mapped_port_snapshot(), // 203.0.113.1:8080 -> 10.0.0.5:80
+            StaticNATRuleSnapshot {
+                counter_id: 0,
+                name: "whole".to_string(),
+                from_zone: "untrust".to_string(),
+                external_ip: "203.0.113.1/32".to_string(),
+                internal_ip: "10.0.0.9/32".to_string(),
+                match_destination_port: 0,
+                mapped_port: 0,
+            },
+        ],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let ext: IpAddr = "203.0.113.1".parse().unwrap();
+
+    // Port-mapped entry wins on 8080.
+    let (port_dec, _) = table.match_dnat_with_counter(ext, 8080, "untrust").expect("port match");
+    assert_eq!(port_dec.rewrite_dst, Some("10.0.0.5".parse().unwrap()));
+    assert_eq!(port_dec.rewrite_dst_port, Some(80));
+
+    // Any other port falls back to the whole-address mapping (no port rewrite).
+    let (whole_dec, _) = table.match_dnat_with_counter(ext, 443, "untrust").expect("fallback match");
+    assert_eq!(whole_dec.rewrite_dst, Some("10.0.0.9".parse().unwrap()));
+    assert_eq!(whole_dec.rewrite_dst_port, None);
+}
+
+// Fail-closed: a mapped_port without a match_destination_port (which the Go
+// strict commit-check rejects, but can slip through the lenient load path) is
+// demoted to a whole-address 1:1 — no port rewrite, no orphaned port key.
+#[test]
+fn static_nat_mapped_port_without_match_port_demotes_to_whole_address() {
+    let table = StaticNatTable::from_snapshots(
+        &[StaticNATRuleSnapshot {
+            counter_id: 0,
+            name: "orphan".to_string(),
+            from_zone: "untrust".to_string(),
+            external_ip: "203.0.113.1/32".to_string(),
+            internal_ip: "10.0.0.5/32".to_string(),
+            match_destination_port: 0,
+            mapped_port: 80,
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let ext: IpAddr = "203.0.113.1".parse().unwrap();
+    // Matches as a whole-address entry on any port, with NO port rewrite.
+    let (decision, _) = table.match_dnat_with_counter(ext, 12345, "untrust").expect("whole-address match");
+    assert_eq!(decision.rewrite_dst, Some("10.0.0.5".parse().unwrap()));
+    assert_eq!(decision.rewrite_dst_port, None, "orphaned mapped-port must not rewrite");
 }
 
 // --- DNAT table tests ---
@@ -4307,12 +4465,14 @@ fn parsed_nat_rules_share_store_counters() {
             from_zone: "untrust".to_string(),
             external_ip: "203.0.113.10".to_string(),
             internal_ip: "192.168.1.10".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
             counter_id: 22,
         }],
         &store,
     );
     let (_d, static_counter) = static_tbl
-        .match_dnat_with_counter("203.0.113.10".parse().unwrap(), "untrust")
+        .match_dnat_with_counter("203.0.113.10".parse().unwrap(), 0, "untrust")
         .expect("static dnat match");
     assert!(
         std::sync::Arc::ptr_eq(

--- a/userspace-dp/src/protocol/nat.rs
+++ b/userspace-dp/src/protocol/nat.rs
@@ -62,6 +62,18 @@ pub(crate) struct StaticNATRuleSnapshot {
     pub external_ip: String,
     #[serde(rename = "internal_ip", default)]
     pub internal_ip: String,
+    /// #2491: external (pre-translation) destination port the inbound packet
+    /// must carry for a port-mapped static-NAT rule. 0 = match any port
+    /// (whole-address 1:1, the legacy behaviour).
+    #[serde(rename = "match_destination_port", default)]
+    pub match_destination_port: u16,
+    /// #2491: internal (post-translation) destination port the 1:1 host
+    /// receives (`then static-nat prefix <ip> mapped-port <port>`). 0 = no
+    /// port translation. When set, the inbound DNAT rewrites the destination
+    /// port to this value and the reverse-path SNAT un-translates it back to
+    /// `match_destination_port`.
+    #[serde(rename = "mapped_port", default)]
+    pub mapped_port: u16,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -1047,6 +1047,8 @@
     "external_ip": "",
     "from_zone": "",
     "internal_ip": "",
+    "mapped_port": 0,
+    "match_destination_port": 0,
     "name": ""
   },
   "three_color_policer_snapshot": {


### PR DESCRIPTION
Closes #2491

## Summary

- Junos static NAT now supports per-port forwarding so several services
  can live behind one public IP: `match destination-port <port>` +
  `then static-nat prefix <ip> mapped-port <port>`.
- Inbound static-DNAT rewrites the destination port to `mapped-port`;
  the reverse static-SNAT un-translates the return packet's source port
  back to the external match port. `NatDecision` already carried
  `rewrite_dst_port`/`rewrite_src_port` and `.reverse()` already mirrored
  them — no decision-type change.
- The Rust `StaticNatTable` is keyed by `(IpAddr, Option<u16>)`, so a
  port-mapped rule and a whole-address 1:1 rule can coexist on one
  external IP (port-specific entry wins; port-less is the fallback).
- Config grammar: `match destination-port` is a typed `ValueInteger`
  (1..65535) schema leaf; `static-nat` stays a `children: nil` free-form
  leaf (SetPath grouping preserved), so the `mapped-port` token is
  range-checked in the compiler instead, which ALSO rejects a
  `mapped-port` with no matching `match destination-port`.
- Fail-closed: an out-of-range port clamps to 0 ("no port translation")
  on the wire; a `mapped_port` with no match-port demotes to whole-address
  in the Rust loader (the strict commit-check already rejects it — this is
  the lenient-load / peer-sync backstop).

## Wire change

Yes — additive and backward compatible. `StaticNATRuleSnapshot` gains
`match_destination_port` / `mapped_port` (Go `omitempty` + Rust
`#[serde(default)]`, default 0). `userspace-dp/tests/fixtures/protocol_wire_v1.json`
regenerated (two new keys, both 0); the wire-invariant test is green.

## Test plan

- [x] `go build ./...`, `gofmt -l`, `go vet` clean
- [x] `go test ./pkg/config/... ./pkg/dataplane/userspace/...`
- [x] `cargo build --release` clean
- [x] `cargo test --release --bin xpf-userspace-dp` — nat module (incl. 4
      new mapped-port tests), afxdp static-NAT tests, and
      `wire_invariant_default_specimens` all pass (131 in the filtered run)

## Fail-on-revert proof

- Rust: dropping `rewrite_dst_port: entry.mapped_port` →
  `static_nat_mapped_port_dnat_rewrites_dst_port` FAILED (verified, then
  restored).
- Go: forcing `rule.MappedPort = 0` in the compiler →
  `TestStaticNATMappedPortCompiles` FAILED ("MappedPort = 0, want 80",
  verified, then restored).
- Strict commit-check tests prove the out-of-range and the
  orphaned-mapped-port cases are rejected.

## Not run

Cluster smoke / `test-failover` not run — no HA / VRRP / session-sync /
fabric code touched; this is a config-grammar + cold-path NAT-table
change covered by unit tests on both planes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi