### PR TITLE
#2524: bound system dataplane ring-entries (max + power-of-two) at commit and in the Rust helper

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-25 — #2524: ring-entries max bound + power-of-two (commit + Rust backstop)
+
+- **Timestamp**: 2026-06-25
+- **Action**: `system dataplane ring-entries` was min-only
+  (`ValidateIntegerMin(1)`) — a large value committed and was handed to the
+  Rust helper, which preallocates ~3×ring_entries UMEM frames per binding
+  (~96 MB/binding at 8192), so an out-of-range value OOM'd at bring-up
+  instead of failing as a clean commit error (codex review-037 037-05).
+  Added `config.MaxRingEntries = 16384` + `ValidateRingEntries` (bounded
+  [1..16384] AND power-of-two), wired into the `ring-entries` schema leaf.
+  Rust backstop: `afxdp::MAX_RING_ENTRIES = 16384`, bring-up clamps to it
+  (`coordinator/reconcile/bringup.rs`), and the `--ring-entries` CLI parse
+  fails closed on out-of-range / non-power-of-two
+  (`server/lifecycle.rs::validate_ring_entries_arg`).
+- **File(s)**: pkg/config/schema_validators.go, pkg/config/schema_system.go,
+  pkg/config/schema_validate_system_test.go,
+  pkg/config/schema_validate_2524_test.go,
+  userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs,
+  userspace-dp/src/server/lifecycle.rs, docs/config-schema.md
+- **Validation**: go build/vet/test ./pkg/config (green); fail-on-revert
+  proven RED (flip to ValidateIntegerMin(1) → over-max + non-pow2 commit
+  clean); cargo build --release + 4 ring_entries unit tests pass.
+
 ## 2026-06-25 — #2620: PBR session-miss counts pre-PBR fall-through term once
 
 - **Timestamp**: 2026-06-25

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -463,6 +463,20 @@ reserved for whole-dataplane selection where a rewrite shim
   subsystems — one dedicated pass later), `track-interface priority-cost`
   (#1814 pre-walk owns it), `cpu-governor` (pass-through by design), dhcp
   client knobs, tunnel keepalives.
+- **#2524 (ring-entries bound):** `system dataplane ring-entries` was
+  min-only (`ValidateIntegerMin(1)`) — any large value committed and was
+  handed to the Rust helper, which preallocates ~3×ring_entries UMEM frames
+  per binding (~96 MB/binding at ring_entries=8192), so an out-of-range
+  value OOM'd at bring-up instead of failing as a clean commit error. The
+  leaf now uses `ValidateRingEntries`: bounded `[1..MaxRingEntries]`
+  (`MaxRingEntries = 16384`) AND required power-of-two (the helper rounds
+  ring sizes up to a power of two, so the configured number stays honest
+  about the depth allocated). A matching helper-side backstop clamps at
+  bring-up (`afxdp::MAX_RING_ENTRIES`,
+  `coordinator/reconcile/bringup.rs`) and rejects out-of-range /
+  non-power-of-two values at the `--ring-entries` CLI boundary
+  (`server/lifecycle.rs validate_ring_entries_arg`). Go and Rust ceilings
+  must stay equal.
 - **#1746:** added the `class-of-service schedulers <s>
   equal-flow-target-policy (slowest | mean | ideal-share)` typed enum
   leaf (ValueEnumOf + `ValidateEnum`, same recipe as the scheduler

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -155,10 +155,11 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 		// garbage silently fell back to the 0 zero-value, which the
 		// manager coerces to the default (workers<=0 -> 1,
 		// ring-entries<=0 -> 1024; pkg/dataplane/userspace/
-		// manager.go:1347-1351). Min-only: the runtime owns any
-		// ceiling, and the Rust helper rounds ring sizes up to a
-		// power of two itself (afxdp/bind.rs
-		// checked_next_power_of_two).
+		// manager.go capabilities.go). `workers` stays min-only (the
+		// runtime owns its ceiling); `ring-entries` is bounded both
+		// ways and required power-of-two as of #2524, because it sizes
+		// per-binding UMEM preallocations directly (an unbounded value
+		// OOM'd at bring-up rather than failing at commit).
 		"workers": {
 			args:          1,
 			desc:          "Worker thread count",
@@ -172,10 +173,14 @@ var schemaSystem = &schemaNode{desc: "System configuration", children: map[strin
 			args:          1,
 			desc:          "AF_XDP ring entries per queue",
 			valueType:     ValueInteger,
-			valueDesc:     "AF_XDP ring entries per queue (>= 1; rounded up to a power of two)",
+			valueDesc:     "AF_XDP ring entries per queue (power of two in [1..16384])",
 			valueExamples: []string{"1024", "2048"},
-			validator:     ValidateIntegerMin(1),
-			children:      nil,
+			// #2524: bound [1..MaxRingEntries] AND power-of-two. The
+			// helper preallocates ~3×ring_entries UMEM frames per binding
+			// (bind.rs), so an unbounded value OOM'd at bring-up instead
+			// of failing as a clean commit error.
+			validator: ValidateRingEntries,
+			children:  nil,
 		},
 		// Only these two strings are acted on; anything else was
 		// silently ignored (compiler_system.go poll-mode case).

--- a/pkg/config/schema_validate_2524_test.go
+++ b/pkg/config/schema_validate_2524_test.go
@@ -1,0 +1,103 @@
+package config_test
+
+// Regression tests for #2524: `system dataplane ring-entries` had only a
+// minimum bound (ValidateIntegerMin(1)). A large value committed and was
+// passed to the Rust helper, which sizes per-binding UMEM preallocations
+// directly from it (~3×ring_entries frames per binding, ~96 MB/binding at
+// ring_entries=8192). An out-of-range value failed by OOM at bring-up
+// instead of as a clean commit/startup error.
+//
+// The fix bounds the leaf at commit (pkg/config ValidateRingEntries):
+//   - in range  [1..MaxRingEntries] (MaxRingEntries = 16384), AND
+//   - a power of two (the helper rounds ring sizes up to a power of two,
+//     so requiring it keeps the configured number honest).
+// A matching helper-side backstop clamps/rejects in the Rust loader
+// (afxdp MAX_RING_ENTRIES, server/lifecycle.rs --ring-entries parse).
+//
+// FAIL-ON-REVERT: flipping ValidateRingEntries back to ValidateIntegerMin(1)
+// in schema_system.go makes TestSchema2524_RejectsOversized and
+// TestSchema2524_RejectsNonPowerOfTwo go RED (the over-max / non-pow2
+// values commit clean again), proving the gate is load-bearing.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// ringEntriesCheck builds the leaf via flat-set (ParseSetCommand + SetPath),
+// the canonical way to exercise set syntax (see CLAUDE.md — never NewParser
+// for set lines).
+func ringEntriesCheck(t *testing.T, val string) error {
+	t.Helper()
+	return flatSchemaCheck(t, "set system dataplane ring-entries "+val)
+}
+
+func TestSchema2524_AcceptsValidPowersOfTwo(t *testing.T) {
+	for _, v := range []string{"1", "2", "1024", "2048", "8192", "16384"} {
+		if err := ringEntriesCheck(t, v); err != nil {
+			t.Errorf("ring-entries %s: expected accept, got %v", v, err)
+		}
+	}
+}
+
+func TestSchema2524_RejectsOversized(t *testing.T) {
+	// 16385 is max+1; 32768/100000 are powers-of-two/round numbers above
+	// the ceiling. All must be rejected (RED if the bound is reverted).
+	for _, v := range []string{"16385", "32768", "100000"} {
+		err := ringEntriesCheck(t, v)
+		if err == nil {
+			t.Fatalf("ring-entries %s: expected out-of-range error, got nil", v)
+		}
+		if !strings.Contains(err.Error(), "ring-entries") {
+			t.Fatalf("ring-entries %s: error should reference ring-entries: %v", v, err)
+		}
+		if !strings.Contains(err.Error(), v) {
+			t.Fatalf("ring-entries %s: error should quote bad value: %v", v, err)
+		}
+	}
+}
+
+func TestSchema2524_RejectsNonPowerOfTwo(t *testing.T) {
+	// In-range but not a power of two — accepted before the fix, rejected
+	// after (RED on revert to ValidateIntegerMin(1)).
+	for _, v := range []string{"3", "1000", "3000", "1023", "12345"} {
+		err := ringEntriesCheck(t, v)
+		if err == nil {
+			t.Fatalf("ring-entries %s: expected power-of-two error, got nil", v)
+		}
+		if !strings.Contains(err.Error(), "power of two") {
+			t.Fatalf("ring-entries %s: error should mention power of two: %v", v, err)
+		}
+	}
+}
+
+func TestSchema2524_RejectsZeroAndGarbage(t *testing.T) {
+	for _, v := range []string{"0", "-1", "asd"} {
+		if err := ringEntriesCheck(t, v); err == nil {
+			t.Fatalf("ring-entries %s: expected error, got nil", v)
+		}
+	}
+}
+
+// TestSchema2524_ValidatorUnit exercises ValidateRingEntries directly so the
+// boundary (MaxRingEntries) and the power-of-two predicate are pinned
+// independent of the schema wiring.
+func TestSchema2524_ValidatorUnit(t *testing.T) {
+	if config.MaxRingEntries != 16384 {
+		t.Fatalf("MaxRingEntries = %d, want 16384", config.MaxRingEntries)
+	}
+	good := []string{"1", "16384"}
+	for _, v := range good {
+		if err := config.ValidateRingEntries(v, nil); err != nil {
+			t.Errorf("ValidateRingEntries(%q): unexpected error: %v", v, err)
+		}
+	}
+	bad := []string{"0", "16385", "24576", "asd", ""}
+	for _, v := range bad {
+		if err := config.ValidateRingEntries(v, nil); err == nil {
+			t.Errorf("ValidateRingEntries(%q): expected error, got nil", v)
+		}
+	}
+}

--- a/pkg/config/schema_validate_system_test.go
+++ b/pkg/config/schema_validate_system_test.go
@@ -47,8 +47,11 @@ var systemLeafMatrix = []systemLeafCase{
 		name:     "dataplane-ring-entries",
 		leaf:     "ring-entries",
 		template: "set system dataplane ring-entries %s",
-		accept:   []string{"1", "1024", "2048", "8192"},
-		reject:   []string{"0", "-1", "asd", ""},
+		// #2524: bounded [1..16384] AND power-of-two. 16384 is the cap;
+		// 1 (2^0) is the floor. Non-powers-of-two and over-max OOM the
+		// dataplane at bring-up before the fix, so they are rejected.
+		accept: []string{"1", "1024", "2048", "8192", "16384"},
+		reject: []string{"0", "-1", "asd", "", "16385", "32768", "1000", "3000", "100000"},
 	},
 	{
 		name:     "dataplane-poll-mode",

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -131,6 +131,46 @@ const MaxDurationMillis = int64(math.MaxInt64) / int64(time.Millisecond)
 // invert the damping behaviour).
 const MaxDurationSeconds = int64(math.MaxInt64) / int64(time.Second)
 
+// MaxRingEntries is the inclusive upper bound for the AF_XDP `ring-entries`
+// per-queue knob (#2524). The Rust helper preallocates UMEM frames directly
+// from this value: per bind.rs binding_frame_count_for_driver, a virtio_net
+// binding reserves ~3×ring_entries frames at UMEM_FRAME_SIZE=4096, i.e.
+// ~96 MB per binding at ring_entries=8192 (×queues ×interfaces). With no
+// ceiling a fat-fingered or malicious value drove an enormous preallocation
+// and OOM'd at bring-up instead of failing as a clean commit/startup error.
+// 16384 is double the documented 8192 example (~192 MB/binding worst case)
+// and is the largest value we consider sane on a router; it must agree with
+// the Rust backstop (afxdp/coordinator/reconcile/bringup.rs clamps to the
+// same ceiling). The value must additionally be a power of two — the helper
+// rounds ring sizes up to a power of two (xsk_ffi.rs next_power_of_two), so
+// requiring it at commit keeps the configured number honest about the size
+// actually allocated.
+const MaxRingEntries = int64(16384)
+
+// ValidateRingEntries accepts a bare integer in [1, MaxRingEntries] that is
+// also a power of two. It is the typed-leaf gate for `system dataplane
+// ring-entries` (#2524). Before #2524 the leaf used ValidateIntegerMin(1):
+// any large value committed and was passed to the dataplane, where it sized
+// per-binding UMEM preallocations and could OOM at bring-up. The power-of-two
+// requirement matches the helper's own rounding so the operator-visible
+// number equals the allocated ring depth.
+func ValidateRingEntries(raw string, _ *Config) error {
+	if strings.TrimSpace(raw) == "" {
+		return fmt.Errorf("missing value (expected integer)")
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fmt.Errorf("not an integer: %q", raw)
+	}
+	if v < 1 || v > MaxRingEntries {
+		return fmt.Errorf("ring-entries out of range [1..%d] (got %d)", MaxRingEntries, v)
+	}
+	if v&(v-1) != 0 {
+		return fmt.Errorf("ring-entries must be a power of two in [1..%d] (got %d)", MaxRingEntries, v)
+	}
+	return nil
+}
+
 // maxWireU16 / maxWireU32 are the inclusive ceilings for typed leaves
 // whose value lands in a Rust u16 / u32 wire field. #1979 Layer B uses
 // these so the commit-time range gate agrees EXACTLY with the build-time

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -42,6 +42,18 @@ pub(super) fn bring_up_workers(
     } = fds;
     // #2524: clamp to the shared sanity ceiling (MAX_RING_ENTRIES) as the
     // helper-side backstop for the Go commit-time bound. Floor stays 64.
+    // The Go gate rejects any normally-committed value > MAX_RING_ENTRIES, so
+    // a clamp here only fires on a config persisted by an older binary (before
+    // the bound landed). Warn so an operator on the stale-binary path can see
+    // the configured ring depth was capped rather than silently running a
+    // smaller ring than configured.
+    if ring_entries > MAX_RING_ENTRIES as usize {
+        eprintln!(
+            "xpf-dp: ring-entries {ring_entries} exceeds MAX_RING_ENTRIES {}; \
+             capping (config predates the #2524 commit-time bound)",
+            MAX_RING_ENTRIES
+        );
+    }
     let ring_entries = ring_entries.max(64).min(MAX_RING_ENTRIES as usize) as u32;
     let mut workers: BTreeMap<u32, Vec<BindingPlan>> = BTreeMap::new();
     for binding in bindings.iter_mut() {

--- a/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/bringup.rs
@@ -40,7 +40,9 @@ pub(super) fn bring_up_workers(
         // reads coord.forwarding, not this field.
         forwarding: _,
     } = fds;
-    let ring_entries = ring_entries.max(64).min(u32::MAX as usize) as u32;
+    // #2524: clamp to the shared sanity ceiling (MAX_RING_ENTRIES) as the
+    // helper-side backstop for the Go commit-time bound. Floor stays 64.
+    let ring_entries = ring_entries.max(64).min(MAX_RING_ENTRIES as usize) as u32;
     let mut workers: BTreeMap<u32, Vec<BindingPlan>> = BTreeMap::new();
     for binding in bindings.iter_mut() {
         if !binding.registered || binding.ifindex <= 0 {

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -252,6 +252,15 @@ const _: () = assert!(
 );
 const MIN_RESERVED_TX_FRAMES: u32 = 256;
 const MAX_RESERVED_TX_FRAMES: u32 = 8192;
+/// #2524: independent backstop ceiling for the AF_XDP `ring-entries` knob.
+/// The Go schema rejects out-of-range / non-power-of-two values at commit
+/// (pkg/config ValidateRingEntries, MaxRingEntries = 16384); this constant
+/// is the helper-side fail-safe so a config or `--ring-entries` flag that
+/// bypassed the Go gate still cannot drive an enormous per-binding UMEM
+/// preallocation (binding_frame_count_for_driver sizes ~3×ring_entries
+/// frames per binding). Bring-up clamps to this ceiling. Must match the
+/// Go MaxRingEntries.
+pub(crate) const MAX_RING_ENTRIES: u32 = 16384;
 const TX_BATCH_SIZE: usize = 64;
 const _: () = assert!(
     TX_BATCH_SIZE == 64,

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -312,6 +312,29 @@ pub(crate) fn derive_event_socket_path(control_socket: &str) -> String {
     }
 }
 
+/// #2524: parse and bound the `--ring-entries` CLI value. Accepts a power
+/// of two in [1..MAX_RING_ENTRIES]; otherwise returns a clean startup error
+/// so an out-of-range value cannot drive an enormous per-binding UMEM
+/// preallocation (binding_frame_count_for_driver ~3×ring_entries frames).
+/// Independent backstop for the Go commit-time gate (ValidateRingEntries).
+fn validate_ring_entries_arg(val: &str) -> Result<usize, String> {
+    let parsed = val
+        .parse::<usize>()
+        .map_err(|e| format!("parse --ring-entries: {e}"))?;
+    let max = crate::afxdp::MAX_RING_ENTRIES as usize;
+    if parsed < 1 || parsed > max {
+        return Err(format!(
+            "--ring-entries out of range [1..{max}] (got {parsed})"
+        ));
+    }
+    if parsed & (parsed - 1) != 0 {
+        return Err(format!(
+            "--ring-entries must be a power of two in [1..{max}] (got {parsed})"
+        ));
+    }
+    Ok(parsed)
+}
+
 pub(crate) fn parse_args() -> Result<Args, String> {
     let mut control_socket = env::temp_dir()
         .join("xpf-userspace-dp")
@@ -341,12 +364,12 @@ pub(crate) fn parse_args() -> Result<Args, String> {
                     .map_err(|e| format!("parse --workers: {e}"))?
                     .max(1)
             }
-            "--ring-entries" => {
-                ring_entries = val
-                    .parse::<usize>()
-                    .map_err(|e| format!("parse --ring-entries: {e}"))?
-                    .max(1)
-            }
+            // #2524: fail-closed at the CLI boundary — reject an
+            // out-of-range or non-power-of-two value with a clean startup
+            // error instead of letting it drive an enormous per-binding
+            // UMEM preallocation. Mirrors the Go commit gate (pkg/config
+            // ValidateRingEntries, MaxRingEntries).
+            "--ring-entries" => ring_entries = validate_ring_entries_arg(&val)?,
             "--poll-mode" => poll_mode = PollMode::from_str(&val),
             other => return Err(format!("unknown argument {other}")),
         }
@@ -359,4 +382,42 @@ pub(crate) fn parse_args() -> Result<Args, String> {
         ring_entries,
         poll_mode,
     })
+}
+
+#[cfg(test)]
+mod ring_entries_tests {
+    use super::validate_ring_entries_arg;
+
+    #[test]
+    fn accepts_powers_of_two_in_range() {
+        for v in ["1", "2", "1024", "4096", "8192", "16384"] {
+            assert!(
+                validate_ring_entries_arg(v).is_ok(),
+                "expected {v} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_over_max() {
+        // 16385 = max+1; 32768 / 65536 powers of two above the ceiling.
+        for v in ["16385", "32768", "65536"] {
+            let err = validate_ring_entries_arg(v).unwrap_err();
+            assert!(err.contains("out of range"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_power_of_two() {
+        for v in ["3", "1000", "1023", "12345"] {
+            let err = validate_ring_entries_arg(v).unwrap_err();
+            assert!(err.contains("power of two"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn rejects_zero_and_garbage() {
+        assert!(validate_ring_entries_arg("0").is_err());
+        assert!(validate_ring_entries_arg("asd").is_err());
+    }
 }


### PR DESCRIPTION
Closes #2524

## Problem
`system dataplane ring-entries` was validated min-only
(`ValidateIntegerMin(1)`). A large value committed cleanly and was passed
to the Rust helper, which sizes per-binding UMEM preallocations directly
from it (`binding_frame_count_for_driver` ≈ 3×ring_entries frames per
binding → ~96 MB/binding at ring_entries=8192). With no ceiling, an
out-of-range value OOM'd at bring-up instead of failing as a clean
commit/startup error (codex review-037 finding 037-05).

## Fix
Bound the value in one shared rule, enforced independently on both sides:

- **Chosen bound:** `[1 .. 16384]` AND **power of two**.
  - `16384` is double the documented 8192 example (~192 MB/binding worst
    case) — the largest value considered sane on a router, absent
    benchmark evidence.
  - Power-of-two is required because the helper rounds ring sizes up to a
    power of two (`xsk_ffi.rs next_power_of_two`); requiring it keeps the
    configured number honest about the depth actually allocated.
  - `1` (2^0) stays the floor — no behavior change for existing valid
    configs.
- **Commit gate (Go):** `config.MaxRingEntries = 16384` +
  `ValidateRingEntries`, wired into the `ring-entries` schema leaf
  (`pkg/config`), replacing `ValidateIntegerMin(1)`. Error names the bad
  value and the valid range.
- **Backstop (Rust):** `afxdp::MAX_RING_ENTRIES = 16384` (== Go ceiling).
  Bring-up clamps to it (`coordinator/reconcile/bringup.rs`, previously
  only `u32::MAX`); the `--ring-entries` CLI parse fails closed on
  out-of-range / non-power-of-two via `validate_ring_entries_arg`
  (`server/lifecycle.rs`), previously only `.max(1)`.

## Tests / fail-on-revert
- Go: extended system-leaf matrix + dedicated `schema_validate_2524_test.go`
  (valid powers-of-two, over-max, non-power-of-two, zero/garbage, direct
  `ValidateRingEntries` unit). **Fail-on-revert proven:** flipping the leaf
  back to `ValidateIntegerMin(1)` makes `TestSchema2524_RejectsOversized`
  and `TestSchema2524_RejectsNonPowerOfTwo` go RED (16385 / 3 commit clean
  again); restored → green.
- Rust: 4 `ring_entries_tests` unit tests pass (accept in-range powers of
  two; reject over-max, non-power-of-two, zero, garbage).

## Gates
- `go build ./...` clean; `gofmt -l` clean on touched files; `go vet
  ./pkg/config/...` clean; `go test ./pkg/config/...` green.
- `cargo build --release` clean (pre-existing warnings only);
  `cargo test --release --bin xpf-userspace-dp ring_entries` 4/4 pass.

## Docs
`docs/config-schema.md` (system/services typed-leaf section) +
`_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
