### PR TITLE
userspace-dp: refresh bindings on reconcile no_snapshot teardown (#2515)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-06-25 — #2515: reconcile no_snapshot teardown now refreshes bindings
+
+- **Timestamp**: 2026-06-25
+- **Action**: The `Coordinator::reconcile` `no_snapshot` (config-cleared /
+  shutdown) early-return ran the teardown + counter-reset phases but
+  returned BEFORE `refresh_bindings`. Teardown stopped every worker
+  (`stop_inner` empties `workers.live` + clears CoS owner maps), but
+  `reset_binding_counters` only zeroes counter scalars +
+  `bound`/`xsk_registered`/`socket_fd` — it leaves `xsk_bind_mode`,
+  `socket_ifindex`/`queue_id`/`bind_flags`, `zero_copy`, and the
+  `flow_cache_capacity`/`active_flow_count` gauges at pre-teardown
+  values. So status commands kept reporting torn-down slots as if bound,
+  and the CoS owner->worker map kept stale entries (operator-visible
+  status + stale CoS scheduling state; not a forwarding bug). Fix: call
+  `self.refresh_bindings(bindings)` in the `no_snapshot` arm before
+  setting the stage — it routes every now-workerless slot through
+  `zero_unbound_slot` (clearing exactly those residual fields) and
+  rebuilds the CoS owner map empty, the same tail the snapshot-apply
+  path runs. Sibling of #2522 (which gated the teardown quiesce on the
+  same path). Provenance: agy (gemini) review-036 finding 036-04.
+- **Validation**: `cargo build --release` clean;
+  `cargo test --release --bin xpf-userspace-dp -- reconcile` 19/19 green
+  (single-thread). Fail-on-revert: new test
+  `reconcile_none_snapshot_refreshes_bindings_clearing_reset_survivor_fields`
+  goes RED ("ZEROCOPY" xsk_bind_mode persists) when the refresh call is
+  removed, GREEN when restored.
+- **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
+  userspace-dp/src/afxdp/coordinator/tests.rs, _Log.md
+
 ## 2026-06-25 — #2620: PBR session-miss counts pre-PBR fall-through term once
 
 - **Timestamp**: 2026-06-25

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -82,6 +82,15 @@ impl Coordinator {
     ///    start neighbor monitor + local tunnel sources.
     /// 5. Final `refresh_bindings(bindings)` so the operator-visible
     ///    `BindingStatus` snapshot reflects the just-spawned workers.
+    ///
+    /// The `no_snapshot` (config-cleared / shutdown) path returns after
+    /// phase 2 but ALSO runs `refresh_bindings(bindings)` before
+    /// returning (#2515) — phase 1 stopped every worker, so the refresh
+    /// routes each now-workerless slot through `zero_unbound_slot`
+    /// (clearing the bind-mode / socket / capacity fields that the phase
+    /// 2 counter reset leaves untouched) and rebuilds the CoS owner map
+    /// empty. Without it, status commands report torn-down slots as if
+    /// still bound and the CoS owner->worker map keeps stale entries.
     pub fn reconcile(
         &mut self,
         snapshot: Option<&ConfigSnapshot>,
@@ -185,6 +194,22 @@ impl Coordinator {
             self.policy_counters.reconcile_rules(&[]);
             // #2218: no snapshot -> no active NAT rules -> drop all counters.
             self.nat_counters.reconcile_ids(&[]);
+            // #2515: the no_snapshot teardown stopped every worker
+            // (`stop_inner` emptied `workers.live` and cleared the CoS
+            // owner maps), but `reset_binding_counters` only zeroes the
+            // counter scalars + `bound`/`xsk_registered`/`socket_fd` — it
+            // leaves `xsk_bind_mode`, `socket_ifindex`/`queue_id`/
+            // `bind_flags`, `zero_copy`, and the `flow_cache_capacity`/
+            // `active_flow_count` gauges at their pre-teardown values.
+            // Without the refresh below, status commands keep reporting
+            // those slots as if still bound, and the rebuilt CoS
+            // owner->worker map is never emptied. `refresh_bindings`
+            // routes every now-workerless slot through `zero_unbound_slot`
+            // (clearing exactly those residual fields) and rebuilds the
+            // CoS owner map empty — the same tail the snapshot-apply path
+            // runs at the end of `reconcile`. Run it BEFORE setting the
+            // stage so the operator-visible state is consistent on return.
+            self.refresh_bindings(bindings);
             self.last_reconcile_stage = "no_snapshot".to_string();
             return;
         };

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1656,6 +1656,96 @@ fn reconcile_with_none_snapshot_reaches_no_snapshot_early_exit() {
     assert_eq!(bindings[0].rx_packets, 0);
 }
 
+/// #2515 fail-on-revert: the `no_snapshot` teardown path must run
+/// `refresh_bindings` so every now-workerless slot is routed through
+/// `zero_unbound_slot` AND the CoS owner->worker map is rebuilt empty.
+///
+/// `reset_binding_counters` (the phase that always runs before the
+/// `no_snapshot` early-return) ONLY zeroes the counter scalars plus
+/// `bound`/`xsk_registered`/`socket_fd`. It deliberately does NOT touch
+/// `xsk_bind_mode`, `socket_ifindex`/`queue_id`/`bind_flags`,
+/// `zero_copy`, `flow_cache_capacity`, or `active_flow_count` — those
+/// are cleared only by `zero_unbound_slot` inside `refresh_bindings`.
+/// So this test pre-populates exactly those reset-survivor fields and a
+/// stale CoS owner-map entry, runs `reconcile(None, ...)`, and asserts
+/// they are cleared. Reverting the `self.refresh_bindings(bindings)`
+/// call added in the `no_snapshot` arm leaves every one of these stale
+/// → the asserts go RED.
+#[test]
+fn reconcile_none_snapshot_refreshes_bindings_clearing_reset_survivor_fields() {
+    let mut coordinator = Coordinator::new();
+    // A stale CoS owner->worker entry that the teardown's
+    // `refresh_cos_owner_worker_map_from_binding_statuses` (reached only
+    // via refresh_bindings) must rebuild empty. `stop_inner` clears the
+    // atomic CoS maps directly, but `cos_owner_worker_by_queue` (the
+    // plain field compared in `refresh_cos_runtime_maps`) is the
+    // operator-facing owner snapshot — confirm it ends empty.
+    coordinator.cos_owner_worker_by_queue.insert((10, 3), 7);
+
+    let mut bindings: Vec<BindingStatus> = vec![BindingStatus {
+        slot: 1,
+        worker_id: 0,
+        queue_id: 0,
+        interface: "ge-0-0-0".into(),
+        ifindex: 10,
+        registered: true,
+        bound: true,
+        xsk_registered: true,
+        ready: true,
+        // Fields the reset pass leaves UNTOUCHED — only
+        // `zero_unbound_slot` (via refresh_bindings) clears them.
+        xsk_bind_mode: "ZEROCOPY".into(),
+        zero_copy: true,
+        socket_ifindex: 10,
+        socket_queue_id: 3,
+        socket_bind_flags: 0xc0,
+        flow_cache_capacity: 65536,
+        active_flow_count: 4096,
+        ..BindingStatus::default()
+    }];
+
+    coordinator.reconcile(None, &mut bindings, 64);
+
+    assert_eq!(coordinator.last_reconcile_stage, "no_snapshot");
+    // The reset-survivor fields must now be cleared by the teardown
+    // refresh. Each of these stays stale if refresh_bindings is skipped.
+    assert_eq!(
+        bindings[0].xsk_bind_mode, "",
+        "#2515: no_snapshot teardown must clear stale xsk_bind_mode"
+    );
+    assert!(
+        !bindings[0].zero_copy,
+        "#2515: no_snapshot teardown must clear stale zero_copy"
+    );
+    assert_eq!(
+        bindings[0].socket_ifindex, 0,
+        "#2515: no_snapshot teardown must clear stale socket_ifindex"
+    );
+    assert_eq!(
+        bindings[0].socket_queue_id, 0,
+        "#2515: no_snapshot teardown must clear stale socket_queue_id"
+    );
+    assert_eq!(
+        bindings[0].socket_bind_flags, 0,
+        "#2515: no_snapshot teardown must clear stale socket_bind_flags"
+    );
+    assert_eq!(
+        bindings[0].flow_cache_capacity, 0,
+        "#2515: no_snapshot teardown must clear stale flow_cache_capacity"
+    );
+    assert_eq!(
+        bindings[0].active_flow_count, 0,
+        "#2515: no_snapshot teardown must clear stale active_flow_count"
+    );
+    // The CoS owner->worker map must be rebuilt empty (no live/ready
+    // workers remain after teardown).
+    assert!(
+        coordinator.cos_owner_worker_by_queue.is_empty(),
+        "#2515: no_snapshot teardown must rebuild the CoS owner->worker \
+         map empty"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // #2522: the mlx5 zero-copy teardown quiesce (500ms) is gated on BOTH
 // `had_live_workers` AND `will_rebind` (a snapshot is being applied, so


### PR DESCRIPTION
Closes #2515

## Summary
- The `Coordinator::reconcile` `no_snapshot` (config-cleared / shutdown) early-return ran the teardown + counter-reset phases but returned **before** `refresh_bindings`.
- Teardown stops every worker (`stop_inner` empties `workers.live`, clears the CoS owner maps), but `reset_binding_counters` only zeroes the counter scalars + `bound`/`xsk_registered`/`socket_fd`. It leaves `xsk_bind_mode`, `socket_ifindex`/`socket_queue_id`/`socket_bind_flags`, `zero_copy`, and the `flow_cache_capacity`/`active_flow_count` gauges stale — only `zero_unbound_slot` (reached via `refresh_bindings`) clears those.
- Impact: after a config delete, status commands kept reporting torn-down slots as if still bound (stale bind mode, socket ifindex/queue/flags, zero-copy, capacity gauges) and the rebuilt CoS owner->worker map was never emptied. Workers are actually stopped + sockets closed, so this is **operator-visible status staleness + stale CoS scheduling state, not a forwarding bug** (MEDIUM-LOW).
- Fix: call `self.refresh_bindings(bindings)` in the `no_snapshot` arm before writing `last_reconcile_stage`. It routes every now-workerless slot through `zero_unbound_slot` and rebuilds the CoS owner map empty — the same tail the snapshot-apply path already runs.
- Sibling of #2522 (which gated the teardown quiesce on the same `no_snapshot` path); this is the separate `refresh_bindings` gap #2522 did not cover. No wire change.

## Test plan
- [x] New fail-on-revert test `reconcile_none_snapshot_refreshes_bindings_clearing_reset_survivor_fields`: pre-populates the reset-survivor fields (`xsk_bind_mode`, `socket_*`, `zero_copy`, `flow_cache_capacity`, `active_flow_count`) + a stale `cos_owner_worker_by_queue` entry, runs `reconcile(None, ...)`, asserts all cleared.
- [x] `CARGO_TARGET_DIR=/tmp/cargo-2515 cargo build --release` — clean.
- [x] `cargo test --release --bin xpf-userspace-dp -- reconcile` — 19/19 green (single-thread).

## Fail-on-revert proof
With `self.refresh_bindings(bindings)` removed from the `no_snapshot` arm:
```
test ...reconcile_none_snapshot_refreshes_bindings_clearing_reset_survivor_fields ... FAILED
assertion `left == right` failed: #2515: no_snapshot teardown must clear stale xsk_bind_mode
  left: "ZEROCOPY"
 right: ""
```
Restored → GREEN (19/19).

## Provenance
agy (gemini) review-036 finding 036-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi