### PR TITLE
userspace-dp: cached TX-selection records all count terms (#2573)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15648,3 +15648,30 @@ top.
   userspace-dp/src/afxdp/coordinator/reconcile/mod.rs,
   userspace-dp/src/afxdp/coordinator/mod.rs,
   userspace-dp/src/afxdp/coordinator/tests.rs, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2573 — cached TX-selection records ALL matched `then count`
+  terms, not just the last. #2544 fall-through lets one packet match
+  multiple `then count` terms; the cached flow-replay descriptor held a
+  single counter `Arc` so only the LAST term incremented on a cache hit
+  (the uncached full-eval path counted each). Added `CachedFilterCounters`
+  (`SmallVec<[Arc<FilterTermCounter>; 2]>`, dedup by `Arc::ptr_eq`, built
+  once at flow-cache install, read-only `for_each` on the per-packet replay
+  → no heap alloc for the common single/dual case). Replaced the single
+  `counter` slot on `CachedTxSelectionFilterResult` and `filter_counter` on
+  `CachedTxSelectionDescriptor`; `merge_matched_cached_modifiers` now
+  `push`es every matched count term; the flow-cache hit path iterates and
+  records all. Fail-on-revert test
+  `cached_tx_selection_records_all_fallthrough_count_terms` (two
+  fall-through count terms + terminal accept) asserts both term counters
+  increment on the cached replay; reverting to last-only leaves term[0] at
+  0 → RED.
+  **File(s)**: userspace-dp/src/filter/mod.rs,
+  userspace-dp/src/filter/engine/cache_sensitive.rs,
+  userspace-dp/src/filter/README.md,
+  userspace-dp/src/afxdp/flow_cache.rs,
+  userspace-dp/src/afxdp/tx/cos_classify.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs,
+  userspace-dp/src/afxdp/umem/tests.rs,
+  userspace-dp/src/filter/tests.rs, _Log.md

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -1,6 +1,5 @@
 use super::*;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 use std::sync::atomic::AtomicU32;
 
 const FLOW_CACHE_SIZE: usize = 4096;
@@ -53,7 +52,9 @@ pub(super) struct CachedTxSelectionDescriptor {
     pub(super) queue_id: Option<u8>,
     pub(super) dscp_rewrite: Option<u8>,
     pub(super) drop: bool,
-    pub(super) filter_counter: Option<Arc<crate::filter::FilterTermCounter>>,
+    // #2573: all matched `then count` term counters for this flow, not just the
+    // last — the cached replay must increment every fall-through count term.
+    pub(super) filter_counters: crate::filter::CachedFilterCounters,
     pub(super) three_color_policers: crate::filter::CachedThreeColorPolicers,
     pub(super) filter_log: Option<crate::filter::FilterLogMatch>,
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/flow_cache_hit.rs
@@ -117,9 +117,14 @@ pub(super) fn stage_flow_cache_hit(
         let cached_decision = cached.decision;
         let cached_descriptor = &cached.descriptor;
         let cached_metadata = &cached.metadata;
-        if let Some(counter) = cached_descriptor.tx_selection.filter_counter.as_ref() {
-            crate::filter::record_filter_counter(counter, meta.pkt_len as u64);
-        }
+        // #2573: replay ALL matched `then count` term counters, not just the
+        // last. A #2544 fall-through flow can match multiple count terms.
+        cached_descriptor
+            .tx_selection
+            .filter_counters
+            .for_each(|counter| {
+                crate::filter::record_filter_counter(counter, meta.pkt_len as u64);
+            });
         let policer_action = crate::filter::apply_cached_three_color_policers(
             &cached_descriptor.tx_selection.three_color_policers,
             now_ns,

--- a/userspace-dp/src/afxdp/tx/cos_classify.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify.rs
@@ -102,7 +102,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
             queue_id: iface.map(|iface| iface.default_queue),
             dscp_rewrite: None,
             drop: false,
-            filter_counter: None,
+            filter_counters: crate::filter::CachedFilterCounters::default(),
             three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
             filter_log: None,
         };
@@ -165,7 +165,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
 
     let mut effective_dscp_rewrite = output_result.dscp_rewrite;
     let mut forwarding_class = output_result.forwarding_class.clone();
-    let mut filter_counter = output_result.counter.clone();
+    let mut filter_counters = output_result.counters;
     let mut three_color_policers = output_result.three_color_policers;
     let filter_log = output_result.log_match;
 
@@ -205,7 +205,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
             effective_dscp_rewrite = effective_dscp_rewrite.or(ingress_result.dscp_rewrite);
             if output_filter.is_none() {
                 forwarding_class = ingress_result.forwarding_class;
-                filter_counter = ingress_result.counter;
+                filter_counters = ingress_result.counters;
             }
             three_color_policers.extend(ingress_result.three_color_policers);
         }
@@ -228,7 +228,7 @@ pub(in crate::afxdp) fn resolve_cached_cos_tx_selection(
         queue_id,
         dscp_rewrite: effective_dscp_rewrite,
         drop: output_result.action != crate::filter::FilterAction::Accept,
-        filter_counter,
+        filter_counters,
         three_color_policers,
         filter_log,
     }

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -1008,7 +1008,7 @@ fn resolve_cached_cos_tx_selection_prefers_egress_output_filter_and_keeps_counte
 
     assert_eq!(cached.queue_id, Some(1));
     assert_eq!(cached.dscp_rewrite, None);
-    assert!(cached.filter_counter.is_some());
+    assert!(!cached.filter_counters.is_empty());
 }
 
 #[test]
@@ -1243,7 +1243,7 @@ fn resolve_cached_cos_tx_selection_uses_ingress_input_filter_when_no_output_exis
 
     assert_eq!(cached.queue_id, Some(1));
     assert_eq!(cached.dscp_rewrite, None);
-    assert!(cached.filter_counter.is_some());
+    assert!(!cached.filter_counters.is_empty());
 }
 
 #[test]
@@ -1325,7 +1325,7 @@ fn resolve_cached_cos_tx_selection_keeps_counter_only_output_filter_hits() {
 
     assert_eq!(cached.queue_id, Some(0));
     assert_eq!(cached.dscp_rewrite, None);
-    assert!(cached.filter_counter.is_some());
+    assert!(!cached.filter_counters.is_empty());
 }
 
 #[test]

--- a/userspace-dp/src/afxdp/umem/tests.rs
+++ b/userspace-dp/src/afxdp/umem/tests.rs
@@ -1497,7 +1497,7 @@ fn active_flow_debug_test_entry(
                 queue_id: Some(2),
                 dscp_rewrite: Some(46),
                 drop: false,
-                filter_counter: None,
+                filter_counters: crate::filter::CachedFilterCounters::default(),
                 three_color_policers: crate::filter::CachedThreeColorPolicers::default(),
                 filter_log: None,
             },

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -89,11 +89,17 @@ Mirrors the BPF firewall-filter pipeline in userspace.
   a later `discard` was never reached. `continue_term` is compared in
   `filter_term_semantics_match` (it flips terminate-vs-fall-through
   without changing the parsed match vecs, so a flow-cache rebuild must
-  catch a `then next term` toggle). The cached TX-selection result holds
-  a single `counter` Arc, so when multiple matched fall-through terms
-  each carry `then count` the cached rebuild path records only the last
-  (a pre-existing structural limit; the uncached full-eval path counts
-  every term).
+  catch a `then next term` toggle). The cached TX-selection result
+  accumulates EVERY matched `then count` term in `CachedFilterCounters`
+  (#2573), deduped by counter identity, so a flow whose fall-through set
+  carries multiple `then count` terms increments all of them on the
+  cached replay — matching the uncached full-eval path. The container is
+  a `SmallVec<[_; 2]>` (built once at flow-cache install, only read on
+  the per-packet replay), so the common single/dual-counter case records
+  with no heap allocation. Before #2573 the result held a single
+  `counter` Arc and the cached rebuild path recorded only the LAST
+  matched count term (the earlier fall-through count terms were silently
+  under-counted on the cached path only).
 
   **Fall-through log action follows the terminal verdict (#2616).** A
   matched fall-through logging term records its identity

--- a/userspace-dp/src/filter/engine/cache_sensitive.rs
+++ b/userspace-dp/src/filter/engine/cache_sensitive.rs
@@ -70,13 +70,16 @@ fn evaluate_filter_ref_tx_selection_cached_v4(
 
 /// #2544: merge a matched term's modifiers into the cached TX-selection result.
 /// Used for both fall-through and terminating matches. Latest matched term wins
-/// for forwarding-class, dscp-rewrite, counter, and log; three-color policers
-/// accumulate via `extend` so a policer on every matched term still meters on
-/// the cached rebuild path. The action is set only by the caller for a
-/// terminating term. NOTE: `counter` holds a single Arc — when multiple matched
-/// fall-through terms each carry `then count`, the cached rebuild path records
-/// only the LAST (a pre-existing structural limit of CachedTxSelectionFilterResult,
-/// unchanged by this fix; the uncached full-eval path counts every term).
+/// for forwarding-class, dscp-rewrite, and log; three-color policers AND
+/// `then count` term counters accumulate so a counter/policer on every matched
+/// term still records on the cached rebuild path. The action is set only by the
+/// caller for a terminating term.
+///
+/// #2573: `counters` accumulates EVERY matched `then count` term (deduped by
+/// counter identity), not just the last. With #2544 fall-through a single packet
+/// can match multiple `then count` terms; the old single-Arc slot kept only the
+/// last, so the earlier fall-through count terms were silently under-counted on
+/// the cached replay path while the uncached full-eval path counted each.
 #[inline]
 fn merge_matched_cached_modifiers(
     acc: &mut CachedTxSelectionFilterResult,
@@ -90,7 +93,7 @@ fn merge_matched_cached_modifiers(
         acc.dscp_rewrite = term.dscp_rewrite;
     }
     if term.has_count {
-        acc.counter = Some(term.counter.clone());
+        acc.counters.push(term.counter.clone());
     }
     acc.three_color_policers
         .extend(CachedThreeColorPolicers::from_option(

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -378,6 +378,54 @@ impl CachedThreeColorPolicers {
     }
 }
 
+/// #2573: the set of `then count` term counters a cached TX-selection decision
+/// must increment on every flow-cache replay. With #2544 fall-through, a single
+/// packet can match multiple `then count` terms; the old single-`Arc` slot kept
+/// only the LAST, so the earlier fall-through count terms were silently
+/// under-counted on the cached path (the uncached full-eval path counted each).
+///
+/// Backed by a `SmallVec` with an inline capacity of 2 so the common single- and
+/// dual-counter flows record with NO heap allocation. The descriptor is built
+/// ONCE at flow-cache install and then only read (`for_each`) on the per-packet
+/// replay, so any spill to the heap for >2 counters happens off the packet hot
+/// path. Dedup is by `Arc::ptr_eq` (FilterTermCounter has no id) so the same
+/// counter referenced by two matched terms is recorded once per packet.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CachedFilterCounters {
+    counters: smallvec::SmallVec<[Arc<FilterTermCounter>; 2]>,
+}
+
+impl CachedFilterCounters {
+    #[inline]
+    pub(crate) fn push(&mut self, counter: Arc<FilterTermCounter>) {
+        if self
+            .counters
+            .iter()
+            .any(|existing| Arc::ptr_eq(existing, &counter))
+        {
+            return;
+        }
+        self.counters.push(counter);
+    }
+
+    #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.counters.is_empty()
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.counters.len()
+    }
+
+    #[inline]
+    pub(crate) fn for_each(&self, mut f: impl FnMut(&Arc<FilterTermCounter>)) {
+        for counter in &self.counters {
+            f(counter);
+        }
+    }
+}
+
 impl ThreeColorPolicerRuntime {
     pub(crate) fn new(id: u32, name: String, state: ThreeColorPolicerState) -> Self {
         Self {
@@ -688,7 +736,8 @@ pub(crate) struct CachedTxSelectionFilterResult {
     pub(crate) action: FilterAction,
     pub(crate) forwarding_class: Option<Arc<str>>,
     pub(crate) dscp_rewrite: Option<u8>,
-    pub(crate) counter: Option<Arc<FilterTermCounter>>,
+    // #2573: record ALL matched `then count` term counters, not just the last.
+    pub(crate) counters: CachedFilterCounters,
     pub(crate) three_color_policers: CachedThreeColorPolicers,
     pub(crate) log_match: Option<FilterLogMatch>,
 }
@@ -731,7 +780,7 @@ impl Default for CachedTxSelectionFilterResult {
             action: FilterAction::Accept,
             forwarding_class: None,
             dscp_rewrite: None,
-            counter: None,
+            counters: CachedFilterCounters::default(),
             three_color_policers: CachedThreeColorPolicers::default(),
             log_match: None,
         }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -5128,6 +5128,111 @@ fn fallthrough_tx_selection_applies_forwarding_class_then_discards() {
 }
 
 // ---------------------------------------------------------------------------
+// #2573: the cached TX-selection path must record EVERY matched `then count`
+// term, not just the last. With #2544 fall-through a single packet can match
+// two count terms on the same flow-cache key; the old single-Arc slot kept only
+// the last, so the earlier fall-through count term was silently under-counted on
+// the cached replay path (the uncached full-eval path counted both).
+//
+// FAIL-ON-REVERT: reverting `merge_matched_cached_modifiers` to
+// `acc.counter = Some(term.counter.clone())` (last-only) makes the cached result
+// carry one counter and replay increments only the terminal term — the
+// `terms[0].counter` assert below then fails RED.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cached_tx_selection_records_all_fallthrough_count_terms() {
+    // Two fall-through `then count` terms both match the same 5-tuple, followed
+    // by a terminating accept. The output filter is the TX-selection filter.
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "reth0.80".into(),
+        ifindex: 9,
+        filter_output_v4: "multi-count".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "multi-count".into(),
+            family: "inet".into(),
+            terms: vec![
+                FirewallTermSnapshot {
+                    name: "count-a".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["80".into()],
+                    action: String::new(),
+                    next_term: true,
+                    count: "count-a-hits".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "count-b".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["80".into()],
+                    action: String::new(),
+                    next_term: true,
+                    count: "count-b-hits".into(),
+                    ..Default::default()
+                },
+                FirewallTermSnapshot {
+                    name: "accept-rest".into(),
+                    protocols: vec!["tcp".into()],
+                    destination_ports: vec!["80".into()],
+                    action: "accept".into(),
+                    ..Default::default()
+                },
+            ],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+
+    let filter = state
+        .iface_filter_out_v4_fast
+        .get(&9)
+        .expect("output filter present");
+    // The compiler must mark the first two terms as fall-through count terms.
+    assert!(filter.terms[0].continue_term && filter.terms[0].has_count);
+    assert!(filter.terms[1].continue_term && filter.terms[1].has_count);
+
+    let src = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let dst = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let cached =
+        evaluate_filter_ref_tx_selection_cached(filter, src, dst, PROTO_TCP, 40000, 80, 0);
+
+    // The cached descriptor must carry BOTH matched count terms (deduped to 2).
+    assert_eq!(
+        cached.counters.len(),
+        2,
+        "cached TX-selection must record every matched `then count` term, not just the last"
+    );
+    assert_eq!(cached.action, FilterAction::Accept);
+
+    // Replay exactly as the flow-cache hit path does: record each cached counter.
+    cached.counters.for_each(|counter| {
+        crate::filter::record_filter_counter(counter, 1500);
+    });
+    crate::filter::flush_recorded_filter_counters();
+
+    // BOTH fall-through count terms must have incremented on the cached replay.
+    // Revert to last-only and terms[0] stays 0 -> this assert fails RED.
+    assert_eq!(
+        filter.terms[0].counter.packets.load(Ordering::Relaxed),
+        1,
+        "first fall-through count term must increment on the cached path"
+    );
+    assert_eq!(filter.terms[0].counter.bytes.load(Ordering::Relaxed), 1500);
+    assert_eq!(
+        filter.terms[1].counter.packets.load(Ordering::Relaxed),
+        1,
+        "second fall-through count term must increment on the cached path"
+    );
+    assert_eq!(filter.terms[1].counter.bytes.load(Ordering::Relaxed), 1500);
+}
+
+// ---------------------------------------------------------------------------
 // #2616: a fall-through `then { log; next term; }` term followed by a terminal
 // discard/reject must report the FINAL verdict (deny) in its RT_FLOW log action,
 // not the Accept placeholder the fall-through term carries. Pre-fix the


### PR DESCRIPTION
Closes #2573

## Summary

#2544 firewall-filter fall-through (`then next term` / modifier-only fall-through) lets a single packet match MULTIPLE terms that each carry `then count`. The uncached full-eval path counts every matched term, but the **flow-cached TX-selection path** held only a single counter `Arc` — `CachedTxSelectionFilterResult.counter` flowing into `CachedTxSelectionDescriptor.filter_counter` — so on a cache-replay hit only the **LAST** matched count term incremented. The earlier fall-through count terms were silently under-counted **on the cached path only**.

Counter-accuracy only: no forwarding/security impact, and the uncached full-eval path was already correct.

## Multi-counter mechanism

Took option (a) from the issue (preserve cache performance, do not decline to cache):

- New `CachedFilterCounters` — a `SmallVec<[Arc<FilterTermCounter>; 2]>` deduped by `Arc::ptr_eq` (`FilterTermCounter` has no id field), modeled on the existing two-slot `CachedThreeColorPolicers`.
- `CachedTxSelectionFilterResult.counter: Option<Arc<…>>` → `counters: CachedFilterCounters`; `CachedTxSelectionDescriptor.filter_counter` → `filter_counters`.
- `merge_matched_cached_modifiers` now `push`es every matched `then count` term instead of overwriting the single slot.
- The flow-cache hit path (`flow_cache_hit.rs`) iterates the set with `for_each` and records all counters on replay.

## Hot-path allocation note

The descriptor is built **once** at flow-cache install and then only **read** (`for_each`) on the per-packet replay. The inline `SmallVec` capacity of 2 means the common single/dual-counter case records with **no heap allocation**; a spill to the heap for >2 distinct count terms happens off the packet hot path, at install time.

## Fail-on-revert proof

New test `cached_tx_selection_records_all_fallthrough_count_terms`: two fall-through `then count` terms + a terminal accept, all matching the same 5-tuple. It asserts the cached result carries 2 counters and that **both** term counters increment on the cached replay.

Verified RED on revert — restoring `merge_matched_cached_modifiers` to the last-only single slot leaves `terms[0]` at 0 packets:
```
test ... cached_tx_selection_records_all_fallthrough_count_terms ... FAILED
assertion `left == right` failed: cached TX-selection must record every matched `then count` term, not just the last
test result: FAILED. 0 passed; 1 failed
```
Restored → GREEN.

## Gates

- `cargo build --release` — clean (148 pre-existing warnings, no new failures).
- `cargo test --release --bin xpf-userspace-dp -- tx flow_cache` — **245 passed, 0 failed**.
- No wire change.

`filter/README.md` updated to replace the documented single-counter limit with the multi-counter contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi