### PR TITLE
dhcp-relay: relay DHCPDECLINE to the server (#2789)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-06-25 — #2789: relay DHCPDECLINE to the server
+
+- **Timestamp**: 2026-06-25
+- **Action**: `clientRequestRelayable` gated the client→server relay loop
+  to DISCOVER/REQUEST/INFORM, dropping DHCPDECLINE. A client that detects
+  an in-use offered address (ARP probe) broadcasts a DHCPDECLINE
+  (RFC 2131 §3.1 step 4, §4.4.1); the relay dropped it, so the upstream
+  server never learned of the conflict and kept re-offering the in-use
+  address. Added `dhcpv4.MessageTypeDecline` to the relayable set so the
+  DECLINE flows through the unchanged path (master-gate #2456, giaddr
+  stamp, RFC 1542 hop-limit, Option 82). RELEASE stays excluded: it is
+  unicast directly to the bound server (RFC 2131 §4.4.4) and is never
+  seen on the relay's client-facing broadcast socket. Composes with the
+  #2606 NAK / #2645 forcerenew reply paths (DECLINE has no server reply).
+  Updated the function doc, the README relayed-type table, and added a
+  fail-on-revert end-to-end test (`TestRunRelay_RelaysDecline`) plus the
+  table case in `TestClientRequestRelayable` — both proven RED when the
+  type is removed, GREEN with the fix.
+- **File(s)**: `pkg/dhcprelay/relay.go`, `pkg/dhcprelay/relay_test.go`,
+  `pkg/dhcprelay/README.md`
+
 ## 2026-06-25 — #2783: PTB egress-MTU decision uses IP-declared length
 
 - **Timestamp**: 2026-06-25

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -39,8 +39,8 @@ carries server-bound options, per RFC 2131 §3.4:
 | `DISCOVER` | yes | lease acquisition |
 | `REQUEST` | yes | lease selection / renewal / rebinding |
 | `INFORM` | yes (#2153) | client already holds an address, asks only for supplemental parameters (DNS/domain/NTP) |
-| `DECLINE` | no | broadcast by the client on address conflict (RFC 2131 §4.4); not relayed (out of scope for #2153) |
-| `RELEASE` | no | unicast by the client to its bound server; no relay-agent obligation |
+| `DECLINE` | yes (#2789) | client detected the offered address already in use (ARP probe) and broadcasts a DHCPDECLINE (RFC 2131 §3.1 step 4, §4.4.1); relayed so the originating server marks the address unavailable instead of re-offering it. Carries no server reply |
+| `RELEASE` | no | unicast by the client directly to its bound server (RFC 2131 §4.4.4) — it routes without relay assistance and is never seen on the relay's client-facing broadcast socket |
 | server reply types (`OFFER`/`ACK`/`NAK`/`FORCERENEW`) | n/a | not client-originated; the client→server gate never sees them. The reverse server→client path (`handleServerResponses`) forwards `OFFER`, `ACK`, `NAK` (#2606), and `FORCERENEW` (#2645) — see the reply matrix below |
 
 The `INFORM` reply (a server-issued `ACK` with no `yiaddr` but a real

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -1165,19 +1165,26 @@ func broadcastReply(ir *interfaceRelay, clientConn net.PacketConn, replyData []b
 //     central configuration; the server answers an INFORM with an ACK, which
 //     the reply path already forwards (see deliverReply: the flag-clear,
 //     yiaddr==0, real-ciaddr case unicasts to the client's ciaddr).
+//   - DECLINE — a client that, after an ARP probe, detected the offered
+//     address already in use broadcasts a DHCPDECLINE (RFC 2131 §3.1 step 4,
+//     §4.4.1). The relay MUST forward it so the originating server marks that
+//     address unavailable; otherwise the server keeps re-offering the
+//     conflicting address and the segment suffers a persistent duplicate-IP
+//     condition (#2789). DECLINE carries no server reply, so no reply-path
+//     handling is needed.
 //
-// DECLINE and RELEASE are intentionally not relayed here, preserving the
-// pre-#2153 behavior (which relayed only DISCOVER/REQUEST). RELEASE is
-// unicast by the client to the server it is bound to, so it does not require
-// relaying. DECLINE is broadcast (RFC 2131 §4.4.1) but signals an address
-// conflict back to the originating server, which is reachable on the relayed
-// path only via DISCOVER/REQUEST state; this relay does not forward it, and
-// widening that set is out of scope for #2153.
+// RELEASE is intentionally not relayed here. Unlike DISCOVER/REQUEST/INFORM/
+// DECLINE — which a client broadcasts when it has no usable server unicast
+// path on the local segment — a RELEASE is unicast by the client directly to
+// the server it is bound to (RFC 2131 §4.4.4), so the datagram routes to the
+// server without relay assistance and is never seen on the relay's
+// client-facing broadcast socket in the first place.
 func clientRequestRelayable(msgType dhcpv4.MessageType) bool {
 	switch msgType {
 	case dhcpv4.MessageTypeDiscover,
 		dhcpv4.MessageTypeRequest,
-		dhcpv4.MessageTypeInform:
+		dhcpv4.MessageTypeInform,
+		dhcpv4.MessageTypeDecline:
 		return true
 	default:
 		return false

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -92,12 +92,14 @@ func TestInterfaceIPv4_Loopback(t *testing.T) {
 }
 
 // TestClientRequestRelayable asserts the client->server forwarding gate
-// (#2153): a relay must forward DISCOVER, REQUEST, and INFORM, but not server
-// reply types or client-to-server-direct types (DECLINE/RELEASE). The INFORM
-// case is the regression target — before #2153 the gate dropped it, so a
-// domain-joined client that holds its own address never received DNS/domain/NTP
-// options from the central server. This test FAILS against the pre-fix gate
-// (which returned false for INFORM).
+// (#2153/#2789): a relay must forward DISCOVER, REQUEST, INFORM, and DECLINE,
+// but not server reply types or the client-to-server-direct RELEASE. INFORM is
+// the #2153 regression target and DECLINE the #2789 target — before each fix
+// the gate returned false for that type. Pre-#2153 the dropped INFORM left a
+// domain-joined client that holds its own address without DNS/domain/NTP
+// options from the central server; pre-#2789 the dropped DECLINE meant a
+// client-detected address conflict never reached the server, which kept
+// re-offering the in-use address.
 func TestClientRequestRelayable(t *testing.T) {
 	cases := []struct {
 		msgType dhcpv4.MessageType
@@ -105,8 +107,8 @@ func TestClientRequestRelayable(t *testing.T) {
 	}{
 		{dhcpv4.MessageTypeDiscover, true},
 		{dhcpv4.MessageTypeRequest, true},
-		{dhcpv4.MessageTypeInform, true}, // #2153 regression target
-		{dhcpv4.MessageTypeDecline, false},
+		{dhcpv4.MessageTypeInform, true},  // #2153 regression target
+		{dhcpv4.MessageTypeDecline, true}, // #2789 regression target
 		{dhcpv4.MessageTypeRelease, false},
 		{dhcpv4.MessageTypeOffer, false},
 		{dhcpv4.MessageTypeAck, false},
@@ -175,6 +177,66 @@ func TestRunRelay_RelaysInform(t *testing.T) {
 	}
 	if !relayed.GatewayIPAddr.Equal(net.IPv4(10, 0, 0, 254)) {
 		t.Errorf("relayed giaddr = %v, want 10.0.0.254", relayed.GatewayIPAddr)
+	}
+}
+
+// TestRunRelay_RelaysDecline is the end-to-end gate proof for #2789: a real
+// BOOTREQUEST/DECLINE datagram pushed through the live runRelay loop must be
+// forwarded to the server conn (so the server marks the conflicting address
+// unavailable per RFC 2131 §4.4.1), and must carry the relay-set giaddr so the
+// server can attribute the decline to this relayed segment. The assertion
+// FAILS against the pre-#2789 gate, which `continue`d on DECLINE and never
+// wrote to the server conn.
+func TestRunRelay_RelaysDecline(t *testing.T) {
+	// Build a client DECLINE: BOOTREQUEST whose Requested-IP option names the
+	// address the client found in use (RFC 2131 §4.4.1 — the declined address
+	// is carried in option 50, ciaddr stays zero).
+	decline, err := dhcpv4.New()
+	if err != nil {
+		t.Fatalf("dhcpv4.New: %v", err)
+	}
+	decline.OpCode = dhcpv4.OpcodeBootRequest
+	decline.ClientHWAddr = net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x02}
+	decline.UpdateOption(dhcpv4.OptMessageType(dhcpv4.MessageTypeDecline))
+	decline.UpdateOption(dhcpv4.OptRequestedIPAddress(net.IPv4(192, 0, 2, 77)))
+
+	client := newFakeConn()
+	client.pending = [][]byte{decline.ToBytes()}
+	server := newFakeConn()
+	factory, _ := recordingFactory(client, server)
+	m := testManager(factory)
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	defer m.Stop()
+
+	// Wait for the DECLINE to be relayed onto the server conn.
+	deadline := time.Now().Add(2 * time.Second)
+	for server.writeCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if server.writeCount() == 0 {
+		t.Fatal("DECLINE was not relayed to the server within 2s " +
+			"(pre-#2789 gate dropped it)")
+	}
+
+	// The relayed datagram must parse, be a BOOTREQUEST/DECLINE, carry the
+	// relay-set giaddr (10.0.0.254, from testManager's resolver), and preserve
+	// the declined address so the server knows which binding to mark in-use.
+	relayed, err := dhcpv4.FromBytes(server.firstWrite(t))
+	if err != nil {
+		t.Fatalf("relayed datagram does not parse: %v", err)
+	}
+	if relayed.OpCode != dhcpv4.OpcodeBootRequest {
+		t.Errorf("relayed opcode = %v, want BOOTREQUEST", relayed.OpCode)
+	}
+	if relayed.MessageType() != dhcpv4.MessageTypeDecline {
+		t.Errorf("relayed message type = %v, want DECLINE", relayed.MessageType())
+	}
+	if !relayed.GatewayIPAddr.Equal(net.IPv4(10, 0, 0, 254)) {
+		t.Errorf("relayed giaddr = %v, want 10.0.0.254", relayed.GatewayIPAddr)
+	}
+	if got := relayed.RequestedIPAddress(); !got.Equal(net.IPv4(192, 0, 2, 77)) {
+		t.Errorf("relayed requested-IP = %v, want 192.0.2.77", got)
 	}
 }
 


### PR DESCRIPTION
Closes #2789

## Problem
The DHCP relay's client→server forwarding gate (`clientRequestRelayable`,
`pkg/dhcprelay/relay.go`) admitted only DISCOVER/REQUEST/INFORM and dropped
DHCPDECLINE. When a client's ARP probe detects that the offered address is
already in use, it broadcasts a DHCPDECLINE so the server marks that address
unavailable. With the relay dropping it, the upstream server never learned of
the conflict and kept re-offering the in-use address — a persistent
duplicate-IP condition on the relayed segment. Filed from agy-review-048
finding 048-07.

## Fix
Add `dhcpv4.MessageTypeDecline` to the relayable set. The DECLINE then flows
through the existing, unchanged path: the #2456 HA master-state gate (only the
RG master relays → no duplicate per-node giaddrs), the giaddr stamp, the RFC
1542 §4.1.1 hop-count check, and Option 82.

## RFC 2131 basis
DHCPDECLINE is a client-originated message the client broadcasts (RFC 2131 §3.1
step 4, §4.4.1) to signal a detected address conflict; a relay must forward it
to the originating server. RELEASE remains excluded: a client unicasts RELEASE
directly to its bound server (RFC 2131 §4.4.4), so it routes without relay
assistance and is never seen on the relay's client-facing broadcast socket.
DECLINE carries no server reply, so the reverse server→client matrix (#2606
NAK, #2645 forcerenew) is unaffected.

## Fail-on-revert
- `TestClientRequestRelayable` now requires `DECLINE == true`.
- `TestRunRelay_RelaysDecline` is an end-to-end proof: a real BOOTREQUEST/DECLINE
  pushed through the live `runRelay` loop reaches the server conn with the
  relay-set giaddr (10.0.0.254) and the declined address (option 50) preserved.

Removing the type from the gate turns both RED (verified); restoring it GREEN.

## Gates
`go build ./...`, `gofmt -l` (clean), `go vet`, and
`go test -race ./pkg/dhcprelay/... ./pkg/daemon/...` all pass.

## Docs
Updated the `clientRequestRelayable` doc comment and the `pkg/dhcprelay/README.md`
relayed-message-type table; logged in `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
