### PR TITLE
ddns/checkip: wire validateCheckIPURL into commit + runtime fail-closed (#2773)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-06-25 — #2773: wire validateCheckIPURL (dead code) into commit + runtime
+
+- **Timestamp**: 2026-06-25
+- **Action**: `ddns.validateCheckIPURL` existed but had NO callers, so a
+  malformed `checkip-url` committed with no warning and then suppressed
+  publishing indefinitely as a phantom "transient" observation failure
+  (`http.NewRequest` accepts `ftp://`, `not a url`, host-less `http://`,
+  so the bad URL fell through to a fetch failure → `ok=false` → engine
+  leaves the scope untouched forever; a previously-published record
+  stays stale). Fix: (1) hardened `validateCheckIPURL` to require an
+  http(s) scheme AND a host (was prefix-only, missed host-less
+  `http://`); (2) wired it into `ddns.CheckIP` as a fail-closed runtime
+  backstop before constructing the request; (3) mirrored the check as
+  `config.ddnsCheckIPURLValid` and emitted a commit-time warning in
+  `validateSurfaceADDNSWarnings` (config cannot import pkg/ddns — same
+  pattern as `ddnsUpdateServerParseable` / `ddnsKnownDyndns2NameSet`) so
+  an operator typo is surfaced at `commit`. Two fail-on-revert tests:
+  `config.TestP3CheckIPURLMalformedWarns` (commit warning; also asserts a
+  valid URL does NOT warn) and `ddns.TestCheckIPRejectsMalformedURL`
+  (runtime gate via a panic-on-dial transport) + `TestValidateCheckIPURL`.
+- **Fail-on-revert proof**: removed the `validateSurfaceADDNSWarnings`
+  checkip block → `TestP3CheckIPURLMalformedWarns` FAILED ("expected a
+  checkip-url warning for provider \"bad-scheme\""); removed the
+  `CheckIP` gate → `TestCheckIPRejectsMalformedURL` FAILED ("CheckIP
+  attempted a request for a malformed URL: ftp://checkip.example/").
+  Both GREEN after restore.
+- **Gates**: `go build ./...` OK; `gofmt -l` clean; `go vet
+  ./pkg/ddns/... ./pkg/config/...` clean; `go test ./pkg/ddns/...` and
+  `go test ./pkg/config/...` PASS.
+- **File(s)**: `pkg/ddns/checkip.go`, `pkg/ddns/checkip_test.go`,
+  `pkg/config/compiler_validate_warn.go`,
+  `pkg/config/compiler_p3_http_providers_test.go`,
+  `docs/config-schema.md`, `pkg/ddns/README.md`
+
 ## 2026-06-25 — #2789: relay DHCPDECLINE to the server
 
 - **Timestamp**: 2026-06-25

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -858,7 +858,13 @@ reserved for whole-dataplane selection where a rewrite shim
     provider (dyndns2 with no server + unknown name, cloudflare missing
     api-token/zone, route53 missing keys/hosted-zone-id, generic missing
     url-template) warns and publishes nothing at runtime (fail-open, never a
-    hard reject). Regression coverage:
+    hard reject). A malformed `checkip-url` (not an http(s) URL with a host —
+    e.g. `ftp://`, `not a url`, host-less `http://`) also warns at commit
+    (#2773): without it the typo committed silently and the runtime fetch then
+    masqueraded forever as a transient observation failure, suppressing
+    publishing indefinitely. The runtime `ddns.CheckIP` gate
+    (`validateCheckIPURL`) fails closed on the same malformed URL regardless, so
+    a URL that slips past commit cannot reach a fetch. Regression coverage:
     `pkg/config/compiler_p3_http_providers_test.go`,
     `pkg/ddns/backend_http_test.go` / `backend_cloudflare_test.go` /
     `backend_route53_test.go` / `sigv4_test.go` / `checkip_test.go` /

--- a/pkg/config/compiler_p3_http_providers_test.go
+++ b/pkg/config/compiler_p3_http_providers_test.go
@@ -118,3 +118,45 @@ func TestP3IncompleteHTTPProviderWarns(t *testing.T) {
 		}
 	}
 }
+
+// TestP3CheckIPURLMalformedWarns is the #2773 fail-on-revert gate: a malformed
+// checkip-url must be flagged at commit (was dead code — validateCheckIPURL had
+// no callers, so a typo committed silently and then masqueraded forever as a
+// transient observation failure that suppressed publishing). Goes GREEN with the
+// validateSurfaceADDNSWarnings wiring and RED if that wiring is removed. The
+// valid-URL providers in the same config must NOT warn (no false positives).
+func TestP3CheckIPURLMalformedWarns(t *testing.T) {
+	tree := buildTree(t, []string{
+		// Malformed checkip-urls that http.NewRequest would otherwise accept and
+		// then fail to fetch forever.
+		"set system services dynamic-dns provider bad-scheme backend dyndns2",
+		"set system services dynamic-dns provider bad-scheme server dyn.example",
+		"set system services dynamic-dns provider bad-scheme checkip-url ftp://checkip.example/",
+		"set system services dynamic-dns provider no-host backend dyndns2",
+		"set system services dynamic-dns provider no-host server dyn.example",
+		"set system services dynamic-dns provider no-host checkip-url http://",
+		"set system services dynamic-dns provider junk backend dyndns2",
+		"set system services dynamic-dns provider junk server dyn.example",
+		`set system services dynamic-dns provider junk checkip-url "not a url"`,
+		// A valid checkip-url must NOT warn.
+		"set system services dynamic-dns provider good backend dyndns2",
+		"set system services dynamic-dns provider good server dyn.example",
+		"set system services dynamic-dns provider good checkip-url https://checkip.example/",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	warns := validateSurfaceADDNSWarnings(cfg)
+	joined := strings.Join(warns, "\n")
+
+	for _, badName := range []string{"bad-scheme", "no-host", "junk"} {
+		want := "provider \"" + badName + "\" checkip-url"
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected a checkip-url warning for provider %q; got:\n%s", badName, joined)
+		}
+	}
+	if strings.Contains(joined, "provider \"good\" checkip-url") {
+		t.Fatalf("valid checkip-url should not warn; got:\n%s", joined)
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"sort"
 	"strings"
 )
@@ -968,6 +969,25 @@ func ddnsKnownDyndns2Provider(name string) bool {
 	return ddnsKnownDyndns2NameSet[strings.ToLower(name)]
 }
 
+// ddnsCheckIPURLValid mirrors pkg/ddns.validateCheckIPURL for the commit-time
+// warning ONLY (config cannot import pkg/ddns). It must stay in sync with that
+// validator; a divergence only affects whether the operator gets a warning at
+// commit — the runtime CheckIP gate in pkg/ddns is authoritative and fails
+// closed regardless (#2773). A checkip-url must be an http(s) URL with a host;
+// without that gate a typo (ftp://, "not a url", host-less "http://") commits
+// silently and then masquerades forever as a transient observation failure,
+// suppressing publishing indefinitely.
+func ddnsCheckIPURLValid(u string) bool {
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return false
+	}
+	parsed, err := url.Parse(u)
+	if err != nil || parsed.Host == "" {
+		return false
+	}
+	return true
+}
+
 // validateSurfaceADDNSWarnings emits WARN-only commit-time messages for the
 // Surface A router/interface-address DDNS bindings + provider catalog (#2691
 // P2). It never returns an error: the typed schema already accepts the leaves,
@@ -1054,6 +1074,17 @@ func validateSurfaceADDNSWarnings(cfg *Config) []string {
 					"provider %q (backend generic) has no url-template; scopes using it publish "+
 					"nothing", name))
 			}
+		}
+
+		// checkip-url is a backend-independent, opt-in behind-NAT address source
+		// (#2691 P3). A malformed URL is a config error, not a transient: without
+		// this warning a typo commits silently and the runtime fetch fails forever,
+		// masquerading as a transient observation failure that suppresses publishing
+		// indefinitely (#2773). The runtime CheckIP gate fails closed regardless.
+		if p.CheckIPURL != "" && !ddnsCheckIPURLValid(p.CheckIPURL) {
+			warnings = append(warnings, fmt.Sprintf("system services dynamic-dns "+
+				"provider %q checkip-url %q is not a valid http(s) URL with a host; "+
+				"scopes using address-source checkip publish nothing", name, p.CheckIPURL))
 		}
 	}
 

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -27,7 +27,7 @@ moved with its assertions intact.
 | `backend_route53.go` | Route 53 backend (#2691 P3): SigV4-signed `ChangeResourceRecordSets` UPSERT/DELETE change batch. |
 | `sigv4.go` | Minimal self-contained AWS SigV4 signer for Route 53 (no AWS SDK dependency). |
 | `backend_generic.go` | Generic templated backend (#2691 P3, inadyn "custom"): `%h/%i/%u/%p/%%` URL template + success-substring matcher — config-only, no Go code per provider. |
-| `checkip.go` | Opt-in external check-IP address source (#2691 P3): bogus-IP validity gate + allowlist (`isPublicAddr`, `parseCheckIPBody`, `CheckIP`, `ParseAllowlist`). |
+| `checkip.go` | Opt-in external check-IP address source (#2691 P3): bogus-IP validity gate + allowlist (`isPublicAddr`, `parseCheckIPBody`, `CheckIP`, `ParseAllowlist`). `CheckIP` fails closed on a malformed `checkip-url` via `validateCheckIPURL` (http(s) scheme + host); a typo is also warned at commit by `config.validateSurfaceADDNSWarnings` so it cannot masquerade as a permanent transient observation failure (#2773). |
 
 Tests moved with the code: `manager_test.go` (engine + state-store + hostname),
 `backend_rfc2136_test.go` (backend, drives a real in-process miekg/dns server),

--- a/pkg/ddns/checkip.go
+++ b/pkg/ddns/checkip.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -40,6 +41,16 @@ var ipAddrRe = regexp.MustCompile(
 func CheckIP(ctx context.Context, client *http.Client, urlStr string, wantV4 bool, allowlist []netip.Addr) (netip.Addr, bool) {
 	if client == nil {
 		client = newHTTPClient()
+	}
+	// Fail-closed on an obviously malformed checkip-url (#2773). http.NewRequest
+	// accepts ftp://, "not a url", and http:// (no host), so without this gate a
+	// bad URL would fall through to a fetch failure and masquerade forever as a
+	// transient observation failure (ok=false), silently suppressing publishing.
+	// A malformed URL is a configuration error, not a transient — reject it here
+	// (the commit-time validateSurfaceADDNSWarnings warning is the operator-facing
+	// half; this is the runtime backstop for a URL that slipped past commit).
+	if err := validateCheckIPURL(urlStr); err != nil {
+		return netip.Addr{}, false
 	}
 	req, err := http.NewRequest(http.MethodGet, urlStr, nil)
 	if err != nil {
@@ -155,11 +166,22 @@ func ParseAllowlist(s string) []netip.Addr {
 // AddressSource values live in surface_a.go.
 const AddressSourceCheckIP AddressSource = "checkip"
 
-// checkIPAllowlistConfigError is returned for an obviously malformed checkip URL
-// at construction so the daemon can degrade the scope rather than spin on it.
+// validateCheckIPURL rejects an obviously malformed checkip URL so a typo is
+// caught at commit (validateSurfaceADDNSWarnings mirrors this) and fails closed
+// at runtime construction (CheckIP) rather than spinning forever as a phantom
+// "transient" observation failure (#2773). It requires an http(s) scheme AND a
+// host: http.NewRequest accepts ftp://, "not a url", and a host-less "http://",
+// none of which can ever fetch a public address.
 func validateCheckIPURL(u string) error {
 	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
 		return fmt.Errorf("ddns checkip: url %q must be http(s)", u)
+	}
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return fmt.Errorf("ddns checkip: url %q is not a valid URL: %w", u, err)
+	}
+	if parsed.Host == "" {
+		return fmt.Errorf("ddns checkip: url %q has no host", u)
 	}
 	return nil
 }

--- a/pkg/ddns/checkip_test.go
+++ b/pkg/ddns/checkip_test.go
@@ -83,3 +83,54 @@ func TestParseAllowlist(t *testing.T) {
 		t.Fatalf("expected 3 parsed addresses, got %d (%v)", len(got), got)
 	}
 }
+
+// TestValidateCheckIPURL is the #2773 validator gate: http(s) scheme + a host.
+// validateCheckIPURL was dead code (no callers) before #2773 wired it into
+// CheckIP and (mirrored) into the commit-time warning.
+func TestValidateCheckIPURL(t *testing.T) {
+	for _, ok := range []string{
+		"http://checkip.example/",
+		"https://checkip.example:8443/cdn-cgi/trace",
+		"https://192.0.2.1/",
+	} {
+		if err := validateCheckIPURL(ok); err != nil {
+			t.Fatalf("validateCheckIPURL(%q) = %v, want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{
+		"",                // empty
+		"ftp://host/",     // non-http scheme
+		"not a url",       // no scheme
+		"http://",         // scheme but no host
+		"https:///path",   // empty host
+		"javascript:0",    // non-http scheme
+		"checkip.example", // bare host, no scheme
+	} {
+		if err := validateCheckIPURL(bad); err == nil {
+			t.Fatalf("validateCheckIPURL(%q) = nil, want error", bad)
+		}
+	}
+}
+
+// TestCheckIPRejectsMalformedURL is the #2773 runtime fail-on-revert gate: a
+// malformed checkip-url must be rejected by CheckIP itself (fail closed), not
+// fall through to a fetch and masquerade as a transient failure. Before the
+// wiring, http.NewRequest accepted these strings and CheckIP returned ok=false
+// only because the *fetch* failed — indistinguishable from a real transient.
+// This goes RED if the validateCheckIPURL gate is removed from CheckIP: the
+// requests would then reach the transport, which fails the test on contact.
+func TestCheckIPRejectsMalformedURL(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		t.Fatalf("CheckIP attempted a request for a malformed URL: %s", r.URL)
+		return nil, nil
+	})}
+	for _, bad := range []string{"ftp://checkip.example/", "http://", "not a url"} {
+		if _, ok := CheckIP(context.Background(), client, bad, true, nil); ok {
+			t.Fatalf("CheckIP(%q) ok=true, want false (malformed URL must fail closed)", bad)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }


### PR DESCRIPTION
Closes #2773

## Problem
`ddns.validateCheckIPURL` was dead code — defined but with no callers. A malformed `checkip-url` committed with no warning, then `ddns.CheckIP` fell through to a fetch failure (`http.NewRequest` accepts `ftp://`, `not a url`, host-less `http://`) and returned `(zero, false)`. The Surface A engine treats `ok=false` as a transient observation failure and leaves the scope untouched (the never-blackhole rule), so a typo masqueraded forever as a transient and any previously-published record went stale instead of being flagged as a config error.

## Fix
Matching the existing ddns/config validation idiom:

- **Hardened `validateCheckIPURL`** to require an http(s) scheme AND a host (was prefix-only; missed host-less `http://` and a bare host). Parses with `net/url`, rejects empty `Host`.
- **Runtime fail-closed** — wired `validateCheckIPURL` into `ddns.CheckIP`, rejecting a malformed URL before constructing the request (backstop for a URL that slips past commit).
- **Commit-time warning** — mirrored as `config.ddnsCheckIPURLValid` (pkg/config cannot import pkg/ddns, same pattern as `ddnsUpdateServerParseable`) and emitted from `validateSurfaceADDNSWarnings`, backend-independent, after the per-backend switch.

## Fail-on-revert proof
- `config.TestP3CheckIPURLMalformedWarns` — removing the `validateSurfaceADDNSWarnings` checkip block:
  `--- FAIL ... expected a checkip-url warning for provider "bad-scheme"`
- `ddns.TestCheckIPRejectsMalformedURL` (panic-on-dial transport) — removing the `CheckIP` gate:
  `--- FAIL ... CheckIP attempted a request for a malformed URL: ftp://checkip.example/`

Both GREEN after restore. Plus `TestValidateCheckIPURL` for the hardened validator.

## Gates
- `go build ./...` — OK
- `gofmt -l` (touched files) — clean
- `go vet ./pkg/ddns/... ./pkg/config/...` — clean
- `go test ./pkg/ddns/...` — PASS
- `go test ./pkg/config/...` — PASS

## Docs
`docs/config-schema.md` (commit-warnings paragraph) + `pkg/ddns/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi