### PR TITLE
config/ddns: redact URL credentials in DDNSProvider.String() (#2781)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -15938,3 +15938,22 @@ top.
   TestAddrWatcher_UnconfiguredInterfaceNoReconcile (over-fire guard).
   **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/addrwatch.go,
   pkg/vrrp/addrwatch_test.go, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2781 — DDNSProvider.String() (pkg/config) printed url-template,
+  server, and checkip-url verbatim. The generic backend supports credentials
+  embedded in the URL template (userinfo or a token in the query string, e.g.
+  https://api.example/update?token=SECRET&host=%h) and a checkip-url can carry
+  an API key, so any %v/%s/slog of a DDNSProvider leaked those tokens. Added
+  config.RedactURL (pkg/config/secret.go): string-based (NOT net/url — the value
+  may be an inadyn template with %h/%i specifiers that url.Parse would mangle)
+  redaction that strips userinfo ("user:pass@" -> "<redacted>@") and the entire
+  query string (after the first '?' -> "<redacted>") while preserving
+  scheme/host/path for diagnostics. String() now wraps Server, URLTemplate,
+  CheckIPURL, and UpdateServer in RedactURL. Fail-on-revert proof: with
+  RedactURL removed from String(), TestDDNSProviderStringRedactsURLCredentials
+  goes RED leaking QUERY-TOKEN-1a2b3c (verified). Gates: go build ./... clean,
+  gofmt -l clean, go vet ./pkg/config/... ./pkg/ddns/... clean,
+  go test ./pkg/config/ + ./pkg/ddns/... pass.
+  **File(s)**: pkg/config/secret.go, pkg/config/types_system.go,
+  pkg/config/ddns_provider_string_test.go, pkg/ddns/README.md, _Log.md

--- a/pkg/config/ddns_provider_string_test.go
+++ b/pkg/config/ddns_provider_string_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDDNSProviderStringRedactsURLCredentials is the #2781 fail-on-revert
+// guard: DDNSProvider.String() (used by %v/%s/slog) must never leak a
+// credential embedded in a URL field. The generic backend supports a token in
+// the URL template (userinfo or query string) and a checkip-url can carry an
+// API key — both are plain (non-Secret) strings printed verbatim before #2781.
+//
+// If RedactURL is removed from String() (revert), the secret substrings reappear
+// and this test goes RED.
+func TestDDNSProviderStringRedactsURLCredentials(t *testing.T) {
+	const (
+		queryToken = "QUERY-TOKEN-1a2b3c"
+		userinfoPw = "USERINFO-PASS-9z8y7x"
+		checkipKey = "CHECKIP-APIKEY-deadbeef"
+		serverPw   = "SERVER-PASS-c0ffee"
+	)
+	p := &DDNSProvider{
+		Name:    "leaky",
+		Backend: "generic",
+		// Token in the query string — the canonical #2781 leak.
+		URLTemplate: "https://api.example.net/update?token=" + queryToken + "&host=%h&ip=%i",
+		// Userinfo credentials in the server URL.
+		Server: "https://user:" + serverPw + "@dyndns.example.net",
+		// API key in the checkip endpoint.
+		CheckIPURL: "https://checkip.example.net/?apikey=" + checkipKey,
+	}
+
+	s := p.String()
+
+	for _, secret := range []string{queryToken, userinfoPw, checkipKey, serverPw} {
+		if strings.Contains(s, secret) {
+			t.Fatalf("DDNSProvider.String() leaked a URL credential %q: %s", secret, s)
+		}
+	}
+	// A redaction marker must be present — proves redaction fired rather than the
+	// fields simply being empty.
+	if !strings.Contains(s, "<redacted>") {
+		t.Fatalf("DDNSProvider.String() produced no redaction marker: %s", s)
+	}
+	// The non-sensitive scheme/host/path prefix must survive for diagnostics.
+	if !strings.Contains(s, "https://api.example.net/update?") {
+		t.Fatalf("DDNSProvider.String() dropped the url-template host/path: %s", s)
+	}
+	if !strings.Contains(s, "@dyndns.example.net") {
+		t.Fatalf("DDNSProvider.String() dropped the server host after userinfo redaction: %s", s)
+	}
+}
+
+// TestRedactURL exercises RedactURL directly across the shapes #2781 cares
+// about: userinfo, query token, both, a plain hostname (rfc2136 update-server),
+// an inadyn template with %-specifiers (must not be mangled by url.Parse), and
+// empty input.
+func TestRedactURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		// mustContain / mustNotContain are substring assertions on the result.
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{
+			name:           "query token",
+			in:             "https://api.example/update?token=SECRET&host=%h",
+			mustContain:    []string{"https://api.example/update?", "<redacted>"},
+			mustNotContain: []string{"SECRET", "token=", "%h"},
+		},
+		{
+			name:           "userinfo password",
+			in:             "https://bob:HUNTER2@dyn.example/path",
+			mustContain:    []string{"https://<redacted>@dyn.example/path"},
+			mustNotContain: []string{"HUNTER2", "bob:"},
+		},
+		{
+			name:           "userinfo and query",
+			in:             "http://bob:HUNTER2@dyn.example/p?key=K3Y",
+			mustContain:    []string{"http://<redacted>@dyn.example/p?", "<redacted>"},
+			mustNotContain: []string{"HUNTER2", "K3Y", "bob:", "key="},
+		},
+		{
+			name:        "plain host:port (rfc2136 update-server)",
+			in:          "ns.example.com:53",
+			mustContain: []string{"ns.example.com:53"},
+		},
+		{
+			name:           "inadyn template no creds still drops query",
+			in:             "https://svc.example/nic/update?hostname=%h&myip=%i",
+			mustContain:    []string{"https://svc.example/nic/update?", "<redacted>"},
+			mustNotContain: []string{"hostname=", "%h", "%i"},
+		},
+		{
+			name: "empty",
+			in:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RedactURL(tc.in)
+			if tc.in == "" && got != "" {
+				t.Fatalf("RedactURL(%q) = %q, want empty", tc.in, got)
+			}
+			for _, sub := range tc.mustContain {
+				if !strings.Contains(got, sub) {
+					t.Errorf("RedactURL(%q) = %q, want to contain %q", tc.in, got, sub)
+				}
+			}
+			for _, sub := range tc.mustNotContain {
+				if strings.Contains(got, sub) {
+					t.Errorf("RedactURL(%q) = %q, must NOT contain %q", tc.in, got, sub)
+				}
+			}
+		})
+	}
+}

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 // errRedactedSecretIngest is returned by Secret.UnmarshalJSON when the
@@ -54,6 +55,59 @@ func (s Secret) String() string {
 		return ""
 	}
 	return SecretRedacted
+}
+
+// RedactURL strips credential-bearing components from a URL or URL template
+// for %v/%s/slog formatting (logging hygiene, #2781). It is deliberately
+// string-based rather than net/url-based because the value may be an inadyn
+// URL TEMPLATE carrying %h/%i/%u/%p specifiers (e.g. the generic DDNS backend,
+// pkg/ddns/backend_generic.go) which are not valid percent-encoding and would
+// make url.Parse fail or mangle the string.
+//
+// Two credential-carrying components are redacted while the scheme/host/path
+// prefix is preserved so the log line stays diagnostically useful:
+//
+//   - userinfo: a "user:pass@" (or "user@") segment between "scheme://" and the
+//     first '/', '?' or '#' becomes "<redacted>@" — operators embed creds there
+//     (e.g. https://user:token@api.example/update).
+//   - query string: everything after the first '?' becomes "<redacted>" — the
+//     #2781 case is a token in the query (e.g. ...?token=SECRET&host=%h).
+//
+// An empty input returns "" so absence stays distinguishable. A value with no
+// credential-bearing component is returned with the query (if any) still
+// redacted; query strings are treated as sensitive because generic templates
+// routinely carry the auth token there.
+func RedactURL(s string) string {
+	if s == "" {
+		return ""
+	}
+	const redacted = "<redacted>"
+
+	// Redact userinfo: locate the authority (between "://" and the next
+	// delimiter) and replace any "...@" prefix within it.
+	if i := strings.Index(s, "://"); i >= 0 {
+		authStart := i + len("://")
+		// The authority ends at the first '/', '?' or '#'.
+		authEnd := len(s)
+		for j := authStart; j < len(s); j++ {
+			if c := s[j]; c == '/' || c == '?' || c == '#' {
+				authEnd = j
+				break
+			}
+		}
+		authority := s[authStart:authEnd]
+		if at := strings.LastIndex(authority, "@"); at >= 0 {
+			// Replace the whole userinfo (everything up to and including '@').
+			s = s[:authStart] + redacted + "@" + authority[at+1:] + s[authEnd:]
+		}
+	}
+
+	// Redact the query string: everything after the first '?' (preserve any
+	// trailing fragment is unnecessary — the token is the concern, drop it all).
+	if q := strings.IndexByte(s, '?'); q >= 0 {
+		s = s[:q+1] + redacted
+	}
+	return s
 }
 
 // Reveal returns the real cleartext value. It is the canonical, audited way

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -294,8 +294,16 @@ type DDNSProvider struct {
 	CheckIPAllowlist string
 }
 
-// String redacts TSIGSecret so a %v/%s/slog format of a DDNSProvider never
-// leaks the shared HMAC key (logging hygiene, mirrors DHCPDynamicDNSConfig).
+// String redacts every credential-bearing field so a %v/%s/slog format of a
+// DDNSProvider never leaks an operator secret (logging hygiene, mirrors
+// DHCPDynamicDNSConfig). The Secret-typed fields (TSIGSecret, Password,
+// APIToken, AWSSecretAccessKey) redact to the secret sentinel. The URL fields
+// (Server, URLTemplate, CheckIPURL) are NOT Secret-typed — they are plain
+// strings — but the generic backend explicitly supports credentials embedded
+// in the URL template (userinfo, or a token in the query string, see
+// pkg/ddns/backend_generic.go) and a checkip-url can carry an API key, so each
+// is run through RedactURL which strips userinfo and the query string while
+// keeping the scheme/host/path for diagnostics (#2781).
 func (p *DDNSProvider) String() string {
 	if p == nil {
 		return "<nil>"
@@ -312,11 +320,11 @@ func (p *DDNSProvider) String() string {
 		"password=%q url-template=%q ok-response=%q api-token=%q zone=%q "+
 		"aws-access-key=%q aws-secret-key=%q aws-region=%q hosted-zone-id=%q "+
 		"checkip-url=%q checkip-allowlist=%q}",
-		p.Name, p.Backend, p.UpdateServer, p.TSIGKeyName, p.TSIGAlgorithm,
+		p.Name, p.Backend, RedactURL(p.UpdateServer), p.TSIGKeyName, p.TSIGAlgorithm,
 		red(p.TSIGSecret), p.SourceAddress, p.DestinationInterface, p.RoutingInstance,
-		p.Server, p.Username, red(p.Password), p.URLTemplate, p.OKResponse,
+		RedactURL(p.Server), p.Username, red(p.Password), RedactURL(p.URLTemplate), p.OKResponse,
 		red(p.APIToken), p.Zone, p.AWSAccessKeyID, red(p.AWSSecretAccessKey),
-		p.AWSRegion, p.HostedZoneID, p.CheckIPURL, p.CheckIPAllowlist)
+		p.AWSRegion, p.HostedZoneID, RedactURL(p.CheckIPURL), p.CheckIPAllowlist)
 }
 
 // SSHServiceConfig holds SSH service settings.

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -54,7 +54,15 @@ single resolution point keyed on `DDNSProvider.Backend`:
 
 All credentials are `config.Secret` (revealed only at the transport boundary,
 never logged); HTTP is HTTPS with system-trust cert+hostname verification, a
-bounded request timeout, and a capped response body. A construction failure
+bounded request timeout, and a capped response body. The `generic` backend
+additionally lets an operator embed a credential directly in the `url-template`
+(userinfo `user:pass@host`, or a token in the query string via `%u`/`%p` or a
+literal `?token=...`), and a `checkip-url` can carry an API key the same way —
+neither is `config.Secret`-typed, so `DDNSProvider.String()`
+(`pkg/config/types_system.go`, used by `%v`/`%s`/slog) runs `server`,
+`url-template`, and `checkip-url` through `config.RedactURL`, which strips
+userinfo and the entire query string while keeping the scheme/host/path for
+diagnostics (#2781). A construction failure
 (missing credential) degrades to the no-op backend (logged; the commit warning
 already fired) — fail-open, matching the rfc2136 posture. Live-provider verify
 is the deferred lab gate; the mock-server tests are the merge gate.


### PR DESCRIPTION
Closes #2781

## Problem
`DDNSProvider.String()` (`pkg/config/types_system.go`) redacted the
`config.Secret`-typed fields but printed `url-template`, `server`, and
`checkip-url` verbatim. The generic backend explicitly supports credentials
embedded in the URL template — userinfo (`user:pass@host`) or a token in the
query string, e.g. `https://api.example/update?token=SECRET&host=%h&ip=%i` —
and a `checkip-url` can carry an API key the same way. None are
`config.Secret`-typed, so any `%v`/`%s`/slog of a `DDNSProvider` leaked the
token. (codex-review-048 finding 048-13.)

## Fix
Added `config.RedactURL` (`pkg/config/secret.go`) and run `Server`,
`URLTemplate`, `CheckIPURL`, and `UpdateServer` through it in `String()`.
`RedactURL` is string-based, NOT `net/url`-based: the value may be an inadyn URL
template with `%h/%i/%u/%p` specifiers (invalid percent-encoding — `url.Parse`
would fail/mangle). It redacts:
- userinfo: `scheme://user:pass@host...` -> `scheme://<redacted>@host...`
- query string: everything after the first `?` -> `<redacted>`

while keeping the scheme/host/path prefix for diagnostics. A plain `host:port`
(the rfc2136 `update-server` shape) is returned unchanged.

Scope: only `DDNSProvider.String()` + the new shared `RedactURL` helper. No
change to checkip.go / surface_a.go / compiler_validate_warn.go.

## Validation
- `go build ./...` clean
- `gofmt -l` clean
- `go vet ./pkg/config/... ./pkg/ddns/...` clean
- `go test ./pkg/config/ ./pkg/ddns/...` pass

### Fail-on-revert proof
`TestDDNSProviderStringRedactsURLCredentials` sets a provider with a query
token, userinfo password, and checkip API key, and asserts none appear in
`String()` while a `<redacted>` marker is present. Reverting `String()` to
print the URLs verbatim makes it RED:

```
--- FAIL: TestDDNSProviderStringRedactsURLCredentials
    ddns_provider_string_test.go:38: DDNSProvider.String() leaked a URL credential
    "QUERY-TOKEN-1a2b3c": ... url-template="https://api.example.net/update?token=QUERY-TOKEN-1a2b3c&host=%h&ip=%i" ...
```

`TestRedactURL` additionally covers userinfo, query token, both, plain
`host:port`, an inadyn `%`-specifier template, and empty input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi