### PR TITLE
ddns/http: make dyndns2 + generic withdraw real, not a silent no-op (#2772)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-06-25 — #2772: ddns http dyndns2 + generic withdraw is no longer a silent no-op
+
+- **Timestamp**: 2026-06-25
+- **Action**: For the dyndns2 and generic HTTP DDNS backends, `DeleteLease`
+  was a no-op that returned nil WITHOUT any remote operation. Surface A's
+  `withdrawOwnedLocked` drops local ownership only on a nil-error
+  `DeleteLease`, so when xpf withdrew a name (scope shrink, binding
+  removed, address lost) it reported the withdraw done while the public
+  record kept resolving forever — the comments assumed a provider
+  TTL/liveness reap that is NOT a portable dyndns2/generic contract.
+  Fix:
+  - **dyndns2**: `DeleteLease` now performs the de-facto dyndns2 withdraw
+    verb — the SAME update GET with `offline=YES` (which dyn/no-ip/
+    dns-o-matic honour by taking the hostname offline). Refactored the
+    request/auth/status/verdict logic into a shared `update(ctx, q)`
+    helper used by both `UpsertLease` and `DeleteLease`, so a provider
+    failure on the withdraw propagates as a non-nil error and the engine
+    keeps ownership for retry.
+  - **generic**: a single inadyn-style update template has no portable
+    delete verb and xpf exposes no per-provider delete template, so
+    `DeleteLease` now FAILS (`errGenericDeleteUnsupported`) instead of
+    returning nil. The engine increments `deleteFail` and KEEPS the
+    ownership entry, so the abandoned record stays operator-visible
+    rather than being silently reported as withdrawn.
+  - **scope**: provider-source only (`backend_dyndns2.go`,
+    `backend_generic.go` + `backend_http_test.go`). No shared file
+    (`surface_a.go`/`provider.go`/config types) touched — the existing
+    withdraw-keeps-ownership-on-error contract did the rest.
+  - **Fail-on-revert proof**: reverted both `DeleteLease` bodies to
+    `return nil` and confirmed all three new tests go RED
+    (`TestDyndns2DeleteIssuesOfflineRequest` — server never hit;
+    `TestDyndns2DeletePropagatesProviderFailure` — badauth not surfaced;
+    `TestGenericDeleteFailsNotSilentSuccess` — silent success), then
+    restored and confirmed GREEN.
+  - **Validation**: `go build ./...`, `gofmt -l pkg/ddns/` (clean),
+    `go vet ./pkg/ddns/...`, `go test ./pkg/ddns/...` all pass.
+- **File(s)**: pkg/ddns/backend_dyndns2.go, pkg/ddns/backend_generic.go,
+  pkg/ddns/backend_http_test.go, pkg/ddns/README.md, _Log.md
+
 ## 2026-06-25 — #2773: wire validateCheckIPURL (dead code) into commit + runtime
 
 - **Timestamp**: 2026-06-25

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -22,11 +22,11 @@ moved with its assertions intact.
 | `hostname.go` | Deterministic hostname → DNS-label normalization (pure) — moved from `dhcpserver/ddns_hostname.go`. |
 | `surface_a.go` | Surface A router/interface-address publish engine (`SurfaceAManager`): change-detection, forced-refresh wire floor, per-scope error backoff, per-RG HA gate, the backend factory `productionSurfaceABackend` (#2691 P2/P3). |
 | `backend_http.go` | Shared HTTP-backend discipline (#2691 P3): hardened `http.Client` (TLS-verified, bounded timeout), capped body read, `classifyHTTPStatus`, `queryEscape`, the `errHTTPAuth`/`errHTTPRateLimited` verdicts. |
-| `backend_dyndns2.go` | dyndns2 backend (#2691 P3): one impl behind many provider names (`dyndns2Endpoints`), `good`/`nochg`/`badauth`/`abuse`/`911`/`nohost` verdict parsing. |
+| `backend_dyndns2.go` | dyndns2 backend (#2691 P3): one impl behind many provider names (`dyndns2Endpoints`), `good`/`nochg`/`badauth`/`abuse`/`911`/`nohost` verdict parsing. **Withdraw (#2772):** `DeleteLease` issues the same update GET with `offline=YES` (the de-facto dyndns2 withdraw verb) and parses the body verdict; a provider failure returns a non-nil error so the engine keeps ownership for retry (was a silent no-op that orphaned the public record). |
 | `backend_cloudflare.go` | Cloudflare API backend (#2691 P3): Bearer token, zone-id resolve → find → PATCH/POST/DELETE record. |
 | `backend_route53.go` | Route 53 backend (#2691 P3): SigV4-signed `ChangeResourceRecordSets` UPSERT/DELETE change batch. |
 | `sigv4.go` | Minimal self-contained AWS SigV4 signer for Route 53 (no AWS SDK dependency). |
-| `backend_generic.go` | Generic templated backend (#2691 P3, inadyn "custom"): `%h/%i/%u/%p/%%` URL template + success-substring matcher — config-only, no Go code per provider. |
+| `backend_generic.go` | Generic templated backend (#2691 P3, inadyn "custom"): `%h/%i/%u/%p/%%` URL template + success-substring matcher — config-only, no Go code per provider. **Withdraw (#2772):** a single update template has no portable delete verb and xpf exposes no delete template, so `DeleteLease` FAILS (`errGenericDeleteUnsupported`) rather than silently reporting success; the engine keeps ownership so the abandoned record stays operator-visible (was a silent no-op that dropped ownership while the record kept resolving). |
 | `checkip.go` | Opt-in external check-IP address source (#2691 P3): bogus-IP validity gate + allowlist (`isPublicAddr`, `parseCheckIPBody`, `CheckIP`, `ParseAllowlist`). `CheckIP` fails closed on a malformed `checkip-url` via `validateCheckIPURL` (http(s) scheme + host); a typo is also warned at commit by `config.validateSurfaceADDNSWarnings` so it cannot masquerade as a permanent transient observation failure (#2773). |
 
 Tests moved with the code: `manager_test.go` (engine + state-store + hostname),
@@ -58,6 +58,24 @@ bounded request timeout, and a capped response body. A construction failure
 (missing credential) degrades to the no-op backend (logged; the commit warning
 already fired) — fail-open, matching the rfc2136 posture. Live-provider verify
 is the deferred lab gate; the mock-server tests are the merge gate.
+
+### Withdraw (DeleteLease) semantics per backend (#2772)
+
+A withdraw is triggered when a Surface A scope shrinks, a binding is removed, or
+the observed address is lost. `withdrawOwnedLocked` drops local ownership ONLY on
+a nil-error `DeleteLease`; a non-nil error increments `deleteFail` and KEEPS the
+ownership entry for retry. The HTTP backends therefore must never report a false
+success for a withdraw they did not actually perform — doing so orphans the
+public record while xpf believes it withdrawn (the #2772 bug, originally a no-op
+that returned nil on both dyndns2 and generic).
+
+| backend | withdraw mechanism |
+|---|---|
+| `dyndns2` | the same update GET with `offline=YES` (the de-facto dyndns2 withdraw — dyn/no-ip/dns-o-matic take the hostname offline). Body verdict parsed like an upsert; a provider failure → non-nil error → ownership kept for retry. |
+| `cloudflare` | real DELETE of the record (zone-id resolve → find → DELETE). |
+| `route53` | SigV4 `ChangeResourceRecordSets` DELETE change batch. |
+| `rfc2136` | exact-RR delete (TTL=0 / CLASS=NONE), DHCID-match guarded. |
+| `generic` | **no portable delete verb and no delete template → FAILS** (`errGenericDeleteUnsupported`). Ownership is kept so the abandoned record stays operator-visible; the operator clears it out of band (or uses a backend that supports a withdraw). |
 
 ## The package boundary (why a `LeaseParser` seam)
 

--- a/pkg/ddns/backend_dyndns2.go
+++ b/pkg/ddns/backend_dyndns2.go
@@ -24,11 +24,18 @@ import (
 //
 // This backend implements the SAME DNSUpdater interface as rfc2136, so the
 // Surface A engine drives it identically. A router record carries no PTR and no
-// ClientID (the firewall owns its own name), so Upsert sends exactly one GET and
-// Delete is a best-effort offline (dyndns2 has no standard delete verb — most
-// providers offman by pointing the record at 0.0.0.0 or simply letting it
-// expire). We implement Delete as a documented no-op-with-warning rather than
-// guessing a per-provider deletion verb.
+// ClientID (the firewall owns its own name), so Upsert sends exactly one GET.
+//
+// Withdraw (#2772): the previous DeleteLease was a no-op that returned nil, so
+// the Surface A engine dropped local ownership while the public record kept
+// resolving forever (the comments assumed a provider TTL/liveness reap that is
+// NOT a portable dyndns2 contract). DeleteLease now performs the de-facto
+// dyndns2 withdraw verb — the SAME update GET with `offline=YES` — which dyn,
+// no-ip, and dns-o-matic honour by taking the hostname offline (it stops
+// resolving / serves the provider's offline redirect). The provider's body
+// verdict (good/nochg/...) is parsed exactly like the upsert path, so a failed
+// withdraw returns a non-nil error and the engine keeps ownership for retry
+// instead of silently orphaning the record.
 
 // dyndns2Endpoints maps a known dyndns2 provider name to its update base URL.
 // The provider's `backend` token selects the protocol (dyndns2); when the
@@ -103,14 +110,45 @@ func resolveDyndns2Endpoint(p *config.DDNSProvider) (string, error) {
 // ClientID fields of the record are ignored (dyndns2 is a forward-only consumer
 // protocol; the firewall owns its own name).
 func (b *dyndns2Backend) UpsertLease(ctx context.Context, rec LeaseDNSRecord) error {
+	q := url.Values{}
+	q.Set("hostname", rec.FQDN)
+	q.Set("myip", rec.Addr.Unmap().String())
+	return b.update(ctx, q)
+}
+
+// DeleteLease withdraws the firewall's own A/AAAA via the de-facto dyndns2
+// offline verb (#2772): the SAME update GET, this time with `offline=YES`, which
+// instructs the provider to take the hostname offline (stop resolving it / serve
+// the provider's offline redirect). dyndns2 has no separate "remove the RR"
+// call, so `offline=YES` is the portable withdraw the well-known dyndns2
+// services (dyn, no-ip, dns-o-matic) implement; the response is parsed exactly
+// like an upsert, so a provider failure propagates as a non-nil error and the
+// Surface A engine keeps ownership for retry rather than reporting a false
+// withdraw and orphaning the public record.
+func (b *dyndns2Backend) DeleteLease(ctx context.Context, rec LeaseDNSRecord) error {
+	q := url.Values{}
+	q.Set("hostname", rec.FQDN)
+	// myip is still required by some providers' parsers; send the address being
+	// withdrawn so the request is well-formed. offline=YES is the operative verb.
+	q.Set("myip", rec.Addr.Unmap().String())
+	q.Set("offline", "YES")
+	return b.update(ctx, q)
+}
+
+// update issues one dyndns2 GET against the resolved endpoint with the supplied
+// query, then parses the body verdict. Shared by UpsertLease and DeleteLease so
+// both paths apply identical auth, status, and response-keyword handling.
+func (b *dyndns2Backend) update(ctx context.Context, q url.Values) error {
 	u, err := url.Parse(b.endpoint)
 	if err != nil {
 		return fmt.Errorf("ddns dyndns2: bad endpoint: %w", err)
 	}
-	q := u.Query()
-	q.Set("hostname", rec.FQDN)
-	q.Set("myip", rec.Addr.Unmap().String())
-	u.RawQuery = q.Encode()
+	// Merge the caller's parameters onto any the endpoint already carries.
+	base := u.Query()
+	for k, vs := range q {
+		base[k] = vs
+	}
+	u.RawQuery = base.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -135,20 +173,6 @@ func (b *dyndns2Backend) UpsertLease(ctx context.Context, rec LeaseDNSRecord) er
 		return fmt.Errorf("ddns dyndns2: %s: unexpected status %d", b.name, code)
 	}
 	return parseDyndns2Response(string(body), b.name)
-}
-
-// DeleteLease is a no-op for dyndns2: the protocol has no portable delete verb,
-// and pointing the record at a bogus address (some providers' offline trick) is
-// a foot-gun we will not do implicitly. The Surface A engine treats a no-op
-// backend's withdraw as a non-success that keeps ownership for retry, but a
-// dyndns2 binding removed from config has nothing safe to do remotely, so we log
-// once and report success (no ownership orphan: the operator removed the binding
-// knowingly; the record ages out via the provider's record TTL / liveness reap).
-func (b *dyndns2Backend) DeleteLease(_ context.Context, rec LeaseDNSRecord) error {
-	// Intentionally not isNopUpdater (that would make withdrawOwnedLocked keep
-	// the ownership entry forever). dyndns2 cannot delete; report success so the
-	// ownership entry is dropped and the engine stops trying.
-	return nil
 }
 
 // parseDyndns2Response maps a dyndns2 response body's first status keyword to a

--- a/pkg/ddns/backend_generic.go
+++ b/pkg/ddns/backend_generic.go
@@ -2,6 +2,7 @@ package ddns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -135,9 +136,25 @@ func (b *genericBackend) UpsertLease(ctx context.Context, rec LeaseDNSRecord) er
 	return fmt.Errorf("ddns generic: %s: response did not match success substring(s) %v", b.name, b.okSubstr)
 }
 
-// DeleteLease is a no-op for the generic backend: a templated update protocol
-// has no portable delete verb. Report success so a removed binding does not wedge
-// the engine (the record ages out via its TTL / the provider's liveness reap).
-func (b *genericBackend) DeleteLease(_ context.Context, _ LeaseDNSRecord) error {
-	return nil
+// errGenericDeleteUnsupported marks the generic backend's lack of a portable
+// withdraw verb (#2772). A single inadyn-style update template carries no notion
+// of "remove this record", and xpf exposes no per-provider delete template, so
+// there is nothing safe to send. Wrapped (never bare) so a caller can errors.Is
+// it and surface the abandoned record rather than treat it as a generic failure.
+var errGenericDeleteUnsupported = errors.New("ddns generic: backend has no delete/withdraw operation")
+
+// DeleteLease FAILS for the generic backend (#2772): a templated update protocol
+// has no portable delete verb, and xpf has no per-provider delete template, so
+// the backend cannot actually clear the record. The previous implementation was
+// a no-op that returned nil — the Surface A engine then dropped local ownership
+// while the public record kept resolving forever. Returning a non-nil error
+// makes the engine increment deleteFail and KEEP the ownership entry, so the
+// stale/abandoned record stays operator-visible (it shows up as a withdraw that
+// did not complete) instead of being silently reported as withdrawn. An operator
+// who needs an actual withdraw must use a backend that supports one (dyndns2's
+// offline verb, cloudflare/route53 DELETE, or rfc2136) and clear the record at
+// the provider out of band.
+func (b *genericBackend) DeleteLease(_ context.Context, rec LeaseDNSRecord) error {
+	return fmt.Errorf("ddns generic: %s: cannot withdraw %s %s: %w",
+		b.name, rec.ForwardType, rec.FQDN, errGenericDeleteUnsupported)
 }

--- a/pkg/ddns/backend_http_test.go
+++ b/pkg/ddns/backend_http_test.go
@@ -2,6 +2,7 @@ package ddns
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
@@ -97,6 +98,96 @@ func TestDyndns2NameEndpointResolution(t *testing.T) {
 	// No server + unknown name → error (fall back to no-op at the manager).
 	if _, err := newDyndns2Backend(&config.DDNSProvider{Name: "weird", Backend: "dyndns2"}); err == nil {
 		t.Fatal("unknown provider with no server must error")
+	}
+}
+
+// TestDyndns2DeleteIssuesOfflineRequest is the #2772 FAIL-ON-REVERT guard for
+// the dyndns2 withdraw path. The previous DeleteLease was a no-op that returned
+// nil WITHOUT contacting the provider, so the engine dropped ownership while the
+// public record kept resolving. This test asserts DeleteLease actually issues
+// the dyndns2 offline GET (offline=YES + the hostname) and that a provider
+// failure verdict propagates as an error. If DeleteLease is reverted to
+// `return nil`, the server handler is never hit (got=="") and the test fails.
+func TestDyndns2DeleteIssuesOfflineRequest(t *testing.T) {
+	var gotPath, gotAuth string
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		gotPath = r.URL.String()
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("good\n"))
+	}))
+	defer srv.Close()
+
+	b, err := newDyndns2Backend(&config.DDNSProvider{
+		Name: "test", Backend: "dyndns2", Server: srv.URL,
+		Username: "u1", Password: config.Secret("p1"),
+	})
+	if err != nil {
+		t.Fatalf("newDyndns2Backend: %v", err)
+	}
+	if err := b.DeleteLease(context.Background(), hostRecord(t, "wan.example.net", "203.0.113.5")); err != nil {
+		t.Fatalf("DeleteLease good: %v", err)
+	}
+	// FAIL-ON-REVERT: a no-op DeleteLease never reaches the server.
+	if hits == 0 {
+		t.Fatal("DeleteLease did not issue any HTTP request — withdraw is a silent no-op (regression #2772)")
+	}
+	if !strings.Contains(gotPath, "offline=YES") {
+		t.Fatalf("dyndns2 withdraw must send offline=YES; got %q", gotPath)
+	}
+	if !strings.Contains(gotPath, "hostname=wan.example.net") {
+		t.Fatalf("dyndns2 withdraw must name the hostname; got %q", gotPath)
+	}
+	if gotAuth == "" {
+		t.Fatal("dyndns2 withdraw must send Basic auth header")
+	}
+}
+
+// TestDyndns2DeletePropagatesProviderFailure asserts that a provider error
+// verdict on the withdraw GET (not a silent success) propagates as a non-nil
+// error so the Surface A engine keeps ownership for retry.
+func TestDyndns2DeletePropagatesProviderFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("badauth\n"))
+	}))
+	defer srv.Close()
+	b, err := newDyndns2Backend(&config.DDNSProvider{
+		Name: "test", Backend: "dyndns2", Server: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("newDyndns2Backend: %v", err)
+	}
+	if err := b.DeleteLease(context.Background(), hostRecord(t, "wan.example.net", "203.0.113.5")); err == nil {
+		t.Fatal("dyndns2 withdraw with a badauth verdict must return an error, not silent success")
+	}
+}
+
+// TestGenericDeleteFailsNotSilentSuccess is the #2772 FAIL-ON-REVERT guard for
+// the generic backend's withdraw path. The generic templated protocol has no
+// portable delete verb, so DeleteLease must FAIL (so the engine keeps ownership
+// and the abandoned record stays operator-visible) rather than return nil and
+// silently drop ownership while the public record persists. If DeleteLease is
+// reverted to `return nil`, this test fails.
+func TestGenericDeleteFailsNotSilentSuccess(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_, _ = w.Write([]byte("good\n"))
+	}))
+	defer srv.Close()
+	b, err := newGenericBackend(&config.DDNSProvider{
+		Name: "g", Backend: "generic", URLTemplate: srv.URL + "/u?h=%h&i=%i",
+	})
+	if err != nil {
+		t.Fatalf("newGenericBackend: %v", err)
+	}
+	err = b.DeleteLease(context.Background(), hostRecord(t, "h.example.net", "198.51.100.7"))
+	if err == nil {
+		t.Fatal("generic DeleteLease must FAIL (no portable delete verb), not report silent success (regression #2772)")
+	}
+	if !errors.Is(err, errGenericDeleteUnsupported) {
+		t.Fatalf("generic DeleteLease error must wrap errGenericDeleteUnsupported; got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #2772

## Problem
For the dyndns2 and generic HTTP DDNS backends, `DeleteLease` was a no-op that returned `nil` without performing any remote operation. Surface A's `withdrawOwnedLocked` drops local ownership **only** on a nil-error `DeleteLease`, so when xpf withdrew a name (scope shrink, binding removed, address lost) it recorded the withdraw as done while the public record kept resolving forever. The original comments assumed a provider TTL / liveness reap, but that is not a portable dyndns2/generic contract.

## Fix
- **dyndns2**: `DeleteLease` now performs the de-facto dyndns2 withdraw verb — the same update GET with `offline=YES` (dyn / no-ip / dns-o-matic honour this by taking the hostname offline). Request/auth/status/verdict logic refactored into a shared `update(ctx, q)` helper used by both `UpsertLease` and `DeleteLease`, so a provider failure on withdraw propagates as a non-nil error and the engine keeps ownership for retry.
- **generic**: a single inadyn-style update template has no portable delete verb and xpf exposes no per-provider delete template, so `DeleteLease` now **FAILS** with `errGenericDeleteUnsupported` instead of returning `nil`. The engine increments `deleteFail` and keeps the ownership entry, so the abandoned record stays operator-visible.

Scope is provider-source only (`backend_dyndns2.go`, `backend_generic.go`, `backend_http_test.go`). No shared file (`surface_a.go`, `provider.go`, config types) touched — the existing withdraw-keeps-ownership-on-error contract does the rest.

## Fail-on-revert proof
Reverted both `DeleteLease` bodies to `return nil` and confirmed all three new tests go RED:
```
--- FAIL: TestDyndns2DeleteIssuesOfflineRequest (0.00s)
    DeleteLease did not issue any HTTP request — withdraw is a silent no-op (regression #2772)
--- FAIL: TestDyndns2DeletePropagatesProviderFailure (0.00s)
    dyndns2 withdraw with a badauth verdict must return an error, not silent success
--- FAIL: TestGenericDeleteFailsNotSilentSuccess (0.00s)
    generic DeleteLease must FAIL (no portable delete verb), not report silent success (regression #2772)
```
Restored the fix → GREEN.

## Gates
- `go build ./...` — pass
- `gofmt -l pkg/ddns/` — clean
- `go vet ./pkg/ddns/...` — pass
- `go test ./pkg/ddns/...` — pass

## Docs
`pkg/ddns/README.md` — per-backend withdraw semantics table + the no-op-orphans-record contract note; `_Log.md` dated entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi