### PR TITLE
ddns/route53: make already-gone DELETE idempotent (unwedge Surface A)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-06-25 — #2771: route53 already-gone DELETE is idempotent (Surface A unwedge)
+
+- **Timestamp**: 2026-06-25
+- **Action**: A Route 53 Surface A withdraw against an already-removed
+  record failed and never converged: `backend_route53.go` `DeleteLease`
+  sent a strict DELETE and a no-such-record response (HTTP 400
+  `InvalidChangeBatch` "... but it was not found") propagated as non-nil.
+  Surface A's `withdrawOwnedLocked` drops ownership only on a nil return,
+  so the withdraw wedged and retried forever while `show system services
+  dynamic-dns` reported an owned record that no longer existed. Fix: made
+  `DeleteLease` IDEMPOTENT — `change` now returns the parsed Route 53
+  error code+message, and `r53DeleteAlreadyGone` classifies the
+  already-gone case (requires BOTH `Code=InvalidChangeBatch` AND a "not
+  found" marker) as success (nil) so ownership releases. Mirrors the
+  rfc2136 backend's NXRRSET/NXDOMAIN idempotent delete (`sendRemove`).
+  Genuine transient/auth/throttle failures (`SignatureDoesNotMatch`, 5xx,
+  429, a non-"not found" `InvalidChangeBatch`) STILL return non-nil so the
+  engine retries — only the already-gone case is swallowed.
+- **Fail-on-revert proof**: copied `backend_route53.go` aside, neutered
+  the `r53DeleteAlreadyGone` branch in `DeleteLease` (return the raw
+  err) → `TestRoute53DeleteAlreadyGoneIdempotent` FAILED ("already-gone
+  DELETE must be idempotent success (nil), got ... InvalidChangeBatch:
+  [Tried to delete resource record set ...] but it was not found ...
+  unexpected status 400"); the genuine-error subtests
+  (`TestRoute53DeleteGenuineErrorRetries`) stayed GREEN through the revert
+  (no over-swallow). Restored the file → all GREEN.
+- **Gates**: `go build ./...` OK; `gofmt -l pkg/ddns/` clean; `go vet
+  ./pkg/ddns/...` clean; `go test ./pkg/ddns/...` PASS.
+- **File(s)**: `pkg/ddns/backend_route53.go`,
+  `pkg/ddns/backend_route53_test.go`, `pkg/ddns/README.md`, `_Log.md`.
+
 ## 2026-06-25 — #2773: wire validateCheckIPURL (dead code) into commit + runtime
 
 - **Timestamp**: 2026-06-25

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -128,6 +128,21 @@ no change in those packages:
   live backend withdraws it for real. `reconcileOnceLocked` / `withdrawAllLocked`
   swallow the sentinel so a legitimate disabled-with-no-backend pass is not
   marked failed. Mirrors the Surface A `withdrawOwnedLocked` precedent.
+- **Route 53 already-gone DELETE is idempotent (#2771)** — `backend_route53.go`
+  `DeleteLease` treats a Route 53 DELETE of an already-absent record as success
+  (nil), mirroring the rfc2136 backend's NXRRSET/NXDOMAIN handling
+  (`sendRemove`). Route 53 reports an already-gone delete as HTTP 400
+  `Code=InvalidChangeBatch` with a per-change message `... but it was not
+  found`; `r53DeleteAlreadyGone` requires BOTH the `InvalidChangeBatch` code AND
+  the "not found" marker, so a genuinely malformed/conflicting batch is NOT
+  mistaken for a no-op. Without this, a withdraw against a manually-removed (or
+  already-withdrawn-but-ack-lost) record returned non-nil forever; Surface A's
+  `withdrawOwnedLocked` only drops ownership on a nil return, so the withdraw
+  wedged and retried indefinitely while `show system services dynamic-dns`
+  reported an owned record that no longer existed. Genuine
+  transient/auth/throttle failures (`SignatureDoesNotMatch`, 5xx, 429, a
+  non-"not found" `InvalidChangeBatch`) STILL return non-nil so the engine
+  keeps retrying — only the already-gone case is swallowed.
 - **Shared-DHCID partial dual-stack teardown (#2700)** — the RFC 4701 DHCID
   digest folds in `client-identity || FQDN` only (NOT the address), so a
   dual-stack client (an A + an AAAA under one FQDN, same client id) shares ONE

--- a/pkg/ddns/backend_route53.go
+++ b/pkg/ddns/backend_route53.go
@@ -146,16 +146,19 @@ func buildChangeBatch(action string, rec LeaseDNSRecord) ([]byte, error) {
 	return append([]byte(xml.Header), out...), nil
 }
 
-// change issues a signed ChangeResourceRecordSets with the given action.
-func (b *route53Backend) change(ctx context.Context, action string, rec LeaseDNSRecord) error {
+// change issues a signed ChangeResourceRecordSets with the given action. When
+// the request fails, the parsed Route 53 error code/message (never the creds)
+// is returned alongside the typed transport error so DELETE-path idempotency
+// classification (r53DeleteAlreadyGone) can inspect the on-wire code/message.
+func (b *route53Backend) change(ctx context.Context, action string, rec LeaseDNSRecord) (errCode, errMsg string, err error) {
 	body, err := buildChangeBatch(action, rec)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 	path := "/" + route53APIVersion + "/hostedzone/" + b.zoneID + "/rrset/"
 	req, err := http.NewRequest(http.MethodPost, b.endpoint+path, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("ddns route53: build request: %w", err)
+		return "", "", fmt.Errorf("ddns route53: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/xml")
 	req.Header.Set("User-Agent", "xpf-ddns/1.0")
@@ -163,30 +166,70 @@ func (b *route53Backend) change(ctx context.Context, action string, rec LeaseDNS
 
 	code, raw, err := doRequest(ctx, b.client, req)
 	if err != nil {
-		return err
+		return "", "", err
 	}
 	if cerr := classifyHTTPStatus(code); cerr != nil {
 		// Surface the Route 53 error code/message when present (never the creds).
 		var e r53ErrorXML
 		if xml.Unmarshal(raw, &e) == nil && e.Error.Code != "" {
-			return fmt.Errorf("ddns route53: %s: %s: %s: %w", b.name, e.Error.Code, e.Error.Message, cerr)
+			return e.Error.Code, e.Error.Message, fmt.Errorf("ddns route53: %s: %s: %s: %w", b.name, e.Error.Code, e.Error.Message, cerr)
 		}
-		return fmt.Errorf("ddns route53: %s: %w", b.name, cerr)
+		return "", "", fmt.Errorf("ddns route53: %s: %w", b.name, cerr)
 	}
-	return nil
+	return "", "", nil
 }
 
 // UpsertLease publishes the A/AAAA via a Route 53 UPSERT (create-or-replace).
 func (b *route53Backend) UpsertLease(ctx context.Context, rec LeaseDNSRecord) error {
-	return b.change(ctx, "UPSERT", rec)
+	_, _, err := b.change(ctx, "UPSERT", rec)
+	return err
 }
 
 // DeleteLease withdraws the A/AAAA via a Route 53 DELETE. Route 53 requires the
 // DELETE to match the existing record's TTL + value; we re-derive both from the
 // owned record the engine passes (the sole-delete-authority boundary), so the
-// delete targets exactly what we published. A NoSuch... error (already gone) is
-// not specially handled here — the engine logs + retries, and a forced re-add
-// next cycle reconverges; over-deletion is impossible (exact match required).
+// delete targets exactly what we published; over-deletion is impossible (exact
+// match required).
+//
+// IDEMPOTENT delete (#2771): if the record is already gone (manually removed,
+// or a prior withdraw that did land but whose ack was lost), Route 53 rejects
+// the DELETE with HTTP 400 InvalidChangeBatch "... but it was not found".
+// Treat that as success (nil) so Surface A's withdrawOwnedLocked drops
+// ownership instead of wedging on a withdraw that can never converge. This
+// mirrors the rfc2136 backend, which treats NXRRSET/NXDOMAIN as a benign
+// idempotent delete (backend_rfc2136.go sendRemove). A genuine
+// transient/auth/throttle failure (SignatureDoesNotMatch, 5xx, 429, …) still
+// returns non-nil so the engine retries — only the already-gone case is
+// swallowed.
 func (b *route53Backend) DeleteLease(ctx context.Context, rec LeaseDNSRecord) error {
-	return b.change(ctx, "DELETE", rec)
+	errCode, errMsg, err := b.change(ctx, "DELETE", rec)
+	if err != nil && r53DeleteAlreadyGone(errCode, errMsg) {
+		return nil
+	}
+	return err
+}
+
+// r53DeleteAlreadyGone reports whether a Route 53 DELETE failure means the
+// target record set was already absent (an idempotent no-op), as opposed to a
+// real failure that must be retried.
+//
+// Route 53 reports a delete of a non-existent record as a single envelope:
+// HTTP 400, Code=InvalidChangeBatch, with a per-change message of the form
+//
+//	[Tried to delete resource record set [name='wan.example.net.', type='A']
+//	 but it was not found]
+//
+// The Code alone (InvalidChangeBatch) is NOT sufficient — it also covers
+// genuine batch errors (e.g. an UPSERT whose value collides). We additionally
+// require the "but it was not found" / "was not found" marker, so a malformed
+// or conflicting batch (which must keep retrying / surface as a conflict) is
+// never mistaken for an idempotent delete.
+func r53DeleteAlreadyGone(code, msg string) bool {
+	if !strings.EqualFold(strings.TrimSpace(code), "InvalidChangeBatch") {
+		return false
+	}
+	m := strings.ToLower(msg)
+	return strings.Contains(m, "but it was not found") ||
+		strings.Contains(m, "was not found") ||
+		strings.Contains(m, "not found")
 }

--- a/pkg/ddns/backend_route53_test.go
+++ b/pkg/ddns/backend_route53_test.go
@@ -113,6 +113,74 @@ func TestRoute53ErrorSurfacesCode(t *testing.T) {
 	}
 }
 
+// TestRoute53DeleteAlreadyGoneIdempotent is the #2771 fail-on-revert guard.
+// When the record is already absent at Route 53, a DELETE returns HTTP 400
+// InvalidChangeBatch "... but it was not found". DeleteLease MUST treat that as
+// idempotent success (nil) so Surface A drops ownership instead of wedging the
+// withdraw forever. Reverting the idempotency makes the already-gone error
+// propagate as a non-nil failure and this test goes RED.
+func TestRoute53DeleteAlreadyGoneIdempotent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><ErrorResponse><Error><Code>InvalidChangeBatch</Code>` +
+			`<Message>[Tried to delete resource record set [name='wan.example.net.', type='A'] but it was not found]</Message>` +
+			`</Error></ErrorResponse>`))
+	}))
+	defer srv.Close()
+	b := newR53TestBackend(t, srv)
+	if err := b.DeleteLease(context.Background(), hostRecord(t, "wan.example.net", "203.0.113.5")); err != nil {
+		t.Fatalf("already-gone DELETE must be idempotent success (nil), got %v", err)
+	}
+}
+
+// TestRoute53DeleteGenuineErrorRetries asserts the idempotency does NOT
+// over-swallow: a real failure (auth, throttle, or a non-"not found"
+// InvalidChangeBatch) must STILL return non-nil so the engine keeps retrying.
+func TestRoute53DeleteGenuineErrorRetries(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		code, msg  string
+		wantSubstr string
+	}{
+		{
+			name: "auth", status: http.StatusForbidden,
+			code: "SignatureDoesNotMatch", msg: "nope",
+			wantSubstr: "SignatureDoesNotMatch",
+		},
+		{
+			name: "throttle", status: http.StatusTooManyRequests,
+			code: "Throttling", msg: "Rate exceeded",
+			wantSubstr: "Throttling",
+		},
+		{
+			// InvalidChangeBatch that is NOT an already-gone delete (a genuine
+			// conflicting/malformed batch) must keep retrying / surface.
+			name: "invalid-batch-not-gone", status: http.StatusBadRequest,
+			code: "InvalidChangeBatch", msg: "[RRSet with DNS name ... is not permitted in zone]",
+			wantSubstr: "InvalidChangeBatch",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(`<?xml version="1.0"?><ErrorResponse><Error><Code>` +
+					tc.code + `</Code><Message>` + tc.msg + `</Message></Error></ErrorResponse>`))
+			}))
+			defer srv.Close()
+			b := newR53TestBackend(t, srv)
+			err := b.DeleteLease(context.Background(), hostRecord(t, "wan.example.net", "203.0.113.5"))
+			if err == nil {
+				t.Fatalf("genuine %s failure must NOT be swallowed (want non-nil)", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantSubstr, err)
+			}
+		})
+	}
+}
+
 func TestRoute53MissingCredsConstructError(t *testing.T) {
 	if _, err := newRoute53Backend(&config.DDNSProvider{Name: "r", Backend: "route53", HostedZoneID: "Z"}); err == nil {
 		t.Fatal("missing keys must error")


### PR DESCRIPTION
Closes #2771

## Problem

A Route 53 Surface A withdraw against an already-removed record failed and never converged. `backend_route53.go` `DeleteLease` sent a strict DELETE; a no-such-record response (HTTP 400 `InvalidChangeBatch` "... but it was not found") propagated as a non-nil error. Surface A's `withdrawOwnedLocked` drops ownership ONLY on a nil return, so the withdraw wedged and retried forever — `show system services dynamic-dns` kept reporting an owned record that no longer existed, and removed bindings never converged. The rfc2136 backend already treats NXRRSET/NXDOMAIN as a benign idempotent delete, so the two backends had inconsistent ownership semantics.

## Fix

Make `DeleteLease` idempotent. `change()` now returns the parsed Route 53 error code+message alongside the typed transport error; `r53DeleteAlreadyGone` classifies the already-gone case as success (nil) so ownership releases — mirroring the rfc2136 `sendRemove` posture.

- Requires BOTH `Code=InvalidChangeBatch` AND a "not found" marker, so a genuinely malformed/conflicting batch is never mistaken for a no-op.
- Genuine transient/auth/throttle failures (`SignatureDoesNotMatch`, 5xx, 429, a non-"not found" `InvalidChangeBatch`) STILL return non-nil so the engine keeps retrying.
- `UpsertLease` is behaviorally unchanged (ignores the new return values).

## Scope

`pkg/ddns/backend_route53.go` + its test only, plus `pkg/ddns/README.md` and `_Log.md` docs. Did NOT touch surface_a.go / provider.go / config types / other backends.

## Fail-on-revert proof

`TestRoute53DeleteAlreadyGoneIdempotent` drives the real backend against an httptest fake returning the `InvalidChangeBatch` "... but it was not found" body and asserts `DeleteLease` returns nil. `TestRoute53DeleteGenuineErrorRetries` asserts auth / throttle / non-"not found"-`InvalidChangeBatch` failures STILL return non-nil (no over-swallow).

Proven via copy-restore: neutering the `r53DeleteAlreadyGone` branch in `DeleteLease`:

```
--- FAIL: TestRoute53DeleteAlreadyGoneIdempotent (0.00s)
    backend_route53_test.go:132: already-gone DELETE must be idempotent success (nil),
    got ddns route53: r53: InvalidChangeBatch: [Tried to delete resource record set
    [name='wan.example.net.', type='A'] but it was not found]: ddns http: unexpected status 400
```

The genuine-error subtests stayed GREEN through the revert. Restored → all GREEN.

## Gates

`go build ./...` OK; `gofmt -l pkg/ddns/` clean; `go vet ./pkg/ddns/...` clean; `go test ./pkg/ddns/...` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi