### PR TITLE
ddns/surface-a: release the manager mutex across provider I/O (#2778)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-06-25 — #2778: ddns/surface-a no longer holds the manager mutex across provider I/O
+
+- **Timestamp**: 2026-06-25
+- **Action**: Surface A provider I/O (`UpsertLease`/`DeleteLease`, 15s HTTP
+  client timeout) ran UNDER `SurfaceAManager.mu`, so a slow/hung provider
+  blocked every other Surface A op — `StatusViews` (operator `show`), `Stats`
+  (Prometheus scrape), and other scopes' reconcile work — for up to 15s exactly
+  while the subsystem was unhealthy. Added `providerIO(fn)`: it unlocks `m.mu`,
+  runs the one wire call, and re-acquires the lock (`defer m.mu.Lock()` so a
+  panicking backend cannot leave the deferred `Reconcile` Unlock unbalanced).
+  `publishLocked` now durably write-aheads ownership BEFORE the wire add (crash
+  in the unlocked window still finds the record owned → next pass converges),
+  releases the lock for the `UpsertLease`, then re-acquires and commits with a
+  racing-op CAS: if a concurrent op changed the owned record while unlocked, the
+  stale result is NOT rolled back / advanced (newer ownership wins,
+  `errSurfaceAPublishRaced` tells `reconcileScopeLocked` to leave the runtime
+  cache + backoff untouched). `withdrawOwnedLocked` releases the lock for the
+  `DeleteLease`, then drops ownership only if the live entry is STILL the exact
+  record it deleted (a concurrent re-publish with a new address keeps its
+  ownership, never orphaned). All preserved invariants: never-blackhole,
+  write-ahead-before-add (#2662), withdraw-keeps-ownership-on-error/no-op-backend
+  (#2691 P2 M1), per-RG HA gate (#2664). The daemon single-flight guard
+  (`surfaceAReconcileInFlight`) already serializes full passes; the CAS keeps the
+  contract correct regardless.
+- **File(s)**: `pkg/ddns/surface_a.go` (`providerIO` helper, lock-release +
+  racing-op CAS in `publishLocked`/`withdrawOwnedLocked`, `errSurfaceAPublishRaced`
+  sentinel), `pkg/ddns/surface_a_lockio_test.go` (new fail-on-revert + race
+  tests), `pkg/ddns/README.md` (P2 lock-discipline bullet).
+- **Fail-on-revert proof**: copied `surface_a.go` aside, reverted `providerIO`
+  to call `fn()` with the lock HELD (the #2778 bug), ran the three new tests:
+  all three FAILED with a 2s bounded-wait timeout —
+  `TestSurfaceALockNotHeldDuringUpsert` (StatusViews blocked behind a blocked
+  UpsertLease), `TestSurfaceALockNotHeldDuringDelete` (StatusViews blocked behind
+  a blocked DeleteLease), `TestSurfaceAPublishRaceDoesNotClobberNewerState`
+  (Reconcile #2 blocked behind #1's lock-held publish). Restored from the copy;
+  all pass with the fix. `go build ./...`, `gofmt -l` (clean on touched files),
+  `go vet`, `go test -race ./pkg/ddns/... ./pkg/daemon/...` all green.
+
 ## 2026-06-25 — #2774: ddns/checkip public-address gate covers the full IANA special-purpose registry
 
 - **Timestamp**: 2026-06-25

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -319,6 +319,29 @@ its OWN learned address — on top of the SAME spine, without forking the engine
 - **HA gate** is the SAME per-RG `ScopeGate` (a router record on a reth/virtual
   interface publishes only on the RG master; stop-writing-never-withdraw
   otherwise). Standalone (nil gate) always publishes.
+- **Lock discipline — I/O is NEVER performed under the manager mutex (#2778).**
+  `SurfaceAManager.mu` guards ALL manager state (the durable ownership store, the
+  per-scope runtime cache, the counters), but it is RELEASED across every
+  provider network call (`UpsertLease`/`DeleteLease`, which run with a 15s HTTP
+  client timeout). A slow or hung provider must NOT block `StatusViews`/`Stats`
+  (operator `show` + Prometheus scrapes) or other scopes' reconcile work — that
+  would freeze the control plane for up to 15s exactly while the subsystem is
+  unhealthy. The pattern (`providerIO`): under the lock, the pass snapshots the
+  exact intent (resolved backend + record) and durably write-aheads the
+  ownership BEFORE the wire op (so a crash in the unlocked window still finds the
+  record owned and converges next pass); it then RELEASES the lock for the wire
+  call and RE-ACQUIRES it to commit the result. The commit is guarded by a
+  racing-op re-validation (CAS): if a concurrent op changed the scope's owned
+  record while the lock was released, the stale wire result does NOT clobber the
+  newer truth — a stale publish-rollback is skipped (the newer ownership wins,
+  signalled via `errSurfaceAPublishRaced` so the runtime cache is not advanced),
+  and a stale withdraw drops ownership only if the live entry is STILL the exact
+  record it deleted (a concurrent re-publish with a new address keeps its
+  ownership, never orphaned). The single-flight guard in the daemon
+  (`surfaceAReconcileInFlight`) means two full passes never run concurrently, but
+  the CAS keeps the contract correct regardless. Proven in
+  `surface_a_lockio_test.go` (a blocking provider + a concurrent `StatusViews`
+  that would hang if the lock were held; fail-on-revert).
 - **Operator surfaces:** `show services dynamic-dns [detail]` (CLI + gRPC), the
   `xpf_ddns_surface_a_*` Prometheus family, and `SurfaceAManager.StatusViews()`
   (per-scope published address + last-published time + last error).

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -164,6 +164,19 @@ type SurfaceAStatusView struct {
 // DHCP-lease Manager (different ownership semantics — self-owned vs DHCID — and
 // a different state file), but it drives the SAME Backend interface and the
 // SAME record/scope/durability primitives.
+//
+// Lock discipline (#2778): m.mu guards ALL manager state — the durable store,
+// the runtime cache, and the counters — but it is NEVER held across provider
+// network I/O (UpsertLease/DeleteLease run with a 15s client timeout). A pass
+// snapshots the exact intent under the lock (the resolved backend + record +
+// the durably-written ownership write-ahead), RELEASES the lock to perform the
+// wire op, then RE-ACQUIRES it to commit the result, re-validating that the
+// scope's desired ownership has not changed while unlocked (the racing-op CAS).
+// This keeps `show system services dynamic-dns`, metric scrapes, and other
+// scopes responsive while one provider is slow or hung. The single-flight guard
+// in the daemon (surfaceAReconcileInFlight) means two full passes never run
+// concurrently, but StatusViews/Stats and any future caller must not block on
+// provider I/O — hence the lock is released around every wire call.
 type SurfaceAManager struct {
 	mu    sync.Mutex
 	state *ddnsState // durable ownership store (interface-ddns-state.json)
@@ -343,6 +356,19 @@ func (m *SurfaceAManager) seedFromStore() {
 	}
 }
 
+// providerIO performs ONE provider network call (UpsertLease/DeleteLease) with
+// m.mu RELEASED, then re-acquires the lock before returning (#2778). The caller
+// MUST hold m.mu on entry and will hold it again on return. Releasing the lock
+// around the (up-to-15s) wire op is the whole point: a slow or hung provider
+// must not block StatusViews/Stats/other-scope reconcile work. The function is
+// careful to re-acquire the lock even if fn panics, so the deferred Unlock in
+// Reconcile stays balanced (a panicking backend would otherwise double-unlock).
+func (m *SurfaceAManager) providerIO(fn func() error) error {
+	m.mu.Unlock()
+	defer m.mu.Lock()
+	return fn()
+}
+
 // Reconcile drives one Surface A reconcile pass over the configured scopes
 // (plan §5.5/§5.6). For each scope it: observes the current address; applies
 // the per-RG HA gate; runs change-detection + forced-refresh + error backoff;
@@ -502,6 +528,16 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 			// sentinel (not a pass error).
 			return nil
 		}
+		if errors.Is(err, errSurfaceAPublishRaced) {
+			// The wire add succeeded but a concurrent op changed the scope's
+			// ownership while the lock was released for the I/O (#2778). Do NOT
+			// advance the runtime cache to a value the live ownership no longer
+			// agrees with, and do NOT arm backoff (the wire op worked). The next
+			// reconcile converges the current desired state. Note: `rt` here may be
+			// the entry a concurrent withdraw deleted from m.runtime — advancing it
+			// would resurrect a stale map entry, so we swallow without touching rt.
+			return nil
+		}
 		m.recordScopeError(rt, sc, err, now)
 		return err
 	}
@@ -530,13 +566,32 @@ const surfaceAIdentity = "router-self"
 // counted no-backend skip that re-attempts next cycle (#2691 P3 review MAJOR).
 var errSurfaceANoBackend = errors.New("ddns surface-a: no live backend for provider")
 
+// errSurfaceAPublishRaced is returned by publishLocked when the wire add
+// SUCCEEDED but a concurrent op changed the scope's owned record while the lock
+// was released for the I/O (#2778). It is NOT a failure (the wire op worked, the
+// counter advanced) and NOT a clean success for THIS desired state — the live
+// ownership now reflects a newer intent. reconcileScopeLocked treats it as a
+// no-op for the runtime cache (do not advance lastAddr/lastPublished, do not arm
+// backoff); the next reconcile converges whatever the current desired state is.
+var errSurfaceAPublishRaced = errors.New("ddns surface-a: publish raced a concurrent ownership change")
+
 // publishLocked publishes the scope's record through the resolved Backend and
 // records ownership write-ahead (the same durability discipline as the lease
 // path, #2662). The ownership key fixes Address="" so a scope owns exactly one
 // record: an address change REPLACES the rdata via the backend's atomic
 // in-place self-owned replace (rfc2136Updater.sendAddSelfOwned: a single UPDATE
 // that delete-RRsets our forward type then inserts the new rdata), never a
-// withdraw-then-add that would blackhole. Caller holds m.mu.
+// withdraw-then-add that would blackhole.
+//
+// Lock discipline (#2778): the caller holds m.mu on entry and exit, but the
+// lock is RELEASED around the wire UpsertLease (via providerIO) so a slow/hung
+// provider cannot block other manager ops. Everything that touches manager
+// state — backend/record construction, the ownership write-ahead + save, the
+// counters, the last-published cache — happens UNDER the lock; only the wire
+// call is unlocked. After the unlocked wire op the result is committed under
+// the re-acquired lock with a racing-op re-validation: if a concurrent op
+// changed the scope's owned record while we were unlocked, the stale wire
+// result is NOT allowed to clobber the newer ownership (see below).
 func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, addr netip.Addr, now time.Time) error {
 	backend, err := m.backendFor(sc)
 	if err != nil {
@@ -599,23 +654,58 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 		return fmt.Errorf("ddns surface-a: cannot durably record ownership before publish: %w", err)
 	}
 
-	if err := backend.UpsertLease(ctx, rec); err != nil {
+	// Perform the wire UpsertLease with m.mu RELEASED (#2778): the 15s-timeout
+	// provider call must not block StatusViews/Stats/other scopes. The ownership
+	// write-ahead above is already durable, so a crash during the unlocked window
+	// still finds the record owned and the next reconcile converges it.
+	wireErr := m.providerIO(func() error { return backend.UpsertLease(ctx, rec) })
+
+	// Re-acquired the lock. Re-validate that THIS publish's write-ahead is still
+	// the live owned record before acting on the (possibly stale) wire result. A
+	// concurrent op (a racing reconcile, a withdraw, a removed-binding cleanup)
+	// could have replaced or deleted the ownership entry while we were unlocked;
+	// if so, the newer state wins and we must NOT clobber it with a rollback or a
+	// stale success — just report the wire outcome and let the next pass converge.
+	cur, stillOwned := m.state.get(sc.Key, surfaceAIdentity, "")
+	stale := !stillOwned || cur.AddrText != ow.AddrText
+	if wireErr != nil {
 		// Hard add failure: the record is NOT live with the new rdata. Restore
 		// the previous durable ownership (the old address is still live) so we
 		// do not claim an address we failed to publish. A conflict refusal
 		// (name owned by another party) also lands here — Surface A does not
 		// adopt a third party's name.
-		if hadPrev {
-			m.state.put(prevOwned)
-		} else {
-			m.state.delete(sc.Key, surfaceAIdentity, "")
+		//
+		// Racing-op guard (#2778): only roll back if OUR write-ahead is still the
+		// live entry. If a concurrent op already changed the owned record while we
+		// were unlocked, rolling back to prevOwned would clobber the newer truth —
+		// leave it alone and let the next reconcile converge.
+		if !stale {
+			if hadPrev {
+				m.state.put(prevOwned)
+			} else {
+				m.state.delete(sc.Key, surfaceAIdentity, "")
+			}
+			_ = m.state.save()
 		}
-		_ = m.state.save()
 		m.upsertFail++
-		if errors.Is(err, errDDNSConflictRefused) {
-			return fmt.Errorf("ddns surface-a: %s is owned by another party (refused): %w", rec.FQDN, err)
+		if errors.Is(wireErr, errDDNSConflictRefused) {
+			return fmt.Errorf("ddns surface-a: %s is owned by another party (refused): %w", rec.FQDN, wireErr)
 		}
-		return fmt.Errorf("ddns surface-a: publish %s %s=%s: %w", rec.ForwardType, rec.FQDN, addr, err)
+		return fmt.Errorf("ddns surface-a: publish %s %s=%s: %w", rec.ForwardType, rec.FQDN, addr, wireErr)
+	}
+
+	if stale {
+		// The wire add succeeded, but a concurrent op changed the scope's desired
+		// ownership while we were unlocked. The owned record now reflects the
+		// newer intent (or the scope was withdrawn); count the successful wire op
+		// for honesty but do NOT advance the (caller-owned) last-published cache
+		// to a value the live ownership no longer agrees with — the next reconcile
+		// reconciles the current desired state. Signal the caller via a sentinel
+		// so it skips the lastAddr/lastPublished advance.
+		m.upsertOK++
+		slog.Debug("ddns surface-a: publish raced a concurrent ownership change; not advancing cache",
+			"fqdn", rec.FQDN, "published", addr.String())
+		return errSurfaceAPublishRaced
 	}
 
 	// Success. If the address CHANGED (replace), the self-owned add already
@@ -646,6 +736,15 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 // deleteOK) and leaves the entry so the next reconcile retries. A no-op backend
 // (provider unresolvable) is treated as a FAILURE — it did NOT remove the RR, so
 // it must not report success nor drop ownership (which would orphan the RR).
+//
+// Lock discipline (#2778): the caller holds m.mu on entry and exit, but the lock
+// is RELEASED around the wire DeleteLease (via providerIO) so a slow/hung
+// provider cannot block other manager ops. After the unlocked delete the
+// ownership drop is committed under the re-acquired lock with a racing-op
+// re-validation: the entry is dropped only if it is STILL the exact record we
+// deleted (same scope+identity+address-text). If a concurrent publish re-asserted
+// the scope with a different address while we were unlocked, we must NOT drop the
+// newer ownership — that would orphan the freshly-published RR.
 func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRecord, backend DNSUpdater) error {
 	a, err := netip.ParseAddr(owned.AddrText)
 	if err != nil {
@@ -672,11 +771,27 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 		m.deleteFail++
 		return err
 	}
-	if err := backend.DeleteLease(ctx, rec); err != nil {
+	// Perform the wire DeleteLease with m.mu RELEASED (#2778): the 15s-timeout
+	// provider call must not block StatusViews/Stats/other scopes.
+	wireErr := m.providerIO(func() error { return backend.DeleteLease(ctx, rec) })
+	if wireErr != nil {
 		m.deleteFail++
-		return fmt.Errorf("ddns surface-a: withdraw %s %s: %w", owned.ForwardType, owned.FQDN, err)
+		return fmt.Errorf("ddns surface-a: withdraw %s %s: %w", owned.ForwardType, owned.FQDN, wireErr)
 	}
 	m.deleteOK++
+
+	// Racing-op guard (#2778): drop ownership only if the live entry is STILL the
+	// exact record we deleted. A concurrent publish could have re-asserted this
+	// scope (new address) while we were unlocked; that publish re-wrote the owned
+	// record (a different AddrText) and already drove its own wire add. Dropping
+	// it here would orphan the freshly-published RR. Leave the newer entry; the
+	// next reconcile converges it.
+	cur, stillOwned := m.state.get(owned.scopeOf(), owned.Identity, owned.Address)
+	if stillOwned && cur.AddrText != owned.AddrText {
+		slog.Debug("ddns surface-a: withdraw raced a concurrent re-publish; keeping newer ownership",
+			"fqdn", owned.FQDN, "withdrew", owned.AddrText, "current", cur.AddrText)
+		return nil
+	}
 	m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
 	delete(m.runtime, owned.scopeOf().scopePrefix())
 	slog.Info("ddns surface-a: withdrew record", "fqdn", owned.FQDN, "addr", owned.AddrText)

--- a/pkg/ddns/surface_a_lockio_test.go
+++ b/pkg/ddns/surface_a_lockio_test.go
@@ -1,0 +1,294 @@
+package ddns
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// surface_a_lockio_test.go: #2778 — Surface A must NOT hold its manager mutex
+// across provider network I/O (UpsertLease/DeleteLease run with a 15s client
+// timeout). A slow/hung provider must not block StatusViews/Stats/other-scope
+// reconcile work. These are the fail-on-revert proofs: if the lock-release is
+// reverted (I/O performed under the lock again), the "concurrent op proceeds
+// while I/O is blocked" assertions HANG and the bounded waits fire t.Fatal.
+
+// blockingUpdater blocks every UpsertLease/DeleteLease until released, signaling
+// entry on `entered` so the test knows the wire op is in flight (and thus the
+// lock, if held, would be held now). Deterministic: channels, no sleeps.
+type blockingUpdater struct {
+	entered chan struct{} // closed-style signal: one send per call entry
+	release chan struct{} // the call returns once this is closed
+	mu      sync.Mutex
+	upserts int
+	deletes int
+}
+
+func newBlockingUpdater() *blockingUpdater {
+	return &blockingUpdater{
+		entered: make(chan struct{}, 8),
+		release: make(chan struct{}),
+	}
+}
+
+func (b *blockingUpdater) UpsertLease(ctx context.Context, _ LeaseDNSRecord) error {
+	b.mu.Lock()
+	b.upserts++
+	b.mu.Unlock()
+	b.entered <- struct{}{}
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *blockingUpdater) DeleteLease(ctx context.Context, _ LeaseDNSRecord) error {
+	b.mu.Lock()
+	b.deletes++
+	b.mu.Unlock()
+	b.entered <- struct{}{}
+	select {
+	case <-b.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// TestSurfaceALockNotHeldDuringUpsert proves m.mu is released while the provider
+// UpsertLease is in flight (#2778). A blocking provider holds the wire op open;
+// concurrently a StatusViews() call must complete (it takes m.mu). If the lock
+// were held across the I/O, StatusViews would block until release and the
+// bounded wait below would fire — fail-on-revert.
+func TestSurfaceALockNotHeldDuringUpsert(t *testing.T) {
+	bu := newBlockingUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, bu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	reconcileDone := make(chan struct{})
+	go func() {
+		_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil)
+		close(reconcileDone)
+	}()
+
+	// Wait until the provider Upsert is actually in flight (wire op open).
+	select {
+	case <-bu.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider UpsertLease never started")
+	}
+
+	// While the wire op is blocked, a StatusViews() (which takes m.mu) MUST
+	// proceed. If the lock were held across the I/O this read would block and the
+	// bounded wait fires — the fail-on-revert assertion.
+	statusDone := make(chan []SurfaceAStatusView, 1)
+	go func() { statusDone <- m.StatusViews() }()
+	select {
+	case <-statusDone:
+		// good: the lock was free during provider I/O.
+	case <-time.After(2 * time.Second):
+		t.Fatal("StatusViews blocked while provider UpsertLease was in flight — lock held across I/O (#2778 regression)")
+	}
+
+	// Same for Stats().
+	statsDone := make(chan SurfaceAStats, 1)
+	go func() { statsDone <- m.Stats() }()
+	select {
+	case <-statsDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stats blocked while provider UpsertLease was in flight — lock held across I/O (#2778 regression)")
+	}
+
+	close(bu.release)
+	select {
+	case <-reconcileDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile did not finish after provider released")
+	}
+	if bu.upserts != 1 {
+		t.Fatalf("expected exactly one upsert, got %d", bu.upserts)
+	}
+	if st := m.Stats(); st.UpsertOK != 1 {
+		t.Fatalf("expected UpsertOK=1 after release, got %+v", st)
+	}
+}
+
+// TestSurfaceALockNotHeldDuringDelete proves m.mu is released while a withdraw's
+// provider DeleteLease is in flight (#2778). First publish a record, then drive
+// a withdraw (binding removed from config → Pass 2 delete) while the provider
+// delete blocks; a concurrent StatusViews must proceed.
+func TestSurfaceALockNotHeldDuringDelete(t *testing.T) {
+	bu := newBlockingUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, bu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	// Publish once (let it through immediately).
+	pubDone := make(chan struct{})
+	go func() {
+		_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil)
+		close(pubDone)
+	}()
+	<-bu.entered
+	close(bu.release)
+	<-pubDone
+
+	// Re-arm the release gate for the delete pass.
+	bu.release = make(chan struct{})
+
+	// Now reconcile with NO scopes → the owned record is withdrawn (Pass 2).
+	withdrawDone := make(chan struct{})
+	go func() {
+		_ = m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, nil)
+		close(withdrawDone)
+	}()
+	select {
+	case <-bu.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider DeleteLease never started")
+	}
+
+	statusDone := make(chan []SurfaceAStatusView, 1)
+	go func() { statusDone <- m.StatusViews() }()
+	select {
+	case <-statusDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StatusViews blocked while provider DeleteLease was in flight — lock held across I/O (#2778 regression)")
+	}
+
+	close(bu.release)
+	select {
+	case <-withdrawDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("withdraw Reconcile did not finish after provider released")
+	}
+	if bu.deletes != 1 {
+		t.Fatalf("expected exactly one delete, got %d", bu.deletes)
+	}
+	if st := m.Stats(); st.DeleteOK != 1 || st.Scopes != 0 {
+		t.Fatalf("expected DeleteOK=1 and no owned scopes after withdraw, got %+v", st)
+	}
+}
+
+// raceUpsertUpdater blocks the FIRST UpsertLease until released (so the test can
+// mutate state while the lock is free during the I/O), and lets every later call
+// through. It records every published address in order.
+type raceUpsertUpdater struct {
+	mu        sync.Mutex
+	entered   chan struct{}
+	release   chan struct{}
+	calls     int
+	published []string
+}
+
+func newRaceUpsertUpdater() *raceUpsertUpdater {
+	return &raceUpsertUpdater{
+		entered: make(chan struct{}, 8),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *raceUpsertUpdater) UpsertLease(ctx context.Context, rec LeaseDNSRecord) error {
+	r.mu.Lock()
+	r.calls++
+	first := r.calls == 1
+	r.published = append(r.published, rec.Addr.String())
+	r.mu.Unlock()
+	if first {
+		r.entered <- struct{}{}
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+func (r *raceUpsertUpdater) DeleteLease(_ context.Context, _ LeaseDNSRecord) error { return nil }
+
+func (r *raceUpsertUpdater) addrs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.published))
+	copy(out, r.published)
+	return out
+}
+
+// TestSurfaceAPublishRaceDoesNotClobberNewerState proves the racing-reconcile
+// guard (#2778): when the lock is released during the wire UpsertLease and a
+// concurrent op changes the scope's owned record, the stale wire result must NOT
+// clobber the newer desired state.
+//
+// Sequence:
+//  1. Reconcile #1 publishes addr A; its wire UpsertLease BLOCKS (lock free).
+//  2. While blocked, a second goroutine runs Reconcile #2 observing addr B; it
+//     acquires the lock, write-aheads B, and publishes B on the wire (the
+//     blocking updater only blocks the FIRST call, so #2 completes).
+//  3. Reconcile #1's wire op is released and returns success — but its
+//     write-ahead (A) is no longer the live owned record (B is). The guard must
+//     leave B as the owned/published address (not roll back to or re-assert A).
+func TestSurfaceAPublishRaceDoesNotClobberNewerState(t *testing.T) {
+	ru := newRaceUpsertUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, ru, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	// Reconcile #1 — observes A, blocks in the wire op with the lock RELEASED.
+	r1Done := make(chan struct{})
+	go func() {
+		_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil)
+		close(r1Done)
+	}()
+	select {
+	case <-ru.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first publish never reached the wire")
+	}
+
+	// Reconcile #2 — observes B; runs fully (its wire call is the 2nd, unblocked).
+	// It can only acquire m.mu if #1 released it during I/O (#2778). The bounded
+	// wait is the fail-on-revert: if the lock were held, this Reconcile hangs.
+	r2Done := make(chan error, 1)
+	go func() {
+		r2Done <- m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.10"), nil, nil)
+	}()
+	select {
+	case err := <-r2Done:
+		if err != nil {
+			t.Fatalf("Reconcile #2 (addr B) failed: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile #2 blocked — lock held across the first publish I/O (#2778 regression)")
+	}
+
+	// Now release #1's stale wire op. Its committed write-ahead was A, but the
+	// live owned record is now B. The guard must NOT roll back / re-assert A.
+	close(ru.release)
+	select {
+	case <-r1Done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile #1 did not finish after release")
+	}
+
+	// The owned/published address must be B (the newer desired state), never
+	// reverted to A by the stale result.
+	views := m.StatusViews()
+	if len(views) != 1 {
+		t.Fatalf("expected one owned scope, got %d: %+v", len(views), views)
+	}
+	if views[0].Published != "203.0.113.10" {
+		t.Fatalf("stale publish clobbered newer state: published=%q want 203.0.113.10", views[0].Published)
+	}
+
+	// Both addresses were sent to the wire (A by #1, B by #2); the guard governs
+	// the OWNERSHIP commit, not the wire op that already happened.
+	got := ru.addrs()
+	if len(got) != 2 {
+		t.Fatalf("expected two wire publishes (A then B), got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #2778

## Problem
Surface A provider I/O (`UpsertLease`/`DeleteLease`, 15s HTTP client timeout) ran under `SurfaceAManager.mu` for the whole reconcile pass. A slow/hung provider blocked **every** other Surface A op — `StatusViews` (operator `show system services dynamic-dns`), `Stats` (Prometheus scrape), and other scopes' reconcile work — for up to 15s, exactly while the subsystem was unhealthy. (codex-review-048 finding 048-06.)

## Lock-discipline change
- New `providerIO(fn)` unlocks `m.mu`, runs the one wire call, re-acquires the lock (`defer m.mu.Lock()` so a panicking backend can't unbalance the deferred `Reconcile` Unlock). All manager state (durable store, runtime cache, counters) is still mutated only under the lock; only the wire op runs unlocked.
- `publishLocked`: durably write-aheads ownership **before** the wire add (crash in the unlocked window still finds the record owned → next pass converges, preserving #2662), releases the lock for `UpsertLease`, re-acquires and commits with a **racing-op CAS** — if a concurrent op changed the owned record while unlocked, the stale result is not rolled back/advanced; the newer ownership wins (`errSurfaceAPublishRaced` keeps the runtime cache + backoff untouched).
- `withdrawOwnedLocked`: releases the lock for `DeleteLease`, then drops ownership **only if the live entry is still the exact record it deleted** — a concurrent re-publish with a new address keeps its freshly-published ownership instead of being orphaned.

Preserved invariants: never-blackhole, write-ahead-before-add (#2662), withdraw-keeps-ownership-on-error / no-op-backend honesty (#2691 P2 M1), per-RG HA master gate (#2664). The daemon single-flight guard (`surfaceAReconcileInFlight`) already serializes full passes; the CAS keeps the contract correct regardless.

## Fail-on-revert proof
`surface_a_lockio_test.go` (new): a blocking provider holds an `Upsert`/`Delete` open on a channel; a concurrent `StatusViews`/`Stats`/other-scope `Reconcile` must complete within a bounded 2s wait (would `t.Fatal` if the lock were held). Plus a racing-reconcile test proving a stale publish result does not clobber a newer desired address.

Reverting `providerIO` to lock-held I/O (copy-restore) makes all three new tests time out:
```
--- FAIL: TestSurfaceALockNotHeldDuringUpsert (2.00s)
    StatusViews blocked while provider UpsertLease was in flight — lock held across I/O (#2778 regression)
--- FAIL: TestSurfaceALockNotHeldDuringDelete (2.00s)
    StatusViews blocked while provider DeleteLease was in flight — lock held across I/O (#2778 regression)
--- FAIL: TestSurfaceAPublishRaceDoesNotClobberNewerState (2.00s)
    Reconcile #2 blocked — lock held across the first publish I/O (#2778 regression)
```
Restored from the copy; all pass with the fix.

## Gates
- `go build ./...` — ok
- `gofmt -l` — clean on touched Go files
- `go vet ./pkg/ddns/...` — ok
- `go test -race ./pkg/ddns/... ./pkg/daemon/...` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi