### PR TITLE
ddns/surface-a: honor IPv6 address lifetime in netlink selection

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-06-25 — #2775: ddns/surface-a netlink selection honors IPv6 address lifetime
+
+- **Timestamp**: 2026-06-25
+- **Action**: Surface A interface-address selection (`observeInterfaceAddr` in
+  `pkg/daemon/daemon_ddns_surface_a.go`) ignored IPv6 address-lifetime state and
+  published the first non-link-local/loopback/multicast netlink address — it
+  could publish a `deprecated` (soon-invalid) or a `tentative`/`dadfailed`
+  (DAD-incomplete/duplicate) address as the router's AAAA record. Extracted the
+  selection into a pure, testable `selectInterfaceAddr([]netlink.Addr, af4)`
+  that: skips `IFA_F_TENTATIVE | IFA_F_DADFAILED | IFA_F_OPTIMISTIC`; PREFERS an
+  RFC 4862 preferred address, falling back to a `IFA_F_DEPRECATED` address only
+  when no preferred exists (never-blackhole); and still gates every candidate
+  through `ddns.IsPublicAddr` (#2776 composition — a preferred-but-ULA address
+  is rejected). The IFA_F_* flags were ALREADY parsed off netlink into
+  `netlink.Addr.Flags` — no extra netlink plumbing was needed, they were simply
+  ignored in selection. Preserves #2776's static-fallback public gate.
+- **File(s)**: `pkg/daemon/daemon_ddns_surface_a.go`,
+  `pkg/daemon/daemon_ddns_surface_a_test.go`, `pkg/ddns/README.md`, `_Log.md`.
+- **Fail-on-revert proof**: `TestSelectInterfaceAddrLifetime` (copy-restore).
+  Reverted the deprecated-deferral (return first eligible incl. deprecated) →
+  RED: subtest "prefer preferred over deprecated (deprecated listed first)"
+  got `2606:4700:4700::2222` (deprecated) want `...::1111` (preferred). Restored
+  → GREEN; file byte-identical (`diff` clean). Also covers deprecated-only
+  fallback, tentative/dadfailed/optimistic never-selected, preferred-ULA
+  rejection (composes #2776), and v4 family filter.
+- **Gates**: `go build ./...` OK; `gofmt -l` clean; `go vet ./pkg/daemon/...
+  ./pkg/ddns/...` clean; `go test ./pkg/daemon/ -run
+  'SurfaceA|ObserveInterface|StaticUnitAddr|SelectInterfaceAddr' ./pkg/ddns/...`
+  PASS.
+
 ## 2026-06-25 — #2776: ddns/surface-a static-address fallback is now public-gated
 
 - **Timestamp**: 2026-06-25

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/ddns"
@@ -297,12 +298,14 @@ func surfaceALinuxIfName(cfg *config.Config, ifName string, unit *config.Interfa
 	return config.DHCPLeaseIfName(resolved, unit)
 }
 
-// observeInterfaceAddr reads the current global-scope address of the given
-// family on a kernel interface via netlink, falling back to the unit's
-// configured static address. Returns (zero, true) when the interface exists but
-// has no usable address of that family (definitively none → the engine
-// withdraws); (zero, false) when the interface cannot be read (transient → the
-// engine leaves the scope untouched).
+// observeInterfaceAddr reads the current publishable address of the given family
+// on a kernel interface via netlink (selection policy in selectInterfaceAddr:
+// prefer an RFC 4862 preferred address over a deprecated one, never a
+// tentative/dadfailed/optimistic one, public-gated via ddns.IsPublicAddr),
+// falling back to the unit's configured static address. Returns (zero, true)
+// when the interface exists but has no usable address of that family
+// (definitively none → the engine withdraws); (zero, false) when the interface
+// cannot be read (transient → the engine leaves the scope untouched).
 func (d *Daemon) observeInterfaceAddr(linuxName string, af4 bool, unit *config.InterfaceUnit) (netip.Addr, bool) {
 	link, err := netlink.LinkByName(linuxName)
 	if err != nil {
@@ -323,37 +326,78 @@ func (d *Daemon) observeInterfaceAddr(linuxName string, af4 bool, unit *config.I
 		}
 		return netip.Addr{}, false
 	}
-	best := netip.Addr{}
+	if best, ok := selectInterfaceAddr(addrs, af4); ok {
+		return best, true
+	}
+	// No usable netlink address: fall back to a configured static address.
+	if a, ok := staticUnitAddr(unit, af4); ok {
+		return a, true
+	}
+	// Interface is up but has no address of this family: definitively none.
+	return netip.Addr{}, true
+}
+
+// selectInterfaceAddr chooses the address to publish from a kernel interface's
+// netlink address list for the requested family. It is the pure (no-netlink-I/O)
+// core of observeInterfaceAddr so the selection policy can be exercised
+// directly with synthetic IFA_F_* flag combinations.
+//
+// Selection policy (RFC 4862 address states + the Surface A publishability gate):
+//
+//   - NEVER select an address whose DAD has not succeeded:
+//     IFA_F_TENTATIVE (DAD in progress), IFA_F_DADFAILED (duplicate detected),
+//     or IFA_F_OPTIMISTIC (RFC 4429 optimistic DAD — usable for some traffic but
+//     not yet DAD-confirmed, so not safe to publish to global DNS). Publishing
+//     one risks a duplicate/black-holed answer.
+//   - NEVER select a non-globally-meaningful address (loopback / link-local
+//     uni+multicast / multicast / unspecified, AND every IANA special-purpose
+//     range) — the SAME ddns.IsPublicAddr gate the static fallback (#2776) and
+//     the checkip source use. A preferred-but-ULA address is still rejected.
+//   - PREFER an RFC 4862 `preferred` address over a `deprecated` one
+//     (IFA_F_DEPRECATED). A deprecated address is being phased out (renumber /
+//     PD churn / privacy-address rotation) and will soon become invalid, so
+//     publishing it black-holes inbound reachability. The first eligible
+//     preferred address wins; a deprecated address is remembered only as a
+//     fallback used IFF no preferred address exists (never blackhole — a
+//     deprecated-but-still-valid address is better than no answer).
+//
+// netlink returns a stable order, so "first eligible" is deterministic.
+func selectInterfaceAddr(addrs []netlink.Addr, af4 bool) (netip.Addr, bool) {
+	deprecated := netip.Addr{}
 	for _, ad := range addrs {
 		ip, ok := netip.AddrFromSlice(ad.IP)
 		if !ok {
 			continue
 		}
 		ip = ip.Unmap()
-		// Skip link-local / loopback / unspecified — Surface A publishes a
-		// globally meaningful address only (the inadyn validity gate, plan §3.2).
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-			ip.IsMulticast() || ip.IsUnspecified() {
-			continue
-		}
 		if af4 != ip.Is4() {
 			continue
 		}
-		// Prefer the first global address (deterministic; netlink returns a
-		// stable order). A more specific selection (primary flag) is a P3
-		// refinement.
-		best = ip
-		break
+		// Skip addresses whose DAD has not succeeded — they may be duplicate or
+		// not yet usable. tentative/dadfailed/optimistic are never publishable.
+		if ad.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_DADFAILED|unix.IFA_F_OPTIMISTIC) != 0 {
+			continue
+		}
+		// Globally-routable-unicast gate (#2776): reject link-local, loopback,
+		// unspecified, multicast, ULA, CGNAT, documentation, and every other
+		// IANA special-purpose range. A preferred-but-ULA address is rejected.
+		if !ddns.IsPublicAddr(ip) {
+			continue
+		}
+		if ad.Flags&unix.IFA_F_DEPRECATED != 0 {
+			// Remember the first deprecated candidate as a no-blackhole fallback.
+			if !deprecated.IsValid() {
+				deprecated = ip
+			}
+			continue
+		}
+		// First eligible preferred address wins.
+		return ip, true
 	}
-	if best.IsValid() {
-		return best, true
+	if deprecated.IsValid() {
+		return deprecated, true
 	}
-	// No global netlink address: fall back to a configured static address.
-	if a, ok := staticUnitAddr(unit, af4); ok {
-		return a, true
-	}
-	// Interface is up but has no address of this family: definitively none.
-	return netip.Addr{}, true
+	return netip.Addr{}, false
 }
 
 // staticUnitAddr returns the first configured static address of the given

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -1,8 +1,12 @@
 package daemon
 
 import (
+	"net"
 	"net/netip"
 	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
@@ -177,5 +181,136 @@ func TestStaticUnitAddrPublicGate(t *testing.T) {
 	a, ok := staticUnitAddr(mixed, true)
 	if !ok || a != netip.MustParseAddr("8.8.4.4") {
 		t.Fatalf("public addr after a rejected one = %v ok=%v, want 8.8.4.4 ok=true", a, ok)
+	}
+}
+
+// mkAddr builds a synthetic netlink.Addr with the given CIDR and IFA_F_* flags
+// for selectInterfaceAddr table tests (no kernel interface required).
+func mkAddr(cidr string, flags int) netlink.Addr {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+	ipnet.IP = ip
+	return netlink.Addr{IPNet: ipnet, Flags: flags}
+}
+
+// TestSelectInterfaceAddrLifetime is the #2775 fail-on-revert gate for IPv6
+// address-lifetime-aware selection. observeInterfaceAddr (via this pure helper)
+// must honor RFC 4862 address state:
+//
+//   - PREFER a `preferred` address over a `deprecated` one. Goes RED if the
+//     lifetime-preference logic is reverted (a deprecated address wrongly
+//     selected over a preferred one).
+//   - fall back to `deprecated` only when no preferred exists (never blackhole).
+//   - NEVER select tentative / dadfailed / optimistic (DAD not succeeded).
+//   - the selected address STILL passes ddns.IsPublicAddr (composes with #2776):
+//     a preferred-but-ULA address is rejected.
+func TestSelectInterfaceAddrLifetime(t *testing.T) {
+	pref6 := netip.MustParseAddr("2606:4700:4700::1111")
+	dep6 := netip.MustParseAddr("2606:4700:4700::2222")
+	pref4 := netip.MustParseAddr("198.51.99.5")
+
+	tests := []struct {
+		name  string
+		addrs []netlink.Addr
+		af4   bool
+		want  netip.Addr
+		ok    bool
+	}{
+		{
+			// Core fail-on-revert: preferred wins over deprecated even though the
+			// deprecated address is listed FIRST (netlink order must not decide).
+			name: "prefer preferred over deprecated (deprecated listed first)",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::2222/64", unix.IFA_F_DEPRECATED),
+				mkAddr("2606:4700:4700::1111/64", 0),
+			},
+			af4:  false,
+			want: pref6,
+			ok:   true,
+		},
+		{
+			// Only deprecated available → use it (never blackhole).
+			name: "deprecated only falls back, no blackhole",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::2222/64", unix.IFA_F_DEPRECATED),
+			},
+			af4:  false,
+			want: dep6,
+			ok:   true,
+		},
+		{
+			// tentative / dadfailed / optimistic are never publishable, even if
+			// they are the only globally-routable addresses present.
+			name: "tentative never selected",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::1111/64", unix.IFA_F_TENTATIVE),
+			},
+			af4:  false,
+			want: netip.Addr{},
+			ok:   false,
+		},
+		{
+			name: "dadfailed never selected",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::1111/64", unix.IFA_F_DADFAILED),
+			},
+			af4:  false,
+			want: netip.Addr{},
+			ok:   false,
+		},
+		{
+			name: "optimistic never selected",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::1111/64", unix.IFA_F_OPTIMISTIC),
+			},
+			af4:  false,
+			want: netip.Addr{},
+			ok:   false,
+		},
+		{
+			// Composition with #2776: a preferred ULA is still rejected; the
+			// preferred GUA listed after it is selected.
+			name: "preferred-but-ULA rejected, GUA selected",
+			addrs: []netlink.Addr{
+				mkAddr("fd00::1/64", 0),
+				mkAddr("2606:4700:4700::1111/64", 0),
+			},
+			af4:  false,
+			want: pref6,
+			ok:   true,
+		},
+		{
+			// A tentative preferred + a deprecated valid → deprecated wins (the
+			// tentative is skipped, the deprecated is the only usable address).
+			name: "tentative preferred skipped, deprecated used",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::1111/64", unix.IFA_F_TENTATIVE),
+				mkAddr("2606:4700:4700::2222/64", unix.IFA_F_DEPRECATED),
+			},
+			af4:  false,
+			want: dep6,
+			ok:   true,
+		},
+		{
+			// IPv4 family filter + preferred selection.
+			name: "v4 preferred selected, v6 ignored",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::1111/64", 0),
+				mkAddr("198.51.99.5/24", 0),
+			},
+			af4:  true,
+			want: pref4,
+			ok:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := selectInterfaceAddr(tc.addrs, tc.af4)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("selectInterfaceAddr() = %v, %v; want %v, %v", got, ok, tc.want, tc.ok)
+			}
+		})
 	}
 }

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -327,6 +327,27 @@ its OWN learned address — on top of the SAME spine, without forking the engine
   longer use divergent publishability predicates (the netlink path already
   rejected multicast; the fallback previously filtered only loopback/
   link-local-unicast/unspecified).
+  **IPv6 address-lifetime-aware netlink selection (#2775):** the netlink
+  selection (`selectInterfaceAddr`, the pure core of `observeInterfaceAddr`)
+  now honors RFC 4862 address state instead of publishing the first
+  non-link-local/loopback/multicast address. (1) It NEVER selects an address
+  whose DAD has not succeeded — `IFA_F_TENTATIVE` (DAD in progress),
+  `IFA_F_DADFAILED` (duplicate detected), or `IFA_F_OPTIMISTIC` (RFC 4429
+  optimistic DAD, not yet DAD-confirmed) — publishing one risks a
+  duplicate/black-holed answer. (2) It PREFERS an RFC 4862 `preferred` address
+  over a `deprecated` one (`IFA_F_DEPRECATED`): a deprecated address is being
+  phased out (renumber / PD churn / privacy-address rotation) and will soon be
+  invalid, so publishing it black-holes inbound reachability. The first eligible
+  preferred address wins; a deprecated address is used ONLY when no preferred
+  address exists (never-blackhole — a still-valid deprecated address beats no
+  answer). (3) Every candidate STILL passes `ddns.IsPublicAddr`, so a
+  preferred-but-ULA (or otherwise reserved) address is rejected — the same gate
+  as the static fallback (#2776) and the checkip source. The IFA_F_* flags are
+  already parsed off the netlink `RTM_NEWADDR` message into
+  `netlink.Addr.Flags` (no extra netlink plumbing was needed — they were simply
+  ignored in selection before). A per-family `preferred-address` operator
+  override for multi-address interfaces (the issue's secondary ask) remains a
+  future refinement.
 - **HA gate** is the SAME per-RG `ScopeGate` (a router record on a reth/virtual
   interface publishes only on the RG master; stop-writing-never-withdraw
   otherwise). Standalone (nil gate) always publishes.


### PR DESCRIPTION
Closes #2775

## Problem
Surface A's interface-address selection (`observeInterfaceAddr` in `pkg/daemon/daemon_ddns_surface_a.go`) picked the **first** netlink address that was not loopback/link-local/multicast/unspecified, ignoring the RFC 4862 IPv6 address state. It could publish:
- a **deprecated** address (being phased out during renumber / PD churn / privacy-address rotation, soon invalid), or
- a **tentative/dadfailed** address (DAD not succeeded, possibly a duplicate)

as the router's AAAA record — black-holing inbound reachability.

## Fix
The `IFA_F_*` flags are **already** parsed off the netlink `RTM_NEWADDR` message into `netlink.Addr.Flags` by `vishvananda/netlink` — they were simply ignored in selection. **No netlink flag plumbing was needed.**

Extracted the selection into a pure, table-testable `selectInterfaceAddr([]netlink.Addr, af4)` that:
- NEVER selects an address whose DAD has not succeeded — `IFA_F_TENTATIVE | IFA_F_DADFAILED | IFA_F_OPTIMISTIC`.
- PREFERS an RFC 4862 `preferred` address over a `deprecated` one (`IFA_F_DEPRECATED`); a deprecated address is used **only** when no preferred exists (never-blackhole — a still-valid deprecated address beats no answer).
- still gates every candidate through `ddns.IsPublicAddr`, so a preferred-but-ULA / reserved address is rejected (**composes with #2776**, preserved).

This also strengthens the netlink path's filter from the old loopback/link-local/multicast/unspecified check to the full `IsPublicAddr` predicate, so the netlink, static-fallback, and checkip sources no longer use divergent publishability gates.

The issue's secondary ask (a per-family `preferred-address` operator override for multi-address interfaces) remains a documented future refinement.

## Gates (foreground)
- `go build ./...` — OK
- `gofmt -l` on changed files — clean
- `go vet ./pkg/daemon/... ./pkg/ddns/...` — clean
- `go test ./pkg/daemon/ -run 'SurfaceA|ObserveInterface|StaticUnitAddr|SelectInterfaceAddr' ./pkg/ddns/...` — PASS

## Fail-on-revert proof (copy-restore)
`TestSelectInterfaceAddrLifetime`. Reverted the deprecated-deferral (return first eligible incl. deprecated):
```
--- FAIL: TestSelectInterfaceAddrLifetime/prefer_preferred_over_deprecated_(deprecated_listed_first)
    selectInterfaceAddr() = 2606:4700:4700::2222, true; want 2606:4700:4700::1111, true
```
Restored → GREEN, file byte-identical (`diff` clean). Subtests also cover deprecated-only fallback, tentative/dadfailed/optimistic never-selected, preferred-ULA rejection (composes #2776), and the v4 family filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi