### PR TITLE
#2684: fix WG PTB inner-MTU under-advertisement (off-by-one encap)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -16369,3 +16369,29 @@ top.
   go test ./pkg/config/... pass.
   **File(s)**: pkg/config/compiler_validate_wireguard.go,
   pkg/config/wireguard_multipeer_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2684 — fix WG PTB inner-MTU under-advertisement (off-by-one
+  encap). The post-transform PMTUD path (`post_transform_inner_mtu`) WG arm
+  sourced the outer MTU via `tunnel_outer_mtu`, which for a WG transit flow
+  (zeroed `endpoint.destination`) falls back to the LOGICAL ifindex MTU
+  (~1420 = underlay − encap); feeding that to `wg_inner_mtu` double-subtracts
+  the WG overhead → PTB advertised ~1345 (v4) / 1325 (v6), ~100B below what
+  the #2680 encap guard admits (`wg_inner_mtu(physical=1500)` = 1425 / 1405).
+  Fix: new `frame::wg_endpoint_physical_outer_mtu` SSOT wrapper over the #2680
+  `outer_physical_egress_mtu` (route-resolves the physical underlay via the
+  first peer endpoint; per-endpoint underlay, #2734); WG arm now derives the
+  outer MTU from the PHYSICAL underlay so the advertised inner MTU =
+  `physical_mtu − WG_OVERHEAD_{V4,V6} − WG_MAX_PADDING` (the exact inverse of
+  `wg_encapped_size`). GRE unaffected (real `destination` resolves to physical
+  already). No shared constant changed (no #2792 conflict). No wire change
+  (`protocol_wire_v1.json` untouched). Tests: 3 new fail-on-revert tests in
+  `icmp_ptb_tests.rs` (v4 Frag-Needed → 1425, v6 Packet-Too-Big → 1405,
+  no-peer fallback → 1345 = logical). Fail-on-revert proven via copy-restore:
+  reverting the WG arm to `tunnel_outer_mtu` yields left:1345 (v4) / left:1325
+  (v6) vs right:1425/1405. Gates: `cargo build --release -p xpf-userspace-dp`
+  clean; `cargo test --release --bin xpf-userspace-dp -- ptb mtu icmp` 192/0;
+  `-- wg tunnel` 268/0. No Go change.
+  **File(s)**: userspace-dp/src/afxdp/icmp_ptb.rs,
+  userspace-dp/src/afxdp/frame/wg.rs, userspace-dp/src/afxdp/frame/mod.rs,
+  userspace-dp/src/afxdp/icmp_ptb_tests.rs, docs/wireguard-interop.md, _Log.md

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -130,6 +130,38 @@ from `wgDefaultOuterMTU` minus the family overhead. The pre-#2300 code
 ignored `tc.MTU` entirely and always derived from 1500, so a
 lowered-underlay deployment could not set a smaller wgN MTU.
 
+**#2684 (PTB advertisement — the #2680 sibling on the same SSOT).** The
+post-transform PMTUD path (`post_transform_inner_mtu`, the TX dispatcher's
+inner-MTU derivation that turns an oversized DF-IPv4 / IPv6 inner into a
+Frag-Needed / Packet-Too-Big) computed the WG arm's outer MTU via
+`tunnel_outer_mtu` (the #2300 transport-MTU SSOT). For a WG transit flow
+`endpoint.destination` is zeroed (the peer carries the real outer hop), so
+`tunnel_outer_mtu`'s `tx_ifindex` resolution NoRoutes and the chain falls
+through to the tunnel LOGICAL `egress_ifindex` MTU (~1420 = underlay −
+encap). Feeding that already-reduced MTU to `wg_inner_mtu` subtracts the WG
+outer overhead a SECOND time, so the PTB advertised
+`wg_inner_mtu(1420)` ≈ 1345 (v4) / 1325 (v6) — ~80-100B SMALLER than the
+underlay actually permits. The encap drop guard (#2680) admits inner packets
+up to `wg_inner_mtu(physical=1500)` ≈ 1425 (v4) / 1405 (v6), so a DF-IPv4 /
+IPv6 inner in the band `(wg_inner_mtu(logical), wg_inner_mtu(physical)]` got
+a PTB clamping the sender ~100B too low (over-conservative — safe, no drops,
+but unnecessary fragmentation pressure / throughput loss).
+
+The WG arm now derives the outer MTU from the PHYSICAL underlay via
+`frame::wg_endpoint_physical_outer_mtu`, a thin wrapper over the same #2680
+`outer_physical_egress_mtu` SSOT the encap guard uses. The PTB path runs
+before the per-packet peer LPM (it has no inner frame), but the WG underlay
+is per-tunnel-endpoint, not per-inner-flow (#2734) — so it route-resolves
+the physical egress via the FIRST peer that carries an endpoint address.
+Corrected formula: advertised inner MTU = `wg_inner_mtu(outer_family,
+physical_underlay_mtu)` = `physical_mtu − WG_OVERHEAD_{V4,V6} −
+WG_MAX_PADDING` — EXACTLY the inverse of `wg_encapped_size` the encap guard
+admits against, so the PTB and the guard now agree. Conservative fallback
+(no peer endpoint to route to / unresolvable outer) reverts to the logical
+`egress_ifindex` MTU — the pre-#2684 value, never worse. GRE is unaffected:
+its `endpoint.destination` is the real outer hop, so `tunnel_outer_mtu`
+already resolves to the physical underlay for `native_gre_inner_mtu`.
+
 **#2701 (transit-egress OUTER SOURCE).** The #2680 MTU fix resolved the
 physical underlay egress for the MTU guard but left the OUTER IP SOURCE
 still read from `decision.resolution.egress_ifindex` (the LOGICAL tunnel

--- a/userspace-dp/src/afxdp/frame/mod.rs
+++ b/userspace-dp/src/afxdp/frame/mod.rs
@@ -13,6 +13,12 @@ mod wg;
 // classifier in `tx/cos_classify.rs` (a sibling afxdp module) can reach it.
 pub(in crate::afxdp) use generated::generated_reply_session_key;
 
+// #2684: the WG physical-underlay outer MTU SSOT, re-exported so the TX
+// dispatcher's `post_transform_inner_mtu` (icmp_ptb.rs) derives the PTB
+// inner MTU from the SAME physical underlay the encap drop guard admits
+// against (the `mod wg` submodule itself is private to `frame`).
+pub(in crate::afxdp) use wg::wg_endpoint_physical_outer_mtu;
+
 // #1440 consolidated outer-header serializers. Re-exported at
 // `frame::write_eth_header`, `frame::write_eth_header_slice`, and
 // `frame::headers::*` to keep existing call sites in icmp.rs,

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -138,6 +138,62 @@ fn outer_physical_egress_mtu(
         .unwrap_or(1500)
 }
 
+/// The PHYSICAL underlay egress MTU for a WireGuard endpoint, for the
+/// post-transform PTB inner-MTU derivation (#2684).
+///
+/// This is the SAME physical-underlay SSOT (`outer_physical_egress_mtu`,
+/// #2680) the encap drop guard uses, exposed so the TX dispatcher's
+/// `post_transform_inner_mtu` advertises an inner MTU consistent with what
+/// the encap guard actually admits. The PTB path runs BEFORE the per-packet
+/// peer LPM (it has no inner frame to select a peer), but the WG outer
+/// underlay is per-tunnel-endpoint, not per-inner-flow (#2734): every peer of
+/// an endpoint egresses the same physical underlay. So we resolve the
+/// physical egress via the FIRST peer endpoint that yields a route; the
+/// fallback inside `outer_physical_egress_mtu` (route unresolvable → the
+/// resolution's own `egress_ifindex` MTU = the tunnel LOGICAL MTU) preserves
+/// the conservative pre-#2684 behaviour, never tighter.
+///
+/// Returns the logical-ifindex MTU fallback when the endpoint has no peer
+/// with a learned/configured endpoint address (no outer hop to route to) —
+/// the same value `tunnel_outer_mtu` would have produced, so the PTB is no
+/// worse than before in that degenerate case.
+///
+/// # Why not `tunnel_outer_mtu`
+/// For a WG transit flow `endpoint.destination` is `0.0.0.0`/`::`
+/// (`forwarding_build::tunnels` zeroes it — the peer carries the real outer
+/// hop), so `tunnel_outer_mtu`'s `tx_ifindex` resolution NoRoutes and the
+/// chain falls through to the LOGICAL `egress_ifindex` MTU (~1420). Feeding
+/// that to `wg_inner_mtu` subtracts the WG encap overhead a SECOND time
+/// (the logical MTU is already underlay − encap), under-advertising the
+/// inner PMTU by ~one encap (~75-95B). GRE is unaffected: its
+/// `endpoint.destination` is the real outer hop, so `tunnel_outer_mtu`
+/// resolves to the physical underlay correctly.
+#[inline]
+pub(in crate::afxdp) fn wg_endpoint_physical_outer_mtu(
+    decision: &SessionDecision,
+    forwarding: &ForwardingState,
+    endpoint: &TunnelEndpoint,
+) -> usize {
+    // The WG underlay is per-endpoint (#2734): the first peer with a known
+    // endpoint address resolves the same physical egress as any other.
+    let outer_dst = endpoint
+        .wg_peers
+        .iter()
+        .find_map(|peer| peer.endpoint.map(|ep| ep.ip()));
+    match outer_dst {
+        Some(dst) => outer_physical_egress_mtu(decision, forwarding, endpoint, dst),
+        // No peer endpoint to route to: fall back to the resolution's own
+        // egress (the logical ifindex), exactly what `tunnel_outer_mtu`
+        // would have yielded — no regression in the degenerate case.
+        None => forwarding
+            .egress
+            .get(&decision.resolution.egress_ifindex)
+            .map(|e| e.mtu)
+            .filter(|m| *m > 0)
+            .unwrap_or(1500),
+    }
+}
+
 pub(super) fn wg_encap_frame(
     inner_frame: &[u8],
     inner_meta: impl Into<ForwardPacketMeta>,

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -144,10 +144,14 @@ pub(in crate::afxdp) fn forwarded_egress_mtu_decision(
 ///   - GRE: the #2300 SSOT `native_gre_inner_mtu` (transport MTU minus the
 ///     outer IP + GRE[+key] header) — the SAME value the #2331 encap drop
 ///     guard enforces, so this site and that drop site agree.
-///   - WireGuard: the pad-aware `wg::mss::wg_inner_mtu` derived from
-///     `tunnel_outer_mtu` (the #2300 transport-MTU SSOT) minus the WG outer
-///     overhead and worst-case §5.4.6 padding — the inverse of the
-///     `frame::wg::wg_encapped_size` drop guard.
+///   - WireGuard: the pad-aware `wg::mss::wg_inner_mtu` derived from the
+///     PHYSICAL underlay egress MTU (`frame::wg_endpoint_physical_outer_mtu`,
+///     the #2680 SSOT) minus the WG outer overhead and worst-case §5.4.6
+///     padding — the inverse of the `frame::wg::wg_encapped_size` drop guard,
+///     so the advertised inner MTU matches the threshold the guard admits
+///     (#2684). NOT `tunnel_outer_mtu`: for a WG flow `endpoint.destination`
+///     is zeroed, so that helper falls back to the LOGICAL ifindex MTU
+///     (already underlay − encap) and double-subtracts the encap overhead.
 ///   - NAT64: the egress MTU adjusted by the v6<->v4 header-size delta
 ///     (RFC 7915): a v6 inner translated to a v4 egress may be 20 bytes
 ///     LARGER on the inner side; a v4 inner translated to a v6 egress 20
@@ -157,8 +161,9 @@ pub(in crate::afxdp) fn forwarded_egress_mtu_decision(
 /// Returns 0 (fail-open — never invent a too-small MTU) when the endpoint
 /// row is missing, the tunnel kind is unknown, or the computed inner MTU is
 /// below the usable minimum (the per-kind inner-MTU helper returns 0). Note:
-/// the outer/transport MTU itself always resolves — `tunnel_outer_mtu` falls
-/// back to 1500 — so a 0 return reflects a missing/unknown endpoint or an
+/// the outer/transport MTU itself always resolves — both `tunnel_outer_mtu`
+/// (GRE) and `wg_endpoint_physical_outer_mtu` (WG) fall back to a non-zero
+/// MTU — so a 0 return reflects a missing/unknown endpoint or an
 /// unusably-small inner budget, never an unresolved outer MTU.
 /// `egress_mtu` is the already-resolved physical egress-interface MTU
 /// (`forwarded_egress_mtu`); used only for the NAT64 arm (the tunnel arms
@@ -200,9 +205,24 @@ pub(in crate::afxdp) fn post_transform_inner_mtu(
         return 0;
     };
     match tunnel_mode_kind(&endpoint.mode) {
+        // GRE's `endpoint.destination` is the real outer hop, so
+        // `native_gre_inner_mtu`'s `tunnel_outer_mtu` resolves to the
+        // physical underlay MTU correctly — leave it.
         TunnelKind::Gre => native_gre_inner_mtu(forwarding, decision),
         TunnelKind::WireGuard => {
-            let outer_mtu = tunnel_outer_mtu(forwarding, decision, endpoint);
+            // #2684: resolve the outer MTU via the PHYSICAL underlay egress
+            // (the #2680 SSOT), NOT `tunnel_outer_mtu`. For a WG transit flow
+            // `endpoint.destination` is zeroed (the peer carries the outer
+            // hop), so `tunnel_outer_mtu` falls back to the tunnel LOGICAL
+            // ifindex MTU (~1420) — already underlay − encap. Feeding that to
+            // `wg_inner_mtu` double-subtracts the WG encap overhead and
+            // under-advertises the inner PMTU by ~one encap. Using the
+            // physical underlay MTU (~1500) makes the advertised inner MTU
+            // match the encap drop guard's admit threshold
+            // (`wg_inner_mtu(physical)`), so DF-IPv4 / IPv6 inners get the
+            // same PMTU the guard tolerates instead of ~100B too small.
+            let outer_mtu =
+                crate::afxdp::frame::wg_endpoint_physical_outer_mtu(decision, forwarding, endpoint);
             crate::afxdp::wg::mss::wg_inner_mtu(endpoint.outer_family, outer_mtu)
         }
         TunnelKind::Unknown => 0,

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -1149,3 +1149,187 @@ fn truncated_ip_header_forwards_fail_open() {
         "truncated IPv6 header must fail-open to Forward"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2684: the WireGuard PTB inner-MTU derives from the PHYSICAL underlay egress
+// (1500), NOT the tunnel LOGICAL ifindex MTU (1420). Before #2684 the WG arm of
+// `post_transform_inner_mtu` read `tunnel_outer_mtu`, which for a WG transit
+// flow (endpoint.destination zeroed) falls back to the LOGICAL egress_ifindex
+// MTU (~1420 = underlay − encap). Feeding that to `wg_inner_mtu` subtracts the
+// WG encap overhead a SECOND time → the PTB advertises ~1345 (v4) / ~1325 (v6),
+// ~80-100B SMALLER than the encap drop guard actually admits
+// (`wg_inner_mtu(physical=1500)` = 1425 v4 / 1405 v6). These tests use the
+// realistic `wg_outer_mtu_snapshot` (logical wg0.0 ifindex 400 MTU 1420 ≠
+// physical reth0.80 ifindex 12 MTU 1500, peer routed via reth0.80) so the
+// logical/physical split is real. They go RED if the WG arm reverts to
+// `tunnel_outer_mtu` (logical 1420).
+// ---------------------------------------------------------------------------
+
+use crate::afxdp::forwarding_build::build_forwarding_state;
+
+/// A tunnel-resolved WG `SessionDecision` matching what the resolver stores
+/// for a WG transit flow: `egress_ifindex` = the tunnel LOGICAL ifindex (the
+/// resolver copies `endpoint.logical_ifindex`), `tx_ifindex` = 0 (the WG
+/// `endpoint.destination` is zeroed so `resolve_tunnel_outer` NoRoutes and the
+/// stored tx_ifindex is unset). This is the production shape that makes
+/// `tunnel_outer_mtu` fall back to the LOGICAL MTU.
+fn wg_logical_tunnel_decision(logical_ifindex: i32, tunnel_endpoint_id: u16) -> SessionDecision {
+    SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::MissingNeighbor,
+            local_ifindex: 0,
+            egress_ifindex: logical_ifindex,
+            tx_ifindex: 0,
+            tunnel_endpoint_id,
+            next_hop: None,
+            neighbor_mac: None,
+            src_mac: None,
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision::default(),
+    }
+}
+
+#[test]
+fn post_transform_wg_inner_mtu_uses_physical_underlay_not_logical_v4() {
+    // Fail-on-revert: with the fix the WG inner MTU is derived from the
+    // PHYSICAL underlay (reth0.80 = 1500): wg_inner_mtu(AF_INET, 1500) =
+    // 1500 - 60 - 15 = 1425. Reverting to tunnel_outer_mtu reads the LOGICAL
+    // wg0.0 MTU (1420) → wg_inner_mtu = 1345 → this assertion fails red.
+    let state = build_forwarding_state(&crate::afxdp::test_fixtures::wg_outer_mtu_snapshot());
+    // Sanity: the fixture really carries the distinct logical/physical MTUs.
+    assert_eq!(state.egress.get(&400).map(|e| e.mtu), Some(1420), "wg0.0 logical");
+    assert_eq!(state.egress.get(&12).map(|e| e.mtu), Some(1500), "reth0.80 physical");
+
+    let decision = wg_logical_tunnel_decision(400, 1);
+    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET as u8, 0);
+    assert_eq!(
+        inner_mtu, 1425,
+        "WG PTB inner MTU MUST be wg_inner_mtu(physical 1500) = 1425, NOT \
+         wg_inner_mtu(logical 1420) = 1345 (the #2684 double-subtract)"
+    );
+    // It MUST equal the encap-guard SSOT: the inverse of wg_encapped_size at
+    // the physical MTU, so the PTB advertises exactly what the guard admits.
+    assert_eq!(
+        inner_mtu,
+        crate::afxdp::wg::mss::wg_inner_mtu(libc::AF_INET, 1500),
+        "WG PTB inner MTU MUST equal wg_inner_mtu(physical underlay)"
+    );
+
+    // End-to-end: a 1400-byte inner v4 DF datagram (L3 = 1400 > 1425? no — it
+    // is 1400 <= 1425 so it FORWARDS; pick > 1425 to fire the PTB). A 1440-byte
+    // L3 (> 1425) must emit a Frag-Needed advertising 1425.
+    let (frame, meta) = inbound_v4_udp(1440 - 28, true); // L3 = 20 + 8 + payload = 1440
+    let l3 = meta.l3_offset as usize;
+    let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu) {
+        EgressMtuDecision::EmitPacketTooBig { next_hop_mtu } => next_hop_mtu,
+        other => panic!("expected EmitPacketTooBig, got {other:?}"),
+    };
+    assert_eq!(next_hop_mtu, 1425, "advertised v4 inner MTU = physical-derived 1425");
+    // The ICMP source is the ingress interface primary; use reth0.80 (ifindex
+    // 12, primary 172.16.80.8) which exists in the snapshot-built state.
+    let out = build_frag_needed_v4(&frame, meta, 12, &state, next_hop_mtu)
+        .expect("WG inner-source frag-needed must build");
+    // reth0.80 carries VLAN 80, so the reply L2 is tagged (18 bytes). Derive
+    // the L3 offset from the ethertype rather than hardcoding 14.
+    let eth = if u16::from_be_bytes([out[12], out[13]]) == 0x8100 { 18 } else { 14 };
+    let icmp = eth + 20;
+    assert_eq!(out[icmp], 3, "ICMP Frag-Needed type");
+    assert_eq!(out[icmp + 1], 4, "ICMP Frag-Needed code");
+    assert_eq!(
+        u16::from_be_bytes([out[icmp + 6], out[icmp + 7]]),
+        1425,
+        "Frag-Needed carries the physical-derived inner MTU"
+    );
+}
+
+#[test]
+fn post_transform_wg_inner_mtu_uses_physical_underlay_not_logical_v6() {
+    // Same fixture, flipped to a v6 outer (peer + transport route in inet6).
+    // With the fix: wg_inner_mtu(AF_INET6, 1500) = 1500 - 80 - 15 = 1405.
+    // Reverting to tunnel_outer_mtu (logical 1420) → 1325 → fails red.
+    let mut snap = crate::afxdp::test_fixtures::wg_outer_mtu_snapshot();
+    // Flip the WG endpoint + its peer + the underlay route to IPv6.
+    {
+        let ep = &mut snap.tunnel_endpoints[0];
+        ep.outer_family = "inet6".to_string();
+        ep.source = "2001:559:8585:80::8".to_string();
+        ep.wg_peers[0].wg_endpoint = "[2001:db8:c0::7]:51820".to_string();
+        ep.wg_peers[0].wg_allowed_ips = vec!["10.123.0.0/24".to_string()];
+        ep.transport_table = "inet6.0".to_string();
+    }
+    // Physical reth0.80 already carries a v6 primary in the v4 fixture? No —
+    // the v4 fixture's reth0.80 has only a v4 address. Give it a v6 primary so
+    // the underlay route resolves on reth0.80, and add the v6 underlay route.
+    snap.interfaces[0].addresses.push(crate::InterfaceAddressSnapshot {
+        family: "inet6".to_string(),
+        address: "2001:559:8585:80::8/64".to_string(),
+        scope: 0,
+    });
+    snap.routes = vec![crate::RouteSnapshot {
+        table: "inet6.0".to_string(),
+        family: "inet6".to_string(),
+        destination: "2001:db8:c0::/64".to_string(),
+        next_hops: vec!["2001:559:8585:80::1@reth0.80".to_string()],
+        discard: false,
+        next_table: String::new(),
+        preference: 0,
+    }];
+
+    let state = build_forwarding_state(&snap);
+    assert_eq!(state.egress.get(&12).map(|e| e.mtu), Some(1500), "reth0.80 physical");
+
+    let decision = wg_logical_tunnel_decision(400, 1);
+    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET6 as u8, 0);
+    assert_eq!(
+        inner_mtu, 1405,
+        "WG PTB inner MTU (v6 outer) MUST be wg_inner_mtu(physical 1500) = 1405, \
+         NOT wg_inner_mtu(logical 1420) = 1325 (the #2684 double-subtract)"
+    );
+    assert_eq!(
+        inner_mtu,
+        crate::afxdp::wg::mss::wg_inner_mtu(libc::AF_INET6, 1500),
+        "WG PTB inner MTU (v6 outer) MUST equal wg_inner_mtu(physical underlay)"
+    );
+
+    // End-to-end: a 1420-byte inner v6 datagram (L3 = 40 + 8 + payload) that
+    // exceeds 1405 must emit a Packet-Too-Big advertising 1405.
+    let (frame, meta) = inbound_v6_udp(1420 - 48); // L3 = 40 + 8 + payload = 1420
+    let l3 = meta.l3_offset as usize;
+    let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu) {
+        EgressMtuDecision::EmitPacketTooBig { next_hop_mtu } => next_hop_mtu,
+        other => panic!("expected EmitPacketTooBig, got {other:?}"),
+    };
+    assert_eq!(next_hop_mtu, 1405, "advertised v6 inner MTU = physical-derived 1405");
+    // ICMPv6 source = ingress interface primary v6; reth0.80 (ifindex 12) now
+    // carries 2001:559:8585:80::8 (added to the snapshot above).
+    let out = build_packet_too_big_v6(&frame, meta, 12, &state, next_hop_mtu as u32)
+        .expect("WG inner-source PTB must build");
+    // VLAN 80 → tagged L2 (18 bytes); derive the L3 offset from the ethertype.
+    let eth = if u16::from_be_bytes([out[12], out[13]]) == 0x8100 { 18 } else { 14 };
+    let icmp = eth + 40;
+    assert_eq!(out[icmp], 2, "ICMPv6 Packet Too Big");
+    assert_eq!(
+        u32::from_be_bytes([out[icmp + 4], out[icmp + 5], out[icmp + 6], out[icmp + 7]]),
+        1405,
+        "Packet-Too-Big carries the physical-derived inner MTU"
+    );
+}
+
+#[test]
+fn post_transform_wg_inner_mtu_falls_back_to_logical_when_no_peer_endpoint() {
+    // Degenerate case: a WG endpoint with no peer endpoint address (no outer
+    // hop to route to) falls back to the resolution's logical egress_ifindex
+    // MTU — exactly what tunnel_outer_mtu would have yielded, so no regression.
+    let mut snap = crate::afxdp::test_fixtures::wg_outer_mtu_snapshot();
+    snap.tunnel_endpoints[0].wg_peers[0].wg_endpoint = String::new(); // responder-only
+    let state = build_forwarding_state(&snap);
+    let decision = wg_logical_tunnel_decision(400, 1);
+    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET as u8, 0);
+    // Logical egress (400) MTU 1420 → wg_inner_mtu(1420) = 1345.
+    assert_eq!(
+        inner_mtu, 1345,
+        "no peer endpoint → fall back to logical egress MTU (1420) → 1345, \
+         no worse than the pre-#2684 tunnel_outer_mtu behaviour"
+    );
+}


### PR DESCRIPTION
Closes #2684

## Summary

The post-transform PMTUD path (`post_transform_inner_mtu` — the TX dispatcher's inner-MTU derivation that turns an oversized **DF-IPv4 / IPv6** inner over a tunnel into a Frag-Needed / Packet-Too-Big) sourced the **WireGuard** arm's outer MTU via `tunnel_outer_mtu` (the #2300 transport-MTU SSOT). For a WG transit flow `endpoint.destination` is zeroed (`forwarding_build::tunnels` — the peer carries the real outer hop), so `tunnel_outer_mtu`'s `tx_ifindex` resolution NoRoutes and the chain falls through to the tunnel **LOGICAL** `egress_ifindex` MTU (~1420 = underlay − encap). Feeding that already-reduced MTU to `wg_inner_mtu` subtracts the WG outer overhead a **second** time → the PTB advertised ~1345 (v4) / 1325 (v6), ~80-100B **smaller** than the underlay permits.

The encap drop guard (#2680) admits inner packets up to `wg_inner_mtu(physical=1500)` = 1425 (v4) / 1405 (v6). So a DF-IPv4 / IPv6 inner in the band `(wg_inner_mtu(logical), wg_inner_mtu(physical)]` got a PTB clamping the sender ~100B too low. Safe (over-conservative — no drops, no black-hole) but causes unnecessary fragmentation pressure / throughput loss; it also meant #2680 fully cured the silent drop only for non-DF IPv4 (which never fires a PTB).

**GRE is NOT affected** — its `endpoint.destination` is the real outer hop, so `tunnel_outer_mtu` already resolves to the physical underlay for `native_gre_inner_mtu`. The GRE arm is left unchanged.

## Fix

The WG arm now derives the outer MTU from the **physical underlay** via the new `frame::wg_endpoint_physical_outer_mtu`, a thin wrapper over the same #2680 `outer_physical_egress_mtu` SSOT the encap guard uses. The PTB path runs *before* the per-packet peer LPM (no inner frame), but the WG outer underlay is per-tunnel-endpoint, not per-inner-flow (#2734) — so it route-resolves the physical egress via the **first peer** that carries an endpoint address. Conservative fallback (no peer endpoint / unresolvable outer) reverts to the logical `egress_ifindex` MTU — the pre-#2684 value, never worse.

No shared encap-overhead constant changed (`WG_OVERHEAD_V4/V6` untouched → no #2792 cross-lane conflict). **No wire change** (`protocol_wire_v1.json` untouched).

## Before / after inner-MTU formula

Per-tunnel outer overhead (`wg/mod.rs`): `WG_OVERHEAD_V4 = 20(IP) + 8(UDP) + 16(WG data hdr) + 16(Poly1305) = 60`; `WG_OVERHEAD_V6 = 40 + 8 + 16 + 16 = 80`; `WG_MAX_PADDING = 15` (worst-case §5.4.6 16-byte alignment pad).

| | outer MTU fed | v4 inner MTU | v6 inner MTU |
|---|---|---|---|
| **before** (`tunnel_outer_mtu` → logical 1420) | 1420 | 1420 − 60 − 15 = **1345** | 1420 − 80 − 15 = **1325** |
| **after** (`wg_endpoint_physical_outer_mtu` → physical 1500) | 1500 | 1500 − 60 − 15 = **1425** | 1500 − 80 − 15 = **1405** |
| **encap guard admit threshold** (`wg_inner_mtu(physical)`) | 1500 | **1425** | **1405** |

Corrected: advertised inner MTU = `physical_mtu − WG_OVERHEAD_{V4,V6} − WG_MAX_PADDING` — the exact inverse of `wg_encapped_size`, so the PTB advertisement and the encap drop guard now derive from one MTU and agree.

## Fail-on-revert proof

New tests in `icmp_ptb_tests.rs` use the realistic `wg_outer_mtu_snapshot` fixture (logical wg0.0 ifindex 400 MTU 1420 ≠ physical reth0.80 ifindex 12 MTU 1500, peer 203.0.113.7 routed via reth0.80):
- `post_transform_wg_inner_mtu_uses_physical_underlay_not_logical_v4` → v4 Frag-Needed advertises **1425**.
- `post_transform_wg_inner_mtu_uses_physical_underlay_not_logical_v6` → v6 Packet-Too-Big advertises **1405**.
- `post_transform_wg_inner_mtu_falls_back_to_logical_when_no_peer_endpoint` → **1345** (degenerate no-peer fallback = pre-fix value, proves no regression).

Proven RED via copy-restore (reverting the WG arm to `tunnel_outer_mtu`):
```
assertion `left == right` failed: WG PTB inner MTU MUST be wg_inner_mtu(physical 1500) = 1425, NOT wg_inner_mtu(logical 1420) = 1345
  left: 1345   right: 1425
assertion `left == right` failed: WG PTB inner MTU (v6 outer) MUST be ... 1405, NOT ... 1325
  left: 1325   right: 1405
```

## Gates
- `cargo build --release -p xpf-userspace-dp`: clean.
- `cargo test --release --bin xpf-userspace-dp -- ptb mtu icmp`: **192/0**.
- `cargo test --release --bin xpf-userspace-dp -- wg tunnel`: **268/0**.
- No Go change. `protocol_wire_v1.json` untouched.

## Docs
`docs/wireguard-interop.md` — new #2684 subsection under the Outer MTU SSOT section. `_Log.md` dated entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
