### PR TITLE
config: type per-interface dynamic-dns source-address leaf (#2780)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -16613,3 +16613,30 @@ top.
   passed / 0 failed.
   **File(s)**: userspace-dp/src/afxdp/frame/wg.rs,
   docs/wireguard-interop.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2780 — type the per-interface Surface A `dynamic-dns
+  source-address` leaf (`ValueIPAddress` + `ValidateIPAddress`, reusing
+  the existing GRE/tunnel IP-literal validator — NO new validator added).
+  The leaf was free-form (placeholder only), so any string committed
+  cleanly. The runtime feeds it to `netip.ParseAddr`
+  (`pkg/ddns/backend_bind.go` `resolveBindConfig`), where an unparseable
+  value is a HARD error → the backend falls back to a no-op for that
+  scope and the binding silently stops emitting UPDATEs. The typed leaf
+  rejects a non-IP literal at COMMIT (riding the generic #1319
+  `SchemaValidate` gate: strict at commit via `compileTreeStrict`,
+  lenient/warn on boot-load + peer-sync, identical to the #2779 hostname
+  leaf). Mirrors the #2779 `ValueHostname`/`ValidateDDNSHostname`
+  pattern. Family-mismatch enforcement (v4 record / v6 bind) is left to
+  the runtime + Surface A status — the schema leaf closure has no family
+  context.
+  FAIL-ON-REVERT: copied `schema_interfaces.go` aside, reverted the leaf
+  to the old free-form `{placeholder:"<ip>"}` form, ran
+  `go test ./pkg/config/ -run TestSchemaValidate_DDNSSourceAddress_2780`
+  → FAILED (all 14 reject cases got nil); restored from the copy, green.
+  Gates: go build ./... clean; gofmt -l clean; go vet ./pkg/config/...
+  ./pkg/ddns/... clean; go test ./pkg/config/... ./pkg/ddns/...
+  ./pkg/cmdtree/... all ok.
+  **File(s)**: pkg/config/schema_interfaces.go,
+  pkg/config/schema_validate_ddns_source_address_2780_test.go,
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -830,6 +830,21 @@ reserved for whole-dataplane selection where a rewrite shim
       canonicalization. Contract: every name that passes commit is a fixed
       point of `sanitizeFQDN` (cross-package test
       `pkg/ddns/surface_a_hostname_2779_test.go`).
+    - **`source-address` is a TYPED leaf (#2780, `ValueIPAddress` +
+      `ValidateIPAddress`, reusing the GRE/tunnel IP-literal validator).** It
+      was free-form. The runtime feeds it to `netip.ParseAddr`
+      (`pkg/ddns/backend_bind.go` `resolveBindConfig`), where an unparseable
+      value is a HARD error: the backend then falls back to a no-op for that
+      scope and the binding SILENTLY stops emitting UPDATEs. Typing the leaf
+      rejects a non-IP literal at commit (naming the `source-address` leaf)
+      instead of committing garbage that disables the scope at runtime. A bare
+      IP only (v4 or v6, no prefix length) — matching `netip.ParseAddr`. The
+      validator has no family context (the leaf closure receives only the raw
+      value), so either family literal commits under either `inet`/`inet6`
+      parent; a genuine v4-record / v6-bind family mismatch is left to the
+      runtime + Surface A status (not a commit-time gate). Regression coverage:
+      `pkg/config/schema_validate_ddns_source_address_2780_test.go`
+      (fail-on-revert accept/reject table).
   - **Reuses the pkg/ddns spine** (`pkg/ddns/surface_a.go`,
     `SurfaceAManager`): the SAME `DNSUpdater`/rfc2136 backend (self-ownership —
     no DHCID), the SAME `ScopeKey`, and the SAME durable-state shape (a separate

--- a/pkg/config/schema_interfaces.go
+++ b/pkg/config/schema_interfaces.go
@@ -463,6 +463,20 @@ func interfaceDynamicDNSSchema() *schemaNode {
 			validator:     ValidateIntegerMin(1),
 			children:      nil,
 		},
-		"source-address": {desc: "Source address to bind the UPDATE socket to (overrides the provider's)", args: 1, placeholder: "<ip>", children: nil},
+		"source-address": {
+			desc: "Source address to bind the UPDATE socket to (overrides the provider's)",
+			args: 1,
+			// #2780: the runtime feeds source-address to netip.ParseAddr
+			// (pkg/ddns/backend_bind.go resolveBindConfig). A free-form value
+			// that does not parse is a hard error there, so the backend falls
+			// back to a no-op for that scope and the binding silently stops
+			// emitting UPDATEs. Reject a non-IP literal at commit (reusing the
+			// GRE/tunnel ValidateIPAddress) instead of committing garbage that
+			// disables the scope at runtime. A bare IP only — no prefix length.
+			valueType: ValueIPAddress,
+			valueDesc: "Source IP literal to bind the UPDATE socket to (v4 or v6, no prefix)",
+			validator: ValidateIPAddress,
+			children:  nil,
+		},
 	}}
 }

--- a/pkg/config/schema_validate_ddns_source_address_2780_test.go
+++ b/pkg/config/schema_validate_ddns_source_address_2780_test.go
@@ -1,0 +1,78 @@
+package config_test
+
+// #2780 — the per-interface Surface A `dynamic-dns source-address` leaf was
+// free-form (untyped) so any string committed cleanly. The runtime feeds it to
+// netip.ParseAddr (pkg/ddns/backend_bind.go resolveBindConfig): a value that
+// does not parse is a HARD error there, so the backend falls back to a no-op
+// for that scope and the binding silently stops emitting UPDATEs. Typing the
+// leaf as ValueIPAddress with ValidateIPAddress rejects a non-IP literal at
+// commit instead of committing garbage that disables the scope at runtime.
+//
+// FAIL-ON-REVERT: the reject cases below go from error to nil if the validator
+// is detached from the schema leaf (or ValidateIPAddress is neutered). Verified
+// by copy-restoring schema_interfaces.go with the typed leaf reverted to the
+// old free-form form; see the PR body.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func ddnsSourceAddrSetCmd(family, addr string) string {
+	// Quote the value so characters the lexer would otherwise reject in a bare
+	// token (slash for a CIDR, garbage punctuation) reach the typed-leaf
+	// validator intact rather than being rejected earlier by the parser.
+	return fmt.Sprintf(
+		"set interfaces ge-0-0-2 unit 0 family %s dynamic-dns source-address %q",
+		family, addr)
+}
+
+func TestSchemaValidate_DDNSSourceAddress_2780_RejectsNonIP(t *testing.T) {
+	// Bare IP literals (v4 or v6, no prefix) are what netip.ParseAddr accepts —
+	// these must commit. The schema validator has no family context (the leaf
+	// closure receives only the raw value), so either family literal is allowed
+	// under either inet/inet6 parent; the runtime + Surface A status surface a
+	// genuine v4/v6 record-vs-bind mismatch.
+	accept := []string{
+		"10.0.1.10",
+		"192.0.2.1",
+		"172.16.50.8",
+		"2001:db8::1",
+		"fe80::1",
+		"::1",
+	}
+	// Free-form garbage and prefixed forms the runtime's netip.ParseAddr would
+	// reject (silently disabling the scope today) must now be commit errors.
+	reject := []string{
+		"not-an-ip",
+		"10.0.1.999",     // octet out of range
+		"10.0.1.10/24",   // prefix length not allowed (bare IP only)
+		"2001:db8::1/64", // prefix length not allowed
+		"10.0.1",         // truncated
+		"interface",      // looks like an address-source enum, not an IP
+		"2001:db8:::1",   // malformed v6
+	}
+
+	for _, family := range []string{"inet", "inet6"} {
+		for _, a := range accept {
+			cmd := ddnsSourceAddrSetCmd(family, a)
+			if err := flatSchemaCheck(t, cmd); err != nil {
+				t.Errorf("accept %q: unexpected commit error: %v", cmd, err)
+			}
+		}
+		for _, a := range reject {
+			cmd := ddnsSourceAddrSetCmd(family, a)
+			err := flatSchemaCheck(t, cmd)
+			if err == nil {
+				t.Errorf("reject %q: expected a commit error (value does not "+
+					"parse as an IP and silently disables the scope at runtime), "+
+					"got nil", cmd)
+				continue
+			}
+			if !strings.Contains(err.Error(), "source-address") {
+				t.Errorf("reject %q: error should name the offending leaf: %v", cmd, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #2780

## Summary
The per-interface Surface A `dynamic-dns source-address` leaf
(`interfaces <if> unit <n> family <af> dynamic-dns source-address`) was
**free-form** — placeholder only, no value type or validator — so any
string committed cleanly. The runtime feeds the value to
`netip.ParseAddr` in `pkg/ddns/backend_bind.go` `resolveBindConfig`,
where an unparseable value is a **hard error**: the backend falls back
to a no-op for that scope and the binding silently stops emitting
UPDATEs (or fails later at socket bind). The bad value committed with no
specific warning and disabled the scope at runtime.

## Chosen type
**`ValueIPAddress` + `ValidateIPAddress`** — a bare IPv4-or-IPv6 literal,
no prefix length, matching `netip.ParseAddr`. **Reused** the existing
GRE/tunnel `ValidateIPAddress` validator (no new validator added). This
mirrors the #2779 `ValueHostname`/`ValidateDDNSHostname` typing approach
and rides the generic #1319 `SchemaValidate` gate, so it is **strict at
commit** and **lenient/warn on boot-load + peer-sync** per #1960
discipline — same path as the just-merged #2779 hostname leaf.

The schema leaf closure has no family context (it receives only the raw
value), so either family literal commits under either `inet`/`inet6`
parent. A genuine v4-record / v6-bind **family mismatch** is left to the
runtime + Surface A status (a larger runtime change, out of scope for
this config-layer typing fix).

## Fail-on-revert proof
Copied `schema_interfaces.go` aside, reverted the leaf to the old
free-form `{desc:..., args:1, placeholder:"<ip>"}` form, ran
`go test ./pkg/config/ -run TestSchemaValidate_DDNSSourceAddress_2780`
→ **FAILED**: all 14 reject cases (`not-an-ip`, `10.0.1.999`,
`10.0.1.10/24`, `2001:db8::1/64`, `10.0.1`, `interface`, `2001:db8:::1`
× inet/inet6) returned nil. Restored from the copy → **green**.

## Gates
- `go build ./...` — clean
- `gofmt -l` — clean on changed files
- `go vet ./pkg/config/... ./pkg/ddns/...` — clean
- `go test ./pkg/config/... ./pkg/ddns/... ./pkg/cmdtree/...` — all pass

## Files
- `pkg/config/schema_interfaces.go` — type the `source-address` leaf
- `pkg/config/schema_validate_ddns_source_address_2780_test.go` — new accept/reject + fail-on-revert table
- `docs/config-schema.md` — document the now-typed leaf
- `_Log.md` — dated entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi