### PR TITLE
ipsec: match local-address family to resolved remote for dynamic-hostname gateways (#2757)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-06-25 — #2757: IPsec dynamic-hostname gateway local-address family match
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed defect #2 of #2404 (deferred by PR #2756). For an
+  IPsec gateway specified by `dynamic hostname <fqdn>` with no explicit
+  `local-address` but an `external-interface`, `PrepareConfig` derived
+  `local_addrs` from the interface using a family hint computed only from
+  `gw.Address`. A dynamic-hostname gateway has `Address == ""`, so the hint
+  was 0 (family-agnostic) and `selectUnitAddress` returned whichever family
+  was listed first on the interface (typically IPv4). On a dual-stack
+  appliance reaching an IPv6 peer, this sourced the IKE SA from the IPv4
+  local-address (wrong family) and the tunnel could not establish. Added
+  `gatewayRemoteFamilyHint` (gateway `address` → that IP's family; dynamic
+  hostname → resolved via the injectable `resolveHostFamily` package var,
+  default `net.LookupIP`: IPv6-only→6, IPv4-only→4, dual-stack→0). The call
+  site now passes the resolved family into `resolveInterfaceAddress`, which
+  constrains selection to that family and falls back to family-agnostic
+  only when the interface is single-stack in the other family (so a
+  degraded config still emits a `local_addrs` line). A bare IP in the
+  hostname slot still classifies directly without a DNS lookup.
+- **File(s)**: `pkg/ipsec/policy.go`, `pkg/ipsec/ipsec_test.go`,
+  `pkg/ipsec/README.md`, `_Log.md`.
+- **Fail-on-revert proof**:
+  `TestPrepareConfig_DynamicHostnameFamilyMatch` injects `resolveHostFamily`
+  so an IPv6 peer must pick the IPv6 local-address (and IPv4→IPv4) from a
+  dual-stack interface whose IPv4 address is listed first. Reverting the
+  call site to the buggy `addressFamilyHint(cp.Address)` made the IPv6
+  subtest FAIL (`local-address = "198.51.100.1", want "2001:db8:1::1"`),
+  proven by copy-restore (`cp policy.go policy.go.bak` → mutate → test RED →
+  restore → test GREEN). Companion tests cover the dual-stack peer
+  (family-agnostic, first-usable) and the single-stack fallback
+  (IPv6 peer / IPv4-only interface → IPv4, not empty).
+- **Gates**: `go build ./...` OK, `gofmt -l pkg/ipsec/` clean,
+  `go vet ./pkg/ipsec/...` clean, `go test ./pkg/ipsec/...` ok.
+
 ## 2026-06-25 — #2651: WG IPv6 outer UDP checksum uses the AVX2 checksum16_ipv6 helper
 
 - **Timestamp**: 2026-06-25

--- a/_Log.md
+++ b/_Log.md
@@ -30,6 +30,24 @@
   restore → test GREEN). Companion tests cover the dual-stack peer
   (family-agnostic, first-usable) and the single-stack fallback
   (IPv6 peer / IPv4-only interface → IPv4, not empty).
+- **Review fold (bounded resolver)**: hostile review (MERGE-NEEDS-MINOR)
+  flagged that the default `resolveHostFamily` used the uncontexted,
+  blocking `net.LookupIP`, and `PrepareConfig` runs SYNCHRONOUSLY in the
+  daemon apply sequence (`pkg/daemon/daemon_apply.go`) and the CLI commit
+  path (`pkg/cli/apply.go`) — neither did any DNS before #2757. A
+  slow/unreachable resolver would stall `commit`/apply for the full glibc
+  resolver timeout. Folded: the default is now `defaultResolveHostFamily`
+  using `net.Resolver.LookupIPAddr(ctx, host)` bounded by a 2s context
+  timeout (`resolveHostFamilyTimeout`); on timeout/error it returns family
+  0 (agnostic), preserving the graceful interface-decides degradation.
+  Since the lookup is only a family hint (strongSwan does the authoritative
+  resolution at IKE time), 2s is ample. The injectable `resolveHostFamily`
+  seam and `func(host string) int` signature are unchanged, so no call-site
+  or family-selection logic changed (reviewer confirmed selection correct).
+  Added `TestDefaultResolveHostFamily_BoundedDegrades` exercising the REAL
+  default impl against an RFC 6761 `.invalid` host: it must return 0 within
+  4× the timeout (a hard deadline that goes RED if the context bound is
+  dropped). The injected-fake family-selection tests stay green.
 - **Gates**: `go build ./...` OK, `gofmt -l pkg/ipsec/` clean,
   `go vet ./pkg/ipsec/...` clean, `go test ./pkg/ipsec/...` ok.
 

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -140,6 +140,32 @@ all files stay in `package ipsec`, so the public API is unchanged.
     gateway — `set security ike gateway <name> address <ip>` (or
     `dynamic hostname <fqdn>`). The shared accept predicate is
     `config.IsUsableIPsecEndpoint`.
+- **Local-address family selection for dynamic-hostname gateways
+  (#2757).** When a gateway has no explicit `local-address` but does name
+  an `external-interface`, `PrepareConfig` derives `local_addrs` from the
+  interface's address. On a dual-stack appliance the interface carries both
+  an IPv4 and an IPv6 address, so the chosen family MUST match the family
+  the remote peer is reached over — otherwise the IKE SA is sourced from
+  the wrong family and never establishes.
+  - **Family hint** (`gatewayRemoteFamilyHint`, `policy.go`): a gateway
+    with a literal `address` takes that IP's family. A **dynamic-hostname**
+    gateway (`address` empty, `dynamic hostname <fqdn>` set) is resolved
+    via `resolveHostFamily` (an injectable package var defaulting to
+    `net.LookupIP`) — IPv6-only → family 6, IPv4-only → family 4. Before
+    #2757 the empty `address` produced a family-agnostic hint (0), so
+    `selectUnitAddress` returned whichever family was listed first on the
+    interface (typically IPv4) regardless of the peer — the defect-#2 bug
+    deferred from #2404.
+  - **Family-matched selection** (`resolveInterfaceAddress`): the local
+    address is constrained to the hinted family. If the interface is
+    single-stack in the OTHER family, selection falls back to
+    family-agnostic so a degraded config still emits a `local_addrs` line
+    instead of an empty one.
+  - **Dual-stack peer:** when the hostname resolves to BOTH families, no
+    explicit preference is configured, so the hint stays family-agnostic
+    (0) and the interface's first usable address decides — strongSwan then
+    initiates from a routable local source. (An explicit `local-address`
+    always wins outright; this path only fires when one is absent.)
 - **IKE policy chain → proposal cross-reference (#2270).** A gateway's
   `ike-policy` reference walks gateway → `ike-policy` → `ike-proposal`
   (`resolveIKESettings`, `ike.go`). When that chain breaks — the

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -150,8 +150,10 @@ all files stay in `package ipsec`, so the public API is unchanged.
   - **Family hint** (`gatewayRemoteFamilyHint`, `policy.go`): a gateway
     with a literal `address` takes that IP's family. A **dynamic-hostname**
     gateway (`address` empty, `dynamic hostname <fqdn>` set) is resolved
-    via `resolveHostFamily` (an injectable package var defaulting to
-    `net.LookupIP`) — IPv6-only → family 6, IPv4-only → family 4. Before
+    via `resolveHostFamily` (an injectable package var; the default,
+    `defaultResolveHostFamily`, uses `net.Resolver.LookupIPAddr` bounded by
+    a 2s context timeout — see the bounded-resolver note below) — IPv6-only
+    → family 6, IPv4-only → family 4. Before
     #2757 the empty `address` produced a family-agnostic hint (0), so
     `selectUnitAddress` returned whichever family was listed first on the
     interface (typically IPv4) regardless of the peer — the defect-#2 bug
@@ -166,6 +168,15 @@ all files stay in `package ipsec`, so the public API is unchanged.
     (0) and the interface's first usable address decides — strongSwan then
     initiates from a routable local source. (An explicit `local-address`
     always wins outright; this path only fires when one is absent.)
+  - **Bounded resolver (review fold):** `PrepareConfig` runs synchronously
+    inside the daemon apply sequence (`pkg/daemon/daemon_apply.go`) and the
+    CLI commit path (`pkg/cli/apply.go`), which did NO DNS before #2757.
+    Because the lookup is only a family *hint* (strongSwan does the
+    authoritative resolution at IKE time), the default `resolveHostFamily`
+    bounds it with a 2s context timeout (`resolveHostFamilyTimeout`). On
+    timeout / NXDOMAIN / SERVFAIL it returns family 0 (agnostic) — a slow or
+    unreachable resolver degrades to the interface-decides path and NEVER
+    stalls `commit` / apply for the full glibc resolver timeout.
 - **IKE policy chain → proposal cross-reference (#2270).** A gateway's
   `ike-policy` reference walks gateway → `ike-policy` → `ike-proposal`
   (`resolveIKESettings`, `ike.go`). When that chain breaks — the

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -1064,6 +1064,139 @@ func TestPrepareConfig_ExternalInterfaceLocalAddress(t *testing.T) {
 	}
 }
 
+// dualStackCfg builds a config whose external interface carries BOTH an IPv4
+// and an IPv6 address, and whose gateway is reached by a dynamic hostname.
+// The local-address family is therefore ambiguous unless it is constrained to
+// the resolved remote family.
+func dualStackCfg(hostname string) *config.Config {
+	return &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"wan0": {
+					Name: "wan0",
+					Units: map[int]*config.InterfaceUnit{
+						0: {
+							// IPv4 listed first so a family-agnostic
+							// selection would wrongly win it for the IPv6
+							// peer (the #2757 bug).
+							Addresses: []string{
+								"198.51.100.1/24",
+								"2001:db8:1::1/64",
+							},
+						},
+					},
+				},
+			},
+		},
+		Security: config.SecurityConfig{
+			IPsec: config.IPsecConfig{
+				Gateways: map[string]*config.IPsecGateway{
+					"gw": {
+						Name:            "gw",
+						DynamicHostname: hostname,
+						ExternalIface:   "wan0.0",
+					},
+				},
+				VPNs: map[string]*config.IPsecVPN{
+					"tun": {Gateway: "gw"},
+				},
+			},
+		},
+	}
+}
+
+// TestPrepareConfig_DynamicHostnameFamilyMatch is the #2757 fail-on-revert
+// guard: a dual-stack appliance reaching a dynamic-hostname gateway must
+// source the IKE SA from the local-address whose family matches the family
+// the peer resolves to. If the family-matching is reverted (the empty
+// gateway.Address yields a family-agnostic hint), the IPv4 address — listed
+// first on the interface — wins for the IPv6 peer and this test goes RED.
+func TestPrepareConfig_DynamicHostnameFamilyMatch(t *testing.T) {
+	orig := resolveHostFamily
+	t.Cleanup(func() { resolveHostFamily = orig })
+
+	tests := []struct {
+		name          string
+		resolvedFam   int
+		wantLocalAddr string
+	}{
+		{"ipv6 peer selects ipv6 local", 6, "2001:db8:1::1"},
+		{"ipv4 peer selects ipv4 local", 4, "198.51.100.1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resolveHostFamily = func(host string) int {
+				if host != "peer.example.com" {
+					t.Fatalf("unexpected host lookup: %q", host)
+				}
+				return tc.resolvedFam
+			}
+			cfg := dualStackCfg("peer.example.com")
+			prepared := PrepareConfig(cfg)
+			got := prepared.Gateways["gw"].LocalAddress
+			if got != tc.wantLocalAddr {
+				t.Fatalf("local-address = %q, want %q (family %d)",
+					got, tc.wantLocalAddr, tc.resolvedFam)
+			}
+		})
+	}
+}
+
+// TestPrepareConfig_DynamicHostnameDualStackPeer verifies that when the peer
+// resolves to BOTH families (no explicit preference), local-address selection
+// stays family-agnostic and degrades to the interface's first usable address
+// rather than guessing — and that a single-stack interface still resolves.
+func TestPrepareConfig_DynamicHostnameDualStackPeer(t *testing.T) {
+	orig := resolveHostFamily
+	t.Cleanup(func() { resolveHostFamily = orig })
+	resolveHostFamily = func(string) int { return 0 } // dual-stack peer
+
+	cfg := dualStackCfg("peer.example.com")
+	prepared := PrepareConfig(cfg)
+	got := prepared.Gateways["gw"].LocalAddress
+	if got != "198.51.100.1" {
+		t.Fatalf("dual-stack peer local-address = %q, want 198.51.100.1 (first usable)", got)
+	}
+}
+
+// TestPrepareConfig_DynamicHostnameFamilyFallback verifies the single-stack
+// fallback: an IPv6-only peer against an IPv4-only interface still yields the
+// IPv4 local-address rather than an empty local_addrs.
+func TestPrepareConfig_DynamicHostnameFamilyFallback(t *testing.T) {
+	orig := resolveHostFamily
+	t.Cleanup(func() { resolveHostFamily = orig })
+	resolveHostFamily = func(string) int { return 6 } // IPv6 peer
+
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"wan0": {
+					Name: "wan0",
+					Units: map[int]*config.InterfaceUnit{
+						0: {Addresses: []string{"198.51.100.1/24"}}, // IPv4 only
+					},
+				},
+			},
+		},
+		Security: config.SecurityConfig{
+			IPsec: config.IPsecConfig{
+				Gateways: map[string]*config.IPsecGateway{
+					"gw": {
+						Name:            "gw",
+						DynamicHostname: "peer.example.com",
+						ExternalIface:   "wan0.0",
+					},
+				},
+				VPNs: map[string]*config.IPsecVPN{"tun": {Gateway: "gw"}},
+			},
+		},
+	}
+	prepared := PrepareConfig(cfg)
+	if got := prepared.Gateways["gw"].LocalAddress; got != "198.51.100.1" {
+		t.Fatalf("IPv6-peer/IPv4-only-iface local-address = %q, want 198.51.100.1 (fallback)", got)
+	}
+}
+
 // #1798 belt test: a pre-shared key (or identity) carrying an embedded
 // newline must not inject extra swanctl.conf sections/keys even if
 // commit-time validation were bypassed.

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -3,6 +3,7 @@ package ipsec
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -1139,6 +1140,29 @@ func TestPrepareConfig_DynamicHostnameFamilyMatch(t *testing.T) {
 					got, tc.wantLocalAddr, tc.resolvedFam)
 			}
 		})
+	}
+}
+
+// TestDefaultResolveHostFamily_BoundedDegrades exercises the REAL default
+// resolver implementation (not an injected fake) and proves it (a) is bounded
+// by resolveHostFamilyTimeout and (b) degrades to family 0 on failure rather
+// than hanging the synchronous commit/apply path (#2757 review fold). It uses
+// the RFC 6761 reserved `.invalid` TLD, which is guaranteed never to resolve,
+// so the lookup fails (NXDOMAIN / no such host) without depending on a
+// reachable nameserver. The hard deadline (4x the timeout) catches a
+// regression that drops the context bound; the expected return is 0.
+func TestDefaultResolveHostFamily_BoundedDegrades(t *testing.T) {
+	done := make(chan int, 1)
+	go func() { done <- defaultResolveHostFamily("xpf-2757-nonexistent.invalid") }()
+
+	select {
+	case fam := <-done:
+		if fam != 0 {
+			t.Fatalf("unresolvable host family = %d, want 0 (degrade-to-agnostic)", fam)
+		}
+	case <-time.After(4 * resolveHostFamilyTimeout):
+		t.Fatalf("default resolver did not return within %v — context bound missing",
+			4*resolveHostFamilyTimeout)
 	}
 }
 

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -1,6 +1,7 @@
 package ipsec
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 )
@@ -553,20 +555,42 @@ func resolveInterfaceAddressFamily(cfg *config.Config, ifaceRef string, family i
 	return ""
 }
 
+// resolveHostFamilyTimeout bounds the default dynamic-hostname DNS lookup.
+// PrepareConfig runs SYNCHRONOUSLY in the daemon's ordered apply sequence
+// (pkg/daemon/daemon_apply.go) and the CLI commit path (pkg/cli/apply.go),
+// neither of which did any DNS before #2757. This lookup is only a *family
+// hint* (strongSwan does the authoritative resolution at IKE time), so it
+// must never stall commit/apply for the full glibc resolver timeout. 2s is
+// ample for a hint; on timeout/error the default returns family 0 and the
+// interface-decides fallback applies — graceful degradation, never a hang.
+const resolveHostFamilyTimeout = 2 * time.Second
+
 // resolveHostFamily is the hook used to resolve a dynamic-hostname gateway to
 // an address family for local-address selection. It is a package var so tests
-// can make resolution deterministic without real DNS. It returns 4 if the
-// host resolves to (or prefers) IPv4, 6 for IPv6, and 0 if it cannot resolve
-// or the host is dual-stack with no clear preference (let the local interface
-// decide). The default uses the system resolver.
-var resolveHostFamily = func(host string) int {
-	ips, err := net.LookupIP(host)
+// can make resolution deterministic without real DNS (tests inject a fake; no
+// real DNS in the test suite). It returns 4 if the host resolves to (or
+// prefers) IPv4, 6 for IPv6, and 0 if it cannot resolve, times out, or the
+// host is dual-stack with no clear preference (let the local interface
+// decide). The default uses the system resolver bounded by
+// resolveHostFamilyTimeout.
+var resolveHostFamily = defaultResolveHostFamily
+
+func defaultResolveHostFamily(host string) int {
+	ctx, cancel := context.WithTimeout(
+		context.Background(), resolveHostFamilyTimeout)
+	defer cancel()
+
+	var r net.Resolver
+	ips, err := r.LookupIPAddr(ctx, host)
 	if err != nil || len(ips) == 0 {
+		// Timeout / NXDOMAIN / SERVFAIL: fall back to family-agnostic so a
+		// slow or unreachable resolver degrades to interface-decides rather
+		// than stalling commit/apply or guessing the family.
 		return 0
 	}
 	var has4, has6 bool
-	for _, ip := range ips {
-		if ip.To4() != nil {
+	for _, addr := range ips {
+		if addr.IP.To4() != nil {
 			has4 = true
 		} else {
 			has6 = true

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -482,7 +482,8 @@ func PrepareConfig(cfg *config.Config) *config.IPsecConfig {
 	for name, gw := range src.Gateways {
 		cp := *gw
 		if cp.LocalAddress == "" && cp.ExternalIface != "" {
-			cp.LocalAddress = resolveInterfaceAddress(cfg, cp.ExternalIface, cp.Address)
+			cp.LocalAddress = resolveInterfaceAddress(
+				cfg, cp.ExternalIface, gatewayRemoteFamilyHint(&cp))
 		}
 		out.Gateways[name] = &cp
 	}
@@ -509,8 +510,32 @@ func PrepareConfig(cfg *config.Config) *config.IPsecConfig {
 	return out
 }
 
-func resolveInterfaceAddress(cfg *config.Config, ifaceRef, remoteAddr string) string {
-	family := addressFamilyHint(remoteAddr)
+// resolveInterfaceAddress selects the local-address to bind for an IKE SA
+// from the external interface, constrained to the remote gateway's address
+// family. family is the resolved remote family hint (4, 6, or 0 for
+// "either" — see gatewayRemoteFamilyHint). Constraining by family is what
+// keeps a dual-stack appliance from sourcing the SA out of the wrong family
+// vs the resolved peer (#2757): if the remote is/resolves to IPv6, the IPv6
+// local-address is chosen, and vice versa.
+//
+// When the constrained family yields no local-address on the interface (the
+// interface is single-stack in the other family), we fall back to a
+// family-agnostic selection so a misconfiguration degrades to the legacy
+// behavior rather than emitting no local_addrs line at all.
+func resolveInterfaceAddress(cfg *config.Config, ifaceRef string, family int) string {
+	if addr := resolveInterfaceAddressFamily(cfg, ifaceRef, family); addr != "" {
+		return addr
+	}
+	if family != 0 {
+		// The remote family has no matching local-address on this
+		// interface — fall back to whatever the interface offers rather
+		// than rendering an empty local_addrs.
+		return resolveInterfaceAddressFamily(cfg, ifaceRef, 0)
+	}
+	return ""
+}
+
+func resolveInterfaceAddressFamily(cfg *config.Config, ifaceRef string, family int) string {
 	if addr := resolveConfiguredInterfaceAddress(cfg, ifaceRef, family); addr != "" {
 		return addr
 	}
@@ -526,6 +551,64 @@ func resolveInterfaceAddress(cfg *config.Config, ifaceRef, remoteAddr string) st
 	}
 
 	return ""
+}
+
+// resolveHostFamily is the hook used to resolve a dynamic-hostname gateway to
+// an address family for local-address selection. It is a package var so tests
+// can make resolution deterministic without real DNS. It returns 4 if the
+// host resolves to (or prefers) IPv4, 6 for IPv6, and 0 if it cannot resolve
+// or the host is dual-stack with no clear preference (let the local interface
+// decide). The default uses the system resolver.
+var resolveHostFamily = func(host string) int {
+	ips, err := net.LookupIP(host)
+	if err != nil || len(ips) == 0 {
+		return 0
+	}
+	var has4, has6 bool
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			has4 = true
+		} else {
+			has6 = true
+		}
+	}
+	switch {
+	case has4 && has6:
+		// Dual-stack peer: no explicit preference is configured, so let
+		// the local interface's available family decide (family-agnostic).
+		return 0
+	case has6:
+		return 6
+	case has4:
+		return 4
+	default:
+		return 0
+	}
+}
+
+// gatewayRemoteFamilyHint determines the address family (4, 6, or 0 for
+// either) that the local-address for this gateway must match. A gateway with
+// a literal remote Address takes the family of that IP. A dynamic-hostname
+// gateway (Address empty, DynamicHostname set) is resolved via
+// resolveHostFamily so the chosen local-address matches the family the peer
+// actually resolves to (#2757) — previously the empty Address yielded a
+// family-agnostic hint and the wrong-family local-address could win on a
+// dual-stack appliance.
+func gatewayRemoteFamilyHint(gw *config.IPsecGateway) int {
+	if gw == nil {
+		return 0
+	}
+	if gw.Address != "" {
+		return addressFamilyHint(gw.Address)
+	}
+	if gw.DynamicHostname != "" {
+		// A bare IP in the hostname slot still classifies directly.
+		if f := addressFamilyHint(gw.DynamicHostname); f != 0 {
+			return f
+		}
+		return resolveHostFamily(gw.DynamicHostname)
+	}
+	return 0
 }
 
 func resolveConfiguredInterfaceAddress(cfg *config.Config, ifaceRef string, family int) string {


### PR DESCRIPTION
Closes #2757

## Summary

Defect #2 of #2404 (deferred by PR #2756): an IKE gateway specified by a
**dynamic hostname** with no explicit `local-address` but with an
`external-interface` picked the WRONG local-address **family** on a
dual-stack appliance, so the IKE SA was sourced from the wrong family vs
the resolved peer and the tunnel could not establish.

**Root cause** (`pkg/ipsec/policy.go`): `PrepareConfig` derived
`local_addrs` from the external interface using a family hint computed
only from `gw.Address`. A dynamic-hostname gateway has `Address == ""`,
so the hint was `0` (family-agnostic) and `selectUnitAddress` returned
whichever family was listed first on the interface (typically IPv4),
regardless of the peer.

**Fix**: `gatewayRemoteFamilyHint` — a gateway with a literal `address`
takes that IP's family; a dynamic-hostname gateway is resolved via the
injectable `resolveHostFamily` package var (default `net.LookupIP`):
IPv6-only → 6, IPv4-only → 4, dual-stack → 0 (no explicit preference →
let the interface decide). `resolveInterfaceAddress` constrains selection
to the hinted family and falls back to family-agnostic only when the
interface is single-stack in the other family (so a degraded config still
emits a `local_addrs` line). A bare IP in the hostname slot classifies
directly without a DNS lookup. An explicit `local-address` still wins
outright.

Scope: `pkg/ipsec` only. No grammar/resolver-path change beyond an
injectable lookup hook.

## Gates (foreground)
- `go build ./...` — OK
- `gofmt -l pkg/ipsec/` — clean
- `go vet ./pkg/ipsec/...` — clean
- `go test ./pkg/ipsec/...` — ok

## Fail-on-revert proof
`TestPrepareConfig_DynamicHostnameFamilyMatch` injects `resolveHostFamily`
so an IPv6 peer must select the IPv6 local-address (and IPv4→IPv4) from a
dual-stack interface whose IPv4 address is listed first. Proven via
copy-restore (`cp policy.go policy.go.bak` → mutate call site back to the
buggy `addressFamilyHint(cp.Address)` → test RED → restore → GREEN):

```
--- FAIL: TestPrepareConfig_DynamicHostnameFamilyMatch/ipv6_peer_selects_ipv6_local
    ipsec_test.go: local-address = "198.51.100.1", want "2001:db8:1::1" (family 6)
```

Companion tests cover the dual-stack peer (family-agnostic, first-usable)
and the single-stack fallback (IPv6 peer / IPv4-only interface → IPv4,
not empty).

## Docs
`pkg/ipsec/README.md` documents the family-selection contract; `_Log.md`
dated entry records files + the fail-on-revert proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi