### PR TITLE
wireguard: clamp advertised/configured inner MTU to engine PADDED_PLAINTEXT_MAX (4096)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-06-25 — #2457: WG advertised/configured inner MTU clamped to engine PADDED_PLAINTEXT_MAX (4096)
+
+- **Timestamp**: 2026-06-25
+- **Action**: The WireGuard engine encrypts at most
+  `PADDED_PLAINTEXT_MAX = 4096` bytes of §5.4.6-padded plaintext per
+  transport message (encap rejects oversized inners → `encap_mtu_drops`),
+  but the inner-MTU derivation was purely `outer_mtu − overhead − pad` with
+  NO clamp to that ceiling. On a jumbo underlay (or an operator-set
+  `mtu 9000` on a wgN device) the advertised/configured inner MTU could
+  exceed 4096, so a sender honoring it still had every oversized inner
+  packet silently dropped at the engine cap (advertised-vs-encryptable
+  mismatch; codex review-033 finding 033-19). Fix: clamp BOTH inner-MTU
+  surfaces to the engine ceiling. Rust: exported
+  `engine::WG_ENGINE_MAX_INNER_MTU` (= `PADDED_PLAINTEXT_MAX`, compile-time
+  asserted as the true unpadded ceiling) and made `wg::mss::wg_inner_mtu`
+  return `min(outer_derived, WG_ENGINE_MAX_INNER_MTU)` — this is the
+  pad-aware SSOT feeding TCP segmentation AND the #2684 PTB advertisement,
+  so both are now capped. Go: `pkg/routing/tunnel.go::wgTunMTUForEndpoint`
+  clamps the configured wgN device MTU (operator override AND default-
+  derived) to `wgEngineMaxInnerMTU = 4096`, mirroring the Rust constant.
+  Distinct from #2684 (which fixed WHICH outer MTU the PTB reads) — #2457
+  caps the RESULT against the engine's hard encryptable limit. Did NOT
+  touch `icmp_ptb.rs` (#2684 surface), `frame/wg.rs` egress (#2792), or the
+  udp6 checksum (#2651). No wire change (`protocol_wire_v1.json` untouched).
+- **File(s)**: `userspace-dp/src/afxdp/wg/engine.rs`,
+  `userspace-dp/src/afxdp/wg/mss.rs`, `pkg/routing/tunnel.go`,
+  `pkg/routing/tunnel_reconcile_test.go`, `docs/wireguard-interop.md`,
+  `_Log.md`.
+- **Fail-on-revert proof (copy-restore, no git checkout)**:
+  - Rust: `cp mss.rs mss.rs.bak`; stripped the `.min(WG_ENGINE_MAX_INNER_MTU)`
+    clamp → `wg_inner_mtu_jumbo_clamped_to_engine_max` and
+    `wg_inner_mtu_below_ceiling_passes_unchanged` both FAILED (jumbo returned
+    the unclamped 8925/8905, boundary at-ceiling returned 4097); restored
+    from backup → all 10 `wg_inner_mtu` tests pass.
+  - Go: `cp tunnel.go tunnel.go.bak`; stripped the operator-override
+    `min(tc.MTU, wgEngineMaxInnerMTU)` → `TestWgTunMTUForEndpointClampsToEngineMax`
+    FAILED ("jumbo override mtu 9000: got 9000, want 4096"); restored → pass.
+- **Gates**: `cargo build --release -p xpf-userspace-dp` OK;
+  `cargo test --release --bin xpf-userspace-dp -- wg mtu` 244/0;
+  `go build`/`gofmt`/`go vet`/`go test ./pkg/routing/` all clean.
+
 ## 2026-06-25 — #2651: WG IPv6 outer UDP checksum uses the AVX2 checksum16_ipv6 helper
 
 - **Timestamp**: 2026-06-25

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -150,11 +150,12 @@ clamp / post-transform PMTUD (#2299/#2330/#2457). Conservative fallback: an
 unresolvable outer route falls back to the resolution's `egress_ifindex` MTU
 (the pre-#2680 behaviour) then 1500 — never tighter than before.
 On the Go side, `wgTunMTUForEndpoint` honors an operator-set `mtu` on the
-tunnel interface (the supported sub-1500 / jumbo override — PPPoE 1492,
-cloud overlays ~1450); with no operator MTU it derives the wgN inner MTU
-from `wgDefaultOuterMTU` minus the family overhead. The pre-#2300 code
-ignored `tc.MTU` entirely and always derived from 1500, so a
-lowered-underlay deployment could not set a smaller wgN MTU.
+tunnel interface (the supported sub-1500 override — PPPoE 1492, cloud
+overlays ~1450); with no operator MTU it derives the wgN inner MTU from
+`wgDefaultOuterMTU` minus the family overhead. The pre-#2300 code ignored
+`tc.MTU` entirely and always derived from 1500, so a lowered-underlay
+deployment could not set a smaller wgN MTU. Both branches are clamped to the
+engine ceiling (#2457, below).
 
 **#2684 (PTB advertisement — the #2680 sibling on the same SSOT).** The
 post-transform PMTUD path (`post_transform_inner_mtu`, the TX dispatcher's
@@ -187,6 +188,44 @@ admits against, so the PTB and the guard now agree. Conservative fallback
 `egress_ifindex` MTU — the pre-#2684 value, never worse. GRE is unaffected:
 its `endpoint.destination` is the real outer hop, so `tunnel_outer_mtu`
 already resolves to the physical underlay for `native_gre_inner_mtu`.
+
+**#2457 (advertised/configured inner MTU clamped to the engine ceiling).**
+The WG engine encrypts at most `PADDED_PLAINTEXT_MAX = 4096` bytes of
+§5.4.6-padded plaintext per transport message; the encap path rejects any
+inner whose 16-byte-padded length exceeds that, counting `encap_mtu_drops`.
+Because `PADDED_PLAINTEXT_MAX` is itself a 16-multiple, the largest
+ENCRYPTABLE unpadded inner IP packet is exactly 4096 — exported as
+`engine::WG_ENGINE_MAX_INNER_MTU` (compile-time-asserted: 4096 pads to ≤4096
+and is accepted, 4097 pads to 4112 and is rejected). This is a HARD ceiling
+INDEPENDENT of the outer link: the prior MTU math was purely
+`outer_mtu − overhead − pad`, so on a jumbo underlay (or an operator
+`set interfaces wgN unit U family inet mtu 9000`) the advertised / configured
+inner MTU could exceed 4096. A sender that honored the larger advertised MTU
+still had every oversized inner packet silently dropped at the engine cap —
+advertised-vs-encryptable mismatch.
+
+Both surfaces now clamp to the ceiling:
+
+- Rust `wg::mss::wg_inner_mtu` (the pad-aware SSOT feeding TCP segmentation
+  AND the #2684 PTB advertisement) returns
+  `min(outer_mtu − overhead − pad, WG_ENGINE_MAX_INNER_MTU)`. At a normal
+  ≤1500 underlay the clamp is a no-op; on a jumbo underlay it caps both the
+  segmentation budget and the PTB the engine advertises to inner senders at
+  4096. This is distinct from #2684, which fixed WHICH outer MTU the PTB
+  reads (logical→physical); #2457 caps the RESULT against what the engine can
+  encrypt regardless of how large the (now-correct) physical underlay is.
+- Go `pkg/routing/tunnel.go::wgTunMTUForEndpoint` clamps the configured wgN
+  DEVICE MTU — an operator `mtu` override (and the default-derived value) is
+  `min(value, wgEngineMaxInnerMTU)`, where `wgEngineMaxInnerMTU = 4096`
+  mirrors the Rust constant. This keeps the kernel from handing the engine a
+  plaintext above the encryptable maximum in the first place.
+
+A jumbo WireGuard inner (>4096) is therefore intentionally NOT supported
+today; raising it is a coordinated bump of `PADDED_PLAINTEXT_MAX` (with
+proven stack/heap safety for the larger staging buffer) plus the two mirrored
+ceiling constants — the compile-time assert in `engine.rs` and the
+`wgEngineMaxInnerMTU != 4096` guard in the Go test fail loudly if one side
+drifts.
 
 **#2701 (transit-egress OUTER SOURCE).** The #2680 MTU fix resolved the
 physical underlay egress for the MTU guard but left the OUTER IP SOURCE

--- a/pkg/routing/tunnel.go
+++ b/pkg/routing/tunnel.go
@@ -1132,6 +1132,23 @@ const (
 	wgPadWorst   = 15
 )
 
+// wgEngineMaxInnerMTU is the largest INNER IP packet (pre-§5.4.6 padding)
+// the WireGuard engine can encrypt in one transport message. It MUST mirror
+// userspace-dp afxdp/wg/engine.rs WG_ENGINE_MAX_INNER_MTU
+// (= PADDED_PLAINTEXT_MAX = 4096). The engine rejects an inner whose
+// 16-byte-padded length exceeds PADDED_PLAINTEXT_MAX; because
+// PADDED_PLAINTEXT_MAX is itself a 16-multiple, the largest accepted unpadded
+// inner length is exactly 4096.
+//
+// #2457: the configured / derived wgN inner MTU MUST be clamped to this
+// ceiling. Without the clamp, an operator who sets `mtu 9000` on a wgN
+// interface (or a jumbo underlay deriving a >4096 inner budget) hands the
+// engine plaintext above its encryptable maximum, so every oversized packet
+// is silently dropped at the encap `padded_len > PADDED_PLAINTEXT_MAX` guard
+// (`encap_mtu_drops`). Clamping makes the advertised/configured inner MTU
+// match what the engine actually accepts.
+const wgEngineMaxInnerMTU = 4080 + 16 // 4096
+
 // wgDefaultOuterMTU is the assumed underlay (outer-link) MTU used to
 // derive the wgN inner MTU when the operator has not set an explicit
 // `mtu` on the tunnel (#2300). It mirrors the Rust control-thread
@@ -1166,8 +1183,15 @@ func wgTunMTUForEndpoint(tc *config.TunnelConfig) int {
 	// the inner wgN MTU. This is the divergence #2300 closes — the prior
 	// code ignored tc.MTU entirely and always derived from 1500, so a
 	// lowered-underlay deployment could not set a smaller wgN MTU.
+	//
+	// #2457: clamp the override to the engine's encryptable ceiling. An
+	// operator who sets `mtu 9000` on a jumbo wgN device would otherwise
+	// have the kernel hand the WG engine plaintext above
+	// wgEngineMaxInnerMTU (4096), which the encap guard silently drops
+	// (`encap_mtu_drops`). Clamping keeps the configured device MTU at or
+	// below what the engine can actually encrypt.
 	if tc.MTU > 0 {
-		return tc.MTU
+		return min(tc.MTU, wgEngineMaxInnerMTU)
 	}
 	// A configured v4 endpoint uses the v4 overhead; a v6 endpoint (or a
 	// responder-only/roaming endpoint with no configured address, which
@@ -1181,7 +1205,11 @@ func wgTunMTUForEndpoint(tc *config.TunnelConfig) int {
 	if !tc.WgOuterFamilyV6() && tc.WgHasEndpoint() {
 		overhead = wgOverheadV4
 	}
-	return wgDefaultOuterMTU - overhead - wgPadWorst
+	// #2457: the default-derived value also clamps to the engine ceiling
+	// so a jumbo wgDefaultOuterMTU (were it ever raised) cannot derive an
+	// inner budget the engine cannot encrypt. At the shipped 1500 default
+	// this is a no-op.
+	return min(wgDefaultOuterMTU-overhead-wgPadWorst, wgEngineMaxInnerMTU)
 }
 
 // applyWireguardTunLocked creates (or reuses) the persistent wgN TUN

--- a/pkg/routing/tunnel_reconcile_test.go
+++ b/pkg/routing/tunnel_reconcile_test.go
@@ -396,6 +396,45 @@ func TestWgTunMTUForEndpointModel(t *testing.T) {
 	}
 }
 
+// #2457 fail-on-revert: the configured wgN inner MTU MUST be clamped to the
+// engine's encryptable ceiling (wgEngineMaxInnerMTU = 4096). An operator who
+// sets a jumbo `mtu` on a wgN device would otherwise hand the WG engine
+// plaintext above PADDED_PLAINTEXT_MAX, silently dropped at encap. Remove the
+// `min(..., wgEngineMaxInnerMTU)` clamp in wgTunMTUForEndpoint and this goes
+// RED (the jumbo override returns the unclamped 9000).
+func TestWgTunMTUForEndpointClampsToEngineMax(t *testing.T) {
+	// Sanity: the Go mirror equals the documented engine ceiling.
+	if wgEngineMaxInnerMTU != 4096 {
+		t.Fatalf("wgEngineMaxInnerMTU drifted to %d; must mirror "+
+			"engine.rs WG_ENGINE_MAX_INNER_MTU (4096)", wgEngineMaxInnerMTU)
+	}
+
+	// Jumbo operator override is clamped to the engine ceiling.
+	jumbo := wgTC()
+	jumbo.MTU = 9000
+	if got := wgTunMTUForEndpoint(jumbo); got != wgEngineMaxInnerMTU {
+		t.Fatalf("jumbo override mtu 9000: got %d, want %d (clamped to "+
+			"engine ceiling)", got, wgEngineMaxInnerMTU)
+	}
+
+	// At-ceiling override passes unchanged (clamp is a no-op at the boundary).
+	atCeiling := wgTC()
+	atCeiling.MTU = wgEngineMaxInnerMTU
+	if got := wgTunMTUForEndpoint(atCeiling); got != wgEngineMaxInnerMTU {
+		t.Fatalf("at-ceiling override mtu %d: got %d, want unchanged %d",
+			wgEngineMaxInnerMTU, got, wgEngineMaxInnerMTU)
+	}
+
+	// Below-ceiling override is honored verbatim (proves no over-clamp of
+	// the common sub-1500 / standard path).
+	below := wgTC()
+	below.MTU = 1380
+	if got := wgTunMTUForEndpoint(below); got != 1380 {
+		t.Fatalf("below-ceiling override mtu 1380: got %d, want 1380 "+
+			"(must not be over-clamped)", got)
+	}
+}
+
 // A CONFIGURED fe80 on the persistent wgN TUN, later removed from
 // config, must be reconciled away (pre-#1905 it leaked forever via the
 // nil applied-set sentinel) — while the kernel's autoconf fe80 on the

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -245,6 +245,34 @@ pub(crate) struct WgEngineConfig {
 /// when the integration layer needs it.
 const PADDED_PLAINTEXT_MAX: usize = 4080 + 16;
 
+/// The largest INNER IP packet length (pre-§5.4.6 padding) the engine
+/// can encrypt in one transport message, i.e. the largest `L` for which
+/// `pad_to_16(L) <= PADDED_PLAINTEXT_MAX`.
+///
+/// Because `pad_to_16` rounds up to a 16-byte multiple and
+/// `PADDED_PLAINTEXT_MAX` is itself a multiple of 16, the largest
+/// accepted unpadded inner length is exactly `PADDED_PLAINTEXT_MAX`
+/// (a 4096-byte inner pads to 4096 and is accepted; a 4097-byte inner
+/// pads to 4112 and is rejected — see the `encap` guard at line ~908).
+///
+/// This is the hard ceiling that any ADVERTISED or CONFIGURED inner
+/// (wgN-interface) MTU must be clamped to: a sender that honors an
+/// advertised inner MTU above this value still has its packets dropped
+/// at the encap `padded_len > PADDED_PLAINTEXT_MAX` guard
+/// (`encap_mtu_drops`). `wg::mss::wg_inner_mtu` clamps to this value
+/// (#2457); the Go control plane mirrors it as
+/// `pkg/routing/tunnel.go::wgEngineMaxInnerMTU`.
+pub(crate) const WG_ENGINE_MAX_INNER_MTU: usize = PADDED_PLAINTEXT_MAX;
+
+// Compile-time proof that WG_ENGINE_MAX_INNER_MTU is the true ceiling:
+// it must itself pad to <= PADDED_PLAINTEXT_MAX (accepted) while the
+// next byte does not (rejected). If PADDED_PLAINTEXT_MAX ever changes
+// to a non-16-multiple, this catches the silent off-by-pad drift.
+const _: () = {
+    assert!(pad_to_16(WG_ENGINE_MAX_INNER_MTU) <= PADDED_PLAINTEXT_MAX);
+    assert!(pad_to_16(WG_ENGINE_MAX_INNER_MTU + 1) > PADDED_PLAINTEXT_MAX);
+};
+
 /// Round `n` up to the nearest multiple of 16. WG spec §5.4.6.
 #[inline]
 const fn pad_to_16(n: usize) -> usize {

--- a/userspace-dp/src/afxdp/wg/mss.rs
+++ b/userspace-dp/src/afxdp/wg/mss.rs
@@ -114,15 +114,27 @@ pub(crate) fn wg_tcp_mss(outer_family: i32, inner_family: i32, mtu: usize) -> u1
 /// address), one of `libc::AF_INET` / `libc::AF_INET6`. The inner family is
 /// irrelevant to the encap overhead (the WG record wraps the raw inner IP
 /// packet whole), so unlike `wg_tcp_mss` no inner-family argument is needed.
+///
+/// #2457: the result is additionally clamped to the engine's hard ceiling
+/// `engine::WG_ENGINE_MAX_INNER_MTU` (= `PADDED_PLAINTEXT_MAX` = 4096) — the
+/// largest inner IP packet the WG engine can encrypt in one transport
+/// message. On a jumbo outer link the outer-derived budget
+/// (`outer_mtu - overhead - pad`) exceeds what the engine can encap, so a
+/// sender that honored an UNCLAMPED advertised inner MTU would still have
+/// its oversized packets dropped at the encap `padded_len >
+/// PADDED_PLAINTEXT_MAX` guard (`encap_mtu_drops`). Clamping here keeps the
+/// advertised / segmentation inner MTU at or below the encryptable maximum,
+/// so what we advertise is what the engine actually accepts.
 pub(crate) fn wg_inner_mtu(outer_family: i32, outer_mtu: usize) -> usize {
     let outer_overhead = match outer_family {
         x if x == libc::AF_INET => WG_OVERHEAD_V4,
         x if x == libc::AF_INET6 => WG_OVERHEAD_V6,
         _ => return 0,
     };
-    outer_mtu
+    let outer_derived = outer_mtu
         .checked_sub(outer_overhead + WG_MAX_PADDING)
-        .unwrap_or(0)
+        .unwrap_or(0);
+    outer_derived.min(super::engine::WG_ENGINE_MAX_INNER_MTU)
 }
 
 #[cfg(test)]
@@ -235,5 +247,53 @@ mod mss_tests {
     #[test]
     fn wg_inner_mtu_unknown_family_returns_zero() {
         assert_eq!(wg_inner_mtu(99, 1500), 0);
+    }
+
+    // #2457 fail-on-revert: the outer-derived inner MTU MUST be clamped to
+    // the engine's hard ceiling (PADDED_PLAINTEXT_MAX = 4096), the largest
+    // inner IP packet the engine can encrypt. Remove the `.min(...)` clamp
+    // in `wg_inner_mtu` and these go RED (the jumbo cases return the
+    // unclamped 8925 / 8905).
+    #[test]
+    fn wg_inner_mtu_jumbo_clamped_to_engine_max() {
+        // 9000 - 60 - 15 = 8925 outer-derived, but the engine caps the
+        // encryptable inner at 4096 → clamp to 4096.
+        assert_eq!(
+            wg_inner_mtu(libc::AF_INET, 9000),
+            super::super::engine::WG_ENGINE_MAX_INNER_MTU
+        );
+        assert_eq!(
+            super::super::engine::WG_ENGINE_MAX_INNER_MTU,
+            4096,
+            "engine ceiling drifted — update the #2457 clamp expectations"
+        );
+        // 9000 - 80 - 15 = 8905 outer-derived (v6 outer), still clamped.
+        assert_eq!(
+            wg_inner_mtu(libc::AF_INET6, 9000),
+            super::super::engine::WG_ENGINE_MAX_INNER_MTU
+        );
+    }
+
+    #[test]
+    fn wg_inner_mtu_below_ceiling_passes_unchanged() {
+        // A standard 1500 outer link is well under the engine ceiling, so
+        // the clamp is a no-op and the pad-aware derivation is returned
+        // unchanged (proves the clamp does not over-clamp the common case).
+        assert_eq!(wg_inner_mtu(libc::AF_INET, 1500), 1425);
+        // The exact MTU whose derived inner sits AT the engine ceiling:
+        // inner = outer - 60 - 15 = 4096 → outer = 4171. At-ceiling passes
+        // unchanged; one byte more is clamped back to the ceiling.
+        assert_eq!(
+            wg_inner_mtu(libc::AF_INET, 4171),
+            super::super::engine::WG_ENGINE_MAX_INNER_MTU
+        );
+        assert_eq!(
+            wg_inner_mtu(libc::AF_INET, 4170),
+            super::super::engine::WG_ENGINE_MAX_INNER_MTU - 1
+        );
+        assert_eq!(
+            wg_inner_mtu(libc::AF_INET, 4172),
+            super::super::engine::WG_ENGINE_MAX_INNER_MTU
+        );
     }
 }


### PR DESCRIPTION
Closes #2457

## Problem
The WireGuard engine encrypts at most `PADDED_PLAINTEXT_MAX = 4096` bytes of §5.4.6-padded plaintext per transport message and rejects any inner whose 16-byte-padded length exceeds that (counting `encap_mtu_drops`). The inner-MTU derivation was purely `outer_mtu − overhead − pad` with **no clamp** to that ceiling. On a jumbo underlay — or an operator-set `mtu 9000` on a wgN device — the advertised/configured inner MTU could exceed 4096, so a sender that honored it still had every oversized inner packet **silently dropped** at the engine cap (advertised-vs-encryptable mismatch). Provenance: codex review-033 finding 033-19.

## Fix — clamp formula
Both inner-MTU surfaces now clamp to the engine ceiling:

- **Rust** `wg::mss::wg_inner_mtu` (the pad-aware SSOT feeding TCP segmentation AND the #2684 PTB advertisement):
  ```
  wg_inner_mtu = min(outer_mtu − overhead − pad, WG_ENGINE_MAX_INNER_MTU)
  WG_ENGINE_MAX_INNER_MTU = PADDED_PLAINTEXT_MAX = 4096
  ```
  `WG_ENGINE_MAX_INNER_MTU` is exported from `engine.rs` with a **compile-time assert** that it is the true unpadded ceiling (`pad_to_16(4096)=4096` accepted, `pad_to_16(4097)=4112` rejected).
- **Go** `pkg/routing/tunnel.go::wgTunMTUForEndpoint` clamps the configured wgN **device** MTU (operator override AND default-derived) to `wgEngineMaxInnerMTU = 4096`, mirroring the Rust constant — the kernel never hands the engine plaintext above the encryptable maximum.

At a normal ≤1500 underlay the clamp is a no-op (no over-clamp of the common path).

## Relationship to #2684
Distinct surface. #2684 fixed **which** outer MTU the PTB reads (logical → physical underlay). #2457 caps the **result** against the engine's hard encryptable limit regardless of how large the (now-correct) physical underlay is. `icmp_ptb.rs` (#2684), `frame/wg.rs` egress (#2792), and the udp6 checksum (#2651) are untouched. **No wire change** (`protocol_wire_v1.json` untouched).

## Validation
- `cargo build --release -p xpf-userspace-dp`: OK
- `cargo test --release --bin xpf-userspace-dp -- wg mtu`: 244/0
- `go build` / `gofmt` / `go vet` / `go test ./pkg/routing/`: clean
- **Fail-on-revert (copy-restore, no git checkout)**:
  - Rust: stripping `.min(WG_ENGINE_MAX_INNER_MTU)` reds `wg_inner_mtu_jumbo_clamped_to_engine_max` (returns unclamped 8925) + `wg_inner_mtu_below_ceiling_passes_unchanged`.
  - Go: stripping `min(tc.MTU, wgEngineMaxInnerMTU)` reds `TestWgTunMTUForEndpointClampsToEngineMax` ("jumbo override mtu 9000: got 9000, want 4096").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi