### PR TITLE
pkg/ra: make config replace make-before-break (no 0-live-RA-conn window) (#2834)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -16796,3 +16796,39 @@ top.
   **File(s)**: pkg/config/schema_interfaces.go,
   pkg/config/schema_validate_ddns_source_address_2780_test.go,
   docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2834 — fix config-replace 0-live-RA-conn outage (make-before-break)
+  pkg/ra: a changed-config `Apply` (hard replace) installs a draining
+  tombstone, proves the OLD conn closed, then starts the replacement via
+  `onProvenClose`→`startLocked`. But `start()` opens the new NDP conn
+  ASYNCHRONOUSLY in the owner goroutine (the `openConn` bind retry, up to
+  ~2s, must not run under `m.mu` — #2453). So `Apply` could return in the
+  window after `startLocked` but before the owner's `openConn` completed →
+  ZERO live RA conns immediately after a config replace = an IPv6-RA
+  outage (hosts could lose the default route / RDNSS until the next
+  periodic sender came up). `TestT2a_ChangedConfigApplyNeverTwoLiveConns`
+  asserted `live==1` synchronously after the replace and failed
+  deterministically with `live==0` (issue #2834; bisected to #2453).
+  ROOT CAUSE: async conn open + no synchronization point for callers to
+  observe the replacement going live.
+  FIX (make-before-break): added `connReady chan` + `connOpened atomic.Bool`
+  to `sender`; the owner calls `signalConnReady(opened)` after `openConn`
+  resolves (success OR give-up/pre-empt, so a waiter is never stranded).
+  `Apply`'s changed-config restart path captures the started replacement
+  and, AFTER `releaseDrain` returns (UNLOCKED — never under `m.mu`), waits
+  on `waitConnReady(claimWaitTimeout)`. `Apply` now returns only once the
+  replacement RA conn is LIVE: 1 → (briefly 0, internal) → 1, no
+  observable 0-conn window, never momentarily 2 (old conn closed first).
+  #2033 PRESERVED: a replace still emits NO goodbye; only a genuine
+  `Withdraw`/`Clear`/removal emits the lifetime-0 goodbye + goes down.
+  New `TestT2c_ReplaceStaysLiveNoGoodbye_WithdrawGoesDownWithGoodbye`
+  asserts BOTH halves (replace stays live + no goodbye; withdraw → 0 conns
+  + goodbye).
+  FAIL-ON-REVERT: copied `ra.go` aside, replaced the `waitConnReady` call
+  with `_ = replacement` → both T2a and T2c FAIL with `live conns = 0,
+  want 1`; restored from the copy, green.
+  Gates: go build ./... clean; gofmt -l pkg/ra clean; go vet ./pkg/ra/...
+  clean; go test -race ./pkg/ra/ -count=3 ok.
+  **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/serialize_test.go,
+  pkg/ra/README.md, _Log.md

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -116,6 +116,25 @@ after HA failover. To make that **structural**, not flag-defended:
   `WithdrawOnce` treats it as a claim and defers. This guarantees **at most
   one live NDP conn per interface** at any time (no `ndp.Listen` collision,
   no goodbye-after-new-burst inversion).
+- **Make-before-break on a changed-config replace (#2834).** The ≤1-conn
+  rule above means the old conn is PROVEN closed before the replacement is
+  started — but `start()` opens the new conn ASYNCHRONOUSLY in the owner
+  goroutine (the `openConn` bind retry must not run under `m.mu`; see "Bind
+  retry runs unlocked"). So between `startLocked` returning and the owner's
+  `openConn` completing there is a brief window with ZERO live conns — an
+  IPv6-RA outage after a config change (hosts could lose the default route /
+  RDNSS). On the changed-config restart path ONLY, `Apply` therefore waits —
+  UNLOCKED, after `releaseDrain` returns — on the replacement sender's
+  `connReady` signal (closed by the owner once `openConn` resolves), bounded
+  by `claimWaitTimeout`. `Apply` returns only once the replacement RA conn is
+  LIVE, so the live-conn count goes 1 → (briefly 0, internal) → 1 with no
+  observable 0-conn window for callers, and never momentarily 2 (the old conn
+  is gone first). This applies ONLY to a replace — it is NOT a withdrawal, so
+  it still emits no goodbye; a genuine `Withdraw`/`Clear`/removal keeps its
+  existing lifetime-0-goodbye + go-down behavior. The sender exposes
+  `waitConnReady(timeout) bool`; the owner calls `signalConnReady(opened)`
+  after `openConn` so a failed/pre-empted open releases the waiter promptly
+  rather than blocking the full timeout on a sender that will never serve.
 - **Deferred / restart Apply is epoch-guarded.** An `Apply` start that
   waits behind a tombstone (a pre-existing drain, or its own changed-config
   stop) captures the manager epoch; if a newer `Withdraw`/`Clear`/`Apply`

--- a/pkg/ra/ra.go
+++ b/pkg/ra/ra.go
@@ -327,6 +327,7 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 	for _, req := range toStop {
 		name := req.name
 		var onProvenClose func() error
+		var replacement *sender // set by onProvenClose on a successful restart start
 		if cfg, isRestart := restartSet[name]; isRestart {
 			cfg := cfg // capture
 			onProvenClose = func() error {
@@ -334,11 +335,26 @@ func (m *Manager) Apply(configs []*config.RAInterfaceConfig) error {
 				if err := m.startLocked(cfg); err != nil {
 					return err
 				}
+				replacement = m.senders[cfg.Interface]
 				return nil
 			}
 		}
 		if err := m.releaseDrain(name, req.s, epoch, onProvenClose); err != nil && firstErr == nil {
 			firstErr = err
+		}
+		// Make-before-break: the old conn was PROVEN closed before startLocked ran
+		// (releaseDrain only invokes onProvenClose on the <-stopped arm), so the
+		// replacement is the sole conn for this interface. start() opens the conn
+		// asynchronously in the owner goroutine; wait (UNLOCKED) for that open to
+		// resolve so Apply returns only once the replacement RA conn is live —
+		// there is no observable 0-live-conn window across a config replace
+		// (#2834). If the open gives up or is pre-empted, waitConnReady returns
+		// promptly (it does not block for the full timeout on a dead sender).
+		if replacement != nil {
+			if !replacement.waitConnReady(claimWaitTimeout) {
+				slog.Warn("ra: replacement sender conn did not come up after a "+
+					"config replace", "interface", name)
+			}
 		}
 	}
 

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -126,6 +126,21 @@ type sender struct {
 	stopped  chan struct{}
 	burstCh  chan struct{} // buffered(1): request a re-burst (ResendBurst)
 
+	// connReady is closed by the owner goroutine ONCE the openConn attempt has
+	// resolved (whether it opened the conn or gave up). It lets a caller observe
+	// the end of the async socket-open window without blocking the owner under
+	// m.mu. connOpened records whether that resolution actually produced a live
+	// conn (true) or gave up / was pre-empted by a stop (false). The manager's
+	// changed-config replace path waits on connReady so Apply returns only once
+	// the REPLACEMENT RA conn is live — a make-before-break guarantee that there
+	// is no observable 0-live-conn window across a config replace (#2834). Both
+	// are written exactly once by the owner before any waiter is released:
+	// connOpened is stored BEFORE close(connReady), so a waiter that observes the
+	// closed channel also observes the stored value (Go memory model).
+	connReady    chan struct{}
+	connReadyOne sync.Once
+	connOpened   atomic.Bool
+
 	// goodbyeEmitted records whether finishShutdown actually emitted the
 	// lifetime-0 goodbye. The manager reads it AFTER the join (<-stopped) to
 	// decide whether it still OWES a standalone goodbye for a graceful
@@ -141,11 +156,12 @@ type sender struct {
 
 func newSender(cfg *config.RAInterfaceConfig, iface *net.Interface) *sender {
 	return &sender{
-		cfg:     cfg,
-		iface:   iface,
-		stopCh:  make(chan struct{}),
-		stopped: make(chan struct{}),
-		burstCh: make(chan struct{}, 1),
+		cfg:       cfg,
+		iface:     iface,
+		stopCh:    make(chan struct{}),
+		stopped:   make(chan struct{}),
+		burstCh:   make(chan struct{}, 1),
+		connReady: make(chan struct{}),
 	}
 }
 
@@ -171,6 +187,34 @@ func newSender(cfg *config.RAInterfaceConfig, iface *net.Interface) *sender {
 func (s *sender) start() error {
 	go s.run()
 	return nil
+}
+
+// signalConnReady records the result of the owner's openConn attempt and
+// releases any waiter on connReady. Owner-only; idempotent. opened MUST be
+// stored before the channel is closed so a waiter that observes the close also
+// observes the value.
+func (s *sender) signalConnReady(opened bool) {
+	s.connReadyOne.Do(func() {
+		s.connOpened.Store(opened)
+		close(s.connReady)
+	})
+}
+
+// waitConnReady blocks until the owner's openConn attempt has resolved (the
+// conn is live or the open gave up / was pre-empted by a stop), or until the
+// bounded deadline elapses. It returns true only when a live conn was actually
+// opened. It is used by the changed-config replace path so Apply returns only
+// once the REPLACEMENT RA conn is live — closing the make-before-break gap that
+// would otherwise leave a brief 0-live-conn window after a config replace
+// (#2834). It NEVER holds m.mu: the wait is the async socket-open latency, which
+// must not serialize other RA manager operations.
+func (s *sender) waitConnReady(timeout time.Duration) bool {
+	select {
+	case <-s.connReady:
+		return s.connOpened.Load()
+	case <-time.After(timeout):
+		return false
+	}
 }
 
 // openConn performs the (potentially slow) NDP socket open for the owner
@@ -356,9 +400,14 @@ func (s *sender) run() {
 	// (no goodbye is written, goodbyeEmitted stays false → the manager's
 	// release-time backstop emits a standalone goodbye if one was owed).
 	if !s.openConn() {
+		// The open attempt resolved (failed or pre-empted by a stop). Release any
+		// waiter on connReady BEFORE finishShutdown so a make-before-break Apply
+		// does not block for the full timeout on a sender that will never serve.
+		s.signalConnReady(false)
 		s.finishShutdown()
 		return
 	}
+	s.signalConnReady(true)
 
 	// A stop may have been signalled while the conn was opening. Honor it before
 	// emitting the startup burst (burstInterruptible also short-circuits, but

--- a/pkg/ra/serialize_test.go
+++ b/pkg/ra/serialize_test.go
@@ -1027,6 +1027,78 @@ func TestT2a_ChangedConfigApplyNeverTwoLiveConns(t *testing.T) {
 	_ = m.Clear()
 }
 
+// TestT2c_ReplaceStaysLiveNoGoodbye_WithdrawGoesDownWithGoodbye is the #2834
+// make-before-break contract, asserting BOTH halves so the replace and withdraw
+// paths can never collapse into one another:
+//
+//	REPLACE  (config changed, RA still served): Apply returns with EXACTLY one
+//	         live conn (the replacement) and emits NO goodbye — no observable
+//	         0-live-conn window, no prefix withdrawal. This is the bug #2834
+//	         fixed: the replacement conn opens asynchronously, so before the fix
+//	         Apply could return with the new conn not yet up (0 live conns = an
+//	         IPv6-RA outage). Apply now waits (unlocked) for the replacement conn
+//	         to come live before returning.
+//
+//	WITHDRAW (interface/prefix genuinely removed): a lifetime-0 goodbye IS
+//	         emitted and the live-conn count drops to 0 — the #2033 behavior is
+//	         preserved.
+//
+// NON-TAUTOLOGY: against the pre-#2834 code the REPLACE assertion (live==1
+// immediately after Apply, no waiting in the test) fails with live==0.
+func TestT2c_ReplaceStaysLiveNoGoodbye_WithdrawGoesDownWithGoodbye(t *testing.T) {
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("lo interface unavailable")
+	}
+	fl := newFakeListen(t)
+
+	m := New()
+	if err := m.Apply([]*config.RAInterfaceConfig{testCfg("lo")}); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+	old := waitConn(t, fl.getConn, "lo")
+	waitWrites(t, old, 1)
+
+	// --- REPLACE: changed config, no gating. Apply must return make-before-break
+	// with the replacement live. The test does NOT poll/wait afterward — the
+	// guarantee is that Apply returned only once the replacement conn was up. ---
+	if err := m.Apply([]*config.RAInterfaceConfig{configChanged("lo")}); err != nil {
+		t.Fatalf("changed-config Apply: %v", err)
+	}
+	if lc := fl.liveCount(); lc != 1 {
+		t.Fatalf("after replace: live conns = %d, want 1 (make-before-break: "+
+			"Apply must return with the replacement RA conn live, #2834)", lc)
+	}
+	newConn := fl.getConn("lo")
+	if newConn == old {
+		t.Fatal("changed-config Apply did not open a new conn (no replace happened)")
+	}
+	// A config replace is NOT a withdrawal: no goodbye on either conn.
+	if total, conns := fl.goodbyeStats("lo"); conns != 0 || total != 0 {
+		t.Fatalf("config replace emitted a goodbye (%d conns, %d writes); a "+
+			"replace must not withdraw the prefix (#2033 preserved)", conns, total)
+	}
+
+	// --- WITHDRAW: a genuine withdrawal still emits the lifetime-0 goodbye and
+	// drops to 0 live conns (the #2033 behavior must not regress). ---
+	if err := m.Withdraw(); err != nil {
+		t.Fatalf("Withdraw: %v", err)
+	}
+	for i := 0; i < 200; i++ {
+		if fl.liveCount() == 0 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if lc := fl.liveCount(); lc != 0 {
+		t.Fatalf("after withdraw: live conns = %d, want 0", lc)
+	}
+	total, conns := fl.goodbyeStats("lo")
+	if conns == 0 || total == 0 {
+		t.Fatalf("withdraw emitted no goodbye (%d conns, %d writes); a genuine "+
+			"withdrawal must emit the lifetime-0 goodbye (#2033)", conns, total)
+	}
+}
+
 // TestT7b_ManagerHardFirstThenGracefulStillGoodbye is the #2033 MAJOR 2
 // regression. A Clear (hard) can acquire m.mu first, delete the sender, install
 // a tombstone and signalStop(modeHard). A graceful Withdraw arriving afterward


### PR DESCRIPTION
Closes #2834

## Summary
A changed-config `Apply` (a hard RA-sender replace) left a brief **0-live-RA-conn window** — an IPv6 Router-Advertisement outage after a config change. `TestT2a_ChangedConfigApplyNeverTwoLiveConns` failed deterministically on master with `after replace: live conns = 0, want 1`.

## Root cause
The replace path correctly proves the old NDP conn closed before starting the replacement (the `<=1`-conn invariant), but `start()` opens the new conn **asynchronously** in the owner goroutine — the `openConn` bind retry (up to ~2s while a settling/RETH link-local appears) must not run under `m.mu` (#2453). So `Apply` could return after `startLocked` but before the owner's `openConn` completed, leaving **0 live conns** until the owner caught up. Hosts can lose the IPv6 default route / RDNSS in that window. (Bisected by the Campaign-6 audit to #2453.)

## Fix (make-before-break)
- Add `connReady chan` + `connOpened atomic.Bool` to `sender`. The owner calls `signalConnReady(opened)` after `openConn` resolves — on success AND on give-up/stop-pre-empt, so a waiter is never stranded.
- On the changed-config restart path only, `Apply` captures the started replacement and, **after `releaseDrain` returns and `m.mu` is released** (the wait is async socket-open latency and must not serialize other RA ops), waits on `waitConnReady(claimWaitTimeout)`.
- `Apply` now returns only once the replacement RA conn is live: `1 -> (briefly 0, internal) -> 1`, no observable 0-conn window, never momentarily 2 (old conn proven closed first).

## #2033 preserved
A config replace is **not** a withdrawal — it still emits **no goodbye**. Only a genuine `Withdraw`/`Clear`/removal emits the lifetime-0 goodbye and drops to 0 live conns. New `TestT2c_ReplaceStaysLiveNoGoodbye_WithdrawGoesDownWithGoodbye` asserts **both** halves so the replace and withdraw paths can never collapse into one another.

## Validation
- `go build ./...` clean; `gofmt -l` clean; `go vet ./pkg/ra/...` clean.
- `go test -race ./pkg/ra/ -count=3` green.
- **FAIL-ON-REVERT**: replacing the `waitConnReady` call with `_ = replacement` makes both `TestT2a` and the new `TestT2c` fail with `live conns = 0, want 1`; restoring it makes them pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi