### PR TITLE
ddns: surface unpublished/errored Surface A scopes in status (#2843)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-06-25 — #2843: DDNS Surface A status omits never-published / errored scopes
+
+- **Timestamp**: 2026-06-25
+- **Action**: `SurfaceAManager.StatusViews` built rows ONLY from durable
+  ownership records, so a configured scope that failed before its first
+  publish (esp. a half-configured provider whose `errSurfaceANoBackend`
+  was swallowed without `recordScopeError`) had no row — invisible in
+  `show services dynamic-dns detail` during bring-up.
+- **Fix**: `StatusViews(scopes []SurfaceAScope)` now returns the UNION of
+  a row per CONFIGURED scope (merged with ownership + runtime state) and
+  any ownership record for a scope no longer configured (withdraw
+  pending). New `SurfaceAStatusView.State`: published / unpublished
+  (no-backend) / error / pending / withdraw-pending. The no-backend
+  sentinel now records a per-scope reason (`rt.noBackend` + `lastErr`)
+  WITHOUT arming retry backoff, cleared on success / superseded by a real
+  error. Daemon `SurfaceAStatus()` materializes the configured scopes via
+  `buildSurfaceAScopes(ActiveConfig())`. CLI + gRPC `show` render the new
+  State column (text only — `SurfaceAStatusView` is an internal Go type,
+  rendered server/client side; NO protobuf/wire field added).
+- **Test**: `TestStatusViewsSurfacesUnpublishedScopes` +
+  `TestStatusViewsSurfacesPendingAndPublished` (fail-on-revert) — a
+  configured no-backend scope appears as `unpublished` with a reason, a
+  never-observed scope as `pending`, a published scope as `published`, and
+  an orphaned ownership record as `withdraw-pending`. Verified RED when
+  StatusViews reverts to ownership-records-only.
+- **File(s)**: pkg/ddns/surface_a.go, pkg/ddns/surface_a_test.go,
+  pkg/ddns/surface_a_http_test.go, pkg/ddns/surface_a_lockio_test.go,
+  pkg/daemon/daemon_ddns_surface_a.go, pkg/cli/cli_show_services.go,
+  pkg/grpcapi/server_show_dhcp_lldp_snmp.go, pkg/ddns/README.md
+- **Validation**: go build ./... ; gofmt -l (clean on touched files) ;
+  go vet ./pkg/ddns/... ./pkg/daemon/... ./pkg/grpcapi/... (clean;
+  pre-existing pkg/cli/cli.go:460 unreachable-code vet warning is on
+  origin/master, in a file I did not touch) ; go test ./pkg/ddns/...
+  ./pkg/daemon/... ./pkg/grpcapi/... ./pkg/cli/... (PASS).
 ## 2026-06-25 — #2838: DDNS generic backend false-success on substring "ok"
 
 - **Timestamp**: 2026-06-25

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -142,11 +142,11 @@ func (c *CLI) showServicesDynamicDNS(detail bool) error {
 
 	if detail && c.surfaceADDNSStatusFn != nil {
 		views := c.surfaceADDNSStatusFn()
-		fmt.Println("\n  Published scopes:")
+		fmt.Println("\n  Configured scopes:")
 		if len(views) == 0 {
 			fmt.Println("    none")
 		} else {
-			fmt.Printf("    %-32s %-6s %-39s %-12s %s\n", "FQDN", "Family", "Address", "Provider", "Last error")
+			fmt.Printf("    %-32s %-6s %-15s %-39s %-12s %s\n", "FQDN", "Family", "State", "Address", "Provider", "Last error")
 			for _, v := range views {
 				fam := "inet"
 				if v.Family == 6 {
@@ -156,8 +156,12 @@ func (c *CLI) showServicesDynamicDNS(detail bool) error {
 				if lastErr == "" {
 					lastErr = "-"
 				}
-				fmt.Printf("    %-32s %-6s %-39s %-12s %s\n",
-					v.FQDN, fam, v.Published, v.Provider, lastErr)
+				addr := v.Published
+				if addr == "" {
+					addr = "-"
+				}
+				fmt.Printf("    %-32s %-6s %-15s %-39s %-12s %s\n",
+					v.FQDN, fam, v.State, addr, v.Provider, lastErr)
 			}
 		}
 	}

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -534,5 +534,13 @@ func (d *Daemon) SurfaceAStatus() []ddns.SurfaceAStatusView {
 	if d.surfaceA == nil {
 		return nil
 	}
-	return d.surfaceA.StatusViews()
+	// Materialize the CURRENTLY configured scopes so the status surfaces every
+	// configured scope — including ones that never published or are erroring —
+	// not just the durably-owned ones (#2843). A nil cfg yields only the
+	// withdraw-pending (orphaned-ownership) rows.
+	var scopes []ddns.SurfaceAScope
+	if cfg := d.store.ActiveConfig(); cfg != nil {
+		scopes = d.buildSurfaceAScopes(cfg)
+	}
+	return d.surfaceA.StatusViews(scopes)
 }

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -403,8 +403,28 @@ its OWN learned address — on top of the SAME spine, without forking the engine
   `surface_a_lockio_test.go` (a blocking provider + a concurrent `StatusViews`
   that would hang if the lock were held; fail-on-revert).
 - **Operator surfaces:** `show services dynamic-dns [detail]` (CLI + gRPC), the
-  `xpf_ddns_surface_a_*` Prometheus family, and `SurfaceAManager.StatusViews()`
-  (per-scope published address + last-published time + last error).
+  `xpf_ddns_surface_a_*` Prometheus family, and
+  `SurfaceAManager.StatusViews(scopes)` (per-scope `State` + published address +
+  last-published time + last error).
+- **Status surfaces EVERY configured scope, not just the owned ones (#2843).**
+  `StatusViews` takes the CURRENTLY configured scopes (materialized by the daemon
+  from the committed config) and returns the UNION of: a row per configured scope
+  (merged with its ownership record + runtime state) AND any ownership record for
+  a scope no longer configured (a withdraw is pending). Each row carries a
+  `State`: `published` (owns a record), `unpublished` (the provider resolved to
+  the no-op backend — `errSurfaceANoBackend`, a half-configured provider; the
+  reason is in `LastError`, no backoff armed), `error` (the last publish attempt
+  failed; reason + backoff armed), `pending` (configured, not yet owned, no
+  recorded error — never attempted or waiting on an address observation / backoff
+  window), or `withdraw-pending` (owned but no longer configured). Before #2843
+  the status was built from ownership records ONLY, so a scope that failed before
+  its first publish — most acutely a half-configured provider whose
+  `errSurfaceANoBackend` was swallowed without `recordScopeError` — was INVISIBLE
+  in `show ... detail`, the opposite of what an operator needs during bring-up.
+  The no-backend state now records a per-scope reason on the runtime cache
+  (without arming retry backoff) so the row reports it. Proven (fail-on-revert)
+  in `surface_a_http_test.go` (`TestStatusViewsSurfacesUnpublishedScopes`,
+  `TestStatusViewsSurfacesPendingAndPublished`).
 - **Tests through the REAL backend.** The self-owned replace, forced-refresh,
   and both withdraw paths are proven in `surface_a_rfc2136_test.go` against the
   stateful in-process fake DNS server (the `backend_rfc2136_test.go` harness) with

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -142,17 +142,53 @@ type surfaceAState struct {
 	backoff      time.Duration
 	lastErr      string
 	lastErrAt    time.Time
+	// noBackend records that the most recent reconcile resolved the scope's
+	// provider to the no-op backend (errSurfaceANoBackend — a half-configured
+	// provider). Unlike lastErr it arms NO backoff (nothing was attempted on the
+	// wire) and is cleared on the first successful publish. It drives the
+	// SurfaceAStateUnpublished status row so a never-published scope is visible to
+	// the operator instead of silently omitted (#2843).
+	noBackend bool
 }
+
+// Surface A scope status states for the operator view (#2843). A configured
+// scope is rendered with exactly one of these so the operator sees every
+// configured scope and its health, not only the successfully-owned ones.
+const (
+	// SurfaceAStatePublished — the scope has a durable ownership record (an RR
+	// is published at the provider).
+	SurfaceAStatePublished = "published"
+	// SurfaceAStatePending — the scope is configured and has no ownership record
+	// and no recorded error yet (never attempted, or skipped waiting on an
+	// address observation / backoff window). Bring-up steady state.
+	SurfaceAStatePending = "pending"
+	// SurfaceAStateUnpublished — the scope is configured but cannot publish
+	// because its provider resolved to the no-op backend (a half-configured
+	// provider, errSurfaceANoBackend). Distinct from a transient error: nothing
+	// is attempted on the wire and no backoff is armed.
+	SurfaceAStateUnpublished = "unpublished"
+	// SurfaceAStateError — the scope is configured and its last publish attempt
+	// failed (provider/wire error); LastError/LastErrorAt carry the reason and
+	// error backoff is armed.
+	SurfaceAStateError = "error"
+	// SurfaceAStateWithdrawPending — an ownership record exists for a scope that
+	// is NO LONGER configured (the binding was removed); the next reconcile will
+	// withdraw it. Surfaced so a wedged withdraw is visible, not silent.
+	SurfaceAStateWithdrawPending = "withdraw-pending"
+)
 
 // SurfaceAStatusView is a read-only projection of one Surface A scope's
 // current publish state, for the operator surfaces (CLI/gRPC/REST). It exposes
-// what is currently published, the last-published time, and the last error.
+// the scope's health State (#2843 — every CONFIGURED scope gets a row, not just
+// the successfully-owned ones), what is currently published, the last-published
+// time, and the last error.
 type SurfaceAStatusView struct {
 	Interface     string
 	Unit          int
 	Family        int
 	FQDN          string
 	Provider      string
+	State         string // one of the SurfaceAState* constants (#2843)
 	Published     string // current published address ("" = none)
 	LastPublished time.Time
 	LastError     string
@@ -523,9 +559,14 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 		if errors.Is(err, errSurfaceANoBackend) {
 			// No live backend (half-configured provider): nothing was attempted on
 			// the wire. Do NOT arm error backoff and do NOT advance the
-			// last-published cache — leave rt untouched so the scope re-attempts
-			// every cycle once the operator adds the credential. Swallow the
-			// sentinel (not a pass error).
+			// last-published cache — leave the publish cadence untouched so the scope
+			// re-attempts every cycle once the operator adds the credential. Swallow
+			// the sentinel (not a pass error). Record noBackend so the status surface
+			// shows an "unpublished: no backend" row instead of omitting the scope
+			// entirely (#2843).
+			rt.noBackend = true
+			rt.lastErr = err.Error()
+			rt.lastErrAt = now
 			return nil
 		}
 		if errors.Is(err, errSurfaceAPublishRaced) {
@@ -547,6 +588,8 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 	rt.nextEligible = time.Time{}
 	rt.backoff = 0
 	rt.lastErr = ""
+	rt.lastErrAt = time.Time{}
+	rt.noBackend = false
 	return nil
 }
 
@@ -857,20 +900,82 @@ func (m *SurfaceAManager) recordScopeError(rt *surfaceAState, sc SurfaceAScope, 
 	rt.nextEligible = now.Add(rt.backoff)
 	rt.lastErr = err.Error()
 	rt.lastErrAt = now
+	rt.noBackend = false
 	slog.Warn("ddns surface-a: scope publish failed; backing off",
 		"fqdn", sc.FQDN, "backoff", rt.backoff, "err", err)
 }
 
-// StatusViews returns a stable-ordered snapshot of every Surface A scope's
-// current publish state for the operator surfaces (plan §5.5 observability). It
-// merges the durable ownership store (what is published) with the in-memory
-// runtime state (last-published time + last error).
-func (m *SurfaceAManager) StatusViews() []SurfaceAStatusView {
+// StatusViews returns a stable-ordered snapshot of EVERY configured Surface A
+// scope's current publish state for the operator surfaces (plan §5.5
+// observability, #2843). It is the union of:
+//
+//   - every CONFIGURED scope (the `scopes` arg, materialized by the daemon from
+//     the committed config) — so a scope that has NEVER successfully published
+//     (no ownership record yet) or that errored (no-backend / provider failure /
+//     wedged) still appears, with its State and reason. Before #2843 these were
+//     silently omitted — the operator saw nothing for a broken bring-up scope.
+//   - any ownership record for a scope NO LONGER configured — a withdraw is
+//     pending; surfaced as withdraw-pending so a wedged teardown is visible.
+//
+// Each row merges the durable ownership store (what is published) with the
+// in-memory runtime state (last-published time, last error, no-backend flag).
+// Caller need not hold the mutex (the method takes it). A nil/empty `scopes`
+// (no configured Surface A bindings) yields only the orphaned-ownership rows.
+func (m *SurfaceAManager) StatusViews(scopes []SurfaceAScope) []SurfaceAStatusView {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]SurfaceAStatusView, 0, len(m.state.records))
+
+	out := make([]SurfaceAStatusView, 0, len(scopes)+len(m.state.records))
+	// configured tracks which scope prefixes are covered by a configured-scope
+	// row so the orphaned-ownership sweep below skips them.
+	configured := make(map[string]struct{}, len(scopes))
+
+	for _, sc := range scopes {
+		sid := sc.scopeID()
+		configured[sid] = struct{}{}
+		v := SurfaceAStatusView{
+			Interface: sc.Key.Interface,
+			Unit:      sc.Key.Unit,
+			Family:    int(sc.Key.Family),
+			FQDN:      sc.FQDN,
+			Provider:  sc.Key.PolicyID,
+		}
+		owned, isOwned := m.state.get(sc.Key, surfaceAIdentity, "")
+		if isOwned {
+			v.Published = owned.AddrText
+			if owned.FQDN != "" {
+				v.FQDN = owned.FQDN
+			}
+		}
+		rt := m.runtime[sid]
+		if rt != nil {
+			v.LastPublished = rt.lastPublished
+			v.LastError = rt.lastErr
+			v.LastErrorAt = rt.lastErrAt
+		}
+		switch {
+		case isOwned:
+			v.State = SurfaceAStatePublished
+		case rt != nil && rt.noBackend:
+			v.State = SurfaceAStateUnpublished
+		case rt != nil && rt.lastErr != "":
+			v.State = SurfaceAStateError
+		default:
+			// Configured, not yet owned, no recorded error: never attempted, or
+			// waiting on an address observation / backoff window.
+			v.State = SurfaceAStatePending
+		}
+		out = append(out, v)
+	}
+
+	// Orphaned ownership: a record for a scope no longer configured. The next
+	// reconcile (Pass 2) withdraws it; surface it as withdraw-pending so a wedged
+	// teardown is not invisible.
 	for _, r := range m.state.all() {
 		sc := r.scopeOf()
+		if _, ok := configured[sc.scopePrefix()]; ok {
+			continue
+		}
 		v := SurfaceAStatusView{
 			Interface: sc.Interface,
 			Unit:      sc.Unit,
@@ -878,6 +983,7 @@ func (m *SurfaceAManager) StatusViews() []SurfaceAStatusView {
 			FQDN:      r.FQDN,
 			Provider:  sc.PolicyID,
 			Published: r.AddrText,
+			State:     SurfaceAStateWithdrawPending,
 		}
 		if rt := m.runtime[sc.scopePrefix()]; rt != nil {
 			v.LastPublished = rt.lastPublished
@@ -886,6 +992,7 @@ func (m *SurfaceAManager) StatusViews() []SurfaceAStatusView {
 		}
 		out = append(out, v)
 	}
+
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].FQDN != out[j].FQDN {
 			return out[i].FQDN < out[j].FQDN

--- a/pkg/ddns/surface_a_http_test.go
+++ b/pkg/ddns/surface_a_http_test.go
@@ -314,3 +314,105 @@ func TestEngineNoBackendNoPhantomOwnership(t *testing.T) {
 		t.Fatalf("a no-backend scope must re-attempt every cycle; got SkippedNoBackend=%d", st2.SkippedNoBackend)
 	}
 }
+
+// TestStatusViewsSurfacesUnpublishedScopes is the #2843 fail-on-revert proof: a
+// CONFIGURED scope that has never successfully published — because its provider
+// resolved to the no-op backend (errSurfaceANoBackend) — MUST appear in
+// StatusViews with the unpublished state and its no-backend reason, NOT be
+// silently omitted. Reverting StatusViews to iterate the ownership records only
+// (the pre-#2843 behavior) turns this RED: the no-backend scope has no ownership
+// record, so it would not appear at all.
+func TestStatusViewsSurfacesUnpublishedScopes(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	m := newHTTPEngineManager(t, func() time.Time { return now })
+
+	// cloudflare with NO credentials → no-op backend → never publishes.
+	noBackend := SurfaceAScope{
+		Key:      ScopeKey{Family: FamilyV4, Interface: "ge-0-0-2", Unit: 50, PolicyID: "cf"},
+		FQDN:     "broken.example.net",
+		TTL:      300,
+		Source:   AddressSourceInterface,
+		Provider: &config.DDNSProvider{Name: "cf", Backend: "cloudflare"}, // missing creds
+	}
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{noBackend}, fixedObserver("93.184.216.34"), nil, nil); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// The status MUST contain the configured-but-unpublished scope even though it
+	// owns no record.
+	views := m.StatusViews([]SurfaceAScope{noBackend})
+	if len(views) != 1 {
+		t.Fatalf("a configured scope with no ownership record must still appear; got %d views: %+v", len(views), views)
+	}
+	v := views[0]
+	if v.FQDN != "broken.example.net" || v.Provider != "cf" || v.Interface != "ge-0-0-2" {
+		t.Fatalf("unpublished status view identity mismatch: %+v", v)
+	}
+	if v.State != SurfaceAStateUnpublished {
+		t.Fatalf("a no-backend scope must report state %q, got %q", SurfaceAStateUnpublished, v.State)
+	}
+	if v.Published != "" {
+		t.Fatalf("a never-published scope must show no published address, got %q", v.Published)
+	}
+	if v.LastError == "" {
+		t.Fatalf("an unpublished (no-backend) scope must carry a reason in LastError")
+	}
+}
+
+// TestStatusViewsSurfacesPendingAndPublished proves the other configured-scope
+// states: a scope still waiting on an address observation is `pending`, and a
+// scope that successfully published is `published`. Mixed with a no-longer-
+// configured owned record (withdraw-pending), it confirms StatusViews is the
+// union of configured scopes + orphaned ownership, stably ordered.
+func TestStatusViewsSurfacesPendingAndPublished(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+
+	published := surfaceAScope("aaa.example.net", FamilyV4, 0)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{published}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("Reconcile published: %v", err)
+	}
+
+	// A second, distinct configured scope whose address cannot be observed this
+	// cycle (interface still coming up) → no ownership, no error → pending.
+	pending := SurfaceAScope{
+		Key:    ScopeKey{Family: FamilyV4, Interface: "ge-0-0-3", Unit: 0, PolicyID: "corp-2136"},
+		FQDN:   "bbb.example.net",
+		TTL:    300,
+		Source: AddressSourceDHCP,
+	}
+	noObserve := func(SurfaceAScope) (AddressObservation, bool) { return AddressObservation{}, false }
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{published, pending}, noObserve, nil, nil); err != nil {
+		t.Fatalf("Reconcile pending: %v", err)
+	}
+
+	views := m.StatusViews([]SurfaceAScope{published, pending})
+	byFQDN := map[string]SurfaceAStatusView{}
+	for _, v := range views {
+		byFQDN[v.FQDN] = v
+	}
+	if got := byFQDN["aaa.example.net"].State; got != SurfaceAStatePublished {
+		t.Fatalf("published scope state = %q, want %q", got, SurfaceAStatePublished)
+	}
+	if got := byFQDN["bbb.example.net"].State; got != SurfaceAStatePending {
+		t.Fatalf("never-observed scope state = %q, want %q", got, SurfaceAStatePending)
+	}
+
+	// Drop the published scope from config → its owned record is now orphaned.
+	// StatusViews (called with only the pending scope configured) must surface the
+	// orphan as withdraw-pending, not omit it.
+	orphanViews := m.StatusViews([]SurfaceAScope{pending})
+	var sawOrphan bool
+	for _, v := range orphanViews {
+		if v.FQDN == "aaa.example.net" {
+			sawOrphan = true
+			if v.State != SurfaceAStateWithdrawPending {
+				t.Fatalf("orphaned ownership state = %q, want %q", v.State, SurfaceAStateWithdrawPending)
+			}
+		}
+	}
+	if !sawOrphan {
+		t.Fatalf("an owned record for a no-longer-configured scope must appear as withdraw-pending; views=%+v", orphanViews)
+	}
+}

--- a/pkg/ddns/surface_a_lockio_test.go
+++ b/pkg/ddns/surface_a_lockio_test.go
@@ -86,7 +86,7 @@ func TestSurfaceALockNotHeldDuringUpsert(t *testing.T) {
 	// proceed. If the lock were held across the I/O this read would block and the
 	// bounded wait fires — the fail-on-revert assertion.
 	statusDone := make(chan []SurfaceAStatusView, 1)
-	go func() { statusDone <- m.StatusViews() }()
+	go func() { statusDone <- m.StatusViews([]SurfaceAScope{sc}) }()
 	select {
 	case <-statusDone:
 		// good: the lock was free during provider I/O.
@@ -153,7 +153,7 @@ func TestSurfaceALockNotHeldDuringDelete(t *testing.T) {
 	}
 
 	statusDone := make(chan []SurfaceAStatusView, 1)
-	go func() { statusDone <- m.StatusViews() }()
+	go func() { statusDone <- m.StatusViews([]SurfaceAScope{sc}) }()
 	select {
 	case <-statusDone:
 	case <-time.After(2 * time.Second):
@@ -277,7 +277,7 @@ func TestSurfaceAPublishRaceDoesNotClobberNewerState(t *testing.T) {
 
 	// The owned/published address must be B (the newer desired state), never
 	// reverted to A by the stale result.
-	views := m.StatusViews()
+	views := m.StatusViews([]SurfaceAScope{sc})
 	if len(views) != 1 {
 		t.Fatalf("expected one owned scope, got %d: %+v", len(views), views)
 	}

--- a/pkg/ddns/surface_a_test.go
+++ b/pkg/ddns/surface_a_test.go
@@ -189,7 +189,7 @@ func TestSurfaceAStatusViews(t *testing.T) {
 	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	views := m.StatusViews()
+	views := m.StatusViews([]SurfaceAScope{sc})
 	if len(views) != 1 {
 		t.Fatalf("expected one status view, got %d", len(views))
 	}
@@ -197,6 +197,9 @@ func TestSurfaceAStatusViews(t *testing.T) {
 	if v.FQDN != "wan.example.net" || v.Published != "203.0.113.5" ||
 		v.Interface != "ge-0-0-2" || v.Family != 4 || v.Provider != "corp-2136" {
 		t.Fatalf("status view mismatch: %+v", v)
+	}
+	if v.State != SurfaceAStatePublished {
+		t.Fatalf("published scope must have state %q, got %q", SurfaceAStatePublished, v.State)
 	}
 	if v.LastPublished.IsZero() {
 		t.Fatal("status view must carry a last-published time")

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -329,11 +329,11 @@ func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder
 
 	if detail && s.surfaceADDNSStatusFn != nil {
 		views := s.surfaceADDNSStatusFn()
-		buf.WriteString("\n  Published scopes:\n")
+		buf.WriteString("\n  Configured scopes:\n")
 		if len(views) == 0 {
 			buf.WriteString("    none\n")
 		} else {
-			fmt.Fprintf(buf, "    %-32s %-6s %-39s %-12s %s\n", "FQDN", "Family", "Address", "Provider", "Last error")
+			fmt.Fprintf(buf, "    %-32s %-6s %-15s %-39s %-12s %s\n", "FQDN", "Family", "State", "Address", "Provider", "Last error")
 			for _, v := range views {
 				fam := "inet"
 				if v.Family == 6 {
@@ -343,8 +343,12 @@ func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder
 				if lastErr == "" {
 					lastErr = "-"
 				}
-				fmt.Fprintf(buf, "    %-32s %-6s %-39s %-12s %s\n",
-					v.FQDN, fam, v.Published, v.Provider, lastErr)
+				addr := v.Published
+				if addr == "" {
+					addr = "-"
+				}
+				fmt.Fprintf(buf, "    %-32s %-6s %-15s %-39s %-12s %s\n",
+					v.FQDN, fam, v.State, addr, v.Provider, lastErr)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #2843

## Problem

`SurfaceAManager.StatusViews` built its rows ONLY from the durable ownership records. A configured scope that failed before its first successful publish had no row at all. The worst case is a half-configured provider: construction degrades to the no-op backend, `publishLocked` returns `errSurfaceANoBackend`, and `reconcileScopeLocked` swallowed that sentinel without recording any per-scope error. The operator saw nothing for the broken scope in `show services dynamic-dns detail` during bring-up — only an aggregate `SkippedNoBackend` counter with no FQDN/interface/provider to debug.

## Fix

`StatusViews(scopes)` now returns the UNION of every CONFIGURED scope plus any orphaned ownership record, each row carrying a `State`:

- `published` — owns a record
- `unpublished` — provider resolved to the no-op backend (half-configured; reason in `LastError`, no backoff armed)
- `error` — last publish failed (reason + backoff armed)
- `pending` — configured, not yet owned, no recorded error (never attempted / waiting on an address observation / backoff window)
- `withdraw-pending` — owned but no longer configured

The `errSurfaceANoBackend` path now records a per-scope reason (`rt.noBackend` + `lastErr`) WITHOUT arming retry backoff, cleared on success and superseded by a real wire error. The daemon materializes the configured scopes via `buildSurfaceAScopes(ActiveConfig())`. CLI + gRPC `show ... detail` render a new State column.

## Wire note

NONE. `SurfaceAStatusView` is an internal Go type rendered to text on both the CLI and gRPC sides (the gRPC server builds the text in `server_show_dhcp_lldp_snmp.go`). No protobuf/wire field is added, so no `protocol_wire_v1.json` regen.

## Fail-on-revert

`surface_a_http_test.go`: `TestStatusViewsSurfacesUnpublishedScopes` + `TestStatusViewsSurfacesPendingAndPublished`. A configured no-backend scope appears as `unpublished` with a reason, a never-observed scope as `pending`, a published scope as `published`, an orphaned ownership record as `withdraw-pending`. Both go RED when StatusViews reverts to ownership-records-only (verified).

## Gates

- `go build ./...` OK
- `gofmt -l` clean on touched files
- `go vet ./pkg/ddns/... ./pkg/daemon/... ./pkg/grpcapi/...` clean (pre-existing `pkg/cli/cli.go:460` unreachable-code warning is on origin/master, untouched here)
- `go test ./pkg/ddns/... ./pkg/daemon/... ./pkg/grpcapi/... ./pkg/cli/...` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi