### PR TITLE
dhcprelay: bind server-facing socket to giaddr:67 (BOOTPS) — Closes #2888

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17106,3 +17106,19 @@ top.
   ./pkg/ddns/... (PASS). Fail-on-revert confirmed: reverting the
   LinkByName-error branch to `(static,true)` makes
   TestObserveInterfaceAddrTransientVsDefinitive/LinkByName_error RED.
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2888 DHCP relay server-facing socket binds giaddr:67 (BOOTPS)
+  instead of giaddr:0 (ephemeral). RFC 2131 §4.1: a strict server unicasts its
+  reply to the relay at giaddr:67, so an ephemeral-port server conn never
+  receives the reply and relayed leases never complete with strict servers. The
+  server conn now binds giaddr:relayPort and sets reusePort=true (SO_REUSEADDR/
+  SO_REUSEPORT) so giaddr:67 coexists with the client listener's 0.0.0.0:67
+  without EADDRINUSE; no BINDTODEVICE, no broadcast. Added fail-on-revert test
+  TestServerConn_BindsGiaddrBOOTPS (asserts giaddr:67 + reusePort; RED on revert
+  to Port:0). Updated TestApply_MultiInterface_NoCollision + the #2347 drift
+  test to classify client-vs-server conns by bind IP (0.0.0.0 wildcard vs
+  specific giaddr) since both now bind port 67. Gates: go build ./..., gofmt -l
+  clean, go vet ./pkg/dhcprelay/..., go test ./pkg/dhcprelay/... PASS.
+  **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_test.go,
+  pkg/dhcprelay/README.md, _Log.md

--- a/pkg/dhcprelay/README.md
+++ b/pkg/dhcprelay/README.md
@@ -207,8 +207,25 @@ OFFER/ACK to forward in the first place; clients still dedupe on
   join the REUSEPORT group unfiltered and steal other interfaces' packets.
 - **`SO_BROADCAST` on the client listener** so broadcast OFFER/ACK replies
   to `255.255.255.255:68` are delivered (Linux returns `EACCES` on a
-  limited-broadcast `sendto` without it). The server conn (bound to
-  `giaddr:0`) sets none of these — it has a unique ephemeral port.
+  limited-broadcast `sendto` without it). The server conn does not set
+  `SO_BROADCAST` (server replies to the relay are unicast) or
+  `SO_BINDTODEVICE` (the routed reply may arrive via the WAN path, not the
+  client interface).
+- **Server-facing socket binds `giaddr:67` (BOOTPS), not an ephemeral port
+  (#2888).** RFC 2131 §4.1 specifies a server unicasts its reply back to the
+  relay agent at the `giaddr` it saw in the relayed request, destination port
+  `67` (BOOTPS) — **not** the relay's source port. A strict-RFC server
+  therefore sends `OFFER`/`ACK` to `giaddr:67`; if the relay's server conn sat
+  on an ephemeral port (`giaddr:0`, the pre-#2888 behavior) nothing listened on
+  `giaddr:67` and the reply was dropped, so a relayed lease never completed with
+  a strict server. The server conn now binds `giaddr:67` and sets
+  `SO_REUSEADDR` + `SO_REUSEPORT` — **required**, because the client listener
+  already holds `0.0.0.0:67`; a second `:67` bind (even to the distinct,
+  specific `giaddr`) would otherwise fail `EADDRINUSE`. The two sockets do not
+  steal each other's traffic: the client listener is `SO_BINDTODEVICE`-pinned to
+  the LAN interface and the server conn binds the **specific** unicast `giaddr`,
+  so the kernel delivers a unicast datagram destined to `giaddr:67` to the
+  address-specific socket in preference to the wildcard listener.
 - **Bounded, deterministic `Stop()`.** Reads use the blocking
   `net.PacketConn.ReadFrom`; a close-on-cancel watcher (started after both
   conns exist) closes BOTH conns when the relay context is cancelled, so a
@@ -246,8 +263,8 @@ OFFER/ACK to forward in the first place; clients still dedupe on
   permanently. The interface is re-looked-up every attempt (no stale cached
   index).
 - **Socket bind/listen retry (#2787).** A *transient* failure to open the
-  client listener (`0.0.0.0:67`) or the giaddr server conn — interface not yet
-  up, its IPv4 not yet bound, or port 67 momentarily busy on a quick reload —
+  client listener (`0.0.0.0:67`) or the `giaddr:67` server conn — interface not
+  yet up, its IPv4 not yet bound, or port 67 momentarily busy on a quick reload —
   is **not terminal**. `runRelaySession` returns `sessionRetry`, and the
   supervisor (`runRelay`) waits the same bounded, `ctx`-cancelable
   `retryInterval` and rebuilds, so the relay recovers on that interface once

--- a/pkg/dhcprelay/relay.go
+++ b/pkg/dhcprelay/relay.go
@@ -180,10 +180,12 @@ type interfaceRelay struct {
 //
 //   - ifaceName: when non-empty, SO_BINDTODEVICE binds the socket to that
 //     interface (required on the client conn so REUSEPORT fanout is filtered
-//     per-interface). Empty for the server conn (which binds a unique giaddr
-//     ephemeral port and needs no device binding).
+//     per-interface). Empty for the server conn, which binds a specific
+//     giaddr:67 (#2888) and is steered by the unicast destination address, not
+//     by a device binding.
 //   - reusePort: when true, SO_REUSEADDR+SO_REUSEPORT are set so multiple
-//     client listeners coexist on 0.0.0.0:67.
+//     client listeners coexist on 0.0.0.0:67, and so the server conn's
+//     giaddr:67 bind (#2888) coexists with the client listener's 0.0.0.0:67.
 //   - broadcast: when true, SO_BROADCAST is set so the socket can send to
 //     255.255.255.255 (the client conn's broadcast reply path).
 //   - bindAddr: the local address to bind.
@@ -810,10 +812,28 @@ func (m *Manager) runRelaySession(ctx context.Context,
 	}
 	defer conn.Close()
 
-	// Server conn: bound to giaddr ephemeral port. No REUSEPORT, no
-	// BINDTODEVICE (unique port), no broadcast.
-	serverConn, err := m.newConn(sctx, "", false, false,
-		&net.UDPAddr{IP: giaddr, Port: 0})
+	// Server conn: bound to giaddr:67 (BOOTPS), NOT an ephemeral port (#2888).
+	// RFC 2131 §4.1 specifies a server unicasts its reply back to the relay
+	// agent at the giaddr it saw in the relayed request, destination port 67
+	// (BOOTPS) — NOT the relay's source port. A strict-RFC server therefore
+	// sends OFFER/ACK to giaddr:67; if the relay's server-facing socket sits on
+	// an ephemeral port nothing is listening on giaddr:67 and the reply is
+	// dropped, so a relayed lease never completes with a strict server. Bind the
+	// server conn to :67 so the giaddr-side reply is received.
+	//
+	// SO_REUSEADDR/SO_REUSEPORT (reusePort=true) is REQUIRED: the client-facing
+	// listener already holds 0.0.0.0:67 (REUSEPORT). A second bind on port 67 —
+	// even to the distinct, specific giaddr — would otherwise fail EADDRINUSE.
+	// The two sockets do not steal each other's traffic: the client listener is
+	// SO_BINDTODEVICE-pinned to the LAN interface (and receives client
+	// broadcasts/limited-broadcast there), while the server conn binds the
+	// SPECIFIC unicast giaddr — the kernel delivers a unicast datagram destined
+	// to giaddr:67 to the address-specific socket in preference to the wildcard
+	// listener. No BINDTODEVICE (the reply arrives via the routed WAN path, not
+	// necessarily the client interface) and no broadcast (server replies to the
+	// relay are unicast).
+	serverConn, err := m.newConn(sctx, "", true, false,
+		&net.UDPAddr{IP: giaddr, Port: relayPort})
 	if err != nil {
 		// #2787: likewise transient — the giaddr may have just been removed
 		// (interface flap) or the ephemeral bind momentarily failed. Retry

--- a/pkg/dhcprelay/relay_test.go
+++ b/pkg/dhcprelay/relay_test.go
@@ -568,8 +568,14 @@ func TestApply_MultiInterface_NoCollision(t *testing.T) {
 	clientIfaces := map[string]bool{}
 	clientListeners, serverListeners := 0, 0
 	for _, c := range calls {
-		if c.bindAddr.Port == relayPort {
+		// Both conns now bind port 67 (#2888): classify by bind IP — the client
+		// listener binds the 0.0.0.0 wildcard, the server conn binds the
+		// specific giaddr.
+		if c.bindAddr.IP.Equal(net.IPv4zero) {
 			clientListeners++
+			if c.bindAddr.Port != relayPort {
+				t.Errorf("client listener must bind :67: %+v", c)
+			}
 			if !c.reusePort {
 				t.Errorf("client listener on :67 must set reusePort: %+v", c)
 			}
@@ -579,14 +585,17 @@ func TestApply_MultiInterface_NoCollision(t *testing.T) {
 			if c.ifaceName == "" {
 				t.Errorf("client listener MUST have non-empty BINDTODEVICE ifaceName: %+v", c)
 			}
-			if !c.bindAddr.IP.Equal(net.IPv4zero) {
-				t.Errorf("client listener must bind 0.0.0.0: %+v", c)
-			}
 			clientIfaces[c.ifaceName] = true
 		} else {
 			serverListeners++
-			if c.reusePort {
-				t.Errorf("server conn must NOT set reusePort: %+v", c)
+			// #2888: the server conn must bind giaddr:67 (BOOTPS) so a strict
+			// server's reply to giaddr:67 is received, and must set reusePort so
+			// the :67 bind coexists with the client listener's 0.0.0.0:67.
+			if c.bindAddr.Port != relayPort {
+				t.Errorf("server conn must bind :67 (BOOTPS), got %+v", c)
+			}
+			if !c.reusePort {
+				t.Errorf("server conn must set reusePort to coexist on :67: %+v", c)
 			}
 			if c.ifaceName != "" {
 				t.Errorf("server conn must NOT set BINDTODEVICE: %+v", c)
@@ -601,6 +610,68 @@ func TestApply_MultiInterface_NoCollision(t *testing.T) {
 	}
 	if len(clientIfaces) != 2 {
 		t.Errorf("expected 2 distinct client ifaceNames, got %v", clientIfaces)
+	}
+}
+
+// TestServerConn_BindsGiaddrBOOTPS is the #2888 fail-on-revert guard. RFC 2131
+// §4.1 specifies a server unicasts its reply back to the relay agent at
+// giaddr:67 (BOOTPS), NOT the relay's source port. If the server-facing socket
+// binds an ephemeral port (giaddr:0) — the pre-#2888 behavior — a strict
+// server's reply to giaddr:67 has no listener and is dropped, so a relayed
+// lease never completes.
+//
+// This test asserts, by construction, that the server conn binds to the resolved
+// giaddr on PORT 67. Reverting the bind to Port:0 (ephemeral) makes the
+// `Port != relayPort` assertion fail RED. It also pins the reusePort=true
+// requirement, since giaddr:67 must coexist with the client listener's
+// 0.0.0.0:67 (without SO_REUSEADDR/SO_REUSEPORT the second :67 bind would
+// EADDRINUSE in production).
+func TestServerConn_BindsGiaddrBOOTPS(t *testing.T) {
+	factory, getCalls := recordingFactory()
+	m := testManager(factory)
+	defer m.Stop()
+
+	// testManager's resolver returns 10.0.0.254 as the giaddr.
+	wantGIAddr := net.IPv4(10, 0, 0, 254)
+
+	m.Apply(context.Background(), singleInterfaceConfig())
+	waitRelays(t, m, 1, 2*time.Second)
+	calls := waitCalls(t, getCalls, 2, 2*time.Second) // client + server conn
+
+	var serverCalls int
+	for _, c := range calls {
+		// The server conn binds the specific giaddr; the client listener binds
+		// the 0.0.0.0 wildcard.
+		if c.bindAddr.IP.Equal(net.IPv4zero) {
+			continue
+		}
+		serverCalls++
+		if !c.bindAddr.IP.Equal(wantGIAddr) {
+			t.Errorf("server conn must bind the resolved giaddr %v, got %v",
+				wantGIAddr, c.bindAddr.IP)
+		}
+		// FAIL-ON-REVERT: the server-facing socket MUST bind BOOTPS (67), not an
+		// ephemeral port (0). Reverting to Port:0 turns this RED.
+		if c.bindAddr.Port != relayPort {
+			t.Errorf("server conn must bind giaddr:%d (BOOTPS) so a strict "+
+				"server's reply to giaddr:67 is received (#2888), got port %d: %+v",
+				relayPort, c.bindAddr.Port, c)
+		}
+		// giaddr:67 must coexist with the client listener's 0.0.0.0:67.
+		if !c.reusePort {
+			t.Errorf("server conn must set SO_REUSEADDR/SO_REUSEPORT to coexist "+
+				"with the client listener on :67 (#2888): %+v", c)
+		}
+		if c.broadcast {
+			t.Errorf("server conn must not set SO_BROADCAST (server replies are unicast): %+v", c)
+		}
+		if c.ifaceName != "" {
+			t.Errorf("server conn must NOT set BINDTODEVICE: %+v", c)
+		}
+	}
+	if serverCalls != 1 {
+		t.Fatalf("expected exactly 1 server conn (non-wildcard bind), got %d: %+v",
+			serverCalls, calls)
 	}
 }
 
@@ -1260,11 +1331,12 @@ func TestRunRelay_IfindexDrift_RebindsListener(t *testing.T) {
 	// producing 2 more factory calls (gen-2 client + server).
 	calls := waitCalls(t, getCalls, 4, 2*time.Second)
 
-	// The rebound client listener (a :67 call after the first two) must keep the
-	// per-interface SO_BINDTODEVICE ifaceName.
+	// The rebound client listener (a 0.0.0.0:67 call after the first two) must
+	// keep the per-interface SO_BINDTODEVICE ifaceName. Both conns now bind :67
+	// (#2888), so classify the client listener by its 0.0.0.0 wildcard bind.
 	clientListeners := 0
 	for _, c := range calls {
-		if c.bindAddr.Port == relayPort {
+		if c.bindAddr.IP.Equal(net.IPv4zero) {
 			clientListeners++
 			if c.ifaceName != "ge-0-0-0" {
 				t.Errorf("rebound client listener lost BINDTODEVICE ifaceName: %+v", c)


### PR DESCRIPTION
Closes #2888

## Problem
The DHCP relay's upstream server-facing socket bound to `giaddr:0` (an
ephemeral port) instead of `giaddr:67`. Per **RFC 2131 §4.1** a relay agent
uses port 67, and a strict-RFC server unicasts its reply back to the relay at
the `giaddr` it saw in the relayed request, destination port **67 (BOOTPS)** —
not the relay's source port. With the server conn on an ephemeral port nothing
listened on `giaddr:67`, so a strict server's `OFFER`/`ACK` was dropped and the
relayed lease never completed. Lenient servers that echo the source port masked
the bug.

## Fix
Bind the server conn to `giaddr:67` (`relayPort`) instead of port 0, and set
`reusePort=true` (`SO_REUSEADDR` + `SO_REUSEPORT`) so `giaddr:67` coexists with
the client listener's `0.0.0.0:67` (a second `:67` bind would otherwise fail
`EADDRINUSE`). The two sockets do not steal each other's traffic: the client
listener is `SO_BINDTODEVICE`-pinned to the LAN interface while the server conn
binds the **specific** unicast `giaddr`, so the kernel prefers the
address-specific socket for a datagram destined to `giaddr:67`. The server conn
keeps no `SO_BINDTODEVICE` (the routed reply may arrive via the WAN path) and no
`SO_BROADCAST` (server replies are unicast). This matches the existing
#2456/#2787 relay socket discipline.

## Scope
Only the server-facing socket bind/port + tests. The client-facing path, the
#2456 master-gate, and Option 82 are untouched. The socket model is a simple
port + REUSEPORT fix (no refactor): the relay uses two `:67` sockets — wildcard
client listener vs address-specific server conn — multiplexed by `SO_REUSEPORT`.

## Fail-on-revert test
`TestServerConn_BindsGiaddrBOOTPS` asserts the server conn binds `giaddr:67`
with `reusePort=true`; reverting the bind to `Port:0` (ephemeral) turns it RED
(verified). Two existing tests (`TestApply_MultiInterface_NoCollision`, the
#2347 ifindex-drift test) were updated to classify client-vs-server conns by
bind IP (`0.0.0.0` wildcard vs the specific giaddr) since both now bind port 67.

## Validation
- `go build ./...`
- `gofmt -l pkg/dhcprelay/` (clean)
- `go vet ./pkg/dhcprelay/...`
- `go test ./pkg/dhcprelay/...` PASS
- Fail-on-revert confirmed RED when the server bind is reverted to `giaddr:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi