### PR TITLE
frr: anchor writeManagedSection end-marker lookup after begin (#2908)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17365,3 +17365,21 @@ top.
   go vet ./pkg/ra/..., go test -race ./pkg/ra/... PASS.
   **File(s)**: pkg/ra/sender.go, pkg/ra/ra.go, pkg/ra/serialize_test.go,
   pkg/ra/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2908 — anchor frr writeManagedSection end-marker lookup after
+  the begin marker so a stale end-marker BEFORE the begin can't yield
+  end<start and duplicate config (agy-review-053 053-03). Was
+  `strings.Index(content, markerEnd)` from index 0; now searches
+  `content[start+len(markerBegin):]` and maps the relative index back to
+  absolute, keeping the end>=start invariant. Degenerate cases preserved:
+  begin+no-end-after-it still falls to the #1646 orphaned-begin discard-to-EOF
+  branch; both-missing still appends fresh. Distinct from #1646 (orphaned
+  begin). Added fail-on-revert test TestWriteManagedSection_StaleEndMarkerBeforeBegin
+  (stale end before live begin with operator config interleaved → exactly one
+  managed begin, operator config on both sides preserved, route replaced; goes
+  RED with the from-0 lookup, showing 2 begin markers after the first write
+  and 3 + duplicated operator config after the second). Gates: go build ./...,
+  gofmt -l clean, go vet ./pkg/frr/..., go test ./pkg/frr/... PASS.
+  **File(s)**: pkg/frr/manager.go, pkg/frr/frr_test.go, pkg/frr/README.md,
+  _Log.md

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -62,6 +62,23 @@ the overlay as step 7.
 content **outside** the markers is preserved across `ApplyFull`. Don't
 move or rename the markers — they're literal strings.
 
+`writeManagedSection` strips the old managed block before re-appending the
+new one. Two corruption hazards are handled defensively because the file
+also carries operator content:
+
+- **Orphaned begin / missing end (#1646).** A torn write can leave a begin
+  marker with no end. The strip discards the begin-to-EOF tail rather than
+  appending a second block (which a later write would over-cut).
+- **Stale end before begin (#2908).** The end-marker search is anchored
+  strictly *after* the begin marker. An unanchored `strings.Index(content,
+  markerEnd)` from index 0 would match a stale/orphaned end marker that
+  appears *before* the live begin marker (operator hand-edit, interleaved
+  partial copy, external tooling), returning `end < start`; the strip
+  `content[:start] + content[end:]` would then DUPLICATE the text between
+  the stale end and the begin while leaving the live begin in place —
+  two begin markers and a corrupt block that FRR reload rejects. Anchoring
+  keeps `end >= start`, so the slice can never duplicate.
+
 ## Gotchas
 
 - Static routes have RETH names (`reth0`) but FRR wants the physical

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -946,6 +946,100 @@ func TestWriteManagedSection_OrphanedBeginMarker(t *testing.T) {
 	}
 }
 
+// TestWriteManagedSection_StaleEndMarkerBeforeBegin is the #2908 regression
+// test (agy-review-053 053-03). A stale end-marker positioned *before* the
+// live begin marker (operator hand-edit, an interleaved partial copy, or
+// external tooling) used to make the unanchored strings.Index(content,
+// markerEnd) return end < start. The strip content[:start] + content[end:]
+// then DUPLICATED the text between end and start while leaving the live begin
+// marker in place, producing two begin markers and a corrupt managed block
+// that FRR reload rejects.
+//
+// This is distinct from #1646 (orphaned begin / missing end). The fix anchors
+// the end-marker search strictly after the begin marker so end >= start always
+// holds and the slice can never duplicate.
+//
+// FAIL-ON-REVERT: if the end-marker lookup is reverted to the from-0
+// strings.Index(content, markerEnd), the stale-end case yields end < start and
+// this test fails on the duplicated begin marker and corrupted body.
+func TestWriteManagedSection_StaleEndMarkerBeforeBegin(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "frr.conf")
+
+	m := &Manager{frrConf: confPath}
+
+	// Construct a file where a STALE end marker appears BEFORE the live begin
+	// marker, with operator config interleaved around them.
+	stale := "log syslog informational\n" +
+		"ip route 192.0.2.0/24 198.51.100.1\n" + // operator config, before stale end
+		markerEnd + "\n" + // STALE/orphaned end marker (no preceding begin)
+		"ip route 203.0.113.0/24 198.51.100.2\n" + // operator config, between markers
+		markerBegin + "\n" +
+		"ip route 10.0.0.0/8 192.168.9.9\n" + // current managed body
+		markerEnd + "\n"
+	if err := os.WriteFile(confPath, []byte(stale), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.2.1\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(confPath)
+	got := string(data)
+
+	// Exactly one begin marker. With the from-0 lookup, end < start kept the
+	// live begin marker AND re-appended the duplicated tail → two begin
+	// markers.
+	if n := strings.Count(got, markerBegin); n != 1 {
+		t.Errorf("expected exactly 1 begin marker, got %d:\n%s", n, got)
+	}
+	// Exactly one end marker — the stale one must be carried as inert operator
+	// text (it is just a comment line outside the managed block) but the
+	// managed block itself must contribute exactly one. The total end-marker
+	// count is the stale one + the managed one = 2; what matters is that the
+	// managed block is well formed (one begin, and an end after it).
+	beginIdx := strings.Index(got, markerBegin)
+	if beginIdx < 0 {
+		t.Fatalf("managed begin marker missing:\n%s", got)
+	}
+	if !strings.Contains(got[beginIdx:], markerEnd) {
+		t.Errorf("managed block has no end marker after its begin:\n%s", got)
+	}
+	// The new managed route is present; the old managed body is gone.
+	if !strings.Contains(got, "ip route 10.0.0.0/8 192.168.2.1") {
+		t.Errorf("new managed route missing:\n%s", got)
+	}
+	if strings.Contains(got, "192.168.9.9") {
+		t.Errorf("old managed body was not replaced:\n%s", got)
+	}
+	// Operator config on both sides of the stale end marker must survive.
+	if !strings.Contains(got, "ip route 192.0.2.0/24 198.51.100.1") {
+		t.Errorf("operator config before stale end marker lost:\n%s", got)
+	}
+	if !strings.Contains(got, "ip route 203.0.113.0/24 198.51.100.2") {
+		t.Errorf("operator config between markers lost:\n%s", got)
+	}
+
+	// A SECOND write must stay stable — exactly one begin marker, operator
+	// config preserved, route updated. This is where a duplicated-begin state
+	// from the first write would corrupt the file on the next over-cut.
+	if err := m.writeManagedSection("ip route 10.0.0.0/8 192.168.3.3\n"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ = os.ReadFile(confPath)
+	got = string(data)
+	if n := strings.Count(got, markerBegin); n != 1 {
+		t.Errorf("second write: expected 1 begin marker, got %d:\n%s", n, got)
+	}
+	if !strings.Contains(got, "ip route 192.0.2.0/24 198.51.100.1") {
+		t.Errorf("second write: operator config before stale end lost:\n%s", got)
+	}
+	if !strings.Contains(got, "192.168.3.3") {
+		t.Errorf("second write's route missing:\n%s", got)
+	}
+}
+
 // TestWriteManagedSection_PreservesExistingMode guards the Copilot finding on
 // #1646: the atomic temp-file + rename write replaces the inode, so it must
 // reuse the existing file's mode rather than unconditionally applying 0644.

--- a/pkg/frr/manager.go
+++ b/pkg/frr/manager.go
@@ -530,10 +530,24 @@ func (m *Manager) writeManagedSection(section string) error {
 	// orphaned begin — deleting everything between them, which may include
 	// unrelated FRR config the operator appended. So we treat a begin with no
 	// end as a corrupt tail and discard it to EOF.
+	//
+	// The end-marker search is anchored AFTER the begin marker (#2908). A
+	// stale end-marker positioned *before* the begin marker (an operator
+	// hand-edit, an interleaved partial copy, or external tooling) must not
+	// be matched: an unanchored strings.Index(content, markerEnd) would
+	// return end < start, and the strip content[:start] + content[end:] would
+	// then DUPLICATE the text between end and start while leaving the live
+	// begin marker in place — corrupting the file with two begin markers and
+	// breaking FRR reload. Anchoring the search keeps the end >= start
+	// invariant, so the slice can never duplicate. (This is distinct from the
+	// #1646 orphaned-begin case handled by the else branch below.)
 	content := string(existing)
 	if start := strings.Index(content, markerBegin); start >= 0 {
-		if end := strings.Index(content, markerEnd); end >= 0 {
-			end += len(markerEnd)
+		// Search for the end marker strictly after the begin marker, then map
+		// the relative index back to an absolute offset.
+		searchFrom := start + len(markerBegin)
+		if rel := strings.Index(content[searchFrom:], markerEnd); rel >= 0 {
+			end := searchFrom + rel + len(markerEnd)
 			// Also consume the trailing newline
 			if end < len(content) && content[end] == '\n' {
 				end++


### PR DESCRIPTION
## Summary

`writeManagedSection` found the begin marker, then searched for the end marker from index 0 of the whole file (`strings.Index(content, markerEnd)`). A stale/orphaned end marker positioned **before** the live begin marker (operator hand-edit, an interleaved partial copy, or external tooling) made that search return `end < start`. The strip `content[:start] + content[end:]` then DUPLICATED the text between the stale end and the begin while leaving the live begin marker in place — two begin markers and a corrupt managed block that FRR reload rejects, tearing down dynamic routing.

This is distinct from #1646 (orphaned begin / missing end), whose discard-to-EOF branch is unchanged.

## Fix

Search for `markerEnd` strictly after the begin marker (`content[start+len(markerBegin):]`) and map the relative index back to an absolute offset, keeping the `end >= start` invariant so the slice can never duplicate. Degenerate cases preserved:

- begin present + no end after it → #1646 orphaned-begin discard-to-EOF branch
- stale end before begin → ignored (the anchored search skips it)
- both missing → fresh managed section appended

## Fail-on-revert test

`TestWriteManagedSection_StaleEndMarkerBeforeBegin`: frr.conf with a stale end marker before the live begin marker, operator config interleaved on both sides → exactly one managed begin marker, managed body replaced, all operator config preserved across two writes. Goes RED if the lookup is reverted to from-0 (2 begin markers after the first write; 3 + duplicated operator config after the second).

## Gates

- `go build ./...` — OK
- `gofmt -l pkg/frr/` — clean
- `go vet ./pkg/frr/...` — OK
- `go test ./pkg/frr/...` — PASS

Closes #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi