### PR TITLE
ipsec: accept IPv6 link-local local binds (matchFamily) — Closes #2885

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17497,3 +17497,27 @@ top.
   gofmt -l clean, go vet ./pkg/ipsec/..., go test ./pkg/ipsec/... PASS.
 - **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/matchfamily_linklocal_test.go,
   pkg/ipsec/README.md, _Log.md
+
+## 2026-06-25 — #2885 review fold (PR #2927 MERGE-NEEDS-MINOR x2)
+- **Timestamp**: 2026-06-25
+- **Action**: Folded two hostile-review MINORs on the #2885 fix.
+  MINOR-1 (global-must-win order-dependence): matchFamily feeds a first-match
+  loop (selectUnitAddress over config order; resolveKernelInterfaceAddress
+  over kernel order). Now that family-6 admits fe80::, a link-local enumerated
+  before the global IPv6 could win. Added selectFamilyAddress doing a two-pass
+  family-6 scan — pass 1 admits only global unicast (bareIPGlobalOnly), pass 2
+  falls back to link-local only if no global exists. Both resolvers route
+  through it; "global wins" is now order-independent.
+  MINOR-2 (bare fe80:: lacks %iface zone): a bare link-local local_addrs is
+  ambiguous on a multi-interface box. Added zoneQualify(addr, iface) appending
+  %<iface> to a link-local result; resolveKernelInterfaceAddress uses the
+  looked-up name, resolveConfiguredInterfaceAddress uses config.LinuxIfName(
+  base). Global/IPv4/already-zoned addresses pass through unchanged.
+  FAIL-ON-REVERT: TestSelectUnitAddressFamily6GlobalWinsOverLinkLocal (link-
+  local listed FIRST, asserts the GLOBAL wins) goes RED when the global-only
+  first pass is removed; TestResolveConfiguredInterfaceAddressZoneQualifiesLink
+  Local asserts fe80::1%ge-0-0-3 and goes RED when zoneQualify is neutered.
+  Both verified via copy-aside revert. Gates: go build ./..., gofmt -l clean,
+  go vet ./pkg/ipsec/..., go test ./pkg/ipsec/... PASS.
+- **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/matchfamily_linklocal_test.go,
+  pkg/ipsec/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -17477,3 +17477,23 @@ top.
   go test ./pkg/routing/... PASS.
   **File(s)**: pkg/routing/xfrm.go, pkg/routing/iface_reuse_test.go,
   pkg/routing/README.md, _Log.md
+
+## 2026-06-25 — #2885 IPsec link-local IPv6 local-bind selection
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed `matchFamily` (pkg/ipsec/policy.go) rejecting IPv6
+  link-local unicast (`fe80::/10`) via `IsGlobalUnicast()`. The local-address
+  resolver gated every candidate interface address on `IsGlobalUnicast()`,
+  which is false for link-local, so an IPsec local-bind on a point-to-point /
+  link-local IPv6 link could never source from `fe80::`. Now `matchFamily`
+  also admits `IsLinkLocalUnicast()`, but link-local is surfaced ONLY for an
+  explicit family-6 hint: excluded from family-4 (and IPv4 link-local
+  169.254.0.0/16 too) and from family-agnostic (hint 0) selection so it never
+  wins implicitly over a global address. Multicast/unspecified/loopback stay
+  excluded for all families. Found by agy-review-051 051-02 (MEDIUM).
+  FAIL-ON-REVERT: TestMatchFamilyLinkLocalIPv6 asserts
+  matchFamily(fe80::1, 6) == "fe80::1"; RED ("" ) when the old IsGlobalUnicast
+  gate is restored (verified by copy-aside revert), GREEN with the fix.
+  TestMatchFamilyExclusions guards the exclusions. Gates: go build ./...,
+  gofmt -l clean, go vet ./pkg/ipsec/..., go test ./pkg/ipsec/... PASS.
+- **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/matchfamily_linklocal_test.go,
+  pkg/ipsec/README.md, _Log.md

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -177,6 +177,18 @@ all files stay in `package ipsec`, so the public API is unchanged.
     timeout / NXDOMAIN / SERVFAIL it returns family 0 (agnostic) — a slow or
     unreachable resolver degrades to the interface-decides path and NEVER
     stalls `commit` / apply for the full glibc resolver timeout.
+  - **IPv6 link-local local binds (#2885):** the candidate filter
+    `matchFamily` (`policy.go`) admits an IPv6 link-local unicast source
+    (`fe80::/10`) when the gateway family hint is IPv6 (family 6). The
+    earlier `IsGlobalUnicast()` gate rejected link-local outright, so an
+    IPsec local-bind on a point-to-point / link-local IPv6 link could never
+    source from `fe80::` — the documented dynamic-routing local-source over
+    such links was unreachable. Link-local is admitted ONLY under an explicit
+    family-6 hint: it is excluded from family-4 selection (and IPv4
+    link-local `169.254.0.0/16` is never a usable source) and from
+    family-agnostic (hint 0) selection, so it never wins implicitly over a
+    global address on a dual-stack interface. Multicast, unspecified, and
+    loopback stay excluded for every family.
 - **IKE policy chain → proposal cross-reference (#2270).** A gateway's
   `ike-policy` reference walks gateway → `ike-policy` → `ike-proposal`
   (`resolveIKESettings`, `ike.go`). When that chain breaks — the

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -189,6 +189,27 @@ all files stay in `package ipsec`, so the public API is unchanged.
     family-agnostic (hint 0) selection, so it never wins implicitly over a
     global address on a dual-stack interface. Multicast, unspecified, and
     loopback stay excluded for every family.
+    - **Global wins, order-independent** (`selectFamilyAddress`): family-6
+      selection feeds a first-match loop over candidates (config order in
+      `selectUnitAddress`; kernel enumeration order in
+      `resolveKernelInterfaceAddress`). To keep a global address from losing
+      to a link-local one that merely happens to be enumerated first,
+      family-6 selection scans twice — pass 1 admits only global-unicast
+      addresses, and a link-local is accepted only if NO global is present.
+      The common case (kernel lists globals first, configs carry no SLAAC
+      `fe80::`) was already safe, but enumeration order is not guaranteed,
+      so the preference is made explicit rather than relied upon. Family-4
+      and family-agnostic selection need only one pass (link-local is never
+      admitted by `matchFamily` there).
+    - **Zone-qualified link-local source** (`zoneQualify`): a bare
+      `local_addrs = fe80::1` is ambiguous to strongSwan / the kernel when
+      more than one interface carries an `fe80::` address. When the selected
+      source is link-local, the resolver appends the IPv6 zone
+      (`%<iface>`) — e.g. `fe80::1%ge-0-0-3` — using the kernel interface
+      name it already has in scope (`config.LinuxIfName(base)` for the
+      configured path, the looked-up interface name for the kernel path).
+      Global and IPv4 sources are emitted bare; an address already carrying
+      a zone is left unchanged.
 - **IKE policy chain → proposal cross-reference (#2270).** A gateway's
   `ike-policy` reference walks gateway → `ike-policy` → `ike-proposal`
   (`resolveIKESettings`, `ike.go`). When that chain breaks — the

--- a/pkg/ipsec/matchfamily_linklocal_test.go
+++ b/pkg/ipsec/matchfamily_linklocal_test.go
@@ -1,0 +1,70 @@
+package ipsec
+
+import (
+	"net"
+	"testing"
+)
+
+// TestMatchFamilyLinkLocalIPv6 is the fail-on-revert guard for #2885:
+// matchFamily must accept an IPv6 link-local unicast (fe80::/10) address when
+// the gateway family hint is IPv6 (family 6). Before the fix, the
+// IsGlobalUnicast() gate rejected link-local, so an IPsec local-bind on a
+// point-to-point / link-local IPv6 link could never source from fe80::.
+func TestMatchFamilyLinkLocalIPv6(t *testing.T) {
+	ll := net.ParseIP("fe80::1")
+	if ll == nil {
+		t.Fatal("failed to parse fe80::1")
+	}
+
+	if got := matchFamily(ll, 6); got != "fe80::1" {
+		t.Fatalf("matchFamily(fe80::1, 6) = %q, want %q (link-local IPv6 must "+
+			"be selectable for family-6 IPsec local binds, #2885)", got, "fe80::1")
+	}
+
+	// A global IPv6 address must still be selected for family 6.
+	if got := matchFamily(net.ParseIP("2001:db8::5"), 6); got != "2001:db8::5" {
+		t.Fatalf("matchFamily(2001:db8::5, 6) = %q, want %q", got, "2001:db8::5")
+	}
+}
+
+// TestMatchFamilyExclusions verifies the fix keeps the unsafe candidates
+// excluded: IPv6 link-local must not leak into family-4 or family-agnostic
+// selection, and multicast/unspecified/loopback stay rejected everywhere.
+func TestMatchFamilyExclusions(t *testing.T) {
+	ll6 := net.ParseIP("fe80::1")
+
+	// Link-local IPv6 must not surface under a family-4 request.
+	if got := matchFamily(ll6, 4); got != "" {
+		t.Fatalf("matchFamily(fe80::1, 4) = %q, want empty", got)
+	}
+	// Link-local IPv6 must not surface implicitly under family-agnostic (0)
+	// selection — only an explicit family-6 hint may bind link-local.
+	if got := matchFamily(ll6, 0); got != "" {
+		t.Fatalf("matchFamily(fe80::1, 0) = %q, want empty", got)
+	}
+
+	// IPv4 link-local (169.254.0.0/16) is not a usable IPsec source.
+	if got := matchFamily(net.ParseIP("169.254.1.2"), 4); got != "" {
+		t.Fatalf("matchFamily(169.254.1.2, 4) = %q, want empty", got)
+	}
+
+	excluded := []net.IP{
+		net.ParseIP("ff02::1"),   // IPv6 multicast
+		net.ParseIP("::"),        // IPv6 unspecified
+		net.ParseIP("::1"),       // IPv6 loopback
+		net.ParseIP("127.0.0.1"), // IPv4 loopback
+		net.ParseIP("0.0.0.0"),   // IPv4 unspecified
+	}
+	for _, ip := range excluded {
+		for _, fam := range []int{0, 4, 6} {
+			if got := matchFamily(ip, fam); got != "" {
+				t.Fatalf("matchFamily(%s, %d) = %q, want empty", ip, fam, got)
+			}
+		}
+	}
+
+	// A global IPv4 still selected for family 4.
+	if got := matchFamily(net.ParseIP("203.0.113.7"), 4); got != "203.0.113.7" {
+		t.Fatalf("matchFamily(203.0.113.7, 4) = %q, want %q", got, "203.0.113.7")
+	}
+}

--- a/pkg/ipsec/matchfamily_linklocal_test.go
+++ b/pkg/ipsec/matchfamily_linklocal_test.go
@@ -3,6 +3,8 @@ package ipsec
 import (
 	"net"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // TestMatchFamilyLinkLocalIPv6 is the fail-on-revert guard for #2885:
@@ -66,5 +68,63 @@ func TestMatchFamilyExclusions(t *testing.T) {
 	// A global IPv4 still selected for family 4.
 	if got := matchFamily(net.ParseIP("203.0.113.7"), 4); got != "203.0.113.7" {
 		t.Fatalf("matchFamily(203.0.113.7, 4) = %q, want %q", got, "203.0.113.7")
+	}
+}
+
+// TestSelectUnitAddressFamily6GlobalWinsOverLinkLocal is the fail-on-revert
+// guard for #2885 MINOR-1: family-6 selection must prefer a global-unicast
+// address over a link-local one REGARDLESS of candidate order. Here the
+// link-local is listed FIRST, so a naive first-match loop would pick it; the
+// two-pass selectFamilyAddress must still return the global. This goes RED if
+// the global-only first pass in selectFamilyAddress is removed.
+func TestSelectUnitAddressFamily6GlobalWinsOverLinkLocal(t *testing.T) {
+	unit := &config.InterfaceUnit{
+		// Link-local enumerated BEFORE the global IPv6.
+		Addresses: []string{"fe80::1/64", "2001:db8::5/64"},
+	}
+	if got := selectUnitAddress(unit, 6); got != "2001:db8::5" {
+		t.Fatalf("selectUnitAddress(family 6) = %q, want %q (global must win "+
+			"over link-local regardless of order, #2885)", got, "2001:db8::5")
+	}
+
+	// When ONLY a link-local IPv6 is present, family 6 falls back to it.
+	llOnly := &config.InterfaceUnit{Addresses: []string{"fe80::1/64"}}
+	if got := selectUnitAddress(llOnly, 6); got != "fe80::1" {
+		t.Fatalf("selectUnitAddress(link-local only, family 6) = %q, want %q",
+			got, "fe80::1")
+	}
+}
+
+// TestResolveConfiguredInterfaceAddressZoneQualifiesLinkLocal is the
+// fail-on-revert guard for #2885 MINOR-2: a link-local local-bind source must
+// be emitted with its IPv6 zone (%<iface>) so strongSwan can disambiguate
+// fe80:: on a multi-interface box. A global address must NOT be zone-qualified.
+// This goes RED if the zoneQualify() call is removed from
+// resolveConfiguredInterfaceAddress.
+func TestResolveConfiguredInterfaceAddressZoneQualifiesLinkLocal(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0/0/3": {
+			Units: map[int]*config.InterfaceUnit{
+				0: {Number: 0, Addresses: []string{"fe80::1/64"}},
+			},
+		},
+	}
+	// config.LinuxIfName("ge-0/0/3") == "ge-0-0-3" is the kernel zone name.
+	want := "fe80::1%" + config.LinuxIfName("ge-0/0/3")
+	if got := resolveConfiguredInterfaceAddress(cfg, "ge-0/0/3.0", 6); got != want {
+		t.Fatalf("resolveConfiguredInterfaceAddress(link-local, family 6) = %q, "+
+			"want %q (link-local source must carry %%iface zone, #2885)", got, want)
+	}
+
+	// A global IPv6 source is emitted bare (no zone).
+	cfg.Interfaces.Interfaces["ge-0/0/4"] = &config.InterfaceConfig{
+		Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"2001:db8::5/64"}},
+		},
+	}
+	if got := resolveConfiguredInterfaceAddress(cfg, "ge-0/0/4.0", 6); got != "2001:db8::5" {
+		t.Fatalf("resolveConfiguredInterfaceAddress(global, family 6) = %q, "+
+			"want %q (global source must NOT be zone-qualified)", got, "2001:db8::5")
 	}
 }

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -735,11 +735,22 @@ func addressFamilyHint(addr string) int {
 }
 
 func matchFamily(ip net.IP, family int) string {
-	if ip == nil || !ip.IsGlobalUnicast() {
+	if ip == nil {
+		return ""
+	}
+	// Global unicast covers the common case. IPv6 link-local unicast
+	// (fe80::/10) is also a valid IPsec local-bind source on point-to-point
+	// / link-local IPv6 links (#2885); IsGlobalUnicast() rejects it, so admit
+	// it explicitly here. Multicast, unspecified, and loopback stay excluded.
+	if !ip.IsGlobalUnicast() && !ip.IsLinkLocalUnicast() {
 		return ""
 	}
 	switch family {
 	case 4:
+		// IPv4 link-local (169.254.0.0/16) is not a usable IPsec source.
+		if ip.IsLinkLocalUnicast() {
+			return ""
+		}
 		if ip4 := ip.To4(); ip4 != nil {
 			return ip4.String()
 		}
@@ -748,6 +759,11 @@ func matchFamily(ip net.IP, family int) string {
 			return ip.String()
 		}
 	default:
+		// Family-agnostic selection: never surface a link-local address
+		// implicitly — only an explicit family-6 hint may bind link-local.
+		if ip.IsLinkLocalUnicast() {
+			return ""
+		}
 		return ip.String()
 	}
 	return ""

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -650,9 +650,13 @@ func resolveConfiguredInterfaceAddress(cfg *config.Config, ifaceRef string, fami
 		return ""
 	}
 
+	// Zone identifier for a link-local result is the kernel interface name of
+	// the configured ifaceRef base (#2885) — the vSRX name xpfd renames to.
+	zone := config.LinuxIfName(base)
+
 	if unit, ok := ifc.Units[unitNum]; ok {
 		if addr := selectUnitAddress(unit, family); addr != "" {
-			return addr
+			return zoneQualify(addr, zone)
 		}
 	}
 
@@ -664,7 +668,7 @@ func resolveConfiguredInterfaceAddress(cfg *config.Config, ifaceRef string, fami
 		sort.Ints(unitIDs)
 		for _, id := range unitIDs {
 			if addr := selectUnitAddress(ifc.Units[id], family); addr != "" {
-				return addr
+				return zoneQualify(addr, zone)
 			}
 		}
 	}
@@ -677,17 +681,12 @@ func selectUnitAddress(unit *config.InterfaceUnit, family int) string {
 		return ""
 	}
 
-	for _, candidate := range []string{unit.PrimaryAddress, unit.PreferredAddress} {
-		if addr := bareIP(candidate, family); addr != "" {
-			return addr
-		}
-	}
-	for _, candidate := range unit.Addresses {
-		if addr := bareIP(candidate, family); addr != "" {
-			return addr
-		}
-	}
-	return ""
+	candidates := make([]string, 0, 2+len(unit.Addresses))
+	candidates = append(candidates, unit.PrimaryAddress, unit.PreferredAddress)
+	candidates = append(candidates, unit.Addresses...)
+	// Global-wins is order-independent (#2885): selectFamilyAddress scans
+	// family-6 candidates for a global address before admitting link-local.
+	return selectFamilyAddress(candidates, family)
 }
 
 func resolveKernelInterfaceAddress(ifaceName string, family int) string {
@@ -702,8 +701,38 @@ func resolveKernelInterfaceAddress(ifaceName string, family int) string {
 	if err != nil {
 		return ""
 	}
+	candidates := make([]string, 0, len(addrs))
 	for _, addr := range addrs {
-		if ip := bareIP(addr.String(), family); ip != "" {
+		candidates = append(candidates, addr.String())
+	}
+	// A global address always wins over a link-local one regardless of
+	// kernel enumeration order (#2885); zone-qualify a link-local result with
+	// the interface name so strongSwan can disambiguate fe80:: on a
+	// multi-interface box.
+	if addr := selectFamilyAddress(candidates, family); addr != "" {
+		return zoneQualify(addr, ifaceName)
+	}
+	return ""
+}
+
+// selectFamilyAddress chooses one address from candidates for the requested
+// family. For family 6 it scans twice: the first pass admits only
+// global-unicast addresses, and a link-local (fe80::/10) candidate is accepted
+// only if no global address is present. This makes "global wins" independent of
+// candidate enumeration order (config order or kernel order) — without it a
+// link-local enumerated before the global IPv6 would be selected first (#2885).
+// For family 4 and family-agnostic (0) selection, link-local is never admitted
+// by matchFamily, so a single pass is sufficient.
+func selectFamilyAddress(candidates []string, family int) string {
+	if family == 6 {
+		for _, c := range candidates {
+			if ip := bareIPGlobalOnly(c); ip != "" {
+				return ip
+			}
+		}
+	}
+	for _, c := range candidates {
+		if ip := bareIP(c, family); ip != "" {
 			return ip
 		}
 	}
@@ -711,16 +740,46 @@ func resolveKernelInterfaceAddress(ifaceName string, family int) string {
 }
 
 func bareIP(addr string, family int) string {
-	if addr == "" {
+	ip := parseBareIP(addr)
+	if ip == nil {
 		return ""
 	}
+	return matchFamily(ip, family)
+}
+
+// bareIPGlobalOnly is bareIP restricted to global-unicast IPv6 — the first pass
+// of the family-6 global-wins scan in selectFamilyAddress (#2885).
+func bareIPGlobalOnly(addr string) string {
+	ip := parseBareIP(addr)
+	if ip == nil || !ip.IsGlobalUnicast() || ip.To4() != nil {
+		return ""
+	}
+	return matchFamily(ip, 6)
+}
+
+func parseBareIP(addr string) net.IP {
+	if addr == "" {
+		return nil
+	}
 	if ip, _, err := net.ParseCIDR(addr); err == nil {
-		return matchFamily(ip, family)
+		return ip
 	}
-	if ip := net.ParseIP(addr); ip != nil {
-		return matchFamily(ip, family)
+	return net.ParseIP(addr)
+}
+
+// zoneQualify appends the IPv6 zone (%<iface>) to a link-local source address
+// so strongSwan/the kernel can pick the right interface when more than one
+// interface carries an fe80:: address (#2885). Non-link-local addresses, an
+// empty iface name, and addresses already carrying a zone are returned
+// unchanged.
+func zoneQualify(addr, ifaceName string) string {
+	if ifaceName == "" || strings.Contains(addr, "%") {
+		return addr
 	}
-	return ""
+	if ip := net.ParseIP(addr); ip != nil && ip.IsLinkLocalUnicast() && ip.To4() == nil {
+		return addr + "%" + ifaceName
+	}
+	return addr
 }
 
 func addressFamilyHint(addr string) int {


### PR DESCRIPTION
## Summary
`matchFamily` (`pkg/ipsec/policy.go`) gated every candidate interface address on `net.IP.IsGlobalUnicast()`, which returns false for IPv6 link-local unicast (`fe80::/10`). The local-address resolver therefore rejected link-local IPv6, so an IPsec local-bind on a point-to-point / link-local IPv6 link could never source from `fe80::`. Found by agy-review-051 051-02 (MEDIUM); verified TRUE at master.

## Fix
`matchFamily` now also admits `IsLinkLocalUnicast()`, but surfaces a link-local address **only under an explicit family-6 hint**:
- Excluded from family-4 selection (and IPv4 link-local `169.254.0.0/16` is never a usable IPsec source).
- Excluded from family-agnostic (hint 0) selection, so link-local never wins implicitly over a global address on a dual-stack interface.
- Multicast, unspecified, and loopback stay excluded for every family.

## Tests (fail-on-revert)
- `TestMatchFamilyLinkLocalIPv6` — asserts `matchFamily(fe80::1, 6) == "fe80::1"`. Verified RED (returns `""`) when the old `IsGlobalUnicast()` gate is restored, GREEN with the fix.
- `TestMatchFamilyExclusions` — guards the family-4 / family-agnostic link-local exclusions and the multicast/unspecified/loopback rejections.

## Gates
- `go build ./...` OK
- `gofmt -l pkg/ipsec/` clean
- `go vet ./pkg/ipsec/...` OK
- `go test ./pkg/ipsec/...` PASS

## Docs
`pkg/ipsec/README.md` (#2885 bullet under family-selection) + `_Log.md`.

Closes #2885

🤖 Generated with [Claude Code](https://claude.com/claude-code)