### PR TITLE
eventengine: place superseding action at queue tail (FIFO, #2869)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17494,3 +17494,21 @@ top.
   ./pkg/eventengine/... PASS.
   **File(s)**: pkg/eventengine/engine.go,
   pkg/eventengine/engine_integration_test.go, pkg/eventengine/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2869 review fix — supersede() metrics double-count. In the
+  all-distinct-overflow case (queue full of distinct policies, a new distinct
+  policy arrives, no same-policy stale to evict) the FIFO tail-placement change
+  made the new action overflow supersede()'s refill default branch
+  (droppedQueueFull++) AND then enqueue() counted+warned again — net +2 on
+  xpf_event_actions_dropped_total{reason="queue_full"} for one dropped action.
+  Fix: guard the refill default increment with `if item.policyName !=
+  a.policyName` so supersede counts only un-replaceable SURVIVORS; the new
+  action's single count + warn is owned by enqueue (supersede returns false).
+  Added fail-on-revert TestSupersede_AllDistinctOverflowCountsDropOnce (fills 64
+  distinct, enqueues a 65th distinct, asserts droppedQueueFull delta == 1 and no
+  survivor evicted). Verified RED (delta=2) with the guard removed. Kept
+  TestSupersede_PreservesFIFOPlacesNewAtTail. Gates: go build ./..., gofmt -l
+  clean, go vet ./pkg/eventengine/..., go test -race ./pkg/eventengine/... PASS.
+  **File(s)**: pkg/eventengine/engine.go,
+  pkg/eventengine/engine_integration_test.go, pkg/eventengine/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -17477,3 +17477,20 @@ top.
   go test ./pkg/routing/... PASS.
   **File(s)**: pkg/routing/xfrm.go, pkg/routing/iface_reuse_test.go,
   pkg/routing/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+  **Action**: #2869 eventengine supersede() FIFO ordering fix. supersede()
+  rebuilt the bounded action queue by PREPENDING the new (superseding) action
+  ahead of drained other-policy survivors, converting the documented FIFO queue
+  into LIFO for the newest arrival and starving older queued remediations under
+  sustained event frequency. Fix: append the new action to the TAIL of the
+  survivors (`all := append(drained, a)`) so unrelated policies keep FIFO order;
+  supersede still drops/replaces only the stale same-policy entry. Added
+  fail-on-revert TestSupersede_PreservesFIFOPlacesNewAtTail (fills queue with
+  distinct other-policy actions + a stale same-policy entry, forces supersede,
+  asserts survivors keep order and the new action lands at the tail). Verified
+  RED under the reverted prepend (new action at index 0). Gates: go build ./...,
+  gofmt -l clean, go vet ./pkg/eventengine/..., go test -race
+  ./pkg/eventengine/... PASS.
+  **File(s)**: pkg/eventengine/engine.go,
+  pkg/eventengine/engine_integration_test.go, pkg/eventengine/README.md, _Log.md

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -124,6 +124,17 @@ cannot occur.
   in applying a stale remediation twice). Overflow bumps
   `xpf_event_actions_dropped_total{reason="queue_full"}`. Loss is always
   counted, never silent.
+- **FIFO ordering across policies (#2869):** the queue is FIFO. When the queue
+  is full and `supersede()` drains/refills it to drop a stale same-policy entry,
+  it re-enqueues the surviving OTHER-policy actions in their original order and
+  places the new (superseding) action at the **TAIL** — never the head.
+  Prepending the new action would let the newest event jump ahead of every older
+  queued remediation (LIFO), starving older policies under sustained event
+  frequency and reordering remediation against the order events were observed.
+  Supersede therefore only ever drops/replaces the stale same-policy entry; it
+  does not reorder unrelated policies. Locked by
+  `TestSupersede_PreservesFIFOPlacesNewAtTail` (fail-on-revert: a prepend lands
+  the new action at index 0 and the test goes RED).
 - A non-lock error (bad apply / CommitCheck reject) is a permanent failure: no
   retry, bumps `xpf_event_actions_rejected_total`.
 

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -122,8 +122,13 @@ cannot occur.
 - **Bounded queue, dedup-by-policy:** the queue holds at most one pending
   action per policy — a newer trigger supersedes an older queued one (no value
   in applying a stale remediation twice). Overflow bumps
-  `xpf_event_actions_dropped_total{reason="queue_full"}`. Loss is always
-  counted, never silent.
+  `xpf_event_actions_dropped_total{reason="queue_full"}` **exactly once per
+  dropped action**. When the queue is full of unrelated policies and there is no
+  stale same-policy entry to evict, the genuinely-unfittable new arrival is
+  dropped (the older FIFO survivors are kept) and counted once by `enqueue` —
+  `supersede()` does NOT also count that overflow in its refill loop (it only
+  counts a SURVIVOR it could not re-place). Loss is always counted, never silent,
+  and never double-counted (#2869).
 - **FIFO ordering across policies (#2869):** the queue is FIFO. When the queue
   is full and `supersede()` drains/refills it to drop a stale same-policy entry,
   it re-enqueues the surviving OTHER-policy actions in their original order and

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -464,9 +464,16 @@ refill:
 				replaced = true
 			}
 		default:
-			// Still no room (lost the race to another producer). Count the
-			// loss for whatever we could not re-place.
-			e.counters.droppedQueueFull.Add(1)
+			// Still no room (lost the race to another producer, or the queue
+			// is full of unrelated policies and there was no stale same-policy
+			// entry to evict). Count the loss for any SURVIVOR we could not
+			// re-place — but NOT for the new action `a` itself: supersede
+			// returns false in that case and enqueue owns `a`'s single
+			// queue_full count + warn. Counting it here too would
+			// double-increment xpf_event_actions_dropped_total (#2869).
+			if item.policyName != a.policyName {
+				e.counters.droppedQueueFull.Add(1)
+			}
 		}
 	}
 	return replaced

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -447,8 +447,15 @@ func (e *Engine) supersede(a plannedAction) bool {
 		}
 	}
 refill:
-	// Put the new action first, then the survivors.
-	all := append([]plannedAction{a}, drained...)
+	// Re-enqueue the surviving other-policy actions in their original FIFO
+	// order, then place the new (superseding) action at the TAIL (#2869).
+	// Prepending `a` would jump it ahead of every already-queued action of
+	// OTHER policies, converting the documented FIFO queue into LIFO for the
+	// newest arrival and starving older queued remediations under sustained
+	// event frequency. Supersede must only drop/replace the stale SAME-policy
+	// entry (done in the drain loop above); it must not reorder unrelated
+	// policies relative to the order their events were observed.
+	all := append(drained, a)
 	for _, item := range all {
 		select {
 		case e.actions <- item:

--- a/pkg/eventengine/engine_integration_test.go
+++ b/pkg/eventengine/engine_integration_test.go
@@ -574,3 +574,44 @@ func TestSupersede_PreservesFIFOPlacesNewAtTail(t *testing.T) {
 		t.Errorf("superseding action prepended to head (LIFO regression, #2869)")
 	}
 }
+
+// #2869 metrics single-count: in the all-distinct-overflow case (queue full of
+// DISTINCT policies, a new DISTINCT policy arrives, NO same-policy stale entry
+// to evict), the new action is genuinely unfittable and must be dropped — but
+// exactly ONCE on xpf_event_actions_dropped_total{reason="queue_full"}.
+// supersede() returns false (it could not place `a` and evicted nothing), so
+// enqueue() owns the single count + warn; supersede() must NOT also count the
+// overflow of `a` itself in its refill `default` branch.
+//
+// FAIL-ON-REVERT: remove the `if item.policyName != a.policyName` guard around
+// supersede()'s refill `default` increment and this test goes RED — the drop is
+// counted twice (delta == 2).
+func TestSupersede_AllDistinctOverflowCountsDropOnce(t *testing.T) {
+	e := New(nil, nil)
+	defer e.Close()
+
+	// Fill the bounded queue completely with DISTINCT other-policy actions; no
+	// same-policy entry exists for the incoming action, so supersede() can evict
+	// nothing and the new action cannot be re-placed.
+	for i := 0; i < actionQueueDepth; i++ {
+		e.actions <- plannedAction{policyName: fmt.Sprintf("p%02d", i)}
+		e.counters.queueDepth.Add(1)
+	}
+
+	before := e.counters.droppedQueueFull.Load()
+
+	// A new DISTINCT policy arrives; enqueue() -> supersede() -> drop (no evict).
+	e.enqueue(plannedAction{policyName: "z"})
+
+	delta := e.counters.droppedQueueFull.Load() - before
+	if delta != 1 {
+		t.Fatalf("droppedQueueFull delta=%d; want exactly 1 (a single dropped action must not double-count, #2869)", delta)
+	}
+
+	// The queue must be unchanged: every original distinct action still present,
+	// none evicted to make room for the unfittable new arrival (correct FIFO:
+	// drop the new arrival, keep the older survivors).
+	if got := int(e.counters.queueDepth.Load()); got != actionQueueDepth {
+		t.Errorf("queueDepth=%d; want %d (no survivor should be evicted for an unfittable new arrival)", got, actionQueueDepth)
+	}
+}

--- a/pkg/eventengine/engine_integration_test.go
+++ b/pkg/eventengine/engine_integration_test.go
@@ -3,6 +3,7 @@ package eventengine
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -503,4 +504,73 @@ func TestQueue_DedupByPolicy(t *testing.T) {
 	// Release and confirm it still converges to a single commit.
 	s.ExitConfigureSession("operator")
 	waitFor(t, "eventual commit", func() bool { return e.Stats().Committed >= 1 })
+}
+
+// #2869 supersede ordering: when supersede() rebuilds a full queue it must
+// preserve the FIFO order of UNRELATED policies and place the new (superseding)
+// action at the TAIL, not the head. A prepend would let the newest event jump
+// ahead of every older queued remediation (LIFO), starving older policies under
+// sustained event frequency.
+//
+// FAIL-ON-REVERT: revert the engine.go fix back to
+// `all := append([]plannedAction{a}, drained...)` and this test goes RED —
+// the new policy "z" lands at index 0 instead of the tail, and the surviving
+// policies are shifted out of FIFO order.
+func TestSupersede_PreservesFIFOPlacesNewAtTail(t *testing.T) {
+	e := New(nil, nil)
+	defer e.Close()
+
+	// Fill the bounded queue with DISTINCT other-policy actions p00..pNN in a
+	// known FIFO order, PLUS one stale same-policy "z" entry at the tail. The
+	// queue is now full (no free slot), so a fresh "z" trigger forces the
+	// supersede() drain/refill path (the only path that reorders).
+	want := make([]string, 0, actionQueueDepth)
+	for i := 0; i < actionQueueDepth-1; i++ {
+		name := fmt.Sprintf("p%02d", i)
+		e.actions <- plannedAction{policyName: name}
+		e.counters.queueDepth.Add(1)
+		want = append(want, name)
+	}
+	// Stale same-policy entry; it must be DROPPED (superseded), freeing the slot
+	// the new "z" will occupy at the TAIL.
+	e.actions <- plannedAction{policyName: "z"}
+	e.counters.queueDepth.Add(1)
+
+	// New "z" trigger cannot fit (queue full); enqueue() falls into supersede().
+	// The stale "z" is dropped and the new "z" is re-placed: the queue must end
+	// up holding every other-policy entry in FIFO order plus "z" at the tail.
+	e.enqueue(plannedAction{policyName: "z"})
+	want = append(want, "z")
+
+	if got := int(e.counters.queueDepth.Load()); got != len(want) {
+		t.Fatalf("queueDepth=%d; want %d (no action should be dropped)", got, len(want))
+	}
+
+	// Drain in dequeue (FIFO) order and compare against the expected sequence.
+	got := make([]string, 0, len(want))
+	for {
+		select {
+		case a := <-e.actions:
+			got = append(got, a.policyName)
+			continue
+		default:
+		}
+		break
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("drained %d actions; want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("queue order wrong at index %d: got %q, want %q\nfull got=%v\nwant=%v",
+				i, got[i], want[i], got, want)
+		}
+	}
+	if got[len(got)-1] != "z" {
+		t.Errorf("superseding action not at tail: tail=%q want %q", got[len(got)-1], "z")
+	}
+	if got[0] == "z" {
+		t.Errorf("superseding action prepended to head (LIFO regression, #2869)")
+	}
 }


### PR DESCRIPTION
## Summary

`pkg/eventengine` `supersede()` rebuilds the bounded action queue when it is full and a new trigger needs to drop a stale same-policy entry. It drained the buffered entries, dropped any older same-policy action, then refilled — but PREPENDED the new (superseding) action ahead of the drained other-policy survivors (`all := append([]plannedAction{a}, drained...)`).

The queue is documented/intended as **FIFO** (one pending action per policy, applied in observation order). Prepending converts it to **LIFO** for the newest arrival: the freshest event's remediation jumps ahead of every already-queued remediation of unrelated policies. Under sustained event frequency older queued policies keep getting pushed back and can be starved, and remediation is reordered against the order events were observed.

## Fix

Append the new action to the **TAIL** of the survivors (`all := append(drained, a)`). Surviving other-policy actions keep FIFO order; supersede still drops/replaces only the stale same-policy entry (the dedup, done in the drain loop). supersede is a dedup mechanism, not a priority mechanism — it must not reorder unrelated policies. This is the minimal correct behavior the issue describes.

Scope: `pkg/eventengine` only. Builds on #2868 (cancellable commit `lifeCtx`/`lifeCancel`) — no changes to that context threading.

## Fail-on-revert test

`TestSupersede_PreservesFIFOPlacesNewAtTail` fills the bounded queue with distinct other-policy actions in known FIFO order (`p00..pNN`) plus one stale same-policy `z` entry, then fires a fresh `z` trigger to force the `supersede()` drain/refill path. Asserts: nothing else dropped, surviving policies keep FIFO order, and the new action lands at the **tail** (index 0 is `p00`, not `z`).

Verified RED under the reverted prepend:
```
queue order wrong at index 0: got "z", want "p00"
```

## Gates (foreground)

- `go build ./...` — OK
- `gofmt -l pkg/eventengine/` — clean
- `go vet ./pkg/eventengine/...` — OK
- `go test -race ./pkg/eventengine/...` — PASS

## Docs

- `pkg/eventengine/README.md` — FIFO ordering contract documented under the fail-safe action queue section.
- `_Log.md` — change logged.

Closes #2869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi