### PR TITLE
routing: fail-closed xfrmi if_id collision guard (Closes #2909)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17442,3 +17442,22 @@ top.
   go vet ./pkg/ddns/..., go test ./pkg/ddns/... PASS.
   **File(s)**: pkg/ddns/backend_bind.go, pkg/ddns/backend_bind_test.go,
   pkg/ddns/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25 13:36
+  **Action**: #2909 — pkg/routing xfrmi if_id collision guard. A bare
+  secure-tunnel bind-interface (`st0`) and an explicit `st0.0` derive
+  DISTINCT device names but the SAME XFRM `if_id` (1, unit defaults to 0
+  with no `.N` suffix). The kernel keys SA<->xfrmi binding on `if_id`, so
+  programming both devices either EEXISTs or silently cross-leaks traffic
+  between VPNs meant to be isolated. `xfrmManager.Apply` now detects two
+  distinct desired names mapping to one `if_id` and refuses to create
+  EITHER (fail-closed); a formerly-good device is torn down if a later
+  commit introduces the alias. Added FAIL-ON-REVERT tests
+  (TestXfrmApplyIfIDCollisionRefused, TestXfrmApplyCollisionDeletesPriorDevice)
+  — RED without the guard (3 LinkAdd / 2 devices sharing if_id 1). Root
+  derivation lives in pkg/config/xfrmi.go; commit-time rejection is a
+  separate lane (#2885) — this is the last-line routing defense.
+  Gates: go build ./..., gofmt -l clean, go vet ./pkg/routing/...,
+  go test ./pkg/routing/... PASS.
+  **File(s)**: pkg/routing/xfrm.go, pkg/routing/iface_reuse_test.go,
+  pkg/routing/README.md, _Log.md

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -26,7 +26,7 @@ which makes each domain unit-testable with a fake (see `rules_test.go`'s
 | `routes.go` | `routeReader` | kernel routing-table reads (`routeLister`) |
 | `routeformat.go` | free fns | Junos `show route` formatters |
 | `tunnel.go` | `tunnelManager` | GRE/IPIP tunnels + keepalive goroutines; own `mu` |
-| `xfrm.go` | `xfrmManager` | XFRM/IPsec interface lifecycle; own `mu` + tracked `name→if_id` set. `Apply` reconciles **differentially** against the tracked set (keep unchanged / create new / delete removed / recreate on `if_id` change) — it does NOT clear-all-then-rebuild, so an unrelated config commit leaves active xfrmi interfaces untouched (#2546) |
+| `xfrm.go` | `xfrmManager` | XFRM/IPsec interface lifecycle; own `mu` + tracked `name→if_id` set. `Apply` reconciles **differentially** against the tracked set (keep unchanged / create new / delete removed / recreate on `if_id` change) — it does NOT clear-all-then-rebuild, so an unrelated config commit leaves active xfrmi interfaces untouched (#2546). Refuses to create either of two distinct devices that derive the same `if_id` — fail-closed collision guard (#2909) |
 | `rules.go` | `nextTableManager` / `ribGroupManager` / `pbrManager` | policy-routing ip-rule reconcilers (`ruleOps`, stateless) |
 | `probe_pin.go` | `probePinManager` | RPM probe next-hop pin reconciler (#1827): fwmark rules in band 50-99 + pinned host routes in reserved tables 7000-7049 (`probePinOps`, stateless). `Apply` returns per-test install failures (keyed by TestKey) and rolls back the fwmark rule when the pinned route fails (best-effort — a failed rollback is swept by the next band clear; the pin reports failed either way); callers thread the failed map into `pkg/rpm` so affected tests hold state instead of probing unpinned (#1895) |
 | `bond.go` | `bondManager` | bond device lifecycle; own `mu` |
@@ -59,6 +59,28 @@ all and rebuilding:
 A no-op commit (identical VPN set) issues zero `LinkDel` and zero
 `LinkAdd`. `Clear()` (shutdown / full teardown) still deletes every
 tracked interface.
+
+#### `if_id` collision guard (#2909)
+
+The kernel keys the SA↔xfrmi binding on the XFRM `if_id`, so the `if_id`
+**must be unique per distinct xfrmi device**. `config.XFRMIfNameAndID`
+can derive a colliding id for two *distinct* `bind-interface` values: a
+bare `st0` and an explicit `st0.0` both resolve to `if_id 1` (the unit
+defaults to 0 when there is no `.N` suffix) under *different* device
+names (`st0` vs `st0.0`). Programming both would either `EEXIST` or,
+worse, silently route both VPNs' SAs through one device — leaking
+traffic between VPNs that are supposed to be isolated.
+
+`Apply` therefore detects when two distinct desired device names map to
+the same `if_id` and **refuses to create either** colliding device
+(fail-closed: no transit for the ambiguous pair beats a cross-VPN leak).
+If one half of the colliding pair was already created by an earlier
+commit, it is torn down on the commit that introduces the alias.
+Non-colliding interfaces in the same commit are created normally. The
+proper long-term fix is a commit-time rejection of an ambiguous
+secure-tunnel `bind-interface` in the config compiler / `pkg/ipsec`
+(separate lane, #2885); this routing guard is the last line of defense
+so a config that slips through never programs colliding kernel state.
 
 ## Entry points
 

--- a/pkg/routing/iface_reuse_test.go
+++ b/pkg/routing/iface_reuse_test.go
@@ -553,3 +553,98 @@ func TestXfrmClearStillDeletesAll(t *testing.T) {
 		t.Errorf("Clear left %d tracked xfrmis, want 0", len(xm.xfrmis))
 	}
 }
+
+// TestXfrmApplyIfIDCollisionRefused is the #2909 regression. A bare
+// secure-tunnel bind-interface ("st0") and an explicit ".0"
+// bind-interface ("st0.0") derive DISTINCT device names ("st0" vs
+// "st0.0") but the SAME XFRM if_id (1, because unit defaults to 0 with
+// no ".N" suffix). The kernel keys SA<->xfrmi binding on if_id, so
+// creating both devices would either EEXIST or, worse, silently route
+// both VPNs' SAs to one device — leaking traffic between isolated VPNs.
+//
+// Apply must refuse to create EITHER colliding device (fail-closed):
+// zero LinkAdd, nothing tracked. The non-colliding interface in the same
+// commit must still be created normally.
+//
+// FAIL-ON-REVERT: without the if_id collision guard in Apply, both "st0"
+// and "st0.0" land in the desired set under different names and are each
+// LinkAdd'd, yielding 3 LinkAdd / 3 tracked xfrmis and two kernel
+// devices sharing if_id 1. The assertions below (2 adds, st1.0 only)
+// then fail.
+func TestXfrmApplyIfIDCollisionRefused(t *testing.T) {
+	// Sanity: the two binds really do collide on if_id under distinct
+	// names — the precondition the guard defends against.
+	nameBare, idBare := config.XFRMIfNameAndID("st0")
+	nameUnit, idUnit := config.XFRMIfNameAndID("st0.0")
+	if idBare == 0 || idUnit == 0 || idBare != idUnit || nameBare == nameUnit {
+		t.Fatalf("precondition broke: st0=(%q,%d) st0.0=(%q,%d); "+
+			"test requires distinct names sharing one if_id",
+			nameBare, idBare, nameUnit, idUnit)
+	}
+
+	ops := newFakeLinkOps()
+	xm := &xfrmManager{ops: ops}
+
+	// st0 + st0.0 collide on if_id; st1.0 is independent and must survive.
+	if err := xm.Apply(xfrmVPNs("st0", "st0.0", "st1.0")); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Only the non-colliding st1.0 may be created.
+	if ops.addCount != 1 {
+		t.Errorf("collision Apply issued %d LinkAdd, want exactly 1 "+
+			"(only the non-colliding st1.0)", ops.addCount)
+	}
+	survivor, _ := config.XFRMIfNameAndID("st1.0")
+	if _, ok := xm.xfrmis[survivor]; !ok {
+		t.Errorf("non-colliding xfrmi %q not tracked", survivor)
+	}
+	if len(xm.xfrmis) != 1 {
+		t.Errorf("tracked %d xfrmis, want exactly 1 (collision pair dropped)",
+			len(xm.xfrmis))
+	}
+	// Neither colliding device may exist in the kernel.
+	for _, n := range []string{nameBare, nameUnit} {
+		if _, ok := ops.links[n]; ok {
+			t.Errorf("colliding xfrmi %q was created in the kernel", n)
+		}
+		if _, ok := xm.xfrmis[n]; ok {
+			t.Errorf("colliding xfrmi %q was tracked", n)
+		}
+	}
+}
+
+// TestXfrmApplyCollisionDeletesPriorDevice covers the case where a
+// previously-created, correctly-tracked xfrmi later becomes one half of
+// an if_id collision (a subsequent commit adds the aliasing
+// bind-interface). The colliding pair must be removed entirely — the
+// formerly-good device is torn down rather than left sharing its if_id.
+func TestXfrmApplyCollisionDeletesPriorDevice(t *testing.T) {
+	ops := newFakeLinkOps()
+	xm := &xfrmManager{ops: ops}
+
+	// First commit: only st0.0 — created and tracked normally.
+	if err := xm.Apply(xfrmVPNs("st0.0")); err != nil {
+		t.Fatalf("first Apply: %v", err)
+	}
+	nameUnit, _ := config.XFRMIfNameAndID("st0.0")
+	if _, ok := xm.xfrmis[nameUnit]; !ok {
+		t.Fatalf("st0.0 not tracked after first Apply")
+	}
+
+	// Second commit introduces the aliasing bare st0 (same if_id 1).
+	if err := xm.Apply(xfrmVPNs("st0.0", "st0")); err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+
+	nameBare, _ := config.XFRMIfNameAndID("st0")
+	if len(xm.xfrmis) != 0 {
+		t.Errorf("collision left %d tracked xfrmis, want 0", len(xm.xfrmis))
+	}
+	if _, ok := ops.links[nameUnit]; ok {
+		t.Errorf("formerly-good xfrmi %q not torn down on collision", nameUnit)
+	}
+	if _, ok := ops.links[nameBare]; ok {
+		t.Errorf("colliding xfrmi %q was created", nameBare)
+	}
+}

--- a/pkg/routing/xfrm.go
+++ b/pkg/routing/xfrm.go
@@ -56,7 +56,27 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 	}
 
 	// Build the desired name -> if_id set from the VPN config.
+	//
+	// The XFRM interface id MUST be unique per distinct xfrmi device:
+	// the kernel keys SA<->xfrmi binding on if_id, so two devices that
+	// share an if_id make the SAs route to whichever device the kernel
+	// matched first — leaking traffic between VPNs that are supposed to
+	// be isolated (#2909). config.XFRMIfNameAndID can derive a colliding
+	// id for distinct bind-interfaces: a bare "st0" and an explicit
+	// "st0.0" both yield if_id 1 (unit defaults to 0 when no ".N" suffix
+	// is present) under DIFFERENT device names ("st0" vs "st0.0"). Detect
+	// such a collision here and refuse to create either colliding device
+	// — better to leave both tunnels' xfrmi absent (fail-closed, no
+	// transit) than to create two devices that silently cross-leak.
+	//
+	// The proper long-term fix is a commit-time rejection of an ambiguous
+	// secure-tunnel bind-interface in the config compiler / pkg/ipsec
+	// (tracked separately); this routing guard is the last line of
+	// defense so a config that slips through never programs colliding
+	// kernel state.
 	desired := make(map[string]uint32, len(vpns))
+	idToName := make(map[uint32]string, len(vpns))
+	collidingIDs := make(map[uint32]struct{})
 	for _, vpn := range vpns {
 		if vpn.BindInterface == "" {
 			continue
@@ -67,7 +87,27 @@ func (x *xfrmManager) Apply(vpns map[string]*config.IPsecVPN) error {
 				"vpn", vpn.Name, "bind-interface", vpn.BindInterface)
 			continue
 		}
+		if prev, dup := idToName[ifID]; dup && prev != ifName {
+			// A different device name already claimed this if_id. Mark
+			// the id as colliding; both names are dropped below.
+			collidingIDs[ifID] = struct{}{}
+			slog.Error("xfrmi if_id collision: distinct bind-interfaces "+
+				"derive the same XFRM if_id; refusing to create either "+
+				"(cross-VPN leak / EEXIST risk)",
+				"if_id", ifID, "name_a", prev, "name_b", ifName,
+				"vpn", vpn.Name)
+			continue
+		}
+		idToName[ifID] = ifName
 		desired[ifName] = ifID
+	}
+	// Drop every device whose if_id collided. The first claimant was
+	// recorded in desired before the collision was seen, so remove it too
+	// — neither colliding device may be programmed.
+	for id := range collidingIDs {
+		if name, ok := idToName[id]; ok {
+			delete(desired, name)
+		}
 	}
 
 	// Delete xfrmis no longer desired, plus those whose if_id changed


### PR DESCRIPTION
## Summary

`config.XFRMIfNameAndID` derives a colliding XFRM `if_id` for two
distinct secure-tunnel bind-interfaces: a bare `st0` and an explicit
`st0.0` both resolve to `if_id 1` (the unit defaults to 0 when there is
no `.N` suffix) under **different** device names (`st0` vs `st0.0`). The
kernel keys the SA↔xfrmi binding on `if_id`, so programming both devices
either `EEXIST`s on the second create or, worse, silently routes both
VPNs' SAs through one device — leaking traffic between VPNs that are
supposed to be isolated (the #2909 invariant violation).

Confirmed empirically on master: `st0 -> (st0, 1)`, `st0.0 -> (st0.0, 1)`
— distinct names, shared `if_id`.

## Fix (pkg/routing only)

`xfrmManager.Apply` now detects when two distinct desired device names
map to the same `if_id` and **refuses to create either** colliding
device (fail-closed: no transit for the ambiguous pair beats a cross-VPN
leak). If one half of the pair was already created by an earlier commit,
it is torn down on the commit that introduces the alias. Non-colliding
interfaces in the same commit are created normally.

The root derivation lives in `pkg/config/xfrmi.go`; the proper long-term
fix is a commit-time rejection of an ambiguous secure-tunnel
`bind-interface` in the config compiler / `pkg/ipsec` (separate lane,
#2885 — noted, not touched). This routing guard is the last line of
defense so a config that slips through never programs colliding kernel
state.

## Tests (FAIL-ON-REVERT)

- `TestXfrmApplyIfIDCollisionRefused` — `st0` + `st0.0` + `st1.0` →
  only the non-colliding `st1.0` is created; the colliding pair is
  dropped (0 of them tracked/in-kernel).
- `TestXfrmApplyCollisionDeletesPriorDevice` — a formerly-good `st0.0`
  is torn down when a later commit adds the aliasing bare `st0`.

Both go RED without the guard: each colliding name lands in `desired`
and is `LinkAdd`'d → 3 LinkAdd / two kernel devices sharing `if_id 1`.
Verified by reverting the guard in-worktree (3 LinkAdd observed) then
restoring.

## Gates

- `go build ./...` ✓
- `gofmt -l` clean ✓
- `go vet ./pkg/routing/...` ✓
- `go test ./pkg/routing/...` ✓

## Docs

- `pkg/routing/README.md` — new "`if_id` collision guard (#2909)"
  subsection + table-row note.
- `_Log.md` entry.

Closes #2909

🤖 Generated with [Claude Code](https://claude.com/claude-code)