### PR TITLE
Closes #2941, #2942, #2943

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17616,3 +17616,19 @@ top.
   go vet ./pkg/ipsec/..., go test ./pkg/ipsec/... PASS.
 - **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/matchfamily_linklocal_test.go,
   pkg/ipsec/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fix three FRR config-render bugs that break frr-reload (#2941,
+  #2942, #2943). #2941: a family-less IPv6 BGP neighbor with a policy was
+  activated under `address-family ipv4 unicast` — gate the ipv4 fall-through
+  on the peer address family and route a policied family-less IPv6 peer into
+  the ipv6 set. #2942: `isis bfd` was emitted AFTER the interface `exit` →
+  global scope → frr-reload reject; moved it inside the interface block before
+  `exit`, mirroring OSPFv3. #2943: `resolveRedistribute` now takes a `self`
+  arg and drops self-redistribution (bare token + policy-term `from protocol
+  <self>`), and `knownRedistProtocols` adds `ospf6`/`ripng`. Fail-on-revert
+  tests added for each; all proven RED without the fix. Gates: go build, gofmt
+  -l clean, go vet ./pkg/frr/... ./pkg/config/..., go test ./pkg/frr/...
+  ./pkg/config/... PASS.
+- **File(s)**: pkg/frr/policy_render.go, pkg/frr/frr_test.go, pkg/frr/README.md,
+  _Log.md

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -292,7 +292,38 @@ also carries operator content:
   source protocol, so skipping is the only correct outcome; the operator is
   warned to add a `from protocol <proto>` (or use a bare protocol token).
   This is the load-bearing invariant: a single unresolvable export can never
-  poison the entire managed-section reload.
+  poison the entire managed-section reload. `knownRedistProtocols` includes
+  `ospf6` and `ripng` (the FRR keywords for OSPFv3 / RIPng redistribution) so
+  a bare `export ospf6` / `export ripng` renders the valid line instead of
+  falling through to skip-and-warn and silently dropping IPv6 IGP
+  redistribution (#2943).
+- **`resolveRedistribute` excludes the SELF protocol (#2943).** It takes a
+  `self` argument naming the enclosing router protocol (`ospf` / `ospf6` /
+  `bgp` / `rip` / `isis`; `""` for callers with no enclosing protocol such as
+  unit tests). FRR rejects a protocol redistributing into itself
+  (`redistribute ospf` under `router ospf`), and one rejected line degrades
+  the whole managed reload (#1880/#2223). Both render paths drop the self
+  protocol: a bare self token returns `""` (skip+warn), and a policy-statement
+  term whose `from protocol` names the self protocol is filtered out while its
+  sibling non-self terms still render. Each `generateProtocols` call site
+  passes its own protocol as `self`.
+- **A policied family-less IPv6 BGP neighbor activates under ipv6 unicast,
+  not ipv4 (#2941).** The "default-activate a family-less policied neighbor
+  under ipv4 unicast" fall-through (#2473/#2490) is correct ONLY for an IPv4
+  peer address. An IPv6 peer (address contains `:`) with a global/per-neighbor
+  policy but no explicit `family inet6` also satisfies `!FamilyInet6`, so the
+  pre-#2941 code routed it into the ipv4 set and emitted `neighbor <v6>
+  activate` under `address-family ipv4 unicast` — FRR cannot resolve an IPv4
+  next-hop over an IPv6 session (no RFC 8950 extended-next-hop), so the
+  session drops prefixes. The ipv4 fall-through is now gated on the peer
+  address family, and a family-less-but-policied IPv6 peer is routed into the
+  ipv6 set so it activates (with its `route-map out`/`in`) under ipv6 unicast.
+- **IS-IS per-interface `isis bfd` is emitted INSIDE the interface block
+  (#2942).** `isis bfd` / `isis bfd profile <name>` are interface-scoped
+  commands; the IS-IS interface loop now writes them before the interface
+  block's `exit\n!\n`, mirroring the OSPFv3 ordering. Emitting them after
+  `exit` lands them in global config scope, which vtysh rejects and (one bad
+  line) fails the whole managed-section reload (#1880/#2223).
 - **Community-lists: `standard` vs `expanded` is per-DEFINITION (#2643).**
   An FRR `standard` community-list accepts ONLY literal community values
   (`ASN:VALUE`, or a well-known name such as `no-export` /

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -5533,3 +5533,56 @@ func TestResolveRedistribute_OSPF6RIPng(t *testing.T) {
 		t.Errorf("ripng must render `redistribute ripng`; got %q", got)
 	}
 }
+
+// TestGenerateProtocols_IPv6NeighborPolicyActivatesUnderV6 is the #2941
+// fail-on-revert guard: an IPv6 BGP peer address (2001:db8::1) with a
+// global export policy but NO explicit `family inet6` must be activated
+// under `address-family ipv6 unicast`, never under ipv4 unicast. Before the
+// fix the `!n.FamilyInet6` fall-through routed the policied family-less peer
+// into the ipv4 set, so FRR tried to resolve an IPv4 next-hop over the IPv6
+// session and dropped prefixes. The export name must be a DEFINED
+// policy-statement so the global default takes the route-map path (not the
+// redistribute path).
+func TestGenerateProtocols_IPv6NeighborPolicyActivatesUnderV6(t *testing.T) {
+	m := New()
+	po := &config.PolicyOptionsConfig{
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"adv-v6": {
+				Name:          "adv-v6",
+				Terms:         []*config.PolicyTerm{{Name: "t1", Action: "accept"}},
+				DefaultAction: "reject",
+			},
+		},
+	}
+	bgp := &config.BGPConfig{
+		LocalAS: 65000,
+		Export:  []string{"adv-v6"}, // global default export, a defined policy
+		Neighbors: []*config.BGPNeighbor{
+			// IPv6 peer, no family stanza, but reached by the global export.
+			{Address: "2001:db8::1", PeerAS: 65001},
+		},
+	}
+	got := m.generateProtocols(nil, nil, bgp, nil, nil, "", 1, po)
+
+	v6Idx := strings.Index(got, "address-family ipv6 unicast")
+	v4Idx := strings.Index(got, "address-family ipv4 unicast")
+	if v6Idx < 0 {
+		t.Fatalf("expected an ipv6 unicast address-family block; got:\n%s", got)
+	}
+	activate := "neighbor 2001:db8::1 activate"
+	aIdx := strings.Index(got, activate)
+	if aIdx < 0 {
+		t.Fatalf("IPv6 neighbor never activated; got:\n%s", got)
+	}
+	// The activate line must fall INSIDE the ipv6 block, not the ipv4 block.
+	if v4Idx >= 0 && v4Idx < aIdx && (v6Idx < 0 || v6Idx > aIdx) {
+		t.Errorf("IPv6 neighbor activated under ipv4 unicast (#2941 regression); got:\n%s", got)
+	}
+	if !(v6Idx < aIdx) {
+		t.Errorf("IPv6 neighbor activate must follow the ipv6 unicast header; got:\n%s", got)
+	}
+	// The route-map out must also land in the ipv6 block.
+	if !strings.Contains(got, "neighbor 2001:db8::1 route-map adv-v6 out") {
+		t.Errorf("expected `neighbor 2001:db8::1 route-map adv-v6 out`; got:\n%s", got)
+	}
+}

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -5586,3 +5586,39 @@ func TestGenerateProtocols_IPv6NeighborPolicyActivatesUnderV6(t *testing.T) {
 		t.Errorf("expected `neighbor 2001:db8::1 route-map adv-v6 out`; got:\n%s", got)
 	}
 }
+
+// TestGenerateProtocols_ISISBFDInsideInterfaceBlock is the #2942
+// fail-on-revert guard: `isis bfd` (interface-scoped) must be emitted
+// INSIDE the `interface <name>` block, BEFORE its `exit`. Emitting it after
+// `exit` lands it in global scope, which vtysh rejects and one rejected
+// line fails the whole managed-section reload (#1880/#2223).
+func TestGenerateProtocols_ISISBFDInsideInterfaceBlock(t *testing.T) {
+	m := New()
+	isis := &config.ISISConfig{
+		NET:   "49.0001.0100.0000.0001.00",
+		Level: "level-2",
+		Interfaces: []*config.ISISInterface{
+			{Name: "ge-0-0-1", BFD: true},
+		},
+	}
+	got := m.generateProtocols(nil, nil, nil, nil, isis, "", 1, nil)
+
+	ifaceIdx := strings.Index(got, "interface ge-0-0-1")
+	if ifaceIdx < 0 {
+		t.Fatalf("expected an `interface ge-0-0-1` block; got:\n%s", got)
+	}
+	bfdIdx := strings.Index(got[ifaceIdx:], " isis bfd\n")
+	if bfdIdx < 0 {
+		t.Fatalf("expected an `isis bfd` line for the interface; got:\n%s", got)
+	}
+	bfdIdx += ifaceIdx
+	// The interface block's `exit` must come AFTER the isis bfd line.
+	exitIdx := strings.Index(got[ifaceIdx:], "exit\n")
+	if exitIdx < 0 {
+		t.Fatalf("expected an `exit` closing the interface block; got:\n%s", got)
+	}
+	exitIdx += ifaceIdx
+	if !(bfdIdx < exitIdx) {
+		t.Errorf("`isis bfd` emitted AFTER the interface `exit` (#2942 regression) — lands in global scope; got:\n%s", got)
+	}
+}

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -2637,7 +2637,7 @@ func TestGenerateProtocols_BGPLogNeighborChanges(t *testing.T) {
 func TestResolveRedistribute_BareProtocol(t *testing.T) {
 	m := New()
 	for _, proto := range []string{"connected", "static", "ospf", "bgp", "rip", "isis", "kernel"} {
-		got := m.resolveRedistribute(proto, nil)
+		got := m.resolveRedistribute(proto, nil, "")
 		want := " redistribute " + proto + "\n"
 		if got != want {
 			t.Errorf("resolveRedistribute(%q, nil) = %q, want %q", proto, got, want)
@@ -2660,7 +2660,7 @@ func TestResolveRedistribute_PolicyStatement(t *testing.T) {
 			},
 		},
 	}
-	got := m.resolveRedistribute("export-connected", po)
+	got := m.resolveRedistribute("export-connected", po, "")
 	want := " redistribute connected route-map export-connected\n"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -2680,7 +2680,7 @@ func TestResolveRedistribute_MultiProtocol(t *testing.T) {
 			},
 		},
 	}
-	got := m.resolveRedistribute("export-all", po)
+	got := m.resolveRedistribute("export-all", po, "")
 	// Should have both protocols, sorted alphabetically
 	if !strings.Contains(got, "redistribute connected route-map export-all\n") {
 		t.Errorf("missing connected route-map in:\n%s", got)
@@ -2903,7 +2903,7 @@ func TestResolveRedistribute_ProtocolLessPolicy(t *testing.T) {
 			},
 		},
 	}
-	got := m.resolveRedistribute("export-comm", po)
+	got := m.resolveRedistribute("export-comm", po, "")
 	if got != "" {
 		t.Errorf("protocol-less policy must yield no redistribute line, got %q", got)
 	}
@@ -2922,7 +2922,7 @@ func TestResolveRedistribute_ProtocolLessPolicy(t *testing.T) {
 func TestResolveRedistribute_UnknownToken(t *testing.T) {
 	m := New()
 	// nil policy-options: the name resolves to nothing.
-	if got := m.resolveRedistribute("no-such-policy", nil); got != "" {
+	if got := m.resolveRedistribute("no-such-policy", nil, ""); got != "" {
 		t.Errorf("unknown token must yield no redistribute line, got %q", got)
 	}
 	// Non-nil policy-options that simply does not define the name.
@@ -2931,7 +2931,7 @@ func TestResolveRedistribute_UnknownToken(t *testing.T) {
 			"other": {Name: "other"},
 		},
 	}
-	if got := m.resolveRedistribute("typo-name", po); got != "" {
+	if got := m.resolveRedistribute("typo-name", po, ""); got != "" {
 		t.Errorf("undefined policy name must yield no redistribute line, got %q", got)
 	}
 }
@@ -5480,4 +5480,56 @@ func TestGeneratePolicyOptionsLocalPreferenceZero(t *testing.T) {
 			t.Errorf("local-preference 200 must still render `set local-preference 200`; got:\n%s", got)
 		}
 	})
+}
+
+// TestResolveRedistribute_SelfExclusion is the #2943 fail-on-revert guard
+// for self-redistribution: a protocol must never redistribute its own
+// routes (FRR rejects `redistribute ospf` under `router ospf`, failing the
+// whole managed reload). Both the bare-token path and the policy-statement
+// `from protocol <self>` path must drop the self protocol.
+func TestResolveRedistribute_SelfExclusion(t *testing.T) {
+	m := New()
+	// Bare-token self redistribute is dropped.
+	if got := m.resolveRedistribute("ospf", nil, "ospf"); got != "" {
+		t.Errorf("self-redistribute (bare token) must be dropped; got %q", got)
+	}
+	// A different protocol still renders.
+	if got := m.resolveRedistribute("static", nil, "ospf"); got != " redistribute static\n" {
+		t.Errorf("non-self protocol must still redistribute; got %q", got)
+	}
+	// Policy-statement path: a term `from protocol ospf` under router ospf
+	// is self-redistribution and must be excluded, while a sibling
+	// `from protocol static` term still renders.
+	po := &config.PolicyOptionsConfig{
+		PolicyStatements: map[string]*config.PolicyStatement{
+			"leak": {
+				Name: "leak",
+				Terms: []*config.PolicyTerm{
+					{Name: "self", FromProtocols: []string{"ospf"}, Action: "accept"},
+					{Name: "other", FromProtocols: []string{"static"}, Action: "accept"},
+				},
+			},
+		},
+	}
+	got := m.resolveRedistribute("leak", po, "ospf")
+	if strings.Contains(got, "redistribute ospf route-map leak") {
+		t.Errorf("self-redistribute via policy term must be excluded (#2943); got %q", got)
+	}
+	if !strings.Contains(got, "redistribute static route-map leak") {
+		t.Errorf("non-self policy term must still render; got %q", got)
+	}
+}
+
+// TestResolveRedistribute_OSPF6RIPng is the #2943 fail-on-revert guard for
+// the missing ospf6 / ripng keywords: a bare `export ospf6` / `export
+// ripng` must render the valid FRR redistribute line, not fall through to
+// the skip-and-warn path that silently drops IPv6 IGP redistribution.
+func TestResolveRedistribute_OSPF6RIPng(t *testing.T) {
+	m := New()
+	if got := m.resolveRedistribute("ospf6", nil, ""); got != " redistribute ospf6\n" {
+		t.Errorf("ospf6 must render `redistribute ospf6`; got %q", got)
+	}
+	if got := m.resolveRedistribute("ripng", nil, ""); got != " redistribute ripng\n" {
+		t.Errorf("ripng must render `redistribute ripng`; got %q", got)
+	}
 }

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -849,7 +849,13 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 					fmt.Fprintf(&b, " isis password clear %s\n", sanitizeFRRValue(iface.AuthKey.Reveal()))
 				}
 			}
-			b.WriteString("exit\n!\n")
+			// `isis bfd` / `isis bfd profile <name>` are interface-scoped
+			// commands and MUST be emitted INSIDE the interface block,
+			// before `exit`. Emitting them after `exit` lands them at
+			// global config scope, which vtysh rejects — and one rejected
+			// line fails the WHOLE managed-section reload (#1880/#2223),
+			// breaking every IS-IS interface with BFD enabled. This mirrors
+			// the OSPFv3 per-interface BFD ordering above (#2942).
 			if iface.BFD {
 				if iface.BFDInterval > 0 || iface.BFDMultiplier > 0 {
 					profile := bfdProfileName(iface.BFDInterval, iface.BFDMultiplier)
@@ -859,6 +865,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 					b.WriteString(" isis bfd\n")
 				}
 			}
+			b.WriteString("exit\n!\n")
 		}
 	}
 

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -56,9 +56,12 @@ func sanitizeFRRValue(s string) string {
 }
 
 // knownRedistProtocols are the FRR redistribute protocol keywords.
+// ospf6 / ripng are the FRR keywords for OSPFv3 / RIPng redistribution;
+// without them a bare `export ospf6` / `export ripng` falls through to the
+// skip-and-warn path and IPv6 IGP redistribution cannot be expressed (#2943).
 var knownRedistProtocols = map[string]bool{
-	"connected": true, "static": true, "ospf": true, "bgp": true,
-	"rip": true, "isis": true, "kernel": true,
+	"connected": true, "static": true, "ospf": true, "ospf6": true,
+	"bgp": true, "rip": true, "ripng": true, "isis": true, "kernel": true,
 }
 
 // resolveRedistribute converts a Junos export value into FRR redistribute commands.
@@ -92,7 +95,7 @@ var knownRedistProtocols = map[string]bool{
 //     load / peer-sync path, opts.lenientRoutingExportRef in pkg/config).
 //     The strict validator REJECTS this case at commit; only the lenient
 //     load/peer-sync path can reach the renderer with such a name.
-func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsConfig) string {
+func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsConfig, self string) string {
 	// Junos spells directly-connected routes "direct"; FRR's redistribute
 	// keyword is "connected". A bare `export direct` must render
 	// `redistribute connected`, not the FRR-invalid `redistribute direct`
@@ -105,6 +108,16 @@ func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsCon
 		export = "connected"
 	}
 	if knownRedistProtocols[export] {
+		// A protocol can never redistribute itself: FRR rejects
+		// `redistribute ospf` under `router ospf` (etc.), and ONE
+		// rejected line degrades the WHOLE managed reload (#1880/#2223).
+		// Drop the self-redistribute rather than poison the section
+		// (#2943). self is "" for callers with no enclosing protocol.
+		if self != "" && export == self {
+			slog.Warn("FRR redistribute export skipped: protocol cannot redistribute itself",
+				"protocol", self)
+			return ""
+		}
 		return fmt.Sprintf(" redistribute %s\n", export)
 	}
 
@@ -115,6 +128,13 @@ func (m *Manager) resolveRedistribute(export string, po *config.PolicyOptionsCon
 				for _, proto := range term.FromProtocols {
 					if proto == "direct" {
 						proto = "connected"
+					}
+					// Skip a policy term that matches the enclosing
+					// protocol's own routes — `redistribute ospf
+					// route-map X` under `router ospf` is self-
+					// redistribution and FRR rejects it (#2943).
+					if self != "" && proto == self {
+						continue
 					}
 					protocols[proto] = true
 				}
@@ -415,7 +435,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			fmt.Fprintf(&b, " maximum-paths %d\n", ecmpMaxPaths)
 		}
 		for _, export := range ospf.Export {
-			b.WriteString(m.resolveRedistribute(export, policyOptions))
+			b.WriteString(m.resolveRedistribute(export, policyOptions, "ospf"))
 		}
 		b.WriteString("exit\n!\n")
 		// OSPF interface settings + per-interface area activation. The
@@ -470,7 +490,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			}
 		}
 		for _, export := range ospfv3.Export {
-			b.WriteString(m.resolveRedistribute(export, policyOptions))
+			b.WriteString(m.resolveRedistribute(export, policyOptions, "ospf6"))
 		}
 		b.WriteString("exit\n!\n")
 		for _, area := range ospfv3.Areas {
@@ -609,8 +629,8 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 				// validator on a lenient load/HA-sync path) → genuine
 				// redistribute. resolveRedistribute normalizes direct→
 				// connected and refuses to emit an invalid bare-name
-				// line (#2223).
-				b.WriteString(m.resolveRedistribute(e, policyOptions))
+				// line (#2223), and drops a self-redistribute (#2943).
+				b.WriteString(m.resolveRedistribute(e, policyOptions, "bgp"))
 			}
 		}
 
@@ -745,7 +765,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			fmt.Fprintf(&b, " passive-interface %s\n", iface)
 		}
 		for _, r := range rip.Redistribute {
-			b.WriteString(m.resolveRedistribute(r, policyOptions))
+			b.WriteString(m.resolveRedistribute(r, policyOptions, "rip"))
 		}
 		b.WriteString("exit\n!\n")
 		// RIP per-interface authentication
@@ -781,7 +801,7 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			b.WriteString(" is-type level-1-2\n")
 		}
 		for _, export := range isis.Export {
-			b.WriteString(m.resolveRedistribute(export, policyOptions))
+			b.WriteString(m.resolveRedistribute(export, policyOptions, "isis"))
 		}
 		if isis.WideMetricsOnly {
 			b.WriteString(" metric-style wide\n")

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -671,10 +671,24 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			// neighbor import/export inclusion is #2490 (symmetric to the
 			// global-default inclusion #2473 added).
 			hasOwnPolicy := bgpEffectiveExport(n, "") != "" || bgpEffectiveImport(n, "") != ""
-			if n.FamilyInet || ((globalExport != "" || globalImport != "" || hasOwnPolicy) && !n.FamilyInet6) {
+			// The "default-activate a family-less policied neighbor under
+			// ipv4 unicast" fall-through (#2473/#2490) is correct ONLY for
+			// an IPv4 peer address. An IPv6 peer (e.g. 2001:db8::1) with a
+			// policy but no explicit `family inet6` also satisfies
+			// !n.FamilyInet6, so the pre-#2941 code activated it under
+			// `address-family ipv4 unicast` — the WRONG family. FRR cannot
+			// resolve an IPv4 next-hop over an IPv6 peer (no RFC 8950
+			// extended-next-hop) so the session drops prefixes / fails, and
+			// the neighbor never participates in ipv6 unicast. Gate the
+			// ipv4 fall-through on the peer address family, and route an
+			// IPv6-address family-less-but-policied neighbor into the ipv6
+			// set instead so it activates under ipv6 unicast (#2941).
+			isIPv6Peer := strings.Contains(n.Address, ":")
+			policyDefault := globalExport != "" || globalImport != "" || hasOwnPolicy
+			if (n.FamilyInet || (policyDefault && !n.FamilyInet6)) && !isIPv6Peer {
 				inet4Neighbors = append(inet4Neighbors, n)
 			}
-			if n.FamilyInet6 {
+			if n.FamilyInet6 || (policyDefault && !n.FamilyInet && isIPv6Peer) {
 				inet6Neighbors = append(inet6Neighbors, n)
 			}
 		}


### PR DESCRIPTION
Three FRR config-render bugs that each break `frr-reload` (a single rejected
line in the xpf-managed section degrades the WHOLE reload — frr-reload.py exits
non-zero on any CMD_WARNING_CONFIG_FAILED, dropping every managed
route/redistribute, #1880/#2223). All three live in pkg/frr config rendering,
so they ship as one PR (three logical commits) to avoid N-way conflicts.

## #2941 — IPv6 BGP neighbor with a policy but no `family inet6` activated under ipv4 unicast
The "default-activate a family-less policied neighbor under ipv4 unicast"
fall-through (#2473/#2490) is correct ONLY for an IPv4 peer. An IPv6 peer (e.g.
`2001:db8::1`) with a global/per-neighbor policy and no explicit `family inet6`
also satisfied `!FamilyInet6`, so it was activated under `address-family ipv4
unicast` — FRR can't resolve an IPv4 next-hop over the IPv6 session (no RFC 8950
extended-next-hop) and drops prefixes. Fix gates the ipv4 fall-through on the
peer address family and routes a family-less-but-policied IPv6 peer into the
ipv6 set (activates, with its route-map out/in, under ipv6 unicast).

## #2942 — IS-IS `isis bfd` emitted AFTER the interface `exit` → global scope
`isis bfd` / `isis bfd profile <name>` are interface-scoped. The IS-IS loop
wrote the interface block's `exit\n!\n` BEFORE the BFD lines, landing them at
global scope where vtysh rejects them. Fix moves `exit` to the end of the loop
body, mirroring the OSPFv3 per-interface BFD ordering.

## #2943 — redistribute self-redistribution + missing ospf6/ripng keywords
`resolveRedistribute` could redistribute a protocol into itself (FRR rejects
`redistribute ospf` under `router ospf`), and `knownRedistProtocols` lacked
`ospf6`/`ripng` so a bare `export ospf6`/`export ripng` was silently dropped.
Fix threads a `self` argument so neither render path (bare token nor
policy-statement `from protocol <self>`) emits the self protocol, and adds
`ospf6`/`ripng` to the known set.

## Fail-on-revert tests (each proven RED without its fix)
- **#2941** `TestGenerateProtocols_IPv6NeighborPolicyActivatesUnderV6` — asserts
  a global-export IPv6 peer with no family stanza activates under the ipv6
  unicast block. RED: peer activated under ipv4.
- **#2942** `TestGenerateProtocols_ISISBFDInsideInterfaceBlock` — asserts
  `isis bfd` appears BEFORE the interface `exit`. RED: bfd line followed exit.
- **#2943** `TestResolveRedistribute_SelfExclusion` (bare token + policy-term
  paths) and `TestResolveRedistribute_OSPF6RIPng`. RED: `redistribute ospf`
  reappeared; `ospf6`/`ripng` returned "".

## Gates (foreground)
`go build ./...`, `gofmt -l` clean, `go vet ./pkg/frr/... ./pkg/config/...`,
`go test ./pkg/frr/... ./pkg/config/...` — all PASS.

Docs: pkg/frr/README.md + _Log.md updated.

Closes #2941
Closes #2942
Closes #2943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi