### PR TITLE
#2919: don't publish a failed initial neighbor dump as generation 1

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17650,3 +17650,22 @@ top.
   go vet ./pkg/ipsec/..., go test ./pkg/ipsec/... PASS.
 - **File(s)**: pkg/ipsec/policy.go, pkg/ipsec/matchfamily_linklocal_test.go,
   pkg/ipsec/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2919 — neighbor monitor: do NOT publish a FAILED initial dump
+  as generation 1; retry the full v4/v6 dump on bounded backoff. Before this,
+  both the Ok and Err arms of `initial_neighbor_dump` stored `neighbor_generation
+  = 1`, so a timed-out / WouldBlock / NLMSG_ERROR dump looked like a successful
+  empty baseline and was never retried, stranding quiet neighbors (first-packet
+  blackhole after startup / HA failover). Fix: pure `dump_establishes_baseline`
+  predicate gates `store(1)` (true ONLY on Ok); `neigh_monitor_thread` retries
+  the full dump on `INITIAL_DUMP_RETRY_BACKOFF_MS` (200/500/1000/2000/5000 ms,
+  `stop`-aware), publishing 1 only after a complete pass; if all retries fail the
+  generation stays 0 ("baseline incomplete") and the steady-state / ENOBUFS
+  re-dump paths recover. #2918 seq-0 absorb in process_dump_batch preserved.
+  FAIL-ON-REVERT: dump_batch_tests::failed_initial_dump_does_not_establish_
+  generation1_baseline goes RED (verified via copy-aside revert of the predicate
+  to always-true). Gates FG: cargo build --release -p xpf-userspace-dp OK;
+  cargo test neighbor PASS (123 passed).
+- **File(s)**: userspace-dp/src/afxdp/neighbor.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -88,6 +88,29 @@ sync.
     the #2368 NA fail-closed discipline. Only opcode-2 replies are ever
     learned; ARP requests (opcode 1) classify `OtherArp` and never write
     the cache.
+- `neighbor.rs` — netlink neighbor monitor (`neigh_monitor_thread`),
+  startup dump (`initial_neighbor_dump` / `process_dump_batch`), the
+  on-demand resolver glue, and `worker::pin_current_thread`. The monitor
+  publishes `neighbor_generation` — the epoch counter the on-demand
+  resolver snapshots for its guard, and whose value `1` is the
+  **"initial baseline acquired" sentinel**.
+  - **Generation-1 baseline invariant (`#2919`):** `neighbor_generation`
+    is advanced to `1` ONLY when a full v4+v6 startup dump COMPLETES
+    (`initial_neighbor_dump` → `Ok`). A failed dump (timeout /
+    `WouldBlock` / `NLMSG_ERROR`) acquired no baseline and is NOT
+    published as `1`; the monitor retries the full dump on a bounded
+    backoff (`INITIAL_DUMP_RETRY_BACKOFF_MS`, `stop`-aware) until one
+    pass succeeds. If every retry fails the generation stays `0`
+    ("baseline incomplete"); the steady-state per-batch `fetch_add` and
+    the ENOBUFS re-dump path then recover the population from `0` rather
+    than from a bogus `1`. The publish/skip decision is the pure
+    `dump_establishes_baseline` predicate (unit-tested fail-on-revert).
+    The pre-#2919 bug stored `1` on BOTH the `Ok` and `Err` arms with no
+    retry, so a failed initial dump looked like a completed empty
+    baseline and quiet neighbors were stranded until an unrelated later
+    event — an avoidable first-packet blackhole after startup / HA
+    failover. The seq-0 absorb in `process_dump_batch` (`#2918`) is the
+    sibling completeness fix on the success path and is preserved.
 - `poll_stages.rs` — sibling of `worker/`, not inside it. Holds the
   per-packet pipeline stages extracted in #946 Phase 1. The screen and
   SYN-cookie stages decide the L3 offset (14 vs 18) on tag PRESENCE

--- a/userspace-dp/src/afxdp/neighbor.rs
+++ b/userspace-dp/src/afxdp/neighbor.rs
@@ -651,6 +651,39 @@ pub(super) fn initial_neighbor_dump(
     Ok(if changed { 1 } else { 0 })
 }
 
+/// Bounded backoff schedule (milliseconds) for retrying a FAILED initial
+/// neighbor dump (#2919). The dump runs once at monitor startup and
+/// publishes `neighbor_generation = 1` as the "baseline acquired"
+/// sentinel the resolver epoch logic relies on. A dump that returns
+/// `Err` (timeout / `WouldBlock` / `NLMSG_ERROR`) acquired NO baseline,
+/// so publishing generation 1 anyway would falsely advertise a complete
+/// neighbor population — quiet existing neighbors missed by the failed
+/// dump would never be loaded until an unrelated later event, an
+/// avoidable first-packet blackhole after helper startup or HA failover.
+///
+/// Instead we retry the full v4/v6 dump on this schedule until one full
+/// pass completes, and publish generation 1 ONLY then. The `stop` flag
+/// is honored between attempts so shutdown is not delayed. If every
+/// attempt fails the generation stays 0 (an explicit "baseline
+/// incomplete" state); the steady-state loop's per-batch `fetch_add` and
+/// the ENOBUFS re-dump path then recover the population from 0 rather
+/// than from a bogus 1.
+const INITIAL_DUMP_RETRY_BACKOFF_MS: &[u64] = &[200, 500, 1000, 2000, 5000];
+
+/// Decide whether an `initial_neighbor_dump` result may be published as
+/// the `neighbor_generation = 1` baseline (#2919).
+///
+/// Only `Ok` — a fully completed v4+v6 dump — establishes the baseline.
+/// An `Err` (timeout, `WouldBlock`, or netlink `NLMSG_ERROR`) means no
+/// complete baseline was acquired and MUST NOT be published as
+/// generation 1; the caller retries instead. Kept as a tiny pure
+/// predicate so the publish/skip contract is unit-testable without a
+/// live netlink socket (a regression that re-publishes the failure as
+/// generation 1 is caught here).
+pub(super) fn dump_establishes_baseline(result: &io::Result<u64>) -> bool {
+    result.is_ok()
+}
+
 /// Requested receive-buffer size for the neighbor-monitor netlink socket
 /// (#1658). Under an RTM_NEWNEIGH/DELNEIGH multicast burst (HA failover,
 /// large neighbor churn) the default rcvbuf can overflow and the kernel
@@ -807,15 +840,59 @@ pub(super) fn neigh_monitor_thread(
             core::mem::size_of::<libc::timeval>() as libc::socklen_t,
         );
     }
-    match initial_neighbor_dump(fd, &dynamic_neighbors) {
-        Ok(_) => {
+    // #2919: publish generation 1 ONLY once a full v4+v6 dump completes.
+    // A failed dump (timeout / WouldBlock / NLMSG_ERROR) acquired no
+    // baseline; publishing it as generation 1 would falsely advertise a
+    // complete neighbor population and there was previously no retry,
+    // stranding quiet neighbors until an unrelated later event. Retry the
+    // full dump on a bounded backoff, honoring `stop` between attempts;
+    // if every attempt fails the generation stays 0 ("baseline
+    // incomplete") and the steady-state / ENOBUFS re-dump paths recover.
+    let mut attempt = 0usize;
+    loop {
+        let result = initial_neighbor_dump(fd, &dynamic_neighbors);
+        if dump_establishes_baseline(&result) {
             neighbor_generation.store(1, Ordering::Relaxed);
-            eprintln!("neigh_monitor: initial kernel neighbor dump complete");
+            if attempt == 0 {
+                eprintln!("neigh_monitor: initial kernel neighbor dump complete");
+            } else {
+                eprintln!(
+                    "neigh_monitor: initial kernel neighbor dump complete \
+                     (after {attempt} retr{})",
+                    if attempt == 1 { "y" } else { "ies" }
+                );
+            }
+            break;
         }
-        Err(err) => {
-            neighbor_generation.store(1, Ordering::Relaxed);
-            eprintln!("neigh_monitor: initial dump failed: {err}");
+        let err = result.expect_err("dump_establishes_baseline rejected an Ok result");
+        if attempt >= INITIAL_DUMP_RETRY_BACKOFF_MS.len() {
+            eprintln!(
+                "neigh_monitor: initial dump failed after {attempt} retries \
+                 ({err}); neighbor baseline incomplete (generation stays 0), \
+                 relying on steady-state events / ENOBUFS re-dump to recover"
+            );
+            break;
         }
+        let backoff_ms = INITIAL_DUMP_RETRY_BACKOFF_MS[attempt];
+        eprintln!(
+            "neigh_monitor: initial dump failed ({err}); retrying in \
+             {backoff_ms}ms (attempt {})",
+            attempt + 1
+        );
+        // Sleep in short slices so a stop request aborts the backoff
+        // promptly instead of blocking shutdown for up to 5s.
+        let mut slept = 0u64;
+        while slept < backoff_ms {
+            if stop.load(Ordering::Relaxed) {
+                eprintln!("neigh_monitor: stop requested during initial-dump backoff");
+                unsafe { libc::close(fd) };
+                return;
+            }
+            let slice = (backoff_ms - slept).min(100);
+            std::thread::sleep(std::time::Duration::from_millis(slice));
+            slept += slice;
+        }
+        attempt += 1;
     }
     eprintln!("neigh_monitor: listening for kernel neighbor events");
     let mut buf = vec![0u8; 8192];
@@ -1217,6 +1294,51 @@ mod dump_batch_tests {
             },
             "only the matching-seq NLMSG_DONE ends the dump",
         );
+    }
+
+    /// #2919 fail-on-revert: a FAILED initial neighbor dump must NOT be
+    /// published as the `neighbor_generation = 1` baseline.
+    ///
+    /// `dump_establishes_baseline` is the predicate the monitor uses to
+    /// gate the `store(1)` publish: it returns `true` ONLY for `Ok`
+    /// (a fully completed v4+v6 dump). The pre-#2919 bug stored
+    /// generation 1 on BOTH the Ok and Err arms, so a timeout /
+    /// WouldBlock / NLMSG_ERROR dump looked like a successful empty
+    /// baseline and was never retried.
+    ///
+    /// Reverting the predicate to "always publish" (e.g. `true` for both
+    /// arms, mirroring the old `Err => store(1)`) makes the Err
+    /// assertion below FAIL. This is the load-bearing invariant:
+    /// generation 1 means a complete baseline was acquired.
+    #[test]
+    fn failed_initial_dump_does_not_establish_generation1_baseline() {
+        // A completed dump (Ok) — empty or populated — establishes the
+        // baseline and may publish generation 1.
+        let ok_empty: io::Result<u64> = Ok(0);
+        let ok_changed: io::Result<u64> = Ok(1);
+        assert!(
+            dump_establishes_baseline(&ok_empty),
+            "a completed (empty) dump establishes the baseline",
+        );
+        assert!(
+            dump_establishes_baseline(&ok_changed),
+            "a completed (populated) dump establishes the baseline",
+        );
+
+        // Every failure mode that initial_neighbor_dump can return —
+        // timeout, WouldBlock, and an NLMSG_ERROR-derived io::Error —
+        // acquired NO baseline and MUST NOT be published as generation 1.
+        for err in [
+            io::Error::from(io::ErrorKind::TimedOut),
+            io::Error::from(io::ErrorKind::WouldBlock),
+            io::Error::other("netlink neighbor dump failed"),
+        ] {
+            let failed: io::Result<u64> = Err(err);
+            assert!(
+                !dump_establishes_baseline(&failed),
+                "a failed dump must NOT publish generation 1 (it acquired no baseline)",
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem (#2919, review-054 054-05)

The userspace-dp neighbor monitor publishes `neighbor_generation = 1` as
the "initial baseline acquired" sentinel the on-demand resolver's epoch
logic relies on. `neigh_monitor_thread` stored `1` on **both** the `Ok`
and `Err` arms of `initial_neighbor_dump`, and there was **no retry**:

```rust
match initial_neighbor_dump(fd, &dynamic_neighbors) {
    Ok(_)    => { neighbor_generation.store(1, Ordering::Relaxed); ... }
    Err(err) => { neighbor_generation.store(1, Ordering::Relaxed); ... } // <- baseline never acquired
}
```

A dump that returns `Err` (timeout / `WouldBlock` / netlink
`NLMSG_ERROR`) acquired **no** baseline yet was published as a completed
generation 1 — indistinguishable from a successful empty dump. Quiet
existing neighbors missed by the failed dump were never loaded until an
unrelated later multicast event or a packet-triggered resolver probe — an
avoidable first-packet blackhole after helper startup or HA failover.

## Fix (scope: userspace-dp `neighbor.rs` only)

Advance the published generation **only** on a fully completed v4+v6 dump.

- New pure predicate `dump_establishes_baseline(&io::Result<u64>) -> bool`
  (true only for `Ok`) gates the `store(1)` publish — kept tiny so the
  contract is unit-testable without a live netlink socket.
- On `Err`, retry the full dump on a bounded backoff
  `INITIAL_DUMP_RETRY_BACKOFF_MS` = 200/500/1000/2000/5000 ms,
  honoring the `stop` flag in short slices (no shutdown delay), publishing
  generation 1 only once a pass completes.
- If every retry fails, generation stays `0` ("baseline incomplete"); the
  steady-state per-batch `fetch_add` and the ENOBUFS re-dump path recover
  the population from `0` rather than from a bogus `1`.

The #2918 seq-0 absorb in `process_dump_batch` is on the success path and
is **untouched** (this builds on it).

## Fail-on-revert test

`dump_batch_tests::failed_initial_dump_does_not_establish_generation1_baseline`
asserts a completed dump (`Ok`) establishes the baseline and that every
failure mode (`TimedOut`, `WouldBlock`, `NLMSG_ERROR`-derived
`io::Error`) does **not**. Reverting the predicate to always-true makes
it **RED** (verified via copy-aside revert):

```
test ...::failed_initial_dump_does_not_establish_generation1_baseline ... FAILED
panicked at src/afxdp/neighbor.rs:1337:13
test result: FAILED. 0 passed; 1 failed
```

## Gates (foreground)

- `cargo build --release -p xpf-userspace-dp` — OK
- `cargo test neighbor` — **123 passed; 0 failed**

## Docs

- `userspace-dp/src/afxdp/README.md` — new `neighbor.rs` entry records the
  generation-1 baseline invariant + the retry behavior.
- `_Log.md` — updated.

Closes #2919

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi