### PR TITLE
config/frr: reject BGP neighbor with missing peer-as at commit-time (Closes #2963)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -17843,3 +17843,30 @@ top.
   go test ./pkg/api/... all PASS.
 - **File(s)**: pkg/api/nat.go, pkg/api/nat_stats_test.go,
   pkg/api/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2963 — reject at COMMIT-TIME a BGP neighbor whose peer-as
+  (remote-as) is missing/0. peer-as is optional in the parser/compiler, so
+  a neighbor authored without one (and without an inherited group peer-as)
+  kept a zero BGPNeighbor.PeerAS and the FRR renderer emitted
+  `neighbor <addr> remote-as 0`. AS 0 is reserved (RFC 7607); FRR/vtysh
+  rejects it, failing the whole frr-reload — a commit-accepted config the
+  routing daemon cannot load. Added validateBGPNeighborPeerASStrict
+  (pkg/config/compiler_validate_strict.go) hard-rejecting PeerAS==0 at
+  commit/commit-check (global + per-routing-instance scopes, naming the
+  group + neighbor) wired into compileConfigWithOpts with a new
+  lenientBGPNeighborPeerAS option (warn-and-boot on load/HA-sync per #1960).
+  Defense-in-depth: generateProtocols (pkg/frr/policy_render.go) now SKIPS a
+  neighbor with PeerAS==0 so AS 0 never reaches frr.conf on the lenient
+  path. Did NOT touch local-AS / router bgp handling (the rejected false
+  half of agy-review-056 056-05 — guarded by LocalAS>0). FAIL-ON-REVERT:
+  config gate test RED without the strict check (compiles + would render
+  remote-as 0); frr render-guard test RED without the skip (emits
+  remote-as 0). Gates: go build ./..., gofmt -l clean (my files),
+  go vet ./pkg/config/... ./pkg/frr/..., go test ./pkg/config/...
+  ./pkg/frr/... all PASS.
+- **File(s)**: pkg/config/compiler.go,
+  pkg/config/compiler_validate_strict.go,
+  pkg/config/bgp_neighbor_peeras_2963_test.go,
+  pkg/frr/policy_render.go, pkg/frr/bgp_remote_as_2963_test.go,
+  pkg/frr/README.md, _Log.md

--- a/pkg/config/bgp_neighbor_peeras_2963_test.go
+++ b/pkg/config/bgp_neighbor_peeras_2963_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2963: a BGP neighbor whose peer-as (remote-as) is missing/0 must be
+// rejected at commit / commit-check. peer-as is optional in the
+// parser/compiler, so a neighbor authored without one keeps a zero PeerAS and
+// the FRR renderer (pkg/frr/policy_render.go) previously emitted
+// `neighbor <addr> remote-as 0`. AS 0 is reserved (RFC 7607) and FRR/vtysh
+// rejects it, failing the whole frr-reload — a commit-accepted config the
+// routing daemon cannot load.
+//
+// These tests drive the real CompileConfig (strict) / CompileConfigLenient
+// (tolerant) paths via buildTreeFromSet (the flat-set helper shared with
+// routing_export_ref_test.go).
+
+// FAIL-ON-REVERT anchor: strict commit rejects a neighbor with no peer-as.
+// Without validateBGPNeighborPeerASStrict (or its call site) this config
+// compiles clean and renders `remote-as 0`, so removing the fix turns this
+// test RED.
+func TestBGPNeighborMissingPeerASRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group EXT neighbor 10.0.2.1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a BGP neighbor with no peer-as; expected rejection (would render remote-as 0)")
+	}
+	for _, want := range []string{"bgp", "neighbor", "10.0.2.1", "peer-as"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// The error names the offending group + neighbor so the operator can locate it.
+func TestBGPNeighborMissingPeerASErrorNamesGroup(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group UPSTREAM neighbor 192.0.2.5",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a BGP neighbor with no peer-as; expected rejection")
+	}
+	for _, want := range []string{"group UPSTREAM", "192.0.2.5"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// A neighbor inheriting a group-level peer-as is accepted (peer-as is resolved
+// before this gate runs on the fully-compiled *Config).
+func TestBGPNeighborGroupPeerASInherited(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group EXT peer-as 65002",
+		"set protocols bgp group EXT neighbor 10.0.2.1",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a neighbor inheriting a group peer-as: %v", err)
+	}
+}
+
+// A per-neighbor peer-as is accepted.
+func TestBGPNeighborPerNeighborPeerASAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group EXT neighbor 10.0.2.1 peer-as 65002",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a neighbor with a per-neighbor peer-as: %v", err)
+	}
+}
+
+// The same gate fires for a per-routing-instance BGP neighbor.
+func TestBGPNeighborMissingPeerASRoutingInstanceRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set routing-instances VR1 instance-type virtual-router",
+		"set routing-instances VR1 protocols bgp local-as 65010",
+		"set routing-instances VR1 protocols bgp group GEXT neighbor 10.1.1.1",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a routing-instance BGP neighbor with no peer-as; expected rejection")
+	}
+	for _, want := range []string{"routing-instance", "VR1", "10.1.1.1", "peer-as"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+// Tolerant load / peer-sync path: an already-persisted config carrying a
+// peer-as-less neighbor must still BOOT (warn, not hard-fail) — #1960
+// fail-closed-on-load doctrine. The render-path guard keeps AS 0 out of
+// frr.conf.
+func TestBGPNeighborMissingPeerASLenientWarns(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set protocols bgp local-as 65001",
+		"set protocols bgp group EXT neighbor 10.0.2.1",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-failed on a peer-as-less neighbor; expected warn-and-boot: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "peer-as") && strings.Contains(w, "10.0.2.1") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("lenient compile did not record a peer-as warning naming the neighbor; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -559,6 +559,25 @@ type compileOpts struct {
 	// loaded test HOLDS state rather than actuating off a dead measurement).
 	// Same doctrine as lenientRPMHTTPGetScheme.
 	lenientRPMRoutingInstance bool
+	// lenientBGPNeighborPeerAS (#2963) downgrades the BGP neighbor peer-as
+	// gate (validateBGPNeighborPeerASStrict) from a hard compile error to a
+	// cfg.Warnings entry. A BGP neighbor whose effective peer-as (remote-as)
+	// is missing/0 (or out of [1, 4294967295]) was previously unvalidated:
+	// peer-as is optional in the parser/compiler, so a neighbor authored
+	// without one keeps the zero value and the FRR renderer (policy_render.go)
+	// emitted `neighbor <addr> remote-as 0`. AS 0 is reserved (RFC 7607) and
+	// FRR/vtysh rejects it, failing the whole frr-reload (a single vtysh -f
+	// add-batch exits non-zero on any CMD_WARNING_CONFIG_FAILED) and leaving
+	// dynamic routing in a broken/stale state — a commit-accepted config the
+	// routing daemon cannot load. The strict commit / commit-check path
+	// hard-rejects so the missing peer-as is operator-visible, naming the
+	// neighbor; the tolerant load / peer-sync paths warn so an
+	// already-persisted or peer-synced config carrying such a neighbor still
+	// BOOTS (#1960 fail-closed-on-load class) — the render path now skips a
+	// remote-as-0 neighbor (defense-in-depth), so AS 0 never reaches frr.conf
+	// and a leniently-loaded bad neighbor is inert. Same doctrine as
+	// lenientRoutingExportRef.
+	lenientBGPNeighborPeerAS bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -614,6 +633,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRPMLinkLocalZone:            true,
 		lenientRPMHTTPGetScheme:            true,
 		lenientRPMRoutingInstance:          true,
+		lenientBGPNeighborPeerAS:           true,
 	})
 }
 
@@ -720,6 +740,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRPMLinkLocalZone:            true,
 		lenientRPMHTTPGetScheme:            true,
 		lenientRPMRoutingInstance:          true,
+		lenientBGPNeighborPeerAS:           true,
 	})
 }
 
@@ -1355,6 +1376,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRoutingExportRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("routing export reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2963: BGP neighbor peer-as gate. peer-as (remote-as) is optional in
+	// the parser/compiler, so a neighbor authored without one keeps a zero
+	// PeerAS and the FRR renderer emitted `neighbor <addr> remote-as 0`. AS 0
+	// is reserved (RFC 7607); FRR/vtysh rejects it, failing the whole
+	// frr-reload and leaving dynamic routing broken — a commit-accepted config
+	// the routing daemon cannot load. Strict on commit / commit-check (hard
+	// reject naming the neighbor); lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960; the render
+	// path now skips a remote-as-0 neighbor so AS 0 never reaches frr.conf).
+	// Runs on the fully-compiled *Config (group peer-as already inherited).
+	// Mirrors validateRoutingExportReferencesStrict.
+	if err := validateBGPNeighborPeerASStrict(cfg); err != nil {
+		if opts.lenientBGPNeighborPeerAS {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("BGP neighbor peer-as (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -962,6 +962,83 @@ func validateFRRAuthValuesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateBGPNeighborPeerASStrict hard-rejects a BGP neighbor whose effective
+// peer-as (remote-as) is missing/0 or out of the valid AS range (#2963).
+//
+// peer-as is optional in the parser/compiler (compiler_protocols.go assigns
+// BGPNeighbor.PeerAS only when a per-neighbor `peer-as` token or an inherited
+// group `peer-as` is present; otherwise it stays the zero value). The FRR
+// renderer (pkg/frr/policy_render.go) emits `neighbor <addr> remote-as <PeerAS>`
+// unconditionally, so a neighbor authored without a peer-as renders
+// `neighbor <addr> remote-as 0`. AS 0 is reserved (RFC 7607) and FRR/vtysh
+// rejects it: the whole frr-reload fails (a single vtysh -f add-batch exits
+// non-zero on any CMD_WARNING_CONFIG_FAILED), leaving dynamic routing in a
+// broken/stale state. That is a commit-accepted config the routing daemon
+// cannot load — exactly the fail-class this gate closes.
+//
+// The valid 4-byte AS space is 1..4294967295 (uint32 max); 0 is reserved
+// (RFC 7607) and 23456 (AS_TRANS) is reserved for 4-byte transition but is a
+// legal configured remote-as, so only 0 is rejected here. (PeerAS is a uint32
+// so the upper bound cannot be exceeded by the typed value — the range check
+// documents intent and is robust to a future wider type.)
+//
+// Both the global `protocols bgp` and per-routing-instance scopes are checked.
+// Neighbor addresses are sorted for a deterministic first-error message.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientBGPNeighborPeerAS) so an already-persisted or
+// peer-synced config carrying such a neighbor still BOOTS (#1960
+// fail-closed-on-load class); the render path now skips a remote-as-0 neighbor
+// (defense-in-depth) so AS 0 never reaches frr.conf and a leniently-loaded bad
+// neighbor is inert. Commit / commit-check stay strict. Mirrors
+// validateRoutingExportReferencesStrict.
+func validateBGPNeighborPeerASStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+
+	checkBGP := func(scope string, bgp *BGPConfig) error {
+		if bgp == nil {
+			return nil
+		}
+		neighbors := append([]*BGPNeighbor(nil), bgp.Neighbors...)
+		sort.SliceStable(neighbors, func(i, j int) bool {
+			return neighbors[i].Address < neighbors[j].Address
+		})
+		for _, n := range neighbors {
+			if n == nil {
+				continue
+			}
+			if n.PeerAS == 0 {
+				detail := fmt.Sprintf("%sprotocols bgp neighbor %s", scope, n.Address)
+				if n.GroupName != "" {
+					detail = fmt.Sprintf("%sprotocols bgp group %s neighbor %s", scope, n.GroupName, n.Address)
+				}
+				return fmt.Errorf("%s: missing/invalid peer-as — a BGP neighbor "+
+					"requires a peer-as (remote-as) in 1..4294967295; AS 0 is "+
+					"reserved (RFC 7607) and FRR/vtysh rejects `remote-as 0`, "+
+					"failing the frr-reload — set the neighbor (or its group) "+
+					"peer-as", detail)
+			}
+		}
+		return nil
+	}
+
+	if err := checkBGP("", cfg.Protocols.BGP); err != nil {
+		return err
+	}
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil {
+			continue
+		}
+		scope := fmt.Sprintf("routing-instance %s ", ri.Name)
+		if err := checkBGP(scope, ri.BGP); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // validateFirewallPolicerReferencesStrict hard-rejects a firewall-filter
 // term whose `then policer <name>` (Finding A, #2217) references neither a
 // defined single-rate policer (`firewall policer <name>`) nor a defined

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -156,6 +156,23 @@ also carries operator content:
   the FRR-invalid `redistribute direct`, failing the reload) — matching the
   policy-term `FromProtocols` normalization and keeping the commit gate's
   acceptance of `direct` honest.
+- **A BGP neighbor's peer-as (remote-as) is validated at commit (#2963).**
+  `peer-as` is optional in the parser/compiler, so a neighbor authored
+  without one (and without an inherited group `peer-as`) keeps a zero
+  `BGPNeighbor.PeerAS`, and `generateProtocols` would emit `neighbor <addr>
+  remote-as 0`. AS 0 is reserved (RFC 7607) and FRR/vtysh rejects
+  `remote-as 0`, which fails the WHOLE `frr-reload` (a single `vtysh -f`
+  add-batch exits non-zero on any `CMD_WARNING_CONFIG_FAILED`) and leaves
+  dynamic routing broken/stale — a commit-accepted config the routing daemon
+  cannot load. `validateBGPNeighborPeerASStrict` (`pkg/config`) hard-rejects
+  a neighbor whose effective `PeerAS == 0` at commit/commit-check (both the
+  global `protocols bgp` and per-routing-instance scopes), naming the
+  offending group + neighbor; lenient (warn) on load/HA-sync (#1960). As
+  defense-in-depth the renderer (`policy_render.go`, `generateProtocols`)
+  SKIPS a neighbor with `PeerAS == 0` entirely, so AS 0 never reaches
+  frr.conf for a config that arrives via the lenient path (an older-binary
+  persisted config or a peer-synced one) — keeping the rest of the reload
+  alive instead of bricking it for every other peer.
 - **A global `protocols bgp export <token>` is split by token shape
   (#2473).** The render classifies each entry by the SAME
   policy-statement-exists predicate the commit-time validator uses

--- a/pkg/frr/bgp_remote_as_2963_test.go
+++ b/pkg/frr/bgp_remote_as_2963_test.go
@@ -1,0 +1,43 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #2963 defense-in-depth: the FRR renderer must never emit
+// `neighbor <addr> remote-as 0`. peer-as is optional in the parser/compiler,
+// so a leniently-loaded (already-persisted / peer-synced) neighbor may carry a
+// zero PeerAS. AS 0 is reserved (RFC 7607) and FRR/vtysh rejects
+// `remote-as 0`, which fails the whole frr-reload for every other peer. The
+// commit-time gate (pkg/config validateBGPNeighborPeerASStrict) hard-rejects
+// on commit; this render guard keeps the leniently-loaded bad neighbor out of
+// frr.conf entirely.
+//
+// FAIL-ON-REVERT: without the `if n.PeerAS == 0 { continue }` guard the
+// rendered output contains `remote-as 0`, turning this test RED.
+func TestGenerateProtocols_BGPRemoteAS0Skipped(t *testing.T) {
+	m := New()
+	bgp := &config.BGPConfig{
+		LocalAS:  65001,
+		RouterID: "1.1.1.1",
+		Neighbors: []*config.BGPNeighbor{
+			{Address: "10.0.2.1", PeerAS: 0, Description: "no-peer-as"}, // peer-as omitted
+			{Address: "10.0.3.1", PeerAS: 65003},                        // valid
+		},
+	}
+	got := m.generateProtocols(nil, nil, bgp, nil, nil, "", 0, nil)
+	if strings.Contains(got, "remote-as 0") {
+		t.Errorf("renderer emitted reserved 'remote-as 0' (RFC 7607); output:\n%s", got)
+	}
+	// The peer-as-less neighbor is skipped entirely, so none of its lines render.
+	if strings.Contains(got, "neighbor 10.0.2.1") {
+		t.Errorf("renderer emitted lines for a peer-as-less neighbor; output:\n%s", got)
+	}
+	// The valid neighbor still renders.
+	if !strings.Contains(got, "neighbor 10.0.3.1 remote-as 65003\n") {
+		t.Errorf("renderer dropped a valid neighbor; output:\n%s", got)
+	}
+}

--- a/pkg/frr/policy_render.go
+++ b/pkg/frr/policy_render.go
@@ -555,6 +555,18 @@ func (m *Manager) generateProtocols(ospf *config.OSPFConfig, ospfv3 *config.OSPF
 			fmt.Fprintf(&b, " bgp dampening %d %d %d %d\n", hl, reuse, suppress, maxSup)
 		}
 		for _, n := range bgp.Neighbors {
+			// Defense-in-depth (#2963): never emit `remote-as 0`. peer-as is
+			// optional in the parser/compiler, so a neighbor authored without
+			// one keeps a zero PeerAS. AS 0 is reserved (RFC 7607) and FRR/vtysh
+			// rejects `remote-as 0`, failing the whole frr-reload. Commit-time
+			// validation (validateBGPNeighborPeerASStrict, pkg/config) rejects
+			// this on commit/commit-check; on the tolerant load/peer-sync path
+			// it is downgraded to a warning, so this render guard keeps a
+			// leniently-loaded remote-as-0 neighbor out of frr.conf entirely
+			// rather than bricking the reload for every other peer.
+			if n.PeerAS == 0 {
+				continue
+			}
 			fmt.Fprintf(&b, " neighbor %s remote-as %d\n", n.Address, n.PeerAS)
 			if n.Description != "" {
 				fmt.Fprintf(&b, " neighbor %s description %s\n", n.Address, sanitizeFRRValue(n.Description))


### PR DESCRIPTION
## Summary

A BGP neighbor configured without a `peer-as` (and without an inherited group `peer-as`) keeps the zero value for `BGPNeighbor.PeerAS`. `peer-as` is optional in the parser/compiler, but `pkg/frr/policy_render.go` (`generateProtocols`) emitted `neighbor <addr> remote-as <PeerAS>` unconditionally — so such a neighbor rendered `neighbor <addr> remote-as 0`.

AS 0 is reserved (RFC 7607) and FRR/vtysh rejects `remote-as 0`. A single rejected line fails the whole `frr-reload` (`frr-reload.py` applies the add-batch via one `vtysh -f` and exits non-zero on any `CMD_WARNING_CONFIG_FAILED`), leaving dynamic routing broken/stale — a commit-accepted config the routing daemon cannot load.

## Fix

- **Primary (commit-time):** `validateBGPNeighborPeerASStrict` (`pkg/config/compiler_validate_strict.go`) hard-rejects any BGP neighbor whose effective `PeerAS == 0` at commit / commit-check, across both the global `protocols bgp` scope and per-routing-instance scopes, with an error naming the offending group + neighbor. Wired into `compileConfigWithOpts` with a new `lenientBGPNeighborPeerAS` option set on the tolerant load / peer-sync paths (warn-and-boot per the #1960 fail-closed-on-load doctrine), exactly like the sibling validators.
- **Defense-in-depth (render):** `generateProtocols` now skips a neighbor with `PeerAS == 0`, so AS 0 never reaches `frr.conf` for a config that arrives via the lenient path — keeping the rest of the reload alive instead of bricking it for every other peer.

## Scope

This is the genuine `remote-as 0` half of agy-review-056 056-05. The companion's `router bgp 0` claim was rejected as **false** — the router block is guarded by `bgp != nil && bgp.LocalAS > 0` and neighbors render only inside it — so local-AS / `router bgp` handling is **untouched**.

## Tests (fail-on-revert)

- `pkg/config`: a BGP neighbor (group + per-routing-instance) with no `peer-as` is rejected at commit; the error names the group + neighbor; group-inherited or per-neighbor `peer-as` is accepted; the lenient path warns-and-boots. **Verified RED** when the strict gate is removed (config compiles + would render `remote-as 0`).
- `pkg/frr`: the renderer never emits `remote-as 0` and skips the peer-as-less neighbor while keeping valid neighbors. **Verified RED** when the render skip is removed.

## Docs

`pkg/frr/README.md` commit-time-validation section + `_Log.md`.

## Gates

`go build ./...`, `gofmt -l` clean, `go vet ./pkg/config/... ./pkg/frr/...`, `go test ./pkg/config/... ./pkg/frr/...` all pass.

Closes #2963

🤖 Generated with [Claude Code](https://claude.com/claude-code)