### PR TITLE
ddns/surface-a: skip IFA_F_TEMPORARY in selectInterfaceAddr (Closes #2975)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -18087,3 +18087,24 @@ top.
 - **File(s)**: pkg/ddns/backend_duckdns.go, pkg/ddns/README.md,
   pkg/config/compiler_validate_warn.go,
   pkg/config/compiler_p3_http_providers_test.go, _Log.md
+
+## 2026-06-25 — #2975 selectInterfaceAddr skip IFA_F_TEMPORARY
+- **Timestamp**: 2026-06-25
+- **Action**: Fix Surface A interface-address selection to skip RFC 4941/8981
+  SLAAC privacy/temporary IPv6 addresses (`IFA_F_TEMPORARY`). The skip mask in
+  `selectInterfaceAddr` previously omitted IFA_F_TEMPORARY, so a rotating
+  privacy address could win on netlink order and be published to public DNS —
+  leaking the ephemeral identifier and black-holing inbound reachability on the
+  next rotation. Added IFA_F_TEMPORARY to the DAD-not-succeeded skip mask
+  (joins TENTATIVE/DADFAILED/OPTIMISTIC) so the stable permanent address is
+  selected. IFA_F_MANAGETEMPADDR (the permanent SLAAC address that spawns
+  temporaries) is intentionally NOT skipped. Added 4 fail-on-revert table cases
+  to TestSelectInterfaceAddrLifetime (temporary-first, temporary-only,
+  temporary+deprecated, deprecated-temporary). Updated function godoc and
+  pkg/ddns/README.md address-lifetime selection paragraph.
+- **Gates**: go build ./... PASS; gofmt -l clean; go vet ./pkg/daemon/ PASS;
+  go test ./pkg/daemon/ -run TestSelectInterfaceAddr PASS (12 cases).
+  Fail-on-revert: dropping IFA_F_TEMPORARY from the mask turns all 4 new cases
+  RED; restore returns green.
+- **File(s)**: pkg/daemon/daemon_ddns_surface_a.go,
+  pkg/daemon/daemon_ddns_surface_a_test.go, pkg/ddns/README.md, _Log.md

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -409,6 +409,11 @@ func (d *Daemon) observeInterfaceAddr(linuxName string, af4 bool, unit *config.I
 //     or IFA_F_OPTIMISTIC (RFC 4429 optimistic DAD — usable for some traffic but
 //     not yet DAD-confirmed, so not safe to publish to global DNS). Publishing
 //     one risks a duplicate/black-holed answer.
+//   - NEVER select an RFC 4941/8981 SLAAC privacy/temporary address
+//     (IFA_F_TEMPORARY, #2975). It is an outbound-only ephemeral identifier that
+//     rotates on a short timer; publishing it leaks the privacy identifier and
+//     black-holes inbound reachability when it rotates. The stable permanent
+//     address (which privacy extensions keep for inbound service) is preferred.
 //   - NEVER select a non-globally-meaningful address (loopback / link-local
 //     uni+multicast / multicast / unspecified, AND every IANA special-purpose
 //     range) — the SAME ddns.IsPublicAddr gate the static fallback (#2776) and
@@ -435,7 +440,16 @@ func selectInterfaceAddr(addrs []netlink.Addr, af4 bool) (netip.Addr, bool) {
 		}
 		// Skip addresses whose DAD has not succeeded — they may be duplicate or
 		// not yet usable. tentative/dadfailed/optimistic are never publishable.
-		if ad.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_DADFAILED|unix.IFA_F_OPTIMISTIC) != 0 {
+		//
+		// Also skip RFC 4941/8981 SLAAC privacy/temporary addresses
+		// (IFA_F_TEMPORARY, #2975). A temporary address is an outbound-only
+		// ephemeral identifier that rotates on a short timer; publishing one to
+		// public DNS leaks the privacy identifier AND black-holes inbound
+		// reachability as soon as it rotates (the record points at an address
+		// that no longer exists). The stable permanent address on the same
+		// interface — which privacy extensions are designed to KEEP for inbound
+		// service — is the correct publication target.
+		if ad.Flags&(unix.IFA_F_TENTATIVE|unix.IFA_F_DADFAILED|unix.IFA_F_OPTIMISTIC|unix.IFA_F_TEMPORARY) != 0 {
 			continue
 		}
 		// Globally-routable-unicast gate (#2776): reject link-local, loopback,

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -295,6 +295,57 @@ func TestSelectInterfaceAddrLifetime(t *testing.T) {
 			ok:   true,
 		},
 		{
+			// #2975 fail-on-revert: a SLAAC privacy/temporary preferred address
+			// listed FIRST must NOT be selected when a stable permanent preferred
+			// address exists. Goes RED if IFA_F_TEMPORARY is dropped from the skip
+			// mask (the temporary 0xdead address would win on netlink order).
+			name: "temporary skipped, permanent preferred selected (temporary first)",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::dead/64", unix.IFA_F_TEMPORARY),
+				mkAddr("2606:4700:4700::1111/64", 0),
+			},
+			af4:  false,
+			want: pref6,
+			ok:   true,
+		},
+		{
+			// A temporary address as the ONLY candidate is rejected outright — a
+			// rotating privacy identifier must never be published, even at the
+			// cost of no answer (it would blackhole on the next rotation anyway).
+			name: "temporary only is rejected (never publish privacy identifier)",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::dead/64", unix.IFA_F_TEMPORARY),
+			},
+			af4:  false,
+			want: netip.Addr{},
+			ok:   false,
+		},
+		{
+			// Composition: a temporary preferred + a deprecated permanent → the
+			// temporary is skipped and the deprecated permanent is the only usable
+			// answer (never blackhole). Confirms the temporary skip does not
+			// accidentally promote a temporary into the deprecated fallback slot.
+			name: "temporary preferred skipped, deprecated permanent used",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::dead/64", unix.IFA_F_TEMPORARY),
+				mkAddr("2606:4700:4700::2222/64", unix.IFA_F_DEPRECATED),
+			},
+			af4:  false,
+			want: dep6,
+			ok:   true,
+		},
+		{
+			// A deprecated temporary address (privacy address mid-rotation) is
+			// skipped twice over — neither TEMPORARY nor DEPRECATED may publish.
+			name: "deprecated temporary never used as fallback",
+			addrs: []netlink.Addr{
+				mkAddr("2606:4700:4700::dead/64", unix.IFA_F_TEMPORARY|unix.IFA_F_DEPRECATED),
+			},
+			af4:  false,
+			want: netip.Addr{},
+			ok:   false,
+		},
+		{
 			// IPv4 family filter + preferred selection.
 			name: "v4 preferred selected, v6 ignored",
 			addrs: []netlink.Addr{

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -440,8 +440,18 @@ its OWN learned address — on top of the SAME spine, without forking the engine
   address exists (never-blackhole — a still-valid deprecated address beats no
   answer). (3) Every candidate STILL passes `ddns.IsPublicAddr`, so a
   preferred-but-ULA (or otherwise reserved) address is rejected — the same gate
-  as the static fallback (#2776) and the checkip source. The IFA_F_* flags are
-  already parsed off the netlink `RTM_NEWADDR` message into
+  as the static fallback (#2776) and the checkip source. (4) It NEVER selects an
+  RFC 4941/8981 SLAAC privacy/temporary address (`IFA_F_TEMPORARY`, #2975): a
+  temporary address is an outbound-only ephemeral identifier that rotates on a
+  short timer, so publishing it leaks the privacy identifier into public DNS AND
+  black-holes inbound reachability the moment it rotates (the record points at an
+  address that no longer exists). `IFA_F_TEMPORARY` joins the
+  tentative/dadfailed/optimistic skip mask, so the stable permanent address —
+  which privacy extensions are designed to KEEP for inbound service — wins even
+  when netlink lists a temporary address first. Note this skips ONLY
+  `IFA_F_TEMPORARY`; `IFA_F_MANAGETEMPADDR` marks the *permanent* SLAAC address
+  that spawns the temporaries and remains a valid publication target. The
+  IFA_F_* flags are already parsed off the netlink `RTM_NEWADDR` message into
   `netlink.Addr.Flags` (no extra netlink plumbing was needed — they were simply
   ignored in selection before). A per-family `preferred-address` operator
   override for multi-address interfaces (the issue's secondary ask) remains a


### PR DESCRIPTION
## Summary
`selectInterfaceAddr` (the Surface A dynamic interface-address selection that
picks which address is published to public DNS for a router-owned record)
filtered tentative/dadfailed/optimistic and deprecated addresses plus the
public-unicast gate, but its DAD-not-succeeded skip mask **omitted
`unix.IFA_F_TEMPORARY`**.

With IPv6 privacy extensions (RFC 4941/8981), netlink returns both a stable
permanent preferred public address and one or more temporary (privacy) preferred
addresses. "First eligible preferred wins" could therefore return a **temporary**
address → published to public DNS → leaks the ephemeral privacy identifier AND
black-holes inbound reachability as soon as the temporary address rotates.

## Fix
Add `IFA_F_TEMPORARY` to the skip mask alongside TENTATIVE/DADFAILED/OPTIMISTIC.
The stable permanent address now wins even when netlink lists a temporary one
first. `IFA_F_MANAGETEMPADDR` is intentionally **not** skipped — it marks the
*permanent* SLAAC address that spawns temporaries and remains a valid target.

Distinct from #2775 (closed — lifetime/DAD-state handling; temporary not
covered). Provenance: agy-review-057 finding 057-01.

## Fail-on-revert test
Added 4 cases to `TestSelectInterfaceAddrLifetime`:
- temporary listed first + permanent present → permanent selected
- temporary-only → rejected (never publish a privacy identifier)
- temporary preferred + deprecated permanent → deprecated permanent used
- deprecated temporary → never used as fallback

Removing `IFA_F_TEMPORARY` from the mask turns **all 4 RED**; restoring returns
green (proven locally via copy-aside + sed revert).

## Gates (foreground)
- `go build ./...` — PASS
- `gofmt -l` changed Go files — clean
- `go vet ./pkg/daemon/` — PASS
- `go test ./pkg/daemon/` (selectInterfaceAddr/observeInterfaceAddr/staticUnitAddr) — PASS

## Docs
- `selectInterfaceAddr` godoc updated
- `pkg/ddns/README.md` address-lifetime selection paragraph (point 4 + MANAGETEMPADDR note)
- `_Log.md`

Closes #2975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi