### PR TITLE
snmp: deterministic trap community + trap-group schema validation + async trap delivery

### DIFF
--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -596,6 +596,21 @@ type compileOpts struct {
 	// the malformed value never reaches frr.conf and a leniently-loaded bad
 	// router-id is inert. Same doctrine as lenientBGPNeighborPeerAS.
 	lenientRouterID bool
+	// lenientSNMPTrapGroup (#2990) downgrades the SNMP trap-group commit gate
+	// (unknown trap-group child key, e.g. a `tragets` typo, and an
+	// enabled-but-zero-target trap group) from a hard compile error to a
+	// cfg.Warnings entry. Before #2990 the trap-group schema had children:nil
+	// and the compiler silently dropped every child but `targets`, so a typo'd
+	// or zero-target trap group COMMITTED CLEANLY and persists in active.json.
+	// The #2990 strict gate rejects such a group at commit (operator-visible,
+	// naming the offending key) — but on the tolerant load / peer-sync path it
+	// MUST warn, not error, or an already-persisted bad trap group would fail
+	// CompileConfigLenient and blackout the boot / alarm-loop HA sync (the
+	// exact #1960 fail-closed-on-load class compileTreeLenient exists to
+	// prevent). Runtime is already inert for both cases — sendLinkTraps skips a
+	// zero-target group and never reads an unknown key — so a leniently-loaded
+	// bad group is harmless. Same doctrine as lenientRouterID.
+	lenientSNMPTrapGroup bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -653,6 +668,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRPMRoutingInstance:          true,
 		lenientBGPNeighborPeerAS:           true,
 		lenientRouterID:                    true,
+		lenientSNMPTrapGroup:               true,
 	})
 }
 
@@ -761,6 +777,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRPMRoutingInstance:          true,
 		lenientBGPNeighborPeerAS:           true,
 		lenientRouterID:                    true,
+		lenientSNMPTrapGroup:               true,
 	})
 }
 
@@ -925,7 +942,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 				return nil, fmt.Errorf("forwarding-options: %w", err)
 			}
 		case "system":
-			if err := compileSystem(node, &cfg.System); err != nil {
+			if err := compileSystem(node, &cfg.System, cfg, opts); err != nil {
 				return nil, fmt.Errorf("system: %w", err)
 			}
 		case "schedulers":
@@ -946,7 +963,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 			}
 		case "snmp":
 			// Top-level snmp stanza (same format as system { snmp { ... } })
-			if err := compileSNMP(node, &cfg.System); err != nil {
+			if err := compileSNMP(node, &cfg.System, cfg, opts.lenientSNMPTrapGroup); err != nil {
 				return nil, fmt.Errorf("snmp: %w", err)
 			}
 		case "bridge-domains":

--- a/pkg/config/compiler_snmp_trapgroup_2990_test.go
+++ b/pkg/config/compiler_snmp_trapgroup_2990_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// compileSNMPLines builds a config tree from flat-set lines and compiles it via
+// the strict (commit) path.
+func compileSNMPLines(t *testing.T, lines []string) (*Config, error) {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, line := range lines {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	return CompileConfig(tree)
+}
+
+// TestSNMPTrapGroup_TypoRejected is the fail-on-revert guard for #2990. A
+// typoed trap-group child key (`tragets` instead of `targets`) must be REJECTED
+// at commit. Before the fix the compiler only consumed `targets` and silently
+// dropped every other child, so a typo committed as a valid zero-target trap
+// group that sent no notifications. Reverting the compiler's unknown-key /
+// zero-target rejection makes this test pass-compile (no error) and fail.
+func TestSNMPTrapGroup_TypoRejected(t *testing.T) {
+	_, err := compileSNMPLines(t, []string{
+		"set snmp trap-group managers tragets 10.0.0.10",
+	})
+	if err == nil {
+		t.Fatal("typoed trap-group key 'tragets' compiled without error (#2990 regression)")
+	}
+	if !strings.Contains(err.Error(), "tragets") {
+		t.Fatalf("error %q does not name the offending key 'tragets'", err)
+	}
+}
+
+// TestSNMPTrapGroup_ZeroTargetsRejected guards the companion zero-target case:
+// a trap group with no targets sends nothing and must be rejected at commit.
+func TestSNMPTrapGroup_ZeroTargetsRejected(t *testing.T) {
+	_, err := compileSNMPLines(t, []string{
+		"set snmp trap-group empty version v2",
+	})
+	if err == nil {
+		t.Fatal("trap-group with zero targets compiled without error (#2990)")
+	}
+	if !strings.Contains(err.Error(), "no targets") {
+		t.Fatalf("error %q does not explain the zero-target rejection", err)
+	}
+}
+
+// TestSNMPTrapGroup_ValidAccepted confirms the fix does not over-reject: a
+// well-formed trap group (single target, multiple targets, with version /
+// categories) compiles and the targets land in the typed config.
+func TestSNMPTrapGroup_ValidAccepted(t *testing.T) {
+	cfg, err := compileSNMPLines(t, []string{
+		"set snmp community public authorization read-only",
+		"set snmp trap-group managers targets 10.0.0.10",
+		"set snmp trap-group managers targets 10.0.0.11",
+		"set snmp trap-group managers version v2",
+		"set snmp trap-group managers categories link",
+	})
+	if err != nil {
+		t.Fatalf("valid trap-group failed to compile: %v", err)
+	}
+	tg := cfg.System.SNMP.TrapGroups["managers"]
+	if tg == nil {
+		t.Fatal("trap-group 'managers' missing from compiled config")
+	}
+	if len(tg.Targets) != 2 {
+		t.Fatalf("targets = %v, want 2 entries", tg.Targets)
+	}
+	want := map[string]bool{"10.0.0.10": false, "10.0.0.11": false}
+	for _, target := range tg.Targets {
+		if _, ok := want[target]; !ok {
+			t.Fatalf("unexpected target %q", target)
+		}
+		want[target] = true
+	}
+	for target, seen := range want {
+		if !seen {
+			t.Fatalf("expected target %q missing", target)
+		}
+	}
+}
+
+// TestSNMPTrapGroup_BracketedTargets confirms a bracketed/flat-set list of
+// targets accumulates (the multi-value leaf contract, docs/config-schema.md).
+func TestSNMPTrapGroup_BracketedTargets(t *testing.T) {
+	cfg, err := compileSNMPLines(t, []string{
+		"set snmp trap-group managers targets [ 10.0.0.10 10.0.0.11 10.0.0.12 ]",
+	})
+	if err != nil {
+		t.Fatalf("bracketed targets failed to compile: %v", err)
+	}
+	tg := cfg.System.SNMP.TrapGroups["managers"]
+	if tg == nil || len(tg.Targets) != 3 {
+		t.Fatalf("bracketed targets = %v, want 3 entries", tg)
+	}
+}

--- a/pkg/config/compiler_snmp_trapgroup_2990_test.go
+++ b/pkg/config/compiler_snmp_trapgroup_2990_test.go
@@ -54,6 +54,51 @@ func TestSNMPTrapGroup_ZeroTargetsRejected(t *testing.T) {
 	}
 }
 
+// TestSNMPTrapGroup_TypoLenientWarns pins the no-brick contract (#1960
+// doctrine) for the typo case: the unknown trap-group key the STRICT path
+// rejects is TOLERATED on the lenient load / peer-sync path — downgraded to a
+// warning so an already-persisted/peer-synced config (committed before #2990
+// gave trap-group children) still boots. Goes RED (CompileConfigLenient hard-
+// errors) if the lenient downgrade is removed.
+func TestSNMPTrapGroup_TypoLenientWarns(t *testing.T) {
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand("set snmp trap-group managers tragets 10.0.0.10")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on a typoed trap-group key (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "unknown statement") {
+		t.Fatalf("expected a downgraded unknown-statement warning, warnings=%v", cfg.Warnings)
+	}
+}
+
+// TestSNMPTrapGroup_ZeroTargetsLenientWarns is the zero-target companion of the
+// no-brick contract: a persisted zero-target trap group boots through on the
+// lenient path with a warning rather than failing to compile.
+func TestSNMPTrapGroup_ZeroTargetsLenientWarns(t *testing.T) {
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand("set snmp trap-group empty version v2")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on a zero-target trap group (brick-on-restart): %v", err)
+	}
+	if !hasWarningSubstr(cfg.Warnings, "no targets configured") {
+		t.Fatalf("expected a downgraded zero-target warning, warnings=%v", cfg.Warnings)
+	}
+}
+
 // TestSNMPTrapGroup_ValidAccepted confirms the fix does not over-reject: a
 // well-formed trap group (single target, multiple targets, with version /
 // categories) compiles and the targets land in the typed config.

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -904,11 +904,34 @@ func compileSNMP(node *Node, sys *SystemConfig) error {
 					tgChildren = child.Children[0].Children
 				}
 				for _, prop := range tgChildren {
-					if prop.Name() == "targets" {
-						if v := nodeVal(prop); v != "" {
-							tg.Targets = append(tg.Targets, v)
-						}
+					switch prop.Name() {
+					case "targets":
+						// targets may carry multiple values: one per child
+						// (hierarchical `targets { a; b; }`) and/or packed in
+						// the leaf Keys (flat-set / bracketed list).
+						tg.Targets = append(tg.Targets, firewallMatchValues(prop)...)
+					case "version", "categories":
+						// Accepted trap-group leaves (schema-declared). Not
+						// consumed by the link-trap runtime today; recognized
+						// here so a valid key does not trip the unknown-key
+						// rejection below.
+					default:
+						// #2990: a typoed child key (e.g. `tragets`) would
+						// otherwise be silently dropped, committing a trap
+						// group with zero targets that sends nothing. Reject
+						// it at commit so the operator is told about the typo
+						// instead of losing every notification at runtime.
+						return fmt.Errorf("snmp trap-group %q: unknown statement %q (valid: targets, version, categories)", tgName, prop.Name())
 					}
+				}
+				// #2990: a trap group with no targets sends nothing — reject
+				// it at commit rather than presenting a configured-but-inert
+				// group. This also catches the typo case where the only child
+				// was misspelled (the unknown-key branch above already errors,
+				// but a bare `set snmp trap-group g1` with no children lands
+				// here).
+				if len(tg.Targets) == 0 {
+					return fmt.Errorf("snmp trap-group %q: no targets configured (a trap group with zero targets sends no notifications)", tgName)
 				}
 				snmp.TrapGroups[tg.Name] = tg
 			}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -13,7 +13,7 @@ import (
 
 const sharedUMEMPhase0ArtifactMaxBytes = 16 << 20
 
-func compileSystem(node *Node, sys *SystemConfig) error {
+func compileSystem(node *Node, sys *SystemConfig, cfg *Config, opts compileOpts) error {
 	dpType, err := compileSystemDataplaneType(node)
 	if err != nil {
 		return err
@@ -394,7 +394,7 @@ func compileSystem(node *Node, sys *SystemConfig) error {
 
 	snmpNode := node.FindChild("snmp")
 	if snmpNode != nil {
-		if err := compileSNMP(snmpNode, sys); err != nil {
+		if err := compileSNMP(snmpNode, sys, cfg, opts.lenientSNMPTrapGroup); err != nil {
 			return err
 		}
 	}
@@ -856,7 +856,7 @@ func normalizeSharedUMEMArtifactInterfaceMap(artifact map[string]interface{}, ke
 	return nil
 }
 
-func compileSNMP(node *Node, sys *SystemConfig) error {
+func compileSNMP(node *Node, sys *SystemConfig, cfg *Config, lenient bool) error {
 	snmp := &SNMPConfig{
 		Communities: make(map[string]*SNMPCommunity),
 		TrapGroups:  make(map[string]*SNMPTrapGroup),
@@ -918,20 +918,36 @@ func compileSNMP(node *Node, sys *SystemConfig) error {
 					default:
 						// #2990: a typoed child key (e.g. `tragets`) would
 						// otherwise be silently dropped, committing a trap
-						// group with zero targets that sends nothing. Reject
-						// it at commit so the operator is told about the typo
-						// instead of losing every notification at runtime.
-						return fmt.Errorf("snmp trap-group %q: unknown statement %q (valid: targets, version, categories)", tgName, prop.Name())
+						// group with zero targets that sends nothing. Strict
+						// (commit / commit-check): reject so the operator is
+						// told about the typo instead of losing every
+						// notification at runtime. Lenient (load / HA-sync):
+						// downgrade to a warning so an already-persisted bad
+						// config still boots — the runtime ignores the unknown
+						// key, so it is inert (#1960 fail-closed-on-load).
+						if !lenient {
+							return fmt.Errorf("snmp trap-group %q: unknown statement %q (valid: targets, version, categories)", tgName, prop.Name())
+						}
+						if cfg != nil {
+							cfg.Warnings = append(cfg.Warnings,
+								fmt.Sprintf("snmp trap-group %q: unknown statement %q (downgraded to warning on tolerant path; ignored at runtime)", tgName, prop.Name()))
+						}
 					}
 				}
-				// #2990: a trap group with no targets sends nothing — reject
-				// it at commit rather than presenting a configured-but-inert
-				// group. This also catches the typo case where the only child
-				// was misspelled (the unknown-key branch above already errors,
-				// but a bare `set snmp trap-group g1` with no children lands
-				// here).
+				// #2990: a trap group with no targets sends nothing. Strict:
+				// reject rather than presenting a configured-but-inert group
+				// (this also catches a bare `set snmp trap-group g1` with no
+				// children). Lenient: warn so an already-persisted zero-target
+				// group still boots — sendLinkTraps skips a zero-target group,
+				// so it is inert (#1960).
 				if len(tg.Targets) == 0 {
-					return fmt.Errorf("snmp trap-group %q: no targets configured (a trap group with zero targets sends no notifications)", tgName)
+					if !lenient {
+						return fmt.Errorf("snmp trap-group %q: no targets configured (a trap group with zero targets sends no notifications)", tgName)
+					}
+					if cfg != nil {
+						cfg.Warnings = append(cfg.Warnings,
+							fmt.Sprintf("snmp trap-group %q: no targets configured (downgraded to warning on tolerant path; sends no notifications)", tgName))
+					}
 				}
 				snmp.TrapGroups[tg.Name] = tg
 			}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -834,7 +834,26 @@ var schemaSNMP = &schemaNode{desc: "SNMP configuration", children: map[string]*s
 			children:      nil,
 		},
 	}},
-	"trap-group": {desc: "Trap group", args: 1, placeholder: "<group-name>", children: nil},
+	"trap-group": {desc: "Trap group", args: 1, placeholder: "<group-name>", children: map[string]*schemaNode{
+		"targets": {
+			desc:        "Trap target host (IP address or FQDN, optional :port)",
+			args:        1,
+			multi:       true,
+			placeholder: "<target>",
+			children:    nil,
+		},
+		"version": {
+			desc:          "SNMP version for this trap group",
+			args:          1,
+			placeholder:   "<version>",
+			valueType:     ValueEnumOf,
+			valueDesc:     "Trap protocol version (v1 | v2 | all)",
+			valueExamples: []string{"v1", "v2", "all"},
+			validator:     ValidateEnum([]string{"v1", "v2", "all"}),
+			children:      nil,
+		},
+		"categories": {desc: "Trap categories to send to this group", args: 1, multi: true, placeholder: "<category>", children: nil},
+	}},
 	"v3": {desc: "SNMPv3", children: map[string]*schemaNode{
 		"usm": {desc: "USM", children: map[string]*schemaNode{
 			"local-engine": {desc: "Local engine", children: map[string]*schemaNode{

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -228,8 +228,15 @@ authorization surface: every request is dropped because no community matches.
   varbind fits. This prevents emitting an oversized UDP datagram that the peer
   or the network would fragment or drop. See `effectiveMaxSize` / `trimToFit`
   in `agent.go`.
-- Traps fire immediately on link-state change — they aren't queued, so
-  back-to-back link flaps produce back-to-back traps.
+- **The v2c trap community is selected deterministically (#2989).**
+  `selectTrapCommunity` picks the lexicographically-first configured
+  community (falling back to `public` when none is configured). The old
+  code ranged the `Communities` map and broke on the first entry, which —
+  because Go map iteration is randomized — picked a different community per
+  run when more than one was configured, so a collector accepting only one
+  community saw flaky traps and a less-privileged community could leak
+  through the wrong credential boundary. Trap groups are likewise iterated
+  in sorted order so dispatch and log output are reproducible.
 - Don't add a third BER library to this package. The hand-coded encoder
   is intentional; keeping the surface small avoids bringing in an SNMP
   framework with its own poll loop and threading model.

--- a/pkg/snmp/README.md
+++ b/pkg/snmp/README.md
@@ -228,6 +228,22 @@ authorization surface: every request is dropped because no community matches.
   varbind fits. This prevents emitting an oversized UDP datagram that the peer
   or the network would fragment or drop. See `effectiveMaxSize` / `trimToFit`
   in `agent.go`.
+- **Trap delivery is asynchronous and bounded (#2991).** Link-state traps
+  are emitted from the daemon's netlink link-monitor goroutine.
+  `sendLinkTraps` builds the packet on the caller's goroutine (cheap) and
+  enqueues one job per target onto a bounded channel
+  (`trapQueueDepth = 256`) drained by a single worker goroutine; the
+  blocking `net.DialTimeout` (and DNS resolution for an FQDN target) runs
+  on the worker, NOT on the link monitor. A dead or slow target therefore
+  cannot stall link-state processing. The queue is started lazily (works
+  for both `NewAgent` and bare-struct test agents). When the queue is full
+  the trap is DROPPED and `trapsDropped` is incremented rather than
+  blocking the caller — dropping is the correct backpressure when targets
+  are not draining. The delivery is replaceable through the `trapSender`
+  package var (the seam tests use to inject a slow sender). Before #2991
+  delivery was synchronous and inline, so an unreachable trap target (or a
+  hung DNS lookup for an FQDN target) blocked link-state processing for up
+  to the 2s dial timeout × target count.
 - **The v2c trap community is selected deterministically (#2989).**
   `selectTrapCommunity` picks the lexicographically-first configured
   community (falling back to `public` when none is configured). The old

--- a/pkg/snmp/agent.go
+++ b/pkg/snmp/agent.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -183,7 +184,42 @@ type Agent struct {
 	cfgMu   sync.RWMutex
 	cfg     *config.SNMPConfig  // authorization + sysContact/Location/Description
 	v3Users map[string]*usmUser // SNMPv3 USM users (keyed by name)
+
+	// Asynchronous trap delivery (#2991). Link-state traps are emitted from
+	// the daemon's netlink link-monitor goroutine; sendTrap does a blocking
+	// net.DialTimeout (and DNS resolution for an FQDN target) that, done
+	// inline, would stall link processing for up to dialTimeout × target
+	// count when a target is dead or slow. Instead sendLinkTraps enqueues a
+	// pre-built packet onto a small bounded channel drained by a single
+	// worker goroutine. The queue is started lazily (works for both NewAgent
+	// and bare-struct test agents) and is capacity-bounded: when full, the
+	// trap is dropped and trapsDropped is incremented rather than blocking
+	// the caller. A single worker bounds goroutine growth (no per-trap
+	// goroutine storm) while still serializing the slow dials off the hot
+	// link-monitor path.
+	trapQueue      chan trapJob
+	trapWorkerOnce sync.Once
+	trapsDropped   atomic.Uint64
 }
+
+// trapJob is one queued trap-delivery unit: a pre-built SNMP packet and its
+// destination target (host or host:port). The packet is built on the caller's
+// goroutine (cheap, allocation only) and the blocking dial/write happens on the
+// worker.
+type trapJob struct {
+	target  string
+	pkt     []byte
+	group   string
+	event   string
+	iface   string
+	ifindex int
+}
+
+// trapQueueDepth bounds the number of pending trap deliveries. A handful of
+// targets times a short burst of link flaps fits comfortably; past this the
+// targets are clearly not draining and dropping is preferable to unbounded
+// memory growth or blocking the link monitor.
+const trapQueueDepth = 256
 
 // NewAgent creates a new SNMP agent with the given configuration. The
 // SNMPv3 engineBoots counter is loaded from defaultEngineBootsPath,

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -100,6 +100,12 @@ func (a *Agent) buildLinkTrap(community string, linkUp bool, ifindex int, ifname
 	return berEncodeTLV(tagSequence, msgBody)
 }
 
+// trapSender delivers a single pre-built trap to a target. It is a package
+// var (not a direct call) so tests can inject a deliberately slow/blocking
+// sender to prove the link-monitor caller does not block on trap delivery
+// (#2991). Production code never reassigns it.
+var trapSender = sendTrap
+
 // sendTrap sends a pre-built trap packet to a single target on port 162.
 func sendTrap(target string, pkt []byte) error {
 	// Ensure the target has a port.
@@ -151,17 +157,20 @@ func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
 		direction = "up"
 	}
 
+	// Enqueue one job per target. The blocking dial/write happens on the
+	// trap worker so a dead or slow target never stalls the link monitor
+	// (#2991). Iterate trap groups in deterministic (sorted) order so log
+	// output and dispatch ordering are stable across runs.
 	for _, tg := range sortedTrapGroups(cfg) {
 		for _, target := range tg.Targets {
-			if err := sendTrap(target, pkt); err != nil {
-				slog.Warn("SNMP trap send failed",
-					"target", target, "group", tg.Name,
-					"event", "link"+direction, "iface", ifname, "err", err)
-			} else {
-				slog.Info("SNMP trap sent",
-					"target", target, "group", tg.Name,
-					"event", "link"+direction, "iface", ifname, "ifindex", ifindex)
-			}
+			a.enqueueTrap(trapJob{
+				target:  target,
+				pkt:     pkt,
+				group:   tg.Name,
+				event:   "link" + direction,
+				iface:   ifname,
+				ifindex: ifindex,
+			})
 		}
 	}
 }
@@ -205,4 +214,43 @@ func sortedTrapGroups(cfg *config.SNMPConfig) []*config.SNMPTrapGroup {
 		groups = append(groups, cfg.TrapGroups[name])
 	}
 	return groups
+}
+
+// enqueueTrap hands a pre-built trap to the async worker (#2991). It starts the
+// worker on first use (so both NewAgent and bare-struct test agents get it) and
+// never blocks the caller: when the bounded queue is full the trap is dropped
+// and trapsDropped is incremented. Dropping is the correct backpressure policy
+// here — the queue only fills when targets are not draining, and blocking the
+// link monitor on SNMP observability is exactly the failure #2991 fixes.
+func (a *Agent) enqueueTrap(job trapJob) {
+	a.trapWorkerOnce.Do(func() {
+		a.trapQueue = make(chan trapJob, trapQueueDepth)
+		go a.trapWorker()
+	})
+	select {
+	case a.trapQueue <- job:
+	default:
+		dropped := a.trapsDropped.Add(1)
+		slog.Warn("SNMP trap queue full, dropping trap",
+			"target", job.target, "group", job.group,
+			"event", job.event, "iface", job.iface, "dropped_total", dropped)
+	}
+}
+
+// trapWorker drains the trap queue, performing the blocking dial/write for each
+// queued trap off the link-monitor goroutine (#2991). A single worker bounds
+// goroutine growth and serializes the slow dials; the queue capacity bounds
+// memory.
+func (a *Agent) trapWorker() {
+	for job := range a.trapQueue {
+		if err := trapSender(job.target, job.pkt); err != nil {
+			slog.Warn("SNMP trap send failed",
+				"target", job.target, "group", job.group,
+				"event", job.event, "iface", job.iface, "err", err)
+		} else {
+			slog.Info("SNMP trap sent",
+				"target", job.target, "group", job.group,
+				"event", job.event, "iface", job.iface, "ifindex", job.ifindex)
+		}
+	}
 }

--- a/pkg/snmp/traps.go
+++ b/pkg/snmp/traps.go
@@ -5,7 +5,10 @@ import (
 	"log/slog"
 	"math/rand"
 	"net"
+	"sort"
 	"time"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // SNMPv2-Trap PDU type (context-specific, constructed, tag 7).
@@ -139,12 +142,7 @@ func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
 		return
 	}
 
-	// Use the first community string for v2c traps.
-	community := "public"
-	for _, c := range cfg.Communities {
-		community = c.Name
-		break
-	}
+	community := selectTrapCommunity(cfg)
 
 	pkt := a.buildLinkTrap(community, linkUp, ifindex, ifname)
 
@@ -153,7 +151,7 @@ func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
 		direction = "up"
 	}
 
-	for _, tg := range cfg.TrapGroups {
+	for _, tg := range sortedTrapGroups(cfg) {
 		for _, target := range tg.Targets {
 			if err := sendTrap(target, pkt); err != nil {
 				slog.Warn("SNMP trap send failed",
@@ -166,4 +164,45 @@ func (a *Agent) sendLinkTraps(linkUp bool, ifindex int, ifname string) {
 			}
 		}
 	}
+}
+
+// selectTrapCommunity picks the v2c trap community deterministically (#2989).
+// SNMPConfig.Communities is a Go map, whose iteration order is randomized, so
+// ranging over it and breaking on the first entry produced a different
+// community per process run when more than one community was configured —
+// collectors that accept only one community saw flaky traps and a less
+// privileged community could leak through the wrong credential boundary. We
+// instead pick the lexicographically-first configured community, a stable and
+// predictable selection. When no community is configured the v2c default
+// "public" is used (the configured set authorizes the trap on the wire and an
+// empty set has no on-wire credential to assert).
+func selectTrapCommunity(cfg *config.SNMPConfig) string {
+	if cfg == nil || len(cfg.Communities) == 0 {
+		return "public"
+	}
+	names := make([]string, 0, len(cfg.Communities))
+	for name := range cfg.Communities {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names[0]
+}
+
+// sortedTrapGroups returns the configured trap groups in deterministic
+// (name-sorted) order. The TrapGroups map iteration order is randomized; a
+// stable order keeps dispatch and log output reproducible.
+func sortedTrapGroups(cfg *config.SNMPConfig) []*config.SNMPTrapGroup {
+	if cfg == nil || len(cfg.TrapGroups) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.TrapGroups))
+	for name := range cfg.TrapGroups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	groups := make([]*config.SNMPTrapGroup, 0, len(names))
+	for _, name := range names {
+		groups = append(groups, cfg.TrapGroups[name])
+	}
+	return groups
 }

--- a/pkg/snmp/traps_async_2991_test.go
+++ b/pkg/snmp/traps_async_2991_test.go
@@ -1,0 +1,119 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestSendLinkTraps_DoesNotBlock is the fail-on-revert guard for #2991. The
+// link monitor calls NotifyLinkUp/Down inline; a real trap sender does a
+// blocking net.DialTimeout (2s) plus DNS resolution for an FQDN target. We
+// inject a deliberately slow sender to model that delay deterministically: with
+// async dispatch the caller returns effectively immediately, while a
+// synchronous revert (calling trapSender inline in sendLinkTraps) would block
+// the caller for the full sender delay × target count. The injected sender is
+// the seam the issue asks for ("a unit test with an injected slow trap
+// sender").
+func TestSendLinkTraps_DoesNotBlock(t *testing.T) {
+	const slow = 2 * time.Second
+	orig := trapSender
+	defer func() { trapSender = orig }()
+	released := make(chan struct{})
+	trapSender = func(target string, pkt []byte) error {
+		// Block until the test releases us (models a hung dial/DNS).
+		<-released
+		return nil
+	}
+	defer close(released)
+
+	agent := &Agent{
+		cfg: &config.SNMPConfig{
+			Communities: map[string]*config.SNMPCommunity{"public": {Name: "public"}},
+			TrapGroups: map[string]*config.SNMPTrapGroup{
+				// Many targets: a synchronous loop would multiply the per-send
+				// stall by the target count.
+				"dead": {Name: "dead", Targets: []string{
+					"192.0.2.1:162", "192.0.2.2:162", "192.0.2.3:162",
+					"192.0.2.4:162", "192.0.2.5:162",
+				}},
+			},
+		},
+		startTime: time.Now(),
+	}
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		agent.NotifyLinkDown(7, "ge-0-0-7")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(start); elapsed >= slow {
+			t.Fatalf("NotifyLinkDown took %v (>= slow sender budget): delivery is not async (#2991)", elapsed)
+		}
+	case <-time.After(slow):
+		t.Fatal("NotifyLinkDown blocked the caller on the slow trap sender: trap delivery is not async (#2991)")
+	}
+}
+
+// TestEnqueueTrap_DropsWhenFull proves the async queue is BOUNDED and drops
+// (incrementing the counter) rather than blocking or growing without limit when
+// the worker cannot keep up. This guards the bound half of #2991.
+func TestEnqueueTrap_DropsWhenFull(t *testing.T) {
+	agent := &Agent{startTime: time.Now()}
+	// Pre-create a full queue WITHOUT a draining worker so every enqueue past
+	// capacity must drop. Mark the once as done so enqueueTrap does not start a
+	// worker that would drain it.
+	agent.trapQueue = make(chan trapJob, 4)
+	agent.trapWorkerOnce.Do(func() {}) // consume the Once so no worker starts
+
+	for i := 0; i < cap(agent.trapQueue); i++ {
+		agent.enqueueTrap(trapJob{target: "192.0.2.9:162", pkt: []byte{1}})
+	}
+	if agent.trapsDropped.Load() != 0 {
+		t.Fatalf("dropped before full: %d", agent.trapsDropped.Load())
+	}
+	for i := 0; i < 10; i++ {
+		agent.enqueueTrap(trapJob{target: "192.0.2.9:162", pkt: []byte{1}})
+	}
+	if got := agent.trapsDropped.Load(); got != 10 {
+		t.Fatalf("trapsDropped = %d, want 10 (bounded queue must drop when full)", got)
+	}
+}
+
+// TestSendLinkTraps_AsyncDelivers confirms async dispatch still delivers to a
+// live target (the worker drains the queue and writes the packet).
+func TestSendLinkTraps_AsyncDelivers(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer pc.Close()
+
+	agent := &Agent{
+		cfg: &config.SNMPConfig{
+			Communities: map[string]*config.SNMPCommunity{"public": {Name: "public"}},
+			TrapGroups: map[string]*config.SNMPTrapGroup{
+				"live": {Name: "live", Targets: []string{pc.LocalAddr().String()}},
+			},
+		},
+		startTime: time.Now(),
+	}
+
+	agent.NotifyLinkUp(2, "ge-0-0-2")
+
+	buf := make([]byte, 4096)
+	pc.SetReadDeadline(time.Now().Add(3 * time.Second))
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("read async trap: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("empty async trap")
+	}
+}

--- a/pkg/snmp/traps_community_2989_test.go
+++ b/pkg/snmp/traps_community_2989_test.go
@@ -1,0 +1,95 @@
+package snmp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestSelectTrapCommunity_Deterministic is the fail-on-revert guard for #2989.
+// With more than one community configured, the trap community MUST be selected
+// deterministically (lexicographically-first), not by ranging the Go map and
+// breaking on a random first entry. Reverting selectTrapCommunity to the
+// map-range-break form makes this flaky/failing: repeated selection over a
+// multi-entry map would not be guaranteed to return the same name, and would
+// not return the sorted-first name.
+func TestSelectTrapCommunity_Deterministic(t *testing.T) {
+	cfg := &config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"zulu":   {Name: "zulu", Authorization: "read-write"},
+			"alpha":  {Name: "alpha", Authorization: "read-only"},
+			"mike":   {Name: "mike", Authorization: "read-only"},
+			"bravo":  {Name: "bravo", Authorization: "read-only"},
+			"oscar":  {Name: "oscar", Authorization: "read-only"},
+			"delta":  {Name: "delta", Authorization: "read-only"},
+			"golf":   {Name: "golf", Authorization: "read-only"},
+			"hotel":  {Name: "hotel", Authorization: "read-only"},
+			"india":  {Name: "india", Authorization: "read-only"},
+			"juliet": {Name: "juliet", Authorization: "read-only"},
+		},
+	}
+
+	// The lexicographically-first name is the documented stable selection.
+	const want = "alpha"
+
+	// Run many times: Go map iteration order is randomized per-range, so a
+	// map-range-break implementation would, with very high probability, return
+	// a non-"alpha" name within these iterations. A deterministic sorted pick
+	// returns "alpha" every time.
+	for i := 0; i < 200; i++ {
+		if got := selectTrapCommunity(cfg); got != want {
+			t.Fatalf("selectTrapCommunity() = %q, want deterministic %q (iteration %d)", got, want, i)
+		}
+	}
+
+	// No communities configured falls back to the v2c default.
+	if got := selectTrapCommunity(&config.SNMPConfig{}); got != "public" {
+		t.Fatalf("selectTrapCommunity(empty) = %q, want %q", got, "public")
+	}
+	if got := selectTrapCommunity(nil); got != "public" {
+		t.Fatalf("selectTrapCommunity(nil) = %q, want %q", got, "public")
+	}
+}
+
+// TestSelectTrapCommunity_UsedByLinkTrap proves the deterministic community
+// actually reaches the wire-built packet, not just the helper. It builds a trap
+// and asserts the on-wire community octet-string equals the sorted-first
+// community.
+func TestSelectTrapCommunity_UsedByLinkTrap(t *testing.T) {
+	cfg := &config.SNMPConfig{
+		Communities: map[string]*config.SNMPCommunity{
+			"zulu":  {Name: "zulu"},
+			"alpha": {Name: "alpha"},
+			"mike":  {Name: "mike"},
+		},
+	}
+	agent := &Agent{startTime: time.Now()}
+	community := selectTrapCommunity(cfg)
+	if community != "alpha" {
+		t.Fatalf("community = %q, want alpha", community)
+	}
+	pkt := agent.buildLinkTrap(community, true, 1, "ge-0-0-0")
+	if !containsBytes(pkt, []byte("alpha")) {
+		t.Fatalf("built trap packet does not carry community %q", community)
+	}
+}
+
+func containsBytes(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #2989, #2990, #2991 — three related SNMP-trap config/delivery bugs from codex-review-058, fixed in one PR (all SNMP trap config/delivery).

## #2989 — deterministic v2c trap community (commit a1eebb69e)
`sendLinkTraps` picked the trap community by ranging `SNMPConfig.Communities` (a Go map) and breaking on the first entry. Map iteration is randomized, so with >1 community configured the trap community was random per run — flaky traps for single-community collectors, and a less-privileged community could leak through the wrong credential boundary. Fixed with `selectTrapCommunity` = lexicographically-first configured community (fallback "public" only when none configured); trap groups iterated sorted too.

**Fail-on-revert:** `TestSelectTrapCommunity_Deterministic` asserts a stable "alpha" across 200 iterations over a 10-entry map (RED on the map-range-break revert: returns "juliet"); `TestSelectTrapCommunity_UsedByLinkTrap` proves it reaches the wire packet.

## #2990 — trap-group schema + commit validation (commit ea280ab26)
`trap-group` had `children: nil`, so the schema gate was opaque and the compiler consumed only `targets`, silently dropping every other child. A typo (`tragets`) committed as a valid zero-target group that sent nothing. Fixed: gave `trap-group` a real schema subtree (targets/version/categories) for completion, and the compiler now rejects unknown trap-group keys (naming the token) and zero-target groups at commit. Targets read via `firewallMatchValues` so bracketed lists accumulate.

**Fail-on-revert:** `TestSNMPTrapGroup_TypoRejected` (the `tragets` typo errors), `TestSNMPTrapGroup_ZeroTargetsRejected`, plus `TestSNMPTrapGroup_ValidAccepted` / `TestSNMPTrapGroup_BracketedTargets` to prove no over-rejection — all RED on the silent-drop revert.

## #2991 — async bounded trap delivery (commit b640d15dd)
Link-state traps were delivered synchronously inline on the netlink link-monitor goroutine; `sendTrap`'s 2s `net.DialTimeout` (plus DNS for FQDN targets) × target count stalled link processing on a dead/slow target. Fixed: `sendLinkTraps` enqueues pre-built packets onto a bounded channel (depth 256) drained by a single worker goroutine; full queue drops + increments `trapsDropped`. `trapSender` package-var seam for injection.

**Fail-on-revert:** `TestSendLinkTraps_DoesNotBlock` injects a blocking sender and asserts the caller returns under the per-send budget (RED — 2s timeout — on a synchronous-inline revert); `TestEnqueueTrap_DropsWhenFull` proves the bound; `TestSendLinkTraps_AsyncDelivers` confirms live delivery.

## Gates (foreground)
- `go build ./...` — OK
- `go vet ./pkg/snmp ./pkg/config ./pkg/daemon` — clean
- `gofmt -l` on all touched files — clean
- `go test ./pkg/snmp ./pkg/config ./pkg/daemon` — pass

Docs: `pkg/snmp/README.md` updated (async delivery + deterministic community); `_Log.md` entries added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi