### PR TITLE
config,dataplane: apply Junos default syn-flood attack-threshold (#3024)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -18381,3 +18381,31 @@ top.
   go test ./pkg/dhcprelay/... ok.
 - **File(s)**: pkg/dhcprelay/relay.go, pkg/dhcprelay/relay_test.go,
   pkg/dhcprelay/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #3024 syn-flood default attack-threshold — when a `tcp syn-flood`
+  screen was enabled WITHOUT an explicit `attack-threshold`, AttackThreshold
+  stayed 0 and the dataplane gate in pkg/dataplane/compiler_iface.go
+  (buildScreenConfig) required `AttackThreshold > 0`, so it never set
+  ScreenSynFlood — SYN-flood protection (and the nested syn-cookie challenge)
+  was silently disabled even though the operator configured it. Matching Junos
+  SRX, the fix applies the default of 200 SYN segments/second when
+  attack-threshold is unset. Two layers: (1) the config compiler
+  (compileScreen in pkg/config/compiler_security.go) seeds
+  defaultSynFloodAttackThreshold=200 at parse time when sf.AttackThreshold<=0;
+  (2) buildScreenConfig now arms whenever profile.TCP.SynFlood != nil and
+  applies the same 200 default defensively if a zero/unset threshold reaches
+  the dataplane. An explicitly-configured attack-threshold is preserved (never
+  overridden). Fail-on-revert tests:
+  pkg/config TestSynFloodDefaultAttackThreshold (syn-flood with only
+  destination-threshold compiles to threshold=200) +
+  TestSynFloodExplicitAttackThresholdPreserved (explicit 1500 kept), and
+  pkg/dataplane TestBuildScreenConfig case "unset attack-threshold defaults
+  and enables". Verified RED by reverting both gates (config seed removed +
+  dataplane gate back to `> 0`): config test got AttackThreshold=0, dataplane
+  test got Flags=0/Thresh=0. Gates: go build ./... OK, gofmt clean (touched
+  files), go vet ./pkg/config/... OK, go test ./pkg/config/... 1492 pass,
+  go test ./pkg/dataplane/ -run TestBuildScreenConfig pass.
+- **File(s)**: pkg/config/compiler_security.go,
+  pkg/config/parser_security_test.go, pkg/dataplane/compiler_iface.go,
+  pkg/dataplane/compiler_test.go, docs/syn-cookie-flood-protection.md, _Log.md

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -25,6 +25,20 @@ exceeded:
 - **Without syn-cookie mode:** SYNs are dropped (existing behavior)
 - **With syn-cookie mode:** SYNs trigger the cookie challenge instead of being dropped
 
+### Default attack-threshold (#3024)
+
+Matching Junos SRX, a `tcp syn-flood` screen that is enabled WITHOUT an
+explicit `attack-threshold` arms at the default of **200 SYN segments/second**.
+Configuring syn-flood with only `destination-threshold`, `source-threshold`,
+`alarm-threshold`, or `timeout` (no `attack-threshold`) still enables the
+screen — and the nested syn-cookie challenge — at that default rate. The
+config compiler seeds the default at parse time
+(`defaultSynFloodAttackThreshold` in `pkg/config/compiler_security.go`); the
+dataplane gate in `pkg/dataplane/compiler_iface.go` (`buildScreenConfig`)
+applies the same default defensively. Previously the dataplane gate required
+`AttackThreshold > 0`, so an unset attack-threshold silently left SYN-flood
+protection disabled even when configured.
+
 ## Algorithm
 
 ```

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -21,6 +21,14 @@ import (
 // userspace-dp/src/screen/scan.rs (= maxScanSweepThreshold + 1).
 const maxScanSweepThreshold = 1023
 
+// defaultSynFloodAttackThreshold is the Junos SRX default attack-threshold
+// (SYN segments per second) applied when a syn-flood screen is enabled
+// without an explicit `attack-threshold`. Matching Junos, configuring
+// syn-flood with only source/destination-threshold or timeout still arms
+// the screen at this rate. See pkg/config/compiler_security.go syn-flood
+// parse and the dataplane gate in pkg/dataplane/compiler_iface.go (#3024).
+const defaultSynFloodAttackThreshold = 200
+
 // validateScreenScanSweepThresholds emits a WARNING (never a hard reject) for
 // any screen profile whose port-scan or ip-sweep threshold exceeds
 // maxScanSweepThreshold. The dataplane clamps the effective threshold to that
@@ -442,6 +450,16 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 								sf.Timeout = n
 							}
 						}
+					}
+					// Junos applies a default attack-threshold of 200
+					// SYN segments/second when syn-flood screening is
+					// enabled without an explicit attack-threshold. Without
+					// this fallback the downstream dataplane gate (which
+					// requires AttackThreshold > 0) would silently leave
+					// SYN-flood protection — including syn-cookie — disabled
+					// even though the operator configured it (#3024).
+					if sf.AttackThreshold <= 0 {
+						sf.AttackThreshold = defaultSynFloodAttackThreshold
 					}
 					profile.TCP.SynFlood = sf
 				case "port-scan":

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -2834,6 +2834,64 @@ func TestScreenSetSyntax(t *testing.T) {
 	}
 }
 
+// TestSynFloodDefaultAttackThreshold is a fail-on-revert guard for #3024: a
+// syn-flood screen enabled WITHOUT an explicit attack-threshold must compile to
+// the Junos default of 200 SYN segments/second, not 0. A zero attack-threshold
+// is the value the dataplane gate (pkg/dataplane/compiler_iface.go) treated as
+// "disabled" — leaving SYN-flood protection (and nested syn-cookie) silently
+// off even though the operator configured it. RED if the parse-time default in
+// pkg/config/compiler_security.go is reverted.
+func TestSynFloodDefaultAttackThreshold(t *testing.T) {
+	tree := &ConfigTree{}
+	// syn-flood enabled with only destination-threshold + timeout — NO
+	// explicit attack-threshold (the bug's trigger).
+	for _, cmd := range []string{
+		"set security screen ids-option untrust-screen tcp syn-flood destination-threshold 4000",
+		"set security screen ids-option untrust-screen tcp syn-flood timeout 20",
+	} {
+		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	profile := cfg.Security.Screen["untrust-screen"]
+	if profile == nil || profile.TCP.SynFlood == nil {
+		t.Fatal("syn-flood profile not found")
+	}
+	if profile.TCP.SynFlood.AttackThreshold != defaultSynFloodAttackThreshold {
+		t.Errorf("AttackThreshold = %d, want default %d",
+			profile.TCP.SynFlood.AttackThreshold, defaultSynFloodAttackThreshold)
+	}
+	if profile.TCP.SynFlood.DestinationThreshold != 4000 {
+		t.Errorf("DestinationThreshold = %d, want 4000",
+			profile.TCP.SynFlood.DestinationThreshold)
+	}
+}
+
+// TestSynFloodExplicitAttackThresholdPreserved guards that the #3024 default
+// does NOT override an operator-supplied attack-threshold.
+func TestSynFloodExplicitAttackThresholdPreserved(t *testing.T) {
+	tree := &ConfigTree{}
+	if err := tree.SetPath(strings.Fields("security screen ids-option untrust-screen tcp syn-flood attack-threshold 1500")); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	profile := cfg.Security.Screen["untrust-screen"]
+	if profile == nil || profile.TCP.SynFlood == nil {
+		t.Fatal("syn-flood profile not found")
+	}
+	if profile.TCP.SynFlood.AttackThreshold != 1500 {
+		t.Errorf("AttackThreshold = %d, want explicit 1500 (default must not override)",
+			profile.TCP.SynFlood.AttackThreshold)
+	}
+}
+
 func TestNATSourceSetSyntax(t *testing.T) {
 	tree := &ConfigTree{}
 	for _, cmd := range []string{"set security nat source pool snat-pool address 203.0.113.0/24", "set security nat source rule-set trust-to-untrust from zone trust", "set security nat source rule-set trust-to-untrust to zone untrust", "set security nat source rule-set trust-to-untrust rule snat-rule match source-address 10.0.0.0/8", "set security nat source rule-set trust-to-untrust rule snat-rule then source-nat interface"} {

--- a/pkg/dataplane/compiler_iface.go
+++ b/pkg/dataplane/compiler_iface.go
@@ -13,6 +13,13 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// defaultSynFloodAttackThreshold is the Junos SRX default attack-threshold
+// (SYN segments per second) used when a syn-flood screen is enabled without an
+// explicit attack-threshold. The config compiler seeds this at parse time; the
+// buildScreenConfig gate also applies it defensively (#3024). MUST match
+// pkg/config defaultSynFloodAttackThreshold.
+const defaultSynFloodAttackThreshold = 200
+
 // protectedInterfaceResolver returns the #1922 management protected set — the
 // interfaces (fxp0, the lifeline NIC, an explicit `system
 // management-interface` leaf) that the reconcile path must NEVER mark
@@ -1281,9 +1288,20 @@ func buildScreenConfig(profile *config.ScreenProfile, synCookie bool) ScreenConf
 	if profile.IP.TearDrop {
 		sc.Flags |= ScreenTearDrop
 	}
-	if profile.TCP.SynFlood != nil && profile.TCP.SynFlood.AttackThreshold > 0 {
+	if profile.TCP.SynFlood != nil {
+		// SYN-flood screening is armed whenever the operator configures
+		// `tcp syn-flood`, even without an explicit attack-threshold. The
+		// config compiler seeds the Junos default (200 SYN seg/s) at parse
+		// time (defaultSynFloodAttackThreshold in pkg/config); this gate is
+		// defensive so a SynFloodConfig that reaches the dataplane with a
+		// zero/unset attack-threshold still arms the screen (and syn-cookie)
+		// at the default rather than silently disabling protection (#3024).
 		sc.Flags |= ScreenSynFlood
-		sc.SynFloodThresh = uint32(profile.TCP.SynFlood.AttackThreshold)
+		thresh := profile.TCP.SynFlood.AttackThreshold
+		if thresh <= 0 {
+			thresh = defaultSynFloodAttackThreshold
+		}
+		sc.SynFloodThresh = uint32(thresh)
 		if profile.TCP.SynFlood.SourceThreshold > 0 {
 			sc.SynFloodSrcThresh = uint32(profile.TCP.SynFlood.SourceThreshold)
 		}

--- a/pkg/dataplane/compiler_test.go
+++ b/pkg/dataplane/compiler_test.go
@@ -443,6 +443,22 @@ func TestBuildScreenConfig(t *testing.T) {
 				SynFloodTimeout: 5,
 			},
 		},
+		{
+			// #3024 fail-on-revert: a syn-flood profile that reaches the
+			// dataplane with attack-threshold unset (0) — e.g. configured
+			// with only destination-threshold — must still ARM the screen
+			// at the Junos default of 200, not be silently disabled by the
+			// old `AttackThreshold > 0` gate. RED if the gate reverts.
+			name: "unset attack-threshold defaults and enables",
+			sf: &config.SynFloodConfig{
+				DestinationThreshold: 4000,
+			},
+			expect: ScreenConfig{
+				Flags:             ScreenSynFlood,
+				SynFloodThresh:    defaultSynFloodAttackThreshold,
+				SynFloodDstThresh: 4000,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

A `tcp syn-flood` screen enabled **without** an explicit `attack-threshold` left `AttackThreshold` at 0. The dataplane gate in `buildScreenConfig` (`pkg/dataplane/compiler_iface.go`) required `AttackThreshold > 0` before setting the `ScreenSynFlood` flag, so an operator who configured syn-flood with only `destination-threshold`, `source-threshold`, `alarm-threshold`, or `timeout` got SYN-flood protection **silently disabled** — including the nested syn-cookie challenge.

## Fix

Matching Junos SRX, a syn-flood screen with no explicit attack-threshold arms at the default of **200 SYN segments/second**. Two layers:

- **Config compiler** (`compileScreen`, `pkg/config/compiler_security.go`): seeds `defaultSynFloodAttackThreshold = 200` at parse time when the parsed attack-threshold is `<= 0`.
- **Dataplane gate** (`buildScreenConfig`): arms whenever `profile.TCP.SynFlood != nil` and applies the same 200 default defensively if a zero/unset threshold reaches the dataplane, instead of gating on `AttackThreshold > 0`.

An explicitly configured attack-threshold is **preserved** and never overridden.

## Fail-on-revert tests

- `pkg/config` `TestSynFloodDefaultAttackThreshold` — syn-flood with only destination-threshold + timeout compiles to `AttackThreshold == 200`.
- `pkg/config` `TestSynFloodExplicitAttackThresholdPreserved` — an explicit `attack-threshold 1500` survives compilation (default does not override).
- `pkg/dataplane` `TestBuildScreenConfig` case `"unset attack-threshold defaults and enables"` — a `SynFloodConfig` with only `DestinationThreshold` yields `Flags=ScreenSynFlood`, `SynFloodThresh=200`.

**Verified RED on revert:** removing the compiler seed + restoring the `> 0` dataplane gate makes the config test report `AttackThreshold=0` and the dataplane test report `Flags=0, SynFloodThresh=0`. Restored → green.

## Validation

- `go build ./...` OK
- `gofmt -l` clean on touched files
- `go vet ./pkg/config/...` OK
- `go test ./pkg/config/...` — 1492 pass
- `go test ./pkg/dataplane/ -run TestBuildScreenConfig` — pass

Docs: `docs/syn-cookie-flood-protection.md` updated with the default attack-threshold behavior.

Closes #3024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi