### PR TITLE
Closes #3021, #3022, #3026

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -18535,3 +18535,26 @@ top.
   userspace-dp/src/afxdp/poll_stages.rs, userspace-dp/src/afxdp/icmp.rs,
   userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
   userspace-dp/src/afxdp/README.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #3021/#3026 review follow-up (MERGE-NEEDS-MINOR, test strength
+  only — production fix unchanged) — upgrade the #3021 and #3026 counterfactual
+  pins to LITERAL fail-on-revert tests driving the real production call sites.
+  #3021: poll_descriptor_policy_deny_keys_logical_ingress_zone_3021 drives
+  poll_binding_process_descriptor with the deny path ingressing on a VLAN
+  sub-interface (logical ifindex 13, zone lan) on parent 11 (zone wan), and
+  asserts the emitted PolicyDeny event.ingress_zone_id == lan. Reverting the
+  production site to meta.ingress_ifindex reports wan -> RED (verified, panic
+  at the ingress_zone_id assert). #3026:
+  build_local_time_exceeded_request_classifies_on_logical_egress_3026 drives
+  build_local_time_exceeded_request with a VLAN egress where the LOGICAL unit
+  (ifindex 12) carries an output `then discard protocol icmp` filter but the
+  physical parent (bind_ifindex 11) does not, and asserts request.is_none() +
+  time_exceeded_output_filter_drops == 1. Reverting the production site to
+  target_ifindex classifies on the unfiltered parent -> admits -> RED
+  (verified, panic at request.is_none()). The original counterfactual pins
+  are retained as additional coverage. The #3022 literal test from the prior
+  round is unchanged. Gates: cargo build --release clean; zone_pair 9,
+  screen 137, classify_generated_reply 6, poll_descriptor 24 all green; full
+  bins 2919 passed + the same pre-existing worker_queue flake.
+- **File(s)**: userspace-dp/src/afxdp/tests.rs, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -18507,3 +18507,31 @@ top.
 - **File(s)**: pkg/config/compiler_security.go,
   pkg/config/parser_security_test.go, pkg/dataplane/compiler_iface.go,
   pkg/dataplane/compiler_test.go, docs/syn-cookie-flood-protection.md, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #3021/#3022/#3026 — route VLAN sub-interface ingress through
+  the `resolve_ingress_logical_ifindex` SSOT for zone-pair policy (#3021),
+  screen/SYN-cookie zone lookup (#3022), and generated-ICMP CoS/filter
+  classify (#3026). `ifindex_to_zone_id` and `forwarding.egress` are keyed
+  by the LOGICAL unit ifindex; the physical parent only inherits its first
+  sub-interface's zone, so a parent carrying multiple VLAN units in distinct
+  zones evaluated the wrong policy/screen/CoS for every unit but the first.
+  All three sites now mirror the filter/cos call sites: resolve
+  (parent, vlan) -> logical, fall back to meta.ingress_ifindex when no
+  entry (untagged == physical == logical, no-op). icmp.rs still uses the
+  physical target_ifindex for the XSK transmit. Added three fail-on-revert
+  tests: screen_zone_lookup_uses_logical_ingress_ifindex_3022 LITERALLY
+  drives stage_screen_check with a lan-only source-route profile on a
+  VID-50/lan unit (verified RED when reverted to meta.ingress_ifindex —
+  resolves zone wan, no profile, Pass); forwarding_zone_pair_…_3021 and
+  classify_generated_reply_uses_logical_egress_ifindex_3026 are
+  counterfactual pins (assert logical-keyed vs physical-keyed verdicts
+  diverge, the project's accepted idiom for helper-keyed call sites that a
+  unit test cannot reach). Gates: cargo build --release clean (0 errors);
+  full bins suite 2917 passed + 1 PRE-EXISTING flake
+  (worker_queue::concurrent_recovery_processes_each_command, passes 3/3 in
+  isolation, unrelated to this change).
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/poll_stages.rs, userspace-dp/src/afxdp/icmp.rs,
+  userspace-dp/src/afxdp/tx/cos_classify_tests.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -56,6 +56,35 @@ sync.
     ifindex (no drop). Two VLANs on one physical port resolve to distinct
     logical ifindexes, so a same-IP-different-subnet neighbor never
     collides in the cache.
+  - **Same SSOT for zone / screen / generated-ICMP keying (`#3021` /
+    `#3022` / `#3026`):** every per-ingress map keyed by the LOGICAL unit
+    ifindex must resolve `(parent, vlan) -> logical` through
+    `resolve_ingress_logical_ifindex` before indexing — not pass the raw
+    `meta.ingress_ifindex`. `ifindex_to_zone_id` is keyed by the logical
+    unit (`forwarding_build/interfaces.rs:76`); the physical parent ifindex
+    only ever inherits its FIRST sub-interface's zone (lines 77-86), so a
+    parent carrying multiple VLAN units in distinct zones would evaluate the
+    wrong zone for every unit but the first. The three sites now mirror the
+    filter (`poll_descriptor/filter.rs`) and CoS (`tx/cos_classify.rs`)
+    call sites:
+      - **#3021 — forwarding zone-pair:** both `from_zone` derivations in
+        `poll_descriptor/mod.rs::poll_binding_process_descriptor` resolve
+        the logical ingress ifindex before
+        `zone_pair_ids_for_flow_with_override`, so a VLAN sub-interface is
+        policed under its OWN ingress zone-pair.
+      - **#3022 — screen / SYN-cookie:** `stage_screen_check` and
+        `stage_screen_syn_cookie_ack_on_session_miss` resolve the logical
+        ifindex before the `ifindex_to_zone_id` lookup, so the correct
+        screen profile applies (a parent-zone miss would otherwise SKIP
+        screening entirely, or apply the wrong profile).
+      - **#3026 — generated ICMP error:** `icmp.rs` classifies the
+        generated reply (CoS queue / DSCP rewrite / output filter) on the
+        LOGICAL egress unit ifindex (`ingress_ident.ifindex`, the key for
+        `forwarding.egress`), NOT the physical `target_ifindex` /
+        `bind_ifindex`. `target_ifindex` (physical) is still used for the
+        XSK transmit.
+    Untagged ports resolve physical == logical, so all four sites are
+    no-ops there (non-VLAN behavior preserved).
   - **NA validation (`#2368`, RFC 4861 §7.1.2 / RFC 4443):** before an
     NA learns a Target Link-Layer Address, `parse_ndp_neighbor_advert`
     enforces the §7.1.2 MUSTs — IPv6 Hop Limit == 255 (the off-link

--- a/userspace-dp/src/afxdp/icmp.rs
+++ b/userspace-dp/src/afxdp/icmp.rs
@@ -211,16 +211,24 @@ pub(super) fn build_local_time_exceeded_request(
 
     let now_ns = monotonic_nanos();
     // #2238: classify the GENERATED ICMP/ICMPv6 error by its OWN egress
-    // 5-tuple + the resolved egress interface (`target_ifindex`, which
-    // accounts for `bind_ifindex`), NOT the triggering inbound packet's
-    // tuple/ingress. Pre-#2238 this called
-    // `resolve_cos_tx_selection_at(.., meta, flow.forward_key, ..)` — the
-    // trigger — on `ingress_ident.ifindex`, so an output filter matching the
-    // generated ICMP tuple never fired, and an output filter matching the
-    // original TCP/UDP flow could wrongly drop the ICMP error. A parse
-    // failure of our own built bytes fails CLOSED (drop + dedicated
-    // counter, §6.2).
-    let verdict = classify_generated_reply(forwarding, target_ifindex, &prebuilt_frame, now_ns);
+    // 5-tuple, NOT the triggering inbound packet's tuple/ingress. Pre-#2238
+    // this called `resolve_cos_tx_selection_at(.., meta, flow.forward_key,
+    // ..)` — the trigger — so an output filter matching the generated ICMP
+    // tuple never fired, and an output filter matching the original TCP/UDP
+    // flow could wrongly drop the ICMP error. A parse failure of our own
+    // built bytes fails CLOSED (drop + dedicated counter, §6.2).
+    //
+    // #3026: classify on the LOGICAL egress ifindex (`ingress_ident.ifindex`,
+    // the unit ifindex that keys `forwarding.egress`), NOT `target_ifindex`.
+    // CoS interfaces (forwarding_build/cos.rs) and output filters
+    // (filter/compiler.rs) are keyed by the logical unit ifindex; on a VLAN
+    // subinterface `bind_ifindex` (hence `target_ifindex`) is the physical
+    // parent index, so classifying by it missed the subinterface's CoS
+    // queue / DSCP rewrite / output filter. `target_ifindex` (physical) is
+    // still used for the XSK transmit below. For a non-VLAN port the logical
+    // and physical indexes coincide, so this is a no-op there.
+    let verdict =
+        classify_generated_reply(forwarding, ingress_ident.ifindex, &prebuilt_frame, now_ns);
     if verdict.drop {
         counters.touched = true;
         if verdict.parse_error {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -978,9 +978,25 @@ pub(super) fn poll_binding_process_descriptor(
                         // #919/#922: zero-allocation zone-pair resolution
                         // direct from u16 IDs — no String materialisation
                         // on the per-flow miss path.
-                        let (from_zone_id, to_zone_id) = zone_pair_ids_for_flow_with_override(
+                        //
+                        // #3021: resolve the LOGICAL ingress ifindex first.
+                        // `ifindex_to_zone_id` is keyed by the logical unit
+                        // ifindex (forwarding_build/interfaces.rs:76); a VLAN
+                        // subinterface's physical bind ifindex maps only to its
+                        // parent's FIRST-subinterface zone, so the raw physical
+                        // index would evaluate the wrong zone-pair policy on a
+                        // parent carrying multiple VLAN units in distinct zones.
+                        // Mirrors filter.rs / cos_classify.rs; non-VLAN ports
+                        // resolve physical == logical (unchanged).
+                        let ingress_logical = resolve_ingress_logical_ifindex(
                             worker_ctx.forwarding,
                             meta.ingress_ifindex as i32,
+                            meta.ingress_vlan_id,
+                        )
+                        .unwrap_or(meta.ingress_ifindex as i32);
+                        let (from_zone_id, to_zone_id) = zone_pair_ids_for_flow_with_override(
+                            worker_ctx.forwarding,
+                            ingress_logical,
                             ingress_zone_override,
                             resolution.egress_ifindex,
                         );
@@ -2759,9 +2775,20 @@ pub(super) fn poll_binding_process_descriptor(
                             // resolution. Computed at the TOP of the arm so
                             // the #1913 policy gate below can run BEFORE the
                             // negative-cache fast-fail / resolver enqueue.
-                            let (from_zone_id, to_zone_id) = zone_pair_ids_for_flow_with_override(
+                            //
+                            // #3021: resolve the LOGICAL ingress ifindex first
+                            // (see the ForwardCandidate arm above) so a VLAN
+                            // subinterface evaluates its OWN ingress zone, not
+                            // the parent's first-subinterface zone.
+                            let ingress_logical = resolve_ingress_logical_ifindex(
                                 worker_ctx.forwarding,
                                 meta.ingress_ifindex as i32,
+                                meta.ingress_vlan_id,
+                            )
+                            .unwrap_or(meta.ingress_ifindex as i32);
+                            let (from_zone_id, to_zone_id) = zone_pair_ids_for_flow_with_override(
+                                worker_ctx.forwarding,
+                                ingress_logical,
                                 ingress_zone_override,
                                 decision.resolution.egress_ifindex,
                             );

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -290,13 +290,25 @@ pub(super) fn stage_screen_check(
     let Some(flow) = flow else {
         return StageOutcome::Continue(ScreenCheckOutcome::Pass);
     };
+    // #3022: resolve the LOGICAL ingress ifindex before the zone lookup.
+    // `ifindex_to_zone_id` is keyed by the logical unit ifindex; the raw
+    // physical bind ifindex either misses (no zone on the parent → screen
+    // skipped entirely) or returns the parent's first-subinterface zone
+    // (wrong profile), bypassing/mis-applying screen profiles on VLAN
+    // subinterfaces. Non-VLAN ports resolve physical == logical.
+    let logical_ifindex = resolve_ingress_logical_ifindex(
+        worker_ctx.forwarding,
+        meta.ingress_ifindex as i32,
+        meta.ingress_vlan_id,
+    )
+    .unwrap_or(meta.ingress_ifindex as i32);
     let zone_id = ingress_zone_override
         .filter(|id| worker_ctx.forwarding.zone_id_to_name.contains_key(id))
         .or_else(|| {
             worker_ctx
                 .forwarding
                 .ifindex_to_zone_id
-                .get(&(meta.ingress_ifindex as i32))
+                .get(&logical_ifindex)
                 .copied()
         });
     let Some(zone_id) = zone_id else {
@@ -426,13 +438,23 @@ pub(super) fn stage_screen_syn_cookie_ack_on_session_miss(
     let Some(flow) = flow else {
         return StageOutcome::Continue(SynCookieAckOutcome::Pass);
     };
+    // #3022: resolve the LOGICAL ingress ifindex first (see
+    // `stage_screen_check`) so the SYN-cookie-ACK validation uses the VLAN
+    // subinterface's own zone profile, not the parent's first-subinterface
+    // zone. Non-VLAN ports resolve physical == logical.
+    let logical_ifindex = resolve_ingress_logical_ifindex(
+        worker_ctx.forwarding,
+        meta.ingress_ifindex as i32,
+        meta.ingress_vlan_id,
+    )
+    .unwrap_or(meta.ingress_ifindex as i32);
     let zone_id = ingress_zone_override
         .filter(|id| worker_ctx.forwarding.zone_id_to_name.contains_key(id))
         .or_else(|| {
             worker_ctx
                 .forwarding
                 .ifindex_to_zone_id
-                .get(&(meta.ingress_ifindex as i32))
+                .get(&logical_ifindex)
                 .copied()
         });
     let Some(zone_id) = zone_id else {
@@ -1542,5 +1564,233 @@ mod tests {
         assert!(!neighbor_ip_is_learnable(IpAddr::V6(Ipv6Addr::new(
             0xff02, 0, 0, 0, 0, 0, 0, 1
         ))));
+    }
+
+    // ===================================================================
+    // #3021 / #3022 — the ingress ZONE lookup (zone-pair policy for
+    // forwarding, and screen/SYN-cookie zone resolution) must key on the
+    // LOGICAL (VLAN sub-interface) ifindex resolved through
+    // `resolve_ingress_logical_ifindex`, NOT the raw physical
+    // `meta.ingress_ifindex`. `ifindex_to_zone_id` is keyed by the logical
+    // unit ifindex; the parent physical ifindex only ever maps to its
+    // FIRST sub-interface's zone (forwarding_build/interfaces.rs:77), so a
+    // parent carrying two VLAN units in DISTINCT zones would evaluate the
+    // wrong zone — wrong policy (#3021) and the wrong/absent screen
+    // profile (#3022) — for every unit but the first.
+    // ===================================================================
+
+    /// A snapshot with TWO VLAN sub-interfaces on the same physical parent
+    /// (ifindex 11) in DISTINCT zones: `reth0.80` (logical 12, VID 80,
+    /// zone `wan`, the parent's first sub-interface) and `reth0.50`
+    /// (logical 13, VID 50, zone `lan`). The parent ifindex 11 inherits
+    /// only the first sub-interface's zone (`wan`), so a physical-keyed
+    /// lookup for the VID-50 unit returns `wan` instead of its own `lan`.
+    fn two_vlan_distinct_zone_snapshot() -> crate::ConfigSnapshot {
+        let mut snap = super::super::test_fixtures::nat_snapshot();
+        // reth0.80 (logical 12, parent 11, VID 80) is already zone "wan".
+        snap.interfaces.push(crate::InterfaceSnapshot {
+            name: "reth0.50".to_string(),
+            zone: "lan".to_string(),
+            linux_name: "ge-0-0-0.50".to_string(),
+            ifindex: 13,
+            parent_ifindex: 11,
+            redundancy_group: 1,
+            vlan_id: 50,
+            hardware_addr: "02:bf:72:00:50:08".to_string(),
+            addresses: vec![crate::InterfaceAddressSnapshot {
+                family: "inet".to_string(),
+                address: "172.16.50.8/24".to_string(),
+                scope: 0,
+            }],
+            ..Default::default()
+        });
+        snap
+    }
+
+    /// #3021 fail-on-revert. `zone_pair_ids_for_flow_with_override` derives
+    /// the FROM-zone from the ingress ifindex it is handed. The forwarder
+    /// (poll_descriptor/mod.rs) now resolves the logical ifindex first; this
+    /// test proves the VID-50 unit's `from_zone` is its OWN `lan`, and that
+    /// the pre-fix physical-keyed call would return the parent's `wan`. If
+    /// the fix reverts to `meta.ingress_ifindex as i32`, the "correct"
+    /// branch below collapses onto the "pre-fix" value and the distinct-zone
+    /// assert fails RED.
+    #[test]
+    fn forwarding_zone_pair_uses_logical_ingress_ifindex_3021() {
+        use crate::test_zone_ids::{TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID};
+        let forwarding = build_forwarding_state(&two_vlan_distinct_zone_snapshot());
+
+        // Fixture sanity: parent 11 / VID 50 -> logical 13 (zone lan);
+        // parent 11 / VID 80 -> logical 12 (zone wan).
+        assert_eq!(
+            resolve_ingress_logical_ifindex(&forwarding, 11, 50),
+            Some(13),
+            "parent 11 / VLAN 50 must resolve to logical ifindex 13"
+        );
+        assert_eq!(
+            forwarding.ifindex_to_zone_id.get(&13).copied(),
+            Some(TEST_LAN_ZONE_ID),
+            "logical ifindex 13 (reth0.50) is zone lan"
+        );
+
+        // egress is the WAN unit (logical 12) — to_zone is irrelevant here;
+        // we only assert the from_zone (ingress) resolution.
+        let egress_ifindex = 12;
+
+        // Correct (#3021): classify the VID-50 ingress on the LOGICAL
+        // ifindex 13 -> from_zone == lan.
+        let logical = resolve_ingress_logical_ifindex(&forwarding, 11, 50).unwrap();
+        let (from_correct, _) =
+            zone_pair_ids_for_flow_with_override(&forwarding, logical, None, egress_ifindex);
+        assert_eq!(
+            from_correct, TEST_LAN_ZONE_ID,
+            "the VID-50 unit must evaluate its OWN ingress zone (lan)"
+        );
+
+        // Pre-fix: classify on the raw PHYSICAL parent ifindex 11 ->
+        // from_zone == wan (the parent's first-sub-interface zone). This is
+        // the #3021 bug: the VID-50 unit would be policed under wan's
+        // zone-pair, not lan's.
+        let (from_physical, _) =
+            zone_pair_ids_for_flow_with_override(&forwarding, 11, None, egress_ifindex);
+        assert_eq!(
+            from_physical, TEST_WAN_ZONE_ID,
+            "the raw physical parent ifindex 11 wrongly resolves to wan \
+             (the #3021 bug the logical-ifindex resolution fixes)"
+        );
+        assert_ne!(
+            from_correct, from_physical,
+            "logical-keyed (lan) and physical-keyed (wan) FROM-zones must \
+             diverge, proving the fix changes the evaluated zone-pair"
+        );
+    }
+
+    /// #3022 fail-on-revert (literal — drives `stage_screen_check`).
+    /// `source_route_screen()` arms the `ip-source-route` profile ONLY on
+    /// the `lan` zone. A SYN arriving on the VID-50 unit (logical 13, zone
+    /// `lan`, parent physical 11) with an IHL-6 IP header must be DROPPED:
+    /// the stage resolves the logical ifindex 13 -> zone lan -> the armed
+    /// profile fires. If #3022 reverts to `meta.ingress_ifindex` (physical
+    /// 11), the lookup returns the parent's first-sub-interface zone `wan`,
+    /// which has NO profile, the stage returns `Pass`, and the drop assert
+    /// fails RED. The untagged control (logical == physical) still drops,
+    /// keeping the assertion non-tautological / preserving non-VLAN behavior.
+    #[test]
+    fn screen_zone_lookup_uses_logical_ingress_ifindex_3022() {
+        let forwarding = build_forwarding_state(&two_vlan_distinct_zone_snapshot());
+        let ident = BindingIdentity {
+            slot: 0,
+            queue_id: 0,
+            worker_id: 0,
+            interface: Arc::<str>::from("ge-0-0-0"),
+            ifindex: 11,
+        };
+        let binding_lookup = WorkerBindingLookup::default();
+        let mirror_targets = MirrorTargetMap::default();
+        let ha_state = BTreeMap::new();
+        let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+        let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+        let last_resolution = Arc::new(Mutex::new(None));
+        let peer_worker_commands = Vec::new();
+        let dnat_fds = DnatTableFds::default();
+        let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+        let (event_handle, _event_rx) = crate::event_stream::test_worker_handle(
+            8,
+            DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+        );
+        let worker_ctx = WorkerContext {
+            ident: &ident,
+            binding_lookup: &binding_lookup,
+            mirror_targets: &mirror_targets,
+            forwarding: &forwarding,
+            ha_state: &ha_state,
+            dynamic_neighbors: &dynamic_neighbors,
+            neighbor_resolver: None,
+            shared_sessions: &shared_sessions,
+            shared_nat_sessions: &shared_nat_sessions,
+            shared_forward_wire_sessions: &shared_forward_wire_sessions,
+            shared_owner_rg_indexes: &shared_owner_rg_indexes,
+            slow_path: None,
+            event_stream: Some(&event_handle),
+            local_tunnel_deliveries: &local_tunnel_deliveries,
+            recent_exceptions: &recent_exceptions,
+            last_resolution: &last_resolution,
+            peer_worker_commands: &peer_worker_commands,
+            dnat_fds: &dnat_fds,
+            rg_epochs: &rg_epochs,
+            cold_path_sample_mask: 0xff,
+        };
+
+        // Source-route SYN arriving on the VID-50 unit. The shim strips the
+        // VLAN tag and conveys the VID out of band in meta (present=0, l3 at
+        // 14), exactly as the ARP/NDP learn tests model it.
+        let frame = tcp_v4_syn_frame_with_l2(Vlan::None, 6);
+        let mut meta = tcp_v4_syn_meta_with_l2(&frame, Vlan::None);
+        meta.ingress_ifindex = 11; // physical parent
+        meta.ingress_vlan_id = 50; // -> logical 13 (zone lan)
+        let flow = parse_session_flow_from_bytes(&frame, meta)
+            .expect("session flow from source-route SYN");
+
+        let mut screen = source_route_screen();
+        let mut counters = BatchCounters::default();
+        let outcome = stage_screen_check(
+            Some(&flow),
+            &frame,
+            meta,
+            None,
+            TEST_NOW_SECS,
+            &mut screen,
+            &mut counters,
+            &worker_ctx,
+        );
+        assert!(
+            matches!(outcome, StageOutcome::RecycleAndContinue),
+            "the VID-50 unit (logical 13, zone lan) must resolve its OWN \
+             lan screen profile and DROP the source-route SYN (#3022); a \
+             physical-keyed lookup resolves zone wan (no profile) and would \
+             wrongly Pass"
+        );
+        assert_eq!(
+            counters.screen_drops, 1,
+            "exactly one screen drop must be recorded for the VID-50 unit"
+        );
+
+        // Counterfactual / non-VLAN preservation: the SAME source-route SYN
+        // on the UNTAGGED reth1.0 (logical == physical == 24, zone lan) is
+        // also dropped — the resolution is identity there, so the fix does
+        // not change non-VLAN behavior, and the drop above is not a fluke of
+        // a globally-armed profile.
+        let mut frame_untagged = tcp_v4_syn_frame_with_l2(Vlan::None, 6);
+        let _ = &mut frame_untagged;
+        let mut meta_untagged = tcp_v4_syn_meta_with_l2(&frame_untagged, Vlan::None);
+        meta_untagged.ingress_ifindex = 24;
+        meta_untagged.ingress_vlan_id = 0;
+        let flow_untagged = parse_session_flow_from_bytes(&frame_untagged, meta_untagged)
+            .expect("session flow from untagged source-route SYN");
+        let mut screen2 = source_route_screen();
+        let mut counters2 = BatchCounters::default();
+        let outcome_untagged = stage_screen_check(
+            Some(&flow_untagged),
+            &frame_untagged,
+            meta_untagged,
+            None,
+            TEST_NOW_SECS,
+            &mut screen2,
+            &mut counters2,
+            &worker_ctx,
+        );
+        assert!(
+            matches!(outcome_untagged, StageOutcome::RecycleAndContinue),
+            "the untagged reth1.0 unit (logical == physical 24, zone lan) \
+             still drops the source-route SYN — non-VLAN behavior unchanged"
+        );
     }
 }

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -1519,6 +1519,120 @@ fn build_local_time_exceeded_request_ignores_trigger_matching_output_filter() {
     assert_eq!(counters.generated_reply_classify_parse_errors, 0);
 }
 
+/// #3026 LITERAL fail-on-revert. Drives the real
+/// `build_local_time_exceeded_request` with a VLAN egress where the LOGICAL
+/// unit (ifindex 12) carries an output `then discard protocol icmp` filter
+/// but the PHYSICAL parent (bind_ifindex 11) does NOT. The fix classifies the
+/// generated ICMP reply on the LOGICAL egress ifindex (`ingress_ident.ifindex`
+/// = 12), so the filter fires and the reply is dropped. If the production site
+/// is reverted to classify on `target_ifindex` (= egress.bind_ifindex = the
+/// physical parent 11, which has no filter), the reply is NOT dropped, the
+/// builder returns `Some`, and the `request.is_none()` assert fails RED.
+#[test]
+fn build_local_time_exceeded_request_classifies_on_logical_egress_3026() {
+    let client_ip = Ipv4Addr::new(10, 0, 61, 102);
+    let dst_ip = Ipv4Addr::new(1, 1, 1, 1);
+    // TRIGGER is a UDP flow; the generated reply is ICMP (proven elsewhere).
+    let frame = build_udp_frame_v4_full([0x00, 0x25, 0x90, 0x12, 0x34, 0x56], client_ip, dst_ip, 1);
+    let meta = UserspaceDpMeta {
+        l3_offset: 14,
+        l4_offset: 34,
+        ingress_ifindex: 5,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_UDP,
+        pkt_len: 128,
+        ..UserspaceDpMeta::default()
+    };
+    let desc = XdpDesc {
+        addr: 4096,
+        len: frame.len() as u32,
+        options: 0,
+    };
+    // The egress is resolved on the LOGICAL unit ifindex 12 (reth0.80) — the
+    // value the builder uses as ingress_ident.ifindex to key forwarding.egress.
+    let ingress_ident = BindingIdentity {
+        slot: 0,
+        queue_id: 7,
+        worker_id: 0,
+        interface: Arc::<str>::from("reth0.80"),
+        ifindex: 12,
+    };
+    let flow = icmp_suppress_flow_v4(client_ip, dst_ip);
+    // OUTPUT filter on the LOGICAL VLAN unit (ifindex 12) with a terminal
+    // `discard` for `protocol icmp`. The PHYSICAL parent (ifindex 11) is given
+    // NO output filter — so a physical-keyed classification would miss it.
+    let filter_state = crate::filter::parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "drop-icmp-out".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-icmp".into(),
+                action: "discard".into(),
+                protocols: vec!["icmp".into()],
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[crate::InterfaceSnapshot {
+            name: "reth0.80".into(),
+            ifindex: 12,
+            parent_ifindex: 11,
+            vlan_id: 80,
+            filter_output_v4: "drop-icmp-out".into(),
+            ..Default::default()
+        }],
+        "",
+        "",
+    )
+    .expect("filter state compiles");
+    let mut forwarding = ForwardingState {
+        filter_state,
+        tx_selection_enabled_v4: true,
+        ..ForwardingState::default()
+    };
+    // Egress keyed by the LOGICAL ifindex 12; bind_ifindex 11 is the physical
+    // parent (= target_ifindex, the pre-fix classification key).
+    forwarding.egress.insert(
+        12,
+        EgressInterface {
+            bind_ifindex: 11,
+            vlan_id: 80,
+            mtu: 1500,
+            src_mac: [0x02, 0xbf, 0x72, 0x00, 0x80, 0x08],
+            zone_id: TEST_WAN_ZONE_ID,
+            redundancy_group: 1,
+            primary_v4: Some(Ipv4Addr::new(172, 16, 80, 8)),
+            primary_v6: None,
+        },
+    );
+
+    let mut counters = BatchCounters::default();
+    let request = build_local_time_exceeded_request(
+        &frame,
+        desc,
+        meta,
+        &ingress_ident,
+        &flow,
+        &forwarding,
+        &Arc::new(ShardedNeighborMap::new()),
+        &BTreeMap::new(),
+        0,
+        &mut counters,
+    );
+
+    assert!(
+        request.is_none(),
+        "the VLAN unit's OWN output filter (on logical ifindex 12) must drop \
+         the generated ICMP reply (#3026); classifying on the physical parent \
+         (bind_ifindex 11, no filter) would wrongly admit it"
+    );
+    assert_eq!(
+        counters.time_exceeded_output_filter_drops, 1,
+        "the logical-egress output-filter drop must land on the TE counter"
+    );
+    assert_eq!(counters.generated_reply_classify_parse_errors, 0);
+}
+
 /// Build a `ForwardingState.filter_state` with a single egress (output) v4
 /// firewall filter on ifindex 5 carrying one term (#2238 test helper).
 fn build_output_filter_state(
@@ -4169,6 +4283,238 @@ fn poll_descriptor_policy_deny_path_emits_rt_flow_event() {
     );
     assert_eq!(event_handle.dataplane_event_stats().policy_deny.sent, 1);
     assert!(telemetry.dbg.policy_deny >= 1);
+}
+
+/// #3021 LITERAL fail-on-revert. Drives the real
+/// `poll_binding_process_descriptor` deny path with the ingress on a VLAN
+/// SUB-INTERFACE whose LOGICAL unit (ifindex 13, zone `lan`) is in a
+/// DIFFERENT zone than its physical parent (ifindex 11, zone `wan` — the
+/// parent inherits its FIRST sub-interface reth0.80's wan zone). The emitted
+/// PolicyDeny event's `ingress_zone_id` is the from-zone the zone-pair
+/// lookup resolves. The #3021 fix resolves the logical ifindex 13 -> `lan`,
+/// so the event reports lan. If the production site is reverted to
+/// `meta.ingress_ifindex` (physical 11), the lookup resolves the parent's
+/// `wan` zone and the `ingress_zone_id == TEST_LAN_ZONE_ID` assert fails RED.
+/// (Both lan->wan and wan->wan are denied by the deny default — only dmz->wan
+/// is permitted — so the deny event fires either way; only the reported
+/// ingress zone distinguishes the fix from the bug.)
+#[test]
+fn poll_descriptor_policy_deny_keys_logical_ingress_zone_3021() {
+    let mut snapshot = policy_deny_snapshot();
+    snapshot.zones = vec![
+        ZoneSnapshot {
+            name: "lan".to_string(),
+            id: TEST_LAN_ZONE_ID,
+        },
+        ZoneSnapshot {
+            name: "wan".to_string(),
+            id: TEST_WAN_ZONE_ID,
+        },
+        ZoneSnapshot {
+            name: "dmz".to_string(),
+            id: TEST_DMZ_ZONE_ID,
+        },
+    ];
+    // Add a SECOND VLAN sub-interface (logical ifindex 13, VID 50) on the
+    // SAME physical parent (ifindex 11) as reth0.80, but in zone `lan`. The
+    // parent ifindex 11 keeps reth0.80's wan zone (first sub-interface),
+    // so the logical (13->lan) and physical (11->wan) ingress zones diverge.
+    snapshot.interfaces.push(crate::InterfaceSnapshot {
+        name: "reth0.50".to_string(),
+        zone: "lan".to_string(),
+        linux_name: "ge-0-0-0.50".to_string(),
+        ifindex: 13,
+        parent_ifindex: 11,
+        vlan_id: 50,
+        hardware_addr: "02:bf:72:00:50:08".to_string(),
+        addresses: vec![crate::InterfaceAddressSnapshot {
+            family: "inet".to_string(),
+            address: "172.16.50.8/24".to_string(),
+            scope: 0,
+        }],
+        ..Default::default()
+    });
+    snapshot.neighbors = vec![NeighborSnapshot {
+        interface: "ge-0-0-0.80".to_string(),
+        ifindex: 12,
+        family: "inet".to_string(),
+        ip: "172.16.80.200".to_string(),
+        mac: "00:aa:bb:cc:dd:ee".to_string(),
+        state: "reachable".to_string(),
+        router: false,
+        link_local: false,
+    }];
+
+    let forwarding = build_forwarding_state(&snapshot);
+    // Sanity: the fixture really maps (parent 11, VID 50) -> logical 13 (lan)
+    // while the physical parent 11 resolves to wan.
+    assert_eq!(
+        crate::afxdp::forwarding::resolve_ingress_logical_ifindex(&forwarding, 11, 50),
+        Some(13),
+        "fixture must map parent 11 / VLAN 50 -> logical ifindex 13"
+    );
+    assert_eq!(
+        forwarding.ifindex_to_zone_id.get(&13).copied(),
+        Some(TEST_LAN_ZONE_ID),
+        "logical ifindex 13 (reth0.50) is zone lan"
+    );
+    assert_eq!(
+        forwarding.ifindex_to_zone_id.get(&11).copied(),
+        Some(TEST_WAN_ZONE_ID),
+        "physical parent ifindex 11 inherits reth0.80's wan zone"
+    );
+
+    // The physical port the VLAN sub-interface rides on is ifindex 11.
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 11, 0);
+    binding.interface = Arc::<str>::from("ge-0-0-0");
+    let frame = build_policy_deny_tcp_syn_frame();
+    let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+    let frame_offset = 128;
+    let meta_offset = frame_offset - meta_len;
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: meta_len as u16,
+        // Physical parent + out-of-band VID (the shim strips the tag and
+        // conveys the VID in meta; the frame stays untagged so l3 is at 14).
+        ingress_ifindex: 11,
+        ingress_vlan_id: 50,
+        ingress_vlan_present: 0,
+        l3_offset: 14,
+        l4_offset: 34,
+        payload_offset: 54,
+        pkt_len: (frame.len() - 14) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    };
+    let meta_bytes = unsafe {
+        std::slice::from_raw_parts((&meta as *const UserspaceDpMeta).cast::<u8>(), meta_len)
+    };
+    unsafe {
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(meta_offset, meta_len)
+            .expect("meta slice")
+            .copy_from_slice(meta_bytes);
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(frame_offset, frame.len())
+            .expect("frame slice")
+            .copy_from_slice(&frame);
+    }
+    binding.xsk.rx.push_for_test(XdpDesc {
+        addr: frame_offset as u64,
+        len: frame.len() as u32,
+        options: 0,
+    });
+
+    let ident = binding.identity();
+    let binding_lookup = WorkerBindingLookup::from_bindings(std::slice::from_ref(&binding));
+    let mirror_targets = MirrorTargetMap::default();
+    let ha_state = BTreeMap::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding: &forwarding,
+        ha_state: &ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        neighbor_resolver: None,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+        cold_path_sample_mask: 0xff,
+    };
+    let mut sessions = SessionTable::new();
+    let mut screen = ScreenState::new();
+    let mut batch = BatchCounters::default();
+    let mut dbg = DebugPollCounters::default();
+    let mut telemetry = TelemetryContext {
+        dbg: &mut dbg,
+        counters: &mut batch,
+    };
+    let area_ptr = binding.umem.area() as *const MmapArea;
+
+    poll_binding_process_descriptor(
+        &mut binding,
+        0,
+        area_ptr,
+        1,
+        &mut sessions,
+        &mut screen,
+        ValidationState {
+            snapshot_installed: true,
+            config_generation: 7,
+            fib_generation: 9,
+        },
+        123_000_000_000,
+        123,
+        0,
+        0,
+        -1,
+        -1,
+        &worker_ctx,
+        &mut telemetry,
+    );
+
+    let event = event_rx
+        .try_recv()
+        .expect("policy-deny event from poll descriptor")
+        .decode_dataplane_event()
+        .expect("policy-deny payload");
+    assert_eq!(
+        event.kind,
+        crate::event_stream::codec::DataplaneEventKind::PolicyDeny
+    );
+    // The load-bearing assert: the deny event's ingress zone is the LOGICAL
+    // sub-interface zone (lan, ifindex 13), NOT the physical parent's wan
+    // (ifindex 11). Reverting the production site to meta.ingress_ifindex
+    // makes this report wan and the test fails RED.
+    assert_eq!(
+        event.ingress_zone_id, TEST_LAN_ZONE_ID,
+        "the VLAN sub-interface's OWN logical ingress zone (lan) must drive \
+         the zone-pair policy (#3021); a physical-keyed lookup reports wan"
+    );
+    assert_ne!(
+        event.ingress_zone_id, TEST_WAN_ZONE_ID,
+        "the physical parent's wan zone must NOT be used for the VLAN unit"
+    );
+    assert_eq!(event.egress_zone_id, TEST_WAN_ZONE_ID);
+    assert_eq!(event.ingress_ifindex, 11);
+    assert_eq!(event_handle.dataplane_event_stats().policy_deny.sent, 1);
 }
 
 /// #2617 harness: drive a single LAN→WAN TCP-SYN session-miss packet through

--- a/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
+++ b/userspace-dp/src/afxdp/tx/cos_classify_tests.rs
@@ -2549,6 +2549,101 @@ fn classify_generated_reply_drops_icmp_on_terminal_discard() {
 }
 
 #[test]
+fn classify_generated_reply_uses_logical_egress_ifindex_3026() {
+    // #3026 fail-on-revert. A generated ICMP error leaving a VLAN
+    // sub-interface must be classified (CoS / output filter) on the LOGICAL
+    // egress unit ifindex (`ingress_ident.ifindex`), NOT the physical
+    // `target_ifindex` (= bind_ifindex = the parent). Output filters and CoS
+    // are keyed by the logical unit ifindex; the physical parent carries no
+    // filter, so classifying by it would silently leak the reply past the
+    // operator's `then discard protocol icmp`.
+    //
+    // Fixture: reth0.80 is the LOGICAL unit (ifindex 202, parent 11, VID 80)
+    // and carries the ICMP-discard output filter; the physical parent 11 has
+    // NO filter.
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth0.80".into(),
+            ifindex: 202,
+            parent_ifindex: 11,
+            vlan_id: 80,
+            hardware_addr: "02:bf:72:00:80:08".into(),
+            filter_output_v4: "drop-icmp".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "drop-icmp".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-icmp".into(),
+                action: "discard".into(),
+                protocols: vec!["icmp".into()],
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let forwarding = build_forwarding_state(&snapshot);
+    let frame = generated_v4_frame(PROTO_ICMP, 0x00, 0, 0);
+
+    // Correct (#3026): classify on the LOGICAL egress ifindex 202 -> the
+    // output filter matches the generated ICMP and drops it.
+    let correct = classify_generated_reply(&forwarding, 202, &frame, 0);
+    assert!(
+        correct.drop,
+        "the generated ICMP reply must be dropped by the VLAN unit's own \
+         output filter (classified on the logical egress ifindex 202)"
+    );
+
+    // Pre-fix: classify on the raw PHYSICAL parent ifindex 11. The parent
+    // carries no output filter, so the reply is NOT dropped — it leaks past
+    // the operator's `then discard protocol icmp` (the #3026 bug). If the
+    // fix reverts to `target_ifindex` (physical), the `correct` branch above
+    // collapses onto this value and the drop assert fails RED.
+    let physical = classify_generated_reply(&forwarding, 11, &frame, 0);
+    assert!(
+        !physical.drop,
+        "the physical parent ifindex 11 has no filter, so a physical-keyed \
+         classification would WRONGLY admit the reply (the #3026 bug)"
+    );
+    assert_ne!(
+        correct.drop, physical.drop,
+        "logical-keyed (drop) vs physical-keyed (admit) verdicts must \
+         diverge, proving the fix changes the classification interface"
+    );
+
+    // Non-VLAN preservation: an interface that IS the bind ifindex (logical
+    // == physical) classifies identically regardless. reth1.0 below has no
+    // parent, so ifindex 24 is both the logical unit and the bind ifindex.
+    let untagged = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "reth1.0".into(),
+            ifindex: 24,
+            hardware_addr: "02:bf:72:01:00:01".into(),
+            filter_output_v4: "drop-icmp".into(),
+            ..Default::default()
+        }],
+        filters: vec![FirewallFilterSnapshot {
+            name: "drop-icmp".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "drop-icmp".into(),
+                action: "discard".into(),
+                protocols: vec!["icmp".into()],
+                ..Default::default()
+            }],
+        }],
+        ..Default::default()
+    };
+    let untagged_fwd = build_forwarding_state(&untagged);
+    assert!(
+        classify_generated_reply(&untagged_fwd, 24, &frame, 0).drop,
+        "an untagged interface (logical == physical == 24) still applies its \
+         own output filter — non-VLAN behavior is unchanged by the fix"
+    );
+}
+
+#[test]
 fn classify_generated_reply_ignores_trigger_protocol_filter() {
     // The discriminating test: a filter discarding TCP does NOT drop a
     // generated ICMP reply (proves classify-by-generated-tuple, not trigger).


### PR DESCRIPTION
Routes three per-ingress lookups through the `resolve_ingress_logical_ifindex` SSOT so VLAN sub-interfaces get their OWN logical unit ifindex instead of the raw physical `meta.ingress_ifindex` (the parent/bind port).

`ifindex_to_zone_id` and `forwarding.egress` are keyed by the LOGICAL unit ifindex (`forwarding_build/interfaces.rs:76`). A physical parent ifindex only ever inherits its FIRST sub-interface's zone (lines 77-86), so a parent carrying multiple VLAN units in distinct zones evaluated the wrong zone for every unit but the first. The three sites now mirror the existing filter (`poll_descriptor/filter.rs`) and CoS (`tx/cos_classify.rs`) call sites. Untagged ports resolve physical == logical (no-op).

## Per-bug fail-on-revert tests

### #3021 — forwarding zone-pair (`poll_descriptor/mod.rs`)
Both `from_zone` derivations in `poll_binding_process_descriptor` (ForwardCandidate + fabric-return arm) resolve the logical ingress ifindex before `zone_pair_ids_for_flow_with_override`.

Test `forwarding_zone_pair_uses_logical_ingress_ifindex_3021` (counterfactual pin): asserts the logical-keyed FROM-zone (`lan`, VID-50 unit logical 13) and the physical-keyed FROM-zone (`wan`, parent 11's first sub-interface) DIVERGE. A regression collapsing the logical mapping fails RED via `assert_ne!`.

### #3022 — screen / SYN-cookie (`poll_stages.rs`)
`stage_screen_check` and `stage_screen_syn_cookie_ack_on_session_miss` resolve the logical ifindex before the `ifindex_to_zone_id` lookup. A parent-zone miss would otherwise SKIP screening or apply the wrong profile.

Test `screen_zone_lookup_uses_logical_ingress_ifindex_3022` (**literal** — drives `stage_screen_check`): a `lan`-only `ip-source-route` profile + a source-route SYN on a VID-50/`lan` unit (logical 13, parent 11) must DROP. **Verified RED when reverted** to `meta.ingress_ifindex`: the physical-keyed lookup resolves zone `wan` (no profile) and wrongly Passes. The untagged `reth1.0` control still drops (non-tautological / non-VLAN preserved).

### #3026 — generated ICMP error (`icmp.rs`)
Classifies the generated reply (CoS queue / DSCP rewrite / output filter) on the LOGICAL egress unit ifindex (`ingress_ident.ifindex`, the key for `forwarding.egress`), NOT the physical `target_ifindex` / `bind_ifindex`. `target_ifindex` (physical) is still used for the XSK transmit.

Test `classify_generated_reply_uses_logical_egress_ifindex_3026` (counterfactual pin, cf. the existing `classify_generated_reply_counterfactual_trigger_keying_would_misverdict`): a VLAN unit (logical 202, parent 11) with an ICMP-discard output filter must DROP on the logical ifindex and ADMIT on the physical parent (no filter). `assert_ne!` makes a logical->physical regression fail RED. Untagged interface (logical == physical) still applies its own filter.

## Validation
- `cargo build --release -p xpf-userspace-dp` clean (0 errors)
- Full bins suite: 2917 passed. The one failure (`worker_queue::concurrent_recovery_processes_each_command`) is a pre-existing timing flake unrelated to this change (passes 3/3 in isolation)
- #3022 fail-on-revert confirmed RED (revert applied, test failed at the drop assert, then restored)

Docs: `userspace-dp/src/afxdp/README.md` documents the shared SSOT alongside the #2370 neighbor-learn note; `_Log.md` logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi