### PR TITLE
eventengine: stop runAction retry backoff timer on shutdown (#2890)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-06-25 — #2890: eventengine runAction retry timer leak (time.After → time.NewTimer+Stop)
+
+- **Timestamp**: 2026-06-25
+- **Action**: fixed the lock-held retry select in `runAction`. The backoff
+  sleep used `case <-time.After(backoff)`, whose runtime timer cannot be
+  stopped — when `stopCh` fired before the backoff elapsed (daemon shutdown or
+  `Apply` churn) the armed timer leaked until it fired. With the doubling
+  backoff toward the 5 s ceiling, orphaned timers accumulate across restart
+  churn. Replaced with an explicit `time.NewTimer` + `Stop()` exposed through a
+  test-injectable `newRetryTimer`/`newTimerFn` seam; the stopCh branch now
+  stops the timer before returning. The #2868 engine-lifetime `lifeCtx` /
+  `commitContext` plumbing is preserved unchanged.
+- **File(s)**: pkg/eventengine/engine.go,
+  pkg/eventengine/engine_integration_test.go, pkg/eventengine/README.md
+- **Validation**: `go build ./...`, `gofmt -l pkg/eventengine` (clean),
+  `go vet ./pkg/eventengine/...`, `go test -race ./pkg/eventengine/...` (26
+  passed). Fail-on-revert proven: reverting the select to `time.After` makes
+  `TestRetry_TimerStoppedOnEngineStop` go RED (the injected `newTimerFn` seam
+  is never consulted on the stop branch).
+
 ## 2026-06-25 — #2923 (review fold, PR #2984 MINOR): forwardable-disposition tunnel-liveness gate
 
 - **Timestamp**: 2026-06-25

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -118,7 +118,17 @@ cannot occur.
   (200 ms → 5 s) up to a 60 s deadline, bumping
   `xpf_event_actions_retried_total`, instead of dropping. After the deadline it
   bumps `xpf_event_actions_dropped_total{reason="lock_held"}`. The sentinel is
-  matched with `errors.Is`, not a fragile string match.
+  matched with `errors.Is`, not a fragile string match. The backoff sleep uses
+  an explicit `time.NewTimer` + `Stop()` (via `newRetryTimer`), NOT
+  `time.After`: when `stopCh` fires before the backoff elapses (daemon shutdown
+  or `Apply` churn), the retry stops the timer immediately and releases the
+  runtime timer instead of leaking an armed timer until it fires (#2890). With
+  a doubling backoff toward the 5 s ceiling, orphaned `time.After` timers would
+  otherwise accumulate across restart churn. Regression-locked by
+  `TestRetry_TimerStoppedOnEngineStop` (fail-on-revert: it injects `newTimerFn`,
+  parks the worker in the retry select under a held lock, closes the engine, and
+  asserts the stop func was invoked — reverting to `time.After` never consults
+  the seam and the test goes RED).
 - **Bounded queue, dedup-by-policy:** the queue holds at most one pending
   action per policy — a newer trigger supersedes an older queued one (no value
   in applying a stale remediation twice). Overflow bumps

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -176,6 +176,14 @@ type Engine struct {
 	// Injectable clock for tests; nil means time.Now.
 	nowFn func() time.Time
 
+	// Injectable retry-backoff timer for tests; nil means newRetryTimer
+	// (backed by time.NewTimer). Returns the fire channel plus a stop func
+	// that releases the underlying timer when the retry is cancelled before
+	// the backoff elapses (#2890 — a plain time.After cannot be stopped, so
+	// its runtime timer leaks until it fires). A test can substitute this to
+	// assert the stop func is invoked on the stopCh branch.
+	newTimerFn func(time.Duration) (<-chan time.Time, func() bool)
+
 	// Lock-retry tuning, overridable in tests. Zero means the package
 	// defaults (lockRetryInitial/Max/Deadline).
 	retryInitial  time.Duration
@@ -232,6 +240,21 @@ func (e *Engine) now() time.Time {
 		return e.nowFn()
 	}
 	return time.Now()
+}
+
+// newRetryTimer returns the backoff fire channel plus a stop func for the
+// runAction retry select (#2890). Using an explicit time.NewTimer (rather than
+// time.After) lets the retry release the runtime timer immediately when stopCh
+// fires before the backoff elapses, instead of leaking an armed timer until it
+// fires on shutdown/restart churn. The stop func reports whether it stopped the
+// timer before it fired (so a caller may drain a fired-but-unread channel),
+// mirroring time.Timer.Stop. Overridable in tests via newTimerFn.
+func (e *Engine) newRetryTimer(d time.Duration) (<-chan time.Time, func() bool) {
+	if e.newTimerFn != nil {
+		return e.newTimerFn(d)
+	}
+	t := time.NewTimer(d)
+	return t.C, t.Stop
 }
 
 // Apply loads new event-options policies, RECONCILING per-policy runtime state
@@ -522,10 +545,17 @@ func (e *Engine) runAction(a plannedAction) {
 			e.counters.retried.Add(1)
 			slog.Debug("event-options: config lock held, will retry",
 				"policy", a.policyName, "backoff", backoff)
+			// Explicit timer (NOT time.After) so the runtime timer is
+			// released the instant stopCh fires before the backoff elapses,
+			// rather than leaking an armed timer until it fires (#2890). The
+			// stop func is only meaningful on the stopCh branch; on the timer
+			// branch the timer has already fired and stopping is a no-op.
+			timerC, stopTimer := e.newRetryTimer(backoff)
 			select {
 			case <-e.stopCh:
+				stopTimer()
 				return
-			case <-time.After(backoff):
+			case <-timerC:
 			}
 			backoff *= 2
 			if backoff > maxBackoff {

--- a/pkg/eventengine/engine_integration_test.go
+++ b/pkg/eventengine/engine_integration_test.go
@@ -230,6 +230,92 @@ func TestCommit_CancelledOnEngineStop(t *testing.T) {
 	}
 }
 
+// #2890: the runAction lock-held retry select must release its backoff timer
+// when stopCh fires before the backoff elapses. A plain time.After cannot be
+// stopped — its runtime timer stays armed until it fires, so on shutdown /
+// restart churn with a doubling backoff toward maxBackoff the orphaned timers
+// accumulate (a temporary memory leak). The fix uses an explicit
+// time.NewTimer + Stop().
+//
+// FAIL-ON-REVERT: this test injects a newTimerFn that records whether the
+// retry stopped the timer. It holds the configure lock so applyOnce returns
+// ErrConfigLocked and the worker enters the retry select with a long backoff,
+// then calls Close() (which closes stopCh) and asserts the stop func WAS
+// invoked. If the select is reverted to `case <-time.After(backoff)`, the seam
+// is never consulted on the stop branch (no Stop call), stopped stays false,
+// and the test fails.
+func TestRetry_TimerStoppedOnEngineStop(t *testing.T) {
+	s := newStore(t)
+	pol := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name remediated"},
+	}
+
+	e := New(s, nil)
+	// Long backoff + deadline so the worker parks in the retry select waiting
+	// on the timer (never hits the deadline, never fires the timer) until we
+	// close stopCh.
+	e.retryInitial = time.Hour
+	e.retryMax = time.Hour
+	e.retryDeadline = time.Hour
+
+	armed := make(chan struct{}, 1) // the retry select has been entered
+	var mu sync.Mutex
+	var stopped bool
+	e.newTimerFn = func(d time.Duration) (<-chan time.Time, func() bool) {
+		// A channel that never fires: the only way out of the select is stopCh.
+		ch := make(chan time.Time)
+		select {
+		case armed <- struct{}{}:
+		default:
+		}
+		return ch, func() bool {
+			mu.Lock()
+			stopped = true
+			mu.Unlock()
+			return true
+		}
+	}
+
+	// Hold the configure lock so applyOnce -> EnterConfigure returns
+	// ErrConfigLocked, driving the worker into the lock-held retry path.
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure (hold lock): %v", err)
+	}
+	defer s.ExitConfigure()
+
+	e.Apply([]*config.EventPolicy{pol})
+	e.HandleEvent(eventFor("ping_test_failed"))
+
+	select {
+	case <-armed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker never entered the retry select (newTimerFn was not consulted)")
+	}
+
+	// Closing the engine closes stopCh; the retry select must take the stopCh
+	// branch and Stop() the timer before returning.
+	closed := make(chan struct{})
+	go func() {
+		e.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close() did not return — worker is stuck in the retry select")
+	}
+
+	mu.Lock()
+	got := stopped
+	mu.Unlock()
+	if !got {
+		t.Fatal("retry backoff timer was NOT stopped on stopCh — a plain" +
+			" time.After leaks its runtime timer until the backoff elapses (#2890)")
+	}
+}
+
 // #2139: a valid-only batch commits in full.
 func TestBatch_ValidBatchCommits(t *testing.T) {
 	s := newStore(t)


### PR DESCRIPTION
## Summary

Closes #2890.

The lock-held retry select in `eventengine.runAction` slept with
`case <-time.After(backoff)`. A `time.After` timer cannot be stopped, so when
`stopCh` fired before the backoff elapsed (daemon shutdown, or an `Apply` that
closes the worker), the armed runtime timer leaked until it fired on its own.
With the doubling backoff toward the 5 s ceiling, orphaned timers accumulate
across restart / reconfigure churn — a temporary memory leak proportional to
retry depth.

## Change

- Replace `time.After` with an explicit `time.NewTimer` + `Stop()`, exposed via
  a small `newRetryTimer` helper (test-injectable through `newTimerFn`).
- The `stopCh` branch now calls the stop func before returning, releasing the
  timer immediately. The timer-fire branch leaves the stop a no-op (already
  fired), matching `time.Timer.Stop` semantics.
- The #2868 engine-lifetime context plumbing (`lifeCtx` / `commitContext` /
  `lifeCancel`) is preserved unchanged — this touches only the backoff sleep.
- Docs: `pkg/eventengine/README.md` held-config-lock bullet + `_Log.md`.

## Validation

- `go build ./...`, `gofmt -l pkg/eventengine` (clean), `go vet ./pkg/eventengine/...`
- `go test -race ./pkg/eventengine/...` — 26 passed.

### Fail-on-revert

`TestRetry_TimerStoppedOnEngineStop` injects `newTimerFn`, parks the worker in
the retry select under a held config lock, closes the engine, and asserts the
stop func was invoked. Verified via copy-aside revert: reverting the select to
`case <-time.After(backoff)` never consults the seam on the stop branch, so the
test goes RED (`worker never entered the retry select (newTimerFn was not
consulted)`). Restored and re-confirmed GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi