### PR TITLE
Unify REST + gRPC protoName on a single SSOT (#2949)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-06-25 — #2949: unify REST + gRPC protoName on a single SSOT
+
+- **Timestamp**: 2026-06-25
+- **Action**: finished the #2949 fix. Added `appid.ProtocolName` as the
+  single source of truth for the named IP-protocol set rendered by the
+  operator surfaces (tcp/udp/icmp/icmpv6/gre/esp/ipip/ipv6); it matches
+  the prior gRPC switch and is NOT a complete inverse of ProtocolNumber
+  (which resolves ospf/igmp/... with no display mapping, and ipv6 has no
+  reverse). Rewired both surfaces: `pkg/grpcapi` `protoName` (lowercase,
+  direct) and `pkg/api` REST `protoName` (upper-cased for its historical
+  TCP/UDP/ICMP display, ICMPv6 mixed case preserved). Before #2949 REST
+  kept its own 4-protocol switch while gRPC rendered gre/esp/ipip/ipv6
+  too, so a REST `protocol=gre` NAMED filter silently returned no rows
+  and a GRE/ESP session displayed numeric on REST but named on gRPC.
+  Added the fail-on-revert tests `TestRESTProtoNameNamedSet` and
+  `TestRESTProtocolFilterNamedGRE` (a GRE-session fixture): both go RED
+  if REST reverts to the 4-protocol set (protoName(47)=="47", named
+  `gre` filter matches 0 rows). Verified RED via copy-aside revert,
+  restored. Review fold (PR #3037 MINOR): softened the ProtocolName doc
+  comment so it no longer over-claims a complete ProtocolNumber inverse.
+- **File(s)**: pkg/appid/catalog.go, pkg/api/sessions.go,
+  pkg/grpcapi/server_helpers.go, pkg/api/rest_filter_failclosed_test.go,
+  _Log.md
+- **Gates**: go build ./... clean; gofmt -l clean on changed files; go
+  vet ./pkg/api/... ./pkg/grpcapi/... ./pkg/appid/... clean; go test
+  ./pkg/api/... ./pkg/grpcapi/... ./pkg/appid/... green (the prior
+  pre-existing `TestShowTextGolden` drift was fixed+merged in #3038,
+  picked up by rebasing onto origin/master).
+
 ## 2026-06-25 — fix TestShowTextGolden syn-flood attack-threshold golden drift (#3033 follow-up)
 
 - **Timestamp**: 2026-06-25

--- a/pkg/api/rest_filter_failclosed_test.go
+++ b/pkg/api/rest_filter_failclosed_test.go
@@ -196,6 +196,110 @@ func TestRESTProtocolFilterCaseInsensitiveNumeric(t *testing.T) {
 	}
 }
 
+// greSessionDP is an apiRuntimeDataPlane that yields exactly one forward
+// IPv4 GRE (proto 47) session, so the #2949 named-protocol rendering and
+// NAMED protocol-filter contract can be exercised end-to-end.
+type greSessionDP struct {
+	*dataplane.Manager
+}
+
+func (d *greSessionDP) IsLoaded() bool { return true }
+
+func (d *greSessionDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	key := dataplane.SessionKey{
+		SrcIP:    [4]byte{10, 0, 1, 5},
+		DstIP:    [4]byte{10, 0, 2, 7},
+		Protocol: 47, // GRE
+	}
+	val := dataplane.SessionValue{
+		State:       dataplane.SessStateEstablished,
+		IsReverse:   0,
+		IngressZone: 2,
+		EgressZone:  3,
+	}
+	fn(key, val)
+	return nil
+}
+
+func (d *greSessionDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+// TestRESTProtoNameNamedSet asserts the #2949 contract: the REST protoName
+// renders the SAME named protocol SET as gRPC (appid.ProtocolName SSOT), so
+// gre/esp/ipip/ipv6 sessions display a name instead of a bare number. REST
+// upper-cases its rendering (its historical TCP/UDP/ICMP display), but the
+// named SET — which protocols are named at all — must match gRPC.
+//
+// FAIL-ON-REVERT: restoring REST's old 4-protocol switch (tcp/udp/icmp/
+// icmpv6 only) makes protoName(47)=="47" instead of "GRE", flipping the
+// gre/esp/ipip/ipv6 rows of this table red.
+func TestRESTProtoNameNamedSet(t *testing.T) {
+	cases := []struct {
+		proto uint8
+		want  string
+	}{
+		{6, "TCP"},
+		{17, "UDP"},
+		{1, "ICMP"},
+		{58, "ICMPv6"},
+		{47, "GRE"},
+		{50, "ESP"},
+		{4, "IPIP"},
+		{41, "IPV6"},
+		{99, "99"}, // unnamed -> numeric fallback
+	}
+	for _, tc := range cases {
+		if got := protoName(tc.proto); got != tc.want {
+			t.Fatalf("protoName(%d) = %q, want %q", tc.proto, got, tc.want)
+		}
+	}
+}
+
+// TestRESTProtocolFilterNamedGRE asserts the #2949 contract end-to-end: a
+// NAMED `protocol=gre` REST session filter (and its numeric form) matches a
+// GRE session, and the rendered row displays the named protocol — exactly
+// like the gRPC surface. Before #2949, REST rendered GRE numeric and a
+// `protocol=gre` filter silently returned no rows.
+//
+// FAIL-ON-REVERT: restoring REST's old 4-protocol protoName switch makes
+// protoName(47)=="47", so the named "gre" filter no longer matches (0 rows)
+// and the displayed protocol reverts to "47", flipping the want-1/"GRE"
+// assertions red.
+func TestRESTProtocolFilterNamedGRE(t *testing.T) {
+	s := &Server{dp: &greSessionDP{Manager: dataplane.New()}}
+
+	cases := []struct {
+		filter string
+		want   int
+	}{
+		{"gre", 1},
+		{"GRE", 1},
+		{"47", 1},
+		{"esp", 0},
+		{"50", 0},
+	}
+	for _, tc := range cases {
+		t.Run("protocol="+tc.filter, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.sessionsHandler(rr, httptest.NewRequest("GET",
+				"/api/v1/security/sessions?protocol="+tc.filter, nil))
+			if rr.Code != 200 {
+				t.Fatalf("protocol=%s: status %d, want 200; body: %s",
+					tc.filter, rr.Code, rr.Body.String())
+			}
+			sess := decodeSessions(t, rr.Body.Bytes()).Sessions
+			if len(sess) != tc.want {
+				t.Fatalf("protocol=%s: %d sessions, want %d", tc.filter, len(sess), tc.want)
+			}
+			if tc.want == 1 && sess[0].Protocol != "GRE" {
+				t.Fatalf("protocol=%s: rendered protocol = %q, want %q",
+					tc.filter, sess[0].Protocol, "GRE")
+			}
+		})
+	}
+}
+
 // TestEventFilterExactNotSubstring asserts the #2939 contract: the event
 // filter must match protocol/action EXACTLY (case-insensitive), not as a
 // substring. protocol=C must NOT match TCP/ICMP/ICMPv6.

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
@@ -365,17 +366,20 @@ func protoFilterMatches(p uint8, filter string) bool {
 	return false
 }
 
+// protoName renders an IP protocol number for the REST surface. The named
+// protocol SET is owned by appid.ProtocolName (the #2949 SSOT shared with gRPC
+// and the catalog) so a NAMED `protocol=gre` REST filter matches and GRE/ESP/
+// IPIP/IPv6 sessions display named instead of numeric. Casing is a REST-local
+// concern: REST has always rendered upper-case (TCP/UDP/ICMP/ICMPv6), so the
+// canonical lowercase name is upper-cased here. ICMPv6 keeps its mixed-case
+// spelling to match the historical REST rendering.
 func protoName(p uint8) string {
-	switch p {
-	case 6:
-		return "TCP"
-	case 17:
-		return "UDP"
-	case 1:
-		return "ICMP"
-	case dataplane.ProtoICMPv6:
-		return "ICMPv6"
-	default:
+	name := appid.ProtocolName(p)
+	if name == "" {
 		return fmt.Sprintf("%d", p)
 	}
+	if p == dataplane.ProtoICMPv6 {
+		return "ICMPv6"
+	}
+	return strings.ToUpper(name)
 }

--- a/pkg/appid/catalog.go
+++ b/pkg/appid/catalog.go
@@ -178,6 +178,54 @@ func ProtocolNumber(name string) (uint8, bool) {
 	}
 }
 
+// ProtocolName is the single source of truth for rendering an IP protocol
+// number as a canonical lowercase protocol name. It returns "" for a
+// protocol that has no display name here, letting callers fall back to the
+// numeric form.
+//
+// This renders the named protocol set the operator surfaces have
+// historically displayed (matching the prior gRPC switch); it is NOT a
+// complete inverse of ProtocolNumber. ProtocolNumber resolves additional
+// protocols (ospf/egp/igmp/pim/ah/sctp/vrrp/...) that have no display
+// mapping here, and ProtocolName(41)=="ipv6" has no reverse
+// (ProtocolNumber("ipv6") returns (0,false)). The round-trip holds only for
+// the gre/esp/ipip + icmp/icmpv6/tcp/udp set.
+//
+// This is the SSOT for the named-protocol set rendered by every operator
+// surface (REST pkg/api, gRPC pkg/grpcapi). Before #2949 each surface kept its
+// own switch: REST rendered only tcp/udp/icmp/icmpv6 while gRPC also rendered
+// gre/esp/ipip/ipv6, so a REST `protocol=gre` NAMED filter silently failed to
+// match and a GRE/ESP session displayed numeric on REST but named on gRPC.
+// Housing the table here (a leaf package importing only pkg/config) keeps the
+// REST and gRPC name sets identical from one definition.
+//
+// Casing is a per-surface concern, not part of this SSOT: REST upper-cases the
+// result to preserve its historical TCP/UDP/ICMP display; gRPC uses the
+// lowercase form directly. The named SET (which protocols are named at all) is
+// identical across surfaces.
+func ProtocolName(p uint8) string {
+	switch p {
+	case 6:
+		return "tcp"
+	case 17:
+		return "udp"
+	case 1:
+		return "icmp"
+	case 58:
+		return "icmpv6"
+	case 47:
+		return "gre"
+	case 50:
+		return "esp"
+	case 4:
+		return "ipip"
+	case 41:
+		return "ipv6"
+	default:
+		return ""
+	}
+}
+
 // catalogProtocolNumber resolves a protocol to its byte for the app-id catalog,
 // returning 0 for an unrepresentable token (the catalog's historical
 // "unknown -> 0" behavior). Delegates to ProtocolNumber (#2124) so the catalog

--- a/pkg/grpcapi/server_helpers.go
+++ b/pkg/grpcapi/server_helpers.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/vishvananda/netlink"
@@ -63,27 +64,15 @@ func policyActionStr(a config.PolicyAction) string {
 	}
 }
 
+// protoName renders an IP protocol number as its canonical lowercase name,
+// falling back to the numeric form for an unnamed protocol. The named set is
+// owned by appid.ProtocolName (the #2949 SSOT) so gRPC, REST, and the catalog
+// agree on which protocols are named.
 func protoName(p uint8) string {
-	switch p {
-	case 6:
-		return "tcp"
-	case 17:
-		return "udp"
-	case 1:
-		return "icmp"
-	case 47:
-		return "gre"
-	case 50:
-		return "esp"
-	case 4:
-		return "ipip"
-	case 41:
-		return "ipv6"
-	case dataplane.ProtoICMPv6:
-		return "icmpv6"
-	default:
-		return fmt.Sprintf("%d", p)
+	if name := appid.ProtocolName(p); name != "" {
+		return name
 	}
+	return fmt.Sprintf("%d", p)
 }
 
 func ntohs(v uint16) uint16 {


### PR DESCRIPTION
## Closes #2949

REST and gRPC each kept their own IP-protocol-number → name switch. REST
rendered only `tcp/udp/icmp/icmpv6` while gRPC also rendered
`gre/esp/ipip/ipv6`, so the two operator surfaces disagreed: a GRE/ESP
session displayed numeric on REST but named on gRPC, and a NAMED REST
filter like `protocol=gre` silently matched no rows (because REST
`protoName(47)` returned `"47"` instead of a name).

## Fix

- New `appid.ProtocolName` — the single source of truth for the
  named-protocol set (inverse of `appid.ProtocolNumber`), housed in the
  leaf `appid` package so the name set stays in lock-step with the number
  table both surfaces already share.
- `pkg/grpcapi` `protoName` renders the canonical lowercase name directly.
- `pkg/api` (REST) `protoName` upper-cases the name to preserve its
  historical `TCP/UDP/ICMP` display (ICMPv6 stays mixed-case). Casing is a
  per-surface concern; the named **set** is now identical across surfaces.
- Both surfaces fall back to the numeric form for an unnamed protocol,
  exactly as before.

After this change a GRE/ESP/IPIP/IPv6 session renders named on REST too,
and `protocol=gre` (or `protocol=47`) matches on REST exactly like gRPC.

## Fail-on-revert tests (pkg/api)

- `TestRESTProtoNameNamedSet` — asserts the full named set incl.
  gre/esp/ipip/ipv6 plus the numeric fallback.
- `TestRESTProtocolFilterNamedGRE` — drives a GRE-session fixture through
  the sessions handler; asserts a NAMED `protocol=gre` filter (and `47`)
  matches and the rendered row shows `GRE`.

Both go RED if REST reverts to the 4-protocol switch. Verified RED via
copy-aside revert of REST `protoName` (`protoName(47)=="47"`, named `gre`
filter → 0 rows), then restored.

## Gates

- `go build ./...` clean
- `gofmt -l` clean on changed files
- `go vet ./pkg/api/... ./pkg/grpcapi/...` clean
- `go test ./pkg/api/... ./pkg/grpcapi/...` green **except** the
  pre-existing `TestShowTextGolden` screen SYN-flood threshold drift,
  which fails identically on clean `origin/master` and is unrelated to
  this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi