### PR TITLE
api: include global policies in REST GET /security/policies (#3045)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,16 @@
+## 2026-06-25 — #3045: REST /security/policies includes global policies
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed `policiesHandler` (REST `GET /api/v1/security/policies`)
+  to enumerate global policies after zone-pair policies, emitting a single
+  `from_zone="*"`/`to_zone="*"` row matching gRPC `GetPolicies`, the
+  Prometheus collector, and the CLI. Global counter IDs continue from the
+  zone-pair `policySetID`. Added fail-on-revert test
+  `TestPoliciesHandlerIncludesGlobalPolicies` (RED when globals omitted).
+  Updated pkg/api README.
+- **File(s)**: pkg/api/security.go, pkg/api/security_test.go,
+  pkg/api/README.md
+
 ## 2026-06-25 — #3009: state_writer instance_is_alive self-shortcut checks full instance
 
 - **Timestamp**: 2026-06-25

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -26,6 +26,14 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
 - `GET /metrics` — Prometheus exposition.
 - `GET /api/v1/...` — REST mirrors of the gRPC API: sessions, routes,
   NAT, DHCP, IPsec, VRRP, OSPF, BGP, etc.
+  - `GET /api/v1/security/policies` enumerates zone-pair policies AND
+    global policies (#3045). Global rules are emitted as a single
+    trailing `PolicyInfo` row with `from_zone="*"`/`to_zone="*"`,
+    matching gRPC `GetPolicies` and the Prometheus collector. Global
+    counter IDs follow the zone-pair policy-set count (the `policySetID`
+    continues from the zone-pair loop), so per-policy hit counters stay
+    aligned with the dataplane when `policy-stats system-wide enable` is
+    set.
 - `GET /api/v1/events/stream` — Server-Sent Events stream of dataplane
   events. Backed by the `pkg/logging` event ring buffer; long-lived
   consumers must drain.

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -121,6 +121,58 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 		result = append(result, pi)
 		policySetID++
 	}
+
+	// Global policies (#3045): the CLI, gRPC GetPolicies, and the
+	// Prometheus collector all expose globals; the REST inventory
+	// endpoint must too, otherwise automation/dashboards cannot audit
+	// rules the dataplane actively enforces. Emit a single global row
+	// with from_zone="*"/to_zone="*" (matching gRPC) after the zone-pair
+	// rows, preserving the policy-counter ID ordering: global counter IDs
+	// start after the zone-pair policy-set count (policySetID continues
+	// from the loop above).
+	if len(cfg.Security.GlobalPolicies) > 0 {
+		pi := PolicyInfo{
+			FromZone: "*",
+			ToZone:   "*",
+		}
+		for i, rule := range cfg.Security.GlobalPolicies {
+			if rule == nil {
+				continue
+			}
+			pr := PolicyRule{
+				Name:         rule.Name,
+				Action:       policyActionStr(rule.Action),
+				SrcAddresses: rule.Match.SourceAddresses,
+				DstAddresses: rule.Match.DestinationAddresses,
+				Applications: rule.Match.Applications,
+				Log:          rule.Log != nil,
+				Count:        rule.Count,
+			}
+			if pr.SrcAddresses == nil {
+				pr.SrcAddresses = []string{}
+			}
+			if pr.DstAddresses == nil {
+				pr.DstAddresses = []string{}
+			}
+			if pr.Applications == nil {
+				pr.Applications = []string{}
+			}
+
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
+				policyID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
+					pr.HitPackets = ctrs.Packets
+					pr.HitBytes = ctrs.Bytes
+				}
+			}
+			pi.Rules = append(pi.Rules, pr)
+		}
+		if pi.Rules == nil {
+			pi.Rules = []PolicyRule{}
+		}
+		result = append(result, pi)
+	}
+
 	writeOK(w, result)
 }
 

--- a/pkg/api/security_test.go
+++ b/pkg/api/security_test.go
@@ -135,3 +135,99 @@ func TestMatchPoliciesHandlerValidation(t *testing.T) {
 		})
 	}
 }
+
+// globalPolicyAPIStore builds a config with one zone-pair policy plus one
+// global policy so the REST /security/policies enumeration must surface
+// both surfaces (#3045).
+func globalPolicyAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy zone-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        global {
+            policy global-deny {
+                match { source-address any; destination-address any; application any; }
+                then { deny; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestPoliciesHandlerIncludesGlobalPolicies is the fail-on-revert guard
+// for #3045: the REST GET /api/v1/security/policies inventory must
+// include configured global policies (from_zone="*"/to_zone="*"),
+// matching the CLI, gRPC GetPolicies, and the Prometheus collector. If
+// the handler reverts to looping zone-pair policies only, the global row
+// is absent and this test goes RED.
+func TestPoliciesHandlerIncludesGlobalPolicies(t *testing.T) {
+	s := &Server{store: globalPolicyAPIStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	var sawZonePair, sawGlobal bool
+	for _, policy := range resp.Data {
+		if policy.FromZone == "trust" && policy.ToZone == "untrust" {
+			for _, rule := range policy.Rules {
+				if rule.Name == "zone-allow" {
+					sawZonePair = true
+				}
+			}
+		}
+		if policy.FromZone == "*" && policy.ToZone == "*" {
+			for _, rule := range policy.Rules {
+				if rule.Name == "global-deny" {
+					if rule.Action != "deny" {
+						t.Fatalf("global-deny action = %q, want deny", rule.Action)
+					}
+					sawGlobal = true
+				}
+			}
+		}
+	}
+	if !sawZonePair {
+		t.Fatal("zone-pair policy zone-allow missing from REST response (regression)")
+	}
+	if !sawGlobal {
+		t.Fatalf("global policy global-deny missing from REST /security/policies response; "+
+			"globals omitted (#3045 regression); body: %s", rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
The REST inventory endpoint `policiesHandler` (`pkg/api/security.go`) looped only zone-pair policies (`cfg.Security.Policies`) and omitted global policies — whereas the CLI, gRPC `GetPolicies`, and the Prometheus collector all include them with `from_zone="*"`/`to_zone="*"`. REST automation/dashboards therefore under-reported the enforced policy set (global rules invisible).

## Fix
Append a single global `PolicyInfo` row (`from_zone="*"`/`to_zone="*"`) after the zone-pair rows, mirroring gRPC `GetPolicies` and the Prometheus collector. The policy-counter ID ordering is preserved: global counter IDs start after the zone-pair policy-set count (`policySetID` continues from the zone-pair loop), so per-policy hit counters stay aligned with the dataplane when `policy-stats system-wide enable` is set. Nil global entries are skipped, matching the Prometheus collector.

## Fail-on-revert test
`TestPoliciesHandlerIncludesGlobalPolicies` configures one zone-pair policy plus one global policy and asserts both the zone-pair row and the `*`/`*` global row are present. Verified RED when the global block is removed (`global policy global-deny missing from REST /security/policies response`) and GREEN with the fix.

## Gates (foreground)
- `go build ./...` — clean
- `gofmt -l` — clean on touched files (`pkg/api/types.go` is pre-existing unformatted on master, untouched here)
- `go vet ./pkg/api/...` — clean
- `go test ./pkg/api/...` — 186 passed

## Docs
- `pkg/api/README.md` — documented the global-policy enumeration
- `_Log.md` — action entry

Closes #3045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi