### PR TITLE
userspace-dp: source-route screen (#2973) + teardrop zero-payload fragment (#3027)

### DIFF
--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -268,6 +268,8 @@ pub(super) fn screen_parse_error_info(
         ip_total_len: 0,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     }
 }
 
@@ -547,6 +549,8 @@ mod tests {
             ip_total_len: 60,
             ip_payload_len: 0,
             frag_data_off: 0,
+            saw_ipv4_source_route: false,
+            saw_ipv6_routing_header: false,
         };
 
         emit_screen_drop_event(Some(&handle), &pkt, test_meta(), 11, "land-attack", mono_now_ns());
@@ -597,6 +601,8 @@ mod tests {
             ip_total_len: 60,
             ip_payload_len: 0,
             frag_data_off: 0,
+            saw_ipv4_source_route: false,
+            saw_ipv6_routing_header: false,
         };
 
         emit_screen_alarm_event(Some(&handle), &pkt, test_meta(), 2, "scan-table-pressure", mono_now_ns());
@@ -643,6 +649,8 @@ mod tests {
             ip_total_len: 60,
             ip_payload_len: 0,
             frag_data_off: 0,
+            saw_ipv4_source_route: false,
+            saw_ipv6_routing_header: false,
         };
 
         emit_screen_drop_event(Some(&handle), &pkt, test_meta(), 11, "icmp-fragment", mono_now_ns());

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -649,7 +649,9 @@ mod tests {
     /// → an 802.1p priority tag (TPID 0x8100, PCP 5, **VID 0**), so the
     /// L3 header starts at offset 18 while `ingress_vlan_id` is 0. The
     /// IPv4 header is built with `ihl` 32-bit words (5 = no options;
-    /// 6 = one option word, which trips the `ip-source-route` screen).
+    /// 6 = one option word carrying an LSRR source-route option, which
+    /// trips the `ip-source-route` screen — #2973 requires a real
+    /// LSRR/SSRR option, not just `ihl > 5`).
     fn tcp_v4_syn_frame_with_l2(vlan: Vlan, ihl: u8) -> Vec<u8> {
         let mut frame = Vec::new();
         let dst_mac = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
@@ -675,8 +677,18 @@ mod tests {
         frame.extend_from_slice(&[0x00, 0x01, 0x40, 0x00, 64, PROTO_TCP, 0x00, 0x00]);
         frame.extend_from_slice(&Ipv4Addr::new(192, 0, 2, 10).octets());
         frame.extend_from_slice(&Ipv4Addr::new(198, 51, 100, 20).octets());
-        // IPv4 options as NOP (0x01) to reach `ihl_bytes`.
+        // IPv4 options to reach `ihl_bytes`. When options are present
+        // (ihl > 5) the first option is an actual LSRR (Loose Source
+        // Route, option type 131) so the `ip-source-route` screen fires.
+        // #2973 made that screen require a real LSRR/SSRR option (the
+        // extractor decodes the options TLVs) instead of dropping on any
+        // ihl > 5, so a NOP-only options region no longer trips it. The
+        // remaining bytes stay NOP (0x01); the extractor detects the
+        // source-route option from the kind byte alone.
         frame.resize(l3 + ihl_bytes, 0x01);
+        if ihl > 5 {
+            frame[l3 + 20] = 131; // LSRR
+        }
         let ip_csum = checksum16(&frame[l3..l3 + ihl_bytes]);
         frame[l3 + 10..l3 + 12].copy_from_slice(&ip_csum.to_be_bytes());
         // TCP SYN.
@@ -727,9 +739,10 @@ mod tests {
     }
 
     /// Screen state with only the IP source-route check armed. The
-    /// check fires purely on `ip_ihl > 5` read from the frame at the
-    /// computed L3 offset, so the verdict is a direct probe of whether
-    /// the screen stage parsed the IP header at the right offset.
+    /// check fires on an actual LSRR/SSRR option decoded from the IPv4
+    /// options region (post-#2973) read from the frame at the computed
+    /// L3 offset, so the verdict is a direct probe of whether the screen
+    /// stage parsed the IP header at the right offset.
     fn source_route_screen() -> ScreenState {
         let mut profiles = FxHashMap::default();
         profiles.insert(
@@ -952,9 +965,10 @@ mod tests {
     /// (`ingress_vlan_present = 1`, `ingress_vlan_id = 0`) must have its
     /// IP header parsed at offset 18 by the screen + SYN-cookie stages,
     /// not at the untagged offset 14. The screen carries an IPv4 header
-    /// with IHL = 6, so the `ip-source-route` check fires *iff* the
-    /// stage reads `ip_ihl` from the real header at offset 18. Pre-fix
-    /// (`ingress_vlan_id > 0`) the stage used offset 14, read the
+    /// with IHL = 6 holding an LSRR source-route option, so the
+    /// `ip-source-route` check fires *iff* the stage reads the IP header
+    /// (and decodes the option) from the real header at offset 18.
+    /// Pre-fix (`ingress_vlan_id > 0`) the stage used offset 14, read the
     /// 802.1Q TPID byte (0x81) as the IP header → `ip_ihl = 1`,
     /// source-route did NOT fire, and the SYN passed. An untagged
     /// control frame (with the same IHL-6 header at offset 14) keeps

--- a/userspace-dp/src/screen/extract.rs
+++ b/userspace-dp/src/screen/extract.rs
@@ -48,6 +48,8 @@ pub(crate) fn extract_screen_info(
         ip_total_len: 0,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     };
 
     let mut tcp_offset: Option<usize> = None;
@@ -64,7 +66,49 @@ pub(crate) fn extract_screen_info(
         info.is_fragment = (info.ip_frag_off & 0x3FFF) != 0;
         info.is_first_fragment =
             (info.ip_frag_off & 0x2000) != 0 && (info.ip_frag_off & 0x1FFF) == 0;
-        tcp_offset = Some(l3_offset + (info.ip_ihl as usize) * 4);
+        // #2973: scan the IPv4 options region (bytes 20..ihl*4) for an
+        // actual source-route option. The `source-route` screen used to
+        // drop on ANY IHL>5 (any options present), which also dropped
+        // benign router-alert/record-route/timestamp/security packets.
+        // Detect only LSRR (option type 131 = copied|control|9) and
+        // SSRR (137 = copied|control|11). Bounded TLV walk; EOOL(0) ends,
+        // NOP(1) is one byte, every other option is length-prefixed.
+        let ihl_bytes = (info.ip_ihl as usize) * 4;
+        if info.ip_ihl > 5 && l3_offset + ihl_bytes <= frame.len() {
+            const IPOPT_EOOL: u8 = 0;
+            const IPOPT_NOP: u8 = 1;
+            const IPOPT_LSRR: u8 = 131;
+            const IPOPT_SSRR: u8 = 137;
+            let opt_end = l3_offset + ihl_bytes;
+            let mut pos = l3_offset + 20;
+            while pos < opt_end {
+                let kind = frame[pos];
+                if kind == IPOPT_EOOL {
+                    break;
+                }
+                if kind == IPOPT_NOP {
+                    pos += 1;
+                    continue;
+                }
+                if kind == IPOPT_LSRR || kind == IPOPT_SSRR {
+                    info.saw_ipv4_source_route = true;
+                    break;
+                }
+                // Length-prefixed option: byte at pos+1 is the total
+                // option length (including the kind/length bytes). A
+                // malformed length (<2 or running past the options end)
+                // ends the walk to avoid an infinite/over-read loop.
+                if pos + 1 >= opt_end {
+                    break;
+                }
+                let opt_len = frame[pos + 1] as usize;
+                if opt_len < 2 || pos + opt_len > opt_end {
+                    break;
+                }
+                pos += opt_len;
+            }
+        }
+        tcp_offset = Some(l3_offset + ihl_bytes);
     } else if addr_family == libc::AF_INET6 as u8 {
         // IPv6: walk the extension header chain looking for
         // NEXTHDR_FRAGMENT (44). Fixed IPv6 base header is 40 bytes.
@@ -111,7 +155,26 @@ pub(crate) fn extract_screen_info(
                 return Err(ScreenParseError::TruncatedIpv6ExtChain);
             }
             match nexthdr {
-                NEXTHDR_HOP | NEXTHDR_ROUTING | NEXTHDR_DEST => {
+                NEXTHDR_ROUTING => {
+                    // #2973: an IPv6 Routing Header. Byte at offset+2 is
+                    // the routing type. Type 0 (RH0, the deprecated
+                    // source-route routing header, RFC 5095) and the
+                    // legacy/experimental type 1 are source routing;
+                    // type 2 (Mobile IPv6) and other types are not. We
+                    // need offset+4 to safely read the type byte (the
+                    // generic HOP/DEST arm only needs offset+2). Mirror
+                    // the IPv4 LSRR/SSRR `source-route` screen for parity.
+                    if offset + 4 > frame.len() {
+                        return Err(ScreenParseError::TruncatedIpv6ExtChain);
+                    }
+                    let routing_type = frame[offset + 2];
+                    if routing_type == 0 || routing_type == 1 {
+                        info.saw_ipv6_routing_header = true;
+                    }
+                    nexthdr = frame[offset];
+                    offset += (frame[offset + 1] as usize + 1) * 8;
+                }
+                NEXTHDR_HOP | NEXTHDR_DEST => {
                     if offset + 2 > frame.len() {
                         return Err(ScreenParseError::TruncatedIpv6ExtChain);
                     }

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -19,7 +19,8 @@
 //!   reassemble past 65535 bytes — #893/#2215 formula, any protocol)
 //! - Teardrop (overlapping fragments)
 //! - ICMP fragment
-//! - IP source route options
+//! - IP source route — IPv4 LSRR/SSRR options and IPv6 Routing Header
+//!   (source-route routing type), not every IHL>5 packet (#2973)
 //! - Rate limiting (ICMP, UDP flood)
 //! - SYN flood (per-zone rate)
 //!

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -17,7 +17,8 @@
 //! - WinNuke (URG to port 139)
 //! - Ping of death (IPv4 fragment whose offset+total-length would
 //!   reassemble past 65535 bytes — #893/#2215 formula, any protocol)
-//! - Teardrop (overlapping fragments)
+//! - Teardrop (overlapping fragments, plus a non-first fragment with no
+//!   /negative payload `ip_total_len <= hdr_len` — #3027)
 //! - ICMP fragment
 //! - IP source route — IPv4 LSRR/SSRR options and IPv6 Routing Header
 //!   (source-route routing type), not every IHL>5 packet (#2973)

--- a/userspace-dp/src/screen/packet.rs
+++ b/userspace-dp/src/screen/packet.rs
@@ -53,6 +53,20 @@ pub(crate) struct ScreenPacketInfo {
     /// L4/data bytes this fragment contributes to the reassembled
     /// datagram. 0 when there is no fragment header.
     pub frag_data_off: u16,
+    /// #2973: an actual IPv4 source-route option (LSRR=131 or SSRR=137)
+    /// was found in the IPv4 options region. The `source-route` screen
+    /// drops ONLY when this is set, not on every IHL>5 packet — benign
+    /// options (router-alert, record-route, timestamp, security) no
+    /// longer trigger a false `ip-source-route` drop.
+    pub saw_ipv4_source_route: bool,
+    /// #2973: an IPv6 Routing Header (next-header 43) carrying a
+    /// source-route routing type was found in the extension-header
+    /// chain. The `source-route` screen drops on this for IPv6 parity
+    /// with the IPv4 LSRR/SSRR detection. Type-0 (RH0, the deprecated
+    /// source-route routing type) and the legacy/experimental type-1
+    /// are treated as source routing; type-2 (Mobile IPv6) and other
+    /// non-source-route types do not set this.
+    pub saw_ipv6_routing_header: bool,
 }
 
 /// Screen profile configuration for a zone. Mirrors the BPF `screen_config`.

--- a/userspace-dp/src/screen/stateless.rs
+++ b/userspace-dp/src/screen/stateless.rs
@@ -155,6 +155,15 @@ pub(super) fn check_ping_of_death(
 }
 
 /// Teardrop: IPv4 non-first fragment with tiny payload (< 8 bytes).
+///
+/// #3027: a non-first fragment whose `ip_total_len <= hdr_len` carries
+/// zero (or, by the field's claimed length, "negative") payload. That is
+/// even more clearly malformed than the classic tiny-but-positive
+/// teardrop signature — exactly the kind of crafted fragment that
+/// confuses downstream reassembly — yet the pre-#3027 code only entered
+/// the payload-size branch when `ip_total_len > hdr_len`, so the
+/// zero/under-length case slipped through as a PASS. Treat it as a
+/// teardrop drop.
 #[inline]
 pub(super) fn check_teardrop(
     profile: &ScreenProfile,
@@ -164,11 +173,13 @@ pub(super) fn check_teardrop(
         let frag_offset = pkt.ip_frag_off & 0x1FFF;
         if frag_offset > 0 {
             let hdr_len = (pkt.ip_ihl as u16) * 4;
-            if pkt.ip_total_len > hdr_len {
-                let payload = pkt.ip_total_len - hdr_len;
-                if payload < 8 {
-                    return Some("teardrop");
-                }
+            if pkt.ip_total_len <= hdr_len {
+                // No / negative payload on a non-first fragment — malformed.
+                return Some("teardrop");
+            }
+            let payload = pkt.ip_total_len - hdr_len;
+            if payload < 8 {
+                return Some("teardrop");
             }
         }
     }

--- a/userspace-dp/src/screen/stateless.rs
+++ b/userspace-dp/src/screen/stateless.rs
@@ -101,9 +101,9 @@ pub(super) fn check_tcp_flag_screens(
 /// Limitation (inherited from #893): a first fragment carrying IP
 /// options combined with non-first fragments without them can craft
 /// `offset_bytes + ip_total_len <= 65535` while the reassembled total
-/// overflows by up to 40 bytes. Operators concerned about this should
-/// also enable the `ip-source-route` screen, which drops any IPv4
-/// packet with `ihl > 5`.
+/// overflows by up to 40 bytes. (Note: the `ip-source-route` screen now
+/// only drops actual LSRR/SSRR options after #2973, so it no longer
+/// blanket-drops every IHL>5 packet as a side defense here.)
 ///
 /// #2293: the IPv6 path applies the same per-fragment oversize formula.
 /// The dataplane does not reassemble, so for an IPv6 fragment we size
@@ -190,13 +190,26 @@ pub(super) fn check_icmp_fragment(
     None
 }
 
-/// IP source-route option: IPv4 with IHL > 5 (options present).
+/// IP source-route screen.
+///
+/// #2973: drop ONLY when an actual source-route option/header is present
+/// — IPv4 LSRR (option 131) / SSRR (option 137), or an IPv6 Routing
+/// Header (next-header 43) carrying a source-route routing type (RH0 /
+/// type 1). The extractor (`extract.rs`) decodes the IPv4 options TLVs
+/// and the IPv6 extension-header chain to set `saw_ipv4_source_route` /
+/// `saw_ipv6_routing_header`.
+///
+/// The pre-#2973 implementation dropped on ANY IPv4 IHL>5 (any options
+/// present), which false-dropped benign router-alert / record-route /
+/// timestamp / security packets, and it ignored IPv6 Routing Headers
+/// entirely — a vSRX/SRX feature-parity gap (the screen is expected to
+/// catch the source-route security intent on both families).
 #[inline]
 pub(super) fn check_source_route(
     profile: &ScreenProfile,
     pkt: &ScreenPacketInfo,
 ) -> Option<&'static str> {
-    if profile.source_route && pkt.addr_family == libc::AF_INET as u8 && pkt.ip_ihl > 5 {
+    if profile.source_route && (pkt.saw_ipv4_source_route || pkt.saw_ipv6_routing_header) {
         return Some("ip-source-route");
     }
     None

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -736,6 +736,58 @@ fn teardrop_first_fragment_passes() {
     assert_eq!(st.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
 }
 
+#[test]
+fn teardrop_zero_payload_non_first_fragment_drops() {
+    // #3027 fail-on-revert: a non-first fragment whose ip_total_len is
+    // EQUAL to the header length (zero payload) is malformed and must
+    // DROP as teardrop. ip_ihl=5 → hdr_len=20, ip_total_len=20.
+    //
+    // The pre-#3027 code only entered the payload-size branch when
+    // ip_total_len > hdr_len, so 20 > 20 is false and this packet
+    // slipped through as a PASS. Reverting the fix makes this assert
+    // fail (Pass instead of Drop). A teardrop-only profile isolates the
+    // check from the no-flag / other screens.
+    let mut profile = ScreenProfile::default();
+    profile.teardrop = true;
+    let mut state = make_state("trust", profile);
+    let pkt = ipv4_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_TCP,
+        2,     // frag offset = 2 (non-first fragment)
+        false, // no MORE_FRAGMENTS — a trailing fragment
+        20,    // ip_total_len == hdr_len (ihl=5*4) → zero payload
+    );
+    assert_eq!(
+        state.check_packet("trust", &pkt, 1),
+        ScreenVerdict::Drop("teardrop")
+    );
+}
+
+#[test]
+fn teardrop_under_length_non_first_fragment_drops() {
+    // #3027 fail-on-revert: a non-first fragment whose claimed
+    // ip_total_len is LESS than the header length ("negative" payload)
+    // is malformed and must DROP. ip_ihl=5 → hdr_len=20,
+    // ip_total_len=18. Pre-#3027 (ip_total_len > hdr_len gate) PASSed
+    // this; the subtraction would also have underflowed.
+    let mut profile = ScreenProfile::default();
+    profile.teardrop = true;
+    let mut state = make_state("trust", profile);
+    let pkt = ipv4_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_TCP,
+        2,     // non-first fragment
+        false,
+        18, // ip_total_len < hdr_len (20) → under-length / "negative"
+    );
+    assert_eq!(
+        state.check_packet("trust", &pkt, 1),
+        ScreenVerdict::Drop("teardrop")
+    );
+}
+
 // ================================================================
 // ICMP fragment
 // ================================================================

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -52,6 +52,8 @@ fn tcp_pkt(src: IpAddr, dst: IpAddr, src_port: u16, dst_port: u16, flags: u8) ->
         ip_total_len: 60,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     }
 }
 
@@ -82,6 +84,8 @@ fn icmp_pkt(src: IpAddr, dst: IpAddr, pkt_len: u16) -> ScreenPacketInfo {
         ip_total_len: pkt_len,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     }
 }
 
@@ -108,6 +112,8 @@ fn udp_pkt(src: IpAddr, dst: IpAddr) -> ScreenPacketInfo {
         ip_total_len: 100,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     }
 }
 
@@ -407,6 +413,8 @@ fn ipv4_fragment(
         ip_total_len,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     }
 }
 
@@ -546,6 +554,8 @@ fn ipv6_fragment(
         ip_total_len: 0,
         ip_payload_len: payload_len,
         frag_data_off,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     }
 }
 
@@ -679,6 +689,8 @@ fn teardrop_drops() {
         ip_total_len: 24,             // 20 byte header + 4 byte payload (< 8)
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     };
     assert_eq!(
         state.check_packet("trust", &pkt, 1),
@@ -712,6 +724,8 @@ fn teardrop_first_fragment_passes() {
         ip_total_len: 24,
         ip_payload_len: 0,
         frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
     };
     // First fragment (offset=0) — teardrop only triggers on non-first
     // However no_flag check will trigger first since tcp_flags=0
@@ -1246,7 +1260,8 @@ fn tcp_syn_fin_passes_on_subsequent_fragment_with_syn_fin_bytes() {
 // ================================================================
 
 #[test]
-fn source_route_drops() {
+fn source_route_actual_lsrr_drops() {
+    // #2973: an actual LSRR (option 131) source-route packet must DROP.
     let mut state = make_state("trust", default_profile());
     let mut pkt = tcp_pkt(
         IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
@@ -1255,7 +1270,8 @@ fn source_route_drops() {
         80,
         TCP_SYN,
     );
-    pkt.ip_ihl = 6; // Options present (IHL > 5)
+    pkt.ip_ihl = 6;
+    pkt.saw_ipv4_source_route = true; // extractor decoded LSRR/SSRR
     assert_eq!(
         state.check_packet("trust", &pkt, 1),
         ScreenVerdict::Drop("ip-source-route")
@@ -1263,7 +1279,29 @@ fn source_route_drops() {
 }
 
 #[test]
-fn source_route_ipv6_ignored() {
+fn source_route_benign_options_pass() {
+    // #2973 fail-on-revert: a packet with IPv4 options present (IHL>5)
+    // but NO source-route option (e.g. router-alert/record-route/
+    // timestamp) must PASS. The pre-#2973 check dropped on ANY IHL>5;
+    // reverting to that makes this assertion fail.
+    let mut state = make_state("trust", default_profile());
+    let mut pkt = tcp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        1234,
+        80,
+        TCP_SYN,
+    );
+    pkt.ip_ihl = 6; // options present, but not source route
+    pkt.saw_ipv4_source_route = false;
+    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+}
+
+#[test]
+fn source_route_ipv6_routing_header_drops() {
+    // #2973 fail-on-revert: an IPv6 Routing Header (source-route routing
+    // type) must DROP for vSRX parity. The pre-#2973 check ignored IPv6
+    // entirely; reverting makes this PASS instead of DROP.
     let mut state = make_state("trust", default_profile());
     let mut pkt = tcp_pkt(
         IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
@@ -1272,8 +1310,149 @@ fn source_route_ipv6_ignored() {
         80,
         TCP_SYN,
     );
-    pkt.ip_ihl = 6; // IPv6 doesn't use IHL, should be ignored
-    assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
+    pkt.saw_ipv6_routing_header = true; // extractor saw RH0/type-1
+    assert_eq!(
+        state.check_packet("trust", &pkt, 1),
+        ScreenVerdict::Drop("ip-source-route")
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv4_lsrr_detected() {
+    // #2973: an IPv4 header carrying an LSRR (131) option sets
+    // saw_ipv4_source_route. Header: version=4, ihl=7 (28 bytes = 20
+    // base + 8 options), LSRR option {131, len=7, ptr=4, addr...} then
+    // padding/EOOL.
+    let ihl_words = 7u8;
+    let hdr_len = (ihl_words as usize) * 4; // 28
+    let mut frame = vec![0u8; 14 + hdr_len + 20];
+    let ip = 14;
+    frame[ip] = 0x40 | ihl_words; // version=4, ihl=7
+    frame[ip + 2..ip + 4].copy_from_slice(&((hdr_len + 20) as u16).to_be_bytes());
+    frame[ip + 9] = 6; // TCP
+    // options begin at ip+20
+    let opt = ip + 20;
+    frame[opt] = 131; // LSRR
+    frame[opt + 1] = 7; // option length
+    frame[opt + 2] = 4; // pointer
+    // bytes opt+3.. : route data (zeroed), then opt+7 = EOOL(0)
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        (hdr_len + 20) as u16,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    )
+    .expect("valid IPv4 LSRR packet parses");
+    assert!(
+        info.saw_ipv4_source_route,
+        "LSRR (option 131) must set saw_ipv4_source_route"
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv4_router_alert_not_source_route() {
+    // #2973 fail-on-revert: an IPv4 header with a benign router-alert
+    // option (148, length 4) must NOT set saw_ipv4_source_route.
+    let ihl_words = 6u8;
+    let hdr_len = (ihl_words as usize) * 4; // 24
+    let mut frame = vec![0u8; 14 + hdr_len + 20];
+    let ip = 14;
+    frame[ip] = 0x40 | ihl_words;
+    frame[ip + 2..ip + 4].copy_from_slice(&((hdr_len + 20) as u16).to_be_bytes());
+    frame[ip + 9] = 6;
+    let opt = ip + 20;
+    frame[opt] = 148; // router alert
+    frame[opt + 1] = 4; // length
+    // opt+2,opt+3 = value (0); fills the 4-byte option exactly.
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET as u8,
+        6,
+        0x02,
+        (hdr_len + 20) as u16,
+        IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
+        IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8)),
+        12345,
+        80,
+        14,
+    )
+    .expect("valid IPv4 router-alert packet parses");
+    assert!(
+        !info.saw_ipv4_source_route,
+        "router-alert (option 148) must NOT set saw_ipv4_source_route"
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv6_routing_header_detected() {
+    // #2973: an IPv6 Routing Header (NextHdr=43) with routing type 0
+    // (RH0, the deprecated source-route type) sets
+    // saw_ipv6_routing_header. Routing ext header is 8 bytes:
+    // {nexthdr, hdr_ext_len=0, routing_type=0, segs_left, ...}.
+    let mut frame = vec![0u8; 14 + 40 + 8 + 20];
+    frame[14] = 0x60; // version=6
+    frame[14 + 6] = 43; // NextHdr = ROUTING
+    let rh = 14 + 40;
+    frame[rh] = 6; // inner nexthdr = TCP
+    frame[rh + 1] = 0; // hdr_ext_len = 0 → 8 bytes
+    frame[rh + 2] = 0; // routing type 0 = RH0 (source route)
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET6 as u8,
+        6,
+        0x02,
+        28,
+        IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+        IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap()),
+        12345,
+        80,
+        14,
+    )
+    .expect("valid IPv6 routing-header packet parses");
+    assert!(
+        info.saw_ipv6_routing_header,
+        "IPv6 RH0 (routing type 0) must set saw_ipv6_routing_header"
+    );
+}
+
+#[test]
+fn extract_screen_info_ipv6_routing_type2_not_source_route() {
+    // #2973: routing type 2 is Mobile IPv6, NOT source routing — it must
+    // NOT set saw_ipv6_routing_header.
+    let mut frame = vec![0u8; 14 + 40 + 8 + 20];
+    frame[14] = 0x60;
+    frame[14 + 6] = 43;
+    let rh = 14 + 40;
+    frame[rh] = 6;
+    frame[rh + 1] = 0;
+    frame[rh + 2] = 2; // routing type 2 = Mobile IPv6 (not source route)
+
+    let info = extract_screen_info(
+        &frame,
+        libc::AF_INET6 as u8,
+        6,
+        0x02,
+        28,
+        IpAddr::V6("2001:db8::1".parse::<Ipv6Addr>().unwrap()),
+        IpAddr::V6("2001:db8::2".parse::<Ipv6Addr>().unwrap()),
+        12345,
+        80,
+        14,
+    )
+    .expect("valid IPv6 type-2 routing-header packet parses");
+    assert!(
+        !info.saw_ipv6_routing_header,
+        "IPv6 routing type 2 (Mobile IPv6) must NOT set saw_ipv6_routing_header"
+    );
 }
 
 // ================================================================


### PR DESCRIPTION
## Summary

Two userspace-dp screen/stateless correctness fixes, each with literal
fail-on-revert tests.

### #2973 — `ip-source-route` drops only an ACTUAL source route

The screen dropped on ANY IPv4 header with `IHL > 5` (any options
present), false-dropping benign router-alert (IGMP/MLD, RSVP),
record-route, timestamp and IP-security packets, and it ignored IPv6
entirely (RH0 source routes were never caught — a vSRX/SRX parity gap).

- `extract.rs` decodes the IPv4 options TLV region (bounded walk: EOOL
  ends, NOP one byte, length-prefixed otherwise; malformed length ends
  the walk) and sets `saw_ipv4_source_route` only on LSRR (131) / SSRR
  (137).
- `extract.rs` splits the IPv6 Routing Header (NH 43) out of the generic
  HOP/DEST arm, reads the routing type, and sets
  `saw_ipv6_routing_header` for type 0 (RH0) and legacy type 1 — not
  type 2 (Mobile IPv6).
- `check_source_route` drops iff either flag is set.
- The #2145 / #3022 poll_stages integration frames that used an IHL=6
  NOP-options header as a source-route proxy now carry a real LSRR
  option so they still exercise the drop path.

### #3027 — teardrop drops a non-first fragment with no/negative payload

`check_teardrop` only entered the payload-size branch when
`ip_total_len > hdr_len`, so a crafted non-first fragment with
`ip_total_len <= hdr_len` (zero / "negative" payload) slipped through as
a PASS (and would have underflowed the subtraction). It is now dropped
before the payload size is computed.

## Fail-on-revert (each proven RED by copy-aside revert of its fix)

- #2973: benign IHL>5 / router-alert packet now PASSes (RED on revert to
  the old IHL>5 check); an IPv6 Routing Header source route DROPs (RED
  on revert — old check ignored IPv6); an actual LSRR packet DROPs
  (positive control, green both ways). Plus extractor unit tests
  (LSRR-detected, router-alert-not, IPv6 RH0-detected, IPv6 type-2-not).
- #3027: `ip_total_len == hdr_len` (zero payload) and `ip_total_len <
  hdr_len` (under-length) both DROP as teardrop; both go RED (Pass) on
  revert to the `> hdr_len` gate.

## Gates

- `cargo build --release -p xpf-userspace-dp` — clean.
- `cargo test --release -p xpf-userspace-dp screen::` — 134 passed.
- Full crate suite green except two pre-existing timing-flaky tests
  (`event_stream::...stalled_consumer...`,
  `afxdp::worker_queue::...concurrent_recovery...`) that pass in
  isolation and are unrelated to these changes.

Closes #2973
Closes #3027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi