### PR TITLE
nat: expand source-NAT pool subnet to the full CIDR range (#3049)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-06-25 — #3049: source-NAT pool subnet expanded to full CIDR range
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed source-NAT pool subnet truncation. The Rust parser
+  `parse_source_nat_rules_with_previous` stripped the mask off a pool
+  address and kept a single `IpAddr`, so a subnet-style pool like
+  `203.0.113.0/28` (16 addresses) collapsed to one host — severe pool/port
+  exhaustion with no operator signal. The Go compiler passes a bare prefix
+  verbatim (only `address X to Y` ranges were expanded), and the host-mask
+  commit gate covered only NAT64 pools. New `expand_pool_address` helper
+  enumerates the FULL prefix range (network..=broadcast inclusive) into
+  `pool_addresses_v4`/`v6` so the port allocator round-robins/hashes across
+  the whole pool; a single-host prefix (/32, /128) still yields exactly one
+  address; an over-broad prefix beyond `MAX_POOL_PREFIX_HOSTS` (65536) is
+  rejected as `SourceNatFailureReason::InvalidPool` (fail-closed). Added 3
+  fail-on-revert tests (subnet expands to 16, host-CIDR stays 1 + v6 /120
+  → 256, over-broad /8 → invalid). Updated `userspace-dp/README.md`.
+- **File(s)**: userspace-dp/src/nat/source.rs, userspace-dp/src/nat/tests.rs,
+  userspace-dp/README.md, _Log.md
+
 ## 2026-06-25 — #3045: REST /security/policies includes global policies
 
 - **Timestamp**: 2026-06-25

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -140,6 +140,24 @@ logging rules, not these specific hot-path constants.
   published or deleted by this path. Fail-on-revert: the wiring test
   `close_delta_deletes_dnat_table_entry_for_snat_flow` plus the key-SSOT
   tests in `src/afxdp/tests.rs`.
+- **Source-NAT pool subnet expansion (#3049)**: a source-NAT pool
+  address entry may be a bare IP, a host CIDR (`/32`, `/128`), or a
+  subnet CIDR (e.g. `203.0.113.0/28`). Junos uses the FULL prefix range
+  for a source-NAT pool, so `parse_source_nat_rules_with_previous`
+  (`src/nat/source.rs`) enumerates every address in the prefix
+  (network..=broadcast inclusive) via `expand_pool_address`, populating
+  `pool_addresses_v4` / `pool_addresses_v6` so the port allocator
+  round-robins / hashes across the whole range. The pre-#3049 code
+  stripped the mask and kept only the network host, silently collapsing
+  a `/28` (16 addresses) to one — severe pool/port exhaustion with no
+  signal. A single-host prefix still yields exactly one address. An
+  over-broad prefix whose host count exceeds `MAX_POOL_PREFIX_HOSTS`
+  (65536; covers up to a v4 `/16` or v6 `/112`) is rejected as an
+  invalid pool (`SourceNatFailureReason::InvalidPool`) — fail-closed, so
+  the operator gets a clear signal rather than a clamped or OOM pool.
+  Fail-on-revert: `pool_snat_subnet_expands_full_cidr_range`,
+  `pool_snat_host_cidr_yields_single_address`, and
+  `pool_snat_overbroad_prefix_marks_invalid` in `src/nat/tests.rs`.
 - `HEARTBEAT_GRACE_PERIOD_NS = 6 s` is defined in
   `userspace-dp/src/afxdp/mod.rs` but currently `#[allow(dead_code)]`
   — reserved for future XDP-shim heartbeat gating logic. Workers

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -208,6 +208,76 @@ impl SourceNatRule {
     }
 }
 
+/// Upper bound on how many host addresses a single source-NAT pool prefix is
+/// expanded into (#3049). Realistic SNAT pools are far smaller; the cap bounds
+/// memory and the allocator's per-address port table for an over-broad prefix
+/// (an unbounded `/8` would be ~16M entries, and any v6 prefix shorter than
+/// `/112` is astronomically large). A prefix whose host count exceeds this is
+/// rejected as an invalid pool so the operator gets a clear commit/runtime
+/// signal rather than a silently clamped pool.
+pub(crate) const MAX_POOL_PREFIX_HOSTS: u64 = 65536;
+
+/// Expand one source-NAT pool address entry into its constituent host
+/// addresses (#3049). A pool entry is either a bare IP, a host CIDR
+/// (`/32`, `/128`), or a subnet CIDR (e.g. `203.0.113.0/28`). Junos uses the
+/// FULL prefix range for a source-NAT pool, so a subnet must enumerate every
+/// address in the prefix (network..=broadcast inclusive) rather than collapse
+/// to the single network host — the pre-#3049 bug that stripped the mask and
+/// kept only one address. A single-host prefix yields exactly one address.
+///
+/// Returns `false` if the entry does not parse or expands beyond
+/// `MAX_POOL_PREFIX_HOSTS` (caller marks the pool invalid).
+fn expand_pool_address(
+    addr_str: &str,
+    out_v4: &mut Vec<Ipv4Addr>,
+    out_v6: &mut Vec<Ipv6Addr>,
+) -> bool {
+    if addr_str.contains('/') {
+        // CIDR form: enumerate every address in the prefix range.
+        match addr_str.parse::<IpNet>() {
+            Ok(IpNet::V4(net)) => {
+                let host_bits = (32 - net.prefix_len()) as u32;
+                let count = 1u64 << host_bits; // 1 for /32
+                if count > MAX_POOL_PREFIX_HOSTS {
+                    return false;
+                }
+                let base = u32::from(net.network());
+                for i in 0..count {
+                    out_v4.push(Ipv4Addr::from(base.wrapping_add(i as u32)));
+                }
+                true
+            }
+            Ok(IpNet::V6(net)) => {
+                let host_bits = (128 - net.prefix_len()) as u32;
+                // host_bits >= 17 already exceeds the cap; avoid 1u128 << 64+.
+                if host_bits >= 64 || (1u128 << host_bits) > MAX_POOL_PREFIX_HOSTS as u128 {
+                    return false;
+                }
+                let count = 1u128 << host_bits; // 1 for /128
+                let base = u128::from(net.network());
+                for i in 0..count {
+                    out_v6.push(Ipv6Addr::from(base.wrapping_add(i)));
+                }
+                true
+            }
+            Err(_) => false,
+        }
+    } else {
+        // Bare IP (no mask): exactly one host.
+        match addr_str.parse::<IpAddr>() {
+            Ok(IpAddr::V4(v4)) => {
+                out_v4.push(v4);
+                true
+            }
+            Ok(IpAddr::V6(v6)) => {
+                out_v6.push(v6);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn parse_source_nat_rules(snaps: &[SourceNATRuleSnapshot]) -> Vec<SourceNatRule> {
     parse_source_nat_rules_with_previous(snaps, None, &NatCounterStore::default())
@@ -283,14 +353,16 @@ pub(crate) fn parse_source_nat_rules_with_previous(
         // Parse pool addresses and port range for pool-mode SNAT.
         let mut invalid_pool_address = false;
         for addr_str in &snap.pool_addresses {
-            // Pool addresses may be bare IPs or /32 CIDRs — strip the mask.
-            let ip_str = addr_str.split('/').next().unwrap_or(addr_str);
-            if let Ok(ip) = ip_str.parse::<IpAddr>() {
-                match ip {
-                    IpAddr::V4(v4) => rule.pool_addresses_v4.push(v4),
-                    IpAddr::V6(v6) => rule.pool_addresses_v6.push(v6),
-                }
-            } else {
+            // #3049: a pool entry may be a bare IP, a host CIDR (/32, /128), or
+            // a subnet CIDR. A subnet must enumerate the FULL prefix range — the
+            // pre-#3049 code stripped the mask and kept only the network host, so
+            // a `203.0.113.0/28` pool collapsed to a single address. A single-
+            // host prefix still yields exactly one address.
+            if !expand_pool_address(
+                addr_str,
+                &mut rule.pool_addresses_v4,
+                &mut rule.pool_addresses_v6,
+            ) {
                 invalid_pool_address = true;
             }
         }

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -2556,6 +2556,134 @@ fn pool_snat_multiple_addresses_round_robin() {
     );
 }
 
+// #3049: a subnet-style source-NAT pool address must enumerate the FULL
+// prefix range, not collapse to the single network host. This is the
+// fail-on-revert guard: pre-#3049 the parser stripped the `/28` mask and kept
+// only `203.0.113.0`, so the pool had ONE address. With the fix a `/28` pool
+// expands to all 16 host addresses and round-robin spreads across them.
+#[test]
+fn pool_snat_subnet_expands_full_cidr_range() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-subnet".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "subnet-pool".to_string(),
+        // A /28 is 16 addresses: 203.0.113.0 .. 203.0.113.15.
+        pool_addresses: vec!["203.0.113.0/28".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    // FAIL-ON-REVERT: the whole /28 must be enumerated. Pre-#3049 this was 1.
+    assert_eq!(
+        rules[0].pool_addresses_v4.len(),
+        16,
+        "a /28 source-NAT pool must expand to all 16 host addresses, not be \
+         truncated to a single host"
+    );
+    assert_eq!(
+        rules[0].pool_addresses_v4[0],
+        "203.0.113.0".parse::<std::net::Ipv4Addr>().unwrap()
+    );
+    assert_eq!(
+        rules[0].pool_addresses_v4[15],
+        "203.0.113.15".parse::<std::net::Ipv4Addr>().unwrap()
+    );
+
+    // The allocator must actually hand out more than one address from the
+    // expanded range — a single-host truncation would only ever return one.
+    let mut seen = std::collections::HashSet::new();
+    for i in 0..64u8 {
+        let src = format!("10.0.1.{}", i);
+        let d = match_source_nat(
+            &rules,
+            "lan",
+            "wan",
+            src.parse().unwrap(),
+            "8.8.8.8".parse().unwrap(),
+            None,
+            None,
+        )
+        .expect("should match subnet pool rule");
+        if let Some(IpAddr::V4(addr)) = d.rewrite_src {
+            seen.insert(addr);
+        }
+    }
+    assert!(
+        seen.len() > 1,
+        "expected SNAT to spread across multiple pool addresses, saw {:?}",
+        seen
+    );
+}
+
+// #3049: a single-host pool prefix (/32, /128) must still yield exactly one
+// address — the expansion must not over-broaden a host route.
+#[test]
+fn pool_snat_host_cidr_yields_single_address() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-host".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "host-pool".to_string(),
+        pool_addresses: vec!["203.0.113.7/32".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    assert_eq!(rules[0].pool_addresses_v4.len(), 1);
+    assert_eq!(
+        rules[0].pool_addresses_v4[0],
+        "203.0.113.7".parse::<std::net::Ipv4Addr>().unwrap()
+    );
+
+    // A v6 /120 expands to 256 addresses; a /128 stays a single host.
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-v6".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["::/0".to_string()],
+        pool_name: "v6-pool".to_string(),
+        pool_addresses: vec!["2001:db8::/120".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    assert_eq!(rules[0].pool_addresses_v6.len(), 256);
+}
+
+// #3049: an over-broad pool prefix (host count beyond MAX_POOL_PREFIX_HOSTS)
+// is rejected as an invalid pool rather than silently clamped or OOM-expanded.
+#[test]
+fn pool_snat_overbroad_prefix_marks_invalid() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "pool-huge".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        pool_name: "huge-pool".to_string(),
+        // /8 = ~16M hosts, far beyond the cap.
+        pool_addresses: vec!["10.0.0.0/8".to_string()],
+        port_low: 1024,
+        port_high: 65535,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    assert!(rules[0].pool_addresses_v4.is_empty());
+    let d = match_source_nat(
+        &rules,
+        "lan",
+        "wan",
+        "10.0.1.100".parse().unwrap(),
+        "8.8.8.8".parse().unwrap(),
+        None,
+        None,
+    );
+    // An invalid pool yields no usable translation (fail-closed, not a single
+    // truncated host).
+    assert!(d.is_none());
+}
+
 // --- #1827 PR-3: per-uplink SNAT pool selection by to-zone ---
 //
 // Multi-WAN per-uplink pools need NO new matcher: the to-zone fed to


### PR DESCRIPTION
## Summary

Source-NAT POOL with a subnet (CIDR) was truncated to a single host. The
Rust parser (`parse_source_nat_rules_with_previous`, `userspace-dp/src/nat/source.rs`)
stripped the mask off a pool address and kept one `IpAddr`, so a configured
pool like `203.0.113.0/28` (16 addresses) only ever SNAT'd to `203.0.113.0`
— severe pool/port exhaustion with no operator signal.

Root cause spans two sides:
- The Go compiler (`pkg/config/compiler_nat.go`) passes a bare `address <prefix>`
  to the wire verbatim; only `address X to Y` ranges are expanded.
- The host-mask commit gate covers only NAT64 source pools, not plain source-NAT pools.
- The Rust side then split on `/`, kept the first label, and pushed a single host.

## Fix

New `expand_pool_address` helper enumerates the FULL prefix range
(network..=broadcast inclusive) into `pool_addresses_v4`/`pool_addresses_v6`,
so the port allocator round-robins / hashes across every address — the real
Junos source-NAT pool semantics.

- Single-host prefix (`/32`, `/128`) and bare IP still yield exactly one address.
- An over-broad prefix beyond `MAX_POOL_PREFIX_HOSTS` (65536; up to a v4 `/16`
  or v6 `/112`) is rejected as `SourceNatFailureReason::InvalidPool` (fail-closed),
  bounding memory and the per-address port table instead of clamping or OOM.

Distinct from #3031 (static-NAT subnet) and #3029 (DNAT prefix) — this is the
source-NAT pool path.

## Fail-on-revert

Three tests in `src/nat/tests.rs`, all RED if the parser is reverted to
single-host truncation (verified by copy-aside revert: `left: 1, right: 16`):
- `pool_snat_subnet_expands_full_cidr_range` — `/28` -> 16 addresses, SNAT spreads across them
- `pool_snat_host_cidr_yields_single_address` — `/32` (and v6 `/128`) stays 1; `/120` -> 256
- `pool_snat_overbroad_prefix_marks_invalid` — `/8` -> invalid pool, no usable translation

## Gates (foreground)

- `cargo build --release -p xpf-userspace-dp` — clean
- `cargo test -p xpf-userspace-dp nat::` — 133 passed

Docs: `userspace-dp/README.md` + `_Log.md`.

Closes #3049

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi