### PR TITLE
grpcapi: include global policies in hit-count text view (#3059)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-06-25 — #3059: gRPC hit-count text includes global policies
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed `showPoliciesHitCount` (gRPC text `show security policies
+  hit-count`) to append a global-policy section after the zone-pair loop,
+  rendering each `cfg.Security.GlobalPolicies` entry with from/to zone `"*"`.
+  Global counter IDs continue from the zone-pair `policySetID`
+  (`policySetID*MaxRulesPerPolicy + i`), keeping global hit counters aligned
+  with the dataplane and matching the gRPC detail view, CLI, Prometheus
+  collector, REST inventory (#3045/#3050), and structured GetPolicies. A
+  from/to-zone filter suppresses the global section (selects zone-pair only).
+  Added fail-on-revert test `TestShowPoliciesHitCountIncludesGlobalPolicies`
+  (RED when globals omitted). Updated pkg/grpcapi README.
+- **File(s)**: pkg/grpcapi/server_show_policies_text.go,
+  pkg/grpcapi/server_show_policies_hitcount_globals_test.go,
+  pkg/grpcapi/README.md
+
 ## 2026-06-25 — #3045: REST /security/policies includes global policies
 
 - **Timestamp**: 2026-06-25

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -92,6 +92,19 @@ contract.
   user-supplied target after a `--` end-of-options separator so a
   `-`-prefixed target is an operand, not a flag (option-confusion
   hardening, #2084).
+- Policy text views (`server_show_policies_text.go`) must render BOTH
+  zone-pair AND global policies (#3059). `showPoliciesHitCount` and
+  `showPoliciesDetail` loop `cfg.Security.Policies` and then append a
+  global section from `cfg.Security.GlobalPolicies` with from/to zone
+  `"*"`. Global counter IDs CONTINUE from the zone-pair loop —
+  `policySetID*dataplane.MaxRulesPerPolicy + i` where `policySetID ==
+  len(cfg.Security.Policies)` after the zone-pair loop — so global hit
+  counters stay aligned with the dataplane and match the gRPC detail
+  view, CLI, Prometheus collector, REST inventory (#3045/#3050), and
+  structured `GetPolicies`. A `from-zone`/`to-zone` filter selects
+  zone-pair policies only, so the global section is suppressed when a
+  filter is set. Omitting globals from any one surface is the #3059 /
+  #3045 class of blind-spot bug.
 - Request-supplied numeric fields are signed on the wire and must be
   range-checked before they index/slice/size anything (#2282). `Complete`
   rejects a negative `pos` with `InvalidArgument` before slicing

--- a/pkg/grpcapi/server_show_policies_hitcount_globals_test.go
+++ b/pkg/grpcapi/server_show_policies_hitcount_globals_test.go
@@ -1,0 +1,136 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3059: the gRPC text `show security policies hit-count` view looped only
+// zone-pair policies and omitted global policies, even though the runtime
+// enforces them and every other surface (gRPC detail, CLI, Prometheus, REST
+// inventory after #3045/#3050, structured GetPolicies) counts them. These
+// tests are the fail-on-revert guard: the hit-count text must include a
+// global policy row with the correct dataplane counter ID.
+
+// globalHitCountStore builds a config with one zone-pair policy plus one
+// global policy and enables policy-stats so the hit-count surface reads live
+// counters.
+func globalHitCountStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    policy-stats {
+        system-wide enable;
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy zone-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        global {
+            policy global-deny {
+                match { source-address any; destination-address any; application any; }
+                then { deny; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if !cfg.Security.PolicyStatsEnabled {
+		t.Fatal("PolicyStatsEnabled = false, want true")
+	}
+	if len(cfg.Security.GlobalPolicies) != 1 {
+		t.Fatalf("GlobalPolicies len = %d, want 1", len(cfg.Security.GlobalPolicies))
+	}
+	return store
+}
+
+// globalDenyPolicyID resolves the dataplane counter slot for the single
+// global global-deny rule. Global counter IDs continue from the zone-pair
+// loop: the first global rule uses policySetID == len(cfg.Security.Policies),
+// the same alignment the dataplane and #3045/#3050 use.
+func globalDenyPolicyID(store *configstore.Store) uint32 {
+	cfg := store.ActiveConfig()
+	return uint32(len(cfg.Security.Policies))*dataplane.MaxRulesPerPolicy + 0
+}
+
+// TestShowPoliciesHitCountIncludesGlobalPolicies is the #3059 fail-on-revert
+// guard: the gRPC hit-count text must render a global policy row with the
+// dataplane counter read at the continued (global) counter ID. If
+// showPoliciesHitCount reverts to zone-pair-only enumeration, the global row
+// is absent and this test goes RED.
+func TestShowPoliciesHitCountIncludesGlobalPolicies(t *testing.T) {
+	store := globalHitCountStore(t)
+	globalID := globalDenyPolicyID(store)
+	s := &Server{
+		store: store,
+		dp: &schedulerCounterGRPCDP{
+			Manager: dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{
+				globalID: {Packets: 77, Bytes: 7700},
+			},
+		},
+	}
+
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "policies-hit-count"})
+	if err != nil {
+		t.Fatalf("ShowText(policies-hit-count) error = %v", err)
+	}
+	out := resp.GetOutput()
+
+	// The zone-pair row must still be present (no regression).
+	if !strings.Contains(out, "zone-allow") {
+		t.Fatalf("zone-pair policy zone-allow missing from hit-count output:\n%s", out)
+	}
+
+	// Locate the global-deny data row.
+	var row string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "global-deny") {
+			row = line
+			break
+		}
+	}
+	if row == "" {
+		t.Fatalf("global policy global-deny missing from hit-count output; "+
+			"globals omitted (#3059 regression):\n%s", out)
+	}
+	// Global row uses "*"/"*" zones and the live counts at the continued ID.
+	fields := strings.Fields(row)
+	if len(fields) < 2 || fields[0] != "*" || fields[1] != "*" {
+		t.Fatalf("global row missing */* zone columns: %q", row)
+	}
+	if !strings.Contains(row, "deny") {
+		t.Fatalf("global-deny row missing deny action: %q", row)
+	}
+	if !strings.Contains(row, "77") || !strings.Contains(row, "7700") {
+		t.Fatalf("global-deny row missing live counts (want 77/7700) at counter ID %d:\n%s",
+			globalID, row)
+	}
+}

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -89,6 +89,43 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 		}
 		policySetID++
 	}
+	// Global policies (#3059): the runtime evaluates global policies after
+	// the exact zone-pair policies, and the gRPC detail view, CLI,
+	// Prometheus collector, and structured GetPolicies all expose them.
+	// The hit-count text surface must too — otherwise an operator using
+	// the exact command meant to prove which policy is catching traffic
+	// sees zero evidence for a global emergency deny/permit. Render globals
+	// with from/to zone "*" (matching the other surfaces). Counter IDs
+	// continue from the zone-pair loop: policySetID*MaxRulesPerPolicy + i,
+	// keeping the global slots aligned with the dataplane (#3045/#3050 did
+	// the same for the REST inventory). A from/to-zone filter selects
+	// zone-pair policies only, so suppress globals when one is set.
+	if len(cfg.Security.GlobalPolicies) > 0 && filterFrom == "" && filterTo == "" {
+		for i, pol := range cfg.Security.GlobalPolicies {
+			if pol == nil {
+				continue
+			}
+			action := "permit"
+			switch pol.Action {
+			case 1:
+				action = "deny"
+			case 2:
+				action = "reject"
+			}
+			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+			var pkts, bytes uint64
+			if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
+				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
+					pkts = counters.Packets
+					bytes = counters.Bytes
+				}
+			}
+			totalPkts += pkts
+			totalBytes += bytes
+			fmt.Fprintf(buf, "%-12s %-12s %-24s %-8s %12d %16d\n",
+				"*", "*", pol.Name, action, pkts, bytes)
+		}
+	}
 	fmt.Fprintln(buf, strings.Repeat("-", 88))
 	fmt.Fprintf(buf, "%-48s %8s %12d %16d\n", "Total", "", totalPkts, totalBytes)
 }


### PR DESCRIPTION
## Summary
The gRPC text `show security policies hit-count` view (`showPoliciesHitCount` in `pkg/grpcapi/server_show_policies_text.go`) looped only zone-pair policies and omitted global policies — even though the runtime enforces them and every other surface counts them (gRPC detail view, CLI, Prometheus collector, REST inventory after #3045/#3050, structured `GetPolicies`). An operator using the exact command meant to prove which policy catches traffic saw zero evidence for a global emergency deny/permit.

This is the gRPC sibling of #3045/#3050 (REST inventory) and reuses the same policySetID-alignment pattern.

## Fix
Append a global-policy section after the zone-pair loop, rendering each `cfg.Security.GlobalPolicies` entry with from/to zone `"*"`. Global counter IDs continue from the zone-pair loop (`policySetID*dataplane.MaxRulesPerPolicy + i`, with `policySetID == len(cfg.Security.Policies)`), keeping global hit counters aligned with the dataplane exactly as the detail view and #3045/#3050 already do. Nil entries skipped; a from/to-zone filter suppresses the global section (zone-pair selection only); the policy-stats gate and running Total are preserved.

## Validation
- **Fail-on-revert test** `TestShowPoliciesHitCountIncludesGlobalPolicies`: one zone-pair + one global policy, policy-stats enabled, fake dataplane populated at the continued global counter ID; asserts the `*`/`*` `global-deny` row with live `77/7700` counts. Verified **RED** when the global block is removed, **GREEN** with the fix.
- `go build ./...`, `gofmt -l` clean on touched files, `go vet ./pkg/grpcapi/...`, `go test ./pkg/grpcapi/...` (155 passed) all green.
- Updated `pkg/grpcapi/README.md` + `_Log.md`.

Closes #3059

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi