### PR TITLE
flowexport: preserve sub-second flow StartTime (#2853)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -18708,3 +18708,27 @@ top.
   per #2871. No code change. Build clean; nat:: 130 / static_nat 28 still green.
 - **File(s)**: docs/feature-coverage.md,
   userspace-dp/src/afxdp/poll_descriptor/nat_exception.rs, _Log.md
+
+- **Timestamp**: 2026-06-25
+- **Action**: #2853 — flowexport session-creation StartTime kept only integer
+  Unix seconds (offset 108, u32), so every flow opened in the same wall-clock
+  second exported one StartTime, flattening IPFIX flowStartMilliseconds for
+  short flows. Fix: the SESSION_CLOSE RT_FLOW frame now ALSO carries the
+  creation instant's sub-second NANOSECOND remainder (0..=999_999_999) in the
+  close-unused policy_id slot (offset 44, LE u32), produced by the new
+  monotonic_ns_to_unix_secs_subnanos helper. The Go decoder reads it as
+  EventRecord.CreatedNanos and zeroes PolicyID (a close never carried a real
+  policy id, so policy-name resolution is unchanged); flowStartTime now builds
+  time.Unix(Created, CreatedNanos) for millisecond-accurate StartTime. Gates:
+  go build ./... clean, go test ./pkg/flowexport/... ./pkg/logging/... 196
+  passed, go vet clean, gofmt clean on touched files; cargo build clean,
+  event_stream:: 58 passed. Fail-on-revert proven RED both sides (Go
+  flowStartTime→whole-second; Rust [44:48] write removed).
+- **File(s)**: userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/event_stream/codec.rs,
+  userspace-dp/src/event_stream/codec_tests.rs,
+  userspace-dp/src/event_stream/tests.rs,
+  userspace-dp/src/event_stream/README.md, pkg/logging/eventbuf.go,
+  pkg/logging/ringbuf.go, pkg/logging/binary_test.go,
+  pkg/flowexport/manager.go, pkg/flowexport/flowstart_test.go,
+  pkg/flowexport/README.md, _Log.md

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -59,6 +59,23 @@ bumps a per-exporter `EstimatedDurations()` counter so operators can see
 how often the heuristic is still in play. The byte/packet **volume**
 counters remain 0 pending #2501 — only the timing is now real.
 
+**#2853 — the flow StartTime keeps MILLISECOND resolution.** #2465's
+`created` field is integer Unix **seconds** (offset 108, u32), so every
+flow opened in the same wall-clock second exported the same StartTime —
+up to ~1000ms of error for short flows (DNS, single HTTP requests),
+flattening IPFIX `flowStartMilliseconds` / `flowStartMicroseconds` and
+making the data unusable for micro-burst analysis or sub-second billing.
+The SESSION_CLOSE RT_FLOW frame now ALSO carries the creation instant's
+sub-second **nanosecond** remainder (0..=999,999,999) in the
+close-unused `policy_id` slot (offset 44, little-endian u32). The Go
+decoder surfaces it as `logging.EventRecord.CreatedNanos` (and zeroes
+`PolicyID`, since a close never carried a real policy id, so the
+close-record policy-name resolution is unchanged); `flowStartTime`
+combines both as `time.Unix(Created, CreatedNanos)`. The exported
+`flowStartMilliseconds` (`StartTime.UnixMilli()`) and NetFlow
+`uptimeMs` now reflect the true sub-second start. The fallback path
+(`Created == 0`) is unchanged.
+
 **#2526 — the exporters now carry the post-NAT (translated) tuple.**
 Before #2526 both the NetFlow v9 and IPFIX templates/encoders exported
 only the pre-NAT 5-tuple, so a collector saw the private endpoint of a

--- a/pkg/flowexport/flowstart_test.go
+++ b/pkg/flowexport/flowstart_test.go
@@ -178,6 +178,87 @@ func TestIPFIXExportSessionCloseUsesRealCreated(t *testing.T) {
 	}
 }
 
+// #2853 fail-on-revert: two flows created within the SAME integer second but at
+// distinct sub-second offsets must keep distinct StartTimes (millisecond
+// resolution) in the flow record. Before #2853 the dataplane stamped only the
+// truncated second, so both flows collapsed onto the same StartTime; this test
+// goes RED if flowStartTime is reverted to time.Unix(int64(rec.Created), 0)
+// (i.e. drops rec.CreatedNanos).
+func TestFlowStartTimeKeepsSubSecondResolution(t *testing.T) {
+	end := time.Unix(1_700_000_300, 0)
+	sec := uint32(1_700_000_000)
+
+	// Two short flows opened ~600ms apart inside the same wall-clock second.
+	recEarly := logging.EventRecord{
+		Time: end, Type: "SESSION_CLOSE", Protocol: "UDP",
+		Created: sec, CreatedNanos: 100_000_000, // .100s
+	}
+	recLate := logging.EventRecord{
+		Time: end, Type: "SESSION_CLOSE", Protocol: "UDP",
+		Created: sec, CreatedNanos: 700_000_000, // .700s
+	}
+
+	startEarly, estEarly := flowStartTime(recEarly, 17)
+	startLate, estLate := flowStartTime(recLate, 17)
+	if estEarly || estLate {
+		t.Fatal("a real created timestamp must NOT use the estimate")
+	}
+	if startEarly.Equal(startLate) {
+		t.Fatalf("same-second flows must have DISTINCT sub-second StartTimes; both = %v (sub-second truncated?)", startEarly)
+	}
+	// Exact instants — proves the nanos are combined, not discarded.
+	if want := time.Unix(int64(sec), 100_000_000); !startEarly.Equal(want) {
+		t.Fatalf("early StartTime = %v, want %v", startEarly, want)
+	}
+	if want := time.Unix(int64(sec), 700_000_000); !startLate.Equal(want) {
+		t.Fatalf("late StartTime = %v, want %v", startLate, want)
+	}
+	// Millisecond delta survives — this is what IPFIX flowStartMilliseconds /
+	// NetFlow uptimeMs render from StartTime.
+	if d := startLate.Sub(startEarly); d != 600*time.Millisecond {
+		t.Fatalf("sub-second delta = %v, want 600ms", d)
+	}
+}
+
+// #2853 fail-on-revert (IPFIX end-to-end): two SESSION_CLOSE events in the same
+// second but at distinct sub-second offsets must produce flow records whose
+// exported flowStartMilliseconds differ. Reverting the dataplane stamp or
+// flowStartTime to whole-second resolution makes both UnixMilli() collapse to
+// sec*1000 and this assertion fails.
+func TestIPFIXExportSessionCloseSubSecondStart(t *testing.T) {
+	e, err := NewIPFIXExporter(&ExportConfig{})
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	end := time.Unix(1_700_000_600, 0)
+	sec := uint32(1_700_000_100)
+	evt := SessionCloseData{SrcIP: net.ParseIP("10.0.1.102"), DstIP: net.ParseIP("172.16.80.200"), Protocol: 6}
+
+	e.ExportSessionClose(logging.EventRecord{
+		Time: end, Type: "SESSION_CLOSE", Created: sec, CreatedNanos: 250_000_000, Protocol: "TCP",
+	}, evt)
+	e.ExportSessionClose(logging.EventRecord{
+		Time: end, Type: "SESSION_CLOSE", Created: sec, CreatedNanos: 850_000_000, Protocol: "TCP",
+	}, evt)
+
+	v4, _ := e.batch.drain()
+	if len(v4) != 2 {
+		t.Fatalf("expected 2 batched flows, got %d", len(v4))
+	}
+	got := map[int64]bool{
+		v4[0].StartTime.UnixMilli(): true,
+		v4[1].StartTime.UnixMilli(): true,
+	}
+	if len(got) != 2 {
+		t.Fatalf("same-second flows produced identical flowStartMilliseconds (sub-second truncated?): %v", got)
+	}
+	wantA := int64(sec)*1000 + 250
+	wantB := int64(sec)*1000 + 850
+	if !got[wantA] || !got[wantB] {
+		t.Fatalf("flowStartMilliseconds = %v, want {%d, %d}", got, wantA, wantB)
+	}
+}
+
 // #2465 (IPFIX fallback): no created ts → estimate + counter bump.
 func TestIPFIXExportSessionCloseFallbackBumpsCounter(t *testing.T) {
 	e, err := NewIPFIXExporter(&ExportConfig{})

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -711,7 +711,13 @@ type SessionCloseData struct {
 // can bump an "estimated-duration-used" counter for operator visibility.
 func flowStartTime(rec logging.EventRecord, proto uint8) (time.Time, bool) {
 	if rec.Created > 0 {
-		created := time.Unix(int64(rec.Created), 0)
+		// #2853: combine the integer Unix second (rec.Created) with the
+		// sub-second nanosecond remainder (rec.CreatedNanos, carried on the
+		// [44:48] wire slot) so the StartTime keeps millisecond resolution.
+		// Pre-#2853 this truncated to the whole second, collapsing every flow
+		// opened in the same second onto one start instant and flattening
+		// IPFIX flowStartMilliseconds for short flows.
+		created := time.Unix(int64(rec.Created), int64(rec.CreatedNanos))
 		// Guard against a created stamp at or after the close time (clock skew
 		// across the monotonic→wall conversion): clamp to the EndTime so the
 		// flow never reports a negative duration.

--- a/pkg/logging/binary_test.go
+++ b/pkg/logging/binary_test.go
@@ -399,6 +399,73 @@ func TestDecodeRawEventCarriesCreatedStamp(t *testing.T) {
 	}
 }
 
+// TestDecodeRawEventCarriesCreatedSubNanos is the #2853 cross-language layout
+// check: the Rust encoder writes the creation instant's sub-second NANOSECOND
+// remainder into the SESSION_CLOSE-unused policy_id slot at offset 44 (LE u32).
+// DecodeRawEventRecord must surface it into EventRecord.CreatedNanos AND clear
+// PolicyID (so the close record's policy id/name stays the "no policy" value,
+// not the nanosecond bits). Reverting the decoder to read [44:48] as PolicyID
+// (the pre-#2853 behavior) makes CreatedNanos 0 and PolicyID nonzero — both
+// assertions catch that.
+func TestDecodeRawEventCarriesCreatedSubNanos(t *testing.T) {
+	const (
+		createdSecs  = uint32(1_700_000_000)
+		createdNanos = uint32(123_456_789) // 123.456789 ms into the second
+		closeNS      = uint64(1_700_000_300_000_000_000)
+	)
+	data := make([]byte, rawEventWireSize)
+	binary.LittleEndian.PutUint64(data[0:8], closeNS)
+	data[40], data[41] = 0x30, 0x39
+	data[42], data[43] = 0x01, 0xbb
+	data[52] = eventTypeSessionClose
+	data[53] = 6
+	data[55] = addrFamilyInet
+	copy(data[8:12], net.ParseIP("10.0.1.102").To4())
+	copy(data[24:28], net.ParseIP("172.16.80.200").To4())
+	binary.LittleEndian.PutUint32(data[108:112], createdSecs)
+	// offset 44: created sub-second nanos (LE u32) — the #2853 repurposed slot.
+	binary.LittleEndian.PutUint32(data[44:48], createdNanos)
+
+	rec, ok := DecodeRawEventRecord(data)
+	if !ok {
+		t.Fatal("DecodeRawEventRecord rejected a valid SESSION_CLOSE frame")
+	}
+	if rec.CreatedNanos != createdNanos {
+		t.Fatalf("rec.CreatedNanos = %d, want %d (offset 44 LE u32)", rec.CreatedNanos, createdNanos)
+	}
+	if rec.PolicyID != 0 {
+		t.Fatalf("rec.PolicyID = %d, want 0 (the [44:48] slot is repurposed on a close)", rec.PolicyID)
+	}
+}
+
+// TestDecodeRawEventPolicyDenyKeepsPolicyID guards the #2853 negative: a
+// non-SESSION_CLOSE frame must still read [44:48] as the real PolicyID (the
+// repurpose is close-only). A POLICY_DENY carrying a policy id must surface it.
+func TestDecodeRawEventPolicyDenyKeepsPolicyID(t *testing.T) {
+	const policyID = uint32(4242)
+	data := make([]byte, rawEventWireSize)
+	data[40], data[41] = 0x30, 0x39
+	data[42], data[43] = 0x01, 0xbb
+	data[52] = eventTypePolicyDeny
+	data[53] = 6
+	data[54] = actionDeny
+	data[55] = addrFamilyInet
+	copy(data[8:12], net.ParseIP("192.0.2.10").To4())
+	copy(data[24:28], net.ParseIP("198.51.100.20").To4())
+	binary.LittleEndian.PutUint32(data[44:48], policyID)
+
+	rec, ok := DecodeRawEventRecord(data)
+	if !ok {
+		t.Fatal("DecodeRawEventRecord rejected a valid POLICY_DENY frame")
+	}
+	if rec.PolicyID != policyID {
+		t.Fatalf("rec.PolicyID = %d, want %d (non-close frames keep the real policy id)", rec.PolicyID, policyID)
+	}
+	if rec.CreatedNanos != 0 {
+		t.Fatalf("rec.CreatedNanos = %d, want 0 (only SESSION_CLOSE repurposes [44:48])", rec.CreatedNanos)
+	}
+}
+
 // TestDecodeRawEventPolicyDenyUsesDecisionTimestamp pins the #2470 contract on
 // the Go side: an RT_FLOW deny/screen/filter-log event carries the dataplane
 // DECISION instant at offset 0 (LE u64, absolute Unix ns). When it is nonzero

--- a/pkg/logging/eventbuf.go
+++ b/pkg/logging/eventbuf.go
@@ -30,6 +30,7 @@ type EventRecord struct {
 	OutZoneName     string // resolved zone name
 	ElapsedTime     uint32 // seconds since session creation (for CLOSE)
 	Created         uint32 // #2465: absolute session-creation Unix seconds (for CLOSE); 0 = unknown (exporter falls back to the packet-count estimate)
+	CreatedNanos    uint32 // #2853: sub-second nanosecond remainder (0..=999_999_999) of the session-creation instant (SESSION_CLOSE only; rides the close-unused [44:48] wire slot). Combined with Created so the flow StartTime keeps millisecond resolution.
 	PolicyName      string // resolved policy name (e.g. "allow-everything")
 	RevSessionPkts  uint64 // packets from server (for SESSION_CLOSE)
 	RevSessionBytes uint64 // bytes from server (for SESSION_CLOSE)

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -474,6 +474,14 @@ func (er *EventReader) logEvent(data []byte) {
 		// #2465: surface the absolute session-creation Unix seconds for the
 		// flow exporters (a real StartTime instead of the packet-count guess).
 		rec.Created = evt.Created
+		// #2853: the [44:48] policy_id slot is repurposed on a SESSION_CLOSE
+		// frame to carry the creation instant's sub-second nanosecond
+		// remainder. Reinterpret it as CreatedNanos and clear PolicyID so the
+		// close record's policy-name resolution (below) is the pre-#2853
+		// "no policy" value, not the nanosecond bits.
+		rec.CreatedNanos = evt.PolicyID
+		rec.PolicyID = 0
+		evt.PolicyID = 0
 		// Compute elapsed time from session creation
 		if evt.Created > 0 {
 			nowSec := uint32(evt.Timestamp / 1000000000)
@@ -768,6 +776,16 @@ func DecodeRawEventRecord(data []byte) (EventRecord, bool) {
 		// NetFlow/IPFIX exporters can set a real flow StartTime instead of the
 		// packet-count heuristic. 0 = unknown (old frame / synthesized close).
 		Created: evt.Created,
+	}
+	if evt.EventType == eventTypeSessionClose {
+		// #2853: the [44:48] policy_id slot is repurposed on a SESSION_CLOSE
+		// frame to carry the creation instant's sub-second nanosecond remainder
+		// (the dataplane never stamps a policy id on a close). Reinterpret it as
+		// CreatedNanos so the flow exporters keep millisecond StartTime
+		// resolution, and clear PolicyID so the close record's policy id/name
+		// stays the pre-#2853 "no policy" value.
+		rec.CreatedNanos = evt.PolicyID
+		rec.PolicyID = 0
 	}
 	if evt.EventType != eventTypeSessionClose {
 		rec.SessionPkts = 0

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -80,7 +80,16 @@ periodic ACK from the daemon.
   in `mod.rs`). The Go exporters use `created` as the flow StartTime
   directly, falling back to the packet-count
   `estimateSessionDuration(SessionPkts)` heuristic only when it is 0 (an
-  explicit-delete / HA-purge close that carried no creation instant). The
+  explicit-delete / HA-purge close that carried no creation instant).
+  (#2853) the `created` second is too coarse on its own — every flow
+  opened in the same second exported the same StartTime, flattening IPFIX
+  `flowStartMilliseconds` for short flows. The close frame now ALSO carries
+  the creation instant's sub-second **nanosecond** remainder
+  (0..=999,999,999) in the close-unused `policy_id` slot (offset 44,
+  little-endian u32), produced by `monotonic_ns_to_unix_secs_subnanos`. The
+  Go decoder reads it as `EventRecord.CreatedNanos` (and zeroes `PolicyID`,
+  which a close never carried) so `flowStartTime` builds a
+  millisecond-accurate `time.Unix(Created, CreatedNanos)`. The
   byte/packet **volume** counters remain 0 pending the per-session
   accounting follow-up #2501 — only the timing is real. (#2512) the close
   frame now rides the SAME per-kind rate limiter + queue budget +

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -480,6 +480,13 @@ impl EventFrame {
     /// frame or a synthesized close that carried no creation instant) do they
     /// fall back to the packet-count `estimateSessionDuration` heuristic.
     /// A `created_unix_secs` of 0 keeps the legacy fallback behavior.
+    ///
+    /// #2853: `created_subsec_nanos` carries the sub-second nanosecond remainder
+    /// of that same creation instant in the SESSION_CLOSE-unused policy_id slot
+    /// (offset 44). The Go exporters combine it with `created_unix_secs` so the
+    /// flow StartTime keeps millisecond resolution; before this, short flows
+    /// (DNS, single HTTP requests) opened in the same second all reported one
+    /// truncated integer-second start, skewing IPFIX `flowStartMilliseconds`.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn encode_session_close_rt_flow(
         seq: u64,
@@ -498,6 +505,11 @@ impl EventFrame {
         owner_rg_id: i16,
         log_syslog: bool,
         created_unix_secs: u32,
+        // #2853: sub-second nanosecond remainder (0..=999_999_999) of the
+        // creation instant. Rides the [44:48] policy_id slot (unused on a
+        // SESSION_CLOSE) so the Go exporters reconstruct a millisecond-accurate
+        // flow StartTime rather than one truncated to `created_unix_secs`.
+        created_subsec_nanos: u32,
         close_unix_ns: u64,
         application_id: u16,
         ingress_ifindex: u32,
@@ -524,7 +536,12 @@ impl EventFrame {
         // `binary.BigEndian` reads in logEvent/DecodeRawEventRecord).
         buf[base + 40..base + 42].copy_from_slice(&src_port.to_be_bytes());
         buf[base + 42..base + 44].copy_from_slice(&dst_port.to_be_bytes());
-        // [44:48] policy_id — unused for SESSION_CLOSE.
+        // [44:48] policy_id — unused for SESSION_CLOSE; #2853 repurposes it to
+        // carry the creation instant's sub-second NANOSECOND remainder
+        // (LITTLE-endian u32), which the Go SESSION_CLOSE decoder reads back as
+        // `CreatedNanos` (and zeroes PolicyID, so the policy-name resolution is
+        // unchanged) to build a millisecond-accurate flow StartTime.
+        buf[base + 44..base + 48].copy_from_slice(&created_subsec_nanos.to_le_bytes());
         // [48:50] ingress zone, [50:52] egress zone — little-endian.
         buf[base + 48..base + 50].copy_from_slice(&ingress_zone_id.to_le_bytes());
         buf[base + 50..base + 52].copy_from_slice(&egress_zone_id.to_le_bytes());

--- a/userspace-dp/src/event_stream/codec_tests.rs
+++ b/userspace-dp/src/event_stream/codec_tests.rs
@@ -278,6 +278,7 @@ fn test_encode_session_close_rt_flow_v4_wire_layout() {
         1,
         false,           // #2508: log_syslog gate
         1_700_000_000,   // #2465: created Unix seconds
+        123_456_789,     // #2853: created sub-second nanos (123.456789 ms)
         1_700_000_123_000_000_000, // #2465: close instant Unix ns
         7,               // #2520: application id
         42,              // #2615: ingress ifindex
@@ -333,6 +334,15 @@ fn test_encode_session_close_rt_flow_v4_wire_layout() {
         u32::from_le_bytes(p[108..112].try_into().unwrap()),
         1_700_000_000
     ); // created Unix secs
+    // #2853 fail-on-revert: the creation instant's sub-second nanosecond
+    // remainder rides the [44:48] policy_id slot (LITTLE-endian u32), which the
+    // Go SESSION_CLOSE decoder reads as CreatedNanos to build a
+    // millisecond-accurate flow StartTime. Reverting the encoder to leave this
+    // slot 0 collapses every same-second flow onto one integer-second start.
+    assert_eq!(
+        u32::from_le_bytes(p[44..48].try_into().unwrap()),
+        123_456_789
+    ); // created sub-second nanos
     assert_eq!(
         u64::from_le_bytes(p[0..8].try_into().unwrap()),
         1_700_000_123_000_000_000
@@ -372,6 +382,7 @@ fn test_encode_session_close_rt_flow_v6() {
         0,
         false, // #2508: log_syslog gate
         0,     // #2465: created Unix seconds (unknown → fallback)
+        0,     // #2853: created sub-second nanos (unknown)
         0,     // #2465: close instant Unix ns
         0,     // #2520: application id (unknown)
         0,     // #2615: ingress ifindex (unknown)
@@ -416,6 +427,7 @@ fn test_session_close_rt_flow_log_gate_byte() {
             0,
             log_syslog,
             0, // #2465: created Unix seconds
+            0, // #2853: created sub-second nanos
             0, // #2465: close instant Unix ns
             0, // #2520: application id
             0, // #2615: ingress ifindex

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -80,8 +80,30 @@ pub(crate) fn monotonic_ns_to_unix_ns(mono_ns: u64, now_mono_ns: u64, now_unix_n
 /// the `created` wire field (offset 108, u32). Truncates toward the epoch;
 /// 0/unknown stays 0; values beyond u32 (year 2106) saturate.
 pub(crate) fn monotonic_ns_to_unix_secs(mono_ns: u64, now_mono_ns: u64, now_unix_ns: u64) -> u32 {
+    monotonic_ns_to_unix_secs_subnanos(mono_ns, now_mono_ns, now_unix_ns).0
+}
+
+/// #2853: convert a monotonic instant to absolute wall-clock Unix SECONDS plus
+/// the sub-second NANOSECOND remainder (0..=999_999_999). The integer seconds
+/// ride the `created` wire field (offset 108, u32); the sub-second nanos ride
+/// the SESSION_CLOSE-unused policy_id slot (offset 44, u32) so the Go flow
+/// exporters can build a MILLISECOND-accurate flow StartTime instead of one
+/// truncated to the whole second (the #2853 defect: short flows — DNS, single
+/// HTTP requests — all collapsed onto the same integer-second start).
+///
+/// 0/unknown stays `(0, 0)`; a seconds value beyond u32 (year 2106) saturates
+/// to `(u32::MAX, 0)` so the saturated record carries no misleading remainder.
+pub(crate) fn monotonic_ns_to_unix_secs_subnanos(
+    mono_ns: u64,
+    now_mono_ns: u64,
+    now_unix_ns: u64,
+) -> (u32, u32) {
     let unix_ns = monotonic_ns_to_unix_ns(mono_ns, now_mono_ns, now_unix_ns);
-    (unix_ns / NS_PER_SEC).min(u32::MAX as u64) as u32
+    let secs = unix_ns / NS_PER_SEC;
+    if secs > u32::MAX as u64 {
+        return (u32::MAX, 0);
+    }
+    (secs as u32, (unix_ns % NS_PER_SEC) as u32)
 }
 
 /// #2470: convert a CLOCK_MONOTONIC instant (the `now_ns`/`now_secs`-derived
@@ -496,8 +518,13 @@ impl EventStreamWorkerHandle {
         // taken here at emit time. A 0 created_ns stays 0 on the wire and
         // triggers the Go-side packet-count fallback.
         let (now_mono_ns, now_unix_ns) = read_mono_and_wall_clocks();
-        let created_unix_secs =
-            monotonic_ns_to_unix_secs(delta.created_ns, now_mono_ns, now_unix_ns);
+        // #2853: carry BOTH the integer Unix second (offset 108) and the
+        // sub-second nanosecond remainder (offset 44, the close-unused policy_id
+        // slot) so the Go exporters render a millisecond-accurate flow
+        // StartTime. The pre-#2853 code stamped only the truncated second, so
+        // every flow opened in the same second shared one start instant.
+        let (created_unix_secs, created_subsec_nanos) =
+            monotonic_ns_to_unix_secs_subnanos(delta.created_ns, now_mono_ns, now_unix_ns);
         let close_unix_ns =
             monotonic_ns_to_unix_ns(delta.last_seen_ns, now_mono_ns, now_unix_ns);
         // #2512: route through the per-kind rate limiter + queue budget +
@@ -535,6 +562,9 @@ impl EventStreamWorkerHandle {
                     // RT_FLOW_SESSION_CLOSE syslog record.
                     delta.metadata.log_session_close,
                     created_unix_secs,
+                    // #2853: sub-second nanosecond remainder of the creation
+                    // instant, rides the [44:48] slot (unused on a close).
+                    created_subsec_nanos,
                     close_unix_ns,
                     // #2520: carry the resolved AppID in the [132:134] wire
                     // slot so SESSION_CLOSE RT_FLOW records (and the

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -181,6 +181,37 @@ fn test_monotonic_ns_to_unix_conversions() {
 }
 
 #[test]
+fn test_monotonic_ns_to_unix_secs_subnanos() {
+    // #2853: the secs+subnanos split must reconstruct the exact wall-clock
+    // nanosecond instant, preserving the sub-second remainder the seconds-only
+    // helper truncated. A creation instant 30.123456789s before a sub-second
+    // wall reference splits into the right second and the right nanos.
+    let now_mono = 1_000_000_000_000u64; // 1000s monotonic
+    let now_unix = 1_700_000_000_123_456_789u64; // 1.7e9 s + 123456789 ns
+    let created_mono = now_mono - 30 * NS_PER_SEC; // 30s ago (whole seconds)
+    let (secs, subnanos) = monotonic_ns_to_unix_secs_subnanos(created_mono, now_mono, now_unix);
+    assert_eq!(secs, 1_700_000_000 - 30);
+    assert_eq!(subnanos, 123_456_789);
+    // The seconds-only helper still returns just the truncated second.
+    assert_eq!(
+        monotonic_ns_to_unix_secs(created_mono, now_mono, now_unix),
+        1_700_000_000 - 30
+    );
+    // Reconstruction is lossless.
+    assert_eq!(
+        secs as u64 * NS_PER_SEC + subnanos as u64,
+        now_unix - 30 * NS_PER_SEC
+    );
+    // 0 / unknown maps to (0, 0).
+    assert_eq!(
+        monotonic_ns_to_unix_secs_subnanos(0, now_mono, now_unix),
+        (0, 0)
+    );
+    // subnanos is always a valid sub-second remainder.
+    assert!(subnanos < NS_PER_SEC as u32);
+}
+
+#[test]
 fn test_emit_session_close_rt_flow_carries_real_created_stamp() {
     // #2465 fail-on-revert: a close delta with a real (non-zero) created_ns
     // must produce a non-zero `created` (offset 108) and `timestamp_ns`


### PR DESCRIPTION
## Summary

The userspace-dp SESSION_CLOSE RT_FLOW frame stamped the session creation instant at **integer-second resolution only** (offset 108, `created`, u32 Unix seconds — #2465). Every flow opened within the same wall-clock second exported an identical flow `StartTime`, so IPFIX `flowStartMilliseconds` / `flowStartMicroseconds` (and NetFlow v9 uptime) lost up to ~1000ms of accuracy for short-lived flows (DNS, single HTTP requests). Confirmed against current master.

## Fix

Carry the creation instant's **sub-second nanosecond remainder** (0..=999,999,999) alongside the integer second:

- **Rust dataplane**: new `monotonic_ns_to_unix_secs_subnanos` splits the single anchored monotonic→wall conversion into `(secs, subnanos)`. The remainder rides the SESSION_CLOSE-**unused** `policy_id` slot (offset 44, LE u32) — a close never carried a real policy id, matching the established #2501/#2615/#2520 pattern of repurposing close-unused slots. Wire size unchanged (136 bytes).
- **Go decoder** (`logEvent` + `DecodeRawEventRecord`): reads offset 44 into the new `EventRecord.CreatedNanos` for SESSION_CLOSE frames and zeroes `PolicyID`, so the close record's policy id/name resolution stays the pre-#2853 "no policy" value. Non-close frames still read offset 44 as the real `PolicyID` (repurpose is close-only).
- **Exporter**: `flowStartTime` now builds `time.Unix(Created, CreatedNanos)`, so `StartTime.UnixMilli()` keeps millisecond resolution. The `Created == 0` packet-count fallback is unchanged.

## Fail-on-revert tests

- Go `TestFlowStartTimeKeepsSubSecondResolution` / `TestIPFIXExportSessionCloseSubSecondStart`: two closes in the same second at distinct sub-second offsets must export **distinct** StartTimes / flowStartMilliseconds — RED if `flowStartTime` drops `CreatedNanos`.
- Go `TestDecodeRawEventCarriesCreatedSubNanos` / `TestDecodeRawEventPolicyDenyKeepsPolicyID`: offset-44 decode + PolicyID clearing for close; PolicyID preserved for non-close.
- Rust `test_encode_session_close_rt_flow_v4_wire_layout` asserts the [44:48] write; `test_monotonic_ns_to_unix_secs_subnanos` pins the lossless split.

**Both revert vectors proven RED** (Go `flowStartTime`→whole-second; Rust [44:48] write removed) then restored.

## Validation

- `go build ./...` clean; `go vet` clean; `gofmt` clean on touched files
- `go test ./pkg/flowexport/... ./pkg/logging/...` — 196 passed
- `cargo build` clean; `cargo test event_stream::` — 58 passed

Note: repo-wide `cargo fmt --check` shows pre-existing drift across hundreds of files (toolchain-version mismatch); the diff at my edit sites is on unchanged pre-existing lines, my added lines are clean.

## Docs

Updated `pkg/flowexport/README.md`, `userspace-dp/src/event_stream/README.md`, `_Log.md`.

Closes #2853

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi