### PR TITLE
fix(userspace-dp): only emit ICMP pseudo-port for identifier-bearing query types (#3067)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-25 — #3067: ICMP pseudo-port only for identifier-bearing query types
+
+- **Timestamp**: 2026-06-25
+- **Action**: `parse_flow_ports` no longer treats ICMP/ICMPv6 header bytes
+  [l4+4, l4+6) as a pseudo source port for ALL ICMP types. Those bytes are
+  the Identifier only for the query types (ICMPv4 Echo + Timestamp +
+  Information, ICMPv6 Echo). For errors / Redirect / ND-MLD the same bytes
+  are a gateway address / next-hop MTU / pointer / unused field. The arm now
+  reads the type byte at `l4` (bounded by `declared_end`) and returns `None`
+  (flowless) for every non-query type, so transit ICMP control packets take
+  the route-based session-less path instead of installing a bogus
+  identifier-keyed session (session-table pollution / spurious collisions).
+  Matching ICMP errors to the embedded inner flow stays out of scope (#2393).
+- **File(s)**: userspace-dp/src/afxdp/frame/inspect.rs (fix),
+  userspace-dp/src/afxdp/frame/inspect_tests.rs (5 new tests, fail-on-revert
+  RED→GREEN verified), userspace-dp/src/afxdp/frame/README.md,
+  userspace-dp/src/filter/README.md (doc), _Log.md
+- **Validation**: `cargo build --release -p xpf-userspace-dp` clean;
+  `cargo test --release inspect` 36 passed; reverting the type
+  discrimination turns the two non-query assertions RED while echo stays
+  green.
+
 ## 2026-06-25 — #3065: unspecified default-policy fails CLOSED (deny-all) + reject-all + schema leaf
 
 - **Timestamp**: 2026-06-25

--- a/userspace-dp/src/afxdp/frame/README.md
+++ b/userspace-dp/src/afxdp/frame/README.md
@@ -133,6 +133,22 @@ inspect or rewrite a packet sitting in a UMEM frame.
   `meta.l4_offset` but does NOT enforce the IP-declared bound, so the meta
   readers re-derive `declared_end` from the L3 header in the frame before
   reading ports (mirroring #2357's meta-fast-path chokepoint concern).
+- **ICMP pseudo-port is only emitted for identifier-bearing query types
+  (#3067)**: in `parse_flow_ports` the 2-byte ICMP/ICMPv6 word at
+  `[l4+4, l4+6)` is the protocol Identifier ONLY for the query types — for
+  ICMPv4 that is Echo Request/Reply (8/0) and the Timestamp/Information
+  query+reply pairs (13/14/15/16, identical Identifier offset per RFC 792);
+  for ICMPv6 only Echo Request/Reply (128/129) per RFC 4443. For every other
+  type — the errors (Dest-Unreachable, Packet-Too-Big, Time-Exceeded,
+  Parameter-Problem), Redirect, and the ND/MLD control types — those two
+  bytes are part of a gateway address, the next-hop MTU, a pointer, or an
+  unused/reserved field, NOT a port. `parse_flow_ports` reads the ICMP type
+  byte at `l4` (bounded by `declared_end`) and returns `None` (flowless) for
+  every non-query type, so transit ICMP error/control packets follow the
+  route-based, session-less forward path instead of installing a bogus
+  identifier-keyed stateful session that would pollute the session table and
+  risk spurious collisions. Matching ICMP errors to their embedded inner flow
+  remains out of scope (tracked as the larger #2393 model).
 - **TCP inspection helpers are ext-header-aware (#2148)**: the read-only
   diagnostic/telemetry helpers `frame_has_tcp_rst`,
   `extract_tcp_flags_and_window`, and `extract_tcp_window` (`tcp.rs`) all

--- a/userspace-dp/src/afxdp/frame/inspect.rs
+++ b/userspace-dp/src/afxdp/frame/inspect.rs
@@ -925,6 +925,40 @@ pub(in crate::afxdp) fn parse_flow_ports(
             ))
         }
         PROTO_ICMP | PROTO_ICMPV6 => {
+            // #3067: bytes [l4+4, l4+6) are the ICMP/ICMPv6 Identifier ONLY for
+            // the identifier-bearing query types. For ICMPv4 those are Echo
+            // Request/Reply and the Timestamp/Information query+reply pairs (the
+            // Identifier sits at the same offset for all of them, per RFC 792);
+            // for ICMPv6 only Echo Request/Reply (RFC 4443). For error and
+            // control messages — Dest-Unreachable, Packet-Too-Big,
+            // Time-Exceeded, Parameter-Problem, Redirect, and the ND/MLD types —
+            // those two bytes are NOT a port: they are part of a gateway
+            // address, the next-hop MTU, a pointer, or an unused/reserved field.
+            // Treating them as a pseudo source port installed bogus
+            // identifier-keyed stateful sessions for transit ICMP control
+            // traffic, polluting the session table and risking spurious
+            // collisions. Return `None` (the caller's "flowless" sentinel) for
+            // every non-query type so the packet takes the session-less,
+            // route-based forward path instead of installing a fake session.
+            //
+            // The type byte at `l4` must itself lie within the IP-declared
+            // datagram (the #2361 fail-closed invariant); a type byte read from
+            // trailing slack past `declared_end` is not authoritative.
+            if l4 >= declared_end {
+                return None;
+            }
+            let icmp_type = *frame.get(l4)?;
+            let identifier_bearing = match protocol {
+                // Echo Reply (0) / Echo Request (8), Timestamp Request (13) /
+                // Reply (14), Information Request (15) / Reply (16).
+                PROTO_ICMP => matches!(icmp_type, 0 | 8 | 13 | 14 | 15 | 16),
+                // Echo Request (128) / Echo Reply (129).
+                PROTO_ICMPV6 => matches!(icmp_type, 128 | 129),
+                _ => false,
+            };
+            if !identifier_bearing {
+                return None;
+            }
             let ident_start = l4.checked_add(4)?;
             let ident_end = l4.checked_add(6)?;
             if ident_end > declared_end {

--- a/userspace-dp/src/afxdp/frame/inspect_tests.rs
+++ b/userspace-dp/src/afxdp/frame/inspect_tests.rs
@@ -289,3 +289,103 @@ fn meta_fast_path_oversized_ihl_truncated_buffer_no_panic() {
         "meta fast path must not panic on an oversized IHL truncated frame"
     );
 }
+
+// ---- #3067: ICMP identifier is a pseudo-port ONLY for query types ----
+//
+// `parse_flow_ports` reads bytes [l4+4, l4+6) of the ICMP/ICMPv6 header as a
+// pseudo source port. Those two bytes are the Identifier ONLY for the query
+// types (Echo, and for ICMPv4 the Timestamp/Information pairs). For error and
+// control types (Dest-Unreachable, Packet-Too-Big, Time-Exceeded,
+// Parameter-Problem, Redirect, ND/MLD) they are part of a gateway address /
+// next-hop MTU / pointer / unused field — NOT a port — so treating them as one
+// installed bogus identifier-keyed sessions for transit ICMP control traffic.
+// These tests pin the type discrimination. Reverting it (back to an
+// unconditional `Some((ident, 0))`) turns the non-query assertions RED.
+
+/// Build an 8-byte ICMP/ICMPv6 header L4 payload: type, code, 2-byte checksum,
+/// then a 2-byte "identifier" word (bytes [4..6]) and a 2-byte sequence word.
+fn icmp_l4(icmp_type: u8, ident: u16) -> [u8; 8] {
+    let id = ident.to_be_bytes();
+    [icmp_type, 0x00, 0x00, 0x00, id[0], id[1], 0x00, 0x01]
+}
+
+const ICMP_IDENT: u16 = 0xABCD;
+// Reachable l4/declared_end for the helper-built frames: eth(14) + IP header.
+const V4_ICMP_L4: usize = 14 + 20;
+const V6_ICMP_L4: usize = 14 + 40;
+
+#[test]
+fn icmpv4_echo_request_reply_still_yields_identifier_pseudo_port() {
+    for icmp_type in [8u8, 0u8] {
+        let frame = v4_frame(PROTO_ICMP, 28, &icmp_l4(icmp_type, ICMP_IDENT));
+        let declared_end = ipv4_declared_l3_end(&frame, 14).expect("v4 declared end");
+        assert_eq!(
+            parse_flow_ports(&frame, V4_ICMP_L4, PROTO_ICMP, declared_end),
+            Some((ICMP_IDENT, 0)),
+            "ICMPv4 echo type {icmp_type} must still carry the identifier as the pseudo-port"
+        );
+    }
+}
+
+#[test]
+fn icmpv4_timestamp_information_query_types_yield_identifier() {
+    // RFC 792 query types whose Identifier sits at the same [4..6] offset.
+    for icmp_type in [13u8, 14u8, 15u8, 16u8] {
+        let frame = v4_frame(PROTO_ICMP, 28, &icmp_l4(icmp_type, ICMP_IDENT));
+        let declared_end = ipv4_declared_l3_end(&frame, 14).unwrap();
+        assert_eq!(
+            parse_flow_ports(&frame, V4_ICMP_L4, PROTO_ICMP, declared_end),
+            Some((ICMP_IDENT, 0)),
+            "ICMPv4 query type {icmp_type} carries an identifier at [4..6]"
+        );
+    }
+}
+
+#[test]
+fn icmpv4_error_control_types_yield_no_pseudo_port() {
+    // Dest-Unreachable (3), Time-Exceeded (11), Parameter-Problem (12),
+    // Redirect (5). Bytes [4..6] here are NOT an identifier — they are part of
+    // the unused word / gateway address / pointer. Must be flowless (None) so
+    // no bogus identifier-keyed session is installed.
+    for icmp_type in [3u8, 5u8, 11u8, 12u8] {
+        // The "identifier" bytes are present in the slice (proving the old
+        // unconditional read would have returned them as a fake port).
+        let frame = v4_frame(PROTO_ICMP, 28, &icmp_l4(icmp_type, ICMP_IDENT));
+        let declared_end = ipv4_declared_l3_end(&frame, 14).unwrap();
+        assert_eq!(
+            parse_flow_ports(&frame, V4_ICMP_L4, PROTO_ICMP, declared_end),
+            None,
+            "ICMPv4 error/control type {icmp_type} must NOT install a pseudo-port"
+        );
+    }
+}
+
+#[test]
+fn icmpv6_echo_request_reply_still_yields_identifier_pseudo_port() {
+    for icmp_type in [128u8, 129u8] {
+        let frame = v6_frame(PROTO_ICMPV6, 8, &icmp_l4(icmp_type, ICMP_IDENT));
+        let declared_end = ipv6_declared_l3_end(&frame, 14).expect("v6 declared end");
+        assert_eq!(
+            parse_flow_ports(&frame, V6_ICMP_L4, PROTO_ICMPV6, declared_end),
+            Some((ICMP_IDENT, 0)),
+            "ICMPv6 echo type {icmp_type} must still carry the identifier as the pseudo-port"
+        );
+    }
+}
+
+#[test]
+fn icmpv6_packet_too_big_redirect_nd_yield_no_pseudo_port() {
+    // Packet-Too-Big (2) — bytes [4..6] are the high half of the next-hop MTU.
+    // Dest-Unreachable (1), Time-Exceeded (3), Parameter-Problem (4),
+    // Redirect (137), Router/Neighbor Solicit/Advert (133..136). None is an
+    // identifier-bearing query type -> flowless.
+    for icmp_type in [1u8, 2u8, 3u8, 4u8, 133u8, 134u8, 135u8, 136u8, 137u8] {
+        let frame = v6_frame(PROTO_ICMPV6, 8, &icmp_l4(icmp_type, ICMP_IDENT));
+        let declared_end = ipv6_declared_l3_end(&frame, 14).unwrap();
+        assert_eq!(
+            parse_flow_ports(&frame, V6_ICMP_L4, PROTO_ICMPV6, declared_end),
+            None,
+            "ICMPv6 error/control/ND type {icmp_type} must NOT install a pseudo-port"
+        );
+    }
+}

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -263,10 +263,16 @@ on those fields.
 `IpAddr` variant carried by `src_ip` / `dst_ip` but is materialized
 on the struct for cheap branchless checks on the hot path.
 For ICMP and ICMPv6 sessions, `parse_flow_ports`
-(`userspace-dp/src/afxdp/frame/inspect.rs:212-232`) unconditionally
-reads bytes 4-5 of the ICMP header into `src_port` (the ICMP
-identifier word — meaningful for Echo Request/Reply, opaque for
-other ICMP types) and stores zero in `dst_port`. ICMP **type**
+(`userspace-dp/src/afxdp/frame/inspect.rs`) reads bytes 4-5 of the
+ICMP header into `src_port` (the ICMP identifier word) and stores
+zero in `dst_port` — but ONLY for the identifier-bearing query types
+(#3067): ICMPv4 Echo Request/Reply and the Timestamp/Information
+query+reply pairs (types 0/8/13/14/15/16), and ICMPv6 Echo
+Request/Reply (128/129). For error and control types — where bytes
+4-5 are a gateway address / next-hop MTU / pointer / unused field,
+not an identifier — `parse_flow_ports` returns `None` so no
+identifier-keyed session is installed for transit ICMP control
+traffic. ICMP **type**
 and **code** are NOT in the cache key — adding an explicit
 `icmp_type` or `icmp_code` filter match makes the filter
 cache-sensitive unless `SessionKey` or trusted per-session


### PR DESCRIPTION
Closes #3067

## Bug
`parse_flow_ports` (`userspace-dp/src/afxdp/frame/inspect.rs`) extracted the
ICMP/ICMPv6 header bytes at `[l4+4, l4+6)` as a pseudo source port for **every**
ICMP type, returning `Some((ident, 0))` unconditionally. Those two bytes are the
protocol Identifier **only** for query types. For error/control messages they are
something else entirely:

- **Redirect (v4 type 5 / v6 type 137):** part of the gateway address
- **Packet-Too-Big (v6 type 2):** the high half of the next-hop MTU
- **Parameter-Problem:** a pointer
- **Dest-Unreachable / Time-Exceeded:** an unused/reserved word

Treating those bytes as a source port installed bogus identifier-keyed stateful
sessions for transit ICMP error/control packets
(`userspace-dp/src/session/install.rs`), polluting the session table and risking
spurious collisions.

## Fix
The ICMP arm now reads the ICMP type byte at `l4` (bounded by the IP-declared
`declared_end`, preserving the #2361 fail-closed invariant) and only returns the
identifier for identifier-bearing query types:

- **ICMPv4:** Echo Reply/Request (0/8), Timestamp Request/Reply (13/14),
  Information Request/Reply (15/16) — same Identifier offset per RFC 792.
- **ICMPv6:** Echo Request/Reply (128/129) per RFC 4443.

Every other type returns `None`. The caller already treats `None` as flowless
(the route-based, session-less forward path, same as #2344 non-first fragments),
so no fake session is installed. Echo/Timestamp/Information query behavior is
unchanged.

Matching ICMP error messages to their embedded inner flow is **out of scope**
(the larger #2393 model); this only stops installing bogus identifier-keyed
sessions for non-query ICMP.

## Validation
- `cargo build --release -p xpf-userspace-dp` — clean.
- `cargo test --release inspect` — 36 passed.
- Five new tests in `inspect_tests.rs`: Echo (v4/v6) + Timestamp + Information
  query types still yield the identifier; Dest-Unreachable / Redirect /
  Time-Exceeded / Parameter-Problem (v4) and Packet-Too-Big / Redirect / ND (v6)
  yield the `None` sentinel.
- **Fail-on-revert (RED→GREEN):** restoring the unconditional
  `identifier_bearing` turns the two non-query assertions RED
  (`ICMPv4 error/control type 3 must NOT install a pseudo-port`,
  `ICMPv6 error/control/ND type 1 must NOT install a pseudo-port`) while the echo
  assertions stay green; restoring the fix returns all green.

Docs: `afxdp/frame/README.md` + `filter/README.md` updated; `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi