### PR TITLE
logging: render gre/esp/ipip/ipv6 named in the event log (#3040)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-25 — #3040: route event-log protoName through appid.ProtocolName SSOT
+
+- **Timestamp**: 2026-06-25
+- **Action**: Replaced the local 4-protocol (tcp/udp/icmp/icmpv6) map in
+  `pkg/logging/ringbuf.go`'s `protoName` with the shared
+  `appid.ProtocolName` SSOT (the same table REST #2949 and gRPC #3037 use),
+  so GRE(47)/ESP(50)/IPIP(4)/IPv6(41) security event-log (RT_FLOW / ring
+  buffer) rows render named (GRE/ESP/IPIP/IPV6) instead of numeric. Casing
+  is preserved (upper-case, ICMPv6 mixed-case for the trace contract);
+  unknown protocols keep the numeric fallback. Added `protoname_test.go`
+  fail-on-revert pin (reverting to the 4-protocol set turns proto 47/50/4/41
+  RED). Confirmed the cross-package `TestRawEventContractMatchesDataplaneEvent`
+  screen-flag contract is untouched. Updated `pkg/logging/README.md` Gotchas.
+- **File(s)**: pkg/logging/ringbuf.go, pkg/logging/protoname_test.go,
+  pkg/logging/README.md, _Log.md
+
 ## 2026-06-25 — #3072: reject an interface assigned to multiple security zones
 
 - **Timestamp**: 2026-06-25

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -132,6 +132,17 @@ if `Handle` runs the re-entrancy guard before the client check.
   syslog delivery as the legacy eBPF ring-buffer events do.
   `DecodeRawEventRecord` is decode-only and must not be used as a
   replacement for the full reader path when audit delivery matters.
+- **Protocol names come from the `appid.ProtocolName` SSOT (#3040).** The
+  event-log `protoName` helper (`ringbuf.go`) renders an IP protocol number
+  through the shared `appid.ProtocolName` table that REST (`pkg/api`,
+  #2949) and gRPC (`pkg/grpcapi`, #3037) already use, so GRE(47)/ESP(50)/
+  IPIP(4)/IPv6(41) sessions display named (GRE/ESP/IPIP/IPV6) instead of
+  numeric — matching the other operator surfaces. Before #3040 this helper
+  carried its own tcp/udp/icmp/icmpv6 map and rendered every other protocol
+  as a bare number. Casing is an event-log-local concern (this surface
+  upper-cases, keeping ICMPv6 mixed-case for the trace-filter contract);
+  unknown protocols still fall back to the numeric form. Pin:
+  `protoname_test.go`.
 - **Event time is DECISION time, not receive time (#2465/#2470/#2511).**
   The on-wire RT_FLOW frame carries an absolute Unix-nanosecond timestamp
   in its first 8 bytes (LE u64), stamped by the userspace-dp producer at

--- a/pkg/logging/protoname_test.go
+++ b/pkg/logging/protoname_test.go
@@ -1,0 +1,36 @@
+package logging
+
+import "testing"
+
+// TestProtoNameSSOT pins the security event-log (RT_FLOW / ring buffer)
+// protocol rendering to the appid.ProtocolName SSOT (#3040). Before #3040 the
+// helper carried a local tcp/udp/icmp/icmpv6 map, so GRE(47)/ESP(50)/IPIP(4)/
+// IPv6(41) sessions rendered NUMERIC while REST and gRPC (already on the SSOT
+// via #2949/#3037) rendered them named. Reverting protoName to the 4-protocol
+// set turns the gre/esp/ipip/ipv6 rows RED.
+//
+// Casing contract: this surface has always rendered upper-case (TCP/UDP/ICMP)
+// with ICMPv6 keeping its mixed-case spelling, and unknown protocols fall back
+// to the numeric form. The new named protocols follow the same upper-case rule.
+func TestProtoNameSSOT(t *testing.T) {
+	cases := []struct {
+		proto uint8
+		want  string
+	}{
+		{6, "TCP"},
+		{17, "UDP"},
+		{1, "ICMP"},
+		{58, "ICMPv6"}, // historical mixed-case preserved (trace contract)
+		{47, "GRE"},    // #3040: was "47" before SSOT routing
+		{50, "ESP"},    // #3040: was "50"
+		{4, "IPIP"},    // #3040: was "4"
+		{41, "IPV6"},   // #3040: was "41"
+		{99, "99"},     // unknown -> numeric fallback preserved
+		{0, "0"},
+	}
+	for _, c := range cases {
+		if got := protoName(c.proto); got != c.want {
+			t.Errorf("protoName(%d) = %q, want %q", c.proto, got, c.want)
+		}
+	}
+}

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/psaab/xpf/pkg/appid"
 )
 
 // EventCallback is called for each processed event record.
@@ -1066,19 +1069,25 @@ func actionName(a uint8) string {
 	}
 }
 
+// protoName renders an IP protocol number for the security event log (RT_FLOW /
+// ring buffer surface). The named protocol SET is owned by appid.ProtocolName
+// (the #2949/#3037 SSOT shared with REST, gRPC, and the app-id catalog) so
+// GRE/ESP/IPIP/IPv6 sessions display named (gre/esp/ipip/ipv6) instead of
+// numeric, matching the other operator surfaces (#3040). Casing is an
+// event-log-local concern: this surface has always rendered upper-case
+// (TCP/UDP/ICMP/ICMPv6), so the canonical lowercase name is upper-cased here.
+// ICMPv6 keeps its mixed-case spelling to match the historical rendering (the
+// trace-filter contract test asserts "ICMPv6"). Unknown protocols fall back to
+// the numeric form the old 4-protocol helper used.
 func protoName(p uint8) string {
-	switch p {
-	case 6:
-		return "TCP"
-	case 17:
-		return "UDP"
-	case 1:
-		return "ICMP"
-	case protoICMPv6:
-		return "ICMPv6"
-	default:
+	name := appid.ProtocolName(p)
+	if name == "" {
 		return fmt.Sprintf("%d", p)
 	}
+	if p == protoICMPv6 {
+		return "ICMPv6"
+	}
+	return strings.ToUpper(name)
 }
 
 func screenFlagName(flag uint32) string {


### PR DESCRIPTION
Closes #3040

## Bug
The security event-log surface (RT_FLOW / ring buffer) rendered
GRE(47)/ESP(50)/IPIP(4)/IPv6(41) sessions with a **numeric** protocol because
`pkg/logging/ringbuf.go`'s `protoName` carried its own local
tcp/udp/icmp/icmpv6 map. REST (`pkg/api`, #2949) and gRPC (`pkg/grpcapi`,
#3037) already unified on the `appid.ProtocolName` SSOT (which renders
gre/esp/ipip/ipv6); the event log was the third surface still divergent, so an
operator saw `47` in the event log and `gre` on REST/gRPC for the same session.

## Fix
Route `protoName` through `appid.ProtocolName`, mirroring the REST helper
(`pkg/api/sessions.go`). The SSOT owns the *named protocol set*; casing stays
an event-log-local concern:

- This surface has always rendered upper-case (`TCP`/`UDP`/`ICMP`), so the
  canonical lowercase SSOT name is upper-cased here — new protocols become
  `GRE`/`ESP`/`IPIP`/`IPV6`.
- `ICMPv6` is kept mixed-case to satisfy the existing trace-filter contract
  (`trace_test.go` asserts `"ICMPv6"`).
- `appid.ProtocolName` returns `""` for an unrepresentable protocol, so
  unknowns keep the **numeric fallback** the old helper used.

No import cycle: `pkg/appid` only depends on `pkg/config` (verified with
`go list -deps`).

## Contract-test confirmation
The change is confined to the `protoName` name set + casing. The cross-package
screen-flag mirror `TestRawEventContractMatchesDataplaneEvent` is untouched —
`go test ./pkg/logging/ ./pkg/dataplane/...` both pass (the whole packages, not
just the changed file).

## Tests (fail-on-revert)
Added `pkg/logging/protoname_test.go` pinning proto 47/50/4/41 →
`GRE/ESP/IPIP/IPV6`, `58 → ICMPv6` (mixed-case), and unknown → numeric.
Reverting `protoName` to the 4-protocol set turns it RED:

```
--- FAIL: TestProtoNameSSOT
    protoName(47) = "47", want "GRE"
    protoName(50) = "50", want "ESP"
    protoName(4)  = "4",  want "IPIP"
    protoName(41) = "41", want "IPV6"
```
Restored → GREEN.

## Validation
- `go build ./...` — OK
- `go test ./pkg/logging/ ./pkg/dataplane/...` — all pass (incl. screen-flag contract)
- `go vet ./pkg/logging/...` — clean
- `gofmt -l` — clean on touched files
- Documented in `pkg/logging/README.md` Gotchas; `_Log.md` entry prepended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi