### PR TITLE
config: reject accepted-but-inert bare `then log` at commit (#3060)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-25 — #3060: reject accepted-but-inert bare `then log` at commit
+
+- **Timestamp**: 2026-06-25
+- **Action**: A bare security-policy `then log` (no session-init/session-close)
+  compiled to a non-nil `PolicyLog` with both flags false — reported as
+  logging-enabled over REST/gRPC/CLI but emitting NO session records (silent
+  audit gap). Added `validatePolicyLogActionStrict` (strict-with-lenient
+  #1960/#3043 pattern): hard-rejects bare `then log` at commit (Junos parity —
+  session-init/session-close required), covering both zone-pair AND global
+  policies; downgraded to a `cfg.Warnings` entry on the two lenient
+  constructors via `lenientPolicyLogAction` so a persisted/peer-synced config
+  still boots. Rejecting at commit moots the REST/gRPC/CLI display divergence.
+- **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler.go, pkg/config/policy_log_action_3060_test.go,
+  pkg/config/README.md, _Log.md
+
 ## 2026-06-25 — #3067: ICMP pseudo-port only for identifier-bearing query types
 
 - **Timestamp**: 2026-06-25

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -166,6 +166,22 @@ path downgrades to a warning AND `compilePolicy` defaults an actionless
 policy's `Action` to `PolicyDeny`, so a leniently-loaded bad config fails
 closed rather than open. See `docs/config-schema.md` "#3043".
 
+**Security-policy `then log` requires session-init/session-close (#3060):**
+the schema accepts a bare `then log`, and `compilePolicy` compiles it to a
+non-nil `PolicyLog` with both `SessionInit` and `SessionClose` false. The
+policy then REPORTS logging enabled over REST (`pkg/api/security.go`:
+`Log: rule.Log != nil`), gRPC, and CLI, yet emits NO session records — on a
+security appliance, audit looks active while producing nothing. Junos
+requires at least one of session-init/session-close under `then log`.
+`validatePolicyLogActionStrict` (`compiler_validate_strict.go`) hard-rejects
+a policy (zone-pair OR global) whose `then log` names neither at commit;
+rejecting the bare form moots the REST/gRPC/CLI display divergence (no
+bare-log config can exist post-commit). The tolerant load/peer-sync path
+downgrades to a warning (`lenientPolicyLogAction`) so an already-persisted or
+peer-synced config still boots (#1960 no-brick) — a leniently-loaded bare-log
+policy simply logs nothing, exactly as before. Same fail-closed-on-load
+doctrine as #3043.
+
 **An interface belongs to exactly one security zone (#3072):**
 `pkg/dataplane/userspace.buildInterfaceZoneMap` builds the interface->zone
 lookup by iterating zone names in SORTED order and writing each interface

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -640,6 +640,20 @@ type compileOpts struct {
 	// permit), so a leniently-loaded actionless policy DENIES rather than
 	// fails open. Same doctrine as lenientPolicyZoneRefs / lenientPolicyMatchAddress.
 	lenientPolicyTerminalAction bool
+	// lenientPolicyLogAction (#3060) downgrades the security-policy `then log`
+	// gate (validatePolicyLogActionStrict) from a hard compile error to a
+	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
+	// policy whose `then log` names neither session-init nor session-close: a
+	// bare `then log` compiles to pol.Log = &PolicyLog{} with both flags false,
+	// so the policy REPORTS logging enabled over REST/gRPC/CLI yet emits NO
+	// session records — audit looks active while producing nothing (a silent
+	// gap on a security appliance). Junos requires at least one of
+	// session-init/session-close. The tolerant load / peer-sync paths downgrade
+	// to a warning so an already-persisted or peer-synced config an older binary
+	// accepted still BOOTS (#1960 no-brick); a leniently-loaded bare-log policy
+	// is harmless (it logs nothing, the pre-existing behavior). Same doctrine as
+	// lenientPolicyTerminalAction.
+	lenientPolicyLogAction bool
 	// lenientScreenProfileRefs (#3066) downgrades the zone screen-profile
 	// reference gate (validateScreenProfileReferencesStrict) from a hard
 	// compile error to a cfg.Warnings entry. The strict commit / commit-check
@@ -730,6 +744,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRouterID:                    true,
 		lenientSNMPTrapGroup:               true,
 		lenientPolicyTerminalAction:        true,
+		lenientPolicyLogAction:             true,
 		lenientScreenProfileRefs:           true,
 		lenientReservedZoneNames:           true,
 	})
@@ -843,6 +858,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRouterID:                    true,
 		lenientSNMPTrapGroup:               true,
 		lenientPolicyTerminalAction:        true,
+		lenientPolicyLogAction:             true,
 		lenientScreenProfileRefs:           true,
 		lenientReservedZoneNames:           true,
 	})
@@ -1239,6 +1255,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientPolicyTerminalAction {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("policy terminal action (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3060 security-policy `then log` accepted-but-inert gate. Strict on commit
+	// / commit-check (hard-reject a policy whose `then log` names neither
+	// session-init nor session-close — a bare `then log` compiles to a non-nil
+	// PolicyLog with both flags false, so the policy REPORTS logging enabled
+	// over REST/gRPC/CLI yet emits NO session records; Junos requires at least
+	// one of session-init/session-close). Lenient on load / peer-sync (warn so
+	// an already-persisted or peer-synced config still boots — #1960 no-brick; a
+	// leniently-loaded bare-log policy simply logs nothing, the pre-existing
+	// behavior). Covers both per-zone-pair and global policies. Runs after the
+	// terminal-action gate so a missing/conflicting terminal action still wins
+	// the first-error slot.
+	if err := validatePolicyLogActionStrict(cfg); err != nil {
+		if opts.lenientPolicyLogAction {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("policy log action (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1818,6 +1818,71 @@ func validatePolicyTerminalActionStrict(cfg *Config) error {
 	return nil
 }
 
+// validatePolicyLogActionStrict hard-rejects a security policy whose `then log`
+// names neither `session-init` nor `session-close` (#3060).
+//
+// Junos requires `then log` to carry at least one of session-init /
+// session-close — a bare `then log` is not valid syntax. xpf's schema accepts
+// the bare form, and compilePolicy sets pol.Log = &PolicyLog{} for it while
+// leaving both SessionInit and SessionClose false. The result is a config that
+// REPORTS logging enabled over REST (pkg/api/security.go: `Log: rule.Log !=
+// nil`) and gRPC/CLI, yet emits NO session records because both log flags are
+// false. On a security appliance this is the worst kind of silent gap: audit
+// looks active while producing nothing.
+//
+// Rejecting the bare form at commit (Junos parity) is the strongest, simplest
+// contract: no bare-log config can exist post-commit, which moots the
+// REST/gRPC/CLI display divergence entirely (every surface agrees because a
+// reported `pol.Log != nil` always carries at least one real session flag).
+// Both per-zone-pair policies and global policies are checked. Iteration order
+// (cfg.Security.Policies, then GlobalPolicies) is deterministic, so the
+// first-reported error is stable.
+//
+// Strict on the commit / commit-check path (CompileConfig — hard-reject);
+// downgraded to a cfg.Warnings entry on the tolerant load / peer-sync paths
+// (CompileConfigLenient / CompileConfigForNodeLenient, flag
+// lenientPolicyLogAction) so an already-persisted or peer-synced config that an
+// older binary accepted still BOOTS (#1960 fail-closed-on-load doctrine). A
+// leniently-loaded bare-log policy is harmless: it simply logs nothing (the
+// pre-existing behavior), and the warning is the operator's signal to fix it.
+// Same doctrine as validatePolicyTerminalActionStrict.
+func validatePolicyLogActionStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(scope string, pol *Policy) error {
+		if pol == nil || pol.Log == nil {
+			return nil
+		}
+		if pol.Log.SessionInit || pol.Log.SessionClose {
+			return nil
+		}
+		detail := "`then log` requires `session-init` and/or `session-close` " +
+			"(a bare `then log` reports logging enabled but emits NO session " +
+			"records — Junos requires at least one of session-init/session-close)"
+		if scope != "" {
+			return fmt.Errorf("%s policy %q: %s", scope, pol.Name, detail)
+		}
+		return fmt.Errorf("policy %q: %s", pol.Name, detail)
+	}
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if err := check("", pol); err != nil {
+				return err
+			}
+		}
+	}
+	for _, pol := range cfg.Security.GlobalPolicies {
+		if err := check("global", pol); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // MaxUsableZoneID is the largest security-zone id the live AF_XDP userspace
 // dataplane can carry. Zone ids are assigned sequentially 1..N in
 // pkg/dataplane/compiler.go and reach the dataplane two ways: as the per-flow

--- a/pkg/config/policy_log_action_3060_test.go
+++ b/pkg/config/policy_log_action_3060_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPolicyBareLogFailsCommit is the #3060 fail-on-revert anchor: a security
+// policy whose `then log` names neither session-init nor session-close compiles
+// to a non-nil PolicyLog with both flags false. The policy then REPORTS logging
+// enabled over REST/gRPC/CLI yet emits NO session records (audit looks active
+// while producing nothing). Junos requires at least one of
+// session-init/session-close, so the strict commit path must hard-reject it.
+// Reverting validatePolicyLogActionStrict to `return nil` makes this CompileConfig
+// succeed (RED).
+func TestPolicyBareLogFailsCommit(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy audit match source-address any",
+		"set security policies from-zone trust to-zone untrust policy audit match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy audit match application any",
+		"set security policies from-zone trust to-zone untrust policy audit then permit",
+		"set security policies from-zone trust to-zone untrust policy audit then log",
+	}
+	tree := buildPolicyTree(t, cmds)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("CompileConfig accepted a policy with a bare `then log`; " +
+			"expected a hard reject (reports logging enabled but emits nothing)")
+	} else if !strings.Contains(err.Error(), "session-init") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestGlobalPolicyBareLogFailsCommit covers the global-policy arm of the #3060
+// gate (a global policy with a bare `then log`).
+func TestGlobalPolicyBareLogFailsCommit(t *testing.T) {
+	cmds := []string{
+		"set security policies global policy g match source-address any",
+		"set security policies global policy g match destination-address any",
+		"set security policies global policy g match application any",
+		"set security policies global policy g then permit",
+		"set security policies global policy g then log",
+	}
+	tree := buildPolicyTree(t, cmds)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("CompileConfig accepted a global policy with a bare `then log`")
+	} else if !strings.Contains(err.Error(), "global policy") ||
+		!strings.Contains(err.Error(), "session-init") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestPolicyLogSessionInitCommits asserts the #3060 gate accepts a `then log`
+// that names session-init (the documented minimum). session-close and both
+// together are also accepted.
+func TestPolicyLogSessionInitCommits(t *testing.T) {
+	for _, variant := range [][]string{
+		{"set security policies from-zone trust to-zone untrust policy audit then log session-init"},
+		{"set security policies from-zone trust to-zone untrust policy audit then log session-close"},
+		{
+			"set security policies from-zone trust to-zone untrust policy audit then log session-init",
+			"set security policies from-zone trust to-zone untrust policy audit then log session-close",
+		},
+	} {
+		cmds := append([]string{
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies from-zone trust to-zone untrust policy audit match source-address any",
+			"set security policies from-zone trust to-zone untrust policy audit match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy audit match application any",
+			"set security policies from-zone trust to-zone untrust policy audit then permit",
+		}, variant...)
+		tree := buildPolicyTree(t, cmds)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig rejected a valid `then log` variant %v: %v", variant, err)
+		}
+	}
+}
+
+// TestPolicyBareLogLenientWarns asserts the #3060 tolerant path: an
+// already-persisted / peer-synced config carrying a bare `then log` must NOT
+// brick the boot (#1960 no-brick doctrine). CompileConfigLenient downgrades the
+// hard reject to a cfg.Warnings entry and still compiles.
+func TestPolicyBareLogLenientWarns(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy audit match source-address any",
+		"set security policies from-zone trust to-zone untrust policy audit match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy audit match application any",
+		"set security policies from-zone trust to-zone untrust policy audit then permit",
+		"set security policies from-zone trust to-zone untrust policy audit then log",
+	}
+	tree := buildPolicyTree(t, cmds)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a bare-log config (should warn, not brick): %v", err)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "policy log action") && strings.Contains(w, "session-init") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'policy log action' downgrade warning; got %v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
Closes #3060

## The bug

A bare security-policy `then log` (no `session-init` / `session-close`)
compiled cleanly. `compilePolicy` set `pol.Log = &PolicyLog{}` for the
`then log` token but left both `SessionInit` and `SessionClose` false. The
policy was then reported as **logging-enabled** over REST
(`pkg/api/security.go`: `Log: rule.Log != nil`), gRPC
(`server_show_policies_text.go` prints `log` whenever `pol.Log != nil`),
and CLI, yet emitted **NO** session records (both log flags false). On a
security appliance this is the worst kind of silent gap: audit looks
active while producing nothing. The surfaces also disagreed
(`cli_show_security.go` suppressed the empty line; REST/gRPC reported it).

Junos requires at least one of `session-init` / `session-close` under
`then log` — a bare `then log` is not valid syntax.

## The fix: reject at commit (Junos parity)

Reject the bare form at commit. This is the strongest, simplest contract:
no bare-log config can exist post-commit, which **moots the
REST/gRPC/CLI display divergence entirely** — a reported `pol.Log != nil`
now always carries at least one real session flag, so every surface
agrees. No display or dataplane-snapshot changes are needed.

Follows the established strict-with-lenient #1960/#3043/#3055 pattern:

- **Strict** `validatePolicyLogActionStrict` (`compiler_validate_strict.go`)
  hard-rejects a policy whose `then log` names neither `session-init` nor
  `session-close`, naming the policy. Covers **both** zone-pair policies
  AND global policies; deterministic iteration so the first-reported error
  is stable.
- **Dispatched** from `compiler.go` after the #3043 terminal-action gate.
- **Lenient** downgrade to a `cfg.Warnings` entry on both lenient
  constructors (`CompileConfigLenient` / `CompileConfigForNodeLenient`)
  via a new `lenientPolicyLogAction` flag, so an already-persisted or
  peer-synced config that an older binary accepted still **BOOTS** (#1960
  no-brick). A leniently-loaded bare-log policy is harmless — it logs
  nothing, the pre-existing behavior; the warning is the operator's signal.

## Validation

- `go build ./...`, `go vet ./pkg/config/...` clean
- `go test ./pkg/config/...` — 1542 pass
- `gofmt -l` clean on touched files
- **Fail-on-revert RED→GREEN**: reverting `validatePolicyLogActionStrict`
  to `return nil` turns `TestPolicyBareLogFailsCommit` and
  `TestGlobalPolicyBareLogFailsCommit` RED; restoring it returns them to
  GREEN. Tests also cover that `then log session-init` / `session-close` /
  both still commit, and that the lenient path downgrades to a warning and
  still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi