### PR TITLE
config: reject wildcard from-zone/to-zone `any` policy at commit (#3018)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-06-25 — #3018: reject wildcard from-zone/to-zone `any` policy at commit
+
+- **Timestamp**: 2026-06-25
+- **Action**: An ordinary zone-pair security policy whose `from-zone` or
+  `to-zone` is the literal Junos wildcard `any` committed cleanly (the #2401
+  reference gate exempts `any`) but the userspace dataplane never indexed it —
+  `PolicyState::from_snapshots` only indexes a rule when both zones resolve to a
+  declared zone-id, and `any` is never inserted into `zone_name_to_id`. Result:
+  an admitted-but-unenforced policy (silent fail-OPEN under a permit default).
+  Added `validatePolicyWildcardZoneStrict` (strict reject at commit, lenient
+  downgrade to a `cfg.Warnings` entry via `lenientPolicyWildcardZone` so an
+  already-persisted/peer-synced config still boots — #1960 no-brick). Interim
+  contract; full wildcard-zone runtime indexing deferred to a follow-up issue.
+  Flipped `TestPolicySpecialZoneTokensCommit` (no longer asserts `any` commits)
+  and added `TestPolicyWildcardZoneFailsCommit` +
+  `TestPolicyWildcardZoneLenientDowngradesToWarning`. Updated comments on
+  `reservedZoneNames`/`policyZoneSpecialTokens` (the "treats it as match-any"
+  claim was false) + a README section.
+- **File(s)**: pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
+  pkg/config/policy_zone_ref_test.go, pkg/config/README.md, _Log.md
+
 ## 2026-06-25 — #3060: reject accepted-but-inert bare `then log` at commit
 
 - **Timestamp**: 2026-06-25

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -260,6 +260,34 @@ to a warning (`lenientReservedZoneNames`) so an already-persisted or peer-synced
 config an older binary accepted still boots — #1960 no-brick doctrine, same as
 #3066/#2401.
 
+**Wildcard from-zone/to-zone `any` is rejected at commit (#3018, interim):** an
+ordinary zone-pair policy whose `from-zone` or `to-zone` is the literal Junos
+wildcard `any` historically committed cleanly — the #2401 reference gate exempts
+`any` (`policyZoneSpecialTokens`) and the old comment claimed the dataplane
+"treats it as match-any". It does NOT: the userspace snapshot builder
+(`pkg/dataplane/userspace/policies.go`) carries the literal `"any"` string
+unchanged for an ordinary zone-pair policy (only `security policies global` maps
+to the `junos-global` sentinel), and `PolicyState::from_snapshots`
+(`userspace-dp/src/policy.rs`) only indexes a non-global rule when BOTH zones
+resolve via `zone_name_to_id.get()`. `any` is never inserted into that map, so a
+`from-zone any` / `to-zone any` rule is KEPT but never indexed and never
+evaluated: `from-zone any to-zone trust ... then deny` commits and looks
+legitimate yet never blocks traffic (silent fail-OPEN under a permit default);
+`from-zone trust to-zone any then permit` cannot permit under a deny default.
+`validatePolicyWildcardZoneStrict` (`compiler_validate_strict.go`) hard-rejects
+such a policy at commit, naming the policy and which side is `any`. This is the
+INTERIM contract: full wildcard-zone runtime indexing (separate ordered index
+lists for exact / from-any / to-any / both-any, evaluated in Junos precedence
+before global/default; no N×N hot-path expansion) is a substantial dataplane
+change deferred to a follow-up. The gate does NOT touch `security policies
+global` (enforced via the `junos-global` sentinel) nor the unrelated `any`
+tokens elsewhere in a policy (`match source-address any` / `match application
+any`) — only the from-zone/to-zone slot. The tolerant load/peer-sync path
+downgrades to a warning (`lenientPolicyWildcardZone`) so an already-persisted or
+peer-synced config carrying a from-zone/to-zone `any` still boots — the rule was
+already inert, so a leniently-loaded config behaves exactly as before, just
+flagged (#1960 no-brick doctrine, same as #3066/#3055/#2401).
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -684,6 +684,21 @@ type compileOpts struct {
 	// peer-synced config an older binary accepted still BOOTS (#1960 no-brick).
 	// Same doctrine as lenientPolicyZoneRefs.
 	lenientReservedZoneNames bool
+	// lenientPolicyWildcardZone (#3018) downgrades the wildcard from-zone/
+	// to-zone gate (validatePolicyWildcardZoneStrict) from a hard compile error
+	// to a cfg.Warnings entry. The strict commit / commit-check path hard-rejects
+	// an ordinary zone-pair policy whose from-zone or to-zone is the literal
+	// Junos wildcard `any`: the userspace snapshot builder carries the literal
+	// "any" string unchanged and PolicyState::from_snapshots
+	// (userspace-dp/src/policy.rs) only indexes a rule when BOTH zones resolve to
+	// a declared zone-id, so a from-zone/to-zone `any` rule is KEPT but never
+	// indexed and never evaluated — a silent fail-OPEN under a permit default.
+	// The tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config carrying a from-zone/to-zone `any`
+	// still BOOTS (#1960 no-brick) — it stays unenforced (the pre-existing
+	// behavior), now flagged. Full wildcard-zone runtime indexing is a deferred
+	// follow-up. Same doctrine as lenientPolicyZoneRefs.
+	lenientPolicyWildcardZone bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -747,6 +762,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyLogAction:             true,
 		lenientScreenProfileRefs:           true,
 		lenientReservedZoneNames:           true,
+		lenientPolicyWildcardZone:          true,
 	})
 }
 
@@ -861,6 +877,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyLogAction:             true,
 		lenientScreenProfileRefs:           true,
 		lenientReservedZoneNames:           true,
+		lenientPolicyWildcardZone:          true,
 	})
 }
 
@@ -1236,6 +1253,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientPolicyZoneRefs {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("policy zone reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3018 security-policy wildcard from-zone/to-zone fail-open gate. Strict on
+	// commit / commit-check (hard-reject an ordinary zone-pair policy whose
+	// from-zone or to-zone is the literal `any` — the userspace snapshot builder
+	// carries the literal "any" string unchanged and the dataplane only indexes a
+	// rule when BOTH zones resolve to a declared zone-id, so a from-zone/to-zone
+	// `any` rule COMMITS but is never indexed and never evaluated, silently
+	// failing OPEN under a permit default); lenient on load / peer-sync (warn so
+	// an already-persisted or peer-synced config with a from-zone/to-zone `any`
+	// still boots — #1960 no-brick; the rule was already inert, so a leniently-
+	// loaded config behaves exactly as before, just flagged). Does NOT touch
+	// `security policies global` (handled via the junos-global sentinel) nor the
+	// unrelated `any` match-address/application tokens. Full wildcard-zone
+	// indexing is a deferred follow-up. Runs AFTER the zone-reference gate so a
+	// genuinely undefined zone still wins the first-error slot.
+	if err := validatePolicyWildcardZoneStrict(cfg); err != nil {
+		if opts.lenientPolicyWildcardZone {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("policy wildcard zone (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1520,9 +1520,12 @@ func validatePolicyMatchAddressesStrict(cfg *Config) error {
 //     rules into device-wide fallbacks that permit traffic for unrelated zone
 //     pairs — a security-boundary escape.
 //
-//   - "any"         — Junos wildcard zone (`from-zone any`/`to-zone any`); the
-//     dataplane treats it as match-any, never a named zone-id lookup, so a real
+//   - "any"         — Junos wildcard zone (`from-zone any`/`to-zone any`); a
+//     reserved policy-context token, never a named zone-id lookup, so a real
 //     zone named "any" can never be selected and would shadow the wildcard.
+//     (The dataplane does NOT actually index a from-zone/to-zone `any` policy —
+//     see validatePolicyWildcardZoneStrict, #3018 — but a zone DEFINITION named
+//     "any" is rejected here regardless.)
 //
 //   - "junos-host"  — Junos reserved self-traffic zone (host-inbound / host-
 //     outbound policy context); it is never declared as a `security zone`.
@@ -1540,8 +1543,13 @@ var reservedZoneNames = map[string]struct{}{
 //   - ""            — an empty token: a zone-pair with no name compiles to no
 //     usable rule and is not an undefined-zone reference per se; leave it to
 //     the structural compiler rather than reporting a confusing `""` error.
-//   - "any"         — Junos wildcard zone (`from-zone any`/`to-zone any`); the
-//     dataplane treats it as match-any, never a named zone-id lookup.
+//   - "any"         — Junos wildcard zone (`from-zone any`/`to-zone any`); kept
+//     exempt HERE so the undefined-zone gate does not emit a confusing "define
+//     `security zones security-zone any`" error (such a zone definition is
+//     itself rejected). A from-zone/to-zone `any` is instead hard-rejected by
+//     the dedicated wildcard gate (validatePolicyWildcardZoneStrict, #3018)
+//     because the dataplane never indexes it (fail-OPEN), NOT because the zone
+//     is undefined.
 //   - "junos-host"  — Junos reserved self-traffic zone (host-inbound / host-
 //     outbound policy context); it is never declared as a `security zone`.
 //
@@ -1663,6 +1671,75 @@ func validatePolicyZoneReferencesStrict(cfg *Config) error {
 				"security policy from-zone %q to-zone %q references undefined to-zone %q; define `set security zones security-zone %s` in the same commit or the rule is silently never matched (zone-pair falls through to the default policy)",
 				zpp.FromZone, zpp.ToZone, zpp.ToZone, zpp.ToZone)
 		}
+	}
+	return nil
+}
+
+// validatePolicyWildcardZoneStrict hard-rejects an ordinary security policy
+// zone-pair (`from-zone <a> to-zone <b> { policy ... }`) whose from-zone or
+// to-zone is the literal Junos wildcard `any` (#3018).
+//
+// The strict zone-reference gate (validatePolicyZoneReferencesStrict) EXEMPTS
+// `any` from the "zone must be defined" check, and the historical comment
+// claimed the dataplane "treats it as match-any". It does NOT. The userspace
+// snapshot builder (pkg/dataplane/userspace/policies.go) carries the literal
+// "any" string unchanged for an ordinary zone-pair policy — only `security
+// policies global` is mapped to the junos-global sentinel — and
+// PolicyState::from_snapshots (userspace-dp/src/policy.rs) only indexes a
+// non-global rule when BOTH zones resolve via zone_name_to_id.get(). "any" is
+// never inserted into zone_name_to_id (only declared zones are), so the rule is
+// KEPT but never indexed and never evaluated. Result: `from-zone any to-zone
+// trust ... then deny` commits and looks legitimate yet never blocks traffic
+// (fail-OPEN under a permit default); `from-zone trust to-zone any then permit`
+// cannot permit under a deny default. An admitted-but-unenforced security policy
+// is a fail-open bug, so the interim fix hard-rejects it at commit rather than
+// letting it silently fail open.
+//
+// This is the INTERIM contract: full wildcard-zone runtime indexing (separate
+// ordered index lists for exact / from-any / to-any / both-any, evaluated in
+// Junos precedence before global/default) is a substantial dataplane change
+// deferred to a follow-up; until it exists a from-zone/to-zone `any` literal is
+// rejected. It does NOT touch the unrelated `any` tokens elsewhere in a policy
+// (`match source-address any` / `match application any`) — only the
+// from-zone/to-zone slot. Global policies (`security policies global`) live in
+// cfg.Security.GlobalPolicies with no from/to-zone strings and are mapped to the
+// junos-global sentinel by the snapshot builder, so they ARE enforced and are
+// not iterated here.
+//
+// Strict on commit / commit-check (CompileConfig — hard reject so the operator
+// sees the unenforceable rule); downgraded to a cfg.Warnings entry on the
+// tolerant load / peer-sync paths (CompileConfigLenient /
+// CompileConfigForNodeLenient, flag lenientPolicyWildcardZone) so an
+// already-persisted or peer-synced config carrying a from-zone/to-zone `any`
+// still BOOTS (#1960 no-brick) — it stays unenforced (the pre-existing
+// behavior), now flagged. Iteration is in cfg.Security.Policies order
+// (deterministic), so the first-reported error is stable.
+func validatePolicyWildcardZoneStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		var side string
+		switch {
+		case zpp.FromZone == "any" && zpp.ToZone == "any":
+			side = "from-zone and to-zone"
+		case zpp.FromZone == "any":
+			side = "from-zone"
+		case zpp.ToZone == "any":
+			side = "to-zone"
+		default:
+			continue
+		}
+		name := "(unnamed)"
+		if len(zpp.Policies) > 0 && zpp.Policies[0] != nil && zpp.Policies[0].Name != "" {
+			name = zpp.Policies[0].Name
+		}
+		return fmt.Errorf(
+			"security policy %q (from-zone %q to-zone %q) uses the wildcard zone `any` on its %s; the userspace dataplane does not index a from-zone/to-zone `any` policy (userspace-dp/src/policy.rs only indexes a rule when both zones resolve to a declared zone-id), so the rule would COMMIT but never be evaluated — failing open under a permit default. Rewrite it as explicit per-zone-pair policies, or as a `security policies global` policy for a device-wide rule; full wildcard-zone support is a deferred follow-up",
+			name, zpp.FromZone, zpp.ToZone, side)
 	}
 	return nil
 }

--- a/pkg/config/policy_zone_ref_test.go
+++ b/pkg/config/policy_zone_ref_test.go
@@ -62,21 +62,19 @@ func TestPolicyUndefinedZoneFailsCommit(t *testing.T) {
 }
 
 // TestPolicySpecialZoneTokensCommit asserts the strict validator does NOT
-// reject the legitimate reserved zone tokens (#2401 anti-over-reject): the
-// `any` wildcard zone, the `junos-host` self-traffic zone, and global policies
-// (which carry no from/to-zone strings). A regression here would break valid
-// operator configs.
+// reject the still-legitimate reserved zone tokens (#2401 anti-over-reject):
+// the `junos-host` self-traffic zone and global policies (which carry no
+// from/to-zone strings). A regression here would break valid operator configs.
+//
+// NOTE (#3018): the wildcard `from-zone any` / `to-zone any` cases that this
+// test once asserted commit-and-work have been MOVED to
+// TestPolicyWildcardZoneFailsCommit — they are now hard-rejected at commit
+// because the userspace dataplane never indexes a from-zone/to-zone `any`
+// policy (silent fail-OPEN). The unrelated `any` tokens (`match source-address
+// any` / `match application any`) remain legitimate and are exercised below.
 func TestPolicySpecialZoneTokensCommit(t *testing.T) {
 	tree := buildTree(t, []string{
 		"set security zones security-zone trust",
-		// from-zone any -> a defined zone
-		"set security policies from-zone any to-zone trust policy fa match source-address any",
-		"set security policies from-zone any to-zone trust policy fa match application any",
-		"set security policies from-zone any to-zone trust policy fa then permit",
-		// a defined zone -> to-zone any
-		"set security policies from-zone trust to-zone any policy ta match source-address any",
-		"set security policies from-zone trust to-zone any policy ta match application any",
-		"set security policies from-zone trust to-zone any policy ta then permit",
 		// junos-host self-traffic context on both sides
 		"set security policies from-zone trust to-zone junos-host policy host match source-address any",
 		"set security policies from-zone trust to-zone junos-host policy host match application any",
@@ -88,6 +86,91 @@ func TestPolicySpecialZoneTokensCommit(t *testing.T) {
 	})
 	if _, err := CompileConfig(tree); err != nil {
 		t.Fatalf("strict commit rejected a legitimate special-zone policy: %v", err)
+	}
+}
+
+// TestPolicyWildcardZoneFailsCommit asserts that an ordinary zone-pair policy
+// whose from-zone or to-zone is the literal Junos wildcard `any` is
+// HARD-REJECTED at commit (#3018).
+//
+// This is the fail-on-revert guard for the fail-open bug: the strict
+// zone-reference gate exempts `any`, so before this fix a `from-zone any` /
+// `to-zone any` policy COMMITTED and looked legitimate, but the userspace
+// snapshot builder carries the literal "any" string unchanged and
+// PolicyState::from_snapshots (userspace-dp/src/policy.rs) only indexes a rule
+// when BOTH zones resolve to a declared zone-id — so the rule was KEPT but
+// never indexed and never evaluated (silent fail-OPEN under a permit default).
+// Make validatePolicyWildcardZoneStrict return nil (or drop its dispatch in
+// compiler.go) and these subtests go green on the BAD config, which is exactly
+// the regression this test exists to catch. Full wildcard-zone runtime indexing
+// is a deferred follow-up.
+func TestPolicyWildcardZoneFailsCommit(t *testing.T) {
+	cases := []struct {
+		name    string
+		cmds    []string
+		wantSub string
+	}{
+		{
+			name: "from-zone any",
+			cmds: []string{
+				"set security zones security-zone trust",
+				"set security policies from-zone any to-zone trust policy P match source-address any",
+				"set security policies from-zone any to-zone trust policy P match application any",
+				"set security policies from-zone any to-zone trust policy P then deny",
+			},
+			wantSub: "wildcard zone `any`",
+		},
+		{
+			name: "to-zone any",
+			cmds: []string{
+				"set security zones security-zone trust",
+				"set security policies from-zone trust to-zone any policy P match source-address any",
+				"set security policies from-zone trust to-zone any policy P match application any",
+				"set security policies from-zone trust to-zone any policy P then permit",
+			},
+			wantSub: "wildcard zone `any`",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, tc.cmds)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject a from-zone/to-zone `any` policy, got nil error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not flag the wildcard zone (want substring %q)", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestPolicyWildcardZoneLenientDowngradesToWarning asserts the tolerant load /
+// peer-sync path downgrades the from-zone/to-zone `any` reject to a warning
+// instead of failing the compile, so an already-persisted or peer-synced config
+// carrying a wildcard-zone policy still boots (#3018 / #1960 no-brick). The
+// dataplane never indexed the rule anyway, so the leniently-loaded config
+// behaves exactly as before — just flagged.
+func TestPolicyWildcardZoneLenientDowngradesToWarning(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone trust",
+		"set security policies from-zone any to-zone trust policy P match source-address any",
+		"set security policies from-zone any to-zone trust policy P match application any",
+		"set security policies from-zone any to-zone trust policy P then deny",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on a wildcard-zone policy: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "policy wildcard zone (downgraded to warning on tolerant path)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a downgraded policy wildcard-zone warning, got warnings: %v", cfg.Warnings)
 	}
 }
 


### PR DESCRIPTION
Closes #3018

## The fail-open bug
An ordinary zone-pair security policy whose `from-zone` or `to-zone` is the literal Junos wildcard `any` COMMITS cleanly but is never enforced. The #2401 strict zone-reference gate exempts `any` (`policyZoneSpecialTokens`) and the old comment claimed the dataplane "treats it as match-any". It does NOT: the userspace snapshot builder (`pkg/dataplane/userspace/policies.go`) carries the literal `"any"` string unchanged for an ordinary zone-pair policy (only `security policies global` maps to the `junos-global` sentinel), and `PolicyState::from_snapshots` (`userspace-dp/src/policy.rs`) only indexes a non-global rule when BOTH zones resolve via `zone_name_to_id.get()`. `any` is never inserted into that map, so the rule is KEPT but never indexed and never evaluated:

- `from-zone any to-zone trust ... then deny` commits and looks legitimate yet never blocks traffic (silent fail-OPEN under a permit default);
- `from-zone trust to-zone any then permit` cannot permit under a deny default.

An admitted-but-unenforced security policy is a fail-open bug.

## Interim contract — reject at commit
Consistent with the #3055/#3060/#3066 pattern for accepted-but-inert security gaps, this hard-rejects a from-zone/to-zone `any` zone-pair policy at commit rather than letting it silently fail open. Full wildcard-zone runtime indexing (separate ordered index lists for exact / from-any / to-any / both-any, evaluated in Junos precedence before global/default; no N×N hot-path expansion) is a substantial dataplane change deferred to a follow-up: **#3090**.

## Implementation
- `validatePolicyWildcardZoneStrict` (`compiler_validate_strict.go`) hard-rejects an ordinary zone-pair policy whose from-zone/to-zone is the literal `any`, naming the policy and which side is `any`. It does NOT touch `security policies global` (enforced via the `junos-global` sentinel) nor the unrelated `any` `match source-address`/`application` tokens — only the from-zone/to-zone slot.
- Strict/lenient split (#1960 doctrine): strict on `CompileConfig`; downgraded to a `cfg.Warnings` entry on `CompileConfigLenient` / `CompileConfigForNodeLenient` via the new `lenientPolicyWildcardZone` flag, so an already-persisted or peer-synced config carrying a from-zone/to-zone `any` still BOOTS — the rule was already inert, so the leniently-loaded config behaves exactly as before, just flagged.
- Fixed the false "treats it as match-any" comments on `reservedZoneNames` and `policyZoneSpecialTokens`.

## Docs / tests
- Flipped `TestPolicySpecialZoneTokensCommit` — it no longer asserts a from-zone/to-zone `any` policy commits-and-works (that directly contradicted the fix). `junos-host` and global policies still commit.
- Added `TestPolicyWildcardZoneFailsCommit` (reject, both sides) and `TestPolicyWildcardZoneLenientDowngradesToWarning` (no-brick).
- Added a `pkg/config/README.md` section.

## Validation
- `go build ./...`, `go vet ./pkg/config/...` clean.
- `go test ./pkg/config/...` 1546 pass; `./pkg/dataplane/... ./pkg/grpcapi/... ./pkg/cli/...` 1142 pass. `gofmt` clean on touched files.
- **Fail-on-revert:** stubbing `validatePolicyWildcardZoneStrict` to `return nil` turns the reject + lenient-warning tests RED (4 failures); restoring it GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi