### PR TITLE
screen: cache SYN-cookie epoch wall clock once per second (#3032)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -19,6 +19,33 @@
 - **File(s)**: pkg/config/compiler.go, pkg/config/compiler_validate_strict.go,
   pkg/config/policy_zone_ref_test.go, pkg/config/README.md, _Log.md
 
+## 2026-06-25 — #3032: cache SYN-cookie epoch wall clock once per second
+
+- **Timestamp**: 2026-06-25
+- **Action**: `SynCookieCodec::current_full_epoch()` read `SystemTime::now()`
+  on every minted/validated cookie — redundant CPU exactly under a SYN flood
+  since the cookie epoch is 64s wide. Made the leaf pure
+  (`current_full_epoch(now_secs)` = `full_epoch_from_unix_secs(now_secs)`) and
+  moved the OS clock read into `ScreenState::current_syn_cookie_full_epoch`,
+  gated to fire at most once per monotonic second (keyed by the batch-cached
+  monotonic `now_secs` already threaded into `check_packet_with_zone_id` and the
+  standby-ACK path). CLOCK-DOMAIN: the batch `now_secs` is `CLOCK_MONOTONIC`
+  (per-node, unrelated across HA peers); the cookie epoch needs Unix wall-clock
+  (NTP-synced) so a cookie minted on one node validates on its peer. So the
+  monotonic second is used ONLY as the refresh throttle; the cached value seeded
+  into the epoch is `SystemTime::now()` wall-clock seconds. Both call sites
+  (mint ~388, standby-ACK validation ~594) share one cached wall-second per
+  second; the ±1-epoch (±64s) validation window absorbs the ≤1s cache staleness.
+- **File(s)**: userspace-dp/src/screen/syncookie.rs,
+  userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/tests.rs,
+  docs/syn-cookie-flood-protection.md, _Log.md
+- **Validation**: cargo build --release -p xpf-userspace-dp (0 errors); cargo
+  test --release -p xpf-userspace-dp → 3022 passed, 2 ignored. New tests:
+  `syn_cookie_current_full_epoch_is_pure_wall_clock_passthrough` (pins leaf ==
+  full_epoch_from_unix_secs for sample seconds) and
+  `syn_cookie_round_trip_with_cached_wall_secs` (mint/validate round-trip across
+  the ±1-epoch window; 2 epochs ahead fails as before).
+
 ## 2026-06-25 — #3060: reject accepted-but-inert bare `then log` at commit
 
 - **Timestamp**: 2026-06-25

--- a/_Log.md
+++ b/_Log.md
@@ -40,11 +40,22 @@
   userspace-dp/src/screen/mod.rs, userspace-dp/src/screen/tests.rs,
   docs/syn-cookie-flood-protection.md, _Log.md
 - **Validation**: cargo build --release -p xpf-userspace-dp (0 errors); cargo
-  test --release -p xpf-userspace-dp → 3022 passed, 2 ignored. New tests:
-  `syn_cookie_current_full_epoch_is_pure_wall_clock_passthrough` (pins leaf ==
-  full_epoch_from_unix_secs for sample seconds) and
+  test --release -p xpf-userspace-dp → 3022 passed, 2 ignored (a later run saw
+  2 unrelated afxdp concurrency flakes — wg::engine reconcile_peers_snapshot
+  and worker_queue concurrent_recovery — both pass in isolation; screen suite
+  137/137 green). Three tests:
+  `syn_cookie_current_full_epoch_is_pure_wall_clock_passthrough` (pins the leaf
+  == full_epoch_from_unix_secs for sample seconds — leaf-level guard) and
   `syn_cookie_round_trip_with_cached_wall_secs` (mint/validate round-trip across
-  the ±1-epoch window; 2 epochs ahead fails as before).
+  the ±1-epoch window; 2 epochs ahead fails as before — codec-level guard).
+  REVIEW FOLD: added `syn_cookie_screen_state_epoch_uses_wall_clock_not_monotonic`
+  — drives `ScreenState::current_syn_cookie_full_epoch(mono=5)` (no test
+  override) and asserts the returned epoch equals the LIVE Unix wall-clock epoch
+  (anchored via `read_unix_wall_secs()`, bracketed for 64s-boundary tolerance)
+  and is NOT `full_epoch_from_unix_secs(5)` and not 0. This is the call-site
+  clock-domain guard the leaf tests could not provide: reverting the call site to
+  `current_full_epoch(mono_now_secs)` was empirically verified RED→GREEN (RED:
+  "epoch must come from the live Unix wall clock (27850618..=27850618), got 0").
 
 ## 2026-06-25 — #3060: reject accepted-but-inert bare `then log` at commit
 

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -139,7 +139,17 @@ is local, but the snapshot-published key is derived from cluster-synced root
 encrypted-password material so peers with the same committed config can
 validate cookies minted by the former active node inside the current,
 previous, or next Unix wall-clock epoch overlap. The next-epoch candidate keeps
-failover stable when peer clocks straddle a 64-second boundary. A standby peer
+failover stable when peer clocks straddle a 64-second boundary. The epoch input
+MUST be Unix wall-clock seconds (not `CLOCK_MONOTONIC`), since peers share only
+the NTP-synced wall clock — their monotonic bases are unrelated. To avoid an OS
+clock read on every minted/validated cookie under a flood (#3032), the helper
+reads `SystemTime::now()` at most once per monotonic second
+(`ScreenState::current_syn_cookie_full_epoch`, gated by the batch-cached
+monotonic second already threaded into the screen check) and caches the derived
+wall-clock seconds; every cookie in the same second reuses the cached value
+because they all map to the same 64-second epoch. The epoch leaf
+(`SynCookieCodec::current_full_epoch`) is a pure function of the supplied
+seconds and never touches the clock. A standby peer
 accepts a valid cookie ACK even when it has not locally observed the flood
 threshold; ACKs outside the transmitted-epoch window are prefiltered before
 SipHash, and plausible standby ACKs are rate-limited per zone over a sliding

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -42,6 +42,7 @@
 //! - `tests`         — relocated screen_tests.rs (loaded via #[path]).
 
 use rustc_hash::FxHashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 mod extract;
 mod packet;
@@ -115,6 +116,15 @@ pub(crate) struct ScreenState {
     /// there.
     syn_cookie_profile_gen: FxHashMap<String, u64>,
     syn_cookie_last_full_epoch: u64,
+    /// #3032: Unix wall-clock seconds cached for SYN-cookie epoch math,
+    /// refreshed at most once per monotonic second (see
+    /// `current_syn_cookie_full_epoch`) so the SYN-flood hot path does not
+    /// read the OS clock per packet.
+    syn_cookie_epoch_wall_secs: u64,
+    /// #3032: the monotonic second at which `syn_cookie_epoch_wall_secs` was
+    /// last refreshed. `u64::MAX` is the "never refreshed" sentinel so the
+    /// first cookie mint/validate always samples the wall clock.
+    syn_cookie_epoch_clock_mono_secs: u64,
     #[cfg(test)]
     syn_cookie_full_epoch_override: Option<u64>,
     // Advanced screen trackers (shared across all zones since they track per-IP)
@@ -136,6 +146,8 @@ impl ScreenState {
             syn_cookie_validated: SynCookieValidatedCache::default(),
             syn_cookie_profile_gen: FxHashMap::default(),
             syn_cookie_last_full_epoch: 0,
+            syn_cookie_epoch_wall_secs: 0,
+            syn_cookie_epoch_clock_mono_secs: u64::MAX,
             #[cfg(test)]
             syn_cookie_full_epoch_override: None,
             port_scan: PortScanTracker::default(),
@@ -225,14 +237,40 @@ impl ScreenState {
         }
     }
 
-    fn current_syn_cookie_full_epoch(&mut self) -> u64 {
+    /// Current SYN-cookie full epoch, latched non-decreasing.
+    ///
+    /// `mono_now_secs` is the batch-cached `CLOCK_MONOTONIC` second already
+    /// threaded into `check_packet_with_zone_id` / the standby-ACK path. It
+    /// is used ONLY as a once-per-second refresh gate (#3032): the actual
+    /// epoch is derived from a cached *Unix wall-clock* sample, not from
+    /// `mono_now_secs`. The monotonic clock is unsuitable as the epoch input
+    /// because HA peers have unrelated monotonic bases — the wall clock is
+    /// the shared (NTP-synced) domain that lets a cookie minted on one node
+    /// validate on its peer. The OS wall clock is read at most once per
+    /// monotonic second, so a SYN flood no longer pays `SystemTime::now()`
+    /// per packet (every cookie in the same second shares one 64s epoch).
+    fn current_syn_cookie_full_epoch(&mut self, mono_now_secs: u64) -> u64 {
         #[cfg(test)]
         if let Some(epoch) = self.syn_cookie_full_epoch_override {
             return epoch;
         }
-        let epoch = SynCookieCodec::current_full_epoch();
+        if self.syn_cookie_epoch_clock_mono_secs != mono_now_secs {
+            self.syn_cookie_epoch_wall_secs = Self::read_unix_wall_secs();
+            self.syn_cookie_epoch_clock_mono_secs = mono_now_secs;
+        }
+        let epoch = SynCookieCodec::current_full_epoch(self.syn_cookie_epoch_wall_secs);
         self.syn_cookie_last_full_epoch = self.syn_cookie_last_full_epoch.max(epoch);
         self.syn_cookie_last_full_epoch
+    }
+
+    /// Read Unix wall-clock seconds. The single OS-clock read behind the
+    /// SYN-cookie epoch (#3032); kept off the per-packet leaf
+    /// (`SynCookieCodec::current_full_epoch`, which is pure).
+    fn read_unix_wall_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0)
     }
 
     #[cfg(test)]
@@ -388,7 +426,7 @@ impl ScreenState {
                             let Some(codec) = self.syn_cookie_codec else {
                                 return ScreenVerdict::Drop("syn-cookie-unavailable");
                             };
-                            let full_epoch = self.current_syn_cookie_full_epoch();
+                            let full_epoch = self.current_syn_cookie_full_epoch(now_secs);
                             let cookie_isn = codec.mint_isn(
                                 SynCookieTuple::from_packet(pkt),
                                 zone_id,
@@ -594,7 +632,7 @@ impl ScreenState {
             };
         };
         let cookie_isn = pkt.tcp_ack.wrapping_sub(1);
-        let current_epoch = self.current_syn_cookie_full_epoch();
+        let current_epoch = self.current_syn_cookie_full_epoch(now_secs);
         if !locally_active {
             if !SynCookieCodec::wire_epoch_matches_validation_window(current_epoch, cookie_isn) {
                 return SynCookieAckVerdict::NotApplicable;

--- a/userspace-dp/src/screen/syncookie.rs
+++ b/userspace-dp/src/screen/syncookie.rs
@@ -16,7 +16,6 @@
 //!   SYN-flood counter then re-sees the connection).
 
 use std::net::IpAddr;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::packet::ScreenPacketInfo;
 
@@ -118,12 +117,18 @@ impl SynCookieCodec {
         unix_secs / Self::EPOCH_SECS
     }
 
-    pub(super) fn current_full_epoch() -> u64 {
-        let unix_secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_secs())
-            .unwrap_or(0);
-        Self::full_epoch_from_unix_secs(unix_secs)
+    /// Derive the SYN-cookie full epoch from a caller-supplied Unix
+    /// wall-clock seconds value. The timestamp is read once per monotonic
+    /// second by `ScreenState::current_syn_cookie_full_epoch` rather than
+    /// per packet (#3032): under a SYN flood every minted/validated cookie
+    /// in the same second shares the same 64-second epoch, so the per-packet
+    /// `SystemTime::now()` was redundant CPU. This leaf is pure — it never
+    /// reads the OS clock. The seconds MUST be Unix wall-clock (not
+    /// `CLOCK_MONOTONIC`): HA peers derive identical epochs across failover
+    /// only because their Unix clocks are NTP-synced while their monotonic
+    /// bases are unrelated (see `ScreenState::update_syn_cookie_master_key`).
+    pub(super) fn current_full_epoch(now_secs: u64) -> u64 {
+        Self::full_epoch_from_unix_secs(now_secs)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -1855,6 +1855,74 @@ fn syn_cookie_epoch_uses_unix_wall_clock_units() {
 }
 
 #[test]
+fn syn_cookie_current_full_epoch_is_pure_wall_clock_passthrough() {
+    // #3032: the epoch leaf must be a pure function of the supplied Unix
+    // wall-clock seconds — it no longer reads the OS clock. Pinning it equal
+    // to `full_epoch_from_unix_secs` for sample seconds catches any
+    // off-by-one-epoch or clock-domain regression at the leaf.
+    for secs in [0u64, 1, 63, 64, 127, 128, 64 * 33 + 9, 1_800_000_000] {
+        assert_eq!(
+            SynCookieCodec::current_full_epoch(secs),
+            SynCookieCodec::full_epoch_from_unix_secs(secs),
+            "current_full_epoch must equal full_epoch_from_unix_secs for {secs}s",
+        );
+    }
+}
+
+#[test]
+fn syn_cookie_round_trip_with_cached_wall_secs() {
+    // #3032: minting with an epoch derived from a cached wall-clock second
+    // (as the hot path now does once per monotonic second) and validating
+    // with the same cached domain must round-trip — and must keep the same
+    // 60s+ window tolerance as before. T sits mid-epoch so the +/-1 epoch
+    // window is exercised, not a boundary artifact.
+    let codec = syn_cookie_codec();
+    let tuple = syn_cookie_tuple();
+    // 1_800_000_000 is an exact multiple of EPOCH_SECS (64), so the second
+    // sits at offset 0 within its epoch and the +/- arithmetic below stays
+    // inside / crosses epochs deterministically.
+    let mint_unix_secs = 1_800_000_000u64;
+    assert_eq!(mint_unix_secs % SynCookieCodec::EPOCH_SECS, 0);
+    let mint_epoch = SynCookieCodec::current_full_epoch(mint_unix_secs);
+    let cookie = codec.mint_isn(tuple, 7, mint_epoch, 1460);
+
+    // Validate at the same cached second.
+    assert!(
+        codec.validate_isn(tuple, 7, mint_epoch, cookie).is_some(),
+        "same-second validation must succeed",
+    );
+    // Validate from a second still inside the same epoch (cached value may be
+    // up to ~1s stale under the once-per-second refresh, well within window).
+    let same_epoch_later =
+        SynCookieCodec::current_full_epoch(mint_unix_secs + (SynCookieCodec::EPOCH_SECS - 1));
+    assert_eq!(same_epoch_later, mint_epoch);
+    assert!(
+        codec
+            .validate_isn(tuple, 7, same_epoch_later, cookie)
+            .is_some(),
+        "validation later in the same epoch must succeed",
+    );
+    // Validate one epoch ahead (next-second crossing into the next epoch) —
+    // still inside the +/-1 epoch acceptance window.
+    let next_epoch =
+        SynCookieCodec::current_full_epoch(mint_unix_secs + SynCookieCodec::EPOCH_SECS);
+    assert_eq!(next_epoch, mint_epoch + 1);
+    assert!(
+        codec.validate_isn(tuple, 7, next_epoch, cookie).is_some(),
+        "validation one epoch later must succeed (window tolerance)",
+    );
+    // Two epochs ahead is outside the window and must fail, exactly as
+    // before the cached-now change.
+    let two_epochs_ahead =
+        SynCookieCodec::current_full_epoch(mint_unix_secs + 2 * SynCookieCodec::EPOCH_SECS);
+    assert_eq!(two_epochs_ahead, mint_epoch + 2);
+    assert!(
+        codec.validate_isn(tuple, 7, two_epochs_ahead, cookie).is_none(),
+        "validation two epochs later must fail as before",
+    );
+}
+
+#[test]
 fn syn_cookie_wall_clock_epoch_survives_peer_uptime_skew() {
     let codec = syn_cookie_codec();
     let tuple = syn_cookie_tuple();

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -1923,6 +1923,46 @@ fn syn_cookie_round_trip_with_cached_wall_secs() {
 }
 
 #[test]
+fn syn_cookie_screen_state_epoch_uses_wall_clock_not_monotonic() {
+    // #3032 (call-site clock-domain guard): `current_syn_cookie_full_epoch`
+    // takes the batch-cached MONOTONIC second purely as a once-per-second
+    // refresh throttle, but must derive the epoch from the cached Unix
+    // wall-clock seconds — NOT from the monotonic argument. This is the exact
+    // HA-breaking regression the issue feared: feeding `mono_now_secs` into
+    // the epoch (`current_full_epoch(mono_now_secs)`) would compile and pass
+    // every leaf/codec test. This test fails if that happens.
+    //
+    // No `set_syn_cookie_full_epoch_for_test` override here — that would
+    // short-circuit the very selection under test.
+    let mut state = make_state("trust", ScreenProfile::default());
+
+    // A small monotonic second lands in a wildly different epoch bucket than
+    // the live wall clock (~1.7e9s ⇒ epoch ~28M vs. epoch 0 for 5s), so the
+    // two are always distinguishable regardless of when the test runs.
+    let mono_now_secs = 5u64;
+    let monotonic_epoch = SynCookieCodec::full_epoch_from_unix_secs(mono_now_secs);
+
+    // Bracket the call with wall-clock samples from the SAME source the
+    // implementation uses, so a 64s-boundary crossing during the call cannot
+    // flake the assertion.
+    let wall_epoch_before =
+        SynCookieCodec::full_epoch_from_unix_secs(ScreenState::read_unix_wall_secs());
+    let got = state.current_syn_cookie_full_epoch(mono_now_secs);
+    let wall_epoch_after =
+        SynCookieCodec::full_epoch_from_unix_secs(ScreenState::read_unix_wall_secs());
+
+    assert!(
+        got == wall_epoch_before || got == wall_epoch_after,
+        "epoch must come from the live Unix wall clock ({wall_epoch_before}..={wall_epoch_after}), got {got}",
+    );
+    assert_ne!(
+        got, monotonic_epoch,
+        "epoch must NOT be derived from the monotonic argument ({mono_now_secs}s ⇒ epoch {monotonic_epoch})",
+    );
+    assert_ne!(got, 0, "a live wall-clock epoch is never 0 (1970)");
+}
+
+#[test]
 fn syn_cookie_wall_clock_epoch_survives_peer_uptime_skew() {
     let codec = syn_cookie_codec();
     let tuple = syn_cookie_tuple();


### PR DESCRIPTION
Closes #3032

## Problem
`SynCookieCodec::current_full_epoch()` read `SystemTime::now()` on **every** minted and standby-validated SYN cookie (`screen/syncookie.rs`, via `current_syn_cookie_full_epoch()` from `mint_isn` ~388 and the standby ACK validation path ~594). Under a SYN flood that is the single hottest place the OS clock could be read, and it is redundant: the SYN-cookie epoch is 64 seconds wide, so every cookie minted/validated within the same second maps to the same epoch.

## Fix
- The epoch leaf is now pure: `current_full_epoch(now_secs)` = `full_epoch_from_unix_secs(now_secs)`, never reads the clock.
- The OS clock read moved into `ScreenState::current_syn_cookie_full_epoch`, gated to fire **at most once per monotonic second**, keyed by the batch-cached `now_secs` already threaded into `check_packet_with_zone_id` and the standby-ACK path.

## Clock-domain confirmation (the real correctness risk)
The batch `now_secs` is **`CLOCK_MONOTONIC`** seconds (`loop_now_secs = monotonic_nanos() / 1e9` in `worker/loop_body/mod.rs`), which is per-node and unrelated across HA peers. The cookie epoch, however, **must be Unix wall-clock** seconds so a cookie minted on the former active node validates on its peer after failover — peers share only the NTP-synced wall clock (documented at `update_syn_cookie_master_key` and pinned by the existing `syn_cookie_wall_clock_epoch_survives_peer_uptime_skew` test).

Therefore the monotonic second is used **only as a once-per-second refresh throttle**; the value seeded into the epoch is a cached `SystemTime::now()` wall-clock sample. Threading the monotonic `now_secs` directly into the epoch (as the issue literally suggested) would have broken cross-node validation — this PR keeps the wall-clock domain. Both mint and standby-ACK validation share the one cached wall-second; the existing ±1-epoch (±64s) validation window absorbs the ≤1s cache staleness. The throttle lives inside the cookie path (not the poll loop), so an idle worker that spins without minting cookies pays zero clock reads.

## Tests (what each one actually guards)
- `syn_cookie_current_full_epoch_is_pure_wall_clock_passthrough` — **leaf-level**: pins `current_full_epoch(s) == full_epoch_from_unix_secs(s)` for sample seconds (off-by-one-epoch guard at the pure leaf).
- `syn_cookie_round_trip_with_cached_wall_secs` — **codec-level**: mint with a cached-wall epoch; validate same-second / later-same-epoch / one-epoch-ahead all succeed; two epochs ahead fails as before (window-tolerance guard with explicit epochs).
- `syn_cookie_screen_state_epoch_uses_wall_clock_not_monotonic` — **call-site clock-domain guard** (review fold). The two tests above operate on the codec leaf with explicit epochs and do NOT exercise `ScreenState::current_syn_cookie_full_epoch`'s wall-vs-monotonic *selection*; a later edit feeding `mono_now_secs` into the epoch would compile and pass them. This test drives `ScreenState::current_syn_cookie_full_epoch(mono = 5)` with **no** test override and asserts the returned epoch equals the **live Unix wall-clock epoch** (anchored via `read_unix_wall_secs()`, bracketed before/after for 64s-boundary tolerance) and is **not** `full_epoch_from_unix_secs(5)` and not 0. Empirically verified **RED→GREEN**: reverting the call site to `current_full_epoch(mono_now_secs)` turns it RED (`epoch must come from the live Unix wall clock (27850618..=27850618), got 0`); restoring it turns it GREEN.

## Validation
- `cargo build --release -p xpf-userspace-dp` — 0 errors
- screen suite — **137/137 green**
- `cargo test --release -p xpf-userspace-dp` — first run 3022 passed / 2 ignored; a later run hit 2 **unrelated** afxdp concurrency flakes (`wg::engine::reconcile_peers_snapshot`, `worker_queue::concurrent_recovery`) that both pass in isolation and do not touch the screen module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)