### PR TITLE
ddns: reap superseded Surface A HTTP transports on binding change (#2956)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,18 @@
+## 2026-06-25 — #2956: reap superseded Surface A HTTP transports on binding change
+
+- **Timestamp**: 2026-06-25
+- **Action**: Added `httpClientCache.reap(live)` + `closeIdleConns` seam +
+  `size()` (pkg/ddns/backend_http.go); `SurfaceAManager.Reconcile` now computes
+  the set of binding keys still referenced by the committed config (configured
+  scopes' providers + catalog providers + unbound default) and reaps any cached
+  client whose key is gone — closing its idle-connection pool and dropping the
+  map entry — so the per-binding cache stays bounded under binding churn (#2904
+  left the superseded entry to linger for the daemon lifetime). Added
+  FAIL-ON-REVERT tests (close+evict via seam, all-live-kept, churn integration).
+  Updated pkg/ddns/README.md.
+- **File(s)**: pkg/ddns/backend_http.go, pkg/ddns/surface_a.go,
+  pkg/ddns/surface_a_httpcache_reap_2956_test.go, pkg/ddns/README.md, _Log.md
+
 ## 2026-06-25 — #3079: reject NAT rule-set interface/routing-instance scope at commit
 
 - **Timestamp**: 2026-06-25

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -321,11 +321,28 @@ P1b (closes **#2663, #2664, #2665**) builds on the P1a spine:
   connects to the host a request targets; the client carries no credential/URL —
   those live on the backend object and apply per-request). The cache invalidates
   implicitly: a commit that changes a binding leaf resolves a NEW key and builds a
-  fresh bound transport, and the stale entry is simply no longer looked up.
-  Cardinality is bounded by the number of distinct configured bindings. Backed by
-  the FAIL-ON-REVERT suite `surface_a_httpcache_2904_test.go` (same-binding reuse,
-  cross-provider same-binding reuse, per-leaf invalidation, checkip↔update shared
-  pool).
+  fresh bound transport. Cardinality is bounded by the number of distinct
+  configured bindings. Backed by the FAIL-ON-REVERT suite
+  `surface_a_httpcache_2904_test.go` (same-binding reuse, cross-provider
+  same-binding reuse, per-leaf invalidation, checkip↔update shared pool).
+- **Superseded-transport reap (#2956)** — the stale entry left behind by a
+  binding-leaf change (above) was never looked up again but also never released,
+  and the `SurfaceAManager` lives for the whole daemon lifetime, so distinct
+  historical binding tuples accumulated forever (the `*http.Transport` + its
+  idle-connection pool retained until process exit, even though `IdleConnTimeout`
+  reaps the sockets). Each `Reconcile` pass now calls `httpClientCache.reap` with
+  the set of binding keys still referenced by the committed config — every
+  configured scope's provider (the per-binding `source-address` override is
+  applied on the scope's provider copy) AND every catalog provider (used by the
+  removed-binding withdraw backend rebuild) plus the unbound default. Any cached
+  client whose key is gone has its idle pool closed (`CloseIdleConnections`, via
+  the `closeIdleConns` seam) and is dropped from the map; an active binding's key
+  is always in the live set so it is never closed (only an ACTUAL key change is
+  superseded). The reap takes the cache's own mutex (the manager's `m.mu` is the
+  outer lock, so no lock-order inversion). Backed by the FAIL-ON-REVERT suite
+  `surface_a_httpcache_reap_2956_test.go` (superseded-entry close+evict via the
+  seam, all-live-bindings-kept, and a binding-churn integration test asserting the
+  map stays bounded across N commits).
 
 **HA correctness:** the per-RG gate change MUST pass `make test-failover` (the
 project rule for any gate / HA-path change). P1b adds the gate + the

--- a/pkg/ddns/backend_http.go
+++ b/pkg/ddns/backend_http.go
@@ -122,13 +122,27 @@ func newHTTPClientBound(b bindConfig) *http.Client {
 // URL — those live on the backend object and are applied per-request — so it is
 // safe to share. The cache invalidates implicitly: when an operator changes a
 // binding leaf on commit the next reconcile resolves a NEW key and builds (and
-// caches) a fresh bound transport; the stale entry is simply no longer looked
-// up. Cardinality is bounded by the number of distinct configured bindings, so
-// the map does not grow without bound.
+// caches) a fresh bound transport.
+//
+// Reap on supersede (#2956): a binding-leaf change keys a FRESH entry, so the
+// OLD entry is never looked up again — but it is not self-evicting. The
+// SurfaceAManager lives for the whole daemon lifetime, so distinct historical
+// binding tuples would otherwise accumulate forever (their *http.Transport +
+// the idle-connection pool retained until process exit even though
+// IdleConnTimeout reaps the sockets). Each reconcile pass therefore calls reap
+// with the set of binding keys still referenced by the committed config; an
+// entry whose key is gone has its idle connection pool closed and is dropped,
+// bounding the map to current config under binding churn.
 type httpClientCache struct {
 	mu      sync.Mutex
 	clients map[string]*http.Client
 }
+
+// closeIdleConns is the seam reap uses to drop a superseded client's keep-alive
+// connection pool. It is a package var so a test can record that the reap
+// actually fired (fail-on-revert for #2956). Production closes the transport's
+// idle connections via the standard *http.Client.CloseIdleConnections.
+var closeIdleConns = func(cl *http.Client) { cl.CloseIdleConnections() }
 
 // newHTTPClientCache builds an empty per-binding client cache.
 func newHTTPClientCache() *httpClientCache {
@@ -167,6 +181,42 @@ func (c *httpClientCache) clientFor(p *config.DDNSProvider) (*http.Client, error
 	cl := newHTTPClientBound(b)
 	c.clients[key] = cl
 	return cl, nil
+}
+
+// reap closes the idle-connection pool of, and evicts, every cached client whose
+// binding key is NOT in the live set (#2956). The caller (the Surface A
+// reconcile) passes the binding keys still referenced by the committed provider
+// catalog + configured scopes, so a binding-leaf change that supersedes a cache
+// entry on the next pass has its stale *http.Transport / idle pool released
+// instead of lingering for the daemon lifetime. A key still in live (the active
+// binding for a current scope) is preserved — only an actual key change is
+// superseded. Safe on a nil cache (the test/no-cache manager). Takes c.mu (the
+// same lock clientFor uses); the manager's m.mu is always the OUTER lock so
+// there is no lock-order inversion.
+func (c *httpClientCache) reap(live map[string]struct{}) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key, cl := range c.clients {
+		if _, ok := live[key]; ok {
+			continue
+		}
+		closeIdleConns(cl)
+		delete(c.clients, key)
+	}
+}
+
+// size returns the number of cached clients (test observability for the #2956
+// bounded-map invariant).
+func (c *httpClientCache) size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.clients)
 }
 
 // resolveProviderBindConfig derives the transport bindConfig (#2846) from a DDNS

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -251,7 +251,10 @@ type SurfaceAManager struct {
 	// instead of paying a full TCP+TLS handshake every ~30s pass (#2904). The
 	// backend OBJECT is still rebuilt per pass (resolve-per-Reconcile, #2691); only
 	// the expensive transport is reused. Keyed on the binding leaves, so a commit
-	// that changes a binding resolves a fresh key and rebuilds the transport.
+	// that changes a binding resolves a fresh key and rebuilds the transport. Each
+	// Reconcile pass reaps cache entries whose binding key is no longer referenced
+	// by the committed config (#2956) — closing the superseded transport's idle
+	// pool and dropping the entry — so the map stays bounded under binding churn.
 	httpClients *httpClientCache
 
 	now func() time.Time
@@ -518,6 +521,29 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 	desired := map[string]SurfaceAScope{}
 	for _, sc := range scopes {
 		desired[sc.scopeID()] = sc
+	}
+
+	// Reap superseded HTTP transports (#2956): the per-binding client cache is
+	// populated lazily by resolveBackend/CheckIPClient and keyed on the
+	// source-binding tuple. A binding-leaf change keys a FRESH entry and the OLD
+	// entry is never looked up again, but the cache outlives any single config, so
+	// stale tuples (and their idle-connection pools) would accumulate for the
+	// daemon lifetime. Compute the set of binding keys still referenced by this
+	// pass — every configured scope's provider (the per-binding source-address
+	// override is applied on the scope's provider copy) AND every catalog provider
+	// (used by the removed-binding withdraw backend rebuild) plus the unbound
+	// default — and drop any cached client whose key is gone. An active binding is
+	// always in `live` so it is never closed.
+	if m.httpClients != nil {
+		live := make(map[string]struct{}, len(scopes)+len(catalog)+1)
+		live[""] = struct{}{} // unbound default (nil provider / fail-open client)
+		for _, sc := range scopes {
+			live[bindCacheKey(sc.Provider)] = struct{}{}
+		}
+		for _, p := range catalog {
+			live[bindCacheKey(p)] = struct{}{}
+		}
+		m.httpClients.reap(live)
 	}
 
 	// Pass 1 — publish / refresh / withdraw-on-address-loss each configured

--- a/pkg/ddns/surface_a_httpcache_reap_2956_test.go
+++ b/pkg/ddns/surface_a_httpcache_reap_2956_test.go
@@ -1,0 +1,158 @@
+package ddns
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// surface_a_httpcache_reap_2956_test.go: FAIL-ON-REVERT coverage for #2956 — the
+// Surface A per-binding HTTP client cache must REAP a superseded entry when a
+// binding leaf changes, closing the old transport's idle-connection pool and
+// dropping the map entry. Before #2956 a binding-leaf change keyed a fresh entry
+// and the old one was simply never looked up again, accumulating for the daemon
+// lifetime (the *http.Transport + idle pool retained). These tests go RED if the
+// reap (close + evict) is removed or stops bounding the map under binding churn.
+
+// TestHTTPClientCacheReapClosesSupersededTransport is the core unit-level
+// fail-on-revert: after a binding change supersedes a cache entry, reap must call
+// CloseIdleConnections on EXACTLY the superseded client and evict it, while
+// leaving the still-live binding's client cached and open. The closeIdleConns
+// seam records the call so the assertion fails if the close is dropped; the
+// size() assertion fails if the eviction is dropped.
+func TestHTTPClientCacheReapClosesSupersededTransport(t *testing.T) {
+	c := newHTTPClientCache()
+
+	var closed []*http.Client
+	orig := closeIdleConns
+	closeIdleConns = func(cl *http.Client) {
+		closed = append(closed, cl)
+		orig(cl) // still close for real
+	}
+	defer func() { closeIdleConns = orig }()
+
+	pOld := &config.DDNSProvider{Name: "p", Backend: "generic", SourceAddress: "192.0.2.1"}
+	pNew := &config.DDNSProvider{Name: "p", Backend: "generic", SourceAddress: "192.0.2.2"}
+
+	clOld, err := c.clientFor(pOld)
+	if err != nil {
+		t.Fatalf("clientFor old: %v", err)
+	}
+	clNew, err := c.clientFor(pNew)
+	if err != nil {
+		t.Fatalf("clientFor new: %v", err)
+	}
+	if clOld == clNew {
+		t.Fatal("distinct bindings must key distinct clients (precondition)")
+	}
+	if c.size() != 2 {
+		t.Fatalf("want 2 cached clients before reap, got %d", c.size())
+	}
+
+	// The binding changed from .1 to .2: only the new key is still referenced.
+	c.reap(map[string]struct{}{bindCacheKey(pNew): {}})
+
+	if c.size() != 1 {
+		t.Fatalf("reap must evict the superseded entry; want size 1, got %d", c.size())
+	}
+	// The still-live binding's client must survive AND remain cached (a re-lookup
+	// returns the same pointer, not a freshly built one).
+	clNew2, err := c.clientFor(pNew)
+	if err != nil {
+		t.Fatalf("clientFor new (2): %v", err)
+	}
+	if clNew2 != clNew {
+		t.Fatal("reap must NOT evict the still-live binding's client")
+	}
+	// The superseded client's idle pool was closed exactly once.
+	if len(closed) != 1 || closed[0] != clOld {
+		t.Fatalf("reap must CloseIdleConnections on exactly the superseded client; closed=%v", closed)
+	}
+}
+
+// TestHTTPClientCacheReapKeepsAllLiveBindings proves reap does not close a
+// transport that is still the active one for a current binding: with every key
+// in the live set, nothing is closed or evicted (only an actual key change is
+// superseded).
+func TestHTTPClientCacheReapKeepsAllLiveBindings(t *testing.T) {
+	c := newHTTPClientCache()
+
+	var closed int
+	orig := closeIdleConns
+	closeIdleConns = func(cl *http.Client) { closed++; orig(cl) }
+	defer func() { closeIdleConns = orig }()
+
+	pA := &config.DDNSProvider{Name: "a", Backend: "generic", SourceAddress: "192.0.2.10"}
+	pB := &config.DDNSProvider{Name: "b", Backend: "generic", SourceAddress: "192.0.2.11"}
+	if _, err := c.clientFor(pA); err != nil {
+		t.Fatalf("clientFor a: %v", err)
+	}
+	if _, err := c.clientFor(pB); err != nil {
+		t.Fatalf("clientFor b: %v", err)
+	}
+
+	c.reap(map[string]struct{}{
+		bindCacheKey(pA): {},
+		bindCacheKey(pB): {},
+	})
+
+	if c.size() != 2 {
+		t.Fatalf("reap must keep every live binding; want 2, got %d", c.size())
+	}
+	if closed != 0 {
+		t.Fatalf("reap must not close any still-live transport; closed=%d", closed)
+	}
+}
+
+// TestSurfaceAReconcileReapsSupersededHTTPClients is the integration
+// fail-on-revert: many successive commits that change a provider's source-address
+// binding leaf must NOT grow the cache without bound. Each pass builds the
+// backend (populating the cache for that binding) then runs a reconcile whose
+// catalog references ONLY the current provider, so the prior binding's entry is
+// superseded and reaped. Without the reap the map grows by one per pass.
+func TestSurfaceAReconcileReapsSupersededHTTPClients(t *testing.T) {
+	st, err := loadDDNSState(filepath.Join(t.TempDir(), "interface-ddns-state.json"))
+	if err != nil {
+		t.Fatalf("loadDDNSState: %v", err)
+	}
+	m := &SurfaceAManager{
+		state:       st,
+		runtime:     map[string]*surfaceAState{},
+		httpClients: newHTTPClientCache(),
+		now:         time.Now,
+	}
+	m.newBackend = m.resolveBackend
+
+	ctx := context.Background()
+	const N = 25
+	for i := 0; i < N; i++ {
+		src := fmt.Sprintf("192.0.2.%d", i+1)
+		p := &config.DDNSProvider{
+			Name:          "p",
+			Backend:       "generic",
+			URLTemplate:   "https://example.test/u?ip=%i",
+			SourceAddress: src,
+		}
+		// Build the backend for this binding — populates the per-binding cache,
+		// exactly as a reconcile pass's resolveBackend would.
+		if _, err := m.resolveBackend(p, "h.example.test", 60); err != nil {
+			t.Fatalf("resolveBackend pass %d: %v", i, err)
+		}
+		catalog := map[string]*config.DDNSProvider{"p": p}
+		err := m.Reconcile(ctx, nil, func(SurfaceAScope) (AddressObservation, bool) {
+			return AddressObservation{}, false
+		}, nil, catalog)
+		if err != nil {
+			t.Fatalf("Reconcile pass %d: %v", i, err)
+		}
+		if got := m.httpClients.size(); got > 2 {
+			t.Fatalf("after pass %d the per-binding cache grew to %d — superseded "+
+				"transports are not reaped (unbounded under binding churn, #2956)", i, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #2956

## Leak
#2904 added a per-binding `httpClientCache` on `SurfaceAManager`, keyed on the source-binding tuple (`source-address` / `destination-interface` / `routing-instance`). When a binding leaf changes, the next reconcile resolves a FRESH key and caches a new `*http.Transport`, but the OLD entry is never looked up again **and never released** — it is neither `CloseIdleConnections()`'d nor evicted. `SurfaceAManager` lives for the whole daemon lifetime, so distinct historical binding tuples accumulate forever (the transport struct + map entry retained until process exit; `IdleConnTimeout=30s` reaps the sockets but not the struct/entry).

## Fix — reap on supersede
Each `Reconcile` pass now computes the set of binding keys still referenced by the committed config and calls the new `httpClientCache.reap(live)`:

- every configured scope's provider (`bindCacheKey(sc.Provider)` — the per-binding `source-address` override is applied on the scope's provider copy),
- every catalog provider (used by the removed-binding withdraw backend rebuild),
- plus the unbound default (`""`).

An entry whose key is no longer live has its idle connection pool closed and is dropped from the map. An active binding's key is always in the live set, so a still-current transport is never closed — **only an actual key change is superseded**. The close goes through a `closeIdleConns` package seam so the reap is testable.

## Locking
`reap` takes the cache's own mutex (`c.mu`), the same lock `clientFor` uses. The manager's `m.mu` is always the OUTER lock, so there is no lock-order inversion. `reap`/`size` are nil-safe (the no-cache test manager).

## Validation
- New fail-on-revert suite `surface_a_httpcache_reap_2956_test.go`:
  - superseded entry's `CloseIdleConnections` fires (seam recorder) **and** the entry is evicted;
  - an all-live reap closes/evicts nothing (no over-close of active bindings);
  - binding-churn integration test drives N=25 commits through `Reconcile` and asserts the cache stays bounded.
- **RED→GREEN proven**: with the reap body gutted, the eviction test fails (`size 2`) and the churn test fails (`grew to 3 ... pass 2`); restored → GREEN.
- `go build ./...`, `go vet ./pkg/ddns/`, `gofmt -l` all clean.
- Full `pkg/ddns` + `pkg/daemon` suites pass (794 tests).
- `pkg/ddns/README.md` #2904 section extended with the #2956 reap; `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi