### PR TITLE
logging: cap session aggregator cardinality (control-plane DoS amplifier) (#2936)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-25 — #2936: cap session aggregator cardinality (control-plane DoS amplifier)
+
+- **Timestamp**: 2026-06-25 19:48
+- **Action**: Bounded `SessionAggregator` source/dest maps by config, not
+  traffic. Added `maxKeys` (default `defaultMaxAggKeys`=10000) admission cap
+  in `Add()`: existing keys keep aggregating, new keys past the cap are
+  dropped and counted in `droppedSrc`/`droppedDst`. `Flush`/`flushWithDropped`
+  swap the dropped counters atomically with the maps; `flushAndLog` emits a
+  warning-severity `RT_FLOW_SESSION_AGGREGATE dropped-keys ...` line when the
+  cap is hit (incident indicator). Below-cap traffic is behavior-preserving.
+  Fail-on-revert test `TestSessionAggregator_CardinalityCap` + below-cap
+  `TestSessionAggregator_BelowCapUnchanged`. Filed Space-Saving top-K
+  accuracy follow-up #3099 (deferred, not required for the DoS fix).
+- **File(s)**: pkg/logging/aggregator.go, pkg/logging/aggregator_test.go,
+  pkg/logging/README.md, _Log.md
+
 ## 2026-06-25 — #2911: reject backup-router explicit destination family-mismatch at commit
 
 - **Timestamp**: 2026-06-25

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -16,7 +16,8 @@ reports.
 - `Subscription` — `eventbuf.go`. A consumer of the event ring.
 - `LocalLogWriter` — `locallog.go`. File-based writer with
   facility/severity filters.
-- `SessionAggregator` — `aggregator.go`. Top-N per-IP rollups.
+- `SessionAggregator` — `aggregator.go`. Top-N per-IP rollups,
+  cardinality-capped (see "Aggregator cardinality cap" below).
 
 ## Callers
 
@@ -197,3 +198,38 @@ if `Handle` runs the re-entrancy guard before the client check.
   drop silently — by design. Don't wire a slow consumer to it.
 - The session aggregator flushes on a 5-minute timer. The flushed
   snapshot is the basis for `show security session aggregate`.
+
+### Aggregator cardinality cap (#2936)
+
+`SessionAggregator` keyed its source/destination maps by every distinct
+IP seen in `SESSION_CLOSE` events with no bound. Under high-cardinality
+traffic (spoofed-source or scan traffic — exactly what a security
+appliance sees during an incident) the two maps grew for the full flush
+window, and `topEntries` then allocated and `sort.Slice`-sorted O(N) over
+the entire cardinality twice per flush. The observability feature became
+a control-plane resource-exhaustion amplifier — it degraded under the
+very traffic it is meant to report on.
+
+The interim fix bounds memory **by configuration, not by traffic
+cardinality**: each map admits at most `defaultMaxAggKeys` (10000)
+distinct keys per flush window. Once a map is at the cap, a NEW key is
+dropped and counted in `droppedSrc`/`droppedDst`; keys already admitted
+keep aggregating, so the top-N over the admitted set stays accurate. The
+per-flush allocate+sort cost is therefore bounded by the cap.
+
+When the cap is hit, `flushAndLog` emits a warning-severity
+`RT_FLOW_SESSION_AGGREGATE dropped-keys source=N destination=M cap=K`
+line in addition to the top-N report. A non-zero `dropped-keys` count is
+itself an incident indicator (cardinality exceeded the cap this window).
+Below-cap traffic produces identical top-N output with no dropped line —
+the common case is behavior-preserving. Coverage:
+`TestSessionAggregator_CardinalityCap` (fail-on-revert) and
+`TestSessionAggregator_BelowCapUnchanged`.
+
+This is a deliberate interim. Capped maps keep the top-N exact only for
+the keys admitted *before* the cap was reached; a heavy hitter whose
+first packet of the window arrives after the cap fills is missed.
+Bounded heavy-hitter accounting (Space-Saving / Misra-Gries top-K with an
+overflow bucket) would make the top-K accurate independent of arrival
+order under adversarial cardinality. That accuracy refinement is tracked
+as a follow-up and is not required to close the DoS.

--- a/pkg/logging/aggregator.go
+++ b/pkg/logging/aggregator.go
@@ -9,12 +9,40 @@ import (
 	"time"
 )
 
+// defaultMaxAggKeys bounds the number of distinct source/destination IPs
+// retained per flush window in each map. It exists to defend against a
+// control-plane resource-exhaustion amplifier (#2936): an attacker driving
+// high source/destination cardinality (spoofed-source or scan traffic — the
+// exact pattern a security appliance observes during an incident) would
+// otherwise force the daemon to retain two unbounded maps for the full flush
+// window, then allocate and sort O(N) entries twice per flush. Capping the
+// admitted key set bounds both the resident memory and the per-flush
+// allocate+sort cost by configuration rather than by traffic cardinality.
+//
+// 10000 distinct keys per map per window keeps the aggregator well within a
+// few MB of transient memory while remaining far above any plausible
+// legitimate top-N working set (the report only emits top-10).
+const defaultMaxAggKeys = 10000
+
 // SessionAggregator tracks session statistics and periodically flushes
 // top-N source and destination reports.
 type SessionAggregator struct {
 	mu   sync.Mutex
 	srcs map[string]*aggEntry // srcIP -> stats
 	dsts map[string]*aggEntry // dstIP -> stats
+
+	// maxKeys caps the distinct keys admitted into each map per window.
+	// Once a map reaches maxKeys, NEW keys are dropped (and counted in
+	// droppedSrc/droppedDst); keys already admitted continue to aggregate
+	// normally, so the top-N over the admitted set stays accurate.
+	maxKeys int
+
+	// droppedSrc/droppedDst count NEW keys refused this window because the
+	// corresponding map was already at maxKeys. They reset on each flush and
+	// are surfaced in the flush report so an operator sees that the cap was
+	// hit — a high cardinality signal that is itself an incident indicator.
+	droppedSrc uint64
+	droppedDst uint64
 
 	flushInterval time.Duration
 	topN          int
@@ -46,6 +74,7 @@ func NewSessionAggregator(flushInterval time.Duration, topN int) *SessionAggrega
 	return &SessionAggregator{
 		srcs:          make(map[string]*aggEntry),
 		dsts:          make(map[string]*aggEntry),
+		maxKeys:       defaultMaxAggKeys,
 		flushInterval: flushInterval,
 		topN:          topN,
 	}
@@ -70,28 +99,47 @@ func (sa *SessionAggregator) Add(rec EventRecord) {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
 
+	// Existing keys always aggregate. A NEW key is admitted only while the
+	// map is below the cardinality cap; otherwise it is dropped and counted,
+	// bounding memory and per-flush sort cost by config (#2936).
 	if e, ok := sa.srcs[srcIP]; ok {
 		e.Sessions++
 		e.Bytes += rec.SessionBytes
-	} else {
+	} else if sa.maxKeys <= 0 || len(sa.srcs) < sa.maxKeys {
 		sa.srcs[srcIP] = &aggEntry{Sessions: 1, Bytes: rec.SessionBytes}
+	} else {
+		sa.droppedSrc++
 	}
 
 	if e, ok := sa.dsts[dstIP]; ok {
 		e.Sessions++
 		e.Bytes += rec.SessionBytes
-	} else {
+	} else if sa.maxKeys <= 0 || len(sa.dsts) < sa.maxKeys {
 		sa.dsts[dstIP] = &aggEntry{Sessions: 1, Bytes: rec.SessionBytes}
+	} else {
+		sa.droppedDst++
 	}
 }
 
 // Flush returns top-N sources and destinations by bytes, then resets counters.
 func (sa *SessionAggregator) Flush() (topSrc, topDst []AggregateEntry) {
+	topSrc, topDst, _, _ = sa.flushWithDropped()
+	return
+}
+
+// flushWithDropped is Flush plus the per-window dropped-key counts. The maps
+// and the dropped counters are swapped out atomically under the lock so the
+// snapshot is internally consistent and the next window starts clean.
+func (sa *SessionAggregator) flushWithDropped() (topSrc, topDst []AggregateEntry, droppedSrc, droppedDst uint64) {
 	sa.mu.Lock()
 	srcs := sa.srcs
 	dsts := sa.dsts
+	droppedSrc = sa.droppedSrc
+	droppedDst = sa.droppedDst
 	sa.srcs = make(map[string]*aggEntry)
 	sa.dsts = make(map[string]*aggEntry)
+	sa.droppedSrc = 0
+	sa.droppedDst = 0
 	sa.mu.Unlock()
 
 	topSrc = topEntries(srcs, sa.topN)
@@ -120,15 +168,29 @@ func (sa *SessionAggregator) HandleEvent(rec EventRecord, _ []byte) {
 }
 
 func (sa *SessionAggregator) flushAndLog() {
-	topSrc, topDst := sa.Flush()
+	topSrc, topDst, droppedSrc, droppedDst := sa.flushWithDropped()
 
-	if len(topSrc) == 0 && len(topDst) == 0 {
+	if len(topSrc) == 0 && len(topDst) == 0 && droppedSrc == 0 && droppedDst == 0 {
 		return
 	}
 
 	sa.mu.Lock()
 	logFn := sa.logFn
 	sa.mu.Unlock()
+
+	// Surface the cardinality cap being hit. A non-zero count means new
+	// source/destination keys were dropped this window because a map reached
+	// the cap (defaultMaxAggKeys) — an incident-grade high-cardinality signal,
+	// not just a sizing hint. Emit at warning severity so it is visible.
+	if droppedSrc > 0 || droppedDst > 0 {
+		msg := fmt.Sprintf("RT_FLOW_SESSION_AGGREGATE dropped-keys source=%d destination=%d cap=%d "+
+			"(high source/destination cardinality exceeded the aggregation cap; top-N covers admitted keys only)",
+			droppedSrc, droppedDst, sa.maxKeys)
+		if logFn != nil {
+			logFn(SyslogWarning, msg)
+		}
+		slog.Warn(msg)
+	}
 
 	for _, e := range topSrc {
 		msg := fmt.Sprintf("RT_FLOW_SESSION_AGGREGATE top-source=%q sessions=%d bytes=%d",

--- a/pkg/logging/aggregator_test.go
+++ b/pkg/logging/aggregator_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -191,5 +192,118 @@ func TestSessionAggregator_Defaults(t *testing.T) {
 	}
 	if agg.topN != 10 {
 		t.Errorf("expected default topN=10, got %d", agg.topN)
+	}
+	if agg.maxKeys != defaultMaxAggKeys {
+		t.Errorf("expected default maxKeys=%d, got %d", defaultMaxAggKeys, agg.maxKeys)
+	}
+}
+
+// TestSessionAggregator_CardinalityCap is the #2936 fail-on-revert guard.
+// It drives more unique sources AND destinations than the cap through Add()
+// and asserts: (1) neither map ever exceeds the cap, (2) the dropped counters
+// increment by exactly (offered - cap), and (3) Flush still returns a valid
+// top-N over the admitted set. Reverting the cap (unbounded insert) turns this
+// RED: the maps grow past the cap and the dropped counters stay 0.
+func TestSessionAggregator_CardinalityCap(t *testing.T) {
+	const cap = 100
+	agg := NewSessionAggregator(time.Hour, 10)
+	agg.maxKeys = cap // small cap for the test; production uses defaultMaxAggKeys
+
+	const offered = cap + 250
+	for i := 0; i < offered; i++ {
+		// Distinct source AND distinct destination per session so both maps
+		// are driven past the cap independently.
+		agg.Add(EventRecord{
+			Type:         "SESSION_CLOSE",
+			SrcAddr:      fmt.Sprintf("10.10.%d.%d:1234", i/256, i%256),
+			DstAddr:      fmt.Sprintf("10.20.%d.%d:80", i/256, i%256),
+			SessionBytes: uint64(i + 1),
+		})
+	}
+
+	agg.mu.Lock()
+	srcLen := len(agg.srcs)
+	dstLen := len(agg.dsts)
+	droppedSrc := agg.droppedSrc
+	droppedDst := agg.droppedDst
+	agg.mu.Unlock()
+
+	if srcLen > cap {
+		t.Errorf("src map exceeded cap: len=%d cap=%d (cap not enforced)", srcLen, cap)
+	}
+	if dstLen > cap {
+		t.Errorf("dst map exceeded cap: len=%d cap=%d (cap not enforced)", dstLen, cap)
+	}
+	if srcLen != cap {
+		t.Errorf("expected src map at cap=%d, got %d", cap, srcLen)
+	}
+	if dstLen != cap {
+		t.Errorf("expected dst map at cap=%d, got %d", cap, dstLen)
+	}
+	if want := uint64(offered - cap); droppedSrc != want {
+		t.Errorf("droppedSrc=%d, want exactly %d (offered-cap)", droppedSrc, want)
+	}
+	if want := uint64(offered - cap); droppedDst != want {
+		t.Errorf("droppedDst=%d, want exactly %d (offered-cap)", droppedDst, want)
+	}
+
+	// Flush must still return a valid, bounded top-N over the admitted set.
+	topSrc, topDst, fdSrc, fdDst := agg.flushWithDropped()
+	if len(topSrc) != 10 || len(topDst) != 10 {
+		t.Errorf("expected top-10 from admitted set, got src=%d dst=%d", len(topSrc), len(topDst))
+	}
+	if fdSrc != uint64(offered-cap) || fdDst != uint64(offered-cap) {
+		t.Errorf("flush dropped counts src=%d dst=%d, want %d", fdSrc, fdDst, offered-cap)
+	}
+	// top-N must be sorted by bytes descending.
+	for i := 1; i < len(topSrc); i++ {
+		if topSrc[i-1].Bytes < topSrc[i].Bytes {
+			t.Errorf("topSrc not sorted descending at %d", i)
+		}
+	}
+
+	// Flush resets the dropped counters for the next window.
+	agg.mu.Lock()
+	resetSrc, resetDst := agg.droppedSrc, agg.droppedDst
+	agg.mu.Unlock()
+	if resetSrc != 0 || resetDst != 0 {
+		t.Errorf("dropped counters not reset after flush: src=%d dst=%d", resetSrc, resetDst)
+	}
+}
+
+// TestSessionAggregator_BelowCapUnchanged asserts normal-cardinality traffic
+// (below the cap) produces identical top-N output with zero dropped keys — the
+// common case is behavior-preserving.
+func TestSessionAggregator_BelowCapUnchanged(t *testing.T) {
+	agg := NewSessionAggregator(time.Hour, 10)
+	agg.maxKeys = 100
+
+	// 5 sources, all under the cap, mirroring TestSessionAggregator_TopN-style
+	// input. Highest bytes last so ordering is exercised.
+	for i := 0; i < 5; i++ {
+		agg.Add(EventRecord{
+			Type:         "SESSION_CLOSE",
+			SrcAddr:      fmt.Sprintf("10.0.1.%d:1234", i+1),
+			DstAddr:      "10.0.2.1:80",
+			SessionBytes: uint64((i + 1) * 1000),
+		})
+	}
+
+	topSrc, topDst, droppedSrc, droppedDst := agg.flushWithDropped()
+	if droppedSrc != 0 || droppedDst != 0 {
+		t.Errorf("below-cap traffic must drop nothing: src=%d dst=%d", droppedSrc, droppedDst)
+	}
+	if len(topSrc) != 5 {
+		t.Fatalf("expected 5 source entries, got %d", len(topSrc))
+	}
+	if len(topDst) != 1 {
+		t.Fatalf("expected 1 destination entry, got %d", len(topDst))
+	}
+	// Highest-bytes source (10.0.1.5, 5000 bytes) ranks first.
+	if topSrc[0].IP != "10.0.1.5" || topSrc[0].Bytes != 5000 {
+		t.Errorf("expected top source 10.0.1.5/5000, got %s/%d", topSrc[0].IP, topSrc[0].Bytes)
+	}
+	if topDst[0].IP != "10.0.2.1" || topDst[0].Sessions != 5 {
+		t.Errorf("expected dest 10.0.2.1 with 5 sessions, got %s/%d", topDst[0].IP, topDst[0].Sessions)
 	}
 }


### PR DESCRIPTION
Closes #2936

## The DoS

`SessionAggregator` (`pkg/logging/aggregator.go`, enabled by `security log
report`) keyed two maps — `srcs`/`dsts` — by every distinct
source/destination IP seen in `SESSION_CLOSE` events, with no capacity or
admission bound. Under high source/destination cardinality (spoofed-source
or scan traffic — exactly what a security appliance observes during an
incident) the maps grew for the full 5-minute flush window, and
`topEntries` then allocated and `sort.Slice`-sorted O(N) over the *entire*
cardinality twice per flush. The observability feature became a
control-plane resource-exhaustion amplifier that degrades under the very
traffic it is meant to report on. Provenance: codex-review-055 finding
055-03.

## The fix — bound by config, not by traffic (interim)

Each map now admits at most `maxKeys` (default `defaultMaxAggKeys` =
10000) distinct keys per flush window:

- `Add()` admits a NEW key only while the map is below the cap. Keys
  already in the map keep aggregating, so the top-N over the admitted set
  stays accurate. A new key past the cap is dropped and counted in
  `droppedSrc`/`droppedDst`.
- `Flush`/`flushWithDropped` swap the dropped counters atomically with the
  maps so each window starts clean. `flushAndLog` emits a warning-severity
  `RT_FLOW_SESSION_AGGREGATE dropped-keys source=N destination=M cap=K`
  line when the cap was hit — a non-zero count is itself an incident
  indicator (the aggregator has no Prometheus wiring; the reported counter
  is the surfacing path).
- The per-flush allocate+sort cost is now bounded by the cap.
- Below-cap traffic is behavior-preserving: identical top-N, no dropped
  line.

### Bound-by-config rationale

10000 keys/map/window keeps the aggregator within a few MB of transient
memory while sitting far above any plausible legitimate working set (the
report only emits top-10). Memory and cost are bounded by configuration
rather than by attacker-controlled cardinality.

## Deferred: Space-Saving accuracy (#3099)

Capped maps keep top-N exact only for keys admitted *before* the cap
fills; a heavy hitter whose first session of the window arrives after the
cap is reached is missed (arrival-order dependent under adversarial
cardinality). Arrival-order-independent top-K accuracy (Space-Saving /
Misra-Gries with an overflow bucket) is tracked as non-closing follow-up
#3099. It is an accuracy refinement and is **not** required to close the
DoS.

## Validation

- `go build ./...`, `go test ./pkg/logging/` (116 pass), `go vet`, `gofmt`
  clean.
- **Fail-on-revert RED→GREEN:** `TestSessionAggregator_CardinalityCap`
  drives `offered = cap + 250` unique sources and destinations and asserts
  neither map exceeds the cap, the dropped counters equal exactly
  `offered - cap`, `Flush` returns a valid bounded top-N, and the counters
  reset after flush. Reverting to the unbounded insert turns it RED (maps
  grow to 350, `dropped` stays 0); restoring the cap is GREEN.
- `TestSessionAggregator_BelowCapUnchanged` asserts normal traffic yields
  identical top-N with zero dropped keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi