### PR TITLE
config: commit-time reject ambiguous secure-tunnel bind-interface aliases (#2933)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-25 — #2933: commit-time reject ambiguous secure-tunnel bind-interface aliases
+
+- **Timestamp**: 2026-06-25
+- **Action**: Add `validateSecureTunnelBindInterfaceAST` reject-at-commit gate.
+  Two VPNs binding two DISTINCT bind-interface strings that derive the SAME
+  XFRM if_id (e.g. `st0` and `st0.0`, both if_id 1 via `XFRMIfNameAndID`)
+  committed cleanly but collide at apply time (#2929 routing guard refuses
+  EITHER device → both tunnels down). New AST pre-walk in `compileExpanded`
+  hard-rejects on the strict commit/commit-check path naming each offending
+  bind-interface string, its VPN(s), and the shared if_id; downgrades to a
+  cfg.Warnings entry on the lenient load/peer-sync path
+  (`lenientSecureTunnelBindIface`) so an already-persisted config still boots
+  (#1960). Surgical: same-string-shared-by-many-VPNs and unparseable bindings
+  are NOT rejected; st0.0+st0.1 / st0+st1 commit cleanly.
+- **File(s)**: pkg/config/compiler_ipsec_bindiface.go (new),
+  pkg/config/compiler_ipsec_bindiface_2933_test.go (new),
+  pkg/config/compiler.go (compileOpts flag + call site + warn append),
+  pkg/config/README.md.
+- **Validation**: go build ./..., go vet ./pkg/config/..., go test
+  ./pkg/config/... (1578 passed). Fail-on-revert confirmed (stub returning
+  nil turns reject + lenient tests RED). gofmt clean.
+
 ## 2026-06-25 — #2936: cap session aggregator cardinality (control-plane DoS amplifier)
 
 - **Timestamp**: 2026-06-25 19:48

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -333,6 +333,30 @@ config, VRF definitions). The tolerant load/peer-sync path downgrades to a warni
 binary silently accepted still boots — it stays applied globally (the pre-existing
 behaviour), now flagged (#1960 no-brick doctrine, same as #3018/#3055/#3060).
 
+**Ambiguous secure-tunnel `bind-interface` aliases are rejected at commit
+(#2933):** `security ipsec vpn <name> bind-interface` is a free-form 1-arg
+string stored verbatim on the typed VPN (`compiler_ipsec.go`); the runtime
+resolves it to a Linux xfrmi device name and a stable XFRM if_id via
+`XFRMIfNameAndID` (`xfrmi.go`): `if_id = stIndex<<16 | (unit+1)`, unit
+defaulting to 0. A bare `st0` is therefore the SAME device as `st0.0` (both
+if_id 1). Two VPNs binding those two distinct strings committed cleanly but
+collide at apply time — only one xfrm device can carry the if_id, so the #2929
+pkg/routing guard refuses to create EITHER device and both tunnels go down with
+a journal ERROR (before #2929 it silently leaked one VPN's SA onto the other's
+tunnel). `validateSecureTunnelBindInterfaceAST` (`compiler_ipsec_bindiface.go`)
+turns that apply-time both-down into a commit-check error: it derives the if_id
+for every VPN's bind-interface and hard-rejects when two DISTINCT strings derive
+the SAME non-zero if_id, naming each offending string, its VPN(s), and the
+shared if_id. The gate is SURGICAL — it does NOT fire when the same string is
+shared by several VPNs (one device, one if_id) nor when a bind-interface cannot
+parse as `st<N>[.unit]` (if_id 0); an unambiguous map (st0.0 + st0.1, or st0 +
+st1) commits cleanly. It is an AST pre-walk in `compileExpanded` so an
+apply-groups-inherited bind-interface is covered and an `inactive:` VPN is
+ignored. The tolerant load/peer-sync path downgrades to a warning
+(`lenientSecureTunnelBindIface`) so an already-persisted or peer-synced config
+an older binary accepted still boots (#1960 no-brick doctrine) — the #2929
+routing guard stays the runtime backstop.
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -734,6 +734,21 @@ type compileOpts struct {
 	// BOOTS (#1960 fail-closed-on-load class). Same doctrine as
 	// lenientNATRuleSetScope.
 	lenientBackupRouterDst bool
+	// lenientSecureTunnelBindIface (#2933) downgrades the secure-tunnel
+	// bind-interface alias-collision gate (validateSecureTunnelBindInterfaceAST)
+	// from a hard compile error to a cfg.Warnings entry. Two VPNs that bind two
+	// DISTINCT bind-interface strings deriving the SAME XFRM if_id (e.g.
+	// `bind-interface st0` and `bind-interface st0.0`, both if_id 1 via
+	// XFRMIfNameAndID) committed cleanly but collide at apply time: only one
+	// xfrm device can carry the if_id, so the routing manager (#2929 guard)
+	// refuses to create EITHER and both tunnels go down. The strict commit /
+	// commit-check path hard-rejects so the operator-error is visible (naming
+	// the offending bind-interface strings, their VPNs, and the shared if_id);
+	// the tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config an older binary silently accepted
+	// still BOOTS (#1960 fail-closed-on-load class) — the #2929 routing guard
+	// remains the runtime backstop. Same doctrine as lenientBackupRouterDst.
+	lenientSecureTunnelBindIface bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -800,6 +815,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyWildcardZone:          true,
 		lenientNATRuleSetScope:             true,
 		lenientBackupRouterDst:             true,
+		lenientSecureTunnelBindIface:       true,
 	})
 }
 
@@ -917,6 +933,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyWildcardZone:          true,
 		lenientNATRuleSetScope:             true,
 		lenientBackupRouterDst:             true,
+		lenientSecureTunnelBindIface:       true,
 	})
 }
 
@@ -1032,6 +1049,24 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #2933 secure-tunnel bind-interface alias-collision gate. Two VPNs that
+	// bind two DISTINCT bind-interface strings deriving the SAME XFRM if_id
+	// (e.g. `bind-interface st0` and `bind-interface st0.0`, both if_id 1 via
+	// XFRMIfNameAndID) committed cleanly but collide at apply time — only one
+	// xfrm device can carry the if_id, so the #2929 routing guard refuses to
+	// create EITHER and both tunnels go down with a journal ERROR. Runs on the
+	// group-expanded, inactive-pruned tree so an apply-groups-inherited
+	// bind-interface is caught. Strict (commit / commit-check): hard-reject
+	// naming the offending bind-interface strings, their VPNs, and the shared
+	// if_id. Lenient (load / peer-sync): warn so an already-persisted or
+	// peer-synced config still boots (#1960) — the #2929 routing guard stays
+	// the runtime backstop.
+	bindIfaceWarnings, err := validateSecureTunnelBindInterfaceAST(
+		tree.Children, opts.lenientSecureTunnelBindIface)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Security: SecurityConfig{
 			Zones:  make(map[string]*ZoneConfig),
@@ -1068,6 +1103,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, natScopeWarnings...)
+	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
 
 	for _, node := range tree.Children {
 		switch node.Name() {

--- a/pkg/config/compiler_ipsec_bindiface.go
+++ b/pkg/config/compiler_ipsec_bindiface.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// compiler_ipsec_bindiface.go carries the #2933 reject-at-commit gate for two
+// distinct secure-tunnel `bind-interface` aliases that derive the SAME Linux
+// XFRM if_id.
+//
+// The defect: `security ipsec vpn <name> bind-interface` is a free-form 1-arg
+// string (schema_security.go) stored verbatim on the typed VPN
+// (compiler_ipsec.go). The runtime resolves it to a Linux xfrmi device name
+// and a stable XFRM if_id via XFRMIfNameAndID (xfrmi.go):
+//
+//	if_id = stIndex<<16 | (unit+1)        (unit defaults to 0)
+//
+// so `bind-interface st0` and `bind-interface st0.0` BOTH derive if_id 1 — a
+// bare `st0` is the same xfrmi device as `st0.0`. Two VPNs that bind these two
+// distinct strings committed cleanly, but at apply time only one xfrm device
+// can carry that if_id. Before #2929 this silently leaked one VPN's SA onto the
+// other's tunnel; #2929 added a pkg/routing last-line-of-defense guard that
+// refuses to create EITHER device and logs an ERROR — correct, but the operator
+// experience is "both tunnels silently down with a journal ERROR" rather than a
+// config-commit error.
+//
+// This gate turns that apply-time both-down into a Junos-style commit-check
+// error (candidate rejected, live config untouched). The #2929 routing guard
+// stays as the runtime backstop.
+//
+// Scope — surgical: the gate fires ONLY when two DISTINCT bind-interface
+// strings derive the SAME non-zero if_id. It does NOT fire when:
+//   - the same bind-interface string is shared by multiple VPNs (that is one
+//     device, one if_id — not the ambiguous-alias case #2929 named), nor
+//   - a bind-interface XFRMIfNameAndID cannot parse as `st<N>[.unit]`
+//     (if_id 0) — out of scope here; some other path handles a bad string.
+//
+// An unambiguous map (st0.0 + st0.1, or st0 + st1) commits cleanly.
+//
+// This is an AST pre-walk (like validateNATRuleSetScopeAST / the other
+// reject-at-commit gates) rather than a typed-Config validator so it runs on
+// the group-expanded, inactive-pruned tree in compileExpanded: an
+// apply-groups-inherited bind-interface is covered and an `inactive:` VPN is
+// ignored for free.
+//
+// Strict path (commit / commit-check, lenient=false): the first colliding
+// if_id is a hard compile error naming every offending bind-interface string,
+// its VPN(s), and the shared if_id.
+//
+// Lenient path (load / peer-sync, lenient=true): every collision is returned as
+// a warning and compilation continues — an already-persisted or peer-synced
+// config that an older binary silently accepted still BOOTS (#1960
+// fail-closed-on-load class). Mirrors the other lenient gates' no-prune
+// handling; the runtime #2929 routing guard still refuses the colliding
+// devices.
+func validateSecureTunnelBindInterfaceAST(nodes []*Node, lenient bool) ([]string, error) {
+	var security *Node
+	for _, n := range nodes {
+		if n.Name() == "security" {
+			security = n
+			break
+		}
+	}
+	if security == nil {
+		return nil, nil
+	}
+	ipsec := security.FindChild("ipsec")
+	if ipsec == nil {
+		return nil, nil
+	}
+
+	// bindRef tracks the VPN(s) that configured one distinct bind-interface
+	// string (a single string may legitimately be shared by several VPNs).
+	type bindRef struct {
+		vpns []string
+	}
+	// if_id -> distinct bind-interface string -> the VPN(s) that bound it.
+	byID := map[uint32]map[string]*bindRef{}
+	order := []uint32{} // first-seen if_id order for deterministic errors
+
+	for _, inst := range namedInstances(ipsec.FindChildren("vpn")) {
+		biNode := inst.node.FindChild("bind-interface")
+		if biNode == nil {
+			continue
+		}
+		bindIface := nodeVal(biNode)
+		if bindIface == "" {
+			continue
+		}
+		_, ifID := XFRMIfNameAndID(bindIface)
+		if ifID == 0 {
+			// Not a recognizable st<N>[.unit] secure-tunnel binding; out of
+			// scope for the if_id-collision gate.
+			continue
+		}
+		group, ok := byID[ifID]
+		if !ok {
+			group = map[string]*bindRef{}
+			byID[ifID] = group
+			order = append(order, ifID)
+		}
+		ref, ok := group[bindIface]
+		if !ok {
+			ref = &bindRef{}
+			group[bindIface] = ref
+		}
+		ref.vpns = append(ref.vpns, inst.name)
+	}
+
+	var warnings []string
+	emit := func(format string, args ...any) error {
+		msg := fmt.Sprintf(format, args...)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
+	for _, ifID := range order {
+		group := byID[ifID]
+		if len(group) < 2 {
+			// One distinct bind-interface string for this if_id (possibly
+			// shared by several VPNs) — not the ambiguous-alias case.
+			continue
+		}
+		// Two or more DISTINCT bind-interface strings collide on this if_id.
+		names := make([]string, 0, len(group))
+		for name := range group {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		descs := make([]string, 0, len(names))
+		for _, name := range names {
+			vpns := append([]string(nil), group[name].vpns...)
+			sort.Strings(vpns)
+			descs = append(descs, fmt.Sprintf(
+				"bind-interface %q (security ipsec vpn %s)",
+				name, strings.Join(vpns, ", ")))
+		}
+		if err := emit(
+			"secure-tunnel bind-interface alias collision: %s all derive the "+
+				"same XFRM if_id %d (a bare st<N> is unit 0, so st<N> and "+
+				"st<N>.0 are the same xfrm device); only one device can carry "+
+				"that if_id, so the others are dropped at apply time (both "+
+				"tunnels down / cross-VPN SA leak). Bind each VPN to a distinct "+
+				"secure-tunnel unit, e.g. st0.0 and st0.1 (#2933)",
+			strings.Join(descs, " and "), ifID,
+		); err != nil {
+			return nil, err
+		}
+	}
+	return warnings, nil
+}

--- a/pkg/config/compiler_ipsec_bindiface_2933_test.go
+++ b/pkg/config/compiler_ipsec_bindiface_2933_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #2933: two VPNs that bind two DISTINCT secure-tunnel
+// `bind-interface` strings deriving the SAME XFRM if_id (e.g.
+// `bind-interface st0` and `bind-interface st0.0`, both if_id 1 via
+// XFRMIfNameAndID) committed cleanly but collide at apply time — only one
+// xfrm device can carry the if_id, so the #2929 routing guard refuses to
+// create EITHER and both tunnels go down. The fix REJECTS the ambiguous
+// alias pair at commit (strict CompileConfig) and WARNS on the tolerant
+// load / peer-sync path (CompileConfigLenient).
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath, never
+// NewParser (the parser merges newline-separated set lines into one giant
+// node).
+
+func buildBindIfaceTree(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		// ParseSetCommand strips the leading "set" verb and returns the path
+		// tokens (with quoting/bracket handling) ready for SetPath.
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestSecureTunnelBindIfaceCollisionRejectedAtCommit proves that an
+// ambiguous-alias bind-interface pair (st0 vs st0.0, and equivalently
+// st1.0 vs st1) is hard-rejected at commit. Reverting
+// validateSecureTunnelBindInterfaceAST to `return nil, nil` turns these
+// cases GREEN (no error) and so RED.
+func TestSecureTunnelBindIfaceCollisionRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		want []string // substrings expected in the commit error
+	}{
+		{
+			name: "st0 vs st0.0",
+			cmds: []string{
+				"set security ipsec vpn V1 bind-interface st0",
+				"set security ipsec vpn V2 bind-interface st0.0",
+			},
+			want: []string{
+				`bind-interface "st0"`,
+				`bind-interface "st0.0"`,
+				"if_id 1",
+				"#2933",
+			},
+		},
+		{
+			name: "st1 vs st1.0 (unit reversed)",
+			cmds: []string{
+				"set security ipsec vpn A bind-interface st1.0",
+				"set security ipsec vpn B bind-interface st1",
+			},
+			want: []string{
+				`bind-interface "st1"`,
+				`bind-interface "st1.0"`,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildBindIfaceTree(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted ambiguous bind-interface pair; want reject")
+			}
+			for _, sub := range tc.want {
+				if !strings.Contains(err.Error(), sub) {
+					t.Errorf("error %q missing substring %q", err.Error(), sub)
+				}
+			}
+		})
+	}
+}
+
+// TestSecureTunnelBindIfaceUnambiguousCommits proves the gate is surgical:
+// distinct units (st0.0 + st0.1), distinct devices (st0 + st1), and the
+// SAME string shared by two VPNs (st0.0 + st0.0 — one device, one if_id,
+// not an ambiguous alias) all commit cleanly. This is the no-over-reject
+// guard.
+func TestSecureTunnelBindIfaceUnambiguousCommits(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{
+			name: "distinct units st0.0 + st0.1",
+			cmds: []string{
+				"set security ipsec vpn V1 bind-interface st0.0",
+				"set security ipsec vpn V2 bind-interface st0.1",
+			},
+		},
+		{
+			name: "distinct devices st0 + st1",
+			cmds: []string{
+				"set security ipsec vpn V1 bind-interface st0",
+				"set security ipsec vpn V2 bind-interface st1",
+			},
+		},
+		{
+			name: "same string shared by two VPNs st0.0 + st0.0",
+			cmds: []string{
+				"set security ipsec vpn V1 bind-interface st0.0",
+				"set security ipsec vpn V2 bind-interface st0.0",
+			},
+		},
+		{
+			name: "single VPN bare st0",
+			cmds: []string{
+				"set security ipsec vpn V1 bind-interface st0",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildBindIfaceTree(t, tc.cmds...)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("CompileConfig rejected unambiguous bind-interface config: %v", err)
+			}
+		})
+	}
+}
+
+// TestSecureTunnelBindIfaceCollisionLenientWarns proves the tolerant
+// load/peer-sync path downgrades the collision to a warning and still
+// compiles, so an already-persisted config an older binary accepted still
+// boots (#1960 fail-closed-on-load class).
+func TestSecureTunnelBindIfaceCollisionLenientWarns(t *testing.T) {
+	tree := buildBindIfaceTree(t,
+		"set security ipsec vpn V1 bind-interface st0",
+		"set security ipsec vpn V2 bind-interface st0.0",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected colliding bind-interface (want warn): %v", err)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "bind-interface") && strings.Contains(w, "if_id 1") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile produced no bind-interface collision warning; got %v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
Closes #2933

## Bug

`security ipsec vpn <name> bind-interface` is a free-form 1-arg string stored
verbatim on the typed VPN. The runtime resolves it to a Linux xfrmi device and a
stable XFRM if_id via `XFRMIfNameAndID` (`xfrmi.go`):

```
if_id = stIndex<<16 | (unit+1)      (unit defaults to 0)
```

so a bare `st0` is the **same device** as `st0.0` (both `if_id 1`). Two VPNs
binding those two distinct strings commit cleanly today but collide at apply
time: only one xfrm device can carry the if_id, so the #2929 `pkg/routing` guard
refuses to create EITHER device and both tunnels go down with a journal ERROR
(before #2929 it silently leaked one VPN's SA onto the other's tunnel). The
operator only discovers the misconfiguration at apply time, never at commit.

## Fix — commit-reject contract

`validateSecureTunnelBindInterfaceAST` (`compiler_ipsec_bindiface.go`) is an AST
pre-walk in `compileExpanded`, mirroring `validateNATRuleSetScopeAST` and the
other reject-at-commit gates. It derives the if_id for every VPN's
bind-interface and rejects when **two DISTINCT strings derive the SAME non-zero
if_id**, naming each offending string, its VPN(s), and the shared if_id —
candidate refused, live config untouched (Junos-style).

**Surgical:** fires ONLY on two distinct strings sharing one if_id. The same
bind-interface string shared by several VPNs (one device, one if_id) and a
bind-interface that cannot parse as `st<N>[.unit]` (if_id 0) are out of scope;
`st0.0 + st0.1` and `st0 + st1` commit cleanly.

## Strict / lenient split (#1960 doctrine)

- Strict commit / commit-check (`CompileConfig` / `CompileConfigForNode`):
  **hard-reject**.
- Tolerant load / peer-sync (`CompileConfigLenient` /
  `CompileConfigForNodeLenient`): downgrade to a `cfg.Warnings` entry via the new
  `lenientSecureTunnelBindIface` flag, so an already-persisted or peer-synced
  config an older binary silently accepted still **boots**. The #2929 routing
  guard remains the runtime backstop.

Running on the group-expanded, inactive-pruned tree means an
apply-groups-inherited bind-interface is caught and an `inactive:` VPN is
ignored for free.

## Validation

- `go build ./...`, `go vet ./pkg/config/...`, `go test ./pkg/config/...` —
  1578 passed; `gofmt` clean.
- Tests: reject `st0`/`st0.0` and `st1.0`/`st1` alias pairs; assert unambiguous
  configs (distinct units, distinct devices, same string shared, single VPN)
  still commit (no over-reject); assert the lenient path warns-and-compiles.
- **Fail-on-revert confirmed**: stubbing the validator to `return nil, nil`
  turns the reject + lenient tests RED.
- README + `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi