### PR TITLE
ddns/surface-a: single-writer RG0/non-HA scopes in active-active HA (Closes #2972)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-06-25 — #2972: ddns surface-a RG0/non-HA scope double-write in active-active HA
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed `surfaceAGate` admitting every `RGOwner==0` (RG0/non-HA)
+  Surface A scope unconditionally. In active-active HA both nodes pass the
+  node-level writer gate (each masters some RG) and both built+published the
+  identical non-HA FQDN — a public A/AAAA flap when the nodes observe different
+  WAN addresses. `RGOwner==0` is now tied to RG0 (control-plane RG) ownership
+  via new helper `surfaceARG0Writer`: the RG0-primary node is the single writer
+  and it follows RG0 failover; when RG0 is untracked (data-RG-only cluster or
+  pre-first-election) it falls back to the lowest-node-ID writer. Standalone
+  (nil gate) still writes every scope. DHCP-lease DDNS is unchanged (its
+  per-node memfiles are already master-filtered, so its `RGOwner==0` case has no
+  peer). Added fail-on-revert tests `TestSurfaceAGateRG0SingleWriter`
+  (active-active + failover) and `TestSurfaceAGateRG0FallbackNoRG0`; updated
+  `TestSurfaceAGatePerRG` for the new semantic.
+- **File(s)**: pkg/daemon/daemon_ddns_surface_a.go,
+  pkg/daemon/daemon_ddns_surface_a_test.go, pkg/ddns/README.md
+
 ## 2026-06-25 — #2936: cap session aggregator cardinality (control-plane DoS amplifier)
 
 - **Timestamp**: 2026-06-25 19:48

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -511,20 +511,56 @@ func staticUnitAddr(unit *config.InterfaceUnit, af4 bool) (netip.Addr, bool) {
 // surfaceAGate builds the per-RG HA writer gate for one reconcile pass (#2664,
 // plan §5.6). It REUSES the same per-RG master snapshot the lease loop uses. A
 // scope on an RG-owned (reth) interface is writable IFF this node is MASTER for
-// that RG; an RG 0 scope (a non-HA interface) is admitted (the node-level
-// writer gate already authorized the pass; no peer to double-write). Standalone
-// (no cluster) returns nil so the engine admits every scope.
+// that RG. An RG 0 scope (a non-HA interface) is bound to RG0 — the
+// control-plane redundancy group — so exactly the RG0-primary node publishes it
+// (#2972). Standalone (no cluster) returns nil so the engine admits every scope.
+//
+// Why RG0/non-HA scopes need their own gate (#2972): unlike DHCP-lease DDNS
+// (where each node's Kea memfile is rendered master-filtered per RG, so the two
+// nodes' lease input sets are disjoint), Surface A scopes are built directly
+// from the active config + the interface observer. BOTH nodes build the
+// IDENTICAL RG0 scope. The node-level writer gate (ddnsWriterGateOpen) opens on
+// ANY-RG mastership, so in active-active HA (node0 masters RG1, node1 masters
+// RG2) BOTH nodes pass it AND — before this fix — both admitted every RGOwner==0
+// scope, double-writing the same configured FQDN. If the two nodes observe
+// different WAN addresses the public A/AAAA record flaps. Tying RGOwner==0 to
+// RG0 ownership yields a single writer that follows RG0 failover.
 func (d *Daemon) surfaceAGate() ddns.ScopeGate {
 	if d.cluster == nil {
 		return nil
 	}
 	master := d.snapshotRethMasterState()
+	rg0Writer := d.surfaceARG0Writer(master)
 	return func(s ddns.ScopeKey) bool {
 		if s.RGOwner == 0 {
-			return true
+			return rg0Writer
 		}
 		return master[s.RGOwner]
 	}
+}
+
+// surfaceARG0Writer reports whether THIS node is the single writer for
+// RG0/non-HA Surface A scopes in a cluster (#2972). RG0 is the control-plane
+// redundancy group (the config-authority group, daemon_ha.go RG0 handling):
+// exactly one node is RG0 primary at any time, so binding the non-HA scopes to
+// RG0 ownership gives a deterministic single writer that follows RG0 failover.
+//
+//   - RG0 tracked (the standard cluster, RG0 configured): the per-RG master
+//     snapshot is authoritative — admit IFF this node masters RG0.
+//   - RG0 NOT tracked (a non-standard cluster with only data RGs, or the brief
+//     window before the first RG0 election settles): master[0] is absent. Fall
+//     back to a deterministic single writer — the lowest node ID (node 0) — so
+//     the non-HA scopes are still written by exactly one node and never
+//     double-written. (A standalone node returns nil from surfaceAGate and never
+//     reaches here.)
+func (d *Daemon) surfaceARG0Writer(master map[int]bool) bool {
+	if d.cluster == nil {
+		return true
+	}
+	if isMaster, tracked := master[0]; tracked {
+		return isMaster
+	}
+	return d.cluster.NodeID() == 0
 }
 
 // nudgeSurfaceADDNSReconcile requests an immediate Surface A reconcile pass

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -100,8 +100,9 @@ func TestSurfaceAGatePerRG(t *testing.T) {
 		rgStates: make(map[int]*rgStateMachine),
 		cluster:  cluster.NewManager(0, 1),
 	}
-	// No RG is master yet → an RG1 scope is gated CLOSED; an RG0 (non-HA)
-	// scope is always admitted.
+	// Node 0. RG1 is not master yet → an RG1 scope is gated CLOSED. RG0 is not
+	// tracked yet, so the RG0/non-HA scope falls back to the lowest-node-ID
+	// writer — node 0 is the writer, so it is admitted here (#2972).
 	gate := d.surfaceAGate()
 	if gate == nil {
 		t.Fatal("cluster daemon must produce a per-RG gate")
@@ -110,7 +111,87 @@ func TestSurfaceAGatePerRG(t *testing.T) {
 		t.Fatal("RG1 scope must be gated closed when not master for RG1")
 	}
 	if !gate(ddns.ScopeKey{RGOwner: 0}) {
-		t.Fatal("RG0 (non-HA) scope must be admitted")
+		t.Fatal("RG0/non-HA scope must be admitted on node 0 (lowest-node-ID fallback)")
+	}
+}
+
+// TestSurfaceAGateRG0SingleWriter is the #2972 fail-on-revert gate. An
+// RG0/non-HA Surface A scope (RGOwner==0) must be admitted by EXACTLY ONE node
+// in an active-active cluster — the node that is RG0 primary — not by every node
+// that happens to master some data RG. Before the fix, surfaceAGate admitted
+// every RGOwner==0 scope unconditionally, so both nodes double-wrote the same
+// configured FQDN. Reverting surfaceARG0Writer to `return true` turns this RED
+// (both nodes would admit the RG0 scope).
+func TestSurfaceAGateRG0SingleWriter(t *testing.T) {
+	// Active-active: node 0 masters RG0 (control plane) + RG1; node 1 masters
+	// RG2. Both pass the node-level writer gate (each masters some RG), so both
+	// would build the identical RGOwner==0 scope.
+	node0 := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(0, 1),
+	}
+	node0.getOrCreateRGState(0).SetCluster(true) // RG0 primary
+	node0.getOrCreateRGState(1).SetCluster(true) // RG1 primary
+	node0.getOrCreateRGState(2).SetCluster(false)
+
+	node1 := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(1, 0),
+	}
+	node1.getOrCreateRGState(0).SetCluster(false) // RG0 secondary
+	node1.getOrCreateRGState(1).SetCluster(false)
+	node1.getOrCreateRGState(2).SetCluster(true) // RG2 primary
+
+	g0 := node0.surfaceAGate()
+	g1 := node1.surfaceAGate()
+	if g0 == nil || g1 == nil {
+		t.Fatal("cluster daemons must produce per-RG gates")
+	}
+
+	rg0Scope := ddns.ScopeKey{RGOwner: 0}
+	a0 := g0(rg0Scope)
+	a1 := g1(rg0Scope)
+	if a0 == a1 {
+		t.Fatalf("RG0/non-HA scope must be admitted by exactly one node; node0=%v node1=%v (double-write)", a0, a1)
+	}
+	if !a0 {
+		t.Fatal("the RG0-primary node (node 0) must be the writer for the RG0/non-HA scope")
+	}
+
+	// Failover: RG0 moves to node 1. The single writer must follow it.
+	node0.getOrCreateRGState(0).SetCluster(false)
+	node1.getOrCreateRGState(0).SetCluster(true)
+	if node0.surfaceAGate()(rg0Scope) {
+		t.Fatal("after RG0 failover, the old RG0-primary (node 0) must stop writing the RG0 scope")
+	}
+	if !node1.surfaceAGate()(rg0Scope) {
+		t.Fatal("after RG0 failover, the new RG0-primary (node 1) must become the RG0 scope writer")
+	}
+}
+
+// TestSurfaceAGateRG0FallbackNoRG0 covers the non-standard cluster where RG0 is
+// not a tracked group (only data RGs). The RG0/non-HA scope must still have a
+// single deterministic writer — the lowest node ID — not be admitted by every
+// node (#2972).
+func TestSurfaceAGateRG0FallbackNoRG0(t *testing.T) {
+	node0 := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(0, 1),
+	}
+	node0.getOrCreateRGState(1).SetCluster(true) // masters RG1, no RG0 tracked
+
+	node1 := &Daemon{
+		rgStates: make(map[int]*rgStateMachine),
+		cluster:  cluster.NewManager(1, 0),
+	}
+	node1.getOrCreateRGState(2).SetCluster(true) // masters RG2, no RG0 tracked
+
+	rg0Scope := ddns.ScopeKey{RGOwner: 0}
+	if !node0.surfaceAGate()(rg0Scope) {
+		t.Fatal("with no RG0 tracked, the lowest-node-ID node (node 0) must write the RG0 scope")
+	}
+	if node1.surfaceAGate()(rg0Scope) {
+		t.Fatal("with no RG0 tracked, a non-lowest node (node 1) must NOT write the RG0 scope (double-write)")
 	}
 }
 

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -476,6 +476,25 @@ its OWN learned address — on top of the SAME spine, without forking the engine
 - **HA gate** is the SAME per-RG `ScopeGate` (a router record on a reth/virtual
   interface publishes only on the RG master; stop-writing-never-withdraw
   otherwise). Standalone (nil gate) always publishes.
+  **RG0/non-HA single-writer (#2972).** A scope on a non-HA interface attributes
+  `RGOwner==0`. Unlike DHCP-lease DDNS — where each node's Kea memfile is
+  rendered master-filtered per RG, so the two nodes' lease input sets are
+  disjoint and an `RGOwner==0` lease is genuinely a non-HA pool with no peer —
+  Surface A scopes are built directly from the active config + interface
+  observer, so BOTH nodes build the IDENTICAL `RGOwner==0` scope. The node-level
+  writer gate (`ddnsWriterGateOpen`) opens on ANY-RG mastership, so in
+  active-active HA (node0 masters RG1, node1 masters RG2) BOTH nodes passed it
+  AND — before this fix — `surfaceAGate` admitted every `RGOwner==0` scope
+  unconditionally, double-writing the same configured FQDN (the public A/AAAA
+  record flaps when the nodes observe different addresses). `surfaceAGate` (in
+  `pkg/daemon/daemon_ddns_surface_a.go`) now ties `RGOwner==0` to RG0 — the
+  control-plane redundancy group — via `surfaceARG0Writer`: exactly the
+  RG0-primary node publishes the non-HA scopes, and the single writer follows
+  RG0 failover. When RG0 is not a tracked group (a non-standard cluster with
+  only data RGs, or the brief pre-first-election window), it falls back to a
+  deterministic single writer — the lowest node ID — so the scope is never
+  double-written. (`TestSurfaceAGateRG0SingleWriter`,
+  `TestSurfaceAGateRG0FallbackNoRG0`.)
 - **Lock discipline — I/O is NEVER performed under the manager mutex (#2778).**
   `SurfaceAManager.mu` guards ALL manager state (the durable ownership store, the
   per-scope runtime cache, the counters), but it is RELEASED across every


### PR DESCRIPTION
## Closes #2972

### The bug (double-write)
`reconcileSurfaceAOnce` returns early only on the NODE-LEVEL writer gate (`ddnsWriterGateOpen`), which opens when this node is MASTER for at least one RG. The per-scope `surfaceAGate` then admitted **every** `RGOwner==0` (RG0 / non-HA-interface) scope unconditionally, on the rationale "no peer to double-write".

That rationale is false for active-active HA. If node0 masters RG1 and node1 masters RG2, **both** pass the node-level gate **and** both admitted every `RGOwner==0` scope — so both published the same configured FQDN. When the two nodes observe different WAN addresses the public A/AAAA record flaps / last-writer-wins to the wrong address.

Unlike DHCP-lease DDNS (each node's Kea memfile is rendered master-filtered per RG, so the nodes' lease input sets are disjoint and an `RGOwner==0` lease is a genuine non-HA pool with no peer), Surface A scopes are built directly from the active config + interface observer, so both nodes build the **identical** `RGOwner==0` scope and nothing else dedups it.

### The single-writer fix
Tie `RGOwner==0` to **RG0** (the control-plane redundancy group) so exactly the RG0-primary node publishes the non-HA scopes, and the single writer follows RG0 failover. `surfaceAGate` consults a new helper `surfaceARG0Writer`:

- **RG0 tracked** (standard cluster): admit IFF this node masters RG0 (the per-RG master snapshot is authoritative).
- **RG0 not tracked** (non-standard data-RG-only cluster, or the brief pre-first-election window): fall back to a deterministic single writer — the **lowest node ID** — so the scope is still written by exactly one node.
- **Standalone** (no cluster): `surfaceAGate` returns `nil`, the engine admits every scope — unchanged, the single node still writes.

DHCP-lease DDNS (`daemon_ddns.go` `ddnsReconcileOptions`) is intentionally **unchanged** (its `RGOwner==0` case has no peer double-write hazard).

### Validation
- `go build ./...`, `go vet ./pkg/ddns/...`, `go test ./pkg/ddns/... ./pkg/daemon/...` (819 passed), gofmt clean on touched Go files.
- **Fail-on-revert proven:** reverting `surfaceARG0Writer` to `return true` turns `TestSurfaceAGateRG0SingleWriter` and `TestSurfaceAGateRG0FallbackNoRG0` RED (both nodes admit the RG0 scope → double-write); restoring → GREEN.
  - `TestSurfaceAGateRG0SingleWriter` — active-active two-node: exactly one writer for the RG0 scope, and the writer follows an RG0 failover.
  - `TestSurfaceAGateRG0FallbackNoRG0` — data-RG-only cluster: lowest-node-ID single writer.
  - `TestSurfaceAGatePerRG` updated for the new semantic; `TestSurfaceAStandaloneGateNil` unchanged (standalone still writes).

### Note on #2971 (sibling)
#2971 (corrupt ownership state fail-opens to empty store) lives in `pkg/ddns/surface_a.go` `NewSurfaceAManager` — a **distinct** code path from this gate fix. It is not addressed here; this PR is scoped to the #2972 double-write gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi