### PR TITLE
feeds: count + surface skipped invalid lines (no silent partial set)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,15 @@
+## 2026-06-25 — #2993: feeds mixed valid/invalid body installs a partial set silently
+- **Action**: parseFeed now counts skipped malformed lines (invalidLines) +
+  bounded sample (invalidSample, maxInvalidSample=5); FeedInfo gains
+  InvalidLines/InvalidSample/Degraded. installSnapshot records them and logs
+  one slog.Warn on a degraded content change; recordFailure drop-to-empty
+  clears them. show security dynamic-address (CLI + grpcapi) prints a DEGRADED
+  line. Clean feeds unchanged (0 invalid, not degraded). Contract: skip-with-
+  count + degraded status (issue primary direction; observable, not silent).
+- **File(s)**: pkg/feeds/feeds.go, pkg/feeds/feeds_test.go,
+  pkg/feeds/README.md, pkg/cli/cli_show_security_objects.go,
+  pkg/grpcapi/server_show_security_text.go
+
 ## 2026-06-25 — #2936: cap session aggregator cardinality (control-plane DoS amplifier)
 
 - **Timestamp**: 2026-06-25 19:48

--- a/pkg/cli/cli_show_security_objects.go
+++ b/pkg/cli/cli_show_security_objects.go
@@ -246,6 +246,12 @@ func (c *CLI) showDynamicAddress() error {
 			} else {
 				fmt.Printf("    Last fetch: never\n")
 			}
+			if fi.Degraded {
+				fmt.Printf("    DEGRADED: %d invalid line(s) skipped (partial set installed)\n", fi.InvalidLines)
+				if len(fi.InvalidSample) > 0 {
+					fmt.Printf("      Sample: %s\n", strings.Join(fi.InvalidSample, ", "))
+				}
+			}
 		}
 	}
 

--- a/pkg/feeds/README.md
+++ b/pkg/feeds/README.md
@@ -46,6 +46,20 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
 - **startup is fail-closed.** Before the first successful fetch there is no
   snapshot; `GetPrefixes` returns empty. A policy referencing a feed-backed
   address resolves to nothing until the first good fetch (bounded to seconds).
+- **mixed valid/invalid bodies are observably degraded (#2993).** A body that
+  mixes valid prefixes with malformed lines still installs the valid prefixes
+  (a clean body is bit-identical to before), but the skipped invalid lines are
+  no longer *silent*: `parseFeed` counts every malformed (non-comment, non-CIDR,
+  non-IP) line and keeps a bounded verbatim sample (`maxInvalidSample`, 5).
+  `FeedInfo` surfaces `InvalidLines`, `InvalidSample`, and `Degraded`
+  (`InvalidLines > 0`); `show security dynamic-address` prints a `DEGRADED`
+  line. A degraded install logs one `slog.Warn` on the content change (not every
+  tick). This is **skip-with-count + degraded status**, not all-or-nothing: a
+  provider bug that mangles one line of a denylist still enforces the rest, but
+  the operator can see (and alarm on) that the installed set differs from the
+  published feed instead of it reporting a clean success. The markers are
+  cleared when a later clean body installs, and on a `hold-interval`
+  drop-to-empty.
 
 `FeedInfo` carries additive status fields (`LastSuccess`, `LastError`,
 `StaleSince`, `Hash`) alongside the legacy `URL`/`Prefixes`/`LastFetch`.
@@ -66,10 +80,12 @@ applies a *retain-last-good* policy rather than installing a partial/empty set:
   base URL.
 - Default refresh interval is 1 hour; the Junos config can override via
   `update-interval`.
-- Feed bodies are parsed line-by-line, one CIDR per line. Invalid lines
-  are skipped silently — by design, since feed providers occasionally
-  emit comments. A *scanner-level* error (overlong line / read error) is
-  NOT skipped: it fails the whole fetch (retain last-good).
+- Feed bodies are parsed line-by-line, one CIDR per line. Comment lines
+  (`#`, `//`) and blanks are skipped silently. A malformed non-comment line
+  is skipped but **counted** (`InvalidLines`/`InvalidSample`, marks the feed
+  `Degraded`, #2993) — it is no longer a silent drop. A *scanner-level* error
+  (overlong line / read error) is NOT skipped: it fails the whole fetch
+  (retain last-good).
 - A successful fetch always replaces the snapshot and stamps success, but
   the `onUpdate` recompile fires only when the canonical content hash
   changes — not on every fetch and not merely on a count change.

--- a/pkg/feeds/feeds.go
+++ b/pkg/feeds/feeds.go
@@ -32,6 +32,12 @@ const retainForever time.Duration = 0
 // fetch (bufio.ErrTooLong) rather than a silent truncation — see fetchFeed.
 const maxLineBytes = 1 << 20 // 1 MiB
 
+// maxInvalidSample bounds how many distinct malformed lines are retained for
+// operator display (#2993). A degraded feed records the total invalid-line
+// count plus a small verbatim sample so an operator can identify the bad lines
+// without the sample growing unbounded for a wholesale-garbage body.
+const maxInvalidSample = 5
+
 // Manager manages dynamic address feed servers and their periodic updates.
 type Manager struct {
 	mu       sync.RWMutex
@@ -56,6 +62,15 @@ type feedState struct {
 	prefixes    []string
 	hash        [32]byte // sha256 over the canonical join; zero when no snapshot
 	hasSnapshot bool     // true once a good fetch has installed a snapshot
+
+	// Parse-quality of the INSTALLED snapshot (#2993). A feed body may mix
+	// valid + invalid lines: the valid prefixes are installed but the skipped
+	// invalid lines are no longer silent. invalidLines counts every malformed
+	// line in the last successfully-installed body; invalidSample keeps up to
+	// maxInvalidSample verbatim offenders for display. Both are zero/nil for a
+	// clean body (no behaviour change) and are cleared on a drop-to-empty.
+	invalidLines  int
+	invalidSample []string
 
 	// Fetch status (separate from the active snapshot).
 	lastFetch   time.Time // last SUCCESSFUL fetch (kept name for show-path compat)
@@ -286,13 +301,16 @@ func (m *Manager) AllFeeds() map[string]FeedInfo {
 			hash = fmt.Sprintf("%x", fs.hash)
 		}
 		result[name] = FeedInfo{
-			URL:         fs.url,
-			Prefixes:    len(fs.prefixes),
-			LastFetch:   fs.lastFetch,
-			LastSuccess: fs.lastSuccess,
-			LastError:   fs.lastError,
-			StaleSince:  fs.staleSince,
-			Hash:        hash,
+			URL:           fs.url,
+			Prefixes:      len(fs.prefixes),
+			LastFetch:     fs.lastFetch,
+			LastSuccess:   fs.lastSuccess,
+			LastError:     fs.lastError,
+			StaleSince:    fs.staleSince,
+			Hash:          hash,
+			InvalidLines:  fs.invalidLines,
+			InvalidSample: append([]string(nil), fs.invalidSample...),
+			Degraded:      fs.invalidLines > 0,
 		}
 	}
 	return result
@@ -314,6 +332,16 @@ type FeedInfo struct {
 	// hold-interval drop cleared the retained snapshot.
 	StaleSince time.Time
 	Hash       string // hex sha256 of the canonical prefix set ("" if none)
+
+	// Parse-quality of the installed snapshot (#2993). InvalidLines is the
+	// number of malformed lines skipped while parsing the last
+	// successfully-installed body; InvalidSample is a bounded verbatim sample
+	// of those lines. Degraded is true when InvalidLines > 0 — the feed
+	// installed a PARTIAL set (some published lines were dropped), which an
+	// operator should investigate even though valid prefixes are enforced.
+	InvalidLines  int
+	InvalidSample []string
+	Degraded      bool
 }
 
 func (m *Manager) refreshLoop(ctx context.Context, fs *feedState, interval time.Duration) {
@@ -338,6 +366,12 @@ func (m *Manager) refreshLoop(ctx context.Context, fs *feedState, interval time.
 type fetchResult struct {
 	prefixes []string // canonicalized, deduped, sorted
 	hash     [32]byte
+
+	// invalidLines counts malformed lines skipped during parse; invalidSample
+	// holds up to maxInvalidSample verbatim offenders (#2993). A clean body
+	// leaves both zero/nil.
+	invalidLines  int
+	invalidSample []string
 }
 
 // fetchFeed performs a single GET, parses + canonicalizes the body, and applies
@@ -384,6 +418,8 @@ func (m *Manager) readFeed(ctx context.Context, fs *feedState) (fetchResult, err
 // Reads io.Reader (not http.Response) so it is unit-testable in isolation.
 func parseFeed(r io.Reader) (fetchResult, error) {
 	var prefixes []string
+	var invalidLines int
+	var invalidSample []string
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxLineBytes)
 	for scanner.Scan() {
@@ -401,9 +437,18 @@ func parseFeed(r io.Reader) (fetchResult, error) {
 			} else {
 				prefixes = append(prefixes, fmt.Sprintf("%s/128", ip.String()))
 			}
+		} else {
+			// A non-comment line that is neither a CIDR nor a bare IP. Feed
+			// providers occasionally emit stray text, but a malformed line can
+			// also be THE line that matters for a denylist (#2993). We still
+			// skip it (the published valid prefixes are installed), but it is no
+			// longer silent: count it and keep a bounded sample so the fetch is
+			// observably degraded rather than reporting a clean success.
+			invalidLines++
+			if len(invalidSample) < maxInvalidSample {
+				invalidSample = append(invalidSample, line)
+			}
 		}
-		// Invalid lines are skipped (feed providers occasionally emit comments
-		// or stray text); only a scanner-level error fails the whole fetch.
 	}
 	if err := scanner.Err(); err != nil {
 		// Overlong line (bufio.ErrTooLong) or transport read error mid-stream.
@@ -418,7 +463,12 @@ func parseFeed(r io.Reader) (fetchResult, error) {
 		return fetchResult{}, fmt.Errorf("feed returned no usable prefixes")
 	}
 
-	return fetchResult{prefixes: canon, hash: hashPrefixes(canon)}, nil
+	return fetchResult{
+		prefixes:      canon,
+		hash:          hashPrefixes(canon),
+		invalidLines:  invalidLines,
+		invalidSample: invalidSample,
+	}, nil
 }
 
 // canonicalize dedups and sorts the prefix list. Input prefixes are already in
@@ -468,11 +518,23 @@ func (m *Manager) installSnapshot(fs *feedState, res fetchResult) {
 	fs.lastSuccess = now
 	fs.lastError = ""
 	fs.staleSince = time.Time{}
+	fs.invalidLines = res.invalidLines
+	fs.invalidSample = res.invalidSample
 	m.mu.Unlock()
 
 	slog.Info("dynamic-address: feed updated",
 		"name", fs.name, "prefixes", len(res.prefixes), "previous", oldCount,
-		"changed", changed)
+		"changed", changed, "invalid_lines", res.invalidLines)
+
+	// A degraded install (some published lines skipped) is loud, but only on a
+	// content change so a persistently-malformed-but-stable feed does not flood
+	// the journal on every refresh tick (#2993). The per-fetch invalid count is
+	// always carried in the Info line above and surfaced via FeedInfo.
+	if changed && res.invalidLines > 0 {
+		slog.Warn("dynamic-address: feed installed a PARTIAL set — skipped invalid lines (degraded)",
+			"name", fs.name, "prefixes", len(res.prefixes),
+			"invalid_lines", res.invalidLines, "invalid_sample", res.invalidSample)
+	}
 
 	if changed && m.onUpdate != nil {
 		m.onUpdate()
@@ -515,6 +577,10 @@ func (m *Manager) recordFailure(fs *feedState, ferr error) {
 			// Copilot #2: no snapshot is retained as stale anymore — clear
 			// StaleSince so FeedInfo.StaleSince matches its docstring.
 			fs.staleSince = time.Time{}
+			// No snapshot remains, so its parse-quality is meaningless — clear
+			// the degraded markers too (#2993).
+			fs.invalidLines = 0
+			fs.invalidSample = nil
 			dropped = true
 		}
 	}

--- a/pkg/feeds/feeds_test.go
+++ b/pkg/feeds/feeds_test.go
@@ -3,6 +3,7 @@ package feeds
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -78,6 +79,144 @@ func TestParseFeedCanonicalizesAndDedups(t *testing.T) {
 		if !gotSet[w] {
 			t.Errorf("missing canonical prefix %q in %v", w, got)
 		}
+	}
+}
+
+// TestParseFeedCountsInvalidLines is the #2993 fail-on-revert test. A feed body
+// mixing valid + invalid lines must install the valid prefixes AND surface the
+// count (plus a bounded sample) of the skipped invalid lines — not silently
+// drop them and report a clean parse. Reverting the parse-side counting makes
+// invalidLines == 0 and turns this RED.
+func TestParseFeedCountsInvalidLines(t *testing.T) {
+	body := strings.Join([]string{
+		"192.0.2.0/24",
+		"garbage one",                  // invalid
+		"203.0.113.0/24",               // valid
+		"203.0.113.0/24 trailing-junk", // CIDR + stray text -> invalid
+		"not-an-ip",                    // invalid
+		"10.0.0.0/8",                   // valid
+		"# a comment",                  // skipped, not counted invalid
+	}, "\n")
+
+	res, err := parseFeed(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	if len(res.prefixes) != 3 {
+		t.Fatalf("got %d valid prefixes %v, want 3 (valid lines still installed)",
+			len(res.prefixes), res.prefixes)
+	}
+	if res.invalidLines != 3 {
+		t.Fatalf("invalidLines = %d, want 3 (mixed body must count skipped lines, not silently drop)",
+			res.invalidLines)
+	}
+	if len(res.invalidSample) == 0 {
+		t.Fatal("invalidSample empty; want a bounded verbatim sample of skipped lines")
+	}
+	for _, s := range res.invalidSample {
+		if s == "# a comment" || s == "192.0.2.0/24" {
+			t.Errorf("invalidSample contains a non-invalid line %q", s)
+		}
+	}
+}
+
+// TestInvalidSampleIsBounded confirms the sample never exceeds maxInvalidSample
+// even for a wholesale-garbage body, while the total count is exact.
+func TestInvalidSampleIsBounded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("192.0.2.0/24\n") // one valid prefix so parse succeeds
+	const garbage = 50
+	for i := 0; i < garbage; i++ {
+		fmt.Fprintf(&b, "junk-line-%d\n", i)
+	}
+	res, err := parseFeed(strings.NewReader(b.String()))
+	if err != nil {
+		t.Fatalf("parseFeed error: %v", err)
+	}
+	if res.invalidLines != garbage {
+		t.Errorf("invalidLines = %d, want %d", res.invalidLines, garbage)
+	}
+	if len(res.invalidSample) != maxInvalidSample {
+		t.Errorf("invalidSample len = %d, want bounded to %d", len(res.invalidSample), maxInvalidSample)
+	}
+}
+
+// TestMixedFeedDegradedStatus confirms a mixed body installs valid prefixes and
+// surfaces a degraded status with the invalid-line count through AllFeeds.
+func TestMixedFeedDegradedStatus(t *testing.T) {
+	m := New(func() {})
+	srv := &bodyServer{}
+	srv.set("192.0.2.0/24\nnot-an-ip\n203.0.113.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("mixed", ts.URL, time.Hour)
+	m.fetchFeed(context.Background(), fs)
+
+	info := m.AllFeeds()["mixed"]
+	if info.Prefixes != 2 {
+		t.Errorf("Prefixes = %d, want 2 (valid lines installed)", info.Prefixes)
+	}
+	if info.InvalidLines != 1 {
+		t.Errorf("InvalidLines = %d, want 1", info.InvalidLines)
+	}
+	if !info.Degraded {
+		t.Error("Degraded = false despite a skipped invalid line; want true")
+	}
+	if len(info.InvalidSample) != 1 || info.InvalidSample[0] != "not-an-ip" {
+		t.Errorf("InvalidSample = %v, want [not-an-ip]", info.InvalidSample)
+	}
+}
+
+// TestCleanFeedNotDegraded is the no-behaviour-change guard: an all-valid feed
+// installs fully with zero invalid lines and is NOT marked degraded.
+func TestCleanFeedNotDegraded(t *testing.T) {
+	m := New(func() {})
+	srv := &bodyServer{}
+	srv.set("192.0.2.0/24\n203.0.113.0/24\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("clean", ts.URL, time.Hour)
+	m.fetchFeed(context.Background(), fs)
+
+	info := m.AllFeeds()["clean"]
+	if info.Prefixes != 2 {
+		t.Errorf("Prefixes = %d, want 2", info.Prefixes)
+	}
+	if info.InvalidLines != 0 {
+		t.Errorf("InvalidLines = %d, want 0 for a clean feed", info.InvalidLines)
+	}
+	if info.Degraded {
+		t.Error("clean feed marked Degraded")
+	}
+	if len(info.InvalidSample) != 0 {
+		t.Errorf("InvalidSample = %v, want empty for a clean feed", info.InvalidSample)
+	}
+}
+
+// TestDegradedClearsAfterCleanRefetch confirms a feed that recovers (provider
+// fixes the body) drops the degraded markers on the next clean install.
+func TestDegradedClearsAfterCleanRefetch(t *testing.T) {
+	m := New(func() {})
+	srv := &bodyServer{}
+	srv.set("192.0.2.0/24\nbad-line\n", http.StatusOK)
+	ts := httptest.NewServer(srv.handler())
+	defer ts.Close()
+
+	fs := m.newFeed("f", ts.URL, time.Hour)
+	ctx := context.Background()
+	m.fetchFeed(ctx, fs)
+	if info := m.AllFeeds()["f"]; !info.Degraded || info.InvalidLines != 1 {
+		t.Fatalf("first fetch not degraded: %+v", info)
+	}
+
+	// Provider fixes the body — a clean content change.
+	srv.set("192.0.2.0/24\n198.51.100.0/24\n", http.StatusOK)
+	m.fetchFeed(ctx, fs)
+	info := m.AllFeeds()["f"]
+	if info.Degraded || info.InvalidLines != 0 {
+		t.Errorf("degraded markers not cleared after clean refetch: %+v", info)
 	}
 }
 

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -743,6 +743,12 @@ func (s *Server) showDynamicAddress(cfg *config.Config, buf *strings.Builder) {
 				} else {
 					fmt.Fprintf(buf, "  Last fetch: never\n")
 				}
+				if fi.Degraded {
+					fmt.Fprintf(buf, "  DEGRADED: %d invalid line(s) skipped (partial set installed)\n", fi.InvalidLines)
+					if len(fi.InvalidSample) > 0 {
+						fmt.Fprintf(buf, "    Sample: %s\n", strings.Join(fi.InvalidSample, ", "))
+					}
+				}
 			}
 			buf.WriteString("\n")
 		}


### PR DESCRIPTION
Closes #2993

## The bug

`pkg/feeds/feeds.go` `parseFeed` parsed each line as CIDR or IP and
**silently skipped** any line that failed both, returning success as long
as at least one valid prefix remained. A feed body mixing valid + invalid
lines installed a **partial set** that silently differs from the published
feed — no error, no invalid-line count, no degraded status.

For a threat/denylist feed this is fail-open: a provider bug or middlebox
injection that turns `203.0.113.0/24` into `203.0.113.0/24 garbage`
quietly drops *that* prefix while still stamping the fetch successful.

## The contract chosen

**Skip-with-count + degraded status** — the issue's primary fix direction
("track invalid_line_count + a bounded sample; mark the feed degraded when
invalid lines were skipped even if valid prefixes remain"), i.e. the SAFE,
OBSERVABLE option.

Rationale for skip-with-count over all-or-nothing atomic: it is consistent
with the existing #2050 retain-last-good posture — a stale-but-mostly-correct
denylist still enforcing the valid prefixes beats fail-open. The change makes
the partial install **visible and alarmable** instead of silent; it does not
reject the whole body (which an atomic mode would, and which the issue lists
only as an optional strict mode). A clean, well-formed feed is bit-identical
to before — no behaviour change.

## Implementation

- `parseFeed` counts every malformed non-comment line (`invalidLines`) and
  keeps a bounded verbatim sample (`invalidSample`, cap `maxInvalidSample=5`).
  Comment/blank lines are still skipped without counting.
- `fetchResult`/`feedState` carry the parse-quality; `installSnapshot` records
  it and logs one `slog.Warn` on a degraded **content change** (not every
  refresh tick — avoids journal flooding for a persistently-malformed-but-
  stable feed; the per-fetch count is always in the Info line).
- `FeedInfo` gains `InvalidLines`, `InvalidSample`, `Degraded`
  (`InvalidLines > 0`). `show security dynamic-address` (CLI + grpcapi text)
  prints a `DEGRADED` line with count + sample.
- `recordFailure`'s `hold-interval` drop-to-empty clears the markers; a later
  clean install clears them too.

## Last-known-good preservation

Unchanged: a fully-failed fetch (transport / non-200 / scanner error /
zero-prefix-200) still retains the prior snapshot untouched. A transient
malformed body that still has ≥1 valid prefix installs the valid prefixes
+ degraded markers; one that parses to zero usable prefixes is treated as
suspect and retains last-good (existing behaviour).

## Validation

- `go build ./...`, `go vet ./pkg/feeds/...` clean (one pre-existing
  unrelated `cli.go:460 unreachable code` on master).
- `go test ./pkg/feeds/... ./pkg/cli/...` — 171 passed.
- `gofmt -l` clean on touched files.
- **Fail-on-revert**: reverting the parse-side counting turns 4 new tests
  RED (`TestParseFeedCountsInvalidLines`, `TestInvalidSampleIsBounded`,
  `TestMixedFeedDegradedStatus`, `TestDegradedClearsAfterCleanRefetch`),
  GREEN with the fix. A clean feed asserts 0 invalid / not degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi