### PR TITLE
config/frr: reject undefined policy community references at commit (#2881)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,32 @@
+## 2026-06-25 — #2881: commit-time reject undefined policy community references
+
+- **Timestamp**: 2026-06-25
+- **Action**: Add `validatePolicyCommunityReferencesStrict` reject-at-commit
+  gate. A policy-statement term's `from community <name>` (rendered FRR `match
+  community <name>`) and `then community delete <name>` (the #2848 strip-by-list
+  operation, rendered `set comm-list <name> delete`) reference an FRR
+  `bgp community-list <name>` that pkg/frr emits ONLY from a defined
+  `policy-options community <name>`. An undefined reference committed cleanly,
+  then the dangling line failed the WHOLE frr-reload of the managed section,
+  leaving dynamic routing stale (#1960-class commit-accepted-but-unloadable).
+  New validator runs on the fully-compiled `*Config`, hard-rejects on the strict
+  commit/commit-check path naming the policy, term, and missing community;
+  downgrades to a cfg.Warnings entry on the lenient load/peer-sync path
+  (`lenientPolicyCommunityRef`) so an already-persisted/peer-synced config still
+  boots. SURGICAL — only NAME refs checked; `then community (set|add) <value>`
+  carries a community VALUE, not a list ref, so it is not validated.
+- **File(s)**: pkg/config/compiler.go (compileOpts flag + 2 lenient blocks +
+  call site), pkg/config/compiler_validate_strict.go (validator),
+  pkg/config/policy_community_ref_test.go (new fail-on-revert tests),
+  pkg/config/policy_from_multileaf_2689_test.go,
+  pkg/config/compiler_policy_term_multimatch_2642_test.go,
+  pkg/config/parser_security_test.go, pkg/frr/frr_test.go (pre-existing tests:
+  define the communities they reference), pkg/config/README.md,
+  pkg/frr/README.md.
+- **Validation**: go build ./..., go vet ./pkg/config/... ./pkg/frr/...,
+  go test ./pkg/config/... ./pkg/frr/... (1806 pass). Fail-on-revert: removing
+  the validator call turns the 3 reject tests + lenient-warn test RED.
+
 ## 2026-06-25 — #2933: commit-time reject ambiguous secure-tunnel bind-interface aliases
 
 - **Timestamp**: 2026-06-25

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -357,6 +357,27 @@ ignored. The tolerant load/peer-sync path downgrades to a warning
 an older binary accepted still boots (#1960 no-brick doctrine) — the #2929
 routing guard stays the runtime backstop.
 
+**Undefined policy community references are rejected at commit (#2881):** a
+policy-statement term's `from community <name>` (rendered FRR `match community
+<name>`) and `then community delete <name>` (the strip-by-list operation added
+in #2848, rendered `set comm-list <name> delete`) both reference an FRR
+`bgp community-list <name>` that `pkg/frr` emits ONLY from a defined
+`policy-options community <name>`. With no validation a term naming an UNDEFINED
+community committed cleanly, then a dangling `match community` / `set comm-list
+... delete` line failed the WHOLE `frr-reload` of the managed section (a single
+`vtysh -f` add-batch exits non-zero on any `CMD_WARNING_CONFIG_FAILED`), leaving
+dynamic routing stale — a commit-accepted config the routing daemon cannot load.
+`validatePolicyCommunityReferencesStrict` (`compiler_validate_strict.go`) runs
+on the fully-compiled `*Config` (the community map is populated regardless of
+authoring order) and hard-rejects an undefined `from community` / `then
+community delete` reference at commit/commit-check, naming the policy, term, and
+missing community. The tolerant load/peer-sync path downgrades to a warning
+(`lenientPolicyCommunityRef`) so an already-persisted or peer-synced config an
+older binary accepted still boots (#1960 no-brick doctrine). The gate is
+SURGICAL — only NAME references are checked; `then community (set|add) <value>`
+carries a community VALUE (e.g. `65000:100`), not a list reference, and a defined
+community reference commits unchanged.
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -749,6 +749,28 @@ type compileOpts struct {
 	// still BOOTS (#1960 fail-closed-on-load class) — the #2929 routing guard
 	// remains the runtime backstop. Same doctrine as lenientBackupRouterDst.
 	lenientSecureTunnelBindIface bool
+	// lenientPolicyCommunityRef (#2881) downgrades the policy community
+	// cross-reference gate (validatePolicyCommunityReferencesStrict) from a
+	// hard compile error to a cfg.Warnings entry. A policy term's
+	// `from community <name>` (rendered `match community <name>`) and
+	// `then community delete <name>` (rendered `set comm-list <name> delete`,
+	// added in #2848) both reference an FRR `bgp community-list <name>` that
+	// xpf renders ONLY from a defined `policy-options community <name>`. With
+	// no validation, a term naming an UNDEFINED community committed cleanly and
+	// broke at FRR render time: a dangling `match community <name>` is rejected
+	// by frr-reload (a single vtysh -f add-batch exits non-zero on any
+	// CMD_WARNING_CONFIG_FAILED, failing the WHOLE reload and leaving routing
+	// stale), and a dangling `set comm-list <name> delete` is likewise
+	// rejected. The strict commit / commit-check path hard-rejects so the typo
+	// is operator-visible (naming the policy, term, and missing community); the
+	// tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config carrying the typo still BOOTS
+	// (#1960 fail-closed-on-load class). Runs on the fully-compiled *Config so
+	// the community map is populated regardless of authoring order. Only a
+	// NAME reference is validated — `then community (set|add) <value>` carries a
+	// community VALUE (e.g. 65000:100), not a list reference, and is not
+	// checked. Same doctrine as lenientRoutingExportRef.
+	lenientPolicyCommunityRef bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -816,6 +838,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientNATRuleSetScope:             true,
 		lenientBackupRouterDst:             true,
 		lenientSecureTunnelBindIface:       true,
+		lenientPolicyCommunityRef:          true,
 	})
 }
 
@@ -934,6 +957,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientNATRuleSetScope:             true,
 		lenientBackupRouterDst:             true,
 		lenientSecureTunnelBindIface:       true,
+		lenientPolicyCommunityRef:          true,
 	})
 }
 
@@ -1736,6 +1760,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientRoutingExportRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("routing export reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #2881: policy community cross-reference gate. A policy term's
+	// `from community <name>` (rendered `match community <name>`) and
+	// `then community delete <name>` (rendered `set comm-list <name> delete`,
+	// added in #2848) both reference an FRR `bgp community-list <name>` that xpf
+	// renders ONLY from a defined `policy-options community <name>`. An
+	// undefined name committed unnoticed, then at FRR render time a dangling
+	// `match community` / `set comm-list ... delete` is rejected by frr-reload,
+	// failing the WHOLE reload (a single vtysh -f add-batch exits non-zero on
+	// any CMD_WARNING_CONFIG_FAILED) and leaving dynamic routing stale. Strict
+	// on commit / commit-check (hard reject naming the policy, term, and missing
+	// community); lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — #1960). Runs on the fully-compiled
+	// *Config so the community map is populated regardless of authoring order.
+	// Mirrors validateRoutingExportReferencesStrict.
+	if err := validatePolicyCommunityReferencesStrict(cfg); err != nil {
+		if opts.lenientPolicyCommunityRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("policy community reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_policy_term_multimatch_2642_test.go
+++ b/pkg/config/compiler_policy_term_multimatch_2642_test.go
@@ -15,7 +15,10 @@ import "testing"
 // overwriting the previous one (see TestPolicyTermMultiMatch_FlatSet_2630).
 
 func TestPolicyTermMultiMatch_Hierarchical_2642(t *testing.T) {
+	// Communities must be defined (#2881 cross-reference gate).
 	cfg := `policy-options {
+    community c1 members 65000:1;
+    community c2 members 65000:2;
     policy-statement P {
         term t1 {
             from {
@@ -61,7 +64,9 @@ func TestPolicyTermMultiMatch_Hierarchical_2642(t *testing.T) {
 // A single same-type match in the hierarchical path keeps working (regression
 // guard for the common case).
 func TestPolicyTermSingleMatch_Hierarchical_2642(t *testing.T) {
+	// Community must be defined (#2881 cross-reference gate).
 	cfg := `policy-options {
+    community c1 members 65000:1;
     policy-statement P {
         term t1 {
             from {
@@ -104,6 +109,9 @@ func TestPolicyTermSingleMatch_Hierarchical_2642(t *testing.T) {
 func TestPolicyTermMultiMatch_FlatSet_2630(t *testing.T) {
 	tree := &ConfigTree{}
 	cmds := []string{
+		// Communities must be defined (#2881 cross-reference gate).
+		"set policy-options community c1 members 65000:1",
+		"set policy-options community c2 members 65000:2",
 		"set policy-options policy-statement P term t1 from community c1",
 		"set policy-options policy-statement P term t1 from community c2",
 		"set policy-options policy-statement P term t1 from prefix-list pl1",

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -809,6 +809,91 @@ func validateRoutingExportReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validatePolicyCommunityReferencesStrict hard-rejects a policy-statement term
+// whose `from community <name>` or `then community delete <name>` references a
+// community the config never defines under `policy-options community <name>`
+// (#2881).
+//
+// xpf renders `from community <name>` as the FRR route-map clause
+// `match community <name>` and `then community delete <name>` (added in #2848)
+// as `set comm-list <name> delete`. Both clauses reference an FRR
+// `bgp community-list <name>`, which xpf emits ONLY for a defined
+// `policy-options community <name>` (policy_render.go). With no validation an
+// undefined name passes commit and breaks at FRR render time: a dangling
+// `match community` / `set comm-list ... delete` line is rejected by
+// frr-reload, and because a single vtysh -f add-batch exits non-zero on any
+// CMD_WARNING_CONFIG_FAILED, the WHOLE reload fails — leaving dynamic routing
+// stale, a commit-accepted config the routing daemon cannot load.
+//
+// Only NAME references are checked. `then community (set|add) <value>` and the
+// bare `then community <value>` carry a community VALUE (e.g. 65000:100 /
+// no-export), not a community-list reference, so they are not validated here;
+// `then community none` carries no argument. Multiple `from community` siblings
+// (FromCommunity slice) and a multi-list `then community delete [ a b ]`
+// (CommunityDelete slice) are each fully walked.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientPolicyCommunityRef) so an already-persisted or
+// peer-synced config carrying the typo still boots (#1960 fail-closed-on-load
+// class). Commit / commit-check stay strict. Runs on the fully-compiled
+// *Config so the community map is populated regardless of authoring order.
+// Mirrors validateRoutingExportReferencesStrict.
+func validatePolicyCommunityReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	defined := func(name string) bool {
+		if cfg.PolicyOptions.Communities == nil {
+			return false
+		}
+		_, ok := cfg.PolicyOptions.Communities[name]
+		return ok
+	}
+
+	// Sort policy-statement names for a deterministic first-error message
+	// (the typed-config map iteration order is otherwise random).
+	names := make([]string, 0, len(cfg.PolicyOptions.PolicyStatements))
+	for name := range cfg.PolicyOptions.PolicyStatements {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, psName := range names {
+		ps := cfg.PolicyOptions.PolicyStatements[psName]
+		if ps == nil {
+			continue
+		}
+		for _, term := range ps.Terms {
+			if term == nil {
+				continue
+			}
+			for _, c := range term.FromCommunity {
+				if c == "" || defined(c) {
+					continue
+				}
+				return fmt.Errorf("policy-statement %s term %s `from community %s` "+
+					"references undefined community %q — xpf renders no "+
+					"`bgp community-list %s`, so the `match community` line would "+
+					"fail frr-reload (failing the entire FRR config load); define "+
+					"`policy-options community %s` or fix the name",
+					psName, term.Name, c, c, c, c)
+			}
+			for _, c := range term.CommunityDelete {
+				if c == "" || defined(c) {
+					continue
+				}
+				return fmt.Errorf("policy-statement %s term %s `then community delete %s` "+
+					"references undefined community %q — xpf renders no "+
+					"`bgp community-list %s`, so the `set comm-list %s delete` line "+
+					"would fail frr-reload (failing the entire FRR config load); "+
+					"define `policy-options community %s` or fix the name",
+					psName, term.Name, c, c, c, c, c)
+			}
+		}
+	}
+	return nil
+}
+
 // frrTokenUnsafeIndex returns the byte index of the first character in s
 // that FRR's command lexer cannot carry inside a single config token, or
 // -1 if every character is safe.

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -3614,6 +3614,9 @@ func TestPolicyStatementRouteMapAttributesSetSyntax(t *testing.T) {
 // land on term.Community and CommunityOp would stay empty).
 func TestPolicyCommunityOperationsCompile(t *testing.T) {
 	cmds := []string{
+		// The `then community delete <name>` form references a defined
+		// community-list (#2881 cross-reference gate); define it.
+		"set policy-options community MYLIST members 65000:999",
 		"set policy-options policy-statement P term t_add then community add 65000:111",
 		"set policy-options policy-statement P term t_del then community delete MYLIST",
 		"set policy-options policy-statement P term t_set then community set 65000:222",
@@ -3679,6 +3682,9 @@ func TestPolicyCommunityOperationsCompile(t *testing.T) {
 // dropping listB... RED if applyCommunityAction reads only the first list value.
 func TestPolicyCommunityDeleteMultiListCompile(t *testing.T) {
 	cmds := []string{
+		// The referenced community-lists must be defined (#2881 gate).
+		"set policy-options community listA members 65000:1",
+		"set policy-options community listB members 65000:2",
 		"set policy-options policy-statement P term t_del then community delete [ listA listB ]",
 	}
 	tree := &ConfigTree{}

--- a/pkg/config/policy_community_ref_test.go
+++ b/pkg/config/policy_community_ref_test.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #2881: a policy-statement term's `from community <name>` (rendered FRR
+// `match community <name>`) and `then community delete <name>` (rendered
+// `set comm-list <name> delete`, added in #2848) reference an FRR
+// `bgp community-list <name>` that xpf emits ONLY from a defined
+// `policy-options community <name>`. A reference to an UNDEFINED community
+// otherwise passes commit and breaks frr-reload at apply time (a dangling
+// match/set line fails the WHOLE reload). These gates hard-reject at commit
+// (CompileConfig) and warn-and-boot on the tolerant load path
+// (CompileConfigLenient). Reverting validatePolicyCommunityReferencesStrict
+// turns the reject tests RED.
+//
+// Tests drive the real CompileConfig (strict) / CompileConfigLenient
+// (tolerant) paths via buildTreeFromSet (the shared flat-set helper).
+
+func TestPolicyFromCommunityUndefinedRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement IMPORT term t1 from community NOTDEFINED",
+		"set policy-options policy-statement IMPORT term t1 then accept",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted `from community NOTDEFINED` with no community defined; expected rejection")
+	}
+	for _, want := range []string{"IMPORT", "t1", "NOTDEFINED", "community"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestPolicyFromCommunityDefinedAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options community DEFINED members 65000:100",
+		"set policy-options policy-statement IMPORT term t1 from community DEFINED",
+		"set policy-options policy-statement IMPORT term t1 then accept",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected `from community DEFINED` with the community defined: %v", err)
+	}
+}
+
+func TestPolicyThenCommunityDeleteUndefinedRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement EXPORT term t1 then community delete NOLIST",
+		"set policy-options policy-statement EXPORT term t1 then accept",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted `then community delete NOLIST` with no community defined; expected rejection")
+	}
+	for _, want := range []string{"EXPORT", "t1", "NOLIST", "community"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestPolicyThenCommunityDeleteDefinedAccepted(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options community STRIP-ME members 65000:200",
+		"set policy-options policy-statement EXPORT term t1 then community delete STRIP-ME",
+		"set policy-options policy-statement EXPORT term t1 then accept",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected `then community delete STRIP-ME` with the community defined: %v", err)
+	}
+}
+
+// A multi-list `then community delete [ A B ]` must validate EVERY referenced
+// name — defining only the first must still reject on the second (the #2902
+// multi-value slice is fully walked).
+func TestPolicyThenCommunityDeleteMultiListUndefinedRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options community LISTA members 65000:1",
+		"set policy-options policy-statement EXPORT term t1 then community delete [ LISTA LISTB ]",
+		"set policy-options policy-statement EXPORT term t1 then accept",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a multi-list `then community delete` with one undefined name; expected rejection")
+	}
+	if !strings.Contains(err.Error(), "LISTB") {
+		t.Errorf("error %q missing the undefined community LISTB", err.Error())
+	}
+}
+
+// `then community (set|add) <value>` carries a community VALUE, not a
+// community-list reference, so it must NOT be rejected even with no
+// `policy-options community` defined.
+func TestPolicyThenCommunitySetAddValueNotRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement EXPORT term t1 then community set 65000:300",
+		"set policy-options policy-statement EXPORT term t2 then community add 65000:400",
+		"set policy-options policy-statement EXPORT term t1 then accept",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a `then community set|add <value>` clause (a value, not a list ref): %v", err)
+	}
+}
+
+// Tolerant path: an already-persisted / peer-synced config referencing an
+// undefined community must still BOOT (warn, not error) per the #1960
+// fail-closed-on-load doctrine.
+func TestPolicyCommunityUndefinedLenientWarns(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set policy-options policy-statement IMPORT term t1 from community NOTDEFINED",
+		"set policy-options policy-statement IMPORT term t1 then accept",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on an undefined community reference: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "policy community reference") && strings.Contains(w, "NOTDEFINED") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a downgraded policy-community warning naming NOTDEFINED, got warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/policy_from_multileaf_2689_test.go
+++ b/pkg/config/policy_from_multileaf_2689_test.go
@@ -31,6 +31,10 @@ import "testing"
 
 func TestPolicyFromCommunityBracketFlatSet_2689(t *testing.T) {
 	cfg, err := compileSet(t, []string{
+		// Communities must be defined (#2881) or the from-community
+		// cross-reference gate rejects the term before this assertion runs.
+		"set policy-options community c1 members 65000:1",
+		"set policy-options community c2 members 65000:2",
 		"set policy-options policy-statement P term T from community [ c1 c2 ]",
 		"set policy-options policy-statement P term T then accept",
 	})
@@ -46,6 +50,8 @@ func TestPolicyFromCommunityBracketFlatSet_2689(t *testing.T) {
 
 func TestPolicyFromCommunityBracketHierarchical_2689(t *testing.T) {
 	src := `policy-options {
+    community c1 members 65000:1;
+    community c2 members 65000:2;
     policy-statement P {
         term T {
             from {
@@ -68,6 +74,9 @@ func TestPolicyFromCommunityBracketHierarchical_2689(t *testing.T) {
 // values accumulate, then the sibling appends, neither overwriting the other.
 func TestPolicyFromCommunityBracketPlusSibling_2689(t *testing.T) {
 	cfg, err := compileSet(t, []string{
+		"set policy-options community c1 members 65000:1",
+		"set policy-options community c2 members 65000:2",
+		"set policy-options community c3 members 65000:3",
 		"set policy-options policy-statement P term T from community [ c1 c2 ]",
 		"set policy-options policy-statement P term T from community c3",
 		"set policy-options policy-statement P term T then accept",

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -386,6 +386,24 @@ also carries operator content:
   (uncommon); a literal-only definition stays `standard` (anchored exact
   match) and is unaffected. This is the same fail-closed-the-whole-reload
   class as the route-filter `ge`/`le` bounds above (#1880).
+- **Policy community references are validated at commit (#2881).** A
+  policy-statement term's `from community <name>` renders `match community
+  <name>` and `then community delete <name>` (the strip-by-list operation
+  added in #2848) renders `set comm-list <name> delete`. Both reference an
+  FRR `bgp community-list <name>` that `generatePolicyOptions` emits ONLY
+  for a defined `policy-options community <name>`. With no validation a term
+  naming an UNDEFINED community committed cleanly, then a dangling `match
+  community` / `set comm-list ... delete` line failed the WHOLE `frr-reload`
+  of the managed section (a single `vtysh -f` add-batch exits non-zero on any
+  `CMD_WARNING_CONFIG_FAILED`), leaving dynamic routing stale — a
+  commit-accepted config the routing daemon cannot load.
+  `validatePolicyCommunityReferencesStrict` (`pkg/config`) hard-rejects an
+  undefined `from community` / `then community delete` reference at
+  commit/commit-check, naming the policy, term, and missing community; lenient
+  (warn) on load/HA-sync (#1960). Only NAME references are checked — `then
+  community (set|add) <value>` carries a community VALUE (e.g. `65000:100`),
+  not a list reference, and is not validated. Same fail-closed-the-whole-reload
+  class as the community-list definition gate above.
 - `vtysh -c` is run synchronously in batch mode for state queries. There
   is no streaming; long output is buffered.
 - All `vtysh` and `frr-reload.py` shell-outs route through the

--- a/pkg/frr/frr_test.go
+++ b/pkg/frr/frr_test.go
@@ -1472,6 +1472,9 @@ func TestBGPDualStackGroupActivatesByAddressVersion(t *testing.T) {
 func TestPolicyCommunityOperations(t *testing.T) {
 	tree := &config.ConfigTree{}
 	setCommands := []string{
+		// The `then community delete <name>` form references a defined
+		// community-list (#2881 cross-reference gate); define it.
+		"set policy-options community MYLIST members 65000:999",
 		// add → additive append
 		"set policy-options policy-statement P term t_add from protocol bgp",
 		"set policy-options policy-statement P term t_add then community add 65000:111",
@@ -1551,6 +1554,10 @@ func TestPolicyCommunityOperations(t *testing.T) {
 func TestPolicyCommunityDeleteMultiList(t *testing.T) {
 	tree := &config.ConfigTree{}
 	setCommands := []string{
+		// The referenced community-lists must be defined (#2881 gate).
+		"set policy-options community listA members 65000:1",
+		"set policy-options community listB members 65000:2",
+		"set policy-options community listC members 65000:3",
 		"set policy-options policy-statement P term t_del from protocol bgp",
 		// Bracketed multi-list: the lexer strips the brackets, so this
 		// flattens to delete + [listA listB listC] (the #2419 multi-value


### PR DESCRIPTION
Closes #2881.

## The risk

A policy-statement term's `from community <name>` renders the FRR route-map clause `match community <name>`, and `then community delete <name>` (the strip-by-list operation added in #2848) renders `set comm-list <name> delete`. Both reference an FRR `bgp community-list <name>` that xpf emits **only** from a defined `policy-options community <name>` (`pkg/frr` `generatePolicyOptions`). There was **no** commit-time validation that the referenced community exists.

An operator naming an undefined community committed cleanly, then at FRR render time the dangling `match community` / `set comm-list ... delete` line failed the **whole** `frr-reload` of the managed section — a single `vtysh -f` add-batch exits non-zero on any `CMD_WARNING_CONFIG_FAILED`, so the entire reload aborts and dynamic routing is left stale. That is a commit-accepted config the routing daemon cannot load (#1960 class). The gap is pre-existing on the `from community` path and was widened by #2848 adding the `then community delete` consumer.

## The fix

`validatePolicyCommunityReferencesStrict` (`compiler_validate_strict.go`) runs on the fully-compiled `*Config` (community map populated regardless of authoring order) and hard-rejects an undefined `from community` / `then community delete` reference, naming the policy-statement, term, and missing community.

Strict/lenient split (established #1960 doctrine, mirrors `validateRoutingExportReferencesStrict`):
- **Strict** on `CompileConfig` (commit / commit-check) — hard reject.
- **Lenient** (warn, still boots) on `CompileConfigLenient` + `CompileConfigForNodeLenient` via a new `lenientPolicyCommunityRef` flag, so an already-persisted or peer-synced config keeps booting.

Surgical: only **name** references are validated. `then community (set|add) <value>` and the bare `then community <value>` carry a community **value** (e.g. `65000:100`), not a list reference, and are not checked; a reference to a **defined** community commits unchanged. Multi-value `from community [ a b ]` and `then community delete [ a b ]` slices are each fully walked.

## Validation

- `go build ./...`, `go vet ./pkg/config/... ./pkg/frr/...`, `go test ./pkg/config/... ./pkg/frr/...` — 1806 pass.
- **Fail-on-revert**: removing the validator call turns the three reject tests + the lenient-warn test RED (confirmed RED→GREEN).
- New tests in `pkg/config/policy_community_ref_test.go`: undefined `from community` rejected; defined `from community` commits; undefined `then community delete` (incl. multi-list) rejected; defined `then community delete` commits; `then community set|add <value>` not rejected; lenient path warns-and-boots.
- Pre-existing community-operation/multileaf tests that referenced communities they never defined now define them (kept testing parse/render while satisfying the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi