### PR TITLE
configstore: fix master-CI-red TestCopyConfig under the #3072 multi-zone gate

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,5 @@
+- **2026-06-26T03:54:14Z**: Fix master-CI-red pkg/configstore TestCopyConfig — removed incidental `interfaces eth0.0` from the trust zone fixture. #3072/#3083's interface-multi-zone commit gate (merged this session) correctly rejects a Copy of a zone-with-interface (the interface lands in both trust and trust2). The interface was incidental to the Copy test. File: pkg/configstore/store_test.go
+
 ## 2026-06-25 — #2993: feeds mixed valid/invalid body installs a partial set silently
 - **Action**: parseFeed now counts skipped malformed lines (invalidLines) +
   bounded sample (invalidSample, maxInvalidSample=5); FeedInfo gains

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -1474,8 +1474,13 @@ func TestCopyConfig(t *testing.T) {
 	if err := s.EnterConfigure(); err != nil {
 		t.Fatal(err)
 	}
+	// NOTE: deliberately no `interfaces` under trust here. Copying a zone that
+	// owns an interface would duplicate that interface into trust2, and the
+	// #3072 interface-multi-zone commit gate (correctly) rejects an interface
+	// assigned to two zones — so a zone-with-interface Copy cannot commit. This
+	// test exercises Copy of nested zone content (host-inbound) + that the
+	// copied zone exists, which does not require an interface.
 	cmds := []string{
-		"security zones security-zone trust interfaces eth0.0",
 		"security zones security-zone trust host-inbound-traffic system-services ping",
 	}
 	for _, cmd := range cmds {


### PR DESCRIPTION
## Master CI was RED

`pkg/configstore TestCopyConfig` fails on master (since #3083 merged this session):
```
Commit: commit check failed: interface "eth0.0" is assigned to security zones "trust" and "trust2"; an interface must belong to exactly one security zone
```

#3072/#3083 added a commit-time gate rejecting a multi-zone interface. `TestCopyConfig` set `interfaces eth0.0` under `trust`, then `Copy`'d trust→trust2 (duplicating eth0.0 into both zones); the subsequent `Commit` now correctly fails the gate.

Copying a zone that owns an interface SHOULD fail commit (Junos parity), so the gate is right and the fixture relied on pre-gate behavior. The interface was incidental — TestCopyConfig only asserts both zones exist after Copy + exercises Copy of nested host-inbound content. Drop the interface line + document why.

## Validation
- `go test ./pkg/configstore/` — PASS (was FAIL on TestCopyConfig). Test-only change (+ _Log entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)