### PR TITLE
grpcapi: route ShowText test-policy through pkg/policymatch (Closes #3103)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-06-25 — #3103: gRPC ShowText `test-policy:` routed through pkg/policymatch
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed codex-review-065 finding 065-01. The gRPC `ShowText`
+  `test-policy:` handler (`grpcapi.showTestPolicy`) — the backing handler for
+  the remote `cli` `test policy` command — was the ONE match-policies surface
+  #3042 missed. It still used the pre-#3042 bespoke `matchShowPolicyAddr` /
+  `matchShowPolicyApp` shadow matcher and hard-coded "Default deny" on a miss,
+  so it could report the OPPOSITE verdict from the runtime (missed predefined
+  apps, literal CIDRs, exclusions, feed overlay; ignored `default-policy
+  permit-all`). Rerouted it through `policymatch.Match` (passing the live feed
+  overlay via `Server.feedOverlayFn`, mirroring `MatchPolicies`); deleted the
+  bespoke `matchShowPolicy*` helpers + the now-unused `policyActionName` and the
+  `strconv` import from `server_cluster.go`. Output format preserved except the
+  default line now reflects the configured default-policy.
+- **File(s)**: pkg/grpcapi/server_show_firewall.go,
+  pkg/grpcapi/server_cluster.go, pkg/grpcapi/test_commands_test.go,
+  pkg/grpcapi/server_cluster_test.go, pkg/policymatch/README.md
+- **Validation**: go build/vet clean; `go test ./pkg/grpcapi/...
+  ./pkg/policymatch/... ./pkg/cli/...` 308 pass; gofmt clean. Fail-on-revert
+  proven: restoring origin/master's bespoke matcher turns the new
+  `TestShowTestPolicyAgreesWithRuntimeOnFixedCases` RED on all three sub-cases
+  (predefined-app permit, global-policy fallback, default-policy permit-all).
+- **Note (out of scope)**: `showTestPolicy` parses only `port=` (destination)
+  and `proto=`; it cannot express a source port (#3107) and does not validate
+  the protocol token (#3108). Left untouched for those issues.
+
 ## 2026-06-25 — #2933: commit-time reject ambiguous secure-tunnel bind-interface aliases
 
 - **Timestamp**: 2026-06-25

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/psaab/xpf/pkg/cluster"
@@ -175,121 +174,6 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		DstAddresses: res.DstAddresses,
 		Applications: res.Applications,
 	}, nil
-}
-
-// policyActionName returns a human-readable policy action name.
-func policyActionName(a config.PolicyAction) string {
-	switch a {
-	case 1:
-		return "deny"
-	case 2:
-		return "reject"
-	default:
-		return "permit"
-	}
-}
-
-// matchShowPolicyAddr checks if an IP matches a list of address-book references.
-func matchShowPolicyAddr(addrs []string, ip net.IP, cfg *config.Config) bool {
-	if len(addrs) == 0 || ip == nil {
-		return true
-	}
-	for _, a := range addrs {
-		if a == "any" {
-			return true
-		}
-		if cfg.Security.AddressBook == nil {
-			continue
-		}
-		if addr, ok := cfg.Security.AddressBook.Addresses[a]; ok {
-			_, cidr, err := net.ParseCIDR(addr.Value)
-			if err == nil && cidr.Contains(ip) {
-				return true
-			}
-		}
-		if matchShowPolicyAddrSet(a, ip, cfg, 0) {
-			return true
-		}
-	}
-	return false
-}
-
-func matchShowPolicyAddrSet(setName string, ip net.IP, cfg *config.Config, depth int) bool {
-	if depth > 5 || cfg.Security.AddressBook == nil {
-		return false
-	}
-	as, ok := cfg.Security.AddressBook.AddressSets[setName]
-	if !ok {
-		return false
-	}
-	for _, addrName := range as.Addresses {
-		if addr, ok := cfg.Security.AddressBook.Addresses[addrName]; ok {
-			_, cidr, err := net.ParseCIDR(addr.Value)
-			if err == nil && cidr.Contains(ip) {
-				return true
-			}
-		}
-	}
-	for _, nested := range as.AddressSets {
-		if matchShowPolicyAddrSet(nested, ip, cfg, depth+1) {
-			return true
-		}
-	}
-	return false
-}
-
-// matchShowPolicyApp checks if a protocol/port matches a list of application references.
-func matchShowPolicyApp(apps []string, proto string, dstPort int, cfg *config.Config) bool {
-	if len(apps) == 0 || proto == "" {
-		return true
-	}
-	for _, a := range apps {
-		if a == "any" {
-			return true
-		}
-		if matchShowSingleApp(a, proto, dstPort, cfg) {
-			return true
-		}
-		if cfg.Applications.ApplicationSets != nil {
-			if as, ok := cfg.Applications.ApplicationSets[a]; ok {
-				for _, appRef := range as.Applications {
-					if matchShowSingleApp(appRef, proto, dstPort, cfg) {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-func matchShowSingleApp(appName, proto string, dstPort int, cfg *config.Config) bool {
-	if cfg.Applications.Applications == nil {
-		return false
-	}
-	app, ok := cfg.Applications.Applications[appName]
-	if !ok {
-		return false
-	}
-	if app.Protocol != "" && !strings.EqualFold(app.Protocol, proto) {
-		return false
-	}
-	if app.DestinationPort != "" && dstPort > 0 {
-		if strings.Contains(app.DestinationPort, "-") {
-			parts := strings.SplitN(app.DestinationPort, "-", 2)
-			lo, _ := strconv.Atoi(parts[0])
-			hi, _ := strconv.Atoi(parts[1])
-			if dstPort < lo || dstPort > hi {
-				return false
-			}
-		} else {
-			p, _ := strconv.Atoi(app.DestinationPort)
-			if p != dstPort {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // grpcResolveAddress looks up a named address in the global address book and returns its CIDR suffix.

--- a/pkg/grpcapi/server_cluster_test.go
+++ b/pkg/grpcapi/server_cluster_test.go
@@ -173,9 +173,11 @@ func TestMatchPoliciesValidIPOutsideTermNoFalsePositive(t *testing.T) {
 }
 
 // TestShowTestPolicyRejectsInvalidIP covers the ShowText "test-policy:"
-// simulator (the operational `test policy` command served via gRPC),
-// which is a separate copy of the matcher (matchShowPolicyAddr). A
-// non-empty malformed IP must not produce a "Policy match" line.
+// simulator (the operational `test policy` command served via gRPC).
+// Since #3103 this routes through the shared pkg/policymatch simulator,
+// but it must still reject a non-empty malformed IP rather than collapse
+// it to a wildcard "any" (the #1711 false-positive): such input must not
+// produce a "Policy match" line.
 func TestShowTestPolicyRejectsInvalidIP(t *testing.T) {
 	s := &Server{store: matchPoliciesTestStore(t)}
 

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -21,6 +21,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/policymatch"
 )
 
 // showFirewall renders the `cli show firewall` output. Writes to
@@ -185,69 +186,60 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			proto = parts[1]
 		}
 	}
-	if cfg == nil {
+	switch {
+	case cfg == nil:
 		buf.WriteString("No active configuration\n")
-	} else if fromZone == "" || toZone == "" {
+	case fromZone == "" || toZone == "":
 		buf.WriteString("Missing from/to zone parameters\n")
-	} else if srcIP != "" && net.ParseIP(srcIP) == nil {
-		// A non-empty but malformed src would parse to nil and be treated
-		// as a wildcard by matchShowPolicyAddr, yielding a false-positive
-		// policy match (#1711). Report it instead. Empty still means any.
+	case srcIP != "" && net.ParseIP(srcIP) == nil:
+		// A non-empty but malformed src would otherwise parse to nil and be
+		// treated as a wildcard, yielding a false-positive policy match
+		// (#1711). Report it instead. Empty still means any.
 		fmt.Fprintf(buf, "invalid src %q\n", srcIP)
-	} else if dstIP != "" && net.ParseIP(dstIP) == nil {
+	case dstIP != "" && net.ParseIP(dstIP) == nil:
 		fmt.Fprintf(buf, "invalid dst %q\n", dstIP)
-	} else {
-		parsedSrc := net.ParseIP(srcIP)
-		parsedDst := net.ParseIP(dstIP)
-		found := false
-		for _, zpp := range cfg.Security.Policies {
-			if zpp.FromZone != fromZone || zpp.ToZone != toZone {
-				continue
-			}
-			for _, pol := range zpp.Policies {
-				if !matchShowPolicyAddr(pol.Match.SourceAddresses, parsedSrc, cfg) {
-					continue
-				}
-				if !matchShowPolicyAddr(pol.Match.DestinationAddresses, parsedDst, cfg) {
-					continue
-				}
-				if !matchShowPolicyApp(pol.Match.Applications, proto, dstPort, cfg) {
-					continue
-				}
-				action := policyActionName(pol.Action)
-				fmt.Fprintf(buf, "Policy match:\n")
-				fmt.Fprintf(buf, "  From zone: %s\n  To zone:   %s\n", fromZone, toZone)
-				fmt.Fprintf(buf, "  Policy:    %s\n", pol.Name)
-				fmt.Fprintf(buf, "  Action:    %s\n", action)
-				found = true
-				break
-			}
-			if found {
-				break
-			}
+	default:
+		// #3103: route the gRPC `test policy` diagnostic through the single
+		// shared simulator (pkg/policymatch) so it agrees with the runtime
+		// policy evaluator — zone-pair -> global -> configured default-policy,
+		// with predefined/nested-app-set applications, literal-CIDR /
+		// any-ipv4 / any-ipv6 / address-exclusion / feed-overlay address
+		// matching, and source/destination-port terms. The pre-#3103 bespoke
+		// matchShowPolicy* helpers skipped the configured default-policy
+		// (hard-coded "Default deny"), missed predefined apps and literal
+		// CIDRs, and ignored the feed overlay — exactly the operator-lie class
+		// #3042 removed from the REST/gRPC MatchPolicies and CLI
+		// match-policies surfaces. This was the one surface #3042 missed.
+		var overlay map[string][]string
+		if s.feedOverlayFn != nil {
+			overlay = s.feedOverlayFn()
 		}
-		if !found {
-			// Check global policies
-			for _, pol := range cfg.Security.GlobalPolicies {
-				if !matchShowPolicyAddr(pol.Match.SourceAddresses, parsedSrc, cfg) {
-					continue
-				}
-				if !matchShowPolicyAddr(pol.Match.DestinationAddresses, parsedDst, cfg) {
-					continue
-				}
-				if !matchShowPolicyApp(pol.Match.Applications, proto, dstPort, cfg) {
-					continue
-				}
-				action := policyActionName(pol.Action)
-				fmt.Fprintf(buf, "Policy match (global):\n")
-				fmt.Fprintf(buf, "  Policy:    %s\n", pol.Name)
-				fmt.Fprintf(buf, "  Action:    %s\n", action)
-				found = true
-				break
-			}
-		}
-		if !found {
-			fmt.Fprintf(buf, "Default deny (no matching policy for %s -> %s)\n", fromZone, toZone)
+		res := policymatch.Match(cfg, policymatch.Query{
+			FromZone:    fromZone,
+			ToZone:      toZone,
+			SrcIP:       net.ParseIP(srcIP),
+			DstIP:       net.ParseIP(dstIP),
+			Protocol:    proto,
+			DstPort:     dstPort,
+			FeedOverlay: overlay,
+		})
+		switch {
+		case res.Matched && res.Global:
+			fmt.Fprintf(buf, "Policy match (global):\n")
+			fmt.Fprintf(buf, "  Policy:    %s\n", res.PolicyName)
+			fmt.Fprintf(buf, "  Action:    %s\n", policymatch.ActionString(res.Action))
+		case res.Matched:
+			fmt.Fprintf(buf, "Policy match:\n")
+			fmt.Fprintf(buf, "  From zone: %s\n  To zone:   %s\n", fromZone, toZone)
+			fmt.Fprintf(buf, "  Policy:    %s\n", res.PolicyName)
+			fmt.Fprintf(buf, "  Action:    %s\n", policymatch.ActionString(res.Action))
+		default:
+			// No zone-pair or global policy matched: report the configured
+			// default-policy, NOT a hard-coded "deny" (#3103). When the
+			// default-policy is deny this still reads "Default deny (...)",
+			// preserving the pre-#3103 wording for that case.
+			fmt.Fprintf(buf, "Default %s (no matching policy for %s -> %s)\n",
+				policymatch.ActionString(res.Action), fromZone, toZone)
 		}
 	}
 	return &pb.ShowTextResponse{Output: buf.String()}, nil

--- a/pkg/grpcapi/test_commands_test.go
+++ b/pkg/grpcapi/test_commands_test.go
@@ -1,103 +1,184 @@
 package grpcapi
 
 import (
-	"net"
+	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/policymatch"
 )
 
-func TestPolicyActionName(t *testing.T) {
-	tests := []struct {
-		action config.PolicyAction
-		want   string
-	}{
-		{0, "permit"},
-		{1, "deny"},
-		{2, "reject"},
-		{99, "permit"},
+// testPolicyStore builds an active config from a raw Junos override and
+// returns a configstore.Store with it committed, for driving the gRPC
+// ShowText "test-policy:" handler.
+func testPolicyStore(t *testing.T, override string) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
 	}
-	for _, tt := range tests {
-		got := policyActionName(tt.action)
-		if got != tt.want {
-			t.Errorf("policyActionName(%d) = %q, want %q", tt.action, got, tt.want)
-		}
+	if err := store.LoadOverride(override); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
 	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
 }
 
-func TestMatchShowPolicyAddr(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.Security.AddressBook = &config.AddressBook{
-		Addresses: map[string]*config.Address{
-			"trust-net": {Value: "10.0.1.0/24"},
-			"server1":   {Value: "192.168.1.1/32"},
-		},
-		AddressSets: map[string]*config.AddressSet{
-			"all-internal": {Addresses: []string{"trust-net", "server1"}},
-		},
+func showTestPolicyOutput(t *testing.T, store *configstore.Store, topic string) string {
+	t.Helper()
+	s := &Server{store: store}
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+	if err != nil {
+		t.Fatalf("ShowText(%q) error = %v", topic, err)
 	}
+	return resp.GetOutput()
+}
 
-	tests := []struct {
-		name  string
-		addrs []string
-		ip    net.IP
-		want  bool
+// TestShowTestPolicyAgreesWithRuntimeOnFixedCases is the #3103 fail-on-revert
+// guard. Before #3103 the gRPC ShowText "test-policy:" handler used a bespoke
+// shadow matcher (matchShowPolicyAddr / matchShowPolicyApp) that diverged from
+// the runtime evaluator. Each sub-case below is one the OLD matcher got wrong:
+//
+//   - predefined-app permit: the old matcher read only
+//     cfg.Applications.Applications, so a predefined Junos application
+//     (junos-http) never matched and the case fell through to "Default deny";
+//   - global-policy fallback: the old matcher looped only the zone-pair sets,
+//     never cfg.Security.GlobalPolicies, so a global policy was reported as
+//     "Default deny";
+//   - default-policy permit-all: the old matcher hard-coded "Default deny" on
+//     a miss even when `default-policy permit-all` was configured.
+//
+// Routing through pkg/policymatch (the same simulator the REST/gRPC
+// MatchPolicies and CLI surfaces use since #3042) makes ShowText agree with
+// the runtime. We assert the rendered ShowText output AND cross-check it
+// against policymatch.Match directly so reverting showTestPolicy to the
+// bespoke matcher turns this RED.
+func TestShowTestPolicyAgreesWithRuntimeOnFixedCases(t *testing.T) {
+	cases := []struct {
+		name       string
+		override   string
+		topic      string
+		wantSubstr []string // all must be present in the ShowText output
+		notSubstr  []string // none may be present
+		// policymatch cross-check inputs (the runtime ground truth):
+		query      policymatch.Query
+		wantAction config.PolicyAction
 	}{
-		{"any matches", []string{"any"}, net.ParseIP("1.2.3.4"), true},
-		{"empty addrs matches", nil, net.ParseIP("1.2.3.4"), true},
-		{"nil IP matches", []string{"trust-net"}, nil, true},
-		{"addr match", []string{"trust-net"}, net.ParseIP("10.0.1.50"), true},
-		{"addr no match", []string{"trust-net"}, net.ParseIP("10.0.2.50"), false},
-		{"addr-set match", []string{"all-internal"}, net.ParseIP("192.168.1.1"), true},
-		{"addr-set no match", []string{"all-internal"}, net.ParseIP("172.16.0.1"), false},
+		{
+			name: "predefined-app permit",
+			override: `
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy allow-http {
+                match { source-address any; destination-address any; application junos-http; }
+                then { permit; }
+            }
+        }
+    }
+}
+`,
+			// junos-http is a PREDEFINED application (tcp/80). The old matcher
+			// only knew about user applications, so it missed this entirely.
+			topic:      "test-policy:from=trust,to=untrust,src=10.0.1.1,dst=10.0.2.1,port=80,proto=tcp",
+			wantSubstr: []string{"Policy match:", "Policy:    allow-http", "Action:    permit"},
+			notSubstr:  []string{"Default", "global"},
+			query: policymatch.Query{
+				FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80,
+			},
+			wantAction: config.PolicyPermit,
+		},
+		{
+			name: "global-policy fallback",
+			override: `
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        global {
+            policy global-allow {
+                match { source-address any; destination-address any; application junos-http; }
+                then { permit; }
+            }
+        }
+    }
+}
+`,
+			// Only a global policy exists, and it matches on a PREDEFINED app
+			// (junos-http). The old matcher's global loop used the user-apps-only
+			// matchShowPolicyApp, so junos-http never matched and it reported
+			// "Default deny". The new path resolves predefined apps and matches
+			// the global rule.
+			topic:      "test-policy:from=trust,to=untrust,src=10.0.1.1,dst=10.0.2.1,port=80,proto=tcp",
+			wantSubstr: []string{"Policy match (global):", "Policy:    global-allow", "Action:    permit"},
+			notSubstr:  []string{"Default"},
+			query: policymatch.Query{
+				FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80,
+			},
+			wantAction: config.PolicyPermit,
+		},
+		{
+			name: "default-policy permit-all",
+			override: `
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy permit-all;
+    }
+}
+`,
+			// No matching policy: the runtime applies the configured
+			// default-policy (permit-all). The old matcher hard-coded
+			// "Default deny" here — the opposite verdict.
+			topic:      "test-policy:from=trust,to=untrust,src=10.0.1.1,dst=10.0.2.1,port=80,proto=tcp",
+			wantSubstr: []string{"Default permit"},
+			notSubstr:  []string{"Default deny", "Policy match"},
+			query: policymatch.Query{
+				FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80,
+			},
+			wantAction: config.PolicyPermit,
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := matchShowPolicyAddr(tt.addrs, tt.ip, cfg)
-			if got != tt.want {
-				t.Errorf("matchShowPolicyAddr(%v, %v) = %v, want %v", tt.addrs, tt.ip, got, tt.want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := testPolicyStore(t, tc.override)
+			out := showTestPolicyOutput(t, store, tc.topic)
+			for _, want := range tc.wantSubstr {
+				if !strings.Contains(out, want) {
+					t.Errorf("ShowText output missing %q\n--- got ---\n%s", want, out)
+				}
 			}
-		})
-	}
-}
+			for _, bad := range tc.notSubstr {
+				if strings.Contains(out, bad) {
+					t.Errorf("ShowText output unexpectedly contains %q\n--- got ---\n%s", bad, out)
+				}
+			}
 
-func TestMatchShowPolicyApp(t *testing.T) {
-	cfg := &config.Config{}
-	cfg.Applications.Applications = map[string]*config.Application{
-		"junos-http":   {Protocol: "tcp", DestinationPort: "80"},
-		"junos-ssh":    {Protocol: "tcp", DestinationPort: "22"},
-		"custom-range": {Protocol: "tcp", DestinationPort: "8000-9000"},
-	}
-	cfg.Applications.ApplicationSets = map[string]*config.ApplicationSet{
-		"web-apps": {Applications: []string{"junos-http"}},
-	}
-
-	tests := []struct {
-		name    string
-		apps    []string
-		proto   string
-		dstPort int
-		want    bool
-	}{
-		{"any matches", []string{"any"}, "tcp", 80, true},
-		{"empty apps matches", nil, "tcp", 80, true},
-		{"empty proto matches", []string{"junos-http"}, "", 80, true},
-		{"exact app match", []string{"junos-http"}, "tcp", 80, true},
-		{"app wrong port", []string{"junos-http"}, "tcp", 443, false},
-		{"app wrong proto", []string{"junos-http"}, "udp", 80, false},
-		{"range match", []string{"custom-range"}, "tcp", 8080, true},
-		{"range no match", []string{"custom-range"}, "tcp", 7999, false},
-		{"app-set match", []string{"web-apps"}, "tcp", 80, true},
-		{"app-set no match", []string{"web-apps"}, "tcp", 22, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := matchShowPolicyApp(tt.apps, tt.proto, tt.dstPort, cfg)
-			if got != tt.want {
-				t.Errorf("matchShowPolicyApp(%v, %q, %d) = %v, want %v",
-					tt.apps, tt.proto, tt.dstPort, got, tt.want)
+			// Cross-check against the shared simulator (the runtime ground
+			// truth). The ShowText handler MUST agree with it.
+			cfg := store.ActiveConfig()
+			res := policymatch.Match(cfg, tc.query)
+			if res.Action != tc.wantAction {
+				t.Errorf("policymatch action = %v, want %v", res.Action, tc.wantAction)
+			}
+			if got := policymatch.ActionString(res.Action); !strings.Contains(out, got) {
+				t.Errorf("ShowText output %q does not contain runtime action %q", out, got)
 			}
 		})
 	}

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -5,10 +5,27 @@ Single operator-side security-policy simulator shared by every
 
 - REST `GET /api/v1/security/match` (`pkg/api` `matchPoliciesHandler`)
 - gRPC `MatchPolicies` (`pkg/grpcapi`)
+- gRPC `ShowText` `test-policy:` topic (`pkg/grpcapi` `showTestPolicy`) — the
+  backing handler for the operational `test policy` CLI command
 - CLI `show security match-policies` and `test policy` (`pkg/cli`)
 
 Each surface is a THIN adapter: it parses/validates inputs and renders the
 verdict, then delegates the matching to `policymatch.Match`.
+
+## The surface #3042 missed (#3103)
+
+The original #3042 consolidation routed the REST/gRPC `MatchPolicies` and CLI
+`match-policies`/`test policy` paths through this package but left the gRPC
+`ShowText` `test-policy:` handler (`grpcapi.showTestPolicy`) on its own pre-#3042
+bespoke matcher (`matchShowPolicyAddr`/`matchShowPolicyApp`). That handler is
+what the remote `cli` binary's `test policy` command actually drives, so a remote
+operator could still be told `Default deny` while the dataplane permits under
+`default-policy permit-all`, or miss a predefined-app / global / literal-CIDR /
+feed-backed match. #3103 made `showTestPolicy` a thin adapter too (passing the
+daemon's live feed overlay via `Server.feedOverlayFn`, mirroring `MatchPolicies`)
+and deleted the bespoke helpers. Its rendered output format is unchanged except
+the formerly hard-coded `Default deny` line now reflects the configured
+default-policy (`Default permit`/`Default deny`/`Default reject`).
 
 ## Why this exists (#3042)
 


### PR DESCRIPTION
Closes #3103.

## The last divergent shadow matcher

The gRPC `ShowText` `test-policy:` handler (`grpcapi.showTestPolicy`,
`pkg/grpcapi/server_show_firewall.go`) was the ONE `match-policies` surface that
the #3042 shared-matcher consolidation missed. It still carried the pre-#3042
bespoke shadow matcher (`matchShowPolicyAddr` / `matchShowPolicyApp` in
`server_cluster.go`) and hard-coded `Default deny` on a miss.

This is not a dead path: it is the gRPC backing for the remote `cli` binary's
`test policy` command (`cmd/cli/main.go` builds the
`test-policy:from=...,to=...` topic and prints the returned text verbatim). The
bespoke matcher was materially narrower than `policymatch.Match`:

- never honored a configured `default-policy permit-all`/`reject` (always
  `Default deny`);
- no source/destination address-exclusion, no `any-ipv4`/`any-ipv6`, no literal
  CIDR / bare IP tokens, no dynamic-address feed overlay;
- no predefined applications, only one application-set level, string-only
  protocol comparison.

So a remote operator running `test policy` could be told `Default deny` while
the dataplane permits — exactly the operator-lie class #3042 removed from the
REST/gRPC `MatchPolicies` and CLI surfaces.

## The policymatch consolidation

`showTestPolicy` is now a thin adapter over `policymatch.Match`, mirroring how
#3042 built the REST `matchPoliciesHandler` / gRPC `MatchPolicies` / CLI
adapters. It passes the daemon's live feed overlay via `Server.feedOverlayFn`
(same as `MatchPolicies`). The bespoke `matchShowPolicy*` helpers, the now-unused
`grpcapi.policyActionName`, and the orphaned `strconv` import are deleted.

Output format is preserved (the `ShowText` golden test for the zone-pair permit
case is unchanged) except where the old text was WRONG: the formerly hard-coded
`Default deny` line now reflects the configured default-policy — `Default permit`
/ `Default deny` / `Default reject`. The #1711 invalid-src/dst guard is retained.

## Validation

- `go build ./...`, `go vet ./pkg/grpcapi/... ./pkg/policymatch/...` clean.
- `go test ./pkg/grpcapi/... ./pkg/policymatch/... ./pkg/cli/...` = 308 pass.
- `gofmt -l` clean on all touched files.
- **Fail-on-revert proven:** `TestShowTestPolicyAgreesWithRuntimeOnFixedCases`
  drives the handler via `ShowText` and cross-checks it against
  `policymatch.Match` for the three cases the old matcher got wrong — a
  predefined-app (junos-http) zone-pair permit, a predefined-app global-policy
  fallback, and `default-policy permit-all`. Restoring origin/master's bespoke
  matcher turns all three RED (predefined-app + global fall to `Default deny`;
  default-policy shows `Default deny` instead of `Default permit`).

## Out of scope (noted)

`showTestPolicy` parses only a destination `port=` and an unvalidated `proto=`
token. Source-port expression is #3107 and invalid-protocol validation is #3108;
both are left untouched here — this PR is scoped to the #3103 routing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi