### PR TITLE
config schema: declare security-policy scheduler-name leaf (#3117)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-06-25 — #3117: security-policy `scheduler-name` added to set-schema
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed codex-review-066 finding 066-05. A security-policy
+  `scheduler-name <name>` is compiled (`compiler_security.go`, both zone-pair
+  and global policies) and an undefined reference is strict-rejected at commit
+  (`validatePolicySchedulerReferencesStrict`), but the leaf was ABSENT from
+  `setSchema` — so it had no structural / value-slot `?` completion, violating
+  the two-SSOT rule that every compiled + validated leaf lives in the schema
+  tree. Declared `scheduler-name` under both the zone-pair policy node and the
+  global policy node as an untyped (plain string) leaf, sibling of
+  `description`/`match`/`then`. The strict reference check remains the SSOT for
+  undefined-scheduler rejection (no `treeValidator` added; no compiler/validator
+  behaviour change). Added fail-on-revert completion + schema-accept tests.
+- **File(s)**: pkg/config/schema_security.go,
+  pkg/config/schema_scheduler_name_3117_test.go, docs/config-schema.md, _Log.md
+
 ## 2026-06-25 — #3103: gRPC ShowText `test-policy:` routed through pkg/policymatch
 
 - **Timestamp**: 2026-06-25

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1250,6 +1250,30 @@ an undefined from-zone and to-zone, `TestPolicySpecialZoneTokensCommit` —
 `any`/`junos-host`/global anti-over-reject, `TestPolicyDefinedZonesCommit`,
 `TestPolicyUndefinedZoneLenientDowngradesToWarning`).
 
+### #3117 — Security-policy `scheduler-name` schema leaf (completion parity)
+
+A security-policy `scheduler-name <name>` binds a class-of-service scheduler
+to the policy. It is compiled — `compiler_security.go`
+(`polInst.node.FindChild("scheduler-name")` → `nodeVal`, read for BOTH
+zone-pair and global policies) — and an undefined reference is strict-rejected
+at commit by `validatePolicySchedulerReferencesStrict`
+(`compiler_validate_strict.go`, downgraded to a warning on the tolerant load /
+peer-sync paths via `compiler_validate_warn.go`). The leaf was nonetheless
+ABSENT from `setSchema`, so `set security policies ... policy <p> scheduler-name`
+had no structural / value-slot `?` completion — a violation of the two-SSOT
+rule that every compiled + validated leaf is declared in the schema tree.
+
+The fix declares `scheduler-name` under both the zone-pair policy node and the
+global policy node in `pkg/config/schema_security.go`, as a sibling of
+`description`/`match`/`then`. It is an **untyped (plain string) leaf** like
+`description`: the compiler consumes the raw token, and the strict
+undefined-scheduler reference check remains the SSOT for rejection (no
+`treeValidator` is added, so completion and validation stay in agreement and
+no compiler/validator behaviour changes). Regression coverage:
+`pkg/config/schema_scheduler_name_3117_test.go` — the leaf is offered by
+`CompleteSetPathWithValues` for zone-pair and global policies (fail-on-revert),
+and the declared form passes `SchemaValidate` without a false reject.
+
 ### #2391 — Security-zone count cap (commit fail-closed)
 
 Security-zone ids are assigned sequentially `1..N` over the sorted zone names

--- a/pkg/config/schema_scheduler_name_3117_test.go
+++ b/pkg/config/schema_scheduler_name_3117_test.go
@@ -1,0 +1,64 @@
+package config
+
+// #3117: a security-policy `scheduler-name <name>` is compiled
+// (compiler_security.go) and strict-validated against the defined
+// class-of-service schedulers (compiler_validate_strict.go
+// validatePolicySchedulerReferencesStrict), but it was ABSENT from
+// setSchema — so the leaf had no structural / `?` completion, violating
+// the two-SSOT rule that every compiled + validated leaf lives in the
+// schema tree. These tests assert the leaf is now offered by config-mode
+// completion for BOTH zone-pair and global policies. Reverting the schema
+// addition turns them RED (the leaf would no longer be a known child),
+// which is the fail-on-revert guard.
+
+import "testing"
+
+// TestSchema3117_SchedulerName_ZonePairCompletion asserts scheduler-name
+// is offered as a child of a zone-pair policy node alongside its
+// description/match/then siblings.
+func TestSchema3117_SchedulerName_ZonePairCompletion(t *testing.T) {
+	results := CompleteSetPathWithValues(
+		[]string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p1"}, nil)
+	if !containsCompletionName(results, "scheduler-name") {
+		t.Fatalf("expected zone-pair policy completion to offer scheduler-name, got %v", completionNames(results))
+	}
+	// Sanity: the established sibling leaves are still present (guards
+	// against an edit that displaces the policy subtree wholesale).
+	if !containsCompletionName(results, "then") || !containsCompletionName(results, "match") {
+		t.Fatalf("expected policy subtree siblings (then, match), got %v", completionNames(results))
+	}
+}
+
+// TestSchema3117_SchedulerName_GlobalCompletion asserts the same for
+// global policies.
+func TestSchema3117_SchedulerName_GlobalCompletion(t *testing.T) {
+	results := CompleteSetPathWithValues(
+		[]string{"security", "policies", "global", "policy", "p1"}, nil)
+	if !containsCompletionName(results, "scheduler-name") {
+		t.Fatalf("expected global policy completion to offer scheduler-name, got %v", completionNames(results))
+	}
+}
+
+// TestSchema3117_SchedulerName_FlatSchemaAccepts confirms the declared
+// leaf validates cleanly via the flat-set typed-leaf gate (no false
+// reject), matching how sibling schema leaves are exercised. The strict
+// undefined-scheduler reference check remains the SSOT for rejection and
+// is not duplicated here.
+func TestSchema3117_SchedulerName_FlatSchemaAccepts(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{
+		"set security policies from-zone trust to-zone untrust policy p1 scheduler-name sched1",
+		"set security policies global policy g1 scheduler-name sched1",
+	} {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q) failed: %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q) failed: %v", cmd, err)
+		}
+	}
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("expected scheduler-name leaves to pass schema validation, got: %v", err)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -48,6 +48,19 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 					"log": {desc: "Log session", children: nil},
 					// permit, deny, reject, count → leaf
 				}},
+				// #3117: `scheduler-name <name>` binds a class-of-service
+				// scheduler to the policy. The compiler reads it as a plain
+				// string (compiler_security.go: polInst.node.FindChild(
+				// "scheduler-name") → nodeVal) and the strict validator
+				// rejects an undefined reference (compiler_validate_strict.go
+				// validatePolicySchedulerReferencesStrict). It was absent from
+				// setSchema, so the leaf had no structural/`?` completion —
+				// inconsistent with the two-SSOT rule that every compiled +
+				// validated leaf lives in the schema tree. Untyped (plain
+				// string) like `description`: the compiler consumes the raw
+				// token and the strict reference check stays the SSOT for
+				// undefined-scheduler rejection (no treeValidator here).
+				"scheduler-name": {desc: "Class-of-service scheduler bound to this policy", args: 1, placeholder: "<scheduler-name>", children: nil},
 			}},
 		}},
 		"global": {desc: "Global policies", children: map[string]*schemaNode{
@@ -63,6 +76,9 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				"then": {desc: "Action", children: map[string]*schemaNode{
 					"log": {desc: "Log session", children: nil},
 				}},
+				// #3117: scheduler-name on global policies — same compiler +
+				// strict-validator path as the zone-pair policy above.
+				"scheduler-name": {desc: "Class-of-service scheduler bound to this policy", args: 1, placeholder: "<scheduler-name>", children: nil},
 			}},
 		}},
 	}},


### PR DESCRIPTION
Closes #3117 (provenance: codex-review-066 finding 066-05).

## Schema gap
A security-policy `scheduler-name <name>` binds a class-of-service scheduler to
the policy. It is already **compiled** — `compiler_security.go` reads
`polInst.node.FindChild("scheduler-name")` → `nodeVal` for BOTH zone-pair and
global policies — and an undefined reference is **strict-rejected at commit** by
`validatePolicySchedulerReferencesStrict` (`compiler_validate_strict.go`,
downgraded to a warning on the tolerant load / peer-sync paths in
`compiler_validate_warn.go`). But the leaf was **absent from `setSchema`**, so
`set security policies ... policy <p> scheduler-name` had no structural /
value-slot `?` completion. That violates the two-SSOT rule (#1319): every
compiled + validated leaf must be declared in the schema tree so completion and
validation agree.

## Fix (surgical)
Declare `scheduler-name` under **both** the zone-pair policy node and the global
policy node in `pkg/config/schema_security.go`, as a sibling of
`description`/`match`/`then`. It is an **untyped (plain string) leaf** like
`description`:
- the compiler consumes the raw token (`nodeVal`), so the schema matches exactly
  what is compiled;
- the strict undefined-scheduler reference check stays the **SSOT** for
  rejection — no `treeValidator` is added, so completion and validation agree
  and **no compiler/validator behaviour changes**.

The leaf path matches exactly where the compiler + strict validator read it
(direct child of the policy node, zone-pair and global).

## Validation
- `go build ./...`, `go vet ./pkg/config/...`, `go test ./pkg/config/...` —
  1588 passed; `gofmt` clean.
- Fail-on-revert: removing either schema leaf turns
  `TestSchema3117_SchedulerName_ZonePairCompletion` /
  `..._GlobalCompletion` **RED** (`got [description match then]`), confirmed
  RED→GREEN. `..._FlatSchemaAccepts` proves the declared form passes
  `SchemaValidate` without a false reject.

Docs: `docs/config-schema.md` gains a #3117 section; `_Log.md` prepended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi