### PR TITLE
ddns/surface-a: fail closed on corrupt ownership state (#2971)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-06-25 — #2971: Surface A DDNS corrupt ownership state fail-closed
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fixed #2971 (codex-review-057 finding 057-03). The Surface A
+  router-record `SurfaceAManager` bypassed the #2650 degraded/quarantine
+  wrapper: `NewSurfaceAManager` called `loadDDNSState` directly and, on a load
+  error, logged a warning and proceeded with the returned EMPTY store — fail
+  OPEN. An empty trusted store made every configured scope look unowned, so the
+  next reconcile re-published EVERY scope (a write storm) — overwriting a
+  peer/manual owner and forgetting what to withdraw. Fix: load through the same
+  `loadStateOrDegrade` gate (added `degraded`/`degradedReason` to
+  `SurfaceAManager` + `SurfaceAStats`); `Reconcile` now fails CLOSED while
+  degraded (no publish/withdraw/save, error returned). A MISSING file (first
+  boot, incl. standalone nil-gate) stays non-degraded and publishes normally.
+  Surfaced as a CLI + gRPC `show services dynamic-dns` ALARM and a new
+  `xpf_ddns_surface_a_degraded` Prometheus gauge.
+- **File(s)**: pkg/ddns/surface_a.go, pkg/ddns/surface_a_test.go,
+  pkg/cli/cli_show_services.go, pkg/grpcapi/server_show_dhcp_lldp_snmp.go,
+  pkg/api/metrics.go, pkg/api/metrics_descriptors.go, pkg/api/metrics_system.go,
+  pkg/ddns/README.md
+- **Validation**: go build ./...; go vet ./pkg/ddns/...; go test
+  ./pkg/ddns/... ./pkg/daemon/... ./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/...
+  all green; new TestSurfaceACorruptStateFailsClosed +
+  TestSurfaceAUnsupportedVersionFailsClosed go RED when the constructor is
+  reverted to fail-open (the revert log shows the spurious "published record"
+  write); TestSurfaceAAbsentStateFirstBootStandaloneWrites stays green on revert.
+
 ## 2026-06-25 — #3117: security-policy `scheduler-name` added to set-schema
 
 - **Timestamp**: 2026-06-25

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -89,6 +89,7 @@ type xpfCollector struct {
 	surfaceADDNSDeletesTotal *prometheus.Desc
 	surfaceADDNSSkippedTotal *prometheus.Desc
 	surfaceADDNSScopes       *prometheus.Desc
+	surfaceADDNSDegraded     *prometheus.Desc
 
 	// System metrics
 	sysCPUUser   *prometheus.Desc
@@ -501,6 +502,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.surfaceADDNSDeletesTotal
 	ch <- c.surfaceADDNSSkippedTotal
 	ch <- c.surfaceADDNSScopes
+	ch <- c.surfaceADDNSDegraded
 	ch <- c.sysCPUUser
 	ch <- c.sysCPUSystem
 	ch <- c.sysMemTotal

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -288,6 +288,12 @@ func newCollector(srv *Server) *xpfCollector {
 			"Current number of Surface A DDNS records this node owns in DNS.",
 			nil, nil,
 		),
+		surfaceADDNSDegraded: prometheus.NewDesc(
+			"xpf_ddns_surface_a_degraded",
+			"1 when the Surface A DDNS ownership state is unloadable and the "+
+				"manager is fail-closed (publishing/withdrawals suspended), else 0.",
+			nil, nil,
+		),
 
 		sysCPUUser: prometheus.NewDesc(
 			"xpf_system_cpu_user_percent",

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -112,6 +112,11 @@ func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.SkippedNoBackend), "no-backend")
 	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSScopes, prometheus.GaugeValue,
 		float64(st.Scopes))
+	var degraded float64
+	if st.Degraded {
+		degraded = 1
+	}
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSDegraded, prometheus.GaugeValue, degraded)
 }
 
 // collectFlowExportMetrics emits the xpf_flow_export_collector_* family

--- a/pkg/cli/cli_show_services.go
+++ b/pkg/cli/cli_show_services.go
@@ -134,6 +134,10 @@ func (c *CLI) showServicesDynamicDNS(detail bool) error {
 		fmt.Println("\n  Runtime counters: unavailable (manager not running)")
 		return nil
 	}
+	if st.Degraded {
+		fmt.Printf("\n  ALARM: Surface A DDNS DEGRADED (fail-closed) — %s\n", st.DegradedReason)
+		fmt.Println("    Publishing and withdrawals are SUSPENDED until the ownership state is resolved.")
+	}
 	fmt.Println("\n  Counters:")
 	fmt.Printf("    Publishes: ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
 	fmt.Printf("    Withdraws: ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -191,6 +191,25 @@ no change in those packages:
   state is surfaced as a `show ... dynamic-dns` ALARM and the
   `xpf_dhcp_ddns_degraded` Prometheus gauge so the lost cleanup authority is
   never silent.
+- **Surface A ownership state fails CLOSED too (#2971)** — the Surface A
+  (router/interface-address) `SurfaceAManager` previously BYPASSED the #2650
+  wrapper: `NewSurfaceAManager` called `loadDDNSState` directly and, on any load
+  error, logged a warning and proceeded with the returned EMPTY store — fail
+  OPEN. An empty trusted store made every configured scope look unowned, so the
+  next `Reconcile` re-published EVERY scope (a write storm) — overwriting a
+  peer/manual owner (the lost ownership can no longer veto the re-claim) and
+  forgetting the records it can no longer withdraw. `NewSurfaceAManager` (and the
+  test constructor) now load through the SAME `loadStateOrDegrade` gate: a corrupt
+  / unsupported-version / unreadable file sets `SurfaceAManager.degraded` (+
+  quarantines a corrupt/unsupported file aside), and `Reconcile` then refuses the
+  WHOLE pass (no publish, no withdraw, no `save()` — the bad file is preserved)
+  until the operator resolves it. A MISSING file (first boot) is NOT degraded, so
+  a fresh node — including a STANDALONE (nil-gate) node — still publishes
+  normally; a restart with the bad file quarantined aside re-reads an absent
+  (clean-empty) store and resumes publishing. The degraded state is surfaced as a
+  `show services dynamic-dns` Surface A ALARM (CLI + gRPC) and the
+  `xpf_ddns_surface_a_degraded` Prometheus gauge, and on `SurfaceAStats.Degraded`
+  / `DegradedReason`.
 - **No secret in any error string** (TSIG secret revealed only at construction).
 
 The HA writer gate (`ddnsWriterGateOpen`) stays in `pkg/daemon/daemon_ddns.go`

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -233,6 +233,20 @@ type SurfaceAManager struct {
 	mu    sync.Mutex
 	state *ddnsState // durable ownership store (interface-ddns-state.json)
 
+	// degraded fails the manager CLOSED when the ownership state file could not
+	// be loaded (corrupt / unsupported-version / unreadable, #2971). It mirrors
+	// the DHCP-lease Manager's #2650 posture: the durable store is the ONLY
+	// authority for which router records this node published, so a load failure
+	// must NOT be treated as "owns nothing" (fail-open) — that empty store would
+	// re-publish every scope (overwriting a peer/manual owner, a write storm) and
+	// permanently forget what to withdraw. While degraded, Reconcile is a
+	// no-op-with-error: no publish, no withdraw, no save (the empty in-memory
+	// store is never written, so a corrupt/quarantined file is preserved). A
+	// MISSING file (first boot) is NOT degraded — it is a legitimately-empty
+	// store, so a fresh (including standalone) node still publishes normally.
+	degraded       bool
+	degradedReason string
+
 	// runtime is the per-scope engine state (change-detect / forced-refresh /
 	// backoff), keyed by scopeID. NOT persisted: it is rebuilt on restart from
 	// the durable store (seedFromStore) so a restart does not blast a redundant
@@ -278,20 +292,24 @@ type SurfaceAManager struct {
 }
 
 // NewSurfaceAManager constructs the production Surface A manager (plan §5.5). It
-// loads the durable ownership store from defaultSurfaceAStatePath (a corrupt
-// store is reset to empty, fail-open) and resolves the live RFC 2136 backend
-// per provider at reconcile time. The runtime cache is seeded from the durable
-// store so a restart does not republish an unchanged address.
+// loads the durable ownership store from defaultSurfaceAStatePath. A corrupt /
+// unsupported-version / unreadable store puts the manager into the FAIL-CLOSED
+// degraded state (#2971, mirroring the DHCP-lease Manager's #2650 posture): the
+// manager is still constructible (the daemon starts) but Reconcile refuses to
+// publish or withdraw any record until the operator resolves the bad file
+// (corrupt/unsupported files are quarantined aside). A MISSING file (first boot)
+// is NOT degraded — a fresh node publishes normally. It resolves the live RFC
+// 2136 backend per provider at reconcile time. The runtime cache is seeded from
+// the durable store so a restart does not republish an unchanged address.
 func NewSurfaceAManager() *SurfaceAManager {
-	st, err := loadDDNSState(defaultSurfaceAStatePath)
-	if err != nil {
-		slog.Warn("ddns surface-a: ownership state load failed; starting empty", "err", err)
-	}
+	st, degraded, reason := loadStateOrDegrade(defaultSurfaceAStatePath, time.Now)
 	m := &SurfaceAManager{
-		state:       st,
-		runtime:     map[string]*surfaceAState{},
-		httpClients: newHTTPClientCache(),
-		now:         time.Now,
+		state:          st,
+		degraded:       degraded,
+		degradedReason: reason,
+		runtime:        map[string]*surfaceAState{},
+		httpClients:    newHTTPClientCache(),
+		now:            time.Now,
 	}
 	// resolveBackend closes over the manager's per-binding HTTP client cache
 	// (#2904) so every HTTP backend the reconcile path builds reuses the cached
@@ -303,14 +321,24 @@ func NewSurfaceAManager() *SurfaceAManager {
 
 // newSurfaceAManagerForTesting builds a manager with an in-memory state file
 // path, an injected backend, and an injectable clock — no real /var/lib path,
-// no network. Used by surface_a_test.go.
+// no network. Used by surface_a_test.go. It loads the durable store through the
+// SAME loadStateOrDegrade gate as production (#2971), so a corrupt/unreadable
+// state file at statePath drives the manager into the fail-closed degraded state
+// in tests exactly as it would in production; a missing file (the common case)
+// yields a clean empty store.
 func newSurfaceAManagerForTesting(statePath string, backend DNSUpdater, now func() time.Time) *SurfaceAManager {
-	st, _ := loadDDNSState(statePath)
+	nowFn := now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	st, degraded, reason := loadStateOrDegrade(statePath, nowFn)
 	m := &SurfaceAManager{
-		state:   st,
-		runtime: map[string]*surfaceAState{},
-		backend: backend,
-		now:     now,
+		state:          st,
+		degraded:       degraded,
+		degradedReason: reason,
+		runtime:        map[string]*surfaceAState{},
+		backend:        backend,
+		now:            now,
 	}
 	m.seedFromStore()
 	return m
@@ -500,6 +528,22 @@ func (m *SurfaceAManager) providerIO(fn func() error) error {
 func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope, observe AddressObserver, gate ScopeGate, catalog map[string]*config.DDNSProvider) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// FAIL CLOSED (#2971, mirroring the DHCP-lease #2650 gate): the ownership
+	// state could not be loaded, so we cannot prove which router records this
+	// node published. Acting now is unsafe — a publish could overwrite a
+	// peer/manual owner (the lost ownership can no longer veto the re-claim) and
+	// would re-publish EVERY configured scope every pass (a write storm), while a
+	// withdraw has no trustworthy owned set to delete against. Refuse the whole
+	// pass and DO NOT touch the state file: the empty in-memory store is never
+	// saved, so the corrupt/quarantined file is preserved for the operator. A
+	// standalone (nil gate) node fails closed the same way — losing the only
+	// authority is no safer without a peer; a restart with the bad file
+	// quarantined aside re-reads an absent (clean-empty) store and resumes
+	// publishing.
+	if m.degraded {
+		return fmt.Errorf("ddns surface-a: reconcile suspended (state degraded): %s", m.degradedReason)
+	}
 
 	now := m.now()
 	var firstErr error
@@ -1155,6 +1199,13 @@ type SurfaceAStats struct {
 	Skipped          uint64
 	BackedOff        uint64
 	SkippedNoBackend uint64
+	// Degraded is the FAIL-CLOSED alarm (#2971): the ownership state file could
+	// not be loaded (corrupt / unsupported-version / unreadable), so Reconcile
+	// refuses every publish/withdraw until the operator resolves it.
+	Degraded bool
+	// DegradedReason is a human-readable explanation of Degraded (the load error
+	// plus the quarantine path of the bad file, if any). Empty when not degraded.
+	DegradedReason string
 }
 
 // Stats returns the current Surface A counters.
@@ -1170,6 +1221,8 @@ func (m *SurfaceAManager) Stats() SurfaceAStats {
 		Skipped:          m.skipped,
 		BackedOff:        m.backedOff,
 		SkippedNoBackend: m.skippedNoBackend,
+		Degraded:         m.degraded,
+		DegradedReason:   m.degradedReason,
 	}
 }
 

--- a/pkg/ddns/surface_a_test.go
+++ b/pkg/ddns/surface_a_test.go
@@ -2,7 +2,9 @@ package ddns
 
 import (
 	"context"
+	"errors"
 	"net/netip"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -399,4 +401,135 @@ func contains(xs []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// TestSurfaceACorruptStateFailsClosed is the #2971 fail-on-revert test: a
+// corrupt Surface A ownership state file must put the manager into the DEGRADED
+// (fail-closed) state — Reconcile refuses to publish AND to withdraw any record,
+// never silently resetting to an empty store and reconciling-from-empty (which
+// would re-publish EVERY scope, overwriting a peer/manual owner, and leak the
+// records it can no longer withdraw). It also proves the bad file is quarantined
+// (preserved, not overwritten) and the alarm is surfaced in Stats. Reverting
+// NewSurfaceAManager/newSurfaceAManagerForTesting to the old fail-open path
+// (loadDDNSState + log-and-continue with the empty store) makes this RED: the
+// reconcile would publish the observed address and the no-op + degraded
+// assertions fail.
+func TestSurfaceACorruptStateFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "iface-ddns.json")
+	// A corrupt store left behind by a crash / disk fault.
+	if err := os.WriteFile(statePath, []byte("{ this is not valid json at all"), 0o600); err != nil {
+		t.Fatalf("seed corrupt state: %v", err)
+	}
+
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAManagerForTesting(statePath, fu, func() time.Time { return now })
+
+	// Degraded must be set at construction and surfaced in Stats.
+	if !m.degraded {
+		t.Fatal("manager must be DEGRADED after loading a corrupt Surface A state file")
+	}
+	if st := m.Stats(); !st.Degraded || st.DegradedReason == "" {
+		t.Fatalf("Stats must report Degraded with a reason, got %+v", st)
+	}
+
+	// The corrupt file must be quarantined aside (preserved for inspection), not
+	// left in place to be overwritten by a later save.
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("corrupt state file must be quarantined (renamed away); stat err=%v", err)
+	}
+	matches, _ := filepath.Glob(statePath + ".corrupt-*")
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one quarantined copy, found %v", matches)
+	}
+
+	// A reconcile of a configured scope with a valid observed address must FAIL
+	// CLOSED: no publish, no withdraw, an error returned, and the state file NOT
+	// recreated. A standalone (nil gate) run is used deliberately — losing the
+	// only ownership authority is no safer without a peer.
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil)
+	if err == nil {
+		t.Fatal("reconcile must return an error while degraded (fail closed)")
+	}
+	if got := len(fu.upserts); got != 0 {
+		t.Fatalf("degraded manager must NOT publish any record, got %d upserts", got)
+	}
+	if got := len(fu.deletes); got != 0 {
+		t.Fatalf("degraded manager must NOT withdraw any record, got %d deletes", got)
+	}
+	// The reconcile must NOT have written a fresh (empty) state file — that would
+	// erase the only signal that ownership was lost.
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatal("degraded manager must not recreate the ownership state file")
+	}
+}
+
+// TestSurfaceAUnsupportedVersionFailsClosed proves the unknown-future-version
+// path also fails closed + quarantines (#2971, sibling of the corrupt path):
+// the manager must not trust records from a format it cannot decode.
+func TestSurfaceAUnsupportedVersionFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "iface-ddns.json")
+	if err := os.WriteFile(statePath,
+		[]byte(`{"version":99,"records":[{"family":4,"identity":"router-self","address":"","fqdn":"wan.example.net","forward_type":"A","ttl":300,"addr_text":"203.0.113.5"}]}`),
+		0o600); err != nil {
+		t.Fatalf("seed unsupported-version state: %v", err)
+	}
+
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAManagerForTesting(statePath, fu, func() time.Time { return now })
+
+	if !m.degraded {
+		t.Fatal("unsupported-version state must put the manager into the degraded state")
+	}
+	// No record from the future-version file leaked into the in-memory store.
+	if len(m.state.records) != 0 {
+		t.Fatalf("unsupported-version records must not load, got %d", len(m.state.records))
+	}
+	matches, _ := filepath.Glob(statePath + ".corrupt-*")
+	if len(matches) != 1 {
+		t.Fatalf("unsupported-version file must be quarantined, found %v", matches)
+	}
+
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err == nil {
+		t.Fatal("reconcile must return an error while degraded (fail closed)")
+	}
+	if got := len(fu.upserts); got != 0 {
+		t.Fatalf("degraded manager must NOT publish, got %d upserts", got)
+	}
+}
+
+// TestSurfaceAAbsentStateFirstBootStandaloneWrites pins the OTHER half of the
+// #2971 contract: a MISSING state file (first boot) is a legitimately-empty
+// store, NOT degraded, so a fresh standalone (nil gate) node still publishes its
+// records. Distinguishing absent (fail-open OK) from corrupt (fail-closed) is
+// the whole point — this proves the fix did not over-apply fail-closed into
+// never-writing for a first-boot node.
+func TestSurfaceAAbsentStateFirstBootStandaloneWrites(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "iface-ddns.json")
+	// Deliberately do NOT create the file: first boot.
+	if _, err := os.Stat(statePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("precondition: state file must be absent, stat err=%v", err)
+	}
+
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAManagerForTesting(statePath, fu, func() time.Time { return now })
+
+	if m.degraded {
+		t.Fatalf("an absent (first-boot) state file must NOT be degraded; reason=%q", m.degradedReason)
+	}
+
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("first-boot standalone reconcile must succeed: %v", err)
+	}
+	if got := len(fu.upserts); got != 1 {
+		t.Fatalf("first-boot standalone node must publish its record, got %d upserts", got)
+	}
 }

--- a/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
+++ b/pkg/grpcapi/server_show_dhcp_lldp_snmp.go
@@ -321,6 +321,10 @@ func (s *Server) showServicesDynamicDNS(cfg *config.Config, buf *strings.Builder
 		buf.WriteString("\n  Runtime counters: unavailable (manager not running)\n")
 		return
 	}
+	if st.Degraded {
+		fmt.Fprintf(buf, "\n  ALARM: Surface A DDNS DEGRADED (fail-closed) — %s\n", st.DegradedReason)
+		buf.WriteString("    Publishing and withdrawals are SUSPENDED until the ownership state is resolved.\n")
+	}
 	buf.WriteString("\n  Counters:\n")
 	fmt.Fprintf(buf, "    Publishes: ok=%d fail=%d\n", st.UpsertOK, st.UpsertFail)
 	fmt.Fprintf(buf, "    Withdraws: ok=%d fail=%d\n", st.DeleteOK, st.DeleteFail)


### PR DESCRIPTION
## Closes #2971

### Bug (fail-open)
The Surface A (router/interface-address) DDNS `SurfaceAManager` bypassed the
#2650 degraded/quarantine path. `NewSurfaceAManager` called `loadDDNSState`
directly and, on **any** load error, logged a warning and proceeded with the
returned **empty** store — fail OPEN. The ownership store is the ONLY authority
for which A/AAAA records this node published, so an empty trusted store makes
every configured scope look unowned. The next `Reconcile` then re-publishes
EVERY scope (a **write storm**) — overwriting a peer/manual owner (the lost
ownership can no longer veto the re-claim) and forgetting the records it can no
longer withdraw (stale public DNS leak). This is exactly the failure mode #2650
closed for the DHCP-lease `Manager`.

### Fix (fail-closed on corrupt, distinguishing absent first-boot)
- `NewSurfaceAManager` and the test constructor now load through the **same**
  `loadStateOrDegrade` gate the lease path uses. A corrupt / unsupported-version
  / unreadable file sets `SurfaceAManager.degraded` (+ `degradedReason`),
  quarantines a corrupt/unsupported file aside (preserved, never overwritten by
  a later `save()`), and `Reconcile` then **fails closed**: returns a visible
  error and does NO publish, withdraw, or save.
- A **missing** file (first boot) is NOT degraded — a fresh node publishes
  normally. This **explicitly includes the STANDALONE (nil-gate) case**: losing
  the only ownership authority is no safer without a peer, so a standalone node
  fails closed on a corrupt file too, and a restart with the bad file
  quarantined aside re-reads an absent (clean-empty) store and resumes
  publishing. Distinguishing absent (fail-open OK) from corrupt (fail-closed) is
  the whole point.

### Observability
`SurfaceAStats` gains `Degraded` / `DegradedReason`; the CLI and gRPC
`show services dynamic-dns` render a Surface A DEGRADED alarm; a new
`xpf_ddns_surface_a_degraded` Prometheus gauge mirrors `xpf_dhcp_ddns_degraded`.

### Tests (fail-on-revert)
- `TestSurfaceACorruptStateFailsClosed` + `TestSurfaceAUnsupportedVersionFailsClosed`
  — degraded set, file quarantined, no publish/withdraw, no recreated state file.
  Both go **RED** when the constructor is reverted to the fail-open
  `loadDDNSState` path (the revert even logs a spurious `published record`).
- `TestSurfaceAAbsentStateFirstBootStandaloneWrites` — pins the
  first-boot/standalone half; stays green on revert.

### Validation
`go build ./...`; `go vet ./pkg/ddns/...`; `go test ./pkg/ddns/... ./pkg/daemon/...
./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/...` all green.

Builds on the sibling ddns fixes #2956 (httpClientCache reap) and #2972 (RG0
single-writer gate); rebased on current origin/master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi