### PR TITLE
userspace-dp: dedup VLAN-child netdevs in the queue planner (#3091)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-26 — #3091: VLAN-child netdevs collapsed the queue-plan min to 1 worker
+
+- **Timestamp**: 2026-06-26
+- **Action**: Fixed a HIGH forwarding regression (~6-7 Gbps). The
+  bondless-RETH WAN VLAN units `reth0.50`/`reth0.80` (Linux
+  `ge-0-0-2.50`/`ge-0-0-2.80`) are software VLAN netdevs with 1 RX queue
+  each. They entered `replan_queues`' candidate list (their `ge-` name
+  passes `include_userspace_binding_interface`; the #1921 `seen_linux`
+  dedup misses them because their netdev name differs from the physical
+  parent `ge-0-0-2`). `queue_count = min(6, 1, 1, 6, 6) = 1` → 1 worker.
+  Added a VLAN-child dedup (`vlan_child_parent_netdev` +
+  `snapshot_has_parent_candidate`): a VLAN child whose physical parent is
+  a candidate is skipped (the parent's 6 hardware queues carry its tagged
+  frames); an orphan VLAN child is re-keyed onto the parent's hardware
+  queue count. Hashed `vlan_id` + `parent_linux_name` into the binding
+  plan key (#2915/#2916 invariant). Two fail-on-revert Rust tests.
+- **File(s)**: userspace-dp/src/server/helpers.rs,
+  userspace-dp/src/main_tests.rs, userspace-dp/README.md, _Log.md
+- **Validation**: `cargo build --release` clean; `cargo test --release`
+  3027 passed. Live on loss userspace cluster: `planned_workers` 1 → 6
+  (5 → 18 bindings), RSS restored to default 6-ring spread (no narrow),
+  ping 0% loss, iperf3 P=12 v4 7.1 → 23.0 Gbps, v6 22.9 Gbps. Manual
+  `ethtool -X ... weight 1 0 0 0 0 0` RSS workaround removed (no longer
+  needed).
+
 ## 2026-06-25 — #3117: security-policy `scheduler-name` added to set-schema
 
 - **Timestamp**: 2026-06-25

--- a/userspace-dp/README.md
+++ b/userspace-dp/README.md
@@ -47,6 +47,44 @@ all bindings in batch (`RX_BATCH_SIZE=64`, up to `MAX_RX_BATCHES_PER_POLL=4`
 per tick). Per descriptor: parse → screen → session lookup → NAT/policy
 decision → forwarding build → enqueue TX or recycle.
 
+## Queue planning (`replan_queues`)
+
+`server::helpers::replan_queues` derives the AF_XDP binding plan from the
+config snapshot. It builds a candidate list of binding-eligible Linux
+netdevs, takes `queue_count = min(rx_queues)` across all candidates, and
+emits one binding per `(netdev, queue_id)` — so `planned_workers` equals
+that per-interface RX-queue minimum. The candidate set is the shared
+binding-exclusion contract (`include_userspace_binding_interface`, the
+Rust mirror of the Go `UserspaceBoundLinuxInterfaces` allowlist): zoned,
+non-tunnel, non-local-fabric netdevs, excluding `fxp*`/`em*`/`fab*`/`lo0`
+and the mgmt/control zones.
+
+Two dedup rules keep the `queue_count` min from collapsing:
+
+- **#1921 (`seen_linux`)**: the snapshot lists both a physical interface
+  (`ge-0/0/0`) and its non-VLAN unit (`ge-0/0/0.0`); both resolve to the
+  same Linux netdev. The first wins; the duplicate is dropped (a second
+  XSK bind on the same `(netdev, queue)` returns EBUSY).
+- **#3091 (`vlan_child_parent_netdev`)**: a VLAN-child unit
+  (`reth0.50`/`reth0.80` → Linux `ge-0-0-2.50`/`ge-0-0-2.80`) is a
+  *software* VLAN device the kernel exposes with a **single** RX queue,
+  but its tagged frames are delivered on the **physical parent's**
+  hardware queues (`ge-0-0-2`, 6 queues). The child netdev name differs
+  from the parent, so the #1921 guard misses it. A VLAN child
+  (`vlan_id != 0` with a distinct non-empty `parent_linux_name`) is
+  therefore deduped onto its parent: when the parent is itself a
+  candidate it is skipped entirely; an orphan VLAN child (parent not a
+  candidate) is re-keyed onto the parent netdev using the parent's
+  hardware queue count, never the child's lone software queue. Without
+  this, `min(6, 1, 1, 6) = 1` forced a single worker (~6-7 Gbps; the
+  #3091 regression). With it the WAN parent binds all 6 hardware queues
+  and forwards at ~23 Gbps multi-worker.
+
+Both `vlan_id` and `parent_linux_name` are hashed into the binding
+plan key (`update_snapshot_binding_plan_key`) so a re-parenting or VLAN
+change always triggers a replan — the #2915/#2916 "the plan key and the
+planner agree on every layout input" invariant.
+
 ## External interfaces
 
 - **Unix socket** (`/tmp/xpf-userspace-dp.sock`): newline-delimited text

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -445,6 +445,156 @@ fn plan_key_covers_every_replan_queues_input() {
     );
 }
 
+// #3091 fail-on-revert: a WAN VLAN unit (`reth0.80` → Linux `ge-0-0-2.80`) is a
+// software VLAN device that the kernel exposes with a SINGLE RX queue. Its
+// physical parent (`ge-0-0-2`) carries the VLAN-tagged frames on its 6 hardware
+// queues. The parent is already a binding candidate, so the VLAN child must be
+// deduped onto it and must NOT enter the candidate list as a separate 1-queue
+// interface — otherwise `replan_bindings_from_candidates` takes the MIN
+// rx_queues across all candidates (`min(6, 1) == 1`), plans a single queue, and
+// the dataplane runs with one worker (~6 Gbps, the regression).
+//
+// Revert proof: delete the `vlan_child_parent_netdev` dedup block in
+// `replan_queues` and this test goes RED — the child re-enters the candidate
+// list, `queue_count` collapses to 1, and the parent binds on a single queue.
+#[test]
+fn queue_planner_dedups_wan_vlan_child_onto_physical_parent() {
+    use crate::server::helpers::replan_queues;
+
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![
+            // Physical WAN netdev: 6 hardware RX queues (mlx5 VF).
+            InterfaceSnapshot {
+                name: "ge-0/0/2".to_string(),
+                linux_name: "ge-0-0-2".to_string(),
+                zone: "untrust".to_string(),
+                ifindex: 12,
+                rx_queues: 6,
+                ..Default::default()
+            },
+            // VLAN unit reth0.50: software VLAN netdev, 1 RX queue.
+            InterfaceSnapshot {
+                name: "ge-0/0/2.50".to_string(),
+                linux_name: "ge-0-0-2.50".to_string(),
+                parent_linux_name: "ge-0-0-2".to_string(),
+                zone: "untrust".to_string(),
+                ifindex: 50,
+                parent_ifindex: 12,
+                vlan_id: 50,
+                rx_queues: 1,
+                ..Default::default()
+            },
+            // VLAN unit reth0.80: software VLAN netdev, 1 RX queue.
+            InterfaceSnapshot {
+                name: "ge-0/0/2.80".to_string(),
+                linux_name: "ge-0-0-2.80".to_string(),
+                parent_linux_name: "ge-0-0-2".to_string(),
+                zone: "untrust".to_string(),
+                ifindex: 80,
+                parent_ifindex: 12,
+                vlan_id: 80,
+                rx_queues: 1,
+                ..Default::default()
+            },
+            // LAN netdev: 6 hardware RX queues (also mlx5 VF).
+            InterfaceSnapshot {
+                name: "ge-0/0/1".to_string(),
+                linux_name: "ge-0-0-1".to_string(),
+                zone: "trust".to_string(),
+                ifindex: 11,
+                rx_queues: 6,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let bindings = replan_queues(Some(&snapshot), 6, &[]);
+
+    // The VLAN-child netdevs must NOT be planned as separate candidates.
+    assert!(
+        bindings
+            .iter()
+            .all(|b| b.interface != "ge-0-0-2.50" && b.interface != "ge-0-0-2.80"),
+        "VLAN-child netdevs must be deduped onto the parent, not planned as \
+         separate 1-queue candidates; got {:?}",
+        bindings.iter().map(|b| &b.interface).collect::<Vec<_>>()
+    );
+
+    // The plan must span all 6 hardware queues (queue_count = min over the two
+    // remaining 6-queue physical candidates), NOT collapse to 1.
+    let queue_ids: std::collections::BTreeSet<u32> = bindings.iter().map(|b| b.queue_id).collect();
+    assert_eq!(
+        queue_ids,
+        (0..6).collect::<std::collections::BTreeSet<u32>>(),
+        "queue_count must be 6 (parent hardware queues), not collapsed to 1 by \
+         the VLAN child's single software queue"
+    );
+
+    // Both physical parents bind on all 6 queues.
+    for netdev in ["ge-0-0-1", "ge-0-0-2"] {
+        let q: std::collections::BTreeSet<u32> = bindings
+            .iter()
+            .filter(|b| b.interface == netdev)
+            .map(|b| b.queue_id)
+            .collect();
+        assert_eq!(
+            q,
+            (0..6).collect::<std::collections::BTreeSet<u32>>(),
+            "{netdev} must bind on all 6 hardware queues"
+        );
+    }
+
+    // The plan spans workers 0..5 (one per queue), i.e. multi-worker.
+    let workers: std::collections::BTreeSet<u32> = bindings.iter().map(|b| b.worker_id).collect();
+    assert_eq!(
+        workers.len(),
+        6,
+        "the plan must spread across 6 workers, not a single worker (#3091)"
+    );
+}
+
+// #3091: an ORPHAN VLAN child whose physical parent is NOT itself a binding
+// candidate must still be re-keyed onto the parent netdev with the parent's
+// HARDWARE queue count, never the child's single software queue. (This is the
+// defensive fallback path; the common case is the parent-is-candidate dedup
+// above.) Here the parent never appears as its own snapshot interface, so the
+// child resolves the parent's queue count from sysfs — in the unit-test
+// sandbox that yields 1 via `rx_queue_count`'s `.max(1)`, but the binding is
+// keyed on the PARENT netdev (`ge-0-0-9`), proving the child's own netdev name
+// never reaches the candidate list.
+#[test]
+fn queue_planner_rekeys_orphan_vlan_child_onto_parent_netdev() {
+    use crate::server::helpers::replan_queues;
+
+    let snapshot = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0/0/9.30".to_string(),
+            linux_name: "ge-0-0-9.30".to_string(),
+            parent_linux_name: "ge-0-0-9".to_string(),
+            zone: "untrust".to_string(),
+            ifindex: 130,
+            parent_ifindex: 19,
+            vlan_id: 30,
+            rx_queues: 1,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let bindings = replan_queues(Some(&snapshot), 2, &[]);
+    assert!(
+        bindings.iter().all(|b| b.interface == "ge-0-0-9"),
+        "orphan VLAN child must bind on the parent netdev, not its own \
+         child netdev; got {:?}",
+        bindings.iter().map(|b| &b.interface).collect::<Vec<_>>()
+    );
+    assert!(
+        bindings.iter().all(|b| b.ifindex == 19),
+        "orphan VLAN child binding must use the parent ifindex"
+    );
+}
+
 #[test]
 fn queue_planner_excludes_tunnel_and_local_fabric_ge_interfaces() {
     // #2915: `ge-*`-named interfaces in tunnel or local-fabric contexts are

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -619,16 +619,25 @@ fn update_snapshot_binding_plan_key(hasher: &mut Sha256, snapshot: &ConfigSnapsh
         .iter()
         .filter(|iface| include_userspace_binding_interface(iface))
     {
+        // #3091: `vlan_id` and `parent_linux_name` are now binding-plan inputs
+        // — `replan_queues` dedups a VLAN-child netdev onto its physical parent
+        // using exactly these two fields. The #2915 invariant requires every
+        // field the planner reads to construct the layout to bump the plan key,
+        // so re-parenting or VLAN-tag changes trigger a replan (never a stale
+        // plan). Additive: an old Go binary that omits them serializes the
+        // serde defaults (0 / ""), matching the non-VLAN physical case.
         hash_update(
             hasher,
             &format!(
-                "iface={}/{}/{}/{}/{}/{};",
+                "iface={}/{}/{}/{}/{}/{}/{}/{};",
                 iface.name,
                 iface.linux_name,
                 iface.ifindex,
                 iface.parent_ifindex,
                 iface.rx_queues,
-                iface.tunnel
+                iface.tunnel,
+                iface.vlan_id,
+                iface.parent_linux_name
             ),
         );
     }
@@ -753,6 +762,52 @@ pub(crate) fn include_userspace_binding_interface(iface: &InterfaceSnapshot) -> 
     !matches!(iface.zone.as_str(), "mgmt" | "control")
 }
 
+/// #3091: a VLAN-child interface (e.g. `reth0.80` → Linux netdev
+/// `ge-0-0-2.80`) is a SOFTWARE VLAN device with a single RX queue. Its
+/// VLAN-tagged frames are delivered on the PHYSICAL PARENT's hardware RX
+/// queues (`ge-0-0-2`, 6 queues on the mlx5 VF), so the child must NOT enter
+/// the queue planner's candidate list — its lone software queue would collapse
+/// the per-interface `queue_count` min (see `replan_bindings_from_candidates`)
+/// to 1, forcing a single worker and the ~6 Gbps forwarding regression. The
+/// pre-existing #1921 `seen_linux` dedup misses VLAN children because the child
+/// netdev name (`ge-0-0-2.80`) differs from the parent (`ge-0-0-2`).
+///
+/// Returns the parent Linux netdev name when `iface` is a distinct VLAN-child
+/// netdev, else None (physical interfaces and non-VLAN units, whose
+/// `parent_linux_name` is empty or equal to their own netdev, are handled by
+/// the existing `seen_linux` dedup).
+fn vlan_child_parent_netdev<'a>(iface: &'a InterfaceSnapshot, linux_name: &str) -> Option<&'a str> {
+    if iface.vlan_id != 0
+        && !iface.parent_linux_name.is_empty()
+        && iface.parent_linux_name != linux_name
+    {
+        Some(iface.parent_linux_name.as_str())
+    } else {
+        None
+    }
+}
+
+/// #3091: true when the physical netdev `parent` is itself a binding candidate
+/// in this snapshot (a zoned, non-tunnel, non-VLAN data interface). When the
+/// parent is a candidate, a VLAN child re-keyed onto it is fully covered by the
+/// parent's per-queue XSKs (VLAN-tagged frames are captured on the parent's
+/// hardware queues), so the child can be dropped from the candidate list.
+fn snapshot_has_parent_candidate(snapshot: &ConfigSnapshot, parent: &str) -> bool {
+    snapshot.interfaces.iter().any(|p| {
+        if !include_userspace_binding_interface(p) {
+            return false;
+        }
+        let p_linux = if p.linux_name.is_empty() {
+            linux_ifname(&p.name)
+        } else {
+            p.linux_name.clone()
+        };
+        // The parent must be the physical netdev itself, not another VLAN
+        // child that happens to share the name string.
+        p_linux == parent && vlan_child_parent_netdev(p, &p_linux).is_none()
+    })
+}
+
 pub(crate) fn replan_queues(
     snapshot: Option<&ConfigSnapshot>,
     workers: usize,
@@ -782,6 +837,41 @@ pub(crate) fn replan_queues(
             } else {
                 iface.linux_name.clone()
             };
+            // #3091: dedup VLAN-child netdevs onto their physical parent. A
+            // bondless-RETH WAN VLAN unit (`reth0.50`/`reth0.80` → Linux
+            // `ge-0-0-2.50`/`ge-0-0-2.80`) is a software VLAN device with a
+            // single RX queue, but its tagged frames arrive on the PARENT
+            // netdev's hardware queues. Pushing it as a separate 1-queue
+            // candidate collapses the `queue_count` min to 1 (single worker,
+            // the #3091 ~6 Gbps regression). The #1921 `seen_linux` guard below
+            // cannot catch this — the child netdev name differs from the parent.
+            if let Some(parent) = vlan_child_parent_netdev(iface, &linux_name) {
+                if snapshot_has_parent_candidate(snapshot, parent) {
+                    // The parent's per-queue XSKs already capture this VLAN's
+                    // tagged frames; skip the 1-queue child entirely.
+                    continue;
+                }
+                // Orphan VLAN child (parent absent from the candidate set):
+                // re-key onto the parent netdev using the parent's HARDWARE
+                // queue count, never the child's single software queue, so it
+                // still cannot collapse the min.
+                let parent = parent.to_string();
+                if seen_linux.contains(&parent) {
+                    continue;
+                }
+                let rx_queues = rx_queue_count(&parent);
+                if rx_queues > 0 {
+                    let parent_ifindex = if iface.parent_ifindex > 0 {
+                        iface.parent_ifindex
+                    } else {
+                        iface.ifindex
+                    };
+                    ifindex_by_name.insert(parent.clone(), parent_ifindex);
+                    seen_linux.insert(parent.clone());
+                    candidates.push((parent, rx_queues));
+                }
+                continue;
+            }
             // #1921: dedup by Linux netdev. The snapshot lists BOTH the
             // physical interface (`ge-0/0/0`) and its unit (`ge-0/0/0.0`);
             // both start with `ge-` and (for a non-VLAN unit) resolve to the


### PR DESCRIPTION
Closes #3091.

## Root cause

Forwarding regressed to ~6-7 Gbps because the helper planned only **1 worker**.

In `userspace-dp/src/server/helpers.rs`, `replan_bindings_from_candidates`
takes `queue_count = candidates.iter().map(|(_, rx)| *rx).min()` — the MIN
rx_queues across all candidate interfaces, and emits one binding per
`(netdev, queue_id)`, so `planned_workers` equals that minimum.

The bondless-RETH WAN VLAN units `reth0.50`/`reth0.80` (Linux netdevs
`ge-0-0-2.50`/`ge-0-0-2.80`) are **software** VLAN devices the kernel exposes
with a **single RX queue** each. They entered the candidate list (their `ge-`
name passes `include_userspace_binding_interface`), and the existing #1921
`seen_linux` dedup misses them because the child netdev name differs from the
physical parent `ge-0-0-2`.

Live snapshot proof: `ge-0-0-2=6`, `ge-0-0-2.50=1`, `ge-0-0-2.80=1`,
`ge-0-0-1=6`, fabric `ge-0-0-0=6` → `min(6,1,1,6,6)=1` → 1 queue → all 5
bindings on queue 0 → `planned_workers=1` → single worker → ~6-7 Gbps.

The physical parent `ge-0-0-2` is already a candidate with the correct 6
hardware queues; VLAN-tagged frames for `reth0.50/.80` arrive on the parent's
hardware queues. The child's 1 "queue" is a software artifact and must not cap
`queue_count`.

## The fix

Dedup a VLAN-child netdev onto its physical parent in `replan_queues`,
mirroring the #1921 dedup:

- `vlan_child_parent_netdev` identifies a VLAN child via the snapshot fields
  (`vlan_id != 0` AND a non-empty `parent_linux_name` distinct from its own
  `linux_name`).
- When the parent is itself a binding candidate (`snapshot_has_parent_candidate`
  — the common bondless-RETH WAN case) the child is skipped entirely: the
  parent's per-queue XSKs already capture the VLAN's tagged frames.
- An orphan VLAN child (parent not a candidate) is re-keyed onto the parent
  netdev using the parent's **hardware** queue count, never the child's single
  software queue.
- `vlan_id` and `parent_linux_name` are hashed into the binding plan key so a
  re-parenting/VLAN change always triggers a replan (#2915/#2916 invariant).

The Go `shouldUseLogicalOnlyParentBoundRethVLAN` returns false when the VLAN
child netdev exists in the kernel (`childIfindex > 0`, as on the loss cluster),
so the units are emitted as real candidates — the upstream contributor. The
Rust dedup is the robust, queue-planner-local fix and fully resolves the
regression regardless of the Go path; changing the logical_only behavior would
affect the RSS allowlist + binding semantics and is left for a separate,
independently-validated change.

## Fail-on-revert tests (`userspace-dp/src/main_tests.rs`)

- `queue_planner_dedups_wan_vlan_child_onto_physical_parent`: a physical
  6-queue netdev + two `vlan_id=50/80` children → asserts the plan spans **6
  queues / 6 workers** and the children are not separate candidates. Reverting
  the dedup collapses `queue_count` to 1 (RED).
- `queue_planner_rekeys_orphan_vlan_child_onto_parent_netdev`: the orphan-parent
  fallback binds on the parent netdev/ifindex, never the child netdev.

## Gates

- `cargo build --release -p xpf-userspace-dp` clean.
- `cargo test --release` — 3027 passed.

## Live cluster validation (loss userspace cluster)

| | Before (single-queue) | After (fix) |
|---|---|---|
| `planned_workers` | **1** (5 bindings) | **6** (18 bindings) |
| RSS `ge-0-0-2` | narrowed to ring 0 (manual `ethtool -X` workaround) | default 6-ring spread (`0 1 2 3 4 5...`), workaround removed |
| iperf3 P=12 v4 | ~7.1 Gbits/sec | **23.0 Gbits/sec** |
| iperf3 P=12 v6 | — | **22.9 Gbits/sec** |
| ping | — | 0% packet loss |

xpfd's own RSS reshape logged `skipped (workers 6 >= queues 6)` — the default
6-ring RSS is correct and queues 1-5 all have bound XSKs (no XDP_DROP
blackhole). The manual RSS workaround is no longer needed and was left removed;
the cluster forwards normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi