### PR TITLE
policymatch: validate simulator protocol token across all surfaces (Closes #3108)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-25 — #3108: policy simulators reject invalid protocol tokens
+
+- **Timestamp**: 2026-06-25
+- **Action**: Added shared `policymatch.ValidateProtocol` and wired it across
+  all four simulator surfaces (codex-review-065 finding 065-05). Mirrors the
+  #3116 port-validation pattern. `matchApp` short-circuits to match-any before
+  the protocol is resolved, so a bogus protocol (unknown name / out-of-range
+  number) silently produced a permit/deny verdict instead of an error. Empty
+  protocol = unspecified (match any, unchanged); a non-empty token must resolve
+  via `appid.ProtocolNumber`. REST `matchPoliciesHandler` → 400, gRPC
+  `MatchPolicies` → InvalidArgument, gRPC `showTestPolicy` → "invalid protocol"
+  diagnostic, local CLI `showMatchPolicies`/`testPolicy` + remote `cli`
+  `testPolicy` → command error. Fail-on-revert verified (stub `return nil`
+  flips every want-error case red across 6 surfaces + the unit test).
+- **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/protocol_test.go,
+  pkg/policymatch/README.md, pkg/api/security.go,
+  pkg/api/rest_filter_failclosed_test.go, pkg/grpcapi/server_cluster.go,
+  pkg/grpcapi/server_show_firewall.go,
+  pkg/grpcapi/server_proto_validation_test.go, pkg/cli/cli_show_security.go,
+  pkg/cli/cli_request.go, pkg/cli/policymatch_protocol_test.go,
+  cmd/cli/main.go, cmd/cli/testpolicy_protocol_test.go
+
 ## 2026-06-25 — #2971: Surface A DDNS corrupt ownership state fail-closed
 
 - **Timestamp**: 2026-06-25

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -493,6 +493,14 @@ func (c *ctl) testPolicy(args []string) error {
 		return nil
 	}
 
+	// #3108: reject a non-empty but unknown/out-of-range protocol token locally
+	// (mirroring the local CLI `test policy`) rather than forwarding it to the
+	// backend where matchApp would short-circuit it to the "any protocol"
+	// wildcard and return a misleading verdict. An empty value is unspecified.
+	if err := policymatch.ValidateProtocol(proto); err != nil {
+		return fmt.Errorf("invalid protocol: %w", err)
+	}
+
 	topic := fmt.Sprintf("test-policy:from=%s,to=%s", fromZone, toZone)
 	if srcIP != "" {
 		topic += ",src=" + srcIP

--- a/cmd/cli/testpolicy_protocol_test.go
+++ b/cmd/cli/testpolicy_protocol_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTestPolicyRejectsInvalidProtocol covers the #3108 gap on the remote `cli`
+// client's `test policy` command (cmd/cli). A non-empty but unknown/out-of-range
+// protocol token must return a clear command error and NEVER be forwarded to the
+// backend, where matchApp would short-circuit an unresolvable protocol to the
+// "any protocol" wildcard and return a misleading verdict.
+//
+// Only the rejection path is unit-testable here: a VALID/ABSENT protocol
+// proceeds to c.showText, which dials the gRPC client (an integration path). The
+// rejection returns before any client call, so an empty *ctl is sufficient.
+//
+// FAIL-ON-REVERT: removing the policymatch.ValidateProtocol guard makes
+// "notaproto"/"999" build a topic and dial the backend with no error, flipping
+// these want-error cases red.
+func TestTestPolicyRejectsInvalidProtocol(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"unknown name", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "notaproto"}},
+		{"typo", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcpp"}},
+		{"out of range", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "999"}},
+	}
+	c := &ctl{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.testPolicy(tc.args)
+			if err == nil {
+				t.Fatalf("testPolicy(%v) err = nil, want an invalid-protocol error", tc.args)
+			}
+			if !strings.Contains(err.Error(), "protocol") {
+				t.Fatalf("testPolicy(%v) err = %v, want a protocol diagnostic", tc.args, err)
+			}
+		})
+	}
+}

--- a/pkg/api/rest_filter_failclosed_test.go
+++ b/pkg/api/rest_filter_failclosed_test.go
@@ -196,6 +196,44 @@ func TestRESTPolicyMatchPortRange(t *testing.T) {
 	}
 }
 
+// TestRESTPolicyMatchProtocol asserts the #3108 contract for the policy-match
+// simulator: a non-empty but unknown/out-of-range protocol token must 400, not
+// silently become the "any protocol" wildcard (the shared matcher's matchApp
+// short-circuits an unresolvable protocol to match-any, and the fixture policy
+// uses `application any`, so the protocol is the only constraining dimension).
+// A valid name/number and an absent protocol proceed (HTTP 200) unchanged.
+//
+// FAIL-ON-REVERT: removing the policymatch.ValidateProtocol guard in
+// matchPoliciesHandler makes protocol=notaproto / protocol=999 pass through and
+// the handler returns HTTP 200, flipping the want-400 cases red.
+func TestRESTPolicyMatchProtocol(t *testing.T) {
+	s := &Server{store: newPolicyMatchStore(t)}
+
+	base := "/api/v1/security/policies/match?from_zone=trust&to_zone=untrust"
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"unknown name", base + "&protocol=notaproto", 400},
+		{"typo", base + "&protocol=tcpp", 400},
+		{"out of range", base + "&protocol=999", 400},
+		{"valid name", base + "&protocol=tcp", 200},
+		{"valid number", base + "&protocol=6", 200},
+		{"absent wildcard", base, 200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.matchPoliciesHandler(rr, httptest.NewRequest("GET", tc.url, nil))
+			if rr.Code != tc.want {
+				t.Fatalf("%s: status = %d, want %d; body: %s",
+					tc.name, rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
 // TestRESTProtocolFilterCaseInsensitiveNumeric asserts the #2935 contract:
 // the REST session protocol filter must be case-insensitive AND accept a
 // numeric IP protocol number, mirroring gRPC/CLI. The fixture yields one

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -295,7 +295,17 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid src_port: "+err.Error())
 		return
 	}
+	// A non-empty but unknown/out-of-range protocol token (e.g. "tcpp", "999")
+	// must NOT silently become "any protocol" — the shared matcher's matchApp
+	// short-circuits to match-any for an empty/unresolvable protocol, yielding a
+	// misleading PERMIT/DENY verdict for a policy using `application any`
+	// (#3108). Reject it with 400. An empty value still means "unspecified"
+	// (match any protocol), unchanged.
 	proto := r.URL.Query().Get("protocol")
+	if err := policymatch.ValidateProtocol(proto); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	// #3042: delegate to the single shared simulator so REST agrees with the
 	// runtime evaluator (zone-pair -> global -> default-policy, predefined +

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -235,6 +235,14 @@ func (c *CLI) testPolicy(args []string) error {
 		return fmt.Errorf("invalid destination-ip %q", dstIP)
 	}
 
+	// #3108: reject a non-empty but unknown/out-of-range protocol token
+	// ("tcpp", "999") instead of letting matchApp short-circuit it to the
+	// "any protocol" wildcard, which would yield a misleading verdict for a
+	// policy using `application any`. An empty value still means "unspecified".
+	if err := policymatch.ValidateProtocol(proto); err != nil {
+		return err
+	}
+
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -305,6 +305,15 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		return fmt.Errorf("invalid destination-ip %q", dstIP)
 	}
 
+	// #3108: a non-empty but unknown/out-of-range protocol token ("tcpp",
+	// "999") must not silently become "any protocol" — matchApp short-circuits
+	// to match-any for an unresolvable protocol, yielding a misleading verdict
+	// for a policy using `application any`. An empty value still means
+	// "unspecified" (match any protocol).
+	if err := policymatch.ValidateProtocol(proto); err != nil {
+		return err
+	}
+
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 

--- a/pkg/cli/policymatch_protocol_test.go
+++ b/pkg/cli/policymatch_protocol_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTestPolicyRejectsInvalidProtocol asserts the #3108 contract for the CLI
+// `test policy` surface: a non-empty but unknown/out-of-range protocol token
+// must return an error instead of silently becoming the "any protocol"
+// wildcard (matchApp short-circuits an unresolvable protocol to match-any, and
+// the fixture policy uses `application any`). A valid name/number and an absent
+// protocol proceed without error.
+//
+// FAIL-ON-REVERT: removing the policymatch.ValidateProtocol guard in testPolicy
+// lets "notaproto"/"999" pass into the matcher with no error, flipping the
+// want-error cases red.
+func TestTestPolicyRejectsInvalidProtocol(t *testing.T) {
+	c := newPolicyMatchCLIStore(t)
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"unknown name", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "notaproto"}, true},
+		{"typo", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcpp"}, true},
+		{"out of range", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "999"}, true},
+		{"valid name", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp"}, false},
+		{"valid number", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "6"}, false},
+		{"absent", []string{"from-zone", "trust", "to-zone", "untrust"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			captureStdout(t, func() { err = c.testPolicy(tc.args) })
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("testPolicy(%v) err = %v, wantErr = %v", tc.args, err, tc.wantErr)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "protocol") {
+				t.Fatalf("testPolicy(%v) err = %v, want a protocol diagnostic", tc.args, err)
+			}
+		})
+	}
+}
+
+// TestShowMatchPoliciesRejectsInvalidProtocol asserts the #3108 contract for
+// the CLI `show security match-policies` surface.
+//
+// FAIL-ON-REVERT: removing the policymatch.ValidateProtocol guard in
+// showMatchPolicies makes the invalid-protocol cases proceed with no error,
+// flipping them red.
+func TestShowMatchPoliciesRejectsInvalidProtocol(t *testing.T) {
+	c := newPolicyMatchCLIStore(t)
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"unknown name", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "notaproto"}, true},
+		{"out of range", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "999"}, true},
+		{"valid name", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "udp"}, false},
+		{"valid number", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "17"}, false},
+		{"absent", []string{"from-zone", "trust", "to-zone", "untrust"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			captureStdout(t, func() { err = c.showMatchPolicies(cfg, tc.args) })
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("showMatchPolicies(%v) err = %v, wantErr = %v", tc.args, err, tc.wantErr)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "protocol") {
+				t.Fatalf("showMatchPolicies(%v) err = %v, want a protocol diagnostic", tc.args, err)
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -154,6 +154,15 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		return nil, status.Errorf(codes.InvalidArgument, "invalid destination-port: %v", err)
 	}
 
+	// A non-empty but unknown/out-of-range protocol token ("tcpp", "999") must
+	// not pass through to the shared matcher, whose matchApp short-circuits to
+	// match-any for an unresolvable protocol, yielding a misleading verdict for
+	// a policy using `application any` (#3108). An empty value stays the
+	// unspecified wildcard (match any protocol).
+	if err := policymatch.ValidateProtocol(req.Protocol); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
 	// #3042: delegate to the single shared simulator so gRPC agrees with the
 	// runtime evaluator (zone-pair -> global -> default-policy, predefined +
 	// nested-app-set + literal-CIDR + any-ipv4/any-ipv6 + exclusion + feed

--- a/pkg/grpcapi/server_proto_validation_test.go
+++ b/pkg/grpcapi/server_proto_validation_test.go
@@ -1,0 +1,110 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestMatchPoliciesRejectsInvalidProtocol asserts the #3108 contract for the
+// gRPC MatchPolicies surface: a non-empty but unknown/out-of-range protocol
+// token must be rejected with InvalidArgument, not passed through to the shared
+// matcher where matchApp short-circuits an unresolvable protocol to match-any
+// (the test policy uses `application any`, so the protocol dimension is the only
+// thing that could constrain the verdict). An empty protocol stays the
+// unspecified wildcard; a valid name/number proceeds.
+//
+// FAIL-ON-REVERT: removing the policymatch.ValidateProtocol guard in
+// MatchPolicies lets Protocol="tcpp"/"999" reach the matcher and return a
+// verdict instead of an error, flipping the want-error cases red.
+func TestMatchPoliciesRejectsInvalidProtocol(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	cases := []struct {
+		name    string
+		proto   string
+		wantErr bool
+	}{
+		{"unknown name", "notaproto", true},
+		{"typo", "tcpp", true},
+		{"out of range", "999", true},
+		{"valid name", "tcp", false},
+		{"valid number", "6", false},
+		{"absent wildcard", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &pb.MatchPoliciesRequest{FromZone: "trust", ToZone: "untrust", Protocol: tc.proto}
+			resp, err := s.MatchPolicies(context.Background(), req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("%s: returned no error; resp = %+v (invalid protocol slipped through)", tc.name, resp)
+				}
+				if status.Code(err) != codes.InvalidArgument {
+					t.Fatalf("%s: status code = %v, want InvalidArgument", tc.name, status.Code(err))
+				}
+				if resp != nil {
+					t.Fatalf("%s: resp = %+v, want nil on InvalidArgument", tc.name, resp)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s: error = %v, want nil", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestShowTestPolicyRejectsInvalidProtocol covers the #3108 gap on the ShowText
+// "test-policy:" simulator (the operational `test policy` served via gRPC). An
+// unknown/out-of-range protocol token must surface an "invalid protocol"
+// diagnostic and must NOT produce a "Policy match" line — an unresolvable
+// protocol that silently coerced to the match-any wildcard would yield a
+// verdict for traffic that cannot exist. A valid protocol and an absent one
+// still evaluate normally.
+//
+// FAIL-ON-REVERT: dropping the protoErr = policymatch.ValidateProtocol(...)
+// branch in showTestPolicy makes "tcpp"/"999" pass straight into the matcher
+// with no diagnostic, flipping the want-"invalid protocol" cases (and the
+// no-"Policy match" assertion) red.
+func TestShowTestPolicyRejectsInvalidProtocol(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+
+	cases := []struct {
+		name      string
+		topic     string
+		wantBad   bool
+		wantMatch bool
+	}{
+		{"unknown name", "test-policy:from=trust,to=untrust,proto=notaproto", true, false},
+		{"typo", "test-policy:from=trust,to=untrust,proto=tcpp", true, false},
+		{"out of range", "test-policy:from=trust,to=untrust,proto=999", true, false},
+		{"valid name", "test-policy:from=trust,to=untrust,src=10.0.1.5,dst=10.0.1.6,proto=tcp", false, true},
+		{"valid number", "test-policy:from=trust,to=untrust,src=10.0.1.5,dst=10.0.1.6,proto=6", false, true},
+		{"absent", "test-policy:from=trust,to=untrust,src=10.0.1.5,dst=10.0.1.6", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: tc.topic})
+			if err != nil {
+				t.Fatalf("ShowText(%q) error = %v", tc.topic, err)
+			}
+			if tc.wantBad {
+				if !strings.Contains(resp.Output, "invalid protocol") {
+					t.Fatalf("%s: output = %q, want an invalid-protocol diagnostic", tc.name, resp.Output)
+				}
+				if strings.Contains(resp.Output, "Policy match") {
+					t.Fatalf("%s: invalid protocol produced a policy match (silent wildcard): %q", tc.name, resp.Output)
+				}
+				return
+			}
+			if tc.wantMatch && !strings.Contains(resp.Output, "Policy match") {
+				t.Fatalf("%s: output = %q, want a Policy match (valid/absent protocol regressed)", tc.name, resp.Output)
+			}
+		})
+	}
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -165,7 +165,7 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 	params := strings.TrimPrefix(req.Topic, "test-policy:")
 	var fromZone, toZone, srcIP, dstIP, proto string
 	var dstPort int
-	var portErr error
+	var portErr, protoErr error
 	for _, kv := range strings.Split(params, ",") {
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) != 2 {
@@ -188,7 +188,14 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			// error the way a bad src/dst is reported below.
 			dstPort, portErr = policymatch.ParsePort(parts[1])
 		case "proto":
+			// #3108: a non-empty but unknown/out-of-range protocol token must
+			// NOT silently coerce to the empty "any protocol" wildcard (the
+			// shared matcher's matchApp short-circuits to match-any for an
+			// unresolvable protocol), which would yield a verdict for traffic
+			// that cannot exist. Validate via the shared helper and report the
+			// error the way a bad port/src is reported below.
 			proto = parts[1]
+			protoErr = policymatch.ValidateProtocol(proto)
 		}
 	}
 	switch {
@@ -198,6 +205,8 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 		buf.WriteString("Missing from/to zone parameters\n")
 	case portErr != nil:
 		fmt.Fprintf(buf, "invalid port: %v\n", portErr)
+	case protoErr != nil:
+		fmt.Fprintf(buf, "%v\n", protoErr)
 	case srcIP != "" && net.ParseIP(srcIP) == nil:
 		// A non-empty but malformed src would otherwise parse to nil and be
 		// treated as a wildcard, yielding a false-positive policy match

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -52,6 +52,45 @@ explicitly-invalid port newly errors. Coverage: `port_test.go` (helpers),
 (`MatchPolicies` + `ShowText` `test-policy:`), `pkg/cli/policymatch_port_test.go`,
 and `cmd/cli/testpolicy_port_test.go`.
 
+## Protocol input validation (#3108)
+
+`matchApp` short-circuits to "match any application" before the query protocol
+is resolved (`len(apps)==0` or an empty `proto`, and a policy term of
+`application any` returns true immediately). That makes an unvalidated protocol
+token DANGEROUS at the adapter boundary in exactly the way an unvalidated port
+is: a non-empty but unresolvable protocol (an operator typo like `tcpp`, an
+unknown name, or an out-of-range number like `999`) is never rejected by the
+matcher — it simply fails to constrain anything and the simulator returns a
+permit/deny verdict, masking the typo. One shared validator closes this:
+
+- `ValidateProtocol(string) error` — an empty/whitespace token is "unspecified"
+  (no protocol constraint — the wildcard, unchanged); a non-empty token must
+  resolve via `appid.ProtocolNumber` (a known name/alias `tcp`/`udp`/`icmp`/
+  `ospf`/... or a numeric `0..255`); an unknown name or out-of-range/non-numeric
+  value is rejected. There is no `any` protocol keyword — omit the token for the
+  wildcard (the runtime constrains the protocol dimension only when a resolvable
+  protocol is supplied). A single string validator suffices for every surface,
+  since each accepts the protocol as a string `matchApp` resolves identically by
+  name or number (unlike ports, which arrive both as a numeric gRPC field and as
+  operator strings).
+
+This is applied at ALL FOUR simulator surfaces (mirroring the #3116 port wiring):
+
+- REST `matchPoliciesHandler` — `ValidateProtocol(protocol)` → HTTP 400;
+- gRPC `MatchPolicies` — `ValidateProtocol(req.Protocol)` → `InvalidArgument`;
+- gRPC `ShowText` `test-policy:` (`showTestPolicy`) — `ValidateProtocol` on the
+  `proto=` token → an "invalid protocol" diagnostic in the handler output (the
+  same way a bad port/src/dst is reported);
+- CLI `test policy` + `show security match-policies` (local `pkg/cli`) AND the
+  remote `cli` client (`cmd/cli`) — `ValidateProtocol` → a command error.
+
+A VALID protocol (name or `0..255`) and an ABSENT protocol behave exactly as
+before; only an explicitly-invalid protocol newly errors. Coverage:
+`protocol_test.go` (helper), `pkg/api/rest_filter_failclosed_test.go`,
+`pkg/grpcapi/server_proto_validation_test.go` (`MatchPolicies` + `ShowText`
+`test-policy:`), `pkg/cli/policymatch_protocol_test.go`, and
+`cmd/cli/testpolicy_protocol_test.go`.
+
 ## The surface #3042 missed (#3103)
 
 The original #3042 consolidation routed the REST/gRPC `MatchPolicies` and CLI

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -84,6 +84,37 @@ func ParsePort(s string) (int, error) {
 	return n, nil
 }
 
+// ValidateProtocol checks an explicitly-supplied simulator protocol token. An
+// empty/whitespace token means "unspecified" — the protocol dimension is not
+// constrained (the established match-any wildcard) — and is accepted. A
+// non-empty token must resolve to an IANA protocol number via
+// appid.ProtocolNumber: a known name/alias ("tcp", "udp", "icmp", "ospf", ...)
+// or a numeric value in 0-255. An unknown name ("notaproto") or an
+// out-of-range / non-numeric value ("999", "tcpp") is REJECTED with an error
+// rather than silently treated as "any protocol" (#3108).
+//
+// This is the protocol analogue of ValidatePort/ParsePort (#3116). The shared
+// matcher (matchApp) short-circuits to match-any when the query protocol is the
+// empty string, so an invalid token that slips through unvalidated silently
+// becomes "no protocol constraint" and yields a permit/deny verdict for traffic
+// that cannot exist — masking an operator typo. There is no "any" protocol
+// keyword: omit the token (empty) for the protocol wildcard, matching the
+// runtime evaluator which constrains the protocol dimension only when a
+// resolvable protocol is supplied.
+//
+// A single string validator covers every simulator surface (REST query, gRPC
+// field, CLI/remote-cli token, gRPC test-policy), since each accepts the
+// protocol as a string that matchApp resolves identically by name or number.
+func ValidateProtocol(proto string) error {
+	if strings.TrimSpace(proto) == "" {
+		return nil
+	}
+	if _, ok := appid.ProtocolNumber(proto); !ok {
+		return fmt.Errorf("invalid protocol %q", proto)
+	}
+	return nil
+}
+
 // Query is a 5-tuple policy-simulation request. A nil SrcIP/DstIP or an empty
 // Protocol means "unspecified" — the corresponding match dimension is not
 // constrained (the established diagnostic behavior). A zero SrcPort/DstPort

--- a/pkg/policymatch/protocol_test.go
+++ b/pkg/policymatch/protocol_test.go
@@ -1,0 +1,44 @@
+package policymatch
+
+import "testing"
+
+// TestValidateProtocol asserts the #3108 contract for the simulator protocol
+// token, the protocol analogue of TestValidatePort/TestParsePort (#3116): an
+// empty/whitespace token is "unspecified" (no constraint) and is accepted; a
+// known name/alias ("tcp", "udp", "icmp", "ospf") or a numeric value in 0-255
+// is accepted; and an unknown name ("notaproto", "tcpp"), an out-of-range
+// number ("999"), or other non-resolvable garbage is REJECTED rather than
+// silently treated as "any protocol".
+//
+// FAIL-ON-REVERT: replacing the body with `return nil` (dropping the
+// appid.ProtocolNumber gate) flips every want-error case ("notaproto", "tcpp",
+// "999", "256", "-1") to nil and turns them red — the exact silent-wildcard
+// regression #3108 fixes.
+func TestValidateProtocol(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"", false},         // absent -> unspecified, no constraint (unchanged)
+		{"   ", false},      // whitespace -> unspecified
+		{"tcp", false},      // known name
+		{"udp", false},      // known name
+		{"icmp", false},     // known name
+		{"ospf", false},     // named, non-display protocol
+		{"6", false},        // numeric tcp
+		{"0", false},        // numeric HOPOPT (valid 0..255)
+		{"255", false},      // numeric high bound
+		{"notaproto", true}, // unknown name
+		{"tcpp", true},      // operator typo
+		{"999", true},       // out of range number
+		{"256", true},       // one past the 8-bit top
+		{"-1", true},        // negative number
+		{"any", true},       // no "any" protocol keyword; omit for wildcard
+	}
+	for _, tc := range cases {
+		err := ValidateProtocol(tc.in)
+		if (err != nil) != tc.wantErr {
+			t.Fatalf("ValidateProtocol(%q) err = %v, wantErr = %v", tc.in, err, tc.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The match-policies / test-policy simulators accepted an **invalid protocol token without validation** (codex-review-065 finding 065-05). The shared matcher's `matchApp` short-circuits to "match any application" *before* the query protocol is resolved (empty app list, empty protocol, or a policy term of `application any` all return `true` immediately), so a non-empty but unresolvable protocol — an operator typo like `tcpp`, an unknown name, or an out-of-range number like `999` — was never rejected. It silently failed to constrain anything and the simulator returned a concrete permit/deny verdict, masking the typo and potentially reporting the wrong allow/deny during policy verification or incident response.

This completes the simulator-hardening alongside **#3116** (port validation, just merged), mirroring that pattern for the protocol input.

## The fix

New shared validator `policymatch.ValidateProtocol(string) error`:
- **absent/empty** token = "unspecified", no protocol constraint (the wildcard) — **unchanged**;
- a **non-empty** token must resolve via `appid.ProtocolNumber` (a known name/alias `tcp`/`udp`/`icmp`/`ospf`/... or a numeric `0..255`);
- an unknown name or out-of-range / non-numeric value is **rejected**.

There is no `any` protocol keyword — omit the token for the wildcard, matching the runtime evaluator which constrains the protocol dimension only when a resolvable protocol is supplied. A single string validator suffices for every surface, since each accepts the protocol as a string `matchApp` resolves identically by name or number (unlike ports, which arrive both as a numeric gRPC field and as operator strings — hence the #3116 `ValidatePort`/`ParsePort` pair).

## Surfaces wired (mirroring #3116)

- REST `matchPoliciesHandler` → HTTP 400;
- gRPC `MatchPolicies` → `InvalidArgument`;
- gRPC `ShowText` `test-policy:` (`showTestPolicy`) → an "invalid protocol" diagnostic in the handler output (the way a bad port/src/dst is reported);
- local CLI `show security match-policies` + `test policy`, and the remote `cli` client's `test policy` → a command error.

The empty/any short-circuit in `matchApp` is untouched, so a valid protocol (name or `0..255`) and an absent protocol behave exactly as before; only an explicitly-invalid protocol newly errors.

## Validation

- `go build ./...`, `go vet`, and `go test` across `pkg/api`, `pkg/grpcapi`, `pkg/cli`, `pkg/policymatch`, `cmd/cli` — **591 tests pass**; `gofmt` clean.
- **Fail-on-revert confirmed:** stubbing `ValidateProtocol` to `return nil` flips every want-error case **red** across all six surfaces plus the unit test (`protocol_test.go`, `rest_filter_failclosed_test.go`, `server_proto_validation_test.go`, `policymatch_protocol_test.go`, `testpolicy_protocol_test.go`); restoring the implementation returns them green.

Closes #3108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi