### PR TITLE
config: close multi-value-leaf escape in the #3113 policy-match gate

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-25 — #3142: close multi-value-leaf escape in the #3113 policy-match gate
+
+- **Timestamp**: 2026-06-25
+- **Action**: Extended `validatePolicyMatchLeavesStrict` to also inspect the
+  COLLAPSED tail tokens of a supported `multi:true` match leaf (the
+  `application` leaf's `Keys[1:]` + child sub-nodes, via `firewallMatchValues`),
+  not just the direct children of `match`. A flat-set `match application <vals>
+  dynamic-application/url-category/source-identity ...` collapses the unsupported
+  match-leaf keyword onto the application leaf (the #2419 absorber), where the
+  #3113 direct-child check never saw it — the criterion escaped the gate and the
+  policy silently armed as a broad application match (fail-open). Added a
+  `unsupportedPolicyMatchLeaves` set (the KNOWN unsupported match dimensions) and
+  reject any such keyword found in the tail. A legitimate application value (e.g.
+  `[ junos-http junos-https ]`) is never one of those keywords, so it is not
+  over-rejected. Same strict-reject / lenient-warn split as #3113.
+- **File(s)**: pkg/config/compiler_policy_match.go,
+  pkg/config/compiler_policy_match_3142_test.go, pkg/config/README.md
+- **Validation**: `go build ./...`; `go test ./pkg/config/...` (all green);
+  fail-on-revert confirmed — reverting the tail scan makes the five escape
+  cases COMMIT (the genuine fail-open), turning the escape test RED; the
+  no-over-reject cases stay green. gofmt clean.
+
 ## 2026-06-25 — #3120: IPv6 screen ext-header walk continues past Fragment header
 
 - **Timestamp**: 2026-06-25

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -383,6 +383,26 @@ older binary silently accepted still boots — the leaf stays dropped (the
 pre-existing behaviour), now flagged (#1960 no-brick doctrine, same as
 #3079/#3055/#3060).
 
+The #3113 gate originally inspected only the DIRECT children of `match`, which
+left a multi-value-leaf ESCAPE (#3142, codex-review-067 finding 067-01). `match
+application` is a `multi:true` leaf (`schema_security.go`), so the flat-set
+absorber collapses every trailing non-sibling token onto the application leaf's
+OWN node (`Keys[1:]` plus child sub-nodes — the #2419 collapse), not as a
+sibling of `match`. So `set ... policy p match application any dynamic-application
+junos:FTP` compiles to a single `application` leaf with tail tokens `[any
+dynamic-application junos:FTP]`; the direct-child scan saw only the supported
+`application` leaf and never the tail, so the unsupported `dynamic-application`
+criterion escaped the gate and the policy silently armed as a broad application
+match (`capabilities.go` short-circuits on the first `any`) — the same fail-open
+#3113 closes, reached via the multi-value path. `validatePolicyMatchLeavesStrict`
+now also scans the collapsed tail of a supported match leaf
+(`firewallMatchValues`) and rejects any token in `unsupportedPolicyMatchLeaves`
+(the KNOWN unsupported match dimensions: `dynamic-application`, `url-category`,
+`source-identity`). A legitimate application VALUE is never one of those keywords,
+so a real bracketed list like `match application [ junos-http junos-https ]` is
+NOT over-rejected — only a known unsupported match-leaf keyword masquerading as
+an application value is. Same strict-reject / lenient-warn split as #3113.
+
 **Unsupported security-policy `then permit` children are rejected at commit
 (#3114, interim):** Junos SRX `then permit` accepts action modifiers that turn a
 bare permit into a permit-with-inspection or a permit-into-tunnel —

--- a/pkg/config/compiler_policy_match.go
+++ b/pkg/config/compiler_policy_match.go
@@ -80,6 +80,35 @@ var supportedPolicyMatchLeaves = map[string]bool{
 	"application":                  true,
 }
 
+// unsupportedPolicyMatchLeaves enumerates the KNOWN vSRX `match` leaves xpf
+// does not enforce. #3113 rejects them when they appear as a DIRECT child of
+// `match`. #3142 closes the multi-value-leaf escape: `match application` (and
+// the other `multi:true` match leaves) absorb every trailing non-sibling
+// token onto the SAME node (the #2419 flat-set collapse — values land in
+// child.Keys[1:] and/or child sub-nodes, not as siblings of `match`). So
+//
+//	set ... policy p match application any dynamic-application junos:FTP
+//
+// compiles to one `application` leaf whose tail tokens are
+// `[any dynamic-application junos:FTP]`. The #3113 direct-child scan only
+// sees the supported `application` leaf and never inspects the tail, so the
+// unsupported `dynamic-application` criterion escapes the gate and the policy
+// silently arms as a broad application match — the same fail-open #3113
+// closes, reached via the multi-value-leaf path.
+//
+// These keywords are not legitimate application names (an app value is
+// `junos-http`, `junos:FTP`, a user-defined app, or `any` — never one of
+// these match-dimension keywords), so a token from this set appearing in a
+// supported match leaf's collapsed tail is unambiguously the unsupported
+// criterion masquerading as a value, and is rejected exactly as a direct
+// child would be. Keep in lockstep with the vSRX match dimensions xpf does
+// not yet enforce.
+var unsupportedPolicyMatchLeaves = map[string]bool{
+	"dynamic-application": true,
+	"url-category":        true,
+	"source-identity":     true,
+}
+
 // validatePolicyMatchLeavesStrict walks the `security policies` subtree of
 // the group-expanded AST and rejects any policy whose `match` clause
 // carries a leaf the compiler does not enforce (see file header). Covers
@@ -127,6 +156,22 @@ func validatePolicyMatchLeavesStrict(nodes []*Node, lenient bool) ([]string, err
 		for _, m := range matchNode.Children {
 			leaf := m.Name()
 			if supportedPolicyMatchLeaves[leaf] {
+				// #3142: a multi:true match leaf (application/source-address/
+				// destination-address) absorbs trailing non-sibling tokens
+				// onto its own node (Keys[1:] + child sub-nodes — the #2419
+				// collapse). An unsupported match-leaf keyword written after
+				// the supported leaf's value lands in this tail, invisible to
+				// the direct-child scan above. Re-apply the reject to any
+				// known unsupported match-leaf keyword found in the collapsed
+				// tail (a real value is never one of these keywords, so legit
+				// `application [ junos-http junos-https ]` is not over-rejected).
+				for _, tok := range firewallMatchValues(m) {
+					if unsupportedPolicyMatchLeaves[tok] {
+						if err := emit(scope, policyName, tok); err != nil {
+							return err
+						}
+					}
+				}
 				continue
 			}
 			if err := emit(scope, policyName, leaf); err != nil {

--- a/pkg/config/compiler_policy_match_3142_test.go
+++ b/pkg/config/compiler_policy_match_3142_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #3142 (codex-review-067 finding 067-01): the #3113
+// unsupported-match-leaf gate only inspected DIRECT children of `match`.
+// Because `match application` is a multi:true leaf, the flat-set absorber
+// collapses every trailing non-sibling token (e.g. `dynamic-application
+// junos:FTP`, `url-category Enhanced_Search_Engines`) ONTO the application
+// leaf's own node (Keys[1:] + child sub-nodes — the #2419 collapse). The
+// direct-child scan never saw the tail, so the unsupported criterion ESCAPED
+// the gate and the policy silently armed as a broad application match — the
+// same fail-open #3113 closes, reached via the multi-value-leaf path.
+//
+// The fix extends validatePolicyMatchLeavesStrict to also scan the collapsed
+// tail of a supported multi-value leaf for KNOWN unsupported match-leaf
+// keywords (dynamic-application/url-category/source-identity) and reject them
+// exactly as a direct child. Legitimate application VALUES (real app names)
+// are never one of those keywords, so they are not over-rejected.
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath — bracketed
+// lists (`[ a b ]`) require the lexer's bracket stripping, which
+// strings.Fields does not do.
+func build3142Tree(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestPolicyMatchMultiValueTailEscapeRejected is the fail-on-revert anchor:
+// an unsupported match-leaf keyword collapsed onto the application leaf's
+// tail must be hard-rejected at commit. Reverting the multi-value tail check
+// in validatePolicyMatchLeavesStrict turns every one of these cases GREEN
+// (no error) and so RED.
+func TestPolicyMatchMultiValueTailEscapeRejected(t *testing.T) {
+	// zoneDefs makes the zone-pair escape policies OTHERWISE valid: both
+	// zones are defined and both address criteria are present, so neither the
+	// undefined-zone gate nor the #3044 missing-criterion gate fires — the
+	// ONLY thing that can reject these is the #3142 multi-value tail check.
+	// Reverting that check makes the config COMMIT (the genuine fail-open
+	// escape), turning these RED.
+	zoneDefs := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+	}
+	cases := []struct {
+		name string
+		cmds []string
+		want string // substring expected in the commit error
+	}{
+		{
+			name: "zone-pair application any dynamic-application",
+			cmds: []string{
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application any dynamic-application junos:FTP",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match "dynamic-application"`,
+		},
+		{
+			name: "zone-pair application junos-http dynamic-application",
+			cmds: []string{
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application junos-http dynamic-application junos:FTP",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match "dynamic-application"`,
+		},
+		{
+			name: "zone-pair application any url-category",
+			cmds: []string{
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application any url-category Enhanced_Search_Engines",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match "url-category"`,
+		},
+		{
+			name: "global application any dynamic-application",
+			cmds: []string{
+				"set security policies global policy g match source-address any",
+				"set security policies global policy g match destination-address any",
+				"set security policies global policy g match application any dynamic-application junos:HTTP",
+				"set security policies global policy g then permit",
+			},
+			want: `global policy "g" match "dynamic-application"`,
+		},
+		{
+			name: "global application any source-identity",
+			cmds: []string{
+				"set security policies global policy g match source-address any",
+				"set security policies global policy g match destination-address any",
+				"set security policies global policy g match application any source-identity authenticated-user",
+				"set security policies global policy g then permit",
+			},
+			want: `global policy "g" match "source-identity"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Defining trust/untrust is harmless for the global cases.
+			tree := build3142Tree(t, append(append([]string{}, zoneDefs...), tc.cmds...)...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a multi-value-leaf match escape; want commit rejection (#3142)")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CompileConfig error = %q, want substring %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "#3113") {
+				t.Fatalf("CompileConfig error = %q, want #3113 reference", err.Error())
+			}
+		})
+	}
+}
+
+// TestPolicyMatchApplicationValuesNotOverRejected proves the guard does NOT
+// over-reject legitimate application values that collapse onto the same
+// multi-value leaf. A bracketed app list and multi-token app sequences are
+// real values, not unsupported match-leaf keywords, and must still commit.
+func TestPolicyMatchApplicationValuesNotOverRejected(t *testing.T) {
+	t.Run("zone-pair bracketed application list", func(t *testing.T) {
+		tree := build3142Tree(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies from-zone trust to-zone untrust policy p match source-address any",
+			"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy p match application [ junos-http junos-https ]",
+			"set security policies from-zone trust to-zone untrust policy p then permit",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig over-rejected a legit bracketed application list: %v", err)
+		}
+	})
+	t.Run("global bracketed application list", func(t *testing.T) {
+		tree := build3142Tree(t,
+			"set security policies global policy g match source-address any",
+			"set security policies global policy g match destination-address any",
+			"set security policies global policy g match application [ junos-http junos-https junos-dns-udp ]",
+			"set security policies global policy g then permit",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig over-rejected a legit global bracketed application list: %v", err)
+		}
+	})
+	t.Run("application any alone", func(t *testing.T) {
+		tree := build3142Tree(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies from-zone trust to-zone untrust policy p match source-address any",
+			"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy p match application any",
+			"set security policies from-zone trust to-zone untrust policy p then permit",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig over-rejected application any: %v", err)
+		}
+	})
+}
+
+// TestPolicyMatchMultiValueTailEscapeLenientWarns proves the tolerant
+// load/peer-sync path (CompileConfigLenient) does NOT fail on the tail
+// escape — it compiles and records a warning naming the keyword, so an
+// already-persisted config still boots (#1960 fail-closed-on-load).
+func TestPolicyMatchMultiValueTailEscapeLenientWarns(t *testing.T) {
+	tree := build3142Tree(t,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application any dynamic-application junos:FTP",
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-failed on a multi-value tail escape; want warn-and-boot: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3113") && strings.Contains(w, "dynamic-application") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CompileConfigLenient warnings = %v, want a #3113 tail-escape warning", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
Closes #3142

## Problem (codex-review-067 finding 067-01)

The #3113 reject-at-commit gate (`validatePolicyMatchLeavesStrict` in
`pkg/config/compiler_policy_match.go`) rejects an unsupported security-policy
`match` leaf (`dynamic-application` / `url-category` / `source-identity`), but it
only inspected the **DIRECT children** of `match`.

`match application` is a `multi:true` leaf (`schema_security.go`), so the
flat-set absorber collapses every trailing non-sibling token onto the
application leaf's **own** node (`Keys[1:]` plus child sub-nodes — the #2419
collapse), not as a sibling of `match`. So:

```
set security policies from-zone trust to-zone untrust policy p \
    match application any dynamic-application junos:FTP
```

compiles to a single `application` leaf whose tail tokens are
`[any dynamic-application junos:FTP]`. The #3113 direct-child scan saw only the
supported `application` leaf and never the tail, so the unsupported
`dynamic-application` criterion **escaped the gate** and the policy silently
armed as a broad application match (`capabilities.go` short-circuits on the
first `any`) — the same fail-open #3113 closes, reached via the multi-value-leaf
path.

## Fix

`validatePolicyMatchLeavesStrict` now also scans the **collapsed tail** of a
supported match leaf (via `firewallMatchValues`, which reads `Keys[1:]` AND
child nodes per the #2419 multi-value-leaf gotcha) and rejects any token in the
new `unsupportedPolicyMatchLeaves` set — the KNOWN unsupported match dimensions:
`dynamic-application`, `url-category`, `source-identity`.

### No over-reject of application values

A legitimate application VALUE is never one of those keywords, so a real
bracketed list like `match application [ junos-http junos-https ]` is **not**
over-rejected — only a known unsupported match-leaf keyword masquerading as an
application value is. The check is keyword-membership, not allowlist-inverse, so
arbitrary app names pass through.

Same strict-reject / lenient-warn split as #3113 (commit hard-fails; tolerant
load/peer-sync downgrades to a #1960 no-brick warning). Both zone-pair and
global policies covered.

## Validation

- `go build ./...` — clean
- `go test ./pkg/config/...` — all green
- `gofmt` clean (the two unrelated files gofmt flags are pre-existing in master)
- **Fail-on-revert**: reverting the tail scan makes all five escape cases
  COMMIT (the genuine fail-open — `dynamic-application` absorbed as a fake app
  value), turning `TestPolicyMatchMultiValueTailEscapeRejected` RED; the
  `TestPolicyMatchApplicationValuesNotOverRejected` cases stay green. Confirmed
  RED→GREEN.

New tests in `pkg/config/compiler_policy_match_3142_test.go` cover the
zone-pair + global escape (dynamic-application/url-category/source-identity),
the no-over-reject guarantee (bracketed list, `application any`), and the
lenient warn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi