### PR TITLE
forwarding: table-scope local-delivery resolution (cross-VRF ifindex leak)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-06-25 — #3151: local-delivery resolution table-scoped (cross-VRF leak)
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fix cross-routing-instance ifindex leak in to-self
+  (local-delivery) forwarding resolution. `lookup_forwarding_resolution_inner_ecmp`
+  scanned the global `connected_v4`/`connected_v6` lists with no
+  `entry.table == table` filter, so a to-self packet in VRF A could
+  resolve its local/egress/tx ifindex to an overlapping local address
+  owned by VRF B → wrong zone/RG attribution. Mirrored the #2388
+  route-path fix: canonicalize the ingress table BEFORE the local check
+  and filter the connected scan by it in BOTH v4 and v6 branches. Default
+  routing-instance (inet.0/inet6.0) case preserved.
+- **File(s)**: userspace-dp/src/afxdp/forwarding/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md
+- **Validation**: cargo build --release clean; new tests
+  `local_delivery_is_table_scoped_no_cross_vrf_leak` (+ v6 sibling)
+  GREEN; fail-on-revert RED with the filter removed; full forwarding
+  suite 193 passed.
+
 ## 2026-06-25 — #3120: IPv6 screen ext-header walk continues past Fragment header
 
 - **Timestamp**: 2026-06-25

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -44,6 +44,19 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
   egress inference at build time, `infer_connected_route_target_*`,
   stays global — that resolves "which interface reaches this gateway IP",
   not a destination egress.)
+  - **Local-delivery (to-self) attribution is table-scoped too (#3151).**
+    The `lookup_forwarding_resolution_inner_ecmp` shortcut for a
+    destination in `local_v[46]` resolves `local_ifindex` /
+    `egress_ifindex` / `tx_ifindex` by scanning `connected_v[46]`. That
+    scan applies the SAME `entry.table == table` filter as the route path
+    (canonicalizing the ingress table FIRST, before the local-address
+    check). Without it, when the same local IP is configured in more than
+    one routing-instance, a to-self packet in VRF A could attribute its
+    local/egress/tx ifindex to VRF B's interface — mis-feeding
+    zone/security-policy selection and HA RG ownership
+    (`owner_rg_for_flow(egress_ifindex)`). The default routing-instance
+    (`inet.0`/`inet6.0`) case still matches default-table connected
+    routes.
 - **ECMP: all next-hops retained, dead ones skipped (#2389), per-FLOW
   spread (#2734).** A static route keeps EVERY configured next-hop
   (`RouteEntryV4::next_hops: Vec<RouteNextHopV4>`). `select_route_next_hop`

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1069,11 +1069,24 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
 ) -> ForwardingResolution {
     match dst {
         IpAddr::V4(ip) => {
+            let table = table
+                .map(|table| canonical_route_table(table, false))
+                .unwrap_or_else(|| DEFAULT_V4_TABLE.to_string());
             if state.local_v4.contains(&ip) {
+                // #3151: local-delivery (to-self) attribution is table-scoped,
+                // exactly like the route-path connected scan (#2388). When the
+                // same local IP exists in more than one routing-instance, a
+                // to-self packet in VRF A must NOT resolve its
+                // local/egress/tx ifindex to VRF B's connected entry — that
+                // would mis-attribute zone/security-policy and HA RG ownership
+                // (owner_rg_for_flow(egress_ifindex)) across VRFs. Filter the
+                // connected scan by the canonical ingress table; the default
+                // routing-instance (inet.0) case still matches default-table
+                // connected routes.
                 let local_ifindex = state
                     .connected_v4
                     .iter()
-                    .find(|entry| entry.prefix.addr() == ip)
+                    .find(|entry| entry.table == table && entry.prefix.addr() == ip)
                     .map(|entry| entry.ifindex)
                     .unwrap_or(0);
                 return ForwardingResolution {
@@ -1088,9 +1101,6 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                     tx_vlan_id: 0,
                 };
             }
-            let table = table
-                .map(|table| canonical_route_table(table, false))
-                .unwrap_or_else(|| DEFAULT_V4_TABLE.to_string());
             lookup_forwarding_resolution_v4(
                 state,
                 dynamic_neighbors,
@@ -1102,11 +1112,16 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
             )
         }
         IpAddr::V6(ip) => {
+            let table = table
+                .map(|table| canonical_route_table(table, true))
+                .unwrap_or_else(|| DEFAULT_V6_TABLE.to_string());
             if state.local_v6.contains(&ip) {
+                // #3151: table-scoped local-delivery attribution (see the v4
+                // branch above and the #2388 route-path connected scan).
                 let local_ifindex = state
                     .connected_v6
                     .iter()
-                    .find(|entry| entry.prefix.addr() == ip)
+                    .find(|entry| entry.table == table && entry.prefix.addr() == ip)
                     .map(|entry| entry.ifindex)
                     .unwrap_or(0);
                 return ForwardingResolution {
@@ -1121,9 +1136,6 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                     tx_vlan_id: 0,
                 };
             }
-            let table = table
-                .map(|table| canonical_route_table(table, true))
-                .unwrap_or_else(|| DEFAULT_V6_TABLE.to_string());
             lookup_forwarding_resolution_v6(
                 state,
                 dynamic_neighbors,

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2498,6 +2498,167 @@ fn connected_routes_are_table_scoped_no_cross_vrf_leak() {
     assert_eq!(resolved_a.egress_ifindex, 101);
 }
 
+/// #3151: local-delivery (to-self) resolution must be table-scoped, mirroring
+/// the #2388 route-path fix. Two routing-instances own the SAME local address
+/// (10.0.0.1) on different interfaces. A to-self packet resolved in tenant-b's
+/// table must attribute local/egress/tx ifindex to tenant-b's interface (202),
+/// never leak to tenant-a's (101, pushed first). Revert (drop the
+/// `entry.table == table` filter in the local-delivery connected scan) → the
+/// global scan returns tenant-a's interface → wrong VRF/zone/RG attribution →
+/// RED.
+#[test]
+fn local_delivery_is_table_scoped_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![
+            crate::ZoneSnapshot {
+                name: "za".to_string(),
+                id: TEST_TRUST_ZONE_ID,
+            },
+            crate::ZoneSnapshot {
+                name: "zb".to_string(),
+                id: TEST_UNTRUST_ZONE_ID,
+            },
+        ],
+        interfaces: vec![
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1.80".to_string(),
+                zone: "za".to_string(),
+                routing_instance: "tenant-a".to_string(),
+                linux_name: "ge-0-0-1.80".to_string(),
+                ifindex: 101,
+                hardware_addr: "02:00:00:00:00:a1".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "10.0.0.1/32".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1.90".to_string(),
+                zone: "zb".to_string(),
+                routing_instance: "tenant-b".to_string(),
+                linux_name: "ge-0-0-1.90".to_string(),
+                ifindex: 202,
+                hardware_addr: "02:00:00:00:00:b2".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet".to_string(),
+                    address: "10.0.0.1/32".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+
+    // The destination is one of our own local addresses (to-self): it is in
+    // both VRFs' connected lists. Resolved in tenant-b's table → tenant-b's
+    // interface (202).
+    let resolved_b = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        Some("tenant-b.inet.0"),
+    );
+    assert_eq!(
+        resolved_b.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "to-self traffic must be local-delivery",
+    );
+    assert_eq!(
+        resolved_b.local_ifindex, 202,
+        "tenant-b to-self must attribute tenant-b's interface, not tenant-a's (cross-VRF leak)",
+    );
+    assert_eq!(resolved_b.egress_ifindex, 202);
+
+    // Mirror: tenant-a's table resolves tenant-a's interface (101).
+    let resolved_a = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        Some("tenant-a.inet.0"),
+    );
+    assert_eq!(resolved_a.local_ifindex, 101);
+}
+
+/// #3151 (v6): identical table-scoped local-delivery guarantee for the IPv6
+/// branch (connected_v6). Revert the `entry.table == table` filter → tenant-a
+/// leak → RED.
+#[test]
+fn local_delivery_v6_is_table_scoped_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![
+            crate::ZoneSnapshot {
+                name: "za".to_string(),
+                id: TEST_TRUST_ZONE_ID,
+            },
+            crate::ZoneSnapshot {
+                name: "zb".to_string(),
+                id: TEST_UNTRUST_ZONE_ID,
+            },
+        ],
+        interfaces: vec![
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1.80".to_string(),
+                zone: "za".to_string(),
+                routing_instance: "tenant-a".to_string(),
+                linux_name: "ge-0-0-1.80".to_string(),
+                ifindex: 301,
+                hardware_addr: "02:00:00:00:00:a1".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet6".to_string(),
+                    address: "2001:db8::1/128".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+            crate::InterfaceSnapshot {
+                name: "ge-0/0/1.90".to_string(),
+                zone: "zb".to_string(),
+                routing_instance: "tenant-b".to_string(),
+                linux_name: "ge-0-0-1.90".to_string(),
+                ifindex: 402,
+                hardware_addr: "02:00:00:00:00:b2".to_string(),
+                addresses: vec![crate::InterfaceAddressSnapshot {
+                    family: "inet6".to_string(),
+                    address: "2001:db8::1/128".to_string(),
+                    scope: 0,
+                }],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+
+    let resolved_b = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        Some("tenant-b.inet6.0"),
+    );
+    assert_eq!(
+        resolved_b.disposition,
+        ForwardingDisposition::LocalDelivery,
+    );
+    assert_eq!(
+        resolved_b.local_ifindex, 402,
+        "tenant-b to-self (v6) must attribute tenant-b's interface, not tenant-a's",
+    );
+
+    let resolved_a = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        IpAddr::V6("2001:db8::1".parse().unwrap()),
+        Some("tenant-a.inet6.0"),
+    );
+    assert_eq!(resolved_a.local_ifindex, 301);
+}
+
 /// #2389: a static route with two next-hops must retain BOTH in the FIB
 /// (equal-cost), and a dead first next-hop must fall back to a live
 /// alternate. Revert the build to `next_hops.first()` → only one candidate


### PR DESCRIPTION
Closes #3151

## Problem
The to-self (local-delivery) shortcut in `lookup_forwarding_resolution_inner_ecmp` (`userspace-dp/src/afxdp/forwarding/mod.rs`) resolved the local/egress/tx ifindex by scanning the **global** `connected_v4` / `connected_v6` lists for the first prefix whose address equals the destination — with **no** routing-instance/table filter:

```rust
.find(|entry| entry.prefix.addr() == ip)   // no entry.table == table
```

When the same local IP is configured in more than one routing-instance (overlapping VRF addressing), a to-self packet arriving in VRF A could match whichever connected entry was inserted first — possibly an interface owned by VRF B. That mis-attributes the local-delivery logical interface, which feeds **zone/security-policy** selection and **HA RG ownership** (`owner_rg_for_flow(egress_ifindex)`): a routing-instance isolation bypass for to-self traffic. (agy-review-069 finding 069-08, verified against source.)

## Fix (v4 + v6)
`ConnectedRouteV4`/`ConnectedRouteV6` already carry the canonical routing-table name for exactly this purpose. This is the **#2388 precedent** — that PR added the `entry.table == table` filter to the **route-path** connected scan, and `forwarding_build/fib.rs:340` documents that the cross-VRF leak is a lookup-time concern fixed at the lookup site. The local-delivery shortcut is reached *before* the table-scoped route path and never applied that filter; the V6 branch had the identical omission.

The fix canonicalizes the ingress table **first** (moving `canonical_route_table` above the `local_v4`/`local_v6` check) and filters the local-delivery connected scan by `entry.table == table` in both branches — identical to #2388.

## Default-VRF still works
A to-self packet with no table (or `inet.0`/`inet6.0`) canonicalizes to the default table and matches default-table connected entries, so the common single-VRF case is unchanged.

## Validation
- `cargo build --release -p xpf-userspace-dp` — clean.
- New **fail-on-revert** tests `local_delivery_is_table_scoped_no_cross_vrf_leak` (+ v6 sibling): a to-self address present in two VRFs resolves the same-table interface (202/402) and never the cross-VRF one (101/301). Reverting the `entry.table == table` filter turns both **RED** (confirmed: 2 failed); restored → GREEN.
- Full forwarding suite: **193 passed**.
- Forwarding module README updated with the #3151 rule.

Dataplane change; the unit test is the primary gate. A cluster smoke can be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi