### PR TITLE
config: align strict app-spec protocol gate to dataplane resolver (#3150)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-06-25 — #3150: strict app-spec protocol gate aligned to dataplane resolver
+
+- **Timestamp**: 2026-06-25
+- **Action**: Fix commit/apply split — `validateApplicationSpecsStrict`
+  resolved a policy/NAT-referenced application's `protocol` leaf via the
+  lenient `validateProtocol` (blanket `strings.HasPrefix("junos-")` accept),
+  so `protocol junos-foobar` committed cleanly while the dataplane resolver
+  `appid.ProtocolNumber` rejects it → userspace policy capability gate
+  disarms (apply fails after a green commit). Switched the strict app-spec
+  protocol check to `filterProtocolResolvable` (the existing
+  `appid.ProtocolNumber` mirror, drift-guarded). Lenient `validateProtocol`
+  unchanged (still used by `ValidateConfig` warning surface / unreferenced
+  apps). Lenient load downgrade (`lenientApplicationSpecs`) preserved.
+- **File(s)**: pkg/config/compiler_validate_strict.go (fix + comments),
+  pkg/config/compiler_application_specs_test.go (fail-on-revert tests),
+  pkg/config/README.md (gotcha note), _Log.md
+- **Validation**: go build ./..., go vet ./pkg/config/..., go test
+  ./pkg/config/... ./pkg/appid/... (1650 pass), gofmt -l clean. Fail-on-
+  revert proven: restoring the broad junos- accept makes the junos-foobar
+  reject test RED.
+
 ## 2026-06-25 — #3025: NAT64 non-fragmented L4 checksum goes incremental (RFC 1624)
 
 - **Timestamp**: 2026-06-25

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -520,6 +520,36 @@ SURGICAL — only NAME references are checked; `then community (set|add) <value>
 carries a community VALUE (e.g. `65000:100`), not a list reference, and a defined
 community reference commits unchanged.
 
+**Policy-referenced application protocols are validated against the dataplane
+resolver (#3150 — codex-review-067 finding 067-06):** a user-defined
+`set applications application <name> protocol <token>` that is REFERENCED by a
+security policy or NAT rule's `match application` (or any application when
+`services application-identification` is on) is hard-rejected at commit by
+`validateApplicationSpecsStrict` (`compiler_validate_strict.go`) when the
+protocol token is unresolvable. The bug: that gate resolved the token via the
+LENIENT `validateProtocol`, which blanket-accepts ANY `junos-` prefix
+(`strings.HasPrefix("junos-")`). So `protocol junos-foobar` committed cleanly,
+but the dataplane resolves protocols only through `appid.ProtocolNumber`
+(`pkg/appid`), which knows only the CONCRETE junos-* aliases (`junos-ping`,
+`junos-tcp-any`, ...) — it rejects `junos-foobar`. The userspace policy
+capability gate (`pkg/dataplane/userspace`) then disarms the snapshot
+(`ForwardingSupported=false`): a commit-succeeds / apply-fails split. The fix
+resolves the application's protocol through `filterProtocolResolvable` — the
+same `appid.ProtocolNumber` mirror the firewall-filter `from protocol` gate
+(#2175) already uses, pinned to the SSOT by the `pkg/appid` drift-guard test
+`TestFilterProtocolResolvableMatchesProtocolNumber` — so a token the dataplane
+cannot represent is rejected at commit. Real protocol names, numeric 0..255
+values, and resolvable junos-* aliases still commit; only genuinely
+unresolvable tokens reject. The lenient `validateProtocol` is unchanged and
+still used by `ValidateConfig`'s warning surface (so an UNREFERENCED library
+app with a bogus protocol stays a warning, not a commit error). The tolerant
+load/peer-sync path downgrades the reject to a warning
+(`lenientApplicationSpecs`) so an already-persisted or peer-synced config an
+older binary accepted still boots (#1960 no-brick doctrine). Distinct from
+#2124/#2142 (those fixed alias drift / malformed port-or-protocol specs); this
+residual was specifically the strict app-spec path still using the blanket
+`junos-` HasPrefix.
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler_application_specs_test.go
+++ b/pkg/config/compiler_application_specs_test.go
@@ -236,3 +236,86 @@ func TestApplicationSpec_ReferencedBad_LenientWarns(t *testing.T) {
 		t.Fatalf("expected lenient path to record an application-spec downgrade warning, got %v", cfg.Warnings)
 	}
 }
+
+// referencedProtoApp wires the issue's exact #3150 trigger: a policy that
+// matches an application whose `protocol` leaf is the supplied token.
+func referencedProtoApp(proto string) []string {
+	return []string{
+		"set applications application BAD protocol " + proto,
+		"set applications application BAD destination-port 80",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application BAD",
+		"set security policies from-zone trust to-zone untrust policy p then deny",
+	}
+}
+
+// #3150: validateProtocol blanket-accepts ANY "junos-" prefix, so a
+// policy-referenced application with `protocol junos-foobar` committed cleanly
+// while the dataplane resolver (appid.ProtocolNumber, mirrored by
+// filterProtocolResolvable) rejects it — disarming the userspace policy
+// capability gate (a commit-succeeds / apply-fails split). The strict gate must
+// resolve the protocol through the SAME authority the dataplane uses, so an
+// unresolvable junos-* token is rejected at COMMIT.
+//
+// Fail-on-revert: restoring the broad `strings.HasPrefix("junos-")` accept in
+// validateApplicationSpecsStrict makes this commit SUCCEED, turning the test RED.
+func TestApplicationSpec_ReferencedUnknownJunosProtocol_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedProtoApp("junos-foobar")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject application BAD with protocol junos-foobar " +
+			"(the dataplane's appid.ProtocolNumber cannot resolve it)")
+	}
+	if !strings.Contains(err.Error(), "BAD") ||
+		!strings.Contains(err.Error(), "junos-foobar") {
+		t.Fatalf("error %q must name application BAD and the bad protocol junos-foobar", err.Error())
+	}
+}
+
+// Non-tautological companion: a RESOLVABLE junos-* alias the catalog actually
+// knows (junos-ping → ICMP) must still commit cleanly, proving the #3150 reject
+// is scoped to genuinely-unresolvable tokens and does not break legitimate
+// junos-* protocol aliases.
+func TestApplicationSpec_ReferencedResolvableJunosProtocol_AcceptsAtCommit(t *testing.T) {
+	for _, proto := range []string{"junos-ping", "junos-tcp-any", "junos-gre"} {
+		tree := flatTreeFromSets(t, referencedProtoApp(proto)...)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("expected commit to accept application BAD with resolvable protocol %q: %v", proto, err)
+		}
+	}
+}
+
+// A numeric protocol referenced by a policy must commit (appid.ProtocolNumber
+// resolves any 0..255 numeric, including the deliberate "0" / HOPOPT).
+func TestApplicationSpec_ReferencedNumericProtocol_AcceptsAtCommit(t *testing.T) {
+	for _, proto := range []string{"0", "47", "255"} {
+		tree := flatTreeFromSets(t, referencedProtoApp(proto)...)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("expected commit to accept application BAD with numeric protocol %q: %v", proto, err)
+		}
+	}
+}
+
+// No-brick (#1960): a config persisted/synced with a policy-referenced
+// unresolvable junos-* protocol must still LOAD on the tolerant path
+// (CompileConfigLenient) — downgraded to a warning — so an upgraded node does
+// not fail closed on boot.
+func TestApplicationSpec_ReferencedUnknownJunosProtocol_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedProtoApp("junos-foobar")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of a referenced bad-protocol app must not fail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "application spec") && strings.Contains(w, "junos-foobar") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected lenient path to record an application-spec downgrade warning, got %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2215,8 +2215,9 @@ func validateZoneInterfaceMembershipStrict(cfg *Config) error {
 // (`set applications application <name> ...`) whose destination-port /
 // source-port is malformed (not a valid numeric port, port range, or known
 // service name, out of 1..65535, or an inverted low>high range) or whose
-// protocol token is not a known name, a junos-*
-// alias, or a 0..255 number (#2142) — but ONLY for applications that are
+// protocol token is not a known name, a RESOLVABLE junos-* alias (one the
+// dataplane's appid.ProtocolNumber actually knows — #3150), or a 0..255 number
+// (#2142) — but ONLY for applications that are
 // actually REFERENCED by a security policy or a source/destination-NAT rule's
 // `match application` (#2187), or for ALL applications when
 // `services application-identification` is enabled (every app then compiles
@@ -2238,12 +2239,16 @@ func validateZoneInterfaceMembershipStrict(cfg *Config) error {
 // such an app is referenced by a policy, or app-id is turned on, the gate
 // engages.
 //
-// It reuses validatePortSpec and validateProtocol — the same config-layer
-// validators that produce the warning in ValidateConfig — so no new divergent
-// port/protocol table is introduced (the dataplane's #2124 capability gate is
-// the runtime backstop, and these validators are a superset of what it admits).
-// Iteration is sorted by application name so the first-reported error is
-// deterministic across runs (Go map order is randomized).
+// It reuses validatePortSpec for ports. For the protocol it uses
+// filterProtocolResolvable (the #2124/#2175 appid.ProtocolNumber mirror) rather
+// than the lenient validateProtocol: validateProtocol blanket-accepts any
+// "junos-" prefix, so a referenced app with `protocol junos-foobar` would commit
+// cleanly while the dataplane's appid.ProtocolNumber rejects it, disarming the
+// userspace policy capability gate (a commit/apply split — #3150). Using the
+// same authority the dataplane uses keeps commit and apply in agreement (the
+// dataplane's #2124 capability gate stays the runtime backstop). Iteration is
+// sorted by application name so the first-reported error is deterministic across
+// runs (Go map order is randomized).
 func validateApplicationSpecsStrict(cfg *Config) error {
 	if cfg == nil || len(cfg.Applications.Applications) == 0 {
 		return nil
@@ -2268,10 +2273,25 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 		if err := validatePortSpec(app.SourcePort); err != nil {
 			return fmt.Errorf("application %q: source-port: %w", name, err)
 		}
-		if app.Protocol != "" {
-			if err := validateProtocol(app.Protocol); err != nil {
-				return fmt.Errorf("application %q: %w", name, err)
-			}
+		// #3150: resolve the protocol against the SAME authority the dataplane
+		// uses (appid.ProtocolNumber, mirrored by filterProtocolResolvable) — NOT
+		// the lenient validateProtocol, which blanket-accepts any "junos-" prefix.
+		// validateProtocol would commit `protocol junos-foobar` cleanly while
+		// appid.ProtocolNumber rejects it, so the userspace policy capability gate
+		// (pkg/dataplane/userspace) then disarms — a commit-succeeds / apply-fails
+		// split. filterProtocolResolvable accepts only the concrete junos-* aliases
+		// the catalog knows (e.g. junos-ping, junos-tcp-any), real protocol names,
+		// and 0..255 numbers, so a referenced app whose protocol the dataplane
+		// cannot represent is rejected at commit instead.
+		if app.Protocol != "" && !filterProtocolResolvable(app.Protocol) {
+			return fmt.Errorf(
+				"application %q: unknown protocol %q (use a protocol name such as "+
+					"tcp/udp/icmp/icmpv6/gre/esp/ah/sctp/ospf, a resolvable junos-* "+
+					"alias such as junos-ping/junos-tcp-any, or a numeric value "+
+					"0-255 — the dataplane resolves protocols via appid.ProtocolNumber "+
+					"and cannot represent an arbitrary junos-* token, so accepting it "+
+					"would commit cleanly but fail to arm the referencing policy)",
+				name, app.Protocol)
 		}
 	}
 	return nil
@@ -2536,12 +2556,15 @@ func validateFilterActionsStrict(cfg *Config) error {
 // test TestFilterProtocolResolvableMatchesProtocolNumber via the exported
 // FilterProtocolResolvable accessor.
 //
-// The acceptance set is intentionally TIGHTER than validateProtocol (used by
-// validateApplicationSpecsStrict): validateProtocol blanket-accepts ANY
-// "junos-" prefix, but appid.ProtocolNumber only resolves the specific
-// junos-* aliases below, so an unknown "junos-foobar" must be rejected here to
-// stay consistent with the dataplane SSOT — otherwise commit would pass while
-// the swallowed dataplane gate dropped the constraint.
+// The acceptance set is intentionally TIGHTER than validateProtocol (the
+// lenient validator used by ValidateConfig's warning surface): validateProtocol
+// blanket-accepts ANY "junos-" prefix, but appid.ProtocolNumber only resolves
+// the specific junos-* aliases below, so an unknown "junos-foobar" must be
+// rejected here to stay consistent with the dataplane SSOT — otherwise commit
+// would pass while the swallowed dataplane gate dropped the constraint. Since
+// #3150, validateApplicationSpecsStrict also resolves an application's own
+// `protocol` leaf through THIS helper (not validateProtocol) for the same
+// reason — the broad junos-* accept there caused a commit/apply split.
 func filterProtocolResolvable(token string) bool {
 	switch strings.ToLower(strings.TrimSpace(token)) {
 	case "tcp", "junos-tcp-any",


### PR DESCRIPTION
## Problem (codex-review-067 finding 067-06): commit/apply split

A user-defined `set applications application <name> protocol <token>` that is **referenced** by a security policy or NAT `match application` (or any app when `services application-identification` is on) is hard-rejected at commit by `validateApplicationSpecsStrict`. But that gate resolved the protocol token through the **lenient** `validateProtocol`, which blanket-accepts ANY `junos-` prefix:

```go
if strings.HasPrefix(strings.ToLower(proto), "junos-") { return nil }
```

So a referenced app with `protocol junos-foobar` **committed cleanly**, while the dataplane resolves protocols only through `appid.ProtocolNumber` (`pkg/appid`), which knows only the concrete junos-* aliases (`junos-ping`, `junos-tcp-any`, ...) and **rejects** `junos-foobar`. The userspace policy capability gate (`pkg/dataplane/userspace`) then disarms the snapshot (`ForwardingSupported=false`): **commit succeeds, apply fails** — the config commits but the dataplane can't arm the policy.

## Fix: appid-aligned validation

Resolve the application's protocol through `filterProtocolResolvable` — the same `appid.ProtocolNumber` mirror the firewall-filter `from protocol` gate (#2175) already uses, pinned to the SSOT by the `pkg/appid` drift-guard `TestFilterProtocolResolvableMatchesProtocolNumber`. A token the dataplane cannot represent is now rejected **at commit**; real protocol names, numeric 0..255 values, and resolvable junos-* aliases still commit.

- The lenient `validateProtocol` is **unchanged** and still backs `ValidateConfig`'s warning surface, so an **unreferenced** library app with a bogus protocol stays a warning (not a commit error).
- The tolerant load / peer-sync path keeps downgrading to a warning (`lenientApplicationSpecs`) so an already-persisted / peer-synced config still boots — #1960 strict-at-commit / lenient-on-load.

Distinct from #2124/#2142 (alias drift / malformed specs); this residual was the strict app-spec path still using the blanket `junos-` HasPrefix.

## Validation

- **Fail-on-revert** (`ParseSetCommand`+`SetPath`+`CompileConfig`): a referenced `protocol junos-foobar` is rejected at commit; restoring the broad accept turns the test **RED** (proven). Resolvable junos-* aliases (`junos-ping`/`junos-tcp-any`/`junos-gre`), numeric protocols (`0`/`47`/`255`), and the lenient-warns no-brick path all asserted.
- `go build ./...`, `go vet ./pkg/config/...`, `go test ./pkg/config/... ./pkg/appid/...` (1650 pass), `gofmt` clean.

Closes #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)