### PR TITLE
nat: reject DNAT destination-address prefix instead of silent narrowing (#3029)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-25 — #3029: DNAT destination-address prefix silently narrowed to a single host
+
+- **Action**: Hard-reject a destination-NAT rule whose `match destination-address`
+  is a MULTI-HOST prefix (e.g. `198.51.100.0/24`). The DNAT snapshot builder strips
+  the `/mask` and the Rust `DnatTable` keys on an EXACT host `IpAddr` (no prefix/LPM),
+  so only the network address translated and every other host in the block silently
+  bypassed DNAT. Contract: commit-REJECT (fail-closed, #1960 strict-with-lenient),
+  NOT honor-prefix — block-mapping semantics (1:1 vs many:one) + an LPM table are an
+  unsettled dataplane feature (issue is a /research candidate). Single-host (bare IP,
+  /32, /128) unchanged.
+- **File(s)**: pkg/config/compiler_validate_strict.go (validateDestinationNATAddressesStrict
+  extended; reuses isHostMaskAddress), pkg/config/compiler_dnat_address_test.go (4 new
+  tests: v4/v6 prefix reject, host-mask compiles, lenient warns), docs/feature-gaps.md.
+- **Validation**: go build ./...; go test ./pkg/config/... (1698 pass + new); RED->GREEN
+  confirmed (disable the gate condition -> reject tests FAIL); gofmt clean.
+
 ## 2026-06-25 — #3149 (folds #3147): policy dangling/empty address-set hard-reject
 
 - **Timestamp**: 2026-06-25

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -168,6 +168,21 @@ User-based policy enforcement integrating with directory services. Not implement
 
 xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, protocol-only match, port rewriting, multi-port matching), static 1:1, NAT64, and exemption rules. These are additional NAT features from the vSRX.
 
+> **DNAT `match destination-address` is exact-host only (#3029).** The
+> userspace `DnatTable` keys on an exact destination `IpAddr` (no prefix /
+> LPM match), so a destination-NAT rule whose `match destination-address` is
+> a multi-host prefix (e.g. `198.51.100.0/24`) cannot be honored — the
+> snapshot builder would strip the mask and translate only the network
+> address, silently bypassing every other host in the block. Such a rule is
+> **hard-rejected at commit** (`validateDestinationNATAddressesStrict`),
+> downgraded to a warning on the tolerant load / peer-sync path (#1960
+> no-brick). Single-host destinations (a bare IP, an explicit `/32`, or
+> `/128`) are accepted unchanged. Block-to-block destination NAT (the Junos
+> 1:1-offset / many:one block-mapping semantics) is a separate dataplane
+> feature — see #3029 (and the static-NAT block sibling #3031); honoring a
+> DNAT destination prefix needs a prefix-match table plus confirmed Junos
+> block-mapping semantics.
+
 > **NAT64 inbound policy matches the SYNTHETIC IPv6 destination, not the
 > real internal IPv4 host (#2358).** For inbound NAT64 flows the security
 > policy is evaluated against the synthetic IPv6 destination the v6 client

--- a/pkg/config/compiler_dnat_address_test.go
+++ b/pkg/config/compiler_dnat_address_test.go
@@ -90,6 +90,66 @@ func TestDNATPartialValidDestinationAccepted(t *testing.T) {
 	}
 }
 
+// #3029: a DNAT match destination-address that is a MULTI-HOST prefix
+// (e.g. 198.51.100.0/24) compiles today but the snapshot builder strips the
+// /mask and the Rust DnatTable keys on an EXACT host IP — so only the network
+// address (198.51.100.0) translates and every other host in the block bypasses
+// DNAT (silent under-translation). The gate must hard-reject it at commit,
+// naming the rule and the offending prefix. Reverting the gate addition makes
+// this RED (the rule compiles and silently narrows).
+func TestDNATPrefixDestinationRejected(t *testing.T) {
+	tree := buildTree(t, dnatSet("198.51.100.0/24"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a DNAT rule whose destination-address is a multi-host prefix must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-nat") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "198.51.100.0/24") ||
+		!strings.Contains(msg, "multi-host prefix") {
+		t.Fatalf("error must name the rule + the offending prefix as multi-host, got: %v", err)
+	}
+}
+
+// #3029: an IPv6 multi-host prefix destination must be rejected the same way.
+func TestDNATPrefixDestinationV6Rejected(t *testing.T) {
+	tree := buildTree(t, dnatSet("2001:db8::/64"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a DNAT rule whose destination-address is an IPv6 multi-host prefix must be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "multi-host prefix") {
+		t.Fatalf("error must name the v6 prefix as multi-host, got: %v", err)
+	}
+}
+
+// #3029: a single-host destination written as an explicit host mask (/32 or
+// /128) is NOT a multi-host prefix and must still compile — the prefix gate
+// must be surgical and not regress the host-mask cases.
+func TestDNATHostMaskDestinationCompiles(t *testing.T) {
+	for _, dst := range []string{"203.0.113.10/32", "2001:db8::5/128", "203.0.113.10"} {
+		tree := buildTree(t, dnatSet(dst))
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("a single-host DNAT destination %q must compile, got: %v", dst, err)
+		}
+	}
+}
+
+// #3029: the tolerant load / peer-sync path must NOT brick on a config that
+// committed before this gate existed (a /24 DNAT destination) — downgrade the
+// prefix rejection to a warning (#1960 no-brick), sharing the existing
+// destination-nat-address lenient warning.
+func TestDNATPrefixDestinationLenientWarns(t *testing.T) {
+	cfg, err := CompileConfigLenient(buildTree(t, dnatSet("198.51.100.0/24")))
+	if err != nil {
+		t.Fatalf("lenient load must NOT fail (brick-on-restart), got: %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, "destination-nat address") {
+		t.Fatalf("lenient load must emit a destination-nat warning, warnings=%v", cfg.Warnings)
+	}
+}
+
 func TestDNATAllInvalidDestinationLenientWarns(t *testing.T) {
 	// Tolerant load / peer-sync must NOT brick on a config that committed
 	// before this gate existed — downgrade to a warning instead.

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3396,6 +3396,32 @@ func validateDestinationNATAddressesStrict(cfg *Config) error {
 						"the rule would commit but never translate any traffic",
 					rs.Name, rule.Name, strings.Join(destAddrs, ", "))
 			}
+			// #3029: a DNAT `match destination-address` that is a MULTI-HOST
+			// prefix (a CIDR with a non-host mask, e.g. 198.51.100.0/24) is
+			// silently narrowed to a single host. The snapshot builder
+			// (buildDestinationNATSnapshots) strips the `/mask` and emits an
+			// entry for the BASE address only, and the Rust DnatTable keys on
+			// an EXACT host IP (no prefix / LPM match) — so only the network
+			// address translates and every other host in the block bypasses
+			// DNAT entirely (silent under-translation). The dataplane has no
+			// prefix-match DNAT, and block-mapping semantics (1:1 offset vs
+			// many:one) are not settled, so REJECT the rule rather than commit a
+			// silently under-translating block. Single-host destinations (a bare
+			// IP, an explicit /32, or /128) are host masks and remain accepted
+			// unchanged. Reuses isHostMaskAddress, the same host-mask predicate
+			// the static-NAT path uses, so the family-specific mask check (32 vs
+			// 128) and the IPv4-mapped-IPv6 classification stay consistent.
+			for _, raw := range destAddrs {
+				if host, parsed := isHostMaskAddress(raw); parsed && !host {
+					return fmt.Errorf(
+						"destination-nat rule-set %q rule %q: match destination-address %q "+
+							"is a multi-host prefix; the dataplane DNAT match is exact-host "+
+							"only, so the rule would translate only the network address and "+
+							"silently bypass every other host in the block (use a /32 or /128 "+
+							"host address, or split the block into per-host rules)",
+						rs.Name, rule.Name, raw)
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #3029

## The bug
A destination-NAT rule whose `match destination-address` is a **multi-host prefix** (e.g. `198.51.100.0/24`) compiled and committed cleanly, but:

- the DNAT snapshot builder (`buildDestinationNATSnapshots`, `pkg/dataplane/userspace/nat.go`) strips the `/mask` and emits a table entry for the **base address only**; and
- the Rust `DnatTable` (`userspace-dp/src/nat/destination.rs`) keys on an **exact** destination `IpAddr` — no prefix / LPM matching.

Net effect: only the network address (`198.51.100.0`) was DNAT'd; packets to `198.51.100.42` etc. bypassed DNAT entirely — **silent under-translation** with no operator feedback. (agy-review-061 finding 061-09.)

## Contract chosen: commit-REJECT (fail-closed), not honor-prefix
Honoring a DNAT destination prefix requires a prefix-match / LPM table in the hot path, local-address registration for the whole block, **and** confirmed Junos block-mapping semantics (1:1 offset vs many:one) — a broad-blast-radius dataplane feature the issue itself flags as a `/research` candidate. Shipping a *guessed* translation would be worse than rejecting.

So this rejects the rule at commit (fail-closed, #1960 strict-with-lenient), which removes the silent drop now and is fully surgical. Block-to-block DNAT remains future work (static-NAT block sibling: #3031).

## Implementation
Extends the existing #2396(c) `validateDestinationNATAddressesStrict` gate to reject any DNAT `match destination-address` that is a parseable but **non-host** prefix, reusing `isHostMaskAddress` (the same host-mask predicate the static-NAT path uses → family-specific `/32` vs `/128` and IPv4-mapped-IPv6 classification stay consistent). The error names the rule-set, rule, and offending prefix. The caller's existing `lenientDestNATAddresses` downgrade keeps a previously-persisted / peer-synced config booting with a warning (#1960 no-brick).

**Single-host destinations (bare IP, explicit `/32`, `/128`) are unchanged.**

No dataplane (Rust) change — the contract is Go commit-gate only.

## Validation
- `go build ./...` clean; `gofmt -l` clean on touched Go files.
- `go test ./pkg/config/...` → 1698 + 4 new tests pass.
- New tests: v4 & v6 multi-host prefix rejected at commit (naming rule + prefix); single-host `/32` / `/128` / bare still compiles; lenient path downgrades to a warning.
- **RED→GREEN**: disabling the new gate condition makes `TestDNATPrefixDestinationRejected` / `TestDNATPrefixDestinationV6Rejected` FAIL; restoring → all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi