### PR TITLE
Wire zone tcp-rst into userspace deny enforcement (#3071)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-06-26 — #3071: zone tcp-rst wired into userspace deny enforcement
+
+- **Timestamp**: 2026-06-26
+- **Action**: Wire the parsed-but-inert `security zones <z> tcp-rst` knob into
+  the userspace dataplane. Go `ZoneConfig.TCPRst` now flows to
+  `ZoneSnapshot.TCPRst` (json `tcp_rst`, omitempty) and across the wire to the
+  Rust `ZoneSnapshot.tcp_rst` (serde rename `tcp_rst`, default false). The Rust
+  forwarding build records tcp-rst-enabled zone ids in
+  `ForwardingState.zone_tcp_rst`; both policy-deny call sites in
+  `poll_descriptor/mod.rs` now route through a unified `enqueue_deny_reply`
+  helper that, for a plain `deny` (not `then reject`), sends a TCP RST via the
+  existing #2521/#2089 reject machinery ONLY when the flow is TCP and the
+  INGRESS (from) zone has tcp-rst. Non-TCP denied traffic and a deny in a
+  non-tcp-rst zone stay silent drops; explicit `then reject` is unchanged. Zone
+  tcp-rst RSTs count under `policy_reject_sent`. Junos semantics: tcp-rst is a
+  source/from-zone property (RST goes back toward the initiator).
+- **File(s)**: pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/zones.go,
+  pkg/dataplane/userspace/zones_tcp_rst_3071_test.go (new),
+  userspace-dp/src/protocol/snapshot.rs (field + round-trip tests),
+  userspace-dp/src/afxdp/types/forwarding.rs (field + accessor),
+  userspace-dp/src/afxdp/forwarding_build/zones.rs (populate),
+  userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs (enqueue_deny_reply +
+  tests), userspace-dp/src/afxdp/poll_descriptor/mod.rs (call sites),
+  userspace-dp/src/filter/README.md, userspace-dp/tests/fixtures/protocol_wire_v1.json
+  (regenerated), plus test-literal updates in forwarding/forwarding_build/
+  test_fixtures/tests for the new field.
+- **Validation**: cargo build --release clean; Rust reject/policy/forwarding/
+  snapshot/wire tests green incl. 6 new tcp-rst tests; fail-on-revert confirmed
+  (disabling the zone arm → deny_reply_zone_tcp_rst_tcp_enqueues_rst RED);
+  go build ./... + go test ./pkg/dataplane/... ./pkg/config/... pass; gofmt clean.
+
 ## 2026-06-25 — #3151: local-delivery resolution table-scoped (cross-VRF leak)
 
 - **Timestamp**: 2026-06-25

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -160,6 +160,15 @@ type SnapshotSummary struct {
 type ZoneSnapshot struct {
 	Name string `json:"name"`
 	ID   uint16 `json:"id"`
+	// TCPRst carries the Junos `security zones security-zone <z> tcp-rst`
+	// knob (#3071). When true, the userspace dataplane sends a TCP RST back
+	// toward the source for a TCP flow DENIED by policy/default-deny whose
+	// INGRESS (from) zone is this zone, instead of the silent drop `deny`
+	// otherwise produces. Non-TCP denied traffic is unaffected. Additive
+	// wire field: an old Rust helper without the field treats every zone as
+	// tcp-rst off (pre-#3071 silent-drop behavior); an old Go binary omits
+	// it (omitempty).
+	TCPRst bool `json:"tcp_rst,omitempty"`
 }
 
 type InterfaceSnapshot struct {

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -19,10 +19,17 @@ func buildZoneSnapshots(cfg *config.Config) []ZoneSnapshot {
 	sort.Strings(names)
 	out := make([]ZoneSnapshot, 0, len(names))
 	for i, name := range names {
-		out = append(out, ZoneSnapshot{
+		zs := ZoneSnapshot{
 			Name: name,
 			ID:   uint16(i + 1),
-		})
+		}
+		// #3071: carry the per-zone `tcp-rst` knob to the dataplane so a
+		// denied TCP flow whose ingress (from) zone has tcp-rst enabled
+		// gets a TCP RST instead of a silent drop.
+		if z := cfg.Security.Zones[name]; z != nil && z.TCPRst {
+			zs.TCPRst = true
+		}
+		out = append(out, zs)
 	}
 	return out
 }

--- a/pkg/dataplane/userspace/zones_tcp_rst_3071_test.go
+++ b/pkg/dataplane/userspace/zones_tcp_rst_3071_test.go
@@ -1,0 +1,73 @@
+package userspace
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildZoneSnapshotsCarriesTCPRst verifies the #3071 fix: the per-zone
+// Junos `tcp-rst` knob (ZoneConfig.TCPRst) is carried into the ZoneSnapshot
+// wire struct (TCPRst -> json "tcp_rst") so the userspace dataplane can honor
+// it. Before #3071 buildZoneSnapshots dropped the flag entirely, leaving the
+// knob inert.
+func TestBuildZoneSnapshotsCarriesTCPRst(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"trust":   {Name: "trust", TCPRst: true},
+				"untrust": {Name: "untrust", TCPRst: false},
+			},
+		},
+	}
+
+	snaps := buildZoneSnapshots(cfg)
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 zone snapshots, got %d", len(snaps))
+	}
+
+	byName := make(map[string]ZoneSnapshot, len(snaps))
+	for _, z := range snaps {
+		byName[z.Name] = z
+	}
+
+	if !byName["trust"].TCPRst {
+		t.Fatalf("trust zone tcp-rst must be carried as true, got %+v", byName["trust"])
+	}
+	if byName["untrust"].TCPRst {
+		t.Fatalf("untrust zone tcp-rst must stay false, got %+v", byName["untrust"])
+	}
+}
+
+// TestZoneSnapshotTCPRstWireField pins the JSON wire contract shared with the
+// Rust ZoneSnapshot (#1961 cross-language discipline): the field serializes to
+// the byte-identical key "tcp_rst", true only when set, and omitted when false
+// (omitempty keeps an old Rust helper at the pre-#3071 silent-drop default).
+func TestZoneSnapshotTCPRstWireField(t *testing.T) {
+	on, err := json.Marshal(ZoneSnapshot{Name: "trust", ID: 1, TCPRst: true})
+	if err != nil {
+		t.Fatalf("marshal tcp-rst zone: %v", err)
+	}
+	if !strings.Contains(string(on), `"tcp_rst":true`) {
+		t.Fatalf("expected tcp_rst:true in wire JSON, got %s", on)
+	}
+
+	off, err := json.Marshal(ZoneSnapshot{Name: "untrust", ID: 2})
+	if err != nil {
+		t.Fatalf("marshal non-tcp-rst zone: %v", err)
+	}
+	if strings.Contains(string(off), "tcp_rst") {
+		t.Fatalf("tcp_rst must be omitted when false, got %s", off)
+	}
+
+	// Round-trip back through ZoneSnapshot.
+	var rt ZoneSnapshot
+	if err := json.Unmarshal(on, &rt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !rt.TCPRst {
+		t.Fatalf("round-trip lost tcp_rst, got %+v", rt)
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -1892,14 +1892,17 @@ fn policy_selection_deny_emits_rt_flow_event() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "dmz".to_string(),
             id: TEST_DMZ_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     let state = build_forwarding_state(&snapshot);
@@ -2429,10 +2432,12 @@ fn connected_routes_are_table_scoped_no_cross_vrf_leak() {
             crate::ZoneSnapshot {
                 name: "za".to_string(),
                 id: TEST_TRUST_ZONE_ID,
+                tcp_rst: false,
             },
             crate::ZoneSnapshot {
                 name: "zb".to_string(),
                 id: TEST_UNTRUST_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -2513,10 +2518,12 @@ fn local_delivery_is_table_scoped_no_cross_vrf_leak() {
             crate::ZoneSnapshot {
                 name: "za".to_string(),
                 id: TEST_TRUST_ZONE_ID,
+                tcp_rst: false,
             },
             crate::ZoneSnapshot {
                 name: "zb".to_string(),
                 id: TEST_UNTRUST_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -2594,10 +2601,12 @@ fn local_delivery_v6_is_table_scoped_no_cross_vrf_leak() {
             crate::ZoneSnapshot {
                 name: "za".to_string(),
                 id: TEST_TRUST_ZONE_ID,
+                tcp_rst: false,
             },
             crate::ZoneSnapshot {
                 name: "zb".to_string(),
                 id: TEST_UNTRUST_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -2669,6 +2678,7 @@ fn ecmp_static_route_retains_all_next_hops_and_skips_dead() {
         zones: vec![crate::ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         }],
         interfaces: vec![
             crate::InterfaceSnapshot {
@@ -3097,6 +3107,7 @@ fn ecmp_static_route_spreads_per_flow_not_per_destination() {
         zones: vec![crate::ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         }],
         interfaces: vec![
             crate::InterfaceSnapshot {
@@ -3294,6 +3305,7 @@ fn same_prefix_routes_tie_break_by_preference_not_insertion_order() {
         zones: vec![crate::ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         }],
         interfaces: vec![
             crate::InterfaceSnapshot {

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -942,10 +942,12 @@ fn build_forwarding_state_keeps_parent_bound_vlan_units_distinct() {
             ZoneSnapshot {
                 name: "wan".into(),
                 id: 11,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "dmz".into(),
                 id: 12,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -1046,14 +1048,17 @@ fn build_forwarding_state_rejects_reserved_zone_ids() {
             ZoneSnapshot {
                 name: "ok".into(),
                 id: 5,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "reserved-edge".into(),
                 id: crate::policy::ZONE_ID_RESERVED_MIN,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "global-sentinel".into(),
                 id: crate::policy::JUNOS_GLOBAL_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         ..Default::default()
@@ -1085,6 +1090,7 @@ fn ifindex_to_zone_id_populated_from_snapshot_at_build_time() {
         zones: vec![ZoneSnapshot {
             name: "trust".into(),
             id: 7,
+            tcp_rst: false,
         }],
         interfaces: vec![InterfaceSnapshot {
             name: "ge-0/0/0".into(),
@@ -1108,6 +1114,7 @@ fn egress_interface_zone_id_set_from_snapshot() {
         zones: vec![ZoneSnapshot {
             name: "wan".into(),
             id: 11,
+            tcp_rst: false,
         }],
         interfaces: vec![InterfaceSnapshot {
             name: "ge-0/0/1".into(),
@@ -1135,6 +1142,7 @@ fn interface_pointing_at_skipped_zone_fails_closed() {
         zones: vec![ZoneSnapshot {
             name: "reserved".into(),
             id: crate::policy::ZONE_ID_RESERVED_MIN, // dropped at populate_zones
+            tcp_rst: false,
         }],
         interfaces: vec![InterfaceSnapshot {
             name: "ge-0/0/2".into(),
@@ -1169,6 +1177,7 @@ fn interface_with_unknown_zone_name_fails_closed() {
         zones: vec![ZoneSnapshot {
             name: "trust".into(),
             id: 3,
+            tcp_rst: false,
         }],
         interfaces: vec![InterfaceSnapshot {
             name: "ge-0/0/3".into(),

--- a/userspace-dp/src/afxdp/forwarding_build/zones.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/zones.rs
@@ -42,5 +42,12 @@ pub(super) fn populate_zones(snapshot: &ConfigSnapshot, state: &mut ForwardingSt
         }
         state.zone_name_to_id.insert(zone.name.clone(), zone.id);
         state.zone_id_to_name.insert(zone.id, zone.name.clone());
+        // #3071: record the per-zone Junos `tcp-rst` knob keyed by zone id so
+        // the policy-deny hot path can answer a denied TCP flow whose ingress
+        // (from) zone has tcp-rst with a RST instead of a silent drop. Only
+        // tcp-rst-enabled zones are inserted; the absence of a key is "off".
+        if zone.tcp_rst {
+            state.zone_tcp_rst.insert(zone.id, true);
+        }
     }
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -36,7 +36,7 @@ use crate::policy::evaluate_policy_result_with_len;
 
 use cookie_reply::{SynCookieReply, enqueue_syn_cookie_reply};
 use nat_exception::{record_source_nat_failure, source_nat_decision_for_flow};
-use reject_reply::{enqueue_filter_reject_reply, enqueue_policy_reject_reply};
+use reject_reply::{enqueue_deny_reply, enqueue_filter_reject_reply};
 
 use filter::{
     apply_lo0_filter_action, emit_input_filter_log_match,
@@ -2205,25 +2205,28 @@ pub(super) fn poll_binding_process_descriptor(
                                         resolution.egress_ifindex,
                                     );
                                 }
-                                // #2089: `reject` actively rejects —
+                                // #2089/#3071: `reject` actively rejects —
                                 // synthesize a TCP RST (TCP) or ICMP
                                 // unreachable (admin-prohibited; other
-                                // protocols) back toward the source.
-                                // `deny` is unchanged (silent drop). The
-                                // reply is enqueued here before the
+                                // protocols) back toward the source. Plain
+                                // `deny` is a silent drop UNLESS the flow is
+                                // TCP and the ingress (from) zone has Junos
+                                // `tcp-rst`, in which case a TCP RST is sent.
+                                // The reply is enqueued here before the
                                 // disposition fall-through, while flow /
-                                // action / packet_frame are in scope.
-                                if matches!(policy_result.action, PolicyAction::Reject) {
-                                    enqueue_policy_reject_reply(
-                                        &mut binding.tx_pipeline,
-                                        worker_ctx.forwarding,
-                                        binding.ifindex,
-                                        packet_frame,
-                                        meta,
-                                        flow,
-                                        telemetry.counters,
-                                    );
-                                }
+                                // action / from_zone_id / packet_frame are in
+                                // scope.
+                                enqueue_deny_reply(
+                                    &mut binding.tx_pipeline,
+                                    worker_ctx.forwarding,
+                                    binding.ifindex,
+                                    packet_frame,
+                                    meta,
+                                    flow,
+                                    telemetry.counters,
+                                    matches!(policy_result.action, PolicyAction::Reject),
+                                    from_zone_id,
+                                );
                                 decision.resolution.disposition =
                                     ForwardingDisposition::PolicyDenied;
                             }
@@ -2938,21 +2941,24 @@ pub(super) fn poll_binding_process_descriptor(
                                         now_ns,
                                     );
                                     telemetry.dbg.policy_deny += 1;
-                                    // #2089: `reject` actively rejects
-                                    // (TCP RST / ICMP unreachable); `deny`
-                                    // stays a silent drop. Enqueue before
-                                    // the disposition record + recycle.
-                                    if matches!(policy_result.action, PolicyAction::Reject) {
-                                        enqueue_policy_reject_reply(
-                                            &mut binding.tx_pipeline,
-                                            worker_ctx.forwarding,
-                                            binding.ifindex,
-                                            packet_frame,
-                                            meta,
-                                            flow,
-                                            telemetry.counters,
-                                        );
-                                    }
+                                    // #2089/#3071: `reject` actively rejects
+                                    // (TCP RST / ICMP unreachable); plain
+                                    // `deny` stays a silent drop UNLESS the
+                                    // flow is TCP and the ingress (from) zone
+                                    // has Junos `tcp-rst`, in which case a TCP
+                                    // RST is sent. Enqueue before the
+                                    // disposition record + recycle.
+                                    enqueue_deny_reply(
+                                        &mut binding.tx_pipeline,
+                                        worker_ctx.forwarding,
+                                        binding.ifindex,
+                                        packet_frame,
+                                        meta,
+                                        flow,
+                                        telemetry.counters,
+                                        matches!(policy_result.action, PolicyAction::Reject),
+                                        from_zone_id,
+                                    );
                                     decision.resolution.disposition =
                                         ForwardingDisposition::PolicyDenied;
                                     record_forwarding_disposition(

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -88,6 +88,63 @@ pub(super) fn enqueue_filter_reject_reply(
     )
 }
 
+/// #3071: unified deny-path reply decision shared by both policy-deny call
+/// sites in `poll_descriptor`. Replaces the bare `if action == Reject` arm so
+/// the zone-level `tcp-rst` knob is honored alongside explicit `then reject`:
+///
+/// * `is_reject` (policy `then reject`): active reject for EVERY protocol — a
+///   TCP RST for TCP, an ICMP/ICMPv6 admin-prohibited unreachable otherwise.
+///   Unchanged from #2089.
+/// * otherwise (plain `deny` / default-deny): a silent drop UNLESS the flow is
+///   TCP AND the INGRESS (from) zone has Junos `tcp-rst` enabled, in which
+///   case a TCP RST is sent back toward the source. Junos `tcp-rst` only
+///   resets TCP; non-TCP denied traffic and a deny in a non-tcp-rst zone stay
+///   silent drops.
+///
+/// Both legs reuse `enqueue_policy_reject_reply` (the #2521/#2089 synthesis +
+/// #2238 output classification + #2472 rate limit + fail-closed budget gate),
+/// so a zone-tcp-rst RST is counted under `policy_reject_sent` — it is a
+/// policy-deny-driven reset. Returns true iff a reply was enqueued; the caller
+/// still performs the silent drop regardless (fail-closed).
+#[cold]
+#[inline(never)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn enqueue_deny_reply(
+    tx_pipeline: &mut WorkerTxPipeline,
+    forwarding: &ForwardingState,
+    ingress_ifindex: i32,
+    packet_frame: &[u8],
+    meta: UserspaceDpMeta,
+    flow: &SessionFlow,
+    counters: &mut BatchCounters,
+    is_reject: bool,
+    from_zone_id: u16,
+) -> bool {
+    if is_reject {
+        return enqueue_policy_reject_reply(
+            tx_pipeline,
+            forwarding,
+            ingress_ifindex,
+            packet_frame,
+            meta,
+            flow,
+            counters,
+        );
+    }
+    if meta.protocol == PROTO_TCP && forwarding.zone_tcp_rst_enabled(from_zone_id) {
+        return enqueue_policy_reject_reply(
+            tx_pipeline,
+            forwarding,
+            ingress_ifindex,
+            packet_frame,
+            meta,
+            flow,
+            counters,
+        );
+    }
+    false
+}
+
 #[cold]
 #[inline(never)]
 #[allow(clippy::too_many_arguments)]
@@ -657,5 +714,177 @@ mod tests {
         assert!(!sent, "inbound RST must not be answered");
         assert_eq!(counters.policy_reject_sent, 0);
         assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3071: an ICMP echo (non-TCP) frame for the zone-tcp-rst tests. Reused
+    /// to prove tcp-rst is TCP-only (non-TCP denied traffic stays silent).
+    fn icmp_v4_echo() -> (Vec<u8>, UserspaceDpMeta, SessionFlow) {
+        let client = std::net::Ipv4Addr::new(10, 0, 61, 102);
+        let server = std::net::Ipv4Addr::new(1, 1, 1, 1);
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        frame.extend_from_slice(&[0x36, 0xe4, 0x2b, 0xd5, 0x39, 0xe6]);
+        frame.extend_from_slice(&0x0800u16.to_be_bytes());
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x40, 0x00, 64, PROTO_ICMP, 0, 0,
+        ]);
+        frame.extend_from_slice(&client.octets());
+        frame.extend_from_slice(&server.octets());
+        frame.extend_from_slice(&[8, 0, 0, 0, 0x12, 0x34, 0, 1]);
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: 5,
+            l3_offset: 14,
+            l4_offset: 34,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_ICMP,
+            pkt_len: (frame.len() - 14) as u16,
+            ..UserspaceDpMeta::default()
+        };
+        let flow = SessionFlow {
+            src_ip: std::net::IpAddr::V4(client),
+            dst_ip: std::net::IpAddr::V4(server),
+            forward_key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_ICMP,
+                src_ip: std::net::IpAddr::V4(client),
+                dst_ip: std::net::IpAddr::V4(server),
+                src_port: 0x1234,
+                dst_port: 0,
+            },
+        };
+        (frame, meta, flow)
+    }
+
+    /// #3071 fail-on-revert: a plain `deny` (is_reject=false) on a TCP flow
+    /// whose INGRESS (from) zone has tcp-rst enabled MUST enqueue a TCP RST.
+    /// Reverting the zone-tcp-rst arm of `enqueue_deny_reply` → no RST → RED.
+    #[test]
+    fn deny_reply_zone_tcp_rst_tcp_enqueues_rst() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+        crate::afxdp::icmp_ratelimit::reset_bucket_for_test(
+            crate::afxdp::icmp_ratelimit::GeneratedErrorReason::Reject,
+            0,
+        );
+        let (frame, meta, flow) = tcp_v4_syn();
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let mut forwarding = ForwardingState::default();
+        // From-zone id 7 has Junos `tcp-rst`.
+        forwarding.zone_tcp_rst.insert(7, true);
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_deny_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+            false, // plain deny, not `then reject`
+            7,     // ingress (from) zone id
+        );
+        assert!(sent, "denied TCP in a tcp-rst zone must enqueue a RST");
+        assert_eq!(counters.policy_reject_sent, 1);
+        let req = pipeline
+            .pending_tx_local
+            .pop_front()
+            .expect("zone tcp-rst RST request");
+        let tcp_flags = req.bytes[14 + 20 + 13];
+        assert_ne!(tcp_flags & 0x04, 0, "RST flag must be set");
+    }
+
+    /// #3071: a plain `deny` on a TCP flow whose from-zone does NOT have
+    /// tcp-rst stays a silent drop (no RST, no counter).
+    #[test]
+    fn deny_reply_no_zone_tcp_rst_is_silent_drop() {
+        let (frame, meta, flow) = tcp_v4_syn();
+        let mut pipeline = tx_pipeline(64, 64);
+        let forwarding = ForwardingState::default(); // zone 7 not in zone_tcp_rst
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_deny_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+            false,
+            7,
+        );
+        assert!(
+            !sent,
+            "denied TCP without zone tcp-rst must stay a silent drop"
+        );
+        assert_eq!(counters.policy_reject_sent, 0);
+        assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3071: zone tcp-rst is TCP-only — a denied NON-TCP (ICMP) flow in a
+    /// tcp-rst zone is unaffected (silent drop, no ICMP unreachable).
+    #[test]
+    fn deny_reply_zone_tcp_rst_non_tcp_is_silent_drop() {
+        let (frame, meta, flow) = icmp_v4_echo();
+        let mut pipeline = tx_pipeline(64, 64);
+        let mut forwarding = ForwardingState::default();
+        forwarding.zone_tcp_rst.insert(7, true);
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_deny_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+            false,
+            7,
+        );
+        assert!(
+            !sent,
+            "non-TCP denied traffic must not get a zone tcp-rst reply"
+        );
+        assert_eq!(counters.policy_reject_sent, 0);
+        assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3071: the unified deny-reply still drives explicit policy `reject`
+    /// (is_reject=true) through the active reject path regardless of zone
+    /// tcp-rst — a TCP RST is enqueued even when the from-zone has no tcp-rst.
+    #[test]
+    fn deny_reply_explicit_reject_still_resets_tcp() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+        crate::afxdp::icmp_ratelimit::reset_bucket_for_test(
+            crate::afxdp::icmp_ratelimit::GeneratedErrorReason::Reject,
+            0,
+        );
+        let (frame, meta, flow) = tcp_v4_syn();
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let forwarding = ForwardingState::default(); // no zone tcp-rst at all
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_deny_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+            true, // explicit `then reject`
+            7,
+        );
+        assert!(
+            sent,
+            "explicit reject must enqueue a RST regardless of zone tcp-rst"
+        );
+        assert_eq!(counters.policy_reject_sent, 1);
+        assert!(!pipeline.pending_tx_local.is_empty());
     }
 }

--- a/userspace-dp/src/afxdp/test_fixtures.rs
+++ b/userspace-dp/src/afxdp/test_fixtures.rs
@@ -11,6 +11,7 @@ pub(super) fn forwarding_snapshot(include_neighbor: bool) -> ConfigSnapshot {
         zones: vec![ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         }],
         interfaces: vec![InterfaceSnapshot {
             name: "ge-0/0/0.50".to_string(),
@@ -96,10 +97,12 @@ pub(super) fn native_gre_snapshot(include_neighbor: bool) -> ConfigSnapshot {
             ZoneSnapshot {
                 name: "wan".to_string(),
                 id: TEST_WAN_ZONE_ID,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "sfmix".to_string(),
                 id: TEST_SFMIX_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -204,10 +207,12 @@ pub(super) fn wg_outer_mtu_snapshot() -> ConfigSnapshot {
             ZoneSnapshot {
                 name: "wan".to_string(),
                 id: TEST_WAN_ZONE_ID,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "sfmix".to_string(),
                 id: TEST_SFMIX_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -293,6 +298,7 @@ pub(super) fn native_gre_pbr_snapshot(include_neighbor: bool) -> ConfigSnapshot 
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
     );
     snapshot.interfaces.push(InterfaceSnapshot {
@@ -336,6 +342,7 @@ pub(super) fn forwarding_snapshot_with_next_table(include_neighbor: bool) -> Con
         zones: vec![ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         }],
         interfaces: vec![InterfaceSnapshot {
             name: "ge-0/0/0.50".to_string(),
@@ -446,10 +453,12 @@ pub(super) fn nat_snapshot() -> ConfigSnapshot {
             ZoneSnapshot {
                 name: "lan".to_string(),
                 id: TEST_LAN_ZONE_ID,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "wan".to_string(),
                 id: TEST_WAN_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -616,14 +625,17 @@ pub(super) fn policy_deny_snapshot() -> ConfigSnapshot {
             ZoneSnapshot {
                 name: "lan".to_string(),
                 id: TEST_LAN_ZONE_ID,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "wan".to_string(),
                 id: TEST_WAN_ZONE_ID,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "dmz".to_string(),
                 id: TEST_DMZ_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![
@@ -699,10 +711,12 @@ pub(super) fn static_nat_snapshot() -> ConfigSnapshot {
             ZoneSnapshot {
                 name: "trust".to_string(),
                 id: TEST_TRUST_ZONE_ID,
+                tcp_rst: false,
             },
             ZoneSnapshot {
                 name: "untrust".to_string(),
                 id: TEST_UNTRUST_ZONE_ID,
+                tcp_rst: false,
             },
         ],
         interfaces: vec![

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -4115,14 +4115,17 @@ fn poll_descriptor_policy_deny_path_emits_rt_flow_event() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "dmz".to_string(),
             id: TEST_DMZ_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.neighbors = vec![NeighborSnapshot {
@@ -4306,14 +4309,17 @@ fn poll_descriptor_policy_deny_keys_logical_ingress_zone_3021() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "dmz".to_string(),
             id: TEST_DMZ_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     // Add a SECOND VLAN sub-interface (logical ifindex 13, VID 50) on the
@@ -4542,10 +4548,12 @@ fn run_input_filter_accept_log_poll(
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.interfaces[0].filter_input_v4 = "log-input".to_string();
@@ -4764,10 +4772,12 @@ fn poll_descriptor_input_filter_discard_drops_and_logs() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.interfaces[0].filter_input_v4 = "drop-input".to_string();
@@ -4932,10 +4942,12 @@ fn poll_descriptor_session_hit_rechecks_dscp_input_filter() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.interfaces[0].filter_input_v4 = "drop-ef-input".to_string();
@@ -5140,10 +5152,12 @@ fn poll_descriptor_lo0_filter_discard_drops_without_reinject() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.interfaces[0].addresses = vec![InterfaceAddressSnapshot {
@@ -5315,10 +5329,12 @@ fn poll_descriptor_lo0_filter_drops_cached_local_delivery_session_hit() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.interfaces[0].addresses = vec![InterfaceAddressSnapshot {
@@ -7616,10 +7632,12 @@ fn txn_policy_denied_missing_neighbor_is_dropped_not_reinjected() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     // No neighbor for 172.16.80.200: the connected WAN route resolves
@@ -7678,10 +7696,12 @@ fn txn_policy_denied_missing_neighbor_skips_neg_cache_fast_fail() {
         ZoneSnapshot {
             name: "lan".to_string(),
             id: TEST_LAN_ZONE_ID,
+            tcp_rst: false,
         },
         ZoneSnapshot {
             name: "wan".to_string(),
             id: TEST_WAN_ZONE_ID,
+            tcp_rst: false,
         },
     ];
     snapshot.neighbors.clear();

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -57,6 +57,11 @@ pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) ifindex_to_zone_id: FastMap<i32, u16>,
     pub(in crate::afxdp) zone_name_to_id: FastMap<String, u16>,
     pub(in crate::afxdp) zone_id_to_name: FastMap<u16, String>,
+    /// #3071: zone IDs (from `ZoneSnapshot.tcp_rst`) with Junos `tcp-rst`
+    /// enabled. A TCP flow DENIED by policy/default-deny whose ingress
+    /// (from) zone is present here is answered with a TCP RST toward the
+    /// source instead of a silent drop. Absent zone ⇒ tcp-rst off.
+    pub(in crate::afxdp) zone_tcp_rst: FastMap<u16, bool>,
     pub(in crate::afxdp) egress: FastMap<i32, EgressInterface>,
     pub(in crate::afxdp) ingress_logical_ifindex: FastMap<(i32, u16), i32>,
     pub(in crate::afxdp) fabrics: Vec<FabricLink>,
@@ -132,6 +137,16 @@ pub(in crate::afxdp) struct ForwardingState {
     /// via `lookup_slot`. Rotated via the ForwardingState ArcSwap.
     pub(in crate::afxdp) cold_path_slot_map:
         std::sync::Arc<crate::afxdp::cold_path_hist::ColdPathSlotMap>,
+}
+
+impl ForwardingState {
+    /// #3071: true iff zone `zone_id` has Junos `tcp-rst` enabled. Used by the
+    /// policy-deny path to decide whether a denied TCP flow whose ingress
+    /// (from) zone is `zone_id` gets a TCP RST instead of a silent drop. An
+    /// unconfigured / unknown zone (e.g. `0`) is always tcp-rst off.
+    pub(in crate::afxdp) fn zone_tcp_rst_enabled(&self, zone_id: u16) -> bool {
+        self.zone_tcp_rst.get(&zone_id).copied().unwrap_or(false)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -581,6 +581,19 @@ paths. `apply_lo0_filter_action` returns the matched `FilterAction`
 (not a bare drop `bool`) so the caller can tell `Reject` from
 `Discard`.
 
+Zone-level Junos `tcp-rst` (#3071) reuses the same `enqueue_policy_reject_reply`
+machinery through the unified `enqueue_deny_reply` decision helper. Both
+policy-deny call sites in `poll_descriptor/mod.rs` now call
+`enqueue_deny_reply(..., is_reject, from_zone_id)`: when `is_reject` (policy
+`then reject`) it actively rejects every protocol as before; otherwise (plain
+`deny` / default-deny) it sends a TCP RST **only** when the flow is TCP and the
+INGRESS (from) zone has `tcp-rst` enabled (`ForwardingState::zone_tcp_rst_enabled`,
+populated from `ZoneSnapshot.tcp_rst`). Non-TCP denied traffic and a deny in a
+non-tcp-rst zone stay silent drops. A zone-tcp-rst RST is counted under
+`policy_reject_sent` — it is a policy-deny-driven reset. Junos applies `tcp-rst`
+to the source/from zone so the RST is sent back toward the connection
+initiator, whose interface is bound to the from-zone.
+
 Because the generated reply runs through the SAME path as policy
 reject, it inherits the #2238 output-filter / CoS / DSCP
 classification (`classify_generated_reply`, keyed on the reply's OWN

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -351,6 +351,15 @@ pub(crate) struct ZoneSnapshot {
     pub name: String,
     #[serde(default)]
     pub id: u16,
+    /// #3071: Junos `security zones security-zone <z> tcp-rst`. When true,
+    /// a TCP flow DENIED by policy/default-deny whose INGRESS (from) zone is
+    /// this zone is answered with a TCP RST toward the source instead of the
+    /// silent drop `deny` otherwise produces. Non-TCP denied traffic is
+    /// unaffected. Additive via serde default: a snapshot from an old Go
+    /// binary lacks the field, in which case the zone is treated as tcp-rst
+    /// off (the pre-#3071 silent-drop behavior).
+    #[serde(rename = "tcp_rst", default)]
+    pub tcp_rst: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -611,6 +620,45 @@ mod wg_snapshot_tests {
         };
         let dbg = format!("{snap:?}");
         assert!(!dbg.contains("deadbeef"), "Debug must redact the private key: {dbg}");
+    }
+}
+
+#[cfg(test)]
+mod zone_tcp_rst_tests {
+    use super::*;
+
+    // #3071: the per-zone `tcp-rst` knob round-trips over the JSON control
+    // wire byte-identically with the Go ZoneSnapshot (`tcp_rst`).
+    #[test]
+    fn zone_snapshot_tcp_rst_serializes_to_tcp_rst_key() {
+        let z = ZoneSnapshot {
+            name: "trust".to_string(),
+            id: 1,
+            tcp_rst: true,
+        };
+        let json = serde_json::to_string(&z).expect("serialize");
+        assert!(
+            json.contains("\"tcp_rst\":true"),
+            "expected tcp_rst:true in wire JSON, got {json}"
+        );
+    }
+
+    // Decode the EXACT shape the Go emitter produces for a tcp-rst zone.
+    #[test]
+    fn zone_snapshot_decodes_go_tcp_rst_payload() {
+        let z: ZoneSnapshot =
+            serde_json::from_str(r#"{"name":"trust","id":1,"tcp_rst":true}"#).expect("decode");
+        assert_eq!(z.name, "trust");
+        assert_eq!(z.id, 1);
+        assert!(z.tcp_rst, "tcp_rst must decode to true");
+    }
+
+    // Cross-version default: a snapshot from an old Go binary omits the field
+    // (omitempty), and serde must default it to false (pre-#3071 silent drop).
+    #[test]
+    fn zone_snapshot_missing_tcp_rst_defaults_false() {
+        let z: ZoneSnapshot = serde_json::from_str(r#"{"name":"untrust","id":2}"#).expect("decode");
+        assert!(!z.tcp_rst, "missing tcp_rst must default to false");
     }
 }
 

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -1140,6 +1140,7 @@
   },
   "zone_snapshot": {
     "id": 0,
-    "name": ""
+    "name": "",
+    "tcp_rst": false
   }
 }


### PR DESCRIPTION
Closes #3071

## The inert knob

`security zones security-zone <z> tcp-rst` (send a TCP RST when denying TCP
traffic, per Junos) was **parsed and modeled** (`ZoneConfig.TCPRst`,
`pkg/config`) but **never serialized to the userspace dataplane**. The
`ZoneSnapshot` wire struct carried only `name`/`id`, so the knob was inert: a
denied TCP flow was silently dropped instead of getting a RST. Active TCP reject
existed only for explicit `PolicyAction::Reject` (#2089/#2521) — there was no
zone `tcp-rst` input.

## Cross-language wire add (#1961 discipline)

- Go `ZoneSnapshot.TCPRst bool` → json `tcp_rst` (omitempty), populated in
  `buildZoneSnapshots`.
- Rust `ZoneSnapshot.tcp_rst: bool` → `#[serde(rename = "tcp_rst", default)]`.
  An old Go binary that omits the key decodes as tcp-rst **off** (pre-#3071
  silent-drop behavior); byte-identical field name both sides.
- `protocol_wire_v1.json` fixture regenerated for the new `zone_snapshot` key.

## RST-on-deny enforcement (reuses the #2521 reject machinery)

The Rust forwarding build records tcp-rst-enabled zone ids in
`ForwardingState.zone_tcp_rst` (accessor `zone_tcp_rst_enabled`). Both
policy-deny call sites in `poll_descriptor/mod.rs` now route through a unified
`enqueue_deny_reply(..., is_reject, from_zone_id)` helper:

- `is_reject` (policy `then reject`): active reject for **every** protocol —
  unchanged from #2089.
- plain `deny` / default-deny: a TCP RST is sent **only** when the flow is TCP
  **and** the ingress (from) zone has tcp-rst. Reuses the existing
  `enqueue_policy_reject_reply` path — RST synthesis + #2238 output
  classification + #2472 rate limit + fail-closed TX-frame budget gate.

Non-TCP denied traffic and a deny in a non-tcp-rst zone stay silent drops. A
zone-tcp-rst RST is counted under `policy_reject_sent` (a policy-deny-driven
reset).

## Zone semantics

Junos `tcp-rst` is a **source/from-zone** property: the RST is reflected back
toward the connection initiator, whose interface is bound to the from-zone. The
gate therefore keys on `from_zone_id` (the ingress zone), and the reply egresses
back out the ingress interface — consistent with the typical deployment (tcp-rst
on internal/trust zones for fast feedback to initiators; off on untrust for
internet stealth).

## Validation

- `cargo build --release -p xpf-userspace-dp` clean.
- Rust: reject / policy / forwarding / snapshot / wire-invariant tests green,
  including 6 new tcp-rst tests:
  - `zone_snapshot_*` serde round-trip incl. cross-version default-false
  - `deny_reply_zone_tcp_rst_tcp_enqueues_rst` (RST on denied TCP in tcp-rst zone)
  - `deny_reply_no_zone_tcp_rst_is_silent_drop`
  - `deny_reply_zone_tcp_rst_non_tcp_is_silent_drop`
  - `deny_reply_explicit_reject_still_resets_tcp`
- **Fail-on-revert**: disabling the zone arm of `enqueue_deny_reply` turns
  `deny_reply_zone_tcp_rst_tcp_enqueues_rst` RED; restoring → GREEN.
- Go: `go build ./...` + `go test ./pkg/dataplane/... ./pkg/config/...` pass
  (incl. the new `zones_tcp_rst_3071_test.go` emit + wire-contract tests).
- gofmt clean on touched Go files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi