### PR TITLE
cli: apply dynamic-address feed overlay in local policy simulators (#3105)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -19738,3 +19738,14 @@ top.
   pkg/logging/ringbuf.go, pkg/logging/binary_test.go,
   pkg/flowexport/manager.go, pkg/flowexport/flowstart_test.go,
   pkg/flowexport/README.md, _Log.md
+
+- **Timestamp**: 2026-06-26
+- **Action**: #3105 — plumb dynamic-address feed overlay into the local CLI
+  policy simulators (`show security match-policies` / `test policy`) so they
+  agree with REST/gRPC and the dataplane. Added CLI.feedOverlayFn +
+  SetFeedOverlayFn + nil-safe feedOverlay(); wired in daemon_run.go from
+  feedSnapshotsForConfig (daemon-local, no control-socket call). New
+  fail-on-revert test.
+- **File(s)**: pkg/cli/cli.go, pkg/cli/cli_show_security.go,
+  pkg/cli/cli_request.go, pkg/daemon/daemon_run.go,
+  pkg/cli/policymatch_feed_overlay_test.go, _Log.md

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -52,6 +52,15 @@ type CLI struct {
 	ipmonStatusFn      func() []ipmon.PolicyStatus
 	natPoolAlarmsFn    func() []natpoolalarm.ActiveAlarm
 	feedsFn            func() map[string]feeds.FeedInfo
+	// feedOverlayFn returns the live dynamic-address feed-prefix overlay
+	// (#3105): an address-name -> union-of-live-feed-CIDR-strings map, the same
+	// source the REST/gRPC simulators consume (daemon SnapshotForBindings). The
+	// local `show security match-policies` / `test policy` simulators pass this
+	// into policymatch so a feed-backed address-name resolves to its live CIDRs
+	// on-box, matching what the dataplane enforces. Nil (CLI spawned outside the
+	// daemon, or no feed manager) means no overlay — exactly the pre-#3105
+	// behavior (feed-backed names resolve to static content only).
+	feedOverlayFn      func() map[string][]string
 	lldpNeighborsFn    func() []*lldp.Neighbor
 	ddnsStatsFn        func() *dhcpserver.DDNSStats
 	ddnsOwnedRecordsFn func() []dhcpserver.DDNSOwnedRecordView
@@ -175,6 +184,28 @@ func (c *CLI) SetNATPoolAlarmsFn(fn func() []natpoolalarm.ActiveAlarm) {
 // SetFeedsFn sets a callback for retrieving live dynamic address feed status.
 func (c *CLI) SetFeedsFn(fn func() map[string]feeds.FeedInfo) {
 	c.feedsFn = fn
+}
+
+// SetFeedOverlayFn sets a callback for retrieving the live dynamic-address
+// feed-prefix overlay (#3105) consumed by the local `show security
+// match-policies` / `test policy` simulators. The callback returns the same
+// address-name -> union-of-feed-CIDRs map the REST/gRPC simulators use
+// (daemon feedSnapshotsForConfig -> feeds.Manager.SnapshotForBindings), read
+// from daemon-local state — no control-socket call. Nil leaves the local
+// simulators overlay-free (feed-backed names resolve to static content only).
+func (c *CLI) SetFeedOverlayFn(fn func() map[string][]string) {
+	c.feedOverlayFn = fn
+}
+
+// feedOverlay returns the live feed-prefix overlay for the policy simulators,
+// or nil when no provider is wired (CLI spawned outside the daemon) — nil is a
+// valid policymatch.Query.FeedOverlay (no feed enforcement), so the caller
+// behaves exactly as before #3105.
+func (c *CLI) feedOverlay() map[string][]string {
+	if c == nil || c.feedOverlayFn == nil {
+		return nil
+	}
+	return c.feedOverlayFn()
 }
 
 // SetLLDPNeighborsFn sets a callback for retrieving live LLDP neighbor data.

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -266,14 +266,19 @@ func (c *CLI) testPolicy(args []string) error {
 	// default-policy permit-all) and used a narrow address/app matcher that
 	// missed predefined apps, nested application-sets, literal CIDRs,
 	// any-ipv4/any-ipv6, and source/destination exclusion.
+	// #3105: pass the live dynamic-address feed-prefix overlay so a feed-backed
+	// address-name resolves to its live CIDRs on-box, matching the REST/gRPC
+	// simulators and the AF_XDP helper. Nil (CLI outside the daemon) keeps the
+	// pre-#3105 static-only behavior.
 	res := policymatch.Match(cfg, policymatch.Query{
-		FromZone: fromZone,
-		ToZone:   toZone,
-		SrcIP:    parsedSrc,
-		DstIP:    parsedDst,
-		Protocol: proto,
-		SrcPort:  srcPort,
-		DstPort:  dstPort,
+		FromZone:    fromZone,
+		ToZone:      toZone,
+		SrcIP:       parsedSrc,
+		DstIP:       parsedDst,
+		Protocol:    proto,
+		SrcPort:     srcPort,
+		DstPort:     dstPort,
+		FeedOverlay: c.feedOverlay(),
 	})
 	if !res.Matched {
 		fmt.Printf("Default %s (no matching policy for %s -> %s)\n",

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -323,14 +323,19 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	// default-policy permit-all), and used a narrow address/app matcher that
 	// missed predefined apps, nested application-sets, literal CIDRs,
 	// any-ipv4/any-ipv6, and source/destination exclusion.
+	// #3105: pass the live dynamic-address feed-prefix overlay so a feed-backed
+	// address-name resolves to its live CIDRs on-box, matching the REST/gRPC
+	// simulators and the AF_XDP helper. Nil (CLI outside the daemon) keeps the
+	// pre-#3105 static-only behavior.
 	res := policymatch.Match(cfg, policymatch.Query{
-		FromZone: fromZone,
-		ToZone:   toZone,
-		SrcIP:    parsedSrc,
-		DstIP:    parsedDst,
-		Protocol: proto,
-		SrcPort:  srcPort,
-		DstPort:  dstPort,
+		FromZone:    fromZone,
+		ToZone:      toZone,
+		SrcIP:       parsedSrc,
+		DstIP:       parsedDst,
+		Protocol:    proto,
+		SrcPort:     srcPort,
+		DstPort:     dstPort,
+		FeedOverlay: c.feedOverlay(),
 	})
 	if !res.Matched {
 		fmt.Printf("No matching policy found for %s -> %s (default %s)\n",

--- a/pkg/cli/policymatch_feed_overlay_test.go
+++ b/pkg/cli/policymatch_feed_overlay_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newFeedPolicyCLI builds a committed store with an address-book name
+// ("bad-actors") referenced by an untrust->trust deny policy. Its STATIC
+// content (198.51.100.0/24) deliberately EXCLUDES the IP the test queries
+// (203.0.113.7); only the live feed overlay carries the 203.0.113.0/24 prefix
+// that makes the query match. This mirrors policymatch's
+// TestFeedOverlayResolvesFeedBackedName but exercises the on-box CLI surfaces
+// (showMatchPolicies / testPolicy) and isolates the overlay contribution: a
+// match on 203.0.113.7 can ONLY come from the feed prefixes the overlay adds.
+func newFeedPolicyCLI(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address bad-actors 198.51.100.0/24;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone untrust to-zone trust {
+            policy block-feed {
+                match { source-address bad-actors; destination-address any; application any; }
+                then { deny; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store}
+}
+
+// TestPolicyMatchAppliesFeedOverlay proves the local CLI policy simulators
+// (#3105) now resolve a feed-backed address-name through the live feed overlay,
+// so they agree with the REST/gRPC simulators and the AF_XDP dataplane. An
+// in-feed source matches the deny rule when the overlay is supplied; with no
+// overlay (the pre-#3105 behavior, or a CLI spawned outside the daemon) the
+// feed-backed name resolves to nothing and no policy matches.
+//
+// FAIL-ON-REVERT: dropping `FeedOverlay: c.feedOverlay()` from either
+// showMatchPolicies or testPolicy makes the "with overlay" assertions go RED —
+// the in-feed source no longer matches block-feed and the output reverts to
+// "No matching policy" / "Default ...".
+func TestPolicyMatchAppliesFeedOverlay(t *testing.T) {
+	c := newFeedPolicyCLI(t)
+	c.feedOverlayFn = func() map[string][]string {
+		return map[string][]string{"bad-actors": {"203.0.113.0/24"}}
+	}
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+
+	// An in-feed source IP must now match the feed-backed deny rule.
+	inFeed := []string{"from-zone", "untrust", "to-zone", "trust", "source-ip", "203.0.113.7"}
+
+	out := captureStdout(t, func() {
+		if err := c.showMatchPolicies(cfg, inFeed); err != nil {
+			t.Fatalf("showMatchPolicies error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "block-feed") {
+		t.Fatalf("show match-policies with overlay: want block-feed match, got:\n%s", out)
+	}
+
+	out = captureStdout(t, func() {
+		if err := c.testPolicy(inFeed); err != nil {
+			t.Fatalf("testPolicy error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "block-feed") {
+		t.Fatalf("test policy with overlay: want block-feed match, got:\n%s", out)
+	}
+
+	// Without an overlay provider the feed-backed name resolves to nothing, so
+	// the rule does not match — exactly the pre-#3105 behavior. nil provider
+	// must not panic.
+	c.feedOverlayFn = nil
+
+	out = captureStdout(t, func() {
+		if err := c.showMatchPolicies(cfg, inFeed); err != nil {
+			t.Fatalf("showMatchPolicies (no overlay) error = %v", err)
+		}
+	})
+	if strings.Contains(out, "block-feed") {
+		t.Fatalf("show match-policies without overlay: feed-backed name should not match, got:\n%s", out)
+	}
+	if !strings.Contains(out, "No matching policy") {
+		t.Fatalf("show match-policies without overlay: want no-match, got:\n%s", out)
+	}
+
+	out = captureStdout(t, func() {
+		if err := c.testPolicy(inFeed); err != nil {
+			t.Fatalf("testPolicy (no overlay) error = %v", err)
+		}
+	})
+	if strings.Contains(out, "block-feed") {
+		t.Fatalf("test policy without overlay: feed-backed name should not match, got:\n%s", out)
+	}
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1483,6 +1483,15 @@ func (d *Daemon) Run(ctx context.Context) error {
 			}
 			return nil
 		})
+		// #3105: live feed-prefix overlay so the in-process CLI's
+		// `show security match-policies` / `test policy` simulators resolve
+		// feed-backed address-names to their live CIDRs, matching the REST/gRPC
+		// simulators (same FeedOverlayFn) and what the AF_XDP helper enforces.
+		// Reads daemon-local state (feedSnapshotsForConfig -> the feed
+		// manager's in-memory snapshots) — no control-socket call.
+		shell.SetFeedOverlayFn(func() map[string][]string {
+			return d.feedSnapshotsForConfig(d.store.ActiveConfig())
+		})
 		shell.SetLLDPNeighborsFn(func() []*lldp.Neighbor {
 			if d.lldpMgr != nil {
 				return d.lldpMgr.Neighbors()


### PR DESCRIPTION
Closes #3105

## Problem

The on-box CLI `show security match-policies` and `test policy` simulators
called the shared `policymatch` matcher with no `FeedOverlay`, so a feed-backed
address-name resolved to its static address-book content only. They therefore
DISAGREED with:

- the REST `match-policies` handler (`pkg/api/security.go`, sets `FeedOverlay`
  from `feedOverlayFn`),
- the gRPC `MatchPolicies` RPC (`pkg/grpcapi/server_cluster.go`), and
- the live AF_XDP dataplane (which enforces the feed prefixes via the #2049
  snapshot overlay).

An on-box operator simulating a threat-feed policy got "no matching policy" for
a source the dataplane actually denies.

## Fix

Plumb the same overlay the server surfaces use into the local CLI paths:

- add `CLI.feedOverlayFn` + `SetFeedOverlayFn` + a nil-safe `feedOverlay()`
  helper (mirrors `SetFeedsFn`);
- wire it in `daemon_run.go` from `d.feedSnapshotsForConfig(ActiveConfig())`,
  the identical source behind `api`/`grpcapi` `FeedOverlayFn`. This reads
  daemon-local feed-manager state — no new control-socket request (CLAUDE.md
  control-socket contention rule respected);
- pass `FeedOverlay: c.feedOverlay()` into both `policymatch.Match` calls
  (`pkg/cli/cli_show_security.go`, `pkg/cli/cli_request.go`).

**Fallback safety:** when no provider is wired (CLI spawned outside the daemon,
or no feed manager) `feedOverlay()` returns nil, which `policymatch` treats as
"no feed enforcement" — byte-identical to pre-#3105 behavior, no panic.

## Tests

New `pkg/cli` test `TestPolicyMatchAppliesFeedOverlay` commits a policy whose
source address-book entry's STATIC prefix (`198.51.100.0/24`) excludes the
queried IP (`203.0.113.7`), so a match can only come from the overlay's feed
prefix (`203.0.113.0/24`). It proves both CLI surfaces now match with the
overlay and do NOT match (no panic) with a nil overlay.

Fail-on-revert verified: dropping the `FeedOverlay` plumb-through turns the
"show match-policies with overlay: want block-feed match" assertion RED.

`go build ./...` and `go test ./pkg/cli/ ./pkg/policymatch/` green.

## Docs

No dedicated operator doc documents the `show security match-policies` /
`test policy` semantics requiring update; the `policymatch` package godoc
already documents the `FeedOverlay` field and lists the CLI as one of the three
shared surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi