### PR TITLE
userspace-dp: bump mac_change_epoch on RX source-MAC neighbor learn (#3169)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-06-26 — #3169: RX source-MAC dynamic-neighbor learn bypassed mac_change_epoch (stale dst_mac blackhole, sibling of #3048)
+
+- **Timestamp**: 2026-06-26
+- **Action**: fixed #3169. `learn_dynamic_neighbor` (#1787 RX source-MAC
+  data-path learn) inserted under `with_all_shards(|bulk| bulk.insert(..))`
+  with no `mac_change_epoch` bump — the FIFTH neighbor-MAC write path that
+  #3048/#3165 left uncovered. Its `pair_write_needed` gate writes on a
+  genuine MAC change (`current != Some(src_mac)`), and `lookup_neighbor_entry`
+  falls back to `dynamic_neighbors` for unresolved fast-path next-hops, so an
+  RX-learned MAC change left a cached `RewriteDescriptor.dst_mac` stale until
+  session expiry (the #3048 blackhole) and could shadow the monitor's
+  `insert_if_changed`. Added `ShardedNeighborMap::learn_pair_if_changed`
+  (bump-aware multi-key insert modeled on `bulk_replace_neighbors`): snapshots
+  each key's prior MAC via `BulkShardGuard::get` under the all-shard lock,
+  inserts the pair, bumps the epoch exactly once iff any key replaces an
+  existing MAC with a different one. First sighting and same-MAC re-learn add
+  one Relaxed read per key and no bump. Routed the learn through it.
+- **File(s)**: userspace-dp/src/afxdp/sharded_neighbor.rs,
+  userspace-dp/src/afxdp/neighbor_dispatch.rs,
+  userspace-dp/src/afxdp/sharded_neighbor_tests.rs,
+  docs/flow-cache-simplification.md, _Log.md
+- **Validation**: `cargo build --release` clean; `cargo test --release`
+  3007 pass (one pre-existing flaky wg concurrency test
+  `reconcile_peers_snapshot_is_atomic_under_concurrent_load` — passes 3/3 in
+  isolation, unrelated). Added 4 tests `mac_change_epoch_rx_learn_*`;
+  fail-on-revert proven: neutralizing the bump turns
+  `mac_change_epoch_rx_learn_bumps_on_mac_change` and
+  `mac_change_epoch_rx_learn_pair_single_bump_for_both_keys` RED while the two
+  no-bump tests stay GREEN; restored byte-identical.
+
 ## 2026-06-25 — #3046: TCP RST sessions reaped on a short timeout (not the 30s FIN close)
 
 - **Timestamp**: 2026-06-25

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -392,7 +392,7 @@ REPLACES an existing neighbor's hwaddr with a DIFFERENT MAC — never on a
 first insert of a new neighbor (no cached flow can reference a MAC that did
 not previously exist) and never on a same-MAC ARP/NDP refresh (the
 overwhelmingly common case; bumping there would flush the whole flow cache on
-every neighbor refresh and collapse the fast-path hit rate). All FOUR
+every neighbor refresh and collapse the fast-path hit rate). All FIVE
 neighbor write paths are covered:
 
 - the netlink monitor (`insert_if_changed`, the primary RTM_NEWNEIGH path);
@@ -423,7 +423,27 @@ neighbor write paths are covered:
   removes, then bumps the epoch exactly once for the whole batch if any
   incoming MAC differs from its snapshotted prior (a pure same-MAC refresh
   and brand-new keys with no prior do NOT bump). HA peer-promoted session
-  closes remain out of scope.
+  closes remain out of scope;
+- the #1787 RX source-MAC data-path learn (`learn_dynamic_neighbor` in
+  `neighbor_dispatch.rs`), now routed through
+  `ShardedNeighborMap::learn_pair_if_changed` (#3169). This learn snoops the
+  source MAC off every received frame and writes it under up to two keys (the
+  physical ingress ifindex plus the resolved logical VLAN sub-ifindex) in the
+  #949 pair-write. Its `pair_write_needed` gate fires on a genuine MAC change
+  (`current != Some(src_mac)`), not just a first sighting, so it really does
+  mutate an existing neighbor's MAC — and `lookup_neighbor_entry`
+  (`forwarding/mod.rs`) falls back to `dynamic_neighbors` for a next-hop
+  absent from the manager set, the common AF_XDP fast-path case where the
+  kernel never ARP-resolves the next-hop because zero-copy bypasses the
+  stack. Without a bump an RX-learned MAC change would leave the cached
+  `dst_mac` stale until session expiry (the #3048 blackhole class), and it
+  could also SHADOW the kernel monitor's `insert_if_changed` (the monitor
+  then observes `prior == new` and does not bump). `learn_pair_if_changed`
+  snapshots each key's prior MAC via `BulkShardGuard::get` under the same
+  all-shard lock as the insert, then bumps the epoch exactly once for the
+  pair if any key replaces an existing MAC with a different one — first
+  sighting and same-MAC re-learn add a single Relaxed read per key and no
+  bump, matching the per-key semantics.
 
 `FlowCacheEntry` carries a `neighbor_mac_epoch` stamped at insert
 (`poll_descriptor/mod.rs`, the single insert site, reading the live
@@ -452,7 +472,10 @@ accumulating on the single global epoch, the three resolver cases
 epoch-reject no-bump), and the four bulk-replace cases
 (`mac_change_epoch_bulk_replace_*`: change bumps — fail-on-revert for
 `bulk_replace_neighbors` —, same-MAC refresh no-bump, brand-new-keys
-no-bump, and a single bump for a multi-key batch).
+no-bump, and a single bump for a multi-key batch), and the four RX-learn
+cases (`mac_change_epoch_rx_learn_*`: first-sighting no-bump, same-MAC
+re-learn no-bump, change bumps — fail-on-revert for `learn_pair_if_changed`
+—, and a single bump for the multi-key #949 pair-write).
 `cached_descriptor_evicted_only_on_neighbor_mac_change`
 (flow_cache_tests.rs) is the end-to-end fail-on-revert: a descriptor stamped
 at the live epoch survives a same-MAC refresh and is evicted on a MAC change.

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -478,11 +478,15 @@ pub(super) fn learn_dynamic_neighbor(
     // get the same MAC under one bulk acquisition so a reader sees
     // either both or neither, never a stale half. Genuine changes
     // (first sighting, MAC flip, removed key) keep this exact path.
-    dynamic_neighbors.with_all_shards(|bulk| {
-        for key in &keys[..n] {
-            bulk.insert(*key, NeighborEntry { mac: src_mac });
-        }
-    });
+    //
+    // #3169: route through the bump-aware bulk insert so a MAC CHANGE on
+    // an existing dynamic neighbor advances `mac_change_epoch` — without
+    // it a flow-cache `RewriteDescriptor.dst_mac` resolved from this map
+    // (lookup_neighbor_entry's dynamic_neighbors fallback) stays stale
+    // until session expiry, the #3048 blackhole class. The bump fires
+    // only on an actual MAC change; a first sighting or same-MAC re-learn
+    // adds a single Relaxed read per key and no bump.
+    dynamic_neighbors.learn_pair_if_changed(&keys[..n], NeighborEntry { mac: src_mac });
 }
 
 pub(super) fn build_missing_neighbor_session_metadata(

--- a/userspace-dp/src/afxdp/sharded_neighbor.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor.rs
@@ -293,6 +293,53 @@ impl ShardedNeighborMap {
         });
     }
 
+    /// #3169: bump-aware atomic multi-key insert for the #1787 RX
+    /// source-MAC data-path learn (`learn_dynamic_neighbor`). Installs
+    /// the SAME MAC under up to N keys (the #949 pair-write: the physical
+    /// ingress ifindex plus the resolved logical VLAN sub-ifindex) under
+    /// ONE all-shard lock so a reader sees either both or neither, never a
+    /// stale half — and bumps `mac_change_epoch` exactly once if ANY key
+    /// REPLACES an existing neighbor's MAC with a different one.
+    ///
+    /// This is the FIFTH neighbor-MAC write path. Its `pair_write_needed`
+    /// caller gate fires on a genuine MAC change (`current != Some(mac)`),
+    /// not just first sighting, so the learn really does mutate an
+    /// existing neighbor's MAC — and `lookup_neighbor_entry` falls back to
+    /// `dynamic_neighbors` for a next-hop the kernel never ARP-resolves
+    /// (the common AF_XDP fast-path case), so a stale cached `dst_mac`
+    /// would blackhole until session expiry without this bump (#3169).
+    ///
+    /// Semantics match the per-key paths exactly: a first insert
+    /// (`prior == None`) and a same-MAC re-learn do NOT bump; only a
+    /// differing prior MAC does. The prior MAC is read via
+    /// `BulkShardGuard::get` under the same bulk lock as the insert and
+    /// the bump, so a concurrent fast-path hit never observes the new MAC
+    /// paired with the old epoch.
+    pub(crate) fn learn_pair_if_changed(
+        &self,
+        keys: &[(i32, IpAddr)],
+        val: NeighborEntry,
+    ) {
+        self.with_all_shards(|bulk| {
+            let mut mac_changed = false;
+            for key in keys {
+                if let Some(prior) = bulk.get(key)
+                    && prior.mac != val.mac
+                {
+                    mac_changed = true;
+                }
+            }
+            for key in keys {
+                bulk.insert(*key, val);
+            }
+            // A single fetch_add covers the whole pair: the flow-cache
+            // invalidation is a coarse global epoch.
+            if mac_changed {
+                self.mac_change_epoch.fetch_add(1, Ordering::Relaxed);
+            }
+        });
+    }
+
     /// Total entry count summed across shards. Locks all shards in
     /// order. Used by `coordinator::dynamic_neighbor_status`.
     pub(crate) fn len(&self) -> usize {

--- a/userspace-dp/src/afxdp/sharded_neighbor_tests.rs
+++ b/userspace-dp/src/afxdp/sharded_neighbor_tests.rs
@@ -474,3 +474,71 @@ fn mac_change_epoch_confirmed_resolver_epoch_reject_no_bump() {
     assert_eq!(map.mac_change_epoch(), 0);
     assert_eq!(map.get(&k), Some(entry(0xAB)));
 }
+
+// ── #3169: RX source-MAC data-path learn (learn_pair_if_changed) ─────
+// The fifth neighbor-MAC write path. learn_dynamic_neighbor routes its
+// #949 pair-write through learn_pair_if_changed, which must follow the
+// same epoch semantics as the other four paths: a genuine MAC change on
+// an existing dynamic neighbor bumps mac_change_epoch (so a flow-cache
+// dst_mac resolved via the dynamic_neighbors fallback is evicted), while
+// a first sighting and a same-MAC re-learn do not.
+
+#[test]
+fn mac_change_epoch_rx_learn_no_bump_on_first_sighting() {
+    let map = ShardedNeighborMap::new();
+    let k = key_v4(7, 42);
+    // A brand-new RX-learned neighbor: no cached flow can hold a stale
+    // MAC for a neighbor that did not exist, so the epoch stays put.
+    map.learn_pair_if_changed(&[k], entry(0xAB));
+    assert_eq!(map.get(&k), Some(entry(0xAB)));
+    assert_eq!(map.mac_change_epoch(), 0);
+}
+
+#[test]
+fn mac_change_epoch_rx_learn_no_bump_on_same_mac_relearn() {
+    let map = ShardedNeighborMap::new();
+    let k = key_v4(7, 42);
+    map.learn_pair_if_changed(&[k], entry(0xAB));
+    // A re-learn of the SAME source MAC (the steady-state case) must not
+    // bump, else every RX packet from a known source would flush the
+    // flow cache. This case must stay GREEN when the bump is neutralized.
+    map.learn_pair_if_changed(&[k], entry(0xAB));
+    assert_eq!(map.mac_change_epoch(), 0);
+}
+
+#[test]
+fn mac_change_epoch_rx_learn_bumps_on_mac_change() {
+    let map = ShardedNeighborMap::new();
+    let k = key_v4(7, 42);
+    map.learn_pair_if_changed(&[k], entry(0xAB));
+    assert_eq!(map.mac_change_epoch(), 0);
+    // An RX-learned MAC change for an existing dynamic neighbor (the
+    // pair_write_needed gate fires on `current != Some(src_mac)`, not
+    // just first sighting). lookup_neighbor_entry falls back to this map
+    // for unresolved fast-path next-hops, so the epoch MUST advance to
+    // evict the stale cached dst_mac (#3169). Fail-on-revert guard for
+    // learn_pair_if_changed: neutralizing its fetch_add makes this RED.
+    map.learn_pair_if_changed(&[k], entry(0xCD));
+    assert_eq!(map.get(&k), Some(entry(0xCD)));
+    assert_eq!(map.mac_change_epoch(), 1);
+    // A subsequent same-MAC re-learn does not advance it further.
+    map.learn_pair_if_changed(&[k], entry(0xCD));
+    assert_eq!(map.mac_change_epoch(), 1);
+}
+
+#[test]
+fn mac_change_epoch_rx_learn_pair_single_bump_for_both_keys() {
+    let map = ShardedNeighborMap::new();
+    // The #949 pair-write installs the same MAC under the physical and
+    // the resolved logical (VLAN sub-) ifindex. Seed both, then change
+    // the MAC on both in one learn: the coarse global epoch bumps exactly
+    // ONCE for the pair, not once per key.
+    let phys = key_v4(7, 42);
+    let logical = key_v4(99, 42);
+    map.learn_pair_if_changed(&[phys, logical], entry(0xAB));
+    assert_eq!(map.mac_change_epoch(), 0);
+    map.learn_pair_if_changed(&[phys, logical], entry(0xCD));
+    assert_eq!(map.get(&phys), Some(entry(0xCD)));
+    assert_eq!(map.get(&logical), Some(entry(0xCD)));
+    assert_eq!(map.mac_change_epoch(), 1);
+}


### PR DESCRIPTION
Closes #3169

## Problem

The #1787 RX source-MAC data-path learn (`learn_dynamic_neighbor` in
`neighbor_dispatch.rs`) was the **fifth** neighbor-MAC write path and the only
one #3048/#3165 left without a `mac_change_epoch` bump. It inserted under
`with_all_shards(|bulk| bulk.insert(..))` directly, so an RX-learned MAC change
on an existing dynamic neighbor never advanced the epoch.

This matters because:
- the learn's `pair_write_needed` gate fires on a genuine MAC change
  (`current != Some(src_mac)`), not just a first sighting;
- `lookup_neighbor_entry` (`forwarding/mod.rs`) falls back to
  `dynamic_neighbors` for next-hops absent from the manager set — the common
  AF_XDP fast-path case where the kernel never ARP-resolves the next-hop
  because zero-copy bypasses the stack.

So a cached `RewriteDescriptor.dst_mac` resolved from that fallback stayed
stale until session expiry — the exact #3048 blackhole class. The
unconditional insert could also **shadow** the kernel monitor's
`insert_if_changed` (the monitor then observes `prior == new` and does not bump
either).

## Fix

Add `ShardedNeighborMap::learn_pair_if_changed`, a bump-aware multi-key insert
modeled on `bulk_replace_neighbors`. Under one all-shard lock it snapshots each
key's prior MAC via `BulkShardGuard::get`, inserts the #949 pair (physical +
resolved logical VLAN sub-ifindex), and bumps `mac_change_epoch` exactly once
iff any key replaces an existing MAC with a different one. A first sighting and
a same-MAC re-learn add a single Relaxed read per key and no bump — matching
the four existing paths exactly. `learn_dynamic_neighbor` now routes its insert
through it.

## Tests

Added four `mac_change_epoch_rx_learn_*` tests (sharded_neighbor_tests.rs):
first-sighting no-bump, same-MAC re-learn no-bump, change bumps, single bump
for the multi-key pair.

**Fail-on-revert proven:** neutralizing the bump turns
`mac_change_epoch_rx_learn_bumps_on_mac_change` and
`mac_change_epoch_rx_learn_pair_single_bump_for_both_keys` RED while the two
no-bump tests stay GREEN; restored byte-identical.

`cargo build --release` clean; `cargo test --release` passes (one pre-existing
flaky wg concurrency test `reconcile_peers_snapshot_is_atomic_under_concurrent_load`,
passes 3/3 in isolation — unrelated).

Docs: `docs/flow-cache-simplification.md` updated FOUR → FIVE write paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi