### PR TITLE
queue-planner: fold sysfs-resolved rx_queues into plan-key (#3007)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-26 — #3007 queue-planner plan-key: fold sysfs-resolved rx_queues
+
+- **Timestamp**: 2026-06-26
+- **Action**: Fixed #3007 (follow-up from PR #3001). When a binding
+  candidate's snapshot `rx_queues == 0`, `replan_queues` resolves the real
+  channel count from sysfs (`rx_queue_count`), but the plan-key hash hashed
+  the raw 0 — so an out-of-band `ethtool -L <if> combined N` (no config
+  commit) kept the key identical and the same-plan-skip left a stale queue
+  layout. Extracted `effective_rx_queues(snapshot_rx_queues, linux_name)` as
+  the single resolution path used by BOTH the planner (iface + fabric loops)
+  and `update_snapshot_binding_plan_key`, so the dedup key can never diverge
+  from the layout. Nonzero snapshot never reads sysfs → key byte-identical to
+  pre-fix for the normal case. Added a `#[cfg(test)]` thread-local override
+  on `rx_queue_count` to drive the sysfs count in tests. Did NOT touch the
+  #3091 VLAN-child dedup or the min-collapse.
+- **File(s)**: userspace-dp/src/server/helpers.rs,
+  userspace-dp/src/main_tests.rs, userspace-dp/src/server/README.md
+- **Tests**: plan_key_folds_sysfs_resolved_rx_queues_when_snapshot_is_zero
+  (fail-on-revert: RED when the iface hash reverts to `iface.rx_queues`),
+  plan_key_for_nonzero_rx_queues_ignores_sysfs (no-regression). Full suite
+  3075 passed / 2 ignored / 0 failed.
+
 ## 2026-06-26 — #3070 re-gate: rebase fix/3070-host-inbound onto master
 
 - **Timestamp**: 2026-06-26

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -445,6 +445,94 @@ fn plan_key_covers_every_replan_queues_input() {
     );
 }
 
+// #3007 fail-on-revert: when the snapshot carries the degenerate `rx_queues ==
+// 0` fallback, `replan_queues` reads the live channel count from sysfs
+// (`rx_queue_count`) and THAT count drives the layout. The plan key MUST hash
+// the same resolved count — otherwise two refreshes with the same (rx_queues=0)
+// snapshot but a DIFFERENT actual sysfs channel count (operator ran `ethtool -L
+// <if> combined N` out of band, no config commit) share a plan key, the
+// same-plan-skip is taken, and the queues are never re-planned to the new count.
+//
+// Revert proof: change the iface hash in `update_snapshot_binding_plan_key` back
+// to hashing `iface.rx_queues` (the raw 0) instead of `effective_rx_queues(...)`
+// and this test goes RED — both keys collapse to the same 0-derived hash.
+#[test]
+fn plan_key_folds_sysfs_resolved_rx_queues_when_snapshot_is_zero() {
+    use crate::server::helpers::{
+        clear_rx_queue_count_override, set_rx_queue_count_override, snapshot_binding_plan_key,
+    };
+
+    // Degenerate snapshot: the Go control plane did not populate a count.
+    let mk = || ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0/0/1".to_string(),
+            linux_name: "ge-0-0-1".to_string(),
+            zone: "trust".to_string(),
+            ifindex: 11,
+            rx_queues: 0,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // sysfs reports 4 combined channels.
+    set_rx_queue_count_override("ge-0-0-1", 4);
+    let key_4 = snapshot_binding_plan_key(&mk());
+
+    // Operator runs `ethtool -L ge-0-0-1 combined 6` out of band; the snapshot
+    // is byte-identical (still rx_queues=0) but the live channel count changed.
+    set_rx_queue_count_override("ge-0-0-1", 6);
+    let key_6 = snapshot_binding_plan_key(&mk());
+
+    clear_rx_queue_count_override();
+
+    assert_ne!(
+        key_4, key_6,
+        "an out-of-band channel change (sysfs rx-queue count) MUST bump the plan \
+         key when the snapshot rx_queues is the degenerate 0 fallback (#3007); \
+         otherwise the same-plan-skip leaves a stale single-/under-queued layout"
+    );
+}
+
+// #3007 no-regression: for a NONZERO snapshot rx_queues the plan key must be
+// independent of sysfs — the resolved count equals the raw field, sysfs is never
+// read, and the key is byte-identical to the pre-#3007 hash for the normal case.
+#[test]
+fn plan_key_for_nonzero_rx_queues_ignores_sysfs() {
+    use crate::server::helpers::{
+        clear_rx_queue_count_override, set_rx_queue_count_override, snapshot_binding_plan_key,
+    };
+
+    let snap = ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0/0/1".to_string(),
+            linux_name: "ge-0-0-1".to_string(),
+            zone: "trust".to_string(),
+            ifindex: 11,
+            rx_queues: 6,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // No override: real sysfs returns 0 for the fake netdev, but rx_queues>0 so
+    // it is never consulted. This is the pre-#3007 code path (hash iface.rx_queues).
+    clear_rx_queue_count_override();
+    let baseline = snapshot_binding_plan_key(&snap);
+
+    // Even a wildly different sysfs count must NOT change the key when the
+    // snapshot already carries a real count.
+    set_rx_queue_count_override("ge-0-0-1", 999);
+    let with_override = snapshot_binding_plan_key(&snap);
+    clear_rx_queue_count_override();
+
+    assert_eq!(
+        baseline, with_override,
+        "a nonzero snapshot rx_queues must produce a plan key independent of \
+         sysfs (no regression for the normal case, #3007)"
+    );
+}
+
 // #3091 fail-on-revert: a WAN VLAN unit (`reth0.80` → Linux `ge-0-0-2.80`) is a
 // software VLAN device that the kernel exposes with a SINGLE RX queue. Its
 // physical parent (`ge-0-0-2`) carries the VLAN-tagged frames on its 6 hardware

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -96,6 +96,19 @@ worker layout. `plan_key_covers_every_replan_queues_input` (#2916) pins this:
 mutating any planner-consumed field bumps the key (and is shown to change the
 produced layout), so a dropped hash field goes RED.
 
+`rx_queues` is folded in via its EFFECTIVE value, not the raw snapshot field
+(#3007). When the snapshot carries the degenerate `rx_queues == 0` fallback,
+`replan_queues` resolves the real channel count from sysfs
+(`rx_queue_count` → `/sys/class/net/<if>/queues`), and THAT count drives the
+layout. `effective_rx_queues(snapshot_rx_queues, linux_name)` is the single
+resolution path shared by both the planner and the hash, so the dedup key can
+never disagree with the layout: a nonzero snapshot never reads sysfs (the key
+stays byte-identical to the raw-field hash), while a 0 snapshot folds the
+sysfs-resolved count in — so an out-of-band channel change (`ethtool -L <if>
+combined N`, no config commit) bumps the key and forces a replan instead of
+taking the same-plan-skip. `plan_key_folds_sysfs_resolved_rx_queues_when_snapshot_is_zero`
+and `plan_key_for_nonzero_rx_queues_ignores_sysfs` pin both halves.
+
 The Rust planner does:
 
 ```rust

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -637,6 +637,23 @@ fn update_snapshot_binding_plan_key(hasher: &mut Sha256, snapshot: &ConfigSnapsh
         // so re-parenting or VLAN-tag changes trigger a replan (never a stale
         // plan). Additive: an old Go binary that omits them serializes the
         // serde defaults (0 / ""), matching the non-VLAN physical case.
+        //
+        // #3007: hash the EFFECTIVE rx_queues, not the raw snapshot field. When
+        // the snapshot carries the degenerate `rx_queues == 0` fallback,
+        // `replan_queues` resolves the real queue count from sysfs
+        // (`rx_queue_count`), and THAT count drives `queue_count`/the layout. The
+        // plan key must hash the same resolved value, or an out-of-band channel
+        // change (`ethtool -L <if> combined N`, no config commit) would leave the
+        // snapshot at 0, keep the key identical, and take the same-plan-skip while
+        // the planner would actually produce a different layout. For a nonzero
+        // snapshot the resolved value equals the raw field (sysfs is not read), so
+        // the key is byte-identical to the pre-#3007 hash for the normal case.
+        let resolved_linux_name = if iface.linux_name.is_empty() {
+            linux_ifname(&iface.name)
+        } else {
+            iface.linux_name.clone()
+        };
+        let rx_queues = effective_rx_queues(iface.rx_queues, &resolved_linux_name);
         hash_update(
             hasher,
             &format!(
@@ -645,7 +662,7 @@ fn update_snapshot_binding_plan_key(hasher: &mut Sha256, snapshot: &ConfigSnapsh
                 iface.linux_name,
                 iface.ifindex,
                 iface.parent_ifindex,
-                iface.rx_queues,
+                rx_queues,
                 iface.tunnel,
                 iface.vlan_id,
                 iface.parent_linux_name
@@ -653,11 +670,16 @@ fn update_snapshot_binding_plan_key(hasher: &mut Sha256, snapshot: &ConfigSnapsh
         );
     }
     for fab in &snapshot.fabrics {
+        // #3007: same effective-rx_queues resolution as the fabric candidate
+        // loop in `replan_queues` — sysfs fallback when the snapshot is 0, then
+        // `.max(1)` (fabric needs at least one TX queue). Keeps the key in lock
+        // step with the value that drives the fabric candidate's queue count.
+        let rx_queues = effective_rx_queues(fab.rx_queues, &fab.parent_linux_name).max(1);
         hash_update(
             hasher,
             &format!(
                 "fabric={}/{}/{}/{};",
-                fab.name, fab.parent_linux_name, fab.parent_ifindex, fab.rx_queues
+                fab.name, fab.parent_linux_name, fab.parent_ifindex, rx_queues
             ),
         );
     }
@@ -897,11 +919,10 @@ pub(crate) fn replan_queues(
             if seen_linux.contains(&linux_name) {
                 continue;
             }
-            let rx_queues = if iface.rx_queues > 0 {
-                iface.rx_queues
-            } else {
-                rx_queue_count(&linux_name)
-            };
+            // #3007: resolve the effective rx_queues ONCE (snapshot value if
+            // nonzero, else sysfs). `snapshot_binding_plan_key` hashes the SAME
+            // helper, so the dedup key can never disagree with the layout.
+            let rx_queues = effective_rx_queues(iface.rx_queues, &linux_name);
             if rx_queues > 0 {
                 ifindex_by_name.insert(linux_name.clone(), iface.ifindex);
                 seen_linux.insert(linux_name.clone());
@@ -917,11 +938,8 @@ pub(crate) fn replan_queues(
             if seen_linux.contains(&fabric.parent_linux_name) {
                 continue;
             }
-            let rx_queues = if fabric.rx_queues > 0 {
-                fabric.rx_queues
-            } else {
-                rx_queue_count(&fabric.parent_linux_name)
-            };
+            // #3007: same effective-rx_queues resolution + plan-key hash.
+            let rx_queues = effective_rx_queues(fabric.rx_queues, &fabric.parent_linux_name);
             let rx_queues = rx_queues.max(1); // fabric needs at least 1 queue for TX
             ifindex_by_name.insert(fabric.parent_linux_name.clone(), fabric.parent_ifindex);
             seen_linux.insert(fabric.parent_linux_name.clone());
@@ -1015,7 +1033,52 @@ pub(crate) fn linux_ifname(name: &str) -> String {
     name.replace('/', "-")
 }
 
+/// Resolve the effective RX queue count that drives the binding layout: the
+/// snapshot's `rx_queues` when nonzero, otherwise the live sysfs channel count
+/// (`rx_queue_count`). This is the SINGLE resolution path consumed by BOTH the
+/// queue planner (`replan_queues`) and the same-plan dedup key
+/// (`update_snapshot_binding_plan_key`), so the key can never hash a value that
+/// disagrees with the layout (#3007). For a nonzero snapshot sysfs is never
+/// read, so the key stays byte-identical to the pre-#3007 hash for the normal
+/// case; the 0 fallback (no committed count) folds the resolved sysfs count into
+/// the key so an out-of-band `ethtool -L` channel change forces a replan.
+pub(crate) fn effective_rx_queues(snapshot_rx_queues: usize, linux_name: &str) -> usize {
+    if snapshot_rx_queues > 0 {
+        snapshot_rx_queues
+    } else {
+        rx_queue_count(linux_name)
+    }
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only override for `rx_queue_count`, keyed by netdev name. Lets a
+    /// test drive the sysfs-resolved queue count without a real
+    /// `/sys/class/net/<if>/queues` tree. Thread-local, so parallel test
+    /// threads never cross-contaminate.
+    static RX_QUEUE_COUNT_OVERRIDE: std::cell::RefCell<std::collections::HashMap<String, usize>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+#[cfg(test)]
+pub(crate) fn set_rx_queue_count_override(name: &str, count: usize) {
+    RX_QUEUE_COUNT_OVERRIDE.with(|m| {
+        m.borrow_mut().insert(name.to_string(), count);
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn clear_rx_queue_count_override() {
+    RX_QUEUE_COUNT_OVERRIDE.with(|m| m.borrow_mut().clear());
+}
+
 pub(crate) fn rx_queue_count(name: &str) -> usize {
+    #[cfg(test)]
+    {
+        if let Some(count) = RX_QUEUE_COUNT_OVERRIDE.with(|m| m.borrow().get(name).copied()) {
+            return count;
+        }
+    }
     let path = format!("/sys/class/net/{name}/queues");
     let Ok(entries) = fs::read_dir(path) else {
         return 0;


### PR DESCRIPTION
Closes #3007

## Problem

Follow-up from PR #3001 (hostile review, Item 2). In `replan_queues` (`userspace-dp/src/server/helpers.rs`), when a binding candidate's snapshot `rx_queues == 0`, the planner resolves the real channel count from sysfs (`rx_queue_count` → `/sys/class/net/<if>/queues`), and that resolved count drives `queue_count` / the binding layout. But the same-plan dedup key (`update_snapshot_binding_plan_key`) hashed the **raw** snapshot field (0), not the resolved count.

Consequence: two refreshes with the same `rx_queues=0` snapshot but a DIFFERENT actual sysfs channel count — an operator running `ethtool -L <if> combined N` out of band, **no config commit** — share the same plan-key. The same-plan-skip in `apply_snapshot` is taken and the queues are never re-planned to the new channel count.

Impact is LOW (0 is a degenerate fallback; real snapshots carry a nonzero count, and commits bump the key via other fields), but it is a real same-key/different-layout hole.

## Fix — issue option (a)

Hash the EFFECTIVE rx_queues, not the raw field. Extracted `effective_rx_queues(snapshot_rx_queues, linux_name)` (snapshot value if nonzero, else `rx_queue_count`) as the **single resolution path** consumed by BOTH `replan_queues` (iface + fabric candidate loops) and `update_snapshot_binding_plan_key`. The value that drives the layout is now the value hashed into the dedup key — they can never diverge, so an out-of-band channel change bumps the key and forces a replan.

- Nonzero snapshot → sysfs is never read → key byte-identical to the pre-fix hash (no regression for the normal case).
- Fabric loop resolves + `.max(1)` in both sites for consistency.
- The #3091 VLAN-child dedup and the `queue_count` min-collapse are untouched.
- A `#[cfg(test)]` thread-local override on `rx_queue_count` lets tests drive the sysfs count without a real `/sys` tree.

No Go control-plane change (option b) and no netlink watcher (option c) — out of scope.

## Tests

- `plan_key_folds_sysfs_resolved_rx_queues_when_snapshot_is_zero` — two `rx_queues=0` snapshots with sysfs counts 4 vs 6 produce DIFFERENT keys. **Fail-on-revert proven**: reverting the iface hash back to `iface.rx_queues` collapses both keys → test goes RED; restored byte-identical.
- `plan_key_for_nonzero_rx_queues_ignores_sysfs` — a nonzero snapshot rx_queues yields a key independent of any sysfs override (no regression).

`cargo build --release` clean; `cargo test --release` 3075 passed / 2 ignored / 0 failed.

Docs: `userspace-dp/src/server/README.md` plan-key section + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi