### PR TITLE
policymatch: skip scheduler-inactive policies in the simulator (#3104)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-06-26 — #3104: policymatch simulator skips scheduler-inactive policies (verdict companion to #3062 display)
+
+- **Timestamp**: 2026-06-26
+- **Action**: fixed #3104. The shared policy simulator (`pkg/policymatch`)
+  returned a definitive permit/deny for scheduled (runtime-inactive) policies,
+  disagreeing with the dataplane (`policy.rs try_match_rule` drops an inactive
+  rule before app/address matching). Threaded live per-scheduler active-state
+  into `policymatch.Query.PolicyInactiveFn`; `ruleMatches` now skips a
+  scheduler-inactive policy FIRST (mirroring the runtime), so the simulator
+  falls through to the next active rule / configured default-policy. Wired at
+  all simulator surfaces: REST `match-policies`, gRPC `MatchPolicies` + `test
+  policy`, and the local CLI `show security match-policies` + `test policy`.
+  The closure is built from the same daemon-local
+  `Manager.PolicySchedulerActiveState` accessor the #3062 display uses, via the
+  new SSOT builder `dataplane/userspace.PolicyInactiveFn` (wraps the shared
+  `PolicyInactive` predicate). Missing-state fallback: when live scheduler
+  state is unavailable to a caller (offline CLI / NoDataplane) the closure is
+  nil and scheduled policies are simulated as-if-active — matching #3062's
+  display fallback and keeping non-scheduled verdicts byte-identical (no
+  regression). Added `pkg/policymatch/scheduler_test.go` (4 cases: inactive
+  permit→default-deny, inactive deny→later active permit, scheduler flip,
+  non-scheduled unchanged); fail-on-revert verified (removing the skip turns
+  the 3 positive cases RED, case 4 stays green).
+- **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/scheduler_test.go,
+  pkg/dataplane/userspace/policies.go, pkg/cli/cli_show_security_dispatch.go,
+  pkg/cli/cli_show_security.go, pkg/cli/cli_request.go,
+  pkg/grpcapi/server_show_policies_text.go, pkg/grpcapi/server_cluster.go,
+  pkg/grpcapi/server_show_firewall.go, pkg/api/server.go, pkg/api/security.go,
+  pkg/daemon/daemon_run.go, pkg/api/README.md, pkg/cli/README.md,
+  pkg/grpcapi/README.md
+
 ## 2026-06-26 — #3169: RX source-MAC dynamic-neighbor learn bypassed mac_change_epoch (stale dst_mac blackhole, sibling of #3048)
 
 - **Timestamp**: 2026-06-26

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -146,7 +146,14 @@ under the daemon's errgroup. Nothing else imports this package.
   (`FeedOverlayFn`). The pre-#3042 hand-written matcher scanned only
   zone-pair policies, hard-coded `deny (default)`, and missed predefined
   apps / literal CIDRs — so the diagnostic could report the OPPOSITE of what
-  the dataplane enforces.
+  the dataplane enforces. #3104: the handler also threads live per-scheduler
+  active-state (`PolicySchedulerActiveStateFn`, wired from the daemon-local
+  `Manager.PolicySchedulerActiveState`) into `policymatch.Query.PolicyInactiveFn`,
+  so a scheduler-inactive policy is SKIPPED exactly like the runtime
+  (`policy.rs try_match_rule`) and the verdict falls through to the next active
+  rule / default-policy. When live state is unavailable (no dataplane) the
+  simulator evaluates scheduled policies as-if-active (the #3062 display
+  fallback) — a non-scheduled policy is unaffected either way.
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/logging"
 	"github.com/psaab/xpf/pkg/policymatch"
 )
@@ -316,15 +317,27 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	if s.feedOverlayFn != nil {
 		overlay = s.feedOverlayFn()
 	}
+	// #3104: thread live per-scheduler active-state so the simulator skips a
+	// scheduler-inactive policy exactly like the runtime (policy.rs
+	// try_match_rule), falling through to the next active rule / default-policy.
+	// When the daemon has not wired the accessor or state is unavailable, the
+	// closure stays nil and scheduled policies are simulated as-if-active.
+	var inactiveFn func(string) bool
+	if s.policySchedActiveFn != nil {
+		if state, ok := s.policySchedActiveFn(); ok {
+			inactiveFn = dpuserspace.PolicyInactiveFn(state)
+		}
+	}
 	res := policymatch.Match(cfg, policymatch.Query{
-		FromZone:    fromZone,
-		ToZone:      toZone,
-		SrcIP:       srcIP,
-		DstIP:       dstIP,
-		Protocol:    proto,
-		SrcPort:     srcPort,
-		DstPort:     dstPort,
-		FeedOverlay: overlay,
+		FromZone:         fromZone,
+		ToZone:           toZone,
+		SrcIP:            srcIP,
+		DstIP:            dstIP,
+		Protocol:         proto,
+		SrcPort:          srcPort,
+		DstPort:          dstPort,
+		FeedOverlay:      overlay,
+		PolicyInactiveFn: inactiveFn,
 	})
 	if !res.Matched {
 		writeOK(w, MatchPoliciesResult{Action: policymatch.ActionString(res.Action) + " (default)"})

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -147,6 +147,15 @@ type Config struct {
 	// token resolves to its live feed prefixes. Optional; if nil the
 	// simulator resolves feed-backed names to their static content only.
 	FeedOverlayFn func() map[string][]string
+	// PolicySchedulerActiveStateFn returns the live daemon-local per-scheduler
+	// active-state map (the same view Manager.PolicySchedulerActiveState
+	// exposes to the CLI/gRPC show surfaces) plus whether it could be queried
+	// (#3104). The `match-policies` simulator consults it so a scheduler-inactive
+	// policy is skipped exactly like the runtime (policy.rs try_match_rule),
+	// instead of reporting a definitive verdict the dataplane disagrees with.
+	// Optional; if nil or it returns ok=false the simulator evaluates scheduled
+	// policies as-if-active (the pre-#3104 behavior / #3062 display fallback).
+	PolicySchedulerActiveStateFn func() (map[string]bool, bool)
 }
 
 // Server is the HTTP API server.
@@ -176,6 +185,7 @@ type Server struct {
 	surfaceAStatsFn         func() *ddns.SurfaceAStats
 	flowCollectorHealthFn   func() []flowexport.ExporterCollectorHealth
 	feedOverlayFn           func() map[string][]string
+	policySchedActiveFn     func() (map[string]bool, bool)
 	startTime               time.Time
 }
 
@@ -205,6 +215,7 @@ func NewServer(cfg Config) *Server {
 		surfaceAStatsFn:         cfg.SurfaceAStatsFn,
 		flowCollectorHealthFn:   cfg.FlowCollectorHealthFn,
 		feedOverlayFn:           cfg.FeedOverlayFn,
+		policySchedActiveFn:     cfg.PolicySchedulerActiveStateFn,
 		startTime:               time.Now(),
 	}
 

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -59,4 +59,8 @@ both the daemon-local CLI (xpfd in TTY mode) and the remote CLI
   `any-ipv4`/`any-ipv6`, and source/destination exclusion — so the
   diagnostic could report the OPPOSITE of what the dataplane enforces.
   `policymatch.Match` now honors the configured `default-policy` and reports
-  whether a global policy matched.
+  whether a global policy matched. #3104: `show security match-policies` and
+  `test policy` thread live per-scheduler active-state
+  (`c.policyInactiveFn()` → `policymatch.Query.PolicyInactiveFn`) so a
+  scheduler-inactive policy is skipped like the runtime; with no live state
+  (offline CLI) scheduled policies are simulated as-if-active.

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -279,6 +279,9 @@ func (c *CLI) testPolicy(args []string) error {
 		SrcPort:     srcPort,
 		DstPort:     dstPort,
 		FeedOverlay: c.feedOverlay(),
+		// #3104: skip scheduler-inactive policies like the runtime does, so the
+		// simulator falls through to the next active rule / default-policy.
+		PolicyInactiveFn: c.policyInactiveFn(),
 	})
 	if !res.Matched {
 		fmt.Printf("Default %s (no matching policy for %s -> %s)\n",

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -350,6 +350,9 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		SrcPort:     srcPort,
 		DstPort:     dstPort,
 		FeedOverlay: c.feedOverlay(),
+		// #3104: skip scheduler-inactive policies like the runtime does, so the
+		// simulator falls through to the next active rule / default-policy.
+		PolicyInactiveFn: c.policyInactiveFn(),
 	})
 	if !res.Matched {
 		fmt.Printf("No matching policy found for %s -> %s (default %s)\n",

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -48,6 +48,21 @@ func (c *CLI) policySchedulerActiveState() (state map[string]bool, ok bool) {
 	return p.PolicySchedulerActiveState(), true
 }
 
+// policyInactiveFn returns a per-policy scheduler-inactivity predicate bound to
+// the live active-state snapshot for use as policymatch.Query.PolicyInactiveFn
+// (#3104), or nil when the runtime scheduler state cannot be queried. When nil
+// the policy simulator treats scheduled policies as active — the pre-#3104
+// behaviour and the same fallback the #3062 display surfaces use when no
+// provider is present — so the verdict never regresses for a surface lacking
+// live state.
+func (c *CLI) policyInactiveFn() func(string) bool {
+	state, ok := c.policySchedulerActiveState()
+	if !ok {
+		return nil
+	}
+	return dpuserspace.PolicyInactiveFn(state)
+}
+
 // policyDetailState renders the Junos "State:" token for a policy detail
 // line: "inactive" when the policy is bound to a scheduler that is
 // currently runtime-inactive, otherwise "enabled". haveSched gates the

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1243,6 +1243,26 @@ func (d *Daemon) Run(ctx context.Context) error {
 			FeedOverlayFn: func() map[string][]string {
 				return d.feedSnapshotsForConfig(d.store.ActiveConfig())
 			},
+			// #3104: live per-scheduler active-state so the REST
+			// match-policies simulator skips a scheduler-inactive policy
+			// exactly like the runtime, instead of returning a verdict the
+			// dataplane disagrees with. Sourced from the same daemon-local
+			// accessor the CLI/gRPC show surfaces use
+			// (Manager.PolicySchedulerActiveState via the dataplane adapter).
+			// ok=false when the dataplane is absent (NoDataplane) so the
+			// simulator falls back to evaluating scheduled policies as-active.
+			PolicySchedulerActiveStateFn: func() (map[string]bool, bool) {
+				if d.dp == nil {
+					return nil, false
+				}
+				p, ok := d.dp.(interface {
+					PolicySchedulerActiveState() map[string]bool
+				})
+				if !ok {
+					return nil, false
+				}
+				return p.PolicySchedulerActiveState(), true
+			},
 			// #1387 inc-2: DHCP dynamic-DNS counters for the
 			// xpf_dhcp_ddns_* metric family. Returns nil when the
 			// manager is absent (NoDataplane), omitting the family.

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -772,6 +772,21 @@ func PolicyInactive(schedulerName string, activeState map[string]bool) bool {
 	return policyRuleInactive(schedulerName, activeState)
 }
 
+// PolicyInactiveFn returns a per-policy scheduler-inactivity predicate bound to
+// a fixed live active-state snapshot, suitable for use as
+// policymatch.Query.PolicyInactiveFn (#3104). It wraps the SSOT PolicyInactive
+// predicate so the operator-side policy simulator skips exactly the rules the
+// dataplane drops (and the #3062 display reports inactive). The snapshot is
+// captured by value at call time; pass the result of
+// Manager.PolicySchedulerActiveState. Callers that cannot obtain live scheduler
+// state must pass nil into the Query instead of calling this, so the simulator
+// stays scheduler-unaware (evaluates scheduled policies as-if-active).
+func PolicyInactiveFn(activeState map[string]bool) func(schedulerName string) bool {
+	return func(schedulerName string) bool {
+		return policyRuleInactive(schedulerName, activeState)
+	}
+}
+
 func policyActionString(action config.PolicyAction) string {
 	switch action {
 	case config.PolicyPermit:

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -78,7 +78,12 @@ contract.
   scanned only zone-pair policies and hard-coded `deny (default)`, so the
   diagnostic could report the OPPOSITE of what the dataplane enforces. The
   request gained a `source_port` field so source-port-constrained app terms
-  are simulated.
+  are simulated. #3104: `MatchPolicies` and the `test policy` ShowText surface
+  thread live per-scheduler active-state (`s.policyInactiveFn()` →
+  `policymatch.Query.PolicyInactiveFn`, sourced from the same
+  `Manager.PolicySchedulerActiveState` the #3062 policy-detail display uses) so
+  a scheduler-inactive policy is skipped like the runtime; with no live state
+  scheduled policies are simulated as-if-active.
 - The `test policy` operational command (local `pkg/cli` + remote `cmd/cli`
   → ShowText `test-policy:` topic → `showTestPolicy`) carries the same
   source-port input (#3107). The topic adds a `srcport=` key alongside the

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -181,6 +181,9 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		SrcPort:     int(req.SourcePort),
 		DstPort:     int(req.DestinationPort),
 		FeedOverlay: overlay,
+		// #3104: skip scheduler-inactive policies like the runtime does, so the
+		// simulator falls through to the next active rule / default-policy.
+		PolicyInactiveFn: s.policyInactiveFn(),
 	})
 	if !res.Matched {
 		return &pb.MatchPoliciesResponse{

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -249,6 +249,10 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			SrcPort:     srcPort,
 			DstPort:     dstPort,
 			FeedOverlay: overlay,
+			// #3104: skip scheduler-inactive policies like the runtime does, so
+			// the `test policy` diagnostic falls through to the next active rule
+			// / default-policy, agreeing with the dataplane.
+			PolicyInactiveFn: s.policyInactiveFn(),
 		})
 		switch {
 		case res.Matched && res.Global:

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -44,6 +44,21 @@ func (s *Server) policySchedulerActiveState() (state map[string]bool, ok bool) {
 	return p.PolicySchedulerActiveState(), true
 }
 
+// policyInactiveFn returns a per-policy scheduler-inactivity predicate bound to
+// the live active-state snapshot for use as policymatch.Query.PolicyInactiveFn
+// (#3104), or nil when the runtime scheduler state cannot be queried. When nil
+// the policy simulator treats scheduled policies as active — the pre-#3104
+// behaviour and the same fallback the #3062 display surfaces use when no
+// provider is present — so the verdict never regresses for a surface lacking
+// live state.
+func (s *Server) policyInactiveFn() func(string) bool {
+	state, ok := s.policySchedulerActiveState()
+	if !ok {
+		return nil
+	}
+	return dpuserspace.PolicyInactiveFn(state)
+}
+
 // policyDetailStateSuffix returns the per-policy detail header suffix for
 // a scheduler-inactive policy (", State: inactive, Scheduler: <name>"),
 // or "" otherwise. haveSched gates the lookup so that when the runtime

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -26,10 +26,22 @@
 // Go snapshot builder (pkg/dataplane/userspace/policies.go). Where the runtime
 // and the old per-surface matchers disagreed, the runtime wins.
 //
-// Note on scheduler state: the runtime honors a policy's scheduler-driven
-// `inactive` flag. This simulator evaluates the configured policy set without
-// applying live scheduler activation (matching the pre-#3042 surfaces), so a
-// scheduled policy is simulated as if active.
+// Note on scheduler state (#3104): the runtime honors a policy's
+// scheduler-driven `inactive` flag — policy.rs try_match_rule returns None for
+// an inactive rule BEFORE app/address matching, and the snapshot builder
+// (pkg/dataplane/userspace/policies.go) stamps that Inactive flag and fails
+// closed on missing scheduler state. This simulator is schedule-aware when the
+// caller threads live per-scheduler active-state into Query.PolicyInactiveFn:
+// it then SKIPS a scheduler-inactive policy exactly like the runtime, falling
+// through to the next active rule / configured default-policy. When
+// PolicyInactiveFn is nil (the caller has no live scheduler state — an offline
+// surface, or the daemon-local dataplane has not published state yet), the
+// simulator falls back to evaluating the configured policy set as-if-active,
+// matching both the pre-#3042 surfaces and the #3062 display fallback. A
+// NON-scheduled policy is unaffected in either case: PolicyInactiveFn is only
+// ever consulted with a policy's scheduler name, and the SSOT predicate
+// (dataplane/userspace.PolicyInactive) reports an empty scheduler name as
+// always active.
 package policymatch
 
 import (
@@ -138,6 +150,25 @@ type Query struct {
 	// name then resolves to its static content only, matching the runtime
 	// fail-closed-before-first-fetch behavior.
 	FeedOverlay map[string][]string
+
+	// PolicyInactiveFn, when non-nil, reports whether a policy bound to the
+	// given scheduler name is currently runtime-inactive (#3104). It mirrors
+	// the runtime's per-rule scheduler gate (policy.rs try_match_rule, which
+	// drops an inactive rule before app/address matching). A policy for which
+	// this returns true is SKIPPED, so the simulator falls through to the next
+	// active rule / configured default-policy — agreeing with the dataplane.
+	//
+	// Callers build this from the live daemon-local per-scheduler active-state
+	// map via dataplane/userspace.PolicyInactiveFn, which wraps the SSOT
+	// PolicyInactive predicate shared with the snapshot builder and the #3062
+	// display surfaces. An empty scheduler name reports active, so a
+	// NON-scheduled policy is never skipped.
+	//
+	// nil is valid and means "no live scheduler state": the simulator evaluates
+	// scheduled policies as-if-active (the pre-#3104 behavior / #3062 display
+	// fallback). The runtime/dataplane callers always supply it when scheduler
+	// state has been published; only offline surfaces leave it nil.
+	PolicyInactiveFn func(schedulerName string) bool
 }
 
 // Result is the simulator verdict.
@@ -211,6 +242,16 @@ func matchedResult(pol *config.Policy, global bool) Result {
 }
 
 func ruleMatches(cfg *config.Config, q Query, pol *config.Policy) bool {
+	// #3104: scheduler gate, FIRST — mirror policy.rs try_match_rule, which
+	// returns None for a scheduler-inactive rule before any app/address
+	// matching. Skipping here lets Match fall through to the next active rule
+	// or the default-policy, exactly as the runtime does. PolicyInactiveFn is
+	// nil when the caller has no live scheduler state (simulate as-if-active),
+	// and reports an empty scheduler name as active, so a non-scheduled policy
+	// is never skipped.
+	if q.PolicyInactiveFn != nil && q.PolicyInactiveFn(pol.SchedulerName) {
+		return false
+	}
 	if !matchAddr(cfg, q.FeedOverlay, pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded, q.SrcIP) {
 		return false
 	}

--- a/pkg/policymatch/scheduler_test.go
+++ b/pkg/policymatch/scheduler_test.go
@@ -1,0 +1,157 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// deny builds a deny policy, optionally scheduler-bound.
+func deny(name string, m config.PolicyMatch) *config.Policy {
+	return &config.Policy{Name: name, Match: m, Action: config.PolicyDeny}
+}
+
+func scheduled(p *config.Policy, schedName string) *config.Policy {
+	p.SchedulerName = schedName
+	return p
+}
+
+// inactiveFnFor builds the production Query.PolicyInactiveFn from a live
+// per-scheduler active-state map, using the SAME SSOT predicate the dataplane
+// snapshot builder and the #3062 display surfaces use. This is exactly what the
+// REST/gRPC/CLI surfaces thread when live scheduler state is available.
+func inactiveFnFor(active map[string]bool) func(string) bool {
+	return dpuserspace.PolicyInactiveFn(active)
+}
+
+// TestSchedulerInactiveSkipsLikeRuntime covers #3104: the shared simulator must
+// agree with the runtime (policy.rs try_match_rule), which drops a
+// scheduler-inactive rule BEFORE app/address matching. Reverting the skip in
+// ruleMatches makes case #1 (inactive scheduled permit -> default-deny) go RED.
+func TestSchedulerInactiveSkipsLikeRuntime(t *testing.T) {
+	// Case 1: an inactive scheduled PERMIT must NOT be reported as a match;
+	// the verdict falls through to the configured default-policy (deny).
+	t.Run("inactive scheduled permit -> default deny", func(t *testing.T) {
+		cfg := cfgWith(config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Policies: []*config.ZonePairPolicies{
+				zonePair("trust", "untrust",
+					scheduled(permit("night-allow", config.PolicyMatch{
+						Applications: []string{"any"},
+					}), "after-hours")),
+			},
+		}, config.ApplicationsConfig{})
+		q := Query{
+			FromZone:         "trust",
+			ToZone:           "untrust",
+			Protocol:         "tcp",
+			DstPort:          80,
+			PolicyInactiveFn: inactiveFnFor(map[string]bool{"after-hours": false}),
+		}
+		res := Match(cfg, q)
+		if res.Matched {
+			t.Fatalf("inactive scheduled permit matched (PolicyName=%q); want default-deny fall-through", res.PolicyName)
+		}
+		if !res.DefaultUsed || res.Action != config.PolicyDeny {
+			t.Fatalf("want default deny, got Matched=%v DefaultUsed=%v Action=%v",
+				res.Matched, res.DefaultUsed, res.Action)
+		}
+	})
+
+	// Case 2: an inactive scheduled DENY must be skipped so a LATER active
+	// permit wins — the runtime would forward such traffic.
+	t.Run("inactive scheduled deny -> falls through to active permit", func(t *testing.T) {
+		cfg := cfgWith(config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Policies: []*config.ZonePairPolicies{
+				zonePair("trust", "untrust",
+					scheduled(deny("block-by-day", config.PolicyMatch{
+						Applications: []string{"any"},
+					}), "business-hours"),
+					permit("allow-rest", config.PolicyMatch{Applications: []string{"any"}})),
+			},
+		}, config.ApplicationsConfig{})
+		q := Query{
+			FromZone:         "trust",
+			ToZone:           "untrust",
+			Protocol:         "tcp",
+			DstPort:          80,
+			PolicyInactiveFn: inactiveFnFor(map[string]bool{"business-hours": false}),
+		}
+		res := Match(cfg, q)
+		if !res.Matched || res.Action != config.PolicyPermit || res.PolicyName != "allow-rest" {
+			t.Fatalf("want permit by allow-rest, got Matched=%v Action=%v PolicyName=%q",
+				res.Matched, res.Action, res.PolicyName)
+		}
+	})
+
+	// Case 3: a scheduler flip changes the verdict for the same query/config.
+	t.Run("scheduler flip changes verdict", func(t *testing.T) {
+		cfg := cfgWith(config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Policies: []*config.ZonePairPolicies{
+				zonePair("trust", "untrust",
+					scheduled(permit("maint-window", config.PolicyMatch{
+						Applications: []string{"any"},
+					}), "maint")),
+			},
+		}, config.ApplicationsConfig{})
+		baseQ := func(active bool) Query {
+			return Query{
+				FromZone:         "trust",
+				ToZone:           "untrust",
+				Protocol:         "tcp",
+				DstPort:          443,
+				PolicyInactiveFn: inactiveFnFor(map[string]bool{"maint": active}),
+			}
+		}
+		// Active -> the scheduled permit matches.
+		if res := Match(cfg, baseQ(true)); !res.Matched || res.Action != config.PolicyPermit {
+			t.Fatalf("scheduler active: want permit match, got Matched=%v Action=%v", res.Matched, res.Action)
+		}
+		// Inactive -> default deny.
+		if res := Match(cfg, baseQ(false)); res.Matched || res.Action != config.PolicyDeny {
+			t.Fatalf("scheduler inactive: want default deny, got Matched=%v Action=%v", res.Matched, res.Action)
+		}
+	})
+
+	// Case 4 (no-regression): a NON-scheduled policy's verdict is identical
+	// whether or not a PolicyInactiveFn is threaded, and regardless of the
+	// active-state map contents. PolicyInactiveFn must never be consulted for a
+	// policy with an empty scheduler name.
+	t.Run("non-scheduled policy unchanged", func(t *testing.T) {
+		cfg := cfgWith(config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Policies: []*config.ZonePairPolicies{
+				zonePair("trust", "untrust",
+					permit("plain-allow", config.PolicyMatch{Applications: []string{"any"}})),
+			},
+		}, config.ApplicationsConfig{})
+		q := Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80}
+
+		// No PolicyInactiveFn (offline surface / pre-#3104 behavior).
+		baseline := Match(cfg, q)
+		if !baseline.Matched || baseline.Action != config.PolicyPermit || baseline.PolicyName != "plain-allow" {
+			t.Fatalf("baseline: want permit by plain-allow, got Matched=%v Action=%v PolicyName=%q",
+				baseline.Matched, baseline.Action, baseline.PolicyName)
+		}
+
+		sameVerdict := func(got Result, label string) {
+			if got.Matched != baseline.Matched || got.Action != baseline.Action ||
+				got.PolicyName != baseline.PolicyName || got.DefaultUsed != baseline.DefaultUsed ||
+				got.Global != baseline.Global {
+				t.Fatalf("non-scheduled verdict changed (%s): baseline=%+v got=%+v", label, baseline, got)
+			}
+		}
+
+		// With a PolicyInactiveFn that marks everything inactive: a
+		// non-scheduled policy (empty scheduler name) is still active.
+		q.PolicyInactiveFn = inactiveFnFor(map[string]bool{})
+		sameVerdict(Match(cfg, q), "empty active map")
+
+		// And with a nil active-state map (state published but empty) — same.
+		q.PolicyInactiveFn = inactiveFnFor(nil)
+		sameVerdict(Match(cfg, q), "nil active map")
+	})
+}


### PR DESCRIPTION
Closes #3104

## The bug
The shared operator-side policy simulator (`pkg/policymatch`) returned a definitive permit/deny for scheduled (runtime-inactive) policies, disagreeing with the dataplane. The runtime (`policy.rs try_match_rule`) drops a scheduler-inactive rule BEFORE app/address matching; the snapshot builder stamps `Inactive` and fails closed on missing scheduler state; `daemon_scheduler.go` republishes active-state flips. So `show security match-policies` / REST / gRPC `MatchPolicies` could report a scheduled PERMIT as matching while the runtime skips it (denies via default or a later rule), and the inverse for a scheduled-inactive DENY. This is the VERDICT companion to the #3062 DISPLAY fix.

## Fix
- New `policymatch.Query.PolicyInactiveFn func(schedulerName string) bool` (threaded like `FeedOverlay`). `ruleMatches` consults it FIRST and skips a scheduler-inactive policy, so `Match` falls through to the next active rule / configured `default-policy` — exactly like the runtime.
- The closure is built from the same daemon-local `Manager.PolicySchedulerActiveState` accessor the #3062 display uses, via a new SSOT builder `dataplane/userspace.PolicyInactiveFn` that wraps the shared `PolicyInactive` predicate. No second scheduler evaluation.
- Wired at every simulator surface so they agree:
  - REST `match-policies` (`pkg/api`) — new `PolicySchedulerActiveStateFn` config fn, wired in `daemon_run.go` next to `FeedOverlayFn`.
  - gRPC `MatchPolicies` and the `test policy` ShowText diagnostic (`pkg/grpcapi`) — via `s.policyInactiveFn()`.
  - Local CLI `show security match-policies` + `test policy` (`pkg/cli`) — via `c.policyInactiveFn()`.

## Missing-state fallback (decision)
When live scheduler state is unavailable to a caller (offline CLI, or `NoDataplane`), the closure is **nil** and the simulator evaluates scheduled policies **as-if-active**. This matches the **#3062 display fallback** (renders inactive only when a provider is present) and the pre-#3104 behavior, and is the simpler option the issue offered. A NON-scheduled policy's verdict is byte-identical regardless of whether state is supplied (`PolicyInactive` reports an empty scheduler name as always active). All in-daemon surfaces do supply live state, so the definitive-but-wrong verdict the issue describes is eliminated in practice; the nil path is the safety fallback only.

## Tests (fail-on-revert)
`pkg/policymatch/scheduler_test.go`, `TestSchedulerInactiveSkipsLikeRuntime`:
1. inactive scheduled PERMIT -> simulator returns default-deny;
2. inactive scheduled DENY -> falls through to a later active PERMIT;
3. scheduler flip changes the verdict;
4. non-scheduled policy unchanged (with nil fn, empty map, and nil map).

Fail-on-revert verified: removing the `ruleMatches` skip turns cases 1-3 RED (inactive permit matches, inactive deny matches, flip fails to deny) and leaves case 4 green; restoring is byte-identical.

`go build ./...` clean. `go test ./pkg/policymatch/ ./pkg/cli/ ./pkg/api/ ./pkg/grpcapi/ ./pkg/dataplane/userspace/ ./pkg/daemon/` all green. Updated the `policymatch` package doc and the REST/CLI/gRPC READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi