### PR TITLE
icmp_embed: reverse embedded destination for DNAT/static return ICMP errors (#3112)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20025,3 +20025,22 @@ top.
   pkg/grpcapi/server_show_policies_text.go,
   pkg/grpcapi/server_show_policies_scheduler_3062_test.go,
   docs/junos-cli-reference.md, _Log.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #3112 — embedded-ICMP DNAT/static destination reversal. Added
+  `original_dst`/`original_dst_port` to `EmbeddedIcmpMatch`, populated from
+  the forward session key (`fwd.key.dst_ip`/`dst_port`) at the v4/v6 NAT
+  match sites. The v4/v6 builders now un-DNAT the embedded (quoted)
+  destination IP + transport port and rewrite the outer source when the
+  matched session carries a destination NAT (`rewrite_dst.is_some()`),
+  recomputing the embedded IPv4 and outer ICMP/ICMPv6 checksums. Gated off
+  for SNAT-only/no-NAT flows (byte-identical). Added 4 Rust tests (v4 DNAT,
+  v4 static, v4 SNAT-only regression guard, v6 DNAT66) + fail-on-revert
+  proof. Doc: `docs/userspace-icmp-te-debugging.md`.
+  **File(s)**: userspace-dp/src/afxdp/icmp_embed/mod.rs,
+  userspace-dp/src/afxdp/icmp_embed/nat_match_v4.rs,
+  userspace-dp/src/afxdp/icmp_embed/nat_match_v6.rs,
+  userspace-dp/src/afxdp/icmp_embed/builders.rs,
+  userspace-dp/src/afxdp/tests.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  docs/userspace-icmp-te-debugging.md

--- a/docs/userspace-icmp-te-debugging.md
+++ b/docs/userspace-icmp-te-debugging.md
@@ -23,6 +23,37 @@ ICMP Time Exceeded (type 11) from intermediate routers arrives at the firewall's
 5. Recompute all checksums (outer IP, outer ICMP, embedded IP)
 6. Forward the rewritten ICMP error to the original client
 
+### Destination reversal for DNAT / static-NAT (#3112)
+
+Steps 3-4 above describe the SOURCE reversal that un-SNATs outbound flows.
+The symmetric DESTINATION reversal handles INBOUND DNAT/static-NAT'd
+servers. For a flow `client C -> public P` that the firewall DNATs to a
+private server `S`, the ICMP error returns from `S` quoting a packet
+addressed to `S` (and originating, on the outer header, from `S`). The
+client opened its socket to `P`, so it silently discards an error that
+quotes `S` — breaking PMTUD and traceroute to NAT'd servers.
+
+When the matched forward session carries a destination NAT
+(`NatDecision.rewrite_dst.is_some()`), the builders additionally:
+
+- rewrite the **outer source** IP `S -> P` (the public address the client
+  used), so the error appears to originate from `P`;
+- rewrite the **embedded (quoted) destination** IP `S -> P`;
+- rewrite the **embedded transport destination port** to the pre-DNAT
+  public port (TCP/UDP only; ICMP echo carries no destination port);
+- recompute the embedded IP-header checksum (IPv4) and the outer
+  ICMP/ICMPv6 checksum (the ICMPv6 pseudo-header picks up the rewritten
+  outer source automatically).
+
+The pre-DNAT public destination + port are recovered from the forward
+session key (`fwd.key.dst_ip` / `fwd.key.dst_port`), which holds the
+ORIGINAL pre-NAT tuple, and are carried on `EmbeddedIcmpMatch` as
+`original_dst` / `original_dst_port`. When the flow has **no** destination
+NAT (SNAT-only or plain transit), these equal the embedded destination and
+the rewrites are gated off — the output is byte-identical to the
+source-only path, so transit/intermediate-router errors keep their real
+outer source.
+
 ### Which ICMP error types are reversed (`is_icmp_error`)
 
 The embedded-NAT reversal only runs for ICMP messages that quote the

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -1051,6 +1051,8 @@ fn embedded_icmp_to_inactive_owner_rg_uses_zone_encoded_fabric_redirect() {
         },
         original_src: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
         original_src_port: 33434,
+        original_dst: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)),
+        original_dst_port: 33434,
         embedded_proto: PROTO_UDP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,
@@ -1103,6 +1105,8 @@ fn embedded_icmp_no_route_uses_zone_encoded_fabric_redirect() {
         },
         original_src: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
         original_src_port: 33434,
+        original_dst: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)),
+        original_dst_port: 33434,
         embedded_proto: PROTO_UDP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::NoRoute,
@@ -1155,6 +1159,8 @@ fn embedded_icmp_discard_route_uses_zone_encoded_fabric_redirect() {
         },
         original_src: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
         original_src_port: 33434,
+        original_dst: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)),
+        original_dst_port: 33434,
         embedded_proto: PROTO_UDP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::DiscardRoute,
@@ -1203,6 +1209,8 @@ fn embedded_icmp_from_fabric_does_not_redirect_back_to_fabric() {
         },
         original_src: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
         original_src_port: 33434,
+        original_dst: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)),
+        original_dst_port: 33434,
         embedded_proto: PROTO_UDP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,

--- a/userspace-dp/src/afxdp/icmp_embed/builders.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/builders.rs
@@ -27,6 +27,14 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v4(
         IpAddr::V4(v4) => v4,
         _ => return None,
     };
+    // #3112: pre-DNAT public destination. Only rewritten when the flow
+    // actually had destination NAT (DNAT/static); otherwise the writes
+    // below are gated off and the output stays byte-identical.
+    let original_dst = match icmp_match.original_dst {
+        IpAddr::V4(v4) => v4,
+        _ => return None,
+    };
+    let had_dst_nat = icmp_match.nat.rewrite_dst.is_some();
 
     #[cfg(feature = "debug-log")]
     let _eth_len = l3;
@@ -57,6 +65,15 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v4(
     pkt.get_mut(16..20)?
         .copy_from_slice(&original_client.octets());
 
+    // #3112: when destination NAT was applied, rewrite the outer SOURCE
+    // so the error appears to originate from the public address the
+    // client sent to (mirrors the unconditional outer-dst rewrite above,
+    // but gated on dst-NAT to leave transit/intermediate-router errors
+    // and SNAT-only flows untouched).
+    if had_dst_nat {
+        pkt.get_mut(12..16)?.copy_from_slice(&original_dst.octets());
+    }
+
     let icmp_offset = ihl;
     let emb_ip_offset = icmp_offset + 8;
     if pkt.len() < emb_ip_offset + 20 {
@@ -69,6 +86,14 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v4(
 
     pkt.get_mut(emb_ip_offset + 12..emb_ip_offset + 16)?
         .copy_from_slice(&original_client.octets());
+
+    // #3112: un-DNAT the embedded (quoted) destination so the client's
+    // stack can match the error to the session it opened to the public
+    // dst. Done before the embedded IP-header checksum recompute below.
+    if had_dst_nat {
+        pkt.get_mut(emb_ip_offset + 16..emb_ip_offset + 20)?
+            .copy_from_slice(&original_dst.octets());
+    }
 
     {
         pkt.get_mut(emb_ip_offset + 10..emb_ip_offset + 12)?
@@ -115,6 +140,23 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v4(
         }
     }
 
+    // #3112: un-DNAT the embedded transport DESTINATION port (TCP/UDP).
+    // Same fragment gate as the source restore above. The embedded L4
+    // checksum is intentionally NOT adjusted here — exactly as the
+    // source-port restore omits it: the quoted L4 header is truncated and
+    // unverifiable, and only the outer ICMP checksum (recomputed below
+    // over the whole payload) covers these bytes. ICMP echo (no dst port)
+    // is excluded — its dst_port is 0 and original_dst_port a no-op.
+    if !emb_non_first_fragment
+        && (icmp_match.nat.rewrite_dst_port.is_some() || icmp_match.nat.rewrite_dst.is_some())
+    {
+        let emb_proto = icmp_match.embedded_proto;
+        if matches!(emb_proto, PROTO_TCP | PROTO_UDP) && pkt.len() >= emb_l4_offset + 4 {
+            pkt.get_mut(emb_l4_offset + 2..emb_l4_offset + 4)?
+                .copy_from_slice(&icmp_match.original_dst_port.to_be_bytes());
+        }
+    }
+
     pkt.get_mut(icmp_offset + 2..icmp_offset + 4)?
         .copy_from_slice(&[0, 0]);
     let icmp_data = pkt.get(icmp_offset..)?;
@@ -152,6 +194,14 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v6(
         IpAddr::V6(v6) => v6.octets(),
         _ => return None,
     };
+    // #3112: pre-DNAT public destination (DNAT66/static). Only applied
+    // when the flow had destination NAT; otherwise gated off so the
+    // output is byte-identical to the SNAT-only / no-NAT path.
+    let original_dst_bytes = match icmp_match.original_dst {
+        IpAddr::V6(v6) => v6.octets(),
+        _ => return None,
+    };
+    let had_dst_nat = icmp_match.nat.rewrite_dst.is_some();
 
     let dst_mac = icmp_match.resolution.neighbor_mac?;
     let src_mac = icmp_match.resolution.src_mac?;
@@ -180,6 +230,14 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v6(
 
     pkt.get_mut(24..40)?.copy_from_slice(&original_client_bytes);
 
+    // #3112: rewrite the outer SOURCE to the public dst on dst-NAT flows
+    // so the error appears to come from the address the client used. The
+    // ICMPv6 checksum recompute below reads the (rewritten) outer src/dst
+    // for its pseudo-header, so the order is correct.
+    if had_dst_nat {
+        pkt.get_mut(8..24)?.copy_from_slice(&original_dst_bytes);
+    }
+
     // Outer ICMPv6 offset: ext-aware via the shared #1838 helper (the
     // outer NAT match in icmp_embed/mod.rs reads the ICMP type at
     // meta.l4_offset, so an outer-ext error MATCHES — a fixed 40 here
@@ -192,6 +250,15 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v6(
     }
     pkt.get_mut(emb_ip_offset + 8..emb_ip_offset + 24)?
         .copy_from_slice(&original_client_bytes);
+
+    // #3112: un-DNAT the embedded (quoted) destination so the client can
+    // match the error to its session. v6 has no IP-header checksum, so no
+    // recompute is needed for this rewrite (the outer ICMPv6 checksum
+    // below covers the whole quoted payload).
+    if had_dst_nat {
+        pkt.get_mut(emb_ip_offset + 24..emb_ip_offset + 40)?
+            .copy_from_slice(&original_dst_bytes);
+    }
 
     // Embedded L4 offset: fragment-aware walk over the quoted packet
     // (plan §5.7). None — e.g. a quoted non-first fragment, which has
@@ -221,6 +288,22 @@ pub(in crate::afxdp::icmp_embed) fn build_nat_reversed_icmp_error_v6(
                         .copy_from_slice(&new_csum.to_be_bytes());
                 }
             }
+        }
+    }
+
+    // #3112: un-DNAT the embedded transport DESTINATION port (TCP/UDP),
+    // mirroring the source-port restore above. Same fragment-aware gate
+    // (skip when the quoted packet has no L4 header). The embedded L4
+    // checksum is left as-is — the outer ICMPv6 checksum recompute below
+    // covers the quoted bytes. ICMPv6 echo carries no dst port.
+    if (icmp_match.nat.rewrite_dst_port.is_some() || icmp_match.nat.rewrite_dst.is_some())
+        && let Some((emb_rel_l4, _)) = emb_l4
+    {
+        let emb_l4_offset = emb_ip_offset.checked_add(emb_rel_l4)?;
+        let emb_proto = icmp_match.embedded_proto;
+        if matches!(emb_proto, PROTO_TCP | PROTO_UDP) && pkt.len() >= emb_l4_offset + 4 {
+            pkt.get_mut(emb_l4_offset + 2..emb_l4_offset + 4)?
+                .copy_from_slice(&icmp_match.original_dst_port.to_be_bytes());
         }
     }
 

--- a/userspace-dp/src/afxdp/icmp_embed/mod.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/mod.rs
@@ -36,6 +36,15 @@ pub(super) struct EmbeddedIcmpMatch {
     pub(super) original_src: IpAddr,
     /// The original source port (if port SNAT was applied).
     pub(super) original_src_port: u16,
+    /// The original (pre-DNAT/static) destination IP the client used —
+    /// i.e. the public address before destination NAT. For a flow with
+    /// NO destination NAT this equals the embedded packet's destination,
+    /// so the destination rewrite in the builders is a no-op and
+    /// SNAT-only / no-NAT behaviour stays byte-identical (#3112).
+    pub(super) original_dst: IpAddr,
+    /// The original (pre-DNAT) destination port. Equals the embedded
+    /// destination port when no port DNAT was applied (no-op rewrite).
+    pub(super) original_dst_port: u16,
     /// The embedded packet's L4 protocol.
     pub(super) embedded_proto: u8,
     /// Forwarding resolution toward the original client.

--- a/userspace-dp/src/afxdp/icmp_embed/nat_match_v4.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/nat_match_v4.rs
@@ -44,6 +44,14 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v4(
         let nat = fwd.decision.nat;
         let original_src = fwd.key.src_ip;
         let original_src_port = fwd.key.src_port;
+        // #3112: the forward session key carries the ORIGINAL (pre-NAT)
+        // tuple, so its dst is the public address the client sent to. For
+        // a DNAT/static flow this is the address the ICMP error must
+        // appear to quote (and originate from); for an SNAT-only flow it
+        // equals the embedded dst, making the builder's dst rewrite a
+        // no-op.
+        let original_dst = fwd.key.dst_ip;
+        let original_dst_port = fwd.key.dst_port;
         let resolution = embedded_icmp_return_resolution(
             ctx,
             &fwd.key,
@@ -55,6 +63,8 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v4(
             nat,
             original_src,
             original_src_port,
+            original_dst,
+            original_dst_port,
             embedded_proto: hdr.proto,
             resolution,
             metadata: fwd.metadata,
@@ -94,6 +104,10 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v4(
             nat: sl.decision.nat,
             original_src: emb_src,
             original_src_port: hdr.src_port,
+            // Plain (non-forward-NAT) match: no pre-DNAT public dst to
+            // recover, so the embedded dst stays as-is (#3112 no-op).
+            original_dst: emb_dst,
+            original_dst_port: hdr.dst_port,
             embedded_proto: hdr.proto,
             resolution,
             metadata: sl.metadata,

--- a/userspace-dp/src/afxdp/icmp_embed/nat_match_v6.rs
+++ b/userspace-dp/src/afxdp/icmp_embed/nat_match_v6.rs
@@ -52,6 +52,12 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v6(
         let nat = fwd.decision.nat;
         let original_src = fwd.key.src_ip;
         let original_src_port = fwd.key.src_port;
+        // #3112: forward session key holds the ORIGINAL (pre-NAT) tuple;
+        // its dst is the public address the client used. DNAT66/static
+        // sets rewrite_dst so the builder un-NATs the embedded dst; for
+        // an SNAT-only flow this equals the embedded dst (no-op).
+        let original_dst = fwd.key.dst_ip;
+        let original_dst_port = fwd.key.dst_port;
         let resolution = embedded_icmp_return_resolution(
             ctx,
             &fwd.key,
@@ -63,6 +69,8 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v6(
             nat,
             original_src,
             original_src_port,
+            original_dst,
+            original_dst_port,
             embedded_proto: hdr.proto,
             resolution,
             metadata: fwd.metadata,
@@ -115,6 +123,10 @@ pub(in crate::afxdp::icmp_embed) fn match_outer_v6(
             nat: sl.decision.nat,
             original_src: emb_src_lookup,
             original_src_port: hdr.src_port,
+            // Plain (non-forward-NAT) match: nothing to un-DNAT, so the
+            // embedded dst is preserved unchanged (#3112 no-op).
+            original_dst: hdr.dst,
+            original_dst_port: hdr.dst_port,
             embedded_proto: hdr.proto,
             resolution,
             metadata: sl.metadata,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -2673,6 +2673,8 @@ fn icmp_te_nat_reversal_v4_rewrites_outer_dst_and_embedded_src() {
         },
         original_src: IpAddr::V4(client_ip),
         original_src_port: client_port,
+        original_dst: IpAddr::V4(server_ip),
+        original_dst_port: 80,
         embedded_proto: PROTO_TCP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,
@@ -2798,6 +2800,8 @@ fn icmp_te_nat_reversal_v4_with_port_snat() {
         },
         original_src: IpAddr::V4(client_ip),
         original_src_port: client_port,
+        original_dst: IpAddr::V4(server_ip),
+        original_dst_port: 53,
         embedded_proto: PROTO_UDP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,
@@ -2916,6 +2920,8 @@ fn icmp_dest_unreach_nat_reversal_v4() {
         },
         original_src: IpAddr::V4(client_ip),
         original_src_port: 12345,
+        original_dst: IpAddr::V4(server_ip),
+        original_dst_port: 80,
         embedded_proto: PROTO_TCP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,
@@ -2957,6 +2963,244 @@ fn icmp_dest_unreach_nat_reversal_v4() {
     assert_eq!(ip_csum_check, 0);
     let icmp_csum_check = checksum16(&result[34..]);
     assert_eq!(icmp_csum_check, 0);
+}
+
+// === #3112: embedded-DESTINATION reversal for DNAT/static-NAT ===
+
+/// Shared meta for the IPv4 embedded-ICMP builder tests.
+fn icmp_err_meta_v4() -> UserspaceDpMeta {
+    UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        l4_offset: 34,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_ICMP,
+        ..UserspaceDpMeta::default()
+    }
+}
+
+/// Resolution + metadata block shared by the v4 #3112 fixtures.
+fn icmp_err_resolution_v4(next_hop: Ipv4Addr) -> ForwardingResolution {
+    ForwardingResolution {
+        disposition: ForwardingDisposition::ForwardCandidate,
+        local_ifindex: 0,
+        egress_ifindex: 5,
+        tx_ifindex: 5,
+        tunnel_endpoint_id: 0,
+        next_hop: Some(IpAddr::V4(next_hop)),
+        neighbor_mac: Some([0x00, 0x11, 0x22, 0x33, 0x44, 0x55]),
+        src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]),
+        tx_vlan_id: 0,
+    }
+}
+
+fn icmp_err_metadata() -> SessionMetadata {
+    SessionMetadata {
+        ingress_zone: TEST_UNTRUST_ZONE_ID,
+        egress_zone: TEST_TRUST_ZONE_ID,
+        owner_rg_id: 0,
+        fabric_ingress: false,
+        is_reverse: false,
+        nat64_reverse: None,
+        log_session_init: false,
+        log_session_close: false,
+        policy_id: 0,
+    }
+}
+
+#[test]
+fn icmp_dnat_reversal_v4_rewrites_embedded_dst_and_outer_src() {
+    // Scenario: client C -> public P:80, DNAT to private S:8080. The
+    // server S returns an ICMP error quoting the packet it received
+    // (src=C, dst=S:8080), with outer src=S, outer dst=C. For the client
+    // to match the error to the session it opened to P:80, the embedded
+    // destination must be un-DNAT'd S:8080 -> P:80 and the outer source
+    // rewritten S -> P. (#3112)
+    let client_c = Ipv4Addr::new(10, 0, 61, 102);
+    let public_p = Ipv4Addr::new(203, 0, 113, 9);
+    let private_s = Ipv4Addr::new(10, 0, 90, 50);
+    let client_port: u16 = 51000;
+    let public_port: u16 = 80;
+    let private_port: u16 = 8080;
+
+    // build_icmp_te_frame_v4(outer_src, outer_dst, embedded_dst,
+    //   embedded_src_port, embedded_dst_port, proto): the "snat_ip"
+    // parameter doubles as outer-dst AND embedded-src, which for the DNAT
+    // return is the client.
+    let frame = build_icmp_te_frame_v4(
+        private_s,    // outer src = server that emitted the error
+        client_c,     // outer dst + embedded src = client
+        private_s,    // embedded dst = the DNAT'd private server
+        client_port,  // embedded src port
+        private_port, // embedded dst port (the DNAT'd port)
+        PROTO_TCP,
+    );
+
+    let icmp_match = EmbeddedIcmpMatch {
+        nat: NatDecision {
+            rewrite_dst: Some(IpAddr::V4(private_s)),
+            rewrite_dst_port: Some(private_port),
+            ..NatDecision::default()
+        },
+        original_src: IpAddr::V4(client_c),
+        original_src_port: client_port,
+        original_dst: IpAddr::V4(public_p),
+        original_dst_port: public_port,
+        embedded_proto: PROTO_TCP,
+        resolution: icmp_err_resolution_v4(client_c),
+        metadata: icmp_err_metadata(),
+    };
+
+    let result = build_nat_reversed_icmp_error_v4(&frame, icmp_err_meta_v4(), &icmp_match)
+        .expect("should build NAT-reversed frame");
+
+    // Outer src is now the public address the client used.
+    let outer_src = Ipv4Addr::new(result[26], result[27], result[28], result[29]);
+    assert_eq!(outer_src, public_p, "outer src must be un-DNAT'd to public P");
+    // Outer dst is still the client.
+    let outer_dst = Ipv4Addr::new(result[30], result[31], result[32], result[33]);
+    assert_eq!(outer_dst, client_c, "outer dst stays the client");
+
+    let emb = 42; // eth(14)+outer ip(20)+icmp(8)
+    let emb_src = Ipv4Addr::new(result[emb + 12], result[emb + 13], result[emb + 14], result[emb + 15]);
+    assert_eq!(emb_src, client_c, "embedded src (client) unchanged");
+    let emb_dst = Ipv4Addr::new(result[emb + 16], result[emb + 17], result[emb + 18], result[emb + 19]);
+    assert_eq!(emb_dst, public_p, "embedded dst must be un-DNAT'd to public P");
+
+    // Embedded transport ports: src unchanged (no SNAT), dst un-DNAT'd.
+    let emb_l4 = emb + 20;
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4], result[emb_l4 + 1]]),
+        client_port,
+        "embedded src port unchanged"
+    );
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4 + 2], result[emb_l4 + 3]]),
+        public_port,
+        "embedded dst port must be un-DNAT'd to the public port"
+    );
+
+    // All checksums valid.
+    assert_eq!(checksum16(&result[14..34]), 0, "outer IP checksum");
+    assert_eq!(checksum16(&result[34..]), 0, "outer ICMP checksum");
+    assert_eq!(checksum16(&result[emb..emb + 20]), 0, "embedded IP checksum");
+}
+
+#[test]
+fn icmp_static_nat_reversal_v4_rewrites_embedded_dst() {
+    // Static 1:1 inbound: client C -> public P, statically mapped to
+    // private S (IP-only, no port translation). The embedded dst must be
+    // rewritten S -> P; ports are unchanged (original_dst_port == the
+    // embedded dst port, so the gated dst-port write is a no-op).
+    let client_c = Ipv4Addr::new(10, 0, 61, 102);
+    let public_p = Ipv4Addr::new(198, 51, 100, 7);
+    let private_s = Ipv4Addr::new(10, 0, 90, 51);
+    let client_port: u16 = 52000;
+    let server_port: u16 = 443;
+
+    let frame = build_icmp_te_frame_v4(
+        private_s,
+        client_c,
+        private_s,
+        client_port,
+        server_port,
+        PROTO_TCP,
+    );
+
+    let icmp_match = EmbeddedIcmpMatch {
+        nat: NatDecision {
+            // static 1:1 reverses dst only (IP), no port DNAT.
+            rewrite_dst: Some(IpAddr::V4(private_s)),
+            ..NatDecision::default()
+        },
+        original_src: IpAddr::V4(client_c),
+        original_src_port: client_port,
+        original_dst: IpAddr::V4(public_p),
+        original_dst_port: server_port, // unchanged port -> no-op
+        embedded_proto: PROTO_TCP,
+        resolution: icmp_err_resolution_v4(client_c),
+        metadata: icmp_err_metadata(),
+    };
+
+    let result = build_nat_reversed_icmp_error_v4(&frame, icmp_err_meta_v4(), &icmp_match)
+        .expect("should build NAT-reversed frame");
+
+    let outer_src = Ipv4Addr::new(result[26], result[27], result[28], result[29]);
+    assert_eq!(outer_src, public_p, "outer src un-NAT'd to public P");
+    let emb = 42;
+    let emb_dst = Ipv4Addr::new(result[emb + 16], result[emb + 17], result[emb + 18], result[emb + 19]);
+    assert_eq!(emb_dst, public_p, "embedded dst un-NAT'd to public P");
+    let emb_l4 = emb + 20;
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4 + 2], result[emb_l4 + 3]]),
+        server_port,
+        "embedded dst port unchanged (IP-only static NAT)"
+    );
+    assert_eq!(checksum16(&result[14..34]), 0);
+    assert_eq!(checksum16(&result[34..]), 0);
+    assert_eq!(checksum16(&result[emb..emb + 20]), 0);
+}
+
+#[test]
+fn icmp_snat_only_reversal_v4_leaves_destination_untouched() {
+    // Regression guard (#3112 fail-on-revert pair): with NO destination
+    // NAT (rewrite_dst == None), the destination-side rewrites are gated
+    // OFF — outer src, embedded dst, and embedded dst port stay exactly
+    // as on the wire, even when original_dst is (deliberately) bogus.
+    // This is the byte-identical SNAT-only path.
+    let router = Ipv4Addr::new(10, 0, 0, 1);
+    let snat_ip = Ipv4Addr::new(172, 16, 80, 8);
+    let client_ip = Ipv4Addr::new(10, 0, 61, 102);
+    let server_ip = Ipv4Addr::new(1, 1, 1, 1);
+    let snat_port: u16 = 40000;
+    let client_port: u16 = 12345;
+
+    let frame = build_icmp_te_frame_v4(router, snat_ip, server_ip, snat_port, 80, PROTO_TCP);
+
+    let icmp_match = EmbeddedIcmpMatch {
+        nat: NatDecision {
+            rewrite_src: Some(IpAddr::V4(snat_ip)),
+            rewrite_src_port: Some(snat_port),
+            // rewrite_dst stays None -> destination rewrite must not fire.
+            ..NatDecision::default()
+        },
+        original_src: IpAddr::V4(client_ip),
+        original_src_port: client_port,
+        // Deliberately bogus values: must be ignored because no dst NAT.
+        original_dst: IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)),
+        original_dst_port: 65000,
+        embedded_proto: PROTO_TCP,
+        resolution: icmp_err_resolution_v4(client_ip),
+        metadata: icmp_err_metadata(),
+    };
+
+    let result = build_nat_reversed_icmp_error_v4(&frame, icmp_err_meta_v4(), &icmp_match)
+        .expect("should build NAT-reversed frame");
+
+    // Outer src stays the router (NOT the bogus original_dst).
+    let outer_src = Ipv4Addr::new(result[26], result[27], result[28], result[29]);
+    assert_eq!(outer_src, router, "SNAT-only: outer src untouched");
+    let emb = 42;
+    let emb_dst = Ipv4Addr::new(result[emb + 16], result[emb + 17], result[emb + 18], result[emb + 19]);
+    assert_eq!(emb_dst, server_ip, "SNAT-only: embedded dst untouched");
+    let emb_l4 = emb + 20;
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4 + 2], result[emb_l4 + 3]]),
+        80,
+        "SNAT-only: embedded dst port untouched"
+    );
+    // Source-side reversal still applies (unchanged behaviour).
+    let emb_src = Ipv4Addr::new(result[emb + 12], result[emb + 13], result[emb + 14], result[emb + 15]);
+    assert_eq!(emb_src, client_ip, "SNAT-only: source still reversed");
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4], result[emb_l4 + 1]]),
+        client_port
+    );
+    assert_eq!(checksum16(&result[14..34]), 0);
+    assert_eq!(checksum16(&result[34..]), 0);
+    assert_eq!(checksum16(&result[emb..emb + 20]), 0);
 }
 
 /// Build an IPv6 ICMPv6 Time Exceeded frame with an embedded TCP packet.
@@ -3051,6 +3295,8 @@ fn icmpv6_te_nat_reversal_v6_rewrites_outer_dst_and_embedded_src() {
         },
         original_src: IpAddr::V6(client_ip),
         original_src_port: client_port,
+        original_dst: IpAddr::V6(client_ip),
+        original_dst_port: client_port,
         embedded_proto: PROTO_TCP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,
@@ -3138,6 +3384,107 @@ fn icmpv6_te_nat_reversal_v6_rewrites_outer_dst_and_embedded_src() {
         actual_csum, expected_csum,
         "ICMPv6 checksum should be valid"
     );
+}
+
+#[test]
+fn icmpv6_dnat66_reversal_v6_rewrites_embedded_dst_and_outer_src() {
+    // DNAT66: client C -> public P:443, mapped to internal S:8443. The
+    // returning ICMPv6 error from S quotes (src=C, dst=S:8443) with outer
+    // src=S, outer dst=C. The embedded dst must be un-NAT'd S:8443 ->
+    // P:443 and the outer source rewritten S -> P, with a valid ICMPv6
+    // checksum (pseudo-header over the rewritten outer addresses). (#3112)
+    let client_c: Ipv6Addr = "fd00::102".parse().unwrap();
+    let public_p: Ipv6Addr = "2001:db8:cafe::1".parse().unwrap();
+    let internal_s: Ipv6Addr = "fd00:90::50".parse().unwrap();
+    let client_port: u16 = 51000;
+    let public_port: u16 = 443;
+    let internal_port: u16 = 8443;
+
+    // build_icmpv6_te_frame(outer_src, outer_dst+embedded_src,
+    //   embedded_dst, embedded_src_port, embedded_dst_port, proto).
+    let frame = build_icmpv6_te_frame(
+        internal_s,
+        client_c,
+        internal_s,
+        client_port,
+        internal_port,
+        PROTO_TCP,
+    );
+
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: std::mem::size_of::<UserspaceDpMeta>() as u16,
+        l3_offset: 14,
+        l4_offset: 54,
+        addr_family: libc::AF_INET6 as u8,
+        protocol: PROTO_ICMPV6,
+        ..UserspaceDpMeta::default()
+    };
+
+    let icmp_match = EmbeddedIcmpMatch {
+        nat: NatDecision {
+            rewrite_dst: Some(IpAddr::V6(internal_s)),
+            rewrite_dst_port: Some(internal_port),
+            ..NatDecision::default()
+        },
+        original_src: IpAddr::V6(client_c),
+        original_src_port: client_port,
+        original_dst: IpAddr::V6(public_p),
+        original_dst_port: public_port,
+        embedded_proto: PROTO_TCP,
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 5,
+            tx_ifindex: 5,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V6(client_c)),
+            neighbor_mac: Some([0x00, 0x11, 0x22, 0x33, 0x44, 0x55]),
+            src_mac: Some([0x02, 0xbf, 0x72, 0x00, 0x50, 0x08]),
+            tx_vlan_id: 0,
+        },
+        metadata: icmp_err_metadata(),
+    };
+
+    let result = build_nat_reversed_icmp_error_v6(&frame, meta, &icmp_match)
+        .expect("should build NAT-reversed ICMPv6 frame");
+
+    // Outer src un-NAT'd to public P (bytes 22..38), outer dst stays C.
+    let outer_src = Ipv6Addr::from(<[u8; 16]>::try_from(&result[22..38]).unwrap());
+    assert_eq!(outer_src, public_p, "outer IPv6 src un-NAT'd to public P");
+    let outer_dst = Ipv6Addr::from(<[u8; 16]>::try_from(&result[38..54]).unwrap());
+    assert_eq!(outer_dst, client_c, "outer IPv6 dst stays the client");
+
+    let emb = 62; // eth(14)+outer(40)+icmp6(8)
+    let emb_src = Ipv6Addr::from(<[u8; 16]>::try_from(&result[emb + 8..emb + 24]).unwrap());
+    assert_eq!(emb_src, client_c, "embedded src (client) unchanged");
+    let emb_dst = Ipv6Addr::from(<[u8; 16]>::try_from(&result[emb + 24..emb + 40]).unwrap());
+    assert_eq!(emb_dst, public_p, "embedded dst un-NAT'd to public P");
+
+    let emb_l4 = emb + 40;
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4], result[emb_l4 + 1]]),
+        client_port,
+        "embedded src port unchanged"
+    );
+    assert_eq!(
+        u16::from_be_bytes([result[emb_l4 + 2], result[emb_l4 + 3]]),
+        public_port,
+        "embedded dst port un-NAT'd to the public port"
+    );
+
+    // ICMPv6 checksum valid over the rewritten outer pseudo-header.
+    let icmp6_start = 54;
+    let mut icmp6_copy = result[icmp6_start..].to_vec();
+    icmp6_copy[2] = 0;
+    icmp6_copy[3] = 0;
+    let expected = {
+        let c = checksum16_ipv6(outer_src, outer_dst, PROTO_ICMPV6, &icmp6_copy);
+        if c == 0 { 0xffff } else { c }
+    };
+    let actual = u16::from_be_bytes([result[icmp6_start + 2], result[icmp6_start + 3]]);
+    assert_eq!(actual, expected, "ICMPv6 checksum valid after dst reversal");
 }
 
 /// Flexible ICMPv6 Time Exceeded fixture for the #1838 §5.7 builder
@@ -3237,6 +3584,8 @@ fn icmpv6_te_match_fixture(
         },
         original_src: IpAddr::V6(client_ip),
         original_src_port: client_port,
+        original_dst: IpAddr::V6(client_ip),
+        original_dst_port: client_port,
         embedded_proto: PROTO_TCP,
         resolution: ForwardingResolution {
             disposition: ForwardingDisposition::ForwardCandidate,


### PR DESCRIPTION
Closes #3112

## Problem

The embedded-ICMP NAT-reversal path only carried and rewrote the SOURCE
side, so it un-SNAT'd outbound flows correctly but left DNAT/static
(inbound) embedded fields stale. For a flow `client C -> public P` that
the firewall DNATs to a private server `S`, the ICMP error returns from
`S` quoting a packet addressed to `S` (outer source `S` too). The client
opened its socket to `P`, so its stack silently discards an error quoting
`S` — breaking PMTUD and traceroute to NAT'd servers.

## Fix

- Add `original_dst` / `original_dst_port` to `EmbeddedIcmpMatch`,
  populated at the v4/v6 NAT-match sites from the forward session key
  (`fwd.key.dst_ip` / `dst_port`), which holds the ORIGINAL pre-NAT
  tuple. The session-fallback arms set them to the embedded dst (no-op).
- In the v4/v6 builders, when the matched session carries a destination
  NAT (`NatDecision.rewrite_dst.is_some()`): rewrite the outer source
  `S -> P`, the embedded (quoted) destination IP `S -> P`, and the
  embedded transport destination port to the pre-DNAT public port
  (TCP/UDP only; ICMP echo has no dst port). Recompute the embedded IPv4
  header checksum and the outer ICMP/ICMPv6 checksum (the ICMPv6
  pseudo-header reads back the rewritten outer source).

The destination rewrites are gated on `rewrite_dst`, so SNAT-only and
plain transit flows are **byte-identical** to before — intermediate-router
errors keep their real outer source, and PMTUD/traceroute to non-NAT'd
destinations is unchanged. The outer source is rewritten only inside the
dst-NAT context, mirroring the established unconditional outer-destination
rewrite on the source path.

## Tests

Four new Rust tests in `userspace-dp/src/afxdp/tests.rs`:
- `icmp_dnat_reversal_v4_rewrites_embedded_dst_and_outer_src`
- `icmp_static_nat_reversal_v4_rewrites_embedded_dst`
- `icmp_snat_only_reversal_v4_leaves_destination_untouched` (regression guard)
- `icmpv6_dnat66_reversal_v6_rewrites_embedded_dst_and_outer_src`

**Fail-on-revert proof:** neutering the destination rewrites turns the
three dst-NAT tests RED while the SNAT-only guard stays GREEN.

`cargo build --release` + `cargo test --release` green (3011 passed; the
sole failure is the documented pre-existing flake
`reconcile_peers_snapshot_is_atomic_under_concurrent_load`, which passes
in isolation).

Doc updated: `docs/userspace-icmp-te-debugging.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi