### PR TITLE
daemon: make applyConfigLocked cancellable at coarse boundaries (#2926)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-26 — #2926 fold: make the apply-cancel signal actually fire on daemon stop (was inert)
+
+- **Timestamp**: 2026-06-26
+- **Action**: folded a hostile-review MAJOR into PR #3181. #2926 threaded a ctx
+  into `applyConfigLocked` with C1/C2/C3 boundary checks, but `applyCancelCtx()`
+  returned `d.daemonCtx`, which production sets to the `context.Background()`
+  that `cmd/xpfd` passes into `Run` — never cancelled. The signal-cancellable
+  context was a LOCAL var created later by `signal.NotifyContext` and never
+  stored back, so on a real `systemctl stop` the boundary checks always saw
+  `ctx.Err()==nil` → dead code; #2926's goal unmet. Chose **Option B** (dedicated
+  `d.applyCancelContext`/`d.applyCancel`, child of the signal context, isolated
+  from `d.daemonCtx`) over Option A (reassign `d.daemonCtx`): `d.dp.Start`,
+  flow-export/IPFIX relays, RPM retry, scheduler, and cluster comms all derive
+  from `d.daemonCtx` and the orderly shutdown teardown (logFinalStats via
+  Telemetry, HA `rg_active` clear via `dp.HA()`, `dp.Teardown`) needs the
+  dataplane runtime live — so cancelling `d.daemonCtx` at SIGTERM is unsafe.
+  `Run` cancels the apply context at the start of shutdown (before subsystem
+  teardown; teardown performs no `applyConfigLocked`). Added a fail-on-revert
+  test driving the REAL `applyCancelCtx()` wiring; verified it goes RED under
+  the original inert wiring and restored byte-identical. `go build ./...` +
+  `go test ./pkg/daemon/... ./pkg/eventengine/...` green.
+- **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_apply.go,
+  pkg/daemon/daemon_run.go, pkg/daemon/apply_ctx_cancel_test.go,
+  pkg/daemon/README.md, _Log.md
+
 ## 2026-06-26 — #3064: run L3-header fragment screens on the flowless (non-first-fragment) path
 
 - **Timestamp**: 2026-06-26

--- a/_Log.md
+++ b/_Log.md
@@ -20113,3 +20113,28 @@ top.
   server README socket-lifecycle section.
   **File(s)**: userspace-dp/src/server/lifecycle.rs,
   userspace-dp/src/server/README.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #2926 — thread ctx into applyConfigLocked so a daemon stop aborts
+  the post-applySem commit/remediation apply (the #2914/#2868 follow-up: #2914
+  only cancelled the pre-semaphore wait). applyConfigLocked now takes ctx and
+  checks ctx.Err() at three coarse boundaries — C1 before the netlink reconcile
+  phase, C2 before the dataplane apply / Rust control-socket sync push, C3
+  before the FRR reload — returning ctx.Err() at the next boundary instead of
+  completing netlink + FRR + Rust sync. Boundaries are placed so a bail leaves a
+  restart-recoverable state (no mid-phase abort; RETH MAC/VIP/rebind between C2
+  and C3 runs as one unit). The cancellation signal is the DAEMON-LIFETIME ctx
+  (new applyCancelCtx → d.daemonCtx), NOT the request ctx — a request disconnect
+  after store.Commit must not abort (would diverge a running daemon). Commit
+  wrappers (commitAndApply/syncAndApply/commitConfirmedAndApply) pass
+  applyCancelCtx; applyConfig (boot/DHCP/feeds) and executeConfirmedRollback
+  pass context.Background(). Added apply_ctx_cancel_test.go (cancel-aborts +
+  live-runs-full) with fail-on-revert proof; updated test call sites to pass a
+  ctx; updated pkg/daemon/README.md.
+  **File(s)**: pkg/daemon/daemon_apply.go, pkg/daemon/apply_ctx_cancel_test.go,
+  pkg/daemon/daemon_apply_runtime_test.go,
+  pkg/daemon/daemon_flowexport_reconcile_test.go,
+  pkg/daemon/daemon_networkd_apply_test.go,
+  pkg/daemon/daemon_snmp_reconcile_test.go,
+  pkg/daemon/persistent_snat_apply_test.go,
+  pkg/daemon/policy_scheduler_apply_test.go, pkg/daemon/README.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -219,6 +219,27 @@ never lock an operator out of a remote box it manages.
 - `commitFn` and `commitConfirmedFn` are passed to `pkg/cli` and
   `pkg/grpcapi`; they hold the apply semaphore across the commit + apply
   pair so concurrent committers serialize.
+- **Cancellable apply at coarse boundaries (#2926, follow-up to #2914/#2868).**
+  `applyConfigLocked(ctx, cfg)` checks `ctx.Err()` at three phase boundaries and
+  returns the ctx error at the next one rather than completing the netlink + FRR
+  reload + Rust control-socket sync: **C1** before the netlink reconcile phase
+  (step 0), **C2** before the dataplane apply / Rust sync push (step 2), and
+  **C3** before the FRR reload (step 3). The checks sit only at boundaries where
+  bailing leaves a consistent, restart-recoverable state — each major
+  side-effecting phase (and the RETH MAC / VIP / worker-rebind sequence between
+  C2 and C3) runs to completion once started, so the apply is never interrupted
+  mid-phase; on the next boot the boot-time apply re-runs the whole pipeline
+  against the active config, so a skipped tail converges. The cancellation
+  signal is the **daemon-lifetime** context (`applyCancelCtx` → `d.daemonCtx`),
+  *not* the request/commit context: a daemon stop aborts an in-flight
+  commit/remediation apply (the eventengine remediation path that #2914 made
+  cancellable only at the pre-semaphore wait), but a mere request cancellation
+  (HTTP/gRPC client disconnect) is deliberately ignored after `store.Commit` —
+  aborting a promoted commit on a still-running daemon would leave the store
+  ahead of the dataplane/FRR with no automatic re-apply to converge. The boot /
+  DHCP / feed applies (`applyConfig`) and the confirmed-rollback re-apply
+  (`executeConfirmedRollback`) pass a non-cancellable `context.Background()` so
+  they always complete.
 - FRR reload runs with a 15 s context timeout to keep `systemctl reload
   frr` from hanging. The systemd unit has `TimeoutStopSec=20` as a safety
   net.

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -230,16 +230,38 @@ never lock an operator out of a remote box it manages.
   C2 and C3) runs to completion once started, so the apply is never interrupted
   mid-phase; on the next boot the boot-time apply re-runs the whole pipeline
   against the active config, so a skipped tail converges. The cancellation
-  signal is the **daemon-lifetime** context (`applyCancelCtx` → `d.daemonCtx`),
-  *not* the request/commit context: a daemon stop aborts an in-flight
-  commit/remediation apply (the eventengine remediation path that #2914 made
-  cancellable only at the pre-semaphore wait), but a mere request cancellation
-  (HTTP/gRPC client disconnect) is deliberately ignored after `store.Commit` —
-  aborting a promoted commit on a still-running daemon would leave the store
-  ahead of the dataplane/FRR with no automatic re-apply to converge. The boot /
-  DHCP / feed applies (`applyConfig`) and the confirmed-rollback re-apply
-  (`executeConfirmedRollback`) pass a non-cancellable `context.Background()` so
-  they always complete.
+  signal is a **dedicated daemon-stop** context (`applyCancelCtx` →
+  `d.applyCancelContext`), *not* the request/commit context: a daemon stop
+  aborts an in-flight commit/remediation apply (the eventengine remediation path
+  that #2914 made cancellable only at the pre-semaphore wait), but a mere request
+  cancellation (HTTP/gRPC client disconnect) is deliberately ignored after
+  `store.Commit` — aborting a promoted commit on a still-running daemon would
+  leave the store ahead of the dataplane/FRR with no automatic re-apply to
+  converge. The boot / DHCP / feed applies (`applyConfig`) and the
+  confirmed-rollback re-apply (`executeConfirmedRollback`) pass a non-cancellable
+  `context.Background()` so they always complete.
+  - **Wiring (the part that makes this actually fire on `systemctl stop`).**
+    `applyCancelCtx` deliberately does **not** return `d.daemonCtx`. In
+    production `cmd/xpfd` passes `context.Background()` into `Run`, and that
+    `context.Background()` is what `d.daemonCtx` holds — it is never cancelled
+    (the signal-cancellable context is a *local* `ctx` created later by
+    `signal.NotifyContext`). Returning `d.daemonCtx` would make C1/C2/C3 dead
+    code on a real stop. Instead `Run` creates `d.applyCancelContext` as a
+    **child of the SIGTERM/SIGINT signal context** (right after
+    `signal.NotifyContext`), so a real `systemctl stop xpfd` cancels it, and the
+    next coarse boundary observes `ctx.Err() != nil` and bails. `d.daemonCtx`
+    stays the (uncancelled) parent of the long-lived background goroutines —
+    flow-export/IPFIX relays, RPM probe-pin retry, the policy scheduler, cluster
+    comms, and the `dp.Start` dataplane runtime. Those are torn down
+    **explicitly** in the shutdown sequence, and the orderly teardown
+    (`logFinalStats` through `dp.Telemetry`, the HA `rg_active` clear through
+    `dp.HA()`, `dp.Teardown`) still needs the dataplane runtime live while it
+    runs — which is why the apply-abort signal is isolated from `d.daemonCtx`
+    rather than cancelling it. `Run` cancels `d.applyCancelContext` at the very
+    start of the shutdown sequence (before the explicit subsystem teardown), and
+    the teardown itself performs no `applyConfigLocked`, so the cancel aborts
+    only a genuinely in-flight commit/remediation apply, never the shutdown's own
+    cleanup.
 - FRR reload runs with a 15 s context timeout to keep `systemctl reload
   frr` from hanging. The systemd unit has `TimeoutStopSec=20` as a safety
   net.

--- a/pkg/daemon/apply_ctx_cancel_test.go
+++ b/pkg/daemon/apply_ctx_cancel_test.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/vrrp"
+)
+
+// minimalApplyCtxDaemon builds a Daemon wired with just enough to drive the
+// REAL applyConfigLocked body (no applyBodyForTest seam): a recording runtime
+// dataplane, a VRRP manager, and a store. d.routing/d.frr/d.networkd are nil,
+// so the netlink reconcile phases (steps 0/1) are skipped and the first
+// side-effecting step the body reaches is the dataplane apply (step 2). That
+// makes the dataplane's applyCalls counter a precise probe for "did the apply
+// proceed past the #2926 cancellation boundaries".
+func minimalApplyCtxDaemon(t *testing.T) (*Daemon, *runtimeOnlyApplyTestDP, *config.Config) {
+	t.Helper()
+	installFakeNetworkctl(t)
+	dp := &runtimeOnlyApplyTestDP{}
+	d := &Daemon{
+		dp:      dp,
+		vrrpMgr: vrrp.NewManager(),
+		store:   newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		opts:    Options{NoDataplane: true},
+	}
+	return d, dp, &config.Config{}
+}
+
+// TestApplyConfigLockedAbortsOnCanceledCtx is the #2926 fail-on-revert guard:
+// applyConfigLocked must honor a canceled context at a coarse boundary and
+// return ctx.Err() WITHOUT performing the heavy work — here, the dataplane
+// apply / Rust control-socket sync push (step 2). The runtimeOnlyApplyTestDP
+// records every ApplyConfig call, so applyCalls==0 proves the sync push never
+// ran.
+//
+// Mutation check (fail-on-revert): delete the `if err := ctx.Err(); err != nil`
+// boundary checks from applyConfigLocked and this test goes RED — the canceled
+// apply proceeds into step 2 (dp.applyCalls becomes 1) and returns nil instead
+// of context.Canceled.
+func TestApplyConfigLockedAbortsOnCanceledCtx(t *testing.T) {
+	d, dp, cfg := minimalApplyCtxDaemon(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // canceled before the apply even begins
+
+	err := d.applyConfigLocked(ctx, cfg)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("applyConfigLocked(canceled ctx) = %v, want context.Canceled", err)
+	}
+	if dp.applyCalls != 0 {
+		t.Fatalf("applyConfigLocked ran the dataplane sync push despite a "+
+			"canceled context (applyCalls=%d, want 0): the #2926 boundary "+
+			"check did not abort the apply", dp.applyCalls)
+	}
+}
+
+// TestApplyConfigLockedRunsFullApplyOnLiveCtx is the regression half: a live
+// (non-canceled) context must run the apply exactly as before #2926 — the
+// dataplane sync push happens (applyCalls==1) and the body returns nil. This
+// guards against an over-eager boundary check that would abort a healthy apply.
+func TestApplyConfigLockedRunsFullApplyOnLiveCtx(t *testing.T) {
+	d, dp, cfg := minimalApplyCtxDaemon(t)
+
+	if err := d.applyConfigLocked(context.Background(), cfg); err != nil {
+		t.Fatalf("applyConfigLocked(live ctx) = %v, want nil", err)
+	}
+	if dp.applyCalls != 1 {
+		t.Fatalf("applyConfigLocked did not run the full apply on a live "+
+			"context (applyCalls=%d, want 1)", dp.applyCalls)
+	}
+}

--- a/pkg/daemon/apply_ctx_cancel_test.go
+++ b/pkg/daemon/apply_ctx_cancel_test.go
@@ -58,6 +58,77 @@ func TestApplyConfigLockedAbortsOnCanceledCtx(t *testing.T) {
 	}
 }
 
+// TestApplyCancelCtxAbortsApplyOnDaemonStop exercises the REAL production
+// wiring (#2926 fold): it does NOT inject a pre-canceled context directly into
+// applyConfigLocked. Instead it reproduces exactly how Run wires the cancel
+// signal — d.daemonCtx is the never-canceled context.Background() that cmd/xpfd
+// passes into Run, and the apply-abort context (d.applyCancelContext) is a
+// SEPARATE child of the SIGTERM/SIGINT signal context. The apply is then driven
+// through d.applyCancelCtx() (the production seam), and "daemon stop" is
+// simulated by canceling the signal parent, which must propagate to the
+// dedicated apply-abort child and make applyConfigLocked bail at boundary C1
+// (dp.applyCalls stays 0).
+//
+// Fail-on-revert: this is the test the ORIGINAL inert wiring fails. If
+// applyCancelCtx() reverts to returning d.daemonCtx (the pre-fold code), it
+// returns the never-canceled context.Background() set below, the apply runs to
+// completion (dp.applyCalls==1) and returns nil instead of context.Canceled —
+// the test goes RED. The earlier TestApplyConfigLockedAbortsOnCanceledCtx
+// (direct-injection) would still PASS under the inert wiring, which is why it
+// gave false confidence; this test closes that gap.
+func TestApplyCancelCtxAbortsApplyOnDaemonStop(t *testing.T) {
+	d, dp, cfg := minimalApplyCtxDaemon(t)
+
+	// Production wiring: daemonCtx is the never-canceled background context
+	// cmd/xpfd passes into Run. The apply-abort context is the separate
+	// signal-child Run creates after signal.NotifyContext.
+	d.daemonCtx = context.Background()
+	signalCtx, daemonStop := context.WithCancel(context.Background())
+	defer daemonStop()
+	d.applyCancelContext, d.applyCancel = context.WithCancel(signalCtx)
+	defer d.applyCancel()
+
+	// Simulate `systemctl stop xpfd`: the signal context is canceled, which
+	// must propagate through to the dedicated apply-abort child returned by
+	// applyCancelCtx().
+	daemonStop()
+
+	err := d.applyConfigLocked(d.applyCancelCtx(), cfg)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("applyConfigLocked(applyCancelCtx after daemon stop) = %v, "+
+			"want context.Canceled — the daemon-stop signal did not reach the "+
+			"#2926 boundary checks (inert wiring)", err)
+	}
+	if dp.applyCalls != 0 {
+		t.Fatalf("applyConfigLocked ran the dataplane sync push despite a "+
+			"daemon stop (applyCalls=%d, want 0): applyCancelCtx() is not wired "+
+			"to the signal-cancellable context", dp.applyCalls)
+	}
+}
+
+// TestApplyCancelCtxRunsFullApplyWhileDaemonLive is the live-daemon companion
+// to TestApplyCancelCtxAbortsApplyOnDaemonStop: with the apply-abort context
+// wired but NOT canceled (daemon running normally), a commit-path apply driven
+// through applyCancelCtx() must run in full (dp.applyCalls==1). This guards
+// against an over-eager wiring that would abort healthy day-2 commits.
+func TestApplyCancelCtxRunsFullApplyWhileDaemonLive(t *testing.T) {
+	d, dp, cfg := minimalApplyCtxDaemon(t)
+
+	d.daemonCtx = context.Background()
+	signalCtx, daemonStop := context.WithCancel(context.Background())
+	defer daemonStop()
+	d.applyCancelContext, d.applyCancel = context.WithCancel(signalCtx)
+	defer d.applyCancel()
+
+	if err := d.applyConfigLocked(d.applyCancelCtx(), cfg); err != nil {
+		t.Fatalf("applyConfigLocked(applyCancelCtx, daemon live) = %v, want nil", err)
+	}
+	if dp.applyCalls != 1 {
+		t.Fatalf("applyConfigLocked did not run the full apply on a live "+
+			"daemon (applyCalls=%d, want 1)", dp.applyCalls)
+	}
+}
+
 // TestApplyConfigLockedRunsFullApplyOnLiveCtx is the regression half: a live
 // (non-canceled) context must run the apply exactly as before #2926 — the
 // dataplane sync push happens (applyCalls==1) and the body returns nil. This

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -344,8 +344,34 @@ type Daemon struct {
 	grpcSrv *grpcapi.Server
 
 	// daemonCtx is the parent context from Run(), used to derive
-	// independently-cancellable sub-contexts for cluster comms.
+	// independently-cancellable sub-contexts for the daemon-lifetime
+	// background goroutines (cluster comms, flow-export/IPFIX relays, RPM
+	// probe-pin retry, the policy scheduler, and the dataplane runtime
+	// dp.Start). In production cmd/xpfd passes context.Background() into Run,
+	// so daemonCtx is NEVER cancelled — those goroutines are torn down
+	// EXPLICITLY in the shutdown sequence (stopFlowExporter, rpm.StopAll,
+	// cluster.Stop, dp.Teardown, ...), and the orderly teardown (logFinalStats
+	// through dp.Telemetry, the HA rg_active clear through dp.HA()) still needs
+	// the dataplane runtime live while it runs. daemonCtx is therefore NOT the
+	// apply-abort signal; see applyCancelContext / applyCancelCtx (#2926).
 	daemonCtx context.Context
+
+	// applyCancelContext is the daemon-lifetime context whose cancellation
+	// aborts an in-flight applyConfigLocked at its coarse boundaries
+	// (C1/C2/C3) on daemon stop (#2926). Run creates it as a child of the
+	// SIGTERM/SIGINT signal context, so a real `systemctl stop xpfd` cancels
+	// it. It is kept SEPARATE from daemonCtx so the apply-abort signal does
+	// not disturb the lifetimes of the other daemonCtx-derived background
+	// goroutines (which the shutdown sequence tears down explicitly and which
+	// the orderly teardown still needs live). applyCancelCtx() returns it; a
+	// nil value (early boot / unit tests with no wiring) falls back to a
+	// non-cancellable context so an apply never aborts spuriously.
+	applyCancelContext context.Context
+
+	// applyCancel cancels applyCancelContext. Run defers it and also calls it
+	// explicitly at the start of the shutdown sequence so an in-flight apply
+	// bails before the explicit subsystem teardown runs.
+	applyCancel context.CancelFunc
 
 	// clusterCommsCancel cancels the sub-context used by startClusterComms
 	// goroutines. Set when cluster comms are started, called to restart them

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -102,8 +102,8 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 
 // applyCancelCtx returns the context whose cancellation aborts the heavy apply
 // pipeline (applyConfigLocked) at its coarse step boundaries (#2926). It is the
-// DAEMON-LIFETIME context (d.daemonCtx), deliberately NOT the request/commit
-// context:
+// dedicated DAEMON-STOP context (d.applyCancelContext), deliberately NOT the
+// request/commit context AND deliberately NOT d.daemonCtx:
 //
 //   - A daemon stop MUST abort an in-flight commit/remediation apply at the
 //     next boundary so termination is not blocked behind netlink + an FRR
@@ -119,11 +119,21 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 //     request context still governs the contended applySem wait in the commit
 //     wrappers (a slow lock holder surfaces 503), exactly as before.
 //
-// When d.daemonCtx is unset (early boot, unit tests) it falls back to a
-// non-cancellable context, so the apply never aborts spuriously.
+// Why a dedicated context and not d.daemonCtx: in production cmd/xpfd passes
+// context.Background() into Run, so d.daemonCtx is never cancelled — returning
+// it here would make the C1/C2/C3 boundary checks dead code on a real
+// `systemctl stop` (the original #2926 wiring bug). Run creates
+// d.applyCancelContext as a child of the SIGTERM/SIGINT signal context, so a
+// real daemon stop cancels it; keeping it separate from d.daemonCtx leaves the
+// other daemonCtx-derived background goroutines (flow-export, RPM, scheduler,
+// cluster comms, the dp.Start dataplane runtime) on their explicit-teardown
+// lifetimes, which the orderly shutdown sequence still needs live.
+//
+// When d.applyCancelContext is unset (early boot, unit tests with no wiring) it
+// falls back to a non-cancellable context, so the apply never aborts spuriously.
 func (d *Daemon) applyCancelCtx() context.Context {
-	if d.daemonCtx != nil {
-		return d.daemonCtx
+	if d.applyCancelContext != nil {
+		return d.applyCancelContext
 	}
 	return context.Background()
 }

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -91,9 +91,41 @@ func (d *Daemon) bootstrapFromFile() error {
 func (d *Daemon) applyConfig(cfg *config.Config) {
 	_ = d.applySem.Acquire(context.Background(), 1)
 	defer d.applySem.Release(1)
-	if err := d.applyConfigLocked(cfg); err != nil {
+	// Boot / DHCP-callback / feed / config-poll applies must always run to
+	// completion (they are not request-bound and there is no operator waiting
+	// to cancel them), so the heavy pipeline is driven with a non-cancellable
+	// context — byte-identical to the pre-#2926 behavior.
+	if err := d.applyConfigLocked(context.Background(), cfg); err != nil {
 		slog.Warn("apply config failed", "err", err)
 	}
+}
+
+// applyCancelCtx returns the context whose cancellation aborts the heavy apply
+// pipeline (applyConfigLocked) at its coarse step boundaries (#2926). It is the
+// DAEMON-LIFETIME context (d.daemonCtx), deliberately NOT the request/commit
+// context:
+//
+//   - A daemon stop MUST abort an in-flight commit/remediation apply at the
+//     next boundary so termination is not blocked behind netlink + an FRR
+//     reload + a Rust control-socket sync (the #2914/#2868 follow-up). On the
+//     next boot the daemon re-applies the active config in full, so skipping
+//     the tail of an apply during shutdown always converges.
+//   - A mere request cancellation (an HTTP/gRPC client disconnect, or a CLI
+//     commit whose context is canceled) MUST NOT abort the apply. By the time
+//     applyConfigLocked runs, store.Commit() has already promoted+persisted the
+//     new config; aborting the apply on a still-running daemon would leave the
+//     store ahead of the dataplane/FRR with no automatic re-apply to converge —
+//     a silent forwarding/policy divergence strictly worse than today. The
+//     request context still governs the contended applySem wait in the commit
+//     wrappers (a slow lock holder surfaces 503), exactly as before.
+//
+// When d.daemonCtx is unset (early boot, unit tests) it falls back to a
+// non-cancellable context, so the apply never aborts spuriously.
+func (d *Daemon) applyCancelCtx() context.Context {
+	if d.daemonCtx != nil {
+		return d.daemonCtx
+	}
+	return context.Background()
 }
 
 // commitAndApply atomically promotes the candidate config and
@@ -103,11 +135,16 @@ func (d *Daemon) applyConfig(cfg *config.Config) {
 // state). Optionally syncs to the cluster peer inside the lock.
 //
 // If ctx is canceled before the semaphore is acquired, returns
-// ctx.Err() and NEITHER commit nor apply runs — no divergence. Once
-// the semaphore is held, commit and apply run to completion;
-// cancellation past that point is ignored (applyConfigLocked is not
-// safe to interrupt mid-stream — kernel route writes, FRR reload,
-// etc.).
+// ctx.Err() and NEITHER commit nor apply runs — no divergence.
+//
+// Once the semaphore is held, store.Commit() promotes the config and the
+// apply runs. The apply itself (applyConfigLocked) is cancellable at coarse
+// boundaries via the DAEMON-LIFETIME context (applyCancelCtx), NOT this
+// request ctx (#2926): a daemon stop aborts an in-flight apply so termination
+// is not blocked behind netlink + FRR reload + Rust sync, while a request
+// cancellation after store.Commit is deliberately ignored (aborting a
+// promoted commit on a still-running daemon would diverge the store from the
+// dataplane). See applyCancelCtx for the full rationale.
 func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bool) (*config.Config, error) {
 	// #1922 Item 2 first-takeover gate (OQ-B, blunt resolution). In
 	// bootstrap mode a plain `commit` is refused: the first commit on a
@@ -160,7 +197,7 @@ func (d *Daemon) commitAndApply(ctx context.Context, comment string, syncPeer bo
 	if err != nil {
 		return nil, err
 	}
-	if err := d.applyConfigLocked(compiled); err != nil {
+	if err := d.applyConfigLocked(d.applyCancelCtx(), compiled); err != nil {
 		return nil, err
 	}
 	if syncPeer {
@@ -185,7 +222,7 @@ func (d *Daemon) syncAndApply(ctx context.Context, configText string, chassisPre
 		return nil, err
 	}
 	if compiled != nil {
-		if err := d.applyConfigLocked(compiled); err != nil {
+		if err := d.applyConfigLocked(d.applyCancelCtx(), compiled); err != nil {
 			return nil, err
 		}
 		// #1956 V-1 passive-node device-map admission gate (OQ-15.1 option
@@ -257,7 +294,7 @@ func (d *Daemon) commitConfirmedAndApply(ctx context.Context, minutes int, syncP
 	if err != nil {
 		return nil, err
 	}
-	if err := d.applyConfigLocked(compiled); err != nil {
+	if err := d.applyConfigLocked(d.applyCancelCtx(), compiled); err != nil {
 		return nil, err
 	}
 	if syncPeer {
@@ -316,7 +353,12 @@ func (d *Daemon) executeConfirmedRollback(gen uint64) {
 	// this fires the target is KNOWN-safe. Aborting here would diverge the
 	// already-promoted store from the running dataplane (split-brain), which
 	// is strictly worse than applying a validated target.
-	if err := d.applyConfigLocked(prevCfg); err != nil {
+	//
+	// The rollback re-apply is driven with a non-cancellable context (#2926):
+	// the store has already been promoted to the rollback target, so the
+	// dataplane MUST be brought into agreement unconditionally — aborting here
+	// would re-open the split-brain this transaction exists to close.
+	if err := d.applyConfigLocked(context.Background(), prevCfg); err != nil {
 		slog.Error("commit confirmed auto-rollback dataplane apply failed", "err", err)
 	}
 	slog.Warn("commit confirmed timed out, configuration rolled back")
@@ -324,7 +366,19 @@ func (d *Daemon) executeConfirmedRollback(gen uint64) {
 
 // applyConfigLocked runs the actual reconcile pipeline. MUST be
 // called with d.applySem held.
-func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
+//
+// ctx is honored at the coarse phase boundaries marked below (#2926): when it
+// is canceled the apply returns ctx.Err() at the NEXT boundary rather than
+// completing the netlink + FRR reload + Rust control-socket sync. This lets a
+// daemon stop abort an in-flight commit/remediation apply once it is past the
+// applySem (the pre-semaphore wait was already cancelled by #2914). The
+// boundaries are chosen so a bail leaves a consistent, restart-recoverable
+// state — each major side-effecting phase is allowed to finish once started
+// (no abort mid-phase), and the next boot re-applies the active config in full.
+// Commit callers pass the daemon-lifetime context (applyCancelCtx); the boot /
+// DHCP / feed and confirmed-rollback callers pass a non-cancellable context so
+// their applies always complete (see applyConfig / executeConfirmedRollback).
+func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) error {
 	if d.applyBodyForTest != nil {
 		d.applyBodyForTest(cfg)
 		return nil
@@ -388,6 +442,15 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 	// Log config validation warnings
 	for _, w := range cfg.Warnings {
 		slog.Warn("config validation", "warning", w)
+	}
+
+	// #2926 boundary C1: before the netlink reconcile phase. Nothing in the
+	// kernel / dataplane / FRR has been touched yet (the SNMP swap above is an
+	// idempotent in-memory pointer flip), so a cancellation here skips the
+	// entire pipeline cleanly. This is the cheapest, safest place to honor a
+	// daemon stop.
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// 0. Reconcile VRF devices (routing-instance VRFs + management VRF).
@@ -688,6 +751,17 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		setter.SetFeedSnapshots(d.feedSnapshotsForConfig(cfg))
 	}
 
+	// #2926 boundary C2: before the dataplane apply (the Rust control-socket
+	// sync push). The fabric-IPVLAN / VRF / tunnel / bond netlink reconciles
+	// above are idempotent and have each run to completion, so bailing here
+	// leaves a consistent kernel state with the dataplane untouched. Once
+	// d.dp.ApplyConfig and the RETH MAC / VIP / worker-rebind sequence that
+	// follows it begin, they run as one unit (no mid-sequence abort) — the
+	// next boundary is before the FRR reload.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// 2. Apply dataplane config through the runtime config sink.
 	var applyResult *dataplane.ApplyResult
 	if d.dp != nil {
@@ -958,6 +1032,18 @@ func (d *Daemon) applyConfigLocked(cfg *config.Config) error {
 		if d.cluster != nil {
 			d.cluster.RestartHeartbeat()
 		}
+	}
+
+	// #2926 boundary C3: before the FRR reload. The dataplane apply and the
+	// RETH MAC / VIP / worker-rebind sequence above have completed; FRR still
+	// holds the previous render. Bailing here skips the FRR reload and the
+	// remaining service reconciles (IPsec, DHCP, RA, VRRP, syslog, exporters);
+	// on the next boot the boot-time apply re-renders FRR and re-runs every
+	// service step against the active config, so the skip converges. (After
+	// store.Commit the store already holds the new config, so this is a clean
+	// "apply the rest on next start" boundary, not a divergence.)
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// 3. Apply all routes + dynamic protocols via FRR.

--- a/pkg/daemon/daemon_apply_runtime_test.go
+++ b/pkg/daemon/daemon_apply_runtime_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,7 +57,7 @@ func TestApplyConfigRuntimeResultDrivesDownstreamConsumers(t *testing.T) {
 		},
 	}
 
-	if err := d.applyConfigLocked(cfg); err != nil {
+	if err := d.applyConfigLocked(context.Background(), cfg); err != nil {
 		t.Fatalf("applyConfigLocked: %v", err)
 	}
 	if dp.applyCalls != 1 {

--- a/pkg/daemon/daemon_flowexport_reconcile_test.go
+++ b/pkg/daemon/daemon_flowexport_reconcile_test.go
@@ -292,7 +292,7 @@ func TestApplyConfigLockedReconcilesFlowExporters(t *testing.T) {
 	}
 	t.Cleanup(d.stopFlowExporter)
 
-	if err := d.applyConfigLocked(flowSamplingConfig("127.0.0.1", 100)); err != nil {
+	if err := d.applyConfigLocked(context.Background(), flowSamplingConfig("127.0.0.1", 100)); err != nil {
 		t.Fatalf("applyConfigLocked: %v", err)
 	}
 

--- a/pkg/daemon/daemon_networkd_apply_test.go
+++ b/pkg/daemon/daemon_networkd_apply_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +49,7 @@ func TestApplyConfigLocked_EmptyManagedSetSweepsStale(t *testing.T) {
 		ManagedInterfaces: nil,
 	})
 
-	if err := d.applyConfigLocked(cfg); err != nil {
+	if err := d.applyConfigLocked(context.Background(), cfg); err != nil {
 		t.Fatalf("applyConfigLocked: %v", err)
 	}
 
@@ -84,7 +85,7 @@ func TestApplyConfigLocked_EmptyManagedSetPreservesLifeline(t *testing.T) {
 	// the mgmt leaf so the lifeline files are exempt from the sweep.
 	d.networkd.SetProtectedResolver(func() map[string]bool { return map[string]bool{"fxp0": true} })
 
-	if err := d.applyConfigLocked(cfg); err != nil {
+	if err := d.applyConfigLocked(context.Background(), cfg); err != nil {
 		t.Fatalf("applyConfigLocked: %v", err)
 	}
 
@@ -120,7 +121,7 @@ func TestApplyConfigLocked_NetworkdWriteErrorFailsCommit(t *testing.T) {
 		}},
 	})
 
-	err := d.applyConfigLocked(cfg)
+	err := d.applyConfigLocked(context.Background(), cfg)
 	if err == nil {
 		t.Fatal("applyConfigLocked must fail when networkd.Apply cannot write a generated file (got nil — error swallowed)")
 	}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -705,6 +705,24 @@ func (d *Daemon) Run(ctx context.Context) error {
 	}
 	defer stop()
 
+	// #2926: dedicated apply-abort context. A child of the signal context
+	// above, so a real daemon stop (SIGTERM, plus SIGINT in daemon mode)
+	// cancels an in-flight commit/remediation apply at its next coarse
+	// boundary (applyConfigLocked C1/C2/C3) instead of blocking termination
+	// behind netlink + an FRR reload + a Rust control-socket sync. It is kept
+	// SEPARATE from d.daemonCtx: d.daemonCtx stays the (production-uncancelled,
+	// context.Background) parent of the long-lived background goroutines —
+	// flow-export/IPFIX relays, RPM probe-pin retry, the policy scheduler,
+	// cluster comms, and the dp.Start dataplane runtime — which the shutdown
+	// sequence below tears down EXPLICITLY and which the orderly teardown
+	// (logFinalStats through dp.Telemetry, the HA rg_active clear through
+	// dp.HA()) still needs live. applyCancelCtx() returns this context; only
+	// the commit/sync/confirmed-commit applies route through it. The boot /
+	// DHCP / feed applies and executeConfirmedRollback still pass
+	// context.Background() unconditionally so they always run to completion.
+	d.applyCancelContext, d.applyCancel = context.WithCancel(ctx)
+	defer d.applyCancel()
+
 	// Create event buffer (shared between event reader and CLI)
 	eventBuf := logging.NewEventBuffer(1000)
 	d.eventBuf = eventBuf
@@ -1590,6 +1608,19 @@ func (d *Daemon) Run(ctx context.Context) error {
 		slog.Info("daemon mode (non-interactive), waiting for signals")
 		<-ctx.Done()
 		slog.Info("signal received, shutting down")
+	}
+
+	// #2926: explicitly abort any in-flight commit/remediation apply NOW, at the
+	// very start of the shutdown sequence and BEFORE the explicit subsystem
+	// teardown below (FRR Stop, HA rg_active clear, dp.Teardown). applyCancelCtx
+	// callers (commit/sync/confirmed-commit) then bail at their next coarse
+	// boundary instead of completing netlink + an FRR reload + a Rust sync while
+	// we tear down. applyCancelContext is a child of the signal context, so a
+	// signal-driven stop has already cancelled it; this call also covers the
+	// interactive CLI-exit path and is idempotent. The teardown itself performs
+	// no applyConfigLocked, so nothing legitimate is aborted here.
+	if d.applyCancel != nil {
+		d.applyCancel()
 	}
 
 	// Cancel context to stop background goroutines, then wait for them.

--- a/pkg/daemon/daemon_snmp_reconcile_test.go
+++ b/pkg/daemon/daemon_snmp_reconcile_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -58,7 +59,7 @@ func TestApplyConfigLockedReconcilesSNMPAuthorization(t *testing.T) {
 		opts:      Options{NoDataplane: true},
 	}
 
-	if err := d.applyConfigLocked(snmpDowngradeConfig()); err != nil {
+	if err := d.applyConfigLocked(context.Background(), snmpDowngradeConfig()); err != nil {
 		t.Fatalf("applyConfigLocked: %v", err)
 	}
 
@@ -108,7 +109,7 @@ func TestApplyConfigLockedReconcilesSNMPBeforeDataplaneAbort(t *testing.T) {
 		opts:      Options{NoDataplane: true},
 	}
 
-	err := d.applyConfigLocked(snmpDowngradeConfig())
+	err := d.applyConfigLocked(context.Background(), snmpDowngradeConfig())
 	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want early abort on "+
 			"ErrPolicySchedulerProtocolIncompatible (the early-return path "+

--- a/pkg/daemon/persistent_snat_apply_test.go
+++ b/pkg/daemon/persistent_snat_apply_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -63,7 +64,7 @@ func TestApplyConfigLockedAbortsCommitOnPersistentSourceNATProtocolMismatch(t *t
 		opts:    Options{NoDataplane: true},
 	}
 
-	err := d.applyConfigLocked(persistentSourceNATConfig())
+	err := d.applyConfigLocked(context.Background(), persistentSourceNATConfig())
 	if !errors.Is(err, dpuserspace.ErrPersistentSourceNATProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want ErrPersistentSourceNATProtocolIncompatible "+
 			"(commit must abort on a required protocol-gate mismatch)", err)

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -201,7 +201,7 @@ func TestApplyConfigClearsDeferWorkersOnAbortCompileError(t *testing.T) {
 		},
 	}
 
-	if err := d.applyConfigLocked(cfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+	if err := d.applyConfigLocked(context.Background(), cfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want protocol incompatibility", err)
 	}
 	if dp.compileCalls != 1 {
@@ -235,7 +235,7 @@ func TestApplyConfigProtocolAbortPreservesExistingScheduler(t *testing.T) {
 		},
 	}
 
-	if err := d.applyConfigLocked(newCfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+	if err := d.applyConfigLocked(context.Background(), newCfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want protocol incompatibility", err)
 	}
 	if d.scheduler != oldScheduler {
@@ -280,7 +280,7 @@ func TestApplyConfigUsesRuntimeConfigSinkWithoutLegacyDataplane(t *testing.T) {
 		opts: Options{NoDataplane: true},
 	}
 
-	err := d.applyConfigLocked(&config.Config{})
+	err := d.applyConfigLocked(context.Background(), &config.Config{})
 	if !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want runtime apply error", err)
 	}
@@ -312,7 +312,7 @@ func TestApplyConfigSeedsUserspacePolicySchedulerStateBeforeCompile(t *testing.T
 	d := &Daemon{dp: dp}
 	cfg := testPolicySchedulerApplyConfig()
 
-	if err := d.applyConfigLocked(cfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
+	if err := d.applyConfigLocked(context.Background(), cfg); !errors.Is(err, dpuserspace.ErrPolicySchedulerProtocolIncompatible) {
 		t.Fatalf("applyConfigLocked error = %v, want protocol incompatibility", err)
 	}
 


### PR DESCRIPTION
Closes #2926.

## Problem
#2914 (#2868) made the eventengine remediation commit cancellable by threading the engine-lifetime context through `applyOnce` -> `commitFn` -> `commitAndApply`, but cancellation was honored at exactly one point: `d.applySem.Acquire(ctx, 1)` (the contended pre-semaphore wait). Once the semaphore was acquired, `store.Commit()` and `applyConfigLocked` (which took **no** ctx) ran the full netlink + FRR reload + Rust control-socket sync to completion. A commit already past the semaphore into FRR-reload would not abort on a daemon stop — termination could block behind seconds of apply work past the systemd `TimeoutStopSec` SIGKILL.

## Fix
`applyConfigLocked(ctx, cfg)` now checks `ctx.Err()` at three coarse phase boundaries and returns the ctx error at the next boundary rather than completing the remaining work:

- **C1** before the netlink reconcile phase (step 0) — nothing kernel/dataplane/FRR touched yet (the SNMP swap above is an idempotent in-memory pointer flip).
- **C2** before the dataplane apply / Rust control-socket sync push (step 2) — the idempotent fabric-IPVLAN / VRF / tunnel / bond netlink reconciles have each completed.
- **C3** before the FRR reload (step 3) — the dataplane apply and the RETH MAC / VIP / worker-rebind sequence have completed.

### Chosen-boundary safety (partial-apply)
The checks sit **only** where a bail leaves a consistent, restart-recoverable state. Each major side-effecting phase runs to completion once started (no mid-phase abort), and the RETH MAC / VIP / worker-rebind sequence between C2 and C3 is treated as one atomic unit. `store.Commit()` has already promoted+persisted the new config before `applyConfigLocked` runs, so a skipped tail is simply "apply the rest on next boot": the boot-time apply re-runs the whole pipeline against the active config and converges. No new half-applied state is reachable that was not already reachable on a crash between the same phases.

### Why the daemon-lifetime ctx, not the request ctx
The cancellation signal is the **daemon-lifetime** context (new `applyCancelCtx` -> `d.daemonCtx`), deliberately **not** the request/commit context. A daemon stop must abort an in-flight commit/remediation apply, but a mere request cancellation (HTTP/gRPC client disconnect, or a CLI commit whose context is canceled) must **not** abort after `store.Commit`: aborting a promoted commit on a still-running daemon would leave the store ahead of the dataplane/FRR with no automatic re-apply to converge — a silent forwarding/policy divergence strictly worse than today. The request context still governs the contended `applySem` wait (503 on a slow lock holder), exactly as before.

### Call sites updated
- `commitAndApply`, `syncAndApply`, `commitConfirmedAndApply` -> pass `d.applyCancelCtx()` (daemon-lifetime).
- `applyConfig` (boot / DHCP / feed / config-poll) -> `context.Background()` (always completes — byte-identical to pre-#2926).
- `executeConfirmedRollback` -> `context.Background()` (the rollback re-apply must be unconditional; aborting would re-open the split-brain it closes).
- All in-package test call sites updated to pass a context.

## Tests
- New `pkg/daemon/apply_ctx_cancel_test.go` drives the **real** `applyConfigLocked` body (no `applyBodyForTest` seam) with a recording runtime dataplane:
  - `TestApplyConfigLockedAbortsOnCanceledCtx`: a canceled ctx returns `context.Canceled` and the dataplane sync push never runs (`applyCalls==0`).
  - `TestApplyConfigLockedRunsFullApplyOnLiveCtx`: a live ctx runs the full apply (`applyCalls==1`).
- **Fail-on-revert proven**: removing the `ctx.Err()` boundary checks turns `TestApplyConfigLockedAbortsOnCanceledCtx` RED (the apply proceeds into the dataplane sync push and returns nil); restored byte-identical.
- `go build ./...` green; `go test ./pkg/daemon/... ./pkg/eventengine/...` green (651 tests).

## Docs
- `pkg/daemon/README.md`: new bullet documenting the cancellable apply, the three boundaries, the partial-apply safety reasoning, and the daemon-lifetime-vs-request-ctx choice.
- `_Log.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi