### PR TITLE
show: render policy-detail Index from the runtime/RT_FLOW policy ID

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20144,3 +20144,29 @@ top.
   server README socket-lifecycle section.
   **File(s)**: userspace-dp/src/server/lifecycle.rs,
   userspace-dp/src/server/README.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #3063 — make `show security policies detail` Index match the
+  runtime/RT_FLOW policy ID. The detail Index was rendered from the raw
+  per-policy ordinal `policySetID*MaxRulesPerPolicy + i`, which does NOT
+  advance by application-set expansion, while the snapshot PolicyID (and the
+  RT_FLOW/event log IDs) DO — so the displayed Index drifted from the logged
+  policy ID after a multi-application policy and an operator landed on the
+  wrong row. Added exported `RuntimePolicyIDs(cfg)` in pkg/dataplane/userspace
+  (built from the SSOT `walkPolicyRuleSlots`, reusing
+  `userspacePolicyRuleExpansionCount`; added `SliceIndex` to `policyRuleSlot`)
+  returning the span-accumulated ID keyed by (policySetID, sliceIndex). The
+  CLI detail surfaces (cli_show_security.go + cli_show_security_dispatch.go,
+  zone-pair AND global) now render Index via a `runtimePolicyIndex` lookup
+  with raw-ordinal fallback. Counter lookups are UNCHANGED: the per-policy
+  store is name-keyed and the raw-ordinal handle round-trips through
+  `policyRuleIDForCounter`, so the gRPC/REST/Prometheus counter paths (which
+  never display an Index) keep passing the raw ordinal. Single-application
+  configs stay byte-identical. Added CLI + userspace fail-on-revert tests
+  (deny-ssh after a 2-term app-set shows Index 2, not 1; global at 256) and a
+  byte-identical single-app regression. Documented in junos-cli-reference.md.
+  **File(s)**: pkg/dataplane/userspace/policies.go,
+  pkg/cli/cli_show_security.go, pkg/cli/cli_show_security_dispatch.go,
+  pkg/cli/cli_show_security_policy_index_3063_test.go,
+  pkg/dataplane/userspace/policy_runtime_ids_3063_test.go,
+  docs/junos-cli-reference.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -215,6 +215,19 @@ From zone: guest, To zone: lan
 
 - **Zone header:** `From zone: <name>, To zone: <name>` (no indentation).
 - **Policy line:** 2-space indent, comma-separated: `Policy: <name>, State: enabled, Index: <N>, Scope Policy: 0, Sequence number: <N>, Log Profile ID: 0`
+  - **Index (#3063):** the `Index:` value is the runtime/RT_FLOW policy
+    ID — the same numeric ID printed by RT_FLOW policy-deny logs and the
+    session surfaces — so an operator can cross-reference a log line to
+    the exact detail row. It is span-accumulated: a policy whose match
+    references an application-set that expands to multiple application
+    terms advances the next policy's Index by the expansion count, not by
+    one. So the Index of a policy that follows a multi-application policy
+    is NOT its 1-based position. The global-policy block starts at a fresh
+    policy-set base (`len(zone-pair sets) * 256`). Configs with no
+    multi-application policy keep Index == the previous per-policy ordinal
+    (byte-identical to pre-#3063). The `Sequence number:` field remains
+    the 1-based per-set position. This Index is a display identity only;
+    per-policy hit counters are name-keyed internally and unaffected.
   - **Scheduler state (#3062):** the `State:` field reflects runtime
     scheduler state, not just configuration. A policy bound to a
     scheduler (`scheduler-name <name>`) that is currently inactive renders

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -7,8 +7,24 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	"github.com/psaab/xpf/pkg/policymatch"
 )
+
+// runtimePolicyIndex returns the span-accumulated runtime/RT_FLOW policy ID for
+// the policy at (policySetID, sliceIndex), used as the displayed detail `Index`
+// so it matches the numeric policy ID the RT_FLOW/event path logs (#3063). It
+// falls back to the raw ordinal policySetID*MaxRulesPerPolicy + sliceIndex when
+// the lookup has no entry (e.g. a config the dataplane would reject for
+// MaxRulesPerPolicy overflow), which is byte-identical to the pre-#3063 value.
+// This is a DISPLAY identity only — it is NOT the counter handle passed to
+// ReadPolicyCounters (that stays the raw ordinal; see policyRuleIDForCounter).
+func runtimePolicyIndex(ids map[[2]uint32]uint32, policySetID, sliceIndex uint32) uint32 {
+	if id, ok := ids[[2]uint32{policySetID, sliceIndex}]; ok {
+		return id
+	}
+	return policySetID*dataplane.MaxRulesPerPolicy + sliceIndex
+}
 
 func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) error {
 	if c.dp == nil || !c.dp.IsLoaded() {
@@ -91,6 +107,12 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 
 func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) error {
 	schedActive, haveSched := c.policySchedulerActiveState()
+	// #3063: the displayed Index must equal the runtime/RT_FLOW policy ID,
+	// which advances by application-set expansion. RuntimePolicyIDs mirrors the
+	// snapshot's PolicyID assignment so an operator cross-referencing a
+	// policy-deny log lands on the correct detail row even after a multi-app
+	// policy shifts the ID namespace.
+	runtimeIDs := dpuserspace.RuntimePolicyIDs(cfg)
 	policySetID := uint32(0)
 	seqNum := 1
 	for _, zpp := range cfg.Security.Policies {
@@ -110,7 +132,7 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 			case 2:
 				action = "reject"
 			}
-			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+			ruleID := runtimePolicyIndex(runtimeIDs, policySetID, uint32(i))
 			// #3062: reflect runtime scheduler state — a policy bound to a
 			// currently-inactive scheduler reports State: inactive (the
 			// dataplane is dropping its rule). Active/non-scheduled policies
@@ -164,8 +186,6 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 				}
 			}
 			seqNum++
-
-			_ = ruleID // available for future counter display
 		}
 		policySetID++
 		fmt.Println()
@@ -181,7 +201,7 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 			case 2:
 				action = "reject"
 			}
-			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+			ruleID := runtimePolicyIndex(runtimeIDs, policySetID, uint32(i))
 			// #3062: scheduler-inactive global policy reports State: inactive.
 			state := policyDetailState(pol.SchedulerName, schedActive, haveSched)
 			fmt.Printf("Policy: %s, action-type: %s, State: %s, Index: %d, Scope Policy: 0\n",

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -272,6 +272,9 @@ func (c *CLI) handleShowSecurity(args []string) error {
 		}
 
 		schedActive, haveSched := c.policySchedulerActiveState()
+		// #3063: render the detail Index from the span-accumulated runtime
+		// policy-ID namespace so it matches the RT_FLOW/event log policy ID.
+		runtimeIDs := dpuserspace.RuntimePolicyIDs(cfg)
 		policySetID := uint32(0)
 		if !globalOnly {
 			for _, zpp := range cfg.Security.Policies {
@@ -293,7 +296,7 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					case 2:
 						action = "reject"
 					}
-					ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+					ruleID := runtimePolicyIndex(runtimeIDs, policySetID, uint32(i))
 					// Junos: Policy: <name>, State: enabled, Index: <N>, Scope Policy: 0, Sequence number: <N>
 					// #3062: a scheduler-inactive policy reports State: inactive.
 					state := policyDetailState(pol.SchedulerName, schedActive, haveSched)
@@ -331,7 +334,7 @@ func (c *CLI) handleShowSecurity(args []string) error {
 				case 2:
 					action = "reject"
 				}
-				ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
+				ruleID := runtimePolicyIndex(runtimeIDs, policySetID, uint32(i))
 				// Junos global: Policy: <name>, State: enabled, Index: <N>, Scope Policy: 0, Sequence number: <N>
 				// #3062: a scheduler-inactive global policy reports State: inactive.
 				state := policyDetailState(pol.SchedulerName, schedActive, haveSched)

--- a/pkg/cli/cli_show_security_policy_index_3063_test.go
+++ b/pkg/cli/cli_show_security_policy_index_3063_test.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// multiAppPolicyIndexConfig mirrors the dataplane userspace fixture: policy set
+// 0 holds "allow-web" (an application-set expanding to junos-http + junos-https,
+// span 2) followed by "allow-ssh" (single application, span 1), plus a global
+// "global-allow" policy. The runtime/RT_FLOW policy ID is span-accumulated, so
+// allow-ssh occupies runtime slot 2 (NOT the raw ordinal 1) and the global set
+// starts at MaxRulesPerPolicy (256).
+func multiAppPolicyIndexConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Applications.ApplicationSets = map[string]*config.ApplicationSet{
+		"web-apps": {
+			Name:         "web-apps",
+			Applications: []string{"junos-http", "junos-https"},
+		},
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "lan",
+		ToZone:   "wan",
+		Policies: []*config.Policy{
+			{
+				Name:   "allow-web",
+				Match:  config.PolicyMatch{Applications: []string{"web-apps"}},
+				Action: config.PolicyPermit,
+			},
+			{
+				Name:   "deny-ssh",
+				Match:  config.PolicyMatch{Applications: []string{"junos-ssh"}},
+				Action: config.PolicyDeny,
+			},
+		},
+	}}
+	cfg.Security.GlobalPolicies = []*config.Policy{{
+		Name:   "global-allow",
+		Match:  config.PolicyMatch{Applications: []string{"junos-ssh"}},
+		Action: config.PolicyPermit,
+	}}
+	return cfg
+}
+
+// policyDetailIndex extracts the `Index: N` value printed for a named policy in
+// `show security policies detail` output.
+func policyDetailIndex(t *testing.T, out, policyName string) uint32 {
+	t.Helper()
+	re := regexp.MustCompile(`Policy: ` + regexp.QuoteMeta(policyName) + `,.*Index: (\d+)`)
+	m := re.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("policy %q Index line not found in output:\n%s", policyName, out)
+	}
+	v, err := strconv.ParseUint(m[1], 10, 32)
+	if err != nil {
+		t.Fatalf("parse Index %q: %v", m[1], err)
+	}
+	return uint32(v)
+}
+
+// Test_3063_PolicyDetailIndexMatchesRuntimePolicyID is the fail-on-revert guard.
+// The displayed detail Index must equal the span-accumulated runtime/RT_FLOW
+// policy ID so an operator cross-referencing a policy-deny log lands on the
+// correct row. deny-ssh follows a 2-term app-set policy, so its runtime Index is
+// 2 (NOT the raw ordinal 1), and the global policy's Index is MaxRulesPerPolicy.
+//
+// Reverting the fix (display Index back to policySetID*MaxRulesPerPolicy + i)
+// makes deny-ssh print Index 1 → this test goes RED.
+func Test_3063_PolicyDetailIndexMatchesRuntimePolicyID(t *testing.T) {
+	cfg := multiAppPolicyIndexConfig()
+	c := &CLI{}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesDetail(cfg, "", ""); err != nil {
+			t.Fatalf("showPoliciesDetail: %v", err)
+		}
+	})
+
+	if got := policyDetailIndex(t, out, "allow-web"); got != 0 {
+		t.Fatalf("allow-web Index = %d, want 0", got)
+	}
+	if got := policyDetailIndex(t, out, "deny-ssh"); got != 2 {
+		t.Fatalf("deny-ssh Index = %d, want 2 (span-accumulated runtime ID, NOT raw ordinal 1)", got)
+	}
+	if got := policyDetailIndex(t, out, "global-allow"); got != 256 {
+		t.Fatalf("global-allow Index = %d, want 256 (MaxRulesPerPolicy base of the global set)", got)
+	}
+}
+
+// Test_3063_PolicyDetailDispatchIndexMatchesRuntimePolicyID asserts the same on
+// the second detail surface (the dispatch `show security policies detail` body
+// reached via handleShow), which also repeated the raw-ordinal Index.
+func Test_3063_PolicyDetailDispatchIndexMatchesRuntimePolicyID(t *testing.T) {
+	store := newConfigStore(t, t.TempDir()+"/xpf.conf")
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, cmd := range []string{
+		"security zones security-zone lan",
+		"security zones security-zone wan",
+		"applications application-set web-apps application junos-http",
+		"applications application-set web-apps application junos-https",
+		"security policies from-zone lan to-zone wan policy allow-web match source-address any",
+		"security policies from-zone lan to-zone wan policy allow-web match destination-address any",
+		"security policies from-zone lan to-zone wan policy allow-web match application web-apps",
+		"security policies from-zone lan to-zone wan policy allow-web then permit",
+		"security policies from-zone lan to-zone wan policy deny-ssh match source-address any",
+		"security policies from-zone lan to-zone wan policy deny-ssh match destination-address any",
+		"security policies from-zone lan to-zone wan policy deny-ssh match application junos-ssh",
+		"security policies from-zone lan to-zone wan policy deny-ssh then deny",
+	} {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	c := &CLI{store: store}
+
+	out := captureStdout(t, func() {
+		if err := c.handleShow([]string{"security", "policies", "detail"}); err != nil {
+			t.Fatalf("handleShow: %v", err)
+		}
+	})
+	if !strings.Contains(out, "deny-ssh") {
+		t.Fatalf("dispatch detail output missing deny-ssh:\n%s", out)
+	}
+	if got := policyDetailIndex(t, out, "deny-ssh"); got != 2 {
+		t.Fatalf("dispatch deny-ssh Index = %d, want 2 (runtime ID, not raw ordinal 1)", got)
+	}
+}
+
+// Test_3063_SingleAppPolicyIndexUnchanged is the byte-identical regression: with
+// no multi-application policy, every policy's span is 1, so the runtime Index
+// equals the raw ordinal and the displayed Index is unchanged from pre-#3063.
+func Test_3063_SingleAppPolicyIndexUnchanged(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "lan",
+		ToZone:   "wan",
+		Policies: []*config.Policy{
+			{Name: "p0", Match: config.PolicyMatch{Applications: []string{"junos-ssh"}}, Action: config.PolicyPermit},
+			{Name: "p1", Match: config.PolicyMatch{Applications: []string{"junos-http"}}, Action: config.PolicyDeny},
+			{Name: "p2", Action: config.PolicyPermit},
+		},
+	}}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{Name: "g0", Action: config.PolicyDeny},
+	}
+	c := &CLI{}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesDetail(cfg, "", ""); err != nil {
+			t.Fatalf("showPoliciesDetail: %v", err)
+		}
+	})
+
+	for name, want := range map[string]uint32{"p0": 0, "p1": 1, "p2": 2, "g0": 256} {
+		if got := policyDetailIndex(t, out, name); got != want {
+			t.Fatalf("%s Index = %d, want %d (single-app config must be byte-identical to raw ordinal)", name, got, want)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -126,6 +126,7 @@ func buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg *config.Config, activeSt
 type policyRuleSlot struct {
 	PolicySetID uint32
 	RuleIndex   uint32 // start index within the policy set's 256-slot namespace
+	SliceIndex  uint32 // raw position within the set's policy slice (display key)
 	Span        uint32 // expansion slots consumed (>=1)
 	FromZone    string
 	ToZone      string
@@ -134,6 +135,37 @@ type policyRuleSlot struct {
 
 func (s policyRuleSlot) policyID() uint32 {
 	return s.PolicySetID*dataplane.MaxRulesPerPolicy + s.RuleIndex
+}
+
+// RuntimePolicyIDs returns the span-accumulated runtime/RT_FLOW policy ID for
+// every configured policy, keyed by [policySetID, sliceIndex] where policySetID
+// is the zone-pair set index (global policies occupy set len(Policies)) and
+// sliceIndex is the raw position within that set's policy slice — exactly the
+// (policySetID, i) loop variables the read-only show surfaces already track.
+//
+// The IDs are computed by walkPolicyRuleSlots, the same SSOT that assigns
+// PolicyRuleSnapshot.PolicyID on the dataplane write side, so a display surface
+// keying off this lookup prints the identical numeric ID the RT_FLOW/event path
+// logs (#3063). Before this, the CLI policy-detail Index used the raw ordinal
+// policySetID*MaxRulesPerPolicy + i, which does NOT advance by application-set
+// expansion, so the displayed Index drifted from the logged policy ID after a
+// multi-application policy and an operator cross-referencing a policy-deny log
+// landed on the wrong row.
+//
+// Returned IDs are display identity only; they are NOT the counter handle. The
+// per-policy counter store is name-keyed and ReadPolicyCounters takes the raw
+// ordinal handle that round-trips through policyRuleIDForCounter — callers MUST
+// keep passing the raw ordinal to ReadPolicyCounters. On a config that would
+// overflow MaxRulesPerPolicy the walk stops early and the partial map omits the
+// offending entries; a caller falls back to the raw ordinal for any missing key
+// (such a config cannot be applied anyway, so the dataplane never enforces it).
+func RuntimePolicyIDs(cfg *config.Config) map[[2]uint32]uint32 {
+	out := make(map[[2]uint32]uint32)
+	_ = walkPolicyRuleSlots(cfg, func(slot policyRuleSlot) error {
+		out[[2]uint32{slot.PolicySetID, slot.SliceIndex}] = slot.policyID()
+		return nil
+	})
+	return out
 }
 
 // walkPolicyRuleSlots invokes fn for every configured policy in config order,
@@ -159,7 +191,7 @@ func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error)
 			continue
 		}
 		ruleIndex := uint32(0)
-		for _, pol := range zpp.Policies {
+		for sliceIdx, pol := range zpp.Policies {
 			if pol == nil {
 				continue
 			}
@@ -171,6 +203,7 @@ func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error)
 			if err := fn(policyRuleSlot{
 				PolicySetID: policySetID,
 				RuleIndex:   ruleIndex,
+				SliceIndex:  uint32(sliceIdx),
 				Span:        span,
 				FromZone:    zpp.FromZone,
 				ToZone:      zpp.ToZone,
@@ -183,7 +216,7 @@ func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error)
 		policySetID++
 	}
 	globalRuleIndex := uint32(0)
-	for _, pol := range cfg.Security.GlobalPolicies {
+	for sliceIdx, pol := range cfg.Security.GlobalPolicies {
 		if pol == nil {
 			continue
 		}
@@ -195,6 +228,7 @@ func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error)
 		if err := fn(policyRuleSlot{
 			PolicySetID: policySetID,
 			RuleIndex:   globalRuleIndex,
+			SliceIndex:  uint32(sliceIdx),
 			Span:        span,
 			FromZone:    "junos-global",
 			ToZone:      "junos-global",

--- a/pkg/dataplane/userspace/policy_runtime_ids_3063_test.go
+++ b/pkg/dataplane/userspace/policy_runtime_ids_3063_test.go
@@ -1,0 +1,49 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// Test_3063_RuntimePolicyIDsMatchSnapshot verifies the exported display helper
+// returns, keyed by (policySetID, sliceIndex), the SAME span-accumulated policy
+// ID that buildPolicySnapshots assigns to PolicyRuleSnapshot.PolicyID. This is
+// the SSOT the CLI policy-detail Index render consumes (#3063) so the displayed
+// Index never drifts from the runtime/RT_FLOW policy ID after a multi-app policy.
+func Test_3063_RuntimePolicyIDsMatchSnapshot(t *testing.T) {
+	cfg := multiAppExpansionConfig()
+
+	ids := RuntimePolicyIDs(cfg)
+
+	// Zone-pair set 0: allow-web (slice 0) expands to 2, allow-ssh (slice 1)
+	// therefore occupies span-accumulated slot 2 — NOT the raw ordinal 1.
+	if got := ids[[2]uint32{0, 0}]; got != 0 {
+		t.Fatalf("allow-web runtime ID = %d, want 0", got)
+	}
+	if got := ids[[2]uint32{0, 1}]; got != 2 {
+		t.Fatalf("allow-ssh runtime ID = %d, want 2 (span-accumulated, not raw ordinal 1)", got)
+	}
+	// Global set occupies policy-set index len(Policies)=1, base MaxRulesPerPolicy.
+	if got := ids[[2]uint32{1, 0}]; got != dataplane.MaxRulesPerPolicy {
+		t.Fatalf("global-allow runtime ID = %d, want %d", got, dataplane.MaxRulesPerPolicy)
+	}
+
+	// Cross-check against the authoritative snapshot PolicyID assignment.
+	snaps, err := buildPolicySnapshots(cfg)
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots: %v", err)
+	}
+	byName := map[string]uint32{}
+	for _, s := range snaps {
+		byName[s.Name] = s.PolicyID
+	}
+	if ids[[2]uint32{0, 1}] != byName["allow-ssh"] {
+		t.Fatalf("RuntimePolicyIDs allow-ssh=%d disagrees with snapshot PolicyID=%d",
+			ids[[2]uint32{0, 1}], byName["allow-ssh"])
+	}
+	if ids[[2]uint32{1, 0}] != byName["global-allow"] {
+		t.Fatalf("RuntimePolicyIDs global-allow=%d disagrees with snapshot PolicyID=%d",
+			ids[[2]uint32{1, 0}], byName["global-allow"])
+	}
+}


### PR DESCRIPTION
Closes #3063

## Problem
`show security policies detail` printed `Index:` from the raw per-policy
ordinal `policySetID*MaxRulesPerPolicy + i`, which does NOT advance by
application-set expansion. The dataplane snapshot `PolicyID` and the
RT_FLOW policy-deny logs / session surfaces (which print the numeric
policy ID) DO advance by the expansion count. After a policy whose match
references a multi-term application-set, the displayed Index drifted below
the logged policy ID, so an operator cross-referencing a policy-deny log
to the detail view landed on the wrong row.

## Fix
- Added exported `RuntimePolicyIDs(cfg)` in `pkg/dataplane/userspace`,
  built from the existing SSOT `walkPolicyRuleSlots` (extended with a
  `SliceIndex` field) so it reuses `userspacePolicyRuleExpansionCount`
  instead of duplicating the expansion logic. It returns the
  span-accumulated runtime policy ID keyed by `(policySetID, sliceIndex)`.
- The CLI detail surfaces (`cli_show_security.go` + the dispatch body,
  zone-pair AND global) now render `Index:` via a `runtimePolicyIndex`
  lookup, with a raw-ordinal fallback for any absent key (overflow configs
  the dataplane rejects anyway).
- Single-application configs stay byte-identical (span 1 per policy).

## Counter lookups: deliberately unchanged
The per-policy counter store is **name-keyed**; the raw-ordinal handle
round-trips through `policyRuleIDForCounter` (caller and resolver both use
the slice index), and the gRPC text / REST / Prometheus surfaces use that
handle purely as a counter key and never display an Index. Changing them
would break the counter path, so only the four CLI detail Index renders
move to the runtime ID.

## Tests (fail-on-revert)
- `Test_3063_PolicyDetailIndexMatchesRuntimePolicyID` and the dispatch
  variant: deny-ssh after a 2-term app-set shows Index 2 (not raw ordinal
  1); global at 256.
- `Test_3063_SingleAppPolicyIndexUnchanged`: byte-identical regression.
- `Test_3063_RuntimePolicyIDsMatchSnapshot`: cross-checks the helper
  against `buildPolicySnapshots` PolicyID.
- Verified RED on revert: neutralizing `runtimePolicyIndex` to the raw
  ordinal turns the two multi-app tests RED while the single-app
  regression stays GREEN.

`go build ./...` + `go test ./pkg/cli/ ./pkg/grpcapi/ ./pkg/dataplane/...`
all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi