### PR TITLE
daemon RA: detect configured link-local on any unit (subinterface support)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-26 — #2996 RA configured-link-local source picked from any unit (subinterface support)
+
+- **Timestamp**: 2026-06-26
+- **Action**: fixed `buildRAConfigs` so the operator-configured IPv6 link-local
+  source is detected on ANY logical unit, not just `Units[0]`. RA on a
+  subinterface (VLAN unit with its own `fe80::/64`) previously fell back to an
+  auto EUI-64 link-local because the lookup only read unit 0. Also handle a
+  unit-qualified RA interface name (`ge-0/0/2.50`, `reth0.50`): the interfaces
+  map is keyed by base name, so the new `resolveRASourceLinkLocal` splits the
+  unit off before the lookup and prefers the bound unit's link-local;
+  unqualified names scan units lowest-first (byte-identical to the old unit-0
+  path when unit 0 holds the link-local). RETH stable-link-local fallback
+  preserved.
+- **File(s)**: pkg/daemon/daemon_ra.go, pkg/daemon/ra_source_test.go,
+  pkg/ra/README.md, _Log.md
+
 ## 2026-06-26 — #2926 fold: make the apply-cancel signal actually fire on daemon stop (was inert)
 
 - **Timestamp**: 2026-06-26

--- a/pkg/daemon/daemon_ra.go
+++ b/pkg/daemon/daemon_ra.go
@@ -4,6 +4,9 @@ package daemon
 import (
 	"log/slog"
 	"net"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
@@ -64,31 +67,25 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 	}
 
 	// Detect explicitly configured link-local addresses on RA interfaces.
-	// If a user configures e.g. fe80::face/64 on a RETH interface, the RA
-	// sender should bind to that address instead of auto-selecting one.
+	// If a user configures e.g. fe80::face/64 on a RETH interface (or on a
+	// VLAN subinterface), the RA sender should bind to that address instead
+	// of auto-selecting a transient EUI-64 link-local.
 	for _, ra := range result {
-		if ifc, ok := cfg.Interfaces.Interfaces[ra.Interface]; ok {
-			if unit, ok := ifc.Units[0]; ok {
-				for _, addr := range unit.Addresses {
-					ip, _, err := net.ParseCIDR(addr)
-					if err != nil {
-						continue
-					}
-					if ip.IsLinkLocalUnicast() && ip.To4() == nil {
-						ra.SourceLinkLocal = ip.String()
-						break
-					}
-				}
-			}
-			if ra.SourceLinkLocal == "" && cfg.Chassis.Cluster != nil && ifc.RedundancyGroup != 0 {
-				// RETH HA startup installs a stable router link-local on the active
-				// member. Bind RA to that address so the sender does not auto-pick a
-				// transient EUI-64 link-local which can later be removed by HA reconcile.
-				ra.SourceLinkLocal = cluster.StableRethLinkLocal(
-					cfg.Chassis.Cluster.ClusterID,
-					ifc.RedundancyGroup,
-				).String()
-			}
+		ifc, ll := resolveRASourceLinkLocal(cfg, ra.Interface)
+		if ifc == nil {
+			continue
+		}
+		if ll != "" {
+			ra.SourceLinkLocal = ll
+		}
+		if ra.SourceLinkLocal == "" && cfg.Chassis.Cluster != nil && ifc.RedundancyGroup != 0 {
+			// RETH HA startup installs a stable router link-local on the active
+			// member. Bind RA to that address so the sender does not auto-pick a
+			// transient EUI-64 link-local which can later be removed by HA reconcile.
+			ra.SourceLinkLocal = cluster.StableRethLinkLocal(
+				cfg.Chassis.Cluster.ClusterID,
+				ifc.RedundancyGroup,
+			).String()
 		}
 	}
 
@@ -98,6 +95,77 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 	}
 
 	return result
+}
+
+// resolveRASourceLinkLocal resolves the operator-configured IPv6 link-local
+// source address for an RA interface, returning the base InterfaceConfig (used
+// by the caller for the RETH stable-link-local fallback) and the link-local
+// string ("" when none is configured).
+//
+// raInterface arrives in Junos form straight from
+// `protocols router-advertisement interface <name>`. It may be a bare
+// physical/RETH name ("reth1", "ge-0/0/2") OR unit-qualified ("reth0.50",
+// "ge-0/0/2.50"). cfg.Interfaces.Interfaces is keyed by the BASE name with
+// logical units under ifc.Units, so a unit-qualified RA name never matches the
+// map directly — split the unit off first (this was the #2996 miss: the old
+// lookup hit the map with the full unit-qualified string and only ever read
+// Units[0]).
+//
+// Selection rule (must be deterministic across reconciles):
+//   - unit-qualified ("base.N"): use the link-local configured on THAT unit.
+//   - bare ("base"): scan units in ASCENDING unit-number order and use the
+//     first (lowest-numbered) unit that carries a configured link-local. This
+//     is byte-identical to the historical Units[0]-only lookup when unit 0
+//     holds the link-local, and now also finds a link-local that lives only on
+//     a higher unit.
+//
+// Within a single unit, the first link-local in Addresses order wins (matching
+// the prior `break`-on-first-match behavior).
+func resolveRASourceLinkLocal(cfg *config.Config, raInterface string) (*config.InterfaceConfig, string) {
+	base, unitTok, hasUnit := strings.Cut(raInterface, ".")
+	ifc, ok := cfg.Interfaces.Interfaces[base]
+	if !ok {
+		return nil, ""
+	}
+	if hasUnit && unitTok != "" {
+		// RA bound to a specific unit: prefer that unit's link-local only.
+		if n, err := strconv.Atoi(unitTok); err == nil {
+			if unit, ok := ifc.Units[n]; ok {
+				return ifc, unitConfiguredLinkLocal(unit)
+			}
+		}
+		return ifc, ""
+	}
+	// Bare interface: scan units lowest-first for a stable choice.
+	nums := make([]int, 0, len(ifc.Units))
+	for n := range ifc.Units {
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+	for _, n := range nums {
+		if ll := unitConfiguredLinkLocal(ifc.Units[n]); ll != "" {
+			return ifc, ll
+		}
+	}
+	return ifc, ""
+}
+
+// unitConfiguredLinkLocal returns the first configured IPv6 link-local unicast
+// address (CIDR-stripped) on the unit, or "" when none is configured.
+func unitConfiguredLinkLocal(unit *config.InterfaceUnit) string {
+	if unit == nil {
+		return ""
+	}
+	for _, addr := range unit.Addresses {
+		ip, _, err := net.ParseCIDR(addr)
+		if err != nil {
+			continue
+		}
+		if ip.IsLinkLocalUnicast() && ip.To4() == nil {
+			return ip.String()
+		}
+	}
+	return ""
 }
 
 func cloneRAInterfaceConfig(src *config.RAInterfaceConfig) *config.RAInterfaceConfig {

--- a/pkg/daemon/ra_source_test.go
+++ b/pkg/daemon/ra_source_test.go
@@ -75,6 +75,79 @@ func TestBuildRAConfigsPrefersExplicitLinkLocal(t *testing.T) {
 	}
 }
 
+// TestBuildRAConfigsPrefersLinkLocalOnNonZeroUnit is the #2996 bug case: RA
+// configured on a bare interface whose link-local lives on a NON-ZERO unit
+// (e.g. a VLAN subinterface). The old Units[0]-only lookup missed it and fell
+// back to an auto-selected link-local. The configured address must win.
+func TestBuildRAConfigsPrefersLinkLocalOnNonZeroUnit(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/2": {
+					Name: "ge-0/0/2",
+					Units: map[int]*config.InterfaceUnit{
+						0:  {Addresses: []string{"2001:db8::1/64"}},
+						50: {VlanID: 50, Addresses: []string{"fe80::50/64", "2001:db8:50::1/64"}},
+					},
+				},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{Interface: "ge-0/0/2"},
+			},
+		},
+	}
+
+	ras := d.buildRAConfigs(cfg)
+	if len(ras) != 1 {
+		t.Fatalf("buildRAConfigs returned %d RAs, want 1", len(ras))
+	}
+	if ras[0].SourceLinkLocal != "fe80::50" {
+		t.Fatalf("SourceLinkLocal = %q, want fe80::50 (link-local on unit 50)", ras[0].SourceLinkLocal)
+	}
+}
+
+// TestBuildRAConfigsUnitQualifiedInterface covers a unit-qualified RA interface
+// name ("ge-0/0/2.50"). cfg.Interfaces.Interfaces is keyed by the base name, so
+// the lookup must split off the unit and prefer THAT unit's configured
+// link-local.
+func TestBuildRAConfigsUnitQualifiedInterface(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/2": {
+					Name: "ge-0/0/2",
+					Units: map[int]*config.InterfaceUnit{
+						0:  {Addresses: []string{"fe80::aaaa/64"}},
+						50: {VlanID: 50, Addresses: []string{"fe80::5050/64", "2001:db8:50::1/64"}},
+						80: {VlanID: 80, Addresses: []string{"fe80::8080/64"}},
+					},
+				},
+			},
+		},
+		Protocols: config.ProtocolsConfig{
+			RouterAdvertisement: []*config.RAInterfaceConfig{
+				{Interface: "ge-0/0/2.50"},
+			},
+		},
+	}
+
+	ras := d.buildRAConfigs(cfg)
+	if len(ras) != 1 {
+		t.Fatalf("buildRAConfigs returned %d RAs, want 1", len(ras))
+	}
+	if ras[0].SourceLinkLocal != "fe80::5050" {
+		t.Fatalf("SourceLinkLocal = %q, want fe80::5050 (link-local on the bound unit 50)", ras[0].SourceLinkLocal)
+	}
+	// And the resolved (Linux) interface name must reflect the unit.
+	if ras[0].Interface != "ge-0-0-2.50" {
+		t.Fatalf("resolved Interface = %q, want ge-0-0-2.50", ras[0].Interface)
+	}
+}
+
 func TestBuildRAConfigsDoesNotMutateConfiguredRAEntries(t *testing.T) {
 	d := &Daemon{}
 	cfg := &config.Config{

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -248,6 +248,23 @@ best-effort).
   MAC degrades to a soft-logged warning (the caller only `slog.Warn`s the
   error); the explicit `source-link-local` config and the `listen()` retry
   loop (now in the owner goroutine, see below) are the recovery path.
+- **Configured source link-local is picked from ANY unit (#2996).** The
+  daemon's `buildRAConfigs` (`pkg/daemon/daemon_ra.go`) seeds each RA's
+  `SourceLinkLocal` from an operator-configured `fe80::/10` address on the RA
+  interface, so the sender binds to that address instead of an auto-selected
+  transient EUI-64. `protocols router-advertisement interface <name>` may name
+  a bare interface (`reth1`, `ge-0/0/2`) or a VLAN subinterface
+  (`ge-0/0/2.50`, `reth0.50`); `cfg.Interfaces.Interfaces` is keyed by the
+  BASE name with logical units under `ifc.Units`, so `resolveRASourceLinkLocal`
+  splits the unit off the RA name before the lookup. Selection rule
+  (deterministic across reconciles): a **unit-qualified** RA name uses the
+  link-local configured on THAT unit; a **bare** name scans units lowest-first
+  and uses the lowest-numbered unit that carries a configured link-local
+  (byte-identical to the historical unit-0-only lookup when unit 0 holds it).
+  When no unit carries a configured link-local, a RETH interface still falls
+  back to `cluster.StableRethLinkLocal`. Before #2996 the lookup only ever read
+  `Units[0]`, so an RA on a subinterface (link-local under a non-zero unit)
+  silently ignored the configured source.
 - **Bind retry runs UNLOCKED, in the owner goroutine (#2453).** `start()` no
   longer opens the NDP conn synchronously. It just launches `run()` and returns,
   so `Manager.startLocked` holds `m.mu` only for the cheap `InterfaceByName`


### PR DESCRIPTION
Closes #2996

## Problem
`buildRAConfigs` (`pkg/daemon/daemon_ra.go`) seeds an RA's `SourceLinkLocal` from an operator-configured `fe80::/10` address on the RA interface, but the lookup only scanned `Units[0]`. An RA configured on a **subinterface** (a VLAN unit carrying its own configured `fe80::.../64`) silently missed the configured address and the sender fell back to an auto-selected transient EUI-64 link-local. On HA/RETH a later reconcile can remove the auto one, leaving the RA source mismatched against the intended router address.

Separately, `ra.Interface` comes straight from `protocols router-advertisement interface <name>` and may be **unit-qualified** (`ge-0/0/2.50`, `reth0.50`), while `cfg.Interfaces.Interfaces` is keyed by the **base** name with logical units under `ifc.Units`. A unit-qualified RA name therefore never matched the map — neither the configured link-local nor the RETH fallback fired.

## Fix
`resolveRASourceLinkLocal` splits the unit off `ra.Interface` before the base-name lookup. Selection rule (deterministic across reconciles):
- **unit-qualified** (`base.N`): use the link-local configured on THAT unit.
- **bare** (`base`): scan units in ascending unit-number order, use the lowest-numbered unit that carries a configured link-local — byte-identical to the old `Units[0]`-only path when unit 0 holds the link-local, and now also finds one that lives only on a higher unit.

The RETH stable-link-local fallback is preserved (keyed off the base interface's redundancy-group).

## Tests
- `TestBuildRAConfigsPrefersLinkLocalOnNonZeroUnit` — the #2996 bug case (link-local on unit 50).
- `TestBuildRAConfigsUnitQualifiedInterface` — `ge-0/0/2.50` resolves to unit 50's link-local and the right Linux ifname.
- Existing regressions (unit-0 explicit link-local, RETH stable fallback, no-mutation) unchanged.

**Fail-on-revert:** restoring the `Units[0]`-only lookup turns BOTH new tests RED while the unit-0 and RETH fallback regressions stay green.

`go build ./...` and `go test ./pkg/daemon/... ./pkg/config/...` green.

> RA is HA-adjacent; parent should run the test-failover no-regression gate before merge. The change is at config-read time only — it changes which source link-local is selected, nothing on the RA send path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi