### PR TITLE
userspace-dp: log post-translation tuple in NAT'd policy-deny RT_FLOW (#3058)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20193,3 +20193,20 @@ top.
   pkg/daemon/daemon_snmp_reconcile_test.go,
   pkg/daemon/persistent_snat_apply_test.go,
   pkg/daemon/policy_scheduler_apply_test.go, pkg/daemon/README.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #3058 — DNAT/static-NAT/NPTv6 policy-DENY RT_FLOW record now
+  carries the #2345 post-translation tuple. `emit_policy_deny_event` takes
+  the deny site's `&decision.nat` and populates nat_src/dst ip+port from
+  `rewrite_*` (mirroring `emit_session_close_rt_flow`: 5-tuple = original,
+  nat_* = translated) instead of hardcoding None/0; AppID resolved from the
+  post-NAT dst port via new `resolve_policy_deny_app_id(policy_dst_port)`.
+  Non-NAT deny (default NatDecision) stays byte-identical. Threaded
+  `&decision.nat` + `policy_dst_port` through both poll_descriptor deny sites
+  (session-miss + MissingNeighbor cold path). Added 3 Rust tests
+  (dnat post-translation dst+app, source-translation nat_src, non-NAT
+  byte-identical regression guard); fail-on-revert: test1 RED, test3 GREEN.
+  **File(s)**: userspace-dp/src/afxdp/event_emit.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/forwarding/tests.rs,
+  userspace-dp/src/event_stream/README.md

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::event_stream::EventStreamWorkerHandle;
 use crate::event_stream::codec::{DataplaneEventKind, DataplaneEventPayload};
 use crate::filter::FilterAction;
+use crate::nat::NatDecision;
 use crate::policy::{AppCatalog, PolicyAction};
 use crate::screen::ScreenPacketInfo;
 
@@ -87,10 +88,35 @@ pub(super) fn resolve_flow_app_id(app_catalog: &AppCatalog, flow: &SessionFlow) 
     )
 }
 
+/// #3058: resolve the AppID for a policy-DENY RT_FLOW record from the
+/// POST-translation destination port the policy was actually evaluated
+/// against. #2345 moved DNAT/static-NAT/inbound-NPTv6 policy evaluation to
+/// the translated destination tuple, so the deny log's application must be
+/// resolved from that same translated port (e.g. a public `:2222` DNAT'd to
+/// inside `:22` resolves `junos-ssh`, not UNKNOWN(2222)). `policy_dst_port`
+/// is `policy_dst_port` at the deny call sites (the value fed to
+/// `evaluate_policy_result_with_len`). For a non-NAT deny it equals
+/// `flow.forward_key.dst_port`, so the result is byte-identical to
+/// `resolve_flow_app_id`. The catalog probe is the SAME `app_catalog.lookup`
+/// the forwarding hot path runs, so no resolution logic is duplicated.
+#[inline]
+pub(super) fn resolve_policy_deny_app_id(
+    app_catalog: &AppCatalog,
+    flow: &SessionFlow,
+    policy_dst_port: u16,
+) -> u16 {
+    app_catalog.lookup(
+        flow.forward_key.protocol,
+        flow.forward_key.src_port,
+        policy_dst_port,
+    )
+}
+
 #[inline]
 pub(super) fn emit_policy_deny_event(
     event_stream: Option<&EventStreamWorkerHandle>,
     flow: &SessionFlow,
+    nat: &NatDecision,
     meta: UserspaceDpMeta,
     ingress_zone_id: u16,
     egress_zone_id: u16,
@@ -108,14 +134,26 @@ pub(super) fn emit_policy_deny_event(
         addr_family: flow.forward_key.addr_family,
         protocol: flow.forward_key.protocol,
         action: policy_action_to_rt_flow(action),
+        // #3058: the 5-tuple carries the ORIGINAL (received) addresses/ports;
+        // the nat_* fields below carry the TRANSLATED values — the SAME
+        // convention `emit_session_close_rt_flow` follows for a permitted
+        // session (event_stream/mod.rs: `delta.key.*` for the tuple,
+        // `nat.rewrite_*` for the nat-* slots). A denied DNAT/static-NAT/
+        // inbound-NPTv6 flow therefore logs the public/received dst in
+        // dst_ip/dst_port AND the real internal dst in nat_dst_ip/nat_dst_port,
+        // matching how a permit record represents the same translation.
         src_ip: flow.src_ip,
         dst_ip: flow.dst_ip,
         src_port: flow.forward_key.src_port,
         dst_port: flow.forward_key.dst_port,
-        nat_src_ip: None,
-        nat_dst_ip: None,
-        nat_src_port: 0,
-        nat_dst_port: 0,
+        // #3058: populate the NAT slots from the decision the policy was
+        // evaluated against (#2345 post-translation tuple) instead of the old
+        // hardcoded None/0. A non-NAT deny passes a default `NatDecision`
+        // (all-None), so the wire is byte-identical to the pre-#3058 record.
+        nat_src_ip: nat.rewrite_src,
+        nat_dst_ip: nat.rewrite_dst,
+        nat_src_port: nat.rewrite_src_port.unwrap_or(0),
+        nat_dst_port: nat.rewrite_dst_port.unwrap_or(0),
         ingress_zone_id,
         egress_zone_id,
         ingress_ifindex: ingress_ifindex_to_wire(meta.ingress_ifindex),
@@ -472,6 +510,27 @@ mod tests {
         }
     }
 
+    /// #3058: a flow whose received destination is a PUBLIC address+port that
+    /// DNATs to an inside host (203.0.113.10:2222 -> 10.0.0.10:22). The
+    /// `forward_key` carries the original (pre-translation) tuple, exactly as
+    /// the live deny sites see it.
+    fn dnat_test_flow() -> SessionFlow {
+        let src_ip = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 50));
+        let dst_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+        SessionFlow {
+            src_ip,
+            dst_ip,
+            forward_key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_TCP,
+                src_ip,
+                dst_ip,
+                src_port: 51000,
+                dst_port: 2222,
+            },
+        }
+    }
+
     fn test_meta() -> UserspaceDpMeta {
         UserspaceDpMeta {
             ingress_ifindex: 42,
@@ -503,6 +562,7 @@ mod tests {
         emit_policy_deny_event(
             Some(&handle),
             &flow,
+            &NatDecision::default(),
             test_meta(),
             7,
             9,
@@ -551,6 +611,7 @@ mod tests {
         emit_policy_deny_event(
             Some(&handle),
             &flow,
+            &NatDecision::default(),
             test_meta(),
             7,
             9,
@@ -880,6 +941,7 @@ mod tests {
         emit_policy_deny_event(
             Some(&handle),
             &flow,
+            &NatDecision::default(),
             test_meta(),
             7,
             9,
@@ -931,6 +993,150 @@ mod tests {
         assert_eq!(resolve_flow_app_id(&catalog, &test_flow()), 0);
     }
 
+    /// #3058 fail-on-revert: a DNAT'd policy-deny RT_FLOW record must log the
+    /// PUBLIC dst in the 5-tuple AND the real internal dst in the nat_* fields
+    /// (the same convention `emit_session_close_rt_flow` uses for a permit),
+    /// and resolve the AppID from the POST-NAT port (22 -> junos-ssh), not the
+    /// pre-NAT port (2222 -> UNKNOWN). Reverting the emitter back to hardcoded
+    /// `nat_*: None/0` + pre-NAT AppID makes this test RED.
+    #[test]
+    fn policy_deny_event_dnat_logs_post_translation_dst_and_app() {
+        let inside = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10));
+        // TCP/22 → app_id 17 (stand-in for junos-ssh).
+        let catalog = AppCatalog::from_snapshot(&[crate::AppCatalogEntry {
+            app_id: 17,
+            protocol: PROTO_TCP,
+            dst_port_low: 22,
+            dst_port_high: 22,
+            src_port_low: 0,
+            src_port_high: 0,
+        }]);
+        let flow = dnat_test_flow();
+        let nat = NatDecision {
+            rewrite_dst: Some(inside),
+            rewrite_dst_port: Some(22),
+            ..NatDecision::default()
+        };
+        // `policy_dst_port` at the deny call site is the translated dst port.
+        let app_id = resolve_policy_deny_app_id(&catalog, &flow, 22);
+        assert_eq!(app_id, 17, "post-NAT dst port 22 must resolve junos-ssh(17)");
+        // The pre-NAT resolution (the #3058 bug) resolves UNKNOWN(0).
+        assert_eq!(
+            resolve_flow_app_id(&catalog, &flow),
+            0,
+            "pre-NAT dst port 2222 resolves UNKNOWN — the misleading old behavior"
+        );
+
+        let (handle, rx) = unlimited_handle();
+        emit_policy_deny_event(
+            Some(&handle),
+            &flow,
+            &nat,
+            test_meta(),
+            7,
+            9,
+            3,
+            101,
+            PolicyAction::Deny,
+            app_id,
+            mono_now_ns(),
+        );
+        let event = rx
+            .try_recv()
+            .expect("policy event frame")
+            .decode_dataplane_event()
+            .expect("policy event payload");
+        // 5-tuple = ORIGINAL public dst.
+        assert_eq!(event.dst_ip, flow.dst_ip);
+        assert_eq!(event.dst_port, 2222);
+        // nat_* = TRANSLATED internal dst.
+        assert_eq!(event.nat_dst_ip, Some(inside));
+        assert_eq!(event.nat_dst_port, 22);
+        // No source translation on a denied flow.
+        assert_eq!(event.nat_src_ip, None);
+        assert_eq!(event.nat_src_port, 0);
+        // AppID from the post-NAT tuple.
+        assert_eq!(event.application_id, 17);
+    }
+
+    /// #3058: a deny whose NatDecision carries a SOURCE rewrite (NPTv6 / SNAT)
+    /// must populate the nat_src_* fields, mirroring the permit/session-close
+    /// record. The emitter serializes every field from the decision.
+    #[test]
+    fn policy_deny_event_source_translation_logs_nat_src() {
+        let xlated_src = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 200));
+        let flow = test_flow(); // src 192.0.2.10:49152 -> dst 198.51.100.20:443
+        let nat = NatDecision {
+            rewrite_src: Some(xlated_src),
+            rewrite_src_port: Some(40000),
+            nptv6: true,
+            ..NatDecision::default()
+        };
+        let (handle, rx) = unlimited_handle();
+        emit_policy_deny_event(
+            Some(&handle),
+            &flow,
+            &nat,
+            test_meta(),
+            7,
+            9,
+            3,
+            101,
+            PolicyAction::Deny,
+            0,
+            mono_now_ns(),
+        );
+        let event = rx
+            .try_recv()
+            .expect("policy event frame")
+            .decode_dataplane_event()
+            .expect("policy event payload");
+        // 5-tuple = ORIGINAL src.
+        assert_eq!(event.src_ip, flow.src_ip);
+        assert_eq!(event.src_port, 49152);
+        // nat_* = TRANSLATED src.
+        assert_eq!(event.nat_src_ip, Some(xlated_src));
+        assert_eq!(event.nat_src_port, 40000);
+        assert_eq!(event.nat_dst_ip, None);
+        assert_eq!(event.nat_dst_port, 0);
+    }
+
+    /// #3058 regression guard (the GREEN-stays half of the fail-on-revert
+    /// exercise): a deny with NO translation (default NatDecision) keeps the
+    /// original 5-tuple and EMPTY nat fields — byte-identical to the pre-#3058
+    /// record. Only NAT'd denies change.
+    #[test]
+    fn policy_deny_event_non_nat_has_empty_nat_fields() {
+        let flow = test_flow();
+        let (handle, rx) = unlimited_handle();
+        emit_policy_deny_event(
+            Some(&handle),
+            &flow,
+            &NatDecision::default(),
+            test_meta(),
+            7,
+            9,
+            3,
+            101,
+            PolicyAction::Deny,
+            0,
+            mono_now_ns(),
+        );
+        let event = rx
+            .try_recv()
+            .expect("policy event frame")
+            .decode_dataplane_event()
+            .expect("policy event payload");
+        assert_eq!(event.src_ip, flow.src_ip);
+        assert_eq!(event.dst_ip, flow.dst_ip);
+        assert_eq!(event.src_port, 49152);
+        assert_eq!(event.dst_port, 443);
+        assert_eq!(event.nat_src_ip, None);
+        assert_eq!(event.nat_dst_ip, None);
+        assert_eq!(event.nat_src_port, 0);
+        assert_eq!(event.nat_dst_port, 0);
+    }
+
     /// #2470: two events emitted in monotonic-instant order carry
     /// non-decreasing wall-clock timestamps on the wire. This is the timeline
     /// correctness property the fix delivers: under queued / backlogged
@@ -945,6 +1151,7 @@ mod tests {
         emit_policy_deny_event(
             Some(&handle),
             &flow,
+            &NatDecision::default(),
             test_meta(),
             7,
             9,

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -1963,6 +1963,7 @@ fn policy_selection_deny_emits_rt_flow_event() {
     super::super::emit_policy_deny_event(
         Some(&event_handle),
         &flow,
+        &crate::nat::NatDecision::default(),
         meta,
         from_id,
         to_id,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -2250,17 +2250,33 @@ pub(super) fn poll_binding_process_descriptor(
                                 emit_policy_deny_event(
                                     worker_ctx.event_stream,
                                     flow,
+                                    // #3058: carry the inbound destination NAT
+                                    // (DNAT / static-DNAT / inbound NPTv6) the
+                                    // policy was evaluated against (#2345) so the
+                                    // deny RT_FLOW record's nat_* fields show the
+                                    // real translated dst, mirroring the permit /
+                                    // session-close record. SNAT is not applied on
+                                    // a denied flow, so `decision.nat` here holds
+                                    // only the dst rewrite (None for a non-NAT
+                                    // deny → byte-identical to the old record).
+                                    &decision.nat,
                                     meta,
                                     from_zone_id,
                                     to_zone_id,
                                     owner_rg_id,
                                     policy_result.policy_id,
                                     policy_result.action,
-                                    // #2520: resolve the AppID with the same
+                                    // #2520/#3058: resolve the AppID with the same
                                     // app_catalog.lookup the session-create hot
-                                    // path runs, so the deny RT_FLOW record
-                                    // carries the application, not UNKNOWN.
-                                    resolve_flow_app_id(&worker_ctx.forwarding.app_catalog, flow),
+                                    // path runs, but from the POST-translation dst
+                                    // port the policy matched (`policy_dst_port`),
+                                    // so a DNAT'd deny logs the inside app (e.g.
+                                    // junos-ssh) instead of UNKNOWN(pre-NAT port).
+                                    resolve_policy_deny_app_id(
+                                        &worker_ctx.forwarding.app_catalog,
+                                        flow,
+                                        policy_dst_port,
+                                    ),
                                     now_ns,
                                 );
                                 telemetry.dbg.policy_deny += 1;
@@ -3010,16 +3026,26 @@ pub(super) fn poll_binding_process_descriptor(
                                     emit_policy_deny_event(
                                         worker_ctx.event_stream,
                                         flow,
+                                        // #3058: same as the ForwardCandidate deny
+                                        // site — `decision.nat` carries the inbound
+                                        // dst translation (DNAT/static-DNAT/NPTv6)
+                                        // the #2345 policy match ran against, so the
+                                        // nat_* fields log the real internal dst.
+                                        // None for a non-NAT deny (byte-identical).
+                                        &decision.nat,
                                         meta,
                                         from_zone_id,
                                         to_zone_id,
                                         owner_rg_id,
                                         policy_result.policy_id,
                                         policy_result.action,
-                                        // #2520: AppID via the hot-path lookup.
-                                        resolve_flow_app_id(
+                                        // #2520/#3058: AppID via the hot-path lookup
+                                        // from the POST-translation dst port the
+                                        // policy matched (`policy_dst_port`).
+                                        resolve_policy_deny_app_id(
                                             &worker_ctx.forwarding.app_catalog,
                                             flow,
+                                            policy_dst_port,
                                         ),
                                         now_ns,
                                     );

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -53,6 +53,20 @@ periodic ACK from the daemon.
   `afxdp::event_emit::resolve_flow_app_id`), so a policy-deny / filter-log /
   session-create / session-close record shows `application=<name>` for a
   resolvable 5-tuple instead of `application="UNKNOWN"`.
+  (#3058) a DNAT / static-NAT / inbound-NPTv6 policy-DENY record now reflects
+  what the policy was actually evaluated against (the #2345 post-translation
+  tuple), mirroring the permit / SESSION_CLOSE convention exactly: the
+  RT_FLOW 5-tuple carries the ORIGINAL (received) addresses/ports and the
+  `nat src/dst` slots (offsets 72/88 ip, 104/106 port) carry the TRANSLATED
+  values — populated from the deny site's `decision.nat`
+  (`rewrite_src/rewrite_dst/rewrite_*_port`) instead of the old hardcoded
+  None/0. The deny AppID is resolved from the POST-translation destination
+  port (`resolve_policy_deny_app_id` against `policy_dst_port`), so a public
+  `:2222` DNAT'd to inside `:22` logs the inside `nat dst 10.0.0.10:22` +
+  `application=junos-ssh` instead of an empty NAT dst + `UNKNOWN(2222)`. A
+  deny with NO translation passes a default `NatDecision` (all-None) and a
+  `policy_dst_port` equal to the original dst port, so its record stays
+  byte-identical to the pre-#3058 wire — only NAT'd denies change.
   (#2615) the SESSION_CREATE and SESSION_CLOSE frames ALSO populate the
   ingress ifindex slot (offset 128, little-endian u32) from the admitting
   binding's `ident.ifindex`, so the Go decoder resolves


### PR DESCRIPTION
Closes #3058

## Problem
DNAT/static-NAT/inbound-NPTv6 policy decisions are evaluated on the post-translation tuple (the #2345 fix), but the policy-deny RT_FLOW record still logged the **pre-translation** tuple with empty NAT fields and a **pre-NAT** AppID. A public `203.0.113.10:2222` DNAT'd to inside `10.0.0.10:22` with a deny on `junos-ssh` logged dst `203.0.113.10:2222`, an empty NAT dst, and `application=UNKNOWN(2222)` — operators could not correlate the deny to the internal service the firewall actually matched.

## Fix
Make the deny record reflect what policy was evaluated against, using the **same field convention `emit_session_close_rt_flow` follows for a permitted session**: the RT_FLOW 5-tuple carries the ORIGINAL (received) addresses/ports and the `nat_*` slots carry the TRANSLATED values.

- `emit_policy_deny_event` now takes a `&NatDecision` and populates `nat_src_ip/nat_dst_ip/nat_src_port/nat_dst_port` from `rewrite_src/rewrite_dst/rewrite_*_port` (mirroring the session-close emitter) instead of hardcoding `None/0`.
- New `resolve_policy_deny_app_id` resolves the AppID from the post-translation destination port (`policy_dst_port`, the value fed to the #2345 policy match) via the same `app_catalog.lookup` the hot path runs.
- Both `poll_descriptor` deny sites (session-miss ForwardCandidate + MissingNeighbor cold path) thread `&decision.nat` + `policy_dst_port` into the emitter. SNAT is not applied on a denied flow, so `decision.nat` there holds only the inbound dst rewrite.

The **wire layout is unchanged** — only previously-zero fields are filled — so the Go decoder (`pkg/logging/ringbuf.go`) interprets the record unchanged: `SrcAddr/DstAddr` = received tuple, `NATSrcAddr/NATDstAddr` = translated. A **non-NAT deny** passes a default `NatDecision` (all-None) + a `policy_dst_port` equal to the original dst port, so its record stays **byte-identical** to the pre-fix wire — only NAT'd denies change.

## Tests
3 new Rust tests in `event_emit.rs`:
1. `policy_deny_event_dnat_logs_post_translation_dst_and_app` — DNAT deny logs internal dst in `nat_dst_ip/nat_dst_port` + `junos-ssh` AppID from port 22 (not UNKNOWN/2222).
2. `policy_deny_event_source_translation_logs_nat_src` — source-translation (NPTv6/SNAT) deny populates `nat_src_*`.
3. `policy_deny_event_non_nat_has_empty_nat_fields` — non-NAT deny keeps original tuple + empty NAT fields (regression guard).

**Fail-on-revert**: reverting the emitter to hardcoded `nat_*: None/0` turns test 1 RED (`nat_dst_ip` None vs Some(10.0.0.10)) while test 3 stays GREEN; restored byte-identical.

- `cargo build --release` clean; `cargo test --release afxdp::` 1994 passed (1 pre-existing flaky concurrency race in `worker_queue`, passes in isolation).
- `go test ./pkg/logging/` 117 passed (decoder contract unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi