### PR TITLE
ddns/surface-a: back off failing withdraws like the publish path (#2813)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20233,3 +20233,26 @@ top.
   pkg/daemon/daemon_snmp_reconcile_test.go,
   pkg/daemon/persistent_snat_apply_test.go,
   pkg/daemon/policy_scheduler_apply_test.go, pkg/daemon/README.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #2813 ddns/surface-a — make both withdraw paths share the publish
+  per-scope error backoff. A permanently-failing withdraw (generic backend with
+  no delete verb, or a persistently-erroring dyndns2/cloudflare/route53/rfc2136
+  delete) re-attempted on every 30s sweep and emitted one slog.Warn per sweep
+  (~2880 lines/day/scope) because only the publish path armed backoff. Refactored
+  recordScopeError to take (fqdn, maxBackoff) instead of the full scope; added
+  withdrawScopeLocked (drives DeleteLease under the shared backoff slot) +
+  markWithdrawUnsupported (terminal classification). Pass-1 (address-loss in
+  reconcileScopeLocked) and Pass-2 (gone-from-config in Reconcile) now arm the
+  same flat exponential backoff (30s→1h) and a backoff-window check skips the
+  re-attempt + warn while backed off. A scope is only ever a publish OR a
+  withdraw candidate at one time, so one shared backoff slot is correct (no
+  withdraw-specific slot). errGenericDeleteUnsupported is terminal (attempt once,
+  one warn, keep ownership; cleared on a successful publish or restart). Added
+  surface_a_withdraw_backoff_2813_test.go (4 tests: gone-from-config backoff,
+  address-loss backoff, retry-after-window-then-succeed-clears, unsupported-
+  terminal). Fail-on-revert: removing the withdraw backoff arming turned both
+  BacksOff tests RED (12 attempts over 12 sweeps); restored byte-identical.
+  go build ./... + go test ./pkg/ddns/... ./pkg/daemon/... green (837 tests).
+  **File(s)**: pkg/ddns/surface_a.go,
+  pkg/ddns/surface_a_withdraw_backoff_2813_test.go, pkg/ddns/README.md, _Log.md

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -82,6 +82,28 @@ success for a withdraw they did not actually perform — doing so orphans the
 public record while xpf believes it withdrawn (the #2772 bug, originally a no-op
 that returned nil on both dyndns2 and generic).
 
+**Withdraw shares the publish error-backoff (#2813).** Both withdraw paths — the
+Pass-1 address-loss withdraw in `reconcileScopeLocked` and the Pass-2
+gone-from-config withdraw in `Reconcile` — now arm the SAME per-scope flat
+exponential backoff (`recordScopeError` → `surfaceAState.nextEligible`) the
+publish path uses, via the shared `withdrawScopeLocked` helper. Before #2813 a
+persistently-failing withdraw re-attempted (and emitted one `slog.Warn`) on
+EVERY 30s reconcile sweep — ~2880 log lines/day/scope — because only publish
+participated in the backoff machinery. Now a failing withdraw backs off (30s →
+1h cap) and its retry/warn cadence collapses to the backoff schedule. A scope is
+only ever a publish OR a withdraw candidate at one time (a gone-from-config scope
+is absent from `desired` and never reaches Pass 1), so a SINGLE shared per-scope
+backoff slot is correct — there is no separate withdraw-specific slot. A
+transient withdraw failure is still retried after the backoff window and clears
+the backoff state on success (the record is actually withdrawn — no leaked
+ownership). A withdraw that returns `errGenericDeleteUnsupported` (the generic
+backend has no portable delete verb) is treated as **terminal**: the wire delete
+is attempted at most once, a single warn is emitted, and ownership is kept (the
+abandoned RR stays operator-visible) — re-attempting a structurally-unsupported
+verb on any cadence is pointless. The terminal mark clears on a successful
+publish or a daemon restart (the runtime cache is rebuilt from the durable
+store), so a later provider change that adds a delete verb is re-probed.
+
 | backend | withdraw mechanism |
 |---|---|
 | `dyndns2` | the same update GET with `offline=YES` (the de-facto dyndns2 withdraw — dyn/no-ip/dns-o-matic take the hostname offline). Body verdict parsed like an upsert; a provider failure → non-nil error → ownership kept for retry. |

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -165,6 +165,18 @@ type surfaceAState struct {
 	// SurfaceAStateUnpublished status row so a never-published scope is visible to
 	// the operator instead of silently omitted (#2843).
 	noBackend bool
+	// withdrawUnsupported records that the scope's backend can NEVER perform a
+	// withdraw (errGenericDeleteUnsupported — the generic HTTP backend has no
+	// portable delete verb, #2772/#2811). Unlike a transient failure this arms NO
+	// retry: re-attempting a structurally-unsupported delete on the backoff
+	// cadence is pointless churn plus a recurring warn (#2813). The wire delete is
+	// attempted at most once; a single warn is emitted; the scope KEEPS ownership
+	// so the abandoned RR stays operator-visible. Both withdraw paths skip the
+	// wire attempt while set. Cleared on a successful publish (the full rt reset)
+	// and on restart (the runtime cache is rebuilt from the durable store, which
+	// only seeds lastAddr), so a later provider change that adds a delete verb is
+	// re-probed.
+	withdrawUnsupported bool
 }
 
 // Surface A scope status states for the operator view (#2843). A configured
@@ -647,12 +659,40 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 			delete(m.runtime, owned.scopeOf().scopePrefix())
 			continue
 		}
+		// Per-scope error backoff for the gone-from-config withdraw (#2813): a
+		// persistently-failing withdraw (a generic backend with no delete verb, or
+		// a dyndns2/cloudflare/route53/rfc2136 delete that keeps erroring) must back
+		// off its retry cadence instead of re-attempting — and warning — on every
+		// 30s sweep. This reuses the SAME per-scope runtime backoff slot the publish
+		// path arms (keyed by scopePrefix == sid); the runtime entry was seeded from
+		// the durable store at startup (seedFromStore), so it usually already exists.
+		// A scope is only ever a publish OR a withdraw candidate at one time (a
+		// gone-from-config scope is absent from `desired` and never reaches Pass 1),
+		// so a single shared backoff slot is correct — no withdraw-specific slot.
+		rt := m.runtime[sid]
+		if rt == nil {
+			rt = &surfaceAState{}
+			m.runtime[sid] = rt
+		}
+		if rt.withdrawUnsupported {
+			// Terminal: the backend can never withdraw (#2813). Keep ownership (the
+			// RR stays operator-visible) and do not re-attempt the wire delete.
+			continue
+		}
+		if !rt.nextEligible.IsZero() && now.Before(rt.nextEligible) {
+			// Still inside the error-backoff window — skip the wire delete this pass.
+			m.backedOff++
+			slog.Debug("ddns surface-a: gone-from-config scope in withdraw backoff; skipping this pass",
+				"fqdn", owned.FQDN, "next-eligible", rt.nextEligible)
+			continue
+		}
 		backend, err := m.backendForOwned(owned, catalog)
 		if err != nil {
+			m.recordScopeError(rt, owned.FQDN, 0, err, now)
 			noteErr(err)
 			continue
 		}
-		noteErr(m.withdrawOwnedLocked(ctx, owned, backend))
+		noteErr(m.withdrawScopeLocked(ctx, owned, backend, rt, owned.FQDN, 0, now))
 	}
 
 	if err := m.state.save(); err != nil {
@@ -699,15 +739,28 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 		// #2691 P2 MAJOR-2 fix; backendForOwned is only needed for the gone-from-
 		// config Pass 2 withdraw where the scope no longer exists).
 		if owned, exists := m.state.get(sc.effectiveKey(), surfaceAIdentity, ""); exists {
+			if rt.withdrawUnsupported {
+				// Terminal: the resolved backend has no withdraw verb (#2813). Do not
+				// re-attempt the wire delete every sweep — keep ownership (the RR is
+				// operator-visible) and stay quiet (the single warn already fired).
+				slog.Debug("ddns surface-a: withdraw unsupported by backend; not re-attempting (record kept)",
+					"fqdn", sc.FQDN)
+				return nil
+			}
 			backend, err := m.backendFor(sc)
 			if err != nil {
+				// Could not even build the backend: arm the SAME per-scope backoff the
+				// publish path uses (#2813) so a persistent resolve failure backs off
+				// instead of re-attempting (and warning) every 30s sweep. The backoff
+				// window check at the top of reconcileScopeLocked skips the next sweeps.
 				m.deleteFail++
+				m.recordScopeError(rt, sc.FQDN, sc.ErrorBackoffMax, err, now)
 				return err
 			}
-			if err := m.withdrawOwnedLocked(ctx, owned, backend); err != nil {
-				return err
-			}
-			delete(m.runtime, sid)
+			// withdrawScopeLocked drives the delete under the shared backoff machinery:
+			// success clears the scope state (the runtime entry is dropped), a transient
+			// failure arms exponential backoff, an unsupported-verb failure is terminal.
+			return m.withdrawScopeLocked(ctx, owned, backend, rt, sc.FQDN, sc.ErrorBackoffMax, now)
 		}
 		return nil
 	}
@@ -761,7 +814,7 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 			// would resurrect a stale map entry, so we swallow without touching rt.
 			return nil
 		}
-		m.recordScopeError(rt, sc, err, now)
+		m.recordScopeError(rt, sc.FQDN, sc.ErrorBackoffMax, err, now)
 		return err
 	}
 	// Success: clear backoff, update the last-published cache.
@@ -772,6 +825,7 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 	rt.lastErr = ""
 	rt.lastErrAt = time.Time{}
 	rt.noBackend = false
+	rt.withdrawUnsupported = false
 	return nil
 }
 
@@ -1071,8 +1125,13 @@ func (m *SurfaceAManager) backendForOwned(owned ownedRecord, catalog map[string]
 // recordScopeError records a failure on a scope and advances its flat error
 // backoff (inadyn idea #8): nextEligible = now + backoff, doubling from
 // surfaceABaseBackoff up to the cap. Surfaced via lastErr for observability.
-func (m *SurfaceAManager) recordScopeError(rt *surfaceAState, sc SurfaceAScope, err error, now time.Time) {
-	maxBackoff := sc.ErrorBackoffMax
+//
+// Shared by the publish AND both withdraw paths (#2813): a scope is only ever a
+// publish OR a withdraw candidate at one time, so one per-scope backoff slot is
+// correct. fqdn is for the log line; maxBackoff is the per-binding cap (0 ⇒ the
+// package default, which is what the gone-from-config withdraw uses since its
+// binding — and its configured cap — is gone).
+func (m *SurfaceAManager) recordScopeError(rt *surfaceAState, fqdn string, maxBackoff time.Duration, err error, now time.Time) {
 	if maxBackoff <= 0 {
 		maxBackoff = defaultErrorBackoffMax
 	}
@@ -1088,8 +1147,54 @@ func (m *SurfaceAManager) recordScopeError(rt *surfaceAState, sc SurfaceAScope, 
 	rt.lastErr = err.Error()
 	rt.lastErrAt = now
 	rt.noBackend = false
-	slog.Warn("ddns surface-a: scope publish failed; backing off",
-		"fqdn", sc.FQDN, "backoff", rt.backoff, "err", err)
+	slog.Warn("ddns surface-a: scope DNS update failed; backing off",
+		"fqdn", fqdn, "backoff", rt.backoff, "err", err)
+}
+
+// withdrawScopeLocked drives ONE withdraw of an owned record through `backend`
+// under the SAME per-scope backoff machinery the publish path uses (#2813). The
+// caller MUST have already passed the backoff-window / terminal checks (so this
+// is invoked only when the scope is eligible to attempt the wire delete) and
+// holds m.mu. Outcomes:
+//
+//   - success: withdrawOwnedLocked already dropped the durable ownership AND the
+//     runtime entry, so the scope's error/backoff state is implicitly cleared;
+//     return nil.
+//   - errGenericDeleteUnsupported: the backend can NEVER withdraw (no portable
+//     delete verb, #2772/#2811). Mark the scope terminal (a single warn, no
+//     exponential-backoff churn) and SWALLOW the error so the reconcile pass does
+//     not warn every sweep; ownership is kept (the RR stays operator-visible).
+//   - any other (transient) failure: arm the shared exponential backoff and
+//     RETURN the error so the pass reports it ONCE per eligible attempt — the
+//     backoff window then skips the next sweeps, collapsing the per-sweep spam.
+func (m *SurfaceAManager) withdrawScopeLocked(ctx context.Context, owned ownedRecord, backend DNSUpdater, rt *surfaceAState, fqdn string, maxBackoff time.Duration, now time.Time) error {
+	err := m.withdrawOwnedLocked(ctx, owned, backend)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errGenericDeleteUnsupported) {
+		m.markWithdrawUnsupported(rt, fqdn, now)
+		return nil
+	}
+	m.recordScopeError(rt, fqdn, maxBackoff, err, now)
+	return err
+}
+
+// markWithdrawUnsupported flags a scope whose backend has no withdraw verb so
+// the withdraw is attempted at most once (#2813). It is idempotent — the single
+// warn fires only on the first transition — and records the reason for the
+// status surface. The scope KEEPS ownership; the abandoned RR stays
+// operator-visible. The flag is cleared by a successful publish (the full rt
+// reset) or a restart (the runtime cache is rebuilt from the durable store).
+func (m *SurfaceAManager) markWithdrawUnsupported(rt *surfaceAState, fqdn string, now time.Time) {
+	rt.lastErr = errGenericDeleteUnsupported.Error()
+	rt.lastErrAt = now
+	if rt.withdrawUnsupported {
+		return
+	}
+	rt.withdrawUnsupported = true
+	slog.Warn("ddns surface-a: backend has no withdraw verb; abandoning withdraw retries (record kept, operator-visible)",
+		"fqdn", fqdn)
 }
 
 // StatusViews returns a stable-ordered snapshot of EVERY configured Surface A

--- a/pkg/ddns/surface_a_withdraw_backoff_2813_test.go
+++ b/pkg/ddns/surface_a_withdraw_backoff_2813_test.go
@@ -1,0 +1,196 @@
+package ddns
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// #2813: a persistently-failing Surface A WITHDRAW must participate in the SAME
+// per-scope error-backoff machinery the publish path uses, instead of
+// re-attempting (and warning) on every 30s reconcile sweep. These are the
+// fail-on-revert proofs: removing the withdraw-path backoff arming makes
+// TestSurfaceAWithdrawBacksOff* go RED (the backend is re-hit every sweep).
+
+// genericDeleteUnsupportedUpdater upserts successfully but FAILS every delete
+// with errGenericDeleteUnsupported — modelling the generic HTTP backend that
+// has no portable withdraw verb (#2772/#2811). Used to prove the terminal
+// (attempt-once) classification.
+type genericDeleteUnsupportedUpdater struct {
+	upserts int
+	deletes int
+}
+
+func (u *genericDeleteUnsupportedUpdater) UpsertLease(_ context.Context, _ LeaseDNSRecord) error {
+	u.upserts++
+	return nil
+}
+
+func (u *genericDeleteUnsupportedUpdater) DeleteLease(_ context.Context, rec LeaseDNSRecord) error {
+	u.deletes++
+	return fmt.Errorf("generic: cannot withdraw %s: %w", rec.FQDN, errGenericDeleteUnsupported)
+}
+
+// publishOneScope publishes a scope so the manager owns a record for it, then
+// returns the scope. Upserts succeed (failDel is set by the caller afterwards).
+func publishOneScope(t *testing.T, m *SurfaceAManager) SurfaceAScope {
+	t.Helper()
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("initial publish Reconcile: %v", err)
+	}
+	if st := m.Stats(); st.Scopes != 1 || st.UpsertOK != 1 {
+		t.Fatalf("expected one owned scope after publish, got %+v", st)
+	}
+	return sc
+}
+
+// TestSurfaceAWithdrawBacksOffGoneFromConfig drives the Pass-2 (binding removed
+// from config) withdraw path. A delete that always fails must arm the per-scope
+// backoff so the backend is NOT re-hit on every sweep — the attempt count over N
+// sweeps is bounded by the doubling backoff schedule, not N.
+func TestSurfaceAWithdrawBacksOffGoneFromConfig(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+
+	publishOneScope(t, m)
+	// Now every delete fails (a persistently-failing provider withdraw).
+	fu.failDel["wan.example.net"] = true
+
+	const sweeps = 12
+	for i := 0; i < sweeps; i++ {
+		now = now.Add(surfaceABaseBackoff) // one 30s sweep
+		// Empty config: the owned record is gone-from-config → Pass 2 withdraw.
+		_ = m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, nil)
+	}
+
+	// Without backoff the backend is hit on EVERY sweep (sweeps failed deletes).
+	// With backoff (30s base, doubling) only a handful land inside the window.
+	st := m.Stats()
+	if fu.failedCalls >= sweeps {
+		t.Fatalf("withdraw must back off, not re-attempt every sweep; got %d delete attempts over %d sweeps",
+			fu.failedCalls, sweeps)
+	}
+	if fu.failedCalls == 0 {
+		t.Fatalf("expected at least one withdraw attempt; got 0")
+	}
+	if st.BackedOff == 0 {
+		t.Fatalf("expected backed-off skips to be counted; stats %+v", st)
+	}
+	// Ownership is KEPT for retry (a failing withdraw must not orphan the record).
+	if st.Scopes != 1 {
+		t.Fatalf("a failing withdraw must keep ownership; got %d scopes", st.Scopes)
+	}
+}
+
+// TestSurfaceAWithdrawBacksOffAddressLoss drives the Pass-1 (address lost)
+// withdraw path: the scope stays configured but its address is gone, so the
+// engine withdraws. A failing delete must arm the same per-scope backoff.
+func TestSurfaceAWithdrawBacksOffAddressLoss(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+
+	sc := publishOneScope(t, m)
+	fu.failDel["wan.example.net"] = true
+
+	// Observer now reports a definitive "no address" (ok=true, invalid Addr) →
+	// the engine withdraws the previously-published record.
+	lost := func(SurfaceAScope) (AddressObservation, bool) {
+		return AddressObservation{Source: AddressSourceDHCP}, true
+	}
+
+	const sweeps = 12
+	for i := 0; i < sweeps; i++ {
+		now = now.Add(surfaceABaseBackoff)
+		_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, lost, nil, nil)
+	}
+
+	st := m.Stats()
+	if fu.failedCalls >= sweeps {
+		t.Fatalf("address-loss withdraw must back off; got %d attempts over %d sweeps",
+			fu.failedCalls, sweeps)
+	}
+	if fu.failedCalls == 0 {
+		t.Fatalf("expected at least one withdraw attempt; got 0")
+	}
+	if st.BackedOff == 0 {
+		t.Fatalf("expected backed-off skips to be counted; stats %+v", st)
+	}
+	if st.Scopes != 1 {
+		t.Fatalf("a failing withdraw must keep ownership; got %d scopes", st.Scopes)
+	}
+}
+
+// TestSurfaceAWithdrawRetriesAfterBackoffThenSucceeds proves the backoff does
+// NOT over-suppress: a withdraw that fails transiently is retried after the
+// backoff window and, once the backend recovers, succeeds and CLEARS the
+// per-scope backoff state (the record is actually withdrawn — no leaked
+// ownership).
+func TestSurfaceAWithdrawRetriesAfterBackoffThenSucceeds(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+
+	publishOneScope(t, m)
+	fu.failDel["wan.example.net"] = true
+
+	// First gone-from-config sweep: attempt the withdraw, it fails, backoff armed.
+	now = now.Add(surfaceABaseBackoff)
+	_ = m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, nil)
+	if fu.failedCalls != 1 {
+		t.Fatalf("expected one failed withdraw attempt, got %d", fu.failedCalls)
+	}
+	if got := len(fu.deletes); got != 0 {
+		t.Fatalf("a failed withdraw records no successful delete; got %d", got)
+	}
+
+	// Immediately again (still inside the backoff window): the backend is NOT hit.
+	now = now.Add(time.Second)
+	_ = m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, nil)
+	if fu.failedCalls != 1 {
+		t.Fatalf("scope in backoff window must not re-hit the backend; attempts %d", fu.failedCalls)
+	}
+
+	// The backend recovers; advance well past the backoff window.
+	delete(fu.failDel, "wan.example.net")
+	now = now.Add(time.Hour)
+	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("recovered withdraw Reconcile returned error: %v", err)
+	}
+	if got := len(fu.deletes); got != 1 {
+		t.Fatalf("after backoff the withdraw must retry and succeed; got %d successful deletes", got)
+	}
+	// Success cleared ownership — the record is gone, not leaked.
+	if st := m.Stats(); st.Scopes != 0 || st.DeleteOK != 1 {
+		t.Fatalf("a successful withdraw must drop ownership; stats %+v", st)
+	}
+}
+
+// TestSurfaceAWithdrawUnsupportedIsTerminal proves errGenericDeleteUnsupported is
+// treated as terminal: the wire delete is attempted at MOST once and never
+// retried (no per-sweep churn), while ownership is kept so the abandoned record
+// stays operator-visible.
+func TestSurfaceAWithdrawUnsupportedIsTerminal(t *testing.T) {
+	up := &genericDeleteUnsupportedUpdater{}
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, up, func() time.Time { return now })
+
+	publishOneScope(t, m)
+
+	const sweeps = 8
+	for i := 0; i < sweeps; i++ {
+		now = now.Add(surfaceABaseBackoff)
+		_ = m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, nil)
+	}
+
+	if up.deletes != 1 {
+		t.Fatalf("an unsupported withdraw verb must be attempted at most once; got %d delete attempts", up.deletes)
+	}
+	// Ownership is kept (the abandoned RR stays operator-visible).
+	if st := m.Stats(); st.Scopes != 1 {
+		t.Fatalf("an unsupported withdraw must keep ownership; got %d scopes", st.Scopes)
+	}
+}


### PR DESCRIPTION
Closes #2813

## Problem
A permanently-failing Surface A withdraw re-attempted on every 30s reconcile sweep and emitted one `slog.Warn` per sweep (~2880 log lines/day/scope), because neither withdraw path armed the per-scope `recordScopeError` backoff the *publish* path uses. #2811 made this reachable for the HTTP backends — the generic backend returns `errGenericDeleteUnsupported` (no portable delete verb) so a withdrawn generic scope never drops ownership and re-attempts forever; a dyndns2 provider ignoring `offline=YES` or a persistently-failing rfc2136/cloudflare/route53 delete is the same unbounded loop.

## Fix
Both withdraw paths now share the SAME per-scope flat exponential backoff (30s → 1h cap) the publish path uses, via a shared `withdrawScopeLocked` helper:
- **Pass-1 address-loss** (`reconcileScopeLocked`) and **Pass-2 gone-from-config** (`Reconcile`) arm `recordScopeError` on a transient failure and skip the re-attempt + warn while inside the backoff window.
- A withdraw **success** clears the scope's backoff/error state (no over-suppression, no leaked ownership — a recoverable withdraw is never abandoned).

**Backoff-slot reuse:** a scope is only ever a publish OR a withdraw candidate at one time (a gone-from-config scope is absent from `desired` and never reaches Pass 1), so a single shared per-scope slot is correct — no withdraw-specific slot. `recordScopeError` was refactored to take `(fqdn, maxBackoff)` so the binding-less Pass-2 withdraw can call it (default cap).

**`errGenericDeleteUnsupported` decision:** TERMINAL, not backed off. The generic backend can never withdraw, so re-attempting on any cadence is pointless — `markWithdrawUnsupported` attempts the wire delete at most once, emits a single warn, and keeps ownership (the abandoned RR stays operator-visible). The mark clears on a successful publish or restart, so a later provider change that adds a delete verb is re-probed.

## Tests (`pkg/ddns/surface_a_withdraw_backoff_2813_test.go`)
- `TestSurfaceAWithdrawBacksOffGoneFromConfig` / `TestSurfaceAWithdrawBacksOffAddressLoss` — attempt count over N sweeps bounded by the backoff schedule, `BackedOff` counted, ownership kept.
- `TestSurfaceAWithdrawRetriesAfterBackoffThenSucceeds` — retried after the window; success drops ownership (no over-suppression).
- `TestSurfaceAWithdrawUnsupportedIsTerminal` — attempted at most once, ownership kept.

**Fail-on-revert:** removing the withdraw backoff arming turned both `BacksOff` tests RED (12 attempts over 12 sweeps); restored byte-identical.

`go build ./...` + `go test ./pkg/ddns/... ./pkg/daemon/...` green (837 tests). Updated `pkg/ddns/README.md` + `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi