### PR TITLE
nat: support block-to-block (subnet) static NAT, 1:1 by offset

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-06-26 — #3031 static-NAT block-to-block (subnet) mappings
+
+- **Timestamp**: 2026-06-26
+- **Action**: Implement block-to-block (subnet) static NAT, 1:1 by offset.
+  `parse_nat_addr` rejected any non-host prefix, so a valid Junos
+  `static-nat prefix <subnet>` rule (e.g. `198.51.100.0/24 -> 192.168.1.0/24`)
+  was silently dropped during Rust snapshot parsing. Replaced with
+  `parse_nat_prefix` (returns base + len, canonicalizes host bits); host
+  (`/32`/`/128`/bare) keeps the exact-IP map path byte-identical. A
+  non-host pair installs a `StaticNatBlock` (Vec, linear-scanned on the
+  cold path) ONLY when the source/destination prefixes are the same family
+  and equal length; mismatched-length / mixed-family pairs are skipped
+  (#2122 rationale). Forward DNAT and reverse SNAT remap by offset
+  (`dst_base | (addr & host_mask(len))`), v4 (u32) and v6 (u128), with
+  `len >= max` shift guards. The decision still carries only
+  `rewrite_dst`/`rewrite_src` (an `IpAddr`), so the existing host static-NAT
+  checksum fixup applies unchanged. Relaxed the Go strict commit gate
+  (`validateNATHostMaskStrict`) to accept an equal-length block pair
+  (`isStaticBlockPair`) while still rejecting the invalid non-host cases.
+- **File(s)**: userspace-dp/src/nat/static_nat.rs, userspace-dp/src/nat/tests.rs,
+  pkg/config/compiler_nat.go, pkg/config/compiler_nat_host_mask_test.go,
+  docs/feature-gaps.md
+- **Validation**: cargo build --release (0 errors); cargo test --release
+  nat:: (143 passed). New Rust tests: block dnat/snat v4 offset, v6 both
+  directions, outside-block no-translate, mismatched-length skip, host /32
+  regression — fail-on-revert confirmed (host-only parse → 3 block tests
+  RED, host regression GREEN). go build ./... + go test ./pkg/config/
+  (1703 passed); new Go tests for block compile / mismatch+mixed-family
+  reject / isStaticBlockPair unit.
+
 ## 2026-06-26 — #2981 V_min lag throttle skips UNSHAPED shared-exact queues
 
 - **Timestamp**: 2026-06-26

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -166,7 +166,7 @@ User-based policy enforcement integrating with directory services. Not implement
 
 ## 8. NAT Enhancements
 
-xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, protocol-only match, port rewriting, multi-port matching), static 1:1, NAT64, and exemption rules. These are additional NAT features from the vSRX.
+xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, protocol-only match, port rewriting, multi-port matching), static 1:1 (host AND block-to-block subnet mappings, #3031), NAT64, and exemption rules. These are additional NAT features from the vSRX.
 
 > **DNAT `match destination-address` is exact-host only (#3029).** The
 > userspace `DnatTable` keys on an exact destination `IpAddr` (no prefix /
@@ -179,8 +179,14 @@ xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT
 > no-brick). Single-host destinations (a bare IP, an explicit `/32`, or
 > `/128`) are accepted unchanged. Block-to-block destination NAT (the Junos
 > 1:1-offset / many:one block-mapping semantics) is a separate dataplane
-> feature — see #3029 (and the static-NAT block sibling #3031); honoring a
-> DNAT destination prefix needs a prefix-match table plus confirmed Junos
+> feature — see #3029. This is the DNAT-table limitation only; the
+> **static-NAT** sibling block mapping (`static-nat prefix <subnet>`, 1:1
+> by offset) is now **supported** (#3031): an equal-length source/
+> destination prefix pair installs an offset-preserving `StaticNatTable`
+> block rule (forward DNAT + reverse SNAT, host bits preserved), and the
+> commit gate accepts the valid equal-length pair while still rejecting
+> mismatched-length / mixed-family pairs. Honoring a DNAT destination
+> prefix still needs a prefix-match table plus confirmed Junos
 > block-mapping semantics.
 
 > **NAT64 inbound policy matches the SYNTHETIC IPv6 destination, not the

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -119,6 +119,56 @@ func isHostMaskAddress(addr string) (host bool, parsed bool) {
 	return maskPart == wantMask, true
 }
 
+// natStaticPrefixInfo classifies a static-NAT address the way the Rust
+// parse_nat_prefix (static_nat.rs, #3031) does: it returns the family, the
+// prefix length, whether the value is a host route, and whether it parsed as
+// an IP at all. A bare address is a host route (len == max). A `/N` mask is
+// parsed numerically; bits < 0 flags a malformed/out-of-range mask (a
+// non-numeric or `/33`/`/129` suffix) so the caller leaves the existing
+// host-route rejection to fire. A non-IP token (address-book name) returns
+// parsedIP == false and is not this validator's concern.
+func natStaticPrefixInfo(addr string) (fam string, bits int, isHost, parsedIP bool) {
+	slash := strings.IndexByte(addr, '/')
+	ipPart := addr
+	if slash >= 0 {
+		ipPart = addr[:slash]
+	}
+	fam = natAddrFamily(ipPart)
+	if fam == "" {
+		return "", -1, false, false
+	}
+	max := 128
+	if fam == "v4" {
+		max = 32
+	}
+	if slash < 0 {
+		return fam, max, true, true
+	}
+	n, err := strconv.Atoi(addr[slash+1:])
+	if err != nil || n < 0 || n > max {
+		return fam, -1, false, true
+	}
+	return fam, n, n == max, true
+}
+
+// isStaticBlockPair reports whether (match, then) is a valid block-to-block
+// (subnet) static-NAT 1:1 mapping (#3031): both sides parse as IPs, both are
+// non-host prefixes of the SAME family with EQUAL prefix length. The Rust
+// dataplane installs exactly this case (offset-preserving remap); a
+// host-vs-block, mismatched-length, mixed-family, or malformed-mask pair is
+// NOT a block pair and falls through to the existing host-route rejection.
+func isStaticBlockPair(match, then string) bool {
+	mf, mb, mh, mp := natStaticPrefixInfo(match)
+	tf, tb, th, tp := natStaticPrefixInfo(then)
+	if !mp || !tp {
+		return false // a non-IP token — leave to existing handling
+	}
+	if mh || th || mb < 0 || tb < 0 {
+		return false // a host side or a malformed mask — not a block pair
+	}
+	return mf == tf && mb == tb
+}
+
 // isNAT64PoolHostAddress reports whether addr is an IPv4 host route the
 // NAT64 source pool can install. It mirrors EXACTLY the Rust parse_pool_v4
 // gate (userspace-dp/src/nat64.rs): the NAT64 pool holds IPv4 source
@@ -247,7 +297,14 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 			if rule.Then == "inet" {
 				continue
 			}
-			if rule.Match != "" {
+			// #3031: a valid block-to-block (subnet) static-NAT rule —
+			// equal-length non-host prefixes of the same family — is now
+			// installed by the dataplane (offset-preserving 1:1 remap), so do
+			// NOT reject it as a non-host mask. Only the genuinely-invalid
+			// non-host cases (host-vs-block, mismatched length, mixed family,
+			// malformed mask) fall through to the host-route rejection below.
+			blockPair := isStaticBlockPair(rule.Match, rule.Then)
+			if rule.Match != "" && !blockPair {
 				if host, parsed := isHostMaskAddress(rule.Match); parsed && !host {
 					if err := emit(fmt.Sprintf(
 						"security nat static rule-set %q rule %q match destination-address %q must be a host route (/32 for IPv4, /128 for IPv6); a non-host mask is silently dropped by the dataplane",
@@ -256,7 +313,7 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 					}
 				}
 			}
-			if rule.Then != "" {
+			if rule.Then != "" && !blockPair {
 				if host, parsed := isHostMaskAddress(rule.Then); parsed && !host {
 					if err := emit(fmt.Sprintf(
 						"security nat static rule-set %q rule %q then static-nat prefix %q must be a host route (/32 for IPv4, /128 for IPv6); a non-host mask is silently dropped by the dataplane",

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -378,3 +378,66 @@ func TestIsNAT64PoolHostAddress(t *testing.T) {
 		}
 	}
 }
+
+// #3031: a valid block-to-block (subnet) static-NAT rule — equal-length
+// non-host prefixes of the same family — must now COMPILE (the dataplane
+// installs an offset-preserving 1:1 remap). It was previously rejected by the
+// host-mask gate.
+func TestStaticNATBlockToBlockV4Compiles(t *testing.T) {
+	tree := buildTree(t, staticNATSet("198.51.100.0/24", "192.168.1.0/24"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("equal-length /24->/24 block static-NAT must compile, got: %v", err)
+	}
+}
+
+func TestStaticNATBlockToBlockV6Compiles(t *testing.T) {
+	tree := buildTree(t, staticNATSet("2001:db8:a::/120", "fd00:1::/120"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("equal-length /120->/120 v6 block static-NAT must compile, got: %v", err)
+	}
+}
+
+// A mismatched-length pair (/24 -> /25) is NOT a 1:1 block map and stays
+// rejected — the dataplane skips it, so the commit gate must surface it.
+func TestStaticNATBlockMismatchedLengthRejected(t *testing.T) {
+	tree := buildTree(t, staticNATSet("198.51.100.0/24", "192.168.1.0/25"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("mismatched-length block static-NAT (/24 -> /25) must be rejected")
+	}
+	if !strings.Contains(err.Error(), "host route") {
+		t.Fatalf("error must still cite the host-route rule, got: %v", err)
+	}
+}
+
+// A mixed-family pair (v4 -> v6) is not a block map and stays rejected.
+func TestStaticNATBlockMixedFamilyRejected(t *testing.T) {
+	tree := buildTree(t, staticNATSet("198.51.100.0/24", "2001:db8::/120"))
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("mixed-family block static-NAT (v4 -> v6) must be rejected")
+	}
+}
+
+// isStaticBlockPair unit coverage.
+func TestIsStaticBlockPair(t *testing.T) {
+	cases := []struct {
+		match, then string
+		want        bool
+	}{
+		{"198.51.100.0/24", "192.168.1.0/24", true},  // equal-length block pair
+		{"2001:db8:a::/120", "fd00:1::/120", true},   // v6 equal-length pair
+		{"198.51.100.0/24", "192.168.1.0/25", false}, // mismatched length
+		{"198.51.100.0/24", "2001:db8::/120", false}, // mixed family
+		{"203.0.113.5/32", "10.0.0.5/32", false},     // both host
+		{"203.0.113.5", "10.0.0.5", false},           // bare hosts
+		{"203.0.113.5/32", "10.0.0.0/24", false},     // host vs block
+		{"198.51.100.0/24", "10.0.0.5/32", false},    // block vs host
+		{"198.51.100.0/33", "192.168.1.0/24", false}, // malformed mask
+		{"book-name", "192.168.1.0/24", false},       // non-IP token
+	}
+	for _, c := range cases {
+		if got := isStaticBlockPair(c.match, c.then); got != c.want {
+			t.Errorf("isStaticBlockPair(%q, %q) = %v, want %v", c.match, c.then, got, c.want)
+		}
+	}
+}

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -3,7 +3,7 @@
 use super::{NatCounterStore, NatDecision, NatRuleCounter};
 use crate::StaticNATRuleSnapshot;
 use rustc_hash::FxHashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 
 /// Static 1:1 NAT entry (bidirectional).
@@ -38,37 +38,158 @@ pub(crate) struct StaticNatTable {
     /// is the internal source port of the return packet (`Some` for a
     /// port-mapped rule, `None` for a whole-address rule).
     snat: FxHashMap<(IpAddr, Option<u16>), StaticNatEntry>,
+    /// #3031: block-to-block (subnet) static-NAT rules. A source prefix maps
+    /// 1:1 by offset to an equal-length destination prefix. These cannot be
+    /// keyed by exact IP, so they are scanned linearly on the session-miss
+    /// cold path (block rules are rare). Exact host entries above take
+    /// precedence over an overlapping block.
+    blocks: Vec<StaticNatBlock>,
+}
+
+/// #3031: a block-to-block static-NAT rule. `external` (the public side) and
+/// `internal` (the private side) are equal-length prefixes; a host H in one
+/// block maps to the same offset in the other (network bits replaced, host
+/// bits preserved). Bidirectional, exactly like the host [`StaticNatEntry`].
+#[derive(Clone, Debug)]
+pub(crate) struct StaticNatBlock {
+    /// External (public) prefix — matched on inbound DNAT (`dst_ip`).
+    external: NatPrefix,
+    /// Internal (private) prefix — matched on outbound SNAT (`src_ip`).
+    internal: NatPrefix,
+    /// Rule's `from zone` external-zone constraint (empty = any zone),
+    /// gated exactly like the host entry's `from_zone`.
+    from_zone: String,
+    /// Per-rule translation hit counter (#2218); None for counter_id 0.
+    hit_counter: Option<Arc<NatRuleCounter>>,
+}
+
+/// Host mask (the low `32-len` bits set) for an IPv4 prefix of `len`
+/// network bits. Guards the `len >= 32` shift: `u32::MAX >> 32` is UB
+/// (release-mode masks the shift amount to 0, a no-op) so a host route
+/// (`len == 32`, no host bits) returns `0` explicitly.
+fn host_mask_v4(len: u8) -> u32 {
+    if len >= 32 {
+        0
+    } else {
+        u32::MAX >> len
+    }
+}
+
+/// Host mask for an IPv6 prefix of `len` network bits. Same `len >= 128`
+/// shift guard as [`host_mask_v4`].
+fn host_mask_v6(len: u8) -> u128 {
+    if len >= 128 {
+        0
+    } else {
+        u128::MAX >> len
+    }
+}
+
+/// A parsed static-NAT prefix: a canonical network base plus the prefix
+/// length. A host route (bare address, `/32`, `/128`) has `len == max` for
+/// its family.
+#[derive(Clone, Copy, Debug)]
+struct NatPrefix {
+    base: IpAddr,
+    len: u8,
+}
+
+impl NatPrefix {
+    /// Maximum prefix length for the address family (32 v4 / 128 v6).
+    fn max_len(&self) -> u8 {
+        match self.base {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        }
+    }
+
+    /// True when this is a host route (`/32` v4, `/128` v6) — the legacy
+    /// exact 1:1 static-NAT case.
+    fn is_host(&self) -> bool {
+        self.len == self.max_len()
+    }
+
+    /// True when `addr` falls within this prefix (same family, network bits
+    /// equal). A cross-family compare is never in-prefix.
+    fn contains(&self, addr: IpAddr) -> bool {
+        match (self.base, addr) {
+            (IpAddr::V4(b), IpAddr::V4(a)) => {
+                let hm = host_mask_v4(self.len);
+                (u32::from(a) & !hm) == u32::from(b)
+            }
+            (IpAddr::V6(b), IpAddr::V6(a)) => {
+                let hm = host_mask_v6(self.len);
+                (u128::from(a) & !hm) == u128::from(b)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Remap `addr` (which lives in the `src` prefix) into the `dst` prefix,
+/// preserving the host bits (offset within the block) and replacing the
+/// network bits: `dst_base | (addr & host_mask(src.len))`. `src.len` and
+/// `dst.len` are equal by construction (enforced in `from_snapshots`), so
+/// the host mask is shared. Returns `None` only on a family mismatch
+/// (never happens for a validated block rule).
+fn remap_addr(addr: IpAddr, src: &NatPrefix, dst: &NatPrefix) -> Option<IpAddr> {
+    match (addr, dst.base) {
+        (IpAddr::V4(a), IpAddr::V4(d)) => {
+            let hm = host_mask_v4(src.len);
+            Some(IpAddr::V4(Ipv4Addr::from(
+                (u32::from(d) & !hm) | (u32::from(a) & hm),
+            )))
+        }
+        (IpAddr::V6(a), IpAddr::V6(d)) => {
+            let hm = host_mask_v6(src.len);
+            Some(IpAddr::V6(Ipv6Addr::from(
+                (u128::from(d) & !hm) | (u128::from(a) & hm),
+            )))
+        }
+        _ => None,
+    }
 }
 
 /// Parse a static-NAT address that may carry a canonical host mask
-/// (`x.x.x.x/32`, `addr/128`). Junos emits static-NAT match/then in
-/// canonical prefix form, and the Go compiler copies that mask verbatim
-/// into the snapshot; `IpAddr::from_str` REJECTS CIDR notation, so the mask
-/// must be stripped before the parse or the rule is silently dropped (#2122).
+/// (`x.x.x.x/32`, `addr/128`) OR a block prefix (`198.51.100.0/24`). Junos
+/// emits static-NAT match/then in canonical prefix form and the Go compiler
+/// copies that mask verbatim into the snapshot; `IpAddr::from_str` REJECTS
+/// CIDR notation, so the mask must be stripped before the parse or the rule
+/// is silently dropped (#2122).
 ///
-/// Static NAT is an exact `IpAddr -> IpAddr` 1:1 mapping, so the ONLY
-/// meaningful mask is the host mask. We accept a bare address or a host mask
-/// (`/32` for v4, `/128` for v6) and reject any other suffix — a non-host
-/// prefix (`/24`), a non-numeric mask, a trailing/empty/double slash etc.
-/// would silently translate the wrong scope, so it is a misconfiguration to
-/// surface (skip), not to coerce to a host route. A genuinely-malformed
-/// address likewise returns `None`, preserving the caller's skip-on-invalid
-/// behavior.
-fn parse_nat_addr(s: &str) -> Option<IpAddr> {
+/// #3031: a non-host prefix is no longer rejected. A bare address / `/32` /
+/// `/128` parses to a host route (`len == max`, the legacy exact 1:1 case);
+/// a shorter prefix parses to a block (`len < max`) whose base is
+/// canonicalized to the network address (host bits beyond the prefix length
+/// are masked off so the offset remap and `contains` use a clean base even
+/// if the operator authored host bits). A non-numeric mask, an out-of-range
+/// length (`/33`, `/129`), or a malformed address still returns `None`,
+/// preserving the caller's skip-on-invalid behavior. Whether a parsed
+/// block is INSTALLED is decided in `from_snapshots` (equal-length 1:1
+/// pairs only).
+fn parse_nat_prefix(s: &str) -> Option<NatPrefix> {
     let mut parts = s.splitn(2, '/');
     let addr: IpAddr = parts.next()?.parse().ok()?;
-    match parts.next() {
-        // Bare address — no mask.
-        None => Some(addr),
-        // Host mask only: /32 for v4, /128 for v6. Anything else is rejected.
+    let max = match addr {
+        IpAddr::V4(_) => 32u8,
+        IpAddr::V6(_) => 128u8,
+    };
+    let len = match parts.next() {
+        // Bare address — a host route.
+        None => max,
         Some(mask) => {
-            let host_len = match addr {
-                IpAddr::V4(_) => "32",
-                IpAddr::V6(_) => "128",
-            };
-            if mask == host_len { Some(addr) } else { None }
+            let len: u8 = mask.parse().ok()?;
+            if len > max {
+                return None;
+            }
+            len
         }
-    }
+    };
+    let base = match addr {
+        IpAddr::V4(a) => IpAddr::V4(Ipv4Addr::from(u32::from(a) & !host_mask_v4(len))),
+        IpAddr::V6(a) => IpAddr::V6(Ipv6Addr::from(u128::from(a) & !host_mask_v6(len))),
+    };
+    Some(NatPrefix { base, len })
 }
 
 impl StaticNatTable {
@@ -78,14 +199,38 @@ impl StaticNatTable {
     ) -> Self {
         let mut table = StaticNatTable::default();
         for snap in snaps {
-            let external_ip: IpAddr = match parse_nat_addr(&snap.external_ip) {
-                Some(ip) => ip,
+            let ext_prefix = match parse_nat_prefix(&snap.external_ip) {
+                Some(p) => p,
                 None => continue,
             };
-            let internal_ip: IpAddr = match parse_nat_addr(&snap.internal_ip) {
-                Some(ip) => ip,
+            let int_prefix = match parse_nat_prefix(&snap.internal_ip) {
+                Some(p) => p,
                 None => continue,
             };
+            // #3031: a non-host prefix on EITHER side is a block-to-block
+            // (subnet) static-NAT rule. A valid block map needs equal-length
+            // prefixes of the SAME family (1:1 by offset). A host-vs-block or
+            // mismatched-length or mixed-family pair is a genuine misconfig —
+            // skip it with the #2122 rationale (the Go strict commit-check
+            // rejects it; this is the lenient-load / peer-sync backstop). The
+            // legacy host (both `/32`/`/128`/bare) case falls through to the
+            // exact-IP map path below, byte-identical to pre-#3031.
+            if !ext_prefix.is_host() || !int_prefix.is_host() {
+                if ext_prefix.base.is_ipv4() != int_prefix.base.is_ipv4()
+                    || ext_prefix.len != int_prefix.len
+                {
+                    continue;
+                }
+                table.blocks.push(StaticNatBlock {
+                    external: ext_prefix,
+                    internal: int_prefix,
+                    from_zone: snap.from_zone.clone(),
+                    hit_counter: nat_counters.rule_counter(snap.counter_id),
+                });
+                continue;
+            }
+            let external_ip: IpAddr = ext_prefix.base;
+            let internal_ip: IpAddr = int_prefix.base;
             // #2491: a `mapped_port` without a `match_destination_port` has no
             // inbound trigger (no external port to match) and the reverse SNAT
             // cannot recover the original port, so fail CLOSED: drop the port
@@ -176,20 +321,45 @@ impl StaticNatTable {
         // but only if its OWN zone check passes. On a port miss OR a
         // port-specific zone mismatch, fall back to the whole-address entry
         // (which is then zone-checked on its own).
-        let entry = self
+        if let Some(entry) = self
             .dnat
             .get(&(dst_ip, Some(dst_port)))
             .filter(zone_ok)
-            .or_else(|| self.dnat.get(&(dst_ip, None)).filter(zone_ok))?;
-        Some((
-            NatDecision {
-                rewrite_src: None,
-                rewrite_dst: Some(entry.internal_ip),
-                rewrite_dst_port: entry.mapped_port,
-                ..NatDecision::default()
-            },
-            entry.hit_counter.clone(),
-        ))
+            .or_else(|| self.dnat.get(&(dst_ip, None)).filter(zone_ok))
+        {
+            return Some((
+                NatDecision {
+                    rewrite_src: None,
+                    rewrite_dst: Some(entry.internal_ip),
+                    rewrite_dst_port: entry.mapped_port,
+                    ..NatDecision::default()
+                },
+                entry.hit_counter.clone(),
+            ));
+        }
+        // #3031: block-to-block DNAT. Exact host entries above take
+        // precedence; on a miss, scan the (rare) block rules. `dst_ip` in the
+        // external prefix translates to the same offset in the internal
+        // prefix (network bits replaced, host bits preserved). The decision
+        // carries only `rewrite_dst` (an `IpAddr`), so the existing host
+        // static-NAT checksum fixup path applies unchanged.
+        for blk in &self.blocks {
+            if (blk.from_zone.is_empty() || blk.from_zone == ingress_zone)
+                && blk.external.contains(dst_ip)
+            {
+                if let Some(translated) = remap_addr(dst_ip, &blk.external, &blk.internal) {
+                    return Some((
+                        NatDecision {
+                            rewrite_src: None,
+                            rewrite_dst: Some(translated),
+                            ..NatDecision::default()
+                        },
+                        blk.hit_counter.clone(),
+                    ));
+                }
+            }
+        }
+        None
     }
 
     /// Match outbound: if src_ip is an internal IP, return SNAT decision.
@@ -248,37 +418,70 @@ impl StaticNatTable {
         let zone_ok = |entry: &&StaticNatEntry| {
             entry.from_zone.is_empty() || entry.from_zone == egress_zone
         };
-        let entry = self
+        if let Some(entry) = self
             .snat
             .get(&(src_ip, Some(src_port)))
             .filter(zone_ok)
-            .or_else(|| self.snat.get(&(src_ip, None)).filter(zone_ok))?;
-        // For a port-mapped rule, un-translate the source port back to the
-        // external (pre-translation) port; for a whole-address rule this is
-        // `None` (no port rewrite).
-        let rewrite_src_port = entry.mapped_port.and(entry.match_dst_port);
-        Some((
-            NatDecision {
-                rewrite_src: Some(entry.external_ip),
-                rewrite_dst: None,
-                rewrite_src_port,
-                ..NatDecision::default()
-            },
-            entry.hit_counter.clone(),
-        ))
+            .or_else(|| self.snat.get(&(src_ip, None)).filter(zone_ok))
+        {
+            // For a port-mapped rule, un-translate the source port back to the
+            // external (pre-translation) port; for a whole-address rule this is
+            // `None` (no port rewrite).
+            let rewrite_src_port = entry.mapped_port.and(entry.match_dst_port);
+            return Some((
+                NatDecision {
+                    rewrite_src: Some(entry.external_ip),
+                    rewrite_dst: None,
+                    rewrite_src_port,
+                    ..NatDecision::default()
+                },
+                entry.hit_counter.clone(),
+            ));
+        }
+        // #3031: block-to-block reverse SNAT — the inverse of the DNAT
+        // offset map. `src_ip` in the internal prefix translates back to the
+        // same offset in the external prefix, so the return path's source is
+        // un-NAT'd to the public block and the reverse session key matches.
+        for blk in &self.blocks {
+            if (blk.from_zone.is_empty() || blk.from_zone == egress_zone)
+                && blk.internal.contains(src_ip)
+            {
+                if let Some(translated) = remap_addr(src_ip, &blk.internal, &blk.external) {
+                    return Some((
+                        NatDecision {
+                            rewrite_src: Some(translated),
+                            rewrite_dst: None,
+                            ..NatDecision::default()
+                        },
+                        blk.hit_counter.clone(),
+                    ));
+                }
+            }
+        }
+        None
     }
 
     /// Returns true if the table has any entries.
     #[allow(dead_code)]
     pub(crate) fn is_empty(&self) -> bool {
-        self.dnat.is_empty()
+        self.dnat.is_empty() && self.blocks.is_empty()
     }
 
     /// Returns all external IPs (for local delivery recognition). #2491: the
     /// DNAT map is now keyed by `(IpAddr, Option<u16>)`; project the IP out.
     /// A given external IP appears once per distinct port mapping, which is
     /// fine for the consumers (they dedup or only test membership).
+    ///
+    /// #3031: also yields each block rule's external network base. A block's
+    /// inbound DNAT match is NOT gated on `local_v4`/`local_v6` membership
+    /// (the cold-path `match_dnat_with_counter` runs on transit regardless),
+    /// so emitting only the base — rather than expanding a whole (possibly
+    /// /16 or v6-huge) prefix into the local set — is sufficient parity for
+    /// the network address without an unbounded blow-up.
     pub(crate) fn external_ips(&self) -> impl Iterator<Item = &IpAddr> {
-        self.dnat.keys().map(|(ip, _)| ip)
+        self.dnat
+            .keys()
+            .map(|(ip, _)| ip)
+            .chain(self.blocks.iter().map(|b| &b.external.base))
     }
 }

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -643,6 +643,159 @@ fn static_nat_snat_matches_internal_ip_v6() {
     );
 }
 
+// #3031: block-to-block (subnet) static NAT — 1:1 by offset. A source
+// host maps to the same offset in the destination block (network bits
+// replaced, host bits preserved), both directions.
+
+fn block_snapshot(ext: &str, int: &str, from_zone: &str) -> StaticNATRuleSnapshot {
+    StaticNATRuleSnapshot {
+        counter_id: 0,
+        name: "block-1".to_string(),
+        from_zone: from_zone.to_string(),
+        external_ip: ext.to_string(),
+        internal_ip: int.to_string(),
+        match_destination_port: 0,
+        mapped_port: 0,
+    }
+}
+
+#[test]
+fn static_nat_block_dnat_v4_preserves_offset() {
+    // 198.51.100.0/24 (external) -> 192.168.1.0/24 (internal). An inbound
+    // packet to 198.51.100.7 DNATs to 192.168.1.7 (offset .7 preserved).
+    let table = StaticNatTable::from_snapshots(
+        &[block_snapshot("198.51.100.0/24", "192.168.1.0/24", "untrust")],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let decision = table.match_dnat("198.51.100.7".parse().expect("ext host"), "untrust");
+    assert_eq!(
+        decision,
+        Some(NatDecision {
+            rewrite_src: None,
+            rewrite_dst: Some("192.168.1.7".parse().expect("int host")),
+            ..NatDecision::default()
+        })
+    );
+}
+
+#[test]
+fn static_nat_block_snat_v4_reverses_offset() {
+    // Reverse: an outbound packet from 192.168.1.7 SNATs back to
+    // 198.51.100.7 (the inverse offset map), so return traffic matches.
+    let table = StaticNatTable::from_snapshots(
+        &[block_snapshot("198.51.100.0/24", "192.168.1.0/24", "untrust")],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let decision = table.match_snat("192.168.1.7".parse().expect("int host"), "untrust");
+    assert_eq!(
+        decision,
+        Some(NatDecision {
+            rewrite_src: Some("198.51.100.7".parse().expect("ext host")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+}
+
+#[test]
+fn static_nat_block_v6_preserves_offset_both_directions() {
+    // /120 -> /120 v6 block map. Offset ::7 preserved both directions.
+    let table = StaticNatTable::from_snapshots(
+        &[block_snapshot("2001:db8:a::/120", "fd00:1::/120", "untrust")],
+        &crate::nat::NatCounterStore::default(),
+    );
+    let dnat = table.match_dnat("2001:db8:a::7".parse().expect("ext v6"), "untrust");
+    assert_eq!(
+        dnat,
+        Some(NatDecision {
+            rewrite_src: None,
+            rewrite_dst: Some("fd00:1::7".parse().expect("int v6")),
+            ..NatDecision::default()
+        })
+    );
+    let snat = table.match_snat("fd00:1::7".parse().expect("int v6"), "untrust");
+    assert_eq!(
+        snat,
+        Some(NatDecision {
+            rewrite_src: Some("2001:db8:a::7".parse().expect("ext v6")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+}
+
+#[test]
+fn static_nat_block_does_not_translate_outside_source_block() {
+    // An address OUTSIDE the external block is not DNAT'd, and an address
+    // outside the internal block is not SNAT'd.
+    let table = StaticNatTable::from_snapshots(
+        &[block_snapshot("198.51.100.0/24", "192.168.1.0/24", "untrust")],
+        &crate::nat::NatCounterStore::default(),
+    );
+    assert_eq!(
+        table.match_dnat("198.51.101.7".parse().expect("outside ext"), "untrust"),
+        None
+    );
+    assert_eq!(
+        table.match_snat("192.168.2.7".parse().expect("outside int"), "untrust"),
+        None
+    );
+}
+
+#[test]
+fn static_nat_block_mismatched_length_is_skipped() {
+    // A /24 -> /25 pair is not a 1:1 block map; the rule is skipped (no
+    // table entry, no translation), preserving the #2122 skip rationale.
+    let table = StaticNatTable::from_snapshots(
+        &[block_snapshot("198.51.100.0/24", "192.168.1.0/25", "untrust")],
+        &crate::nat::NatCounterStore::default(),
+    );
+    assert!(table.is_empty());
+    assert_eq!(
+        table.match_dnat("198.51.100.7".parse().expect("ext host"), "untrust"),
+        None
+    );
+}
+
+#[test]
+fn static_nat_host_v4_unchanged_with_block_support() {
+    // #3031 regression: a /32 host rule still behaves byte-identical to
+    // pre-#3031 (exact 1:1, no offset math). Both directions.
+    let table = StaticNatTable::from_snapshots(
+        &[StaticNATRuleSnapshot {
+            counter_id: 0,
+            name: "static-1".to_string(),
+            from_zone: "untrust".to_string(),
+            external_ip: "203.0.113.10/32".to_string(),
+            internal_ip: "192.168.1.10/32".to_string(),
+            match_destination_port: 0,
+            mapped_port: 0,
+        }],
+        &crate::nat::NatCounterStore::default(),
+    );
+    assert_eq!(
+        table.match_dnat("203.0.113.10".parse().expect("ext"), "untrust"),
+        Some(NatDecision {
+            rewrite_src: None,
+            rewrite_dst: Some("192.168.1.10".parse().expect("int")),
+            ..NatDecision::default()
+        })
+    );
+    assert_eq!(
+        table.match_snat("192.168.1.10".parse().expect("int"), "untrust"),
+        Some(NatDecision {
+            rewrite_src: Some("203.0.113.10".parse().expect("ext")),
+            rewrite_dst: None,
+            ..NatDecision::default()
+        })
+    );
+    // A non-mapped host (not the /32) is not translated.
+    assert_eq!(
+        table.match_dnat("203.0.113.11".parse().expect("other"), "untrust"),
+        None
+    );
+}
+
 #[test]
 fn static_nat_zone_mismatch_returns_none_for_dnat() {
     let table = StaticNatTable::from_snapshots(


### PR DESCRIPTION
Closes #3031

## Problem
A Junos `static-nat prefix <subnet>` rule mapping a source block 1:1 to an equal-length destination block (e.g. `198.51.100.0/24 -> 192.168.1.0/24`) was **silently dropped** during Rust snapshot parsing. `parse_nat_addr` (`userspace-dp/src/nat/static_nat.rs`) accepted only a bare address or a host mask (`/32`, `/128`) and returned `None` for any other prefix; `from_snapshots` then `continue`d past the rule. The prefix compiled into the snapshot but the dataplane installed no translation and surfaced no error -- a real Junos feature lost to a silent no-op.

## Change
- **`parse_nat_prefix`** replaces `parse_nat_addr`: returns a base address + prefix length, canonicalizing host bits off the base. A host route (bare / `/32` / `/128`) keeps the **exact-IP map path byte-identical** to before.
- A non-host pair installs a **`StaticNatBlock`** (Vec, linear-scanned on the cold path) **only** when the external/internal prefixes are the **same family and equal length** (a 1:1 block map). Mismatched-length / mixed-family / host-vs-block pairs are **skipped** (preserving the #2122 skip rationale).
- **Offset mapping**: forward DNAT and reverse SNAT remap by offset -- `dst_base | (addr & host_mask(len))` -- replacing network bits, preserving host bits; the reverse is the inverse map so return traffic matches. IPv4 (u32) + IPv6 (u128) with `len >= max` shift guards (no `1<<32`/`1<<128` UB). Exact host entries take precedence over an overlapping block.
- **Checksums**: the block case yields the same `NatDecision` (`rewrite_dst`/`rewrite_src` only), so the **existing** host static-NAT checksum fixup applies unchanged -- no separate path.
- **Go commit gate**: `validateNATHostMaskStrict` now accepts a valid equal-length block pair (`isStaticBlockPair`) while still rejecting the invalid non-host cases, keeping Go commit-check and the Rust dataplane in agreement.

## Mismatched-length decision
A mismatched-length / mixed-family pair is **not** a 1:1 block map: the Rust side skips it (no install) and the Go strict gate rejects it at commit -- preferring the existing skip for genuinely-invalid rules and only newly supporting valid equal-length mappings.

## Tests
Rust (`nat::tests`): `/24->/24` forward + reverse offset, `/120->/120` v6 both directions, address-outside-block no-translate, mismatched-length skip, `/32` host regression. **Fail-on-revert confirmed**: restoring the host-only parse turns the 3 block tests RED while the host regression stays GREEN.

Go (`pkg/config`): block compile, mismatched-length + mixed-family rejection, `isStaticBlockPair` unit table.

- `cargo build --release` (0 errors); `cargo test --release nat::` -> **143 passed**
- `go build ./...` + `go test ./pkg/config/` -> **1703 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi