### PR TITLE
userspace-dp: classify generated SYN-cookie / reject reply on logical VLAN ifindex (#3035)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-26 — #3035 generated SYN-cookie / reject reply classify on logical VLAN ifindex
+
+- **Timestamp**: 2026-06-26
+- **Action**: Route the two remaining generated-reply egress classifications
+  through the `resolve_ingress_logical_ifindex` SSOT, mirroring #3034 (#3026).
+  `cookie_reply.rs::enqueue_syn_cookie_reply` classified the SYN-cookie
+  SYN-ACK / ACK-RST on the physical bind `ifindex`, and
+  `reject_reply.rs::enqueue_reject_reply` (policy/filter `reject` + zone
+  `tcp-rst`) classified the TCP RST / ICMP unreachable on the physical
+  `ingress_ifindex`. On a VLAN sub-interface that applied the parent's (or
+  first sub-interface's) CoS queue / DSCP rewrite / output filter instead of
+  the unit's. Both now resolve `(physical, meta.ingress_vlan_id) -> logical`
+  before `classify_generated_reply`, falling back to the physical index when
+  there is no mapping (untagged ports → byte-identical). The physical index
+  is still used for the reflected-reply build and the XSK transmit. These two
+  pre-date #3034 (#2238) and were out of its scope.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs,
+  userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs,
+  userspace-dp/src/afxdp/README.md, _Log.md
+- **Validation**: `cargo build --release` clean. Four new fail-on-revert
+  tests (`syn_cookie_reply_classifies_on_logical_vlan_ifindex_3035`,
+  `reject_reply_classifies_on_logical_vlan_ifindex_3035`, plus two non-VLAN
+  regression tests) pass; reverting the classify to the physical index turns
+  the two VLAN tests RED while the non-VLAN tests stay GREEN.
+
 ## 2026-06-26 — #3031 static-NAT block-to-block (subnet) mappings
 
 - **Timestamp**: 2026-06-26

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -93,7 +93,17 @@ sync.
         `forwarding.egress`), NOT the physical `target_ifindex` /
         `bind_ifindex`. `target_ifindex` (physical) is still used for the
         XSK transmit.
-    Untagged ports resolve physical == logical, so all four sites are
+      - **#3035 — generated SYN-cookie / reject reply:**
+        `poll_descriptor/cookie_reply.rs` (SYN-cookie SYN-ACK / ACK-RST)
+        and `poll_descriptor/reject_reply.rs` (policy/filter `reject` TCP
+        RST or ICMP/ICMPv6 unreachable, and zone `tcp-rst`) classify the
+        generated reply (CoS queue / DSCP rewrite / output filter) on the
+        LOGICAL egress unit ifindex resolved from the physical bind /
+        ingress ifindex via the SSOT, NOT the raw physical index. These two
+        pre-date #3034 (#2238) and were out of its scope; the physical
+        index is still used for the reflected-reply build and the XSK
+        transmit (`egress_ifindex`).
+    Untagged ports resolve physical == logical, so all six sites are
     no-ops there (non-VLAN behavior preserved).
   - **NA validation (`#2368`, RFC 4861 §7.1.2 / RFC 4443):** before an
     NA learns a Target Link-Layer Address, `parse_ndp_neighbor_advert`

--- a/userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs
@@ -82,8 +82,22 @@ pub(super) fn enqueue_syn_cookie_reply(
     // a legitimate (rare) choice. Pre-#2238 this enqueued an UNCLASSIFIED
     // TxRequest the drain path honored verbatim — no output filter / CoS /
     // DSCP was applied to the reply.
+    //
+    // #3035: classify on the LOGICAL egress ifindex, NOT the physical bind
+    // `ifindex`. CoS interfaces (forwarding_build/cos.rs) and output filters
+    // (filter/compiler.rs) are keyed by the logical unit ifindex; on a VLAN
+    // subinterface `ifindex` is the physical parent index, so classifying by
+    // it applied the parent's (or first subinterface's) CoS queue / DSCP
+    // rewrite / output filter instead of this unit's. Mirrors the #3026
+    // generated-ICMP-error fix and the filter/CoS sites via the
+    // `resolve_ingress_logical_ifindex` SSOT; the physical `ifindex` is still
+    // used for the XSK transmit (`egress_ifindex`) below. For a non-VLAN port
+    // the logical and physical indexes coincide, so this is a no-op there.
     let now_ns = monotonic_nanos();
-    let verdict = classify_generated_reply(forwarding, ifindex, &bytes, now_ns);
+    let classify_ifindex =
+        resolve_ingress_logical_ifindex(forwarding, ifindex, meta.ingress_vlan_id)
+            .unwrap_or(ifindex);
+    let verdict = classify_generated_reply(forwarding, classify_ifindex, &bytes, now_ns);
     if verdict.drop {
         counters.touched = true;
         if verdict.parse_error {
@@ -299,6 +313,160 @@ mod tests {
         assert_eq!(counters.syn_cookie_output_filter_drops, 1);
         assert_eq!(counters.generated_reply_classify_parse_errors, 0);
         assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3035: build a forwarding state where the VLAN unit reth0.80 (logical
+    /// ifindex 202, parent 11, VID 80) carries a TCP-discard output filter and
+    /// the physical parent 11 carries NONE. Used to prove the SYN-cookie reply
+    /// is classified on the LOGICAL unit ifindex, not the physical bind port.
+    fn vlan_drop_tcp_snapshot() -> crate::ConfigSnapshot {
+        crate::ConfigSnapshot {
+            interfaces: vec![crate::InterfaceSnapshot {
+                name: "reth0.80".into(),
+                ifindex: 202,
+                parent_ifindex: 11,
+                vlan_id: 80,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                filter_output_v4: "drop-tcp".into(),
+                ..Default::default()
+            }],
+            filters: vec![crate::FirewallFilterSnapshot {
+                name: "drop-tcp".into(),
+                family: "inet".into(),
+                terms: vec![crate::FirewallTermSnapshot {
+                    name: "drop-tcp".into(),
+                    action: "discard".into(),
+                    protocols: vec!["tcp".into()],
+                    ..Default::default()
+                }],
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// #3035 fail-on-revert: a SYN-cookie reply for a SYN arriving on a VLAN
+    /// sub-interface must be classified (output filter / CoS) on the LOGICAL
+    /// unit ifindex, not the physical bind port. The logical unit reth0.80
+    /// (202) carries a TCP-discard output filter; the physical parent 11 does
+    /// not. Driving the real enqueue with the physical bind ifindex 11 must
+    /// resolve the logical unit and drop the reply. If the classify reverts to
+    /// the physical `ifindex`, the parent has no filter and the reply is
+    /// wrongly admitted -> this test goes RED.
+    #[test]
+    fn syn_cookie_reply_classifies_on_logical_vlan_ifindex_3035() {
+        let (frame, mut meta, flow) = tcp_v4_syn_frame();
+        // Inbound SYN arrives on physical parent ifindex 11, tagged VID 80.
+        meta.ingress_ifindex = 11;
+        meta.ingress_vlan_id = 80;
+        let forwarding = build_forwarding_state(&vlan_drop_tcp_snapshot());
+
+        // Fixture sanity + divergence: logical-keyed classify drops (the
+        // unit's drop-tcp filter), physical-parent-keyed classify admits.
+        assert_eq!(
+            resolve_ingress_logical_ifindex(&forwarding, 11, 80),
+            Some(202),
+            "parent 11 / VLAN 80 must resolve to logical ifindex 202"
+        );
+        let now_ns = monotonic_nanos();
+        assert!(
+            classify_generated_reply(&forwarding, 202, &frame, now_ns).drop,
+            "logical-keyed classify must hit the VLAN unit's drop-tcp filter"
+        );
+        assert!(
+            !classify_generated_reply(&forwarding, 11, &frame, now_ns).drop,
+            "physical-parent-keyed classify has no filter and would wrongly admit"
+        );
+
+        // Drive the real enqueue with the PHYSICAL bind ifindex 11.
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+            0,
+        );
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_syn_cookie_reply(
+            &mut pipeline,
+            &forwarding,
+            11, // physical parent bind ifindex
+            &frame,
+            meta,
+            Some(&flow),
+            SynCookieReply::SynAck(SynCookieChallenge {
+                cookie_isn: 0xaabb_ccdd,
+                peer_mss: 1460,
+            }),
+            &mut counters,
+        );
+        assert!(
+            !sent,
+            "SYN-cookie reply on a VLAN unit must be dropped by the unit's output filter"
+        );
+        assert_eq!(counters.syn_cookie_output_filter_drops, 1);
+        assert_eq!(counters.syn_cookie_syn_ack_sent, 0);
+        assert_eq!(counters.generated_reply_classify_parse_errors, 0);
+        assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3035 non-VLAN regression: on an untagged interface the logical unit IS
+    /// the bind ifindex (no (parent, vlan) mapping), so `resolve_ingress_-
+    /// logical_ifindex` returns None and the classify falls back to the
+    /// physical ifindex unchanged — behavior is byte-identical to pre-#3035.
+    #[test]
+    fn syn_cookie_reply_non_vlan_classify_unchanged_3035() {
+        let (frame, meta, flow) = tcp_v4_syn_frame(); // ingress_ifindex 5, vlan 0
+        let snapshot = crate::ConfigSnapshot {
+            interfaces: vec![crate::InterfaceSnapshot {
+                name: "ge-0/0/1.0".into(),
+                ifindex: 5,
+                hardware_addr: "02:bf:72:00:00:05".into(),
+                filter_output_v4: "drop-tcp".into(),
+                ..Default::default()
+            }],
+            filters: vec![crate::FirewallFilterSnapshot {
+                name: "drop-tcp".into(),
+                family: "inet".into(),
+                terms: vec![crate::FirewallTermSnapshot {
+                    name: "drop-tcp".into(),
+                    action: "discard".into(),
+                    protocols: vec!["tcp".into()],
+                    ..Default::default()
+                }],
+            }],
+            ..Default::default()
+        };
+        let forwarding = build_forwarding_state(&snapshot);
+        // An untagged unit maps to ITSELF (logical == physical == 5), so the
+        // resolve is a no-op and the classify ifindex is unchanged.
+        assert_eq!(
+            resolve_ingress_logical_ifindex(&forwarding, 5, 0),
+            Some(5),
+            "an untagged port resolves logical == physical; the classify ifindex is unchanged"
+        );
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+            0,
+        );
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_syn_cookie_reply(
+            &mut pipeline,
+            &forwarding,
+            5, // logical == physical for an untagged port
+            &frame,
+            meta,
+            Some(&flow),
+            SynCookieReply::SynAck(SynCookieChallenge {
+                cookie_isn: 0xaabb_ccdd,
+                peer_mss: 1460,
+            }),
+            &mut counters,
+        );
+        assert!(
+            !sent,
+            "untagged interface still applies its own output filter (unchanged)"
+        );
+        assert_eq!(counters.syn_cookie_output_filter_drops, 1);
+        assert_eq!(counters.syn_cookie_syn_ack_sent, 0);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -202,8 +202,23 @@ fn enqueue_reject_reply(
     // Pre-#2238 this enqueued an UNCLASSIFIED TxRequest (`cos_queue_id:
     // None, dscp_rewrite: None`) that the drain path honored verbatim — no
     // output filter / CoS / DSCP was ever applied to the reply.
+    //
+    // #3035: classify on the LOGICAL egress ifindex, NOT the physical
+    // `ingress_ifindex`. CoS interfaces (forwarding_build/cos.rs) and output
+    // filters (filter/compiler.rs) are keyed by the logical unit ifindex; on
+    // a VLAN subinterface `ingress_ifindex` is the physical parent index, so
+    // classifying by it applied the parent's (or first subinterface's) CoS
+    // queue / DSCP rewrite / output filter instead of this unit's. Mirrors
+    // the #3026 generated-ICMP-error fix and the filter/CoS sites via the
+    // `resolve_ingress_logical_ifindex` SSOT; the physical `ingress_ifindex`
+    // is still used for the reflected-reply build above and the XSK transmit
+    // (`egress_ifindex`) below. For a non-VLAN port the logical and physical
+    // indexes coincide, so this is a no-op there.
     let now_ns = monotonic_nanos();
-    let verdict = classify_generated_reply(forwarding, ingress_ifindex, &bytes, now_ns);
+    let classify_ifindex =
+        resolve_ingress_logical_ifindex(forwarding, ingress_ifindex, meta.ingress_vlan_id)
+            .unwrap_or(ingress_ifindex);
+    let verdict = classify_generated_reply(forwarding, classify_ifindex, &bytes, now_ns);
     if verdict.drop {
         counters.touched = true;
         if verdict.parse_error {
@@ -849,6 +864,164 @@ mod tests {
         );
         assert_eq!(counters.policy_reject_sent, 0);
         assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3035: forwarding state where the VLAN unit reth0.80 (logical ifindex
+    /// 202, parent 11, VID 80) carries a TCP-discard output filter and the
+    /// physical parent 11 carries NONE. Proves the reject reply is classified
+    /// on the LOGICAL unit ifindex, not the physical ingress port.
+    fn vlan_drop_tcp_snapshot() -> crate::ConfigSnapshot {
+        crate::ConfigSnapshot {
+            interfaces: vec![crate::InterfaceSnapshot {
+                name: "reth0.80".into(),
+                ifindex: 202,
+                parent_ifindex: 11,
+                vlan_id: 80,
+                hardware_addr: "02:bf:72:00:80:08".into(),
+                filter_output_v4: "drop-tcp".into(),
+                ..Default::default()
+            }],
+            filters: vec![crate::FirewallFilterSnapshot {
+                name: "drop-tcp".into(),
+                family: "inet".into(),
+                terms: vec![crate::FirewallTermSnapshot {
+                    name: "drop-tcp".into(),
+                    action: "discard".into(),
+                    protocols: vec!["tcp".into()],
+                    ..Default::default()
+                }],
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// #3035 fail-on-revert: a reject reply (TCP RST) for a SYN arriving on a
+    /// VLAN sub-interface must be classified (output filter / CoS) on the
+    /// LOGICAL unit ifindex, not the physical ingress port. The logical unit
+    /// reth0.80 (202) carries a TCP-discard output filter; the physical parent
+    /// 11 does not. Driving the real enqueue with the physical ingress ifindex
+    /// 11 must resolve the logical unit and drop the RST. If the classify
+    /// reverts to the physical `ingress_ifindex`, the parent has no filter and
+    /// the reply is wrongly admitted -> this test goes RED. A reflected TCP RST
+    /// needs no egress primary, so this isolates the classify ifindex.
+    #[test]
+    fn reject_reply_classifies_on_logical_vlan_ifindex_3035() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+        crate::afxdp::icmp_ratelimit::reset_bucket_for_test(
+            crate::afxdp::icmp_ratelimit::GeneratedErrorReason::Reject,
+            0,
+        );
+        let (frame, mut meta, flow) = tcp_v4_syn();
+        // Inbound SYN arrives on physical parent ifindex 11, tagged VID 80.
+        meta.ingress_ifindex = 11;
+        meta.ingress_vlan_id = 80;
+        let forwarding = build_forwarding_state(&vlan_drop_tcp_snapshot());
+
+        // Fixture sanity + divergence: logical-keyed classify drops (the
+        // unit's drop-tcp filter), physical-parent-keyed classify admits.
+        assert_eq!(
+            resolve_ingress_logical_ifindex(&forwarding, 11, 80),
+            Some(202),
+            "parent 11 / VLAN 80 must resolve to logical ifindex 202"
+        );
+        let rst = build_reject_rst_frame(&frame).expect("reflected RST builds");
+        let now_ns = monotonic_nanos();
+        assert!(
+            classify_generated_reply(&forwarding, 202, &rst, now_ns).drop,
+            "logical-keyed classify must hit the VLAN unit's drop-tcp filter"
+        );
+        assert!(
+            !classify_generated_reply(&forwarding, 11, &rst, now_ns).drop,
+            "physical-parent-keyed classify has no filter and would wrongly admit"
+        );
+
+        // Drive the real enqueue with the PHYSICAL ingress ifindex 11.
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_policy_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            11, // physical parent ingress ifindex
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(
+            !sent,
+            "reject reply on a VLAN unit must be dropped by the unit's output filter"
+        );
+        assert_eq!(counters.policy_reject_output_filter_drops, 1);
+        assert_eq!(counters.policy_reject_sent, 0);
+        assert_eq!(counters.generated_reply_classify_parse_errors, 0);
+        assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3035 non-VLAN regression: on an untagged interface the logical unit IS
+    /// the ingress ifindex (no (parent, vlan) mapping), so `resolve_ingress_-
+    /// logical_ifindex` returns None and the classify falls back to the
+    /// physical ifindex unchanged — behavior is byte-identical to pre-#3035.
+    #[test]
+    fn reject_reply_non_vlan_classify_unchanged_3035() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        let _g = crate::afxdp::icmp_ratelimit::global_bucket_test_lock();
+        crate::afxdp::icmp_ratelimit::reset_bucket_for_test(
+            crate::afxdp::icmp_ratelimit::GeneratedErrorReason::Reject,
+            0,
+        );
+        let (frame, meta, flow) = tcp_v4_syn(); // ingress_ifindex 5, vlan 0
+        let snapshot = crate::ConfigSnapshot {
+            interfaces: vec![crate::InterfaceSnapshot {
+                name: "ge-0/0/1.0".into(),
+                ifindex: 5,
+                hardware_addr: "02:bf:72:00:00:05".into(),
+                filter_output_v4: "drop-tcp".into(),
+                ..Default::default()
+            }],
+            filters: vec![crate::FirewallFilterSnapshot {
+                name: "drop-tcp".into(),
+                family: "inet".into(),
+                terms: vec![crate::FirewallTermSnapshot {
+                    name: "drop-tcp".into(),
+                    action: "discard".into(),
+                    protocols: vec!["tcp".into()],
+                    ..Default::default()
+                }],
+            }],
+            ..Default::default()
+        };
+        let forwarding = build_forwarding_state(&snapshot);
+        // An untagged unit maps to ITSELF (logical == physical == 5), so the
+        // resolve is a no-op and the classify ifindex is unchanged.
+        assert_eq!(
+            resolve_ingress_logical_ifindex(&forwarding, 5, 0),
+            Some(5),
+            "an untagged port resolves logical == physical; the classify ifindex is unchanged"
+        );
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_policy_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            5, // logical == physical for an untagged port
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(
+            !sent,
+            "untagged interface still applies its own output filter (unchanged)"
+        );
+        assert_eq!(counters.policy_reject_output_filter_drops, 1);
+        assert_eq!(counters.policy_reject_sent, 0);
     }
 
     /// #3071: the unified deny-reply still drives explicit policy `reject`


### PR DESCRIPTION
Closes #3035

## Problem

Two pre-#3034 generated-reply paths classified the reply's OWN egress treatment (CoS queue / DSCP rewrite / output filter) on the PHYSICAL ingress ifindex instead of the LOGICAL VLAN sub-interface ifindex:

- `userspace-dp/src/afxdp/poll_descriptor/cookie_reply.rs` (`enqueue_syn_cookie_reply`) — SYN-cookie SYN-ACK / ACK-RST classified on the physical bind `ifindex`.
- `userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs` (`enqueue_reject_reply`, shared by policy/filter `reject` + zone `tcp-rst`) — TCP RST / ICMP unreachable classified on the physical `ingress_ifindex`.

CoS interfaces and output filters are keyed by the logical unit ifindex. On a VLAN sub-interface the physical parent index misses or inherits the parent's first sub-interface treatment, so the generated reply got the wrong unit's CoS / DSCP / output filter — the same bug class as #3026. These two sites pre-date #3034 (#2238) and were genuinely out of its scope.

## Fix

Both sites now resolve `(physical, meta.ingress_vlan_id) -> logical` through the `resolve_ingress_logical_ifindex` SSOT before `classify_generated_reply`, falling back to the physical index when there is no `(parent, vlan)` mapping. This mirrors #3034's SSOT usage and the existing filter / CoS / generated-ICMP-error (#3026) sites. The physical index is still used for the reflected-reply build and the XSK transmit (`egress_ifindex`) — classify-logical / transmit-physical split. Untagged ports resolve logical == physical, so non-VLAN behavior is byte-identical.

## Tests (fail-on-revert)

- `syn_cookie_reply_classifies_on_logical_vlan_ifindex_3035`
- `reject_reply_classifies_on_logical_vlan_ifindex_3035`

Each builds a forwarding state where the VLAN unit reth0.80 (logical 202, parent 11, VID 80) carries a TCP-discard output filter and the physical parent 11 carries none, then drives the real enqueue with the physical bind ifindex 11 — the reply must be dropped by the unit's filter. Each also asserts the logical-keyed (drop) vs physical-keyed (admit) verdicts diverge. **Verified:** reverting the classify ifindex to physical turns both VLAN tests RED while the two non-VLAN regression tests (`syn_cookie_reply_non_vlan_classify_unchanged_3035`, `reject_reply_non_vlan_classify_unchanged_3035`) stay GREEN.

## Validation

`cargo build --release` clean (0 errors). Full bins suite: 3094 passed, 2 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi