### PR TITLE
applications: junos-ping/junos-pingv6 echo-request only (#3020)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-06-26 — #3020 junos-ping / junos-pingv6 echo-request-only (ICMP type constraint)
+
+- **Timestamp**: 2026-06-26
+- **Action**: Constrain `junos-ping` / `junos-pingv6` to ICMP echo-request
+  only (ICMP type 8 / ICMPv6 type 128) instead of matching every ICMP type
+  like `junos-icmp-all`. Added an optional ICMP type/code constraint to the
+  predefined-application model (`config.Application.ICMPType/ICMPCode`), the
+  policy snapshot application term (`PolicyApplicationSnapshot.ICMPType/
+  ICMPCode`, Go + Rust serde with pointer/omitempty + `skip_serializing_if`
+  so the wire is additive and version-skew decodes to `None` = match-all).
+  The Rust matcher (`policy.rs`) routes an icmp-type-constrained term into a
+  per-protocol `icmp_constraints` list and matches it only when the packet's
+  type (and code, if set) equals the constraint; an unconstrained ICMP term
+  (junos-icmp-all) stays a match-all `range_terms` entry, so a rule citing
+  both still matches all ICMP. The packet's ICMP type/code is read at
+  policy-eval time via `policy_packet_icmp` (reusing the fragment/truncation-
+  safe `term_match_extra_from_frame`); unknown type/code fails closed. The
+  all-ICMP aliases are byte-identical. The app-id catalog is unchanged
+  (cosmetic naming, not enforcement). Fixture `protocol_wire_v1.json` did NOT
+  need regen (Option fields skip-serialize when None). Fail-on-revert proven:
+  routing icmp-constrained terms as match-all turns the junos-ping /
+  junos-pingv6 echo-request tests RED while junos-icmp-all stays GREEN.
+- **File(s)**: pkg/config/predefined.go, pkg/config/types_security.go,
+  pkg/config/predefined_icmp_3020_test.go, pkg/dataplane/userspace/protocol.go,
+  pkg/dataplane/userspace/capabilities.go,
+  pkg/dataplane/userspace/junos_ping_icmp_3020_test.go,
+  userspace-dp/src/protocol/security.rs, userspace-dp/src/policy.rs,
+  userspace-dp/src/policy_tests.rs, userspace-dp/src/afxdp/tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  docs/services-application-identification.md
+
 ## 2026-06-26 — #3035 generated SYN-cookie / reject reply classify on logical VLAN ifindex
 
 - **Timestamp**: 2026-06-26

--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -86,6 +86,48 @@ upfront what they're getting and not getting.
      `junos-ftp=21`, etc. — the 15-entry `builtinFallbacks`
      map).
 
+### ICMP type/code constraint in policy matching (#3020)
+
+`junos-ping` and `junos-pingv6` are **echo-request only** — Junos
+parity is ICMP type 8 (`junos-ping`) and ICMPv6 type 128
+(`junos-pingv6`), each with no code constraint. They are NOT the same
+as the all-ICMP aliases `junos-icmp-all` / `junos-icmp6-all`, which
+stay unconstrained and match every ICMP/ICMPv6 type/code. Before
+#3020 every predefined ICMP application carried only a protocol with
+no type/code, so `application junos-ping` matched all ICMP (identical
+to `junos-icmp-all`) — a `permit junos-ping` rule also admitted
+destination-unreachable, time-exceeded, redirect, neighbor-discovery,
+etc.
+
+The constraint is modeled as an optional `(ICMPType, ICMPCode)` on the
+predefined application (`pkg/config/predefined.go`), carried on the
+policy snapshot's application term (`PolicyApplicationSnapshot.ICMPType`
+/ `.ICMPCode`, `pkg/dataplane/userspace/protocol.go`) and the Rust
+matcher (`ApplicationMatch.icmp_type` / `.icmp_code`,
+`userspace-dp/src/policy.rs`). `nil`/`None` means "no constraint"
+(match all of the protocol — what the all-ICMP aliases keep). The wire
+field is additive: a pointer + `omitempty` on the Go side and
+`#[serde(default, skip_serializing_if = "Option::is_none")]` on the
+Rust side, so an old helper missing the field — or an old Go snapshot
+omitting it — decodes to `None` and ignores the constraint (match-all,
+the pre-#3020 behavior); version skew degrades safely rather than
+failing to decode.
+
+The Rust matcher reads the packet's ICMP type/code from the live frame
+at policy-evaluation time (`policy_packet_icmp` in
+`poll_descriptor`, reusing the fragment/truncation-safe
+`term_match_extra_from_frame`). When the type/code is unknown (a
+truncated frame or a non-first fragment) an icmp-type-constrained term
+fails closed (does not match). Policy evaluation is on the cold path
+(session miss), so the per-packet extraction cost is incurred once per
+session.
+
+This affects **policy matching** only. The app-identification catalog
+(`app_id` session stamping, above) does NOT carry ICMP type/code, so
+`junos-ping` and `junos-icmp-all` can still resolve to the same
+`app_id` for `show security flow session` display — that is cosmetic
+naming, not enforcement.
+
 ## What's parsed but not implemented
 
 These config paths are accepted at commit time and their

--- a/pkg/config/predefined.go
+++ b/pkg/config/predefined.go
@@ -2,6 +2,10 @@ package config
 
 import "fmt"
 
+// u8p returns a pointer to a uint8 literal, used to set the optional ICMP
+// type/code constraint on a predefined application (#3020).
+func u8p(v uint8) *uint8 { return &v }
+
 // PredefinedApplications contains built-in Junos application definitions.
 // Based on the official Junos OS predefined application list.
 var PredefinedApplications = map[string]*Application{
@@ -125,8 +129,12 @@ var PredefinedApplications = map[string]*Application{
 	"junos-ns-global-pro": {Name: "junos-ns-global-pro", Protocol: "tcp", DestinationPort: "15397"},
 
 	// --- ICMP / ICMPv6 ---
-	"junos-ping":      {Name: "junos-ping", Protocol: "icmp"},
-	"junos-pingv6":    {Name: "junos-pingv6", Protocol: "icmpv6"},
+	// #3020: junos-ping / junos-pingv6 are echo-request ONLY (Junos parity:
+	// ICMP type 8 / ICMPv6 type 128), NOT every ICMP type. The all-ICMP
+	// aliases below stay unconstrained (match any type/code) so they remain
+	// distinct from the ping applications.
+	"junos-ping":      {Name: "junos-ping", Protocol: "icmp", ICMPType: u8p(8)},
+	"junos-pingv6":    {Name: "junos-pingv6", Protocol: "icmpv6", ICMPType: u8p(128)},
 	"junos-icmp-all":  {Name: "junos-icmp-all", Protocol: "icmp"},
 	"junos-icmp6-all": {Name: "junos-icmp6-all", Protocol: "icmpv6"},
 

--- a/pkg/config/predefined_icmp_3020_test.go
+++ b/pkg/config/predefined_icmp_3020_test.go
@@ -1,0 +1,40 @@
+package config
+
+import "testing"
+
+// #3020 — junos-ping / junos-pingv6 are echo-request only (ICMP type 8 /
+// ICMPv6 type 128), distinct from the unconstrained all-ICMP aliases.
+func TestPredefinedPingApplicationsCarryEchoRequestType(t *testing.T) {
+	cases := []struct {
+		name      string
+		proto     string
+		wantType  uint8
+		wantTypeP bool
+	}{
+		{"junos-ping", "icmp", 8, true},
+		{"junos-pingv6", "icmpv6", 128, true},
+		{"junos-icmp-all", "icmp", 0, false},
+		{"junos-icmp6-all", "icmpv6", 0, false},
+	}
+	for _, tc := range cases {
+		app, ok := PredefinedApplications[tc.name]
+		if !ok {
+			t.Fatalf("predefined application %q missing", tc.name)
+		}
+		if app.Protocol != tc.proto {
+			t.Errorf("%s Protocol = %q, want %q", tc.name, app.Protocol, tc.proto)
+		}
+		if tc.wantTypeP {
+			if app.ICMPType == nil {
+				t.Errorf("%s ICMPType = nil, want %d", tc.name, tc.wantType)
+			} else if *app.ICMPType != tc.wantType {
+				t.Errorf("%s ICMPType = %d, want %d", tc.name, *app.ICMPType, tc.wantType)
+			}
+		} else if app.ICMPType != nil {
+			t.Errorf("%s ICMPType = %d, want nil (unconstrained)", tc.name, *app.ICMPType)
+		}
+		if app.ICMPCode != nil {
+			t.Errorf("%s ICMPCode = %d, want nil", tc.name, *app.ICMPCode)
+		}
+	}
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -529,6 +529,13 @@ type Application struct {
 	InactivityTimeout int    // seconds (0 = default)
 	ALG               string // "ssh", "ftp", etc. (informational)
 	Description       string
+	// ICMPType / ICMPCode constrain an ICMP/ICMPv6 application to a single
+	// message type (and optionally code), e.g. junos-ping = ICMP type 8
+	// (echo-request) and junos-pingv6 = ICMPv6 type 128. nil means "no
+	// constraint" — the application matches every type/code of its protocol
+	// (the historical behavior and what the all-ICMP aliases keep). #3020.
+	ICMPType *uint8
+	ICMPCode *uint8
 }
 
 // IPsecConfig holds IPsec VPN configuration.

--- a/pkg/dataplane/userspace/capabilities.go
+++ b/pkg/dataplane/userspace/capabilities.go
@@ -343,8 +343,15 @@ func expandUserspacePolicyApplications(cfg *config.Config, apps []string) ([]Pol
 				Protocol:        proto,
 				SourcePort:      app.SourcePort,
 				DestinationPort: app.DestinationPort,
+				// #3020: carry the optional ICMP/ICMPv6 type/code constraint so
+				// the Rust matcher enforces junos-ping == echo-request only,
+				// rather than matching every ICMP type like junos-icmp-all.
+				// nil stays nil (the all-ICMP aliases remain unconstrained).
+				ICMPType: app.ICMPType,
+				ICMPCode: app.ICMPCode,
 			}
-			key := strings.Join([]string{snap.Name, snap.Protocol, snap.SourcePort, snap.DestinationPort}, "\x00")
+			key := strings.Join([]string{snap.Name, snap.Protocol, snap.SourcePort, snap.DestinationPort,
+				icmpKeyPart(snap.ICMPType), icmpKeyPart(snap.ICMPCode)}, "\x00")
 			if _, exists := seen[key]; exists {
 				continue
 			}
@@ -362,9 +369,29 @@ func expandUserspacePolicyApplications(cfg *config.Config, apps []string) ([]Pol
 		if expanded[i].SourcePort != expanded[j].SourcePort {
 			return expanded[i].SourcePort < expanded[j].SourcePort
 		}
-		return expanded[i].DestinationPort < expanded[j].DestinationPort
+		if expanded[i].DestinationPort != expanded[j].DestinationPort {
+			return expanded[i].DestinationPort < expanded[j].DestinationPort
+		}
+		// #3020: keep ICMP type/code in the sort key so two terms differing
+		// ONLY by the ICMP constraint (e.g. junos-ping vs junos-icmp-all, both
+		// proto icmp, no ports) order deterministically across HA peers.
+		if k := icmpKeyPart(expanded[i].ICMPType); k != icmpKeyPart(expanded[j].ICMPType) {
+			return k < icmpKeyPart(expanded[j].ICMPType)
+		}
+		return icmpKeyPart(expanded[i].ICMPCode) < icmpKeyPart(expanded[j].ICMPCode)
 	})
 	return expanded, true
+}
+
+// icmpKeyPart renders an optional ICMP type/code constraint as a stable string
+// for snapshot-term dedup + deterministic ordering (#3020). A nil constraint
+// (match-all) sorts before any concrete value so it is distinct from type/code
+// 0 (the "" vs "0" distinction the dedup key relies on).
+func icmpKeyPart(v *uint8) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.Itoa(int(*v))
 }
 
 func resolveUserspaceApplicationNames(cfg *config.Config, name string) ([]string, bool) {

--- a/pkg/dataplane/userspace/junos_ping_icmp_3020_test.go
+++ b/pkg/dataplane/userspace/junos_ping_icmp_3020_test.go
@@ -1,0 +1,82 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3020 — junos-ping / junos-pingv6 must compile to a policy application term
+// carrying an ICMP/ICMPv6 type constraint (echo-request: type 8 / 128), while
+// the all-ICMP aliases stay UNCONSTRAINED (nil type) so they keep matching
+// every ICMP message. Before #3020 every ICMP predefined app expanded to the
+// same protocol-only term, making junos-ping identical to junos-icmp-all.
+
+func icmpAppCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.DefaultPolicy = config.PolicyDeny
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"lan": {Name: "lan", Interfaces: []string{"reth1"}},
+		"wan": {Name: "wan", Interfaces: []string{"reth0.80"}},
+	}
+	return cfg
+}
+
+func TestJunosPingExpandsToEchoRequestTypeConstraint(t *testing.T) {
+	cfg := icmpAppCfg()
+	terms, ok := expandUserspacePolicyApplications(cfg, []string{"junos-ping"})
+	if !ok {
+		t.Fatal("expandUserspacePolicyApplications(junos-ping) ok=false, want true")
+	}
+	if len(terms) != 1 {
+		t.Fatalf("len(terms) = %d, want 1", len(terms))
+	}
+	if terms[0].Protocol != "icmp" {
+		t.Fatalf("junos-ping Protocol = %q, want \"icmp\"", terms[0].Protocol)
+	}
+	if terms[0].ICMPType == nil {
+		t.Fatal("junos-ping ICMPType = nil, want 8 (echo-request) — would match all ICMP like junos-icmp-all")
+	}
+	if *terms[0].ICMPType != 8 {
+		t.Fatalf("junos-ping ICMPType = %d, want 8", *terms[0].ICMPType)
+	}
+	if terms[0].ICMPCode != nil {
+		t.Fatalf("junos-ping ICMPCode = %d, want nil (any code of the type)", *terms[0].ICMPCode)
+	}
+}
+
+func TestJunosPingV6ExpandsToEchoRequestTypeConstraint(t *testing.T) {
+	cfg := icmpAppCfg()
+	terms, ok := expandUserspacePolicyApplications(cfg, []string{"junos-pingv6"})
+	if !ok {
+		t.Fatal("expandUserspacePolicyApplications(junos-pingv6) ok=false, want true")
+	}
+	if len(terms) != 1 {
+		t.Fatalf("len(terms) = %d, want 1", len(terms))
+	}
+	if terms[0].Protocol != "icmpv6" {
+		t.Fatalf("junos-pingv6 Protocol = %q, want \"icmpv6\"", terms[0].Protocol)
+	}
+	if terms[0].ICMPType == nil || *terms[0].ICMPType != 128 {
+		t.Fatalf("junos-pingv6 ICMPType = %v, want 128 (echo-request)", terms[0].ICMPType)
+	}
+}
+
+func TestJunosIcmpAllStaysUnconstrained(t *testing.T) {
+	cfg := icmpAppCfg()
+	for _, name := range []string{"junos-icmp-all", "junos-icmp6-all"} {
+		terms, ok := expandUserspacePolicyApplications(cfg, []string{name})
+		if !ok {
+			t.Fatalf("expandUserspacePolicyApplications(%s) ok=false, want true", name)
+		}
+		if len(terms) != 1 {
+			t.Fatalf("%s: len(terms) = %d, want 1", name, len(terms))
+		}
+		if terms[0].ICMPType != nil {
+			t.Fatalf("%s: ICMPType = %d, want nil (match all ICMP)", name, *terms[0].ICMPType)
+		}
+		if terms[0].ICMPCode != nil {
+			t.Fatalf("%s: ICMPCode = %d, want nil", name, *terms[0].ICMPCode)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -734,6 +734,16 @@ type PolicyApplicationSnapshot struct {
 	Protocol        string `json:"protocol,omitempty"`
 	SourcePort      string `json:"source_port,omitempty"`
 	DestinationPort string `json:"destination_port,omitempty"`
+	// #3020: optional ICMP/ICMPv6 type (and code) constraint. nil = "no
+	// constraint" — the term matches every type/code of its protocol (the
+	// historical behavior, kept by the all-ICMP aliases). junos-ping sets
+	// ICMPType=8, junos-pingv6 sets ICMPType=128. omitempty + pointer keeps
+	// the wire additive: an old helper missing the field decodes None and
+	// ignores the constraint (match-all, today's behavior), and an old Go
+	// snapshot omitting it decodes to None on the Rust side the same way, so
+	// version skew degrades safely to match-all rather than failing to decode.
+	ICMPType *uint8 `json:"icmp_type,omitempty"`
+	ICMPCode *uint8 `json:"icmp_code,omitempty"`
 }
 
 // AppCatalogEntrySnapshot is one row of the application-identification catalog

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -32,7 +32,7 @@ use super::poll_stages::{
     stage_screen_syn_cookie_ack_on_session_miss,
 };
 use super::*;
-use crate::policy::evaluate_policy_result_with_len;
+use crate::policy::evaluate_policy_result_with_icmp;
 
 use cookie_reply::{SynCookieReply, enqueue_syn_cookie_reply};
 use nat_exception::{record_source_nat_failure, source_nat_decision_for_flow};
@@ -43,6 +43,29 @@ use filter::{
     evaluate_dscp_sensitive_input_filter_on_session_hit, evaluate_non_pbr_input_filter,
     evaluate_non_pbr_input_filter_log_only,
 };
+
+/// #3020: extract the ICMP/ICMPv6 `(type, code)` for policy matching. Returns
+/// `None` for non-ICMP protocols, and for ICMP/ICMPv6 frames whose type/code
+/// bytes are not safely readable (a truncated frame or a non-first fragment),
+/// so an icmp-type-constrained application term (junos-ping = echo-request only)
+/// fails closed rather than matching against a fabricated type/code of 0.
+///
+/// Reuses the canonical, fragment/truncation-safe extractor
+/// `term_match_extra_from_frame` (the same one the firewall-filter icmp-type
+/// terms consume), so the policy and filter planes agree on which type/code a
+/// frame carries. Cold-path only (policy is evaluated on session miss).
+#[inline]
+fn policy_packet_icmp(packet_frame: &[u8], meta: UserspaceDpMeta) -> Option<(u8, u8)> {
+    if !matches!(meta.protocol, PROTO_ICMP | PROTO_ICMPV6) {
+        return None;
+    }
+    let extra = crate::afxdp::frame::term_match_extra_from_frame(packet_frame, meta);
+    if extra.l4_present {
+        Some((extra.icmp_type, extra.icmp_code))
+    } else {
+        None
+    }
+}
 
 // Per-batch packet processing lifted from `poll_binding` (#678).
 //
@@ -1585,7 +1608,14 @@ pub(super) fn poll_binding_process_descriptor(
                             // translated-dst zone. `policy_dst_ip` /
                             // `policy_dst_port` collapse to the original dst when
                             // no inbound destination translation applies.
-                            let policy_result = evaluate_policy_result_with_len(
+                            // #3020: extract the ICMP/ICMPv6 type/code so an
+                            // icmp-type-constrained application term (junos-ping
+                            // = echo-request only) is enforced. `None` for
+                            // non-ICMP flows and for ICMP frames whose L4 header
+                            // is not safely readable (truncated / non-first
+                            // fragment), so such terms fail closed.
+                            let policy_icmp = policy_packet_icmp(packet_frame, meta);
+                            let policy_result = evaluate_policy_result_with_icmp(
                                 &worker_ctx.forwarding.policy,
                                 from_zone_id,
                                 to_zone_id,
@@ -1594,6 +1624,7 @@ pub(super) fn poll_binding_process_descriptor(
                                 flow.forward_key.protocol,
                                 flow.forward_key.src_port,
                                 policy_dst_port,
+                                policy_icmp,
                                 desc.len as u64,
                             );
                             // #1620: cold-path latency histogram post-eval record.
@@ -2974,7 +3005,13 @@ pub(super) fn poll_binding_process_descriptor(
                                     .nat
                                     .rewrite_dst_port
                                     .unwrap_or(flow.forward_key.dst_port);
-                                let policy_result = evaluate_policy_result_with_len(
+                                // #3020: same ICMP type/code extraction as the
+                                // ForwardCandidate path so a denied/permitted
+                                // verdict for an icmp-type-constrained term
+                                // (junos-ping) is identical whether or not the
+                                // next-hop neighbor is already resolved.
+                                let policy_icmp = policy_packet_icmp(packet_frame, meta);
+                                let policy_result = evaluate_policy_result_with_icmp(
                                     &worker_ctx.forwarding.policy,
                                     from_zone_id,
                                     to_zone_id,
@@ -2983,6 +3020,7 @@ pub(super) fn poll_binding_process_descriptor(
                                     flow.forward_key.protocol,
                                     flow.forward_key.src_port,
                                     policy_dst_port,
+                                    policy_icmp,
                                     desc.len as u64,
                                 );
                                 if cp_sample_tag {

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -9835,6 +9835,8 @@ fn policy_inbound_dnat_matches_translated_destination_port() {
         protocol: "tcp".to_string(),
         source_port: String::new(),
         destination_port: "8443".to_string(),
+        icmp_type: None,
+        icmp_code: None,
     }];
     let snapshot = inbound_dnat_snapshot(permit);
     let forwarding = build_forwarding_state(&snapshot);

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -597,6 +597,14 @@ pub(crate) struct ApplicationMatch {
     pub(crate) protocol: u8,
     pub(crate) source_ports: Vec<PortRange>,
     pub(crate) destination_ports: Vec<PortRange>,
+    /// #3020: optional ICMP/ICMPv6 type constraint. `Some(t)` restricts the
+    /// term to ICMP messages of type `t` (e.g. junos-ping = type 8); `None`
+    /// leaves the term unconstrained on type (the all-ICMP aliases). Only
+    /// meaningful when `protocol` is ICMP/ICMPv6; ignored for TCP/UDP terms.
+    pub(crate) icmp_type: Option<u8>,
+    /// #3020: optional ICMP/ICMPv6 code constraint, paired with `icmp_type`.
+    /// `None` matches any code of the constrained type.
+    pub(crate) icmp_code: Option<u8>,
 }
 
 /// Pre-indexed application matcher: groups terms by protocol for O(1) lookup.
@@ -616,6 +624,14 @@ struct ProtoTerms {
     exact_dst_ports: rustc_hash::FxHashSet<u16>,
     /// Port range terms that need linear scan (multi-port ranges).
     range_terms: Vec<(Vec<PortRange>, Vec<PortRange>)>, // (src_ranges, dst_ranges)
+    /// #3020: ICMP/ICMPv6 type[,code] constraints for icmp-constrained terms
+    /// (e.g. junos-ping = type 8). Each entry is `(type, optional code)`. A
+    /// packet matches this protocol via the icmp path iff its type (and code,
+    /// when the entry constrains it) equals one of these entries. An
+    /// UNCONSTRAINED ICMP term (junos-icmp-all) does NOT land here — it stays a
+    /// `range_terms` entry with empty ranges, which matches every ICMP packet,
+    /// so a rule citing both still matches all ICMP.
+    icmp_constraints: Vec<(u8, Option<u8>)>,
 }
 
 impl CompiledApplications {
@@ -629,8 +645,20 @@ impl CompiledApplications {
         let mut by_protocol: FxHashMap<u8, ProtoTerms> = FxHashMap::default();
         for app in apps {
             let entry = by_protocol.entry(app.protocol).or_default();
-            // Optimise the common case: single exact dst port, no src port restriction.
-            if app.source_ports.is_empty()
+            // #3020: an ICMP/ICMPv6 term with a type constraint (junos-ping)
+            // is steered to `icmp_constraints` so it matches ONLY that type
+            // (and code, when set) instead of every ICMP message. A term with
+            // NO icmp_type constraint falls through to the existing port path —
+            // an unconstrained ICMP term (junos-icmp-all) has empty ports and
+            // lands as a `range_terms` entry with empty ranges (match-all), so a
+            // rule citing both junos-ping AND junos-icmp-all still matches all
+            // ICMP. (ICMP terms never carry ports in practice; the type
+            // constraint takes precedence so a stray port is irrelevant here.)
+            if app.icmp_type.is_some() {
+                entry
+                    .icmp_constraints
+                    .push((app.icmp_type.expect("icmp_type is Some"), app.icmp_code));
+            } else if app.source_ports.is_empty()
                 && app.destination_ports.len() == 1
                 && app.destination_ports[0].low == app.destination_ports[0].high
             {
@@ -647,8 +675,22 @@ impl CompiledApplications {
         }
     }
 
+    /// #3020: `packet_icmp` carries the packet's ICMP/ICMPv6 `(type, code)` when
+    /// the protocol is ICMP-family AND the bytes were safely readable (not a
+    /// truncated frame or non-first fragment); `None` otherwise. It gates the
+    /// icmp-type-constrained terms (junos-ping): a constrained term matches only
+    /// when the type/code is known and equal, so an unknown type/code (or a
+    /// non-ICMP packet) fails closed for those terms. Port/range terms are
+    /// unaffected, so non-ICMP applications and the all-ICMP aliases behave
+    /// exactly as before.
     #[inline]
-    fn matches(&self, protocol: u8, src_port: u16, dst_port: u16) -> bool {
+    fn matches(
+        &self,
+        protocol: u8,
+        src_port: u16,
+        dst_port: u16,
+        packet_icmp: Option<(u8, u8)>,
+    ) -> bool {
         if self.match_any {
             return true;
         }
@@ -659,10 +701,26 @@ impl CompiledApplications {
         if terms.exact_dst_ports.contains(&dst_port) {
             return true;
         }
-        // Slow path: check range terms.
-        terms.range_terms.iter().any(|(src_ranges, dst_ranges)| {
+        // Slow path: check range terms (an unconstrained ICMP term, e.g.
+        // junos-icmp-all, lives here as an empty-range entry → match-all).
+        if terms.range_terms.iter().any(|(src_ranges, dst_ranges)| {
             port_ranges_match(src_ranges, src_port) && port_ranges_match(dst_ranges, dst_port)
-        })
+        }) {
+            return true;
+        }
+        // #3020: ICMP/ICMPv6 type[,code]-constrained terms (junos-ping). Match
+        // only when the packet's type/code is known and equals a constraint.
+        // When `packet_icmp` is None (non-ICMP packet, truncated frame, or
+        // non-first fragment) the constrained term does NOT match — fail closed.
+        if !terms.icmp_constraints.is_empty() {
+            if let Some((ptype, pcode)) = packet_icmp {
+                return terms
+                    .icmp_constraints
+                    .iter()
+                    .any(|&(ctype, ccode)| ctype == ptype && ccode.map_or(true, |c| c == pcode));
+            }
+        }
+        false
     }
 }
 
@@ -1255,6 +1313,10 @@ pub(crate) fn evaluate_policy_with_len(
     .action
 }
 
+/// Back-compat entry point with no ICMP type/code awareness (#3020): delegates
+/// to [`evaluate_policy_result_with_icmp`] with `packet_icmp = None`, so an
+/// icmp-type-constrained application term (junos-ping) does not match (fail
+/// closed) when the caller has no type/code. Non-ICMP flows are unaffected.
 pub(crate) fn evaluate_policy_result_with_len(
     state: &PolicyState,
     from_id: u16,
@@ -1264,6 +1326,31 @@ pub(crate) fn evaluate_policy_result_with_len(
     protocol: u8,
     src_port: u16,
     dst_port: u16,
+    packet_len: u64,
+) -> PolicyEvaluationResult {
+    evaluate_policy_result_with_icmp(
+        state, from_id, to_id, src_ip, dst_ip, protocol, src_port, dst_port, None, packet_len,
+    )
+}
+
+/// #3020: ICMP-aware policy evaluation. `packet_icmp` is the packet's
+/// ICMP/ICMPv6 `(type, code)` for ICMP-family flows whose L4 header was safely
+/// readable, else `None`. It gates the icmp-type-constrained application terms
+/// (junos-ping = echo-request only); non-ICMP flows pass `None` and are
+/// unaffected. The forwarding path (poll_descriptor) calls this directly with
+/// the per-packet type/code; the back-compat `evaluate_policy_result_with_len`
+/// and the `evaluate_policy*` test/legacy wrappers pass `None`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn evaluate_policy_result_with_icmp(
+    state: &PolicyState,
+    from_id: u16,
+    to_id: u16,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    packet_icmp: Option<(u8, u8)>,
     packet_len: u64,
 ) -> PolicyEvaluationResult {
     // #3110: zone id 0 is the reserved "unknown / no zone" sentinel
@@ -1290,6 +1377,7 @@ pub(crate) fn evaluate_policy_result_with_len(
                     protocol,
                     src_port,
                     dst_port,
+                    packet_icmp,
                     packet_len,
                 ) {
                     return result;
@@ -1305,6 +1393,7 @@ pub(crate) fn evaluate_policy_result_with_len(
                 protocol,
                 src_port,
                 dst_port,
+                packet_icmp,
                 packet_len,
             ) {
                 return result;
@@ -1338,12 +1427,16 @@ fn try_match_rule(
     protocol: u8,
     src_port: u16,
     dst_port: u16,
+    packet_icmp: Option<(u8, u8)>,
     packet_len: u64,
 ) -> Option<PolicyEvaluationResult> {
     if rule.inactive {
         return None;
     }
-    if !rule.compiled_apps.matches(protocol, src_port, dst_port) {
+    if !rule
+        .compiled_apps
+        .matches(protocol, src_port, dst_port, packet_icmp)
+    {
         return None;
     }
     // #2008 H2: when a side is `*-excluded`, the rule matches every
@@ -1529,6 +1622,10 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications
             protocol,
             source_ports,
             destination_ports,
+            // #3020: carry the optional ICMP type/code constraint through to the
+            // compiled matcher. A non-ICMP term simply has these as None.
+            icmp_type: term.icmp_type,
+            icmp_code: term.icmp_code,
         });
     }
     ParsedApplications {

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -623,6 +623,8 @@ fn named_application_matches_protocol_and_port() {
                 protocol: "tcp".to_string(),
                 source_port: String::new(),
                 destination_port: "80".to_string(),
+                icmp_type: None,
+                icmp_code: None,
             }],
             action: "permit".to_string(),
             ..Default::default()
@@ -679,6 +681,8 @@ fn proto_only_app_rule(rule_id: &str, protocol: &str) -> PolicyRuleSnapshot {
             protocol: protocol.to_string(),
             source_port: String::new(),
             destination_port: String::new(),
+            icmp_type: None,
+            icmp_code: None,
         }],
         action: "permit".to_string(),
         ..Default::default()
@@ -892,12 +896,16 @@ fn mixed_parseable_and_unparseable_fails_closed() {
                     protocol: "esp".to_string(),
                     source_port: String::new(),
                     destination_port: String::new(),
+                    icmp_type: None,
+                    icmp_code: None,
                 },
                 PolicyApplicationSnapshot {
                     name: "bogus".to_string(),
                     protocol: "definitely-not-a-proto".to_string(),
                     source_port: String::new(),
                     destination_port: String::new(),
+                    icmp_type: None,
+                    icmp_code: None,
                 },
             ],
             action: "permit".to_string(),
@@ -936,12 +944,16 @@ fn all_parseable_terms_match_each_protocol() {
                     protocol: "esp".to_string(),
                     source_port: String::new(),
                     destination_port: String::new(),
+                    icmp_type: None,
+                    icmp_code: None,
                 },
                 PolicyApplicationSnapshot {
                     name: "https".to_string(),
                     protocol: "tcp".to_string(),
                     source_port: String::new(),
                     destination_port: "443".to_string(),
+                    icmp_type: None,
+                    icmp_code: None,
                 },
             ],
             action: "permit".to_string(),
@@ -991,12 +1003,16 @@ fn application_set_matches_any_expanded_term() {
                     protocol: "tcp".to_string(),
                     source_port: String::new(),
                     destination_port: "80".to_string(),
+                    icmp_type: None,
+                    icmp_code: None,
                 },
                 PolicyApplicationSnapshot {
                     name: "junos-https".to_string(),
                     protocol: "tcp".to_string(),
                     source_port: String::new(),
                     destination_port: "443".to_string(),
+                    icmp_type: None,
+                    icmp_code: None,
                 },
             ],
             action: "permit".to_string(),
@@ -2742,4 +2758,212 @@ fn app_catalog_empty_resolves_unknown() {
     let cat = AppCatalog::default();
     assert!(cat.is_empty());
     assert_eq!(cat.lookup(6, 51000, 443), 0);
+}
+
+// ---------------------------------------------------------------------------
+// #3020 — junos-ping / junos-pingv6 are echo-request ONLY (ICMP type 8 /
+// ICMPv6 type 128), not every ICMP type. The all-ICMP aliases stay
+// unconstrained. The matcher gates an icmp-type-constrained term on the
+// packet's ICMP type/code, which is threaded into
+// `evaluate_policy_result_with_len` as `packet_icmp`.
+// ---------------------------------------------------------------------------
+
+fn icmp_app_rule(name: &str, protocol: &str, icmp_type: Option<u8>) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        name: name.to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec![name.to_string()],
+        application_terms: vec![PolicyApplicationSnapshot {
+            name: name.to_string(),
+            protocol: protocol.to_string(),
+            source_port: String::new(),
+            destination_port: String::new(),
+            icmp_type,
+            icmp_code: None,
+        }],
+        action: "permit".to_string(),
+        ..Default::default()
+    }
+}
+
+fn eval_icmp(state: &PolicyState, protocol: u8, icmp_type: u8, icmp_code: u8) -> PolicyAction {
+    evaluate_policy_result_with_icmp(
+        state,
+        TEST_LAN_ZONE_ID,
+        TEST_WAN_ZONE_ID,
+        "10.0.61.100".parse().expect("src"),
+        "172.16.80.200".parse().expect("dst"),
+        protocol,
+        0,
+        0,
+        Some((icmp_type, icmp_code)),
+        0,
+    )
+    .action
+}
+
+#[test]
+fn junos_ping_matches_echo_request_only() {
+    let state = parse_policy_state(
+        "deny",
+        &[icmp_app_rule("junos-ping", "icmp", Some(8))],
+        &test_zone_name_to_id(),
+    );
+    // Echo-request (type 8) is permitted.
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 8, 0), PolicyAction::Permit);
+    // Echo-reply (type 0) must NOT match — falls through to default deny.
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 0, 0), PolicyAction::Deny);
+    // Destination-unreachable (type 3) must NOT match.
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 3, 1), PolicyAction::Deny);
+}
+
+#[test]
+fn junos_pingv6_matches_echo_request_only() {
+    let state = parse_policy_state(
+        "deny",
+        &[icmp_app_rule("junos-pingv6", "icmpv6", Some(128))],
+        &test_zone_name_to_id(),
+    );
+    // ICMPv6 echo-request is type 128.
+    assert_eq!(eval_icmp(&state, PROTO_ICMPV6, 128, 0), PolicyAction::Permit);
+    // Echo-reply is 129 — must NOT match.
+    assert_eq!(eval_icmp(&state, PROTO_ICMPV6, 129, 0), PolicyAction::Deny);
+    // Neighbor solicitation (135) — must NOT match.
+    assert_eq!(eval_icmp(&state, PROTO_ICMPV6, 135, 0), PolicyAction::Deny);
+}
+
+#[test]
+fn junos_icmp_all_matches_every_type() {
+    // Regression: an UNCONSTRAINED ICMP term (junos-icmp-all) still matches
+    // every ICMP type/code, regardless of the packet's type.
+    let state = parse_policy_state(
+        "deny",
+        &[icmp_app_rule("junos-icmp-all", "icmp", None)],
+        &test_zone_name_to_id(),
+    );
+    for t in [0u8, 3, 8, 11, 13] {
+        assert_eq!(
+            eval_icmp(&state, PROTO_ICMP, t, 0),
+            PolicyAction::Permit,
+            "junos-icmp-all must match ICMP type {t}"
+        );
+    }
+}
+
+#[test]
+fn junos_ping_with_icmp_all_matches_every_type() {
+    // A rule citing BOTH junos-ping AND junos-icmp-all matches all ICMP: the
+    // unconstrained term short-circuits the type constraint.
+    let mut rule = icmp_app_rule("ping-and-all", "icmp", Some(8));
+    rule.application_terms.push(PolicyApplicationSnapshot {
+        name: "junos-icmp-all".to_string(),
+        protocol: "icmp".to_string(),
+        source_port: String::new(),
+        destination_port: String::new(),
+        icmp_type: None,
+        icmp_code: None,
+    });
+    let state = parse_policy_state("deny", &[rule], &test_zone_name_to_id());
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 8, 0), PolicyAction::Permit);
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 3, 0), PolicyAction::Permit);
+}
+
+#[test]
+fn icmp_constraint_does_not_affect_tcp_app() {
+    // A TCP application is completely unaffected by the icmp constraint path.
+    let state = parse_policy_state(
+        "deny",
+        &[PolicyRuleSnapshot {
+            name: "allow-http".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["junos-http".to_string()],
+            application_terms: vec![PolicyApplicationSnapshot {
+                name: "junos-http".to_string(),
+                protocol: "tcp".to_string(),
+                source_port: String::new(),
+                destination_port: "80".to_string(),
+                icmp_type: None,
+                icmp_code: None,
+            }],
+            action: "permit".to_string(),
+            ..Default::default()
+        }],
+        &test_zone_name_to_id(),
+    );
+    // TCP/80 permitted; a None packet_icmp (non-ICMP) is irrelevant.
+    assert_eq!(
+        evaluate_policy_result_with_icmp(
+            &state,
+            TEST_LAN_ZONE_ID,
+            TEST_WAN_ZONE_ID,
+            "10.0.61.100".parse().expect("src"),
+            "172.16.80.200".parse().expect("dst"),
+            PROTO_TCP,
+            40000,
+            80,
+            None,
+            0,
+        )
+        .action,
+        PolicyAction::Permit
+    );
+}
+
+#[test]
+fn junos_ping_unknown_icmp_type_fails_closed() {
+    // When the packet's ICMP type/code is unknown (truncated frame / non-first
+    // fragment → packet_icmp == None), an icmp-type-constrained term must NOT
+    // match (fail closed) rather than matching a fabricated type 0.
+    let state = parse_policy_state(
+        "deny",
+        &[icmp_app_rule("junos-ping", "icmp", Some(8))],
+        &test_zone_name_to_id(),
+    );
+    let action = evaluate_policy_result_with_icmp(
+        &state,
+        TEST_LAN_ZONE_ID,
+        TEST_WAN_ZONE_ID,
+        "10.0.61.100".parse().expect("src"),
+        "172.16.80.200".parse().expect("dst"),
+        PROTO_ICMP,
+        0,
+        0,
+        None, // type/code unknown
+        0,
+    )
+    .action;
+    assert_eq!(action, PolicyAction::Deny);
+}
+
+#[test]
+fn icmp_skew_old_snapshot_without_type_matches_all() {
+    // Version skew: a snapshot whose application term OMITS the icmp_type field
+    // (old Go control plane) decodes to icmp_type=None → the term is
+    // unconstrained and matches every ICMP type — today's pre-#3020 behavior,
+    // so skew degrades safely to match-all rather than failing to decode.
+    let json = r#"{
+        "name": "legacy-ping",
+        "from_zone": "lan",
+        "to_zone": "wan",
+        "source_addresses": ["any"],
+        "destination_addresses": ["any"],
+        "applications": ["junos-ping"],
+        "application_terms": [{"name": "junos-ping", "protocol": "icmp"}],
+        "action": "permit"
+    }"#;
+    let snap: PolicyRuleSnapshot =
+        serde_json::from_str(json).expect("legacy snapshot without icmp_type decodes");
+    assert!(
+        snap.application_terms[0].icmp_type.is_none(),
+        "omitted icmp_type must decode to None"
+    );
+    let state = parse_policy_state("deny", &[snap], &test_zone_name_to_id());
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 8, 0), PolicyAction::Permit);
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 3, 0), PolicyAction::Permit);
 }

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -352,6 +352,18 @@ pub(crate) struct PolicyApplicationSnapshot {
     pub source_port: String,
     #[serde(rename = "destination_port", default)]
     pub destination_port: String,
+    /// #3020: optional ICMP/ICMPv6 type (and code) constraint. `None` means
+    /// "no constraint" — the term matches every type/code of its protocol (the
+    /// historical behavior, kept by the all-ICMP aliases). junos-ping sets
+    /// `icmp_type = Some(8)`, junos-pingv6 `Some(128)`. `#[serde(default)]`
+    /// makes an old Go snapshot that omits the field decode to `None` (match
+    /// all ICMP — today's behavior), so version skew degrades safely rather
+    /// than failing to decode. `skip_serializing_if = Option::is_none` keeps
+    /// the default specimen (and the `protocol_wire_v1` fixture) byte-identical.
+    #[serde(rename = "icmp_type", default, skip_serializing_if = "Option::is_none")]
+    pub icmp_type: Option<u8>,
+    #[serde(rename = "icmp_code", default, skip_serializing_if = "Option::is_none")]
+    pub icmp_code: Option<u8>,
 }
 
 /// One row of the L3/L4 application-identification catalog (#2008 M5). Mirrors


### PR DESCRIPTION
Closes #3020.

## Problem
`junos-ping` / `junos-pingv6` were protocol-only predefined apps with no
ICMP type/code constraint, so for policy matching they were identical to
`junos-icmp-all` / `junos-icmp6-all`: a `permit junos-ping` rule also
admitted destination-unreachable, time-exceeded, redirect, and (for IPv6)
the whole ICMPv6 control-plane / neighbor-discovery / error set. Junos
parity is echo-request only — ICMP type 8 / ICMPv6 type 128.

## Fix (end-to-end ICMP type/code constraint, #1961 wire discipline)
- `config.Application` gains `ICMPType`/`ICMPCode` (`*uint8`); `predefined.go`
  sets junos-ping=8, junos-pingv6=128. The all-ICMP aliases stay
  unconstrained (nil) and byte-identical.
- Carried on `PolicyApplicationSnapshot.ICMPType/ICMPCode` (Go) + the Rust
  serde struct. Additive wire: pointer + `omitempty` (Go),
  `#[serde(default, skip_serializing_if = "Option::is_none")]` (Rust). Skew
  decodes to `None` = match-all (prior behavior); the `protocol_wire_v1`
  fixture is unchanged.
- Rust matcher routes an icmp-type-constrained term into a per-protocol
  `icmp_constraints` list, matching only when the packet's type (and code,
  if set) equals it. An unconstrained ICMP term (junos-icmp-all) stays a
  match-all `range_terms` entry, so a rule citing both still matches all
  ICMP. TCP/UDP apps unaffected.
- Packet ICMP type/code IS reachable at policy-match time (cold path,
  session miss): `policy_packet_icmp` extracts `(type, code)` via the
  fragment/truncation-safe `term_match_extra_from_frame`; unknown type/code
  fails closed. `evaluate_policy_result_with_len` keeps its signature and
  delegates to the new `evaluate_policy_result_with_icmp`; the two
  forwarding sites call the icmp-aware entry.
- App-identification catalog (`app_id` stamping) intentionally unchanged —
  cosmetic naming, not enforcement.

## Tests
- Go: junos-ping→type 8, junos-pingv6→type 128; junos-icmp-all/6-all stay nil.
- Rust: junos-ping matches type 8, not 0/3; junos-pingv6 matches 128, not
  129/135; junos-icmp-all matches every type; ping+icmp-all matches all;
  TCP unaffected; unknown type fails closed; old snapshot omitting the field
  matches all ICMP.
- `go test ./pkg/config/ ./pkg/dataplane/... ./pkg/appid/` 2580 pass;
  `cargo test --release` 3130 pass incl. `wire_invariant_default_specimens`
  (no fixture regen).
- Fail-on-revert: routing icmp-constrained terms as match-all turns
  `junos_ping_matches_echo_request_only` / `junos_pingv6_matches_echo_request_only`
  RED while `junos_icmp_all_matches_every_type` stays GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi