### PR TITLE
userspace-dp: enforce to-zone junos-host security policy (#3019)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20451,3 +20451,25 @@ top.
   userspace-dp/src/nat/allocator.rs, userspace-dp/src/nat/status.rs,
   userspace-dp/src/nat/tests.rs, userspace-dp/tests/fixtures/protocol_wire_v1.json,
   docs/userspace-dataplane-gaps.md, docs/config-schema.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #3019 — enforce `to-zone junos-host` self-traffic security
+  policy on the dataplane LocalDelivery path (it previously committed +
+  documented but was never evaluated). Reserve `JUNOS_HOST_ZONE_ID`
+  (`u16::MAX-1`); `PolicyState::from_snapshots` now INDEXES junos-host rules
+  via `resolve_policy_zone_id` (+ `has_junos_host_rules` gate). New
+  `evaluate_junos_host_policy` (match-driven, no implicit default-deny =
+  lifeline fail-safe). Wired `junos_host_policy_drops` into BOTH
+  poll_descriptor LocalDelivery sites (session-miss + session-hit) AFTER
+  `host_inbound_admits` (Junos order: host-inbound THEN policy). Deny/reject
+  emits the policy-deny RT_FLOW + reject/tcp-rst reply and tears down a cached
+  host-local session. `from-zone junos-host` indexed but not consulted
+  (host-originated path = follow-up). Tests: 5 policy unit + 3 poll-path
+  (miss deny + no-policy GREEN pair + hit deny) Rust, 1 Go snapshot test;
+  fail-on-revert verified (miss deny RED, no-policy GREEN). Docs updated.
+  **File(s)**: userspace-dp/src/policy.rs, userspace-dp/src/policy_tests.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  pkg/dataplane/userspace/junos_host_policy_3019_test.go,
+  docs/junos-cli-reference.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -241,6 +241,31 @@ From zone: guest, To zone: lan
 - **Policy fields:** 4-space indent, `<Key>: <value>`.
 - **Action line:** `Action: permit` or `Action: reject, log` or `Action: deny, log`.
 - Multiple addresses shown as named address entries.
+- **`junos-host` self-traffic policy (#3019):** a `from-zone <z> to-zone
+  junos-host` policy is the Junos self-traffic (host-bound) security policy.
+  As of #3019 these policies are ENFORCED on the dataplane LocalDelivery path
+  (host-bound traffic destined to a firewall-local interface IP), not merely
+  accepted at commit. Ordering follows Junos: **host-inbound-traffic admission
+  (`set security zones security-zone <z> host-inbound-traffic ...`, #3070)
+  runs FIRST**, then the `to-zone junos-host` security policy. A packet that
+  host-inbound already rejected never reaches policy, so a `to-zone junos-host
+  then permit` cannot re-admit a service host-inbound denies. A matching
+  `then deny`/`then reject` drops the host-bound packet (emitting the same
+  policy-deny RT_FLOW + `reject`/zone-`tcp-rst` reply as a transit deny) and
+  tears down any cached host-local session on the next hit. Hit counters for
+  these rules now advance.
+  - **Lifeline fail-safe:** enforcement is strictly MATCH-DRIVEN. If NO
+    `junos-host` policy is configured, or a host-bound flow matches no
+    `junos-host` rule, behavior is UNCHANGED from before #3019 — there is no
+    implicit junos-host default-deny, so configuring some junos-host policy
+    cannot silently brick management/host traffic that does not match a deny
+    rule. (The stricter Junos "any configured junos-host zone-pair implies a
+    default-deny for that pair" posture is intentionally deferred.)
+  - **Scope:** `to-zone junos-host` (host-INBOUND) is enforced.
+    `from-zone junos-host` (host-ORIGINATED / locally-generated traffic) rules
+    are accepted and indexed but NOT yet consulted — locally-generated traffic
+    does not traverse the ingress LocalDelivery path; that direction is a
+    documented follow-up.
 
 ### Filtering
 

--- a/pkg/dataplane/userspace/junos_host_policy_3019_test.go
+++ b/pkg/dataplane/userspace/junos_host_policy_3019_test.go
@@ -1,0 +1,69 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestJunosHostPolicySnapshotCarriesRule is the Go-side #3019 guard. A
+// `from-zone trust to-zone junos-host` security policy commits (the strict
+// validator exempts the reserved `junos-host` self zone) and MUST reach the
+// dataplane snapshot with its from/to zone NAME strings intact, so the Rust
+// PolicyState::from_snapshots can resolve `junos-host` to the reserved
+// JUNOS_HOST_ZONE_ID and INDEX the rule (the Go↔Rust agreement is on the
+// reserved name string, not a wire zone id — `junos-host` is never put on the
+// wire because zone ids are u8). Before #3019 the rule was accepted at commit
+// but the snapshot/runtime never wired it to the LocalDelivery policy gate.
+func TestJunosHostPolicySnapshotCarriesRule(t *testing.T) {
+	tree := &config.ConfigTree{}
+	cmds := []string{
+		"set security zones security-zone trust interfaces eth0",
+		"set security zones security-zone untrust interfaces eth1",
+		"set security policies from-zone trust to-zone junos-host policy deny-host match source-address any",
+		"set security policies from-zone trust to-zone junos-host policy deny-host match destination-address any",
+		"set security policies from-zone trust to-zone junos-host policy deny-host match application any",
+		"set security policies from-zone trust to-zone junos-host policy deny-host then deny",
+	}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (junos-host policy must commit): %v", err)
+	}
+
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{Workers: 1, RingEntries: 2048}, 1, 1)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+
+	var found *PolicyRuleSnapshot
+	for i := range snap.Policies {
+		if snap.Policies[i].ToZone == "junos-host" {
+			found = &snap.Policies[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("policy snapshot must carry a to-zone junos-host rule; got %+v", snap.Policies)
+	}
+	if found.FromZone != "trust" {
+		t.Fatalf("junos-host rule FromZone = %q, want %q", found.FromZone, "trust")
+	}
+	if found.ToZone != "junos-host" {
+		t.Fatalf("junos-host rule ToZone = %q, want %q", found.ToZone, "junos-host")
+	}
+	if found.Action != "deny" {
+		t.Fatalf("junos-host rule Action = %q, want %q", found.Action, "deny")
+	}
+	if found.Name != "deny-host" {
+		t.Fatalf("junos-host rule Name = %q, want %q", found.Name, "deny-host")
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -169,7 +169,7 @@ hit). A packet host-inbound already rejected never reaches policy, so a
 name to `JUNOS_HOST_ZONE_ID` (`u16::MAX-1`, the bottom of the reserved range,
 never on the wire because zone ids are u8) and looks up the
 `(ingress_zone_id, JUNOS_HOST_ZONE_ID)` zone pair in the SAME `zone_pair_index`
-as transit rules — `PolicyState::from_snapshots` now INDEXES junos-host rules
+as transit rules — `parse_policy_state_with_counters` now INDEXES junos-host rules
 via `resolve_policy_zone_id` (pre-#3019 they were kept-but-not-indexed, like the
 wildcard-`any` case). A matched deny/reject drops the packet, emits the
 policy-deny RT_FLOW (egress zone reported as `0`/host since the synthetic id

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -155,6 +155,36 @@ admit; an unrecognised token contributes nothing (fail-closed). ICMP-based
 services (`ping`, `router-discovery`) admit at L4-protocol granularity, not
 ICMP sub-type.
 
+## `junos-host` self-traffic security policy (#3019)
+
+Host-bound (LocalDelivery) traffic is also subject to the Junos
+`from-zone <z> to-zone junos-host` security policy. Junos order is
+**host-inbound admission FIRST, then security policy** — so the
+`junos_host_policy_drops` gate runs immediately AFTER `host_inbound_admits`
+at BOTH local-delivery sites in `poll_descriptor` (session miss and session
+hit). A packet host-inbound already rejected never reaches policy, so a
+`to-zone junos-host then permit` cannot re-admit it.
+
+`policy::evaluate_junos_host_policy` resolves the reserved `junos-host` zone
+name to `JUNOS_HOST_ZONE_ID` (`u16::MAX-1`, the bottom of the reserved range,
+never on the wire because zone ids are u8) and looks up the
+`(ingress_zone_id, JUNOS_HOST_ZONE_ID)` zone pair in the SAME `zone_pair_index`
+as transit rules — `PolicyState::from_snapshots` now INDEXES junos-host rules
+via `resolve_policy_zone_id` (pre-#3019 they were kept-but-not-indexed, like the
+wildcard-`any` case). A matched deny/reject drops the packet, emits the
+policy-deny RT_FLOW (egress zone reported as `0`/host since the synthetic id
+does not fit the u8 wire slot), synthesizes a `reject`/zone-`tcp-rst` reply, and
+on the hit path tears down the cached host-local session.
+
+Enforcement is MATCH-DRIVEN and fail-safe: the gate is a NO-OP unless
+`PolicyState::has_junos_host_rules` is set (some junos-host rule configured),
+and a no-match falls through to today's behavior (local delivery proceeds).
+There is NO implicit junos-host default-deny — the deliberate lifeline
+guarantee that configuring junos-host policy can never silently brick
+management/host traffic. `from-zone junos-host` (host-ORIGINATED) rules are
+indexed but not consulted here (locally-generated traffic does not traverse
+this ingress path) — a documented follow-up.
+
 ## Host-terminated IPsec passthrough
 
 `is_ipsec_traffic(protocol, dst_port)` recognizes packets destined for

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -67,6 +67,90 @@ fn policy_packet_icmp(packet_frame: &[u8], meta: UserspaceDpMeta) -> Option<(u8,
     }
 }
 
+/// #3019: enforce a configured `to-zone junos-host` security policy on the
+/// host-bound (LocalDelivery) path. MUST be called AFTER `host_inbound_admits`
+/// (Junos order: host-inbound-traffic admission first, then security policy),
+/// so a `then permit` can never re-admit what host-inbound already rejected.
+///
+/// Returns `true` iff the packet must be DROPPED — a `to-zone junos-host` rule
+/// MATCHED with `deny`/`reject`. On a deny/reject it emits the policy-deny
+/// RT_FLOW (mirroring the transit deny path) and synthesizes a `reject` / zone
+/// `tcp-rst` reply. Returns `false` (continue local delivery) when no
+/// junos-host policy is configured, none matches, or a matching rule permits —
+/// preserving pre-#3019 host-bound behavior so management traffic is never
+/// newly denied (the lifeline guarantee). Cold path only (LocalDelivery).
+#[allow(clippy::too_many_arguments)]
+fn junos_host_policy_drops(
+    forwarding: &ForwardingState,
+    event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
+    tx_pipeline: &mut crate::afxdp::worker::WorkerTxPipeline,
+    ingress_ifindex: i32,
+    packet_frame: &[u8],
+    counters: &mut BatchCounters,
+    flow: &SessionFlow,
+    meta: UserspaceDpMeta,
+    from_zone_id: u16,
+    packet_len: u64,
+    now_ns: u64,
+) -> bool {
+    let policy_icmp = policy_packet_icmp(packet_frame, meta);
+    let Some(result) = crate::policy::evaluate_junos_host_policy(
+        &forwarding.policy,
+        from_zone_id,
+        flow.src_ip,
+        flow.dst_ip,
+        flow.forward_key.protocol,
+        flow.forward_key.src_port,
+        flow.forward_key.dst_port,
+        policy_icmp,
+        packet_len,
+    ) else {
+        return false;
+    };
+    match result.action {
+        PolicyAction::Permit => false,
+        PolicyAction::Deny | PolicyAction::Reject => {
+            emit_policy_deny_event(
+                event_stream,
+                flow,
+                // LocalDelivery applies no NAT — the deny record carries no
+                // nat_* translation (byte-identical to a non-NAT transit deny).
+                &crate::nat::NatDecision::default(),
+                meta,
+                from_zone_id,
+                // The egress "zone" is the firewall host itself. The reserved
+                // JUNOS_HOST_ZONE_ID (u16::MAX-1) does not fit the u8 wire
+                // zone-id slot (#919/#922), so the deny RT_FLOW carries 0
+                // ("unknown / host", the #3110 sentinel) rather than a value
+                // that would truncate into a real zone id on the wire.
+                0,
+                // Host-local sessions are not policy-forwarded; owner_rg_id 0.
+                0,
+                result.policy_id,
+                result.action,
+                resolve_policy_deny_app_id(
+                    &forwarding.app_catalog,
+                    flow,
+                    flow.forward_key.dst_port,
+                ),
+                now_ns,
+            );
+            enqueue_deny_reply(
+                tx_pipeline,
+                forwarding,
+                ingress_ifindex,
+                packet_frame,
+                meta,
+                flow,
+                counters,
+                matches!(result.action, PolicyAction::Reject),
+                from_zone_id,
+            );
+            true
+        }
+    }
+}
+
 // Per-batch packet processing lifted from `poll_binding` (#678).
 //
 // Runs `binding.xsk.rx.receive(available)` + the descriptor while-let +
@@ -560,6 +644,51 @@ pub(super) fn poll_binding_process_descriptor(
                                 meta.protocol,
                                 resolved.key.dst_port,
                                 matches!(flow.dst_ip, IpAddr::V6(_)),
+                            )
+                        {
+                            delete_terminal_filtered_session(
+                                sessions,
+                                binding.bpf_maps.session_map_fd,
+                                conntrack_v4_fd,
+                                conntrack_v6_fd,
+                                worker_ctx.shared_sessions,
+                                worker_ctx.shared_nat_sessions,
+                                worker_ctx.shared_forward_wire_sessions,
+                                &worker_ctx.shared_owner_rg_indexes,
+                                worker_ctx.peer_worker_commands,
+                                &resolved.key,
+                                resolved.decision,
+                                &resolved.metadata,
+                                resolved.origin,
+                            );
+                            telemetry.dbg.local += 1;
+                            telemetry.dbg.policy_deny += 1;
+                            binding.scratch.scratch_recycle.push(desc.addr);
+                            continue;
+                        }
+                        // #3019: `to-zone junos-host` security policy on the
+                        // session-HIT local-delivery path, mirroring the #3070
+                        // host-inbound re-check above: re-evaluated on every hit
+                        // so a tightened junos-host deny tears down an already
+                        // established host-bound session WITHOUT an explicit
+                        // purge. Runs AFTER host-inbound admission (Junos order).
+                        // A matching deny/reject drops + emits the policy-deny
+                        // RT_FLOW; permit / no-match continue. No-op unless a
+                        // junos-host policy is configured.
+                        if resolved.decision.resolution.disposition
+                            == ForwardingDisposition::LocalDelivery
+                            && junos_host_policy_drops(
+                                worker_ctx.forwarding,
+                                worker_ctx.event_stream,
+                                &mut binding.tx_pipeline,
+                                binding.ifindex,
+                                packet_frame,
+                                telemetry.counters,
+                                flow,
+                                meta,
+                                resolved.metadata.ingress_zone,
+                                desc.len as u64,
+                                now_ns,
                             )
                         {
                             delete_terminal_filtered_session(
@@ -1330,6 +1459,34 @@ pub(super) fn poll_binding_process_descriptor(
                                 meta.protocol,
                                 flow.forward_key.dst_port,
                                 matches!(flow.dst_ip, IpAddr::V6(_)),
+                            )
+                        {
+                            telemetry.dbg.local += 1;
+                            telemetry.dbg.policy_deny += 1;
+                            telemetry.counters.touched = true;
+                            binding.scratch.scratch_recycle.push(desc.addr);
+                            continue;
+                        }
+                        // #3019: `to-zone junos-host` security policy on the
+                        // session-MISS local-delivery path, AFTER host-inbound
+                        // admission (Junos order). A matching junos-host deny/
+                        // reject drops the host-bound packet (and emits the
+                        // policy-deny RT_FLOW + reject/tcp-rst reply); a permit
+                        // or no-match continues to local delivery unchanged.
+                        // No-op unless a junos-host policy is configured.
+                        if resolution.disposition == ForwardingDisposition::LocalDelivery
+                            && junos_host_policy_drops(
+                                worker_ctx.forwarding,
+                                worker_ctx.event_stream,
+                                &mut binding.tx_pipeline,
+                                binding.ifindex,
+                                packet_frame,
+                                telemetry.counters,
+                                flow,
+                                meta,
+                                from_zone_id,
+                                desc.len as u64,
+                                now_ns,
                             )
                         {
                             telemetry.dbg.local += 1;

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -8400,6 +8400,372 @@ fn unencapsulated_local_delivery_reinjects_slow_path_exactly_once() {
     );
 }
 
+/// #3019: gre_to_self_snapshot (default-permit, lan ingress, 10.255.0.1 local)
+/// optionally extended with a `from-zone lan to-zone junos-host` policy.
+fn junos_host_local_delivery_snapshot(action: Option<&str>) -> ConfigSnapshot {
+    let mut snapshot = gre_to_self_snapshot();
+    if let Some(act) = action {
+        snapshot.policies.push(PolicyRuleSnapshot {
+            name: "host-policy".to_string(),
+            from_zone: "lan".to_string(),
+            to_zone: "junos-host".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["any".to_string()],
+            application_terms: Vec::new(),
+            action: act.to_string(),
+            ..Default::default()
+        });
+    }
+    snapshot
+}
+
+/// #3019 LITERAL fail-on-revert (session-MISS): a `from-zone lan to-zone
+/// junos-host then deny` policy DROPS a host-bound packet on the LocalDelivery
+/// session-miss path, AFTER host-inbound admission. The packet is denied
+/// (dbg.policy_deny == 1), never reaches the slow-path reinject
+/// (slow_path_drops == 0), and no host-local session is cached. Remove the
+/// `junos_host_policy_drops` call in the session-miss LocalDelivery arm and
+/// this test goes RED (the packet would reinject to the slow path instead),
+/// while `poll_descriptor_no_junos_host_policy_local_delivery_unchanged_session_miss`
+/// stays GREEN.
+#[test]
+fn poll_descriptor_junos_host_deny_drops_local_delivery_session_miss() {
+    let forwarding = build_forwarding_state(&junos_host_local_delivery_snapshot(Some("deny")));
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(10, 0, 61, 102),
+        Ipv4Addr::new(10, 255, 0, 1),
+        12345,
+        179,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(24, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+
+    let (tx, rx) = mpsc::sync_channel(8);
+    let wake = Arc::new(TunnelWake::new().expect("eventfd"));
+    let mut deliveries = BTreeMap::new();
+    deliveries.insert(77, LocalTunnelDelivery { tx, wake });
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(deliveries));
+
+    let (_batch, dbg) = txn_run_descriptor_with_deliveries(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+        &local_tunnel_deliveries,
+    );
+
+    assert_eq!(dbg.local, 1, "packet must take the LocalDelivery arm");
+    assert_eq!(
+        dbg.policy_deny, 1,
+        "to-zone junos-host deny must drop the host-bound packet"
+    );
+    assert_eq!(
+        binding.live.slow_path_drops.load(Ordering::Relaxed),
+        0,
+        "a junos-host-denied host-bound packet must NOT reach the slow-path \
+         reinject (#3019 — the deny short-circuits before should_cache)"
+    );
+    assert_eq!(
+        sessions.len(),
+        0,
+        "no host-local session may be cached for a junos-host-denied flow"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "a denied packet must not reach any delivery channel"
+    );
+}
+
+/// #3019 lifeline fail-safe (session-MISS GREEN pair): with NO junos-host
+/// policy configured, a host-bound packet keeps pre-#3019 behavior — admitted
+/// (dbg.policy_deny == 0) and reinjected to the slow path (slow_path_drops ==
+/// 1). This stays GREEN when the LocalDelivery policy-eval call is removed,
+/// proving the deny test above is the literal fail-on-revert sentinel and that
+/// the change cannot newly deny management/host traffic.
+#[test]
+fn poll_descriptor_no_junos_host_policy_local_delivery_unchanged_session_miss() {
+    let forwarding = build_forwarding_state(&junos_host_local_delivery_snapshot(None));
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(10, 0, 61, 102),
+        Ipv4Addr::new(10, 255, 0, 1),
+        12345,
+        179,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(24, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+
+    let (tx, rx) = mpsc::sync_channel(8);
+    let wake = Arc::new(TunnelWake::new().expect("eventfd"));
+    let mut deliveries = BTreeMap::new();
+    deliveries.insert(77, LocalTunnelDelivery { tx, wake });
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(deliveries));
+
+    let (_batch, dbg) = txn_run_descriptor_with_deliveries(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+        &local_tunnel_deliveries,
+    );
+
+    assert_eq!(dbg.local, 1, "packet must take the LocalDelivery arm");
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "no junos-host policy: host-bound packet must not be policy-denied"
+    );
+    assert_eq!(
+        binding.live.slow_path_drops.load(Ordering::Relaxed),
+        1,
+        "no junos-host policy: host-bound packet keeps pre-#3019 slow-path reinject"
+    );
+    assert!(rx.try_recv().is_err());
+}
+
+/// #3019 LITERAL fail-on-revert (session-HIT): a tightened `to-zone junos-host
+/// then deny` tears down an ALREADY ESTABLISHED host-bound session on the next
+/// hit (mirroring the #3070 host-inbound re-check) and emits the policy-deny
+/// RT_FLOW. Remove the `junos_host_policy_drops` call in the session-HIT
+/// LocalDelivery arm and this test goes RED (the session would survive and no
+/// PolicyDeny event would be emitted).
+#[test]
+fn poll_descriptor_junos_host_deny_drops_local_delivery_session_hit() {
+    let mut snapshot = policy_deny_snapshot();
+    snapshot.default_policy = "permit".to_string();
+    snapshot.policies = vec![PolicyRuleSnapshot {
+        name: "host-deny".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "junos-host".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: "deny".to_string(),
+        ..Default::default()
+    }];
+    snapshot.interfaces[0].addresses = vec![InterfaceAddressSnapshot {
+        family: "inet".to_string(),
+        address: "10.0.61.1/24".to_string(),
+        scope: 0,
+    }];
+
+    let forwarding = build_forwarding_state(&snapshot);
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut frame = build_policy_deny_tcp_syn_frame();
+    set_ipv4_dst(&mut frame, Ipv4Addr::new(10, 0, 61, 1));
+    let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+    let frame_offset = 128;
+    let meta_offset = frame_offset - meta_len;
+    let meta = UserspaceDpMeta {
+        magic: USERSPACE_META_MAGIC,
+        version: USERSPACE_META_VERSION,
+        length: meta_len as u16,
+        ingress_ifindex: 24,
+        l3_offset: 14,
+        l4_offset: 34,
+        payload_offset: 54,
+        pkt_len: (frame.len() - 14) as u16,
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        config_generation: 7,
+        fib_generation: 9,
+        ..UserspaceDpMeta::default()
+    };
+    let meta_bytes = unsafe {
+        std::slice::from_raw_parts((&meta as *const UserspaceDpMeta).cast::<u8>(), meta_len)
+    };
+    unsafe {
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(meta_offset, meta_len)
+            .expect("meta slice")
+            .copy_from_slice(meta_bytes);
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(frame_offset, frame.len())
+            .expect("frame slice")
+            .copy_from_slice(&frame);
+    }
+    binding.xsk.rx.push_for_test(XdpDesc {
+        addr: frame_offset as u64,
+        len: frame.len() as u32,
+        options: 0,
+    });
+
+    let ident = binding.identity();
+    let binding_lookup = WorkerBindingLookup::from_bindings(std::slice::from_ref(&binding));
+    let mirror_targets = MirrorTargetMap::default();
+    let ha_state = BTreeMap::new();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding: &forwarding,
+        ha_state: &ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        neighbor_resolver: None,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+        cold_path_sample_mask: 0xff,
+    };
+    let mut sessions = SessionTable::new();
+    let flow_key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 1)),
+        src_port: 12345,
+        dst_port: 5201,
+    };
+    let local_decision = SessionDecision {
+        resolution: ForwardingResolution {
+            disposition: ForwardingDisposition::LocalDelivery,
+            local_ifindex: 24,
+            egress_ifindex: 24,
+            tx_ifindex: 24,
+            tunnel_endpoint_id: 0,
+            next_hop: None,
+            neighbor_mac: None,
+            src_mac: None,
+            tx_vlan_id: 0,
+        },
+        nat: NatDecision::default(),
+    };
+    let local_metadata = SessionMetadata {
+        ingress_zone: TEST_LAN_ZONE_ID,
+        egress_zone: TEST_LAN_ZONE_ID,
+        owner_rg_id: 0,
+        fabric_ingress: false,
+        is_reverse: false,
+        nat64_reverse: None,
+        log_session_init: false,
+        log_session_close: false,
+        policy_id: 0,
+    };
+    assert!(sessions.install_with_protocol_with_origin(
+        flow_key.clone(),
+        local_decision,
+        local_metadata.clone(),
+        SessionOrigin::LocalMiss,
+        123_000_000_000,
+        PROTO_TCP,
+        TCP_FLAG_SYN,
+    ));
+    let shared_entry = SyncedSessionEntry {
+        key: flow_key.clone(),
+        decision: local_decision,
+        metadata: local_metadata,
+        origin: SessionOrigin::LocalMiss,
+        protocol: PROTO_TCP,
+        tcp_flags: TCP_FLAG_SYN,
+        generation: 0,
+    };
+    publish_shared_session(
+        &shared_sessions,
+        &shared_nat_sessions,
+        &shared_forward_wire_sessions,
+        &shared_owner_rg_indexes,
+        &shared_entry,
+    );
+    assert_eq!(sessions.drain_deltas(16).len(), 1, "initial open delta");
+    let mut screen = ScreenState::new();
+    let mut batch = BatchCounters::default();
+    let mut dbg = DebugPollCounters::default();
+    let mut telemetry = TelemetryContext {
+        dbg: &mut dbg,
+        counters: &mut batch,
+    };
+    let area_ptr = binding.umem.area() as *const MmapArea;
+
+    poll_binding_process_descriptor(
+        &mut binding,
+        0,
+        area_ptr,
+        1,
+        &mut sessions,
+        &mut screen,
+        ValidationState {
+            snapshot_installed: true,
+            config_generation: 7,
+            fib_generation: 9,
+        },
+        123_000_000_000,
+        123,
+        0,
+        0,
+        -1,
+        -1,
+        &worker_ctx,
+        &mut telemetry,
+    );
+
+    let event = event_rx
+        .try_recv()
+        .expect("policy-deny event from junos-host deny on cached local session hit")
+        .decode_dataplane_event()
+        .expect("policy-deny payload");
+    assert_eq!(
+        event.kind,
+        crate::event_stream::codec::DataplaneEventKind::PolicyDeny
+    );
+    assert_eq!(event.ingress_zone_id, TEST_LAN_ZONE_ID);
+    assert_eq!(event.src_port, 12345);
+    assert_eq!(event.dst_port, 5201);
+    assert_eq!(sessions.len(), 0, "junos-host deny must tear down the cached session");
+    let deltas = sessions.drain_deltas(16);
+    assert_eq!(deltas.len(), 1);
+    assert_eq!(deltas[0].kind, SessionDeltaKind::Close);
+    assert_eq!(deltas[0].key, flow_key);
+    assert!(telemetry.dbg.policy_deny >= 1);
+    assert_eq!(event_handle.dataplane_event_stats().policy_deny.sent, 1);
+}
+
 /// #1885 decap-level consistency pin: on VLAN-TAGGED ingress the decap
 /// must produce a synthetic frame and an inner meta that describe EACH
 /// OTHER — `synthetic[meta.l3_offset..]` IS the inner packet. (The

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -341,6 +341,24 @@ pub(crate) fn zone_pair_key(from_id: u16, to_id: u16) -> ZonePairKey {
 pub(crate) const JUNOS_GLOBAL_ZONE_ID: u16 = u16::MAX;
 pub(crate) const ZONE_ID_RESERVED_MIN: u16 = u16::MAX - 1;
 
+/// #3019: synthetic reserved zone id for the Junos `junos-host` self-traffic
+/// zone (`to-zone junos-host` / `from-zone junos-host` security policies). It
+/// lives at the BOTTOM of the reserved range (`ZONE_ID_RESERVED_MIN`), so a
+/// configured zone can never collide: `forwarding_build::populate_zones`
+/// already skips any snapshot zone whose id is `>= ZONE_ID_RESERVED_MIN`, and
+/// `configured_zone_pairs` excludes both sentinels from the cold-path
+/// histogram. The id is never put on the wire (the event-stream codec writes
+/// zone ids as u8); it exists only as the in-runtime key so a `junos-host`
+/// rule is INDEXED in `zone_pair_index` and reachable by the LocalDelivery
+/// policy gate. The Go control plane emits the `junos-host` zone NAME string
+/// in the rule snapshot; `parse_policy_state_with_counters` resolves that name
+/// to this id (Go↔Rust agreement is on the reserved name, not a wire id).
+pub(crate) const JUNOS_HOST_ZONE_ID: u16 = u16::MAX - 1;
+
+/// #3019: reserved Junos self-traffic zone name, recognized in policy
+/// from/to zone resolution and mapped to [`JUNOS_HOST_ZONE_ID`].
+pub(crate) const JUNOS_HOST_ZONE_NAME: &str = "junos-host";
+
 use crate::ip_proto::{
     PROTO_AH, PROTO_EGP, PROTO_ESP, PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6, PROTO_IGMP, PROTO_IPIP,
     PROTO_OSPF, PROTO_PIM, PROTO_SCTP, PROTO_TCP, PROTO_UDP, PROTO_VRRP,
@@ -859,6 +877,11 @@ pub(crate) struct PolicyState {
     pub(crate) books: Vec<BookEntry>,
     /// #1606: wire-ID → dense-index map used at parse time only.
     book_id_to_idx: FxHashMap<u32, u32>,
+    /// #3019: true iff at least one rule names `junos-host` as its from OR to
+    /// zone. The LocalDelivery junos-host policy gate is a NO-OP unless this is
+    /// set, so a config with no junos-host policy keeps pre-#3019 host-bound
+    /// behavior exactly (no risk of newly denying management traffic).
+    has_junos_host_rules: bool,
 }
 
 impl Default for PolicyState {
@@ -870,6 +893,7 @@ impl Default for PolicyState {
             global_indices: Vec::new(),
             books: Vec::new(),
             book_id_to_idx: FxHashMap::default(),
+            has_junos_host_rules: false,
         }
     }
 }
@@ -931,6 +955,8 @@ pub(crate) fn parse_policy_state_with_counters(
         global_indices: Vec::new(),
         books: Vec::with_capacity(address_books.len()),
         book_id_to_idx: FxHashMap::default(),
+        // #3019: armed below if any rule names the `junos-host` self zone.
+        has_junos_host_rules: false,
     };
 
     // #1606: build the dense book table first. Hard-fail on
@@ -1100,12 +1126,18 @@ pub(crate) fn parse_policy_state_with_counters(
         let is_global = rule.from_zone == "junos-global" || rule.to_zone == "junos-global";
         state.rules.push(rule);
 
+        // #3019: arm the LocalDelivery junos-host policy gate iff a rule
+        // actually names the reserved self zone on either side.
+        if snap.from_zone == JUNOS_HOST_ZONE_NAME || snap.to_zone == JUNOS_HOST_ZONE_NAME {
+            state.has_junos_host_rules = true;
+        }
+
         if is_global {
             state.global_indices.push(idx);
         } else {
             match (
-                zone_name_to_id.get(&snap.from_zone).copied(),
-                zone_name_to_id.get(&snap.to_zone).copied(),
+                resolve_policy_zone_id(zone_name_to_id, &snap.from_zone),
+                resolve_policy_zone_id(zone_name_to_id, &snap.to_zone),
             ) {
                 (Some(from_id), Some(to_id)) => {
                     let key = zone_pair_key(from_id, to_id);
@@ -1412,6 +1444,83 @@ pub(crate) fn evaluate_policy_result_with_icmp(
         log_session_init: false,
         log_session_close: false,
     }
+}
+
+/// #3019: resolve a policy rule's from/to zone NAME to a numeric id, mapping
+/// the reserved `junos-host` self zone to [`JUNOS_HOST_ZONE_ID`]. A configured
+/// zone can never be named `junos-host` (the Go strict validator + definition
+/// gate reject it), so this never shadows a real zone. All other names resolve
+/// through `zone_name_to_id` exactly as before.
+fn resolve_policy_zone_id(
+    zone_name_to_id: &FxHashMap<String, u16>,
+    name: &str,
+) -> Option<u16> {
+    if name == JUNOS_HOST_ZONE_NAME {
+        Some(JUNOS_HOST_ZONE_ID)
+    } else {
+        zone_name_to_id.get(name).copied()
+    }
+}
+
+/// #3019: evaluate a configured `to-zone junos-host` security policy for a
+/// host-bound (LocalDelivery) flow whose ingress (from) zone id is `from_id`.
+///
+/// Junos ordering: host-inbound-traffic admission runs FIRST in the caller; a
+/// packet only reaches this gate after host-inbound has admitted it, so a
+/// `then permit` here can never override a host-inbound reject.
+///
+/// CONSERVATIVE / FAIL-SAFE semantics, by design (#3019 brief): enforcement is
+/// strictly MATCH-DRIVEN. Returns:
+///   - `None` when no `junos-host` policy is configured at all
+///     (`has_junos_host_rules == false`), when the ingress zone is unknown
+///     (id 0, mirroring the #3110 unzoned guard), or when no `junos-host` rule
+///     MATCHES the flow.
+///   - `Some(result)` only when a `to-zone junos-host` rule MATCHES.
+///
+/// Crucially there is NO implicit default-deny here: an unmatched host-bound
+/// flow falls through to today's behavior (local delivery proceeds). This is
+/// the deliberate lifeline guarantee — configuring some junos-host policy
+/// cannot silently brick management/host traffic that does not match a deny
+/// rule. The stricter Junos "configured zone-pair implies default-deny"
+/// posture is intentionally deferred (see docs/junos-cli-reference.md).
+///
+/// `from-zone junos-host` (host-ORIGINATED) rules are indexed by the same name
+/// resolution but are NOT consulted here: locally-generated traffic does not
+/// traverse the ingress LocalDelivery path. That direction is a documented
+/// follow-up.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn evaluate_junos_host_policy(
+    state: &PolicyState,
+    from_id: u16,
+    src_ip: IpAddr,
+    dst_ip: IpAddr,
+    protocol: u8,
+    src_port: u16,
+    dst_port: u16,
+    packet_icmp: Option<(u8, u8)>,
+    packet_len: u64,
+) -> Option<PolicyEvaluationResult> {
+    if !state.has_junos_host_rules || from_id == 0 {
+        return None;
+    }
+    let key = zone_pair_key(from_id, JUNOS_HOST_ZONE_ID);
+    let indices = state.zone_pair_index.get(&key)?;
+    for &idx in indices {
+        if let Some(result) = try_match_rule(
+            &state.rules[idx],
+            state,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            packet_icmp,
+            packet_len,
+        ) {
+            return Some(result);
+        }
+    }
+    None
 }
 
 /// Try to match a single policy rule against packet fields.

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -2967,3 +2967,159 @@ fn icmp_skew_old_snapshot_without_type_matches_all() {
     assert_eq!(eval_icmp(&state, PROTO_ICMP, 8, 0), PolicyAction::Permit);
     assert_eq!(eval_icmp(&state, PROTO_ICMP, 3, 0), PolicyAction::Permit);
 }
+
+// ---------------------------------------------------------------------------
+// #3019: `to-zone junos-host` / `from-zone junos-host` self-traffic policy.
+// ---------------------------------------------------------------------------
+
+fn junos_host_deny_snapshot(action: &str) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        name: "host-ssh".to_string(),
+        from_zone: "trust".to_string(),
+        to_zone: JUNOS_HOST_ZONE_NAME.to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: action.to_string(),
+        ..Default::default()
+    }
+}
+
+/// #3019: a `to-zone junos-host` rule is INDEXED under the reserved synthetic
+/// zone id (mirroring a normal zone-pair) and arms `has_junos_host_rules`.
+/// Pre-fix the rule was kept-but-not-indexed (like the wildcard-`any` case),
+/// so the LocalDelivery gate could never reach it.
+#[test]
+fn junos_host_rule_is_indexed_under_reserved_zone_id() {
+    let state = parse_policy_state("permit", &[junos_host_deny_snapshot("deny")], &test_zone_name_to_id());
+    assert!(state.has_junos_host_rules, "junos-host rule must arm the gate");
+    let key = zone_pair_key(TEST_TRUST_ZONE_ID, JUNOS_HOST_ZONE_ID);
+    assert!(
+        state.zone_pair_index.contains_key(&key),
+        "trust->junos-host rule must be indexed under (trust_id, JUNOS_HOST_ZONE_ID)"
+    );
+}
+
+/// #3019: a configured `from-zone trust to-zone junos-host then deny` DENIES a
+/// host-bound flow from trust (the deny test). The eval consults the
+/// junos-host zone-pair and returns the matched Deny action.
+#[test]
+fn junos_host_policy_denies_matching_host_bound_flow() {
+    let state = parse_policy_state("permit", &[junos_host_deny_snapshot("deny")], &test_zone_name_to_id());
+    let result = evaluate_junos_host_policy(
+        &state,
+        TEST_TRUST_ZONE_ID,
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 102)),
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 1)),
+        PROTO_TCP,
+        12345,
+        22,
+        None,
+        64,
+    );
+    assert_eq!(
+        result.map(|r| r.action),
+        Some(PolicyAction::Deny),
+        "trust->junos-host deny must match and deny"
+    );
+}
+
+/// #3019: `then permit` admits the host-bound flow (returns Permit). Ordering:
+/// host-inbound admission runs FIRST in the caller, so this permit cannot
+/// re-admit what host-inbound rejected — that is enforced by the poll-path
+/// call order, not here.
+#[test]
+fn junos_host_policy_permits_matching_host_bound_flow() {
+    let state = parse_policy_state("deny", &[junos_host_deny_snapshot("permit")], &test_zone_name_to_id());
+    let result = evaluate_junos_host_policy(
+        &state,
+        TEST_TRUST_ZONE_ID,
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 102)),
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 1)),
+        PROTO_TCP,
+        12345,
+        22,
+        None,
+        64,
+    );
+    assert_eq!(result.map(|r| r.action), Some(PolicyAction::Permit));
+}
+
+/// #3019 lifeline fail-safe: with NO junos-host policy configured at all, the
+/// gate is a NO-OP (`None`) regardless of the (deny) default policy — host-
+/// bound traffic keeps pre-#3019 behavior and can never be newly denied.
+#[test]
+fn junos_host_policy_no_op_without_configured_rule() {
+    let state = parse_policy_state(
+        "deny",
+        &[PolicyRuleSnapshot {
+            name: "transit".to_string(),
+            from_zone: "trust".to_string(),
+            to_zone: "untrust".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["any".to_string()],
+            action: "permit".to_string(),
+            ..Default::default()
+        }],
+        &test_zone_name_to_id(),
+    );
+    assert!(!state.has_junos_host_rules);
+    assert!(
+        evaluate_junos_host_policy(
+            &state,
+            TEST_TRUST_ZONE_ID,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 102)),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 1, 1)),
+            PROTO_TCP,
+            12345,
+            22,
+            None,
+            64,
+        )
+        .is_none(),
+        "no junos-host policy configured: gate must be a no-op"
+    );
+}
+
+/// #3019 fail-safe: a junos-host policy is configured for trust, but a flow
+/// from a DIFFERENT ingress zone (untrust) matches no junos-host rule for that
+/// pair → `None` (no implicit default-deny — host-bound traffic from untrust
+/// is unaffected). Also covers the unzoned (id 0) ingress short-circuit.
+#[test]
+fn junos_host_policy_no_match_falls_through_to_today_behavior() {
+    let state = parse_policy_state("permit", &[junos_host_deny_snapshot("deny")], &test_zone_name_to_id());
+    // Different ingress zone, no junos-host rule for (untrust, junos-host).
+    assert!(
+        evaluate_junos_host_policy(
+            &state,
+            TEST_UNTRUST_ZONE_ID,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 2, 102)),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 2, 1)),
+            PROTO_TCP,
+            12345,
+            22,
+            None,
+            64,
+        )
+        .is_none(),
+        "no junos-host rule for this ingress zone: no implicit default-deny"
+    );
+    // Unzoned (id 0) ingress is never eligible (mirror #3110).
+    assert!(
+        evaluate_junos_host_policy(
+            &state,
+            0,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 2, 102)),
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 2, 1)),
+            PROTO_TCP,
+            12345,
+            22,
+            None,
+            64,
+        )
+        .is_none(),
+        "unzoned ingress must not be eligible for junos-host policy"
+    );
+}


### PR DESCRIPTION
Closes #3019

## Problem

`from-zone <z> to-zone junos-host` self-traffic security policies committed and were documented as policy-visible, but the dataplane never evaluated them. `junos-host` was never inserted into `zone_name_to_id`, so `PolicyState::from_snapshots` kept-but-did-not-index the rule (like the wildcard-`any` case), and the LocalDelivery session-hit/miss paths applied only input/lo0 filters and the #3070 host-inbound admission — they never called the security-policy evaluator. So `to-zone junos-host then deny` commits and shows as a legitimate policy but does not deny host-bound traffic, and hit counts stay zero.

## Fix (issue option (a): reserve a runtime junos-host zone id + LocalDelivery policy gate)

- **Zone indexing:** reserve `JUNOS_HOST_ZONE_ID` (`u16::MAX-1`) at the bottom of the already-reserved range (a configured zone can never collide — `populate_zones` already skips ids `>= ZONE_ID_RESERVED_MIN`). Never on the wire (zone ids are u8); it is only the in-runtime index key. `PolicyState::from_snapshots` resolves the reserved `junos-host` NAME to that id via `resolve_policy_zone_id`, so junos-host rules are INDEXED in `zone_pair_index` like a normal pair. Go already emits the `junos-host` zone name string (Go↔Rust agreement is on the name).
- **Policy eval slot vs #3070:** new `evaluate_junos_host_policy` + `junos_host_policy_drops` wired into BOTH poll_descriptor LocalDelivery sites (session-miss + session-hit), **AFTER** the #3070 `host_inbound_admits` check.
- **Ordering (Junos):** host-inbound admission FIRST, then to-zone junos-host policy. A packet host-inbound rejected never reaches policy, so `then permit` cannot re-admit it. A matched deny/reject drops the packet, emits the policy-deny RT_FLOW + reject/zone-tcp-rst reply, and on the hit path tears down the cached host-local session.
- **No-config fail-safe (lifeline):** enforcement is strictly MATCH-DRIVEN via `has_junos_host_rules`. No junos-host policy configured, or a no-match → returns None and local delivery proceeds. There is NO implicit junos-host default-deny, so configuring some junos-host policy cannot silently brick management/host traffic. Stricter "configured zone-pair implies default-deny" posture deferred.
- **from-zone coverage:** `to-zone junos-host` (host-INBOUND) is enforced. `from-zone junos-host` (host-ORIGINATED) rules are accepted + indexed but NOT consulted on this path (locally-generated traffic does not traverse ingress LocalDelivery) — documented follow-up.

## Tests + fail-on-revert

- Rust policy unit (5): indexing under reserved id, deny/permit match, no-config no-op, no-match + unzoned fall-through.
- Rust poll-path (3): `poll_descriptor_junos_host_deny_drops_local_delivery_session_miss`, `..._no_junos_host_policy_local_delivery_unchanged_session_miss` (GREEN pair), `..._junos_host_deny_drops_local_delivery_session_hit` (teardown + RT_FLOW).
- Go (1): `TestJunosHostPolicySnapshotCarriesRule` — junos-host rule reaches the snapshot with from/to zone intact.
- **Fail-on-revert proven:** disabling the session-miss LocalDelivery policy-eval call turned the miss deny test RED (policy_deny 0 vs 1) while the no-policy test stayed GREEN; restored byte-identical.

## Status

`cargo build --release` + full `cargo test` (3067 passed); `go build ./...` + `go test ./pkg/config/ ./pkg/dataplane/...` (all pass). Docs updated: docs/junos-cli-reference.md + forwarding LocalDelivery README + _Log.md. Change is scoped + conservative (LocalDelivery is HA-adjacent — parent runs the test-failover gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi