### PR TITLE
config: reject unparseable static-NAT match/prefix at commit (#3206)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-06-26 — #3206 static-NAT unparseable match destination-address / prefix rejected at commit
+
+- **Timestamp**: 2026-06-26
+- **Action**: Fail-closed fix. A static-NAT rule whose `match
+  destination-address` or `then static-nat prefix` was NOT a parseable
+  literal IP/CIDR (an address-book name, or a typo'd prefix) committed
+  cleanly: the existing host-mask check fires only when the value parses
+  (`parsed && !host`), so an unparseable value skipped both the host-mask
+  and block-pair checks and fell through to the Rust dataplane, where
+  `parse_nat_prefix` returns `None` and `from_snapshots` does `continue`,
+  silently dropping the WHOLE static-NAT mapping with no commit error or
+  runtime feedback. Fix: `validateNATHostMaskStrict` (compiler_nat.go) now
+  rejects an unparseable `match`/`then` FIRST (before the block-pair /
+  host-mask checks) using `natStaticPrefixInfo`'s `parsedIP == false`
+  signal, naming the rule-set, rule, slot, and offending value. Strict =
+  hard commit error; lenient (#1960) = `cfg.Warnings` entry. The Rust
+  `from_snapshots` None-drop stays as the lenient/peer-sync backstop (no
+  Rust change). Applies to BOTH the match destination-address and the
+  then static-nat prefix slots. NPTv6 / `static-nat inet` exemptions
+  unchanged; valid host (/32) and block (/24, #3031) static NAT still
+  compile byte-identical (no over-rejection).
+- **File(s)**: pkg/config/compiler_nat.go,
+  pkg/config/compiler_nat_host_mask_test.go, docs/config-schema.md, _Log.md
+- **Validation**: `go build ./...`; `go test ./pkg/config/` ok;
+  `cargo build --release` + `cargo test --release nat::` 149/0. Fail-on-revert:
+  removing the #3206 blocks turns TestStaticNATUnparseableMatchRejected,
+  TestStaticNATUnparseablePrefixRejected, TestStaticNATUnparseableLenientWarns
+  RED while TestStaticNATParseableValuesStillCompile stays GREEN; restored
+  byte-identical.
+
 ## 2026-06-26 — #3199 host-inbound `protocols all` scoped to routing protocols (control-plane exposure)
 
 - **Timestamp**: 2026-06-26

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1716,8 +1716,7 @@ gate EXACTLY (shared predicate `isHostMaskAddress`):
   translation, never host-checked by the Rust parser) and `then static-nat
   inet` rules (a NAT64 translation whose `match` is the well-known prefix, e.g.
   `64:ff9b::/96`, driven by the separate NAT64 snapshot, not the static_nat
-  table). A non-IP token (an address-book name) is left to the existing address
-  handling. NPTv6 prefixes are exempt from the *host-mask* gate (a prefix is
+  table). NPTv6 prefixes are exempt from the *host-mask* gate (a prefix is
   expected, not a host), but they have their own strict gate
   (`validateNPTv6Strict`, #2240/#2241/#2380): prefix-length equality, supported
   length (`/48` or `/64`), IPv6 family, overlap rejection, and — #2380 — a
@@ -1746,10 +1745,28 @@ gate EXACTLY (shared predicate `isHostMaskAddress`):
   independently, so a leniently-loaded config is already inert for that rule —
   and the operator's next strict commit rejects it loudly.
 
+**#3206 — unparseable static-NAT match/prefix.** The host-mask check above
+fires only when the value *parses* as an IP (`parsed && !host`). A
+`match destination-address` or `then static-nat prefix` that is NOT a parseable
+literal IP/CIDR (an address-book name like `web-server`, or a typo'd prefix like
+`10.0.0.300`) therefore skipped both the host-mask and block-pair checks and
+fell through to the Rust dataplane, where `parse_nat_prefix`
+(`userspace-dp/src/nat/static_nat.rs`) returns `None` and `from_snapshots` does
+`continue`, SILENTLY dropping the WHOLE static-NAT mapping with no commit error
+or runtime feedback — the operator authored a rule that does not exist at
+runtime. `validateNATHostMaskStrict` now rejects an unparseable match/prefix
+FIRST (before the block-pair / host-mask checks) via `natStaticPrefixInfo`'s
+`parsedIP == false` signal, naming the rule-set, rule, slot, and offending
+value. Static NAT takes literal IP/CIDR endpoints, not address-book references.
+Strict = hard commit error; lenient = `cfg.Warnings` entry (the Rust
+`from_snapshots` drop remains the lenient/peer-sync backstop). Same exemptions
+apply (NPTv6, `then static-nat inet`).
+
 Regression coverage: `pkg/config/compiler_nat_host_mask_test.go` (bare/​/32/​/128
 accept; v4 + v6 non-host match/prefix reject with asserted message; NPTv6 and
 `inet` exemptions; NAT64 source-pool host vs non-host; strict-reject /
-lenient-warn / valid-no-warning; `isHostMaskAddress` table). Like
+lenient-warn / valid-no-warning; `isHostMaskAddress` table; #3206 unparseable
+match/prefix reject + parseable host/​block still-compile + lenient-warn). Like
 `pool-utilization-alarm`, this is compiler-side only — not yet a typed
 `setSchema` leaf.
 

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -297,6 +297,41 @@ func validateNATHostMaskStrict(cfg *Config, lenient bool) ([]string, error) {
 			if rule.Then == "inet" {
 				continue
 			}
+			// #3206: a `match destination-address` / `then static-nat
+			// prefix` that is not a parseable literal IP or CIDR (an
+			// address-book name, or a typo'd prefix) is NOT caught by the
+			// host-mask check below — that check fires only when the value
+			// parses (`parsed && !host`). An unparseable value falls all the
+			// way through to the Rust dataplane, where `parse_nat_prefix`
+			// returns None and `from_snapshots` does `continue`, SILENTLY
+			// dropping the entire static-NAT mapping with no commit error or
+			// runtime feedback (the operator authored a rule that simply does
+			// not exist at runtime). Static NAT takes literal IP/CIDR
+			// endpoints, not address-book references, so reject an
+			// unparseable value at commit. `natStaticPrefixInfo` mirrors the
+			// Rust `parse_nat_prefix` classification; its `parsedIP == false`
+			// is precisely the silently-dropped case. Run this BEFORE the
+			// blockPair / host-mask checks so an unparseable value reports its
+			// own (clearer) error rather than being skipped as "not a block
+			// pair".
+			if rule.Match != "" {
+				if _, _, _, parsedIP := natStaticPrefixInfo(rule.Match); !parsedIP {
+					if err := emit(fmt.Sprintf(
+						"security nat static rule-set %q rule %q match destination-address %q is not a valid IP address or CIDR prefix (static NAT requires a literal address or prefix, not an address-book name or a typo'd value)",
+						rs.Name, rule.Name, rule.Match)); err != nil {
+						return nil, err
+					}
+				}
+			}
+			if rule.Then != "" {
+				if _, _, _, parsedIP := natStaticPrefixInfo(rule.Then); !parsedIP {
+					if err := emit(fmt.Sprintf(
+						"security nat static rule-set %q rule %q then static-nat prefix %q is not a valid IP address or CIDR prefix (static NAT requires a literal address or prefix, not an address-book name or a typo'd value)",
+						rs.Name, rule.Name, rule.Then)); err != nil {
+						return nil, err
+					}
+				}
+			}
 			// #3031: a valid block-to-block (subnet) static-NAT rule —
 			// equal-length non-host prefixes of the same family — is now
 			// installed by the dataplane (offset-preserving 1:1 remap), so do

--- a/pkg/config/compiler_nat_host_mask_test.go
+++ b/pkg/config/compiler_nat_host_mask_test.go
@@ -492,3 +492,75 @@ func TestIsStaticBlockPair(t *testing.T) {
 		}
 	}
 }
+
+// #3206: a static-NAT match destination-address / then static-nat prefix that
+// is NOT a parseable literal IP/CIDR (an address-book name, or a typo'd
+// prefix) committed cleanly before this gate — the host-mask check only fires
+// when the value parses, so an unparseable value fell through to the Rust
+// dataplane, where parse_nat_prefix returns None and from_snapshots `continue`
+// silently drops the WHOLE static-NAT mapping. The commit gate now rejects it.
+//
+// Fail-on-revert: delete the `#3206` blocks in validateNATHostMaskStrict and
+// these reject tests compile cleanly → RED. The valid host (/32) and block
+// (/24) tests in this file stay GREEN (no over-rejection of legit configs).
+
+func TestStaticNATUnparseableMatchRejected(t *testing.T) {
+	// An address-book name in the match destination-address slot.
+	tree := buildTree(t, staticNATSet("web-server", "10.0.0.5/32"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-NAT match with an unparseable address (address-book name) must be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "match destination-address") ||
+		!strings.Contains(msg, "web-server") ||
+		!strings.Contains(msg, "not a valid IP address or CIDR prefix") {
+		t.Fatalf("error must name the slot + offending value + reason, got: %v", err)
+	}
+}
+
+func TestStaticNATUnparseablePrefixRejected(t *testing.T) {
+	// A typo'd prefix in the then static-nat prefix slot (not a literal IP).
+	tree := buildTree(t, staticNATSet("203.0.113.5/32", "10.0.0.300"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("static-NAT prefix with an unparseable value (typo) must be rejected")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "then static-nat prefix") ||
+		!strings.Contains(msg, "10.0.0.300") ||
+		!strings.Contains(msg, "not a valid IP address or CIDR prefix") {
+		t.Fatalf("error must name the prefix slot + offending value + reason, got: %v", err)
+	}
+}
+
+// A valid host (/32) and a valid block (/24) static NAT must still compile —
+// the #3206 unparseable gate must not over-reject legitimate literal values.
+func TestStaticNATParseableValuesStillCompile(t *testing.T) {
+	cases := [][]string{
+		staticNATSet("203.0.113.5", "10.0.0.5"),              // bare hosts
+		staticNATSet("203.0.113.5/32", "10.0.0.5/32"),        // /32 host pair
+		staticNATSet("2001:db8::5/128", "2001:db8:1::5/128"), // /128 host pair
+		staticNATSet("198.51.100.0/24", "192.168.1.0/24"),    // /24 block pair (#3031)
+	}
+	for i, lines := range cases {
+		if _, err := CompileConfig(buildTree(t, lines)); err != nil {
+			t.Fatalf("case %d: parseable static-NAT must compile, got: %v", i, err)
+		}
+	}
+}
+
+// Lenient load must NOT brick the daemon on an unparseable static-NAT value —
+// it accepts and warns (the dataplane independently drops the rule).
+func TestStaticNATUnparseableLenientWarns(t *testing.T) {
+	cfg, err := CompileConfigLenient(buildTree(t, staticNATSet("web-server", "10.0.0.5/32")))
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must NOT fail (brick-on-restart), got: %v", err)
+	}
+	if !hasWarningContaining(cfg.Warnings, "not a valid IP address or CIDR prefix") {
+		t.Fatalf("lenient load must warn about the unparseable value, warnings=%v", cfg.Warnings)
+	}
+	if !hasWarningContaining(cfg.Warnings, "rule dropped by dataplane") {
+		t.Fatalf("warning must say the rule is dropped by the dataplane, warnings=%v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
Closes #3206

## Problem
A static-NAT rule whose `match destination-address` or `then static-nat prefix`
is not a parseable literal IP/CIDR (an address-book name like `web-server`, or a
typo'd prefix like `10.0.0.300`) commits cleanly, then the Rust dataplane fails
to parse it and silently discards the entire NAT mapping — a non-functional rule
with no notification.

The existing host-mask check in `validateNATHostMaskStrict` fires only when the
value *parses* (`parsed && !host`), and `isStaticBlockPair` returns false for a
non-IP token, so an unparseable value skips both checks and falls through to the
Rust side, where `parse_nat_prefix` returns `None` and `from_snapshots` does
`continue` (`userspace-dp/src/nat/static_nat.rs`) — the rule is parsed-out and
never installed.

## Fix (fail-closed at commit)
`validateNATHostMaskStrict` (`pkg/config/compiler_nat.go`) now rejects an
unparseable `match destination-address` AND `then static-nat prefix` FIRST
(before the block-pair / host-mask checks) using `natStaticPrefixInfo`'s
`parsedIP == false` signal — the same classifier that mirrors the Rust
`parse_nat_prefix`. The error names the rule-set, rule, slot, and offending
value. It routes through the existing strict/lenient `emit`: a hard commit error
under strict, a `cfg.Warnings` entry under `CompileConfigLenient` (#1960 — a
config committed before this gate still boots after upgrade). The Rust
`from_snapshots` None-drop stays as the lenient/peer-sync backstop (no Rust
change).

NPTv6 and `static-nat inet` (NAT64) rules stay exempt. Valid host (/32, /128,
bare) and valid block (/24, #3031) static NAT still compile byte-identical — no
over-rejection of legitimate literal values.

## Tests (`pkg/config/compiler_nat_host_mask_test.go`)
- `TestStaticNATUnparseableMatchRejected` — address-book name in the match slot.
- `TestStaticNATUnparseablePrefixRejected` — typo'd prefix in the then slot.
- `TestStaticNATParseableValuesStillCompile` — bare/​/32/​/128 host + /24 block.
- `TestStaticNATUnparseableLenientWarns` — lenient load warns, says rule dropped.

**Fail-on-revert:** removing the #3206 blocks turns the three reject/lenient
tests RED while `TestStaticNATParseableValuesStillCompile` stays GREEN; restored
byte-identical.

## Validation
- `go build ./...`
- `go test ./pkg/config/` ok
- `cargo build --release`
- `cargo test --release nat::` 149/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi