### PR TITLE
config: name zone-pair in policy terminal-action error (#3207)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-26 — #3207 policy terminal-action validation error: thread zone-pair context
+
+- **Timestamp**: 2026-06-26
+- **Action**: The zone-pair arm of `validatePolicyTerminalActionStrict`
+  called `check("", pol)` with an EMPTY scope, so a missing/conflicting
+  terminal-action error named only the policy (no from/to-zone). With
+  duplicate policy names across zone-pairs the offending policy was hard to
+  locate. Threaded the real scope `fmt.Sprintf("from-zone %s to-zone %s",
+  zpp.FromZone, zpp.ToZone)` (the established convention in
+  compiler_policy_then.go / compiler_policy_match.go) into the error; global
+  policies keep "global". Pure message/context improvement — the set of
+  accepted/rejected configs is unchanged. Added two fail-on-revert tests
+  (zone-pair names the pair + policy; global names "global" + policy).
+- **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/policy_terminal_action_3043_test.go
+
 ## 2026-06-26 — #3200 host-inbound unknown/typo token: commit validation + both-layer fail-closed
 
 - **Timestamp**: 2026-06-26

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2325,8 +2325,9 @@ func validatePolicyTerminalActionStrict(cfg *Config) error {
 		if zpp == nil {
 			continue
 		}
+		scope := fmt.Sprintf("from-zone %s to-zone %s", zpp.FromZone, zpp.ToZone)
 		for _, pol := range zpp.Policies {
-			if err := check("", pol); err != nil {
+			if err := check(scope, pol); err != nil {
 				return err
 			}
 		}

--- a/pkg/config/policy_terminal_action_3043_test.go
+++ b/pkg/config/policy_terminal_action_3043_test.go
@@ -166,3 +166,58 @@ func TestPolicyExactlyOneTerminalActionCommits(t *testing.T) {
 		t.Errorf("block policy action = %s, want deny", policyActionName(pol.Action))
 	}
 }
+
+// TestPolicyTerminalActionErrorNamesZonePair is the #3207 fail-on-revert
+// anchor: a zone-pair policy with no terminal action must produce an error
+// that NAMES the offending from/to-zone pair (not just the policy name).
+// Before #3207 the zone-pair loop called check("", pol) with an EMPTY scope,
+// so the message omitted the zone-pair context and a duplicate policy name
+// across zone-pairs was impossible to locate. Restoring the empty scope makes
+// the "from-zone trust to-zone untrust" assertion go RED.
+func TestPolicyTerminalActionErrorNamesZonePair(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy audit match source-address any",
+		"set security policies from-zone trust to-zone untrust policy audit match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy audit match application any",
+		"set security policies from-zone trust to-zone untrust policy audit then log session-init",
+	}
+	tree := buildPolicyTree(t, cmds)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a zone-pair policy with no terminal action")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "from-zone trust to-zone untrust") {
+		t.Errorf("terminal-action error omits the zone-pair context; got %q", msg)
+	}
+	if !strings.Contains(msg, `"audit"`) {
+		t.Errorf("terminal-action error omits the policy name; got %q", msg)
+	}
+}
+
+// TestGlobalPolicyTerminalActionErrorNamesGlobal asserts the global-policy arm
+// of the #3207 context fix: a global policy with no terminal action names
+// "global" (not a zone-pair) so the operator can distinguish it from a
+// same-named zone-pair policy.
+func TestGlobalPolicyTerminalActionErrorNamesGlobal(t *testing.T) {
+	cmds := []string{
+		"set security policies global policy g match source-address any",
+		"set security policies global policy g match destination-address any",
+		"set security policies global policy g match application any",
+		"set security policies global policy g then count",
+	}
+	tree := buildPolicyTree(t, cmds)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a global policy with no terminal action")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "global policy") {
+		t.Errorf("terminal-action error omits the global scope; got %q", msg)
+	}
+	if !strings.Contains(msg, `"g"`) {
+		t.Errorf("terminal-action error omits the policy name; got %q", msg)
+	}
+}


### PR DESCRIPTION
Closes #3207

## Problem
The zone-pair arm of `validatePolicyTerminalActionStrict` called
`check("", pol)` with an EMPTY scope (`pkg/config/compiler_validate_strict.go`),
so a missing- or conflicting-terminal-action error printed only the policy name
with no from/to-zone context. With duplicate policy names across zone-pairs the
operator could not locate the offending policy. The global-policy arm already
passed `"global"`.

## Fix
Thread the real scope into the error using the established convention in this
compiler — `from-zone <X> to-zone <Y>` (mirrors `compiler_policy_then.go` and
`compiler_policy_match.go`). Global policies keep `"global"`. The error now reads
e.g.

```
from-zone trust to-zone untrust policy "default-deny": no terminal action; ...
```

Pure diagnostics/UX change. The validation logic is untouched — exactly the same
configs are accepted/rejected; only the error string gains zone-pair context.

## Tests
- `TestPolicyTerminalActionErrorNamesZonePair` — asserts the zone-pair and policy
  name appear in the error. Fail-on-revert anchor: restoring `check("", pol)`
  turns it RED (verified — error reverts to `policy "audit": ...`).
- `TestGlobalPolicyTerminalActionErrorNamesGlobal` — asserts the global arm names
  `global` + the policy.

`go build ./...` clean; `go test ./pkg/config/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi