### PR TITLE
queue-planner: orphan VLAN child plan-key follows parent's rx_queues (#3175)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-26 — #3175 queue-planner: orphan VLAN child plan-key follows parent's rx_queues
+
+- **Timestamp**: 2026-06-26
+- **Action**: Follow-up to #3007/#3131/#3173. In
+  `update_snapshot_binding_plan_key` the plan-key loop hashed the CHILD's own
+  `effective_rx_queues` for an ORPHAN VLAN child (a VLAN unit whose physical
+  parent is NOT itself a binding candidate), but `replan_queues`' LAYOUT loop
+  re-keys that child onto its parent using `rx_queue_count(parent)`. So an
+  out-of-band `ethtool -L <parent> combined N` (no config commit) on the parent
+  of an orphan VLAN child did NOT bump the plan key → same-plan-skip → stale
+  layout. Added `plan_key_rx_queues(snapshot, iface, linux_name)` as the single
+  resolution path for the hash: orphan VLAN child → `rx_queue_count(parent)`
+  (mirrors the layout); normal VLAN child (parent IS a candidate) and
+  physical/non-VLAN ifaces → `effective_rx_queues(...)` exactly as #3007 (no
+  change). The #3131 VLAN-child-dedup-onto-physical-parent and the min-collapse
+  are untouched. Two new fail-on-revert tests
+  (`plan_key_folds_parent_sysfs_queues_for_orphan_vlan_child`,
+  `plan_key_for_normal_vlan_child_ignores_parent_sysfs`); reverting the orphan
+  branch turns the orphan test RED (keys collide) while the normal/nonzero tests
+  stay green. `cargo build --release` + `cargo test --release` green (plan_key
+  7/7, queue_planner 13/13).
+- **File(s)**: userspace-dp/src/server/helpers.rs,
+  userspace-dp/src/main_tests.rs, userspace-dp/src/server/README.md
+
 ## 2026-06-26 — #3207 policy terminal-action validation error: thread zone-pair context
 
 - **Timestamp**: 2026-06-26

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -683,6 +683,121 @@ fn queue_planner_rekeys_orphan_vlan_child_onto_parent_netdev() {
     );
 }
 
+// #3175 fail-on-revert: an ORPHAN VLAN child (a VLAN unit whose physical parent
+// is NOT itself a binding candidate) is re-keyed in the LAYOUT onto its parent
+// netdev using the parent's HARDWARE queue count (`rx_queue_count(parent)`). The
+// plan key MUST hash the SAME value. Before #3175 the key loop hashed the
+// child's own software-queue count (`effective_rx_queues(child.rx_queues, ...)`,
+// the lone 1-queue VLAN device), so an out-of-band `ethtool -L <parent> combined
+// N` on the parent (no config commit) left the key unchanged → same-plan-skip →
+// stale layout while `replan_queues` would actually re-plan to the new count.
+//
+// Revert proof: change `plan_key_rx_queues` back to returning
+// `effective_rx_queues(iface.rx_queues, resolved_linux_name)` for the orphan
+// case and this test goes RED — the child's rx_queues=1 is hashed for both
+// counts, so key_4 == key_6.
+#[test]
+fn plan_key_folds_parent_sysfs_queues_for_orphan_vlan_child() {
+    use crate::server::helpers::{
+        clear_rx_queue_count_override, set_rx_queue_count_override, snapshot_binding_plan_key,
+    };
+
+    // Orphan VLAN child only: its physical parent `ge-0-0-9` is NOT present as
+    // its own snapshot interface, so it is not a binding candidate. The child is
+    // a real software VLAN device with a single RX queue (rx_queues=1, nonzero),
+    // proving the key must NOT hash the child's own count.
+    let mk = || ConfigSnapshot {
+        interfaces: vec![InterfaceSnapshot {
+            name: "ge-0/0/9.30".to_string(),
+            linux_name: "ge-0-0-9.30".to_string(),
+            parent_linux_name: "ge-0-0-9".to_string(),
+            zone: "untrust".to_string(),
+            ifindex: 130,
+            parent_ifindex: 19,
+            vlan_id: 30,
+            rx_queues: 1,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Parent sysfs reports 4 combined channels.
+    set_rx_queue_count_override("ge-0-0-9", 4);
+    let key_4 = snapshot_binding_plan_key(&mk());
+
+    // Operator runs `ethtool -L ge-0-0-9 combined 6` out of band; the snapshot is
+    // byte-identical (child still rx_queues=1) but the parent's live channel
+    // count changed.
+    set_rx_queue_count_override("ge-0-0-9", 6);
+    let key_6 = snapshot_binding_plan_key(&mk());
+
+    clear_rx_queue_count_override();
+
+    assert_ne!(
+        key_4, key_6,
+        "an out-of-band channel change on the parent of an ORPHAN VLAN child MUST \
+         bump the plan key — the key must hash rx_queue_count(parent), the same \
+         value the layout uses, not the child's lone software queue (#3175)"
+    );
+}
+
+// #3175 no-regression: a NORMAL VLAN child (parent IS a binding candidate) keeps
+// the pre-#3175 behavior. The layout dedups the child onto the candidate parent
+// (which carries its own physical key entry), so the child's key contribution
+// stays `effective_rx_queues(child.rx_queues, ...)` and must NOT reach into the
+// parent's sysfs channel count. Overriding the parent's sysfs must leave the
+// plan key byte-identical.
+#[test]
+fn plan_key_for_normal_vlan_child_ignores_parent_sysfs() {
+    use crate::server::helpers::{
+        clear_rx_queue_count_override, set_rx_queue_count_override, snapshot_binding_plan_key,
+    };
+
+    let snap = ConfigSnapshot {
+        interfaces: vec![
+            // Physical parent IS a candidate (nonzero rx_queues).
+            InterfaceSnapshot {
+                name: "ge-0/0/2".to_string(),
+                linux_name: "ge-0-0-2".to_string(),
+                zone: "untrust".to_string(),
+                ifindex: 12,
+                rx_queues: 6,
+                ..Default::default()
+            },
+            // Normal VLAN child (parent present as a candidate above).
+            InterfaceSnapshot {
+                name: "ge-0/0/2.80".to_string(),
+                linux_name: "ge-0-0-2.80".to_string(),
+                parent_linux_name: "ge-0-0-2".to_string(),
+                zone: "untrust".to_string(),
+                ifindex: 80,
+                parent_ifindex: 12,
+                vlan_id: 80,
+                rx_queues: 1,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    clear_rx_queue_count_override();
+    let baseline = snapshot_binding_plan_key(&snap);
+
+    // A wildly different parent sysfs count must NOT change the key: the parent's
+    // own rx_queues (6) is nonzero so sysfs is never consulted, and the normal
+    // VLAN child must NOT take the orphan branch (parent IS a candidate).
+    set_rx_queue_count_override("ge-0-0-2", 999);
+    let with_override = snapshot_binding_plan_key(&snap);
+    clear_rx_queue_count_override();
+
+    assert_eq!(
+        baseline, with_override,
+        "a normal VLAN child (parent IS a candidate) must keep the #3007 \
+         behavior — the plan key stays independent of the parent's sysfs channel \
+         count (only the orphan case re-keys onto the parent, #3175)"
+    );
+}
+
 #[test]
 fn queue_planner_excludes_tunnel_and_local_fabric_ge_interfaces() {
     // #2915: `ge-*`-named interfaces in tunnel or local-fabric contexts are

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -122,6 +122,21 @@ combined N`, no config commit) bumps the key and forces a replan instead of
 taking the same-plan-skip. `plan_key_folds_sysfs_resolved_rx_queues_when_snapshot_is_zero`
 and `plan_key_for_nonzero_rx_queues_ignores_sysfs` pin both halves.
 
+For an ORPHAN VLAN child — a VLAN unit whose physical parent is NOT itself a
+binding candidate — the planner re-keys the child onto its parent netdev and
+uses the parent's HARDWARE queue count (`rx_queue_count(parent)`), never the
+child's lone software queue (#3091). The plan key must hash the SAME value, so
+`plan_key_rx_queues(snapshot, iface, linux_name)` is the single resolution path
+for the hash: for the orphan case it returns `rx_queue_count(parent)`, matching
+the layout; for the normal VLAN case (parent IS a candidate, child deduped onto
+it and covered by the parent's own physical key entry) and physical/non-VLAN
+ifaces it returns `effective_rx_queues(...)` exactly as #3007. Before #3175 the
+key hashed the child's own software-queue count, so an out-of-band `ethtool -L
+<parent> combined N` on the parent of an orphan VLAN child did NOT bump the key
+→ same-plan-skip → stale layout. `plan_key_folds_parent_sysfs_queues_for_orphan_vlan_child`
+and `plan_key_for_normal_vlan_child_ignores_parent_sysfs` pin the orphan re-key
+and the normal-case no-regression.
+
 The Rust planner does:
 
 ```rust

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -648,12 +648,19 @@ fn update_snapshot_binding_plan_key(hasher: &mut Sha256, snapshot: &ConfigSnapsh
         // the planner would actually produce a different layout. For a nonzero
         // snapshot the resolved value equals the raw field (sysfs is not read), so
         // the key is byte-identical to the pre-#3007 hash for the normal case.
+        //
+        // #3175: for an ORPHAN VLAN child (parent NOT a candidate) the layout
+        // re-keys onto the parent's hardware queue count, so `plan_key_rx_queues`
+        // hashes `rx_queue_count(parent)` here too — otherwise the child's lone
+        // software-queue count is hashed and an out-of-band `ethtool -L <parent>`
+        // would not bump the key. The normal VLAN case (parent IS a candidate)
+        // and physical ifaces keep the #3007 `effective_rx_queues` behavior.
         let resolved_linux_name = if iface.linux_name.is_empty() {
             linux_ifname(&iface.name)
         } else {
             iface.linux_name.clone()
         };
-        let rx_queues = effective_rx_queues(iface.rx_queues, &resolved_linux_name);
+        let rx_queues = plan_key_rx_queues(snapshot, iface, &resolved_linux_name);
         hash_update(
             hasher,
             &format!(
@@ -839,6 +846,38 @@ fn snapshot_has_parent_candidate(snapshot: &ConfigSnapshot, parent: &str) -> boo
         // child that happens to share the name string.
         p_linux == parent && vlan_child_parent_netdev(p, &p_linux).is_none()
     })
+}
+
+/// #3175: resolve the rx_queue count the PLAN KEY must hash for `iface`,
+/// mirroring exactly what `replan_queues`' candidate loop feeds the LAYOUT.
+///
+/// For an ORPHAN VLAN child — a VLAN unit whose physical parent is NOT itself a
+/// binding candidate — `replan_queues` re-keys the child onto its parent netdev
+/// and uses the parent's HARDWARE queue count (`rx_queue_count(parent)`), never
+/// the child's lone software queue. The plan-key loop previously hashed the
+/// child's own `effective_rx_queues`, so an out-of-band `ethtool -L <parent>
+/// combined N` (no config commit) left the key unchanged → same-plan-skip →
+/// stale layout. Hash the parent's count for the orphan case so the key follows
+/// the layout, single-sourcing the resolution exactly as #3007 unified the
+/// `rx_queues == 0` sysfs fallback.
+///
+/// The NORMAL VLAN case (parent IS a candidate) and physical/non-VLAN ifaces are
+/// unchanged: the layout drops the normal VLAN child (it is covered by the
+/// parent's own physical key entry), and physical ifaces use
+/// `effective_rx_queues` exactly as before.
+pub(crate) fn plan_key_rx_queues(
+    snapshot: &ConfigSnapshot,
+    iface: &InterfaceSnapshot,
+    resolved_linux_name: &str,
+) -> usize {
+    if let Some(parent) = vlan_child_parent_netdev(iface, resolved_linux_name) {
+        if !snapshot_has_parent_candidate(snapshot, parent) {
+            // Orphan VLAN child: the layout re-keys onto the parent's hardware
+            // queue count. Hash the same value so the key follows the layout.
+            return rx_queue_count(parent);
+        }
+    }
+    effective_rx_queues(iface.rx_queues, resolved_linux_name)
 }
 
 pub(crate) fn replan_queues(


### PR DESCRIPTION
## Summary
Follow-up to the merged #3007/#3131/#3173. For an **orphan** VLAN child (a VLAN unit whose physical parent is NOT itself a binding candidate), `replan_queues`' LAYOUT loop re-keys the child onto its parent netdev using the parent's **hardware** queue count (`rx_queue_count(parent)`), but the PLAN-KEY loop in `update_snapshot_binding_plan_key` hashed the child's own `effective_rx_queues` (the 1-queue software VLAN device).

So an out-of-band `ethtool -L <parent> combined N` (no config commit) on the parent of an orphan VLAN child left the plan key unchanged → same-plan-skip → stale worker layout, while `replan_queues` would actually re-plan to the new parent channel count. Pre-existing and narrow; not a #3091/#3131 regression.

## Fix
Single-source the per-candidate effective rx_queues for the hash via a new `plan_key_rx_queues(snapshot, iface, linux_name)`, mirroring exactly what the candidate loop feeds the layout:
- **orphan VLAN child** (parent not a candidate) → `rx_queue_count(parent)` (same value the layout uses).
- **normal VLAN child** (parent IS a candidate, deduped onto it + covered by the parent's own physical key entry) and **physical/non-VLAN** ifaces → `effective_rx_queues(...)` exactly as #3007 (byte-identical for the normal case).

The #3131 VLAN-child-dedup-onto-physical-parent and the min-collapse are untouched.

## Tests (fail-on-revert)
- `plan_key_folds_parent_sysfs_queues_for_orphan_vlan_child` — orphan VLAN child, parent sysfs 4 vs 6 → different plan keys (re-plan not skipped).
- `plan_key_for_normal_vlan_child_ignores_parent_sysfs` — normal VLAN child plan key independent of the parent sysfs count (no regression).

Fail-on-revert proven: restoring `effective_rx_queues(child)` for the orphan case turns the orphan test **RED** (keys collide); the normal-VLAN and #3007 nonzero tests stay green. Restored byte-identical.

`cargo build --release` + `cargo test --release` green (plan_key 7/7, queue_planner 13/13).

## Docs
- `userspace-dp/src/server/README.md` queue-planner section
- `_Log.md`

Closes #3175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi