### PR TITLE
host-inbound: admit ICMP error/PMTUD on a ping-less zone (#3171)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -20800,3 +20800,27 @@ top.
   FALSE for WG). Full frame suite 313 passed; wg suite 152 passed; build green.
   **File(s)**: userspace-dp/src/afxdp/frame/wg.rs,
   userspace-dp/src/afxdp/frame/README.md
+
+- **Timestamp**: 2026-06-26
+  **Action**: #3171 host-inbound: admit ICMP/ICMPv6 error/PMTUD control
+  messages on a configured ping-less zone so the userspace LocalDelivery
+  classifier matches the kernel host-inbound chain. Added
+  `is_icmp_host_inbound_error` (ICMPv4 dest-unreachable/time-exceeded/
+  parameter-problem; ICMPv6 type 1/2/3/4 = dest-unreachable/packet-too-big/
+  time-exceeded/parameter-problem) and an early-return exemption in
+  `host_inbound_admits` BEFORE the per-zone lookup; threaded the first L4 byte
+  (ICMP type) into both poll_descriptor call sites (session miss + session
+  hit). Echo-request (v4 type 8 / v6 type 128) is NOT exempt — still gated on
+  the `ping` system-service. Broadened the kernel nft chain to the same set
+  (`icmp type { destination-unreachable, time-exceeded, parameter-problem }`,
+  `icmpv6 type { 1, 2, 3, 4, 133..137 }`) so kernel + userspace stay
+  consistent. Reconciled the #3070 README embedded-ICMP claim. Rust test
+  `build_forwarding_state_admits_icmp_errors_on_pingless_zone` +
+  Go `TestHostInboundFilterExemptsIPsecAndV6Errors` updated; fail-on-revert
+  proven (disabling the early-return turns "admits dest-unreachable" RED,
+  "drops echo without ping" stays GREEN).
+  **File(s)**: userspace-dp/src/afxdp/forwarding/host_inbound.rs,
+  userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+  userspace-dp/src/afxdp/forwarding_build/tests.rs,
+  userspace-dp/src/afxdp/forwarding/README.md,
+  pkg/daemon/daemon_nft.go, pkg/daemon/host_inbound_nft_test.go

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -154,11 +154,13 @@ func hostInboundHasEnforceableView(views []dpuserspace.ZoneHostInboundView) bool
 //  2. meta l4proto { 50, 51 } accept — raw ESP/AH exemption for host-terminated
 //     IPsec (mirrors the userspace stage_ipsec_passthrough_check); the kernel
 //     XFRM stack decrypts before any host-inbound deny can apply.
-//  3. icmpv6 ND + PacketTooBig + dest-unreachable accept, icmp dest-unreachable
-//     accept — IPv6 Neighbor Discovery and v4/v6 PMTUD/error control messages
-//     are mandatory link operation, never a "service" exposure; accepted
-//     globally so a host-inbound set omitting `ping` does not black-hole
-//     PMTUD/ND/error delivery.
+//  3. icmpv6 ND + error/PMTUD accept, icmp error/PMTUD accept — IPv6 Neighbor
+//     Discovery and v4/v6 PMTUD/error control messages (dest-unreachable,
+//     packet-too-big, time-exceeded, parameter-problem) are mandatory link
+//     operation, never a "service" exposure; accepted globally so a host-inbound
+//     set omitting `ping` does not black-hole PMTUD/ND/error delivery. This set
+//     is mirrored by the userspace host-inbound exemption (#3171) so kernel and
+//     XSK LocalDelivery agree. Echo-request stays gated on the `ping` service.
 //  4. Per host-inbound-configured zone, per family with addresses:
 //     - if `system-services all` / `any-service`: <fam> daddr <addrs> accept
 //     (and no deny — the operator opened the zone to all services).
@@ -187,11 +189,19 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView) stri
 	// enforcement.
 	rules = append(rules, "    meta l4proto { 50, 51 } accept")
 	// IPv6 ND + v4/v6 PMTUD/error control messages — accepted regardless of the
-	// host-inbound set so enforcement never breaks core L3 operation. icmpv6
-	// type 1 (destination-unreachable) + 2 (packet-too-big) carry v6 error /
-	// PMTUD signalling; 133-137 are Neighbor Discovery.
-	rules = append(rules, "    icmpv6 type { 1, 2, 133, 134, 135, 136, 137 } accept")
-	rules = append(rules, "    icmp type destination-unreachable accept")
+	// host-inbound set so enforcement never breaks core L3 operation. The ICMP
+	// error subtypes accepted here MUST stay in lock-step with the userspace
+	// host-inbound exemption (`is_icmp_host_inbound_error` in
+	// userspace-dp/.../forwarding/host_inbound.rs, #3171) so the kernel chain and
+	// the XSK LocalDelivery classifier agree on a configured ping-less zone.
+	// icmpv6 type 1 (destination-unreachable), 2 (packet-too-big, PMTUD), 3
+	// (time-exceeded), 4 (parameter-problem) carry v6 error/PMTUD/traceroute
+	// signalling; 133-137 are Neighbor Discovery. ICMPv4 destination-unreachable
+	// (3, also PMTUD frag-needed code 4), time-exceeded (11, traceroute) and
+	// parameter-problem (12) are the v4 error set. Echo-request is NOT here — it
+	// stays gated on the per-zone `ping` system-service.
+	rules = append(rules, "    icmpv6 type { 1, 2, 3, 4, 133, 134, 135, 136, 137 } accept")
+	rules = append(rules, "    icmp type { destination-unreachable, time-exceeded, parameter-problem } accept")
 
 	for _, v := range views {
 		emitHostInboundZone(&rules, v, "ip", v.V4Addrs)

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -116,9 +116,17 @@ func TestHostInboundFilterExemptsIPsecAndV6Errors(t *testing.T) {
 	if !strings.Contains(payload, espAH) {
 		t.Errorf("payload missing raw ESP/AH exemption %q\n---\n%s", espAH, payload)
 	}
-	// icmpv6 type 1 (destination-unreachable) must be in the accepted set.
-	if !strings.Contains(payload, "icmpv6 type { 1, 2, 133, 134, 135, 136, 137 } accept") {
-		t.Errorf("payload missing icmpv6 type-1 (dest-unreachable) in the global accept:\n%s", payload)
+	// icmpv6 error/PMTUD types 1-4 + ND 133-137 must be in the accepted set.
+	if !strings.Contains(payload, "icmpv6 type { 1, 2, 3, 4, 133, 134, 135, 136, 137 } accept") {
+		t.Errorf("payload missing icmpv6 error/PMTUD (1-4) + ND in the global accept:\n%s", payload)
+	}
+	// #3171: the ICMPv4 error/PMTUD set must agree with the userspace
+	// host-inbound exemption (is_icmp_host_inbound_error) so the kernel chain and
+	// the XSK LocalDelivery classifier admit the same ICMP errors on a ping-less
+	// zone. Fail-on-revert: narrowing this back to bare destination-unreachable
+	// turns this RED.
+	if !strings.Contains(payload, "icmp type { destination-unreachable, time-exceeded, parameter-problem } accept") {
+		t.Errorf("payload missing icmpv4 error/PMTUD (dest-unreachable/time-exceeded/parameter-problem) accept:\n%s", payload)
 	}
 
 	// The ESP/AH exemption MUST precede every per-zone scoped drop, otherwise a

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -152,8 +152,20 @@ classification covers the common Junos `system-services` (ssh, ping, dns,
 dhcp/dhcpv6, ike, ntp, snmp, ...) and `protocols` (ospf, bgp,
 router-discovery, ...) names; `system-services all` / `any-service`
 short-circuit to a full admit; an unrecognised token contributes nothing
-(fail-closed). ICMP-based services (`ping`, `router-discovery`) admit at
-L4-protocol granularity, not ICMP sub-type.
+(fail-closed). ICMP-based services (`ping`, `router-discovery`) admit echo /
+solicitation at L4-protocol granularity, not ICMP sub-type.
+
+**ICMP error / PMTUD control messages are always admitted (#3171).** Before
+the per-zone lookup, `host_inbound_admits` exempts ICMP/ICMPv6 *error* subtypes
+(`is_icmp_host_inbound_error`: ICMPv4 destination-unreachable/time-exceeded/
+parameter-problem, ICMPv6 type 1/2/3/4) regardless of whether the ingress zone
+lists `ping`. This mirrors the kernel `chain input` global ICMP-error accept
+(`pkg/daemon/daemon_nft.go`) so the embedded-ICMP / DNAT-to-self subset listed
+above — e.g. a PMTUD packet-too-big or traceroute time-exceeded landing on the
+XSK LocalDelivery path — is no longer fail-toward-dropped on a configured
+ping-less zone. ECHO-REQUEST (v4 type 8 / v6 type 128) is **not** in the error
+set, so a ping-less zone still drops echo. Keep `is_icmp_host_inbound_error` in
+lock-step with the kernel chain's `icmp`/`icmpv6` accept lines.
 
 **`protocols all` is scoped, NOT a blanket bypass (#3199).** In Junos
 `host-inbound-traffic protocols all` admits every supported ROUTING protocol

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -232,18 +232,64 @@ fn classify_protocol(token: &str, hi: &mut ZoneHostInbound) {
     }
 }
 
+/// #3171: ICMP/ICMPv6 error (control) message subtypes that the host-inbound
+/// layer admits UNCONDITIONALLY — regardless of whether the ingress zone lists
+/// `ping` — so the userspace LocalDelivery classifier matches the kernel
+/// host-inbound chain's global ICMP-error accept (`pkg/daemon/daemon_nft.go`:
+/// `icmp type { destination-unreachable, time-exceeded, parameter-problem }`
+/// and `icmpv6 type { 1, 2, 3, 4, 133..137 }`). These carry PMTUD / unreachable
+/// / traceroute-to-self signalling that must reach a firewall-local address
+/// (e.g. a DNAT-to-self embedded ICMP error landing on the XSK) even on a
+/// configured ping-less zone. Without this exemption the userspace path dropped
+/// them while the kernel chain accepted them — a fail-toward-drop edge and the
+/// doc-vs-behavior inconsistency #3070's README flagged for embedded-ICMP.
+///
+/// This set is deliberately NARROWER than `icmp::is_icmp_error` (the
+/// embedded-NAT reversal set, which also includes v4 Source Quench (4) and
+/// Redirect (5)): Source Quench is deprecated (RFC 6633) and Redirect is
+/// link-scoped — neither is a control message we admit to the host. ECHO
+/// REQUEST (v4 type 8 / v6 type 128) is NOT here: it stays gated on the `ping`
+/// system-service, so a ping-less zone still drops echo.
+///
+/// Keep this set in lock-step with the kernel chain in
+/// `pkg/daemon/daemon_nft.go` and its
+/// `TestHostInboundFilterExemptsIPsecAndV6Errors` accept assertions.
+fn is_icmp_host_inbound_error(protocol: u8, icmp_type: u8) -> bool {
+    match protocol {
+        // ICMPv4: destination-unreachable (3, also carries PMTUD
+        // "fragmentation needed" as code 4), time-exceeded (11),
+        // parameter-problem (12).
+        1 => matches!(icmp_type, 3 | 11 | 12),
+        // ICMPv6: destination-unreachable (1), packet-too-big (2, PMTUD),
+        // time-exceeded (3), parameter-problem (4).
+        58 => matches!(icmp_type, 1 | 2 | 3 | 4),
+        _ => false,
+    }
+}
+
 /// Per-packet host-inbound admit check for a host-bound (local-delivery)
-/// packet ingressing `ingress_zone_id`. Returns true (admit) when the zone has
-/// no host-inbound stanza (absent from the table — the admit-all default) or
-/// when the packet's service/protocol is in the zone's set. Returns false
-/// (deny) only when the zone IS configured and the packet matches nothing.
+/// packet ingressing `ingress_zone_id`. Returns true (admit) when the packet is
+/// an ICMP/ICMPv6 error/PMTUD control message (#3171 — always exempt, mirroring
+/// the kernel chain), when the zone has no host-inbound stanza (absent from the
+/// table — the admit-all default), or when the packet's service/protocol is in
+/// the zone's set. Returns false (deny) only when the zone IS configured and the
+/// packet matches nothing. `icmp_type` is the first L4 byte for ICMP/ICMPv6
+/// packets and is ignored for every other protocol (pass 0).
 pub(in crate::afxdp) fn host_inbound_admits(
     state: &ForwardingState,
     ingress_zone_id: u16,
     protocol: u8,
     dst_port: u16,
     is_v6: bool,
+    icmp_type: u8,
 ) -> bool {
+    // #3171: error/PMTUD control messages are admitted before the zone lookup
+    // so PMTUD / unreachable / traceroute-to-self works on a configured zone
+    // that omits `ping`, matching the kernel host-inbound chain. Echo-request is
+    // not in this set, so it stays gated on the `ping` system-service below.
+    if is_icmp_host_inbound_error(protocol, icmp_type) {
+        return true;
+    }
     match state.zone_host_inbound.get(&ingress_zone_id) {
         None => true,
         Some(hi) => hi.admits(protocol, dst_port, is_v6),

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1053,41 +1053,142 @@ fn build_forwarding_state_enforces_host_inbound_traffic() {
 
     // wan (id 11): ping (icmp) admitted, gre (proto 47) admitted, ssh (tcp/22)
     // DENIED, ospf (proto 89) DENIED.
-    assert!(host_inbound_admits(&state, 11, 1, 0, false), "wan ping");
-    assert!(host_inbound_admits(&state, 11, 47, 0, false), "wan gre");
-    assert!(!host_inbound_admits(&state, 11, 6, 22, false), "wan ssh deny");
-    assert!(!host_inbound_admits(&state, 11, 89, 0, false), "wan ospf deny");
+    assert!(host_inbound_admits(&state, 11, 1, 0, false, 0), "wan ping");
+    assert!(host_inbound_admits(&state, 11, 47, 0, false, 0), "wan gre");
+    assert!(
+        !host_inbound_admits(&state, 11, 6, 22, false, 0),
+        "wan ssh deny"
+    );
+    assert!(
+        !host_inbound_admits(&state, 11, 89, 0, false, 0),
+        "wan ospf deny"
+    );
 
     // lan (id 12): ssh (tcp/22) admitted, ping admitted, telnet (tcp/23)
     // DENIED, dhcp (udp/67) DENIED (not listed).
-    assert!(host_inbound_admits(&state, 12, 6, 22, false), "lan ssh");
-    assert!(host_inbound_admits(&state, 12, 1, 0, false), "lan ping");
-    assert!(!host_inbound_admits(&state, 12, 6, 23, false), "lan telnet deny");
-    assert!(!host_inbound_admits(&state, 12, 17, 67, false), "lan dhcp deny");
+    assert!(host_inbound_admits(&state, 12, 6, 22, false, 0), "lan ssh");
+    assert!(host_inbound_admits(&state, 12, 1, 0, false, 0), "lan ping");
+    assert!(
+        !host_inbound_admits(&state, 12, 6, 23, false, 0),
+        "lan telnet deny"
+    );
+    assert!(
+        !host_inbound_admits(&state, 12, 17, 67, false, 0),
+        "lan dhcp deny"
+    );
 
     // control (id 13): all → admit everything.
     assert!(
-        host_inbound_admits(&state, 13, 6, 12345, false),
+        host_inbound_admits(&state, 13, 6, 12345, false, 0),
         "control all tcp"
     );
     assert!(
-        host_inbound_admits(&state, 13, 89, 0, false),
+        host_inbound_admits(&state, 13, 89, 0, false, 0),
         "control all ospf"
     );
 
     // legacy (id 14): unconfigured → admit everything (pre-#3070 behaviour).
     assert!(
-        host_inbound_admits(&state, 14, 6, 22, false),
+        host_inbound_admits(&state, 14, 6, 22, false, 0),
         "legacy admit-all"
     );
     assert!(
-        host_inbound_admits(&state, 14, 89, 0, false),
+        host_inbound_admits(&state, 14, 89, 0, false, 0),
         "legacy admit-all proto"
     );
     // A zone id that does not exist at all also admits (no entry).
     assert!(
-        host_inbound_admits(&state, 99, 6, 22, false),
+        host_inbound_admits(&state, 99, 6, 22, false, 0),
         "unknown zone admit"
+    );
+}
+
+// #3171: a CONFIGURED ping-less zone must still admit ICMP/ICMPv6 ERROR /
+// PMTUD control messages (destination-unreachable, packet-too-big, time-
+// exceeded, parameter-problem) reaching the XSK LocalDelivery path — mirroring
+// the kernel host-inbound chain's global ICMP-error accept — while still
+// DENYING ICMP echo-request when `ping` is not configured. A zone WITH `ping`
+// still admits echo-request.
+//
+// Fail-on-revert: deleting the `is_icmp_host_inbound_error` early-return in
+// `host_inbound_admits` (the blanket ICMP-drop behaviour) turns the
+// "admits dest-unreachable" assertions RED while the "drops echo without ping"
+// assertions stay GREEN.
+#[test]
+fn build_forwarding_state_admits_icmp_errors_on_pingless_zone() {
+    use crate::ZoneSnapshot;
+    use crate::afxdp::forwarding::host_inbound_admits;
+
+    let snapshot = ConfigSnapshot {
+        zones: vec![
+            // ping-less zone: ssh only, NO ping.
+            ZoneSnapshot {
+                name: "wan-noping".into(),
+                id: 31,
+                host_inbound_configured: true,
+                host_inbound_system_services: vec!["ssh".into()],
+                host_inbound_protocols: vec![],
+                ..Default::default()
+            },
+            // ping zone: echo-request must still be admitted.
+            ZoneSnapshot {
+                name: "lan-ping".into(),
+                id: 32,
+                host_inbound_configured: true,
+                host_inbound_system_services: vec!["ping".into()],
+                host_inbound_protocols: vec![],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+
+    // ping-less zone (id 31) ADMITS ICMPv4 error / PMTUD control messages even
+    // though it lists no `ping`: destination-unreachable (3), time-exceeded
+    // (11), parameter-problem (12).
+    assert!(
+        host_inbound_admits(&state, 31, 1, 0, false, 3),
+        "ping-less zone admits icmp destination-unreachable (PMTUD)"
+    );
+    assert!(
+        host_inbound_admits(&state, 31, 1, 0, false, 11),
+        "ping-less zone admits icmp time-exceeded (traceroute)"
+    );
+    assert!(
+        host_inbound_admits(&state, 31, 1, 0, false, 12),
+        "ping-less zone admits icmp parameter-problem"
+    );
+    // ...and ICMPv6 destination-unreachable (1) + packet-too-big (2, PMTUD).
+    assert!(
+        host_inbound_admits(&state, 31, 58, 0, true, 1),
+        "ping-less zone admits icmpv6 destination-unreachable"
+    );
+    assert!(
+        host_inbound_admits(&state, 31, 58, 0, true, 2),
+        "ping-less zone admits icmpv6 packet-too-big (PMTUD)"
+    );
+
+    // ...but echo-request (v4 type 8 / v6 type 128) is STILL DENIED — it is
+    // gated on the `ping` system-service, which this zone does not list.
+    assert!(
+        !host_inbound_admits(&state, 31, 1, 0, false, 8),
+        "ping-less zone DENIES icmp echo-request"
+    );
+    assert!(
+        !host_inbound_admits(&state, 31, 58, 0, true, 128),
+        "ping-less zone DENIES icmpv6 echo-request"
+    );
+
+    // ping zone (id 32) admits echo-request on both families.
+    assert!(
+        host_inbound_admits(&state, 32, 1, 0, false, 8),
+        "ping zone admits icmp echo-request"
+    );
+    assert!(
+        host_inbound_admits(&state, 32, 58, 0, true, 128),
+        "ping zone admits icmpv6 echo-request"
     );
 }
 
@@ -1133,42 +1234,42 @@ fn build_forwarding_state_protocols_all_admits_routing_not_system_services() {
 
     // routing (id 21): `protocols all` admits routing protocols of every kind.
     assert!(
-        host_inbound_admits(&state, 21, 89, 0, false),
+        host_inbound_admits(&state, 21, 89, 0, false, 0),
         "protocols all admits ospf (proto 89)"
     );
     assert!(
-        host_inbound_admits(&state, 21, 6, 179, false),
+        host_inbound_admits(&state, 21, 6, 179, false, 0),
         "protocols all admits bgp (tcp/179)"
     );
     assert!(
-        host_inbound_admits(&state, 21, 112, 0, false),
+        host_inbound_admits(&state, 21, 112, 0, false, 0),
         "protocols all admits vrrp (proto 112)"
     );
     assert!(
-        host_inbound_admits(&state, 21, 17, 520, false),
+        host_inbound_admits(&state, 21, 17, 520, false, 0),
         "protocols all admits rip (udp/520)"
     );
     // ...but NOT system-services: SSH, HTTPS, SNMP must be DENIED.
     assert!(
-        !host_inbound_admits(&state, 21, 6, 22, false),
+        !host_inbound_admits(&state, 21, 6, 22, false, 0),
         "protocols all must NOT admit ssh (tcp/22)"
     );
     assert!(
-        !host_inbound_admits(&state, 21, 6, 443, false),
+        !host_inbound_admits(&state, 21, 6, 443, false, 0),
         "protocols all must NOT admit https (tcp/443)"
     );
     assert!(
-        !host_inbound_admits(&state, 21, 17, 161, false),
+        !host_inbound_admits(&state, 21, 17, 161, false, 0),
         "protocols all must NOT admit snmp (udp/161)"
     );
 
     // mgmt (id 22): explicit ssh still admits ssh (regression), denies https.
     assert!(
-        host_inbound_admits(&state, 22, 6, 22, false),
+        host_inbound_admits(&state, 22, 6, 22, false, 0),
         "system-services ssh admits ssh"
     );
     assert!(
-        !host_inbound_admits(&state, 22, 6, 443, false),
+        !host_inbound_admits(&state, 22, 6, 443, false, 0),
         "system-services ssh does not admit https"
     );
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -644,6 +644,14 @@ pub(super) fn poll_binding_process_descriptor(
                                 meta.protocol,
                                 resolved.key.dst_port,
                                 matches!(flow.dst_ip, IpAddr::V6(_)),
+                                // #3171: first L4 byte = ICMP/ICMPv6 type, so an
+                                // error/PMTUD control message stays admitted on a
+                                // ping-less zone (mirrors the kernel chain). 0
+                                // for non-ICMP (ignored by host_inbound_admits).
+                                raw_frame
+                                    .get(meta.l4_offset as usize)
+                                    .copied()
+                                    .unwrap_or(0),
                             )
                         {
                             delete_terminal_filtered_session(
@@ -1459,6 +1467,14 @@ pub(super) fn poll_binding_process_descriptor(
                                 meta.protocol,
                                 flow.forward_key.dst_port,
                                 matches!(flow.dst_ip, IpAddr::V6(_)),
+                                // #3171: first L4 byte = ICMP/ICMPv6 type, so
+                                // error/PMTUD control messages are admitted on a
+                                // ping-less zone (mirrors the kernel chain). 0
+                                // for non-ICMP (ignored by host_inbound_admits).
+                                raw_frame
+                                    .get(meta.l4_offset as usize)
+                                    .copied()
+                                    .unwrap_or(0),
                             )
                         {
                             telemetry.dbg.local += 1;


### PR DESCRIPTION
## Summary

Closes #3171.

#3070 enforces `host-inbound-traffic` in two layers that disagreed on ICMP errors for a CONFIGURED zone that does not list `ping`:

- Kernel chain (`pkg/daemon/daemon_nft.go`) globally accepted ICMP `destination-unreachable` + `icmpv6 type {1,2}` (PMTUD / unreachable).
- Userspace `host_inbound_admits` DROPPED ICMP (proto 1/58) for a configured ping-less zone.

This bit the XSK-reaching subset — e.g. a DNAT-to-self embedded ICMP error on the userspace LocalDelivery path — a fail-toward-drop edge for PMTUD/traceroute-to-self and the doc-vs-behavior inconsistency #3070's README flagged for the "embedded-ICMP" userspace case.

## Fix

Exempt ICMP/ICMPv6 **error** control subtypes on the userspace host-inbound path, and keep kernel + userspace consistent by mirroring the same set.

- **`is_icmp_host_inbound_error(protocol, icmp_type)`** (new, `forwarding/host_inbound.rs`):
  - ICMPv4: destination-unreachable (3, also carries PMTUD frag-needed code 4), time-exceeded (11), parameter-problem (12).
  - ICMPv6: destination-unreachable (1), packet-too-big (2), time-exceeded (3), parameter-problem (4).
  - Deliberately **narrower** than `icmp::is_icmp_error` (excludes v4 Source Quench / Redirect — not control messages we admit to the host).
- **`host_inbound_admits` gains an `icmp_type` arg** and returns admit for an error subtype **before** the per-zone lookup. Echo-request (v4 type 8 / v6 type 128) is **not** in the set, so a ping-less zone still drops echo; a `ping` zone still admits echo.
- Both `poll_descriptor` LocalDelivery call sites (session miss + session hit) thread the first L4 byte (ICMP type) into the check.
- **Kernel nft chain broadened to the SAME set** so kernel + XSK agree:
  - `icmp type { destination-unreachable, time-exceeded, parameter-problem } accept`
  - `icmpv6 type { 1, 2, 3, 4, 133..137 } accept`
  - Cross-referenced both ways in comments.
- Reconciled the #3070 forwarding README embedded-ICMP claim.

## Tests (fail-on-revert)

- **Rust** `build_forwarding_state_admits_icmp_errors_on_pingless_zone`: a configured ping-less zone admits ICMPv4 dest-unreachable/time-exceeded/parameter-problem and ICMPv6 type 1/2; still DENIES echo-request; a `ping` zone admits echo. Proven fail-on-revert: disabling the `is_icmp_host_inbound_error` early-return turns the "admits dest-unreachable" assertion **RED** while "drops echo without ping" stays **GREEN**.
- **Go** `TestHostInboundFilterExemptsIPsecAndV6Errors` updated for the broadened v4 + v6 accept sets.

## Validation

- `cargo build --release` green.
- `cargo test --release --bin xpf-userspace-dp forwarding_build` — 76 passed; new test + existing host-inbound tests green.
- `go test ./pkg/daemon/ -run HostInbound -count=1` green.

> NOTE: host-inbound is HA-adjacent — parent runs `test-failover` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi