### PR TITLE
wg: derive PTB inner-MTU from the per-peer underlay (#2845)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-06-26 — #2845 WG PTB inner-MTU per-peer underlay
+
+- **Timestamp**: 2026-06-26
+- **Action**: Fix the WireGuard Packet-Too-Big inner-MTU computation, which
+  assumed one underlay MTU per wg interface (resolved via the FIRST peer with
+  an endpoint). The encap path LPM-selects the peer by inner destination
+  (`engine.peer_for_dest`) and computes the outer hop / MTU guard from THAT
+  peer's endpoint, but the PTB path ran before peer selection — so a PTB for
+  traffic to peer B could quote peer A's underlay MTU (over-advertise → next
+  packet dropped by peer B's encap guard; or under-advertise → throughput
+  loss). Fix: the TX dispatcher now derives the pre-encap inner destination
+  and threads it into `post_transform_inner_mtu` →
+  `frame::wg_endpoint_physical_outer_mtu`, which selects the SAME peer the
+  encap path will (`engine.peer_for_dest` on the inner destination) and
+  resolves the physical underlay MTU via THAT peer's endpoint route. Falls
+  back to the pre-#2845 first-peer behaviour (byte-identical single-underlay)
+  when the inner destination is unavailable / no live engine / no covering
+  peer; a covering peer with no endpoint uses the conservative logical
+  fallback rather than borrowing a different peer's underlay.
+- **File(s)**: `userspace-dp/src/afxdp/frame/wg.rs` (new `wg_peer_outer_dst`
+  helper + `wg_endpoint_physical_outer_mtu` gains an `inner_dst` param),
+  `userspace-dp/src/afxdp/icmp_ptb.rs` (`post_transform_inner_mtu` threads
+  `inner_dst` to the WG arm), `userspace-dp/src/afxdp/tx/dispatch/mod.rs`
+  (derive inner dst from `source_frame` + pass it),
+  `userspace-dp/src/afxdp/icmp_ptb_tests.rs` (new
+  `post_transform_wg_inner_mtu_is_per_peer_underlay` two-peer asymmetric
+  fixture + existing calls updated), `userspace-dp/src/afxdp/README.md`,
+  `docs/wireguard-interop.md`.
+- **Validation**: `cargo build --release` clean; new per-peer test green;
+  fail-on-revert proven (restore first-peer assumption → the per-peer test
+  goes RED on peer B while the three single-underlay #2684 tests stay GREEN).
+  Full `cargo test --release --bin xpf-userspace-dp` = 3089 passed / 0 failed.
+
 ## 2026-06-26 — #3200 host-inbound unknown/typo token: commit validation + both-layer fail-closed
 
 - **Timestamp**: 2026-06-26

--- a/docs/wireguard-interop.md
+++ b/docs/wireguard-interop.md
@@ -176,18 +176,36 @@ but unnecessary fragmentation pressure / throughput loss).
 
 The WG arm now derives the outer MTU from the PHYSICAL underlay via
 `frame::wg_endpoint_physical_outer_mtu`, a thin wrapper over the same #2680
-`outer_physical_egress_mtu` SSOT the encap guard uses. The PTB path runs
-before the per-packet peer LPM (it has no inner frame), but the WG underlay
-is per-tunnel-endpoint, not per-inner-flow (#2734) — so it route-resolves
-the physical egress via the FIRST peer that carries an endpoint address.
+`outer_physical_egress_mtu` SSOT the encap guard uses.
 Corrected formula: advertised inner MTU = `wg_inner_mtu(outer_family,
 physical_underlay_mtu)` = `physical_mtu − WG_OVERHEAD_{V4,V6} −
 WG_MAX_PADDING` — EXACTLY the inverse of `wg_encapped_size` the encap guard
-admits against, so the PTB and the guard now agree. Conservative fallback
-(no peer endpoint to route to / unresolvable outer) reverts to the logical
-`egress_ifindex` MTU — the pre-#2684 value, never worse. GRE is unaffected:
+admits against, so the PTB and the guard now agree. GRE is unaffected:
 its `endpoint.destination` is the real outer hop, so `tunnel_outer_mtu`
 already resolves to the physical underlay for `native_gre_inner_mtu`.
+
+**#2845 (per-peer underlay — the #2684 follow-up).** #2684 originally
+resolved the physical egress via the FIRST peer that carried an endpoint
+address, on the assumption that the WG underlay is per-tunnel-endpoint, not
+per-inner-flow (#2734). That assumption is wrong when one wg interface has
+peers on DIFFERENT underlay paths: the encap path LPM-selects the peer by
+inner destination (`engine.peer_for_dest`) and computes the outer hop / MTU
+guard from THAT peer's endpoint, but the PTB ran before peer selection and
+used the first peer's endpoint. So a PTB for traffic to peer B could quote
+peer A's underlay MTU — over-advertising (next packet dropped by peer B's
+encap guard) or under-advertising (needless throughput loss). The dispatcher
+now threads the pre-encap inner destination into `post_transform_inner_mtu`,
+which passes it to `wg_endpoint_physical_outer_mtu`. The helper selects the
+SAME peer the encap path will (`engine.peer_for_dest` on the inner
+destination — the live engine owns the AllowedIPs LPM and the per-snapshot
+endpoint binding, #2836) and resolves the underlay via THAT peer's endpoint
+route. Conservative fallback (no inner destination available, no live engine,
+or no peer covers the destination) reverts to the first peer with an endpoint
+— byte-identical when all peers share one underlay; the pre-#2684 logical
+`egress_ifindex` MTU when even that has no endpoint. A covering peer with NO
+endpoint resolves to the logical fallback rather than borrowing a different
+peer's underlay (the encap path drops such a packet anyway, so the PTB value
+is moot).
 
 **#2457 (advertised/configured inner MTU clamped to the engine ceiling).**
 The WG engine encrypts at most `PADDED_PLAINTEXT_MAX = 4096` bytes of

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -263,6 +263,21 @@ sync.
     IPv4 inner stays fragmentable → `Forward` → the #2331 drop guard remains
     the backstop). `mtu == 0` (no MTU resolvable / unknown tunnel kind)
     fails open to `Forward`.
+    **Per-peer WG underlay (#2845):** for WireGuard the underlay MTU is
+    NOT one-per-interface — different peers of one wg endpoint can have
+    different endpoints / transport routes / underlay MTUs. The dispatcher
+    threads the pre-encap inner destination into `post_transform_inner_mtu`,
+    which passes it to `frame::wg_endpoint_physical_outer_mtu`. That helper
+    selects the SAME peer the encap path will (`engine.peer_for_dest` —
+    AllowedIPs LPM on the inner destination) and resolves the physical
+    underlay MTU via THAT peer's endpoint route, so the advertised inner PMTU
+    matches the underlay the encap guard will actually admit the packet onto.
+    When the inner destination is unavailable, no live engine is present, or
+    no peer covers it, it falls back to the first peer with an endpoint (the
+    pre-#2845 per-interface behaviour — byte-identical when all peers share
+    one underlay). A covering peer with NO endpoint resolves to the
+    conservative logical-ifindex MTU rather than borrowing a different peer's
+    underlay.
 - `icmp_ptb.rs` — #2301 PMTUD error generators for the generic
   forwarder: the egress-MTU decision plus the ICMPv4 Frag-Needed /
   ICMPv6 Packet-Too-Big builders (MTU in the body). Mirrors

--- a/userspace-dp/src/afxdp/frame/wg.rs
+++ b/userspace-dp/src/afxdp/frame/wg.rs
@@ -173,25 +173,84 @@ fn outer_physical_egress_mtu(
         .unwrap_or(1500)
 }
 
+/// The peer-endpoint outer destination whose underlay MTU the PTB must
+/// derive from, for a given inner destination (#2845).
+///
+/// The encap path selects the egress peer by the inner destination's
+/// longest-prefix match in the AllowedIPs trie
+/// (`wg_encap_frame` → `engine.peer_for_dest`) and resolves the outer hop
+/// from THAT peer's endpoint. Different peers of one wg interface can have
+/// different endpoints / underlay paths / MTUs, so the PTB must select the
+/// SAME peer rather than assuming one underlay per interface.
+///
+/// Resolution mirrors the encap path exactly: the live engine
+/// (`forwarding.wg_engines`) owns the AllowedIPs LPM and the per-snapshot
+/// endpoint binding (#2836), so the PTB and the encap agree on both the peer
+/// and its (possibly roamed) endpoint.
+///
+/// Returns:
+///   - `Some(ip)` — a covering peer was found with a known endpoint; resolve
+///     the underlay via the route to `ip`.
+///   - `None` — either no inner destination was available, no live engine is
+///     present yet, or no peer covers the inner destination: fall back to the
+///     pre-#2845 first-peer-with-endpoint behaviour (byte-identical in the
+///     single-underlay common case, the only available answer with no inner
+///     destination to select on).
+///
+/// NOTE: a covering peer found with NO endpoint (responder-only / unlearned)
+/// resolves to that peer's `None` and is returned as `None` here — the caller
+/// then uses the conservative logical-ifindex fallback rather than borrowing a
+/// DIFFERENT peer's underlay (which would reintroduce the #2845 mismatch). The
+/// encap path drops such a packet anyway, so the PTB value is moot.
+#[inline]
+fn wg_peer_outer_dst(
+    forwarding: &ForwardingState,
+    endpoint: &TunnelEndpoint,
+    inner_dst: Option<IpAddr>,
+) -> Option<IpAddr> {
+    if let Some(dst) = inner_dst {
+        if let Some(engine) = forwarding.wg_engines.get(&endpoint.id) {
+            if let Some((_pubkey, peer_endpoint)) = engine.peer_for_dest(dst) {
+                // A covering peer was found: use ITS endpoint (or None if the
+                // peer has no learned/configured endpoint — see the doc note).
+                return peer_endpoint.map(|ep| ep.ip());
+            }
+        }
+    }
+    // No inner dst, no live engine, or no covering peer: the pre-#2845
+    // first-peer-with-endpoint behaviour. Byte-identical in the single-
+    // underlay common case (one peer, or all peers on one underlay).
+    endpoint
+        .wg_peers
+        .iter()
+        .find_map(|peer| peer.endpoint.map(|ep| ep.ip()))
+}
+
 /// The PHYSICAL underlay egress MTU for a WireGuard endpoint, for the
-/// post-transform PTB inner-MTU derivation (#2684).
+/// post-transform PTB inner-MTU derivation (#2684, per-peer #2845).
 ///
 /// This is the SAME physical-underlay SSOT (`outer_physical_egress_mtu`,
 /// #2680) the encap drop guard uses, exposed so the TX dispatcher's
 /// `post_transform_inner_mtu` advertises an inner MTU consistent with what
-/// the encap guard actually admits. The PTB path runs BEFORE the per-packet
-/// peer LPM (it has no inner frame to select a peer), but the WG outer
-/// underlay is per-tunnel-endpoint, not per-inner-flow (#2734): every peer of
-/// an endpoint egresses the same physical underlay. So we resolve the
-/// physical egress via the FIRST peer endpoint that yields a route; the
-/// fallback inside `outer_physical_egress_mtu` (route unresolvable → the
+/// the encap guard actually admits.
+///
+/// #2845: the PTB path runs BEFORE the per-packet peer LPM in the builder, but
+/// the dispatcher already holds the pre-encap inner frame and threads the inner
+/// destination here. We select the SAME peer the encap path will
+/// (`wg_peer_outer_dst` → `engine.peer_for_dest`) and resolve the underlay via
+/// THAT peer's endpoint, so two peers of one wg interface with asymmetric
+/// underlay MTUs each get the PTB derived from their OWN underlay — not an
+/// arbitrary first peer's. When the inner destination is unavailable or no peer
+/// covers it, this falls back to the first peer with an endpoint (the pre-#2845
+/// per-interface behaviour, byte-identical when all peers share one underlay).
+/// The fallback inside `outer_physical_egress_mtu` (route unresolvable → the
 /// resolution's own `egress_ifindex` MTU = the tunnel LOGICAL MTU) preserves
 /// the conservative pre-#2684 behaviour, never tighter.
 ///
-/// Returns the logical-ifindex MTU fallback when the endpoint has no peer
-/// with a learned/configured endpoint address (no outer hop to route to) —
-/// the same value `tunnel_outer_mtu` would have produced, so the PTB is no
-/// worse than before in that degenerate case.
+/// Returns the logical-ifindex MTU fallback when the selected peer has no
+/// learned/configured endpoint address (no outer hop to route to) — the same
+/// value `tunnel_outer_mtu` would have produced, so the PTB is no worse than
+/// before in that degenerate case.
 ///
 /// # Why not `tunnel_outer_mtu`
 /// For a WG transit flow `endpoint.destination` is `0.0.0.0`/`::`
@@ -208,13 +267,12 @@ pub(in crate::afxdp) fn wg_endpoint_physical_outer_mtu(
     decision: &SessionDecision,
     forwarding: &ForwardingState,
     endpoint: &TunnelEndpoint,
+    inner_dst: Option<IpAddr>,
 ) -> usize {
-    // The WG underlay is per-endpoint (#2734): the first peer with a known
-    // endpoint address resolves the same physical egress as any other.
-    let outer_dst = endpoint
-        .wg_peers
-        .iter()
-        .find_map(|peer| peer.endpoint.map(|ep| ep.ip()));
+    // #2845: resolve the outer hop of the SAME peer the encap path selects
+    // for this inner destination (per-peer underlay), with the pre-#2845
+    // first-peer behaviour as the fallback.
+    let outer_dst = wg_peer_outer_dst(forwarding, endpoint, inner_dst);
     match outer_dst {
         Some(dst) => outer_physical_egress_mtu(decision, forwarding, endpoint, dst),
         // No peer endpoint to route to: fall back to the resolution's own

--- a/userspace-dp/src/afxdp/icmp_ptb.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb.rs
@@ -174,6 +174,7 @@ pub(in crate::afxdp) fn post_transform_inner_mtu(
     is_nat64: bool,
     inner_addr_family: u8,
     egress_mtu: usize,
+    inner_dst: Option<std::net::IpAddr>,
 ) -> usize {
     if is_nat64 {
         if egress_mtu == 0 {
@@ -221,8 +222,14 @@ pub(in crate::afxdp) fn post_transform_inner_mtu(
             // match the encap drop guard's admit threshold
             // (`wg_inner_mtu(physical)`), so DF-IPv4 / IPv6 inners get the
             // same PMTU the guard tolerates instead of ~100B too small.
-            let outer_mtu =
-                crate::afxdp::frame::wg_endpoint_physical_outer_mtu(decision, forwarding, endpoint);
+            //
+            // #2845: thread the inner destination so the underlay MTU is
+            // derived from the SAME peer the encap path will select (per-peer
+            // underlay), not an arbitrary first peer's. Two peers of one wg
+            // interface can egress different underlays with different MTUs.
+            let outer_mtu = crate::afxdp::frame::wg_endpoint_physical_outer_mtu(
+                decision, forwarding, endpoint, inner_dst,
+            );
             crate::afxdp::wg::mss::wg_inner_mtu(endpoint.outer_family, outer_mtu)
         }
         TunnelKind::Unknown => 0,

--- a/userspace-dp/src/afxdp/icmp_ptb_tests.rs
+++ b/userspace-dp/src/afxdp/icmp_ptb_tests.rs
@@ -880,7 +880,7 @@ fn post_transform_inner_mtu_gre_subtracts_outer_and_gre_header() {
     let mut fwd = forwarding_with_egress(1400);
     insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0);
     let decision = tunnel_decision();
-    let inner = post_transform_inner_mtu(&decision, &fwd, false, libc::AF_INET as u8, 1400);
+    let inner = post_transform_inner_mtu(&decision, &fwd, false, libc::AF_INET as u8, 1400, None);
     assert_eq!(inner, 1376, "GRE inner MTU = transport - outer_ip(20) - gre(4)");
     assert_eq!(
         inner,
@@ -895,7 +895,7 @@ fn post_transform_inner_mtu_gre_counts_key_word() {
     let mut fwd = forwarding_with_egress(1400);
     insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0xdead_beef);
     let inner =
-        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400);
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400, None);
     assert_eq!(inner, 1372, "key-present GRE counts the extra 4-byte key word");
 }
 
@@ -907,7 +907,7 @@ fn post_transform_inner_mtu_wireguard_is_pad_aware() {
     let mut fwd = forwarding_with_egress(1400);
     insert_tunnel_endpoint(&mut fwd, "wireguard", libc::AF_INET, 0);
     let inner =
-        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400);
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400, None);
     assert_eq!(inner, 1325, "WG inner MTU = outer_mtu - WG_OVERHEAD_V4 - max_pad");
     assert_eq!(
         inner,
@@ -923,7 +923,7 @@ fn post_transform_inner_mtu_unknown_tunnel_kind_fails_open() {
     let mut fwd = forwarding_with_egress(1400);
     insert_tunnel_endpoint(&mut fwd, "l2tp", libc::AF_INET, 0);
     assert_eq!(
-        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400),
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, libc::AF_INET as u8, 1400, None),
         0,
         "unknown tunnel mode -> 0 (fail-open)"
     );
@@ -935,7 +935,7 @@ fn post_transform_inner_mtu_nat64_v6_to_v4_adds_header_delta() {
     // so a v6 inner up to egress_mtu + 20 still fits. egress 1400 -> 1420.
     let fwd = forwarding_with_egress(1400);
     let inner =
-        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, libc::AF_INET6 as u8, 1400);
+        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, libc::AF_INET6 as u8, 1400, None);
     assert_eq!(inner, 1420, "NAT64 v6->v4 inner MTU = egress + 20");
 }
 
@@ -945,7 +945,7 @@ fn post_transform_inner_mtu_nat64_v4_to_v6_subtracts_header_delta() {
     // so the v4 inner must be 20 bytes SMALLER. egress 1400 -> 1380.
     let fwd = forwarding_with_egress(1400);
     let inner =
-        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, libc::AF_INET as u8, 1400);
+        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, libc::AF_INET as u8, 1400, None);
     assert_eq!(inner, 1380, "NAT64 v4->v6 inner MTU = egress - 20");
 }
 
@@ -961,7 +961,7 @@ fn post_transform_gre_oversized_v4_df_emits_inner_ptb() {
     insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0);
     let decision = tunnel_decision();
     let inner_mtu =
-        post_transform_inner_mtu(&decision, &fwd, false, meta.addr_family, 1400);
+        post_transform_inner_mtu(&decision, &fwd, false, meta.addr_family, 1400, None);
     assert_eq!(inner_mtu, 1376);
 
     // Source-vs-egress (the WRONG pre-#2330 comparison) would advertise 1400;
@@ -996,7 +996,7 @@ fn post_transform_wireguard_oversized_v6_emits_inner_ptb() {
     let mut fwd = forwarding_with_egress(1400);
     insert_tunnel_endpoint(&mut fwd, "wireguard", libc::AF_INET, 0);
     let inner_mtu =
-        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, meta.addr_family, 1400);
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, meta.addr_family, 1400, None);
     assert_eq!(inner_mtu, 1325);
     let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu)
     {
@@ -1023,7 +1023,7 @@ fn post_transform_nat64_v6_oversized_emits_inner_ptb() {
     let l3 = meta.l3_offset as usize;
     let fwd = forwarding_with_egress(1400);
     let inner_mtu =
-        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, meta.addr_family, 1400);
+        post_transform_inner_mtu(&nat64_decision(true), &fwd, true, meta.addr_family, 1400, None);
     assert_eq!(inner_mtu, 1420, "NAT64 v6->v4 inner MTU = egress + 20");
     let next_hop_mtu = match forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu)
     {
@@ -1050,7 +1050,7 @@ fn post_transform_in_mtu_forwards_no_ptb() {
     let mut fwd = forwarding_with_egress(1400);
     insert_tunnel_endpoint(&mut fwd, "gre", libc::AF_INET, 0);
     let inner_mtu =
-        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, meta.addr_family, 1400);
+        post_transform_inner_mtu(&tunnel_decision(), &fwd, false, meta.addr_family, 1400, None);
     assert_eq!(
         forwarded_egress_mtu_decision(&frame, l3, meta.addr_family, inner_mtu),
         EgressMtuDecision::Forward,
@@ -1202,7 +1202,7 @@ fn post_transform_wg_inner_mtu_uses_physical_underlay_not_logical_v4() {
     assert_eq!(state.egress.get(&12).map(|e| e.mtu), Some(1500), "reth0.80 physical");
 
     let decision = wg_logical_tunnel_decision(400, 1);
-    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET as u8, 0);
+    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET as u8, 0, None);
     assert_eq!(
         inner_mtu, 1425,
         "WG PTB inner MTU MUST be wg_inner_mtu(physical 1500) = 1425, NOT \
@@ -1280,7 +1280,7 @@ fn post_transform_wg_inner_mtu_uses_physical_underlay_not_logical_v6() {
     assert_eq!(state.egress.get(&12).map(|e| e.mtu), Some(1500), "reth0.80 physical");
 
     let decision = wg_logical_tunnel_decision(400, 1);
-    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET6 as u8, 0);
+    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET6 as u8, 0, None);
     assert_eq!(
         inner_mtu, 1405,
         "WG PTB inner MTU (v6 outer) MUST be wg_inner_mtu(physical 1500) = 1405, \
@@ -1325,11 +1325,128 @@ fn post_transform_wg_inner_mtu_falls_back_to_logical_when_no_peer_endpoint() {
     snap.tunnel_endpoints[0].wg_peers[0].wg_endpoint = String::new(); // responder-only
     let state = build_forwarding_state(&snap);
     let decision = wg_logical_tunnel_decision(400, 1);
-    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET as u8, 0);
+    let inner_mtu = post_transform_inner_mtu(&decision, &state, false, libc::AF_INET as u8, 0, None);
     // Logical egress (400) MTU 1420 → wg_inner_mtu(1420) = 1345.
     assert_eq!(
         inner_mtu, 1345,
         "no peer endpoint → fall back to logical egress MTU (1420) → 1345, \
          no worse than the pre-#2684 tunnel_outer_mtu behaviour"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #2845: per-peer underlay MTU. One wg interface, TWO peers whose endpoints
+// route over DIFFERENT physical underlays with DIFFERENT MTUs. The PTB inner
+// MTU advertised for an inner destination must reflect the underlay of the
+// SAME peer the encap path selects (by AllowedIPs LPM), NOT an arbitrary first
+// peer's. Before #2845 the helper resolved via the FIRST peer with an endpoint
+// regardless of inner destination, so traffic to peer B got peer A's underlay
+// MTU (over- or under-advertised PMTU).
+// ---------------------------------------------------------------------------
+
+/// Extend the shared single-peer WG fixture with a SECOND physical underlay
+/// (reth0.50, ifindex 13, MTU 1400) and a SECOND peer (peer B) whose endpoint
+/// routes out reth0.50. Peer A keeps the original reth0.80 (ifindex 12, MTU
+/// 1500) underlay. The two peers cover disjoint inner prefixes:
+///   - peer A: 10.123.0.0/24 → endpoint 203.0.113.7 → reth0.80 (MTU 1500)
+///   - peer B: 10.124.0.0/24 → endpoint 198.51.100.7 → reth0.50 (MTU 1400)
+/// Peer A is listed first AND given the lexicographically-smaller pubkey, so
+/// the pre-#2845 first-peer fallback always resolves to peer A's underlay
+/// (1500) — the source of the fail-on-revert RED for peer B.
+fn wg_two_peer_asymmetric_snapshot() -> crate::ConfigSnapshot {
+    let mut snap = crate::afxdp::test_fixtures::wg_outer_mtu_snapshot();
+    // Second physical underlay: reth0.50, ifindex 13, MTU 1400.
+    snap.interfaces.push(crate::InterfaceSnapshot {
+        name: "reth0.50".to_string(),
+        zone: "wan".to_string(),
+        linux_name: "ge-0-0-2.50".to_string(),
+        ifindex: 13,
+        parent_ifindex: 6,
+        vlan_id: 50,
+        mtu: 1400,
+        redundancy_group: 1,
+        hardware_addr: "02:bf:72:00:50:08".to_string(),
+        addresses: vec![crate::InterfaceAddressSnapshot {
+            family: "inet".to_string(),
+            address: "172.16.50.8/24".to_string(),
+            scope: 0,
+        }],
+        ..Default::default()
+    });
+    // Route to peer B's endpoint egresses reth0.50.
+    snap.routes.push(crate::RouteSnapshot {
+        table: "inet.0".to_string(),
+        family: "inet".to_string(),
+        destination: "198.51.100.0/24".to_string(),
+        next_hops: vec!["172.16.50.1@reth0.50".to_string()],
+        discard: false,
+        next_table: String::new(),
+        preference: 0,
+    });
+    {
+        let ep = &mut snap.tunnel_endpoints[0];
+        // Peer A: give it the smaller pubkey so it is first in any sorted order
+        // (the first-peer revert path resolves here).
+        ep.wg_peers[0].wg_peer_pubkey_hex = "0a0a0a0a".repeat(8);
+        ep.wg_peers[0].wg_allowed_ips = vec!["10.123.0.0/24".to_string()];
+        ep.wg_peers[0].wg_endpoint = "203.0.113.7:51820".to_string();
+        // Peer B: distinct prefix + endpoint routing over the smaller underlay.
+        ep.wg_peers.push(crate::TunnelWgPeerSnapshot {
+            wg_peer_pubkey_hex: "0b0b0b0b".repeat(8),
+            wg_allowed_ips: vec!["10.124.0.0/24".to_string()],
+            wg_endpoint: "198.51.100.7:51820".to_string(),
+            ..Default::default()
+        });
+    }
+    snap
+}
+
+#[test]
+fn post_transform_wg_inner_mtu_is_per_peer_underlay() {
+    let state = build_forwarding_state(&wg_two_peer_asymmetric_snapshot());
+    // Sanity: the two underlays really carry distinct MTUs, so the per-peer
+    // assertion below is meaningful.
+    assert_eq!(state.egress.get(&12).map(|e| e.mtu), Some(1500), "reth0.80 underlay");
+    assert_eq!(state.egress.get(&13).map(|e| e.mtu), Some(1400), "reth0.50 underlay");
+
+    let decision = wg_logical_tunnel_decision(400, 1);
+
+    // Inner destination covered by peer A → its underlay is reth0.80 (1500).
+    let peer_a_dst = std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 123, 0, 9));
+    let mtu_a = post_transform_inner_mtu(
+        &decision,
+        &state,
+        false,
+        libc::AF_INET as u8,
+        0,
+        Some(peer_a_dst),
+    );
+    // Inner destination covered by peer B → its underlay is reth0.50 (1400).
+    let peer_b_dst = std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 124, 0, 9));
+    let mtu_b = post_transform_inner_mtu(
+        &decision,
+        &state,
+        false,
+        libc::AF_INET as u8,
+        0,
+        Some(peer_b_dst),
+    );
+
+    assert_eq!(
+        mtu_a,
+        crate::afxdp::wg::mss::wg_inner_mtu(libc::AF_INET, 1500),
+        "peer A PTB inner MTU MUST derive from ITS underlay (reth0.80=1500)"
+    );
+    assert_eq!(
+        mtu_b,
+        crate::afxdp::wg::mss::wg_inner_mtu(libc::AF_INET, 1400),
+        "peer B PTB inner MTU MUST derive from ITS underlay (reth0.50=1400), \
+         NOT peer A's 1500 — reverting to the per-interface first-peer \
+         assumption returns 1500 here and fails red"
+    );
+    // The whole point: asymmetric underlays yield DIFFERENT inner MTUs.
+    assert_ne!(
+        mtu_a, mtu_b,
+        "per-peer underlay MTUs must differ for asymmetric peers"
     );
 }

--- a/userspace-dp/src/afxdp/tx/dispatch/mod.rs
+++ b/userspace-dp/src/afxdp/tx/dispatch/mod.rs
@@ -519,6 +519,21 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                 // `GRE_ENCAP_DF_OVERSIZE_DROPS` / `encap_mtu_drops`.
                 {
                     let egress_mtu = forwarded_egress_mtu(&request.decision, forwarding);
+                    // #2845: derive the inner destination so the WG PTB picks
+                    // the SAME peer (and thus the SAME underlay MTU) the encap
+                    // path will. `source_frame` IS the pre-encap inner packet
+                    // and `request.meta.addr_family` its family. Only the WG arm
+                    // of `post_transform_inner_mtu` consumes this; cheap enough
+                    // to always derive.
+                    let inner_dst = frame_l3_offset(source_frame)
+                        .or_else(|| match request.meta.l3_offset {
+                            14 | 18 => Some(request.meta.l3_offset as usize),
+                            _ => None,
+                        })
+                        .and_then(|l3| source_frame.get(l3..))
+                        .and_then(|pkt| {
+                            crate::afxdp::gre::inner_dst_ip(pkt, request.meta.addr_family)
+                        });
                     let mtu = if is_nat64 || uses_native_tunnel {
                         post_transform_inner_mtu(
                             &request.decision,
@@ -526,6 +541,7 @@ pub(in crate::afxdp) fn enqueue_pending_forwards(
                             is_nat64,
                             request.meta.addr_family,
                             egress_mtu,
+                            inner_dst,
                         )
                     } else {
                         egress_mtu


### PR DESCRIPTION
## Problem

The WireGuard Packet-Too-Big inner-MTU computation assumed one underlay MTU per wg interface. `frame::wg_endpoint_physical_outer_mtu` resolved the physical egress via the FIRST peer carrying an endpoint, on the #2734 assumption that every peer of a wg endpoint egresses the same physical underlay.

The encap path does not share that assumption: `wg_encap_frame` LPM-selects the egress peer by inner destination (`engine.peer_for_dest`) and computes the outer hop + the #2680 MTU guard from THAT peer's endpoint. The PTB path runs `post_transform_inner_mtu` BEFORE peer selection, so for a wg interface with two peers on different underlay paths/MTUs the PTB for traffic to peer B could quote peer A's underlay MTU:

- A's underlay larger -> over-advertise -> peer B's encap guard drops the next packet.
- A's underlay smaller -> under-advertise -> needless throughput loss.

Distinct from #2684 (logical-vs-physical SSOT under-advertisement); this is per-peer asymmetric underlay within one endpoint.

## Fix

Make the PTB peer-aware. The TX dispatcher already holds the pre-encap inner frame, so it derives the inner destination and threads it through `post_transform_inner_mtu` into `wg_endpoint_physical_outer_mtu`. A new `wg_peer_outer_dst` helper selects the SAME peer the encap path will (`engine.peer_for_dest` on the inner destination — the live engine owns the AllowedIPs LPM and the per-snapshot endpoint binding, #2836) and resolves the physical underlay MTU via THAT peer's endpoint route.

The per-peer underlay MTU comes from: inner dst -> `engine.peer_for_dest` (same selection as encap) -> that peer's endpoint -> route lookup in the endpoint transport table -> the resolved physical egress interface MTU (the #2680 `outer_physical_egress_mtu` SSOT) -> `wg_inner_mtu(outer_family, physical_mtu)`.

Single-underlay common case is byte-identical: no inner dst / no live engine / no covering peer falls back to the pre-#2845 first-peer behaviour; with all peers on one underlay the numeric result is unchanged. A covering peer with no endpoint uses the conservative logical fallback rather than borrowing a different peer's underlay.

## Tests

`post_transform_wg_inner_mtu_is_per_peer_underlay` builds one wg endpoint with two peers on asymmetric underlays (peer A -> reth0.80 MTU 1500, peer B -> reth0.50 MTU 1400) and asserts each peer's PTB inner MTU derives from ITS own underlay.

**Fail-on-revert proven:** restoring the first-peer assumption (ignore `inner_dst`) turns the peer-B assertion RED (it gets peer A's 1500) while the three single-underlay #2684 tests stay GREEN — proving the single-underlay case is byte-identical.

Full `cargo build --release` clean; `cargo test --release --bin xpf-userspace-dp` = 3089 passed / 0 failed.

## Docs

`userspace-dp/src/afxdp/README.md` post-transform PMTUD section and `docs/wireguard-interop.md` #2684 section gain a per-peer (#2845) subsection.

Closes #2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi