### PR TITLE
userspace-dp neighbor: anti-poison NAT-excluded interface IPs + RX learn path (#3182)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-06-26 — #3182 neighbor own-IP anti-poison: NAT-excluded interface IPs + RX learn path
+
+- **Timestamp**: 2026-06-26
+- **Action**: Follow-up to the merged #2851/#3180 own-IP anti-poison guard.
+  Two residuals. (1) `owns_configured_ip` reused the NAT-aware `local_v*` set,
+  which `nat_translated_local_exclusions` strips of any interface-mode-SNAT
+  `to_zone` interface IP (e.g. WAN `reth0.80` 172.16.80.8) — so an unsolicited
+  ARP/NDP claiming the router's own WAN IP was NOT rejected. Added a decoupled
+  `configured_iface_v4`/`configured_iface_v6` set on `ForwardingState`,
+  populated in `populate_interfaces` BEFORE the NAT-exclusion branch (every
+  configured interface address, regardless of NAT role). Switched
+  `owns_configured_ip` to read `configured_iface_v*` OR `local_v*` (the OR
+  keeps the late-stage static-NAT-external / DNAT-destination protections;
+  `local_v*` still drives `LocalDelivery` unchanged). (2) The #1787 RX
+  source-MAC learn path `learn_dynamic_neighbor` had NO own-IP guard; added
+  `if forwarding.owns_configured_ip(src_ip) { return; }` at the top, before the
+  dedup pre-check / `learn_pair_if_changed` insert, mirroring the ARP/NDP gate.
+  Legitimate non-own learning (ARP/NDP + RX) byte-identical, incl. the
+  #3048/#3169 `mac_change_epoch` bump on a real MAC change. Three new
+  fail-on-revert tests in poll_stages.rs
+  (`arp_nat_excluded_wan_ip_not_learned_3182`,
+  `ndp_nat_excluded_wan_ip_not_learned_3182`,
+  `rx_learn_own_wan_ip_rejected_3182`): reverting the guard to the NAT-excluded
+  `local_v*` set + removing the RX-learn guard turns all three RED while the
+  two #2851 tests stay GREEN. `cargo build --release` + `cargo test --release`
+  green (poll_stages 19/19 incl. 3 new + 2 #2851, neighbor 144/144,
+  forwarding 195/195).
+- **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs,
+  userspace-dp/src/afxdp/forwarding_build/interfaces.rs,
+  userspace-dp/src/afxdp/neighbor_dispatch.rs,
+  userspace-dp/src/afxdp/poll_stages.rs,
+  userspace-dp/src/afxdp/README.md
+
 ## 2026-06-26 — #3175 queue-planner: orphan VLAN child plan-key follows parent's rx_queues
 
 - **Timestamp**: 2026-06-26

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -137,6 +137,36 @@ sync.
     the #2368 NA fail-closed discipline. Only opcode-2 replies are ever
     learned; ARP requests (opcode 1) classify `OtherArp` and never write
     the cache.
+  - **Own-IP anti-poison (`#2851` / `#3182`, RFC 826 / RFC 4861):** the
+    learn paths refuse to install a neighbor entry for an address the
+    router OWNS, so a host on the local link cannot teach us
+    `(ifindex, our_own_ip) -> attacker_mac`. The gate is the
+    `ForwardingState::owns_configured_ip(ip)` predicate, applied at three
+    sites BEFORE the cache write (so a rejected own-IP neither inserts nor
+    bumps `mac_change_epoch`):
+      - the ARP-reply arm and the NDP-NA arm of `stage_link_layer_classify`
+        (`poll_stages.rs`), and
+      - the **RX source-MAC learn path** `learn_dynamic_neighbor`
+        (`neighbor_dispatch.rs`, the #1787 learn reached via
+        `stage_parse_flow_and_learn`), which would otherwise cache
+        `(ingress_ifindex, flow.src_ip) -> src_mac` from a transit packet
+        whose source IP is spoofed to one of our own IPs.
+    **`owns_configured_ip` reads the NAT-DECOUPLED `configured_iface_v*`
+    set, NOT `local_v*` (`#3182`).** `local_v4`/`local_v6` exclude the IP of
+    any interface whose zone is an interface-mode-SNAT `to_zone`
+    (`nat_translated_local_exclusions` routes it into `interface_nat_v*`),
+    so under #2851 the router's own WAN/SNAT interface IP (e.g.
+    `reth0.80`'s `172.16.80.8`) was NOT protected and an unsolicited
+    ARP/NDP/RX-learn claiming it WAS cached. `configured_iface_v4`/
+    `configured_iface_v6` capture EVERY configured interface address
+    regardless of NAT role (populated in `populate_interfaces` BEFORE the
+    NAT-exclusion branch); the predicate OR-s in `local_v*` so the
+    late-stage static-NAT-external and DNAT-destination local-delivery
+    targets appended to `local_v*` keep their protection too. NAT-translated
+    POOL addresses are in neither set, so the gate stays scoped to addresses
+    the router actually owns. `local_v*` continues to drive the
+    `LocalDelivery` to-self disposition unchanged — only the anti-poison
+    predicate switched sets.
 - `neighbor.rs` — netlink neighbor monitor (`neigh_monitor_thread`),
   startup dump (`initial_neighbor_dump` / `process_dump_batch`), the
   on-demand resolver glue, and `worker::pin_current_thread`. The monitor

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -120,6 +120,12 @@ pub(super) fn populate_interfaces(
             })?;
             match net {
                 IpNet::V4(v4) => {
+                    // #3182: record EVERY configured interface IP in the
+                    // NAT-decoupled set BEFORE the NAT-exclusion branch, so the
+                    // anti-poison `owns_configured_ip` gate protects the
+                    // SNAT/WAN interface IP that the exclusion routes into
+                    // `interface_nat_v4` (out of `local_v4`).
+                    state.configured_iface_v4.insert(v4.addr());
                     if excluded_local_v4.contains(&v4.addr()) {
                         state.interface_nat_v4.insert(v4.addr(), iface.ifindex);
                     } else {
@@ -133,6 +139,9 @@ pub(super) fn populate_interfaces(
                     });
                 }
                 IpNet::V6(v6) => {
+                    // #3182: NAT-decoupled full interface-IP set (see the V4
+                    // arm above) — protects the SNAT/WAN IPv6 interface IP too.
+                    state.configured_iface_v6.insert(v6.addr());
                     if excluded_local_v6.contains(&v6.addr()) {
                         state.interface_nat_v6.insert(v6.addr(), iface.ifindex);
                     } else {

--- a/userspace-dp/src/afxdp/neighbor_dispatch.rs
+++ b/userspace-dp/src/afxdp/neighbor_dispatch.rs
@@ -429,6 +429,20 @@ pub(super) fn learn_dynamic_neighbor(
     src_ip: IpAddr,
     src_mac: [u8; 6],
 ) {
+    // #3182: anti-poisoning own-IP gate on the #1787 RX source-MAC learn
+    // path, mirroring the #2851 ARP/NDP gate in poll_stages.rs. An attacker
+    // can spoof a transit packet whose SOURCE IP is one of the router's own
+    // configured interface IPs; never cache `(ingress_ifindex, our_own_ip)
+    // -> attacker_mac`. Driven from the NAT-decoupled
+    // `configured_iface_v*` set (via `owns_configured_ip`) so the
+    // NAT-excluded WAN/SNAT interface IP — the only forwarding-relevant
+    // own-IP overlap on this path — is rejected too. Runs BEFORE the
+    // dedup pre-check / `learn_pair_if_changed` insert so a rejected own-IP
+    // neither caches nor bumps `mac_change_epoch` (#3048/#3169). Genuine
+    // non-own neighbors are unaffected.
+    if forwarding.owns_configured_ip(src_ip) {
+        return;
+    }
     // #1787: stack array, no per-packet heap alloc. At most 2 keys:
     // the physical ingress ifindex plus the resolved logical (VLAN
     // sub-) ifindex when it differs. keys[1] stays an unused

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -1816,6 +1816,169 @@ mod tests {
         );
     }
 
+    /// #3182 fail-on-revert (ARP own-IP anti-poison, NAT-EXCLUDED interface
+    /// IP). The `nat_snapshot` fixture has `reth0.80` (wan zone, logical
+    /// ifindex 12) with IP `172.16.80.8`. The wan zone is an interface-mode
+    /// SNAT `to_zone`, so `nat_translated_local_exclusions` strips
+    /// `172.16.80.8` from `local_v4` (it lands in `interface_nat_v4`). Under
+    /// #2851 the anti-poison gate read `local_v4`, so an ARP reply claiming
+    /// the router's OWN WAN IP was NOT rejected — it was learned + written to
+    /// the kernel ARP table. The #3182 gate is driven from the NAT-decoupled
+    /// `configured_iface_v4` set, so it is now REJECTED.
+    ///
+    /// Reverting `owns_configured_ip` to the NAT-excluded `local_v4` set
+    /// (`self.local_v4.contains(&v4)`) makes the "must NOT be present" assert
+    /// fail RED (172.16.80.8 is not in `local_v4`); the non-own learn assert
+    /// keeps the gate honest.
+    #[test]
+    fn arp_nat_excluded_wan_ip_not_learned_3182() {
+        let forwarding: &'static ForwardingState = Box::leak(Box::new(build_forwarding_state(
+            &super::super::test_fixtures::nat_snapshot(),
+        )));
+        let wan_ip = Ipv4Addr::new(172, 16, 80, 8);
+        // Precondition that distinguishes #3182 from #2851: the WAN/SNAT IP
+        // is NAT-excluded from local_v4 yet IS an owned interface IP via the
+        // decoupled set. (If this IP were in local_v4 the test would not
+        // prove the decoupling.)
+        assert!(
+            !forwarding.local_v4.contains(&wan_ip),
+            "test precondition: the interface-mode-SNAT WAN IP must be \
+             NAT-excluded from local_v4"
+        );
+        assert!(
+            forwarding.owns_configured_ip(IpAddr::V4(wan_ip)),
+            "the WAN IP must be owned via the decoupled configured_iface_v4 set"
+        );
+        let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+        // Arrive on (parent=11, vlan=80) → logical reth0.80 (ifindex 12).
+        let meta = link_layer_meta(11, 80);
+
+        // 1) Spoofed reply claiming the router's OWN WAN IP — must NOT learn.
+        let attacker_mac = [0x02, 0x00, 0x00, 0x00, 0xba, 0xad];
+        let outcome =
+            stage_link_layer_classify(&arp_reply_frame(wan_ip, attacker_mac), meta, ctx);
+        assert!(matches!(outcome, StageOutcome::RecycleAndContinue));
+        assert!(
+            neighbors.get(&(12, IpAddr::V4(wan_ip))).is_none(),
+            "an ARP reply claiming the router's OWN NAT-excluded WAN IP must \
+             NOT be learned (#3182)"
+        );
+        assert!(
+            neighbors.get(&(11, IpAddr::V4(wan_ip))).is_none(),
+            "and not under the physical/parent ifindex either"
+        );
+
+        // 2) A legitimate NON-own neighbor on the same VLAN still learns.
+        let good_ip = Ipv4Addr::new(172, 16, 80, 9);
+        let good_mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x09];
+        let _ = stage_link_layer_classify(&arp_reply_frame(good_ip, good_mac), meta, ctx);
+        assert_eq!(
+            neighbors.get(&(12, IpAddr::V4(good_ip))).map(|e| e.mac),
+            Some(good_mac),
+            "a legitimate non-own ARP neighbor on the WAN VLAN must still learn"
+        );
+    }
+
+    /// #3182 — same NAT-excluded own-IP anti-poison, NDP NA / IPv6 side.
+    /// `reth0.80`'s IPv6 `2001:559:8585:80::8` is NAT-excluded from
+    /// `local_v6` (interface-mode SNAT to_zone), so the #2851 gate did not
+    /// reject an NA advertising it. The #3182 decoupled set does.
+    #[test]
+    fn ndp_nat_excluded_wan_ip_not_learned_3182() {
+        let forwarding: &'static ForwardingState = Box::leak(Box::new(build_forwarding_state(
+            &super::super::test_fixtures::nat_snapshot(),
+        )));
+        let wan_v6_bytes = [
+            0x20, 0x01, 0x05, 0x59, 0x85, 0x85, 0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x08,
+        ];
+        let wan_v6 = IpAddr::V6(Ipv6Addr::from(wan_v6_bytes));
+        assert!(
+            !forwarding.local_v6.contains(&Ipv6Addr::from(wan_v6_bytes)),
+            "test precondition: the SNAT WAN IPv6 must be NAT-excluded from \
+             local_v6"
+        );
+        assert!(
+            forwarding.owns_configured_ip(wan_v6),
+            "the WAN IPv6 must be owned via the decoupled configured_iface_v6 set"
+        );
+        let (ctx, neighbors) = neighbor_learn_ctx(forwarding);
+        let meta = link_layer_meta(11, 80);
+
+        let (frame, target_ip, _mac) = ndp_na_frame_with_target(wan_v6_bytes);
+        assert_eq!(target_ip, wan_v6, "frame target must be the own WAN IPv6");
+        let outcome = stage_link_layer_classify(&frame, meta, ctx);
+        assert!(matches!(outcome, StageOutcome::Continue(())));
+        assert!(
+            neighbors.get(&(12, wan_v6)).is_none() && neighbors.get(&(11, wan_v6)).is_none(),
+            "an NDP NA advertising the router's OWN NAT-excluded WAN IPv6 must \
+             NOT be learned (#3182)"
+        );
+    }
+
+    /// #3182 fail-on-revert (RX source-MAC learn path own-IP anti-poison).
+    /// `learn_dynamic_neighbor` (the #1787 RX learn, reached via
+    /// `stage_parse_flow_and_learn`) caches `(ingress_ifindex, flow.src_ip)
+    /// -> src_mac` from every transit packet's source. An attacker can spoof
+    /// a packet whose SOURCE is one of the router's own interface IPs. The
+    /// #3182 guard rejects such a learn before the `learn_pair_if_changed`
+    /// insert; a non-own source still caches.
+    ///
+    /// Removing the `if forwarding.owns_configured_ip(src_ip) { return; }`
+    /// guard at the top of `learn_dynamic_neighbor` makes the "own-IP must
+    /// NOT be present" asserts fail RED; the non-own assert keeps it honest.
+    #[test]
+    fn rx_learn_own_wan_ip_rejected_3182() {
+        let forwarding = build_forwarding_state(&super::super::test_fixtures::nat_snapshot());
+        let neighbors = Arc::new(ShardedNeighborMap::default());
+
+        let wan_ip = Ipv4Addr::new(172, 16, 80, 8);
+        let own_wan = IpAddr::V4(wan_ip);
+        assert!(
+            !forwarding.local_v4.contains(&wan_ip),
+            "test precondition: the WAN IP is NAT-excluded from local_v4"
+        );
+        assert!(
+            forwarding.owns_configured_ip(own_wan),
+            "the WAN IP is owned via the decoupled set"
+        );
+
+        // 1) Spoofed transit packet sourced FROM the router's own WAN IP —
+        //    must NOT be cached under either the physical (11) or logical
+        //    (12) ifindex.
+        let attacker_mac = [0x02, 0x00, 0x00, 0x00, 0xba, 0xad];
+        crate::afxdp::neighbor_dispatch::learn_dynamic_neighbor(
+            &forwarding,
+            &neighbors,
+            11,
+            80,
+            own_wan,
+            attacker_mac,
+        );
+        assert!(
+            neighbors.get(&(12, own_wan)).is_none() && neighbors.get(&(11, own_wan)).is_none(),
+            "the RX learn path must reject an own-IP source (#3182)"
+        );
+
+        // 2) A non-own transit source still caches (under the logical
+        //    ifindex 12, the route-egress key).
+        let good = IpAddr::V4(Ipv4Addr::new(172, 16, 80, 9));
+        let good_mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x09];
+        crate::afxdp::neighbor_dispatch::learn_dynamic_neighbor(
+            &forwarding,
+            &neighbors,
+            11,
+            80,
+            good,
+            good_mac,
+        );
+        assert_eq!(
+            neighbors.get(&(12, good)).map(|e| e.mac),
+            Some(good_mac),
+            "a non-own RX-learned source must still cache (#3182 guard must \
+             not over-reject)"
+        );
+    }
+
     // ===================================================================
     // #3021 / #3022 — the ingress ZONE lookup (zone-pair policy for
     // forwarding, and screen/SYN-cookie zone resolution) must key on the

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -14,6 +14,18 @@ use super::*;
 pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) local_v4: FastSet<Ipv4Addr>,
     pub(in crate::afxdp) local_v6: FastSet<Ipv6Addr>,
+    /// #3182: EVERY configured interface address, decoupled from the
+    /// NAT-aware `local_v*` exclusion. `local_v4`/`local_v6` drop the IP of
+    /// any interface whose zone is an interface-mode-SNAT `to_zone`
+    /// (`nat_translated_local_exclusions`), so they are NOT a complete
+    /// "addresses this router owns" set — the SNAT/WAN interface IP is
+    /// missing. The anti-poison `owns_configured_ip` predicate is driven
+    /// from this full set instead so an unsolicited ARP/NDP (or RX-learn)
+    /// claiming the router's own WAN/SNAT interface IP is still rejected.
+    /// Built alongside `local_v*` in `populate_interfaces`, BEFORE the NAT
+    /// exclusion branch, from the same per-interface address list.
+    pub(in crate::afxdp) configured_iface_v4: FastSet<Ipv4Addr>,
+    pub(in crate::afxdp) configured_iface_v6: FastSet<Ipv6Addr>,
     pub(in crate::afxdp) interface_nat_v4: FastMap<Ipv4Addr, i32>,
     pub(in crate::afxdp) interface_nat_v6: FastMap<Ipv6Addr, i32>,
     pub(in crate::afxdp) connected_v4: Vec<ConnectedRouteV4>,
@@ -237,11 +249,11 @@ impl ForwardingState {
         self.zone_tcp_rst.get(&zone_id).copied().unwrap_or(false)
     }
 
-    /// #2851: true iff `ip` is one of the router's OWN configured interface
-    /// IPs — i.e. an address this firewall delivers to itself
-    /// (`local_v4`/`local_v6`, the same authoritative set the to-self
-    /// `LocalDelivery` disposition tests in `forwarding::mod`). The dynamic
-    /// neighbor-learn path (ARP reply / NDP NA) uses this as an
+    /// #2851/#3182: true iff `ip` is one of the router's OWN configured
+    /// interface IPs — i.e. an address this firewall must never learn from a
+    /// link-local advertisement. The dynamic
+    /// neighbor-learn path (ARP reply / NDP NA, and the #1787 RX source-MAC
+    /// learn) uses this as an
     /// anti-poisoning gate: a host on the local link must never be able to
     /// teach us `(ifindex, our_own_ip) -> attacker_mac`. RFC 826 / RFC 4861:
     /// a node does not install a neighbor entry for an address it owns from
@@ -251,14 +263,27 @@ impl ForwardingState {
     /// scoped): if `ip` is one of our addresses in ANY routing-instance,
     /// refusing to learn it is always correct — we resolve our own
     /// addresses via the to-self path, never via a dynamic neighbor entry.
-    /// NAT-translated pool addresses are deliberately NOT in `local_v4`/
-    /// `local_v6` (they are excluded at build time), so this gate scopes to
-    /// genuine configured interface IPs only.
+    ///
+    /// #3182: the gate is driven from the NAT-DECOUPLED `configured_iface_v*`
+    /// set, NOT `local_v*`. `local_v*` excludes the IP of an interface whose
+    /// zone is an interface-mode-SNAT `to_zone`
+    /// (`nat_translated_local_exclusions` — e.g. the WAN `reth0.80` IP), so
+    /// reusing it left the router's own SNAT/WAN interface IP poisonable. The
+    /// `local_v*` membership is still OR-ed in so the static-NAT-external and
+    /// DNAT-destination addresses appended to `local_v*` (late-stage
+    /// local-delivery targets the router also answers for) keep their #2851
+    /// protection; `configured_iface_v*` adds the genuine interface IPs that
+    /// the NAT exclusion stripped. NAT-translated POOL addresses are in
+    /// neither set, so the gate still scopes to addresses the router owns.
     #[inline]
     pub(in crate::afxdp) fn owns_configured_ip(&self, ip: IpAddr) -> bool {
         match ip {
-            IpAddr::V4(v4) => self.local_v4.contains(&v4),
-            IpAddr::V6(v6) => self.local_v6.contains(&v6),
+            IpAddr::V4(v4) => {
+                self.configured_iface_v4.contains(&v4) || self.local_v4.contains(&v4)
+            }
+            IpAddr::V6(v6) => {
+                self.configured_iface_v6.contains(&v6) || self.local_v6.contains(&v6)
+            }
         }
     }
 }


### PR DESCRIPTION
## Closes #3182

Two residuals from the merged #2851/#3180 own-IP anti-poison guard.

### 1. NAT-excluded interface IPs not protected
`owns_configured_ip` reused the NAT-aware `local_v4`/`local_v6` set, but
`nat_translated_local_exclusions` strips the IP of any interface whose zone is
an interface-mode-SNAT `to_zone` (e.g. WAN `reth0.80` `172.16.80.8`). So an
unsolicited ARP/NDP claiming the router's own WAN IP was NOT rejected and was
written to `dynamic_neighbors` + the kernel neighbor table.

### 2. RX source-MAC learn path unguarded
The #1787 RX learn (`learn_dynamic_neighbor`, via `stage_parse_flow_and_learn`)
cached `(ingress_ifindex, flow.src_ip) -> src_mac` with no own-IP guard. Inert
today (userspace-only; genuine `local_v*` own-IPs short-circuit to
LocalDelivery), but the same NAT-excluded WAN IP is the one forwarding-relevant
overlap.

## Fix
- New NAT-DECOUPLED `configured_iface_v4`/`configured_iface_v6` set on
  `ForwardingState`, populated in `populate_interfaces` BEFORE the
  NAT-exclusion branch (every configured interface address regardless of NAT
  role).
- `owns_configured_ip` now reads `configured_iface_v*` OR `local_v*`. The OR
  keeps the late-stage static-NAT-external / DNAT-destination local-delivery
  targets protected; `configured_iface_v*` adds the interface IPs the NAT
  exclusion stripped. `local_v*` still drives `LocalDelivery` unchanged — only
  the anti-poison predicate switched sets.
- RX learn path: `if forwarding.owns_configured_ip(src_ip) { return; }` at the
  top of `learn_dynamic_neighbor`, before the dedup pre-check /
  `learn_pair_if_changed` insert.

Legitimate non-own learning (ARP/NDP + RX) is byte-identical, incl. the
#3048/#3169 `mac_change_epoch` bump on a real MAC change.

## Tests (fail-on-revert)
`poll_stages.rs`: `arp_nat_excluded_wan_ip_not_learned_3182`,
`ndp_nat_excluded_wan_ip_not_learned_3182`, `rx_learn_own_wan_ip_rejected_3182`.
Reverting `owns_configured_ip` to the NAT-excluded `local_v*` set AND removing
the RX-learn guard turns all three RED; the two #2851 tests stay GREEN.

`cargo build --release` + `cargo test --release` green (poll_stages 19/19,
neighbor 144/144, forwarding 195/195). One unrelated pre-existing flake
(`worker_queue::concurrent_recovery_processes_each_command_exactly_once`, a
concurrency timing test) passes consistently in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi