### PR TITLE
host-inbound: scope kernel deny to RETH VRRP VIPs (#3172)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-26 — #3172 host-inbound: scope kernel deny to RETH VRRP VIPs
+
+- **Timestamp**: 2026-06-26
+- **Action**: Follow-up to #3070. `BuildZoneHostInboundViews` scoped the
+  kernel `xpf_hostinbound` deny rules only to STATIC interface addresses
+  resolved from the live snapshot. RETH VRRP VIPs are live on the kernel
+  interface only on the RG master; on the backup the VIP was absent from the
+  snapshot, so the deny was not scoped to it and `chain input` fell through to
+  `policy accept` (FAIL-OPEN) for VIP-destined host-bound traffic. Added a
+  config-resolved pass that folds each zone's `unit.VRRPGroups[*].VirtualAddresses`
+  into the per-zone host-inbound address set (deterministic sorted iteration,
+  deduped against the live snapshot so the master node stays byte-identical),
+  preserving the fxp0/em0/fab* lifeline exclusion (a VIP on em0 is never
+  scoped) and leaving standalone (no-VRRP) zones unchanged. Go test
+  `TestBuildZoneHostInboundViewsIncludesVRRPVIP` (wan gets static+VIP, lan
+  standalone unchanged, control/em0 lifeline contributes nothing);
+  fail-on-revert proven (neutering addZoneVIP turns the wan VIP assertion RED,
+  the pre-existing `TestBuildZoneHostInboundViews` stays GREEN). cargo
+  build/test (host_inbound 2/2, forwarding 196/0) + go test
+  ./pkg/dataplane/... ./pkg/daemon/... green.
+- **File(s)**: pkg/dataplane/userspace/zones.go,
+  pkg/dataplane/userspace/zones_host_inbound_test.go,
+  docs/junos-cli-reference.md
+
 ## 2026-06-26 — #3175 queue-planner: orphan VLAN child plan-key follows parent's rx_queues
 
 - **Timestamp**: 2026-06-26

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -278,6 +278,20 @@ From zone: guest, To zone: lan
     accepting `SSH` would itself reintroduce a split-brain). Recognized tokens
     (`ssh`, `ping`, `all`, `any-service`, `ipsec`/`ike`, `protocols all`
     routing-scoped per #3199, …) are unaffected.
+  - **RETH VRRP VIP scoping (#3172):** the kernel host-inbound chain scopes
+    its accept/deny rules to each zone's firewall-local addresses. Those
+    addresses now include the zone's RETH **VRRP virtual IPs** (the
+    `vrrp-group ... virtual-address` entries on the reth unit), resolved from
+    config rather than only from the live kernel address list. A VIP is present
+    on the kernel interface only of the node that currently owns the redundancy
+    group (master); on the BACKUP node the VIP is not yet live, so before #3172
+    a host-inbound deny was not scoped to the VIP there and `chain input` fell
+    through to `policy accept` (FAIL-OPEN) for VIP-destined host-bound traffic.
+    Resolving the VIPs from config scopes the deny identically on both nodes
+    regardless of mastership; on the master the live address dedups so the rule
+    set is byte-identical. Management/cluster-control lifeline interfaces
+    (fxp0/em0/fab*) are still excluded — a VIP on em0 is never scoped — and
+    standalone (no-VRRP) zones are unchanged.
   - **Lifeline fail-safe:** enforcement is strictly MATCH-DRIVEN. If NO
     `junos-host` policy is configured, or a host-bound flow matches no
     `junos-host` rule, behavior is UNCHANGED from before #3019 — there is no

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -51,8 +51,11 @@ func hostInboundLifelineInterface(name string) bool {
 // BuildZoneHostInboundViews returns one ZoneHostInboundView per
 // host-inbound-CONFIGURED zone (#3070), resolving each zone's firewall-local
 // host addresses via the canonical interface-snapshot builder (the same
-// resolution that populates the dataplane), with management/cluster-control
-// lifeline interfaces (fxp0 / em0 / fab*) excluded from the address set. A zone
+// resolution that populates the dataplane) PLUS each zone's RETH VRRP virtual
+// addresses (#3172, resolved from config so they scope the deny on the backup
+// node too, where the VIP is not yet live on the kernel interface), with
+// management/cluster-control lifeline interfaces (fxp0 / em0 / fab*) excluded
+// from the address set. A zone
 // that declared NO host-inbound-traffic stanza is omitted entirely (admit-all
 // preserved — zero regression). A configured zone with no resolvable static
 // address (e.g. a DHCP-only interface) yields an empty address set; the daemon
@@ -94,6 +97,83 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 			} else if !set.seen4[host] {
 				set.seen4[host] = true
 				set.v4 = append(set.v4, host)
+			}
+		}
+	}
+
+	// VRRP RETH VIPs (#3172): the host-inbound destination address set must
+	// also include each zone's RETH virtual IPs, not only the static interface
+	// addresses resolved above. A VIP is present on the kernel interface ONLY of
+	// the node that currently owns the redundancy group (master); on the backup
+	// node the VIP is absent from buildLinkSnapshot's live address list, so
+	// without this the kernel host-inbound deny would not be scoped to the VIP
+	// and `chain input` would fall through to `policy accept` (FAIL-OPEN) for
+	// VIP-destined host-bound traffic. The VIPs are identical on both nodes, so
+	// resolving them from config (unit.VRRPGroups[*].VirtualAddresses) scopes the
+	// deny consistently regardless of mastership. The seen maps dedup against the
+	// live snapshot, so on the master node (where the VIP is already live) the
+	// result is byte-identical. Lifeline interfaces (fxp0/em0/fab*) are excluded,
+	// mirroring the static-address path; standalone (no-VRRP) zones are untouched.
+	addZoneVIP := func(zone, host string) {
+		set := byZone[zone]
+		if set == nil {
+			set = &addrSet{seen4: map[string]bool{}, seen6: map[string]bool{}}
+			byZone[zone] = set
+		}
+		if strings.Contains(host, ":") {
+			if !set.seen6[host] {
+				set.seen6[host] = true
+				set.v6 = append(set.v6, host)
+			}
+		} else if !set.seen4[host] {
+			set.seen4[host] = true
+			set.v4 = append(set.v4, host)
+		}
+	}
+	zoneByIface := buildInterfaceZoneMap(cfg)
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for n := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, n)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		iface := cfg.Interfaces.Interfaces[ifName]
+		if iface == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(iface.Units))
+		for u := range iface.Units {
+			unitNums = append(unitNums, u)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := iface.Units[un]
+			if unit == nil || len(unit.VRRPGroups) == 0 {
+				continue
+			}
+			unitName := fmt.Sprintf("%s.%d", ifName, un)
+			if hostInboundLifelineInterface(unitName) {
+				continue
+			}
+			zone := zoneByIface[unitName]
+			if zone == "" {
+				continue
+			}
+			vgKeys := make([]string, 0, len(unit.VRRPGroups))
+			for k := range unit.VRRPGroups {
+				vgKeys = append(vgKeys, k)
+			}
+			sort.Strings(vgKeys)
+			for _, k := range vgKeys {
+				vg := unit.VRRPGroups[k]
+				if vg == nil {
+					continue
+				}
+				for _, vip := range vg.VirtualAddresses {
+					if host := hostIPFromCIDR(vip); host != "" {
+						addZoneVIP(zone, host)
+					}
+				}
 			}
 		}
 	}

--- a/pkg/dataplane/userspace/zones_host_inbound_test.go
+++ b/pkg/dataplane/userspace/zones_host_inbound_test.go
@@ -136,6 +136,105 @@ func TestBuildZoneHostInboundViews(t *testing.T) {
 	}
 }
 
+// TestBuildZoneHostInboundViewsIncludesVRRPVIP verifies #3172: a zone whose
+// RETH unit carries VRRP virtual addresses (VIPs) gets those VIPs into its
+// host-inbound destination address set, so the kernel deny is scoped to the VIP
+// on BOTH cluster nodes — including the backup, where the VIP is not yet live on
+// the kernel interface (and thus absent from the live address snapshot). A
+// standalone zone with no VIP is unchanged, and a VIP configured on a lifeline
+// interface (em0) is still excluded.
+func TestBuildZoneHostInboundViewsIncludesVRRPVIP(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			50: {
+				Number:    50,
+				VlanID:    50,
+				Addresses: []string{"172.16.50.8/24", "2001:db8:50::8/64"},
+				VRRPGroups: map[string]*config.VRRPGroup{
+					"172.16.50.8/24":    {ID: 50, VirtualAddresses: []string{"172.16.50.1"}},
+					"2001:db8:50::8/64": {ID: 51, VirtualAddresses: []string{"2001:db8:50::1"}},
+				},
+			},
+		}},
+		// standalone zone interface — no VRRP, must be unchanged.
+		"reth1": {Name: "reth1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.61.1/24"}},
+		}},
+		// lifeline (cluster control plane) with a VRRP group — its VIP must NOT
+		// be scoped (denying on em0 could break HA).
+		"em0": {Name: "em0", Units: map[int]*config.InterfaceUnit{
+			0: {
+				Number:    0,
+				Addresses: []string{"10.99.0.1/24"},
+				VRRPGroups: map[string]*config.VRRPGroup{
+					"10.99.0.1/24": {ID: 99, VirtualAddresses: []string{"10.99.0.254"}},
+				},
+			},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"wan": {
+			Name:               "wan",
+			Interfaces:         []string{"reth0.50"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
+		},
+		"lan": {
+			Name:               "lan",
+			Interfaces:         []string{"reth1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
+		},
+		"control": {
+			Name:               "control",
+			Interfaces:         []string{"em0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"all"}},
+		},
+	}
+
+	views := BuildZoneHostInboundViews(cfg)
+	byZone := make(map[string]ZoneHostInboundView, len(views))
+	for _, v := range views {
+		byZone[v.Zone] = v
+	}
+
+	wan, ok := byZone["wan"]
+	if !ok {
+		t.Fatal("wan view missing")
+	}
+	// Static interface address first, then the VRRP VIP (#3172). Without the
+	// VIP-inclusion the VIP entries are absent and the deny is unscoped for the
+	// VIP (fail-open) — this assertion is the fail-on-revert guard.
+	if !eqStr(wan.V4Addrs, []string{"172.16.50.8", "172.16.50.1"}) {
+		t.Errorf("wan v4 addrs = %v, want [172.16.50.8 172.16.50.1] (static + VIP)", wan.V4Addrs)
+	}
+	if !eqStr(wan.V6Addrs, []string{"2001:db8:50::8", "2001:db8:50::1"}) {
+		t.Errorf("wan v6 addrs = %v, want [2001:db8:50::8 2001:db8:50::1] (static + VIP)", wan.V6Addrs)
+	}
+
+	// lan has no VRRP group → byte-identical to pre-#3172 (static only).
+	lan, ok := byZone["lan"]
+	if !ok {
+		t.Fatal("lan view missing")
+	}
+	if !eqStr(lan.V4Addrs, []string{"10.0.61.1"}) {
+		t.Errorf("lan v4 addrs = %v, want [10.0.61.1] (standalone, unchanged)", lan.V4Addrs)
+	}
+	if len(lan.V6Addrs) != 0 {
+		t.Errorf("lan v6 addrs = %v, want empty", lan.V6Addrs)
+	}
+
+	// control/em0 is a lifeline → neither its static address nor its VIP is
+	// scoped (no deny, can never break HA).
+	control, ok := byZone["control"]
+	if !ok {
+		t.Fatal("control view missing")
+	}
+	if len(control.V4Addrs) != 0 || len(control.V6Addrs) != 0 {
+		t.Errorf("control/em0 lifeline must contribute no addresses (incl. VIP), got v4=%v v6=%v",
+			control.V4Addrs, control.V6Addrs)
+	}
+}
+
 func TestHostInboundLifelineInterface(t *testing.T) {
 	for _, name := range []string{"fxp0", "fxp0.0", "em0", "em0.0", "fab0", "fab1", "fab1.0"} {
 		if !hostInboundLifelineInterface(name) {


### PR DESCRIPTION
Closes #3172

## Problem
`BuildZoneHostInboundViews` (#3070) scopes the kernel `xpf_hostinbound`
accept/deny rules to each zone's firewall-local host addresses, resolved from
the live interface snapshot (kernel address list + statically-configured unit
addresses). RETH **VRRP VIPs** are live on the kernel interface only of the node
that currently owns the redundancy group (master); on the **backup** node the
VIP is not yet live and was absent from the snapshot. A host-inbound deny was
therefore not scoped to the VIP on the backup, and `chain input` fell through to
`policy accept` — **FAIL-OPEN** for VIP-destined host-bound traffic. Safe
direction (no brick), but a real completeness gap: a host-inbound DENY on a zone
whose traffic arrives on a RETH VIP was not enforced for the VIP address.

## Fix
After gathering static addresses from the snapshot, `BuildZoneHostInboundViews`
now folds each zone's VRRP VIPs into the per-zone host-inbound destination
address set, resolved from config (`unit.VRRPGroups[*].VirtualAddresses`) so the
deny is scoped identically on both nodes regardless of mastership.

- **Source of truth:** the reth unit's `vrrp-group ... virtual-address` entries.
- **Master byte-identical:** the address-set dedup maps absorb the live VIP, so
  the master node's emitted rule set is unchanged.
- **Deterministic:** sorted interface names, unit numbers, and VRRP-group keys.
- **Lifeline preserved:** fxp0/em0/fab* still excluded — a VIP on em0 is never
  scoped (denying on the cluster-control plane could break HA).
- **Standalone unchanged:** zones with no VRRP group are byte-identical to
  pre-#3172.

## Tests
`TestBuildZoneHostInboundViewsIncludesVRRPVIP`: wan gets static+VIP (v4 and v6),
lan (no VRRP) unchanged, control/em0 (lifeline with a VRRP group) contributes
nothing. **Fail-on-revert proven:** neutering the VIP-inclusion turns the wan
VIP assertion RED while the pre-existing `TestBuildZoneHostInboundViews` stays
GREEN.

Validated: `cargo build --release` + `cargo test` (host_inbound 2/2, forwarding
196/0) + `go test ./pkg/dataplane/... ./pkg/daemon/...` (all green).

## HA note
Host-inbound is HA-adjacent. Change is scoped to the address-set construction;
the parent runs `make test-failover` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi