### PR TITLE
config: reject a partial-valid dest-NAT destination list at commit (#3228)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-26 — #3228 dest-NAT: reject a partial-valid destination-address list at commit
+
+- **Timestamp**: 2026-06-26
+- **Action**: `validateDestinationNATAddressesStrict`
+  (`pkg/config/compiler_validate_strict.go`) used an `anyGood` break — it
+  passed commit if AT LEAST ONE `match destination-address` parsed. The
+  snapshot builder (`buildDestinationNATSnapshots`,
+  `pkg/dataplane/userspace/nat.go`) skips malformed entries PER-ENTRY, so a
+  mixed list like `[ 192.0.2.1 web-server ]` committed clean while
+  `web-server` was silently dropped from the DNAT table (traffic to it never
+  translated). Replaced the `anyGood` break with a per-entry check that
+  mirrors the builder's exact skip predicate (`natCIDRIPPart` CIDR strip,
+  then empty / `net.ParseIP` test): the gate now rejects the rule on ANY
+  unparseable entry, naming the offending token. An all-valid list still
+  compiles byte-identical; the tolerant load / peer-sync path still
+  downgrades to a `destination-nat address` warning (#1960). Inverted the
+  stale `TestDNATPartialValidDestinationAccepted` test to
+  `TestDNATPartialValidDestinationRejected` and added
+  `TestDNATAllValidDestinationListAccepted`. Fail-on-revert: restoring the
+  `anyGood` break turns `TestDNATPartialValidDestinationRejected` RED while
+  the all-valid test stays GREEN.
+- **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_dnat_address_test.go, docs/userspace-dnat-plan.md,
+  _Log.md
+
 ## 2026-06-26 — #3193 persistent-nat SHOW: report the three-way permit mode
 
 - **Timestamp**: 2026-06-26

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -441,3 +441,25 @@ is unchanged).
 
 The rewrite target (translated destination/port from the pool) is unchanged —
 only the MATCH set grows from one destination to all configured destinations.
+
+### 11.1 Per-entry commit gate on a partial-valid list (#3228)
+
+The all-malformed fail-closed posture above (no snapshot row when EVERY
+destination is malformed) is caught at commit by
+`validateDestinationNATAddressesStrict` (`compiler_validate_strict.go`). That
+gate originally used an `anyGood` break: it passed commit as long as AT LEAST
+ONE destination parsed. But the builder skips malformed entries PER-ENTRY, so a
+MIXED list such as `match destination-address [ 192.0.2.1 web-server ]`
+committed clean (one good entry satisfied `anyGood`) while `web-server` was
+silently dropped from the installed DNAT table — traffic to it was never
+translated, a partial, silent drop of a forwarding-relevant config (#3228).
+
+The gate now rejects the rule if ANY listed destination-address fails to parse,
+mirroring the builder's exact skip predicate (`natCIDRIPPart` CIDR strip, then
+empty / `net.ParseIP` check). Validator and dataplane view agree: anything the
+builder would drop, the validator rejects, naming the offending entry. An
+all-valid list still compiles byte-identical and installs every entry (the
+multi-destination behavior above is unchanged). On the tolerant load / peer-sync
+path the rejection is downgraded to a `destination-nat address` warning (#1960
+no-brick), consistent with the all-malformed (#2396(c)) and multi-host-prefix
+(#3029) gates that share this validator.

--- a/pkg/config/compiler_dnat_address_test.go
+++ b/pkg/config/compiler_dnat_address_test.go
@@ -60,15 +60,20 @@ func TestDNATAllInvalidDestinationRejected(t *testing.T) {
 	}
 }
 
-func TestDNATPartialValidDestinationAccepted(t *testing.T) {
-	// One malformed + one valid destination in a bracket list: the valid one
-	// still installs (the builder emits an entry for it and skips the typo),
-	// so this is NOT a total silent no-op. The gate must NOT reject it.
-	//
-	// Constructed at the struct level (not via flat-set syntax) because the
-	// flat-set parser collapses a `[ a b ]` destination-address list to its
-	// first token; the builder/gate operate on DestinationAddresses, which the
-	// hierarchical parser and the dataplane snapshot path populate fully.
+// #3228: a bracket list with one valid + one malformed destination (e.g.
+// `[ 203.0.113.10 web-server ]`) used to pass the gate (the old anyGood break
+// required only ONE good entry). The snapshot builder then silently `continue`s
+// past the typo, so traffic to it never translates — a partial, silent drop of
+// a forwarding-relevant config. The gate must now reject the rule, naming the
+// bad entry, so validator and builder agree (anything the builder would skip,
+// the validator rejects). Reverting the per-entry check to the anyGood break
+// makes this RED (the partial-valid rule compiles).
+//
+// Constructed at the struct level (not via flat-set syntax) because the
+// flat-set parser collapses a `[ a b ]` destination-address list to its first
+// token; the builder/gate operate on DestinationAddresses, which the
+// hierarchical parser and the dataplane snapshot path populate fully.
+func TestDNATPartialValidDestinationRejected(t *testing.T) {
 	cfg := &Config{}
 	cfg.Security.NAT.Destination = &DestinationNATConfig{
 		Pools: map[string]*NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
@@ -77,8 +82,42 @@ func TestDNATPartialValidDestinationAccepted(t *testing.T) {
 				{
 					Name: "r1",
 					Match: NATMatch{
-						DestinationAddresses: []string{"not-an-ip", "203.0.113.10"},
-						DestinationAddress:   "not-an-ip",
+						DestinationAddresses: []string{"203.0.113.10", "web-server"},
+						DestinationAddress:   "203.0.113.10",
+					},
+					Then: NATThen{Type: NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+	err := validateDestinationNATAddressesStrict(cfg)
+	if err == nil {
+		t.Fatal("a DNAT rule with a malformed destination in an otherwise-valid " +
+			"list must be rejected at commit (the builder silently drops it)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-nat") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "web-server") {
+		t.Fatalf("error must name the rule-set/rule + the malformed token, got: %v", err)
+	}
+}
+
+// #3228 (positive half): an all-valid bracket list must still pass the gate
+// unchanged — the per-entry rejection must not regress a list where every
+// entry parses. The builder's all-entries-installed behavior is covered by
+// userspace.TestBuildDestinationNATSnapshotsMultiDestination.
+func TestDNATAllValidDestinationListAccepted(t *testing.T) {
+	cfg := &Config{}
+	cfg.Security.NAT.Destination = &DestinationNATConfig{
+		Pools: map[string]*NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*NATRuleSet{
+			{Name: "rs1", FromZone: "untrust", Rules: []*NATRule{
+				{
+					Name: "r1",
+					Match: NATMatch{
+						DestinationAddresses: []string{"203.0.113.10", "203.0.113.11/32", "203.0.113.12"},
+						DestinationAddress:   "203.0.113.10",
 					},
 					Then: NATThen{Type: NATDestination, PoolName: "dp"},
 				},
@@ -86,7 +125,7 @@ func TestDNATPartialValidDestinationAccepted(t *testing.T) {
 		},
 	}
 	if err := validateDestinationNATAddressesStrict(cfg); err != nil {
-		t.Fatalf("a DNAT rule with at least one valid destination must pass the gate, got: %v", err)
+		t.Fatalf("a DNAT rule whose destination list is entirely valid must pass the gate, got: %v", err)
 	}
 }
 

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3502,20 +3502,28 @@ func validateDestinationNATAddressesStrict(cfg *Config) error {
 				// No destination match at all — out of scope.
 				continue
 			}
-			anyGood := false
+			// #3228: reject the rule if ANY listed destination-address is
+			// unparseable, not just when they ALL are. The snapshot builder
+			// (buildDestinationNATSnapshots) strips the CIDR suffix and then
+			// per-entry `continue`s past any token that is empty or fails
+			// net.ParseIP — silently dropping it from the installed DNAT
+			// table. A mixed list such as `[ 192.0.2.1 web-server ]` would
+			// otherwise commit clean (the old anyGood break) while
+			// `web-server` never translates. Mirror the builder's exact skip
+			// predicate (CIDR strip via natCIDRIPPart, then empty/ParseIP
+			// check) so the validator rejects precisely what the builder
+			// would drop: validator and dataplane view agree, and an
+			// all-valid list still compiles byte-identical.
 			for _, raw := range destAddrs {
 				ipPart := natCIDRIPPart(raw)
-				if ipPart != "" && net.ParseIP(ipPart) != nil {
-					anyGood = true
-					break
+				if ipPart == "" || net.ParseIP(ipPart) == nil {
+					return fmt.Errorf(
+						"destination-nat rule-set %q rule %q: match destination-address "+
+							"%q is not a valid IP/CIDR; the rule would commit but the "+
+							"dataplane silently drops the malformed entry, leaving traffic "+
+							"to it untranslated (full list: %s)",
+						rs.Name, rule.Name, raw, strings.Join(destAddrs, ", "))
 				}
-			}
-			if !anyGood {
-				return fmt.Errorf(
-					"destination-nat rule-set %q rule %q: no valid destination-address "+
-						"(every match destination-address is malformed: %s); "+
-						"the rule would commit but never translate any traffic",
-					rs.Name, rule.Name, strings.Join(destAddrs, ", "))
 			}
 			// #3029: a DNAT `match destination-address` that is a MULTI-HOST
 			// prefix (a CIDR with a non-host mask, e.g. 198.51.100.0/24) is


### PR DESCRIPTION
## Problem

The strict commit gate `validateDestinationNATAddressesStrict`
(`pkg/config/compiler_validate_strict.go`) used an `anyGood` break — it
passed commit as long as AT LEAST ONE `match destination-address` parsed.
The dataplane snapshot builder `buildDestinationNATSnapshots`
(`pkg/dataplane/userspace/nat.go`) skips malformed entries PER-ENTRY.

So a mixed list such as `match destination-address [ 192.0.2.1 web-server ]`
committed clean (one good entry satisfied `anyGood`) while `web-server` was
silently dropped from the installed DNAT table. Traffic to the omitted
destination was never translated — a partial, silent drop of a
forwarding-relevant config (agy-review-071 finding 071-01).

## Fix

Replace the `anyGood` break with a per-entry check that mirrors the
builder's exact skip predicate (`natCIDRIPPart` CIDR strip, then empty /
`net.ParseIP` test). The validator now rejects the rule on ANY unparseable
destination, naming the offending token, so the Go validation and the
dataplane view agree: anything the builder would drop, the validator
rejects. An all-valid list still compiles byte-identical and installs every
entry. The tolerant load / peer-sync path still downgrades the rejection to
a `destination-nat address` warning (#1960 no-brick), consistent with the
all-malformed (#2396(c)) and multi-host-prefix (#3029) gates that share this
validator. Source-NAT does not use the `anyGood` pattern (verified) — fix is
scoped to dest-NAT as the issue covers.

## Tests

- Inverted the stale `TestDNATPartialValidDestinationAccepted` to
  `TestDNATPartialValidDestinationRejected` — a `[valid, invalid]` list is
  now rejected at commit and the error names the bad entry.
- Added `TestDNATAllValidDestinationListAccepted` — an entirely-valid list
  still passes the gate.
- A single invalid entry (not a list) stays rejected
  (`TestDNATAllInvalidDestinationRejected`, unchanged).
- Builder all-entries-installed behavior unchanged, still covered by
  `userspace.TestBuildDestinationNATSnapshotsMultiDestination`.

**Fail-on-revert:** restoring the `anyGood` break turns
`TestDNATPartialValidDestinationRejected` RED (the partial-valid rule
compiles) while `TestDNATAllValidDestinationListAccepted` stays GREEN
(all-valid behavior byte-identical).

`go build ./...` and `go test ./pkg/config/ ./pkg/dataplane/userspace/` pass.

Closes #3228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi