### PR TITLE
screen: default icmp/udp flood + port-scan + ip-sweep thresholds (#3230)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-26 — #3230 screen icmp/udp flood + port-scan + ip-sweep default thresholds
+
+- **Timestamp**: 2026-06-26
+- **Action**: Sibling of #3024. When icmp-flood, udp-flood, tcp port-scan,
+  or ip ip-sweep was enabled WITHOUT an explicit threshold, the screen
+  compiled to threshold 0 and the Rust screen engine's `threshold > 0`
+  gate silently skipped the check. Added Junos-aligned parse-time defaults
+  in `compileScreen` so an enabled-but-unset check arms at a nonzero rate:
+  icmp/udp flood = 1000 pps, port-scan/ip-sweep = 10 distinct destinations
+  (Junos's detection count; this engine reads the threshold as a count over
+  a fixed 10s window, not Junos's 5000us window). Explicit thresholds are
+  preserved; unconfigured checks stay off (0). New constants
+  `defaultICMPFloodThreshold`/`defaultUDPFloodThreshold`/
+  `defaultPortScanThreshold`/`defaultIPSweepThreshold`.
+- **File(s)**: pkg/config/compiler_security.go,
+  pkg/config/parser_security_test.go (TestScreenFloodScanDefaultThresholds,
+  TestScreenFloodScanExplicitThresholdsPreserved,
+  TestScreenFloodScanNotConfiguredStaysOff),
+  docs/syn-cookie-flood-protection.md, _Log.md
+- **Validation**: go build ./...; go test ./pkg/config/ ./pkg/dataplane/...
+  all green. Fail-on-revert: removing the four defaulting blocks turned
+  TestScreenFloodScanDefaultThresholds RED (icmp=0, udp=0, port-scan=0,
+  ip-sweep=0); restored byte-identical → green.
+
 ## 2026-06-26 — #3193 persistent-nat SHOW: report the three-way permit mode
 
 - **Timestamp**: 2026-06-26

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -39,6 +39,34 @@ applies the same default defensively. Previously the dataplane gate required
 `AttackThreshold > 0`, so an unset attack-threshold silently left SYN-flood
 protection disabled even when configured.
 
+### Default thresholds for the other rate/scan screens (#3230)
+
+The Rust screen engine (`userspace-dp/src/screen/mod.rs`, `scan.rs`) gates
+icmp-flood, udp-flood, tcp port-scan, and ip ip-sweep on `threshold > 0`. Like
+syn-flood before #3024, these checks had NO default: enabling one without an
+explicit threshold compiled to 0 and the check was silently skipped. The config
+compiler now seeds a Junos-aligned default at parse time
+(`pkg/config/compiler_security.go`) for each ENABLED-but-unset check. An
+explicit threshold is always preserved, and a check that is not configured stays
+off (threshold 0).
+
+| Screen check        | Default | Junos basis |
+|---------------------|---------|-------------|
+| `icmp flood`        | 1000    | Junos `icmp flood threshold` default of 1000 pps |
+| `udp flood`         | 1000    | Junos `udp flood threshold` default of 1000 pps |
+| `tcp port-scan`     | 10      | Junos flags a port scan at 10 distinct destination ports |
+| `ip ip-sweep`       | 10      | Junos flags an address sweep at 10 distinct destination addresses |
+
+Note on the scan/sweep defaults: Junos expresses the port-scan / ip-sweep
+`threshold` as a time window (default 5000 microseconds) within which 10 distinct
+ports / addresses trigger detection. This engine instead interprets the
+threshold as a DISTINCT-DESTINATION COUNT over a fixed 10-second window
+(`WINDOW_SECS` in `scan.rs`, comparison `len() > threshold`), so the default
+uses Junos's distinct-destination detection count (10) rather than its 5000-
+microsecond time-window value. Feeding 5000 here would be read as a count and
+clamped to the dataplane cap (1023, `maxScanSweepThreshold`) — effectively never
+firing.
+
 ## Algorithm
 
 ```

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -29,6 +29,34 @@ const maxScanSweepThreshold = 1023
 // parse and the dataplane gate in pkg/dataplane/compiler_iface.go (#3024).
 const defaultSynFloodAttackThreshold = 200
 
+// Junos SRX default thresholds applied when the corresponding screen check is
+// enabled WITHOUT an explicit threshold. The Rust screen engine
+// (userspace-dp/src/screen/mod.rs, scan.rs) gates every check on
+// `threshold > 0`, so an enabled-but-unset check would compile to 0 and be
+// silently skipped. These are the siblings of #3024 (#3230).
+const (
+	// defaultICMPFloodThreshold matches the Junos SRX `icmp flood threshold`
+	// default of 1000 ICMP packets per second.
+	defaultICMPFloodThreshold = 1000
+
+	// defaultUDPFloodThreshold matches the Junos SRX `udp flood threshold`
+	// default of 1000 UDP packets per second.
+	defaultUDPFloodThreshold = 1000
+
+	// defaultPortScanThreshold / defaultIPSweepThreshold supply a default for
+	// `tcp port-scan` / `ip ip-sweep` when enabled without a threshold. Junos
+	// flags a port scan / address sweep when one source reaches 10 distinct
+	// destination ports / addresses within a 5000-microsecond window. This
+	// engine interprets the threshold as a DISTINCT-DESTINATION COUNT over a
+	// fixed 10-second window (WINDOW_SECS in scan.rs, `len() > threshold`), so
+	// the default uses Junos's distinct-destination detection count (10), NOT
+	// its 5000-microsecond time-window value — feeding 5000 here would be read
+	// as a count and clamped to the dataplane cap (1023), effectively never
+	// firing.
+	defaultPortScanThreshold = 10
+	defaultIPSweepThreshold  = 10
+)
+
 // validateScreenScanSweepThresholds emits a WARNING (never a hard reject) for
 // any screen profile whose port-scan or ip-sweep threshold exceeds
 // maxScanSweepThreshold. The dataplane clamps the effective threshold to that
@@ -499,6 +527,12 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 							profile.ICMP.FloodThreshold = n
 						}
 					}
+					// icmp flood enabled without an explicit threshold: arm at
+					// the Junos default (1000 pps) so the dataplane `>0` gate
+					// fires rather than silently skipping the check (#3230).
+					if profile.ICMP.FloodThreshold <= 0 {
+						profile.ICMP.FloodThreshold = defaultICMPFloodThreshold
+					}
 				}
 			}
 		}
@@ -522,6 +556,13 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 								profile.IP.IPSweepThreshold = n
 							}
 						}
+					}
+					// ip-sweep enabled without an explicit threshold: arm at the
+					// Junos distinct-address detection count (10) so the
+					// dataplane `>0` gate fires rather than skipping the check
+					// (#3230).
+					if profile.IP.IPSweepThreshold <= 0 {
+						profile.IP.IPSweepThreshold = defaultIPSweepThreshold
 					}
 				}
 			}
@@ -589,6 +630,13 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 							}
 						}
 					}
+					// port-scan enabled without an explicit threshold: arm at
+					// the Junos distinct-port detection count (10) so the
+					// dataplane `>0` gate fires rather than skipping the check
+					// (#3230).
+					if profile.TCP.PortScanThreshold <= 0 {
+						profile.TCP.PortScanThreshold = defaultPortScanThreshold
+					}
 				}
 			}
 		}
@@ -606,6 +654,12 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 						if n, err := strconv.Atoi(v); err == nil {
 							profile.UDP.FloodThreshold = n
 						}
+					}
+					// udp flood enabled without an explicit threshold: arm at
+					// the Junos default (1000 pps) so the dataplane `>0` gate
+					// fires rather than silently skipping the check (#3230).
+					if profile.UDP.FloodThreshold <= 0 {
+						profile.UDP.FloodThreshold = defaultUDPFloodThreshold
 					}
 				}
 			}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -2893,6 +2893,100 @@ func TestSynFloodExplicitAttackThresholdPreserved(t *testing.T) {
 	}
 }
 
+// compileScreenProfile is a helper that compiles a set of `set` commands and
+// returns the named screen profile.
+func compileScreenProfile(t *testing.T, name string, cmds ...string) *ScreenProfile {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	p := cfg.Security.Screen[name]
+	if p == nil {
+		t.Fatalf("screen profile %q not found", name)
+	}
+	return p
+}
+
+// TestScreenFloodScanDefaultThresholds is a fail-on-revert guard for #3230
+// (siblings of #3024): icmp-flood, udp-flood, tcp port-scan, and ip ip-sweep
+// enabled WITHOUT an explicit threshold must compile to a NONZERO Junos default
+// so the Rust screen engine's `threshold > 0` gate fires. A zero threshold is
+// the value the dataplane treats as "disabled" — silently leaving the
+// configured screen non-functional. RED if the parse-time defaults in
+// pkg/config/compiler_security.go are reverted.
+func TestScreenFloodScanDefaultThresholds(t *testing.T) {
+	p := compileScreenProfile(t, "s",
+		"set security screen ids-option s icmp flood",
+		"set security screen ids-option s udp flood",
+		"set security screen ids-option s tcp port-scan",
+		"set security screen ids-option s ip ip-sweep",
+	)
+	if p.ICMP.FloodThreshold != defaultICMPFloodThreshold {
+		t.Errorf("icmp FloodThreshold = %d, want default %d", p.ICMP.FloodThreshold, defaultICMPFloodThreshold)
+	}
+	if p.UDP.FloodThreshold != defaultUDPFloodThreshold {
+		t.Errorf("udp FloodThreshold = %d, want default %d", p.UDP.FloodThreshold, defaultUDPFloodThreshold)
+	}
+	if p.TCP.PortScanThreshold != defaultPortScanThreshold {
+		t.Errorf("PortScanThreshold = %d, want default %d", p.TCP.PortScanThreshold, defaultPortScanThreshold)
+	}
+	if p.IP.IPSweepThreshold != defaultIPSweepThreshold {
+		t.Errorf("IPSweepThreshold = %d, want default %d", p.IP.IPSweepThreshold, defaultIPSweepThreshold)
+	}
+}
+
+// TestScreenFloodScanExplicitThresholdsPreserved guards that the #3230 defaults
+// do NOT override an operator-supplied threshold.
+func TestScreenFloodScanExplicitThresholdsPreserved(t *testing.T) {
+	p := compileScreenProfile(t, "s",
+		"set security screen ids-option s icmp flood threshold 500",
+		"set security screen ids-option s udp flood threshold 600",
+		"set security screen ids-option s tcp port-scan threshold 100",
+		"set security screen ids-option s ip ip-sweep threshold 50",
+	)
+	if p.ICMP.FloodThreshold != 500 {
+		t.Errorf("icmp FloodThreshold = %d, want explicit 500", p.ICMP.FloodThreshold)
+	}
+	if p.UDP.FloodThreshold != 600 {
+		t.Errorf("udp FloodThreshold = %d, want explicit 600", p.UDP.FloodThreshold)
+	}
+	if p.TCP.PortScanThreshold != 100 {
+		t.Errorf("PortScanThreshold = %d, want explicit 100", p.TCP.PortScanThreshold)
+	}
+	if p.IP.IPSweepThreshold != 50 {
+		t.Errorf("IPSweepThreshold = %d, want explicit 50", p.IP.IPSweepThreshold)
+	}
+}
+
+// TestScreenFloodScanNotConfiguredStaysOff guards that a screen profile which
+// does NOT enable icmp/udp flood, port-scan, or ip-sweep leaves every threshold
+// at 0 (the check stays disabled). The #3230 defaults must only apply to an
+// ENABLED-but-unset check, never spontaneously enable an unconfigured one.
+func TestScreenFloodScanNotConfiguredStaysOff(t *testing.T) {
+	p := compileScreenProfile(t, "s",
+		"set security screen ids-option s tcp land",
+	)
+	if p.ICMP.FloodThreshold != 0 {
+		t.Errorf("icmp FloodThreshold = %d, want 0 (not configured)", p.ICMP.FloodThreshold)
+	}
+	if p.UDP.FloodThreshold != 0 {
+		t.Errorf("udp FloodThreshold = %d, want 0 (not configured)", p.UDP.FloodThreshold)
+	}
+	if p.TCP.PortScanThreshold != 0 {
+		t.Errorf("PortScanThreshold = %d, want 0 (not configured)", p.TCP.PortScanThreshold)
+	}
+	if p.IP.IPSweepThreshold != 0 {
+		t.Errorf("IPSweepThreshold = %d, want 0 (not configured)", p.IP.IPSweepThreshold)
+	}
+}
+
 func TestNATSourceSetSyntax(t *testing.T) {
 	tree := &ConfigTree{}
 	for _, cmd := range []string{"set security nat source pool snat-pool address 203.0.113.0/24", "set security nat source rule-set trust-to-untrust from zone trust", "set security nat source rule-set trust-to-untrust to zone untrust", "set security nat source rule-set trust-to-untrust rule snat-rule match source-address 10.0.0.0/8", "set security nat source rule-set trust-to-untrust rule snat-rule then source-nat interface"} {


### PR DESCRIPTION
## Summary

Sibling of #3024. The Rust screen engine (`userspace-dp/src/screen/mod.rs`, `scan.rs`) gates **icmp-flood**, **udp-flood**, **tcp port-scan**, and **ip ip-sweep** on `threshold > 0`. Like syn-flood before #3024, these checks had no default: enabling one without an explicit threshold compiled to `0`, so the dataplane gate silently skipped the check — a screen the operator believed enabled was non-functional.

`compileScreen` (`pkg/config/compiler_security.go`) now seeds a Junos-aligned default for each ENABLED-but-unset check, mirroring `defaultSynFloodAttackThreshold`:

| Screen check    | Default | Junos basis |
|-----------------|---------|-------------|
| `icmp flood`    | 1000    | Junos `icmp flood threshold` default of 1000 pps |
| `udp flood`     | 1000    | Junos `udp flood threshold` default of 1000 pps |
| `tcp port-scan` | 10      | Junos flags a port scan at 10 distinct destination ports |
| `ip ip-sweep`   | 10      | Junos flags an address sweep at 10 distinct destination addresses |

**Scan/sweep note:** Junos expresses the port-scan / ip-sweep threshold as a 5000-microsecond window in which 10 distinct destinations trigger detection. This engine instead reads the threshold as a distinct-destination COUNT over a fixed 10-second window (`len() > threshold`), so the default uses Junos's distinct-destination detection count (10), not its 5000-us time-window value — feeding 5000 here would be read as a count and clamped to the dataplane cap (1023, `maxScanSweepThreshold`), effectively never firing.

An explicit threshold is always preserved; an unconfigured check stays off (threshold 0). No Rust touched — the parse-time seed makes the threshold nonzero, which the existing dataplane gate and Rust `>0` gate then honor.

## Tests (pkg/config)
- `TestScreenFloodScanDefaultThresholds` — fail-on-revert guard: each of the four, enabled without a threshold, compiles to its nonzero default.
- `TestScreenFloodScanExplicitThresholdsPreserved` — explicit thresholds (500/600/100/50) are not overridden.
- `TestScreenFloodScanNotConfiguredStaysOff` — a profile that does not enable these checks leaves all four thresholds at 0.

**Fail-on-revert proven:** removing the four defaulting blocks turned `TestScreenFloodScanDefaultThresholds` RED (icmp=0, udp=0, port-scan=0, ip-sweep=0); restored byte-identical → green.

## Validation
`go build ./...`; `go test ./pkg/config/ ./pkg/dataplane/...` all green.

Closes #3230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi