### PR TITLE
host-inbound: doc-correction + real-path regression test — DHCP/DHCPv6 scope is non-reproducing (#3224)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,38 @@
+## 2026-06-26 — #3224 host-inbound DHCP scope: NON-REPRODUCING (doc correction + real regression test)
+
+- **Timestamp**: 2026-06-26
+- **Action**: Reworked after hostile review found the prior "SECURITY
+  fail-open fix" was byte-identical to master in production and its test
+  used an injected fake `dynAddrs` provider that never exercised the
+  production address source. VERIFIED the #3224 premise does NOT
+  reproduce: master's `BuildZoneHostInboundViews` already resolves each
+  zone's addresses through `buildInterfaceSnapshots` ->
+  `buildLinkSnapshot` -> `buildInterfaceAddressSnapshots` ->
+  `netlink.AddrList(FAMILY_ALL)`, which enumerates EVERY kernel address
+  with NO scope/flag/dynamic filtering — so DHCP/DHCPv6-learned addresses
+  were ALREADY captured and scoped by the deny. Reverted the no-op 3-source
+  refactor (and the injected-seam that enabled the misleading test) so
+  `BuildZoneHostInboundViews` code is byte-identical to master. CORRECTED
+  master's false doc comment (which claimed "a DHCP-only interface yields
+  an empty address set -> fail-open") in zones.go, daemon_nft.go, and
+  pkg/daemon/README.md to state that DHCP/DHCPv6 addresses ARE captured via
+  the live snapshot, plus the lease-change refresh path. REPLACED the fake
+  test with `TestBuildZoneHostInboundViewsScopesKernelLearnedAddr`, which
+  drives the REAL production path (`BuildZoneHostInboundViews` ->
+  `buildInterfaceSnapshots` -> `AddrList`) using the loopback interface as
+  a kernel address absent from the static config (modeling DHCP), with no
+  fake provider and no root. It asserts the kernel-learned address IS
+  scoped — a fail-on-revert guard against a future filter regression.
+- **File(s)**: pkg/dataplane/userspace/zones.go (comment only — code
+  reverted to master), pkg/dataplane/userspace/zones_host_inbound_test.go,
+  pkg/daemon/daemon_nft.go (comment), pkg/daemon/README.md
+- **Validation**: `go build ./...`; `go test ./pkg/dataplane/...
+  ./pkg/daemon/...` green. Verified empirically: the new real-path test
+  PASSES on master-equivalent code (proving master already scopes a
+  config-absent kernel address); a destructive probe that drops the live
+  snapshot loop turns it RED (untrust loses 127.0.0.1/::1) while the new
+  test isolates the dynamic-address property — restored byte-identical.
+
 ## 2026-06-26 — #3193 persistent-nat SHOW: report the three-way permit mode
 
 - **Timestamp**: 2026-06-26

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -293,7 +293,21 @@ never lock an operator out of a remote box it manages.
   host-inbound-CONFIGURED zone it accepts the listed system-services/protocols
   to that zone's addresses and DROPs the rest; the userspace-dp LocalDelivery
   check (`forwarding/host_inbound.rs`) is the secondary path for the XSK-reaching
-  subset. **Lifeline safety:** a zone with NO stanza emits no deny (admit-all);
+  subset. **Address sources (#3172, #3224):** the per-zone destination address
+  set is the de-duplicated union of (a) the live interface snapshot
+  (`buildInterfaceSnapshots` -> `AddrList(FAMILY_ALL)`), which carries BOTH static
+  `family inet[6] address` config leaves AND DHCP/DHCPv6-learned kernel addresses
+  (the snapshot does no scope/flag/dynamic filtering, so a DHCP-addressed WAN's
+  learned address IS scoped — the #3224 fail-open premise does not reproduce), and
+  (b) RETH VRRP VIPs resolved from config (so the deny is scoped on the backup
+  node too, where the VIP is not yet live). SLAAC is not a separate case: xpfd sets
+  `IPv6AcceptRA=no` on every managed interface (`pkg/networkd`), so DHCPv6 is the
+  only IPv6 dynamic path and the live snapshot captures it. **Refresh:** the chain
+  is rebuilt on every commit and on every DHCP/DHCPv6 lease change on a dataplane
+  interface (`onDHCPAddressChange` → `dhcpLeaseChangeRequiresRecompile` →
+  `applyConfig` → `applyHostInboundFilter`), so a renewed/flapped lease re-scopes
+  the deny within one reconcile rather than staying fail-open until the next
+  commit. **Lifeline safety:** a zone with NO stanza emits no deny (admit-all);
   management/cluster-control interfaces (fxp0 / em0 / fab*) are excluded from
   the address sets so a host-inbound deny can never strand management or break
   HA; `ct state established,related` and IPv6 ND + v4/v6 PMTUD control messages

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -129,10 +129,14 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) {
 }
 
 // hostInboundHasEnforceableView reports whether at least one view carries a
-// resolvable address. A configured zone with no address (e.g. DHCP-only) cannot
-// be scoped to a deny, so it produces nothing; if NO zone is enforceable the
-// whole table is removed (fail-open is the safe direction for this
-// lifeline-adjacent feature).
+// resolvable address. Static, VRRP-VIP and DHCP/DHCPv6-learned addresses all
+// count: the live interface snapshot enumerates every kernel address via
+// AddrList(FAMILY_ALL), so a DHCP-only interface with a live lease IS scoped
+// (#3224 — see BuildZoneHostInboundViews). The only no-address case left is a
+// configured zone whose interfaces have no static address AND no live address
+// yet (e.g. a DHCP WAN before its first lease). That zone produces nothing; if
+// NO zone is enforceable the whole table is removed (it self-heals once an
+// address appears, because the lease-change / commit paths re-render).
 func hostInboundHasEnforceableView(views []dpuserspace.ZoneHostInboundView) bool {
 	for _, v := range views {
 		if len(v.V4Addrs) > 0 || len(v.V6Addrs) > 0 {

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -55,12 +55,31 @@ func hostInboundLifelineInterface(name string) bool {
 // addresses (#3172, resolved from config so they scope the deny on the backup
 // node too, where the VIP is not yet live on the kernel interface), with
 // management/cluster-control lifeline interfaces (fxp0 / em0 / fab*) excluded
-// from the address set. A zone
-// that declared NO host-inbound-traffic stanza is omitted entirely (admit-all
-// preserved — zero regression). A configured zone with no resolvable static
-// address (e.g. a DHCP-only interface) yields an empty address set; the daemon
-// emits no deny for it (cannot scope a deny without an address — fail-open is
-// the safe direction for a lifeline-adjacent feature).
+// from the address set.
+//
+// Address completeness (#3224 — non-reproducing): the snapshot builder resolves
+// each interface's addresses through buildLinkSnapshot -> AddrList(FAMILY_ALL),
+// which enumerates EVERY kernel address with no scope/flag/dynamic filtering.
+// So DHCP / DHCPv6-learned addresses are captured exactly like static ones —
+// a DHCP-only interface with a live lease yields a NON-empty address set and IS
+// scoped by the deny. (xpfd disables IPv6 RA on every managed interface in
+// pkg/networkd, so DHCPv6 is the only IPv6 dynamic-address path and the same
+// snapshot captures it; SLAAC is not a separate case.) The deny is also
+// re-rendered on every DHCP/DHCPv6 lease change on a dataplane interface
+// (onDHCPAddressChange -> dhcpLeaseChangeRequiresRecompile -> applyConfig ->
+// applyHostInboundFilter), so a renewed/flapped lease re-scopes within one
+// reconcile pass. #3224 was filed on the premise that DHCP addresses fell out
+// of scope (FAIL OPEN); that does not reproduce because the live snapshot has
+// always carried them — see TestBuildZoneHostInboundViewsScopesKernelLearnedAddr,
+// which exercises this real path with a config-absent kernel address.
+//
+// A zone that declared NO host-inbound-traffic stanza is omitted entirely
+// (admit-all preserved — zero regression). The only no-address case left is a
+// configured zone whose interfaces have neither a static config address nor any
+// live kernel address yet (e.g. a DHCP WAN before its first lease, or a backup
+// node before VIP install): it yields an empty address set, the daemon emits no
+// deny for it, and it self-heals once an address appears because the
+// lease-change / commit paths re-render.
 func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 	if cfg == nil || len(cfg.Security.Zones) == 0 {
 		return nil

--- a/pkg/dataplane/userspace/zones_host_inbound_test.go
+++ b/pkg/dataplane/userspace/zones_host_inbound_test.go
@@ -235,6 +235,106 @@ func TestBuildZoneHostInboundViewsIncludesVRRPVIP(t *testing.T) {
 	}
 }
 
+// TestBuildZoneHostInboundViewsScopesKernelLearnedAddr is the #3224
+// regression guard, and it deliberately drives the REAL production address
+// source — BuildZoneHostInboundViews -> buildInterfaceSnapshots ->
+// buildLinkSnapshot -> buildInterfaceAddressSnapshots -> netlink.AddrList(
+// FAMILY_ALL) — with NO injected/fake provider.
+//
+// #3224 was filed on the premise that a DHCP/DHCPv6-learned firewall-local
+// address (one that exists only on the kernel netdev, never in the static
+// config) would fall out of the host-inbound deny scope and FAIL OPEN to
+// `policy accept`. That premise does NOT reproduce: buildInterfaceAddressSnapshots
+// enumerates EVERY address via netlink.AddrList(FAMILY_ALL) with no
+// scope/flag/dynamic filtering, so a kernel-learned address is captured exactly
+// like a static one. This test proves that property on the real path.
+//
+// We model "a kernel address that is absent from the static config" with the
+// loopback interface (always present, no root required): the config maps a zone
+// interface onto `lo` and declares NO static address, so 127.0.0.1 / ::1 reach
+// the view ONLY through the live kernel snapshot — the identical mechanism that
+// captures a DHCP/DHCPv6 lease. If a future refactor ever filters dynamic /
+// non-config addresses out of the snapshot path (the gap #3224 feared), this
+// test goes RED.
+func TestBuildZoneHostInboundViewsScopesKernelLearnedAddr(t *testing.T) {
+	// Sanity: the loopback must carry its kernel address (it is not in any config
+	// here). If a sandbox somehow lacks it, skip rather than false-fail.
+	loSnap := liveZoneHostInboundAddrsForIface(t, "lo")
+	if !contains(loSnap, "127.0.0.1") {
+		t.Skipf("loopback has no 127.0.0.1 (got %v) — cannot exercise real netlink path", loSnap)
+	}
+
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		// Zone interface mapped onto the real `lo` netdev with NO static address:
+		// its only addresses (127.0.0.1/8, ::1/128) come from the live kernel
+		// snapshot — exactly how a DHCP/DHCPv6 lease appears (config-absent,
+		// kernel-present).
+		"lo": {Name: "lo", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0},
+		}},
+		// Static-only control: unchanged regardless of the live snapshot.
+		"reth1": {Name: "reth1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.61.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"untrust": {Name: "untrust", Interfaces: []string{"lo.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+		"lan": {Name: "lan", Interfaces: []string{"reth1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+
+	// REAL production entry point — no injected dynamic source.
+	views := BuildZoneHostInboundViews(cfg)
+	byZone := make(map[string]ZoneHostInboundView, len(views))
+	for _, v := range views {
+		byZone[v.Zone] = v
+	}
+
+	// untrust: the kernel-learned (config-absent) v4 address IS scoped. This is
+	// the fail-on-revert guard for the #3224 premise — the production snapshot
+	// path captures it without any static config address.
+	untrust, ok := byZone["untrust"]
+	if !ok {
+		t.Fatal("untrust view missing")
+	}
+	if !contains(untrust.V4Addrs, "127.0.0.1") {
+		t.Errorf("untrust v4 addrs = %v, want to contain 127.0.0.1 "+
+			"(kernel-learned, config-absent address must be scoped — #3224)", untrust.V4Addrs)
+	}
+	// IPv6 loopback (::1) is standard on Linux; assert it too when present so the
+	// guard also covers the v6 dynamic path (DHCPv6).
+	if contains(loSnap, "::1") && !contains(untrust.V6Addrs, "::1") {
+		t.Errorf("untrust v6 addrs = %v, want to contain ::1 "+
+			"(kernel-learned v6 address must be scoped — #3224)", untrust.V6Addrs)
+	}
+
+	// lan: static-only, untouched by the live snapshot.
+	lan, ok := byZone["lan"]
+	if !ok {
+		t.Fatal("lan view missing")
+	}
+	if !eqStr(lan.V4Addrs, []string{"10.0.61.1"}) {
+		t.Errorf("lan v4 addrs = %v, want [10.0.61.1] (static only, unchanged)", lan.V4Addrs)
+	}
+}
+
+// liveZoneHostInboundAddrsForIface returns the bare host IPs the real snapshot
+// path resolves for a single live netdev, used only to gate the loopback test on
+// the address actually being present (no fake injection).
+func liveZoneHostInboundAddrsForIface(t *testing.T, linuxName string) []string {
+	t.Helper()
+	_, _, _, addrs := buildLinkSnapshot(linuxName)
+	out := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		if host := hostIPFromCIDR(a.Address); host != "" {
+			out = append(out, host)
+		}
+	}
+	return out
+}
+
 func TestHostInboundLifelineInterface(t *testing.T) {
 	for _, name := range []string{"fxp0", "fxp0.0", "em0", "em0.0", "fab0", "fab1", "fab1.0"} {
 		if !hostInboundLifelineInterface(name) {


### PR DESCRIPTION
## Summary — #3224 does not reproduce (reframed after hostile review)

A hostile review of the original PR found the "SECURITY fail-open fix" was
**byte-identical to master in production**, and its test injected a fake
`dynAddrs` provider that never exercised the real address source. This rework
verifies that finding and reframes the change honestly: a doc correction plus a
**real-path** regression test. There is no behavior change.

## What was verified

`BuildZoneHostInboundViews` resolves each zone's firewall-local addresses through:

```
BuildZoneHostInboundViews -> buildInterfaceSnapshots -> buildLinkSnapshot
  -> buildInterfaceAddressSnapshots -> netlink.AddrList(link, FAMILY_ALL)
```

`buildInterfaceAddressSnapshots` (`pkg/dataplane/userspace/interfaces.go:457`)
enumerates **every** kernel address with **no scope/flag/dynamic filtering**, so
a DHCP/DHCPv6-learned address is captured exactly like a static one and is
already scoped by the deny. The lease-change refresh path
(`onDHCPAddressChange -> dhcpLeaseChangeRequiresRecompile -> applyConfig ->
applyHostInboundFilter`) also pre-existed. The net production address set is
identical to master — master's own doc comment ("a DHCP-only interface yields an
empty address set -> fail-open") was simply **wrong**.

## What changed

- **`zones.go`**: reverted the no-op three-source refactor (and the injected
  `dynAddrs` seam that only existed to enable the misleading fake test) so
  `BuildZoneHostInboundViews` is **byte-identical to master** (comment-only
  diff). Corrected the false doc comment to state DHCP/DHCPv6 addresses ARE
  captured via the live snapshot, plus the genuine no-address edge (a DHCP WAN
  before its first lease / a backup node before VIP install — self-healing once
  an address appears).
- **`daemon_nft.go`, `pkg/daemon/README.md`**: same doc correction.
- **`zones_host_inbound_test.go`**: replaced the fake-provider test with
  `TestBuildZoneHostInboundViewsScopesKernelLearnedAddr`, which drives the
  **real** production path using the loopback interface as a kernel address
  absent from the static config — the identical mechanism by which a DHCP/DHCPv6
  lease appears (config-absent, kernel-present). No fake provider, no root. It
  asserts the kernel-learned address IS scoped, and is a fail-on-revert guard:
  removing the live-snapshot address loop turns it RED while a static-only zone
  stays GREEN.

## Validation

- `go build ./...` green
- `go test ./pkg/dataplane/... ./pkg/daemon/...` green
- New real-path test passes on master-equivalent code (proving master already
  scopes a config-absent kernel address); destructive probe removing the live
  snapshot loop turns it RED, then restored byte-identical.

## Disposition

`#3224` should be **closed as non-reproducing** — the live snapshot has always
carried DHCP/DHCPv6 addresses into the deny scope. This PR ships the doc
correction and a real regression test so the (already-correct) behavior is
locked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi