### PR TITLE
nat: support match destination-address-name in source/destination NAT (#3229)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-06-26 — #3229 dest-NAT: `match destination-address-name` (address-book reference)
+
+- **Timestamp**: 2026-06-26
+- **Action**: Added `destination-address-name` support to source AND
+  destination NAT, mirroring the #2416 `source-address-name` mechanism
+  exactly. New `DestinationAddressName` field on `NATMatch`
+  (`pkg/config/types_security.go`); parsed in both the source and dest NAT
+  rule blocks of `pkg/config/compiler_nat.go`; schema leaf added to both
+  match blocks in `pkg/config/schema_security.go`. Resolution:
+  `appendNATDestinationAddressName` (`pkg/dataplane/userspace/nat.go`)
+  expands the name via the same `resolveUserspaceAddressBookEntry` expander
+  the policy + source-address-name paths use and feeds the resolved prefixes
+  into the existing destination list — no new wire field (each resolved DNAT
+  host installs its own exact-host snapshot row). Called from both
+  `buildSourceNATSnapshots` and `buildDestinationNATSnapshots`. Commit-time
+  reject: `validateNATSourceAddressNameReferencesStrict`
+  (`pkg/config/compiler_validate_strict.go`) extended to gate BOTH the source
+  and destination name leaves; lenient load/peer-sync downgrades to a warning
+  (#1960) and the dataplane fails closed (unknown name = unparseable token =
+  matches nothing). Warn-only parity check also added to the retired-eBPF
+  `pkg/dataplane/compiler_nat.go`.
+- **File(s)**: pkg/config/types_security.go, pkg/config/schema_security.go,
+  pkg/config/compiler_nat.go, pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler.go, pkg/dataplane/userspace/nat.go,
+  pkg/dataplane/compiler_nat.go,
+  pkg/config/compiler_nat_dest_address_name_3229_test.go,
+  pkg/dataplane/userspace/nat_dest_address_name_3229_test.go,
+  docs/feature-gaps.md, docs/config-schema.md
+- **Tests**: Go `pkg/config` (parse both SNAT/DNAT, reject undefined both,
+  lenient-warns) + `pkg/dataplane/userspace` (resolve DNAT, literal+name
+  union, unknown fail-closed, resolve in source builder). Fail-on-revert:
+  neutralizing the dest-builder `appendNATDestinationAddressName` call turned
+  `TestBuildDestinationNATSnapshotsResolvesDestinationAddressName` RED (empty
+  destination list, rule dropped); restored byte-identical. Rust matcher
+  unchanged (names resolve to literals on the Go side, flow through the
+  existing `destination_address` snapshot field).
+
 ## 2026-06-26 — #3228 dest-NAT: reject a partial-valid destination-address list at commit
 
 - **Timestamp**: 2026-06-26

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -752,6 +752,22 @@ reserved for whole-dataplane selection where a rewrite shim
     plus a port-less whole-address 1:1 rule (the dataplane keys the
     static-NAT tables by `(IP, Option<port>)` and falls back to the
     port-less entry).
+  - `security nat source/destination rule-set rule match
+    destination-address-name <book-entry>` (#3229) — the destination twin
+    of the `source-address-name` leaf (#2416). It references an
+    `security address-book` address / address-set instead of a literal
+    prefix; the snapshot builder
+    (`appendNATDestinationAddressName`, `pkg/dataplane/userspace/nat.go`)
+    resolves the name through the same address-book expander the policy +
+    source-address-name paths use and feeds the resolved prefixes into the
+    existing destination list (no new wire field). For DNAT each resolved
+    host installs its own exact-host `DnatTable` entry; a non-host prefix is
+    stripped to its network address exactly like a literal `match
+    destination-address` CIDR. An undefined name is hard-rejected at commit
+    (`validateNATSourceAddressNameReferencesStrict`, which gates BOTH the
+    source and destination name leaves) and fails closed on the lenient
+    load / peer-sync path (the unresolved raw token cannot parse as an IP,
+    so the rule matches NOTHING rather than broadening to match-any).
   - `protocols router-advertisement interface` — typed the
     second-denominated leaves (`max/min-advertisement-interval`,
     `default-lifetime`, `link-mtu`; the latter was tightened from

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -166,7 +166,7 @@ User-based policy enforcement integrating with directory services. Not implement
 
 ## 8. NAT Enhancements
 
-xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, protocol-only match, port rewriting, multi-port matching), static 1:1 (host AND block-to-block subnet mappings, #3031), NAT64, and exemption rules. These are additional NAT features from the vSRX.
+xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT (with pools, hit counters, source-address-name match, destination-address-name match (#3229), protocol-only match, port rewriting, multi-port matching), static 1:1 (host AND block-to-block subnet mappings, #3031), NAT64, and exemption rules. These are additional NAT features from the vSRX.
 
 > **DNAT `match destination-address` is exact-host only (#3029).** The
 > userspace `DnatTable` keys on an exact destination `IpAddr` (no prefix /

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2284,7 +2284,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	if err := validateNATSourceAddressNameReferencesStrict(cfg); err != nil {
 		if opts.lenientFirewallRefs {
 			cfg.Warnings = append(cfg.Warnings,
-				fmt.Sprintf("NAT source-address-name reference (downgraded to warning on tolerant path): %v", err))
+				fmt.Sprintf("NAT address-name reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1211,6 +1211,10 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 						} else {
 							rule.Match.DestinationAddress = nodeVal(m)
 						}
+					case "destination-address-name":
+						// #3229: address-book reference; resolved to prefixes at
+						// snapshot-build time (appendNATDestinationAddressName).
+						rule.Match.DestinationAddressName = nodeVal(m)
 					case "destination-port":
 						if len(m.Children) > 0 {
 							for _, child := range m.Children {
@@ -1352,6 +1356,10 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 						} else {
 							rule.Match.DestinationAddress = nodeVal(m)
 						}
+					case "destination-address-name":
+						// #3229: address-book reference; resolved to prefixes at
+						// snapshot-build time (appendNATDestinationAddressName).
+						rule.Match.DestinationAddressName = nodeVal(m)
 					case "destination-port":
 						rule.Match.DestinationPorts = append(rule.Match.DestinationPorts, parseDNATPortList(m)...)
 						if rule.Match.DestinationPort == 0 && len(rule.Match.DestinationPorts) > 0 {

--- a/pkg/config/compiler_nat_dest_address_name_3229_test.go
+++ b/pkg/config/compiler_nat_dest_address_name_3229_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3229: NAT `match destination-address-name <book-entry>` is an address-book
+// reference, the destination twin of the #2416 source-address-name support. The
+// compiler must (1) parse it into NATMatch.DestinationAddressName for both
+// source and destination NAT, and (2) hard-reject at commit a rule whose name
+// is not defined under `security address-book`
+// (validateNATSourceAddressNameReferencesStrict, which also gates the
+// destination name) so the typo is operator-visible instead of silently failing
+// closed.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+func dnatDestNameSet(matchName string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security address-book global address svc-a 203.0.113.20/32",
+		"set security address-book global address-set svc-net address svc-a",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address-name " + matchName,
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	}
+}
+
+func snatDestNameSet(matchName string) []string {
+	return []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security address-book global address svc-a 203.0.113.20/32",
+		"set security address-book global address-set svc-net address svc-a",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match destination-address-name " + matchName,
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+}
+
+func TestNATDNATDestinationAddressNameParsed(t *testing.T) {
+	tree := buildTree(t, dnatDestNameSet("svc-net"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("DNAT with a defined destination-address-name must compile, got: %v", err)
+	}
+	if cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
+		t.Fatal("destination NAT rule-set missing after compile")
+	}
+	rule := cfg.Security.NAT.Destination.RuleSets[0].Rules[0]
+	if rule.Match.DestinationAddressName != "svc-net" {
+		t.Fatalf("DNAT DestinationAddressName = %q, want svc-net (parse dropped)", rule.Match.DestinationAddressName)
+	}
+}
+
+func TestNATSNATDestinationAddressNameParsed(t *testing.T) {
+	tree := buildTree(t, snatDestNameSet("svc-net"))
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("SNAT with a defined destination-address-name must compile, got: %v", err)
+	}
+	if len(cfg.Security.NAT.Source) == 0 {
+		t.Fatal("source NAT rule-set missing after compile")
+	}
+	rule := cfg.Security.NAT.Source[0].Rules[0]
+	if rule.Match.DestinationAddressName != "svc-net" {
+		t.Fatalf("SNAT DestinationAddressName = %q, want svc-net (parse dropped)", rule.Match.DestinationAddressName)
+	}
+}
+
+func TestNATDNATUnknownDestinationAddressNameRejected(t *testing.T) {
+	tree := buildTree(t, dnatDestNameSet("does-not-exist"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a DNAT rule naming an undefined destination-address-name must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-address-name") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "does-not-exist") {
+		t.Fatalf("error must name the rule + the undefined book entry, got: %v", err)
+	}
+}
+
+func TestNATSNATUnknownDestinationAddressNameRejected(t *testing.T) {
+	tree := buildTree(t, snatDestNameSet("does-not-exist"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("a SNAT rule naming an undefined destination-address-name must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-address-name") ||
+		!strings.Contains(msg, "r1") ||
+		!strings.Contains(msg, "does-not-exist") {
+		t.Fatalf("error must name the rule + the undefined book entry, got: %v", err)
+	}
+}
+
+// The tolerant load / peer-sync path downgrades the undefined reference to a
+// warning so an already-persisted or peer-synced config still boots (#1960).
+func TestNATUnknownDestinationAddressNameLenientWarns(t *testing.T) {
+	tree := buildTree(t, dnatDestNameSet("does-not-exist"))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant path must not hard-reject an undefined destination-address-name, got: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "destination-address-name") && strings.Contains(w, "does-not-exist") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant path must record a warning for the undefined reference, got warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3755,8 +3755,9 @@ func validatePrefixLengthRange(rf *RouteFilter) error {
 }
 
 // validateNATSourceAddressNameReferencesStrict hard-rejects a source or
-// destination NAT rule whose `match source-address-name <name>` names an
-// address-book entry not defined under `security address-book` (#2416).
+// destination NAT rule whose `match source-address-name <name>` OR `match
+// destination-address-name <name>` (#3229) names an address-book entry not
+// defined under `security address-book` (#2416).
 //
 // The name is resolved to concrete source prefixes at snapshot-build time
 // (appendNATSourceAddressName). A dangling reference contributes no prefix and
@@ -3790,20 +3791,35 @@ func validateNATSourceAddressNameReferencesStrict(cfg *Config) error {
 			return nil
 		}
 		for _, rule := range rs.Rules {
-			if rule == nil || rule.Match.SourceAddressName == "" {
+			if rule == nil {
 				continue
 			}
-			if defined(rule.Match.SourceAddressName) {
-				continue
+			if rule.Match.SourceAddressName != "" && !defined(rule.Match.SourceAddressName) {
+				return fmt.Errorf(
+					"%s NAT rule-set %q rule %q references undefined "+
+						"source-address-name %q (define `security address-book "+
+						"address %s` / `address-set %s`, or fix the name — the "+
+						"source scope would otherwise be silently lost and the "+
+						"rule would match no traffic)",
+					natType, rs.Name, rule.Name, rule.Match.SourceAddressName,
+					rule.Match.SourceAddressName, rule.Match.SourceAddressName)
 			}
-			return fmt.Errorf(
-				"%s NAT rule-set %q rule %q references undefined "+
-					"source-address-name %q (define `security address-book "+
-					"address %s` / `address-set %s`, or fix the name — the "+
-					"source scope would otherwise be silently lost and the "+
-					"rule would match no traffic)",
-				natType, rs.Name, rule.Name, rule.Match.SourceAddressName,
-				rule.Match.SourceAddressName, rule.Match.SourceAddressName)
+			// #3229: destination-address-name is the destination twin of
+			// source-address-name and resolves through the same address-book
+			// expander (appendNATDestinationAddressName). A dangling reference
+			// installs no destination = the rule matches nothing (fail-closed
+			// but silent); gate it here so the typo is operator-visible at
+			// commit, exactly like the source name above.
+			if rule.Match.DestinationAddressName != "" && !defined(rule.Match.DestinationAddressName) {
+				return fmt.Errorf(
+					"%s NAT rule-set %q rule %q references undefined "+
+						"destination-address-name %q (define `security address-book "+
+						"address %s` / `address-set %s`, or fix the name — the "+
+						"destination scope would otherwise be silently lost and the "+
+						"rule would match no traffic)",
+					natType, rs.Name, rule.Name, rule.Match.DestinationAddressName,
+					rule.Match.DestinationAddressName, rule.Match.DestinationAddressName)
+			}
 		}
 		return nil
 	}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -143,11 +143,12 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				}},
 				"rule": {desc: "Source NAT rule name", args: 1, placeholder: "<rule-name>", children: map[string]*schemaNode{
 					"match": {desc: "Match criteria", children: map[string]*schemaNode{
-						"source-address":      {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
-						"source-address-name": {desc: "Source address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
-						"destination-address": {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
-						"destination-port":    {desc: "Destination port to match", args: 1, multi: true, placeholder: "<port>", children: nil},
-						"application":         {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},
+						"source-address":           {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						"source-address-name":      {desc: "Source address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
+						"destination-address":      {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						"destination-address-name": {desc: "Destination address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
+						"destination-port":         {desc: "Destination port to match", args: 1, multi: true, placeholder: "<port>", children: nil},
+						"application":              {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},
 					}},
 					"then": {desc: "Source NAT action", children: map[string]*schemaNode{
 						"source-nat": {desc: "Source NAT translation", children: map[string]*schemaNode{
@@ -170,12 +171,13 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				}},
 				"rule": {desc: "Destination NAT rule name", args: 1, placeholder: "<rule-name>", children: map[string]*schemaNode{
 					"match": {desc: "Match criteria", children: map[string]*schemaNode{
-						"source-address":      {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
-						"source-address-name": {desc: "Source address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
-						"destination-address": {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
-						"destination-port":    {desc: "Destination port or range to match", args: 1, multi: true, placeholder: "<port>", children: nil},
-						"protocol":            {desc: "IP protocol to match", args: 1, multi: true, placeholder: "<protocol>", children: nil},
-						"application":         {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},
+						"source-address":           {desc: "Source address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						"source-address-name":      {desc: "Source address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
+						"destination-address":      {desc: "Destination address prefix to match", args: 1, multi: true, placeholder: "<prefix>", children: nil},
+						"destination-address-name": {desc: "Destination address book entry to match", args: 1, multi: true, placeholder: "<address-name>", children: nil},
+						"destination-port":         {desc: "Destination port or range to match", args: 1, multi: true, placeholder: "<port>", children: nil},
+						"protocol":                 {desc: "IP protocol to match", args: 1, multi: true, placeholder: "<protocol>", children: nil},
+						"application":              {desc: "Application to match", args: 1, multi: true, placeholder: "<application>", children: nil},
 					}},
 					"then": {desc: "Destination NAT action", children: map[string]*schemaNode{
 						"destination-nat": {desc: "Destination NAT translation", children: map[string]*schemaNode{

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -331,15 +331,16 @@ type NATRule struct {
 
 // NATMatch defines what traffic a NAT rule matches.
 type NATMatch struct {
-	SourceAddress        string   // CIDR (first address, for backward compat)
-	SourceAddresses      []string // all matched source CIDRs (bracket list support)
-	SourceAddressName    string   // address-book name (resolved during compilation)
-	DestinationAddress   string   // CIDR (first address, for backward compat)
-	DestinationAddresses []string // all matched destination CIDRs (bracket list support)
-	DestinationPort      int      // primary port (first port for BPF rule)
-	DestinationPorts     []int    // all matched ports (for multi-port DNAT rules)
-	Protocol             string   // "tcp", "udp", "icmp6", "gre", or "" (auto)
-	Application          string   // application name (e.g. "junos-http")
+	SourceAddress          string   // CIDR (first address, for backward compat)
+	SourceAddresses        []string // all matched source CIDRs (bracket list support)
+	SourceAddressName      string   // address-book name (resolved during compilation)
+	DestinationAddress     string   // CIDR (first address, for backward compat)
+	DestinationAddresses   []string // all matched destination CIDRs (bracket list support)
+	DestinationAddressName string   // address-book name (resolved during compilation, #3229)
+	DestinationPort        int      // primary port (first port for BPF rule)
+	DestinationPorts       []int    // all matched ports (for multi-port DNAT rules)
+	Protocol               string   // "tcp", "udp", "icmp6", "gre", or "" (auto)
+	Application            string   // application name (e.g. "junos-http")
 }
 
 // NATThen defines the NAT translation action.

--- a/pkg/dataplane/compiler_nat.go
+++ b/pkg/dataplane/compiler_nat.go
@@ -691,6 +691,14 @@ func compileNAT(dp DataPlane, cfg *config.Config, result *CompileResult) error {
 					}
 				}
 
+				// #3229: validate destination-address-name (config compat)
+				if rule.Match.DestinationAddressName != "" {
+					if _, ok := result.AddrIDs[rule.Match.DestinationAddressName]; !ok {
+						slog.Warn("DNAT destination-address-name not found in address-book",
+							"rule", rule.Name, "name", rule.Match.DestinationAddressName)
+					}
+				}
+
 				// Parse match destination address
 				if rule.Match.DestinationAddress == "" {
 					slog.Warn("DNAT rule has no match destination-address",

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -49,6 +49,33 @@ func appendNATSourceAddressName(cfg *config.Config, sourceAddrs []string, name s
 	return append(sourceAddrs, name)
 }
 
+// appendNATDestinationAddressName resolves a NAT rule's `match
+// destination-address-name <book-entry>` into concrete destination prefixes and
+// appends them to the rule's destination list (#3229). It is the destination
+// twin of appendNATSourceAddressName and shares the same address-book expander
+// (resolveUserspaceAddressBookEntry) the security-policy and source-address-name
+// paths use, so a name-scoped destination matches the same prefixes a literal
+// `match destination-address` would.
+//
+// Fail-closed on an unknown / unresolvable name: the raw token is appended so
+// the destination list stays NON-EMPTY (the rule does not collapse to no
+// destination = skip), while the token itself fails IP parse downstream and
+// contributes no installed table entry — the rule then matches NOTHING rather
+// than broadening. Backstopped at commit by
+// validateNATSourceAddressNameReferencesStrict, which also gates
+// destination-address-name.
+func appendNATDestinationAddressName(cfg *config.Config, destAddrs []string, name string) []string {
+	if name == "" {
+		return destAddrs
+	}
+	if values, ok := resolveUserspaceAddressBookEntry(cfg, name); ok && len(values) > 0 {
+		return append(destAddrs, values...)
+	}
+	// Unknown / empty book entry: keep the list non-empty but unmatchable
+	// (fail-closed). The raw name cannot parse as an IP.
+	return append(destAddrs, name)
+}
+
 func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32) []SourceNATRuleSnapshot {
 	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
 		return nil
@@ -74,6 +101,11 @@ func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
 				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
 			}
+			// #3229: resolve `match destination-address-name` the same way the
+			// source path resolves source-address-name — without this a
+			// name-scoped destination constraint published an EMPTY list =
+			// match-any destination (fail-open).
+			destAddrs = appendNATDestinationAddressName(cfg, destAddrs, rule.Match.DestinationAddressName)
 			var poolAddresses []string
 			var portLow, portHigh uint16
 			var persistentNAT bool
@@ -276,6 +308,21 @@ func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]u
 			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
 				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
 			}
+			// #3229: `match destination-address-name <book-entry>` selects the
+			// translated destination by an address-book reference instead of a
+			// literal prefix. It was parsed into DestinationAddressName but never
+			// resolved into the destination list the DNAT table is keyed on, so a
+			// name-scoped DNAT rule installed NO table entry (silently dropped).
+			// Resolve the name to its concrete prefixes via the same address-book
+			// expander the source path uses (appendNATDestinationAddressName).
+			// Each resolved host installs its own table entry below; a non-host
+			// prefix is stripped to its network address like a literal CIDR
+			// destination. On an unknown name the raw token is appended: it
+			// cannot parse as an IP and is skipped in the emit loop, so the rule
+			// matches NOTHING (fail-closed). The commit-time strict gate
+			// (validateNATSourceAddressNameReferencesStrict) makes the typo
+			// operator-visible.
+			destAddrs = appendNATDestinationAddressName(cfg, destAddrs, rule.Match.DestinationAddressName)
 			if len(destAddrs) == 0 {
 				continue
 			}

--- a/pkg/dataplane/userspace/nat_dest_address_name_3229_test.go
+++ b/pkg/dataplane/userspace/nat_dest_address_name_3229_test.go
@@ -1,0 +1,144 @@
+package userspace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3229: a DNAT rule scoped by `match destination-address-name <book-entry>` is
+// an address-book reference, the destination twin of #2416's source path. The
+// compiler parses it into NATMatch.DestinationAddressName but the snapshot
+// builder must resolve it into the destination list the DNAT table is keyed on —
+// otherwise a name-scoped DNAT installs NO table entry and is silently dropped.
+// appendNATDestinationAddressName resolves the name to its concrete prefixes
+// (reusing the policy-path address-book expander) and appends them so each
+// resolved host installs its own snapshot entry.
+//
+// The compiler-side parse + commit-time reject are covered in pkg/config
+// (compiler_nat_dest_address_name_3229_test.go).
+
+func destAddressBookForNAT() *config.AddressBook {
+	return &config.AddressBook{
+		Addresses: map[string]*config.Address{
+			"svc-a": {Name: "svc-a", Value: "203.0.113.20/32"},
+			"svc-b": {Name: "svc-b", Value: "203.0.113.21/32"},
+		},
+		AddressSets: map[string]*config.AddressSet{
+			"svc-net": {Name: "svc-net", Addresses: []string{"svc-a", "svc-b"}},
+		},
+	}
+}
+
+func dnatCfgWithDestName(name string, litDest string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = destAddressBookForNAT()
+	match := config.NATMatch{
+		DestinationAddressName: name,
+		Protocol:               "tcp",
+		DestinationPort:        443,
+	}
+	if litDest != "" {
+		match.DestinationAddress = litDest
+		match.DestinationAddresses = []string{litDest}
+	}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "scoped", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "name-scoped",
+					Match: match,
+					Then:  config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+	return cfg
+}
+
+// dnatDestinations returns the set of DestinationAddress values emitted for the
+// name-scoped rule.
+func dnatDestinations(snaps []DestinationNATRuleSnapshot) []string {
+	var got []string
+	for _, s := range snaps {
+		if s.Name == "name-scoped" {
+			got = append(got, s.DestinationAddress)
+		}
+	}
+	return got
+}
+
+// TestBuildDestinationNATSnapshotsResolvesDestinationAddressName is the core
+// fail-on-revert pin: a DNAT rule with `match destination-address-name svc-net`
+// must install one table entry per expanded address-set host. Reverting
+// appendNATDestinationAddressName leaves the destination list empty so the rule
+// is `continue`-skipped (no snapshot row) and this test FAILS.
+func TestBuildDestinationNATSnapshotsResolvesDestinationAddressName(t *testing.T) {
+	cfg := dnatCfgWithDestName("svc-net", "")
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	got := dnatDestinations(snaps)
+	want := []string{"203.0.113.20", "203.0.113.21"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("name-scoped DNAT destinations = %+v, want resolved book hosts %+v "+
+			"(empty => destination-address-name not resolved => rule dropped #3229)", got, want)
+	}
+}
+
+// TestBuildDestinationNATSnapshotsDestinationNameAndLiteralUnion: a rule can mix
+// a literal destination with a name; both install entries.
+func TestBuildDestinationNATSnapshotsDestinationNameAndLiteralUnion(t *testing.T) {
+	cfg := dnatCfgWithDestName("svc-a", "198.51.100.9")
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	got := dnatDestinations(snaps)
+	want := []string{"198.51.100.9", "203.0.113.20"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("union DNAT destinations = %+v, want literal+resolved %+v", got, want)
+	}
+}
+
+// TestBuildDestinationNATSnapshotsUnknownDestinationNameFailsClosed: an unknown
+// name resolves to the raw token, which is not a valid IP and is skipped in the
+// emit loop, so the rule installs NO entry (matches nothing) rather than
+// broadening to match-any.
+func TestBuildDestinationNATSnapshotsUnknownDestinationNameFailsClosed(t *testing.T) {
+	cfg := dnatCfgWithDestName("does-not-exist", "")
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if got := dnatDestinations(snaps); len(got) != 0 {
+		t.Fatalf("unknown destination-address-name must install no entry (fail-closed), got %+v", got)
+	}
+}
+
+// TestBuildSourceNATSnapshotsResolvesDestinationAddressName: the source NAT
+// builder carries the destination constraint too, so destination-address-name
+// must resolve there as well (else the source NAT destination scope is lost =
+// fail-open). Reverting the source-builder resolution call leaves
+// DestinationAddresses empty and this FAILS.
+func TestBuildSourceNATSnapshotsResolvesDestinationAddressName(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = destAddressBookForNAT()
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{Name: "scoped", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+			{
+				Name: "name-scoped",
+				Match: config.NATMatch{
+					DestinationAddressName: "svc-net",
+				},
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			},
+		}},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	var got []string
+	for _, s := range snaps {
+		if s.Name == "name-scoped" {
+			got = s.DestinationAddresses
+		}
+	}
+	want := []string{"203.0.113.20/32", "203.0.113.21/32"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("name-scoped SNAT DestinationAddresses = %+v, want resolved book prefixes %+v "+
+			"(empty => destination-address-name not resolved => fail-open #3229)", got, want)
+	}
+}


### PR DESCRIPTION
Closes #3229

## Problem
Junos NAT `match destination-address-name <book-entry>` references a named
address-book entry/host-group as the destination match instead of a literal
prefix. xpf supported `source-address-name` (#2416) but had no destination
twin — there was no `DestinationAddressName` field anywhere, so the token was
parsed-and-dropped: a name-scoped destination NAT rule installed no DNAT table
entry (silently broke the rule), and a name-scoped source-NAT destination
constraint published an empty list = match-any (fail-open).

## Fix (mirrors the #2416 source-address-name mechanism exactly)
- Add `DestinationAddressName` to `NATMatch`; parse it in both the source and
  destination NAT rule blocks of the compiler (`pkg/config/compiler_nat.go`).
- Declare the `destination-address-name` leaf in both NAT match blocks of the
  set-schema (`pkg/config/schema_security.go`) — CLI completion + structural
  commit validation.
- Resolve the name to concrete prefixes at snapshot-build time via
  `appendNATDestinationAddressName` (`pkg/dataplane/userspace/nat.go`), reusing
  the same `resolveUserspaceAddressBookEntry` expander the policy and
  source-address-name paths use, feeding the result into the existing
  destination list. **No new wire field** — each resolved DNAT host installs
  its own exact-host snapshot row through the existing `destination_address`
  field, so the Rust matcher is unchanged. Wired into both
  `buildSourceNATSnapshots` and `buildDestinationNATSnapshots`.
- Hard-reject an undefined name at commit by extending
  `validateNATSourceAddressNameReferencesStrict` to gate BOTH the source and
  destination name leaves. Tolerant load / peer-sync downgrades to a warning
  (#1960); the dataplane fails closed (unresolved name = raw token that cannot
  parse as an IP = rule matches nothing, never match-any).

A literal `match destination-address` is byte-identical. Docs updated
(feature-gaps, config-schema, _Log).

## Tests
- `pkg/config`: parse (SNAT + DNAT), reject-undefined (SNAT + DNAT),
  lenient-warns.
- `pkg/dataplane/userspace`: resolve-DNAT, literal+name union,
  unknown-fail-closed, resolve-in-source-builder.
- **Fail-on-revert:** neutralizing the dest-builder
  `appendNATDestinationAddressName` call turns
  `TestBuildDestinationNATSnapshotsResolvesDestinationAddressName` RED (empty
  destination list, rule dropped); restored byte-identical.
- `go build ./...`, `go test ./pkg/config/ ./pkg/dataplane/...` green;
  `cargo build --release` + `cargo test --release nat::` green (150 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi