### PR TITLE
vrrp: track interfaces robustly across a runtime rename (#2944)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-06-26 — #2944 VRRP link watcher robust to runtime interface rename
+
+- **Timestamp**: 2026-06-26
+- **Action**: The link watcher (`runLinkWatcher`) applied tracked-link state
+  strictly by interface NAME. A runtime kernel rename (e.g. `wan0`->`wan1`)
+  arrives as a SINGLE `RTM_NEWLINK` carrying the SAME ifindex with the NEW
+  name and NO `RTM_DELLINK` for the old name, so an instance tracking `wan0`
+  never saw the event and kept its last (typically up) `trackDown` forever —
+  it never demoted even though the configured interface no longer existed.
+  Fix: route each event through a new `applyLinkEvent(ifindex, name, del, up)`
+  that maintains a per-run ifindex->name cache (`Manager.linkNames`). The
+  event's own up/down is authoritative for instances tracking the event's
+  CURRENT name (normal path, no extra syscall); when the ifindex previously
+  carried a DIFFERENT name, that old name has been renamed away and is
+  re-evaluated against the kernel via `reevaluateTrackedName` (LinkByName
+  fails -> down), so the instance demotes. This matches Junos semantics —
+  tracking follows the configured NAME, and a renamed-away name is treated as
+  down rather than silently following the ifindex to the new name. The
+  production subscribe seam now uses `LinkSubscribeWithOptions{ListExisting:
+  true}` (`netlinkLinkSubscribe`) so the cache is seeded from current kernel
+  state at watcher start, closing the cold-start window for an interface up
+  since boot. `linkNames` is reset in `resetRunStateLocked` so a Stop()->Start()
+  re-warms cleanly. The poller fallback (`pollTrackedLinks`) already handled
+  rename correctly (LinkByName err -> down), so it is unchanged. Added
+  `TestLinkWatcher_RenameAwayDemotes`; fail-on-revert verified (reverting the
+  watcher to name-only matching reds the rename test, normal up/down stays
+  green). `go build ./...` + `go test -race ./pkg/vrrp/...` + `go test
+  ./pkg/daemon/...` green.
+- **File(s)**: pkg/vrrp/track.go, pkg/vrrp/manager.go,
+  pkg/vrrp/track_test.go, docs/feature-coverage.md, _Log.md
+
 ## 2026-06-26 — #2900 VRRP: re-validate an armed preempt hold-timer
 
 - **Timestamp**: 2026-06-26

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -71,7 +71,12 @@ the userspace dataplane admission boundary is in
 - **Chassis cluster** with ~60ms failover (30ms VRRP intervals).
 - **Native VRRPv3**: Go state machine, AF_PACKET, per-instance sockets,
   IPv6 NODAD, 30ms RETH advertisements, async GARP burst, single-interface
-  tracking (nested `track-interface <if> priority-cost <n>`).
+  tracking (nested `track-interface <if> priority-cost <n>`). Tracking
+  follows the configured interface NAME (Junos semantics) and is robust to a
+  runtime kernel rename: the link watcher keys rename detection on the stable
+  ifindex, so when the tracked name is renamed away (a single `RTM_NEWLINK`
+  with the same ifindex but a new name, no `RTM_DELLINK`) the instance demotes
+  rather than holding stale "up" state (#2944).
 - **Bondless RETH**: VRRP on physical member interfaces, per-node virtual
   MAC (`02:bf:72:CC:RR:NN`), no Linux bonding required.
 - **Session sync**: incremental 1s sweep + ring buffer + GC delete

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -47,6 +47,16 @@ type Manager struct {
 	linkState      func(name string) (bool, error)
 	subscribeLinks func(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error
 
+	// linkNames is the link-watcher's ifindex -> current-name cache (#2944).
+	// The kernel emits a runtime rename as a SINGLE RTM_NEWLINK carrying the
+	// SAME ifindex with the NEW name and NO RTM_DELLINK for the old name, so
+	// name-only matching would leave an instance tracking the old name stuck at
+	// its last (typically up) state forever. Keying on the stable ifindex lets
+	// the watcher notice that an ifindex's name CHANGED and re-evaluate the old
+	// (now-vanished) name so the tracking instance demotes. Guarded by mu;
+	// owned by the singleton link-watcher goroutine and reset per run.
+	linkNames map[int]string
+
 	// Source-address watcher (#2528): ONE singleton goroutine subscribing to
 	// netlink ADDRESS updates so an instance's cached advert source
 	// (localIP/localIPv6) is re-resolved when the interface's address changes
@@ -114,8 +124,9 @@ func NewManager() *Manager {
 		instances:          make(map[instanceKey]*vrrpInstance),
 		eventCh:            make(chan VRRPEvent, 256),
 		watcherStop:        make(chan struct{}),
+		linkNames:          make(map[int]string),
 		linkState:          netlinkLinkState,
-		subscribeLinks:     netlink.LinkSubscribe,
+		subscribeLinks:     netlinkLinkSubscribe,
 		subscribeAddrs:     netlink.AddrSubscribe,
 		resolveLinkName:    netlinkLinkName,
 		resolveIface:       net.InterfaceByName,
@@ -163,6 +174,10 @@ func (m *Manager) resetRunStateLocked() {
 	m.closeEventOnce = sync.Once{}
 	m.watcherRunning = false
 	m.addrWatcherRunning = false
+	// Drop the previous run's ifindex->name cache (#2944): a re-subscribe
+	// re-seeds it from current kernel state (ListExisting), so a stale mapping
+	// from before the Stop() must not survive into the new run.
+	m.linkNames = make(map[int]string)
 }
 
 // Stop stops all instances, removes VIPs, and cancels the context.

--- a/pkg/vrrp/track.go
+++ b/pkg/vrrp/track.go
@@ -123,7 +123,11 @@ func (m *Manager) clearLinkWatcherLatch(stop chan struct{}) {
 // subscribes to netlink link updates and pushes trackDown into every
 // instance tracking the affected interface. The tracked-ifname →
 // instance mapping is re-read from the manager under lock on EVERY
-// event — instance churn is never captured stale. Cancellation follows
+// event — instance churn is never captured stale. Each event is fed
+// through applyLinkEvent, which keys on the stable ifindex so a runtime
+// kernel rename (a single RTM_NEWLINK with the same ifindex but a new
+// name) demotes an instance tracking the now-vanished old name (#2944).
+// Cancellation follows
 // the done-channel pattern (pkg/daemon/daemon_flow.go): m.watcherStop
 // is closed from Manager.Stop and the netlink subscription observes the
 // same channel. On subscribe failure (or unexpected subscription close)
@@ -162,8 +166,9 @@ func (m *Manager) runLinkWatcher(stop chan struct{}) {
 			if attrs == nil {
 				continue
 			}
-			up := u.Header.Type != unix.RTM_DELLINK && linkAttrsUp(attrs)
-			m.applyTrackedLinkState(attrs.Name, up)
+			del := u.Header.Type == unix.RTM_DELLINK
+			up := !del && linkAttrsUp(attrs)
+			m.applyLinkEvent(attrs.Index, attrs.Name, del, up)
 		}
 	}
 }
@@ -205,6 +210,64 @@ func (m *Manager) pollTrackedLinks() {
 	}
 }
 
+// applyLinkEvent feeds a single netlink link event into interface tracking,
+// robust to a runtime kernel rename (#2944).
+//
+// The kernel emits a rename (e.g. wan0 -> wan1) as a SINGLE RTM_NEWLINK that
+// carries the SAME ifindex with the NEW name and NO RTM_DELLINK for the old
+// name. The pre-#2944 watcher applied state strictly by the event's name, so
+// an instance tracking the old name never saw the event and kept its last
+// (typically up) trackDown forever — it never demoted even though the
+// configured interface no longer existed.
+//
+// We key rename detection on the stable ifindex via the m.linkNames cache:
+//   - The event's own up/down is authoritative for instances tracking the
+//     event's CURRENT name (the normal up/down/delete path, no extra syscall).
+//   - When this ifindex previously carried a DIFFERENT name, that old name has
+//     been renamed away. We re-evaluate it against the kernel (linkState):
+//     LinkByName fails for a name that no longer exists, so the instance
+//     tracking it demotes. This matches Junos semantics — tracking follows the
+//     configured NAME, and a name that has been renamed away is treated as
+//     down (it does NOT silently follow the ifindex to the new name).
+//
+// The cache is seeded at watcher start by the ListExisting subscribe
+// (netlinkLinkSubscribe), so an interface that has been up since boot — and
+// thus produced no prior event — is already known when its first runtime event
+// (the rename) arrives.
+func (m *Manager) applyLinkEvent(ifindex int, name string, del, up bool) {
+	m.mu.Lock()
+	prev, hadPrev := m.linkNames[ifindex]
+	if del {
+		delete(m.linkNames, ifindex)
+	} else {
+		m.linkNames[ifindex] = name
+	}
+	m.mu.Unlock()
+
+	// Apply the event's operational state to instances tracking the event's
+	// name. A delete is unconditionally down regardless of the carried attrs.
+	if name != "" {
+		m.applyTrackedLinkState(name, up && !del)
+	}
+
+	// Rename / replacement detection: this ifindex used to carry a different
+	// name, which is now gone from it. Settle that old name against current
+	// kernel state so an instance tracking the renamed-away name demotes.
+	if hadPrev && prev != "" && prev != name {
+		m.reevaluateTrackedName(prev)
+	}
+}
+
+// reevaluateTrackedName queries current kernel state for a single interface
+// name and applies it to every instance tracking that name (#2944). Used to
+// settle the OLD name after a rename: linkState (LinkByName) returns an error
+// for a name that no longer resolves to any link, which counts as down — the
+// same convention pollTrackedLinks uses.
+func (m *Manager) reevaluateTrackedName(name string) {
+	up, err := m.linkState(name)
+	m.applyTrackedLinkState(name, err == nil && up)
+}
+
 // applyTrackedLinkState updates trackDown on every instance tracking
 // ifName. Takes only the manager read lock; setTrackDown takes the
 // per-instance lock (no reverse ordering exists — instances never take
@@ -236,6 +299,21 @@ func (m *Manager) seedTrackState(vi *vrrpInstance, trackIface string) {
 		return
 	}
 	vi.setTrackDown(!up)
+}
+
+// netlinkLinkSubscribe is the production subscribeLinks seam. It subscribes to
+// netlink link updates with ListExisting=true so the kernel replays every
+// current link as an RTM_NEWLINK immediately after subscribe. This seeds the
+// watcher's ifindex->name cache (m.linkNames) from current state, so a
+// runtime rename of an interface that has been up since boot — and thus
+// produced no prior event — is still detected on its first event (#2944).
+// ListExisting only front-loads current state; the watcher's event handling is
+// idempotent, so the replay sets each tracked interface to its current up/down
+// (consistent with seedTrackState) and matches nothing for untracked names.
+func netlinkLinkSubscribe(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error {
+	return netlink.LinkSubscribeWithOptions(ch, done, netlink.LinkSubscribeOptions{
+		ListExisting: true,
+	})
 }
 
 // netlinkLinkState is the production linkState seam: report whether the

--- a/pkg/vrrp/track_test.go
+++ b/pkg/vrrp/track_test.go
@@ -299,6 +299,78 @@ func TestLinkWatcher_EventUpdatesTrackedInstances(t *testing.T) {
 	}
 }
 
+// TestLinkWatcher_RenameAwayDemotes covers #2944: a runtime kernel rename of a
+// tracked interface (wan0 -> wan1) arrives as a SINGLE RTM_NEWLINK carrying the
+// SAME ifindex with the NEW name and NO RTM_DELLINK for the old name. An
+// instance tracking the configured name (wan0) must DEMOTE because the named
+// interface no longer exists — it must NOT silently follow the ifindex to wan1
+// and stay up. Reverting applyLinkEvent to the old name-only matching makes the
+// rename event match nothing and the tracker stays at full priority (RED).
+func TestLinkWatcher_RenameAwayDemotes(t *testing.T) {
+	m := NewManager()
+	defer stopManagerForTest(m)
+	// wan0 no longer resolves after the rename (LinkByName fails -> down); any
+	// other name is up. This is what the kernel does post-rename.
+	m.linkState = func(name string) (bool, error) {
+		if name == "wan0" {
+			return false, errors.New("no such link")
+		}
+		return true, nil
+	}
+
+	updates := make(chan chan<- netlink.LinkUpdate, 1)
+	m.subscribeLinks = func(ch chan<- netlink.LinkUpdate, done <-chan struct{}) error {
+		updates <- ch
+		return nil
+	}
+	m.subscribeAddrs = func(ch chan<- netlink.AddrUpdate, done <-chan struct{}) error { return nil }
+
+	tracker := newTrackTestInstance(200, 50, "wan0")
+	m.mu.Lock()
+	m.instances[instanceKey{iface: "eth0", groupID: 101}] = tracker
+	m.ensureLinkWatcherLocked()
+	m.mu.Unlock()
+
+	var ch chan<- netlink.LinkUpdate
+	select {
+	case ch = <-updates:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher never subscribed")
+	}
+
+	const ifindex = 5
+	// First sighting at ifindex 5 with the configured name wan0, up. Represents
+	// the ListExisting seed / a prior up event; warms the ifindex->name cache.
+	ch <- netlink.LinkUpdate{
+		Header: unix.NlMsghdr{Type: unix.RTM_NEWLINK},
+		Link:   &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: ifindex, Name: "wan0", OperState: netlink.OperUp}},
+	}
+	// Settle: tracker should be up (priority 200) after the wan0-up event.
+	deadline := time.After(2 * time.Second)
+	for tracker.getPriority() != 200 {
+		select {
+		case <-deadline:
+			t.Fatalf("tracker priority = %d, want 200 after wan0 up event", tracker.getPriority())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// The rename: SAME ifindex, NEW name wan1, still OperUp, NO RTM_DELLINK for
+	// wan0. The instance tracking wan0 must demote.
+	ch <- netlink.LinkUpdate{
+		Header: unix.NlMsghdr{Type: unix.RTM_NEWLINK},
+		Link:   &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: ifindex, Name: "wan1", OperState: netlink.OperUp}},
+	}
+	deadline = time.After(2 * time.Second)
+	for tracker.getPriority() != 150 {
+		select {
+		case <-deadline:
+			t.Fatalf("tracker priority = %d, want 150 after wan0 renamed away to wan1", tracker.getPriority())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 func TestPollTrackedLinks(t *testing.T) {
 	m := NewManager()
 	defer stopManagerForTest(m)


### PR DESCRIPTION
Closes #2944

## Problem

`pkg/vrrp/track.go` `runLinkWatcher` (the primary event-driven path) applied tracked-link state strictly by interface NAME. A runtime kernel rename (e.g. `wan0`->`wan1`) arrives as a SINGLE `RTM_NEWLINK` carrying the SAME ifindex with the NEW name and NO `RTM_DELLINK` for the old name. The watcher processed the event for the new name but never updated any instance tracking the old name, so a VRRP instance tracking `wan0` kept its last (typically up) `trackDown` value forever — it never demoted even though the configured interface no longer existed, silently breaking interface-tracking failover.

## Fix

Route every event through a new `applyLinkEvent(ifindex, name, del, up)` that keys rename detection on the stable ifindex:

- A per-run ifindex->name cache (`Manager.linkNames`) records the current name for each ifindex.
- The event's own up/down stays authoritative for instances tracking the event's CURRENT name (normal up/down/delete path, no extra syscall) — existing behavior preserved.
- When the ifindex previously carried a DIFFERENT name, that old name has been renamed away. `reevaluateTrackedName` re-queries it against the kernel (`LinkByName`) — a name that no longer resolves counts as down — so the instance demotes.

This matches **Junos semantics**: tracking follows the configured NAME, and a name that has been renamed away is treated as **down** rather than silently following the ifindex to the new name (the interpretation the issue calls for: "never demotes even though wan0 no longer exists" → correct behavior is to DEMOTE).

The production subscribe seam now uses `LinkSubscribeWithOptions{ListExisting: true}` (`netlinkLinkSubscribe`) so the cache is seeded from current kernel state at watcher start, closing the cold-start window for an interface up since boot. `linkNames` is reset in `resetRunStateLocked` so a Stop()->Start() re-warms cleanly. The poller fallback (`pollTrackedLinks`) already handled rename correctly (`LinkByName` err → down) and is unchanged.

## Tests

- Added `TestLinkWatcher_RenameAwayDemotes`: instance tracks `wan0`; first sighting at ifindex 5 (warms cache), then a rename event (same ifindex, new name `wan1`, no `RTM_DELLINK`) → instance demotes.
- **Fail-on-revert verified**: reverting the watcher to name-only matching reds `TestLinkWatcher_RenameAwayDemotes` (tracker stays 200, want 150) while `TestLinkWatcher_EventUpdatesTrackedInstances` (normal up/down) stays green.
- Clamp `[1,254]` and owner-255 exemption unaffected (`TestGetPriority_TrackMatrix`).

`go build ./...` + `go test -race ./pkg/vrrp/...` + `go test ./pkg/daemon/...` all green.

NOTE: VRRP track/failover change — parent runs `make test-failover` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi