### PR TITLE
vrrp: receive VRRP adverts via ALLMULTI instead of PROMISC (#2870)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-06-26 — #2870 VRRP AF_PACKET receiver: ALLMULTI instead of PROMISC
+
+- **Timestamp**: 2026-06-26
+- **Action**: `openAfPacketReceiver` (`pkg/vrrp/manager.go`) put the capture
+  interface into full promiscuous mode (`PACKET_MR_PROMISC`), which disables
+  the NIC's hardware unicast filter and copies every frame on the segment to
+  the host CPU — a perf hit on data-bearing RETH VLANs and a tenant-traffic
+  leak to the raw control-plane socket. Replaced with `PACKET_MR_ALLMULTI`
+  (receive-all-multicast) via a new testable helper `buildAfPacketMembership`.
+  VRRP adverts always use a multicast destination MAC (IPv4 224.0.0.18 ->
+  01:00:5e:00:00:12, IPv6 ff02::12 -> 33:33:00:00:00:12), so ALLMULTI delivers
+  every advert PROMISC did while restoring unicast filtering. ALLMULTI is
+  provably non-regressive: on a VLAN sub-interface both flags propagate to the
+  physical parent through the same kernel path (vlan_dev_change_rx_flags ->
+  dev_set_allmulti / dev_set_promiscuity). Specific-group PACKET_MR_MULTICAST
+  was NOT chosen: its dev_mc_add -> dev_mc_sync -> VF rx-mode propagation is
+  unconfirmed on the mlx5 SR-IOV VFs under a VLAN subif, and a silent MC-filter
+  miss there = split-brain (STOP-ON-FORK; group-MAC constants left in place for
+  a future live-validated switch). cBPF delivery filter unchanged.
+- **File(s)**: pkg/vrrp/manager.go, pkg/vrrp/afpacket_membership_test.go,
+  docs/vrrp-afpacket-receiver.md, _Log.md
+- **Validation**: `go build ./...`; `go test ./pkg/vrrp/... ./pkg/daemon/...`
+  green. New unit tests TestAfPacketMembershipUsesAllmultiNotPromisc (membership
+  type) + TestVRRPGroupMACsAreCorrect (group MACs); fail-on-revert confirmed
+  (flip helper back to PROMISC -> RED). Live `make test-failover` on the loss
+  userspace cluster is the gating check before merge (broken receiver = no
+  failover).
+
 ## 2026-06-26 — #2944 VRRP link watcher robust to runtime interface rename
 
 - **Timestamp**: 2026-06-26

--- a/docs/vrrp-afpacket-receiver.md
+++ b/docs/vrrp-afpacket-receiver.md
@@ -1,0 +1,78 @@
+# VRRP AF_PACKET receiver — multicast membership
+
+The native VRRPv3 state machine (`pkg/vrrp`) receives advertisements through a
+per-instance `AF_PACKET` `SOCK_RAW` socket opened by `openAfPacketReceiver`
+(`pkg/vrrp/manager.go`). This socket is used on VLAN sub-interfaces (e.g.
+`reth0.50`, `reth0.80`) and in generic-XDP environments where a raw IP socket
+(`IPPROTO_VRRP = 112`) does not reliably receive multicast: the AF_PACKET tap
+fires before generic XDP in the kernel receive path, so it always sees the
+frame.
+
+The socket binds the **VLAN sub-interface ifindex** (`vi.iface.Index`), so it
+observes de-tagged frames; the cBPF program attached to it accepts both
+untagged and 802.1Q-tagged VRRP for IPv4 and IPv6 and is the precise delivery
+gate.
+
+## Membership: ALLMULTI, not PROMISC (#2870)
+
+The receiver must put the NIC into a mode that delivers VRRP's multicast
+advertisements. Historically it requested `PACKET_MR_PROMISC` (full
+promiscuous mode). That delivered the adverts, but it also disabled the NIC's
+hardware unicast MAC filter, so on a data-bearing RETH VLAN the NIC copied
+**every** unicast frame on the segment to the host CPU (the cBPF then dropped
+the non-VRRP ones). Two problems:
+
+- **Performance**: all segment unicast/broadcast/multicast is DMA'd to the host
+  and walked by the BPF filter instead of being dropped in hardware.
+- **Isolation**: other tenants' unicast traffic on the shared L2 domain is
+  exposed to a raw socket held by the control plane.
+
+The receiver now requests **`PACKET_MR_ALLMULTI`** (receive-all-multicast). The
+membership request is built by the testable helper `buildAfPacketMembership`.
+
+### Why ALLMULTI is correct and non-regressive
+
+VRRP advertisements are **always** sent to a multicast destination MAC:
+
+| Family | Multicast IP | Ethernet destination MAC |
+| ------ | ------------ | ------------------------ |
+| IPv4   | 224.0.0.18   | `01:00:5e:00:00:12`      |
+| IPv6   | ff02::12     | `33:33:00:00:00:12`      |
+
+(See `vrrpGroupMACv4` / `vrrpGroupMACv6` in `manager.go`.)
+
+ALLMULTI delivers every frame with a multicast destination MAC. Therefore every
+VRRP advert frame that PROMISC delivered is also delivered under ALLMULTI — the
+only frames no longer delivered are unicast frames not addressed to our own MAC,
+which is exactly the leak being closed. The cBPF filter is unchanged.
+
+Crucially, on a VLAN sub-interface both PROMISC and ALLMULTI propagate to the
+physical parent device through the **same** kernel path —
+`vlan_dev_change_rx_flags` calls `dev_set_promiscuity` / `dev_set_allmulti` on
+the real device. So the propagation mechanism that made PROMISC work on the
+mlx5 SR-IOV VFs makes ALLMULTI work identically. This makes ALLMULTI provably
+non-regressive for advert reception relative to PROMISC.
+
+### Why not specific-group `PACKET_MR_MULTICAST`
+
+Joining only the two VRRP group MACs via `PACKET_MR_MULTICAST` (hardware
+filtering to just the group instead of all multicast) is the theoretical
+optimum and would be a further improvement. It is **not** used yet because it
+routes through a different propagation path
+(`dev_mc_add` → `dev_mc_sync` → the VF's `ndo_set_rx_mode` programming) whose
+reliability on the mlx5 SR-IOV VFs under a VLAN sub-interface has not been
+confirmed on the loss userspace HA cluster (`reth0.50` / `reth0.80`). A silent
+multicast-filter miss there would drop adverts and cause split-brain, so the
+conservative ALLMULTI membership is used. A future change may switch to
+specific-group membership once it is live-validated that `PACKET_MR_MULTICAST`
+delivers VRRP adverts on those VLAN sub-interfaces/VFs (and `test/failover`
+still passes). The group-MAC constants are already in place for that work.
+
+## Validation
+
+- Unit: `TestAfPacketMembershipUsesAllmultiNotPromisc` asserts the membership is
+  `PACKET_MR_ALLMULTI` (not `PACKET_MR_PROMISC`); `TestVRRPGroupMACsAreCorrect`
+  pins the two group MACs. Fail-on-revert verified.
+- Live: `make test-failover` on the loss userspace cluster must continue to show
+  VRRP adverts arriving and zero-drop failover — a broken receiver means no
+  failover. This is the gating check before merge.

--- a/pkg/vrrp/afpacket_membership_test.go
+++ b/pkg/vrrp/afpacket_membership_test.go
@@ -1,0 +1,49 @@
+package vrrp
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestAfPacketMembershipUsesAllmultiNotPromisc asserts that the VRRP AF_PACKET
+// receiver requests PACKET_MR_ALLMULTI (receive all multicast) rather than
+// PACKET_MR_PROMISC (receive everything). PROMISC disabled the NIC's unicast
+// hardware filter, copying every tenant frame on the segment to the host CPU
+// and leaking other tenants' unicast traffic to the raw capture socket (#2870).
+// ALLMULTI still delivers VRRP's multicast adverts while preserving unicast
+// filtering.
+//
+// Fail-on-revert: changing buildAfPacketMembership back to PACKET_MR_PROMISC
+// makes this test fail.
+func TestAfPacketMembershipUsesAllmultiNotPromisc(t *testing.T) {
+	const ifIndex = 7
+	mreq := buildAfPacketMembership(ifIndex)
+
+	if mreq.Type == unix.PACKET_MR_PROMISC {
+		t.Fatalf("VRRP receiver membership uses PACKET_MR_PROMISC; want ALLMULTI/MULTICAST (#2870)")
+	}
+	if mreq.Type != unix.PACKET_MR_ALLMULTI {
+		t.Fatalf("VRRP receiver membership type = %#x; want PACKET_MR_ALLMULTI (%#x)",
+			mreq.Type, unix.PACKET_MR_ALLMULTI)
+	}
+	if mreq.Ifindex != int32(ifIndex) {
+		t.Fatalf("VRRP receiver membership ifindex = %d; want %d", mreq.Ifindex, ifIndex)
+	}
+}
+
+// TestVRRPGroupMACsAreCorrect pins the VRRP advertisement multicast destination
+// MACs. IPv4 224.0.0.18 maps to 01:00:5e:00:00:12 and IPv6 ff02::12 maps to
+// 33:33:00:00:00:12. These are the groups ALLMULTI must deliver (and the MACs a
+// future PACKET_MR_MULTICAST membership would join), so guard the constants
+// against typos.
+func TestVRRPGroupMACsAreCorrect(t *testing.T) {
+	wantV4 := [6]byte{0x01, 0x00, 0x5e, 0x00, 0x00, 0x12}
+	wantV6 := [6]byte{0x33, 0x33, 0x00, 0x00, 0x00, 0x12}
+	if vrrpGroupMACv4 != wantV4 {
+		t.Fatalf("vrrpGroupMACv4 = %x; want %x", vrrpGroupMACv4, wantV4)
+	}
+	if vrrpGroupMACv6 != wantV6 {
+		t.Fatalf("vrrpGroupMACv6 = %x; want %x", vrrpGroupMACv6, wantV6)
+	}
+}

--- a/pkg/vrrp/manager.go
+++ b/pkg/vrrp/manager.go
@@ -831,6 +831,32 @@ func openPerInterfaceSocket(ifName string, iface *net.Interface, isVLAN bool) (*
 // flags (notably SOCK_CLOEXEC) without needing CAP_NET_RAW.
 var afPacketSocket = unix.Socket
 
+// VRRP advertisement multicast destination MACs. IPv4 VRRP adverts go to
+// 224.0.0.18 which maps to the Ethernet multicast MAC 01:00:5e:00:00:12; IPv6
+// VRRP adverts go to ff02::12 which maps to 33:33:00:00:00:12. These are kept
+// as named constants for documentation and for any future PACKET_MR_MULTICAST
+// (specific-group) membership; the current receiver joins via ALLMULTI (see
+// buildAfPacketMembership / #2870).
+var (
+	vrrpGroupMACv4 = [6]byte{0x01, 0x00, 0x5e, 0x00, 0x00, 0x12}
+	vrrpGroupMACv6 = [6]byte{0x33, 0x33, 0x00, 0x00, 0x00, 0x12}
+)
+
+// buildAfPacketMembership builds the PACKET_ADD_MEMBERSHIP request that the
+// VRRP AF_PACKET receiver applies to its capture socket. It returns a
+// PACKET_MR_ALLMULTI membership (receive all multicast) rather than
+// PACKET_MR_PROMISC (receive everything) -- ALLMULTI delivers the VRRP group
+// multicast adverts without disabling unicast hardware filtering, fixing the
+// tenant-unicast leak and the all-frames-to-CPU overhead of promisc (#2870).
+// Factored out so a unit test can assert the membership type without needing
+// CAP_NET_RAW.
+func buildAfPacketMembership(ifIndex int) unix.PacketMreq {
+	return unix.PacketMreq{
+		Ifindex: int32(ifIndex),
+		Type:    unix.PACKET_MR_ALLMULTI,
+	}
+}
+
 // openAfPacketReceiver opens an AF_PACKET SOCK_RAW socket bound to the
 // given interface for receiving VRRP packets. This is used on VLAN sub-
 // interfaces where raw IP sockets don't reliably receive multicast.
@@ -867,16 +893,35 @@ func openAfPacketReceiver(ifIndex int) (int, error) {
 		return -1, fmt.Errorf("set rcvtimeo: %w", err)
 	}
 
-	// Promiscuous mode is required to receive multicast frames from
-	// remote peers on VLAN sub-interfaces. Without it, only locally-
-	// generated multicast (IP-layer loopback) is delivered. This matches
-	// tcpdump's behavior, which also sets PACKET_MR_PROMISC.
-	mreq := &unix.PacketMreq{
-		Ifindex: int32(ifIndex),
-		Type:    unix.PACKET_MR_PROMISC,
-	}
-	if err := unix.SetsockoptPacketMreq(fd, unix.SOL_PACKET, unix.PACKET_ADD_MEMBERSHIP, mreq); err != nil {
-		slog.Debug("vrrp: failed to set promisc", "err", err)
+	// Put the NIC into receive-all-multicast (ALLMULTI) mode rather than full
+	// promiscuous mode (#2870). VRRP advertisements are ALWAYS sent to a
+	// multicast destination MAC -- 01:00:5e:00:00:12 for IPv4 (224.0.0.18) and
+	// 33:33:00:00:00:12 for IPv6 (ff02::12) -- so ALLMULTI delivers every frame
+	// the old PROMISC membership delivered for VRRP, while leaving hardware
+	// UNICAST filtering intact. That closes two PROMISC problems: the NIC no
+	// longer copies every tenant unicast frame on a data-bearing RETH VLAN to
+	// the host CPU (perf), and the raw capture socket no longer sees other
+	// tenants' unicast traffic (isolation).
+	//
+	// ALLMULTI is provably non-regressive for VRRP reception relative to the
+	// previous PROMISC: on a VLAN sub-interface both flags propagate to the
+	// physical parent through the SAME kernel path (vlan_dev_change_rx_flags ->
+	// dev_set_allmulti / dev_set_promiscuity on the real device), and every
+	// frame PROMISC delivered with a multicast destination MAC is also
+	// delivered under ALLMULTI. The only frames no longer delivered are unicast
+	// frames not addressed to our MAC -- exactly the leak we are closing.
+	//
+	// A tighter PACKET_MR_MULTICAST membership for just the two VRRP group MACs
+	// (hardware-filtering to the group instead of all multicast) is the
+	// theoretical optimum, but it routes through a different propagation path
+	// (dev_mc_add -> dev_mc_sync -> the VF's rx-mode programming) whose
+	// reliability on the mlx5 SR-IOV VFs under a VLAN sub-interface is not
+	// confirmed; a silent MC-filter miss there would drop adverts and cause
+	// split-brain. ALLMULTI is the conservative correct choice. See
+	// docs/vrrp-afpacket-receiver.md.
+	mreq := buildAfPacketMembership(ifIndex)
+	if err := unix.SetsockoptPacketMreq(fd, unix.SOL_PACKET, unix.PACKET_ADD_MEMBERSHIP, &mreq); err != nil {
+		slog.Debug("vrrp: failed to set allmulti", "err", err)
 	}
 
 	// BPF filter: accept VRRP for IPv4, IPv6, and 802.1Q-tagged variants.


### PR DESCRIPTION
Closes #2870

## Problem
`openAfPacketReceiver` (`pkg/vrrp/manager.go`) put the VRRP capture interface into full promiscuous mode (`PACKET_MR_PROMISC`). The cBPF filter only limits *delivery* to the raw socket; PROMISC still disables the NIC's hardware unicast MAC filter, so the NIC copies **every** frame on the segment to the host CPU. On a data-bearing RETH VLAN (e.g. `reth0.80`) this is a measurable CPU overhead and an isolation problem — other tenants' unicast traffic on the shared L2 domain is exposed to a raw socket held by the control plane.

## Fix
Replace `PACKET_MR_PROMISC` with **`PACKET_MR_ALLMULTI`** (receive-all-multicast), via a new testable helper `buildAfPacketMembership`. VRRP adverts always use a multicast destination MAC (IPv4 `224.0.0.18` → `01:00:5e:00:00:12`, IPv6 `ff02::12` → `33:33:00:00:00:12`), so ALLMULTI delivers every advert PROMISC delivered while restoring unicast hardware filtering — closing the leak and the all-frames-to-CPU overhead. The cBPF delivery filter is unchanged.

## Why ALLMULTI, not specific-group PACKET_MR_MULTICAST
ALLMULTI is **provably non-regressive** for advert reception vs. PROMISC: the socket binds the VLAN sub-interface ifindex, and on a VLAN both PROMISC and ALLMULTI propagate to the physical parent through the **same** kernel path (`vlan_dev_change_rx_flags` → `dev_set_allmulti` / `dev_set_promiscuity`). Every multicast-destination frame PROMISC delivered is delivered under ALLMULTI; only non-our-MAC unicast (the leak) stops.

Specific-group `PACKET_MR_MULTICAST` (HW-filter just the two VRRP MACs) is the theoretical optimum but is **deliberately not used yet** (STOP-ON-FORK): it routes through a different path (`dev_mc_add` → `dev_mc_sync` → VF rx-mode programming) whose reliability on the **mlx5 SR-IOV VFs under a VLAN sub-interface** (`reth0.50`/`reth0.80`) is unconfirmed, and a silent MC-filter miss there = dropped adverts = split-brain. The group-MAC constants (`vrrpGroupMACv4`/`v6`) are left in place for a future switch once `PACKET_MR_MULTICAST` delivery is live-validated and `test-failover` still passes.

## Tests
- `TestAfPacketMembershipUsesAllmultiNotPromisc` — asserts membership type is `PACKET_MR_ALLMULTI`, not `PACKET_MR_PROMISC`. **Fail-on-revert verified** (flip helper back to PROMISC → RED).
- `TestVRRPGroupMACsAreCorrect` — pins `01:00:5e:00:00:12` (v4) and `33:33:00:00:00:12` (v6).
- `go build ./...` and `go test ./pkg/vrrp/... ./pkg/daemon/...` green.

## Gating before merge
`make test-failover` on the loss userspace cluster MUST pass — a broken receiver = no failover. If adverts stop arriving under ALLMULTI, the multicast approach is wrong for these VFs (not expected, given the shared VLAN→parent propagation path).

Doc: `docs/vrrp-afpacket-receiver.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi