### PR TITLE
HA: run owner-RG export ack-wait off the ServerState lock (#2962)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-06-26 — #2962 HA: owner-RG export ack-wait off the ServerState lock
+
+- **Timestamp**: 2026-06-26
+- **Action**: The control-socket dispatcher held the global
+  `Mutex<ServerState>` across the ENTIRE request `match`, including
+  `export_owner_rg_sessions`, whose `afxdp/ha.rs` ack-wait blocks up to 15 s
+  for every worker to ack the export sequence. A slow/stalled worker therefore
+  froze the whole control plane (status poll, session installs, snapshot/FIB
+  bumps, HA state updates) for up to 15 s — on the failover-critical path. Fix:
+  split the export into a locked KICK phase and a lock-free WAIT phase.
+  `Coordinator::kick_owner_rg_export` (under the lock) enqueues the
+  `ExportOwnerRGSessions` command to every worker, bumps `export_seq`, and
+  snapshots the lock-free handles the wait needs — the per-worker
+  `session_export_ack` atomics (`Arc<AtomicU64>`) and per-binding delta buffers
+  (`Arc<BindingLiveState>`) — returning an `OwnerRgExportWait`. The dispatcher
+  drops the `ServerState` lock, then runs `OwnerRgExportWait::wait_and_collect`
+  (the 15 s ack-wait + delta drain) off-lock, re-deriving status afterward under
+  a fresh short-lived lock. No TOCTOU: the worker set is mutated only by other
+  lock-holding handlers, so it is stable for the lock-free window; the worker
+  threads only advance monotonic ack atomics + push deltas (both Arc-shared,
+  lock-free). 15 s deadline + timeout error preserved verbatim. The old
+  single-call `export_owner_rg_sessions` wrapper was removed (unused after the
+  split). Tests (fail-on-revert proven): server-level
+  `export_owner_rg_does_not_hold_state_lock_during_ack_wait` (RED at
+  "status poll blocked 652ms ... lock held across the ack-wait" when the wait is
+  restored under the lock) + afxdp `kick_owner_rg_export_empty_set_is_noop...`
+  and `kick_owner_rg_export_enqueues_command_then_wait_completes_on_ack`. Added
+  a `#[cfg(test)]` `Coordinator::test_install_export_worker` seam. cargo
+  build/test (ha/export/server/session_glue) green.
+  **File(s)**: userspace-dp/src/afxdp/ha.rs,
+  userspace-dp/src/afxdp/mod.rs,
+  userspace-dp/src/afxdp/coordinator/mod.rs,
+  userspace-dp/src/afxdp/ha_tests.rs,
+  userspace-dp/src/server/handlers/mod.rs,
+  userspace-dp/src/server/handlers/export.rs,
+  userspace-dp/src/server/tests.rs,
+  docs/session-sync-architecture.md
+
 ## 2026-06-26 — #2900 VRRP: re-validate an armed preempt hold-timer
 
 - **Timestamp**: 2026-06-26

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -339,6 +339,32 @@ all userspace sessions owned by the demoting RGs. This is not the same thing as
 the steady-state delta drain. It is an explicit republish step used to reduce
 handoff loss.
 
+**The export ack-wait runs OFF the global `ServerState` lock (#2962).** The
+helper-side control-socket dispatcher (`server/handlers/mod.rs`) holds a single
+`Mutex<ServerState>` across its request `match`, which serializes every control
+RPC (status poll, session install, snapshot/FIB bump, HA state update, neighbor
+update). The owner-RG export blocks up to 15 s waiting for every worker to ack
+the export sequence — so doing that wait under the lock would freeze the whole
+control plane for up to 15 s whenever a worker is slow or stalled (exactly the
+failover-critical moment). The handler is therefore split into two phases:
+
+- **Locked phase** (`Coordinator::kick_owner_rg_export`): enqueue the
+  `ExportOwnerRGSessions` command to every worker, bump `export_seq`, and
+  snapshot the lock-free handles the wait needs — the per-worker
+  `session_export_ack` atomics (`Arc<AtomicU64>`) and the per-binding delta
+  buffers (`Arc<BindingLiveState>`). Returns an `OwnerRgExportWait` immediately.
+- **Lock-free phase** (`OwnerRgExportWait::wait_and_collect`): the dispatcher
+  drops the `ServerState` lock, then runs the 15 s ack-wait + delta drain on the
+  snapshotted `Arc`s. Status is re-derived afterward under a fresh short-lived
+  lock acquisition. While one export drains, all other control RPCs proceed.
+
+There is no TOCTOU: the worker SET (`workers.handles` / `workers.live`) is only
+mutated by other control-socket handlers, which all hold the same lock, so the
+worker set cannot change during the lock-free wait. The worker THREADS only
+advance their ack atomics (monotonic seq) and push into their delta buffers —
+both `Arc`-shared and lock-free — so the snapshot observes their progress
+faithfully. The 15 s deadline and the timeout error are preserved verbatim.
+
 ### Delta-ring overflow → loss-of-sync resync (#2442)
 
 Each worker buffers session open/close deltas in an in-worker ring

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -848,5 +848,29 @@ fn build_mirror_target_map(
 }
 
 #[cfg(test)]
+impl Coordinator {
+    /// #2962 test seam: install a worker handle whose `session_export_ack`
+    /// never advances on its own, and return the ack atomic so the caller
+    /// (e.g. the server-level dispatcher test in `crate::server::tests`) can
+    /// control when the owner-RG export ack-wait completes. Lets a test
+    /// prove the global `ServerState` lock is NOT held across the wait.
+    pub(crate) fn test_install_export_worker(&mut self, worker_id: u32) -> Arc<AtomicU64> {
+        let ack = Arc::new(AtomicU64::new(0));
+        let handle = WorkerHandle {
+            stop: Arc::new(AtomicBool::new(false)),
+            heartbeat: Arc::new(AtomicU64::new(0)),
+            commands: Arc::new(Mutex::new(VecDeque::new())),
+            session_export_ack: ack.clone(),
+            cos_status: Arc::new(ArcSwap::from_pointee(Vec::new())),
+            runtime_atomics: Arc::new(super::worker_runtime::WorkerRuntimeAtomics::new()),
+            cold_path_atomics: Arc::new(super::cold_path_hist::WorkerColdPathAtomics::new()),
+            join: None,
+        };
+        self.workers.handles.insert(worker_id, handle);
+        ack
+    }
+}
+
+#[cfg(test)]
 #[path = "tests.rs"]
 mod tests;

--- a/userspace-dp/src/afxdp/ha.rs
+++ b/userspace-dp/src/afxdp/ha.rs
@@ -184,59 +184,68 @@ impl super::Coordinator {
         self.on_rg_promote_active();
     }
 
-    pub fn export_owner_rg_sessions(
-        &self,
-        owner_rgs: &[i32],
-        max: usize,
-    ) -> Result<Vec<SessionDeltaInfo>, String> {
+    /// Phase 1 of the owner-RG session export (#2962): enqueue the export
+    /// command to every worker and capture the lock-free handles the
+    /// ack-wait needs, then RETURN immediately. The blocking ack-wait runs
+    /// in [`OwnerRgExportWait::wait_and_collect`] AFTER the caller releases
+    /// the global `ServerState` mutex, so a slow/stalled worker can no
+    /// longer freeze the whole control plane (status poll, session
+    /// installs, snapshot/FIB bumps, HA state updates) for up to 15 s.
+    ///
+    /// This method MUST be called under the `ServerState` lock: it reads
+    /// `workers.handles` / `workers.live` and bumps `export_seq`. Those
+    /// collections are only mutated by other control-socket handlers, which
+    /// all hold the same lock, so snapshotting the per-worker ack atomics
+    /// (`Arc<AtomicU64>`) and the per-binding delta buffers
+    /// (`Arc<BindingLiveState>`) here is equivalent to re-reading them live:
+    /// the worker SET cannot change while the export waits lock-free
+    /// (no TOCTOU). The worker THREADS only bump their ack atomics and push
+    /// into their delta buffers — both `Arc`-shared and lock-free — so the
+    /// wait observes their progress without the global lock.
+    pub fn kick_owner_rg_export(&self, owner_rgs: &[i32], max: usize) -> OwnerRgExportWait {
+        // Snapshot the per-binding delta buffers (same Arcs as
+        // `drain_session_deltas` iterates) so the post-lock drain reads
+        // exactly the buffers that existed at kick time.
+        let live: Vec<Arc<BindingLiveState>> = self.workers.live.values().cloned().collect();
         if owner_rgs.is_empty() {
-            return Ok(Vec::new());
+            // Preserve the pre-split early return: no export is kicked and
+            // no sequence is consumed, and the wait drains nothing.
+            return OwnerRgExportWait {
+                sequence: 0,
+                max,
+                skip: true,
+                ack_atomics: Vec::new(),
+                live,
+            };
         }
         let sequence = self
-            .sessions.export_seq
+            .sessions
+            .export_seq
             .fetch_add(1, Ordering::Relaxed)
             .saturating_add(1);
+        let mut ack_atomics = Vec::with_capacity(self.workers.handles.len());
         for handle in self.workers.handles.values() {
             // #1790/#1807: recover, don't early-return — one dead worker's
             // poisoned queue must not block session export for every
             // HEALTHY worker (the export-ack timeout handles dead workers
-            // at the caller). Same policy as update_ha_state above.
+            // in the wait). Same policy as update_ha_state above.
             let mut pending = worker_queue::lock_recover(&handle.commands);
             pending.push_back(WorkerCommand::ExportOwnerRGSessions {
                 sequence,
                 owner_rgs: owner_rgs.to_vec(),
             });
+            drop(pending);
+            ack_atomics.push(handle.session_export_ack.clone());
         }
-        let deadline = std::time::Instant::now() + Duration::from_secs(15);
-        loop {
-            if self
-                .workers
-                .handles
-                .values()
-                .all(|handle| handle.session_export_ack.load(Ordering::Acquire) >= sequence)
-            {
-                break;
-            }
-            if std::time::Instant::now() >= deadline {
-                return Err(format!(
-                    "timed out waiting for session export ack seq={sequence}"
-                ));
-            }
-            thread::sleep(Duration::from_millis(5));
+        OwnerRgExportWait {
+            sequence,
+            max,
+            skip: false,
+            ack_atomics,
+            live,
         }
-        let mut out = Vec::new();
-        let mut remaining = if max == 0 { usize::MAX } else { max.max(1) };
-        while remaining > 0 {
-            let batch_size = remaining.min(1024);
-            let drained = self.drain_session_deltas(batch_size);
-            if drained.is_empty() {
-                break;
-            }
-            remaining = remaining.saturating_sub(drained.len());
-            out.extend(drained);
-        }
-        Ok(out)
     }
+
 
     pub fn ha_groups(&self) -> Vec<HAGroupStatus> {
         let now_secs = monotonic_nanos() / 1_000_000_000;
@@ -621,6 +630,97 @@ impl super::Coordinator {
         );
         Ok(count)
     }
+}
+
+/// Lock-free handle returned by [`Coordinator::kick_owner_rg_export`] so
+/// the control-socket dispatcher can release the global `ServerState`
+/// mutex BEFORE blocking on the per-worker export ack-wait (#2962).
+///
+/// At construction the export command has already been enqueued to every
+/// worker; the only state the wait still needs is the per-worker ack
+/// atomics (`ack_atomics`) and the per-binding delta buffers (`live`),
+/// all `Arc`-shared and advanced by the worker threads without the global
+/// lock. Holding these `Arc` clones lets the wait + drain run entirely
+/// off the `ServerState` lock.
+pub struct OwnerRgExportWait {
+    sequence: u64,
+    max: usize,
+    /// `true` when no export was kicked (empty owner-RG set):
+    /// `wait_and_collect` returns an empty delta set without touching the
+    /// per-binding buffers, byte-identical to the pre-split early return.
+    skip: bool,
+    /// Per-worker `session_export_ack` atomics captured at kick time. The
+    /// worker SET is stable for the lock-free wait window (every mutator
+    /// holds the `ServerState` lock), so this snapshot is equivalent to
+    /// re-reading `workers.handles` live.
+    ack_atomics: Vec<Arc<AtomicU64>>,
+    /// Per-binding delta buffers (`workers.live` values) captured at kick
+    /// time; drained after all workers ack.
+    live: Vec<Arc<BindingLiveState>>,
+}
+
+impl OwnerRgExportWait {
+    /// Phase 2 of the owner-RG export (#2962): block up to 15 s for every
+    /// worker to ack the export sequence, then drain the produced session
+    /// deltas. Runs WITHOUT the global `ServerState` lock, so concurrent
+    /// control RPCs (status poll, session installs, snapshot/FIB bumps, HA
+    /// state updates) stay responsive while one export drains. Preserves
+    /// the original 15 s deadline and timeout error.
+    pub fn wait_and_collect(self) -> Result<Vec<SessionDeltaInfo>, String> {
+        if self.skip {
+            return Ok(Vec::new());
+        }
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            if self
+                .ack_atomics
+                .iter()
+                .all(|ack| ack.load(Ordering::Acquire) >= self.sequence)
+            {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out waiting for session export ack seq={}",
+                    self.sequence
+                ));
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        let mut out = Vec::new();
+        let mut remaining = if self.max == 0 { usize::MAX } else { self.max.max(1) };
+        while remaining > 0 {
+            let batch_size = remaining.min(1024);
+            let drained = drain_session_deltas_from_live(&self.live, batch_size);
+            if drained.is_empty() {
+                break;
+            }
+            remaining = remaining.saturating_sub(drained.len());
+            out.extend(drained);
+        }
+        Ok(out)
+    }
+}
+
+/// Drain up to `max` session deltas across the captured per-binding
+/// buffers. Mirrors `Coordinator::drain_session_deltas` exactly, but over
+/// an owned snapshot of the `Arc<BindingLiveState>` values so it needs no
+/// `&Coordinator` (and therefore no `ServerState` lock).
+fn drain_session_deltas_from_live(
+    live: &[Arc<BindingLiveState>],
+    max: usize,
+) -> Vec<SessionDeltaInfo> {
+    let mut remaining = max.max(1);
+    let mut out = Vec::new();
+    for binding in live {
+        if remaining == 0 {
+            break;
+        }
+        let drained = binding.drain_session_deltas(remaining);
+        remaining = remaining.saturating_sub(drained.len());
+        out.extend(drained);
+    }
+    out
 }
 
 #[cfg(test)]

--- a/userspace-dp/src/afxdp/ha_tests.rs
+++ b/userspace-dp/src/afxdp/ha_tests.rs
@@ -696,3 +696,56 @@ fn delete_synced_session_zero_generation_is_unconditional() {
         "a gen-0 (unconditional) delete must remove the entry"
     );
 }
+
+// #2962: kicking an export for an EMPTY owner-RG set is a no-op — it must
+// not consume an export sequence and the wait must drain nothing, preserving
+// the pre-split early return semantics.
+#[test]
+fn kick_owner_rg_export_empty_set_is_noop_and_consumes_no_sequence() {
+    let coordinator = Coordinator::new();
+    let before = coordinator.sessions.export_seq.load(Ordering::Relaxed);
+    let wait = coordinator.kick_owner_rg_export(&[], 0);
+    assert_eq!(
+        coordinator.sessions.export_seq.load(Ordering::Relaxed),
+        before,
+        "empty owner-RG export must not consume a sequence"
+    );
+    assert!(
+        wait.wait_and_collect().expect("empty export").is_empty(),
+        "empty owner-RG export must drain no deltas"
+    );
+}
+
+// #2962: the locked KICK phase enqueues the export command (with the bumped
+// sequence) to every worker and returns immediately; the lock-free wait
+// completes once the worker acks. This isolates the blocking ack-wait into
+// `OwnerRgExportWait::wait_and_collect`, off the global ServerState lock.
+#[test]
+fn kick_owner_rg_export_enqueues_command_then_wait_completes_on_ack() {
+    let mut coordinator = Coordinator::new();
+    let commands = Arc::new(Mutex::new(VecDeque::new()));
+    let handle = test_worker_handle(commands.clone());
+    let ack = handle.session_export_ack.clone();
+    coordinator.workers.handles.insert(0, handle);
+
+    let wait = coordinator.kick_owner_rg_export(&[1, 2], 0);
+
+    {
+        let pending = commands.lock().expect("commands");
+        assert_eq!(pending.len(), 1, "exactly one export command enqueued");
+        match pending.front().expect("front") {
+            WorkerCommand::ExportOwnerRGSessions { sequence, owner_rgs } => {
+                assert_eq!(*sequence, 1, "first export bumps the sequence to 1");
+                assert_eq!(owner_rgs, &vec![1, 2], "owner-RG set propagated verbatim");
+            }
+            other => panic!("expected ExportOwnerRGSessions, got {other:?}"),
+        }
+    }
+
+    // No real bindings, so the drain yields an empty set once the worker acks.
+    ack.store(1, Ordering::Release);
+    assert!(
+        wait.wait_and_collect().expect("export after ack").is_empty(),
+        "no bindings means no deltas to drain"
+    );
+}

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -434,6 +434,11 @@ mod worker_queue;
 #[path = "worker_runtime.rs"]
 mod worker_runtime;
 pub use self::coordinator::Coordinator;
+// #2962: the lock-free owner-RG export wait handle. The control-socket
+// dispatcher (server/handlers) names this as the return type of
+// kick_owner_rg_export so it can run the blocking ack-wait off the
+// global ServerState lock.
+pub(crate) use self::ha::OwnerRgExportWait;
 // #1636: re-export the warmer types/consts into afxdp scope so the
 // neighbor-warmer loop in neighbor.rs (which uses `use super::*`) and
 // the unit tests can name them without a fully-qualified path.

--- a/userspace-dp/src/server/handlers/export.rs
+++ b/userspace-dp/src/server/handlers/export.rs
@@ -1,25 +1,43 @@
 // #1345: per-verb handlers for export_owner_rg_sessions and
-// export_all_sessions. Both verbs produce session deltas. Bodies
-// byte-identical to handlers.rs lines 354-370 and 371-379.
+// export_all_sessions. Both verbs produce session deltas.
+//
+// #2962: export_owner_rg_sessions is now a TWO-PHASE handler. `owner_rg_kick`
+// runs the LOCKED phase — it enqueues the export command to every worker and
+// returns an `OwnerRgExportWait`. The control-socket dispatcher
+// (server/handlers/mod.rs) then RELEASES the global `ServerState` mutex and
+// runs `OwnerRgExportWait::wait_and_collect` (the blocking 15 s ack-wait)
+// lock-free, so a slow worker can no longer freeze the whole control plane.
 
 use super::super::helpers::refresh_status;
 use super::super::ServerState;
+use crate::afxdp::OwnerRgExportWait;
 use crate::{ControlResponse, SessionExportRequest};
 
-pub(super) fn owner_rg(
+/// Locked phase: enqueue the owner-RG export to every worker and capture the
+/// lock-free wait handle. Returns the handle to the dispatcher, which runs
+/// the blocking ack-wait AFTER dropping the `ServerState` lock (#2962).
+pub(super) fn owner_rg_kick(
     guard: &mut ServerState,
     session_export: Option<SessionExportRequest>,
+) -> OwnerRgExportWait {
+    let export_req = session_export.unwrap_or_default();
+    guard
+        .afxdp
+        .kick_owner_rg_export(&export_req.owner_rgs, export_req.max as usize)
+}
+
+/// Lock-free phase: block for the worker acks, drain the deltas, and fold the
+/// result into the response. Called by the dispatcher with the `ServerState`
+/// lock RELEASED. Mirrors the pre-split `Ok`/`Err` handling (deltas + persist
+/// on success; ok/error on timeout).
+pub(super) fn owner_rg_collect(
+    wait: OwnerRgExportWait,
     response: &mut ControlResponse,
     persist_state: &mut bool,
 ) {
-    let export_req = session_export.unwrap_or_default();
-    match guard
-        .afxdp
-        .export_owner_rg_sessions(&export_req.owner_rgs, export_req.max as usize)
-    {
+    match wait.wait_and_collect() {
         Ok(deltas) => {
             response.session_deltas = deltas;
-            refresh_status(guard);
             *persist_state = true;
         }
         Err(err) => {

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -101,6 +101,16 @@ pub(crate) fn handle_stream(
     let suppress_status = request.suppress_status;
     let neighbor_replace = request.neighbor_replace;
 
+    // #2962: the owner-RG session export must NOT block under the global
+    // ServerState lock. The locked `match` arm only KICKS the export
+    // (enqueues the per-worker command + captures the lock-free ack/delta
+    // handles); the blocking 15 s ack-wait runs here, AFTER the lock is
+    // dropped, so a slow/stalled worker can no longer freeze status polls,
+    // session installs, snapshot/FIB bumps, and HA state updates. When set,
+    // the post-match status attach is also deferred until after the wait so
+    // the reported status reflects the drained state.
+    let mut export_wait: Option<crate::afxdp::OwnerRgExportWait> = None;
+
     {
         let mut guard = state.lock().expect("server state poisoned");
         match request.request_type.as_str() {
@@ -173,12 +183,11 @@ pub(crate) fn handle_stream(
                 &mut response,
                 &mut persist_state,
             ),
-            "export_owner_rg_sessions" => export::owner_rg(
-                &mut guard,
-                request.session_export,
-                &mut response,
-                &mut persist_state,
-            ),
+            "export_owner_rg_sessions" => {
+                // #2962: locked phase only — enqueue + capture the wait
+                // handle. The blocking ack-wait runs after the lock drops.
+                export_wait = Some(export::owner_rg_kick(&mut guard, request.session_export));
+            }
             "export_all_sessions" => export::all(&mut guard, &mut response),
             "rebind" => rebind::handle(&mut guard, &mut persist_state),
             "stop_workers" => stop_workers::handle(&mut guard, &mut persist_state),
@@ -192,7 +201,23 @@ pub(crate) fn handle_stream(
                 response.error = format!("unknown request type {other}");
             }
         }
+        // #2962: defer status attach for the export verb — it is computed
+        // after the lock-free ack-wait below so it reflects the drained
+        // state (and is not produced while holding the lock across a wait).
+        if export_wait.is_none() && !suppress_status {
+            refresh_status(&mut guard);
+            response.status = Some(guard.status.clone());
+        }
+    }
+
+    // #2962: blocking owner-RG export ack-wait runs here, with the global
+    // ServerState lock RELEASED, so the control plane stays responsive while
+    // one export drains. Status is then re-derived under a fresh short-lived
+    // lock acquisition (the wait is already done).
+    if let Some(wait) = export_wait {
+        export::owner_rg_collect(wait, &mut response, &mut persist_state);
         if !suppress_status {
+            let mut guard = state.lock().expect("server state poisoned");
             refresh_status(&mut guard);
             response.status = Some(guard.status.clone());
         }

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -16,8 +16,8 @@ use super::{handle_stream, ServerState};
 use crate::state_writer::StateWriter;
 use crate::{
     afxdp, BindingControlRequest, BindingStatus, ControlRequest, ControlResponse, ForwardingControlRequest,
-    HAGroupStatus, HAStateUpdateRequest, ProcessStatus, QueueControlRequest, SessionSyncRequest,
-    UserspaceCapabilities, MAX_CONTROL_REQUEST_BYTES,
+    HAGroupStatus, HAStateUpdateRequest, ProcessStatus, QueueControlRequest, SessionExportRequest,
+    SessionSyncRequest, UserspaceCapabilities, MAX_CONTROL_REQUEST_BYTES,
 };
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
@@ -1092,4 +1092,68 @@ fn wg1866_disarmed_same_plan_apply_does_not_hold_wg_ports() {
         exceptions, 0,
         "disarmed helper must not even attempt a WG bind (no transient spawn)"
     );
+}
+
+// --- #2962: owner-RG export must not hold the ServerState lock ----------
+
+/// Fail-on-revert: the owner-RG session export must run its blocking 15 s
+/// ack-wait WITHOUT holding the global `ServerState` lock, so a slow/stalled
+/// worker cannot freeze the rest of the control plane. This test installs a
+/// worker that never acks on its own, kicks an export (which blocks in
+/// `wait_and_collect`), and proves a concurrent `status` poll is still served
+/// promptly. If the wait runs under the lock again (the bug), the status poll
+/// blocks until the ack arrives and this assertion goes RED.
+#[test]
+fn export_owner_rg_does_not_hold_state_lock_during_ack_wait() {
+    use std::sync::atomic::Ordering;
+    use std::time::{Duration, Instant};
+
+    let state = new_state(ProcessStatus::default());
+
+    // Install a worker whose export ack never advances on its own. A timer
+    // thread acks it after 800ms so the export wait stays bounded in BOTH
+    // the fixed and the reverted code paths (no 15 s hang on revert).
+    let ack = {
+        let mut guard = state.lock().expect("lock state");
+        guard.afxdp.test_install_export_worker(0)
+    };
+    let ack_thread = {
+        let ack = ack.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(800));
+            ack.store(u64::MAX, Ordering::Release);
+        })
+    };
+
+    // Run the export in the background: it kicks under the lock, releases the
+    // lock, then blocks in the ack-wait until the timer thread acks (~800ms).
+    let export_state = state.clone();
+    let export_thread = std::thread::spawn(move || {
+        let mut r = req("export_owner_rg_sessions");
+        r.session_export = Some(SessionExportRequest {
+            owner_rgs: vec![1],
+            max: 0,
+        });
+        run_request(export_state, r)
+    });
+
+    // Let the export reach its wait.
+    std::thread::sleep(Duration::from_millis(150));
+
+    // The control plane MUST answer a status poll WHILE the export waits.
+    // With the lock held across the wait (the #2962 bug) this would block
+    // until the 800ms ack releases it (~650ms after t0).
+    let t0 = Instant::now();
+    let resp = run_request(state.clone(), req("status"));
+    let elapsed = t0.elapsed();
+    assert!(resp.ok, "status poll failed: {}", resp.error);
+    assert!(
+        elapsed < Duration::from_millis(400),
+        "status poll blocked {elapsed:?} during owner-RG export — \
+         ServerState lock held across the ack-wait (#2962 regression)"
+    );
+
+    let export_resp = export_thread.join().expect("export thread");
+    assert!(export_resp.ok, "export failed: {}", export_resp.error);
+    ack_thread.join().expect("ack thread");
 }


### PR DESCRIPTION
Closes #2962

## Problem

The control-socket dispatcher (`server/handlers/mod.rs`) holds the global
`Mutex<ServerState>` across its entire request `match`, including
`export_owner_rg_sessions` -> `afxdp.export_owner_rg_sessions(...)`. That path
blocks on a synchronous ack-wait loop with a 15s deadline while every worker
acks the export sequence. A slow/stalled worker therefore froze the WHOLE
control plane (status poll, session installs, snapshot/FIB bumps, HA state
updates, neighbor updates -- all serialize on that mutex) for up to 15s, exactly
on the failover-critical owner-RG export path.

## Fix: locked-kick / lock-free-wait split

- **Locked phase** `Coordinator::kick_owner_rg_export`: enqueue the
  `ExportOwnerRGSessions` command to every worker, bump `export_seq`, and
  snapshot the lock-free handles the wait needs -- per-worker
  `session_export_ack` atomics (`Arc<AtomicU64>`) and per-binding delta buffers
  (`Arc<BindingLiveState>`). Returns an `OwnerRgExportWait` immediately.
- **Lock-free phase** `OwnerRgExportWait::wait_and_collect`: the dispatcher
  drops the `ServerState` lock, then runs the 15s ack-wait + delta drain on the
  snapshotted `Arc`s. Status is re-derived afterward under a fresh short-lived
  lock. While one export drains, all other control RPCs stay responsive.

The 15s deadline and the timeout error string are preserved verbatim.

## TOCTOU reasoning

`workers.handles` / `workers.live` are mutated only by other control-socket
handlers, which all hold the same `ServerState` lock -- so the worker SET cannot
change during the lock-free window, and snapshotting the ack atomics + delta
buffers under the lock is equivalent to re-reading them live. The worker THREADS
only advance monotonic ack seq atomics and push into their delta buffers (both
`Arc`-shared and lock-free), so the wait observes their progress without the
global lock. No state the wait depends on can change in a corrupting way.

## Tests (fail-on-revert proven)

- `server::tests::export_owner_rg_does_not_hold_state_lock_during_ack_wait` --
  installs a never-acking worker (timer-acks at 800ms so the test is bounded),
  kicks an export, and asserts a concurrent `status` poll is served in <400ms.
  Restoring the wait under the lock reds it: "status poll blocked 652ms ...
  ServerState lock held across the ack-wait (#2962 regression)".
- `afxdp::ha::tests::kick_owner_rg_export_empty_set_is_noop_and_consumes_no_sequence`
- `afxdp::ha::tests::kick_owner_rg_export_enqueues_command_then_wait_completes_on_ack`

Added a `#[cfg(test)]` `Coordinator::test_install_export_worker` seam.

## Build / validation

`cargo build --release` + `cargo test --release` (afxdp::ha, server::tests,
afxdp::session_glue::tests::export) green. `go build ./pkg/dataplane/userspace/...`
green (wire protocol unchanged). Docs updated in
`docs/session-sync-architecture.md` + `_Log.md`.

Note: this is on the HA owner-RG export / failover path -- parent runs
`make test-failover` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi