### PR TITLE
event_stream: fix three coupled write-path defects (#2877/#2882/#2883)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-26 — #2883 event-stream idle keepalive rides write_buf backpressure
+
+- **Timestamp**: 2026-06-26
+- **Action**: the idle keepalive in `run_connected_loop`
+  (`userspace-dp/src/event_stream/mod.rs`) built a frame and called `write_all`
+  directly on the nonblocking socket, returning true (immediate reconnect) on
+  ANY error — including `WouldBlock` when the kernel send buffer is full under a
+  slow reader. That bypassed the normal `write_buf` partial-write/WouldBlock
+  backpressure + stall accounting and caused reconnect churn -> replay storms
+  (which then hit the blocking replay path, #2877). Fix: enqueue the keepalive
+  bytes into `write_buf` so the top-of-loop flush handles WouldBlock as ordinary
+  backpressure. Made the keepalive interval injectable: `run_connected_loop`
+  takes a `keepalive_interval: Duration` (production passes the new
+  `KEEPALIVE_IDLE_INTERVAL` = 10s; the old dead `KEEPALIVE_INTERVAL_NS` const
+  was removed). A genuinely dead consumer is still caught by the socket-error /
+  EOF path.
+- **File(s)**: `userspace-dp/src/event_stream/mod.rs`,
+  `userspace-dp/src/event_stream/tests.rs`,
+  `userspace-dp/src/event_stream/README.md`,
+  `docs/session-sync-design.md`
+- **Tests**: `test_idle_keepalive_wouldblock_is_backpressure_not_reconnect_2883`
+  — a connected daemon stops reading (send buffer filled), the keepalive fires
+  (interval 0); assert `run_connected_loop` does NOT report reconnect. Goes RED
+  when the keepalive is reverted to `write_all` + `return true`.
+
 ## 2026-06-26 — #2882 event-stream drain honors the target_seq fence
 
 - **Timestamp**: 2026-06-26

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-26 — #2882 event-stream drain honors the target_seq fence
+
+- **Timestamp**: 2026-06-26
+- **Action**: `handle_drain_request`
+  (`userspace-dp/src/event_stream/mod.rs`) wrote EVERY frame in
+  `replay_buf.iter()` with no `frame.seq <= target_seq` filter and reported
+  DrainComplete with `replay_buf.back().seq` rather than the requested target.
+  DrainRequest is contracted (docs/session-sync-design.md, the arm comment) as
+  "flush all buffered events up to target seq", so flushing/reporting beyond
+  the fence changed it to "dump current replay head" — masking holes and
+  coupling demotion correctness to unrelated later-buffered frames. Fix: skip
+  frames with `seq > target_seq`, track the highest seq `<= target` actually
+  written (`drained_up_to`), and report that (or `target_seq` when the buffer
+  held nothing at/below the fence because it was already ACK-trimmed).
+  DrainComplete is still withheld if the fence was never reached (#2876) or a
+  write failed (#2877).
+- **File(s)**: `userspace-dp/src/event_stream/mod.rs`,
+  `userspace-dp/src/event_stream/tests.rs`,
+  `docs/session-sync-design.md`
+- **Tests**: `test_drain_filters_to_target_and_reports_target_2882` — replay
+  buffer seqs 1..=10, fence target 5; assert only seqs 1..=5 are written and
+  DrainComplete reports 5. Goes RED when the `<= target` filter or the
+  drain_seq fix is reverted (back().seq=10 leaks / is reported).
+
 ## 2026-06-26 — #2877 event-stream replay/drain stop-aware nonblocking writes
 
 - **Timestamp**: 2026-06-26

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-06-26 — #2877 event-stream replay/drain stop-aware nonblocking writes
+
+- **Timestamp**: 2026-06-26
+- **Action**: `replay_buffered` and `handle_drain_request`
+  (`userspace-dp/src/event_stream/mod.rs`) flipped the event-stream socket to
+  BLOCKING and called `write_all` with no write deadline and no stop check. A
+  daemon that connected but stopped reading wedged the helper I/O thread in the
+  blocking write; because `EventStreamSender::stop` joins that thread, a
+  write-blocked thread could not observe the stop flag, so helper stop / RG
+  demotion hung — violating the slow-consumer invariant
+  (`docs/session-sync-design.md`). Fix: moved the stop flag into the shared
+  state (`EventStreamShared.stop`) so every I/O-thread function observes it, and
+  routed replay/drain writes through a new `write_all_backpressured` helper that
+  keeps the socket NONBLOCKING (the canonical data-frame mode) and, on
+  `WouldBlock`, sleeps `REPLAY_DRAIN_WRITE_POLL` and retries while polling
+  `shared.stop` and bailing at a `REPLAY_DRAIN_WRITE_DEADLINE` (5s) shared
+  across the pass. Replay returns Err -> reconnect; drain withholds
+  DrainComplete on a write failure so the daemon times out and refuses demotion
+  (#2876) rather than reporting a false drain. Removed `write_frame_blocking`
+  and the standalone `stop: Arc<AtomicBool>` threaded into `io_thread_main` /
+  `run_connected_loop` / `try_connect`.
+- **File(s)**: `userspace-dp/src/event_stream/mod.rs`,
+  `userspace-dp/src/event_stream/tests.rs`,
+  `userspace-dp/src/event_stream/README.md`,
+  `docs/session-sync-design.md`
+- **Tests**: `test_replay_does_not_wedge_on_stuck_reader_2877`,
+  `test_drain_does_not_wedge_on_stuck_reader_2877` — a stuck (non-reading)
+  connected daemon during replay/drain; assert the I/O-thread function observes
+  the stop flag and returns within 2s instead of wedging. Both go RED when the
+  writer is reverted to the blocking `write_all`.
+
 ## 2026-06-26 — #2959 event-stream MSG_ACK watermark validation
 
 - **Timestamp**: 2026-06-26

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -605,6 +605,18 @@ DrainComplete. This replaces `ExportOwnerRGSessions` RPC for demotion prep —
 the daemon drains the stream to current head instead of doing a separate RPC
 export.
 
+The fence is honored strictly (#2882): `handle_drain_request` writes ONLY
+buffered frames with `seq <= target_seq` and reports DrainComplete with the
+fence target (the highest seq `<= target` actually flushed; `target_seq` when
+the buffer held nothing at/below the fence because it was already ACK-trimmed).
+It does NOT write every frame in the replay buffer, and it does NOT report
+`replay_buf.back().seq` (which can exceed the target). Before #2882 the handler
+flushed and reported the current replay head, changing the contract from "fence
+up to target" to "dump current replay head" — that masks holes and couples
+demotion correctness to unrelated later-buffered frames. DrainComplete is still
+withheld entirely if the fence was never reached within the drain timeout
+(#2876) or a frame write failed against a stuck/stopping reader (#2877).
+
 ### Reconnect / Replay
 
 On disconnect, the helper retains its replay buffer (bounded, ~4096 events per

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -559,6 +559,22 @@ backlog (`write_buf`) and writes non-blocking; on `WouldBlock` it keeps the
 remainder for the next cycle. Daemon detects gaps via sequence numbers and can
 request a full reconciliation.
 
+The reconnect **replay** (`replay_buffered`) and demotion **drain**
+(`handle_drain_request`) paths write on the SAME nonblocking socket via a
+bounded, stop-aware writer (`write_all_backpressured`, #2877) — they do NOT
+flip the socket to blocking and call `write_all`. On `WouldBlock` the writer
+sleeps `REPLAY_DRAIN_WRITE_POLL` and retries, polling the I/O-thread stop flag
+each cycle and bailing at a `REPLAY_DRAIN_WRITE_DEADLINE` (5s) shared across the
+whole pass. Before #2877 these two paths used a blocking `write_all` with no
+deadline and no stop check: a daemon that connected but stopped reading wedged
+the I/O thread in the blocking write, and because `EventStreamSender::stop`
+joins that thread, the write-blocked thread could not observe the stop flag —
+so helper stop / RG demotion hung. The stop flag now lives in the shared state
+(`EventStreamShared.stop`) so every I/O-thread function observes it; a stuck
+reader during replay forces a reconnect, and during drain causes DrainComplete
+to be withheld (the daemon then times out and refuses demotion, #2876) instead
+of wedging.
+
 The bounded channel is the ONLY backpressure surface. The write backlog is
 capped at `WRITE_BACKLOG_MAX_BYTES` (16 MiB ≈ 8× a fully-drained 8192×256 B
 channel, since `EventFrame` is a fixed `[u8; 256]`; `drain_channel_into_write_buf`

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -559,6 +559,17 @@ backlog (`write_buf`) and writes non-blocking; on `WouldBlock` it keeps the
 remainder for the next cycle. Daemon detects gaps via sequence numbers and can
 request a full reconciliation.
 
+The idle **keepalive** also rides the canonical write path (#2883): the
+connected loop enqueues the keepalive frame into `write_buf` rather than calling
+`write_all` directly. Before #2883 the keepalive used `write_all` on the
+nonblocking socket and treated ANY error — including `WouldBlock` when the
+kernel send buffer is full under a slow reader — as fatal, returning an
+immediate reconnect. That bypassed the partial-write/WouldBlock backpressure and
+stall accounting and caused reconnect churn → replay storms (which then hit the
+blocking replay path, #2877). Routed through `write_buf`, a keepalive WouldBlock
+is ordinary backpressure (retained for the next flush); a genuinely dead
+consumer is still detected by the normal socket-error / EOF path.
+
 The reconnect **replay** (`replay_buffered`) and demotion **drain**
 (`handle_drain_request`) paths write on the SAME nonblocking socket via a
 bounded, stop-aware writer (`write_all_backpressured`, #2877) — they do NOT

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -272,6 +272,16 @@ cluster-scoped.
   already-bounded replay buffer, never to `write_buf`. **Invariant: the
   data plane never stalls because a telemetry consumer is slow; a stuck
   consumer degrades telemetry (counted drops), nothing else.**
+- **Idle keepalive rides write_buf, not write_all (#2883).** The connected
+  loop enqueues its idle keepalive frame into `write_buf` (the same path data
+  frames use), so a `WouldBlock` on a full kernel send buffer is ordinary
+  backpressure (retained for the next flush), not a fatal reconnect. The old
+  keepalive called `write_all` directly and `return true`d on any error,
+  including WouldBlock under a slow reader — causing reconnect churn -> replay
+  storms (which then hit the blocking replay path, #2877). A genuinely dead
+  consumer is still caught by the normal socket-error / EOF path. The keepalive
+  interval is `KEEPALIVE_IDLE_INTERVAL` (10s), passed into `run_connected_loop`
+  (injectable so tests can fire it immediately).
 - **Replay/drain writes are nonblocking + stop-aware (#2877).** The reconnect
   replay (`replay_buffered`) and demotion drain (`handle_drain_request`) paths
   push frames through `write_all_backpressured`, which keeps the socket

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -272,6 +272,22 @@ cluster-scoped.
   already-bounded replay buffer, never to `write_buf`. **Invariant: the
   data plane never stalls because a telemetry consumer is slow; a stuck
   consumer degrades telemetry (counted drops), nothing else.**
+- **Replay/drain writes are nonblocking + stop-aware (#2877).** The reconnect
+  replay (`replay_buffered`) and demotion drain (`handle_drain_request`) paths
+  push frames through `write_all_backpressured`, which keeps the socket
+  NONBLOCKING (the same mode steady-state data-frame writes use) and, on
+  `WouldBlock`, retries with a `REPLAY_DRAIN_WRITE_POLL` sleep while polling the
+  shared stop flag and bailing at a `REPLAY_DRAIN_WRITE_DEADLINE` (5s) shared
+  across the pass. They MUST NOT flip the socket to blocking and call
+  `write_all`: a daemon that connects but stops reading would wedge the I/O
+  thread in the unbounded blocking write, and since `EventStreamSender::stop`
+  joins that thread, helper stop / RG demotion would hang (the slow-consumer
+  invariant: a stalled consumer degrades telemetry, never wedges the helper).
+  The stop flag lives in `EventStreamShared.stop` so every I/O-thread function
+  (connect, replay, the connected loop, drain) observes it. A stuck reader
+  during replay returns Err -> reconnect; during drain it withholds
+  DrainComplete so the daemon times out and refuses demotion (#2876) rather
+  than reporting a false drain.
 - RT_FLOW dataplane telemetry producers must use
   `try_emit_dataplane_event_at()` (or, for a producer that builds its own
   frame layout such as the session-close/create frames,

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -1136,21 +1136,44 @@ fn handle_drain_request(
     // drain write.
     let write_deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
     let mut write_failed = false;
+    // #2882: honor the fence — write only frames UP TO the requested target,
+    // not the whole replay head. DrainRequest is contracted (see
+    // docs/session-sync-design.md) as "flush all buffered events up to target
+    // seq". Frames newer than the fence belong to a later drain/replay;
+    // flushing (and reporting) them here changes the contract to "dump current
+    // replay head", which masks holes and couples demotion correctness to
+    // unrelated later-buffered frames. `drained_up_to` tracks the highest seq
+    // <= target actually written (the replay buffer is seq-ordered).
+    let mut drained_up_to = 0u64;
     for frame in replay_buf.iter() {
+        if frame.seq > target_seq {
+            continue; // beyond the fence — not part of this drain
+        }
         if let Err(e) = write_all_backpressured(stream, frame.as_bytes(), shared, write_deadline) {
             eprintln!("xpf-event-stream: drain write error: {e}");
             write_failed = true;
             break;
         }
+        drained_up_to = frame.seq;
     }
 
     // Send DrainComplete ONLY when the target fence was reached AND every frame
-    // was flushed. If the drain timed out below the fence, or a write failed
-    // against a stuck/stopping reader, withhold DrainComplete: the daemon's
-    // SendDrainRequest then times out (or rejects a below-target seq) and
-    // refuses to proceed with demotion, rather than silently losing the
+    // up to it was flushed. If the drain timed out below the fence, or a write
+    // failed against a stuck/stopping reader, withhold DrainComplete: the
+    // daemon's SendDrainRequest then times out (or rejects a below-target seq)
+    // and refuses to proceed with demotion, rather than silently losing the
     // post-fence sessions on failover (#2876/#2877).
-    let drain_seq = replay_buf.back().map(|f| f.seq).unwrap_or(target_seq);
+    //
+    // #2882: report the fence the daemon requested, not replay_buf.back().seq
+    // (which could exceed the target). Everything with seq <= target_seq is now
+    // flushed, so report the highest such seq actually written; if the buffer
+    // held nothing at/below the fence (all already ACK-trimmed), the fence is
+    // still satisfied, so report target_seq.
+    let drain_seq = if drained_up_to == 0 {
+        target_seq
+    } else {
+        drained_up_to
+    };
     if reached_target && !write_failed {
         let complete_frame = EventFrame::encode_drain_complete(drain_seq);
         if let Err(e) =

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -127,9 +127,11 @@ pub(crate) fn mono_ns_to_wall_clock_unix_ns(mono_ns: u64) -> u64 {
     monotonic_ns_to_unix_ns(mono_ns, now_mono_ns, now_unix_ns)
 }
 
-/// Interval between keepalive frames to prevent idle disconnect.
-#[allow(dead_code)] // reserved for event stream keepalive logic
-const KEEPALIVE_INTERVAL_NS: u64 = 10_000_000_000; // 10 seconds
+/// Idle interval after which the connected loop enqueues a keepalive frame to
+/// keep the Go listener from treating the stream as dead. The keepalive is
+/// routed through the normal `write_buf` backpressure path (#2883), so this is
+/// the cadence of enqueue, not of a guaranteed flush.
+const KEEPALIVE_IDLE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Maximum event frames buffered in the mpsc channel (shared across workers).
 const CHANNEL_CAPACITY: usize = 8192;
@@ -734,6 +736,7 @@ fn io_thread_main(
             &shared,
             &mut replay_buf,
             &mut ctrl_read_buf,
+            KEEPALIVE_IDLE_INTERVAL,
         );
 
         shared.connected.store(false, Ordering::Release);
@@ -882,6 +885,7 @@ fn run_connected_loop(
     shared: &Arc<EventStreamShared>,
     replay_buf: &mut VecDeque<EventFrame>,
     ctrl_read_buf: &mut Vec<u8>,
+    keepalive_interval: Duration,
 ) -> bool {
     use std::io::{Read, Write};
 
@@ -961,13 +965,23 @@ fn run_connected_loop(
         } else {
             idle_cycles = idle_cycles.saturating_add(1);
             if idle_cycles > 10 {
-                // Send keepalive to prevent idle disconnect on Go side
-                if last_write.elapsed().as_secs() >= 10 {
+                // Enqueue a keepalive (prevents idle disconnect on the Go side)
+                // through the SAME `write_buf` backpressure path data frames use
+                // (#2883). The old code called `write_all` directly on the
+                // nonblocking socket and returned true (immediate reconnect) on
+                // ANY error — including `WouldBlock` when the kernel send buffer
+                // is full under a slow reader — bypassing the partial-write /
+                // WouldBlock backpressure and stall accounting and causing
+                // reconnect churn -> replay storms. Routing the keepalive bytes
+                // into `write_buf` makes WouldBlock ordinary backpressure: the
+                // top-of-loop flush retains the remainder for the next cycle,
+                // and a genuinely dead consumer is still detected by the normal
+                // socket-error / EOF path rather than by a false reconnect on
+                // transient fullness.
+                if last_write.elapsed() >= keepalive_interval {
                     let mut ka = [0u8; FRAME_HEADER_SIZE];
                     ka[4] = MSG_KEEPALIVE;
-                    if let Err(_) = (&*stream).write_all(&ka) {
-                        return true; // disconnect
-                    }
+                    write_buf.extend_from_slice(&ka);
                     last_write = Instant::now();
                 }
                 thread::sleep(Duration::from_millis(1));

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -172,6 +172,20 @@ const WRITE_BACKLOG_MAX_BYTES: usize = 16 * 1024 * 1024;
 const LOSSLESS_QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
 const LOSSLESS_QUEUE_RETRY_DELAY: Duration = Duration::from_micros(50);
 
+/// Bounded time the stop-aware replay/drain writer (`write_all_backpressured`)
+/// will spend backpressured on a slow/stuck reader before giving up — i.e.
+/// reconnecting (replay) or withholding DrainComplete (drain). This caps how
+/// long a wedged daemon can hold the I/O thread in the replay/drain write even
+/// if the stop flag is never raised (#2877). The replay/drain paths used to
+/// flip the socket to BLOCKING and `write_all` with no deadline, so a daemon
+/// that stopped reading wedged the I/O thread indefinitely — and because
+/// `EventStreamSender::stop` joins that thread, stop/demotion hung.
+const REPLAY_DRAIN_WRITE_DEADLINE: Duration = Duration::from_secs(5);
+/// Sleep between `WouldBlock` retries in `write_all_backpressured`. Also the
+/// worst-case latency for that writer to observe a raised stop flag, so
+/// stop/demotion never waits more than one poll interval on a stuck reader.
+const REPLAY_DRAIN_WRITE_POLL: Duration = Duration::from_millis(1);
+
 // ---------------------------------------------------------------------------
 // Shared state between I/O thread and workers
 // ---------------------------------------------------------------------------
@@ -218,6 +232,15 @@ struct EventStreamShared {
     acked_seq: AtomicU64,
     /// Set by Pause, cleared by Resume.
     paused: AtomicBool,
+    /// Raised once by `EventStreamSender::stop` (and `Drop`) to ask the I/O
+    /// thread to exit. Lives in the shared state — rather than as a separately
+    /// threaded `Arc<AtomicBool>` — so every I/O-thread function that already
+    /// holds `shared` (connect, replay, drain, the connected loop) can observe
+    /// it. This is what makes the bounded replay/drain writer
+    /// (`write_all_backpressured`) stop-aware: a write that keeps hitting
+    /// `WouldBlock` against a stuck reader bails out as soon as this is set, so
+    /// the stop-join can never deadlock behind a wedged write (#2877).
+    stop: AtomicBool,
     /// True when the event socket is connected.
     connected: AtomicBool,
     /// Counters.
@@ -261,6 +284,7 @@ impl EventStreamShared {
             next_seq: AtomicU64::new(0),
             acked_seq: AtomicU64::new(0),
             paused: AtomicBool::new(false),
+            stop: AtomicBool::new(false),
             connected: AtomicBool::new(false),
             frames_sent: AtomicU64::new(0),
             frames_dropped: AtomicU64::new(0),
@@ -290,7 +314,6 @@ pub(crate) struct EventStreamSender {
     tx: SyncSender<EventFrame>,
     shared: Arc<EventStreamShared>,
     io_thread: Option<JoinHandle<()>>,
-    stop: Arc<AtomicBool>,
 }
 
 impl EventStreamSender {
@@ -299,16 +322,14 @@ impl EventStreamSender {
     pub(crate) fn new(socket_path: &str) -> Self {
         let (tx, rx) = mpsc::sync_channel(CHANNEL_CAPACITY);
         let shared = Arc::new(EventStreamShared::new());
-        let stop = Arc::new(AtomicBool::new(false));
 
         let shared_clone = shared.clone();
-        let stop_clone = stop.clone();
         let path = socket_path.to_string();
 
         let io_thread = thread::Builder::new()
             .name("xpf-event-stream".to_string())
             .spawn(move || {
-                io_thread_main(rx, shared_clone, stop_clone, path);
+                io_thread_main(rx, shared_clone, path);
             })
             .expect("spawn event stream I/O thread");
 
@@ -316,7 +337,6 @@ impl EventStreamSender {
             tx,
             shared,
             io_thread: Some(io_thread),
-            stop,
         }
     }
 
@@ -345,8 +365,13 @@ impl EventStreamSender {
     }
 
     /// Signal the I/O thread to stop and wait for it to exit.
+    ///
+    /// The stop flag lives in `shared`, so a replay/drain write that is
+    /// currently backpressured against a stuck reader observes it within one
+    /// `REPLAY_DRAIN_WRITE_POLL` and bails out — the join below cannot deadlock
+    /// behind a wedged blocking write (#2877).
     pub(crate) fn stop(&mut self) {
-        self.stop.store(true, Ordering::Release);
+        self.shared.stop.store(true, Ordering::Release);
         if let Some(join) = self.io_thread.take() {
             let _ = join.join();
         }
@@ -677,15 +702,14 @@ impl EventStreamWorkerHandle {
 fn io_thread_main(
     rx: mpsc::Receiver<EventFrame>,
     shared: Arc<EventStreamShared>,
-    stop: Arc<AtomicBool>,
     socket_path: String,
 ) {
     let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
     let mut ctrl_read_buf: Vec<u8> = Vec::with_capacity(128);
 
-    while !stop.load(Ordering::Acquire) {
+    while !shared.stop.load(Ordering::Acquire) {
         // ---- Connect phase ----
-        let stream = match try_connect(&socket_path, &stop) {
+        let stream = match try_connect(&socket_path, &shared) {
             Some(s) => s,
             None => break, // stop requested during connect
         };
@@ -708,7 +732,6 @@ fn io_thread_main(
             &rx,
             &stream,
             &shared,
-            &stop,
             &mut replay_buf,
             &mut ctrl_read_buf,
         );
@@ -728,9 +751,9 @@ fn io_thread_main(
 
 /// Try to connect to the daemon event socket, retrying every 100ms.
 /// Returns None if stop is requested.
-fn try_connect(path: &str, stop: &Arc<AtomicBool>) -> Option<UnixStream> {
+fn try_connect(path: &str, shared: &Arc<EventStreamShared>) -> Option<UnixStream> {
     loop {
-        if stop.load(Ordering::Acquire) {
+        if shared.stop.load(Ordering::Acquire) {
             return None;
         }
         match UnixStream::connect(path) {
@@ -750,6 +773,12 @@ fn replay_buffered(
     acked_seq: u64,
     shared: &Arc<EventStreamShared>,
 ) -> io::Result<()> {
+    // One shared deadline bounds the whole replay so a stuck reader cannot hold
+    // the I/O thread for `frames * deadline` (#2877). `write_all_backpressured`
+    // keeps the socket NONBLOCKING (the canonical data-frame mode) and polls
+    // the stop flag each WouldBlock cycle; on stop/deadline/error it returns
+    // Err and the caller reconnects.
+    let deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
     // Check if replay buffer covers what we need. On a true fresh start
     // (acked_seq == 0 and no buffered frames), start clean. Otherwise any gap
     // at acked+1 requires FullResync, including the acked_seq==0 case where an
@@ -759,7 +788,7 @@ fn replay_buffered(
     if has_gap {
         let seq = shared.next_seq.fetch_add(1, Ordering::Relaxed) + 1;
         let frame = EventFrame::encode_full_resync(seq);
-        write_frame_blocking(stream, &frame)?;
+        write_all_backpressured(stream, frame.as_bytes(), shared, deadline)?;
         shared.frames_sent.fetch_add(1, Ordering::Relaxed);
         eprintln!(
             "xpf-event-stream: sent FullResync (buffer gap: acked={}, oldest_buffered={})",
@@ -775,7 +804,7 @@ fn replay_buffered(
     let mut replayed = 0u64;
     for frame in replay_buf.iter() {
         if frame.seq > acked_seq {
-            write_frame_blocking(stream, frame)?;
+            write_all_backpressured(stream, frame.as_bytes(), shared, deadline)?;
             replayed += 1;
         }
     }
@@ -788,14 +817,62 @@ fn replay_buffered(
     Ok(())
 }
 
-/// Write a full frame to the stream (blocking).
-fn write_frame_blocking(stream: &UnixStream, frame: &EventFrame) -> io::Result<()> {
+/// Write all of `bytes` to the NONBLOCKING `stream`, honoring backpressure
+/// without ever wedging the I/O thread (#2877).
+///
+/// The replay (`replay_buffered`) and drain (`handle_drain_request`) paths must
+/// push frames to a socket whose daemon reader may have stalled. The old
+/// `write_frame_blocking` flipped the socket to BLOCKING and called `write_all`
+/// with no deadline and no stop check, so a stuck reader held the I/O thread in
+/// the blocking write forever — and since `EventStreamSender::stop` joins that
+/// thread, a write-blocked thread could not observe the stop flag and
+/// stop/demotion hung. That violates the slow-consumer invariant in
+/// `docs/session-sync-design.md`: a slow telemetry/session consumer must never
+/// stall the helper.
+///
+/// This writer keeps the socket nonblocking (the same mode the steady-state
+/// data-frame writes use) and, on `WouldBlock`, sleeps `REPLAY_DRAIN_WRITE_POLL`
+/// and retries — polling `shared.stop` every cycle and bailing at `deadline`.
+/// It returns `Err` on stop (Interrupted), deadline (TimedOut), or a real
+/// socket error so the caller reconnects / withholds DrainComplete rather than
+/// blocking indefinitely. `deadline` is shared across all frames in one
+/// replay/drain pass so total time is bounded even if stop is never raised.
+fn write_all_backpressured(
+    stream: &UnixStream,
+    bytes: &[u8],
+    shared: &Arc<EventStreamShared>,
+    deadline: Instant,
+) -> io::Result<()> {
     use std::io::Write;
-    // Temporarily set blocking for reliable writes during replay/drain
-    stream.set_nonblocking(false).ok();
-    let result = (&*stream).write_all(frame.as_bytes());
-    stream.set_nonblocking(true).ok();
-    result
+    let mut written = 0usize;
+    while written < bytes.len() {
+        if shared.stop.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "event stream stop requested during replay/drain write",
+            ));
+        }
+        match (&*stream).write(&bytes[written..]) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "event stream replay/drain write returned 0",
+                ));
+            }
+            Ok(n) => written += n,
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "event stream replay/drain write deadline exceeded",
+                    ));
+                }
+                thread::sleep(REPLAY_DRAIN_WRITE_POLL);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
 }
 
 /// Main connected loop. Returns true if we should reconnect, false if stopping.
@@ -803,7 +880,6 @@ fn run_connected_loop(
     rx: &mpsc::Receiver<EventFrame>,
     stream: &UnixStream,
     shared: &Arc<EventStreamShared>,
-    stop: &Arc<AtomicBool>,
     replay_buf: &mut VecDeque<EventFrame>,
     ctrl_read_buf: &mut Vec<u8>,
 ) -> bool {
@@ -815,7 +891,7 @@ fn run_connected_loop(
     let mut last_write = Instant::now();
 
     loop {
-        if stop.load(Ordering::Acquire) {
+        if shared.stop.load(Ordering::Acquire) {
             return false;
         }
 
@@ -1010,9 +1086,6 @@ fn handle_drain_request(
     shared: &Arc<EventStreamShared>,
     replay_buf: &mut VecDeque<EventFrame>,
 ) {
-    use std::io::Write;
-    use std::time::Instant;
-
     let deadline = Instant::now() + Duration::from_millis(200);
     let was_paused = shared.paused.load(Ordering::Acquire);
 
@@ -1055,30 +1128,39 @@ fn handle_drain_request(
         }
     }
 
-    // Write all replay-buffered frames to socket (blocking)
-    stream.set_nonblocking(false).ok();
+    // Write replay-buffered frames to the socket using the canonical
+    // nonblocking + stop-aware backpressure writer (#2877). The socket stays
+    // nonblocking (the connected loop set it so); a stuck reader can no longer
+    // wedge the I/O thread in a blocking write, and a raised stop flag is
+    // observed within one poll interval. A shared deadline bounds the whole
+    // drain write.
+    let write_deadline = Instant::now() + REPLAY_DRAIN_WRITE_DEADLINE;
+    let mut write_failed = false;
     for frame in replay_buf.iter() {
-        if let Err(e) = (&*stream).write_all(frame.as_bytes()) {
+        if let Err(e) = write_all_backpressured(stream, frame.as_bytes(), shared, write_deadline) {
             eprintln!("xpf-event-stream: drain write error: {e}");
+            write_failed = true;
             break;
         }
     }
 
-    // Send DrainComplete ONLY when the target fence was reached. If the drain
-    // timed out below the fence, withhold DrainComplete: the daemon's
+    // Send DrainComplete ONLY when the target fence was reached AND every frame
+    // was flushed. If the drain timed out below the fence, or a write failed
+    // against a stuck/stopping reader, withhold DrainComplete: the daemon's
     // SendDrainRequest then times out (or rejects a below-target seq) and
     // refuses to proceed with demotion, rather than silently losing the
-    // post-fence sessions on failover (#2876).
+    // post-fence sessions on failover (#2876/#2877).
     let drain_seq = replay_buf.back().map(|f| f.seq).unwrap_or(target_seq);
-    if reached_target {
+    if reached_target && !write_failed {
         let complete_frame = EventFrame::encode_drain_complete(drain_seq);
-        if let Err(e) = (&*stream).write_all(complete_frame.as_bytes()) {
+        if let Err(e) =
+            write_all_backpressured(stream, complete_frame.as_bytes(), shared, write_deadline)
+        {
             eprintln!("xpf-event-stream: drain complete write error: {e}");
         } else {
             shared.frames_sent.fetch_add(1, Ordering::Relaxed);
         }
     }
-    stream.set_nonblocking(true).ok();
 
     // Restore pause state
     if was_paused {

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -664,7 +664,6 @@ fn dataplane_event_budget_stays_held_after_connected_loop_drains_channel() {
         tx,
         shared: shared.clone(),
     };
-    let stop = Arc::new(AtomicBool::new(false));
 
     assert_eq!(
         handle.try_emit_dataplane_event_at(
@@ -675,7 +674,6 @@ fn dataplane_event_budget_stays_held_after_connected_loop_drains_channel() {
     );
 
     let loop_shared = shared.clone();
-    let loop_stop = stop.clone();
     let loop_join = thread::spawn(move || {
         let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
         let mut ctrl_read_buf: Vec<u8> = Vec::new();
@@ -683,7 +681,6 @@ fn dataplane_event_budget_stays_held_after_connected_loop_drains_channel() {
             &rx,
             &helper_side,
             &loop_shared,
-            &loop_stop,
             &mut replay_buf,
             &mut ctrl_read_buf,
         );
@@ -729,7 +726,7 @@ fn dataplane_event_budget_stays_held_after_connected_loop_drains_channel() {
         }
     }
 
-    stop.store(true, Ordering::Release);
+    shared.stop.store(true, Ordering::Release);
     assert!(
         !loop_join.join().expect("connected loop thread"),
         "test loop should stop without requesting reconnect"
@@ -891,7 +888,6 @@ fn replay_evictions_surface_in_event_stream_stats_2382() {
         tx: mpsc::sync_channel(1).0,
         shared: Arc::new(EventStreamShared::new()),
         io_thread: None,
-        stop: Arc::new(AtomicBool::new(false)),
     };
     sender
         .shared
@@ -1022,14 +1018,12 @@ fn stalled_consumer_does_not_grow_backlog_unbounded_end_to_end() {
     let capacity = 64;
     let (tx, rx) = mpsc::sync_channel::<EventFrame>(capacity);
     let shared = Arc::new(EventStreamShared::new());
-    let stop = Arc::new(AtomicBool::new(false));
     let handle = EventStreamWorkerHandle {
         tx: tx.clone(),
         shared: shared.clone(),
     };
 
     let loop_shared = shared.clone();
-    let loop_stop = stop.clone();
     let loop_join = thread::spawn(move || {
         let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
         let mut ctrl_read_buf: Vec<u8> = Vec::new();
@@ -1037,7 +1031,6 @@ fn stalled_consumer_does_not_grow_backlog_unbounded_end_to_end() {
             &rx,
             &helper_side,
             &loop_shared,
-            &loop_stop,
             &mut replay_buf,
             &mut ctrl_read_buf,
         )
@@ -1082,7 +1075,7 @@ fn stalled_consumer_does_not_grow_backlog_unbounded_end_to_end() {
         thread::sleep(Duration::from_millis(1));
     }
 
-    stop.store(true, Ordering::Release);
+    shared.stop.store(true, Ordering::Release);
     let _ = loop_join.join();
 
     assert!(
@@ -1116,7 +1109,6 @@ fn keeping_up_consumer_sees_full_fidelity_and_no_stalls() {
     let capacity = 16;
     let (tx, rx) = mpsc::sync_channel::<EventFrame>(capacity);
     let shared = Arc::new(EventStreamShared::new());
-    let stop = Arc::new(AtomicBool::new(false));
     let handle = EventStreamWorkerHandle {
         tx: tx.clone(),
         shared: shared.clone(),
@@ -1129,7 +1121,6 @@ fn keeping_up_consumer_sees_full_fidelity_and_no_stalls() {
     }
 
     let loop_shared = shared.clone();
-    let loop_stop = stop.clone();
     let loop_join = thread::spawn(move || {
         let mut replay_buf: VecDeque<EventFrame> = VecDeque::with_capacity(REPLAY_BUFFER_CAPACITY);
         let mut ctrl_read_buf: Vec<u8> = Vec::new();
@@ -1137,7 +1128,6 @@ fn keeping_up_consumer_sees_full_fidelity_and_no_stalls() {
             &rx,
             &helper_side,
             &loop_shared,
-            &loop_stop,
             &mut replay_buf,
             &mut ctrl_read_buf,
         )
@@ -1182,7 +1172,7 @@ fn keeping_up_consumer_sees_full_fidelity_and_no_stalls() {
     }
 
     let got = read_join.join().expect("reader thread");
-    stop.store(true, Ordering::Release);
+    shared.stop.store(true, Ordering::Release);
     let _ = loop_join.join();
 
     assert_eq!(got.len(), want, "every frame byte must be delivered");
@@ -1651,4 +1641,102 @@ fn test_drain_at_fence_emits_drain_complete() {
         }
     }
     assert!(saw_complete, "helper did not emit DrainComplete at fence");
+}
+
+// Fill a nonblocking socket's send buffer so subsequent writes return
+// WouldBlock. Used to simulate a daemon that connected but stopped reading.
+fn fill_send_buffer(stream: &std::os::unix::net::UnixStream) {
+    let junk = [0u8; 65536];
+    loop {
+        match (&*stream).write(&junk) {
+            Ok(0) => break,
+            Ok(_) => continue,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+            Err(_) => break,
+        }
+    }
+}
+
+// #2877 fail-on-revert guard: a daemon that connects but stops reading must NOT
+// wedge the I/O thread during REPLAY. With the old blocking `write_all`
+// (set_nonblocking(false)) the replay write blocks forever on a full socket and
+// cannot observe the stop flag, so `EventStreamSender::stop` (which joins the
+// I/O thread) hangs. The fixed `write_all_backpressured` keeps the socket
+// nonblocking and polls `shared.stop`, so replay returns promptly once stop is
+// raised. Reverting to the blocking write makes this time out -> RED.
+#[test]
+fn test_replay_does_not_wedge_on_stuck_reader_2877() {
+    let (daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    helper_side.set_nonblocking(true).unwrap();
+    // Daemon never reads -> fill the send buffer so every write WouldBlocks.
+    fill_send_buffer(&helper_side);
+
+    let shared = Arc::new(EventStreamShared::new());
+    // One buffered frame to replay (seq 1 > acked 0, no gap).
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    replay_buf.push_back(replay_seq_frame(1));
+
+    let (done_tx, done_rx) = mpsc::channel::<bool>();
+    let h_shared = shared.clone();
+    let handle = thread::spawn(move || {
+        let r = replay_buffered(&helper_side, &mut replay_buf, 0, &h_shared);
+        done_tx.send(r.is_err()).ok();
+    });
+
+    // Let the replay write block on the full socket, then ask the helper to
+    // stop. A stop-aware writer must observe this within one poll interval.
+    thread::sleep(Duration::from_millis(50));
+    shared.stop.store(true, Ordering::Release);
+
+    let completed = done_rx.recv_timeout(Duration::from_secs(2));
+    assert!(
+        completed.is_ok(),
+        "replay wedged on a stuck reader and never observed stop (#2877 regression)"
+    );
+    assert!(
+        completed.unwrap(),
+        "replay against a stuck/stopping reader must return Err, not succeed"
+    );
+
+    drop(daemon_side);
+    let _ = handle.join();
+}
+
+// #2877 fail-on-revert guard: a stuck daemon reader must NOT wedge the I/O
+// thread during DRAIN either. handle_drain_request used to flip the socket to
+// blocking and `write_all` all frames; on a full socket that blocks forever and
+// the stop flag is never seen. The fixed path uses `write_all_backpressured`,
+// which bails on stop. Reverting makes this time out -> RED.
+#[test]
+fn test_drain_does_not_wedge_on_stuck_reader_2877() {
+    let (daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    helper_side.set_nonblocking(true).unwrap();
+    fill_send_buffer(&helper_side);
+
+    let shared = Arc::new(EventStreamShared::new());
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    for seq in 1..=3u64 {
+        replay_buf.push_back(replay_seq_frame(seq));
+    }
+    // Keep `tx` alive so the drain loop sees Empty (not Disconnected) and
+    // reaches the fence via replay_buf.back().seq (3) >= target (3).
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+
+    let (done_tx, done_rx) = mpsc::channel::<()>();
+    let h_shared = shared.clone();
+    let handle = thread::spawn(move || {
+        handle_drain_request(3, &rx, &helper_side, &h_shared, &mut replay_buf);
+        done_tx.send(()).ok();
+    });
+
+    thread::sleep(Duration::from_millis(50));
+    shared.stop.store(true, Ordering::Release);
+
+    assert!(
+        done_rx.recv_timeout(Duration::from_secs(2)).is_ok(),
+        "drain wedged on a stuck reader and never observed stop (#2877 regression)"
+    );
+
+    drop(daemon_side);
+    let _ = handle.join();
 }

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -683,6 +683,7 @@ fn dataplane_event_budget_stays_held_after_connected_loop_drains_channel() {
             &loop_shared,
             &mut replay_buf,
             &mut ctrl_read_buf,
+            Duration::from_secs(10),
         );
         drain_remaining(&rx, &loop_shared);
         release_replay_dataplane_event_queue_budget(&loop_shared, &mut replay_buf);
@@ -1033,6 +1034,7 @@ fn stalled_consumer_does_not_grow_backlog_unbounded_end_to_end() {
             &loop_shared,
             &mut replay_buf,
             &mut ctrl_read_buf,
+            Duration::from_secs(10),
         )
     });
 
@@ -1130,6 +1132,7 @@ fn keeping_up_consumer_sees_full_fidelity_and_no_stalls() {
             &loop_shared,
             &mut replay_buf,
             &mut ctrl_read_buf,
+            Duration::from_secs(10),
         )
     });
 
@@ -1788,4 +1791,56 @@ fn test_drain_does_not_wedge_on_stuck_reader_2877() {
 
     drop(daemon_side);
     let _ = handle.join();
+}
+
+// #2883 fail-on-revert guard: the idle keepalive must ride the normal write_buf
+// backpressure path. The old code called write_all directly on the nonblocking
+// socket and returned true (immediate reconnect) on ANY error, including
+// WouldBlock when the kernel send buffer is full under a slow reader. Here a
+// connected daemon stops reading (send buffer filled) and the keepalive fires
+// (interval 0): the fixed loop enqueues it into write_buf as ordinary
+// backpressure and keeps running; the old loop reconnects. We assert the loop
+// does NOT report reconnect. Reverting to the write_all + `return true`
+// keepalive makes the loop return true -> RED.
+#[test]
+fn test_idle_keepalive_wouldblock_is_backpressure_not_reconnect_2883() {
+    let (daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    helper_side.set_nonblocking(true).unwrap();
+    // Daemon connects but never reads -> fill the send buffer so the keepalive
+    // write returns WouldBlock.
+    fill_send_buffer(&helper_side);
+
+    // Empty channel + alive tx -> the connected loop is idle (no data frames),
+    // so the idle keepalive path is exercised.
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    let shared = Arc::new(EventStreamShared::new());
+
+    let loop_shared = shared.clone();
+    let loop_join = thread::spawn(move || {
+        let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+        let mut ctrl_read_buf: Vec<u8> = Vec::new();
+        // keepalive_interval 0 -> the keepalive fires as soon as the loop is
+        // idle, against the already-full socket.
+        run_connected_loop(
+            &rx,
+            &helper_side,
+            &loop_shared,
+            &mut replay_buf,
+            &mut ctrl_read_buf,
+            Duration::from_millis(0),
+        )
+    });
+
+    // Give the idle keepalive several chances to fire against the full socket.
+    // The buggy write_all keepalive would have reconnected (returned true) by
+    // now; the fixed path keeps running as backpressure.
+    thread::sleep(Duration::from_millis(200));
+    shared.stop.store(true, Ordering::Release);
+    let reconnect = loop_join.join().expect("connected loop thread");
+
+    assert!(
+        !reconnect,
+        "idle keepalive WouldBlock must be backpressure, not a fatal reconnect (#2883)"
+    );
+    drop(daemon_side);
 }

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -1643,6 +1643,55 @@ fn test_drain_at_fence_emits_drain_complete() {
     assert!(saw_complete, "helper did not emit DrainComplete at fence");
 }
 
+// #2882 fail-on-revert guard: DrainRequest is contracted as "flush all
+// buffered events UP TO target seq". With a replay buffer holding seqs 1..=10
+// and a fence target of 5, handle_drain_request must write ONLY seqs 1..=5 and
+// report DrainComplete == 5 (the fence) — not every buffered frame and not
+// replay_buf.back().seq (10). Reverting the `frame.seq <= target_seq` filter
+// makes 6..=10 leak onto the wire; reverting the drain_seq fix reports 10 ->
+// either makes this RED.
+#[test]
+fn test_drain_filters_to_target_and_reports_target_2882() {
+    let (mut daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    daemon_side
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    let shared = Arc::new(EventStreamShared::new());
+
+    // Buffer holds frames newer than the fence (1..=10, fence = 5).
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    for seq in 1..=10u64 {
+        replay_buf.push_back(replay_seq_frame(seq));
+    }
+    // Keep tx alive so the drain loop sees Empty (not Disconnected) and reaches
+    // the fence via replay_buf.back().seq (10) >= target (5).
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+
+    handle_drain_request(5, &rx, &helper_side, &shared, &mut replay_buf);
+
+    // Collect everything the helper wrote until DrainComplete.
+    let mut data_seqs: Vec<u64> = Vec::new();
+    let mut drain_complete_seq: Option<u64> = None;
+    while let Some((msg_type, seq)) = try_read_frame_header(&mut daemon_side) {
+        if msg_type == MSG_DRAIN_COMPLETE {
+            drain_complete_seq = Some(seq);
+            break;
+        }
+        data_seqs.push(seq);
+    }
+
+    assert_eq!(
+        data_seqs,
+        vec![1, 2, 3, 4, 5],
+        "drain must write only frames with seq <= target fence (#2882)"
+    );
+    assert_eq!(
+        drain_complete_seq,
+        Some(5),
+        "DrainComplete must report the fence target, not replay_buf.back().seq (#2882)"
+    );
+}
+
 // Fill a nonblocking socket's send buffer so subsequent writes return
 // WouldBlock. Used to simulate a daemon that connected but stopped reading.
 fn fill_send_buffer(stream: &std::os::unix::net::UnixStream) {


### PR DESCRIPTION
Closes #2877
Closes #2882
Closes #2883

Three coupled defects in the `userspace-dp/src/event_stream/mod.rs` I/O
write path, all converging on the canonical nonblocking `write_buf` +
WouldBlock backpressure mechanism. Fixed as three bisectable commits.

## #2877 (HIGH) — blocking replay/drain writes wedge stop/demotion
`replay_buffered` and `handle_drain_request` flipped the socket to
BLOCKING and called `write_all` with no deadline and no stop check. A
daemon that connected but stopped reading wedged the I/O thread in the
blocking write; since `EventStreamSender::stop` joins that thread, a
write-blocked thread could not observe the stop flag and stop/RG demotion
hung — violating the slow-consumer invariant
(`docs/session-sync-design.md`).

Fix: the stop flag moves into `EventStreamShared.stop` (so every
I/O-thread function observes it), and replay/drain write through a new
`write_all_backpressured` that keeps the socket NONBLOCKING and, on
WouldBlock, sleeps `REPLAY_DRAIN_WRITE_POLL` and retries while polling
`shared.stop` and bailing at a 5s `REPLAY_DRAIN_WRITE_DEADLINE` shared
across the pass. Replay -> reconnect on stuck reader; drain withholds
DrainComplete on a write failure (daemon then times out, refuses
demotion, #2876).

## #2882 (MEDIUM) — drain ignored the target_seq fence
`handle_drain_request` wrote EVERY frame in `replay_buf.iter()` with no
`seq <= target_seq` filter and reported `replay_buf.back().seq` instead
of the requested target — "dump current replay head" rather than "fence
up to target". Fix: skip frames `> target_seq`, report the highest seq
`<= target` actually written (or `target_seq` when the buffer was already
ACK-trimmed below the fence).

## #2883 (MEDIUM) — idle keepalive treated WouldBlock as fatal
The idle keepalive called `write_all` directly on the nonblocking socket
and `return true`d (reconnect) on any error, including WouldBlock under a
slow reader — reconnect churn -> replay storms. Fix: enqueue the
keepalive into `write_buf` so the normal flush handles WouldBlock as
backpressure. The keepalive interval is now injected into
`run_connected_loop` (`KEEPALIVE_IDLE_INTERVAL` = 10s in production).

## Tests (fail-on-revert verified, each went RED on revert)
- `test_replay_does_not_wedge_on_stuck_reader_2877`,
  `test_drain_does_not_wedge_on_stuck_reader_2877` — stuck reader during
  replay/drain observes the stop flag, returns within 2s (RED: wedges).
- `test_drain_filters_to_target_and_reports_target_2882` — buffer
  1..=10, fence 5 -> only 1..=5 written, DrainComplete == 5 (RED: 6..=10
  leak / reports 10).
- `test_idle_keepalive_wouldblock_is_backpressure_not_reconnect_2883` —
  full send buffer + keepalive fires -> no reconnect (RED: reconnects).

`cargo build --release` clean; `cargo test --release` event_stream 69/69
pass. The only full-suite failure is the pre-existing
`afxdp::worker_queue concurrent_recovery` parallel-load flake (passes in
isolation, unrelated).

NOTE: this is the HA session-sync/demotion I/O path — run test-failover
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi