### PR TITLE
event_stream: paused-demotion drain poison + control-payload cap (#2875, #2879)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -21650,3 +21650,19 @@ top.
   pkg/dataplane/userspace/eventstream.go,
   pkg/dataplane/userspace/eventstream_test.go,
   pkg/dataplane/userspace/protocol.go
+
+- **Timestamp**: 2026-06-26
+  **Action**: #2875 + #2879 event-stream buffer robustness — paused-demotion
+  drain poison-on-session-eviction (withhold DrainComplete + emit FullResync;
+  poison set on session-delta eviction while paused in evict_replay_frame,
+  cleared at MSG_PAUSE and after the poisoned-drain resync) and a
+  daemon→helper control-frame payload cap (MAX_CONTROL_PAYLOAD_LEN=0, reject
+  any nonzero/oversized payload_len before buffering → disconnect; all current
+  opcodes are header-only). Added EventFrame::is_session_sync(). Also removed a
+  stray `stop:` field initializer in test_sender that broke the test build on
+  master. 6 new fail-on-revert tests.
+  **File(s)**: userspace-dp/src/event_stream/mod.rs,
+  userspace-dp/src/event_stream/codec.rs,
+  userspace-dp/src/event_stream/tests.rs,
+  userspace-dp/src/event_stream/README.md,
+  docs/session-sync-design.md

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -651,6 +651,22 @@ Poison lifecycle: set on session-frame eviction during pause; cleared at
 pause-start (`MSG_PAUSE`, so each fresh pause window starts clean) and after a
 poisoned drain emits its `FullResync`.
 
+**Control-frame payload cap (#2879).** `process_control_frames` reads the
+32-bit length from each daemon→helper frame and waits for the full frame before
+parsing. All current daemon→helper opcodes (Ack/Pause/Resume/DrainRequest) are
+header-only (zero payload), so `MAX_CONTROL_PAYLOAD_LEN` is `0`. The parser
+validates the declared length on the header alone (the loop already requires a
+full 16-byte header) BEFORE waiting for the rest of the frame: any
+`payload_len` above the cap can never form a valid control frame, so the helper
+disconnects (reconnect clears `ctrl_read_buf`) instead of buffering. Without
+this a buggy or compromised local daemon could send a header with
+`payload_len = 1<<30` and trickle bytes, growing `ctrl_read_buf` without bound
+on the forwarding plane while consuming nothing. A legitimately partial
+header-only frame still parses once complete — a split HEADER never reaches the
+length check, and a zero `payload_len` always passes. The constant is named so
+a future payload-carrying opcode raises it deliberately rather than the parser
+honoring an arbitrary 32-bit length.
+
 ### Reconnect / Replay
 
 On disconnect, the helper retains its replay buffer (bounded, ~4096 events per

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -628,6 +628,29 @@ demotion correctness to unrelated later-buffered frames. DrainComplete is still
 withheld entirely if the fence was never reached within the drain timeout
 (#2876) or a frame write failed against a stuck/stopping reader (#2877).
 
+**Lossless-demotion fence for session deltas (#2875).** A paused drain is the
+stable window the future owner reads before demotion completes, but the replay
+buffer is bounded (`REPLAY_BUFFER_CAPACITY`, 4096). A pause long enough to
+overrun the buffer evicts the oldest frames (the #2382 path), and an evicted
+frame may be an HA session-sync delta (`SessionOpen`/`SessionUpdate`/
+`SessionClose`). Reporting `DrainComplete` after such an eviction would finish
+demotion even though the evicted session mutation never reached the new owner —
+silent session loss on failover. The drain is therefore POISONED on any
+session-delta eviction during pause: `evict_replay_frame` sets
+`session_evicted_while_paused` when it evicts a frame whose
+`EventFrame::is_session_sync()` is true while the helper is paused, and
+`handle_drain_request` then WITHHOLDS `DrainComplete` and emits a `FullResync`
+(type 9) instead — the same recovery path as the reconnect replay-gap below.
+The daemon's `SendDrainRequest` receives no DrainComplete, times out, and
+refuses to proceed with demotion until the resync re-exports full session
+state. The fix is poison-on-loss, NOT an unbounded buffer (that would be a
+memory DoS on the forwarding plane). Telemetry eviction (RT_FLOW
+deny/screen/filter + session create/close frames) does NOT poison — those are
+not session-sync deltas, and poisoning on them would cause spurious resyncs.
+Poison lifecycle: set on session-frame eviction during pause; cleared at
+pause-start (`MSG_PAUSE`, so each fresh pause window starts clean) and after a
+poisoned drain emits its `FullResync`.
+
 ### Reconnect / Replay
 
 On disconnect, the helper retains its replay buffer (bounded, ~4096 events per

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -317,6 +317,22 @@ cluster-scoped.
   during replay returns Err -> reconnect; during drain it withholds
   DrainComplete so the daemon times out and refuses demotion (#2876) rather
   than reporting a false drain.
+- **Control-frame payload cap (#2879).** `process_control_frames()` reads a
+  32-bit `payload_len` from each daemon→helper frame and waits for the full
+  `FRAME_HEADER_SIZE + payload_len` bytes before parsing. Every current
+  daemon→helper opcode (Ack/Pause/Resume/DrainRequest) is HEADER-ONLY (zero
+  payload), so `MAX_CONTROL_PAYLOAD_LEN` is `0`. Without a cap a buggy or
+  compromised local daemon sends a header with `payload_len = 1<<30` and
+  trickles bytes; the helper would keep extending `ctrl_read_buf` (consuming
+  nothing, since the frame never completes) and grow the heap without bound on
+  the **forwarding plane**. The parser validates `payload_len` on the header
+  alone (the loop guard guarantees a full 16-byte header) BEFORE waiting for
+  the rest of the frame: any `payload_len > MAX_CONTROL_PAYLOAD_LEN`
+  disconnects (returns `Some(true)` → reconnect, which clears `ctrl_read_buf`)
+  instead of buffering. A legitimately partial header-only frame still works —
+  `payload_len == 0` passes, and a split HEADER never reaches the check. The
+  constant is named so a future payload-carrying opcode raises it deliberately
+  rather than the parser honoring an arbitrary 32-bit length.
 - RT_FLOW dataplane telemetry producers must use
   `try_emit_dataplane_event_at()` (or, for a producer that builds its own
   frame layout such as the session-close/create frames,

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -272,6 +272,25 @@ cluster-scoped.
   already-bounded replay buffer, never to `write_buf`. **Invariant: the
   data plane never stalls because a telemetry consumer is slow; a stuck
   consumer degrades telemetry (counted drops), nothing else.**
+- **Lossless-demotion fence for session deltas (#2875).** A paused drain is
+  the stable window the future owner reads before demotion completes
+  (`docs/session-sync-design.md`). The replay buffer is bounded, so a long
+  pause that overruns `REPLAY_BUFFER_CAPACITY` evicts the oldest frames —
+  and an evicted frame may be an HA session-sync delta
+  (`MSG_SESSION_OPEN`/`UPDATE`/`CLOSE`). Bumping `frames_replay_evicted` and
+  reporting `DrainComplete` anyway would finish demotion with **lost session
+  mutations on the new owner**. The fix is poison-on-loss, NOT an unbounded
+  buffer (that would be a memory DoS on the forwarding plane):
+  `evict_replay_frame()` sets `session_evicted_while_paused` when it evicts a
+  frame for which `EventFrame::is_session_sync()` is true AND the helper is
+  paused. `handle_drain_request()` then WITHHOLDS `DrainComplete` and emits a
+  `FullResync` instead, so the daemon re-exports full session state (the same
+  recovery path as #2874 / the replay-gap resync) and refuses to proceed with
+  demotion. **Telemetry eviction does NOT poison** (RT_FLOW deny/screen/filter
+  + session create/close frames return `is_session_sync() == false`) — that
+  would cause spurious resyncs. Lifecycle: set on a session-frame eviction
+  during pause; cleared at pause-start (`MSG_PAUSE`, so each window starts
+  clean) and after the poisoned drain emits its `FullResync`.
 - **Idle keepalive rides write_buf, not write_all (#2883).** The connected
   loop enqueues its idle keepalive frame into `write_buf` (the same path data
   frames use), so a `WouldBlock` on a full kernel send buffer is ordinary

--- a/userspace-dp/src/event_stream/codec.rs
+++ b/userspace-dp/src/event_stream/codec.rs
@@ -881,6 +881,21 @@ impl EventFrame {
         DataplaneEventKind::from_msg_type(self.data[4])
     }
 
+    /// True for the correctness-critical HA session-sync deltas
+    /// (`SessionOpen` / `SessionUpdate` / `SessionClose`). These mutate peer
+    /// session state on failover, so they must not be silently dropped from a
+    /// paused demotion drain window (#2875). Telemetry / RT_FLOW frames
+    /// (deny / screen / filter, RT_FLOW session create+close) return `false`:
+    /// evicting them is a tolerated telemetry loss, not a demotion-correctness
+    /// failure, and must not trigger a spurious FullResync. Same discriminator
+    /// (`data[4]` msg_type) the budget/release path keys on (#2874).
+    pub(super) fn is_session_sync(&self) -> bool {
+        matches!(
+            self.data[4],
+            MSG_SESSION_OPEN | MSG_SESSION_CLOSE | MSG_SESSION_UPDATE
+        )
+    }
+
     #[allow(dead_code)]
     pub(crate) fn decode_dataplane_event(&self) -> Option<DataplaneEventPayload> {
         decode_dataplane_event(self.data[4], self.dataplane_event_payload()?)

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -139,6 +139,22 @@ const CHANNEL_CAPACITY: usize = 8192;
 /// Maximum frames retained for replay after disconnect.
 const REPLAY_BUFFER_CAPACITY: usize = 4096;
 
+/// Hard ceiling on any single daemon->helper control-frame payload (#2879).
+///
+/// `process_control_frames` reads a 32-bit `payload_len` from the wire and waits
+/// for `FRAME_HEADER_SIZE + payload_len` bytes before parsing. Every current
+/// daemon->helper opcode (Ack / Pause / Resume / DrainRequest) is HEADER-ONLY --
+/// zero payload -- so this is 0 today. Without a cap a buggy or compromised local
+/// daemon sends a header with `payload_len = 1<<30` and trickles bytes; the
+/// helper would keep extending `ctrl_read_buf` (consuming nothing, since the
+/// frame never completes) and grow the heap without bound on the forwarding
+/// plane. Any `payload_len` above this ceiling can never form a valid control
+/// frame, so the helper disconnects (reconnect resets `ctrl_read_buf`) instead
+/// of buffering. It is a NAMED constant so a future payload-carrying opcode
+/// raises it deliberately, rather than the parser silently honoring an arbitrary
+/// 32-bit length.
+const MAX_CONTROL_PAYLOAD_LEN: usize = 0;
+
 /// Hard cap on the I/O thread's pending socket-write backlog (`write_buf`).
 ///
 /// The bounded mpsc channel (`CHANNEL_CAPACITY`) is the only intended
@@ -1069,6 +1085,29 @@ fn process_control_frames(
             data[offset + 2],
             data[offset + 3],
         ]);
+        // #2879: reject an impossible payload_len BEFORE waiting for the rest of
+        // the frame. The full header is present (loop guard above), so we can
+        // validate the declared length on the header alone, regardless of how
+        // few payload bytes have arrived. Every current daemon->helper opcode is
+        // header-only, so any payload_len beyond MAX_CONTROL_PAYLOAD_LEN can
+        // never form a valid frame. Disconnecting (Some(true) -> reconnect,
+        // which clears ctrl_read_buf) stops a buggy/compromised daemon from
+        // trickling a 1<<30-length header and growing ctrl_read_buf without
+        // bound on the forwarding plane. A legitimately partial header-only
+        // frame still works: a payload_len of 0 passes here, and a split HEADER
+        // never reaches this point (the loop guard requires a full 16-byte
+        // header first). `offset` is returned so any complete frames parsed
+        // before the bad one are still accounted as consumed.
+        if payload_len as usize > MAX_CONTROL_PAYLOAD_LEN {
+            eprintln!(
+                "xpf-event-stream: control frame opcode {} declared payload_len={} \
+                 exceeds max {} -- disconnecting (#2879)",
+                data[offset + 4],
+                payload_len,
+                MAX_CONTROL_PAYLOAD_LEN
+            );
+            return (Some(true), offset);
+        }
         let frame_len = FRAME_HEADER_SIZE + payload_len as usize;
         if offset + frame_len > data.len() {
             break; // incomplete frame -- wait for more data

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -234,6 +234,30 @@ struct EventStreamShared {
     acked_seq: AtomicU64,
     /// Set by Pause, cleared by Resume.
     paused: AtomicBool,
+    /// #2875: poison flag for the paused demotion drain. Set when a SESSION-SYNC
+    /// delta (`SessionOpen`/`SessionUpdate`/`SessionClose`) is evicted from the
+    /// bounded replay buffer at `REPLAY_BUFFER_CAPACITY` WHILE PAUSED.
+    ///
+    /// A paused drain is meant to be a lossless, stable window the future owner
+    /// reads before demotion completes (`docs/session-sync-design.md`). The
+    /// replay buffer is bounded, so a long pause that overruns it evicts the
+    /// oldest frames (bumping `frames_replay_evicted` only). If an evicted frame
+    /// is a session mutation, that mutation never reaches the new owner — yet
+    /// `handle_drain_request` would still report `DrainComplete` and demotion
+    /// would finish with lost sessions on the peer.
+    ///
+    /// When set, `handle_drain_request` WITHHOLDS `DrainComplete` and emits a
+    /// `FullResync` instead, forcing the daemon to re-export full session state
+    /// (the same recovery path as #2874 / the replay-gap resync). Telemetry
+    /// eviction does NOT set this — it must not trigger a spurious resync.
+    ///
+    /// Lifecycle: set on a session-frame eviction during pause
+    /// (`evict_replay_frame`); cleared at pause-start (`MSG_PAUSE`) so each
+    /// fresh pause window starts clean, and after a poisoned drain emits its
+    /// `FullResync` (window consumed — a later eviction re-poisons). NOT a
+    /// substitute for bounding the buffer: the fix is poison-on-loss, the buffer
+    /// stays bounded (no unbounded growth / memory DoS).
+    session_evicted_while_paused: AtomicBool,
     /// Raised once by `EventStreamSender::stop` (and `Drop`) to ask the I/O
     /// thread to exit. Lives in the shared state — rather than as a separately
     /// threaded `Arc<AtomicBool>` — so every I/O-thread function that already
@@ -286,6 +310,7 @@ impl EventStreamShared {
             next_seq: AtomicU64::new(0),
             acked_seq: AtomicU64::new(0),
             paused: AtomicBool::new(false),
+            session_evicted_while_paused: AtomicBool::new(false),
             stop: AtomicBool::new(false),
             connected: AtomicBool::new(false),
             frames_sent: AtomicU64::new(0),
@@ -385,7 +410,6 @@ impl EventStreamSender {
                 tx,
                 shared,
                 io_thread: None,
-                stop: Arc::new(AtomicBool::new(false)),
             },
             rx,
         )
@@ -1105,6 +1129,12 @@ fn process_control_frames(
                 }
             }
             MSG_PAUSE => {
+                // #2875: a fresh pause window starts lossless. Clear any poison
+                // left from a previous drain so only an eviction WITHIN this
+                // pause window can withhold the upcoming DrainComplete.
+                shared
+                    .session_evicted_while_paused
+                    .store(false, Ordering::Release);
                 shared.paused.store(true, Ordering::Release);
                 eprintln!("xpf-event-stream: paused by daemon");
             }
@@ -1224,7 +1254,43 @@ fn handle_drain_request(
     } else {
         drained_up_to
     };
-    if reached_target && !write_failed {
+
+    // #2875: a SESSION-SYNC delta was evicted from the bounded replay buffer
+    // while paused, so this drain window is missing mutations the new owner
+    // needs. The drain is POISONED: it must NOT report DrainComplete (that
+    // would complete demotion with lost sessions on the peer). Checked AFTER
+    // the drain+write loops so an eviction during this drain's own
+    // push_replay_frame calls is also caught.
+    let session_evicted = shared
+        .session_evicted_while_paused
+        .load(Ordering::Acquire);
+
+    if session_evicted {
+        // Surface the poison the same way as #2874 / the replay-gap path: emit
+        // a FullResync so the daemon re-exports full session state. The
+        // daemon's SendDrainRequest receives no DrainComplete, times out, and
+        // refuses to proceed with demotion until the resync re-establishes
+        // state. Allocate a fresh seq (mirrors replay_buffered's resync).
+        let resync_seq = shared.next_seq.fetch_add(1, Ordering::Relaxed) + 1;
+        let resync_frame = EventFrame::encode_full_resync(resync_seq);
+        if let Err(e) =
+            write_all_backpressured(stream, resync_frame.as_bytes(), shared, write_deadline)
+        {
+            eprintln!("xpf-event-stream: drain-poison FullResync write error: {e}");
+        } else {
+            shared.frames_sent.fetch_add(1, Ordering::Relaxed);
+            eprintln!(
+                "xpf-event-stream: drain POISONED -- session delta evicted while paused; \
+                 sent FullResync seq {} instead of DrainComplete (demotion must full-resync)",
+                resync_seq
+            );
+        }
+        // Window consumed: clear so a later clean drain in this pause window can
+        // complete (a fresh session-frame eviction re-poisons).
+        shared
+            .session_evicted_while_paused
+            .store(false, Ordering::Release);
+    } else if reached_target && !write_failed {
         let complete_frame = EventFrame::encode_drain_complete(drain_seq);
         if let Err(e) =
             write_all_backpressured(stream, complete_frame.as_bytes(), shared, write_deadline)
@@ -1240,7 +1306,9 @@ fn handle_drain_request(
         shared.paused.store(true, Ordering::Release);
     }
 
-    if reached_target {
+    if session_evicted {
+        // Already logged above (poison + FullResync).
+    } else if reached_target {
         eprintln!("xpf-event-stream: drain complete up to seq {}", drain_seq);
     } else {
         eprintln!(
@@ -1367,10 +1435,23 @@ fn evict_replay_frame(
     replay_buf: &mut VecDeque<EventFrame>,
 ) -> Option<EventFrame> {
     let frame = pop_replay_frame(shared, replay_buf);
-    if frame.is_some() {
+    if let Some(evicted) = frame.as_ref() {
         shared
             .frames_replay_evicted
             .fetch_add(1, Ordering::Relaxed);
+        // #2875: evicting a SESSION-SYNC delta WHILE PAUSED loses a session
+        // mutation the future owner needs to take over cleanly. Poison the
+        // pending demotion drain so `handle_drain_request` withholds
+        // DrainComplete and forces a FullResync instead of silently
+        // completing demotion. Telemetry eviction is a tolerated loss and
+        // must NOT poison (no spurious resync). Read `paused` here so the
+        // poison fires for evictions both in the connected-loop paused drain
+        // and in the drain-request drain loop (both run while paused).
+        if evicted.is_session_sync() && shared.paused.load(Ordering::Acquire) {
+            shared
+                .session_evicted_while_paused
+                .store(true, Ordering::Release);
+        }
     }
     frame
 }

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -1998,3 +1998,105 @@ fn test_pause_start_clears_drain_poison_2875() {
         "MSG_PAUSE must clear stale drain poison (#2875)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #2879 — daemon→helper control frames must have a bounded payload
+// ---------------------------------------------------------------------------
+
+// Build a control header with an arbitrary payload_len and opcode.
+fn build_ctrl_header(payload_len: u32, msg_type: u8) -> [u8; FRAME_HEADER_SIZE] {
+    let mut buf = [0u8; FRAME_HEADER_SIZE];
+    buf[0..4].copy_from_slice(&payload_len.to_le_bytes());
+    buf[4] = msg_type;
+    buf
+}
+
+// #2879 fail-on-revert guard: a daemon that declares payload_len = 1<<30 and
+// trickles bytes must be DISCONNECTED before the helper buffers the (never
+// completing) frame, so ctrl_read_buf cannot grow without bound. Reverting the
+// cap makes process_control_frames return (None, 0) — incomplete-frame break —
+// and the bytes accumulate -> this goes RED.
+#[test]
+fn test_oversized_control_payload_disconnects_2879() {
+    let shared = Arc::new(EventStreamShared::new());
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    let (sock_a, _sock_b) = std::os::unix::net::UnixStream::pair().unwrap();
+
+    let mut ctrl: Vec<u8> = Vec::new();
+    ctrl.extend_from_slice(&build_ctrl_header(1u32 << 30, MSG_PAUSE));
+    // Trickle a few payload bytes — far short of 1<<30.
+    ctrl.extend_from_slice(&[0u8; 8]);
+
+    let (action, _consumed) =
+        process_control_frames(&ctrl, &shared, &rx, &sock_a, &mut replay_buf);
+    assert_eq!(
+        action,
+        Some(true),
+        "oversized payload_len must force a disconnect, not unbounded buffering (#2879)"
+    );
+    // The bogus PAUSE frame must NOT have been processed before the disconnect.
+    assert!(
+        !shared.paused.load(Ordering::Acquire),
+        "an invalid oversized frame must not be applied (#2879)"
+    );
+}
+
+// #2879: the current daemon→helper opcodes (Ack/Pause/Resume/DrainRequest) are
+// header-only; a NONZERO payload_len on any of them is invalid and must be
+// rejected (disconnect).
+#[test]
+fn test_nonzero_payload_on_header_only_opcodes_rejected_2879() {
+    let shared = Arc::new(EventStreamShared::new());
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    let (sock_a, _sock_b) = std::os::unix::net::UnixStream::pair().unwrap();
+
+    for opcode in [MSG_ACK, MSG_PAUSE, MSG_RESUME, MSG_DRAIN_REQUEST] {
+        let mut ctrl: Vec<u8> = Vec::new();
+        // payload_len = 8 (nonzero) plus 8 payload bytes so the frame is fully
+        // present — proving the rejection is on the length, not on completeness.
+        ctrl.extend_from_slice(&build_ctrl_header(8, opcode));
+        ctrl.extend_from_slice(&[0u8; 8]);
+        let (action, _consumed) =
+            process_control_frames(&ctrl, &shared, &rx, &sock_a, &mut replay_buf);
+        assert_eq!(
+            action,
+            Some(true),
+            "nonzero payload on header-only opcode {opcode} must be rejected (#2879)"
+        );
+    }
+}
+
+// #2879 no-regression: a legitimate header-only control frame whose HEADER is
+// split across two reads must still parse once complete — the cap only rejects
+// an invalid payload_len, never a merely-incomplete header.
+#[test]
+fn test_split_header_only_frame_still_parses_2879() {
+    let shared = Arc::new(EventStreamShared::new());
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    let (sock_a, _sock_b) = std::os::unix::net::UnixStream::pair().unwrap();
+
+    let header = build_ctrl_header(0, MSG_PAUSE); // header-only, zero payload
+    let mut ctrl: Vec<u8> = Vec::new();
+
+    // First read: only the first 8 bytes of the 16-byte header.
+    ctrl.extend_from_slice(&header[..8]);
+    let (action, consumed) =
+        process_control_frames(&ctrl, &shared, &rx, &sock_a, &mut replay_buf);
+    assert!(action.is_none(), "partial header must not disconnect (#2879)");
+    assert_eq!(consumed, 0, "partial header must not be consumed");
+    assert!(!shared.paused.load(Ordering::Acquire));
+
+    // Second read: the rest of the header arrives; the PAUSE now applies.
+    ctrl.extend_from_slice(&header[8..]);
+    let (action, consumed) =
+        process_control_frames(&ctrl, &shared, &rx, &sock_a, &mut replay_buf);
+    assert!(action.is_none());
+    assert_eq!(consumed, FRAME_HEADER_SIZE);
+    assert!(
+        shared.paused.load(Ordering::Acquire),
+        "a header-only frame split across reads must still parse (#2879)"
+    );
+}

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -1844,3 +1844,157 @@ fn test_idle_keepalive_wouldblock_is_backpressure_not_reconnect_2883() {
     );
     drop(daemon_side);
 }
+
+// ---------------------------------------------------------------------------
+// #2875 — paused-demotion drain must not silently lose session-sync deltas
+// ---------------------------------------------------------------------------
+
+// Build a benign header-only TELEMETRY frame (RT_FLOW screen-drop type) so we
+// can prove that evicting it while paused does NOT poison the drain. Unlike
+// `replay_seq_frame` (a SESSION_OPEN), this msg_type is not a session-sync
+// delta, so `EventFrame::is_session_sync()` returns false for it.
+fn telemetry_seq_frame(seq: u64) -> EventFrame {
+    let mut data = [0u8; 256];
+    data[4] = super::codec::MSG_SCREEN_DROP;
+    data[8..16].copy_from_slice(&seq.to_le_bytes());
+    EventFrame {
+        data,
+        len: FRAME_HEADER_SIZE as u16,
+        seq,
+    }
+}
+
+// #2875 fail-on-revert guard: pause the helper, overrun the bounded replay
+// buffer so a SESSION-SYNC delta is evicted, then issue DrainRequest. The drain
+// MUST be poisoned — it withholds DrainComplete and emits a FullResync instead,
+// forcing the daemon to full-resync rather than complete demotion with lost
+// session mutations. Reverting the poison gate makes the helper emit
+// DrainComplete here -> this goes RED.
+#[test]
+fn test_paused_session_eviction_poisons_drain_2875() {
+    let (mut daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    daemon_side
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    let shared = Arc::new(EventStreamShared::new());
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+
+    // Fill the replay buffer to capacity with SESSION-SYNC deltas (no eviction
+    // yet: the buffer holds exactly REPLAY_BUFFER_CAPACITY frames).
+    for seq in 1..=REPLAY_BUFFER_CAPACITY as u64 {
+        push_replay_frame(&shared, &mut replay_buf, replay_seq_frame(seq));
+    }
+    assert_eq!(replay_buf.len(), REPLAY_BUFFER_CAPACITY);
+    assert!(!shared.session_evicted_while_paused.load(Ordering::Acquire));
+
+    // Demotion pause window begins, then one more session delta arrives and
+    // evicts the OLDEST session frame (seq 1) — a lost session mutation.
+    shared.paused.store(true, Ordering::Release);
+    push_replay_frame(
+        &shared,
+        &mut replay_buf,
+        replay_seq_frame(REPLAY_BUFFER_CAPACITY as u64 + 1),
+    );
+    assert!(
+        shared.session_evicted_while_paused.load(Ordering::Acquire),
+        "evicting a session delta while paused must poison the drain (#2875)"
+    );
+
+    // Keep tx alive so the drain loop sees Empty (not Disconnected) and reaches
+    // the fence via replay_buf.back().seq >= target.
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    handle_drain_request(5, &rx, &helper_side, &shared, &mut replay_buf);
+
+    // The daemon must observe a FullResync and NEVER a DrainComplete.
+    let mut saw_full_resync = false;
+    while let Some((msg_type, _seq)) = try_read_frame_header(&mut daemon_side) {
+        assert_ne!(
+            msg_type, MSG_DRAIN_COMPLETE,
+            "poisoned drain must NOT report DrainComplete (#2875 regression)"
+        );
+        if msg_type == MSG_FULL_RESYNC {
+            saw_full_resync = true;
+        }
+    }
+    assert!(
+        saw_full_resync,
+        "poisoned drain must emit a FullResync so the daemon full-resyncs (#2875)"
+    );
+    // Poison is consumed once the resync is sent.
+    assert!(!shared.session_evicted_while_paused.load(Ordering::Acquire));
+}
+
+// #2875: a TELEMETRY-only eviction while paused must NOT poison the drain — the
+// drain still completes normally (no spurious FullResync / FullResync storm).
+#[test]
+fn test_paused_telemetry_eviction_does_not_poison_drain_2875() {
+    let (mut daemon_side, helper_side) = std::os::unix::net::UnixStream::pair().unwrap();
+    daemon_side
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    let shared = Arc::new(EventStreamShared::new());
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+
+    // Fill to capacity with TELEMETRY frames, then evict one while paused.
+    for seq in 1..=REPLAY_BUFFER_CAPACITY as u64 {
+        push_replay_frame(&shared, &mut replay_buf, telemetry_seq_frame(seq));
+    }
+    shared.paused.store(true, Ordering::Release);
+    push_replay_frame(
+        &shared,
+        &mut replay_buf,
+        telemetry_seq_frame(REPLAY_BUFFER_CAPACITY as u64 + 1),
+    );
+    assert!(
+        !shared.session_evicted_while_paused.load(Ordering::Acquire),
+        "telemetry eviction while paused must NOT poison the drain (#2875)"
+    );
+
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    handle_drain_request(5, &rx, &helper_side, &shared, &mut replay_buf);
+
+    // The drain must complete normally — DrainComplete present, no FullResync.
+    let mut saw_complete = false;
+    while let Some((msg_type, _seq)) = try_read_frame_header(&mut daemon_side) {
+        assert_ne!(
+            msg_type, MSG_FULL_RESYNC,
+            "telemetry eviction must not cause a spurious FullResync (#2875)"
+        );
+        if msg_type == MSG_DRAIN_COMPLETE {
+            saw_complete = true;
+        }
+    }
+    assert!(
+        saw_complete,
+        "non-poisoned drain must still report DrainComplete (#2875)"
+    );
+}
+
+// #2875: a fresh pause window must start lossless — MSG_PAUSE clears any poison
+// left by a previous drain so a stale flag cannot withhold this window's
+// DrainComplete.
+#[test]
+fn test_pause_start_clears_drain_poison_2875() {
+    let shared = Arc::new(EventStreamShared::new());
+    let (_tx, rx) = mpsc::sync_channel::<EventFrame>(4);
+    let mut replay_buf: VecDeque<EventFrame> = VecDeque::new();
+    let (sock_a, _sock_b) = std::os::unix::net::UnixStream::pair().unwrap();
+
+    // Simulate a leftover poison from a prior window.
+    shared
+        .session_evicted_while_paused
+        .store(true, Ordering::Release);
+
+    // A PAUSE control frame must clear it.
+    let mut pause = [0u8; FRAME_HEADER_SIZE];
+    pause[4] = MSG_PAUSE;
+    let (action, consumed) =
+        process_control_frames(&pause, &shared, &rx, &sock_a, &mut replay_buf);
+    assert!(action.is_none());
+    assert_eq!(consumed, FRAME_HEADER_SIZE);
+    assert!(shared.paused.load(Ordering::Acquire));
+    assert!(
+        !shared.session_evicted_while_paused.load(Ordering::Acquire),
+        "MSG_PAUSE must clear stale drain poison (#2875)"
+    );
+}


### PR DESCRIPTION
Two event-stream buffer-robustness fixes in `userspace-dp/src/event_stream/mod.rs`, one per bisectable commit.

## #2875 (HIGH) — paused-demotion drain evicts session deltas yet reports DrainComplete
During RG demotion the daemon PAUSEs the helper so the future owner drains a stable window. While paused, frames are consumed into the **bounded** replay buffer, which evicts the oldest frame at `REPLAY_BUFFER_CAPACITY` (bumping `frames_replay_evicted` only). An evicted frame can be an HA session-sync delta (SessionOpen/Update/Close); `handle_drain_request` then reported `DrainComplete` anyway → silent session loss on the new owner.

Fix = poison-on-loss (the buffer stays bounded; no unbounded growth / memory DoS):
- `EventFrame::is_session_sync()` distinguishes the correctness-critical HA deltas (msg_type 1/2/3) from telemetry / RT_FLOW frames (same `data[4]` discriminator #2874 uses).
- `evict_replay_frame` sets a new `session_evicted_while_paused` flag when it evicts a session-sync frame **while paused**. Telemetry eviction does NOT poison (no spurious resync).
- `handle_drain_request`, when poisoned, **withholds DrainComplete and emits a FullResync** instead, forcing the daemon to re-export full session state (same recovery path as #2874). `SendDrainRequest` then gets no DrainComplete, times out, and refuses demotion.
- Poison lifecycle: set on session-frame eviction during pause; cleared at pause-start (`MSG_PAUSE`) and after the poisoned drain emits its FullResync.

Also removes a stray `stop:` field initializer in the `cfg(test)` `test_sender` helper (the real stop flag lives in `EventStreamShared.stop`) that was breaking the test build.

## #2879 (MEDIUM-HIGH) — control payload has no length cap → unbounded `ctrl_read_buf` growth
`process_control_frames` read a 32-bit `payload_len` and, if the frame wasn't complete, broke without consuming — no max, no opcode validation. A buggy/compromised local daemon could send `payload_len = 1<<30` and trickle bytes, growing `ctrl_read_buf` without bound on the forwarding plane.

Fix = add `MAX_CONTROL_PAYLOAD_LEN` (0 today; all daemon→helper opcodes are header-only) and validate `payload_len` on the header alone, **before** waiting for the rest of the frame: any oversized/nonzero `payload_len` disconnects (reconnect clears `ctrl_read_buf`). A legitimately partial header-only frame still parses once complete.

## Tests (fail-on-revert, proven for each)
- #2875: session-delta eviction while paused poisons the drain (FullResync, no DrainComplete) — RED if the poison gate is reverted; telemetry-only eviction does NOT poison (DrainComplete still emitted); `MSG_PAUSE` clears a stale poison.
- #2879: oversized `payload_len`(1<<30)+trickle disconnects & `ctrl_read_buf` stays bounded — RED if the cap is reverted; nonzero payload on each header-only opcode rejected; split header-only frame still parses.

`cargo build --release` clean; `cargo test --release event_stream` → 77 passed. The `concurrent_recovery`/`stalled_consumer` flakes are unrelated/pre-existing.

NOTE: #2875 touches HA session-sync/demotion — run `make test-failover` before merge.

Closes #2875
Closes #2879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi