### PR TITLE
host-inbound: derive lifeline interface set from cluster config (#3277)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22279,3 +22279,10 @@ top.
   userspace-dp/src/afxdp/coordinator/status.rs,
   userspace-dp/src/afxdp/tests.rs, userspace-dp/src/afxdp/test_fixtures.rs,
   userspace-dp/tests/fixtures/protocol_wire_v1.json
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3277 — derive host-inbound lifeline interface set from chassis-cluster config (configured control-interface / fabric interfaces) instead of the hardcoded fxp0/em0/fab* list, so a non-default `control-interface fxp1` is excluded from host-inbound deny scoping (fixes latent HA split-brain). Added fail-on-revert tests at the predicate and full-payload levels; updated host-inbound lifeline doc.
+  **File(s)**: pkg/dataplane/userspace/zones.go,
+  pkg/dataplane/userspace/zones_host_inbound_test.go,
+  pkg/daemon/host_inbound_nft_test.go,
+  docs/junos-cli-reference.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -292,6 +292,19 @@ From zone: guest, To zone: lan
     set is byte-identical. Management/cluster-control lifeline interfaces
     (fxp0/em0/fab*) are still excluded — a VIP on em0 is never scoped — and
     standalone (no-VRRP) zones are unchanged.
+  - **Lifeline set derived from cluster config (#3277):** the lifeline
+    interfaces excluded from host-inbound deny scoping are no longer a fixed
+    fxp0/em0/fab* hardcode. The set is now `fxp0` (always-mgmt) UNION the
+    configured chassis-cluster `control-interface` and `fabric-interface` /
+    `fabric1-interface` names, UNION the backward-compatible defaults em0 and
+    fab*. So a deployment whose control/heartbeat link rides a non-default name
+    (e.g. `set chassis cluster control-interface fxp1`) has that interface
+    correctly excluded — its address is never subjected to a host-inbound deny,
+    closing a latent HA split-brain (heartbeat drop) gap that would surface once
+    the control zone's host-inbound set is scoped rather than full-admit.
+    Canonical em0/fab*-named configs are byte-identical (the defaults still
+    match unconditionally); a standalone config with no chassis-cluster stanza
+    keeps fxp0 as its only lifeline (#1960).
   - **Lifeline fail-safe:** enforcement is strictly MATCH-DRIVEN. If NO
     `junos-host` policy is configured, or a host-bound flow matches no
     `junos-host` rule, behavior is UNCHANGED from before #3019 — there is no

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -353,6 +353,54 @@ func TestHostInboundFilterFamilyAware(t *testing.T) {
 	}
 }
 
+// TestHostInboundFilterConfiguredControlInterfaceLifeline is the #3277
+// fail-on-revert proof through the full payload path: a chassis cluster whose
+// `control-interface` is the operator-renamed fxp1 (NOT the default em0) must
+// have fxp1's address excluded from host-inbound deny scoping, exactly like the
+// default em0. Reverting the lifeline set to the hardcoded fxp0/em0/fab* list
+// leaves fxp1 SUBJECT to deny scoping -> its address appears in the payload ->
+// this goes RED (the latent HA split-brain the issue describes).
+func TestHostInboundFilterConfiguredControlInterfaceLifeline(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Chassis.Cluster = &config.ClusterConfig{ControlInterface: "fxp1"}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"172.16.50.8/24"}},
+		}},
+		// Control link rides the non-default-named fxp1 with a static address.
+		"fxp1": {Name: "fxp1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.99.0.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		// An enforced zone so the table is actually emitted.
+		"wan": {
+			Name:               "wan",
+			Interfaces:         []string{"reth0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
+		},
+		// The control zone scopes `all` but, more importantly, fxp1 must never be
+		// subjected to a deny regardless of its zone's stanza.
+		"control": {
+			Name:               "control",
+			Interfaces:         []string{"fxp1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
+		},
+	}
+	views := buildAndCheckViews(t, cfg)
+	payload := buildHostInboundFilterPayload(views)
+
+	// fxp1's control-link address must NEVER appear (accept or drop): it is the
+	// configured cluster control-interface and so a lifeline (#3277).
+	if strings.Contains(payload, "10.99.0.1") {
+		t.Errorf("configured control-interface fxp1 address must never appear in host-inbound payload:\n%s", payload)
+	}
+	// Sanity: the enforced wan zone still scopes its own address.
+	if !strings.Contains(payload, "172.16.50.8 drop") {
+		t.Errorf("wan zone must still emit a scoped deny:\n%s", payload)
+	}
+}
+
 // buildAndCheckViews resolves the per-zone views and asserts the table would be
 // applied (at least one enforceable zone).
 func buildAndCheckViews(t *testing.T, cfg *config.Config) []dpuserspace.ZoneHostInboundView {

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -32,20 +32,66 @@ type ZoneHostInboundView struct {
 	V6Addrs        []string // bare host IPv6 addresses (no prefix)
 }
 
-// hostInboundLifelineInterface reports whether the given logical interface name
-// is a management / cluster-control LIFELINE that must NEVER be subjected to a
-// host-inbound deny: fxp0 (out-of-band management), em0 (cluster control plane
-// / heartbeat), and the fabric links (fab*). Denying host-bound traffic on
-// these would strand management or break HA. fxp0 is DHCP-managed (no static
-// config address) and the canonical `control` zone is `system-services { all }`
-// anyway, so this is defense-in-depth on top of those facts. The base name
-// (before the unit suffix) is matched so "fxp0.0" / "em0.0" are caught too.
-func hostInboundLifelineInterface(name string) bool {
-	base := name
+// lifelineBaseName strips the unit suffix (".0") and surrounding whitespace from
+// a logical interface name, returning the bare device name used for lifeline
+// matching ("fxp0.0" -> "fxp0", "fab1.0" -> "fab1"). Returns "" for an empty
+// name.
+func lifelineBaseName(name string) string {
+	base := strings.TrimSpace(name)
 	if i := strings.IndexByte(base, '.'); i >= 0 {
 		base = base[:i]
 	}
-	return base == "fxp0" || base == "em0" || strings.HasPrefix(base, "fab")
+	return base
+}
+
+// hostInboundLifelineSet resolves the set of management / cluster-control
+// LIFELINE interface base names that must NEVER be subjected to a host-inbound
+// deny. It is the config-aware superset of the always-on defaults:
+//
+//   - fxp0 (out-of-band management) is always a lifeline.
+//   - The chassis-cluster control-interface and fabric interface(s) are added
+//     from config so an operator-renamed control link (e.g.
+//     `control-interface fxp1`) or a non-default fabric name is excluded too.
+//     This is the #3277 fix: the old matcher hardcoded fxp0/em0/fab* and so left
+//     a configured `control-interface fxp1` SUBJECT to host-inbound deny scoping
+//     -> potential heartbeat drop -> HA split-brain.
+//
+// em0 (the canonical cluster-control default name) and the fabric prefix fab*
+// stay matched unconditionally in hostInboundLifelineInterface so the canonical
+// default-named configs remain byte-identical (#3070/#3172/#3224 behavior is
+// preserved). A standalone config (no chassis-cluster stanza) contributes no
+// extra names here, so its only lifeline is fxp0 (em0/fab* are no-ops because
+// such interfaces are not present) — #1960.
+func hostInboundLifelineSet(cfg *config.Config) map[string]bool {
+	set := map[string]bool{"fxp0": true}
+	if cfg != nil && cfg.Chassis.Cluster != nil {
+		cc := cfg.Chassis.Cluster
+		for _, name := range []string{cc.ControlInterface, cc.FabricInterface, cc.Fabric1Interface} {
+			if base := lifelineBaseName(name); base != "" {
+				set[base] = true
+			}
+		}
+	}
+	return set
+}
+
+// hostInboundLifelineInterface reports whether the given logical interface name
+// is a management / cluster-control LIFELINE that must NEVER be subjected to a
+// host-inbound deny. The lifeline set is the config-derived set (fxp0 plus the
+// configured chassis-cluster control-interface / fabric interfaces, #3277) UNION
+// the always-on backward-compatible defaults em0 (cluster control plane /
+// heartbeat default name) and the fabric links (fab*). Denying host-bound
+// traffic on these would strand management or break HA. The base name (before
+// the unit suffix) is matched so "fxp0.0" / "em0.0" are caught too.
+func hostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
+	base := lifelineBaseName(name)
+	if base == "" {
+		return false
+	}
+	if lifelines[base] {
+		return true
+	}
+	return base == "em0" || strings.HasPrefix(base, "fab")
 }
 
 // BuildZoneHostInboundViews returns one ZoneHostInboundView per
@@ -85,6 +131,11 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 		return nil
 	}
 	ifaceSnaps := buildInterfaceSnapshots(cfg)
+	// Lifeline interfaces (fxp0 + the configured chassis-cluster
+	// control-interface / fabric interfaces, plus the em0/fab* defaults) are
+	// excluded from host-inbound deny scoping so management / cluster-control
+	// traffic is never denied (#3277).
+	lifelines := hostInboundLifelineSet(cfg)
 	// Gather per-zone host addresses from the resolved interface snapshots,
 	// skipping lifeline interfaces.
 	type addrSet struct {
@@ -95,7 +146,7 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 	}
 	byZone := make(map[string]*addrSet)
 	for _, snap := range ifaceSnaps {
-		if snap.Zone == "" || hostInboundLifelineInterface(snap.Name) {
+		if snap.Zone == "" || hostInboundLifelineInterface(snap.Name, lifelines) {
 			continue
 		}
 		set := byZone[snap.Zone]
@@ -171,7 +222,7 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 				continue
 			}
 			unitName := fmt.Sprintf("%s.%d", ifName, un)
-			if hostInboundLifelineInterface(unitName) {
+			if hostInboundLifelineInterface(unitName, lifelines) {
 				continue
 			}
 			zone := zoneByIface[unitName]

--- a/pkg/dataplane/userspace/zones_host_inbound_test.go
+++ b/pkg/dataplane/userspace/zones_host_inbound_test.go
@@ -336,15 +336,39 @@ func liveZoneHostInboundAddrsForIface(t *testing.T, linuxName string) []string {
 }
 
 func TestHostInboundLifelineInterface(t *testing.T) {
+	// Standalone (no chassis-cluster stanza): only fxp0 is config-derived, but
+	// the em0/fab* backward-compatible defaults still match unconditionally.
+	def := hostInboundLifelineSet(nil)
 	for _, name := range []string{"fxp0", "fxp0.0", "em0", "em0.0", "fab0", "fab1", "fab1.0"} {
-		if !hostInboundLifelineInterface(name) {
+		if !hostInboundLifelineInterface(name, def) {
 			t.Errorf("%q should be a lifeline interface", name)
 		}
 	}
-	for _, name := range []string{"reth0.50", "reth1", "ge-0/0/0.0", "gr-0/0/0.0"} {
-		if hostInboundLifelineInterface(name) {
-			t.Errorf("%q must NOT be a lifeline interface", name)
+	for _, name := range []string{"reth0.50", "reth1", "ge-0/0/0.0", "gr-0/0/0.0", "fxp1", "fxp1.0"} {
+		if hostInboundLifelineInterface(name, def) {
+			t.Errorf("%q must NOT be a lifeline interface (no cluster config)", name)
 		}
+	}
+}
+
+// TestHostInboundLifelineFromControlInterface is the #3277 fail-on-revert proof
+// at the predicate level: a configured chassis-cluster `control-interface fxp1`
+// (an operator-renamed control link) is treated as a lifeline. Reverting to the
+// hardcoded fxp0/em0/fab* set leaves fxp1 NOT a lifeline -> this goes RED.
+func TestHostInboundLifelineFromControlInterface(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Chassis.Cluster = &config.ClusterConfig{
+		ControlInterface: "fxp1",
+		FabricInterface:  "xe-0/0/9",
+	}
+	set := hostInboundLifelineSet(cfg)
+	for _, name := range []string{"fxp1", "fxp1.0", "xe-0/0/9", "xe-0/0/9.0", "fxp0", "em0", "fab0"} {
+		if !hostInboundLifelineInterface(name, set) {
+			t.Errorf("%q should be a lifeline with control-interface fxp1 configured", name)
+		}
+	}
+	if hostInboundLifelineInterface("reth0.50", set) {
+		t.Errorf("reth0.50 must NOT be a lifeline")
 	}
 }
 


### PR DESCRIPTION
## Problem

The host-inbound deny scoping (#3070) excludes management / cluster-control LIFELINE interfaces from its address sets so SSH / heartbeat / fabric traffic is never denied. `hostInboundLifelineInterface` (pkg/dataplane/userspace/zones.go) hardcoded that set as **fxp0 / em0 / fab\***.

But the chassis-cluster `control-interface` is operator-configurable — `test/incus/xpf-cluster-fw0.conf` uses `control-interface fxp1`. A deployment whose control/heartbeat link rides a non-default-named interface had that interface **subject** to host-inbound deny scoping. If a host-inbound deny is in effect on its zone, cluster control-plane / heartbeat traffic to that address can be dropped → **HA split-brain**. Latent today (canonical em0/fab\* configs match the hardcode and the control zone's `system-services all` full-admit masks it), but a real correctness gap and a prerequisite for scoping the control zone.

## Fix

Resolve the lifeline set from config:

- `hostInboundLifelineSet(cfg)` = `fxp0` (always-mgmt) ∪ configured chassis-cluster `control-interface` ∪ `fabric-interface` / `fabric1-interface`.
- `hostInboundLifelineInterface` unions that set with the backward-compatible defaults **em0** and the **fab\*** prefix, which still match unconditionally → canonical default-named configs are **byte-identical** (#3070/#3172/#3224 preserved).
- Standalone config (no chassis-cluster stanza) → only `fxp0` is a lifeline (#1960).
- Set computed once in `BuildZoneHostInboundViews` and threaded to both exclusion sites (static-address + VRRP-VIP). Family-awareness (#3225) intact.

## Tests (fail-on-revert)

- `TestHostInboundLifelineFromControlInterface` — predicate level: `control-interface fxp1` (+ a non-default fabric name) is a lifeline.
- `TestHostInboundFilterConfiguredControlInterfaceLifeline` — full nft payload: fxp1's control-link address (`10.99.0.1`) never appears in the deny scope.
- Reverting to the hardcoded list leaves `10.99.0.1` in the deny scope → **both go RED** (verified).
- `TestHostInboundLifelineInterface` updated for the new signature; standalone set excludes fxp1 but still matches em0/fab\* defaults. All existing host-inbound tests stay green.

## Validation

`go build ./...`; `go test ./pkg/dataplane/... ./pkg/daemon/... ./pkg/config/...`; full `go test ./...` green.

This touches the HA control-plane lifeline — parent runs `test-failover` before merge.

Closes #3277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi