### PR TITLE
Surface scoped-global zone context in policy inventory (#3286)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22357,3 +22357,26 @@ top.
   pkg/dataplane/userspace/zones_host_inbound_test.go,
   pkg/daemon/host_inbound_nft_test.go,
   docs/junos-cli-reference.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3286 — surface scoped-global-policy zone context (#3148
+  `match from-zone`/`to-zone`) on every policy inventory/show surface.
+  Previously only the dataplane enforced the scope; REST, gRPC, and CLI
+  rendered scoped globals as all-zones (`*`/`*`, junos-global, any),
+  hiding the scope from audit and making scoped-global hit counters
+  ambiguous. Added `match_from_zone`/`match_to_zone` to the REST
+  `PolicyRule` (omitempty) and the protobuf `PolicyRule` (fields 11/12,
+  regenerated), populated from `Policy.Match.FromZone/ToZone` in the
+  global loops; rendered the scoped zones in the CLI standard, detail,
+  brief, and hit-count views and the gRPC text hit-count/detail views.
+  Unscoped globals unchanged. Fail-on-revert tests across all three
+  packages (REST, gRPC structured + text, CLI all four views).
+  **File(s)**: proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go,
+  pkg/api/types.go, pkg/api/security.go,
+  pkg/grpcapi/server_show_zones.go,
+  pkg/grpcapi/server_show_policies_text.go,
+  pkg/cli/cli_show_security.go, pkg/cli/cli_show_security_dispatch.go,
+  pkg/api/security_scoped_global_3286_test.go,
+  pkg/grpcapi/server_show_zones_scoped_global_3286_test.go,
+  pkg/cli/cli_show_security_scoped_global_3286_test.go,
+  docs/junos-cli-reference.md, pkg/api/README.md, pkg/grpcapi/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -22380,3 +22380,22 @@ top.
   pkg/grpcapi/server_show_zones_scoped_global_3286_test.go,
   pkg/cli/cli_show_security_scoped_global_3286_test.go,
   docs/junos-cli-reference.md, pkg/api/README.md, pkg/grpcapi/README.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3286 follow-up (Claude-SMR NEEDS-MINOR) — fold in the 4th
+  inventory surface the first pass missed: the Prometheus
+  `xpf_policy_hits_total` collector emitted `from_zone="*"`/`to_zone="*"`
+  for ALL global policies, scoped included. Prometheus is the canonical
+  counter-validation surface the issue's "scoped-global hit counters...
+  ambiguous" concern names directly. metrics_counters.go now uses the
+  policy's Match.FromZone/ToZone for the from_zone/to_zone labels when set
+  (identical conditional to the REST/gRPC/CLI surfaces); unscoped globals
+  keep `*`/`*`. Added a fail-on-revert metrics test (RED when reverted to
+  `*`/`*`). Confirmed no 5th surface: remaining `junos-global`/`*` uses are
+  the group-level PolicyInfo row (correct) and the dataplane
+  snapshot/counter-key computation (by design — tier classification +
+  stable counter IDs, real scope carried out-of-band in MatchFromZone/
+  ToZone and enforced in policy.rs), neither operator-facing display.
+  **File(s)**: pkg/api/metrics_counters.go,
+  pkg/api/metrics_scoped_global_3286_test.go, docs/phases.md,
+  pkg/api/README.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -435,7 +435,7 @@ Global policies:
 
 - Same as regular policies but with `Global policies:` header.
 - Uses `From zones:` and `To zones:` (plural) instead of `From zone:` / `To zone:`.
-- **Zone context (#3148).** A global policy may carry optional
+- **Zone context (#3148, display #3286).** A global policy may carry optional
   `set security policies global policy <p> match from-zone <z>` /
   `match to-zone <z>` to scope it to a chosen zone pair (or one wildcard side)
   instead of every zone pair. With a context set, `From zones:` / `To zones:`
@@ -446,6 +446,20 @@ Global policies:
   omitted leaf and an explicit `match from-zone any` are identical (all zones);
   an undefined match zone is rejected at commit, and `match from-zone junos-host`
   / `to-zone junos-host` is rejected (not supported on a global policy).
+- **#3286 — scope shown on EVERY inventory surface.** Before #3286 only the
+  dataplane enforced the scope; the show/inventory surfaces dropped it and
+  rendered scoped globals as all-zones. All surfaces now reflect the configured
+  scope consistently: CLI `show security policies` (`From zones:`/`To zones:`),
+  `... detail` (`From zone:`/`To zone:`), `... brief` (the From/To columns),
+  and `... hit-count` (the From zone/To zone columns) print the scoped zone for
+  a scoped global; the gRPC `GetPolicies` `PolicyRule` carries
+  `match_from_zone`/`match_to_zone` (empty for an unscoped global) and the gRPC
+  text `policies-hit-count`/`policies-detail` views show the scope; the REST
+  `GET /api/v1/security/policies` `PolicyRule` carries
+  `match_from_zone`/`match_to_zone` (omitted when empty). The global PolicyInfo
+  group still reports `from_zone="*"`/`to_zone="*"` (the all-zones tier) — the
+  per-rule fields carry the narrowing. An unscoped global is unchanged
+  (junos-global / any / `*`).
 
 ---
 

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -222,7 +222,9 @@
 - 15 additional REST endpoints for full gRPC parity
 - Session prefix filtering (source/destination CIDR)
 - Expanded Prometheus metrics: session breakdowns (IPv4/IPv6, SNAT/DNAT), NAT pool usage, DHCP lease counts
-- Per-policy hit counters (`xpf_policy_hits_total` with zone/rule labels)
+- Per-policy hit counters (`xpf_policy_hits_total` with zone/rule labels;
+  a scoped global policy (#3148/#3286) reports its `from-zone`/`to-zone` on
+  the `from_zone`/`to_zone` labels, an unscoped global keeps `*`/`*`)
 - Config management endpoints: load override/merge via REST
 
 ## Phase 48: VRRP State Detection & Load Commands (`6a07fb5`–`9745c61`)

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -33,7 +33,11 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     counter IDs follow the zone-pair policy-set count (the `policySetID`
     continues from the zone-pair loop), so per-policy hit counters stay
     aligned with the dataplane when `policy-stats system-wide enable` is
-    set.
+    set. A scoped global policy (#3148 `match from-zone`/`to-zone`)
+    carries its narrowing on the per-rule `match_from_zone` /
+    `match_to_zone` fields (#3286), omitted when empty; the group row
+    stays `*`/`*` (the all-zones tier). Before #3286 these were absent,
+    so a scoped global looked all-zones to automation.
 - `GET /api/v1/events/stream` — Server-Sent Events stream of dataplane
   events. Backed by the `pkg/logging` event ring buffer; long-lived
   consumers must drain.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -37,7 +37,11 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     carries its narrowing on the per-rule `match_from_zone` /
     `match_to_zone` fields (#3286), omitted when empty; the group row
     stays `*`/`*` (the all-zones tier). Before #3286 these were absent,
-    so a scoped global looked all-zones to automation.
+    so a scoped global looked all-zones to automation. The Prometheus
+    `xpf_policy_hits_total` collector (metrics_counters.go) likewise emits
+    the scoped global's real zones on its `from_zone`/`to_zone` labels
+    (#3286) — an unscoped global keeps `*`/`*` — so counter-based
+    validation is unambiguous on the canonical metrics surface.
 - `GET /api/v1/events/stream` — Server-Sent Events stream of dataplane
   events. Backed by the `pkg/logging` event ring buffer; long-lived
   consumers must drain.

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -168,8 +168,23 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 		if err != nil {
 			continue
 		}
+		// #3286: a scoped global policy (#3148 `match from-zone`/`to-zone`)
+		// narrows itself to a zone pair. Prometheus is the canonical
+		// counter-validation surface, so the per-policy hit metric must
+		// carry the real scope on its from_zone/to_zone labels instead of
+		// the all-zones "*"/"*" — otherwise scoped-global counters are
+		// indistinguishable from an all-zones global. An unscoped global
+		// keeps from_zone="*"/to_zone="*" (no regression). The rule label
+		// is unchanged.
+		fromZone, toZone := "*", "*"
+		if rule.Match.FromZone != "" {
+			fromZone = rule.Match.FromZone
+		}
+		if rule.Match.ToZone != "" {
+			toZone = rule.Match.ToZone
+		}
 		ch <- prometheus.MustNewConstMetric(c.policyHitsTotal, prometheus.CounterValue,
-			float64(ctrs.Packets), "*", "*", rule.Name)
+			float64(ctrs.Packets), fromZone, toZone, rule.Name)
 	}
 }
 

--- a/pkg/api/metrics_scoped_global_3286_test.go
+++ b/pkg/api/metrics_scoped_global_3286_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3286: the Prometheus `xpf_policy_hits_total` collector emitted
+// from_zone="*"/to_zone="*" for ALL global policies, scoped included.
+// Prometheus is the canonical counter-validation surface, so a scoped
+// global (#3148 `match from-zone`/`to-zone`) showing all-zones labels is the
+// exact ambiguity the issue calls out. The collector now uses the policy's
+// Match.FromZone/ToZone for the labels when set. This test is the
+// fail-on-revert guard: revert the label fix to "*"/"*" → the scoped
+// assertion goes RED.
+
+func scopedGlobalMetricsStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	// policy-stats enabled so both globals emit a per-policy counter.
+	if err := store.LoadOverride(`
+security {
+    policy-stats {
+        system-wide enable;
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        global {
+            policy scoped-global {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy open-global {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || len(cfg.Security.GlobalPolicies) != 2 {
+		t.Fatalf("want 2 global policies, got %v", cfg)
+	}
+	if !cfg.Security.PolicyStatsEnabled {
+		t.Fatal("policy-stats precondition not met")
+	}
+	return store
+}
+
+func TestCollectPolicyCountersScopedGlobalLabels(t *testing.T) {
+	store := scopedGlobalMetricsStore(t)
+	scopedID := globalCounterPolicyID(t, store, "scoped-global")
+	openID := globalCounterPolicyID(t, store, "open-global")
+	c := &xpfCollector{
+		srv: &Server{store: store},
+		policyHitsTotal: prometheus.NewDesc(
+			"xpf_policy_hits_total",
+			"policy hits",
+			[]string{"from_zone", "to_zone", "policy_name"},
+			nil,
+		),
+	}
+	dp := &schedulerCounterAPIDP{
+		Manager: dataplane.New(),
+		counters: map[uint32]dataplane.CounterValue{
+			scopedID: {Packets: 41, Bytes: 4100},
+			openID:   {Packets: 52, Bytes: 5200},
+		},
+	}
+
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.collectPolicyCounters(ch, dp)
+		close(ch)
+	}()
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+
+	// Scoped global must carry its real zone pair on the labels — NOT */*.
+	assertCounterClose(t, got, c.policyHitsTotal, map[string]string{
+		"from_zone":   "trust",
+		"to_zone":     "untrust",
+		"policy_name": "scoped-global",
+	}, 41)
+	// Unscoped global keeps the all-zones labels (no regression).
+	assertCounterClose(t, got, c.policyHitsTotal, map[string]string{
+		"from_zone":   "*",
+		"to_zone":     "*",
+		"policy_name": "open-global",
+	}, 52)
+}

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -147,6 +147,11 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				Applications: rule.Match.Applications,
 				Log:          rule.Log != nil,
 				Count:        rule.Count,
+				// #3286: surface the scoped-global zone context (#3148) so
+				// a global narrowed to a zone pair is not reported as
+				// all-zones. Empty for an unscoped global — no regression.
+				MatchFromZone: rule.Match.FromZone,
+				MatchToZone:   rule.Match.ToZone,
 			}
 			if pr.SrcAddresses == nil {
 				pr.SrcAddresses = []string{}

--- a/pkg/api/security_scoped_global_3286_test.go
+++ b/pkg/api/security_scoped_global_3286_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3286: the REST GET /api/v1/security/policies inventory rendered a scoped
+// global policy (#3148, `match from-zone`/`to-zone`) as all-zones, dropping
+// the configured zone scope. PolicyRule now carries match_from_zone /
+// match_to_zone so a scoped global shows its real scope. This is the
+// fail-on-revert guard: drop the population in security.go and the scoped
+// assertion goes RED.
+
+// scopedGlobalAPIStore builds a config with one scoped global policy
+// (from-zone trust, to-zone untrust) and one unscoped (all-zones) global.
+func scopedGlobalAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        global {
+            policy scoped-global {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy open-global {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestPoliciesHandlerScopedGlobalShowsZones is the #3286 fail-on-revert guard:
+// the REST inventory must surface the from/to-zone of a scoped global rule and
+// leave them empty (omitted) for an unscoped global.
+func TestPoliciesHandlerScopedGlobalShowsZones(t *testing.T) {
+	s := &Server{store: scopedGlobalAPIStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	var sawScoped, sawOpen bool
+	for _, policy := range resp.Data {
+		// Globals stay grouped under the all-zones "*"/"*" PolicyInfo.
+		if policy.FromZone != "*" || policy.ToZone != "*" {
+			continue
+		}
+		for _, rule := range policy.Rules {
+			switch rule.Name {
+			case "scoped-global":
+				sawScoped = true
+				if rule.MatchFromZone != "trust" || rule.MatchToZone != "untrust" {
+					t.Fatalf("scoped-global match zones = %q/%q, want trust/untrust "+
+						"(scoped global rendered as all-zones — #3286 regression); body: %s",
+						rule.MatchFromZone, rule.MatchToZone, rr.Body.String())
+				}
+			case "open-global":
+				sawOpen = true
+				if rule.MatchFromZone != "" || rule.MatchToZone != "" {
+					t.Fatalf("open-global match zones = %q/%q, want empty (all-zones global)",
+						rule.MatchFromZone, rule.MatchToZone)
+				}
+			}
+		}
+	}
+	if !sawScoped {
+		t.Fatalf("scoped-global policy missing from REST inventory; body: %s", rr.Body.String())
+	}
+	if !sawOpen {
+		t.Fatalf("open-global policy missing from REST inventory; body: %s", rr.Body.String())
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -79,6 +79,15 @@ type PolicyRule struct {
 	Count        bool     `json:"count"`
 	HitPackets   uint64   `json:"hit_packets"`
 	HitBytes     uint64   `json:"hit_bytes"`
+	// MatchFromZone / MatchToZone carry the optional from-zone/to-zone
+	// match context of a scoped GLOBAL policy (#3148, #3286). The global
+	// PolicyInfo group still reports from_zone="*"/to_zone="*" (all-zones
+	// tier), but a global policy may narrow itself to a zone pair; these
+	// per-rule fields surface that scope so automation/audit do not see a
+	// scoped global as all-zones. Empty (omitted) for an all-zones global
+	// and for ordinary zone-pair rules.
+	MatchFromZone string `json:"match_from_zone,omitempty"`
+	MatchToZone   string `json:"match_to_zone,omitempty"`
 }
 
 // SessionEntry holds a single session table entry.

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -95,8 +95,18 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 					count = counters.Packets
 				}
 			}
+			// #3286: a scoped global (#3148) shows its zone pair in the
+			// From/To columns so counter-based validation is unambiguous;
+			// an unscoped global keeps junos-global/junos-global.
+			hcFrom, hcTo := "junos-global", "junos-global"
+			if pol.Match.FromZone != "" {
+				hcFrom = pol.Match.FromZone
+			}
+			if pol.Match.ToZone != "" {
+				hcTo = pol.Match.ToZone
+			}
 			fmt.Printf("%-8d%-17s%-18s%-24s%-14d%s\n",
-				index, "junos-global", "junos-global", pol.Name, count, action)
+				index, hcFrom, hcTo, pol.Name, count, action)
 			index++
 		}
 	}
@@ -211,7 +221,19 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 				fmt.Printf("  Scheduler: %s (inactive)\n", pol.SchedulerName)
 			}
 			fmt.Printf("  Sequence number: %d\n", seqNum)
-			fmt.Printf("  From zone: junos-global, To zone: junos-global\n")
+			// #3286: a scoped global policy (#3148) narrows itself to a
+			// zone pair via `match from-zone/to-zone`. Show the configured
+			// scope instead of the all-zones "junos-global" placeholder so
+			// an operator can tell which zone pair a global rule applies to.
+			// An unscoped global keeps junos-global/junos-global.
+			globalFromZone, globalToZone := "junos-global", "junos-global"
+			if pol.Match.FromZone != "" {
+				globalFromZone = pol.Match.FromZone
+			}
+			if pol.Match.ToZone != "" {
+				globalToZone = pol.Match.ToZone
+			}
+			fmt.Printf("  From zone: %s, To zone: %s\n", globalFromZone, globalToZone)
 			if pol.Description != "" {
 				fmt.Printf("  Description: %s\n", pol.Description)
 			}

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -264,8 +264,18 @@ func (c *CLI) handleShowSecurity(args []string) error {
 							hits = fmt.Sprintf("%d", counters.Packets)
 						}
 					}
+					// #3286: a scoped global (#3148) shows its zone pair in
+					// the From/To columns instead of the all-zones "*"; an
+					// unscoped global still reads "*"/"*".
+					briefFrom, briefTo := "*", "*"
+					if pol.Match.FromZone != "" {
+						briefFrom = pol.Match.FromZone
+					}
+					if pol.Match.ToZone != "" {
+						briefTo = pol.Match.ToZone
+					}
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
-						"*", "*", pol.Name, action, hits)
+						briefFrom, briefTo, pol.Name, action, hits)
 				}
 			}
 			return nil
@@ -343,8 +353,18 @@ func (c *CLI) handleShowSecurity(args []string) error {
 				if pol.Description != "" {
 					fmt.Printf("    Description: %s\n", pol.Description)
 				}
-				fmt.Printf("    From zones: any\n")
-				fmt.Printf("    To zones: any\n")
+				// #3286: render the scoped-global zone context (#3148)
+				// instead of the all-zones "any" placeholder. An unscoped
+				// global still shows any/any — no regression.
+				globalFromZone, globalToZone := "any", "any"
+				if pol.Match.FromZone != "" {
+					globalFromZone = pol.Match.FromZone
+				}
+				if pol.Match.ToZone != "" {
+					globalToZone = pol.Match.ToZone
+				}
+				fmt.Printf("    From zones: %s\n", globalFromZone)
+				fmt.Printf("    To zones: %s\n", globalToZone)
 				fmt.Printf("    Source addresses: %s\n",
 					strings.Join(pol.Match.SourceAddresses, ", "))
 				fmt.Printf("    Destination addresses: %s\n",

--- a/pkg/cli/cli_show_security_scoped_global_3286_test.go
+++ b/pkg/cli/cli_show_security_scoped_global_3286_test.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3286: the CLI `show security policies` surfaces rendered a scoped global
+// policy (#3148, `match from-zone`/`to-zone`) as all-zones — the detail view
+// printed "From zone: junos-global, To zone: junos-global", the standard view
+// printed "From zones: any / To zones: any", and the brief view printed "*"/"*"
+// — hiding the configured zone scope. These tests are the fail-on-revert guard:
+// each surface must now print the scoped zones for a scoped global and keep the
+// all-zones placeholder for an unscoped global.
+
+// scopedGlobalCLIConfig has one scoped global (trust->untrust deny) and one
+// unscoped global (all-zones permit).
+func scopedGlobalCLIConfig() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{
+			Name:   "scoped-global",
+			Match:  config.PolicyMatch{FromZone: "trust", ToZone: "untrust"},
+			Action: config.PolicyDeny,
+		},
+		{
+			Name:   "open-global",
+			Action: config.PolicyPermit,
+		},
+	}
+	return cfg
+}
+
+// Test_3286_PolicyDetailScopedGlobalShowsZones covers the detail view
+// (showPoliciesDetail). Reverting the render to the hard-coded junos-global
+// placeholder turns the scoped assertion RED.
+func Test_3286_PolicyDetailScopedGlobalShowsZones(t *testing.T) {
+	cfg := scopedGlobalCLIConfig()
+	c := &CLI{}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesDetail(cfg, "", ""); err != nil {
+			t.Fatalf("showPoliciesDetail: %v", err)
+		}
+	})
+
+	scoped := policyDetailZoneLine(t, out, "scoped-global")
+	if !strings.Contains(scoped, "From zone: trust") || !strings.Contains(scoped, "To zone: untrust") {
+		t.Fatalf("scoped-global detail zone line = %q, want From zone: trust / To zone: untrust "+
+			"(scoped global shown as all-zones — #3286 regression)", scoped)
+	}
+	open := policyDetailZoneLine(t, out, "open-global")
+	if !strings.Contains(open, "From zone: junos-global") || !strings.Contains(open, "To zone: junos-global") {
+		t.Fatalf("open-global detail zone line = %q, want junos-global/junos-global (unscoped global)", open)
+	}
+}
+
+// policyDetailZoneLine returns the "From zone: ..., To zone: ..." line that
+// follows the named policy's "Policy: <name>" header in detail output.
+func policyDetailZoneLine(t *testing.T, out, name string) string {
+	t.Helper()
+	lines := strings.Split(out, "\n")
+	hdr := regexp.MustCompile(`Policy: ` + regexp.QuoteMeta(name) + `,`)
+	for i, line := range lines {
+		if hdr.MatchString(line) {
+			for _, follow := range lines[i:] {
+				if strings.Contains(follow, "From zone:") {
+					return follow
+				}
+			}
+		}
+	}
+	t.Fatalf("policy %q zone line not found in detail output:\n%s", name, out)
+	return ""
+}
+
+// Test_3286_PolicyStandardScopedGlobalShowsZones covers the standard
+// (non-detail) view reached via handleShow. Reverting to the hard-coded
+// "any"/"any" lines turns the scoped assertion RED.
+func Test_3286_PolicyStandardScopedGlobalShowsZones(t *testing.T) {
+	c := scopedGlobalCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.handleShow([]string{"security", "policies"}); err != nil {
+			t.Fatalf("handleShow(security policies): %v", err)
+		}
+	})
+
+	scoped := policyStandardBlock(t, out, "scoped-global")
+	if !strings.Contains(scoped, "From zones: trust") || !strings.Contains(scoped, "To zones: untrust") {
+		t.Fatalf("scoped-global standard block = %q, want From zones: trust / To zones: untrust "+
+			"(scoped global shown as all-zones — #3286 regression)", scoped)
+	}
+	open := policyStandardBlock(t, out, "open-global")
+	if !strings.Contains(open, "From zones: any") || !strings.Contains(open, "To zones: any") {
+		t.Fatalf("open-global standard block = %q, want any/any (unscoped global)", open)
+	}
+}
+
+// policyStandardBlock returns the two zone lines following a named policy
+// header in the standard "Global policies:" view.
+func policyStandardBlock(t *testing.T, out, name string) string {
+	t.Helper()
+	lines := strings.Split(out, "\n")
+	hdr := regexp.MustCompile(`Policy: ` + regexp.QuoteMeta(name) + `,`)
+	for i, line := range lines {
+		if hdr.MatchString(line) {
+			end := i + 6
+			if end > len(lines) {
+				end = len(lines)
+			}
+			return strings.Join(lines[i:end], "\n")
+		}
+	}
+	t.Fatalf("policy %q block not found in standard output:\n%s", name, out)
+	return ""
+}
+
+// Test_3286_PolicyBriefScopedGlobalShowsZones covers the brief tabular view.
+// Reverting to the hard-coded "*"/"*" columns turns the scoped assertion RED.
+func Test_3286_PolicyBriefScopedGlobalShowsZones(t *testing.T) {
+	c := scopedGlobalCLI(t)
+
+	out := captureStdout(t, func() {
+		if err := c.handleShow([]string{"security", "policies", "brief"}); err != nil {
+			t.Fatalf("handleShow(security policies brief): %v", err)
+		}
+	})
+
+	scoped := briefRow(t, out, "scoped-global")
+	if !(strings.Contains(scoped, "trust") && strings.Contains(scoped, "untrust")) {
+		t.Fatalf("scoped-global brief row = %q, want trust/untrust columns "+
+			"(scoped global shown as all-zones — #3286 regression)", scoped)
+	}
+	open := briefRow(t, out, "open-global")
+	fields := strings.Fields(open)
+	if len(fields) < 2 || fields[0] != "*" || fields[1] != "*" {
+		t.Fatalf("open-global brief row = %q, want */* columns (unscoped global)", open)
+	}
+}
+
+// Test_3286_PolicyHitCountScopedGlobalShowsZones covers the CLI hit-count
+// table. Reverting to the hard-coded junos-global columns turns the scoped
+// assertion RED.
+func Test_3286_PolicyHitCountScopedGlobalShowsZones(t *testing.T) {
+	c := scopedGlobalCLI(t)
+	// hit-count returns early unless a dataplane is loaded.
+	c.dp = &policyCounterCLIDP{
+		Manager:  dataplane.New(),
+		counters: map[uint32]dataplane.CounterValue{},
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.handleShow([]string{"security", "policies", "hit-count"}); err != nil {
+			t.Fatalf("handleShow(security policies hit-count): %v", err)
+		}
+	})
+
+	scoped := briefRow(t, out, "scoped-global")
+	if !(strings.Contains(scoped, "trust") && strings.Contains(scoped, "untrust")) {
+		t.Fatalf("scoped-global hit-count row = %q, want trust/untrust columns "+
+			"(scoped global shown as all-zones — #3286 regression)", scoped)
+	}
+	open := briefRow(t, out, "open-global")
+	if !strings.Contains(open, "junos-global") {
+		t.Fatalf("open-global hit-count row = %q, want junos-global columns (unscoped global)", open)
+	}
+}
+
+func briefRow(t *testing.T, out, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, name) {
+			return line
+		}
+	}
+	t.Fatalf("policy %q row not found in brief output:\n%s", name, out)
+	return ""
+}
+
+// scopedGlobalCLI builds a store-backed CLI with a scoped + unscoped global
+// policy via the configuration grammar (exercises the #3148 compile path).
+func scopedGlobalCLI(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, t.TempDir()+"/xpf.conf")
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	for _, cmd := range []string{
+		"security zones security-zone trust",
+		"security zones security-zone untrust",
+		"security policies global policy scoped-global match from-zone trust",
+		"security policies global policy scoped-global match to-zone untrust",
+		"security policies global policy scoped-global match source-address any",
+		"security policies global policy scoped-global match destination-address any",
+		"security policies global policy scoped-global match application any",
+		"security policies global policy scoped-global then deny",
+		"security policies global policy open-global match source-address any",
+		"security policies global policy open-global match destination-address any",
+		"security policies global policy open-global match application any",
+		"security policies global policy open-global then permit",
+	} {
+		if err := store.SetFromInput(cmd); err != nil {
+			t.Fatalf("SetFromInput(%q): %v", cmd, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || len(cfg.Security.GlobalPolicies) != 2 {
+		t.Fatalf("expected 2 global policies, got %v", cfg)
+	}
+	if cfg.Security.GlobalPolicies[0].Match.FromZone != "trust" {
+		t.Fatalf("scoped-global FromZone = %q, want trust", cfg.Security.GlobalPolicies[0].Match.FromZone)
+	}
+	return &CLI{store: store}
+}

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -131,7 +131,14 @@ contract.
   structured `GetPolicies`. A `from-zone`/`to-zone` filter selects
   zone-pair policies only, so the global section is suppressed when a
   filter is set. Omitting globals from any one surface is the #3059 /
-  #3045 class of blind-spot bug.
+  #3045 class of blind-spot bug. A scoped global (#3148 `match
+  from-zone`/`to-zone`) carries its narrowing (#3286): the text
+  `policies-hit-count` From/To columns and the `policies-detail` `Source
+  zone:`/`Destination zone:` lines show the configured zone for a scoped
+  global (group still `*`), and structured `GetPolicies` populates the
+  per-rule `match_from_zone`/`match_to_zone` proto fields (empty for an
+  unscoped global). Showing the group `*`/`*` but dropping the per-rule
+  scope is the #3286 blind spot.
 - Request-supplied numeric fields are signed on the wire and must be
   range-checked before they index/slice/size anything (#2282). `Complete`
   rejects a negative `pos` with `InvalidArgument` before slicing

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -174,8 +174,18 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 			}
 			totalPkts += pkts
 			totalBytes += bytes
+			// #3286: a scoped global (#3148) reports its zone pair in the
+			// From/To columns so the hit-count row is not ambiguous; an
+			// unscoped global keeps "*"/"*".
+			hcFrom, hcTo := "*", "*"
+			if pol.Match.FromZone != "" {
+				hcFrom = pol.Match.FromZone
+			}
+			if pol.Match.ToZone != "" {
+				hcTo = pol.Match.ToZone
+			}
 			fmt.Fprintf(buf, "%-12s %-12s %-24s %-8s %12d %16d\n",
-				"*", "*", pol.Name, action, pkts, bytes)
+				hcFrom, hcTo, pol.Name, action, pkts, bytes)
 		}
 	}
 	fmt.Fprintln(buf, strings.Repeat("-", 88))
@@ -292,6 +302,15 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 				fmt.Fprintf(buf, "    Description: %s\n", pol.Description)
 			}
 			fmt.Fprintf(buf, "    Match:\n")
+			// #3286: a scoped global (#3148) narrows itself to a zone pair;
+			// surface the configured scope so the detail view does not read
+			// as all-zones. Omitted for an unscoped global (no regression).
+			if pol.Match.FromZone != "" {
+				fmt.Fprintf(buf, "      Source zone: %s\n", pol.Match.FromZone)
+			}
+			if pol.Match.ToZone != "" {
+				fmt.Fprintf(buf, "      Destination zone: %s\n", pol.Match.ToZone)
+			}
 			fmt.Fprintf(buf, "      Source addresses:\n")
 			for _, addr := range pol.Match.SourceAddresses {
 				resolved := grpcResolveAddress(cfg, addr)

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -130,6 +130,13 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				Applications: rule.Match.Applications,
 				Log:          rule.Log != nil,
 				Count:        rule.Count,
+				// #3286: a scoped global policy (#3148) narrows the
+				// all-zones group to a zone pair. Carry the configured
+				// from/to-zone so the inventory shows the real scope
+				// instead of the group-level "*"/"*". Empty for an
+				// unscoped (all-zones) global — no regression.
+				MatchFromZone: rule.Match.FromZone,
+				MatchToZone:   rule.Match.ToZone,
 			}
 			if pr.SrcAddresses == nil {
 				pr.SrcAddresses = []string{}

--- a/pkg/grpcapi/server_show_zones_scoped_global_3286_test.go
+++ b/pkg/grpcapi/server_show_zones_scoped_global_3286_test.go
@@ -1,0 +1,155 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3286: a scoped global policy (#3148, `match from-zone`/`to-zone`) was
+// rendered as all-zones in the gRPC GetPolicies inventory — the per-rule
+// match-zone context was dropped, so an operator could not tell that a
+// global rule was narrowed to a zone pair. The structured response now
+// carries MatchFromZone/MatchToZone on the global rule. These tests are the
+// fail-on-revert guard: drop the population in server_show_zones.go and the
+// scoped assertion goes RED (zones come back empty / all-zones).
+
+// scopedGlobalGRPCStore builds a config with one scoped global policy
+// (from-zone trust, to-zone untrust) and one unscoped (all-zones) global
+// policy so the inventory must distinguish them.
+func scopedGlobalGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        global {
+            policy scoped-global {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy open-global {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if len(cfg.Security.GlobalPolicies) != 2 {
+		t.Fatalf("GlobalPolicies len = %d, want 2", len(cfg.Security.GlobalPolicies))
+	}
+	return store
+}
+
+// TestGetPoliciesScopedGlobalCarriesZones is the #3286 fail-on-revert guard:
+// the gRPC GetPolicies global row must carry the scoped from/to-zone on the
+// scoped rule and leave them empty on the unscoped rule.
+func TestGetPoliciesScopedGlobalCarriesZones(t *testing.T) {
+	s := &Server{store: scopedGlobalGRPCStore(t)}
+
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+
+	var sawScoped, sawOpen bool
+	for _, policy := range resp.GetPolicies() {
+		// Globals are still grouped under the all-zones "*"/"*" PolicyInfo.
+		if policy.GetFromZone() != "*" || policy.GetToZone() != "*" {
+			continue
+		}
+		for _, rule := range policy.GetRules() {
+			switch rule.GetName() {
+			case "scoped-global":
+				sawScoped = true
+				if rule.GetMatchFromZone() != "trust" || rule.GetMatchToZone() != "untrust" {
+					t.Fatalf("scoped-global match zones = %q/%q, want trust/untrust "+
+						"(scoped global rendered as all-zones — #3286 regression)",
+						rule.GetMatchFromZone(), rule.GetMatchToZone())
+				}
+			case "open-global":
+				sawOpen = true
+				if rule.GetMatchFromZone() != "" || rule.GetMatchToZone() != "" {
+					t.Fatalf("open-global match zones = %q/%q, want empty (all-zones global)",
+						rule.GetMatchFromZone(), rule.GetMatchToZone())
+				}
+			}
+		}
+	}
+	if !sawScoped {
+		t.Fatal("scoped-global policy missing from gRPC GetPolicies global group")
+	}
+	if !sawOpen {
+		t.Fatal("open-global policy missing from gRPC GetPolicies global group")
+	}
+}
+
+// TestShowTextPoliciesScopedGlobalShowsZones is the #3286 fail-on-revert guard
+// for the gRPC text surfaces (ShowText): the hit-count table row for a scoped
+// global must carry its zone pair (not "*"/"*"), and the detail view must print
+// the Source/Destination zone scope.
+func TestShowTextPoliciesScopedGlobalShowsZones(t *testing.T) {
+	s := &Server{store: scopedGlobalGRPCStore(t)}
+
+	hc, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "policies-hit-count"})
+	if err != nil {
+		t.Fatalf("ShowText(policies-hit-count) error = %v", err)
+	}
+	var scopedRow string
+	for _, line := range strings.Split(hc.GetOutput(), "\n") {
+		if strings.Contains(line, "scoped-global") {
+			scopedRow = line
+			break
+		}
+	}
+	if scopedRow == "" {
+		t.Fatalf("scoped-global missing from hit-count text:\n%s", hc.GetOutput())
+	}
+	if !strings.Contains(scopedRow, "trust") || !strings.Contains(scopedRow, "untrust") {
+		t.Fatalf("hit-count scoped-global row = %q, want trust/untrust columns "+
+			"(scoped global shown as all-zones — #3286 regression)", scopedRow)
+	}
+
+	det, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "policies-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(policies-detail) error = %v", err)
+	}
+	out := det.GetOutput()
+	idx := strings.Index(out, "scoped-global")
+	if idx < 0 {
+		t.Fatalf("scoped-global missing from detail text:\n%s", out)
+	}
+	block := out[idx:]
+	if !strings.Contains(block, "Source zone: trust") || !strings.Contains(block, "Destination zone: untrust") {
+		t.Fatalf("detail text scoped-global block missing zone scope "+
+			"(want Source zone: trust / Destination zone: untrust):\n%s", block)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -2159,17 +2159,24 @@ func (x *PolicyInfo) GetRules() []*PolicyRule {
 }
 
 type PolicyRule struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Action        string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
-	SrcAddresses  []string               `protobuf:"bytes,3,rep,name=src_addresses,json=srcAddresses,proto3" json:"src_addresses,omitempty"`
-	DstAddresses  []string               `protobuf:"bytes,4,rep,name=dst_addresses,json=dstAddresses,proto3" json:"dst_addresses,omitempty"`
-	Applications  []string               `protobuf:"bytes,5,rep,name=applications,proto3" json:"applications,omitempty"`
-	Log           bool                   `protobuf:"varint,6,opt,name=log,proto3" json:"log,omitempty"`
-	Count         bool                   `protobuf:"varint,7,opt,name=count,proto3" json:"count,omitempty"`
-	HitPackets    uint64                 `protobuf:"varint,8,opt,name=hit_packets,json=hitPackets,proto3" json:"hit_packets,omitempty"`
-	HitBytes      uint64                 `protobuf:"varint,9,opt,name=hit_bytes,json=hitBytes,proto3" json:"hit_bytes,omitempty"`
-	Description   string                 `protobuf:"bytes,10,opt,name=description,proto3" json:"description,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Name         string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Action       string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
+	SrcAddresses []string               `protobuf:"bytes,3,rep,name=src_addresses,json=srcAddresses,proto3" json:"src_addresses,omitempty"`
+	DstAddresses []string               `protobuf:"bytes,4,rep,name=dst_addresses,json=dstAddresses,proto3" json:"dst_addresses,omitempty"`
+	Applications []string               `protobuf:"bytes,5,rep,name=applications,proto3" json:"applications,omitempty"`
+	Log          bool                   `protobuf:"varint,6,opt,name=log,proto3" json:"log,omitempty"`
+	Count        bool                   `protobuf:"varint,7,opt,name=count,proto3" json:"count,omitempty"`
+	HitPackets   uint64                 `protobuf:"varint,8,opt,name=hit_packets,json=hitPackets,proto3" json:"hit_packets,omitempty"`
+	HitBytes     uint64                 `protobuf:"varint,9,opt,name=hit_bytes,json=hitBytes,proto3" json:"hit_bytes,omitempty"`
+	Description  string                 `protobuf:"bytes,10,opt,name=description,proto3" json:"description,omitempty"`
+	// match_from_zone / match_to_zone carry the optional from-zone/to-zone
+	// match context of a scoped GLOBAL policy (#3148). Empty for an
+	// all-zones global policy and for ordinary zone-pair rules (whose zones
+	// come from the enclosing PolicyInfo from_zone/to_zone). #3286: surfaces
+	// the configured zone scope so a scoped global is not shown as all-zones.
+	MatchFromZone string `protobuf:"bytes,11,opt,name=match_from_zone,json=matchFromZone,proto3" json:"match_from_zone,omitempty"`
+	MatchToZone   string `protobuf:"bytes,12,opt,name=match_to_zone,json=matchToZone,proto3" json:"match_to_zone,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2270,6 +2277,20 @@ func (x *PolicyRule) GetHitBytes() uint64 {
 func (x *PolicyRule) GetDescription() string {
 	if x != nil {
 		return x.Description
+	}
+	return ""
+}
+
+func (x *PolicyRule) GetMatchFromZone() string {
+	if x != nil {
+		return x.MatchFromZone
+	}
+	return ""
+}
+
+func (x *PolicyRule) GetMatchToZone() string {
+	if x != nil {
+		return x.MatchToZone
 	}
 	return ""
 }
@@ -7106,7 +7127,7 @@ const file_xpf_proto_rawDesc = "" +
 	"PolicyInfo\x12\x1b\n" +
 	"\tfrom_zone\x18\x01 \x01(\tR\bfromZone\x12\x17\n" +
 	"\ato_zone\x18\x02 \x01(\tR\x06toZone\x12(\n" +
-	"\x05rules\x18\x03 \x03(\v2\x12.xpf.v1.PolicyRuleR\x05rules\"\xae\x02\n" +
+	"\x05rules\x18\x03 \x03(\v2\x12.xpf.v1.PolicyRuleR\x05rules\"\xfa\x02\n" +
 	"\n" +
 	"PolicyRule\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
@@ -7120,7 +7141,9 @@ const file_xpf_proto_rawDesc = "" +
 	"hitPackets\x12\x1b\n" +
 	"\thit_bytes\x18\t \x01(\x04R\bhitBytes\x12 \n" +
 	"\vdescription\x18\n" +
-	" \x01(\tR\vdescription\"\x9e\x04\n" +
+	" \x01(\tR\vdescription\x12&\n" +
+	"\x0fmatch_from_zone\x18\v \x01(\tR\rmatchFromZone\x12\"\n" +
+	"\rmatch_to_zone\x18\f \x01(\tR\vmatchToZone\"\x9e\x04\n" +
 	"\x12GetSessionsRequest\x12\x14\n" +
 	"\x05limit\x18\x01 \x01(\x05R\x05limit\x12\x16\n" +
 	"\x06offset\x18\x02 \x01(\x05R\x06offset\x12\x12\n" +

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -245,6 +245,13 @@ message PolicyRule {
   uint64 hit_packets = 8;
   uint64 hit_bytes = 9;
   string description = 10;
+  // match_from_zone / match_to_zone carry the optional from-zone/to-zone
+  // match context of a scoped GLOBAL policy (#3148). Empty for an
+  // all-zones global policy and for ordinary zone-pair rules (whose zones
+  // come from the enclosing PolicyInfo from_zone/to_zone). #3286: surfaces
+  // the configured zone scope so a scoped global is not shown as all-zones.
+  string match_from_zone = 11;
+  string match_to_zone = 12;
 }
 
 message GetSessionsRequest {


### PR DESCRIPTION
## Problem

A global security policy can narrow itself to a zone pair via #3148
`match from-zone <z>` / `match to-zone <z>`. The dataplane enforces this
scope, but every operator inventory/show surface dropped it and rendered
scoped globals as all-zones (`*`/`*`, `junos-global`, `any`). During an
audit an operator could not tell whether `dmz -> untrust` hit a global
`from-zone trust to-zone untrust deny`, and scoped-global hit counters
appeared under an all-zones-looking row, making counter-based validation
ambiguous. Display-only drift — the runtime was correct.

## Fix

Carry `Policy.Match.FromZone`/`.ToZone` through all three display planes:

- **REST**: `match_from_zone`/`match_to_zone` (omitempty) added to the
  `PolicyRule` JSON shape and populated in `policiesHandler`'s global loop.
- **gRPC**: `match_from_zone`/`match_to_zone` (fields 11/12) added to the
  protobuf `PolicyRule` (regenerated) and populated in structured
  `GetPolicies`; the text `policies-hit-count` (From/To columns) and
  `policies-detail` (`Source zone:`/`Destination zone:`) views render the
  scope too.
- **CLI**: `show security policies` (standard `From zones:`/`To zones:`),
  `... detail` (`From zone:`/`To zone:`), `... brief` (From/To columns),
  and `... hit-count` (From zone/To zone columns) all show the scoped zone.

The global `PolicyInfo` group still reports `from_zone="*"`/`to_zone="*"`
(the all-zones tier); the per-rule fields carry the narrowing. An unscoped
global is byte-identical to before.

## Tests (fail-on-revert)

- `pkg/api/security_scoped_global_3286_test.go` —
  `TestPoliciesHandlerScopedGlobalShowsZones`
- `pkg/grpcapi/server_show_zones_scoped_global_3286_test.go` —
  `TestGetPoliciesScopedGlobalCarriesZones`,
  `TestShowTextPoliciesScopedGlobalShowsZones`
- `pkg/cli/cli_show_security_scoped_global_3286_test.go` —
  `Test_3286_PolicyDetailScopedGlobalShowsZones`,
  `Test_3286_PolicyStandardScopedGlobalShowsZones`,
  `Test_3286_PolicyBriefScopedGlobalShowsZones`,
  `Test_3286_PolicyHitCountScopedGlobalShowsZones`

Each verified RED when the per-surface render is reverted to the
all-zones placeholder, and an unscoped global keeps the placeholder (no
regression). `go build ./...` and full `go test ./...` green.

## Docs

`docs/junos-cli-reference.md` (global-policy zone-context section
expanded with the cross-surface guarantee), `pkg/api/README.md`,
`pkg/grpcapi/README.md`, `_Log.md`.

Closes #3286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi