### PR TITLE
policymatch: parity with dataplane policy-eval (wildcard-zone, scoped-global, ICMP type/code, junos-host, zone-local globals)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22365,3 +22365,12 @@ top.
   pkg/policymatch/README.md, pkg/api/security.go,
   pkg/cli/cli_request.go, pkg/grpcapi/server_cluster.go,
   pkg/grpcapi/server_show_firewall.go
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3284 — policymatch simulator now enforces ICMP/ICMPv6 type/code application constraints (junos-ping = type 8, junos-pingv6 = type 128) like the dataplane (policy.rs CompiledApplications.matches). Added Query.ICMPType/ICMPCode (*uint8), enforcement in matchSingleApp (fail-closed when the query omits the type for a type-constrained term), and the ParseICMPValue shared parser. Plumbed type/code through every simulator surface: proto3 optional icmp_type/icmp_code on MatchPoliciesRequest (regenerated), REST icmp_type/icmp_code query params, gRPC test-policy ictype=/iccode= topic keys, and CLI/remote-CLI icmp-type/icmp-code tokens. Added fail-on-revert table tests.
+  **File(s)**: pkg/policymatch/policymatch.go,
+  pkg/policymatch/icmp_test.go, pkg/policymatch/README.md,
+  proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go,
+  pkg/grpcapi/server_cluster.go, pkg/grpcapi/server_show_firewall.go,
+  pkg/api/security.go, pkg/cli/cli_request.go,
+  pkg/cli/cli_show_security.go, cmd/cli/main.go, cmd/cli/show.go

--- a/_Log.md
+++ b/_Log.md
@@ -22357,3 +22357,11 @@ top.
   pkg/dataplane/userspace/zones_host_inbound_test.go,
   pkg/daemon/host_inbound_nft_test.go,
   docs/junos-cli-reference.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3283 — policymatch simulator parity with dataplane wildcard-zone (#3090) and scoped-global (#3148) precedence. Restructured Match() into the dataplane tier chain: exact zone-pair -> single-wildcard (from-any/to-any merged in config order) -> both-any -> global (gated by the optional #3148 from/to-zone match scope, undefined-zone scope fails closed) -> default. Added globalScopeMatches replicating GlobalZoneScope::matches + build_global_zone_scope. Updated stale precedence comments on every surface and the README. Added fail-on-revert table tests.
+  **File(s)**: pkg/policymatch/policymatch.go,
+  pkg/policymatch/wildcard_scoped_test.go,
+  pkg/policymatch/README.md, pkg/api/security.go,
+  pkg/cli/cli_request.go, pkg/grpcapi/server_cluster.go,
+  pkg/grpcapi/server_show_firewall.go

--- a/_Log.md
+++ b/_Log.md
@@ -22374,3 +22374,12 @@ top.
   pkg/grpcapi/server_cluster.go, pkg/grpcapi/server_show_firewall.go,
   pkg/api/security.go, pkg/cli/cli_request.go,
   pkg/cli/cli_show_security.go, cmd/cli/main.go, cmd/cli/show.go
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3285 — policymatch simulator now mirrors the dataplane host gate (evaluate_junos_host_policy) for to-zone junos-host queries: exact from-zone <ingress> to-zone junos-host then from-zone any to-zone junos-host, with NO global/default transit fallback (and to-zone any / both-any NOT consulted). Added Match() branch + matchJunosHost + Result.HostInboundUnmatched; surfaced through REST (host_inbound_unmatched JSON), gRPC MatchPolicies (new proto bool field), gRPC test-policy text, and local/remote CLI rendering. Added fail-on-revert tests.
+  **File(s)**: pkg/policymatch/policymatch.go,
+  pkg/policymatch/junos_host_test.go, pkg/policymatch/README.md,
+  proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go,
+  pkg/grpcapi/server_cluster.go, pkg/grpcapi/server_show_firewall.go,
+  pkg/api/security.go, pkg/api/types.go, pkg/cli/cli_request.go,
+  pkg/cli/cli_show_security.go, cmd/cli/show.go

--- a/_Log.md
+++ b/_Log.md
@@ -22389,3 +22389,9 @@ top.
   **File(s)**: pkg/config/compiler_security.go,
   pkg/policymatch/scoped_global_zonelocal_test.go,
   docs/config-schema.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: PR #3289 quad-review fold (5 findings). (1) Remote CLI `show security match-policies` no-match path now renders the server-provided resp.Action ("<action> (default)") instead of hard-coded "default deny" — the #3283 drift class on the remote surface (wrong verdict under default-policy permit-all). (2) Remote CLI icmp-type/icmp-code now route through policymatch.ParseICMPValue and return an explicit error on invalid/out-of-range input (was a silent inline strconv.Atoi drop). (3) Corrected the stale matchApp docstring (now documents the empty-protocol match-any short-circuit as a diagnostic convenience and the ICMP type/code enforcement). (4) matchSingleApp now gates an ICMP-type-constrained app term on the query being ICMP(1)/ICMPv6(58) so a type-constrained term cannot match a TCP/UDP flow (mirrors the dataplane keying icmp_constraints under the ICMP protocol). (5) Documented the intentional REST-vs-gRPC Action asymmetry for host-inbound-unmatched in the policymatch README. Added 3 fail-on-revert tests (all RED on revert).
+  **File(s)**: cmd/cli/show.go, cmd/cli/nontty_test.go,
+  cmd/cli/show_matchpolicies_test.go, pkg/policymatch/policymatch.go,
+  pkg/policymatch/icmp_test.go, pkg/policymatch/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -22383,3 +22383,9 @@ top.
   pkg/grpcapi/server_cluster.go, pkg/grpcapi/server_show_firewall.go,
   pkg/api/security.go, pkg/api/types.go, pkg/cli/cli_request.go,
   pkg/cli/cli_show_security.go, cmd/cli/show.go
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3287 — resolveZoneLocalAddressBooks now rewrites a scoped global policy's (#3148) source/dest address tokens under its match from-zone/to-zone scope, so a zone-local (#3061) address reference in a scoped global resolves to the zone-qualified global-book entry instead of silently match-none / commit-reject. Unscoped globals (empty/any scope) are left to the global book. Both the simulator (pkg/policymatch) and the dataplane snapshot builder consume the post-fold book, keeping them in agreement. Added a fail-on-revert test that compiles a real config and asserts the simulator resolves the zone-local ref.
+  **File(s)**: pkg/config/compiler_security.go,
+  pkg/policymatch/scoped_global_zonelocal_test.go,
+  docs/config-schema.md

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -443,6 +443,7 @@ func (c *ctl) handleTest(args []string) error {
 func (c *ctl) testPolicy(args []string) error {
 	var fromZone, toZone, srcIP, dstIP, proto string
 	var srcPort, dstPort int
+	var icmpType, icmpCode *uint8
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "from-zone":
@@ -498,6 +499,26 @@ func (c *ctl) testPolicy(args []string) error {
 				i++
 				proto = args[i]
 			}
+		case "icmp-type":
+			if i+1 < len(args) {
+				i++
+				// #3284: thread an ICMP/ICMPv6 type into the backend matcher so a
+				// type-constrained app term (junos-ping = type 8) is honored.
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-type: %w", err)
+				}
+				icmpType = v
+			}
+		case "icmp-code":
+			if i+1 < len(args) {
+				i++
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-code: %w", err)
+				}
+				icmpCode = v
+			}
 		}
 	}
 
@@ -530,6 +551,12 @@ func (c *ctl) testPolicy(args []string) error {
 	}
 	if proto != "" {
 		topic += ",proto=" + proto
+	}
+	if icmpType != nil {
+		topic += ",ictype=" + strconv.Itoa(int(*icmpType))
+	}
+	if icmpCode != nil {
+		topic += ",iccode=" + strconv.Itoa(int(*icmpCode))
 	}
 	return c.showText(topic)
 }

--- a/cmd/cli/nontty_test.go
+++ b/cmd/cli/nontty_test.go
@@ -40,6 +40,22 @@ type fakeBpfrxClient struct {
 	showTextCalls  int
 	showTextTopic  string
 	showTextOutput string
+
+	// MatchPolicies recorder (#3283/#3284 remote-surface coverage).
+	matchPoliciesCalls int
+	matchPoliciesReq   *pb.MatchPoliciesRequest
+	matchPoliciesResp  *pb.MatchPoliciesResponse
+}
+
+func (f *fakeBpfrxClient) MatchPolicies(
+	_ context.Context, in *pb.MatchPoliciesRequest, _ ...grpc.CallOption,
+) (*pb.MatchPoliciesResponse, error) {
+	f.matchPoliciesCalls++
+	f.matchPoliciesReq = in
+	if f.matchPoliciesResp != nil {
+		return f.matchPoliciesResp, nil
+	}
+	return &pb.MatchPoliciesResponse{}, nil
 }
 
 func (f *fakeBpfrxClient) ShowText(

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -924,6 +924,24 @@ func (c *ctl) showMatchPolicies(args []string) error {
 				i++
 				req.Protocol = args[i]
 			}
+		case "icmp-type":
+			if i+1 < len(args) {
+				i++
+				// #3284: thread an ICMP/ICMPv6 type so a type-constrained app
+				// term (junos-ping = type 8) is honored by the backend matcher.
+				if v, err := strconv.Atoi(args[i]); err == nil && v >= 0 && v <= 255 {
+					u := uint32(v)
+					req.IcmpType = &u
+				}
+			}
+		case "icmp-code":
+			if i+1 < len(args) {
+				i++
+				if v, err := strconv.Atoi(args[i]); err == nil && v >= 0 && v <= 255 {
+					u := uint32(v)
+					req.IcmpCode = &u
+				}
+			}
 		}
 	}
 

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -964,6 +964,10 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		fmt.Printf("    Destination addresses: %v\n", resp.DstAddresses)
 		fmt.Printf("    Applications: %v\n", resp.Applications)
 		fmt.Printf("    Action: %s\n", resp.Action)
+	} else if resp.HostInboundUnmatched {
+		// #3285: host-bound traffic — no transit global/default fallback.
+		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", req.FromZone)
+		fmt.Printf("  host-inbound: local delivery proceeds (transit global/default-policy NOT applied)\n")
 	} else {
 		fmt.Printf("No matching policy found for %s -> %s (default deny)\n", req.FromZone, req.ToZone)
 	}

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/policymatch"
 )
 
 func (c *ctl) handleShow(args []string) error {
@@ -929,16 +930,27 @@ func (c *ctl) showMatchPolicies(args []string) error {
 				i++
 				// #3284: thread an ICMP/ICMPv6 type so a type-constrained app
 				// term (junos-ping = type 8) is honored by the backend matcher.
-				if v, err := strconv.Atoi(args[i]); err == nil && v >= 0 && v <= 255 {
-					u := uint32(v)
+				// Route through the shared validator so an invalid/out-of-range
+				// token errors instead of silently dropping to the unconstrained
+				// nil wildcard (mirrors every other surface).
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-type: %w", err)
+				}
+				if v != nil {
+					u := uint32(*v)
 					req.IcmpType = &u
 				}
 			}
 		case "icmp-code":
 			if i+1 < len(args) {
 				i++
-				if v, err := strconv.Atoi(args[i]); err == nil && v >= 0 && v <= 255 {
-					u := uint32(v)
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-code: %w", err)
+				}
+				if v != nil {
+					u := uint32(*v)
 					req.IcmpCode = &u
 				}
 			}
@@ -969,7 +981,13 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", req.FromZone)
 		fmt.Printf("  host-inbound: local delivery proceeds (transit global/default-policy NOT applied)\n")
 	} else {
-		fmt.Printf("No matching policy found for %s -> %s (default deny)\n", req.FromZone, req.ToZone)
+		// #3283: render the SERVER-provided default verdict (resp.Action carries
+		// "<action> (default)" from the configured default-policy), NOT a
+		// hard-coded "default deny". Under `default-policy permit-all` the old
+		// literal reported the OPPOSITE of the dataplane — the same simulator
+		// drift class #3283 fixes — and diverged from the local CLI / gRPC text
+		// surfaces, which already report resp.Action.
+		fmt.Printf("No matching policy found for %s -> %s (%s)\n", req.FromZone, req.ToZone, resp.Action)
 	}
 	return nil
 }

--- a/cmd/cli/show_matchpolicies_test.go
+++ b/cmd/cli/show_matchpolicies_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestShowMatchPoliciesRendersServerVerdict covers the #3283 drift on the REMOTE
+// CLI surface: `show security match-policies` previously hard-coded the no-match
+// output as "default deny" and ignored resp.Action. Under
+// `default-policy permit-all` the server returns Matched=false with
+// Action="permit (default)", and the remote CLI must render that real verdict —
+// not the literal "default deny" (which is the OPPOSITE of the dataplane, the
+// same class #3283 fixes on the simulator).
+//
+// FAIL-ON-REVERT: restoring the hard-coded "(default deny)" string makes the
+// "permit (default)" assertion fail (and the no-"default deny" assertion fail).
+func TestShowMatchPoliciesRendersServerVerdict(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		matchPoliciesResp: &pb.MatchPoliciesResponse{
+			Matched: false,
+			Action:  "permit (default)",
+		},
+	}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showMatchPolicies([]string{"from-zone", "trust", "to-zone", "untrust"}); err != nil {
+			t.Fatalf("showMatchPolicies: %v", err)
+		}
+	})
+
+	if fake.matchPoliciesCalls != 1 {
+		t.Fatalf("MatchPolicies called %d times, want 1", fake.matchPoliciesCalls)
+	}
+	if !strings.Contains(out, "permit (default)") {
+		t.Fatalf("output missing server verdict %q:\n%s", "permit (default)", out)
+	}
+	if strings.Contains(out, "default deny") {
+		t.Fatalf("output still renders hard-coded 'default deny':\n%s", out)
+	}
+}
+
+// TestShowMatchPoliciesRejectsInvalidICMP covers the #3284 gap on the remote
+// surface: an invalid/out-of-range icmp-type/icmp-code token was silently
+// dropped (inline strconv.Atoi + range check left the field nil → unconstrained
+// query). It must now route through policymatch.ParseICMPValue and return an
+// explicit error, like every other surface. The error returns during arg
+// parsing, before any RPC, so an empty client suffices.
+//
+// FAIL-ON-REVERT: reverting to the inline strconv.Atoi drop makes these
+// want-error cases return nil (and never error).
+func TestShowMatchPoliciesRejectsInvalidICMP(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"icmp-type out of range", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "icmp", "icmp-type", "300"}},
+		{"icmp-type non-numeric", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "icmp", "icmp-type", "abc"}},
+		{"icmp-code out of range", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "icmp", "icmp-code", "999"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeBpfrxClient{}
+			c := &ctl{client: fake}
+			err := c.showMatchPolicies(tc.args)
+			if err == nil {
+				t.Fatalf("showMatchPolicies(%v) err = nil, want an invalid icmp diagnostic", tc.args)
+			}
+			if !strings.Contains(err.Error(), "icmp") {
+				t.Fatalf("showMatchPolicies(%v) err = %v, want an icmp diagnostic", tc.args, err)
+			}
+			if fake.matchPoliciesCalls != 0 {
+				t.Fatalf("MatchPolicies issued %d times on invalid input; want 0", fake.matchPoliciesCalls)
+			}
+		})
+	}
+}

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1418,10 +1418,26 @@ policy is not evaluated on the host-bound (LocalDelivery) path, so
 `to-zone junos-host` at commit (rather than committing a silent never-match);
 real junos-host global-zone-context support is a follow-up.
 
+**Zone-local address books in a scoped global (#3287).** A scoped global
+(`match from-zone <z>` / `match to-zone <z>`) resolves a zone-local
+address-book reference (#3061) against that zone's local book — the same
+zone-qualified resolution `resolveZoneLocalAddressBooks` already applied to
+zone-pair policies. It rewrites a scoped global's `source-address` tokens under
+its `match from-zone` scope and `destination-address` tokens under its `match
+to-zone` scope to the `zone-local/<zone>/<name>` qualified entry. Without this,
+the bare token kept pointing at the global book (which holds the entry only
+under its qualified name), so the constraint silently resolved to match-none and
+legitimate zone-scoped global traffic fell through to default-deny (or was
+rejected at commit as an undefined address). An UNSCOPED global (empty / `any`
+scope) names no single zone-local book and is left to resolve against the global
+book. Because the simulator (`pkg/policymatch`) and the dataplane snapshot
+builder both consume the post-fold compiled book, this keeps them in agreement.
+
 Regression coverage:
 `pkg/config/compiler_policy_global_zone_3148_test.go`,
-`pkg/dataplane/userspace/policy_global_zone_3148_test.go`, and the Rust
-`global_policy_*` tests in `userspace-dp/src/policy_tests.rs`.
+`pkg/dataplane/userspace/policy_global_zone_3148_test.go`, the Rust
+`global_policy_*` tests in `userspace-dp/src/policy_tests.rs`, and
+`pkg/policymatch/scoped_global_zonelocal_test.go` (#3287).
 
 ### #2391 — Security-zone count cap (commit fail-closed)
 

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -356,6 +356,18 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		FeedOverlay:      overlay,
 		PolicyInactiveFn: inactiveFn,
 	})
+	// #3285: a `to-zone junos-host` query that matched no host-bound policy is
+	// not a transit default — the dataplane host gate returns None (local
+	// delivery; no global/default fallback). Surface it explicitly so the
+	// caller does not read a misleading default-policy verdict for the host
+	// path.
+	if res.HostInboundUnmatched {
+		writeOK(w, MatchPoliciesResult{
+			HostInboundUnmatched: true,
+			Action:               "host-inbound (local delivery; not governed by transit/global/default policy)",
+		})
+		return
+	}
 	if !res.Matched {
 		writeOK(w, MatchPoliciesResult{Action: policymatch.ActionString(res.Action) + " (default)"})
 		return

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -307,6 +307,20 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	// #3284: optional ICMP/ICMPv6 type/code so a type-constrained application
+	// term (junos-ping = type 8) is honored. An empty value is unspecified (a
+	// type-constrained term then fails closed, mirroring the dataplane); a
+	// malformed/out-of-range value is rejected, never coerced.
+	icmpType, err := policymatch.ParseICMPValue(r.URL.Query().Get("icmp_type"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid icmp_type: "+err.Error())
+		return
+	}
+	icmpCode, err := policymatch.ParseICMPValue(r.URL.Query().Get("icmp_code"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid icmp_code: "+err.Error())
+		return
+	}
 
 	// #3042: delegate to the single shared simulator so REST agrees with the
 	// runtime evaluator (exact zone-pair -> wildcard-zone tiers (#3090) ->
@@ -337,6 +351,8 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		Protocol:         proto,
 		SrcPort:          srcPort,
 		DstPort:          dstPort,
+		ICMPType:         icmpType,
+		ICMPCode:         icmpCode,
 		FeedOverlay:      overlay,
 		PolicyInactiveFn: inactiveFn,
 	})

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -309,10 +309,11 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// #3042: delegate to the single shared simulator so REST agrees with the
-	// runtime evaluator (zone-pair -> global -> default-policy, predefined +
-	// nested-app-set + literal-CIDR + any-ipv4/any-ipv6 + exclusion + feed
-	// overlay). The pre-#3042 hand-written loop skipped globals, hard-coded
-	// "deny (default)", and missed predefined apps / literal CIDRs.
+	// runtime evaluator (exact zone-pair -> wildcard-zone tiers (#3090) ->
+	// scoped global (#3148) -> default-policy, predefined + nested-app-set +
+	// literal-CIDR + any-ipv4/any-ipv6 + exclusion + feed overlay). The
+	// pre-#3042 hand-written loop skipped globals, hard-coded "deny (default)",
+	// and missed predefined apps / literal CIDRs.
 	var overlay map[string][]string
 	if s.feedOverlayFn != nil {
 		overlay = s.feedOverlayFn()

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -232,6 +232,11 @@ type MatchPoliciesResult struct {
 	SrcAddresses []string `json:"src_addresses,omitempty"`
 	DstAddresses []string `json:"dst_addresses,omitempty"`
 	Applications []string `json:"applications,omitempty"`
+	// HostInboundUnmatched is true for a `to-zone junos-host` query that matched
+	// no host-bound policy (#3285): the dataplane host gate returns None (local
+	// delivery; no transit global/default fallback), so Action is not a
+	// default-policy verdict for this case.
+	HostInboundUnmatched bool `json:"host_inbound_unmatched,omitempty"`
 }
 
 // ClearSessionsResult holds session clear results.

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -307,6 +307,12 @@ func (c *CLI) testPolicy(args []string) error {
 		// simulator falls through to the next active rule / default-policy.
 		PolicyInactiveFn: c.policyInactiveFn(),
 	})
+	if res.HostInboundUnmatched {
+		// #3285: host-bound traffic — no transit global/default fallback.
+		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", fromZone)
+		fmt.Printf("  host-inbound: local delivery proceeds (transit global/default-policy NOT applied)\n")
+		return nil
+	}
 	if !res.Matched {
 		fmt.Printf("Default %s (no matching policy for %s -> %s)\n",
 			policymatch.ActionString(res.Action), fromZone, toZone)

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -261,11 +261,12 @@ func (c *CLI) testPolicy(args []string) error {
 	parsedSrc := net.ParseIP(srcIP)
 	parsedDst := net.ParseIP(dstIP)
 
-	// #3042: delegate to the single shared simulator (zone-pair -> global ->
-	// default-policy). The pre-#3042 loop hard-coded "Default deny" (ignoring
-	// default-policy permit-all) and used a narrow address/app matcher that
-	// missed predefined apps, nested application-sets, literal CIDRs,
-	// any-ipv4/any-ipv6, and source/destination exclusion.
+	// #3042: delegate to the single shared simulator (exact zone-pair ->
+	// wildcard-zone tiers (#3090) -> scoped global (#3148) -> default-policy).
+	// The pre-#3042 loop hard-coded "Default deny" (ignoring default-policy
+	// permit-all) and used a narrow address/app matcher that missed predefined
+	// apps, nested application-sets, literal CIDRs, any-ipv4/any-ipv6, and
+	// source/destination exclusion.
 	// #3105: pass the live dynamic-address feed-prefix overlay so a feed-backed
 	// address-name resolves to its live CIDRs on-box, matching the REST/gRPC
 	// simulators and the AF_XDP helper. Nil (CLI outside the daemon) keeps the

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -179,6 +179,7 @@ func (c *CLI) testPolicy(args []string) error {
 
 	var fromZone, toZone, srcIP, dstIP, proto string
 	var srcPort, dstPort int
+	var icmpType, icmpCode *uint8
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "from-zone":
@@ -230,6 +231,26 @@ func (c *CLI) testPolicy(args []string) error {
 				i++
 				proto = args[i]
 			}
+		case "icmp-type":
+			if i+1 < len(args) {
+				i++
+				// #3284: thread an ICMP/ICMPv6 type into the shared matcher so a
+				// type-constrained app term (junos-ping = type 8) is honored.
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-type: %w", err)
+				}
+				icmpType = v
+			}
+		case "icmp-code":
+			if i+1 < len(args) {
+				i++
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-code: %w", err)
+				}
+				icmpCode = v
+			}
 		}
 	}
 
@@ -279,6 +300,8 @@ func (c *CLI) testPolicy(args []string) error {
 		Protocol:    proto,
 		SrcPort:     srcPort,
 		DstPort:     dstPort,
+		ICMPType:    icmpType,
+		ICMPCode:    icmpCode,
 		FeedOverlay: c.feedOverlay(),
 		// #3104: skip scheduler-inactive policies like the runtime does, so the
 		// simulator falls through to the next active rule / default-policy.

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -274,6 +274,7 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	//                   destination-port <p> protocol <proto>
 	var fromZone, toZone, srcIP, dstIP, proto string
 	var dstPort, srcPort int
+	var icmpType, icmpCode *uint8
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "from-zone":
@@ -318,6 +319,26 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 			if i+1 < len(args) {
 				i++
 				proto = args[i]
+			}
+		case "icmp-type":
+			if i+1 < len(args) {
+				i++
+				// #3284: honor ICMP/ICMPv6 type-constrained app terms
+				// (junos-ping = type 8).
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-type: %w", err)
+				}
+				icmpType = v
+			}
+		case "icmp-code":
+			if i+1 < len(args) {
+				i++
+				v, err := policymatch.ParseICMPValue(args[i])
+				if err != nil {
+					return fmt.Errorf("invalid icmp-code: %w", err)
+				}
+				icmpCode = v
 			}
 		}
 	}
@@ -369,6 +390,8 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		Protocol:    proto,
 		SrcPort:     srcPort,
 		DstPort:     dstPort,
+		ICMPType:    icmpType,
+		ICMPCode:    icmpCode,
 		FeedOverlay: c.feedOverlay(),
 		// #3104: skip scheduler-inactive policies like the runtime does, so the
 		// simulator falls through to the next active rule / default-policy.

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -397,6 +397,12 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		// simulator falls through to the next active rule / default-policy.
 		PolicyInactiveFn: c.policyInactiveFn(),
 	})
+	if res.HostInboundUnmatched {
+		// #3285: host-bound traffic — no transit global/default fallback.
+		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", fromZone)
+		fmt.Printf("  host-inbound: local delivery proceeds (transit global/default-policy NOT applied)\n")
+		return nil
+	}
 	if !res.Matched {
 		fmt.Printf("No matching policy found for %s -> %s (default %s)\n",
 			fromZone, toZone, policymatch.ActionString(res.Action))

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -281,7 +281,9 @@ func resolveZoneLocalAddressBooks(sec *SecurityConfig) {
 	}
 
 	rewrite := func(zone string, tokens []string) {
-		if zone == "" {
+		// An empty or wildcard ("any") zone names no single zone-local book to
+		// resolve against, so leave such tokens for the global book.
+		if zone == "" || zone == "any" {
 			return
 		}
 		for i, t := range tokens {
@@ -306,8 +308,21 @@ func resolveZoneLocalAddressBooks(sec *SecurityConfig) {
 			rewrite(zpp.ToZone, p.Match.DestinationAddresses)
 		}
 	}
-	// Global policies (junos-global) have no zone-local scope — they resolve
-	// only against the global book, so their tokens are left unchanged.
+	// #3287: a scoped global policy (#3148, `match from-zone <z>` /
+	// `match to-zone <z>`) resolves its zone-local address references against
+	// that zone's local book, exactly like a zone-pair policy. Without this the
+	// bare token kept pointing at the global book (where the entry exists only
+	// under its zone-qualified name), so the address constraint silently
+	// resolved to match-none and legitimate zone-scoped global traffic fell
+	// through to default-deny. An unscoped global (empty / `any` scope) has no
+	// single zone-local book and is left to resolve against the global book.
+	for _, p := range sec.GlobalPolicies {
+		if p == nil {
+			continue
+		}
+		rewrite(p.Match.FromZone, p.Match.SourceAddresses)
+		rewrite(p.Match.ToZone, p.Match.DestinationAddresses)
+	}
 }
 
 func compileZones(node *Node, sec *SecurityConfig) error {

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -202,6 +202,16 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		// simulator falls through to the next active rule / default-policy.
 		PolicyInactiveFn: s.policyInactiveFn(),
 	})
+	// #3285: a `to-zone junos-host` query that matched no host-bound policy is
+	// NOT a transit default — the dataplane host gate returns None (local
+	// delivery; no global/default fallback). Signal it explicitly so the client
+	// does not render a misleading default-policy verdict for the host path.
+	if res.HostInboundUnmatched {
+		return &pb.MatchPoliciesResponse{
+			Matched:              false,
+			HostInboundUnmatched: true,
+		}, nil
+	}
 	if !res.Matched {
 		return &pb.MatchPoliciesResponse{
 			Matched: false,

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -163,6 +163,20 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
+	// #3284: thread the optional ICMP/ICMPv6 type/code into the simulator so a
+	// type-constrained application term (junos-ping = type 8) matches only the
+	// declared type. The proto3 optional uint32 carries presence; values
+	// outside [0,255] cannot describe a real ICMP packet, so reject them
+	// rather than truncate to 8 bits (which would silently alias e.g. 264->8).
+	icmpType, err := grpcICMPValue(req.IcmpType)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid icmp-type: %v", err)
+	}
+	icmpCode, err := grpcICMPValue(req.IcmpCode)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid icmp-code: %v", err)
+	}
+
 	// #3042: delegate to the single shared simulator so gRPC agrees with the
 	// runtime evaluator (exact zone-pair -> wildcard-zone tiers (#3090) ->
 	// scoped global (#3148) -> default-policy, predefined + nested-app-set +
@@ -181,6 +195,8 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		Protocol:    req.Protocol,
 		SrcPort:     int(req.SourcePort),
 		DstPort:     int(req.DestinationPort),
+		ICMPType:    icmpType,
+		ICMPCode:    icmpCode,
 		FeedOverlay: overlay,
 		// #3104: skip scheduler-inactive policies like the runtime does, so the
 		// simulator falls through to the next active rule / default-policy.
@@ -200,6 +216,21 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		DstAddresses: res.DstAddresses,
 		Applications: res.Applications,
 	}, nil
+}
+
+// grpcICMPValue converts an optional proto3 uint32 ICMP type/code field into
+// the *uint8 the shared simulator consumes (#3284). nil (field absent) stays
+// nil (unspecified). A present value must fit the 8-bit ICMP type/code space;
+// anything above 255 is rejected rather than truncated.
+func grpcICMPValue(v *uint32) (*uint8, error) {
+	if v == nil {
+		return nil, nil
+	}
+	if *v > 255 {
+		return nil, fmt.Errorf("%d out of range (0-255)", *v)
+	}
+	u := uint8(*v)
+	return &u, nil
 }
 
 // grpcResolveAddress looks up a named address in the global address book and returns its CIDR suffix.

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -164,10 +164,11 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 	}
 
 	// #3042: delegate to the single shared simulator so gRPC agrees with the
-	// runtime evaluator (zone-pair -> global -> default-policy, predefined +
-	// nested-app-set + literal-CIDR + any-ipv4/any-ipv6 + exclusion + feed
-	// overlay). The pre-#3042 loop skipped globals, hard-coded "deny
-	// (default)", and missed predefined apps / literal CIDRs.
+	// runtime evaluator (exact zone-pair -> wildcard-zone tiers (#3090) ->
+	// scoped global (#3148) -> default-policy, predefined + nested-app-set +
+	// literal-CIDR + any-ipv4/any-ipv6 + exclusion + feed overlay). The
+	// pre-#3042 loop skipped globals, hard-coded "deny (default)", and missed
+	// predefined apps / literal CIDRs.
 	var overlay map[string][]string
 	if s.feedOverlayFn != nil {
 		overlay = s.feedOverlayFn()

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -165,7 +165,8 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 	params := strings.TrimPrefix(req.Topic, "test-policy:")
 	var fromZone, toZone, srcIP, dstIP, proto string
 	var srcPort, dstPort int
-	var srcPortErr, portErr, protoErr error
+	var icmpType, icmpCode *uint8
+	var srcPortErr, portErr, protoErr, icmpTypeErr, icmpCodeErr error
 	for _, kv := range strings.Split(params, ",") {
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) != 2 {
@@ -204,6 +205,13 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			// error the way a bad port/src is reported below.
 			proto = parts[1]
 			protoErr = policymatch.ValidateProtocol(proto)
+		case "ictype":
+			// #3284: ICMP/ICMPv6 type so a type-constrained application term
+			// (junos-ping = type 8) is honored. Empty is unspecified (the term
+			// fails closed); a malformed/out-of-range value errors.
+			icmpType, icmpTypeErr = policymatch.ParseICMPValue(parts[1])
+		case "iccode":
+			icmpCode, icmpCodeErr = policymatch.ParseICMPValue(parts[1])
 		}
 	}
 	switch {
@@ -217,6 +225,10 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 		fmt.Fprintf(buf, "invalid port: %v\n", portErr)
 	case protoErr != nil:
 		fmt.Fprintf(buf, "%v\n", protoErr)
+	case icmpTypeErr != nil:
+		fmt.Fprintf(buf, "invalid icmp-type: %v\n", icmpTypeErr)
+	case icmpCodeErr != nil:
+		fmt.Fprintf(buf, "invalid icmp-code: %v\n", icmpCodeErr)
 	case srcIP != "" && net.ParseIP(srcIP) == nil:
 		// A non-empty but malformed src would otherwise parse to nil and be
 		// treated as a wildcard, yielding a false-positive policy match
@@ -249,6 +261,8 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			Protocol:    proto,
 			SrcPort:     srcPort,
 			DstPort:     dstPort,
+			ICMPType:    icmpType,
+			ICMPCode:    icmpCode,
 			FeedOverlay: overlay,
 			// #3104: skip scheduler-inactive policies like the runtime does, so
 			// the `test policy` diagnostic falls through to the next active rule

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -270,6 +270,12 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 			PolicyInactiveFn: s.policyInactiveFn(),
 		})
 		switch {
+		case res.HostInboundUnmatched:
+			// #3285: host-bound traffic — the dataplane host gate returns None
+			// (local delivery; no transit global/default fallback). Do NOT
+			// report a default-policy verdict here.
+			fmt.Fprintf(buf, "No matching to-zone junos-host policy for %s -> junos-host\n", fromZone)
+			fmt.Fprintf(buf, "  host-inbound: local delivery proceeds (transit global/default-policy NOT applied)\n")
 		case res.Matched && res.Global:
 			fmt.Fprintf(buf, "Policy match (global):\n")
 			fmt.Fprintf(buf, "  Policy:    %s\n", res.PolicyName)

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -227,7 +227,8 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 	default:
 		// #3103: route the gRPC `test policy` diagnostic through the single
 		// shared simulator (pkg/policymatch) so it agrees with the runtime
-		// policy evaluator — zone-pair -> global -> configured default-policy,
+		// policy evaluator — exact zone-pair -> wildcard-zone tiers (#3090) ->
+		// scoped global (#3148) -> configured default-policy,
 		// with predefined/nested-app-set applications, literal-CIDR /
 		// any-ipv4 / any-ipv6 / address-exclusion / feed-overlay address
 		// matching, and source/destination-port terms. The pre-#3103 bespoke

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -6077,15 +6077,22 @@ func (x *MatchPoliciesRequest) GetIcmpCode() uint32 {
 }
 
 type MatchPoliciesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PolicyName    string                 `protobuf:"bytes,1,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
-	Action        string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
-	SrcAddresses  []string               `protobuf:"bytes,3,rep,name=src_addresses,json=srcAddresses,proto3" json:"src_addresses,omitempty"`
-	DstAddresses  []string               `protobuf:"bytes,4,rep,name=dst_addresses,json=dstAddresses,proto3" json:"dst_addresses,omitempty"`
-	Applications  []string               `protobuf:"bytes,5,rep,name=applications,proto3" json:"applications,omitempty"`
-	Matched       bool                   `protobuf:"varint,6,opt,name=matched,proto3" json:"matched,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	PolicyName   string                 `protobuf:"bytes,1,opt,name=policy_name,json=policyName,proto3" json:"policy_name,omitempty"`
+	Action       string                 `protobuf:"bytes,2,opt,name=action,proto3" json:"action,omitempty"`
+	SrcAddresses []string               `protobuf:"bytes,3,rep,name=src_addresses,json=srcAddresses,proto3" json:"src_addresses,omitempty"`
+	DstAddresses []string               `protobuf:"bytes,4,rep,name=dst_addresses,json=dstAddresses,proto3" json:"dst_addresses,omitempty"`
+	Applications []string               `protobuf:"bytes,5,rep,name=applications,proto3" json:"applications,omitempty"`
+	Matched      bool                   `protobuf:"varint,6,opt,name=matched,proto3" json:"matched,omitempty"`
+	// host_inbound_unmatched is true ONLY for a `to-zone junos-host` query that
+	// matched no host-bound policy (#3285). The dataplane host gate returns None
+	// here — no implicit host default-deny and NO transit global/default
+	// fallback — so local delivery proceeds. When set, `matched` is false and
+	// `action` is empty; clients must render "host-inbound (local delivery; not
+	// governed by transit/global/default policy)", NOT a default-policy verdict.
+	HostInboundUnmatched bool `protobuf:"varint,7,opt,name=host_inbound_unmatched,json=hostInboundUnmatched,proto3" json:"host_inbound_unmatched,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *MatchPoliciesResponse) Reset() {
@@ -6156,6 +6163,13 @@ func (x *MatchPoliciesResponse) GetApplications() []string {
 func (x *MatchPoliciesResponse) GetMatched() bool {
 	if x != nil {
 		return x.Matched
+	}
+	return false
+}
+
+func (x *MatchPoliciesResponse) GetHostInboundUnmatched() bool {
+	if x != nil {
+		return x.HostInboundUnmatched
 	}
 	return false
 }
@@ -7439,7 +7453,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
-	"_icmp_code\"\xd8\x01\n" +
+	"_icmp_code\"\x8e\x02\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -7447,7 +7461,8 @@ const file_xpf_proto_rawDesc = "" +
 	"\rsrc_addresses\x18\x03 \x03(\tR\fsrcAddresses\x12#\n" +
 	"\rdst_addresses\x18\x04 \x03(\tR\fdstAddresses\x12\"\n" +
 	"\fapplications\x18\x05 \x03(\tR\fapplications\x12\x18\n" +
-	"\amatched\x18\x06 \x01(\bR\amatched\"N\n" +
+	"\amatched\x18\x06 \x01(\bR\amatched\x124\n" +
+	"\x16host_inbound_unmatched\x18\a \x01(\bR\x14hostInboundUnmatched\"N\n" +
 	"\x16GetNATRuleStatsRequest\x12\x19\n" +
 	"\brule_set\x18\x01 \x01(\tR\aruleSet\x12\x19\n" +
 	"\bnat_type\x18\x02 \x01(\tR\anatType\"E\n" +

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -5971,7 +5971,14 @@ type MatchPoliciesRequest struct {
 	Protocol        string                 `protobuf:"bytes,6,opt,name=protocol,proto3" json:"protocol,omitempty"`
 	// source_port lets the simulator honor source-port-constrained application
 	// terms (#3042). 0 = unspecified (does not constrain the match).
-	SourcePort    int32 `protobuf:"varint,7,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`
+	SourcePort int32 `protobuf:"varint,7,opt,name=source_port,json=sourcePort,proto3" json:"source_port,omitempty"`
+	// icmp_type / icmp_code let the simulator honor ICMP/ICMPv6 type-constrained
+	// application terms (#3284, junos-ping = type 8). proto3 `optional` so the
+	// simulator can distinguish "unspecified" (a type-constrained app term then
+	// fails closed, mirroring the dataplane's packet_icmp = None) from a valid
+	// type/code 0 (ICMP type 0 = echo-reply).
+	IcmpType      *uint32 `protobuf:"varint,8,opt,name=icmp_type,json=icmpType,proto3,oneof" json:"icmp_type,omitempty"`
+	IcmpCode      *uint32 `protobuf:"varint,9,opt,name=icmp_code,json=icmpCode,proto3,oneof" json:"icmp_code,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -6051,6 +6058,20 @@ func (x *MatchPoliciesRequest) GetProtocol() string {
 func (x *MatchPoliciesRequest) GetSourcePort() int32 {
 	if x != nil {
 		return x.SourcePort
+	}
+	return 0
+}
+
+func (x *MatchPoliciesRequest) GetIcmpType() uint32 {
+	if x != nil && x.IcmpType != nil {
+		return *x.IcmpType
+	}
+	return 0
+}
+
+func (x *MatchPoliciesRequest) GetIcmpCode() uint32 {
+	if x != nil && x.IcmpCode != nil {
+		return *x.IcmpCode
 	}
 	return 0
 }
@@ -7403,7 +7424,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\x05state\x18\x03 \x01(\tR\x05state\x12\x1a\n" +
 	"\bpriority\x18\x04 \x01(\x05R\bpriority\x12+\n" +
 	"\x11virtual_addresses\x18\x05 \x03(\tR\x10virtualAddresses\x12\x18\n" +
-	"\apreempt\x18\x06 \x01(\bR\apreempt\"\xf8\x01\n" +
+	"\apreempt\x18\x06 \x01(\bR\apreempt\"\xd8\x02\n" +
 	"\x14MatchPoliciesRequest\x12\x1b\n" +
 	"\tfrom_zone\x18\x01 \x01(\tR\bfromZone\x12\x17\n" +
 	"\ato_zone\x18\x02 \x01(\tR\x06toZone\x12\x1b\n" +
@@ -7412,7 +7433,13 @@ const file_xpf_proto_rawDesc = "" +
 	"\x10destination_port\x18\x05 \x01(\x05R\x0fdestinationPort\x12\x1a\n" +
 	"\bprotocol\x18\x06 \x01(\tR\bprotocol\x12\x1f\n" +
 	"\vsource_port\x18\a \x01(\x05R\n" +
-	"sourcePort\"\xd8\x01\n" +
+	"sourcePort\x12 \n" +
+	"\ticmp_type\x18\b \x01(\rH\x00R\bicmpType\x88\x01\x01\x12 \n" +
+	"\ticmp_code\x18\t \x01(\rH\x01R\bicmpCode\x88\x01\x01B\f\n" +
+	"\n" +
+	"_icmp_typeB\f\n" +
+	"\n" +
+	"_icmp_code\"\xd8\x01\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -7827,6 +7854,7 @@ func file_xpf_proto_init() {
 	if File_xpf_proto != nil {
 		return
 	}
+	file_xpf_proto_msgTypes[101].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -128,8 +128,19 @@ the OPPOSITE of what the dataplane actually enforces (a dangerous bug for a
 The semantics replicate `userspace-dp/src/policy.rs`
 (`evaluate_policy_result_with_len` + `try_match_rule` + `parse_v3_literal_set`
 + `CompiledApplications`) fed by the Go snapshot builder
-(`pkg/dataplane/userspace/policies.go`). Precedence: **exact zone-pair → global
-→ configured default-policy**. Address matching honors literal CIDRs, address
+(`pkg/dataplane/userspace/policies.go`). Transit precedence, first-match
+terminating:
+
+1. **exact zone-pair** (both zones concrete);
+2. **single-wildcard tier** (#3090) — `from-zone any to-zone <X>` and
+   `from-zone <X> to-zone any`, merged in config order;
+3. **both-any** (#3090) — `from-zone any to-zone any`;
+4. **global** (`junos-global`), gated by the optional `match from-zone` /
+   `match to-zone` scope (#3148): an empty/`any` scope applies to every zone, a
+   typo'd/undefined-zone scope fails closed (matches nothing);
+5. **configured default-policy**.
+
+Address matching honors literal CIDRs, address
 books (recursive set expansion), `any`/`any-ipv4`/`any-ipv6`, source/destination
 exclusion (with the #2008 empty-excluded fail-closed rule), and the live
 dynamic-address feed overlay (`Query.FeedOverlay`, supplied by the daemon via

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -140,6 +140,17 @@ terminating:
    typo'd/undefined-zone scope fails closed (matches nothing);
 5. **configured default-policy**.
 
+A `to-zone junos-host` query takes the separate **host gate** (#3285,
+`matchJunosHost` ↔ `evaluate_junos_host_policy`): exact `from-zone <ingress>
+to-zone junos-host` then `from-zone any to-zone junos-host`, with **no** global
+or default transit fallback (and `to-zone any` / `from-zone any to-zone any` are
+NOT pulled onto the host path). An unmatched host-bound flow returns
+`Result.HostInboundUnmatched` — local delivery proceeds (the management lifeline
+guarantee), never an inherited transit verdict. The surfaces render this as
+"host-inbound: local delivery proceeds (transit global/default-policy NOT
+applied)"; the gRPC `MatchPolicies` response carries it as
+`host_inbound_unmatched`.
+
 Address matching honors literal CIDRs, address
 books (recursive set expansion), `any`/`any-ipv4`/`any-ipv6`, source/destination
 exclusion (with the #2008 empty-excluded fail-closed rule), and the live

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -147,7 +147,16 @@ dynamic-address feed overlay (`Query.FeedOverlay`, supplied by the daemon via
 `feeds.Manager.SnapshotForBindings`). Application matching resolves predefined +
 user apps via `config.ResolveApplication`, expands application-sets recursively
 via `config.ExpandApplicationSet`, compares protocols by IANA number via
-`appid.ProtocolNumber`, and honors both source-port and destination-port terms.
+`appid.ProtocolNumber`, honors both source-port and destination-port terms, and
+enforces ICMP/ICMPv6 type/code constraints (#3284, junos-ping = type 8,
+junos-pingv6 = type 128) from `Query.ICMPType` / `Query.ICMPCode`. A
+type-constrained application term matches only when the query's type is known
+and equal (and the code too, when the term constrains a code); a query that
+omits the type fails closed for that term, mirroring the dataplane's
+`packet_icmp = None` path. An unconstrained ICMP application (junos-icmp-all) is
+unaffected. The surfaces accept the type/code as `icmp_type`/`icmp_code` (REST
+query, gRPC `MatchPolicies` optional fields), `icmp-type`/`icmp-code` (CLI
+tokens), and `ictype=`/`iccode=` (gRPC `test policy` topic).
 
 Where the runtime and the old simulators disagreed, the runtime wins.
 

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -151,6 +151,16 @@ guarantee), never an inherited transit verdict. The surfaces render this as
 applied)"; the gRPC `MatchPolicies` response carries it as
 `host_inbound_unmatched`.
 
+Surface asymmetry (intentional, not a bug): for a host-inbound-unmatched
+result the REST `match-policies` response fills `action` with the descriptive
+string "host-inbound (local delivery; not governed by transit/global/default
+policy)" so a bare REST consumer reads a meaningful verdict, whereas the gRPC
+`MatchPolicies` response leaves `action` EMPTY and sets `matched=false` +
+`host_inbound_unmatched=true`, delegating the wording to the client (the remote
+CLI formats the two-line host-inbound message above). Both convey the same
+"no transit verdict applies" fact; they differ only in where the human string is
+composed.
+
 Address matching honors literal CIDRs, address
 books (recursive set expansion), `any`/`any-ipv4`/`any-ipv6`, source/destination
 exclusion (with the #2008 empty-excluded fail-closed rule), and the live

--- a/pkg/policymatch/icmp_test.go
+++ b/pkg/policymatch/icmp_test.go
@@ -113,6 +113,43 @@ func TestICMPTypeConstraintParity(t *testing.T) {
 	}
 }
 
+// TestICMPTypeConstrainedTermRequiresICMPProtocol pins the defensive gate: an
+// application term that constrains ICMPType must never match a non-ICMP flow.
+// A predefined ICMP app pins its protocol (so the protocol check already gates
+// it), but a CUSTOM app can carry an icmp-type without a pinned protocol; the
+// dataplane keys icmp_constraints under the ICMP protocol, so a TCP query must
+// not satisfy a type-constrained term. Without the gate, an app with
+// Protocol="" + ICMPType set would match any protocol whose query happened to
+// carry a matching ICMPType.
+func TestICMPTypeConstrainedTermRequiresICMPProtocol(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         zones("trust", "untrust"),
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("allow-custom",
+				config.PolicyMatch{Applications: []string{"custom-icmp-noproto"}})),
+		},
+	}, config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			// No Protocol pinned — only an ICMP type constraint.
+			"custom-icmp-noproto": {Name: "custom-icmp-noproto", ICMPType: u8(8)},
+		},
+	})
+
+	// A TCP query carrying ICMPType 8 must NOT match (default deny). Without the
+	// ICMP-family gate this would falsely permit.
+	tcp := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", ICMPType: u8(8)})
+	if tcp.Matched || tcp.Action != config.PolicyDeny {
+		t.Errorf("TCP query matched a type-constrained term: Matched=%v Action=%v", tcp.Matched, tcp.Action)
+	}
+
+	// The same term still matches a genuine ICMP echo (type 8).
+	icmp := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp", ICMPType: u8(8)})
+	if !icmp.Matched || icmp.Action != config.PolicyPermit {
+		t.Errorf("ICMP echo did not match type-constrained term: Matched=%v Action=%v", icmp.Matched, icmp.Action)
+	}
+}
+
 // TestParseICMPValue covers the shared ICMP type/code token parser used by the
 // REST/gRPC/CLI/test-policy surfaces.
 func TestParseICMPValue(t *testing.T) {

--- a/pkg/policymatch/icmp_test.go
+++ b/pkg/policymatch/icmp_test.go
@@ -1,0 +1,137 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func u8(v uint8) *uint8 { return &v }
+
+// TestICMPTypeConstraintParity pins the #3284 fix: the simulator must enforce
+// an application's ICMP/ICMPv6 type/code constraint the way the dataplane does
+// (policy.rs CompiledApplications.matches, fed packet_icmp). junos-ping is
+// echo-request ONLY (ICMP type 8), junos-pingv6 is ICMPv6 type 128; the
+// pre-#3284 simulator matched them on protocol alone and over-permitted every
+// ICMP message.
+func TestICMPTypeConstraintParity(t *testing.T) {
+	pingCfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         zones("trust", "untrust"),
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("allow-ping",
+				config.PolicyMatch{Applications: []string{"junos-ping"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	allIcmpCfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         zones("trust", "untrust"),
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("allow-all-icmp",
+				config.PolicyMatch{Applications: []string{"junos-icmp-all"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	pingv6Cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         zones("trust", "untrust"),
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", permit("allow-ping6",
+				config.PolicyMatch{Applications: []string{"junos-pingv6"}})),
+		},
+	}, config.ApplicationsConfig{})
+
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		q           Query
+		wantMatched bool
+		wantAction  config.PolicyAction
+	}{
+		{
+			name:        "junos-ping permits ICMP echo type 8",
+			cfg:         pingCfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp", ICMPType: u8(8)},
+			wantMatched: true, wantAction: config.PolicyPermit,
+		},
+		{
+			// timestamp request (type 13) is NOT echo-request: junos-ping must
+			// NOT match -> default deny. The old simulator reported permit.
+			name:        "junos-ping denies ICMP timestamp type 13",
+			cfg:         pingCfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp", ICMPType: u8(13)},
+			wantMatched: false, wantAction: config.PolicyDeny,
+		},
+		{
+			// No type supplied for an ICMP query: a type-constrained term fails
+			// closed (mirrors the dataplane packet_icmp = None path).
+			name:        "junos-ping fails closed when type omitted",
+			cfg:         pingCfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp"},
+			wantMatched: false, wantAction: config.PolicyDeny,
+		},
+		{
+			// An UNCONSTRAINED ICMP app (junos-icmp-all) still matches every
+			// ICMP type, including timestamp and even with no type supplied.
+			name:        "junos-icmp-all permits timestamp type 13",
+			cfg:         allIcmpCfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp", ICMPType: u8(13)},
+			wantMatched: true, wantAction: config.PolicyPermit,
+		},
+		{
+			name:        "junos-icmp-all permits with no type supplied",
+			cfg:         allIcmpCfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp"},
+			wantMatched: true, wantAction: config.PolicyPermit,
+		},
+		{
+			name:        "junos-pingv6 permits ICMPv6 echo type 128",
+			cfg:         pingv6Cfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmpv6", ICMPType: u8(128)},
+			wantMatched: true, wantAction: config.PolicyPermit,
+		},
+		{
+			// Router advertisement (type 134) is not echo-request.
+			name:        "junos-pingv6 denies ICMPv6 router-advert type 134",
+			cfg:         pingv6Cfg,
+			q:           Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmpv6", ICMPType: u8(134)},
+			wantMatched: false, wantAction: config.PolicyDeny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Match(tt.cfg, tt.q)
+			if res.Matched != tt.wantMatched {
+				t.Errorf("Matched = %v, want %v (policy %q)", res.Matched, tt.wantMatched, res.PolicyName)
+			}
+			if res.Action != tt.wantAction {
+				t.Errorf("Action = %v, want %v", res.Action, tt.wantAction)
+			}
+		})
+	}
+}
+
+// TestParseICMPValue covers the shared ICMP type/code token parser used by the
+// REST/gRPC/CLI/test-policy surfaces.
+func TestParseICMPValue(t *testing.T) {
+	if v, err := ParseICMPValue(""); err != nil || v != nil {
+		t.Errorf("empty: got (%v,%v), want (nil,nil)", v, err)
+	}
+	if v, err := ParseICMPValue("0"); err != nil || v == nil || *v != 0 {
+		t.Errorf("0: got (%v,%v), want (*0,nil)", v, err)
+	}
+	if v, err := ParseICMPValue("255"); err != nil || v == nil || *v != 255 {
+		t.Errorf("255: got (%v,%v), want (*255,nil)", v, err)
+	}
+	if _, err := ParseICMPValue("256"); err == nil {
+		t.Error("256: want range error")
+	}
+	if _, err := ParseICMPValue("-1"); err == nil {
+		t.Error("-1: want range error")
+	}
+	if _, err := ParseICMPValue("abc"); err == nil {
+		t.Error("abc: want parse error")
+	}
+}

--- a/pkg/policymatch/junos_host_test.go
+++ b/pkg/policymatch/junos_host_test.go
@@ -1,0 +1,147 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestJunosHostGateNoTransitFallback pins the #3285 fix: a `to-zone junos-host`
+// query must mirror the dataplane host gate evaluate_junos_host_policy
+// (policy.rs) — exact `from-zone <ingress> to-zone junos-host`, then
+// `from-zone any to-zone junos-host`, with NO global / default transit
+// fallback. An unmatched host-bound flow returns HostInboundUnmatched (local
+// delivery proceeds), NOT the transit default-policy or a global verdict. The
+// pre-#3285 simulator ran the transit chain (exact -> every global -> default)
+// for every query, so it reported the wrong verdict on the host path.
+func TestJunosHostGateNoTransitFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		cfg           *config.Config
+		q             Query
+		wantMatched   bool
+		wantHostUnmat bool
+		wantName      string
+		wantAction    config.PolicyAction
+	}{
+		{
+			// Host-inbound permits SSH, no matching to-zone junos-host policy,
+			// default deny-all: runtime delivers locally (host gate None). The
+			// old simulator reported default DENY.
+			name: "no junos-host policy, default deny -> host-inbound (not default deny)",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("trust", "untrust", permit("transit", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:             Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched:   false,
+			wantHostUnmat: true,
+		},
+		{
+			// A global deny exists: runtime ignores global on the host path. The
+			// old simulator reported the global deny as the matching rule.
+			name: "global deny is NOT applied on the host path",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "global-deny", Action: config.PolicyDeny},
+				},
+			}, config.ApplicationsConfig{}),
+			q:             Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched:   false,
+			wantHostUnmat: true,
+		},
+		{
+			// A `to-zone any` rule must NOT be pulled onto the host path.
+			name: "to-zone any is NOT applied on the host path",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("trust", "any", deny3285("to-any-deny", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:             Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched:   false,
+			wantHostUnmat: true,
+		},
+		{
+			// An exact `from-zone trust to-zone junos-host deny` MATCHES.
+			name: "exact junos-host deny matches",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("trust", "junos-host", deny3285("host-deny", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched: true, wantName: "host-deny", wantAction: config.PolicyDeny,
+		},
+		{
+			// A `from-zone any to-zone junos-host deny` wildcard MATCHES every
+			// ingress (the host path DOES consult from-any).
+			name: "from-any junos-host deny matches",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "dmz"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "junos-host", deny3285("host-any-deny", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "dmz", ToZone: "junos-host"},
+			wantMatched: true, wantName: "host-any-deny", wantAction: config.PolicyDeny,
+		},
+		{
+			// Exact ingress->junos-host outranks the from-any junos-host
+			// wildcard (most-specific-first).
+			name: "exact junos-host outranks from-any junos-host",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "junos-host", deny3285("any-host-deny", config.PolicyMatch{})),
+					zonePair("trust", "junos-host", permit("trust-host-permit", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched: true, wantName: "trust-host-permit", wantAction: config.PolicyPermit,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Match(tt.cfg, tt.q)
+			if res.HostInboundUnmatched != tt.wantHostUnmat {
+				t.Errorf("HostInboundUnmatched = %v, want %v", res.HostInboundUnmatched, tt.wantHostUnmat)
+			}
+			if res.Matched != tt.wantMatched {
+				t.Errorf("Matched = %v, want %v (policy %q)", res.Matched, tt.wantMatched, res.PolicyName)
+			}
+			if tt.wantHostUnmat {
+				// Host-inbound-unmatched must NOT be reported as a transit
+				// default verdict.
+				if res.DefaultUsed {
+					t.Errorf("DefaultUsed = true; host-inbound must not inherit the transit default")
+				}
+				return
+			}
+			if tt.wantName != "" {
+				if res.PolicyName != tt.wantName {
+					t.Errorf("PolicyName = %q, want %q", res.PolicyName, tt.wantName)
+				}
+				if res.Action != tt.wantAction {
+					t.Errorf("Action = %v, want %v", res.Action, tt.wantAction)
+				}
+			}
+		})
+	}
+}
+
+func deny3285(name string, m config.PolicyMatch) *config.Policy {
+	return &config.Policy{Name: name, Match: m, Action: config.PolicyDeny}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -96,6 +96,30 @@ func ParsePort(s string) (int, error) {
 	return n, nil
 }
 
+// ParseICMPValue parses an operator-supplied ICMP type or code token (#3284)
+// into a *uint8 the simulator threads into Query.ICMPType / Query.ICMPCode. An
+// empty/whitespace token means "unspecified" and returns (nil, nil) — the
+// dimension is not constrained, the established wildcard behavior. A non-empty
+// token must parse to an integer in [0, 255] (the 8-bit ICMP type/code space);
+// a malformed, negative, or >255 token is REJECTED with an error so it can
+// never silently degrade to the nil wildcard. The pointer return distinguishes
+// "unspecified" from a valid 0 (ICMP type 0 = echo-reply, code 0 is common).
+func ParseICMPValue(s string) (*uint8, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid icmp type/code %q", s)
+	}
+	if n < 0 || n > 255 {
+		return nil, fmt.Errorf("icmp type/code %d out of range (0-255)", n)
+	}
+	v := uint8(n)
+	return &v, nil
+}
+
 // ValidateProtocol checks an explicitly-supplied simulator protocol token. An
 // empty/whitespace token means "unspecified" — the protocol dimension is not
 // constrained (the established match-any wildcard) — and is accepted. A
@@ -140,6 +164,21 @@ type Query struct {
 	Protocol string // "tcp", "udp", "89", "ospf", ... ("" = unspecified)
 	SrcPort  int
 	DstPort  int
+
+	// ICMPType / ICMPCode carry the query packet's ICMP/ICMPv6 type and code
+	// (#3284). They mirror the dataplane's per-packet `packet_icmp` tuple
+	// (policy.rs evaluate_policy_result_with_icmp): a type-constrained
+	// application term (junos-ping = ICMP type 8, junos-pingv6 = ICMPv6
+	// type 128) matches ONLY when the query's type is known and equal (and the
+	// code too, when the term constrains a code). A nil ICMPType means the
+	// query did not specify a type: a type-constrained term then fails closed
+	// (does NOT match), exactly like the runtime passing `packet_icmp = None`.
+	// An UNCONSTRAINED ICMP application (junos-icmp-all) is unaffected by these
+	// fields — it matches every ICMP packet on protocol alone. Pointers
+	// distinguish "unspecified" from a valid type/code 0 (ICMP type 0 is
+	// echo-reply, code 0 is common), which a plain int could not.
+	ICMPType *uint8
+	ICMPCode *uint8
 
 	// FeedOverlay is the dynamic-address feed-prefix overlay (#2049): an
 	// address-name -> union-of-live-feed-CIDR-strings map, the same shape the
@@ -324,7 +363,7 @@ func ruleMatches(cfg *config.Config, q Query, pol *config.Policy) bool {
 	if !matchAddr(cfg, q.FeedOverlay, pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded, q.DstIP) {
 		return false
 	}
-	return matchApp(cfg, pol.Match.Applications, q.Protocol, q.SrcPort, q.DstPort)
+	return matchApp(cfg, pol.Match.Applications, q.Protocol, q.SrcPort, q.DstPort, q.ICMPType, q.ICMPCode)
 }
 
 // matchAddr replicates policy.rs try_match_rule's per-side address logic.
@@ -508,7 +547,7 @@ func expandBookName(cfg *config.Config, name string, visited map[string]bool) []
 // An empty application list is the runtime match-any case. An unspecified
 // query protocol does not constrain the match (the established diagnostic
 // behavior).
-func matchApp(cfg *config.Config, apps []string, proto string, srcPort, dstPort int) bool {
+func matchApp(cfg *config.Config, apps []string, proto string, srcPort, dstPort int, icmpType, icmpCode *uint8) bool {
 	if len(apps) == 0 {
 		return true
 	}
@@ -529,20 +568,20 @@ func matchApp(cfg *config.Config, apps []string, proto string, srcPort, dstPort 
 				continue
 			}
 			for _, m := range members {
-				if matchSingleApp(cfg, m, queryProto, queryProtoOK, srcPort, dstPort) {
+				if matchSingleApp(cfg, m, queryProto, queryProtoOK, srcPort, dstPort, icmpType, icmpCode) {
 					return true
 				}
 			}
 			continue
 		}
-		if matchSingleApp(cfg, a, queryProto, queryProtoOK, srcPort, dstPort) {
+		if matchSingleApp(cfg, a, queryProto, queryProtoOK, srcPort, dstPort, icmpType, icmpCode) {
 			return true
 		}
 	}
 	return false
 }
 
-func matchSingleApp(cfg *config.Config, appName string, queryProto uint8, queryProtoOK bool, srcPort, dstPort int) bool {
+func matchSingleApp(cfg *config.Config, appName string, queryProto uint8, queryProtoOK bool, srcPort, dstPort int, icmpType, icmpCode *uint8) bool {
 	app, ok := config.ResolveApplication(appName, cfg.Applications.Applications)
 	if !ok {
 		return false
@@ -553,6 +592,21 @@ func matchSingleApp(cfg *config.Config, appName string, queryProto uint8, queryP
 	if app.Protocol != "" {
 		appProto, appOK := appid.ProtocolNumber(app.Protocol)
 		if !appOK || !queryProtoOK || appProto != queryProto {
+			return false
+		}
+	}
+	// #3284: ICMP/ICMPv6 type[,code] constraint (junos-ping = type 8). Mirror
+	// policy.rs CompiledApplications.matches: a type-constrained term matches
+	// ONLY when the query's ICMP type is known and equal — and the code too,
+	// when the term constrains a code. A nil query type fails closed for the
+	// term (the runtime's `packet_icmp == None` path). An application with NO
+	// ICMP type constraint (junos-icmp-all, or any non-ICMP app) is unaffected:
+	// it matches on protocol/ports alone, exactly as before.
+	if app.ICMPType != nil {
+		if icmpType == nil || *icmpType != *app.ICMPType {
+			return false
+		}
+		if app.ICMPCode != nil && (icmpCode == nil || *icmpCode != *app.ICMPCode) {
 			return false
 		}
 	}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -192,31 +192,82 @@ type Result struct {
 }
 
 // Match runs the simulator against the active config and returns the verdict
-// with the same precedence the runtime enforces: an exact zone-pair policy
-// match wins first, then a global policy, then the configured default-policy.
+// with the SAME precedence the runtime enforces (userspace-dp/src/policy.rs
+// evaluate_policy_result_with_icmp / try_match_rule), first-match terminating:
+//
+//	1. exact zone-pair (both zones concrete)
+//	2. single-wildcard tier — `from-zone any to-zone <X>` and
+//	   `from-zone <X> to-zone any`, MERGED in config order (#3090)
+//	3. both-any — `from-zone any to-zone any` (#3090)
+//	4. global (`junos-global`), gated by the optional `match from-zone` /
+//	   `match to-zone` scope (#3148); an empty/`any` scope applies to every
+//	   zone, an undefined-zone scope fails closed (matches nothing)
+//	5. configured default-policy
 func Match(cfg *config.Config, q Query) Result {
 	if cfg == nil {
 		return Result{DefaultUsed: true, Action: config.PolicyDeny}
 	}
 
-	// 1) Exact zone-pair policies, in config order (first match wins).
+	// Tier 1: exact zone-pair policies, in config order (first match wins).
+	// q.FromZone/q.ToZone are concrete zone names; a wildcard set
+	// (FromZone/ToZone == "any") never compares equal, so it is excluded here.
 	for _, zpp := range cfg.Security.Policies {
 		if zpp == nil || zpp.FromZone != q.FromZone || zpp.ToZone != q.ToZone {
 			continue
 		}
 		for _, pol := range zpp.Policies {
-			if pol == nil {
-				continue
-			}
-			if ruleMatches(cfg, q, pol) {
+			if pol != nil && ruleMatches(cfg, q, pol) {
 				return matchedResult(pol, false)
 			}
 		}
 	}
 
-	// 2) Global policies (junos-global), in config order.
+	// Tier 2: single-wildcard tier (#3090) — `from-zone any to-zone <q.ToZone>`
+	// OR `from-zone <q.FromZone> to-zone any`, MERGED in config order. The
+	// dataplane two-pointer-merges its from_any/to_any index buckets by global
+	// rule index; the snapshot builder (walkPolicyRuleSlots) emits rules in
+	// cfg.Security.Policies slice order with each set's policies contiguous, so
+	// a single in-order pass over the sets reproduces that merge exactly.
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		fromAny := zpp.FromZone == "any"
+		toAny := zpp.ToZone == "any"
+		if fromAny == toAny {
+			continue // both-any (Tier 3) or neither (Tier 1) — not single-wildcard
+		}
+		applies := (fromAny && zpp.ToZone == q.ToZone) || (toAny && zpp.FromZone == q.FromZone)
+		if !applies {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if pol != nil && ruleMatches(cfg, q, pol) {
+				return matchedResult(pol, false)
+			}
+		}
+	}
+
+	// Tier 3: both-any (`from-zone any to-zone any`), in config order.
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil || zpp.FromZone != "any" || zpp.ToZone != "any" {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if pol != nil && ruleMatches(cfg, q, pol) {
+				return matchedResult(pol, false)
+			}
+		}
+	}
+
+	// Tier 4: global policies (junos-global), in config order, gated by the
+	// optional #3148 from-zone/to-zone match scope.
 	for _, pol := range cfg.Security.GlobalPolicies {
 		if pol == nil {
+			continue
+		}
+		if !globalScopeMatches(cfg, pol.Match.FromZone, q.FromZone) ||
+			!globalScopeMatches(cfg, pol.Match.ToZone, q.ToZone) {
 			continue
 		}
 		if ruleMatches(cfg, q, pol) {
@@ -224,8 +275,23 @@ func Match(cfg *config.Config, q Query) Result {
 		}
 	}
 
-	// 3) Configured default-policy (NOT a hard-coded deny).
+	// Tier 5: configured default-policy (NOT a hard-coded deny).
 	return Result{DefaultUsed: true, Action: cfg.Security.DefaultPolicy}
+}
+
+// globalScopeMatches replicates GlobalZoneScope::matches + build_global_zone_scope
+// (policy.rs, #3148). An empty or explicit "any" scope applies to every zone.
+// Any other name must resolve to a DEFINED zone and equal the flow's zone; an
+// undefined (typo'd, or reserved like junos-host) scope fails closed — it
+// matches nothing, never silently widening to all-zones.
+func globalScopeMatches(cfg *config.Config, scopeZone, flowZone string) bool {
+	if scopeZone == "" || scopeZone == "any" {
+		return true
+	}
+	if _, ok := cfg.Security.Zones[scopeZone]; !ok {
+		return false // Unresolved → matches nothing
+	}
+	return scopeZone == flowZone
 }
 
 func matchedResult(pol *config.Policy, global bool) Result {

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -57,6 +57,12 @@ import (
 // MaxPort is the largest valid TCP/UDP port number.
 const MaxPort = 65535
 
+// JunosHostZone is the reserved self-traffic zone name. A query whose ToZone is
+// this name is host-bound (LocalDelivery) traffic; it is evaluated by the
+// dataplane's separate host gate (evaluate_junos_host_policy), not the transit
+// precedence chain. See matchJunosHost / Result.HostInboundUnmatched (#3285).
+const JunosHostZone = "junos-host"
+
 // ValidatePort checks an already-parsed simulator port value (the gRPC int32
 // field and the REST query int, which arrive numeric). A zero value means
 // "unspecified" — the port dimension is not constrained, the established
@@ -222,6 +228,17 @@ type Result struct {
 	// default-policy.
 	DefaultUsed bool
 
+	// HostInboundUnmatched is true ONLY for a `to-zone junos-host` query that
+	// matched no host-bound policy (#3285). The dataplane host gate
+	// (evaluate_junos_host_policy) returns None here — there is no implicit
+	// host default-deny and NO transit global/default fallback, so local
+	// delivery proceeds (the management lifeline). Matched is false and
+	// DefaultUsed is false; callers must render this as "host-inbound, not
+	// governed by transit/global/default policy", NOT as the default-policy
+	// verdict. Action is unset (PolicyPermit zero value) and carries no
+	// meaning in this case.
+	HostInboundUnmatched bool
+
 	PolicyName   string
 	Description  string
 	Action       config.PolicyAction
@@ -242,9 +259,20 @@ type Result struct {
 //	   `match to-zone` scope (#3148); an empty/`any` scope applies to every
 //	   zone, an undefined-zone scope fails closed (matches nothing)
 //	5. configured default-policy
+//
+// A `to-zone junos-host` query is host-bound and takes the separate host-gate
+// path (matchJunosHost, #3285): exact ingress->junos-host then
+// `from-zone any`->junos-host, with NO global/default transit fallback.
 func Match(cfg *config.Config, q Query) Result {
 	if cfg == nil {
 		return Result{DefaultUsed: true, Action: config.PolicyDeny}
+	}
+
+	// #3285: host-bound (LocalDelivery) traffic is governed by the dataplane's
+	// host gate, which does NOT apply transit global/default fallback. Branch
+	// before the transit tiers so that invariant cannot regress.
+	if q.ToZone == JunosHostZone {
+		return matchJunosHost(cfg, q)
 	}
 
 	// Tier 1: exact zone-pair policies, in config order (first match wins).
@@ -316,6 +344,44 @@ func Match(cfg *config.Config, q Query) Result {
 
 	// Tier 5: configured default-policy (NOT a hard-coded deny).
 	return Result{DefaultUsed: true, Action: cfg.Security.DefaultPolicy}
+}
+
+// matchJunosHost mirrors the dataplane host gate evaluate_junos_host_policy
+// (policy.rs) for a `to-zone junos-host` query (#3285). It consults ONLY exact
+// `from-zone <ingress> to-zone junos-host` rules, then the
+// `from-zone any to-zone junos-host` wildcard — in that order. There is NO
+// implicit host default-deny and NO global / transit-default fallback: an
+// unmatched host-bound flow falls through to local delivery (the management
+// lifeline guarantee), so the simulator returns HostInboundUnmatched rather
+// than inheriting the transit global/default verdict. `to-zone any` and
+// `from-zone any to-zone any` are deliberately NOT pulled onto the host path,
+// matching the runtime gate.
+func matchJunosHost(cfg *config.Config, q Query) Result {
+	// Exact ingress -> junos-host.
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil || zpp.ToZone != JunosHostZone || zpp.FromZone != q.FromZone {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if pol != nil && ruleMatches(cfg, q, pol) {
+				return matchedResult(pol, false)
+			}
+		}
+	}
+	// from-zone any -> junos-host.
+	for _, zpp := range cfg.Security.Policies {
+		if zpp == nil || zpp.ToZone != JunosHostZone || zpp.FromZone != "any" {
+			continue
+		}
+		for _, pol := range zpp.Policies {
+			if pol != nil && ruleMatches(cfg, q, pol) {
+				return matchedResult(pol, false)
+			}
+		}
+	}
+	// No host-bound rule matched: local delivery proceeds. Do NOT fall through
+	// to global/default — the dataplane host gate returns None here.
+	return Result{HostInboundUnmatched: true}
 }
 
 // globalScopeMatches replicates GlobalZoneScope::matches + build_global_zone_scope

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -251,14 +251,14 @@ type Result struct {
 // with the SAME precedence the runtime enforces (userspace-dp/src/policy.rs
 // evaluate_policy_result_with_icmp / try_match_rule), first-match terminating:
 //
-//	1. exact zone-pair (both zones concrete)
-//	2. single-wildcard tier — `from-zone any to-zone <X>` and
-//	   `from-zone <X> to-zone any`, MERGED in config order (#3090)
-//	3. both-any — `from-zone any to-zone any` (#3090)
-//	4. global (`junos-global`), gated by the optional `match from-zone` /
-//	   `match to-zone` scope (#3148); an empty/`any` scope applies to every
-//	   zone, an undefined-zone scope fails closed (matches nothing)
-//	5. configured default-policy
+//  1. exact zone-pair (both zones concrete)
+//  2. single-wildcard tier — `from-zone any to-zone <X>` and
+//     `from-zone <X> to-zone any`, MERGED in config order (#3090)
+//  3. both-any — `from-zone any to-zone any` (#3090)
+//  4. global (`junos-global`), gated by the optional `match from-zone` /
+//     `match to-zone` scope (#3148); an empty/`any` scope applies to every
+//     zone, an undefined-zone scope fails closed (matches nothing)
+//  5. configured default-policy
 //
 // A `to-zone junos-host` query is host-bound and takes the separate host-gate
 // path (matchJunosHost, #3285): exact ingress->junos-host then

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -57,6 +57,15 @@ import (
 // MaxPort is the largest valid TCP/UDP port number.
 const MaxPort = 65535
 
+// icmpProtoNum / icmpv6ProtoNum are the IANA protocol numbers for ICMP and
+// ICMPv6. They gate an ICMP-type-constrained application term (#3284) so it can
+// only match an ICMP-family flow, mirroring the dataplane keying its
+// icmp_constraints under the ICMP protocol (policy.rs CompiledApplications).
+const (
+	icmpProtoNum   uint8 = 1
+	icmpv6ProtoNum uint8 = 58
+)
+
 // JunosHostZone is the reserved self-traffic zone name. A query whose ToZone is
 // this name is host-bound (LocalDelivery) traffic; it is evaluated by the
 // dataplane's separate host gate (evaluate_junos_host_policy), not the transit
@@ -608,11 +617,17 @@ func expandBookName(cfg *config.Config, name string, visited map[string]bool) []
 // matchApp replicates policy.rs CompiledApplications.matches fed by the
 // snapshot builder's application expansion: predefined + user applications via
 // ResolveApplication, recursive application-set expansion via
-// ExpandApplicationSet, and BOTH source-port and destination-port terms.
+// ExpandApplicationSet, BOTH source-port and destination-port terms, and the
+// ICMP/ICMPv6 type/code constraints enforced in matchSingleApp (#3284).
 //
-// An empty application list is the runtime match-any case. An unspecified
-// query protocol does not constrain the match (the established diagnostic
-// behavior).
+// An empty application list is the runtime match-any case. An empty query
+// protocol short-circuits to match-any here — a diagnostic convenience (the
+// runtime always has a concrete protocol), NOT a claim that a protocol-bearing
+// app term would match a protocol-less packet. Once a non-empty protocol is
+// supplied, matchSingleApp constrains by protocol (and ICMP type/code for a
+// type-constrained term), failing closed exactly like the dataplane; a
+// non-empty but UNRESOLVABLE protocol therefore fails closed for every
+// protocol-constrained app term.
 func matchApp(cfg *config.Config, apps []string, proto string, srcPort, dstPort int, icmpType, icmpCode *uint8) bool {
 	if len(apps) == 0 {
 		return true
@@ -669,6 +684,15 @@ func matchSingleApp(cfg *config.Config, appName string, queryProto uint8, queryP
 	// ICMP type constraint (junos-icmp-all, or any non-ICMP app) is unaffected:
 	// it matches on protocol/ports alone, exactly as before.
 	if app.ICMPType != nil {
+		// The dataplane keys icmp_constraints under the app's ICMP protocol, so
+		// the type constraint is only ever consulted for an ICMP-family packet.
+		// A predefined ICMP app pins app.Protocol (handled by the check above),
+		// but a custom app could carry an icmp-type without a pinned protocol;
+		// require the query to be ICMP (1) / ICMPv6 (58) so a type-constrained
+		// term can never match a TCP/UDP flow.
+		if !queryProtoOK || (queryProto != icmpProtoNum && queryProto != icmpv6ProtoNum) {
+			return false
+		}
 		if icmpType == nil || *icmpType != *app.ICMPType {
 			return false
 		}

--- a/pkg/policymatch/scoped_global_zonelocal_test.go
+++ b/pkg/policymatch/scoped_global_zonelocal_test.go
@@ -1,0 +1,82 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// compileFromSet compiles a config from flat `set` commands using the
+// ParseSetCommand + SetPath loop (NewParser must not be used for set syntax —
+// see CLAUDE.md "Testing flat set syntax").
+func compileFromSet(t *testing.T, cmds []string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg
+}
+
+// TestScopedGlobalResolvesZoneLocalAddress pins the #3287 fix: a scoped global
+// policy (#3148, `match from-zone <z>`) must resolve a zone-local address
+// reference (#3061) against that zone's local book — the same zone-qualified
+// resolution the compiler already does for zone-pair policies. Before the fix
+// resolveZoneLocalAddressBooks rewrote zone-pair tokens only, so the scoped
+// global kept the bare token, the global book held the entry only under its
+// zone-qualified name, the constraint resolved to match-none, and legitimate
+// zone-scoped global traffic silently fell through to default-deny.
+func TestScopedGlobalResolvesZoneLocalAddress(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust address-book address LOCALNET 10.0.1.0/24",
+		"set security policies global policy allow-local match source-address LOCALNET",
+		"set security policies global policy allow-local match destination-address any",
+		"set security policies global policy allow-local match application any",
+		"set security policies global policy allow-local match from-zone trust",
+		"set security policies global policy allow-local then permit",
+		"set security policies default-policy deny-all",
+	}
+	cfg := compileFromSet(t, cmds)
+
+	// A trust-sourced packet inside LOCALNET must match the scoped global and be
+	// permitted. With the bug the source constraint resolved to match-none, so
+	// the verdict was the default deny.
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5"),
+	})
+	if !res.Matched || !res.Global {
+		t.Fatalf("expected scoped-global match, got Matched=%v Global=%v action=%v",
+			res.Matched, res.Global, res.Action)
+	}
+	if res.PolicyName != "allow-local" {
+		t.Errorf("PolicyName = %q, want allow-local", res.PolicyName)
+	}
+	if res.Action != config.PolicyPermit {
+		t.Errorf("Action = %v, want permit", res.Action)
+	}
+
+	// A source OUTSIDE LOCALNET must NOT match the global (the constraint is
+	// real, not match-any) — falls through to default deny.
+	res2 := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.9.9.9"),
+	})
+	if res2.Matched {
+		t.Errorf("expected default (no match) for out-of-LOCALNET source, got policy %q", res2.PolicyName)
+	}
+	if res2.Action != config.PolicyDeny {
+		t.Errorf("out-of-LOCALNET Action = %v, want deny", res2.Action)
+	}
+}

--- a/pkg/policymatch/wildcard_scoped_test.go
+++ b/pkg/policymatch/wildcard_scoped_test.go
@@ -1,0 +1,187 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// zones builds a defined-zone set for globalScopeMatches resolution.
+func zones(names ...string) map[string]*config.ZoneConfig {
+	out := make(map[string]*config.ZoneConfig, len(names))
+	for _, n := range names {
+		out[n] = &config.ZoneConfig{Name: n}
+	}
+	return out
+}
+
+// TestWildcardZoneAndScopedGlobalPrecedence pins the #3283 parity fix: the
+// simulator must replicate the dataplane precedence chain
+// (userspace-dp/src/policy.rs evaluate_policy_result_with_icmp) —
+//
+//	exact zone-pair -> from-any/to-any single-wildcard (config order) ->
+//	both-any -> global (scoped by #3148 match from/to-zone) -> default.
+//
+// Each case below returns the OPPOSITE verdict on the pre-#3283 simulator,
+// which only knew exact-zone-pair -> unconditional-global -> default.
+func TestWildcardZoneAndScopedGlobalPrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		q          Query
+		wantAction config.PolicyAction
+		wantName   string // "" => default (no match)
+		wantGlobal bool
+	}{
+		{
+			// #3283 example 1: `from-zone any to-zone untrust deny` is invisible
+			// to the old simulator, which then reports the default permit.
+			name: "from-any wildcard deny beats default permit",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "untrust", deny("block-admin", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "trust", ToZone: "untrust"},
+			wantAction: config.PolicyDeny, wantName: "block-admin",
+		},
+		{
+			name: "to-any wildcard deny beats default permit",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("trust", "any", deny("lockdown", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "trust", ToZone: "untrust"},
+			wantAction: config.PolicyDeny, wantName: "lockdown",
+		},
+		{
+			name: "both-any wildcard deny beats default permit",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "any", deny("global-block", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "trust", ToZone: "untrust"},
+			wantAction: config.PolicyDeny, wantName: "global-block",
+		},
+		{
+			// Exact zone-pair MUST outrank a wildcard, even though the wildcard
+			// is configured first.
+			name: "exact zone-pair outranks earlier wildcard",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "untrust", deny("wild-deny", config.PolicyMatch{})),
+					zonePair("trust", "untrust", permit("exact-permit", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "trust", ToZone: "untrust"},
+			wantAction: config.PolicyPermit, wantName: "exact-permit",
+		},
+		{
+			// Single-wildcard tier merges from-any and to-any in config order:
+			// `from-zone any to-zone trust deny` configured BEFORE
+			// `from-zone untrust to-zone any permit` wins for untrust->trust.
+			name: "single-wildcard tier honors config order across from/to-any",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust", "untrust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("any", "trust", deny("any-to-trust-deny", config.PolicyMatch{})),
+					zonePair("untrust", "any", permit("untrust-to-any-permit", config.PolicyMatch{})),
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "untrust", ToZone: "trust"},
+			wantAction: config.PolicyDeny, wantName: "any-to-trust-deny",
+		},
+		{
+			// #3283 example 2: a zone-scoped global must NOT apply outside its
+			// scope. The old simulator applied every global unconditionally.
+			name: "scoped global does NOT apply to non-matching zone",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust", "dmz"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "scoped-deny", Action: config.PolicyDeny,
+						Match: config.PolicyMatch{FromZone: "trust", ToZone: "untrust"}},
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "dmz", ToZone: "untrust"},
+			wantAction: config.PolicyPermit, wantName: "", // falls through to default permit
+		},
+		{
+			name: "scoped global applies to matching zone pair",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust", "dmz"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "scoped-deny", Action: config.PolicyDeny,
+						Match: config.PolicyMatch{FromZone: "trust", ToZone: "untrust"}},
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "trust", ToZone: "untrust"},
+			wantAction: config.PolicyDeny, wantName: "scoped-deny", wantGlobal: true,
+		},
+		{
+			// An unresolved (typo'd / undefined) global scope fails closed —
+			// it matches nothing and the verdict is the default.
+			name: "undefined global scope fails closed",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "typo-deny", Action: config.PolicyDeny,
+						Match: config.PolicyMatch{FromZone: "trsut"}}, // typo
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "trust", ToZone: "untrust"},
+			wantAction: config.PolicyPermit, wantName: "",
+		},
+		{
+			// An empty/"any" global scope still applies to every zone pair.
+			name: "unscoped global applies everywhere",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "untrust", "dmz"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "broad-deny", Action: config.PolicyDeny,
+						Match: config.PolicyMatch{FromZone: "any"}}, // explicit any
+				},
+			}, config.ApplicationsConfig{}),
+			q:          Query{FromZone: "dmz", ToZone: "untrust"},
+			wantAction: config.PolicyDeny, wantName: "broad-deny", wantGlobal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Match(tt.cfg, tt.q)
+			if res.Action != tt.wantAction {
+				t.Errorf("Action = %v, want %v", res.Action, tt.wantAction)
+			}
+			if tt.wantName == "" {
+				if res.Matched {
+					t.Errorf("expected default (no match), got policy %q", res.PolicyName)
+				}
+				return
+			}
+			if !res.Matched {
+				t.Errorf("expected match %q, got default", tt.wantName)
+			}
+			if res.PolicyName != tt.wantName {
+				t.Errorf("PolicyName = %q, want %q", res.PolicyName, tt.wantName)
+			}
+			if res.Global != tt.wantGlobal {
+				t.Errorf("Global = %v, want %v", res.Global, tt.wantGlobal)
+			}
+		})
+	}
+}

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -578,6 +578,13 @@ message MatchPoliciesRequest {
   // source_port lets the simulator honor source-port-constrained application
   // terms (#3042). 0 = unspecified (does not constrain the match).
   int32 source_port = 7;
+  // icmp_type / icmp_code let the simulator honor ICMP/ICMPv6 type-constrained
+  // application terms (#3284, junos-ping = type 8). proto3 `optional` so the
+  // simulator can distinguish "unspecified" (a type-constrained app term then
+  // fails closed, mirroring the dataplane's packet_icmp = None) from a valid
+  // type/code 0 (ICMP type 0 = echo-reply).
+  optional uint32 icmp_type = 8;
+  optional uint32 icmp_code = 9;
 }
 message MatchPoliciesResponse {
   string policy_name = 1;

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -593,6 +593,13 @@ message MatchPoliciesResponse {
   repeated string dst_addresses = 4;
   repeated string applications = 5;
   bool matched = 6;
+  // host_inbound_unmatched is true ONLY for a `to-zone junos-host` query that
+  // matched no host-bound policy (#3285). The dataplane host gate returns None
+  // here — no implicit host default-deny and NO transit global/default
+  // fallback — so local delivery proceeds. When set, `matched` is false and
+  // `action` is empty; clients must render "host-inbound (local delivery; not
+  // governed by transit/global/default policy)", NOT a default-policy verdict.
+  bool host_inbound_unmatched = 7;
 }
 
 // --- NAT rule counters ---


### PR DESCRIPTION
Brings the operator-side security-policy simulator (`pkg/policymatch`,
behind REST `match-policies`, gRPC `MatchPolicies`, CLI `show security
match-policies`, and `test policy`) back to PARITY with the Rust dataplane
policy evaluator (`userspace-dp/src/policy.rs`). The simulator drifted
during campaign-7 and could report the OPPOSITE permit/deny from the
actual dataplane. Four drift bugs, one bisectable commit each (plus a
whitespace-only gofmt fixup).

## #3283 — wildcard-zone (#3090) + scoped-global (#3148) precedence
`Match()` restructured into the dataplane tier chain, first-match
terminating: exact zone-pair -> single-wildcard (`from-zone any` /
`to-zone any`, merged in config order) -> both-any -> global (gated by the
optional `match from-zone`/`to-zone` scope; undefined-zone scope fails
closed) -> default. New `globalScopeMatches` replicates
`GlobalZoneScope::matches` + `build_global_zone_scope`.

## #3284 — ICMP type/code application constraints (#3020)
`Query.ICMPType`/`ICMPCode` added; `matchSingleApp` enforces an app's ICMP
type/code the way `CompiledApplications.matches` does (junos-ping = type 8,
junos-pingv6 = type 128), failing closed for a type-constrained term when
the query omits the type. Threaded through every surface: proto3 `optional`
`icmp_type`/`icmp_code` on `MatchPoliciesRequest` (regenerated), REST
query params, gRPC `test policy` `ictype=`/`iccode=` topic keys, and
local/remote CLI `icmp-type`/`icmp-code` tokens.

## #3285 — no transit fallback for to-zone junos-host
New host-gate path (`matchJunosHost`) mirrors `evaluate_junos_host_policy`:
exact ingress->junos-host then `from-zone any`->junos-host, with NO
global/default transit fallback. Unmatched host-bound flows return the new
`Result.HostInboundUnmatched` (local delivery proceeds, the lifeline
guarantee) instead of a misleading default-policy verdict. Surfaced via a
new `host_inbound_unmatched` proto/REST field and explicit CLI/text
rendering.

## #3287 — scoped globals resolve zone-local address books (#3061)
`resolveZoneLocalAddressBooks` now rewrites a scoped global's source/dest
tokens under its `match from-zone`/`to-zone` scope, so a zone-local
address reference in a scoped global resolves to the zone-qualified entry
instead of silently match-none / commit-reject. Both the simulator and the
dataplane snapshot builder consume the post-fold book, keeping them in
agreement.

## Tests
Per-issue fail-on-revert table tests
(`pkg/policymatch/wildcard_scoped_test.go`, `icmp_test.go`,
`junos_host_test.go`, `scoped_global_zonelocal_test.go`); each was
confirmed RED with its fix reverted. Stale precedence comments and the
package README / `docs/config-schema.md` updated. Full `go test ./...`
green (53 packages, 0 failures).

Closes #3283
Closes #3284
Closes #3285
Closes #3287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi