### PR TITLE
config: reject firewall term with both port and port-except (#3297)

### DIFF
--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -356,6 +356,22 @@ type compileOpts struct {
 	// already-persisted or peer-synced config still BOOTS (#1960 no-brick).
 	// Same doctrine as lenientFilterMatchValues.
 	lenientFlexMatch bool
+	// lenientFilterPortExcept (#3297) downgrades the firewall-filter
+	// positive-vs-except port mutual-exclusion gate
+	// (validateFilterPortExceptStrict) from a hard compile error to a
+	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
+	// term that carries BOTH a positive port match (source-port /
+	// destination-port) AND the negated *-port-except list in the SAME
+	// direction — Junos treats those as mutually exclusive match families and
+	// rejects the term at commit. Before this gate xpf accepted the ambiguous
+	// term and the Rust matcher resolved it deterministically as positive-wins
+	// (the except side silently dropped) — fail-safe at runtime but a
+	// Junos-invalid config accepted with one side of the operator's intent
+	// lost. The tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config still BOOTS (#1960 no-brick); the
+	// dataplane's positive-wins fallback keeps that direction fail-safe. Same
+	// doctrine as lenientFilterMatchValues.
+	lenientFilterPortExcept bool
 	// lenientNPTv6 (#2240) downgrades the NPTv6 (RFC 6296) validation gate
 	// (validateNPTv6Strict) from a hard compile error to a cfg.Warnings entry.
 	// The strict commit / commit-check path hard-rejects an NPTv6 static-NAT
@@ -985,6 +1001,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFilterActions:                true,
 		lenientFilterMatchValues:            true,
 		lenientFlexMatch:                    true,
+		lenientFilterPortExcept:             true,
 		lenientNPTv6:                        true,
 		lenientFirewallRefs:                 true,
 		lenientFlowServerTemplateRef:        true,
@@ -1114,6 +1131,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFilterActions:                true,
 		lenientFilterMatchValues:            true,
 		lenientFlexMatch:                    true,
+		lenientFilterPortExcept:             true,
 		lenientNPTv6:                        true,
 		lenientFirewallRefs:                 true,
 		lenientFlowServerTemplateRef:        true,
@@ -1992,6 +2010,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFlexMatch {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("firewall filter flexible-match-range (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3297 firewall-filter positive-vs-except port mutual-exclusion gate.
+	// Strict on commit / commit-check (hard-reject a term carrying BOTH a
+	// positive port match and the negated *-port-except list in the same
+	// direction — Junos rejects this as ambiguous). Before this gate xpf
+	// accepted the term and the Rust matcher silently applied positive-wins,
+	// dropping the except side. Lenient on load / peer-sync (warn so an
+	// already-persisted or peer-synced config still boots — #1960 no-brick; the
+	// dataplane's positive-wins fallback keeps that direction fail-safe). Runs
+	// on the fully-compiled *Config so the typed term list (with
+	// SourcePorts/DestinationPorts and SourcePortsExcept/DestPortsExcept
+	// populated by compileFilterFrom) is available.
+	if err := validateFilterPortExceptStrict(cfg); err != nil {
+		if opts.lenientFilterPortExcept {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter port-except (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3054,6 +3054,71 @@ func validateFilterFlexMatchStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// validateFilterPortExceptStrict hard-rejects any firewall-filter term that
+// carries BOTH a positive port match and the negated `*-port-except` list in
+// the SAME direction — #3297.
+//
+// Junos treats `source-port` / `destination-port` and their
+// `source-port-except` / `destination-port-except` counterparts as mutually
+// exclusive match families and rejects a term carrying both at commit. xpf's
+// parser, however, lands the positive list on term.SourcePorts /
+// term.DestinationPorts and the negated list on term.SourcePortsExcept /
+// term.DestPortsExcept (compileFilterFrom), so both can coexist on one term.
+//
+// The Rust matcher (userspace-dp filter/compiler.rs) resolves the ambiguity
+// deterministically as positive-wins (the positive list builds the matcher and
+// the except list is ignored). That is fail-safe at runtime — the configured
+// positive scope is honored, no traffic leaks — but it silently accepts a
+// Junos-invalid term and discards one side of the operator's intent. This gate
+// makes the conflict an operator-visible commit error instead.
+//
+// The walk is deterministic (filters sorted by name, terms in config order).
+// On the tolerant load / peer-sync path the caller downgrades the returned
+// error to a warning (#1960 no-brick); the dataplane's positive-wins fallback
+// keeps that direction fail-safe independently.
+func validateFilterPortExceptStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil {
+					continue
+				}
+				if len(term.SourcePorts) > 0 && len(term.SourcePortsExcept) > 0 {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: `from source-port` and "+
+							"`from source-port-except` are mutually exclusive in the same "+
+							"term (Junos rejects this; remove one)",
+						family, name, term.Name)
+				}
+				if len(term.DestinationPorts) > 0 && len(term.DestPortsExcept) > 0 {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: `from destination-port` and "+
+							"`from destination-port-except` are mutually exclusive in the same "+
+							"term (Junos rejects this; remove one)",
+						family, name, term.Name)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // filterProtocolResolvable reports whether a `from protocol <token>` is
 // representable: it INLINE-mirrors the acceptance set of
 // appid.ProtocolNumber's ok==true result (the #2124/#2175 SSOT). pkg/config

--- a/pkg/config/firewall_port_except_mutex_3297_test.go
+++ b/pkg/config/firewall_port_except_mutex_3297_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3297: a single firewall-filter term may carry BOTH a positive port match
+// (source-port / destination-port) AND the negated *-port-except list in the
+// same direction. Junos treats these as mutually exclusive match families and
+// rejects the term at commit. xpf's parser lands the positive list and the
+// except list on separate term fields, so both coexist; the Rust matcher then
+// silently resolves the conflict as positive-wins and drops the except side
+// (fail-safe at runtime, but a Junos-invalid config accepted with one side of
+// the operator's intent lost). validateFilterPortExceptStrict makes the
+// conflict an operator-visible commit error instead.
+//
+// FAIL-ON-REVERT: remove the validateFilterPortExceptStrict invocation (or the
+// function's reject) and these strict-path tests go RED — CompileConfig accepts
+// the ambiguous term instead of erroring.
+
+func TestFilterSourcePortPositiveAndExceptRejected_3297(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from source-port 80",
+		"set firewall family inet filter f term t from source-port-except 443",
+		"set firewall family inet filter f term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with both source-port and source-port-except must be " +
+			"rejected at commit (Junos-invalid, #3297)")
+	}
+	if !strings.Contains(err.Error(), "source-port") ||
+		!strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error %q must name the source-port conflict", err)
+	}
+	if !strings.Contains(err.Error(), `filter "f"`) ||
+		!strings.Contains(err.Error(), `term "t"`) {
+		t.Fatalf("error %q must name the offending filter and term", err)
+	}
+	// Tolerant path downgrades to a warning so a persisted/peer-synced config
+	// still boots (#1960 no-brick); the dataplane positive-wins fallback keeps
+	// the direction fail-safe.
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the port-except conflict: %v", lerr)
+	}
+}
+
+func TestFilterDestPortPositiveAndExceptRejected_3297(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from destination-port 22",
+		"set firewall family inet filter f term t from destination-port-except 22",
+		"set firewall family inet filter f term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with both destination-port and destination-port-except " +
+			"must be rejected at commit (Junos-invalid, #3297)")
+	}
+	if !strings.Contains(err.Error(), "destination-port") ||
+		!strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error %q must name the destination-port conflict", err)
+	}
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the port-except conflict: %v", lerr)
+	}
+}
+
+// inet6 family must be gated identically (the validator walks both families).
+func TestFilterDestPortPositiveAndExceptRejectedV6_3297(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet6 filter f6 term t from destination-port 22",
+		"set firewall family inet6 filter f6 term t from destination-port-except 22",
+		"set firewall family inet6 filter f6 term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("inet6 term with both destination-port and " +
+			"destination-port-except must be rejected at commit (#3297)")
+	}
+	if !strings.Contains(err.Error(), "inet6") {
+		t.Fatalf("error %q must name the inet6 family", err)
+	}
+}
+
+// A term with ONLY a positive port match, or ONLY an except list, must still
+// compile cleanly — the gate fires only when both are present in one direction.
+func TestFilterPortExceptOnlyOneSideAccepted_3297(t *testing.T) {
+	posOnly := buildFilterTree(t,
+		"set firewall family inet filter pos term t from source-port 80",
+		"set firewall family inet filter pos term t then discard",
+	)
+	if _, err := CompileConfig(posOnly); err != nil {
+		t.Fatalf("source-port alone must compile: %v", err)
+	}
+	exceptOnly := buildFilterTree(t,
+		"set firewall family inet filter exc term t from destination-port-except 22",
+		"set firewall family inet filter exc term t then discard",
+	)
+	if _, err := CompileConfig(exceptOnly); err != nil {
+		t.Fatalf("destination-port-except alone must compile: %v", err)
+	}
+	// Positive source + except destination (different directions) is allowed.
+	crossDir := buildFilterTree(t,
+		"set firewall family inet filter cross term t from source-port 80",
+		"set firewall family inet filter cross term t from destination-port-except 22",
+		"set firewall family inet filter cross term t then discard",
+	)
+	if _, err := CompileConfig(crossDir); err != nil {
+		t.Fatalf("source-port + destination-port-except (different directions) must compile: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

A single firewall-filter term can carry BOTH a positive port match
(`source-port` / `destination-port`) AND the negated `*-port-except` list
in the SAME direction. Junos treats these as mutually exclusive match
families and rejects the term at commit. xpf's strict validator did not,
and the Rust matcher silently resolved the conflict as positive-wins (the
except side dropped) — fail-safe at runtime, but a Junos-invalid config
accepted with one side of the operator's intent lost.

This adds `validateFilterPortExceptStrict`, a strict commit-time gate that
hard-rejects any term carrying both a positive and a negated port list in
the same direction (source or destination), for both `inet` and `inet6`.
The error names the family, filter, term, and the conflicting direction,
mirroring the existing strict-reject style
(`validateFilterMatchValuesStrict` / `validateFilterFlexMatchStrict`) and
wired into `CompileConfig` after the flexible-match-range gate.

The Rust matcher's positive-wins behavior is left unchanged (it remains the
fail-safe runtime fallback). A new `lenientFilterPortExcept` opts flag
downgrades the gate to a `cfg.Warnings` entry on the tolerant load /
peer-sync paths so an already-persisted or peer-synced config still boots
(#1960 no-brick); commit stays strict.

## Finding status

NOT structurally prevented — both fields coexist post-parse
(`compiler_firewall.go` lands the positive list on `term.SourcePorts` /
`term.DestinationPorts` and the except list on `term.SourcePortsExcept` /
`term.DestPortsExcept`), so the strict reject was needed.

## Tests / validation

`go build ./...` and `go test ./pkg/config/...` pass. New fail-on-revert
tests cover source and destination directions on `inet` and `inet6`, plus
negative cases (one-side-only and cross-direction must still compile) and
the tolerant-path downgrade. With the reject disabled the three strict
tests go RED; the one-side-accepted test stays green.

Closes #3297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi