### PR TITLE
host-inbound: admit multi-hop BFD (UDP 4784, RFC 5883) for protocols bfd

### DIFF
--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -444,7 +444,10 @@ func hostInboundProtocolMatches(token, family string) []string {
 	case "vrrp":
 		return []string{"meta l4proto 112"}
 	case "bfd":
-		return []string{"udp dport { 3784, 3785 }"}
+		// #3299: single-hop control (3784) + echo (3785) AND multi-hop
+		// control (4784, RFC 5883). Keep this set in lockstep with the
+		// AF_XDP host_inbound classifier (host_inbound.rs "bfd" arm).
+		return []string{"udp dport { 3784, 3785, 4784 }"}
 	case "ldp":
 		return []string{"tcp dport 646", "udp dport 646"}
 	case "msdp":

--- a/pkg/daemon/host_inbound_parity_test.go
+++ b/pkg/daemon/host_inbound_parity_test.go
@@ -67,6 +67,26 @@ func TestHostInboundNftMatchesKnownTokens(t *testing.T) {
 	}
 }
 
+// TestHostInboundBfdAdmitsMultiHop asserts the nft host-inbound rule for
+// `protocols bfd` admits multi-hop BFD control (UDP 4784, RFC 5883) in addition
+// to single-hop control (3784) + echo (3785). Operators running BFD-assisted
+// multi-hop BGP (or BFD over multi-hop static routes) to the firewall depend on
+// 4784 reaching the host (#3299). This must stay in lockstep with the AF_XDP
+// host_inbound classifier ("bfd" arm in host_inbound.rs). Fail-on-revert:
+// dropping 4784 from the dport set turns this RED.
+func TestHostInboundBfdAdmitsMultiHop(t *testing.T) {
+	matches := hostInboundProtocolMatches("bfd", "ip")
+	if len(matches) == 0 {
+		t.Fatalf("bfd produced no nft match for ip family")
+	}
+	joined := strings.Join(matches, " ; ")
+	for _, port := range []string{"3784", "3785", "4784"} {
+		if !strings.Contains(joined, port) {
+			t.Errorf("bfd nft match %q missing UDP dport %s (single-hop 3784/echo 3785 + multi-hop 4784 RFC 5883)", joined, port)
+		}
+	}
+}
+
 // TestHostInboundEmptyStanzaFailsClosed asserts that a host-inbound-CONFIGURED
 // zone whose stanza yields zero recognized matches (an empty
 // `host-inbound-traffic { }`, or — on the tolerant load path — a zone whose

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -237,9 +237,14 @@ fn classify_protocol(token: &str, hi: &mut ZoneHostInbound) {
         "vrrp" => {
             hi.ip_protocols.insert(112);
         }
+        // #3299: BFD admits single-hop control (3784) + echo (3785) AND
+        // multi-hop control (4784, RFC 5883). Multi-hop is control-only; echo
+        // stays single-hop on 3785. Keep this set in lockstep with the nft
+        // host-inbound rule (`hostInboundProtocolMatches`, pkg/daemon).
         "bfd" => {
             hi.udp_ports.insert(3784);
             hi.udp_ports.insert(3785);
+            hi.udp_ports.insert(4784);
         }
         "ldp" => {
             hi.tcp_ports.insert(646);

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1109,6 +1109,60 @@ fn build_forwarding_state_enforces_host_inbound_traffic() {
     );
 }
 
+// #3299: `host-inbound-traffic protocols bfd` must admit multi-hop BFD control
+// (UDP 4784, RFC 5883) in addition to single-hop control (3784) + echo (3785).
+// Multi-hop BFD (for multi-hop BGP / BFD over multi-hop static routes) carries
+// control packets on UDP/4784; before this fix the "bfd" arm inserted only
+// 3784/3785 so 4784 was denied by host-inbound admission. Fail-on-revert:
+// removing `hi.udp_ports.insert(4784)` from the "bfd" arm in host_inbound.rs
+// turns the 4784-admit assertion RED. Keep in lockstep with the nft rule
+// (`hostInboundProtocolMatches` "bfd", pkg/daemon/daemon_nft.go).
+#[test]
+fn build_forwarding_state_bfd_admits_multihop_control() {
+    use crate::ZoneSnapshot;
+    use crate::afxdp::forwarding::host_inbound_admits;
+
+    let snapshot = ConfigSnapshot {
+        zones: vec![ZoneSnapshot {
+            name: "wan".into(),
+            id: 41,
+            host_inbound_configured: true,
+            host_inbound_system_services: vec![],
+            host_inbound_protocols: vec!["bfd".into()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let state = build_forwarding_state(&snapshot);
+    assert!(state.zone_host_inbound.contains_key(&41));
+
+    // Single-hop control (3784) + echo (3785) still admitted.
+    assert!(
+        host_inbound_admits(&state, 41, 17, 3784, false, 0),
+        "bfd single-hop control udp/3784 admitted"
+    );
+    assert!(
+        host_inbound_admits(&state, 41, 17, 3785, false, 0),
+        "bfd echo udp/3785 admitted"
+    );
+    // Multi-hop control (4784, RFC 5883) admitted — the #3299 fix.
+    assert!(
+        host_inbound_admits(&state, 41, 17, 4784, false, 0),
+        "bfd multi-hop control udp/4784 (RFC 5883) admitted"
+    );
+    // Also admitted on IPv6 (BFD runs over both families).
+    assert!(
+        host_inbound_admits(&state, 41, 17, 4784, true, 0),
+        "bfd multi-hop control udp/4784 admitted on v6"
+    );
+    // A non-BFD UDP port stays DENIED (the arm did not open all of UDP).
+    assert!(
+        !host_inbound_admits(&state, 41, 17, 4783, false, 0),
+        "bfd zone does not admit unrelated udp/4783"
+    );
+}
+
 // #3171: a CONFIGURED ping-less zone must still admit ICMP/ICMPv6 ERROR /
 // PMTUD control messages (destination-unreachable, packet-too-big, time-
 // exceeded, parameter-problem) reaching the XSK LocalDelivery path — mirroring


### PR DESCRIPTION
Closes #3299

## Summary

`security zones <z> host-inbound-traffic protocols bfd` admitted only the
single-hop BFD control port (UDP 3784) and echo (3785). Multi-hop BFD
(RFC 5883, UDP **4784**) — used for BFD-assisted multi-hop BGP and BFD
over multi-hop static routes — had its control packets dropped by
host-inbound admission, so multi-hop BFD sessions terminating on the
firewall failed to establish. Junos admits BFD broadly on the host when
`protocols bfd` is configured.

The gap existed on BOTH host-inbound enforcement surfaces (they must
agree). The fix adds UDP 4784 to the bfd admit set on each:

| Surface | Before | After |
|---|---|---|
| AF_XDP dataplane (`userspace-dp/src/afxdp/forwarding/host_inbound.rs`, `"bfd"` arm) | `udp_ports {3784, 3785}` | `udp_ports {3784, 3785, 4784}` |
| Kernel nft (`pkg/daemon/daemon_nft.go`, `hostInboundProtocolMatches`) | `udp dport { 3784, 3785 }` | `udp dport { 3784, 3785, 4784 }` |

4784 is the multi-hop **control** port only; echo stays single-hop on
3785, so no echo port is added.

## Tests (both fail-on-revert, verified RED then restored)

- **Rust** `build_forwarding_state_bfd_admits_multihop_control`: asserts a
  UDP/4784 packet to a `protocols bfd` zone is admitted on v4 and v6,
  3784/3785 stay admitted, an unrelated UDP port stays denied. RED when
  the `hi.udp_ports.insert(4784)` is removed.
- **Go** `TestHostInboundBfdAdmitsMultiHop`: asserts the generated nft bfd
  match contains dport 4784 alongside 3784/3785. RED when 4784 is dropped
  from the dport set.

## Validation

- `go build ./...` clean; `go test ./pkg/daemon/...` ok.
- `cargo test --release`: 3187 passed, only the known
  `concurrent_recovery` flake failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi