### PR TITLE
config: reject undefined dynamic-address feed-name at commit (#3300)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22575,3 +22575,16 @@ top.
   **File(s)**: pkg/config/compiler_validate_strict.go, pkg/config/compiler.go,
   pkg/config/compiler_dynamic_address_feed_ref_3300_test.go,
   docs/config-schema.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3300 residual (Codex MERGE-NEEDS-MAJOR): a feed-server with no
+  url AND no hostname is SKIPPED by feeds.Manager.Apply (resolveBaseURL=="")
+  → registers no feeds → a bound address-name still resolves empty → the
+  silent match-none persists, and the declared-set parity claim was
+  overstated. Added validateDynamicAddressFeedServerEndpointStrict (replicates
+  resolveBaseURL emptiness, no pkg/feeds import) dispatched BEFORE the feed-ref
+  gate, sharing lenientDynamicAddressFeedRef. Fixed the now-exact parity
+  docstring. Fail-on-revert test + url/hostname positive controls.
+  **File(s)**: pkg/config/compiler_validate_strict.go, pkg/config/compiler.go,
+  pkg/config/compiler_dynamic_address_feed_ref_3300_test.go,
+  docs/config-schema.md

--- a/_Log.md
+++ b/_Log.md
@@ -22563,3 +22563,15 @@ top.
   **File(s)**: pkg/dataplane/userspace/capabilities.go,
   pkg/dataplane/userspace/app_inactivity_timeout_precedence_3298_test.go,
   docs/userspace-dataplane-gaps.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3300 strict cross-reference: reject a
+  `security dynamic-address address-name … profile feed-name <feed>` whose
+  feed-name resolves to no declared feed-server feed at commit. Previously a
+  typo compiled clean and armed a silent match-none address book (feed-backed
+  deny denied nothing). Added `validateDynamicAddressFeedReferencesStrict`
+  (mirrors feeds.Manager keying) + `lenientDynamicAddressFeedRef` tolerant
+  downgrade. Fail-on-revert test + positive controls.
+  **File(s)**: pkg/config/compiler_validate_strict.go, pkg/config/compiler.go,
+  pkg/config/compiler_dynamic_address_feed_ref_3300_test.go,
+  docs/config-schema.md

--- a/_Log.md
+++ b/_Log.md
@@ -22588,3 +22588,17 @@ top.
   **File(s)**: pkg/config/compiler_validate_strict.go, pkg/config/compiler.go,
   pkg/config/compiler_dynamic_address_feed_ref_3300_test.go,
   docs/config-schema.md
+
+- **Timestamp**: 2026-06-27
+  **Action**: #3300 residual #2 (Codex re-review): the endpoint gate's flat
+  `url=="" && hostname==""` check did NOT match resolveBaseURL, which returns
+  TrimRight(url,"/") BEFORE the hostname fallback — so a slash-only `url /`
+  (operator-reachable: `/` is a valid lexer char, no url-format schema check)
+  trims to "" → Apply skips the server → #3300 silent-miss reproduces.
+  Replaced with feedServerBaseURLEmpty mirroring resolveBaseURL
+  branch-for-branch (url-branch wins; slash-only url rejected even with a
+  hostname set; no whitespace trim, matching resolveBaseURL). Added
+  slash-url + slash-url-with-hostname reject tests (RED on the flat check).
+  **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_dynamic_address_feed_ref_3300_test.go,
+  docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1383,9 +1383,16 @@ address-name resolves to a match-nothing book exactly as a typo'd feed-name
 would. Rejecting the endpoint-less server at its root ALSO makes the
 cross-reference gate's declared-feed set EXACT — every server it trusts is one
 `Apply` would actually register. The gate replicates `resolveBaseURL`'s
-emptiness condition (`URL == "" && Hostname == ""`) directly on the
-`FeedServer` struct rather than importing `pkg/feeds` (no import cycle); keep
-in sync with `resolveBaseURL`.
+emptiness condition (`feedServerBaseURLEmpty`) directly on the `FeedServer`
+struct rather than importing `pkg/feeds` (no import cycle), mirroring it
+BRANCH-FOR-BRANCH: `resolveBaseURL` prefers `url` and returns
+`strings.TrimRight(url, "/")` BEFORE it ever falls back to `hostname`, so a
+slash-only `url` (`/`, `//`) trims to `""` and the server is skipped EVEN when
+a hostname is also set — a flat `url=="" && hostname==""` check would miss it
+(`/` is a valid lexer identifier char, accepted by the schema with no
+url-format validation). No whitespace trimming is performed (resolveBaseURL
+only `TrimRight`s `"/"`). Keep `feedServerBaseURLEmpty` in sync with
+`resolveBaseURL`.
 
 **Strict/lenient split (flag `lenientDynamicAddressFeedRef`, shared by both
 gates):** strict on the commit / commit-check path (`CompileConfig` —

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1371,18 +1371,36 @@ set is computed exactly as `feeds.Manager` keys feeds (`feeds.go` Start): each
 `feed-server`'s `feed-name` entries, or — for a single-feed server with no
 explicit `feed-name` — the server name itself.
 
-**Strict/lenient split (flag `lenientDynamicAddressFeedRef`):** strict on the
-commit / commit-check path (`CompileConfig` — hard-reject), downgraded to a
-`cfg.Warnings` entry on the tolerant load / peer-sync paths
-(`CompileConfigLenient` / `CompileConfigForNodeLenient`) so an
+A second gate closes the same fail-open at the feed-server **root**:
+**`validateDynamicAddressFeedServerEndpointStrict`** (run just before the
+cross-reference gate) hard-rejects a `feed-server` with neither `url` nor
+`hostname`. `feeds.Manager.Apply` derives a server's base URL via
+`resolveBaseURL` (explicit `url`, else `https://<hostname>`, else `""`) and
+SKIPS a server whose base URL is empty — it registers NONE of its feeds. Such
+a server still compiles into `DynamicAddress.FeedServers`, so its feed names
+are syntactically "declared", but no feed exists at runtime: a bound
+address-name resolves to a match-nothing book exactly as a typo'd feed-name
+would. Rejecting the endpoint-less server at its root ALSO makes the
+cross-reference gate's declared-feed set EXACT — every server it trusts is one
+`Apply` would actually register. The gate replicates `resolveBaseURL`'s
+emptiness condition (`URL == "" && Hostname == ""`) directly on the
+`FeedServer` struct rather than importing `pkg/feeds` (no import cycle); keep
+in sync with `resolveBaseURL`.
+
+**Strict/lenient split (flag `lenientDynamicAddressFeedRef`, shared by both
+gates):** strict on the commit / commit-check path (`CompileConfig` —
+hard-reject), downgraded to a `cfg.Warnings` entry on the tolerant load /
+peer-sync paths (`CompileConfigLenient` / `CompileConfigForNodeLenient`) so an
 already-persisted config (older binaries never validated the reference) or a
 peer-synced config still BOOTS (#1960 / #3261 fail-closed-on-load doctrine) —
-the runtime stays fail-closed (match-none) for the unknown feed, so a
-leniently-loaded typo denies nothing rather than bricking. Regression
-coverage: `pkg/config/compiler_dynamic_address_feed_ref_3300_test.go`
+the runtime stays fail-closed (match-none) for the unknown feed or skipped
+server, so a leniently-loaded typo/endpoint-less server denies nothing rather
+than bricking. Regression coverage:
+`pkg/config/compiler_dynamic_address_feed_ref_3300_test.go`
 (`TestValidateDynamicAddressFeedReferences` — the fail-on-revert guard plus
 feed-entry / single-feed / server-name positive controls and the lenient
-downgrade).
+downgrade; `TestValidateDynamicAddressFeedServerEndpoint` — endpoint-less
+reject, url / hostname-only positive controls, lenient downgrade).
 
 ### #3117 — Security-policy `scheduler-name` schema leaf (completion parity)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1349,6 +1349,41 @@ an undefined from-zone and to-zone, `TestPolicySpecialZoneTokensCommit` —
 `any`/`junos-host`/global anti-over-reject, `TestPolicyDefinedZonesCommit`,
 `TestPolicyUndefinedZoneLenientDowngradesToWarning`).
 
+### #3300 — Dynamic-address `address-name … feed-name` cross-reference gate
+
+A `security dynamic-address address-name <addr> profile feed-name <feed>`
+binding records `<feed>` verbatim into `AddressBinding.FeedNames`
+(`compileDynamicAddress`, `compiler_services.go`) with no cross-reference
+against the configured `feed-server`s. The `feed-name` schema leaf is a
+free-form value (`schema_security.go`), so the #2008/#2009 undefined-token
+gate does NOT catch a typo. At runtime an unknown feed name resolves to a
+non-nil EMPTY prefix set (`feeds.Manager.SnapshotForBindings`, `feeds.go`),
+so the AF_XDP address book gets a book ID matching NOTHING — fail-closed,
+which is correct for a "declared but not yet fetched" feed but
+indistinguishable from a typo. A feed-backed deny policy then silently
+denies nothing, with no commit error.
+
+**`validateDynamicAddressFeedReferencesStrict`** (`compiler_validate_strict.go`)
+restores Junos commit-time parity: a binding whose `feed-name` resolves to no
+declared feed is hard-rejected at commit / commit-check, with a message
+naming both the address-name and the unknown feed-name. The valid feed-name
+set is computed exactly as `feeds.Manager` keys feeds (`feeds.go` Start): each
+`feed-server`'s `feed-name` entries, or — for a single-feed server with no
+explicit `feed-name` — the server name itself.
+
+**Strict/lenient split (flag `lenientDynamicAddressFeedRef`):** strict on the
+commit / commit-check path (`CompileConfig` — hard-reject), downgraded to a
+`cfg.Warnings` entry on the tolerant load / peer-sync paths
+(`CompileConfigLenient` / `CompileConfigForNodeLenient`) so an
+already-persisted config (older binaries never validated the reference) or a
+peer-synced config still BOOTS (#1960 / #3261 fail-closed-on-load doctrine) —
+the runtime stays fail-closed (match-none) for the unknown feed, so a
+leniently-loaded typo denies nothing rather than bricking. Regression
+coverage: `pkg/config/compiler_dynamic_address_feed_ref_3300_test.go`
+(`TestValidateDynamicAddressFeedReferences` — the fail-on-revert guard plus
+feed-entry / single-feed / server-name positive controls and the lenient
+downgrade).
+
 ### #3117 — Security-policy `scheduler-name` schema leaf (completion parity)
 
 A security-policy `scheduler-name <name>` binds a class-of-service scheduler

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2155,6 +2155,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #3300 residual: an endpoint-less dynamic-address feed-server (no url
+	// AND no hostname) is SKIPPED by feeds.Manager.Apply (resolveBaseURL ==
+	// "" registers none of its feeds), so an address-name bound to it
+	// resolves to an empty match-nothing book and a feed-backed deny policy
+	// silently denies nothing — the #3300 symptom at the feed-server root.
+	// Reject it so the runtime-nonfunctional config fails at commit. This
+	// must run BEFORE the feed-name cross-reference gate below so the
+	// declared-feed set the latter trusts is exact (no skipped servers in
+	// it). Strict on commit / commit-check; lenient on load / peer-sync
+	// (warn — the runtime already drops the server, so a bound address-name
+	// is fail-closed rather than bricking the load — #1960 / #3261).
+	if err := validateDynamicAddressFeedServerEndpointStrict(cfg); err != nil {
+		if opts.lenientDynamicAddressFeedRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("dynamic-address feed-server endpoint (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	// #3300 dynamic-address feed cross-reference gate. A
 	// `security dynamic-address address-name <addr> profile feed-name <feed>`
 	// whose feed-name resolves to no declared feed-server feed records an

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -200,6 +200,22 @@ type compileOpts struct {
 	// lenientIPsecPolicyProposalRef.
 	lenientLogProfileStreamRef bool
 
+	// lenientDynamicAddressFeedRef (#3300) downgrades the
+	// `security dynamic-address address-name <addr> profile feed-name <feed>`
+	// cross-reference (validateDynamicAddressFeedReferencesStrict) from a
+	// hard error to a warning on the tolerant load / peer-sync paths. An
+	// already-persisted config (older binaries never validated the feed-name
+	// reference), or one synced from a peer, may carry an address-name whose
+	// profile feed-name does not resolve to a declared feed; an upgrading /
+	// receiving node must still boot through it (warn) rather than
+	// fail-closed-on-load (#1960 / #3261 class). The runtime is already
+	// fail-closed (an unknown feed resolves to an empty, match-nothing
+	// address book), so a leniently-loaded typo denies nothing rather than
+	// bricking. Commit / commit-check stay strict — a new operator edit that
+	// names an undefined feed (whose deny policy would silently match
+	// nothing) is rejected. Same doctrine as lenientLogProfileStreamRef.
+	lenientDynamicAddressFeedRef bool
+
 	// lenientNATHostMask (#2173) downgrades the static-NAT / NAT64
 	// host-mask gate (validateNATHostMaskStrict) from a hard compile error
 	// to a cfg.Warnings entry. Set ONLY on the tolerant load / peer-sync
@@ -990,6 +1006,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientIPsecGatewayRefs:             true,
 		lenientIKEPolicyChainRef:            true,
 		lenientLogProfileStreamRef:          true,
+		lenientDynamicAddressFeedRef:        true,
 		lenientNATPoolAlarmThreshold:        true,
 		lenientNATHostMask:                  true,
 		lenientUnsupportedInterfaceStanzas:  true,
@@ -1120,6 +1137,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientIPsecGatewayRefs:             true,
 		lenientIKEPolicyChainRef:            true,
 		lenientLogProfileStreamRef:          true,
+		lenientDynamicAddressFeedRef:        true,
 		lenientNATPoolAlarmThreshold:        true,
 		lenientNATHostMask:                  true,
 		lenientUnsupportedInterfaceStanzas:  true,
@@ -2132,6 +2150,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientLogProfileStreamRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("security log profile stream reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3300 dynamic-address feed cross-reference gate. A
+	// `security dynamic-address address-name <addr> profile feed-name <feed>`
+	// whose feed-name resolves to no declared feed-server feed records an
+	// empty (match-nothing) address book at runtime, so a feed-backed deny
+	// policy silently denies nothing with no commit error — a typo is
+	// indistinguishable from a not-yet-fetched feed. Strict on commit /
+	// commit-check (hard reject so the typo is operator-visible); lenient on
+	// load / peer-sync (warn so an already-persisted or peer-synced config
+	// still boots — #1960 / #3261; the runtime stays fail-closed match-none
+	// for the unknown feed). Runs on the fully-compiled *Config so the
+	// feed-server map is populated regardless of authoring order. Mirrors
+	// validateLogProfileStreamReferencesStrict.
+	if err := validateDynamicAddressFeedReferencesStrict(cfg); err != nil {
+		if opts.lenientDynamicAddressFeedRef {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("dynamic-address feed reference (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_dynamic_address_feed_ref_3300_test.go
+++ b/pkg/config/compiler_dynamic_address_feed_ref_3300_test.go
@@ -106,3 +106,71 @@ func TestValidateDynamicAddressFeedReferences(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateDynamicAddressFeedServerEndpoint covers the #3300 residual: a
+// feed-server with neither url nor hostname is SKIPPED by feeds.Manager.Apply
+// (resolveBaseURL == "") and registers no feeds, so an address-name bound to
+// it resolves to a match-nothing book. Such a server must be rejected at
+// commit (strict); a server with a url or a hostname is accepted; the
+// tolerant load path downgrades to a warning.
+func TestValidateDynamicAddressFeedServerEndpoint(t *testing.T) {
+	t.Run("commit rejects feed-server with no url or hostname", func(t *testing.T) {
+		// A feed-server that declares a feed-name but no endpoint: it
+		// registers nothing at runtime, so the bound address-name is a
+		// silent match-none — the same #3300 fail-open at the server root.
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("CompileConfig should reject feed-server with no url/hostname")
+		}
+		if !strings.Contains(err.Error(), "threat") {
+			t.Fatalf("error should name the endpoint-less feed-server, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts feed-server with url", func(t *testing.T) {
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("feed-server with url should compile, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts feed-server with hostname only", func(t *testing.T) {
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat hostname feeds.example.com",
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("feed-server with hostname should compile, got: %v", err)
+		}
+	})
+
+	t.Run("lenient load downgrades endpoint-less server to warning", func(t *testing.T) {
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile should not fail on endpoint-less server, got: %v", err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "threat") && strings.Contains(w, "feed-server") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile should record a feed-server endpoint warning, warnings=%v", cfg.Warnings)
+		}
+	})
+}

--- a/pkg/config/compiler_dynamic_address_feed_ref_3300_test.go
+++ b/pkg/config/compiler_dynamic_address_feed_ref_3300_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree3300 compiles a set-command list into a ConfigTree for the
+// #3300 dynamic-address feed cross-reference tests. Uses ParseSetCommand
+// + SetPath (never NewParser, which merges newlines into one node).
+func buildTree3300(t *testing.T, setCommands []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range setCommands {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestValidateDynamicAddressFeedReferences covers #3300: a
+// `security dynamic-address address-name <addr> profile feed-name <feed>`
+// binding whose feed-name resolves to no declared feed must be rejected at
+// commit (strict). Before the fix the typo compiled clean and armed a
+// silent match-none address book (a feed-backed deny policy then denied
+// nothing). Valid references and the tolerant-load downgrade still work.
+func TestValidateDynamicAddressFeedReferences(t *testing.T) {
+	// The exact reproduction from the issue: a feed-server declaring feed
+	// "malware", an address-name binding with the typo "malwrae".
+	bogusBinding := []string{
+		"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+		"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+		"set security dynamic-address address-name bad-actors profile feed-name malwrae",
+	}
+
+	t.Run("commit rejects typo'd feed-name", func(t *testing.T) {
+		tree := buildTree3300(t, bogusBinding)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("CompileConfig should reject address-name referencing undefined feed %q", "malwrae")
+		}
+		if !strings.Contains(err.Error(), "malwrae") {
+			t.Fatalf("error should name the undefined feed-name, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "bad-actors") {
+			t.Fatalf("error should name the offending address-name, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts feed entry reference", func(t *testing.T) {
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("correctly-referenced feed-entry should compile, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts single-feed reference by feed-name", func(t *testing.T) {
+		// Single-feed server (no per-feed entries): the feed is keyed by
+		// its FeedName. A binding may reference that name.
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+			"set security dynamic-address feed-server threat feed-name solo",
+			"set security dynamic-address address-name bad-actors profile feed-name solo",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("single-feed-name reference should compile, got: %v", err)
+		}
+	})
+
+	t.Run("commit accepts reference to server name when no feed-name set", func(t *testing.T) {
+		// A feed-server with neither per-feed entries nor an explicit
+		// feed-name is keyed by the server name (feeds.Manager fallback).
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name threat",
+		})
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("server-name fallback reference should compile, got: %v", err)
+		}
+	})
+
+	t.Run("lenient load downgrades typo to warning", func(t *testing.T) {
+		tree := buildTree3300(t, bogusBinding)
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile should not fail on undefined feed-name, got: %v", err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "malwrae") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile should record a warning naming the bad feed, warnings=%v", cfg.Warnings)
+		}
+	})
+}

--- a/pkg/config/compiler_dynamic_address_feed_ref_3300_test.go
+++ b/pkg/config/compiler_dynamic_address_feed_ref_3300_test.go
@@ -131,6 +131,47 @@ func TestValidateDynamicAddressFeedServerEndpoint(t *testing.T) {
 		}
 	})
 
+	t.Run("commit rejects slash-only url", func(t *testing.T) {
+		// resolveBaseURL returns TrimRight(url, "/") == "" for a slash-only
+		// url, so Apply skips the server — the bound address-name is a silent
+		// match-none. `/` is a valid lexer identifier char and passes the
+		// schema (no url-format validation), so this is operator-reachable.
+		for _, slash := range []string{"/", "//", "///"} {
+			tree := buildTree3300(t, []string{
+				"set security dynamic-address feed-server threat url " + slash,
+				"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+				"set security dynamic-address address-name bad-actors profile feed-name malware",
+			})
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig should reject slash-only url %q (resolves to empty endpoint)", slash)
+			}
+			if !strings.Contains(err.Error(), "threat") {
+				t.Fatalf("error should name the feed-server for url %q, got: %v", slash, err)
+			}
+		}
+	})
+
+	t.Run("commit rejects slash-only url even with hostname set", func(t *testing.T) {
+		// resolveBaseURL checks url FIRST and returns "" for a slash-only
+		// url WITHOUT falling back to hostname, so the server is still
+		// skipped despite the hostname. A flat (url=="" && hostname=="")
+		// gate would wrongly accept this.
+		tree := buildTree3300(t, []string{
+			"set security dynamic-address feed-server threat url /",
+			"set security dynamic-address feed-server threat hostname feeds.example.com",
+			"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+			"set security dynamic-address address-name bad-actors profile feed-name malware",
+		})
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatalf("CompileConfig should reject slash-only url even when hostname is set (url branch wins in resolveBaseURL)")
+		}
+		if !strings.Contains(err.Error(), "threat") {
+			t.Fatalf("error should name the feed-server, got: %v", err)
+		}
+	})
+
 	t.Run("commit accepts feed-server with url", func(t *testing.T) {
 		tree := buildTree3300(t, []string{
 			"set security dynamic-address feed-server threat url https://feeds.example/list.txt",

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -393,9 +393,12 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 // symptom one layer up, at the feed-server root rather than the binding.
 //
 // This gate replicates resolveBaseURL's emptiness condition directly on the
-// FeedServer config struct (URL == "" AND Hostname == "") rather than
-// importing pkg/feeds (pkg/config must not depend on pkg/feeds). Keep in sync
-// with resolveBaseURL.
+// FeedServer config struct (feedServerBaseURLEmpty) rather than importing
+// pkg/feeds (pkg/config must not depend on pkg/feeds). resolveBaseURL prefers
+// `url` and returns strings.TrimRight(url, "/") BEFORE it ever falls back to
+// `hostname`, so a slash-only `url` (e.g. `/`, `//`) trims to "" and the
+// server is skipped even when a hostname is also set — feedServerBaseURLEmpty
+// mirrors that branch order exactly. Keep in sync with resolveBaseURL.
 //
 // On the tolerant load / peer-sync paths the call site downgrades this to a
 // warning (opts.lenientDynamicAddressFeedRef, shared with the feed-name
@@ -424,19 +427,43 @@ func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
 		if fs == nil {
 			continue
 		}
-		// Mirror feeds.resolveBaseURL: empty iff no url AND no hostname.
-		if fs.URL == "" && fs.Hostname == "" {
+		if feedServerBaseURLEmpty(fs) {
 			display := fs.Name
 			if display == "" {
 				display = name
 			}
-			return fmt.Errorf("security dynamic-address feed-server %q has no "+
-				"url or hostname so it registers no feeds — any address-name "+
-				"bound to it silently matches nothing; set a url or hostname",
+			return fmt.Errorf("security dynamic-address feed-server %q resolves "+
+				"to an empty endpoint (no url or hostname, or a slash-only url) "+
+				"so it registers no feeds — any address-name bound to it "+
+				"silently matches nothing; set a valid url or hostname",
 				display)
 		}
 	}
 	return nil
+}
+
+// feedServerBaseURLEmpty reports whether feeds.resolveBaseURL would return ""
+// for this feed-server — i.e. feeds.Manager.Apply would SKIP it and register
+// none of its feeds. It mirrors resolveBaseURL (pkg/feeds/feeds.go)
+// BRANCH-FOR-BRANCH:
+//
+//	if URL != "":            empty iff strings.TrimRight(URL, "/") == ""
+//	else if Hostname != "":  never empty ("https://" + ... is always non-empty)
+//	else:                    empty
+//
+// The URL branch wins outright, so a slash-only `url` (e.g. `/`, `//`) trims to
+// "" and the server is skipped EVEN IF a hostname is also configured — the
+// fallback is never reached. resolveBaseURL performs no whitespace trimming
+// (only strings.TrimRight on "/"), so this does not either. pkg/config cannot
+// import pkg/feeds (import cycle); keep this in sync with resolveBaseURL.
+func feedServerBaseURLEmpty(fs *FeedServer) bool {
+	if fs.URL != "" {
+		return strings.TrimRight(fs.URL, "/") == ""
+	}
+	if fs.Hostname != "" {
+		return false
+	}
+	return true
 }
 
 // validateDynamicAddressFeedReferencesStrict hard-rejects a

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -379,6 +379,66 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateDynamicAddressFeedServerEndpointStrict hard-rejects a
+// `security dynamic-address feed-server <name>` that configures no endpoint —
+// neither `url` nor `hostname` (#3300 residual). feeds.Manager.Apply derives
+// each server's base URL via resolveBaseURL (feeds.go): explicit `url`, else
+// `https://<hostname>`, else the empty string — and an empty base URL makes
+// Apply SKIP the whole server (it registers NONE of its feeds, including any
+// nested feed-name entries). The endpoint-less server still compiles into
+// SecurityConfig.DynamicAddress.FeedServers, so its feed names are
+// syntactically "declared", but at runtime no feed exists: an address-name
+// bound to one resolves to an empty (match-nothing) address book and a
+// feed-backed deny policy silently denies nothing — the same #3300 fail-open
+// symptom one layer up, at the feed-server root rather than the binding.
+//
+// This gate replicates resolveBaseURL's emptiness condition directly on the
+// FeedServer config struct (URL == "" AND Hostname == "") rather than
+// importing pkg/feeds (pkg/config must not depend on pkg/feeds). Keep in sync
+// with resolveBaseURL.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientDynamicAddressFeedRef, shared with the feed-name
+// cross-reference gate) so an already-persisted or peer-synced config carrying
+// an endpoint-less server still boots — the runtime already drops the server
+// (registers no feed), so any bound address-name is fail-closed match-none
+// rather than bricking the load (#1960 / #3261 class). Commit / commit-check
+// stay strict. Mirrors validateLogProfileStreamReferencesStrict.
+func validateDynamicAddressFeedServerEndpointStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	servers := cfg.Security.DynamicAddress.FeedServers
+	if len(servers) == 0 {
+		return nil
+	}
+	// FeedServers is a map (unordered); sort keys so the first-error
+	// commit-check message is deterministic across runs.
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fs := servers[name]
+		if fs == nil {
+			continue
+		}
+		// Mirror feeds.resolveBaseURL: empty iff no url AND no hostname.
+		if fs.URL == "" && fs.Hostname == "" {
+			display := fs.Name
+			if display == "" {
+				display = name
+			}
+			return fmt.Errorf("security dynamic-address feed-server %q has no "+
+				"url or hostname so it registers no feeds — any address-name "+
+				"bound to it silently matches nothing; set a url or hostname",
+				display)
+		}
+	}
+	return nil
+}
+
 // validateDynamicAddressFeedReferencesStrict hard-rejects a
 // `security dynamic-address address-name <addr> profile feed-name <feed>`
 // binding whose `<feed>` resolves to no declared feed (#3300). The
@@ -397,13 +457,16 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 // feed-name does not resolve to a declared feed at commit; this gate
 // restores that behavior.
 //
-// The valid feed-name set mirrors exactly the keys feeds.Manager registers
-// (feeds.go Start): a feed-server with per-feed entries contributes each
-// FeedEntry.Name; a single-feed server contributes its FeedName, or the
-// server name itself when no explicit feed-name is set. The schema accepts
-// `profile feed-name` as a free-form value leaf (schema_security.go), so the
-// undefined-token gate (#2008/#2009) does NOT cover a typo here — only this
-// cross-reference does.
+// The valid feed-name set mirrors the keys feeds.Manager registers (feeds.go
+// Start): a feed-server with per-feed entries contributes each FeedEntry.Name;
+// a single-feed server contributes its FeedName, or the server name itself
+// when no explicit feed-name is set. This parity is EXACT because
+// validateDynamicAddressFeedServerEndpointStrict (run just before this gate)
+// rejects any feed-server with no url/hostname — the only servers
+// feeds.Manager.Apply silently SKIPS — so every server in the declared set is
+// one Apply would actually register. The schema accepts `profile feed-name` as
+// a free-form value leaf (schema_security.go), so the undefined-token gate
+// (#2008/#2009) does NOT cover a typo here — only this cross-reference does.
 //
 // On the tolerant load / peer-sync paths the call site downgrades this to a
 // warning (opts.lenientDynamicAddressFeedRef) so an already-persisted config

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -379,6 +379,98 @@ func validateLogProfileStreamReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// validateDynamicAddressFeedReferencesStrict hard-rejects a
+// `security dynamic-address address-name <addr> profile feed-name <feed>`
+// binding whose `<feed>` resolves to no declared feed (#3300). The
+// address-name→feed binding is recorded verbatim into
+// AddressBinding.FeedNames with no cross-reference against the configured
+// feed-servers (compileDynamicAddress in compiler_services.go), and at
+// runtime an unknown feed name contributes nothing: feeds.Manager.
+// SnapshotForBindings skips a feed it never registered and still publishes
+// a non-nil EMPTY prefix set for the binding (feeds.go SnapshotForBindings),
+// so the AF_XDP address book gets a book ID that matches nothing
+// (fail-closed). The runtime fail-closed posture is correct for "feed
+// declared but not yet fetched", but a TYPO in the feed-name is
+// indistinguishable from that and arms a silent match-none book: a
+// feed-backed deny policy referencing the dynamic-address denies nothing,
+// with no commit error. Junos rejects an address-name whose profile
+// feed-name does not resolve to a declared feed at commit; this gate
+// restores that behavior.
+//
+// The valid feed-name set mirrors exactly the keys feeds.Manager registers
+// (feeds.go Start): a feed-server with per-feed entries contributes each
+// FeedEntry.Name; a single-feed server contributes its FeedName, or the
+// server name itself when no explicit feed-name is set. The schema accepts
+// `profile feed-name` as a free-form value leaf (schema_security.go), so the
+// undefined-token gate (#2008/#2009) does NOT cover a typo here — only this
+// cross-reference does.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientDynamicAddressFeedRef) so an already-persisted config
+// (older binaries never validated the reference) or a peer-synced config
+// still boots — the runtime is already fail-closed (match-none) for an
+// unknown feed, so a leniently-loaded typo denies nothing rather than
+// bricking the load (#1960 / #3261 class). Commit / commit-check stay strict
+// so the operator's next edit fails loudly. Mirrors
+// validateLogProfileStreamReferencesStrict.
+func validateDynamicAddressFeedReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	da := cfg.Security.DynamicAddress
+	if len(da.AddressBindings) == 0 {
+		return nil
+	}
+
+	// Build the set of declared feed names exactly as feeds.Manager keys
+	// them (pkg/feeds Start): FeedEntries name each feed; a single-feed
+	// server keys on FeedName, falling back to the server name.
+	declared := make(map[string]bool)
+	for _, fs := range da.FeedServers {
+		if fs == nil {
+			continue
+		}
+		if len(fs.FeedEntries) > 0 {
+			for _, fe := range fs.FeedEntries {
+				declared[fe.Name] = true
+			}
+			continue
+		}
+		key := fs.FeedName
+		if key == "" {
+			key = fs.Name
+		}
+		if key != "" {
+			declared[key] = true
+		}
+	}
+
+	// AddressBindings is a map (unordered); sort keys so the first-error
+	// commit-check message is deterministic across runs.
+	names := make([]string, 0, len(da.AddressBindings))
+	for name := range da.AddressBindings {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		ab := da.AddressBindings[name]
+		if ab == nil {
+			continue
+		}
+		for _, fn := range ab.FeedNames {
+			if fn == "" || declared[fn] {
+				continue
+			}
+			return fmt.Errorf("security dynamic-address address-name %q "+
+				"profile references undefined feed-name %q (the binding would "+
+				"resolve to an empty address set — a feed-backed policy would "+
+				"silently match nothing; declare the feed under a "+
+				"dynamic-address feed-server or fix the feed-name)", ab.Name, fn)
+		}
+	}
+	return nil
+}
+
 // validateFlowServerTemplateReferencesStrict hard-rejects a per-flow-server
 // NetFlow v9 / IPFIX template reference (`version9 { template <name> }`,
 // `version9-template <name>`, `version-ipfix { template <name> }`, or


### PR DESCRIPTION
Closes #3300

## Problem

A `security dynamic-address address-name <addr> profile feed-name <feed>`
binding records `<feed>` verbatim into `AddressBinding.FeedNames`
(`compileDynamicAddress`, `compiler_services.go`) with **no** cross-reference
against the configured `feed-server`s. The `feed-name` schema leaf is a
free-form value (`schema_security.go`), so the #2008/#2009 undefined-token
gate does **not** catch a typo.

At runtime an unknown feed name resolves to a non-nil **empty** prefix set
(`feeds.Manager.SnapshotForBindings`, `feeds.go`), so the AF_XDP address book
gets a book ID that matches nothing. That fail-closed posture is correct for a
"declared but not yet fetched" feed, but a **typo** is indistinguishable from
it: a feed-backed deny policy referencing the dynamic-address then silently
denies nothing, with no commit error. Junos rejects such a reference at commit.

## Fix

`validateDynamicAddressFeedReferencesStrict` (`compiler_validate_strict.go`)
hard-rejects, at commit / commit-check, a binding whose `feed-name` resolves to
no declared feed — naming both the address-name and the unknown feed-name. The
valid feed-name set is computed exactly as `feeds.Manager` keys feeds: each
feed-server's per-feed entries, or the server name when a single-feed server
sets no explicit `feed-name`.

Strict/lenient split mirrors `validateLogProfileStreamReferencesStrict`: the
new `lenientDynamicAddressFeedRef` flag downgrades the error to a
`cfg.Warnings` entry on the tolerant load / peer-sync paths
(`CompileConfigLenient` / `CompileConfigForNodeLenient`) so an
already-persisted or peer-synced config still boots (#1960 / #3261
fail-closed-on-load doctrine) — the runtime stays fail-closed (match-none) for
the unknown feed, so a leniently-loaded typo denies nothing rather than
bricking. Commit / commit-check stay strict.

## Scope note

The #2008/#2009 undefined-token gate does **not** already cover this case:
`profile feed-name` is a free-form value leaf in `setSchema`, so a typo'd value
is accepted by the token gate. This cross-reference is the genuinely-uncovered
gap.

## Validation

- `go build ./...` clean; `go test ./pkg/config/... ./pkg/feeds/...` green.
- New `TestValidateDynamicAddressFeedReferences`: the typo (issue's `malwrae`)
  is rejected naming the address-name + feed; feed-entry / single-feed /
  server-name references compile; the lenient path records a warning.
- Fail-on-revert confirmed (copy-aside/restore): neutering the validator turns
  the strict reject and the lenient downgrade RED.
- Documented in `docs/config-schema.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi