### PR TITLE
userspace NAT: thread dynamic-address feed overlay into NAT builders (#3303)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,18 @@
+## 2026-06-27 — #3303 thread feed overlay into NAT snapshot builders
+
+- **Timestamp**: 2026-06-27
+- **Action**: NAT `match {source,destination}-address-name` resolved
+  static-only because the snapshot builder never passed feedOverlay to the
+  source/destination NAT builders. Added resolveNATAddressNamePrefixes
+  (static book ∪ feed overlay), threaded feedOverlay through the append
+  helpers + buildSourceNATSnapshotsWithFeeds /
+  buildDestinationNATSnapshotsWithFeeds, wired them in builder.go, fixed the
+  docs/feature-gaps.md drift, and added the #3303 fail-on-revert test.
+- **File(s)**: pkg/dataplane/userspace/nat.go,
+  pkg/dataplane/userspace/builder.go,
+  pkg/dataplane/userspace/nat_feed_overlay_3303_test.go,
+  docs/feature-gaps.md
+
 ## 2026-06-27 — #3276 DDNS operator force-now / check-now verb
 
 - **Timestamp**: 2026-06-27

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -137,7 +137,13 @@ are ENFORCED: a policy/NAT rule referencing a feed-backed `address-name` now
 has the live feed prefixes overlaid into the userspace dataplane's address
 book (the `apply_snapshot` the AF_XDP helper enforces), and a feed refresh
 republishes the snapshot. Previously the prefixes were fetched and shown but
-never reached the forwarding path.
+never reached the forwarding path. The NAT side was completed in #3303: the
+snapshot builder now threads the feed overlay into the source/destination NAT
+builders, so a NAT rule scoped to a feed-backed `match
+source-address-name` / `match destination-address-name` resolves the live feed
+prefixes the same way the policy path does (a DIRECT name reference; an
+address-SET whose member is feed-backed is the separate recursive-overlay gap
+tracked in #3294).
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -79,9 +79,13 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 		Flow:                  buildFlowSnapshot(cfg),
 		DefaultPolicy:         policyActionString(cfg.Security.DefaultPolicy),
 		Policies:              policies,
-		SourceNAT:             buildSourceNATSnapshots(cfg, natCounterIDs),
+		// #3303: thread feedOverlay into the NAT builders so a NAT rule scoped
+		// to a feed-backed `match {source,destination}-address-name` resolves the
+		// live feed prefixes, exactly as the policy/address-book path does. Static
+		// NAT has no address-name match, so it needs no overlay.
+		SourceNAT:             buildSourceNATSnapshotsWithFeeds(cfg, natCounterIDs, feedOverlay),
 		StaticNAT:             buildStaticNATSnapshots(cfg, natCounterIDs),
-		DestinationNAT:        buildDestinationNATSnapshots(cfg, natCounterIDs),
+		DestinationNAT:        buildDestinationNATSnapshotsWithFeeds(cfg, natCounterIDs, feedOverlay),
 		NAT64:                 buildNAT64Snapshots(cfg),
 		Nptv6:                 buildNptv6Snapshots(cfg),
 		Screens:               buildScreenSnapshots(cfg),

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -24,11 +24,42 @@ func natCounterID(ids map[string]uint32, natType, ruleSet, rule string) uint32 {
 	return ids[dataplane.NATCounterKey(natType, ruleSet, rule)]
 }
 
+// resolveNATAddressNamePrefixes resolves a NAT `match {source,destination}-
+// address-name` reference into concrete prefixes, unioning the static global
+// address-book expansion (resolveUserspaceAddressBookEntry) with the live
+// dynamic-address feed overlay (#2049 / #3303). feedOverlay maps a
+// `security dynamic-address address-name ... profile <feed>` binding to its
+// live feed-backed CIDR strings (resolved by the daemon from
+// feeds.Manager.SnapshotForBindings).
+//
+// Before #3303 the NAT snapshot builders never received feedOverlay, so a NAT
+// rule scoped to a feed-backed address-name resolved STATIC-ONLY and matched
+// nothing on live feed content — contradicting the docs claim that feeds are
+// enforced via "policy/NAT address-name bindings". This helper mirrors the
+// policy path (buildAddressBookTableWithFeeds), which merges feedOverlay[name]
+// into the name's address-book bucket.
+//
+// The recursive case — an address-SET whose member is feed-backed — remains the
+// known #3294 gap (the static expander does not pull feed prefixes for nested
+// set members). A DIRECT `match ...-address-name <feed-name>` reference is fully
+// resolved here, which is the #3303 NAT-side gap.
+func resolveNATAddressNamePrefixes(cfg *config.Config, feedOverlay map[string][]string, name string) []string {
+	var out []string
+	if values, ok := resolveUserspaceAddressBookEntry(cfg, name); ok {
+		out = append(out, values...)
+	}
+	if feeds := feedOverlay[name]; len(feeds) > 0 {
+		out = append(out, feeds...)
+	}
+	return out
+}
+
 // appendNATSourceAddressName resolves a NAT rule's `match source-address-name
 // <book-entry>` into concrete source prefixes and appends them to the rule's
-// source list (#2416). It reuses resolveUserspaceAddressBookEntry — the same
-// global-address-book expander the security-policy snapshot path uses — so a
-// name-scoped NAT rule carries the entry's prefixes into the #2394 source
+// source list (#2416). It reuses resolveNATAddressNamePrefixes — the same
+// static-book expander the security-policy snapshot path uses, now unioned with
+// the dynamic-address feed overlay (#3303) — so a name-scoped NAT rule carries
+// the entry's prefixes (static AND feed-backed) into the #2394 source
 // constraint instead of publishing an empty (match-any) source list.
 //
 // Fail-closed on an unknown / unresolvable name: the raw token is appended so
@@ -37,11 +68,11 @@ func natCounterID(ids map[string]uint32, natType, ruleSet, rule string) uint32 {
 // prefix — the rule then matches NOTHING rather than collapsing to match-any.
 // This mirrors the policy path's behavior for an unresolved address reference
 // and is backstopped at commit by validateNATSourceAddressNameReferencesStrict.
-func appendNATSourceAddressName(cfg *config.Config, sourceAddrs []string, name string) []string {
+func appendNATSourceAddressName(cfg *config.Config, feedOverlay map[string][]string, sourceAddrs []string, name string) []string {
 	if name == "" {
 		return sourceAddrs
 	}
-	if values, ok := resolveUserspaceAddressBookEntry(cfg, name); ok && len(values) > 0 {
+	if values := resolveNATAddressNamePrefixes(cfg, feedOverlay, name); len(values) > 0 {
 		return append(sourceAddrs, values...)
 	}
 	// Unknown / empty book entry: keep the constraint non-empty but
@@ -52,10 +83,11 @@ func appendNATSourceAddressName(cfg *config.Config, sourceAddrs []string, name s
 // appendNATDestinationAddressName resolves a NAT rule's `match
 // destination-address-name <book-entry>` into concrete destination prefixes and
 // appends them to the rule's destination list (#3229). It is the destination
-// twin of appendNATSourceAddressName and shares the same address-book expander
-// (resolveUserspaceAddressBookEntry) the security-policy and source-address-name
-// paths use, so a name-scoped destination matches the same prefixes a literal
-// `match destination-address` would.
+// twin of appendNATSourceAddressName and shares the same expander
+// (resolveNATAddressNamePrefixes) the security-policy and source-address-name
+// paths use — static address book unioned with the dynamic-address feed overlay
+// (#3303) — so a name-scoped destination matches the same prefixes a literal
+// `match destination-address` would, including feed-backed members.
 //
 // Fail-closed on an unknown / unresolvable name: the raw token is appended so
 // the destination list stays NON-EMPTY (the rule does not collapse to no
@@ -64,11 +96,11 @@ func appendNATSourceAddressName(cfg *config.Config, sourceAddrs []string, name s
 // than broadening. Backstopped at commit by
 // validateNATSourceAddressNameReferencesStrict, which also gates
 // destination-address-name.
-func appendNATDestinationAddressName(cfg *config.Config, destAddrs []string, name string) []string {
+func appendNATDestinationAddressName(cfg *config.Config, feedOverlay map[string][]string, destAddrs []string, name string) []string {
 	if name == "" {
 		return destAddrs
 	}
-	if values, ok := resolveUserspaceAddressBookEntry(cfg, name); ok && len(values) > 0 {
+	if values := resolveNATAddressNamePrefixes(cfg, feedOverlay, name); len(values) > 0 {
 		return append(destAddrs, values...)
 	}
 	// Unknown / empty book entry: keep the list non-empty but unmatchable
@@ -76,7 +108,16 @@ func appendNATDestinationAddressName(cfg *config.Config, destAddrs []string, nam
 	return append(destAddrs, name)
 }
 
+// buildSourceNATSnapshots is the static-only convenience wrapper retained for
+// callers that carry no dynamic-address feed overlay (tests, legacy paths). The
+// production snapshot path uses buildSourceNATSnapshotsWithFeeds so feed-backed
+// `match {source,destination}-address-name` references resolve their live feed
+// prefixes (#3303).
 func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32) []SourceNATRuleSnapshot {
+	return buildSourceNATSnapshotsWithFeeds(cfg, natCounterIDs, nil)
+}
+
+func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[string]uint32, feedOverlay map[string][]string) []SourceNATRuleSnapshot {
 	if cfg == nil || len(cfg.Security.NAT.Source) == 0 {
 		return nil
 	}
@@ -96,7 +137,7 @@ func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 			// #2416: resolve `match source-address-name` for SNAT too — same
 			// builder gap as DNAT (the source list only carried literal
 			// prefixes). See appendNATSourceAddressName.
-			sourceAddrs = appendNATSourceAddressName(cfg, sourceAddrs, rule.Match.SourceAddressName)
+			sourceAddrs = appendNATSourceAddressName(cfg, feedOverlay, sourceAddrs, rule.Match.SourceAddressName)
 			destAddrs := append([]string(nil), rule.Match.DestinationAddresses...)
 			if len(destAddrs) == 0 && rule.Match.DestinationAddress != "" {
 				destAddrs = append(destAddrs, rule.Match.DestinationAddress)
@@ -105,7 +146,7 @@ func buildSourceNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32
 			// source path resolves source-address-name — without this a
 			// name-scoped destination constraint published an EMPTY list =
 			// match-any destination (fail-open).
-			destAddrs = appendNATDestinationAddressName(cfg, destAddrs, rule.Match.DestinationAddressName)
+			destAddrs = appendNATDestinationAddressName(cfg, feedOverlay, destAddrs, rule.Match.DestinationAddressName)
 			var poolAddresses []string
 			var portLow, portHigh uint16
 			var persistentNAT bool
@@ -325,7 +366,14 @@ func dnatDestinationParts(raw string) (base, prefix string, ok bool) {
 	return ipNet.IP.String(), ipNet.String(), true
 }
 
+// buildDestinationNATSnapshots is the static-only convenience wrapper retained
+// for callers without a dynamic-address feed overlay (tests, legacy paths). The
+// production snapshot path uses buildDestinationNATSnapshotsWithFeeds (#3303).
 func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]uint32) []DestinationNATRuleSnapshot {
+	return buildDestinationNATSnapshotsWithFeeds(cfg, natCounterIDs, nil)
+}
+
+func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[string]uint32, feedOverlay map[string][]string) []DestinationNATRuleSnapshot {
 	if cfg == nil || cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) == 0 {
 		return nil
 	}
@@ -369,7 +417,7 @@ func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]u
 			// matches NOTHING (fail-closed). The commit-time strict gate
 			// (validateNATSourceAddressNameReferencesStrict) makes the typo
 			// operator-visible.
-			destAddrs = appendNATDestinationAddressName(cfg, destAddrs, rule.Match.DestinationAddressName)
+			destAddrs = appendNATDestinationAddressName(cfg, feedOverlay, destAddrs, rule.Match.DestinationAddressName)
 			if len(destAddrs) == 0 {
 				continue
 			}
@@ -399,7 +447,7 @@ func buildDestinationNATSnapshots(cfg *config.Config, natCounterIDs map[string]u
 			// (fail-closed) instead of collapsing back to match-any. A commit-
 			// time strict gate (validateNATSourceAddressNameReferencesStrict)
 			// makes the typo operator-visible; this is the dataplane backstop.
-			sourceAddrs = appendNATSourceAddressName(cfg, sourceAddrs, rule.Match.SourceAddressName)
+			sourceAddrs = appendNATSourceAddressName(cfg, feedOverlay, sourceAddrs, rule.Match.SourceAddressName)
 
 			// Resolve application match to protocol+ports if specified.
 			type appTerm struct {

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -35,9 +35,18 @@ func natCounterID(ids map[string]uint32, natType, ruleSet, rule string) uint32 {
 // Before #3303 the NAT snapshot builders never received feedOverlay, so a NAT
 // rule scoped to a feed-backed address-name resolved STATIC-ONLY and matched
 // nothing on live feed content — contradicting the docs claim that feeds are
-// enforced via "policy/NAT address-name bindings". This helper mirrors the
-// policy path (buildAddressBookTableWithFeeds), which merges feedOverlay[name]
-// into the name's address-book bucket.
+// enforced via "policy/NAT address-name bindings". This brings NAT into line
+// with the policy path (buildAddressBookTableWithFeeds), which also merges
+// feedOverlay[name] into a name's content.
+//
+// It is NOT a byte-for-byte mirror of that path: the policy builder
+// family-splits the feed CIDRs and re-sorts/dedups across the static+feed union
+// (it must, to assign a content-hash ID), whereas this helper appends the feed
+// strings to the prefix list directly. That difference is functionally inert —
+// feeds.Manager.SnapshotForBindings already returns the overlay CIDRs sorted
+// and deduped, and the NAT consumer treats the list as an unordered prefix set
+// (duplicates contribute no extra table entry, ordering is irrelevant) — so no
+// re-dedup or family-split is needed here.
 //
 // The recursive case — an address-SET whose member is feed-backed — remains the
 // known #3294 gap (the static expander does not pull feed prefixes for nested

--- a/pkg/dataplane/userspace/nat_feed_overlay_3303_test.go
+++ b/pkg/dataplane/userspace/nat_feed_overlay_3303_test.go
@@ -146,6 +146,51 @@ func TestDNATDestinationAddressNameResolvesFeedOverlay(t *testing.T) {
 	}
 }
 
+// TestDNATSourceAddressNameResolvesFeedOverlay: a DNAT rule scoped to a
+// feed-backed `match source-address-name` carries the #2394 source constraint;
+// the feed prefixes must resolve into the snapshot's SourceAddresses (otherwise
+// the destination translation the operator scoped to a named feed set fires for
+// every source = fail-open). This completes the source+dest feed coverage
+// symmetry alongside TestDNATDestinationAddressNameResolvesFeedOverlay. With the
+// overlay un-threaded the name resolves to the raw token (fail-closed) instead.
+func TestDNATSourceAddressNameResolvesFeedOverlay(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name: "feed-src-dnat",
+					Match: config.NATMatch{
+						SourceAddressName:  "bad-feed",
+						DestinationAddress: "198.51.100.9",
+						Protocol:           "tcp",
+						DestinationPort:    443,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+	overlay := map[string][]string{"bad-feed": {"203.0.113.0/24", "192.0.2.7/32"}}
+
+	snap := natFeedSnapHelper(t, cfg, overlay)
+	var got []string
+	for _, s := range snap.DestinationNAT {
+		if s.Name == "feed-src-dnat" {
+			got = s.SourceAddresses
+			break
+		}
+	}
+	if !contains(got, "203.0.113.0/24") || !contains(got, "192.0.2.7/32") {
+		t.Fatalf("DNAT source-address-name must resolve feed prefixes, got %v "+
+			"(missing => feedOverlay not threaded into DNAT builder #3303)", got)
+	}
+	if contains(got, "bad-feed") {
+		t.Fatalf("DNAT source list must not carry the raw feed name token (fail-closed fallback => overlay not threaded), got %v", got)
+	}
+}
+
 // TestNATAddressNameUnionsStaticBookAndFeedOverlay: a name that exists BOTH as a
 // static book entry and as a feed binding resolves to the union, mirroring the
 // policy address-book bucket merge. This guards against a revert that resolves

--- a/pkg/dataplane/userspace/nat_feed_overlay_3303_test.go
+++ b/pkg/dataplane/userspace/nat_feed_overlay_3303_test.go
@@ -1,0 +1,179 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3303: NAT `match {source,destination}-address-name` references must resolve
+// the dynamic-address feed overlay (#2049), exactly as the policy/address-book
+// path does. Before the fix the snapshot builder threaded feedOverlay into the
+// policy and address-book builders but called the NAT builders with NO overlay,
+// so a NAT rule scoped to a feed-backed address-name resolved STATIC-ONLY and
+// matched nothing on live feed content — contradicting docs/feature-gaps.md's
+// claim that feeds are enforced via "policy/NAT address-name bindings".
+//
+// These are the fail-on-revert pins. They drive the FULL public snapshot path
+// (buildSnapshotWithSchedulerState) with a feed overlay whose feed-backed name
+// is ABSENT from the static address book — so the ONLY way the feed prefixes
+// reach the NAT source/destination lists is the overlay threading. Reverting
+// nat.go + builder.go to the pre-#3303 state makes every assertion below RED:
+//   - SNAT source-address-name falls back to the raw "bad-feed" token
+//     (fail-closed, no feed prefix),
+//   - SNAT destination-address-name likewise,
+//   - DNAT destination-address-name resolves nothing → the rule installs no
+//     table row at all.
+
+func natFeedSnapHelper(t *testing.T, cfg *config.Config, overlay map[string][]string) *ConfigSnapshot {
+	t.Helper()
+	snap, err := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 1, 0, nil, nil, overlay)
+	if err != nil {
+		t.Fatalf("buildSnapshotWithSchedulerState: %v", err)
+	}
+	if snap == nil {
+		t.Fatal("nil snapshot")
+	}
+	return snap
+}
+
+func snatSourceAddrs(snap *ConfigSnapshot, name string) []string {
+	for _, s := range snap.SourceNAT {
+		if s.Name == name {
+			return s.SourceAddresses
+		}
+	}
+	return nil
+}
+
+func snatDestAddrs(snap *ConfigSnapshot, name string) []string {
+	for _, s := range snap.SourceNAT {
+		if s.Name == name {
+			return s.DestinationAddresses
+		}
+	}
+	return nil
+}
+
+// TestSNATSourceAddressNameResolvesFeedOverlay: a source NAT rule scoped to a
+// feed-backed `match source-address-name` must carry the live feed prefixes in
+// its source constraint. The feed-backed name is NOT in any static book, so the
+// raw-token fail-closed fallback is what a revert produces.
+func TestSNATSourceAddressNameResolvesFeedOverlay(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+			{
+				Name:  "feed-scoped",
+				Match: config.NATMatch{SourceAddressName: "bad-feed"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			},
+		}},
+	}
+	overlay := map[string][]string{"bad-feed": {"198.51.100.0/24", "203.0.113.7/32"}}
+
+	snap := natFeedSnapHelper(t, cfg, overlay)
+	got := snatSourceAddrs(snap, "feed-scoped")
+	if !contains(got, "198.51.100.0/24") || !contains(got, "203.0.113.7/32") {
+		t.Fatalf("SNAT source-address-name must resolve feed prefixes, got %v "+
+			"(missing => feedOverlay not threaded into NAT builder #3303)", got)
+	}
+	if contains(got, "bad-feed") {
+		t.Fatalf("SNAT source list must not carry the raw feed name token (fail-closed fallback => overlay not threaded), got %v", got)
+	}
+}
+
+// TestSNATDestinationAddressNameResolvesFeedOverlay: the SNAT builder also
+// carries the destination constraint; a feed-backed destination-address-name
+// must resolve there too.
+func TestSNATDestinationAddressNameResolvesFeedOverlay(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+			{
+				Name:  "feed-dst",
+				Match: config.NATMatch{DestinationAddressName: "bad-feed"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			},
+		}},
+	}
+	overlay := map[string][]string{"bad-feed": {"198.51.100.0/24"}}
+
+	snap := natFeedSnapHelper(t, cfg, overlay)
+	got := snatDestAddrs(snap, "feed-dst")
+	if !contains(got, "198.51.100.0/24") {
+		t.Fatalf("SNAT destination-address-name must resolve feed prefixes, got %v #3303", got)
+	}
+	if contains(got, "bad-feed") {
+		t.Fatalf("SNAT destination list must not carry the raw feed name token, got %v", got)
+	}
+}
+
+// TestDNATDestinationAddressNameResolvesFeedOverlay: a DNAT rule scoped to a
+// feed-backed destination-address-name must install one table entry per feed
+// host. With the overlay un-threaded the name resolves to nothing → the rule is
+// continue-skipped → NO snapshot row at all.
+func TestDNATDestinationAddressNameResolvesFeedOverlay(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+		RuleSets: []*config.NATRuleSet{
+			{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name: "feed-dnat",
+					Match: config.NATMatch{
+						DestinationAddressName: "bad-feed",
+						Protocol:               "tcp",
+						DestinationPort:        443,
+					},
+					Then: config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+	}
+	overlay := map[string][]string{"bad-feed": {"198.51.100.42/32", "198.51.100.43/32"}}
+
+	snap := natFeedSnapHelper(t, cfg, overlay)
+	var got []string
+	for _, s := range snap.DestinationNAT {
+		if s.Name == "feed-dnat" {
+			got = append(got, s.DestinationAddress)
+		}
+	}
+	if !contains(got, "198.51.100.42") || !contains(got, "198.51.100.43") {
+		t.Fatalf("DNAT destination-address-name must install one entry per feed host, got %v "+
+			"(empty => feedOverlay not threaded => rule dropped #3303)", got)
+	}
+}
+
+// TestNATAddressNameUnionsStaticBookAndFeedOverlay: a name that exists BOTH as a
+// static book entry and as a feed binding resolves to the union, mirroring the
+// policy address-book bucket merge. This guards against a revert that resolves
+// only one source.
+func TestNATAddressNameUnionsStaticBookAndFeedOverlay(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = &config.AddressBook{
+		Addresses: map[string]*config.Address{
+			"mixed": {Name: "mixed", Value: "10.10.0.0/16"},
+		},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+			{
+				Name:  "union",
+				Match: config.NATMatch{SourceAddressName: "mixed"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			},
+		}},
+	}
+	overlay := map[string][]string{"mixed": {"198.51.100.0/24"}}
+
+	snap := natFeedSnapHelper(t, cfg, overlay)
+	got := snatSourceAddrs(snap, "union")
+	if !contains(got, "10.10.0.0/16") {
+		t.Fatalf("union must keep the static book prefix, got %v", got)
+	}
+	if !contains(got, "198.51.100.0/24") {
+		t.Fatalf("union must add the feed prefix, got %v #3303", got)
+	}
+}


### PR DESCRIPTION
Closes #3303

## Problem

`docs/feature-gaps.md` claims dynamic-address feeds are ENFORCED through
"policy/NAT address-name bindings" (#2049), but the NAT half was never wired.
The snapshot builder threaded `feedOverlay` into the policy and address-book
builders yet called `buildSourceNATSnapshots` / `buildDestinationNATSnapshots`
with **no** overlay. The NAT name resolvers consulted only
`resolveUserspaceAddressBookEntry` (STATIC book). A NAT rule scoped to a
feed-backed `match source-address-name` / `match destination-address-name`
resolved static-only and matched nothing on live feed content — the SNAT did
not fire, and a feed-scoped DNAT failed closed and dropped the rule entirely.
Fail-closed but feature-incomplete and hard to diagnose given the docs claim.

## Decision: implement (thread the overlay), not doc-correct

Feed-driven NAT address-name scoping is the intended behavior — the policy path
already supports it via the same address-name machinery, the docs promise it,
and only the rule's MATCH set needs the feed prefixes (the translation pool is
unaffected, so there is no concrete-pool blocker forcing static-only). This
makes NAT consistent with policy rather than narrowing a documented capability.

## Fix

- Add `resolveNATAddressNamePrefixes` — unions the static address-book
  expansion with the live feed overlay (`feedOverlay[name]`), mirroring how
  `buildAddressBookTableWithFeeds` merges `feedOverlay[name]` into a name's
  bucket.
- Thread `feedOverlay` through both append helpers and new
  `buildSourceNATSnapshotsWithFeeds` / `buildDestinationNATSnapshotsWithFeeds`
  variants (the two-arg builders stay as static-only wrappers, so existing
  callers/tests are untouched), and call the WithFeeds variants from
  `builder.go`.
- The fail-closed raw-token fallback for a genuinely unknown name is preserved.
  The recursive case (an address-SET whose member is feed-backed) stays the
  known #3294 gap; a direct address-name reference is fully resolved here.
- `docs/feature-gaps.md` updated to record the NAT completion + #3294 caveat.

## Validation

- `go build ./...` clean; `go test ./pkg/dataplane/... ./pkg/config/...
  ./pkg/feeds/...` all pass.
- `nat_feed_overlay_3303_test.go` drives the full public snapshot path with a
  feed-backed name absent from the static book. **RED-on-revert**: restoring
  `nat.go` + `builder.go` to `origin/master` turns all four assertions RED
  (SNAT source / SNAT destination fall back to the raw token; DNAT installs no
  row; the static∪feed union loses the feed prefix); GREEN with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi