### PR TITLE
config: make the ICMP-fragment screen reachable from config (#3316)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22695,3 +22695,15 @@ top.
   pkg/config/schema_security.go, pkg/dataplane/userspace/screens.go,
   pkg/config/parser_security_test.go, pkg/dataplane/userspace/manager_test.go,
   docs/feature-gaps.md
+
+## 2026-06-27 — #3324 quad fold: correct overstated typo-rejection comment
+- **Timestamp**: 2026-06-27
+- **Action**: Fold the one cosmetic MINOR from the #3324 quad (Codex MEDIUM +
+  SMR). The original commit/PR framed the new `fragment` schema leaf as adding
+  commit-time typo validation; that is inaccurate. `fragment` is a childless
+  ValueAny node and walkSchemaNode ignores unknown keywords (schema_walk.go
+  242-243), so `icmp framgent` is NOT rejected by this PR. Added a precise
+  code comment stating the leaf only exposes `fragment` for tab-completion and
+  routes `icmp fragment` to ICMPScreen.Fragment; unknown-screen-leaf rejection
+  is the separate #3318. Comment-only, no behavior change.
+- **File(s)**: pkg/config/schema_security.go

--- a/_Log.md
+++ b/_Log.md
@@ -22680,3 +22680,18 @@ top.
     pkg/dataplane/userspace/manager_ha.go, pkg/daemon/daemon_ha_userspace.go,
     pkg/dataplane/types.go, pkg/cluster/sync_protocol.go,
     docs/userspace-dataplane-gaps.md, plus tests + fixture.
+
+## 2026-06-27 — #3316 ICMP-fragment screen config plumbing
+- **Timestamp**: 2026-06-27
+- **Action**: Plumb config→snapshot path for the ICMP-fragment screen. The
+  Rust dataplane (screen/stateless.rs check_icmp_fragment) already dropped
+  fragmented ICMP/ICMPv6 when icmp_fragment was set, but the screen was
+  unreachable from config (no typed field, no compiler case, open schema
+  subtree, snapshot never published). Added ICMPScreen.Fragment, the
+  `icmp fragment` compiler case, the schema leaf, and the snapshot publish +
+  emit-gate inclusion. Added RED-on-revert Go tests (config compile + snapshot
+  publish) and updated docs/feature-gaps.md (12 screen checks).
+- **File(s)**: pkg/config/types_security.go, pkg/config/compiler_security.go,
+  pkg/config/schema_security.go, pkg/dataplane/userspace/screens.go,
+  pkg/config/parser_security_test.go, pkg/dataplane/userspace/manager_test.go,
+  docs/feature-gaps.md

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -237,7 +237,7 @@ xpf has SNAT (interface + pool, address-persistent, source-nat off bypass), DNAT
 
 ## 9. Screen/IDS Enhancements
 
-xpf implements 11 screen checks (land, syn-flood, ping-death, teardrop, rate-limiting, ip-sweep, winnuke, syn-frag, syn-fin, no-flag, fin-no-ack) plus per-IP session limiting. These are additional vSRX screen options.
+xpf implements 12 screen checks (land, syn-flood, ping-death, icmp-fragment, teardrop, rate-limiting, ip-sweep, winnuke, syn-frag, syn-fin, no-flag, fin-no-ack) plus per-IP session limiting. These are additional vSRX screen options.
 
 | Feature | Junos Config Path | Description | Priority | Status |
 |---------|-------------------|-------------|----------|--------|
@@ -247,6 +247,7 @@ xpf implements 11 screen checks (land, syn-flood, ping-death, teardrop, rate-lim
 | **UDP Port Scan Detection** | `security screen ids-option ... udp port-scan threshold N` | Same as TCP port scan but for UDP | Medium | Missing |
 | **UDP Sweep Detection** | `security screen ids-option ... udp udp-sweep threshold N` | Detect UDP sweeps (same port, many destinations) | Low | Missing |
 | **TCP Sweep Detection** | `security screen ids-option ... tcp tcp-sweep threshold N` | Detect TCP sweeps (same port, many destinations) | Low | Missing |
+| **ICMP Fragment** | `security screen ids-option ... icmp fragment` | Drop any fragmented ICMP/ICMPv6 packet (a fragmentation-based attack signature). | Medium | **Done** (#3316) -- the userspace dataplane (`screen/stateless.rs check_icmp_fragment`) already dropped fragmented ICMP/ICMPv6 when `icmp_fragment` was set, but the Go config→snapshot path was missing (`ICMPScreen` had no field, `compileScreen` ignored the leaf, the schema subtree was open, and `buildScreenSnapshots` never published `ICMPFragment`), so the check was unreachable from config. #3316 adds `ICMPScreen.Fragment`, the `icmp fragment` compiler case, the schema leaf, and the snapshot publish + emit-gate inclusion. |
 | **IP Block Fragment** | `security screen ids-option ... ip block-frag` | Block all IP fragments unconditionally | Low | Partial (fragment checks exist but not unconditional block option) |
 | **IPv6 Extension Header Filtering** | `security screen ids-option ... ip ipv6-extension-header ...` | Filter/block specific IPv6 extension headers (hop-by-hop, routing, destination, fragment, mobility, no-next) | Medium | Missing |
 

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -693,6 +693,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				switch opt.Name() {
 				case "ping-death":
 					profile.ICMP.PingDeath = true
+				case "fragment":
+					profile.ICMP.Fragment = true
 				case "flood":
 					if len(opt.Keys) >= 3 {
 						if v, err := strconv.Atoi(opt.Keys[2]); err == nil {

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1337,7 +1337,7 @@ func TestDNATWithProtocol(t *testing.T) {
 
 func TestScreenCompilation(t *testing.T) {
 	tree := &ConfigTree{}
-	setCommands := []string{"set security screen ids-option wan-screen tcp syn-flood alarm-threshold 1000", "set security screen ids-option wan-screen tcp syn-flood attack-threshold 2000", "set security screen ids-option wan-screen tcp land", "set security screen ids-option wan-screen tcp syn-fin", "set security screen ids-option wan-screen tcp no-flag", "set security screen ids-option wan-screen tcp winnuke", "set security screen ids-option wan-screen tcp fin-no-ack", "set security screen ids-option wan-screen icmp ping-death", "set security screen ids-option wan-screen icmp flood threshold 500", "set security screen ids-option wan-screen ip source-route-option", "set security screen ids-option wan-screen ip tear-drop", "set security screen ids-option wan-screen udp flood threshold 1000", "set security screen ids-option wan-screen tcp port-scan threshold 5000", "set security screen ids-option wan-screen ip ip-sweep threshold 3000"}
+	setCommands := []string{"set security screen ids-option wan-screen tcp syn-flood alarm-threshold 1000", "set security screen ids-option wan-screen tcp syn-flood attack-threshold 2000", "set security screen ids-option wan-screen tcp land", "set security screen ids-option wan-screen tcp syn-fin", "set security screen ids-option wan-screen tcp no-flag", "set security screen ids-option wan-screen tcp winnuke", "set security screen ids-option wan-screen tcp fin-no-ack", "set security screen ids-option wan-screen icmp ping-death", "set security screen ids-option wan-screen icmp fragment", "set security screen ids-option wan-screen icmp flood threshold 500", "set security screen ids-option wan-screen ip source-route-option", "set security screen ids-option wan-screen ip tear-drop", "set security screen ids-option wan-screen udp flood threshold 1000", "set security screen ids-option wan-screen tcp port-scan threshold 5000", "set security screen ids-option wan-screen ip ip-sweep threshold 3000"}
 	for _, cmd := range setCommands {
 		path, err := ParseSetCommand(cmd)
 		if err != nil {
@@ -1375,6 +1375,14 @@ func TestScreenCompilation(t *testing.T) {
 	}
 	if !screen.ICMP.PingDeath {
 		t.Error("expected icmp ping-death")
+	}
+	// #3316: the icmp-fragment screen must compile from `icmp fragment`. The
+	// Rust dataplane (screen/stateless.rs check_icmp_fragment) already drops
+	// fragmented ICMP/ICMPv6, but the typed field/compiler path was missing,
+	// so the screen was unreachable from config. RED if compileScreen drops
+	// the `fragment` case.
+	if !screen.ICMP.Fragment {
+		t.Error("expected icmp fragment")
 	}
 	if screen.ICMP.FloodThreshold != 500 {
 		t.Errorf("icmp flood threshold: got %d, want 500", screen.ICMP.FloodThreshold)
@@ -4985,8 +4993,8 @@ func TestFlexibleMatchRangeDefaultMaskNonStandardBitLength(t *testing.T) {
 	}{
 		{24, "0x010203", 0x00FFFFFF},
 		{12, "0x0abc", 0x00000FFF},
-		{8, "0x11", 0xFF},          // unchanged from #3077
-		{16, "0x0800", 0xFFFF},     // unchanged from #3077
+		{8, "0x11", 0xFF},              // unchanged from #3077
+		{16, "0x0800", 0xFFFF},         // unchanged from #3077
 		{32, "0x12345678", 0xFFFFFFFF}, // unchanged from #3077
 	}
 	for _, tc := range cases {

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -107,6 +107,12 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 	"screen": {desc: "Screen options", children: map[string]*schemaNode{
 		"ids-option": {desc: "Screen profile name", args: 1, valueHint: ValueHintScreenProfile, placeholder: "<screen-name>", children: map[string]*schemaNode{
 			"icmp": {desc: "ICMP screening", children: map[string]*schemaNode{
+				// #3316: exposes `fragment` for tab-completion and routes
+				// `icmp fragment` to ICMPScreen.Fragment. This is NOT typo
+				// rejection — `fragment` is a childless ValueAny node, and
+				// walkSchemaNode ignores unknown keywords (the gate is
+				// opt-in; schema_walk.go), so `icmp framgent` is not caught
+				// here. Unknown-screen-leaf rejection is the separate #3318.
 				"fragment": {desc: "Drop fragmented ICMP/ICMPv6 packets", children: nil},
 				// ping-death, flood -> leaf
 			}},

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -106,7 +106,10 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 	}},
 	"screen": {desc: "Screen options", children: map[string]*schemaNode{
 		"ids-option": {desc: "Screen profile name", args: 1, valueHint: ValueHintScreenProfile, placeholder: "<screen-name>", children: map[string]*schemaNode{
-			"icmp": {desc: "ICMP screening", children: nil},
+			"icmp": {desc: "ICMP screening", children: map[string]*schemaNode{
+				"fragment": {desc: "Drop fragmented ICMP/ICMPv6 packets", children: nil},
+				// ping-death, flood -> leaf
+			}},
 			"tcp": {desc: "TCP screening", children: map[string]*schemaNode{
 				"syn-flood": {desc: "SYN flood protection", children: nil},
 				"port-scan": {desc: "Port scan protection", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -500,6 +500,7 @@ type ScreenProfile struct {
 // ICMPScreen configures ICMP screening.
 type ICMPScreen struct {
 	PingDeath      bool
+	Fragment       bool
 	FloodThreshold int
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -5293,6 +5293,38 @@ func TestBuildScreenSnapshotsIncludesSynFragOnlyProfile(t *testing.T) {
 	}
 }
 
+// #3316: an icmp-fragment-only screen profile must publish ICMPFragment in the
+// snapshot AND pass the emit gate. The Rust dataplane (screen/stateless.rs
+// check_icmp_fragment) consumes the `icmp_fragment` field and drops fragmented
+// ICMP/ICMPv6 — but buildScreenSnapshots never set the field nor counted it in
+// the enabled-profile predicate, so the protection was unreachable from config.
+// RED if the screens.go publish (or the predicate inclusion) is reverted.
+func TestBuildScreenSnapshotsIncludesICMPFragmentOnlyProfile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"lan": {Name: "lan", ScreenProfile: "icmp-frag-only"},
+	}
+	cfg.Security.Screen = map[string]*config.ScreenProfile{
+		"icmp-frag-only": {
+			Name: "icmp-frag-only",
+			ICMP: config.ICMPScreen{Fragment: true},
+		},
+	}
+	snaps := buildScreenSnapshots(cfg)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1 — icmp-fragment-only profile must pass the emit gate", len(snaps))
+	}
+	if !snaps[0].ICMPFragment {
+		t.Fatalf("ICMPFragment = false, want true — snapshot must publish the icmp-fragment screen")
+	}
+	// Sanity: nothing else should be on.
+	if snaps[0].SynFin || snaps[0].NoFlag || snaps[0].FinNoAck ||
+		snaps[0].WinNuke || snaps[0].PingDeath || snaps[0].Teardrop ||
+		snaps[0].SynFrag || snaps[0].SourceRoute || snaps[0].Land {
+		t.Fatalf("unexpected other-checks set: %+v", snaps[0])
+	}
+}
+
 // #3082: a zone that REFERENCES an undefined screen profile must be recorded
 // in the references-missing set so the dataplane can emit a runtime WARN
 // (instead of silently passing all screen checks). A zone with no screen

--- a/pkg/dataplane/userspace/screens.go
+++ b/pkg/dataplane/userspace/screens.go
@@ -22,16 +22,17 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 			continue
 		}
 		snap := ScreenProfileSnapshot{
-			Zone:        zone.Name,
-			Land:        sp.TCP.Land,
-			SynFin:      sp.TCP.SynFin,
-			NoFlag:      sp.TCP.NoFlag,
-			FinNoAck:    sp.TCP.FinNoAck,
-			WinNuke:     sp.TCP.WinNuke,
-			PingDeath:   sp.ICMP.PingDeath,
-			Teardrop:    sp.IP.TearDrop,
-			SynFrag:     sp.TCP.SynFrag, // #1137 — port from typed config
-			SourceRoute: sp.IP.SourceRouteOption,
+			Zone:         zone.Name,
+			Land:         sp.TCP.Land,
+			SynFin:       sp.TCP.SynFin,
+			NoFlag:       sp.TCP.NoFlag,
+			FinNoAck:     sp.TCP.FinNoAck,
+			WinNuke:      sp.TCP.WinNuke,
+			PingDeath:    sp.ICMP.PingDeath,
+			ICMPFragment: sp.ICMP.Fragment,
+			Teardrop:     sp.IP.TearDrop,
+			SynFrag:      sp.TCP.SynFrag, // #1137 — port from typed config
+			SourceRoute:  sp.IP.SourceRouteOption,
 		}
 		if sp.ICMP.FloodThreshold > 0 {
 			snap.ICMPFloodThreshold = uint32(sp.ICMP.FloodThreshold)
@@ -57,7 +58,7 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 		}
 		// Only include profiles that have at least one check enabled
 		if snap.Land || snap.SynFin || snap.NoFlag || snap.FinNoAck ||
-			snap.WinNuke || snap.PingDeath || snap.Teardrop ||
+			snap.WinNuke || snap.PingDeath || snap.ICMPFragment || snap.Teardrop ||
 			snap.SynFrag || snap.SourceRoute ||
 			snap.ICMPFloodThreshold > 0 || snap.UDPFloodThreshold > 0 ||
 			snap.SYNFloodThreshold > 0 ||


### PR DESCRIPTION
## Summary

The userspace dataplane fully implements an ICMP-fragment screen
(`screen/stateless.rs check_icmp_fragment` drops fragmented ICMP/ICMPv6 when
the per-zone profile's `icmp_fragment` flag is set; wired into both flow and
flowless fragment paths; snapshot field + `FEATURES.md` advertisement already
exist), but there was **no Go config→snapshot path**, so an operator could
never enable it. `set security screen ids-option <name> icmp fragment` was
silently dropped — a shipped, advertised screen check that was a no-op
(the screen analog of the #3302-class "runtime exists but no config plumbing").

## Fix

- Add `ICMPScreen.Fragment` (`pkg/config/types_security.go`).
- Handle the `fragment` leaf in `compileScreen` (`pkg/config/compiler_security.go`).
- Model the `fragment` leaf under the `icmp` screen subtree
  (`pkg/config/schema_security.go`). This **exposes `fragment` for
  tab-completion** and routes `icmp fragment` to `ICMPScreen.Fragment`,
  consistent with how the tcp/ip screen siblings are modeled. It does **not**
  add commit-time typo rejection — `fragment` is a childless node and
  `walkSchemaNode` ignores unknown keywords (`schema_walk.go:242-243`), so
  `icmp framgent` is not caught here. Unknown-screen-leaf rejection is the
  separate #3318.
- Publish `snap.ICMPFragment` from `sp.ICMP.Fragment` and include it in the
  enabled-profile emit predicate (`pkg/dataplane/userspace/screens.go`).

Set path wired: `set security screen ids-option <name> icmp fragment`
Snapshot field wired: `ScreenProfileSnapshot.ICMPFragment` (JSON `icmp_fragment`,
consumed by Rust `ScreenProfile.icmp_fragment`).

## Validation

- `TestScreenCompilation` extended — RED if the compiler case is reverted
  (`expected icmp fragment`).
- New `TestBuildScreenSnapshotsIncludesICMPFragmentOnlyProfile` — RED if the
  `screens.go` publish or emit-predicate inclusion is reverted
  (`len(snaps)=0` on revert, verified).
- Rust enforcement already covered by `screen/tests.rs icmp_fragment_drops`;
  no Rust change needed.
- `go build ./...` and `go test ./pkg/config/... ./pkg/dataplane/...` pass.
- `docs/feature-gaps.md` updated (12 reachable screen checks; new ICMP Fragment
  row marked Done).

Closes #3316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi