### PR TITLE
security/config: strict-validate screen numeric + unknown leaves (#3317, #3318)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22707,3 +22707,17 @@ top.
   routes `icmp fragment` to ICMPScreen.Fragment; unknown-screen-leaf rejection
   is the separate #3318. Comment-only, no behavior change.
 - **File(s)**: pkg/config/schema_security.go
+
+- **Timestamp**: 2026-06-27
+- **Action**: #3317/#3318 fold — rebased fix/3317-3318-screen-strict onto
+  origin/master (merged #3316 icmp fragment, 726fbd5ee). compileScreen icmp
+  switch conflict resolved additively: kept BOTH #3316 `case "fragment"` and
+  #3318 `default:` arm (fragment above default, so the handled leaf never
+  reaches UnknownLeaves). Added `fragment` to the validateScreenUnknownStrict
+  supported-icmp doc + error hint. Softened the doc's "every accepted leaf maps
+  to a field the engine enforces" claim: syn-flood alarm/source/destination-
+  threshold/timeout are accepted-but-not-yet-published (cross-ref #3315; SMR
+  nuance). New regression TestScreenIcmpFragmentNotRejected guards the
+  interaction (RED if #3316's case arm is dropped).
+- **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/screen_unknown_strict_3318_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22721,3 +22721,17 @@ top.
   interaction (RED if #3316's case arm is dropped).
 - **File(s)**: pkg/config/compiler_validate_strict.go,
   pkg/config/screen_unknown_strict_3318_test.go, _Log.md
+
+- **Timestamp**: 2026-06-27
+- **Action**: #3317 fold — close uint32-overflow fail-open in the screen
+  numeric gate (Codex MAJOR). parseThresh accepted any positive 64-bit int;
+  a value > 2^32-1 (e.g. 4294967296) passed the gate but wrapped to 0 at the
+  uint32 publish cast (pkg/dataplane/userspace/screens.go) → Rust screen
+  treats 0 as unset and omits the check. Added `int64(n) > math.MaxUint32`
+  rejection (portable: a >2^32 literal already fails Atoi on 32-bit int).
+  Bounds ALL 7 published-as-uint32 leaves (ICMP/UDP flood, syn-flood
+  attack-threshold, limit-session src/dst, port-scan, ip-sweep) plus the
+  shared not-yet-published syn-flood subfields. Added 3 overflow test cases
+  + MaxUint32/few-million accepted cases.
+- **File(s)**: pkg/config/compiler_security.go,
+  pkg/config/screen_numeric_strict_3317_test.go, _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -842,6 +842,20 @@ type compileOpts struct {
 	// leniently-loaded profile is no worse than the pre-gate behavior. Same
 	// doctrine as lenientFilterDSCP.
 	lenientScreenNumeric bool
+	// lenientScreenUnknown (#3318) downgrades the unknown-screen-leaf gate
+	// (validateScreenUnknownStrict) from a hard compile error to a cfg.Warnings
+	// entry. The strict commit / commit-check path hard-rejects a screen leaf
+	// the dataplane does NOT support. The screen schema subtrees are open and
+	// compileScreen switched only on known child names with no default case, so
+	// a misspelled or unsupported leaf committed cleanly and was silently
+	// dropped — the operator believed a protection was enabled when it was
+	// absent. compileScreen now records every unsupported leaf on
+	// ScreenProfile.UnknownLeaves; this gate makes the refusal operator-visible
+	// at commit. The tolerant load / peer-sync paths downgrade to a warning so
+	// an already-persisted or peer-synced config still BOOTS (#1960 no-brick);
+	// the dataplane never represented the leaf, so a leniently-loaded profile
+	// runs without it independently. Same doctrine as lenientFilterFromMatch.
+	lenientScreenUnknown bool
 	// lenientReservedZoneNames (#3055) downgrades the reserved zone-name
 	// definition gate (validateReservedZoneNamesStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -1103,6 +1117,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyLogAction:               true,
 		lenientScreenProfileRefs:             true,
 		lenientScreenNumeric:                 true,
+		lenientScreenUnknown:                 true,
 		lenientReservedZoneNames:             true,
 		lenientBackupRouterDst:               true,
 		lenientSecureTunnelBindIface:         true,
@@ -1238,6 +1253,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyLogAction:               true,
 		lenientScreenProfileRefs:             true,
 		lenientScreenNumeric:                 true,
+		lenientScreenUnknown:                 true,
 		lenientReservedZoneNames:             true,
 		lenientBackupRouterDst:               true,
 		lenientSecureTunnelBindIface:         true,
@@ -1870,6 +1886,24 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #3318 unknown-screen-leaf gate. Strict on commit / commit-check
+	// (hard-reject a screen leaf the dataplane does NOT support). The screen
+	// schema subtrees are open and compileScreen had no default case, so a
+	// misspelled or unsupported leaf committed cleanly and was silently dropped
+	// — the operator believed a protection was enabled when it was absent.
+	// Lenient on load / peer-sync (warn so an already-persisted or peer-synced
+	// config still boots — #1960 no-brick; the dataplane never represented the
+	// leaf, so the profile runs without it independently). Runs on the
+	// fully-compiled *Config so the typed profile list (with UnknownLeaves
+	// populated by compileScreen) is available.
+	if err := validateScreenUnknownStrict(cfg); err != nil {
+		if opts.lenientScreenUnknown {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("screen unknown leaf (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
 
 	// #3055 reserved zone-name definition gate. Strict on commit / commit-check
 	// (hard-reject a `security zones security-zone <name>` whose name is a

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -827,6 +827,21 @@ type compileOpts struct {
 	// is the real fix; the warning is the only signal on a leniently-loaded
 	// config. Same doctrine as lenientPolicyZoneRefs.
 	lenientScreenProfileRefs bool
+	// lenientScreenNumeric (#3317) downgrades the screen numeric-value gate
+	// (validateScreenNumericStrict) from a hard compile error to a cfg.Warnings
+	// entry. The strict commit / commit-check path hard-rejects a screen
+	// threshold / count leaf whose explicitly-provided value is not a positive
+	// integer. Before this gate compileScreen swallowed the strconv.Atoi error
+	// and fell back to a Junos default (icmp/udp flood, ip-sweep, port-scan,
+	// syn-flood attack-threshold) or to zero/disabled (the other syn-flood
+	// subfields, limit-session) — a typo'd threshold silently disabled or
+	// weakened the protection (fail-open). The tolerant load / peer-sync paths
+	// downgrade to a warning so an already-persisted or peer-synced config that
+	// an older binary accepted still BOOTS (#1960 no-brick); compileScreen
+	// independently applies the default for the bad value on that path, so the
+	// leniently-loaded profile is no worse than the pre-gate behavior. Same
+	// doctrine as lenientFilterDSCP.
+	lenientScreenNumeric bool
 	// lenientReservedZoneNames (#3055) downgrades the reserved zone-name
 	// definition gate (validateReservedZoneNamesStrict) from a hard compile
 	// error to a cfg.Warnings entry. The strict commit / commit-check path
@@ -1087,6 +1102,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyTerminalAction:          true,
 		lenientPolicyLogAction:               true,
 		lenientScreenProfileRefs:             true,
+		lenientScreenNumeric:                 true,
 		lenientReservedZoneNames:             true,
 		lenientBackupRouterDst:               true,
 		lenientSecureTunnelBindIface:         true,
@@ -1221,6 +1237,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyTerminalAction:          true,
 		lenientPolicyLogAction:               true,
 		lenientScreenProfileRefs:             true,
+		lenientScreenNumeric:                 true,
 		lenientReservedZoneNames:             true,
 		lenientBackupRouterDst:               true,
 		lenientSecureTunnelBindIface:         true,
@@ -1833,6 +1850,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 			return nil, err
 		}
 	}
+
+	// #3317 screen numeric-value gate. Strict on commit / commit-check
+	// (hard-reject a screen threshold / count leaf whose explicitly-provided
+	// value is not a positive integer). Before this gate compileScreen swallowed
+	// the strconv.Atoi error and silently fell back to a Junos default or to
+	// zero/disabled — a typo'd threshold disabled or weakened the protection
+	// (fail-open). Lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — #1960 no-brick; compileScreen applies the
+	// default for the bad value independently on that path). Runs on the
+	// fully-compiled *Config so the typed profile list (with BadNumeric
+	// populated by compileScreen) is available.
+	if err := validateScreenNumericStrict(cfg); err != nil {
+		if opts.lenientScreenNumeric {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("screen numeric value (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 
 	// #3055 reserved zone-name definition gate. Strict on commit / commit-check
 	// (hard-reject a `security zones security-zone <name>` whose name is a

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"sort"
 	"strconv"
@@ -701,7 +702,20 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				return 0, false
 			}
 			n, err := strconv.Atoi(val)
-			if err != nil || n < 1 {
+			// Reject non-numeric, non-positive, AND > math.MaxUint32. Every
+			// published screen threshold is cast to uint32 in the snapshot
+			// builder (pkg/dataplane/userspace/screens.go) — a value above
+			// 2^32-1 (e.g. 4294967296) would WRAP on that cast (uint32(2^32)==0),
+			// and the Rust screen treats a zero threshold as unset and OMITS the
+			// check. That is the exact fail-open class #3317 closes, so the gate
+			// must reject it at commit rather than let it wrap silently. int64(n)
+			// keeps the comparison portable: on a 32-bit `int` platform an
+			// over-2^32 literal already fails Atoi (err != nil), so this only
+			// adds a real bound on 64-bit. The dataplane-meaningful ceilings are
+			// tighter still (e.g. maxScanSweepThreshold clamps port-scan/ip-sweep
+			// downstream), but math.MaxUint32 is the required floor that prevents
+			// the wrap.
+			if err != nil || n < 1 || int64(n) > math.MaxUint32 {
 				profile.BadNumeric = append(profile.BadNumeric,
 					ScreenBadNumeric{Path: path, Value: val})
 				return 0, false

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -687,6 +687,41 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 	for _, inst := range namedInstances(node.FindChildren("ids-option")) {
 		profile := &ScreenProfile{Name: inst.name}
 
+		// parseThresh parses an explicitly-provided screen numeric value. An
+		// EMPTY value means the leaf was enabled without an explicit threshold:
+		// ok=false signals the caller to apply the Junos default (#3230) — that
+		// is NOT a bad value. A non-empty value that fails to parse or is not a
+		// positive integer is recorded on profile.BadNumeric for
+		// validateScreenNumericStrict (#3317): before this the strconv error was
+		// swallowed and the leaf silently became the default or zero/disabled
+		// (fail-open). ok=false on a bad value too, so the lenient / load path
+		// still falls back to the default and boots (#1960 no-brick).
+		parseThresh := func(path, val string) (int, bool) {
+			if val == "" {
+				return 0, false
+			}
+			n, err := strconv.Atoi(val)
+			if err != nil || n < 1 {
+				profile.BadNumeric = append(profile.BadNumeric,
+					ScreenBadNumeric{Path: path, Value: val})
+				return 0, false
+			}
+			return n, true
+		}
+		// numVal extracts the numeric value a screen leaf carries at Keys[keyIdx].
+		// In both AST shapes a leaf collapses its tokens onto Keys, so the value
+		// is at a fixed offset: a `threshold <N>` leaf carries it at Keys[1]
+		// (keyIdx=1); a `flood threshold <N>` leaf carries the intermediate
+		// `threshold` keyword at Keys[1] and the number at Keys[2] (keyIdx=2).
+		// nodeVal (Keys[1]) is the fallback only when Keys is too short. An empty
+		// result means the leaf was enabled without an explicit value.
+		numVal := func(n *Node, keyIdx int) string {
+			if len(n.Keys) > keyIdx {
+				return n.Keys[keyIdx]
+			}
+			return nodeVal(n)
+		}
+
 		icmpNode := inst.node.FindChild("icmp")
 		if icmpNode != nil {
 			for _, opt := range icmpNode.Children {
@@ -694,14 +729,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				case "ping-death":
 					profile.ICMP.PingDeath = true
 				case "flood":
-					if len(opt.Keys) >= 3 {
-						if v, err := strconv.Atoi(opt.Keys[2]); err == nil {
-							profile.ICMP.FloodThreshold = v
-						}
-					} else if v := nodeVal(opt); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							profile.ICMP.FloodThreshold = n
-						}
+					if n, ok := parseThresh("icmp flood", numVal(opt, 2)); ok {
+						profile.ICMP.FloodThreshold = n
 					}
 					// icmp flood enabled without an explicit threshold: arm at
 					// the Junos default (1000 pps) so the dataplane `>0` gate
@@ -723,12 +752,9 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					profile.IP.TearDrop = true
 				case "ip-sweep":
 					for _, swOpt := range opt.Children {
-						if swOpt.Name() == "threshold" {
-							val := nodeVal(swOpt)
-							if val == "" && len(swOpt.Keys) >= 2 {
-								val = swOpt.Keys[1]
-							}
-							if n, err := strconv.Atoi(val); err == nil {
+						switch swOpt.Name() {
+						case "threshold":
+							if n, ok := parseThresh("ip ip-sweep threshold", numVal(swOpt, 1)); ok {
 								profile.IP.IPSweepThreshold = n
 							}
 						}
@@ -763,22 +789,26 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				case "syn-flood":
 					sf := &SynFloodConfig{}
 					for _, sfOpt := range opt.Children {
-						val := nodeVal(sfOpt)
-						if val == "" && len(sfOpt.Keys) >= 2 {
-							val = sfOpt.Keys[1]
-						}
-						if val != "" {
-							n, _ := strconv.Atoi(val)
-							switch sfOpt.Name() {
-							case "alarm-threshold":
+						val := numVal(sfOpt, 1)
+						switch sfOpt.Name() {
+						case "alarm-threshold":
+							if n, ok := parseThresh("tcp syn-flood alarm-threshold", val); ok {
 								sf.AlarmThreshold = n
-							case "attack-threshold":
+							}
+						case "attack-threshold":
+							if n, ok := parseThresh("tcp syn-flood attack-threshold", val); ok {
 								sf.AttackThreshold = n
-							case "source-threshold":
+							}
+						case "source-threshold":
+							if n, ok := parseThresh("tcp syn-flood source-threshold", val); ok {
 								sf.SourceThreshold = n
-							case "destination-threshold":
+							}
+						case "destination-threshold":
+							if n, ok := parseThresh("tcp syn-flood destination-threshold", val); ok {
 								sf.DestinationThreshold = n
-							case "timeout":
+							}
+						case "timeout":
+							if n, ok := parseThresh("tcp syn-flood timeout", val); ok {
 								sf.Timeout = n
 							}
 						}
@@ -796,12 +826,9 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					profile.TCP.SynFlood = sf
 				case "port-scan":
 					for _, psOpt := range opt.Children {
-						if psOpt.Name() == "threshold" {
-							val := nodeVal(psOpt)
-							if val == "" && len(psOpt.Keys) >= 2 {
-								val = psOpt.Keys[1]
-							}
-							if n, err := strconv.Atoi(val); err == nil {
+						switch psOpt.Name() {
+						case "threshold":
+							if n, ok := parseThresh("tcp port-scan threshold", numVal(psOpt, 1)); ok {
 								profile.TCP.PortScanThreshold = n
 							}
 						}
@@ -822,14 +849,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			for _, opt := range udpNode.Children {
 				switch opt.Name() {
 				case "flood":
-					if len(opt.Keys) >= 3 {
-						if v, err := strconv.Atoi(opt.Keys[2]); err == nil {
-							profile.UDP.FloodThreshold = v
-						}
-					} else if v := nodeVal(opt); v != "" {
-						if n, err := strconv.Atoi(v); err == nil {
-							profile.UDP.FloodThreshold = n
-						}
+					if n, ok := parseThresh("udp flood", numVal(opt, 2)); ok {
+						profile.UDP.FloodThreshold = n
 					}
 					// udp flood enabled without an explicit threshold: arm at
 					// the Junos default (1000 pps) so the dataplane `>0` gate
@@ -844,16 +865,14 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 		limitNode := inst.node.FindChild("limit-session")
 		if limitNode != nil {
 			for _, opt := range limitNode.Children {
-				val := nodeVal(opt)
-				if val == "" && len(opt.Keys) >= 2 {
-					val = opt.Keys[1]
-				}
-				if val != "" {
-					n, _ := strconv.Atoi(val)
-					switch opt.Name() {
-					case "source-ip-based":
+				val := numVal(opt, 1)
+				switch opt.Name() {
+				case "source-ip-based":
+					if n, ok := parseThresh("limit-session source-ip-based", val); ok {
 						profile.LimitSession.SourceIPBased = n
-					case "destination-ip-based":
+					}
+				case "destination-ip-based":
+					if n, ok := parseThresh("limit-session destination-ip-based", val); ok {
 						profile.LimitSession.DestinationIPBased = n
 					}
 				}

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -722,6 +722,18 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			return nodeVal(n)
 		}
 
+		// #3318: the screen schema subtrees are open. Record any unknown/
+		// unsupported top-level screen family so validateScreenUnknownStrict can
+		// reject the commit fail-closed instead of silently dropping it.
+		for _, fam := range inst.node.Children {
+			switch fam.Name() {
+			case "icmp", "ip", "tcp", "udp", "limit-session":
+				// handled below
+			default:
+				profile.UnknownLeaves = append(profile.UnknownLeaves, fam.Name())
+			}
+		}
+
 		icmpNode := inst.node.FindChild("icmp")
 		if icmpNode != nil {
 			for _, opt := range icmpNode.Children {
@@ -738,6 +750,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					if profile.ICMP.FloodThreshold <= 0 {
 						profile.ICMP.FloodThreshold = defaultICMPFloodThreshold
 					}
+				default:
+					profile.UnknownLeaves = append(profile.UnknownLeaves, "icmp "+opt.Name())
 				}
 			}
 		}
@@ -757,6 +771,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 							if n, ok := parseThresh("ip ip-sweep threshold", numVal(swOpt, 1)); ok {
 								profile.IP.IPSweepThreshold = n
 							}
+						default:
+							profile.UnknownLeaves = append(profile.UnknownLeaves, "ip ip-sweep "+swOpt.Name())
 						}
 					}
 					// ip-sweep enabled without an explicit threshold: arm at the
@@ -766,6 +782,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					if profile.IP.IPSweepThreshold <= 0 {
 						profile.IP.IPSweepThreshold = defaultIPSweepThreshold
 					}
+				default:
+					profile.UnknownLeaves = append(profile.UnknownLeaves, "ip "+opt.Name())
 				}
 			}
 		}
@@ -811,6 +829,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 							if n, ok := parseThresh("tcp syn-flood timeout", val); ok {
 								sf.Timeout = n
 							}
+						default:
+							profile.UnknownLeaves = append(profile.UnknownLeaves, "tcp syn-flood "+sfOpt.Name())
 						}
 					}
 					// Junos applies a default attack-threshold of 200
@@ -831,6 +851,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 							if n, ok := parseThresh("tcp port-scan threshold", numVal(psOpt, 1)); ok {
 								profile.TCP.PortScanThreshold = n
 							}
+						default:
+							profile.UnknownLeaves = append(profile.UnknownLeaves, "tcp port-scan "+psOpt.Name())
 						}
 					}
 					// port-scan enabled without an explicit threshold: arm at
@@ -840,6 +862,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					if profile.TCP.PortScanThreshold <= 0 {
 						profile.TCP.PortScanThreshold = defaultPortScanThreshold
 					}
+				default:
+					profile.UnknownLeaves = append(profile.UnknownLeaves, "tcp "+opt.Name())
 				}
 			}
 		}
@@ -858,6 +882,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					if profile.UDP.FloodThreshold <= 0 {
 						profile.UDP.FloodThreshold = defaultUDPFloodThreshold
 					}
+				default:
+					profile.UnknownLeaves = append(profile.UnknownLeaves, "udp "+opt.Name())
 				}
 			}
 		}
@@ -875,6 +901,8 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					if n, ok := parseThresh("limit-session destination-ip-based", val); ok {
 						profile.LimitSession.DestinationIPBased = n
 					}
+				default:
+					profile.UnknownLeaves = append(profile.UnknownLeaves, "limit-session "+opt.Name())
 				}
 			}
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2397,6 +2397,65 @@ func validateScreenProfileReferencesStrict(cfg *Config) error {
 	return nil
 }
 
+// sortedScreenNames returns the screen-profile names in deterministic order so
+// the strict validators report the first offender stably across runs.
+func sortedScreenNames(screens map[string]*ScreenProfile) []string {
+	names := make([]string, 0, len(screens))
+	for name := range screens {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// validateScreenNumericStrict hard-rejects a screen profile carrying a numeric
+// threshold / count leaf whose explicitly-provided value is not a positive
+// integer — #3317.
+//
+// Screen threshold leaves (icmp/udp flood, ip ip-sweep threshold, tcp port-scan
+// threshold, the tcp syn-flood alarm/attack/source/destination-threshold and
+// timeout subfields, and limit-session source/destination-ip-based) are untyped
+// in the schema. Before this gate compileScreen swallowed the strconv.Atoi
+// failure and silently fell back to a Junos default (icmp/udp flood, ip-sweep,
+// port-scan, syn-flood attack-threshold via #3024/#3230) or to zero/disabled
+// (the other syn-flood subfields and limit-session). A typo'd value
+// (`attack-threshold abc`, `udp flood 99999999999999999999`, `source-ip-based
+// -1`) therefore committed cleanly while the enforced control was materially
+// different from — usually weaker or fully disabled relative to — what the
+// operator authored: a silent fail-open. SRX rejects a non-numeric screen value
+// at commit.
+//
+// compileScreen records every explicitly-provided value that does not parse as
+// a positive integer on ScreenProfile.BadNumeric (path + raw value); an EMPTY
+// value is the "enabled without an explicit threshold" case and is NOT recorded
+// (it legitimately takes the Junos default — #3230). This gate makes the
+// refusal operator-visible at commit, naming the screen profile, the leaf path,
+// and the offending value. The walk is deterministic (profiles sorted by name,
+// BadNumeric in config order). On the tolerant load / peer-sync path the caller
+// downgrades the returned error to a warning (#1960 no-brick); compileScreen
+// applied the default for the bad value independently, so a leniently-loaded
+// profile is no worse than the pre-gate behavior — but the operator never
+// reaches that state through a commit. Mirrors validateFilterDSCPStrict.
+func validateScreenNumericStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, name := range sortedScreenNames(cfg.Security.Screen) {
+		profile := cfg.Security.Screen[name]
+		if profile == nil || len(profile.BadNumeric) == 0 {
+			continue
+		}
+		bad := profile.BadNumeric[0]
+		return fmt.Errorf(
+			"security screen ids-option %q: `%s` value %q is not a positive "+
+				"integer (an unparseable value is silently dropped and the leaf "+
+				"falls back to a default or to zero/disabled, so the protection "+
+				"is weaker than — or fully different from — what was configured)",
+			name, bad.Path, bad.Value)
+	}
+	return nil
+}
+
 // policyActionName renders a PolicyAction as its Junos `then` token for
 // operator-facing validator errors.
 func policyActionName(a PolicyAction) string {

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2456,6 +2456,58 @@ func validateScreenNumericStrict(cfg *Config) error {
 	return nil
 }
 
+// validateScreenUnknownStrict hard-rejects a screen profile carrying a leaf the
+// dataplane does NOT support — #3318.
+//
+// The screen schema subtrees are open (schema_security.go: `icmp`, `tcp`, `ip`,
+// `udp` model only their named children; an unknown keyword resolves to a nil
+// schema child and returns no error), and compileScreen switched only on the
+// known child names with no default arm. A misspelled or unsupported leaf
+// (`icmp pong-death`, `tcp syn-flood whitelist`, `ip bad-option`, an unsupported
+// SRX screen such as `tcp sweep`/`ip block-frag`) therefore committed cleanly
+// and was silently DROPPED — the operator believed a protection was enabled when
+// it was entirely absent, a "configured but not enforced" posture with no
+// warning. SRX fails commit on an unknown screen option.
+//
+// The supported set is EXACTLY the compileScreen switch cases: icmp
+// {ping-death, flood}; ip {source-route-option, tear-drop, ip-sweep
+// {threshold}}; tcp {land, winnuke, syn-frag, syn-fin, no-flag, fin-no-ack,
+// syn-flood {alarm/attack/source/destination-threshold, timeout}, port-scan
+// {threshold}}; udp {flood}; limit-session {source-ip-based,
+// destination-ip-based}. Every one maps to a field the userspace screen engine
+// (userspace-dp/src/screen) enforces. compileScreen's default arms record every
+// other leaf — at the top-level family, per-family, and per-subtree depth — on
+// ScreenProfile.UnknownLeaves (the full `<family> <leaf>` path); this gate makes
+// the refusal operator-visible at commit. No NEW screening is implemented — the
+// unsupported leaf is rejected, which is the fail-closed-correct outcome. The
+// walk is deterministic (profiles sorted by name, UnknownLeaves in config
+// order). On the tolerant load / peer-sync path the caller downgrades the
+// returned error to a warning (#1960 no-brick); the dataplane never represented
+// the leaf, so a leniently-loaded profile runs without it independently — but
+// the operator never reaches that state through a commit. Mirrors
+// validateFilterFromMatchStrict.
+func validateScreenUnknownStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	for _, name := range sortedScreenNames(cfg.Security.Screen) {
+		profile := cfg.Security.Screen[name]
+		if profile == nil || len(profile.UnknownLeaves) == 0 {
+			continue
+		}
+		return fmt.Errorf(
+			"security screen ids-option %q: `%s` is not a supported screen "+
+				"option (the dataplane does not enforce it, so it would be "+
+				"silently dropped and the protection the operator believes is "+
+				"enabled would be absent); remove it or use a supported option "+
+				"such as icmp ping-death/flood, ip source-route-option/tear-drop/"+
+				"ip-sweep, tcp land/winnuke/syn-frag/syn-fin/no-flag/fin-no-ack/"+
+				"syn-flood/port-scan, udp flood, or limit-session",
+			name, profile.UnknownLeaves[0])
+	}
+	return nil
+}
+
 // policyActionName renders a PolicyAction as its Junos `then` token for
 // operator-facing validator errors.
 func policyActionName(a PolicyAction) string {

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2470,12 +2470,19 @@ func validateScreenNumericStrict(cfg *Config) error {
 // warning. SRX fails commit on an unknown screen option.
 //
 // The supported set is EXACTLY the compileScreen switch cases: icmp
-// {ping-death, flood}; ip {source-route-option, tear-drop, ip-sweep
+// {ping-death, fragment, flood}; ip {source-route-option, tear-drop, ip-sweep
 // {threshold}}; tcp {land, winnuke, syn-frag, syn-fin, no-flag, fin-no-ack,
 // syn-flood {alarm/attack/source/destination-threshold, timeout}, port-scan
 // {threshold}}; udp {flood}; limit-session {source-ip-based,
-// destination-ip-based}. Every one maps to a field the userspace screen engine
-// (userspace-dp/src/screen) enforces. compileScreen's default arms record every
+// destination-ip-based}. These are the leaves compileScreen ACCEPTS (records a
+// typed field for) — most also map to a field the userspace screen engine
+// (userspace-dp/src/screen) enforces, but a few are accepted-but-not-yet-
+// published to the snapshot: the syn-flood alarm-threshold / source-threshold /
+// destination-threshold / timeout subfields are compiled into SynFloodConfig and
+// not currently emitted to the dataplane (tracked in #3315). This gate's
+// contract is "rejects what compileScreen does NOT model", not "guarantees every
+// accepted leaf is enforced" — closing the publish gap is #3315's scope.
+// compileScreen's default arms record every
 // other leaf — at the top-level family, per-family, and per-subtree depth — on
 // ScreenProfile.UnknownLeaves (the full `<family> <leaf>` path); this gate makes
 // the refusal operator-visible at commit. No NEW screening is implemented — the
@@ -2500,7 +2507,7 @@ func validateScreenUnknownStrict(cfg *Config) error {
 				"option (the dataplane does not enforce it, so it would be "+
 				"silently dropped and the protection the operator believes is "+
 				"enabled would be absent); remove it or use a supported option "+
-				"such as icmp ping-death/flood, ip source-route-option/tear-drop/"+
+				"such as icmp ping-death/fragment/flood, ip source-route-option/tear-drop/"+
 				"ip-sweep, tcp land/winnuke/syn-frag/syn-fin/no-flag/fin-no-ack/"+
 				"syn-flood/port-scan, udp flood, or limit-session",
 			name, profile.UnknownLeaves[0])

--- a/pkg/config/screen_numeric_strict_3317_test.go
+++ b/pkg/config/screen_numeric_strict_3317_test.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3317: screen numeric threshold / count leaves are untyped and compileScreen
+// swallowed the strconv.Atoi failure — a typo'd value committed cleanly and the
+// leaf silently fell back to a Junos default (icmp/udp flood, ip-sweep,
+// port-scan, syn-flood attack-threshold) or to zero/disabled (the other
+// syn-flood subfields, limit-session), a fail-open. validateScreenNumericStrict
+// makes a non-positive-integer value an operator-visible commit error.
+//
+// FAIL-ON-REVERT: remove the parseThresh BadNumeric recording in compileScreen
+// (compiler_security.go) OR the validateScreenNumericStrict dispatch in
+// compiler.go and the bad-value subtests below go green on the BAD config,
+// which is exactly the regression this test exists to catch.
+func TestScreenNumericBadValueFailsCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		line string // the offending `set` line under ids-option bad-screen
+		want string // substring the error must name
+	}{
+		{
+			name: "icmp-flood-non-numeric",
+			line: "set security screen ids-option bad-screen icmp flood threshold abc",
+			want: "icmp flood",
+		},
+		{
+			name: "udp-flood-non-numeric",
+			line: "set security screen ids-option bad-screen udp flood threshold xyz",
+			want: "udp flood",
+		},
+		{
+			name: "ip-sweep-threshold-non-numeric",
+			line: "set security screen ids-option bad-screen ip ip-sweep threshold notnum",
+			want: "ip ip-sweep threshold",
+		},
+		{
+			name: "port-scan-threshold-non-numeric",
+			line: "set security screen ids-option bad-screen tcp port-scan threshold bad",
+			want: "tcp port-scan threshold",
+		},
+		{
+			name: "syn-flood-attack-threshold-non-numeric",
+			line: "set security screen ids-option bad-screen tcp syn-flood attack-threshold zzz",
+			want: "tcp syn-flood attack-threshold",
+		},
+		{
+			name: "syn-flood-source-threshold-negative",
+			line: "set security screen ids-option bad-screen tcp syn-flood source-threshold -5",
+			want: "tcp syn-flood source-threshold",
+		},
+		{
+			name: "limit-session-source-ip-based-non-numeric",
+			line: "set security screen ids-option bad-screen limit-session source-ip-based foo",
+			want: "limit-session source-ip-based",
+		},
+		{
+			name: "limit-session-destination-ip-based-zero",
+			line: "set security screen ids-option bad-screen limit-session destination-ip-based 0",
+			want: "limit-session destination-ip-based",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, []string{tc.line})
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject a non-positive-integer screen value, got nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name the offending leaf %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "bad-screen") {
+				t.Fatalf("error %q does not name the screen profile", err.Error())
+			}
+		})
+	}
+}
+
+// TestScreenNumericValidCommit asserts well-formed positive-integer screen
+// values (and the threshold-less "enabled at default" forms — #3230) commit
+// cleanly (anti-over-reject).
+func TestScreenNumericValidCommit(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option ok-screen icmp flood threshold 1000",
+		"set security screen ids-option ok-screen udp flood threshold 2000",
+		"set security screen ids-option ok-screen ip ip-sweep threshold 10",
+		"set security screen ids-option ok-screen tcp port-scan threshold 14",
+		"set security screen ids-option ok-screen tcp syn-flood attack-threshold 200",
+		"set security screen ids-option ok-screen tcp syn-flood alarm-threshold 512",
+		"set security screen ids-option ok-screen tcp syn-flood timeout 20",
+		"set security screen ids-option ok-screen limit-session source-ip-based 128",
+		"set security screen ids-option ok-screen limit-session destination-ip-based 128",
+		// threshold-less enable forms must NOT be flagged (default applies)
+		"set security screen ids-option ok-screen tcp land",
+		"set security screen ids-option ok-screen icmp ping-death",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("strict commit rejected a well-formed screen profile: %v", err)
+	}
+}
+
+// TestScreenNumericLenientDowngradesToWarning asserts the tolerant load /
+// peer-sync path downgrades the bad-value error to a warning so an
+// already-persisted or peer-synced config carrying a typo'd threshold still
+// boots (#3317 / #1960 no-brick); compileScreen applies the default for the bad
+// value independently on that path.
+func TestScreenNumericLenientDowngradesToWarning(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option bad-screen tcp syn-flood attack-threshold abc",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must not hard-fail on a bad screen value: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "screen numeric value") && strings.Contains(w, "attack-threshold") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path did not record a downgraded screen-numeric warning; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/screen_numeric_strict_3317_test.go
+++ b/pkg/config/screen_numeric_strict_3317_test.go
@@ -62,6 +62,26 @@ func TestScreenNumericBadValueFailsCommit(t *testing.T) {
 			line: "set security screen ids-option bad-screen limit-session destination-ip-based 0",
 			want: "limit-session destination-ip-based",
 		},
+		{
+			// 2^32: passes the non-positive/non-numeric gate but WRAPS to 0 on
+			// the uint32 publish cast (uint32(4294967296)==0), which disables the
+			// check — the exact fail-open #3317 closes. Must be rejected at
+			// commit by the math.MaxUint32 ceiling.
+			name: "syn-flood-attack-threshold-uint32-wrap",
+			line: "set security screen ids-option bad-screen tcp syn-flood attack-threshold 4294967296",
+			want: "tcp syn-flood attack-threshold",
+		},
+		{
+			// just over MaxUint32 (2^32) on another published leaf.
+			name: "udp-flood-over-maxuint32",
+			line: "set security screen ids-option bad-screen udp flood threshold 4294967296",
+			want: "udp flood",
+		},
+		{
+			name: "port-scan-far-over-maxuint32",
+			line: "set security screen ids-option bad-screen tcp port-scan threshold 9999999999",
+			want: "tcp port-scan threshold",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -90,6 +110,10 @@ func TestScreenNumericValidCommit(t *testing.T) {
 		"set security screen ids-option ok-screen ip ip-sweep threshold 10",
 		"set security screen ids-option ok-screen tcp port-scan threshold 14",
 		"set security screen ids-option ok-screen tcp syn-flood attack-threshold 200",
+		// in-range large values (a few million, and MaxUint32 itself) must be
+		// ACCEPTED — only > math.MaxUint32 wraps the publish cast and is rejected.
+		"set security screen ids-option big-screen tcp syn-flood attack-threshold 5000000",
+		"set security screen ids-option big-screen udp flood threshold 4294967295",
 		"set security screen ids-option ok-screen tcp syn-flood alarm-threshold 512",
 		"set security screen ids-option ok-screen tcp syn-flood timeout 20",
 		"set security screen ids-option ok-screen limit-session source-ip-based 128",

--- a/pkg/config/screen_unknown_strict_3318_test.go
+++ b/pkg/config/screen_unknown_strict_3318_test.go
@@ -115,6 +115,37 @@ func TestScreenSupportedLeavesCommit(t *testing.T) {
 	}
 }
 
+// TestScreenIcmpFragmentNotRejected guards the #3316 (`icmp fragment`) /
+// #3318 (unknown-leaf gate) interaction across the merge ordering: with #3316's
+// `case "fragment"` arm present in compileScreen's icmp switch, `icmp fragment`
+// is a HANDLED leaf — it sets ScreenProfile.ICMP.Fragment and is NOT recorded on
+// UnknownLeaves, so validateScreenUnknownStrict must NOT reject it.
+//
+// FAIL-ON-REVERT: drop #3316's `case "fragment"` arm and the leaf falls through
+// to compileScreen's `default:` → UnknownLeaves → validateScreenUnknownStrict
+// rejects it, turning this test RED. This is exactly the merge-ordering hazard
+// the #3316/#3318 rebase had to resolve (keep BOTH the fragment case and the
+// default arm).
+func TestScreenIcmpFragmentNotRejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option frag-screen icmp fragment",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected `icmp fragment` (a supported #3316 leaf): %v", err)
+	}
+	profile := cfg.Security.Screen["frag-screen"]
+	if profile == nil {
+		t.Fatalf("screen profile frag-screen missing from compiled config")
+	}
+	if !profile.ICMP.Fragment {
+		t.Fatalf("`icmp fragment` did not set ICMP.Fragment; it was dropped or misrouted")
+	}
+	if len(profile.UnknownLeaves) != 0 {
+		t.Fatalf("`icmp fragment` was recorded as an unknown leaf %v; the #3316 case arm is missing or below the default", profile.UnknownLeaves)
+	}
+}
+
 // TestScreenUnknownLenientDowngradesToWarning asserts the tolerant load /
 // peer-sync path downgrades the unknown-leaf error to a warning so an
 // already-persisted or peer-synced config carrying an unsupported leaf still

--- a/pkg/config/screen_unknown_strict_3318_test.go
+++ b/pkg/config/screen_unknown_strict_3318_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3318: the screen schema subtrees are open and compileScreen switched only on
+// known child names with no default case — a misspelled or unsupported screen
+// leaf committed cleanly and was silently dropped, so the operator believed a
+// protection was enabled when it was absent. validateScreenUnknownStrict makes
+// the unsupported leaf an operator-visible commit error.
+//
+// FAIL-ON-REVERT: remove the compileScreen default arms that record
+// UnknownLeaves (compiler_security.go) OR the validateScreenUnknownStrict
+// dispatch in compiler.go and the subtests below go green on the BAD config,
+// which is exactly the regression this test exists to catch.
+func TestScreenUnknownLeafFailsCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string // the `<family> <leaf>` path the error must name
+	}{
+		{
+			name: "unknown-top-level-family",
+			line: "set security screen ids-option bad-screen bogus-family something",
+			want: "bogus-family",
+		},
+		{
+			name: "unknown-icmp-leaf",
+			line: "set security screen ids-option bad-screen icmp pong-death",
+			want: "icmp pong-death",
+		},
+		{
+			name: "unknown-ip-leaf",
+			line: "set security screen ids-option bad-screen ip block-frag",
+			want: "ip block-frag",
+		},
+		{
+			name: "unknown-ip-sweep-subleaf",
+			line: "set security screen ids-option bad-screen ip ip-sweep bogus 10",
+			want: "ip ip-sweep bogus",
+		},
+		{
+			name: "unknown-tcp-leaf",
+			line: "set security screen ids-option bad-screen tcp sweep",
+			want: "tcp sweep",
+		},
+		{
+			name: "unknown-syn-flood-subleaf",
+			line: "set security screen ids-option bad-screen tcp syn-flood whitelist foo",
+			want: "tcp syn-flood whitelist",
+		},
+		{
+			name: "unknown-port-scan-subleaf",
+			line: "set security screen ids-option bad-screen tcp port-scan bogus 10",
+			want: "tcp port-scan bogus",
+		},
+		{
+			name: "unknown-udp-leaf",
+			line: "set security screen ids-option bad-screen udp bad-udp-option",
+			want: "udp bad-udp-option",
+		},
+		{
+			name: "unknown-limit-session-leaf",
+			line: "set security screen ids-option bad-screen limit-session both-ip-based 10",
+			want: "limit-session both-ip-based",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, []string{tc.line})
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject an unsupported screen leaf, got nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name the unsupported leaf %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "bad-screen") {
+				t.Fatalf("error %q does not name the screen profile", err.Error())
+			}
+		})
+	}
+}
+
+// TestScreenSupportedLeavesCommit asserts the full set of supported screen
+// leaves commits cleanly (anti-over-reject) — every compileScreen switch case
+// across all families.
+func TestScreenSupportedLeavesCommit(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option ok-screen icmp ping-death",
+		"set security screen ids-option ok-screen icmp flood threshold 1000",
+		"set security screen ids-option ok-screen ip source-route-option",
+		"set security screen ids-option ok-screen ip tear-drop",
+		"set security screen ids-option ok-screen ip ip-sweep threshold 10",
+		"set security screen ids-option ok-screen tcp land",
+		"set security screen ids-option ok-screen tcp winnuke",
+		"set security screen ids-option ok-screen tcp syn-frag",
+		"set security screen ids-option ok-screen tcp syn-fin",
+		"set security screen ids-option ok-screen tcp no-flag",
+		"set security screen ids-option ok-screen tcp fin-no-ack",
+		"set security screen ids-option ok-screen tcp syn-flood attack-threshold 200",
+		"set security screen ids-option ok-screen tcp syn-flood alarm-threshold 512",
+		"set security screen ids-option ok-screen tcp syn-flood source-threshold 100",
+		"set security screen ids-option ok-screen tcp syn-flood destination-threshold 200",
+		"set security screen ids-option ok-screen tcp syn-flood timeout 20",
+		"set security screen ids-option ok-screen tcp port-scan threshold 14",
+		"set security screen ids-option ok-screen udp flood threshold 1000",
+		"set security screen ids-option ok-screen limit-session source-ip-based 128",
+		"set security screen ids-option ok-screen limit-session destination-ip-based 128",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("strict commit rejected a fully-supported screen profile: %v", err)
+	}
+}
+
+// TestScreenUnknownLenientDowngradesToWarning asserts the tolerant load /
+// peer-sync path downgrades the unknown-leaf error to a warning so an
+// already-persisted or peer-synced config carrying an unsupported leaf still
+// boots (#3318 / #1960 no-brick).
+func TestScreenUnknownLenientDowngradesToWarning(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option bad-screen icmp pong-death",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must not hard-fail on an unsupported screen leaf: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "screen unknown leaf") && strings.Contains(w, "pong-death") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path did not record a downgraded screen-unknown warning; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -495,6 +495,23 @@ type ScreenProfile struct {
 	TCP          TCPScreen
 	UDP          UDPScreen
 	LimitSession LimitSessionScreen
+
+	// BadNumeric records screen numeric leaves whose explicitly-provided value
+	// failed to parse as a positive integer (#3317). compileScreen previously
+	// swallowed the strconv.Atoi error and fell back to a Junos default or to
+	// zero/disabled — a typo'd threshold silently disabled or weakened the
+	// protection (fail-open). validateScreenNumericStrict reads this to reject
+	// the commit fail-closed instead of silently defaulting. Each entry names
+	// the screen leaf path and the offending value.
+	BadNumeric []ScreenBadNumeric
+}
+
+// ScreenBadNumeric records a screen numeric leaf whose explicitly-provided value
+// did not parse as a positive integer (#3317): the full leaf path (e.g.
+// "tcp syn-flood attack-threshold") and the raw offending value.
+type ScreenBadNumeric struct {
+	Path  string
+	Value string
 }
 
 // ICMPScreen configures ICMP screening.

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -504,6 +504,14 @@ type ScreenProfile struct {
 	// the commit fail-closed instead of silently defaulting. Each entry names
 	// the screen leaf path and the offending value.
 	BadNumeric []ScreenBadNumeric
+	// UnknownLeaves records screen leaves the dataplane does NOT support
+	// (#3318). The screen schema subtrees are open and compileScreen switched
+	// only on known child names with no default case, so a misspelled or
+	// unsupported leaf committed cleanly and was silently dropped — the operator
+	// believed a control was enabled when it was absent. validateScreenUnknownStrict
+	// reads this to reject the commit fail-closed. Each entry is the full
+	// `<family> <leaf>` path under the ids-option.
+	UnknownLeaves []string
 }
 
 // ScreenBadNumeric records a screen numeric leaf whose explicitly-provided value


### PR DESCRIPTION
Closes #3317
Closes #3318

Two coupled screen-config strict-commit validators in `pkg/config`, the
screen analogs of the just-merged firewall-filter gates #3309 (out-of-range
DSCP) and #3307 (unknown `from` leaf). Both follow the established
strict-with-lenient-downgrade pattern (#1960/#3261): a new `compileOpts`
flag set true ONLY in `CompileConfigLenient` + `CompileConfigForNodeLenient`
(warn, no-brick) while the normal commit / commit-check path hard-rejects.

## Commit 1 — #3317: malformed screen numeric values fail open
Screen threshold/count leaves are untyped and `compileScreen` swallowed the
`strconv.Atoi` failure, so a typo'd value committed cleanly and the leaf
silently fell back to a Junos default or to zero/disabled (fail-open). All 6
Atoi sites now route through a `parseThresh` helper that records any
non-positive-integer value on `ScreenProfile.BadNumeric`;
`validateScreenNumericStrict` rejects it, naming the screen/leaf/value. An
EMPTY value (enabled-without-explicit-threshold, #3230) is NOT flagged.

## Commit 2 — #3318: unknown/unsupported screen leaves silently dropped
The screen schema subtrees are open and `compileScreen` had no `default`
case, so a misspelled/unsupported leaf committed cleanly and did nothing.
`compileScreen` gains default arms at every depth (top-level family, each
per-family switch, the ip-sweep/syn-flood/port-scan subtree loops) recording
`ScreenProfile.UnknownLeaves`; `validateScreenUnknownStrict` rejects the
first one. Supported set verified against `userspace-dp/src/screen`.

### Supported (accepted) vs unknown (rejected)
Supported: icmp {ping-death, flood}; ip {source-route-option, tear-drop,
ip-sweep {threshold}}; tcp {land, winnuke, syn-frag, syn-fin, no-flag,
fin-no-ack, syn-flood {alarm/attack/source/destination-threshold, timeout},
port-scan {threshold}}; udp {flood}; limit-session {source-ip-based,
destination-ip-based}. Everything else is rejected as unsupported.

## Validation
`go build ./...` and `go test ./pkg/config/...` green. New fail-on-revert
tests in `screen_numeric_strict_3317_test.go` and
`screen_unknown_strict_3318_test.go`; neutralizing either validator turns
the bad-config subtests RED (verified via copy-aside). Acceptance +
lenient-downgrade tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi