### PR TITLE
logging: guard EventBuffer against non-positive n and size (#3342)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22735,3 +22735,15 @@ top.
   + MaxUint32/few-million accepted cases.
 - **File(s)**: pkg/config/compiler_security.go,
   pkg/config/screen_numeric_strict_3317_test.go, _Log.md
+
+- **Timestamp**: 2026-06-28
+- **Action**: #3342 — guard EventBuffer against non-positive n/size panics.
+  Latest(n) now returns nil for n<=0 (was: negative n reached
+  make([]EventRecord,n) → "makeslice: len out of range" panic, reachable via
+  `show security log -1`). NewEventBuffer clamps size<1 to
+  defaultEventBufferSize=1000 (zero ring panicked on first Add via head%size).
+  CLI showSecurityLog rejects a non-positive count with a clean error.
+- **File(s)**: pkg/logging/eventbuf.go, pkg/logging/README.md,
+  pkg/cli/cli_show_security_log.go,
+  pkg/logging/eventbuf_negative_3342_test.go,
+  pkg/cli/cli_show_security_log_negative_3342_test.go, _Log.md

--- a/pkg/cli/cli_show_security_log.go
+++ b/pkg/cli/cli_show_security_log.go
@@ -47,8 +47,15 @@ func (c *CLI) showSecurityLog(args []string) error {
 				filter.Action = args[i]
 			}
 		default:
-			// Try parsing as count.
+			// Try parsing as count. Reject a non-positive count at the
+			// boundary so `show security log -1` is a clean error rather
+			// than a panic — defense in depth alongside the EventBuffer
+			// guard (#3342). A bare non-numeric token is ignored, as
+			// before.
 			if v, err := strconv.Atoi(args[i]); err == nil {
+				if v <= 0 {
+					return fmt.Errorf("event count must be a positive integer, got %d", v)
+				}
 				n = v
 			}
 		}

--- a/pkg/cli/cli_show_security_log_negative_3342_test.go
+++ b/pkg/cli/cli_show_security_log_negative_3342_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestShowSecurityLogNegativeCount guards #3342: `show security log -1` must
+// return a clean error at the CLI boundary, not crash the daemon. Before the
+// fix the negative count flowed into EventBuffer.Latest(-1) ->
+// make([]EventRecord, -1), panicking the control-plane process.
+//
+// FAIL-ON-REVERT: dropping the `v <= 0` boundary check in showSecurityLog
+// (and the EventBuffer.Latest guard) makes "-1" panic instead of erroring.
+func TestShowSecurityLogNegativeCount(t *testing.T) {
+	c := &CLI{eventBuf: logging.NewEventBuffer(16)}
+	c.eventBuf.Add(logging.EventRecord{Type: "SESSION_OPEN"})
+
+	for _, arg := range []string{"-1", "-1000", "0"} {
+		err := c.showSecurityLog([]string{arg})
+		if err == nil {
+			t.Errorf("showSecurityLog([%q]) = nil error, want a rejection", arg)
+			continue
+		}
+		if !strings.Contains(err.Error(), "positive") {
+			t.Errorf("showSecurityLog([%q]) error = %q, want it to mention 'positive'", arg, err.Error())
+		}
+	}
+}
+
+// TestShowSecurityLogPositiveCount confirms the boundary guard does not break
+// the normal positive-count path.
+func TestShowSecurityLogPositiveCount(t *testing.T) {
+	c := &CLI{eventBuf: logging.NewEventBuffer(16)}
+	c.eventBuf.Add(logging.EventRecord{Type: "SESSION_OPEN"})
+
+	if err := c.showSecurityLog([]string{"5"}); err != nil {
+		t.Errorf("showSecurityLog([\"5\"]) = %v, want nil", err)
+	}
+}

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -12,7 +12,12 @@ reports.
   fans events out to configured syslog clients.
 - `EventBuffer` — `eventbuf.go`. `NewEventBuffer(size int)` — the
   caller picks the size; `pkg/daemon/daemon_run.go` constructs it
-  with 1000. Bounded ring; full → drops the oldest entry.
+  with 1000. A non-positive size is clamped to `defaultEventBufferSize`
+  (1000) so the ring is never zero-capacity (a zero ring panics on the
+  first `Add` via `head % size`, #3342). Bounded ring; full → drops the
+  oldest entry. `Latest(n)` and `LatestFiltered(n, …)` both treat
+  `n <= 0` as "return nothing" — a count argument never reaches
+  `make([]EventRecord, n)` with a negative len (which panics).
 - `Subscription` — `eventbuf.go`. A consumer of the event ring.
 - `LocalLogWriter` — `locallog.go`. File-based writer with
   facility/severity filters.

--- a/pkg/logging/eventbuf.go
+++ b/pkg/logging/eventbuf.go
@@ -84,8 +84,19 @@ func (s *Subscription) Close() {
 	s.eb.unsubscribe(s)
 }
 
-// NewEventBuffer creates a new event buffer with the given capacity.
+// defaultEventBufferSize is the fallback ring capacity used when a caller
+// requests a non-positive size. A zero-capacity ring is a footgun: Add
+// indexes buf[head] and computes head % size, so size==0 panics with an
+// index-out-of-range / divide-by-zero on the first event (#3342).
+const defaultEventBufferSize = 1000
+
+// NewEventBuffer creates a new event buffer with the given capacity. A
+// non-positive size is clamped to defaultEventBufferSize so the ring is
+// always usable; Add must never index an empty buffer or divide by zero.
 func NewEventBuffer(size int) *EventBuffer {
+	if size < 1 {
+		size = defaultEventBufferSize
+	}
 	return &EventBuffer{
 		buf:  make([]EventRecord, size),
 		size: size,
@@ -191,6 +202,13 @@ func (eb *EventBuffer) Latest(n int) []EventRecord {
 	eb.mu.RLock()
 	defer eb.mu.RUnlock()
 
+	// Guard non-positive n first: a negative count must not reach
+	// make([]EventRecord, n), which panics ("makeslice: len out of
+	// range"). This mirrors LatestFiltered's `n <= 0` contract so a
+	// count argument behaves identically on both surfaces (#3342).
+	if n <= 0 {
+		return nil
+	}
 	if n > eb.count {
 		n = eb.count
 	}

--- a/pkg/logging/eventbuf_negative_3342_test.go
+++ b/pkg/logging/eventbuf_negative_3342_test.go
@@ -40,17 +40,35 @@ func TestLatestFilteredNegativeN(t *testing.T) {
 // or divide by zero (head % size).
 //
 // FAIL-ON-REVERT: removing the `if size < 1` clamp in NewEventBuffer makes
-// the first Add panic (index out of range / integer divide by zero).
+// the first Add PANIC at the real footgun path — eb.buf[eb.head] is an
+// index-out-of-range on a zero-length slice and eb.head % eb.size is an
+// integer divide-by-zero. The test exercises Add (and reads back via
+// Latest) FIRST so the revert fails AT the Add/modulo path, not at a size
+// assertion that would short-circuit before Add ever runs.
 func TestNewEventBufferZeroSize(t *testing.T) {
 	for _, size := range []int{0, -1, -100} {
 		eb := NewEventBuffer(size)
-		if eb.size < 1 {
-			t.Fatalf("NewEventBuffer(%d) left size=%d (<1)", size, eb.size)
-		}
-		// Must not panic on the first event.
-		eb.Add(EventRecord{Type: "SESSION_OPEN"})
+
+		// Drive the genuine Add/modulo path. A recover-based assertion
+		// turns the revert panic into a clear test failure attributed to
+		// the Add call (rather than a bare panic stack), and proves the
+		// fixed buffer accepts an event without panicking.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("NewEventBuffer(%d): Add panicked (size not clamped): %v", size, r)
+				}
+			}()
+			eb.Add(EventRecord{Type: "SESSION_OPEN"})
+		}()
+
 		if got := eb.Latest(1); len(got) != 1 {
 			t.Errorf("NewEventBuffer(%d): Latest(1) = %d, want 1", size, len(got))
+		}
+		// Sanity: the clamp left a usable capacity. Checked last so it
+		// never short-circuits the Add/modulo exercise above.
+		if eb.size < 1 {
+			t.Errorf("NewEventBuffer(%d) left size=%d (<1)", size, eb.size)
 		}
 	}
 }

--- a/pkg/logging/eventbuf_negative_3342_test.go
+++ b/pkg/logging/eventbuf_negative_3342_test.go
@@ -1,0 +1,56 @@
+package logging
+
+import "testing"
+
+// TestLatestNegativeN guards #3342: Latest(n) with a non-positive n must
+// return an empty slice and never reach make([]EventRecord, n), which panics
+// with "makeslice: len out of range" for a negative len.
+//
+// FAIL-ON-REVERT: removing the `if n <= 0 { return nil }` guard in Latest
+// makes Latest(-1) panic, failing this test.
+func TestLatestNegativeN(t *testing.T) {
+	eb := NewEventBuffer(8)
+	eb.Add(EventRecord{Type: "SESSION_OPEN"})
+	eb.Add(EventRecord{Type: "SESSION_CLOSE"})
+
+	for _, n := range []int{-1, -1000, 0} {
+		got := eb.Latest(n)
+		if len(got) != 0 {
+			t.Errorf("Latest(%d) = %d records, want 0", n, len(got))
+		}
+	}
+}
+
+// TestLatestFilteredNegativeN locks the contract symmetry with Latest: a
+// non-positive count returns empty rather than panicking or over-returning.
+func TestLatestFilteredNegativeN(t *testing.T) {
+	eb := NewEventBuffer(8)
+	eb.Add(EventRecord{Type: "SESSION_OPEN", Protocol: "TCP"})
+
+	for _, n := range []int{-1, -1000, 0} {
+		got := eb.LatestFiltered(n, EventFilter{})
+		if len(got) != 0 {
+			t.Errorf("LatestFiltered(%d) = %d records, want 0", n, len(got))
+		}
+	}
+}
+
+// TestNewEventBufferZeroSize guards the #3342 secondary footgun: a
+// non-positive size must be clamped so Add does not index an empty buffer
+// or divide by zero (head % size).
+//
+// FAIL-ON-REVERT: removing the `if size < 1` clamp in NewEventBuffer makes
+// the first Add panic (index out of range / integer divide by zero).
+func TestNewEventBufferZeroSize(t *testing.T) {
+	for _, size := range []int{0, -1, -100} {
+		eb := NewEventBuffer(size)
+		if eb.size < 1 {
+			t.Fatalf("NewEventBuffer(%d) left size=%d (<1)", size, eb.size)
+		}
+		// Must not panic on the first event.
+		eb.Add(EventRecord{Type: "SESSION_OPEN"})
+		if got := eb.Latest(1); len(got) != 1 {
+			t.Errorf("NewEventBuffer(%d): Latest(1) = %d, want 1", size, len(got))
+		}
+	}
+}


### PR DESCRIPTION
Closes #3342

## Problem
`EventBuffer.Latest(n)` did not clamp a non-positive `n`. A negative
count reached `make([]EventRecord, n)` and panicked the control-plane
process with `makeslice: len out of range`. The existing guards only
handled `n == 0` (`n > eb.count` is false for negative n).

Reachable from the operator surface: the interactive CLI parses the
event count with `strconv.Atoi` and no lower bound, so
`show security log -1` set `n=-1` → `Latest(-1)` → daemon crash. A single
CLI token crashes the daemon on a security appliance (codex-review-081
H01/H02/L02).

`LatestFiltered` already guarded `n <= 0 -> nil`, so this was an API
asymmetry, not an intentional contract.

Secondary footgun: `NewEventBuffer(size)` stored `size` with no lower
bound. `Add` computes `head % size`, so `NewEventBuffer(0)` would panic
(index-out-of-range / divide-by-zero) on the first event.

## Fix
- `Latest(n)`: `n <= 0 -> nil`, centralizing the same contract as
  `LatestFiltered` so a count argument behaves identically on both
  surfaces and never reaches the `make`.
- `NewEventBuffer(size)`: clamp `size < 1` to `defaultEventBufferSize`
  (1000, matching the production caller) so the ring is always usable.
- CLI `showSecurityLog`: reject a non-positive count with a clear error
  (`event count must be a positive integer`) — defense in depth at the
  boundary. The gRPC and REST paths already rejected `n < 0` and are
  unchanged.
- Doc: `pkg/logging/README.md` records the clamp + `n <= 0` contract.

## Tests (fail-on-revert)
- `pkg/logging`: `Latest(-1)`/`LatestFiltered(-1)` return empty;
  `NewEventBuffer(0).Add()` does not panic.
- `pkg/cli`: `show security log -1` returns an error; positive count
  still works.

RED-on-revert verified via copy-aside: removing each guard turns the
corresponding test red with `makeslice: len out of range` /
divide-by-zero panics. `go build ./...` + `go test ./pkg/logging/...
./cmd/cli/... ./pkg/cli/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi