### PR TITLE
config: reject firewall term mixing positive address with except (#3359)

### DIFF
--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -537,16 +537,26 @@ fail-closed via the `nets_match` empty guard returning `except` = false); an
 v6 vec, and a v6 address is trivially "not in" a v4 list, so the except term
 matches v6 (the v4 list does not constrain v6).
 
-Scope (this PR): the two clean cases — positive prefix-lists (with or without
-literal addresses) and an `except` prefix-list as the SOLE address source for
-the direction — are wired through. The MIXED case (literal/positive addresses
-AND an `except` prefix-list in the SAME direction of ONE term) has no single
-boolean-inversion representation; the `except` modifier is dropped (prefixes
-fold into the positive set) with a warning. That fold is **action-dependent in
-safety**: under-broadening the match is fail-safe for `accept`/permit terms but
-fail-OPEN for a `discard`/`reject` term (traffic the operator meant to drop via
-`except` is no longer dropped). Splitting into two terms is the operator
-workaround; the structured mixed case is a documented follow-up.
+Scope: the two clean cases — positive prefix-lists (with or without literal
+addresses) and an `except` prefix-list as the SOLE address source for the
+direction — are wired through. The MIXED case (literal/positive addresses AND an
+`except` prefix-list in the SAME direction of ONE term) has no single
+boolean-inversion representation (one direction would need both a positive set
+and a negated set). **It is now hard-rejected at commit**
+(`validateFilterAddressExceptStrict`, #3359) — Junos rejects the same
+combination — so the operator is told to split the term. Before #3359 the
+`except` modifier was silently dropped and its prefixes were FOLDED into the
+positive set with only a runtime warning; that fold was **fail-OPEN**: a
+`discard`/`reject` term no longer dropped the traffic the operator carved out via
+`except`, and an `accept` term ADMITTED the prefixes the operator wrote to
+exclude. On the tolerant load / peer-sync path (an already-persisted or
+peer-synced config — #1960 no-brick) the gate downgrades to a warning and the
+runtime is now **positive-wins** (the `except` prefixes are ignored, never folded
+in): an `accept` term's admit set is no wider than the operator's positive scope
+and a `discard`/`reject` term drops at least the positive set — fail-safe in both
+directions. Splitting into two terms is the operator fix; the faithful structured
+representation (a positive set AND a negated set per direction) is a documented
+follow-up. This is the address-match sibling of the #3297 port-except gate.
 
 **Firewall-filter `then loss-priority` is PARTIAL (parse-only, inert-with-warning, #2507).**
 `then loss-priority <low|medium-low|medium-high|high>` is parsed and stored on

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -388,6 +388,22 @@ type compileOpts struct {
 	// dataplane's positive-wins fallback keeps that direction fail-safe. Same
 	// doctrine as lenientFilterMatchValues.
 	lenientFilterPortExcept bool
+	// lenientFilterAddressExcept (#3359) downgrades the firewall-filter
+	// positive-vs-except ADDRESS mutual-exclusion gate
+	// (validateFilterAddressExceptStrict) from a hard compile error to a
+	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
+	// term that mixes a positive address match (a literal source-address /
+	// destination-address OR a non-except prefix-list) with an `except`
+	// prefix-list in the SAME direction — Junos treats those as mutually
+	// exclusive and rejects the term at commit. Before this gate xpf accepted
+	// the ambiguous term and the userspace lowering FOLDED the except prefixes
+	// into the positive match set (dropping the except modifier) — a silent
+	// fail-OPEN for a discard/reject term (#3359). The runtime fold is now
+	// positive-wins (the except side ignored, never folded in) so a
+	// leniently-loaded term is fail-safe; the tolerant load / peer-sync paths
+	// downgrade to a warning so an already-persisted or peer-synced config still
+	// BOOTS (#1960 no-brick). Sibling of lenientFilterPortExcept (#3297).
+	lenientFilterAddressExcept bool
 	// lenientFilterFromMatch (#3307) downgrades the firewall-filter
 	// unenforced-`from`-leaf gate (validateFilterFromMatchStrict) from a hard
 	// compile error to a cfg.Warnings entry. The strict commit / commit-check
@@ -1087,6 +1103,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFilterMatchValues:             true,
 		lenientFlexMatch:                     true,
 		lenientFilterPortExcept:              true,
+		lenientFilterAddressExcept:           true,
 		lenientFilterFromMatch:               true,
 		lenientFilterRoutingInstanceConflict: true,
 		lenientFilterDSCP:                    true,
@@ -1223,6 +1240,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFilterMatchValues:             true,
 		lenientFlexMatch:                     true,
 		lenientFilterPortExcept:              true,
+		lenientFilterAddressExcept:           true,
 		lenientFilterFromMatch:               true,
 		lenientFilterRoutingInstanceConflict: true,
 		lenientFilterDSCP:                    true,
@@ -2164,6 +2182,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFilterPortExcept {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("firewall filter port-except (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3359 firewall-filter positive-vs-except ADDRESS mutual-exclusion gate.
+	// Strict on commit / commit-check (hard-reject a term that mixes a positive
+	// address match — literal source/destination-address or a non-except
+	// prefix-list — with an `except` prefix-list in the same direction; Junos
+	// rejects this as ambiguous). Before this gate xpf accepted the term and the
+	// userspace lowering FOLDED the except prefixes into the positive set,
+	// dropping the except modifier — a silent fail-OPEN for a discard/reject
+	// term. Lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — #1960 no-brick; the dataplane's
+	// positive-wins fallback keeps that direction fail-safe). Sibling of the
+	// #3297 port-except gate above.
+	if err := validateFilterAddressExceptStrict(cfg); err != nil {
+		if opts.lenientFilterAddressExcept {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter address-except (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3421,6 +3421,110 @@ func validateFilterPortExceptStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// validateFilterAddressExceptStrict hard-rejects any firewall-filter term that
+// mixes a POSITIVE address match (a literal `source-address`/`destination-address`
+// OR a non-except `source-prefix-list`/`destination-prefix-list`) with an
+// `except` prefix-list in the SAME direction — #3359.
+//
+// Junos treats a positive address match and an `except` prefix-list as mutually
+// exclusive in one term and rejects the combination at commit. xpf's parser,
+// however, lands literal addresses on term.SourceAddresses / term.DestAddresses
+// and prefix-list references (positive AND except) on term.SourcePrefixLists /
+// term.DestPrefixLists (compileFilterFrom), so a positive set and an except set
+// can coexist on one direction of one term.
+//
+// The userspace lowering (pkg/dataplane/userspace/filters.go
+// resolvePrefixListAddrs) has no single boolean-inversion representation for the
+// mixed shape — one direction would need both a positive set and a negated set.
+// Before this gate it FOLDED the except prefixes into the positive match set
+// (dropping the `except` modifier) and only emitted a runtime slog.Warn. That
+// fold is a silent fail-OPEN on a stateless drop path: for a `discard`/`reject`
+// term the operator's `(positive) AND NOT (except)` (or `NOT(except)`) intent
+// collapses to a plain positive match, and traffic the operator meant to drop
+// via the except carve-out is no longer dropped. For an `accept` term the fold
+// is also fail-open in the other direction — it ADMITS the except prefixes the
+// operator wrote to exclude. The runtime fold is now changed to positive-wins
+// (the except side is ignored, never folded in) so a leniently-loaded term is
+// fail-safe; this gate makes the conflict an operator-visible commit error so
+// the term is split into faithful per-direction terms instead.
+//
+// The walk is deterministic (filters sorted by name, terms in config order). On
+// the tolerant load / peer-sync path the caller downgrades the returned error to
+// a warning (#1960 no-brick); the dataplane's positive-wins fallback keeps that
+// direction fail-safe independently. Mirrors validateFilterPortExceptStrict
+// (#3297, the port-match sibling of this address-match case).
+func validateFilterAddressExceptStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	// hasExcept reports whether any prefix-list ref in the direction carries the
+	// `except` modifier; hasPositiveRef whether any ref is a plain (non-except)
+	// reference.
+	hasExcept := func(refs []PrefixListRef) bool {
+		for _, ref := range refs {
+			if ref.Except {
+				return true
+			}
+		}
+		return false
+	}
+	hasPositiveRef := func(refs []PrefixListRef) bool {
+		for _, ref := range refs {
+			if !ref.Except {
+				return true
+			}
+		}
+		return false
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil {
+					continue
+				}
+				srcPositive := len(term.SourceAddresses) > 0 || hasPositiveRef(term.SourcePrefixLists)
+				if srcPositive && hasExcept(term.SourcePrefixLists) {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: a positive source "+
+							"address match (`from source-address` or a non-except "+
+							"`from source-prefix-list`) and an `except` "+
+							"source-prefix-list are mutually exclusive in the same "+
+							"term (Junos rejects this; split into separate terms — the "+
+							"mixed shape cannot be enforced faithfully and would "+
+							"fail open for discard/reject)",
+						family, name, term.Name)
+				}
+				dstPositive := len(term.DestAddresses) > 0 || hasPositiveRef(term.DestPrefixLists)
+				if dstPositive && hasExcept(term.DestPrefixLists) {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: a positive destination "+
+							"address match (`from destination-address` or a non-except "+
+							"`from destination-prefix-list`) and an `except` "+
+							"destination-prefix-list are mutually exclusive in the same "+
+							"term (Junos rejects this; split into separate terms — the "+
+							"mixed shape cannot be enforced faithfully and would "+
+							"fail open for discard/reject)",
+						family, name, term.Name)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // validateFilterFromMatchStrict hard-rejects any firewall-filter term whose
 // `from` block carries a match leaf the dataplane does NOT enforce — #3307.
 //

--- a/pkg/config/firewall_address_except_mutex_3359_test.go
+++ b/pkg/config/firewall_address_except_mutex_3359_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3359: a single firewall-filter term may carry BOTH a positive address match
+// (a literal source-address / destination-address OR a non-except prefix-list)
+// AND an `except` prefix-list in the same direction. Junos treats these as
+// mutually exclusive and rejects the term at commit. xpf's parser lands the
+// literal addresses and the prefix-list references (positive AND except) on
+// separate term fields, so both coexist; the userspace lowering then FOLDED the
+// except prefixes into the positive set (dropping the except modifier) — a
+// silent fail-OPEN for a discard/reject term (traffic the operator carved out
+// via `except` was no longer dropped). validateFilterAddressExceptStrict makes
+// the conflict an operator-visible commit error instead; the runtime fold is
+// now positive-wins (fail-safe) for any leniently-loaded term.
+//
+// FAIL-ON-REVERT: remove the validateFilterAddressExceptStrict invocation (or
+// the function's reject) and these strict-path tests go RED — CompileConfig
+// accepts the ambiguous term instead of erroring.
+
+func TestFilterSourceAddrPositiveAndExceptRejected_3359(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set policy-options prefix-list trusted 10.1.0.0/16",
+		"set firewall family inet filter f term t from source-address 10.0.0.0/8",
+		"set firewall family inet filter f term t from source-prefix-list trusted except",
+		"set firewall family inet filter f term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with both a positive source-address and an except " +
+			"source-prefix-list must be rejected at commit (Junos-invalid, #3359)")
+	}
+	if !strings.Contains(err.Error(), "source") ||
+		!strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error %q must name the source-address conflict", err)
+	}
+	if !strings.Contains(err.Error(), `filter "f"`) ||
+		!strings.Contains(err.Error(), `term "t"`) {
+		t.Fatalf("error %q must name the offending filter and term", err)
+	}
+	// Tolerant path downgrades to a warning so a persisted/peer-synced config
+	// still boots (#1960 no-brick); the dataplane positive-wins fallback keeps
+	// the direction fail-safe.
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the address-except conflict: %v", lerr)
+	}
+}
+
+// A positive PREFIX-LIST (not a literal address) mixed with an except
+// prefix-list in the same direction must also be rejected.
+func TestFilterDestPrefixListPositiveAndExceptRejected_3359(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set policy-options prefix-list servers 192.168.0.0/16",
+		"set policy-options prefix-list mgmt 192.168.1.0/24",
+		"set firewall family inet filter f term t from destination-prefix-list servers",
+		"set firewall family inet filter f term t from destination-prefix-list mgmt except",
+		"set firewall family inet filter f term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("term with both a positive destination-prefix-list and an except " +
+			"destination-prefix-list must be rejected at commit (#3359)")
+	}
+	if !strings.Contains(err.Error(), "destination") ||
+		!strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error %q must name the destination-address conflict", err)
+	}
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the address-except conflict: %v", lerr)
+	}
+}
+
+// inet6 family must be gated identically (the validator walks both families).
+func TestFilterSourceAddrPositiveAndExceptRejectedV6_3359(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set policy-options prefix-list trusted6 2001:db8:1::/48",
+		"set firewall family inet6 filter f6 term t from source-address 2001:db8::/32",
+		"set firewall family inet6 filter f6 term t from source-prefix-list trusted6 except",
+		"set firewall family inet6 filter f6 term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("inet6 term with both a positive source-address and an except " +
+			"source-prefix-list must be rejected at commit (#3359)")
+	}
+	if !strings.Contains(err.Error(), "inet6") {
+		t.Fatalf("error %q must name the inet6 family", err)
+	}
+}
+
+// A term with ONLY positive addresses, or ONLY an except prefix-list, must
+// still compile cleanly — the gate fires only when both shapes are present in
+// one direction. A positive source + except destination (different directions)
+// is also allowed.
+func TestFilterAddressExceptOnlyOneSideAccepted_3359(t *testing.T) {
+	posOnly := buildFilterTree(t,
+		"set policy-options prefix-list pl 10.2.0.0/16",
+		"set firewall family inet filter pos term t from source-address 10.0.0.0/8",
+		"set firewall family inet filter pos term t from source-prefix-list pl",
+		"set firewall family inet filter pos term t then discard",
+	)
+	if _, err := CompileConfig(posOnly); err != nil {
+		t.Fatalf("positive source-address + positive prefix-list must compile: %v", err)
+	}
+	exceptOnly := buildFilterTree(t,
+		"set policy-options prefix-list trusted 10.1.0.0/16",
+		"set firewall family inet filter exc term t from source-prefix-list trusted except",
+		"set firewall family inet filter exc term t then discard",
+	)
+	if _, err := CompileConfig(exceptOnly); err != nil {
+		t.Fatalf("except prefix-list alone must compile: %v", err)
+	}
+	// Positive source + except destination (different directions) is allowed —
+	// the conflict is per-direction.
+	crossDir := buildFilterTree(t,
+		"set policy-options prefix-list trusted 10.1.0.0/16",
+		"set firewall family inet filter cross term t from source-address 10.0.0.0/8",
+		"set firewall family inet filter cross term t from destination-prefix-list trusted except",
+		"set firewall family inet filter cross term t then discard",
+	)
+	if _, err := CompileConfig(crossDir); err != nil {
+		t.Fatalf("source-address + destination-prefix-list except (different directions) must compile: %v", err)
+	}
+}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -663,9 +663,11 @@ firewall {
         filter filter-mgmt {
             term block_unauthorised {
                 from {
-                    source-address {
-                        0.0.0.0/0;
-                    }
+                    /* A clean source-prefix-list except already means "match
+                       every source NOT in the list"; mixing it with a positive
+                       source-address (e.g. 0.0.0.0/0) in one term is the #3359
+                       fail-open shape and is now rejected at commit
+                       (validateFilterAddressExceptStrict). */
                     source-prefix-list {
                         management-hosts except;
                     }

--- a/pkg/dataplane/userspace/filters.go
+++ b/pkg/dataplane/userspace/filters.go
@@ -264,13 +264,20 @@ func buildFilterTermSnapshots(filterName string, filter *config.FirewallFilter, 
 // The MIXED case — literal/positive addresses AND an `except` prefix-list in
 // the SAME direction of ONE term — has no single boolean-inversion
 // representation (one direction would need both a positive set and a negated
-// set). Rather than silently pick a wrong interpretation, the except modifier
-// is dropped (the prefixes fold into the positive set) and a warning is
-// emitted. This fold is ACTION-DEPENDENT in safety: it under-broadens the match
-// (the listed prefixes are matched positively instead of excluded), which is
-// fail-safe for `accept`/permit terms but fail-OPEN for a `discard`/`reject`
-// term (traffic the operator meant to drop via `except` is no longer dropped).
-// The structured mixed case is a documented follow-up.
+// set). This shape is hard-rejected at commit by
+// config.validateFilterAddressExceptStrict (#3359); it reaches here only on the
+// tolerant load / peer-sync path (an already-persisted or peer-synced config —
+// #1960 no-brick). The resolution is POSITIVE-WINS: the except prefixes are
+// IGNORED (never folded into the positive set) and a warning is emitted. The
+// earlier behavior folded the except prefixes INTO the positive set, which was
+// fail-OPEN: a `discard`/`reject` term then no longer dropped the traffic the
+// operator carved out via `except`, and an `accept` term ADMITTED the prefixes
+// the operator wrote to exclude. Positive-wins keeps an `accept` term's admit
+// set no wider than the operator's positive scope and keeps a `discard`/`reject`
+// term dropping at least the positive set — fail-safe in both directions.
+// Sibling of the #3297 port-except positive-wins fallback. The faithful
+// structured representation (a positive set AND a negated set per direction) is
+// a documented follow-up.
 //
 // An undefined prefix-list reference is NOT silently dropped here — it is a
 // strict commit-time error (validateFirewallPrefixListReferencesStrict, #1960
@@ -338,14 +345,26 @@ func resolvePrefixListAddrs(
 
 	if hasExcept {
 		// Mixed positive + except in one direction — out of scope for the
-		// boolean-inversion model. Fold the except prefixes into the positive
-		// set and warn so the operator can split the term. Documented
-		// follow-up. (Action-dependent safety — see the doc comment above.)
+		// boolean-inversion model (one direction would need both a positive set
+		// and a negated set). This shape is hard-rejected at commit by
+		// validateFilterAddressExceptStrict (#3359); it only reaches here on the
+		// tolerant load / peer-sync path (an already-persisted or peer-synced
+		// config — #1960 no-brick). POSITIVE-WINS: ignore the except prefixes
+		// entirely (do NOT fold them in) and warn so the operator splits the
+		// term. The earlier fold (`positive = append(positive, exceptPrefixes)`)
+		// was fail-OPEN: it widened the match by treating the excepted prefixes
+		// as a positive match, so a `discard`/`reject` term no longer dropped
+		// the traffic the operator carved out via `except`, and an `accept` term
+		// ADMITTED the prefixes the operator wrote to exclude. Dropping the
+		// except side instead keeps an `accept` term's admit set no wider than
+		// the operator's positive scope and keeps a `discard`/`reject` term
+		// dropping at least the positive set — fail-safe in both directions.
+		// Sibling of the #3297 port-except positive-wins fallback.
 		slog.Warn("firewall filter term mixes literal/positive addresses with an "+
 			"except prefix-list in one direction; the except modifier is ignored "+
-			"(prefixes treated as a positive match). Split into separate terms.",
+			"(positive-wins — the except prefixes are NOT matched). Split into "+
+			"separate terms (commit rejects this shape, #3359).",
 			"filter", filterName, "term", termName, "direction", direction)
-		positive = append(positive, exceptPrefixes...)
 	}
 
 	// `positive` may be empty here (e.g. a positive prefix-list that resolved to

--- a/pkg/dataplane/userspace/filters_address_except_3359_test.go
+++ b/pkg/dataplane/userspace/filters_address_except_3359_test.go
@@ -1,0 +1,78 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3359: a firewall-filter term mixing a positive address match (a literal
+// source/destination-address or a non-except prefix-list) with an `except`
+// prefix-list in the same direction has no faithful boolean-inversion form. The
+// commit gate (config.validateFilterAddressExceptStrict) rejects the shape, but
+// an already-persisted / peer-synced config can still reach the userspace
+// lowering on the tolerant path. resolvePrefixListAddrs MUST be fail-safe there:
+// POSITIVE-WINS — the except prefixes are ignored (NOT folded into the positive
+// set). The earlier code did `positive = append(positive, exceptPrefixes...)`,
+// which was fail-OPEN: a discard/reject term no longer dropped the excepted
+// traffic and an accept term admitted the prefixes the operator wrote to
+// exclude.
+//
+// FAIL-ON-REVERT: restore the fold and `except` (10.1.0.0/16) appears in the
+// returned positive set — this test goes RED.
+func TestResolvePrefixListAddrsMixedPositiveExceptFailsSafe_3359(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.PolicyOptions.PrefixLists = map[string]*config.PrefixList{
+		"trusted": {Name: "trusted", Prefixes: []string{"10.1.0.0/16"}},
+	}
+
+	// Positive literal 10.0.0.0/8 + except prefix-list trusted (10.1.0.0/16) in
+	// the same (source) direction.
+	addrs, except, constrained := resolvePrefixListAddrs(
+		[]string{"10.0.0.0/8"},
+		[]config.PrefixListRef{{Name: "trusted", Except: true}},
+		cfg, "f", "t", "source",
+	)
+
+	if except {
+		t.Fatalf("mixed positive+except must resolve except=false (positive-wins), got except=true")
+	}
+	if !constrained {
+		t.Fatalf("a term with a written address scope must stay constrained")
+	}
+	// The positive set must be EXACTLY the operator's positive scope — the
+	// except prefixes must NOT be folded in (the #3359 fail-open).
+	for _, a := range addrs {
+		if a == "10.1.0.0/16" {
+			t.Fatalf("except prefix 10.1.0.0/16 was folded into the positive set "+
+				"(fail-OPEN #3359); positive-wins must drop it. addrs=%v", addrs)
+		}
+	}
+	if len(addrs) != 1 || addrs[0] != "10.0.0.0/8" {
+		t.Fatalf("positive set = %v, want exactly [10.0.0.0/8] (positive-wins)", addrs)
+	}
+}
+
+// The clean except case (an except prefix-list as the SOLE address source for
+// the direction) is unchanged and must still produce except=true so the matcher
+// evaluates "match everything NOT in the list".
+func TestResolvePrefixListAddrsCleanExceptUnchanged_3359(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.PolicyOptions.PrefixLists = map[string]*config.PrefixList{
+		"trusted": {Name: "trusted", Prefixes: []string{"10.1.0.0/16"}},
+	}
+	addrs, except, constrained := resolvePrefixListAddrs(
+		nil,
+		[]config.PrefixListRef{{Name: "trusted", Except: true}},
+		cfg, "f", "t", "source",
+	)
+	if !except {
+		t.Fatalf("clean except case must resolve except=true, got false")
+	}
+	if !constrained {
+		t.Fatalf("clean except case must stay constrained")
+	}
+	if len(addrs) != 1 || addrs[0] != "10.1.0.0/16" {
+		t.Fatalf("clean except prefixes = %v, want [10.1.0.0/16]", addrs)
+	}
+}

--- a/pkg/dataplane/userspace/filters_prefix_list_2506_test.go
+++ b/pkg/dataplane/userspace/filters_prefix_list_2506_test.go
@@ -106,9 +106,18 @@ func TestFilterSnapshotDestPrefixListExcept(t *testing.T) {
 }
 
 // The mixed case (literal addresses + an except prefix-list in ONE direction)
-// is out of scope: the except modifier is dropped (folded to a positive set)
-// rather than silently mis-inverting.
-func TestFilterSnapshotMixedLiteralAndExceptFoldsPositive(t *testing.T) {
+// is out of scope for the boolean-inversion model and is hard-rejected at commit
+// (config.validateFilterAddressExceptStrict, #3359). It reaches the userspace
+// lowering only on the tolerant load / peer-sync path, where the resolver is
+// POSITIVE-WINS: the except modifier is dropped AND the except prefixes are NOT
+// folded into the positive set. The earlier fold (`append(positive,
+// exceptPrefixes...)`) was fail-OPEN — it widened the match by treating the
+// excepted prefixes as a positive match, so a discard/reject term no longer
+// dropped the operator's carve-out (#3359).
+//
+// FAIL-ON-REVERT: restore the fold and the except prefix 10.0.0.0/8 reappears in
+// SourceAddresses — this test goes RED.
+func TestFilterSnapshotMixedLiteralAndExceptPositiveWins(t *testing.T) {
 	cfg := prefixListCfg(
 		[]config.PrefixListRef{{Name: "internal", Except: true}},
 		nil,
@@ -120,9 +129,12 @@ func TestFilterSnapshotMixedLiteralAndExceptFoldsPositive(t *testing.T) {
 	if term.SourceExcept {
 		t.Fatal("mixed literal+except must NOT set source_except (ambiguous, scoped out)")
 	}
-	want := []string{"192.168.0.0/16", "10.0.0.0/8"}
+	want := []string{"192.168.0.0/16"}
 	if !reflect.DeepEqual(term.SourceAddresses, want) {
-		t.Fatalf("source addresses = %v, want %v (mixed folds to positive)", term.SourceAddresses, want)
+		t.Fatalf("source addresses = %v, want %v (positive-wins: except NOT folded in, #3359)", term.SourceAddresses, want)
+	}
+	if !term.SourceConstrained {
+		t.Error("source_constrained MUST stay true for a term with a written address scope")
 	}
 }
 

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -652,8 +652,15 @@ type FirewallTermSnapshot struct {
 	// SourceAddresses / DestAddresses set (Junos `from source-prefix-list NAME
 	// except` / `destination-prefix-list NAME except`). The Rust matcher
 	// evaluates `(addr ∈ prefixes) XOR except`. These are populated only when the
-	// except prefix-list is the sole address source for the direction; the mixed
-	// literal+except case folds to a positive set (see resolvePrefixListAddrs).
+	// except prefix-list is the sole address source for the direction. The mixed
+	// positive+except case (a literal/positive address AND an except prefix-list
+	// in the same direction) is hard-rejected at strict commit
+	// (config.validateFilterAddressExceptStrict, #3359); on the lenient /
+	// peer-sync path resolvePrefixListAddrs resolves it POSITIVE-WINS — the
+	// except prefixes are IGNORED (except stays false), NOT folded into the
+	// positive set — so a leniently-loaded term is fail-safe (an accept term's
+	// admit set is no wider than the positive scope; a discard/reject term drops
+	// at least the positive set).
 	SourceExcept bool `json:"source_except,omitempty"`
 	DestExcept   bool `json:"destination_except,omitempty"`
 	// SourceConstrained / DestConstrained record that the term SPECIFIED a


### PR DESCRIPTION
## Summary

Closes #3359 — the address-match sibling of #3297 (port positive+except).

A single firewall-filter term may carry BOTH a positive address match (a literal `source-address`/`destination-address` OR a non-except prefix-list) AND an `except` prefix-list in the SAME direction. Junos rejects this; xpf accepted it and the userspace lowering FOLDED the except prefixes into the positive set, dropping the `except` modifier with only a runtime warning. That fold is a silent **fail-OPEN**: a `discard`/`reject` term no longer drops the traffic the operator carved out via `except`, and an `accept` term ADMITS the prefixes the operator wrote to exclude.

## Decision: strict-reject + runtime fail-safe (mirror #3297)

1. **Strict commit gate** `validateFilterAddressExceptStrict` (pkg/config) hard-rejects a term mixing a positive address match with an `except` prefix-list in the same direction — source + destination, inet + inet6. Wired right after the #3297 port-except gate with the #1960/#3261 lenient downgrade (`lenientFilterAddressExcept`): warn on tolerant-load/peer-sync (no-brick), hard-reject on commit.

2. **Runtime fail-safe.** The current fold WAS fail-open. Fixed `resolvePrefixListAddrs` (pkg/dataplane/userspace/filters.go) so the mixed case is now **positive-wins**: the except prefixes are ignored (never folded in). An `accept` term's admit set is then no wider than the operator's positive scope; a `discard`/`reject` term drops at least the positive set — fail-safe both directions. No Rust change needed (positive-wins emits `except=false` with only positive addrs; the existing wire flags + matcher handle it).

## Tests (fail-on-revert)

- **Strict:** source + destination, inet + inet6 → commit REJECTED; plus the lenient-path downgrade and one-side-only / cross-direction negatives. Disabling the reject turns 3 config tests RED.
- **Runtime fail-safe:** the mixed positive+except resolves to positive-only with `except=false`; the except prefix must NOT appear in the resolved set. Restoring the fold turns 2 dataplane tests RED.
- Updated the pre-existing `TestFilterSnapshotMixed...` and `TestFirewallPrefixList` (its `source-address 0.0.0.0/0` + except `reject` shape is the exact #3359 fail-open case) to the new fail-safe semantics.

`go build ./...` and `go test ./pkg/config/... ./pkg/dataplane/...` pass. docs/feature-gaps.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi