### PR TITLE
cli: harden monitor security flow trace file + filter parsing (#3378/#3379/#3380)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22757,3 +22757,8 @@ top.
 - **Timestamp**: 2026-06-28
 - **Action**: #3379 — enforce size/files rotation in the flow-trace writer (traceWriter + rotateTraceFile); rotate at `size`, cap at `files` generations.
 - **File(s)**: pkg/cli/monitor.go, pkg/cli/monitor_security_test.go
+
+## 2026-06-28 — #3380 monitor security flow/packet-drop fail-open parsing
+- **Timestamp**: 2026-06-28
+- **Action**: #3380 — atomic parse for flow file/filter (commit only after all tokens validate), default cases reject unknown tokens, require option values, reject empty (match-all) filters, reject edits while active; same default+require-value hardening for packet-drop.
+- **File(s)**: pkg/cli/monitor.go, pkg/cli/monitor_security_test.go, pkg/cli/monitor_match_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -22747,3 +22747,8 @@ top.
   pkg/cli/cli_show_security_log.go,
   pkg/logging/eventbuf_negative_3342_test.go,
   pkg/cli/cli_show_security_log_negative_3342_test.go, _Log.md
+
+## 2026-06-28 — #3378 monitor security flow trace file hardening
+- **Timestamp**: 2026-06-28
+- **Action**: #3378 — sanitize trace filename (basename only, reject `..`/separators/absolute), open O_NOFOLLOW + regular-file check, create mode 0600 (was 0644). Validate at config and defensively at open.
+- **File(s)**: pkg/cli/monitor.go, pkg/cli/monitor_security_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -22752,3 +22752,8 @@ top.
 - **Timestamp**: 2026-06-28
 - **Action**: #3378 — sanitize trace filename (basename only, reject `..`/separators/absolute), open O_NOFOLLOW + regular-file check, create mode 0600 (was 0644). Validate at config and defensively at open.
 - **File(s)**: pkg/cli/monitor.go, pkg/cli/monitor_security_test.go
+
+## 2026-06-28 — #3379 monitor security flow rotation enforcement
+- **Timestamp**: 2026-06-28
+- **Action**: #3379 — enforce size/files rotation in the flow-trace writer (traceWriter + rotateTraceFile); rotate at `size`, cap at `files` generations.
+- **File(s)**: pkg/cli/monitor.go, pkg/cli/monitor_security_test.go

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -5,14 +5,71 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/psaab/xpf/pkg/logging"
 )
+
+// traceLogDir is the directory flow-trace files are written to. It is a
+// package var (not a const) only so tests can redirect it to a temp dir;
+// production always writes under /var/log.
+var traceLogDir = "/var/log"
+
+// sanitizeTraceFilename validates an operator-supplied flow-trace filename.
+// The trace file always lives directly under traceLogDir, so only a bare
+// basename is accepted: path separators, "." / "..", and absolute paths are
+// rejected. Without this a "monitor security flow file ../../etc/x" command
+// resolves to /var/log/../../etc/x and the daemon appends root-written flow
+// telemetry outside the log directory (#3378 HC-01).
+func sanitizeTraceFilename(name string) error {
+	if name == "" {
+		return fmt.Errorf("trace filename must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid trace filename: %q", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("trace filename must be a bare name, not a path: %q", name)
+	}
+	if name != filepath.Base(name) {
+		return fmt.Errorf("trace filename must be a bare name, not a path: %q", name)
+	}
+	return nil
+}
+
+// openTraceFile opens the flow-trace file inside traceLogDir with restrictive
+// permissions. The name is sanitized first (basename only), the file is opened
+// O_NOFOLLOW so a pre-planted symlink under /var/log cannot redirect the
+// root-written telemetry (#3378 MC-02), the opened descriptor is verified to be
+// a regular file, and it is created mode 0600 rather than world-readable 0644
+// — flow tuples/zones/policy names are audit-grade telemetry (#3378 MC-01).
+func openTraceFile(name string) (*os.File, string, error) {
+	if err := sanitizeTraceFilename(name); err != nil {
+		return nil, "", err
+	}
+	path := filepath.Join(traceLogDir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, path, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, path, err
+	}
+	if !fi.Mode().IsRegular() {
+		f.Close()
+		return nil, path, fmt.Errorf("trace target %s is not a regular file", path)
+	}
+	return f, path, nil
+}
 
 // monitorFlowFilter holds the criteria for a single named flow filter.
 type monitorFlowFilter struct {
@@ -214,7 +271,12 @@ func (c *CLI) handleMonitorSecurityFlowFile(args []string) error {
 		return nil
 	}
 
-	// First non-option arg is the filename.
+	// First non-option arg is the filename; reject path traversal up front so a
+	// bad name is never stored (#3378).
+	if err := sanitizeTraceFilename(args[0]); err != nil {
+		fmt.Printf("error: %v\n", err)
+		return nil
+	}
 	c.monitorFlow.filename = args[0]
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
@@ -385,13 +447,13 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 	// <regex>` filter actually drops non-matching trace lines (#2288).
 	matchRe := c.monitorFlow.matchRe
 
-	// Open trace file.
-	path := "/var/log/" + c.monitorFlow.filename
-	logFile, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	// Open trace file inside /var/log with a sanitized basename, O_NOFOLLOW,
+	// regular-file verification and mode 0600 (#3378).
+	logFile, _, err := openTraceFile(c.monitorFlow.filename)
 	if err != nil {
 		c.monitorFlow.active = false
 		c.monitorFlow.mu.Unlock()
-		return fmt.Errorf("failed to open trace file %s: %w", path, err)
+		return fmt.Errorf("failed to open trace file: %w", err)
 	}
 
 	// Subscribe to event buffer.
@@ -468,7 +530,7 @@ func (c *CLI) showMonitorSecurityFlow() error {
 
 	fmt.Printf("  Monitor security flow session status: %s\n", status)
 	if c.monitorFlow.filename != "" {
-		fmt.Printf("  Monitor security flow trace file: /var/log/%s\n", c.monitorFlow.filename)
+		fmt.Printf("  Monitor security flow trace file: %s\n", filepath.Join(traceLogDir, c.monitorFlow.filename))
 	} else {
 		fmt.Printf("  Monitor security flow trace file: (not configured)\n")
 	}

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -325,53 +325,85 @@ func (c *CLI) handleMonitorSecurityFlowFile(args []string) error {
 	c.monitorFlow.mu.Lock()
 	defer c.monitorFlow.mu.Unlock()
 
+	if c.monitorFlow.active {
+		fmt.Println("error: stop the active flow monitor before changing the trace file.")
+		return nil
+	}
+
 	if len(args) == 0 {
 		fmt.Println("error: Please specify the trace filename.")
 		return nil
 	}
 
-	// First non-option arg is the filename; reject path traversal up front so a
-	// bad name is never stored (#3378).
+	// Parse every token into locals and commit atomically only after all of
+	// them validate (#3380 HC-04/MC-07/MC-08). Previously the filename and
+	// each option were written into the shared state as they were parsed, so a
+	// later failing option (a bad regex, an out-of-range size) left a
+	// half-applied config — including a possibly-traversal filename — behind,
+	// and unknown tokens / value-less options were silently dropped.
 	if err := sanitizeTraceFilename(args[0]); err != nil {
 		fmt.Printf("error: %v\n", err)
 		return nil
 	}
-	c.monitorFlow.filename = args[0]
+	filename := args[0]
+	// Seed from current state so existing size/files/match survive a command
+	// that only changes one option.
+	fileSize := c.monitorFlow.fileSize
+	files := c.monitorFlow.files
+	matchPat := c.monitorFlow.match
+	matchRe := c.monitorFlow.matchRe
+
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
 		case "size":
-			if i+1 < len(args) {
-				i++
-				v, err := strconv.ParseInt(args[i], 10, 64)
-				if err != nil || v < 10240 || v > 1073741824 {
-					fmt.Println("error: size must be 10240..1073741824")
-					return nil
-				}
-				c.monitorFlow.fileSize = v
+			if i+1 >= len(args) {
+				fmt.Println("error: size requires a value")
+				return nil
 			}
+			i++
+			v, err := strconv.ParseInt(args[i], 10, 64)
+			if err != nil || v < 10240 || v > 1073741824 {
+				fmt.Println("error: size must be 10240..1073741824")
+				return nil
+			}
+			fileSize = v
 		case "files":
-			if i+1 < len(args) {
-				i++
-				v, err := strconv.Atoi(args[i])
-				if err != nil || v < 2 || v > 1000 {
-					fmt.Println("error: files must be 2..1000")
-					return nil
-				}
-				c.monitorFlow.files = v
+			if i+1 >= len(args) {
+				fmt.Println("error: files requires a value")
+				return nil
 			}
+			i++
+			v, err := strconv.Atoi(args[i])
+			if err != nil || v < 2 || v > 1000 {
+				fmt.Println("error: files must be 2..1000")
+				return nil
+			}
+			files = v
 		case "match":
-			if i+1 < len(args) {
-				i++
-				re, err := regexp.Compile(args[i])
-				if err != nil {
-					fmt.Printf("error: invalid match regex %q: %v\n", args[i], err)
-					return nil
-				}
-				c.monitorFlow.match = args[i]
-				c.monitorFlow.matchRe = re
+			if i+1 >= len(args) {
+				fmt.Println("error: match requires a value")
+				return nil
 			}
+			i++
+			re, err := regexp.Compile(args[i])
+			if err != nil {
+				fmt.Printf("error: invalid match regex %q: %v\n", args[i], err)
+				return nil
+			}
+			matchPat = args[i]
+			matchRe = re
+		default:
+			fmt.Printf("error: unknown flow file option: %s\n", args[i])
+			return nil
 		}
 	}
+
+	// All tokens validated: commit.
+	c.monitorFlow.filename = filename
+	c.monitorFlow.fileSize = fileSize
+	c.monitorFlow.files = files
+	c.monitorFlow.match = matchPat
+	c.monitorFlow.matchRe = matchRe
 	return nil
 }
 
@@ -383,89 +415,128 @@ func (c *CLI) handleMonitorSecurityFlowFilter(args []string) error {
 	c.monitorFlow.mu.Lock()
 	defer c.monitorFlow.mu.Unlock()
 
+	if c.monitorFlow.active {
+		fmt.Println("error: stop the active flow monitor before editing filters.")
+		return nil
+	}
+
 	if len(args) == 0 {
 		fmt.Println("error: Please specify the filter name.")
 		return nil
 	}
 
+	// Build into a temporary filter (seeded from the existing one if present)
+	// and commit it into the map only after every token validates (#3380
+	// HC-03/MC-07/MC-08). Previously the named filter was inserted before any
+	// value was parsed, so a command that then failed left an empty filter in
+	// the map — and an empty filter matches every event, silently arming broad
+	// tracing of all flows. Unknown tokens and value-less options were also
+	// dropped, widening collection instead of erroring.
 	name := args[0]
-	f, ok := c.monitorFlow.filters[name]
-	if !ok {
-		f = &monitorFlowFilter{Name: name}
-		c.monitorFlow.filters[name] = f
+	f := &monitorFlowFilter{Name: name}
+	if existing, ok := c.monitorFlow.filters[name]; ok {
+		fc := *existing
+		f = &fc
 	}
 
 	for i := 1; i < len(args); i++ {
 		switch args[i] {
 		case "source-prefix":
-			if i+1 < len(args) {
-				i++
-				_, cidr, err := net.ParseCIDR(args[i])
-				if err != nil {
-					// Try as host address
-					ip := net.ParseIP(args[i])
-					if ip == nil {
-						fmt.Printf("error: invalid source-prefix: %s\n", args[i])
-						return nil
-					}
-					if ip.To4() != nil {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
-					} else {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
-					}
-				}
-				f.SrcIP = cidr
+			if i+1 >= len(args) {
+				fmt.Println("error: source-prefix requires a value")
+				return nil
 			}
+			i++
+			_, cidr, err := net.ParseCIDR(args[i])
+			if err != nil {
+				// Try as host address
+				ip := net.ParseIP(args[i])
+				if ip == nil {
+					fmt.Printf("error: invalid source-prefix: %s\n", args[i])
+					return nil
+				}
+				if ip.To4() != nil {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+				} else {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+				}
+			}
+			f.SrcIP = cidr
 		case "destination-prefix":
-			if i+1 < len(args) {
-				i++
-				_, cidr, err := net.ParseCIDR(args[i])
-				if err != nil {
-					ip := net.ParseIP(args[i])
-					if ip == nil {
-						fmt.Printf("error: invalid destination-prefix: %s\n", args[i])
-						return nil
-					}
-					if ip.To4() != nil {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
-					} else {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
-					}
-				}
-				f.DstIP = cidr
+			if i+1 >= len(args) {
+				fmt.Println("error: destination-prefix requires a value")
+				return nil
 			}
+			i++
+			_, cidr, err := net.ParseCIDR(args[i])
+			if err != nil {
+				ip := net.ParseIP(args[i])
+				if ip == nil {
+					fmt.Printf("error: invalid destination-prefix: %s\n", args[i])
+					return nil
+				}
+				if ip.To4() != nil {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+				} else {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+				}
+			}
+			f.DstIP = cidr
 		case "source-port":
-			if i+1 < len(args) {
-				i++
-				p, err := strconv.ParseUint(args[i], 10, 16)
-				if err != nil {
-					fmt.Printf("error: invalid source-port: %s\n", args[i])
-					return nil
-				}
-				f.SrcPort = uint16(p)
+			if i+1 >= len(args) {
+				fmt.Println("error: source-port requires a value")
+				return nil
 			}
+			i++
+			p, err := strconv.ParseUint(args[i], 10, 16)
+			if err != nil {
+				fmt.Printf("error: invalid source-port: %s\n", args[i])
+				return nil
+			}
+			f.SrcPort = uint16(p)
 		case "destination-port":
-			if i+1 < len(args) {
-				i++
-				p, err := strconv.ParseUint(args[i], 10, 16)
-				if err != nil {
-					fmt.Printf("error: invalid destination-port: %s\n", args[i])
-					return nil
-				}
-				f.DstPort = uint16(p)
+			if i+1 >= len(args) {
+				fmt.Println("error: destination-port requires a value")
+				return nil
 			}
+			i++
+			p, err := strconv.ParseUint(args[i], 10, 16)
+			if err != nil {
+				fmt.Printf("error: invalid destination-port: %s\n", args[i])
+				return nil
+			}
+			f.DstPort = uint16(p)
 		case "protocol":
-			if i+1 < len(args) {
-				i++
-				f.Protocol = args[i]
+			if i+1 >= len(args) {
+				fmt.Println("error: protocol requires a value")
+				return nil
 			}
+			i++
+			f.Protocol = args[i]
 		case "interface":
-			if i+1 < len(args) {
-				i++
-				f.Iface = args[i]
+			if i+1 >= len(args) {
+				fmt.Println("error: interface requires a value")
+				return nil
 			}
+			i++
+			f.Iface = args[i]
+		default:
+			fmt.Printf("error: unknown flow filter option: %s\n", args[i])
+			return nil
 		}
 	}
+
+	// Reject a filter with no match criteria: an empty filter matches every
+	// event, so silently installing one would fail open into broad tracing of
+	// all flows (#3380 HC-03).
+	if f.SrcIP == nil && f.DstIP == nil && f.SrcPort == 0 && f.DstPort == 0 &&
+		f.Protocol == "" && f.Iface == "" {
+		fmt.Println("error: filter requires at least one match criterion.")
+		return nil
+	}
+
+	// All tokens validated: commit the filter atomically.
+	c.monitorFlow.filters[name] = f
 	return nil
 }
 
@@ -672,86 +743,105 @@ func (c *CLI) handleMonitorSecurityPacketDrop(args []string) error {
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "source-prefix":
-			if i+1 < len(args) {
-				i++
-				_, cidr, err := net.ParseCIDR(args[i])
-				if err != nil {
-					ip := net.ParseIP(args[i])
-					if ip == nil {
-						fmt.Printf("error: invalid source-prefix: %s\n", args[i])
-						return nil
-					}
-					if ip.To4() != nil {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
-					} else {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
-					}
-				}
-				srcIP = cidr
+			if i+1 >= len(args) {
+				fmt.Println("error: source-prefix requires a value")
+				return nil
 			}
+			i++
+			_, cidr, err := net.ParseCIDR(args[i])
+			if err != nil {
+				ip := net.ParseIP(args[i])
+				if ip == nil {
+					fmt.Printf("error: invalid source-prefix: %s\n", args[i])
+					return nil
+				}
+				if ip.To4() != nil {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+				} else {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+				}
+			}
+			srcIP = cidr
 		case "destination-prefix":
-			if i+1 < len(args) {
-				i++
-				_, cidr, err := net.ParseCIDR(args[i])
-				if err != nil {
-					ip := net.ParseIP(args[i])
-					if ip == nil {
-						fmt.Printf("error: invalid destination-prefix: %s\n", args[i])
-						return nil
-					}
-					if ip.To4() != nil {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
-					} else {
-						cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
-					}
-				}
-				dstIP = cidr
+			if i+1 >= len(args) {
+				fmt.Println("error: destination-prefix requires a value")
+				return nil
 			}
+			i++
+			_, cidr, err := net.ParseCIDR(args[i])
+			if err != nil {
+				ip := net.ParseIP(args[i])
+				if ip == nil {
+					fmt.Printf("error: invalid destination-prefix: %s\n", args[i])
+					return nil
+				}
+				if ip.To4() != nil {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+				} else {
+					cidr = &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
+				}
+			}
+			dstIP = cidr
 		case "source-port":
-			if i+1 < len(args) {
-				i++
-				p, err := strconv.ParseUint(args[i], 10, 16)
-				if err != nil {
-					fmt.Printf("error: invalid source-port: %s\n", args[i])
-					return nil
-				}
-				srcPort = uint16(p)
+			if i+1 >= len(args) {
+				fmt.Println("error: source-port requires a value")
+				return nil
 			}
+			i++
+			p, err := strconv.ParseUint(args[i], 10, 16)
+			if err != nil {
+				fmt.Printf("error: invalid source-port: %s\n", args[i])
+				return nil
+			}
+			srcPort = uint16(p)
 		case "destination-port":
-			if i+1 < len(args) {
-				i++
-				p, err := strconv.ParseUint(args[i], 10, 16)
-				if err != nil {
-					fmt.Printf("error: invalid destination-port: %s\n", args[i])
-					return nil
-				}
-				dstPort = uint16(p)
+			if i+1 >= len(args) {
+				fmt.Println("error: destination-port requires a value")
+				return nil
 			}
+			i++
+			p, err := strconv.ParseUint(args[i], 10, 16)
+			if err != nil {
+				fmt.Printf("error: invalid destination-port: %s\n", args[i])
+				return nil
+			}
+			dstPort = uint16(p)
 		case "protocol":
-			if i+1 < len(args) {
-				i++
-				protocol = args[i]
+			if i+1 >= len(args) {
+				fmt.Println("error: protocol requires a value")
+				return nil
 			}
+			i++
+			protocol = args[i]
 		case "from-zone":
-			if i+1 < len(args) {
-				i++
-				fromZone = args[i]
+			if i+1 >= len(args) {
+				fmt.Println("error: from-zone requires a value")
+				return nil
 			}
+			i++
+			fromZone = args[i]
 		case "interface":
-			if i+1 < len(args) {
-				i++
-				iface = args[i]
+			if i+1 >= len(args) {
+				fmt.Println("error: interface requires a value")
+				return nil
 			}
+			i++
+			iface = args[i]
 		case "count":
-			if i+1 < len(args) {
-				i++
-				v, err := strconv.Atoi(args[i])
-				if err != nil || v < 1 || v > 8192 {
-					fmt.Println("error: count must be 1..8192")
-					return nil
-				}
-				count = v
+			if i+1 >= len(args) {
+				fmt.Println("error: count requires a value")
+				return nil
 			}
+			i++
+			v, err := strconv.Atoi(args[i])
+			if err != nil || v < 1 || v > 8192 {
+				fmt.Println("error: count must be 1..8192")
+				return nil
+			}
+			count = v
+		default:
+			fmt.Printf("error: unknown packet-drop option: %s\n", args[i])
+			return nil
 		}
 	}
 

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -78,17 +78,37 @@ func openTraceFile(name string) (*os.File, string, error) {
 // clamped to a 2 minimum. It honors the operator's `files` cap so a long
 // running trace cannot grow without bound (#3379).
 func rotateTraceFile(cur *os.File, name string, maxFiles int) (*os.File, error) {
-	cur.Close()
+	// Best-effort close of the old descriptor. A Close error does not gate the
+	// cap (the file's bytes are already on disk), so it must not abort the
+	// rotation — the rename/remove below are what enforce maxFiles.
+	_ = cur.Close()
 	if maxFiles < 2 {
 		maxFiles = 2
 	}
 	base := filepath.Join(traceLogDir, name)
-	// Drop the oldest archive, then shift the rest up by one.
-	_ = os.Remove(fmt.Sprintf("%s.%d", base, maxFiles-1))
-	for i := maxFiles - 2; i >= 1; i-- {
-		_ = os.Rename(fmt.Sprintf("%s.%d", base, i), fmt.Sprintf("%s.%d", base, i+1))
+	// Drop the oldest archive so the generation count stays within maxFiles. A
+	// missing oldest archive is expected (fewer than maxFiles generations have
+	// accumulated yet) and is fine; any other Remove failure means the count
+	// cap is no longer enforced, so fail closed instead of letting writeLine
+	// reset `written` and keep growing on a broken cap (#3379 follow-up).
+	if err := os.Remove(fmt.Sprintf("%s.%d", base, maxFiles-1)); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("trace rotate: dropping oldest archive: %w", err)
 	}
-	_ = os.Rename(base, base+".1")
+	// Shift the surviving archives up by one. A missing intermediate
+	// generation is expected early in a trace, so skip it, but surface any
+	// other failure rather than silently breaking the generation chain.
+	for i := maxFiles - 2; i >= 1; i-- {
+		if err := os.Rename(fmt.Sprintf("%s.%d", base, i), fmt.Sprintf("%s.%d", base, i+1)); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("trace rotate: shifting archive %d->%d: %w", i, i+1, err)
+		}
+	}
+	// Roll the active file to .1. The active file always exists (we just wrote
+	// to it), so a failure here means the size cap did not actually rotate the
+	// file; returning the error makes writeLine stop the writer instead of
+	// reopening and resetting `written` on top of an un-rotated, over-cap file.
+	if err := os.Rename(base, base+".1"); err != nil {
+		return nil, fmt.Errorf("trace rotate: rolling active file: %w", err)
+	}
 	f, _, err := openTraceFile(name)
 	return f, err
 }

--- a/pkg/cli/monitor.go
+++ b/pkg/cli/monitor.go
@@ -71,6 +71,65 @@ func openTraceFile(name string) (*os.File, string, error) {
 	return f, path, nil
 }
 
+// rotateTraceFile closes the current trace file and rolls the generations:
+// the oldest archive (name.maxFiles-1) is dropped, name.N shifts to name.N+1,
+// the active file becomes name.1, and a fresh active file is opened. maxFiles
+// is the total number of generations to keep (active + archives) and is
+// clamped to a 2 minimum. It honors the operator's `files` cap so a long
+// running trace cannot grow without bound (#3379).
+func rotateTraceFile(cur *os.File, name string, maxFiles int) (*os.File, error) {
+	cur.Close()
+	if maxFiles < 2 {
+		maxFiles = 2
+	}
+	base := filepath.Join(traceLogDir, name)
+	// Drop the oldest archive, then shift the rest up by one.
+	_ = os.Remove(fmt.Sprintf("%s.%d", base, maxFiles-1))
+	for i := maxFiles - 2; i >= 1; i-- {
+		_ = os.Rename(fmt.Sprintf("%s.%d", base, i), fmt.Sprintf("%s.%d", base, i+1))
+	}
+	_ = os.Rename(base, base+".1")
+	f, _, err := openTraceFile(name)
+	return f, err
+}
+
+// traceWriter wraps the active flow-trace file and enforces size/count based
+// rotation (#3379). A zero maxSize disables rotation (unbounded, the pre-3379
+// behavior only when the operator configured no `size`).
+type traceWriter struct {
+	name     string
+	maxSize  int64
+	maxFiles int
+	f        *os.File
+	written  int64
+}
+
+func newTraceWriter(name string, f *os.File, maxSize int64, maxFiles int) *traceWriter {
+	w := &traceWriter{name: name, maxSize: maxSize, maxFiles: maxFiles, f: f}
+	if fi, err := f.Stat(); err == nil {
+		w.written = fi.Size()
+	}
+	return w
+}
+
+// writeLine appends one trace line, rotating first if appending it would push
+// the active file past maxSize. The byte budget includes the trailing newline.
+func (w *traceWriter) writeLine(line string) error {
+	if w.maxSize > 0 && w.written > 0 && w.written+int64(len(line))+1 > w.maxSize {
+		nf, err := rotateTraceFile(w.f, w.name, w.maxFiles)
+		if err != nil {
+			return err
+		}
+		w.f = nf
+		w.written = 0
+	}
+	n, err := fmt.Fprintln(w.f, line)
+	w.written += int64(n)
+	return err
+}
+
+func (w *traceWriter) close() error { return w.f.Close() }
+
 // monitorFlowFilter holds the criteria for a single named flow filter.
 type monitorFlowFilter struct {
 	Name     string
@@ -447,6 +506,11 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 	// <regex>` filter actually drops non-matching trace lines (#2288).
 	matchRe := c.monitorFlow.matchRe
 
+	// Snapshot the rotation limits for the writer (#3379).
+	traceName := c.monitorFlow.filename
+	maxSize := c.monitorFlow.fileSize
+	maxFiles := c.monitorFlow.files
+
 	// Open trace file inside /var/log with a sanitized basename, O_NOFOLLOW,
 	// regular-file verification and mode 0600 (#3378).
 	logFile, _, err := openTraceFile(c.monitorFlow.filename)
@@ -464,9 +528,12 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 	c.monitorFlow.cancel = cancel
 	c.monitorFlow.mu.Unlock()
 
-	// Run the monitor goroutine in the background.
+	// Run the monitor goroutine in the background. The writer enforces the
+	// configured size/files rotation so the trace cannot grow unbounded under
+	// a deny storm or a broad filter (#3379).
+	writer := newTraceWriter(traceName, logFile, maxSize, maxFiles)
 	go func() {
-		defer logFile.Close()
+		defer writer.close()
 		defer sub.Close()
 		for {
 			select {
@@ -488,7 +555,11 @@ func (c *CLI) handleMonitorSecurityFlowStart() error {
 				if !traceLineMatches(line, matchRe) {
 					continue
 				}
-				fmt.Fprintln(logFile, line)
+				if err := writer.writeLine(line); err != nil {
+					// Rotation or write failed; stop tracing rather than grow
+					// the active file without bound.
+					return
+				}
 			}
 		}
 	}()

--- a/pkg/cli/monitor_match_test.go
+++ b/pkg/cli/monitor_match_test.go
@@ -58,9 +58,10 @@ func TestHandleMonitorSecurityFlowFile_RejectsBadRegex(t *testing.T) {
 	if c.monitorFlow.matchRe != nil {
 		t.Fatal("matchRe should remain nil after a rejected regex")
 	}
-	// The filename (first arg) is still accepted.
-	if c.monitorFlow.filename != "trace" {
-		t.Fatalf("filename = %q, want trace", c.monitorFlow.filename)
+	// #3380: the file command now commits atomically — a failed option (the bad
+	// regex) must NOT mutate the stored filename. It stays empty.
+	if c.monitorFlow.filename != "" {
+		t.Fatalf("filename = %q, want empty (failed option must not mutate filename)", c.monitorFlow.filename)
 	}
 }
 

--- a/pkg/cli/monitor_security_test.go
+++ b/pkg/cli/monitor_security_test.go
@@ -146,3 +146,88 @@ func TestTraceWriter_RotatesAndCapsFiles(t *testing.T) {
 func itoa(i int) string {
 	return string(rune('0' + i))
 }
+
+// #3380: the flow file/filter parsers committed state incrementally and had no
+// default case, so a failed option mutated the filename, an empty/invalid
+// filter became match-all, and unknown/value-less tokens were silently dropped
+// (widening forensic collection). These tests pin the atomic, fail-closed
+// behavior.
+
+func TestFlowFile_FailedOptionDoesNotMutateFilename(t *testing.T) {
+	c := &CLI{}
+	// Bad size must abort the whole command without storing the filename.
+	if err := c.handleMonitorSecurityFlowFile([]string{"trace", "size", "1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.monitorFlow.filename != "" {
+		t.Fatalf("filename = %q, want empty (failed size must not commit filename)", c.monitorFlow.filename)
+	}
+}
+
+func TestFlowFile_UnknownOptionRejected(t *testing.T) {
+	c := &CLI{}
+	if err := c.handleMonitorSecurityFlowFile([]string{"trace", "bogus", "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Unknown token must abort: nothing committed.
+	if c.monitorFlow.filename != "" {
+		t.Fatalf("filename = %q, want empty (unknown option must reject the command)", c.monitorFlow.filename)
+	}
+}
+
+func TestFlowFile_MissingOptionValueRejected(t *testing.T) {
+	c := &CLI{}
+	if err := c.handleMonitorSecurityFlowFile([]string{"trace", "size"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.monitorFlow.filename != "" {
+		t.Fatalf("filename = %q, want empty (value-less size must reject)", c.monitorFlow.filename)
+	}
+}
+
+func TestFlowFilter_EmptyFilterRejected(t *testing.T) {
+	c := &CLI{}
+	// A filter name with no criteria must NOT be installed (empty == match-all).
+	if err := c.handleMonitorSecurityFlowFilter([]string{"f1"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := c.monitorFlow.filters["f1"]; ok {
+		t.Fatal("empty filter was installed; an empty filter matches everything (fail-open)")
+	}
+}
+
+func TestFlowFilter_FailedOptionLeavesNoFilter(t *testing.T) {
+	c := &CLI{}
+	// Invalid source-port must abort and must NOT leave an empty match-all filter.
+	if err := c.handleMonitorSecurityFlowFilter([]string{"f1", "source-port", "notaport"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := c.monitorFlow.filters["f1"]; ok {
+		t.Fatal("failed filter command left an (empty, match-all) filter installed")
+	}
+}
+
+func TestFlowFilter_UnknownTokenRejected(t *testing.T) {
+	c := &CLI{}
+	// 'from-zone' is a packet-drop token, not a valid flow-filter token.
+	if err := c.handleMonitorSecurityFlowFilter([]string{"f1", "from-zone", "trust"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := c.monitorFlow.filters["f1"]; ok {
+		t.Fatal("unknown filter token was silently dropped and the filter installed")
+	}
+}
+
+func TestFlowFilter_ValidCriterionCommits(t *testing.T) {
+	c := &CLI{}
+	if err := c.handleMonitorSecurityFlowFilter([]string{"f1", "protocol", "tcp"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	f, ok := c.monitorFlow.filters["f1"]
+	if !ok {
+		t.Fatal("valid filter was not installed")
+	}
+	if f.Protocol != "tcp" {
+		t.Fatalf("protocol = %q, want tcp", f.Protocol)
+	}
+}

--- a/pkg/cli/monitor_security_test.go
+++ b/pkg/cli/monitor_security_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #3378: the flow-trace file was opened by raw "/var/log/"+name concatenation,
+// with no path sanitization, mode 0644 (world-readable telemetry) and no
+// symlink guard. These tests pin the hardened behavior.
+
+func TestSanitizeTraceFilename_RejectsTraversal(t *testing.T) {
+	bad := []string{
+		"",
+		".",
+		"..",
+		"../../etc/xpf-flow",
+		"/etc/passwd",
+		"sub/dir/trace",
+		`sub\dir\trace`,
+		"foo/..",
+	}
+	for _, name := range bad {
+		if err := sanitizeTraceFilename(name); err == nil {
+			t.Errorf("sanitizeTraceFilename(%q) = nil, want error (traversal must be rejected)", name)
+		}
+	}
+
+	good := []string{"trace", "flow-trace.log", "trace_2026"}
+	for _, name := range good {
+		if err := sanitizeTraceFilename(name); err != nil {
+			t.Errorf("sanitizeTraceFilename(%q) = %v, want nil (bare name)", name, err)
+		}
+	}
+}
+
+func TestHandleMonitorSecurityFlowFile_RejectsTraversalFilename(t *testing.T) {
+	c := &CLI{}
+	if err := c.handleMonitorSecurityFlowFile([]string{"../../etc/xpf-flow"}); err != nil {
+		t.Fatalf("unexpected error return (should print + return nil): %v", err)
+	}
+	if c.monitorFlow == nil {
+		t.Fatal("monitorFlow not initialized")
+	}
+	if c.monitorFlow.filename != "" {
+		t.Fatalf("traversal filename was stored: %q (must be rejected)", c.monitorFlow.filename)
+	}
+}
+
+func TestOpenTraceFile_Mode0600(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	f, path, err := openTraceFile("trace")
+	if err != nil {
+		t.Fatalf("openTraceFile error: %v", err)
+	}
+	defer f.Close()
+	if path != filepath.Join(dir, "trace") {
+		t.Fatalf("path = %q, want %q", path, filepath.Join(dir, "trace"))
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("trace file perm = %o, want 0600 (must not be world-readable)", perm)
+	}
+}
+
+func TestOpenTraceFile_RefusesSymlinkTarget(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	// A pre-planted symlink under the log dir pointing at an attacker target.
+	target := filepath.Join(dir, "secret-target")
+	link := filepath.Join(dir, "trace")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	f, _, err := openTraceFile("trace")
+	if err == nil {
+		f.Close()
+		t.Fatal("openTraceFile followed a symlink; O_NOFOLLOW must refuse it")
+	}
+	// The symlink target must NOT have been created/written.
+	if _, statErr := os.Lstat(target); statErr == nil {
+		t.Fatal("symlink target was created; the redirected write was not refused")
+	}
+}

--- a/pkg/cli/monitor_security_test.go
+++ b/pkg/cli/monitor_security_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -53,6 +54,13 @@ func TestOpenTraceFile_Mode0600(t *testing.T) {
 	old := traceLogDir
 	traceLogDir = dir
 	defer func() { traceLogDir = old }()
+
+	// Force a permissive umask for the duration of the test. Without this a
+	// reverted 0644 create mode would be masked down to 0600 under an inherited
+	// umask of 077 and the assertion below would pass falsely. With umask 0 a
+	// reverted 0644 actually lands on disk as 0644 and turns this test RED.
+	oldMask := syscall.Umask(0)
+	defer syscall.Umask(oldMask)
 
 	f, path, err := openTraceFile("trace")
 	if err != nil {
@@ -229,5 +237,64 @@ func TestFlowFilter_ValidCriterionCommits(t *testing.T) {
 	}
 	if f.Protocol != "tcp" {
 		t.Fatalf("protocol = %q, want tcp", f.Protocol)
+	}
+}
+
+// #3378 (open-time hardening): openTraceFile must independently reject
+// traversal/separator names even if the parse-time sanitizeTraceFilename guard
+// were bypassed. This pins the open-site sanitize call directly, not just the
+// command-handler path covered above.
+func TestOpenTraceFile_RejectsTraversalAtOpen(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	for _, name := range []string{"../escape", "a/b"} {
+		f, _, err := openTraceFile(name)
+		if err == nil {
+			f.Close()
+			t.Fatalf("openTraceFile(%q) = nil error, want rejection (open-time sanitize must block traversal/separators)", name)
+		}
+	}
+
+	// RED-on-revert anchor: with the sanitize call removed from openTraceFile,
+	// "../escape" resolves to a sibling of traceLogDir and the root-written
+	// file is actually created there. Assert nothing escaped the log dir.
+	escaped := filepath.Join(filepath.Dir(dir), "escape")
+	if _, err := os.Stat(escaped); err == nil {
+		os.Remove(escaped)
+		t.Fatalf("a trace file escaped traceLogDir to %s; open-time sanitize did not block traversal", escaped)
+	}
+}
+
+// #3380 (atomic parse default-reject): the packet-drop parser must reject an
+// unknown token or a value-less option instead of silently skipping it (which
+// would widen forensic collection). The handler reaches the event-subscription
+// loop only on a fully accepted parse; with a nil eventBuf that manifests as a
+// panic in Subscribe, while a parse-time rejection returns before touching the
+// buffer. reachedEventLoop turns that distinction into a boolean.
+func reachedEventLoop(t *testing.T, c *CLI, args []string) (reached bool) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			reached = true
+		}
+	}()
+	_ = c.handleMonitorSecurityPacketDrop(args)
+	return false
+}
+
+func TestPacketDrop_RejectsUnknownToken(t *testing.T) {
+	c := &CLI{} // nil eventBuf: a rejected parse never reaches Subscribe.
+	if reachedEventLoop(t, c, []string{"bogus", "x"}) {
+		t.Fatal("unknown packet-drop token was not rejected (parser fell through to the event loop)")
+	}
+}
+
+func TestPacketDrop_RejectsMissingOptionValue(t *testing.T) {
+	c := &CLI{}
+	if reachedEventLoop(t, c, []string{"count"}) {
+		t.Fatal("value-less packet-drop option was not rejected (parser fell through to the event loop)")
 	}
 }

--- a/pkg/cli/monitor_security_test.go
+++ b/pkg/cli/monitor_security_test.go
@@ -94,3 +94,55 @@ func TestOpenTraceFile_RefusesSymlinkTarget(t *testing.T) {
 		t.Fatal("symlink target was created; the redirected write was not refused")
 	}
 }
+
+// #3379: size/files rotation params were parsed but the writer never rotated,
+// allowing unbounded log growth. This pins enforcement: writing past `size`
+// rotates and the file count is capped at `files` generations.
+func TestTraceWriter_RotatesAndCapsFiles(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	const name = "trace"
+	const maxFiles = 3
+	f, _, err := openTraceFile(name)
+	if err != nil {
+		t.Fatalf("openTraceFile: %v", err)
+	}
+	// Small cap so a handful of ~25-byte lines forces several rotations.
+	w := newTraceWriter(name, f, 40, maxFiles)
+	for i := 0; i < 50; i++ {
+		if err := w.writeLine("flow-trace-line-padding-xx"); err != nil {
+			t.Fatalf("writeLine[%d]: %v", i, err)
+		}
+	}
+	w.close()
+
+	base := filepath.Join(dir, name)
+	// The active file plus exactly (maxFiles-1) archives must exist.
+	if _, err := os.Stat(base); err != nil {
+		t.Fatalf("active trace file missing: %v", err)
+	}
+	for i := 1; i <= maxFiles-1; i++ {
+		if _, err := os.Stat(base + "." + itoa(i)); err != nil {
+			t.Fatalf("expected archive %s.%d to exist: %v", base, i, err)
+		}
+	}
+	// No generation beyond the cap may survive.
+	if _, err := os.Stat(base + "." + itoa(maxFiles)); err == nil {
+		t.Fatalf("generation %s.%d exists; files cap (%d) not enforced", base, maxFiles, maxFiles)
+	}
+	// The active file itself must respect the size cap.
+	fi, err := os.Stat(base)
+	if err != nil {
+		t.Fatalf("stat active: %v", err)
+	}
+	if fi.Size() > 40 {
+		t.Fatalf("active file size %d exceeds cap 40; rotation not triggered", fi.Size())
+	}
+}
+
+func itoa(i int) string {
+	return string(rune('0' + i))
+}


### PR DESCRIPTION
Three coupled fixes to the `monitor security flow` / `monitor security
packet-drop` operational CLI commands in `pkg/cli/monitor.go`, found via
adversarial code audit (codex-093). One commit per issue.

## Commit 1 — #3378 (path traversal + 0644 + symlink follow)
The trace path was built by raw `"/var/log/" + name` concatenation,
opened mode 0644 while following symlinks. Added `sanitizeTraceFilename`
(bare basename only; reject `.`/`..`/separators/absolute) and
`openTraceFile` (O_NOFOLLOW, regular-file verification, mode 0600).
Filename validated at configure time and defensively at open.

## Commit 2 — #3379 (rotation parsed but not enforced)
`size`/`files` were stored but the writer never rotated — unbounded
growth under a deny storm. Added `traceWriter`/`rotateTraceFile`: rotate
before a write that would exceed `size`, cap at `files` generations.

## Commit 3 — #3380 (fail-open parsing)
The flow file/filter and packet-drop parsers committed state
incrementally with no default case: a failed option mutated the
filename, an empty/invalid filter became match-all, and unknown /
value-less tokens were silently dropped. Now parsed into locals / a
temp filter and committed atomically only after every token validates;
default cases reject unknown tokens; option values required; empty
(match-all) filters rejected; edits refused while a monitor is active.

### Design note
`matches()` empty-filter == match-all is the documented Junos `match`
default and is unchanged. The fix is scoped to the **invalid/empty
filter becomes installed** case (the actual fail-open), not the
intentional match-all semantics.

### Scope note
The issues (and this PR) live in `pkg/cli/monitor.go` — the
`monitor security flow` operational CLI command — not
`pkg/logging/monitor.go` or pkg/config. These are operational commands
parsed at invocation; "commit" here is parse time, so there is no
config-mode set-command path involved.

## Validation
- `go build ./...` green; `go vet ./pkg/cli/` clean for these changes
  (the one `cli.go:503 unreachable code` warning is pre-existing).
- `go test ./pkg/cli/... ./pkg/logging/... ./pkg/config/...` all pass.
- New tests in `pkg/cli/monitor_security_test.go` (+ updated
  `monitor_match_test.go`); each fix verified RED on revert.

Closes #3378
Closes #3379
Closes #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)