### PR TITLE
daemon: fail-closed host-inbound nftables apply/delete (#3333)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22788,3 +22788,18 @@ top.
     subcases to TestApplicationSpec_PortOnNonPortProtocol_LenientWarns.
   - **File(s)**: pkg/config/compiler_validate_strict.go,
     pkg/config/compiler_application_specs_test.go, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3333 host-inbound nft fail-closed — applyHostInboundFilter now
+    returns an error on apply (`nft -f -`) AND teardown failure instead of a
+    swallowed WARN; applyConfigLocked joins it into the commit result
+    (errors.Join with networkdErr/dhcpServerErr) so a committed deny that did
+    not reach the kernel reports commit FAILURE. Teardown switched to
+    `nft destroy` (idempotent on absent table) so the benign no-table case is
+    still a no-op while a real teardown failure surfaces. Added package-var
+    seams nftApplyPayload / nftDeleteTable for test failure injection; new
+    seam-injection tests + RED-on-revert. Extended installFakeNetworkctl to
+    stub nft so full-apply tests don't fail on nft-not-found.
+  - **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/daemon_apply.go,
+    pkg/daemon/host_inbound_nft_test.go, pkg/daemon/daemon_apply_runtime_test.go,
+    _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22803,3 +22803,21 @@ top.
   - **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/daemon_apply.go,
     pkg/daemon/host_inbound_nft_test.go, pkg/daemon/daemon_apply_runtime_test.go,
     _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3333 Codex re-review fold (PR #3389). MAJOR-2: replaced the
+    `nft destroy` teardown (recent verb; project pins no min nftables version)
+    with an idempotent `add table` + `delete table` payload through
+    nftApplyPayload — universal verbs only, still surfaces real failures,
+    mirrors the in-tree `delete` idiom. MAJOR-6: added a commit-level wiring
+    test (TestApplyConfigLockedSurfacesHostInboundFailure) driving the real
+    applyConfigLocked with an injected nft failure, asserting the returned
+    error includes hostInboundErr (RED on removing it from errors.Join). Added
+    TestNftDeleteTableIdempotentAddDelete pinning the add+delete teardown
+    shape. MAJOR-4: confirmed (no code change) — syncAndApply returns the
+    applyConfigLocked error verbatim and the HA config-sync caller
+    (daemon_ha_sync.go:368) logs+returns, the same path that already carries
+    networkdErr/dhcpServerErr; no retry loop or standby wedge.
+  - **File(s)**: pkg/daemon/daemon_nft.go,
+    pkg/daemon/host_inbound_nft_test.go,
+    pkg/daemon/daemon_apply_runtime_test.go, _Log.md

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1257,7 +1257,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	d.applyTimezone(cfg)
 	d.applyKernelTuning(cfg)
 	d.applyLo0Filter(cfg)
-	d.applyHostInboundFilter(cfg)
+	// #3333: host-inbound is the kernel-nftables PRIMARY enforcement of the
+	// host-inbound contract, so an apply/teardown failure must fail the commit
+	// closed rather than be swallowed at WARN. The error is joined into the
+	// commit result at the tail (alongside networkdErr / dhcpServerErr); the
+	// remaining apply steps still run so management/SSH reconcile is never
+	// skipped by a host-inbound nft failure.
+	hostInboundErr := d.applyHostInboundFilter(cfg)
 
 	// 9.6. Write SSH known hosts file
 	d.applySSHKnownHosts(cfg)
@@ -1445,7 +1451,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// restart/stop failure through the commit so a write that left stale
 	// kernel state fails the commit (fail-closed) instead of reporting
 	// success. Both are joined so neither masks the other.
-	return errors.Join(networkdErr, dhcpServerErr)
+	return errors.Join(networkdErr, dhcpServerErr, hostInboundErr)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/daemon_apply_runtime_test.go
+++ b/pkg/daemon/daemon_apply_runtime_test.go
@@ -87,5 +87,15 @@ func installFakeNetworkctl(t *testing.T) {
 	if err := os.WriteFile(networkctl, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
 		t.Fatalf("write fake networkctl: %v", err)
 	}
+	// #3333: applyConfigLocked now surfaces a host-inbound `nft` apply/teardown
+	// failure as a commit error (fail-closed). The CI/test host has no `nft`
+	// binary, so without a benign stub these full-apply tests would fail on an
+	// nft-not-found error unrelated to what they assert. Install a no-op nft
+	// alongside networkctl (the host-inbound failure semantics themselves are
+	// covered by the seam-injection tests in host_inbound_nft_test.go).
+	nft := filepath.Join(binDir, "nft")
+	if err := os.WriteFile(nft, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write fake nft: %v", err)
+	}
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 }

--- a/pkg/daemon/daemon_apply_runtime_test.go
+++ b/pkg/daemon/daemon_apply_runtime_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,62 @@ import (
 	"github.com/psaab/xpf/pkg/networkd"
 	"github.com/psaab/xpf/pkg/vrrp"
 )
+
+// TestApplyConfigLockedSurfacesHostInboundFailure is the #3333 commit-level
+// wiring proof: it drives the REAL applyConfigLocked body (not the
+// applyHostInboundFilter helper directly) with an injected host-inbound nft
+// failure via the nftApplyPayload seam, and asserts the returned commit error
+// includes that failure. This pins the production wiring — the
+// errors.Join(networkdErr, dhcpServerErr, hostInboundErr) at the tail of
+// applyConfigLocked — which the helper-level seam tests do NOT cover.
+//
+// RED-on-revert: remove hostInboundErr from that join and this test goes RED
+// (the apply completes and returns nil despite the host-inbound deny failing to
+// install — the silent fail-open the issue describes).
+func TestApplyConfigLockedSurfacesHostInboundFailure(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	injected := errors.New("nft: host-inbound rule load failed")
+	origApply := nftApplyPayload
+	nftApplyPayload = func(string) ([]byte, error) { return []byte("Error: load failed\n"), injected }
+	defer func() { nftApplyPayload = origApply }()
+
+	networkDir := t.TempDir()
+	d := &Daemon{
+		dp:       &runtimeOnlyApplyTestDP{},
+		networkd: networkd.NewInDir(networkDir),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	// Enforceable host-inbound config: a non-lifeline zone with a static
+	// address and a host-inbound stanza, so applyConfigLocked reaches the APPLY
+	// path and the injected nft failure is the deny-not-installed failure.
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.7.7.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {
+			Name:               "trust",
+			Interfaces:         []string{"reth0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}},
+		},
+	}
+
+	err := d.applyConfigLocked(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("applyConfigLocked must surface the host-inbound nft failure " +
+			"(fail-closed); got nil (the silent fail-open #3333 describes)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned commit error must include the host-inbound failure "+
+			"via errors.Join wiring, got %v", err)
+	}
+}
 
 func TestApplyConfigRuntimeResultDrivesDownstreamConsumers(t *testing.T) {
 	networkDir := t.TempDir()

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -29,16 +29,23 @@ var nftApplyPayload = func(payload string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-// nftDeleteTable idempotently removes an nft table. It uses `nft destroy`
-// rather than `nft delete`: `destroy` is a no-op when the table is absent (the
-// common no-host-inbound case), so it returns no error for the benign
-// never-existed case while a genuine teardown failure — which would leave stale
-// deny rules in the kernel — surfaces as an error. That lets the host-inbound
-// teardown fail closed (#3333). `destroy` is available on the project's nft
-// floor (Ubuntu 26.04 / nftables 1.1.x, kernel >= 6.18). Package var for test
-// failure injection.
+// nftDeleteTable idempotently removes an nft table using only the universally
+// available `add` / `delete` verbs (NOT `nft destroy`). `destroy` is a recent
+// nftables verb and the project does not pin a minimum nftables version
+// (debian/control depends on UNVERSIONED `nftables`, with no preflight), so a
+// `destroy` dependency would raise "unknown command" on any non-floor base —
+// and, now that teardown failures propagate (#3333), that would fail EVERY
+// commit. Instead emit a two-line `nft -f -` payload: `add table` makes the
+// table exist (a no-op when it already does), so the following `delete table`
+// always has a target whether or not the table pre-existed — idempotent without
+// `destroy`. A genuine failure (permissions / kernel) still surfaces on either
+// line. This mirrors the established in-tree `delete table` idiom (applyLo0Filter
+// below, scripts/migrate-bpfrx-to-xpf.sh) and reuses the atomic nftApplyPayload
+// runner. Package var for test failure injection.
 var nftDeleteTable = func(family, name string) ([]byte, error) {
-	return runCommandTimeout("nft", "destroy", "table", family, name)
+	payload := "add table " + family + " " + name + "\n" +
+		"delete table " + family + " " + name + "\n"
+	return nftApplyPayload(payload)
 }
 
 // applyLo0Filter applies loopback filter rules for host-bound traffic.
@@ -149,11 +156,11 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	views := dpuserspace.BuildZoneHostInboundViews(cfg)
 	if !hostInboundHasEnforceableView(views) {
 		// No host-inbound-configured zone with a resolvable address — nothing to
-		// enforce. Remove any stale table. nftDeleteTable uses `nft destroy`,
-		// which is idempotent (no error when the table is absent — the common
-		// case), so a non-nil error here is a REAL teardown failure that left a
-		// stale deny in the kernel: surface it so the commit fails closed rather
-		// than reporting that host-inbound was relaxed when it was not.
+		// enforce. Remove any stale table. nftDeleteTable is idempotent (an
+		// add-then-delete payload, so no error when the table is absent — the
+		// common case), so a non-nil error here is a REAL teardown failure that
+		// left a stale deny in the kernel: surface it so the commit fails closed
+		// rather than reporting that host-inbound was relaxed when it was not.
 		if out, err := nftDeleteTable("inet", "xpf_hostinbound"); err != nil {
 			slog.Warn("failed to delete stale host-inbound filter table", "err", err, "output", string(out))
 			return fmt.Errorf("delete stale host-inbound nftables table: %w", err)

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -3,6 +3,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os/exec"
 	"strconv"
@@ -12,6 +13,33 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
+
+// nftApplyPayload runs `nft -f -` with the supplied ruleset payload on stdin.
+// It is a package var so the host-inbound apply path's failure semantics are
+// unit-testable without invoking nft (#3333). The 5s context + WaitDelay mirror
+// the established inline apply sites (#1794): an `-f -` payload loads atomically,
+// so on failure the kernel retains the PREVIOUS table untouched rather than a
+// half-applied ruleset.
+var nftApplyPayload = func(payload string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "nft", "-f", "-")
+	cmd.WaitDelay = 5 * time.Second
+	cmd.Stdin = strings.NewReader(payload)
+	return cmd.CombinedOutput()
+}
+
+// nftDeleteTable idempotently removes an nft table. It uses `nft destroy`
+// rather than `nft delete`: `destroy` is a no-op when the table is absent (the
+// common no-host-inbound case), so it returns no error for the benign
+// never-existed case while a genuine teardown failure — which would leave stale
+// deny rules in the kernel — surfaces as an error. That lets the host-inbound
+// teardown fail closed (#3333). `destroy` is available on the project's nft
+// floor (Ubuntu 26.04 / nftables 1.1.x, kernel >= 6.18). Package var for test
+// failure injection.
+var nftDeleteTable = func(family, name string) ([]byte, error) {
+	return runCommandTimeout("nft", "destroy", "table", family, name)
+}
 
 // applyLo0Filter applies loopback filter rules for host-bound traffic.
 // Implements "interfaces lo0 unit 0 family inet filter input <name>" by
@@ -106,26 +134,39 @@ func buildLo0FilterPayload(cfg *config.Config, filterV4, filterV6 string) string
 // BuildZoneHostInboundViews, so a host-inbound deny can never strand management
 // or break HA. Established sessions and IPv6 ND / PMTUD control messages are
 // accepted before any deny.
-func (d *Daemon) applyHostInboundFilter(cfg *config.Config) {
+//
+// Fail-closed (#3333): both the apply and the teardown surface their failure as
+// a returned error instead of a swallowed WARN. applyConfigLocked joins this
+// into the commit result, so a committed host-inbound deny that did not reach
+// the kernel reports commit FAILURE rather than silent success. The retained
+// kernel state is always the more- or equally-restrictive prior state: an `-f -`
+// apply loads atomically (the previous table is kept on failure), and a failed
+// teardown leaves the existing deny in place — neither can strand management,
+// since lifeline interfaces are excluded from the address sets. Boot / DHCP
+// re-applies go through applyConfig(), which only logs the error, so a transient
+// nft failure cannot brick startup; the next clean commit re-renders.
+func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	views := dpuserspace.BuildZoneHostInboundViews(cfg)
 	if !hostInboundHasEnforceableView(views) {
-		// No host-inbound-configured zone with a resolvable address — nothing
-		// to enforce. Remove any stale table (idempotent; delete fails benignly
-		// when the table is absent). Timeout-bounded (#1794).
-		_, _ = runCommandTimeout("nft", "delete", "table", "inet", "xpf_hostinbound")
-		return
+		// No host-inbound-configured zone with a resolvable address — nothing to
+		// enforce. Remove any stale table. nftDeleteTable uses `nft destroy`,
+		// which is idempotent (no error when the table is absent — the common
+		// case), so a non-nil error here is a REAL teardown failure that left a
+		// stale deny in the kernel: surface it so the commit fails closed rather
+		// than reporting that host-inbound was relaxed when it was not.
+		if out, err := nftDeleteTable("inet", "xpf_hostinbound"); err != nil {
+			slog.Warn("failed to delete stale host-inbound filter table", "err", err, "output", string(out))
+			return fmt.Errorf("delete stale host-inbound nftables table: %w", err)
+		}
+		return nil
 	}
 	nftConf := buildHostInboundFilterPayload(views)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "nft", "-f", "-")
-	cmd.WaitDelay = 5 * time.Second
-	cmd.Stdin = strings.NewReader(nftConf)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := nftApplyPayload(nftConf); err != nil {
 		slog.Warn("failed to apply host-inbound filter", "err", err, "output", string(out))
-	} else {
-		slog.Info("host-inbound filter applied", "zones", len(views))
+		return fmt.Errorf("apply host-inbound nftables filter: %w", err)
 	}
+	slog.Info("host-inbound filter applied", "zones", len(views))
+	return nil
 }
 
 // hostInboundHasEnforceableView reports whether at least one view carries a

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -398,6 +399,107 @@ func TestHostInboundFilterConfiguredControlInterfaceLifeline(t *testing.T) {
 	// Sanity: the enforced wan zone still scopes its own address.
 	if !strings.Contains(payload, "172.16.50.8 drop") {
 		t.Errorf("wan zone must still emit a scoped deny:\n%s", payload)
+	}
+}
+
+// TestHostInboundFilterApplyFailureSurfaced is the #3333 fail-on-revert proof
+// for the APPLY path: when `nft -f -` fails, applyHostInboundFilter must return
+// the error (so applyConfigLocked fails the commit closed) rather than swallow
+// it at WARN. With the pre-fix warn-only code the function returned nothing and
+// this goes RED. The nft invocation is replaced by the package-var seam so no
+// real nft is run.
+func TestHostInboundFilterApplyFailureSurfaced(t *testing.T) {
+	cfg := hostInboundTestConfig()
+
+	injected := errors.New("nft: rule load failed")
+	var called bool
+	orig := nftApplyPayload
+	nftApplyPayload = func(payload string) ([]byte, error) {
+		called = true
+		// Sanity: the payload fed to nft must be the enforced host-inbound
+		// ruleset (an enforceable view exists), so a failure here is a real
+		// deny-not-installed event.
+		if !strings.Contains(payload, "table inet xpf_hostinbound") {
+			t.Errorf("apply seam got unexpected payload:\n%s", payload)
+		}
+		return []byte("Error: could not process rule\n"), injected
+	}
+	defer func() { nftApplyPayload = orig }()
+
+	d := &Daemon{}
+	err := d.applyHostInboundFilter(cfg)
+	if !called {
+		t.Fatal("expected nft apply seam to be invoked for an enforceable config")
+	}
+	if err == nil {
+		t.Fatal("apply failure must be surfaced as an error (fail-closed), got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the nft failure, got %v", err)
+	}
+}
+
+// TestHostInboundFilterDeleteFailureSurfaced is the #3333 fail-on-revert proof
+// for the TEARDOWN path: when no zone is enforceable, the stale table is
+// removed via `nft destroy`; a genuine destroy failure (stale deny left in the
+// kernel) must surface as an error. `destroy` is idempotent for the benign
+// absent-table case, so any error from the seam is a real failure. Pre-fix the
+// delete error was discarded entirely (`_, _ =`), so this goes RED.
+func TestHostInboundFilterDeleteFailureSurfaced(t *testing.T) {
+	// A config with no enforceable host-inbound view (no zone declares a
+	// stanza) drives the teardown branch.
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+	if hostInboundHasEnforceableView(dpuserspace.BuildZoneHostInboundViews(cfg)) {
+		t.Fatal("test config must have no enforceable host-inbound view")
+	}
+
+	injected := errors.New("nft: device or resource busy")
+	var gotFamily, gotName string
+	orig := nftDeleteTable
+	nftDeleteTable = func(family, name string) ([]byte, error) {
+		gotFamily, gotName = family, name
+		return []byte("Error: Could not process rule\n"), injected
+	}
+	defer func() { nftDeleteTable = orig }()
+
+	d := &Daemon{}
+	err := d.applyHostInboundFilter(cfg)
+	if gotName != "xpf_hostinbound" || gotFamily != "inet" {
+		t.Errorf("teardown must target inet xpf_hostinbound, got %s %s", gotFamily, gotName)
+	}
+	if err == nil {
+		t.Fatal("teardown failure must be surfaced as an error (fail-closed), got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the nft destroy failure, got %v", err)
+	}
+}
+
+// TestHostInboundFilterApplySuccessNoError verifies the happy paths return nil:
+// a successful apply (enforceable view) and a successful/benign teardown (no
+// enforceable view) must NOT report a commit failure.
+func TestHostInboundFilterApplySuccessNoError(t *testing.T) {
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	d := &Daemon{}
+	if err := d.applyHostInboundFilter(hostInboundTestConfig()); err != nil {
+		t.Errorf("successful apply must return nil, got %v", err)
+	}
+
+	empty := &config.Config{}
+	if err := d.applyHostInboundFilter(empty); err != nil {
+		t.Errorf("benign teardown (no enforceable view) must return nil, got %v", err)
 	}
 }
 

--- a/pkg/daemon/host_inbound_nft_test.go
+++ b/pkg/daemon/host_inbound_nft_test.go
@@ -440,11 +440,12 @@ func TestHostInboundFilterApplyFailureSurfaced(t *testing.T) {
 }
 
 // TestHostInboundFilterDeleteFailureSurfaced is the #3333 fail-on-revert proof
-// for the TEARDOWN path: when no zone is enforceable, the stale table is
-// removed via `nft destroy`; a genuine destroy failure (stale deny left in the
-// kernel) must surface as an error. `destroy` is idempotent for the benign
-// absent-table case, so any error from the seam is a real failure. Pre-fix the
-// delete error was discarded entirely (`_, _ =`), so this goes RED.
+// for the TEARDOWN path: when no zone is enforceable, the stale table is removed
+// via the idempotent add-then-delete payload; a genuine teardown failure (stale
+// deny left in the kernel) must surface as an error. The add+delete is
+// idempotent for the benign absent-table case, so any error from the seam is a
+// real failure. Pre-fix the delete error was discarded entirely (`_, _ =`), so
+// this goes RED.
 func TestHostInboundFilterDeleteFailureSurfaced(t *testing.T) {
 	// A config with no enforceable host-inbound view (no zone declares a
 	// stanza) drives the teardown branch.
@@ -479,7 +480,38 @@ func TestHostInboundFilterDeleteFailureSurfaced(t *testing.T) {
 		t.Fatal("teardown failure must be surfaced as an error (fail-closed), got nil")
 	}
 	if !errors.Is(err, injected) {
-		t.Errorf("returned error must wrap the nft destroy failure, got %v", err)
+		t.Errorf("returned error must wrap the nft teardown failure, got %v", err)
+	}
+}
+
+// TestNftDeleteTableIdempotentAddDelete pins the #3333 MAJOR-2 teardown shape:
+// the default nftDeleteTable must NOT depend on the recent `nft destroy` verb
+// (the project pins no minimum nftables version), and must instead emit an
+// idempotent add-then-delete payload through the atomic nftApplyPayload runner.
+// Reverting to `nft destroy` (or dropping the `add`) turns this RED.
+func TestNftDeleteTableIdempotentAddDelete(t *testing.T) {
+	var got string
+	orig := nftApplyPayload
+	nftApplyPayload = func(payload string) ([]byte, error) { got = payload; return nil, nil }
+	defer func() { nftApplyPayload = orig }()
+
+	if _, err := nftDeleteTable("inet", "xpf_hostinbound"); err != nil {
+		t.Fatalf("nftDeleteTable: %v", err)
+	}
+	if strings.Contains(got, "destroy") {
+		t.Errorf("teardown must not use the unpinned `nft destroy` verb:\n%s", got)
+	}
+	for _, want := range []string{
+		"add table inet xpf_hostinbound",
+		"delete table inet xpf_hostinbound",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("teardown payload missing %q:\n%s", want, got)
+		}
+	}
+	// `add` must precede `delete` so the delete always has a target.
+	if strings.Index(got, "add table") > strings.Index(got, "delete table") {
+		t.Errorf("add must precede delete in the teardown payload:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Closes #3333

## Problem (fail-open)
The kernel-nftables host-inbound enforcement chain (`inet xpf_hostinbound`) was applied and torn down best-effort:
- `applyHostInboundFilter` apply path: on `nft -f -` error only `slog.Warn(...)`, no error returned.
- teardown path: `_, _ = runCommandTimeout("nft", "delete", "table", "inet", "xpf_hostinbound")` — output AND error discarded (not just the benign absent-table case).
- `applyConfigLocked` called it with no error propagation.

A committed host-inbound **deny** could fail to install in the kernel while the commit reported success — a silent fail-open on the host-admission control plane (SSH/HTTP/BGP/etc. are shunted to Linux before userspace). The inverse (a relaxed config whose teardown failed) left stale deny rules active, also unsurfaced.

## Fix (fail-closed)
`applyHostInboundFilter` now returns an error from **both** the apply and teardown paths; `applyConfigLocked` joins it into the commit result via `errors.Join(networkdErr, dhcpServerErr, hostInboundErr)` — the same deferred-failure pattern already used at the tail of the apply. A committed deny that did not reach the kernel now reports commit **FAILURE**.

The retained kernel state is always the more- or equally-restrictive prior state, so this cannot strand management:
- `nft -f -` loads atomically — a failed apply keeps the **previous** table untouched (known-good, not half-applied).
- teardown switched to `nft destroy table` (idempotent: a no-op when the table is absent, the common no-host-inbound case) so the benign never-existed case returns no error while a genuine teardown failure (stale deny left behind) surfaces.
- lifeline interfaces (fxp0 / em0 / fab* / configured control-interface) are excluded from the address sets, so neither a retained-previous nor a failed apply can deny management.
- boot / DHCP re-applies go through `applyConfig()`, which only **logs** the error, so a transient nft failure cannot brick startup; the next clean commit re-renders. Only operator-facing commit / cluster-sync paths propagate the error.

## Test seam
Extracted the nft invocations behind package-var seams `nftApplyPayload` / `nftDeleteTable` so failure semantics are unit-testable without invoking nft.

New tests in `host_inbound_nft_test.go`:
- `TestHostInboundFilterApplyFailureSurfaced` — inject `nft -f -` failure → error wraps it.
- `TestHostInboundFilterDeleteFailureSurfaced` — no enforceable view → inject destroy failure → error wraps it.
- `TestHostInboundFilterApplySuccessNoError` — happy apply + benign teardown both return nil.

`installFakeNetworkctl` now also stubs a benign `nft` so the existing full-apply reconcile tests don't fail on nft-not-found.

## RED-on-revert
Reverting `applyHostInboundFilter` to the warn-only form (swallow errors, return nil):
```
--- FAIL: TestHostInboundFilterApplyFailureSurfaced
    apply failure must be surfaced as an error (fail-closed), got nil
--- FAIL: TestHostInboundFilterDeleteFailureSurfaced
    teardown failure must be surfaced as an error (fail-closed), got nil
```
(the success test stays green).

## Validation
- `go build ./...` clean; `go vet ./pkg/daemon/` clean; gofmt clean.
- `go test ./pkg/daemon/...` green (incl. the 7 full-apply tests that surfaced the nft dependency).

## HA note
This touches the runtime host-admission apply path. Behavior on the common path is unchanged (nft is always present in production); the change only adds error propagation on nft failure and switches teardown `delete`→`destroy`. Lifelines remain excluded and boot/DHCP/sync re-applies stay non-fatal, so failover is not expected to regress — but flagging it since it is host-admission + apply-path. `make test-failover` if desired.

## Scope
Host-inbound only (the #3333 surface). The sibling `applyLo0Filter` has the same warn-only pattern but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi