### PR TITLE
policy: evaluate application terms in config order, first-match (#3346)

### DIFF
--- a/pkg/dataplane/userspace/capabilities.go
+++ b/pkg/dataplane/userspace/capabilities.go
@@ -349,7 +349,13 @@ func expandUserspacePolicyApplications(cfg *config.Config, apps []string) ([]Pol
 	// preserves member order; resolveUserspaceApplicationNames no longer sorts).
 	// The Rust matcher resolves an overlapping per-application inactivity-timeout
 	// first-writer-wins on the exact port (policy.rs `exact_dst_ports.or_insert`,
-	// #3227), so the emit order decides which timeout wins. Sorting by Name here
+	// #3227), so the emit order decides which timeout wins. #3346: the matcher
+	// now also honors this emit order ACROSS application classes — it stamps each
+	// term with its config-order index and the FIRST listed matching term wins
+	// (Junos first-term-wins), so an exact-port term no longer beats a range or
+	// icmp-constrained term listed earlier. This emit order is therefore the
+	// cross-class precedence contract, not just the within-exact-class one.
+	// Sorting by Name here
 	// made that precedence alphabetical — contradicting #3227's
 	// first-writer-wins-by-config-order contract and Junos/operator intent (two
 	// overlapping apps would resolve to the timeout of whichever name sorts

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -911,22 +911,27 @@ struct CompiledApplications {
 #[derive(Clone, Debug, Default)]
 struct ProtoTerms {
     /// Exact destination port set (single-port terms compiled for O(1) lookup).
-    /// #3227: the value is the term's per-application inactivity timeout
-    /// (`None` = use the global per-protocol timeout). First writer wins on an
-    /// overlapping port (matches the catalog "first match wins" convention).
-    exact_dst_ports: FxHashMap<u16, Option<u32>>,
-    /// Port range terms that need linear scan (multi-port ranges).
-    /// #3227: third tuple element is the term's inactivity timeout.
-    range_terms: Vec<(Vec<PortRange>, Vec<PortRange>, Option<u32>)>, // (src, dst, timeout)
+    /// #3227: the value carries the term's per-application inactivity timeout
+    /// (`None` = use the global per-protocol timeout). #3346: the value also
+    /// carries the term's CONFIG-ORDER index (`u32`) so cross-class precedence
+    /// can honor Junos first-term-wins instead of always probing exact before
+    /// range/icmp. First writer wins on an overlapping port (the lower config
+    /// index, matching the catalog "first match wins" convention).
+    exact_dst_ports: FxHashMap<u16, (u32, Option<u32>)>, // port -> (order, timeout)
+    /// Port range terms that need linear scan (multi-port ranges). #3346: the
+    /// leading `u32` is the term's config-order index; the trailing element is
+    /// the #3227 inactivity timeout. Pushed in config order, so the first
+    /// matching entry in the vector is the lowest-order matching range.
+    range_terms: Vec<(u32, Vec<PortRange>, Vec<PortRange>, Option<u32>)>, // (order, src, dst, timeout)
     /// #3020: ICMP/ICMPv6 type[,code] constraints for icmp-constrained terms
-    /// (e.g. junos-ping = type 8). Each entry is `(type, optional code,
-    /// inactivity timeout)`. A packet matches this protocol via the icmp path
-    /// iff its type (and code, when the entry constrains it) equals one of these
-    /// entries. An UNCONSTRAINED ICMP term (junos-icmp-all) does NOT land here —
-    /// it stays a `range_terms` entry with empty ranges, which matches every
-    /// ICMP packet, so a rule citing both still matches all ICMP. #3227 added
-    /// the trailing timeout.
-    icmp_constraints: Vec<(u8, Option<u8>, Option<u32>)>,
+    /// (e.g. junos-ping = type 8). #3346: each entry is `(config-order index,
+    /// type, optional code, inactivity timeout)`. A packet matches this protocol
+    /// via the icmp path iff its type (and code, when the entry constrains it)
+    /// equals one of these entries. An UNCONSTRAINED ICMP term (junos-icmp-all)
+    /// does NOT land here — it stays a `range_terms` entry with empty ranges,
+    /// which matches every ICMP packet, so a rule citing both still matches all
+    /// ICMP. Pushed in config order. #3227 added the timeout.
+    icmp_constraints: Vec<(u32, u8, Option<u8>, Option<u32>)>, // (order, type, code, timeout)
 }
 
 impl CompiledApplications {
@@ -938,7 +943,13 @@ impl CompiledApplications {
             };
         }
         let mut by_protocol: FxHashMap<u8, ProtoTerms> = FxHashMap::default();
-        for app in apps {
+        // #3346: stamp each term with its CONFIG-ORDER index (the order the
+        // operator listed the applications, preserved by the Go emit path —
+        // capabilities.go resolveUserspaceApplicationNames, #3298). The index is
+        // assigned across ALL terms of the rule; since matching is per-protocol,
+        // the relative order WITHIN a protocol is what `matches` compares, and
+        // that relative order is preserved by a single monotonic counter.
+        for (order, app) in (0u32..).zip(apps.iter()) {
             let entry = by_protocol.entry(app.protocol).or_default();
             // #3020: an ICMP/ICMPv6 term with a type constraint (junos-ping)
             // is steered to `icmp_constraints` so it matches ONLY that type
@@ -951,6 +962,7 @@ impl CompiledApplications {
             // constraint takes precedence so a stray port is irrelevant here.)
             if app.icmp_type.is_some() {
                 entry.icmp_constraints.push((
+                    order,
                     app.icmp_type.expect("icmp_type is Some"),
                     app.icmp_code,
                     // #3227: carry the term's idle timeout onto the constraint.
@@ -960,14 +972,16 @@ impl CompiledApplications {
                 && app.destination_ports.len() == 1
                 && app.destination_ports[0].low == app.destination_ports[0].high
             {
-                // #3227: store the term timeout keyed by exact port. First
-                // writer wins on an overlapping port so precedence is stable.
+                // #3227: store the term timeout keyed by exact port. #3346: also
+                // store the config-order index. First writer wins on an
+                // overlapping port (the lower order) so precedence is stable.
                 entry
                     .exact_dst_ports
                     .entry(app.destination_ports[0].low)
-                    .or_insert(app.inactivity_timeout);
+                    .or_insert((order, app.inactivity_timeout));
             } else {
                 entry.range_terms.push((
+                    order,
                     app.source_ports.clone(),
                     app.destination_ports.clone(),
                     // #3227: carry the term's idle timeout onto the range entry.
@@ -995,11 +1009,18 @@ impl CompiledApplications {
     ///   - `None`              → no application term matched (rule does not apply)
     ///   - `Some(None)`        → matched, no custom timeout (use the global one)
     ///   - `Some(Some(secs))`  → matched, use this per-app idle timeout
-    /// Precedence among a rule's terms is the lookup order: the exact
-    /// destination-port term wins first, then range terms in config order, then
-    /// ICMP-type-constrained terms — the first hit supplies the timeout. The
-    /// match-any short-circuit yields `Some(None)` (use-global), so an
-    /// `application any` rule is byte-identical to today.
+    /// #3346: precedence among a rule's terms is CONFIG ORDER — the FIRST term
+    /// the operator listed that matches supplies the timeout (Junos
+    /// first-term-wins), regardless of which class (exact-port / range / icmp)
+    /// it lands in. Each term carries its config-order index; this gathers the
+    /// best (lowest-index) match across all three classes. The O(1) exact-port
+    /// map is retained purely as a lookup accelerator for the common
+    /// single-port term, NOT as a precedence tier — before #3346 it always beat
+    /// a range/icmp term listed earlier, which diverged from vSRX. The match-any
+    /// short-circuit yields `Some(None)` (use-global), so an `application any`
+    /// rule is byte-identical to today. The boolean "does the rule apply?"
+    /// verdict (`Some` vs `None`) is unchanged — only WHICH matched term's
+    /// timeout is returned.
     #[inline]
     fn matches(
         &self,
@@ -1012,16 +1033,24 @@ impl CompiledApplications {
             return Some(None);
         }
         let terms = self.by_protocol.get(&protocol)?;
-        // Fast path: check exact dst port set first (O(1)).
-        if let Some(&timeout) = terms.exact_dst_ports.get(&dst_port) {
-            return Some(timeout);
+        // #3346: track the lowest-config-order matching term across all classes.
+        // `best` holds `(order, timeout)`; a smaller order wins (first listed).
+        let mut best: Option<(u32, Option<u32>)> = None;
+        // Exact dst-port term — O(1) accelerator for the common single-port case.
+        if let Some(&(order, timeout)) = terms.exact_dst_ports.get(&dst_port) {
+            best = Some((order, timeout));
         }
-        // Slow path: check range terms (an unconstrained ICMP term, e.g.
-        // junos-icmp-all, lives here as an empty-range entry → match-all).
-        if let Some(&(_, _, timeout)) = terms.range_terms.iter().find(|(src_ranges, dst_ranges, _)| {
-            port_ranges_match(src_ranges, src_port) && port_ranges_match(dst_ranges, dst_port)
-        }) {
-            return Some(timeout);
+        // Range terms (an unconstrained ICMP term, e.g. junos-icmp-all, lives
+        // here as an empty-range entry → match-all). Pushed in config order, so
+        // the first match in the vector is the lowest-order matching range.
+        if let Some(&(order, _, _, timeout)) = terms.range_terms.iter().find(
+            |(_, src_ranges, dst_ranges, _)| {
+                port_ranges_match(src_ranges, src_port) && port_ranges_match(dst_ranges, dst_port)
+            },
+        ) {
+            if best.map_or(true, |(b, _)| order < b) {
+                best = Some((order, timeout));
+            }
         }
         // #3020: ICMP/ICMPv6 type[,code]-constrained terms (junos-ping). Match
         // only when the packet's type/code is known and equals a constraint.
@@ -1029,16 +1058,16 @@ impl CompiledApplications {
         // non-first fragment) the constrained term does NOT match — fail closed.
         if !terms.icmp_constraints.is_empty() {
             if let Some((ptype, pcode)) = packet_icmp {
-                if let Some(&(_, _, timeout)) = terms
-                    .icmp_constraints
-                    .iter()
-                    .find(|&&(ctype, ccode, _)| ctype == ptype && ccode.map_or(true, |c| c == pcode))
-                {
-                    return Some(timeout);
+                if let Some(&(order, _, _, timeout)) = terms.icmp_constraints.iter().find(
+                    |&&(_, ctype, ccode, _)| ctype == ptype && ccode.map_or(true, |c| c == pcode),
+                ) {
+                    if best.map_or(true, |(b, _)| order < b) {
+                        best = Some((order, timeout));
+                    }
                 }
             }
         }
-        None
+        best.map(|(_, timeout)| timeout)
     }
 }
 

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -4074,3 +4074,112 @@ fn nat46_v4_src_v6_dst_tuple_never_matches() {
         "(V4 src, V6 dst) must never match — NAT46 is unsupported"
     );
 }
+
+// ===========================================================================
+// #3346: application-term precedence is CONFIG ORDER (Junos first-term-wins),
+// not the old class heuristic (exact-port always beats range beats
+// icmp-constrained). These tests pin the per-application inactivity-timeout
+// selected by CompiledApplications::matches to the FIRST listed matching term.
+// ===========================================================================
+
+fn exact_app(port: u16, timeout: Option<u32>) -> ApplicationMatch {
+    ApplicationMatch {
+        protocol: PROTO_TCP,
+        source_ports: Vec::new(),
+        destination_ports: vec![PortRange {
+            low: port,
+            high: port,
+        }],
+        icmp_type: None,
+        icmp_code: None,
+        inactivity_timeout: timeout,
+    }
+}
+
+fn range_app(low: u16, high: u16, timeout: Option<u32>) -> ApplicationMatch {
+    ApplicationMatch {
+        protocol: PROTO_TCP,
+        source_ports: Vec::new(),
+        destination_ports: vec![PortRange { low, high }],
+        icmp_type: None,
+        icmp_code: None,
+        inactivity_timeout: timeout,
+    }
+}
+
+#[test]
+fn app_term_range_listed_before_exact_wins() {
+    // Range 80-90 listed FIRST, exact 80 listed SECOND. For dst port 80 (in
+    // BOTH), Junos first-term-wins → the range term's timeout (200) must win.
+    // RED-on-revert: the pre-#3346 class heuristic always probed exact_dst_ports
+    // before range_terms, so the exact term's timeout (100) wrongly won.
+    let apps = vec![range_app(80, 90, Some(200)), exact_app(80, Some(100))];
+    let compiled = CompiledApplications::from_matches(&apps);
+    assert_eq!(
+        compiled.matches(PROTO_TCP, 12345, 80, None),
+        Some(Some(200)),
+        "range term listed first must win the timeout for a port both match"
+    );
+    // Port 85: only the range matches → 200 regardless of order.
+    assert_eq!(
+        compiled.matches(PROTO_TCP, 12345, 85, None),
+        Some(Some(200))
+    );
+}
+
+#[test]
+fn app_term_exact_listed_before_range_wins() {
+    // Reverse order: exact 80 listed FIRST, range 80-90 SECOND. For port 80 the
+    // exact term is first → its timeout (100) wins. Confirms the fix is true
+    // config-order, not "range always wins".
+    let apps = vec![exact_app(80, Some(100)), range_app(80, 90, Some(200))];
+    let compiled = CompiledApplications::from_matches(&apps);
+    assert_eq!(
+        compiled.matches(PROTO_TCP, 12345, 80, None),
+        Some(Some(100)),
+        "exact term listed first must win the timeout for a port both match"
+    );
+    // Port 85: only the range matches → 200.
+    assert_eq!(
+        compiled.matches(PROTO_TCP, 12345, 85, None),
+        Some(Some(200))
+    );
+}
+
+#[test]
+fn app_term_icmp_constrained_before_all_icmp_wins() {
+    // junos-ping (icmp type 8 → icmp_constraints) listed FIRST, junos-icmp-all
+    // (unconstrained → range_terms empty-range match-all) SECOND. For an echo
+    // (type 8) packet both match; first-term-wins → the constrained term's
+    // timeout (11). RED-on-revert: the old order checked range_terms (icmp-all)
+    // before icmp_constraints, so the all-ICMP timeout (22) wrongly won.
+    let ping = ApplicationMatch {
+        protocol: PROTO_ICMP,
+        source_ports: Vec::new(),
+        destination_ports: Vec::new(),
+        icmp_type: Some(8),
+        icmp_code: None,
+        inactivity_timeout: Some(11),
+    };
+    let icmp_all = ApplicationMatch {
+        protocol: PROTO_ICMP,
+        source_ports: Vec::new(),
+        destination_ports: Vec::new(),
+        icmp_type: None,
+        icmp_code: None,
+        inactivity_timeout: Some(22),
+    };
+    let compiled = CompiledApplications::from_matches(&vec![ping.clone(), icmp_all.clone()]);
+    assert_eq!(
+        compiled.matches(PROTO_ICMP, 0, 0, Some((8, 0))),
+        Some(Some(11)),
+        "icmp-type-constrained term listed first must win for an echo packet"
+    );
+    // Reverse order: junos-icmp-all first → its timeout (22) wins.
+    let compiled_rev = CompiledApplications::from_matches(&vec![icmp_all, ping]);
+    assert_eq!(
+        compiled_rev.matches(PROTO_ICMP, 0, 0, Some((8, 0))),
+        Some(Some(22)),
+        "all-icmp term listed first must win for an echo packet"
+    );
+}


### PR DESCRIPTION
Closes #3346

## The bug
`CompiledApplications::matches` (userspace-dp/src/policy.rs) resolved a rule's overlapping application terms by **class**, not by configured order:

1. exact destination-port term (O(1) `exact_dst_ports` map) — always probed first
2. range terms (config order)
3. ICMP-type-constrained terms

The first hit in that fixed class order supplied the matched term's per-application inactivity timeout (#3227) and app attribution, regardless of the order the operator listed the applications.

This diverged from the Junos rule that the **first listed matching term wins**:
- **H11**: a broad/range app listed BEFORE a specific exact-port app lost to the exact term for a port both match (exact bucket probed first).
- **H12**: an unconstrained ICMP app (`junos-icmp-all`, a match-all `range_terms` entry) was checked before an ICMP-type-constrained app (`junos-ping` in `icmp_constraints`), so the all-ICMP term supplied the timeout for echo traffic even when the constrained app was listed first.

The permit/deny verdict was never affected (any term match means the rule applies — an order-independent OR); only which matched term's idle timeout / app attribution was selected.

## The fix
Stamp each compiled term with its **config-order index** (the emit order the Go control plane already produces — `capabilities.go` `resolveUserspaceApplicationNames`, #3298) and select the **lowest-index matching term across all three classes**. The O(1) exact-port map is retained purely as a lookup **accelerator** for the common single-port term, not as a precedence tier. Range/ICMP candidate lists are pushed in config order, so the first match in each list is its lowest-order match; `matches()` compares the three class candidates and returns the earliest-listed.

## policy.rs ↔ policymatch mirror
The Go diagnostic simulator (`pkg/policymatch`) returns only a boolean "does the rule apply?" verdict plus the full configured application-name list — it never selects a per-term timeout — so it already iterates in config order and needs **no logic change**; its tests still pass. The `capabilities.go` emit-order comment is updated to record that the emit order is now the cross-class precedence contract, not just within-exact-class.

## Validation
- New `policy_tests.rs` cases: a range term listed before an exact term wins for a port both match (200, not 100); the reverse order wins for exact (100); `junos-ping` listed before `junos-icmp-all` wins for an echo packet (11, not 22) and vice-versa.
- **RED-on-revert verified**: restoring the class heuristic returns 100 / 22 (both new assertions fail).
- `cargo build` clean; full `policy::` module 109/109 pass.
- `go test ./pkg/policymatch/... ./pkg/dataplane/userspace/... ./pkg/config/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi