### PR TITLE
config: resolve custom-application named ports via service catalog (#3340)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22821,3 +22821,15 @@ top.
   - **File(s)**: pkg/daemon/daemon_nft.go,
     pkg/daemon/host_inbound_nft_test.go,
     pkg/daemon/daemon_apply_runtime_test.go, _Log.md
+
+- **Timestamp**: 2026-06-28 15:33 PDT
+  - **Action**: #3340 — custom-application destination-port/source-port named
+    ports now resolve through the shared `junosServicePorts` catalog at compile
+    time (resolveAppPort) instead of a hard-coded 15-name subset, so valid Junos
+    service names (`domain`, `www`, `kerberos-sec`, hyphenated names, mixed-case)
+    resolve to numerics the dataplane can represent. Unknown names still hard-
+    reject at the strict commit gate and downgrade to a warning on the lenient
+    path. Added tests + README note.
+  - **File(s)**: pkg/config/compiler_applications.go,
+    pkg/config/compiler_application_destport_names_3340_test.go,
+    pkg/config/README.md, _Log.md

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -776,6 +776,31 @@ downgrades the reject to a warning (`lenientApplicationSpecs`) per the #1960
 no-brick doctrine. Junos does not couple ports to non-port protocols, so this is
 a vSRX-parity fix.
 
+**Custom-application named ports resolve through the shared service catalog
+(#3340):** a custom application's `source-port`/`destination-port` used to accept
+only a hard-coded 15-name subset (`http https ssh telnet ftp ftp-data smtp dns
+pop3 imap snmp ntp bgp ldap syslog`), so a valid Junos service name beyond it —
+notably `domain`, the canonical alias of the already-accepted `dns` — was
+rejected at commit even though the dataplane can represent the numeric port
+exactly. `compileApplications` / `parseApplicationTerms` now run each port spec
+through `resolveAppPort`, which resolves named ports against the **same
+`junosServicePorts` catalog** (`filter_match_resolve.go`) the firewall-filter
+path uses (`resolveFilterPortTokens`) — the single source of truth for Junos
+service-name → port number. Resolution emits the NUMERIC form (`domain` → `53`,
+`http-https` → `80-443`) so the dataplane only ever parses numerics: the Rust
+`parse_port_spec` and its Go mirror `userspacePortSpecRepresentable` (the #2124
+capability gate) recognize only the 15 literal names, so passing a broader name
+through verbatim would commit yet be unrepresentable at apply (a commit/apply
+split that disables forwarding). `resolveFilterPort` is NOT reused for this
+because it splits on `-` before a whole-spec lookup, mangling hyphenated service
+names (`ftp-data`, `tacacs-ds`, `kerberos-sec`); `resolveAppPort` does the
+whole-spec catalog lookup first. The lookup is case-insensitive, so a mixed-case
+service name resolves rather than passing through unresolved. An unresolvable
+name (unknown service, out-of-range/malformed number, inverted/unresolved range)
+is left verbatim so `validatePortSpec` hard-rejects it at the strict commit gate
+and the tolerant load/peer-sync path downgrades it to a warning
+(`lenientApplicationSpecs`, #1960 no-brick).
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler_application_destport_names_3340_test.go
+++ b/pkg/config/compiler_application_destport_names_3340_test.go
@@ -1,0 +1,195 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3340: a custom application's destination-port / source-port only recognized a
+// hard-coded 15-name subset (http https ssh telnet ftp ftp-data smtp dns pop3
+// imap snmp ntp bgp ldap syslog). Any other valid Junos service name — notably
+// `domain`, the canonical alias of the already-accepted `dns` — was rejected at
+// commit as "not a number or known service", even though the dataplane can
+// represent the numeric port exactly. The fix resolves application named ports
+// through the shared junosServicePorts catalog (the SAME SSOT the firewall-filter
+// path uses) at compile time, so the dataplane only ever sees numerics. An
+// unknown name still hard-rejects at the strict commit gate and downgrades to a
+// warning on the lenient (tolerant load / HA sync) path.
+//
+// These trees are built from flat `set` commands via flatTreeFromSets — the only
+// correct way to exercise the flat-set AST shape (see compiler_application_specs_test.go).
+
+func referencedAppDestPort(destPort string) []string {
+	return []string{
+		"set applications application BAD protocol tcp",
+		"set applications application BAD destination-port " + destPort,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application BAD",
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	}
+}
+
+// The issue's headline case: `domain` (alias of `dns`, port 53) was rejected;
+// it must now resolve and commit. Fail-on-revert: without resolveAppPort,
+// "domain" reaches validatePortSpec's 15-name map (which has `dns` but not
+// `domain`) and CompileConfig errors — this test goes RED.
+func TestApplicationDestPort_DomainAlias_ResolvesAndCommits(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedAppDestPort("domain")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept application BAD with destination-port domain: %v", err)
+	}
+	if got := cfg.Applications.Applications["BAD"].DestinationPort; got != "53" {
+		t.Fatalf("destination-port domain must resolve to numeric 53, got %q", got)
+	}
+}
+
+// A spread of Junos service names beyond the old 15-name subset — including
+// hyphenated names (ftp-data, kerberos-sec, tacacs-ds) that a naive range-split
+// would mangle — must resolve to their numeric port and commit.
+func TestApplicationDestPort_CatalogNames_ResolveAndCommit(t *testing.T) {
+	cases := map[string]string{
+		"domain":       "53",
+		"www":          "80",
+		"kerberos-sec": "88",
+		"ftp-data":     "20",
+		"tacacs-ds":    "65",
+		"snmptrap":     "162",
+		"radius":       "1812",
+		"nfsd":         "2049",
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, referencedAppDestPort(name)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept destination-port %q: %v", name, err)
+			}
+			if got := cfg.Applications.Applications["BAD"].DestinationPort; got != want {
+				t.Fatalf("destination-port %q must resolve to %q, got %q", name, want, got)
+			}
+		})
+	}
+}
+
+// Mixed-case service name must resolve (the catalog lookup is case-insensitive)
+// rather than passing through unresolved. This is the application-path corner of
+// the #3372 mixed-case concern — exercised here only to prove this change does
+// not regress it; #3372 itself is out of scope.
+func TestApplicationDestPort_MixedCaseName_Resolves(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedAppDestPort("Domain")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept mixed-case destination-port Domain: %v", err)
+	}
+	if got := cfg.Applications.Applications["BAD"].DestinationPort; got != "53" {
+		t.Fatalf("mixed-case Domain must resolve to 53, got %q", got)
+	}
+}
+
+// source-port named-port resolution rides the same path.
+func TestApplicationSourcePort_CatalogName_Resolves(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application BAD protocol tcp",
+		"set applications application BAD source-port domain",
+		"set applications application BAD destination-port 80",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application BAD",
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept source-port domain: %v", err)
+	}
+	if got := cfg.Applications.Applications["BAD"].SourcePort; got != "53" {
+		t.Fatalf("source-port domain must resolve to 53, got %q", got)
+	}
+}
+
+// Numeric ports and numeric ranges must keep working unchanged (positive
+// control proving the resolver does not perturb the already-numeric path).
+func TestApplicationDestPort_NumericAndRange_StillCommit(t *testing.T) {
+	for _, spec := range []string{"443", "8080-8090"} {
+		tree := flatTreeFromSets(t, referencedAppDestPort(spec)...)
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("expected commit to accept destination-port %q: %v", spec, err)
+		}
+		if got := cfg.Applications.Applications["BAD"].DestinationPort; got != spec {
+			t.Fatalf("numeric spec %q must pass through unchanged, got %q", spec, got)
+		}
+	}
+}
+
+// A named range (service-name endpoints) resolves to a numeric range.
+func TestApplicationDestPort_NamedRange_Resolves(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedAppDestPort("http-https")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept destination-port http-https: %v", err)
+	}
+	if got := cfg.Applications.Applications["BAD"].DestinationPort; got != "80-443" {
+		t.Fatalf("named range http-https must resolve to 80-443, got %q", got)
+	}
+}
+
+// An inline term's destination-port named port resolves on the term path too.
+func TestApplicationDestPort_InlineTerm_Resolves(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application MT term t1 protocol tcp destination-port domain",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("inline-term destination-port domain must compile: %v", err)
+	}
+	app := cfg.Applications.Applications["MT-t1"]
+	if app == nil {
+		t.Fatalf("expected inline-term application MT-t1, got %v", cfg.Applications.Applications)
+	}
+	if app.DestinationPort != "53" {
+		t.Fatalf("inline-term destination-port domain must resolve to 53, got %q", app.DestinationPort)
+	}
+}
+
+// An unknown service name must still hard-reject at the strict commit gate.
+// Fail-on-revert: this is the unchanged strict-reject half of the contract — a
+// genuinely unresolvable name (not in the catalog, not numeric) must never
+// commit, so widening the catalog does not turn into accept-anything.
+func TestApplicationDestPort_UnknownName_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedAppDestPort("not-a-service")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to reject application BAD with unknown destination-port not-a-service")
+	}
+	if !strings.Contains(err.Error(), "BAD") || !strings.Contains(err.Error(), "destination-port") {
+		t.Fatalf("error %q must name application BAD and destination-port", err.Error())
+	}
+}
+
+// No-brick (#1960/#3261): a config persisted/synced with a policy-referenced
+// unknown-named-port application must still LOAD on the tolerant path
+// (CompileConfigLenient) — downgraded to a warning, NOT a hard fail — so an
+// upgraded/peer-syncing node does not fail closed on boot. The runtime #2124
+// capability gate keeps that one unrepresentable app inert.
+func TestApplicationDestPort_UnknownName_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, referencedAppDestPort("not-a-service")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of a referenced unknown-named-port app must not fail: %v", err)
+	}
+	var warned bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "application spec") && strings.Contains(w, "BAD") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected lenient path to record an application-spec downgrade warning, got %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -51,9 +51,9 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 			case "protocol":
 				app.Protocol = nodeVal(prop)
 			case "destination-port":
-				app.DestinationPort = nodeVal(prop)
+				app.DestinationPort = resolveAppPort(nodeVal(prop))
 			case "source-port":
-				app.SourcePort = nodeVal(prop)
+				app.SourcePort = resolveAppPort(nodeVal(prop))
 			case "inactivity-timeout", "timeout":
 				if v := nodeVal(prop); v != "" {
 					if n, ok := parseAppTimeout(v); ok {
@@ -154,12 +154,12 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 		case "destination-port":
 			if i+1 < len(keys) {
 				i++
-				dstPort = keys[i]
+				dstPort = resolveAppPort(keys[i])
 			}
 		case "source-port":
 			if i+1 < len(keys) {
 				i++
-				srcPort = keys[i]
+				srcPort = resolveAppPort(keys[i])
 			}
 		case "inactivity-timeout", "timeout":
 			if i+1 < len(keys) {
@@ -240,8 +240,76 @@ func normalizeProtocol(name string) string {
 	}
 }
 
+// resolveAppPort rewrites a custom-application port spec (destination-port /
+// source-port) so any Junos service name is replaced by its numeric value,
+// leaving the dataplane to ever parse only numerics. This is the application
+// counterpart of resolveFilterPortTokens (filter_match_resolve.go): both back
+// named-port resolution with the SAME junosServicePorts catalog (the single
+// source of truth for Junos service-name → port number), so a name the firewall
+// filter path accepts (`domain`, `www`, `kerberos-sec`, ...) is accepted here
+// too — closing the #3340 gap where a custom application's destination-port only
+// knew a hard-coded 15-name subset (`dns` yes, its alias `domain` no).
+//
+// Why resolve to a number rather than widen the accepted name set: the Rust
+// dataplane's parse_port_spec (userspace-dp/src/policy.rs) and its Go mirror
+// userspacePortSpecRepresentable (pkg/dataplane/userspace/capabilities.go, the
+// #2124 capability gate) recognize ONLY the 15 literal names. Passing a broader
+// name straight through would parse at commit but be unrepresentable at apply —
+// the #2124 gate would set ForwardingSupported=false for the whole dataplane (a
+// commit/apply split). Resolving to a number here means BOTH the strict commit
+// gate and the runtime capability gate see the numeric form and agree.
+//
+// resolveFilterPort is deliberately NOT reused: it splits on '-' BEFORE a
+// whole-spec name lookup, so a hyphenated service name (ftp-data, tacacs-ds,
+// kerberos-sec) would be misparsed as a low-high range and rejected. The
+// whole-spec catalog lookup here comes first so hyphenated names resolve.
+//
+// On success the canonical numeric string is returned. An UNRESOLVABLE spec
+// (unknown name, out-of-range / malformed number, inverted or unresolved range)
+// is returned verbatim so the caller leaves it for validatePortSpec to reject at
+// the strict commit gate (and to downgrade to a warning on the lenient path) —
+// the strict-reject + lenient-warn discipline (#1960/#3261). The catalog lookup
+// is case-insensitive (strings.ToLower), so a mixed-case service name resolves
+// rather than passing through unresolved.
+func resolveAppPort(spec string) string {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return spec
+	}
+	// Whole-spec service name first — covers hyphenated names (ftp-data,
+	// kerberos-sec) that a range-split would otherwise mangle.
+	if p, ok := junosServicePorts[strings.ToLower(trimmed)]; ok {
+		return strconv.Itoa(int(p))
+	}
+	// A bare numeric port is already in the form the dataplane wants; leave it
+	// byte-identical (validatePortSpec still range-checks it).
+	if _, err := strconv.Atoi(trimmed); err == nil {
+		return spec
+	}
+	// A low-high range whose endpoints are numbers or (non-hyphenated) service
+	// names: resolve each side through the catalog and emit a numeric range.
+	if lo, hi, found := strings.Cut(trimmed, "-"); found {
+		l, ok1 := resolveSinglePort(lo)
+		h, ok2 := resolveSinglePort(hi)
+		if ok1 && ok2 && l <= h {
+			return fmt.Sprintf("%d-%d", l, h)
+		}
+	}
+	// Unresolvable — return verbatim so the strict gate rejects / lenient warns.
+	return spec
+}
+
 // validatePortSpec checks that a port specification is valid.
 // Valid formats: "80", "8080-8090", named ports like "http".
+//
+// Application named ports are resolved to numerics by resolveAppPort at compile
+// time (compileApplications / parseApplicationTerms), so by the time this gate
+// runs a recognized service name is already a number. The 15 literal names below
+// are the set the Rust dataplane (parse_port_spec) accepts directly, kept as a
+// belt-and-suspenders backstop so those names still validate even if a future
+// caller reaches this gate without resolving first — it stays in lock-step with
+// userspacePortSpecRepresentable so this validator never accepts a raw name the
+// dataplane cannot represent.
 func validatePortSpec(spec string) error {
 	if spec == "" {
 		return nil


### PR DESCRIPTION
## Summary
Closes #3340.

A custom application's `source-port` / `destination-port` accepted only a hard-coded 15-name subset (`http https ssh telnet ftp ftp-data smtp dns pop3 imap snmp ntp bgp ldap syslog`). Any other valid Junos service name was rejected at commit as *"not a number or known service"* — notably `domain`, the canonical alias of the already-accepted `dns`, even though the dataplane can represent the numeric port exactly. vSRX configs commonly use names like `domain`, `www`, `kerberos-sec`.

## Fix
`compileApplications` / `parseApplicationTerms` now resolve each port spec through the new `resolveAppPort`, backed by the **shared `junosServicePorts` catalog** (`filter_match_resolve.go`) — the same SSOT the firewall-filter path uses (`resolveFilterPortTokens`). Resolution emits the NUMERIC form (`domain` → `53`, `http-https` → `80-443`).

**Why resolve to a number rather than widen the name set:** the Rust `parse_port_spec` and its Go mirror `userspacePortSpecRepresentable` (the #2124 capability gate) recognize only the 15 literal names. Passing a broader name through verbatim would commit yet be unrepresentable at apply — a commit/apply split that sets `ForwardingSupported=false` for the whole dataplane. Emitting numerics keeps the strict commit gate and the runtime gate in agreement.

`resolveFilterPort` is **not** reused — it splits on `-` before a whole-spec lookup, mangling hyphenated names (`ftp-data`, `tacacs-ds`, `kerberos-sec`). `resolveAppPort` does the whole-spec catalog lookup first. The lookup is case-insensitive, so a mixed-case name resolves (the application corner of #3372 — out of scope, just not regressed).

## Strict-reject + lenient-warn (unchanged)
An unresolvable name (unknown service, out-of-range/malformed number, inverted/unresolved range) is left verbatim so `validatePortSpec` hard-rejects it at the strict commit gate (`validateApplicationSpecsStrict`) and the tolerant load / HA-sync path downgrades it to a warning (`lenientApplicationSpecs`, #1960/#3261 no-brick).

## Tests
- `domain` (and a catalog spread incl. hyphenated names) resolves to its numeric port and commits — **RED on revert** (verified: drops back to *"not a number or known service"* / *"invalid port range … non-numeric"*).
- mixed-case resolves; numeric ports + ranges + named ranges still commit; inline-term and source-port paths resolve.
- unknown name still rejects at strict commit; warns-not-bricks under `CompileConfigLenient`.

`go build ./... && go test ./pkg/config/... ./pkg/appid/... ./pkg/dataplane/userspace/...` all green. README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi