### PR TITLE
config/firewall-filter: whole-spec service lookup before range split (Closes #3397)

### DIFF
--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -259,10 +259,15 @@ func normalizeProtocol(name string) string {
 // commit/apply split). Resolving to a number here means BOTH the strict commit
 // gate and the runtime capability gate see the numeric form and agree.
 //
-// resolveFilterPort is deliberately NOT reused: it splits on '-' BEFORE a
-// whole-spec name lookup, so a hyphenated service name (ftp-data, tacacs-ds,
-// kerberos-sec) would be misparsed as a low-high range and rejected. The
-// whole-spec catalog lookup here comes first so hyphenated names resolve.
+// resolveFilterPort (filter_match_resolve.go) now uses the SAME whole-spec
+// catalog lookup first (#3397), so a hyphenated service name (ftp-data,
+// tacacs-ds, kerberos-sec) resolves on BOTH the application and the firewall
+// filter path. The two helpers are kept separate only because their miss
+// contract differs: resolveAppPort returns the spec VERBATIM on an
+// unresolvable miss (so validatePortSpec rejects it strictly / the lenient
+// path warns), whereas resolveFilterPort returns ok=false so its caller keeps
+// the raw token and records it on term.UnknownPorts for the filter commit
+// gate.
 //
 // On success the canonical numeric string is returned. An UNRESOLVABLE spec
 // (unknown name, out-of-range / malformed number, inverted or unresolved range)
@@ -307,9 +312,14 @@ func resolveAppPort(spec string) string {
 // runs a recognized service name is already a number. The 15 literal names below
 // are the set the Rust dataplane (parse_port_spec) accepts directly, kept as a
 // belt-and-suspenders backstop so those names still validate even if a future
-// caller reaches this gate without resolving first — it stays in lock-step with
-// userspacePortSpecRepresentable so this validator never accepts a raw name the
-// dataplane cannot represent.
+// caller reaches this gate without resolving first. The name SET matches
+// userspacePortSpecRepresentable (the #2124 capability gate) and Rust
+// parse_port_spec, but the case handling does NOT: this gate is
+// case-INSENSITIVE (strings.ToLower), whereas userspacePortSpecRepresentable /
+// parse_port_spec match case-SENSITIVELY. That divergence is not a fail-open in
+// practice because resolveAppPort lowercases and resolves named ports to
+// numerics before this gate ever runs, so a mixed-case name ("HTTP") never
+// reaches the runtime capability gate as a raw name.
 func validatePortSpec(spec string) error {
 	if spec == "" {
 		return nil

--- a/pkg/config/filter_match_resolve.go
+++ b/pkg/config/filter_match_resolve.go
@@ -245,6 +245,15 @@ func resolveFilterPort(spec string) (string, bool) {
 	if spec == "" {
 		return "", false
 	}
+	// Whole-spec service name first — covers hyphenated catalog names
+	// (ftp-data, kerberos-sec, tacacs-ds) that a range-split on '-' would
+	// otherwise mangle into a malformed low-high range and reject. Mirrors
+	// resolveAppPort (compiler_applications.go, #3340). A two-token range
+	// such as http-https is not a catalog name, so it falls through to the
+	// range path below and still resolves.
+	if p, ok := junosServicePorts[strings.ToLower(spec)]; ok {
+		return strconv.Itoa(int(p)), true
+	}
 	if i := strings.IndexByte(spec, '-'); i > 0 && i < len(spec)-1 {
 		lo, ok1 := resolveSinglePort(spec[:i])
 		hi, ok2 := resolveSinglePort(spec[i+1:])

--- a/pkg/config/firewall_symbolic_match_3205_test.go
+++ b/pkg/config/firewall_symbolic_match_3205_test.go
@@ -174,6 +174,102 @@ func TestFilterUnknownPortRejected_3205(t *testing.T) {
 	}
 }
 
+// #3397: a HYPHENATED catalog service name (kerberos-sec, ftp-data, tacacs-ds)
+// resolves to its single port on a firewall-filter source/destination-port.
+// FAIL-ON-REVERT: restore the old split-on-'-'-first order in resolveFilterPort
+// and these names misparse as malformed low-high ranges (e.g. kerberos / sec)
+// and are rejected, leaving them on UnknownPorts.
+func TestFilterHyphenatedServiceNameResolves_3397(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from protocol tcp",
+		"set firewall family inet filter f term t from destination-port kerberos-sec",
+		"set firewall family inet filter f term t from source-port ftp-data",
+		"set firewall family inet filter f term t then accept",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := firstInetTerm(t, cfg, "f")
+	if len(term.DestinationPorts) != 1 || term.DestinationPorts[0] != "88" {
+		t.Fatalf("destination-port kerberos-sec => %v, want [88] (#3397)", term.DestinationPorts)
+	}
+	if len(term.SourcePorts) != 1 || term.SourcePorts[0] != "20" {
+		t.Fatalf("source-port ftp-data => %v, want [20] (#3397)", term.SourcePorts)
+	}
+	if len(term.UnknownPorts) != 0 {
+		t.Fatalf("hyphenated catalog names must resolve, got UnknownPorts %v", term.UnknownPorts)
+	}
+}
+
+// #3397: a hyphenated name also resolves on the *-port-except path.
+func TestFilterHyphenatedServiceNameExceptResolves_3397(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from protocol tcp",
+		"set firewall family inet filter f term t from destination-port-except tacacs-ds",
+		"set firewall family inet filter f term t then accept",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := firstInetTerm(t, cfg, "f")
+	if len(term.DestPortsExcept) != 1 || term.DestPortsExcept[0] != "65" {
+		t.Fatalf("destination-port-except tacacs-ds => %v, want [65] (#3397)", term.DestPortsExcept)
+	}
+	if len(term.UnknownPorts) != 0 {
+		t.Fatalf("tacacs-ds must resolve, got UnknownPorts %v", term.UnknownPorts)
+	}
+}
+
+// #3397: a two-token spec that is NOT a catalog name (http-https) still resolves
+// as a low-high range — the whole-spec lookup falls through to the range path.
+func TestFilterServiceNameRangeStillResolves_3397(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from protocol tcp",
+		"set firewall family inet filter f term t from destination-port http-https",
+		"set firewall family inet filter f term t then accept",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := firstInetTerm(t, cfg, "f")
+	if len(term.DestinationPorts) != 1 || term.DestinationPorts[0] != "80-443" {
+		t.Fatalf("destination-port http-https => %v, want [80-443] (#3397)", term.DestinationPorts)
+	}
+	if len(term.UnknownPorts) != 0 {
+		t.Fatalf("http-https range must resolve, got UnknownPorts %v", term.UnknownPorts)
+	}
+}
+
+// #3397: a numeric port still passes through and an unknown name is still
+// rejected — the new whole-spec-first order does not weaken either behavior.
+func TestFilterNumericAndUnknownUnaffected_3397(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from protocol tcp",
+		"set firewall family inet filter f term t from destination-port 8080",
+		"set firewall family inet filter f term t then accept",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	term := firstInetTerm(t, cfg, "f")
+	if len(term.DestinationPorts) != 1 || term.DestinationPorts[0] != "8080" {
+		t.Fatalf("numeric destination-port => %v, want [8080]", term.DestinationPorts)
+	}
+
+	bad := buildFilterTree(t,
+		"set firewall family inet filter b term t from protocol tcp",
+		"set firewall family inet filter b term t from destination-port not-a-service",
+		"set firewall family inet filter b term t then accept",
+	)
+	if _, err := CompileConfig(bad); err == nil {
+		t.Fatal("unknown hyphenated name not-a-service must be rejected at commit (#3397)")
+	}
+}
+
 // #3205: an out-of-range numeric icmp-type is rejected (defense against a
 // silently-truncated u8 cast).
 func TestFilterICMPTypeOutOfRangeRejected_3205(t *testing.T) {


### PR DESCRIPTION
## Summary

`resolveFilterPort` (pkg/config/filter_match_resolve.go) split a firewall-filter `from {source,destination}-port` spec on the first `-` BEFORE consulting the `junosServicePorts` catalog, so a hyphenated catalog service name (`ftp-data`=20, `kerberos-sec`=88, `tacacs-ds`=65) was misparsed as a malformed low-high range and rejected at commit — even though the name exists in the catalog. This is the firewall-filter sibling of the #3340 custom-application bug fixed in `resolveAppPort` (PR #3396).

## Fix

- `resolveFilterPort` now does the whole-spec catalog lookup `junosServicePorts[ToLower(spec)]` FIRST; only on a miss does it split on `-` for a range — mirroring `resolveAppPort`.
- Hyphenated catalog names resolve to their single port; a genuine two-token range that is NOT a catalog name (`http-https` -> `80-443`) falls through to the range path and still resolves.
- Strict-reject (unknown name -> commit error) and lenient-downgrade (kept verbatim for a fail-closed dataplane) behavior already on the filter path is unchanged.
- Corrected two now-inaccurate comments in `compiler_applications.go`: the "resolveFilterPort is deliberately NOT reused because it splits first" note (both helpers now do whole-spec-first; they differ only in their miss contract), and the overstated `validatePortSpec`/`userspacePortSpecRepresentable` "lock-step" claim (name SET matches but case handling does not — not a fail-open because `resolveAppPort` lowercases and resolves to numerics first).

## Tests

`firewall_symbolic_match_3205_test.go`:
- hyphenated names resolve on `source-port`/`destination-port` and `*-port-except` (RED-on-revert vs the old split-first order)
- `http-https` still resolves as a range
- numeric + unknown ports still behave (numeric passes through, unknown still rejected at commit)

RED-on-revert verified: restoring the old split-first order fails `TestFilterHyphenatedServiceNameResolves_3397` and `TestFilterHyphenatedServiceNameExceptResolves_3397` with `unknown port "kerberos-sec"` / `unknown port "tacacs-ds"`; the range and numeric tests pass both ways.

`go build ./... && go test ./pkg/config/...` green.

Closes #3397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi