### PR TITLE
daemon: fail-closed lo0 nftables apply/delete (#3392)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-28 — #3392 lo0 nftables apply/delete fail-closed (sibling of #3333)
+
+- **Timestamp**: 2026-06-28
+- **Action**: Mirror the #3333/#3389 host-inbound fail-closed fix onto the lo0
+  input-filter path. `applyLo0Filter` now RETURNS the apply/teardown error
+  instead of swallowing it at WARN; `applyConfigLocked` joins it (`lo0Err`) into
+  the deferred-tail `errors.Join(networkdErr, dhcpServerErr, hostInboundErr,
+  lo0Err)` so a committed lo0 filter that did not reach the kernel reports commit
+  FAILURE rather than silent success. The no-filter teardown switched from a
+  bare `nft delete table` (errors when absent) to the idempotent
+  `add table; delete table` payload via the shared `nftDeleteTable` seam
+  (universal verbs — NO `nft destroy`), reusing the atomic `nftApplyPayload`
+  runner. Boot/DHCP re-applies stay log-only via `applyConfig` (no startup
+  brick). Added a commit-level wiring test (RED-on-revert: removing `lo0Err`
+  from the join) + helper apply/teardown failure-surfaced + success-no-error +
+  idempotent add+delete teardown tests. Updated the README lo0 bullet (was
+  documenting the old fail-OPEN warn-only behavior). RED-on-revert verified for
+  the join wiring AND both helper paths.
+- **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/daemon_apply.go,
+  pkg/daemon/lo0_filter_test.go, pkg/daemon/daemon_apply_runtime_test.go,
+  pkg/daemon/README.md
+
 ## 2026-06-27 — #3311 host-inbound `protocols isis` (L2 no-op, vSRX parity)
 
 - **Timestamp**: 2026-06-27

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -272,17 +272,32 @@ never lock an operator out of a remote box it manages.
 - lo0 input filters (`interfaces lo0 unit 0 family inet[6] filter input
   <name>`) lock down host-bound/control-plane traffic via an nftables table
   `inet xpf_lo0`. `daemon_nft.go:applyLo0Filter` builds the table with
-  `buildLo0FilterPayload` and feeds it to `nft -f -`. nft parses an `-f -`
-  payload **atomically** — a syntax error on any line rejects the ENTIRE
-  payload (the filter then fails OPEN, logging only a `slog.Warn`). The
-  payload MUST therefore reset the prior table with the valid atomic idiom:
-  `table inet xpf_lo0` (create-if-absent, no body — idempotent) +
-  `flush table inet xpf_lo0` + the redefined table. Do NOT use
-  `flush ruleset inet xpf_lo0`: `flush ruleset` takes at most an OPTIONAL
-  family (`flush ruleset [<family>]`), never a table name — appending one is
-  an nft parse error that silently dropped the whole filter (#2069).
-  `TestLo0FilterPayloadNftParses` parse-checks the real payload with
-  `nft -c -f -` when nft is on PATH.
+  `buildLo0FilterPayload` and feeds it to `nft -f -` (via the `nftApplyPayload`
+  seam). nft parses an `-f -` payload **atomically** — a syntax error on any
+  line rejects the ENTIRE payload (the kernel keeps the PREVIOUS table
+  untouched, not a half-applied ruleset). The payload MUST therefore reset the
+  prior table with the valid atomic idiom: `table inet xpf_lo0`
+  (create-if-absent, no body — idempotent) + `flush table inet xpf_lo0` + the
+  redefined table. Do NOT use `flush ruleset inet xpf_lo0`: `flush ruleset`
+  takes at most an OPTIONAL family (`flush ruleset [<family>]`), never a table
+  name — appending one is an nft parse error that silently dropped the whole
+  filter (#2069). `TestLo0FilterPayloadNftParses` parse-checks the real payload
+  with `nft -c -f -` when nft is on PATH.
+  **Fail-closed (#3392, mirroring host-inbound #3333):** `applyLo0Filter`
+  RETURNS the apply/teardown error instead of swallowing it at WARN, and
+  `applyConfigLocked` joins it (`lo0Err`) into the commit result alongside
+  `networkdErr`/`dhcpServerErr`/`hostInboundErr`, so a committed lo0 filter that
+  did not reach the kernel reports commit FAILURE rather than silent success.
+  The teardown (no filter bound) uses the idempotent `add table; delete table`
+  payload via `nftDeleteTable` (universal verbs — NOT the unpinned `nft
+  destroy`), so the benign absent-table case is a no-op while a genuine teardown
+  failure (stale filter left in the kernel) still surfaces. Boot / DHCP
+  re-applies go through `applyConfig`, which only LOGS the error, so a transient
+  nft failure cannot brick startup; the next clean commit re-renders. Tests:
+  `lo0_filter_test.go` (apply/teardown failure-surfaced fail-on-revert,
+  success-no-error, idempotent add+delete teardown) and
+  `daemon_apply_runtime_test.go:TestApplyConfigLockedSurfacesLo0Failure` (the
+  commit-level `errors.Join` wiring proof).
 - host-inbound-traffic (`security zones <z> host-inbound-traffic`) is the
   PRIMARY kernel enforcement for host-bound traffic to a firewall interface IP
   / VRRP VIP (SSH, ping, OSPF/BGP to the box — #3070). Such traffic is shunted

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1256,7 +1256,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	d.applyHostname(cfg)
 	d.applyTimezone(cfg)
 	d.applyKernelTuning(cfg)
-	d.applyLo0Filter(cfg)
+	// #3392: the lo0 input filter is host-protection control-plane enforcement,
+	// so an apply/teardown failure must fail the commit closed rather than be
+	// swallowed at WARN — the same fail-open #3333 fixed for host-inbound. The
+	// error is joined into the commit result at the tail (alongside networkdErr /
+	// dhcpServerErr / hostInboundErr); the remaining apply steps still run so
+	// management/SSH reconcile is never skipped by an lo0 nft failure.
+	lo0Err := d.applyLo0Filter(cfg)
 	// #3333: host-inbound is the kernel-nftables PRIMARY enforcement of the
 	// host-inbound contract, so an apply/teardown failure must fail the commit
 	// closed rather than be swallowed at WARN. The error is joined into the
@@ -1451,7 +1457,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// restart/stop failure through the commit so a write that left stale
 	// kernel state fails the commit (fail-closed) instead of reporting
 	// success. Both are joined so neither masks the other.
-	return errors.Join(networkdErr, dhcpServerErr, hostInboundErr)
+	return errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err)
 }
 
 // compileErrorMustAbortApply reports whether a dataplane ApplyConfig error

--- a/pkg/daemon/daemon_apply_runtime_test.go
+++ b/pkg/daemon/daemon_apply_runtime_test.go
@@ -30,9 +30,18 @@ func TestApplyConfigLockedSurfacesHostInboundFailure(t *testing.T) {
 	installFakeNetworkctl(t)
 
 	injected := errors.New("nft: host-inbound rule load failed")
-	origApply := nftApplyPayload
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
 	nftApplyPayload = func(string) ([]byte, error) { return []byte("Error: load failed\n"), injected }
-	defer func() { nftApplyPayload = origApply }()
+	// #3392: applyLo0Filter now also routes its no-filter teardown through the
+	// shared nftDeleteTable seam (whose default impl delegates to nftApplyPayload).
+	// This config binds no lo0 filter, so without stubbing nftDeleteTable the lo0
+	// teardown would ALSO fail with `injected` and ride in via lo0Err — making the
+	// hostInboundErr RED-on-revert false-green (dropping hostInboundErr from the
+	// join would still surface `injected` through lo0Err). Stub the teardown to
+	// succeed so the injected failure rides SOLELY on the host-inbound apply path,
+	// isolating this test to its own join term.
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
 
 	networkDir := t.TempDir()
 	d := &Daemon{

--- a/pkg/daemon/daemon_apply_runtime_test.go
+++ b/pkg/daemon/daemon_apply_runtime_test.go
@@ -71,6 +71,77 @@ func TestApplyConfigLockedSurfacesHostInboundFailure(t *testing.T) {
 	}
 }
 
+// TestApplyConfigLockedSurfacesLo0Failure is the #3392 commit-level wiring
+// proof: it drives the REAL applyConfigLocked body (not the applyLo0Filter
+// helper directly) with an injected lo0-filter nft failure via the
+// nftApplyPayload seam, and asserts the returned commit error includes that
+// failure. This pins the production wiring — the errors.Join(networkdErr,
+// dhcpServerErr, hostInboundErr, lo0Err) at the tail of applyConfigLocked —
+// which the helper-level seam tests do NOT cover.
+//
+// RED-on-revert: remove lo0Err from that join and this test goes RED (the apply
+// completes and returns nil despite the lo0 input filter failing to install —
+// the silent fail-open the issue describes). The config binds an lo0 filter but
+// declares NO host-inbound stanza, so the only nftApplyPayload caller that can
+// fail is applyLo0Filter — isolating this from the #3333 host-inbound wiring.
+func TestApplyConfigLockedSurfacesLo0Failure(t *testing.T) {
+	installFakeNetworkctl(t)
+
+	injected := errors.New("nft: lo0 rule load failed")
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return []byte("Error: load failed\n"), injected }
+	// nftDeleteTable's default impl delegates to nftApplyPayload, so without this
+	// stub the host-inbound no-enforceable-view TEARDOWN (which this config takes)
+	// would also fail with `injected` and mask the RED-on-revert: removing lo0Err
+	// from the join must be the ONLY thing that surfaces `injected`. Stub the
+	// teardown to succeed so the injected error rides solely on the lo0 apply.
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	networkDir := t.TempDir()
+	d := &Daemon{
+		dp:       &runtimeOnlyApplyTestDP{},
+		networkd: networkd.NewInDir(networkDir),
+		store:    newConfigStore(t, filepath.Join(t.TempDir(), "config.db")),
+		vrrpMgr:  vrrp.NewManager(),
+		opts:     Options{NoDataplane: true},
+	}
+
+	// An lo0 input filter is bound (so applyLo0Filter reaches the APPLY path and
+	// the injected nft failure is the filter-not-installed failure). No zone
+	// declares a host-inbound stanza, so applyHostInboundFilter takes the
+	// no-enforceable-view teardown branch, which is stubbed to succeed above —
+	// keeping the injected error scoped to the lo0 apply wiring.
+	cfg := &config.Config{}
+	cfg.System.Lo0FilterInputV4 = "mgmt-lockdown"
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"mgmt-lockdown": {
+			Name: "mgmt-lockdown",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "deny-all", Action: "discard"},
+			},
+		},
+	}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.7.7.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+	}
+
+	err := d.applyConfigLocked(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("applyConfigLocked must surface the lo0 nft failure " +
+			"(fail-closed); got nil (the silent fail-open #3392 describes)")
+	}
+	if !errors.Is(err, injected) {
+		t.Fatalf("returned commit error must include the lo0 failure "+
+			"via errors.Join wiring, got %v", err)
+	}
+}
+
 func TestApplyConfigRuntimeResultDrivesDownstreamConsumers(t *testing.T) {
 	networkDir := t.TempDir()
 	installFakeNetworkctl(t)

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -51,30 +51,43 @@ var nftDeleteTable = func(family, name string) ([]byte, error) {
 // applyLo0Filter applies loopback filter rules for host-bound traffic.
 // Implements "interfaces lo0 unit 0 family inet filter input <name>" by
 // generating nftables rules from the named firewall filter.
-func (d *Daemon) applyLo0Filter(cfg *config.Config) {
+//
+// Fail-closed (#3392, mirroring the host-inbound #3333 fix): both the apply and
+// the teardown surface their failure as a returned error instead of a swallowed
+// WARN. applyConfigLocked joins this into the commit result, so a committed lo0
+// input filter that did not reach the kernel reports commit FAILURE rather than
+// silent success (the lo0 filter is host-protection control-plane enforcement,
+// the same class of fail-open #3333 closed for host-inbound). The retained
+// kernel state is always the more- or equally-restrictive prior state: an `-f -`
+// apply loads atomically (the previous table is kept untouched on failure), and
+// a failed teardown leaves the existing filter in place — neither relaxes
+// enforcement silently. Boot / DHCP re-applies go through applyConfig(), which
+// only logs the error, so a transient nft failure cannot brick startup; the next
+// clean commit re-renders.
+func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 	filterV4 := cfg.System.Lo0FilterInputV4
 	filterV6 := cfg.System.Lo0FilterInputV6
 	if filterV4 == "" && filterV6 == "" {
-		// No lo0 filter configured — clean up any stale nftables rules.
-		// The error stays discarded: delete fails normally when the
-		// table doesn't exist (the common case). Timeout-bounded so a
-		// wedged nft cannot stall the apply path (#1794).
-		_, _ = runCommandTimeout("nft", "delete", "table", "inet", "xpf_lo0")
-		return
+		// No lo0 filter configured — remove any stale table. nftDeleteTable is
+		// idempotent (an add-then-delete payload, so no error when the table is
+		// absent — the common no-lo0-filter case), so a non-nil error here is a
+		// REAL teardown failure that left a stale lo0 input filter in the kernel:
+		// surface it so the commit fails closed rather than reporting that the lo0
+		// filter was removed when it was not.
+		if out, err := nftDeleteTable("inet", "xpf_lo0"); err != nil {
+			slog.Warn("failed to delete stale lo0 filter table", "err", err, "output", string(out))
+			return fmt.Errorf("delete stale lo0 nftables table: %w", err)
+		}
+		return nil
 	}
 
 	nftConf := buildLo0FilterPayload(cfg, filterV4, filterV6)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "nft", "-f", "-")
-	// WaitDelay caps the post-SIGKILL pipe-drain window (#1794).
-	cmd.WaitDelay = 5 * time.Second
-	cmd.Stdin = strings.NewReader(nftConf)
-	if out, err := cmd.CombinedOutput(); err != nil {
+	if out, err := nftApplyPayload(nftConf); err != nil {
 		slog.Warn("failed to apply lo0 filter", "err", err, "output", string(out))
-	} else {
-		slog.Info("lo0 filter applied", "v4", filterV4, "v6", filterV6)
+		return fmt.Errorf("apply lo0 nftables filter: %w", err)
 	}
+	slog.Info("lo0 filter applied", "v4", filterV4, "v6", filterV6)
+	return nil
 }
 
 // buildLo0FilterPayload assembles the exact nft ruleset payload that

--- a/pkg/daemon/lo0_filter_test.go
+++ b/pkg/daemon/lo0_filter_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
@@ -124,6 +125,125 @@ func TestLo0FilterPayloadNftParses(t *testing.T) {
 	// Anything else (typically `Operation not permitted` without CAP_NET_ADMIN)
 	// means the syntax parsed; that is a pass for this parse-check test.
 	t.Logf("nft -c parsed the payload; non-syntax error (expected without CAP_NET_ADMIN): %v\n%s", err, combined)
+}
+
+// TestLo0FilterApplyFailureSurfaced is the #3392 fail-on-revert proof for the
+// APPLY path: when `nft -f -` fails, applyLo0Filter must return the error (so
+// applyConfigLocked fails the commit closed) rather than swallow it at WARN.
+// With the pre-fix warn-only code the function returned nothing and this goes
+// RED. The nft invocation is replaced by the package-var seam so no real nft is
+// run. Mirrors TestHostInboundFilterApplyFailureSurfaced (#3333).
+func TestLo0FilterApplyFailureSurfaced(t *testing.T) {
+	cfg := lo0FilterTestConfig()
+
+	injected := errors.New("nft: lo0 rule load failed")
+	var called bool
+	orig := nftApplyPayload
+	nftApplyPayload = func(payload string) ([]byte, error) {
+		called = true
+		// Sanity: the payload fed to nft must be the lo0 filter ruleset, so a
+		// failure here is a real filter-not-installed event.
+		if !strings.Contains(payload, "table inet xpf_lo0") {
+			t.Errorf("apply seam got unexpected payload:\n%s", payload)
+		}
+		return []byte("Error: could not process rule\n"), injected
+	}
+	defer func() { nftApplyPayload = orig }()
+
+	d := &Daemon{}
+	err := d.applyLo0Filter(cfg)
+	if !called {
+		t.Fatal("expected nft apply seam to be invoked for a configured lo0 filter")
+	}
+	if err == nil {
+		t.Fatal("apply failure must be surfaced as an error (fail-closed), got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the nft failure, got %v", err)
+	}
+}
+
+// TestLo0FilterDeleteFailureSurfaced is the #3392 fail-on-revert proof for the
+// TEARDOWN path: when no lo0 filter is configured, the stale table is removed via
+// the idempotent add-then-delete payload; a genuine teardown failure (stale lo0
+// filter left in the kernel) must surface as an error. The add+delete is
+// idempotent for the benign absent-table case, so any error from the seam is a
+// real failure. Pre-fix the delete error was discarded entirely (`_, _ =`), so
+// this goes RED. Mirrors TestHostInboundFilterDeleteFailureSurfaced (#3333).
+func TestLo0FilterDeleteFailureSurfaced(t *testing.T) {
+	// A config with NO lo0 filter bound drives the teardown branch.
+	cfg := &config.Config{}
+
+	injected := errors.New("nft: device or resource busy")
+	var gotFamily, gotName string
+	orig := nftDeleteTable
+	nftDeleteTable = func(family, name string) ([]byte, error) {
+		gotFamily, gotName = family, name
+		return []byte("Error: Could not process rule\n"), injected
+	}
+	defer func() { nftDeleteTable = orig }()
+
+	d := &Daemon{}
+	err := d.applyLo0Filter(cfg)
+	if gotName != "xpf_lo0" || gotFamily != "inet" {
+		t.Errorf("teardown must target inet xpf_lo0, got %s %s", gotFamily, gotName)
+	}
+	if err == nil {
+		t.Fatal("teardown failure must be surfaced as an error (fail-closed), got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("returned error must wrap the nft teardown failure, got %v", err)
+	}
+}
+
+// TestLo0FilterApplySuccessNoError verifies the happy paths return nil: a
+// successful apply (configured filter) and a successful/benign teardown (no
+// filter bound) must NOT report a commit failure.
+func TestLo0FilterApplySuccessNoError(t *testing.T) {
+	origApply, origDelete := nftApplyPayload, nftDeleteTable
+	nftApplyPayload = func(string) ([]byte, error) { return nil, nil }
+	nftDeleteTable = func(string, string) ([]byte, error) { return nil, nil }
+	defer func() { nftApplyPayload, nftDeleteTable = origApply, origDelete }()
+
+	d := &Daemon{}
+	if err := d.applyLo0Filter(lo0FilterTestConfig()); err != nil {
+		t.Errorf("successful apply must return nil, got %v", err)
+	}
+	if err := d.applyLo0Filter(&config.Config{}); err != nil {
+		t.Errorf("benign teardown (no lo0 filter) must return nil, got %v", err)
+	}
+}
+
+// TestNftDeleteTableLo0IdempotentAddDelete pins the #3392 teardown shape for the
+// lo0 table: the teardown must NOT depend on the recent `nft destroy` verb (the
+// project pins no minimum nftables version) and must instead emit an idempotent
+// add-then-delete payload through the atomic nftApplyPayload runner. Reverting to
+// `nft destroy` (or the bare `delete table` that errors when absent) turns this
+// RED. Mirrors TestNftDeleteTableIdempotentAddDelete (#3333).
+func TestNftDeleteTableLo0IdempotentAddDelete(t *testing.T) {
+	var got string
+	orig := nftApplyPayload
+	nftApplyPayload = func(payload string) ([]byte, error) { got = payload; return nil, nil }
+	defer func() { nftApplyPayload = orig }()
+
+	if _, err := nftDeleteTable("inet", "xpf_lo0"); err != nil {
+		t.Fatalf("nftDeleteTable: %v", err)
+	}
+	if strings.Contains(got, "destroy") {
+		t.Errorf("teardown must not use the unpinned `nft destroy` verb:\n%s", got)
+	}
+	for _, want := range []string{
+		"add table inet xpf_lo0",
+		"delete table inet xpf_lo0",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("teardown payload missing %q:\n%s", want, got)
+		}
+	}
+	// `add` must precede `delete` so the delete always has a target.
+	if strings.Index(got, "add table") > strings.Index(got, "delete table") {
+		t.Errorf("add must precede delete in the teardown payload:\n%s", got)
+	}
 }
 
 func TestNftRuleFromTermPrefixListExpansion(t *testing.T) {


### PR DESCRIPTION
Closes #3392.

## Summary

Mirrors the just-merged #3333/#3389 host-inbound fail-closed fix onto the sibling **lo0 input-filter** path (`daemon_nft.go:applyLo0Filter`).

Before this change the lo0 filter was apply/teardown best-effort: an `nft -f -` apply failure was logged at WARN and swallowed, and the no-filter teardown discarded both output and error (`_, _ = runCommandTimeout(...)`) using a bare `delete table` that also errors when the table is absent. A committed lo0 filter could fail to install in the kernel while the commit reported **success** — a silent fail-open on the host-protection control plane.

## Fix (same pattern as #3389)

- `applyLo0Filter` now **returns** the apply/teardown error instead of swallowing it at WARN.
- `applyConfigLocked` joins it (`lo0Err`) into the deferred-tail `errors.Join(networkdErr, dhcpServerErr, hostInboundErr, lo0Err)`, so a committed lo0 filter that did not reach the kernel reports commit **FAILURE**.
- apply uses the `nftApplyPayload` seam (atomic `-f -`: a failed apply keeps the previous table untouched).
- teardown uses the shared `nftDeleteTable` seam — the idempotent `add table; delete table` payload via universal verbs (**no `nft destroy`**, since the project pins no minimum nftables version). Benign absent-table case is a no-op; a genuine teardown failure surfaces.
- Boot/DHCP re-applies stay **log-only** via `applyConfig()` (no startup brick); only operator-facing commit / cluster-sync paths propagate. **The sync caller handling is unchanged from #3389.**

## Tests

- `TestApplyConfigLockedSurfacesLo0Failure` — commit-level wiring proof through the real `applyConfigLocked` body (host-inbound teardown stubbed to succeed so the injected error rides solely on the lo0 apply, isolating it from the #3333 wiring).
- Helper seam tests: apply-failure-surfaced, teardown-failure-surfaced, success-returns-nil, idempotent add+delete teardown — mirroring `TestApplyConfigLockedSurfacesHostInboundFailure` / `TestNftDeleteTableIdempotentAddDelete`.
- README lo0 bullet updated (it still documented the old fail-OPEN warn-only behavior).

## RED-on-revert evidence

- Remove `lo0Err` from the join → `TestApplyConfigLockedSurfacesLo0Failure` FAILS: `applyConfigLocked must surface the lo0 nft failure (fail-closed); got nil`.
- Revert the helper apply path to warn-only → `TestLo0FilterApplyFailureSurfaced` FAILS: `apply failure must be surfaced as an error (fail-closed), got nil`.
- Revert the helper teardown to warn-only → `TestLo0FilterDeleteFailureSurfaced` FAILS: `teardown failure must be surfaced as an error (fail-closed), got nil`.

## Validation

`go build ./...`, `go vet ./pkg/daemon/`, and `go test ./pkg/daemon/... -count=1` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi