### PR TITLE
surface counter read errors (global + per-zone + per-policy) across REST/gRPC/Prometheus/CLI

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22850,3 +22850,20 @@ top.
     pkg/cli/cli_show_security_screen.go, pkg/cli/cli_show_security_log.go,
     pkg/cli/show_security_counter_error_test.go,
     pkg/grpcapi/server_show_security_text.go, pkg/api/README.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3345 fold (Codex MAJOR + SMR) — complete GLOBAL counter-read
+    error surfacing. H1: GetGlobalStats now checks readErr AFTER the full
+    struct build so late reads (RxPackets/HostInbound) are covered. Added
+    warnings to show security flow statistics (CLI showStatistics +
+    showFlowStatistics, gRPC showFlowStatistics) and show chassis cluster
+    fabric statistics (CLI + gRPC). M1: REST test asserts exactly 500.
+    README updated to actual coverage + #3408 for per-zone/policy.
+    RED-on-revert tests added for each new global site.
+  - **File(s)**: pkg/grpcapi/server_show_status.go,
+    pkg/cli/cli_show_flow.go, pkg/grpcapi/server_show_flow.go,
+    pkg/grpcapi/server_show_cluster_text.go, pkg/cli/cli_show_cluster.go,
+    pkg/api/stats_counter_error_test.go,
+    pkg/grpcapi/global_stats_counter_error_test.go,
+    pkg/grpcapi/flow_cluster_counter_error_test.go,
+    pkg/cli/show_security_counter_error_test.go, pkg/api/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22867,3 +22867,18 @@ top.
     pkg/grpcapi/global_stats_counter_error_test.go,
     pkg/grpcapi/flow_cluster_counter_error_test.go,
     pkg/cli/show_security_counter_error_test.go, pkg/api/README.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3345 fold round 3 (Codex re-review) — fix early-warn/late-read
+    ordering. The round-2 warnings were placed BEFORE later detail reads (same
+    bug as the H1 GetGlobalStats fix). Moved the readErr check to AFTER all
+    global-counter reads in: cli showScreen, cli showStatistics, cli
+    showFlowStatistics, gRPC showScreen (per-type drop block). Made
+    showNATSource emit an explicit warning on read error (was silent omit).
+    Audited EVERY global-counter read call site (16 total) — all now check
+    readErr after all reads, none swallow silently. Added late-read RED-on-
+    revert tests (lateCounterErrCLIDP fails only a per-type counter).
+  - **File(s)**: pkg/cli/cli_show_security_screen.go, pkg/cli/cli_show_flow.go,
+    pkg/cli/cli_show_nat.go, pkg/grpcapi/server_show_security_text.go,
+    pkg/cli/show_security_counter_error_test.go,
+    pkg/grpcapi/global_stats_counter_error_test.go, pkg/api/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22833,3 +22833,20 @@ top.
   - **File(s)**: pkg/config/compiler_applications.go,
     pkg/config/compiler_application_destport_names_3340_test.go,
     pkg/config/README.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3345 — surface global/dataplane counter read errors across
+    REST/Prometheus/gRPC/CLI instead of swallowing to 0 (a degraded counter
+    bridge must not look identical to "no events"). REST /stats/global → 500;
+    gRPC GetGlobalStats → codes.Internal; Prometheus omits the failed sample
+    and bumps xpf_counter_read_errors_total; text screen/alarms print a warning.
+    Added RED-on-revert tests for each surface.
+  - **File(s)**: pkg/api/stats.go, pkg/api/metrics.go,
+    pkg/api/metrics_descriptors.go, pkg/api/metrics_counters.go,
+    pkg/api/stats_counter_error_test.go,
+    pkg/api/metrics_descriptor_coverage_test.go,
+    pkg/grpcapi/server_show_status.go,
+    pkg/grpcapi/global_stats_counter_error_test.go,
+    pkg/cli/cli_show_security_screen.go, pkg/cli/cli_show_security_log.go,
+    pkg/cli/show_security_counter_error_test.go,
+    pkg/grpcapi/server_show_security_text.go, pkg/api/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22904,3 +22904,16 @@ top.
     pkg/cli/cli_show_security_zones.go, pkg/cli/cli_show_security_screen.go,
     pkg/cli/cli_show_security_filters.go, pkg/cli/cli_show_nat.go,
     pkg/cli/show_security_counter_error_test.go, pkg/api/README.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3345/#3408 fold round 5 (Codex final) — MAJOR: Prometheus
+    collectFilterCounters must SKIP the xpf_filter_hits_total sample on a
+    filter read error (was bumping counterReadErrors but still emitting a
+    stale 0). Fixed with a termFailed gate (continue before emit; ruleOffset
+    still advances). MINORS: added the 8 missing RED-on-revert tests for the
+    newly-added per-zone/per-policy/filter/flood sites across Prometheus,
+    gRPC text, and CLI text surfaces.
+  - **File(s)**: pkg/api/metrics_counters.go,
+    pkg/api/zones_policies_counter_error_test.go,
+    pkg/grpcapi/text_filter_flood_counter_error_test.go,
+    pkg/cli/show_security_counter_error_test.go, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22882,3 +22882,25 @@ top.
     pkg/cli/cli_show_nat.go, pkg/grpcapi/server_show_security_text.go,
     pkg/cli/show_security_counter_error_test.go,
     pkg/grpcapi/global_stats_counter_error_test.go, pkg/api/README.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3345 fold round 4 (Codex claim-4 scope) — OWN #3408: extend
+    counter-read error surfacing to per-zone / per-policy / screen-flood /
+    filter sites under the SAME contract (REST 500 / gRPC codes.Internal /
+    Prometheus skip+xpf_counter_read_errors_total / CLI+gRPC-text warning
+    after all reads). Covered REST zonesHandler/policiesHandler, gRPC
+    GetZones/GetPolicies, Prometheus collectZone/Policy/Filter, and the
+    text views (policies hit-count/brief/detail, zones, screen-stats-all,
+    firewall filter). Added RED-on-revert tests per surface. PR now Closes
+    #3345 + #3408; README #3408-deferred note dropped.
+  - **File(s)**: pkg/api/security.go, pkg/api/metrics_counters.go,
+    pkg/api/zones_policies_counter_error_test.go,
+    pkg/grpcapi/server_show_zones.go, pkg/grpcapi/server_show_policies_text.go,
+    pkg/grpcapi/server_show_zones_text.go,
+    pkg/grpcapi/server_show_security_text.go,
+    pkg/grpcapi/server_show_firewall.go,
+    pkg/grpcapi/zones_policies_counter_error_test.go,
+    pkg/cli/cli_show_security.go, pkg/cli/cli_show_security_dispatch.go,
+    pkg/cli/cli_show_security_zones.go, pkg/cli/cli_show_security_screen.go,
+    pkg/cli/cli_show_security_filters.go, pkg/cli/cli_show_nat.go,
+    pkg/cli/show_security_counter_error_test.go, pkg/api/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -110,44 +110,49 @@ under the daemon's errgroup. Nothing else imports this package.
   `sessions_iterator_error_test.go` in this package and in `pkg/grpcapi`
   / `pkg/cli` (CLI top-talkers fails the command; NAT summaries print a
   stderr warning).
-- Global dataplane counters get the same observability-integrity
-  treatment (#3345): a failed `ReadGlobalCounter` is no longer swallowed
-  to `0`, because a degraded counter bridge must not be
-  indistinguishable from "no events" on a security appliance. The fix
-  covers EVERY global-counter read surface:
-  - **Structured APIs**: REST `/stats/global` returns HTTP 500 when any
-    global-counter read fails; gRPC `GetGlobalStats` returns
-    `codes.Internal` (the error is checked AFTER the full response struct
-    is built, so a failure on a late read — e.g. `RxPackets`, read after
-    the screen-detail loop — is also covered).
-  - **Prometheus** (`metrics_counters.go`) OMITS the affected per-counter
-    sample (rather than emitting a misleading `0`) and bumps the monotonic
+- Dataplane counter read failures get a uniform observability-integrity
+  treatment (#3345 global; #3408 per-zone / per-policy / screen-flood /
+  filter): a failed counter read is no longer swallowed to `0`, because a
+  degraded counter bridge must not be indistinguishable from "no events"
+  on a security appliance. The fix covers EVERY global, per-zone,
+  per-policy, screen-flood, and filter read surface:
+  - **Structured APIs** return an explicit failure instead of clean-zero
+    counter fields. REST `/stats/global` (global), `/security/zones`
+    (per-zone), and `/security/policies` (per-policy) return HTTP 500 on
+    a read error; gRPC `GetGlobalStats`, `GetZones`, and `GetPolicies`
+    return `codes.Internal`. The error is checked AFTER the full response
+    is built, so a failure on a late read (e.g. `RxPackets` after the
+    screen-detail loop, or any policy/zone in the loop) is covered.
+  - **Prometheus** (`metrics_counters.go`) OMITS the affected sample
+    (rather than emitting a misleading `0`) for global, per-zone,
+    per-policy, and per-filter reads, and bumps the monotonic
     `xpf_counter_read_errors_total` scrape-error counter, always emitted
     (0 when healthy) for alerting.
   - **Text commands** print a `warning: ... counter read failed ...` line
     instead of a clean zero: `show security screen` / `show security
-    alarms` (CLI + gRPC), `show security flow statistics` — the canonical
-    operator global-counter view (CLI `showStatistics`/`showFlowStatistics`
-    + gRPC `showFlowStatistics`), `show chassis cluster fabric
-    statistics` (CLI + gRPC fabric-redirect counters), and `show security
-    nat source` (NAT alloc-fail counter — previously the line was silently
-    omitted on a read error, now an explicit warning is emitted).
+    alarms` / `show security flow statistics` / `show chassis cluster
+    fabric statistics` / `show security nat source` (global + flood), and
+    `show security policies hit-count` + brief (per-policy), `show
+    security zones` (per-zone), `show security screen statistics` (flood),
+    and `show firewall filter` (filter) — across both the CLI and the gRPC
+    text mirrors.
   - **Ordering invariant**: in every multi-read renderer the `readErr`
-    check runs AFTER all global-counter reads in the function (incl. the
-    detail / per-type screen-breakdown loops), so a failure on a LATE read
-    is surfaced rather than printing a stale `0` under an earlier passed
-    check. The structured APIs follow the same rule (check after the full
-    struct build).
+    check runs AFTER all counter reads in the function (incl. the detail /
+    per-type screen-breakdown and per-policy/per-zone loops), so a failure
+    on a LATE read is surfaced rather than printing a stale `0` under an
+    earlier passed check. The structured APIs follow the same rule (check
+    after the full response is built).
+  - **Out of scope**: per-interface and NAT-rule/port counters are not
+    security counters and keep their existing per-read handling.
 
-  Pinned by `stats_counter_error_test.go` (REST + Prometheus),
+  Pinned by `stats_counter_error_test.go` +
+  `zones_policies_counter_error_test.go` (REST + Prometheus),
   `pkg/grpcapi/global_stats_counter_error_test.go` (incl. the late-read
-  ordering case), `pkg/grpcapi/flow_cluster_counter_error_test.go`, and
+  ordering case) + `flow_cluster_counter_error_test.go` +
+  `zones_policies_counter_error_test.go`, and
   `pkg/cli/show_security_counter_error_test.go` (incl. late-read ordering
   cases that fail if a warn is moved before the per-type screen-breakdown
-  loop). Per-zone / per-policy /
-  per-filter counter-read surfacing (the `collectZoneCounters` /
-  `collectPolicyCounters` / `collectFilterCounters` paths that today
-  `continue` on error) is tracked separately in #3408.
+  loop). This resolves both #3345 and #3408.
 - Named source-NAT pool stats are sourced from the userspace helper's
   LIVE runtime status, not config text (#2938). `natPoolStatsHandler`
   (`/security/nat/source/pools`) reads `s.runtimeSourceNATPools()` — the

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -113,18 +113,31 @@ under the daemon's errgroup. Nothing else imports this package.
 - Global dataplane counters get the same observability-integrity
   treatment (#3345): a failed `ReadGlobalCounter` is no longer swallowed
   to `0`, because a degraded counter bridge must not be
-  indistinguishable from "no events" on a security appliance. REST
-  `/stats/global` returns HTTP 500 when any global-counter read fails;
-  gRPC `GetGlobalStats` returns `codes.Internal`. The Prometheus
-  collector (`metrics_counters.go`) OMITS the affected per-counter
-  sample (rather than emitting a misleading `0`) and bumps the monotonic
-  `xpf_counter_read_errors_total` scrape-error counter, which is always
-  emitted (0 when healthy) for alerting. The text CLI / gRPC `show
-  security screen` and `show security alarms` commands print a
-  `warning: screen counter read failed ...` line instead of a clean
-  `Total screen drops: 0`. Pinned by `stats_counter_error_test.go`
-  (REST + Prometheus), `pkg/grpcapi/global_stats_counter_error_test.go`,
-  and `pkg/cli/show_security_counter_error_test.go`.
+  indistinguishable from "no events" on a security appliance. The fix
+  covers EVERY global-counter read surface:
+  - **Structured APIs**: REST `/stats/global` returns HTTP 500 when any
+    global-counter read fails; gRPC `GetGlobalStats` returns
+    `codes.Internal` (the error is checked AFTER the full response struct
+    is built, so a failure on a late read — e.g. `RxPackets`, read after
+    the screen-detail loop — is also covered).
+  - **Prometheus** (`metrics_counters.go`) OMITS the affected per-counter
+    sample (rather than emitting a misleading `0`) and bumps the monotonic
+    `xpf_counter_read_errors_total` scrape-error counter, always emitted
+    (0 when healthy) for alerting.
+  - **Text commands** print a `warning: ... counter read failed ...` line
+    instead of a clean zero: `show security screen` / `show security
+    alarms` (CLI + gRPC), `show security flow statistics` — the canonical
+    operator global-counter view (CLI `showStatistics`/`showFlowStatistics`
+    + gRPC `showFlowStatistics`), and `show chassis cluster fabric
+    statistics` (CLI + gRPC fabric-redirect counters).
+
+  Pinned by `stats_counter_error_test.go` (REST + Prometheus),
+  `pkg/grpcapi/global_stats_counter_error_test.go` (incl. the late-read
+  ordering case), `pkg/grpcapi/flow_cluster_counter_error_test.go`, and
+  `pkg/cli/show_security_counter_error_test.go`. Per-zone / per-policy /
+  per-filter counter-read surfacing (the `collectZoneCounters` /
+  `collectPolicyCounters` / `collectFilterCounters` paths that today
+  `continue` on error) is tracked separately in #3408.
 - Named source-NAT pool stats are sourced from the userspace helper's
   LIVE runtime status, not config text (#2938). `natPoolStatsHandler`
   (`/security/nat/source/pools`) reads `s.runtimeSourceNATPools()` — the

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -128,13 +128,23 @@ under the daemon's errgroup. Nothing else imports this package.
     instead of a clean zero: `show security screen` / `show security
     alarms` (CLI + gRPC), `show security flow statistics` — the canonical
     operator global-counter view (CLI `showStatistics`/`showFlowStatistics`
-    + gRPC `showFlowStatistics`), and `show chassis cluster fabric
-    statistics` (CLI + gRPC fabric-redirect counters).
+    + gRPC `showFlowStatistics`), `show chassis cluster fabric
+    statistics` (CLI + gRPC fabric-redirect counters), and `show security
+    nat source` (NAT alloc-fail counter — previously the line was silently
+    omitted on a read error, now an explicit warning is emitted).
+  - **Ordering invariant**: in every multi-read renderer the `readErr`
+    check runs AFTER all global-counter reads in the function (incl. the
+    detail / per-type screen-breakdown loops), so a failure on a LATE read
+    is surfaced rather than printing a stale `0` under an earlier passed
+    check. The structured APIs follow the same rule (check after the full
+    struct build).
 
   Pinned by `stats_counter_error_test.go` (REST + Prometheus),
   `pkg/grpcapi/global_stats_counter_error_test.go` (incl. the late-read
   ordering case), `pkg/grpcapi/flow_cluster_counter_error_test.go`, and
-  `pkg/cli/show_security_counter_error_test.go`. Per-zone / per-policy /
+  `pkg/cli/show_security_counter_error_test.go` (incl. late-read ordering
+  cases that fail if a warn is moved before the per-type screen-breakdown
+  loop). Per-zone / per-policy /
   per-filter counter-read surfacing (the `collectZoneCounters` /
   `collectPolicyCounters` / `collectFilterCounters` paths that today
   `continue` on error) is tracked separately in #3408.

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -110,6 +110,21 @@ under the daemon's errgroup. Nothing else imports this package.
   `sessions_iterator_error_test.go` in this package and in `pkg/grpcapi`
   / `pkg/cli` (CLI top-talkers fails the command; NAT summaries print a
   stderr warning).
+- Global dataplane counters get the same observability-integrity
+  treatment (#3345): a failed `ReadGlobalCounter` is no longer swallowed
+  to `0`, because a degraded counter bridge must not be
+  indistinguishable from "no events" on a security appliance. REST
+  `/stats/global` returns HTTP 500 when any global-counter read fails;
+  gRPC `GetGlobalStats` returns `codes.Internal`. The Prometheus
+  collector (`metrics_counters.go`) OMITS the affected per-counter
+  sample (rather than emitting a misleading `0`) and bumps the monotonic
+  `xpf_counter_read_errors_total` scrape-error counter, which is always
+  emitted (0 when healthy) for alerting. The text CLI / gRPC `show
+  security screen` and `show security alarms` commands print a
+  `warning: screen counter read failed ...` line instead of a clean
+  `Total screen drops: 0`. Pinned by `stats_counter_error_test.go`
+  (REST + Prometheus), `pkg/grpcapi/global_stats_counter_error_test.go`,
+  and `pkg/cli/show_security_counter_error_test.go`.
 - Named source-NAT pool stats are sourced from the userspace helper's
   LIVE runtime status, not config text (#2938). `natPoolStatsHandler`
   (`/security/nat/source/pools`) reads `s.runtimeSourceNATPools()` — the

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -3,6 +3,7 @@ package api
 import (
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,6 +30,14 @@ type xpfCollector struct {
 	tcEgressPacketsTotal *prometheus.Desc
 	syncookieTotal       *prometheus.Desc
 	flowCacheTotal       *prometheus.Desc
+
+	// #3345: monotonic count of global-counter map reads that failed during
+	// a scrape. A failed read SKIPS emitting that counter's sample (so a
+	// degraded counter bridge does NOT report a misleading 0); this metric
+	// is the scrape-error signal an operator alerts on. Persisted on the
+	// collector so it accumulates across scrapes like a real counter.
+	counterReadErrorsTotal *prometheus.Desc
+	counterReadErrors      atomic.Uint64
 
 	// Interface counters
 	ifacePacketsTotal *prometheus.Desc
@@ -470,6 +479,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.tcEgressPacketsTotal
 	ch <- c.syncookieTotal
 	ch <- c.flowCacheTotal
+	ch <- c.counterReadErrorsTotal
 	ch <- c.ifacePacketsTotal
 	ch <- c.ifaceBytesTotal
 	ch <- c.zonePacketsTotal

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -11,53 +11,47 @@ import (
 )
 
 func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
-	readCounter := func(idx uint32) float64 {
-		v, _ := dp.ReadGlobalCounter(idx)
-		return float64(v)
+	// #3345: on a counter-read failure, SKIP emitting the sample instead of
+	// reporting a misleading 0, and bump xpf_counter_read_errors_total. A
+	// missing sample is distinguishable from a 0 sample; a clean zero would
+	// make a degraded counter bridge indistinguishable from "no events".
+	emit := func(desc *prometheus.Desc, idx uint32, labels ...string) {
+		v, err := dp.ReadGlobalCounter(idx)
+		if err != nil {
+			c.counterReadErrors.Add(1)
+			return
+		}
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, float64(v), labels...)
 	}
 
-	ch <- prometheus.MustNewConstMetric(c.packetsTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrRxPackets), "rx")
-	ch <- prometheus.MustNewConstMetric(c.packetsTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrTxPackets), "tx")
-	ch <- prometheus.MustNewConstMetric(c.dropsTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrDrops))
-	ch <- prometheus.MustNewConstMetric(c.sessionsCreatedTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrSessionsNew))
-	ch <- prometheus.MustNewConstMetric(c.sessionsClosedTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrSessionsClosed))
-	ch <- prometheus.MustNewConstMetric(c.screenDropsTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrScreenDrops))
-	ch <- prometheus.MustNewConstMetric(c.policyDeniesTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrPolicyDeny))
-	ch <- prometheus.MustNewConstMetric(c.natAllocFailsTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrNATAllocFail))
-	ch <- prometheus.MustNewConstMetric(c.nat64XlateTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrNAT64Xlate))
-	ch <- prometheus.MustNewConstMetric(c.hostInboundDeny, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrHostInboundDeny))
-	ch <- prometheus.MustNewConstMetric(c.tcEgressPacketsTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrTCEgressPackets))
+	emit(c.packetsTotal, dataplane.GlobalCtrRxPackets, "rx")
+	emit(c.packetsTotal, dataplane.GlobalCtrTxPackets, "tx")
+	emit(c.dropsTotal, dataplane.GlobalCtrDrops)
+	emit(c.sessionsCreatedTotal, dataplane.GlobalCtrSessionsNew)
+	emit(c.sessionsClosedTotal, dataplane.GlobalCtrSessionsClosed)
+	emit(c.screenDropsTotal, dataplane.GlobalCtrScreenDrops)
+	emit(c.policyDeniesTotal, dataplane.GlobalCtrPolicyDeny)
+	emit(c.natAllocFailsTotal, dataplane.GlobalCtrNATAllocFail)
+	emit(c.nat64XlateTotal, dataplane.GlobalCtrNAT64Xlate)
+	emit(c.hostInboundDeny, dataplane.GlobalCtrHostInboundDeny)
+	emit(c.tcEgressPacketsTotal, dataplane.GlobalCtrTCEgressPackets)
 
 	// SYN cookie counters
-	ch <- prometheus.MustNewConstMetric(c.syncookieTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrSyncookieSent), "sent")
-	ch <- prometheus.MustNewConstMetric(c.syncookieTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrSyncookieValid), "valid")
-	ch <- prometheus.MustNewConstMetric(c.syncookieTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrSyncookieInvalid), "invalid")
-	ch <- prometheus.MustNewConstMetric(c.syncookieTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrSyncookieBypass), "bypass")
+	emit(c.syncookieTotal, dataplane.GlobalCtrSyncookieSent, "sent")
+	emit(c.syncookieTotal, dataplane.GlobalCtrSyncookieValid, "valid")
+	emit(c.syncookieTotal, dataplane.GlobalCtrSyncookieInvalid, "invalid")
+	emit(c.syncookieTotal, dataplane.GlobalCtrSyncookieBypass, "bypass")
 
 	// Flow cache counters (IPv4 + IPv6)
-	ch <- prometheus.MustNewConstMetric(c.flowCacheTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrFlowCacheHit), "hit")
-	ch <- prometheus.MustNewConstMetric(c.flowCacheTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrFlowCacheMiss), "miss")
-	ch <- prometheus.MustNewConstMetric(c.flowCacheTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrFlowCacheFlush), "flush")
-	ch <- prometheus.MustNewConstMetric(c.flowCacheTotal, prometheus.CounterValue,
-		readCounter(dataplane.GlobalCtrFlowCacheInvalidate), "invalidate")
+	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheHit, "hit")
+	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheMiss, "miss")
+	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheFlush, "flush")
+	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheInvalidate, "invalidate")
+
+	// #3345: always emit the scrape-error counter (0 when healthy) so the
+	// signal is present for alerting whether or not any read failed.
+	ch <- prometheus.MustNewConstMetric(c.counterReadErrorsTotal, prometheus.CounterValue,
+		float64(c.counterReadErrors.Load()))
 }
 
 func (c *xpfCollector) collectInterfaceCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -228,16 +228,25 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 				}
 				numRules := uint32(nSrc * nDst)
 				var totalPkts uint64
+				termFailed := false
 				for i := uint32(0); i < numRules; i++ {
 					if ctrs, err := dp.ReadFilterCounters(ruleOffset + i); err == nil {
 						totalPkts += ctrs.Packets
 					} else {
 						c.counterReadErrors.Add(1)
+						termFailed = true
 					}
+				}
+				// Advance the offset regardless so later terms stay aligned.
+				ruleOffset += numRules
+				// #3408: on a read failure SKIP this term's sample (a missing
+				// sample, not a stale/partial 0) — matching the zone/policy
+				// collectors — and rely on the bumped counterReadErrors signal.
+				if termFailed {
+					continue
 				}
 				ch <- prometheus.MustNewConstMetric(c.filterHitsTotal, prometheus.CounterValue,
 					float64(totalPkts), name, family, term.Name)
-				ruleOffset += numRules
 			}
 		}
 	}

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -92,12 +92,17 @@ func (c *xpfCollector) collectZoneCounters(ch chan<- prometheus.Metric, dp apiRu
 	}
 
 	for zoneName, zoneID := range cr.ZoneIDs {
+		// #3408: a failed per-zone read SKIPS the sample (no misleading 0) and
+		// bumps xpf_counter_read_errors_total — the same contract as the
+		// global counters (#3345).
 		ingress, err := dp.ReadZoneCounters(zoneID, 0)
 		if err != nil {
+			c.counterReadErrors.Add(1)
 			continue
 		}
 		egress, err := dp.ReadZoneCounters(zoneID, 1)
 		if err != nil {
+			c.counterReadErrors.Add(1)
 			continue
 		}
 		ch <- prometheus.MustNewConstMetric(c.zonePacketsTotal, prometheus.CounterValue,
@@ -142,6 +147,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 			policyID := policyCounterID(policySetID, i)
 			ctrs, err := dp.ReadPolicyCounters(policyID)
 			if err != nil {
+				c.counterReadErrors.Add(1)
 				continue
 			}
 			ch <- prometheus.MustNewConstMetric(c.policyHitsTotal, prometheus.CounterValue,
@@ -160,6 +166,7 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 		policyID := policyCounterID(policySetID, i)
 		ctrs, err := dp.ReadPolicyCounters(policyID)
 		if err != nil {
+			c.counterReadErrors.Add(1)
 			continue
 		}
 		// #3286: a scoped global policy (#3148 `match from-zone`/`to-zone`)
@@ -206,6 +213,7 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 			}
 			fcfg, err := dp.ReadFilterConfig(fid)
 			if err != nil {
+				c.counterReadErrors.Add(1)
 				continue
 			}
 			ruleOffset := fcfg.RuleStart
@@ -223,6 +231,8 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 				for i := uint32(0); i < numRules; i++ {
 					if ctrs, err := dp.ReadFilterCounters(ruleOffset + i); err == nil {
 						totalPkts += ctrs.Packets
+					} else {
+						c.counterReadErrors.Add(1)
 					}
 				}
 				ch <- prometheus.MustNewConstMetric(c.filterHitsTotal, prometheus.CounterValue,

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -64,6 +64,14 @@ func (d *descriptorCoverageDP) LastApplyResult() *dataplane.ApplyResult {
 	return d.apply
 }
 
+// #3345: collectGlobalCounters now SKIPS emitting a counter sample when the
+// read fails (so a degraded bridge is not reported as a clean 0). dataplane.New()
+// answers ReadGlobalCounter with a map-missing error, which would drop the
+// global-counter descriptor families out of coverage — override it to succeed.
+func (d *descriptorCoverageDP) ReadGlobalCounter(uint32) (uint64, error) {
+	return 0, nil
+}
+
 func (d *descriptorCoverageDP) ReadInterfaceCounters(int) (dataplane.InterfaceCounterValue, error) {
 	return dataplane.InterfaceCounterValue{}, nil
 }

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -21,6 +21,15 @@ func newCollector(srv *Server) *xpfCollector {
 			"Total packets dropped.",
 			nil, nil,
 		),
+		// #3345: scrape-error signal for global-counter map reads. A failed
+		// read omits the affected counter sample instead of emitting a
+		// misleading 0, and bumps this monotonic counter so a degraded
+		// counter bridge is alertable rather than silently reported as zero.
+		counterReadErrorsTotal: prometheus.NewDesc(
+			"xpf_counter_read_errors_total",
+			"Total global-counter map read failures during metric scrapes.",
+			nil, nil,
+		),
 		sessionsCreatedTotal: prometheus.NewDesc(
 			"xpf_sessions_created_total",
 			"Total sessions created.",

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -22,6 +22,10 @@ func (s *Server) zonesHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	cr := s.applyResult()
+	// #3408: a per-zone counter read failure must not be reported as a clean
+	// 0 — surface it as HTTP 500 after building, mirroring the global
+	// /stats/global contract (#3345).
+	var readErr error
 	var zones []ZoneInfo
 	for zoneName, zone := range cfg.Security.Zones {
 		zi := ZoneInfo{
@@ -52,15 +56,24 @@ func (s *Server) zonesHandler(w http.ResponseWriter, _ *http.Request) {
 					if ing, err := s.dp.ReadZoneCounters(id, 0); err == nil {
 						zi.IngressPackets = ing.Packets
 						zi.IngressBytes = ing.Bytes
+					} else if readErr == nil {
+						readErr = err
 					}
 					if eg, err := s.dp.ReadZoneCounters(id, 1); err == nil {
 						zi.EgressPackets = eg.Packets
 						zi.EgressBytes = eg.Bytes
+					} else if readErr == nil {
+						readErr = err
 					}
 				}
 			}
 		}
 		zones = append(zones, zi)
+	}
+	if readErr != nil {
+		writeError(w, http.StatusInternalServerError,
+			"zone counter read failed: "+readErr.Error())
+		return
 	}
 	sort.Slice(zones, func(i, j int) bool { return zones[i].Name < zones[j].Name })
 	writeOK(w, zones)
@@ -79,6 +92,9 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 	// collector and the CLI/gRPC display surfaces. When the knob is off,
 	// hit_packets/hit_bytes stay 0 (we skip the dataplane read).
 	statsEnabled := cfg.Security.PolicyStatsEnabled
+	// #3408: surface a per-policy counter read failure as HTTP 500 after
+	// building, rather than reporting clean-zero hit counts.
+	var readErr error
 	var policySetID uint32
 	var result []PolicyInfo
 	for _, zpp := range cfg.Security.Policies {
@@ -111,6 +127,8 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			pi.Rules = append(pi.Rules, pr)
@@ -168,6 +186,8 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			pi.Rules = append(pi.Rules, pr)
@@ -178,6 +198,11 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 		result = append(result, pi)
 	}
 
+	if readErr != nil {
+		writeError(w, http.StatusInternalServerError,
+			"policy counter read failed: "+readErr.Error())
+		return
+	}
 	writeOK(w, result)
 }
 

--- a/pkg/api/stats.go
+++ b/pkg/api/stats.go
@@ -14,8 +14,16 @@ func (s *Server) globalStatsHandler(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
+	// #3345: surface a global-counter read failure instead of silently
+	// reporting 0. A degraded userspace shim / counter bridge must not be
+	// indistinguishable from "no events" — for a security appliance,
+	// "counter unavailable" and "zero attacks" cannot look identical.
+	var readErr error
 	readCounter := func(idx uint32) uint64 {
-		v, _ := s.dp.ReadGlobalCounter(idx)
+		v, err := s.dp.ReadGlobalCounter(idx)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
 		return v
 	}
 
@@ -36,6 +44,11 @@ func (s *Server) globalStatsHandler(w http.ResponseWriter, _ *http.Request) {
 		FlowCacheMisses:      readCounter(dataplane.GlobalCtrFlowCacheMiss),
 		FlowCacheFlushes:     readCounter(dataplane.GlobalCtrFlowCacheFlush),
 		FlowCacheInvalidates: readCounter(dataplane.GlobalCtrFlowCacheInvalidate),
+	}
+	if readErr != nil {
+		writeError(w, http.StatusInternalServerError,
+			"global counter read failed: "+readErr.Error())
+		return
 	}
 	writeOK(w, stats)
 }

--- a/pkg/api/stats_counter_error_test.go
+++ b/pkg/api/stats_counter_error_test.go
@@ -1,0 +1,86 @@
+// #3345: a global-counter read failure must be surfaced, not reported as a
+// clean 0. REST returns 500; the Prometheus collector SKIPS the affected
+// sample (rather than emitting 0) and bumps xpf_counter_read_errors_total.
+//
+// FAIL-ON-REVERT: restoring `v, _ := dp.ReadGlobalCounter(idx)` in
+// globalStatsHandler / collectGlobalCounters makes REST return 200 with a
+// zero body and Prometheus emit the per-counter families as 0 with the error
+// total stuck at 0 — both want-assertions below go RED.
+package api
+
+import (
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// counterErrAPIDP is a loaded apiRuntimeDataPlane whose global-counter reads
+// always fail, modeling a degraded counter bridge / userspace shim.
+type counterErrAPIDP struct {
+	*dataplane.Manager
+}
+
+func (d *counterErrAPIDP) IsLoaded() bool { return true }
+
+func (d *counterErrAPIDP) ReadGlobalCounter(uint32) (uint64, error) {
+	return 0, errors.New("counter bridge degraded")
+}
+
+func TestGlobalStatsHandlerSurfacesReadError(t *testing.T) {
+	s := &Server{dp: &counterErrAPIDP{Manager: dataplane.New()}}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/stats/global", nil)
+	s.globalStatsHandler(rr, req)
+
+	if rr.Code == 200 {
+		t.Fatalf("globalStatsHandler returned 200 on counter read failure; "+
+			"want a non-200 (read error must not look like a clean zero). body=%s",
+			rr.Body.String())
+	}
+}
+
+func TestCollectGlobalCountersSkipsAndCountsReadErrors(t *testing.T) {
+	c := newCollector(&Server{})
+	dp := &counterErrAPIDP{Manager: dataplane.New()}
+
+	ch := make(chan prometheus.Metric, 64)
+	c.collectGlobalCounters(ch, dp)
+	close(ch)
+
+	var perCounterEmitted int
+	var errTotal float64
+	var sawErrTotal bool
+	for m := range ch {
+		desc := m.Desc().String()
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric write: %v", err)
+		}
+		if strings.Contains(desc, "xpf_counter_read_errors_total") {
+			sawErrTotal = true
+			errTotal = pb.GetCounter().GetValue()
+			continue
+		}
+		// Any non-error per-counter sample emitted on an all-failing DP would
+		// be a misleading 0 — that is exactly the bug.
+		perCounterEmitted++
+	}
+
+	if perCounterEmitted != 0 {
+		t.Errorf("collectGlobalCounters emitted %d per-counter samples on an "+
+			"all-failing DP; want 0 (must not report 0 on read error)", perCounterEmitted)
+	}
+	if !sawErrTotal {
+		t.Fatal("xpf_counter_read_errors_total was not emitted")
+	}
+	if errTotal <= 0 {
+		t.Errorf("xpf_counter_read_errors_total = %v, want > 0", errTotal)
+	}
+}

--- a/pkg/api/stats_counter_error_test.go
+++ b/pkg/api/stats_counter_error_test.go
@@ -10,6 +10,7 @@ package api
 
 import (
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -39,10 +40,12 @@ func TestGlobalStatsHandlerSurfacesReadError(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/v1/stats/global", nil)
 	s.globalStatsHandler(rr, req)
 
-	if rr.Code == 200 {
-		t.Fatalf("globalStatsHandler returned 200 on counter read failure; "+
-			"want a non-200 (read error must not look like a clean zero). body=%s",
-			rr.Body.String())
+	// Assert exactly 500 so a future regression to 200/400/503 is caught
+	// (a read error must surface as an internal failure, not a clean zero).
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("globalStatsHandler status = %d, want %d (read error must not "+
+			"look like a clean zero). body=%s",
+			rr.Code, http.StatusInternalServerError, rr.Body.String())
 	}
 }
 

--- a/pkg/api/zones_policies_counter_error_test.go
+++ b/pkg/api/zones_policies_counter_error_test.go
@@ -97,6 +97,75 @@ func TestCollectPolicyCountersCountsReadErrors(t *testing.T) {
 	}
 }
 
+// filterErrAPIDP fails the filter reads. cfgErr selects whether the
+// ReadFilterConfig (gate) or ReadFilterCounters (per-term) read fails.
+type filterErrAPIDP struct {
+	*dataplane.Manager
+	apply  *dataplane.ApplyResult
+	cfgErr bool
+}
+
+func (d *filterErrAPIDP) IsLoaded() bool                          { return true }
+func (d *filterErrAPIDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *filterErrAPIDP) ReadFilterConfig(uint32) (dataplane.FilterConfig, error) {
+	if d.cfgErr {
+		return dataplane.FilterConfig{}, errors.New("counter bridge degraded")
+	}
+	return dataplane.FilterConfig{RuleStart: 0}, nil
+}
+func (d *filterErrAPIDP) ReadFilterCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+func filterApplyResult() *dataplane.ApplyResult {
+	return &dataplane.ApplyResult{FilterIDs: map[string]uint32{"inet:fin": 0, "inet6:fin6": 100}}
+}
+
+func countFilterSamples(t *testing.T, c *xpfCollector, dp apiRuntimeDataPlane) int {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	c.collectFilterCounters(ch, dp)
+	close(ch)
+	var n int
+	for m := range ch {
+		if strings.Contains(m.Desc().String(), "xpf_filter_hits_total") {
+			n++
+		}
+	}
+	return n
+}
+
+// MAJOR pin: on a ReadFilterCounters failure the collector must SKIP the
+// xpf_filter_hits_total sample (a missing sample, not a stale 0) AND bump
+// counterReadErrors — matching the zone/policy collectors.
+// FAIL-ON-REVERT: dropping the `if termFailed { continue }` makes the sample
+// emit and `emitted != 0` goes RED.
+func TestCollectFilterCountersSkipsSampleOnCounterReadError(t *testing.T) {
+	c := newCollector(&Server{store: newDescriptorCoverageStore(t)})
+	dp := &filterErrAPIDP{Manager: dataplane.New(), apply: filterApplyResult()}
+
+	emitted := countFilterSamples(t, c, dp)
+	if emitted != 0 {
+		t.Errorf("collectFilterCounters emitted %d filter samples on ReadFilterCounters failure; want 0 (skip on error)", emitted)
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("counterReadErrors not bumped on a filter counter read failure")
+	}
+}
+
+func TestCollectFilterCountersSkipsSampleOnConfigReadError(t *testing.T) {
+	c := newCollector(&Server{store: newDescriptorCoverageStore(t)})
+	dp := &filterErrAPIDP{Manager: dataplane.New(), apply: filterApplyResult(), cfgErr: true}
+
+	emitted := countFilterSamples(t, c, dp)
+	if emitted != 0 {
+		t.Errorf("collectFilterCounters emitted %d filter samples on ReadFilterConfig failure; want 0", emitted)
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("counterReadErrors not bumped on a filter config read failure")
+	}
+}
+
 func TestCollectZoneCountersCountsReadErrors(t *testing.T) {
 	srv := &Server{store: newDescriptorCoverageStore(t)}
 	c := newCollector(srv)

--- a/pkg/api/zones_policies_counter_error_test.go
+++ b/pkg/api/zones_policies_counter_error_test.go
@@ -1,0 +1,124 @@
+// #3408: per-zone / per-policy counter read failures must be surfaced, not
+// reported as clean zeros — the same contract as the global counters (#3345).
+// REST returns HTTP 500; the Prometheus collector SKIPS the affected sample
+// and bumps xpf_counter_read_errors_total.
+//
+// FAIL-ON-REVERT: restoring the `err == nil` swallow (dropping the readErr
+// capture / the counterReadErrors bump) makes REST return 200 with clean-zero
+// counts and the collector emit policy samples without an error count — the
+// want-assertions below go RED.
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// policyZoneErrAPIDP is a loaded apiRuntimeDataPlane whose per-zone and
+// per-policy counter reads fail. It supplies a LastApplyResult so the zone
+// handler reaches the read (zone IDs must resolve).
+type policyZoneErrAPIDP struct {
+	*dataplane.Manager
+	apply *dataplane.ApplyResult
+}
+
+func (d *policyZoneErrAPIDP) IsLoaded() bool { return true }
+
+func (d *policyZoneErrAPIDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+
+func (d *policyZoneErrAPIDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+func (d *policyZoneErrAPIDP) ReadZoneCounters(uint16, int) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+func TestPoliciesHandlerSurfacesReadError(t *testing.T) {
+	s := &Server{
+		store: newDescriptorCoverageStore(t),
+		dp:    &policyZoneErrAPIDP{Manager: dataplane.New()},
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("policiesHandler status = %d, want %d on policy counter read failure. body=%s",
+			rr.Code, http.StatusInternalServerError, rr.Body.String())
+	}
+}
+
+func TestZonesHandlerSurfacesReadError(t *testing.T) {
+	s := &Server{
+		store: newDescriptorCoverageStore(t),
+		dp: &policyZoneErrAPIDP{
+			Manager: dataplane.New(),
+			apply:   &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2}},
+		},
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/zones", nil)
+	s.zonesHandler(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("zonesHandler status = %d, want %d on zone counter read failure. body=%s",
+			rr.Code, http.StatusInternalServerError, rr.Body.String())
+	}
+}
+
+func TestCollectPolicyCountersCountsReadErrors(t *testing.T) {
+	srv := &Server{store: newDescriptorCoverageStore(t)}
+	c := newCollector(srv)
+	dp := &policyZoneErrAPIDP{Manager: dataplane.New()}
+
+	ch := make(chan prometheus.Metric, 64)
+	c.collectPolicyCounters(ch, dp)
+	close(ch)
+
+	var policyEmitted int
+	for m := range ch {
+		if strings.Contains(m.Desc().String(), "xpf_policy_hits_total") {
+			policyEmitted++
+		}
+	}
+	if policyEmitted != 0 {
+		t.Errorf("collectPolicyCounters emitted %d policy samples on an all-failing DP; want 0", policyEmitted)
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("counterReadErrors not bumped on a per-policy read failure")
+	}
+}
+
+func TestCollectZoneCountersCountsReadErrors(t *testing.T) {
+	srv := &Server{store: newDescriptorCoverageStore(t)}
+	c := newCollector(srv)
+	dp := &policyZoneErrAPIDP{
+		Manager: dataplane.New(),
+		apply:   &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2}},
+	}
+
+	ch := make(chan prometheus.Metric, 64)
+	c.collectZoneCounters(ch, dp)
+	close(ch)
+
+	var zoneEmitted int
+	for m := range ch {
+		if strings.Contains(m.Desc().String(), "xpf_zone_") {
+			zoneEmitted++
+		}
+	}
+	if zoneEmitted != 0 {
+		t.Errorf("collectZoneCounters emitted %d zone samples on an all-failing DP; want 0", zoneEmitted)
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("counterReadErrors not bumped on a per-zone read failure")
+	}
+}

--- a/pkg/cli/cli_show_cluster.go
+++ b/pkg/cli/cli_show_cluster.go
@@ -28,14 +28,20 @@ type fabricRedirectCounters struct {
 }
 
 // readFabricRedirectCounters samples the dataplane fabric counters.
-// Returns (zeroed, false) when the dataplane is not loaded.
-func (c *CLI) readFabricRedirectCounters() (fabricRedirectCounters, bool) {
+// Returns (zeroed, false, nil) when the dataplane is not loaded. The third
+// value is the first global-counter read error (#3345) so the caller can
+// surface a degraded counter bridge instead of presenting clean zeros.
+func (c *CLI) readFabricRedirectCounters() (fabricRedirectCounters, bool, error) {
 	if !c.dataplaneLoaded() {
-		return fabricRedirectCounters{}, false
+		return fabricRedirectCounters{}, false, nil
 	}
 	telemetry := dataplane.TelemetryOf(c.dp)
+	var readErr error
 	read := func(index uint32) uint64 {
-		v, _ := telemetry.GlobalCounter(index)
+		v, err := telemetry.GlobalCounter(index)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
 		return v
 	}
 	return fabricRedirectCounters{
@@ -44,7 +50,7 @@ func (c *CLI) readFabricRedirectCounters() (fabricRedirectCounters, bool) {
 		fab1:  read(dataplane.GlobalCtrFabricRedirectFab1),
 		zone:  read(dataplane.GlobalCtrFabricRedirectZone),
 		drops: read(dataplane.GlobalCtrFabricFwdDrop),
-	}, true
+	}, true, readErr
 }
 
 // showChassis shows hardware information (like Junos "show chassis hardware").
@@ -281,13 +287,16 @@ func (c *CLI) showChassisClusterStatistics() error {
 }
 
 func (c *CLI) showChassisClusterFabricStatistics() error {
-	counters, ok := c.readFabricRedirectCounters()
+	counters, ok, readErr := c.readFabricRedirectCounters()
 	if !ok {
 		fmt.Println("Dataplane not loaded")
 		return nil
 	}
 
 	fmt.Println("Fabric redirect statistics:")
+	if readErr != nil {
+		fmt.Printf("warning: fabric counter read failed (statistics may be incomplete): %v\n", readErr)
+	}
 	fmt.Printf("    Total redirects:          %d\n", counters.total)
 	fmt.Printf("    fab0 redirects:           %d\n", counters.fab0)
 	fmt.Printf("    fab1 redirects:           %d\n", counters.fab1)

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -95,8 +95,15 @@ func (c *CLI) showStatistics(detail bool) error {
 		return nil
 	}
 
+	// #3345: surface a counter-read failure rather than printing clean zeros
+	// that hide a degraded counter bridge. This is the canonical operator
+	// global-counter view (`show security flow statistics`).
+	var readErr error
 	readCounter := func(idx uint32) uint64 {
-		v, _ := c.dp.ReadGlobalCounter(idx)
+		v, err := c.dp.ReadGlobalCounter(idx)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
 		return v
 	}
 
@@ -121,6 +128,9 @@ func (c *CLI) showStatistics(detail bool) error {
 	fmt.Println("Global statistics:")
 	for _, n := range names {
 		fmt.Printf("  %-25s %d\n", n.name+":", readCounter(n.idx))
+	}
+	if readErr != nil {
+		fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
 	}
 
 	if !detail {
@@ -933,8 +943,14 @@ func (c *CLI) showFlowStatistics() error {
 		return nil
 	}
 
+	// #3345: surface a counter-read failure rather than printing clean zeros
+	// that hide a degraded counter bridge.
+	var readErr error
 	readCounter := func(idx uint32) uint64 {
-		v, _ := c.dp.ReadGlobalCounter(idx)
+		v, err := c.dp.ReadGlobalCounter(idx)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
 		return v
 	}
 
@@ -957,6 +973,9 @@ func (c *CLI) showFlowStatistics() error {
 	cacheInval := readCounter(dataplane.GlobalCtrFlowCacheInvalidate)
 
 	fmt.Println("Flow statistics:")
+	if readErr != nil {
+		fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
+	}
 	fmt.Printf("  %-30s %d\n", "Current sessions:", dataplane.CurrentSessions(sessNew, sessClosed))
 	fmt.Printf("  %-30s %d\n", "Sessions created:", sessNew)
 	fmt.Printf("  %-30s %d\n", "Sessions closed:", sessClosed)

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -129,11 +129,13 @@ func (c *CLI) showStatistics(detail bool) error {
 	for _, n := range names {
 		fmt.Printf("  %-25s %d\n", n.name+":", readCounter(n.idx))
 	}
-	if readErr != nil {
-		fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
-	}
 
 	if !detail {
+		// #3345: even in the non-detail path, surface a read failure (the
+		// global loop above is the only read set here).
+		if readErr != nil {
+			fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
+		}
 		return nil
 	}
 
@@ -187,6 +189,13 @@ func (c *CLI) showStatistics(detail bool) error {
 			}
 			fmt.Printf("  %-24s %d/%d (%.1f%%)%s\n", s.Name+":", s.UsedCount, s.MaxEntries, pct, flag)
 		}
+	}
+
+	// #3345: check AFTER all global-counter reads (incl. the detail screen
+	// breakdown) so a failure on a late read is surfaced rather than printing
+	// a stale 0.
+	if readErr != nil {
+		fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
 	}
 
 	return nil
@@ -973,9 +982,6 @@ func (c *CLI) showFlowStatistics() error {
 	cacheInval := readCounter(dataplane.GlobalCtrFlowCacheInvalidate)
 
 	fmt.Println("Flow statistics:")
-	if readErr != nil {
-		fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
-	}
 	fmt.Printf("  %-30s %d\n", "Current sessions:", dataplane.CurrentSessions(sessNew, sessClosed))
 	fmt.Printf("  %-30s %d\n", "Sessions created:", sessNew)
 	fmt.Printf("  %-30s %d\n", "Sessions closed:", sessClosed)
@@ -1036,6 +1042,13 @@ func (c *CLI) showFlowStatistics() error {
 				fmt.Printf("    %-28s %d\n", sc.name+":", v)
 			}
 		}
+	}
+
+	// #3345: check AFTER all global-counter reads (incl. the screen breakdown
+	// loop) so a failure on a late read is surfaced rather than printing a
+	// stale 0.
+	if readErr != nil {
+		fmt.Printf("warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
 	}
 
 	return nil

--- a/pkg/cli/cli_show_nat.go
+++ b/pkg/cli/cli_show_nat.go
@@ -157,9 +157,13 @@ func (c *CLI) showNATSource(cfg *config.Config, args []string) error {
 	warnSessionScan(errV4, errV6)
 	fmt.Printf("Active SNAT sessions: %d\n", snatCount)
 
-	// Show NAT alloc fail counter
+	// Show NAT alloc fail counter. #3345: emit an explicit warning on a read
+	// failure rather than silently omitting the line — a degraded counter
+	// bridge must be distinguishable from "zero allocation failures".
 	if allocFails, err := c.dp.ReadGlobalCounter(dataplane.GlobalCtrNATAllocFail); err == nil {
 		fmt.Printf("NAT allocation failures: %d\n", allocFails)
+	} else {
+		fmt.Printf("warning: NAT allocation-failure counter read failed (counter unavailable): %v\n", err)
 	}
 
 	return nil

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -46,6 +46,9 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 	fmt.Printf("%-8s%-17s%-18s%-24s%-14s%s\n",
 		"Index", "From zone", "To zone", "Name", "Policy count", "Action")
 
+	// #3408: surface a per-policy counter read failure as a warning AFTER
+	// all reads, rather than printing clean-zero hit counts.
+	var readErr error
 	index := uint32(1)
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
@@ -70,6 +73,8 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			if statsEnabled || pol.Count {
 				if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 					count = counters.Packets
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			fmt.Printf("%-8d%-17s%-18s%-24s%-14d%s\n",
@@ -93,6 +98,8 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			if statsEnabled || pol.Count {
 				if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 					count = counters.Packets
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			// #3286: a scoped global (#3148) shows its zone pair in the
@@ -109,6 +116,9 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 				index, hcFrom, hcTo, pol.Name, count, action)
 			index++
 		}
+	}
+	if readErr != nil {
+		fmt.Printf("warning: policy counter read failed (counts may be incomplete): %v\n", readErr)
 	}
 	return nil
 }

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -208,6 +208,9 @@ func (c *CLI) handleShowSecurity(args []string) error {
 			// the Prometheus collector. When the knob is off the column
 			// reads 0 (we skip the dataplane read).
 			statsEnabled := cfg.Security.PolicyStatsEnabled
+			// #3408: surface a per-policy counter read failure as a warning
+			// AFTER all reads rather than rendering a clean "0" hits column.
+			var readErr error
 			// Brief tabular summary
 			fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 				"From", "To", "Name", "Action", "Hits")
@@ -238,6 +241,8 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					if (statsEnabled || pol.Count) && c.dp != nil && c.dp.IsLoaded() {
 						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
+						} else if readErr == nil {
+							readErr = err
 						}
 					}
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
@@ -262,6 +267,8 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					if (statsEnabled || pol.Count) && c.dp != nil && c.dp.IsLoaded() {
 						if counters, err := c.dp.ReadPolicyCounters(ruleID); err == nil {
 							hits = fmt.Sprintf("%d", counters.Packets)
+						} else if readErr == nil {
+							readErr = err
 						}
 					}
 					// #3286: a scoped global (#3148) shows its zone pair in
@@ -277,6 +284,9 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
 						briefFrom, briefTo, pol.Name, action, hits)
 				}
+			}
+			if readErr != nil {
+				fmt.Printf("warning: policy counter read failed (hit counts may be incomplete): %v\n", readErr)
 			}
 			return nil
 		}

--- a/pkg/cli/cli_show_security_filters.go
+++ b/pkg/cli/cli_show_security_filters.go
@@ -34,6 +34,9 @@ func (c *CLI) showFirewallFilters() error {
 	}
 	userspaceCounters := dpuserspace.BuildFirewallFilterTermCounterIndex(userspaceStatus)
 
+	// #3408: surface a filter counter read failure as a warning AFTER all
+	// filters, rather than printing clean-zero / omitted hit counts.
+	var readErr error
 	showFilters := func(family string, filters map[string]*config.FirewallFilter, names []string) {
 		for _, name := range names {
 			f := filters[name]
@@ -47,6 +50,8 @@ func (c *CLI) showFirewallFilters() error {
 					if fcfg, err := c.dp.ReadFilterConfig(fid); err == nil {
 						ruleStart = fcfg.RuleStart
 						hasCounters = true
+					} else if readErr == nil {
+						readErr = err
 					}
 				}
 			}
@@ -126,6 +131,8 @@ func (c *CLI) showFirewallFilters() error {
 						if ctrs, err := c.dp.ReadFilterCounters(ruleOffset + i); err == nil {
 							totalPkts += ctrs.Packets
 							totalBytes += ctrs.Bytes
+						} else if readErr == nil {
+							readErr = err
 						}
 					}
 					ruleOffset += numRules
@@ -160,6 +167,9 @@ func (c *CLI) showFirewallFilters() error {
 
 	showFilters("inet", cfg.Firewall.FiltersInet, inetNames)
 	showFilters("inet6", cfg.Firewall.FiltersInet6, inet6Names)
+	if readErr != nil {
+		fmt.Printf("warning: filter counter read failed (hit counts may be incomplete): %v\n", readErr)
+	}
 	return nil
 }
 
@@ -203,7 +213,9 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 		return nil
 	}
 
-	// Resolve filter IDs for counter display
+	// Resolve filter IDs for counter display. #3408: surface a read failure
+	// as a warning AFTER all terms rather than printing clean-zero counts.
+	var readErr error
 	var ruleStart uint32
 	var hasCounters bool
 	if c.dp != nil && c.dp.IsLoaded() {
@@ -212,6 +224,8 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 				if fcfg, err := c.dp.ReadFilterConfig(fid); err == nil {
 					ruleStart = fcfg.RuleStart
 					hasCounters = true
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 		}
@@ -297,6 +311,8 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 				if ctrs, err := c.dp.ReadFilterCounters(ruleOffset + i); err == nil {
 					totalPkts += ctrs.Packets
 					totalBytes += ctrs.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			ruleOffset += numRules
@@ -313,6 +329,9 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 		}
 	}
 	fmt.Println()
+	if readErr != nil {
+		fmt.Printf("warning: filter counter read failed (hit counts may be incomplete): %v\n", readErr)
+	}
 	return nil
 }
 

--- a/pkg/cli/cli_show_security_log.go
+++ b/pkg/cli/cli_show_security_log.go
@@ -191,8 +191,14 @@ func (c *CLI) showSecurityAlarms(args []string) error {
 
 	// Screen drop alarms — any non-zero screen counter indicates detected attacks
 	if c.dp != nil && c.dp.IsLoaded() {
+		// #3345: track a counter-read failure so a degraded counter bridge
+		// is reported as a warning rather than masquerading as "no alarms".
+		var readErr error
 		readCtr := func(idx uint32) uint64 {
-			v, _ := c.dp.ReadGlobalCounter(idx)
+			v, err := c.dp.ReadGlobalCounter(idx)
+			if err != nil && readErr == nil {
+				readErr = err
+			}
 			return v
 		}
 		screenNames := []struct {
@@ -220,6 +226,9 @@ func (c *CLI) showSecurityAlarms(args []string) error {
 					fmt.Printf("Alarm %d:\n  Class: IDS\n  Severity: Major\n  Description: %s attack detected (%d drops)\n\n", alarmCount, s.name, val)
 				}
 			}
+		}
+		if readErr != nil {
+			fmt.Printf("warning: screen counter read failed (alarms may be incomplete): %v\n", readErr)
 		}
 	}
 

--- a/pkg/cli/cli_show_security_screen.go
+++ b/pkg/cli/cli_show_security_screen.go
@@ -375,10 +375,17 @@ func (c *CLI) showScreenStatisticsAll() error {
 	}
 	sort.Strings(zones)
 
+	// #3408: surface a per-zone flood-counter read failure as a warning AFTER
+	// all zones, rather than silently dropping the zone (which reads as "no
+	// flood events for that zone").
+	var readErr error
 	for _, zoneName := range zones {
 		zoneID := cr.ZoneIDs[zoneName]
 		fs, err := c.dp.ReadFloodCounters(zoneID)
 		if err != nil {
+			if readErr == nil {
+				readErr = err
+			}
 			continue
 		}
 		screenProfile := ""
@@ -397,6 +404,9 @@ func (c *CLI) showScreenStatisticsAll() error {
 	}
 	if rows := c.screenSYNCookieCounterRows(); rows != "" {
 		fmt.Print(rows)
+	}
+	if readErr != nil {
+		fmt.Printf("warning: flood counter read failed (screen statistics may be incomplete): %v\n", readErr)
 	}
 	return nil
 }

--- a/pkg/cli/cli_show_security_screen.go
+++ b/pkg/cli/cli_show_security_screen.go
@@ -89,13 +89,23 @@ func (c *CLI) showScreen() error {
 
 	// Show screen drop counters (total + per-type)
 	if c.dp != nil && c.dp.IsLoaded() {
+		// #3345: surface a counter-read failure rather than printing a clean
+		// zero that hides a degraded counter bridge.
+		var readErr error
 		readCtr := func(idx uint32) uint64 {
-			v, _ := c.dp.ReadGlobalCounter(idx)
+			v, err := c.dp.ReadGlobalCounter(idx)
+			if err != nil && readErr == nil {
+				readErr = err
+			}
 			return v
 		}
 
 		totalDrops := readCtr(dataplane.GlobalCtrScreenDrops)
-		fmt.Printf("Total screen drops: %d\n", totalDrops)
+		if readErr != nil {
+			fmt.Printf("warning: screen counter read failed (counters unavailable): %v\n", readErr)
+		} else {
+			fmt.Printf("Total screen drops: %d\n", totalDrops)
+		}
 
 		if totalDrops > 0 {
 			screenCounters := []struct {

--- a/pkg/cli/cli_show_security_screen.go
+++ b/pkg/cli/cli_show_security_screen.go
@@ -101,11 +101,7 @@ func (c *CLI) showScreen() error {
 		}
 
 		totalDrops := readCtr(dataplane.GlobalCtrScreenDrops)
-		if readErr != nil {
-			fmt.Printf("warning: screen counter read failed (counters unavailable): %v\n", readErr)
-		} else {
-			fmt.Printf("Total screen drops: %d\n", totalDrops)
-		}
+		fmt.Printf("Total screen drops: %d\n", totalDrops)
 
 		if totalDrops > 0 {
 			screenCounters := []struct {
@@ -131,6 +127,12 @@ func (c *CLI) showScreen() error {
 					fmt.Printf("  %-25s %d\n", sc.name+":", v)
 				}
 			}
+		}
+		// #3345: check AFTER all reads (incl. the per-type loop) so a failure
+		// on ANY read — not just the first — is surfaced. An early check
+		// before the loop would let a late read print a stale 0.
+		if readErr != nil {
+			fmt.Printf("warning: screen counter read failed (counters may be incomplete): %v\n", readErr)
 		}
 	}
 

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -17,6 +17,10 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 	sort.Strings(zoneNames)
 	cr := c.applyResult()
 
+	// #3408: surface a per-zone counter read failure as a warning AFTER all
+	// zones are rendered, rather than silently dropping the traffic-statistics
+	// block (which would read like a true zero).
+	var readErr error
 	for _, name := range zoneNames {
 		if filterZone != "" && name != filterZone {
 			continue
@@ -72,6 +76,12 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 					ingress.Packets, ingress.Bytes)
 				fmt.Printf("    Output: %d packets, %d bytes\n",
 					egress.Packets, egress.Bytes)
+			} else if readErr == nil {
+				if errIn != nil {
+					readErr = errIn
+				} else {
+					readErr = errOut
+				}
 			}
 		}
 
@@ -172,6 +182,9 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 		}
 
 		fmt.Println()
+	}
+	if readErr != nil {
+		fmt.Printf("warning: zone counter read failed (traffic statistics may be incomplete): %v\n", readErr)
 	}
 	if filterZone != "" {
 		if _, ok := cfg.Security.Zones[filterZone]; !ok {

--- a/pkg/cli/show_security_counter_error_test.go
+++ b/pkg/cli/show_security_counter_error_test.go
@@ -29,6 +29,50 @@ func (d *counterErrCLIDP) ReadGlobalCounter(uint32) (uint64, error) {
 	return 0, errors.New("counter bridge degraded")
 }
 
+// lateCounterErrCLIDP fails ONLY a LATE read (a per-type screen counter that
+// is read after the leading screen-drops total / the global-stats loop), while
+// returning a non-zero GlobalCtrScreenDrops so the per-type breakdown loop is
+// entered. It models the early-warn/late-read ordering bug: an error check
+// placed before the late read would pass, printing a stale 0 with no warning.
+type lateCounterErrCLIDP struct {
+	dataplane.DataPlane
+}
+
+func (d *lateCounterErrCLIDP) IsLoaded() bool { return true }
+
+func (d *lateCounterErrCLIDP) ReadGlobalCounter(idx uint32) (uint64, error) {
+	switch idx {
+	case dataplane.GlobalCtrScreenSynFlood:
+		return 0, errors.New("counter bridge degraded (late read)")
+	case dataplane.GlobalCtrScreenDrops:
+		return 5, nil // non-zero -> the per-type breakdown loop runs
+	}
+	return 0, nil
+}
+
+func (d *lateCounterErrCLIDP) SessionCount() (int, int)          { return 0, 0 }
+func (d *lateCounterErrCLIDP) GetMapStats() []dataplane.MapStats { return nil }
+
+// natCounterErrCLIDP fails ReadGlobalCounter and stubs the session iterators
+// that showNATSource walks before reading the NAT alloc-fail counter.
+type natCounterErrCLIDP struct {
+	dataplane.DataPlane
+}
+
+func (d *natCounterErrCLIDP) IsLoaded() bool { return true }
+
+func (d *natCounterErrCLIDP) ReadGlobalCounter(uint32) (uint64, error) {
+	return 0, errors.New("counter bridge degraded")
+}
+
+func (d *natCounterErrCLIDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+
+func (d *natCounterErrCLIDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
 // screenProfileStore commits a config with a screen profile + zone so that
 // showScreen reaches the per-type counter section (it returns early when no
 // screen profiles are configured).
@@ -61,11 +105,10 @@ func TestShowScreenWarnsOnCounterReadError(t *testing.T) {
 		}
 	})
 
+	// The total line may still print its (possibly 0) value, but the trailing
+	// warning is what makes a degraded read distinguishable from a true zero.
 	if !strings.Contains(out, "warning") {
 		t.Fatalf("showScreen output lacks a counter-read warning; got:\n%s", out)
-	}
-	if strings.Contains(out, "Total screen drops: 0") {
-		t.Fatalf("showScreen printed a clean zero on read failure; got:\n%s", out)
 	}
 }
 
@@ -113,6 +156,56 @@ func TestShowFlowStatisticsWarnsOnCounterReadError(t *testing.T) {
 	}
 }
 
+// The following three tests pin the early-warn/late-read ORDERING fix: the
+// warning must be checked AFTER all global-counter reads, so a failure on a
+// LATE read (per-type screen breakdown) is surfaced rather than printing a
+// stale 0 under an earlier passed check. Each FAILS if the readErr check is
+// moved before the late read.
+func TestShowScreenWarnsOnLateCounterReadError(t *testing.T) {
+	c := &CLI{store: screenProfileStore(t), dp: &lateCounterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showScreen(); err != nil {
+			t.Fatalf("showScreen() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showScreen lacks a warning on a LATE counter-read failure "+
+			"(early-warn/late-read ordering); got:\n%s", out)
+	}
+}
+
+func TestShowStatisticsDetailWarnsOnLateCounterReadError(t *testing.T) {
+	c := &CLI{dp: &lateCounterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showStatistics(true); err != nil {
+			t.Fatalf("showStatistics(detail) error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showStatistics(detail) lacks a warning on a LATE counter-read "+
+			"failure (early-warn/late-read ordering); got:\n%s", out)
+	}
+}
+
+func TestShowFlowStatisticsWarnsOnLateCounterReadError(t *testing.T) {
+	c := &CLI{dp: &lateCounterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showFlowStatistics(); err != nil {
+			t.Fatalf("showFlowStatistics() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showFlowStatistics lacks a warning on a LATE counter-read "+
+			"failure (early-warn/late-read ordering); got:\n%s", out)
+	}
+}
+
 func TestShowChassisClusterFabricStatisticsWarnsOnCounterReadError(t *testing.T) {
 	c := &CLI{dp: &counterErrCLIDP{}}
 
@@ -124,5 +217,23 @@ func TestShowChassisClusterFabricStatisticsWarnsOnCounterReadError(t *testing.T)
 
 	if !strings.Contains(out, "warning") {
 		t.Fatalf("showChassisClusterFabricStatistics output lacks a counter-read warning; got:\n%s", out)
+	}
+}
+
+// showNATSource previously OMITTED the NAT alloc-fail line on a read error
+// (acceptable — no stale 0 — but indistinguishable from "no failures"). It now
+// emits an explicit warning. FAIL-ON-REVERT: dropping the else branch removes
+// the warning line.
+func TestShowNATSourceWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{dp: &natCounterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showNATSource(nil, nil); err != nil {
+			t.Fatalf("showNATSource() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showNATSource output lacks a NAT alloc-fail counter-read warning; got:\n%s", out)
 	}
 }

--- a/pkg/cli/show_security_counter_error_test.go
+++ b/pkg/cli/show_security_counter_error_test.go
@@ -220,6 +220,35 @@ func TestShowChassisClusterFabricStatisticsWarnsOnCounterReadError(t *testing.T)
 	}
 }
 
+// policyCounterErrCLIDP is a loaded cliRuntime whose per-policy counter reads
+// fail.
+type policyCounterErrCLIDP struct {
+	dataplane.DataPlane
+}
+
+func (d *policyCounterErrCLIDP) IsLoaded() bool { return true }
+
+func (d *policyCounterErrCLIDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+// #3408: the CLI `show security policies hit-count` table must warn on a
+// per-policy counter read failure rather than printing clean-zero counts.
+func TestShowPoliciesHitCountWarnsOnCounterReadError(t *testing.T) {
+	store := newPolicyHitCountCLIStore(t, true) // policy-stats enabled
+	c := &CLI{store: store, dp: &policyCounterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesHitCount(store.ActiveConfig(), "", ""); err != nil {
+			t.Fatalf("showPoliciesHitCount() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showPoliciesHitCount lacks a counter-read warning; got:\n%s", out)
+	}
+}
+
 // showNATSource previously OMITTED the NAT alloc-fail line on a read error
 // (acceptable — no stale 0 — but indistinguishable from "no failures"). It now
 // emits an explicit warning. FAIL-ON-REVERT: dropping the else branch removes

--- a/pkg/cli/show_security_counter_error_test.go
+++ b/pkg/cli/show_security_counter_error_test.go
@@ -1,0 +1,84 @@
+// #3345: the text `show security screen` / `show security alarms` commands
+// must print a warning when a global-counter read fails, rather than printing
+// a clean "Total screen drops: 0" / "No security alarms" that hides a degraded
+// counter bridge.
+//
+// FAIL-ON-REVERT: restoring `v, _ := c.dp.ReadGlobalCounter(idx)` (dropping
+// the readErr capture + the warning print) makes both commands emit the clean
+// zero output with no warning and the want-"warning" assertions go RED.
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// counterErrCLIDP is a loaded cliRuntime whose global-counter reads fail.
+type counterErrCLIDP struct {
+	dataplane.DataPlane
+}
+
+func (d *counterErrCLIDP) IsLoaded() bool { return true }
+
+func (d *counterErrCLIDP) ReadGlobalCounter(uint32) (uint64, error) {
+	return 0, errors.New("counter bridge degraded")
+}
+
+// screenProfileStore commits a config with a screen profile + zone so that
+// showScreen reaches the per-type counter section (it returns early when no
+// screen profiles are configured).
+func screenProfileStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	for _, line := range []string{
+		"set security screen ids-option untrust-screen icmp flood threshold 1000",
+		"set security zones security-zone untrust screen untrust-screen",
+	} {
+		if _, err := store.LoadSet(line); err != nil {
+			t.Fatalf("LoadSet(%q) error = %v", line, err)
+		}
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestShowScreenWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{store: screenProfileStore(t), dp: &counterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showScreen(); err != nil {
+			t.Fatalf("showScreen() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showScreen output lacks a counter-read warning; got:\n%s", out)
+	}
+	if strings.Contains(out, "Total screen drops: 0") {
+		t.Fatalf("showScreen printed a clean zero on read failure; got:\n%s", out)
+	}
+}
+
+func TestShowSecurityAlarmsWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")), dp: &counterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showSecurityAlarms(nil); err != nil {
+			t.Fatalf("showSecurityAlarms() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showSecurityAlarms output lacks a counter-read warning; got:\n%s", out)
+	}
+}

--- a/pkg/cli/show_security_counter_error_test.go
+++ b/pkg/cli/show_security_counter_error_test.go
@@ -249,6 +249,95 @@ func TestShowPoliciesHitCountWarnsOnCounterReadError(t *testing.T) {
 	}
 }
 
+// textErrCLIDP fails per-zone / per-policy / filter / flood reads (filter
+// config read succeeds so the per-term read is reached) and supplies an apply
+// result so zone/flood/filter renderers resolve their IDs.
+type textErrCLIDP struct {
+	dataplane.DataPlane
+	apply *dataplane.ApplyResult
+}
+
+func (d *textErrCLIDP) IsLoaded() bool                          { return true }
+func (d *textErrCLIDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *textErrCLIDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+func (d *textErrCLIDP) ReadZoneCounters(uint16, int) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+func (d *textErrCLIDP) ReadFloodCounters(uint16) (dataplane.FloodState, error) {
+	return dataplane.FloodState{}, errors.New("counter bridge degraded")
+}
+func (d *textErrCLIDP) ReadFilterConfig(uint32) (dataplane.FilterConfig, error) {
+	return dataplane.FilterConfig{RuleStart: 0}, nil
+}
+func (d *textErrCLIDP) ReadFilterCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+func TestShowPoliciesBriefWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{store: newPolicyHitCountCLIStore(t, true), dp: &textErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.handleShowSecurity([]string{"policies", "brief"}); err != nil {
+			t.Fatalf("handleShowSecurity(policies brief) error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("policies brief lacks a counter-read warning; got:\n%s", out)
+	}
+}
+
+func TestShowZonesDisplayWarnsOnCounterReadError(t *testing.T) {
+	store := newPolicyHitCountCLIStore(t, true) // has trust/untrust zones
+	c := &CLI{store: store, dp: &textErrCLIDP{
+		apply: &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2}},
+	}}
+
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(store.ActiveConfig(), false, ""); err != nil {
+			t.Fatalf("showZonesDisplay() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showZonesDisplay lacks a zone counter-read warning; got:\n%s", out)
+	}
+}
+
+func TestShowFirewallFiltersWarnsOnCounterReadError(t *testing.T) {
+	store := newFirewallFilterTestStore(t)
+	c := &CLI{store: store, dp: &textErrCLIDP{
+		apply: &dataplane.ApplyResult{FilterIDs: map[string]uint32{
+			"inet:bandwidth-output": 0, "inet6:bandwidth-output": 100,
+		}},
+	}}
+
+	out := captureStdout(t, func() {
+		if err := c.showFirewallFilters(); err != nil {
+			t.Fatalf("showFirewallFilters() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showFirewallFilters lacks a filter counter-read warning; got:\n%s", out)
+	}
+}
+
+func TestShowScreenStatisticsAllWarnsOnCounterReadError(t *testing.T) {
+	store := screenProfileStore(t) // has untrust zone + screen profile
+	c := &CLI{store: store, dp: &textErrCLIDP{
+		apply: &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"untrust": 1}},
+	}}
+
+	out := captureStdout(t, func() {
+		if err := c.showScreenStatisticsAll(); err != nil {
+			t.Fatalf("showScreenStatisticsAll() error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showScreenStatisticsAll lacks a flood counter-read warning; got:\n%s", out)
+	}
+}
+
 // showNATSource previously OMITTED the NAT alloc-fail line on a read error
 // (acceptable — no stale 0 — but indistinguishable from "no failures"). It now
 // emits an explicit warning. FAIL-ON-REVERT: dropping the else branch removes

--- a/pkg/cli/show_security_counter_error_test.go
+++ b/pkg/cli/show_security_counter_error_test.go
@@ -82,3 +82,47 @@ func TestShowSecurityAlarmsWarnsOnCounterReadError(t *testing.T) {
 		t.Fatalf("showSecurityAlarms output lacks a counter-read warning; got:\n%s", out)
 	}
 }
+
+// showStatistics / showFlowStatistics are the canonical operator global-counter
+// views (`show security flow statistics`). Both must warn on a degraded read.
+func TestShowStatisticsWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{dp: &counterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showStatistics(false); err != nil {
+			t.Fatalf("showStatistics() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showStatistics output lacks a counter-read warning; got:\n%s", out)
+	}
+}
+
+func TestShowFlowStatisticsWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{dp: &counterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showFlowStatistics(); err != nil {
+			t.Fatalf("showFlowStatistics() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showFlowStatistics output lacks a counter-read warning; got:\n%s", out)
+	}
+}
+
+func TestShowChassisClusterFabricStatisticsWarnsOnCounterReadError(t *testing.T) {
+	c := &CLI{dp: &counterErrCLIDP{}}
+
+	out := captureStdout(t, func() {
+		if err := c.showChassisClusterFabricStatistics(); err != nil {
+			t.Fatalf("showChassisClusterFabricStatistics() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "warning") {
+		t.Fatalf("showChassisClusterFabricStatistics output lacks a counter-read warning; got:\n%s", out)
+	}
+}

--- a/pkg/grpcapi/flow_cluster_counter_error_test.go
+++ b/pkg/grpcapi/flow_cluster_counter_error_test.go
@@ -1,0 +1,39 @@
+// #3345: the gRPC text `show security flow statistics` and `show chassis
+// cluster ... fabric` views must print a warning when a global-counter read
+// fails, rather than rendering clean zeros that hide a degraded counter bridge.
+//
+// FAIL-ON-REVERT: restoring `v, _ := s.dp.ReadGlobalCounter(idx)` (dropping the
+// readErr capture + the warning line) makes both renderers emit only the
+// zero-valued rows and the want-"warning" assertions go RED.
+package grpcapi
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+func TestShowFlowStatisticsTextWarnsOnCounterReadError(t *testing.T) {
+	dp := &counterFaultGRPCDP{Manager: dataplane.New()}
+	s := newViewServer(t, dp)
+
+	var buf strings.Builder
+	s.showFlowStatistics(&buf)
+
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showFlowStatistics output lacks a counter-read warning; got:\n%s", buf.String())
+	}
+}
+
+func TestShowClusterFabricTextWarnsOnCounterReadError(t *testing.T) {
+	dp := &counterFaultGRPCDP{Manager: dataplane.New()}
+	s := newViewServer(t, dp)
+
+	var buf strings.Builder
+	s.showChassisClusterFabricStatistics(&buf)
+
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showChassisClusterFabricStatistics output lacks a counter-read warning; got:\n%s", buf.String())
+	}
+}

--- a/pkg/grpcapi/global_stats_counter_error_test.go
+++ b/pkg/grpcapi/global_stats_counter_error_test.go
@@ -42,3 +42,34 @@ func TestGetGlobalStatsFailsOnCounterReadError(t *testing.T) {
 		t.Fatalf("GetGlobalStats error code = %v, want Internal; err: %v", status.Code(err), err)
 	}
 }
+
+// lateCounterFaultGRPCDP fails ONLY GlobalCtrRxPackets, which GetGlobalStats
+// reads AFTER the screen-counter loop. This pins the H1 ordering fix: the
+// readErr check must run AFTER the full response struct is built, or a
+// failure on a late read returns a nil-error zero-valued field.
+type lateCounterFaultGRPCDP struct {
+	*dataplane.Manager
+}
+
+func (d *lateCounterFaultGRPCDP) IsLoaded() bool { return true }
+
+func (d *lateCounterFaultGRPCDP) ReadGlobalCounter(idx uint32) (uint64, error) {
+	if idx == dataplane.GlobalCtrRxPackets {
+		return 0, errors.New("counter bridge degraded")
+	}
+	return 0, nil
+}
+
+func TestGetGlobalStatsFailsOnLateCounterReadError(t *testing.T) {
+	dp := &lateCounterFaultGRPCDP{Manager: dataplane.New()}
+	s := newViewServer(t, dp)
+
+	_, err := s.GetGlobalStats(context.Background(), &pb.GetGlobalStatsRequest{})
+	if err == nil {
+		t.Fatal("GetGlobalStats returned nil error on a LATE (post-screen-loop) " +
+			"counter read failure; want codes.Internal (H1 ordering)")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetGlobalStats error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}

--- a/pkg/grpcapi/global_stats_counter_error_test.go
+++ b/pkg/grpcapi/global_stats_counter_error_test.go
@@ -1,0 +1,44 @@
+// #3345: GetGlobalStats must fail with codes.Internal when a global-counter
+// read fails, rather than returning a zero-valued response that is
+// indistinguishable from "no events".
+//
+// FAIL-ON-REVERT: restoring `v, _ := s.dp.ReadGlobalCounter(idx)` (dropping
+// the readErr capture + the status.Errorf return) makes GetGlobalStats return
+// a non-error zero response and the want-Internal assertion goes RED.
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// counterFaultGRPCDP is a loaded grpcRuntime whose global-counter reads fail.
+type counterFaultGRPCDP struct {
+	*dataplane.Manager
+}
+
+func (d *counterFaultGRPCDP) IsLoaded() bool { return true }
+
+func (d *counterFaultGRPCDP) ReadGlobalCounter(uint32) (uint64, error) {
+	return 0, errors.New("counter bridge degraded")
+}
+
+func TestGetGlobalStatsFailsOnCounterReadError(t *testing.T) {
+	dp := &counterFaultGRPCDP{Manager: dataplane.New()}
+	s := newViewServer(t, dp)
+
+	_, err := s.GetGlobalStats(context.Background(), &pb.GetGlobalStatsRequest{})
+	if err == nil {
+		t.Fatal("GetGlobalStats returned nil error on counter read failure; want codes.Internal")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetGlobalStats error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}

--- a/pkg/grpcapi/server_show_cluster_text.go
+++ b/pkg/grpcapi/server_show_cluster_text.go
@@ -214,12 +214,25 @@ func (s *Server) showChassisClusterFabricStatistics(buf *strings.Builder) {
 		fmt.Fprintln(buf, "Dataplane not loaded")
 		return
 	}
-	total, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirect)
-	fab0, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab0)
-	fab1, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectFab1)
-	zone, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricRedirectZone)
-	drops, _ := s.dp.ReadGlobalCounter(dataplane.GlobalCtrFabricFwdDrop)
+	// #3345: surface a counter-read failure rather than emitting clean zeros
+	// that hide a degraded counter bridge.
+	var readErr error
+	readCtr := func(idx uint32) uint64 {
+		v, err := s.dp.ReadGlobalCounter(idx)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
+		return v
+	}
+	total := readCtr(dataplane.GlobalCtrFabricRedirect)
+	fab0 := readCtr(dataplane.GlobalCtrFabricRedirectFab0)
+	fab1 := readCtr(dataplane.GlobalCtrFabricRedirectFab1)
+	zone := readCtr(dataplane.GlobalCtrFabricRedirectZone)
+	drops := readCtr(dataplane.GlobalCtrFabricFwdDrop)
 	fmt.Fprintln(buf, "Fabric redirect statistics:")
+	if readErr != nil {
+		fmt.Fprintf(buf, "warning: fabric counter read failed (statistics may be incomplete): %v\n", readErr)
+	}
 	fmt.Fprintf(buf, "    Total redirects:          %d\n", total)
 	fmt.Fprintf(buf, "    fab0 redirects:           %d\n", fab0)
 	fmt.Fprintf(buf, "    fab1 redirects:           %d\n", fab1)

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -46,6 +46,9 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 		}
 	}
 
+	// #3408: surface a filter counter read failure as a warning AFTER all
+	// filters rather than printing clean-zero / omitted hit counts.
+	var readErr error
 	printFilters := func(family string, filters map[string]*config.FirewallFilter) {
 		names := make([]string, 0, len(filters))
 		for name := range filters {
@@ -64,6 +67,8 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 					if fcfg, err := s.dp.ReadFilterConfig(fid); err == nil {
 						ruleStart = fcfg.RuleStart
 						hasCounters = true
+					} else if readErr == nil {
+						readErr = err
 					}
 				}
 			}
@@ -137,6 +142,8 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 						if ctrs, err := s.dp.ReadFilterCounters(ruleOffset + i); err == nil {
 							totalPkts += ctrs.Packets
 							totalBytes += ctrs.Bytes
+						} else if readErr == nil {
+							readErr = err
 						}
 					}
 					ruleOffset += numRules
@@ -157,6 +164,9 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 	}
 	printFilters("inet", cfg.Firewall.FiltersInet)
 	printFilters("inet6", cfg.Firewall.FiltersInet6)
+	if readErr != nil {
+		fmt.Fprintf(buf, "warning: filter counter read failed (hit counts may be incomplete): %v\n", readErr)
+	}
 }
 
 // --- #1700: residual ShowText branches ---
@@ -347,6 +357,9 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 					filterIDs = cr.FilterIDs
 				}
 			}
+			// #3408: surface a filter counter read failure as a warning AFTER
+			// all terms rather than printing clean-zero / omitted hit counts.
+			var readErr error
 			var ruleStart uint32
 			var hasCounters bool
 			if filterIDs != nil {
@@ -354,6 +367,8 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 					if fcfg, err := s.dp.ReadFilterConfig(fid); err == nil {
 						ruleStart = fcfg.RuleStart
 						hasCounters = true
+					} else if readErr == nil {
+						readErr = err
 					}
 				}
 			}
@@ -426,6 +441,8 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 						if ctrs, err := s.dp.ReadFilterCounters(ruleOffset + i); err == nil {
 							totalPkts += ctrs.Packets
 							totalBytes += ctrs.Bytes
+						} else if readErr == nil {
+							readErr = err
 						}
 					}
 					ruleOffset += numRules
@@ -442,6 +459,9 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 				}
 			}
 			buf.WriteString("\n")
+			if readErr != nil {
+				fmt.Fprintf(buf, "warning: filter counter read failed (hit counts may be incomplete): %v\n", readErr)
+			}
 		}
 	}
 	return &pb.ShowTextResponse{Output: buf.String()}, nil

--- a/pkg/grpcapi/server_show_flow.go
+++ b/pkg/grpcapi/server_show_flow.go
@@ -140,8 +140,14 @@ func (s *Server) showFlowStatistics(buf *strings.Builder) {
 		buf.WriteString("Flow statistics: dataplane not loaded\n")
 		return
 	}
+	// #3345: surface a counter-read failure rather than emitting clean zeros
+	// that hide a degraded counter bridge.
+	var readErr error
 	readCtr := func(idx uint32) uint64 {
-		v, _ := s.dp.ReadGlobalCounter(idx)
+		v, err := s.dp.ReadGlobalCounter(idx)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
 		return v
 	}
 	sessNew := readCtr(dataplane.GlobalCtrSessionsNew)
@@ -174,6 +180,9 @@ func (s *Server) showFlowStatistics(buf *strings.Builder) {
 			hitRate := float64(cacheHit) / float64(cacheHit+cacheMiss) * 100
 			fmt.Fprintf(buf, "  %-30s %.1f%%\n", "Flow cache hit rate:", hitRate)
 		}
+	}
+	if readErr != nil {
+		fmt.Fprintf(buf, "warning: global counter read failed (statistics may be incomplete): %v\n", readErr)
 	}
 }
 

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -107,6 +107,9 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 	// the dataplane read) rather than surfacing live counts the operator
 	// did not enable.
 	statsEnabled := cfg.Security.PolicyStatsEnabled
+	// #3408: surface a per-policy counter read failure as a warning AFTER all
+	// reads rather than printing clean-zero hit counts.
+	var readErr error
 	fmt.Fprintf(buf, "%-12s %-12s %-24s %-8s %12s %16s\n",
 		"From zone", "To zone", "Policy", "Action", "Packets", "Bytes")
 	fmt.Fprintln(buf, strings.Repeat("-", 88))
@@ -132,6 +135,8 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					pkts = counters.Packets
 					bytes = counters.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			totalPkts += pkts
@@ -170,6 +175,8 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					pkts = counters.Packets
 					bytes = counters.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			totalPkts += pkts
@@ -190,6 +197,9 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 	}
 	fmt.Fprintln(buf, strings.Repeat("-", 88))
 	fmt.Fprintf(buf, "%-48s %8s %12d %16d\n", "Total", "", totalPkts, totalBytes)
+	if readErr != nil {
+		fmt.Fprintf(buf, "warning: policy counter read failed (hit counts may be incomplete): %v\n", readErr)
+	}
 }
 
 // showPoliciesDetail renders per-policy detail (match conditions,
@@ -220,6 +230,9 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 	// it must honor the knob for cross-surface consistency.
 	statsEnabled := cfg.Security.PolicyStatsEnabled
 	schedActive, haveSched := s.policySchedulerActiveState()
+	// #3408: surface a per-policy counter read failure as a warning AFTER all
+	// reads rather than silently omitting the session-statistics block.
+	var readErr error
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
 		if (filterFrom != "" && zpp.FromZone != filterFrom) ||
@@ -276,6 +289,8 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					fmt.Fprintf(buf, "    Session statistics:\n")
 					fmt.Fprintf(buf, "      %d packets, %d bytes\n", counters.Packets, counters.Bytes)
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 		}
@@ -337,10 +352,15 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 				if counters, err := s.dp.ReadPolicyCounters(ruleID); err == nil {
 					fmt.Fprintf(buf, "    Session statistics:\n")
 					fmt.Fprintf(buf, "      %d packets, %d bytes\n", counters.Packets, counters.Bytes)
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 		}
 		fmt.Fprintln(buf)
+	}
+	if readErr != nil {
+		fmt.Fprintf(buf, "warning: policy counter read failed (session statistics may be incomplete): %v\n", readErr)
 	}
 }
 

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -688,11 +688,7 @@ func (s *Server) showScreen(cfg *config.Config, buf *strings.Builder) {
 				return v
 			}
 			totalDrops := readCtr(dataplane.GlobalCtrScreenDrops)
-			if readErr != nil {
-				fmt.Fprintf(buf, "warning: screen counter read failed (counters unavailable): %v\n", readErr)
-			} else {
-				fmt.Fprintf(buf, "Total screen drops: %d\n", totalDrops)
-			}
+			fmt.Fprintf(buf, "Total screen drops: %d\n", totalDrops)
 			if totalDrops > 0 {
 				screenCounters := []struct {
 					idx  uint32
@@ -717,6 +713,11 @@ func (s *Server) showScreen(cfg *config.Config, buf *strings.Builder) {
 						fmt.Fprintf(buf, "  %-25s %d\n", sc.name+":", v)
 					}
 				}
+			}
+			// #3345: check AFTER all reads (incl. the per-type loop) so a
+			// failure on a late read is surfaced, not just the first.
+			if readErr != nil {
+				fmt.Fprintf(buf, "warning: screen counter read failed (counters may be incomplete): %v\n", readErr)
 			}
 		}
 	}

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -321,8 +321,14 @@ func (s *Server) showSecurityAlarms(cfg *config.Config, topic string, buf *strin
 	}
 
 	if s.dp != nil && s.dp.IsLoaded() {
+		// #3345: track a counter-read failure so a degraded counter bridge
+		// is reported as a warning rather than masquerading as "no alarms".
+		var readErr error
 		readCtr := func(idx uint32) uint64 {
-			v, _ := s.dp.ReadGlobalCounter(idx)
+			v, err := s.dp.ReadGlobalCounter(idx)
+			if err != nil && readErr == nil {
+				readErr = err
+			}
 			return v
 		}
 		screenNames := []struct {
@@ -350,6 +356,9 @@ func (s *Server) showSecurityAlarms(cfg *config.Config, topic string, buf *strin
 					fmt.Fprintf(buf, "Alarm %d:\n  Class: IDS\n  Severity: Major\n  Description: %s attack detected (%d drops)\n\n", alarmCount, sc.name, val)
 				}
 			}
+		}
+		if readErr != nil {
+			fmt.Fprintf(buf, "warning: screen counter read failed (counters may be incomplete): %v\n", readErr)
 		}
 	}
 
@@ -668,12 +677,22 @@ func (s *Server) showScreen(cfg *config.Config, buf *strings.Builder) {
 		}
 		// Per-type drop counters
 		if s.dp != nil && s.dp.IsLoaded() {
+			// #3345: surface a counter-read failure rather than printing a
+			// clean zero that hides a degraded counter bridge.
+			var readErr error
 			readCtr := func(idx uint32) uint64 {
-				v, _ := s.dp.ReadGlobalCounter(idx)
+				v, err := s.dp.ReadGlobalCounter(idx)
+				if err != nil && readErr == nil {
+					readErr = err
+				}
 				return v
 			}
 			totalDrops := readCtr(dataplane.GlobalCtrScreenDrops)
-			fmt.Fprintf(buf, "Total screen drops: %d\n", totalDrops)
+			if readErr != nil {
+				fmt.Fprintf(buf, "warning: screen counter read failed (counters unavailable): %v\n", readErr)
+			} else {
+				fmt.Fprintf(buf, "Total screen drops: %d\n", totalDrops)
+			}
 			if totalDrops > 0 {
 				screenCounters := []struct {
 					idx  uint32

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -510,10 +510,16 @@ func (s *Server) showScreenStatisticsAll(cfg *config.Config, buf *strings.Builde
 			zones = append(zones, name)
 		}
 		sort.Strings(zones)
+		// #3408: surface a per-zone flood-counter read failure as a warning
+		// AFTER all zones rather than silently dropping the zone.
+		var readErr error
 		for _, zoneName := range zones {
 			zoneID := cr.ZoneIDs[zoneName]
 			fs, err := s.dp.ReadFloodCounters(zoneID)
 			if err != nil {
+				if readErr == nil {
+					readErr = err
+				}
 				continue
 			}
 			screenProfile := ""
@@ -531,6 +537,9 @@ func (s *Server) showScreenStatisticsAll(cfg *config.Config, buf *strings.Builde
 			buf.WriteString("\n")
 		}
 		buf.WriteString(s.screenSYNCookieCounterRows())
+		if readErr != nil {
+			fmt.Fprintf(buf, "warning: flood counter read failed (screen statistics may be incomplete): %v\n", readErr)
+		}
 	}
 	return &pb.ShowTextResponse{Output: buf.String()}, nil
 }

--- a/pkg/grpcapi/server_show_status.go
+++ b/pkg/grpcapi/server_show_status.go
@@ -47,8 +47,15 @@ func (s *Server) GetGlobalStats(_ context.Context, _ *pb.GetGlobalStatsRequest) 
 	if s.dp == nil || !s.dp.IsLoaded() {
 		return nil, status.Error(codes.Unavailable, "dataplane not loaded")
 	}
+	// #3345: surface a global-counter read failure instead of silently
+	// reporting 0. A degraded counter bridge must not be indistinguishable
+	// from "no events" on the structured stats RPC.
+	var readErr error
 	readCounter := func(idx uint32) uint64 {
-		v, _ := s.dp.ReadGlobalCounter(idx)
+		v, err := s.dp.ReadGlobalCounter(idx)
+		if err != nil && readErr == nil {
+			readErr = err
+		}
 		return v
 	}
 
@@ -82,6 +89,11 @@ func (s *Server) GetGlobalStats(_ context.Context, _ *pb.GetGlobalStatsRequest) 
 		if v > 0 {
 			screenDetails[sc.name] = v
 		}
+	}
+
+	if readErr != nil {
+		return nil, status.Errorf(codes.Internal,
+			"reading global counter: %v", readErr)
 	}
 
 	return &pb.GetGlobalStatsResponse{

--- a/pkg/grpcapi/server_show_status.go
+++ b/pkg/grpcapi/server_show_status.go
@@ -91,12 +91,7 @@ func (s *Server) GetGlobalStats(_ context.Context, _ *pb.GetGlobalStatsRequest) 
 		}
 	}
 
-	if readErr != nil {
-		return nil, status.Errorf(codes.Internal,
-			"reading global counter: %v", readErr)
-	}
-
-	return &pb.GetGlobalStatsResponse{
+	resp := &pb.GetGlobalStatsResponse{
 		RxPackets:          readCounter(dataplane.GlobalCtrRxPackets),
 		TxPackets:          readCounter(dataplane.GlobalCtrTxPackets),
 		Drops:              readCounter(dataplane.GlobalCtrDrops),
@@ -110,7 +105,17 @@ func (s *Server) GetGlobalStats(_ context.Context, _ *pb.GetGlobalStatsRequest) 
 		Nat64Translations:  readCounter(dataplane.GlobalCtrNAT64Xlate),
 		HostInboundAllowed: readCounter(dataplane.GlobalCtrHostInbound),
 		ScreenDropDetails:  screenDetails,
-	}, nil
+	}
+
+	// #3345: check readErr AFTER the full struct build so EVERY global read
+	// (incl. RxPackets/HostInbound below the screen loop) is covered — a
+	// failure on any of them must not return a zero-valued field.
+	if readErr != nil {
+		return nil, status.Errorf(codes.Internal,
+			"reading global counter: %v", readErr)
+	}
+
+	return resp, nil
 }
 
 func (s *Server) GetSystemInfo(ctx context.Context, req *pb.GetSystemInfoRequest) (*pb.GetSystemInfoResponse, error) {

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"sort"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/psaab/xpf/pkg/dataplane"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 )
@@ -16,6 +19,9 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 
 	cr := s.applyResult()
 
+	// #3408: a per-zone counter read failure must surface as codes.Internal
+	// rather than a clean-zero field, mirroring GetGlobalStats (#3345).
+	var readErr error
 	resp := &pb.GetZonesResponse{}
 	for zoneName, zone := range cfg.Security.Zones {
 		zi := &pb.ZoneInfo{
@@ -45,15 +51,22 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 					if ing, err := s.dp.ReadZoneCounters(id, 0); err == nil {
 						zi.IngressPackets = ing.Packets
 						zi.IngressBytes = ing.Bytes
+					} else if readErr == nil {
+						readErr = err
 					}
 					if eg, err := s.dp.ReadZoneCounters(id, 1); err == nil {
 						zi.EgressPackets = eg.Packets
 						zi.EgressBytes = eg.Bytes
+					} else if readErr == nil {
+						readErr = err
 					}
 				}
 			}
 		}
 		resp.Zones = append(resp.Zones, zi)
+	}
+	if readErr != nil {
+		return nil, status.Errorf(codes.Internal, "reading zone counter: %v", readErr)
 	}
 	sort.Slice(resp.Zones, func(i, j int) bool { return resp.Zones[i].Name < resp.Zones[j].Name })
 	return resp, nil
@@ -71,6 +84,8 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 	// collector and the CLI/gRPC text surfaces. When the knob is off,
 	// HitPackets/HitBytes stay 0 (we skip the dataplane read).
 	statsEnabled := cfg.Security.PolicyStatsEnabled
+	// #3408: surface a per-policy counter read failure as codes.Internal.
+	var readErr error
 	resp := &pb.GetPoliciesResponse{}
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
@@ -103,6 +118,8 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			pi.Rules = append(pi.Rules, pr)
@@ -152,6 +169,8 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				if ctrs, err := s.dp.ReadPolicyCounters(policyID); err == nil {
 					pr.HitPackets = ctrs.Packets
 					pr.HitBytes = ctrs.Bytes
+				} else if readErr == nil {
+					readErr = err
 				}
 			}
 			pi.Rules = append(pi.Rules, pr)
@@ -162,6 +181,9 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 		resp.Policies = append(resp.Policies, pi)
 	}
 
+	if readErr != nil {
+		return nil, status.Errorf(codes.Internal, "reading policy counter: %v", readErr)
+	}
 	return resp, nil
 }
 

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -31,6 +31,9 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 	}
 	sort.Strings(zoneNames)
 	cr := s.applyResult()
+	// #3408: surface a per-zone counter read failure as a warning AFTER all
+	// zones rather than silently dropping the traffic-statistics block.
+	var readErr error
 	for _, name := range zoneNames {
 		zone := cfg.Security.Zones[name]
 		var zoneID uint16
@@ -70,6 +73,12 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 				buf.WriteString("  Traffic statistics:\n")
 				fmt.Fprintf(buf, "    Input:  %d packets, %d bytes\n", ingress.Packets, ingress.Bytes)
 				fmt.Fprintf(buf, "    Output: %d packets, %d bytes\n", egress.Packets, egress.Bytes)
+			} else if readErr == nil {
+				if errIn != nil {
+					readErr = errIn
+				} else {
+					readErr = errOut
+				}
 			}
 		}
 		// Policies referencing this zone
@@ -177,6 +186,9 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 			buf.WriteString("    (no policies)\n")
 		}
 		buf.WriteString("\n")
+	}
+	if readErr != nil {
+		fmt.Fprintf(buf, "warning: zone counter read failed (traffic statistics may be incomplete): %v\n", readErr)
 	}
 }
 

--- a/pkg/grpcapi/text_filter_flood_counter_error_test.go
+++ b/pkg/grpcapi/text_filter_flood_counter_error_test.go
@@ -1,0 +1,114 @@
+// #3408: the gRPC TEXT mirrors (show security policies hit-count/detail, show
+// security zones, show firewall, show security screen statistics all-zones)
+// must print a warning when a per-policy / per-zone / filter / flood counter
+// read fails, rather than rendering clean-zero / silently-omitted counts.
+//
+// FAIL-ON-REVERT: dropping the readErr capture + the trailing warning line in
+// each renderer removes the warning and the want-"warning" assertions go RED.
+package grpcapi
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// filterErrGRPCDP fails filter counter reads (config read succeeds so the
+// per-term read is reached).
+type filterErrGRPCDP struct {
+	*dataplane.Manager
+	apply *dataplane.ApplyResult
+}
+
+func (d *filterErrGRPCDP) IsLoaded() bool                          { return true }
+func (d *filterErrGRPCDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *filterErrGRPCDP) ReadFilterConfig(uint32) (dataplane.FilterConfig, error) {
+	return dataplane.FilterConfig{RuleStart: 0}, nil
+}
+func (d *filterErrGRPCDP) ReadFilterCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+// floodErrGRPCDP fails per-zone flood counter reads.
+type floodErrGRPCDP struct {
+	*dataplane.Manager
+	apply *dataplane.ApplyResult
+}
+
+func (d *floodErrGRPCDP) IsLoaded() bool                          { return true }
+func (d *floodErrGRPCDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *floodErrGRPCDP) ReadFloodCounters(uint16) (dataplane.FloodState, error) {
+	return dataplane.FloodState{}, errors.New("counter bridge degraded")
+}
+
+func TestShowPoliciesHitCountTextWarnsOnReadError(t *testing.T) {
+	s := &Server{store: newSchedulerCounterGRPCStore(t), dp: &policyZoneErrGRPCDP{Manager: dataplane.New()}}
+	var buf strings.Builder
+	s.showPoliciesHitCount("", &buf)
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showPoliciesHitCount text lacks a counter-read warning; got:\n%s", buf.String())
+	}
+}
+
+func TestShowPoliciesDetailTextWarnsOnReadError(t *testing.T) {
+	s := &Server{store: newSchedulerCounterGRPCStore(t), dp: &policyZoneErrGRPCDP{Manager: dataplane.New()}}
+	var buf strings.Builder
+	s.showPoliciesDetail("", &buf)
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showPoliciesDetail text lacks a counter-read warning; got:\n%s", buf.String())
+	}
+}
+
+func TestShowZonesDetailTextWarnsOnReadError(t *testing.T) {
+	store := newSchedulerCounterGRPCStore(t)
+	s := &Server{
+		store: store,
+		dp: &policyZoneErrGRPCDP{
+			Manager: dataplane.New(),
+			apply:   &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2, "dmz": 3}},
+		},
+	}
+	var buf strings.Builder
+	s.showZonesDetail(store.ActiveConfig(), &buf)
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showZonesDetail text lacks a counter-read warning; got:\n%s", buf.String())
+	}
+}
+
+func TestShowFirewallTextWarnsOnReadError(t *testing.T) {
+	store := newFirewallFilterShowStore(t)
+	s := &Server{
+		store: store,
+		dp: &filterErrGRPCDP{
+			Manager: dataplane.New(),
+			apply: &dataplane.ApplyResult{FilterIDs: map[string]uint32{
+				"inet:bandwidth-output": 0, "inet6:bandwidth-output": 100,
+			}},
+		},
+	}
+	var buf strings.Builder
+	s.showFirewall(store.ActiveConfig(), &buf)
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showFirewall text lacks a filter counter-read warning; got:\n%s", buf.String())
+	}
+}
+
+func TestShowScreenStatisticsAllTextWarnsOnReadError(t *testing.T) {
+	store := newSchedulerCounterGRPCStore(t)
+	s := &Server{
+		store: store,
+		dp: &floodErrGRPCDP{
+			Manager: dataplane.New(),
+			apply:   &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2, "dmz": 3}},
+		},
+	}
+	var buf strings.Builder
+	if _, err := s.showScreenStatisticsAll(store.ActiveConfig(), &buf); err != nil {
+		t.Fatalf("showScreenStatisticsAll() error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "warning") {
+		t.Fatalf("showScreenStatisticsAll text lacks a flood counter-read warning; got:\n%s", buf.String())
+	}
+}

--- a/pkg/grpcapi/zones_policies_counter_error_test.go
+++ b/pkg/grpcapi/zones_policies_counter_error_test.go
@@ -1,0 +1,69 @@
+// #3408: gRPC structured GetZones / GetPolicies must fail with codes.Internal
+// when a per-zone / per-policy counter read fails, rather than returning
+// clean-zero counter fields — the same contract as GetGlobalStats (#3345).
+//
+// FAIL-ON-REVERT: restoring the `err == nil` swallow (dropping the readErr
+// capture + the codes.Internal return) makes both RPCs return a non-error
+// zero-counter response and the want-Internal assertions go RED.
+package grpcapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+type policyZoneErrGRPCDP struct {
+	*dataplane.Manager
+	apply *dataplane.ApplyResult
+}
+
+func (d *policyZoneErrGRPCDP) IsLoaded() bool { return true }
+
+func (d *policyZoneErrGRPCDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+
+func (d *policyZoneErrGRPCDP) ReadPolicyCounters(uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+func (d *policyZoneErrGRPCDP) ReadZoneCounters(uint16, int) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("counter bridge degraded")
+}
+
+func TestGetPoliciesFailsOnCounterReadError(t *testing.T) {
+	// newSchedulerCounterGRPCStore enables policy-stats + has counted policies,
+	// so a per-policy read is attempted.
+	s := &Server{store: newSchedulerCounterGRPCStore(t), dp: &policyZoneErrGRPCDP{Manager: dataplane.New()}}
+
+	_, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err == nil {
+		t.Fatal("GetPolicies returned nil error on policy counter read failure; want codes.Internal")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetPolicies error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}
+
+func TestGetZonesFailsOnCounterReadError(t *testing.T) {
+	s := &Server{
+		store: newSchedulerCounterGRPCStore(t),
+		dp: &policyZoneErrGRPCDP{
+			Manager: dataplane.New(),
+			apply:   &dataplane.ApplyResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2, "dmz": 3}},
+		},
+	}
+
+	_, err := s.GetZones(context.Background(), &pb.GetZonesRequest{})
+	if err == nil {
+		t.Fatal("GetZones returned nil error on zone counter read failure; want codes.Internal")
+	}
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("GetZones error code = %v, want Internal; err: %v", status.Code(err), err)
+	}
+}


### PR DESCRIPTION
Closes #3345
Closes #3408

## Problem
Every surface reading dataplane counters discarded the read error and reported `0`, so a degraded userspace shim / counter bridge was indistinguishable from "no events". For a security appliance, "counter unavailable" and "zero attacks/hits" must not look identical. This applies to **global**, **per-zone**, **per-policy**, **screen-flood**, and **filter** counters.

## Contract (uniform across surfaces; check AFTER all reads so late reads are covered)
- **REST**: `/stats/global`, `/security/zones`, `/security/policies` return HTTP 500 on a read failure.
- **gRPC structured**: `GetGlobalStats`, `GetZones`, `GetPolicies` return `codes.Internal`.
- **Prometheus** (`metrics_counters.go`): OMITS the affected sample (global/zone/policy/filter) instead of emitting a misleading `0`, and bumps the monotonic `xpf_counter_read_errors_total` scrape-error counter (always emitted, 0 when healthy, for alerting).
- **Text (CLI + gRPC mirrors)**: print a `warning: ... counter read failed ...` line instead of a clean zero — `show security flow statistics`, `show security screen` / `screen statistics`, `show security alarms`, `show chassis cluster fabric statistics`, `show security nat source`, `show security policies hit-count`/brief/detail, `show security zones`, `show firewall filter`.

**Ordering invariant**: the `readErr` check runs after all counter reads in each multi-read renderer (incl. per-type screen-breakdown and per-policy/per-zone loops), so a failure on a LATE read is surfaced rather than printing a stale `0` under an earlier passed check. Structured APIs check after the full response is built.

**Out of scope** (kept as-is): per-interface and NAT-rule/port counters are not security counters.

## Tests (RED-on-revert per surface, each verified)
- `pkg/api/stats_counter_error_test.go` + `zones_policies_counter_error_test.go` — REST 500 + Prometheus skip/error-count (global, zone, policy).
- `pkg/grpcapi/global_stats_counter_error_test.go` (incl. late-read ordering) + `flow_cluster_counter_error_test.go` + `zones_policies_counter_error_test.go` — `codes.Internal` + text warnings.
- `pkg/cli/show_security_counter_error_test.go` — CLI warnings incl. late-read ordering cases.

`go build ./...` and `go test ./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi