### PR TITLE
Closes #3349: validate security log stream/top-level fields

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22847,3 +22847,15 @@ top.
     pkg/config/schema_validators.go, pkg/config/compiler.go,
     pkg/config/compiler_security.go,
     pkg/config/log_stream_config_3349_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3349 fold (Codex MAJOR) — event-mode log format silent
+    fallback. Top-level `security log format` feeds the event-mode
+    LocalLogWriter which only honors binary/standard text, so structured/
+    sd-syslog validated then silently fell back. Added cross-field
+    validateLogEventModeFormatStrict (strict commit / lenient load),
+    event-mode format support matrix in docs, tests, filed follow-up #3409
+    for event-mode structured/sd-syslog support.
+  - **File(s)**: pkg/config/compiler_validate_strict.go,
+    pkg/config/compiler.go,
+    pkg/config/log_stream_config_3349_test.go, docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22833,3 +22833,17 @@ top.
   - **File(s)**: pkg/config/compiler_applications.go,
     pkg/config/compiler_application_destport_names_3340_test.go,
     pkg/config/README.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3349 — validate security log stream/top-level fields that
+    were parsed but committed without enum/range validation (audit fail-open).
+    Typed schema leaves for mode/format/severity/facility/category/
+    source-address/source-interface (strict-commit / lenient-load via
+    SchemaValidate); new ValidateSyslogSourceInterface for non-numeric units;
+    new validateSecurityLogStreamPortsAST compiler pass for the dual-location
+    port (direct + nested host{port}), strict on commit / lenient on load.
+    Enum sets pinned to pkg/logging parsers. Added RED-on-revert tests.
+  - **File(s)**: pkg/config/schema_security.go,
+    pkg/config/schema_validators.go, pkg/config/compiler.go,
+    pkg/config/compiler_security.go,
+    pkg/config/log_stream_config_3349_test.go, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -859,6 +859,33 @@ reserved for whole-dataplane selection where a rewrite shim
   parity but not yet used to alter the emitted structured-data field set.
   Regression coverage: `pkg/config/log_profile_test.go` +
   `pkg/config/log_profile_schema_test.go`.
+- **#3349 (security log stream/top-level field validation):** the remaining
+  `security log` leaves were untyped (`children: nil`, no `valueType`), so a
+  typo committed cleanly and then silently widened / remapped / fell back at
+  runtime — a fail-open for an audit path. Typed as enum/value schema leaves
+  (validated by `SchemaValidate`, strict on commit / commit-check, downgraded
+  to a warning on the tolerant load / peer-sync paths exactly like every other
+  typed leaf): `security log mode` (`stream|event`), `format` and `stream
+  <s> format` (`sd-syslog|syslog|binary|structured`), `stream <s> severity`
+  (`error|warning|info`, matching `pkg/logging` `ParseSeverity`), `facility`
+  (the `ParseFacility` set incl. `local0..7`/`change-log`), `category`
+  (`all|session|policy|screen|firewall`, matching `ParseCategory`), and
+  `source-address` (`ValueIPAddress`). `source-interface` uses
+  `ValidateSyslogSourceInterface`, which rejects a non-numeric `.<unit>`
+  suffix (`resolveSourceAddr` silently `Atoi`-fell-back to unit 0, binding the
+  wrong source IP). The enum value sets live in `schema_security.go`
+  (`syslogLogModes`/`syslogLogFormats`/`syslogSeverities`/`syslogFacilities`/
+  `syslogCategories`) and MUST stay in sync with those `pkg/logging` parsers —
+  a value the validator allows but the runtime does not recognize would
+  reintroduce the silent-fallback bug. **Port** (`stream <s> port` AND the
+  nested `host { port }`) is range-checked `[1..65535]` by the
+  `validateSecurityLogStreamPortsAST` compiler pass instead of a schema leaf,
+  because the value has two AST locations the declarative schema walker cannot
+  express — the same dual-location rationale as `tcp-mss`
+  (`validateTCPMSSRanges`); strict on commit, `lenientLogStreamPort`-downgraded
+  to a warning on load/peer-sync. Before this change a bad port was ignored by
+  `compileLog` and silently kept the default 514. No runtime/dataplane change.
+  Regression coverage: `pkg/config/log_stream_config_3349_test.go`.
 - **#2008 H9/H10 (interface silent-drop reject):** two interface stanzas
   that parsed-accepted and were silently dropped (no schema child, no
   compiler case, no dataplane consumer) are now hard-rejected at commit /

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -886,6 +886,31 @@ reserved for whole-dataplane selection where a rewrite shim
   to a warning on load/peer-sync. Before this change a bad port was ignored by
   `compileLog` and silently kept the default 514. No runtime/dataplane change.
   Regression coverage: `pkg/config/log_stream_config_3349_test.go`.
+
+  **Event-mode format compatibility (cross-field).** The top-level
+  `security log format` value feeds two different runtimes depending on
+  `security log mode`, and they honor different format sets. The schema leaf
+  validates the value to a known format in *any* mode; a second compiler pass
+  (`validateLogEventModeFormatStrict`, post-compile on `cfg.Security.Log`,
+  strict on commit / `lenientLogEventModeFormat`-downgraded on load/peer-sync)
+  rejects an event-mode-incompatible format because the event-mode local-file
+  writer (`pkg/logging` `LocalLogWriter`, driven by the `ringbuf.go`
+  local-writer fanout) only branches on `binary` and otherwise writes standard
+  text — so `structured` / `sd-syslog` would validate at commit and then
+  silently fall back to text (the exact #3349 failure). Support matrix:
+
+  | `format` | `mode stream` (remote syslog) | `mode event` (local file) |
+  |---|---|---|
+  | `binary` | binary records | binary records |
+  | `structured` | Junos RT_FLOW | **rejected at commit** (silently fell back to text) |
+  | `sd-syslog` | RFC 5424 envelope | **rejected at commit** (silently fell back to text) |
+  | `syslog` / unset | standard RFC 3164 text | standard RFC 3164 text |
+
+  Event-mode `structured` / `sd-syslog` is a feature gap, not a deliberate
+  exclusion — tracked in #3409 (widen the event-honorable set once the
+  `LocalLogWriter` implements those formats). The event-honorable set in
+  `validateLogEventModeFormatStrict` MUST stay in sync with the `ringbuf.go`
+  local-writer fanout.
 - **#2008 H9/H10 (interface silent-drop reject):** two interface stanzas
   that parsed-accepted and were silently dropped (no schema child, no
   compiler case, no dataplane consumer) are now hard-rejected at commit /

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -107,6 +107,18 @@ type compileOpts struct {
 	// SchemaValidate (tcp-mss stays opaque there).
 	lenientTCPMSSRange bool
 
+	// lenientLogStreamPort (#3349) downgrades the security-log stream port
+	// range gate (validateSecurityLogStreamPortsAST) from a hard compile
+	// error to a cfg.Warnings entry. Set ONLY on the tolerant load /
+	// peer-sync paths: a persisted or peer-synced config carrying a
+	// non-numeric / out-of-range `stream port` (or nested `host { port }`)
+	// that an older binary accepted — and that the compiler still maps to the
+	// default 514 — must still boot, not blackout the upgraded node (#1960
+	// fail-closed-on-load class). Like the tcp-mss gate this is an AST-level
+	// compile decision (the port value can live in two positions) and so does
+	// NOT live in SchemaValidate. Same doctrine as lenientTCPMSSRange.
+	lenientLogStreamPort bool
+
 	// lenientNATPoolAlarmThreshold (#2079) downgrades the
 	// security-nat-source pool-utilization-alarm threshold gate
 	// (validatePoolUtilizationAlarm) from a hard compile error to a
@@ -1085,6 +1097,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientDeviceMap:                     true,
 		lenientPolicyMatchAddress:            true,
 		lenientTCPMSSRange:                   true,
+		lenientLogStreamPort:                 true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
 		lenientIPsecGatewayRefs:              true,
@@ -1222,6 +1235,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientDeviceMap:                     true,
 		lenientPolicyMatchAddress:            true,
 		lenientTCPMSSRange:                   true,
+		lenientLogStreamPort:                 true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
 		lenientIPsecGatewayRefs:              true,
@@ -1359,6 +1373,19 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// Lenient (load / peer-sync): warn + let Layer A coerce so an upgraded
 	// node loading a legacy out-of-range MSS still boots.
 	mssWarnings, err := validateTCPMSSRanges(tree.Children, "", opts.lenientTCPMSSRange)
+	if err != nil {
+		return nil, err
+	}
+
+	// #3349 security-log stream port range gate. The syslog port lives in two
+	// AST locations (direct `stream port` and nested `host { port }`) that the
+	// declarative SchemaValidate walker cannot express, so — like tcp-mss — it
+	// is range-checked here on the group-expanded tree, BEFORE compileLog
+	// swallows a bad value and silently keeps the default 514. Strict (commit
+	// / commit-check): a non-numeric / out-of-range port hard-rejects. Lenient
+	// (load / peer-sync): warn so an already-persisted or peer-synced config
+	// still boots.
+	logStreamPortWarnings, err := validateSecurityLogStreamPortsAST(tree.Children, "", opts.lenientLogStreamPort)
 	if err != nil {
 		return nil, err
 	}
@@ -1533,6 +1560,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, ctrlCharWarnings...)
 	cfg.Warnings = append(cfg.Warnings, trackWarnings...)
 	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
+	cfg.Warnings = append(cfg.Warnings, logStreamPortWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMatchWarnings...)

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -119,6 +119,17 @@ type compileOpts struct {
 	// NOT live in SchemaValidate. Same doctrine as lenientTCPMSSRange.
 	lenientLogStreamPort bool
 
+	// lenientLogEventModeFormat (#3349) downgrades the event-mode log-format
+	// compatibility gate (validateLogEventModeFormatStrict) from a hard
+	// compile error to a cfg.Warnings entry. Set ONLY on the tolerant load /
+	// peer-sync paths: a persisted or peer-synced config carrying
+	// `mode event; format structured|sd-syslog` (which an older binary
+	// accepted and the event writer silently renders as standard text) must
+	// still boot, not blackout the upgraded node (#1960 fail-closed-on-load
+	// class). The runtime already falls back, so a leniently-loaded value is
+	// inert. Same doctrine as lenientLogProfileStreamRef.
+	lenientLogEventModeFormat bool
+
 	// lenientNATPoolAlarmThreshold (#2079) downgrades the
 	// security-nat-source pool-utilization-alarm threshold gate
 	// (validatePoolUtilizationAlarm) from a hard compile error to a
@@ -1098,6 +1109,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyMatchAddress:            true,
 		lenientTCPMSSRange:                   true,
 		lenientLogStreamPort:                 true,
+		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
 		lenientIPsecGatewayRefs:              true,
@@ -1236,6 +1248,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyMatchAddress:            true,
 		lenientTCPMSSRange:                   true,
 		lenientLogStreamPort:                 true,
+		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
 		lenientIPsecGatewayRefs:              true,
@@ -2394,6 +2407,24 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientLogProfileStreamRef {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("security log profile stream reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3349 follow-up: event-mode log-format compatibility. The top-level
+	// `security log format` is schema-validated to a known format in any mode,
+	// but the EVENT-mode local-file writer only honors binary / standard text
+	// — `structured` and `sd-syslog` silently fall back to standard text. That
+	// silent no-op is the exact failure #3349 closes, so reject an
+	// event-incompatible format at commit (cross-field rule the per-leaf
+	// SchemaValidate gate cannot express). Strict on commit / commit-check;
+	// lenient on load / peer-sync (warn — the runtime already falls back, so a
+	// leniently-loaded value is inert rather than bricking the load).
+	if err := validateLogEventModeFormatStrict(cfg); err != nil {
+		if opts.lenientLogEventModeFormat {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("security log event-mode format (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -1179,6 +1179,78 @@ func compileLog(node *Node, sec *SecurityConfig) error {
 	return nil
 }
 
+// validateSecurityLogStreamPortsAST is the #3349 commit-time range gate for
+// `security log stream <s> port <p>` and the nested `host { port <p>; }`
+// spelling. The syslog port value lives in TWO AST locations — a direct
+// `port` child of the stream and a `port` child of a nested `host` block
+// (compileLog reads both) — a dual value-location the declarative
+// SchemaValidate walker cannot express, the same rationale as tcp-mss
+// (validateTCPMSSRanges). compileLog ignores a non-numeric or out-of-range
+// port (strconv.Atoi error path) and silently keeps the default 514, so a typo
+// such as `port 6514x` commits and quietly logs audit to the wrong port. This
+// pass reads the raw tokens before that swallowing and range-checks them.
+//
+// It mirrors compileLog's traversal exactly (FindChild("log") +
+// namedInstances(stream) + per-child switch on host/port) so it validates
+// precisely the tokens the compiler consumes. Runs on the group-expanded tree
+// so apply-groups-inherited ports are covered.
+//
+// Strict path (commit / commit-check, lenient=false): a non-numeric or
+// out-of-range port is a hard compile error. Lenient path (load / peer-sync,
+// lenient=true): downgraded to a warning so an already-persisted or
+// peer-synced config that an older binary accepted (and that the compiler
+// still maps to 514) still boots (#1960 / #3261 fail-closed-on-load class).
+func validateSecurityLogStreamPortsAST(nodes []*Node, prefix string, lenient bool) ([]string, error) {
+	var warnings []string
+	check := func(path, raw string) error {
+		if raw == "" {
+			// No value token: the compiler keeps the default 514. The
+			// missing-value case is the schema walker's concern, not this
+			// range gate.
+			return nil
+		}
+		if n, err := strconv.Atoi(raw); err == nil && n >= 1 && n <= 65535 {
+			return nil
+		}
+		msg := fmt.Sprintf("%s: invalid syslog port %q (expected an integer in "+
+			"[1..65535]; an invalid value silently keeps the default 514)", path, raw)
+		if lenient {
+			warnings = append(warnings, msg)
+			return nil
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	for _, n := range nodes {
+		if n.Name() != "security" {
+			continue
+		}
+		secPath := joinNodePath(prefix, n.Keys)
+		for _, logNode := range n.FindChildren("log") {
+			logPath := joinNodePath(secPath, []string{"log"})
+			for _, inst := range namedInstances(logNode.FindChildren("stream")) {
+				streamPath := joinNodePath(logPath, []string{"stream", inst.name})
+				for _, prop := range inst.node.Children {
+					switch prop.Name() {
+					case "port":
+						if err := check(joinNodePath(streamPath, []string{"port"}), nodeVal(prop)); err != nil {
+							return warnings, err
+						}
+					case "host":
+						for _, hc := range prop.Children {
+							if hc.Name() == "port" {
+								if err := check(joinNodePath(streamPath, []string{"host", "port"}), nodeVal(hc)); err != nil {
+									return warnings, err
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return warnings, nil
+}
+
 // tcpMSSKinds are the four tcp-mss sub-kinds the compiler reads
 // (compileFlow MSS switch). Each carries a u16 MSS value that lands in a
 // Rust u16 wire field (TCPMSS{IPsecVPN,GreIn,GreOut}; all-tcp fans out into

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -9,6 +9,58 @@ import (
 	"strings"
 )
 
+// validateLogEventModeFormatStrict rejects a top-level `security log format`
+// that the EVENT-mode writer cannot honor (#3349 follow-up). The top-level
+// format leaf is schema-validated to one of {binary, sd-syslog, structured,
+// syslog} regardless of mode, but the value feeds two different runtimes:
+//
+//   - stream mode (remote syslog): honors binary (formatBinaryRecord),
+//     structured (formatStructuredMsg), sd-syslog (RFC 5424 envelope in
+//     SyslogClient.Send), and the standard RFC 3164 default — all four.
+//   - event mode (local file, pkg/logging LocalLogWriter via
+//     ringbuf.go ProcessRawEvent local-writer fanout): branches ONLY on
+//     `binary`; every other value writes standard text. So `structured`
+//     and `sd-syslog` SILENTLY fall back to standard text — the exact
+//     silent-config-fallback #3349 exists to eliminate, on the new typed
+//     surface.
+//
+// This is a CROSS-FIELD rule (format validity depends on the sibling mode),
+// which the declarative per-leaf SchemaValidate walker cannot express, so it
+// lives here as a post-compile pass on cfg.Security.Log. When mode is event,
+// only the event-honorable formats are accepted; structured / sd-syslog are
+// rejected at commit instead of silently no-opping. Event-mode structured /
+// sd-syslog support is a feature gap tracked separately (see the follow-up
+// issue cited in docs/config-schema.md); restricting the enum here is the
+// fail-closed half.
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientLogEventModeFormat) so an already-persisted or
+// peer-synced config that an older binary accepted still boots — the runtime
+// already falls back to standard text, so a leniently-loaded value is inert
+// rather than bricking the load (#1960 / #3261). Commit / commit-check stay
+// strict. Mirrors validateLogProfileStreamReferencesStrict.
+//
+// The event-honorable set MUST stay in sync with the LocalLogWriter fanout in
+// pkg/logging/ringbuf.go (binary branch + standard-text default): a value
+// allowed here but unhonored there reintroduces the silent fallback.
+func validateLogEventModeFormatStrict(cfg *Config) error {
+	if cfg == nil || cfg.Security.Log.Mode != "event" {
+		return nil
+	}
+	switch cfg.Security.Log.Format {
+	case "", "binary", "syslog":
+		// "" / "syslog" => standard RFC 3164 text (what the writer produces
+		// and what the operator named); "binary" => binary records. All
+		// honored by the event-mode LocalLogWriter.
+		return nil
+	default:
+		return fmt.Errorf("security log format %q is not honored in event mode "+
+			"(the local-file writer only emits binary or standard text); use "+
+			"`binary` or `syslog`, or switch to `mode stream` for structured / "+
+			"sd-syslog output", cfg.Security.Log.Format)
+	}
+}
+
 func validateThreeColorPolicersStrict(policers map[string]*ThreeColorPolicerConfig) error {
 	for name, pol := range policers {
 		if pol == nil {

--- a/pkg/config/log_stream_config_3349_test.go
+++ b/pkg/config/log_stream_config_3349_test.go
@@ -1,0 +1,165 @@
+package config_test
+
+// #3349: security log stream / top-level log field validation. Before this
+// change each of these sub-fields committed cleanly with a typo and then
+// silently widened, remapped, or fell back at runtime (audit fail-open):
+//   - category typo  -> 0 = no filter = send ALL categories
+//   - severity typo  -> 0 = no floor  = send ALL severities
+//   - facility typo  -> silently remapped to local0
+//   - port typo      -> strconv.Atoi error ignored -> stays 514
+//   - source-address invalid -> stream silently dropped at apply
+//   - source-interface non-numeric unit -> wrong source IP (unit 0)
+//   - mode/format typo -> silent fallback
+//
+// The enum/value fields are now typed schema leaves (validated by
+// SchemaValidate, the commit-check gate) and port is validated by the
+// validateSecurityLogStreamPortsAST compiler pass. Each test below is
+// RED-on-revert: removing the validator makes the bad value pass.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func buildTree3349(t *testing.T, cmds ...string) *config.ConfigTree {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// schemaCheck3349 runs the commit-check typed-leaf gate over a flat-set config.
+func schemaCheck3349(t *testing.T, cmds ...string) error {
+	t.Helper()
+	return config.SchemaValidate(buildTree3349(t, cmds...), nil)
+}
+
+// TestLogStream3349_SchemaFields_RejectTypos asserts every typed log field
+// rejects a bad value at commit (was silently accepted before #3349).
+func TestLogStream3349_SchemaFields_RejectTypos(t *testing.T) {
+	bad := map[string][]string{
+		"category":         {"set security log stream s host 192.0.2.1", "set security log stream s category sesion"},
+		"severity":         {"set security log stream s host 192.0.2.1", "set security log stream s severity wraning"},
+		"facility":         {"set security log stream s host 192.0.2.1", "set security log stream s facility locl0"},
+		"stream-format":    {"set security log stream s host 192.0.2.1", "set security log stream s format sdsyslog"},
+		"source-address":   {"set security log stream s host 192.0.2.1", "set security log stream s source-address not-an-ip"},
+		"mode":             {"set security log mode steam"},
+		"format":           {"set security log format sdsyslog"},
+		"source-interface": {"set security log source-interface reth1.abc"},
+	}
+	for name, cmds := range bad {
+		t.Run(name, func(t *testing.T) {
+			if err := schemaCheck3349(t, cmds...); err == nil {
+				t.Fatalf("expected commit rejection for %v, got nil (field silently accepted)", cmds)
+			}
+		})
+	}
+}
+
+// TestLogStream3349_SchemaFields_AcceptValid asserts a fully-valid stanza
+// commits cleanly — the validators must not reject legitimate config.
+func TestLogStream3349_SchemaFields_AcceptValid(t *testing.T) {
+	good := []string{
+		"set security log mode stream",
+		"set security log format sd-syslog",
+		"set security log source-interface ge-0-0-0",
+		"set security log stream s host 192.0.2.1",
+		"set security log stream s category session",
+		"set security log stream s severity warning",
+		"set security log stream s facility local7",
+		"set security log stream s format structured",
+		"set security log stream s source-address 2001:db8::1",
+		"set security log stream s2 host 10.0.0.2",
+		"set security log stream s2 source-interface reth1.100",
+	}
+	if err := schemaCheck3349(t, good...); err != nil {
+		t.Fatalf("valid log config rejected: %v", err)
+	}
+	// And it must actually compile (strict).
+	if _, err := config.CompileConfig(buildTree3349(t, good...)); err != nil {
+		t.Fatalf("valid log config failed strict compile: %v", err)
+	}
+}
+
+// TestLogStream3349_Port_StrictReject covers the port range gate
+// (validateSecurityLogStreamPortsAST) for both the direct `stream port` and
+// the nested `host { port }` spellings. A non-numeric or out-of-range port
+// previously committed and silently stayed 514.
+func TestLogStream3349_Port_StrictReject(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{"direct-nonnumeric", []string{"set security log stream s host 192.0.2.1", "set security log stream s port 6514x"}},
+		{"direct-zero", []string{"set security log stream s host 192.0.2.1", "set security log stream s port 0"}},
+		{"direct-overrange", []string{"set security log stream s host 192.0.2.1", "set security log stream s port 70000"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := config.CompileConfig(buildTree3349(t, tc.cmds...))
+			if err == nil {
+				t.Fatalf("expected strict compile rejection for %v, got nil", tc.cmds)
+			}
+			if !strings.Contains(err.Error(), "port") {
+				t.Fatalf("error should mention port, got %v", err)
+			}
+		})
+	}
+}
+
+// TestLogStream3349_Port_NestedHostReject covers the Junos-canonical nested
+// host{port} location parsed hierarchically.
+func TestLogStream3349_Port_NestedHostReject(t *testing.T) {
+	const cfg = `security {
+		log {
+			stream s {
+				host {
+					192.0.2.1;
+					port 6514x;
+				}
+			}
+		}
+	}`
+	p := config.NewParser(cfg)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := config.CompileConfig(tree); err == nil {
+		t.Fatalf("expected strict compile rejection for nested host{port 6514x}, got nil")
+	}
+}
+
+// TestLogStream3349_Port_LenientWarns proves the #1960/#3261 doctrine: an
+// already-persisted/peer-synced config carrying a bad port must NOT brick the
+// load — it is downgraded to a warning and still compiles.
+func TestLogStream3349_Port_LenientWarns(t *testing.T) {
+	tree := buildTree3349(t,
+		"set security log stream s host 192.0.2.1",
+		"set security log stream s port 6514x",
+	)
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on a bad port, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "port") && strings.Contains(w, "6514x") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a lenient warning about the bad port, warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/log_stream_config_3349_test.go
+++ b/pkg/config/log_stream_config_3349_test.go
@@ -140,6 +140,69 @@ func TestLogStream3349_Port_NestedHostReject(t *testing.T) {
 	}
 }
 
+// TestLogStream3349_EventModeFormat covers the cross-field event-mode format
+// compatibility gate (validateLogEventModeFormatStrict). The top-level format
+// schema-validates to a known format in any mode, but the event-mode
+// LocalLogWriter only honors binary / standard text — structured / sd-syslog
+// silently fall back to text, the exact silent no-op #3349 closes.
+func TestLogStream3349_EventModeFormat(t *testing.T) {
+	reject := map[string][]string{
+		"event-structured": {"set security log mode event", "set security log format structured"},
+		"event-sd-syslog":  {"set security log mode event", "set security log format sd-syslog"},
+	}
+	for name, cmds := range reject {
+		t.Run("reject/"+name, func(t *testing.T) {
+			_, err := config.CompileConfig(buildTree3349(t, cmds...))
+			if err == nil {
+				t.Fatalf("expected strict compile rejection for %v, got nil", cmds)
+			}
+			if !strings.Contains(err.Error(), "event mode") {
+				t.Fatalf("error should explain event-mode incompatibility, got %v", err)
+			}
+		})
+	}
+	accept := map[string][]string{
+		"event-binary":       {"set security log mode event", "set security log format binary"},
+		"event-syslog":       {"set security log mode event", "set security log format syslog"},
+		"event-no-format":    {"set security log mode event"},
+		"stream-structured":  {"set security log mode stream", "set security log format structured"},
+		"stream-sd-syslog":   {"set security log mode stream", "set security log format sd-syslog"},
+		"default-structured": {"set security log format structured"}, // no mode => stream default
+	}
+	for name, cmds := range accept {
+		t.Run("accept/"+name, func(t *testing.T) {
+			if _, err := config.CompileConfig(buildTree3349(t, cmds...)); err != nil {
+				t.Fatalf("expected %v to compile, got %v", cmds, err)
+			}
+		})
+	}
+}
+
+// TestLogStream3349_EventModeFormat_LenientWarns proves the #1960/#3261
+// doctrine for the event-mode format gate: a persisted/peer-synced
+// `mode event; format structured` must NOT brick the load — it is downgraded
+// to a warning and still compiles (the runtime already falls back to text).
+func TestLogStream3349_EventModeFormat_LenientWarns(t *testing.T) {
+	tree := buildTree3349(t,
+		"set security log mode event",
+		"set security log format structured",
+	)
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on event-mode structured, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "event-mode format") && strings.Contains(w, "structured") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a lenient warning about event-mode format, warnings=%v", cfg.Warnings)
+	}
+}
+
 // TestLogStream3349_Port_LenientWarns proves the #1960/#3261 doctrine: an
 // already-persisted/peer-synced config carrying a bad port must NOT brick the
 // load — it is downgraded to a warning and still compiles.

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -8,6 +8,35 @@ package config
 // in-package by schema_complete.go / schema_walk.go (two-SSOT doctrine,
 // #1319).
 
+// Security-log enum value sets (#3349). Each MUST stay in sync with the
+// corresponding runtime consumer so the commit-time validator accepts
+// exactly the set the runtime applies — a value the validator allows but the
+// runtime does not recognize would reintroduce the same silent-fallback bug
+// the validator exists to close.
+//
+//   - syslogLogModes:   pkg/daemon/daemon_system.go (Mode == "event" enters
+//     event mode; anything else is stream mode).
+//   - syslogLogFormats: pkg/logging (syslog.go "sd-syslog" timestamp branch,
+//     ringbuf.go "binary"/"structured" branches; "syslog"/"" => RFC 3164).
+//   - syslogSeverities: pkg/logging ParseSeverity (error/warning/info map to
+//     a floor; everything else => 0 = no floor).
+//   - syslogFacilities: pkg/logging ParseFacility (recognized names; every
+//     other name silently remaps to local0).
+//   - syslogCategories: pkg/logging ParseCategory (all/session/policy/screen/
+//     firewall; every other name => 0 = no filter = send ALL).
+var (
+	syslogLogModes   = []string{"event", "stream"}
+	syslogLogFormats = []string{"binary", "sd-syslog", "structured", "syslog"}
+	syslogSeverities = []string{"error", "info", "warning"}
+	syslogFacilities = []string{
+		"auth", "change-log", "daemon", "kern",
+		"local0", "local1", "local2", "local3",
+		"local4", "local5", "local6", "local7",
+		"syslog", "user",
+	}
+	syslogCategories = []string{"all", "firewall", "policy", "screen", "session"}
+)
+
 var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[string]*schemaNode{
 	"zones": {desc: "Security zones", children: map[string]*schemaNode{
 		"security-zone": {desc: "Security zone name", args: 1, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: map[string]*schemaNode{
@@ -305,17 +334,53 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		}},
 	}},
 	"log": {desc: "Security logging configuration", children: map[string]*schemaNode{
-		"mode":             {desc: "Logging mode (stream|event)", args: 1, placeholder: "<mode>", children: nil},
-		"format":           {desc: "Log format (sd-syslog|syslog|binary|structured)", args: 1, placeholder: "<format>", children: nil},
-		"source-interface": {desc: "Interface whose address is used as the syslog source", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
+		// #3349: typed enum/value leaves so a typo (`mode steam`,
+		// `format sdsyslog`, `severity wraning`, `facility locl0`,
+		// `category sesion`, a non-numeric source-interface unit) fails the
+		// commit instead of silently falling back at runtime (mode->stream,
+		// format->RFC3164, severity->0=no floor, facility->local0,
+		// category->0=all). Enum sets are pinned to the runtime parsers in
+		// pkg/logging (daemon_system.go applyLogStreams + ParseSeverity /
+		// ParseFacility / ParseCategory); keep in sync if those change.
+		"mode": {desc: "Logging mode (stream|event)", args: 1, placeholder: "<mode>",
+			valueType: ValueEnumOf, valueDesc: "security log mode",
+			valueExamples: []string{"stream", "event"},
+			validator:     ValidateEnum(syslogLogModes), children: nil},
+		"format": {desc: "Log format (sd-syslog|syslog|binary|structured)", args: 1, placeholder: "<format>",
+			valueType: ValueEnumOf, valueDesc: "security log format",
+			valueExamples: []string{"sd-syslog", "syslog", "binary", "structured"},
+			validator:     ValidateEnum(syslogLogFormats), children: nil},
+		"source-interface": {desc: "Interface whose address is used as the syslog source", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>",
+			valueType: ValueIdentifier, valueDesc: "interface name (optionally .<unit>)",
+			valueExamples: []string{"ge-0-0-0", "reth1.100"},
+			validator:     ValidateSyslogSourceInterface, children: nil},
 		"stream": {desc: "Syslog stream name", args: 1, valueHint: ValueHintStreamName, placeholder: "<stream-name>", children: map[string]*schemaNode{
-			"host":           {desc: "Syslog server address", args: 1, placeholder: "<address>", children: nil},
-			"port":           {desc: "Syslog server port (default 514)", args: 1, placeholder: "<port>", children: nil},
-			"severity":       {desc: "Severity filter (error|warning|info)", args: 1, placeholder: "<severity>", children: nil},
-			"facility":       {desc: "Syslog facility (e.g. local0; default local0)", args: 1, placeholder: "<facility>", children: nil},
-			"format":         {desc: "Per-stream format override", args: 1, placeholder: "<format>", children: nil},
-			"category":       {desc: "Event category filter (all or a specific category)", args: 1, placeholder: "<category>", children: nil},
-			"source-address": {desc: "Source IP for this stream", args: 1, placeholder: "<address>", children: nil},
+			"host": {desc: "Syslog server address", args: 1, placeholder: "<address>", children: nil},
+			// `port` validation (direct AND nested host{port}) lives in the
+			// validateSecurityLogStreamPortsAST compiler pass (#3349): the
+			// value has two AST locations the declarative schema walker cannot
+			// express, the same dual-location rationale as tcp-mss.
+			"port": {desc: "Syslog server port (default 514)", args: 1, placeholder: "<port>", children: nil},
+			"severity": {desc: "Severity filter (error|warning|info)", args: 1, placeholder: "<severity>",
+				valueType: ValueEnumOf, valueDesc: "syslog severity floor",
+				valueExamples: []string{"error", "warning", "info"},
+				validator:     ValidateEnum(syslogSeverities), children: nil},
+			"facility": {desc: "Syslog facility (e.g. local0; default local0)", args: 1, placeholder: "<facility>",
+				valueType: ValueEnumOf, valueDesc: "syslog facility",
+				valueExamples: []string{"local0", "local7", "daemon", "change-log"},
+				validator:     ValidateEnum(syslogFacilities), children: nil},
+			"format": {desc: "Per-stream format override", args: 1, placeholder: "<format>",
+				valueType: ValueEnumOf, valueDesc: "security log format",
+				valueExamples: []string{"sd-syslog", "syslog", "binary", "structured"},
+				validator:     ValidateEnum(syslogLogFormats), children: nil},
+			"category": {desc: "Event category filter (all or a specific category)", args: 1, placeholder: "<category>",
+				valueType: ValueEnumOf, valueDesc: "security log category",
+				valueExamples: []string{"all", "session", "policy", "screen", "firewall"},
+				validator:     ValidateEnum(syslogCategories), children: nil},
+			"source-address": {desc: "Source IP for this stream", args: 1, placeholder: "<address>",
+				valueType: ValueIPAddress, valueDesc: "source IP address for this stream",
+				valueExamples: []string{"10.0.1.10", "2001:db8::1"},
+				validator:     ValidateIPAddress, children: nil},
 			// H8 (#2008): transport is fully compiled
 			// (compiler_security.go stream loop) and runtime-honored
 			// (pkg/logging/syslog.go dial), but the schema declared no

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -935,3 +935,31 @@ const (
 	maxDNSLabelLen = 63
 	maxDNSNameLen  = 253
 )
+
+// ValidateSyslogSourceInterface accepts a `security log source-interface`
+// value: an interface name with an optional `.<unit>` suffix where the unit,
+// when present, MUST be a non-negative integer (#3349). The source resolver
+// (pkg/daemon/daemon_system.go resolveSourceAddr) splits on the FIRST '.' and
+// strconv.Atoi's the remainder; a non-numeric unit is an ignored error that
+// silently falls back to unit 0 — binding the syslog source to the WRONG
+// logical unit's address. Rejecting it at commit makes the typo
+// operator-visible instead of misrouting the audit source IP. The split rule
+// (first '.') mirrors resolveSourceAddr's strings.Cut exactly.
+func ValidateSyslogSourceInterface(raw string, _ *Config) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("missing value (expected an interface name, e.g. ge-0-0-0 or reth1.100)")
+	}
+	base, unit, hasUnit := strings.Cut(trimmed, ".")
+	if base == "" {
+		return fmt.Errorf("invalid interface name %q (empty name before '.')", raw)
+	}
+	if hasUnit {
+		n, err := strconv.Atoi(unit)
+		if err != nil || n < 0 {
+			return fmt.Errorf("invalid logical unit %q in %q (expected a non-negative "+
+				"integer; a non-numeric unit silently binds the syslog source to unit 0)", unit, raw)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Most `security log stream` sub-fields and the top-level `log mode`/`format`
were untyped schema leaves with no commit-time validation. A typo committed
cleanly and then silently *widened*, *remapped*, or *fell back* at runtime
instead of failing the commit — a fail-open for the audit path.

Closes #3349.

## Fields fixed (each a confirmed silent-fallback before this change)

| Config | Old typo behavior | Now |
|---|---|---|
| `stream <s> category <c>` | unknown → 0 = send ALL categories | rejected (enum) |
| `stream <s> severity <v>` | unknown → 0 = no floor = send ALL | rejected (enum) |
| `stream <s> facility <f>` | unknown → silently remapped to local0 | rejected (enum) |
| `stream <s> format` / `log format` | raw string, silent RFC3164 fallback | rejected (enum) |
| `log mode <m>` | any non-`event` → stream mode | rejected (enum `stream\|event`) |
| `stream <s> source-address <a>` | invalid → stream dropped at apply | rejected (IP) |
| `log source-interface <if>.<bad>` | non-numeric unit → unit 0 (wrong src IP) | rejected |
| `stream <s> port` / `host { port }` | non-numeric/oob → stays 514 | rejected (`[1..65535]`) |

## Implementation

- **Enum/value schema leaves** (`schema_security.go`) for mode/format,
  stream severity/facility/category/format, source-address — validated by the
  existing `SchemaValidate` gate: **strict on commit / commit-check, downgraded
  to a warning on the tolerant load / peer-sync paths** (the #1960/#3261
  fail-closed-on-load doctrine, identical to the #2008 H8 transport-protocol
  enum). Enum sets are pinned to the `pkg/logging` parsers
  (`ParseSeverity`/`ParseFacility`/`ParseCategory` + the daemon apply path) so
  the validator accepts exactly the set the runtime applies.
- **`ValidateSyslogSourceInterface`** rejects a non-numeric `.<unit>` suffix,
  mirroring `resolveSourceAddr`'s first-dot split.
- **`validateSecurityLogStreamPortsAST`** compiler pass range-checks port in
  BOTH AST locations (direct `stream port` + nested `host { port }`) — a
  dual-location value the declarative schema walker cannot express, the same
  rationale as `tcp-mss`. Strict on commit; `lenientLogStreamPort`-downgraded
  on load/peer-sync.

No runtime/dataplane change — purely commit-time validation of fields the
compiler and runtime already consume.

## Tests

`pkg/config/log_stream_config_3349_test.go`:
- RED-on-revert rejection of a typo for every field (verified each fails when
  its validator is removed).
- Valid config still commits (schema + strict compile).
- Lenient path warns-not-bricks for a bad port.

`go build ./...` and `go test ./pkg/config/... ./pkg/logging/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi