### PR TITLE
userspace-dp AppID: make catalog lookup direction-aware (Closes #3321)

### DIFF
--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -71,17 +71,23 @@ pub(super) fn event_now_ns_from_secs(now_secs: u64) -> u64 {
 
 /// #2520: resolve the AppID for a cold-path RT_FLOW record (policy-deny /
 /// filter-log / session-close) from the flow 5-tuple, reusing the SAME
-/// `app_catalog.lookup` the forwarding hot path runs when it stamps the
-/// conntrack entry (`poll_descriptor` session-create:
-/// `worker_ctx.forwarding.app_catalog.lookup(protocol, src_port, dst_port)`).
-/// There is no duplicated resolution logic — the catalog probes both port
-/// slots so a forward- or reverse-keyed tuple resolves to the same app_id.
+/// direction-aware `app_catalog` the forwarding hot path runs when it stamps
+/// the conntrack entry. #3321: a cold-path record carries the received
+/// (forward) 5-tuple, so this uses `lookup_forward` — the service port is the
+/// DESTINATION and a forward flow whose source port coincides with a service
+/// port is NOT mislabeled. (The session-create / -close stamps that DO know
+/// their binding direction call `lookup_directional` with `metadata.is_reverse`
+/// so a legitimately reverse-keyed session still resolves on the src slot.)
 /// Returns 0 (UNKNOWN) when nothing matches, which the Go RT_FLOW logger
 /// renders as `application="UNKNOWN"` — the unchanged behavior for an
 /// unresolvable tuple.
 #[inline]
 pub(super) fn resolve_flow_app_id(app_catalog: &AppCatalog, flow: &SessionFlow) -> u16 {
-    app_catalog.lookup(
+    // #3321: a cold-path record carries the received (forward) 5-tuple, so the
+    // service port is the destination — resolve forward-directionally so a
+    // forward flow whose source port coincides with a service port is not
+    // mislabeled.
+    app_catalog.lookup_forward(
         flow.forward_key.protocol,
         flow.forward_key.src_port,
         flow.forward_key.dst_port,
@@ -105,7 +111,9 @@ pub(super) fn resolve_policy_deny_app_id(
     flow: &SessionFlow,
     policy_dst_port: u16,
 ) -> u16 {
-    app_catalog.lookup(
+    // #3321: forward-directional — the policy was evaluated against the
+    // (post-translation) destination port, which is the service slot.
+    app_catalog.lookup_forward(
         flow.forward_key.protocol,
         flow.forward_key.src_port,
         policy_dst_port,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -511,10 +511,15 @@ pub(super) fn poll_binding_process_descriptor(
                             // `show security flow session` zone/interface display.
                             // #2008 M5: resolve the application id from the
                             // 5-tuple so the conntrack entry carries app_id.
-                            let app_id = worker_ctx.forwarding.app_catalog.lookup(
+                            // #3321: resolve directionally — the service port
+                            // is the dst on a forward-keyed session, the src on
+                            // a reverse-keyed one, so a forward flow with a
+                            // service-valued SOURCE port is not mislabeled.
+                            let app_id = worker_ctx.forwarding.app_catalog.lookup_directional(
                                 flow.forward_key.protocol,
                                 flow.forward_key.src_port,
                                 flow.forward_key.dst_port,
+                                resolved.metadata.is_reverse,
                             );
                             publish_bpf_conntrack_entry(
                                 conntrack_v4_fd,
@@ -1624,10 +1629,13 @@ pub(super) fn poll_binding_process_descriptor(
                                     c.add(desc.len as u64);
                                 }
                                 // #2008 M5: stamp the resolved application id.
-                                let app_id = worker_ctx.forwarding.app_catalog.lookup(
+                                // #3321: directional resolution (service = dst
+                                // forward / src reverse).
+                                let app_id = worker_ctx.forwarding.app_catalog.lookup_directional(
                                     flow.forward_key.protocol,
                                     flow.forward_key.src_port,
                                     flow.forward_key.dst_port,
+                                    local_metadata.is_reverse,
                                 );
                                 publish_bpf_conntrack_entry(
                                     conntrack_v4_fd,
@@ -3823,10 +3831,13 @@ pub(super) fn poll_binding_process_descriptor(
                                             .fetch_add(1, Ordering::Relaxed);
                                     }
                                     // #2008 M5: stamp the resolved app id.
-                                    let app_id = worker_ctx.forwarding.app_catalog.lookup(
+                                    // #3321: directional resolution (service =
+                                    // dst forward / src reverse).
+                                    let app_id = worker_ctx.forwarding.app_catalog.lookup_directional(
                                         flow.forward_key.protocol,
                                         flow.forward_key.src_port,
                                         flow.forward_key.dst_port,
+                                        entry.metadata.is_reverse,
                                     );
                                     publish_bpf_conntrack_entry(
                                         conntrack_v4_fd,

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -213,13 +213,17 @@ pub(super) fn flush_session_deltas(
             // 1:1 pair per close — no double-counting on the HA channel.
             if delta.kind == SessionDeltaKind::Close {
                 // #2520: resolve the AppID for the closing 5-tuple with the
-                // SAME app_catalog.lookup the forwarding hot path runs, so the
+                // SAME app_catalog the forwarding hot path runs, so the
                 // SESSION_CLOSE RT_FLOW record carries the application instead
                 // of UNKNOWN. 0 (no match) keeps the prior UNKNOWN rendering.
-                let app_id = forwarding.app_catalog.lookup(
+                // #3321: resolve directionally off the delta's own direction
+                // flag (service = dst forward / src reverse) so a forward flow
+                // with a service-valued source port is not mislabeled.
+                let app_id = forwarding.app_catalog.lookup_directional(
                     delta.key.protocol,
                     delta.key.src_port,
                     delta.key.dst_port,
+                    delta.metadata.is_reverse,
                 );
                 // #2615: thread the closing binding's ingress ifindex so the
                 // SESSION_CLOSE RT_FLOW record shows the admitting interface
@@ -239,17 +243,19 @@ pub(super) fn flush_session_deltas(
             // frame's gate byte) because flowexport still needs every close.
             if delta.kind == SessionDeltaKind::Open && delta.metadata.log_session_init {
                 // #2615: resolve the AppID for the new 5-tuple with the SAME
-                // app_catalog.lookup the forwarding hot path runs (mirroring
-                // the #2520 close-side fix), so the SESSION_CREATE RT_FLOW
-                // record carries the application instead of UNKNOWN. 0 (no
-                // match) keeps the prior UNKNOWN rendering. The ingress
-                // ifindex comes from the admitting binding (`ident`); a kernel
-                // ifindex is always positive so the i32 -> u32 cast is
-                // loss-free.
-                let app_id = forwarding.app_catalog.lookup(
+                // app_catalog the forwarding hot path runs (mirroring the #2520
+                // close-side fix), so the SESSION_CREATE RT_FLOW record carries
+                // the application instead of UNKNOWN. 0 (no match) keeps the
+                // prior UNKNOWN rendering. The ingress ifindex comes from the
+                // admitting binding (`ident`); a kernel ifindex is always
+                // positive so the i32 -> u32 cast is loss-free.
+                // #3321: directional resolution off the delta's direction flag
+                // (service = dst forward / src reverse).
+                let app_id = forwarding.app_catalog.lookup_directional(
                     delta.key.protocol,
                     delta.key.src_port,
                     delta.key.dst_port,
+                    delta.metadata.is_reverse,
                 );
                 es.emit_session_create_rt_flow(delta, app_id, ident.ifindex as u32);
             }

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -63,12 +63,20 @@ periodic ACK from the daemon.
   slot (offset 132, little-endian u16) instead of hardcoding 0. The
   `emit_policy_deny_event` / `emit_filter_log_event` call sites and the
   `emit_session_close_rt_flow` (#2520) AND `emit_session_create_rt_flow`
-  (#2615) callers resolve the AppID with the SAME
-  `app_catalog.lookup(protocol, src_port, dst_port)` the forwarding hot
-  path runs when it stamps the conntrack entry on session create (see
-  `afxdp::event_emit::resolve_flow_app_id`), so a policy-deny / filter-log /
-  session-create / session-close record shows `application=<name>` for a
-  resolvable 5-tuple instead of `application="UNKNOWN"`.
+  (#2615) callers resolve the AppID with the SAME direction-aware
+  `app_catalog` the forwarding hot path runs when it stamps the conntrack
+  entry on session create (see `afxdp::event_emit::resolve_flow_app_id`), so
+  a policy-deny / filter-log / session-create / session-close record shows
+  `application=<name>` for a resolvable 5-tuple instead of
+  `application="UNKNOWN"`.
+  (#3321) the lookup is DIRECTIONAL: `lookup_forward` matches the service on
+  the DESTINATION port for a forward-keyed 5-tuple, and `lookup_directional`
+  matches the source slot when the caller knows the entry is reverse-keyed
+  (`metadata.is_reverse`). The cold-path resolvers (`resolve_flow_app_id` /
+  `resolve_policy_deny_app_id`) use `lookup_forward`; the session-create /
+  -close stamps pass the binding's own direction flag. A forward flow whose
+  SOURCE port coincides with a service port (e.g. tcp `src=443`) is no longer
+  mislabeled — the old probe matched the service on either slot.
   (#3058) a DNAT / static-NAT / inbound-NPTv6 policy-DENY record now reflects
   what the policy was actually evaluated against (the #2345 post-translation
   tuple), mirroring the permit / SESSION_CLOSE convention exactly: the

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -1144,40 +1144,59 @@ impl AppCatalog {
         self.by_protocol.is_empty()
     }
 
-    /// Resolve the app_id for a session 5-tuple. The well-known service port is
-    /// the destination on a forward session and the source on a reverse-keyed
-    /// session, so both port slots are probed — both directions of one session
-    /// then resolve to the same app_id (required because the publisher installs
-    /// forward + reverse conntrack entries). Returns 0 (unknown) when nothing
+    /// Resolve the app_id for a session 5-tuple, honouring flow DIRECTION.
+    ///
+    /// The well-known service port is the DESTINATION on a forward-keyed
+    /// session and the SOURCE on a reverse-keyed session. `is_reverse` selects
+    /// which slot carries the service port, so the catalog's destination-port
+    /// constraint is matched against the real service side ONLY — the lookup
+    /// does not probe both slots. Both directions of one session still resolve
+    /// to the same app_id because the caller passes the matching `is_reverse`
+    /// for each direction (and the publisher stamps the forward + reverse
+    /// conntrack entries from one resolution). Returns 0 (unknown) when nothing
     /// matches; 0 is the existing default the show path treats as "no AppID".
+    ///
+    /// #3321: the previous directionless probe matched the service port on
+    /// EITHER slot. A forward flow whose CLIENT source port coincidentally
+    /// equalled a service port (e.g. tcp `src=443, dst=ephemeral`) was then
+    /// mislabeled as that service in session display / RT_FLOW create+close /
+    /// policy-deny / filter-log records — log-integrity pollution during
+    /// incident response. Matching on the directional service slot fixes it.
     #[inline]
-    pub(crate) fn lookup(&self, protocol: u8, src_port: u16, dst_port: u16) -> u16 {
+    pub(crate) fn lookup_directional(
+        &self,
+        protocol: u8,
+        src_port: u16,
+        dst_port: u16,
+        is_reverse: bool,
+    ) -> u16 {
         let Some(bucket) = self.by_protocol.get(&protocol) else {
             return 0;
         };
-        // Exact single-port match on either slot (service port = dst forward,
-        // src reverse). Prefer the lower app_id when both slots hit distinct
-        // apps, for determinism.
-        let dst_hit = bucket.exact_dst.get(&dst_port).copied();
-        let src_hit = bucket.exact_dst.get(&src_port).copied();
-        let exact = match (dst_hit, src_hit) {
-            (Some(a), Some(b)) => Some(a.min(b)),
-            (Some(a), None) | (None, Some(a)) => Some(a),
-            (None, None) => None,
+        // Service port = destination on a forward flow, source on a reverse-
+        // keyed flow; the client port is the other slot.
+        let (service_port, client_port) = if is_reverse {
+            (src_port, dst_port)
+        } else {
+            (dst_port, src_port)
         };
-        // Scan entries (ranges / protocol-only). Catalog order = ascending id.
+        // Exact single-port entries carry no source constraint by construction
+        // (`from_snapshot` only routes src-unconstrained single-dst entries to
+        // `exact_dst`), so an exact hit needs only the service port.
+        let exact = bucket.exact_dst.get(&service_port).copied();
+        // Scan entries (ranges / source-constrained / protocol-only). Catalog
+        // order = ascending id.
         let in_range = |low: u16, high: u16, p: u16| -> bool {
             // (0,0) means "no constraint".
             (low == 0 && high == 0) || (p >= low && p <= high)
         };
         let mut scan_hit: Option<u16> = None;
         for s in &bucket.scan {
-            // Destination-port constraint may be satisfied by either slot, the
-            // same forward/reverse symmetry the exact path uses.
-            let dst_ok = in_range(s.dst_low, s.dst_high, dst_port)
-                || in_range(s.dst_low, s.dst_high, src_port);
-            let src_ok = in_range(s.src_low, s.src_high, src_port)
-                || in_range(s.src_low, s.src_high, dst_port);
+            // Destination constraint is matched against the service slot and
+            // the source constraint against the client slot — directional, no
+            // cross-slot probing.
+            let dst_ok = in_range(s.dst_low, s.dst_high, service_port);
+            let src_ok = in_range(s.src_low, s.src_high, client_port);
             if dst_ok && src_ok {
                 scan_hit = Some(s.app_id);
                 break;
@@ -1188,6 +1207,15 @@ impl AppCatalog {
             (Some(a), None) | (None, Some(a)) => a,
             (None, None) => 0,
         }
+    }
+
+    /// Forward-keyed convenience wrapper: the service port is the destination.
+    /// This is the common case for cold-path RT_FLOW / filter-log / policy-deny
+    /// resolution where the 5-tuple is the received (forward) packet and there
+    /// is no session-direction flag at the call site.
+    #[inline]
+    pub(crate) fn lookup_forward(&self, protocol: u8, src_port: u16, dst_port: u16) -> u16 {
+        self.lookup_directional(protocol, src_port, dst_port, false)
     }
 }
 

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -2872,25 +2872,78 @@ fn cat_entry(app_id: u16, proto: u8, dlo: u16, dhi: u16) -> crate::AppCatalogEnt
 fn app_catalog_exact_dst_port_resolves_id() {
     let cat = AppCatalog::from_snapshot(&[cat_entry(7, 6, 443, 443)]);
     // forward session: client ephemeral src -> server dst 443.
-    assert_eq!(cat.lookup(6, 51000, 443), 7);
-    // reverse-keyed session carries the service port in the src slot.
-    assert_eq!(cat.lookup(6, 443, 51000), 7);
+    assert_eq!(cat.lookup_forward(6, 51000, 443), 7);
+    // reverse-keyed session carries the service port in the src slot; only the
+    // reverse-aware lookup probes that slot (#3321).
+    assert_eq!(cat.lookup_directional(6, 443, 51000, true), 7);
+    // #3321 fail-on-revert: a FORWARD flow whose SOURCE port coincides with the
+    // service port (src=443, dst=ephemeral) must NOT be mislabeled. The old
+    // directionless probe returned 7 here.
+    assert_eq!(cat.lookup_forward(6, 443, 51000), 0);
     // wrong protocol on the same port is not the app.
-    assert_eq!(cat.lookup(17, 51000, 443), 0);
+    assert_eq!(cat.lookup_forward(17, 51000, 443), 0);
     // unrelated port resolves to unknown (0).
-    assert_eq!(cat.lookup(6, 51000, 80), 0);
+    assert_eq!(cat.lookup_forward(6, 51000, 80), 0);
 }
 
 #[test]
 fn app_catalog_port_range_resolves_id() {
     let cat = AppCatalog::from_snapshot(&[cat_entry(9, 6, 9000, 9100)]);
-    assert_eq!(cat.lookup(6, 40000, 9000), 9); // low edge
-    assert_eq!(cat.lookup(6, 40000, 9100), 9); // high edge
-    assert_eq!(cat.lookup(6, 40000, 9050), 9); // interior
-    assert_eq!(cat.lookup(6, 40000, 8999), 0); // below
-    assert_eq!(cat.lookup(6, 40000, 9101), 0); // above
-    // reverse-keyed: service-port range in the src slot still resolves.
-    assert_eq!(cat.lookup(6, 9050, 40000), 9);
+    assert_eq!(cat.lookup_forward(6, 40000, 9000), 9); // low edge
+    assert_eq!(cat.lookup_forward(6, 40000, 9100), 9); // high edge
+    assert_eq!(cat.lookup_forward(6, 40000, 9050), 9); // interior
+    assert_eq!(cat.lookup_forward(6, 40000, 8999), 0); // below
+    assert_eq!(cat.lookup_forward(6, 40000, 9101), 0); // above
+    // reverse-keyed: service-port range in the src slot still resolves via the
+    // reverse-aware lookup.
+    assert_eq!(cat.lookup_directional(6, 9050, 40000, true), 9);
+    // #3321: a forward flow with the service-port range in the SOURCE slot is
+    // not mislabeled.
+    assert_eq!(cat.lookup_forward(6, 9050, 40000), 0);
+}
+
+// #3321: the AppID lookup must be DIRECTION-AWARE. A forward flow whose source
+// port coincides with a well-known service port must resolve to UNKNOWN, while
+// the SAME tuple presented as a reverse-keyed session (service in the src slot)
+// resolves to the service. The pre-#3321 directionless probe matched the
+// service on EITHER slot, so the forward false-positive below returned the
+// service id — polluting session display / RT_FLOW / policy-deny / filter-log.
+#[test]
+fn app_catalog_directional_forward_not_mislabeled_by_source_port() {
+    // junos-https stand-in: TCP dst/443 (exact-port path).
+    let https = AppCatalog::from_snapshot(&[cat_entry(7, 6, 443, 443)]);
+    // Forward: src=443 (server-like source), dst=ephemeral client port.
+    assert_eq!(
+        https.lookup_forward(6, 443, 51000),
+        0,
+        "forward flow with a service-valued SOURCE port must be UNKNOWN"
+    );
+    // Reverse-keyed: the service port legitimately rides the src slot.
+    assert_eq!(
+        https.lookup_directional(6, 443, 51000, true),
+        7,
+        "reverse-keyed session with the service port in the src slot resolves"
+    );
+    // The genuine forward direction still resolves on the destination.
+    assert_eq!(https.lookup_forward(6, 51000, 443), 7);
+
+    // Same property on the scan (range) path, with a source-constrained app:
+    // dst range 9000-9100 AND src range 1000-2000.
+    let ranged = AppCatalog::from_snapshot(&[crate::AppCatalogEntry {
+        app_id: 9,
+        protocol: 6,
+        dst_port_low: 9000,
+        dst_port_high: 9100,
+        src_port_low: 1000,
+        src_port_high: 2000,
+    }]);
+    // Forward: client src in 1000-2000, server dst in 9000-9100 -> match.
+    assert_eq!(ranged.lookup_forward(6, 1500, 9050), 9);
+    // Forward false-positive: service-range value in the SOURCE slot, client
+    // value in the dst slot -> must NOT match.
+    assert_eq!(ranged.lookup_forward(6, 9050, 1500), 0);
+    // Reverse-keyed: service range in src, client range in dst -> match.
+    assert_eq!(ranged.lookup_directional(6, 9050, 1500, true), 9);
 }
 
 // A (0,0) dst-port pair means "protocol-only" (e.g. ICMP) — match on protocol
@@ -2898,9 +2951,9 @@ fn app_catalog_port_range_resolves_id() {
 #[test]
 fn app_catalog_protocol_only_entry() {
     let cat = AppCatalog::from_snapshot(&[cat_entry(3, 1, 0, 0)]); // ICMP
-    assert_eq!(cat.lookup(1, 0, 0), 3);
-    assert_eq!(cat.lookup(1, 1234, 5678), 3);
-    assert_eq!(cat.lookup(6, 1234, 5678), 0); // different protocol
+    assert_eq!(cat.lookup_forward(1, 0, 0), 3);
+    assert_eq!(cat.lookup_forward(1, 1234, 5678), 3);
+    assert_eq!(cat.lookup_forward(6, 1234, 5678), 0); // different protocol
 }
 
 // app_id 0 is the reserved unknown sentinel and must never be indexed even if a
@@ -2909,7 +2962,7 @@ fn app_catalog_protocol_only_entry() {
 fn app_catalog_skips_zero_app_id() {
     let cat = AppCatalog::from_snapshot(&[cat_entry(0, 6, 443, 443)]);
     assert!(cat.is_empty());
-    assert_eq!(cat.lookup(6, 51000, 443), 0);
+    assert_eq!(cat.lookup_forward(6, 51000, 443), 0);
 }
 
 // Overlapping entries: first/lowest app_id wins, deterministically (the Go
@@ -2918,18 +2971,18 @@ fn app_catalog_skips_zero_app_id() {
 fn app_catalog_overlap_lowest_id_wins() {
     // Two apps both claiming tcp/80 — exact-port path.
     let cat = AppCatalog::from_snapshot(&[cat_entry(5, 6, 80, 80), cat_entry(11, 6, 80, 80)]);
-    assert_eq!(cat.lookup(6, 40000, 80), 5);
+    assert_eq!(cat.lookup_forward(6, 40000, 80), 5);
 
     // Range vs exact overlap — lowest id still wins.
     let cat = AppCatalog::from_snapshot(&[cat_entry(2, 6, 8000, 8100), cat_entry(20, 6, 8050, 8050)]);
-    assert_eq!(cat.lookup(6, 40000, 8050), 2);
+    assert_eq!(cat.lookup_forward(6, 40000, 8050), 2);
 }
 
 #[test]
 fn app_catalog_empty_resolves_unknown() {
     let cat = AppCatalog::default();
     assert!(cat.is_empty());
-    assert_eq!(cat.lookup(6, 51000, 443), 0);
+    assert_eq!(cat.lookup_forward(6, 51000, 443), 0);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3321

## Problem
`AppCatalog::lookup` resolved an application by probing **both** the source and destination port slots with no direction input. The dual-slot probe is correct for a reverse-keyed conntrack entry (service port in the src slot), but the same function stamped **forward** flows at session-create and attributed cold-path RT_FLOW records. A forward packet whose **source** port equalled a well-known service port (e.g. tcp `src=443, dst=ephemeral`) was mislabeled as that service in session display, RT_FLOW create/close, policy-deny, and filter-log records.

## Fix
Directional APIs in `userspace-dp/src/policy.rs`:

- `lookup_directional(proto, src, dst, is_reverse)` — service port = dst (forward) or src (reverse-keyed); dst-constraint matched against the service slot, src-constraint against the client slot. No cross-slot probing. Both directions of one session still resolve to the same app_id (caller passes the matching `is_reverse`).
- `lookup_forward(proto, src, dst)` — forward wrapper for cold-path callers carrying the received 5-tuple.

Call sites:
- Conntrack stamps (poll_descriptor ×3) + SESSION_CREATE/CLOSE RT_FLOW (session_delta ×2) pass the binding's `metadata.is_reverse`, so a legitimately reverse-keyed session still resolves on the src slot.
- `resolve_flow_app_id` / `resolve_policy_deny_app_id` (filter-log, policy-deny) use `lookup_forward`; the deny path keeps resolving from the post-translation dst port (#3058).

Go `pkg/appid` is a catalog **builder** only (id↔name); the tuple lookup is Rust-only, so there is no Go mirror to keep in step.

## Tests
New `app_catalog_directional_forward_not_mislabeled_by_source_port`: forward flow with a service-valued source port → UNKNOWN(0); same tuple as reverse-keyed → service id; covers exact-port and source-constrained range paths. Existing reverse-symmetry assertions now use `lookup_directional(..., true)`.

**RED-on-revert verified:** restoring the directionless exact probe makes the new test fail (`forward flow with a service-valued SOURCE port must be UNKNOWN`).

Validation: `cargo build` clean; `cargo test --release policy::` (110 ok) + `cold_path` (41 ok); `go test ./pkg/appid/... ./pkg/dataplane/userspace/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi