### PR TITLE
dataplane: accept an exact 256-rule policy-set fill (off-by-one cap)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-06-28 — #3404 policy-ID namespace exact-256 off-by-one (>= → >)
+
+- **Timestamp**: 2026-06-28
+- **Action**: Fixed the off-by-one in the MaxRulesPerPolicy namespace guard.
+  `walkPolicyRuleSlots` (zone-pair + global) and the legacy `compiler.go`
+  mirror used `>=`, rejecting a policy set that exactly fills its 256-slot
+  namespace (indices 0..255) though every ID stays in-namespace. Changed to
+  `>` so exactly 256 rules arm and only the 257th (index 256) is rejected.
+  Corrected the walkPolicyRuleSlots doc comment + docs/feature-gaps.md, and
+  added exact-256-accept / 257-reject / no-cross-set-collision boundary tests
+  for both the userspace and legacy paths (RED-on-revert verified).
+- **File(s)**: pkg/dataplane/userspace/policies.go,
+  pkg/dataplane/userspace/policy_namespace_3143_3145_test.go,
+  pkg/dataplane/compiler.go, pkg/dataplane/compiler_test.go,
+  docs/feature-gaps.md
+
 ## 2026-06-28 — #3392 lo0 nftables apply/delete fail-closed (sibling of #3333)
 
 - **Timestamp**: 2026-06-28

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -927,13 +927,25 @@ drift) closed in `fix/2008-quickwins-batch1`:
 
   **#3145 (WRITE side, real bug — FIXED):** `buildPolicySnapshots` advanced
   `ruleIndex` by the expansion count with no `MaxRulesPerPolicy` guard. A set
-  whose cumulative expansion reached 256 pushed the next policy's snapshot
-  PolicyID into the following set's base namespace, mis-attributing RT_FLOW
-  policy IDs and colliding the dataplane/event namespace. The legacy guard at
-  `compiler.go:765/901` is the retired-eBPF path and never fires here. The fix
-  routes ID assignment through `walkPolicyRuleSlots`, which enforces the cap
-  fail-closed — a set whose expansion reaches 256 is rejected at snapshot
-  build (the apply path retains the prior good dataplane state).
+  whose cumulative expansion pushed a policy's ID past index 255 spilled the
+  next policy's snapshot PolicyID into the following set's base namespace,
+  mis-attributing RT_FLOW policy IDs and colliding the dataplane/event
+  namespace. The legacy guard in `compiler.go` is the retired-eBPF path and
+  never fires here. The fix routes ID assignment through `walkPolicyRuleSlots`,
+  which enforces the cap fail-closed — a policy whose expansion would require an
+  ID at index >= `MaxRulesPerPolicy` (256) is rejected at snapshot build (the
+  apply path retains the prior good dataplane state).
+
+  **#3404 (off-by-one in the #3145 cap — FIXED):** the cap originally used `>=`
+  (`ruleIndex+span >= MaxRulesPerPolicy`), which rejected a set that EXACTLY
+  fills its 256-slot namespace (indices 0..255) even though every ID stays in
+  the set's own namespace. The boundary was changed to `>` in both
+  `walkPolicyRuleSlots` and the legacy `compiler.go` mirror, so a set with
+  exactly 256 rules arms and only the 257th rule (which would need index 256)
+  is rejected. Cross-set namespaces stay disjoint: set N's last ID is
+  `N*256+255`, set N+1's first is `(N+1)*256`, so the corrected boundary cannot
+  let them collide. Boundary tests cover exact-256 accept / 257 reject /
+  no-cross-set-collision for both the userspace and legacy paths.
 
   **#3143 (READ side, misdiagnosis — no functional change):** the issue
   assumed `policyRuleIDForCounter`'s `policyID % MaxRulesPerPolicy` was wrong

--- a/pkg/dataplane/compiler.go
+++ b/pkg/dataplane/compiler.go
@@ -769,7 +769,7 @@ func compilePolicies(dp DataPlane, cfg *config.Config, result *CompileResult) er
 			}
 		}
 
-		if len(expanded) >= MaxRulesPerPolicy {
+		if len(expanded) > MaxRulesPerPolicy {
 			return fmt.Errorf("policy %s->%s: %d expanded rules exceeds MaxRulesPerPolicy (%d)",
 				zpp.FromZone, zpp.ToZone, len(expanded), MaxRulesPerPolicy)
 		}
@@ -905,7 +905,7 @@ func compilePolicies(dp DataPlane, cfg *config.Config, result *CompileResult) er
 			}
 		}
 
-		if len(expanded) >= MaxRulesPerPolicy {
+		if len(expanded) > MaxRulesPerPolicy {
 			return fmt.Errorf("global policy: %d expanded rules exceeds MaxRulesPerPolicy (%d)",
 				len(expanded), MaxRulesPerPolicy)
 		}

--- a/pkg/dataplane/compiler_test.go
+++ b/pkg/dataplane/compiler_test.go
@@ -98,6 +98,60 @@ func TestCompilePoliciesRecordsExpandedPolicyScheduleSlots(t *testing.T) {
 	}
 }
 
+// TestCompilePoliciesExactMaxRulesBoundary covers the #3404 off-by-one in the
+// legacy compiler guard. A zone-pair set with exactly MaxRulesPerPolicy (256)
+// expanded rules occupies RuleIDs policySetID*256+0..255 — all inside its own
+// namespace — and must compile; a 257th rule would need index 256 and spill, so
+// it is rejected. Each policy here has no applications, expanding to one rule.
+//
+// Fail-on-revert: with the old `len(expanded) >= MaxRulesPerPolicy` guard the
+// exact-256 case is rejected and the first assertion fails RED.
+func TestCompilePoliciesExactMaxRulesBoundary(t *testing.T) {
+	mkCfg := func(n int) *config.Config {
+		cfg := &config.Config{}
+		pols := make([]*config.Policy, 0, n)
+		for i := 0; i < n; i++ {
+			pols = append(pols, &config.Policy{
+				Name:   "p",
+				Action: config.PolicyPermit,
+				Match: config.PolicyMatch{
+					SourceAddresses:      []string{"any"},
+					DestinationAddresses: []string{"any"},
+				},
+			})
+		}
+		cfg.Security.Policies = []*config.ZonePairPolicies{{
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Policies: pols,
+		}}
+		return cfg
+	}
+	result := func() *CompileResult {
+		return &CompileResult{ZoneIDs: map[string]uint16{"trust": 1, "untrust": 2}}
+	}
+
+	// Exactly 256 expanded rules: in-namespace (IDs 0..255), must compile.
+	dp := &policyScheduleSlotTestDP{}
+	if err := compilePolicies(dp, mkCfg(MaxRulesPerPolicy), result()); err != nil {
+		t.Fatalf("compilePolicies(256 rules) returned error, want success: %v", err)
+	}
+	if len(dp.rules) != MaxRulesPerPolicy {
+		t.Fatalf("compiled %d rules, want %d", len(dp.rules), MaxRulesPerPolicy)
+	}
+	for _, r := range dp.rules {
+		if r.RuleID >= MaxRulesPerPolicy {
+			t.Fatalf("rule RuleID %d >= %d (spilled out of policy-set 0 namespace)", r.RuleID, MaxRulesPerPolicy)
+		}
+	}
+
+	// 257 expanded rules: would require index 256, rejected fail-closed.
+	dp2 := &policyScheduleSlotTestDP{}
+	if err := compilePolicies(dp2, mkCfg(MaxRulesPerPolicy+1), result()); err == nil {
+		t.Fatalf("compilePolicies(257 rules) succeeded, want MaxRulesPerPolicy rejection")
+	}
+}
+
 func TestExpandFilterTermNegateFlags(t *testing.T) {
 	prefixLists := map[string]*config.PrefixList{
 		"rfc1918": {

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -230,11 +230,13 @@ func RuntimePolicyIDs(cfg *config.Config) map[[2]uint32]uint32 {
 // drift on how a policy ID maps to a (policy-set, rule-index) pair.
 //
 // Each policy's application-set expansion advances the per-set rule index by
-// userspacePolicyRuleExpansionCount. If a policy set's cumulative expansion
-// reaches MaxRulesPerPolicy (256), the next policy's ID would cross into the
-// following set's namespace; this mirrors the legacy compiler guard
-// (pkg/dataplane/compiler.go) and is rejected fail-closed so the apply path
-// retains the prior good dataplane state.
+// userspacePolicyRuleExpansionCount. A policy set may exactly fill its 256-slot
+// namespace (indices 0..255, the full MaxRulesPerPolicy range) — every such ID
+// stays inside the set's own namespace. Only a policy whose expansion would
+// advance the per-set rule index PAST MaxRulesPerPolicy (256) — i.e. require an
+// ID at index >= 256 — would cross into the following set's namespace; that is
+// rejected fail-closed so the apply path retains the prior good dataplane state.
+// This mirrors the legacy compiler guard (pkg/dataplane/compiler.go).
 func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error) error {
 	if cfg == nil {
 		return nil
@@ -251,8 +253,8 @@ func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error)
 				continue
 			}
 			span := userspacePolicyRuleExpansionCount(cfg, pol.Match.Applications)
-			if ruleIndex+span >= dataplane.MaxRulesPerPolicy {
-				return fmt.Errorf("policy %s->%s: expanded rules reach MaxRulesPerPolicy (%d) and would spill into the next policy set's ID namespace",
+			if ruleIndex+span > dataplane.MaxRulesPerPolicy {
+				return fmt.Errorf("policy %s->%s: expanded rules exceed MaxRulesPerPolicy (%d) and would spill into the next policy set's ID namespace",
 					zpp.FromZone, zpp.ToZone, dataplane.MaxRulesPerPolicy)
 			}
 			if err := fn(policyRuleSlot{
@@ -276,8 +278,8 @@ func walkPolicyRuleSlots(cfg *config.Config, fn func(slot policyRuleSlot) error)
 			continue
 		}
 		span := userspacePolicyRuleExpansionCount(cfg, pol.Match.Applications)
-		if globalRuleIndex+span >= dataplane.MaxRulesPerPolicy {
-			return fmt.Errorf("global policy: expanded rules reach MaxRulesPerPolicy (%d) and would spill into the next policy set's ID namespace",
+		if globalRuleIndex+span > dataplane.MaxRulesPerPolicy {
+			return fmt.Errorf("global policy: expanded rules exceed MaxRulesPerPolicy (%d) and would spill into the next policy set's ID namespace",
 				dataplane.MaxRulesPerPolicy)
 		}
 		if err := fn(policyRuleSlot{

--- a/pkg/dataplane/userspace/policy_namespace_3143_3145_test.go
+++ b/pkg/dataplane/userspace/policy_namespace_3143_3145_test.go
@@ -197,9 +197,13 @@ func singleBigPolicyConfig(nApps int) *config.Config {
 }
 
 // Test_3145_MaxRulesPerPolicyCap verifies the per-set MaxRulesPerPolicy cap on
-// the LIVE userspace snapshot path. A set whose cumulative app-set expansion
-// reaches 256 is rejected fail-closed; 255 builds. Reverting the cap in
-// walkPolicyRuleSlots makes the 256/257 cases build, failing this test.
+// the LIVE userspace snapshot path. The 256-slot namespace is indices 0..255
+// (the full MaxRulesPerPolicy range), so a set whose cumulative app-set
+// expansion EXACTLY fills it (256 terms → IDs 0..255) builds; only an expansion
+// that would require an ID at index >= 256 is rejected fail-closed.
+//
+// Fail-on-revert (#3404): with the off-by-one >= guard, the exact-256 case is
+// rejected and this test's "256 builds" assertion fails RED.
 func Test_3145_MaxRulesPerPolicyCap(t *testing.T) {
 	const max = dataplane.MaxRulesPerPolicy
 
@@ -207,13 +211,85 @@ func Test_3145_MaxRulesPerPolicyCap(t *testing.T) {
 	if _, err := buildPolicySnapshots(singleBigPolicyConfig(max - 1)); err != nil {
 		t.Fatalf("buildPolicySnapshots(255 apps) returned error, want success: %v", err)
 	}
-	// 256 effective terms: at the cap, rejected.
-	if _, err := buildPolicySnapshots(singleBigPolicyConfig(max)); err == nil {
-		t.Fatalf("buildPolicySnapshots(256 apps) succeeded, want MaxRulesPerPolicy rejection")
+	// 256 effective terms: EXACTLY fills the namespace (IDs 0..255), accepted.
+	// This is the #3404 boundary: rejected by the old >= guard, accepted by >.
+	// buildPolicySnapshots emits one snapshot per POLICY (slot), so the single
+	// big policy yields one snapshot whose span fills indices 0..255.
+	snaps256, err := buildPolicySnapshots(singleBigPolicyConfig(max))
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots(256 apps) returned error, want success (exact 256-fill is in-namespace): %v", err)
 	}
-	// 257 effective terms: over the cap, rejected.
+	if len(snaps256) != 1 {
+		t.Fatalf("buildPolicySnapshots(256-term single policy) emitted %d snapshots, want 1", len(snaps256))
+	}
+	// The exact-fill set must occupy IDs 0..255 — none at or past MaxRulesPerPolicy.
+	for _, s := range snaps256 {
+		if s.PolicyID >= max {
+			t.Fatalf("256-fill snapshot %q has runtime ID %d >= %d (spilled out of its own namespace)", s.Name, s.PolicyID, max)
+		}
+	}
+	// 257 effective terms: over the cap (would need index 256), rejected.
 	if _, err := buildPolicySnapshots(singleBigPolicyConfig(max + 1)); err == nil {
 		t.Fatalf("buildPolicySnapshots(257 apps) succeeded, want MaxRulesPerPolicy rejection")
+	}
+}
+
+// Test_3404_ExactFillNoCrossSetCollision proves the corrected boundary keeps
+// adjacent policy sets in disjoint ID namespaces. The first zone-pair set is
+// filled with exactly MaxRulesPerPolicy (256) single-application policies
+// (indices 0..255); a second set follows. The first set's last ID must be
+// policySetID*256+255 and the second set's first ID must be (policySetID+1)*256,
+// so the +1 boundary cannot let set N's last ID collide with set N+1's first.
+//
+// Fail-on-revert (#3404): the old >= guard rejects the exact 256-fill outright,
+// so buildPolicySnapshots errors and this test fails RED at the build step.
+func Test_3404_ExactFillNoCrossSetCollision(t *testing.T) {
+	const max = dataplane.MaxRulesPerPolicy
+	cfg := &config.Config{}
+	first := make([]*config.Policy, 0, max)
+	for i := 0; i < max; i++ {
+		first = append(first, &config.Policy{
+			Name:   fmt.Sprintf("rule-%d", i),
+			Match:  config.PolicyMatch{Applications: []string{"junos-ssh"}},
+			Action: config.PolicyPermit,
+		})
+	}
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		{FromZone: "lan", ToZone: "wan", Policies: first},
+		{FromZone: "dmz", ToZone: "wan", Policies: []*config.Policy{{
+			Name:   "next-set-rule",
+			Match:  config.PolicyMatch{Applications: []string{"junos-ssh"}},
+			Action: config.PolicyPermit,
+		}}},
+	}
+
+	snaps, err := buildPolicySnapshots(cfg)
+	if err != nil {
+		t.Fatalf("buildPolicySnapshots(exact 256-fill + second set): %v", err)
+	}
+
+	seen := map[uint32]string{}
+	var firstMax, nextBase uint32
+	haveNext := false
+	for _, s := range snaps {
+		key := stablePolicyRuleID(s.FromZone, s.ToZone, s.Name)
+		if prev, ok := seen[s.PolicyID]; ok && prev != key {
+			t.Fatalf("runtime policy ID %d shared by %q and %q (cross-set namespace collision)", s.PolicyID, prev, key)
+		}
+		seen[s.PolicyID] = key
+		if s.FromZone == "lan" && s.PolicyID > firstMax {
+			firstMax = s.PolicyID
+		}
+		if s.Name == "next-set-rule" {
+			nextBase = s.PolicyID
+			haveNext = true
+		}
+	}
+	if firstMax != max-1 {
+		t.Fatalf("first set's max runtime ID = %d, want %d (indices 0..255)", firstMax, max-1)
+	}
+	if !haveNext || nextBase != max {
+		t.Fatalf("second set base runtime ID = %d, want %d (its own namespace, no overlap with first set's %d)", nextBase, max, firstMax)
 	}
 }
 


### PR DESCRIPTION
Closes #3404

## Problem

`walkPolicyRuleSlots` (`pkg/dataplane/userspace/policies.go`) and the legacy
mirror in `pkg/dataplane/compiler.go` guarded the per-set policy-ID namespace
with `>=` against `MaxRulesPerPolicy` (256). That rejected a zone-pair or
global policy set whose expanded rules EXACTLY fill the 256-slot namespace
(indices 0..255) even though every rule ID stays inside the set's own
namespace.

A runtime policy ID is `policySetID*MaxRulesPerPolicy + ruleIndex`. With the
256th rule, `ruleIndex == 255`, `span == 1`, so `255 + 1 == 256 >= 256` fired
one rule early. The rule that actually spills is the 257th (`ruleIndex == 256`).

## Fix

Change all four guards (zone-pair + global, userspace + legacy) from `>=` to
`>`, so an expansion is rejected only when it would require an ID at index
`>= MaxRulesPerPolicy`. The corrected boundary keeps adjacent sets disjoint:
a set caps at index 255, so set N's last ID (`N*256+255`) can never equal set
N+1's first (`N*256+256`).

Also corrects the `walkPolicyRuleSlots` doc comment (it described exact-fill as
overflow) and the #3145 note in `docs/feature-gaps.md`, plus a new #3404 doc
entry.

## Tests (RED-on-revert verified)

- userspace: exact-256-term single policy now builds (IDs 0..255); 257 rejected.
- userspace: 256 single-app policies + a second set → no cross-set ID
  collision (first set max ID 255, second set base 256).
- legacy compiler: 256 expanded rules compile (RuleIDs 0..255); 257 rejected.

All three new assertions fail RED when the `>=` guard is restored.

Scope is the off-by-one cap only — does not touch the deferred #3322/#3395
positional policy-ID redesign.

`go build ./...` and `go test ./pkg/dataplane/... ./pkg/config/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi