### PR TITLE
config: reject trailing garbage tokens on a supported screen leaf (#3332)

### DIFF
--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -736,6 +736,45 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			return nodeVal(n)
 		}
 
+		// recordKeyExtras flags trailing tokens collapsed onto a RECOGNIZED
+		// screen leaf's Keys beyond the tokens compileScreen legitimately
+		// reads (#3332). In the flat-set AST a leaf with no schema children
+		// absorbs every trailing token onto its Keys, so `tcp land bogus`
+		// lands as Keys=["land","bogus"] and the compiler reads only the
+		// keyword (and, for value leaves, a fixed Keys index), silently
+		// dropping the rest — a typo'd extra token is accepted with no
+		// warning. `allowed` is the total Keys length the leaf legitimately
+		// carries: 1 for a boolean flag (`land`), 2 for a single-value leaf
+		// whose value sits at Keys[1] (`port-scan threshold <n>`,
+		// `syn-flood attack-threshold <n>`, `limit-session source-ip-based
+		// <n>` value tail), 3 for `flood threshold <n>` (value at Keys[2]).
+		// Each token past that span is operator garbage; record it on
+		// UnknownLeaves so validateScreenUnknownStrict rejects the commit
+		// (the tolerant load / peer-sync path downgrades to a warning —
+		// #3318 / #1960 no-brick). This is distinct from the #3318 unknown-
+		// KEYWORD gate: here the leaf keyword itself IS supported.
+		recordKeyExtras := func(prefix string, n *Node, allowed int) {
+			for i := allowed; i < len(n.Keys); i++ {
+				profile.UnknownLeaves = append(profile.UnknownLeaves, prefix+" "+n.Keys[i])
+			}
+		}
+		// recordChildExtras flags unexpected CHILD nodes hanging off a
+		// recognized screen leaf that takes no sub-stanza (#3332). A leaf
+		// declared with args>0 in setSchema (limit-session source-ip-based /
+		// destination-ip-based) has SetPath consume its value into Keys and
+		// park any further trailing token as a CHILD node rather than on
+		// Keys, so recordKeyExtras cannot see it. The leaf models no children,
+		// so every child here is garbage that would otherwise be silently
+		// dropped.
+		recordChildExtras := func(prefix string, n *Node) {
+			for _, c := range n.Children {
+				if c == nil || len(c.Keys) == 0 {
+					continue
+				}
+				profile.UnknownLeaves = append(profile.UnknownLeaves, prefix+" "+c.Keys[0])
+			}
+		}
+
 		// #3318: the screen schema subtrees are open. Record any unknown/
 		// unsupported top-level screen family so validateScreenUnknownStrict can
 		// reject the commit fail-closed instead of silently dropping it.
@@ -754,9 +793,12 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				switch opt.Name() {
 				case "ping-death":
 					profile.ICMP.PingDeath = true
+					recordKeyExtras("icmp ping-death", opt, 1)
 				case "fragment":
 					profile.ICMP.Fragment = true
+					recordKeyExtras("icmp fragment", opt, 1)
 				case "flood":
+					recordKeyExtras("icmp flood", opt, 3)
 					if n, ok := parseThresh("icmp flood", numVal(opt, 2)); ok {
 						profile.ICMP.FloodThreshold = n
 					}
@@ -778,12 +820,15 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				switch opt.Name() {
 				case "source-route-option":
 					profile.IP.SourceRouteOption = true
+					recordKeyExtras("ip source-route-option", opt, 1)
 				case "tear-drop":
 					profile.IP.TearDrop = true
+					recordKeyExtras("ip tear-drop", opt, 1)
 				case "ip-sweep":
 					for _, swOpt := range opt.Children {
 						switch swOpt.Name() {
 						case "threshold":
+							recordKeyExtras("ip ip-sweep threshold", swOpt, 2)
 							if n, ok := parseThresh("ip ip-sweep threshold", numVal(swOpt, 1)); ok {
 								profile.IP.IPSweepThreshold = n
 							}
@@ -810,38 +855,49 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				switch opt.Name() {
 				case "land":
 					profile.TCP.Land = true
+					recordKeyExtras("tcp land", opt, 1)
 				case "winnuke":
 					profile.TCP.WinNuke = true
+					recordKeyExtras("tcp winnuke", opt, 1)
 				case "syn-frag":
 					profile.TCP.SynFrag = true
+					recordKeyExtras("tcp syn-frag", opt, 1)
 				case "syn-fin":
 					profile.TCP.SynFin = true
+					recordKeyExtras("tcp syn-fin", opt, 1)
 				case "no-flag":
 					profile.TCP.NoFlag = true
+					recordKeyExtras("tcp no-flag", opt, 1)
 				case "fin-no-ack":
 					profile.TCP.FinNoAck = true
+					recordKeyExtras("tcp fin-no-ack", opt, 1)
 				case "syn-flood":
 					sf := &SynFloodConfig{}
 					for _, sfOpt := range opt.Children {
 						val := numVal(sfOpt, 1)
 						switch sfOpt.Name() {
 						case "alarm-threshold":
+							recordKeyExtras("tcp syn-flood alarm-threshold", sfOpt, 2)
 							if n, ok := parseThresh("tcp syn-flood alarm-threshold", val); ok {
 								sf.AlarmThreshold = n
 							}
 						case "attack-threshold":
+							recordKeyExtras("tcp syn-flood attack-threshold", sfOpt, 2)
 							if n, ok := parseThresh("tcp syn-flood attack-threshold", val); ok {
 								sf.AttackThreshold = n
 							}
 						case "source-threshold":
+							recordKeyExtras("tcp syn-flood source-threshold", sfOpt, 2)
 							if n, ok := parseThresh("tcp syn-flood source-threshold", val); ok {
 								sf.SourceThreshold = n
 							}
 						case "destination-threshold":
+							recordKeyExtras("tcp syn-flood destination-threshold", sfOpt, 2)
 							if n, ok := parseThresh("tcp syn-flood destination-threshold", val); ok {
 								sf.DestinationThreshold = n
 							}
 						case "timeout":
+							recordKeyExtras("tcp syn-flood timeout", sfOpt, 2)
 							if n, ok := parseThresh("tcp syn-flood timeout", val); ok {
 								sf.Timeout = n
 							}
@@ -864,6 +920,7 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 					for _, psOpt := range opt.Children {
 						switch psOpt.Name() {
 						case "threshold":
+							recordKeyExtras("tcp port-scan threshold", psOpt, 2)
 							if n, ok := parseThresh("tcp port-scan threshold", numVal(psOpt, 1)); ok {
 								profile.TCP.PortScanThreshold = n
 							}
@@ -889,6 +946,7 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 			for _, opt := range udpNode.Children {
 				switch opt.Name() {
 				case "flood":
+					recordKeyExtras("udp flood", opt, 3)
 					if n, ok := parseThresh("udp flood", numVal(opt, 2)); ok {
 						profile.UDP.FloodThreshold = n
 					}
@@ -910,10 +968,14 @@ func compileScreen(node *Node, sec *SecurityConfig) error {
 				val := numVal(opt, 1)
 				switch opt.Name() {
 				case "source-ip-based":
+					recordKeyExtras("limit-session source-ip-based", opt, 2)
+					recordChildExtras("limit-session source-ip-based", opt)
 					if n, ok := parseThresh("limit-session source-ip-based", val); ok {
 						profile.LimitSession.SourceIPBased = n
 					}
 				case "destination-ip-based":
+					recordKeyExtras("limit-session destination-ip-based", opt, 2)
+					recordChildExtras("limit-session destination-ip-based", opt)
 					if n, ok := parseThresh("limit-session destination-ip-based", val); ok {
 						profile.LimitSession.DestinationIPBased = n
 					}

--- a/pkg/config/screen_trailing_token_3332_test.go
+++ b/pkg/config/screen_trailing_token_3332_test.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3332: a flat-set screen leaf that is itself SUPPORTED but carries EXTRA
+// trailing tokens beyond its value arity silently dropped the garbage at
+// commit. `set security screen ids-option X tcp land bogus` parses as a `land`
+// leaf with Keys=["land","bogus"]; compileScreen reads only Keys[0] ("land"),
+// enables Land, and "bogus" was consumed with no warning. This is distinct from
+// #3318 (which rejects an unknown leaf KEYWORD): here the keyword IS known, so
+// the #3318 default arm can never see it. compileScreen now records the trailing
+// token(s) on ScreenProfile.UnknownLeaves and validateScreenUnknownStrict makes
+// the commit fail.
+//
+// FAIL-ON-REVERT: drop the recordKeyExtras / recordChildExtras calls in
+// compileScreen (compiler_security.go) and every subtest below goes GREEN on the
+// garbage config, which is exactly the regression this guards.
+func TestScreenTrailingTokenFailsCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string // substring the error must name (the dropped garbage token in context)
+	}{
+		{
+			name: "tcp-boolean-land",
+			line: "set security screen ids-option bad-screen tcp land bogus",
+			want: "tcp land bogus",
+		},
+		{
+			name: "tcp-boolean-winnuke",
+			line: "set security screen ids-option bad-screen tcp winnuke extra",
+			want: "tcp winnuke extra",
+		},
+		{
+			name: "icmp-boolean-ping-death",
+			line: "set security screen ids-option bad-screen icmp ping-death garbage",
+			want: "icmp ping-death garbage",
+		},
+		{
+			name: "ip-boolean-source-route-option",
+			line: "set security screen ids-option bad-screen ip source-route-option junk",
+			want: "ip source-route-option junk",
+		},
+		{
+			name: "ip-boolean-tear-drop",
+			line: "set security screen ids-option bad-screen ip tear-drop nope",
+			want: "ip tear-drop nope",
+		},
+		{
+			name: "icmp-flood-trailing",
+			line: "set security screen ids-option bad-screen icmp flood threshold 1000 extra",
+			want: "icmp flood extra",
+		},
+		{
+			name: "udp-flood-trailing",
+			line: "set security screen ids-option bad-screen udp flood threshold 1000 extra",
+			want: "udp flood extra",
+		},
+		{
+			name: "tcp-port-scan-threshold-trailing",
+			line: "set security screen ids-option bad-screen tcp port-scan threshold 14 extra",
+			want: "tcp port-scan threshold extra",
+		},
+		{
+			name: "ip-ip-sweep-threshold-trailing",
+			line: "set security screen ids-option bad-screen ip ip-sweep threshold 10 extra",
+			want: "ip ip-sweep threshold extra",
+		},
+		{
+			name: "tcp-syn-flood-subfield-trailing",
+			line: "set security screen ids-option bad-screen tcp syn-flood attack-threshold 200 extra",
+			want: "tcp syn-flood attack-threshold extra",
+		},
+		{
+			// args>0 leaf: SetPath parks the trailing token as a CHILD of the
+			// leaf, not on its Keys, so recordChildExtras is the catch.
+			name: "limit-session-source-ip-based-trailing",
+			line: "set security screen ids-option bad-screen limit-session source-ip-based 128 extra",
+			want: "limit-session source-ip-based extra",
+		},
+		{
+			name: "limit-session-destination-ip-based-trailing",
+			line: "set security screen ids-option bad-screen limit-session destination-ip-based 128 extra",
+			want: "limit-session destination-ip-based extra",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, []string{tc.line})
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected commit to reject trailing garbage on a supported screen leaf, got nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name the trailing-token leaf %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "bad-screen") {
+				t.Fatalf("error %q does not name the screen profile", err.Error())
+			}
+		})
+	}
+}
+
+// TestScreenExactAritySupportedLeavesCommit is the anti-over-reject guard: every
+// supported screen leaf with its EXACT legitimate token arity (boolean flag, or
+// keyword + value) must still commit cleanly. A bug in recordKeyExtras' `allowed`
+// count (e.g. off-by-one on `flood threshold <n>` or the syn-flood subfields)
+// would turn one of these green-path lines RED.
+func TestScreenExactAritySupportedLeavesCommit(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option ok-screen icmp ping-death",
+		"set security screen ids-option ok-screen icmp fragment",
+		"set security screen ids-option ok-screen icmp flood threshold 1000",
+		"set security screen ids-option ok-screen ip source-route-option",
+		"set security screen ids-option ok-screen ip tear-drop",
+		"set security screen ids-option ok-screen ip ip-sweep threshold 10",
+		"set security screen ids-option ok-screen tcp land",
+		"set security screen ids-option ok-screen tcp winnuke",
+		"set security screen ids-option ok-screen tcp syn-frag",
+		"set security screen ids-option ok-screen tcp syn-fin",
+		"set security screen ids-option ok-screen tcp no-flag",
+		"set security screen ids-option ok-screen tcp fin-no-ack",
+		"set security screen ids-option ok-screen tcp syn-flood attack-threshold 200",
+		"set security screen ids-option ok-screen tcp syn-flood alarm-threshold 512",
+		"set security screen ids-option ok-screen tcp syn-flood source-threshold 100",
+		"set security screen ids-option ok-screen tcp syn-flood destination-threshold 200",
+		"set security screen ids-option ok-screen tcp syn-flood timeout 20",
+		"set security screen ids-option ok-screen tcp port-scan threshold 14",
+		"set security screen ids-option ok-screen udp flood threshold 1000",
+		"set security screen ids-option ok-screen limit-session source-ip-based 128",
+		"set security screen ids-option ok-screen limit-session destination-ip-based 128",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected an exact-arity supported screen profile: %v", err)
+	}
+	if profile := cfg.Security.Screen["ok-screen"]; profile == nil || len(profile.UnknownLeaves) != 0 {
+		t.Fatalf("exact-arity supported leaves recorded spurious UnknownLeaves: %+v", profile)
+	}
+}
+
+// TestScreenTrailingTokenLenientDowngradesToWarning asserts the tolerant load /
+// peer-sync path downgrades the trailing-token error to a warning so an
+// already-persisted or peer-synced config carrying the garbage still boots
+// (#3332 reuses the #3318 / #1960 no-brick downgrade).
+func TestScreenTrailingTokenLenientDowngradesToWarning(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security screen ids-option bad-screen tcp land bogus",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must not hard-fail on a trailing-token screen leaf: %v", err)
+	}
+	// The supported leaf must still compile (Land enabled) on the lenient path —
+	// the garbage trailing token does not disable the protection it rides on.
+	if profile := cfg.Security.Screen["bad-screen"]; profile == nil || !profile.TCP.Land {
+		t.Fatalf("lenient path dropped the supported `tcp land` leaf while tolerating its trailing token: %+v", profile)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "screen unknown leaf") && strings.Contains(w, "tcp land bogus") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path did not record a downgraded trailing-token warning; warnings=%v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
Refs #3332 (screen subset; general flat-set arity contract tracked on #3332).

## Problem
The #3318 strict screen-leaf validator rejects an unknown screen leaf *keyword*, but cannot catch extra trailing tokens on an otherwise-supported leaf. In the flat-set AST a leaf with no schema children absorbs every trailing token onto its `Keys`, so:

```
set security screen ids-option X tcp land bogus
```

parses as a `land` leaf with `Keys=["land","bogus"]`. `compileScreen` read only `Keys[0]` ("land"), enabled `Land`, and silently dropped `bogus` — no commit error, a typo'd/garbage token accepted. The same leakage hit the value leaves (a numeric leaf reads a fixed `Keys` index and dropped anything past it, e.g. `tcp port-scan threshold 14 extra`) and the `args>0` `limit-session` leaves (SetPath parks the trailing token as a *child* node, invisible to a Keys-based check).

This is distinct from #3318: the leaf keyword itself IS known, so the #3318 default arm never fires.

## Fix
`compileScreen` now records the genuinely-extra tokens on `ScreenProfile.UnknownLeaves` and reuses the existing `validateScreenUnknownStrict` gate — **strict reject at commit / commit-check, downgraded to a warning on the tolerant load / peer-sync path** (#1960 no-brick). The supported leaf still compiles on the lenient path; the garbage token does not disable the protection it rides on.

Two helpers, scoped to `compileScreen` so the compiler-faithful schema-walk arity contract is untouched:
- `recordKeyExtras` — flags Keys tokens past the leaf's legitimate arity (1 = boolean flag, 2 = keyword+value, 3 = `flood threshold <n>`).
- `recordChildExtras` — flags unexpected child nodes on the `args>0` `limit-session` leaves.

### Multi-value safety
Screen leaves are fixed-arity — none are `multi: true`, and bracketed-list absorption (#2419) does not apply to any screen leaf — so there is nothing legitimate to over-reject. The exact-arity anti-over-reject test asserts the full supported set still commits with zero `UnknownLeaves`.

## Validation
- `go build ./...` + `go test ./pkg/config/...` green.
- New `screen_trailing_token_3332_test.go`: every family's boolean and value leaves rejected (RED-on-revert: neutering the two helpers makes all subtests go green on the garbage config), an exact-arity anti-over-reject guard, and the lenient warn-not-brick downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi