### PR TITLE
host-inbound: recognize rsvp/pgm/sap/dvmrp routing protocols (Closes #3341)

### DIFF
--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -293,6 +293,21 @@ From zone: guest, To zone: lan
     outside the IP host-inbound filter, so adjacencies form regardless. The nft
     parity test skips L2 tokens and instead asserts they produce no IP match;
     the Rust `classify_protocol` mirrors this with an explicit no-op arm.
+  - **Routing-control protocol tokens (#3341):** four further Junos/vSRX
+    `host-inbound-traffic protocols` tokens are now recognized — before #3341
+    they were absent from `KnownHostInboundProtocols`, so since #3200 made the
+    set typed a valid vSRX config naming them was HARD-REJECTED at commit. Unlike
+    IS-IS, all four ride IP and so map to a concrete IP host-inbound match on
+    BOTH enforcement surfaces (nft kernel mirror + Rust AF_XDP classifier):
+    `rsvp` (RSVP, IP protocol 46, dual-family), `pgm` (Pragmatic General
+    Multicast, IP protocol 113, dual-family), `sap` (Session Announcement
+    Protocol, UDP/9875, dual-family), and `dvmrp` (carried inside IGMP, IP
+    protocol 2, **IPv4-only** via `config.HostInboundProtocolFamily` — like
+    `igmp`). Each is included in the `protocols all` expansion. Fail-on-revert
+    Go (`TestHostInboundRoutingProtocolTokensCommit`,
+    `TestHostInboundRoutingProtocolTokenMatches`) + Rust
+    (`routing_control_protocol_tokens_classify`) tests guard commit acceptance,
+    the nft match/family scoping, and the Rust admit semantics.
   - **RETH VRRP VIP scoping (#3172):** the kernel host-inbound chain scopes
     its accept/deny rules to each zone's firewall-local addresses. Those
     addresses now include the zone's RETH **VRRP virtual IPs** (the

--- a/pkg/config/host_inbound_tokens.go
+++ b/pkg/config/host_inbound_tokens.go
@@ -105,6 +105,22 @@ var KnownHostInboundProtocols = map[string]bool{
 	"msdp":             true,
 	"nhrp":             true,
 	"router-discovery": true,
+	// #3341: additional routing-control protocols Junos/vSRX accepts under
+	// host-inbound-traffic. All ride IP (none are L2), so each maps to a
+	// concrete IP host-inbound match on both enforcement surfaces:
+	//   rsvp  — Resource Reservation Protocol, IP protocol 46 (dual-family).
+	//   pgm   — Pragmatic General Multicast, IP protocol 113 (dual-family).
+	//   sap   — Session Announcement Protocol, UDP/9875 (dual-family).
+	//   dvmrp — Distance Vector Multicast Routing Protocol, carried inside IGMP
+	//           (IP protocol 2) and IPv4-only (see HostInboundProtocolFamily).
+	// Before #3341 these were absent, so since #3200 made tokens typed a valid
+	// vSRX config naming them was hard-rejected at commit. Keep in lockstep with
+	// pkg/daemon hostInboundProtocolMatches and the Rust classify_protocol +
+	// KNOWN_ROUTING_PROTOCOL_TOKENS.
+	"rsvp":  true,
+	"pgm":   true,
+	"sap":   true,
+	"dvmrp": true,
 	// #3311: IS-IS is a recognized host-inbound protocol for vSRX parity, but
 	// it rides OSI/CLNP directly over L2 (LLC-encapsulated, NOT IP) — see
 	// HostInboundL2Protocols below. It admits at commit yet produces NO IP
@@ -190,12 +206,17 @@ var HostInboundServiceFamily = map[string]string{
 
 // HostInboundProtocolFamily maps a family-SPECIFIC `protocols` (routing) token
 // to its only valid address family. Dual-family protocols (bgp, pim, vrrp, bfd,
-// ldp, msdp, nhrp, router-discovery) are absent. `ospf`/`ospf3` are split here
-// even though both ride IP protocol 89: OSPFv2 is IPv4, OSPFv3 is IPv6.
+// ldp, msdp, nhrp, router-discovery, rsvp, pgm, sap) are absent. `ospf`/`ospf3`
+// are split here even though both ride IP protocol 89: OSPFv2 is IPv4, OSPFv3 is
+// IPv6.
 var HostInboundProtocolFamily = map[string]string{
 	"ospf":  "ip",
 	"ospf3": "ip6",
 	"rip":   "ip",
 	"ripng": "ip6",
 	"igmp":  "ip",
+	// #3341: DVMRP is carried inside IGMP (IP protocol 2) and is an IPv4-only
+	// multicast routing protocol — like igmp it must not open proto 2 on the v6
+	// path. rsvp/pgm/sap are dual-family (absent here).
+	"dvmrp": "ip",
 }

--- a/pkg/config/host_inbound_tokens_test.go
+++ b/pkg/config/host_inbound_tokens_test.go
@@ -92,6 +92,42 @@ func TestHostInboundKnownTokensCommit(t *testing.T) {
 	}
 }
 
+// TestHostInboundRoutingProtocolTokensCommit asserts the #3341 routing-control
+// tokens (rsvp/pgm/sap/dvmrp) are ACCEPTED at commit and carry the correct
+// address-family scoping. Before #3341 they were absent from
+// KnownHostInboundProtocols, so since #3200 made tokens typed a valid vSRX
+// config naming them was HARD-REJECTED at commit. Fail-on-revert: remove any of
+// these from KnownHostInboundProtocols and the commit subtest goes RED.
+func TestHostInboundRoutingProtocolTokensCommit(t *testing.T) {
+	for _, tok := range []string{"rsvp", "pgm", "sap", "dvmrp"} {
+		t.Run(tok, func(t *testing.T) {
+			tree := buildTree(t, []string{
+				"set security zones security-zone wan host-inbound-traffic protocols " + tok,
+			})
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("strict commit rejected `host-inbound-traffic protocols %s` (vSRX parity, #3341): %v", tok, err)
+			}
+			if !KnownHostInboundProtocols[tok] {
+				t.Fatalf("%s must be in KnownHostInboundProtocols so commit accepts it", tok)
+			}
+			if HostInboundL2Protocols[tok] {
+				t.Fatalf("%s rides IP, it must NOT be in HostInboundL2Protocols", tok)
+			}
+		})
+	}
+	// rsvp/pgm/sap are dual-family (absent from the family map); dvmrp is
+	// IPv4-only (IGMP-encapsulated), like igmp.
+	for _, dual := range []string{"rsvp", "pgm", "sap"} {
+		if _, scoped := HostInboundProtocolFamily[dual]; scoped {
+			t.Errorf("%s must be dual-family (absent from HostInboundProtocolFamily)", dual)
+		}
+	}
+	if HostInboundProtocolFamily["dvmrp"] != "ip" {
+		t.Errorf("dvmrp must be IPv4-only (HostInboundProtocolFamily[\"dvmrp\"]=%q, want \"ip\")",
+			HostInboundProtocolFamily["dvmrp"])
+	}
+}
+
 // TestHostInboundIsisCommitsAsL2NoOp asserts that
 // `host-inbound-traffic protocols isis` is ACCEPTED at commit (#3311). IS-IS
 // routing is supported via FRR, but before #3311 `isis` was absent from

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -511,6 +511,21 @@ func hostInboundProtocolMatches(token, family string) []string {
 		return []string{"tcp dport 639"}
 	case "nhrp":
 		return []string{"meta l4proto 54"}
+	case "rsvp":
+		// #3341: RSVP rides directly over IP, protocol 46 (dual-family).
+		return []string{"meta l4proto 46"}
+	case "pgm":
+		// #3341: PGM (Pragmatic General Multicast) rides over IP, protocol 113
+		// (dual-family).
+		return []string{"meta l4proto 113"}
+	case "sap":
+		// #3341: SAP (Session Announcement Protocol) is UDP/9875 (dual-family).
+		return []string{"udp dport 9875"}
+	case "dvmrp":
+		// #3341: DVMRP is carried inside IGMP (IP protocol 2) and is IPv4-only;
+		// the family gate above (config.HostInboundProtocolFamily["dvmrp"]="ip")
+		// restricts it to IPv4, matching igmp.
+		return []string{"meta l4proto 2"}
 	case "isis":
 		// #3311: IS-IS rides OSI/CLNP directly over L2 (LLC-encapsulated, NOT
 		// IP), so it cannot be expressed as an ip/ip6 host-inbound match. It is

--- a/pkg/daemon/host_inbound_parity_test.go
+++ b/pkg/daemon/host_inbound_parity_test.go
@@ -103,6 +103,39 @@ func TestHostInboundBfdAdmitsMultiHop(t *testing.T) {
 	}
 }
 
+// TestHostInboundRoutingProtocolTokenMatches asserts the nft host-inbound rules
+// for the #3341 routing-control tokens emit the correct match fragment and
+// family scoping: rsvp=IP proto 46 (dual), pgm=IP proto 113 (dual), sap=UDP/9875
+// (dual), dvmrp=IP proto 2 / IGMP (IPv4-only). These must stay in lockstep with
+// the AF_XDP host_inbound classifier (host_inbound.rs classify_protocol).
+// Fail-on-revert: before #3341 these tokens returned nil (default arm) → no
+// match in either family, turning every subtest RED.
+func TestHostInboundRoutingProtocolTokenMatches(t *testing.T) {
+	dual := []struct {
+		token string
+		want  string
+	}{
+		{"rsvp", "meta l4proto 46"},
+		{"pgm", "meta l4proto 113"},
+		{"sap", "udp dport 9875"},
+	}
+	for _, c := range dual {
+		for _, fam := range []string{"ip", "ip6"} {
+			got := strings.Join(hostInboundProtocolMatches(c.token, fam), " ; ")
+			if !strings.Contains(got, c.want) {
+				t.Errorf("%s (%s) nft match %q missing %q (dual-family)", c.token, fam, got, c.want)
+			}
+		}
+	}
+	// dvmrp is IPv4-only: proto 2 on ip, nothing on ip6 (family gate).
+	if got := strings.Join(hostInboundProtocolMatches("dvmrp", "ip"), " ; "); !strings.Contains(got, "meta l4proto 2") {
+		t.Errorf("dvmrp (ip) nft match %q missing `meta l4proto 2`", got)
+	}
+	if got := hostInboundProtocolMatches("dvmrp", "ip6"); len(got) != 0 {
+		t.Errorf("dvmrp (ip6) must produce NO match (IPv4-only, IGMP-encapsulated); got %v", got)
+	}
+}
+
 // TestHostInboundProtocolsAllExcludesL2Isis asserts that the nft `protocols all`
 // expansion EXCLUDES the L2/non-IP protocol IS-IS (#3311). The nft `all` case
 // derives its expansion from config.HostInboundAllExpansionProtocols()

--- a/userspace-dp/src/afxdp/forwarding/host_inbound.rs
+++ b/userspace-dp/src/afxdp/forwarding/host_inbound.rs
@@ -192,6 +192,14 @@ const KNOWN_ROUTING_PROTOCOL_TOKENS: &[&str] = &[
     "msdp",
     "nhrp",
     "router-discovery",
+    // #3341: additional Junos/vSRX routing-control protocols. All ride IP, so
+    // each contributes a concrete IP admit in classify_protocol: rsvp (proto 46,
+    // dual), pgm (proto 113, dual), sap (UDP/9875, dual), dvmrp (proto 2 / IGMP,
+    // IPv4-only). Mirror of config.KnownHostInboundProtocols.
+    "rsvp",
+    "pgm",
+    "sap",
+    "dvmrp",
     // #3311: IS-IS is a recognized protocol but rides L2 (OSI/CLNP), so it is
     // EXCLUDED from the IP `all` expansion below via HOST_INBOUND_L2_PROTOCOLS.
     "isis",
@@ -292,6 +300,25 @@ fn classify_protocol(token: &str, hi: &mut ZoneHostInbound) {
         }
         "nhrp" => {
             hi.ip_protocols.insert(54);
+        }
+        // #3341: RSVP rides directly over IP, protocol 46 (dual-family).
+        "rsvp" => {
+            hi.ip_protocols.insert(46);
+        }
+        // #3341: PGM (Pragmatic General Multicast) rides over IP, protocol 113
+        // (dual-family).
+        "pgm" => {
+            hi.ip_protocols.insert(113);
+        }
+        // #3341: SAP (Session Announcement Protocol) is UDP/9875 (dual-family).
+        "sap" => {
+            hi.udp_ports.insert(9875);
+        }
+        // #3341: DVMRP is carried inside IGMP (IP protocol 2) and is an IPv4-only
+        // multicast routing protocol (SSOT: config.HostInboundProtocolFamily
+        // ["dvmrp"]="ip"), so it admits proto 2 on v4 only — matching igmp.
+        "dvmrp" => {
+            hi.ip_protocols_v4.insert(2);
         }
         // #3311: IS-IS rides OSI/CLNP directly over L2 (LLC-encapsulated, NOT
         // IP), so it cannot be expressed in this IP-keyed admit model (proto
@@ -450,6 +477,54 @@ mod tests {
     // HOST_INBOUND_L2_PROTOCOLS — isis enters the expansion, but its
     // classify_protocol arm is a no-op, so this stays green; the
     // protocols_all_excludes_l2 token test above is the real RED-on-revert guard.
+    // #3341: the routing-control tokens rsvp/pgm/sap/dvmrp must each classify to
+    // the correct IP admit with the correct family scoping, mirroring the nft
+    // matcher (hostInboundProtocolMatches) and the Go SSOT. Fail-on-revert:
+    // before #3341 these hit the catch-all `_ => {}` no-op arm, so every admit
+    // assertion below goes RED.
+    #[test]
+    fn routing_control_protocol_tokens_classify() {
+        // rsvp — IP proto 46, dual-family.
+        let mut hi = ZoneHostInbound::default();
+        classify_protocol("rsvp", &mut hi);
+        assert!(hi.admits(46, 0, false, 0), "rsvp must admit proto 46 on v4");
+        assert!(hi.admits(46, 0, true, 0), "rsvp must admit proto 46 on v6 (dual)");
+
+        // pgm — IP proto 113, dual-family.
+        let mut hi = ZoneHostInbound::default();
+        classify_protocol("pgm", &mut hi);
+        assert!(hi.admits(113, 0, false, 0), "pgm must admit proto 113 on v4");
+        assert!(hi.admits(113, 0, true, 0), "pgm must admit proto 113 on v6 (dual)");
+
+        // sap — UDP/9875, dual-family.
+        let mut hi = ZoneHostInbound::default();
+        classify_protocol("sap", &mut hi);
+        assert!(hi.admits(17, 9875, false, 0), "sap must admit udp/9875 on v4");
+        assert!(hi.admits(17, 9875, true, 0), "sap must admit udp/9875 on v6 (dual)");
+
+        // dvmrp — IGMP-encapsulated (proto 2), IPv4-only.
+        let mut hi = ZoneHostInbound::default();
+        classify_protocol("dvmrp", &mut hi);
+        assert!(hi.admits(2, 0, false, 0), "dvmrp must admit proto 2 (IGMP) on v4");
+        assert!(
+            !hi.admits(2, 0, true, 0),
+            "dvmrp must NOT admit proto 2 on v6 (IPv4-only)",
+        );
+
+        // All four are recognized routing tokens (so `protocols all` covers them)
+        // and none are L2.
+        for tok in ["rsvp", "pgm", "sap", "dvmrp"] {
+            assert!(
+                KNOWN_ROUTING_PROTOCOL_TOKENS.contains(&tok),
+                "{tok} must be a recognized routing token",
+            );
+            assert!(
+                !is_host_inbound_l2_protocol(tok),
+                "{tok} rides IP, must not be an L2 protocol",
+            );
+        }
+    }
+
     #[test]
     fn protocols_all_admits_ip_routing_not_l2() {
         let mut hi = ZoneHostInbound::default();


### PR DESCRIPTION
Closes #3341

## Problem

Junos/vSRX accepts `rsvp`, `pgm`, `sap`, and `dvmrp` under `security zones <z> host-inbound-traffic protocols <token>`, but they were absent from the recognized-token SSOT (`config.KnownHostInboundProtocols`). Since #3200 made these tokens typed, an unrecognized token is a HARD commit error — so a valid vSRX config naming any of these four was rejected at `commit` / `commit check` rather than being a silent no-op.

## Fix

Add the four tokens end to end across the three layers #3200 requires to agree (commit validation, the nft kernel mirror, and the Rust AF_XDP classifier), so each is actually ENFORCED, mirroring the existing routing-protocol wiring (ospf/bgp/pim/igmp/...):

| token | admit semantics | family |
|-------|-----------------|--------|
| `rsvp`  | IP protocol 46 (`meta l4proto 46`) | dual |
| `pgm`   | IP protocol 113 (`meta l4proto 113`) | dual |
| `sap`   | UDP/9875 (`udp dport 9875`) | dual |
| `dvmrp` | IGMP-encapsulated, IP protocol 2 (`meta l4proto 2`) | **IPv4-only** |

Unlike IS-IS (#3311), all four ride IP, so none belong in `HostInboundL2Protocols`; each maps to a concrete IP host-inbound match and is included in the `protocols all` expansion. `dvmrp` is registered in `HostInboundProtocolFamily` as `ip` so proto 2 never opens on the v6 path (matching `igmp`).

### Files
- `pkg/config/host_inbound_tokens.go` — SSOT tokens + dvmrp family scoping
- `pkg/daemon/daemon_nft.go` — `hostInboundProtocolMatches` nft fragments
- `userspace-dp/src/afxdp/forwarding/host_inbound.rs` — `KNOWN_ROUTING_PROTOCOL_TOKENS` + `classify_protocol` arms
- `docs/junos-cli-reference.md` — operator doc

## Tests (RED-on-revert verified)

Removing the source arms with the new tests retained turns each test RED:
- config `TestHostInboundRoutingProtocolTokensCommit` — each token commits; family scoping asserted
- daemon `TestHostInboundRoutingProtocolTokenMatches` — correct nft match; dvmrp produces proto 2 on ip, NOTHING on ip6
- rust `routing_control_protocol_tokens_classify` — each admits on correct protocol/port/family

`go build ./...`, `go test ./pkg/config/... ./pkg/daemon/... ./pkg/dataplane/userspace/...`, and `cargo test host_inbound` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi