### PR TITLE
config: reject security-log stream tls-profile (parsed but never applied) — Closes #3350

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,24 @@
+## 2026-06-28 — #3350 security-log stream tls-profile reject (parsed-but-never-applied)
+
+- **Timestamp**: 2026-06-28
+- **Action**: `security log stream <s> transport tls-profile <name>` parsed,
+  validated, and stored (compiler_security.go) but was NEVER resolved into a
+  `*tls.Config` at runtime — daemon_system.go applyLogStreams always passes a
+  nil `*tls.Config` to NewSyslogClientTransport, so a TLS syslog stream
+  silently fell back to the system CA roots instead of the named profile (a
+  secure-syslog posture silently downgraded, fail-open). There is also no TLS
+  profile DEFINITION stanza anywhere in the config (only IPsec/IKE define
+  certs), so the named profile has nothing to resolve to — wiring it is
+  impossible. Chose REJECT (issue option b): added
+  `validateSecurityLogStreamTLSProfileAST`, the strict-reject + lenient-
+  downgrade (#1960/#3261) AST-gate pattern shared with the #3349 stream-port
+  gate. A plain `transport protocol tls` (system-root TLS) stays valid; only
+  the named-but-unapplied profile is rejected. Documented the runtime nil-pass
+  + the lift path. RED-on-revert verified.
+- **File(s)**: pkg/config/compiler_security.go, pkg/config/compiler.go,
+  pkg/config/schema_security.go, pkg/daemon/daemon_system.go,
+  pkg/config/log_stream_tls_profile_3350_test.go, docs/config-schema.md
+
 ## 2026-06-28 — #3404 policy-ID namespace exact-256 off-by-one (>= → >)
 
 - **Timestamp**: 2026-06-28

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -701,6 +701,22 @@ reserved for whole-dataplane selection where a rewrite shim
   skipped them and an invalid value committed silently:
   - `security log stream transport` — `protocol` (enum `udp|tcp|tls`,
     matching the `pkg/logging/syslog.go` dial switch) + `tls-profile`.
+    - **#3350 (tls-profile reject):** `transport tls-profile <name>` is
+      parsed/stored but was NEVER resolved into a `*tls.Config` at runtime
+      (`daemon_system.go` applyLogStreams passes a nil `*tls.Config`, and
+      there is no TLS profile definition stanza — cert / trusted-ca / SNI —
+      to resolve it to; only IPsec/IKE define certs). A TLS syslog stream
+      therefore silently used the system CA roots instead of the named
+      profile — a secure-syslog posture silently downgraded (fail-open). It
+      is now REJECTED at commit by `validateSecurityLogStreamTLSProfileAST`
+      (compiler.go), the strict-reject + lenient-downgrade (#1960/#3261)
+      AST-gate pattern shared with the #3349 stream-port gate (the token
+      lives under the `transport` block, a location SchemaValidate cannot
+      express, so it is gated in the compiler not setSchema). A plain
+      `transport protocol tls` stream that trusts the system CA roots stays
+      valid; only the named-but-unapplied profile is rejected. If profile
+      resolution is implemented later, build the `*tls.Config` in
+      `daemon_system.go` and lift the compiler reject.
   - IKE (`security ike proposal`) and IPsec (`security ipsec proposal`)
     crypto leaves — `authentication-method` (IKE only, enum
     `pre-shared-keys|rsa-signatures|ecdsa-signatures`, matching

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -119,6 +119,19 @@ type compileOpts struct {
 	// NOT live in SchemaValidate. Same doctrine as lenientTCPMSSRange.
 	lenientLogStreamPort bool
 
+	// lenientLogTLSProfile (#3350) downgrades the security-log stream
+	// tls-profile gate (validateSecurityLogStreamTLSProfileAST) from a hard
+	// compile error to a cfg.Warnings entry. Set ONLY on the tolerant load /
+	// peer-sync paths: a persisted or peer-synced config naming a
+	// `transport tls-profile` that an older binary accepted (and that the
+	// runtime silently ignored, falling back to system CA roots) must still
+	// boot, not blackout the upgraded node (#1960 / #3261 fail-closed-on-load
+	// class). The profile was never applied either way, so a leniently-loaded
+	// value is inert. Like the port gate this is an AST-level compile decision
+	// (the token lives under the `transport` block) and so does NOT live in
+	// SchemaValidate. Same doctrine as lenientLogStreamPort.
+	lenientLogTLSProfile bool
+
 	// lenientLogEventModeFormat (#3349) downgrades the event-mode log-format
 	// compatibility gate (validateLogEventModeFormatStrict) from a hard
 	// compile error to a cfg.Warnings entry. Set ONLY on the tolerant load /
@@ -1109,6 +1122,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyMatchAddress:            true,
 		lenientTCPMSSRange:                   true,
 		lenientLogStreamPort:                 true,
+		lenientLogTLSProfile:                 true,
 		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
@@ -1248,6 +1262,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyMatchAddress:            true,
 		lenientTCPMSSRange:                   true,
 		lenientLogStreamPort:                 true,
+		lenientLogTLSProfile:                 true,
 		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
@@ -1399,6 +1414,21 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// (load / peer-sync): warn so an already-persisted or peer-synced config
 	// still boots.
 	logStreamPortWarnings, err := validateSecurityLogStreamPortsAST(tree.Children, "", opts.lenientLogStreamPort)
+	if err != nil {
+		return nil, err
+	}
+
+	// #3350 security-log stream tls-profile gate. `transport tls-profile <name>`
+	// is parsed, validated, and stored but NEVER resolved into a *tls.Config at
+	// runtime (daemon_system.go always passes nil), and there is no TLS profile
+	// definition stanza to resolve it to — so a TLS syslog stream silently uses
+	// the system CA roots instead of the named profile (a secure-syslog posture
+	// silently downgraded, fail-open). Like the port gate this is an AST-level
+	// decision under the `transport` block, so it lives here, not in
+	// SchemaValidate. Strict (commit / commit-check): a present tls-profile
+	// hard-rejects. Lenient (load / peer-sync): warn so an already-persisted or
+	// peer-synced config still boots (the profile was never applied either way).
+	logTLSProfileWarnings, err := validateSecurityLogStreamTLSProfileAST(tree.Children, "", opts.lenientLogTLSProfile)
 	if err != nil {
 		return nil, err
 	}
@@ -1574,6 +1604,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, trackWarnings...)
 	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logStreamPortWarnings...)
+	cfg.Warnings = append(cfg.Warnings, logTLSProfileWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMatchWarnings...)

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -1313,6 +1313,78 @@ func validateSecurityLogStreamPortsAST(nodes []*Node, prefix string, lenient boo
 	return warnings, nil
 }
 
+// validateSecurityLogStreamTLSProfileAST is the #3350 commit-time gate for
+// `security log stream <s> transport tls-profile <name>`. The token is parsed
+// (schema_security.go), validated for syntax, and stored on
+// stream.Transport.TLSProfile (compileLog) — but it is NEVER resolved into a
+// *tls.Config at runtime: daemon_system.go applyLogStreams always passes a nil
+// *tls.Config to logging.NewSyslogClientTransport, so the TLS dialer falls back
+// to the system CA roots (pkg/logging/syslog.go dialTLS). There is also no
+// `tls-profile` DEFINITION stanza anywhere in the config (no local-certificate /
+// trusted-ca / SNI source for syslog — only IPsec/IKE define certs), so the
+// named profile has nothing to resolve to. An operator who configures
+// `tls-profile` believes mutual TLS / a pinned CA is in force when it is not —
+// a secure-syslog posture silently downgraded to system roots (a fail-open).
+//
+// Because the profile can never be honored, this gate REJECTS any
+// `transport tls-profile` at commit rather than letting it silently no-op.
+// `transport protocol tls` ON ITS OWN is left intact: a TLS stream that trusts
+// the system CA roots is a legitimate, fully-honored configuration — only the
+// named-but-unapplied profile is rejected.
+//
+// It mirrors compileLog's traversal exactly (FindChild("log") +
+// namedInstances(stream) + the `transport` child loop) so it gates precisely
+// the token the compiler reads. Runs on the group-expanded tree so an
+// apply-groups-inherited tls-profile is covered.
+//
+// Strict path (commit / commit-check, lenient=false): a present tls-profile is
+// a hard compile error. Lenient path (load / peer-sync, lenient=true):
+// downgraded to a warning so an already-persisted or peer-synced config that an
+// older binary accepted (and that silently used system roots) still boots
+// (#1960 / #3261 fail-closed-on-load class). The runtime behavior is unchanged
+// by the lenient downgrade — the profile was never applied either way — so a
+// leniently-loaded value is inert, now flagged.
+func validateSecurityLogStreamTLSProfileAST(nodes []*Node, prefix string, lenient bool) ([]string, error) {
+	var warnings []string
+	for _, n := range nodes {
+		if n.Name() != "security" {
+			continue
+		}
+		secPath := joinNodePath(prefix, n.Keys)
+		for _, logNode := range n.FindChildren("log") {
+			logPath := joinNodePath(secPath, []string{"log"})
+			for _, inst := range namedInstances(logNode.FindChildren("stream")) {
+				streamPath := joinNodePath(logPath, []string{"stream", inst.name})
+				for _, prop := range inst.node.Children {
+					if prop.Name() != "transport" {
+						continue
+					}
+					for _, tc := range prop.Children {
+						if tc.Name() != "tls-profile" {
+							continue
+						}
+						profile := nodeVal(tc)
+						path := joinNodePath(streamPath, []string{"transport", "tls-profile"})
+						msg := fmt.Sprintf("%s: tls-profile %q is not applied at runtime — "+
+							"xpf has no TLS profile definition (certificate / trusted-ca / "+
+							"SNI) to resolve it to, so the TLS syslog stream silently falls "+
+							"back to the system CA roots instead of the named profile. Remove "+
+							"the tls-profile (a `transport protocol tls` stream that trusts the "+
+							"system CA roots is honored) until profile resolution is implemented",
+							path, profile)
+						if lenient {
+							warnings = append(warnings, msg)
+							continue
+						}
+						return warnings, fmt.Errorf("%s", msg)
+					}
+				}
+			}
+		}
+	}
+	return warnings, nil
+}
+
 // tcpMSSKinds are the four tcp-mss sub-kinds the compiler reads
 // (compileFlow MSS switch). Each carries a u16 MSS value that lands in a
 // Rust u16 wire field (TCPMSS{IPsecVPN,GreIn,GreOut}; all-tcp fans out into

--- a/pkg/config/log_stream_tls_profile_3350_test.go
+++ b/pkg/config/log_stream_tls_profile_3350_test.go
@@ -1,0 +1,124 @@
+package config_test
+
+// #3350: `security log stream <s> transport tls-profile <name>` was parsed,
+// validated, and stored but NEVER resolved into a *tls.Config at runtime
+// (daemon_system.go always passes nil; there is no TLS profile definition
+// stanza to resolve it to), so a TLS syslog stream silently fell back to the
+// system CA roots instead of the named profile — a secure-syslog posture
+// silently downgraded (fail-open). The compiler now REJECTS a named tls-profile
+// at commit (validateSecurityLogStreamTLSProfileAST) while leaving a plain
+// `transport protocol tls` (system-root TLS) intact. These tests are
+// RED-on-revert: removing the gate makes the named profile pass silently.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestLogStreamTLSProfile3350_StrictReject asserts a named tls-profile is a
+// hard compile error on the strict (commit / commit-check) path.
+func TestLogStreamTLSProfile3350_StrictReject(t *testing.T) {
+	cases := map[string][]string{
+		"flat-set": {
+			"set security log stream s host 192.0.2.1",
+			"set security log stream s transport protocol tls",
+			"set security log stream s transport tls-profile mytls",
+		},
+		"profile-without-explicit-protocol": {
+			"set security log stream s host 192.0.2.1",
+			"set security log stream s transport tls-profile mytls",
+		},
+	}
+	for name, cmds := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := config.CompileConfig(buildTree3349(t, cmds...))
+			if err == nil {
+				t.Fatalf("expected strict compile rejection for %v, got nil (tls-profile silently accepted)", cmds)
+			}
+			if !strings.Contains(err.Error(), "tls-profile") {
+				t.Fatalf("error should mention tls-profile, got %v", err)
+			}
+		})
+	}
+}
+
+// TestLogStreamTLSProfile3350_NestedReject covers the hierarchical AST shape
+// (Junos-canonical nested transport block) parsed by the real parser.
+func TestLogStreamTLSProfile3350_NestedReject(t *testing.T) {
+	const cfg = `security {
+		log {
+			stream s {
+				host 192.0.2.1;
+				transport {
+					protocol tls;
+					tls-profile mytls;
+				}
+			}
+		}
+	}`
+	p := config.NewParser(cfg)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if _, err := config.CompileConfig(tree); err == nil {
+		t.Fatalf("expected strict compile rejection for nested transport{tls-profile}, got nil")
+	}
+}
+
+// TestLogStreamTLSProfile3350_AcceptPlainTLS asserts a TLS stream WITHOUT a
+// named profile (system-root TLS) — and tcp/udp streams — still commit cleanly.
+// The gate must reject only the named-but-unapplied profile, not TLS itself.
+func TestLogStreamTLSProfile3350_AcceptPlainTLS(t *testing.T) {
+	good := map[string][]string{
+		"plain-tls": {
+			"set security log stream s host 192.0.2.1",
+			"set security log stream s transport protocol tls",
+		},
+		"tcp": {
+			"set security log stream s host 192.0.2.1",
+			"set security log stream s transport protocol tcp",
+		},
+		"udp-default": {
+			"set security log stream s host 192.0.2.1",
+		},
+	}
+	for name, cmds := range good {
+		t.Run(name, func(t *testing.T) {
+			if err := schemaCheck3349(t, cmds...); err != nil {
+				t.Fatalf("valid config rejected by commit-check: %v", err)
+			}
+			if _, err := config.CompileConfig(buildTree3349(t, cmds...)); err != nil {
+				t.Fatalf("valid config failed strict compile: %v", err)
+			}
+		})
+	}
+}
+
+// TestLogStreamTLSProfile3350_LenientWarns proves the #1960/#3261 doctrine: an
+// already-persisted / peer-synced config naming a tls-profile must NOT brick
+// the load — it is downgraded to a warning and still compiles (the profile was
+// never applied either way, so the leniently-loaded value is inert).
+func TestLogStreamTLSProfile3350_LenientWarns(t *testing.T) {
+	tree := buildTree3349(t,
+		"set security log stream s host 192.0.2.1",
+		"set security log stream s transport protocol tls",
+		"set security log stream s transport tls-profile mytls",
+	)
+	cfg, err := config.CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on a named tls-profile, got %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "tls-profile") && strings.Contains(w, "mytls") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a lenient warning about the tls-profile, warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -394,7 +394,16 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 					valueType: ValueEnumOf, valueDesc: "syslog transport protocol",
 					valueExamples: []string{"udp", "tcp", "tls"},
 					validator:     ValidateEnum([]string{"udp", "tcp", "tls"}), children: nil},
-				"tls-profile": {desc: "TLS profile name (for protocol tls)", args: 1, placeholder: "<tls-profile-name>", children: nil},
+				// #3350: tls-profile is kept as a parseable leaf (so `?` /
+				// completion still offer it) but is REJECTED at commit by
+				// validateSecurityLogStreamTLSProfileAST (compiler.go) — it is
+				// never resolved into a *tls.Config at runtime (daemon_system.go
+				// passes nil; there is no TLS profile definition stanza to
+				// resolve it to), so a TLS syslog stream silently uses the system
+				// CA roots. The compiler gate gives a descriptive reject rather
+				// than a bare schema "unknown token". `transport protocol tls`
+				// alone (system-root TLS) stays valid.
+				"tls-profile": {desc: "TLS profile name (rejected: not applied at runtime, #3350)", args: 1, placeholder: "<tls-profile-name>", children: nil},
 			}},
 		}},
 		// H7 (#2008): `security log profile <name>` is a Junos log-routing

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -102,6 +102,14 @@ func (d *Daemon) applySyslogConfig(er *logging.EventReader, cfg *config.Config) 
 		if protocol == "" {
 			protocol = "udp"
 		}
+		// #3350: the final *tls.Config is nil — a TLS stream trusts the system
+		// CA roots (pkg/logging/syslog.go dialTLS). A named `transport
+		// tls-profile` is NOT honored here (there is no TLS profile definition
+		// stanza to resolve into a cert/CA/SNI config); it is rejected at commit
+		// by validateSecurityLogStreamTLSProfileAST so it can never silently
+		// degrade the secure-syslog posture. If profile resolution is ever
+		// implemented, build the *tls.Config from stream.Transport.TLSProfile
+		// here and lift that compiler reject.
 		client, err := logging.NewSyslogClientTransport(stream.Host, stream.Port, srcAddr, protocol, nil)
 		if err != nil {
 			slog.Warn("failed to create syslog client",


### PR DESCRIPTION
## Summary

`security log stream <s> transport tls-profile <name>` was parsed, syntax-validated, and stored on `stream.Transport.TLSProfile`, but **never resolved into a `*tls.Config` at runtime**. `daemon_system.go` `applyLogStreams` always passes a nil `*tls.Config` to `logging.NewSyslogClientTransport`, so the TLS dialer (`pkg/logging/syslog.go` `dialTLS`) silently falls back to the **system CA roots** — no client certificate, no custom CA, no SNI/pinning. The operator believes mutual TLS / a pinned CA is in force when it is not (secure-syslog posture silently downgraded, a fail-open). Found via codex-review-082 (082-H12).

## Disposition: reject (issue option b)

There is **no TLS profile definition stanza anywhere in the xpf config** (no `local-certificate` / `trusted-ca` / SNI source for syslog — only IPsec/IKE define certs), so the named profile has nothing to resolve to. Wiring it through (option a) is impossible without first designing that definition surface. Per the issue's option (b), the named profile is now **rejected at commit** rather than silently no-opping.

## Mechanism

`validateSecurityLogStreamTLSProfileAST` — the strict-reject + lenient-downgrade AST gate (#1960 / #3261 fail-closed-on-load doctrine), the same pattern as the adjacent #3349 stream-port gate. The token lives under the `transport` block, a location the declarative `SchemaValidate` walker cannot express, so it is gated in the compiler (not `setSchema`), exactly like the port/tcp-mss gates.

- **Strict (commit / commit-check):** a present `tls-profile` hard-rejects with a message explaining the secure-syslog degradation and pointing at plain `transport protocol tls`.
- **Lenient (load / peer-sync):** downgraded to a `cfg.Warnings` entry so an already-persisted / peer-synced config that an older binary accepted still boots — the profile was never applied either way, so the value is inert, now flagged.
- A plain `transport protocol tls` stream (system-root TLS) stays fully valid; only the named-but-unapplied profile is rejected.
- The schema keeps `tls-profile` as a parseable leaf (completion/`?` still offer it) so the operator gets the descriptive compiler reject, not a bare unknown-token error.
- Documents the runtime nil-pass + the lift path (build the `*tls.Config` in `daemon_system.go` and remove the reject) for if profile resolution is implemented later.

## Tests (RED-on-revert verified)

Forcing the gate lenient makes the strict tests go RED:
- `TestLogStreamTLSProfile3350_StrictReject` (flat-set + profile-without-explicit-protocol)
- `TestLogStreamTLSProfile3350_NestedReject` (hierarchical transport block)
- `TestLogStreamTLSProfile3350_AcceptPlainTLS` (plain TLS / tcp / udp stay valid)
- `TestLogStreamTLSProfile3350_LenientWarns` (lenient warns + still compiles)

`go build ./...` + `go test ./pkg/config/... ./pkg/logging/...` green.

Closes #3350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi