### PR TITLE
flow: thread gre-performance-acceleration into the dataplane (Closes #3360)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22979,3 +22979,7 @@ top.
   - **File(s)**: pkg/config/compiler_validate_strict.go,
     pkg/config/compiler.go,
     pkg/config/log_stream_config_3349_test.go, docs/config-schema.md, _Log.md
+
+## 2026-06-28 — #3360 gre-performance-acceleration config-truth
+- **Action**: Wire GREAcceleration into Rust ForwardingState for parity (mirror power_mode_disable); fix overstated Go wire comment; add mutation-verify tests (Go + Rust); doc feature-gaps entry.
+- **File(s)**: userspace-dp/src/afxdp/forwarding_build/mod.rs, userspace-dp/src/afxdp/types/forwarding.rs, userspace-dp/src/afxdp/forwarding_build/tests.rs, pkg/dataplane/userspace/protocol.go, pkg/dataplane/userspace/flow_wire_coerce_test.go, docs/feature-gaps.md

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -1045,10 +1045,12 @@ drift) closed in `fix/2008-quickwins-batch1`:
   into session ports", behavior that never happened). On vSRX the knob extracts
   the GRE key/call-id into the session tuple so multiple GRE tunnels between the
   same endpoints map to distinct sessions; the userspace dataplane keys GRE
-  flows on the 5-tuple only, so the flag is now carried for config truth/parity
-  and does not currently alter packet handling (there is no GRE-key extraction
-  path to switch on). Actually keying GRE sessions on the extracted call-id is a
-  separate dataplane feature, not part of this config-truth fix.
+  flows on the 5-tuple only, so the flag is now threaded into the Rust
+  `ForwardingState` for config truth/parity but is NOT yet read by any
+  packet/forwarding path (the field is still `#[allow(dead_code)]`). The
+  consumer — GRE key/call-id extraction into the session tuple — is the deferred
+  feature, and this is the seam it would read; it is not part of this
+  config-truth fix.
 - **M9 `security flow tcp-session no-sequence-check`** — DONE (typed). Added
   the schema child (`pkg/config/schema_security.go`), the
   `TCPSessionConfig.NoSequenceCheck` field (`pkg/config/types_security.go`),

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -1034,6 +1034,21 @@ drift) closed in `fix/2008-quickwins-batch1`:
   express datapath; the userspace dataplane has a single forwarding path, so
   the flag is carried for config truth/parity and does not currently switch
   packet behavior (there is no express/regular split to select between).
+- **`security flow gre-performance-acceleration`** — DONE (threaded, #3360).
+  The parsed `cfg.Security.Flow.GREPerformanceAcceleration` reaches the
+  dataplane via `FlowSnapshot.GREAcceleration` (`buildFlowSnapshot` +
+  `pkg/dataplane/userspace/protocol.go`) and the Rust
+  `FlowSnapshot`/`ForwardingState` (`gre_acceleration`, mirroring
+  `power_mode_disable`). Before #3360 the bit was deserialized on the Rust side
+  and rendered in `show security flow` but never assigned into runtime state —
+  a silent config-truth gap (the Go wire comment even claimed "extract GRE key
+  into session ports", behavior that never happened). On vSRX the knob extracts
+  the GRE key/call-id into the session tuple so multiple GRE tunnels between the
+  same endpoints map to distinct sessions; the userspace dataplane keys GRE
+  flows on the 5-tuple only, so the flag is now carried for config truth/parity
+  and does not currently alter packet handling (there is no GRE-key extraction
+  path to switch on). Actually keying GRE sessions on the extracted call-id is a
+  separate dataplane feature, not part of this config-truth fix.
 - **M9 `security flow tcp-session no-sequence-check`** — DONE (typed). Added
   the schema child (`pkg/config/schema_security.go`), the
   `TCPSessionConfig.NoSequenceCheck` field (`pkg/config/types_security.go`),

--- a/pkg/dataplane/userspace/flow_wire_coerce_test.go
+++ b/pkg/dataplane/userspace/flow_wire_coerce_test.go
@@ -203,3 +203,18 @@ func TestBuildFlowSnapshotThreadsPowerModeDisable(t *testing.T) {
 		t.Fatal("PowerModeDisable should be threaded into FlowSnapshot")
 	}
 }
+
+// TestBuildFlowSnapshotThreadsGREAcceleration pins the #3360 thread-through:
+// `security flow gre-performance-acceleration`
+// (cfg.Security.Flow.GREPerformanceAcceleration) must reach
+// FlowSnapshot.GREAcceleration so the wire bit reflects operator intent.
+func TestBuildFlowSnapshotThreadsGREAcceleration(t *testing.T) {
+	cfg := &config.Config{}
+	if snap := buildFlowSnapshot(cfg); snap.GREAcceleration {
+		t.Fatal("GREAcceleration should be false when unset")
+	}
+	cfg.Security.Flow.GREPerformanceAcceleration = true
+	if snap := buildFlowSnapshot(cfg); !snap.GREAcceleration {
+		t.Fatal("GREAcceleration should be threaded into FlowSnapshot")
+	}
+}

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -145,9 +145,10 @@ type FlowSnapshot struct {
 	// (#3360). On vSRX this extracts the GRE key/call-id into the session tuple
 	// so multiple GRE tunnels between the same endpoints map to distinct
 	// sessions. The userspace dataplane keys GRE flows on the 5-tuple only, so
-	// this threads the operator's intent into ForwardingState (mirroring the
-	// PowerModeDisable plumbing) and is read on the Rust side for parity; it does
-	// not currently alter packet handling (there is no GRE-key extraction path).
+	// this threads the operator's intent into the Rust ForwardingState
+	// (mirroring the PowerModeDisable plumbing) for config truth/parity; the bit
+	// is NOT yet read by any forwarding path. The consumer (GRE key/call-id
+	// extraction) is a deferred feature.
 	GREAcceleration bool `json:"gre_acceleration,omitempty"`
 	// PowerModeDisable carries `security flow power-mode-disable` (#2008 H14).
 	// On vSRX power-mode is an express datapath; disabling it forces the

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -141,7 +141,14 @@ type FlowSnapshot struct {
 	TCPSessionTimeout  int  `json:"tcp_session_timeout,omitempty"`  // seconds, 0=default
 	UDPSessionTimeout  int  `json:"udp_session_timeout,omitempty"`  // seconds, 0=default
 	ICMPSessionTimeout int  `json:"icmp_session_timeout,omitempty"` // seconds, 0=default
-	GREAcceleration    bool `json:"gre_acceleration,omitempty"`     // extract GRE key into session ports
+	// GREAcceleration carries `security flow gre-performance-acceleration`
+	// (#3360). On vSRX this extracts the GRE key/call-id into the session tuple
+	// so multiple GRE tunnels between the same endpoints map to distinct
+	// sessions. The userspace dataplane keys GRE flows on the 5-tuple only, so
+	// this threads the operator's intent into ForwardingState (mirroring the
+	// PowerModeDisable plumbing) and is read on the Rust side for parity; it does
+	// not currently alter packet handling (there is no GRE-key extraction path).
+	GREAcceleration bool `json:"gre_acceleration,omitempty"`
 	// PowerModeDisable carries `security flow power-mode-disable` (#2008 H14).
 	// On vSRX power-mode is an express datapath; disabling it forces the
 	// regular flow path. The userspace dataplane has a single forwarding path,

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -243,6 +243,11 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // #2008 H14: thread `security flow power-mode-disable` into ForwardingState
     // for config truth/parity (single forwarding path; no behavior switch).
     state.power_mode_disable = snapshot.flow.power_mode_disable;
+    // #3360: thread `security flow gre-performance-acceleration` into
+    // ForwardingState for config truth/parity. The userspace dataplane keys GRE
+    // flows on the 5-tuple only (no GRE key/call-id extraction), so this flag is
+    // held for parity and does not currently alter packet handling.
+    state.gre_acceleration = snapshot.flow.gre_acceleration;
     state.session_timeouts = crate::session::SessionTimeouts::from_seconds(
         snapshot.flow.tcp_session_timeout,
         snapshot.flow.udp_session_timeout,

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -244,9 +244,11 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // for config truth/parity (single forwarding path; no behavior switch).
     state.power_mode_disable = snapshot.flow.power_mode_disable;
     // #3360: thread `security flow gre-performance-acceleration` into
-    // ForwardingState for config truth/parity. The userspace dataplane keys GRE
-    // flows on the 5-tuple only (no GRE key/call-id extraction), so this flag is
-    // held for parity and does not currently alter packet handling.
+    // ForwardingState for config truth/parity. The bit lands in ForwardingState
+    // but is not yet read by any packet/forwarding path: the userspace dataplane
+    // keys GRE flows on the 5-tuple only, and the consumer (GRE key/call-id
+    // extraction into the session tuple) is a deferred feature. Carried here so
+    // `show security flow` reflects real plumbed state, not a phantom field.
     state.gre_acceleration = snapshot.flow.gre_acceleration;
     state.session_timeouts = crate::session::SessionTimeouts::from_seconds(
         snapshot.flow.tcp_session_timeout,

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -3757,3 +3757,25 @@ fn build_forwarding_state_carries_power_mode_disable() {
         "ForwardingState.power_mode_disable must equal snapshot.flow.power_mode_disable"
     );
 }
+
+// #3360: pin the snapshot -> runtime read of `gre_acceleration` in
+// forwarding_build/mod.rs (`state.gre_acceleration =
+// snapshot.flow.gre_acceleration`). MUTATION-VERIFY: dropping that assignment
+// (leaving the ForwardingState default of false) must fail this test. Before
+// #3360 the field was deserialized and shown in `show security flow` but never
+// assigned into runtime state — a silent config-truth gap.
+#[test]
+fn build_forwarding_state_carries_gre_acceleration() {
+    let snapshot = ConfigSnapshot {
+        flow: crate::FlowSnapshot {
+            gre_acceleration: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert!(
+        state.gre_acceleration,
+        "ForwardingState.gre_acceleration must equal snapshot.flow.gre_acceleration"
+    );
+}

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -129,9 +129,11 @@ pub(in crate::afxdp) struct ForwardingState {
     /// `security flow gre-performance-acceleration` (#3360). On vSRX this
     /// extracts the GRE key/call-id into the session tuple so multiple GRE
     /// tunnels between the same endpoints map to distinct sessions. The
-    /// userspace dataplane keys GRE flows on the 5-tuple only, so the flag is
-    /// held here for config truth/parity and does not currently alter packet
-    /// handling (there is no GRE-key extraction path to switch on).
+    /// userspace dataplane keys GRE flows on the 5-tuple only, so this flag is
+    /// threaded into ForwardingState for config truth/parity but is NOT yet read
+    /// by any packet/forwarding path — hence `#[allow(dead_code)]`. The consumer
+    /// (GRE key/call-id extraction) is a deferred feature; this is the seam it
+    /// would read.
     #[allow(dead_code)]
     pub(in crate::afxdp) gre_acceleration: bool,
     /// `security flow power-mode-disable` (#2008 H14). vSRX power-mode is an

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -126,6 +126,12 @@ pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) cos: CoSState,
     pub(in crate::afxdp) tx_selection_enabled_v4: bool,
     pub(in crate::afxdp) tx_selection_enabled_v6: bool,
+    /// `security flow gre-performance-acceleration` (#3360). On vSRX this
+    /// extracts the GRE key/call-id into the session tuple so multiple GRE
+    /// tunnels between the same endpoints map to distinct sessions. The
+    /// userspace dataplane keys GRE flows on the 5-tuple only, so the flag is
+    /// held here for config truth/parity and does not currently alter packet
+    /// handling (there is no GRE-key extraction path to switch on).
     #[allow(dead_code)]
     pub(in crate::afxdp) gre_acceleration: bool,
     /// `security flow power-mode-disable` (#2008 H14). vSRX power-mode is an


### PR DESCRIPTION
## Summary
`security flow gre-performance-acceleration` parsed, compiled, threaded into the wire `FlowSnapshot`, and was rendered in `show security flow`, but the Rust dataplane only **deserialized** the wire bit (`gre_acceleration`) and declared it `#[allow(dead_code)]` — it was never assigned into `ForwardingState` and never read. Operators could enable the feature, see it advertised, and get no dataplane behavior. The Go wire comment overstated this further, claiming `// extract GRE key into session ports` — behavior that never happened. A silent config-truth gap on an advertised flow feature (codex-review-084 H3/H8).

## Disposition
Fix direction **(b)** from the issue — the bounded, honest fix mirroring the sibling `power-mode-disable` (#2008 H14). Implementing actual GRE key/call-id extraction into the session tuple is a separate dataplane feature (a fork), not a config-truth fix. The operator's intent is threaded into `ForwardingState` for config truth/parity, and every stale claim of runtime effect is corrected to honest wording.

## Changes
- `userspace-dp/.../forwarding_build/mod.rs`: assign `state.gre_acceleration = snapshot.flow.gre_acceleration` so the bit reaches runtime state instead of defaulting to `false`.
- `userspace-dp/.../types/forwarding.rs`: replace the bare `#[allow(dead_code)]` field with an honest doc comment — the dataplane keys GRE flows on the 5-tuple only, so the flag is held for parity and does not alter packet handling (no GRE-key extraction path to switch on).
- `pkg/dataplane/userspace/protocol.go`: rewrite the Go wire comment to match, dropping the overstated "extract GRE key into session ports" claim.
- mutation-verify tests, **both RED on revert**: Rust `build_forwarding_state_carries_gre_acceleration` (fails if the `mod.rs` assignment is dropped) and Go `TestBuildFlowSnapshotThreadsGREAcceleration` (fails if the `buildFlowSnapshot` thread is dropped).
- `docs/feature-gaps.md`: record the fix and that keying GRE sessions on the extracted call-id is a separate dataplane feature.

## Validation
- `go build ./...` + `go test ./pkg/config/... ./pkg/dataplane/userspace/` green.
- `cargo build` + targeted `cargo test` green.
- Both new tests confirmed RED on revert (assignment / thread removed).

Closes #3360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi