### PR TITLE
config: reject application/application-set name collisions at commit (Closes #3339)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -22979,3 +22979,14 @@ top.
   - **File(s)**: pkg/config/compiler_validate_strict.go,
     pkg/config/compiler.go,
     pkg/config/log_stream_config_3349_test.go, docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3339 — reject application/application-set name collisions at
+    commit (AST gate validateApplicationNameCollisionsAST: cross-namespace
+    app-vs-set, duplicate definitions, duplicate term-generated names). Strict
+    on commit, lenient-warn on load/peer-sync (lenientApplicationNameCollisions).
+    Added docs/config-schema.md #3339 subsection + tests.
+  - **File(s)**: pkg/config/compiler_applications_collision.go,
+    pkg/config/compiler.go,
+    pkg/config/compiler_applications_collision_3339_test.go,
+    docs/config-schema.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -22990,3 +22990,13 @@ top.
     pkg/config/compiler.go,
     pkg/config/compiler_applications_collision_3339_test.go,
     docs/config-schema.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3339 fold (Codex MAJOR) — aggregate collision detection
+    across ALL top-level applications {} blocks, not just the first. The
+    compiler compiles every applications node; a collision split across two
+    sibling blocks (hierarchical parse) was silently accepted. Added 3 split-
+    across-blocks reject tests + 1 distinct-split commit test; doc updated.
+  - **File(s)**: pkg/config/compiler_applications_collision.go,
+    pkg/config/compiler_applications_collision_3339_test.go,
+    docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2203,7 +2203,11 @@ the group-expanded, inactive-pruned tree in `compileExpanded` (alongside
 `validateUnsupportedInterfaceStanzasAST`), NOT a post-compile check on the typed
 `*Config`: by the time the maps are built the colliding definitions have already
 been merged away by last-write-wins — only the raw AST still carries every
-definition. The predefined `junos-*` table lives outside the AST, so a user
+definition. It aggregates counts across EVERY top-level `applications {}` node (a
+hierarchical parse can emit several sibling blocks and `compileExpanded` compiles
+all of them), so a collision SPLIT across two `applications {}` blocks is caught
+just like one inside a single block — the walk must not stop at the first node.
+The predefined `junos-*` table lives outside the AST, so a user
 `application junos-http` that merely SHADOWS a predefined application is not a
 collision (one AST stanza, no peer) and is left untouched; a multi-term
 application minting an implicit set under its own name is likewise not a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2167,6 +2167,63 @@ lenient-warns; plus three-color-policer + `junos-*` predefined + nested-set +
 implicit-multi-term-not-false-rejected cases). Like the gates above, these are
 compiler-side only — not yet typed `setSchema` leaves.
 
+### #3339 — application / application-set name-collision validation
+
+`compileApplications` (`compiler_applications.go`) collects user applications and
+application-sets into two name-keyed maps with **last-write-wins** semantics, and
+a multi-term `applications application <X>` additionally MINTS an implicit
+application-set under the application's own name
+(`apps.ApplicationSets[appName] = implicitSet`). Every one of these writes
+silently overwrote a colliding earlier definition with no commit error
+(Codex review 080, M07 + M08):
+
+- **Application vs application-set sharing a name (M07).** An explicit
+  `applications application-set <X>` silently replaced the implicit set minted
+  for a multi-term `applications application <X>` (and, generally, an application
+  and an application-set are one flat Junos namespace). A policy referencing `<X>`
+  then enforced whichever definition won the map-write race — and the two
+  resolvers DISAGREE on which that is: policy expansion
+  (`resolveUserspaceApplicationNames`) resolves application-first, while the
+  AppID catalog (`addPolicyApps`) resolves application-set-first, so a session
+  could be admitted by one definition but cataloged/labeled by the other.
+- **Duplicate term-generated application name (M08).** Two `term`s under one
+  application generating the same per-term name (`<parent>-<term>`, with a
+  protocol suffix only when one term carries multiple protocols) made the later
+  `apps.Applications[name] = t` overwrite the earlier while the implicit set
+  still listed the duplicate member — ambiguous and silent.
+- **Duplicate application / application-set definition** (the same name authored
+  twice in one namespace) is also rejected. Such duplicates survive as distinct
+  AST siblings only on a hierarchical file parse (the set-command config tree
+  merges same-named siblings), but rejecting them keeps the gate honest for
+  either representation.
+
+The gate `validateApplicationNameCollisionsAST`
+(`pkg/config/compiler_applications_collision.go`) is an **AST pre-walk** run on
+the group-expanded, inactive-pruned tree in `compileExpanded` (alongside
+`validateUnsupportedInterfaceStanzasAST`), NOT a post-compile check on the typed
+`*Config`: by the time the maps are built the colliding definitions have already
+been merged away by last-write-wins — only the raw AST still carries every
+definition. The predefined `junos-*` table lives outside the AST, so a user
+`application junos-http` that merely SHADOWS a predefined application is not a
+collision (one AST stanza, no peer) and is left untouched; a multi-term
+application minting an implicit set under its own name is likewise not a
+self-collision.
+
+**Strict (`commit` / `commit check`):** the first collision is a HARD commit
+error naming the offending name. **Lenient (`Store.Load` / HA peer-sync —
+`CompileConfigLenient` / `CompileConfigForNodeLenient`, flag
+`lenientApplicationNameCollisions`):** the violation downgrades to a
+`cfg.Warnings` entry so a node that committed a colliding config BEFORE this gate
+existed (or a peer-synced config) still BOOTS after upgrade instead of failing
+closed (#1960 / #3261 fail-closed-on-load doctrine); `compileApplications` keeps
+producing the same (arbitrary but stable) last-write-wins maps on that path.
+
+Regression coverage: `pkg/config/compiler_applications_collision_3339_test.go`
+(app-vs-set collision, implicit-set-overwrite, duplicate application / set
+definition, duplicate term-generated name, distinct-names-commit incl. a
+predefined shadow, lenient-warns). Compiler-side only — not a typed `setSchema`
+leaf (applications stay opaque to `SchemaValidate`).
+
 ### #2226 — rib-group `import-rib` undefined-reference validation
 
 `routing-options rib-groups <group> import-rib <rib>` was unvalidated: an

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -338,6 +338,21 @@ type compileOpts struct {
 	// SchemaValidate (applications stay opaque there). Same doctrine as
 	// lenientPolicyMatchAddress / lenientNATHostMask.
 	lenientApplicationSpecs bool
+	// lenientApplicationNameCollisions (#3339, Codex review 080 M07/M08)
+	// downgrades the application / application-set name-collision gate
+	// (validateApplicationNameCollisionsAST) from a hard compile error to a
+	// cfg.Warnings entry. The strict commit / commit-check path hard-rejects a
+	// duplicate application or application-set definition, a name authored as both
+	// an application and an application-set (an explicit set silently overwriting
+	// the implicit set minted for a multi-term application), or two terms whose
+	// generated per-term application names collide — all of which compileApplications
+	// resolves last-write-wins with no commit error, leaving policy expansion and
+	// the AppID catalog free to pick different definitions. The tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or peer-synced
+	// config an older binary silently accepted still BOOTS (#1960 no-brick); the
+	// last-write-wins maps it always produced are unchanged on that path. Same
+	// doctrine as lenientApplicationSpecs / lenientApplicationSetMembers.
+	lenientApplicationNameCollisions bool
 	// lenientFilterProtocols (#2175 review) downgrades the firewall-filter
 	// `from protocol <token>` gate (validateFilterProtocolsStrict) from a
 	// hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1123,6 +1138,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFRRAuthValues:                 true,
 		lenientRouteFilterMatchTypes:         true,
 		lenientApplicationSpecs:              true,
+		lenientApplicationNameCollisions:     true,
 		lenientFilterProtocols:               true,
 		lenientFilterActions:                 true,
 		lenientFilterMatchValues:             true,
@@ -1262,6 +1278,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFRRAuthValues:                 true,
 		lenientRouteFilterMatchTypes:         true,
 		lenientApplicationSpecs:              true,
+		lenientApplicationNameCollisions:     true,
 		lenientFilterProtocols:               true,
 		lenientFilterActions:                 true,
 		lenientFilterMatchValues:             true,
@@ -1413,6 +1430,26 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// accepted still boots (#1960 fail-closed-on-load class).
 	unsupportedIfaceWarnings, err := validateUnsupportedInterfaceStanzasAST(
 		tree.Children, opts.lenientUnsupportedInterfaceStanzas)
+	if err != nil {
+		return nil, err
+	}
+
+	// #3339 (Codex review 080 M07/M08) application / application-set name
+	// collision gate. compileApplications collects applications and
+	// application-sets into name-keyed maps with last-write-wins semantics — a
+	// duplicate definition, an application and application-set sharing a name (an
+	// explicit set overwriting the implicit set minted for a multi-term
+	// application), or two terms generating the same per-term application name all
+	// silently keep the last definition with no commit error, and policy
+	// expansion vs the AppID catalog can then resolve the name to different
+	// definitions. Strict (commit / commit-check): the first collision hard-
+	// rejects. Lenient (load / peer-sync): warn so an already-persisted or
+	// peer-synced config an older binary silently accepted still BOOTS (#1960 /
+	// #3261). Runs on the group-expanded, inactive-pruned AST because the
+	// colliding definitions are merged away by last-write-wins by the time the
+	// typed maps exist — only the raw AST still carries every definition.
+	appCollisionWarnings, err := validateApplicationNameCollisionsAST(
+		tree.Children, opts.lenientApplicationNameCollisions)
 	if err != nil {
 		return nil, err
 	}
@@ -1575,6 +1612,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logStreamPortWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
+	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMatchWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyThenPermitWarnings...)

--- a/pkg/config/compiler_applications_collision.go
+++ b/pkg/config/compiler_applications_collision.go
@@ -69,14 +69,20 @@ import (
 // group-expanded AST and rejects duplicate / cross-namespace application name
 // definitions. See the file-level comment for the doctrine.
 func validateApplicationNameCollisionsAST(nodes []*Node, lenient bool) ([]string, error) {
-	var appsNode *Node
+	// The compiler compiles EVERY top-level `applications` node (compiler.go's
+	// `for _, node := range tree.Children` switch hits `case "applications"`
+	// once per node), so a collision SPLIT across two sibling `applications {}`
+	// blocks (which a hierarchical parse emits as separate top-level nodes) is
+	// just as real as one inside a single block. Aggregate counts across ALL of
+	// them rather than stopping at the first — stopping at the first missed the
+	// exact #3339 bug for a split definition.
+	var appsNodes []*Node
 	for _, n := range nodes {
 		if n.Name() == "applications" {
-			appsNode = n
-			break
+			appsNodes = append(appsNodes, n)
 		}
 	}
-	if appsNode == nil {
+	if len(appsNodes) == 0 {
 		return nil, nil
 	}
 
@@ -90,25 +96,28 @@ func validateApplicationNameCollisionsAST(nodes []*Node, lenient bool) ([]string
 		return nil
 	}
 
-	// Count each name within its namespace. namedInstances enumerates every
-	// instance (it does NOT dedup), so a name authored twice yields count > 1.
+	// Count each name within its namespace across every `applications` block.
+	// namedInstances enumerates every instance (it does NOT dedup), so a name
+	// authored twice — in one block or split across blocks — yields count > 1.
 	appCounts := map[string]int{}
 	appOrder := []string{}
-	for _, inst := range namedInstances(appsNode.FindChildren("application")) {
-		if inst.name == "" {
-			continue
-		}
-		if appCounts[inst.name] == 0 {
-			appOrder = append(appOrder, inst.name)
-		}
-		appCounts[inst.name]++
-	}
 	setCounts := map[string]int{}
-	for _, inst := range namedInstances(appsNode.FindChildren("application-set")) {
-		if inst.name == "" {
-			continue
+	for _, appsNode := range appsNodes {
+		for _, inst := range namedInstances(appsNode.FindChildren("application")) {
+			if inst.name == "" {
+				continue
+			}
+			if appCounts[inst.name] == 0 {
+				appOrder = append(appOrder, inst.name)
+			}
+			appCounts[inst.name]++
 		}
-		setCounts[inst.name]++
+		for _, inst := range namedInstances(appsNode.FindChildren("application-set")) {
+			if inst.name == "" {
+				continue
+			}
+			setCounts[inst.name]++
+		}
 	}
 
 	// 1. Duplicate application definition (same name twice in the application
@@ -172,43 +181,54 @@ func validateApplicationNameCollisionsAST(nodes []*Node, lenient bool) ([]string
 	//    (M08). Two terms whose generated `<parent>-<term>` names collide make
 	//    the later overwrite the earlier in apps.Applications. Computed via the
 	//    SAME parseApplicationTerms the compiler uses so the detected names match
-	//    exactly what would be written. Applications iterated in first-seen order.
-	for _, inst := range namedInstances(appsNode.FindChildren("application")) {
-		appName := inst.name
-		if appName == "" {
-			continue
-		}
-		seen := map[string]bool{}
-		var dupReported = map[string]bool{}
-		for _, prop := range inst.node.Children {
-			if prop.Name() != "term" || len(prop.Keys) < 2 {
+	//    exactly what would be written. The seen/reported sets are keyed by
+	//    application NAME (not per AST node) so a name whose terms are split
+	//    across two `applications` blocks is still caught. Applications iterated
+	//    in first-seen order.
+	termSeen := map[string]map[string]bool{}
+	termDupReported := map[string]map[string]bool{}
+	for _, appsNode := range appsNodes {
+		for _, inst := range namedInstances(appsNode.FindChildren("application")) {
+			appName := inst.name
+			if appName == "" {
 				continue
 			}
-			// Reassemble the term tokens across both AST shapes, mirroring
-			// compileApplications: hierarchical packs values in prop.Keys, flat
-			// set splits them across prop.Keys and prop.Children.
-			allKeys := append([]string(nil), prop.Keys[1:]...)
-			for _, c := range prop.Children {
-				allKeys = append(allKeys, c.Keys...)
+			if termSeen[appName] == nil {
+				termSeen[appName] = map[string]bool{}
+				termDupReported[appName] = map[string]bool{}
 			}
-			for _, t := range parseApplicationTerms(appName, allKeys) {
-				if seen[t.Name] {
-					if !dupReported[t.Name] {
-						dupReported[t.Name] = true
-						if err := emit(
-							"applications application %q has terms that generate "+
-								"the duplicate application name %q — the later term "+
-								"silently overwrites the earlier (with no commit "+
-								"error) while the implicit set still lists the "+
-								"duplicate member; give the terms distinct names "+
-								"(#3339)",
-							appName, t.Name); err != nil {
-							return nil, err
-						}
-					}
+			seen := termSeen[appName]
+			dupReported := termDupReported[appName]
+			for _, prop := range inst.node.Children {
+				if prop.Name() != "term" || len(prop.Keys) < 2 {
 					continue
 				}
-				seen[t.Name] = true
+				// Reassemble the term tokens across both AST shapes, mirroring
+				// compileApplications: hierarchical packs values in prop.Keys,
+				// flat set splits them across prop.Keys and prop.Children.
+				allKeys := append([]string(nil), prop.Keys[1:]...)
+				for _, c := range prop.Children {
+					allKeys = append(allKeys, c.Keys...)
+				}
+				for _, t := range parseApplicationTerms(appName, allKeys) {
+					if seen[t.Name] {
+						if !dupReported[t.Name] {
+							dupReported[t.Name] = true
+							if err := emit(
+								"applications application %q has terms that generate "+
+									"the duplicate application name %q — the later term "+
+									"silently overwrites the earlier (with no commit "+
+									"error) while the implicit set still lists the "+
+									"duplicate member; give the terms distinct names "+
+									"(#3339)",
+								appName, t.Name); err != nil {
+								return nil, err
+							}
+						}
+						continue
+					}
+					seen[t.Name] = true
+				}
 			}
 		}
 	}

--- a/pkg/config/compiler_applications_collision.go
+++ b/pkg/config/compiler_applications_collision.go
@@ -1,0 +1,217 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+)
+
+// compiler_applications_collision.go carries the #3339 (Codex review 080 M07 +
+// M08) reject-at-commit gate for application / application-set NAME COLLISIONS.
+//
+// compileApplications collects user applications and application-sets into two
+// maps keyed by name (apps.Applications[name], apps.ApplicationSets[name]) and a
+// multi-term application additionally MINTS an implicit application-set under the
+// application's own name (apps.ApplicationSets[appName] = implicitSet). Every one
+// of these writes is last-write-wins: a second definition silently OVERWRITES
+// the first, with no commit error. The observable failures (#3339):
+//
+//   - M07: an explicit `applications application-set <X>` silently replaces the
+//     implicit set minted for a multi-term `applications application <X>` (or,
+//     more generally, an application and an application-set share a name). A
+//     policy referencing <X> then enforces whichever definition won the
+//     map-write race — and policy expansion vs the AppID catalog disagree on
+//     which that is (resolveUserspaceApplicationNames resolves application-first;
+//     addPolicyApps resolves application-set-first), so a session can be
+//     admitted by one definition but cataloged/labeled by the other.
+//
+//   - M08: two `term` statements under one application that generate the same
+//     per-term application name (`<parent>-<term>`, with a protocol suffix only
+//     when a single term carries multiple protocols) — the later
+//     apps.Applications[name] = t silently overwrites the earlier while the
+//     implicit set still lists the duplicated member. Ambiguous and silent.
+//
+// Junos treats applications and application-sets as a SINGLE flat namespace and
+// rejects a duplicate definition / a name used for both; this gate restores that
+// parity. It is an AST pre-walk (run on the group-expanded, inactive-pruned tree
+// in compileExpanded) rather than a post-compile check on the typed *Config,
+// because by the time the maps are built the colliding definitions have ALREADY
+// been merged away by last-write-wins — only the raw AST still carries every
+// definition. This mirrors validateUnsupportedInterfaceStanzasAST and the other
+// AST reject-at-commit gates.
+//
+// Strict path (commit / commit-check, lenient=false): the first collision is a
+// hard compile error naming the offending name. Lenient path (load / peer-sync,
+// lenient=true): every collision is returned as a warning and compilation
+// continues with the existing last-write-wins behavior, so an already-persisted
+// or peer-synced config that an older binary silently accepted still BOOTS
+// (#1960 / #3261 fail-closed-on-load doctrine). compileApplications is unchanged
+// — the lenient path deliberately keeps producing the (arbitrary but stable)
+// last-write-wins maps it always did.
+//
+// Scope notes:
+//   - Only USER-authored AST stanzas are examined. The predefined junos-* table
+//     lives outside the AST, so a user `application junos-http` that shadows a
+//     predefined application is NOT a collision (one AST stanza, no peer) and is
+//     left untouched — the legitimate shadow/extend case the #3339 issue calls
+//     out.
+//   - A multi-term application <X> minting an implicit set <X> is NOT a
+//     self-collision: the application stanza and its synthesized set share a name
+//     by design. The collision is only between two OPERATOR-authored stanzas,
+//     i.e. an `application <X>` AND an `application-set <X>`, which is exactly the
+//     M07 implicit-set-overwrite case.
+//   - Duplicate application or application-set definitions (the same name authored
+//     twice in the same namespace) are also rejected; these survive as distinct
+//     AST siblings only on a hierarchical file parse (the set-command config tree
+//     merges same-named siblings), but rejecting them keeps the gate honest for
+//     either representation.
+
+// validateApplicationNameCollisionsAST walks the `applications` subtree of the
+// group-expanded AST and rejects duplicate / cross-namespace application name
+// definitions. See the file-level comment for the doctrine.
+func validateApplicationNameCollisionsAST(nodes []*Node, lenient bool) ([]string, error) {
+	var appsNode *Node
+	for _, n := range nodes {
+		if n.Name() == "applications" {
+			appsNode = n
+			break
+		}
+	}
+	if appsNode == nil {
+		return nil, nil
+	}
+
+	var warnings []string
+	emit := func(format string, args ...any) error {
+		msg := fmt.Sprintf(format, args...)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
+	// Count each name within its namespace. namedInstances enumerates every
+	// instance (it does NOT dedup), so a name authored twice yields count > 1.
+	appCounts := map[string]int{}
+	appOrder := []string{}
+	for _, inst := range namedInstances(appsNode.FindChildren("application")) {
+		if inst.name == "" {
+			continue
+		}
+		if appCounts[inst.name] == 0 {
+			appOrder = append(appOrder, inst.name)
+		}
+		appCounts[inst.name]++
+	}
+	setCounts := map[string]int{}
+	for _, inst := range namedInstances(appsNode.FindChildren("application-set")) {
+		if inst.name == "" {
+			continue
+		}
+		setCounts[inst.name]++
+	}
+
+	// 1. Duplicate application definition (same name twice in the application
+	//    namespace). Reported in first-seen order for a deterministic error.
+	for _, name := range appOrder {
+		if appCounts[name] > 1 {
+			if err := emit(
+				"applications application %q is defined %d times — a duplicate "+
+					"application definition is silently last-write-wins (the later "+
+					"definition replaces the earlier with no commit error); remove "+
+					"the duplicate or rename it (#3339)",
+				name, appCounts[name]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// 2. Duplicate application-set definition (same name twice in the
+	//    application-set namespace).
+	setNames := make([]string, 0, len(setCounts))
+	for name := range setCounts {
+		setNames = append(setNames, name)
+	}
+	sort.Strings(setNames)
+	for _, name := range setNames {
+		if setCounts[name] > 1 {
+			if err := emit(
+				"applications application-set %q is defined %d times — a duplicate "+
+					"application-set definition is silently last-write-wins (the "+
+					"later definition replaces the earlier with no commit error); "+
+					"remove the duplicate or rename it (#3339)",
+				name, setCounts[name]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// 3. Cross-namespace collision: a name authored as BOTH an application and an
+	//    application-set. Applications and application-sets share one flat Junos
+	//    namespace; a multi-term application additionally mints an implicit set
+	//    under its own name, so an explicit `application-set <X>` here silently
+	//    overwrites it. Either way enforcement (policy expansion) and the AppID
+	//    catalog can resolve <X> to different definitions (M07). Reported in
+	//    application first-seen order.
+	for _, name := range appOrder {
+		if setCounts[name] > 0 {
+			if err := emit(
+				"name %q is defined as BOTH an application and an "+
+					"application-set — they share one namespace, so the "+
+					"application-set silently overwrites the application (or the "+
+					"implicit set minted for a multi-term application), and a policy "+
+					"referencing %q may enforce one definition while AppID catalogs "+
+					"the other; rename one of them (#3339)",
+				name, name); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// 4. Duplicate generated per-term application name within one application
+	//    (M08). Two terms whose generated `<parent>-<term>` names collide make
+	//    the later overwrite the earlier in apps.Applications. Computed via the
+	//    SAME parseApplicationTerms the compiler uses so the detected names match
+	//    exactly what would be written. Applications iterated in first-seen order.
+	for _, inst := range namedInstances(appsNode.FindChildren("application")) {
+		appName := inst.name
+		if appName == "" {
+			continue
+		}
+		seen := map[string]bool{}
+		var dupReported = map[string]bool{}
+		for _, prop := range inst.node.Children {
+			if prop.Name() != "term" || len(prop.Keys) < 2 {
+				continue
+			}
+			// Reassemble the term tokens across both AST shapes, mirroring
+			// compileApplications: hierarchical packs values in prop.Keys, flat
+			// set splits them across prop.Keys and prop.Children.
+			allKeys := append([]string(nil), prop.Keys[1:]...)
+			for _, c := range prop.Children {
+				allKeys = append(allKeys, c.Keys...)
+			}
+			for _, t := range parseApplicationTerms(appName, allKeys) {
+				if seen[t.Name] {
+					if !dupReported[t.Name] {
+						dupReported[t.Name] = true
+						if err := emit(
+							"applications application %q has terms that generate "+
+								"the duplicate application name %q — the later term "+
+								"silently overwrites the earlier (with no commit "+
+								"error) while the implicit set still lists the "+
+								"duplicate member; give the terms distinct names "+
+								"(#3339)",
+							appName, t.Name); err != nil {
+							return nil, err
+						}
+					}
+					continue
+				}
+				seen[t.Name] = true
+			}
+		}
+	}
+
+	return warnings, nil
+}

--- a/pkg/config/compiler_applications_collision_3339_test.go
+++ b/pkg/config/compiler_applications_collision_3339_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3339 (Codex review 080 M07/M08): the application compiler silently overwrote
+// application / application-set definitions on a name collision (last-write-wins
+// map writes) instead of rejecting at commit, letting policy expansion and the
+// AppID catalog resolve a name to different definitions. These tests pin the
+// strict reject at commit (CompileConfig) and the lenient downgrade-to-warning
+// on the tolerant load / peer-sync path (CompileConfigLenient).
+
+// buildTreeFromSet (shared with ipsec_proposal_ref_test.go) builds a candidate
+// ConfigTree from flat `set` commands the way the configstore does
+// (ParseSetCommand + SetPath), NOT NewParser — the parser merges newlines and
+// would collapse separate set lines into one node.
+
+// M07: an application and an application-set sharing a name. The set-command
+// config tree keeps these as distinct stanzas (different keywords), so both
+// reach the compiler and the application-set silently overwrites the
+// application's map entry.
+func TestApplicationVsApplicationSetNameCollisionRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application web protocol tcp",
+		"set applications application web destination-port 80",
+		"set applications application-set web application junos-https",
+	})
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of application/application-set name collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "web") ||
+		!strings.Contains(err.Error(), "BOTH an application and an application-set") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// M07 variant: a MULTI-TERM application <X> mints an implicit application-set
+// <X>; an explicit `application-set <X>` then silently replaces it. This is the
+// exact implicit-set-overwrite case from the issue.
+func TestImplicitSetOverwrittenByExplicitSetRejected(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application multi term t1 protocol tcp destination-port 80",
+		"set applications application multi term t2 protocol udp destination-port 53",
+		"set applications application-set multi application junos-http",
+	})
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of explicit set overwriting implicit multi-term set, got nil")
+	}
+	if !strings.Contains(err.Error(), "multi") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Duplicate application definition (same name twice). Survives as distinct AST
+// siblings on a hierarchical representation; built here directly so the gate is
+// exercised independently of how the tree was produced.
+func TestDuplicateApplicationDefinitionRejected(t *testing.T) {
+	tree := &ConfigTree{Children: []*Node{
+		{Keys: []string{"applications"}, Children: []*Node{
+			{Keys: []string{"application", "dup"}, Children: []*Node{
+				{Keys: []string{"protocol", "tcp"}, IsLeaf: true},
+			}},
+			{Keys: []string{"application", "dup"}, Children: []*Node{
+				{Keys: []string{"protocol", "udp"}, IsLeaf: true},
+			}},
+		}},
+	}}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of duplicate application definition, got nil")
+	}
+	if !strings.Contains(err.Error(), "application \"dup\"") ||
+		!strings.Contains(err.Error(), "defined 2 times") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Duplicate application-set definition (same name twice).
+func TestDuplicateApplicationSetDefinitionRejected(t *testing.T) {
+	tree := &ConfigTree{Children: []*Node{
+		{Keys: []string{"applications"}, Children: []*Node{
+			{Keys: []string{"application", "a1"}, Children: []*Node{
+				{Keys: []string{"protocol", "tcp"}, IsLeaf: true},
+			}},
+			{Keys: []string{"application-set", "dupset"}, Children: []*Node{
+				{Keys: []string{"application", "a1"}, IsLeaf: true},
+			}},
+			{Keys: []string{"application-set", "dupset"}, Children: []*Node{
+				{Keys: []string{"application", "junos-http"}, IsLeaf: true},
+			}},
+		}},
+	}}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of duplicate application-set definition, got nil")
+	}
+	if !strings.Contains(err.Error(), "application-set \"dupset\"") ||
+		!strings.Contains(err.Error(), "defined 2 times") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// M08: two terms generating the same per-term application name. Built as
+// distinct term siblings (the hierarchical shape) so both reach
+// parseApplicationTerms and the later overwrites the earlier.
+func TestDuplicateTermGeneratedNameRejected(t *testing.T) {
+	tree := &ConfigTree{Children: []*Node{
+		{Keys: []string{"applications"}, Children: []*Node{
+			{Keys: []string{"application", "app"}, Children: []*Node{
+				{Keys: []string{"term", "dup", "protocol", "tcp", "destination-port", "80"}, IsLeaf: true},
+				{Keys: []string{"term", "dup", "protocol", "udp", "destination-port", "53"}, IsLeaf: true},
+			}},
+		}},
+	}}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of duplicate term generated name, got nil")
+	}
+	if !strings.Contains(err.Error(), "app-dup") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Valid distinct names commit cleanly: an application, a same-config
+// application-set with a DIFFERENT name, a multi-term application whose implicit
+// set name is not reused, and a user application shadowing a predefined junos-*
+// application (the legitimate shadow case must NOT be rejected).
+func TestDistinctApplicationNamesCommit(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application web protocol tcp destination-port 80",
+		"set applications application-set webset application web",
+		"set applications application-set webset application junos-https",
+		"set applications application multi term t1 protocol tcp destination-port 80",
+		"set applications application multi term t2 protocol udp destination-port 53",
+		// A user application shadowing a predefined name is legitimate, not a
+		// collision: there is no application-set with this name.
+		"set applications application junos-ssh protocol tcp destination-port 22",
+	})
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: unexpected error on distinct names: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3339") {
+			t.Fatalf("unexpected #3339 collision warning on a valid config: %q", w)
+		}
+	}
+}
+
+// Lenient path (load / peer-sync) must WARN, not brick: an already-persisted
+// colliding config still compiles, with the collision surfaced as a warning.
+func TestApplicationNameCollisionLenientWarns(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set applications application web protocol tcp destination-port 80",
+		"set applications application-set web application junos-https",
+	})
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: collision must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "web") && strings.Contains(w, "#3339") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #3339 collision warning on the lenient path, got: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_applications_collision_3339_test.go
+++ b/pkg/config/compiler_applications_collision_3339_test.go
@@ -157,6 +157,129 @@ func TestDistinctApplicationNamesCommit(t *testing.T) {
 	}
 }
 
+// parseHier (shared with vrrp_track_test.go) parses a hierarchical (braced)
+// config string. A hierarchical parse can emit MULTIPLE top-level sibling
+// `applications {}` nodes; the compiler compiles every one, so the collision
+// gate must aggregate across all of them.
+
+// Collision SPLIT across two top-level `applications {}` blocks: an application
+// in the first block, an application-set of the same name in the second. The
+// compiler compiles both blocks, so this must be rejected — a walker that
+// stopped at the first `applications` node missed it.
+func TestApplicationVsApplicationSetCollisionSplitAcrossBlocks(t *testing.T) {
+	tree := parseHier(t, `
+applications {
+    application web {
+        protocol tcp;
+        destination-port 80;
+    }
+}
+applications {
+    application-set web {
+        application junos-https;
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of app/app-set collision split across applications blocks, got nil")
+	}
+	if !strings.Contains(err.Error(), "web") ||
+		!strings.Contains(err.Error(), "BOTH an application and an application-set") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Duplicate application definition split across two `applications {}` blocks.
+func TestDuplicateApplicationDefinitionSplitAcrossBlocks(t *testing.T) {
+	tree := parseHier(t, `
+applications {
+    application dup {
+        protocol tcp;
+        destination-port 80;
+    }
+}
+applications {
+    application dup {
+        protocol udp;
+        destination-port 53;
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of duplicate application split across blocks, got nil")
+	}
+	if !strings.Contains(err.Error(), "application \"dup\"") ||
+		!strings.Contains(err.Error(), "defined 2 times") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Duplicate application-set definition split across two `applications {}` blocks.
+func TestDuplicateApplicationSetDefinitionSplitAcrossBlocks(t *testing.T) {
+	tree := parseHier(t, `
+applications {
+    application a1 {
+        protocol tcp;
+        destination-port 80;
+    }
+    application-set dupset {
+        application a1;
+    }
+}
+applications {
+    application-set dupset {
+        application junos-http;
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of duplicate application-set split across blocks, got nil")
+	}
+	if !strings.Contains(err.Error(), "application-set \"dupset\"") ||
+		!strings.Contains(err.Error(), "defined 2 times") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Two distinct `applications {}` blocks with non-colliding names commit cleanly
+// — the aggregation must not over-reject legitimately split definitions.
+func TestDistinctApplicationNamesSplitAcrossBlocksCommit(t *testing.T) {
+	tree := parseHier(t, `
+applications {
+    application web {
+        protocol tcp;
+        destination-port 80;
+    }
+}
+applications {
+    application ssh {
+        protocol tcp;
+        destination-port 22;
+    }
+    application-set webset {
+        application web;
+        application ssh;
+    }
+}
+`)
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: unexpected error on distinct names split across blocks: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3339") {
+			t.Fatalf("unexpected #3339 collision warning on a valid split config: %q", w)
+		}
+	}
+}
+
 // Lenient path (load / peer-sync) must WARN, not brick: an already-persisted
 // colliding config still compiles, with the collision surfaced as a warning.
 func TestApplicationNameCollisionLenientWarns(t *testing.T) {


### PR DESCRIPTION
## Summary

`compileApplications` collected user applications and application-sets into two
name-keyed maps with **last-write-wins** semantics, and a multi-term application
additionally minted an implicit application-set under the application's own name.
Every such write silently overwrote a colliding earlier definition with no commit
error (Codex review 080, #3339 M07/M08):

- An explicit `application-set <X>` silently replaced the implicit set minted for
  a multi-term `application <X>` (applications and application-sets are one flat
  Junos namespace). A policy referencing `<X>` then enforced whichever definition
  won the map-write race, and the two resolvers disagree on which that is: policy
  expansion (`resolveUserspaceApplicationNames`) resolves application-first while
  the AppID catalog (`addPolicyApps`) resolves application-set-first — so a
  session could be admitted by one definition but cataloged/labeled by the other.
- Two terms under one application generating the same per-term application name
  made the later overwrite the earlier while the implicit set still listed the
  duplicate member.
- A duplicate application / application-set definition (same name twice in one
  namespace) silently kept the last.

## Fix

`validateApplicationNameCollisionsAST` (`pkg/config/compiler_applications_collision.go`)
— an AST pre-walk run on the group-expanded, inactive-pruned tree in
`compileExpanded` (alongside `validateUnsupportedInterfaceStanzasAST`). It must
read the raw AST, not the typed `*Config`: by the time the maps are built the
colliding definitions have already been merged away by last-write-wins.

- **Strict** on commit / commit-check: the first collision hard-rejects.
- **Lenient** on load / peer-sync (`lenientApplicationNameCollisions`):
  downgrades to a `cfg.Warnings` entry so a config an older binary silently
  accepted still boots after upgrade (#1960 / #3261 fail-closed-on-load).
  `compileApplications` keeps its last-write-wins maps on that path.

Out of #3339 scope: M09 (unifying the application-vs-application-set *precedence*
between policy expansion and the AppID catalog) is not needed once collisions are
rejected — a name can no longer be both.

### Not rejected (legitimate)

- A user `application junos-http` that **shadows** a predefined `junos-*`
  application (one AST stanza, no peer) — the predefined table lives outside the
  AST, so it is never counted.
- A multi-term application minting an implicit set under its own name (not a
  self-collision).

## Validation

- `go build ./...` and `go test ./pkg/config/...` green.
- New tests `pkg/config/compiler_applications_collision_3339_test.go`: cross-
  namespace collision, implicit-set-overwrite, duplicate application / set
  definition, duplicate term-generated name, distinct-names-commit (incl. a
  predefined shadow), lenient warns-not-bricks.
- RED-on-revert verified: stubbing the gate to a no-op fails all 6 strict +
  lenient assertions; restored = green.
- `docs/config-schema.md` gains a #3339 subsection.

Closes #3339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi