### PR TITLE
policy: fail closed on unknown snapshot action string (Closes #3365)

### DIFF
--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -219,6 +219,26 @@ pub(crate) enum SnapshotIntegrityError {
         forwarding_class: String,
         target_policy: String,
     },
+    /// #3365: a policy rule's `action` field, or the snapshot `default_policy`,
+    /// carried a NON-EMPTY string that is not one of `permit` / `reject` /
+    /// `deny`. The pre-fix `parse_action` mapped any unrecognized string to
+    /// `PolicyAction::Deny` via a catch-all match arm — so a future `reject-*`
+    /// variant, a mixed-version snapshot token, or a corrupt/truncated action
+    /// silently LOST its intended permit/reject/RST semantics and collapsed to a
+    /// plain Deny with no failure surfaced. That is fail-closed for a `permit`
+    /// typo but fail-OPEN for a `reject`: an unrecognized reject downgrades to
+    /// Deny, dropping the RST/ICMP-unreachable behavior the operator configured,
+    /// and it masks wire-contract drift. The Go producer (`policyActionString`
+    /// in `pkg/dataplane/userspace/policies.go`) only ever renders the three
+    /// known tokens, so a normal Go snapshot never trips this; it is the
+    /// helper-boundary backstop for version drift / a corrupt snapshot,
+    /// consistent with the #2124/#3261 fail-closed family. Rejecting the WHOLE
+    /// snapshot (the preflight keeps the previous good state; a fresh boot keeps
+    /// the default-deny `PolicyState`) is action-agnostic. An EMPTY
+    /// `default_policy` is the legitimate `omitempty`/unspecified wire state
+    /// (decodes to the default Deny) and is NOT an error; an empty per-rule
+    /// action IS rejected (every configured rule has a concrete action).
+    UnknownPolicyAction { context: String, action: String },
 }
 
 impl std::fmt::Display for SnapshotIntegrityError {
@@ -330,6 +350,11 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "cos forwarding-class {:?} has equal-flow-target-policy {:?} that is not one of slowest | mean | ideal-share — refusing to silently map it to the \"slowest\" default (which would change queue fairness with no failure surfaced)",
                 forwarding_class, target_policy
+            ),
+            Self::UnknownPolicyAction { context, action } => write!(
+                f,
+                "{} has action {:?} that is not one of permit | reject | deny — refusing to silently map it to Deny (which fail-OPENs an unrecognized reject by dropping its RST/ICMP-unreachable semantics and masks wire-contract drift)",
+                context, action
             ),
         }
     }
@@ -1343,8 +1368,20 @@ pub(crate) fn parse_policy_state_with_counters(
     address_books: &[AddressBookSnapshot],
     counter_store: &PolicyCounterStore,
 ) -> Result<PolicyState, SnapshotIntegrityError> {
+    // #3365: an EMPTY default_policy is the legitimate `omitempty`/unspecified
+    // wire state and decodes to the default-deny posture. A NON-EMPTY string
+    // that is not permit/reject/deny is rejected (fail closed) rather than
+    // silently collapsing to Deny.
+    let default_action = if default_policy.is_empty() {
+        PolicyAction::Deny
+    } else {
+        parse_action(default_policy).ok_or_else(|| SnapshotIntegrityError::UnknownPolicyAction {
+            context: "default-policy".to_string(),
+            action: default_policy.to_string(),
+        })?
+    };
     let mut state = PolicyState {
-        default_action: parse_action(default_policy),
+        default_action,
         rules: Vec::with_capacity(rules.len()),
         zone_pair_index: FxHashMap::default(),
         from_any_index: FxHashMap::default(),
@@ -1540,7 +1577,15 @@ pub(crate) fn parse_policy_state_with_counters(
             destination_v6_empty,
             applications,
             compiled_apps,
-            action: parse_action(&snap.action),
+            // #3365: every configured rule carries a concrete action; an unknown
+            // (or empty) action is rejected fail-closed rather than silently
+            // mapped to Deny (which would fail-OPEN an unrecognized reject).
+            action: parse_action(&snap.action).ok_or_else(|| {
+                SnapshotIntegrityError::UnknownPolicyAction {
+                    context: format!("rule {:?}", rule_id),
+                    action: snap.action.clone(),
+                }
+            })?,
             // #2508: carry the per-policy SYSLOG log selection.
             log_session_init: snap.log_session_init,
             log_session_close: snap.log_session_close,
@@ -2303,11 +2348,19 @@ fn stable_policy_rule_id(snap: &PolicyRuleSnapshot) -> String {
     format!("{}->{}/{}", snap.from_zone, snap.to_zone, snap.name)
 }
 
-fn parse_action(action: &str) -> PolicyAction {
+/// #3365: parse a wire action token into a `PolicyAction`. Returns `None` for
+/// any string that is not one of the three known tokens so the caller can fail
+/// the snapshot closed instead of silently collapsing an unrecognized action
+/// (e.g. a future `reject-*` variant, a typo, or a corrupt token) to Deny. The
+/// empty string is intentionally NOT recognized here; callers decide whether an
+/// empty value is a legitimate unspecified state (snapshot `default_policy`,
+/// `omitempty` on the wire) or a hard error (a per-rule action).
+fn parse_action(action: &str) -> Option<PolicyAction> {
     match action {
-        "permit" => PolicyAction::Permit,
-        "reject" => PolicyAction::Reject,
-        _ => PolicyAction::Deny,
+        "permit" => Some(PolicyAction::Permit),
+        "reject" => Some(PolicyAction::Reject),
+        "deny" => Some(PolicyAction::Deny),
+        _ => None,
     }
 }
 

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -834,6 +834,124 @@ fn go_unsupported_sentinel_fails_closed() {
 }
 
 #[test]
+fn unknown_rule_action_rejects_whole_snapshot() {
+    // #3365 RED-on-revert: a per-rule action string that is not
+    // permit/reject/deny must reject the WHOLE snapshot. Pre-fix `parse_action`
+    // mapped any unknown token to PolicyAction::Deny via a catch-all match arm,
+    // so a future `reject-*` variant or a corrupt token silently downgraded to
+    // a plain Deny (a `reject` losing its RST/ICMP-unreachable semantics) with
+    // NO integrity error. Reverting the fix returns Ok(state) here, so this is
+    // non-tautological.
+    let store = PolicyCounterStore::default();
+    let bad = PolicyRuleSnapshot {
+        rule_id: "bad-action".to_string(),
+        name: "bad-action".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: "reject-tcp".to_string(),
+        ..Default::default()
+    };
+    let result =
+        parse_policy_state_with_counters("deny", &[bad], &test_zone_name_to_id(), &[], &store);
+    match result {
+        Err(SnapshotIntegrityError::UnknownPolicyAction { context, action }) => {
+            assert!(context.contains("bad-action"), "context names the rule: {context}");
+            assert_eq!(action, "reject-tcp");
+        }
+        other => panic!("expected UnknownPolicyAction, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_rule_action_rejects_whole_snapshot() {
+    // #3365: every configured rule carries a concrete action; an EMPTY action
+    // (which pre-fix also collapsed silently to Deny) is rejected fail-closed.
+    let store = PolicyCounterStore::default();
+    let bad = PolicyRuleSnapshot {
+        rule_id: "empty-action".to_string(),
+        name: "empty-action".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: String::new(),
+        ..Default::default()
+    };
+    let result =
+        parse_policy_state_with_counters("deny", &[bad], &test_zone_name_to_id(), &[], &store);
+    assert!(
+        matches!(result, Err(SnapshotIntegrityError::UnknownPolicyAction { .. })),
+        "an empty per-rule action must fail closed, got {result:?}"
+    );
+}
+
+#[test]
+fn unknown_default_policy_action_rejects_whole_snapshot() {
+    // #3365: the snapshot `default_policy` is the other side of the same
+    // string boundary. A non-empty unknown default action must reject the whole
+    // snapshot rather than silently collapse to Deny.
+    let store = PolicyCounterStore::default();
+    let result =
+        parse_policy_state_with_counters("permit-all", &[], &test_zone_name_to_id(), &[], &store);
+    match result {
+        Err(SnapshotIntegrityError::UnknownPolicyAction { context, action }) => {
+            assert_eq!(context, "default-policy");
+            assert_eq!(action, "permit-all");
+        }
+        other => panic!("expected UnknownPolicyAction for default-policy, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_default_policy_is_accepted_as_deny() {
+    // #3365 guard against over-rejection: an EMPTY default_policy is the
+    // legitimate `omitempty`/unspecified wire state and must decode to the
+    // default-deny posture WITHOUT an integrity error. The Rust snapshot field
+    // is `#[serde(default)]`, so a snapshot that omits default_policy delivers
+    // "" — this must NOT be rejected.
+    let store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters("", &[], &test_zone_name_to_id(), &[], &store)
+        .expect("empty default_policy must be accepted");
+    assert_eq!(state.default_action, PolicyAction::Deny);
+}
+
+#[test]
+fn known_actions_still_parse() {
+    // #3365 sanity: the three known tokens still decode to their actions on both
+    // the default-policy and per-rule boundaries.
+    let store = PolicyCounterStore::default();
+    for (tok, want) in [
+        ("permit", PolicyAction::Permit),
+        ("reject", PolicyAction::Reject),
+        ("deny", PolicyAction::Deny),
+    ] {
+        let rule = PolicyRuleSnapshot {
+            rule_id: format!("r-{tok}"),
+            name: format!("r-{tok}"),
+            from_zone: "lan".to_string(),
+            to_zone: "wan".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["any".to_string()],
+            application_terms: Vec::new(),
+            action: tok.to_string(),
+            ..Default::default()
+        };
+        let state =
+            parse_policy_state_with_counters(tok, &[rule], &test_zone_name_to_id(), &[], &store)
+                .unwrap_or_else(|e| panic!("token {tok} must parse: {e:?}"));
+        assert_eq!(state.default_action, want, "default-policy {tok}");
+        assert_eq!(state.rules[0].action, want, "rule action {tok}");
+    }
+}
+
+#[test]
 fn deny_rule_with_unrepresentable_app_rejects_whole_snapshot_no_fall_through() {
     // #3261 doctrine guard (plan test #4): a `deny` rule naming an
     // unrepresentable application AHEAD of a later `permit application any` in


### PR DESCRIPTION
## Summary
`parse_action` in the Rust dataplane mapped any action string that was not
`permit` or `reject` to `PolicyAction::Deny` via a catch-all match arm. This was
applied to both the per-rule action and the snapshot `default_policy`, so a
corrupt, truncated, or mixed-version action token (a future `reject-*` variant,
a typo) silently lost its intended permit/reject/RST semantics and collapsed to
a plain Deny with no `SnapshotIntegrityError` surfaced.

That is fail-closed for a `permit` typo but **fail-OPEN for a `reject`**: an
unrecognized reject downgrades to Deny, dropping the RST/ICMP-unreachable
behavior the operator configured. It also masks wire-contract drift at the last
stringly-typed three-value boundary after the #2124/#3261/#2505 fail-closed
family moved every other unrepresentable snapshot field to an explicit
whole-snapshot reject.

## Fix
- `parse_action` is now fallible (`Option<PolicyAction>`, also recognizing
  `"deny"` explicitly).
- The `parse_policy_state_with_counters` preflight rejects an unknown action —
  for both `default_policy` and any per-rule action — via a new
  `SnapshotIntegrityError::UnknownPolicyAction { context, action }`, before any
  side-effecting snapshot mutation. Whole-snapshot reject keeps the previous
  good state (or fresh-boot default-deny); action-agnostic, mirroring the
  existing book-id / address / application integrity checks (#3261 pattern).
- **Empty** `default_policy` remains the legitimate `omitempty`/unspecified wire
  state (`#[serde(default)]`) and still decodes to default-deny without error; an
  empty per-rule action is rejected (every configured rule has a concrete
  action).
- The Go producer (`policyActionString`) only renders the three known tokens, so
  a normal Go snapshot never trips this — helper-boundary backstop for version
  drift / a corrupt snapshot. The Go simulator (`pkg/policymatch`) works on the
  typed `config.PolicyAction` enum and never parses an action string into a
  verdict, so no change there.

## Tests
New Rust tests in `policy_tests.rs`: unknown per-rule action, empty per-rule
action, and unknown `default_policy` each reject with `UnknownPolicyAction`;
empty `default_policy` accepted as Deny; the three known tokens still parse on
both boundaries.

**RED-on-revert verified**: restoring the old fail-open catch-all
(`_ => Some(PolicyAction::Deny)`) makes the three reject tests fail — the
unknown `reject-tcp` token returns `Ok(state)` with `action: Deny` (silent
permit/reject→deny downgrade), exactly the bug.

## Validation
- `cargo build` green; `cargo test` policy suite green (174 passed). The 3
  `event_stream`/`worker_queue` failures in the full binary suite are
  pre-existing on clean `origin/master` (verified in a pristine worktree) and
  unrelated — this diff touches only `policy.rs` + `policy_tests.rs`.
- `go test ./pkg/dataplane/... ./pkg/policymatch/...` all green.

Closes #3365

🤖 Generated with [Claude Code](https://claude.com/claude-code)