### PR TITLE
policymatch: return matched policy scope and runtime ID (#3331)

### DIFF
--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -978,9 +978,23 @@ func (c *ctl) showMatchPolicies(args []string) error {
 	}
 
 	if resp.Matched {
-		fmt.Printf("Matching policy:\n")
+		if resp.Global {
+			fmt.Printf("Matching policy (global):\n")
+		} else {
+			fmt.Printf("Matching policy:\n")
+		}
 		fmt.Printf("  From zone: %s, To zone: %s\n", req.FromZone, req.ToZone)
 		fmt.Printf("  Policy: %s\n", resp.PolicyName)
+		// #3331: identify WHICH scoped/global policy matched so a verdict maps
+		// back to the runtime policy / session-table ID / audit record when the
+		// same policy name repeats across zone pairs or global scope.
+		fmt.Printf("    Policy ID: %d\n", resp.PolicyId)
+		if resp.Global {
+			fmt.Printf("    Scope: global (match from-zone: %s, to-zone: %s)\n",
+				matchScopeZone(resp.FromZone), matchScopeZone(resp.ToZone))
+		} else {
+			fmt.Printf("    Scope: zone-pair (from-zone: %s, to-zone: %s)\n", resp.FromZone, resp.ToZone)
+		}
 		fmt.Printf("    Source addresses: %v\n", resp.SrcAddresses)
 		fmt.Printf("    Destination addresses: %v\n", resp.DstAddresses)
 		fmt.Printf("    Applications: %v\n", resp.Applications)
@@ -999,6 +1013,16 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		fmt.Printf("No matching policy found for %s -> %s (%s)\n", req.FromZone, req.ToZone, resp.Action)
 	}
 	return nil
+}
+
+// matchScopeZone renders a global policy's match from-zone/to-zone scope for the
+// match-policies output (#3331). An empty scope means the global policy applies
+// to every zone, shown as "any" to match the Junos / `show policies` convention.
+func matchScopeZone(z string) string {
+	if z == "" {
+		return "any"
+	}
+	return z
 }
 
 func (c *ctl) showVRRP() error {

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -415,6 +415,10 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, MatchPoliciesResult{
 		Matched:      true,
 		PolicyName:   res.PolicyName,
+		Global:       res.Global,
+		FromZone:     res.FromZone,
+		ToZone:       res.ToZone,
+		PolicyID:     res.PolicyID,
 		Action:       policymatch.ActionString(res.Action),
 		SrcAddresses: res.SrcAddresses,
 		DstAddresses: res.DstAddresses,

--- a/pkg/api/security_matchpolicies_scope_3331_test.go
+++ b/pkg/api/security_matchpolicies_scope_3331_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// scopeIDAPIStore mirrors the gRPC TestMatchPoliciesResponseCarriesScopeAndID
+// fixture: two zone pairs sharing the duplicate policy NAME "allow" (legal in
+// Junos) plus a scoped global policy, so a name-only verdict is ambiguous —
+// exactly the #3331 case.
+func scopeIDAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone untrust to-zone trust {
+            policy allow {
+                match { source-address any; destination-address any; application any; }
+                then { deny; }
+            }
+        }
+        global {
+            policy g-allow {
+                match { source-address any; destination-address any; application any; from-zone trust; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// scopeIDResponse decodes the REST /security/match envelope including the
+// #3331 scope/id fields.
+type scopeIDResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Matched    bool   `json:"matched"`
+		PolicyName string `json:"policy_name"`
+		Global     bool   `json:"global"`
+		FromZone   string `json:"from_zone"`
+		ToZone     string `json:"to_zone"`
+		PolicyID   uint32 `json:"policy_id"`
+	} `json:"data"`
+}
+
+func matchScopeID(t *testing.T, s *Server, q url.Values) scopeIDResponse {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+	s.matchPoliciesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp scopeIDResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	return resp
+}
+
+// TestMatchPoliciesRESTCarriesScopeAndID pins #3331 on the REST surface: the
+// /security/match JSON must carry the matched policy's global/from_zone/to_zone/
+// policy_id so a caller can disambiguate a verdict when policy names collide
+// across zone pairs / global scope.
+//
+// RED-on-revert: removing the global/from_zone/to_zone/policy_id field copies in
+// matchPoliciesHandler (pkg/api/security.go) zeroes every field below and every
+// assertion fails. The matcher + gRPC tests pin those layers; this pins the REST
+// mapping the gRPC/CLI tests do NOT exercise.
+func TestMatchPoliciesRESTCarriesScopeAndID(t *testing.T) {
+	store := scopeIDAPIStore(t)
+	s := &Server{store: store}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+
+	// untrust->trust "allow" (deny) — a zone-pair match.
+	resp := matchScopeID(t, s, url.Values{"from_zone": {"untrust"}, "to_zone": {"trust"}})
+	if !resp.Data.Matched {
+		t.Fatalf("expected match; got %+v", resp.Data)
+	}
+	if resp.Data.Global {
+		t.Errorf("global = true, want false (zone-pair policy)")
+	}
+	if resp.Data.FromZone != "untrust" || resp.Data.ToZone != "trust" {
+		t.Errorf("scope = %s->%s, want untrust->trust", resp.Data.FromZone, resp.Data.ToZone)
+	}
+	if resp.Data.PolicyName != "allow" {
+		t.Errorf("policy_name = %q, want allow", resp.Data.PolicyName)
+	}
+	var untrustSet, trustSet int
+	for i, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		if zpp.FromZone == "untrust" && zpp.ToZone == "trust" {
+			untrustSet = i
+		}
+		if zpp.FromZone == "trust" && zpp.ToZone == "untrust" {
+			trustSet = i
+		}
+	}
+	wantID := ids[[2]uint32{uint32(untrustSet), 0}]
+	if resp.Data.PolicyID != wantID {
+		t.Errorf("policy_id = %d, want %d (untrust->trust runtime ID)", resp.Data.PolicyID, wantID)
+	}
+	if otherID := ids[[2]uint32{uint32(trustSet), 0}]; otherID == resp.Data.PolicyID {
+		t.Errorf("duplicate-name policies share policy_id %d; cannot disambiguate", resp.Data.PolicyID)
+	}
+
+	// trust->trust has no exact zone-pair rule, so the scoped global g-allow
+	// wins — proving the global branch's scope/id flows through REST too.
+	gp := matchScopeID(t, s, url.Values{"from_zone": {"trust"}, "to_zone": {"trust"}})
+	if !gp.Data.Matched || !gp.Data.Global {
+		t.Fatalf("expected scoped-global match for trust->trust; got %+v", gp.Data)
+	}
+	if gp.Data.PolicyName != "g-allow" {
+		t.Errorf("policy_name = %q, want g-allow", gp.Data.PolicyName)
+	}
+	if gp.Data.FromZone != "trust" {
+		t.Errorf("global scope from_zone = %q, want trust", gp.Data.FromZone)
+	}
+	wantGID := ids[[2]uint32{uint32(len(cfg.Security.Policies)), 0}]
+	if gp.Data.PolicyID != wantGID {
+		t.Errorf("policy_id = %d, want %d (global set runtime ID)", gp.Data.PolicyID, wantGID)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -19,16 +19,16 @@ type StatusResponse struct {
 
 // GlobalStats holds all global counter values.
 type GlobalStats struct {
-	RxPackets       uint64 `json:"rx_packets"`
-	TxPackets       uint64 `json:"tx_packets"`
-	Drops           uint64 `json:"drops"`
-	SessionsCreated uint64 `json:"sessions_created"`
-	SessionsClosed  uint64 `json:"sessions_closed"`
-	ScreenDrops     uint64 `json:"screen_drops"`
-	PolicyDenies    uint64 `json:"policy_denies"`
-	NATAllocFails   uint64 `json:"nat_alloc_failures"`
-	HostInboundDeny  uint64 `json:"host_inbound_denies"`
-	TCEgressPackets  uint64 `json:"tc_egress_packets"`
+	RxPackets            uint64 `json:"rx_packets"`
+	TxPackets            uint64 `json:"tx_packets"`
+	Drops                uint64 `json:"drops"`
+	SessionsCreated      uint64 `json:"sessions_created"`
+	SessionsClosed       uint64 `json:"sessions_closed"`
+	ScreenDrops          uint64 `json:"screen_drops"`
+	PolicyDenies         uint64 `json:"policy_denies"`
+	NATAllocFails        uint64 `json:"nat_alloc_failures"`
+	HostInboundDeny      uint64 `json:"host_inbound_denies"`
+	TCEgressPackets      uint64 `json:"tc_egress_packets"`
 	FabricRedirects      uint64 `json:"fabric_redirects"`
 	FabricFwdDrops       uint64 `json:"fabric_fwd_drops"`
 	FlowCacheHits        uint64 `json:"flow_cache_hits"`
@@ -120,13 +120,13 @@ type SessionListResponse struct {
 
 // SessionSummary holds session table summary stats.
 type SessionSummary struct {
-	TotalEntries  int `json:"total_entries"`
-	ForwardOnly   int `json:"forward_only"`
-	Established   int `json:"established"`
-	IPv4Sessions  int `json:"ipv4_sessions"`
-	IPv6Sessions  int `json:"ipv6_sessions"`
-	SNATSessions  int `json:"snat_sessions"`
-	DNATSessions  int `json:"dnat_sessions"`
+	TotalEntries int `json:"total_entries"`
+	ForwardOnly  int `json:"forward_only"`
+	Established  int `json:"established"`
+	IPv4Sessions int `json:"ipv4_sessions"`
+	IPv6Sessions int `json:"ipv6_sessions"`
+	SNATSessions int `json:"snat_sessions"`
+	DNATSessions int `json:"dnat_sessions"`
 }
 
 // EventEntry holds a single event record.
@@ -155,10 +155,10 @@ type NATSourceInfo struct {
 
 // NATDestInfo holds destination NAT configuration.
 type NATDestInfo struct {
-	Name        string `json:"name"`
-	DstAddr     string `json:"dst_addr"`
-	DstPort     uint16 `json:"dst_port,omitempty"`
-	TranslateIP string `json:"translate_ip"`
+	Name          string `json:"name"`
+	DstAddr       string `json:"dst_addr"`
+	DstPort       uint16 `json:"dst_port,omitempty"`
+	TranslateIP   string `json:"translate_ip"`
 	TranslatePort uint16 `json:"translate_port,omitempty"`
 }
 
@@ -206,15 +206,15 @@ type NATPoolStatsInfo struct {
 
 // NATRuleStatsInfo holds NAT rule counters.
 type NATRuleStatsInfo struct {
-	RuleSet     string `json:"rule_set"`
-	RuleName    string `json:"rule_name"`
-	FromZone    string `json:"from_zone"`
-	ToZone      string `json:"to_zone"`
-	Action      string `json:"action"`
-	SrcMatch    string `json:"source_match"`
-	DstMatch    string `json:"destination_match"`
-	HitPackets  uint64 `json:"hit_packets"`
-	HitBytes    uint64 `json:"hit_bytes"`
+	RuleSet    string `json:"rule_set"`
+	RuleName   string `json:"rule_name"`
+	FromZone   string `json:"from_zone"`
+	ToZone     string `json:"to_zone"`
+	Action     string `json:"action"`
+	SrcMatch   string `json:"source_match"`
+	DstMatch   string `json:"destination_match"`
+	HitPackets uint64 `json:"hit_packets"`
+	HitBytes   uint64 `json:"hit_bytes"`
 }
 
 // VRRPInstanceInfo holds VRRP instance information.
@@ -235,8 +235,24 @@ type VRRPStatusResponse struct {
 
 // MatchPoliciesResult holds policy match results.
 type MatchPoliciesResult struct {
-	Matched      bool     `json:"matched"`
-	PolicyName   string   `json:"policy_name,omitempty"`
+	Matched    bool   `json:"matched"`
+	PolicyName string `json:"policy_name,omitempty"`
+	// Global is true when the matched policy is a `policy global` rule rather
+	// than a zone-pair rule (#3331). It distinguishes a global-scope verdict
+	// from a same-named zone-pair policy.
+	Global bool `json:"global,omitempty"`
+	// FromZone/ToZone are the SCOPE of the matched policy (#3331): for a
+	// zone-pair policy the surrounding from-zone/to-zone stanza; for a global
+	// policy its optional `match from-zone`/`match to-zone` scope (empty when
+	// the global policy applies to all zones). They disambiguate a verdict when
+	// the same policy name repeats across zone pairs (legal in Junos).
+	FromZone string `json:"from_zone,omitempty"`
+	ToZone   string `json:"to_zone,omitempty"`
+	// PolicyID is the stable runtime/RT_FLOW/session-table policy ID of the
+	// matched policy (#3331), so a match-policies answer can be cross-referenced
+	// against the session table and the policy-deny/permit audit log even when
+	// policy names collide across scopes. Present only when matched.
+	PolicyID     uint32   `json:"policy_id,omitempty"`
 	Action       string   `json:"action"`
 	SrcAddresses []string `json:"src_addresses,omitempty"`
 	DstAddresses []string `json:"dst_addresses,omitempty"`

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -447,6 +447,15 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	}
 	fmt.Printf("  From zone: %s, To zone: %s\n", fromZone, toZone)
 	fmt.Printf("  Policy: %s\n", res.PolicyName)
+	// #3331: identify WHICH scoped/global policy matched so a verdict maps back
+	// to the runtime policy / session-table ID / audit record when names repeat.
+	fmt.Printf("    Policy ID: %d\n", res.PolicyID)
+	if res.Global {
+		fmt.Printf("    Scope: global (match from-zone: %s, to-zone: %s)\n",
+			matchScopeZone(res.FromZone), matchScopeZone(res.ToZone))
+	} else {
+		fmt.Printf("    Scope: zone-pair (from-zone: %s, to-zone: %s)\n", res.FromZone, res.ToZone)
+	}
 	if res.Description != "" {
 		fmt.Printf("    Description: %s\n", res.Description)
 	}
@@ -455,4 +464,14 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	fmt.Printf("    Applications: %v\n", res.Applications)
 	fmt.Printf("    Action: %s\n", policymatch.ActionString(res.Action))
 	return nil
+}
+
+// matchScopeZone renders a global policy's match from-zone/to-zone scope for the
+// match-policies output (#3331). An empty scope means the global policy applies
+// to every zone, shown as "any" to match the Junos / `show policies` convention.
+func matchScopeZone(z string) string {
+	if z == "" {
+		return "any"
+	}
+	return z
 }

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -230,6 +230,10 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 	return &pb.MatchPoliciesResponse{
 		Matched:      true,
 		PolicyName:   res.PolicyName,
+		Global:       res.Global,
+		FromZone:     res.FromZone,
+		ToZone:       res.ToZone,
+		PolicyId:     res.PolicyID,
 		Action:       policymatch.ActionString(res.Action),
 		SrcAddresses: res.SrcAddresses,
 		DstAddresses: res.DstAddresses,

--- a/pkg/grpcapi/server_matchpolicies_scope_3331_test.go
+++ b/pkg/grpcapi/server_matchpolicies_scope_3331_test.go
@@ -1,0 +1,144 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// scopeIDPolicyStore commits two zone pairs that share a duplicate policy NAME
+// "allow" (legal in Junos) plus a scoped global policy, so a name-only verdict
+// is ambiguous — exactly the #3331 case.
+func scopeIDPolicyStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        from-zone untrust to-zone trust {
+            policy allow {
+                match { source-address any; destination-address any; application any; }
+                then { deny; }
+            }
+        }
+        global {
+            policy g-allow {
+                match { source-address any; destination-address any; application any; from-zone trust; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesResponseCarriesScopeAndID pins #3331 on the gRPC surface:
+// the MatchPolicies response must report Global, FromZone/ToZone scope, and the
+// stable runtime PolicyId so a caller can disambiguate a verdict when policy
+// names collide across zone pairs / global scope.
+//
+// RED-on-revert: before #3331 MatchPoliciesResponse carried only
+// policy_name/action, so Global/FromZone/ToZone/PolicyId are all zero-value and
+// every assertion below fails.
+func TestMatchPoliciesResponseCarriesScopeAndID(t *testing.T) {
+	store := scopeIDPolicyStore(t)
+	s := &Server{store: store}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+
+	// untrust->trust "allow" (deny) — a zone-pair match.
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "untrust", ToZone: "trust",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies error = %v", err)
+	}
+	if !resp.Matched {
+		t.Fatalf("expected match, got %+v", resp)
+	}
+	if resp.Global {
+		t.Errorf("Global = true, want false (zone-pair policy)")
+	}
+	if resp.FromZone != "untrust" || resp.ToZone != "trust" {
+		t.Errorf("scope = %s->%s, want untrust->trust", resp.FromZone, resp.ToZone)
+	}
+	if resp.PolicyName != "allow" {
+		t.Errorf("PolicyName = %q, want allow", resp.PolicyName)
+	}
+	// PolicyId must be the untrust->trust set's runtime ID, NOT the same-named
+	// trust->untrust policy's.
+	var untrustSet, trustSet int
+	for i, zpp := range cfg.Security.Policies {
+		if zpp == nil {
+			continue
+		}
+		if zpp.FromZone == "untrust" && zpp.ToZone == "trust" {
+			untrustSet = i
+		}
+		if zpp.FromZone == "trust" && zpp.ToZone == "untrust" {
+			trustSet = i
+		}
+	}
+	wantID := ids[[2]uint32{uint32(untrustSet), 0}]
+	if resp.PolicyId != wantID {
+		t.Errorf("PolicyId = %d, want %d (untrust->trust runtime ID)", resp.PolicyId, wantID)
+	}
+	if otherID := ids[[2]uint32{uint32(trustSet), 0}]; otherID == resp.PolicyId {
+		t.Errorf("duplicate-name policies share PolicyId %d; cannot disambiguate", resp.PolicyId)
+	}
+
+	// trust->untrust matches the SCOPED GLOBAL g-allow first? No — the exact
+	// zone-pair "allow" (permit) outranks global. Query a pair with NO exact
+	// zone-pair rule so the scoped global wins, proving the global branch
+	// stamps scope/id too. trust->untrust has an exact rule, so use a flow that
+	// only the global covers: trust as ingress, but choose to-zone that has no
+	// exact pair. Here trust->untrust IS exact (permit), so assert that path
+	// reports the zone-pair, then separately exercise the global via from trust
+	// to a different (defined) zone with no exact pair.
+	respGP, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust", ToZone: "trust",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(global) error = %v", err)
+	}
+	if !respGP.Matched || !respGP.Global {
+		t.Fatalf("expected scoped-global match for trust->trust, got %+v", respGP)
+	}
+	if respGP.PolicyName != "g-allow" {
+		t.Errorf("PolicyName = %q, want g-allow", respGP.PolicyName)
+	}
+	if respGP.FromZone != "trust" {
+		t.Errorf("global scope from-zone = %q, want trust", respGP.FromZone)
+	}
+	wantGID := ids[[2]uint32{uint32(len(cfg.Security.Policies)), 0}]
+	if respGP.PolicyId != wantGID {
+		t.Errorf("PolicyId = %d, want %d (global set runtime ID)", respGP.PolicyId, wantGID)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -6112,8 +6112,25 @@ type MatchPoliciesResponse struct {
 	// `action` is empty; clients must render "host-inbound (local delivery; not
 	// governed by transit/global/default policy)", NOT a default-policy verdict.
 	HostInboundUnmatched bool `protobuf:"varint,7,opt,name=host_inbound_unmatched,json=hostInboundUnmatched,proto3" json:"host_inbound_unmatched,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// global is true when the matched policy is a `policy global` rule rather
+	// than a zone-pair rule (#3331); it distinguishes a global-scope verdict from
+	// a same-named zone-pair policy.
+	Global bool `protobuf:"varint,8,opt,name=global,proto3" json:"global,omitempty"`
+	// from_zone/to_zone are the SCOPE of the matched policy (#3331): for a
+	// zone-pair policy the surrounding from-zone/to-zone stanza; for a global
+	// policy its optional `match from-zone`/`match to-zone` scope (empty when the
+	// global policy applies to all zones). They disambiguate a verdict when the
+	// same policy name repeats across zone pairs (legal in Junos). Set only when
+	// matched is true.
+	FromZone string `protobuf:"bytes,9,opt,name=from_zone,json=fromZone,proto3" json:"from_zone,omitempty"`
+	ToZone   string `protobuf:"bytes,10,opt,name=to_zone,json=toZone,proto3" json:"to_zone,omitempty"`
+	// policy_id is the stable runtime/RT_FLOW/session-table policy ID of the
+	// matched policy (#3331), so a match-policies answer can be cross-referenced
+	// against the session table and the policy-deny/permit audit log even when
+	// policy names collide across scopes. Set only when matched is true.
+	PolicyId      uint32 `protobuf:"varint,11,opt,name=policy_id,json=policyId,proto3" json:"policy_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MatchPoliciesResponse) Reset() {
@@ -6193,6 +6210,34 @@ func (x *MatchPoliciesResponse) GetHostInboundUnmatched() bool {
 		return x.HostInboundUnmatched
 	}
 	return false
+}
+
+func (x *MatchPoliciesResponse) GetGlobal() bool {
+	if x != nil {
+		return x.Global
+	}
+	return false
+}
+
+func (x *MatchPoliciesResponse) GetFromZone() string {
+	if x != nil {
+		return x.FromZone
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetToZone() string {
+	if x != nil {
+		return x.ToZone
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetPolicyId() uint32 {
+	if x != nil {
+		return x.PolicyId
+	}
+	return 0
 }
 
 type GetNATRuleStatsRequest struct {
@@ -7476,7 +7521,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
-	"_icmp_code\"\x8e\x02\n" +
+	"_icmp_code\"\xf9\x02\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -7485,7 +7530,12 @@ const file_xpf_proto_rawDesc = "" +
 	"\rdst_addresses\x18\x04 \x03(\tR\fdstAddresses\x12\"\n" +
 	"\fapplications\x18\x05 \x03(\tR\fapplications\x12\x18\n" +
 	"\amatched\x18\x06 \x01(\bR\amatched\x124\n" +
-	"\x16host_inbound_unmatched\x18\a \x01(\bR\x14hostInboundUnmatched\"N\n" +
+	"\x16host_inbound_unmatched\x18\a \x01(\bR\x14hostInboundUnmatched\x12\x16\n" +
+	"\x06global\x18\b \x01(\bR\x06global\x12\x1b\n" +
+	"\tfrom_zone\x18\t \x01(\tR\bfromZone\x12\x17\n" +
+	"\ato_zone\x18\n" +
+	" \x01(\tR\x06toZone\x12\x1b\n" +
+	"\tpolicy_id\x18\v \x01(\rR\bpolicyId\"N\n" +
 	"\x16GetNATRuleStatsRequest\x12\x19\n" +
 	"\brule_set\x18\x01 \x01(\tR\aruleSet\x12\x19\n" +
 	"\bnat_type\x18\x02 \x01(\tR\anatType\"E\n" +

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -112,6 +112,32 @@ and deleted the bespoke helpers. Its rendered output format is unchanged except
 the formerly hard-coded `Default deny` line now reflects the configured
 default-policy (`Default permit`/`Default deny`/`Default reject`).
 
+## Verdict scope and identity (#3331)
+
+A match-policies answer of "policy X matched" is ambiguous: duplicate policy
+names are legal across different from-zone/to-zone pairs and the global scope
+(Junos), so a name alone cannot be mapped back to the runtime policy, the
+session-table policy ID, or the policy-deny/permit audit record. `Result` (and
+the REST `MatchPoliciesResult` / gRPC `MatchPoliciesResponse` it feeds) therefore
+carries the matched policy's full identity:
+
+- `Global` — true when the match came from a `policy global` rule rather than a
+  zone-pair rule.
+- `FromZone` / `ToZone` — the SCOPE of the matched policy. For a zone-pair policy
+  these are the surrounding `from-zone`/`to-zone` stanza; for a global policy
+  they are its optional `match from-zone`/`match to-zone` scope (#3148), empty
+  meaning the global policy applies to every zone (rendered `any`).
+- `PolicyID` — the stable runtime/RT_FLOW/session-table policy ID, computed by
+  the SSOT `dataplane/userspace.RuntimePolicyIDs` (the same span-accumulated
+  namespace the dataplane write side and the `show policies` Index column use,
+  #3063). `Match` resolves this map once up front and stamps the ID by the
+  matched policy's `[policySetID, sliceIndex]` coordinates (a global policy's
+  `policySetID` is `len(cfg.Security.Policies)`), so a verdict cross-references
+  the session table / audit log even when policy names collide across scopes.
+
+These are meaningful only on a concrete match (`Matched == true`); the
+default-policy and host-inbound verdicts leave them zero-valued.
+
 ## Why this exists (#3042)
 
 Before #3042 each surface carried its own hand-written shadow matcher, and all

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
 // MaxPort is the largest valid TCP/UDP port number.
@@ -248,6 +249,28 @@ type Result struct {
 	// meaning in this case.
 	HostInboundUnmatched bool
 
+	// FromZone and ToZone identify the SCOPE of the matched policy (#3331), so
+	// a caller can disambiguate a verdict when the same policy name repeats
+	// across zone pairs / global scope (legal in Junos). For a zone-pair policy
+	// these are the surrounding `from-zone`/`to-zone` stanza. For a GLOBAL
+	// policy they are the optional `match from-zone`/`match to-zone` scope
+	// (#3148/#3288); an empty value means the global policy is unconstrained and
+	// applies to every zone (callers render "" as "any" when Global is true).
+	// Both are empty when no policy matched (DefaultUsed / HostInboundUnmatched).
+	FromZone string
+	ToZone   string
+
+	// PolicyID is the stable runtime/RT_FLOW/session-table policy ID of the
+	// matched policy (#3331), computed by the SSOT
+	// dataplane/userspace.RuntimePolicyIDs (the same span-accumulated namespace
+	// the dataplane write side and the `show policies` Index column use, #3063).
+	// It lets a match-policies verdict be cross-referenced against the session
+	// table and the policy-deny/permit audit log even when policy names collide
+	// across scopes. Meaningful only when Matched is true; 0 for the
+	// default-policy / host-inbound verdicts (and for a config that overflows
+	// MaxRulesPerPolicy, which cannot be applied anyway — see RuntimePolicyIDs).
+	PolicyID uint32
+
 	PolicyName   string
 	Description  string
 	Action       config.PolicyAction
@@ -277,11 +300,18 @@ func Match(cfg *config.Config, q Query) Result {
 		return Result{DefaultUsed: true, Action: config.PolicyDeny}
 	}
 
+	// #3331: resolve the stable runtime policy-ID namespace once, up front, so a
+	// match can stamp Result.PolicyID. This is the SAME SSOT the dataplane write
+	// side and the `show policies` Index column use (RuntimePolicyIDs ->
+	// walkPolicyRuleSlots), keyed by [policySetID, sliceIndex] — the exact
+	// (set index, slice index) coordinates the tier loops below already iterate.
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+
 	// #3285: host-bound (LocalDelivery) traffic is governed by the dataplane's
 	// host gate, which does NOT apply transit global/default fallback. Branch
 	// before the transit tiers so that invariant cannot regress.
 	if q.ToZone == JunosHostZone {
-		return matchJunosHost(cfg, q)
+		return matchJunosHost(cfg, q, ids)
 	}
 
 	// #3355: the runtime gates the ENTIRE transit block — exact zone-pair, the
@@ -301,13 +331,13 @@ func Match(cfg *config.Config, q Query) Result {
 	// Tier 1: exact zone-pair policies, in config order (first match wins).
 	// q.FromZone/q.ToZone are concrete zone names; a wildcard set
 	// (FromZone/ToZone == "any") never compares equal, so it is excluded here.
-	for _, zpp := range cfg.Security.Policies {
+	for setIdx, zpp := range cfg.Security.Policies {
 		if zpp == nil || zpp.FromZone != q.FromZone || zpp.ToZone != q.ToZone {
 			continue
 		}
-		for _, pol := range zpp.Policies {
+		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(pol, false)
+				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
 			}
 		}
 	}
@@ -318,7 +348,7 @@ func Match(cfg *config.Config, q Query) Result {
 	// rule index; the snapshot builder (walkPolicyRuleSlots) emits rules in
 	// cfg.Security.Policies slice order with each set's policies contiguous, so
 	// a single in-order pass over the sets reproduces that merge exactly.
-	for _, zpp := range cfg.Security.Policies {
+	for setIdx, zpp := range cfg.Security.Policies {
 		if zpp == nil {
 			continue
 		}
@@ -331,28 +361,32 @@ func Match(cfg *config.Config, q Query) Result {
 		if !applies {
 			continue
 		}
-		for _, pol := range zpp.Policies {
+		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(pol, false)
+				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
 			}
 		}
 	}
 
 	// Tier 3: both-any (`from-zone any to-zone any`), in config order.
-	for _, zpp := range cfg.Security.Policies {
+	for setIdx, zpp := range cfg.Security.Policies {
 		if zpp == nil || zpp.FromZone != "any" || zpp.ToZone != "any" {
 			continue
 		}
-		for _, pol := range zpp.Policies {
+		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(pol, false)
+				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
 			}
 		}
 	}
 
 	// Tier 4: global policies (junos-global), in config order, gated by the
-	// optional #3148 from-zone/to-zone match scope.
-	for _, pol := range cfg.Security.GlobalPolicies {
+	// optional #3148 from-zone/to-zone match scope. The runtime policy-ID
+	// namespace places global policies in the policy set that immediately
+	// follows the last zone-pair set (walkPolicyRuleSlots), i.e. policySetID ==
+	// len(cfg.Security.Policies); use that as the RuntimePolicyIDs lookup key.
+	globalSetIdx := len(cfg.Security.Policies)
+	for sliceIdx, pol := range cfg.Security.GlobalPolicies {
 		if pol == nil {
 			continue
 		}
@@ -361,7 +395,10 @@ func Match(cfg *config.Config, q Query) Result {
 			continue
 		}
 		if ruleMatches(cfg, q, pol) {
-			return matchedResult(pol, true)
+			// A global policy's scope is its `match from-zone`/`match to-zone`
+			// (empty = all zones), NOT the surrounding stanza — report that as
+			// the result's zone context (#3331/#3148).
+			return matchedResult(ids, pol, true, pol.Match.FromZone, pol.Match.ToZone, globalSetIdx, sliceIdx)
 		}
 	}
 
@@ -379,7 +416,7 @@ func Match(cfg *config.Config, q Query) Result {
 // than inheriting the transit global/default verdict. `to-zone any` and
 // `from-zone any to-zone any` are deliberately NOT pulled onto the host path,
 // matching the runtime gate.
-func matchJunosHost(cfg *config.Config, q Query) Result {
+func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Result {
 	// #3355: evaluate_junos_host_policy returns None for from_id == 0 (the
 	// unknown/undefined ingress zone), mirroring the #3110 unzoned guard. An
 	// undefined query from-zone therefore matches no host-bound rule; local
@@ -390,24 +427,24 @@ func matchJunosHost(cfg *config.Config, q Query) Result {
 		return Result{HostInboundUnmatched: true}
 	}
 	// Exact ingress -> junos-host.
-	for _, zpp := range cfg.Security.Policies {
+	for setIdx, zpp := range cfg.Security.Policies {
 		if zpp == nil || zpp.ToZone != JunosHostZone || zpp.FromZone != q.FromZone {
 			continue
 		}
-		for _, pol := range zpp.Policies {
+		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(pol, false)
+				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
 			}
 		}
 	}
 	// from-zone any -> junos-host.
-	for _, zpp := range cfg.Security.Policies {
+	for setIdx, zpp := range cfg.Security.Policies {
 		if zpp == nil || zpp.ToZone != JunosHostZone || zpp.FromZone != "any" {
 			continue
 		}
-		for _, pol := range zpp.Policies {
+		for sliceIdx, pol := range zpp.Policies {
 			if pol != nil && ruleMatches(cfg, q, pol) {
-				return matchedResult(pol, false)
+				return matchedResult(ids, pol, false, zpp.FromZone, zpp.ToZone, setIdx, sliceIdx)
 			}
 		}
 	}
@@ -453,10 +490,20 @@ func zoneKnown(cfg *config.Config, zone string) bool {
 	return ok
 }
 
-func matchedResult(pol *config.Policy, global bool) Result {
+// matchedResult builds the verdict for a concrete policy hit, stamping its zone
+// scope (#3331) and the stable runtime policy ID resolved from the shared
+// RuntimePolicyIDs namespace. setIdx/sliceIdx are the [policySetID, sliceIndex]
+// coordinates of the policy in the typed config — the exact key RuntimePolicyIDs
+// uses (a global policy's setIdx is len(cfg.Security.Policies)). A missing key
+// (a config that overflows MaxRulesPerPolicy and so cannot be applied) yields
+// PolicyID 0; the zone scope + name still disambiguate the verdict.
+func matchedResult(ids map[[2]uint32]uint32, pol *config.Policy, global bool, fromZone, toZone string, setIdx, sliceIdx int) Result {
 	return Result{
 		Matched:      true,
 		Global:       global,
+		FromZone:     fromZone,
+		ToZone:       toZone,
+		PolicyID:     ids[[2]uint32{uint32(setIdx), uint32(sliceIdx)}],
 		PolicyName:   pol.Name,
 		Description:  pol.Description,
 		Action:       pol.Action,

--- a/pkg/policymatch/scope_id_3331_test.go
+++ b/pkg/policymatch/scope_id_3331_test.go
@@ -1,0 +1,162 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestMatchResultCarriesZonePairScopeAndID pins #3331: a zone-pair match must
+// report the matched policy's from-zone/to-zone scope, that it is NOT global,
+// and the stable runtime policy ID (the SSOT RuntimePolicyIDs namespace) so a
+// verdict can be mapped back to the runtime policy / session-table / audit
+// record. RED on revert: before #3331 Result carried only PolicyName/Action.
+func TestMatchResultCarriesZonePairScopeAndID(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		// Two zone pairs that share a duplicate policy NAME "allow" — legal in
+		// Junos and exactly the collision that made a name-only verdict
+		// ambiguous before #3331.
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application any",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies from-zone untrust to-zone trust policy allow match source-address any",
+		"set security policies from-zone untrust to-zone trust policy allow match destination-address any",
+		"set security policies from-zone untrust to-zone trust policy allow match application any",
+		"set security policies from-zone untrust to-zone trust policy allow then deny",
+		"set security policies default-policy deny-all",
+	}
+	cfg := compileFromSet(t, cmds)
+
+	res := Match(cfg, Query{
+		FromZone: "untrust", ToZone: "trust",
+		SrcIP: net.ParseIP("10.0.2.5"), DstIP: net.ParseIP("10.0.1.5"),
+	})
+	if !res.Matched {
+		t.Fatalf("expected a match, got Matched=false")
+	}
+	if res.Global {
+		t.Errorf("Global = true, want false for a zone-pair policy")
+	}
+	if res.FromZone != "untrust" || res.ToZone != "trust" {
+		t.Errorf("scope = %s->%s, want untrust->trust", res.FromZone, res.ToZone)
+	}
+	if res.PolicyName != "allow" {
+		t.Errorf("PolicyName = %q, want allow", res.PolicyName)
+	}
+
+	// The reported PolicyID must equal the SSOT runtime ID for THIS policy
+	// (the untrust->trust set's "allow"), NOT the same-named trust->untrust
+	// policy — that is the disambiguation #3331 delivers.
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+	var untrustSetIdx int
+	for i, zpp := range cfg.Security.Policies {
+		if zpp != nil && zpp.FromZone == "untrust" && zpp.ToZone == "trust" {
+			untrustSetIdx = i
+		}
+	}
+	wantID := ids[[2]uint32{uint32(untrustSetIdx), 0}]
+	if res.PolicyID != wantID {
+		t.Errorf("PolicyID = %d, want %d (untrust->trust runtime ID)", res.PolicyID, wantID)
+	}
+	// Sanity: the duplicate-named trust->untrust policy has a DIFFERENT runtime
+	// ID, so the ID truly disambiguates.
+	var trustSetIdx int
+	for i, zpp := range cfg.Security.Policies {
+		if zpp != nil && zpp.FromZone == "trust" && zpp.ToZone == "untrust" {
+			trustSetIdx = i
+		}
+	}
+	if otherID := ids[[2]uint32{uint32(trustSetIdx), 0}]; otherID == res.PolicyID {
+		t.Errorf("trust->untrust ID %d collides with untrust->trust ID %d; scope/id cannot disambiguate", otherID, res.PolicyID)
+	}
+}
+
+// TestMatchResultCarriesGlobalScopeAndID pins #3331 for the global tier: a
+// global-policy match must report Global=true, the policy's match from-zone/
+// to-zone scope (#3148, empty == all zones), and the runtime policy ID drawn
+// from the global policy set (policySetID == len(cfg.Security.Policies)).
+func TestMatchResultCarriesGlobalScopeAndID(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies global policy g-allow match source-address any",
+		"set security policies global policy g-allow match destination-address any",
+		"set security policies global policy g-allow match application any",
+		"set security policies global policy g-allow match from-zone trust",
+		"set security policies global policy g-allow then permit",
+		"set security policies default-policy deny-all",
+	}
+	cfg := compileFromSet(t, cmds)
+
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+	})
+	if !res.Matched || !res.Global {
+		t.Fatalf("expected global match, got Matched=%v Global=%v", res.Matched, res.Global)
+	}
+	if res.FromZone != "trust" {
+		t.Errorf("global scope from-zone = %q, want trust", res.FromZone)
+	}
+	if res.ToZone != "" {
+		t.Errorf("global scope to-zone = %q, want \"\" (any)", res.ToZone)
+	}
+	if res.PolicyName != "g-allow" {
+		t.Errorf("PolicyName = %q, want g-allow", res.PolicyName)
+	}
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+	wantID := ids[[2]uint32{uint32(len(cfg.Security.Policies)), 0}]
+	if res.PolicyID != wantID {
+		t.Errorf("PolicyID = %d, want %d (global set runtime ID)", res.PolicyID, wantID)
+	}
+}
+
+// TestMatchResultRuntimeIDMatchesShowPolicies pins that a multi-application
+// policy's reported match-policies PolicyID equals its span-accumulated runtime
+// ID — i.e. it advances past an earlier multi-application policy's expansion
+// exactly like the `show policies` Index column (#3063), not the raw ordinal.
+// This is the property that lets the diagnostic cross-reference the audit log.
+func TestMatchResultRuntimeIDMatchesShowPolicies(t *testing.T) {
+	cmds := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		// First policy matches an application-set so its runtime span > 1,
+		// pushing the second policy's runtime ID past the raw ordinal.
+		"set applications application-set webset application junos-http",
+		"set applications application-set webset application junos-https",
+		"set security policies from-zone trust to-zone untrust policy first match source-address any",
+		"set security policies from-zone trust to-zone untrust policy first match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy first match application webset",
+		"set security policies from-zone trust to-zone untrust policy first then permit",
+		"set security policies from-zone trust to-zone untrust policy second match source-address any",
+		"set security policies from-zone trust to-zone untrust policy second match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy second match application any",
+		"set security policies from-zone trust to-zone untrust policy second then deny",
+		"set security policies default-policy deny-all",
+	}
+	cfg := compileFromSet(t, cmds)
+
+	// A non-web flow falls through "first" (web-only) to "second".
+	res := Match(cfg, Query{
+		FromZone: "trust", ToZone: "untrust",
+		SrcIP: net.ParseIP("10.0.1.5"), DstIP: net.ParseIP("10.0.2.5"),
+		Protocol: "udp", DstPort: 9999,
+	})
+	if !res.Matched || res.PolicyName != "second" {
+		t.Fatalf("expected match on second, got Matched=%v name=%q", res.Matched, res.PolicyName)
+	}
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+	wantID := ids[[2]uint32{0, 1}] // set 0, slice index 1 (second policy)
+	if res.PolicyID != wantID {
+		t.Errorf("PolicyID = %d, want %d (SSOT span-accumulated runtime ID)", res.PolicyID, wantID)
+	}
+	// The span-accumulated ID must NOT equal the raw ordinal (set*256 + 1 == 1
+	// here); "first" expanded to 2 slots, so "second" sits at runtime ID 2.
+	if res.PolicyID == 1 {
+		t.Errorf("PolicyID = 1 looks like the raw ordinal, not the span-accumulated runtime ID")
+	}
+}

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -607,6 +607,23 @@ message MatchPoliciesResponse {
   // `action` is empty; clients must render "host-inbound (local delivery; not
   // governed by transit/global/default policy)", NOT a default-policy verdict.
   bool host_inbound_unmatched = 7;
+  // global is true when the matched policy is a `policy global` rule rather
+  // than a zone-pair rule (#3331); it distinguishes a global-scope verdict from
+  // a same-named zone-pair policy.
+  bool global = 8;
+  // from_zone/to_zone are the SCOPE of the matched policy (#3331): for a
+  // zone-pair policy the surrounding from-zone/to-zone stanza; for a global
+  // policy its optional `match from-zone`/`match to-zone` scope (empty when the
+  // global policy applies to all zones). They disambiguate a verdict when the
+  // same policy name repeats across zone pairs (legal in Junos). Set only when
+  // matched is true.
+  string from_zone = 9;
+  string to_zone = 10;
+  // policy_id is the stable runtime/RT_FLOW/session-table policy ID of the
+  // matched policy (#3331), so a match-policies answer can be cross-referenced
+  // against the session table and the policy-deny/permit audit log even when
+  // policy names collide across scopes. Set only when matched is true.
+  uint32 policy_id = 11;
 }
 
 // --- NAT rule counters ---


### PR DESCRIPTION
## Summary
Closes #3331.

The `match-policies` diagnostic (REST `MatchPoliciesResult`, gRPC `MatchPoliciesResponse`, and the shared `policymatch.Result` they feed) returned only a policy name and action. Duplicate policy names are legal in Junos across different from-zone/to-zone pairs and the global scope, so a name-only verdict could not be mapped back to the runtime policy / session-table policy ID / audit record when names collide.

## What changed
`policymatch.Result` (and the REST/gRPC surfaces) now carry the matched policy's full identity:

- **`Global`** (already present) — `policy global` rule vs zone-pair rule.
- **`FromZone` / `ToZone`** — the matched policy's SCOPE. Zone-pair policy: the surrounding from/to-zone stanza. Global policy: its optional `match from-zone`/`match to-zone` scope (#3148), empty = all-zones (rendered `any`).
- **`PolicyID`** — the stable runtime/RT_FLOW/session-table policy ID, resolved from the SSOT `dataplane/userspace.RuntimePolicyIDs` (the same span-accumulated namespace the dataplane write side and the `show policies` Index column use, #3063). `Match` resolves the map once and stamps the ID by the matched policy's `[policySetID, sliceIndex]` coordinates (global policies use `policySetID == len(cfg.Security.Policies)`).

### Surfaces
- REST `MatchPoliciesResult`: `global`, `from_zone`, `to_zone`, `policy_id`.
- gRPC `MatchPoliciesResponse`: `global`, `from_zone`, `to_zone`, `policy_id` (proto fields 8-11). **Bindings regenerated** (`protoc`, paths unchanged).
- Local + remote CLI `show security match-policies` now print `Policy ID:` and a `Scope:` line (global vs zone-pair, global match scope rendered `any` when unconstrained).

## Tests
- `pkg/policymatch`: zone-pair, global, and span-accumulated-ID cases assert the new scope/id fields and that duplicate-named policies across zone pairs get **distinct** runtime IDs.
- `pkg/grpcapi`: a `MatchPolicies` response test asserts the same on the wire.
- RED-on-revert verified by zeroing the populated fields (every new assertion failed).

`go build ./...` and `go test ./pkg/policymatch/... ./pkg/grpcapi/... ./pkg/api/... ./pkg/cli/... ./cmd/cli/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi