### PR TITLE
userspace-dp: resolve permit-side AppID from post-NAT dst port (Closes #3416)

### DIFF
--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -515,11 +515,16 @@ pub(super) fn poll_binding_process_descriptor(
                             // is the dst on a forward-keyed session, the src on
                             // a reverse-keyed one, so a forward flow with a
                             // service-valued SOURCE port is not mislabeled.
-                            let app_id = worker_ctx.forwarding.app_catalog.lookup_directional(
+                            // #3416: resolve the forward service port from the
+                            // post-translation (DNAT-rewritten) destination so a
+                            // port-forwarded session's conntrack row carries the
+                            // admitting application, not the pre-NAT public port.
+                            let app_id = worker_ctx.forwarding.app_catalog.lookup_admitted(
                                 flow.forward_key.protocol,
                                 flow.forward_key.src_port,
                                 flow.forward_key.dst_port,
                                 resolved.metadata.is_reverse,
+                                resolved.decision.nat.rewrite_dst_port,
                             );
                             publish_bpf_conntrack_entry(
                                 conntrack_v4_fd,
@@ -1631,11 +1636,18 @@ pub(super) fn poll_binding_process_descriptor(
                                 // #2008 M5: stamp the resolved application id.
                                 // #3321: directional resolution (service = dst
                                 // forward / src reverse).
-                                let app_id = worker_ctx.forwarding.app_catalog.lookup_directional(
+                                // #3416: this is the DNAT-to-firewall-local
+                                // delivery path — resolve the forward service
+                                // port from the post-translation (rewritten)
+                                // destination so the local-service conntrack row
+                                // shows the admitting application (e.g. the
+                                // private :22), not the public port.
+                                let app_id = worker_ctx.forwarding.app_catalog.lookup_admitted(
                                     flow.forward_key.protocol,
                                     flow.forward_key.src_port,
                                     flow.forward_key.dst_port,
                                     local_metadata.is_reverse,
+                                    decision.nat.rewrite_dst_port,
                                 );
                                 publish_bpf_conntrack_entry(
                                     conntrack_v4_fd,
@@ -3833,11 +3845,17 @@ pub(super) fn poll_binding_process_descriptor(
                                     // #2008 M5: stamp the resolved app id.
                                     // #3321: directional resolution (service =
                                     // dst forward / src reverse).
-                                    let app_id = worker_ctx.forwarding.app_catalog.lookup_directional(
+                                    // #3416: forward service port from the
+                                    // post-translation (DNAT-rewritten)
+                                    // destination so a port-forwarded
+                                    // neighbor-seed row carries the admitting
+                                    // application, not the public port.
+                                    let app_id = worker_ctx.forwarding.app_catalog.lookup_admitted(
                                         flow.forward_key.protocol,
                                         flow.forward_key.src_port,
                                         flow.forward_key.dst_port,
                                         entry.metadata.is_reverse,
+                                        pending_decision.nat.rewrite_dst_port,
                                     );
                                     publish_bpf_conntrack_entry(
                                         conntrack_v4_fd,

--- a/userspace-dp/src/afxdp/session_delta.rs
+++ b/userspace-dp/src/afxdp/session_delta.rs
@@ -219,11 +219,16 @@ pub(super) fn flush_session_deltas(
                 // #3321: resolve directionally off the delta's own direction
                 // flag (service = dst forward / src reverse) so a forward flow
                 // with a service-valued source port is not mislabeled.
-                let app_id = forwarding.app_catalog.lookup_directional(
+                // #3416: resolve the FORWARD service port from the
+                // post-translation destination (the DNAT-rewritten port the
+                // policy admitted the session under), mirroring the deny side,
+                // so a port-forwarded service is not mislabeled UNKNOWN/public.
+                let app_id = forwarding.app_catalog.lookup_admitted(
                     delta.key.protocol,
                     delta.key.src_port,
                     delta.key.dst_port,
                     delta.metadata.is_reverse,
+                    delta.decision.nat.rewrite_dst_port,
                 );
                 // #2615: thread the closing binding's ingress ifindex so the
                 // SESSION_CLOSE RT_FLOW record shows the admitting interface
@@ -251,11 +256,16 @@ pub(super) fn flush_session_deltas(
                 // positive so the i32 -> u32 cast is loss-free.
                 // #3321: directional resolution off the delta's direction flag
                 // (service = dst forward / src reverse).
-                let app_id = forwarding.app_catalog.lookup_directional(
+                // #3416: forward service port from the post-translation
+                // (DNAT-rewritten) destination — the port the policy admitted
+                // the session under — so a port-forwarded create record carries
+                // the admitting application instead of UNKNOWN/the public port.
+                let app_id = forwarding.app_catalog.lookup_admitted(
                     delta.key.protocol,
                     delta.key.src_port,
                     delta.key.dst_port,
                     delta.metadata.is_reverse,
+                    delta.decision.nat.rewrite_dst_port,
                 );
                 es.emit_session_create_rt_flow(delta, app_id, ident.ifindex as u32);
             }

--- a/userspace-dp/src/afxdp/session_glue/tests.rs
+++ b/userspace-dp/src/afxdp/session_glue/tests.rs
@@ -5026,6 +5026,144 @@ fn flush_session_deltas_without_binding_reaches_global_consumers() {
     );
 }
 
+/// #3416 FAIL-ON-REVERT (call-site WIRING pin): the permit-side RT_FLOW
+/// SESSION_CREATE / SESSION_CLOSE application id is resolved INSIDE
+/// `flush_session_deltas` via `AppCatalog::lookup_admitted`, which substitutes
+/// the post-NAT (DNAT-rewritten) destination port for the forward service slot.
+/// The helper-level test (`app_catalog_lookup_admitted_uses_post_nat_dst_port`)
+/// proves `lookup_admitted` in isolation; this drives the PRODUCTION drain loop
+/// end to end against a port-forwarded session and decodes the emitted RT_FLOW
+/// frames, so reverting EITHER session_delta.rs call site back to
+/// `lookup_directional` (dropping the `rewrite_dst_port` argument) makes the
+/// stamped `application_id` resolve UNKNOWN(0) from the pre-NAT public port and
+/// the assertions below go red.
+#[test]
+fn flush_session_deltas_rt_flow_app_id_uses_post_nat_dst_port() {
+    // junos-ssh stand-in: app_id 22 on TCP/22 (the INTERNAL/post-NAT port).
+    // Nothing is registered on the PUBLIC :2222, so a pre-NAT resolution yields
+    // UNKNOWN(0) — exactly the #3416 mislabel the wiring must avoid.
+    const JUNOS_SSH: u16 = 22;
+    let mut forwarding = ForwardingState::default();
+    forwarding.app_catalog = crate::policy::AppCatalog::from_snapshot(&[crate::AppCatalogEntry {
+        app_id: JUNOS_SSH,
+        protocol: PROTO_TCP,
+        dst_port_low: 22,
+        dst_port_high: 22,
+        src_port_low: 0,
+        src_port_high: 0,
+    }]);
+
+    // Forward DNAT session: client 192.0.2.50:51000 -> PUBLIC 203.0.113.10:2222,
+    // DNAT-rewritten to inside 10.0.0.10:22 (admitted by junos-ssh). The forward
+    // session key carries the PRE-NAT public port; the decision carries the
+    // POST-NAT rewrite the policy admitted the flow under.
+    let key = SessionKey {
+        addr_family: libc::AF_INET as u8,
+        protocol: PROTO_TCP,
+        src_ip: IpAddr::V4(Ipv4Addr::new(192, 0, 2, 50)),
+        dst_ip: IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10)),
+        src_port: 51000,
+        dst_port: 2222,
+    };
+    let mut decision = test_decision();
+    decision.nat.rewrite_dst = Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10)));
+    decision.nat.rewrite_dst_port = Some(22);
+    let mut metadata = test_metadata();
+    // SESSION_CREATE is producer-gated on the admitting policy's session-init
+    // log selection; SESSION_CLOSE always emits.
+    metadata.log_session_init = true;
+
+    let make_delta = |kind| SessionDelta {
+        kind,
+        key: key.clone(),
+        decision,
+        metadata: metadata.clone(),
+        origin: SessionOrigin::ForwardFlow,
+        fabric_redirect_sync: false,
+        created_ns: 0,
+        last_seen_ns: 0,
+        counters: crate::session::SessionCounters::default(),
+        observed_tos: 0,
+        observed_tcp_flags: 0,
+    };
+
+    // Drive the production drain loop and return the stamped application_id off
+    // the emitted RT_FLOW frame. `want_event_type` is the RT_FLOW event-type
+    // byte at payload[52] (1 = SESSION_OPEN/create, 2 = SESSION_CLOSE). The
+    // drain also queues an HA session-sync frame (type 1/2 — `from_msg_type`
+    // returns None, so `dataplane_event_payload()` is None for it); the RT_FLOW
+    // create/close frame (type 15/14) is the only one with a Some payload.
+    // NOTE: `decode_dataplane_event()` is NOT used here — it decodes only the
+    // deny/screen/filter kinds (`from_rt_flow_event_type` rejects the session
+    // event types), so app_id is read from the payload [132:134] slot directly,
+    // exactly as the codec/Go side reads it.
+    let stamped_app = |delta: SessionDelta, want_event_type: u8| -> u16 {
+        let (handle, rx) = crate::event_stream::test_worker_handle(
+            8,
+            // Unlimited (events_per_second == 0) — the proven RT_FLOW-emit test
+            // harness config; the default carries a real per-bucket rate limit.
+            crate::event_stream::DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+        );
+        let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+        let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+        let recent_session_deltas = Arc::new(Mutex::new(VecDeque::new()));
+        let peer_worker_commands: Vec<Arc<Mutex<VecDeque<WorkerCommand>>>> = Vec::new();
+        let ident = BindingIdentity {
+            slot: 0,
+            queue_id: 0,
+            worker_id: 0,
+            interface: Arc::<str>::from("ge-0-0-2"),
+            ifindex: 7,
+        };
+        let dnat_fds = crate::afxdp::checksum::DnatTableFds::default();
+        flush_session_deltas(
+            &ident,
+            None,
+            -1,
+            -1,
+            -1,
+            &dnat_fds,
+            &[delta],
+            &shared_sessions,
+            &shared_nat_sessions,
+            &shared_forward_wire_sessions,
+            &shared_owner_rg_indexes,
+            &recent_session_deltas,
+            &peer_worker_commands,
+            &Some(handle),
+            &forwarding,
+        );
+        let frames: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        let payload = frames
+            .iter()
+            .find_map(|f| f.dataplane_event_payload())
+            .expect("an RT_FLOW dataplane-event frame on the channel");
+        assert_eq!(
+            payload[52], want_event_type,
+            "RT_FLOW frame must carry the expected session event type at [52]"
+        );
+        u16::from_le_bytes([payload[132], payload[133]])
+    };
+
+    assert_eq!(
+        stamped_app(make_delta(SessionDeltaKind::Open), 1),
+        JUNOS_SSH,
+        "SESSION_CREATE RT_FLOW must stamp the post-NAT app (junos-ssh/22), \
+         not UNKNOWN(0) resolved from the pre-NAT public :2222"
+    );
+    assert_eq!(
+        stamped_app(make_delta(SessionDeltaKind::Close), 2),
+        JUNOS_SSH,
+        "SESSION_CLOSE RT_FLOW must stamp the post-NAT app (junos-ssh/22), \
+         not UNKNOWN(0) resolved from the pre-NAT public :2222"
+    );
+}
+
 /// #2874 FAIL-ON-REVERT: a correctness-critical HA session OPEN delta that
 /// cannot be queued losslessly to the event-stream consumer must be reported as
 /// out-of-sync (flush_session_deltas returns true) so the worker loop forces a

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -1242,6 +1242,43 @@ impl AppCatalog {
     pub(crate) fn lookup_forward(&self, protocol: u8, src_port: u16, dst_port: u16) -> u16 {
         self.lookup_directional(protocol, src_port, dst_port, false)
     }
+
+    /// #3416: resolve the AppID a session was ADMITTED under for the permit-side
+    /// audit surfaces (RT_FLOW `SESSION_CREATE`/`SESSION_CLOSE` and the
+    /// BPF-compatible conntrack publish). A forward DNAT / static-DNAT /
+    /// inbound-NPTv6 flow has its policy evaluated against the POST-translation
+    /// destination port (poll_descriptor `policy_dst_port`, #2345), so the
+    /// permitted-flow audit AppID must use that same translated port — not the
+    /// pre-NAT forward-key destination — or a port-forwarded service (public
+    /// `:2222` -> internal `:22` admitted by `junos-ssh`) renders as
+    /// UNKNOWN/the public-port app. This mirrors the deny-side fix that resolves
+    /// from the post-translation `policy_dst_port` (`resolve_policy_deny_app_id`,
+    /// #3058/#3185), making the permit side symmetric.
+    ///
+    /// `is_reverse` selects the service slot exactly as `lookup_directional`.
+    /// The post-translation rewrite is applied ONLY to the FORWARD service slot
+    /// (the destination). A reverse-keyed entry keeps its received service slot:
+    /// the reverse key already carries the real internal service port, and the
+    /// reverse NAT decision's `rewrite_dst_port` un-translates a destination
+    /// back toward the client side, so applying it there would re-introduce the
+    /// very mislabel this fixes. For a non-translated flow `rewrite_dst_port` is
+    /// `None`, so the result is byte-identical to `lookup_directional`.
+    #[inline]
+    pub(crate) fn lookup_admitted(
+        &self,
+        protocol: u8,
+        src_port: u16,
+        dst_port: u16,
+        is_reverse: bool,
+        rewrite_dst_port: Option<u16>,
+    ) -> u16 {
+        let service_dst_port = if is_reverse {
+            dst_port
+        } else {
+            rewrite_dst_port.unwrap_or(dst_port)
+        };
+        self.lookup_directional(protocol, src_port, service_dst_port, is_reverse)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -3064,6 +3064,64 @@ fn app_catalog_directional_forward_not_mislabeled_by_source_port() {
     assert_eq!(ranged.lookup_directional(6, 9050, 1500, true), 9);
 }
 
+// #3416: the permit-side audit AppID must resolve from the POST-translation
+// destination port a DNAT'd session was admitted under, mirroring the deny side
+// (#3058/#3185). A public-port -> private-port forward (e.g. :2222 -> :22 for
+// junos-ssh) must render the admitting application, not UNKNOWN/the public port.
+#[test]
+fn app_catalog_lookup_admitted_uses_post_nat_dst_port() {
+    // junos-ssh stand-in: TCP dst/22 (exact-port path).
+    let ssh = AppCatalog::from_snapshot(&[cat_entry(22, 6, 22, 22)]);
+
+    // Forward DNAT: client src=51000 -> public dst=2222, DNAT-rewritten to :22.
+    // RED-on-revert: passing the pre-NAT forward-key dst (2222) to the plain
+    // directional lookup mislabels the session UNKNOWN — exactly the #3416 bug.
+    assert_eq!(
+        ssh.lookup_directional(6, 51000, 2222, false),
+        0,
+        "pre-NAT public dst port resolves UNKNOWN — the #3416 mislabel"
+    );
+    // The fix: lookup_admitted substitutes the post-NAT (rewritten) dst port and
+    // resolves the admitting application.
+    assert_eq!(
+        ssh.lookup_admitted(6, 51000, 2222, false, Some(22)),
+        22,
+        "forward DNAT session resolves on the post-NAT (rewritten) dst port"
+    );
+
+    // Negative control: public == private port (no rewrite). rewrite_dst_port is
+    // None, so the result is byte-identical to the plain directional lookup.
+    assert_eq!(
+        ssh.lookup_admitted(6, 51000, 22, false, None),
+        22,
+        "non-translated flow falls back to the forward-key dst port"
+    );
+    // A DNAT that does NOT change the port (rewrite_dst_port None even though the
+    // dst address changed) also falls back to the received service port.
+    assert_eq!(
+        ssh.lookup_admitted(6, 51000, 22, false, None),
+        22,
+        "address-only DNAT (no port rewrite) still resolves on the dst port"
+    );
+
+    // Reverse-keyed entry: the service rides the SRC slot and the key already
+    // carries the real internal port. The forward-only rewrite must NOT touch
+    // the reverse service slot, so a (bogus, for this direction) rewrite_dst_port
+    // is ignored and the src slot still resolves.
+    assert_eq!(
+        ssh.lookup_admitted(6, 22, 51000, true, Some(2222)),
+        22,
+        "reverse-keyed session resolves on its received src service slot"
+    );
+
+    // Wrong post-NAT port still resolves to UNKNOWN (no false positive).
+    assert_eq!(
+        ssh.lookup_admitted(6, 51000, 2222, false, Some(8080)),
+        0,
+        "post-NAT port with no catalog entry resolves UNKNOWN"
+    );
+}
+
 // A (0,0) dst-port pair means "protocol-only" (e.g. ICMP) — match on protocol
 // regardless of ports.
 #[test]


### PR DESCRIPTION
## Summary
The permit-side audit surfaces (RT_FLOW `SESSION_CREATE`/`SESSION_CLOSE` and the BPF-compatible conntrack publish) resolved the session AppID from the **pre-NAT** forward-key destination port, while policy evaluation matches a DNAT/static-DNAT/inbound-NPTv6 flow against the **post-translation** destination port (`poll_descriptor` `policy_dst_port`, #2345). A port-forwarded service (public `:2222` DNAT'd to internal `:22`, admitted by `junos-ssh`) therefore showed `UNKNOWN`/the public-port app on `show security flow session`, the RT_FLOW create/close records, and conntrack rows — asymmetric with the deny side, which already logs the post-translation tuple (`resolve_policy_deny_app_id`, #3058/#3185).

## Fix
- Add `AppCatalog::lookup_admitted`, the permit-side sibling of `lookup_forward`/`lookup_directional`: it substitutes the post-NAT (rewritten) destination port into the **forward** service slot before the directional catalog probe. Applied only to the forward service slot — a reverse-keyed entry keeps its received service slot (the reverse key already carries the real internal service port; the reverse decision's `rewrite_dst_port` un-translates back toward the client and would re-introduce the mislabel). For a non-translated flow `rewrite_dst_port` is `None`, so the result is byte-identical to the prior `lookup_directional` behavior.
- Wire it into the five permit-side resolution sites, each of which already has the `NatDecision` in hand (it rides the shared session map and the HA session-sync wire — no new metadata/wire field needed): the `SESSION_CLOSE` + `SESSION_CREATE` RT_FLOW stamps in `session_delta.rs`, and the three conntrack publish paths in `poll_descriptor` (main forward install, DNAT-to-firewall-local delivery, pending-neighbor seed).

## Tests
`app_catalog_lookup_admitted_uses_post_nat_dst_port` covers a forward DNAT `public:2222 -> private:22` resolving `junos-ssh` on the post-NAT port, the non-translated fallback, the reverse-keyed slot, and a no-catalog-match negative control.

**RED-on-revert verified:** neutralizing the post-NAT substitution turns the forward-DNAT assertion red (resolves `UNKNOWN` — the #3416 mislabel).

`cargo build` green; full Go `pkg/dataplane/...` and `pkg/appid/...` suites pass. (The pre-existing `event_stream` #2875 budget-underflow test fails identically on clean `origin/master` and is unrelated.)

Closes #3416

🤖 Generated with [Claude Code](https://claude.com/claude-code)