### PR TITLE
grpcapi: resolve kernel ifname in GetInterfaces (#3460)

### DIFF
--- a/pkg/grpcapi/iface_name_test.go
+++ b/pkg/grpcapi/iface_name_test.go
@@ -1,0 +1,79 @@
+package grpcapi
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestGetInterfaces_ResolvesRethToLoopback is the gRPC analogue of the
+// REST TestInterfacesHandler_ResolvesRethToLoopback (pkg/api). It pins
+// the #3460 fix: GetInterfaces must translate a Junos config name to its
+// kernel ifname via (*Config).ResolveKernelIfName before calling
+// net.InterfaceByName, exactly like REST /interfaces, /stats/interfaces,
+// and the Prometheus collector (#1565).
+//
+// We synthesize a cfg where reth0's RETH member is literally named "lo"
+// — the loopback netdev is the only one guaranteed to exist on any Linux
+// test runner. Pre-fix, the raw lookup of "reth0" returns no kernel
+// ifindex (RETH names are virtual aliases). Post-fix,
+// ResolveKernelIfName("reth0") returns "lo" and the row's ifindex matches
+// net.InterfaceByName("lo").Index. Revert the fix (raw ifName lookup) and
+// the ifindex assertion goes RED (ifindex=0).
+func TestGetInterfaces_ResolvesRethToLoopback(t *testing.T) {
+	loIface, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skipf("test runner has no lo netdev: %v", err)
+	}
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	sets := []string{
+		"set chassis cluster reth-count 1",
+		"set interfaces lo gigether-options redundant-parent reth0",
+		"set interfaces reth0 redundant-ether-options redundancy-group 1",
+		"set security zones security-zone trust interfaces reth0",
+	}
+	for _, s := range sets {
+		if _, err := store.LoadSet(s); err != nil {
+			t.Fatalf("LoadSet(%q): %v", s, err)
+		}
+	}
+	cfg, err := store.Commit()
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Sanity: the test cfg must actually resolve reth0 -> lo, else we'd be
+	// asserting against a false-zero rather than the translation.
+	if got := cfg.ResolveKernelIfName("reth0"); got != "lo" {
+		t.Fatalf("ResolveKernelIfName(reth0) = %q, want lo (test cfg setup wrong)", got)
+	}
+
+	s := &Server{store: store}
+
+	resp, err := s.GetInterfaces(context.Background(), &pb.GetInterfacesRequest{})
+	if err != nil {
+		t.Fatalf("GetInterfaces: %v", err)
+	}
+
+	var rethRow *pb.InterfaceInfo
+	for _, ii := range resp.Interfaces {
+		if ii.Name == "reth0" {
+			rethRow = ii
+			break
+		}
+	}
+	if rethRow == nil {
+		t.Fatalf("no row for reth0 in GetInterfaces response: %+v", resp.Interfaces)
+	}
+	if int(rethRow.Ifindex) != loIface.Index {
+		t.Errorf("reth0 ifindex = %d, want %d (loopback) — kernel-name translation broken",
+			rethRow.Ifindex, loIface.Index)
+	}
+}

--- a/pkg/grpcapi/server_show_interfaces.go
+++ b/pkg/grpcapi/server_show_interfaces.go
@@ -28,7 +28,13 @@ func (s *Server) GetInterfaces(_ context.Context, _ *pb.GetInterfacesRequest) (*
 
 	resp := &pb.GetInterfacesResponse{}
 	for ifName := range allInterfaceNames(cfg) {
-		iface, err := net.InterfaceByName(ifName)
+		// Translate the Junos config name to the Linux kernel ifname
+		// before the kernel lookup. Config names may contain '/' (e.g.
+		// "ge-0/0/0", forbidden by IFNAMSIZ) or be virtual aliases
+		// (reth0, fab0, irb.0, gr-0/0/0.0) that don't directly map to a
+		// kernel ifindex. Matches REST /interfaces (pkg/api/interfaces.go)
+		// and the Prometheus collector. See #1565, #3460.
+		iface, err := net.InterfaceByName(cfg.ResolveKernelIfName(ifName))
 		ii := &pb.InterfaceInfo{
 			Name: ifName,
 			Zone: ifZone[ifName],


### PR DESCRIPTION
## Summary

`Server.GetInterfaces` (`pkg/grpcapi/server_show_interfaces.go`) looked up the kernel netdev with the **raw Junos config name** (`net.InterfaceByName(ifName)`), unlike REST `/interfaces`, `/stats/interfaces`, and the Prometheus interface collector, which all call `cfg.ResolveKernelIfName(ifName)` first (#1565).

Junos virtual/config names are not Linux netdev names: `/` is forbidden by IFNAMSIZ (`ge-0/0/0`), and `reth`/`fab`/`irb` are aliases with no direct kernel ifindex. So the gRPC lookup failed for exactly the interface-name class a vSRX-like router uses, returning the row with `Ifindex=0` and false-zero packet/byte counters on active interfaces — REST and gRPC disagreed for the same interface.

## Fix

Resolve the kernel ifname via `cfg.ResolveKernelIfName` before `net.InterfaceByName`, mirroring the REST/Prometheus path. One-line change plus the explanatory comment.

## Test

Adds `pkg/grpcapi/iface_name_test.go`, the gRPC analogue of REST's `TestInterfacesHandler_ResolvesRethToLoopback`: it binds `reth0`'s member to the loopback netdev and asserts the returned ifindex equals `net.InterfaceByName("lo").Index`.

RED-on-revert verified: reverting to the raw-name lookup fails with `reth0 ifindex = 0, want 1`. `go build ./...` and `go test ./pkg/grpcapi/...` green.

Closes #3460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi