### PR TITLE
flow traceoptions: constrain trace file to a basename under /var/log (Closes #3420)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23033,3 +23033,17 @@ top.
     host-inbound system-service. No behavior/admit change — docs-only; the
     #3368 under-admission premise is not borne out by the Junos contract.
   - **File(s)**: docs/junos-cli-reference.md, _Log.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3420 — constrain persistent `security flow traceoptions file`
+    to a basename under /var/log and reject path-traversal. Added commit-time
+    gate `validateFlowTraceFileAST` (strict reject absolute / separator / ".."
+    values; lenient downgrade to a warning on load / peer-sync) plus a
+    `lenientFlowTraceFile` opt wired in compiler.go. Hardened the runtime
+    writer (`NewTraceWriter`/rotate): `sanitizeTraceFileName` basename check,
+    `openTraceFile` with O_NOFOLLOW + regular-file verify + 0600 mode under a
+    `traceLogDir` var. Tests RED-on-revert. Persistent-config sibling of the
+    #3378 monitor-path fix.
+  - **File(s)**: pkg/config/compiler_security.go, pkg/config/compiler.go,
+    pkg/logging/trace.go, pkg/config/flow_traceoptions_file_3420_test.go,
+    pkg/logging/trace_test.go, pkg/logging/README.md, _Log.md

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -132,6 +132,19 @@ type compileOpts struct {
 	// SchemaValidate. Same doctrine as lenientLogStreamPort.
 	lenientLogTLSProfile bool
 
+	// lenientFlowTraceFile (#3420) downgrades the flow-trace file path-traversal
+	// gate (validateFlowTraceFileAST) from a hard compile error to a
+	// cfg.Warnings entry. Set ONLY on the tolerant load / peer-sync paths: a
+	// persisted or peer-synced config carrying a non-basename
+	// `security flow traceoptions file` value (an absolute path or a ".."
+	// escape) that an older binary accepted must still boot — NewTraceWriter
+	// independently refuses the unsafe path at runtime, so a leniently-loaded
+	// value just disables tracing instead of writing outside /var/log (#1960
+	// fail-closed-on-load class). Like the port/tls-profile gates the filename
+	// is an AST value SchemaValidate treats as opaque, so the check does NOT
+	// live there. Same doctrine as lenientLogStreamPort.
+	lenientFlowTraceFile bool
+
 	// lenientLogEventModeFormat (#3349) downgrades the event-mode log-format
 	// compatibility gate (validateLogEventModeFormatStrict) from a hard
 	// compile error to a cfg.Warnings entry. Set ONLY on the tolerant load /
@@ -1138,6 +1151,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientTCPMSSRange:                   true,
 		lenientLogStreamPort:                 true,
 		lenientLogTLSProfile:                 true,
+		lenientFlowTraceFile:                 true,
 		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
@@ -1279,6 +1293,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientTCPMSSRange:                   true,
 		lenientLogStreamPort:                 true,
 		lenientLogTLSProfile:                 true,
+		lenientFlowTraceFile:                 true,
 		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
@@ -1446,6 +1461,21 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// hard-rejects. Lenient (load / peer-sync): warn so an already-persisted or
 	// peer-synced config still boots (the profile was never applied either way).
 	logTLSProfileWarnings, err := validateSecurityLogStreamTLSProfileAST(tree.Children, "", opts.lenientLogTLSProfile)
+	if err != nil {
+		return nil, err
+	}
+
+	// #3420 flow-trace file path-traversal gate. The compiler stores
+	// `security flow traceoptions file <name>` verbatim and NewTraceWriter
+	// opens it under /var/log without rejecting an absolute path or a ".."
+	// escape — a committed config can append root-written flow telemetry
+	// outside the appliance log area. The filename is a single AST value
+	// SchemaValidate treats as opaque, so it is checked here on the
+	// group-expanded tree. Strict (commit / commit-check): a non-basename value
+	// hard-rejects. Lenient (load / peer-sync): warn so an already-persisted or
+	// peer-synced config still boots (NewTraceWriter refuses the unsafe path at
+	// runtime, so tracing is simply disabled).
+	flowTraceFileWarnings, err := validateFlowTraceFileAST(tree.Children, "", opts.lenientFlowTraceFile)
 	if err != nil {
 		return nil, err
 	}
@@ -1642,6 +1672,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, mssWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logStreamPortWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logTLSProfileWarnings...)
+	cfg.Warnings = append(cfg.Warnings, flowTraceFileWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // maxScanSweepThreshold is the largest port-scan / ip-sweep threshold the
@@ -1380,6 +1382,87 @@ func validateSecurityLogStreamTLSProfileAST(nodes []*Node, prefix string, lenien
 					}
 				}
 			}
+		}
+	}
+	return warnings, nil
+}
+
+// flowTraceFileNameError reports why an operator-supplied
+// `security flow traceoptions file <name>` value is unsafe, or nil if the
+// value is an acceptable bare basename. The persistent flow-trace file always
+// lives directly under /var/log (NewTraceWriter), so only a bare filename is
+// permitted: an absolute path, a path separator, or a "." / ".." component
+// would let a committed config steer root-written flow telemetry (internal
+// addresses, ports, zones, actions, policy IDs) outside the appliance log area
+// — e.g. `file /tmp/x` is kept verbatim and `file ../../tmp/x` cleans to
+// /tmp/x (#3420, Codex audit 097 H02). This is the persistent-config sibling
+// of the interactive `monitor security flow file` hardening (#3378).
+func flowTraceFileNameError(name string) error {
+	if name == "" {
+		// A missing value token is the schema walker's concern, not this gate.
+		return nil
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("%q is not a valid trace filename", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("trace filename %q must be a bare name, not a path "+
+			"(the file is written under /var/log)", name)
+	}
+	if filepath.IsAbs(name) || name != filepath.Base(name) {
+		return fmt.Errorf("trace filename %q must be a bare name, not a path "+
+			"(the file is written under /var/log)", name)
+	}
+	return nil
+}
+
+// validateFlowTraceFileAST is the #3420 commit-time path-traversal gate for
+// `security flow traceoptions file <name>`. The compiler stores the filename
+// verbatim (compileFlow traceoptions: to.File = nodeVal(fileNode)) and
+// NewTraceWriter then joins/opens it under /var/log without rejecting an
+// absolute path or a ".." escape, so a committed config can append flow trace
+// records anywhere the daemon user can write. The filename is a single AST
+// value the declarative SchemaValidate walker treats as opaque free text, so —
+// like the syslog port and tls-profile gates — it is checked here on the
+// group-expanded tree, mirroring compileFlow's traversal
+// (FindChild("flow") > FindChild("traceoptions") > FindChild("file")).
+//
+// Strict path (commit / commit-check, lenient=false): an absolute,
+// separator-bearing, or dot-component filename is a hard compile error.
+// Lenient path (load / peer-sync, lenient=true): downgraded to a warning so an
+// already-persisted or peer-synced config an older binary accepted still boots;
+// NewTraceWriter independently refuses the unsafe path at runtime, so a
+// leniently-loaded value simply disables tracing rather than writing outside
+// /var/log (#1960 / #3261 fail-closed-on-load class).
+func validateFlowTraceFileAST(nodes []*Node, prefix string, lenient bool) ([]string, error) {
+	var warnings []string
+	for _, n := range nodes {
+		if n.Name() != "security" {
+			continue
+		}
+		secPath := joinNodePath(prefix, n.Keys)
+		flowNode := n.FindChild("flow")
+		if flowNode == nil {
+			continue
+		}
+		toNode := flowNode.FindChild("traceoptions")
+		if toNode == nil {
+			continue
+		}
+		fileNode := toNode.FindChild("file")
+		if fileNode == nil {
+			continue
+		}
+		name := nodeVal(fileNode)
+		if err := flowTraceFileNameError(name); err != nil {
+			path := joinNodePath(secPath, []string{"flow", "traceoptions", "file"})
+			msg := fmt.Sprintf("%s: %s", path, err.Error())
+			if lenient {
+				warnings = append(warnings, msg+
+					" (ignored: tracing disabled, not written outside /var/log)")
+				continue
+			}
+			return warnings, fmt.Errorf("%s", msg)
 		}
 	}
 	return warnings, nil

--- a/pkg/config/flow_traceoptions_file_3420_test.go
+++ b/pkg/config/flow_traceoptions_file_3420_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3420: `security flow traceoptions file <name>` was stored verbatim and
+// NewTraceWriter joined/opened it under /var/log without rejecting an absolute
+// path or a ".." escape, so a committed config could append root-written flow
+// telemetry anywhere the daemon user can write. validateFlowTraceFileAST now
+// hard-rejects a non-basename file value at strict commit / commit-check.
+//
+// FAIL-ON-REVERT: delete the validateFlowTraceFileAST call in compiler.go (or
+// neuter flowTraceFileNameError) and every reject subtest below goes GREEN on
+// the traversal config, which is exactly the regression this guards.
+func TestFlowTraceFilePathTraversalFailsCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want string // substring the error must name
+	}{
+		{
+			name: "absolute-path",
+			line: "set security flow traceoptions file /tmp/rt-flow-leak",
+			want: "/tmp/rt-flow-leak",
+		},
+		{
+			name: "dotdot-escape",
+			line: "set security flow traceoptions file ../../tmp/rt-flow-leak",
+			want: "../../tmp/rt-flow-leak",
+		},
+		{
+			name: "subdir-separator",
+			line: "set security flow traceoptions file sub/dir/x",
+			want: "sub/dir/x",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, []string{tc.line})
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected strict commit to reject a non-basename flow-trace file, got nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name the offending file value %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "traceoptions") {
+				t.Fatalf("error %q does not name the traceoptions path", err.Error())
+			}
+		})
+	}
+}
+
+// TestFlowTraceFileBasenameCommits is the anti-over-reject guard: a legitimate
+// bare basename (with size/files attributes) must still commit cleanly.
+func TestFlowTraceFileBasenameCommits(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions file rt-flow.log size 1048576 files 5",
+		"set security flow traceoptions flag basic-datapath",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected a valid basename flow-trace file: %v", err)
+	}
+	to := cfg.Security.Flow.Traceoptions
+	if to == nil || to.File != "rt-flow.log" {
+		t.Fatalf("traceoptions file = %+v, want File=rt-flow.log", to)
+	}
+}
+
+// TestFlowTraceFileLenientDowngrade verifies the load / peer-sync path
+// downgrades a persisted non-basename value to a warning instead of failing the
+// boot (#1960 fail-closed-on-load class) — NewTraceWriter independently refuses
+// the unsafe path at runtime.
+func TestFlowTraceFileLenientDowngrade(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions file ../../tmp/rt-flow-leak",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load must not fail on a persisted traversal value: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "../../tmp/rt-flow-leak") && strings.Contains(w, "traceoptions") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient load did not record a flow-trace file warning; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -158,6 +158,25 @@ if `Handle` runs the re-entrancy guard before the client check.
   upper-cases, keeping ICMPv6 mixed-case for the trace-filter contract);
   unknown protocols still fall back to the numeric form. Pin:
   `protoname_test.go`.
+- **Flow-trace files are basename-only under `/var/log` (#3420).**
+  `NewTraceWriter` (`trace.go`) treats the persistent
+  `security flow traceoptions file <name>` value as a bare basename: an
+  absolute path, a path separator, or a `.`/`..` component is rejected
+  (`sanitizeTraceFileName`), the file is opened under `traceLogDir`
+  (`/var/log` in production; a package var only so tests can redirect it)
+  with `O_NOFOLLOW` and verified to be a regular file, and it is created
+  mode `0600` rather than world-readable — flow tuples/zones/policy IDs are
+  audit-grade telemetry. Rotation reopens through the same `openTraceFile`
+  guard. Before #3420 the value was kept verbatim (absolute) or joined under
+  `/var/log` without a `..` check, so a committed config could append
+  root-written telemetry anywhere the daemon could write. The committed
+  config is also rejected at commit-time (`validateFlowTraceFileAST`,
+  `pkg/config`); this runtime guard is the defense-in-depth backstop that
+  fails safe (tracing disabled) on a leniently-loaded / peer-synced value.
+  This is the persistent-config sibling of the interactive
+  `monitor security flow file` hardening (#3378). Pins:
+  `TestNewTraceWriterRejectsPathTraversal`,
+  `TestNewTraceWriterNoFollowSymlink`.
 - **Event time is DECISION time, not receive time (#2465/#2470/#2511).**
   The on-wire RT_FLOW frame carries an absolute Unix-nanosecond timestamp
   in its first 8 bytes (LE u64), stamped by the userspace-dp producer at

--- a/pkg/logging/trace.go
+++ b/pkg/logging/trace.go
@@ -9,15 +9,77 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/psaab/xpf/pkg/config"
 )
+
+// traceLogDir is the directory persistent flow-trace files are written to. It
+// is a package var (not a const) only so tests can redirect it to a temp dir;
+// production always writes under /var/log. The persistent
+// `security flow traceoptions file <name>` knob accepts a bare basename and the
+// file always lives directly under this directory.
+var traceLogDir = "/var/log"
+
+// sanitizeTraceFileName validates an operator-supplied flow-trace filename.
+// The trace file always lives directly under traceLogDir, so only a bare
+// basename is accepted: path separators, "." / "..", and absolute paths are
+// rejected. Without this a committed `security flow traceoptions file
+// ../../tmp/x` resolves to /tmp/x and the daemon appends root-written flow
+// telemetry (internal addresses, ports, zones, actions, policy IDs) outside the
+// log directory (#3420). This is the persistent-config sibling of the
+// interactive monitor-path hardening (#3378). The commit-time gate
+// (validateFlowTraceFileAST) rejects such a value loudly; this runtime check is
+// defense-in-depth that fails safe (tracing disabled) on a leniently-loaded or
+// peer-synced config.
+func sanitizeTraceFileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("trace filename must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid trace filename: %q", name)
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("trace filename must be a bare name, not a path: %q", name)
+	}
+	if filepath.IsAbs(name) || name != filepath.Base(name) {
+		return fmt.Errorf("trace filename must be a bare name, not a path: %q", name)
+	}
+	return nil
+}
+
+// openTraceFile opens a flow-trace file (the active file or a rotated
+// generation) inside traceLogDir with restrictive semantics: O_NOFOLLOW so a
+// pre-planted symlink under /var/log cannot redirect the root-written telemetry
+// (#3420), the opened descriptor is verified to be a regular file, and it is
+// created mode 0600 rather than world-readable 0644 — flow tuples/zones/policy
+// names are audit-grade telemetry. The caller passes an already-sanitized
+// basename (NewTraceWriter validates once up front).
+func openTraceFile(name string) (*os.File, error) {
+	path := filepath.Join(traceLogDir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		f.Close()
+		return nil, fmt.Errorf("trace target %s is not a regular file", path)
+	}
+	return f, nil
+}
 
 // TraceWriter writes matching flow events to a trace file with rotation.
 type TraceWriter struct {
 	mu       sync.Mutex
 	file     *os.File
-	path     string
-	maxSize  int64 // bytes
+	name     string // sanitized basename, written under traceLogDir
+	path     string // traceLogDir/name (rotation suffixes append to this)
+	maxSize  int64  // bytes
 	maxFiles int
 	written  int64
 	filters  []traceFilter
@@ -37,10 +99,15 @@ func NewTraceWriter(opts *config.FlowTraceoptions) (*TraceWriter, error) {
 		return nil, fmt.Errorf("no trace file specified")
 	}
 
-	path := opts.File
-	if !filepath.IsAbs(path) {
-		path = filepath.Join("/var/log", path)
+	// Reject a non-basename file value (absolute path, separator, or ".."
+	// escape) so a committed config cannot steer root-written flow telemetry
+	// outside /var/log (#3420). The commit-time gate rejects this loudly; here
+	// we fail safe (no trace writer) for a leniently-loaded / peer-synced value.
+	if err := sanitizeTraceFileName(opts.File); err != nil {
+		return nil, err
 	}
+	name := opts.File
+	path := filepath.Join(traceLogDir, name)
 
 	maxSize := int64(opts.FileSize)
 	if maxSize <= 0 {
@@ -52,6 +119,7 @@ func NewTraceWriter(opts *config.FlowTraceoptions) (*TraceWriter, error) {
 	}
 
 	tw := &TraceWriter{
+		name:     name,
 		path:     path,
 		maxSize:  maxSize,
 		maxFiles: maxFiles,
@@ -95,11 +163,11 @@ func NewTraceWriter(opts *config.FlowTraceoptions) (*TraceWriter, error) {
 		tw.filters = append(tw.filters, f)
 	}
 
-	// Open trace file
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	// Open trace file under traceLogDir (O_NOFOLLOW, regular-file checked, 0600).
+	if err := os.MkdirAll(traceLogDir, 0755); err != nil {
 		return nil, fmt.Errorf("create trace dir: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := openTraceFile(name)
 	if err != nil {
 		return nil, fmt.Errorf("open trace file: %w", err)
 	}
@@ -262,8 +330,9 @@ func (tw *TraceWriter) rotate() {
 	excess := fmt.Sprintf("%s.%d", tw.path, tw.maxFiles+1)
 	os.Remove(excess)
 
-	// Open fresh file
-	f, err := os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	// Open fresh file (O_NOFOLLOW, regular-file checked, 0600). The active path
+	// was just renamed to .1, so this creates a new empty file.
+	f, err := openTraceFile(tw.name)
 	if err != nil {
 		slog.Warn("failed to open rotated trace file", "err", err)
 		return

--- a/pkg/logging/trace_test.go
+++ b/pkg/logging/trace_test.go
@@ -4,6 +4,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
@@ -62,6 +63,120 @@ func TestNewTraceWriterRejectsPathTraversal(t *testing.T) {
 		}
 		if perm := fi.Mode().Perm(); perm != 0o600 {
 			t.Fatalf("trace file mode = %o, want 0600", perm)
+		}
+	})
+}
+
+// TestOpenTraceFileRejectsNonRegular pins the fd fstat regular-file check in
+// openTraceFile independently (#3420 Codex MINOR). A non-regular target (here a
+// FIFO planted under traceLogDir) must be refused even though O_NOFOLLOW lets
+// the open through — without the IsRegular() guard the daemon would append flow
+// telemetry into a pipe/device an attacker pre-planted in /var/log.
+//
+// RED-on-revert: delete the !fi.Mode().IsRegular() check in openTraceFile and
+// the open below succeeds (returns a non-nil fd, nil error), so this test goes
+// green on the FIFO target — exactly the regression it guards.
+func TestOpenTraceFileRejectsNonRegular(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	fifo := filepath.Join(dir, "flow.fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported: %v", err)
+	}
+	// Hold the read end open (non-blocking) so openTraceFile's O_WRONLY open on
+	// the FIFO does not block waiting for a reader; the open then reaches the
+	// fstat regular-file check, which is the guard under test.
+	rf, err := os.OpenFile(fifo, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("open fifo read end: %v", err)
+	}
+	defer rf.Close()
+
+	f, err := openTraceFile("flow.fifo")
+	if err == nil {
+		if f != nil {
+			f.Close()
+		}
+		t.Fatalf("openTraceFile opened a FIFO target, want regular-file rejection")
+	}
+}
+
+// TestRotateUsesHardenedOpen pins that rotate() reopens the fresh active file
+// through the hardened openTraceFile path rather than a raw os.OpenFile (#3420
+// Codex MINOR). It asserts two consequences of routing through openTraceFile:
+// the reopened active file is mode 0600 (not the old raw-open 0644), and a
+// symlink planted at the active path before the reopen is refused (O_NOFOLLOW),
+// so a post-rotation symlink cannot redirect telemetry.
+//
+// RED-on-revert: change rotate() back to
+// `os.OpenFile(tw.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)` and the
+// mode-0600 assertion fails (perm becomes 0644) and the symlink sub-case fails
+// (the raw open follows the symlink).
+func TestRotateUsesHardenedOpen(t *testing.T) {
+	t.Run("mode-0600", func(t *testing.T) {
+		dir := t.TempDir()
+		old := traceLogDir
+		traceLogDir = dir
+		defer func() { traceLogDir = old }()
+
+		tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "rot.log"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tw.Close()
+		if _, err := tw.file.WriteString("seed\n"); err != nil {
+			t.Fatal(err)
+		}
+		tw.rotate()
+		active := filepath.Join(dir, "rot.log")
+		fi, err := os.Stat(active)
+		if err != nil {
+			t.Fatalf("active trace file missing after rotate: %v", err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("rotated active file mode = %o, want 0600 (rotate must use openTraceFile)", perm)
+		}
+		if _, err := os.Stat(active + ".1"); err != nil {
+			t.Fatalf("rotated archive rot.log.1 missing: %v", err)
+		}
+	})
+
+	t.Run("nofollow-symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		old := traceLogDir
+		traceLogDir = dir
+		defer func() { traceLogDir = old }()
+
+		tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "rot2.log"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tw.Close()
+
+		// Simulate the active file having been rolled away (as rotate does) and a
+		// symlink pre-planted at the active path before the fresh reopen. A
+		// hardened reopen (openTraceFile, O_NOFOLLOW) must refuse it; a raw
+		// os.OpenFile would follow it and create the target.
+		active := filepath.Join(dir, "rot2.log")
+		tw.file.Close()
+		tw.file = nil
+		os.Remove(active)
+		target := filepath.Join(t.TempDir(), "victim")
+		if err := os.Symlink(target, active); err != nil {
+			t.Fatal(err)
+		}
+		f, err := openTraceFile(tw.name)
+		if err == nil {
+			if f != nil {
+				f.Close()
+			}
+			t.Fatalf("rotate reopen followed a symlink at the active path, want O_NOFOLLOW rejection")
+		}
+		if _, statErr := os.Stat(target); statErr == nil {
+			t.Fatalf("symlink target %s was created (followed)", target)
 		}
 	})
 }

--- a/pkg/logging/trace_test.go
+++ b/pkg/logging/trace_test.go
@@ -2,8 +2,95 @@ package logging
 
 import (
 	"net/netip"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
 )
+
+// TestNewTraceWriterRejectsPathTraversal verifies the #3420 runtime guard:
+// NewTraceWriter refuses an absolute path, a "../" escape, or any
+// separator-bearing file value so a leniently-loaded / peer-synced config
+// cannot write root-owned flow telemetry outside /var/log. The accepted bare
+// basename writes inside the configured trace directory.
+func TestNewTraceWriterRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	bad := []string{
+		"/tmp/rt-flow-leak",
+		"../../tmp/rt-flow-leak",
+		"sub/dir/x",
+		"..",
+		".",
+		`a\b`,
+	}
+	for _, name := range bad {
+		t.Run("reject/"+name, func(t *testing.T) {
+			tw, err := NewTraceWriter(&config.FlowTraceoptions{File: name})
+			if err == nil {
+				if tw != nil {
+					tw.Close()
+				}
+				t.Fatalf("NewTraceWriter(%q) = nil error, want rejection", name)
+			}
+			// Nothing must have been created outside the trace dir.
+			if _, statErr := os.Stat("/tmp/rt-flow-leak"); statErr == nil {
+				os.Remove("/tmp/rt-flow-leak")
+				t.Fatalf("NewTraceWriter(%q) created /tmp/rt-flow-leak", name)
+			}
+		})
+	}
+
+	t.Run("accept-basename", func(t *testing.T) {
+		tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "rt-flow.log"})
+		if err != nil {
+			t.Fatalf("NewTraceWriter(basename) = %v, want nil", err)
+		}
+		defer tw.Close()
+		want := filepath.Join(dir, "rt-flow.log")
+		if _, err := os.Stat(want); err != nil {
+			t.Fatalf("expected trace file %s: %v", want, err)
+		}
+		// Created mode 0600 (audit-grade telemetry), not world-readable 0644.
+		fi, err := os.Stat(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("trace file mode = %o, want 0600", perm)
+		}
+	})
+}
+
+// TestNewTraceWriterNoFollowSymlink verifies O_NOFOLLOW: a symlink pre-planted
+// at the trace path is not followed, so a writable-/var/log attacker cannot
+// redirect telemetry to an arbitrary target (#3420).
+func TestNewTraceWriterNoFollowSymlink(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	target := filepath.Join(t.TempDir(), "victim")
+	link := filepath.Join(dir, "flow.log")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "flow.log"})
+	if err == nil {
+		if tw != nil {
+			tw.Close()
+		}
+		t.Fatalf("NewTraceWriter opened through a symlink, want O_NOFOLLOW rejection")
+	}
+	if _, statErr := os.Stat(target); statErr == nil {
+		t.Fatalf("symlink target %s was created (followed)", target)
+	}
+}
 
 // TestMatchFiltersProtocol verifies the M8 (#2008) traceoptions packet-filter
 // `protocol` match: a filter with protocol set matches only records of that


### PR DESCRIPTION
## Summary
Closes #3420 (Codex audit 097 H02). The persistent `security flow traceoptions file <name>` knob accepted absolute paths verbatim and joined relative paths under `/var/log` without rejecting a `..` escape, then `MkdirAll` + `OpenFile(O_CREATE|O_APPEND)` at the resolved path — a committed config could append root-written flow telemetry (internal addresses, ports, zones, actions, policy IDs) anywhere the daemon user can write. This is the persistent-config sibling of the interactive `monitor security flow file` path hardened in #3378.

## What is applied / validated
**Commit-time gate (`pkg/config`)** — `validateFlowTraceFileAST` walks `security > flow > traceoptions > file` on the group-expanded tree and rejects a non-basename value (absolute path, `/`/`\` separator, `.`/`..` component). Lives in the compiler alongside the syslog port / tls-profile gates because the filename is a single AST value `SchemaValidate` treats as opaque.
- **Strict** (commit / commit-check): hard reject.
- **Lenient** (load / peer-sync, new `lenientFlowTraceFile` opt): downgrade to a `cfg.Warnings` entry so an already-persisted / peer-synced config an older binary accepted still boots (#1960 fail-closed-on-load class).

**Runtime hardening (`pkg/logging/trace.go`)** — `NewTraceWriter` validates `opts.File` with `sanitizeTraceFileName` (basename only) and opens via `openTraceFile` under `traceLogDir` (`/var/log`; package var only so tests can redirect) with `O_NOFOLLOW`, a regular-file check, and mode `0600` instead of world-readable `0644`. Rotation reopens through the same guard. This is the defense-in-depth backstop that fails safe (tracing disabled) on a leniently-loaded value.

## RED-on-revert evidence
- Dropping the `validateFlowTraceFileAST` call → `TestFlowTraceFilePathTraversalFailsCommit` (absolute / `..` / subdir) and `TestFlowTraceFileLenientDowngrade` go green on the traversal config (verified: "got nil error" / "did not record a flow-trace file warning").
- Removing the sanitize / `O_NOFOLLOW` guard → `TestNewTraceWriterRejectsPathTraversal` and `TestNewTraceWriterNoFollowSymlink` go green.
- `TestFlowTraceFileBasenameCommits` is the anti-over-reject guard (a valid `rt-flow.log size ... files ...` still commits).

## Validation
`go build ./...`, `go vet ./pkg/config/ ./pkg/logging/`, `go test ./pkg/config/... ./pkg/logging/...` all green; `gofmt -l` clean.

Scope is precisely #3420. Siblings #3422 (invalid packet-filter/flag) and #3424 (unbounded rotation) are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi