### PR TITLE
nat: enforce source-NAT match destination-port/application (#3429)

### DIFF
--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1335,20 +1335,17 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 						// snapshot-build time (appendNATDestinationAddressName).
 						rule.Match.DestinationAddressName = nodeVal(m)
 					case "destination-port":
-						if len(m.Children) > 0 {
-							for _, child := range m.Children {
-								if n, err := strconv.Atoi(child.Name()); err == nil {
-									rule.Match.DestinationPorts = append(rule.Match.DestinationPorts, n)
-									if rule.Match.DestinationPort == 0 {
-										rule.Match.DestinationPort = n
-									}
-								}
-							}
-						} else if v := nodeVal(m); v != "" {
-							if n, err := strconv.Atoi(v); err == nil {
-								rule.Match.DestinationPort = n
-								rule.Match.DestinationPorts = append(rule.Match.DestinationPorts, n)
-							}
+						// #3429 (H03): route source-NAT destination-port through
+						// the shared DNAT port-list parser. The old scalar path
+						// read only nodeVal/single child, so a flat-set
+						// `destination-port 20000 to 20003` (collapsed onto
+						// Keys=[destination-port 20000 to 20003], no children)
+						// silently kept only the first port. parseDNATPortList
+						// handles bracket lists and `low to high` ranges in both
+						// the hierarchical and flat-set AST shapes.
+						rule.Match.DestinationPorts = append(rule.Match.DestinationPorts, parseDNATPortList(m)...)
+						if rule.Match.DestinationPort == 0 && len(rule.Match.DestinationPorts) > 0 {
+							rule.Match.DestinationPort = rule.Match.DestinationPorts[0]
 						}
 					case "application":
 						rule.Match.Application = nodeVal(m)

--- a/pkg/config/compiler_nat_source_dport_3429_test.go
+++ b/pkg/config/compiler_nat_source_dport_3429_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3429 (H03): source-NAT `match destination-port` must be parsed through the
+// shared DNAT port-list parser so a bracket list or a `low to high` range is
+// fully captured. Before the fix the scalar path read only nodeVal, so a
+// flat-set `destination-port 20000 to 20003` (lexer-collapsed onto
+// Keys=[destination-port 20000 to 20003], no children) kept ONLY the first port
+// (20000). Reverting compiler_nat.go to the scalar path turns these RED.
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath, never NewParser
+// (the parser merges newline-separated set lines into one giant node).
+
+func compileSourceNATDPort(t *testing.T, dportCmd string) *NATRule {
+	t.Helper()
+	tree := &ConfigTree{}
+	cmds := []string{
+		"set security nat source rule-set RS from zone lan",
+		"set security nat source rule-set RS to zone wan",
+		dportCmd,
+		"set security nat source rule-set RS rule R1 then source-nat interface",
+	}
+	for _, cmd := range cmds {
+		if err := tree.SetPath(strings.Fields(cmd)[1:]); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if len(cfg.Security.NAT.Source) != 1 || len(cfg.Security.NAT.Source[0].Rules) != 1 {
+		t.Fatalf("unexpected source NAT shape: %+v", cfg.Security.NAT.Source)
+	}
+	return cfg.Security.NAT.Source[0].Rules[0]
+}
+
+func TestSourceNATDestinationPortRangeParsed_3429(t *testing.T) {
+	rule := compileSourceNATDPort(t,
+		"set security nat source rule-set RS rule R1 match destination-port 20000 to 20003")
+	want := []int{20000, 20001, 20002, 20003}
+	if len(rule.Match.DestinationPorts) != len(want) {
+		t.Fatalf("DestinationPorts = %v, want %v (range must expand, not collapse to first)",
+			rule.Match.DestinationPorts, want)
+	}
+	for i, p := range want {
+		if rule.Match.DestinationPorts[i] != p {
+			t.Fatalf("DestinationPorts[%d] = %d, want %d", i, rule.Match.DestinationPorts[i], p)
+		}
+	}
+}
+
+func TestSourceNATDestinationPortBracketListParsed_3429(t *testing.T) {
+	rule := compileSourceNATDPort(t,
+		"set security nat source rule-set RS rule R1 match destination-port [ 80 443 8080 ]")
+	want := map[int]bool{80: true, 443: true, 8080: true}
+	if len(rule.Match.DestinationPorts) != len(want) {
+		t.Fatalf("DestinationPorts = %v, want the 3-element bracket list",
+			rule.Match.DestinationPorts)
+	}
+	for _, p := range rule.Match.DestinationPorts {
+		if !want[p] {
+			t.Fatalf("unexpected port %d in %v", p, rule.Match.DestinationPorts)
+		}
+	}
+}
+
+func TestSourceNATDestinationPortScalarStillWorks_3429(t *testing.T) {
+	rule := compileSourceNATDPort(t,
+		"set security nat source rule-set RS rule R1 match destination-port 8080")
+	if len(rule.Match.DestinationPorts) != 1 || rule.Match.DestinationPorts[0] != 8080 {
+		t.Fatalf("DestinationPorts = %v, want [8080]", rule.Match.DestinationPorts)
+	}
+}

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -222,7 +222,7 @@ func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[stri
 			// member). The Rust matcher enforces these before translating AND
 			// before applying a `then source-nat off` exemption, so a
 			// port/app-scoped rule no longer silently widens to every port.
-			matchDestPorts := coalescePortRanges(rule.Match.DestinationPorts)
+			matchDestPorts := sourceNATDestPortRanges(rule.Match.DestinationPorts)
 			matchApps := buildSourceNATAppTerms(cfg, rule.Match.Application)
 
 			out = append(out, SourceNATRuleSnapshot{
@@ -258,9 +258,17 @@ func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[stri
 }
 
 // natProtoAny is the source-NAT match-term protocol wildcard, mirroring the
-// Rust PROTO_ANY (256): outside the 0-255 protocol range so it never aliases
-// protocol 0 (HOPOPT). #3429.
+// Rust SOURCE_NAT_PROTO_ANY (256): outside the 0-255 protocol range so it never
+// aliases protocol 0 (HOPOPT). It denotes a GENUINELY unconstrained term and
+// must never be used as a fallback for an unresolvable protocol (that is a
+// fail-open widen — Codex finding on PR #3471; see natAppProtoNumber). The
+// builder does not currently emit it: an application always constrains protocol,
+// and an unconstrained `match application` (empty / "any") produces NO term at
+// all rather than an any-protocol term. Kept defined to document the wire
+// wildcard the Rust matcher honors and to keep the two sides legible. #3429.
 const natProtoAny uint16 = 256
+
+var _ = natProtoAny // reserved wire wildcard; see doc above (not emitted today)
 
 // natProtoNever is a reserved protocol sentinel that can never equal a real
 // 0-255 protocol and is not the wildcard, so a term carrying it matches no flow
@@ -271,12 +279,32 @@ const natProtoAny uint16 = 256
 // is only the lenient load / peer-sync backstop.
 const natProtoNever uint16 = 0xFFFF
 
+// natNeverMatchPortRange is an impossible inclusive range (Low > High): no L4
+// port satisfies `p >= 1 && p <= 0`, so a rule carrying it matches NOTHING
+// (#3429). It is the fail-CLOSED sentinel emitted when a destination-port (or an
+// application's destination-port) constraint WAS configured but every value is
+// unrepresentable / out of the valid 1..65535 range. Without it, coalescing to
+// an EMPTY range list would be read downstream as "no port constraint" = match
+// any port — re-introducing the exact fail-OPEN widening #3429 closes (AGY
+// finding on PR #3471). The Rust matcher PRESERVES a Low>High range (it never
+// matches) rather than dropping it, so the sentinel survives the wire. The
+// strict commit gate (#3386) already rejects an out-of-range port at commit;
+// this hardens the lenient / tolerant-load / peer-sync path.
+var natNeverMatchPortRange = NatPortRangeWire{Low: 1, High: 0}
+
 // coalescePortRanges collapses a list of individual L4 ports (the expanded
 // output of parseDNATPortList / appPortsFromSpec) into a minimal set of
-// inclusive [Low,High] wire ranges (#3429). Anything outside the valid
-// 1..65535 range is dropped (fail closed — a bad/wrapping value never becomes a
-// wrong u16 match). The result is sorted, deduplicated, and run-merged so a
+// inclusive [Low,High] wire ranges (#3429). Any value outside the valid
+// 1..65535 range is skipped (a bad/wrapping value never becomes a wrong u16
+// match). The result is sorted, deduplicated, and run-merged so a
 // `destination-port 20000 to 20003` carries one range, not four entries.
+//
+// This is a pure utility: it returns an EMPTY slice both for "no ports given"
+// AND for "ports given but none representable" — the two are indistinguishable
+// here and an empty result means "unconstrained" downstream. Callers that must
+// fail CLOSED on an all-out-of-range constraint (rather than widen to match-any)
+// MUST go through sourceNATDestPortRanges / the app-term guard, which substitute
+// natNeverMatchPortRange when the input was non-empty but coalesced to nothing.
 func coalescePortRanges(ports []int) []NatPortRangeWire {
 	if len(ports) == 0 {
 		return nil
@@ -311,15 +339,40 @@ func coalescePortRanges(ports []int) []NatPortRangeWire {
 	return ranges
 }
 
+// sourceNATDestPortRanges coalesces a configured source-NAT `match
+// destination-port` list to wire ranges, failing CLOSED when the constraint was
+// specified but nothing is representable (#3429). An empty input (no constraint
+// configured) stays empty — a legitimate match-any-port wildcard. A non-empty
+// input that coalesces to nothing (every port out of 1..65535) returns the
+// never-match sentinel so the rule matches NOTHING instead of widening to every
+// port (the AGY-found fail-open on PR #3471). NOTE: source NAT has no
+// `match source-port` grammar (the SNAT parser only reads source/destination
+// address(-name), destination-port, and application), so there is no
+// source-port coalesce path to guard symmetrically.
+func sourceNATDestPortRanges(ports []int) []NatPortRangeWire {
+	ranges := coalescePortRanges(ports)
+	if len(ports) > 0 && len(ranges) == 0 {
+		return []NatPortRangeWire{natNeverMatchPortRange}
+	}
+	return ranges
+}
+
 // natAppProtoNumber resolves an application's protocol token to its IANA number
-// for the source-NAT match wire, returning natProtoAny when the token is empty
-// or unresolvable (#3429). A concrete number — including 0 (HOPOPT) — is
-// honored. Mirrors the appid SSOT (appid.ProtocolNumber) the policy path uses.
+// for the source-NAT match wire (#3429). A resolvable token — including a
+// numeric "0" (HOPOPT) — maps to its IANA value via the appid SSOT
+// (appid.ProtocolNumber, the same resolver the policy path uses). An EMPTY or
+// unresolvable protocol returns natProtoNever (0xFFFF), a never-match sentinel:
+// a Junos application ALWAYS constrains protocol, so a term whose protocol
+// cannot be resolved must match NOTHING. Returning natProtoAny (256, the
+// wildcard) here would widen the app-scoped rule to EVERY protocol — a fail-open
+// of the same class #3429 closes (Codex finding on PR #3471). natProtoAny is
+// reserved for a genuinely unconstrained term, which the app path never produces
+// (the "any" / empty app name short-circuits to no terms before this is called).
 func natAppProtoNumber(proto string) uint16 {
 	if n, ok := appid.ProtocolNumber(proto); ok {
 		return uint16(n)
 	}
-	return natProtoAny
+	return natProtoNever
 }
 
 // buildSourceNATAppTerms resolves a source-NAT `match application <name>` into
@@ -340,9 +393,18 @@ func buildSourceNATAppTerms(cfg *config.Config, appName string) []NatAppTermWire
 		if a == nil {
 			return
 		}
+		ports := coalescePortRanges(appPortsFromSpec(a.DestinationPort))
+		if a.DestinationPort != "" && len(ports) == 0 {
+			// #3429: the application carried a destination-port spec but none of
+			// it is representable (out of 1..65535) — fail CLOSED so the term
+			// matches nothing rather than silently demoting to a protocol-only
+			// (any-port) match. An app with NO destination-port keeps Ports empty
+			// (a legitimate protocol-only match).
+			ports = []NatPortRangeWire{natNeverMatchPortRange}
+		}
 		terms = append(terms, NatAppTermWire{
 			Protocol: natAppProtoNumber(a.Protocol),
-			Ports:    coalescePortRanges(appPortsFromSpec(a.DestinationPort)),
+			Ports:    ports,
 		})
 	}
 	if app, found := config.ResolveApplication(appName, userApps); found {

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -3,9 +3,11 @@ package userspace
 import (
 	"log/slog"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 )
@@ -213,6 +215,16 @@ func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[stri
 					}
 				}
 			}
+			// #3429: carry the source-NAT L4 match constraints to the
+			// dataplane. `match destination-port` becomes a set of inclusive
+			// port ranges; `match application` is pre-expanded to (protocol,
+			// port-range) terms (an application-set yields one term per resolved
+			// member). The Rust matcher enforces these before translating AND
+			// before applying a `then source-nat off` exemption, so a
+			// port/app-scoped rule no longer silently widens to every port.
+			matchDestPorts := coalescePortRanges(rule.Match.DestinationPorts)
+			matchApps := buildSourceNATAppTerms(cfg, rule.Match.Application)
+
 			out = append(out, SourceNATRuleSnapshot{
 				Name:                             rule.Name,
 				FromZone:                         rs.FromZone,
@@ -236,11 +248,119 @@ func buildSourceNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map[stri
 				PersistentNATInactivityTimeout:   persistentNATInactivityTimeout,
 				PoolUnusable:                     poolUnusable,
 				PoolUnusableReason:               poolUnusableReason,
+				MatchDestinationPorts:            matchDestPorts,
+				MatchApplications:                matchApps,
 				CounterID:                        natCounterID(natCounterIDs, dataplane.NATCounterTypeSource, rs.Name, rule.Name),
 			})
 		}
 	}
 	return out
+}
+
+// natProtoAny is the source-NAT match-term protocol wildcard, mirroring the
+// Rust PROTO_ANY (256): outside the 0-255 protocol range so it never aliases
+// protocol 0 (HOPOPT). #3429.
+const natProtoAny uint16 = 256
+
+// natProtoNever is a reserved protocol sentinel that can never equal a real
+// 0-255 protocol and is not the wildcard, so a term carrying it matches no flow
+// (#3429). Emitted for a `match application` that was configured but resolved to
+// ZERO terms (a typo / dangling reference / empty application-set) so the rule
+// fails CLOSED — it matches nothing — rather than silently widening to every
+// protocol/port. The commit-time strict gate (#2187) rejects the typo so this
+// is only the lenient load / peer-sync backstop.
+const natProtoNever uint16 = 0xFFFF
+
+// coalescePortRanges collapses a list of individual L4 ports (the expanded
+// output of parseDNATPortList / appPortsFromSpec) into a minimal set of
+// inclusive [Low,High] wire ranges (#3429). Anything outside the valid
+// 1..65535 range is dropped (fail closed — a bad/wrapping value never becomes a
+// wrong u16 match). The result is sorted, deduplicated, and run-merged so a
+// `destination-port 20000 to 20003` carries one range, not four entries.
+func coalescePortRanges(ports []int) []NatPortRangeWire {
+	if len(ports) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{}, len(ports))
+	uniq := make([]int, 0, len(ports))
+	for _, p := range ports {
+		if p < 1 || p > 65535 {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		uniq = append(uniq, p)
+	}
+	if len(uniq) == 0 {
+		return nil
+	}
+	sort.Ints(uniq)
+	var ranges []NatPortRangeWire
+	lo, hi := uniq[0], uniq[0]
+	for _, p := range uniq[1:] {
+		if p == hi+1 {
+			hi = p
+			continue
+		}
+		ranges = append(ranges, NatPortRangeWire{Low: uint16(lo), High: uint16(hi)})
+		lo, hi = p, p
+	}
+	ranges = append(ranges, NatPortRangeWire{Low: uint16(lo), High: uint16(hi)})
+	return ranges
+}
+
+// natAppProtoNumber resolves an application's protocol token to its IANA number
+// for the source-NAT match wire, returning natProtoAny when the token is empty
+// or unresolvable (#3429). A concrete number — including 0 (HOPOPT) — is
+// honored. Mirrors the appid SSOT (appid.ProtocolNumber) the policy path uses.
+func natAppProtoNumber(proto string) uint16 {
+	if n, ok := appid.ProtocolNumber(proto); ok {
+		return uint16(n)
+	}
+	return natProtoAny
+}
+
+// buildSourceNATAppTerms resolves a source-NAT `match application <name>` into
+// (protocol, destination-port range) terms for the dataplane match (#3429). A
+// single user/predefined application yields one term; an application-set yields
+// one term per resolved member. The empty name (or "any") is unconstrained and
+// yields no terms. A term's Ports are the application's destination-port spec
+// coalesced to ranges; an application with no destination port leaves Ports
+// empty (protocol-only match). A configured-but-unresolvable reference yields a
+// single never-match term so the rule fails closed (see natProtoNever).
+func buildSourceNATAppTerms(cfg *config.Config, appName string) []NatAppTermWire {
+	if cfg == nil || appName == "" || appName == "any" {
+		return nil
+	}
+	userApps := cfg.Applications.Applications
+	var terms []NatAppTermWire
+	addApp := func(a *config.Application) {
+		if a == nil {
+			return
+		}
+		terms = append(terms, NatAppTermWire{
+			Protocol: natAppProtoNumber(a.Protocol),
+			Ports:    coalescePortRanges(appPortsFromSpec(a.DestinationPort)),
+		})
+	}
+	if app, found := config.ResolveApplication(appName, userApps); found {
+		addApp(app)
+	} else if _, isSet := cfg.Applications.ApplicationSets[appName]; isSet {
+		if expanded, err := config.ExpandApplicationSet(appName, &cfg.Applications); err == nil {
+			for _, termName := range expanded {
+				if a, ok := config.ResolveApplication(termName, userApps); ok {
+					addApp(a)
+				}
+			}
+		}
+	}
+	if len(terms) == 0 {
+		// Configured app reference that resolved to nothing -> fail closed.
+		terms = []NatAppTermWire{{Protocol: natProtoNever}}
+	}
+	return terms
 }
 
 func sourceNATPoolPortRange(pool *config.NATPool) (uint16, uint16, bool) {

--- a/pkg/dataplane/userspace/nat_l4_match_3429_test.go
+++ b/pkg/dataplane/userspace/nat_l4_match_3429_test.go
@@ -1,0 +1,139 @@
+// #3429: source-NAT `match destination-port` / `match application` enforcement.
+// These tests prove the Go snapshot builder carries the L4 match constraints
+// onto the userspace SourceNATRuleSnapshot (the per-flow match itself is
+// enforced Rust-side in nat::tests::*_3429). Before the fix these match fields
+// were parsed and compiled but DROPPED at the snapshot boundary, so a
+// port/app-scoped source-NAT rule silently widened to every port/protocol.
+// Dropping the builder assignment turns these RED.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func TestBuildSourceNATSnapshotsCarriesDestinationPortMatch(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name: "r1",
+				Match: config.NATMatch{
+					// `destination-port 20000 to 20003` -> compiler stores the
+					// range expanded to individual ports; the builder coalesces
+					// them back to one wire range.
+					DestinationPorts: []int{20000, 20001, 20002, 20003},
+				},
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	got := snaps[0].MatchDestinationPorts
+	want := []NatPortRangeWire{{Low: 20000, High: 20003}}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("MatchDestinationPorts = %+v, want %+v", got, want)
+	}
+}
+
+func TestBuildSourceNATSnapshotsDropsOutOfRangePort(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name: "r1",
+				Match: config.NATMatch{
+					// 0 and >65535 must be dropped (fail closed), 443 kept.
+					DestinationPorts: []int{0, 443, 70000},
+				},
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	got := snaps[0].MatchDestinationPorts
+	want := []NatPortRangeWire{{Low: 443, High: 443}}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("MatchDestinationPorts = %+v, want %+v (out-of-range dropped)", got, want)
+	}
+}
+
+func TestBuildSourceNATSnapshotsCarriesApplicationMatch(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Applications.Applications = map[string]*config.Application{
+		"app-https": {Name: "app-https", Protocol: "tcp", DestinationPort: "443"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name:  "r1",
+				Match: config.NATMatch{Application: "app-https"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	apps := snaps[0].MatchApplications
+	if len(apps) != 1 {
+		t.Fatalf("MatchApplications = %+v, want 1 term", apps)
+	}
+	if apps[0].Protocol != 6 { // tcp
+		t.Fatalf("term protocol = %d, want 6 (tcp)", apps[0].Protocol)
+	}
+	if len(apps[0].Ports) != 1 || apps[0].Ports[0] != (NatPortRangeWire{Low: 443, High: 443}) {
+		t.Fatalf("term ports = %+v, want [{443 443}]", apps[0].Ports)
+	}
+}
+
+func TestBuildSourceNATSnapshotsUnresolvableApplicationFailsClosed(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name:  "r1",
+				Match: config.NATMatch{Application: "does-not-exist"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	apps := snaps[0].MatchApplications
+	if len(apps) != 1 || apps[0].Protocol != natProtoNever {
+		t.Fatalf("MatchApplications = %+v, want one never-match term (proto %d)", apps, natProtoNever)
+	}
+}
+
+func TestBuildSourceNATSnapshotsUnconstrainedHasNoL4Match(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name: "r1",
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	if len(snaps[0].MatchDestinationPorts) != 0 || len(snaps[0].MatchApplications) != 0 {
+		t.Fatalf("unconstrained rule must carry no L4 match: %+v", snaps[0])
+	}
+}

--- a/pkg/dataplane/userspace/nat_l4_match_3429_test.go
+++ b/pkg/dataplane/userspace/nat_l4_match_3429_test.go
@@ -68,6 +68,85 @@ func TestBuildSourceNATSnapshotsDropsOutOfRangePort(t *testing.T) {
 	}
 }
 
+// #3471 AGY fail-open: a destination-port constraint whose ports are ALL out of
+// range must NOT coalesce to an empty list — empty means "unconstrained" =
+// match-any-port. It must emit the never-match sentinel so the rule matches
+// nothing. RED-on-revert: with the plain coalescePortRanges (drop-to-empty),
+// MatchDestinationPorts is empty and the rule widens to every port.
+func TestBuildSourceNATSnapshotsAllOutOfRangePortFailsClosed(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name: "r1",
+				Match: config.NATMatch{
+					DestinationPorts: []int{0, 70000, 99999},
+				},
+				Then: config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	snaps := buildSourceNATSnapshots(cfg, nil)
+	got := snaps[0].MatchDestinationPorts
+	if len(got) != 1 || got[0] != natNeverMatchPortRange {
+		t.Fatalf("MatchDestinationPorts = %+v, want one never-match range %+v (fail closed, not empty wildcard)",
+			got, natNeverMatchPortRange)
+	}
+}
+
+// #3471 Codex fail-open: an application whose protocol is empty or unresolvable
+// must emit the never-match protocol sentinel, NOT natProtoAny (256, wildcard).
+// RED-on-revert: returning natProtoAny widens the app term to every protocol.
+func TestBuildSourceNATSnapshotsAppEmptyProtocolFailsClosed(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Applications.Applications = map[string]*config.Application{
+		"app-noproto": {Name: "app-noproto", Protocol: "", DestinationPort: "443"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name:  "r1",
+				Match: config.NATMatch{Application: "app-noproto"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	apps := buildSourceNATSnapshots(cfg, nil)[0].MatchApplications
+	if len(apps) != 1 || apps[0].Protocol != natProtoNever {
+		t.Fatalf("MatchApplications = %+v, want one never-match term (proto %d), NOT natProtoAny %d",
+			apps, natProtoNever, natProtoAny)
+	}
+}
+
+func TestBuildSourceNATSnapshotsAppUnknownProtocolFailsClosed(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Applications.Applications = map[string]*config.Application{
+		"app-bad": {Name: "app-bad", Protocol: "frobnicate", DestinationPort: "443"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name:  "r1",
+				Match: config.NATMatch{Application: "app-bad"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	apps := buildSourceNATSnapshots(cfg, nil)[0].MatchApplications
+	if len(apps) != 1 || apps[0].Protocol != natProtoNever {
+		t.Fatalf("MatchApplications = %+v, want one never-match term (proto %d)", apps, natProtoNever)
+	}
+}
+
 func TestBuildSourceNATSnapshotsCarriesApplicationMatch(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Applications.Applications = map[string]*config.Application{

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -440,6 +440,25 @@ type TunnelWgPeerWire struct {
 	WgPresharedKeyHex string `json:"wg_preshared_key_hex,omitempty"`
 }
 
+// NatPortRangeWire is one inclusive [Low,High] L4 destination-port range on the
+// Go->Rust source-NAT match wire (#3429). A single port is Low==High. Used by
+// SourceNATRuleSnapshot.MatchDestinationPorts and inside NatAppTermWire.Ports.
+type NatPortRangeWire struct {
+	Low  uint16 `json:"low"`
+	High uint16 `json:"high"`
+}
+
+// NatAppTermWire is one resolved source-NAT `match application` term (#3429): an
+// L4 protocol (IANA number; 256 = any/unspecified — outside the 0-255 protocol
+// range so it never aliases protocol 0/HOPOPT) and optional destination-port
+// ranges. The flow matches the term when its protocol equals Protocol (or
+// Protocol==256) AND, if Ports is non-empty, its destination port falls in one
+// of the ranges. An application-set expands to one term per resolved member.
+type NatAppTermWire struct {
+	Protocol uint16             `json:"protocol"`
+	Ports    []NatPortRangeWire `json:"ports,omitempty"`
+}
+
 type SourceNATRuleSnapshot struct {
 	Name     string `json:"name"`
 	FromZone string `json:"from_zone,omitempty"`
@@ -478,6 +497,24 @@ type SourceNATRuleSnapshot struct {
 	PersistentNATInactivityTimeout int    `json:"persistent_nat_inactivity_timeout,omitempty"`
 	PoolUnusable                   bool   `json:"pool_unusable,omitempty"`
 	PoolUnusableReason             string `json:"pool_unusable_reason,omitempty"`
+	// MatchDestinationPorts carries the source-NAT rule's `match
+	// destination-port` constraint as inclusive [Low,High] ranges (#3429).
+	// Empty = unconstrained on destination port (match any port, the
+	// pre-#3429 behaviour). Non-empty = the flow's destination port MUST fall
+	// in one of the ranges, otherwise the rule does NOT match (so a port-scoped
+	// SNAT — including a `then source-nat off` exemption — no longer silently
+	// widens to every port). Additive wire field: an old helper without it
+	// treats every rule as port-unconstrained (the pre-#3429 over-match); an
+	// old Go binary omits it (omitempty).
+	MatchDestinationPorts []NatPortRangeWire `json:"match_destination_ports,omitempty"`
+	// MatchApplications carries the source-NAT rule's `match application`
+	// constraint, pre-expanded to (protocol, destination-port ranges) terms at
+	// snapshot build (#3429). Empty = unconstrained on application. Non-empty =
+	// the flow's protocol/destination port MUST satisfy one of the terms,
+	// otherwise the rule does NOT match. An application-set expands to one term
+	// per resolved member. Additive wire field, same skew semantics as
+	// MatchDestinationPorts.
+	MatchApplications []NatAppTermWire `json:"match_applications,omitempty"`
 	// CounterID is the compiler-assigned per-rule translation hit counter ID
 	// (stable key-derived hash, non-zero; 0 means "no counter"). The userspace
 	// dataplane attributes each SNAT translation on this rule to this slot, and

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -183,6 +183,26 @@ impl SourceNatFlowKey {
     }
 }
 
+/// #3429: source-NAT `match application` protocol wildcard. 256 is outside the
+/// 0-255 protocol range so it never aliases protocol 0 (HOPOPT); a term carrying
+/// it matches any L4 protocol. The Go builder emits it for an application whose
+/// protocol token is empty/unresolvable. A reserved 0xFFFF sentinel (any value
+/// in 257..=65535 works) can never equal a real protocol and is not the
+/// wildcard, so a term carrying it matches nothing — the fail-closed marker the
+/// Go builder emits for a configured-but-unresolvable `match application`.
+pub(crate) const SOURCE_NAT_PROTO_ANY: u16 = 256;
+
+/// #3429: one resolved source-NAT `match application` term — an L4 protocol
+/// (IANA number, or `SOURCE_NAT_PROTO_ANY` for any) and optional inclusive
+/// destination-port ranges. The flow matches the term when its protocol equals
+/// `protocol` (or `protocol == SOURCE_NAT_PROTO_ANY`) AND, when `ports` is
+/// non-empty, its destination port falls in one of the ranges.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SourceNatAppTerm {
+    pub(crate) protocol: u16,
+    pub(crate) ports: Vec<(u16, u16)>,
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct SourceNatRule {
     pub(crate) name: String,
@@ -211,6 +231,16 @@ pub(crate) struct SourceNatRule {
     /// constraint at all. Same fail-closed semantics as `source_constrained`,
     /// for the destination match set.
     pub(crate) destination_constrained: bool,
+    /// #3429: source-NAT `match destination-port` constraint as inclusive
+    /// (low, high) ranges. Empty = port-unconstrained (match any destination
+    /// port, the pre-#3429 behavior). Non-empty = the flow's destination port
+    /// MUST fall in one range or the rule does not match. Enforced in
+    /// `l4_matches`, before translation AND before an `off` exemption.
+    pub(crate) match_dst_ports: Vec<(u16, u16)>,
+    /// #3429: source-NAT `match application` constraint, pre-expanded by the Go
+    /// builder to (protocol, port-range) terms. Empty = app-unconstrained.
+    /// Non-empty = the flow MUST satisfy one term. Enforced in `l4_matches`.
+    pub(crate) match_apps: Vec<SourceNatAppTerm>,
     pub(crate) interface_mode: bool,
     pub(crate) off: bool,
     pub(crate) pool_name: String,
@@ -284,6 +314,39 @@ impl SourceNatRule {
         true
     }
 
+    /// #3429: does the flow satisfy this rule's L4 `match destination-port` /
+    /// `match application` constraints? An empty constraint set is a wildcard
+    /// (unchanged match-any behavior). A non-empty set is AND-ed across the two
+    /// kinds (destination-port AND application), mirroring Junos.
+    ///
+    /// `protocol == 0` is the synthetic "L4 tuple unknown" sentinel used by the
+    /// address-only `match_source_nat` callers: a rule that carries ANY L4
+    /// constraint cannot be satisfied by an unknown tuple, so it fails closed
+    /// (an L4-scoped rule must never fire on traffic whose port/protocol the
+    /// caller could not supply). An unconstrained rule is unaffected.
+    fn l4_matches(&self, protocol: u8, dst_port: u16) -> bool {
+        if self.match_dst_ports.is_empty() && self.match_apps.is_empty() {
+            return true;
+        }
+        if protocol == 0 {
+            return false;
+        }
+        if !self.match_dst_ports.is_empty() && !port_in_ranges(dst_port, &self.match_dst_ports) {
+            return false;
+        }
+        if !self.match_apps.is_empty() {
+            let proto16 = protocol as u16;
+            let ok = self.match_apps.iter().any(|t| {
+                (t.protocol == SOURCE_NAT_PROTO_ANY || t.protocol == proto16)
+                    && (t.ports.is_empty() || port_in_ranges(dst_port, &t.ports))
+            });
+            if !ok {
+                return false;
+            }
+        }
+        true
+    }
+
     fn matches(
         &self,
         scope: &NatScopeCtx,
@@ -291,6 +354,8 @@ impl SourceNatRule {
         to_zone: &str,
         src_ip: IpAddr,
         dst_ip: IpAddr,
+        protocol: u8,
+        dst_port: u16,
     ) -> bool {
         if !self.from_zone.is_empty() && self.from_zone != from_zone {
             return false;
@@ -299,6 +364,9 @@ impl SourceNatRule {
             return false;
         }
         if !self.scope_matches(scope) {
+            return false;
+        }
+        if !self.l4_matches(protocol, dst_port) {
             return false;
         }
         match (src_ip, dst_ip) {
@@ -464,6 +532,27 @@ pub(crate) fn parse_source_nat_rules_with_previous(
         }
         for prefix in &snap.destination_addresses {
             parse_match_prefix(prefix, &mut rule.destination_v4, &mut rule.destination_v6);
+        }
+        // #3429: source-NAT L4 match constraints. `match destination-port`
+        // ranges and the pre-expanded `match application` terms. A range with
+        // low > high is dropped (never matches anything anyway); an empty list
+        // leaves the rule unconstrained on that axis.
+        for r in &snap.match_destination_ports {
+            if r.low <= r.high {
+                rule.match_dst_ports.push((r.low, r.high));
+            }
+        }
+        for term in &snap.match_applications {
+            let mut ports = Vec::with_capacity(term.ports.len());
+            for r in &term.ports {
+                if r.low <= r.high {
+                    ports.push((r.low, r.high));
+                }
+            }
+            rule.match_apps.push(SourceNatAppTerm {
+                protocol: term.protocol,
+                ports,
+            });
         }
         // Parse pool addresses and port range for pool-mode SNAT.
         let mut invalid_pool_address = false;
@@ -690,7 +779,9 @@ pub(crate) fn match_source_nat_result_for_tuple(
         dst_port,
     };
     for rule in rules {
-        if !rule.matches(scope, from_zone, to_zone, src_ip, dst_ip) {
+        if !rule.matches(
+            scope, from_zone, to_zone, src_ip, dst_ip, protocol, dst_port,
+        ) {
             continue;
         }
         if rule.off {
@@ -906,6 +997,11 @@ fn parse_match_prefix(prefix: &str, v4: &mut Vec<PrefixV4>, v6: &mut Vec<PrefixV
             Err(_) => {}
         },
     }
+}
+
+/// #3429: is `port` within any inclusive (low, high) range in `ranges`?
+fn port_in_ranges(port: u16, ranges: &[(u16, u16)]) -> bool {
+    ranges.iter().any(|&(lo, hi)| port >= lo && port <= hi)
 }
 
 /// #2398: match a v4 IP against a rule's match set.

--- a/userspace-dp/src/nat/source.rs
+++ b/userspace-dp/src/nat/source.rs
@@ -534,21 +534,21 @@ pub(crate) fn parse_source_nat_rules_with_previous(
             parse_match_prefix(prefix, &mut rule.destination_v4, &mut rule.destination_v6);
         }
         // #3429: source-NAT L4 match constraints. `match destination-port`
-        // ranges and the pre-expanded `match application` terms. A range with
-        // low > high is dropped (never matches anything anyway); an empty list
-        // leaves the rule unconstrained on that axis.
+        // ranges and the pre-expanded `match application` terms. Ranges are kept
+        // VERBATIM — including a deliberately impossible `low > high` range,
+        // which `port_in_ranges` can never satisfy. The Go builder emits exactly
+        // such a range (natNeverMatchPortRange = {1,0}) as a fail-CLOSED sentinel
+        // when a port constraint was configured but every value is out of range:
+        // dropping it here would empty the list, and an empty list is read as
+        // "unconstrained" by `l4_matches` (match any port) — re-opening the
+        // fail-open this fix closes (AGY finding on PR #3471). A non-empty list
+        // that is purely such sentinels therefore matches NOTHING; an empty list
+        // (no constraint configured) leaves the rule unconstrained on that axis.
         for r in &snap.match_destination_ports {
-            if r.low <= r.high {
-                rule.match_dst_ports.push((r.low, r.high));
-            }
+            rule.match_dst_ports.push((r.low, r.high));
         }
         for term in &snap.match_applications {
-            let mut ports = Vec::with_capacity(term.ports.len());
-            for r in &term.ports {
-                if r.low <= r.high {
-                    ports.push((r.low, r.high));
-                }
-            }
+            let ports = term.ports.iter().map(|r| (r.low, r.high)).collect();
             rule.match_apps.push(SourceNatAppTerm {
                 protocol: term.protocol,
                 ports,

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -7,7 +7,7 @@ use super::allocator::{
     ALLOCATION_GC_BUDGET, NS_PER_SEC, PersistentLease, PersistentSourceKey, PoolAddressFamily,
     sticky_pool_index,
 };
-use super::source::{PersistentNatPermit, SourceNatFlowKey};
+use super::source::{PersistentNatPermit, SOURCE_NAT_PROTO_ANY, SourceNatFlowKey};
 use super::destination::{PROTO_ANY, PROTO_TCP, PROTO_UDP};
 use super::*;
 use crate::ip_proto::{PROTO_ESP, PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6};
@@ -6821,4 +6821,127 @@ fn source_nat_l4_constrained_rule_fails_closed_on_unknown_tuple_3429() {
         d.is_none(),
         "an L4-scoped SNAT rule must NOT fire for an unknown (proto=0) tuple"
     );
+}
+
+// #3471 fold: a destination-port constraint that is purely an impossible
+// (low > high) range — the natNeverMatchPortRange fail-closed sentinel the Go
+// builder emits when every configured port is out of range — must match
+// NOTHING, NOT collapse to "unconstrained". The Rust parser keeps a low > high
+// range verbatim; dropping it (the pre-fold revert) empties match_dst_ports and
+// l4_matches then treats the rule as port-unconstrained = match-all (fail-open).
+#[test]
+fn source_nat_never_match_port_sentinel_matches_nothing_3429() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        // natNeverMatchPortRange = {low:1, high:0} — impossible, never matches.
+        match_destination_ports: vec![NatPortRangeWire { low: 1, high: 0 }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let src: IpAddr = "10.0.1.100".parse().unwrap();
+    let dst: IpAddr = "8.8.8.8".parse().unwrap();
+    for dport in [1u16, 80, 443, 20001, 65535] {
+        let mut counter = None;
+        let r = match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src,
+            dst,
+            PROTO_TCP,
+            12345,
+            dport,
+            egress_v4,
+            None,
+            0,
+            false,
+            &mut counter,
+        );
+        assert_eq!(
+            r,
+            SourceNatLookup::NoMatch,
+            "never-match port sentinel must reject dst port {}",
+            dport
+        );
+    }
+}
+
+// #3471 fold: an app term whose protocol is the never-match sentinel (0xFFFF,
+// what the Go builder emits for an empty/unresolvable app protocol) must match
+// NOTHING, while a genuinely-any term (SOURCE_NAT_PROTO_ANY = 256) still matches
+// every protocol. This locks the distinction the Codex finding turned on:
+// returning natProtoAny for an unresolvable protocol (the revert) would make the
+// never term behave like the any term — fail-open.
+#[test]
+fn source_nat_app_protocol_never_vs_any_3429() {
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let src: IpAddr = "10.0.1.100".parse().unwrap();
+    let dst: IpAddr = "8.8.8.8".parse().unwrap();
+    let lookup = |rules: &[_], proto: u8| {
+        let mut counter = None;
+        match_source_nat_result_for_tuple(
+            rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src,
+            dst,
+            proto,
+            12345,
+            443,
+            egress_v4,
+            None,
+            0,
+            false,
+            &mut counter,
+        )
+    };
+
+    // Never-match protocol sentinel (0xFFFF): no protocol satisfies the term.
+    let never = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        match_applications: vec![NatAppTermWire {
+            protocol: 0xFFFF,
+            ports: vec![],
+        }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    for proto in [PROTO_TCP, PROTO_UDP, PROTO_ICMP, PROTO_GRE] {
+        assert_eq!(
+            lookup(&never, proto),
+            SourceNatLookup::NoMatch,
+            "never-match app protocol must reject protocol {}",
+            proto
+        );
+    }
+
+    // Genuinely-any protocol (256): every protocol matches the term.
+    let any = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        match_applications: vec![NatAppTermWire {
+            protocol: SOURCE_NAT_PROTO_ANY,
+            ports: vec![],
+        }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    for proto in [PROTO_TCP, PROTO_UDP, PROTO_ICMP, PROTO_GRE] {
+        assert!(
+            matches!(lookup(&any, proto), SourceNatLookup::Matched(_)),
+            "any-protocol app term must match protocol {}",
+            proto
+        );
+    }
 }

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -11,7 +11,10 @@ use super::source::{PersistentNatPermit, SourceNatFlowKey};
 use super::destination::{PROTO_ANY, PROTO_TCP, PROTO_UDP};
 use super::*;
 use crate::ip_proto::{PROTO_ESP, PROTO_GRE, PROTO_ICMP, PROTO_ICMPV6};
-use crate::{DestinationNATRuleSnapshot, SourceNATRuleSnapshot, StaticNATRuleSnapshot};
+use crate::{
+    DestinationNATRuleSnapshot, NatAppTermWire, NatPortRangeWire, SourceNATRuleSnapshot,
+    StaticNATRuleSnapshot,
+};
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -6560,5 +6563,262 @@ fn destination_nat_from_routing_instance_scope_matches_only_named_vrf() {
             .lookup_with_counter_scoped(PROTO_TCP, src, dst, 443, "", "", "VR2")
             .is_none(),
         "RI-scoped DNAT must NOT match in another VRF"
+    );
+}
+
+// === #3429: source-NAT `match destination-port` / `match application`
+// enforcement. Before the fix these match fields were parsed and compiled but
+// never carried to the dataplane, so a port/app-scoped source-NAT rule
+// (including a `then source-nat off` exemption) silently widened to every
+// port/protocol. Reverting the l4_matches gate makes the wrong-port / wrong-app
+// lookups translate, turning the NoMatch assertions RED. ===
+
+#[test]
+fn source_nat_match_destination_port_constrains_flow_3429() {
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        // `match destination-port 20000 to 20003`.
+        match_destination_ports: vec![NatPortRangeWire {
+            low: 20000,
+            high: 20003,
+        }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let src: IpAddr = "10.0.1.100".parse().unwrap();
+    let dst: IpAddr = "8.8.8.8".parse().unwrap();
+    let mut counter = None;
+    // In-range destination port -> translated.
+    let hit = match_source_nat_result_for_tuple(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src,
+        dst,
+        PROTO_TCP,
+        12345,
+        20001,
+        egress_v4,
+        None,
+        0,
+        false,
+        &mut counter,
+    );
+    assert!(
+        matches!(hit, SourceNatLookup::Matched(_)),
+        "in-range dst port must match: {:?}",
+        hit
+    );
+    // Out-of-range destination port -> NO match (pre-fix this over-matched).
+    let miss = match_source_nat_result_for_tuple(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src,
+        dst,
+        PROTO_TCP,
+        12345,
+        80,
+        egress_v4,
+        None,
+        0,
+        false,
+        &mut counter,
+    );
+    assert_eq!(
+        miss,
+        SourceNatLookup::NoMatch,
+        "out-of-range dst port must NOT match"
+    );
+}
+
+#[test]
+fn source_nat_match_destination_port_constrains_off_exemption_3429() {
+    // `then source-nat off` scoped to a destination port must exempt ONLY that
+    // port. Pre-fix the exemption widened to every port, so a flow on a
+    // different port was wrongly left untranslated (Matched(default)).
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "no-nat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        off: true,
+        match_destination_ports: vec![NatPortRangeWire { low: 53, high: 53 }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let src: IpAddr = "10.0.1.100".parse().unwrap();
+    let dst: IpAddr = "8.8.8.8".parse().unwrap();
+    let mut counter = None;
+    // Exempt port -> matched as a no-op (off) rule.
+    let on_port = match_source_nat_result_for_tuple(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src,
+        dst,
+        PROTO_UDP,
+        40000,
+        53,
+        egress_v4,
+        None,
+        0,
+        false,
+        &mut counter,
+    );
+    assert!(
+        matches!(on_port, SourceNatLookup::Matched(_)),
+        "exempt port must match the off rule: {:?}",
+        on_port
+    );
+    // Different port -> the off rule must NOT swallow it.
+    let other_port = match_source_nat_result_for_tuple(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        src,
+        dst,
+        PROTO_UDP,
+        40000,
+        443,
+        egress_v4,
+        None,
+        0,
+        false,
+        &mut counter,
+    );
+    assert_eq!(
+        other_port,
+        SourceNatLookup::NoMatch,
+        "a port-scoped `source-nat off` must NOT exempt other ports"
+    );
+}
+
+#[test]
+fn source_nat_match_application_constrains_protocol_and_port_3429() {
+    // `match application` pre-expanded to (proto=TCP, ports=[443]).
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        match_applications: vec![NatAppTermWire {
+            protocol: PROTO_TCP as u16,
+            ports: vec![NatPortRangeWire {
+                low: 443,
+                high: 443,
+            }],
+        }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let src: IpAddr = "10.0.1.100".parse().unwrap();
+    let dst: IpAddr = "8.8.8.8".parse().unwrap();
+    let lookup = |proto: u8, dport: u16| {
+        let mut counter = None;
+        match_source_nat_result_for_tuple(
+            &rules,
+            &NatScopeCtx::default(),
+            "lan",
+            "wan",
+            src,
+            dst,
+            proto,
+            12345,
+            dport,
+            egress_v4,
+            None,
+            0,
+            false,
+            &mut counter,
+        )
+    };
+    // Right proto + right port -> match.
+    assert!(
+        matches!(lookup(PROTO_TCP, 443), SourceNatLookup::Matched(_)),
+        "tcp/443 must match the app-scoped rule"
+    );
+    // Right proto, wrong port -> no match.
+    assert_eq!(
+        lookup(PROTO_TCP, 80),
+        SourceNatLookup::NoMatch,
+        "tcp/80 must NOT match an app scoped to tcp/443"
+    );
+    // Wrong proto (UDP) on the same port -> no match.
+    assert_eq!(
+        lookup(PROTO_UDP, 443),
+        SourceNatLookup::NoMatch,
+        "udp/443 must NOT match an app scoped to tcp/443"
+    );
+}
+
+#[test]
+fn source_nat_unconstrained_rule_still_matches_any_l4_3429() {
+    // A rule with NO L4 match fields keeps the pre-#3429 match-any behavior,
+    // including for the address-only (proto=0) tuple-unknown caller.
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let d = match_source_nat(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "10.0.1.100".parse().unwrap(),
+        "8.8.8.8".parse().unwrap(),
+        egress_v4,
+        None,
+    );
+    assert!(
+        d.is_some(),
+        "an unconstrained SNAT rule must still match (proto-unknown caller)"
+    );
+}
+
+#[test]
+fn source_nat_l4_constrained_rule_fails_closed_on_unknown_tuple_3429() {
+    // The address-only (proto=0) caller cannot supply a port/protocol, so an
+    // L4-constrained rule fails closed (does not fire) rather than over-match.
+    let rules = parse_source_nat_rules(&[SourceNATRuleSnapshot {
+        name: "snat".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["0.0.0.0/0".to_string()],
+        interface_mode: true,
+        match_destination_ports: vec![NatPortRangeWire {
+            low: 443,
+            high: 443,
+        }],
+        ..SourceNATRuleSnapshot::default()
+    }]);
+    let egress_v4 = Some("172.16.80.8".parse::<Ipv4Addr>().unwrap());
+    let d = match_source_nat(
+        &rules,
+        &NatScopeCtx::default(),
+        "lan",
+        "wan",
+        "10.0.1.100".parse().unwrap(),
+        "8.8.8.8".parse().unwrap(),
+        egress_v4,
+        None,
+    );
+    assert!(
+        d.is_none(),
+        "an L4-scoped SNAT rule must NOT fire for an unknown (proto=0) tuple"
     );
 }

--- a/userspace-dp/src/protocol/nat.rs
+++ b/userspace-dp/src/protocol/nat.rs
@@ -4,6 +4,27 @@
 
 use serde::{Deserialize, Serialize};
 
+/// #3429: one inclusive [low,high] L4 destination-port range on the source-NAT
+/// match wire. A single port is `low == high`. Mirrors the Go NatPortRangeWire.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct NatPortRangeWire {
+    #[serde(default)]
+    pub low: u16,
+    #[serde(default)]
+    pub high: u16,
+}
+
+/// #3429: one resolved source-NAT `match application` term — an L4 protocol
+/// (IANA number; 256 = any, 0xFFFF = never/fail-closed sentinel) and optional
+/// destination-port ranges. Mirrors the Go NatAppTermWire.
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub(crate) struct NatAppTermWire {
+    #[serde(default)]
+    pub protocol: u16,
+    #[serde(default)]
+    pub ports: Vec<NatPortRangeWire>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub(crate) struct SourceNATRuleSnapshot {
     pub name: String,
@@ -69,6 +90,22 @@ pub(crate) struct SourceNATRuleSnapshot {
     pub pool_unusable: bool,
     #[serde(rename = "pool_unusable_reason", default)]
     pub pool_unusable_reason: String,
+    /// #3429: source-NAT `match destination-port` constraint as inclusive
+    /// [low,high] ranges. Empty = port-unconstrained (match any port). A
+    /// non-empty set requires the flow's destination port to fall in one of the
+    /// ranges, otherwise the rule does NOT match — so a port-scoped SNAT
+    /// (including a `then source-nat off` exemption) no longer silently widens
+    /// to every port. Additive wire field (#1961): an older control plane omits
+    /// it; this helper defaults it empty (the pre-#3429 over-match).
+    #[serde(rename = "match_destination_ports", default)]
+    pub match_destination_ports: Vec<NatPortRangeWire>,
+    /// #3429: source-NAT `match application` constraint, pre-expanded by the Go
+    /// builder to (protocol, destination-port range) terms (an application-set
+    /// expands to one term per resolved member). Empty = unconstrained. A
+    /// non-empty set requires the flow's protocol/destination port to satisfy
+    /// one term. Additive wire field, same skew semantics.
+    #[serde(rename = "match_applications", default)]
+    pub match_applications: Vec<NatAppTermWire>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -1054,6 +1054,8 @@
     "from_routing_instance": "",
     "from_zone": "",
     "interface_mode": false,
+    "match_applications": [],
+    "match_destination_ports": [],
     "name": "",
     "off": false,
     "persistent_nat": false,


### PR DESCRIPTION
Closes #3429

## Problem
Source-NAT rules accept `match destination-port` and `match application`, but those constraints were parsed and (for `application`) strict-validated yet never carried to the dataplane. The userspace `SourceNatRule` keyed only zones/scopes/src-ip/dst-ip (`fn matches`), so a port- or app-scoped source-NAT rule — **including a `then source-nat off` exemption** — silently widened to every protocol and port (codex-audit-095 H01/H02/H03, L01).

## Fix (enforce at the dataplane, mirroring DNAT)
- **Wire (additive, #1961 skew-safe):** `SourceNATRuleSnapshot` gains `match_destination_ports` (inclusive `[low,high]` ranges) and `match_applications` (pre-expanded `(protocol, port-range)` terms; an application-set yields one term per resolved member). Empty = the pre-#3429 unconstrained match-any. Go `NatPortRangeWire`/`NatAppTermWire` mirror the Rust structs.
- **Go builder:** `coalescePortRanges` collapses the parsed destination-port list to minimal ranges and drops anything outside `1..65535` (fail closed); `buildSourceNATAppTerms` resolves `match application` to `(proto, ports)` via the `appid` SSOT. A configured-but-unresolvable reference emits a never-match sentinel so the rule fails **closed** rather than over-matching (the #2187 strict gate already rejects the typo at commit).
- **Rust matcher:** `SourceNatRule` gains `match_dst_ports`/`match_apps` + a `l4_matches` gate, evaluated inside `matches()` so it applies **before translation AND before an `off` exemption**. An L4-constrained rule fails closed for the address-only (`protocol==0`, tuple-unknown) caller.
- **H03:** source-NAT `match destination-port` now routes through the shared `parseDNATPortList`, so a flat-set `destination-port 20000 to 20003` captures the full range instead of silently keeping only the first port.

## Tests (RED-on-revert)
- Rust `nat::tests::*_3429`: in-range matches; out-of-range / wrong-proto / off-port flows do **not** match (RED when the `l4_matches` gate is reverted); unconstrained rule still matches any L4.
- Go config: range/bracket-list parse (RED on the scalar revert) — confirmed `[20000]` / `[]` before fix; snapshot builder carries the L4 match (RED if the builder assignment is dropped).
- Wire fixture regenerated.

## Validation
`go test ./pkg/config/... ./pkg/dataplane/userspace/...` green; `cargo build` + `cargo test 3429 wire_invariant_default_specimens` green. (Pre-existing, unrelated `event_stream::tests::test_paused_telemetry_eviction_does_not_poison_drain_2875` failure on master is not touched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi