### PR TITLE
Validate flow traceoptions packet-filter prefixes and flags (#3422)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23091,3 +23091,7 @@ top.
 - **Timestamp**: 2026-06-28
   - **Action**: #3427 fold — routing-instance lo0 term now TERMINATES as accept (mirror userspace continue_term=false + Accept placeholder), not skip. Skip introduced an over-drop when a later deny term matched on the kernel-primary lo0 chain. Fall-through/modifier-only still emit no rule.
   - **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/lo0_filter_test.go, pkg/daemon/README.md
+
+- **Timestamp**: 2026-06-28
+  - **Action**: #3422 validate flow traceoptions packet-filter prefixes + flags. Strict commit now rejects an unparseable source/destination-prefix or an unimplemented flag (validateFlowTraceFlagsAndFiltersAST); lenient load/peer-sync downgrades to a warning. Runtime fail-safe: NewTraceWriter keeps an invalid filter as never-match (M01: was dropped -> empty filters -> trace everything) and drops an unknown flag so basic-datapath/session defaults still apply (M02: was installed -> defaults suppressed -> matchFilters never matches -> empty trace file while reporting enabled). Tests RED-on-revert.
+  - **File(s)**: pkg/config/compiler_security.go, pkg/config/compiler.go, pkg/logging/trace.go, pkg/config/flow_traceoptions_filter_3422_test.go, pkg/logging/trace_filter_3422_test.go, pkg/logging/README.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-28 — #3422 fold: quoted-empty trace packet-filter prefix fail-open
+
+- **Timestamp**: 2026-06-28
+- **Action**: Codex BLOCKER fold into #3422. `source-prefix ""` /
+  `destination-prefix ""` is representable — the lexer/parser preserve the
+  empty-string token, so the AST node is PRESENT with an empty value
+  (`Keys=["source-prefix",""]`, nodeVal == ""). The commit gate
+  (validateFlowTraceFlagsAndFiltersAST) SKIPPED `v == ""` and the runtime
+  (NewTraceWriter) skipped an empty prefix string without marking the filter
+  invalid, so the filter was appended fully-unconstrained (zero
+  srcNet/dstNet, no proto) → matchFilters matched EVERY event — the M01
+  fail-open in a smaller costume. Fixed BOTH layers: (1) the commit gate now
+  REJECTS a present-but-empty prefix at strict / downgrades to a warning at
+  lenient (AST-distinguishable: node-present-but-empty ≠ node-absent, so a
+  legitimate protocol-only filter that omits prefixes is untouched);
+  (2) added TracePacketFilter.InvalidPrefix, set by the compiler when a prefix
+  node is present-but-empty, and seeded into traceFilter.invalid so the
+  runtime fails the filter closed (match-none) on the lenient load / peer-sync
+  path. Strengthened TestTraceWriterOneValidOneInvalidFilter to assert
+  len(filters)==2 AND filters[1].invalid. RED-on-revert verified for all three
+  fix sites; protocol-only filter confirmed still matching (no over-rejection).
+- **File(s)**: pkg/config/types_security.go, pkg/config/compiler_security.go,
+  pkg/logging/trace.go, pkg/config/flow_traceoptions_filter_3422_test.go,
+  pkg/logging/trace_filter_3422_test.go
+
 ## 2026-06-28 — #3350 security-log stream tls-profile reject (parsed-but-never-applied)
 
 - **Timestamp**: 2026-06-28

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -145,6 +145,20 @@ type compileOpts struct {
 	// live there. Same doctrine as lenientLogStreamPort.
 	lenientFlowTraceFile bool
 
+	// lenientFlowTraceFilter (#3422) downgrades the flow-trace flag /
+	// packet-filter-prefix gate (validateFlowTraceFlagsAndFiltersAST) from a
+	// hard compile error to a cfg.Warnings entry. Set ONLY on the tolerant
+	// load / peer-sync paths: a persisted or peer-synced config carrying an
+	// unparseable `packet-filter <n> source-prefix` value or an unimplemented
+	// `flag` token (values an older binary accepted) must still boot — the
+	// runtime fixes in NewTraceWriter keep an invalid filter match-none and
+	// drop an unknown flag so the defaults still apply, so a leniently-loaded
+	// value is fail-safe rather than the pre-#3422 fail-open (trace
+	// everything) / fail-silent (trace nothing). Like the file gate the flag
+	// and prefix values are AST leaves SchemaValidate treats as opaque, so the
+	// check does NOT live there. Same doctrine as lenientFlowTraceFile.
+	lenientFlowTraceFilter bool
+
 	// lenientLogEventModeFormat (#3349) downgrades the event-mode log-format
 	// compatibility gate (validateLogEventModeFormatStrict) from a hard
 	// compile error to a cfg.Warnings entry. Set ONLY on the tolerant load /
@@ -1152,6 +1166,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientLogStreamPort:                 true,
 		lenientLogTLSProfile:                 true,
 		lenientFlowTraceFile:                 true,
+		lenientFlowTraceFilter:               true,
 		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
@@ -1294,6 +1309,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientLogStreamPort:                 true,
 		lenientLogTLSProfile:                 true,
 		lenientFlowTraceFile:                 true,
+		lenientFlowTraceFilter:               true,
 		lenientLogEventModeFormat:            true,
 		lenientEventAttributesMatch:          true,
 		lenientIPsecPolicyProposalRef:        true,
@@ -1476,6 +1492,19 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// peer-synced config still boots (NewTraceWriter refuses the unsafe path at
 	// runtime, so tracing is simply disabled).
 	flowTraceFileWarnings, err := validateFlowTraceFileAST(tree.Children, "", opts.lenientFlowTraceFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// #3422 flow-trace flag / packet-filter prefix gate. The compiler copies
+	// flag tokens and filter prefixes verbatim; an unparseable prefix makes
+	// NewTraceWriter drop the filter (every-filter-invalid -> trace everything,
+	// M01) and an unimplemented flag makes matchFlags never match (trace
+	// nothing while reporting enabled, M02). Strict (commit / commit-check):
+	// reject. Lenient (load / peer-sync): warn so a persisted/peer-synced value
+	// still boots — the runtime now fails safe either way.
+	flowTraceFilterWarnings, err := validateFlowTraceFlagsAndFiltersAST(
+		tree.Children, "", opts.lenientFlowTraceFilter)
 	if err != nil {
 		return nil, err
 	}
@@ -1673,6 +1702,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, logStreamPortWarnings...)
 	cfg.Warnings = append(cfg.Warnings, logTLSProfileWarnings...)
 	cfg.Warnings = append(cfg.Warnings, flowTraceFileWarnings...)
+	cfg.Warnings = append(cfg.Warnings, flowTraceFilterWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -1463,6 +1464,109 @@ func validateFlowTraceFileAST(nodes []*Node, prefix string, lenient bool) ([]str
 				continue
 			}
 			return warnings, fmt.Errorf("%s", msg)
+		}
+	}
+	return warnings, nil
+}
+
+// flowTraceImplementedFlags is the set of `security flow traceoptions flag`
+// values the persistent trace writer actually honours
+// (logging.TraceWriter.matchFlags recognizes exactly these two). Any other
+// token is fail-silent at runtime: NewTraceWriter installs it into a non-empty
+// flag map, which suppresses the basic-datapath/session defaults, and
+// matchFlags then never matches — the daemon reports flow tracing enabled while
+// the trace file stays empty (#3422 M02, false evidence during an incident).
+// Keep in sync with logging.matchFlags / logging.traceFlagImplemented.
+var flowTraceImplementedFlags = map[string]bool{
+	"basic-datapath": true,
+	"session":        true,
+}
+
+// validateFlowTraceFlagsAndFiltersAST is the #3422 commit-time gate for
+// `security flow traceoptions { flag <name>; packet-filter <n> { source-prefix
+// / destination-prefix <prefix>; } }`. The compiler copies both flag tokens
+// (compileFlow: to.Flags = append(...)) and filter prefixes
+// (pf.SourcePrefix/DestinationPrefix = nodeVal(...)) verbatim with no
+// validation, and the runtime then fails silently in two directions:
+//
+//   - M01: NewTraceWriter drops a filter whose prefix does not parse, so a
+//     config whose every filter is a typo (`source-prefix 10.0.0.999/32`)
+//     leaves tw.filters empty and HandleEvent traces EVERYTHING — a filter
+//     meant to narrow tracing broadens it.
+//   - M02: an unknown flag (`flag sesson`) makes the flag map non-empty,
+//     suppressing the defaults, so matchFlags never matches and nothing is
+//     traced while the daemon reports tracing enabled.
+//
+// Both values are single AST leaves SchemaValidate treats as opaque free text,
+// so — like the file gate above — they are checked here on the group-expanded
+// tree, mirroring compileFlow's traversal (FindChild("flow") >
+// FindChild("traceoptions") > flag / packet-filter children).
+//
+// Strict path (commit / commit-check, lenient=false): an unparseable
+// source/destination prefix or an unimplemented flag is a hard compile error.
+// Lenient path (load / peer-sync, lenient=true): downgraded to a warning so an
+// already-persisted or peer-synced config an older binary accepted still boots;
+// the runtime fixes (NewTraceWriter marks an invalid filter match-none and
+// drops an unknown flag so defaults still apply) keep a leniently-loaded value
+// fail-safe rather than fail-open (#1960 / #3261 fail-closed-on-load class).
+func validateFlowTraceFlagsAndFiltersAST(nodes []*Node, prefix string, lenient bool) ([]string, error) {
+	var warnings []string
+	for _, n := range nodes {
+		if n.Name() != "security" {
+			continue
+		}
+		secPath := joinNodePath(prefix, n.Keys)
+		flowNode := n.FindChild("flow")
+		if flowNode == nil {
+			continue
+		}
+		toNode := flowNode.FindChild("traceoptions")
+		if toNode == nil {
+			continue
+		}
+		toPath := joinNodePath(secPath, []string{"flow", "traceoptions"})
+
+		// flag tokens
+		for _, flagNode := range toNode.FindChildren("flag") {
+			v := nodeVal(flagNode)
+			if v == "" || flowTraceImplementedFlags[v] {
+				continue
+			}
+			path := joinNodePath(toPath, []string{"flag"})
+			msg := fmt.Sprintf("%s: unknown flow trace flag %q "+
+				"(supported: basic-datapath, session)", path, v)
+			if lenient {
+				warnings = append(warnings, msg+
+					" (ignored: unknown flag dropped, defaults apply)")
+				continue
+			}
+			return warnings, fmt.Errorf("%s", msg)
+		}
+
+		// packet-filter source/destination prefixes
+		for _, pf := range namedInstances(toNode.FindChildren("packet-filter")) {
+			pfPath := joinNodePath(toPath, []string{"packet-filter", pf.name})
+			for _, leaf := range []string{"source-prefix", "destination-prefix"} {
+				pn := pf.node.FindChild(leaf)
+				if pn == nil {
+					continue
+				}
+				v := nodeVal(pn)
+				if v == "" {
+					continue
+				}
+				if _, err := netip.ParsePrefix(v); err != nil {
+					path := joinNodePath(pfPath, []string{leaf})
+					msg := fmt.Sprintf("%s: invalid %s %q: %v",
+						path, leaf, v, err)
+					if lenient {
+						warnings = append(warnings, msg+
+							" (ignored: filter set to match-none)")
+						continue
+					}
+					return warnings, fmt.Errorf("%s", msg)
+				}
+			}
 		}
 	}
 	return warnings, nil

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -1549,11 +1549,33 @@ func validateFlowTraceFlagsAndFiltersAST(nodes []*Node, prefix string, lenient b
 			for _, leaf := range []string{"source-prefix", "destination-prefix"} {
 				pn := pf.node.FindChild(leaf)
 				if pn == nil {
+					// Absent prefix: a protocol-only filter is legitimate, so
+					// leave it alone. This is AST-distinguishable from the
+					// present-but-empty case below (node missing vs node
+					// present with an empty value).
 					continue
 				}
 				v := nodeVal(pn)
 				if v == "" {
-					continue
+					// Present-but-empty (`source-prefix ""`): the node exists
+					// but carries no prefix. Accepting it lets the runtime
+					// append a fully-unconstrained filter (zero srcNet/dstNet,
+					// no proto) that matches EVERY event — the #3422 M01
+					// fail-open in a smaller costume. Reject at strict; downgrade
+					// to a warning on the lenient load / peer-sync path, where
+					// the compiler marks the filter InvalidPrefix and the
+					// runtime fails it closed (match-none).
+					path := joinNodePath(pfPath, []string{leaf})
+					msg := fmt.Sprintf("%s: %s is present but empty; an empty "+
+						"prefix would match every event (omit %s for a "+
+						"protocol-only filter, or set a CIDR prefix)",
+						path, leaf, leaf)
+					if lenient {
+						warnings = append(warnings, msg+
+							" (ignored: filter set to match-none)")
+						continue
+					}
+					return warnings, fmt.Errorf("%s", msg)
 				}
 				if _, err := netip.ParsePrefix(v); err != nil {
 					path := joinNodePath(pfPath, []string{leaf})
@@ -1877,11 +1899,23 @@ func compileFlow(node *Node, sec *SecurityConfig) error {
 		}
 		for _, pfInst := range namedInstances(toNode.FindChildren("packet-filter")) {
 			pf := &TracePacketFilter{Name: pfInst.name}
+			// A prefix node that is PRESENT but empty (`source-prefix ""`) is
+			// malformed: an empty prefix is not "no constraint" but a typo that
+			// must narrow tracing to nothing, not broaden it to everything
+			// (#3422 M01). Record the distinction here (present-but-empty vs the
+			// absent protocol-only case) so the runtime can fail it closed; the
+			// strict commit gate rejects it outright before it ever lands here.
 			if spNode := pfInst.node.FindChild("source-prefix"); spNode != nil {
 				pf.SourcePrefix = nodeVal(spNode)
+				if pf.SourcePrefix == "" {
+					pf.InvalidPrefix = true
+				}
 			}
 			if dpNode := pfInst.node.FindChild("destination-prefix"); dpNode != nil {
 				pf.DestinationPrefix = nodeVal(dpNode)
+				if pf.DestinationPrefix == "" {
+					pf.InvalidPrefix = true
+				}
 			}
 			if protoNode := pfInst.node.FindChild("protocol"); protoNode != nil {
 				pf.Protocol = nodeVal(protoNode)

--- a/pkg/config/flow_traceoptions_filter_3422_test.go
+++ b/pkg/config/flow_traceoptions_filter_3422_test.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3422: `security flow traceoptions` copied both `flag <name>` tokens and
+// `packet-filter <n> { source-prefix / destination-prefix <prefix> }` values
+// verbatim with no validation, and the runtime then failed silently in two
+// directions — an unparseable filter prefix was dropped (every-filter-invalid
+// -> trace EVERYTHING, M01), and an unimplemented flag suppressed the defaults
+// (matchFlags never matches -> trace NOTHING while reporting enabled, M02).
+// validateFlowTraceFlagsAndFiltersAST now hard-rejects both at strict commit /
+// commit-check.
+//
+// FAIL-ON-REVERT: delete the validateFlowTraceFlagsAndFiltersAST call in
+// compiler.go (or neuter the validator) and every reject subtest below goes
+// GREEN, which is exactly the regression this guards.
+func TestFlowTraceFilterFailsCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		set  []string
+		want string // substring the error must name
+	}{
+		{
+			name: "invalid-source-prefix",
+			set: []string{
+				"set security flow traceoptions packet-filter pf1 source-prefix 10.0.0.999/32",
+			},
+			want: "10.0.0.999/32",
+		},
+		{
+			name: "invalid-destination-prefix",
+			set: []string{
+				"set security flow traceoptions packet-filter pf1 destination-prefix 10.0.0.0/40",
+			},
+			want: "10.0.0.0/40",
+		},
+		{
+			name: "bare-address-not-prefix",
+			set: []string{
+				"set security flow traceoptions packet-filter pf1 source-prefix 10.0.0.1",
+			},
+			want: "10.0.0.1",
+		},
+		{
+			name: "one-valid-one-invalid",
+			set: []string{
+				"set security flow traceoptions packet-filter pf1 source-prefix 10.0.1.0/24",
+				"set security flow traceoptions packet-filter pf2 source-prefix bogus/24",
+			},
+			want: "bogus/24",
+		},
+		{
+			name: "unknown-flag",
+			set: []string{
+				"set security flow traceoptions flag sesson",
+			},
+			want: "sesson",
+		},
+		{
+			name: "mixed-valid-and-unknown-flag",
+			set: []string{
+				"set security flow traceoptions flag session",
+				"set security flow traceoptions flag bogus-flag",
+			},
+			want: "bogus-flag",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildTree(t, tc.set)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("expected strict commit to reject the traceoptions filter/flag, got nil error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not name the offending value %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "traceoptions") {
+				t.Fatalf("error %q does not name the traceoptions path", err.Error())
+			}
+		})
+	}
+}
+
+// TestFlowTraceFilterValidCommits is the anti-over-reject guard: a legitimate
+// filter (parseable prefixes, recognized protocol) and the implemented flags
+// must still commit cleanly.
+func TestFlowTraceFilterValidCommits(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions file rt-flow.log",
+		"set security flow traceoptions flag basic-datapath",
+		"set security flow traceoptions packet-filter pf1 source-prefix 10.0.1.0/24",
+		"set security flow traceoptions packet-filter pf1 destination-prefix 2001:db8::/32",
+		"set security flow traceoptions packet-filter pf1 protocol tcp",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected a valid traceoptions filter: %v", err)
+	}
+	to := cfg.Security.Flow.Traceoptions
+	if to == nil {
+		t.Fatalf("traceoptions not compiled")
+	}
+	if len(to.PacketFilters) != 1 || to.PacketFilters[0].SourcePrefix != "10.0.1.0/24" {
+		t.Fatalf("packet filters = %+v, want one pf1 with source 10.0.1.0/24", to.PacketFilters)
+	}
+	if to.PacketFilters[0].DestinationPrefix != "2001:db8::/32" {
+		t.Fatalf("dest prefix = %q, want 2001:db8::/32", to.PacketFilters[0].DestinationPrefix)
+	}
+	if len(to.Flags) != 1 || to.Flags[0] != "basic-datapath" {
+		t.Fatalf("flags = %v, want [basic-datapath]", to.Flags)
+	}
+}
+
+// TestFlowTraceFilterSessionFlagCommits verifies the second implemented flag
+// (session) is also accepted by the strict gate.
+func TestFlowTraceFilterSessionFlagCommits(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions flag session",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("strict commit rejected the session flag: %v", err)
+	}
+}
+
+// TestFlowTraceFilterLenientDowngrade verifies the load / peer-sync path
+// downgrades a persisted invalid prefix / unknown flag to a warning instead of
+// failing the boot (#1960 fail-closed-on-load class) — NewTraceWriter
+// independently fails safe at runtime (invalid filter -> match-none, unknown
+// flag -> dropped so defaults apply).
+func TestFlowTraceFilterLenientDowngrade(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions packet-filter pf1 source-prefix 10.0.0.999/32",
+		"set security flow traceoptions flag sesson",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load must not fail on persisted invalid filter/flag: %v", err)
+	}
+	wantPrefix, wantFlag := false, false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "10.0.0.999/32") && strings.Contains(w, "traceoptions") {
+			wantPrefix = true
+		}
+		if strings.Contains(w, "sesson") && strings.Contains(w, "traceoptions") {
+			wantFlag = true
+		}
+	}
+	if !wantPrefix {
+		t.Fatalf("lenient load did not record an invalid-prefix warning; warnings=%v", cfg.Warnings)
+	}
+	if !wantFlag {
+		t.Fatalf("lenient load did not record an unknown-flag warning; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/flow_traceoptions_filter_3422_test.go
+++ b/pkg/config/flow_traceoptions_filter_3422_test.go
@@ -45,6 +45,20 @@ func TestFlowTraceFilterFailsCommit(t *testing.T) {
 			want: "10.0.0.1",
 		},
 		{
+			name: "empty-source-prefix",
+			set: []string{
+				`set security flow traceoptions packet-filter pf1 source-prefix ""`,
+			},
+			want: "source-prefix",
+		},
+		{
+			name: "empty-destination-prefix",
+			set: []string{
+				`set security flow traceoptions packet-filter pf1 destination-prefix ""`,
+			},
+			want: "destination-prefix",
+		},
+		{
 			name: "one-valid-one-invalid",
 			set: []string{
 				"set security flow traceoptions packet-filter pf1 source-prefix 10.0.1.0/24",
@@ -112,6 +126,68 @@ func TestFlowTraceFilterValidCommits(t *testing.T) {
 	}
 	if len(to.Flags) != 1 || to.Flags[0] != "basic-datapath" {
 		t.Fatalf("flags = %v, want [basic-datapath]", to.Flags)
+	}
+}
+
+// TestFlowTraceFilterProtocolOnlyCommits is the #3422 BLOCKER anti-over-reject
+// guard: a filter that legitimately OMITS its prefixes (protocol-only) must
+// still commit on the strict path. The empty-prefix rejection is for a
+// present-but-empty node only — an absent prefix is fine.
+//
+// FAIL-ON-REVERT: reject a filter with no prefix and this test fails.
+func TestFlowTraceFilterProtocolOnlyCommits(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security flow traceoptions file rt-flow.log",
+		"set security flow traceoptions packet-filter pf1 protocol tcp",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("strict commit rejected a protocol-only filter: %v", err)
+	}
+	to := cfg.Security.Flow.Traceoptions
+	if to == nil || len(to.PacketFilters) != 1 {
+		t.Fatalf("traceoptions filters = %+v, want one pf1", to)
+	}
+	if to.PacketFilters[0].InvalidPrefix {
+		t.Fatalf("protocol-only filter wrongly marked InvalidPrefix (over-rejection)")
+	}
+	if to.PacketFilters[0].Protocol != "tcp" {
+		t.Fatalf("protocol = %q, want tcp", to.PacketFilters[0].Protocol)
+	}
+}
+
+// TestFlowTraceFilterEmptyPrefixLenient is the #3422 BLOCKER lenient backstop:
+// a persisted / peer-synced `source-prefix ""` must NOT fail the boot (downgrade
+// to a warning) but must compile to a filter marked InvalidPrefix so the runtime
+// fails it closed (match-none) rather than tracing everything.
+//
+// FAIL-ON-REVERT: restore the `v == ""` skip in the validator and no warning is
+// recorded; drop the compiler InvalidPrefix marking and the filter compiles as a
+// match-everything filter.
+func TestFlowTraceFilterEmptyPrefixLenient(t *testing.T) {
+	tree := buildTree(t, []string{
+		`set security flow traceoptions packet-filter pf1 source-prefix ""`,
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load must not fail on a persisted empty prefix: %v", err)
+	}
+	gotWarn := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "source-prefix") && strings.Contains(w, "traceoptions") &&
+			strings.Contains(w, "empty") {
+			gotWarn = true
+		}
+	}
+	if !gotWarn {
+		t.Fatalf("lenient load did not warn about the empty prefix; warnings=%v", cfg.Warnings)
+	}
+	to := cfg.Security.Flow.Traceoptions
+	if to == nil || len(to.PacketFilters) != 1 {
+		t.Fatalf("traceoptions filters = %+v, want one pf1", to)
+	}
+	if !to.PacketFilters[0].InvalidPrefix {
+		t.Fatalf("empty-prefix filter not marked InvalidPrefix; runtime would trace everything (#3422 BLOCKER)")
 	}
 }
 

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -97,6 +97,20 @@ type TracePacketFilter struct {
 	SourcePrefix      string
 	DestinationPrefix string
 	Protocol          string // protocol name (tcp|udp|icmp|...) or number
+	// InvalidPrefix marks a filter whose source-prefix or destination-prefix
+	// node was PRESENT in the config but carried an empty value (e.g.
+	// `source-prefix ""`). An empty prefix string is indistinguishable from an
+	// absent one once it reaches the runtime (PacketFilter carries only
+	// strings), but the two have opposite intent: an absent prefix is a
+	// legitimate protocol-only filter, while a present-but-empty prefix is
+	// malformed and — if treated as "no constraint" — collapses the filter to
+	// match EVERY event (the #3422 M01 fail-open in a smaller costume). The
+	// compiler, which alone sees the AST and can tell present-empty from
+	// absent, sets this so the runtime (NewTraceWriter) can fail the filter
+	// closed (match-none) without over-rejecting a protocol-only filter. The
+	// strict commit gate rejects present-but-empty loudly; this carries the
+	// conclusion through the lenient load / peer-sync path.
+	InvalidPrefix bool
 }
 
 // ALGConfig holds ALG (Application Layer Gateway) disable flags.

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -177,6 +177,24 @@ if `Handle` runs the re-entrancy guard before the client check.
   `monitor security flow file` hardening (#3378). Pins:
   `TestNewTraceWriterRejectsPathTraversal`,
   `TestNewTraceWriterNoFollowSymlink`.
+- **Flow-trace flags and packet-filter prefixes are validated, and fail
+  safe at runtime (#3422).** A `security flow traceoptions packet-filter
+  <n> { source-prefix / destination-prefix <prefix> }` whose value does not
+  parse, or a `flag <name>` the writer does not implement (only
+  `basic-datapath` and `session` are honoured — `matchFlags`), is rejected
+  at commit-time (`validateFlowTraceFlagsAndFiltersAST`, `pkg/config`). The
+  lenient load / peer-sync path downgrades both to warnings and
+  `NewTraceWriter` fails safe: an unparseable filter is kept but marked
+  `invalid` (never-match) instead of being dropped — dropping every typo'd
+  filter would leave `tw.filters` empty and `HandleEvent` would then trace
+  EVERYTHING (a filter meant to narrow tracing broadened it, M01); an
+  unimplemented flag is dropped rather than installed into a non-empty flag
+  map that suppresses the `basic-datapath`/`session` defaults and makes
+  `matchFlags` never match (an empty trace file while the daemon reports
+  tracing enabled, M02). Pins: `TestFlowTraceFilterFailsCommit` /
+  `TestFlowTraceFilterLenientDowngrade` (`pkg/config`),
+  `TestTraceWriterInvalidFilterMatchesNone` /
+  `TestTraceWriterUnknownFlagAppliesDefaults` (`pkg/logging`).
 - **Event time is DECISION time, not receive time (#2465/#2470/#2511).**
   The on-wire RT_FLOW frame carries an absolute Unix-nanosecond timestamp
   in its first 8 bytes (LE u64), stamped by the userspace-dp producer at

--- a/pkg/logging/trace.go
+++ b/pkg/logging/trace.go
@@ -91,6 +91,26 @@ type traceFilter struct {
 	srcNet netip.Prefix
 	dstNet netip.Prefix
 	proto  string // normalized protocol name (e.g. "TCP"); "" = any
+	// invalid marks a filter whose configured source/destination prefix did
+	// not parse. Such a filter is kept (so the writer still has a non-empty
+	// filter set) but never matches — a typo'd prefix must NARROW tracing to
+	// nothing, not be silently dropped which would leave tw.filters empty and
+	// trace EVERYTHING (#3422 M01). The commit-time gate
+	// (validateFlowTraceFlagsAndFiltersAST) rejects this loudly; this keeps a
+	// leniently-loaded / peer-synced config fail-safe.
+	invalid bool
+}
+
+// traceFlagImplemented reports whether a `security flow traceoptions flag`
+// token is one the writer actually honours (matchFlags). Keep in sync with
+// matchFlags and config.flowTraceImplementedFlags.
+func traceFlagImplemented(flag string) bool {
+	switch flag {
+	case "basic-datapath", "session":
+		return true
+	default:
+		return false
+	}
 }
 
 // NewTraceWriter creates a trace writer from flow traceoptions config.
@@ -126,36 +146,58 @@ func NewTraceWriter(opts *config.FlowTraceoptions) (*TraceWriter, error) {
 		flags:    make(map[string]bool),
 	}
 
-	// Parse flags
+	// Parse flags. Only flags the writer actually implements are installed.
+	// An unimplemented flag (a typo like `sesson`) is dropped here rather than
+	// inserted into the map: a non-empty map of unrecognized flags would
+	// suppress the defaults below, and matchFlags would then never match, so
+	// the daemon would report tracing enabled while writing an empty trace
+	// file (#3422 M02). The commit-time gate
+	// (validateFlowTraceFlagsAndFiltersAST) rejects an unknown flag loudly;
+	// this keeps a leniently-loaded / peer-synced config tracing with the
+	// defaults instead of silently tracing nothing.
 	for _, f := range opts.Flags {
-		tw.flags[f] = true
+		if traceFlagImplemented(f) {
+			tw.flags[f] = true
+		} else {
+			slog.Warn("ignoring unimplemented flow trace flag",
+				"flag", f, "supported", "basic-datapath,session")
+		}
 	}
-	// If no flags specified, trace everything
+	// If no implemented flags specified, trace everything
 	if len(tw.flags) == 0 {
 		tw.flags["basic-datapath"] = true
 		tw.flags["session"] = true
 	}
 
-	// Parse packet filters
+	// Parse packet filters. A filter whose source or destination prefix does
+	// not parse is marked invalid (never-match) but STILL appended, rather
+	// than dropped: dropping every typo'd filter would leave tw.filters empty,
+	// and HandleEvent skips filtering entirely when len(tw.filters)==0, so a
+	// filter meant to narrow tracing would broaden it to every event (#3422
+	// M01). Keeping an invalid filter in the set fails safe — it narrows
+	// tracing to nothing. The commit-time gate rejects an unparseable prefix
+	// loudly; this is the leniently-loaded / peer-synced backstop.
 	for _, pf := range opts.PacketFilters {
 		f := traceFilter{name: pf.Name}
 		if pf.SourcePrefix != "" {
 			prefix, err := netip.ParsePrefix(pf.SourcePrefix)
 			if err != nil {
-				slog.Warn("invalid trace filter source prefix",
+				slog.Warn("invalid trace filter source prefix; filter set to match-none",
 					"filter", pf.Name, "prefix", pf.SourcePrefix, "err", err)
-				continue
+				f.invalid = true
+			} else {
+				f.srcNet = prefix
 			}
-			f.srcNet = prefix
 		}
 		if pf.DestinationPrefix != "" {
 			prefix, err := netip.ParsePrefix(pf.DestinationPrefix)
 			if err != nil {
-				slog.Warn("invalid trace filter destination prefix",
+				slog.Warn("invalid trace filter destination prefix; filter set to match-none",
 					"filter", pf.Name, "prefix", pf.DestinationPrefix, "err", err)
-				continue
+				f.invalid = true
+			} else {
+				f.dstNet = prefix
 			}
-			f.dstNet = prefix
 		}
 		if pf.Protocol != "" {
 			f.proto = normalizeTraceProto(pf.Protocol)
@@ -246,6 +288,10 @@ func (tw *TraceWriter) matchFilters(rec EventRecord) bool {
 	recProto := normalizeTraceProto(rec.Protocol)
 
 	for _, f := range tw.filters {
+		if f.invalid {
+			// A filter with an unparseable prefix never matches (#3422 M01).
+			continue
+		}
 		srcMatch := !f.srcNet.IsValid() || (srcAddr.IsValid() && f.srcNet.Contains(srcAddr))
 		dstMatch := !f.dstNet.IsValid() || (dstAddr.IsValid() && f.dstNet.Contains(dstAddr))
 		protoMatch := f.proto == "" || f.proto == recProto

--- a/pkg/logging/trace.go
+++ b/pkg/logging/trace.go
@@ -92,10 +92,11 @@ type traceFilter struct {
 	dstNet netip.Prefix
 	proto  string // normalized protocol name (e.g. "TCP"); "" = any
 	// invalid marks a filter whose configured source/destination prefix did
-	// not parse. Such a filter is kept (so the writer still has a non-empty
-	// filter set) but never matches — a typo'd prefix must NARROW tracing to
-	// nothing, not be silently dropped which would leave tw.filters empty and
-	// trace EVERYTHING (#3422 M01). The commit-time gate
+	// not parse OR was present-but-empty (`source-prefix ""`, flagged by the
+	// compiler as InvalidPrefix). Such a filter is kept (so the writer still
+	// has a non-empty filter set) but never matches — a typo'd or empty prefix
+	// must NARROW tracing to nothing, not be silently dropped which would leave
+	// tw.filters empty and trace EVERYTHING (#3422 M01). The commit-time gate
 	// (validateFlowTraceFlagsAndFiltersAST) rejects this loudly; this keeps a
 	// leniently-loaded / peer-synced config fail-safe.
 	invalid bool
@@ -178,7 +179,19 @@ func NewTraceWriter(opts *config.FlowTraceoptions) (*TraceWriter, error) {
 	// tracing to nothing. The commit-time gate rejects an unparseable prefix
 	// loudly; this is the leniently-loaded / peer-synced backstop.
 	for _, pf := range opts.PacketFilters {
-		f := traceFilter{name: pf.Name}
+		// A filter whose source/destination prefix node was present in the
+		// config but empty (`source-prefix ""`) arrives here with an empty
+		// string, indistinguishable from a legitimately-absent prefix (a
+		// protocol-only filter). The compiler tells them apart and sets
+		// InvalidPrefix for the present-but-empty case; seed f.invalid from it
+		// so the filter fails closed (match-none) instead of matching every
+		// event (#3422 M01). A protocol-only filter (InvalidPrefix false, no
+		// prefixes, a protocol) stays valid and matches on its protocol.
+		f := traceFilter{name: pf.Name, invalid: pf.InvalidPrefix}
+		if pf.InvalidPrefix {
+			slog.Warn("empty trace filter prefix; filter set to match-none",
+				"filter", pf.Name)
+		}
 		if pf.SourcePrefix != "" {
 			prefix, err := netip.ParsePrefix(pf.SourcePrefix)
 			if err != nil {

--- a/pkg/logging/trace_filter_3422_test.go
+++ b/pkg/logging/trace_filter_3422_test.go
@@ -1,0 +1,141 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestTraceWriterInvalidFilterMatchesNone is the #3422 M01 runtime guard: a
+// packet-filter whose prefix does not parse must NARROW tracing to nothing, not
+// be silently dropped. Before the fix NewTraceWriter dropped the typo'd filter,
+// leaving tw.filters empty, and HandleEvent skips filtering when there are no
+// filters — so a filter meant to narrow tracing broadened it to every event.
+//
+// FAIL-ON-REVERT: restore the `continue` that drops an invalid filter and this
+// test fails (filters becomes empty -> matchFilters reports a match).
+func TestTraceWriterInvalidFilterMatchesNone(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{
+		File: "rt-flow.log",
+		PacketFilters: []*config.TracePacketFilter{
+			{Name: "pf1", SourcePrefix: "10.0.0.999/32"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer tw.Close()
+
+	// The invalid filter must be retained so the writer still has a non-empty
+	// filter set (otherwise HandleEvent traces everything).
+	if len(tw.filters) != 1 {
+		t.Fatalf("filters = %d, want 1 (invalid filter retained as match-none)", len(tw.filters))
+	}
+	if !tw.filters[0].invalid {
+		t.Fatalf("filter not marked invalid")
+	}
+
+	// No event matches the all-invalid filter set.
+	rec := EventRecord{SrcAddr: "10.0.1.5:1000", DstAddr: "10.0.2.5:80", Protocol: "TCP"}
+	if tw.matchFilters(rec) {
+		t.Fatalf("matchFilters returned true for an all-invalid filter set; tracing was broadened (#3422 M01)")
+	}
+}
+
+// TestTraceWriterOneValidOneInvalidFilter verifies a valid filter alongside an
+// invalid one still works: the valid filter matches its traffic, the invalid
+// one never matches (and never broadens to all traffic).
+func TestTraceWriterOneValidOneInvalidFilter(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{
+		File: "rt-flow.log",
+		PacketFilters: []*config.TracePacketFilter{
+			{Name: "pf1", SourcePrefix: "10.0.1.0/24"},
+			{Name: "pf2", SourcePrefix: "bogus/24"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer tw.Close()
+
+	// Inside the valid filter -> match.
+	if !tw.matchFilters(EventRecord{SrcAddr: "10.0.1.5:1000", DstAddr: "10.0.2.5:80", Protocol: "TCP"}) {
+		t.Fatalf("valid filter did not match its own traffic")
+	}
+	// Outside the valid filter -> no match (the invalid filter must not catch it).
+	if tw.matchFilters(EventRecord{SrcAddr: "10.0.9.5:1000", DstAddr: "10.0.2.5:80", Protocol: "TCP"}) {
+		t.Fatalf("invalid filter broadened tracing to non-matching traffic (#3422 M01)")
+	}
+}
+
+// TestTraceWriterUnknownFlagAppliesDefaults is the #3422 M02 runtime guard: an
+// unimplemented flag must be dropped so the basic-datapath/session defaults
+// still apply, not installed into a non-empty map that suppresses the defaults
+// and makes matchFlags never match (empty trace file while reporting enabled).
+//
+// FAIL-ON-REVERT: install every flag unconditionally and this test fails (the
+// unknown flag suppresses defaults, so SESSION_OPEN no longer matches).
+func TestTraceWriterUnknownFlagAppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{
+		File:  "rt-flow.log",
+		Flags: []string{"sesson"}, // typo for "session"
+	})
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer tw.Close()
+
+	if tw.flags["sesson"] {
+		t.Fatalf("unknown flag was installed into the flag map (#3422 M02)")
+	}
+	// Defaults applied -> matchFlags recognizes the event types.
+	if !tw.matchFlags("SESSION_OPEN") {
+		t.Fatalf("defaults not applied after dropping unknown flag; SESSION_OPEN did not match (#3422 M02)")
+	}
+	if !tw.matchFlags("BASIC_EVENT") {
+		t.Fatalf("basic-datapath default not applied after dropping unknown flag")
+	}
+}
+
+// TestTraceWriterKnownFlagSuppressesOther verifies an implemented single flag is
+// still honored exactly (defaults are NOT auto-added when a real flag is set).
+func TestTraceWriterKnownFlagSuppressesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{
+		File:  "rt-flow.log",
+		Flags: []string{"session"},
+	})
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer tw.Close()
+
+	if tw.flags["basic-datapath"] {
+		t.Fatalf("basic-datapath default added despite an explicit session flag")
+	}
+	if !tw.matchFlags("SESSION_OPEN") {
+		t.Fatalf("explicit session flag did not match SESSION_OPEN")
+	}
+	if tw.matchFlags("BASIC_EVENT") {
+		t.Fatalf("session-only flag matched a basic-datapath event")
+	}
+}

--- a/pkg/logging/trace_filter_3422_test.go
+++ b/pkg/logging/trace_filter_3422_test.go
@@ -68,6 +68,20 @@ func TestTraceWriterOneValidOneInvalidFilter(t *testing.T) {
 	}
 	defer tw.Close()
 
+	// Both filters must be retained (the invalid one kept as match-none, not
+	// dropped) so the writer has a non-empty filter set and the second filter
+	// is marked invalid. Asserting both pins the M01 fail-safe: if the invalid
+	// filter were dropped instead, len would be 1 and this fails.
+	if len(tw.filters) != 2 {
+		t.Fatalf("filters = %d, want 2 (valid + invalid both retained)", len(tw.filters))
+	}
+	if tw.filters[0].invalid {
+		t.Fatalf("valid filter pf1 wrongly marked invalid")
+	}
+	if !tw.filters[1].invalid {
+		t.Fatalf("invalid filter pf2 not marked invalid")
+	}
+
 	// Inside the valid filter -> match.
 	if !tw.matchFilters(EventRecord{SrcAddr: "10.0.1.5:1000", DstAddr: "10.0.2.5:80", Protocol: "TCP"}) {
 		t.Fatalf("valid filter did not match its own traffic")
@@ -75,6 +89,85 @@ func TestTraceWriterOneValidOneInvalidFilter(t *testing.T) {
 	// Outside the valid filter -> no match (the invalid filter must not catch it).
 	if tw.matchFilters(EventRecord{SrcAddr: "10.0.9.5:1000", DstAddr: "10.0.2.5:80", Protocol: "TCP"}) {
 		t.Fatalf("invalid filter broadened tracing to non-matching traffic (#3422 M01)")
+	}
+}
+
+// TestTraceWriterEmptyPrefixMatchesNone is the #3422 BLOCKER runtime guard: a
+// filter whose source-prefix was PRESENT but empty (`source-prefix ""`, flagged
+// by the compiler as InvalidPrefix) must NARROW tracing to nothing, not broaden
+// it to every event. An empty prefix string is indistinguishable from an absent
+// one at the runtime, so the compiler carries the present-but-empty conclusion
+// in InvalidPrefix and NewTraceWriter must fail the filter closed.
+//
+// FAIL-ON-REVERT: drop the `invalid: pf.InvalidPrefix` seed in NewTraceWriter
+// and this filter parses to zero srcNet/dstNet/proto -> matchFilters returns
+// true for everything (the M01 fail-open in a smaller costume).
+func TestTraceWriterEmptyPrefixMatchesNone(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{
+		File: "rt-flow.log",
+		PacketFilters: []*config.TracePacketFilter{
+			// Present-but-empty prefix: the compiler sets InvalidPrefix.
+			{Name: "pf1", SourcePrefix: "", InvalidPrefix: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer tw.Close()
+
+	if len(tw.filters) != 1 {
+		t.Fatalf("filters = %d, want 1 (empty-prefix filter retained as match-none)", len(tw.filters))
+	}
+	if !tw.filters[0].invalid {
+		t.Fatalf("empty-prefix filter not marked invalid; it would match every event (#3422 BLOCKER)")
+	}
+	if tw.matchFilters(EventRecord{SrcAddr: "10.0.1.5:1000", DstAddr: "10.0.2.5:80", Protocol: "TCP"}) {
+		t.Fatalf("empty-prefix filter matched an event; tracing was broadened to everything (#3422 BLOCKER)")
+	}
+}
+
+// TestTraceWriterProtocolOnlyFilterMatches is the anti-over-rejection guard for
+// the #3422 BLOCKER fix: a filter with NO prefixes but a protocol (an absent
+// prefix, InvalidPrefix false) must stay VALID and match on its protocol. This
+// is the case the empty-prefix rejection must NOT catch.
+//
+// FAIL-ON-REVERT: mark an absent-prefix filter invalid (over-reject) and this
+// fails (a legitimate protocol-only filter would stop matching).
+func TestTraceWriterProtocolOnlyFilterMatches(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{
+		File: "rt-flow.log",
+		PacketFilters: []*config.TracePacketFilter{
+			{Name: "pf1", Protocol: "tcp"}, // no prefixes, InvalidPrefix false
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewTraceWriter: %v", err)
+	}
+	defer tw.Close()
+
+	if len(tw.filters) != 1 {
+		t.Fatalf("filters = %d, want 1", len(tw.filters))
+	}
+	if tw.filters[0].invalid {
+		t.Fatalf("protocol-only filter wrongly marked invalid (over-rejection)")
+	}
+	// Matches its protocol regardless of address.
+	if !tw.matchFilters(EventRecord{SrcAddr: "10.0.9.5:1000", DstAddr: "8.8.8.8:80", Protocol: "TCP"}) {
+		t.Fatalf("protocol-only filter did not match a TCP event")
+	}
+	// Does not match a different protocol.
+	if tw.matchFilters(EventRecord{SrcAddr: "10.0.9.5:1000", DstAddr: "8.8.8.8:80", Protocol: "UDP"}) {
+		t.Fatalf("protocol-only TCP filter matched a UDP event")
 	}
 }
 


### PR DESCRIPTION
Closes #3422

## Problem
`security flow traceoptions` copied both `flag <name>` tokens and `packet-filter <n> { source-prefix / destination-prefix <prefix> }` values verbatim with no validation, and the runtime then failed silently in two directions:

- **M01 (fail-open):** `NewTraceWriter` dropped a filter whose prefix did not parse. If every packet-filter is a typo (`source-prefix 10.0.0.999/32`), `tw.filters` ends up empty, and `HandleEvent` skips filtering entirely when there are no filters — so a filter meant to **narrow** tracing **broadened** it to every event.
- **M02 (fail-silent):** an unimplemented flag (`flag sesson`) was installed into the flag map, making it non-empty and suppressing the `basic-datapath`/`session` defaults. `matchFlags` only recognizes those two flags, so nothing was traced while the daemon reported tracing enabled — false evidence during an incident.

## Fix
Mirrors the #3420 file-path gate doctrine (strict-reject at commit + lenient-downgrade on load, #1960/#3261 fail-closed-on-load class):

- **Commit-time gate** `validateFlowTraceFlagsAndFiltersAST` (`pkg/config`) hard-rejects an unparseable source/destination-prefix or a flag outside the implemented set `{basic-datapath, session}`. The tolerant load / peer-sync path (`lenientFlowTraceFilter`) downgrades both to `cfg.Warnings` so a persisted/peer-synced config an older binary accepted still boots.
- **Runtime fail-safe** (`pkg/logging/trace.go`): `NewTraceWriter` keeps an invalid filter but marks it never-match (filter set stays non-empty → tracing narrows to nothing instead of broadening), and drops an unimplemented flag rather than installing it (defaults still apply). `matchFilters` skips invalid filters.

## Tests (RED-on-revert verified)
- `pkg/config`: `TestFlowTraceFilterFailsCommit` (invalid src/dst prefix, bare address, one-valid-one-invalid, unknown flag, mixed valid+unknown), `TestFlowTraceFilterValidCommits`, `TestFlowTraceFilterSessionFlagCommits`, `TestFlowTraceFilterLenientDowngrade`.
- `pkg/logging`: `TestTraceWriterInvalidFilterMatchesNone`, `TestTraceWriterOneValidOneInvalidFilter`, `TestTraceWriterUnknownFlagAppliesDefaults`, `TestTraceWriterKnownFlagSuppressesDefaults`.

Neutering the config gate flips all reject subtests green; reverting the runtime fixes flips M01/M02 runtime tests red. `go build ./...` + `go test ./pkg/config/... ./pkg/logging/...` green.

Scope note: only #3422 (M01/M02/L02). Sibling #3420 (file path) is already merged; #3424 (rotation) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi