### PR TITLE
logging: harden event-mode security log + make audit-log failures observable (#3477, #3478)

### DIFF
--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -29,7 +29,20 @@ reports.
   stream uses them so a typo'd query rejects rather than streaming
   everything (#3383).
 - `LocalLogWriter` — `locallog.go`. File-based writer with
-  facility/severity filters.
+  facility/severity filters. The active file and every rotation reopen go
+  through the shared hardened open (`openHardenedAuditLog`, `trace.go`):
+  `O_NOFOLLOW`, regular-file verified, mode `0600` (not world-readable
+  `0644`), dir `0750` — the event-mode security log carries the same
+  policy/session/NAT forensics the flow-trace writer was hardened for
+  (#3477). The `0600` is *enforced*, not create-only: an existing
+  pre-hardening `0644` file is `fchmod`-tightened on open (on the held
+  O_NOFOLLOW regular-file fd) so an upgrade does not leave it
+  world-readable. Write and rotation failures are observable:
+  `DroppedWrites()` counts lost lines (write error AND nil-file/closed
+  paths), `FailedRotations()` counts incomplete rotations (a generation
+  shift, the active-file rename, or the reopen), and a ≤1/s WARN — with
+  separate clocks per failure class so a write-drop storm cannot suppress
+  the rotation warning — carries both counts (#3478).
 - `SessionAggregator` — `aggregator.go`. Top-N per-IP rollups,
   cardinality-capped (see "Aggregator cardinality cap" below).
 
@@ -164,10 +177,15 @@ if `Handle` runs the re-entrancy guard before the client check.
   absolute path, a path separator, or a `.`/`..` component is rejected
   (`sanitizeTraceFileName`), the file is opened under `traceLogDir`
   (`/var/log` in production; a package var only so tests can redirect it)
-  with `O_NOFOLLOW` and verified to be a regular file, and it is created
-  mode `0600` rather than world-readable — flow tuples/zones/policy IDs are
-  audit-grade telemetry. Rotation reopens through the same `openTraceFile`
-  guard. Before #3420 the value was kept verbatim (absolute) or joined under
+  with `O_NOFOLLOW` and verified to be a regular file, and its mode is
+  enforced to `0600` rather than world-readable — created `0600`, and an
+  existing looser file `fchmod`-tightened on open (#3477) — flow
+  tuples/zones/policy IDs are audit-grade telemetry. Rotation reopens
+  through the same `openTraceFile` guard, which now delegates to the shared
+  `openHardenedAuditLog` helper that `LocalLogWriter` also uses (#3477) —
+  both audit-log writers get identical O_NOFOLLOW / regular-file /
+  enforced-0600 semantics. Before #3420 the value was kept
+  verbatim (absolute) or joined under
   `/var/log` without a `..` check, so a committed config could append
   root-written telemetry anywhere the daemon could write. The committed
   config is also rejected at commit-time (`validateFlowTraceFileAST`,
@@ -195,6 +213,37 @@ if `Handle` runs the re-entrancy guard before the client check.
   `TestFlowTraceFilterLenientDowngrade` (`pkg/config`),
   `TestTraceWriterInvalidFilterMatchesNone` /
   `TestTraceWriterUnknownFlagAppliesDefaults` (`pkg/logging`).
+- **Audit-log write/rotation failures are observable, not silent (#3478).**
+  Both audit-log writers (`TraceWriter`, `LocalLogWriter`) and the session
+  aggregator (`ForwardLogMsg`) previously swallowed write and rotation
+  failures — a bare `return`, a `_ =`, or a production-off `slog.Debug` — so
+  an operator who had enabled `traceoptions` / `security log mode event`
+  could not tell ENOSPC/EIO/closed-fd/failed-rename was dropping audit lines.
+  Each writer now exposes `DroppedWrites()` and `FailedRotations()` as atomic
+  counters, with a ≤1/s WARN carrying both (CLAUDE.md hot-path logging
+  rules — never per-event). The two failure classes use SEPARATE warn clocks
+  so a write-drop storm cannot suppress the rotation warning, and vice versa.
+  `DroppedWrites()` covers EVERY drop path — a failed write AND a
+  nil/closed-file write (a writer wedged by a prior failed reopen would
+  otherwise drop every subsequent event after a single `FailedRotations`
+  bump). `FailedRotations()` covers a failed generation shift (a lost
+  retained generation), a failed active-file rename, and a failed reopen.
+  `rotate()` returns an error on any of those and resets the byte accounting
+  to 0 ONLY when the active file was actually rolled aside; on a failed
+  primary rename it re-syncs `written` to the real file size so the next
+  write retries rotation instead of growing unbounded under a bogus 0. The
+  aggregator surfaces the per-call error at Debug (the writer counter is the
+  aggregate metric). Pins: `TestTraceWriter_WriteFailureObservable`,
+  `TestTraceWriter_RotationFailureObservable`,
+  `TestTraceWriter_GenerationShiftFailureObservable`,
+  `TestTraceWriter_NilFileDropObservable`,
+  `TestTraceWriter_TightensExistingMode`,
+  `TestLocalLogWriter_WriteFailureObservable`,
+  `TestLocalLogWriter_RotationFailureObservable`,
+  `TestLocalLogWriter_GenerationShiftFailureObservable`,
+  `TestLocalLogWriter_NilFileDropObservable`,
+  `TestLocalLogWriter_TightensExistingMode`,
+  `TestLocalLogWriter_HardenedOpen`.
 - **Event time is DECISION time, not receive time (#2465/#2470/#2511).**
   The on-wire RT_FLOW frame carries an absolute Unix-nanosecond timestamp
   in its first 8 bytes (LE u64), stamped by the userspace-dp producer at

--- a/pkg/logging/locallog.go
+++ b/pkg/logging/locallog.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -23,7 +24,44 @@ type LocalLogWriter struct {
 	MinSeverity int
 	Categories  uint8
 	Format      string // "structured" or "" (standard)
+
+	// Failure observability (#3478). droppedWrites counts security-log lines
+	// lost because the file write failed or the file handle is nil (closed, or
+	// a prior rotation reopen failed); failedRotations counts rotations that
+	// could not complete (a generation shift, the active-file rename, or the
+	// post-rotation reopen failed). These are audit-grade signals — an operator
+	// running `security log mode event` must be able to tell that audit lines
+	// are being lost. The two failure classes get SEPARATE ≤1/s warn clocks
+	// (lastDropWarn / lastRotWarn, mu-guarded) so a write-drop storm cannot
+	// suppress the rotation warning and vice versa.
+	droppedWrites   atomic.Uint64
+	failedRotations atomic.Uint64
+	lastDropWarn    time.Time
+	lastRotWarn     time.Time
 }
+
+// warnRateLimited emits a ≤1/s WARN carrying the current failure counters,
+// gated by the supplied per-class clock. Must be called with lw.mu held.
+func (lw *LocalLogWriter) warnRateLimited(clock *time.Time, msg string, err error) {
+	now := time.Now()
+	if !clock.IsZero() && now.Sub(*clock) < time.Second {
+		return
+	}
+	*clock = now
+	slog.Warn(msg,
+		"err", err,
+		"path", lw.path,
+		"dropped_writes", lw.droppedWrites.Load(),
+		"failed_rotations", lw.failedRotations.Load())
+}
+
+// DroppedWrites reports the number of security-log lines lost because the file
+// write failed (#3478). Observability accessor for status/metrics surfaces.
+func (lw *LocalLogWriter) DroppedWrites() uint64 { return lw.droppedWrites.Load() }
+
+// FailedRotations reports the number of security-log rotations that could not
+// complete (#3478).
+func (lw *LocalLogWriter) FailedRotations() uint64 { return lw.failedRotations.Load() }
 
 // LocalLogConfig configures a LocalLogWriter.
 type LocalLogConfig struct {
@@ -47,10 +85,16 @@ func NewLocalLogWriter(cfg LocalLogConfig) (*LocalLogWriter, error) {
 		maxFiles = 5
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	// Directory 0750 (not 0755) — the security log dir should not be
+	// world-traversable (#3477 M02).
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return nil, fmt.Errorf("create log dir: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	// Open the active file with the shared audit-log hardening (#3477 M01):
+	// O_NOFOLLOW (no symlink redirect), regular-file verified, mode 0600 (not
+	// world-readable 0644 — the event-mode security log carries the same
+	// policy/session/NAT forensics the flow-trace writer was hardened for).
+	f, err := openHardenedAuditLog(path, os.O_APPEND)
 	if err != nil {
 		return nil, fmt.Errorf("open log file: %w", err)
 	}
@@ -77,17 +121,29 @@ func (lw *LocalLogWriter) Send(severity int, msg string) error {
 	defer lw.mu.Unlock()
 
 	if lw.file == nil {
+		// #3478 item 1/4: a nil file (closed, or a prior rotation reopen
+		// failed) drops the line. Count it on EVERY failure path — not just a
+		// write error — so a wedged writer is observable, and return the error.
+		lw.droppedWrites.Add(1)
+		lw.warnRateLimited(&lw.lastDropWarn, "local security-log write dropped: file unavailable", errFileUnavailable)
 		return fmt.Errorf("log file closed")
 	}
 
 	n, err := lw.file.WriteString(line)
 	if err != nil {
+		// #3478 M04: count the lost audit line and surface it (the error is
+		// also returned to the caller; the counter makes the aggregate
+		// observable even where callers discard it).
+		lw.droppedWrites.Add(1)
+		lw.warnRateLimited(&lw.lastDropWarn, "local security-log write failed (audit line lost)", err)
 		return err
 	}
 	lw.written += int64(n)
 
 	if lw.written >= lw.maxSize {
-		lw.rotate()
+		if rerr := lw.rotate(); rerr != nil {
+			lw.warnRateLimited(&lw.lastRotWarn, "local security-log rotation failed", rerr)
+		}
 	}
 	return nil
 }
@@ -100,17 +156,24 @@ func (lw *LocalLogWriter) SendBinary(data []byte) error {
 	defer lw.mu.Unlock()
 
 	if lw.file == nil {
+		// #3478 item 1/4: count the dropped binary record on the nil-file path.
+		lw.droppedWrites.Add(1)
+		lw.warnRateLimited(&lw.lastDropWarn, "local security-log binary write dropped: file unavailable", errFileUnavailable)
 		return fmt.Errorf("log file closed")
 	}
 
 	n, err := lw.file.Write(data)
 	if err != nil {
+		lw.droppedWrites.Add(1)
+		lw.warnRateLimited(&lw.lastDropWarn, "local security-log binary write failed (audit record lost)", err)
 		return err
 	}
 	lw.written += int64(n)
 
 	if lw.written >= lw.maxSize {
-		lw.rotate()
+		if rerr := lw.rotate(); rerr != nil {
+			lw.warnRateLimited(&lw.lastRotWarn, "local security-log rotation failed", rerr)
+		}
 	}
 	return nil
 }
@@ -135,25 +198,60 @@ func (lw *LocalLogWriter) Close() error {
 	return nil
 }
 
-func (lw *LocalLogWriter) rotate() {
+// rotate rolls the active security-log file aside and reopens a fresh one. It
+// returns a non-nil error if the rotation could not complete and bumps
+// failedRotations (#3478 M03). The reopen uses the shared hardened open
+// (O_NOFOLLOW, regular-file verified, 0600) instead of the old
+// O_TRUNC|0644 — O_TRUNC followed a symlink planted between the rename and the
+// reopen, turning rotation into a truncate-arbitrary-file primitive (#3477
+// M02). lw.written is reset to 0 ONLY when the active file was actually moved
+// aside; on a failed primary rename it is re-synced to the real size so the
+// next write retries rotation rather than silently growing unbounded.
+func (lw *LocalLogWriter) rotate() error {
 	lw.file.Close()
 	lw.file = nil
 
+	// A missing generation is normal (ENOENT); any other shift failure means a
+	// retained generation was lost — count and surface it (#3478 item 2).
+	var shiftErr error
 	for i := lw.maxFiles - 1; i > 0; i-- {
 		old := fmt.Sprintf("%s.%d", lw.path, i)
 		next := fmt.Sprintf("%s.%d", lw.path, i+1)
-		os.Rename(old, next)
+		if err := os.Rename(old, next); err != nil && !os.IsNotExist(err) {
+			slog.Debug("local log rotate generation shift failed", "from", old, "to", next, "err", err)
+			lw.failedRotations.Add(1)
+			if shiftErr == nil {
+				shiftErr = fmt.Errorf("rotate shift %s->%s: %w", old, next, err)
+			}
+		}
 	}
-	os.Rename(lw.path, lw.path+".1")
-	os.Remove(fmt.Sprintf("%s.%d", lw.path, lw.maxFiles+1))
+	renameErr := os.Rename(lw.path, lw.path+".1")
+	excess := fmt.Sprintf("%s.%d", lw.path, lw.maxFiles+1)
+	if err := os.Remove(excess); err != nil && !os.IsNotExist(err) {
+		slog.Debug("local log rotate excess removal failed", "path", excess, "err", err)
+	}
 
-	f, err := os.OpenFile(lw.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	// Reopen with the shared hardened semantics. The primary rename (when it
+	// succeeds) removed the active path, so O_CREATE yields a fresh empty file;
+	// O_TRUNC is deliberately NOT used (see openHardenedAuditLog).
+	f, err := openHardenedAuditLog(lw.path, os.O_APPEND)
 	if err != nil {
-		slog.Warn("failed to open rotated local log file", "err", err)
-		return
+		lw.failedRotations.Add(1)
+		return fmt.Errorf("reopen after rotate: %w", err)
 	}
 	lw.file = f
+
+	if renameErr != nil {
+		lw.failedRotations.Add(1)
+		if info, statErr := f.Stat(); statErr == nil {
+			lw.written = info.Size()
+		}
+		return fmt.Errorf("rotate rename %s: %w", lw.path, renameErr)
+	}
+	// Active file rotated cleanly; reset the byte count. shiftErr (if any) is a
+	// retained-generation loss only — surface it so the caller warns.
 	lw.written = 0
+	return shiftErr
 }
 
 func severityTag(severity int) string {

--- a/pkg/logging/locallog_test.go
+++ b/pkg/logging/locallog_test.go
@@ -7,6 +7,228 @@ import (
 	"testing"
 )
 
+// TestLocalLogWriter_HardenedOpen pins the #3477 hardening: the active
+// security-log file is created mode 0600 (not world-readable 0644) and a
+// symlink pre-planted at the path is refused (O_NOFOLLOW) rather than followed.
+//
+// RED-on-revert: restore the old
+// `os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)` in
+// NewLocalLogWriter and the mode sub-test fails (perm 0644) and the symlink
+// sub-test fails (the raw open follows the link and creates the victim).
+func TestLocalLogWriter_HardenedOpen(t *testing.T) {
+	t.Run("mode-0600", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "security.log")
+		lw, err := NewLocalLogWriter(LocalLogConfig{Path: path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lw.Close()
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("security-log mode = %o, want 0600 (world-readable audit data leak)", perm)
+		}
+	})
+
+	t.Run("nofollow-symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "security.log")
+		target := filepath.Join(t.TempDir(), "victim")
+		if err := os.Symlink(target, path); err != nil {
+			t.Fatal(err)
+		}
+		lw, err := NewLocalLogWriter(LocalLogConfig{Path: path})
+		if err == nil {
+			if lw != nil {
+				lw.Close()
+			}
+			t.Fatalf("NewLocalLogWriter opened through a symlink, want O_NOFOLLOW rejection")
+		}
+		if _, statErr := os.Stat(target); statErr == nil {
+			t.Fatalf("symlink target %s was created (followed)", target)
+		}
+	})
+}
+
+// TestLocalLogWriter_WriteFailureObservable pins #3478: a write that fails
+// increments DroppedWrites so an operator can detect lost audit lines.
+//
+// RED-on-revert: remove the `lw.droppedWrites.Add(1)` in Send and the counter
+// stays 0.
+func TestLocalLogWriter_WriteFailureObservable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "security.log")
+	lw, err := NewLocalLogWriter(LocalLogConfig{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Close the underlying fd out from under the writer so the next write
+	// fails with EBADF while lw.file is still non-nil.
+	if err := lw.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := lw.Send(SyslogInfo, "after fd close"); err == nil {
+		t.Fatal("expected Send to fail on a closed descriptor")
+	}
+	if got := lw.DroppedWrites(); got != 1 {
+		t.Fatalf("DroppedWrites = %d, want 1 (write failure not observable)", got)
+	}
+}
+
+// TestLocalLogWriter_RotationFailureObservable pins #3478 M03 + item 6: a
+// rotation whose primary rename cannot complete (a) returns a non-nil error,
+// (b) bumps FailedRotations, and (c) re-syncs `written` to the real file size
+// rather than resetting it to a bogus 0. Calling rotate() directly pins all
+// three invariants (a Send-only test cannot see the returned error or assert
+// written).
+//
+// RED-on-revert: make rotate() ignore the rename result and unconditionally set
+// written=0 / return nil (the pre-fix behavior) — the error-return, the
+// written==realSize, and the FailedRotations assertions all fail.
+func TestLocalLogWriter_RotationFailureObservable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "security.log")
+	// MaxFiles=1 so the generation-shift loop does not run and cannot move our
+	// blocking directory aside before the primary rename.
+	lw, err := NewLocalLogWriter(LocalLogConfig{Path: path, MaxSize: 40, MaxFiles: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lw.Close()
+
+	// Seed real content so the post-failed-rotation re-stat sees a nonzero size.
+	if _, err := lw.file.WriteString("0123456789012345678901234567890123456789\n"); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realSize := fi.Size()
+	lw.written = 999 // deliberately wrong to prove rotate() re-syncs to real size
+
+	// Pre-create a non-empty DIRECTORY at the archive path so
+	// os.Rename(path, path+".1") fails.
+	archive := path + ".1"
+	if err := os.Mkdir(archive, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archive, "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if rerr := lw.rotate(); rerr == nil {
+		t.Fatal("rotate() returned nil on a failed primary rename, want a non-nil error")
+	}
+	if got := lw.FailedRotations(); got == 0 {
+		t.Fatalf("FailedRotations = 0, want >=1 (failed rename not observable)")
+	}
+	if lw.written != realSize {
+		t.Fatalf("written = %d after a failed rotation, want re-synced to real size %d (not a bogus 0/stale value)", lw.written, realSize)
+	}
+}
+
+// TestLocalLogWriter_GenerationShiftFailureObservable pins #3478 item 2: when a
+// retained generation cannot be shifted (old->next rename fails) but the
+// active-file rotation itself succeeds, the failure is still counted in
+// FailedRotations and surfaced as a non-nil rotate() error.
+//
+// RED-on-revert: drop the failedRotations.Add(1)+shiftErr in the shift loop and
+// both assertions fail (the active rotation succeeds, masking the lost
+// generation).
+func TestLocalLogWriter_GenerationShiftFailureObservable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "security.log")
+	// MaxFiles=2 so the shift loop runs once: rename path.1 -> path.2.
+	lw, err := NewLocalLogWriter(LocalLogConfig{Path: path, MaxFiles: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lw.Close()
+
+	// A regular .1 so the shift attempts rename(.1 -> .2); a non-empty .2
+	// directory so that shift rename fails while the primary rename
+	// (path -> path.1, replacing the regular .1) still succeeds.
+	if err := os.WriteFile(path+".1", []byte("gen1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path+".2", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path+".2", "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rerr := lw.rotate()
+	if rerr == nil {
+		t.Fatal("rotate() returned nil despite a failed generation shift, want a non-nil error")
+	}
+	if got := lw.FailedRotations(); got == 0 {
+		t.Fatalf("FailedRotations = 0, want >=1 (generation-shift failure not observable)")
+	}
+}
+
+// TestLocalLogWriter_NilFileDropObservable pins #3478 item 1/4: a write to a
+// writer whose file handle is nil (here via Close, the same state a failed
+// rotation reopen leaves) increments DroppedWrites rather than returning
+// silently.
+//
+// RED-on-revert: restore the bare `return fmt.Errorf("log file closed")`
+// without the droppedWrites.Add(1) and the counter stays 0.
+func TestLocalLogWriter_NilFileDropObservable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "security.log")
+	lw, err := NewLocalLogWriter(LocalLogConfig{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lw.Close() // file = nil
+
+	if err := lw.Send(SyslogInfo, "dropped"); err == nil {
+		t.Fatal("expected Send to fail on a nil file")
+	}
+	if err := lw.SendBinary([]byte("dropped")); err == nil {
+		t.Fatal("expected SendBinary to fail on a nil file")
+	}
+	if got := lw.DroppedWrites(); got != 2 {
+		t.Fatalf("DroppedWrites = %d, want 2 (nil-file drops not observable)", got)
+	}
+}
+
+// TestLocalLogWriter_TightensExistingMode pins #3477 item 3: opening an
+// existing world-readable (0644) security log tightens it to 0600 — the
+// create-time mode is a no-op for an already-present file, so a pre-hardening
+// upgrade would otherwise leave it world-readable.
+//
+// RED-on-revert: remove the fchmod-on-existing block in openHardenedAuditLog
+// and the mode stays 0644.
+func TestLocalLogWriter_TightensExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "security.log")
+	if err := os.WriteFile(path, []byte("legacy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Defeat umask so the pre-existing file is genuinely 0644.
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lw, err := NewLocalLogWriter(LocalLogConfig{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lw.Close()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("existing security-log mode = %o after open, want tightened to 0600", perm)
+	}
+}
+
 func TestLocalLogWriter_Send(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.log")

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -372,7 +372,13 @@ func (er *EventReader) ForwardLogMsg(severity int, msg string) {
 	writers := er.localWriters
 	er.localMu.RUnlock()
 	for _, lw := range writers {
-		_ = lw.Send(severity, msg)
+		// #3478 M05: don't discard the aggregator's local-writer error.
+		// LocalLogWriter.Send already counts the drop (DroppedWrites) and
+		// emits a rate-limited WARN; surface it here at Debug so the
+		// per-aggregation context is available without spamming the hot path.
+		if err := lw.Send(severity, msg); err != nil {
+			slog.Debug("aggregation report local log write failed", "err", err)
+		}
 	}
 }
 

--- a/pkg/logging/trace.go
+++ b/pkg/logging/trace.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -8,11 +9,18 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/config"
 )
+
+// errFileUnavailable is the cause attributed to a dropped audit-log line when
+// the writer's file handle is nil because a prior rotation reopen failed
+// (#3478 item 1). Shared by TraceWriter and LocalLogWriter.
+var errFileUnavailable = errors.New("audit log file unavailable (failed rotation)")
 
 // traceLogDir is the directory persistent flow-trace files are written to. It
 // is a package var (not a const) only so tests can redirect it to a temp dir;
@@ -48,16 +56,28 @@ func sanitizeTraceFileName(name string) error {
 	return nil
 }
 
-// openTraceFile opens a flow-trace file (the active file or a rotated
-// generation) inside traceLogDir with restrictive semantics: O_NOFOLLOW so a
-// pre-planted symlink under /var/log cannot redirect the root-written telemetry
-// (#3420), the opened descriptor is verified to be a regular file, and it is
-// created mode 0600 rather than world-readable 0644 — flow tuples/zones/policy
-// names are audit-grade telemetry. The caller passes an already-sanitized
-// basename (NewTraceWriter validates once up front).
-func openTraceFile(name string) (*os.File, error) {
-	path := filepath.Join(traceLogDir, name)
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY|unix.O_NOFOLLOW, 0o600)
+// openHardenedAuditLog opens an audit-grade log file at an absolute path with
+// the symlink/permission hardening shared by the flow-trace writer and the
+// event-mode security-log writer (#3420, #3477): O_NOFOLLOW so a pre-planted
+// symlink at the path cannot redirect root-written telemetry to an arbitrary
+// target, the opened descriptor verified to be a regular file, and mode 0600
+// rather than world-readable 0644 — flow tuples/zones/policy/NAT metadata are
+// audit-grade and must not leak to other local users. The caller supplies the
+// open mode bits (O_APPEND for an existing/active file). O_TRUNC must NOT be
+// passed: with O_NOFOLLOW a symlink open already fails, but truncation of a
+// confirmed file is also undesirable on the rotation path — a fresh file is
+// produced by renaming the old one aside before this open, so O_CREATE alone
+// yields an empty file. This avoids the O_TRUNC-follows-symlink primitive
+// (#3477 M02).
+//
+// The 0600 mode argument to OpenFile only applies when the file is *created*;
+// an existing pre-hardening file (e.g. a 0644 trace/security log written by an
+// older build) keeps its looser mode across upgrade. Since #3477 IS the
+// mode-hardening contract, the descriptor — already confirmed a regular file
+// opened O_NOFOLLOW, so fchmod is safe and cannot be redirected — is tightened
+// to 0600 whenever its current group/other bits are non-zero.
+func openHardenedAuditLog(path string, mode int) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|unix.O_NOFOLLOW|mode, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -68,9 +88,28 @@ func openTraceFile(name string) (*os.File, error) {
 	}
 	if !fi.Mode().IsRegular() {
 		f.Close()
-		return nil, fmt.Errorf("trace target %s is not a regular file", path)
+		return nil, fmt.Errorf("audit log target %s is not a regular file", path)
+	}
+	// Enforce 0600 on an existing file whose mode differs (create-time mode is
+	// a no-op for an already-present file, so a pre-hardening 0644 log would
+	// stay world-readable across upgrade). f.Chmod is an fchmod on the held
+	// regular-file fd, so this cannot be steered to another path (#3477 item 3).
+	if fi.Mode().Perm() != 0o600 {
+		if err := f.Chmod(0o600); err != nil {
+			f.Close()
+			return nil, fmt.Errorf("tighten audit log mode %s: %w", path, err)
+		}
 	}
 	return f, nil
+}
+
+// openTraceFile opens a flow-trace file (the active file or a rotated
+// generation) inside traceLogDir with the shared hardened semantics
+// (O_NOFOLLOW, regular-file verified, 0600 — see openHardenedAuditLog). The
+// caller passes an already-sanitized basename (NewTraceWriter validates once up
+// front).
+func openTraceFile(name string) (*os.File, error) {
+	return openHardenedAuditLog(filepath.Join(traceLogDir, name), os.O_APPEND)
 }
 
 // TraceWriter writes matching flow events to a trace file with rotation.
@@ -84,7 +123,44 @@ type TraceWriter struct {
 	written  int64
 	filters  []traceFilter
 	flags    map[string]bool // which event types to trace
+
+	// Failure observability (#3478). droppedWrites counts trace lines lost
+	// because the file write failed or the file is nil (a prior rotation reopen
+	// failed); failedRotations counts rotations that could not complete (a
+	// generation shift, the active-file rename, or the post-rotation reopen
+	// failed). Both are audit-grade signals: an operator who enabled
+	// traceoptions must be able to tell that telemetry is being lost. The two
+	// failure classes get SEPARATE ≤1/s warn clocks (lastDropWarn /
+	// lastRotWarn, mu-guarded; HandleEvent/rotate run under mu) so a write-drop
+	// storm cannot suppress the rotation warning, and vice versa.
+	droppedWrites   atomic.Uint64
+	failedRotations atomic.Uint64
+	lastDropWarn    time.Time
+	lastRotWarn     time.Time
 }
+
+// warnRateLimited emits a ≤1/s WARN carrying the current failure counters,
+// gated by the supplied per-class clock. Must be called with tw.mu held.
+func (tw *TraceWriter) warnRateLimited(clock *time.Time, msg string, err error) {
+	now := time.Now()
+	if !clock.IsZero() && now.Sub(*clock) < time.Second {
+		return
+	}
+	*clock = now
+	slog.Warn(msg,
+		"err", err,
+		"path", tw.path,
+		"dropped_writes", tw.droppedWrites.Load(),
+		"failed_rotations", tw.failedRotations.Load())
+}
+
+// DroppedWrites reports the number of trace lines lost because the file write
+// failed (#3478). Observability accessor for status/metrics surfaces.
+func (tw *TraceWriter) DroppedWrites() uint64 { return tw.droppedWrites.Load() }
+
+// FailedRotations reports the number of trace-file rotations that could not
+// complete (#3478).
+func (tw *TraceWriter) FailedRotations() uint64 { return tw.failedRotations.Load() }
 
 type traceFilter struct {
 	name   string
@@ -265,18 +341,30 @@ func (tw *TraceWriter) HandleEvent(rec EventRecord, raw []byte) {
 	defer tw.mu.Unlock()
 
 	if tw.file == nil {
+		// #3478 item 1: a nil file means a prior rotation reopen failed and the
+		// writer is wedged. Every subsequent event is lost — count and warn
+		// (rate-limited) instead of returning silently, otherwise the operator
+		// sees a single FailedRotations bump and no further signal.
+		tw.droppedWrites.Add(1)
+		tw.warnRateLimited(&tw.lastDropWarn, "flow-trace write dropped: file unavailable after failed rotation", errFileUnavailable)
 		return
 	}
 
 	n, err := tw.file.WriteString(line)
 	if err != nil {
+		// #3478 H21: a swallowed write error means lost audit telemetry the
+		// operator cannot detect. Count it and emit a rate-limited WARN.
+		tw.droppedWrites.Add(1)
+		tw.warnRateLimited(&tw.lastDropWarn, "flow-trace write failed (audit lines lost)", err)
 		return
 	}
 	tw.written += int64(n)
 
 	// Rotate if needed
 	if tw.written >= tw.maxSize {
-		tw.rotate()
+		if err := tw.rotate(); err != nil {
+			tw.warnRateLimited(&tw.lastRotWarn, "flow-trace rotation failed", err)
+		}
 	}
 }
 
@@ -373,29 +461,62 @@ func (tw *TraceWriter) formatTrace(rec EventRecord) string {
 		rec.PolicyID, rec.InZone, rec.OutZone)
 }
 
-func (tw *TraceWriter) rotate() {
+// rotate rolls the active trace file aside and reopens a fresh one. It returns
+// a non-nil error if the rotation could not complete and bumps failedRotations
+// (#3478 H22). Crucially, tw.written is reset to 0 ONLY when the active file was
+// actually moved aside and a fresh empty file opened; on a failed primary
+// rename the daemon keeps writing to the same (still-full) file, so written is
+// re-synced to the real size to retry rotation on the next write rather than
+// silently growing unbounded with a bogus 0 byte count.
+func (tw *TraceWriter) rotate() error {
 	tw.file.Close()
 	tw.file = nil
 
-	// Shift existing files: .2 -> .3, .1 -> .2, current -> .1
+	// Shift existing files: .2 -> .3, .1 -> .2. A missing generation is normal
+	// (ENOENT); any other rename failure means a retained generation was lost,
+	// so it is counted and surfaced (#3478 item 2) even though the active-file
+	// rotation below can still succeed.
+	var shiftErr error
 	for i := tw.maxFiles - 1; i > 0; i-- {
 		old := fmt.Sprintf("%s.%d", tw.path, i)
-		new := fmt.Sprintf("%s.%d", tw.path, i+1)
-		os.Rename(old, new)
+		next := fmt.Sprintf("%s.%d", tw.path, i+1)
+		if err := os.Rename(old, next); err != nil && !os.IsNotExist(err) {
+			slog.Debug("trace rotate generation shift failed", "from", old, "to", next, "err", err)
+			tw.failedRotations.Add(1)
+			if shiftErr == nil {
+				shiftErr = fmt.Errorf("rotate shift %s->%s: %w", old, next, err)
+			}
+		}
 	}
-	os.Rename(tw.path, tw.path+".1")
+	renameErr := os.Rename(tw.path, tw.path+".1")
 
-	// Remove excess files
+	// Remove excess files (best-effort).
 	excess := fmt.Sprintf("%s.%d", tw.path, tw.maxFiles+1)
-	os.Remove(excess)
+	if err := os.Remove(excess); err != nil && !os.IsNotExist(err) {
+		slog.Debug("trace rotate excess removal failed", "path", excess, "err", err)
+	}
 
-	// Open fresh file (O_NOFOLLOW, regular-file checked, 0600). The active path
-	// was just renamed to .1, so this creates a new empty file.
+	// Open fresh file (O_NOFOLLOW, regular-file checked, 0600). When the
+	// primary rename succeeded the active path no longer exists, so this
+	// creates a new empty file.
 	f, err := openTraceFile(tw.name)
 	if err != nil {
-		slog.Warn("failed to open rotated trace file", "err", err)
-		return
+		tw.failedRotations.Add(1)
+		return fmt.Errorf("reopen after rotate: %w", err)
 	}
 	tw.file = f
+
+	if renameErr != nil {
+		// The active file was NOT rolled aside; we reopened the same full file.
+		tw.failedRotations.Add(1)
+		if info, statErr := f.Stat(); statErr == nil {
+			tw.written = info.Size()
+		}
+		return fmt.Errorf("rotate rename %s: %w", tw.path, renameErr)
+	}
+	// The active file rotated cleanly (fresh empty file); reset the byte count.
+	// shiftErr is non-nil only when a retained generation could not be shifted;
+	// surface it so the caller warns, but the active rotation itself succeeded.
 	tw.written = 0
+	return shiftErr
 }

--- a/pkg/logging/trace_test.go
+++ b/pkg/logging/trace_test.go
@@ -281,3 +281,180 @@ func TestMatchFiltersProtocolWithPrefix(t *testing.T) {
 		}
 	}
 }
+
+// TestTraceWriter_WriteFailureObservable pins #3478 H21: a swallowed trace
+// write error is now counted in DroppedWrites so lost audit telemetry is
+// detectable.
+//
+// RED-on-revert: remove the `tw.droppedWrites.Add(1)` in HandleEvent and the
+// counter stays 0.
+func TestTraceWriter_WriteFailureObservable(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "flow.log"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tw.Close()
+
+	// Close the fd out from under the writer so the next write fails (EBADF)
+	// while tw.file is still non-nil.
+	if err := tw.file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	tw.HandleEvent(EventRecord{Type: "SESSION_OPEN"}, nil)
+
+	if got := tw.DroppedWrites(); got != 1 {
+		t.Fatalf("DroppedWrites = %d, want 1 (trace write failure not observable)", got)
+	}
+}
+
+// TestTraceWriter_RotationFailureObservable pins #3478 H22 + item 6: a rotation
+// whose primary rename cannot complete (a) returns a non-nil error, (b) bumps
+// FailedRotations, and (c) re-syncs `written` to the real file size rather than
+// resetting to a bogus 0. Calling rotate() directly pins all three.
+//
+// RED-on-revert: make rotate() ignore the rename result and unconditionally set
+// written=0 / return nil — the error-return, the written==realSize, and the
+// FailedRotations assertions all fail.
+func TestTraceWriter_RotationFailureObservable(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	// FileCount=1 so the generation-shift loop does not run and cannot move our
+	// blocking directory aside before the primary rename.
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "flow.log", FileSize: 40, FileCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tw.Close()
+
+	if _, err := tw.file.WriteString("0123456789012345678901234567890123456789\n"); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(tw.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realSize := fi.Size()
+	tw.written = 999 // deliberately wrong to prove rotate() re-syncs to real size
+
+	// Block the primary rename target with a non-empty directory so
+	// os.Rename(path, path+".1") fails.
+	archive := tw.path + ".1"
+	if err := os.Mkdir(archive, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archive, "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if rerr := tw.rotate(); rerr == nil {
+		t.Fatal("rotate() returned nil on a failed primary rename, want a non-nil error")
+	}
+	if got := tw.FailedRotations(); got == 0 {
+		t.Fatalf("FailedRotations = 0, want >=1 (failed rename not observable)")
+	}
+	if tw.written != realSize {
+		t.Fatalf("written = %d after a failed rotation, want re-synced to real size %d (not a bogus 0/stale value)", tw.written, realSize)
+	}
+}
+
+// TestTraceWriter_GenerationShiftFailureObservable pins #3478 item 2: a failed
+// retained-generation shift (old->next) is counted and surfaced even when the
+// active-file rotation itself succeeds.
+//
+// RED-on-revert: drop the failedRotations.Add(1)+shiftErr in the shift loop and
+// both assertions fail.
+func TestTraceWriter_GenerationShiftFailureObservable(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	// FileCount=2 so the shift loop runs once: rename .1 -> .2.
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "flow.log", FileCount: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tw.Close()
+
+	if err := os.WriteFile(tw.path+".1", []byte("gen1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(tw.path+".2", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tw.path+".2", "keep"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rerr := tw.rotate()
+	if rerr == nil {
+		t.Fatal("rotate() returned nil despite a failed generation shift, want a non-nil error")
+	}
+	if got := tw.FailedRotations(); got == 0 {
+		t.Fatalf("FailedRotations = 0, want >=1 (generation-shift failure not observable)")
+	}
+}
+
+// TestTraceWriter_NilFileDropObservable pins #3478 item 1: a HandleEvent on a
+// writer whose file is nil (here via Close, the state a failed rotation reopen
+// leaves) increments DroppedWrites rather than returning silently.
+//
+// RED-on-revert: restore the bare `return` on the tw.file==nil branch without
+// the droppedWrites.Add(1) and the counter stays 0.
+func TestTraceWriter_NilFileDropObservable(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "flow.log"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw.Close() // file = nil
+
+	tw.HandleEvent(EventRecord{Type: "SESSION_OPEN"}, nil)
+	if got := tw.DroppedWrites(); got != 1 {
+		t.Fatalf("DroppedWrites = %d, want 1 (nil-file drop not observable)", got)
+	}
+}
+
+// TestTraceWriter_TightensExistingMode pins #3477 item 3: opening an existing
+// 0644 trace file tightens it to 0600.
+//
+// RED-on-revert: remove the fchmod-on-existing block in openHardenedAuditLog
+// and the mode stays 0644.
+func TestTraceWriter_TightensExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	old := traceLogDir
+	traceLogDir = dir
+	defer func() { traceLogDir = old }()
+
+	path := filepath.Join(dir, "flow.log")
+	if err := os.WriteFile(path, []byte("legacy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil { // defeat umask
+		t.Fatal(err)
+	}
+	tw, err := NewTraceWriter(&config.FlowTraceoptions{File: "flow.log"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tw.Close()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("existing trace-file mode = %o after open, want tightened to 0600", perm)
+	}
+}


### PR DESCRIPTION
Closes #3477
Closes #3478

## What

Brings the event-mode security-log writer (`LocalLogWriter`) to the same
symlink/permission hardening the flow-trace writer already has, and makes
write/rotation failures across both writers and the session aggregator
observable instead of silently swallowed.

### #3477 — symlink/mode hardening for `LocalLogWriter`
- Extracted the flow-trace open semantics into a shared
  `openHardenedAuditLog(path, mode)` helper: `O_NOFOLLOW`, regular-file
  verified, mode `0600`. `openTraceFile` now delegates to it.
- `0600` is **enforced, not create-only**: an existing pre-hardening `0644`
  file is `fchmod`-tightened on the held `O_NOFOLLOW` regular-file fd, so an
  upgrade does not leave it world-readable.
- `NewLocalLogWriter` opens via the helper, log dir `0750`.
- Rotation reopens through the helper (`O_APPEND`, no `O_TRUNC`) — closes the
  `O_TRUNC`-follows-symlink primitive.

### #3478 — make write/rotation failures observable
- `TraceWriter` and `LocalLogWriter` each expose `DroppedWrites()` and
  `FailedRotations()` atomic counters + a ≤1/s WARN with **separate clocks
  per failure class** (a write-drop storm can't suppress the rotation warn).
- `DroppedWrites` covers **every** drop path — failed write AND
  nil/closed-file (a writer wedged by a failed reopen no longer drops every
  subsequent event after one `FailedRotations` bump).
- `FailedRotations` covers a failed generation shift, a failed active-file
  rename, and a failed reopen.
- `rotate()` returns an error and resets the byte count to 0 **only** when
  the active file was actually rolled aside; on a failed rename it re-syncs
  `written` to the real size so the next write retries rotation.
- The session aggregator (`ForwardLogMsg`) no longer discards the
  local-writer error; the writer-owned counter is the metric of record.

## Codex re-review folds (round 2)
All six MUST-FOLD items addressed: (1) nil-file silent-drop now counted +
warned on both writers; (2) generation-shift rename failures bump
`FailedRotations` + surface an error; (3) existing-file mode enforced to
0600 via `fchmod`; (4) every `Send`/`SendBinary` failure path counts,
including closed/nil writer; (5) per-counter-type warn throttle; (6)
rotation tests strengthened to pin `written` re-sync AND the `rotate()`
error return (RED if `written=0`-on-failed-rename is reintroduced).

## Out of scope (tracked separately)
Codex flagged pre-existing per-event `slog.Info("firewall event")` calls in
`ringbuf.go` — a separate logging-rule violation, not touched here.

## Validation
- `go build ./...` and `go test ./pkg/logging/... -count=1 -race` pass.
- RED-on-revert verified on **both** writers for every fix (mode+symlink,
  TightensExistingMode, DroppedWrites incl. nil-file, FailedRotations incl.
  generation-shift, rotate()-returns-error + written-re-sync).
- `gofmt` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi