### PR TITLE
security display: nil-guard policy/screen inventory surfaces (#3476)

### DIFF
--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -137,10 +137,20 @@ func (c *xpfCollector) collectPolicyCounters(ch chan<- prometheus.Metric, dp api
 
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: the compile path normalizes nil entries out, but the
+		// tolerant / HA-sync config path (#3474) can leave a nil zone-pair
+		// set or rule that the runtime walker skips. Mirror that here so a
+		// Prometheus scrape does not crash on zpp.FromZone / rule.Count.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		fromZone := zpp.FromZone
 		toZone := zpp.ToZone
-		// Zone-pair compile output normalizes nil entries out of zpp.Policies.
 		for i, rule := range zpp.Policies {
+			if rule == nil {
+				continue
+			}
 			if !statsEnabled && !rule.Count {
 				continue
 			}

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -98,11 +98,24 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 	var policySetID uint32
 	var result []PolicyInfo
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: the tolerant / HA-sync config path can leave a nil
+		// zone-pair set (Policies is []*ZonePairPolicies); the runtime
+		// walker skips it while advancing the policy-set ID. Mirror that so
+		// the inventory does not panic on zpp.FromZone.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		pi := PolicyInfo{
 			FromZone: zpp.FromZone,
 			ToZone:   zpp.ToZone,
 		}
 		for _, rule := range zpp.Policies {
+			// #3476: skip a nil rule (Policies is []*Policy) like the
+			// runtime walker does, rather than dereferencing rule.Name.
+			if rule == nil {
+				continue
+			}
 			pr := PolicyRule{
 				Name:         rule.Name,
 				Action:       policyActionStr(rule.Action),
@@ -440,6 +453,14 @@ func policyActionStr(a config.PolicyAction) string {
 }
 
 func screenChecks(p *config.ScreenProfile) []string {
+	// #3476: the Screen map is `map[string]*ScreenProfile`; the tolerant /
+	// HA-sync config path can leave a nil profile value the runtime walker
+	// (pkg/dataplane/userspace/screens.go) skips. Treat a nil profile as
+	// "no checks" so the REST/gRPC inventory renders it absent rather than
+	// panicking on p.TCP.SynFlood.
+	if p == nil {
+		return nil
+	}
 	var checks []string
 	if p.TCP.SynFlood != nil {
 		checks = append(checks, "syn-flood")

--- a/pkg/api/security_screen_nil_3476_test.go
+++ b/pkg/api/security_screen_nil_3476_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3476: the policy/screen inventory display surfaces dereference nil
+// zone-pair sets, nil rules, nil global rules, and nil screen-profile map
+// values that the tolerant / HA-sync config path (#3474) can produce and the
+// runtime walker (pkg/dataplane/userspace/{policies,screens}.go) tolerates.
+// These tests inject those nil slots into the live ActiveConfig and drive each
+// REST/Prometheus surface; reverting any of the security.go / metrics_counters.go
+// nil guards makes the corresponding subtest panic (RED on revert).
+
+// nilSlotStore builds a committed config with one zone-pair policy set, one
+// global policy, and one screen profile, then injects a nil zone-pair set, a
+// nil rule, a nil global rule, and a nil screen-profile value into the live
+// ActiveConfig (the strict compiler never emits these; the tolerant path can).
+func nilSlotStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    policy-stats {
+        system-wide enable;
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+            }
+        }
+        global {
+            policy g1 {
+                match { source-address any; destination-address any; application any; }
+                then { deny; count; }
+            }
+        }
+    }
+    screen {
+        ids-option sp {
+            tcp { land; syn-flood; }
+            icmp { ping-death; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	injectNilSlots(t, store)
+	return store
+}
+
+// injectNilSlots mutates the live compiled config to add the nil slots a
+// tolerant/HA-sync config path can leave behind. Must run AFTER the final
+// Commit (which recompiles and would normalize the nils away).
+func injectNilSlots(t *testing.T, store *configstore.Store) {
+	t.Helper()
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if len(cfg.Security.Policies) == 0 || len(cfg.Security.GlobalPolicies) == 0 {
+		t.Fatalf("fixture missing policies: %d zone-pair sets, %d globals",
+			len(cfg.Security.Policies), len(cfg.Security.GlobalPolicies))
+	}
+	// nil rule inside the real zone-pair set
+	cfg.Security.Policies[0].Policies = append(cfg.Security.Policies[0].Policies, nil)
+	// nil zone-pair set
+	cfg.Security.Policies = append(cfg.Security.Policies, nil)
+	// nil global rule
+	cfg.Security.GlobalPolicies = append(cfg.Security.GlobalPolicies, nil)
+	// nil screen-profile map value (the fixture always commits one profile, so
+	// the map is non-nil here)
+	cfg.Security.Screen["zz-nil-profile"] = nil
+}
+
+func TestPoliciesHandlerNilSlotsNoPanic(t *testing.T) {
+	s := &Server{
+		store: nilSlotStore(t),
+		dp: &schedulerCounterAPIDP{
+			Manager:  dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{},
+		},
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req) // panics on revert of the zpp/rule guards
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success=false; body: %s", rr.Body.String())
+	}
+}
+
+func TestScreenHandlerNilProfileNoPanic(t *testing.T) {
+	s := &Server{store: nilSlotStore(t)}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/screen", nil)
+	s.screenHandler(rr, req) // panics on revert of the screenChecks(nil) guard
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestScreenChecksNilReturnsNil(t *testing.T) {
+	if got := screenChecks(nil); got != nil {
+		t.Fatalf("screenChecks(nil) = %v, want nil", got)
+	}
+}
+
+func TestCollectPolicyCountersNilSlotsNoPanic(t *testing.T) {
+	store := nilSlotStore(t)
+	c := &xpfCollector{
+		srv: &Server{store: store},
+		policyHitsTotal: prometheus.NewDesc(
+			"xpf_policy_hits_total", "policy hits",
+			[]string{"from_zone", "to_zone", "policy_name"}, nil,
+		),
+	}
+	dp := &schedulerCounterAPIDP{
+		Manager:  dataplane.New(),
+		counters: map[uint32]dataplane.CounterValue{},
+	}
+	ch := make(chan prometheus.Metric)
+	go func() {
+		// panics on revert of the zpp/rule guards in collectPolicyCounters
+		c.collectPolicyCounters(ch, dp)
+		close(ch)
+	}()
+	for range ch {
+	}
+}

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -52,6 +52,12 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 	index := uint32(1)
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: skip a nil zone-pair set (tolerant / HA-sync path) while
+		// advancing the policy-set ID, mirroring the runtime walker.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		if fromZone != "" && zpp.FromZone != fromZone {
 			policySetID++
 			continue
@@ -61,6 +67,10 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 			continue
 		}
 		for i, pol := range zpp.Policies {
+			// #3476: skip a nil rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "Permit"
 			switch pol.Action {
 			case 1:
@@ -86,6 +96,10 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 	// Global policies
 	if len(cfg.Security.GlobalPolicies) > 0 && fromZone == "" && toZone == "" {
 		for i, pol := range cfg.Security.GlobalPolicies {
+			// #3476: skip a nil global rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "Permit"
 			switch pol.Action {
 			case 1:
@@ -136,6 +150,12 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 	policySetID := uint32(0)
 	seqNum := 1
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: skip a nil zone-pair set (tolerant / HA-sync path) while
+		// advancing the policy-set ID, mirroring the runtime walker.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		if fromZone != "" && zpp.FromZone != fromZone {
 			policySetID++
 			continue
@@ -145,6 +165,10 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 			continue
 		}
 		for i, pol := range zpp.Policies {
+			// #3476: skip a nil rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "permit"
 			switch pol.Action {
 			case 1:
@@ -214,6 +238,10 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 	// Global policies
 	if len(cfg.Security.GlobalPolicies) > 0 && fromZone == "" && toZone == "" {
 		for i, pol := range cfg.Security.GlobalPolicies {
+			// #3476: skip a nil global rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "permit"
 			switch pol.Action {
 			case 1:

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -216,6 +216,12 @@ func (c *CLI) handleShowSecurity(args []string) error {
 				"From", "To", "Name", "Action", "Hits")
 			policySetID := uint32(0)
 			for _, zpp := range cfg.Security.Policies {
+				// #3476: skip a nil zone-pair set (tolerant / HA-sync path)
+				// while advancing the policy-set ID, like the runtime walker.
+				if zpp == nil {
+					policySetID++
+					continue
+				}
 				if fromZone != "" && zpp.FromZone != fromZone {
 					policySetID++
 					continue
@@ -225,6 +231,10 @@ func (c *CLI) handleShowSecurity(args []string) error {
 					continue
 				}
 				for i, pol := range zpp.Policies {
+					// #3476: skip a nil rule like the runtime walker does.
+					if pol == nil {
+						continue
+					}
 					action := "permit"
 					switch pol.Action {
 					case 1:
@@ -253,6 +263,10 @@ func (c *CLI) handleShowSecurity(args []string) error {
 			// Global policies in brief view
 			if len(cfg.Security.GlobalPolicies) > 0 && fromZone == "" && toZone == "" {
 				for i, pol := range cfg.Security.GlobalPolicies {
+					// #3476: skip a nil global rule like the runtime walker.
+					if pol == nil {
+						continue
+					}
 					action := "permit"
 					switch pol.Action {
 					case 1:
@@ -298,6 +312,12 @@ func (c *CLI) handleShowSecurity(args []string) error {
 		policySetID := uint32(0)
 		if !globalOnly {
 			for _, zpp := range cfg.Security.Policies {
+				// #3476: skip a nil zone-pair set (tolerant / HA-sync path)
+				// while advancing the policy-set ID, like the runtime walker.
+				if zpp == nil {
+					policySetID++
+					continue
+				}
 				if fromZone != "" && zpp.FromZone != fromZone {
 					policySetID++
 					continue
@@ -309,6 +329,10 @@ func (c *CLI) handleShowSecurity(args []string) error {
 				// Junos format: "From zone: X, To zone: Y" header
 				fmt.Printf("From zone: %s, To zone: %s\n", zpp.FromZone, zpp.ToZone)
 				for i, pol := range zpp.Policies {
+					// #3476: skip a nil rule like the runtime walker does.
+					if pol == nil {
+						continue
+					}
 					action := "permit"
 					switch pol.Action {
 					case 1:
@@ -347,6 +371,10 @@ func (c *CLI) handleShowSecurity(args []string) error {
 		if len(cfg.Security.GlobalPolicies) > 0 && (globalOnly || (fromZone == "" && toZone == "")) {
 			fmt.Println("Global policies:")
 			for i, pol := range cfg.Security.GlobalPolicies {
+				// #3476: skip a nil global rule like the runtime walker.
+				if pol == nil {
+					continue
+				}
 				action := "permit"
 				switch pol.Action {
 				case 1:

--- a/pkg/cli/cli_show_security_nil_3476_test.go
+++ b/pkg/cli/cli_show_security_nil_3476_test.go
@@ -115,6 +115,64 @@ func TestCLIScreenDisplayNilProfileNoPanic(t *testing.T) {
 	})
 }
 
+// nilSlotZonesCLIStore mirrors nilSlotZonesGRPCStore for the local CLI: a zone
+// referencing a screen profile, a policy set, with a nil referenced profile, a
+// nil rule, and a nil zone-pair set injected. Drives the `show security zones`
+// detail renderer's present-but-nil screen lookup and policy-summary derefs.
+func nilSlotZonesCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            screen sp;
+        }
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+    screen {
+        ids-option sp {
+            tcp { land; syn-flood; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || len(cfg.Security.Policies) == 0 {
+		t.Fatalf("fixture missing policies")
+	}
+	cfg.Security.Screen["sp"] = nil
+	cfg.Security.Policies[0].Policies = append(cfg.Security.Policies[0].Policies, nil)
+	cfg.Security.Policies = append(cfg.Security.Policies, nil)
+	return store
+}
+
+func TestCLIShowZonesDetailNilSlotsNoPanic(t *testing.T) {
+	store := nilSlotZonesCLIStore(t)
+	c := &CLI{store: store} // dp nil: skip counters, run screen+summary in detail mode
+	captureStdout(t, func() {
+		if err := c.showZonesDisplay(store.ActiveConfig(), true, ""); err != nil {
+			t.Fatalf("showZonesDisplay(detail): %v", err)
+		}
+	})
+}
+
 func TestCLIValueProviderPolicyNameNilSlotsNoPanic(t *testing.T) {
 	c := &CLI{store: nilSlotCLIStore(t)}
 	_ = c.valueProvider(config.ValueHintPolicyName,

--- a/pkg/cli/cli_show_security_nil_3476_test.go
+++ b/pkg/cli/cli_show_security_nil_3476_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3476: the local CLI policy/screen display + completion surfaces dereference
+// nil zone-pair sets, nil rules, nil global rules, and nil screen-profile map
+// values reachable on the tolerant / HA-sync config path (#3474) that the
+// runtime walker tolerates. These tests inject those nil slots into the live
+// ActiveConfig and drive each CLI surface; reverting any of the
+// cli_show_security*.go / completion.go nil guards makes the matching subtest
+// panic (RED on revert).
+
+func nilSlotCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    policy-stats {
+        system-wide enable;
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+            }
+        }
+        global {
+            policy g1 {
+                match { source-address any; destination-address any; application any; }
+                then { deny; count; }
+            }
+        }
+    }
+    screen {
+        ids-option sp {
+            tcp { land; syn-flood; }
+            icmp { ping-death; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || len(cfg.Security.Policies) == 0 || len(cfg.Security.GlobalPolicies) == 0 {
+		t.Fatalf("fixture missing policies")
+	}
+	cfg.Security.Policies[0].Policies = append(cfg.Security.Policies[0].Policies, nil)
+	cfg.Security.Policies = append(cfg.Security.Policies, nil)
+	cfg.Security.GlobalPolicies = append(cfg.Security.GlobalPolicies, nil)
+	cfg.Security.Screen["zz-nil-profile"] = nil
+	return store
+}
+
+func TestCLIPolicyDisplayNilSlotsNoPanic(t *testing.T) {
+	store := nilSlotCLIStore(t)
+	cfg := store.ActiveConfig()
+	c := &CLI{
+		store: store,
+		dp: &policyCounterCLIDP{
+			Manager:  dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{},
+		},
+	}
+	// Each call panics on revert of the zpp/rule guards in the matching loop.
+	captureStdout(t, func() {
+		if err := c.showPoliciesHitCount(cfg, "", ""); err != nil {
+			t.Fatalf("showPoliciesHitCount: %v", err)
+		}
+		if err := c.showPoliciesDetail(cfg, "", ""); err != nil {
+			t.Fatalf("showPoliciesDetail: %v", err)
+		}
+		if err := c.handleShowSecurity([]string{"policies"}); err != nil {
+			t.Fatalf("handleShowSecurity(policies): %v", err)
+		}
+		if err := c.handleShowSecurity([]string{"policies", "brief"}); err != nil {
+			t.Fatalf("handleShowSecurity(policies brief): %v", err)
+		}
+		if err := c.handleShowSecurity([]string{"policies", "detail"}); err != nil {
+			t.Fatalf("handleShowSecurity(policies detail): %v", err)
+		}
+	})
+}
+
+func TestCLIScreenDisplayNilProfileNoPanic(t *testing.T) {
+	c := &CLI{store: nilSlotCLIStore(t)} // no dp: skip counter reads, exercise map walk
+	captureStdout(t, func() {
+		if err := c.handleShowScreen(nil); err != nil {
+			t.Fatalf("handleShowScreen: %v", err)
+		}
+		if err := c.handleShowScreen([]string{"ids-option", "zz-nil-profile"}); err != nil {
+			t.Fatalf("handleShowScreen(ids-option nil): %v", err)
+		}
+		if err := c.handleShowScreen([]string{"ids-option", "zz-nil-profile", "detail"}); err != nil {
+			t.Fatalf("handleShowScreen(ids-option nil detail): %v", err)
+		}
+	})
+}
+
+func TestCLIValueProviderPolicyNameNilSlotsNoPanic(t *testing.T) {
+	c := &CLI{store: nilSlotCLIStore(t)}
+	_ = c.valueProvider(config.ValueHintPolicyName,
+		[]string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy"})
+	_ = c.valueProvider(config.ValueHintPolicyName,
+		[]string{"security", "policies", "global", "policy"})
+}

--- a/pkg/cli/cli_show_security_screen.go
+++ b/pkg/cli/cli_show_security_screen.go
@@ -31,6 +31,12 @@ func (c *CLI) showScreen() error {
 	}
 
 	for name, profile := range cfg.Security.Screen {
+		// #3476: skip a nil profile map value (reachable on the tolerant /
+		// HA-sync config path the runtime walker skips) rather than
+		// dereferencing profile.TCP.Land.
+		if profile == nil {
+			continue
+		}
 		fmt.Printf("Screen profile: %s\n", name)
 
 		// TCP checks
@@ -146,7 +152,9 @@ func (c *CLI) showScreenIdsOption(name string) error {
 		return nil
 	}
 	profile, ok := cfg.Security.Screen[name]
-	if !ok {
+	if !ok || profile == nil {
+		// #3476: a present-but-nil profile value (tolerant / HA-sync path)
+		// must not panic on profile.TCP.Land.
 		fmt.Printf("Screen profile '%s' not found\n", name)
 		return nil
 	}
@@ -217,7 +225,9 @@ func (c *CLI) showScreenIdsOptionDetail(name string) error {
 		return nil
 	}
 	profile, ok := cfg.Security.Screen[name]
-	if !ok {
+	if !ok || profile == nil {
+		// #3476: a present-but-nil profile value must not panic on the
+		// profile.TCP.* derefs below.
 		fmt.Printf("Screen profile '%s' not found\n", name)
 		return nil
 	}

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -110,7 +110,9 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 
 			// Screen profile details
 			if zone.ScreenProfile != "" {
-				if profile, ok := cfg.Security.Screen[zone.ScreenProfile]; ok {
+				// #3476: a present-but-nil screen-profile map value (tolerant
+				// / HA-sync config path) must not panic on profile.TCP.Land.
+				if profile, ok := cfg.Security.Screen[zone.ScreenProfile]; ok && profile != nil {
 					fmt.Printf("  Screen profile details (%s):\n", zone.ScreenProfile)
 					var checks []string
 					if profile.TCP.Land {
@@ -161,8 +163,19 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 			fmt.Println("  Policy summary:")
 			totalPolicies := 0
 			for _, zpp := range cfg.Security.Policies {
+				// #3476: skip a nil zone-pair set (tolerant / HA-sync config
+				// path the runtime walker skips) rather than dereferencing
+				// zpp.FromZone.
+				if zpp == nil {
+					continue
+				}
 				if zpp.FromZone == name || zpp.ToZone == name {
 					for _, pol := range zpp.Policies {
+						// #3476: skip a nil rule rather than dereferencing
+						// pol.Action / pol.Name.
+						if pol == nil {
+							continue
+						}
 						action := "permit"
 						switch pol.Action {
 						case 1:

--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -513,6 +513,11 @@ func (c *CLI) valueProvider(hint config.ValueHint, path []string) []config.Schem
 				fromZone := path[i+1]
 				toZone := path[i+3]
 				for _, zpp := range cfg.Security.Policies {
+					// #3476: skip a nil zone-pair set (tolerant / HA-sync
+					// path) rather than dereferencing zpp.FromZone.
+					if zpp == nil {
+						continue
+					}
 					if zpp.FromZone == fromZone && zpp.ToZone == toZone {
 						policies = zpp.Policies
 						break
@@ -527,6 +532,11 @@ func (c *CLI) valueProvider(hint config.ValueHint, path []string) []config.Schem
 		}
 		var out []config.SchemaCompletion
 		for _, pol := range policies {
+			// #3476: skip a nil policy (Policies / GlobalPolicies are
+			// []*Policy) rather than dereferencing pol.Description.
+			if pol == nil {
+				continue
+			}
 			desc := pol.Description
 			if desc == "" {
 				desc = "(configured)"

--- a/pkg/cmdtree/completion_nil_3476_test.go
+++ b/pkg/cmdtree/completion_nil_3476_test.go
@@ -1,0 +1,40 @@
+package cmdtree
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3476: the `show security policies … policy <TAB>` ContextDynamicFn in
+// OperationalTree derefs zpp.FromZone and p.Name without nil guards. The
+// tolerant / HA-sync config path (#3474) can leave a nil zone-pair set or nil
+// rule the runtime walker tolerates. This drives the real completer; reverting
+// either guard makes it panic (RED on revert).
+func TestShowPoliciesPolicyCompletionNilSlotsNoPanic(t *testing.T) {
+	cfg := &config.Config{}
+	// nil zpp FIRST (exercises the zpp guard before the matching set), then the
+	// matching trust->untrust set whose rule slice leads with a nil rule.
+	cfg.Security.Policies = []*config.ZonePairPolicies{
+		nil,
+		{
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Policies: []*config.Policy{nil, {Name: "p1"}},
+		},
+	}
+
+	cands := CompleteFromTree(OperationalTree,
+		[]string{"show", "security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy"},
+		"", cfg)
+
+	// The nil rule must be skipped and the real policy name surfaced.
+	if !contains(cands, "p1") {
+		t.Fatalf("expected policy name p1 in completions, got %v", cands)
+	}
+	for _, c := range cands {
+		if c == "" {
+			t.Fatalf("nil rule produced an empty completion candidate: %v", cands)
+		}
+	}
+}

--- a/pkg/cmdtree/tree.go
+++ b/pkg/cmdtree/tree.go
@@ -307,9 +307,20 @@ var OperationalTree = map[string]*Node{
 								return nil
 							}
 							for _, zpp := range cfg.Security.Policies {
+								// #3476: skip a nil zone-pair set (tolerant /
+								// HA-sync config path the runtime walker skips)
+								// rather than dereferencing zpp.FromZone.
+								if zpp == nil {
+									continue
+								}
 								if zpp.FromZone == fromZone && zpp.ToZone == toZone {
 									names := make([]string, 0, len(zpp.Policies))
 									for _, p := range zpp.Policies {
+										// #3476: skip a nil rule rather than
+										// dereferencing p.Name.
+										if p == nil {
+											continue
+										}
 										names = append(names, p.Name)
 									}
 									return names

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -602,6 +602,11 @@ func (s *Server) valueProvider(hint config.ValueHint, path []string) []config.Sc
 				fromZone := path[i+1]
 				toZone := path[i+3]
 				for _, zpp := range cfg.Security.Policies {
+					// #3476: skip a nil zone-pair set (tolerant / HA-sync
+					// path) rather than dereferencing zpp.FromZone.
+					if zpp == nil {
+						continue
+					}
 					if zpp.FromZone == fromZone && zpp.ToZone == toZone {
 						policies = zpp.Policies
 						break
@@ -616,6 +621,11 @@ func (s *Server) valueProvider(hint config.ValueHint, path []string) []config.Sc
 		}
 		var out []config.SchemaCompletion
 		for _, pol := range policies {
+			// #3476: skip a nil policy (Policies / GlobalPolicies are
+			// []*Policy) rather than dereferencing pol.Description.
+			if pol == nil {
+				continue
+			}
 			desc := pol.Description
 			if desc == "" {
 				desc = "(configured)"

--- a/pkg/grpcapi/server_helpers.go
+++ b/pkg/grpcapi/server_helpers.go
@@ -250,6 +250,12 @@ func lookupAppFilter(appName string, cfg *config.Config) (proto uint8, port uint
 }
 
 func screenChecks(p *config.ScreenProfile) []string {
+	// #3476: a nil screen-profile map value (reachable on the tolerant /
+	// HA-sync config path the runtime walker skips) must render as "no
+	// checks", not panic on p.TCP.SynFlood.
+	if p == nil {
+		return nil
+	}
 	var checks []string
 	if p.TCP.SynFlood != nil {
 		checks = append(checks, "syn-flood")

--- a/pkg/grpcapi/server_security_nil_3476_test.go
+++ b/pkg/grpcapi/server_security_nil_3476_test.go
@@ -1,0 +1,125 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3476: the gRPC policy/screen display + completion surfaces dereference nil
+// zone-pair sets, nil rules, nil global rules, and nil screen-profile map
+// values reachable on the tolerant / HA-sync config path (#3474) that the
+// runtime walker tolerates. These tests inject those nil slots into the live
+// ActiveConfig and drive each surface; reverting any of the server_show_zones.go
+// / server_show_policies_text.go / server_helpers.go / server_show_security_text.go
+// / server_cluster.go nil guards makes the matching subtest panic (RED on revert).
+
+func nilSlotGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    policy-stats {
+        system-wide enable;
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match { source-address any; destination-address any; application any; }
+                then { permit; count; }
+            }
+        }
+        global {
+            policy g1 {
+                match { source-address any; destination-address any; application any; }
+                then { deny; count; }
+            }
+        }
+    }
+    screen {
+        ids-option sp {
+            tcp { land; syn-flood; }
+            icmp { ping-death; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || len(cfg.Security.Policies) == 0 || len(cfg.Security.GlobalPolicies) == 0 {
+		t.Fatalf("fixture missing policies")
+	}
+	cfg.Security.Policies[0].Policies = append(cfg.Security.Policies[0].Policies, nil)
+	cfg.Security.Policies = append(cfg.Security.Policies, nil)
+	cfg.Security.GlobalPolicies = append(cfg.Security.GlobalPolicies, nil)
+	cfg.Security.Screen["zz-nil-profile"] = nil
+	return store
+}
+
+func nilSlotGRPCServer(t *testing.T) *Server {
+	t.Helper()
+	return &Server{
+		store: nilSlotGRPCStore(t),
+		dp: &schedulerCounterGRPCDP{
+			Manager:  dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{},
+		},
+	}
+}
+
+func TestGetPoliciesNilSlotsNoPanic(t *testing.T) {
+	s := nilSlotGRPCServer(t)
+	if _, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{}); err != nil {
+		t.Fatalf("GetPolicies error = %v", err)
+	}
+}
+
+func TestGetScreenNilProfileNoPanic(t *testing.T) {
+	s := nilSlotGRPCServer(t)
+	if _, err := s.GetScreen(context.Background(), &pb.GetScreenRequest{}); err != nil {
+		t.Fatalf("GetScreen error = %v", err)
+	}
+}
+
+func TestScreenChecksNilReturnsNil(t *testing.T) {
+	if got := screenChecks(nil); got != nil {
+		t.Fatalf("screenChecks(nil) = %v, want nil", got)
+	}
+}
+
+func TestShowTextSecurityNilSlotsNoPanic(t *testing.T) {
+	for _, topic := range []string{"policies-hit-count", "policies-detail", "screen"} {
+		t.Run(topic, func(t *testing.T) {
+			s := nilSlotGRPCServer(t)
+			if _, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic}); err != nil {
+				t.Fatalf("ShowText(%s) error = %v", topic, err)
+			}
+		})
+	}
+}
+
+func TestValueProviderPolicyNameNilSlotsNoPanic(t *testing.T) {
+	s := nilSlotGRPCServer(t)
+	// zone-pair completion path (iterates cfg.Security.Policies)
+	_ = s.valueProvider(config.ValueHintPolicyName,
+		[]string{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy"})
+	// global completion path (iterates cfg.Security.GlobalPolicies)
+	_ = s.valueProvider(config.ValueHintPolicyName,
+		[]string{"security", "policies", "global", "policy"})
+}

--- a/pkg/grpcapi/server_security_nil_3476_test.go
+++ b/pkg/grpcapi/server_security_nil_3476_test.go
@@ -114,6 +114,62 @@ func TestShowTextSecurityNilSlotsNoPanic(t *testing.T) {
 	}
 }
 
+// nilSlotZonesGRPCStore builds a zone (trust) that references a screen profile
+// plus a trust->untrust policy set, then injects a nil screen-profile value for
+// the referenced profile, a nil rule, and a nil zone-pair set. This exercises
+// the `show security zones` detail renderer's present-but-nil screen lookup and
+// its policy-summary zpp/pol derefs (the #3476 sites missed in the first pass).
+func nilSlotZonesGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            screen sp;
+        }
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p1 {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+    screen {
+        ids-option sp {
+            tcp { land; syn-flood; }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil || len(cfg.Security.Policies) == 0 {
+		t.Fatalf("fixture missing policies")
+	}
+	cfg.Security.Screen["sp"] = nil // zone trust now references a nil profile
+	cfg.Security.Policies[0].Policies = append(cfg.Security.Policies[0].Policies, nil)
+	cfg.Security.Policies = append(cfg.Security.Policies, nil)
+	return store
+}
+
+func TestShowZonesDetailNilSlotsNoPanic(t *testing.T) {
+	s := &Server{store: nilSlotZonesGRPCStore(t)} // dp nil: skip counters, run screen+summary
+	if _, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "zones-detail"}); err != nil {
+		t.Fatalf("ShowText(zones-detail) error = %v", err)
+	}
+}
+
 func TestValueProviderPolicyNameNilSlotsNoPanic(t *testing.T) {
 	s := nilSlotGRPCServer(t)
 	// zone-pair completion path (iterates cfg.Security.Policies)

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -116,12 +116,22 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 	policySetID := uint32(0)
 	var totalPkts, totalBytes uint64
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: skip a nil zone-pair set (tolerant / HA-sync path) while
+		// advancing the policy-set ID, mirroring the runtime walker.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		if (filterFrom != "" && zpp.FromZone != filterFrom) ||
 			(filterTo != "" && zpp.ToZone != filterTo) {
 			policySetID++
 			continue
 		}
 		for i, pol := range zpp.Policies {
+			// #3476: skip a nil rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "permit"
 			switch pol.Action {
 			case 1:
@@ -235,6 +245,12 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 	var readErr error
 	policySetID := uint32(0)
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: skip a nil zone-pair set (tolerant / HA-sync path) while
+		// advancing the policy-set ID, mirroring the runtime walker.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		if (filterFrom != "" && zpp.FromZone != filterFrom) ||
 			(filterTo != "" && zpp.ToZone != filterTo) {
 			policySetID++
@@ -242,6 +258,10 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 		}
 		fmt.Fprintf(buf, "Policy: %s -> %s, State: enabled\n", zpp.FromZone, zpp.ToZone)
 		for i, pol := range zpp.Policies {
+			// #3476: skip a nil rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "permit"
 			switch pol.Action {
 			case 1:
@@ -301,6 +321,10 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 	if len(cfg.Security.GlobalPolicies) > 0 && filterFrom == "" && filterTo == "" {
 		fmt.Fprintf(buf, "Global policies:\n")
 		for i, pol := range cfg.Security.GlobalPolicies {
+			// #3476: skip a nil global rule like the runtime walker does.
+			if pol == nil {
+				continue
+			}
 			action := "permit"
 			switch pol.Action {
 			case 1:

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -389,7 +389,9 @@ func (s *Server) showScreenIDSOption(req *pb.ShowTextRequest, cfg *config.Config
 		buf.WriteString("No screen profiles configured\n")
 	} else {
 		profile, ok := cfg.Security.Screen[profileName]
-		if !ok {
+		if !ok || profile == nil {
+			// #3476: a present-but-nil profile value (tolerant / HA-sync
+			// path) must not panic on the profile.TCP.* derefs below.
 			fmt.Fprintf(buf, "Screen profile '%s' not found\n", profileName)
 		} else {
 			fmt.Fprintf(buf, "Screen object status:\n\n")
@@ -550,7 +552,9 @@ func (s *Server) showScreenIDSOptionDetail(req *pb.ShowTextRequest, cfg *config.
 		buf.WriteString("No screen profiles configured\n")
 	} else {
 		profile, ok := cfg.Security.Screen[profileName]
-		if !ok {
+		if !ok || profile == nil {
+			// #3476: a present-but-nil profile value must not panic on the
+			// profile.TCP.* derefs below.
 			fmt.Fprintf(buf, "Screen profile '%s' not found\n", profileName)
 		} else {
 			fmt.Fprintf(buf, "Screen object status (detail):\n\n")
@@ -641,6 +645,11 @@ func (s *Server) showScreen(cfg *config.Config, buf *strings.Builder) {
 		sort.Strings(names)
 		for _, name := range names {
 			profile := cfg.Security.Screen[name]
+			// #3476: skip a nil profile map value (tolerant / HA-sync path)
+			// rather than dereferencing profile.TCP.Land below.
+			if profile == nil {
+				continue
+			}
 			fmt.Fprintf(buf, "Screen profile: %s\n", name)
 			if profile.TCP.Land {
 				buf.WriteString("  TCP LAND attack detection: enabled\n")

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -89,11 +89,22 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 	resp := &pb.GetPoliciesResponse{}
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
+		// #3476: skip a nil zone-pair set (tolerant / HA-sync path) while
+		// advancing the policy-set ID, mirroring the runtime walker, rather
+		// than dereferencing zpp.FromZone.
+		if zpp == nil {
+			policySetID++
+			continue
+		}
 		pi := &pb.PolicyInfo{
 			FromZone: zpp.FromZone,
 			ToZone:   zpp.ToZone,
 		}
 		for i, rule := range zpp.Policies {
+			// #3476: skip a nil rule like the runtime walker does.
+			if rule == nil {
+				continue
+			}
 			pr := &pb.PolicyRule{
 				Name:         rule.Name,
 				Description:  rule.Description,
@@ -138,6 +149,11 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			ToZone:   "*",
 		}
 		for i, rule := range cfg.Security.GlobalPolicies {
+			// #3476: skip a nil global rule (GlobalPolicies is []*Policy)
+			// like the runtime walker does.
+			if rule == nil {
+				continue
+			}
 			pr := &pb.PolicyRule{
 				Name:         rule.Name,
 				Description:  rule.Description,

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -84,6 +84,12 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 		// Policies referencing this zone
 		var policyRefs []string
 		for _, zpp := range cfg.Security.Policies {
+			// #3476: skip a nil zone-pair set (tolerant / HA-sync config
+			// path the runtime walker skips) rather than dereferencing
+			// zpp.FromZone.
+			if zpp == nil {
+				continue
+			}
 			if zpp.FromZone == name || zpp.ToZone == name {
 				dir := "from"
 				peer := zpp.ToZone
@@ -119,7 +125,9 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 		}
 		// Screen profile detail
 		if zone.ScreenProfile != "" {
-			if profile, ok := cfg.Security.Screen[zone.ScreenProfile]; ok {
+			// #3476: a present-but-nil screen-profile map value (tolerant /
+			// HA-sync config path) must not panic on profile.TCP.Land.
+			if profile, ok := cfg.Security.Screen[zone.ScreenProfile]; ok && profile != nil {
 				fmt.Fprintf(buf, "  Screen profile details (%s):\n", zone.ScreenProfile)
 				var checks []string
 				if profile.TCP.Land {
@@ -167,8 +175,18 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 		buf.WriteString("  Policy summary:\n")
 		totalPolicies := 0
 		for _, zpp := range cfg.Security.Policies {
+			// #3476: skip a nil zone-pair set rather than dereferencing
+			// zpp.FromZone.
+			if zpp == nil {
+				continue
+			}
 			if zpp.FromZone == name || zpp.ToZone == name {
 				for _, pol := range zpp.Policies {
+					// #3476: skip a nil rule rather than dereferencing
+					// pol.Action / pol.Name.
+					if pol == nil {
+						continue
+					}
 					action := "permit"
 					switch pol.Action {
 					case 1:


### PR DESCRIPTION
Closes #3476

## What
Add nil guards at every policy/screen inventory/render/metrics/completion deref site so a nil policy, nil zone-pair set, nil rule, or nil screen-profile renders as empty/absent instead of panicking. This is the display-side sibling of #3474: the userspace runtime walkers (`pkg/dataplane/userspace/policies.go` `walkPolicyRuleSlots`, `screens.go`) are nil-tolerant, but the operator-facing surfaces re-implemented partial loops that dropped the guards.

## Why
`SecurityConfig` makes the nils representable (`Policies []*ZonePairPolicies`, `GlobalPolicies []*Policy`, `ZonePairPolicies.Policies []*Policy`, `Screen map[string]*ScreenProfile`). The strict compiler never emits them, but the tolerant / HA-sync config path can — the reachability premise #3474 established. On master only some `GlobalPolicies` loops were guarded; zone-pair set loops, inner rule loops, and screen-map-value derefs were not, and the local CLI guarded nothing. A nil slot the runtime enforces around turned `show security policies`, `/metrics`, `GetPolicies`/`GetScreen`, the gRPC/CLI text views, and policy-name tab-completion into a panic / HTTP 500 / crashed scrape. Notably `screenChecks(nil)` dereferenced `p.TCP.SynFlood`.

The fix mirrors the runtime walker exactly: `if zpp == nil { policySetID++; continue }` and `if pol == nil { continue }`, plus `screenChecks(nil) == nil` (both copies) and present-but-nil screen-profile map lookups treated as "not found".

### Surfaces guarded
- REST `policiesHandler` + `screenChecks` (`pkg/api/security.go`)
- Prometheus `collectPolicyCounters` (`pkg/api/metrics_counters.go`)
- gRPC `GetPolicies`/`GetScreen` (`server_show_zones.go`) + `screenChecks` (`server_helpers.go`) + text hit-count/detail (`server_show_policies_text.go`) + text screen + per-profile ids-option/detail (`server_show_security_text.go`) + policy-name completion (`server_cluster.go`)
- Local CLI hit-count/detail (`cli_show_security.go`) + brief/detail dispatch (`cli_show_security_dispatch.go`) + screen views (`cli_show_security_screen.go`) + policy-name completion (`completion.go`)

Output is byte-identical for every config the strict compiler can produce; a nil slot now renders absent rather than crashing.

## Validation
- New RED-on-revert tests in `pkg/api`, `pkg/grpcapi`, `pkg/cli`: a shared fixture injects a nil zone-pair set, nil zone-pair rule, nil global rule, and nil screen-profile map value into the live `ActiveConfig` (post-commit, since the compiler normalizes them away), then drives each surface — REST, gRPC structured + text, CLI text, Prometheus scrape, and both completion paths. **Verified that reverting any guard makes the matching test panic** (RED across all three packages); restored guards → all green.
- `go build ./...` clean.
- `go test ./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/... ./pkg/cmdtree/... -count=1` all pass.

No doc change: the operator contract is unchanged (identical output for all compiler-producible configs); this only aligns display robustness with the already-documented runtime nil tolerance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi