### PR TITLE
daemon lo0 nft: emit icmp-code predicate independent of icmp-type (#3483)

### DIFF
--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -349,6 +349,21 @@ never lock an operator out of a remote box it manages.
   load path — #1960 no-brick). Pinned by `TestNftRuleFromTermAddressSemantics3433`,
   `TestNftRuleFromTermWrongFamilyMatchesNothing`, and (config side)
   `firewall_address_literal_3433_test.go`.
+
+  **ICMP type/code lowering mirrors userspace (#3483):** `nftRuleFromTerm`
+  renders `icmp-type` and `icmp-code` as INDEPENDENT predicates, each gated
+  only on its own value list — `icmp[v6] type <set>` when `len(ICMPTypes) > 0`
+  and `icmp[v6] code <set>` when `len(ICMPCodes) > 0` (family selects `icmp`
+  vs `icmpv6`). This matches both userspace projections: `filters.go` emits
+  `ICMPCodes` gated only on `len > 0`, and the Rust matcher tests
+  `icmp_code_match_enabled` in a block separate from `icmp_type_match_enabled`.
+  The pre-fix nft mirror nested the code predicate inside
+  `if len(term.ICMPTypes) > 0`, so a code-only term (`from protocol icmp
+  icmp-code 4 then discard`, no `icmp-type`) dropped the code match on the
+  kernel lo0 path — the kernel mirror then matched BROADER than userspace (a
+  `discard` dropped ALL ICMP fail-closed-over-broad, an `accept` admitted ALL
+  ICMP fail-open). Pinned by `TestNftRuleFromTermICMPCodeOnly` (v4 + v6 +
+  multi-value, code-only) and `TestNftRuleFromTermICMPTypeCode`.
 - host-inbound-traffic (`security zones <z> host-inbound-traffic`) is the
   PRIMARY kernel enforcement for host-bound traffic to a firewall interface IP
   / VRRP VIP (SSH, ping, OSPF/BGP to the box — #3070). Such traffic is shunted

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -723,12 +723,28 @@ func nftRuleFromTerm(term *config.FirewallFilterTerm, family string, prefixLists
 	}
 
 	// ICMP type/code matching (#2545: multi-value).
-	if len(term.ICMPTypes) > 0 {
+	//
+	// #3483: emit the `icmp code` predicate WHENEVER a code is configured,
+	// independent of whether a type is also set. The userspace projections
+	// enforce the code criterion on its own — pkg/dataplane/userspace/filters.go
+	// emits ICMPCodes gated only on len(term.ICMPCodes) > 0, and the Rust matcher
+	// (userspace-dp/src/filter/engine/matching.rs) tests icmp_code_match_enabled
+	// in a block separate from icmp_type_match_enabled. The pre-fix nft mirror
+	// nested the code predicate under `if len(term.ICMPTypes) > 0`, so a
+	// code-only term (`from protocol icmp icmp-code 4 then discard`, no
+	// icmp-type) dropped the code match entirely on the kernel lo0 path. That
+	// made the kernel mirror match BROADER than userspace: a `discard` term
+	// dropped ALL ICMP (fail-closed over-broad), an `accept` term admitted ALL
+	// ICMP (fail-open). Render type and code as independent predicates so a
+	// code-only term matches the same packets in nft as in userspace.
+	if len(term.ICMPTypes) > 0 || len(term.ICMPCodes) > 0 {
 		icmpFamily := "icmp"
 		if family == "ip6" {
 			icmpFamily = "icmpv6"
 		}
-		parts = append(parts, icmpFamily+" type "+nftIntSet(term.ICMPTypes))
+		if len(term.ICMPTypes) > 0 {
+			parts = append(parts, icmpFamily+" type "+nftIntSet(term.ICMPTypes))
+		}
 		if len(term.ICMPCodes) > 0 {
 			parts = append(parts, icmpFamily+" code "+nftIntSet(term.ICMPCodes))
 		}

--- a/pkg/daemon/lo0_filter_test.go
+++ b/pkg/daemon/lo0_filter_test.go
@@ -531,6 +531,64 @@ func TestNftRuleFromTermICMPTypeCode(t *testing.T) {
 	}
 }
 
+// TestNftRuleFromTermICMPCodeOnly is the #3483 RED-on-revert guard: an lo0
+// term that specifies an `icmp code` but NO `icmp type` MUST still emit the
+// `code` predicate on the kernel-nft mirror, matching the userspace matcher
+// (pkg/dataplane/userspace/filters.go gates ICMPCodes on len > 0; the Rust
+// matcher's icmp_code_match_enabled is a block separate from
+// icmp_type_match_enabled). Before #3483 the code predicate was nested under
+// `if len(term.ICMPTypes) > 0`, so a code-only discard term dropped the code
+// match entirely and matched ALL ICMP (over-broad / fail-open vs userspace).
+// Reverting the fix (re-nesting code under the type guard) drops the predicate
+// and fails this test in both families.
+func TestNftRuleFromTermICMPCodeOnly(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+
+	// IPv4: code-only, no type. nft must still constrain on the code.
+	v4 := &config.FirewallFilterTerm{
+		Name:      "drop-icmp-code4",
+		Protocols: []string{"icmp"},
+		ICMPCodes: []int{4},
+		Action:    "discard",
+	}
+	ruleV4 := nftRuleFromTerm(v4, "ip", prefixLists)
+	wantV4 := "meta l4proto icmp icmp code 4 drop"
+	if ruleV4 != wantV4 {
+		t.Errorf("v4 code-only:\n  got:  %s\n  want: %s", ruleV4, wantV4)
+	}
+	if !strings.Contains(ruleV4, "icmp code 4") {
+		t.Errorf("v4 code-only rule dropped the code predicate (the #3483 bug): %q", ruleV4)
+	}
+
+	// IPv6: code-only, no type. icmpv6 family, code still emitted.
+	v6 := &config.FirewallFilterTerm{
+		Name:      "drop-icmpv6-code1",
+		Protocols: []string{"icmpv6"},
+		ICMPCodes: []int{1},
+		Action:    "discard",
+	}
+	ruleV6 := nftRuleFromTerm(v6, "ip6", prefixLists)
+	wantV6 := "meta l4proto icmpv6 icmpv6 code 1 drop"
+	if ruleV6 != wantV6 {
+		t.Errorf("v6 code-only:\n  got:  %s\n  want: %s", ruleV6, wantV6)
+	}
+	if !strings.Contains(ruleV6, "icmpv6 code 1") {
+		t.Errorf("v6 code-only rule dropped the code predicate (the #3483 bug): %q", ruleV6)
+	}
+
+	// Multi-value code-only (no type) renders an nft set.
+	multi := &config.FirewallFilterTerm{
+		Name:      "drop-icmp-codes",
+		ICMPCodes: []int{0, 4},
+		Action:    "discard",
+	}
+	ruleMulti := nftRuleFromTerm(multi, "ip", prefixLists)
+	wantMulti := "icmp code { 0, 4 } drop"
+	if ruleMulti != wantMulti {
+		t.Errorf("multi code-only:\n  got:  %s\n  want: %s", ruleMulti, wantMulti)
+	}
+}
+
 func TestNftRuleFromTermDSCP(t *testing.T) {
 	prefixLists := map[string]*config.PrefixList{}
 


### PR DESCRIPTION
## What

The lo0 kernel-nft mirror (`nftRuleFromTerm` in `pkg/daemon/daemon_nft.go`)
nested the `icmp code` predicate inside `if len(term.ICMPTypes) > 0`, so a
firewall-filter term that specifies an `icmp-code` but NO `icmp-type` dropped
the code match entirely on the kernel control-plane path. This change renders
`icmp[v6] type` and `icmp[v6] code` as INDEPENDENT predicates, each gated only
on its own value list.

## Why — verified divergence direction (origin/master cf718ff01)

Both userspace projections enforce the code criterion on its own:

- `pkg/dataplane/userspace/filters.go` emits `ICMPCodes` gated only on
  `len(term.ICMPCodes) > 0`.
- The Rust matcher `userspace-dp/src/filter/engine/matching.rs` tests
  `icmp_code_match_enabled` in a block separate from `icmp_type_match_enabled`.
- The compiler `pkg/config/compiler_firewall.go` records `icmp-code`
  independently of `icmp-type`.

The nft mirror DROPPED the code constraint, so the kernel matched **broader**
than userspace: a code-only `discard` term dropped **ALL** ICMP (fail-closed,
over-broad) and a code-only `accept` term admitted **ALL** ICMP (fail-open),
relative to the sole runtime dataplane.

## Validation

- **RED-on-revert:** `TestNftRuleFromTermICMPCodeOnly` (v4 + v6 + multi-value,
  code-only). Re-nesting the code predicate under the type guard renders
  `meta l4proto icmp drop` (no code match) and fails the test. Confirmed: the
  reverted code produces `got: meta l4proto icmp drop` / `want: ... icmp code 4 drop`.
- `go build ./...` green.
- `go test ./pkg/daemon/... ./pkg/dataplane/userspace/... -count=1` all green.
- `gofmt -w` on touched files.
- Docs: `pkg/daemon/README.md` records the independent ICMP type/code lowering
  contract alongside the #3433 address-lowering note.

Closes #3483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi