### PR TITLE
daemon: guard buildZoneRGMap against nil zone values (#3492)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23162,3 +23162,8 @@ top.
 - **Timestamp**: 2026-06-28
 - **Action**: Fold reviewer-found siblings (Codex MAJOR flowexport.BuildSamplingZones nil-zone; SMR buildZoneRGMap (nil,true) ifc + rgHasRETH nil ifc) + broad apply-path sweep guarding every nil zone/interface VALUE deref; add 3 RED-on-revert tests
 - **File(s)**: pkg/flowexport/manager.go, pkg/flowexport/exporter_test.go, pkg/daemon/{daemon_ha_userspace,daemon_ha_vip,daemon_apply,daemon_ipmon,daemon_ha,daemon_ra,daemon_system,daemon_run,daemon_ddns,daemon_ha_fabric}.go, pkg/daemon/per_rg_test.go
+
+## 2026-06-28 — fix/3492 close flowexport ifCfg==nil test-coverage gap
+- **Timestamp**: 2026-06-28
+- **Action**: trust zone in TestBuildSamplingZonesSkipsNilZone now references the nil interface (nilif.0) so the BuildSamplingZones `ifCfg == nil` comma-ok clause is RED-on-revert (was only zone==nil covered)
+- **File(s)**: pkg/flowexport/exporter_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -23153,3 +23153,7 @@ top.
   pkg/dataplane/userspace/nat_l4_match_3429_test.go, userspace-dp/src/protocol/nat.rs,
   userspace-dp/src/nat/source.rs, userspace-dp/src/nat/tests.rs,
   docs/services-application-identification.md
+## 2026-06-28 — fix/3492 buildZoneRGMap nil-zone guard
+- **Timestamp**: 2026-06-28
+- **Action**: Add `zone == nil` guard in buildZoneRGMap (per-RG session-sync apply path); add RED-on-revert TestBuildZoneRGMapSkipsNilZones
+- **File(s)**: pkg/daemon/daemon_ha_userspace.go, pkg/daemon/per_rg_test.go

--- a/_Log.md
+++ b/_Log.md
@@ -23157,3 +23157,8 @@ top.
 - **Timestamp**: 2026-06-28
 - **Action**: Add `zone == nil` guard in buildZoneRGMap (per-RG session-sync apply path); add RED-on-revert TestBuildZoneRGMapSkipsNilZones
 - **File(s)**: pkg/daemon/daemon_ha_userspace.go, pkg/daemon/per_rg_test.go
+
+## 2026-06-28 — fix/3492 broadened apply-path nil-zone/nil-interface sweep
+- **Timestamp**: 2026-06-28
+- **Action**: Fold reviewer-found siblings (Codex MAJOR flowexport.BuildSamplingZones nil-zone; SMR buildZoneRGMap (nil,true) ifc + rgHasRETH nil ifc) + broad apply-path sweep guarding every nil zone/interface VALUE deref; add 3 RED-on-revert tests
+- **File(s)**: pkg/flowexport/manager.go, pkg/flowexport/exporter_test.go, pkg/daemon/{daemon_ha_userspace,daemon_ha_vip,daemon_apply,daemon_ipmon,daemon_ha,daemon_ra,daemon_system,daemon_run,daemon_ddns,daemon_ha_fabric}.go, pkg/daemon/per_rg_test.go

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -577,6 +577,9 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	if d.routing != nil {
 		var bondIfaces []*config.InterfaceConfig
 		for _, ifc := range cfg.Interfaces.Interfaces {
+			if ifc == nil {
+				continue
+			}
 			if len(ifc.FabricMembers) > 0 {
 				bondIfaces = append(bondIfaces, ifc)
 			}
@@ -612,7 +615,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	var deferredOverlays []deferredIPVLAN
 	bindingCtrl, isUserspaceDP := d.dp.(userspaceXSKBindingController)
 	for ifName, ifCfg := range cfg.Interfaces.Interfaces {
-		if ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
+		if ifCfg == nil || ifCfg.LocalFabricMember == "" || !strings.HasPrefix(ifName, "fab") {
 			continue
 		}
 		parentLinux := config.LinuxIfName(ifCfg.LocalFabricMember)
@@ -704,7 +707,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		cc := cfg.Chassis.Cluster
 		for rethName, physName := range cfg.RethToPhysical() {
 			rethCfg, ok := cfg.Interfaces.Interfaces[rethName]
-			if !ok || rethCfg.RedundancyGroup <= 0 {
+			if !ok || rethCfg == nil || rethCfg.RedundancyGroup <= 0 {
 				continue
 			}
 			linuxName := config.LinuxIfName(physName)
@@ -871,7 +874,7 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 
 		for rethName, physName := range rethToPhys {
 			rethCfg, ok := cfg.Interfaces.Interfaces[rethName]
-			if !ok || rethCfg.RedundancyGroup <= 0 {
+			if !ok || rethCfg == nil || rethCfg.RedundancyGroup <= 0 {
 				continue
 			}
 			linuxName := config.LinuxIfName(physName)

--- a/pkg/daemon/daemon_ddns.go
+++ b/pkg/daemon/daemon_ddns.go
@@ -292,7 +292,7 @@ func rgForInterfaces(cfg *config.Config, ifaces []string) int {
 		if i := strings.IndexByte(base, '.'); i >= 0 {
 			base = base[:i]
 		}
-		if ifc, ok := cfg.Interfaces.Interfaces[base]; ok {
+		if ifc, ok := cfg.Interfaces.Interfaces[base]; ok && ifc != nil {
 			if ifc.RedundancyGroup > 0 {
 				return ifc.RedundancyGroup
 			}

--- a/pkg/daemon/daemon_ha.go
+++ b/pkg/daemon/daemon_ha.go
@@ -782,6 +782,9 @@ func (d *Daemon) reconcileRGState() {
 func rethInterfacesForRG(cfg *config.Config, rgID int) []string {
 	var names []string
 	for name, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
 		if ifc.RedundancyGroup == rgID && strings.HasPrefix(name, "reth") {
 			// Resolve RETH to physical member for Linux-level operations.
 			resolved := config.LinuxIfName(cfg.ResolveReth(name))
@@ -815,6 +818,9 @@ func (d *Daemon) injectBlackholeRoutes(rgID int) {
 
 	var routes []netlink.Route
 	for name, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
 		if ifc.RedundancyGroup != rgID || !strings.HasPrefix(name, "reth") {
 			continue
 		}

--- a/pkg/daemon/daemon_ha_fabric.go
+++ b/pkg/daemon/daemon_ha_fabric.go
@@ -168,7 +168,7 @@ func (d *Daemon) resolveFabricParent(fabName string) string {
 	if cfg == nil {
 		return fabName
 	}
-	if ifCfg, ok := cfg.Interfaces.Interfaces[fabName]; ok && ifCfg.LocalFabricMember != "" {
+	if ifCfg, ok := cfg.Interfaces.Interfaces[fabName]; ok && ifCfg != nil && ifCfg.LocalFabricMember != "" {
 		return config.LinuxIfName(ifCfg.LocalFabricMember)
 	}
 	return fabName

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -447,7 +447,9 @@ func buildZoneRGMap(cfg *config.Config, zoneIDs map[string]uint16) map[uint16]in
 			if idx := strings.IndexByte(ifName, '.'); idx >= 0 {
 				baseName = ifName[:idx]
 			}
-			if ifc, ok := cfg.Interfaces.Interfaces[baseName]; ok && ifc.RedundancyGroup > 0 {
+			// comma-ok checks key-presence, not value-non-nil; a
+			// (nil, true) map entry would panic on ifc.RedundancyGroup.
+			if ifc, ok := cfg.Interfaces.Interfaces[baseName]; ok && ifc != nil && ifc.RedundancyGroup > 0 {
 				if rgSeen >= 0 && rgSeen != ifc.RedundancyGroup {
 					slog.Warn("zone spans multiple redundancy groups; "+
 						"active/active session sync ownership is ambiguous",
@@ -470,6 +472,9 @@ func rgHasRETH(cfg *config.Config, rgID int) bool {
 		return false
 	}
 	for _, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
 		if ifc.RedundancyGroup == rgID {
 			return true
 		}

--- a/pkg/daemon/daemon_ha_userspace.go
+++ b/pkg/daemon/daemon_ha_userspace.go
@@ -428,6 +428,14 @@ func (d *Daemon) shouldSyncUserspaceDelta(delta dpuserspace.SessionDeltaInfo, in
 func buildZoneRGMap(cfg *config.Config, zoneIDs map[string]uint16) map[uint16]int {
 	result := make(map[uint16]int)
 	for zoneName, zone := range cfg.Security.Zones {
+		// Tolerant/programmatic/HA-peer-sync configs can leave a nil
+		// zone value in the map (the established nil-slot invariant the
+		// dataplane SSOT defends, e.g. zones.go's `if zone == nil`).
+		// Skip it here too, otherwise the zone.Interfaces deref below
+		// panics the per-RG session-sync apply path.
+		if zone == nil {
+			continue
+		}
 		zid, ok := zoneIDs[zoneName]
 		if !ok {
 			continue

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -309,7 +309,7 @@ func (d *Daemon) addStableRethLinkLocal(rgID int) {
 	rethToPhys := cfg.RethToPhysical()
 
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
-		if ifc.RedundancyGroup != rgID {
+		if ifc == nil || ifc.RedundancyGroup != rgID {
 			continue
 		}
 		if !strings.HasPrefix(ifName, "reth") {
@@ -373,7 +373,7 @@ func (d *Daemon) removeStableRethLinkLocal(rgID int) {
 	rethToPhys := cfg.RethToPhysical()
 
 	for ifName, ifc := range cfg.Interfaces.Interfaces {
-		if ifc.RedundancyGroup != rgID {
+		if ifc == nil || ifc.RedundancyGroup != rgID {
 			continue
 		}
 		if !strings.HasPrefix(ifName, "reth") {
@@ -591,7 +591,7 @@ func (d *Daemon) directSendGARPs(rgID int) {
 		rethToPhys := cfg.RethToPhysical()
 		seen := make(map[string]bool)
 		for ifName, ifc := range cfg.Interfaces.Interfaces {
-			if ifc.RedundancyGroup != rgID || !strings.HasPrefix(ifName, "reth") {
+			if ifc == nil || ifc.RedundancyGroup != rgID || !strings.HasPrefix(ifName, "reth") {
 				continue
 			}
 			// Use configured link-local if present, otherwise stable LL.

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -91,6 +91,9 @@ func (d *Daemon) assembleFRRConfig(cfg *config.Config, overlay []config.RouteOve
 	ifaceBandwidths := make(map[string]uint64)
 	ifaceP2P := make(map[string]bool)
 	for name, ifc := range cfg.Interfaces.Interfaces {
+		if ifc == nil {
+			continue
+		}
 		linuxName := config.LinuxIfName(name)
 		if ifc.Bandwidth > 0 {
 			ifaceBandwidths[linuxName] = ifc.Bandwidth

--- a/pkg/daemon/daemon_ra.go
+++ b/pkg/daemon/daemon_ra.go
@@ -124,7 +124,7 @@ func (d *Daemon) buildRAConfigs(cfg *config.Config) []*config.RAInterfaceConfig 
 func resolveRASourceLinkLocal(cfg *config.Config, raInterface string) (*config.InterfaceConfig, string) {
 	base, unitTok, hasUnit := strings.Cut(raInterface, ".")
 	ifc, ok := cfg.Interfaces.Interfaces[base]
-	if !ok {
+	if !ok || ifc == nil {
 		return nil, ""
 	}
 	if hasUnit && unitTok != "" {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1900,6 +1900,9 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 	sort.Strings(ifNames)
 	for _, ifName := range ifNames {
 		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
 		base := config.LinuxIfName(ifName)
 		unitNums := make([]int, 0, len(ifc.Units))
 		for unitNum := range ifc.Units {

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -158,7 +158,7 @@ func resolveSourceAddr(cfg *config.Config, srcIface string) string {
 			unitNum = n
 		}
 	}
-	if ifc, ok := cfg.Interfaces.Interfaces[base]; ok {
+	if ifc, ok := cfg.Interfaces.Interfaces[base]; ok && ifc != nil {
 		if unit, ok := ifc.Units[unitNum]; ok && unit.PrimaryAddress != "" {
 			// PrimaryAddress is CIDR — strip the prefix length
 			if ip, _, err := net.ParseCIDR(unit.PrimaryAddress); err == nil {

--- a/pkg/daemon/per_rg_test.go
+++ b/pkg/daemon/per_rg_test.go
@@ -358,6 +358,61 @@ func TestBuildZoneRGMapSkipsNilZones(t *testing.T) {
 	}
 }
 
+// TestBuildZoneRGMapSkipsNilInterfaceValue asserts that a nil interface VALUE
+// in cfg.Interfaces.Interfaces (a `(nil, true)` map entry — the comma-ok in
+// buildZoneRGMap checks key-presence, not value-non-nil) does NOT panic.
+// Reverting the `ifc != nil` clause makes this test panic (RED-on-revert).
+func TestBuildZoneRGMapSkipsNilInterfaceValue(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+				"bad":   {Name: "bad", Interfaces: []string{"reth9.0"}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {Name: "reth0", RedundancyGroup: 1},
+				"reth9": nil, // (nil, true) map entry
+			},
+		},
+	}
+
+	zoneIDs := map[string]uint16{"trust": 2, "bad": 5}
+
+	// Must not panic on the nil "reth9" interface value.
+	m := buildZoneRGMap(cfg, zoneIDs)
+
+	if rg, ok := m[2]; !ok || rg != 1 {
+		t.Errorf("zone 'trust' (ID 2): expected RG 1, got %d (ok=%v)", rg, ok)
+	}
+	if _, ok := m[5]; ok {
+		t.Error("zone 'bad' (ID 5): nil interface value should contribute no RG")
+	}
+}
+
+// TestRgHasRETHSkipsNilInterfaceValue asserts that a nil interface VALUE in
+// cfg.Interfaces.Interfaces does NOT panic rgHasRETH. Reverting the
+// `if ifc == nil { continue }` guard makes this test panic (RED-on-revert).
+func TestRgHasRETHSkipsNilInterfaceValue(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {Name: "reth0", RedundancyGroup: 1},
+				"nilif": nil, // (nil) map value
+			},
+		},
+	}
+
+	// Must not panic on the nil "nilif" interface value.
+	if !rgHasRETH(cfg, 1) {
+		t.Error("rgHasRETH(cfg, 1): expected true (reth0 in RG 1)")
+	}
+	if rgHasRETH(cfg, 2) {
+		t.Error("rgHasRETH(cfg, 2): expected false (no interface in RG 2)")
+	}
+}
+
 func TestBuildZoneRGMapEmptyConfig(t *testing.T) {
 	cfg := &config.Config{}
 	m := buildZoneRGMap(cfg, nil)

--- a/pkg/daemon/per_rg_test.go
+++ b/pkg/daemon/per_rg_test.go
@@ -318,6 +318,46 @@ func TestBuildZoneRGMap(t *testing.T) {
 	}
 }
 
+// TestBuildZoneRGMapSkipsNilZones asserts that a nil zone value in
+// cfg.Security.Zones (reachable on the tolerant/programmatic/HA-peer-sync
+// config path, the same nil-slot invariant the dataplane SSOT defends) does
+// NOT panic the per-RG session-sync apply path. Reverting the `zone == nil`
+// guard in buildZoneRGMap makes this test panic (RED-on-revert).
+func TestBuildZoneRGMapSkipsNilZones(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"trust": {Name: "trust", Interfaces: []string{"reth0.0"}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0": {Name: "reth0", RedundancyGroup: 1},
+			},
+		},
+	}
+	// Inject a nil zone slot post-construction, mirroring the reachable
+	// nil-slot invariant exercised by the other nil-safety tests.
+	cfg.Security.Zones["bogus"] = nil
+
+	zoneIDs := map[string]uint16{
+		"trust": 2,
+		"bogus": 9,
+	}
+
+	// Must not panic on the nil "bogus" zone.
+	m := buildZoneRGMap(cfg, zoneIDs)
+
+	// The healthy zone is still mapped: trust (zone 2) → reth0 → RG 1.
+	if rg, ok := m[2]; !ok || rg != 1 {
+		t.Errorf("zone 'trust' (ID 2): expected RG 1, got %d (ok=%v)", rg, ok)
+	}
+	// The nil zone contributes nothing.
+	if _, ok := m[9]; ok {
+		t.Error("nil zone 'bogus' (ID 9): should not be in zone RG map")
+	}
+}
+
 func TestBuildZoneRGMapEmptyConfig(t *testing.T) {
 	cfg := &config.Config{}
 	m := buildZoneRGMap(cfg, nil)

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -109,6 +109,46 @@ func TestBuildSamplingZones(t *testing.T) {
 	}
 }
 
+// TestBuildSamplingZonesSkipsNilZone is the fail-on-revert guard for the
+// #3492 apply-path nil-zone crash class: a nil zone value (reachable on the
+// tolerant/programmatic/HA-peer-sync config path) must be skipped, not
+// dereferenced. Reverting the `if zone == nil` guard in BuildSamplingZones
+// makes this test panic.
+func TestBuildSamplingZonesSkipsNilZone(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"trust": {Interfaces: []string{"eth0.0"}},
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"eth0": {Units: map[int]*config.InterfaceUnit{
+					0: {SamplingInput: true},
+				}},
+			},
+		},
+	}
+	// Inject a nil zone slot and a nil interface value post-construction,
+	// mirroring the reachable nil-slot invariant.
+	cfg.Security.Zones["bogus"] = nil
+	cfg.Interfaces.Interfaces["nilif"] = nil
+
+	zoneIDs := map[string]uint16{"trust": 2, "bogus": 9}
+
+	// Must not panic on the nil "bogus" zone or nil interface value.
+	sz := BuildSamplingZones(cfg, zoneIDs)
+
+	// The healthy zone is still mapped.
+	if d, ok := sz[2]; !ok || !d.Input {
+		t.Errorf("trust zone (id=2): want Input=true, got %+v (ok=%v)", sz[2], ok)
+	}
+	// The nil zone contributes nothing.
+	if _, ok := sz[9]; ok {
+		t.Errorf("nil zone (id=9) should not be in sampling map, got %+v", sz[9])
+	}
+}
+
 func TestShouldExport(t *testing.T) {
 	ec := &ExportConfig{
 		SamplingZones: map[uint16]SamplingDir{

--- a/pkg/flowexport/exporter_test.go
+++ b/pkg/flowexport/exporter_test.go
@@ -118,7 +118,10 @@ func TestBuildSamplingZonesSkipsNilZone(t *testing.T) {
 	cfg := &config.Config{
 		Security: config.SecurityConfig{
 			Zones: map[string]*config.ZoneConfig{
-				"trust": {Interfaces: []string{"eth0.0"}},
+				// trust references BOTH a healthy interface (eth0.0) AND a
+				// nil-valued interface (nilif.0) so the inner
+				// `ifCfg == nil` clause is exercised on the apply path.
+				"trust": {Interfaces: []string{"eth0.0", "nilif.0"}},
 			},
 		},
 		Interfaces: config.InterfacesConfig{
@@ -130,7 +133,9 @@ func TestBuildSamplingZonesSkipsNilZone(t *testing.T) {
 		},
 	}
 	// Inject a nil zone slot and a nil interface value post-construction,
-	// mirroring the reachable nil-slot invariant.
+	// mirroring the reachable nil-slot invariant. "nilif" is a (nil) value
+	// referenced by the trust zone above, so BuildSamplingZones reaches the
+	// `if !ok || ifCfg == nil` comma-ok clause for it.
 	cfg.Security.Zones["bogus"] = nil
 	cfg.Interfaces.Interfaces["nilif"] = nil
 

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -539,6 +539,13 @@ func BuildIPFIXExportConfig(svc *config.ServicesConfig, fo *config.ForwardingOpt
 func BuildSamplingZones(cfg *config.Config, zoneIDs map[string]uint16) map[uint16]SamplingDir {
 	result := make(map[uint16]SamplingDir)
 	for zoneName, zone := range cfg.Security.Zones {
+		// A nil zone value is reachable on the tolerant/programmatic/
+		// HA-peer-sync config path (the same nil-slot invariant the
+		// dataplane SSOT defends). Skip it, otherwise the zone.Interfaces
+		// deref below panics the flow-export apply path (#3492).
+		if zone == nil {
+			continue
+		}
 		zid, ok := zoneIDs[zoneName]
 		if !ok {
 			continue
@@ -556,7 +563,9 @@ func BuildSamplingZones(cfg *config.Config, zoneIDs map[string]uint16) map[uint1
 				continue
 			}
 			ifCfg, ok := cfg.Interfaces.Interfaces[physName]
-			if !ok {
+			if !ok || ifCfg == nil {
+				// comma-ok checks key-presence, not value-non-nil; a
+				// (nil, true) entry would panic on ifCfg.Units below.
 				continue
 			}
 			unit, ok := ifCfg.Units[unitNum]


### PR DESCRIPTION
Closes #3492

## What
Guard the config-apply path against nil zone values AND nil/`(nil, true)`
interface map entries — the established nil-slot invariant (reachable on the
tolerant/programmatic/HA-peer-sync config path) the dataplane SSOT already
defends (`pkg/dataplane/userspace/zones.go`). Sibling of the display-side
#3476 and counter-resolver #3474.

Initial fix guarded only `buildZoneRGMap`'s zone deref. Code review (Codex
MAJOR + SMR) found genuine sibling nil-deref panics on the SAME apply-path
crash class; this PR folds them all plus a broad sweep.

## Guards added
**Reviewer-named siblings:**
- `flowexport.BuildSamplingZones` — `if zone == nil` after the range +
  `ifCfg == nil` on the interface comma-ok (Units deref).
- `buildZoneRGMap` — `ifc != nil` on the interface comma-ok (the comma-ok
  checks key-presence, not value-non-nil; `(nil, true)` panics).
- `rgHasRETH` — `if ifc == nil { continue }`.

**Broader apply-path sweep** (every nil zone/interface VALUE deref without a
check, incl. comma-ok-without-nil):
- `daemon_ha_vip.go` (3 RETH loops), `daemon_apply.go` (fabric-member bond,
  local-fabric-member, 2 reth comma-ok), `daemon_ipmon.go` (bandwidth),
  `daemon_ha.go` (2 RETH loops), `daemon_ra.go`, `daemon_system.go`,
  `daemon_run.go`, `daemon_ddns.go`, `daemon_ha_fabric.go`.

**Already-guarded, left untouched (verified):** dataplane/userspace
interfaces.go:177/191, zones.go:210/358/382, neighbors.go, manager_ha.go:1239,
format/cos.go:510, fabric.go:34; daemon_run.go:136, daemon_neighbor.go,
daemon_dhcp.go, daemon_ddns_surface_a.go, daemon_rpm.go,
daemon_ha_userspace.go:1061, daemon_system.go:52.

All guards are defensive skips: no behavior change for valid configs, no
failover-logic change.

## Why
`buildZoneRGMap` (and `BuildSamplingZones`) run in the apply path
(`SetZoneRGMap(buildZoneRGMap(...))` during `ApplyConfig`; flow-export
`buildZoneIDs`→`BuildSamplingZones`). A single nil zone slot or nil interface
value turned a config refresh into a **daemon panic** BEFORE session-sync
ownership could update — an HA availability regression, higher severity than
display fragility.

## Validation
- `gofmt -w` on touched files
- `go build ./...` — green
- `go test ./pkg/daemon/... ./pkg/flowexport/... -count=1` — all pass
- **RED-on-revert** (3 tests): `TestBuildZoneRGMapSkipsNilZones`,
  `TestBuildZoneRGMapSkipsNilInterfaceValue`, `TestRgHasRETHSkipsNilInterfaceValue`
  (daemon) + `TestBuildSamplingZonesSkipsNilZone` (flowexport). Reverting each
  corresponding guard makes the test panic (nil pointer deref); with the guard
  it passes.

## HA note
Touches the per-RG session-sync / HA-VIP apply path, but every change is a
defensive nil guard with no failover-logic change, so `make test-failover` is
likely not required — flagged for the reviewer to decide.

## Docs
No docs change warranted: the nil-slot invariant is the established contract
already documented at the SSOT (`zones.go`) and siblings #3474/#3476; the HA
zone→RG-map design doc (`docs/next-features/ha-session-ownership-and-fabric-failover.md`)
describes a separate larger refactor, not nil-safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi