### PR TITLE
api: surface zone description/tcp-rst + policy description in REST (#3329)

### DIFF
--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -32,8 +32,10 @@ func (s *Server) zonesHandler(w http.ResponseWriter, _ *http.Request) {
 			continue
 		}
 		zi := ZoneInfo{
-			Name:       zoneName,
-			Interfaces: zone.Interfaces,
+			Name:        zoneName,
+			Description: zone.Description,
+			TcpRst:      zone.TCPRst,
+			Interfaces:  zone.Interfaces,
 		}
 		if zone.ScreenProfile != "" {
 			zi.ScreenProfile = zone.ScreenProfile
@@ -121,6 +123,7 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 			}
 			pr := PolicyRule{
 				Name:         rule.Name,
+				Description:  rule.Description,
 				Action:       policyActionStr(rule.Action),
 				SrcAddresses: rule.Match.SourceAddresses,
 				DstAddresses: rule.Match.DestinationAddresses,
@@ -175,6 +178,7 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 			}
 			pr := PolicyRule{
 				Name:         rule.Name,
+				Description:  rule.Description,
 				Action:       policyActionStr(rule.Action),
 				SrcAddresses: rule.Match.SourceAddresses,
 				DstAddresses: rule.Match.DestinationAddresses,

--- a/pkg/api/security_zone_policy_meta_3329_test.go
+++ b/pkg/api/security_zone_policy_meta_3329_test.go
@@ -43,6 +43,13 @@ security {
                 then { permit; }
             }
         }
+        global {
+            policy global-audit {
+                description "global owner=secops ticket=JIRA-99";
+                match { source-address any; destination-address any; application any; }
+                then { deny; }
+            }
+        }
     }
 }
 `); err != nil {
@@ -155,20 +162,39 @@ func TestPoliciesHandlerExposesDescription(t *testing.T) {
 		t.Fatalf("success = false; body: %s", rr.Body.String())
 	}
 
-	var saw bool
+	// Cover BOTH projection sites in security.go: the zone-pair policy loop
+	// AND the global policy loop. Each Description population line is its own
+	// RED-on-revert target — deleting either must fail this test.
+	var sawZonePair, sawGlobal bool
 	for _, policy := range resp.Data {
 		for _, rule := range policy.Rules {
-			if rule.Name != "allow-web" {
-				continue
-			}
-			saw = true
-			if rule.Description != "break-glass exception, decommission 2026-12" {
-				t.Fatalf("allow-web description = %q, want %q (REST dropped policy description — #3329 regression); body: %s",
-					rule.Description, "break-glass exception, decommission 2026-12", rr.Body.String())
+			switch rule.Name {
+			case "allow-web":
+				sawZonePair = true
+				if policy.FromZone != "trust" || policy.ToZone != "untrust" {
+					t.Fatalf("allow-web grouped under %q/%q, want trust/untrust", policy.FromZone, policy.ToZone)
+				}
+				if rule.Description != "break-glass exception, decommission 2026-12" {
+					t.Fatalf("allow-web description = %q, want %q (REST dropped zone-pair policy description — #3329 regression); body: %s",
+						rule.Description, "break-glass exception, decommission 2026-12", rr.Body.String())
+				}
+			case "global-audit":
+				sawGlobal = true
+				// Globals stay grouped under the all-zones "*"/"*" PolicyInfo.
+				if policy.FromZone != "*" || policy.ToZone != "*" {
+					t.Fatalf("global-audit grouped under %q/%q, want */* (global group)", policy.FromZone, policy.ToZone)
+				}
+				if rule.Description != "global owner=secops ticket=JIRA-99" {
+					t.Fatalf("global-audit description = %q, want %q (REST dropped global policy description — #3329 regression); body: %s",
+						rule.Description, "global owner=secops ticket=JIRA-99", rr.Body.String())
+				}
 			}
 		}
 	}
-	if !saw {
-		t.Fatalf("allow-web policy missing from REST inventory; body: %s", rr.Body.String())
+	if !sawZonePair {
+		t.Fatalf("allow-web (zone-pair) policy missing from REST inventory; body: %s", rr.Body.String())
+	}
+	if !sawGlobal {
+		t.Fatalf("global-audit (global) policy missing from REST inventory; body: %s", rr.Body.String())
 	}
 }

--- a/pkg/api/security_zone_policy_meta_3329_test.go
+++ b/pkg/api/security_zone_policy_meta_3329_test.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3329: the REST security inventory dropped zone `description`, zone
+// `tcp-rst`, and policy `description` that gRPC GetZones/GetPolicies already
+// expose from the same config. The two structured APIs disagreed on the
+// firewall's posture/audit view. ZoneInfo now carries Description + TcpRst and
+// PolicyRule now carries Description. These are the fail-on-revert guards:
+// drop the population in security.go (zonesHandler / policiesHandler) and the
+// assertions below go RED.
+
+// zonePolicyMetaAPIStore builds a config where one zone sets a description and
+// tcp-rst, a second zone sets neither, and a policy carries a description.
+func zonePolicyMetaAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            description "owner=neteng ticket=JIRA-42";
+            tcp-rst;
+        }
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy allow-web {
+                description "break-glass exception, decommission 2026-12";
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestZonesHandlerExposesDescriptionAndTCPRst is the #3329 fail-on-revert guard
+// for the zone projection: REST must surface a zone's description + tcp-rst and
+// omit them for a zone that sets neither.
+func TestZonesHandlerExposesDescriptionAndTCPRst(t *testing.T) {
+	s := &Server{store: zonePolicyMetaAPIStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/zones", nil)
+	s.zonesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool       `json:"success"`
+		Data    []ZoneInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	var sawTrust, sawUntrust bool
+	for _, z := range resp.Data {
+		switch z.Name {
+		case "trust":
+			sawTrust = true
+			if z.Description != "owner=neteng ticket=JIRA-42" {
+				t.Fatalf("trust description = %q, want %q (REST dropped zone description — #3329 regression); body: %s",
+					z.Description, "owner=neteng ticket=JIRA-42", rr.Body.String())
+			}
+			if !z.TcpRst {
+				t.Fatalf("trust tcp_rst = false, want true (REST dropped zone tcp-rst — #3329 regression); body: %s",
+					rr.Body.String())
+			}
+		case "untrust":
+			sawUntrust = true
+			if z.Description != "" {
+				t.Fatalf("untrust description = %q, want empty (no description configured)", z.Description)
+			}
+			if z.TcpRst {
+				t.Fatalf("untrust tcp_rst = true, want false (no tcp-rst configured)")
+			}
+		}
+	}
+	if !sawTrust {
+		t.Fatalf("trust zone missing from REST inventory; body: %s", rr.Body.String())
+	}
+	if !sawUntrust {
+		t.Fatalf("untrust zone missing from REST inventory; body: %s", rr.Body.String())
+	}
+
+	// The tcp_rst / description JSON keys must be ABSENT for the unset zone so
+	// existing consumers see no behavior change for configs that don't set
+	// them (omitempty contract).
+	var raw struct {
+		Data []map[string]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw response: %v", err)
+	}
+	for _, z := range raw.Data {
+		name := ""
+		_ = json.Unmarshal(z["name"], &name)
+		if name != "untrust" {
+			continue
+		}
+		if _, ok := z["tcp_rst"]; ok {
+			t.Fatalf("untrust zone serialized a tcp_rst key for an unset zone; want omitted")
+		}
+		if _, ok := z["description"]; ok {
+			t.Fatalf("untrust zone serialized a description key for an unset zone; want omitted")
+		}
+	}
+}
+
+// TestPoliciesHandlerExposesDescription is the #3329 fail-on-revert guard for
+// the policy projection: REST must surface a policy's description.
+func TestPoliciesHandlerExposesDescription(t *testing.T) {
+	s := &Server{store: zonePolicyMetaAPIStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	var saw bool
+	for _, policy := range resp.Data {
+		for _, rule := range policy.Rules {
+			if rule.Name != "allow-web" {
+				continue
+			}
+			saw = true
+			if rule.Description != "break-glass exception, decommission 2026-12" {
+				t.Fatalf("allow-web description = %q, want %q (REST dropped policy description — #3329 regression); body: %s",
+					rule.Description, "break-glass exception, decommission 2026-12", rr.Body.String())
+			}
+		}
+	}
+	if !saw {
+		t.Fatalf("allow-web policy missing from REST inventory; body: %s", rr.Body.String())
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -50,8 +50,18 @@ type InterfaceStats struct {
 
 // ZoneInfo holds zone configuration and counter data.
 type ZoneInfo struct {
-	Name           string   `json:"name"`
-	ID             uint16   `json:"id"`
+	Name string `json:"name"`
+	ID   uint16 `json:"id"`
+	// Description carries the zone's `description` sub-stanza (#3329). gRPC
+	// GetZones already exposes it; REST omits it when unset (no behavior
+	// change for zones without a description). Security audits routinely use
+	// the description to carry intent/owner/ticket metadata.
+	Description string `json:"description,omitempty"`
+	// TcpRst mirrors gRPC GetZones (#3329): when `set security zones
+	// security-zone <z> tcp-rst` is configured the zone sends a TCP RST for
+	// non-SYN packets to closed ports, changing client-visible deny
+	// behaviour. Omitted (false) for zones without it.
+	TcpRst         bool     `json:"tcp_rst,omitempty"`
 	ScreenProfile  string   `json:"screen_profile,omitempty"`
 	Interfaces     []string `json:"interfaces"`
 	HostInbound    []string `json:"host_inbound_services"`
@@ -70,7 +80,12 @@ type PolicyInfo struct {
 
 // PolicyRule holds a single policy rule with counters.
 type PolicyRule struct {
-	Name         string   `json:"name"`
+	Name string `json:"name"`
+	// Description carries the policy's `description` sub-stanza (#3329). gRPC
+	// GetPolicies already exposes it; REST omits it when unset (no behavior
+	// change for rules without a description). Audits use it for
+	// intent/owner/ticket/break-glass metadata.
+	Description  string   `json:"description,omitempty"`
 	Action       string   `json:"action"`
 	SrcAddresses []string `json:"src_addresses"`
 	DstAddresses []string `json:"dst_addresses"`


### PR DESCRIPTION
## Summary
The REST security inventory dropped three config fields that gRPC `GetZones`/`GetPolicies` already project from the same `ActiveConfig`:
- security zone `description`
- security zone `tcp-rst`
- policy `description`

A REST consumer building a security-audit / posture view silently lost the intent/owner/ticket/break-glass metadata operators carry in descriptions, and could not see that a zone changes client-visible deny behaviour via `tcp-rst`. The two structured APIs disagreed on the firewall's posture.

## Change
- `ZoneInfo` gains `description` + `tcp_rst`, populated in `zonesHandler` from `zone.Description` / `zone.TCPRst`.
- `PolicyRule` gains `description`, populated in `policiesHandler` for both the zone-pair and global policy loops from `rule.Description`.

All three JSON keys are `omitempty` — a zone/policy that does not set them serializes exactly as before (no behavior change for existing configs/consumers). gRPC and CLI are untouched; this only widens the REST projection to match gRPC.

## Scope
Strictly #3329's named fields. The sibling API-inventory gaps — screen thresholds (#3327), host-inbound state (#3328), and policy address-exclusion / log-mode / runtime policy_id (#3336) — are deliberately untouched.

## Tests
`security_zone_policy_meta_3329_test.go` adds REST/config parity guards:
- `TestZonesHandlerExposesDescriptionAndTCPRst` — a zone with a description + tcp-rst surfaces both; a zone with neither omits both keys (omitempty contract).
- `TestPoliciesHandlerExposesDescription` — a policy description is surfaced.

**RED-on-revert verified:** reverting the `security.go` population to origin/master makes both tests FAIL. Full `go test ./pkg/api/...` passes; gofmt clean.

No REST response contract doc enumerates these JSON fields, so no docs change is required.

Closes #3329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi