### PR TITLE
config: constrain custom protocol junos-ping to echo + add icmp-type/icmp-code grammar

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-06-29 — #3348 custom protocol junos-ping echo constraint + icmp-type/icmp-code grammar
+
+- **Timestamp**: 2026-06-29
+- **Action**: A user-defined application with `protocol junos-ping` /
+  `junos-pingv6` lowered to bare ICMP with no type constraint, so the
+  projected policy term matched EVERY ICMP type (security widening — a
+  permit term admitted unreachable/redirect/timestamp, not just echo),
+  broader than the predefined junos-ping object (ICMPType=8, #3020). Added
+  `aliasEchoICMPType` to attach echo type 8/128 on both the top-level and
+  inline-term application paths (after the child loop so an explicit
+  icmp-type wins; all-ICMP aliases stay unconstrained). Also added the
+  missing `icmp-type`/`icmp-code` typed-integer (0..255) schema leaves so
+  an operator can author a constrained custom echo/traceroute/ICMP-control
+  app, wired through to Application.ICMPType/ICMPCode on both paths. Added
+  strict guards (validateApplicationSpecsStrict + protocolIsICMPFamily):
+  reject icmp-type/code on a non-ICMP protocol (never-match term, #3373
+  hazard) and icmp-code without icmp-type; both downgrade to a warning on
+  the lenient load/peer-sync path (#1960). No wire/Rust change — the
+  snapshot already carries the constraint and the matcher already enforces
+  it (#3020).
+- **File(s)**: pkg/config/compiler_applications.go,
+  pkg/config/compiler_validate_strict.go, pkg/config/schema_security.go,
+  pkg/config/compiler_application_junos_ping_3348_test.go,
+  pkg/policymatch/app_junos_ping_3348_test.go,
+  pkg/policymatch/icmp_test.go (stale-comment fix), pkg/config/README.md,
+  docs/config-schema.md
+
 ## 2026-06-28 — #3499 compiler_iface nil zone/interface map-value guards
 
 - **Timestamp**: 2026-06-28

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-29 — #3348 (PR #3506 review fold) inline-term edge cases
+
+- **Timestamp**: 2026-06-29
+- **Action**: Codex MERGE-NEEDS-MAJOR on PR #3506 — top-level junos-ping
+  fix correct, two inline-term edge cases folded. (1) Widening inversion:
+  a term listing BOTH junos-ping AND an all-ICMP alias normalizes both to
+  "icmp" and dedups to one term; applying echoByProto narrowed the union
+  to echo-only. Added unconstrainedICMP[proto] tracking — an all-ICMP
+  alias (icmp/icmpv6/junos-icmp-all/junos-icmp6-all) on a normalized proto
+  suppresses the echo default for that proto. (2) Fail-open: a malformed
+  inline-term icmp-type (e.g. 999) was silently dropped (term opaque to
+  schema) → unconstrained all-ICMP. Added Application.UnknownICMP
+  (mirroring UnknownTimeouts), recorded in both inline-term and top-level
+  parse, rejected by validateApplicationSpecsStrict at commit /
+  downgraded to warning on the lenient load/peer-sync path. RED-on-revert
+  tests added for both. go test config/appid/policymatch green; gofmt +
+  vet clean. Rebased on origin/master (clean, no #3332 overlap).
+- **File(s)**: pkg/config/compiler_applications.go,
+  pkg/config/compiler_validate_strict.go, pkg/config/types_security.go,
+  pkg/config/compiler_application_junos_ping_3348_test.go,
+  pkg/config/README.md, docs/config-schema.md
+
 ## 2026-06-29 — #3348 custom protocol junos-ping echo constraint + icmp-type/icmp-code grammar
 
 - **Timestamp**: 2026-06-29

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2260,6 +2260,44 @@ definition, duplicate term-generated name, distinct-names-commit incl. a
 predefined shadow, lenient-warns). Compiler-side only — not a typed `setSchema`
 leaf (applications stay opaque to `SchemaValidate`).
 
+### #3348 — custom `protocol junos-ping` echo constraint + `icmp-type`/`icmp-code` grammar
+
+A **user-defined** application that set `protocol junos-ping` (or `junos-pingv6`)
+lowered to bare ICMP with NO type constraint, so the projected policy term matched
+**every** ICMP type — silently widening any policy referencing it (a permit term
+then admitted unreachable / redirect / timestamp / ... not just echo), and broader
+than the predefined `junos-ping` object which carries `ICMPType=8` (the #3020 fix).
+`appid.ProtocolNumber` and the capability snapshot (`capabilities.go`) folded the
+alias to ICMP and carried `app.ICMPType`, which was `nil` for the custom-app path.
+
+- **alias echo constraint** — `aliasEchoICMPType` (`compiler_applications.go`)
+  maps `junos-ping`→type 8, `junos-pingv6`→type 128. `compileApplications`
+  applies it AFTER the child loop (so an explicit `icmp-type` leaf wins), and
+  `parseApplicationTerms` applies it per normalized protocol inside an inline
+  `term` (capturing the echo type before `normalizeProtocol` folds the alias to
+  `icmp`/`icmpv6`). The all-ICMP aliases (`junos-icmp-all`/`junos-icmp6-all`)
+  return `nil` so they stay match-ALL.
+- **typed grammar** — `schemaApplications.application` gains `icmp-type` and
+  `icmp-code` `ValueInteger` leaves (`ValidateInteger(0,255)`), so an operator can
+  author a constrained custom echo / traceroute / ICMP-control app. The compiler
+  parses them on both the top-level and inline-`term` paths into
+  `Application.ICMPType`/`ICMPCode`.
+- **strict guards** — `validateApplicationSpecsStrict` rejects an
+  `icmp-type`/`icmp-code` on a NON-ICMP protocol (a never-match term — the same
+  fail-open/fail-closed hazard as the #3373 port-on-non-port gate) via
+  `protocolIsICMPFamily`, and rejects an `icmp-code` without an `icmp-type` (an
+  ambiguous half-constraint the matcher would apply code-only). Both downgrade to
+  a `cfg.Warnings` entry on the tolerant load / HA peer-sync path
+  (`lenientApplicationSpecs`, #1960 no-brick).
+
+No wire/Rust change: the snapshot already carries `ICMPType`/`ICMPCode` and the
+matcher already enforces `icmp_constraints` (#3020). Regression coverage:
+`pkg/config/compiler_application_junos_ping_3348_test.go` (alias echo type top-level
++ inline term, all-ICMP stays unconstrained, explicit grammar, explicit-over-alias,
+both strict guards) and the end-to-end matcher test
+`pkg/policymatch/app_junos_ping_3348_test.go` (custom `protocol junos-ping` permits
+type 8, denies 13/5).
+
 ### #2226 — rib-group `import-rib` undefined-reference validation
 
 `routing-options rib-groups <group> import-rib <rib>` was unvalidated: an

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2290,6 +2290,26 @@ alias to ICMP and carried `app.ICMPType`, which was `nil` for the custom-app pat
   a `cfg.Warnings` entry on the tolerant load / HA peer-sync path
   (`lenientApplicationSpecs`, #1960 no-brick).
 
+Two inline-`term` edge cases (the term shape is opaque to `SchemaValidate`, so
+both are handled in `parseApplicationTerms` + the deferred strict gate):
+
+- **widening inversion** — a term that lists BOTH a junos-ping alias AND an
+  unconstrained ICMP alias (`term t { protocol junos-ping; protocol
+  junos-icmp-all; }`) normalizes both to `icmp` and DEDUPS to one term. The
+  union of echo + all-ICMP is all-ICMP (the Rust matcher ORs separate app
+  terms), so applying the echo type to the collapsed term would spuriously
+  NARROW it. `unconstrainedICMP[proto]` records that an all-ICMP alias landed on
+  the normalized protocol and SUPPRESSES the `echoByProto` default for it — the
+  collapsed term stays unconstrained.
+- **fail-open malformed inline icmp-type/code** — a bad inline `icmp-type`
+  (`term t { protocol icmp; icmp-type 999; }`) is NOT seen by the schema range
+  check (opaque term), so silently dropping it would leave the term matching
+  every ICMP type. `parseApplicationTerms` records the raw token on
+  `Application.UnknownICMP` (mirroring `UnknownTimeouts`) and the strict gate
+  rejects the first one at commit (lenient-warn on load/peer-sync). The
+  top-level path also records `UnknownICMP` so the malformed value is caught on
+  the tolerant load path (which does not run `SchemaValidate`).
+
 No wire/Rust change: the snapshot already carries `ICMPType`/`ICMPCode` and the
 matcher already enforces `icmp_constraints` (#3020). Regression coverage:
 `pkg/config/compiler_application_junos_ping_3348_test.go` (alias echo type top-level

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -821,6 +821,13 @@ non-ICMP protocol (a never-match term, the same #3373 hazard as a port on a
 non-port protocol) and an `icmp-code` without an `icmp-type` (an ambiguous
 half-constraint); both downgrade to a warning on the tolerant load/peer-sync
 path. `protocolIsICMPFamily` mirrors the ICMP arm of `filterProtocolResolvable`.
+Two inline-`term` edge cases (the term is opaque to `SchemaValidate`): a term
+listing BOTH a junos-ping alias AND an unconstrained ICMP alias dedups onto one
+`icmp` term whose union is all-ICMP, so `unconstrainedICMP[proto]` suppresses the
+echo narrowing (a widening INVERSION otherwise); and a malformed inline
+`icmp-type`/`icmp-code` is recorded on `Application.UnknownICMP` (not silently
+dropped, which would leave the term matching all ICMP) for the same strict-reject
+/ lenient-warn gate.
 
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -801,6 +801,27 @@ is left verbatim so `validatePortSpec` hard-rejects it at the strict commit gate
 and the tolerant load/peer-sync path downgrades it to a warning
 (`lenientApplicationSpecs`, #1960 no-brick).
 
+**Custom-application ICMP type/code constraints (#3348):** a user-defined
+application whose `protocol` is the `junos-ping` / `junos-pingv6` alias now
+carries the same echo-request type constraint the predefined `junos-ping`
+object does (ICMP type 8 / ICMPv6 type 128, the #3020 parity). Before this fix
+the alias lowered to bare ICMP with no type, so a custom `protocol junos-ping`
+app projected a term the userspace matcher (and the `pkg/policymatch`
+simulator) treated as match-ALL ICMP — silently widening any policy that
+referenced it to every ICMP type (unreachable / redirect / timestamp / ...).
+`aliasEchoICMPType` (`compiler_applications.go`) attaches the echo type on both
+the top-level and inline-`term` paths, AFTER the child loop so an explicit
+`icmp-type` leaf still wins; the all-ICMP aliases (`junos-icmp-all` /
+`junos-icmp6-all`) stay unconstrained. The grammar now also exposes typed
+`icmp-type` / `icmp-code` leaves (0..255, range-validated by the schema) on a
+custom application and inline term, so an operator can author a constrained
+echo / traceroute / ICMP-control app rather than only the all-ICMP widening.
+`validateApplicationSpecsStrict` rejects an `icmp-type`/`icmp-code` on a
+non-ICMP protocol (a never-match term, the same #3373 hazard as a port on a
+non-port protocol) and an `icmp-code` without an `icmp-type` (an ambiguous
+half-constraint); both downgrade to a warning on the tolerant load/peer-sync
+path. `protocolIsICMPFamily` mirrors the ICMP arm of `filterProtocolResolvable`.
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler_application_junos_ping_3348_test.go
+++ b/pkg/config/compiler_application_junos_ping_3348_test.go
@@ -156,6 +156,79 @@ func TestApplicationICMPCodeWithoutType_Rejected(t *testing.T) {
 	}
 }
 
+// #3348 inline-term edge case 1 (widening INVERSION): an inline term that
+// lists BOTH a junos-ping alias AND an unconstrained ICMP alias normalizes both
+// to "icmp" and dedups to ONE term. The union of "echo" and "all-ICMP" is
+// all-ICMP (the Rust matcher ORs separate app terms), so the collapsed term
+// must stay UNCONSTRAINED — the junos-ping echo type must NOT spuriously narrow
+// it. Fail-on-revert: without the unconstrainedICMP suppression the term gets
+// ICMPType=8 and this assertion goes RED.
+func TestApplicationJunosPing_InlineTerm_MixedAllICMP_StaysUnconstrained(t *testing.T) {
+	cases := []struct {
+		name string
+		term string
+	}{
+		{"ping-then-all", "term t protocol junos-ping protocol junos-icmp-all"},
+		{"all-then-ping", "term t protocol junos-icmp-all protocol junos-ping"},
+		{"ping-then-bare-icmp", "term t protocol junos-ping protocol icmp"},
+		{"pingv6-then-all6", "term t protocol junos-pingv6 protocol junos-icmp6-all"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("mixed", c.term)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept %q: %v", c.term, err)
+			}
+			app := cfg.Applications.Applications["mixed-t"]
+			if app == nil {
+				t.Fatalf("inline-term application mixed-t missing; have %v", appNames(cfg))
+			}
+			if app.ICMPType != nil {
+				t.Fatalf("a term mixing junos-ping with an all-ICMP alias must stay UNCONSTRAINED (ICMPType nil — union is all-ICMP), got type %d", *app.ICMPType)
+			}
+		})
+	}
+}
+
+// #3348 inline-term edge case 2 (fail-open): a malformed inline-term icmp-type
+// must NOT be silently dropped (which would leave the term matching ALL ICMP).
+// The schema does not validate inside an opaque `term`, so the compiler records
+// it on UnknownICMP and the strict gate rejects it at commit. Fail-on-revert:
+// without the badICMP recording the value is dropped, the term compiles
+// unconstrained, CompileConfig succeeds, and this assertion goes RED.
+func TestApplicationICMPType_InlineTerm_Malformed_Rejected(t *testing.T) {
+	cases := []string{
+		"term t protocol icmp icmp-type 999",
+		"term t protocol icmp icmp-type notanumber",
+		"term t protocol icmp icmp-type 8 icmp-code 300",
+	}
+	for _, term := range cases {
+		t.Run(term, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("badterm", term)...)
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("expected commit to REJECT malformed inline icmp-type/code %q", term)
+			} else if !strings.Contains(err.Error(), "icmp-type/icmp-code") {
+				t.Fatalf("error should mention icmp-type/icmp-code, got: %v", err)
+			}
+		})
+	}
+}
+
+// A WELL-FORMED inline-term icmp-type still wires through (guards the above
+// against over-rejection).
+func TestApplicationICMPType_InlineTerm_Valid(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("okterm", "term t protocol icmp icmp-type 8")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept inline icmp-type 8: %v", err)
+	}
+	app := cfg.Applications.Applications["okterm-t"]
+	if app == nil || app.ICMPType == nil || *app.ICMPType != 8 {
+		t.Fatalf("inline term icmp-type 8 must set ICMPType=8, got %+v", app)
+	}
+}
+
 func appNames(cfg *Config) []string {
 	var n []string
 	for name := range cfg.Applications.Applications {

--- a/pkg/config/compiler_application_junos_ping_3348_test.go
+++ b/pkg/config/compiler_application_junos_ping_3348_test.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3348: a USER-DEFINED application that sets `protocol junos-ping` (or
+// junos-pingv6) was lowered to bare ICMP with no type constraint, so the
+// projected policy term matched EVERY ICMP type (unreachable / redirect /
+// timestamp / ...) — silently widening any policy that referenced it, and
+// broader than the predefined junos-ping object which carries ICMPType=8
+// (#3020). The compiler must now attach the echo-request type (8 / 128) to a
+// custom app whose protocol is the ping alias, AND support explicit
+// icmp-type/icmp-code grammar on a custom application.
+//
+// Trees are built from flat `set` commands via flatTreeFromSets — the only
+// correct way to exercise the flat-set AST shape (see
+// compiler_application_specs_test.go).
+
+func refApp(name string, props ...string) []string {
+	sets := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application " + name,
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	}
+	for _, p := range props {
+		sets = append(sets, "set applications application "+name+" "+p)
+	}
+	return sets
+}
+
+// Core fail-on-revert: `protocol junos-ping` must lower to ICMP type 8. Revert
+// the compiler change (alias default removed) and app.ICMPType stays nil, so
+// this assertion goes RED.
+func TestApplicationJunosPing_AttachesEchoType(t *testing.T) {
+	cases := []struct {
+		proto    string
+		wantType uint8
+	}{
+		{"junos-ping", 8},
+		{"junos-pingv6", 128},
+	}
+	for _, c := range cases {
+		t.Run(c.proto, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("ping-app", "protocol "+c.proto)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept protocol %s: %v", c.proto, err)
+			}
+			app := cfg.Applications.Applications["ping-app"]
+			if app == nil {
+				t.Fatalf("application ping-app missing from compiled config")
+			}
+			if app.ICMPType == nil {
+				t.Fatalf("protocol %s must attach an ICMP echo type; got nil (matches ALL ICMP — the #3348 widening)", c.proto)
+			}
+			if *app.ICMPType != c.wantType {
+				t.Fatalf("protocol %s must lower to ICMP type %d, got %d", c.proto, c.wantType, *app.ICMPType)
+			}
+			if app.ICMPCode != nil {
+				t.Fatalf("protocol %s must not pin a code, got %d", c.proto, *app.ICMPCode)
+			}
+		})
+	}
+}
+
+// The all-ICMP aliases stay UNCONSTRAINED (nil type) — they intentionally match
+// every ICMP type and must not gain the echo constraint.
+func TestApplicationJunosIcmpAll_StaysUnconstrained(t *testing.T) {
+	for _, proto := range []string{"junos-icmp-all", "junos-icmp6-all"} {
+		t.Run(proto, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("all-icmp", "protocol "+proto)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept protocol %s: %v", proto, err)
+			}
+			if app := cfg.Applications.Applications["all-icmp"]; app == nil || app.ICMPType != nil {
+				t.Fatalf("protocol %s must stay unconstrained (ICMPType nil), got %+v", proto, app)
+			}
+		})
+	}
+}
+
+// Inline term: `term t protocol junos-ping` must attach the echo type to the
+// generated term application too.
+func TestApplicationJunosPing_InlineTerm_AttachesEchoType(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("ping-term", "term t protocol junos-ping")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept inline term protocol junos-ping: %v", err)
+	}
+	app := cfg.Applications.Applications["ping-term-t"]
+	if app == nil {
+		t.Fatalf("inline-term application ping-term-t missing; have %v", appNames(cfg))
+	}
+	if app.ICMPType == nil || *app.ICMPType != 8 {
+		t.Fatalf("inline term protocol junos-ping must lower to ICMP type 8, got %v", app.ICMPType)
+	}
+}
+
+// Explicit grammar: `protocol icmp icmp-type 8 icmp-code 0` must wire through to
+// the typed fields. Fail-on-revert: without the icmp-type/icmp-code schema
+// leaves the set command is rejected at commit (unknown leaf), and without the
+// compiler cases the fields stay nil.
+func TestApplicationExplicitICMPTypeCode(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("echo", "protocol icmp", "icmp-type 8", "icmp-code 0")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept icmp-type/icmp-code grammar: %v", err)
+	}
+	app := cfg.Applications.Applications["echo"]
+	if app == nil || app.ICMPType == nil || *app.ICMPType != 8 {
+		t.Fatalf("explicit icmp-type 8 must set ICMPType=8, got %+v", app)
+	}
+	if app.ICMPCode == nil || *app.ICMPCode != 0 {
+		t.Fatalf("explicit icmp-code 0 must set ICMPCode=0, got %v", app.ICMPCode)
+	}
+}
+
+// An explicit icmp-type wins over the junos-ping alias default.
+func TestApplicationExplicitICMPTypeOverridesAlias(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("ovr", "protocol junos-ping", "icmp-type 13")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept explicit icmp-type override: %v", err)
+	}
+	app := cfg.Applications.Applications["ovr"]
+	if app == nil || app.ICMPType == nil || *app.ICMPType != 13 {
+		t.Fatalf("explicit icmp-type 13 must override the junos-ping echo default, got %+v", app)
+	}
+}
+
+// Strict guard: icmp-type on a non-ICMP protocol is a never-match term — reject
+// at commit (#3348, mirroring the #3373 port-on-non-port-protocol gate).
+func TestApplicationICMPTypeOnNonICMPProtocol_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("bad", "protocol tcp", "icmp-type 8")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT icmp-type on protocol tcp")
+	} else if !strings.Contains(err.Error(), "icmp-type") {
+		t.Fatalf("error should mention icmp-type, got: %v", err)
+	}
+}
+
+// Strict guard: an icmp-code without an icmp-type is an ambiguous half
+// constraint — reject at commit.
+func TestApplicationICMPCodeWithoutType_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("bad2", "protocol icmp", "icmp-code 3")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT icmp-code without icmp-type")
+	} else if !strings.Contains(err.Error(), "icmp-code") {
+		t.Fatalf("error should mention icmp-code, got: %v", err)
+	}
+}
+
+func appNames(cfg *Config) []string {
+	var n []string
+	for name := range cfg.Applications.Applications {
+		n = append(n, name)
+	}
+	return n
+}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -69,16 +69,26 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 				}
 			case "icmp-type":
 				// #3348: explicit ICMP/ICMPv6 message-type constraint for a
-				// custom application. The schema validates the 0..255 range on
-				// the strict commit path (schema_security.go ValidateInteger),
-				// so a malformed token has already been rejected before compile;
-				// drop a stray unparsable value here rather than widening.
-				if t, ok := parseICMPTypeCode(nodeVal(prop)); ok {
-					app.ICMPType = t
+				// custom application. The schema range-validates 0..255 on the
+				// strict commit path (schema_security.go ValidateInteger). The
+				// tolerant load / peer-sync path does NOT run SchemaValidate, so
+				// record a malformed value (mirroring UnknownTimeouts) rather than
+				// silently dropping it — a dropped value would leave an ICMP app
+				// UNCONSTRAINED (matches all types), a fail-open widening.
+				if v := nodeVal(prop); v != "" {
+					if t, ok := parseICMPTypeCode(v); ok {
+						app.ICMPType = t
+					} else {
+						app.UnknownICMP = append(app.UnknownICMP, v)
+					}
 				}
 			case "icmp-code":
-				if c, ok := parseICMPTypeCode(nodeVal(prop)); ok {
-					app.ICMPCode = c
+				if v := nodeVal(prop); v != "" {
+					if c, ok := parseICMPTypeCode(v); ok {
+						app.ICMPCode = c
+					} else {
+						app.UnknownICMP = append(app.UnknownICMP, v)
+					}
 				}
 			case "alg":
 				app.ALG = nodeVal(prop)
@@ -171,12 +181,22 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	var timeout int
 	var badTimeouts []string
 	var icmpType, icmpCode *uint8
+	var badICMP []string
 	// #3348: per normalized-protocol echo-type implied by a junos-ping /
 	// junos-pingv6 alias inside an inline term. normalizeProtocol folds the
 	// alias to "icmp"/"icmpv6" and loses the ping distinction, so capture the
 	// echo type keyed by the normalized protocol before that information is
 	// gone.
 	echoByProto := map[string]*uint8{}
+	// #3348: a normalized protocol for which the SAME term also lists an
+	// unconstrained ICMP alias (icmp / icmpv6 / junos-icmp-all / junos-icmp6-all)
+	// that dedups onto it. Two app terms — one ping, one all-icmp — union to
+	// all-ICMP in the Rust matcher (policy.rs: separate terms OR together), but
+	// because both normalize to "icmp" here they collapse to ONE term. Applying
+	// the junos-ping echo type to that collapsed term would spuriously NARROW the
+	// union to echo-only (a widening INVERSION). Record the poisoning alias so the
+	// echo default is suppressed for that protocol.
+	unconstrainedICMP := map[string]bool{}
 
 	for i := 1; i < len(keys); i++ {
 		switch keys[i] {
@@ -187,6 +207,12 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 				protocols = append(protocols, norm)
 				if t := aliasEchoICMPType(keys[i]); t != nil {
 					echoByProto[norm] = t
+				} else if norm == "icmp" || norm == "icmpv6" {
+					// An unconstrained ICMP alias (icmp / junos-icmp-all / ...)
+					// for this normalized protocol — widens to all types, so the
+					// junos-ping echo narrowing must NOT apply when both land on
+					// the same collapsed term.
+					unconstrainedICMP[norm] = true
 				}
 			}
 		case "icmp-type":
@@ -194,6 +220,12 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 				i++
 				if t, ok := parseICMPTypeCode(keys[i]); ok {
 					icmpType = t
+				} else {
+					// #3348: a malformed inline-term icmp-type. The schema does
+					// NOT validate inside an opaque `term`, so silently dropping
+					// it would leave the term UNCONSTRAINED (matches all ICMP) —
+					// a fail-open widening. Record it for the strict gate.
+					badICMP = append(badICMP, keys[i])
 				}
 			}
 		case "icmp-code":
@@ -201,6 +233,8 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 				i++
 				if c, ok := parseICMPTypeCode(keys[i]); ok {
 					icmpCode = c
+				} else {
+					badICMP = append(badICMP, keys[i])
 				}
 			}
 		case "destination-port":
@@ -258,9 +292,11 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 		}
 		// An explicit inline-term `icmp-type` wins; otherwise fall back to the
 		// echo type implied by a junos-ping / junos-pingv6 protocol alias on
-		// this protocol (#3348).
+		// this protocol (#3348) — UNLESS the same term also lists an
+		// unconstrained ICMP alias that dedups onto this protocol, in which case
+		// the union is all-ICMP and the echo narrowing must be suppressed.
 		it := icmpType
-		if it == nil {
+		if it == nil && !unconstrainedICMP[proto] {
 			it = echoByProto[proto]
 		}
 		result = append(result, &Application{
@@ -273,6 +309,7 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			UnknownTimeouts:   badTimeouts,
 			ICMPType:          it,
 			ICMPCode:          icmpCode,
+			UnknownICMP:       badICMP,
 		})
 	}
 	return result

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -67,6 +67,19 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 						app.UnknownTimeouts = append(app.UnknownTimeouts, v)
 					}
 				}
+			case "icmp-type":
+				// #3348: explicit ICMP/ICMPv6 message-type constraint for a
+				// custom application. The schema validates the 0..255 range on
+				// the strict commit path (schema_security.go ValidateInteger),
+				// so a malformed token has already been rejected before compile;
+				// drop a stray unparsable value here rather than widening.
+				if t, ok := parseICMPTypeCode(nodeVal(prop)); ok {
+					app.ICMPType = t
+				}
+			case "icmp-code":
+				if c, ok := parseICMPTypeCode(nodeVal(prop)); ok {
+					app.ICMPCode = c
+				}
 			case "alg":
 				app.ALG = nodeVal(prop)
 			case "description":
@@ -85,6 +98,20 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 				}
 				termApps := parseApplicationTerms(appName, allKeys)
 				terms = append(terms, termApps...)
+			}
+		}
+
+		// #3348: a custom application whose `protocol` is the junos-ping /
+		// junos-pingv6 alias must carry the same echo-request type constraint
+		// the predefined junos-ping object does (#3020). Without it the alias
+		// lowered to bare ICMP with ICMPType=nil, which the userspace matcher
+		// (and the pkg/policymatch simulator) treat as match-ALL ICMP — silently
+		// widening any policy referencing the app to every ICMP type
+		// (unreachable / redirect / timestamp / ...). Apply the default AFTER the
+		// child loop so an explicit `icmp-type` leaf still wins.
+		if app.ICMPType == nil {
+			if t := aliasEchoICMPType(app.Protocol); t != nil {
+				app.ICMPType = t
 			}
 		}
 
@@ -143,13 +170,38 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	var dstPort, srcPort, alg string
 	var timeout int
 	var badTimeouts []string
+	var icmpType, icmpCode *uint8
+	// #3348: per normalized-protocol echo-type implied by a junos-ping /
+	// junos-pingv6 alias inside an inline term. normalizeProtocol folds the
+	// alias to "icmp"/"icmpv6" and loses the ping distinction, so capture the
+	// echo type keyed by the normalized protocol before that information is
+	// gone.
+	echoByProto := map[string]*uint8{}
 
 	for i := 1; i < len(keys); i++ {
 		switch keys[i] {
 		case "protocol":
 			if i+1 < len(keys) {
 				i++
-				protocols = append(protocols, normalizeProtocol(keys[i]))
+				norm := normalizeProtocol(keys[i])
+				protocols = append(protocols, norm)
+				if t := aliasEchoICMPType(keys[i]); t != nil {
+					echoByProto[norm] = t
+				}
+			}
+		case "icmp-type":
+			if i+1 < len(keys) {
+				i++
+				if t, ok := parseICMPTypeCode(keys[i]); ok {
+					icmpType = t
+				}
+			}
+		case "icmp-code":
+			if i+1 < len(keys) {
+				i++
+				if c, ok := parseICMPTypeCode(keys[i]); ok {
+					icmpCode = c
+				}
 			}
 		case "destination-port":
 			if i+1 < len(keys) {
@@ -204,6 +256,13 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			}
 			name = parentName + "-" + termName + "-" + suffix
 		}
+		// An explicit inline-term `icmp-type` wins; otherwise fall back to the
+		// echo type implied by a junos-ping / junos-pingv6 protocol alias on
+		// this protocol (#3348).
+		it := icmpType
+		if it == nil {
+			it = echoByProto[proto]
+		}
 		result = append(result, &Application{
 			Name:              name,
 			Protocol:          proto,
@@ -212,9 +271,50 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			InactivityTimeout: timeout,
 			ALG:               alg,
 			UnknownTimeouts:   badTimeouts,
+			ICMPType:          it,
+			ICMPCode:          icmpCode,
 		})
 	}
 	return result
+}
+
+// aliasEchoICMPType returns the echo-request ICMP / ICMPv6 type implied by a
+// "ping" protocol alias — junos-ping -> 8 (ICMP echo-request), junos-pingv6 ->
+// 128 (ICMPv6 echo-request) — or nil for any other token.
+//
+// #3348: a user-defined application that set `protocol junos-ping` was lowered
+// to bare ICMP with no type constraint, so the projected policy term matched
+// EVERY ICMP type (unreachable / redirect / timestamp / ...) — silently
+// widening any policy that referenced it, and broader than the predefined
+// junos-ping object which carries ICMPType=8 (#3020). Attaching the echo type
+// makes a custom `protocol junos-ping` app behave like the predefined one. The
+// all-ICMP aliases (junos-icmp-all / junos-icmp6-all) intentionally return nil
+// so they stay unconstrained (match every type).
+func aliasEchoICMPType(proto string) *uint8 {
+	switch strings.ToLower(strings.TrimSpace(proto)) {
+	case "junos-ping":
+		return u8p(8)
+	case "junos-pingv6":
+		return u8p(128)
+	default:
+		return nil
+	}
+}
+
+// parseICMPTypeCode parses an application `icmp-type` / `icmp-code` token. It
+// returns the value and true when the token is a base-10 integer in [0,255]
+// (the ICMP/ICMPv6 type and code wire range); otherwise (nil, false). The
+// strict commit path validates the range earlier via the schema
+// (schema_security.go ValidateInteger(0,255)), so this is the compile-time
+// projection of an already-accepted token; an unparsable value is dropped
+// rather than widening the term.
+func parseICMPTypeCode(raw string) (*uint8, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n < 0 || n > 255 {
+		return nil, false
+	}
+	v := uint8(n)
+	return &v, true
 }
 
 // normalizeProtocol maps Junos protocol aliases to canonical names

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3141,6 +3141,36 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"configured one)",
 				name, app.UnknownTimeouts[0], appTimeoutMin, appTimeoutMax)
 		}
+		// #3348: an icmp-type/icmp-code constraint is only meaningful on an
+		// ICMP/ICMPv6 protocol. The userspace matcher keys icmp_constraints
+		// under the ICMP protocol number (userspace-dp policy.rs), and the
+		// pkg/policymatch simulator only consults app.ICMPType when the query
+		// protocol is ICMP/ICMPv6 — so a type/code on tcp/udp/gre/... compiles a
+		// term that can never match (fail-open for a deny rule, fail-closed for a
+		// permit rule), the same #3373 hazard as a port on a non-port protocol.
+		// Junos couples icmp-type/code to an ICMP application, so reject at COMMIT
+		// (strict-at-commit / #1960 fail-closed). The call site downgrades to a
+		// warning on the tolerant load / peer-sync path.
+		if (app.ICMPType != nil || app.ICMPCode != nil) && !protocolIsICMPFamily(app.Protocol) {
+			return fmt.Errorf(
+				"application %q: icmp-type/icmp-code is set on protocol %q, which is "+
+					"not an ICMP protocol; an ICMP type/code constraint is valid only on "+
+					"icmp/icmpv6 (or the junos-ping/junos-pingv6/junos-icmp-all aliases, "+
+					"or protocol number 1/58) — on any other protocol the term can never "+
+					"match (remove the constraint or change the protocol)",
+				name, app.Protocol)
+		}
+		// A code with no type leaves the matcher constraining the code while
+		// ignoring the type (pkg/policymatch matchSingleApp checks ICMPCode
+		// independently of ICMPType), an ambiguous half-constraint Junos does not
+		// allow. Require a type whenever a code is set.
+		if app.ICMPCode != nil && app.ICMPType == nil {
+			return fmt.Errorf(
+				"application %q: icmp-code is set without icmp-type; an ICMP code is "+
+					"meaningful only together with a type (set icmp-type as well, or "+
+					"remove icmp-code)",
+				name)
+		}
 	}
 	return nil
 }
@@ -4148,6 +4178,25 @@ func protocolIsPortBearing(token string) bool {
 		// ports (ip_proto.rs has_l4_ports).
 		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
 			return n == 6 || n == 17
+		}
+		return false
+	}
+}
+
+// protocolIsICMPFamily reports whether a protocol token names ICMP or ICMPv6 —
+// the only protocols on which an application `icmp-type`/`icmp-code` constraint
+// is enforceable (#3348). It recognizes the canonical names, the junos-*
+// aliases that resolve to ICMP/ICMPv6 (including junos-ping/junos-pingv6, which
+// carry an implicit echo type), and the numeric protocol numbers 1 (ICMP) and
+// 58 (ICMPv6). The set mirrors the ICMP arm of filterProtocolResolvable.
+func protocolIsICMPFamily(token string) bool {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "icmp", "junos-icmp-all", "junos-ping",
+		"icmpv6", "icmp6", "junos-icmp6-all", "junos-pingv6":
+		return true
+	default:
+		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
+			return n == 1 || n == 58
 		}
 		return false
 	}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3141,6 +3141,26 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"configured one)",
 				name, app.UnknownTimeouts[0], appTimeoutMin, appTimeoutMax)
 		}
+		// #3348: a malformed icmp-type / icmp-code (non-integer or outside
+		// 0..255). The schema range-validates the TOP-LEVEL application leaves at
+		// commit-check, but an inline `term` is opaque to the schema walk
+		// (children:nil), so a bad inline icmp-type would otherwise be silently
+		// dropped by parseICMPTypeCode — leaving the term UNCONSTRAINED (matching
+		// EVERY ICMP type), a fail-open widening that is the exact inverse of this
+		// issue's fix. compileApplications records the raw token in app.UnknownICMP
+		// (mirroring UnknownTimeouts); reject the first one here so the silent
+		// widening becomes an operator-visible commit error. Strict on the
+		// commit / commit-check path; the call site (compiler.go,
+		// lenientApplicationSpecs) downgrades it to a warning on the tolerant
+		// load / peer-sync path (#1960 no-brick).
+		if len(app.UnknownICMP) > 0 {
+			return fmt.Errorf(
+				"application %q: invalid icmp-type/icmp-code %q; must be an integer "+
+					"in 0..255 (a non-numeric or out-of-range value is silently dropped "+
+					"and leaves the application matching EVERY ICMP type instead of the "+
+					"intended one)",
+				name, app.UnknownICMP[0])
+		}
 		// #3348: an icmp-type/icmp-code constraint is only meaningful on an
 		// ICMP/ICMPv6 protocol. The userspace matcher keys icmp_constraints
 		// under the ICMP protocol number (userspace-dp policy.rs), and the

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -700,7 +700,15 @@ var schemaApplications = &schemaNode{desc: "Applications", children: map[string]
 		"timeout":            {desc: "Timeout", args: 1, valueType: ValueInteger, valueDesc: "Timeout in seconds", valueExamples: []string{"300", "1800"}, validator: ValidateInteger(appTimeoutMin, appTimeoutMax), placeholder: "<seconds>", children: nil},
 		"alg":                {desc: "Application layer gateway", args: 1, placeholder: "<alg>", children: nil},
 		"description":        {desc: "Description", args: 1, placeholder: "<text>", children: nil},
-		"term":               {desc: "Term", args: 1, placeholder: "<term>", children: nil},
+		// #3348: typed ICMP/ICMPv6 type/code constraints (0..255) so an operator
+		// can author a constrained custom echo / traceroute / ICMP-control app —
+		// the runtime supports it (userspace-dp icmp_constraints, the #3020 fix)
+		// but the grammar previously did not. Range-validated at the strict
+		// commit gate; validateApplicationSpecsStrict additionally rejects the
+		// constraint on a non-ICMP protocol (and a code without a type).
+		"icmp-type": {desc: "ICMP/ICMPv6 message type", args: 1, valueType: ValueInteger, valueDesc: "ICMP type (e.g. 8 = echo-request, 128 = ICMPv6 echo-request)", valueExamples: []string{"8", "128"}, validator: ValidateInteger(0, 255), placeholder: "<type>", children: nil},
+		"icmp-code": {desc: "ICMP/ICMPv6 message code", args: 1, valueType: ValueInteger, valueDesc: "ICMP code", valueExamples: []string{"0"}, validator: ValidateInteger(0, 255), placeholder: "<code>", children: nil},
+		"term":      {desc: "Term", args: 1, placeholder: "<term>", children: nil},
 	}},
 	"application-set": {desc: "Application set", args: 1, valueHint: ValueHintAppSetName, placeholder: "<name>", children: nil},
 }}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -641,6 +641,17 @@ type Application struct {
 	// zero default, silently falling the application back to the global
 	// per-protocol timeout instead of the configured one (#3320).
 	UnknownTimeouts []string
+	// UnknownICMP records the raw `icmp-type` / `icmp-code` tokens (top-level or
+	// inline-term) that did NOT parse to a valid integer in 0..255. The schema
+	// range-validates the TOP-LEVEL leaves at commit-check, but the inline
+	// `term` is opaque to the schema walk (children:nil), so a malformed inline
+	// `icmp-type` would otherwise be silently dropped by parseICMPTypeCode —
+	// leaving the term UNCONSTRAINED, i.e. matching every ICMP type (a fail-open
+	// widening, the inverse of the #3348 fix). Mirroring UnknownTimeouts, the
+	// offending raw token is recorded here and the deferred gate
+	// (validateApplicationSpecsStrict) hard-rejects it on the strict commit path
+	// / warns on the lenient load / peer-sync path (#3348).
+	UnknownICMP []string
 }
 
 // IPsecConfig holds IPsec VPN configuration.

--- a/pkg/policymatch/app_junos_ping_3348_test.go
+++ b/pkg/policymatch/app_junos_ping_3348_test.go
@@ -1,0 +1,51 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestCustomJunosPingApp_EchoOnly is the #3348 end-to-end fail-on-revert: a
+// USER-DEFINED application `mgmt-ping` whose protocol is the junos-ping alias,
+// referenced by an allow policy, must permit ICMP echo-request (type 8) ONLY,
+// not every ICMP type. Before the compiler attached the echo constraint to the
+// alias, the custom app lowered to bare ICMP (ICMPType nil) and the matcher
+// treated it as match-ALL ICMP, so timestamp/redirect/etc. were silently
+// permitted — the security widening this issue fixes. Reverting the
+// compiler_applications.go alias default makes the "denies timestamp" case go
+// RED (the matcher permits it).
+func TestCustomJunosPingApp_EchoOnly(t *testing.T) {
+	cfg := compileFromSet(t, []string{
+		"set applications application mgmt-ping protocol junos-ping",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application mgmt-ping",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	})
+
+	tests := []struct {
+		name        string
+		icmpType    uint8
+		wantMatched bool
+		wantAction  config.PolicyAction
+	}{
+		{"echo-request type 8 permitted", 8, true, config.PolicyPermit},
+		{"timestamp type 13 denied", 13, false, config.PolicyDeny},
+		{"redirect type 5 denied", 5, false, config.PolicyDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ty := tt.icmpType
+			q := Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp", ICMPType: &ty}
+			res := Match(cfg, q)
+			if res.Matched != tt.wantMatched || res.Action != tt.wantAction {
+				t.Fatalf("custom junos-ping app, ICMP type %d: got matched=%v action=%v, want matched=%v action=%v",
+					tt.icmpType, res.Matched, res.Action, tt.wantMatched, tt.wantAction)
+			}
+		})
+	}
+}

--- a/pkg/policymatch/icmp_test.go
+++ b/pkg/policymatch/icmp_test.go
@@ -121,10 +121,13 @@ func TestICMPTypeConstraintParity(t *testing.T) {
 // (normalizeUserspaceApplicationProtocol("")=="") → the __unsupported__ sentinel
 // → whole-snapshot reject (#3261), and strict commit hard-rejects a protocol-less
 // app (pkg/config/compiler_validate_strict.go). It is also not constructible via
-// real config: the application compiler (compiler_applications.go) has no
-// `icmp-type` property, so a user app can NEVER set ICMPType — only predefined
-// apps do (junos-ping/junos-pingv6), and those always pin Protocol. So
-// Protocol=="" implies a no-protocol app the runtime drops.
+// real config: as of #3348 a user app CAN carry an ICMP type (via the
+// `icmp-type`/`icmp-code` grammar or a junos-ping/junos-pingv6 protocol alias),
+// but the application compiler (compiler_applications.go) only ever attaches a
+// type alongside a pinned ICMP protocol — and validateApplicationSpecsStrict
+// rejects an icmp-type on a non-ICMP protocol and a protocol-less app outright.
+// So a real config can never produce Protocol=="" with ICMPType set; this case
+// is the hand-built unrepresentable shape the runtime drops.
 //
 // The simulator must therefore report NO concrete match for this app, for EVERY
 // query protocol — mirroring the dataplane reject. Before #3323 the


### PR DESCRIPTION
## Summary

Closes #3348.

A **user-defined** application that set `protocol junos-ping` (or `junos-pingv6`) lowered to bare ICMP with no type constraint, so the projected security-policy term matched **every** ICMP type. A permit term referencing such an app silently admitted unreachable / redirect / timestamp / etc. — broader than a "ping" app should be, and broader than the same-named **predefined** object, which carries an echo-request type constraint (ICMP type 8 / ICMPv6 128, the #3020 fix). The capability snapshot already carried `app.ICMPType` into the matcher, but it was `nil` on the custom-app path, so both the userspace matcher and the `pkg/policymatch` simulator treated the term as match-ALL ICMP. This is a security-policy widening (High).

## Changes

- **Alias echo constraint** — `aliasEchoICMPType` (`compiler_applications.go`) maps `junos-ping`→8 / `junos-pingv6`→128. Applied AFTER the child loop on the top-level path (so an explicit `icmp-type` wins) and per normalized protocol inside an inline `term` (capturing the echo type before `normalizeProtocol` folds the alias). `junos-icmp-all` / `junos-icmp6-all` stay unconstrained.
- **Grammar gap** — `schemaApplications.application` gains typed `icmp-type` / `icmp-code` `ValueInteger(0..255)` leaves (top-level + inline term), wired through to `Application.ICMPType`/`ICMPCode`, so an operator can author a constrained custom echo / traceroute / ICMP-control app.
- **Strict guards** — `validateApplicationSpecsStrict` (via `protocolIsICMPFamily`) rejects an `icmp-type`/`icmp-code` on a non-ICMP protocol (never-match term — same #3373 hazard) and an `icmp-code` without an `icmp-type`; both downgrade to a warning on the tolerant load / HA peer-sync path (`lenientApplicationSpecs`, #1960 no-brick).

No wire or Rust change: the snapshot already carries `ICMPType`/`ICMPCode` and the matcher already enforces `icmp_constraints` (#3020).

## Tests (fail-on-revert)

- `pkg/config/compiler_application_junos_ping_3348_test.go` — alias echo type (top-level + inline term), all-ICMP stays unconstrained, explicit grammar, explicit-over-alias, both strict guards.
- `pkg/policymatch/app_junos_ping_3348_test.go` — end-to-end: a custom `protocol junos-ping` app permits ICMP type 8, denies 13/5.

Reverting the `aliasEchoICMPType` defaults makes the junos-ping echo-type assertions and the "denies timestamp" matcher case go RED (verified).

## Validation

`go test ./pkg/config/... ./pkg/appid/... ./pkg/policymatch/...` green; `gofmt` + `go vet` clean.

## Docs

`pkg/config/README.md` and `docs/config-schema.md` (new #3348 section) document the echo constraint, the `icmp-type`/`icmp-code` grammar, and the strict guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi