### PR TITLE
config: reject undefined interface/lo0 filter references (#3296)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-06-29 — #3296 undefined interface/lo0 filter reference fail-open
+
+- **Timestamp**: 2026-06-29
+- **Action**: Promote an undefined interface/lo0 firewall filter reference
+  from a commit WARNING to a strict commit error + add a fail-closed
+  dataplane backstop. Before: `interfaces <if> unit <n> family inet|inet6
+  filter input|output <name>` (and lo0 input) naming a filter not defined
+  under `firewall family ... filter` was warn-only at commit, and the Rust
+  snapshot compiler left the per-interface fast-path map (and output
+  needs_tx_eval set) empty for the missing key → hot path returned the
+  default Accept → hook silently disarmed (fail-OPEN on a typo'd security
+  hook). Go: new `validateFirewallFilterReferencesStrict`
+  (compiler_validate_strict.go), wired at the firewall-gate cluster
+  (compiler.go) gated on `opts.lenientFirewallRefs` — strict on commit,
+  downgraded-warn on lenient/peer-sync (#1960). Deleted the superseded
+  warn-only interface filter-reference loop in compiler_validate_warn.go
+  (avoids a duplicate warning on the lenient path). lo0 is covered for free
+  (stored as cfg.Interfaces.Interfaces["lo0"]). Rust: new
+  `SnapshotIntegrityError::MissingFilterRef` raised by `parse_filter_state`
+  (filter/compiler.rs) on a named-but-missing interface/lo0 ref —
+  preflight reject preserves prior good state, never falls open to Accept.
+  Mirrors the policer (#2217) / prefix-list (#2506) strict-reference
+  precedent and the #2505 snapshot-integrity backstop doctrine.
+- **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler.go, pkg/config/compiler_validate_warn.go,
+  pkg/config/compiler_filter_ref_3296_test.go (new),
+  pkg/config/compiler_interfaces_unsupported_test.go,
+  pkg/config/parser_ast_test.go, pkg/config/parser_services_test.go,
+  userspace-dp/src/policy.rs, userspace-dp/src/filter/compiler.rs,
+  userspace-dp/src/filter/tests.rs, userspace-dp/src/filter/README.md
+- **Validation**: `go test ./pkg/config/...` green (8 new + 5 fixed
+  pre-existing tests that referenced undefined filters); `cargo build`
+  green; new Rust tests `missing_filter_ref_3296_*` /
+  `defined_filter_ref_3296_compiles_cleanly` pass; full Rust suite 3223
+  pass / 2 pre-existing flakes (event_stream/worker_queue, confirmed
+  failing on pristine origin/master, unrelated to filters).
+
 ## 2026-06-28 — #3499 compiler_iface nil zone/interface map-value guards
 
 - **Timestamp**: 2026-06-28

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2863,6 +2863,29 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #3296: interface/unit (and lo0) `family inet|inet6 filter input|output
+	// <name>` cross-reference. A filter hook naming a filter not defined under
+	// `firewall family inet|inet6 filter` compiled cleanly with only a
+	// warning, and the userspace filter compiler left the per-interface
+	// fast-path map empty for the missing key, so the hot path returned the
+	// default Accept — the security hook was silently disarmed and the
+	// interface forwarded unfiltered (a fail-OPEN on a typo'd firewall hook).
+	// Strict on commit / commit-check (hard reject so the typo is operator-
+	// visible); lenient on load / peer-sync (warn so an already-persisted or
+	// peer-synced config still boots — #1960; the helper's snapshot-integrity
+	// backstop then refuses to publish a snapshot whose interface references an
+	// undefined filter, preserving prior good state rather than degrading the
+	// hook to Accept). Supersedes the warn-only interface filter-reference loop
+	// in ValidateConfig. Mirrors validateFirewallPrefixListReferencesStrict.
+	if err := validateFirewallFilterReferencesStrict(cfg); err != nil {
+		if opts.lenientFirewallRefs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter reference (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	// #2461: per-flow-server NetFlow v9 / IPFIX template cross-reference. A
 	// flow-server `version9 { template <name> }` / `version-ipfix { template
 	// <name> }` (or the flat `version9-template` / `version-ipfix-template`)

--- a/pkg/config/compiler_filter_ref_3296_test.go
+++ b/pkg/config/compiler_filter_ref_3296_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3296: an interface/unit (or lo0) `family inet|inet6 filter input|output
+// <name>` reference naming a filter not defined under `firewall family
+// inet|inet6 filter` must be hard-rejected at commit
+// (validateFirewallFilterReferencesStrict). A dangling reference otherwise
+// compiled with only a warning and the userspace filter compiler left the
+// per-interface fast-path map empty for the missing key, so the hot path
+// returned the default Accept — the security hook was silently disarmed and
+// the interface forwarded unfiltered (fail-OPEN on a typo'd firewall hook).
+// Mirrors the #2217 policer / #2506 prefix-list reference gates.
+//
+// Each direction asserts the reject (fail-on-revert: delete the validator and
+// the reject disappears) and a defined reference asserts no false reject; the
+// lenient path asserts the downgrade-to-warning (#1960).
+
+func TestFilterRefUndefinedInputV4Rejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet filter input WAN-BLOCK",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for undefined inet input filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined filter") ||
+		!strings.Contains(err.Error(), "WAN-BLOCK") ||
+		!strings.Contains(err.Error(), "input") {
+		t.Fatalf("error = %v, want it to name the undefined inet input filter", err)
+	}
+}
+
+func TestFilterRefUndefinedInputV6Rejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet6 filter input v6-ghost",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for undefined inet6 input filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined filter") ||
+		!strings.Contains(err.Error(), "v6-ghost") ||
+		!strings.Contains(err.Error(), "inet6") {
+		t.Fatalf("error = %v, want it to name the undefined inet6 input filter", err)
+	}
+}
+
+func TestFilterRefUndefinedOutputV4Rejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet filter output egress-ghost",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for undefined inet output filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined filter") ||
+		!strings.Contains(err.Error(), "egress-ghost") ||
+		!strings.Contains(err.Error(), "output") {
+		t.Fatalf("error = %v, want it to name the undefined inet output filter", err)
+	}
+}
+
+func TestFilterRefUndefinedOutputV6Rejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet6 filter output egress6-ghost",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for undefined inet6 output filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined filter") ||
+		!strings.Contains(err.Error(), "egress6-ghost") {
+		t.Fatalf("error = %v, want it to name the undefined inet6 output filter", err)
+	}
+}
+
+// lo0 is stored as an ordinary interface (cfg.Interfaces.Interfaces["lo0"]),
+// so the strict gate covers the host-bound lo0 input/output hooks too — the
+// canonical "protect-RE lockout" filter must not silently fail open on a typo.
+func TestFilterRefUndefinedLo0InputV4Rejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces lo0 unit 0 family inet filter input protect-re-typo",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for undefined lo0 inet input filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined filter") ||
+		!strings.Contains(err.Error(), "protect-re-typo") ||
+		!strings.Contains(err.Error(), "lo0") {
+		t.Fatalf("error = %v, want it to name the undefined lo0 inet input filter", err)
+	}
+}
+
+func TestFilterRefUndefinedLo0InputV6Rejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces lo0 unit 0 family inet6 filter input protect-re6-typo",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit rejection for undefined lo0 inet6 input filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "undefined filter") ||
+		!strings.Contains(err.Error(), "protect-re6-typo") ||
+		!strings.Contains(err.Error(), "lo0") {
+		t.Fatalf("error = %v, want it to name the undefined lo0 inet6 input filter", err)
+	}
+}
+
+// A reference whose target filter IS defined must commit cleanly, in all four
+// interface directions plus lo0.
+func TestFilterRefDefinedCommitsCleanly(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set firewall family inet filter in4 term t1 then accept",
+		"set firewall family inet filter out4 term t1 then accept",
+		"set firewall family inet6 filter in6 term t1 then accept",
+		"set firewall family inet6 filter out6 term t1 then accept",
+		"set firewall family inet filter lo4 term t1 then accept",
+		"set interfaces ge-0/0/0 unit 0 family inet filter input in4",
+		"set interfaces ge-0/0/0 unit 0 family inet filter output out4",
+		"set interfaces ge-0/0/0 unit 0 family inet6 filter input in6",
+		"set interfaces ge-0/0/0 unit 0 family inet6 filter output out6",
+		"set interfaces lo0 unit 0 family inet filter input lo4",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("defined filter references must commit cleanly, got: %v", err)
+	}
+	u := cfg.Interfaces.Interfaces["ge-0/0/0"].Units[0]
+	if u.FilterInputV4 != "in4" || u.FilterOutputV4 != "out4" ||
+		u.FilterInputV6 != "in6" || u.FilterOutputV6 != "out6" {
+		t.Fatalf("filter refs lost: %+v", u)
+	}
+	if cfg.System.Lo0FilterInputV4 != "lo4" {
+		t.Fatalf("lo0 input ref lost: %q", cfg.System.Lo0FilterInputV4)
+	}
+}
+
+// The strict reject is downgraded to a warning on the tolerant load / peer-sync
+// path so an already-persisted or peer-synced config carrying the typo still
+// boots (#1960 fail-closed-on-load class). The dataplane's snapshot-integrity
+// backstop then refuses to publish the broken snapshot (fail-closed), so the
+// hook never degrades to Accept.
+func TestFilterRefUndefinedLenientWarns(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set interfaces ge-0/0/0 unit 0 family inet filter input WAN-BLOCK",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must boot through undefined filter ref, got: %v", err)
+	}
+	if !warningsContain(cfg.Warnings, "firewall filter reference") {
+		t.Fatalf("expected a downgraded filter-reference warning, got: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_interfaces_unsupported_test.go
+++ b/pkg/config/compiler_interfaces_unsupported_test.go
@@ -240,8 +240,10 @@ func TestUnsupportedGateDoesNotMatchDeviceMapMAC(t *testing.T) {
 }
 
 func TestUnsupportedGateDoesNotMatchInterfaceFilter(t *testing.T) {
-	// A unit-level firewall filter binding is supported and must compile.
+	// A unit-level firewall filter binding is supported and must compile
+	// (the referenced filter is defined; #3296 only rejects DANGLING refs).
 	assertCommitAccepts(t, flatTreeFromSets(t,
+		"set firewall family inet filter myfilter term t1 then accept",
 		"set interfaces ge-0/0/0 unit 0 family inet filter input myfilter",
 		"set interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24",
 	))

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -1653,6 +1653,108 @@ func validateFirewallRoutingInstanceReferencesStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// validateFirewallFilterReferencesStrict hard-rejects an interface/unit (and
+// lo0) `family inet|inet6 filter input|output <name>` reference that names a
+// filter not defined under `firewall family inet|inet6 filter <name>` (#3296).
+//
+// A dangling filter reference compiled cleanly: ValidateConfig only WARNED
+// (`compiler_validate_warn.go`, "filter input %q not defined"), and at runtime
+// the userspace filter compiler left the per-interface fast-path map with NO
+// entry for the missing key, so the hot path returned the default
+// FilterResult — Accept. The security hook was silently disarmed,
+// indistinguishable from "no filter configured": a fail-OPEN on a typo'd
+// firewall hook (e.g. `filter input WAN-BLOCK` where the defined filter is
+// `WAN_BLOCK`). This gate makes the typo an operator-visible commit error,
+// consistent with the policer / prefix-list / routing-instance reference
+// gates above.
+//
+// lo0 input/output references are covered for free: lo0 is stored as an
+// ordinary interface under `cfg.Interfaces.Interfaces["lo0"]`
+// (compiler.go:1819), so the interface walk validates the lo0 host-bound
+// filter hooks too.
+//
+// Interfaces are walked in sorted name order, then by ascending unit number,
+// then in a fixed direction order (input-v4, input-v6, output-v4, output-v6),
+// so the first-reported error is deterministic across runs (Go map order is
+// randomized).
+//
+// On the tolerant load / peer-sync paths the call site downgrades this to a
+// warning (opts.lenientFirewallRefs) so an already-persisted or peer-synced
+// config carrying the typo still BOOTS (#1960 fail-closed-on-load class); the
+// userspace helper's own snapshot-integrity backstop then refuses to publish a
+// snapshot whose interface references an undefined filter (preserving the
+// prior good state rather than degrading the hook to Accept). Commit /
+// commit-check stay strict. Mirrors validateFirewallPolicerReferencesStrict.
+func validateFirewallFilterReferencesStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	inetDefined := func(name string) bool {
+		if cfg.Firewall.FiltersInet == nil {
+			return false
+		}
+		_, ok := cfg.Firewall.FiltersInet[name]
+		return ok
+	}
+	inet6Defined := func(name string) bool {
+		if cfg.Firewall.FiltersInet6 == nil {
+			return false
+		}
+		_, ok := cfg.Firewall.FiltersInet6[name]
+		return ok
+	}
+
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, name)
+	}
+	sort.Strings(ifNames)
+
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil { // tolerant/HA-sync path may carry a nil interface (#3494)
+			continue
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for unitNum := range ifc.Units {
+			unitNums = append(unitNums, unitNum)
+		}
+		sort.Ints(unitNums)
+		for _, unitNum := range unitNums {
+			unit := ifc.Units[unitNum]
+			if unit == nil { // tolerant/HA-sync path may carry a nil unit (#3494)
+				continue
+			}
+			// Fixed direction order for a deterministic first error.
+			type ref struct {
+				name      string
+				family    string
+				direction string
+				defined   func(string) bool
+			}
+			for _, r := range []ref{
+				{unit.FilterInputV4, "inet", "input", inetDefined},
+				{unit.FilterInputV6, "inet6", "input", inet6Defined},
+				{unit.FilterOutputV4, "inet", "output", inetDefined},
+				{unit.FilterOutputV6, "inet6", "output", inet6Defined},
+			} {
+				if r.name == "" || r.defined(r.name) {
+					continue
+				}
+				return fmt.Errorf(
+					"interface %s unit %d family %s filter %s references "+
+						"undefined filter %q (define `firewall family %s "+
+						"filter %s` or fix the name — the security hook would "+
+						"otherwise be silently disarmed and the interface would "+
+						"forward unfiltered, a fail-open on a firewall filter)",
+					ifName, unitNum, r.family, r.direction, r.name,
+					r.family, r.name)
+			}
+		}
+	}
+	return nil
+}
+
 // validateApplicationSetMembersStrict hard-rejects an `applications
 // application-set <set>` (Finding B, #2217) whose member references neither a
 // defined application (user-defined or junos-* predefined), nor a defined

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -383,45 +383,13 @@ func ValidateConfig(cfg *Config) []string {
 		}
 	}
 
-	// Validate firewall filter references on interfaces
-	for ifName, ifc := range cfg.Interfaces.Interfaces {
-		if ifc == nil { // #3494: tolerant/HA-sync path may carry a nil interface
-			continue
-		}
-		for unitNum, unit := range ifc.Units {
-			if unit == nil { // #3494: tolerant/HA-sync path may carry a nil unit
-				continue
-			}
-			if unit.FilterInputV4 != "" {
-				if _, ok := cfg.Firewall.FiltersInet[unit.FilterInputV4]; !ok {
-					warnings = append(warnings, fmt.Sprintf(
-						"interface %s unit %d: filter input %q not defined",
-						ifName, unitNum, unit.FilterInputV4))
-				}
-			}
-			if unit.FilterInputV6 != "" {
-				if _, ok := cfg.Firewall.FiltersInet6[unit.FilterInputV6]; !ok {
-					warnings = append(warnings, fmt.Sprintf(
-						"interface %s unit %d: filter input-v6 %q not defined",
-						ifName, unitNum, unit.FilterInputV6))
-				}
-			}
-			if unit.FilterOutputV4 != "" {
-				if _, ok := cfg.Firewall.FiltersInet[unit.FilterOutputV4]; !ok {
-					warnings = append(warnings, fmt.Sprintf(
-						"interface %s unit %d: filter output %q not defined",
-						ifName, unitNum, unit.FilterOutputV4))
-				}
-			}
-			if unit.FilterOutputV6 != "" {
-				if _, ok := cfg.Firewall.FiltersInet6[unit.FilterOutputV6]; !ok {
-					warnings = append(warnings, fmt.Sprintf(
-						"interface %s unit %d: filter output-v6 %q not defined",
-						ifName, unitNum, unit.FilterOutputV6))
-				}
-			}
-		}
-	}
+	// Firewall filter references on interfaces (and lo0) are validated by the
+	// strict commit gate validateFirewallFilterReferencesStrict (#3296):
+	// hard-reject on commit / commit-check, downgraded to a warning on the
+	// tolerant load / peer-sync path. The strict gate fully subsumes the
+	// warn-only loop that previously lived here (it would otherwise emit a
+	// duplicate warning alongside the downgraded gate warning on the lenient
+	// path).
 
 	// Validate chassis cluster fabric config
 	if cc := cfg.Chassis.Cluster; cc != nil {

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -4803,7 +4803,23 @@ func TestValidateConfig_ArchiveSitesPasswordWarns(t *testing.T) {
 }
 
 func TestLo0FilterExtraction(t *testing.T) {
-	input := `interfaces {
+	input := `firewall {
+    family inet {
+        filter filter-management {
+            term t1 {
+                then accept;
+            }
+        }
+    }
+    family inet6 {
+        filter filter-management6 {
+            term t1 {
+                then accept;
+            }
+        }
+    }
+}
+interfaces {
     lo0 {
         unit 0 {
             family inet {
@@ -4837,7 +4853,12 @@ func TestLo0FilterExtraction(t *testing.T) {
 }
 
 func TestLo0FilterExtractionSet(t *testing.T) {
-	lines := []string{"set interfaces lo0 unit 0 family inet filter input mgmt-v4", "set interfaces lo0 unit 0 family inet6 filter input mgmt-v6"}
+	lines := []string{
+		"set firewall family inet filter mgmt-v4 term t1 then accept",
+		"set firewall family inet6 filter mgmt-v6 term t1 then accept",
+		"set interfaces lo0 unit 0 family inet filter input mgmt-v4",
+		"set interfaces lo0 unit 0 family inet6 filter input mgmt-v6",
+	}
 	tree := &ConfigTree{}
 	for _, line := range lines {
 		cmd, err := ParseSetCommand(line)

--- a/pkg/config/parser_services_test.go
+++ b/pkg/config/parser_services_test.go
@@ -304,7 +304,19 @@ func TestVLANInterfaceCompilation(t *testing.T) {
 }
 
 func TestInterfaceFilterAssignment(t *testing.T) {
-	input := `interfaces {
+	input := `firewall {
+    family inet {
+        filter inet-source-dscp {
+            term t1 { then accept; }
+        }
+    }
+    family inet6 {
+        filter inet6-source-dscp {
+            term t1 { then accept; }
+        }
+    }
+}
+interfaces {
     enp6s0 {
         unit 0 {
             family inet {
@@ -350,6 +362,16 @@ func TestInterfaceFilterAssignment(t *testing.T) {
 
 func TestInterfaceSamplingAndFilterOutput(t *testing.T) {
 	input := `
+firewall {
+    family inet {
+        filter ingress-filter { term t1 { then accept; } }
+        filter egress-filter { term t1 { then accept; } }
+    }
+    family inet6 {
+        filter ingress-v6 { term t1 { then accept; } }
+        filter egress-v6 { term t1 { then accept; } }
+    }
+}
 interfaces {
     ge-0/0/0 {
         unit 0 {

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -446,6 +446,40 @@ follow-up. An undefined prefix-list reference is rejected at commit by
 `validateFirewallPrefixListReferencesStrict` (Go), so the Rust side never has to
 reason about a dangling name.
 
+### Undefined interface/lo0 filter reference (#3296)
+
+A hook that attaches a filter to an interface (`interfaces <if> unit <n> family
+inet|inet6 filter input|output <name>`) or to lo0 (`interfaces lo0 unit 0 family
+inet|inet6 filter input <name>`) can name a filter that does not exist under
+`firewall family inet|inet6 filter <name>` — a typo on a security hook (e.g.
+`filter input WAN-BLOCK` where the defined filter is `WAN_BLOCK`). Before #3296
+this was only a commit WARNING, and the snapshot compiler (`compiler.rs`) left
+the per-interface fast-path map (`iface_filter_*_fast`) and — for output hooks —
+the `iface_filter_out_*_needs_tx_eval` set with NO entry for the missing key, so
+the hot path returned the default `FilterResult` — **Accept**. The hook was
+silently disarmed, indistinguishable from "no filter configured": a fail-OPEN on
+a firewall filter.
+
+Primary defense (Go): `validateFirewallFilterReferencesStrict`
+(`pkg/config/compiler_validate_strict.go`) hard-rejects a dangling interface/lo0
+filter reference at commit / commit-check, downgraded to a warning on the
+tolerant load / peer-sync path (`opts.lenientFirewallRefs`, #1960) so an already-
+persisted or peer-synced config still boots. It supersedes the old warn-only
+interface filter-reference loop in `ValidateConfig`.
+
+Dataplane backstop (Rust): `parse_filter_state` raises
+`SnapshotIntegrityError::MissingFilterRef` when an interface (or lo0) names a
+filter not present in the compiled table. As a preflight snapshot-integrity
+error it aborts the reconcile BEFORE teardown/publish, preserving the prior good
+filter state on a warm reconcile rather than degrading the hook to Accept —
+consistent with the #2124/#2391/#2505 fail-closed family. The Go gate is the
+primary defense (a freshly committed config can never carry a dangling
+reference); this backstop guards against version/snapshot drift on the lenient /
+peer-sync path. An EMPTY reference (no filter on the hook) is the legitimate
+"unfiltered" case and is NOT an error. Covers all four interface directions plus
+both lo0 input families. Tests: `missing_filter_ref_3296_*` /
+`defined_filter_ref_3296_compiles_cleanly` in `filter/tests.rs` (fail-on-revert).
+
 ### Negated port match — `source-port-except` / `destination-port-except` (#2622)
 
 Junos `from source-port-except` / `from destination-port-except` matches every

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -163,6 +163,17 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 state
                     .iface_filter_v4_fast
                     .insert(iface.ifindex, filter.clone());
+            } else {
+                // #3296: the hook names a filter that is not in the compiled
+                // table. Leaving no _fast entry would fall through to the
+                // default Accept — a fail-open on a typo'd security hook.
+                // Refuse the snapshot (preflight preserves prior good state).
+                return Err(SnapshotIntegrityError::MissingFilterRef {
+                    interface: iface.name.clone(),
+                    family: "inet".to_string(),
+                    direction: "input".to_string(),
+                    filter: iface.filter_input_v4.clone(),
+                });
             }
             state.iface_filter_v4.insert(iface.ifindex, key);
         }
@@ -185,6 +196,16 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 state
                     .iface_filter_out_v4_fast
                     .insert(iface.ifindex, filter.clone());
+            } else {
+                // #3296: missing output filter ref. With no _fast entry AND no
+                // needs_tx_eval flag, the TX evaluator is skipped entirely and
+                // the packet is accepted — a fail-open. Refuse the snapshot.
+                return Err(SnapshotIntegrityError::MissingFilterRef {
+                    interface: iface.name.clone(),
+                    family: "inet".to_string(),
+                    direction: "output".to_string(),
+                    filter: iface.filter_output_v4.clone(),
+                });
             }
             state.iface_filter_out_v4.insert(iface.ifindex, key);
         }
@@ -216,6 +237,14 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 state
                     .iface_filter_v6_fast
                     .insert(iface.ifindex, filter.clone());
+            } else {
+                // #3296: missing input filter ref → fail-open. Refuse.
+                return Err(SnapshotIntegrityError::MissingFilterRef {
+                    interface: iface.name.clone(),
+                    family: "inet6".to_string(),
+                    direction: "input".to_string(),
+                    filter: iface.filter_input_v6.clone(),
+                });
             }
             state.iface_filter_v6.insert(iface.ifindex, key);
         }
@@ -238,6 +267,14 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
                 state
                     .iface_filter_out_v6_fast
                     .insert(iface.ifindex, filter.clone());
+            } else {
+                // #3296: missing output filter ref → fail-open. Refuse.
+                return Err(SnapshotIntegrityError::MissingFilterRef {
+                    interface: iface.name.clone(),
+                    family: "inet6".to_string(),
+                    direction: "output".to_string(),
+                    filter: iface.filter_output_v6.clone(),
+                });
             }
             state.iface_filter_out_v6.insert(iface.ifindex, key);
         }
@@ -249,12 +286,32 @@ pub(crate) fn parse_filter_state_with_three_color_preserving(
         qualify_filter_key("inet", lo0_filter_v4)
     };
     state.lo0_filter_v4_fast = state.filters.get(&state.lo0_filter_v4).cloned();
+    if !lo0_filter_v4.is_empty() && state.lo0_filter_v4_fast.is_none() {
+        // #3296: lo0 host-bound input filter names a filter not in the table.
+        // Falling through to the default Accept would leave the routing-engine
+        // protect filter unarmed (the canonical lo0 lockout hook) — fail-open.
+        return Err(SnapshotIntegrityError::MissingFilterRef {
+            interface: "lo0".to_string(),
+            family: "inet".to_string(),
+            direction: "input".to_string(),
+            filter: lo0_filter_v4.to_string(),
+        });
+    }
     state.lo0_filter_v6 = if lo0_filter_v6.is_empty() {
         String::new()
     } else {
         qualify_filter_key("inet6", lo0_filter_v6)
     };
     state.lo0_filter_v6_fast = state.filters.get(&state.lo0_filter_v6).cloned();
+    if !lo0_filter_v6.is_empty() && state.lo0_filter_v6_fast.is_none() {
+        // #3296: lo0 host-bound inet6 input filter missing → fail-open. Refuse.
+        return Err(SnapshotIntegrityError::MissingFilterRef {
+            interface: "lo0".to_string(),
+            family: "inet6".to_string(),
+            direction: "input".to_string(),
+            filter: lo0_filter_v6.to_string(),
+        });
+    }
 
     Ok(state)
 }

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -4804,6 +4804,124 @@ fn protocol_2505_empty_list_is_unconstrained() {
     );
 }
 
+// #3296: an interface hook naming a filter NOT present in the compiled table
+// must reject the whole snapshot (fail closed / preflight preserves prior
+// good state), NOT leave the per-interface fast-path empty and fall through to
+// the default Accept. This is the fail-on-revert canary: deleting the `else`
+// arm in compiler.rs that raises MissingFilterRef turns the missing reference
+// back into a silent Accept and flips these asserts.
+#[test]
+fn missing_filter_ref_3296_input_v4_rejects_not_accepts() {
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "ge-0/0/0.0".into(),
+        ifindex: 5,
+        // typo: the defined filter is WAN_BLOCK; the hook names WAN-BLOCK
+        filter_input_v4: "WAN-BLOCK".into(),
+        ..Default::default()
+    }];
+    let err = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "WAN_BLOCK".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "deny-all".into(),
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect_err("a missing input filter reference must fail the build closed");
+    match err {
+        SnapshotIntegrityError::MissingFilterRef {
+            interface,
+            family,
+            direction,
+            filter,
+        } => {
+            assert_eq!(interface, "ge-0/0/0.0");
+            assert_eq!(family, "inet");
+            assert_eq!(direction, "input");
+            assert_eq!(filter, "WAN-BLOCK");
+        }
+        other => panic!("expected MissingFilterRef, got {other:?}"),
+    }
+}
+
+#[test]
+fn missing_filter_ref_3296_output_v6_rejects_not_accepts() {
+    // The output path is independently fail-open (no needs_tx_eval flag set
+    // for a missing ref), so it must be covered too.
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "ge-0/0/0.0".into(),
+        ifindex: 5,
+        filter_output_v6: "egress6-ghost".into(),
+        ..Default::default()
+    }];
+    let err = parse_filter_state(&[], &[], &ifaces, "", "")
+        .expect_err("a missing output v6 filter reference must fail the build closed");
+    assert!(
+        matches!(
+            err,
+            SnapshotIntegrityError::MissingFilterRef { ref direction, ref family, .. }
+                if direction == "output" && family == "inet6"
+        ),
+        "expected MissingFilterRef output/inet6, got {err:?}"
+    );
+}
+
+#[test]
+fn missing_filter_ref_3296_lo0_input_rejects_not_accepts() {
+    // lo0 host-bound filter (the protect-RE lockout hook) names a filter not
+    // in the table → must reject, not silently leave lo0_filter_v4_fast None
+    // (which falls through to Accept).
+    let err = parse_filter_state(&[], &[], &[], "protect-re-typo", "")
+        .expect_err("a missing lo0 input filter reference must fail the build closed");
+    assert!(
+        matches!(
+            err,
+            SnapshotIntegrityError::MissingFilterRef { ref interface, ref filter, .. }
+                if interface == "lo0" && filter == "protect-re-typo"
+        ),
+        "expected MissingFilterRef lo0/protect-re-typo, got {err:?}"
+    );
+}
+
+#[test]
+fn defined_filter_ref_3296_compiles_cleanly() {
+    // The positive control: a hook whose referenced filter IS defined must
+    // compile (the gate only rejects DANGLING references).
+    let ifaces = vec![crate::InterfaceSnapshot {
+        name: "ge-0/0/0.0".into(),
+        ifindex: 5,
+        filter_input_v4: "WAN_BLOCK".into(),
+        ..Default::default()
+    }];
+    let state = parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "WAN_BLOCK".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "deny-all".into(),
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &ifaces,
+        "",
+        "",
+    )
+    .expect("a defined filter reference must compile cleanly");
+    assert!(
+        state.iface_filter_v4_fast.contains_key(&5),
+        "the resolved filter must be installed on the interface fast path"
+    );
+}
+
 // Go->Rust fixture: the exact #2505 reproduction — `from protocol esp; then
 // discard` must discard ONLY ESP, not all protocols. This is the fail-on-
 // revert canary: restoring the stale local parse_protocol (which drops esp)

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -111,6 +111,33 @@ pub(crate) enum SnapshotIntegrityError {
         term: String,
         token: String,
     },
+    /// #3296: an interface (or lo0) snapshot named a NON-EMPTY firewall filter
+    /// (`filter_input_v4/v6` / `filter_output_v4/v6`, or the lo0 host-bound
+    /// filter) that is not present in the compiled filter table. The pre-fix
+    /// compiler left the per-interface fast-path map (and, for output hooks,
+    /// the `needs_tx_eval` set) with NO entry for the missing key, so the hot
+    /// path returned the default `FilterResult` — Accept. The security hook
+    /// was silently disarmed, indistinguishable from "no filter configured": a
+    /// fail-OPEN on a typo'd firewall reference (e.g. `filter input WAN-BLOCK`
+    /// where the defined filter is `WAN_BLOCK`). Rejecting the whole snapshot
+    /// (the preflight keeps the previous good filter state on a warm reconcile)
+    /// is the fail-closed backstop, consistent with the
+    /// #2124/#2391/#2505 fail-closed family. The Go STRICT commit gate
+    /// (`validateFirewallFilterReferencesStrict`, #3296) is the primary
+    /// defense — a freshly committed config can never carry a dangling
+    /// reference — so a gate-passing config never reaches this arm in normal
+    /// operation; it guards against version/snapshot drift on the lenient /
+    /// peer-sync path. An EMPTY reference (no filter on the hook) is the
+    /// legitimate "unfiltered" case and is NOT an error.
+    ///
+    /// `family` (inet / inet6) is carried alongside the filter name because
+    /// filter names can be REUSED across families.
+    MissingFilterRef {
+        interface: String,
+        family: String,
+        direction: String,
+        filter: String,
+    },
     /// #2391: an interface snapshot named a NON-EMPTY security zone that is not
     /// present in the zone table (`zone_name_to_id`). The pre-fix code resolved
     /// the missing name to `zone_id == 0` (`unwrap_or(0)`), silently collapsing
@@ -291,6 +318,16 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "firewall family {:?} filter {:?} term {:?} has an unresolvable protocol token {:?} — refusing to fail wide by dropping it (which would make the term match every protocol)",
                 family, filter, term, token
+            ),
+            Self::MissingFilterRef {
+                interface,
+                family,
+                direction,
+                filter,
+            } => write!(
+                f,
+                "interface {:?} family {:?} filter {} references undefined filter {:?} — refusing to fail open by leaving the hook unarmed (which would forward unfiltered, equivalent to no filter)",
+                interface, family, direction, filter
             ),
             Self::InterfaceUnknownZone { interface, zone } => write!(
                 f,


### PR DESCRIPTION
## Summary

An interface or lo0 firewall-filter reference naming a filter not defined under `firewall family inet|inet6 filter <name>` was only a commit **warning**, and at runtime the userspace filter compiler left the per-interface fast-path map empty for the missing key, so the hot path returned the default `FilterResult` — **Accept**. The interface forwarded unfiltered, indistinguishable from having no filter: a typo on a security hook (`filter input WAN-BLOCK` where the defined filter is `WAN_BLOCK`) silently failed **OPEN**.

This is the clean shippable win identified in the converged `research/3295-filter-failopen` plan (the sibling #3295 implicit-accept default flip is PLAN-KILLed by the "keep GOOD" wall; this PR ships only the unambiguous #3296 fix).

## Fix

**Primary defense (Go):** new `validateFirewallFilterReferencesStrict` (`pkg/config/compiler_validate_strict.go`), modeled on the existing policer (#2217) and prefix-list (#2506) strict-reference gates. Walks every interface unit's `FilterInputV4/V6` + `FilterOutputV4/V6` against the compiled inet/inet6 filter tables in deterministic order and hard-rejects a dangling reference at commit / commit-check. The firewall-gate cluster call site (`compiler.go`) downgrades it to a warning on the tolerant load / peer-sync path (`opts.lenientFirewallRefs`, #1960) so an already-persisted/peer-synced config still boots. lo0 is covered for free (stored as `cfg.Interfaces.Interfaces["lo0"]`). The new gate supersedes and replaces the warn-only interface filter-reference loop in `compiler_validate_warn.go`.

**Dataplane backstop (Rust):** new `SnapshotIntegrityError::MissingFilterRef`, raised by `parse_filter_state` (`userspace-dp/src/filter/compiler.rs`) when an interface/lo0 names a filter not in the compiled table. As a preflight integrity error it aborts the reconcile before teardown/publish, preserving prior good filter state rather than degrading the hook to Accept (#2124/#2391/#2505 fail-closed family). Covers all four interface directions plus both lo0 input families (the output path is independently fail-open — a missing ref leaves `needs_tx_eval` unset, skipping the TX evaluator). An empty reference (no filter) remains the legitimate unfiltered case.

## RED-on-revert tests

- **Go** (`compiler_filter_ref_3296_test.go`): strict reject for all four interface directions + both lo0 input families; clean commit for defined refs; lenient downgrade-to-warning. Updated 5 pre-existing tests that referenced filters without defining them.
- **Rust**: `missing_filter_ref_3296_{input_v4,output_v6,lo0_input}` assert `MissingFilterRef` not a silent Accept; `defined_filter_ref_3296_compiles_cleanly` positive control.

## Validation

- `go test ./pkg/config/...` green
- `cargo build` green; new Rust tests pass; full Rust suite 3223 pass / 2 pre-existing flakes (event_stream/worker_queue, confirmed failing on pristine origin/master, unrelated)
- Docs: `userspace-dp/src/filter/README.md` updated

Closes #3296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi