### PR TITLE
config: reject unknown inline-term leaf and validate per-application alg (#3352, #3353)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-06-29 — #3348 custom protocol junos-ping echo constraint + icmp-type/icmp-code grammar
+
+- **Timestamp**: 2026-06-29
+- **Action**: A user-defined application with `protocol junos-ping` /
+  `junos-pingv6` lowered to bare ICMP with no type constraint, so the
+  projected policy term matched EVERY ICMP type (security widening — a
+  permit term admitted unreachable/redirect/timestamp, not just echo),
+  broader than the predefined junos-ping object (ICMPType=8, #3020). Added
+  `aliasEchoICMPType` to attach echo type 8/128 on both the top-level and
+  inline-term application paths (after the child loop so an explicit
+  icmp-type wins; all-ICMP aliases stay unconstrained). Also added the
+  missing `icmp-type`/`icmp-code` typed-integer (0..255) schema leaves so
+  an operator can author a constrained custom echo/traceroute/ICMP-control
+  app, wired through to Application.ICMPType/ICMPCode on both paths. Added
+  strict guards (validateApplicationSpecsStrict + protocolIsICMPFamily):
+  reject icmp-type/code on a non-ICMP protocol (never-match term, #3373
+  hazard) and icmp-code without icmp-type; both downgrade to a warning on
+  the lenient load/peer-sync path (#1960). No wire/Rust change — the
+  snapshot already carries the constraint and the matcher already enforces
+  it (#3020).
+- **File(s)**: pkg/config/compiler_applications.go,
+  pkg/config/compiler_validate_strict.go, pkg/config/schema_security.go,
+  pkg/config/compiler_application_junos_ping_3348_test.go,
+  pkg/policymatch/app_junos_ping_3348_test.go,
+  pkg/policymatch/icmp_test.go (stale-comment fix), pkg/config/README.md,
+  docs/config-schema.md
+
 ## 2026-06-28 — #3499 compiler_iface nil zone/interface map-value guards
 
 - **Timestamp**: 2026-06-28

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-06-29 — #3352/#3353 unknown inline-term leaf rejected + per-application alg validated
+
+- **Timestamp**: 2026-06-29
+- **Action**: Two applications-strict-validation gaps, one PR, stacked on
+  #3348. #3352: an unknown leaf inside an inline `application <a> term <t> ...`
+  was silently dropped — `parseApplicationTerms` had no default arm, so a typo
+  like `destination-poort 22` lost the port and the term widened to all-TCP
+  with a clean commit. Added a `default:` arm recording the keyword on
+  `Application.UnknownTermLeaves`; `validateApplicationSpecsStrict` rejects it
+  (lenient-warn on the tolerant path, #1960). #3353: per-application `alg` was
+  stored verbatim with no validation (`alg ftpp` committed clean, silent
+  no-op). Added `supportedApplicationALGs`/`applicationALGSupported` (SSOT =
+  dns/ftp/sip/tftp, mirroring the global `security alg` control + ALGConfig) and
+  a strict-gate check covering both the top-level leaf and the inline-term
+  shape; schema `alg` leaf gained completion examples. ENFORCEMENT DEFERRED
+  (design fork): the per-application ALG is not carried into the userspace
+  snapshot (capabilities.go has no ALG field; only the global alg_disable_flags
+  bitfield is wired) — validate-only, deferred to #2008. Documented the
+  validate-only posture at the gate, schema leaf, and Application.ALG field.
+- **File(s)**: pkg/config/compiler_applications.go,
+  pkg/config/compiler_validate_strict.go, pkg/config/schema_security.go,
+  pkg/config/types_security.go,
+  pkg/config/compiler_application_term_alg_3352_3353_test.go,
+  docs/config-schema.md, pkg/config/README.md
+
 ## 2026-06-29 — #3348 custom protocol junos-ping echo constraint + icmp-type/icmp-code grammar
 
 - **Timestamp**: 2026-06-29

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2260,6 +2260,44 @@ definition, duplicate term-generated name, distinct-names-commit incl. a
 predefined shadow, lenient-warns). Compiler-side only — not a typed `setSchema`
 leaf (applications stay opaque to `SchemaValidate`).
 
+### #3348 — custom `protocol junos-ping` echo constraint + `icmp-type`/`icmp-code` grammar
+
+A **user-defined** application that set `protocol junos-ping` (or `junos-pingv6`)
+lowered to bare ICMP with NO type constraint, so the projected policy term matched
+**every** ICMP type — silently widening any policy referencing it (a permit term
+then admitted unreachable / redirect / timestamp / ... not just echo), and broader
+than the predefined `junos-ping` object which carries `ICMPType=8` (the #3020 fix).
+`appid.ProtocolNumber` and the capability snapshot (`capabilities.go`) folded the
+alias to ICMP and carried `app.ICMPType`, which was `nil` for the custom-app path.
+
+- **alias echo constraint** — `aliasEchoICMPType` (`compiler_applications.go`)
+  maps `junos-ping`→type 8, `junos-pingv6`→type 128. `compileApplications`
+  applies it AFTER the child loop (so an explicit `icmp-type` leaf wins), and
+  `parseApplicationTerms` applies it per normalized protocol inside an inline
+  `term` (capturing the echo type before `normalizeProtocol` folds the alias to
+  `icmp`/`icmpv6`). The all-ICMP aliases (`junos-icmp-all`/`junos-icmp6-all`)
+  return `nil` so they stay match-ALL.
+- **typed grammar** — `schemaApplications.application` gains `icmp-type` and
+  `icmp-code` `ValueInteger` leaves (`ValidateInteger(0,255)`), so an operator can
+  author a constrained custom echo / traceroute / ICMP-control app. The compiler
+  parses them on both the top-level and inline-`term` paths into
+  `Application.ICMPType`/`ICMPCode`.
+- **strict guards** — `validateApplicationSpecsStrict` rejects an
+  `icmp-type`/`icmp-code` on a NON-ICMP protocol (a never-match term — the same
+  fail-open/fail-closed hazard as the #3373 port-on-non-port gate) via
+  `protocolIsICMPFamily`, and rejects an `icmp-code` without an `icmp-type` (an
+  ambiguous half-constraint the matcher would apply code-only). Both downgrade to
+  a `cfg.Warnings` entry on the tolerant load / HA peer-sync path
+  (`lenientApplicationSpecs`, #1960 no-brick).
+
+No wire/Rust change: the snapshot already carries `ICMPType`/`ICMPCode` and the
+matcher already enforces `icmp_constraints` (#3020). Regression coverage:
+`pkg/config/compiler_application_junos_ping_3348_test.go` (alias echo type top-level
++ inline term, all-ICMP stays unconstrained, explicit grammar, explicit-over-alias,
+both strict guards) and the end-to-end matcher test
+`pkg/policymatch/app_junos_ping_3348_test.go` (custom `protocol junos-ping` permits
+type 8, denies 13/5).
+
 ### #2226 — rib-group `import-rib` undefined-reference validation
 
 `routing-options rib-groups <group> import-rib <rib>` was unvalidated: an

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2298,6 +2298,69 @@ both strict guards) and the end-to-end matcher test
 `pkg/policymatch/app_junos_ping_3348_test.go` (custom `protocol junos-ping` permits
 type 8, denies 13/5).
 
+### #3352 — unknown leaf inside an inline `application <a> term <t>` rejected
+
+An inline `applications application <a> term <t> ...` is parsed by
+`parseApplicationTerms` (`compiler_applications.go`), whose `switch` over the
+known term leaves (`protocol` / `source-port` / `destination-port` /
+`icmp-type` / `icmp-code` / `inactivity-timeout` / `timeout` / `alg`) had **no
+default arm**. An unknown keyword — and its value token — were silently dropped,
+so a typo like `protocol tcp destination-poort 22` compiled to an application
+with `Protocol=tcp` and an **empty** `DestinationPort`: a narrow per-port term
+silently widened to **all-TCP**, and the commit SUCCEEDED. The inline-term shape
+is opaque to the schema walk (the `term` leaf is an `args:1` leaf with no typed
+subtree), so `SchemaValidate` cannot reach term leaves.
+
+- **record** — `parseApplicationTerms` now has a `default:` arm that records the
+  unrecognized keyword on the generated `Application.UnknownTermLeaves`
+  (mirroring `UnknownTimeouts`, #3320), consuming the presumed value token so a
+  stray value is not recorded as a second phantom leaf.
+- **reject** — `validateApplicationSpecsStrict` (`compiler_validate_strict.go`)
+  rejects the first `UnknownTermLeaves` entry at the strict commit gate, naming
+  the application and the bad keyword and listing the valid term leaves. The
+  call site (`compiler.go`, `lenientApplicationSpecs`) downgrades it to a
+  `cfg.Warnings` entry on the tolerant load / HA peer-sync path (#1960
+  no-brick).
+
+Regression: `pkg/config/compiler_application_term_alg_3352_3353_test.go`
+(the issue's `destination-poort` example + a bare bogus keyword reject; a
+well-formed term commits cleanly with the port landing; lenient-warn).
+
+### #3353 — per-application `alg` validated at commit (enforcement deferred)
+
+A per-application `alg` (`applications application <a> alg <x>`, top-level or
+inline `term`) was stored verbatim on `Application.ALG` with **no validation**:
+a typo like `alg ftpp` committed cleanly. The operator believed an ALG
+(FTP/SIP/TFTP/DNS control + data tracking) was pinned when none was.
+
+- **validate** — `validateApplicationSpecsStrict` now rejects an `alg` name that
+  is not one of the four ALGs xpf implements — `dns` / `ftp` / `sip` / `tftp`,
+  the SSOT `supportedApplicationALGs` / `applicationALGSupported`, mirroring the
+  global `security alg` control children (`schema_security.go`) and the
+  `ALGConfig` disable flags (`types_security.go`). Strict-reject at commit,
+  lenient-warn on the tolerant load / peer-sync path (#1960). The check reads
+  `app.ALG`, so it covers BOTH the top-level leaf and the inline-`term` shape.
+  The schema `alg` leaf gains `valueExamples` (dns/ftp/sip/tftp) for `?`
+  completion.
+- **enforcement — DEFERRED (design fork).** Validating the name is shipped here;
+  *carrying* a per-application ALG (and a custom-port pin such as `alg ftp
+  destination-port 2121`) into the dataplane is a larger change and is **not**
+  in this PR. The only ALG signal on the userspace wire today is the **global**
+  `alg_disable_flags` bitfield (`userspace-dp/src/protocol/snapshot.rs`); the
+  per-application policy snapshot (`pkg/dataplane/userspace/capabilities.go`)
+  has **no ALG field**, and the matcher does not track a per-app ALG data
+  channel. Wiring it requires a new snapshot field, a Rust decode + session-
+  metadata ALG pin, and matcher enforcement — the per-application slice of the
+  broader ALG parity tracked under #2008. Until then a recognized per-app `alg`
+  is **validate-only** (it gates typos but does not open a data channel), which
+  is documented at the gate, on the schema leaf, and on the `Application.ALG`
+  field. This is the explicit fail-closed-on-typo / honest-no-op posture: reject
+  what xpf cannot enforce, and do not silently accept a name that does nothing.
+
+Regression: `pkg/config/compiler_application_term_alg_3352_3353_test.go`
+(unknown alg reject — top-level + inline term; all four supported ALGs accepted
+and land on the app; lenient-warn).
+
 ### #2226 — rib-group `import-rib` undefined-reference validation
 
 `routing-options rib-groups <group> import-rib <rib>` was unvalidated: an

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -822,6 +822,30 @@ non-port protocol) and an `icmp-code` without an `icmp-type` (an ambiguous
 half-constraint); both downgrade to a warning on the tolerant load/peer-sync
 path. `protocolIsICMPFamily` mirrors the ICMP arm of `filterProtocolResolvable`.
 
+**Unknown inline-term leaf rejected (#3352):** `parseApplicationTerms`
+(`compiler_applications.go`) switches on the known inline-`term` leaves with no
+default arm, so an unknown keyword — and its value — were silently dropped. A
+typo like `term t protocol tcp destination-poort 22` compiled to all-TCP with
+NO destination-port (a silent match widening) and the commit succeeded. The
+inline-term shape is opaque to the schema walk, so the compiler is the only
+place to catch it: a `default:` arm now records the keyword on
+`Application.UnknownTermLeaves` and `validateApplicationSpecsStrict` rejects the
+first one at the strict commit gate (lenient-warn on the tolerant load /
+peer-sync path, #1960).
+
+**Per-application `alg` validated, enforcement deferred (#3353):** a per-app
+`alg` was stored verbatim with no validation — `alg ftpp` committed cleanly (a
+silent no-op). `validateApplicationSpecsStrict` now rejects any name outside the
+four ALGs xpf implements (`dns`/`ftp`/`sip`/`tftp` — `supportedApplicationALGs`,
+the same set the global `security alg` control exposes), covering the top-level
+leaf and the inline-`term` shape via `app.ALG`; strict-reject at commit,
+lenient-warn on the tolerant path. Enforcement is a deliberate fork left to the
+#2008 ALG-parity work: a recognized per-app `alg` is currently **validate-only**
+— it is NOT carried into the userspace snapshot (`capabilities.go` has no ALG
+field; only the global `alg_disable_flags` bitfield is wired), so a custom-port
+ALG pin does not yet open a data channel. The validate-only posture is
+documented at the gate, the schema leaf, and the `Application.ALG` field.
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -801,6 +801,27 @@ is left verbatim so `validatePortSpec` hard-rejects it at the strict commit gate
 and the tolerant load/peer-sync path downgrades it to a warning
 (`lenientApplicationSpecs`, #1960 no-brick).
 
+**Custom-application ICMP type/code constraints (#3348):** a user-defined
+application whose `protocol` is the `junos-ping` / `junos-pingv6` alias now
+carries the same echo-request type constraint the predefined `junos-ping`
+object does (ICMP type 8 / ICMPv6 type 128, the #3020 parity). Before this fix
+the alias lowered to bare ICMP with no type, so a custom `protocol junos-ping`
+app projected a term the userspace matcher (and the `pkg/policymatch`
+simulator) treated as match-ALL ICMP — silently widening any policy that
+referenced it to every ICMP type (unreachable / redirect / timestamp / ...).
+`aliasEchoICMPType` (`compiler_applications.go`) attaches the echo type on both
+the top-level and inline-`term` paths, AFTER the child loop so an explicit
+`icmp-type` leaf still wins; the all-ICMP aliases (`junos-icmp-all` /
+`junos-icmp6-all`) stay unconstrained. The grammar now also exposes typed
+`icmp-type` / `icmp-code` leaves (0..255, range-validated by the schema) on a
+custom application and inline term, so an operator can author a constrained
+echo / traceroute / ICMP-control app rather than only the all-ICMP widening.
+`validateApplicationSpecsStrict` rejects an `icmp-type`/`icmp-code` on a
+non-ICMP protocol (a never-match term, the same #3373 hazard as a port on a
+non-port protocol) and an `icmp-code` without an `icmp-type` (an ambiguous
+half-constraint); both downgrade to a warning on the tolerant load/peer-sync
+path. `protocolIsICMPFamily` mirrors the ICMP arm of `filterProtocolResolvable`.
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler_application_junos_ping_3348_test.go
+++ b/pkg/config/compiler_application_junos_ping_3348_test.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3348: a USER-DEFINED application that sets `protocol junos-ping` (or
+// junos-pingv6) was lowered to bare ICMP with no type constraint, so the
+// projected policy term matched EVERY ICMP type (unreachable / redirect /
+// timestamp / ...) — silently widening any policy that referenced it, and
+// broader than the predefined junos-ping object which carries ICMPType=8
+// (#3020). The compiler must now attach the echo-request type (8 / 128) to a
+// custom app whose protocol is the ping alias, AND support explicit
+// icmp-type/icmp-code grammar on a custom application.
+//
+// Trees are built from flat `set` commands via flatTreeFromSets — the only
+// correct way to exercise the flat-set AST shape (see
+// compiler_application_specs_test.go).
+
+func refApp(name string, props ...string) []string {
+	sets := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application " + name,
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	}
+	for _, p := range props {
+		sets = append(sets, "set applications application "+name+" "+p)
+	}
+	return sets
+}
+
+// Core fail-on-revert: `protocol junos-ping` must lower to ICMP type 8. Revert
+// the compiler change (alias default removed) and app.ICMPType stays nil, so
+// this assertion goes RED.
+func TestApplicationJunosPing_AttachesEchoType(t *testing.T) {
+	cases := []struct {
+		proto    string
+		wantType uint8
+	}{
+		{"junos-ping", 8},
+		{"junos-pingv6", 128},
+	}
+	for _, c := range cases {
+		t.Run(c.proto, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("ping-app", "protocol "+c.proto)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept protocol %s: %v", c.proto, err)
+			}
+			app := cfg.Applications.Applications["ping-app"]
+			if app == nil {
+				t.Fatalf("application ping-app missing from compiled config")
+			}
+			if app.ICMPType == nil {
+				t.Fatalf("protocol %s must attach an ICMP echo type; got nil (matches ALL ICMP — the #3348 widening)", c.proto)
+			}
+			if *app.ICMPType != c.wantType {
+				t.Fatalf("protocol %s must lower to ICMP type %d, got %d", c.proto, c.wantType, *app.ICMPType)
+			}
+			if app.ICMPCode != nil {
+				t.Fatalf("protocol %s must not pin a code, got %d", c.proto, *app.ICMPCode)
+			}
+		})
+	}
+}
+
+// The all-ICMP aliases stay UNCONSTRAINED (nil type) — they intentionally match
+// every ICMP type and must not gain the echo constraint.
+func TestApplicationJunosIcmpAll_StaysUnconstrained(t *testing.T) {
+	for _, proto := range []string{"junos-icmp-all", "junos-icmp6-all"} {
+		t.Run(proto, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("all-icmp", "protocol "+proto)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept protocol %s: %v", proto, err)
+			}
+			if app := cfg.Applications.Applications["all-icmp"]; app == nil || app.ICMPType != nil {
+				t.Fatalf("protocol %s must stay unconstrained (ICMPType nil), got %+v", proto, app)
+			}
+		})
+	}
+}
+
+// Inline term: `term t protocol junos-ping` must attach the echo type to the
+// generated term application too.
+func TestApplicationJunosPing_InlineTerm_AttachesEchoType(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("ping-term", "term t protocol junos-ping")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept inline term protocol junos-ping: %v", err)
+	}
+	app := cfg.Applications.Applications["ping-term-t"]
+	if app == nil {
+		t.Fatalf("inline-term application ping-term-t missing; have %v", appNames(cfg))
+	}
+	if app.ICMPType == nil || *app.ICMPType != 8 {
+		t.Fatalf("inline term protocol junos-ping must lower to ICMP type 8, got %v", app.ICMPType)
+	}
+}
+
+// Explicit grammar: `protocol icmp icmp-type 8 icmp-code 0` must wire through to
+// the typed fields. Fail-on-revert: without the icmp-type/icmp-code schema
+// leaves the set command is rejected at commit (unknown leaf), and without the
+// compiler cases the fields stay nil.
+func TestApplicationExplicitICMPTypeCode(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("echo", "protocol icmp", "icmp-type 8", "icmp-code 0")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept icmp-type/icmp-code grammar: %v", err)
+	}
+	app := cfg.Applications.Applications["echo"]
+	if app == nil || app.ICMPType == nil || *app.ICMPType != 8 {
+		t.Fatalf("explicit icmp-type 8 must set ICMPType=8, got %+v", app)
+	}
+	if app.ICMPCode == nil || *app.ICMPCode != 0 {
+		t.Fatalf("explicit icmp-code 0 must set ICMPCode=0, got %v", app.ICMPCode)
+	}
+}
+
+// An explicit icmp-type wins over the junos-ping alias default.
+func TestApplicationExplicitICMPTypeOverridesAlias(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("ovr", "protocol junos-ping", "icmp-type 13")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept explicit icmp-type override: %v", err)
+	}
+	app := cfg.Applications.Applications["ovr"]
+	if app == nil || app.ICMPType == nil || *app.ICMPType != 13 {
+		t.Fatalf("explicit icmp-type 13 must override the junos-ping echo default, got %+v", app)
+	}
+}
+
+// Strict guard: icmp-type on a non-ICMP protocol is a never-match term — reject
+// at commit (#3348, mirroring the #3373 port-on-non-port-protocol gate).
+func TestApplicationICMPTypeOnNonICMPProtocol_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("bad", "protocol tcp", "icmp-type 8")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT icmp-type on protocol tcp")
+	} else if !strings.Contains(err.Error(), "icmp-type") {
+		t.Fatalf("error should mention icmp-type, got: %v", err)
+	}
+}
+
+// Strict guard: an icmp-code without an icmp-type is an ambiguous half
+// constraint — reject at commit.
+func TestApplicationICMPCodeWithoutType_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("bad2", "protocol icmp", "icmp-code 3")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT icmp-code without icmp-type")
+	} else if !strings.Contains(err.Error(), "icmp-code") {
+		t.Fatalf("error should mention icmp-code, got: %v", err)
+	}
+}
+
+func appNames(cfg *Config) []string {
+	var n []string
+	for name := range cfg.Applications.Applications {
+		n = append(n, name)
+	}
+	return n
+}

--- a/pkg/config/compiler_application_term_alg_3352_3353_test.go
+++ b/pkg/config/compiler_application_term_alg_3352_3353_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3352: an unknown leaf inside an inline `applications application <a> term
+// <t> ...` was SILENTLY ignored — parseApplicationTerms switched on the known
+// term leaves with no default arm, so a typo like `destination-poort 22` (and
+// its value) were dropped and the term kept only its other constraints. A
+// narrow `protocol tcp destination-port 22` term thus widened to all-TCP with
+// NO destination-port, and the commit SUCCEEDED. The compiler now records the
+// unknown keyword on Application.UnknownTermLeaves and
+// validateApplicationSpecsStrict rejects it at the strict commit gate
+// (lenient-warn on the tolerant load / peer-sync path).
+//
+// #3353: a per-application `alg` name was stored verbatim with no validation, so
+// a typo like `alg ftpp` committed cleanly (a silent no-op — the operator
+// believes an ALG is pinned when none is). The strict gate now rejects any name
+// outside the four ALGs xpf implements (dns/ftp/sip/tftp), again lenient-warn on
+// the tolerant path. NOTE: even a recognized per-application alg is validate-only
+// today — per-application ALG enforcement is the deferred half of #3353.
+//
+// All trees are built from flat `set` commands via flatTreeFromSets — the only
+// correct way to exercise set syntax (see CLAUDE.md). refApp / appNames are
+// defined in compiler_application_junos_ping_3348_test.go.
+
+// --- #3352: unknown inline-term leaf -----------------------------------------
+
+// FAIL-ON-REVERT: removing the `default:` arm in parseApplicationTerms (or the
+// `len(app.UnknownTermLeaves) > 0` block in validateApplicationSpecsStrict)
+// makes this commit clean again, so CompileConfig returns nil and the
+// `err == nil` assertion fires RED.
+func TestApplicationTermUnknownLeaf_RejectsAtCommit(t *testing.T) {
+	// The exact worked example from the issue: a misspelled destination-port that
+	// silently widened a narrow TCP/22 term to all-TCP.
+	tree := flatTreeFromSets(t, refApp("widen", "term t1 protocol tcp destination-poort 22")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to REJECT an unknown leaf (destination-poort) inside an inline term")
+	}
+	if !strings.Contains(err.Error(), "destination-poort") {
+		t.Fatalf("error %q must name the unknown leaf destination-poort", err.Error())
+	}
+}
+
+// A second typo shape (an entirely unknown keyword) also rejects, proving the
+// gate is the default arm and not a destination-port-specific check.
+func TestApplicationTermBogusLeaf_RejectsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("bogus", "term t1 protocol tcp frobnicate 9")...)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("expected commit to REJECT an unknown leaf (frobnicate) inside an inline term")
+	}
+	if !strings.Contains(err.Error(), "frobnicate") {
+		t.Fatalf("error %q must name the unknown leaf frobnicate", err.Error())
+	}
+}
+
+// Non-tautological companion: the SAME term with the CORRECT spelling commits
+// cleanly AND the destination-port constraint actually lands on the generated
+// term application (a regression that accepted but dropped the port would be
+// caught by the want check).
+func TestApplicationTermValidLeaves_AcceptsAtCommit(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("ok", "term t1 protocol tcp destination-port 22 source-port 1024-65535")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected a well-formed inline term to commit cleanly: %v", err)
+	}
+	app := cfg.Applications.Applications["ok-t1"]
+	if app == nil {
+		t.Fatalf("inline-term application ok-t1 missing; have %v", appNames(cfg))
+	}
+	if app.DestinationPort != "22" {
+		t.Fatalf("term destination-port must land as 22, got %q (silent widening regression)", app.DestinationPort)
+	}
+	if len(app.UnknownTermLeaves) != 0 {
+		t.Fatalf("well-formed term must record no unknown leaves, got %v", app.UnknownTermLeaves)
+	}
+}
+
+// No-brick (#1960): a config persisted/synced with an unknown inline-term leaf
+// must still LOAD on the tolerant path, downgraded to a warning.
+func TestApplicationTermUnknownLeaf_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("widen", "term t1 protocol tcp destination-poort 22")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of an unknown-term-leaf config must not fail: %v", err)
+	}
+	if !hasAppSpecWarning(cfg.Warnings, "destination-poort") {
+		t.Fatalf("expected a downgraded application-spec warning naming destination-poort, got %v", cfg.Warnings)
+	}
+}
+
+// --- #3353: per-application alg validation -----------------------------------
+
+// FAIL-ON-REVERT: removing the alg block in validateApplicationSpecsStrict makes
+// these commit clean again, turning the assertions RED.
+func TestApplicationUnknownALG_RejectsAtCommit(t *testing.T) {
+	// Top-level alg leaf.
+	t.Run("top-level", func(t *testing.T) {
+		tree := flatTreeFromSets(t, refApp("a", "protocol tcp", "alg ftpp")...)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected commit to REJECT a typo alg ftpp")
+		}
+		if !strings.Contains(err.Error(), "ftpp") || !strings.Contains(err.Error(), "alg") {
+			t.Fatalf("error %q must name the bad alg and the alg keyword", err.Error())
+		}
+	})
+	// Inline-term alg leaf (opaque to the schema walk — only the strict gate
+	// covers it).
+	t.Run("inline-term", func(t *testing.T) {
+		tree := flatTreeFromSets(t, refApp("b", "term t1 protocol tcp alg sipp")...)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("expected commit to REJECT a typo alg sipp inside an inline term")
+		}
+		if !strings.Contains(err.Error(), "sipp") {
+			t.Fatalf("error %q must name the bad alg sipp", err.Error())
+		}
+	})
+}
+
+// Every supported ALG (the four xpf implements) commits cleanly and the value
+// lands on the compiled application.
+func TestApplicationValidALG_AcceptsAtCommit(t *testing.T) {
+	for _, alg := range []string{"dns", "ftp", "sip", "tftp"} {
+		t.Run(alg, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("c", "protocol tcp", "alg "+alg)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept alg %s: %v", alg, err)
+			}
+			if app := cfg.Applications.Applications["c"]; app == nil || app.ALG != alg {
+				t.Fatalf("alg %s must land on the compiled application, got %+v", alg, app)
+			}
+		})
+	}
+}
+
+// No-brick (#1960): a config persisted/synced with an unsupported alg must still
+// LOAD on the tolerant path, downgraded to a warning.
+func TestApplicationUnknownALG_LenientWarns(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("a", "protocol tcp", "alg ftpp")...)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient load of an unknown-alg config must not fail: %v", err)
+	}
+	if !hasAppSpecWarning(cfg.Warnings, "ftpp") {
+		t.Fatalf("expected a downgraded application-spec warning naming ftpp, got %v", cfg.Warnings)
+	}
+}
+
+func hasAppSpecWarning(warnings []string, needle string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, "application spec") && strings.Contains(w, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -170,6 +170,7 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	var dstPort, srcPort, alg string
 	var timeout int
 	var badTimeouts []string
+	var unknownLeaves []string
 	var icmpType, icmpCode *uint8
 	// #3348: per normalized-protocol echo-type implied by a junos-ping /
 	// junos-pingv6 alias inside an inline term. normalizeProtocol folds the
@@ -230,6 +231,22 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 				i++
 				alg = keys[i]
 			}
+		default:
+			// #3352: an unknown leaf keyword inside an inline term (e.g. a
+			// misspelled `destination-poort`) was silently dropped here — the
+			// switch had no default arm, so the keyword AND its value token were
+			// skipped, and the term kept only its other constraints. A narrow
+			// `protocol tcp destination-poort 22` then widened to all-TCP with no
+			// destination-port, and the commit SUCCEEDED. Record the offending
+			// keyword so validateApplicationSpecsStrict rejects it at the strict
+			// commit gate (lenient-warn on the tolerant load / peer-sync path).
+			// Skip the presumed value token too — every term leaf in this grammar
+			// is keyword+value, so consuming the value keeps a stray value from
+			// being recorded as a second phantom unknown leaf.
+			unknownLeaves = append(unknownLeaves, keys[i])
+			if i+1 < len(keys) {
+				i++
+			}
 		}
 	}
 
@@ -271,6 +288,7 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			InactivityTimeout: timeout,
 			ALG:               alg,
 			UnknownTimeouts:   badTimeouts,
+			UnknownTermLeaves: unknownLeaves,
 			ICMPType:          it,
 			ICMPCode:          icmpCode,
 		})

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -67,6 +67,19 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 						app.UnknownTimeouts = append(app.UnknownTimeouts, v)
 					}
 				}
+			case "icmp-type":
+				// #3348: explicit ICMP/ICMPv6 message-type constraint for a
+				// custom application. The schema validates the 0..255 range on
+				// the strict commit path (schema_security.go ValidateInteger),
+				// so a malformed token has already been rejected before compile;
+				// drop a stray unparsable value here rather than widening.
+				if t, ok := parseICMPTypeCode(nodeVal(prop)); ok {
+					app.ICMPType = t
+				}
+			case "icmp-code":
+				if c, ok := parseICMPTypeCode(nodeVal(prop)); ok {
+					app.ICMPCode = c
+				}
 			case "alg":
 				app.ALG = nodeVal(prop)
 			case "description":
@@ -85,6 +98,20 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 				}
 				termApps := parseApplicationTerms(appName, allKeys)
 				terms = append(terms, termApps...)
+			}
+		}
+
+		// #3348: a custom application whose `protocol` is the junos-ping /
+		// junos-pingv6 alias must carry the same echo-request type constraint
+		// the predefined junos-ping object does (#3020). Without it the alias
+		// lowered to bare ICMP with ICMPType=nil, which the userspace matcher
+		// (and the pkg/policymatch simulator) treat as match-ALL ICMP — silently
+		// widening any policy referencing the app to every ICMP type
+		// (unreachable / redirect / timestamp / ...). Apply the default AFTER the
+		// child loop so an explicit `icmp-type` leaf still wins.
+		if app.ICMPType == nil {
+			if t := aliasEchoICMPType(app.Protocol); t != nil {
+				app.ICMPType = t
 			}
 		}
 
@@ -143,13 +170,38 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	var dstPort, srcPort, alg string
 	var timeout int
 	var badTimeouts []string
+	var icmpType, icmpCode *uint8
+	// #3348: per normalized-protocol echo-type implied by a junos-ping /
+	// junos-pingv6 alias inside an inline term. normalizeProtocol folds the
+	// alias to "icmp"/"icmpv6" and loses the ping distinction, so capture the
+	// echo type keyed by the normalized protocol before that information is
+	// gone.
+	echoByProto := map[string]*uint8{}
 
 	for i := 1; i < len(keys); i++ {
 		switch keys[i] {
 		case "protocol":
 			if i+1 < len(keys) {
 				i++
-				protocols = append(protocols, normalizeProtocol(keys[i]))
+				norm := normalizeProtocol(keys[i])
+				protocols = append(protocols, norm)
+				if t := aliasEchoICMPType(keys[i]); t != nil {
+					echoByProto[norm] = t
+				}
+			}
+		case "icmp-type":
+			if i+1 < len(keys) {
+				i++
+				if t, ok := parseICMPTypeCode(keys[i]); ok {
+					icmpType = t
+				}
+			}
+		case "icmp-code":
+			if i+1 < len(keys) {
+				i++
+				if c, ok := parseICMPTypeCode(keys[i]); ok {
+					icmpCode = c
+				}
 			}
 		case "destination-port":
 			if i+1 < len(keys) {
@@ -204,6 +256,13 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			}
 			name = parentName + "-" + termName + "-" + suffix
 		}
+		// An explicit inline-term `icmp-type` wins; otherwise fall back to the
+		// echo type implied by a junos-ping / junos-pingv6 protocol alias on
+		// this protocol (#3348).
+		it := icmpType
+		if it == nil {
+			it = echoByProto[proto]
+		}
 		result = append(result, &Application{
 			Name:              name,
 			Protocol:          proto,
@@ -212,9 +271,50 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			InactivityTimeout: timeout,
 			ALG:               alg,
 			UnknownTimeouts:   badTimeouts,
+			ICMPType:          it,
+			ICMPCode:          icmpCode,
 		})
 	}
 	return result
+}
+
+// aliasEchoICMPType returns the echo-request ICMP / ICMPv6 type implied by a
+// "ping" protocol alias — junos-ping -> 8 (ICMP echo-request), junos-pingv6 ->
+// 128 (ICMPv6 echo-request) — or nil for any other token.
+//
+// #3348: a user-defined application that set `protocol junos-ping` was lowered
+// to bare ICMP with no type constraint, so the projected policy term matched
+// EVERY ICMP type (unreachable / redirect / timestamp / ...) — silently
+// widening any policy that referenced it, and broader than the predefined
+// junos-ping object which carries ICMPType=8 (#3020). Attaching the echo type
+// makes a custom `protocol junos-ping` app behave like the predefined one. The
+// all-ICMP aliases (junos-icmp-all / junos-icmp6-all) intentionally return nil
+// so they stay unconstrained (match every type).
+func aliasEchoICMPType(proto string) *uint8 {
+	switch strings.ToLower(strings.TrimSpace(proto)) {
+	case "junos-ping":
+		return u8p(8)
+	case "junos-pingv6":
+		return u8p(128)
+	default:
+		return nil
+	}
+}
+
+// parseICMPTypeCode parses an application `icmp-type` / `icmp-code` token. It
+// returns the value and true when the token is a base-10 integer in [0,255]
+// (the ICMP/ICMPv6 type and code wire range); otherwise (nil, false). The
+// strict commit path validates the range earlier via the schema
+// (schema_security.go ValidateInteger(0,255)), so this is the compile-time
+// projection of an already-accepted token; an unparsable value is dropped
+// rather than widening the term.
+func parseICMPTypeCode(raw string) (*uint8, bool) {
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n < 0 || n > 255 {
+		return nil, false
+	}
+	v := uint8(n)
+	return &v, true
 }
 
 // normalizeProtocol maps Junos protocol aliases to canonical names

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3141,6 +3141,36 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"configured one)",
 				name, app.UnknownTimeouts[0], appTimeoutMin, appTimeoutMax)
 		}
+		// #3348: an icmp-type/icmp-code constraint is only meaningful on an
+		// ICMP/ICMPv6 protocol. The userspace matcher keys icmp_constraints
+		// under the ICMP protocol number (userspace-dp policy.rs), and the
+		// pkg/policymatch simulator only consults app.ICMPType when the query
+		// protocol is ICMP/ICMPv6 — so a type/code on tcp/udp/gre/... compiles a
+		// term that can never match (fail-open for a deny rule, fail-closed for a
+		// permit rule), the same #3373 hazard as a port on a non-port protocol.
+		// Junos couples icmp-type/code to an ICMP application, so reject at COMMIT
+		// (strict-at-commit / #1960 fail-closed). The call site downgrades to a
+		// warning on the tolerant load / peer-sync path.
+		if (app.ICMPType != nil || app.ICMPCode != nil) && !protocolIsICMPFamily(app.Protocol) {
+			return fmt.Errorf(
+				"application %q: icmp-type/icmp-code is set on protocol %q, which is "+
+					"not an ICMP protocol; an ICMP type/code constraint is valid only on "+
+					"icmp/icmpv6 (or the junos-ping/junos-pingv6/junos-icmp-all aliases, "+
+					"or protocol number 1/58) — on any other protocol the term can never "+
+					"match (remove the constraint or change the protocol)",
+				name, app.Protocol)
+		}
+		// A code with no type leaves the matcher constraining the code while
+		// ignoring the type (pkg/policymatch matchSingleApp checks ICMPCode
+		// independently of ICMPType), an ambiguous half-constraint Junos does not
+		// allow. Require a type whenever a code is set.
+		if app.ICMPCode != nil && app.ICMPType == nil {
+			return fmt.Errorf(
+				"application %q: icmp-code is set without icmp-type; an ICMP code is "+
+					"meaningful only together with a type (set icmp-type as well, or "+
+					"remove icmp-code)",
+				name)
+		}
 	}
 	return nil
 }
@@ -4148,6 +4178,25 @@ func protocolIsPortBearing(token string) bool {
 		// ports (ip_proto.rs has_l4_ports).
 		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
 			return n == 6 || n == 17
+		}
+		return false
+	}
+}
+
+// protocolIsICMPFamily reports whether a protocol token names ICMP or ICMPv6 —
+// the only protocols on which an application `icmp-type`/`icmp-code` constraint
+// is enforceable (#3348). It recognizes the canonical names, the junos-*
+// aliases that resolve to ICMP/ICMPv6 (including junos-ping/junos-pingv6, which
+// carry an implicit echo type), and the numeric protocol numbers 1 (ICMP) and
+// 58 (ICMPv6). The set mirrors the ICMP arm of filterProtocolResolvable.
+func protocolIsICMPFamily(token string) bool {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "icmp", "junos-icmp-all", "junos-ping",
+		"icmpv6", "icmp6", "junos-icmp6-all", "junos-pingv6":
+		return true
+	default:
+		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
+			return n == 1 || n == 58
 		}
 		return false
 	}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3171,8 +3171,78 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"remove icmp-code)",
 				name)
 		}
+		// #3352: an unknown leaf keyword inside an inline `term { ... }` was
+		// silently dropped by parseApplicationTerms (its switch had no default
+		// arm), so a typo like `destination-poort 22` lost the port constraint
+		// and the term widened (e.g. a narrow `protocol tcp destination-port 22`
+		// term became all-TCP) with the commit succeeding. The inline-term shape
+		// is opaque to the schema walk (the `term` leaf carries no typed subtree),
+		// so this gate — fed by the recorded Application.UnknownTermLeaves — is the
+		// only place the unknown leaf can be rejected. Junos rejects an unknown
+		// statement under `applications application <a> term`; reject at COMMIT
+		// (strict-at-commit / #1960 fail-closed). The call site downgrades to a
+		// warning on the tolerant load / peer-sync path so an already-persisted or
+		// older-peer-synced config still BOOTS.
+		if len(app.UnknownTermLeaves) > 0 {
+			return fmt.Errorf(
+				"application %q: unknown statement %q inside inline term; a misspelled "+
+					"or unsupported term leaf is silently dropped along with its value, "+
+					"which can WIDEN the term's match (e.g. dropping a destination-port "+
+					"leaves an all-port term) — valid inline-term leaves are protocol, "+
+					"source-port, destination-port, icmp-type, icmp-code, "+
+					"inactivity-timeout/timeout, alg",
+				name, app.UnknownTermLeaves[0])
+		}
+		// #3353: a per-application `alg` name was stored verbatim with no
+		// validation, so a typo like `alg ftpp` committed cleanly and the operator
+		// believed an ALG was pinned when none was. xpf recognizes only the four
+		// ALGs the dataplane implements (the same set the global `security alg`
+		// control exposes — dns/ftp/sip/tftp, ALGConfig); any other name is a
+		// silent no-op. Reject an unknown name at COMMIT (strict-at-commit / #1960
+		// fail-closed), lenient-warn on the tolerant load / peer-sync path. NOTE:
+		// even a recognized per-application alg is currently validate-only — the
+		// per-application ALG (and a custom-port pin) is NOT carried into the
+		// userspace snapshot (capabilities.go has no ALG field); only the GLOBAL
+		// alg-disable bitfield is wired to the dataplane. Per-application ALG
+		// enforcement is deferred to the broader #2008 ALG parity work and tracked
+		// by the #3353 enforcement half (see docs/config-schema.md).
+		if app.ALG != "" && !applicationALGSupported(app.ALG) {
+			return fmt.Errorf(
+				"application %q: unknown alg %q; xpf supports the ALGs %s — an "+
+					"unrecognized name is silently accepted but never enforced, so the "+
+					"data channel is not tracked (fix the name or remove the alg)",
+				name, app.ALG, strings.Join(supportedApplicationALGs(), "/"))
+		}
 	}
 	return nil
+}
+
+// supportedApplicationALGs is the SSOT for the ALG names xpf recognizes on a
+// per-application `alg` leaf. It mirrors the global `security alg` control
+// children (schema_security.go) and the ALGConfig disable flags
+// (types_security.go) — the only ALGs the dataplane implements. The list is
+// returned sorted so error messages are deterministic.
+//
+// #3353: per-application ALG is validated against this set at commit. The set is
+// deliberately the four implemented ALGs rather than the broader Junos ALG
+// catalog (rtsp/h323/sunrpc/...): xpf cannot enforce an ALG it does not
+// implement, so accepting such a name would reproduce the silent-no-op the gate
+// exists to prevent. Recognized names are still NOT enforced per-application
+// today (only the global disable bitfield is wired) — see the deferred
+// enforcement half of #3353.
+func supportedApplicationALGs() []string {
+	return []string{"dns", "ftp", "sip", "tftp"}
+}
+
+// applicationALGSupported reports whether name is one of the ALGs xpf
+// implements (case-insensitive). #3353.
+func applicationALGSupported(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "dns", "ftp", "sip", "tftp":
+		return true
+	default:
+		return false
+	}
 }
 
 // applicationsToValidateStrict returns the set of user-defined application

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -698,8 +698,17 @@ var schemaApplications = &schemaNode{desc: "Applications", children: map[string]
 		// walk, so it is covered by validateApplicationSpecsStrict instead.
 		"inactivity-timeout": {desc: "Inactivity timeout", args: 1, valueType: ValueInteger, valueDesc: "Timeout in seconds", valueExamples: []string{"300", "1800"}, validator: ValidateInteger(appTimeoutMin, appTimeoutMax), placeholder: "<seconds>", children: nil},
 		"timeout":            {desc: "Timeout", args: 1, valueType: ValueInteger, valueDesc: "Timeout in seconds", valueExamples: []string{"300", "1800"}, validator: ValidateInteger(appTimeoutMin, appTimeoutMax), placeholder: "<seconds>", children: nil},
-		"alg":                {desc: "Application layer gateway", args: 1, placeholder: "<alg>", children: nil},
-		"description":        {desc: "Description", args: 1, placeholder: "<text>", children: nil},
+		// #3353: per-application ALG. The value is validated against the four
+		// implemented ALGs (dns/ftp/sip/tftp) at the strict commit gate
+		// (validateApplicationSpecsStrict / applicationALGSupported), which also
+		// covers the inline-`term` shape (opaque to the schema walk); the examples
+		// here drive `?` completion. An unknown name is rejected at commit and
+		// lenient-warned on the tolerant load/peer-sync path. NOTE: a recognized
+		// per-application alg is currently validate-only — it is not yet carried to
+		// the userspace dataplane (only the global `security alg` disable bitfield
+		// is wired); per-application enforcement is the deferred half of #3353.
+		"alg":         {desc: "Application layer gateway (dns/ftp/sip/tftp)", args: 1, valueExamples: []string{"dns", "ftp", "sip", "tftp"}, placeholder: "<alg>", children: nil},
+		"description": {desc: "Description", args: 1, placeholder: "<text>", children: nil},
 		// #3348: typed ICMP/ICMPv6 type/code constraints (0..255) so an operator
 		// can author a constrained custom echo / traceroute / ICMP-control app —
 		// the runtime supports it (userspace-dp icmp_constraints, the #3020 fix)

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -700,7 +700,15 @@ var schemaApplications = &schemaNode{desc: "Applications", children: map[string]
 		"timeout":            {desc: "Timeout", args: 1, valueType: ValueInteger, valueDesc: "Timeout in seconds", valueExamples: []string{"300", "1800"}, validator: ValidateInteger(appTimeoutMin, appTimeoutMax), placeholder: "<seconds>", children: nil},
 		"alg":                {desc: "Application layer gateway", args: 1, placeholder: "<alg>", children: nil},
 		"description":        {desc: "Description", args: 1, placeholder: "<text>", children: nil},
-		"term":               {desc: "Term", args: 1, placeholder: "<term>", children: nil},
+		// #3348: typed ICMP/ICMPv6 type/code constraints (0..255) so an operator
+		// can author a constrained custom echo / traceroute / ICMP-control app —
+		// the runtime supports it (userspace-dp icmp_constraints, the #3020 fix)
+		// but the grammar previously did not. Range-validated at the strict
+		// commit gate; validateApplicationSpecsStrict additionally rejects the
+		// constraint on a non-ICMP protocol (and a code without a type).
+		"icmp-type": {desc: "ICMP/ICMPv6 message type", args: 1, valueType: ValueInteger, valueDesc: "ICMP type (e.g. 8 = echo-request, 128 = ICMPv6 echo-request)", valueExamples: []string{"8", "128"}, validator: ValidateInteger(0, 255), placeholder: "<type>", children: nil},
+		"icmp-code": {desc: "ICMP/ICMPv6 message code", args: 1, valueType: ValueInteger, valueDesc: "ICMP code", valueExamples: []string{"0"}, validator: ValidateInteger(0, 255), placeholder: "<code>", children: nil},
+		"term":      {desc: "Term", args: 1, placeholder: "<term>", children: nil},
 	}},
 	"application-set": {desc: "Application set", args: 1, valueHint: ValueHintAppSetName, placeholder: "<name>", children: nil},
 }}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -621,8 +621,17 @@ type Application struct {
 	DestinationPort   string // "80", "8080-8090"
 	SourcePort        string // "1024-65535" (optional)
 	InactivityTimeout int    // seconds (0 = default)
-	ALG               string // "ssh", "ftp", etc. (informational)
-	Description       string
+	// ALG names a per-application application-layer gateway. #3353: it is
+	// validated at commit against the four ALGs xpf implements (dns/ftp/sip/tftp,
+	// validateApplicationSpecsStrict / applicationALGSupported) — an unknown name
+	// is rejected at commit / lenient-warned on the tolerant path. It remains
+	// validate-only: the per-application ALG is NOT carried into the userspace
+	// snapshot (capabilities.go has no ALG field; only the global
+	// `security alg` disable bitfield is wired), so a recognized per-app alg does
+	// not yet open/track a data channel. Per-application enforcement is the
+	// deferred half of #3353, tracked under the #2008 ALG-parity work.
+	ALG         string
+	Description string
 	// ICMPType / ICMPCode constrain an ICMP/ICMPv6 application to a single
 	// message type (and optionally code), e.g. junos-ping = ICMP type 8
 	// (echo-request) and junos-pingv6 = ICMPv6 type 128. nil means "no
@@ -641,6 +650,19 @@ type Application struct {
 	// zero default, silently falling the application back to the global
 	// per-protocol timeout instead of the configured one (#3320).
 	UnknownTimeouts []string
+	// UnknownTermLeaves records the unrecognized leaf keywords found inside an
+	// inline `application <a> term <t> { ... }` definition. The inline-term shape
+	// is opaque to the schema walk (the `term` leaf is an args:1 leaf with no
+	// typed subtree), so parseApplicationTerms is the only place an unknown leaf
+	// such as a misspelled `destination-poort` can be detected. Before #3352 its
+	// switch had no default arm: an unknown leaf — and its value token — were
+	// silently dropped, so a term like `protocol tcp destination-poort 22`
+	// compiled to all-TCP with NO destination-port constraint (a silent match
+	// widening). parseApplicationTerms now records the offending keyword(s) here
+	// (mirroring UnknownTimeouts) and the deferred gate
+	// (validateApplicationSpecsStrict) hard-rejects them on the strict commit
+	// path / warns on the lenient load / peer-sync path (#1960 no-brick).
+	UnknownTermLeaves []string
 }
 
 // IPsecConfig holds IPsec VPN configuration.

--- a/pkg/policymatch/app_junos_ping_3348_test.go
+++ b/pkg/policymatch/app_junos_ping_3348_test.go
@@ -1,0 +1,51 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestCustomJunosPingApp_EchoOnly is the #3348 end-to-end fail-on-revert: a
+// USER-DEFINED application `mgmt-ping` whose protocol is the junos-ping alias,
+// referenced by an allow policy, must permit ICMP echo-request (type 8) ONLY,
+// not every ICMP type. Before the compiler attached the echo constraint to the
+// alias, the custom app lowered to bare ICMP (ICMPType nil) and the matcher
+// treated it as match-ALL ICMP, so timestamp/redirect/etc. were silently
+// permitted — the security widening this issue fixes. Reverting the
+// compiler_applications.go alias default makes the "denies timestamp" case go
+// RED (the matcher permits it).
+func TestCustomJunosPingApp_EchoOnly(t *testing.T) {
+	cfg := compileFromSet(t, []string{
+		"set applications application mgmt-ping protocol junos-ping",
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security policies from-zone trust to-zone untrust policy allow match source-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy allow match application mgmt-ping",
+		"set security policies from-zone trust to-zone untrust policy allow then permit",
+		"set security policies default-policy deny-all",
+	})
+
+	tests := []struct {
+		name        string
+		icmpType    uint8
+		wantMatched bool
+		wantAction  config.PolicyAction
+	}{
+		{"echo-request type 8 permitted", 8, true, config.PolicyPermit},
+		{"timestamp type 13 denied", 13, false, config.PolicyDeny},
+		{"redirect type 5 denied", 5, false, config.PolicyDeny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ty := tt.icmpType
+			q := Query{FromZone: "trust", ToZone: "untrust", Protocol: "icmp", ICMPType: &ty}
+			res := Match(cfg, q)
+			if res.Matched != tt.wantMatched || res.Action != tt.wantAction {
+				t.Fatalf("custom junos-ping app, ICMP type %d: got matched=%v action=%v, want matched=%v action=%v",
+					tt.icmpType, res.Matched, res.Action, tt.wantMatched, tt.wantAction)
+			}
+		})
+	}
+}

--- a/pkg/policymatch/icmp_test.go
+++ b/pkg/policymatch/icmp_test.go
@@ -121,10 +121,13 @@ func TestICMPTypeConstraintParity(t *testing.T) {
 // (normalizeUserspaceApplicationProtocol("")=="") → the __unsupported__ sentinel
 // → whole-snapshot reject (#3261), and strict commit hard-rejects a protocol-less
 // app (pkg/config/compiler_validate_strict.go). It is also not constructible via
-// real config: the application compiler (compiler_applications.go) has no
-// `icmp-type` property, so a user app can NEVER set ICMPType — only predefined
-// apps do (junos-ping/junos-pingv6), and those always pin Protocol. So
-// Protocol=="" implies a no-protocol app the runtime drops.
+// real config: as of #3348 a user app CAN carry an ICMP type (via the
+// `icmp-type`/`icmp-code` grammar or a junos-ping/junos-pingv6 protocol alias),
+// but the application compiler (compiler_applications.go) only ever attaches a
+// type alongside a pinned ICMP protocol — and validateApplicationSpecsStrict
+// rejects an icmp-type on a non-ICMP protocol and a protocol-less app outright.
+// So a real config can never produce Protocol=="" with ICMPType set; this case
+// is the hand-built unrepresentable shape the runtime drops.
 //
 // The simulator must therefore report NO concrete match for this app, for EVERY
 // query protocol — mirroring the dataplane reject. Before #3323 the


### PR DESCRIPTION
Two applications strict-validation gaps from codex-review-082, fixed together. **Stacked on #3348 (PR #3506)** — base is `fix/3348-app-junos-ping`; GitHub auto-retargets to `master` when #3506 merges. Until then the file-diff view also shows #3348's commits; the per-issue changes are the `compiler_application_term_alg_3352_3353_test.go` file plus the term-leaf / alg blocks.

## #3352 — unknown inline-term leaf rejected
An unknown leaf inside an inline `application <a> term <t> ...` was silently ignored: `parseApplicationTerms` switched on the known term leaves with **no default arm**, so a typo like `protocol tcp destination-poort 22` dropped the keyword AND its value, leaving the term with no destination-port — a narrow per-port term silently widened to **all-TCP**, commit SUCCEEDED. The inline-term shape is opaque to the schema walk, so the compiler is the only place to catch it.

- `parseApplicationTerms` gains a `default:` arm recording the keyword on `Application.UnknownTermLeaves` (mirrors `UnknownTimeouts`, #3320), consuming the presumed value token.
- `validateApplicationSpecsStrict` rejects the first entry at the strict commit gate; lenient-warn on the tolerant load / HA peer-sync path (#1960).

## #3353 — per-application `alg` validated (enforcement deferred)
`alg ftpp` committed cleanly (silent no-op). `validateApplicationSpecsStrict` now rejects any name outside the four ALGs xpf implements (`dns`/`ftp`/`sip`/`tftp` — SSOT `supportedApplicationALGs`/`applicationALGSupported`, mirroring the global `security alg` control + `ALGConfig`), covering the top-level leaf and the inline-`term` shape via `app.ALG`; strict-reject / lenient-warn. Schema `alg` leaf gains completion examples.

**Enforcement is a deliberate fork, DEFERRED.** Carrying a per-application ALG (and a custom-port pin) into the dataplane needs a new snapshot field + Rust decode + session-metadata pin + matcher enforcement — the per-application slice of #2008. The userspace snapshot (`capabilities.go`) has no ALG field today; only the global `alg_disable_flags` bitfield is wired. A recognized per-app `alg` is **validate-only** until then, documented at the gate, schema leaf, `Application.ALG`, `pkg/config/README.md`, and `docs/config-schema.md`. Fail-closed-on-typo / honest-no-op: reject what xpf cannot enforce, never silently accept a name that does nothing.

## Validation
- `go test ./pkg/config/... ./pkg/appid/...` green; `gofmt` clean; `go vet` clean.
- **RED-on-revert verified**: neutralizing the parse default arm + the two strict blocks turns all six new assertions red.
- New tests (`pkg/config/compiler_application_term_alg_3352_3353_test.go`): unknown term leaf rejected (issue's `destination-poort` example + a bogus keyword), well-formed term accepted with the port landing, unknown alg rejected (top-level + inline term), all four supported ALGs accepted and landing, both gaps lenient-warn.

Closes #3352
Closes #3353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi