### PR TITLE
applications: reject unknown inline-term leaves and unsupported per-app alg (#3352, #3353)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2412,6 +2412,53 @@ both strict guards) and the end-to-end matcher test
 `pkg/policymatch/app_junos_ping_3348_test.go` (custom `protocol junos-ping` permits
 type 8, denies 13/5).
 
+### #3352 / #3353 — unknown inline-`term` leaf + per-application `alg` validation
+
+An inline `applications application <a> term <t> { ... }` is declared as an
+opaque `args:1` schema leaf (`schemaApplications.application.term`,
+`children:nil`), so `SchemaValidate` cannot reach inside it. Two silent-accept
+gaps lived under that opacity:
+
+- **#3352 — unknown leaf inside a `term`.** `parseApplicationTerms`
+  (`compiler_applications.go`) was a fixed `switch` with no `default` arm, so a
+  typo'd leaf (`term t1 { protocol tcp; destination-poort 22; }`) was silently
+  dropped along with its value token — the term kept only its remaining
+  constraints (`protocol tcp`) and a narrow permit/deny term **widened to
+  all-TCP**, with no commit error. The parser now records every unrecognized
+  token on `Application.UnknownTermLeaves` (mirroring `UnknownTimeouts` /
+  `UnknownICMP`), and `validateApplicationSpecsStrict` rejects the first one at
+  commit. A custom application term accepts only `protocol` / `source-port` /
+  `destination-port` / `inactivity-timeout` / `timeout` / `icmp-type` /
+  `icmp-code` / `alg`.
+- **#3353 — unsupported per-application `alg`.** The `alg` leaf was a raw
+  `args:1` string with no validator, so a typo (`alg ftpp`) committed cleanly
+  and the operator believed an ALG was pinned when none existed (a silent no-op
+  on a security knob). `validateApplicationSpecsStrict` now validates the name
+  against `supportedApplicationALGs` (`compiler_applications.go`) — the SSOT
+  set `dns`/`ftp`/`sip`/`tftp`, MIRRORING the global `security alg <proto>`
+  control (`algDisableFlags`, `pkg/dataplane/userspace/flow.go`). The same gate
+  covers the top-level `app.ALG` and the inline-term `alg` (the term app carries
+  it). The match is case-insensitive.
+
+  **#3353 is VALIDATION only — enforcement is deferred.** A per-application ALG
+  is recorded on `Application.ALG` but is NOT carried into the userspace
+  dataplane snapshot: the only ALG signal on the wire is the *global*
+  `alg_disable_flags` bitfield (`userspace-dp` `snapshot.rs`), with no
+  per-application ALG / custom-port pin. Wiring per-application ALG (e.g. `alg
+  ftp destination-port 2121`) through to enforcement needs a new snapshot field
+  plus Rust session-metadata handling — a genuine dataplane fork that is the
+  per-application slice of the broader ALG parity tracked under **#2008**, and
+  is deliberately not built here. Until then this gate makes an unsupported
+  name an operator-visible commit error instead of a silent no-op.
+
+Both checks are STRICT on the commit / commit-check path and downgrade to a
+`cfg.Warnings` entry on the tolerant load / HA peer-sync path
+(`lenientApplicationSpecs`, #1960 no-brick), the same discipline as the #3320 /
+#3348 application gates. Regression coverage:
+`pkg/config/compiler_application_term_alg_3352_3353_test.go` (unknown term leaf
+rejected, well-formed term keeps its port constraint, unknown alg rejected
+top-level + inline-term, supported alg names accepted on both paths).
+
 ### #2226 — rib-group `import-rib` undefined-reference validation
 
 `routing-options rib-groups <group> import-rib <rib>` was unvalidated: an

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2451,13 +2451,34 @@ gaps lived under that opacity:
   is deliberately not built here. Until then this gate makes an unsupported
   name an operator-visible commit error instead of a silent no-op.
 
+**Scope — ALL user-defined applications, referenced or not.** These two checks
+live in a SEPARATE pass, `validateApplicationSyntaxStrict`, that iterates every
+entry in `cfg.Applications.Applications`, NOT the reference-scoped
+`applicationsToValidateStrict` subset that `validateApplicationSpecsStrict` uses
+for its port / protocol / icmp / timeout checks. The reference scope is correct
+for those SEMANTIC checks (an unreferenced malformed-port app cannot break a
+live policy decision, so it stays a warning so an operator iterating on a
+not-yet-wired application library is not blocked). But an unknown term statement
+and an unsupported `alg` are SYNTACTIC / enum violations — the config names a
+statement or an ALG that does not exist — which Junos rejects at commit
+regardless of policy wiring; deferring them until reference would let a typo'd
+term-leaf silently widen a term, or a bogus `alg` silently no-op, from the
+moment the app is defined. `cfg.Applications.Applications` holds ONLY
+user-defined applications (and the per-term apps they generate); PREDEFINED
+junos-* apps (`junos-rtsp`, `junos-h323`, ...) live in the separate
+`PredefinedApplications` table and are never in this map, so the `alg` check
+never false-rejects a predefined app that legitimately carries an
+out-of-supported-set ALG.
+
 Both checks are STRICT on the commit / commit-check path and downgrade to a
 `cfg.Warnings` entry on the tolerant load / HA peer-sync path
 (`lenientApplicationSpecs`, #1960 no-brick), the same discipline as the #3320 /
 #3348 application gates. Regression coverage:
 `pkg/config/compiler_application_term_alg_3352_3353_test.go` (unknown term leaf
-rejected, well-formed term keeps its port constraint, unknown alg rejected
-top-level + inline-term, supported alg names accepted on both paths).
+rejected referenced AND unreferenced, well-formed term keeps its port
+constraint, unknown alg rejected top-level + inline-term + unreferenced,
+supported alg names accepted on both paths, predefined-app reference not
+rejected).
 
 ### #2226 — rib-group `import-rib` undefined-reference validation
 

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2362,6 +2362,24 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #3352/#3353: syntactic application errors (an unknown leaf inside an
+	// opaque inline `term`, or an unsupported `alg` name) are rejected for ALL
+	// user-defined applications — referenced or not — unlike the
+	// reference-scoped semantic specs above. These are grammar / enum
+	// violations Junos rejects at commit regardless of policy wiring; a typo'd
+	// term-leaf silently widens a term and a bogus `alg` silently no-ops from
+	// the moment the app is defined, so they must be caught at definition.
+	// Lenient-downgrade on the tolerant load / peer-sync path, identical to
+	// validateApplicationSpecsStrict (#1960 no-brick).
+	if err := validateApplicationSyntaxStrict(cfg); err != nil {
+		if opts.lenientApplicationSpecs {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("application syntax (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
 	// #2175 firewall-filter `from protocol <token>` fail-open gate. Strict on
 	// commit / commit-check (hard-reject a term whose protocol token is not
 	// resolvable by the centralized appid.ProtocolNumber SSOT — neither a

--- a/pkg/config/compiler_application_term_alg_3352_3353_test.go
+++ b/pkg/config/compiler_application_term_alg_3352_3353_test.go
@@ -125,3 +125,88 @@ func TestApplicationALG_SupportedName_InlineTerm_Accepted(t *testing.T) {
 		t.Fatalf("inline-term alg ftp must be recorded, got %+v", app)
 	}
 }
+
+// unrefAppOnly builds a config carrying ONLY `set applications application
+// <name> <prop>...` lines — the application is NOT named by any policy,
+// application-set, or NAT rule, so it is OUTSIDE applicationsToValidateStrict's
+// referenced / app-id-enabled subset. The #3352/#3353 syntactic gate
+// (validateApplicationSyntaxStrict) must still reject a typo'd term leaf or a
+// bad alg here, at the moment the app is defined.
+func unrefAppOnly(name string, props ...string) []string {
+	var sets []string
+	for _, p := range props {
+		sets = append(sets, "set applications application "+name+" "+p)
+	}
+	return sets
+}
+
+// #3352 scope fail-on-revert (the Codex MERGE-NEEDS-MAJOR gap): an UNREFERENCED
+// user application with a typo'd inline-term leaf must be rejected at commit.
+// Before widening the gate to all user apps this committed silently (the app is
+// not in applicationsToValidateStrict). Revert validateApplicationSyntaxStrict's
+// all-user-apps loop and this goes RED.
+func TestApplicationTerm_UnknownLeaf_Unreferenced_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t, unrefAppOnly("lonely", "term t1 protocol tcp destination-poort 22")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT unknown term leaf on an UNREFERENCED app")
+	} else if !strings.Contains(err.Error(), "unknown statement") {
+		t.Fatalf("error should mention the unknown statement, got: %v", err)
+	}
+}
+
+// #3353 scope fail-on-revert: an UNREFERENCED user application with an
+// unsupported `alg` must be rejected at commit (top-level and inline-term).
+func TestApplicationALG_UnknownName_Unreferenced_Rejected(t *testing.T) {
+	cases := [][]string{
+		{"protocol tcp", "alg ftpp"},
+		{"term t protocol tcp alg h323"},
+	}
+	for i, props := range cases {
+		t.Run(strings.Join(props, "_"), func(t *testing.T) {
+			tree := flatTreeFromSets(t, unrefAppOnly("lonely", props...)...)
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("case %d: expected commit to REJECT unknown alg on an UNREFERENCED app", i)
+			} else if !strings.Contains(err.Error(), "unknown alg") {
+				t.Fatalf("case %d: error should mention the unknown alg, got: %v", i, err)
+			}
+		})
+	}
+}
+
+// Guard against over-rejection: an UNREFERENCED user app with only valid leaves
+// and a supported alg still commits cleanly.
+func TestApplicationTermALG_Unreferenced_Valid_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t, unrefAppOnly("lonely",
+		"protocol tcp", "destination-port 22", "alg ftp",
+		"term t protocol udp destination-port 53 alg dns")...)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("expected commit to accept a well-formed UNREFERENCED app: %v", err)
+	}
+}
+
+// Predefined junos-* applications (junos-rtsp / junos-ftp / ...) are owned by
+// the PredefinedApplications table, NOT cfg.Applications.Applications, so the
+// all-user-apps syntax gate never reaches them. A policy referencing a
+// predefined app — including ones that legitimately carry ALGs — must still
+// commit cleanly (the widening must not false-reject predefined apps).
+func TestApplicationALG_PredefinedApp_NotRejected(t *testing.T) {
+	for _, pre := range []string{"junos-rtsp", "junos-ftp"} {
+		t.Run(pre, func(t *testing.T) {
+			sets := []string{
+				"set security zones security-zone trust",
+				"set security zones security-zone untrust",
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application " + pre,
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			}
+			tree := flatTreeFromSets(t, sets...)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("expected commit to accept predefined app %q reference: %v", pre, err)
+			}
+			if _, isUser := PredefinedApplications[pre]; !isUser {
+				t.Fatalf("test precondition: %q must be a predefined app", pre)
+			}
+		})
+	}
+}

--- a/pkg/config/compiler_application_term_alg_3352_3353_test.go
+++ b/pkg/config/compiler_application_term_alg_3352_3353_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3352 / #3353: an inline `applications application <a> term <t> { ... }` is an
+// opaque `args:1` schema leaf (children:nil), so the SchemaValidate walk cannot
+// reach inside it. Before these fixes:
+//   - #3352: an unknown leaf inside a term (a typo like `destination-poort 22`)
+//     was silently dropped along with its value — parseApplicationTerms had no
+//     default arm — so a narrow permit/deny term widened to all-protocol.
+//   - #3353: a per-application `alg` name was a raw string with no validator, so
+//     a typo (`alg ftpp`) committed cleanly and the operator believed an ALG was
+//     pinned when none was.
+//
+// Trees are built from flat `set` commands via flatTreeFromSets + refApp (shared
+// with compiler_application_junos_ping_3348_test.go) — the only correct way to
+// exercise the flat-set AST shape.
+
+// #3352 core fail-on-revert: an unknown leaf inside an inline term must be
+// rejected at commit. Revert the parseApplicationTerms default arm (or the
+// strict gate) and the typo'd leaf is silently dropped, the term compiles to
+// all-TCP, CompileConfig succeeds, and this assertion goes RED.
+func TestApplicationTerm_UnknownLeaf_Rejected(t *testing.T) {
+	cases := []string{
+		"term t1 protocol tcp destination-poort 22",
+		"term t1 protocol tcp source-prt 1024",
+		"term t1 protocol tcp bogus-leaf foo",
+	}
+	for _, term := range cases {
+		t.Run(term, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("badterm", term)...)
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("expected commit to REJECT unknown term leaf %q", term)
+			} else if !strings.Contains(err.Error(), "unknown statement") {
+				t.Fatalf("error should mention the unknown statement, got: %v", err)
+			}
+		})
+	}
+}
+
+// A WELL-FORMED inline term (only recognized leaves) still compiles and keeps
+// its port constraint — guards the #3352 gate against over-rejection and proves
+// the widening is gone (the term carries the destination-port, not all-TCP).
+func TestApplicationTerm_ValidLeaves_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("okterm",
+		"term t1 protocol tcp destination-port 22 source-port 1024-65535 inactivity-timeout 300")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept a well-formed inline term: %v", err)
+	}
+	app := cfg.Applications.Applications["okterm-t1"]
+	if app == nil {
+		t.Fatalf("inline-term application okterm-t1 missing; have %v", appNames(cfg))
+	}
+	if app.DestinationPort != "22" {
+		t.Fatalf("term must keep its destination-port 22 (not widen to all-TCP), got %q", app.DestinationPort)
+	}
+	if app.SourcePort != "1024-65535" {
+		t.Fatalf("term must keep its source-port, got %q", app.SourcePort)
+	}
+	if app.InactivityTimeout != 300 {
+		t.Fatalf("term must keep its inactivity-timeout 300, got %d", app.InactivityTimeout)
+	}
+}
+
+// #3353 core fail-on-revert: an unknown per-application `alg` name (top-level)
+// must be rejected at commit. Revert the strict-gate ALG check and `alg ftpp`
+// commits cleanly, so this assertion goes RED.
+func TestApplicationALG_UnknownName_TopLevel_Rejected(t *testing.T) {
+	for _, bad := range []string{"ftpp", "ssh", "h323", "bogus"} {
+		t.Run(bad, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("bad", "protocol tcp", "alg "+bad)...)
+			if _, err := CompileConfig(tree); err == nil {
+				t.Fatalf("expected commit to REJECT unknown alg %q", bad)
+			} else if !strings.Contains(err.Error(), "unknown alg") {
+				t.Fatalf("error should mention the unknown alg, got: %v", err)
+			}
+		})
+	}
+}
+
+// #3353: an unknown `alg` inside an inline term must also be rejected — the term
+// app carries the ALG and the strict gate validates it the same way.
+func TestApplicationALG_UnknownName_InlineTerm_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("badterm", "term t protocol tcp alg ftpp")...)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT unknown inline-term alg")
+	} else if !strings.Contains(err.Error(), "unknown alg") {
+		t.Fatalf("error should mention the unknown alg, got: %v", err)
+	}
+}
+
+// A supported `alg` name (the DNS/FTP/SIP/TFTP set the global `security alg`
+// control exposes) must still commit and be recorded — guards against
+// over-rejection and proves the SSOT set is honored on both paths.
+func TestApplicationALG_SupportedNames_Accepted(t *testing.T) {
+	for _, ok := range []string{"dns", "ftp", "sip", "tftp", "FTP"} {
+		t.Run(ok, func(t *testing.T) {
+			tree := flatTreeFromSets(t, refApp("okalg", "protocol tcp", "alg "+ok)...)
+			cfg, err := CompileConfig(tree)
+			if err != nil {
+				t.Fatalf("expected commit to accept supported alg %q: %v", ok, err)
+			}
+			app := cfg.Applications.Applications["okalg"]
+			if app == nil || app.ALG != ok {
+				t.Fatalf("supported alg %q must be recorded on the application, got %+v", ok, app)
+			}
+		})
+	}
+}
+
+// A supported inline-term `alg` still commits and is carried onto the generated
+// term application.
+func TestApplicationALG_SupportedName_InlineTerm_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t, refApp("okterm", "term t protocol tcp alg ftp")...)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("expected commit to accept inline-term alg ftp: %v", err)
+	}
+	app := cfg.Applications.Applications["okterm-t"]
+	if app == nil || app.ALG != "ftp" {
+		t.Fatalf("inline-term alg ftp must be recorded, got %+v", app)
+	}
+}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -182,6 +182,11 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 	var badTimeouts []string
 	var icmpType, icmpCode *uint8
 	var badICMP []string
+	// #3352: tokens inside the inline term that are not a recognized leaf.
+	// The term subtree is opaque to SchemaValidate (children:nil), so without
+	// a default arm an unknown leaf (and its value) were silently dropped,
+	// widening the term. Record them for the deferred strict gate.
+	var badTermLeaves []string
 	// #3348: per normalized-protocol echo-type implied by a junos-ping /
 	// junos-pingv6 alias inside an inline term. normalizeProtocol folds the
 	// alias to "icmp"/"icmpv6" and loses the ping distinction, so capture the
@@ -264,6 +269,15 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 				i++
 				alg = keys[i]
 			}
+		default:
+			// #3352: an unrecognized token inside the inline term. This catches
+			// both a typo'd leaf keyword (e.g. `destination-poort`) and the value
+			// that follows it (which, being a non-keyword, also lands here) —
+			// either way the term subtree carried something the parser cannot
+			// honor, so record it and let validateApplicationSpecsStrict reject
+			// the first one rather than silently dropping the constraint and
+			// widening the match.
+			badTermLeaves = append(badTermLeaves, keys[i])
 		}
 	}
 
@@ -310,6 +324,7 @@ func parseApplicationTerms(parentName string, keys []string) []*Application {
 			ICMPType:          it,
 			ICMPCode:          icmpCode,
 			UnknownICMP:       badICMP,
+			UnknownTermLeaves: badTermLeaves,
 		})
 	}
 	return result
@@ -496,6 +511,40 @@ func validatePortSpec(spec string) error {
 		return fmt.Errorf("invalid port %d: must be 1-65535", port)
 	}
 	return nil
+}
+
+// supportedApplicationALGs is the single source of truth for the per-application
+// `alg` names xpf recognizes. It MIRRORS the global `security alg <proto>`
+// control surface (schema_security.go `alg` children + algDisableFlags in
+// pkg/dataplane/userspace/flow.go), which exposes exactly DNS / FTP / SIP / TFTP.
+// A name outside this set is a silent operator error today: before #3353 the
+// per-application `alg` leaf was a raw `args:1` string with no validator, so a
+// typo (`alg ftpp`) committed cleanly and the operator believed an ALG was
+// pinned when none existed.
+//
+// #3353 ships VALIDATION only. The per-application ALG is recorded on
+// Application.ALG but is NOT carried into the userspace dataplane snapshot — the
+// only ALG signal on the wire is the global alg_disable_flags bitfield
+// (userspace-dp snapshot.rs), there is no per-application ALG / custom-port pin.
+// Wiring per-application ALG (e.g. `alg ftp destination-port 2121`) through to
+// enforcement is a genuine dataplane fork (it needs a new snapshot field plus
+// Rust session-metadata handling) and is the per-application slice of the
+// broader ALG parity tracked under #2008; it is deliberately deferred. Until
+// then this gate makes an unsupported name an operator-visible commit error
+// instead of a silent no-op.
+var supportedApplicationALGs = map[string]bool{
+	"dns":  true,
+	"ftp":  true,
+	"sip":  true,
+	"tftp": true,
+}
+
+// validApplicationALG reports whether name is a supported per-application ALG.
+// The match is case-insensitive (like validatePortSpec / validateProtocol). An
+// empty name means "no alg" and is treated as valid by the caller before this
+// is reached.
+func validApplicationALG(name string) bool {
+	return supportedApplicationALGs[strings.ToLower(strings.TrimSpace(name))]
 }
 
 // validateProtocol checks that a protocol specification is valid.

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -167,7 +167,7 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 }
 
 // parseApplicationTerms parses an inline term like:
-// "term-name [alg ssh] protocol tcp [source-port 22] [destination-port 22] [inactivity-timeout 86400]"
+// "term-name [alg ftp] protocol tcp [source-port 22] [destination-port 22] [inactivity-timeout 86400]"
 // When multiple protocol values are present, returns one Application per
 // unique protocol (each sharing the same ports/timeout/alg).
 func parseApplicationTerms(parentName string, keys []string) []*Application {

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3386,18 +3386,61 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"remove icmp-code)",
 				name)
 		}
+	}
+	return nil
+}
+
+// validateApplicationSyntaxStrict hard-rejects SYNTACTIC errors in a
+// user-defined application definition that the typed-schema walk cannot reach:
+// an unrecognized leaf inside an opaque inline `term { ... }` (#3352) and an
+// `alg` name xpf does not support (#3353).
+//
+// Unlike validateApplicationSpecsStrict — whose port / protocol / icmp / timeout
+// checks are SEMANTIC and deliberately scoped to REFERENCED applications (an
+// unreferenced malformed app cannot break a live policy decision, so it stays a
+// warning so an operator iterating on a not-yet-wired application library is not
+// blocked, see that function's doc) — these two checks run over EVERY
+// user-defined application, referenced or not. They are grammar / enum
+// violations (the config names a statement or an ALG that does not exist), the
+// same class Junos rejects at commit regardless of whether the application is
+// wired into a policy; deferring them until the app is referenced would let a
+// typo'd term-leaf silently widen a term, or a bogus `alg` silently no-op, from
+// the moment it is defined. The map iterated is cfg.Applications.Applications,
+// which holds ONLY user-defined applications and the per-term applications they
+// generate (`<parent>-<term>`); PREDEFINED junos-* applications (junos-rtsp /
+// junos-h323 / junos-pptp, which legitimately use ALGs outside the supported
+// set) are owned by the predefined table and are never in this map, so they are
+// never reached by the `alg` check. Iteration is sorted by name so the
+// first-reported error is deterministic.
+//
+// Strict on the commit / commit-check path; the call site (compiler.go,
+// lenientApplicationSpecs) downgrades a returned error to a warning on the
+// tolerant load / peer-sync path so an already-persisted or older-peer-synced
+// config still BOOTS (#1960 no-brick).
+func validateApplicationSyntaxStrict(cfg *Config) error {
+	if cfg == nil || len(cfg.Applications.Applications) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(cfg.Applications.Applications))
+	for name := range cfg.Applications.Applications {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		app := cfg.Applications.Applications[name]
+		if app == nil {
+			continue
+		}
 		// #3352: an unrecognized leaf inside an inline `term { ... }`. The term
 		// subtree is an opaque `args:1` schema leaf (children:nil), so the
 		// SchemaValidate walk never reaches inside it and a typo'd leaf (e.g.
 		// `destination-poort 22`) was silently dropped along with its value —
 		// the term kept only its remaining constraints (e.g. `protocol tcp`) and
 		// a narrow permit/deny term widened to all-protocol (all-TCP), with no
-		// commit error. parseApplicationTerms now records the offending token on
+		// commit error. parseApplicationTerms records the offending token on
 		// UnknownTermLeaves (mirroring UnknownTimeouts / UnknownICMP); reject the
-		// first one here so the silent match-widening becomes an operator-visible
-		// commit error. Strict on the commit / commit-check path; the call site
-		// (compiler.go, lenientApplicationSpecs) downgrades it to a warning on the
-		// tolerant load / peer-sync path (#1960 no-brick).
+		// first one so the silent match-widening becomes an operator-visible
+		// commit error.
 		if len(app.UnknownTermLeaves) > 0 {
 			return fmt.Errorf(
 				"application %q: unknown statement %q inside `term`; a custom "+
@@ -3417,8 +3460,7 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 		// (the wire has only the global alg_disable_flags bitfield), so a valid
 		// `alg` name remains informational until the enforcement half lands. That
 		// dataplane half is a genuine fork (new snapshot field + Rust) tracked as
-		// the per-application slice of #2008. Strict on the commit / commit-check
-		// path; lenient-warn on the tolerant load / peer-sync path.
+		// the per-application slice of #2008.
 		if app.ALG != "" && !validApplicationALG(app.ALG) {
 			return fmt.Errorf(
 				"application %q: unknown alg %q; supported application ALGs are "+

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3386,6 +3386,48 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 					"remove icmp-code)",
 				name)
 		}
+		// #3352: an unrecognized leaf inside an inline `term { ... }`. The term
+		// subtree is an opaque `args:1` schema leaf (children:nil), so the
+		// SchemaValidate walk never reaches inside it and a typo'd leaf (e.g.
+		// `destination-poort 22`) was silently dropped along with its value —
+		// the term kept only its remaining constraints (e.g. `protocol tcp`) and
+		// a narrow permit/deny term widened to all-protocol (all-TCP), with no
+		// commit error. parseApplicationTerms now records the offending token on
+		// UnknownTermLeaves (mirroring UnknownTimeouts / UnknownICMP); reject the
+		// first one here so the silent match-widening becomes an operator-visible
+		// commit error. Strict on the commit / commit-check path; the call site
+		// (compiler.go, lenientApplicationSpecs) downgrades it to a warning on the
+		// tolerant load / peer-sync path (#1960 no-brick).
+		if len(app.UnknownTermLeaves) > 0 {
+			return fmt.Errorf(
+				"application %q: unknown statement %q inside `term`; a custom "+
+					"application term accepts only protocol / source-port / "+
+					"destination-port / inactivity-timeout / timeout / icmp-type / "+
+					"icmp-code / alg (an unrecognized leaf is silently dropped along "+
+					"with its value, widening the term to match more than intended)",
+				name, app.UnknownTermLeaves[0])
+		}
+		// #3353: a per-application `alg` name that is not one xpf supports. The
+		// `alg` leaf is a raw string with no schema validator, so a typo
+		// (`alg ftpp`) committed cleanly and the operator believed an ALG was
+		// pinned when none existed (a silent no-op on a security knob). Validate
+		// it against supportedApplicationALGs — the same DNS/FTP/SIP/TFTP set the
+		// global `security alg` control exposes. This is VALIDATION only: the
+		// per-application ALG is still not carried to the userspace dataplane
+		// (the wire has only the global alg_disable_flags bitfield), so a valid
+		// `alg` name remains informational until the enforcement half lands. That
+		// dataplane half is a genuine fork (new snapshot field + Rust) tracked as
+		// the per-application slice of #2008. Strict on the commit / commit-check
+		// path; lenient-warn on the tolerant load / peer-sync path.
+		if app.ALG != "" && !validApplicationALG(app.ALG) {
+			return fmt.Errorf(
+				"application %q: unknown alg %q; supported application ALGs are "+
+					"dns/ftp/sip/tftp (the same set the global `security alg` control "+
+					"exposes). NOTE: a per-application alg is validated at commit but "+
+					"is not yet enforced by the userspace dataplane — enforcement is "+
+					"deferred to the per-application ALG slice of #2008",
+				name, app.ALG)
+		}
 	}
 	return nil
 }

--- a/pkg/config/parser_ast_test.go
+++ b/pkg/config/parser_ast_test.go
@@ -1606,8 +1606,8 @@ func TestMultiTermApplication(t *testing.T) {
 	input := `applications {
     application ssh-long {
         description "Long SSH sessions";
-        term 22 alg ssh protocol tcp destination-port 22 inactivity-timeout 86400;
-        term 2222 alg ssh protocol tcp destination-port 2222 inactivity-timeout 86400;
+        term 22 alg ftp protocol tcp destination-port 22 inactivity-timeout 86400;
+        term 2222 alg ftp protocol tcp destination-port 2222 inactivity-timeout 86400;
     }
     application FaceTime {
         term 41642_65535 protocol udp source-port 41642-65535 destination-port 3478-3497;
@@ -1644,8 +1644,8 @@ func TestMultiTermApplication(t *testing.T) {
 	if term22.DestinationPort != "22" {
 		t.Errorf("ssh-long-22 dest-port: got %q, want 22", term22.DestinationPort)
 	}
-	if term22.ALG != "ssh" {
-		t.Errorf("ssh-long-22 ALG: got %q, want ssh", term22.ALG)
+	if term22.ALG != "ftp" {
+		t.Errorf("ssh-long-22 ALG: got %q, want ftp", term22.ALG)
 	}
 	if term22.InactivityTimeout != 86400 {
 		t.Errorf("ssh-long-22 timeout: got %d, want 86400", term22.InactivityTimeout)

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -660,6 +660,20 @@ type Application struct {
 	// (validateApplicationSpecsStrict) hard-rejects it on the strict commit path
 	// / warns on the lenient load / peer-sync path (#3348).
 	UnknownICMP []string
+	// UnknownTermLeaves records the raw tokens inside an inline
+	// `application <a> term <t> { ... }` that are NOT a recognized term leaf
+	// (protocol / source-port / destination-port / inactivity-timeout / timeout
+	// / icmp-type / icmp-code / alg). The inline `term` is declared as an opaque
+	// `args:1` schema leaf (children:nil), so the SchemaValidate walk cannot
+	// reach inside it; before #3352 parseApplicationTerms had no default arm, so
+	// an unknown leaf (a typo like `destination-poort 22`) was silently dropped
+	// along with its value — the term kept only its remaining constraints and a
+	// narrow permit/deny term widened to all-protocol (e.g. all-TCP). Mirroring
+	// UnknownTimeouts / UnknownICMP, the offending token is recorded here and the
+	// deferred gate (validateApplicationSpecsStrict) hard-rejects the first one
+	// on the strict commit path / warns on the tolerant load / peer-sync path
+	// (#3352).
+	UnknownTermLeaves []string
 }
 
 // IPsecConfig holds IPsec VPN configuration.


### PR DESCRIPTION
## Summary

Two silent-accept gaps under the opaque inline `applications application <a>
term <t> { ... }` schema leaf (`args:1`, `children:nil` — invisible to the
`SchemaValidate` walk). Re-implemented cleanly on current master (prior stacked
PR #3512 was closed/superseded; #3348 + #3332 are now merged, so no stacking).

### #3352 — unknown leaf inside a `term`
`parseApplicationTerms` was a fixed `switch` with no `default` arm, so a typo'd
leaf (`term t1 { protocol tcp; destination-poort 22; }`) was silently dropped
along with its value token — the term kept only its remaining constraints
(`protocol tcp`) and a narrow permit/deny term **widened to all-TCP**, with no
commit error. The parser now records unrecognized tokens on
`Application.UnknownTermLeaves` (mirroring `UnknownTimeouts` / `UnknownICMP`)
and `validateApplicationSpecsStrict` rejects the first at commit.

### #3353 — unsupported per-application `alg`
The `alg` leaf was a raw string with no validator (`alg ftpp` committed
cleanly). `validateApplicationSpecsStrict` now validates against
`supportedApplicationALGs` — the SSOT set `dns`/`ftp`/`sip`/`tftp`, mirroring
the global `security alg` control (`algDisableFlags`). Covers the top-level
`app.ALG` and the inline-term `alg`; case-insensitive.

**#3353 is VALIDATION only — enforcement deferred.** A per-application ALG is
recorded on `Application.ALG` but is NOT carried into the userspace snapshot
(the wire has only the global `alg_disable_flags` bitfield). Wiring
per-application ALG (e.g. `alg ftp destination-port 2121`) through to
enforcement is a genuine dataplane fork (new snapshot field + Rust) and is the
per-application slice of #2008 — deliberately not built here.

Both checks are STRICT on commit / commit-check and lenient-warn on the tolerant
load / HA peer-sync path (`lenientApplicationSpecs`, #1960 no-brick).

## Validation
- `go test ./pkg/config/... ./pkg/appid/...` green.
- `pkg/config/compiler_application_term_alg_3352_3353_test.go` is **RED-on-revert**:
  neutering either strict gate makes the unknown-term-leaf and unknown-alg
  rejections fail; the well-formed term/alg acceptance tests guard against
  over-rejection.
- gofmt clean on all touched files.
- `docs/config-schema.md` documents both gates and the deferred #2008 enforcement.

Closes #3352
Closes #3353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi