### PR TITLE
REST session view: mirror gRPC contract (#3419)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-06-29 — #3419 REST session-view parity with gRPC
+
+- **Timestamp**: 2026-06-29
+- **Action**: The REST `GET /api/v1/security/sessions` view diverged from
+  the gRPC `GetSessions` contract (Codex audit 099 H1/H2/H3/M1/M3/M4/M6).
+  Fixed: `age_seconds` is now wall age (now-`Created`) with a separate
+  `idle_seconds` (now-`LastSeen`) — REST previously reported idle time AS
+  age (H1); a session with both SNAT and DNAT now joins both `nat` text
+  parts and exposes structured `nat_src_addr/port` + `nat_dst_addr/port`
+  instead of the DNAT branch overwriting the SNAT string (H2); the
+  companion reverse entry's counters are merged into the forward entry via
+  new `GetSessionV4/V6` on `apiRuntimeDataPlane` (H3); `application`,
+  `ingress_interface`/`egress_interface`, `policy_name`,
+  `ingress_zone_name`/`egress_zone_name`, `session_id`, and `ha_active`
+  are surfaced (M1/M4/M6), and `application=`, `interface=`, `nat_only=`,
+  `source_nat_pool=` filters added (M1/M3/M4) — an unresolved pool fails
+  CLOSED (HTTP 400) like the gRPC `sessionFilter.validate`. `ha_active`
+  is wired from the daemon via a new optional `HAActiveFn` (default true
+  standalone = `cluster.IsLocalPrimary(0)`). Numeric `policy_id`/zone ids
+  retained for compatibility. Pagination/clear out of scope (#3421/#3423).
+- **File(s)**: pkg/api/sessions.go, pkg/api/types.go, pkg/api/api.go,
+  pkg/api/server.go, pkg/api/sessions_parity_test.go, pkg/api/README.md,
+  pkg/daemon/runtime_probes.go, pkg/daemon/daemon_run.go
+
 ## 2026-06-29 — #3322 reorder-stable policy hit-counter handle
 
 - **Timestamp**: 2026-06-29

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -202,6 +202,30 @@ under the daemon's errgroup. Nothing else imports this package.
   EXACTLY (case-insensitive), not by substring — `protocol=C` no longer
   over-matches TCP/ICMP/ICMPv6. These contracts are pinned by
   `rest_filter_failclosed_test.go` in this package.
+- The `GET /api/v1/security/sessions` view mirrors the gRPC `GetSessions`
+  session contract (#3419). The REST `SessionEntry` previously diverged from
+  gRPC — `age_seconds` carried IDLE time (now-LastSeen) instead of wall age,
+  a session with both SNAT and DNAT lost the SNAT part (the DNAT branch
+  overwrote the single `nat` string), the reverse entry's counters were not
+  merged into the forward entry, and the application/interface/policy-name/
+  zone-name/session-id/ha-active fields were absent. The handler now:
+  - splits `age_seconds` (now-`Created`) from `idle_seconds` (now-`LastSeen`);
+  - joins BOTH NAT parts in `nat` and exposes structured `nat_src_addr/port`
+    and `nat_dst_addr/port`;
+  - merges the companion reverse entry's counters via `GetSessionV4/V6`
+    (added to `apiRuntimeDataPlane`) so top-talkers/accounting report full
+    bidirectional volume;
+  - resolves `application` (`appid.ResolveSessionName`), `ingress_interface`/
+    `egress_interface` (FIB ifindex+VLAN → unit name), `policy_name`,
+    `ingress_zone_name`/`egress_zone_name`, `session_id`, and `ha_active`
+    (wired from the daemon via `HAActiveFn`, default true standalone).
+
+  It also accepts the gRPC filter set: `application=`, `interface=`,
+  `nat_only=true`, and `source_nat_pool=<pool>` (an unresolved pool fails
+  CLOSED with HTTP 400, like the gRPC `sessionFilter.validate`). The numeric
+  `policy_id`/`ingress_zone`/`egress_zone` fields are retained for
+  compatibility. Pagination/clear (limit/offset cursor, filtered clear) are
+  tracked separately (#3421/#3423). Pinned by `sessions_parity_test.go`.
 - `GET /api/v1/security/match` (`matchPoliciesHandler`) is a THIN adapter
   over the single shared policy simulator `pkg/policymatch` (#3042). It only
   validates/parses inputs (400 on a malformed IP/port) and renders the

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,6 +17,13 @@ type apiRuntimeDataPlane interface {
 	IsLoaded() bool
 	IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error
 	IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	// GetSessionV4/V6 look up a single session entry by key. The session
+	// view uses them to merge the companion reverse entry's counters into
+	// the forward entry, matching the gRPC enrichment (#3419 H3). Without
+	// the merge, REST top-talkers/accounting under-report the reverse
+	// direction's volume.
+	GetSessionV4(dataplane.SessionKey) (dataplane.SessionValue, error)
+	GetSessionV6(dataplane.SessionKeyV6) (dataplane.SessionValueV6, error)
 	ClearAllSessions() (int, int, error)
 
 	ReadGlobalCounter(uint32) (uint64, error)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -167,6 +167,12 @@ type Config struct {
 	// Optional; if nil or it returns ok=false the simulator evaluates scheduled
 	// policies as-if-active (the pre-#3104 behavior / #3062 display fallback).
 	PolicySchedulerActiveStateFn func() (map[string]bool, bool)
+	// HAActiveFn reports whether THIS node is the active cluster member for
+	// the default resource group, surfaced as the session ha_active field
+	// (#3419 M6), mirroring the gRPC contract (server_sessions.go
+	// IsLocalPrimary(0)). Optional; if nil the session view reports
+	// ha_active=true (the standalone default).
+	HAActiveFn func() bool
 }
 
 // Server is the HTTP API server.
@@ -198,6 +204,7 @@ type Server struct {
 	flowCollectorHealthFn     func() []flowexport.ExporterCollectorHealth
 	feedOverlayFn             func() map[string][]string
 	policySchedActiveFn       func() (map[string]bool, bool)
+	haActiveFn                func() bool
 	startTime                 time.Time
 }
 
@@ -229,6 +236,7 @@ func NewServer(cfg Config) *Server {
 		flowCollectorHealthFn:     cfg.FlowCollectorHealthFn,
 		feedOverlayFn:             cfg.FeedOverlayFn,
 		policySchedActiveFn:       cfg.PolicySchedulerActiveStateFn,
+		haActiveFn:                cfg.HAActiveFn,
 		startTime:                 time.Now(),
 	}
 

--- a/pkg/api/sessions.go
+++ b/pkg/api/sessions.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/psaab/xpf/pkg/appid"
+	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
@@ -26,12 +27,13 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 		limit = 10000
 	}
 	offset := queryInt(r, "offset", 0)
-	zoneFilter, ok := queryUint16Strict(r, "zone", 0)
-	if !ok {
-		writeError(w, http.StatusBadRequest, "invalid zone filter: "+r.URL.Query().Get("zone"))
+
+	view := s.buildSessionView()
+	q, errMsg := buildSessionQuery(r, view)
+	if errMsg != "" {
+		writeError(w, http.StatusBadRequest, errMsg)
 		return
 	}
-	protoFilter := r.URL.Query().Get("protocol")
 
 	now := monotonicSeconds()
 	all := make([]SessionEntry, 0)
@@ -41,18 +43,20 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 	// mid-scan) must fail the request rather than returning HTTP 200 with
 	// a partial/zero session list as a healthy result (#2469).
 	if err := s.dp.IterateSessions(func(key dataplane.SessionKey, val dataplane.SessionValue) bool {
-		if val.IsReverse != 0 {
+		if !q.matchV4(key, val) {
 			return true
 		}
-		if zoneFilter != 0 && val.IngressZone != zoneFilter && val.EgressZone != zoneFilter {
-			return true
-		}
-		if protoFilter != "" && !protoFilterMatches(key.Protocol, protoFilter) {
-			return true
-		}
-
 		if idx >= offset && len(all) < limit {
-			all = append(all, sessionEntryV4(key, val, now))
+			// Merge the companion reverse entry's counters into the
+			// forward entry so REST top-talkers/accounting report the
+			// full bidirectional volume, matching gRPC (#3419 H3).
+			if rev, err := s.dp.GetSessionV4(val.ReverseKey); err == nil {
+				val.RevPackets += rev.RevPackets
+				val.RevBytes += rev.RevBytes
+				val.FwdPackets += rev.FwdPackets
+				val.FwdBytes += rev.FwdBytes
+			}
+			all = append(all, sessionEntryV4(key, val, now, view))
 		}
 		idx++
 		return true
@@ -63,18 +67,17 @@ func (s *Server) sessionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// IPv6 sessions
 	if err := s.dp.IterateSessionsV6(func(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
-		if val.IsReverse != 0 {
+		if !q.matchV6(key, val) {
 			return true
 		}
-		if zoneFilter != 0 && val.IngressZone != zoneFilter && val.EgressZone != zoneFilter {
-			return true
-		}
-		if protoFilter != "" && !protoFilterMatches(key.Protocol, protoFilter) {
-			return true
-		}
-
 		if idx >= offset && len(all) < limit {
-			all = append(all, sessionEntryV6(key, val, now))
+			if rev, err := s.dp.GetSessionV6(val.ReverseKey); err == nil {
+				val.RevPackets += rev.RevPackets
+				val.RevBytes += rev.RevBytes
+				val.FwdPackets += rev.FwdPackets
+				val.FwdBytes += rev.FwdBytes
+			}
+			all = append(all, sessionEntryV6(key, val, now, view))
 		}
 		idx++
 		return true
@@ -283,61 +286,333 @@ func uint32ToIP(v uint32) net.IP {
 	return ip
 }
 
-func sessionEntryV4(key dataplane.SessionKey, val dataplane.SessionValue, now uint64) SessionEntry {
+// sessionEgressKey identifies a FIB-resolved egress interface (ifindex +
+// VLAN), mirroring the gRPC sessionEgressKey used to resolve a session's
+// egress interface name (#3419 M4).
+type sessionEgressKey struct {
+	ifindex uint32
+	vlanID  uint16
+}
+
+// sessionView holds the enrichment context shared across a single session
+// list/iteration: zone/policy/app name maps, the zone->first-interface and
+// FIB->interface resolution tables, the active config, and the local HA
+// active state. It mirrors the maps the gRPC sessionFilter precomputes
+// (#3419 M1/M4/M6) so the REST session view exposes the same fields.
+type sessionView struct {
+	zoneNames    map[uint16]string
+	policyNames  map[uint32]string
+	appNames     map[uint16]string
+	zoneIfaces   map[uint16]string
+	egressIfaces map[sessionEgressKey]string
+	cfg          *config.Config
+	haActive     bool
+}
+
+// buildSessionView precomputes the enrichment maps from the last apply
+// result and the active config, mirroring grpcapi buildSessionFilter
+// (#3419). It is safe to call when the store/apply result is absent (the
+// maps stay empty and the view degrades to numeric ids).
+func (s *Server) buildSessionView() sessionView {
+	v := sessionView{
+		zoneNames:    make(map[uint16]string),
+		zoneIfaces:   make(map[uint16]string),
+		egressIfaces: make(map[sessionEgressKey]string),
+		haActive:     true, // standalone default
+	}
+	if s.store != nil {
+		v.cfg = s.store.ActiveConfig()
+	}
+	if s.haActiveFn != nil {
+		v.haActive = s.haActiveFn()
+	}
+	cr := s.applyResult()
+	if cr != nil {
+		for name, id := range cr.ZoneIDs {
+			v.zoneNames[id] = name
+		}
+		v.policyNames = cr.PolicyNames
+		v.appNames = cr.AppNames
+	}
+	if v.cfg != nil && cr != nil {
+		for zoneName, zone := range v.cfg.Security.Zones {
+			if zone == nil { // #3493: tolerant/HA-sync path may carry a nil zone value
+				continue
+			}
+			if zid, ok := cr.ZoneIDs[zoneName]; ok && len(zone.Interfaces) > 0 {
+				v.zoneIfaces[zid] = zone.Interfaces[0]
+			}
+		}
+		// FIB ifindex+VLAN -> display name, so a session's egress interface
+		// resolves to the configured unit name (mirrors grpcapi).
+		for ifName, ifc := range v.cfg.Interfaces.Interfaces {
+			resolvedParent := config.LinuxIfName(strings.SplitN(v.cfg.ResolveReth(ifName), ".", 2)[0])
+			parentLink, err := net.InterfaceByName(resolvedParent)
+			if err != nil {
+				continue
+			}
+			for _, unit := range ifc.Units {
+				displayName := ifName
+				if unit.Number != 0 || unit.VlanID != 0 {
+					displayName = fmt.Sprintf("%s.%d", ifName, unit.Number)
+				}
+				vlanID := uint16(unit.VlanID)
+				if vlanID == 0 && unit.Number > 0 {
+					vlanID = uint16(unit.Number)
+				}
+				key := sessionEgressKey{ifindex: uint32(parentLink.Index), vlanID: vlanID}
+				if _, exists := v.egressIfaces[key]; !exists {
+					v.egressIfaces[key] = displayName
+				}
+			}
+		}
+	}
+	return v
+}
+
+// sessionQuery holds the parsed REST session filter predicates. It mirrors
+// the gRPC sessionFilter subset that applies to the REST surface: zone,
+// protocol, application, interface, nat-only and source-nat-pool (#3419
+// M1/M3/M4). Pagination (limit/offset) is handled by the caller and is out
+// of scope here (separate from #3421/#3423).
+type sessionQuery struct {
+	zone         uint16
+	proto        string
+	natOnly      bool
+	app          string
+	iface        string
+	snatPool     string
+	snatPoolNets []*net.IPNet
+	view         sessionView
+}
+
+// buildSessionQuery parses and validates the session filter query
+// parameters. A non-empty but malformed/unresolved filter FAILS CLOSED
+// with an error message (the caller emits HTTP 400) rather than silently
+// matching every session — mirroring the gRPC sessionFilter.validate
+// contract (#2934/#3439, and source-nat-pool not-found per #3419 M3).
+func buildSessionQuery(r *http.Request, view sessionView) (sessionQuery, string) {
+	q := sessionQuery{view: view}
+	zoneFilter, ok := queryUint16Strict(r, "zone", 0)
+	if !ok {
+		return q, "invalid zone filter: " + r.URL.Query().Get("zone")
+	}
+	q.zone = zoneFilter
+	q.proto = r.URL.Query().Get("protocol")
+	q.app = r.URL.Query().Get("application")
+	q.iface = r.URL.Query().Get("interface")
+	q.snatPool = r.URL.Query().Get("source_nat_pool")
+	if v := r.URL.Query().Get("nat_only"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return q, "invalid nat_only filter: " + v
+		}
+		q.natOnly = b
+	}
+	if q.snatPool != "" {
+		if view.cfg == nil {
+			return q, "source NAT pool " + q.snatPool + " not found"
+		}
+		nets, ok := config.SourceNATPoolNets(&view.cfg.Security.NAT, q.snatPool)
+		if !ok {
+			return q, "source NAT pool " + q.snatPool + " not found"
+		}
+		q.snatPoolNets = nets
+	}
+	return q, ""
+}
+
+func (q *sessionQuery) matchV4(key dataplane.SessionKey, val dataplane.SessionValue) bool {
+	if val.IsReverse != 0 {
+		return false
+	}
+	if q.zone != 0 && val.IngressZone != q.zone && val.EgressZone != q.zone {
+		return false
+	}
+	if q.proto != "" && !protoFilterMatches(key.Protocol, q.proto) {
+		return false
+	}
+	if q.natOnly && val.Flags&(dataplane.SessFlagSNAT|dataplane.SessFlagDNAT) == 0 {
+		return false
+	}
+	if q.app != "" && !appid.SessionMatches(q.app, q.view.appNames, q.view.cfg,
+		key.Protocol, ntohs(key.SrcPort), ntohs(key.DstPort), val.AppID) {
+		return false
+	}
+	if q.iface != "" {
+		inIf := q.view.zoneIfaces[val.IngressZone]
+		outIf := resolveSessionEgressIface(val.FibIfindex, val.FibVlanID, val.EgressZone, q.view.zoneIfaces, q.view.egressIfaces)
+		if !sessionIfaceMatches(q.iface, inIf) && !sessionIfaceMatches(q.iface, outIf) {
+			return false
+		}
+	}
+	if q.snatPool != "" {
+		if val.Flags&dataplane.SessFlagSNAT == 0 || !config.IPInNets(uint32ToIP(val.NATSrcIP), q.snatPoolNets) {
+			return false
+		}
+	}
+	return true
+}
+
+func (q *sessionQuery) matchV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
+	if val.IsReverse != 0 {
+		return false
+	}
+	if q.zone != 0 && val.IngressZone != q.zone && val.EgressZone != q.zone {
+		return false
+	}
+	if q.proto != "" && !protoFilterMatches(key.Protocol, q.proto) {
+		return false
+	}
+	if q.natOnly && val.Flags&(dataplane.SessFlagSNAT|dataplane.SessFlagDNAT) == 0 {
+		return false
+	}
+	if q.app != "" && !appid.SessionMatches(q.app, q.view.appNames, q.view.cfg,
+		key.Protocol, ntohs(key.SrcPort), ntohs(key.DstPort), val.AppID) {
+		return false
+	}
+	if q.iface != "" {
+		inIf := q.view.zoneIfaces[val.IngressZone]
+		outIf := resolveSessionEgressIface(val.FibIfindex, val.FibVlanID, val.EgressZone, q.view.zoneIfaces, q.view.egressIfaces)
+		if !sessionIfaceMatches(q.iface, inIf) && !sessionIfaceMatches(q.iface, outIf) {
+			return false
+		}
+	}
+	if q.snatPool != "" {
+		if val.Flags&dataplane.SessFlagSNAT == 0 || !config.IPInNets(net.IP(val.NATSrcIP[:]), q.snatPoolNets) {
+			return false
+		}
+	}
+	return true
+}
+
+// sessionIfaceMatches matches a session interface against an operator
+// filter, accepting either the exact unit name or a base-interface prefix
+// (mirrors grpcapi).
+func sessionIfaceMatches(filter, ifName string) bool {
+	if ifName == "" {
+		return false
+	}
+	return ifName == filter || strings.HasPrefix(ifName, filter+".")
+}
+
+// resolveSessionEgressIface resolves a session's egress interface from its
+// FIB result, falling back to the egress zone's first interface (mirrors
+// grpcapi).
+func resolveSessionEgressIface(fibIfindex uint32, fibVlanID uint16, egressZone uint16, zoneIfaces map[uint16]string, egressIfaces map[sessionEgressKey]string) string {
+	if fibIfindex != 0 {
+		if ifName, ok := egressIfaces[sessionEgressKey{ifindex: fibIfindex, vlanID: fibVlanID}]; ok && ifName != "" {
+			return ifName
+		}
+	}
+	return zoneIfaces[egressZone]
+}
+
+func sessionEntryV4(key dataplane.SessionKey, val dataplane.SessionValue, now uint64, view sessionView) SessionEntry {
+	inIf := view.zoneIfaces[val.IngressZone]
+	if inIf == "" {
+		inIf = view.zoneNames[val.IngressZone]
+	}
+	outIf := resolveSessionEgressIface(val.FibIfindex, val.FibVlanID, val.EgressZone, view.zoneIfaces, view.egressIfaces)
+	if outIf == "" {
+		outIf = view.zoneNames[val.EgressZone]
+	}
 	se := SessionEntry{
-		SrcAddr:    net.IP(key.SrcIP[:]).String(),
-		DstAddr:    net.IP(key.DstIP[:]).String(),
-		SrcPort:    ntohs(key.SrcPort),
-		DstPort:    ntohs(key.DstPort),
-		Protocol:   protoName(key.Protocol),
-		State:      sessionStateName(val.State),
-		PolicyID:   val.PolicyID,
-		InZone:     val.IngressZone,
-		OutZone:    val.EgressZone,
-		FwdPackets: val.FwdPackets,
-		FwdBytes:   val.FwdBytes,
-		RevPackets: val.RevPackets,
-		RevBytes:   val.RevBytes,
-		Timeout:    val.Timeout,
+		SrcAddr:          net.IP(key.SrcIP[:]).String(),
+		DstAddr:          net.IP(key.DstIP[:]).String(),
+		SrcPort:          ntohs(key.SrcPort),
+		DstPort:          ntohs(key.DstPort),
+		Protocol:         protoName(key.Protocol),
+		State:            sessionStateName(val.State),
+		PolicyID:         val.PolicyID,
+		PolicyName:       view.policyNames[val.PolicyID],
+		IngressZoneName:  view.zoneNames[val.IngressZone],
+		EgressZoneName:   view.zoneNames[val.EgressZone],
+		InZone:           val.IngressZone,
+		OutZone:          val.EgressZone,
+		IngressInterface: inIf,
+		EgressInterface:  outIf,
+		Application:      appid.ResolveSessionName(view.appNames, view.cfg, key.Protocol, ntohs(key.SrcPort), ntohs(key.DstPort), val.AppID),
+		FwdPackets:       val.FwdPackets,
+		FwdBytes:         val.FwdBytes,
+		RevPackets:       val.RevPackets,
+		RevBytes:         val.RevBytes,
+		Timeout:          val.Timeout,
+		SessionID:        val.SessionID,
+		HAActive:         view.haActive,
+	}
+	if val.Created > 0 && now > val.Created {
+		se.Age = int64(now - val.Created)
 	}
 	if val.LastSeen > 0 && now > val.LastSeen {
-		se.Age = int64(now - val.LastSeen)
+		se.Idle = int64(now - val.LastSeen)
 	}
+	var natParts []string
 	if val.Flags&dataplane.SessFlagSNAT != 0 {
-		se.NAT = fmt.Sprintf("SNAT %s:%d", uint32ToIP(val.NATSrcIP), ntohs(val.NATSrcPort))
+		natParts = append(natParts, fmt.Sprintf("SNAT %s:%d", uint32ToIP(val.NATSrcIP), ntohs(val.NATSrcPort)))
+		se.NATSrcAddr = uint32ToIP(val.NATSrcIP).String()
+		se.NATSrcPort = ntohs(val.NATSrcPort)
 	}
 	if val.Flags&dataplane.SessFlagDNAT != 0 {
-		se.NAT = fmt.Sprintf("DNAT %s:%d", uint32ToIP(val.NATDstIP), ntohs(val.NATDstPort))
+		natParts = append(natParts, fmt.Sprintf("DNAT %s:%d", uint32ToIP(val.NATDstIP), ntohs(val.NATDstPort)))
+		se.NATDstAddr = uint32ToIP(val.NATDstIP).String()
+		se.NATDstPort = ntohs(val.NATDstPort)
 	}
+	se.NAT = strings.Join(natParts, "; ")
 	return se
 }
 
-func sessionEntryV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, now uint64) SessionEntry {
+func sessionEntryV6(key dataplane.SessionKeyV6, val dataplane.SessionValueV6, now uint64, view sessionView) SessionEntry {
+	inIf := view.zoneIfaces[val.IngressZone]
+	if inIf == "" {
+		inIf = view.zoneNames[val.IngressZone]
+	}
+	outIf := resolveSessionEgressIface(val.FibIfindex, val.FibVlanID, val.EgressZone, view.zoneIfaces, view.egressIfaces)
+	if outIf == "" {
+		outIf = view.zoneNames[val.EgressZone]
+	}
 	se := SessionEntry{
-		SrcAddr:    net.IP(key.SrcIP[:]).String(),
-		DstAddr:    net.IP(key.DstIP[:]).String(),
-		SrcPort:    ntohs(key.SrcPort),
-		DstPort:    ntohs(key.DstPort),
-		Protocol:   protoName(key.Protocol),
-		State:      sessionStateName(val.State),
-		PolicyID:   val.PolicyID,
-		InZone:     val.IngressZone,
-		OutZone:    val.EgressZone,
-		FwdPackets: val.FwdPackets,
-		FwdBytes:   val.FwdBytes,
-		RevPackets: val.RevPackets,
-		RevBytes:   val.RevBytes,
-		Timeout:    val.Timeout,
+		SrcAddr:          net.IP(key.SrcIP[:]).String(),
+		DstAddr:          net.IP(key.DstIP[:]).String(),
+		SrcPort:          ntohs(key.SrcPort),
+		DstPort:          ntohs(key.DstPort),
+		Protocol:         protoName(key.Protocol),
+		State:            sessionStateName(val.State),
+		PolicyID:         val.PolicyID,
+		PolicyName:       view.policyNames[val.PolicyID],
+		IngressZoneName:  view.zoneNames[val.IngressZone],
+		EgressZoneName:   view.zoneNames[val.EgressZone],
+		InZone:           val.IngressZone,
+		OutZone:          val.EgressZone,
+		IngressInterface: inIf,
+		EgressInterface:  outIf,
+		Application:      appid.ResolveSessionName(view.appNames, view.cfg, key.Protocol, ntohs(key.SrcPort), ntohs(key.DstPort), val.AppID),
+		FwdPackets:       val.FwdPackets,
+		FwdBytes:         val.FwdBytes,
+		RevPackets:       val.RevPackets,
+		RevBytes:         val.RevBytes,
+		Timeout:          val.Timeout,
+		SessionID:        val.SessionID,
+		HAActive:         view.haActive,
+	}
+	if val.Created > 0 && now > val.Created {
+		se.Age = int64(now - val.Created)
 	}
 	if val.LastSeen > 0 && now > val.LastSeen {
-		se.Age = int64(now - val.LastSeen)
+		se.Idle = int64(now - val.LastSeen)
 	}
+	var natParts []string
 	if val.Flags&dataplane.SessFlagSNAT != 0 {
-		se.NAT = fmt.Sprintf("SNAT [%s]:%d", net.IP(val.NATSrcIP[:]).String(), ntohs(val.NATSrcPort))
+		natParts = append(natParts, fmt.Sprintf("SNAT [%s]:%d", net.IP(val.NATSrcIP[:]).String(), ntohs(val.NATSrcPort)))
+		se.NATSrcAddr = net.IP(val.NATSrcIP[:]).String()
+		se.NATSrcPort = ntohs(val.NATSrcPort)
 	}
 	if val.Flags&dataplane.SessFlagDNAT != 0 {
-		se.NAT = fmt.Sprintf("DNAT [%s]:%d", net.IP(val.NATDstIP[:]).String(), ntohs(val.NATDstPort))
+		natParts = append(natParts, fmt.Sprintf("DNAT [%s]:%d", net.IP(val.NATDstIP[:]).String(), ntohs(val.NATDstPort)))
+		se.NATDstAddr = net.IP(val.NATDstIP[:]).String()
+		se.NATDstPort = ntohs(val.NATDstPort)
 	}
+	se.NAT = strings.Join(natParts, "; ")
 	return se
 }
 

--- a/pkg/api/sessions_parity_test.go
+++ b/pkg/api/sessions_parity_test.go
@@ -1,0 +1,221 @@
+package api
+
+import (
+	"encoding/binary"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// paritySessionDP yields one forward IPv4 session that exercises every
+// REST-vs-gRPC parity gap from #3419: a long-lived but recently-active
+// session (H1 age-vs-idle), both SNAT and DNAT set (H2 twice-NAT), and a
+// companion reverse entry carrying counters (H3 reverse-merge). It also
+// supplies an ApplyResult so policy/zone names resolve (M6).
+type paritySessionDP struct {
+	*dataplane.Manager
+	apply  *dataplane.ApplyResult
+	fwdKey dataplane.SessionKey
+	fwdVal dataplane.SessionValue
+	revKey dataplane.SessionKey
+	revVal dataplane.SessionValue
+}
+
+func (d *paritySessionDP) IsLoaded() bool { return true }
+
+func (d *paritySessionDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+
+func (d *paritySessionDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	fn(d.fwdKey, d.fwdVal)
+	return nil
+}
+
+func (d *paritySessionDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func (d *paritySessionDP) GetSessionV4(key dataplane.SessionKey) (dataplane.SessionValue, error) {
+	if key == d.revKey {
+		return d.revVal, nil
+	}
+	return dataplane.SessionValue{}, errors.New("not found")
+}
+
+func (d *paritySessionDP) GetSessionV6(dataplane.SessionKeyV6) (dataplane.SessionValueV6, error) {
+	return dataplane.SessionValueV6{}, errors.New("not found")
+}
+
+// TestRESTSessionParityWithGRPC asserts the #3419 REST session contract:
+//   - age_seconds is wall age (now-Created), idle_seconds is time since the
+//     last packet (now-LastSeen) — NOT idle reported as age (H1).
+//   - a session with BOTH SNAT and DNAT exposes both text parts and the
+//     structured nat_src/nat_dst fields — the DNAT branch no longer
+//     overwrites the SNAT branch (H2).
+//   - the companion reverse entry's counters are merged into the forward
+//     entry (H3).
+//   - policy_name / ingress_zone_name / egress_zone_name / session_id /
+//     ha_active are surfaced (M6).
+//
+// FAIL-ON-REVERT: reverting sessionEntryV4 to set Age from LastSeen flips
+// the age/idle assertions; dropping the reverse-counter merge in the
+// handler flips rev_packets; restoring the single-NAT-string overwrite
+// flips the SNAT-present assertion; removing the enrichment maps flips the
+// name assertions.
+func TestRESTSessionParityWithGRPC(t *testing.T) {
+	base := monotonicSeconds()
+	dp := &paritySessionDP{
+		Manager: dataplane.New(),
+		apply: &dataplane.ApplyResult{
+			ZoneIDs:     map[string]uint16{"trust": 2, "untrust": 3},
+			PolicyNames: map[uint32]string{5: "allow-web"},
+		},
+		fwdKey: dataplane.SessionKey{
+			SrcIP:    [4]byte{10, 0, 1, 5},
+			DstIP:    [4]byte{10, 0, 2, 7},
+			SrcPort:  ntohs(12345),
+			DstPort:  ntohs(443),
+			Protocol: 6,
+		},
+		revKey: dataplane.SessionKey{
+			SrcIP:    [4]byte{10, 0, 2, 7},
+			DstIP:    [4]byte{10, 0, 1, 5},
+			SrcPort:  ntohs(443),
+			DstPort:  ntohs(12345),
+			Protocol: 6,
+		},
+	}
+	dp.fwdVal = dataplane.SessionValue{
+		State:       dataplane.SessStateEstablished,
+		IsReverse:   0,
+		PolicyID:    5,
+		IngressZone: 2,
+		EgressZone:  3,
+		FwdPackets:  10,
+		FwdBytes:    1000,
+		RevPackets:  0,
+		RevBytes:    0,
+		SessionID:   0xABCD,
+		Created:     base - 1000, // created long ago
+		LastSeen:    base - 2,    // refreshed 2s ago (active)
+		Flags:       dataplane.SessFlagSNAT | dataplane.SessFlagDNAT,
+		NATSrcIP:    natIPv4(192, 0, 2, 1),
+		NATSrcPort:  ntohs(50000),
+		NATDstIP:    natIPv4(198, 51, 100, 9),
+		NATDstPort:  ntohs(8443),
+		ReverseKey: dataplane.SessionKey{
+			SrcIP:    [4]byte{10, 0, 2, 7},
+			DstIP:    [4]byte{10, 0, 1, 5},
+			SrcPort:  ntohs(443),
+			DstPort:  ntohs(12345),
+			Protocol: 6,
+		},
+	}
+	dp.revVal = dataplane.SessionValue{
+		IsReverse:  1,
+		FwdPackets: 3,
+		FwdBytes:   300,
+		RevPackets: 7,
+		RevBytes:   700,
+	}
+
+	s := &Server{
+		dp:         dp,
+		eventBuf:   logging.NewEventBuffer(8),
+		haActiveFn: func() bool { return false },
+	}
+
+	rr := httptest.NewRecorder()
+	s.sessionsHandler(rr, httptest.NewRequest("GET", "/api/v1/security/sessions", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeSessions(t, rr.Body.Bytes())
+	if len(resp.Sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(resp.Sessions))
+	}
+	se := resp.Sessions[0]
+
+	// H1: age is wall age from Created (~1000s), idle is small.
+	if se.Age < 500 {
+		t.Errorf("H1: age_seconds = %d, want >=500 (computed from Created)", se.Age)
+	}
+	if se.Idle <= 0 || se.Idle > 60 {
+		t.Errorf("H1: idle_seconds = %d, want a small positive value (from LastSeen)", se.Idle)
+	}
+	if se.Age <= se.Idle {
+		t.Errorf("H1: age (%d) must exceed idle (%d) for a long-lived active session", se.Age, se.Idle)
+	}
+
+	// H2: both SNAT and DNAT surfaced; neither overwrites the other.
+	if !strings.Contains(se.NAT, "SNAT") || !strings.Contains(se.NAT, "DNAT") {
+		t.Errorf("H2: nat = %q, want both SNAT and DNAT parts", se.NAT)
+	}
+	if se.NATSrcAddr == "" || se.NATDstAddr == "" {
+		t.Errorf("H2: structured nat fields lost: src=%q dst=%q", se.NATSrcAddr, se.NATDstAddr)
+	}
+
+	// H3: reverse entry's counters merged into the forward entry.
+	if se.RevPackets != 7 {
+		t.Errorf("H3: rev_packets = %d, want 7 (merged from reverse entry)", se.RevPackets)
+	}
+	if se.FwdPackets != 13 {
+		t.Errorf("H3: fwd_packets = %d, want 13 (10 fwd + 3 from reverse entry)", se.FwdPackets)
+	}
+
+	// M6: names, session id, ha-active surfaced.
+	if se.PolicyName != "allow-web" {
+		t.Errorf("M6: policy_name = %q, want allow-web", se.PolicyName)
+	}
+	if se.IngressZoneName != "trust" || se.EgressZoneName != "untrust" {
+		t.Errorf("M6: zone names = %q/%q, want trust/untrust", se.IngressZoneName, se.EgressZoneName)
+	}
+	if se.SessionID != 0xABCD {
+		t.Errorf("M6: session_id = %#x, want 0xABCD", se.SessionID)
+	}
+	if se.HAActive != false {
+		t.Errorf("M6: ha_active = %v, want false (haActiveFn wired)", se.HAActive)
+	}
+}
+
+// TestRESTSessionFiltersFailClosed asserts the new #3419 filters
+// (nat_only, application, interface, source_nat_pool) parse and that an
+// unresolved source_nat_pool fails closed with HTTP 400 rather than
+// silently matching every session.
+func TestRESTSessionFiltersFailClosed(t *testing.T) {
+	s := &Server{
+		dp:       &oneSessionDP{Manager: dataplane.New()},
+		eventBuf: logging.NewEventBuffer(8),
+	}
+
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"nat_only true", "/api/v1/security/sessions?nat_only=true", 200},
+		{"nat_only bad", "/api/v1/security/sessions?nat_only=maybe", 400},
+		{"application filter", "/api/v1/security/sessions?application=http", 200},
+		{"interface filter", "/api/v1/security/sessions?interface=ge-0-0-0", 200},
+		// No active config -> the pool cannot resolve -> fail closed.
+		{"source_nat_pool unknown", "/api/v1/security/sessions?source_nat_pool=nope", 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.sessionsHandler(rr, httptest.NewRequest("GET", tc.url, nil))
+			if rr.Code != tc.want {
+				t.Errorf("status = %d, want %d; body=%s", rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+// natIPv4 builds the native-endian u32 the dataplane stores for an IPv4
+// NAT address (octets read as u32::from_ne_bytes), matching uint32ToIP.
+func natIPv4(a, b, c, d byte) uint32 {
+	return binary.NativeEndian.Uint32([]byte{a, b, c, d})
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -129,23 +129,59 @@ type PolicyRule struct {
 }
 
 // SessionEntry holds a single session table entry.
+//
+// Field parity with the gRPC SessionEntry contract (#3419): the REST view
+// previously dropped or conflated several fields the gRPC GetSessions RPC
+// already surfaced. The numeric PolicyID/InZone/OutZone fields are retained
+// for backward compatibility; the *_name, interface, application,
+// session_id, idle_seconds and structured nat_* fields mirror gRPC.
 type SessionEntry struct {
-	SrcAddr    string `json:"src_addr"`
-	DstAddr    string `json:"dst_addr"`
-	SrcPort    uint16 `json:"src_port"`
-	DstPort    uint16 `json:"dst_port"`
-	Protocol   string `json:"protocol"`
-	State      string `json:"state"`
-	PolicyID   uint32 `json:"policy_id"`
-	InZone     uint16 `json:"ingress_zone"`
-	OutZone    uint16 `json:"egress_zone"`
-	FwdPackets uint64 `json:"fwd_packets"`
-	FwdBytes   uint64 `json:"fwd_bytes"`
-	RevPackets uint64 `json:"rev_packets"`
-	RevBytes   uint64 `json:"rev_bytes"`
+	SrcAddr  string `json:"src_addr"`
+	DstAddr  string `json:"dst_addr"`
+	SrcPort  uint16 `json:"src_port"`
+	DstPort  uint16 `json:"dst_port"`
+	Protocol string `json:"protocol"`
+	State    string `json:"state"`
+	PolicyID uint32 `json:"policy_id"`
+	// PolicyName / IngressZoneName / EgressZoneName mirror the gRPC
+	// enrichment (#3419 M6). The numeric ids above stay for compatibility;
+	// these resolve them to operator-facing names. Omitted when unresolved.
+	PolicyName      string `json:"policy_name,omitempty"`
+	IngressZoneName string `json:"ingress_zone_name,omitempty"`
+	EgressZoneName  string `json:"egress_zone_name,omitempty"`
+	InZone          uint16 `json:"ingress_zone"`
+	OutZone         uint16 `json:"egress_zone"`
+	// IngressInterface / EgressInterface mirror the gRPC FIB-resolved
+	// interface display (#3419 M4). Empty when unresolved.
+	IngressInterface string `json:"ingress_interface,omitempty"`
+	EgressInterface  string `json:"egress_interface,omitempty"`
+	// Application is the resolved application name (#3419 M1), mirroring
+	// gRPC's appid.ResolveSessionName. Empty when enrichment is unavailable.
+	Application string `json:"application,omitempty"`
+	FwdPackets  uint64 `json:"fwd_packets"`
+	FwdBytes    uint64 `json:"fwd_bytes"`
+	RevPackets  uint64 `json:"rev_packets"`
+	RevBytes    uint64 `json:"rev_bytes"`
+	// NAT keeps the human-readable summary, but a session with BOTH SNAT
+	// and DNAT now joins both parts instead of the DNAT branch overwriting
+	// the SNAT branch (#3419 H2). The structured NatSrc*/NatDst* fields
+	// mirror gRPC so callers do not have to parse the text.
 	NAT        string `json:"nat,omitempty"`
-	Age        int64  `json:"age_seconds"`
-	Timeout    uint32 `json:"timeout_seconds"`
+	NATSrcAddr string `json:"nat_src_addr,omitempty"`
+	NATSrcPort uint16 `json:"nat_src_port,omitempty"`
+	NATDstAddr string `json:"nat_dst_addr,omitempty"`
+	NATDstPort uint16 `json:"nat_dst_port,omitempty"`
+	// Age is wall age since the session was CREATED; Idle is time since the
+	// last packet (#3419 H1). REST previously reported idle time in the
+	// age_seconds field, so a long-lived active session looked seconds old.
+	Age     int64  `json:"age_seconds"`
+	Idle    int64  `json:"idle_seconds"`
+	Timeout uint32 `json:"timeout_seconds"`
+	// SessionID is the dataplane session identity; HAActive reports whether
+	// this node is the active member for the session's resource group
+	// (#3419 M6). HAActive defaults true on a standalone firewall.
+	SessionID uint64 `json:"session_id,omitempty"`
+	HAActive  bool   `json:"ha_active"`
 }
 
 // SessionListResponse holds paginated session results.

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1296,6 +1296,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// #2464: per-collector NetFlow v9 / IPFIX write-health for the
 			// xpf_flow_export_collector_* family + /services/flow-exporters.
 			FlowCollectorHealthFn: d.FlowCollectorHealth,
+			// #3419 M6: report whether this node is the active cluster member
+			// for RG0 so the REST session view's ha_active field matches the
+			// gRPC contract (server_sessions.go IsLocalPrimary(0)). Standalone
+			// (no cluster) reports active.
+			HAActiveFn: func() bool {
+				if d.cluster == nil {
+					return true
+				}
+				return d.cluster.IsLocalPrimary(0)
+			},
 		}
 		// Resolve interface bindings from web-management config
 		if cfg := d.store.ActiveConfig(); cfg != nil && cfg.System.Services != nil &&

--- a/pkg/daemon/runtime_probes.go
+++ b/pkg/daemon/runtime_probes.go
@@ -58,6 +58,8 @@ type apiDataPlane interface {
 	IsLoaded() bool
 	IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error
 	IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
+	GetSessionV4(dataplane.SessionKey) (dataplane.SessionValue, error)
+	GetSessionV6(dataplane.SessionKeyV6) (dataplane.SessionValueV6, error)
 	ClearAllSessions() (int, int, error)
 
 	ReadGlobalCounter(uint32) (uint64, error)


### PR DESCRIPTION
## Summary

Brings the REST `GET /api/v1/security/sessions` view into parity with the gRPC `GetSessions` contract. Codex audit 099 found seven REST-vs-gRPC gaps; this PR fixes all of them. Verified against origin/master before the change.

- **H1 — age vs idle:** REST set `age_seconds` from `now-LastSeen` (idle time), so a long-lived session refreshed seconds ago looked seconds old. Now `age_seconds = now-Created` and a new `idle_seconds = now-LastSeen`, matching gRPC.
- **H2 — twice-NAT:** a session with both SNAT and DNAT lost the SNAT part (the DNAT branch overwrote the single `nat` string). Now joins both parts and exposes structured `nat_src_addr/port` + `nat_dst_addr/port`.
- **H3 — reverse counters:** the forward entry was serialized as stored, skipping the reverse entry. Added `GetSessionV4/V6` to the REST dataplane interface (+ the daemon's `apiDataPlane` mirror) and merge the companion reverse entry's counters, as gRPC does.
- **M1/M3/M4 — filters + display:** added `application=`, `interface=`, `nat_only=`, `source_nat_pool=` filters (shared `appid.SessionMatches` / `config.SourceNATPoolNets`); an unresolved pool fails CLOSED with HTTP 400 (gRPC `sessionFilter.validate` parity). Surfaces resolved `application` and FIB-resolved `ingress_interface`/`egress_interface`.
- **M6 — names/id/ha:** surfaces `policy_name`, `ingress_zone_name`, `egress_zone_name`, `session_id`, `ha_active` (wired from the daemon via a new optional `HAActiveFn` = `cluster.IsLocalPrimary(0)`, true standalone). Numeric ids retained for compatibility.

Pagination and filtered-clear are intentionally **out of scope** (tracked by #3421/#3423).

## Test

- `sessions_parity_test.go` pins the H1/H2/H3/M6 contract and a fail-closed filter matrix.
- **RED-on-revert verified:** reverting `sessionEntryV4`'s Age-from-Created + the H2 NAT join flips 4 assertions (age_seconds=2, idle_seconds=0, nat="DNAT…" only, structured nat fields empty).
- `go test ./pkg/api/... ./pkg/grpcapi/...` green; `go build ./...`, `go vet ./pkg/api/...`, `gofmt` clean.

Closes #3419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi