### PR TITLE
api: surface nat64_translations + host_inbound_allowed in REST global stats (#3426)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -51,6 +51,16 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     the scoped global's real zones on its `from_zone`/`to_zone` labels
     (#3286) — an unscoped global keeps `*`/`*` — so counter-based
     validation is unambiguous on the canonical metrics surface.
+  - `GET /api/v1/statistics/global` — global dataplane counters
+    (`GlobalStats`, types.go). The field set mirrors the gRPC
+    `GetGlobalStats` reader: as of #3426 it includes `nat64_translations`
+    (`GlobalCtrNAT64Xlate`) and `host_inbound_allowed`
+    (`GlobalCtrHostInbound`) alongside the long-standing
+    `host_inbound_denies`. Before #3426 REST omitted both, so an automation
+    client reading only REST could not see NAT64 translation volume or the
+    host-inbound allow count even though gRPC and Prometheus
+    (`xpf_nat64_translations_total`) exposed them. A counter read failure
+    returns HTTP 500 (#3345), not a clean zero.
 - `GET /api/v1/events/stream` — Server-Sent Events stream of dataplane
   events. Backed by the `pkg/logging` event ring buffer; long-lived
   consumers must drain. `?category=` (and `?severity=` on

--- a/pkg/api/stats.go
+++ b/pkg/api/stats.go
@@ -37,6 +37,8 @@ func (s *Server) globalStatsHandler(w http.ResponseWriter, _ *http.Request) {
 		PolicyDenies:         readCounter(dataplane.GlobalCtrPolicyDeny),
 		NATAllocFails:        readCounter(dataplane.GlobalCtrNATAllocFail),
 		HostInboundDeny:      readCounter(dataplane.GlobalCtrHostInboundDeny),
+		HostInboundAllowed:   readCounter(dataplane.GlobalCtrHostInbound),
+		NAT64Translations:    readCounter(dataplane.GlobalCtrNAT64Xlate),
 		TCEgressPackets:      readCounter(dataplane.GlobalCtrTCEgressPackets),
 		FabricRedirects:      readCounter(dataplane.GlobalCtrFabricRedirect),
 		FabricFwdDrops:       readCounter(dataplane.GlobalCtrFabricFwdDrop),

--- a/pkg/api/stats_global_parity_3426_test.go
+++ b/pkg/api/stats_global_parity_3426_test.go
@@ -1,0 +1,77 @@
+// #3426: REST /statistics/global must surface the same global counters the
+// gRPC reader exposes. Before this fix REST `GlobalStats` had no
+// nat64_translations and no host_inbound_allowed field, and stats.go never
+// read GlobalCtrNAT64Xlate / GlobalCtrHostInbound, so REST could not represent
+// either counter even though gRPC GetGlobalStats and Prometheus do.
+//
+// FAIL-ON-REVERT: dropping either struct field or its readCounter() call in
+// globalStatsHandler returns the field as a zero (or drops it entirely), so the
+// value-equality assertions below go RED.
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// idxValueAPIDP is a loaded apiRuntimeDataPlane whose global-counter reads
+// return a distinct, index-derived value so a test can prove a specific
+// counter index was actually read into a specific response field.
+type idxValueAPIDP struct {
+	*dataplane.Manager
+}
+
+func (d *idxValueAPIDP) IsLoaded() bool { return true }
+
+func (d *idxValueAPIDP) ReadGlobalCounter(idx uint32) (uint64, error) {
+	// Unique per index, non-zero, and far from any field's zero value so a
+	// dropped read (which would leave the field at 0) is unambiguous.
+	return uint64(idx)*1000 + 7, nil
+}
+
+func TestGlobalStatsHandlerSurfacesNAT64AndHostInbound(t *testing.T) {
+	s := &Server{dp: &idxValueAPIDP{Manager: dataplane.New()}}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/statistics/global", nil)
+	s.globalStatsHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("globalStatsHandler status = %d, want %d. body=%s",
+			rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp struct {
+		Success bool        `json:"success"`
+		Data    GlobalStats `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("response success=false body=%s", rr.Body.String())
+	}
+
+	wantNAT64 := uint64(dataplane.GlobalCtrNAT64Xlate)*1000 + 7
+	if resp.Data.NAT64Translations != wantNAT64 {
+		t.Errorf("NAT64Translations = %d, want %d (must read GlobalCtrNAT64Xlate)",
+			resp.Data.NAT64Translations, wantNAT64)
+	}
+
+	wantHostInbound := uint64(dataplane.GlobalCtrHostInbound)*1000 + 7
+	if resp.Data.HostInboundAllowed != wantHostInbound {
+		t.Errorf("HostInboundAllowed = %d, want %d (must read GlobalCtrHostInbound)",
+			resp.Data.HostInboundAllowed, wantHostInbound)
+	}
+
+	// Sanity: the pre-existing deny counter still reads its own (distinct)
+	// index, guarding against a copy-paste that points both at the same slot.
+	wantDeny := uint64(dataplane.GlobalCtrHostInboundDeny)*1000 + 7
+	if resp.Data.HostInboundDeny != wantDeny {
+		t.Errorf("HostInboundDeny = %d, want %d", resp.Data.HostInboundDeny, wantDeny)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -28,6 +28,8 @@ type GlobalStats struct {
 	PolicyDenies         uint64 `json:"policy_denies"`
 	NATAllocFails        uint64 `json:"nat_alloc_failures"`
 	HostInboundDeny      uint64 `json:"host_inbound_denies"`
+	HostInboundAllowed   uint64 `json:"host_inbound_allowed"`
+	NAT64Translations    uint64 `json:"nat64_translations"`
 	TCEgressPackets      uint64 `json:"tc_egress_packets"`
 	FabricRedirects      uint64 `json:"fabric_redirects"`
 	FabricFwdDrops       uint64 `json:"fabric_fwd_drops"`


### PR DESCRIPTION
## Summary

REST `GET /api/v1/statistics/global` omitted two global counters that the
gRPC `GetGlobalStats` reader exposes. `GlobalStats` (`pkg/api/types.go`)
had `host_inbound_denies` but no `host_inbound_allowed`, and no NAT64
field; `globalStatsHandler` (`pkg/api/stats.go`) never read
`GlobalCtrNAT64Xlate` or `GlobalCtrHostInbound`. gRPC reads both
(`pkg/grpcapi/server_show_status.go:105-106`) and Prometheus already
publishes `xpf_nat64_translations_total`, so a REST-only automation client
could not see NAT64 translation volume or the host-inbound allow count.

This is Codex audit 099 finding **M7**.

## Change

- Add `nat64_translations` and `host_inbound_allowed` to the REST
  `GlobalStats` struct.
- Read them in `globalStatsHandler` via the existing `readCounter()`
  helper, which preserves the #3345 counter-read-failure handling (HTTP
  500 on a degraded counter bridge, never a misleading zero).
- `pkg/api/README.md` documents the `/statistics/global` field set and the
  parity fix.

## Scope

M7 only — coordinates with #3421 (REST session pagination, touches
`pkg/api/sessions.go`, a disjoint endpoint). The **L1** sibling
(`GlobalCtrVlanPushFail` slot 40 has no global stats surface) is left
as-is: the userspace dataplane publishes per-binding VLAN push /
no-headroom counters via helper status, so slot 40 is a legacy-only
counter with no live producer — surfacing it would expose a
permanently-zero field, not real telemetry.

## Validation

- `go build ./pkg/api/...` + `go test ./pkg/api/...` green; `gofmt` clean.
- New `stats_global_parity_3426_test.go` drives the handler against a stub
  dataplane returning index-derived counter values and asserts each new
  field reads its own counter slot.
- **RED-on-revert verified**: removing either `readCounter` call leaves
  the field at 0 and fails the test (`NAT64Translations = 0, want 10007`;
  `HostInboundAllowed = 0, want 11007`).

Closes #3426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi