### PR TITLE
daemon lo0 nft: normalize protocol aliases and DSCP names (#3436)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23377,3 +23377,8 @@ top.
 - **Timestamp**: 2026-06-29
 - **Action**: Verified #3385 over-match already structurally fixed on master by #3321 (lookup_directional removed the OR-decomposition). Added a #3385-specific RED-on-revert regression test for the distinct OVERLAPPING-range cross-slot over-match. No behavior change.
 - **File(s)**: userspace-dp/src/policy_tests.rs (app_catalog_overlapping_dual_range_no_cross_slot_overmatch)
+
+## #3436 — daemon lo0 nft: normalize protocol aliases + DSCP names through shared resolvers
+- **Timestamp**: 2026-06-29
+- **Action**: nftRuleFromTerm emitted `from protocol` tokens and `dscp`/`traffic-class` tokens RAW (codex-094 H08/M01). Junos protocol aliases (junos-gre, junos-tcp-any, junos-icmp-all, ipip/junos-ip-in-ip) and case-variant / `be` DSCP names are accepted by the commit gate and userspace matcher but are not valid nft tokens, so the atomic lo0 load failed (commit broken) or the kernel mirror matched a different protocol/code point than userspace. Fix: resolve protocols through appid.ProtocolNumber and emit NUMERIC l4proto tokens; resolve DSCP through dataplane.DSCPValues (case-insensitive, numeric 0..63 pass-through) and emit numeric values. Unresolvable protocol dropped with a warning on the lenient path. Added RED-on-revert tests (alias single + multi set, DSCP EF/Af11/be/numeric + multi set); updated existing l4proto/DSCP test expectations to numeric; documented in pkg/daemon/README.md.
+- **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/lo0_filter_test.go, pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -364,6 +364,30 @@ never lock an operator out of a remote box it manages.
   `discard` dropped ALL ICMP fail-closed-over-broad, an `accept` admitted ALL
   ICMP fail-open). Pinned by `TestNftRuleFromTermICMPCodeOnly` (v4 + v6 +
   multi-value, code-only) and `TestNftRuleFromTermICMPTypeCode`.
+
+  **Protocol / DSCP lowering normalizes through the shared resolvers (#3436):**
+  `nftRuleFromTerm` resolves each `from protocol` token through the shared
+  `appid.ProtocolNumber` SSOT (the same resolver the commit gate
+  `filterProtocolResolvable` and the userspace matcher `ip_proto.rs` use) and
+  emits the NUMERIC nft `l4proto` token (`meta l4proto 47`, set form
+  `meta l4proto { 47, 6, 50 }`). It resolves each `dscp` / `traffic-class` token
+  through the `dataplane.DSCPValues` SSOT (case-insensitive, numeric 0..63
+  pass-through) and emits the numeric `ip[6] dscp` value. The pre-fix code
+  emitted both tokens RAW (codex-094 H08/M01): nft does not share the Junos
+  alias table — `meta l4proto junos-gre` / `junos-tcp-any` / `ipip` is a parse
+  error that rejects the whole atomically-loaded lo0 table (legitimate commit
+  broken) or, on the lenient/peer-sync path, leaves the kernel mirror absent
+  while userspace stays armed. Likewise nft's DSCP names are lowercase only and
+  do not cover every xpf code point — an upper-case `EF` (accepted
+  case-insensitively at commit) and `be` (best-effort, which has NO nft name)
+  both failed the atomic load. Emitting numeric values is unconditionally
+  nft-safe and matches the SAME protocol / code point as userspace. An
+  unresolvable token cannot reach a committed config (the commit gate rejects
+  it); on the lenient path an unresolvable protocol is dropped with a warning
+  (mirroring the tcp-flags lowering) and an unresolvable DSCP token falls back
+  to its lower-cased form. Pinned by `TestNftRuleFromTermProtocolAliases`,
+  `TestNftRuleFromTermProtocolMultiAliasSet`, `TestNftRuleFromTermDSCP`, and
+  `TestNftRuleFromTermDSCPNamesAndCase`.
 - host-inbound-traffic (`security zones <z> host-inbound-traffic`) is the
   PRIMARY kernel enforcement for host-bound traffic to a firewall interface IP
   / VRRP VIP (SSH, ping, OSPF/BGP to the box — #3070). Such traffic is shunted

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 )
 
@@ -668,10 +670,35 @@ func nftRuleFromTerm(term *config.FirewallFilterTerm, family string, prefixLists
 	}
 
 	// Protocol matching (#2545: multi-value — emit an nft set on >1).
-	if len(term.Protocols) == 1 {
-		parts = append(parts, "meta l4proto "+term.Protocols[0])
-	} else if len(term.Protocols) > 1 {
-		parts = append(parts, "meta l4proto { "+strings.Join(term.Protocols, ", ")+" }")
+	//
+	// #3436: resolve every `from protocol` token through the shared
+	// appid.ProtocolNumber SSOT and emit NUMERIC protocol numbers. The commit
+	// gate (filterProtocolResolvable) and the userspace matcher (ip_proto.rs)
+	// accept Junos predefined-protocol aliases — junos-gre, junos-tcp-any,
+	// junos-icmp-all, ipip/junos-ip-in-ip, ... — that nft does NOT understand.
+	// Emitting them raw (`meta l4proto junos-gre`) is an nft parse error that
+	// rejects the WHOLE atomic lo0 table (legitimate commit broken) or, on the
+	// lenient/peer-sync path, mirrors a DIFFERENT protocol than userspace. The
+	// numeric form is unconditionally nft-safe and resolves to the SAME protocol
+	// number the Rust matcher uses. A token outside the SSOT cannot reach a
+	// committed config (the gate rejects it); a leniently-loaded one is dropped
+	// with a warning rather than emitted as unloadable nft (mirroring the
+	// tcp-flags lowering below).
+	if len(term.Protocols) > 0 {
+		protos := make([]string, 0, len(term.Protocols))
+		for _, p := range term.Protocols {
+			if n, ok := appid.ProtocolNumber(p); ok {
+				protos = append(protos, strconv.Itoa(int(n)))
+			} else {
+				slog.Warn("dropping unresolvable protocol from lo0 filter term",
+					"term", term.Name, "protocol", p)
+			}
+		}
+		if len(protos) == 1 {
+			parts = append(parts, "meta l4proto "+protos[0])
+		} else if len(protos) > 1 {
+			parts = append(parts, "meta l4proto { "+strings.Join(protos, ", ")+" }")
+		}
 	}
 
 	// Source port matching
@@ -914,9 +941,30 @@ func nftIntSet(vals []int) string {
 	return "{ " + strings.Join(strs, ", ") + " }"
 }
 
+// nftDSCPValue converts a firewall-filter DSCP / traffic-class match token to a
+// numeric nft dscp token, resolving code-point NAMES through the
+// dataplane.DSCPValues SSOT (#3436). The pre-fix pass-through was wrong on two
+// counts that nft rejects atomically (failing the whole lo0 load) or that
+// silently stop the kernel mirror matching:
+//
+//   - Case: the commit gate (filterDSCPResolvable) and the userspace matcher
+//     (pkg/dataplane/userspace/filters.go, via strings.ToLower) accept names
+//     case-insensitively, so `from dscp EF` reaches here as "EF" — but nft's
+//     DSCP names are lowercase only, so `ip dscp EF` is a parse error.
+//   - Name coverage: xpf accepts `be` (best-effort) as a code point, but nft
+//     has NO `be` DSCP name at all — `ip dscp be` is unloadable.
+//
+// Resolving to the numeric value yields an unconditionally nft-safe token that
+// matches the SAME code point as userspace (which resolves the identical table).
+// A numeric 0..63 token passes through as-is. An unresolvable token is
+// unreachable for a committed config (filterDSCPResolvable gates it); it is
+// lower-cased as a best-effort fallback rather than emitted with stray case.
 func nftDSCPValue(name string) string {
-	// Junos and nftables use the same naming for standard DSCP values.
-	// Just pass through — nftables accepts ef, af11, af12, af13, af21,
-	// af22, af23, af31, af32, af33, af41, af42, af43, cs0-cs7.
-	return name
+	if val, ok := dataplane.DSCPValues[strings.ToLower(strings.TrimSpace(name))]; ok {
+		return strconv.Itoa(int(val))
+	}
+	if v, err := strconv.Atoi(strings.TrimSpace(name)); err == nil && v >= 0 && v <= 63 {
+		return strconv.Itoa(v)
+	}
+	return strings.ToLower(strings.TrimSpace(name))
 }

--- a/pkg/daemon/lo0_filter_test.go
+++ b/pkg/daemon/lo0_filter_test.go
@@ -266,7 +266,7 @@ func TestNftRuleFromTermPrefixListExpansion(t *testing.T) {
 
 	rule := nftRuleFromTerm(term, "ip", prefixLists)
 	// Should contain expanded CIDRs in nft set syntax
-	want := "ip saddr { 10.0.1.0/24, 10.0.2.0/24, 192.168.1.0/24 } meta l4proto tcp th dport 22 accept"
+	want := "ip saddr { 10.0.1.0/24, 10.0.2.0/24, 192.168.1.0/24 } meta l4proto 6 th dport 22 accept"
 	if rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
@@ -291,7 +291,7 @@ func TestNftRuleFromTermPrefixListExcept(t *testing.T) {
 	}
 
 	rule := nftRuleFromTerm(term, "ip", prefixLists)
-	want := "ip saddr != { 10.0.1.0/24, 10.0.2.0/24 } meta l4proto tcp th dport 22 reject"
+	want := "ip saddr != { 10.0.1.0/24, 10.0.2.0/24 } meta l4proto 6 th dport 22 reject"
 	if rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
@@ -337,7 +337,7 @@ func TestNftRuleFromTermMultiplePorts(t *testing.T) {
 	}
 
 	rule := nftRuleFromTerm(term, "ip", prefixLists)
-	want := "meta l4proto tcp th dport { 80, 443 } accept"
+	want := "meta l4proto 6 th dport { 80, 443 } accept"
 	if rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
@@ -441,7 +441,7 @@ func TestNftRuleFromTermAddressSemantics3433(t *testing.T) {
 				DestinationPorts:  []string{"22"}, Action: "discard",
 			},
 			fam:  "ip",
-			want: "meta l4proto tcp th dport 22 drop",
+			want: "meta l4proto 6 th dport 22 drop",
 		},
 		{
 			// H04: a lenient/peer-sync UNRESOLVED positive prefix-list resolves to
@@ -552,7 +552,7 @@ func TestNftRuleFromTermICMPCodeOnly(t *testing.T) {
 		Action:    "discard",
 	}
 	ruleV4 := nftRuleFromTerm(v4, "ip", prefixLists)
-	wantV4 := "meta l4proto icmp icmp code 4 drop"
+	wantV4 := "meta l4proto 1 icmp code 4 drop"
 	if ruleV4 != wantV4 {
 		t.Errorf("v4 code-only:\n  got:  %s\n  want: %s", ruleV4, wantV4)
 	}
@@ -568,7 +568,7 @@ func TestNftRuleFromTermICMPCodeOnly(t *testing.T) {
 		Action:    "discard",
 	}
 	ruleV6 := nftRuleFromTerm(v6, "ip6", prefixLists)
-	wantV6 := "meta l4proto icmpv6 icmpv6 code 1 drop"
+	wantV6 := "meta l4proto 58 icmpv6 code 1 drop"
 	if ruleV6 != wantV6 {
 		t.Errorf("v6 code-only:\n  got:  %s\n  want: %s", ruleV6, wantV6)
 	}
@@ -598,16 +598,110 @@ func TestNftRuleFromTermDSCP(t *testing.T) {
 		Action: "accept",
 	}
 	rule := nftRuleFromTerm(term, "ip", prefixLists)
-	want := "ip dscp ef accept"
+	// #3436: the DSCP name resolves to its numeric value (ef == 46). nft's DSCP
+	// names are lowercase only and do not cover every xpf code point (e.g. `be`),
+	// so emitting the numeric value is unconditionally nft-safe.
+	want := "ip dscp 46 accept"
 	if rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
 
 	// IPv6 traffic-class
 	rule6 := nftRuleFromTerm(term, "ip6", prefixLists)
-	want6 := "ip6 dscp ef accept"
+	want6 := "ip6 dscp 46 accept"
 	if rule6 != want6 {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule6, want6)
+	}
+}
+
+// TestNftRuleFromTermProtocolAliases is the #3436 H08 proof: a firewall-filter
+// `from protocol` token that is a Junos predefined-protocol alias (junos-gre,
+// junos-tcp-any, junos-icmp-all, ipip, ...) — accepted by the commit gate
+// filterProtocolResolvable and the userspace matcher — must lower to its NUMERIC
+// nft l4proto token, never the raw alias. nft does not share the Junos alias
+// table, so `meta l4proto junos-gre` is a parse error that rejects the whole
+// atomic lo0 table (commit broken) or, on the lenient path, mirrors a different
+// protocol than userspace. RED-on-revert: the pre-fix raw pass-through emits the
+// alias verbatim.
+func TestNftRuleFromTermProtocolAliases(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+	cases := []struct {
+		name  string
+		proto string
+		want  string // l4proto fragment
+	}{
+		{"junos-gre", "junos-gre", "meta l4proto 47"},
+		{"junos-tcp-any", "junos-tcp-any", "meta l4proto 6"},
+		{"junos-icmp-all", "junos-icmp-all", "meta l4proto 1"},
+		{"ipip", "ipip", "meta l4proto 4"},
+		{"junos-ip-in-ip", "junos-ip-in-ip", "meta l4proto 4"},
+		{"numeric", "47", "meta l4proto 47"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			term := &config.FirewallFilterTerm{
+				Name: "p", Protocols: []string{c.proto}, Action: "accept",
+			}
+			want := c.want + " accept"
+			if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != want {
+				t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
+			}
+		})
+	}
+}
+
+// TestNftRuleFromTermProtocolMultiAliasSet is the #3436 H08 multi-value proof: a
+// `from protocol [ junos-gre tcp 50 ]` set must lower to a numeric nft set
+// (`meta l4proto { 47, 6, 50 }`), preserving order and resolving every alias —
+// not a set containing the raw alias token that fails the atomic load.
+func TestNftRuleFromTermProtocolMultiAliasSet(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+	term := &config.FirewallFilterTerm{
+		Name: "p", Protocols: []string{"junos-gre", "tcp", "50"}, Action: "accept",
+	}
+	want := "meta l4proto { 47, 6, 50 } accept"
+	if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != want {
+		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
+	}
+}
+
+// TestNftRuleFromTermDSCPNamesAndCase is the #3436 M01 proof: a DSCP name is
+// resolved through dataplane.DSCPValues to its numeric value regardless of case
+// (`EF` accepted case-insensitively by the commit gate), `be` (no nft name)
+// resolves to 0, and a numeric token passes through. The pre-fix pass-through
+// emitted `ip dscp EF` / `ip dscp be`, both nft parse errors that reject the
+// whole atomic lo0 table.
+func TestNftRuleFromTermDSCPNamesAndCase(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+	cases := []struct {
+		name string
+		dscp string
+		want string // dscp fragment
+	}{
+		{"upper-EF", "EF", "ip dscp 46"},
+		{"mixed-Af11", "Af11", "ip dscp 10"},
+		{"be", "be", "ip dscp 0"},
+		{"numeric", "34", "ip dscp 34"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			term := &config.FirewallFilterTerm{
+				Name: "d", DSCPs: []string{c.dscp}, Action: "accept",
+			}
+			want := c.want + " accept"
+			if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != want {
+				t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
+			}
+		})
+	}
+
+	// Multi-value DSCP set with a mixed-case name and a numeric token.
+	multi := &config.FirewallFilterTerm{
+		Name: "d", DSCPs: []string{"EF", "af21", "0"}, Action: "accept",
+	}
+	want := "ip dscp { 46, 18, 0 } accept"
+	if rule := nftRuleFromTerm(multi, "ip", prefixLists); rule != want {
+		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
 }
 
@@ -629,21 +723,21 @@ func TestNftRuleFromTermTCPFlags(t *testing.T) {
 			// Single required flag — no parentheses needed on either side.
 			name:  "syn-only",
 			flags: []string{"syn"},
-			want:  "meta l4proto tcp tcp flags & syn == syn drop",
+			want:  "meta l4proto 6 tcp flags & syn == syn drop",
 		},
 		{
 			// Plain list is the Junos AND-conjunction (both required), NOT a
 			// disjunctive comma set. mask == required == syn|ack.
 			name:  "syn-ack-list",
 			flags: []string{"syn", "ack"},
-			want:  "meta l4proto tcp tcp flags & (syn | ack) == (syn | ack) drop",
+			want:  "meta l4proto 6 tcp flags & (syn | ack) == (syn | ack) drop",
 		},
 		{
 			// Negated form: SYN required, ACK forbidden. The mentioned mask is
 			// syn|ack; the required side is just syn (ACK must be clear).
 			name:  "syn-not-ack",
 			flags: []string{"syn", "&", "!ack"},
-			want:  "meta l4proto tcp tcp flags & (syn | ack) == syn drop",
+			want:  "meta l4proto 6 tcp flags & (syn | ack) == syn drop",
 		},
 	}
 	for _, c := range cases {
@@ -681,7 +775,7 @@ func TestNftRuleFromTermPortExcept(t *testing.T) {
 		Action:          "accept",
 	}
 	rule := nftRuleFromTerm(term, "ip", prefixLists)
-	want := "meta l4proto tcp th dport != 22 accept"
+	want := "meta l4proto 6 th dport != 22 accept"
 	if rule != want {
 		t.Errorf("dest-port-except single:\n got:  %s\n want: %s", rule, want)
 	}
@@ -694,7 +788,7 @@ func TestNftRuleFromTermPortExcept(t *testing.T) {
 		Action:          "accept",
 	}
 	rule2 := nftRuleFromTerm(term2, "ip", prefixLists)
-	want2 := "meta l4proto tcp th dport != { 80, 443 } accept"
+	want2 := "meta l4proto 6 th dport != { 80, 443 } accept"
 	if rule2 != want2 {
 		t.Errorf("dest-port-except multi:\n got:  %s\n want: %s", rule2, want2)
 	}
@@ -707,7 +801,7 @@ func TestNftRuleFromTermPortExcept(t *testing.T) {
 		Action:            "discard",
 	}
 	rule3 := nftRuleFromTerm(term3, "ip", prefixLists)
-	want3 := "meta l4proto udp th sport != 123 drop"
+	want3 := "meta l4proto 17 th sport != 123 drop"
 	if rule3 != want3 {
 		t.Errorf("source-port-except:\n got:  %s\n want: %s", rule3, want3)
 	}
@@ -840,7 +934,7 @@ func TestNftRuleFromTermRoutingInstanceTerminatesAccept(t *testing.T) {
 // TestLo0PayloadFallThroughDoesNotShadowDiscard is the end-to-end #3427 proof:
 // a fall-through term followed by a discard term must leave the discard
 // REACHABLE in the rendered nft payload. Before the fix term1 rendered
-// `meta l4proto tcp accept`, which (atomic, first-match-wins chain) made the
+// `meta l4proto 6 accept`, which (atomic, first-match-wins chain) made the
 // later `tcp dport 22 drop` unreachable — SSH was silently permitted in the
 // kernel lo0 mirror. The fix drops term1's rule entirely so the discard stands.
 func TestLo0PayloadFallThroughDoesNotShadowDiscard(t *testing.T) {
@@ -857,7 +951,7 @@ func TestLo0PayloadFallThroughDoesNotShadowDiscard(t *testing.T) {
 
 	payload := buildLo0FilterPayload(cfg, "lo0-in", "")
 
-	if strings.Contains(payload, "meta l4proto tcp accept") {
+	if strings.Contains(payload, "meta l4proto 6 accept") {
 		t.Errorf("fall-through term emitted a shadowing accept in the lo0 payload (#3427 fail-open):\n%s", payload)
 	}
 	if !strings.Contains(payload, "th dport 22 drop") {
@@ -873,7 +967,7 @@ func TestLo0PayloadFallThroughDoesNotShadowDiscard(t *testing.T) {
 // terminating `accept` for the steer term — NOT skip it. A skip lets the later
 // `then discard` match and OVER-DROP legitimate host traffic on the
 // kernel-primary lo0 chain. RED-on-revert: with the skip disposition the steer
-// rule is absent and `meta l4proto tcp drop` is the only verdict.
+// rule is absent and `meta l4proto 6 drop` is the only verdict.
 func TestLo0PayloadRoutingInstanceTerminatesAcceptNoOverDrop(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
@@ -891,11 +985,11 @@ func TestLo0PayloadRoutingInstanceTerminatesAcceptNoOverDrop(t *testing.T) {
 	// The steer term must terminate as accept BEFORE the deny term, so the
 	// accept appears in the payload and (first-match-wins) shields tcp traffic
 	// from the drop. The over-drop bug would leave only the drop rule.
-	if !strings.Contains(payload, "meta l4proto tcp accept") {
+	if !strings.Contains(payload, "meta l4proto 6 accept") {
 		t.Errorf("routing-instance term did not emit a terminating accept (#3427 over-drop): the later discard would over-drop host traffic:\n%s", payload)
 	}
-	acceptIdx := strings.Index(payload, "meta l4proto tcp accept")
-	dropIdx := strings.Index(payload, "meta l4proto tcp drop")
+	acceptIdx := strings.Index(payload, "meta l4proto 6 accept")
+	dropIdx := strings.Index(payload, "meta l4proto 6 drop")
 	if acceptIdx == -1 || (dropIdx != -1 && dropIdx < acceptIdx) {
 		t.Errorf("routing-instance accept must precede the deny term (first-match-wins) so legit traffic is not over-dropped:\n%s", payload)
 	}


### PR DESCRIPTION
## Summary
`nftRuleFromTerm` (pkg/daemon/daemon_nft.go) emitted firewall-filter `from protocol` and `dscp`/`traffic-class` match tokens **verbatim** instead of normalizing them through the shared resolvers the commit gate and userspace matcher use. Tokens those surfaces accept can be syntactically invalid to nft, so the atomic lo0 input-filter load fails (legitimate commit broken) or — on the lenient/peer-sync path — the kernel mirror is silently absent while userspace stays armed. Codex audit 094 H08/M01 (+ test gaps L05/L07).

## Fix
- **H08 protocol aliases**: resolve every `from protocol` token through the shared `appid.ProtocolNumber` SSOT (the same resolver `filterProtocolResolvable` and the Rust `ip_proto.rs` matcher use) and emit the **numeric** nft `l4proto` token (`meta l4proto 47`, set form `meta l4proto { 47, 6, 50 }`). nft does not share the Junos alias table (`junos-gre`, `junos-tcp-any`, `ipip`, ...), so the raw form was a parse error rejecting the whole atomic lo0 table. An unresolvable token cannot reach a committed config (the gate rejects it); a leniently-loaded one is dropped with a warning, mirroring the tcp-flags lowering.
- **M01 DSCP case / coverage**: resolve `dscp`/`traffic-class` names through the `dataplane.DSCPValues` SSOT (case-insensitive; numeric 0..63 pass-through) and emit the numeric value. nft's DSCP names are lowercase only and lack `be` (best-effort) entirely, so `ip dscp EF` / `ip dscp be` failed the atomic load. Numeric is unconditionally nft-safe and matches the same code point as userspace.

## Tests
- New: `TestNftRuleFromTermProtocolAliases` (junos-gre/junos-tcp-any/junos-icmp-all/ipip/junos-ip-in-ip/numeric), `TestNftRuleFromTermProtocolMultiAliasSet`, `TestNftRuleFromTermDSCPNamesAndCase` (EF/Af11/be/numeric + mixed-case multi set).
- Updated existing l4proto/DSCP expectations from names to numeric.
- **RED-on-revert verified**: reverting the two emission sites makes the new tests fail with `meta l4proto junos-gre`, `ip dscp EF`, `ip dscp be`.
- `go test ./pkg/daemon/ ./pkg/config/ ./pkg/appid/` green; `go vet` + `go build ./...` clean; gofmt clean.

## Docs
- pkg/daemon/README.md: new "Protocol / DSCP lowering normalizes through the shared resolvers (#3436)" subsection.

Closes #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi