### PR TITLE
test/docs: allowlist pkg/daemon/daemon_nft.go legacy dataplane import (#3436)

### DIFF
--- a/docs/pr/1373-retire-ebpf-dataplane/README.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/README.md
@@ -283,6 +283,7 @@ surfaces move to domain interfaces such as `RuntimeDataPlane`, `SessionStore`,
 | `pkg/daemon/daemon_apply.go` | Apply path still adapts legacy compile/apply metadata. |
 | `pkg/daemon/daemon_proxyarp.go` | #2197: extracted proxy-ARP/NDP reconcile + periodic re-assert call `dataplane.ReconcileProxyARP` (control-plane kernel responder reconcile relocated from `daemon_apply.go`). |
 | `pkg/daemon/daemon_flow.go` | Flow logging still names legacy `dataplane.GlobalCtr*` counter indices read via `dataplane.Telemetry`. |
+| `pkg/daemon/daemon_nft.go` | #3436: lo0/host-inbound nft generation resolves DSCP names through the `dataplane.DSCPValues` SSOT to emit numeric nft (avoids unloadable Junos DSCP tokens); generation-only, no legacy enforcement path. |
 | `pkg/daemon/daemon_ha.go` | HA state updates still call legacy bridge methods. |
 | `pkg/daemon/daemon_ha_fabric.go` | Fabric HA updates still call legacy bridge methods. |
 | `pkg/daemon/daemon_ha_userspace.go` | Userspace HA control still crosses the legacy bridge. |

--- a/pkg/dataplane/retirement_boundary_canary_test.go
+++ b/pkg/dataplane/retirement_boundary_canary_test.go
@@ -62,6 +62,7 @@ var legacyDataplaneImportAllowlist = map[string]string{
 	"pkg/daemon/daemon_apply.go":               "apply path still adapts legacy compile/apply metadata",
 	"pkg/daemon/daemon_proxyarp.go":            "#2197: extracted proxy-ARP/NDP reconcile + periodic re-assert still call dataplane.ReconcileProxyARP (control-plane kernel responder reconcile relocated from daemon_apply.go)",
 	"pkg/daemon/daemon_flow.go":                "flow logging still names legacy dataplane.GlobalCtr* counter indices via dataplane.Telemetry",
+	"pkg/daemon/daemon_nft.go":                 "#3436: lo0/host-inbound nft generation resolves DSCP names through the dataplane.DSCPValues SSOT to emit numeric nft (avoids unloadable Junos DSCP tokens); generation-only, no legacy enforcement path",
 	"pkg/daemon/daemon_ha.go":                  "HA state updates still call legacy bridge methods",
 	"pkg/daemon/daemon_ha_fabric.go":           "fabric HA updates still call legacy bridge methods",
 	"pkg/daemon/daemon_ha_userspace.go":        "userspace HA control still crosses the legacy bridge",


### PR DESCRIPTION
## Hotfix: master CI red

#3436 (PR #3530) added a `pkg/dataplane` import to `pkg/daemon/daemon_nft.go` (DSCP name → numeric nft via the `dataplane.DSCPValues` SSOT) without recording it in the retirement-boundary canary allowlist, leaving these red on `origin/master`:
- `TestOperatorPackagesOnlyUseDocumentedLegacyDataplaneImports`
- `TestRetirementBoundaryDocsMentionLegacyImportAllowlist`

This adds the missing `legacyDataplaneImportAllowlist` entry + the matching `#1451` docs-table row. Generation-only import, no legacy enforcement path — consistent with the existing `pkg/daemon/daemon_flow.go` telemetry allowance.

Both canary tests now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)