### PR TITLE
nat: attribute interface-mode SNAT pool stats per rule set

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -216,6 +216,21 @@ under the daemon's errgroup. Nothing else imports this package.
   the legacy counter and are the follow-up SSOT surfaces (the Prometheus
   `xpf_userspace_snat_pool_*` family in `metrics_userspace.go` already
   exposes the runtime per-pool view).
+- Interface-mode source-NAT rows (`source-nat interface`, no named pool)
+  report `UsedPorts` as the count of forward SNAT sessions that traversed
+  THAT rule set's own from/to zone pair — not the firewall-wide SNAT total
+  (#3417). `natPoolStatsHandler` iterates sessions once, keying the count by
+  the session's ingress/egress zone (mapped to names via the apply result's
+  `ZoneIDs`), and each `<from>-><to>` row reads only its own bucket. Without
+  the zone map (no apply result yet) attribution is impossible, so rows
+  report 0 rather than a wrong aggregate. The #2469 fail-closed behavior is
+  preserved: a partial session scan returns HTTP 500 rather than a
+  healthy-but-low figure. The gRPC `GetNATPoolStats` mirrors this, setting
+  each interface row from `counts.ruleSetSessions[{from,to}]` (the same
+  per-rule-set breakdown it already surfaces in `RuleSetSessions`); CLI `show
+  security nat source pool` renders the gRPC value directly. Pinned by
+  `TestNATPoolStatsHandlerInterfaceModePerRuleSet` (REST) and
+  `TestGetNATPoolStatsInterfaceModePerRuleSet` (gRPC), both fail-on-revert.
 - Query-filter parsing fails CLOSED, matching the gRPC contract
   (#2934/#2935/#2939). A filter sentinel of `0`/`""` means "no filter",
   so a *malformed* filter value must error rather than silently fall

--- a/pkg/api/nat.go
+++ b/pkg/api/nat.go
@@ -190,29 +190,50 @@ func (s *Server) natPoolStatsHandler(w http.ResponseWriter, _ *http.Request) {
 		})
 	}
 
-	// Interface-mode pools
+	// Interface-mode pools. Count forward SNAT sessions ONCE, keyed by the
+	// ingress/egress zone pair, so each interface-mode rule set reports only
+	// the sessions that traversed its own from/to zone — not the firewall-wide
+	// SNAT total attributed to every row (#3417). A partial scan under-counts
+	// interface-mode NAT usage; fail rather than report a healthy-but-low
+	// figure (#2469).
+	hasInterfaceRule := false
 	for _, rs := range cfg.Security.NAT.Source {
 		for _, rule := range rs.Rules {
 			if rule.Then.Interface {
-				used := 0
-				if s.dp != nil && s.dp.IsLoaded() {
-					// A partial scan under-counts interface-mode NAT
-					// usage; fail rather than report a healthy-but-low
-					// figure (#2469).
-					if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
-						if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 {
-							used++
-						}
-						return true
-					}); err != nil {
-						writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
-						return
-					}
-				}
+				hasInterfaceRule = true
+			}
+		}
+	}
+	ruleSetUsed := map[[2]string]int{}
+	if hasInterfaceRule && s.dp != nil && s.dp.IsLoaded() {
+		// Map zone ID -> name so the per-session ingress/egress zone IDs can
+		// be attributed to the configured from/to zone pair. Without the zone
+		// map (no apply result yet) attribution is impossible, so rows report
+		// 0 rather than a wrong aggregate.
+		var zoneByID map[uint16]string
+		if cr != nil {
+			zoneByID = make(map[uint16]string, len(cr.ZoneIDs))
+			for name, id := range cr.ZoneIDs {
+				zoneByID[id] = name
+			}
+		}
+		if err := s.dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
+			if val.IsReverse == 0 && val.Flags&dataplane.SessFlagSNAT != 0 && zoneByID != nil {
+				ruleSetUsed[[2]string{zoneByID[val.IngressZone], zoneByID[val.EgressZone]}]++
+			}
+			return true
+		}); err != nil {
+			writeError(w, http.StatusInternalServerError, "iterate sessions: "+err.Error())
+			return
+		}
+	}
+	for _, rs := range cfg.Security.NAT.Source {
+		for _, rule := range rs.Rules {
+			if rule.Then.Interface {
 				result = append(result, NATPoolStatsInfo{
 					Name:        fmt.Sprintf("%s->%s", rs.FromZone, rs.ToZone),
 					Address:     "interface",
-					UsedPorts:   used,
+					UsedPorts:   ruleSetUsed[[2]string{rs.FromZone, rs.ToZone}],
 					IsInterface: true,
 				})
 			}

--- a/pkg/api/nat_stats_test.go
+++ b/pkg/api/nat_stats_test.go
@@ -193,6 +193,127 @@ func TestNATPoolStatsHandlerUsesRuntimeStatus(t *testing.T) {
 	}
 }
 
+// natIfaceSNATSessionsDP yields a fixed set of forward/reverse SNAT and
+// non-SNAT IPv4 sessions across two interface-mode rule-set zone pairs, plus
+// an ApplyResult zone map, so the REST handler can attribute each row.
+//
+// Zone IDs: trust=2, guest=4, wan=5.
+//   - 3 forward SNAT sessions trust(2)->wan(5)
+//   - 1 forward SNAT session  guest(4)->wan(5)
+//   - 1 reverse SNAT session trust->wan (must NOT count)
+//   - 1 forward NON-SNAT session trust->wan (must NOT count)
+type natIfaceSNATSessionsDP struct {
+	*dataplane.Manager
+	result *dataplane.ApplyResult
+}
+
+func (d *natIfaceSNATSessionsDP) IsLoaded() bool { return true }
+
+func (d *natIfaceSNATSessionsDP) LastApplyResult() *dataplane.ApplyResult {
+	return d.result.Clone()
+}
+
+func (d *natIfaceSNATSessionsDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	emit := func(ingress, egress uint16, reverse uint8, flags uint8) {
+		fn(dataplane.SessionKey{Protocol: 6}, dataplane.SessionValue{
+			IsReverse:   reverse,
+			Flags:       flags,
+			IngressZone: ingress,
+			EgressZone:  egress,
+		})
+	}
+	// 3 forward SNAT trust(2)->wan(5)
+	emit(2, 5, 0, dataplane.SessFlagSNAT)
+	emit(2, 5, 0, dataplane.SessFlagSNAT)
+	emit(2, 5, 0, dataplane.SessFlagSNAT)
+	// 1 forward SNAT guest(4)->wan(5)
+	emit(4, 5, 0, dataplane.SessFlagSNAT)
+	// reverse SNAT trust->wan: must be excluded
+	emit(5, 2, 1, dataplane.SessFlagSNAT)
+	// forward non-SNAT trust->wan: must be excluded
+	emit(2, 5, 0, dataplane.SessFlagDNAT)
+	return nil
+}
+
+func (d *natIfaceSNATSessionsDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
+func newIfaceNATStatsAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set security nat source rule-set trust-to-wan from zone trust
+set security nat source rule-set trust-to-wan to zone wan
+set security nat source rule-set trust-to-wan rule r1 match source-address 0.0.0.0/0
+set security nat source rule-set trust-to-wan rule r1 then source-nat interface
+set security nat source rule-set guest-to-wan from zone guest
+set security nat source rule-set guest-to-wan to zone wan
+set security nat source rule-set guest-to-wan rule r1 match source-address 0.0.0.0/0
+set security nat source rule-set guest-to-wan rule r1 then source-nat interface`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestNATPoolStatsHandlerInterfaceModePerRuleSet is a FAIL-ON-REVERT guard for
+// #3417: each interface-mode source NAT row must report only the SNAT sessions
+// that traversed its own from/to zone pair, NOT the firewall-wide SNAT total.
+//
+// Fixture: 3 SNAT sessions on trust->wan, 1 on guest->wan, plus a reverse and
+// a non-SNAT session that must not count. The global SNAT total is 4. If the
+// attribution is reverted to counts.total / a global counter, BOTH rows report
+// 4 and the per-row assertions fail.
+func TestNATPoolStatsHandlerInterfaceModePerRuleSet(t *testing.T) {
+	dp := &natIfaceSNATSessionsDP{
+		Manager: dataplane.New(),
+		result: &dataplane.ApplyResult{
+			ZoneIDs: map[string]uint16{"trust": 2, "guest": 4, "wan": 5},
+		},
+	}
+	s := &Server{store: newIfaceNATStatsAPIStore(t), dp: dp}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/nat/source/pools", nil)
+	s.natPoolStatsHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool               `json:"success"`
+		Data    []NATPoolStatsInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	got := map[string]int{}
+	for _, p := range resp.Data {
+		if !p.IsInterface {
+			t.Errorf("unexpected non-interface row %q", p.Name)
+			continue
+		}
+		got[p.Name] = p.UsedPorts
+	}
+	// trust->wan must report ONLY its 3 sessions; guest->wan ONLY its 1.
+	// The firewall-wide SNAT total is 4 — neither row may report it.
+	if got["trust->wan"] != 3 {
+		t.Errorf("trust->wan UsedPorts = %d, want 3 (per-rule-set, NOT global total 4)", got["trust->wan"])
+	}
+	if got["guest->wan"] != 1 {
+		t.Errorf("guest->wan UsedPorts = %d, want 1 (per-rule-set, NOT global total 4)", got["guest->wan"])
+	}
+}
+
 func TestNATRuleStatsHandlerReadsApplyResultOnce(t *testing.T) {
 	dp := &natApplyResultAPIDP{
 		Manager: dataplane.New(),

--- a/pkg/grpcapi/server_nat.go
+++ b/pkg/grpcapi/server_nat.go
@@ -170,14 +170,19 @@ func (s *Server) GetNATPoolStats(_ context.Context, _ *pb.GetNATPoolStatsRequest
 	}
 	resp.TotalActiveTranslations = counts.total
 
-	// Interface-mode pools
+	// Interface-mode pools. Each interface-mode rule set must report only
+	// the SNAT sessions that traversed its own from/to zone pair, not the
+	// firewall-wide SNAT total — otherwise per-uplink/per-tenant pool usage
+	// is masked by every row showing the global count (#3417). The
+	// per-rule-set breakdown is already computed in counts.ruleSetSessions
+	// (keyed by ingress/egress zone name) and surfaced via resp.RuleSetSessions.
 	for _, rs := range cfg.Security.NAT.Source {
 		for _, rule := range rs.Rules {
 			if rule.Then.Interface {
 				resp.Pools = append(resp.Pools, &pb.NATPoolStats{
 					Name:        fmt.Sprintf("%s->%s", rs.FromZone, rs.ToZone),
 					Address:     "interface",
-					UsedPorts:   counts.total,
+					UsedPorts:   counts.ruleSetSessions[natRuleSetKey{rs.FromZone, rs.ToZone}],
 					IsInterface: true,
 				})
 			}

--- a/pkg/grpcapi/server_nat_test.go
+++ b/pkg/grpcapi/server_nat_test.go
@@ -96,6 +96,78 @@ set security nat source rule-set trust-to-untrust rule r2 then source-nat interf
 	return store
 }
 
+func newIfaceNATStatsGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(`set security nat source rule-set trust-to-wan from zone trust
+set security nat source rule-set trust-to-wan to zone wan
+set security nat source rule-set trust-to-wan rule r1 match source-address 0.0.0.0/0
+set security nat source rule-set trust-to-wan rule r1 then source-nat interface
+set security nat source rule-set guest-to-wan from zone guest
+set security nat source rule-set guest-to-wan to zone wan
+set security nat source rule-set guest-to-wan rule r1 match source-address 0.0.0.0/0
+set security nat source rule-set guest-to-wan rule r1 then source-nat interface`); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestGetNATPoolStatsInterfaceModePerRuleSet is a FAIL-ON-REVERT guard for
+// #3417: each interface-mode pool row must report only the SNAT sessions that
+// traversed its own from/to zone pair, NOT the firewall-wide SNAT total.
+//
+// Two distinct interface-mode rule sets: trust->wan (3 SNAT sessions) and
+// guest->wan (1 SNAT session). The global SNAT total is 4. If the row UsedPorts
+// is reverted to counts.total, BOTH rows report 4 and the assertions fail.
+func TestGetNATPoolStatsInterfaceModePerRuleSet(t *testing.T) {
+	dp := &natSessionProviderGRPCDP{
+		Manager: dataplane.New(),
+		result: &dataplane.ApplyResult{
+			ZoneIDs: map[string]uint16{"trust": 2, "guest": 4, "wan": 5},
+		},
+		store: &natSessionGRPCStore{
+			v4: []dataplane.SessionValue{
+				{Flags: dataplane.SessFlagSNAT, IngressZone: 2, EgressZone: 5},
+				{Flags: dataplane.SessFlagSNAT, IngressZone: 2, EgressZone: 5},
+				{Flags: dataplane.SessFlagSNAT, IngressZone: 2, EgressZone: 5},
+				{Flags: dataplane.SessFlagSNAT, IngressZone: 4, EgressZone: 5},
+				// reverse + non-SNAT noise that must not count.
+				{Flags: dataplane.SessFlagSNAT, IsReverse: 1, IngressZone: 5, EgressZone: 2},
+				{Flags: dataplane.SessFlagDNAT, IngressZone: 2, EgressZone: 5},
+			},
+		},
+	}
+	s := &Server{store: newIfaceNATStatsGRPCStore(t), dp: dp}
+
+	resp, err := s.GetNATPoolStats(context.Background(), &pb.GetNATPoolStatsRequest{})
+	if err != nil {
+		t.Fatalf("GetNATPoolStats() error = %v", err)
+	}
+	if resp.TotalActiveTranslations != 4 {
+		t.Fatalf("TotalActiveTranslations = %d, want 4", resp.TotalActiveTranslations)
+	}
+	got := map[string]int32{}
+	for _, pool := range resp.Pools {
+		if !pool.IsInterface {
+			t.Errorf("unexpected non-interface pool %q", pool.Name)
+			continue
+		}
+		got[pool.Name] = pool.UsedPorts
+	}
+	if got["trust->wan"] != 3 {
+		t.Errorf("trust->wan UsedPorts = %d, want 3 (per-rule-set, NOT global total 4)", got["trust->wan"])
+	}
+	if got["guest->wan"] != 1 {
+		t.Errorf("guest->wan UsedPorts = %d, want 1 (per-rule-set, NOT global total 4)", got["guest->wan"])
+	}
+}
+
 func TestGetNATRuleStatsReadsApplyResultOnce(t *testing.T) {
 	dp := &natApplyResultGRPCDP{
 		Manager: dataplane.New(),


### PR DESCRIPTION
Closes #3417

## Problem

Interface-mode source NAT rows in `show security nat source pool` reported
the firewall-wide SNAT session total for **every** interface-mode rule set
instead of the per-rule-set (from/to zone) count. Operators reading
per-uplink/per-tenant NAT pressure saw every row attributed the global total,
masking the actually-hot rule set. REST (`/security/nat/source/pools`), gRPC
`GetNATPoolStats`, and the CLI (which renders the gRPC value) were all affected.

This is distinct from #2469 (partial-iterator under-count: the scan succeeds
here, but the *attribution* is wrong).

## Fix

- **gRPC** (`server_nat.go`): the interface-mode pool row now reads
  `counts.ruleSetSessions[natRuleSetKey{rs.FromZone, rs.ToZone}]` instead of
  `counts.total`. The per-rule-set breakdown was already computed (keyed by
  ingress/egress zone name) and surfaced in `RuleSetSessions`.
- **REST** (`nat.go`): iterate sessions **once**, keying the forward-SNAT
  count by the session's ingress/egress zone pair (mapped to names via the
  apply result's `ZoneIDs`); each `<from>-><to>` row reads only its own bucket.
  Without a zone map (no apply result yet) attribution is impossible, so rows
  report 0 rather than a wrong aggregate. The #2469 fail-closed behavior is
  preserved (partial scan -> HTTP 500).

**No wire change**: the per-rule-set counts are derived entirely from Go-side
session iteration; no new proto/counter field was added.

## Tests (fail-on-revert)

- `TestNATPoolStatsHandlerInterfaceModePerRuleSet` (REST)
- `TestGetNATPoolStatsInterfaceModePerRuleSet` (gRPC)

Both build two distinct interface-mode rule sets (`trust->wan` with 3 SNAT
sessions, `guest->wan` with 1) plus reverse + non-SNAT noise; each asserts its
row reports its own count (3 / 1), not the global total of 4. Restoring the
global-total attribution flips both rows to 4 and the assertions fail (verified).

Docs updated in `pkg/api/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi