### PR TITLE
Surface host-inbound posture distinctly in REST/gRPC zone API (#3328)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23882,3 +23882,17 @@ top.
   - **File(s)**: pkg/config/filter_protocol_rust_mirror_3393_test.go (new),
     pkg/config/compiler_validate_strict.go, pkg/config/compiler_dnat_protocol_test.go,
     userspace-dp/src/filter/tests.rs, _Log.md
+
+## 2026-06-29 — #3328 REST/gRPC host-inbound posture
+- **Timestamp**: 2026-06-29
+- **Action**: Surface per-zone (and per-interface #3362) host-inbound state
+  distinctly in REST + gRPC instead of one flattened host_inbound_services
+  list. Added host_inbound_configured / host_inbound_system_services /
+  host_inbound_protocols + interface_host_inbound; kept the flattened field as
+  a back-compat alias. proto field 12-15 (additive) + new InterfaceHostInbound
+  message. SSOT helper ZoneConfig.SortedInterfaceHostInboundRefs.
+- **File(s)**: proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go (regen),
+  pkg/grpcapi/server_show_zones.go, pkg/api/types.go, pkg/api/security.go,
+  pkg/config/types_security.go, pkg/api/security_zone_hostinbound_3328_test.go (new),
+  pkg/grpcapi/server_show_zones_hostinbound_3328_test.go (new),
+  pkg/api/README.md, pkg/grpcapi/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -51,6 +51,26 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     the scoped global's real zones on its `from_zone`/`to_zone` labels
     (#3286) — an unscoped global keeps `*`/`*` — so counter-based
     validation is unambiguous on the canonical metrics surface.
+  - `GET /api/v1/security/zones` enumerates security zones (`ZoneInfo`,
+    types.go). The host-inbound admission set is surfaced distinctly
+    (#3328): `host_inbound_configured` is the dataplane posture bit
+    (mirrors `ZoneSnapshot.HostInboundConfigured`, #3070/#3362) — true
+    when the zone declares a `host-inbound-traffic` stanza OR carries any
+    per-interface override. This lets automation tell apart the three
+    postures the dataplane actually models: no stanza
+    (`host_inbound_configured=false` → admit-all for host-bound traffic),
+    explicit empty stanza (`configured=true` with empty lists → deny-all),
+    and a populated set. `host_inbound_system_services` and
+    `host_inbound_protocols` carry the zone-level set split so a
+    system-service (ssh, ping, dhcp) is distinguishable from a routing
+    protocol (ospf, bgp). `interface_host_inbound` (omitted when none)
+    carries per-interface overrides (#3362); the effective set for an
+    interface is the union of the zone-level set and its override. The
+    legacy flattened `host_inbound_services` (services + protocols
+    concatenated) is retained as a back-compat alias. Before #3328 REST
+    exposed only the flattened list and no `configured` flag, so a
+    controller could not distinguish admit-all from deny-all — a
+    host-inbound / control-plane-protection posture ambiguity.
   - `GET /api/v1/security/screen` enumerates the configured screen
     profiles. Each `ScreenInfo` carries the profile `name`, a `checks`
     string list, and a `thresholds` map (keyed by check name). The

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -43,13 +43,38 @@ func (s *Server) zonesHandler(w http.ResponseWriter, _ *http.Request) {
 			zi.ScreenProfile = zone.ScreenProfile
 		}
 
-		// Host-inbound services
+		// Host-inbound services. #3328: surface the admission posture
+		// distinctly. HostInbound stays the flattened back-compat alias, but the
+		// split fields let automation tell a service apart from a protocol and —
+		// via HostInboundConfigured — tell "no stanza" (admit-all) apart from an
+		// explicit empty stanza (deny-all).
 		if zone.HostInboundTraffic != nil {
 			zi.HostInbound = append(zi.HostInbound, zone.HostInboundTraffic.SystemServices...)
 			zi.HostInbound = append(zi.HostInbound, zone.HostInboundTraffic.Protocols...)
+			zi.HostInboundSystemServices = append(zi.HostInboundSystemServices, zone.HostInboundTraffic.SystemServices...)
+			zi.HostInboundProtocols = append(zi.HostInboundProtocols, zone.HostInboundTraffic.Protocols...)
+		}
+		// HostInboundConfigured mirrors ZoneSnapshot.HostInboundConfigured
+		// (#3070/#3362): the zone is host-inbound ENFORCING when it declares a
+		// zone-level stanza OR carries any per-interface override.
+		zi.HostInboundConfigured = zone.HostInboundTraffic != nil || len(zone.InterfaceHostInbound) > 0
+		for _, ref := range zone.SortedInterfaceHostInboundRefs() {
+			hib := zone.InterfaceHostInbound[ref]
+			zi.InterfaceHostInbound = append(zi.InterfaceHostInbound, ZoneInterfaceHostInbound{
+				Interface:      ref,
+				Configured:     true,
+				SystemServices: append([]string{}, hib.SystemServices...),
+				Protocols:      append([]string{}, hib.Protocols...),
+			})
 		}
 		if zi.HostInbound == nil {
 			zi.HostInbound = []string{}
+		}
+		if zi.HostInboundSystemServices == nil {
+			zi.HostInboundSystemServices = []string{}
+		}
+		if zi.HostInboundProtocols == nil {
+			zi.HostInboundProtocols = []string{}
 		}
 		if zi.Interfaces == nil {
 			zi.Interfaces = []string{}

--- a/pkg/api/security_zone_hostinbound_3328_test.go
+++ b/pkg/api/security_zone_hostinbound_3328_test.go
@@ -1,0 +1,196 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3328: the REST zone inventory flattened the host-inbound admission set into
+// one host_inbound_services list and never exposed whether a host-inbound
+// stanza was configured at all, so automation could not tell apart the three
+// dataplane postures: no stanza (admit-all), explicit empty stanza (deny-all),
+// and a populated set (split into system-services vs protocols). ZoneInfo now
+// carries host_inbound_configured, host_inbound_system_services,
+// host_inbound_protocols, and per-interface overrides (#3362). These are the
+// fail-on-revert guards: drop the population in zonesHandler and the assertions
+// below go RED.
+
+// zoneHostInboundAPIStore builds a config exercising every host-inbound
+// posture:
+//   - trust: zone-level stanza with both system-services AND protocols
+//     (populated → configured=true, split lists non-empty),
+//   - locked: explicit EMPTY zone-level stanza (deny-all → configured=true,
+//     empty split lists),
+//   - edge: NO zone-level stanza but a per-interface override on ge-0/0/9.0
+//     (enforcing via override → configured=true, empty zone lists, one
+//     interface entry),
+//   - open: NO host-inbound at all (admit-all → configured=false).
+func zoneHostInboundAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services {
+                    ssh;
+                    ping;
+                }
+                protocols {
+                    ospf;
+                }
+            }
+        }
+        security-zone locked {
+            host-inbound-traffic;
+        }
+        security-zone edge {
+            interfaces {
+                ge-0/0/9.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            https;
+                        }
+                    }
+                }
+            }
+        }
+        security-zone open;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestZonesHandlerSurfacesHostInboundPosture(t *testing.T) {
+	s := &Server{store: zoneHostInboundAPIStore(t)}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/zones", nil)
+	s.zonesHandler(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool       `json:"success"`
+		Data    []ZoneInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+
+	byName := map[string]ZoneInfo{}
+	for _, z := range resp.Data {
+		byName[z.Name] = z
+	}
+
+	// trust: populated zone-level stanza. system-services and protocols must be
+	// split distinctly (the #3328 ambiguity), configured true.
+	trust, ok := byName["trust"]
+	if !ok {
+		t.Fatalf("trust zone missing from REST inventory; body: %s", rr.Body.String())
+	}
+	if !trust.HostInboundConfigured {
+		t.Fatalf("trust host_inbound_configured = false, want true (#3328 regression)")
+	}
+	if got := trust.HostInboundSystemServices; len(got) != 2 || got[0] != "ssh" || got[1] != "ping" {
+		t.Fatalf("trust host_inbound_system_services = %v, want [ssh ping] (#3328 regression — services flattened)", got)
+	}
+	if got := trust.HostInboundProtocols; len(got) != 1 || got[0] != "ospf" {
+		t.Fatalf("trust host_inbound_protocols = %v, want [ospf] (#3328 regression — protocols flattened)", got)
+	}
+	// Legacy flattened alias must remain (system-services + protocols).
+	if got := trust.HostInbound; len(got) != 3 {
+		t.Fatalf("trust host_inbound_services (legacy alias) = %v, want 3 entries", got)
+	}
+
+	// locked: explicit empty stanza = deny-all. The whole point of #3328:
+	// configured=true distinguishes it from a zone with no stanza (open).
+	locked, ok := byName["locked"]
+	if !ok {
+		t.Fatalf("locked zone missing from REST inventory")
+	}
+	if !locked.HostInboundConfigured {
+		t.Fatalf("locked host_inbound_configured = false, want true (explicit empty stanza = deny-all; #3328 the no-stanza-vs-empty-stanza distinction)")
+	}
+	if len(locked.HostInboundSystemServices) != 0 || len(locked.HostInboundProtocols) != 0 {
+		t.Fatalf("locked host-inbound lists = %v/%v, want empty (deny-all)",
+			locked.HostInboundSystemServices, locked.HostInboundProtocols)
+	}
+
+	// open: no stanza at all = admit-all. configured MUST be false so it is
+	// distinguishable from locked.
+	open, ok := byName["open"]
+	if !ok {
+		t.Fatalf("open zone missing from REST inventory")
+	}
+	if open.HostInboundConfigured {
+		t.Fatalf("open host_inbound_configured = true, want false (no stanza = admit-all; #3328 must not collapse with the empty-stanza deny-all posture)")
+	}
+
+	// edge: no zone-level stanza but a per-interface override. The zone is
+	// enforcing (configured=true) via the override, the zone-level lists are
+	// empty, and the override is surfaced per-interface.
+	edge, ok := byName["edge"]
+	if !ok {
+		t.Fatalf("edge zone missing from REST inventory")
+	}
+	if !edge.HostInboundConfigured {
+		t.Fatalf("edge host_inbound_configured = false, want true (per-interface override makes the zone enforcing; #3362/#3328)")
+	}
+	if len(edge.HostInboundSystemServices) != 0 || len(edge.HostInboundProtocols) != 0 {
+		t.Fatalf("edge zone-level host-inbound lists = %v/%v, want empty (override is per-interface only)",
+			edge.HostInboundSystemServices, edge.HostInboundProtocols)
+	}
+	if len(edge.InterfaceHostInbound) != 1 {
+		t.Fatalf("edge interface_host_inbound = %v, want 1 entry (#3328 per-interface override dropped)", edge.InterfaceHostInbound)
+	}
+	iface := edge.InterfaceHostInbound[0]
+	if iface.Interface != "ge-0/0/9.0" {
+		t.Fatalf("edge override interface = %q, want ge-0/0/9.0", iface.Interface)
+	}
+	if !iface.Configured {
+		t.Fatalf("edge override configured = false, want true")
+	}
+	if len(iface.SystemServices) != 1 || iface.SystemServices[0] != "https" {
+		t.Fatalf("edge override system_services = %v, want [https]", iface.SystemServices)
+	}
+
+	// The interface_host_inbound key must be ABSENT for a zone with no
+	// per-interface override (omitempty contract) so existing consumers see no
+	// change for configs that don't use #3362.
+	var raw struct {
+		Data []map[string]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw response: %v", err)
+	}
+	for _, z := range raw.Data {
+		name := ""
+		_ = json.Unmarshal(z["name"], &name)
+		if name != "trust" {
+			continue
+		}
+		if _, ok := z["interface_host_inbound"]; ok {
+			t.Fatalf("trust zone serialized interface_host_inbound for a zone with no per-interface override; want omitted")
+		}
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -72,14 +72,50 @@ type ZoneInfo struct {
 	// security-zone <z> tcp-rst` is configured the zone sends a TCP RST for
 	// non-SYN packets to closed ports, changing client-visible deny
 	// behaviour. Omitted (false) for zones without it.
-	TcpRst         bool     `json:"tcp_rst,omitempty"`
-	ScreenProfile  string   `json:"screen_profile,omitempty"`
-	Interfaces     []string `json:"interfaces"`
-	HostInbound    []string `json:"host_inbound_services"`
-	IngressPackets uint64   `json:"ingress_packets"`
-	IngressBytes   uint64   `json:"ingress_bytes"`
-	EgressPackets  uint64   `json:"egress_packets"`
-	EgressBytes    uint64   `json:"egress_bytes"`
+	TcpRst        bool     `json:"tcp_rst,omitempty"`
+	ScreenProfile string   `json:"screen_profile,omitempty"`
+	Interfaces    []string `json:"interfaces"`
+	// HostInbound is the LEGACY flattened admission set: system-services +
+	// protocols concatenated. Kept as a back-compat alias (#3328); new
+	// consumers should read the split fields below.
+	HostInbound []string `json:"host_inbound_services"`
+	// HostInboundConfigured (#3328) records whether the zone is host-inbound
+	// ENFORCING: true when the zone declares a `host-inbound-traffic` stanza OR
+	// carries any per-interface override (#3362). Mirrors the dataplane posture
+	// bit (ZoneSnapshot.HostInboundConfigured): false = no stanza = default
+	// admit-all for host-bound traffic; true with EMPTY service/protocol lists
+	// = explicit deny-all. Without it an operator cannot distinguish "no
+	// stanza" (admit-all) from "empty stanza" (deny-all).
+	HostInboundConfigured bool `json:"host_inbound_configured"`
+	// HostInboundSystemServices / HostInboundProtocols (#3328) carry the
+	// ZONE-LEVEL admission set, kept distinct so automation can tell a
+	// system-service (ssh, ping, dhcp) apart from a routing protocol (ospf,
+	// bgp). Empty when the zone expresses host-inbound only via per-interface
+	// overrides.
+	HostInboundSystemServices []string `json:"host_inbound_system_services"`
+	HostInboundProtocols      []string `json:"host_inbound_protocols"`
+	// InterfaceHostInbound (#3328, #3362) carries per-interface host-inbound
+	// overrides. An entry exists only for an interface that declares its own
+	// `host-inbound-traffic` stanza; the effective admission set for that
+	// interface is the UNION of the zone-level set above and the override.
+	// Omitted when no interface declares an override.
+	InterfaceHostInbound []ZoneInterfaceHostInbound `json:"interface_host_inbound,omitempty"`
+	IngressPackets       uint64                     `json:"ingress_packets"`
+	IngressBytes         uint64                     `json:"ingress_bytes"`
+	EgressPackets        uint64                     `json:"egress_packets"`
+	EgressBytes          uint64                     `json:"egress_bytes"`
+}
+
+// ZoneInterfaceHostInbound is a per-interface host-inbound-traffic override
+// (#3328, #3362): a zone may expose a service (e.g. ssh) on one interface
+// while denying it on the others. Configured is always true for an emitted
+// entry (the stanza is present); empty SystemServices/Protocols with
+// Configured=true mean an explicit deny-all override on that interface.
+type ZoneInterfaceHostInbound struct {
+	Interface      string   `json:"interface"`
+	Configured     bool     `json:"configured"`
+	SystemServices []string `json:"system_services"`
+	Protocols      []string `json:"protocols"`
 }
 
 // PolicyInfo holds policy configuration data.

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -1,5 +1,7 @@
 package config
 
+import "sort"
+
 // Security policy domain: zones, policies, NAT, screen/IDS, address book,
 // applications, flow/session, ALG, logging, IPsec/IKE, dynamic-address
 // feeds, and the [edit schedulers] policy time-range scheduler.
@@ -245,6 +247,23 @@ type ZoneConfig struct {
 type HostInboundTraffic struct {
 	SystemServices []string // ssh, ping, dns, etc.
 	Protocols      []string // ospf, bgp, etc.
+}
+
+// SortedInterfaceHostInboundRefs returns the interface refs that declare a
+// per-interface host-inbound-traffic override (#3362), sorted for a stable
+// presentation order. It is the SSOT for the REST/gRPC zone-inventory
+// projection (#3328) so both surfaces iterate the overrides identically.
+// Returns nil for a zone with no per-interface overrides.
+func (z *ZoneConfig) SortedInterfaceHostInboundRefs() []string {
+	if z == nil || len(z.InterfaceHostInbound) == 0 {
+		return nil
+	}
+	refs := make([]string, 0, len(z.InterfaceHostInbound))
+	for ref := range z.InterfaceHostInbound {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs
 }
 
 // ZonePairPolicies contains ordered policies for a from-zone/to-zone pair.

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -155,6 +155,25 @@ contract.
   per-rule `match_from_zone`/`match_to_zone` proto fields (empty for an
   unscoped global). Showing the group `*`/`*` but dropping the per-rule
   scope is the #3286 blind spot.
+- `GetZones` enumerates security zones (`ZoneInfo`). The host-inbound
+  admission set is surfaced distinctly (#3328): `host_inbound_configured`
+  is the dataplane posture bit (mirrors `ZoneSnapshot.HostInboundConfigured`,
+  #3070/#3362) — true when the zone declares a `host-inbound-traffic`
+  stanza OR carries any per-interface override. It lets a controller tell
+  apart the three postures the dataplane models: no stanza
+  (`configured=false` → admit-all for host-bound traffic), explicit empty
+  stanza (`configured=true` with empty lists → deny-all), and a populated
+  set. `host_inbound_system_services` / `host_inbound_protocols` carry the
+  zone-level set split (a service vs a routing protocol);
+  `interface_host_inbound` (repeated `InterfaceHostInbound`) carries
+  per-interface overrides (#3362), the effective set being the union of
+  the zone-level set and the override. The legacy `host_inbound_services`
+  flattened list (services + protocols) is kept as a back-compat alias.
+  The split projection is the SSOT-shared `ZoneConfig.SortedInterfaceHostInboundRefs`
+  iteration the REST `GET /api/v1/security/zones` handler also uses. Before
+  #3328 this RPC exposed only the flattened list and no `configured` flag —
+  a host-inbound / control-plane-protection posture ambiguity for
+  automation.
 - `GetScreen` enumerates the configured screen profiles. `ScreenInfo`
   carries `name`, the `checks` string list, and a `map<string,int64>
   thresholds`. The `checks` list and thresholds come from the shared

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -38,9 +38,30 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 		if zone.ScreenProfile != "" {
 			zi.ScreenProfile = zone.ScreenProfile
 		}
+		// #3328: surface the host-inbound admission posture distinctly. The
+		// legacy host_inbound_services list stays as a flattened back-compat
+		// alias (system-services + protocols), but the split fields below let
+		// automation tell a service apart from a protocol and — via
+		// host_inbound_configured — tell "no stanza" (admit-all) apart from an
+		// explicit empty stanza (deny-all).
 		if zone.HostInboundTraffic != nil {
 			zi.HostInboundServices = append(zi.HostInboundServices, zone.HostInboundTraffic.SystemServices...)
 			zi.HostInboundServices = append(zi.HostInboundServices, zone.HostInboundTraffic.Protocols...)
+			zi.HostInboundSystemServices = append(zi.HostInboundSystemServices, zone.HostInboundTraffic.SystemServices...)
+			zi.HostInboundProtocols = append(zi.HostInboundProtocols, zone.HostInboundTraffic.Protocols...)
+		}
+		// host_inbound_configured mirrors ZoneSnapshot.HostInboundConfigured
+		// (#3070/#3362): the zone is host-inbound ENFORCING when it declares a
+		// zone-level stanza OR carries any per-interface override.
+		zi.HostInboundConfigured = zone.HostInboundTraffic != nil || len(zone.InterfaceHostInbound) > 0
+		for _, ref := range zone.SortedInterfaceHostInboundRefs() {
+			hib := zone.InterfaceHostInbound[ref]
+			zi.InterfaceHostInbound = append(zi.InterfaceHostInbound, &pb.InterfaceHostInbound{
+				Interface:      ref,
+				Configured:     true,
+				SystemServices: append([]string{}, hib.SystemServices...),
+				Protocols:      append([]string{}, hib.Protocols...),
+			})
 		}
 		if zi.Interfaces == nil {
 			zi.Interfaces = []string{}

--- a/pkg/grpcapi/server_show_zones_hostinbound_3328_test.go
+++ b/pkg/grpcapi/server_show_zones_hostinbound_3328_test.go
@@ -1,0 +1,141 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3328: gRPC GetZones flattened the host-inbound admission set into one
+// host_inbound_services repeated field and exposed no host_inbound_configured,
+// so a controller could not distinguish no-stanza (admit-all) from an explicit
+// empty stanza (deny-all), nor a system-service from a routing protocol.
+// ZoneInfo now carries host_inbound_configured, host_inbound_system_services,
+// host_inbound_protocols, and interface_host_inbound (#3362). These are the
+// fail-on-revert guards.
+
+func zoneHostInboundGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services {
+                    ssh;
+                    ping;
+                }
+                protocols {
+                    ospf;
+                }
+            }
+        }
+        security-zone locked {
+            host-inbound-traffic;
+        }
+        security-zone edge {
+            interfaces {
+                ge-0/0/9.0 {
+                    host-inbound-traffic {
+                        system-services {
+                            https;
+                        }
+                    }
+                }
+            }
+        }
+        security-zone open;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestGetZonesSurfacesHostInboundPosture(t *testing.T) {
+	s := &Server{store: zoneHostInboundGRPCStore(t)}
+
+	resp, err := s.GetZones(context.Background(), &pb.GetZonesRequest{})
+	if err != nil {
+		t.Fatalf("GetZones() error = %v", err)
+	}
+
+	byName := map[string]*pb.ZoneInfo{}
+	for _, z := range resp.GetZones() {
+		byName[z.GetName()] = z
+	}
+
+	trust, ok := byName["trust"]
+	if !ok {
+		t.Fatal("trust zone missing from gRPC inventory")
+	}
+	if !trust.GetHostInboundConfigured() {
+		t.Fatal("trust host_inbound_configured = false, want true (#3328 regression)")
+	}
+	if got := trust.GetHostInboundSystemServices(); len(got) != 2 || got[0] != "ssh" || got[1] != "ping" {
+		t.Fatalf("trust host_inbound_system_services = %v, want [ssh ping] (#3328 regression — services flattened)", got)
+	}
+	if got := trust.GetHostInboundProtocols(); len(got) != 1 || got[0] != "ospf" {
+		t.Fatalf("trust host_inbound_protocols = %v, want [ospf] (#3328 regression — protocols flattened)", got)
+	}
+	if got := trust.GetHostInboundServices(); len(got) != 3 {
+		t.Fatalf("trust host_inbound_services (legacy alias) = %v, want 3 entries", got)
+	}
+
+	locked, ok := byName["locked"]
+	if !ok {
+		t.Fatal("locked zone missing")
+	}
+	if !locked.GetHostInboundConfigured() {
+		t.Fatal("locked host_inbound_configured = false, want true (explicit empty stanza = deny-all; the no-stanza-vs-empty-stanza distinction #3328)")
+	}
+	if len(locked.GetHostInboundSystemServices()) != 0 || len(locked.GetHostInboundProtocols()) != 0 {
+		t.Fatalf("locked host-inbound lists = %v/%v, want empty (deny-all)",
+			locked.GetHostInboundSystemServices(), locked.GetHostInboundProtocols())
+	}
+
+	open, ok := byName["open"]
+	if !ok {
+		t.Fatal("open zone missing")
+	}
+	if open.GetHostInboundConfigured() {
+		t.Fatal("open host_inbound_configured = true, want false (no stanza = admit-all; #3328 must not collapse with the empty-stanza deny-all posture)")
+	}
+
+	edge, ok := byName["edge"]
+	if !ok {
+		t.Fatal("edge zone missing")
+	}
+	if !edge.GetHostInboundConfigured() {
+		t.Fatal("edge host_inbound_configured = false, want true (per-interface override makes the zone enforcing; #3362/#3328)")
+	}
+	if len(edge.GetHostInboundSystemServices()) != 0 || len(edge.GetHostInboundProtocols()) != 0 {
+		t.Fatalf("edge zone-level host-inbound lists = %v/%v, want empty (override is per-interface only)",
+			edge.GetHostInboundSystemServices(), edge.GetHostInboundProtocols())
+	}
+	if len(edge.GetInterfaceHostInbound()) != 1 {
+		t.Fatalf("edge interface_host_inbound = %v, want 1 entry (#3328 per-interface override dropped)", edge.GetInterfaceHostInbound())
+	}
+	iface := edge.GetInterfaceHostInbound()[0]
+	if iface.GetInterface() != "ge-0/0/9.0" {
+		t.Fatalf("edge override interface = %q, want ge-0/0/9.0", iface.GetInterface())
+	}
+	if !iface.GetConfigured() {
+		t.Fatal("edge override configured = false, want true")
+	}
+	if got := iface.GetSystemServices(); len(got) != 1 || got[0] != "https" {
+		t.Fatalf("edge override system_services = %v, want [https]", got)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -1895,20 +1895,43 @@ func (x *GetZonesResponse) GetZones() []*ZoneInfo {
 }
 
 type ZoneInfo struct {
-	state               protoimpl.MessageState `protogen:"open.v1"`
-	Name                string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Id                  uint32                 `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
-	ScreenProfile       string                 `protobuf:"bytes,3,opt,name=screen_profile,json=screenProfile,proto3" json:"screen_profile,omitempty"`
-	Interfaces          []string               `protobuf:"bytes,4,rep,name=interfaces,proto3" json:"interfaces,omitempty"`
-	HostInboundServices []string               `protobuf:"bytes,5,rep,name=host_inbound_services,json=hostInboundServices,proto3" json:"host_inbound_services,omitempty"`
-	IngressPackets      uint64                 `protobuf:"varint,6,opt,name=ingress_packets,json=ingressPackets,proto3" json:"ingress_packets,omitempty"`
-	IngressBytes        uint64                 `protobuf:"varint,7,opt,name=ingress_bytes,json=ingressBytes,proto3" json:"ingress_bytes,omitempty"`
-	EgressPackets       uint64                 `protobuf:"varint,8,opt,name=egress_packets,json=egressPackets,proto3" json:"egress_packets,omitempty"`
-	EgressBytes         uint64                 `protobuf:"varint,9,opt,name=egress_bytes,json=egressBytes,proto3" json:"egress_bytes,omitempty"`
-	TcpRst              bool                   `protobuf:"varint,10,opt,name=tcp_rst,json=tcpRst,proto3" json:"tcp_rst,omitempty"`
-	Description         string                 `protobuf:"bytes,11,opt,name=description,proto3" json:"description,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Id            uint32                 `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
+	ScreenProfile string                 `protobuf:"bytes,3,opt,name=screen_profile,json=screenProfile,proto3" json:"screen_profile,omitempty"`
+	Interfaces    []string               `protobuf:"bytes,4,rep,name=interfaces,proto3" json:"interfaces,omitempty"`
+	// host_inbound_services is the LEGACY flattened admission set:
+	// system-services + protocols concatenated into one list. Kept as a
+	// back-compat alias; new consumers should read the split fields below.
+	HostInboundServices []string `protobuf:"bytes,5,rep,name=host_inbound_services,json=hostInboundServices,proto3" json:"host_inbound_services,omitempty"`
+	IngressPackets      uint64   `protobuf:"varint,6,opt,name=ingress_packets,json=ingressPackets,proto3" json:"ingress_packets,omitempty"`
+	IngressBytes        uint64   `protobuf:"varint,7,opt,name=ingress_bytes,json=ingressBytes,proto3" json:"ingress_bytes,omitempty"`
+	EgressPackets       uint64   `protobuf:"varint,8,opt,name=egress_packets,json=egressPackets,proto3" json:"egress_packets,omitempty"`
+	EgressBytes         uint64   `protobuf:"varint,9,opt,name=egress_bytes,json=egressBytes,proto3" json:"egress_bytes,omitempty"`
+	TcpRst              bool     `protobuf:"varint,10,opt,name=tcp_rst,json=tcpRst,proto3" json:"tcp_rst,omitempty"`
+	Description         string   `protobuf:"bytes,11,opt,name=description,proto3" json:"description,omitempty"`
+	// host_inbound_configured (#3328) records whether the zone is host-inbound
+	// ENFORCING: true when the zone declares a `host-inbound-traffic` stanza OR
+	// carries any per-interface override (#3362). This is the dataplane posture
+	// bit (ZoneSnapshot.HostInboundConfigured): false = no stanza = default
+	// admit-all for host-bound traffic; true with EMPTY lists = explicit
+	// deny-all. Without it an operator cannot distinguish "no stanza"
+	// (admit-all) from "empty stanza" (deny-all).
+	HostInboundConfigured bool `protobuf:"varint,12,opt,name=host_inbound_configured,json=hostInboundConfigured,proto3" json:"host_inbound_configured,omitempty"`
+	// host_inbound_system_services / host_inbound_protocols (#3328) carry the
+	// ZONE-LEVEL admission set, kept distinct so automation can tell a
+	// system-service (ssh, ping, dhcp) apart from a routing protocol (ospf,
+	// bgp). Empty when the zone has no zone-level stanza (e.g. host-inbound is
+	// expressed only via per-interface overrides below).
+	HostInboundSystemServices []string `protobuf:"bytes,13,rep,name=host_inbound_system_services,json=hostInboundSystemServices,proto3" json:"host_inbound_system_services,omitempty"`
+	HostInboundProtocols      []string `protobuf:"bytes,14,rep,name=host_inbound_protocols,json=hostInboundProtocols,proto3" json:"host_inbound_protocols,omitempty"`
+	// interface_host_inbound (#3328, #3362) carries per-interface host-inbound
+	// overrides. An entry exists only for an interface that declares its own
+	// `host-inbound-traffic` stanza; the effective admission set for that
+	// interface is the UNION of the zone-level set above and its override.
+	InterfaceHostInbound []*InterfaceHostInbound `protobuf:"bytes,15,rep,name=interface_host_inbound,json=interfaceHostInbound,proto3" json:"interface_host_inbound,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ZoneInfo) Reset() {
@@ -2018,6 +2041,107 @@ func (x *ZoneInfo) GetDescription() string {
 	return ""
 }
 
+func (x *ZoneInfo) GetHostInboundConfigured() bool {
+	if x != nil {
+		return x.HostInboundConfigured
+	}
+	return false
+}
+
+func (x *ZoneInfo) GetHostInboundSystemServices() []string {
+	if x != nil {
+		return x.HostInboundSystemServices
+	}
+	return nil
+}
+
+func (x *ZoneInfo) GetHostInboundProtocols() []string {
+	if x != nil {
+		return x.HostInboundProtocols
+	}
+	return nil
+}
+
+func (x *ZoneInfo) GetInterfaceHostInbound() []*InterfaceHostInbound {
+	if x != nil {
+		return x.InterfaceHostInbound
+	}
+	return nil
+}
+
+// InterfaceHostInbound (#3328, #3362) is a per-interface host-inbound-traffic
+// override: a zone may expose a service (e.g. ssh) on one interface while
+// denying it on the others. `configured` is always true for an emitted entry
+// (the stanza is present); empty service/protocol lists with configured=true
+// mean an explicit deny-all override on that interface.
+type InterfaceHostInbound struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Interface      string                 `protobuf:"bytes,1,opt,name=interface,proto3" json:"interface,omitempty"`
+	Configured     bool                   `protobuf:"varint,2,opt,name=configured,proto3" json:"configured,omitempty"`
+	SystemServices []string               `protobuf:"bytes,3,rep,name=system_services,json=systemServices,proto3" json:"system_services,omitempty"`
+	Protocols      []string               `protobuf:"bytes,4,rep,name=protocols,proto3" json:"protocols,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *InterfaceHostInbound) Reset() {
+	*x = InterfaceHostInbound{}
+	mi := &file_xpf_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InterfaceHostInbound) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InterfaceHostInbound) ProtoMessage() {}
+
+func (x *InterfaceHostInbound) ProtoReflect() protoreflect.Message {
+	mi := &file_xpf_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InterfaceHostInbound.ProtoReflect.Descriptor instead.
+func (*InterfaceHostInbound) Descriptor() ([]byte, []int) {
+	return file_xpf_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *InterfaceHostInbound) GetInterface() string {
+	if x != nil {
+		return x.Interface
+	}
+	return ""
+}
+
+func (x *InterfaceHostInbound) GetConfigured() bool {
+	if x != nil {
+		return x.Configured
+	}
+	return false
+}
+
+func (x *InterfaceHostInbound) GetSystemServices() []string {
+	if x != nil {
+		return x.SystemServices
+	}
+	return nil
+}
+
+func (x *InterfaceHostInbound) GetProtocols() []string {
+	if x != nil {
+		return x.Protocols
+	}
+	return nil
+}
+
 type GetPoliciesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2026,7 +2150,7 @@ type GetPoliciesRequest struct {
 
 func (x *GetPoliciesRequest) Reset() {
 	*x = GetPoliciesRequest{}
-	mi := &file_xpf_proto_msgTypes[38]
+	mi := &file_xpf_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2038,7 +2162,7 @@ func (x *GetPoliciesRequest) String() string {
 func (*GetPoliciesRequest) ProtoMessage() {}
 
 func (x *GetPoliciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[38]
+	mi := &file_xpf_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2051,7 +2175,7 @@ func (x *GetPoliciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPoliciesRequest.ProtoReflect.Descriptor instead.
 func (*GetPoliciesRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{38}
+	return file_xpf_proto_rawDescGZIP(), []int{39}
 }
 
 type GetPoliciesResponse struct {
@@ -2063,7 +2187,7 @@ type GetPoliciesResponse struct {
 
 func (x *GetPoliciesResponse) Reset() {
 	*x = GetPoliciesResponse{}
-	mi := &file_xpf_proto_msgTypes[39]
+	mi := &file_xpf_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2075,7 +2199,7 @@ func (x *GetPoliciesResponse) String() string {
 func (*GetPoliciesResponse) ProtoMessage() {}
 
 func (x *GetPoliciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[39]
+	mi := &file_xpf_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2088,7 +2212,7 @@ func (x *GetPoliciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPoliciesResponse.ProtoReflect.Descriptor instead.
 func (*GetPoliciesResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{39}
+	return file_xpf_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *GetPoliciesResponse) GetPolicies() []*PolicyInfo {
@@ -2109,7 +2233,7 @@ type PolicyInfo struct {
 
 func (x *PolicyInfo) Reset() {
 	*x = PolicyInfo{}
-	mi := &file_xpf_proto_msgTypes[40]
+	mi := &file_xpf_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2121,7 +2245,7 @@ func (x *PolicyInfo) String() string {
 func (*PolicyInfo) ProtoMessage() {}
 
 func (x *PolicyInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[40]
+	mi := &file_xpf_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2134,7 +2258,7 @@ func (x *PolicyInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyInfo.ProtoReflect.Descriptor instead.
 func (*PolicyInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{40}
+	return file_xpf_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *PolicyInfo) GetFromZone() string {
@@ -2204,7 +2328,7 @@ type PolicyRule struct {
 
 func (x *PolicyRule) Reset() {
 	*x = PolicyRule{}
-	mi := &file_xpf_proto_msgTypes[41]
+	mi := &file_xpf_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2216,7 +2340,7 @@ func (x *PolicyRule) String() string {
 func (*PolicyRule) ProtoMessage() {}
 
 func (x *PolicyRule) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[41]
+	mi := &file_xpf_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2229,7 +2353,7 @@ func (x *PolicyRule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PolicyRule.ProtoReflect.Descriptor instead.
 func (*PolicyRule) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{41}
+	return file_xpf_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *PolicyRule) GetName() string {
@@ -2385,7 +2509,7 @@ type GetSessionsRequest struct {
 
 func (x *GetSessionsRequest) Reset() {
 	*x = GetSessionsRequest{}
-	mi := &file_xpf_proto_msgTypes[42]
+	mi := &file_xpf_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2397,7 +2521,7 @@ func (x *GetSessionsRequest) String() string {
 func (*GetSessionsRequest) ProtoMessage() {}
 
 func (x *GetSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[42]
+	mi := &file_xpf_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2410,7 +2534,7 @@ func (x *GetSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionsRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{42}
+	return file_xpf_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *GetSessionsRequest) GetLimit() int32 {
@@ -2540,7 +2664,7 @@ type GetSessionsResponse struct {
 
 func (x *GetSessionsResponse) Reset() {
 	*x = GetSessionsResponse{}
-	mi := &file_xpf_proto_msgTypes[43]
+	mi := &file_xpf_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2552,7 +2676,7 @@ func (x *GetSessionsResponse) String() string {
 func (*GetSessionsResponse) ProtoMessage() {}
 
 func (x *GetSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[43]
+	mi := &file_xpf_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2565,7 +2689,7 @@ func (x *GetSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionsResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{43}
+	return file_xpf_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *GetSessionsResponse) GetTotal() int32 {
@@ -2654,7 +2778,7 @@ type SessionEntry struct {
 
 func (x *SessionEntry) Reset() {
 	*x = SessionEntry{}
-	mi := &file_xpf_proto_msgTypes[44]
+	mi := &file_xpf_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2666,7 +2790,7 @@ func (x *SessionEntry) String() string {
 func (*SessionEntry) ProtoMessage() {}
 
 func (x *SessionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[44]
+	mi := &file_xpf_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2679,7 +2803,7 @@ func (x *SessionEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionEntry.ProtoReflect.Descriptor instead.
 func (*SessionEntry) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{44}
+	return file_xpf_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *SessionEntry) GetSrcAddr() string {
@@ -2894,7 +3018,7 @@ type GetSessionSummaryRequest struct {
 
 func (x *GetSessionSummaryRequest) Reset() {
 	*x = GetSessionSummaryRequest{}
-	mi := &file_xpf_proto_msgTypes[45]
+	mi := &file_xpf_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2906,7 +3030,7 @@ func (x *GetSessionSummaryRequest) String() string {
 func (*GetSessionSummaryRequest) ProtoMessage() {}
 
 func (x *GetSessionSummaryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[45]
+	mi := &file_xpf_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2919,7 +3043,7 @@ func (x *GetSessionSummaryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionSummaryRequest.ProtoReflect.Descriptor instead.
 func (*GetSessionSummaryRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{45}
+	return file_xpf_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *GetSessionSummaryRequest) GetIncludePeer() bool {
@@ -2946,7 +3070,7 @@ type GetSessionSummaryResponse struct {
 
 func (x *GetSessionSummaryResponse) Reset() {
 	*x = GetSessionSummaryResponse{}
-	mi := &file_xpf_proto_msgTypes[46]
+	mi := &file_xpf_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2958,7 +3082,7 @@ func (x *GetSessionSummaryResponse) String() string {
 func (*GetSessionSummaryResponse) ProtoMessage() {}
 
 func (x *GetSessionSummaryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[46]
+	mi := &file_xpf_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2971,7 +3095,7 @@ func (x *GetSessionSummaryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSessionSummaryResponse.ProtoReflect.Descriptor instead.
 func (*GetSessionSummaryResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{46}
+	return file_xpf_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *GetSessionSummaryResponse) GetTotalEntries() int32 {
@@ -3045,7 +3169,7 @@ type GetNATSourceRequest struct {
 
 func (x *GetNATSourceRequest) Reset() {
 	*x = GetNATSourceRequest{}
-	mi := &file_xpf_proto_msgTypes[47]
+	mi := &file_xpf_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3057,7 +3181,7 @@ func (x *GetNATSourceRequest) String() string {
 func (*GetNATSourceRequest) ProtoMessage() {}
 
 func (x *GetNATSourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[47]
+	mi := &file_xpf_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3070,7 +3194,7 @@ func (x *GetNATSourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATSourceRequest.ProtoReflect.Descriptor instead.
 func (*GetNATSourceRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{47}
+	return file_xpf_proto_rawDescGZIP(), []int{48}
 }
 
 type GetNATSourceResponse struct {
@@ -3082,7 +3206,7 @@ type GetNATSourceResponse struct {
 
 func (x *GetNATSourceResponse) Reset() {
 	*x = GetNATSourceResponse{}
-	mi := &file_xpf_proto_msgTypes[48]
+	mi := &file_xpf_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3094,7 +3218,7 @@ func (x *GetNATSourceResponse) String() string {
 func (*GetNATSourceResponse) ProtoMessage() {}
 
 func (x *GetNATSourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[48]
+	mi := &file_xpf_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3107,7 +3231,7 @@ func (x *GetNATSourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATSourceResponse.ProtoReflect.Descriptor instead.
 func (*GetNATSourceResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{48}
+	return file_xpf_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetNATSourceResponse) GetRules() []*NATSourceInfo {
@@ -3129,7 +3253,7 @@ type NATSourceInfo struct {
 
 func (x *NATSourceInfo) Reset() {
 	*x = NATSourceInfo{}
-	mi := &file_xpf_proto_msgTypes[49]
+	mi := &file_xpf_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3141,7 +3265,7 @@ func (x *NATSourceInfo) String() string {
 func (*NATSourceInfo) ProtoMessage() {}
 
 func (x *NATSourceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[49]
+	mi := &file_xpf_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3154,7 +3278,7 @@ func (x *NATSourceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATSourceInfo.ProtoReflect.Descriptor instead.
 func (*NATSourceInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{49}
+	return file_xpf_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *NATSourceInfo) GetFromZone() string {
@@ -3193,7 +3317,7 @@ type GetNATDestinationRequest struct {
 
 func (x *GetNATDestinationRequest) Reset() {
 	*x = GetNATDestinationRequest{}
-	mi := &file_xpf_proto_msgTypes[50]
+	mi := &file_xpf_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3205,7 +3329,7 @@ func (x *GetNATDestinationRequest) String() string {
 func (*GetNATDestinationRequest) ProtoMessage() {}
 
 func (x *GetNATDestinationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[50]
+	mi := &file_xpf_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3218,7 +3342,7 @@ func (x *GetNATDestinationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATDestinationRequest.ProtoReflect.Descriptor instead.
 func (*GetNATDestinationRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{50}
+	return file_xpf_proto_rawDescGZIP(), []int{51}
 }
 
 type GetNATDestinationResponse struct {
@@ -3232,7 +3356,7 @@ type GetNATDestinationResponse struct {
 
 func (x *GetNATDestinationResponse) Reset() {
 	*x = GetNATDestinationResponse{}
-	mi := &file_xpf_proto_msgTypes[51]
+	mi := &file_xpf_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3244,7 +3368,7 @@ func (x *GetNATDestinationResponse) String() string {
 func (*GetNATDestinationResponse) ProtoMessage() {}
 
 func (x *GetNATDestinationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[51]
+	mi := &file_xpf_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3257,7 +3381,7 @@ func (x *GetNATDestinationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATDestinationResponse.ProtoReflect.Descriptor instead.
 func (*GetNATDestinationResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{51}
+	return file_xpf_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *GetNATDestinationResponse) GetRules() []*NATDestInfo {
@@ -3294,7 +3418,7 @@ type NATDestInfo struct {
 
 func (x *NATDestInfo) Reset() {
 	*x = NATDestInfo{}
-	mi := &file_xpf_proto_msgTypes[52]
+	mi := &file_xpf_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3306,7 +3430,7 @@ func (x *NATDestInfo) String() string {
 func (*NATDestInfo) ProtoMessage() {}
 
 func (x *NATDestInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[52]
+	mi := &file_xpf_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3319,7 +3443,7 @@ func (x *NATDestInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATDestInfo.ProtoReflect.Descriptor instead.
 func (*NATDestInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{52}
+	return file_xpf_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *NATDestInfo) GetName() string {
@@ -3365,7 +3489,7 @@ type GetScreenRequest struct {
 
 func (x *GetScreenRequest) Reset() {
 	*x = GetScreenRequest{}
-	mi := &file_xpf_proto_msgTypes[53]
+	mi := &file_xpf_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3377,7 +3501,7 @@ func (x *GetScreenRequest) String() string {
 func (*GetScreenRequest) ProtoMessage() {}
 
 func (x *GetScreenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[53]
+	mi := &file_xpf_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3390,7 +3514,7 @@ func (x *GetScreenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetScreenRequest.ProtoReflect.Descriptor instead.
 func (*GetScreenRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{53}
+	return file_xpf_proto_rawDescGZIP(), []int{54}
 }
 
 type GetScreenResponse struct {
@@ -3402,7 +3526,7 @@ type GetScreenResponse struct {
 
 func (x *GetScreenResponse) Reset() {
 	*x = GetScreenResponse{}
-	mi := &file_xpf_proto_msgTypes[54]
+	mi := &file_xpf_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3414,7 +3538,7 @@ func (x *GetScreenResponse) String() string {
 func (*GetScreenResponse) ProtoMessage() {}
 
 func (x *GetScreenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[54]
+	mi := &file_xpf_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3427,7 +3551,7 @@ func (x *GetScreenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetScreenResponse.ProtoReflect.Descriptor instead.
 func (*GetScreenResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{54}
+	return file_xpf_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetScreenResponse) GetScreens() []*ScreenInfo {
@@ -3453,7 +3577,7 @@ type ScreenInfo struct {
 
 func (x *ScreenInfo) Reset() {
 	*x = ScreenInfo{}
-	mi := &file_xpf_proto_msgTypes[55]
+	mi := &file_xpf_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3465,7 +3589,7 @@ func (x *ScreenInfo) String() string {
 func (*ScreenInfo) ProtoMessage() {}
 
 func (x *ScreenInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[55]
+	mi := &file_xpf_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3478,7 +3602,7 @@ func (x *ScreenInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScreenInfo.ProtoReflect.Descriptor instead.
 func (*ScreenInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{55}
+	return file_xpf_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ScreenInfo) GetName() string {
@@ -3521,7 +3645,7 @@ type GetEventsRequest struct {
 
 func (x *GetEventsRequest) Reset() {
 	*x = GetEventsRequest{}
-	mi := &file_xpf_proto_msgTypes[56]
+	mi := &file_xpf_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3533,7 +3657,7 @@ func (x *GetEventsRequest) String() string {
 func (*GetEventsRequest) ProtoMessage() {}
 
 func (x *GetEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[56]
+	mi := &file_xpf_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3546,7 +3670,7 @@ func (x *GetEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEventsRequest.ProtoReflect.Descriptor instead.
 func (*GetEventsRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{56}
+	return file_xpf_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *GetEventsRequest) GetLimit() int32 {
@@ -3593,7 +3717,7 @@ type GetEventsResponse struct {
 
 func (x *GetEventsResponse) Reset() {
 	*x = GetEventsResponse{}
-	mi := &file_xpf_proto_msgTypes[57]
+	mi := &file_xpf_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3605,7 +3729,7 @@ func (x *GetEventsResponse) String() string {
 func (*GetEventsResponse) ProtoMessage() {}
 
 func (x *GetEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[57]
+	mi := &file_xpf_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3618,7 +3742,7 @@ func (x *GetEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetEventsResponse.ProtoReflect.Descriptor instead.
 func (*GetEventsResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{57}
+	return file_xpf_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *GetEventsResponse) GetEvents() []*EventEntry {
@@ -3656,7 +3780,7 @@ type EventEntry struct {
 
 func (x *EventEntry) Reset() {
 	*x = EventEntry{}
-	mi := &file_xpf_proto_msgTypes[58]
+	mi := &file_xpf_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3668,7 +3792,7 @@ func (x *EventEntry) String() string {
 func (*EventEntry) ProtoMessage() {}
 
 func (x *EventEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[58]
+	mi := &file_xpf_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3681,7 +3805,7 @@ func (x *EventEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EventEntry.ProtoReflect.Descriptor instead.
 func (*EventEntry) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{58}
+	return file_xpf_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *EventEntry) GetTime() string {
@@ -3832,7 +3956,7 @@ type GetInterfacesRequest struct {
 
 func (x *GetInterfacesRequest) Reset() {
 	*x = GetInterfacesRequest{}
-	mi := &file_xpf_proto_msgTypes[59]
+	mi := &file_xpf_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3844,7 +3968,7 @@ func (x *GetInterfacesRequest) String() string {
 func (*GetInterfacesRequest) ProtoMessage() {}
 
 func (x *GetInterfacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[59]
+	mi := &file_xpf_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3857,7 +3981,7 @@ func (x *GetInterfacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInterfacesRequest.ProtoReflect.Descriptor instead.
 func (*GetInterfacesRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{59}
+	return file_xpf_proto_rawDescGZIP(), []int{60}
 }
 
 type GetInterfacesResponse struct {
@@ -3869,7 +3993,7 @@ type GetInterfacesResponse struct {
 
 func (x *GetInterfacesResponse) Reset() {
 	*x = GetInterfacesResponse{}
-	mi := &file_xpf_proto_msgTypes[60]
+	mi := &file_xpf_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3881,7 +4005,7 @@ func (x *GetInterfacesResponse) String() string {
 func (*GetInterfacesResponse) ProtoMessage() {}
 
 func (x *GetInterfacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[60]
+	mi := &file_xpf_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3894,7 +4018,7 @@ func (x *GetInterfacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInterfacesResponse.ProtoReflect.Descriptor instead.
 func (*GetInterfacesResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{60}
+	return file_xpf_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetInterfacesResponse) GetInterfaces() []*InterfaceInfo {
@@ -3919,7 +4043,7 @@ type InterfaceInfo struct {
 
 func (x *InterfaceInfo) Reset() {
 	*x = InterfaceInfo{}
-	mi := &file_xpf_proto_msgTypes[61]
+	mi := &file_xpf_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3931,7 +4055,7 @@ func (x *InterfaceInfo) String() string {
 func (*InterfaceInfo) ProtoMessage() {}
 
 func (x *InterfaceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[61]
+	mi := &file_xpf_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3944,7 +4068,7 @@ func (x *InterfaceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InterfaceInfo.ProtoReflect.Descriptor instead.
 func (*InterfaceInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{61}
+	return file_xpf_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *InterfaceInfo) GetName() string {
@@ -4006,7 +4130,7 @@ type ShowInterfacesDetailRequest struct {
 
 func (x *ShowInterfacesDetailRequest) Reset() {
 	*x = ShowInterfacesDetailRequest{}
-	mi := &file_xpf_proto_msgTypes[62]
+	mi := &file_xpf_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4018,7 +4142,7 @@ func (x *ShowInterfacesDetailRequest) String() string {
 func (*ShowInterfacesDetailRequest) ProtoMessage() {}
 
 func (x *ShowInterfacesDetailRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[62]
+	mi := &file_xpf_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4031,7 +4155,7 @@ func (x *ShowInterfacesDetailRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShowInterfacesDetailRequest.ProtoReflect.Descriptor instead.
 func (*ShowInterfacesDetailRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{62}
+	return file_xpf_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ShowInterfacesDetailRequest) GetFilter() string {
@@ -4057,7 +4181,7 @@ type ShowInterfacesDetailResponse struct {
 
 func (x *ShowInterfacesDetailResponse) Reset() {
 	*x = ShowInterfacesDetailResponse{}
-	mi := &file_xpf_proto_msgTypes[63]
+	mi := &file_xpf_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4069,7 +4193,7 @@ func (x *ShowInterfacesDetailResponse) String() string {
 func (*ShowInterfacesDetailResponse) ProtoMessage() {}
 
 func (x *ShowInterfacesDetailResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[63]
+	mi := &file_xpf_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4082,7 +4206,7 @@ func (x *ShowInterfacesDetailResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShowInterfacesDetailResponse.ProtoReflect.Descriptor instead.
 func (*ShowInterfacesDetailResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{63}
+	return file_xpf_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ShowInterfacesDetailResponse) GetOutput() string {
@@ -4100,7 +4224,7 @@ type GetDHCPLeasesRequest struct {
 
 func (x *GetDHCPLeasesRequest) Reset() {
 	*x = GetDHCPLeasesRequest{}
-	mi := &file_xpf_proto_msgTypes[64]
+	mi := &file_xpf_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4112,7 +4236,7 @@ func (x *GetDHCPLeasesRequest) String() string {
 func (*GetDHCPLeasesRequest) ProtoMessage() {}
 
 func (x *GetDHCPLeasesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[64]
+	mi := &file_xpf_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4125,7 +4249,7 @@ func (x *GetDHCPLeasesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDHCPLeasesRequest.ProtoReflect.Descriptor instead.
 func (*GetDHCPLeasesRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{64}
+	return file_xpf_proto_rawDescGZIP(), []int{65}
 }
 
 type GetDHCPLeasesResponse struct {
@@ -4137,7 +4261,7 @@ type GetDHCPLeasesResponse struct {
 
 func (x *GetDHCPLeasesResponse) Reset() {
 	*x = GetDHCPLeasesResponse{}
-	mi := &file_xpf_proto_msgTypes[65]
+	mi := &file_xpf_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4149,7 +4273,7 @@ func (x *GetDHCPLeasesResponse) String() string {
 func (*GetDHCPLeasesResponse) ProtoMessage() {}
 
 func (x *GetDHCPLeasesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[65]
+	mi := &file_xpf_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4162,7 +4286,7 @@ func (x *GetDHCPLeasesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDHCPLeasesResponse.ProtoReflect.Descriptor instead.
 func (*GetDHCPLeasesResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{65}
+	return file_xpf_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetDHCPLeasesResponse) GetLeases() []*DHCPLeaseInfo {
@@ -4188,7 +4312,7 @@ type DHCPLeaseInfo struct {
 
 func (x *DHCPLeaseInfo) Reset() {
 	*x = DHCPLeaseInfo{}
-	mi := &file_xpf_proto_msgTypes[66]
+	mi := &file_xpf_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4200,7 +4324,7 @@ func (x *DHCPLeaseInfo) String() string {
 func (*DHCPLeaseInfo) ProtoMessage() {}
 
 func (x *DHCPLeaseInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[66]
+	mi := &file_xpf_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4213,7 +4337,7 @@ func (x *DHCPLeaseInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DHCPLeaseInfo.ProtoReflect.Descriptor instead.
 func (*DHCPLeaseInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{66}
+	return file_xpf_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *DHCPLeaseInfo) GetInterface() string {
@@ -4285,7 +4409,7 @@ type DHCPDelegatedPrefix struct {
 
 func (x *DHCPDelegatedPrefix) Reset() {
 	*x = DHCPDelegatedPrefix{}
-	mi := &file_xpf_proto_msgTypes[67]
+	mi := &file_xpf_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4297,7 +4421,7 @@ func (x *DHCPDelegatedPrefix) String() string {
 func (*DHCPDelegatedPrefix) ProtoMessage() {}
 
 func (x *DHCPDelegatedPrefix) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[67]
+	mi := &file_xpf_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4310,7 +4434,7 @@ func (x *DHCPDelegatedPrefix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DHCPDelegatedPrefix.ProtoReflect.Descriptor instead.
 func (*DHCPDelegatedPrefix) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{67}
+	return file_xpf_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *DHCPDelegatedPrefix) GetInterface() string {
@@ -4356,7 +4480,7 @@ type GetDHCPClientIdentifiersRequest struct {
 
 func (x *GetDHCPClientIdentifiersRequest) Reset() {
 	*x = GetDHCPClientIdentifiersRequest{}
-	mi := &file_xpf_proto_msgTypes[68]
+	mi := &file_xpf_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4368,7 +4492,7 @@ func (x *GetDHCPClientIdentifiersRequest) String() string {
 func (*GetDHCPClientIdentifiersRequest) ProtoMessage() {}
 
 func (x *GetDHCPClientIdentifiersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[68]
+	mi := &file_xpf_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4381,7 +4505,7 @@ func (x *GetDHCPClientIdentifiersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDHCPClientIdentifiersRequest.ProtoReflect.Descriptor instead.
 func (*GetDHCPClientIdentifiersRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{68}
+	return file_xpf_proto_rawDescGZIP(), []int{69}
 }
 
 type GetDHCPClientIdentifiersResponse struct {
@@ -4393,7 +4517,7 @@ type GetDHCPClientIdentifiersResponse struct {
 
 func (x *GetDHCPClientIdentifiersResponse) Reset() {
 	*x = GetDHCPClientIdentifiersResponse{}
-	mi := &file_xpf_proto_msgTypes[69]
+	mi := &file_xpf_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4405,7 +4529,7 @@ func (x *GetDHCPClientIdentifiersResponse) String() string {
 func (*GetDHCPClientIdentifiersResponse) ProtoMessage() {}
 
 func (x *GetDHCPClientIdentifiersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[69]
+	mi := &file_xpf_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4418,7 +4542,7 @@ func (x *GetDHCPClientIdentifiersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDHCPClientIdentifiersResponse.ProtoReflect.Descriptor instead.
 func (*GetDHCPClientIdentifiersResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{69}
+	return file_xpf_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *GetDHCPClientIdentifiersResponse) GetIdentifiers() []*DHCPClientIdentifierInfo {
@@ -4440,7 +4564,7 @@ type DHCPClientIdentifierInfo struct {
 
 func (x *DHCPClientIdentifierInfo) Reset() {
 	*x = DHCPClientIdentifierInfo{}
-	mi := &file_xpf_proto_msgTypes[70]
+	mi := &file_xpf_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4452,7 +4576,7 @@ func (x *DHCPClientIdentifierInfo) String() string {
 func (*DHCPClientIdentifierInfo) ProtoMessage() {}
 
 func (x *DHCPClientIdentifierInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[70]
+	mi := &file_xpf_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4465,7 +4589,7 @@ func (x *DHCPClientIdentifierInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DHCPClientIdentifierInfo.ProtoReflect.Descriptor instead.
 func (*DHCPClientIdentifierInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{70}
+	return file_xpf_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *DHCPClientIdentifierInfo) GetInterface() string {
@@ -4505,7 +4629,7 @@ type ClearDHCPClientIdentifierRequest struct {
 
 func (x *ClearDHCPClientIdentifierRequest) Reset() {
 	*x = ClearDHCPClientIdentifierRequest{}
-	mi := &file_xpf_proto_msgTypes[71]
+	mi := &file_xpf_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4517,7 +4641,7 @@ func (x *ClearDHCPClientIdentifierRequest) String() string {
 func (*ClearDHCPClientIdentifierRequest) ProtoMessage() {}
 
 func (x *ClearDHCPClientIdentifierRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[71]
+	mi := &file_xpf_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4530,7 +4654,7 @@ func (x *ClearDHCPClientIdentifierRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearDHCPClientIdentifierRequest.ProtoReflect.Descriptor instead.
 func (*ClearDHCPClientIdentifierRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{71}
+	return file_xpf_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *ClearDHCPClientIdentifierRequest) GetInterface() string {
@@ -4549,7 +4673,7 @@ type ClearDHCPClientIdentifierResponse struct {
 
 func (x *ClearDHCPClientIdentifierResponse) Reset() {
 	*x = ClearDHCPClientIdentifierResponse{}
-	mi := &file_xpf_proto_msgTypes[72]
+	mi := &file_xpf_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4561,7 +4685,7 @@ func (x *ClearDHCPClientIdentifierResponse) String() string {
 func (*ClearDHCPClientIdentifierResponse) ProtoMessage() {}
 
 func (x *ClearDHCPClientIdentifierResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[72]
+	mi := &file_xpf_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4574,7 +4698,7 @@ func (x *ClearDHCPClientIdentifierResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ClearDHCPClientIdentifierResponse.ProtoReflect.Descriptor instead.
 func (*ClearDHCPClientIdentifierResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{72}
+	return file_xpf_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *ClearDHCPClientIdentifierResponse) GetMessage() string {
@@ -4592,7 +4716,7 @@ type GetRoutesRequest struct {
 
 func (x *GetRoutesRequest) Reset() {
 	*x = GetRoutesRequest{}
-	mi := &file_xpf_proto_msgTypes[73]
+	mi := &file_xpf_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4604,7 +4728,7 @@ func (x *GetRoutesRequest) String() string {
 func (*GetRoutesRequest) ProtoMessage() {}
 
 func (x *GetRoutesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[73]
+	mi := &file_xpf_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4617,7 +4741,7 @@ func (x *GetRoutesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoutesRequest.ProtoReflect.Descriptor instead.
 func (*GetRoutesRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{73}
+	return file_xpf_proto_rawDescGZIP(), []int{74}
 }
 
 type GetRoutesResponse struct {
@@ -4629,7 +4753,7 @@ type GetRoutesResponse struct {
 
 func (x *GetRoutesResponse) Reset() {
 	*x = GetRoutesResponse{}
-	mi := &file_xpf_proto_msgTypes[74]
+	mi := &file_xpf_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4641,7 +4765,7 @@ func (x *GetRoutesResponse) String() string {
 func (*GetRoutesResponse) ProtoMessage() {}
 
 func (x *GetRoutesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[74]
+	mi := &file_xpf_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4654,7 +4778,7 @@ func (x *GetRoutesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRoutesResponse.ProtoReflect.Descriptor instead.
 func (*GetRoutesResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{74}
+	return file_xpf_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetRoutesResponse) GetRoutes() []*RouteInfo {
@@ -4677,7 +4801,7 @@ type RouteInfo struct {
 
 func (x *RouteInfo) Reset() {
 	*x = RouteInfo{}
-	mi := &file_xpf_proto_msgTypes[75]
+	mi := &file_xpf_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4689,7 +4813,7 @@ func (x *RouteInfo) String() string {
 func (*RouteInfo) ProtoMessage() {}
 
 func (x *RouteInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[75]
+	mi := &file_xpf_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4702,7 +4826,7 @@ func (x *RouteInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RouteInfo.ProtoReflect.Descriptor instead.
 func (*RouteInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{75}
+	return file_xpf_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *RouteInfo) GetDestination() string {
@@ -4749,7 +4873,7 @@ type GetOSPFStatusRequest struct {
 
 func (x *GetOSPFStatusRequest) Reset() {
 	*x = GetOSPFStatusRequest{}
-	mi := &file_xpf_proto_msgTypes[76]
+	mi := &file_xpf_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4761,7 +4885,7 @@ func (x *GetOSPFStatusRequest) String() string {
 func (*GetOSPFStatusRequest) ProtoMessage() {}
 
 func (x *GetOSPFStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[76]
+	mi := &file_xpf_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4774,7 +4898,7 @@ func (x *GetOSPFStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOSPFStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetOSPFStatusRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{76}
+	return file_xpf_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *GetOSPFStatusRequest) GetType() string {
@@ -4793,7 +4917,7 @@ type GetOSPFStatusResponse struct {
 
 func (x *GetOSPFStatusResponse) Reset() {
 	*x = GetOSPFStatusResponse{}
-	mi := &file_xpf_proto_msgTypes[77]
+	mi := &file_xpf_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4805,7 +4929,7 @@ func (x *GetOSPFStatusResponse) String() string {
 func (*GetOSPFStatusResponse) ProtoMessage() {}
 
 func (x *GetOSPFStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[77]
+	mi := &file_xpf_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4818,7 +4942,7 @@ func (x *GetOSPFStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetOSPFStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetOSPFStatusResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{77}
+	return file_xpf_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *GetOSPFStatusResponse) GetOutput() string {
@@ -4837,7 +4961,7 @@ type GetBGPStatusRequest struct {
 
 func (x *GetBGPStatusRequest) Reset() {
 	*x = GetBGPStatusRequest{}
-	mi := &file_xpf_proto_msgTypes[78]
+	mi := &file_xpf_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4849,7 +4973,7 @@ func (x *GetBGPStatusRequest) String() string {
 func (*GetBGPStatusRequest) ProtoMessage() {}
 
 func (x *GetBGPStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[78]
+	mi := &file_xpf_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4862,7 +4986,7 @@ func (x *GetBGPStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBGPStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetBGPStatusRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{78}
+	return file_xpf_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *GetBGPStatusRequest) GetType() string {
@@ -4881,7 +5005,7 @@ type GetBGPStatusResponse struct {
 
 func (x *GetBGPStatusResponse) Reset() {
 	*x = GetBGPStatusResponse{}
-	mi := &file_xpf_proto_msgTypes[79]
+	mi := &file_xpf_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4893,7 +5017,7 @@ func (x *GetBGPStatusResponse) String() string {
 func (*GetBGPStatusResponse) ProtoMessage() {}
 
 func (x *GetBGPStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[79]
+	mi := &file_xpf_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4906,7 +5030,7 @@ func (x *GetBGPStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetBGPStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetBGPStatusResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{79}
+	return file_xpf_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *GetBGPStatusResponse) GetOutput() string {
@@ -4924,7 +5048,7 @@ type GetRIPStatusRequest struct {
 
 func (x *GetRIPStatusRequest) Reset() {
 	*x = GetRIPStatusRequest{}
-	mi := &file_xpf_proto_msgTypes[80]
+	mi := &file_xpf_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4936,7 +5060,7 @@ func (x *GetRIPStatusRequest) String() string {
 func (*GetRIPStatusRequest) ProtoMessage() {}
 
 func (x *GetRIPStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[80]
+	mi := &file_xpf_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4949,7 +5073,7 @@ func (x *GetRIPStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRIPStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetRIPStatusRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{80}
+	return file_xpf_proto_rawDescGZIP(), []int{81}
 }
 
 type GetRIPStatusResponse struct {
@@ -4961,7 +5085,7 @@ type GetRIPStatusResponse struct {
 
 func (x *GetRIPStatusResponse) Reset() {
 	*x = GetRIPStatusResponse{}
-	mi := &file_xpf_proto_msgTypes[81]
+	mi := &file_xpf_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4973,7 +5097,7 @@ func (x *GetRIPStatusResponse) String() string {
 func (*GetRIPStatusResponse) ProtoMessage() {}
 
 func (x *GetRIPStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[81]
+	mi := &file_xpf_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4986,7 +5110,7 @@ func (x *GetRIPStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRIPStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetRIPStatusResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{81}
+	return file_xpf_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *GetRIPStatusResponse) GetOutput() string {
@@ -5005,7 +5129,7 @@ type GetISISStatusRequest struct {
 
 func (x *GetISISStatusRequest) Reset() {
 	*x = GetISISStatusRequest{}
-	mi := &file_xpf_proto_msgTypes[82]
+	mi := &file_xpf_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5017,7 +5141,7 @@ func (x *GetISISStatusRequest) String() string {
 func (*GetISISStatusRequest) ProtoMessage() {}
 
 func (x *GetISISStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[82]
+	mi := &file_xpf_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5030,7 +5154,7 @@ func (x *GetISISStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetISISStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetISISStatusRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{82}
+	return file_xpf_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *GetISISStatusRequest) GetType() string {
@@ -5049,7 +5173,7 @@ type GetISISStatusResponse struct {
 
 func (x *GetISISStatusResponse) Reset() {
 	*x = GetISISStatusResponse{}
-	mi := &file_xpf_proto_msgTypes[83]
+	mi := &file_xpf_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5061,7 +5185,7 @@ func (x *GetISISStatusResponse) String() string {
 func (*GetISISStatusResponse) ProtoMessage() {}
 
 func (x *GetISISStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[83]
+	mi := &file_xpf_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5074,7 +5198,7 @@ func (x *GetISISStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetISISStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetISISStatusResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{83}
+	return file_xpf_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *GetISISStatusResponse) GetOutput() string {
@@ -5092,7 +5216,7 @@ type GetIPsecSARequest struct {
 
 func (x *GetIPsecSARequest) Reset() {
 	*x = GetIPsecSARequest{}
-	mi := &file_xpf_proto_msgTypes[84]
+	mi := &file_xpf_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5104,7 +5228,7 @@ func (x *GetIPsecSARequest) String() string {
 func (*GetIPsecSARequest) ProtoMessage() {}
 
 func (x *GetIPsecSARequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[84]
+	mi := &file_xpf_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5117,7 +5241,7 @@ func (x *GetIPsecSARequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIPsecSARequest.ProtoReflect.Descriptor instead.
 func (*GetIPsecSARequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{84}
+	return file_xpf_proto_rawDescGZIP(), []int{85}
 }
 
 type GetIPsecSAResponse struct {
@@ -5129,7 +5253,7 @@ type GetIPsecSAResponse struct {
 
 func (x *GetIPsecSAResponse) Reset() {
 	*x = GetIPsecSAResponse{}
-	mi := &file_xpf_proto_msgTypes[85]
+	mi := &file_xpf_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5141,7 +5265,7 @@ func (x *GetIPsecSAResponse) String() string {
 func (*GetIPsecSAResponse) ProtoMessage() {}
 
 func (x *GetIPsecSAResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[85]
+	mi := &file_xpf_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5154,7 +5278,7 @@ func (x *GetIPsecSAResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetIPsecSAResponse.ProtoReflect.Descriptor instead.
 func (*GetIPsecSAResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{85}
+	return file_xpf_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *GetIPsecSAResponse) GetOutput() string {
@@ -5177,7 +5301,7 @@ type PingRequest struct {
 
 func (x *PingRequest) Reset() {
 	*x = PingRequest{}
-	mi := &file_xpf_proto_msgTypes[86]
+	mi := &file_xpf_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5189,7 +5313,7 @@ func (x *PingRequest) String() string {
 func (*PingRequest) ProtoMessage() {}
 
 func (x *PingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[86]
+	mi := &file_xpf_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5202,7 +5326,7 @@ func (x *PingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingRequest.ProtoReflect.Descriptor instead.
 func (*PingRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{86}
+	return file_xpf_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *PingRequest) GetTarget() string {
@@ -5249,7 +5373,7 @@ type PingResponse struct {
 
 func (x *PingResponse) Reset() {
 	*x = PingResponse{}
-	mi := &file_xpf_proto_msgTypes[87]
+	mi := &file_xpf_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5261,7 +5385,7 @@ func (x *PingResponse) String() string {
 func (*PingResponse) ProtoMessage() {}
 
 func (x *PingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[87]
+	mi := &file_xpf_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5274,7 +5398,7 @@ func (x *PingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PingResponse.ProtoReflect.Descriptor instead.
 func (*PingResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{87}
+	return file_xpf_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *PingResponse) GetOutput() string {
@@ -5295,7 +5419,7 @@ type TracerouteRequest struct {
 
 func (x *TracerouteRequest) Reset() {
 	*x = TracerouteRequest{}
-	mi := &file_xpf_proto_msgTypes[88]
+	mi := &file_xpf_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5307,7 +5431,7 @@ func (x *TracerouteRequest) String() string {
 func (*TracerouteRequest) ProtoMessage() {}
 
 func (x *TracerouteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[88]
+	mi := &file_xpf_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5320,7 +5444,7 @@ func (x *TracerouteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerouteRequest.ProtoReflect.Descriptor instead.
 func (*TracerouteRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{88}
+	return file_xpf_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *TracerouteRequest) GetTarget() string {
@@ -5353,7 +5477,7 @@ type TracerouteResponse struct {
 
 func (x *TracerouteResponse) Reset() {
 	*x = TracerouteResponse{}
-	mi := &file_xpf_proto_msgTypes[89]
+	mi := &file_xpf_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5365,7 +5489,7 @@ func (x *TracerouteResponse) String() string {
 func (*TracerouteResponse) ProtoMessage() {}
 
 func (x *TracerouteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[89]
+	mi := &file_xpf_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5378,7 +5502,7 @@ func (x *TracerouteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracerouteResponse.ProtoReflect.Descriptor instead.
 func (*TracerouteResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{89}
+	return file_xpf_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *TracerouteResponse) GetOutput() string {
@@ -5406,7 +5530,7 @@ type ClearSessionsRequest struct {
 
 func (x *ClearSessionsRequest) Reset() {
 	*x = ClearSessionsRequest{}
-	mi := &file_xpf_proto_msgTypes[90]
+	mi := &file_xpf_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5418,7 +5542,7 @@ func (x *ClearSessionsRequest) String() string {
 func (*ClearSessionsRequest) ProtoMessage() {}
 
 func (x *ClearSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[90]
+	mi := &file_xpf_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5431,7 +5555,7 @@ func (x *ClearSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ClearSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{90}
+	return file_xpf_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *ClearSessionsRequest) GetSourcePrefix() string {
@@ -5524,7 +5648,7 @@ type ClearSessionsResponse struct {
 
 func (x *ClearSessionsResponse) Reset() {
 	*x = ClearSessionsResponse{}
-	mi := &file_xpf_proto_msgTypes[91]
+	mi := &file_xpf_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5536,7 +5660,7 @@ func (x *ClearSessionsResponse) String() string {
 func (*ClearSessionsResponse) ProtoMessage() {}
 
 func (x *ClearSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[91]
+	mi := &file_xpf_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5549,7 +5673,7 @@ func (x *ClearSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ClearSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{91}
+	return file_xpf_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *ClearSessionsResponse) GetIpv4Cleared() int32 {
@@ -5588,7 +5712,7 @@ type ClearCountersRequest struct {
 
 func (x *ClearCountersRequest) Reset() {
 	*x = ClearCountersRequest{}
-	mi := &file_xpf_proto_msgTypes[92]
+	mi := &file_xpf_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5600,7 +5724,7 @@ func (x *ClearCountersRequest) String() string {
 func (*ClearCountersRequest) ProtoMessage() {}
 
 func (x *ClearCountersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[92]
+	mi := &file_xpf_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5613,7 +5737,7 @@ func (x *ClearCountersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearCountersRequest.ProtoReflect.Descriptor instead.
 func (*ClearCountersRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{92}
+	return file_xpf_proto_rawDescGZIP(), []int{93}
 }
 
 type ClearCountersResponse struct {
@@ -5624,7 +5748,7 @@ type ClearCountersResponse struct {
 
 func (x *ClearCountersResponse) Reset() {
 	*x = ClearCountersResponse{}
-	mi := &file_xpf_proto_msgTypes[93]
+	mi := &file_xpf_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5636,7 +5760,7 @@ func (x *ClearCountersResponse) String() string {
 func (*ClearCountersResponse) ProtoMessage() {}
 
 func (x *ClearCountersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[93]
+	mi := &file_xpf_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5649,7 +5773,7 @@ func (x *ClearCountersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClearCountersResponse.ProtoReflect.Descriptor instead.
 func (*ClearCountersResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{93}
+	return file_xpf_proto_rawDescGZIP(), []int{94}
 }
 
 type GetNATPoolStatsRequest struct {
@@ -5660,7 +5784,7 @@ type GetNATPoolStatsRequest struct {
 
 func (x *GetNATPoolStatsRequest) Reset() {
 	*x = GetNATPoolStatsRequest{}
-	mi := &file_xpf_proto_msgTypes[94]
+	mi := &file_xpf_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5672,7 +5796,7 @@ func (x *GetNATPoolStatsRequest) String() string {
 func (*GetNATPoolStatsRequest) ProtoMessage() {}
 
 func (x *GetNATPoolStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[94]
+	mi := &file_xpf_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5685,7 +5809,7 @@ func (x *GetNATPoolStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATPoolStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetNATPoolStatsRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{94}
+	return file_xpf_proto_rawDescGZIP(), []int{95}
 }
 
 type GetNATPoolStatsResponse struct {
@@ -5699,7 +5823,7 @@ type GetNATPoolStatsResponse struct {
 
 func (x *GetNATPoolStatsResponse) Reset() {
 	*x = GetNATPoolStatsResponse{}
-	mi := &file_xpf_proto_msgTypes[95]
+	mi := &file_xpf_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5711,7 +5835,7 @@ func (x *GetNATPoolStatsResponse) String() string {
 func (*GetNATPoolStatsResponse) ProtoMessage() {}
 
 func (x *GetNATPoolStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[95]
+	mi := &file_xpf_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5724,7 +5848,7 @@ func (x *GetNATPoolStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATPoolStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetNATPoolStatsResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{95}
+	return file_xpf_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *GetNATPoolStatsResponse) GetPools() []*NATPoolStats {
@@ -5763,7 +5887,7 @@ type NATPoolStats struct {
 
 func (x *NATPoolStats) Reset() {
 	*x = NATPoolStats{}
-	mi := &file_xpf_proto_msgTypes[96]
+	mi := &file_xpf_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5775,7 +5899,7 @@ func (x *NATPoolStats) String() string {
 func (*NATPoolStats) ProtoMessage() {}
 
 func (x *NATPoolStats) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[96]
+	mi := &file_xpf_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5788,7 +5912,7 @@ func (x *NATPoolStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATPoolStats.ProtoReflect.Descriptor instead.
 func (*NATPoolStats) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{96}
+	return file_xpf_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *NATPoolStats) GetName() string {
@@ -5851,7 +5975,7 @@ type NATRuleSetSessions struct {
 
 func (x *NATRuleSetSessions) Reset() {
 	*x = NATRuleSetSessions{}
-	mi := &file_xpf_proto_msgTypes[97]
+	mi := &file_xpf_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5863,7 +5987,7 @@ func (x *NATRuleSetSessions) String() string {
 func (*NATRuleSetSessions) ProtoMessage() {}
 
 func (x *NATRuleSetSessions) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[97]
+	mi := &file_xpf_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5876,7 +6000,7 @@ func (x *NATRuleSetSessions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATRuleSetSessions.ProtoReflect.Descriptor instead.
 func (*NATRuleSetSessions) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{97}
+	return file_xpf_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *NATRuleSetSessions) GetFromZone() string {
@@ -5908,7 +6032,7 @@ type GetVRRPStatusRequest struct {
 
 func (x *GetVRRPStatusRequest) Reset() {
 	*x = GetVRRPStatusRequest{}
-	mi := &file_xpf_proto_msgTypes[98]
+	mi := &file_xpf_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5920,7 +6044,7 @@ func (x *GetVRRPStatusRequest) String() string {
 func (*GetVRRPStatusRequest) ProtoMessage() {}
 
 func (x *GetVRRPStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[98]
+	mi := &file_xpf_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5933,7 +6057,7 @@ func (x *GetVRRPStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVRRPStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetVRRPStatusRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{98}
+	return file_xpf_proto_rawDescGZIP(), []int{99}
 }
 
 type GetVRRPStatusResponse struct {
@@ -5946,7 +6070,7 @@ type GetVRRPStatusResponse struct {
 
 func (x *GetVRRPStatusResponse) Reset() {
 	*x = GetVRRPStatusResponse{}
-	mi := &file_xpf_proto_msgTypes[99]
+	mi := &file_xpf_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5958,7 +6082,7 @@ func (x *GetVRRPStatusResponse) String() string {
 func (*GetVRRPStatusResponse) ProtoMessage() {}
 
 func (x *GetVRRPStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[99]
+	mi := &file_xpf_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5971,7 +6095,7 @@ func (x *GetVRRPStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVRRPStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetVRRPStatusResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{99}
+	return file_xpf_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *GetVRRPStatusResponse) GetInstances() []*VRRPInstanceInfo {
@@ -6002,7 +6126,7 @@ type VRRPInstanceInfo struct {
 
 func (x *VRRPInstanceInfo) Reset() {
 	*x = VRRPInstanceInfo{}
-	mi := &file_xpf_proto_msgTypes[100]
+	mi := &file_xpf_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6014,7 +6138,7 @@ func (x *VRRPInstanceInfo) String() string {
 func (*VRRPInstanceInfo) ProtoMessage() {}
 
 func (x *VRRPInstanceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[100]
+	mi := &file_xpf_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6027,7 +6151,7 @@ func (x *VRRPInstanceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VRRPInstanceInfo.ProtoReflect.Descriptor instead.
 func (*VRRPInstanceInfo) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{100}
+	return file_xpf_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *VRRPInstanceInfo) GetInterface() string {
@@ -6096,7 +6220,7 @@ type MatchPoliciesRequest struct {
 
 func (x *MatchPoliciesRequest) Reset() {
 	*x = MatchPoliciesRequest{}
-	mi := &file_xpf_proto_msgTypes[101]
+	mi := &file_xpf_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6108,7 +6232,7 @@ func (x *MatchPoliciesRequest) String() string {
 func (*MatchPoliciesRequest) ProtoMessage() {}
 
 func (x *MatchPoliciesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[101]
+	mi := &file_xpf_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6121,7 +6245,7 @@ func (x *MatchPoliciesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MatchPoliciesRequest.ProtoReflect.Descriptor instead.
 func (*MatchPoliciesRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{101}
+	return file_xpf_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *MatchPoliciesRequest) GetFromZone() string {
@@ -6235,7 +6359,7 @@ type MatchPoliciesResponse struct {
 
 func (x *MatchPoliciesResponse) Reset() {
 	*x = MatchPoliciesResponse{}
-	mi := &file_xpf_proto_msgTypes[102]
+	mi := &file_xpf_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6247,7 +6371,7 @@ func (x *MatchPoliciesResponse) String() string {
 func (*MatchPoliciesResponse) ProtoMessage() {}
 
 func (x *MatchPoliciesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[102]
+	mi := &file_xpf_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6260,7 +6384,7 @@ func (x *MatchPoliciesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MatchPoliciesResponse.ProtoReflect.Descriptor instead.
 func (*MatchPoliciesResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{102}
+	return file_xpf_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *MatchPoliciesResponse) GetPolicyName() string {
@@ -6357,7 +6481,7 @@ type GetNATRuleStatsRequest struct {
 
 func (x *GetNATRuleStatsRequest) Reset() {
 	*x = GetNATRuleStatsRequest{}
-	mi := &file_xpf_proto_msgTypes[103]
+	mi := &file_xpf_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6369,7 +6493,7 @@ func (x *GetNATRuleStatsRequest) String() string {
 func (*GetNATRuleStatsRequest) ProtoMessage() {}
 
 func (x *GetNATRuleStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[103]
+	mi := &file_xpf_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6382,7 +6506,7 @@ func (x *GetNATRuleStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATRuleStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetNATRuleStatsRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{103}
+	return file_xpf_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *GetNATRuleStatsRequest) GetRuleSet() string {
@@ -6408,7 +6532,7 @@ type GetNATRuleStatsResponse struct {
 
 func (x *GetNATRuleStatsResponse) Reset() {
 	*x = GetNATRuleStatsResponse{}
-	mi := &file_xpf_proto_msgTypes[104]
+	mi := &file_xpf_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6420,7 +6544,7 @@ func (x *GetNATRuleStatsResponse) String() string {
 func (*GetNATRuleStatsResponse) ProtoMessage() {}
 
 func (x *GetNATRuleStatsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[104]
+	mi := &file_xpf_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6433,7 +6557,7 @@ func (x *GetNATRuleStatsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetNATRuleStatsResponse.ProtoReflect.Descriptor instead.
 func (*GetNATRuleStatsResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{104}
+	return file_xpf_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *GetNATRuleStatsResponse) GetRules() []*NATRuleStats {
@@ -6460,7 +6584,7 @@ type NATRuleStats struct {
 
 func (x *NATRuleStats) Reset() {
 	*x = NATRuleStats{}
-	mi := &file_xpf_proto_msgTypes[105]
+	mi := &file_xpf_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6472,7 +6596,7 @@ func (x *NATRuleStats) String() string {
 func (*NATRuleStats) ProtoMessage() {}
 
 func (x *NATRuleStats) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[105]
+	mi := &file_xpf_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6485,7 +6609,7 @@ func (x *NATRuleStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NATRuleStats.ProtoReflect.Descriptor instead.
 func (*NATRuleStats) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{105}
+	return file_xpf_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *NATRuleStats) GetRuleSet() string {
@@ -6562,7 +6686,7 @@ type CompleteRequest struct {
 
 func (x *CompleteRequest) Reset() {
 	*x = CompleteRequest{}
-	mi := &file_xpf_proto_msgTypes[106]
+	mi := &file_xpf_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6574,7 +6698,7 @@ func (x *CompleteRequest) String() string {
 func (*CompleteRequest) ProtoMessage() {}
 
 func (x *CompleteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[106]
+	mi := &file_xpf_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6587,7 +6711,7 @@ func (x *CompleteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompleteRequest.ProtoReflect.Descriptor instead.
 func (*CompleteRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{106}
+	return file_xpf_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *CompleteRequest) GetLine() string {
@@ -6621,7 +6745,7 @@ type CompleteResponse struct {
 
 func (x *CompleteResponse) Reset() {
 	*x = CompleteResponse{}
-	mi := &file_xpf_proto_msgTypes[107]
+	mi := &file_xpf_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6633,7 +6757,7 @@ func (x *CompleteResponse) String() string {
 func (*CompleteResponse) ProtoMessage() {}
 
 func (x *CompleteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[107]
+	mi := &file_xpf_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6646,7 +6770,7 @@ func (x *CompleteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CompleteResponse.ProtoReflect.Descriptor instead.
 func (*CompleteResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{107}
+	return file_xpf_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *CompleteResponse) GetCandidates() []string {
@@ -6675,7 +6799,7 @@ type ShowTextRequest struct {
 
 func (x *ShowTextRequest) Reset() {
 	*x = ShowTextRequest{}
-	mi := &file_xpf_proto_msgTypes[108]
+	mi := &file_xpf_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6687,7 +6811,7 @@ func (x *ShowTextRequest) String() string {
 func (*ShowTextRequest) ProtoMessage() {}
 
 func (x *ShowTextRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[108]
+	mi := &file_xpf_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6700,7 +6824,7 @@ func (x *ShowTextRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShowTextRequest.ProtoReflect.Descriptor instead.
 func (*ShowTextRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{108}
+	return file_xpf_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ShowTextRequest) GetTopic() string {
@@ -6726,7 +6850,7 @@ type ShowTextResponse struct {
 
 func (x *ShowTextResponse) Reset() {
 	*x = ShowTextResponse{}
-	mi := &file_xpf_proto_msgTypes[109]
+	mi := &file_xpf_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6738,7 +6862,7 @@ func (x *ShowTextResponse) String() string {
 func (*ShowTextResponse) ProtoMessage() {}
 
 func (x *ShowTextResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[109]
+	mi := &file_xpf_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6751,7 +6875,7 @@ func (x *ShowTextResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShowTextResponse.ProtoReflect.Descriptor instead.
 func (*ShowTextResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{109}
+	return file_xpf_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ShowTextResponse) GetOutput() string {
@@ -6770,7 +6894,7 @@ type GetSystemInfoRequest struct {
 
 func (x *GetSystemInfoRequest) Reset() {
 	*x = GetSystemInfoRequest{}
-	mi := &file_xpf_proto_msgTypes[110]
+	mi := &file_xpf_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6782,7 +6906,7 @@ func (x *GetSystemInfoRequest) String() string {
 func (*GetSystemInfoRequest) ProtoMessage() {}
 
 func (x *GetSystemInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[110]
+	mi := &file_xpf_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6795,7 +6919,7 @@ func (x *GetSystemInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetSystemInfoRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{110}
+	return file_xpf_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *GetSystemInfoRequest) GetType() string {
@@ -6814,7 +6938,7 @@ type GetSystemInfoResponse struct {
 
 func (x *GetSystemInfoResponse) Reset() {
 	*x = GetSystemInfoResponse{}
-	mi := &file_xpf_proto_msgTypes[111]
+	mi := &file_xpf_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6826,7 +6950,7 @@ func (x *GetSystemInfoResponse) String() string {
 func (*GetSystemInfoResponse) ProtoMessage() {}
 
 func (x *GetSystemInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[111]
+	mi := &file_xpf_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6839,7 +6963,7 @@ func (x *GetSystemInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSystemInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetSystemInfoResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{111}
+	return file_xpf_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *GetSystemInfoResponse) GetOutput() string {
@@ -6859,7 +6983,7 @@ type SystemActionRequest struct {
 
 func (x *SystemActionRequest) Reset() {
 	*x = SystemActionRequest{}
-	mi := &file_xpf_proto_msgTypes[112]
+	mi := &file_xpf_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6871,7 +6995,7 @@ func (x *SystemActionRequest) String() string {
 func (*SystemActionRequest) ProtoMessage() {}
 
 func (x *SystemActionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[112]
+	mi := &file_xpf_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6884,7 +7008,7 @@ func (x *SystemActionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemActionRequest.ProtoReflect.Descriptor instead.
 func (*SystemActionRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{112}
+	return file_xpf_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *SystemActionRequest) GetAction() string {
@@ -6910,7 +7034,7 @@ type SystemActionResponse struct {
 
 func (x *SystemActionResponse) Reset() {
 	*x = SystemActionResponse{}
-	mi := &file_xpf_proto_msgTypes[113]
+	mi := &file_xpf_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6922,7 +7046,7 @@ func (x *SystemActionResponse) String() string {
 func (*SystemActionResponse) ProtoMessage() {}
 
 func (x *SystemActionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[113]
+	mi := &file_xpf_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6935,7 +7059,7 @@ func (x *SystemActionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemActionResponse.ProtoReflect.Descriptor instead.
 func (*SystemActionResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{113}
+	return file_xpf_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *SystemActionResponse) GetMessage() string {
@@ -6962,7 +7086,7 @@ type MonitorPacketDropRequest struct {
 
 func (x *MonitorPacketDropRequest) Reset() {
 	*x = MonitorPacketDropRequest{}
-	mi := &file_xpf_proto_msgTypes[114]
+	mi := &file_xpf_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6974,7 +7098,7 @@ func (x *MonitorPacketDropRequest) String() string {
 func (*MonitorPacketDropRequest) ProtoMessage() {}
 
 func (x *MonitorPacketDropRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[114]
+	mi := &file_xpf_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6987,7 +7111,7 @@ func (x *MonitorPacketDropRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MonitorPacketDropRequest.ProtoReflect.Descriptor instead.
 func (*MonitorPacketDropRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{114}
+	return file_xpf_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *MonitorPacketDropRequest) GetSourcePrefix() string {
@@ -7062,7 +7186,7 @@ type MonitorPacketDropResponse struct {
 
 func (x *MonitorPacketDropResponse) Reset() {
 	*x = MonitorPacketDropResponse{}
-	mi := &file_xpf_proto_msgTypes[115]
+	mi := &file_xpf_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7074,7 +7198,7 @@ func (x *MonitorPacketDropResponse) String() string {
 func (*MonitorPacketDropResponse) ProtoMessage() {}
 
 func (x *MonitorPacketDropResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[115]
+	mi := &file_xpf_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7087,7 +7211,7 @@ func (x *MonitorPacketDropResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MonitorPacketDropResponse.ProtoReflect.Descriptor instead.
 func (*MonitorPacketDropResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{115}
+	return file_xpf_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *MonitorPacketDropResponse) GetLine() string {
@@ -7107,7 +7231,7 @@ type MonitorInterfaceRequest struct {
 
 func (x *MonitorInterfaceRequest) Reset() {
 	*x = MonitorInterfaceRequest{}
-	mi := &file_xpf_proto_msgTypes[116]
+	mi := &file_xpf_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7119,7 +7243,7 @@ func (x *MonitorInterfaceRequest) String() string {
 func (*MonitorInterfaceRequest) ProtoMessage() {}
 
 func (x *MonitorInterfaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[116]
+	mi := &file_xpf_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7132,7 +7256,7 @@ func (x *MonitorInterfaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MonitorInterfaceRequest.ProtoReflect.Descriptor instead.
 func (*MonitorInterfaceRequest) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{116}
+	return file_xpf_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *MonitorInterfaceRequest) GetInterfaceName() string {
@@ -7158,7 +7282,7 @@ type MonitorInterfaceResponse struct {
 
 func (x *MonitorInterfaceResponse) Reset() {
 	*x = MonitorInterfaceResponse{}
-	mi := &file_xpf_proto_msgTypes[117]
+	mi := &file_xpf_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7170,7 +7294,7 @@ func (x *MonitorInterfaceResponse) String() string {
 func (*MonitorInterfaceResponse) ProtoMessage() {}
 
 func (x *MonitorInterfaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_xpf_proto_msgTypes[117]
+	mi := &file_xpf_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7183,7 +7307,7 @@ func (x *MonitorInterfaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MonitorInterfaceResponse.ProtoReflect.Descriptor instead.
 func (*MonitorInterfaceResponse) Descriptor() ([]byte, []int) {
-	return file_xpf_proto_rawDescGZIP(), []int{117}
+	return file_xpf_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *MonitorInterfaceResponse) GetFrame() string {
@@ -7291,7 +7415,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"\x11\n" +
 	"\x0fGetZonesRequest\":\n" +
 	"\x10GetZonesResponse\x12&\n" +
-	"\x05zones\x18\x01 \x03(\v2\x10.xpf.v1.ZoneInfoR\x05zones\"\xfc\x02\n" +
+	"\x05zones\x18\x01 \x03(\v2\x10.xpf.v1.ZoneInfoR\x05zones\"\xff\x04\n" +
 	"\bZoneInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\rR\x02id\x12%\n" +
@@ -7306,7 +7430,18 @@ const file_xpf_proto_rawDesc = "" +
 	"\fegress_bytes\x18\t \x01(\x04R\vegressBytes\x12\x17\n" +
 	"\atcp_rst\x18\n" +
 	" \x01(\bR\x06tcpRst\x12 \n" +
-	"\vdescription\x18\v \x01(\tR\vdescription\"\x14\n" +
+	"\vdescription\x18\v \x01(\tR\vdescription\x126\n" +
+	"\x17host_inbound_configured\x18\f \x01(\bR\x15hostInboundConfigured\x12?\n" +
+	"\x1chost_inbound_system_services\x18\r \x03(\tR\x19hostInboundSystemServices\x124\n" +
+	"\x16host_inbound_protocols\x18\x0e \x03(\tR\x14hostInboundProtocols\x12R\n" +
+	"\x16interface_host_inbound\x18\x0f \x03(\v2\x1c.xpf.v1.InterfaceHostInboundR\x14interfaceHostInbound\"\x9b\x01\n" +
+	"\x14InterfaceHostInbound\x12\x1c\n" +
+	"\tinterface\x18\x01 \x01(\tR\tinterface\x12\x1e\n" +
+	"\n" +
+	"configured\x18\x02 \x01(\bR\n" +
+	"configured\x12'\n" +
+	"\x0fsystem_services\x18\x03 \x03(\tR\x0esystemServices\x12\x1c\n" +
+	"\tprotocols\x18\x04 \x03(\tR\tprotocols\"\x14\n" +
 	"\x12GetPoliciesRequest\"E\n" +
 	"\x13GetPoliciesResponse\x12.\n" +
 	"\bpolicies\x18\x01 \x03(\v2\x12.xpf.v1.PolicyInfoR\bpolicies\"l\n" +
@@ -7799,7 +7934,7 @@ func file_xpf_proto_rawDescGZIP() []byte {
 }
 
 var file_xpf_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_xpf_proto_msgTypes = make([]protoimpl.MessageInfo, 120)
+var file_xpf_proto_msgTypes = make([]protoimpl.MessageInfo, 121)
 var file_xpf_proto_goTypes = []any{
 	(ConfigFormat)(0),                         // 0: xpf.v1.ConfigFormat
 	(ConfigTarget)(0),                         // 1: xpf.v1.ConfigTarget
@@ -7842,222 +7977,224 @@ var file_xpf_proto_goTypes = []any{
 	(*GetZonesRequest)(nil),                   // 38: xpf.v1.GetZonesRequest
 	(*GetZonesResponse)(nil),                  // 39: xpf.v1.GetZonesResponse
 	(*ZoneInfo)(nil),                          // 40: xpf.v1.ZoneInfo
-	(*GetPoliciesRequest)(nil),                // 41: xpf.v1.GetPoliciesRequest
-	(*GetPoliciesResponse)(nil),               // 42: xpf.v1.GetPoliciesResponse
-	(*PolicyInfo)(nil),                        // 43: xpf.v1.PolicyInfo
-	(*PolicyRule)(nil),                        // 44: xpf.v1.PolicyRule
-	(*GetSessionsRequest)(nil),                // 45: xpf.v1.GetSessionsRequest
-	(*GetSessionsResponse)(nil),               // 46: xpf.v1.GetSessionsResponse
-	(*SessionEntry)(nil),                      // 47: xpf.v1.SessionEntry
-	(*GetSessionSummaryRequest)(nil),          // 48: xpf.v1.GetSessionSummaryRequest
-	(*GetSessionSummaryResponse)(nil),         // 49: xpf.v1.GetSessionSummaryResponse
-	(*GetNATSourceRequest)(nil),               // 50: xpf.v1.GetNATSourceRequest
-	(*GetNATSourceResponse)(nil),              // 51: xpf.v1.GetNATSourceResponse
-	(*NATSourceInfo)(nil),                     // 52: xpf.v1.NATSourceInfo
-	(*GetNATDestinationRequest)(nil),          // 53: xpf.v1.GetNATDestinationRequest
-	(*GetNATDestinationResponse)(nil),         // 54: xpf.v1.GetNATDestinationResponse
-	(*NATDestInfo)(nil),                       // 55: xpf.v1.NATDestInfo
-	(*GetScreenRequest)(nil),                  // 56: xpf.v1.GetScreenRequest
-	(*GetScreenResponse)(nil),                 // 57: xpf.v1.GetScreenResponse
-	(*ScreenInfo)(nil),                        // 58: xpf.v1.ScreenInfo
-	(*GetEventsRequest)(nil),                  // 59: xpf.v1.GetEventsRequest
-	(*GetEventsResponse)(nil),                 // 60: xpf.v1.GetEventsResponse
-	(*EventEntry)(nil),                        // 61: xpf.v1.EventEntry
-	(*GetInterfacesRequest)(nil),              // 62: xpf.v1.GetInterfacesRequest
-	(*GetInterfacesResponse)(nil),             // 63: xpf.v1.GetInterfacesResponse
-	(*InterfaceInfo)(nil),                     // 64: xpf.v1.InterfaceInfo
-	(*ShowInterfacesDetailRequest)(nil),       // 65: xpf.v1.ShowInterfacesDetailRequest
-	(*ShowInterfacesDetailResponse)(nil),      // 66: xpf.v1.ShowInterfacesDetailResponse
-	(*GetDHCPLeasesRequest)(nil),              // 67: xpf.v1.GetDHCPLeasesRequest
-	(*GetDHCPLeasesResponse)(nil),             // 68: xpf.v1.GetDHCPLeasesResponse
-	(*DHCPLeaseInfo)(nil),                     // 69: xpf.v1.DHCPLeaseInfo
-	(*DHCPDelegatedPrefix)(nil),               // 70: xpf.v1.DHCPDelegatedPrefix
-	(*GetDHCPClientIdentifiersRequest)(nil),   // 71: xpf.v1.GetDHCPClientIdentifiersRequest
-	(*GetDHCPClientIdentifiersResponse)(nil),  // 72: xpf.v1.GetDHCPClientIdentifiersResponse
-	(*DHCPClientIdentifierInfo)(nil),          // 73: xpf.v1.DHCPClientIdentifierInfo
-	(*ClearDHCPClientIdentifierRequest)(nil),  // 74: xpf.v1.ClearDHCPClientIdentifierRequest
-	(*ClearDHCPClientIdentifierResponse)(nil), // 75: xpf.v1.ClearDHCPClientIdentifierResponse
-	(*GetRoutesRequest)(nil),                  // 76: xpf.v1.GetRoutesRequest
-	(*GetRoutesResponse)(nil),                 // 77: xpf.v1.GetRoutesResponse
-	(*RouteInfo)(nil),                         // 78: xpf.v1.RouteInfo
-	(*GetOSPFStatusRequest)(nil),              // 79: xpf.v1.GetOSPFStatusRequest
-	(*GetOSPFStatusResponse)(nil),             // 80: xpf.v1.GetOSPFStatusResponse
-	(*GetBGPStatusRequest)(nil),               // 81: xpf.v1.GetBGPStatusRequest
-	(*GetBGPStatusResponse)(nil),              // 82: xpf.v1.GetBGPStatusResponse
-	(*GetRIPStatusRequest)(nil),               // 83: xpf.v1.GetRIPStatusRequest
-	(*GetRIPStatusResponse)(nil),              // 84: xpf.v1.GetRIPStatusResponse
-	(*GetISISStatusRequest)(nil),              // 85: xpf.v1.GetISISStatusRequest
-	(*GetISISStatusResponse)(nil),             // 86: xpf.v1.GetISISStatusResponse
-	(*GetIPsecSARequest)(nil),                 // 87: xpf.v1.GetIPsecSARequest
-	(*GetIPsecSAResponse)(nil),                // 88: xpf.v1.GetIPsecSAResponse
-	(*PingRequest)(nil),                       // 89: xpf.v1.PingRequest
-	(*PingResponse)(nil),                      // 90: xpf.v1.PingResponse
-	(*TracerouteRequest)(nil),                 // 91: xpf.v1.TracerouteRequest
-	(*TracerouteResponse)(nil),                // 92: xpf.v1.TracerouteResponse
-	(*ClearSessionsRequest)(nil),              // 93: xpf.v1.ClearSessionsRequest
-	(*ClearSessionsResponse)(nil),             // 94: xpf.v1.ClearSessionsResponse
-	(*ClearCountersRequest)(nil),              // 95: xpf.v1.ClearCountersRequest
-	(*ClearCountersResponse)(nil),             // 96: xpf.v1.ClearCountersResponse
-	(*GetNATPoolStatsRequest)(nil),            // 97: xpf.v1.GetNATPoolStatsRequest
-	(*GetNATPoolStatsResponse)(nil),           // 98: xpf.v1.GetNATPoolStatsResponse
-	(*NATPoolStats)(nil),                      // 99: xpf.v1.NATPoolStats
-	(*NATRuleSetSessions)(nil),                // 100: xpf.v1.NATRuleSetSessions
-	(*GetVRRPStatusRequest)(nil),              // 101: xpf.v1.GetVRRPStatusRequest
-	(*GetVRRPStatusResponse)(nil),             // 102: xpf.v1.GetVRRPStatusResponse
-	(*VRRPInstanceInfo)(nil),                  // 103: xpf.v1.VRRPInstanceInfo
-	(*MatchPoliciesRequest)(nil),              // 104: xpf.v1.MatchPoliciesRequest
-	(*MatchPoliciesResponse)(nil),             // 105: xpf.v1.MatchPoliciesResponse
-	(*GetNATRuleStatsRequest)(nil),            // 106: xpf.v1.GetNATRuleStatsRequest
-	(*GetNATRuleStatsResponse)(nil),           // 107: xpf.v1.GetNATRuleStatsResponse
-	(*NATRuleStats)(nil),                      // 108: xpf.v1.NATRuleStats
-	(*CompleteRequest)(nil),                   // 109: xpf.v1.CompleteRequest
-	(*CompleteResponse)(nil),                  // 110: xpf.v1.CompleteResponse
-	(*ShowTextRequest)(nil),                   // 111: xpf.v1.ShowTextRequest
-	(*ShowTextResponse)(nil),                  // 112: xpf.v1.ShowTextResponse
-	(*GetSystemInfoRequest)(nil),              // 113: xpf.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),             // 114: xpf.v1.GetSystemInfoResponse
-	(*SystemActionRequest)(nil),               // 115: xpf.v1.SystemActionRequest
-	(*SystemActionResponse)(nil),              // 116: xpf.v1.SystemActionResponse
-	(*MonitorPacketDropRequest)(nil),          // 117: xpf.v1.MonitorPacketDropRequest
-	(*MonitorPacketDropResponse)(nil),         // 118: xpf.v1.MonitorPacketDropResponse
-	(*MonitorInterfaceRequest)(nil),           // 119: xpf.v1.MonitorInterfaceRequest
-	(*MonitorInterfaceResponse)(nil),          // 120: xpf.v1.MonitorInterfaceResponse
-	nil,                                       // 121: xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
-	nil,                                       // 122: xpf.v1.ScreenInfo.ThresholdsEntry
+	(*InterfaceHostInbound)(nil),              // 41: xpf.v1.InterfaceHostInbound
+	(*GetPoliciesRequest)(nil),                // 42: xpf.v1.GetPoliciesRequest
+	(*GetPoliciesResponse)(nil),               // 43: xpf.v1.GetPoliciesResponse
+	(*PolicyInfo)(nil),                        // 44: xpf.v1.PolicyInfo
+	(*PolicyRule)(nil),                        // 45: xpf.v1.PolicyRule
+	(*GetSessionsRequest)(nil),                // 46: xpf.v1.GetSessionsRequest
+	(*GetSessionsResponse)(nil),               // 47: xpf.v1.GetSessionsResponse
+	(*SessionEntry)(nil),                      // 48: xpf.v1.SessionEntry
+	(*GetSessionSummaryRequest)(nil),          // 49: xpf.v1.GetSessionSummaryRequest
+	(*GetSessionSummaryResponse)(nil),         // 50: xpf.v1.GetSessionSummaryResponse
+	(*GetNATSourceRequest)(nil),               // 51: xpf.v1.GetNATSourceRequest
+	(*GetNATSourceResponse)(nil),              // 52: xpf.v1.GetNATSourceResponse
+	(*NATSourceInfo)(nil),                     // 53: xpf.v1.NATSourceInfo
+	(*GetNATDestinationRequest)(nil),          // 54: xpf.v1.GetNATDestinationRequest
+	(*GetNATDestinationResponse)(nil),         // 55: xpf.v1.GetNATDestinationResponse
+	(*NATDestInfo)(nil),                       // 56: xpf.v1.NATDestInfo
+	(*GetScreenRequest)(nil),                  // 57: xpf.v1.GetScreenRequest
+	(*GetScreenResponse)(nil),                 // 58: xpf.v1.GetScreenResponse
+	(*ScreenInfo)(nil),                        // 59: xpf.v1.ScreenInfo
+	(*GetEventsRequest)(nil),                  // 60: xpf.v1.GetEventsRequest
+	(*GetEventsResponse)(nil),                 // 61: xpf.v1.GetEventsResponse
+	(*EventEntry)(nil),                        // 62: xpf.v1.EventEntry
+	(*GetInterfacesRequest)(nil),              // 63: xpf.v1.GetInterfacesRequest
+	(*GetInterfacesResponse)(nil),             // 64: xpf.v1.GetInterfacesResponse
+	(*InterfaceInfo)(nil),                     // 65: xpf.v1.InterfaceInfo
+	(*ShowInterfacesDetailRequest)(nil),       // 66: xpf.v1.ShowInterfacesDetailRequest
+	(*ShowInterfacesDetailResponse)(nil),      // 67: xpf.v1.ShowInterfacesDetailResponse
+	(*GetDHCPLeasesRequest)(nil),              // 68: xpf.v1.GetDHCPLeasesRequest
+	(*GetDHCPLeasesResponse)(nil),             // 69: xpf.v1.GetDHCPLeasesResponse
+	(*DHCPLeaseInfo)(nil),                     // 70: xpf.v1.DHCPLeaseInfo
+	(*DHCPDelegatedPrefix)(nil),               // 71: xpf.v1.DHCPDelegatedPrefix
+	(*GetDHCPClientIdentifiersRequest)(nil),   // 72: xpf.v1.GetDHCPClientIdentifiersRequest
+	(*GetDHCPClientIdentifiersResponse)(nil),  // 73: xpf.v1.GetDHCPClientIdentifiersResponse
+	(*DHCPClientIdentifierInfo)(nil),          // 74: xpf.v1.DHCPClientIdentifierInfo
+	(*ClearDHCPClientIdentifierRequest)(nil),  // 75: xpf.v1.ClearDHCPClientIdentifierRequest
+	(*ClearDHCPClientIdentifierResponse)(nil), // 76: xpf.v1.ClearDHCPClientIdentifierResponse
+	(*GetRoutesRequest)(nil),                  // 77: xpf.v1.GetRoutesRequest
+	(*GetRoutesResponse)(nil),                 // 78: xpf.v1.GetRoutesResponse
+	(*RouteInfo)(nil),                         // 79: xpf.v1.RouteInfo
+	(*GetOSPFStatusRequest)(nil),              // 80: xpf.v1.GetOSPFStatusRequest
+	(*GetOSPFStatusResponse)(nil),             // 81: xpf.v1.GetOSPFStatusResponse
+	(*GetBGPStatusRequest)(nil),               // 82: xpf.v1.GetBGPStatusRequest
+	(*GetBGPStatusResponse)(nil),              // 83: xpf.v1.GetBGPStatusResponse
+	(*GetRIPStatusRequest)(nil),               // 84: xpf.v1.GetRIPStatusRequest
+	(*GetRIPStatusResponse)(nil),              // 85: xpf.v1.GetRIPStatusResponse
+	(*GetISISStatusRequest)(nil),              // 86: xpf.v1.GetISISStatusRequest
+	(*GetISISStatusResponse)(nil),             // 87: xpf.v1.GetISISStatusResponse
+	(*GetIPsecSARequest)(nil),                 // 88: xpf.v1.GetIPsecSARequest
+	(*GetIPsecSAResponse)(nil),                // 89: xpf.v1.GetIPsecSAResponse
+	(*PingRequest)(nil),                       // 90: xpf.v1.PingRequest
+	(*PingResponse)(nil),                      // 91: xpf.v1.PingResponse
+	(*TracerouteRequest)(nil),                 // 92: xpf.v1.TracerouteRequest
+	(*TracerouteResponse)(nil),                // 93: xpf.v1.TracerouteResponse
+	(*ClearSessionsRequest)(nil),              // 94: xpf.v1.ClearSessionsRequest
+	(*ClearSessionsResponse)(nil),             // 95: xpf.v1.ClearSessionsResponse
+	(*ClearCountersRequest)(nil),              // 96: xpf.v1.ClearCountersRequest
+	(*ClearCountersResponse)(nil),             // 97: xpf.v1.ClearCountersResponse
+	(*GetNATPoolStatsRequest)(nil),            // 98: xpf.v1.GetNATPoolStatsRequest
+	(*GetNATPoolStatsResponse)(nil),           // 99: xpf.v1.GetNATPoolStatsResponse
+	(*NATPoolStats)(nil),                      // 100: xpf.v1.NATPoolStats
+	(*NATRuleSetSessions)(nil),                // 101: xpf.v1.NATRuleSetSessions
+	(*GetVRRPStatusRequest)(nil),              // 102: xpf.v1.GetVRRPStatusRequest
+	(*GetVRRPStatusResponse)(nil),             // 103: xpf.v1.GetVRRPStatusResponse
+	(*VRRPInstanceInfo)(nil),                  // 104: xpf.v1.VRRPInstanceInfo
+	(*MatchPoliciesRequest)(nil),              // 105: xpf.v1.MatchPoliciesRequest
+	(*MatchPoliciesResponse)(nil),             // 106: xpf.v1.MatchPoliciesResponse
+	(*GetNATRuleStatsRequest)(nil),            // 107: xpf.v1.GetNATRuleStatsRequest
+	(*GetNATRuleStatsResponse)(nil),           // 108: xpf.v1.GetNATRuleStatsResponse
+	(*NATRuleStats)(nil),                      // 109: xpf.v1.NATRuleStats
+	(*CompleteRequest)(nil),                   // 110: xpf.v1.CompleteRequest
+	(*CompleteResponse)(nil),                  // 111: xpf.v1.CompleteResponse
+	(*ShowTextRequest)(nil),                   // 112: xpf.v1.ShowTextRequest
+	(*ShowTextResponse)(nil),                  // 113: xpf.v1.ShowTextResponse
+	(*GetSystemInfoRequest)(nil),              // 114: xpf.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),             // 115: xpf.v1.GetSystemInfoResponse
+	(*SystemActionRequest)(nil),               // 116: xpf.v1.SystemActionRequest
+	(*SystemActionResponse)(nil),              // 117: xpf.v1.SystemActionResponse
+	(*MonitorPacketDropRequest)(nil),          // 118: xpf.v1.MonitorPacketDropRequest
+	(*MonitorPacketDropResponse)(nil),         // 119: xpf.v1.MonitorPacketDropResponse
+	(*MonitorInterfaceRequest)(nil),           // 120: xpf.v1.MonitorInterfaceRequest
+	(*MonitorInterfaceResponse)(nil),          // 121: xpf.v1.MonitorInterfaceResponse
+	nil,                                       // 122: xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
+	nil,                                       // 123: xpf.v1.ScreenInfo.ThresholdsEntry
 }
 var file_xpf_proto_depIdxs = []int32{
 	0,   // 0: xpf.v1.ShowConfigRequest.format:type_name -> xpf.v1.ConfigFormat
 	1,   // 1: xpf.v1.ShowConfigRequest.target:type_name -> xpf.v1.ConfigTarget
 	0,   // 2: xpf.v1.ShowRollbackRequest.format:type_name -> xpf.v1.ConfigFormat
 	33,  // 3: xpf.v1.ListHistoryResponse.entries:type_name -> xpf.v1.HistoryEntry
-	121, // 4: xpf.v1.GetGlobalStatsResponse.screen_drop_details:type_name -> xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
+	122, // 4: xpf.v1.GetGlobalStatsResponse.screen_drop_details:type_name -> xpf.v1.GetGlobalStatsResponse.ScreenDropDetailsEntry
 	40,  // 5: xpf.v1.GetZonesResponse.zones:type_name -> xpf.v1.ZoneInfo
-	43,  // 6: xpf.v1.GetPoliciesResponse.policies:type_name -> xpf.v1.PolicyInfo
-	44,  // 7: xpf.v1.PolicyInfo.rules:type_name -> xpf.v1.PolicyRule
-	47,  // 8: xpf.v1.GetSessionsResponse.sessions:type_name -> xpf.v1.SessionEntry
-	46,  // 9: xpf.v1.GetSessionsResponse.peer:type_name -> xpf.v1.GetSessionsResponse
-	49,  // 10: xpf.v1.GetSessionSummaryResponse.peer:type_name -> xpf.v1.GetSessionSummaryResponse
-	52,  // 11: xpf.v1.GetNATSourceResponse.rules:type_name -> xpf.v1.NATSourceInfo
-	55,  // 12: xpf.v1.GetNATDestinationResponse.rules:type_name -> xpf.v1.NATDestInfo
-	100, // 13: xpf.v1.GetNATDestinationResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
-	58,  // 14: xpf.v1.GetScreenResponse.screens:type_name -> xpf.v1.ScreenInfo
-	122, // 15: xpf.v1.ScreenInfo.thresholds:type_name -> xpf.v1.ScreenInfo.ThresholdsEntry
-	61,  // 16: xpf.v1.GetEventsResponse.events:type_name -> xpf.v1.EventEntry
-	64,  // 17: xpf.v1.GetInterfacesResponse.interfaces:type_name -> xpf.v1.InterfaceInfo
-	69,  // 18: xpf.v1.GetDHCPLeasesResponse.leases:type_name -> xpf.v1.DHCPLeaseInfo
-	70,  // 19: xpf.v1.DHCPLeaseInfo.delegated_prefixes:type_name -> xpf.v1.DHCPDelegatedPrefix
-	73,  // 20: xpf.v1.GetDHCPClientIdentifiersResponse.identifiers:type_name -> xpf.v1.DHCPClientIdentifierInfo
-	78,  // 21: xpf.v1.GetRoutesResponse.routes:type_name -> xpf.v1.RouteInfo
-	99,  // 22: xpf.v1.GetNATPoolStatsResponse.pools:type_name -> xpf.v1.NATPoolStats
-	100, // 23: xpf.v1.GetNATPoolStatsResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
-	103, // 24: xpf.v1.GetVRRPStatusResponse.instances:type_name -> xpf.v1.VRRPInstanceInfo
-	108, // 25: xpf.v1.GetNATRuleStatsResponse.rules:type_name -> xpf.v1.NATRuleStats
-	2,   // 26: xpf.v1.MonitorInterfaceRequest.summary_mode:type_name -> xpf.v1.MonitorInterfaceSummaryMode
-	3,   // 27: xpf.v1.BpfrxService.EnterConfigure:input_type -> xpf.v1.EnterConfigureRequest
-	5,   // 28: xpf.v1.BpfrxService.ExitConfigure:input_type -> xpf.v1.ExitConfigureRequest
-	7,   // 29: xpf.v1.BpfrxService.GetConfigModeStatus:input_type -> xpf.v1.GetConfigModeStatusRequest
-	9,   // 30: xpf.v1.BpfrxService.Set:input_type -> xpf.v1.SetRequest
-	11,  // 31: xpf.v1.BpfrxService.Delete:input_type -> xpf.v1.DeleteRequest
-	13,  // 32: xpf.v1.BpfrxService.Load:input_type -> xpf.v1.LoadRequest
-	15,  // 33: xpf.v1.BpfrxService.Commit:input_type -> xpf.v1.CommitRequest
-	17,  // 34: xpf.v1.BpfrxService.CommitCheck:input_type -> xpf.v1.CommitCheckRequest
-	19,  // 35: xpf.v1.BpfrxService.CommitConfirmed:input_type -> xpf.v1.CommitConfirmedRequest
-	21,  // 36: xpf.v1.BpfrxService.ConfirmCommit:input_type -> xpf.v1.ConfirmCommitRequest
-	23,  // 37: xpf.v1.BpfrxService.Rollback:input_type -> xpf.v1.RollbackRequest
-	25,  // 38: xpf.v1.BpfrxService.ShowConfig:input_type -> xpf.v1.ShowConfigRequest
-	27,  // 39: xpf.v1.BpfrxService.ShowCompare:input_type -> xpf.v1.ShowCompareRequest
-	29,  // 40: xpf.v1.BpfrxService.ShowRollback:input_type -> xpf.v1.ShowRollbackRequest
-	31,  // 41: xpf.v1.BpfrxService.ListHistory:input_type -> xpf.v1.ListHistoryRequest
-	34,  // 42: xpf.v1.BpfrxService.GetStatus:input_type -> xpf.v1.GetStatusRequest
-	36,  // 43: xpf.v1.BpfrxService.GetGlobalStats:input_type -> xpf.v1.GetGlobalStatsRequest
-	38,  // 44: xpf.v1.BpfrxService.GetZones:input_type -> xpf.v1.GetZonesRequest
-	41,  // 45: xpf.v1.BpfrxService.GetPolicies:input_type -> xpf.v1.GetPoliciesRequest
-	45,  // 46: xpf.v1.BpfrxService.GetSessions:input_type -> xpf.v1.GetSessionsRequest
-	48,  // 47: xpf.v1.BpfrxService.GetSessionSummary:input_type -> xpf.v1.GetSessionSummaryRequest
-	50,  // 48: xpf.v1.BpfrxService.GetNATSource:input_type -> xpf.v1.GetNATSourceRequest
-	53,  // 49: xpf.v1.BpfrxService.GetNATDestination:input_type -> xpf.v1.GetNATDestinationRequest
-	56,  // 50: xpf.v1.BpfrxService.GetScreen:input_type -> xpf.v1.GetScreenRequest
-	59,  // 51: xpf.v1.BpfrxService.GetEvents:input_type -> xpf.v1.GetEventsRequest
-	62,  // 52: xpf.v1.BpfrxService.GetInterfaces:input_type -> xpf.v1.GetInterfacesRequest
-	65,  // 53: xpf.v1.BpfrxService.ShowInterfacesDetail:input_type -> xpf.v1.ShowInterfacesDetailRequest
-	67,  // 54: xpf.v1.BpfrxService.GetDHCPLeases:input_type -> xpf.v1.GetDHCPLeasesRequest
-	71,  // 55: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:input_type -> xpf.v1.GetDHCPClientIdentifiersRequest
-	76,  // 56: xpf.v1.BpfrxService.GetRoutes:input_type -> xpf.v1.GetRoutesRequest
-	79,  // 57: xpf.v1.BpfrxService.GetOSPFStatus:input_type -> xpf.v1.GetOSPFStatusRequest
-	81,  // 58: xpf.v1.BpfrxService.GetBGPStatus:input_type -> xpf.v1.GetBGPStatusRequest
-	83,  // 59: xpf.v1.BpfrxService.GetRIPStatus:input_type -> xpf.v1.GetRIPStatusRequest
-	85,  // 60: xpf.v1.BpfrxService.GetISISStatus:input_type -> xpf.v1.GetISISStatusRequest
-	87,  // 61: xpf.v1.BpfrxService.GetIPsecSA:input_type -> xpf.v1.GetIPsecSARequest
-	97,  // 62: xpf.v1.BpfrxService.GetNATPoolStats:input_type -> xpf.v1.GetNATPoolStatsRequest
-	106, // 63: xpf.v1.BpfrxService.GetNATRuleStats:input_type -> xpf.v1.GetNATRuleStatsRequest
-	101, // 64: xpf.v1.BpfrxService.GetVRRPStatus:input_type -> xpf.v1.GetVRRPStatusRequest
-	104, // 65: xpf.v1.BpfrxService.MatchPolicies:input_type -> xpf.v1.MatchPoliciesRequest
-	89,  // 66: xpf.v1.BpfrxService.Ping:input_type -> xpf.v1.PingRequest
-	91,  // 67: xpf.v1.BpfrxService.Traceroute:input_type -> xpf.v1.TracerouteRequest
-	117, // 68: xpf.v1.BpfrxService.MonitorPacketDrop:input_type -> xpf.v1.MonitorPacketDropRequest
-	119, // 69: xpf.v1.BpfrxService.MonitorInterface:input_type -> xpf.v1.MonitorInterfaceRequest
-	93,  // 70: xpf.v1.BpfrxService.ClearSessions:input_type -> xpf.v1.ClearSessionsRequest
-	95,  // 71: xpf.v1.BpfrxService.ClearCounters:input_type -> xpf.v1.ClearCountersRequest
-	74,  // 72: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:input_type -> xpf.v1.ClearDHCPClientIdentifierRequest
-	111, // 73: xpf.v1.BpfrxService.ShowText:input_type -> xpf.v1.ShowTextRequest
-	113, // 74: xpf.v1.BpfrxService.GetSystemInfo:input_type -> xpf.v1.GetSystemInfoRequest
-	115, // 75: xpf.v1.BpfrxService.SystemAction:input_type -> xpf.v1.SystemActionRequest
-	109, // 76: xpf.v1.BpfrxService.Complete:input_type -> xpf.v1.CompleteRequest
-	4,   // 77: xpf.v1.BpfrxService.EnterConfigure:output_type -> xpf.v1.EnterConfigureResponse
-	6,   // 78: xpf.v1.BpfrxService.ExitConfigure:output_type -> xpf.v1.ExitConfigureResponse
-	8,   // 79: xpf.v1.BpfrxService.GetConfigModeStatus:output_type -> xpf.v1.GetConfigModeStatusResponse
-	10,  // 80: xpf.v1.BpfrxService.Set:output_type -> xpf.v1.SetResponse
-	12,  // 81: xpf.v1.BpfrxService.Delete:output_type -> xpf.v1.DeleteResponse
-	14,  // 82: xpf.v1.BpfrxService.Load:output_type -> xpf.v1.LoadResponse
-	16,  // 83: xpf.v1.BpfrxService.Commit:output_type -> xpf.v1.CommitResponse
-	18,  // 84: xpf.v1.BpfrxService.CommitCheck:output_type -> xpf.v1.CommitCheckResponse
-	20,  // 85: xpf.v1.BpfrxService.CommitConfirmed:output_type -> xpf.v1.CommitConfirmedResponse
-	22,  // 86: xpf.v1.BpfrxService.ConfirmCommit:output_type -> xpf.v1.ConfirmCommitResponse
-	24,  // 87: xpf.v1.BpfrxService.Rollback:output_type -> xpf.v1.RollbackResponse
-	26,  // 88: xpf.v1.BpfrxService.ShowConfig:output_type -> xpf.v1.ShowConfigResponse
-	28,  // 89: xpf.v1.BpfrxService.ShowCompare:output_type -> xpf.v1.ShowCompareResponse
-	30,  // 90: xpf.v1.BpfrxService.ShowRollback:output_type -> xpf.v1.ShowRollbackResponse
-	32,  // 91: xpf.v1.BpfrxService.ListHistory:output_type -> xpf.v1.ListHistoryResponse
-	35,  // 92: xpf.v1.BpfrxService.GetStatus:output_type -> xpf.v1.GetStatusResponse
-	37,  // 93: xpf.v1.BpfrxService.GetGlobalStats:output_type -> xpf.v1.GetGlobalStatsResponse
-	39,  // 94: xpf.v1.BpfrxService.GetZones:output_type -> xpf.v1.GetZonesResponse
-	42,  // 95: xpf.v1.BpfrxService.GetPolicies:output_type -> xpf.v1.GetPoliciesResponse
-	46,  // 96: xpf.v1.BpfrxService.GetSessions:output_type -> xpf.v1.GetSessionsResponse
-	49,  // 97: xpf.v1.BpfrxService.GetSessionSummary:output_type -> xpf.v1.GetSessionSummaryResponse
-	51,  // 98: xpf.v1.BpfrxService.GetNATSource:output_type -> xpf.v1.GetNATSourceResponse
-	54,  // 99: xpf.v1.BpfrxService.GetNATDestination:output_type -> xpf.v1.GetNATDestinationResponse
-	57,  // 100: xpf.v1.BpfrxService.GetScreen:output_type -> xpf.v1.GetScreenResponse
-	60,  // 101: xpf.v1.BpfrxService.GetEvents:output_type -> xpf.v1.GetEventsResponse
-	63,  // 102: xpf.v1.BpfrxService.GetInterfaces:output_type -> xpf.v1.GetInterfacesResponse
-	66,  // 103: xpf.v1.BpfrxService.ShowInterfacesDetail:output_type -> xpf.v1.ShowInterfacesDetailResponse
-	68,  // 104: xpf.v1.BpfrxService.GetDHCPLeases:output_type -> xpf.v1.GetDHCPLeasesResponse
-	72,  // 105: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:output_type -> xpf.v1.GetDHCPClientIdentifiersResponse
-	77,  // 106: xpf.v1.BpfrxService.GetRoutes:output_type -> xpf.v1.GetRoutesResponse
-	80,  // 107: xpf.v1.BpfrxService.GetOSPFStatus:output_type -> xpf.v1.GetOSPFStatusResponse
-	82,  // 108: xpf.v1.BpfrxService.GetBGPStatus:output_type -> xpf.v1.GetBGPStatusResponse
-	84,  // 109: xpf.v1.BpfrxService.GetRIPStatus:output_type -> xpf.v1.GetRIPStatusResponse
-	86,  // 110: xpf.v1.BpfrxService.GetISISStatus:output_type -> xpf.v1.GetISISStatusResponse
-	88,  // 111: xpf.v1.BpfrxService.GetIPsecSA:output_type -> xpf.v1.GetIPsecSAResponse
-	98,  // 112: xpf.v1.BpfrxService.GetNATPoolStats:output_type -> xpf.v1.GetNATPoolStatsResponse
-	107, // 113: xpf.v1.BpfrxService.GetNATRuleStats:output_type -> xpf.v1.GetNATRuleStatsResponse
-	102, // 114: xpf.v1.BpfrxService.GetVRRPStatus:output_type -> xpf.v1.GetVRRPStatusResponse
-	105, // 115: xpf.v1.BpfrxService.MatchPolicies:output_type -> xpf.v1.MatchPoliciesResponse
-	90,  // 116: xpf.v1.BpfrxService.Ping:output_type -> xpf.v1.PingResponse
-	92,  // 117: xpf.v1.BpfrxService.Traceroute:output_type -> xpf.v1.TracerouteResponse
-	118, // 118: xpf.v1.BpfrxService.MonitorPacketDrop:output_type -> xpf.v1.MonitorPacketDropResponse
-	120, // 119: xpf.v1.BpfrxService.MonitorInterface:output_type -> xpf.v1.MonitorInterfaceResponse
-	94,  // 120: xpf.v1.BpfrxService.ClearSessions:output_type -> xpf.v1.ClearSessionsResponse
-	96,  // 121: xpf.v1.BpfrxService.ClearCounters:output_type -> xpf.v1.ClearCountersResponse
-	75,  // 122: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:output_type -> xpf.v1.ClearDHCPClientIdentifierResponse
-	112, // 123: xpf.v1.BpfrxService.ShowText:output_type -> xpf.v1.ShowTextResponse
-	114, // 124: xpf.v1.BpfrxService.GetSystemInfo:output_type -> xpf.v1.GetSystemInfoResponse
-	116, // 125: xpf.v1.BpfrxService.SystemAction:output_type -> xpf.v1.SystemActionResponse
-	110, // 126: xpf.v1.BpfrxService.Complete:output_type -> xpf.v1.CompleteResponse
-	77,  // [77:127] is the sub-list for method output_type
-	27,  // [27:77] is the sub-list for method input_type
-	27,  // [27:27] is the sub-list for extension type_name
-	27,  // [27:27] is the sub-list for extension extendee
-	0,   // [0:27] is the sub-list for field type_name
+	41,  // 6: xpf.v1.ZoneInfo.interface_host_inbound:type_name -> xpf.v1.InterfaceHostInbound
+	44,  // 7: xpf.v1.GetPoliciesResponse.policies:type_name -> xpf.v1.PolicyInfo
+	45,  // 8: xpf.v1.PolicyInfo.rules:type_name -> xpf.v1.PolicyRule
+	48,  // 9: xpf.v1.GetSessionsResponse.sessions:type_name -> xpf.v1.SessionEntry
+	47,  // 10: xpf.v1.GetSessionsResponse.peer:type_name -> xpf.v1.GetSessionsResponse
+	50,  // 11: xpf.v1.GetSessionSummaryResponse.peer:type_name -> xpf.v1.GetSessionSummaryResponse
+	53,  // 12: xpf.v1.GetNATSourceResponse.rules:type_name -> xpf.v1.NATSourceInfo
+	56,  // 13: xpf.v1.GetNATDestinationResponse.rules:type_name -> xpf.v1.NATDestInfo
+	101, // 14: xpf.v1.GetNATDestinationResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
+	59,  // 15: xpf.v1.GetScreenResponse.screens:type_name -> xpf.v1.ScreenInfo
+	123, // 16: xpf.v1.ScreenInfo.thresholds:type_name -> xpf.v1.ScreenInfo.ThresholdsEntry
+	62,  // 17: xpf.v1.GetEventsResponse.events:type_name -> xpf.v1.EventEntry
+	65,  // 18: xpf.v1.GetInterfacesResponse.interfaces:type_name -> xpf.v1.InterfaceInfo
+	70,  // 19: xpf.v1.GetDHCPLeasesResponse.leases:type_name -> xpf.v1.DHCPLeaseInfo
+	71,  // 20: xpf.v1.DHCPLeaseInfo.delegated_prefixes:type_name -> xpf.v1.DHCPDelegatedPrefix
+	74,  // 21: xpf.v1.GetDHCPClientIdentifiersResponse.identifiers:type_name -> xpf.v1.DHCPClientIdentifierInfo
+	79,  // 22: xpf.v1.GetRoutesResponse.routes:type_name -> xpf.v1.RouteInfo
+	100, // 23: xpf.v1.GetNATPoolStatsResponse.pools:type_name -> xpf.v1.NATPoolStats
+	101, // 24: xpf.v1.GetNATPoolStatsResponse.rule_set_sessions:type_name -> xpf.v1.NATRuleSetSessions
+	104, // 25: xpf.v1.GetVRRPStatusResponse.instances:type_name -> xpf.v1.VRRPInstanceInfo
+	109, // 26: xpf.v1.GetNATRuleStatsResponse.rules:type_name -> xpf.v1.NATRuleStats
+	2,   // 27: xpf.v1.MonitorInterfaceRequest.summary_mode:type_name -> xpf.v1.MonitorInterfaceSummaryMode
+	3,   // 28: xpf.v1.BpfrxService.EnterConfigure:input_type -> xpf.v1.EnterConfigureRequest
+	5,   // 29: xpf.v1.BpfrxService.ExitConfigure:input_type -> xpf.v1.ExitConfigureRequest
+	7,   // 30: xpf.v1.BpfrxService.GetConfigModeStatus:input_type -> xpf.v1.GetConfigModeStatusRequest
+	9,   // 31: xpf.v1.BpfrxService.Set:input_type -> xpf.v1.SetRequest
+	11,  // 32: xpf.v1.BpfrxService.Delete:input_type -> xpf.v1.DeleteRequest
+	13,  // 33: xpf.v1.BpfrxService.Load:input_type -> xpf.v1.LoadRequest
+	15,  // 34: xpf.v1.BpfrxService.Commit:input_type -> xpf.v1.CommitRequest
+	17,  // 35: xpf.v1.BpfrxService.CommitCheck:input_type -> xpf.v1.CommitCheckRequest
+	19,  // 36: xpf.v1.BpfrxService.CommitConfirmed:input_type -> xpf.v1.CommitConfirmedRequest
+	21,  // 37: xpf.v1.BpfrxService.ConfirmCommit:input_type -> xpf.v1.ConfirmCommitRequest
+	23,  // 38: xpf.v1.BpfrxService.Rollback:input_type -> xpf.v1.RollbackRequest
+	25,  // 39: xpf.v1.BpfrxService.ShowConfig:input_type -> xpf.v1.ShowConfigRequest
+	27,  // 40: xpf.v1.BpfrxService.ShowCompare:input_type -> xpf.v1.ShowCompareRequest
+	29,  // 41: xpf.v1.BpfrxService.ShowRollback:input_type -> xpf.v1.ShowRollbackRequest
+	31,  // 42: xpf.v1.BpfrxService.ListHistory:input_type -> xpf.v1.ListHistoryRequest
+	34,  // 43: xpf.v1.BpfrxService.GetStatus:input_type -> xpf.v1.GetStatusRequest
+	36,  // 44: xpf.v1.BpfrxService.GetGlobalStats:input_type -> xpf.v1.GetGlobalStatsRequest
+	38,  // 45: xpf.v1.BpfrxService.GetZones:input_type -> xpf.v1.GetZonesRequest
+	42,  // 46: xpf.v1.BpfrxService.GetPolicies:input_type -> xpf.v1.GetPoliciesRequest
+	46,  // 47: xpf.v1.BpfrxService.GetSessions:input_type -> xpf.v1.GetSessionsRequest
+	49,  // 48: xpf.v1.BpfrxService.GetSessionSummary:input_type -> xpf.v1.GetSessionSummaryRequest
+	51,  // 49: xpf.v1.BpfrxService.GetNATSource:input_type -> xpf.v1.GetNATSourceRequest
+	54,  // 50: xpf.v1.BpfrxService.GetNATDestination:input_type -> xpf.v1.GetNATDestinationRequest
+	57,  // 51: xpf.v1.BpfrxService.GetScreen:input_type -> xpf.v1.GetScreenRequest
+	60,  // 52: xpf.v1.BpfrxService.GetEvents:input_type -> xpf.v1.GetEventsRequest
+	63,  // 53: xpf.v1.BpfrxService.GetInterfaces:input_type -> xpf.v1.GetInterfacesRequest
+	66,  // 54: xpf.v1.BpfrxService.ShowInterfacesDetail:input_type -> xpf.v1.ShowInterfacesDetailRequest
+	68,  // 55: xpf.v1.BpfrxService.GetDHCPLeases:input_type -> xpf.v1.GetDHCPLeasesRequest
+	72,  // 56: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:input_type -> xpf.v1.GetDHCPClientIdentifiersRequest
+	77,  // 57: xpf.v1.BpfrxService.GetRoutes:input_type -> xpf.v1.GetRoutesRequest
+	80,  // 58: xpf.v1.BpfrxService.GetOSPFStatus:input_type -> xpf.v1.GetOSPFStatusRequest
+	82,  // 59: xpf.v1.BpfrxService.GetBGPStatus:input_type -> xpf.v1.GetBGPStatusRequest
+	84,  // 60: xpf.v1.BpfrxService.GetRIPStatus:input_type -> xpf.v1.GetRIPStatusRequest
+	86,  // 61: xpf.v1.BpfrxService.GetISISStatus:input_type -> xpf.v1.GetISISStatusRequest
+	88,  // 62: xpf.v1.BpfrxService.GetIPsecSA:input_type -> xpf.v1.GetIPsecSARequest
+	98,  // 63: xpf.v1.BpfrxService.GetNATPoolStats:input_type -> xpf.v1.GetNATPoolStatsRequest
+	107, // 64: xpf.v1.BpfrxService.GetNATRuleStats:input_type -> xpf.v1.GetNATRuleStatsRequest
+	102, // 65: xpf.v1.BpfrxService.GetVRRPStatus:input_type -> xpf.v1.GetVRRPStatusRequest
+	105, // 66: xpf.v1.BpfrxService.MatchPolicies:input_type -> xpf.v1.MatchPoliciesRequest
+	90,  // 67: xpf.v1.BpfrxService.Ping:input_type -> xpf.v1.PingRequest
+	92,  // 68: xpf.v1.BpfrxService.Traceroute:input_type -> xpf.v1.TracerouteRequest
+	118, // 69: xpf.v1.BpfrxService.MonitorPacketDrop:input_type -> xpf.v1.MonitorPacketDropRequest
+	120, // 70: xpf.v1.BpfrxService.MonitorInterface:input_type -> xpf.v1.MonitorInterfaceRequest
+	94,  // 71: xpf.v1.BpfrxService.ClearSessions:input_type -> xpf.v1.ClearSessionsRequest
+	96,  // 72: xpf.v1.BpfrxService.ClearCounters:input_type -> xpf.v1.ClearCountersRequest
+	75,  // 73: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:input_type -> xpf.v1.ClearDHCPClientIdentifierRequest
+	112, // 74: xpf.v1.BpfrxService.ShowText:input_type -> xpf.v1.ShowTextRequest
+	114, // 75: xpf.v1.BpfrxService.GetSystemInfo:input_type -> xpf.v1.GetSystemInfoRequest
+	116, // 76: xpf.v1.BpfrxService.SystemAction:input_type -> xpf.v1.SystemActionRequest
+	110, // 77: xpf.v1.BpfrxService.Complete:input_type -> xpf.v1.CompleteRequest
+	4,   // 78: xpf.v1.BpfrxService.EnterConfigure:output_type -> xpf.v1.EnterConfigureResponse
+	6,   // 79: xpf.v1.BpfrxService.ExitConfigure:output_type -> xpf.v1.ExitConfigureResponse
+	8,   // 80: xpf.v1.BpfrxService.GetConfigModeStatus:output_type -> xpf.v1.GetConfigModeStatusResponse
+	10,  // 81: xpf.v1.BpfrxService.Set:output_type -> xpf.v1.SetResponse
+	12,  // 82: xpf.v1.BpfrxService.Delete:output_type -> xpf.v1.DeleteResponse
+	14,  // 83: xpf.v1.BpfrxService.Load:output_type -> xpf.v1.LoadResponse
+	16,  // 84: xpf.v1.BpfrxService.Commit:output_type -> xpf.v1.CommitResponse
+	18,  // 85: xpf.v1.BpfrxService.CommitCheck:output_type -> xpf.v1.CommitCheckResponse
+	20,  // 86: xpf.v1.BpfrxService.CommitConfirmed:output_type -> xpf.v1.CommitConfirmedResponse
+	22,  // 87: xpf.v1.BpfrxService.ConfirmCommit:output_type -> xpf.v1.ConfirmCommitResponse
+	24,  // 88: xpf.v1.BpfrxService.Rollback:output_type -> xpf.v1.RollbackResponse
+	26,  // 89: xpf.v1.BpfrxService.ShowConfig:output_type -> xpf.v1.ShowConfigResponse
+	28,  // 90: xpf.v1.BpfrxService.ShowCompare:output_type -> xpf.v1.ShowCompareResponse
+	30,  // 91: xpf.v1.BpfrxService.ShowRollback:output_type -> xpf.v1.ShowRollbackResponse
+	32,  // 92: xpf.v1.BpfrxService.ListHistory:output_type -> xpf.v1.ListHistoryResponse
+	35,  // 93: xpf.v1.BpfrxService.GetStatus:output_type -> xpf.v1.GetStatusResponse
+	37,  // 94: xpf.v1.BpfrxService.GetGlobalStats:output_type -> xpf.v1.GetGlobalStatsResponse
+	39,  // 95: xpf.v1.BpfrxService.GetZones:output_type -> xpf.v1.GetZonesResponse
+	43,  // 96: xpf.v1.BpfrxService.GetPolicies:output_type -> xpf.v1.GetPoliciesResponse
+	47,  // 97: xpf.v1.BpfrxService.GetSessions:output_type -> xpf.v1.GetSessionsResponse
+	50,  // 98: xpf.v1.BpfrxService.GetSessionSummary:output_type -> xpf.v1.GetSessionSummaryResponse
+	52,  // 99: xpf.v1.BpfrxService.GetNATSource:output_type -> xpf.v1.GetNATSourceResponse
+	55,  // 100: xpf.v1.BpfrxService.GetNATDestination:output_type -> xpf.v1.GetNATDestinationResponse
+	58,  // 101: xpf.v1.BpfrxService.GetScreen:output_type -> xpf.v1.GetScreenResponse
+	61,  // 102: xpf.v1.BpfrxService.GetEvents:output_type -> xpf.v1.GetEventsResponse
+	64,  // 103: xpf.v1.BpfrxService.GetInterfaces:output_type -> xpf.v1.GetInterfacesResponse
+	67,  // 104: xpf.v1.BpfrxService.ShowInterfacesDetail:output_type -> xpf.v1.ShowInterfacesDetailResponse
+	69,  // 105: xpf.v1.BpfrxService.GetDHCPLeases:output_type -> xpf.v1.GetDHCPLeasesResponse
+	73,  // 106: xpf.v1.BpfrxService.GetDHCPClientIdentifiers:output_type -> xpf.v1.GetDHCPClientIdentifiersResponse
+	78,  // 107: xpf.v1.BpfrxService.GetRoutes:output_type -> xpf.v1.GetRoutesResponse
+	81,  // 108: xpf.v1.BpfrxService.GetOSPFStatus:output_type -> xpf.v1.GetOSPFStatusResponse
+	83,  // 109: xpf.v1.BpfrxService.GetBGPStatus:output_type -> xpf.v1.GetBGPStatusResponse
+	85,  // 110: xpf.v1.BpfrxService.GetRIPStatus:output_type -> xpf.v1.GetRIPStatusResponse
+	87,  // 111: xpf.v1.BpfrxService.GetISISStatus:output_type -> xpf.v1.GetISISStatusResponse
+	89,  // 112: xpf.v1.BpfrxService.GetIPsecSA:output_type -> xpf.v1.GetIPsecSAResponse
+	99,  // 113: xpf.v1.BpfrxService.GetNATPoolStats:output_type -> xpf.v1.GetNATPoolStatsResponse
+	108, // 114: xpf.v1.BpfrxService.GetNATRuleStats:output_type -> xpf.v1.GetNATRuleStatsResponse
+	103, // 115: xpf.v1.BpfrxService.GetVRRPStatus:output_type -> xpf.v1.GetVRRPStatusResponse
+	106, // 116: xpf.v1.BpfrxService.MatchPolicies:output_type -> xpf.v1.MatchPoliciesResponse
+	91,  // 117: xpf.v1.BpfrxService.Ping:output_type -> xpf.v1.PingResponse
+	93,  // 118: xpf.v1.BpfrxService.Traceroute:output_type -> xpf.v1.TracerouteResponse
+	119, // 119: xpf.v1.BpfrxService.MonitorPacketDrop:output_type -> xpf.v1.MonitorPacketDropResponse
+	121, // 120: xpf.v1.BpfrxService.MonitorInterface:output_type -> xpf.v1.MonitorInterfaceResponse
+	95,  // 121: xpf.v1.BpfrxService.ClearSessions:output_type -> xpf.v1.ClearSessionsResponse
+	97,  // 122: xpf.v1.BpfrxService.ClearCounters:output_type -> xpf.v1.ClearCountersResponse
+	76,  // 123: xpf.v1.BpfrxService.ClearDHCPClientIdentifier:output_type -> xpf.v1.ClearDHCPClientIdentifierResponse
+	113, // 124: xpf.v1.BpfrxService.ShowText:output_type -> xpf.v1.ShowTextResponse
+	115, // 125: xpf.v1.BpfrxService.GetSystemInfo:output_type -> xpf.v1.GetSystemInfoResponse
+	117, // 126: xpf.v1.BpfrxService.SystemAction:output_type -> xpf.v1.SystemActionResponse
+	111, // 127: xpf.v1.BpfrxService.Complete:output_type -> xpf.v1.CompleteResponse
+	78,  // [78:128] is the sub-list for method output_type
+	28,  // [28:78] is the sub-list for method input_type
+	28,  // [28:28] is the sub-list for extension type_name
+	28,  // [28:28] is the sub-list for extension extendee
+	0,   // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_xpf_proto_init() }
@@ -8065,14 +8202,14 @@ func file_xpf_proto_init() {
 	if File_xpf_proto != nil {
 		return
 	}
-	file_xpf_proto_msgTypes[101].OneofWrappers = []any{}
+	file_xpf_proto_msgTypes[102].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_xpf_proto_rawDesc), len(file_xpf_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   120,
+			NumMessages:   121,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -216,6 +216,9 @@ message ZoneInfo {
   uint32 id = 2;
   string screen_profile = 3;
   repeated string interfaces = 4;
+  // host_inbound_services is the LEGACY flattened admission set:
+  // system-services + protocols concatenated into one list. Kept as a
+  // back-compat alias; new consumers should read the split fields below.
   repeated string host_inbound_services = 5;
   uint64 ingress_packets = 6;
   uint64 ingress_bytes = 7;
@@ -223,6 +226,38 @@ message ZoneInfo {
   uint64 egress_bytes = 9;
   bool tcp_rst = 10;
   string description = 11;
+  // host_inbound_configured (#3328) records whether the zone is host-inbound
+  // ENFORCING: true when the zone declares a `host-inbound-traffic` stanza OR
+  // carries any per-interface override (#3362). This is the dataplane posture
+  // bit (ZoneSnapshot.HostInboundConfigured): false = no stanza = default
+  // admit-all for host-bound traffic; true with EMPTY lists = explicit
+  // deny-all. Without it an operator cannot distinguish "no stanza"
+  // (admit-all) from "empty stanza" (deny-all).
+  bool host_inbound_configured = 12;
+  // host_inbound_system_services / host_inbound_protocols (#3328) carry the
+  // ZONE-LEVEL admission set, kept distinct so automation can tell a
+  // system-service (ssh, ping, dhcp) apart from a routing protocol (ospf,
+  // bgp). Empty when the zone has no zone-level stanza (e.g. host-inbound is
+  // expressed only via per-interface overrides below).
+  repeated string host_inbound_system_services = 13;
+  repeated string host_inbound_protocols = 14;
+  // interface_host_inbound (#3328, #3362) carries per-interface host-inbound
+  // overrides. An entry exists only for an interface that declares its own
+  // `host-inbound-traffic` stanza; the effective admission set for that
+  // interface is the UNION of the zone-level set above and its override.
+  repeated InterfaceHostInbound interface_host_inbound = 15;
+}
+
+// InterfaceHostInbound (#3328, #3362) is a per-interface host-inbound-traffic
+// override: a zone may expose a service (e.g. ssh) on one interface while
+// denying it on the others. `configured` is always true for an emitted entry
+// (the stanza is present); empty service/protocol lists with configured=true
+// mean an explicit deny-all override on that interface.
+message InterfaceHostInbound {
+  string interface = 1;
+  bool configured = 2;
+  repeated string system_services = 3;
+  repeated string protocols = 4;
 }
 
 message GetPoliciesRequest {}


### PR DESCRIPTION
## Summary

The structured zone inventory in both REST (`GET /api/v1/security/zones`) and gRPC (`GetZones`) flattened the per-zone host-inbound admission set into a single `host_inbound_services` list and never exposed whether a host-inbound stanza was configured at all. Automation could not distinguish the three security postures the dataplane actually models (`ZoneSnapshot.HostInboundConfigured`, #3070/#3362):

1. **no host-inbound stanza** → default admit-all for host-bound traffic,
2. **explicit empty stanza** → deny-all,
3. **populated set**, split into system-services vs routing protocols.

That is a host-inbound / control-plane-protection posture ambiguity.

## Changes

- **proto** `ZoneInfo` gains additive fields 12-15 (`host_inbound_configured`, `host_inbound_system_services`, `host_inbound_protocols`, `interface_host_inbound`) plus a new `InterfaceHostInbound` message; `xpf.pb.go` regenerated via `make proto`.
- **REST** `ZoneInfo` mirror struct gains the same fields plus a `ZoneInterfaceHostInbound` type.
- Both handlers populate the split fields; the legacy flattened `host_inbound_services` stays as a back-compat alias.
- `ZoneConfig.SortedInterfaceHostInboundRefs` is the SSOT helper both surfaces iterate so the per-interface projection (#3362) stays in lockstep.
- READMEs (`pkg/api`, `pkg/grpcapi`) updated.

## Posture semantics

`host_inbound_configured` = true when the zone declares a zone-level stanza OR carries any per-interface override (mirrors the dataplane enforcing bit). `configured=false` → admit-all; `configured=true` with empty lists → deny-all. The two are now distinguishable.

## Validation

- New RED-on-revert parity tests in `pkg/api` and `pkg/grpcapi` assert all four postures (populated, explicit-empty deny-all, override-only-enforcing, no-stanza admit-all) plus the per-interface override are surfaced distinctly. Reverting the handler population makes both go red (verified).
- `go test ./pkg/api/ ./pkg/grpcapi/ ./pkg/config/` green; `go vet` clean; `gofmt` clean; `go build ./...` green.

Closes #3328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi