### PR TITLE
Surface dropped RT_FLOW forensic fields on event APIs (#3337)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23896,3 +23896,20 @@ top.
   pkg/config/types_security.go, pkg/api/security_zone_hostinbound_3328_test.go (new),
   pkg/grpcapi/server_show_zones_hostinbound_3328_test.go (new),
   pkg/api/README.md, pkg/grpcapi/README.md, _Log.md
+
+- **Timestamp**: 2026-06-29
+- **Action**: #3337 — surface dropped RT_FLOW forensic fields on the
+  security-event APIs. REST/SSE EventEntry expanded to mirror the gRPC entry
+  (zone names, policy name, app name, ingress iface, close reason, reverse
+  counters) AND the new forensic block; gRPC proto EventEntry gained additive
+  fields 21-31 (nat_src_addr, nat_dst_addr, session_id, elapsed_time, created,
+  created_nanos, egress_ifindex, ingress_ifindex, tos, tcp_control_bits,
+  reason). All machine APIs now format RFC3339Nano (sub-second); CLI keeps
+  whole-second. REST+SSE share one mapper (eventEntryFromRecord) so they can't
+  drift. RED-on-revert tests added on both surfaces (verified failing when the
+  mappings are reverted).
+- **File(s)**: proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go (regen),
+  pkg/grpcapi/server_show_events.go, pkg/api/types.go, pkg/api/security.go,
+  pkg/api/sse.go, pkg/api/rest_events_forensic_3337_test.go (new),
+  pkg/grpcapi/server_show_events_forensic_3337_test.go (new),
+  pkg/api/README.md, pkg/grpcapi/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -110,6 +110,21 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
   forwards) is classified `notice`, not `error`, mirroring the canonical
   `logging.eventSeverity`; an unknown event type fails closed under a
   narrow category mask.
+- `GET /api/v1/security/events` (and the SSE event stream) return the full
+  RT_FLOW forensic `EventEntry` (#3337). Both surfaces share one mapper,
+  `eventEntryFromRecord`, so they never drift: beyond the 5-tuple they carry
+  the resolved ingress/egress zone names, policy name, application name,
+  ingress interface, close reason / policy reason, the reverse
+  (server→client) packet/byte counters, the post-NAT source/destination
+  tuples, session ID, elapsed/created time (with `created_nanos` sub-second
+  remainder), ingress/egress SNMP ifIndex, IP TOS, and the OR of the TCP
+  control bits. These mirror the gRPC `EventEntry`
+  (`pkg/grpcapi` `GetEvents`) and the CLI RT_FLOW line. All forensic fields
+  are `omitempty`, so a non-close event (or an unNAT'd / screen-drop record)
+  omits the ones it does not carry. The machine APIs format timestamps with
+  `RFC3339Nano` (sub-second), so high-rate events keep ordering/burst
+  fidelity for cross-system correlation; the CLI keeps human-friendly
+  whole-second output.
 
 ## Callers
 

--- a/pkg/api/rest_events_forensic_3337_test.go
+++ b/pkg/api/rest_events_forensic_3337_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// forensicCloseRecord is a SESSION_CLOSE event carrying every RT_FLOW forensic
+// field the buffer can hold, with a sub-second timestamp.
+func forensicCloseRecord() logging.EventRecord {
+	return logging.EventRecord{
+		Time:            time.Date(2026, 6, 29, 12, 0, 0, 123456789, time.UTC),
+		Type:            "SESSION_CLOSE",
+		SrcAddr:         "10.0.1.5:51000",
+		DstAddr:         "10.0.2.9:443",
+		Protocol:        "TCP",
+		Action:          "permit",
+		PolicyID:        7,
+		InZone:          3,
+		OutZone:         4,
+		InZoneName:      "trust",
+		OutZoneName:     "untrust",
+		ScreenCheck:     "",
+		SessionPkts:     12,
+		SessionBytes:    3400,
+		RevSessionPkts:  10,
+		RevSessionBytes: 9000,
+		PolicyName:      "allow-web",
+		AppName:         "junos-https",
+		IngressIface:    "ge-0-0-0.0",
+		CloseReason:     "TCP FIN",
+		Reason:          "policy",
+		NATSrcAddr:      "172.16.1.1:12345",
+		NATDstAddr:      "10.0.2.9:443",
+		SessionID:       0xDEADBEEF,
+		ElapsedTime:     42,
+		Created:         1750000000,
+		CreatedNanos:    500000000,
+		EgressIfindex:   17,
+		IngressIfindex:  9,
+		TOS:             0xB8,
+		TCPControlBits:  0x1B,
+	}
+}
+
+// TestRESTEventForensicFieldsSurfaced pins #3337 on the REST surface: the GET
+// /security/events response must carry every RT_FLOW forensic field the
+// EventRecord holds, and the timestamp must keep sub-second (RFC3339Nano)
+// resolution.
+//
+// FAIL-ON-REVERT: reverting EventEntry / eventEntryFromRecord to the reduced
+// type/src/dst/proto/action/policy_id/zones/screen_check/session_pkts/bytes
+// view drops PolicyName, AppName, CloseReason, the reverse counters, NAT
+// tuples, session ID, elapsed/created, ifindexes, TOS, and TCP flags — every
+// assertion below for those fields fails. Reverting RFC3339Nano -> RFC3339
+// truncates the timestamp and fails the nanosecond-fraction assertion.
+func TestRESTEventForensicFieldsSurfaced(t *testing.T) {
+	eb := logging.NewEventBuffer(16)
+	eb.Add(forensicCloseRecord())
+	s := &Server{eventBuf: eb}
+
+	rr := httptest.NewRecorder()
+	s.eventsHandler(rr, httptest.NewRequest("GET", "/api/v1/security/events", nil))
+	if rr.Code != 200 {
+		t.Fatalf("events status = %d; want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	evs := decodeEvents(t, rr.Body.Bytes())
+	if len(evs) != 1 {
+		t.Fatalf("got %d events; want 1", len(evs))
+	}
+	got := evs[0]
+
+	// Sub-second timestamp must survive (RFC3339Nano, not RFC3339).
+	if !strings.Contains(got.Time, ".123456789") {
+		t.Errorf("Time = %q; want RFC3339Nano with sub-second fraction .123456789", got.Time)
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"InZoneName", got.InZoneName, "trust"},
+		{"OutZoneName", got.OutZoneName, "untrust"},
+		{"PolicyName", got.PolicyName, "allow-web"},
+		{"AppName", got.AppName, "junos-https"},
+		{"IngressIface", got.IngressIface, "ge-0-0-0.0"},
+		{"CloseReason", got.CloseReason, "TCP FIN"},
+		{"Reason", got.Reason, "policy"},
+		{"RevSessionPkts", got.RevSessionPkts, uint64(10)},
+		{"RevSessionBytes", got.RevSessionBytes, uint64(9000)},
+		{"NATSrcAddr", got.NATSrcAddr, "172.16.1.1:12345"},
+		{"NATDstAddr", got.NATDstAddr, "10.0.2.9:443"},
+		{"SessionID", got.SessionID, uint64(0xDEADBEEF)},
+		{"ElapsedTime", got.ElapsedTime, uint32(42)},
+		{"Created", got.Created, uint32(1750000000)},
+		{"CreatedNanos", got.CreatedNanos, uint32(500000000)},
+		{"EgressIfindex", got.EgressIfindex, uint32(17)},
+		{"IngressIfindex", got.IngressIfindex, uint32(9)},
+		{"TOS", got.TOS, uint8(0xB8)},
+		{"TCPControlBits", got.TCPControlBits, uint8(0x1B)},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("EventEntry.%s = %v; want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// TestSSEEventForensicFieldsSurfaced pins the SSE surface to the same SSOT
+// mapper: eventEntryFromRecord must carry the forensic fields and RFC3339Nano
+// timestamp, so the live event stream matches the GET response.
+func TestSSEEventForensicFieldsSurfaced(t *testing.T) {
+	got := eventEntryFromRecord(forensicCloseRecord())
+	if !strings.Contains(got.Time, ".123456789") {
+		t.Errorf("Time = %q; want RFC3339Nano with sub-second fraction", got.Time)
+	}
+	if got.PolicyName != "allow-web" || got.AppName != "junos-https" ||
+		got.CloseReason != "TCP FIN" || got.NATSrcAddr != "172.16.1.1:12345" ||
+		got.SessionID != 0xDEADBEEF || got.RevSessionBytes != 9000 ||
+		got.TOS != 0xB8 || got.TCPControlBits != 0x1B || got.IngressIface != "ge-0-0-0.0" {
+		t.Errorf("eventEntryFromRecord dropped a forensic field: %+v", got)
+	}
+}

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -373,20 +372,7 @@ func (s *Server) eventsHandler(w http.ResponseWriter, r *http.Request) {
 
 	result := make([]EventEntry, len(events))
 	for i, ev := range events {
-		result[i] = EventEntry{
-			Time:         ev.Time.Format(time.RFC3339),
-			Type:         ev.Type,
-			SrcAddr:      ev.SrcAddr,
-			DstAddr:      ev.DstAddr,
-			Protocol:     ev.Protocol,
-			Action:       ev.Action,
-			PolicyID:     ev.PolicyID,
-			InZone:       ev.InZone,
-			OutZone:      ev.OutZone,
-			ScreenCheck:  ev.ScreenCheck,
-			SessionPkts:  ev.SessionPkts,
-			SessionBytes: ev.SessionBytes,
-		}
+		result[i] = eventEntryFromRecord(ev)
 	}
 	writeOK(w, result)
 }

--- a/pkg/api/sse.go
+++ b/pkg/api/sse.go
@@ -133,20 +133,44 @@ type LogStreamEntry struct {
 	Message  string `json:"message"`
 }
 
+// eventEntryFromRecord maps a logging.EventRecord to the REST/SSE EventEntry.
+// It is the single SSOT for both the GET /security/events response and the SSE
+// event stream, so the two surfaces never drift (#3337). The timestamp uses
+// RFC3339Nano so high-rate RT_FLOW events keep sub-second ordering for
+// cross-system correlation (the CLI keeps human-friendly seconds).
 func eventEntryFromRecord(rec logging.EventRecord) EventEntry {
 	return EventEntry{
-		Time:         rec.Time.Format(time.RFC3339),
-		Type:         rec.Type,
-		SrcAddr:      rec.SrcAddr,
-		DstAddr:      rec.DstAddr,
-		Protocol:     rec.Protocol,
-		Action:       rec.Action,
-		PolicyID:     rec.PolicyID,
-		InZone:       rec.InZone,
-		OutZone:      rec.OutZone,
-		ScreenCheck:  rec.ScreenCheck,
-		SessionPkts:  rec.SessionPkts,
-		SessionBytes: rec.SessionBytes,
+		Time:            rec.Time.Format(time.RFC3339Nano),
+		Type:            rec.Type,
+		SrcAddr:         rec.SrcAddr,
+		DstAddr:         rec.DstAddr,
+		Protocol:        rec.Protocol,
+		Action:          rec.Action,
+		PolicyID:        rec.PolicyID,
+		InZone:          rec.InZone,
+		OutZone:         rec.OutZone,
+		InZoneName:      rec.InZoneName,
+		OutZoneName:     rec.OutZoneName,
+		ScreenCheck:     rec.ScreenCheck,
+		SessionPkts:     rec.SessionPkts,
+		SessionBytes:    rec.SessionBytes,
+		RevSessionPkts:  rec.RevSessionPkts,
+		RevSessionBytes: rec.RevSessionBytes,
+		PolicyName:      rec.PolicyName,
+		AppName:         rec.AppName,
+		IngressIface:    rec.IngressIface,
+		CloseReason:     rec.CloseReason,
+		Reason:          rec.Reason,
+		NATSrcAddr:      rec.NATSrcAddr,
+		NATDstAddr:      rec.NATDstAddr,
+		SessionID:       rec.SessionID,
+		ElapsedTime:     rec.ElapsedTime,
+		Created:         rec.Created,
+		CreatedNanos:    rec.CreatedNanos,
+		EgressIfindex:   rec.EgressIfindex,
+		IngressIfindex:  rec.IngressIfindex,
+		TOS:             rec.TOS,
+		TCPControlBits:  rec.TCPControlBits,
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -259,20 +259,43 @@ type SessionSummary struct {
 	DNATSessions int `json:"dnat_sessions"`
 }
 
-// EventEntry holds a single event record.
+// EventEntry holds a single event record. The forensic fields below the
+// core 5-tuple mirror the gRPC EventEntry (proto/xpf/v1/xpf.proto) and the
+// RT_FLOW record the CLI prints (#3337), so REST/SSE consumers can reproduce
+// the full close record. They are omitempty: an event that does not carry a
+// field (a non-close event, an unNAT'd flow, a screen drop) omits it.
 type EventEntry struct {
-	Time         string `json:"time"`
-	Type         string `json:"type"`
-	SrcAddr      string `json:"src_addr"`
-	DstAddr      string `json:"dst_addr"`
-	Protocol     string `json:"protocol"`
-	Action       string `json:"action"`
-	PolicyID     uint32 `json:"policy_id"`
-	InZone       uint16 `json:"ingress_zone"`
-	OutZone      uint16 `json:"egress_zone"`
-	ScreenCheck  string `json:"screen_check,omitempty"`
-	SessionPkts  uint64 `json:"session_packets,omitempty"`
-	SessionBytes uint64 `json:"session_bytes,omitempty"`
+	Time            string `json:"time"`
+	Type            string `json:"type"`
+	SrcAddr         string `json:"src_addr"`
+	DstAddr         string `json:"dst_addr"`
+	Protocol        string `json:"protocol"`
+	Action          string `json:"action"`
+	PolicyID        uint32 `json:"policy_id"`
+	InZone          uint16 `json:"ingress_zone"`
+	OutZone         uint16 `json:"egress_zone"`
+	InZoneName      string `json:"ingress_zone_name,omitempty"`
+	OutZoneName     string `json:"egress_zone_name,omitempty"`
+	ScreenCheck     string `json:"screen_check,omitempty"`
+	SessionPkts     uint64 `json:"session_packets,omitempty"`
+	SessionBytes    uint64 `json:"session_bytes,omitempty"`
+	RevSessionPkts  uint64 `json:"rev_session_pkts,omitempty"`
+	RevSessionBytes uint64 `json:"rev_session_bytes,omitempty"`
+	PolicyName      string `json:"policy_name,omitempty"`
+	AppName         string `json:"app_name,omitempty"`
+	IngressIface    string `json:"ingress_iface,omitempty"`
+	CloseReason     string `json:"close_reason,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	NATSrcAddr      string `json:"nat_src_addr,omitempty"`
+	NATDstAddr      string `json:"nat_dst_addr,omitempty"`
+	SessionID       uint64 `json:"session_id,omitempty"`
+	ElapsedTime     uint32 `json:"elapsed_time,omitempty"`
+	Created         uint32 `json:"created,omitempty"`
+	CreatedNanos    uint32 `json:"created_nanos,omitempty"`
+	EgressIfindex   uint32 `json:"egress_ifindex,omitempty"`
+	IngressIfindex  uint32 `json:"ingress_ifindex,omitempty"`
+	TOS             uint8  `json:"tos,omitempty"`
+	TCPControlBits  uint8  `json:"tcp_control_bits,omitempty"`
 }
 
 // NATSourceInfo holds source NAT configuration.

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -186,6 +186,23 @@ contract.
   and exposed no thresholds — under-reporting active enforcement to a
   structured-state consumer. The `checks` set is kept a superset of the
   dataplane-enforced set; the duplicated-helper drift mechanism is gone.
+- `GetEvents` returns recent security events (`EventEntry`) from the
+  `pkg/logging` ring buffer. As of #3337 the entry carries the full RT_FLOW
+  forensic record so a SIEM can reproduce the CLI close line: beyond the
+  5-tuple / zones / policy ID it maps the resolved zone names, policy name,
+  application name, ingress interface, close reason, the reverse counters,
+  and the additive forensic block — `nat_src_addr`, `nat_dst_addr`,
+  `session_id`, `elapsed_time`, `created` (+`created_nanos`),
+  `egress_ifindex`, `ingress_ifindex`, `tos`, `tcp_control_bits`, and
+  `reason` (proto field numbers 21-31, additive — no renumber). Before
+  #3337 the proto stopped at `close_reason` (field 20) and dropped the NAT
+  tuples, session ID, timing, ifIndexes, and CoS bits the `EventRecord`
+  already held, and REST/SSE dropped even the policy/app/zone-name/reverse
+  fields gRPC exposed. The `time` field now formats `RFC3339Nano`
+  (sub-second) so high-rate events keep ordering; the REST/SSE surfaces
+  mirror the same fields via the shared `eventEntryFromRecord` mapper. The
+  zone filter (`zone` + `has_zone`) and out-of-range rejection are unchanged
+  (#3334/#3338).
 - Request-supplied numeric fields are signed on the wire and must be
   range-checked before they index/slice/size anything (#2282). `Complete`
   rejects a negative `pos` with `InvalidArgument` before slicing

--- a/pkg/grpcapi/server_show_events.go
+++ b/pkg/grpcapi/server_show_events.go
@@ -81,7 +81,7 @@ func (s *Server) GetEvents(_ context.Context, req *pb.GetEventsRequest) (*pb.Get
 	resp := &pb.GetEventsResponse{}
 	for _, ev := range events {
 		resp.Events = append(resp.Events, &pb.EventEntry{
-			Time:            ev.Time.Format(time.RFC3339),
+			Time:            ev.Time.Format(time.RFC3339Nano),
 			Type:            ev.Type,
 			SrcAddr:         ev.SrcAddr,
 			DstAddr:         ev.DstAddr,
@@ -101,6 +101,17 @@ func (s *Server) GetEvents(_ context.Context, req *pb.GetEventsRequest) (*pb.Get
 			AppName:         ev.AppName,
 			IngressIface:    ev.IngressIface,
 			CloseReason:     ev.CloseReason,
+			NatSrcAddr:      ev.NATSrcAddr,
+			NatDstAddr:      ev.NATDstAddr,
+			SessionId:       ev.SessionID,
+			ElapsedTime:     ev.ElapsedTime,
+			Created:         ev.Created,
+			CreatedNanos:    ev.CreatedNanos,
+			EgressIfindex:   ev.EgressIfindex,
+			IngressIfindex:  ev.IngressIfindex,
+			Tos:             uint32(ev.TOS),
+			TcpControlBits:  uint32(ev.TCPControlBits),
+			Reason:          ev.Reason,
 		})
 	}
 	return resp, nil

--- a/pkg/grpcapi/server_show_events_forensic_3337_test.go
+++ b/pkg/grpcapi/server_show_events_forensic_3337_test.go
@@ -1,0 +1,93 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// TestGetEventsForensicFieldsSurfaced pins #3337 on the gRPC surface: GetEvents
+// must map the remaining RT_FLOW forensic fields (NAT tuples, session ID,
+// elapsed/created, ingress/egress ifindex, TOS, TCP control bits, reason) from
+// the EventRecord into the proto EventEntry, and the timestamp must keep
+// sub-second (RFC3339Nano) resolution.
+//
+// FAIL-ON-REVERT: removing the new field assignments in GetEvents (or removing
+// the proto fields) zeroes NatSrcAddr/NatDstAddr/SessionId/ElapsedTime/Created/
+// CreatedNanos/EgressIfindex/IngressIfindex/Tos/TcpControlBits/Reason, failing
+// the per-field assertions. Reverting RFC3339Nano -> RFC3339 truncates the
+// timestamp and fails the nanosecond-fraction assertion.
+func TestGetEventsForensicFieldsSurfaced(t *testing.T) {
+	eb := logging.NewEventBuffer(16)
+	eb.Add(logging.EventRecord{
+		Time:           time.Date(2026, 6, 29, 12, 0, 0, 123456789, time.UTC),
+		Type:           "SESSION_CLOSE",
+		SrcAddr:        "10.0.1.5:51000",
+		DstAddr:        "10.0.2.9:443",
+		Protocol:       "TCP",
+		Action:         "permit",
+		PolicyID:       7,
+		NATSrcAddr:     "172.16.1.1:12345",
+		NATDstAddr:     "10.0.2.9:443",
+		SessionID:      0xDEADBEEF,
+		ElapsedTime:    42,
+		Created:        1750000000,
+		CreatedNanos:   500000000,
+		EgressIfindex:  17,
+		IngressIfindex: 9,
+		TOS:            0xB8,
+		TCPControlBits: 0x1B,
+		Reason:         "policy",
+	})
+	s := &Server{eventBuf: eb}
+
+	resp, err := s.GetEvents(context.Background(), &pb.GetEventsRequest{})
+	if err != nil {
+		t.Fatalf("GetEvents = %v; want success", err)
+	}
+	if len(resp.Events) != 1 {
+		t.Fatalf("got %d events; want 1", len(resp.Events))
+	}
+	e := resp.Events[0]
+
+	if !strings.Contains(e.Time, ".123456789") {
+		t.Errorf("Time = %q; want RFC3339Nano with sub-second fraction", e.Time)
+	}
+	if e.NatSrcAddr != "172.16.1.1:12345" {
+		t.Errorf("NatSrcAddr = %q; want 172.16.1.1:12345", e.NatSrcAddr)
+	}
+	if e.NatDstAddr != "10.0.2.9:443" {
+		t.Errorf("NatDstAddr = %q; want 10.0.2.9:443", e.NatDstAddr)
+	}
+	if e.SessionId != 0xDEADBEEF {
+		t.Errorf("SessionId = %d; want %d", e.SessionId, 0xDEADBEEF)
+	}
+	if e.ElapsedTime != 42 {
+		t.Errorf("ElapsedTime = %d; want 42", e.ElapsedTime)
+	}
+	if e.Created != 1750000000 {
+		t.Errorf("Created = %d; want 1750000000", e.Created)
+	}
+	if e.CreatedNanos != 500000000 {
+		t.Errorf("CreatedNanos = %d; want 500000000", e.CreatedNanos)
+	}
+	if e.EgressIfindex != 17 {
+		t.Errorf("EgressIfindex = %d; want 17", e.EgressIfindex)
+	}
+	if e.IngressIfindex != 9 {
+		t.Errorf("IngressIfindex = %d; want 9", e.IngressIfindex)
+	}
+	if e.Tos != 0xB8 {
+		t.Errorf("Tos = %d; want %d", e.Tos, 0xB8)
+	}
+	if e.TcpControlBits != 0x1B {
+		t.Errorf("TcpControlBits = %d; want %d", e.TcpControlBits, 0x1B)
+	}
+	if e.Reason != "policy" {
+		t.Errorf("Reason = %q; want policy", e.Reason)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -3774,8 +3774,24 @@ type EventEntry struct {
 	AppName         string                 `protobuf:"bytes,18,opt,name=app_name,json=appName,proto3" json:"app_name,omitempty"`
 	IngressIface    string                 `protobuf:"bytes,19,opt,name=ingress_iface,json=ingressIface,proto3" json:"ingress_iface,omitempty"`
 	CloseReason     string                 `protobuf:"bytes,20,opt,name=close_reason,json=closeReason,proto3" json:"close_reason,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// #3337 additive forensic fields. These carry the remaining RT_FLOW
+	// record values the CLI prints (cli_show_security_log.go) so a SIEM
+	// consuming GetEvents can reproduce the full close record. All are
+	// additive (new field numbers, no renumber). 0 / "" means the event
+	// did not carry the field (e.g. a non-close event, or no NAT applied).
+	NatSrcAddr     string `protobuf:"bytes,21,opt,name=nat_src_addr,json=natSrcAddr,proto3" json:"nat_src_addr,omitempty"`              // post-NAT source "ip:port" ("" = no NAT)
+	NatDstAddr     string `protobuf:"bytes,22,opt,name=nat_dst_addr,json=natDstAddr,proto3" json:"nat_dst_addr,omitempty"`              // post-NAT destination "ip:port"
+	SessionId      uint64 `protobuf:"varint,23,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`                  // unique session identifier
+	ElapsedTime    uint32 `protobuf:"varint,24,opt,name=elapsed_time,json=elapsedTime,proto3" json:"elapsed_time,omitempty"`            // seconds since session creation (CLOSE)
+	Created        uint32 `protobuf:"varint,25,opt,name=created,proto3" json:"created,omitempty"`                                       // absolute session-creation Unix seconds (CLOSE)
+	CreatedNanos   uint32 `protobuf:"varint,26,opt,name=created_nanos,json=createdNanos,proto3" json:"created_nanos,omitempty"`         // sub-second nanosecond remainder of created
+	EgressIfindex  uint32 `protobuf:"varint,27,opt,name=egress_ifindex,json=egressIfindex,proto3" json:"egress_ifindex,omitempty"`      // SNMP ifIndex of the resolved output interface
+	IngressIfindex uint32 `protobuf:"varint,28,opt,name=ingress_ifindex,json=ingressIfindex,proto3" json:"ingress_ifindex,omitempty"`   // SNMP ifIndex of the ingress interface
+	Tos            uint32 `protobuf:"varint,29,opt,name=tos,proto3" json:"tos,omitempty"`                                               // IP ToS byte observed on the forward direction
+	TcpControlBits uint32 `protobuf:"varint,30,opt,name=tcp_control_bits,json=tcpControlBits,proto3" json:"tcp_control_bits,omitempty"` // OR of every TCP flag byte seen over the flow
+	Reason         string `protobuf:"bytes,31,opt,name=reason,proto3" json:"reason,omitempty"`                                          // policy/screen reason (deny/drop events)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *EventEntry) Reset() {
@@ -3944,6 +3960,83 @@ func (x *EventEntry) GetIngressIface() string {
 func (x *EventEntry) GetCloseReason() string {
 	if x != nil {
 		return x.CloseReason
+	}
+	return ""
+}
+
+func (x *EventEntry) GetNatSrcAddr() string {
+	if x != nil {
+		return x.NatSrcAddr
+	}
+	return ""
+}
+
+func (x *EventEntry) GetNatDstAddr() string {
+	if x != nil {
+		return x.NatDstAddr
+	}
+	return ""
+}
+
+func (x *EventEntry) GetSessionId() uint64 {
+	if x != nil {
+		return x.SessionId
+	}
+	return 0
+}
+
+func (x *EventEntry) GetElapsedTime() uint32 {
+	if x != nil {
+		return x.ElapsedTime
+	}
+	return 0
+}
+
+func (x *EventEntry) GetCreated() uint32 {
+	if x != nil {
+		return x.Created
+	}
+	return 0
+}
+
+func (x *EventEntry) GetCreatedNanos() uint32 {
+	if x != nil {
+		return x.CreatedNanos
+	}
+	return 0
+}
+
+func (x *EventEntry) GetEgressIfindex() uint32 {
+	if x != nil {
+		return x.EgressIfindex
+	}
+	return 0
+}
+
+func (x *EventEntry) GetIngressIfindex() uint32 {
+	if x != nil {
+		return x.IngressIfindex
+	}
+	return 0
+}
+
+func (x *EventEntry) GetTos() uint32 {
+	if x != nil {
+		return x.Tos
+	}
+	return 0
+}
+
+func (x *EventEntry) GetTcpControlBits() uint32 {
+	if x != nil {
+		return x.TcpControlBits
+	}
+	return 0
+}
+
+func (x *EventEntry) GetReason() string {
+	if x != nil {
+		return x.Reason
 	}
 	return ""
 }
@@ -7592,7 +7685,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\bprotocol\x18\x04 \x01(\tR\bprotocol\x12\x19\n" +
 	"\bhas_zone\x18\x05 \x01(\bR\ahasZone\"?\n" +
 	"\x11GetEventsResponse\x12*\n" +
-	"\x06events\x18\x01 \x03(\v2\x12.xpf.v1.EventEntryR\x06events\"\xa0\x05\n" +
+	"\x06events\x18\x01 \x03(\v2\x12.xpf.v1.EventEntryR\x06events\"\x89\b\n" +
 	"\n" +
 	"EventEntry\x12\x12\n" +
 	"\x04time\x18\x01 \x01(\tR\x04time\x12\x12\n" +
@@ -7617,7 +7710,21 @@ const file_xpf_proto_rawDesc = "" +
 	"\x11rev_session_bytes\x18\x11 \x01(\x04R\x0frevSessionBytes\x12\x19\n" +
 	"\bapp_name\x18\x12 \x01(\tR\aappName\x12#\n" +
 	"\ringress_iface\x18\x13 \x01(\tR\fingressIface\x12!\n" +
-	"\fclose_reason\x18\x14 \x01(\tR\vcloseReason\"\x16\n" +
+	"\fclose_reason\x18\x14 \x01(\tR\vcloseReason\x12 \n" +
+	"\fnat_src_addr\x18\x15 \x01(\tR\n" +
+	"natSrcAddr\x12 \n" +
+	"\fnat_dst_addr\x18\x16 \x01(\tR\n" +
+	"natDstAddr\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x17 \x01(\x04R\tsessionId\x12!\n" +
+	"\felapsed_time\x18\x18 \x01(\rR\velapsedTime\x12\x18\n" +
+	"\acreated\x18\x19 \x01(\rR\acreated\x12#\n" +
+	"\rcreated_nanos\x18\x1a \x01(\rR\fcreatedNanos\x12%\n" +
+	"\x0eegress_ifindex\x18\x1b \x01(\rR\regressIfindex\x12'\n" +
+	"\x0fingress_ifindex\x18\x1c \x01(\rR\x0eingressIfindex\x12\x10\n" +
+	"\x03tos\x18\x1d \x01(\rR\x03tos\x12(\n" +
+	"\x10tcp_control_bits\x18\x1e \x01(\rR\x0etcpControlBits\x12\x16\n" +
+	"\x06reason\x18\x1f \x01(\tR\x06reason\"\x16\n" +
 	"\x14GetInterfacesRequest\"N\n" +
 	"\x15GetInterfacesResponse\x125\n" +
 	"\n" +

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -464,6 +464,22 @@ message EventEntry {
   string app_name = 18;
   string ingress_iface = 19;
   string close_reason = 20;
+  // #3337 additive forensic fields. These carry the remaining RT_FLOW
+  // record values the CLI prints (cli_show_security_log.go) so a SIEM
+  // consuming GetEvents can reproduce the full close record. All are
+  // additive (new field numbers, no renumber). 0 / "" means the event
+  // did not carry the field (e.g. a non-close event, or no NAT applied).
+  string nat_src_addr = 21;     // post-NAT source "ip:port" ("" = no NAT)
+  string nat_dst_addr = 22;     // post-NAT destination "ip:port"
+  uint64 session_id = 23;       // unique session identifier
+  uint32 elapsed_time = 24;     // seconds since session creation (CLOSE)
+  uint32 created = 25;          // absolute session-creation Unix seconds (CLOSE)
+  uint32 created_nanos = 26;    // sub-second nanosecond remainder of created
+  uint32 egress_ifindex = 27;   // SNMP ifIndex of the resolved output interface
+  uint32 ingress_ifindex = 28;  // SNMP ifIndex of the ingress interface
+  uint32 tos = 29;              // IP ToS byte observed on the forward direction
+  uint32 tcp_control_bits = 30; // OR of every TCP flag byte seen over the flow
+  string reason = 31;           // policy/screen reason (deny/drop events)
 }
 
 message GetInterfacesRequest {}


### PR DESCRIPTION
Closes #3337

## Problem
The machine-readable security-event APIs (REST `GET /api/v1/security/events`,
SSE event stream, gRPC `GetEvents`) dropped RT_FLOW forensic fields the
`logging.EventRecord` already carries, and the surfaces diverged:

- **REST/SSE** stopped at type/src/dst/proto/action/policy_id/zones/screen_check/session_pkts/bytes — silently dropping policy name, app name, close reason, the reverse counters, ingress iface, and the resolved zone names that gRPC already exposed.
- **gRPC** stopped at `close_reason` and omitted the NAT source/destination tuples, session ID, elapsed/created time, ingress/egress ifIndex, TOS, and TCP control bits the CLI RT_FLOW line prints.
- **All three** formatted timestamps with `RFC3339` (whole-second), losing sub-second ordering for high-rate events.

## Change (additive, 2-sided)
- REST/SSE `EventEntry` expanded to mirror the gRPC entry + the forensic block; REST and SSE now share one mapper (`eventEntryFromRecord`) so they can't drift. All forensic fields `omitempty`.
- gRPC proto `EventEntry` gains additive fields **21-31** (`nat_src_addr`, `nat_dst_addr`, `session_id`, `elapsed_time`, `created`, `created_nanos`, `egress_ifindex`, `ingress_ifindex`, `tos`, `tcp_control_bits`, `reason`) — new field numbers, no renumber. Regenerated `xpf.pb.go` via `make proto`.
- All machine APIs format `RFC3339Nano`; CLI keeps human-friendly whole-second.
- Updated `pkg/api/README.md` + `pkg/grpcapi/README.md`.

## Tests (RED-on-revert)
`pkg/api/rest_events_forensic_3337_test.go` and `pkg/grpcapi/server_show_events_forensic_3337_test.go` assert each previously-omitted field is surfaced and the timestamp keeps its nanosecond fraction. Verified failing when the mappings / RFC3339Nano change are reverted (gRPC: all 11 forensic field assertions + the nanosecond assertion fail; REST: FAIL).

`go test ./pkg/logging/ ./pkg/api/ ./pkg/grpcapi/` green; gofmt clean; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi