### PR TITLE
config/nat: reject defined-but-unresolvable match address-name at strict commit (#3425)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23896,3 +23896,14 @@ top.
   pkg/config/types_security.go, pkg/api/security_zone_hostinbound_3328_test.go (new),
   pkg/grpcapi/server_show_zones_hostinbound_3328_test.go (new),
   pkg/api/README.md, pkg/grpcapi/README.md, _Log.md
+
+- **Timestamp**: 2026-06-29
+  **Action**: #3425 — NAT match {source,destination}-address-name strict gate now
+  rejects defined-but-unresolvable references (empty/dangling address-set,
+  prefix-less address) at commit; lenient-warn on tolerant load/peer-sync; direct
+  dynamic-address feed bindings carved out (accepted). Dataplane already fails
+  closed (raw unmatchable token / zero DNAT entries) — added regression tests.
+  **File(s)**: pkg/config/compiler_validate_strict.go,
+  pkg/config/compiler_nat_address_name_resolvable_3425_test.go (new),
+  pkg/dataplane/userspace/nat_address_name_failclosed_3425_test.go (new),
+  docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -897,6 +897,28 @@ reserved for whole-dataplane selection where a rewrite shim
     source and destination name leaves) and fails closed on the lenient
     load / peer-sync path (the unresolved raw token cannot parse as an IP,
     so the rule matches NOTHING rather than broadening to match-any).
+    **#3425 — defined-but-unresolvable references**: the same gate now also
+    rejects a name that IS defined under `security address-book` but
+    resolves to NO concrete address — a defined-but-empty `address-set`, a
+    set whose members dangle, or an `address` with no prefix
+    (`Value == ""`). Existence alone is not enough: the snapshot builder
+    resolves the name through `resolveUserspaceAddressBookEntry` (which
+    returns `ok=false` for these cases) and appends the raw unparseable
+    token, so the SNAT source list stays non-empty-but-unmatchable and the
+    DNAT rule emits zero `DnatTable` entries — the rule translates no
+    traffic. Strict commit now surfaces this as an operator-visible error
+    (resolution mirrors the runtime via the shared
+    `policyMatchAddressBookResolves` helper, so commit and apply cannot
+    diverge — the NAT analog of the #3149 policy-address representability
+    gate and the #3434 NAT match-application gate). A DIRECT
+    `security dynamic-address address-name <name>` feed binding is ACCEPTED
+    (its static expansion is empty but the live feed overlay supplies the
+    prefixes at runtime, #3303) — mirroring the
+    `validatePolicyMatchAddressesStrict` feed carve-out (#3294); a feed
+    member NESTED in an address-set stays poisoned by the static resolver
+    (the anti-Option-C guardrail). Lenient load / peer-sync downgrades to a
+    warning so an already-persisted or peer-synced config still boots
+    (#1960); the dataplane fails closed independently.
   - `protocols router-advertisement interface` — typed the
     second-denominated leaves (`max/min-advertisement-interval`,
     `default-lifetime`, `link-mtu`; the latter was tightened from

--- a/pkg/config/compiler_nat_address_name_resolvable_3425_test.go
+++ b/pkg/config/compiler_nat_address_name_resolvable_3425_test.go
@@ -1,0 +1,174 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3425: NAT `match {source,destination}-address-name <name>` strict validation
+// previously checked only that the name was DEFINED in the address book, not
+// whether it RESOLVES to any concrete address. A defined-but-empty address-set
+// (or a prefix-less address) passed commit, but the snapshot builder
+// (resolveUserspaceAddressBookEntry → empty) then appends the raw unparseable
+// token to keep the constraint non-empty, so the rule translates NO traffic.
+// This is the NAT analog of the #3149 policy-address representability gate and
+// the #3434 NAT match-application gate.
+//
+// validateNATSourceAddressNameReferencesStrict now rejects a defined-but-
+// unresolvable reference at strict commit (hard error), warns on the tolerant
+// load / peer-sync path (#1960), and accepts a DIRECT dynamic-address feed
+// binding (resolved via the live overlay at runtime, #3303).
+//
+// All trees use ParseSetCommand + SetPath (buildTree), never NewParser.
+
+// emptySetSNATSource builds a source NAT rule whose match source-address-name
+// references the named address-set, which is DEFINED but has no members.
+func emptySetSNATSource(matchName string) []string {
+	return []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		// Define the set but give it no members: it is present in
+		// ab.AddressSets yet expands to nothing.
+		"set security address-book global address-set " + matchName + " description empty",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address-name " + matchName,
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+}
+
+// emptySetDNATDest builds a destination NAT rule whose match
+// destination-address-name references a defined-but-empty address-set.
+func emptySetDNATDest(matchName string) []string {
+	return []string{
+		"set security zones security-zone untrust",
+		"set security address-book global address-set " + matchName + " description empty",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address-name " + matchName,
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	}
+}
+
+// TestNATSourceAddressNameEmptySetRejected is the RED-on-revert anchor: an SNAT
+// rule referencing a defined-but-empty address-set must be hard-rejected at
+// strict commit. Reverting the #3425 resolvability gate (back to the bare
+// `defined` existence check) makes CompileConfig accept it — this test then
+// fails.
+func TestNATSourceAddressNameEmptySetRejected(t *testing.T) {
+	tree := buildTree(t, emptySetSNATSource("EMPTY"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("SNAT referencing a defined-but-empty source-address-name must be rejected at commit (#3425)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "source-address-name") ||
+		!strings.Contains(msg, "EMPTY") ||
+		!strings.Contains(msg, "does not resolve") {
+		t.Fatalf("error must name the field, the entry, and the unresolvable cause, got: %v", err)
+	}
+}
+
+// TestNATDestinationAddressNameEmptySetRejected: the destination twin (#3229)
+// must reject a defined-but-empty destination-address-name too.
+func TestNATDestinationAddressNameEmptySetRejected(t *testing.T) {
+	tree := buildTree(t, emptySetDNATDest("EMPTY"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("DNAT referencing a defined-but-empty destination-address-name must be rejected at commit (#3425)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "destination-address-name") ||
+		!strings.Contains(msg, "EMPTY") ||
+		!strings.Contains(msg, "does not resolve") {
+		t.Fatalf("error must name the field, the entry, and the unresolvable cause, got: %v", err)
+	}
+}
+
+// TestNATSourceAddressNamePrefixlessAddressRejected: a defined `address` with
+// no configured prefix (empty Value) also resolves to nothing. The snapshot
+// builder would append the raw token; strict commit must reject it.
+func TestNATSourceAddressNamePrefixlessAddressRejected(t *testing.T) {
+	// `address foo description ...` creates the address object with an empty
+	// Value (no prefix leaf), exercising the addr.Value == "" branch of
+	// resolveUserspaceAddressBookEntry / policyMatchAddressBookResolves.
+	lines := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security address-book global address noprefix description placeholder",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address-name noprefix",
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+	tree := buildTree(t, lines)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("SNAT referencing a prefix-less address must be rejected at commit (#3425)")
+	}
+	if !strings.Contains(err.Error(), "does not resolve") {
+		t.Fatalf("error must explain the address resolves to nothing, got: %v", err)
+	}
+}
+
+// TestNATAddressNameEmptySetLenientWarns: the tolerant load / peer-sync path
+// must NOT hard-reject (so an already-persisted or peer-synced config still
+// boots #1960) and must record a warning naming the dead reference.
+func TestNATAddressNameEmptySetLenientWarns(t *testing.T) {
+	tree := buildTree(t, emptySetSNATSource("EMPTY"))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("tolerant path must not hard-reject a defined-but-empty reference, got: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "source-address-name") && strings.Contains(w, "EMPTY") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("tolerant path must warn about the unresolvable reference, got warnings: %v", cfg.Warnings)
+	}
+}
+
+// TestNATSourceAddressNameNonEmptySetAccepted: the gate must NOT regress a
+// VALID reference — a defined set with a resolvable member still commits.
+func TestNATSourceAddressNameNonEmptySetAccepted(t *testing.T) {
+	lines := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security address-book global address corp-a 198.51.100.0/24",
+		"set security address-book global address-set corp-net address corp-a",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address-name corp-net",
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("SNAT referencing a resolvable address-set must commit, got: %v", err)
+	}
+}
+
+// TestNATSourceAddressNameDirectFeedAccepted: a DIRECT dynamic-address feed
+// binding name has an empty STATIC book expansion but resolves via the live
+// feed overlay at runtime (#3303). It must be accepted at strict commit, like
+// the policy-address feed carve-out (#3294) — otherwise the documented
+// feed-in-NAT feature is un-committable.
+func TestNATSourceAddressNameDirectFeedAccepted(t *testing.T) {
+	lines := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+		"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+		"set security dynamic-address address-name bad-actors profile feed-name malware",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match source-address-name bad-actors",
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("SNAT referencing a direct dynamic-address feed binding must commit (#3303/#3425), got: %v", err)
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -5576,15 +5576,37 @@ func validatePrefixLengthRange(rf *RouteFilter) error {
 
 // validateNATSourceAddressNameReferencesStrict hard-rejects a source or
 // destination NAT rule whose `match source-address-name <name>` OR `match
-// destination-address-name <name>` (#3229) names an address-book entry not
-// defined under `security address-book` (#2416).
+// destination-address-name <name>` (#3229) names an address-book entry that
+// either is not defined under `security address-book` (#2416) OR is defined
+// but does not resolve to >= 1 concrete address (#3425).
 //
-// The name is resolved to concrete source prefixes at snapshot-build time
-// (appendNATSourceAddressName). A dangling reference contributes no prefix and
-// the rule fails closed (matches NOTHING) — safe, but silent: the operator's
-// intended source scoping vanishes with no signal. This gate makes the typo
-// operator-visible at commit, consistent with the firewall prefix-list and
-// policer reference gates.
+// The name is resolved to concrete prefixes at snapshot-build time
+// (appendNATSourceAddressName → resolveNATAddressNamePrefixes →
+// resolveUserspaceAddressBookEntry). Two distinct failures both translate to a
+// rule that matches NOTHING (fail-closed but SILENT):
+//
+//   - a wholly UNDEFINED name (a typo) — neither an address-book entry nor a
+//     dynamic-address feed binding; and
+//   - a DEFINED-but-UNRESOLVABLE name (#3425) — a defined `address` with no
+//     prefix (empty Value), a defined-but-EMPTY `address-set`, or a set with a
+//     dangling / member-less expansion. resolveUserspaceAddressBookEntry
+//     returns ok=false for these, so the builder appends the raw (unparseable)
+//     token to keep the constraint non-empty and the rule translates no
+//     traffic — exactly the policy-address fail-open class #3149 closes for
+//     security policies, here for NAT.
+//
+// This gate makes BOTH visible at commit, consistent with the policy-address
+// representability gate (validatePolicyMatchAddressSetMembersStrict) and the
+// NAT match-application gate (validateNATMatchApplicationsStrict).
+//
+// Feed carve-out (#3303 / #3294): a DIRECT `match ...-address-name <feed-name>`
+// reference to a `security dynamic-address address-name <name> profile <feed>`
+// binding is ACCEPTED — the static book expansion is empty but
+// resolveNATAddressNamePrefixes unions the live feed overlay at runtime, so the
+// rule does carry prefixes. Mirrors validatePolicyMatchAddressesStrict's
+// AddressBindings carve-out; deliberately scoped to the DIRECT reference (a
+// feed member NESTED in an address-set is still poisoned by the static
+// resolver — the anti-Option-C guardrail, identical to the policy path).
 //
 // On the tolerant load / peer-sync paths the call site downgrades to a warning
 // (opts.lenientFirewallRefs) so an already-persisted or peer-synced config
@@ -5596,6 +5618,13 @@ func validateNATSourceAddressNameReferencesStrict(cfg *Config) error {
 		return nil
 	}
 	ab := cfg.Security.AddressBook
+	feedBinding := func(name string) bool {
+		if name == "" {
+			return false
+		}
+		_, ok := cfg.Security.DynamicAddress.AddressBindings[name]
+		return ok
+	}
 	defined := func(name string) bool {
 		if name == "" || ab == nil {
 			return false
@@ -5606,6 +5635,38 @@ func validateNATSourceAddressNameReferencesStrict(cfg *Config) error {
 		_, ok := ab.AddressSets[name]
 		return ok
 	}
+	// nameError returns nil when the reference is valid, or the strict
+	// rejection error otherwise. field is "source-address-name" /
+	// "destination-address-name" and scope is "source scope" / "destination
+	// scope" for the operator-facing message.
+	nameError := func(natType, ruleSet, ruleName, field, scope, name string) error {
+		if name == "" || feedBinding(name) {
+			return nil
+		}
+		if !defined(name) {
+			return fmt.Errorf(
+				"%s NAT rule-set %q rule %q references undefined "+
+					"%s %q (define `security address-book "+
+					"address %s` / `address-set %s`, or fix the name — the "+
+					"%s would otherwise be silently lost and the "+
+					"rule would match no traffic)",
+				natType, ruleSet, ruleName, field, name, name, name, scope)
+		}
+		// #3425: a DEFINED name that the runtime resolver cannot expand to >= 1
+		// literal address (empty address, empty/dangling set). The builder
+		// appends the raw token → the rule is non-empty but unmatchable. Reject
+		// it so the operator sees the dead scope at commit.
+		if cause := policyMatchAddressBookResolves(ab, name); cause != nil {
+			return fmt.Errorf(
+				"%s NAT rule-set %q rule %q match %s %q does not resolve to "+
+					"any address: %w — the rule commits but the dataplane "+
+					"installs a match-nothing %s so the translation never "+
+					"fires (add at least one resolvable member / a prefix to "+
+					"the address, or remove the reference) (#3425)",
+				natType, ruleSet, ruleName, field, name, cause, scope)
+		}
+		return nil
+	}
 	check := func(natType string, rs *NATRuleSet) error {
 		if rs == nil {
 			return nil
@@ -5614,31 +5675,21 @@ func validateNATSourceAddressNameReferencesStrict(cfg *Config) error {
 			if rule == nil {
 				continue
 			}
-			if rule.Match.SourceAddressName != "" && !defined(rule.Match.SourceAddressName) {
-				return fmt.Errorf(
-					"%s NAT rule-set %q rule %q references undefined "+
-						"source-address-name %q (define `security address-book "+
-						"address %s` / `address-set %s`, or fix the name — the "+
-						"source scope would otherwise be silently lost and the "+
-						"rule would match no traffic)",
-					natType, rs.Name, rule.Name, rule.Match.SourceAddressName,
-					rule.Match.SourceAddressName, rule.Match.SourceAddressName)
+			if err := nameError(natType, rs.Name, rule.Name,
+				"source-address-name", "source scope",
+				rule.Match.SourceAddressName); err != nil {
+				return err
 			}
 			// #3229: destination-address-name is the destination twin of
 			// source-address-name and resolves through the same address-book
-			// expander (appendNATDestinationAddressName). A dangling reference
-			// installs no destination = the rule matches nothing (fail-closed
-			// but silent); gate it here so the typo is operator-visible at
-			// commit, exactly like the source name above.
-			if rule.Match.DestinationAddressName != "" && !defined(rule.Match.DestinationAddressName) {
-				return fmt.Errorf(
-					"%s NAT rule-set %q rule %q references undefined "+
-						"destination-address-name %q (define `security address-book "+
-						"address %s` / `address-set %s`, or fix the name — the "+
-						"destination scope would otherwise be silently lost and the "+
-						"rule would match no traffic)",
-					natType, rs.Name, rule.Name, rule.Match.DestinationAddressName,
-					rule.Match.DestinationAddressName, rule.Match.DestinationAddressName)
+			// expander (appendNATDestinationAddressName). A dangling or
+			// unresolvable reference installs no destination = the rule matches
+			// nothing (fail-closed but silent); gate it here so the problem is
+			// operator-visible at commit, exactly like the source name above.
+			if err := nameError(natType, rs.Name, rule.Name,
+				"destination-address-name", "destination scope",
+				rule.Match.DestinationAddressName); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/pkg/dataplane/userspace/nat_address_name_failclosed_3425_test.go
+++ b/pkg/dataplane/userspace/nat_address_name_failclosed_3425_test.go
@@ -1,0 +1,95 @@
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3425: on the tolerant load / peer-sync path a NAT rule may carry a
+// defined-but-unresolvable `match {source,destination}-address-name` (the
+// strict commit gate downgrades to a warning so the config still boots #1960).
+// The snapshot builder must fail CLOSED for such a reference: it appends the
+// raw, unparseable book-name token so the source/destination constraint stays
+// NON-EMPTY (source_constrained / destination present) but matches NOTHING — it
+// must NOT collapse to an empty (match-any) list that would broaden the rule.
+//
+// These tests pin that fail-closed contract directly at the builder, so a
+// future change that "cleaned up" the raw-token append (turning the unresolved
+// reference into a no-op = wildcard) would be caught here.
+
+// emptySetCfgSNAT builds a config whose SNAT rule references a DEFINED but
+// member-less address-set — resolveUserspaceAddressBookEntry returns ok=false,
+// so the builder takes the raw-token fail-closed branch.
+func emptySetCfgSNAT() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = &config.AddressBook{
+		AddressSets: map[string]*config.AddressSet{
+			"EMPTY": {Name: "EMPTY"}, // defined, no members
+		},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{Name: "rs", FromZone: "trust", ToZone: "untrust", Rules: []*config.NATRule{
+			{
+				Name:  "dead-scope",
+				Match: config.NATMatch{SourceAddressName: "EMPTY"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			},
+		}},
+	}
+	return cfg
+}
+
+// TestSNATEmptyAddressSetFailsClosed: the source list must carry the raw
+// unmatchable token and must NOT be empty (which would match any source).
+func TestSNATEmptyAddressSetFailsClosed(t *testing.T) {
+	snaps := buildSourceNATSnapshots(emptySetCfgSNAT(), nil)
+	if len(snaps) == 0 {
+		t.Fatal("expected a source NAT snapshot")
+	}
+	src := snaps[0].SourceAddresses
+	if len(src) == 0 {
+		t.Fatal("source list collapsed to empty (match-any) — fail-OPEN; an " +
+			"unresolvable source-address-name must stay non-empty + unmatchable (#3425)")
+	}
+	if !contains(src, "EMPTY") {
+		t.Fatalf("source list must carry the raw unmatchable token to fail closed, got %v", src)
+	}
+}
+
+// emptySetCfgDNAT is the destination twin.
+func emptySetCfgDNAT() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.AddressBook = &config.AddressBook{
+		AddressSets: map[string]*config.AddressSet{
+			"EMPTY": {Name: "EMPTY"},
+		},
+	}
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		RuleSets: []*config.NATRuleSet{
+			{Name: "rs", FromZone: "untrust", Rules: []*config.NATRule{
+				{
+					Name:  "dead-scope",
+					Match: config.NATMatch{DestinationAddressName: "EMPTY"},
+					Then:  config.NATThen{Type: config.NATDestination, PoolName: "dp"},
+				},
+			}},
+		},
+		Pools: map[string]*config.NATPool{"dp": {Name: "dp", Address: "10.0.0.5"}},
+	}
+	return cfg
+}
+
+// TestDNATEmptyAddressSetFailsClosed: the DNAT builder appends the raw
+// unparseable token to the destination list, then dnatDestinationParts rejects
+// it and emits NO snapshot entry — the rule matches NOTHING (fail-closed). It
+// must NOT emit an unscoped entry that would DNAT every destination.
+func TestDNATEmptyAddressSetFailsClosed(t *testing.T) {
+	snaps := buildDestinationNATSnapshots(emptySetCfgDNAT(), nil)
+	if len(snaps) != 0 {
+		t.Fatalf("a DNAT rule whose only destination-address-name is "+
+			"unresolvable must emit no snapshot entry (match-nothing), got %d "+
+			"entries %+v — fail-OPEN if any entry DNATs an unscoped destination (#3425)",
+			len(snaps), snaps)
+	}
+}


### PR DESCRIPTION
Closes #3425

## Problem
NAT `match {source,destination}-address-name <name>` strict validation
(`validateNATSourceAddressNameReferencesStrict`) only checked that the name was
DEFINED in `security address-book`, not whether it RESOLVES to any concrete
address. A defined-but-empty `address-set`, a set with dangling members, or an
`address` with no prefix (empty `Value`) passed strict commit, but the snapshot
builder resolves it to nothing and appends the raw unparseable token to keep the
constraint non-empty — the SNAT source list becomes non-empty-but-unmatchable
and the DNAT rule emits zero `DnatTable` entries. The rule commits "valid" yet
translates no traffic. This is the NAT analog of the #3149 policy-address
representability gate and the #3434 NAT match-application gate.

## Fix (fail-closed, mirrors #3149/#3434)
- Strict commit (`CompileConfig`) now REJECTS a defined-but-unresolvable
  reference, resolving the name through the shared
  `policyMatchAddressBookResolves` helper that mirrors the runtime
  `resolveUserspaceAddressBookEntry` exactly, so commit and apply cannot diverge.
- DIRECT `security dynamic-address address-name <name>` feed bindings are carved
  out and ACCEPTED (empty static expansion, but the live feed overlay supplies
  prefixes at runtime, #3303) — mirroring the
  `validatePolicyMatchAddressesStrict` feed carve-out (#3294). A feed member
  NESTED in an address-set stays poisoned by the static resolver (anti-Option-C
  guardrail).
- Lenient load / peer-sync (`CompileConfigLenient`) downgrades to a warning so an
  already-persisted/peer-synced config still boots (#1960); the dataplane fails
  closed independently (raw unmatchable token / zero DNAT entries — unchanged,
  now pinned by tests).

## Tests (RED on reverting the gate)
- `pkg/config`: strict reject of empty-set source/dest name + prefix-less
  address; lenient warn; valid-set + direct-feed accept (no regression).
- `pkg/dataplane/userspace`: SNAT keeps the raw unmatchable token (no collapse to
  match-any); DNAT emits zero snapshot entries for an unresolvable name.

Verified RED-on-revert: neutering the new `policyMatchAddressBookResolves` branch
makes the three strict-reject tests fail. `go test ./pkg/config/
./pkg/dataplane/userspace/` green; gofmt + go vet clean. Updated
`docs/config-schema.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi