### PR TITLE
policy views: surface scoped global policies in filtered + remote views (#3357)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -23896,3 +23896,22 @@ top.
   pkg/config/types_security.go, pkg/api/security_zone_hostinbound_3328_test.go (new),
   pkg/grpcapi/server_show_zones_hostinbound_3328_test.go (new),
   pkg/api/README.md, pkg/grpcapi/README.md, _Log.md
+
+## 2026-06-29 — #3357 scoped global policies suppressed in filtered/remote policy views
+
+- **Timestamp**: 2026-06-29
+- **Action**: Surface scoped global policies (#3148) in the FILTERED local-CLI
+  hit-count/detail/brief/standard views, the gRPC text hit-count/detail views,
+  and the remote-CLI filtered + brief views. Added shared selection predicate
+  `policymatch.GlobalPolicyAppliesToZonePair` (empty/"any" scope = all-zones,
+  mirroring runtime globalScopeMatches). RED-on-revert tests across all four
+  surfaces + a predicate unit test. Doc note in junos-cli-reference.md.
+- **File(s)**: pkg/policymatch/policymatch.go,
+  pkg/policymatch/global_zone_filter_3357_test.go (new),
+  pkg/cli/cli_show_security.go, pkg/cli/cli_show_security_dispatch.go,
+  pkg/cli/cli_show_security_scoped_global_3357_test.go (new),
+  pkg/grpcapi/server_show_policies_text.go,
+  pkg/grpcapi/server_show_policies_text_scoped_global_3357_test.go (new),
+  cmd/cli/show.go, cmd/cli/nontty_test.go,
+  cmd/cli/show_policies_scoped_global_3357_test.go (new),
+  docs/junos-cli-reference.md, _Log.md

--- a/cmd/cli/nontty_test.go
+++ b/cmd/cli/nontty_test.go
@@ -45,6 +45,20 @@ type fakeBpfrxClient struct {
 	matchPoliciesCalls int
 	matchPoliciesReq   *pb.MatchPoliciesRequest
 	matchPoliciesResp  *pb.MatchPoliciesResponse
+
+	// GetPolicies recorder (#3357 remote filtered/brief scoped-global coverage).
+	getPoliciesCalls int
+	getPoliciesResp  *pb.GetPoliciesResponse
+}
+
+func (f *fakeBpfrxClient) GetPolicies(
+	_ context.Context, _ *pb.GetPoliciesRequest, _ ...grpc.CallOption,
+) (*pb.GetPoliciesResponse, error) {
+	f.getPoliciesCalls++
+	if f.getPoliciesResp != nil {
+		return f.getPoliciesResp, nil
+	}
+	return &pb.GetPoliciesResponse{}, nil
 }
 
 func (f *fakeBpfrxClient) MatchPolicies(

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -525,7 +525,44 @@ func (c *ctl) showPoliciesFiltered(fromZone, toZone string) error {
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}
+	renderRule := func(rule *pb.PolicyRule) {
+		fmt.Printf("  Rule: %s\n", rule.Name)
+		if rule.Description != "" {
+			fmt.Printf("    Description: %s\n", rule.Description)
+		}
+		fmt.Printf("    Match: src=%v dst=%v app=%v\n",
+			rule.SrcAddresses, rule.DstAddresses, rule.Applications)
+		fmt.Printf("    Action: %s\n", rule.Action)
+		if rule.HitPackets > 0 || rule.HitBytes > 0 {
+			fmt.Printf("    Hit count: %d packets, %d bytes\n", rule.HitPackets, rule.HitBytes)
+		}
+	}
 	for _, pi := range resp.Policies {
+		// #3357: the global group is exposed by GetPolicies with the group-level
+		// zones "*"/"*"; the per-rule scope of a scoped global (#3148) is carried
+		// in rule.MatchFromZone/MatchToZone. Filtering the whole group on its
+		// "*"/"*" zones dropped every scoped global from the filtered view — the
+		// exact command an operator uses to prove which rules govern a zone pair.
+		// Detect the global group and filter per-rule, rendering each rule under a
+		// header that shows its effective scope (falling back to "*"/"*").
+		if pi.FromZone == "*" && pi.ToZone == "*" {
+			for _, rule := range pi.Rules {
+				if !policymatch.GlobalPolicyAppliesToZonePair(rule.MatchFromZone, rule.MatchToZone, fromZone, toZone) {
+					continue
+				}
+				gf, gt := "*", "*"
+				if rule.MatchFromZone != "" {
+					gf = rule.MatchFromZone
+				}
+				if rule.MatchToZone != "" {
+					gt = rule.MatchToZone
+				}
+				fmt.Printf("From zone: %s, To zone: %s\n", gf, gt)
+				renderRule(rule)
+				fmt.Println()
+			}
+			continue
+		}
 		if fromZone != "" && pi.FromZone != fromZone {
 			continue
 		}
@@ -534,16 +571,7 @@ func (c *ctl) showPoliciesFiltered(fromZone, toZone string) error {
 		}
 		fmt.Printf("From zone: %s, To zone: %s\n", pi.FromZone, pi.ToZone)
 		for _, rule := range pi.Rules {
-			fmt.Printf("  Rule: %s\n", rule.Name)
-			if rule.Description != "" {
-				fmt.Printf("    Description: %s\n", rule.Description)
-			}
-			fmt.Printf("    Match: src=%v dst=%v app=%v\n",
-				rule.SrcAddresses, rule.DstAddresses, rule.Applications)
-			fmt.Printf("    Action: %s\n", rule.Action)
-			if rule.HitPackets > 0 || rule.HitBytes > 0 {
-				fmt.Printf("    Hit count: %d packets, %d bytes\n", rule.HitPackets, rule.HitBytes)
-			}
+			renderRule(rule)
 		}
 		fmt.Println()
 	}
@@ -1883,8 +1911,22 @@ func (c *ctl) showPoliciesBrief() error {
 			if rule.HitPackets > 0 {
 				hits = fmt.Sprintf("%d", rule.HitPackets)
 			}
+			// #3357: a scoped global (#3148) is exposed under the global group
+			// (pi.FromZone/ToZone == "*"), but its real zone scope is carried
+			// per-rule in MatchFromZone/MatchToZone. Render the effective scope
+			// so the brief view does not regress a scoped global to "*"/"*",
+			// matching the local-CLI #3286 display. Zone-pair rules and the
+			// default-policy row leave the match-scope empty and fall back to the
+			// group zones (real zones / "-"), so they are unchanged.
+			from, to := pi.FromZone, pi.ToZone
+			if rule.MatchFromZone != "" {
+				from = rule.MatchFromZone
+			}
+			if rule.MatchToZone != "" {
+				to = rule.MatchToZone
+			}
 			fmt.Printf("%-12s %-12s %-20s %-8s %s\n",
-				pi.FromZone, pi.ToZone, rule.Name, rule.Action, hits)
+				from, to, rule.Name, rule.Action, hits)
 		}
 	}
 	return nil

--- a/cmd/cli/show_policies_scoped_global_3357_test.go
+++ b/cmd/cli/show_policies_scoped_global_3357_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3357: the remote CLI dropped scoped global policies (#3148) from the
+// FILTERED policy view and rendered them as "*"/"*" in the brief view.
+//
+//   - showPoliciesFiltered compared the enclosing group zones (the global
+//     group is "*"/"*") against the filter, so a `from-zone X to-zone Y`
+//     filter dropped the whole global block — including a scoped global that
+//     targets exactly that pair.
+//   - showPoliciesBrief printed the group zones ("*") instead of the per-rule
+//     MatchFromZone/MatchToZone the proto already carries, regressing the
+//     local-CLI #3286 display.
+//
+// These tests are the fail-on-revert guard.
+
+// scopedGlobalPoliciesResp models GetPolicies output: a zone-pair set
+// (trust->untrust), a second zone-pair set (trust->dmz) used to prove the
+// per-set filter still works, and the global group "*"/"*" carrying a scoped
+// global for trust->untrust, a scoped global for the off-pair trust->dmz, and
+// an unscoped (all-zones) global.
+func scopedGlobalPoliciesResp() *pb.GetPoliciesResponse {
+	return &pb.GetPoliciesResponse{
+		Policies: []*pb.PolicyInfo{
+			{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Rules: []*pb.PolicyRule{
+					{Name: "zp-allow", Action: "permit"},
+				},
+			},
+			{
+				FromZone: "trust",
+				ToZone:   "dmz",
+				Rules: []*pb.PolicyRule{
+					{Name: "zp-dmz", Action: "deny"},
+				},
+			},
+			{
+				FromZone: "*",
+				ToZone:   "*",
+				Rules: []*pb.PolicyRule{
+					{Name: "scoped-tu", Action: "deny", MatchFromZone: "trust", MatchToZone: "untrust"},
+					{Name: "scoped-td", Action: "deny", MatchFromZone: "trust", MatchToZone: "dmz"},
+					{Name: "open-global", Action: "permit"},
+				},
+			},
+		},
+	}
+}
+
+// TestShowPoliciesFilteredKeepsScopedGlobal: a `from-zone trust to-zone untrust`
+// filter must include the scoped global that targets that pair AND the unscoped
+// (all-zones) global, while excluding a scoped global bound to a different pair
+// and the non-matching zone-pair set.
+//
+// FAIL-ON-REVERT: restoring the group-level `pi.FromZone != fromZone` filter
+// drops the whole "*"/"*" global block, so the scoped-tu / open-global
+// assertions go RED.
+func TestShowPoliciesFilteredKeepsScopedGlobal(t *testing.T) {
+	fake := &fakeBpfrxClient{getPoliciesResp: scopedGlobalPoliciesResp()}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesFiltered("trust", "untrust"); err != nil {
+			t.Fatalf("showPoliciesFiltered: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Rule: scoped-tu") {
+		t.Fatalf("filtered view dropped scoped global trust->untrust (#3357 regression):\n%s", out)
+	}
+	// The scoped global must render under its effective scope, not "*"/"*".
+	if !strings.Contains(out, "From zone: trust, To zone: untrust") {
+		t.Fatalf("filtered view missing scoped-global scope header trust/untrust:\n%s", out)
+	}
+	if !strings.Contains(out, "Rule: open-global") {
+		t.Fatalf("filtered view dropped unscoped (all-zones) global:\n%s", out)
+	}
+	if strings.Contains(out, "Rule: scoped-td") {
+		t.Fatalf("filtered view leaked an off-pair scoped global (trust->dmz):\n%s", out)
+	}
+	if strings.Contains(out, "Rule: zp-dmz") {
+		t.Fatalf("filtered view leaked a non-matching zone-pair set (trust->dmz):\n%s", out)
+	}
+	if !strings.Contains(out, "Rule: zp-allow") {
+		t.Fatalf("filtered view dropped the matching zone-pair rule:\n%s", out)
+	}
+}
+
+// TestShowPoliciesBriefRendersScopedGlobalScope: the brief tabular view must
+// print a scoped global's per-rule zones, not the group "*"/"*".
+//
+// FAIL-ON-REVERT: restoring `pi.FromZone`/`pi.ToZone` in the brief columns
+// prints "*"/"*" for scoped-tu, so the trust/untrust column assertion goes RED.
+func TestShowPoliciesBriefRendersScopedGlobalScope(t *testing.T) {
+	fake := &fakeBpfrxClient{getPoliciesResp: scopedGlobalPoliciesResp()}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesBrief(); err != nil {
+			t.Fatalf("showPoliciesBrief: %v", err)
+		}
+	})
+
+	scoped := briefRowFor(t, out, "scoped-tu")
+	fields := strings.Fields(scoped)
+	if len(fields) < 2 || fields[0] != "trust" || fields[1] != "untrust" {
+		t.Fatalf("scoped-tu brief row = %q, want trust/untrust columns (rendered as */* — #3357 regression)", scoped)
+	}
+	open := briefRowFor(t, out, "open-global")
+	ofields := strings.Fields(open)
+	if len(ofields) < 2 || ofields[0] != "*" || ofields[1] != "*" {
+		t.Fatalf("open-global brief row = %q, want */* columns (unscoped global)", open)
+	}
+}
+
+// briefRowFor returns the brief output line containing the named policy.
+func briefRowFor(t *testing.T, out, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, name) {
+			return line
+		}
+	}
+	t.Fatalf("policy %q row not found in brief output:\n%s", name, out)
+	return ""
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -460,6 +460,9 @@ From zone: guest, To zone: lan
 ### Filtering
 
 - `show security policies from-zone lan to-zone Internet-ATT` shows only that zone pair.
+  Global policies that govern the pair are also shown (#3357): an unscoped/`any`
+  global and a scoped global (#3148) whose `match from-zone`/`to-zone` equals the
+  filter; a scoped global bound to a different pair is omitted.
 
 ---
 
@@ -611,6 +614,19 @@ Global policies:
   group still reports `from_zone="*"`/`to_zone="*"` (the all-zones tier) — the
   per-rule fields carry the narrowing. An unscoped global is unchanged
   (junos-global / any / `*`).
+- **#3357 — scope shown in the FILTERED and remote views too.** #3286 fixed the
+  *unfiltered* surfaces; the *filtered* form (`show security policies hit-count
+  from-zone X to-zone Y`, `... detail ...`, the standard/brief forms, and the
+  gRPC `policies-hit-count`/`policies-detail` text views) plus the remote CLI
+  still suppressed scoped globals. A `from-zone X to-zone Y` filter now includes
+  every global that GOVERNS that pair — an unscoped/`any` global (enforced for
+  every pair) and a scoped global whose `match from-zone`/`to-zone` equals the
+  filter — and excludes a scoped global bound to a different pair, mirroring the
+  runtime `globalScopeMatches` selection. The remote `show security policies`
+  (filtered) renders each global rule under its effective scope, and the remote
+  `... brief` prints the per-rule `match_from_zone`/`match_to_zone` (falling back
+  to `*`/`*` only for an unscoped global) instead of the group `*`. The shared
+  selection predicate is `policymatch.GlobalPolicyAppliesToZonePair`.
 
 ---
 

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -93,11 +93,20 @@ func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) 
 		}
 		policySetID++
 	}
-	// Global policies
-	if len(cfg.Security.GlobalPolicies) > 0 && fromZone == "" && toZone == "" {
+	// Global policies. #3357: a from/to-zone filter no longer suppresses the
+	// global block — an unscoped global is enforced for every zone pair and a
+	// scoped global (#3148) may target exactly the filtered pair, so the
+	// filtered hit-count table must show the globals that govern it. Per-rule
+	// scope is matched against the filter via GlobalPolicyAppliesToZonePair;
+	// the ruleID is the loop index so skipped rows keep counter alignment.
+	if len(cfg.Security.GlobalPolicies) > 0 {
 		for i, pol := range cfg.Security.GlobalPolicies {
 			// #3476: skip a nil global rule like the runtime walker does.
 			if pol == nil {
+				continue
+			}
+			// #3357: drop a scoped global that targets a different zone pair.
+			if !policymatch.GlobalPolicyAppliesToZonePair(pol.Match.FromZone, pol.Match.ToZone, fromZone, toZone) {
 				continue
 			}
 			action := "Permit"
@@ -269,11 +278,18 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 		fmt.Println()
 	}
 
-	// Global policies
-	if len(cfg.Security.GlobalPolicies) > 0 && fromZone == "" && toZone == "" {
+	// Global policies. #3357: a from/to-zone filter no longer suppresses the
+	// global block — the filtered detail view must still show an unscoped
+	// global (enforced for every pair) and a scoped global (#3148) targeting
+	// the filtered pair. GlobalPolicyAppliesToZonePair selects per-rule scope.
+	if len(cfg.Security.GlobalPolicies) > 0 {
 		for i, pol := range cfg.Security.GlobalPolicies {
 			// #3476: skip a nil global rule like the runtime walker does.
 			if pol == nil {
+				continue
+			}
+			// #3357: drop a scoped global that targets a different zone pair.
+			if !policymatch.GlobalPolicyAppliesToZonePair(pol.Match.FromZone, pol.Match.ToZone, fromZone, toZone) {
 				continue
 			}
 			action := "permit"

--- a/pkg/cli/cli_show_security_dispatch.go
+++ b/pkg/cli/cli_show_security_dispatch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/policymatch"
 )
 
 // enabledStr returns "enabled" or "disabled" for a boolean flag.
@@ -260,11 +261,17 @@ func (c *CLI) handleShowSecurity(args []string) error {
 				}
 				policySetID++
 			}
-			// Global policies in brief view
-			if len(cfg.Security.GlobalPolicies) > 0 && fromZone == "" && toZone == "" {
+			// Global policies in brief view. #3357: a from/to-zone filter no
+			// longer suppresses the globals — show the unscoped globals (every
+			// pair) plus any scoped global (#3148) targeting the filtered pair.
+			if len(cfg.Security.GlobalPolicies) > 0 {
 				for i, pol := range cfg.Security.GlobalPolicies {
 					// #3476: skip a nil global rule like the runtime walker.
 					if pol == nil {
+						continue
+					}
+					// #3357: drop a scoped global for a different zone pair.
+					if !policymatch.GlobalPolicyAppliesToZonePair(pol.Match.FromZone, pol.Match.ToZone, fromZone, toZone) {
 						continue
 					}
 					action := "permit"
@@ -367,13 +374,27 @@ func (c *CLI) handleShowSecurity(args []string) error {
 			// When globalOnly, still count zone-pair policy sets to get correct global ruleID base
 			policySetID = uint32(len(cfg.Security.Policies))
 		}
-		// Global policies
-		if len(cfg.Security.GlobalPolicies) > 0 && (globalOnly || (fromZone == "" && toZone == "")) {
-			fmt.Println("Global policies:")
+		// Global policies. #3357: a from/to-zone filter no longer suppresses the
+		// global block (only `global`-only and the unfiltered view did before) —
+		// the filtered standard view must show an unscoped global (every pair)
+		// and a scoped global (#3148) targeting the filtered pair. When globalOnly
+		// the filter is empty so every global is selected (no regression).
+		if len(cfg.Security.GlobalPolicies) > 0 {
+			// #3357: print the "Global policies:" header lazily so a filter that
+			// selects no global does not leave a dangling empty header.
+			globalHeaderPrinted := false
 			for i, pol := range cfg.Security.GlobalPolicies {
 				// #3476: skip a nil global rule like the runtime walker.
 				if pol == nil {
 					continue
+				}
+				// #3357: drop a scoped global for a different zone pair.
+				if !policymatch.GlobalPolicyAppliesToZonePair(pol.Match.FromZone, pol.Match.ToZone, fromZone, toZone) {
+					continue
+				}
+				if !globalHeaderPrinted {
+					fmt.Println("Global policies:")
+					globalHeaderPrinted = true
 				}
 				action := "permit"
 				switch pol.Action {

--- a/pkg/cli/cli_show_security_scoped_global_3357_test.go
+++ b/pkg/cli/cli_show_security_scoped_global_3357_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3357: the FILTERED local-CLI policy views (`show security policies
+// hit-count from-zone X to-zone Y`, `... detail ...`) suppressed the global
+// block entirely (`fromZone == "" && toZone == ""` gate). A scoped global
+// (#3148) `match from-zone X to-zone Y` that is actively enforced for that
+// exact pair was therefore omitted from the very command an operator uses to
+// prove which rules govern the pair. The filtered views now include an
+// unscoped global (every pair) and a scoped global targeting the filter, and
+// exclude a scoped global bound to a different pair.
+
+// scopedGlobalCLIConfig3357 has a scoped global for trust->untrust, a scoped
+// global for the off-pair trust->dmz, and an unscoped (all-zones) global.
+func scopedGlobalCLIConfig3357() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{
+			Name:   "scoped-tu",
+			Match:  config.PolicyMatch{FromZone: "trust", ToZone: "untrust"},
+			Action: config.PolicyDeny,
+		},
+		{
+			Name:   "scoped-td",
+			Match:  config.PolicyMatch{FromZone: "trust", ToZone: "dmz"},
+			Action: config.PolicyDeny,
+		},
+		{
+			Name:   "open-global",
+			Action: config.PolicyPermit,
+		},
+	}
+	return cfg
+}
+
+// Test_3357_PolicyHitCountFilteredShowsScopedGlobal covers the hit-count table.
+// FAIL-ON-REVERT: restoring the `fromZone == "" && toZone == ""` gate suppresses
+// the global block, so the scoped-tu / open-global assertions go RED.
+func Test_3357_PolicyHitCountFilteredShowsScopedGlobal(t *testing.T) {
+	cfg := scopedGlobalCLIConfig3357()
+	c := &CLI{
+		// hit-count returns early unless a dataplane is loaded.
+		dp: &policyCounterCLIDP{
+			Manager:  dataplane.New(),
+			counters: map[uint32]dataplane.CounterValue{},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesHitCount(cfg, "trust", "untrust"); err != nil {
+			t.Fatalf("showPoliciesHitCount: %v", err)
+		}
+	})
+
+	scoped := briefRow(t, out, "scoped-tu")
+	if !(strings.Contains(scoped, "trust") && strings.Contains(scoped, "untrust")) {
+		t.Fatalf("scoped-tu hit-count row = %q, want trust/untrust columns "+
+			"(filtered view suppressed the scoped global — #3357 regression)", scoped)
+	}
+	open := briefRow(t, out, "open-global")
+	if !strings.Contains(open, "junos-global") {
+		t.Fatalf("open-global hit-count row = %q, want junos-global columns (unscoped global)", open)
+	}
+	if strings.Contains(out, "scoped-td") {
+		t.Fatalf("filtered hit-count leaked an off-pair scoped global (trust->dmz):\n%s", out)
+	}
+}
+
+// Test_3357_PolicyDetailFilteredShowsScopedGlobal covers the detail view.
+// FAIL-ON-REVERT: restoring the gate suppresses the global block, so the
+// scoped-tu zone-line assertion goes RED.
+func Test_3357_PolicyDetailFilteredShowsScopedGlobal(t *testing.T) {
+	cfg := scopedGlobalCLIConfig3357()
+	c := &CLI{}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesDetail(cfg, "trust", "untrust"); err != nil {
+			t.Fatalf("showPoliciesDetail: %v", err)
+		}
+	})
+
+	scoped := policyDetailZoneLine(t, out, "scoped-tu")
+	if !strings.Contains(scoped, "From zone: trust") || !strings.Contains(scoped, "To zone: untrust") {
+		t.Fatalf("scoped-tu detail zone line = %q, want From zone: trust / To zone: untrust "+
+			"(filtered view suppressed the scoped global — #3357 regression)", scoped)
+	}
+	if !strings.Contains(out, "Policy: open-global") {
+		t.Fatalf("filtered detail dropped the unscoped (all-zones) global:\n%s", out)
+	}
+	if strings.Contains(out, "scoped-td") {
+		t.Fatalf("filtered detail leaked an off-pair scoped global (trust->dmz):\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -19,6 +19,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/policymatch"
 )
 
 // policySchedulerStateProvider is the optional dataplane capability the
@@ -165,11 +166,20 @@ func (s *Server) showPoliciesHitCount(filter string, buf *strings.Builder) {
 	// with from/to zone "*" (matching the other surfaces). Counter IDs
 	// continue from the zone-pair loop: policySetID*MaxRulesPerPolicy + i,
 	// keeping the global slots aligned with the dataplane (#3045/#3050 did
-	// the same for the REST inventory). A from/to-zone filter selects
-	// zone-pair policies only, so suppress globals when one is set.
-	if len(cfg.Security.GlobalPolicies) > 0 && filterFrom == "" && filterTo == "" {
+	// the same for the REST inventory).
+	//
+	// #3357: a from/to-zone filter no longer suppresses the whole global
+	// block. An unscoped global is enforced for every zone pair and a scoped
+	// global (#3148) may target exactly the filtered pair, so the filtered
+	// hit-count surface must show the globals that govern it.
+	// GlobalPolicyAppliesToZonePair selects per-rule scope against the filter.
+	if len(cfg.Security.GlobalPolicies) > 0 {
 		for i, pol := range cfg.Security.GlobalPolicies {
 			if pol == nil {
+				continue
+			}
+			// #3357: drop a scoped global that targets a different zone pair.
+			if !policymatch.GlobalPolicyAppliesToZonePair(pol.Match.FromZone, pol.Match.ToZone, filterFrom, filterTo) {
 				continue
 			}
 			action := "permit"
@@ -344,13 +354,25 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 		policySetID++
 		fmt.Fprintln(buf)
 	}
-	// Global policies
-	if len(cfg.Security.GlobalPolicies) > 0 && filterFrom == "" && filterTo == "" {
-		fmt.Fprintf(buf, "Global policies:\n")
+	// Global policies. #3357: a from/to-zone filter no longer suppresses the
+	// global block — the filtered detail surface must still show an unscoped
+	// global (enforced for every pair) and a scoped global (#3148) targeting
+	// the filtered pair. The "Global policies:" header prints lazily so a
+	// filter that selects no global leaves no dangling empty header.
+	if len(cfg.Security.GlobalPolicies) > 0 {
+		globalHeaderPrinted := false
 		for i, pol := range cfg.Security.GlobalPolicies {
 			// #3476: skip a nil global rule like the runtime walker does.
 			if pol == nil {
 				continue
+			}
+			// #3357: drop a scoped global that targets a different zone pair.
+			if !policymatch.GlobalPolicyAppliesToZonePair(pol.Match.FromZone, pol.Match.ToZone, filterFrom, filterTo) {
+				continue
+			}
+			if !globalHeaderPrinted {
+				fmt.Fprintf(buf, "Global policies:\n")
+				globalHeaderPrinted = true
 			}
 			action := "permit"
 			switch pol.Action {

--- a/pkg/grpcapi/server_show_policies_text_scoped_global_3357_test.go
+++ b/pkg/grpcapi/server_show_policies_text_scoped_global_3357_test.go
@@ -1,0 +1,140 @@
+package grpcapi
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3357: the gRPC text hit-count and detail surfaces suppressed the global
+// block whenever a `from-zone X to-zone Y` filter was present
+// (`filterFrom == "" && filterTo == ""` gate), so a scoped global (#3148)
+// enforced for exactly that pair vanished from the filtered output. The
+// filtered surfaces now include an unscoped global (every pair) and a scoped
+// global targeting the filter, while excluding a scoped global bound to a
+// different pair.
+
+// scopedGlobalFilterStore builds a config with a scoped global for
+// trust->untrust, a scoped global for the off-pair trust->dmz, and an
+// unscoped (all-zones) global, plus the zones they reference.
+func scopedGlobalFilterStore(t *testing.T) *configstore.Store {
+	t.Helper()
+
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+        security-zone dmz;
+    }
+    policies {
+        global {
+            policy scoped-tu {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy scoped-td {
+                match {
+                    from-zone trust;
+                    to-zone dmz;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy open-global {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if cfg := store.ActiveConfig(); cfg == nil || len(cfg.Security.GlobalPolicies) != 3 {
+		t.Fatalf("expected 3 global policies, got %v", cfg)
+	}
+	return store
+}
+
+// TestGRPCHitCountFilteredKeepsScopedGlobal covers the gRPC text hit-count
+// surface. FAIL-ON-REVERT: restoring the `filterFrom == "" && filterTo == ""`
+// gate suppresses the global block, so the scoped-tu / open-global assertions
+// go RED.
+func TestGRPCHitCountFilteredKeepsScopedGlobal(t *testing.T) {
+	s := &Server{store: scopedGlobalFilterStore(t)}
+
+	var buf strings.Builder
+	s.showPoliciesHitCount("from-zone trust to-zone untrust", &buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "scoped-tu") {
+		t.Fatalf("filtered hit-count dropped scoped global trust->untrust (#3357 regression):\n%s", out)
+	}
+	if !strings.Contains(out, "open-global") {
+		t.Fatalf("filtered hit-count dropped the unscoped (all-zones) global:\n%s", out)
+	}
+	if strings.Contains(out, "scoped-td") {
+		t.Fatalf("filtered hit-count leaked an off-pair scoped global (trust->dmz):\n%s", out)
+	}
+	scoped := hitCountRow(t, out, "scoped-tu")
+	if !(strings.Contains(scoped, "trust") && strings.Contains(scoped, "untrust")) {
+		t.Fatalf("scoped-tu hit-count row = %q, want trust/untrust columns", scoped)
+	}
+}
+
+// TestGRPCDetailFilteredKeepsScopedGlobal covers the gRPC text detail surface.
+// FAIL-ON-REVERT: restoring the gate suppresses the "Global policies:" block,
+// so the scoped-tu assertions go RED.
+func TestGRPCDetailFilteredKeepsScopedGlobal(t *testing.T) {
+	s := &Server{store: scopedGlobalFilterStore(t)}
+
+	var buf strings.Builder
+	s.showPoliciesDetail("from-zone trust to-zone untrust", &buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "Global policies:") {
+		t.Fatalf("filtered detail dropped the Global policies block (#3357 regression):\n%s", out)
+	}
+	if !strings.Contains(out, "Policy: scoped-tu") {
+		t.Fatalf("filtered detail dropped scoped global trust->untrust:\n%s", out)
+	}
+	if !strings.Contains(out, "Source zone: trust") || !strings.Contains(out, "Destination zone: untrust") {
+		t.Fatalf("filtered detail missing scoped-tu zone scope:\n%s", out)
+	}
+	if !strings.Contains(out, "Policy: open-global") {
+		t.Fatalf("filtered detail dropped the unscoped (all-zones) global:\n%s", out)
+	}
+	if strings.Contains(out, "Policy: scoped-td") {
+		t.Fatalf("filtered detail leaked an off-pair scoped global (trust->dmz):\n%s", out)
+	}
+}
+
+// hitCountRow returns the hit-count output line containing the named policy.
+func hitCountRow(t *testing.T, out, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, name) {
+			return line
+		}
+	}
+	t.Fatalf("policy %q row not found in hit-count output:\n%s", name, out)
+	return ""
+}

--- a/pkg/policymatch/global_zone_filter_3357_test.go
+++ b/pkg/policymatch/global_zone_filter_3357_test.go
@@ -1,0 +1,34 @@
+package policymatch
+
+import "testing"
+
+// #3357: GlobalPolicyAppliesToZonePair governs which scoped/unscoped global
+// policies a filtered policy view shows. Its semantics mirror the runtime
+// globalScopeMatches: an empty or "any" match-scope axis spans every zone.
+func TestGlobalPolicyAppliesToZonePair(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		matchFrom, matchTo, filtFrom, filtTo string
+		want                                 bool
+	}{
+		{"no filter, unscoped", "", "", "", "", true},
+		{"no filter, scoped", "trust", "untrust", "", "", true},
+		{"filter, unscoped global always applies", "", "", "trust", "untrust", true},
+		{"filter, any-scope global always applies", "any", "any", "trust", "untrust", true},
+		{"filter, scoped matches", "trust", "untrust", "trust", "untrust", true},
+		{"filter, scoped from differs", "dmz", "untrust", "trust", "untrust", false},
+		{"filter, scoped to differs", "trust", "dmz", "trust", "untrust", false},
+		{"from-only filter, scoped to-only is all-from", "", "untrust", "trust", "", true},
+		{"from-only filter, scoped from differs", "dmz", "", "trust", "", false},
+		{"to-only filter, scoped from-only is all-to", "trust", "", "", "untrust", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GlobalPolicyAppliesToZonePair(tc.matchFrom, tc.matchTo, tc.filtFrom, tc.filtTo)
+			if got != tc.want {
+				t.Fatalf("GlobalPolicyAppliesToZonePair(%q,%q,%q,%q) = %v, want %v",
+					tc.matchFrom, tc.matchTo, tc.filtFrom, tc.filtTo, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -483,6 +483,25 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 	return Result{HostInboundUnmatched: true}
 }
 
+// GlobalPolicyAppliesToZonePair reports whether a global policy (#3148) with the
+// given match-scope zones is selected by a `from-zone X to-zone Y` display
+// filter (#3357). It governs which scoped/unscoped globals a FILTERED policy
+// view shows. An empty filter axis selects every global on that axis. A global
+// whose match-scope zone is empty or "any" spans every zone, so it always
+// applies (it IS enforced for the filtered pair). A scoped global is selected
+// only when its scope equals the filter on each constrained axis. The semantics
+// mirror globalScopeMatches (an "any"/empty scope is all-zones) so the filtered
+// view shows exactly the globals the runtime enforces for that zone pair.
+func GlobalPolicyAppliesToZonePair(matchFrom, matchTo, filterFrom, filterTo string) bool {
+	axisApplies := func(scope, filter string) bool {
+		if filter == "" || scope == "" || scope == "any" {
+			return true
+		}
+		return scope == filter
+	}
+	return axisApplies(matchFrom, filterFrom) && axisApplies(matchTo, filterTo)
+}
+
 // globalScopeMatches replicates GlobalZoneScope::matches + build_global_zone_scope
 // (policy.rs, #3148). An empty or explicit "any" scope applies to every zone.
 // Any other name must resolve to a DEFINED zone and equal the flow's zone; an


### PR DESCRIPTION
Closes #3357

## Problem

Scoped global policies (#3148 — a `junos-global` policy with `match from-zone X to-zone Y`) are enforced for that exact zone pair, but the **filtered** policy views and the **remote CLI** failed to show them. #3286 fixed only the *unfiltered* surfaces. Three concrete gaps:

1. **Filtered local CLI + gRPC text suppress globals entirely.** A `from/to-zone` filter gated the whole global block off, so `show security policies hit-count from-zone trust to-zone untrust` omitted a scoped global `match from-zone trust to-zone untrust` actively enforced for that pair.
2. **Remote CLI filtered view dropped scoped globals by the group `*/*`.** `showPoliciesFiltered` filtered on the enclosing `PolicyInfo.FromZone/ToZone` (`*` for the global group), dropping the whole block even though per-rule scope is in the proto.
3. **Remote CLI brief rendered scoped globals as `*/*`.** `showPoliciesBrief` printed the group zones instead of the per-rule `MatchFromZone/MatchToZone`.

The filtered `from-zone X to-zone Y` form is exactly the command an operator uses to prove which rules govern a zone pair — a scoped emergency deny/permit could be silently omitted or shown as all-zones, undermining audit evidence.

## Fix

Shared selection predicate `policymatch.GlobalPolicyAppliesToZonePair(matchFrom, matchTo, filterFrom, filterTo)`: empty filter axis selects every global; empty/`"any"` match-scope axis spans every zone; a scoped global is selected only when its scope equals the filter on each constrained axis. Mirrors the runtime `globalScopeMatches` so the filtered view shows exactly what the runtime enforces.

- **Local CLI** (hit-count, detail, brief, standard): drop the `from/to-zone == ""` gate, filter the global block per-rule. Standard + gRPC-text detail `Global policies:` headers print lazily (no dangling empty header).
- **gRPC text** (hit-count, detail): same per-rule selection.
- **Remote CLI**: `showPoliciesFiltered` detects the `*/*` group, filters per-rule, renders each under its effective scope (fallback `*/*`); `showPoliciesBrief` prints per-rule scope, falling back to the group zones only when empty (zone-pair + default-policy rows unchanged).

REST inventory + Prometheus already carry per-rule scope (unfiltered) — unchanged.

## Tests (RED on revert)

Filtered hit-count + detail (local CLI, gRPC text), remote `showPoliciesFiltered` + `showPoliciesBrief`, plus a predicate unit test. Each asserts: a scoped global matching the filter appears with its zones, an unscoped global appears, and a scoped global bound to a different pair is excluded. Verified all four surfaces go RED when their fix is reverted; `go test ./pkg/cli/ ./pkg/api/ ./pkg/grpcapi/ ./pkg/config/ ./pkg/policymatch/ ./cmd/cli/` green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi