### PR TITLE
config: reject collapsed 'then deny session-init'/'session-close' without log (#3374)

### DIFF
--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -628,7 +628,17 @@ direct child of `deny` is a top-level modifier, checked against the
 `supportedPolicyThenDenyChildren` allowlist (`log`/`count`); its sub-tokens
 nest deeper. Keep `recognizedCollapsedDenyToken` /
 `supportedPolicyThenDenyChildren` in lockstep with
-`applyCollapsedDenyModifiers`. The tolerant load/peer-sync path downgrades
+`applyCollapsedDenyModifiers`. **#3374:** `session-init`/`session-close` are
+LOG sub-options, valid ONLY when a `log` token accompanies them in the same
+collapsed action. Because `recognizedCollapsedDenyToken` cannot tell a
+sub-token from a top-level modifier positionally, a flat-set
+`then deny session-init` (no `log`, `Keys=["deny","session-init"]`) used to
+pass the gate and `applyCollapsedDenyModifiers` silently wired session-init
+logging — syntax Junos rejects. The gate now scans the collapsed tail for a
+`log` token and rejects a bare `session-init`/`session-close` that has no
+`log` parent (`emitOrphanLogSub`); `then deny log session-init` (and the
+standalone `then log session-init`) still commit. The tolerant load/peer-sync
+path downgrades both the unsupported-modifier and the orphan-sub-token reject
 to a warning (`lenientPolicyThenDeny`) so an already-persisted or peer-synced
 config an older binary silently accepted still boots (#1960 no-brick doctrine,
 same as #3114/#3115).

--- a/pkg/config/compiler_policy_then.go
+++ b/pkg/config/compiler_policy_then.go
@@ -430,6 +430,32 @@ func validatePolicyThenDenyStrict(nodes []*Node, lenient bool) ([]string, error)
 		return nil
 	}
 
+	// #3374: session-init/session-close are LOG sub-options, valid ONLY when
+	// a `log` token accompanies them in the same collapsed action. A flat-set
+	// `then deny session-init` (no `log`) collapses to
+	// Keys=["deny","session-init"]; recognizedCollapsedDenyToken accepts the
+	// bare sub-token (it cannot tell a sub-token from a top-level modifier
+	// positionally), so the gate above let it through and
+	// applyCollapsedDenyModifiers silently wired session-init logging for a
+	// form Junos rejects. emitOrphanLogSub flags a session-init/session-close
+	// sub-token that has no `log` parent in the collapsed tail.
+	emitOrphanLogSub := func(scope, policyName, tok string) error {
+		msg := fmt.Sprintf(
+			"security policies %s policy %q then deny %q is not valid without "+
+				"a log token — session-init/session-close are sub-options of "+
+				"then deny log (or the standalone then log), not bare deny "+
+				"modifiers, so a collapsed then deny %s silently wires logging "+
+				"for syntax Junos rejects — use then deny log %s (or then log "+
+				"%s) instead (#3374)",
+			scope, policyName, tok, tok, tok, tok,
+		)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
 		thenNode := polNode.FindChild("then")
 		if thenNode == nil {
@@ -462,9 +488,25 @@ func validatePolicyThenDenyStrict(nodes []*Node, lenient bool) ([]string, error)
 		//     sub-tokens nest deeper, so a direct child must be a top-level
 		//     modifier — checked against supportedPolicyThenDenyChildren
 		//     ({log, count}).
-		for _, tok := range denyNode.Keys[1:] {
+		tail := denyNode.Keys[1:]
+		hasLog := false
+		for _, tok := range tail {
+			if tok == "log" {
+				hasLog = true
+				break
+			}
+		}
+		for _, tok := range tail {
 			if !recognizedCollapsedDenyToken(tok) {
 				if err := emit(scope, policyName, tok); err != nil {
+					return err
+				}
+				continue
+			}
+			// #3374: a recognized session-init/session-close sub-token is
+			// valid only with a `log` token in the same collapsed tail.
+			if (tok == "session-init" || tok == "session-close") && !hasLog {
+				if err := emitOrphanLogSub(scope, policyName, tok); err != nil {
 					return err
 				}
 			}

--- a/pkg/config/compiler_policy_then_deny_3374_test.go
+++ b/pkg/config/compiler_policy_then_deny_3374_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #3374: a flat-set `then deny session-init` (or `session-close`)
+// with NO accompanying `log` token collapses onto the deny node as
+// Keys=["deny","session-init"]. recognizedCollapsedDenyToken accepts the bare
+// sub-token positionally, so before this fix the collapsed form committed and
+// applyCollapsedDenyModifiers silently wired session-init/session-close
+// logging — syntax Junos rejects (session-init/session-close are sub-options
+// of `log` only). #3374 rejects an orphaned session sub-token at commit
+// (lenient-warn on the load/peer-sync path) while keeping the legitimate
+// `then deny log session-init` (and the standalone `then log session-init`)
+// forms working.
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath, never
+// NewParser. buildPolicyThenTree / findZonePairPolicy / findGlobalPolicy are
+// shared with the #3141/#3114 tests in this package.
+
+// TestPolicyThenDenyOrphanLogSubRejectedAtCommit is the fail-on-revert proof:
+// a collapsed `then deny session-init`/`session-close` (no `log`) is
+// hard-rejected at commit for both zone-pair and global scopes. Reverting the
+// #3374 emitOrphanLogSub gate makes CompileConfig ACCEPT these (the bug), so
+// every case here goes RED.
+func TestPolicyThenDenyOrphanLogSubRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		want string
+	}{
+		{
+			name: "zone-pair deny session-init (no log)",
+			cmds: []string{
+				"set security zones security-zone trust",
+				"set security zones security-zone untrust",
+				"set security policies from-zone trust to-zone untrust policy web match source-address any",
+				"set security policies from-zone trust to-zone untrust policy web match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy web match application any",
+				"set security policies from-zone trust to-zone untrust policy web then deny session-init",
+			},
+			want: `from-zone trust to-zone untrust policy "web" then deny "session-init"`,
+		},
+		{
+			name: "zone-pair deny session-close (no log)",
+			cmds: []string{
+				"set security zones security-zone trust",
+				"set security zones security-zone untrust",
+				"set security policies from-zone trust to-zone untrust policy web match source-address any",
+				"set security policies from-zone trust to-zone untrust policy web match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy web match application any",
+				"set security policies from-zone trust to-zone untrust policy web then deny session-close",
+			},
+			want: `from-zone trust to-zone untrust policy "web" then deny "session-close"`,
+		},
+		{
+			name: "zone-pair deny session-init session-close (no log)",
+			cmds: []string{
+				"set security zones security-zone trust",
+				"set security zones security-zone untrust",
+				"set security policies from-zone trust to-zone untrust policy web match source-address any",
+				"set security policies from-zone trust to-zone untrust policy web match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy web match application any",
+				"set security policies from-zone trust to-zone untrust policy web then deny session-init session-close",
+			},
+			want: `from-zone trust to-zone untrust policy "web" then deny "session-init"`,
+		},
+		{
+			name: "global deny session-init (no log)",
+			cmds: []string{
+				"set security policies global policy gd match source-address any",
+				"set security policies global policy gd match destination-address any",
+				"set security policies global policy gd match application any",
+				"set security policies global policy gd then deny session-init",
+			},
+			want: `global policy "gd" then deny "session-init"`,
+		},
+		{
+			// count LEADS, orphaned session-init TRAILS — the whole collapsed
+			// tail is inspected and the orphan sub-token still fires even when a
+			// legitimate `count` modifier precedes it.
+			name: "zone-pair deny count session-init (no log)",
+			cmds: []string{
+				"set security zones security-zone trust",
+				"set security zones security-zone untrust",
+				"set security policies from-zone trust to-zone untrust policy web match source-address any",
+				"set security policies from-zone trust to-zone untrust policy web match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy web match application any",
+				"set security policies from-zone trust to-zone untrust policy web then deny count session-init",
+			},
+			want: `from-zone trust to-zone untrust policy "web" then deny "session-init"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildPolicyThenTree(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted orphaned then-deny log sub-token; want commit rejection (#3374)")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CompileConfig error = %q, want substring %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "#3374") {
+				t.Fatalf("CompileConfig error = %q, want #3374 reference", err.Error())
+			}
+		})
+	}
+}
+
+// TestPolicyThenDenyOrphanLogSubLenientWarns proves the tolerant
+// load/peer-sync path (CompileConfigLenient) does NOT fail on an orphaned
+// session sub-token — it compiles and records a #3374 warning so an
+// already-persisted config still boots (#1960 fail-closed-on-load doctrine).
+func TestPolicyThenDenyOrphanLogSubLenientWarns(t *testing.T) {
+	tree := buildPolicyThenTree(t,
+		"set security policies from-zone trust to-zone untrust policy web then deny session-init",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-failed on orphaned then-deny sub-token; want warn-and-boot: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3374") && strings.Contains(w, "session-init") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CompileConfigLenient warnings = %v, want a #3374 orphan-log-sub warning", cfg.Warnings)
+	}
+}
+
+// TestPolicyThenDenyLogWithSessionSubStillCommits proves the #3374 gate does
+// NOT regress the legitimate forms: a collapsed `then deny log session-init`
+// (and session-close, and both) and the canonical separate-node
+// `then deny` + `then log session-init` still commit and wire the log flags.
+func TestPolicyThenDenyLogWithSessionSubStillCommits(t *testing.T) {
+	t.Run("collapsed deny log session-init session-close", func(t *testing.T) {
+		tree := buildPolicyThenTree(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies from-zone trust to-zone untrust policy web match source-address any",
+			"set security policies from-zone trust to-zone untrust policy web match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy web match application any",
+			"set security policies from-zone trust to-zone untrust policy web then deny log session-init session-close",
+		)
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig rejected then deny log session-init session-close: %v", err)
+		}
+		p := findZonePairPolicy(t, cfg, "trust", "untrust", "web")
+		if p.Action != PolicyDeny {
+			t.Fatalf("Action = %v, want PolicyDeny", p.Action)
+		}
+		if p.Log == nil || !p.Log.SessionInit || !p.Log.SessionClose {
+			t.Fatalf("pol.Log both flags not wired: %+v (#3374 must not regress #3141)", p.Log)
+		}
+	})
+
+	t.Run("separate-node deny + log session-init", func(t *testing.T) {
+		tree := buildPolicyThenTree(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies from-zone trust to-zone untrust policy web match source-address any",
+			"set security policies from-zone trust to-zone untrust policy web match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy web match application any",
+			"set security policies from-zone trust to-zone untrust policy web then deny",
+			"set security policies from-zone trust to-zone untrust policy web then log session-init",
+		)
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig rejected separate-node deny + log session-init: %v", err)
+		}
+		p := findZonePairPolicy(t, cfg, "trust", "untrust", "web")
+		if p.Log == nil || !p.Log.SessionInit {
+			t.Fatalf("separate-node deny + log session-init not wired: %+v", p.Log)
+		}
+	})
+}


### PR DESCRIPTION
Closes #3374

## Problem

A flat-set `set security policies ... then deny session-init` (or
`session-close`) with NO accompanying `log` token collapses the session
sub-token onto the deny node as `Keys=["deny","session-init"]`.
`recognizedCollapsedDenyToken` accepts `session-init`/`session-close`
positionally — it cannot distinguish a top-level modifier from a `log`
sub-token on the flattened tail — so `validatePolicyThenDenyStrict` let the
form through and `applyCollapsedDenyModifiers` silently wired session-init/
session-close logging. In Junos `session-init`/`session-close` are
sub-options of `log` only; a bare `then deny session-init` is invalid syntax.

## Fix

The collapsed-tail scan in `validatePolicyThenDenyStrict` now detects whether
a `log` token is present in the same `then deny` action and rejects a bare
`session-init`/`session-close` that has no `log` parent (`emitOrphanLogSub`):

- **Strict (commit / commit-check):** hard-reject, naming the policy scope
  (zone-pair or global), the policy, and the offending sub-token, with a
  `#3374` reference and the corrective `then deny log session-init` form.
- **Lenient (load / peer-sync, `lenientPolicyThenDeny`):** downgrade to a
  `#3374` warning so an already-persisted config an older binary silently
  accepted still boots (#1960 no-brick doctrine, same as #3141/#3114/#3115).

The legitimate collapsed `then deny log session-init` and the canonical
separate-node `then deny` + `then log session-init` forms are unaffected. The
hierarchical shape `then { deny { session-init; } }` was already rejected by
the `supportedPolicyThenDenyChildren` allowlist (log/count only).

## Tests (RED on revert)

`pkg/config/compiler_policy_then_deny_3374_test.go`:
- strict reject: zone-pair + global, `session-init`/`session-close`/both, and
  a `count`-leads/orphan-trails tail;
- lenient warns (compiles, records the `#3374` warning);
- legitimate `then deny log session-init session-close` and separate-node
  `then deny` + `then log session-init` still commit and wire the log flags.

Neutering the orphan gate (forcing `hasLog := true`) makes every strict-reject
case ACCEPT the collapsed form again and drops the lenient warning — verified
RED on revert. `go test ./pkg/config/`, `go vet`, and `gofmt` are clean.

Docs: `pkg/config/README.md` then-deny grammar section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi