### PR TITLE
policymatch: fail closed on omitted query source-port (#3415)

### DIFF
--- a/pkg/cli/testpolicy_srcport_test.go
+++ b/pkg/cli/testpolicy_srcport_test.go
@@ -48,18 +48,24 @@ security {
 	return &CLI{store: store}
 }
 
-// TestTestPolicySourcePort asserts the #3107 contract for the local CLI `test
-// policy` surface: a source-port token threads into policymatch.Query.SrcPort,
-// so the verdict reflects a source-port-constrained policy.
+// TestTestPolicySourcePort asserts the #3107 source-port plumbing AND the #3415
+// fail-closed semantics for the local CLI `test policy` surface: a source-port
+// token threads into policymatch.Query.SrcPort, so the verdict reflects a
+// source-port-constrained policy.
 //
 //   - correct source-port 5000 (and dest 80) -> Policy match (permit)
 //   - wrong source-port 6000                  -> Default deny
-//   - absent source-port                      -> unspecified (matches, the
-//     pre-#3107 behavior is preserved when no source-port is given)
+//   - absent source-port                      -> Default deny (#3415): an
+//     omitted query source port fails closed against a source-port-constrained
+//     app, since the runtime always carries a concrete source port and would
+//     not match a packet whose source port differs from the app's `source-port`
+//     (supersedes #3107's earlier "absent matches" stance).
 //
 // FAIL-ON-REVERT: dropping the source-port parsing / the SrcPort field on the
 // Query makes SrcPort always 0 ("any port"), so the wrong-port case would
-// PERMIT (overmatch) and "wrong src port" flips red.
+// PERMIT (overmatch) and "wrong src port" flips red. Restoring the
+// `&& srcPort > 0` wildcard gate makes "absent src port" PERMIT again, flipping
+// that case red.
 func TestTestPolicySourcePort(t *testing.T) {
 	c := newSrcPortPolicyCLI(t)
 
@@ -81,7 +87,7 @@ func TestTestPolicySourcePort(t *testing.T) {
 		{
 			"absent src port",
 			[]string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "destination-port", "80"},
-			true,
+			false,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/grpcapi/server_show_testpolicy_srcport_test.go
+++ b/pkg/grpcapi/server_show_testpolicy_srcport_test.go
@@ -50,15 +50,22 @@ security {
 	return &Server{store: store}
 }
 
-// TestShowTestPolicySourcePort asserts the #3107 contract on the ShowText
-// "test-policy:" simulator (the operational `test policy` served via gRPC, the
-// remote `cli` backend): the `srcport=` topic key threads into
-// policymatch.Query.SrcPort, so the verdict reflects a source-port-constrained
-// policy.
+// TestShowTestPolicySourcePort asserts the #3107 source-port plumbing AND the
+// #3415 fail-closed semantics on the ShowText "test-policy:" simulator (the
+// operational `test policy` served via gRPC, the remote `cli` backend): the
+// `srcport=` topic key threads into policymatch.Query.SrcPort, so the verdict
+// reflects a source-port-constrained policy.
+//
+// #3415 supersedes #3107's original "absent src port matches" contract: an
+// OMITTED query source port against a SOURCE-port-constrained app now fails
+// closed (the runtime always carries a concrete source port and would not match
+// a packet whose source port differs from the app's `source-port`), so the
+// "absent src port" case is now a NON-match (default deny-all).
 //
 // FAIL-ON-REVERT: dropping the srcport parse / the SrcPort field on the Query
 // makes SrcPort always 0 ("any port"), so the wrong-port case would PERMIT
-// (overmatch) and "wrong src port" flips red.
+// (overmatch) and "wrong src port" flips red. Restoring the `&& srcPort > 0`
+// wildcard gate makes "absent src port" PERMIT again, flipping that case red.
 func TestShowTestPolicySourcePort(t *testing.T) {
 	s := srcPortPolicyStore(t)
 
@@ -69,7 +76,7 @@ func TestShowTestPolicySourcePort(t *testing.T) {
 	}{
 		{"correct src port", "test-policy:from=trust,to=untrust,proto=tcp,srcport=5000,port=80", true},
 		{"wrong src port", "test-policy:from=trust,to=untrust,proto=tcp,srcport=6000,port=80", false},
-		{"absent src port", "test-policy:from=trust,to=untrust,proto=tcp,port=80", true},
+		{"absent src port", "test-policy:from=trust,to=untrust,proto=tcp,port=80", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -235,8 +235,13 @@ simulator too. Only the literal `application any` token is match-any), honors bo
 source-port and destination-port terms
 (a destination-port-constrained term fails closed on an OMITTED query
 destination port, #3330 — mirroring the runtime keying exact_dst_ports/range
-terms on the concrete packet port; an omitted SOURCE port stays unconstrained
-per #3107's diagnostic stance), and
+terms on the concrete packet port; a SOURCE-port-constrained term likewise
+fails closed on an OMITTED query source port, #3415 — the runtime always
+carries a concrete source port and gates the app on it
+(`appid.matchTuple`/`policy.rs CompiledApplications.matches`), so certifying a
+permit for an omitted source port over-matches vs the runtime. This supersedes
+#3107's earlier "omitted source port stays unconstrained" diagnostic stance;
+an unconstrained source-port term still matches any source port), and
 enforces ICMP/ICMPv6 type/code constraints (#3284, junos-ping = type 8,
 junos-pingv6 = type 128) from `Query.ICMPType` / `Query.ICMPCode`. A
 type-constrained application term matches only when the query's type is known

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -927,14 +927,29 @@ func matchSingleApp(cfg *config.Config, appName string, queryProto uint8, queryP
 			return false
 		}
 	}
-	// Source port retains #3107's deliberate diagnostic stance: an OMITTED query
-	// source port (the ephemeral, operator-rarely-known dimension) is treated as
-	// "unconstrained" so a source-port-bearing app term still resolves. Only a
-	// SPECIFIED source port is checked. Narrowing this too would change the
-	// #3107 absent-source-port contract (TestShowTestPolicySourcePort), which is
-	// out of #3330's destination-port scope.
-	if app.SourcePort != "" && srcPort > 0 && !portMatches(app.SourcePort, srcPort) {
-		return false
+	// #3415: when the application term CONSTRAINS a source port, an OMITTED query
+	// source port must NOT match-any — it must fail closed, mirroring the runtime
+	// and the now fail-closed protocol (#3323) and destination-port (#3330)
+	// siblings above. The runtime always carries a concrete source port and the
+	// dataplane gates a source-port-constrained app on it (appid.matchTuple ->
+	// portInSpec(srcPort, appSrcPort); policy.rs CompiledApplications.matches): a
+	// packet whose source port differs from the app's `source-port` never
+	// matches. An omitted query source port arrives as 0, which a real app source
+	// port (e.g. 5000) never equals and no app range admits, so the constrained
+	// term does NOT match. The old `&& srcPort > 0` gate skipped the check for an
+	// omitted port — #3107's deliberate diagnostic stance — and over-certified a
+	// permit for a source-port-bearing app no concrete packet would hit. This
+	// supersedes that #3107 absent-source-port contract: source port is ephemeral
+	// and rarely known, but a SOURCE-PORT-CONSTRAINED app is rare, and certifying
+	// a permit/deny for a broader class of packets than the runtime enforces is
+	// the exact over-match #3323/#3330 closed. An UNCONSTRAINED source-port term
+	// (app.SourcePort == "") still matches any port, unchanged — the common case
+	// (no source-port constraint) is unaffected, so a query omitting source port
+	// against an ordinary destination-port app behaves exactly as before.
+	if app.SourcePort != "" {
+		if srcPort <= 0 || !portMatches(app.SourcePort, srcPort) {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/policymatch/srcport_omitted_3415_test.go
+++ b/pkg/policymatch/srcport_omitted_3415_test.go
@@ -1,0 +1,109 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// srcPortConstrainedAppCfg builds a trust->untrust permit policy whose
+// application term is a custom app constrained to TCP source-port 5000 (and
+// destination-port 80, so the term is otherwise satisfiable). Zones are defined
+// so the #3355 guard passes and this test isolates the #3415 source-port
+// semantics.
+func srcPortConstrainedAppCfg() *config.Config {
+	sec := config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Zones:         zones("trust", "untrust"),
+		Policies: []*config.ZonePairPolicies{
+			{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Policies: []*config.Policy{
+					{
+						Name:   "src5000-permit",
+						Action: config.PolicyPermit,
+						Match: config.PolicyMatch{
+							SourceAddresses:      []string{"any"},
+							DestinationAddresses: []string{"any"},
+							Applications:         []string{"src5000"},
+						},
+					},
+				},
+			},
+		},
+	}
+	apps := config.ApplicationsConfig{
+		Applications: map[string]*config.Application{
+			"src5000": {Name: "src5000", Protocol: "tcp", SourcePort: "5000", DestinationPort: "80"},
+		},
+	}
+	return cfgWith(sec, apps)
+}
+
+// TestSrcPortConstrainedAppOmittedQuerySrcPortNoMatch pins #3415: a
+// source-port-constrained application term must NOT match when the query OMITS
+// the source port. The runtime always carries a concrete source port and gates
+// a source-port-constrained app on it (appid.matchTuple -> portInSpec(srcPort,
+// appSrcPort); policy.rs CompiledApplications.matches), so a packet whose
+// source port differs from the app's `source-port` never matches. An omitted
+// query source port arrives as 0, which the real app source port (5000) never
+// equals, so the term fails closed — mirroring the #3323 (protocol) and #3330
+// (destination-port) siblings.
+//
+// FAIL-ON-REVERT: restoring `app.SourcePort != "" && srcPort > 0 && ...` skips
+// the source-port check for an omitted port, making this query MATCH
+// (Matched=true, permit) and over-certifying a permit no concrete packet could
+// hit (the #3107 wildcard stance #3415 supersedes), failing the
+// want-default-deny assertion.
+func TestSrcPortConstrainedAppOmittedQuerySrcPortNoMatch(t *testing.T) {
+	cfg := srcPortConstrainedAppCfg()
+
+	// SrcPort omitted (0); destination port supplied so only the source-port
+	// dimension is in question.
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	if res.Matched {
+		t.Fatalf("source-port-constrained app over-matched an omitted query source port (#3415); res = %+v", res)
+	}
+	if !res.DefaultUsed || res.Action != config.PolicyDeny {
+		t.Fatalf("want default-policy deny for an omitted query source port, got %+v", res)
+	}
+}
+
+// TestSrcPortConstrainedAppMatchingSrcPortStillPermits is the positive control:
+// the concrete in-spec source port still matches (the fix narrows, not breaks,
+// matching).
+func TestSrcPortConstrainedAppMatchingSrcPortStillPermits(t *testing.T) {
+	cfg := srcPortConstrainedAppCfg()
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", SrcPort: 5000, DstPort: 80})
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("concrete in-spec source port no longer matches (#3415 over-narrowed); res = %+v", res)
+	}
+}
+
+// TestSrcPortConstrainedAppWrongSrcPortNoMatch confirms the constraint is live:
+// a concrete WRONG source port does not match (this held before #3415 too, via
+// the SPECIFIED-port branch; it pins that the fix did not regress it).
+func TestSrcPortConstrainedAppWrongSrcPortNoMatch(t *testing.T) {
+	cfg := srcPortConstrainedAppCfg()
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", SrcPort: 6000, DstPort: 80})
+	if res.Matched {
+		t.Fatalf("wrong source port matched a source-port-constrained app; res = %+v", res)
+	}
+}
+
+// TestUnconstrainedSrcPortAppOmittedQuerySrcPortStillMatches pins that the
+// #3415 narrowing is scoped to SOURCE-port-CONSTRAINED apps only: an ordinary
+// app with NO source-port constraint still matches a query that omits the
+// source port (the common case is unaffected). web80 constrains only the
+// destination port, supplied here.
+func TestUnconstrainedSrcPortAppOmittedQuerySrcPortStillMatches(t *testing.T) {
+	cfg := portConstrainedAppCfg() // web80: tcp, destination-port 80, no source-port
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80}) // SrcPort omitted (0)
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("source-port-UNCONSTRAINED app must still match an omitted query source port (#3415 over-narrowed); res = %+v", res)
+	}
+}


### PR DESCRIPTION
## Summary

The policy-match simulator (`show security match-policies` / `test policy`, shared by the REST, gRPC, and CLI surfaces) checked an application term's source-port constraint ONLY when the query supplied a concrete source port. An OMITTED query source port was treated as unconstrained (`&& srcPort > 0` gate), so a source-port-bearing custom app still resolved to a match. This **over-certified** a permit/deny relative to the runtime, which always carries a concrete source port and would not match a packet whose source port differs from the app's `source-port`.

This was the last source-port residual that still failed OPEN. Its siblings in the same matcher were already closed:
- **#3323** — fails closed on an omitted/unresolvable query **protocol**.
- **#3330** — fails closed on an omitted query **destination port** for a dst-port-constrained term.

## Chosen semantics: fail closed (mirror #3323/#3330)

When the application term constrains a source port and the query omits it, the term does not match — an omitted source port arrives as 0, which a real app source port (e.g. 5000) never equals and no app range admits. This is exactly how the runtime behaves: `appid.matchTuple -> portInSpec(srcPort, appSrcPort)` / `policy.rs CompiledApplications.matches`.

This **supersedes #3107's** earlier "omitted source port stays unconstrained" diagnostic stance. An indeterminate-result UX was considered but rejected: it would be far more invasive (a new `Result` axis threaded through all three surfaces) and inconsistent with the two fail-closed siblings in the same function. An **UNCONSTRAINED** source-port term (`app.SourcePort == ""`) still matches any source port, so the common case (the vast majority of apps) is unaffected.

## Validation

- New `pkg/policymatch/srcport_omitted_3415_test.go`: omitted query source port vs a source-port-constrained app → default deny; positive control (concrete in-spec port still permits); wrong-port + source-port-UNCONSTRAINED-app controls.
- Updated #3107 contract tests (grpcapi `ShowText` test-policy, cli `testPolicy`): "absent src port" now expects a non-match.
- **RED-on-revert verified**: restoring `&& srcPort > 0` flips the new policymatch test AND both "absent src port" contract cases red across all three surfaces.
- `go test ./pkg/policymatch/ ./pkg/grpcapi/ ./pkg/api/ ./pkg/cli/` green; gofmt clean; go vet clean for touched files.
- README.md updated to document the #3415 source-port fail-closed semantics alongside its #3323/#3330 siblings.

Closes #3415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi