### PR TITLE
userspace-dp/policy: clear epoch so hit-count clear is durable (#3448)

### DIFF
--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -780,6 +780,16 @@ impl Clone for PolicyRule {
 pub(crate) struct PolicyRuleCounter {
     packets: AtomicU64,
     bytes: AtomicU64,
+    /// #3448: clear epoch. `clear security policies hit-count` resets the
+    /// shared `packets`/`bytes` atomics but cannot reach the per-worker
+    /// pending hit-count batches buffered by `record_policy_hit_counter`
+    /// (up to `POLICY_HIT_FLUSH_PACKETS`). Without an epoch, a pending batch
+    /// recorded before the clear would `add_batch` its stale pre-clear counts
+    /// onto the freshly-zeroed counter at the next RX-batch flush, so the
+    /// clear appeared to fail or to invent traffic. `reset()` bumps this
+    /// generation; each pending batch records the generation it was captured
+    /// under and is DISCARDED (not flushed) if the generation has advanced.
+    generation: AtomicU64,
 }
 
 impl PolicyRuleCounter {
@@ -805,8 +815,20 @@ impl PolicyRuleCounter {
     }
 
     fn reset(&self) {
+        // #3448: bump the clear epoch so any per-worker pending batch still
+        // holding pre-clear counts (recorded under the previous generation)
+        // is discarded at its next flush instead of replaying onto the
+        // freshly-zeroed atomics. The generation only ever increases.
+        self.generation.fetch_add(1, Ordering::Relaxed);
         self.packets.store(0, Ordering::Relaxed);
         self.bytes.store(0, Ordering::Relaxed);
+    }
+
+    /// #3448: current clear epoch. Stamped onto a per-worker pending batch
+    /// when it is captured and re-checked at flush time to drop stale
+    /// pre-clear counts.
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
     }
 
     fn snapshot(&self, rule_id: &str) -> PolicyRuleCounterStatus {
@@ -878,6 +900,11 @@ impl PolicyCounterStore {
 // run of same-flow packets on a pure thread-local add.
 struct PendingPolicyHitRecord {
     counter: Option<Arc<PolicyRuleCounter>>,
+    /// #3448: clear epoch the buffered `packets`/`bytes` were recorded under.
+    /// Compared against the counter's current generation at flush time so a
+    /// `clear` that happened after this batch was captured discards the
+    /// pre-clear counts instead of replaying them.
+    generation: u64,
     packets: u64,
     bytes: u64,
 }
@@ -886,6 +913,7 @@ impl Default for PendingPolicyHitRecord {
     fn default() -> Self {
         Self {
             counter: None,
+            generation: 0,
             packets: 0,
             bytes: 0,
         }
@@ -901,13 +929,22 @@ thread_local! {
         std::cell::RefCell::new(PendingPolicyHitRecord::default());
 }
 
-#[cfg(not(test))]
+// Not gated on `#[cfg(not(test))]`: the generation-discard logic is the
+// load-bearing part of the #3448 fix and is unit-tested directly (the
+// per-worker thread-local coalescer itself is bypassed under `#[cfg(test)]`).
 #[inline(always)]
 fn flush_pending_policy_hit_record(record: &mut PendingPolicyHitRecord) {
     let Some(counter) = record.counter.take() else {
         return;
     };
-    counter.add_batch(record.packets, record.bytes);
+    // #3448: only fold the pending batch into the shared counter if it was
+    // recorded under the counter's CURRENT clear epoch. If a
+    // `clear security policies hit-count` bumped the generation between
+    // capture and this flush, these are pre-clear hits — discard them so the
+    // clear is durable and the freshly-zeroed counter does not snap back.
+    if record.generation == counter.generation() {
+        counter.add_batch(record.packets, record.bytes);
+    }
     record.packets = 0;
     record.bytes = 0;
 }
@@ -922,16 +959,25 @@ fn flush_pending_policy_hit_record(record: &mut PendingPolicyHitRecord) {
 pub(crate) fn record_policy_hit_counter(counter: &Arc<PolicyRuleCounter>, packet_bytes: u64) {
     PENDING_POLICY_HIT_RECORD.with(|pending| {
         let mut pending = pending.borrow_mut();
+        let generation = counter.generation();
+        // #3448: continue the current batch only when it is the SAME counter
+        // AND the SAME clear epoch. A `clear` mid-batch advances the
+        // generation; the else branch then flushes (and discards, via the
+        // generation guard) the stale pre-clear tally and re-captures the
+        // counter under the new generation, so post-clear packets are counted
+        // fresh from zero instead of being dropped with the pre-clear batch.
         if pending
             .counter
             .as_ref()
             .is_some_and(|current| Arc::ptr_eq(current, counter))
+            && pending.generation == generation
         {
             pending.packets = pending.packets.saturating_add(1);
             pending.bytes = pending.bytes.saturating_add(packet_bytes);
         } else {
             flush_pending_policy_hit_record(&mut pending);
             pending.counter = Some(counter.clone());
+            pending.generation = generation;
             pending.packets = 1;
             pending.bytes = packet_bytes;
         }

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -4601,3 +4601,121 @@ fn app_term_icmp_constrained_before_all_icmp_wins() {
         "all-icmp term listed first must win for an echo packet"
     );
 }
+
+// ── #3448: `clear security policies hit-count` must not replay pre-clear
+// hits buffered in the per-worker pending coalescer ────────────────────────
+//
+// The #3073 coalescer (`record_policy_hit_counter`) buffers up to
+// POLICY_HIT_FLUSH_PACKETS established-flow hits in a thread-local
+// `PendingPolicyHitRecord` before folding them into the shared
+// `PolicyRuleCounter` atomics. `clear()` only zeroes the shared atomics, so
+// before #3448 a pending batch captured before the clear would `add_batch`
+// its stale pre-clear counts onto the freshly-zeroed counter at the next
+// flush — the clear appeared to fail or to invent traffic.
+//
+// These tests drive the load-bearing flush helper directly because the
+// thread-local coalescer is compiled out under `#[cfg(test)]`.
+
+#[test]
+fn clear_discards_pre_clear_pending_policy_hits_3448() {
+    let counter = Arc::new(PolicyRuleCounter::default());
+
+    // A worker buffered 30 established-flow hits for an admitting policy that
+    // have NOT yet been folded into the shared atomics.
+    let mut pending = PendingPolicyHitRecord {
+        counter: Some(counter.clone()),
+        generation: counter.generation(),
+        packets: 30,
+        bytes: 30 * 100,
+    };
+
+    // Operator runs `clear security policies hit-count`: shared atomics zeroed,
+    // clear epoch bumped.
+    counter.reset();
+    let after_clear = counter.snapshot("allow-web");
+    assert_eq!(after_clear.packets, 0, "clear must zero the shared atomics");
+    assert_eq!(after_clear.bytes, 0);
+
+    // The worker's next RX-batch flush must DISCARD the stale pre-clear batch,
+    // not replay it onto the freshly-zeroed counter.
+    flush_pending_policy_hit_record(&mut pending);
+    let after_flush = counter.snapshot("allow-web");
+    assert_eq!(
+        after_flush.packets, 0,
+        "pre-clear pending hits replayed after clear (snap-back) — #3448"
+    );
+    assert_eq!(
+        after_flush.bytes, 0,
+        "pre-clear pending bytes replayed after clear (snap-back) — #3448"
+    );
+    // The discarded batch is drained so it cannot be re-applied.
+    assert!(pending.counter.is_none());
+    assert_eq!(pending.packets, 0);
+    assert_eq!(pending.bytes, 0);
+}
+
+#[test]
+fn post_clear_pending_policy_hits_flush_normally_3448() {
+    let counter = Arc::new(PolicyRuleCounter::default());
+    // Clear first so the live epoch is non-zero.
+    counter.reset();
+
+    // A batch captured AFTER the clear (current epoch) must flush normally —
+    // the generation guard must not over-discard legitimate post-clear hits.
+    let mut pending = PendingPolicyHitRecord {
+        counter: Some(counter.clone()),
+        generation: counter.generation(),
+        packets: 7,
+        bytes: 7 * 100,
+    };
+    flush_pending_policy_hit_record(&mut pending);
+    let snap = counter.snapshot("allow-web");
+    assert_eq!(
+        snap.packets, 7,
+        "post-clear hits captured under the current epoch must be counted"
+    );
+    assert_eq!(snap.bytes, 700);
+}
+
+#[test]
+fn clear_bumps_policy_counter_generation_3448() {
+    let counter = Arc::new(PolicyRuleCounter::default());
+    let g0 = counter.generation();
+    counter.reset();
+    let g1 = counter.generation();
+    counter.reset();
+    let g2 = counter.generation();
+    assert!(g1 > g0, "clear must advance the counter generation");
+    assert!(g2 > g1, "each clear must advance the counter generation");
+}
+
+#[test]
+fn store_clear_bumps_generation_for_all_counters_3448() {
+    // PolicyCounterStore::clear (the control-plane `clear_policy_counters`
+    // entry point) must bump every registered counter's epoch so buffered
+    // pre-clear batches against any rule are discarded.
+    let store = PolicyCounterStore::default();
+    let c_allow = store.rule_hit_counter("security-policy:trust:untrust:allow-web");
+    let c_deny = store.rule_hit_counter(DEFAULT_POLICY_COUNTER_RULE_ID);
+    let g_allow0 = c_allow.generation();
+    let g_deny0 = c_deny.generation();
+
+    // Buffer a pre-clear batch against allow-web.
+    let mut pending = PendingPolicyHitRecord {
+        counter: Some(c_allow.clone()),
+        generation: c_allow.generation(),
+        packets: 50,
+        bytes: 50 * 64,
+    };
+
+    store.clear();
+    assert!(c_allow.generation() > g_allow0);
+    assert!(c_deny.generation() > g_deny0);
+
+    flush_pending_policy_hit_record(&mut pending);
+    assert_eq!(
+        c_allow.snapshot("allow-web").packets,
+        0,
+        "store clear must invalidate pre-clear pending batches — #3448"
+    );
+}


### PR DESCRIPTION
Closes #3448

## Problem
`clear security policies hit-count` could leave pre-clear hits that
reappear after the clear. The #3073 per-worker hit-count coalescer keeps
up to `POLICY_HIT_FLUSH_PACKETS` (64) pending hits in thread-local state
per worker before folding them into the shared `PolicyRuleCounter`
atomics. The clear path
(`clear_policy_counters` -> `PolicyCounterStore::clear` ->
`PolicyRuleCounter::reset`) reset only the shared atomics; it could not
reach the per-worker pending batches. After the clear, the next RX-batch
flush did `add_batch(pending)` and re-added the stale pre-clear counts
onto the freshly-zeroed counter, so `show security policies hit-count`
reported non-zero hits that predate the clear (#2218-class snap-back),
undermining clear-then-observe incident/audit workflows.

## Fix
Add a clear epoch (generation `AtomicU64`) to `PolicyRuleCounter`:
- `reset()` bumps the generation and zeroes the atomics.
- Each per-worker `PendingPolicyHitRecord` stamps the generation it was
  captured under; `flush_pending_policy_hit_record` **discards** (does not
  fold) any batch whose generation no longer matches the counter's current
  generation, so pre-clear hits cannot resurrect post-clear.
- `record_policy_hit_counter` re-checks the generation: a clear mid-batch
  advances the epoch, the stale tally is dropped, and the counter is
  re-captured under the new epoch so legitimate post-clear packets are
  counted fresh from zero rather than discarded with the pre-clear batch.

Mirrors the durable-clear discipline of the #2218 NAT-counter clear and the
#3363 default-policy counter clear.

### Scope notes
- The sibling filter-term coalescer (`filter::flush_recorded_filter_counters`)
  has the same structural pattern but **no control-plane clear path reaches
  it** (there is no clear-firewall-filter-counters command in userspace-dp),
  so it cannot replay and is left unchanged.
- The Go control plane only forwards the clear (`cli clear security policies
  hit-count` -> `ClearPolicyCounters` -> `clear_policy_counters`) and needs
  no change.

## Tests (RED on revert)
- `clear_discards_pre_clear_pending_policy_hits_3448` — a batch captured
  before `reset()` is discarded at flush; counter stays 0. **RED on revert**
  of the flush generation guard (replays 30 packets / 3000 bytes).
- `store_clear_bumps_generation_for_all_counters_3448` — `PolicyCounterStore::clear`
  bumps every registered counter's epoch (incl. the reserved default-policy
  counter); a buffered pre-clear batch is discarded. **RED on revert.**
- `post_clear_pending_policy_hits_flush_normally_3448` — a batch captured
  under the current epoch flushes normally (guards against over-discard of
  legitimate post-clear hits).
- `clear_bumps_policy_counter_generation_3448` — each clear advances the epoch.

## Validation
- `cargo test policy::` — 122 existing + 4 new pass; the two snap-back tests
  fail when the flush generation guard is reverted (verified).
- `go test ./pkg/dataplane/userspace/ ./pkg/cli/ ./pkg/grpcapi/ ./pkg/config/` — green.
- `go vet` clean for touched packages (pre-existing cli.go:503 warning untouched).
- No operator/design doc change needed: the coalescer is an internal
  correctness invariant (documented in code); clear-then-observe now behaves
  as the CLI reference already describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi