### PR TITLE
config/nat: reject destination-NAT rule-set `to` scope at commit (#3444)

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1095,6 +1095,38 @@ reserved for whole-dataplane selection where a rewrite shim
   no-op knob, not a false dataplane/identity promise — and its real
   implementation is split to /research. Regression coverage:
   `pkg/config/compiler_interfaces_unsupported_test.go`.
+- **#3444 (destination-NAT rule-set `to` scope reject):** a Junos
+  destination-NAT rule-set has only a `from` clause (zone | interface |
+  routing-instance) — DNAT translates the destination on inbound, so there
+  is no egress / `to` context (only source NAT, which has both `from` and
+  `to`, can scope by an egress context). xpf briefly advertised a `to`
+  subtree under `security nat destination rule-set` and
+  `compileNATDestination` Cartesian-expanded the collected `to` scopes onto
+  each `NATRuleSet` (`ToZone`/`ToInterface`/`ToRoutingInstance`), but the
+  userspace snapshot builder (`buildDestinationNATSnapshots`,
+  `pkg/dataplane/userspace/nat.go`) and the Rust DNAT runtime
+  (`userspace-dp/src/nat/destination.rs`) model ONLY the `from` clause — the
+  `DestinationNATRuleSnapshot` wire struct intentionally has no `to_*`. So a
+  configured `to` scope was silently dropped: the translation applied
+  regardless of the operator's declared destination context, with no commit
+  error. The `to` subtree is removed from the DNAT rule-set `setSchema` (so
+  completion no longer offers it), `compileNATDestination` no longer collects
+  or stamps a `to` scope (`collectNATScopes(..., false)` — no phantom `To*`
+  on the typed config), and an AST pre-walk
+  (`validateDNATRuleSetToScopeAST`, `compiler_nat_dnat_to.go`) hard-rejects
+  any `to` scope at strict commit / commit-check, naming the rule-set. Strict
+  on commit, downgraded to a warning on the tolerant load / peer-sync paths
+  (`lenientDNATToScope`, #1960 fail-closed-on-load doctrine) so an
+  older-binary-persisted or peer-synced config that silently accepted a `to`
+  scope still boots (the scope is ignored either way, now flagged); an
+  `inactive:` / apply-groups-inherited `to` is handled correctly (the walk
+  runs after the inactive prune + group expansion). Detection is scoped to
+  `security nat destination rule-set` so the source-NAT `to` clause (a real
+  feature, #3096) is untouched. If a future design genuinely wants
+  egress-scoped DNAT after route resolution, that is a separate enhancement
+  (add `to_*` to the snapshot + runtime + a regression that a mismatched
+  `to zone` DNAT does not translate). Regression coverage:
+  `pkg/config/compiler_nat_dnat_to_3444_test.go`.
 - **#3200 (host-inbound-traffic token validation):** `security zones <z>
   host-inbound-traffic { system-services <tok>; protocols <tok>; }` keeps its
   untyped-container schema shape (the leaves stay `children: nil` so flat-set

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1208,6 +1208,25 @@ type compileOpts struct {
 	// peer-synced config an older binary accepted still BOOTS (#1960
 	// fail-closed-on-load class). Same doctrine as lenientBackupRouterDst.
 	lenientVRRPVirtualAddress bool
+
+	// lenientDNATToScope (#3444) downgrades the destination-NAT rule-set
+	// `to` scope reject (validateDNATRuleSetToScopeAST) from a hard compile
+	// error to a cfg.Warnings entry. Junos destination NAT rule-sets have
+	// only a `from` clause (DNAT translates the destination on inbound, so
+	// there is no egress context yet); xpf's schema briefly advertised a
+	// `to` scope under `security nat destination rule-set` and the compiler
+	// Cartesian-expanded it onto each NATRuleSet, but the userspace snapshot
+	// builder and the Rust DNAT runtime model ONLY the `from` clause — so a
+	// configured `to zone|interface|routing-instance` was silently dropped
+	// and the translation applied regardless of the operator's declared
+	// destination context (a silent functional lie). The strict commit /
+	// commit-check path hard-rejects so the operator error is visible; the
+	// tolerant load / peer-sync paths downgrade to a warning so an
+	// already-persisted or peer-synced config an older binary accepted still
+	// BOOTS (#1960 fail-closed-on-load class) — the `to` scope is ignored
+	// either way, now flagged. Same doctrine as
+	// lenientUnsupportedInterfaceStanzas.
+	lenientDNATToScope bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -1305,6 +1324,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyMissingMatch:            true,
 		lenientPolicyCommunityRef:            true,
 		lenientVRRPVirtualAddress:            true,
+		lenientDNATToScope:                   true,
 	})
 }
 
@@ -1453,6 +1473,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyMissingMatch:            true,
 		lenientPolicyCommunityRef:            true,
 		lenientVRRPVirtualAddress:            true,
+		lenientDNATToScope:                   true,
 	})
 }
 
@@ -1648,6 +1669,12 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	// named ingress/egress interface or routing-instance instead of being
 	// silently widened to match-any. The validateNATRuleSetScopeAST gate and
 	// its lenientNATRuleSetScope opt are removed.
+	//
+	// #3444 caveat: this enforcement covers the `from` scope for all three
+	// NAT kinds AND the `to` scope for SOURCE NAT (source.rs reads to_*).
+	// DESTINATION NAT has only a `from` clause (Junos) — the DNAT snapshot /
+	// runtime model no `to_*`, so a DNAT `to` scope is rejected at commit by
+	// validateDNATRuleSetToScopeAST below rather than enforced.
 
 	// #2933 secure-tunnel bind-interface alias-collision gate. Two VPNs that
 	// bind two DISTINCT bind-interface strings deriving the SAME XFRM if_id
@@ -1759,6 +1786,25 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #3444: reject a `security nat destination rule-set <name> to ...`
+	// scope. A Junos destination-NAT rule-set has only a `from` clause —
+	// DNAT translates the destination on inbound, so there is no egress
+	// context yet. xpf briefly advertised a `to` scope under the DNAT
+	// rule-set and Cartesian-expanded it onto each NATRuleSet, but the
+	// userspace snapshot builder and the Rust DNAT runtime model ONLY the
+	// `from` clause, so the `to` scope was silently dropped and the
+	// translation applied regardless of the declared destination context.
+	// Runs on the group-expanded, inactive-pruned tree so an apply-groups-
+	// inherited `to` is caught and an inactive rule-set is ignored. Strict
+	// (commit / commit-check): hard-reject naming the rule-set. Lenient
+	// (load / peer-sync): warn so an already-persisted or peer-synced
+	// config still boots (#1960) — the `to` stays ignored, now flagged.
+	dnatToScopeWarnings, err := validateDNATRuleSetToScopeAST(
+		tree.Children, opts.lenientDNATToScope)
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		Security: SecurityConfig{
 			Zones:  make(map[string]*ZoneConfig),
@@ -1806,6 +1852,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, policyThenRejectWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyThenDenyWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMissingMatchWarnings...)
+	cfg.Warnings = append(cfg.Warnings, dnatToScopeWarnings...)
 
 	for _, node := range tree.Children {
 		switch node.Name() {

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1452,9 +1452,15 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 
 	// Parse rule-sets
 	for _, rsInst := range namedInstances(node.FindChildren("rule-set")) {
-		// #3096: capture from/to scope across zone | interface |
+		// #3096: capture the `from` scope across zone | interface |
 		// routing-instance (bracket lists produce multiple scopes).
-		fromScopes, toScopes := collectNATScopes(rsInst.node, true)
+		// #3444: a destination-NAT rule-set has only a `from` clause — DNAT
+		// translates the destination on inbound, so there is no egress
+		// context. A `to` scope is rejected at strict commit
+		// (validateDNATRuleSetToScopeAST); it is NOT collected here so it
+		// can never be stamped onto a NATRuleSet (the snapshot builder and
+		// the Rust DNAT runtime model only the `from` clause).
+		fromScopes, _ := collectNATScopes(rsInst.node, false)
 
 		var rules []*NATRule
 		for _, ruleInst := range namedInstances(rsInst.node.FindChildren("rule")) {
@@ -1547,17 +1553,14 @@ func compileNATDestination(node *Node, sec *SecurityConfig) error {
 			rules = append(rules, rule)
 		}
 
-		// Expand Cartesian product of from-scopes × to-scopes (#3096).
+		// Expand per from-scope (#3096). DNAT carries no `to` scope (#3444).
 		for _, fs := range fromScopes {
-			for _, ts := range toScopes {
-				rs := &NATRuleSet{
-					Name:  rsInst.name,
-					Rules: rules,
-				}
-				applyNATFromScope(rs, fs)
-				applyNATToScope(rs, ts)
-				sec.NAT.Destination.RuleSets = append(sec.NAT.Destination.RuleSets, rs)
+			rs := &NATRuleSet{
+				Name:  rsInst.name,
+				Rules: rules,
 			}
+			applyNATFromScope(rs, fs)
+			sec.NAT.Destination.RuleSets = append(sec.NAT.Destination.RuleSets, rs)
 		}
 	}
 	return nil

--- a/pkg/config/compiler_nat_dnat_to.go
+++ b/pkg/config/compiler_nat_dnat_to.go
@@ -61,41 +61,71 @@ func validateDNATRuleSetToScopeAST(nodes []*Node, lenient bool) ([]string, error
 		return nil
 	}
 
-	// Iterate EVERY top-level `security` node, not just the first match.
-	// parseStatements APPENDS a repeated top-level block instead of merging
-	// it (parser.go) and compileExpanded processes every `security` root, so
-	// a config (e.g. a hierarchical LoadOverride input) with two `security {}`
-	// blocks where only the SECOND carries the DNAT `to` would bypass a
-	// first-match-only walk while the compiler still compiled the second
-	// block's rule-set with the `to` silently dropped (the original #3444
-	// bug). Mirror the compiler's root iteration so a DNAT `to` in ANY
-	// duplicate `security` block is caught.
-	for _, n := range nodes {
-		if n.Name() != "security" {
-			continue
-		}
-		natNode := n.FindChild("nat")
-		if natNode == nil {
-			continue
-		}
-		dstNode := natNode.FindChild("destination")
-		if dstNode == nil {
-			continue
-		}
-		for _, rs := range namedInstances(dstNode.FindChildren("rule-set")) {
-			if rs.node.FindChild("to") == nil {
-				continue
-			}
-			if err := emit(
-				"security nat destination rule-set %q: a `to` scope is not "+
-					"supported on a destination-NAT rule-set (Junos DNAT has only "+
-					"a `from` clause — the destination is translated on inbound, so "+
-					"there is no egress context; the `to` scope was silently ignored "+
-					"and the translation applied regardless of it) — remove it (#3444)",
-				rs.name); err != nil {
-				return nil, err
-			}
-		}
+	// Iterate ALL matching children at EVERY level the walk descends, not
+	// the first match at any level. parseStatements APPENDS a repeated block
+	// instead of merging it (parser.go), and the compiler iterates siblings
+	// at each level it descends — compileExpanded processes every `security`
+	// root, compileSecurity compiles every `nat` sibling. So a first-match-
+	// only walk is bypassable at EVERY level (the multi-level duplicate-block
+	// class, #3562): e.g. ONE `security` root with a benign first `nat {}` +
+	// a second `nat { destination { rule-set RD { to zone trust; ... } } }`
+	// would slip past a first-`nat` walk while the compiler still compiles
+	// the second `nat`'s rule-set with the `to` silently dropped (the
+	// original #3444 bug, reachable via a hierarchical LoadOverride input).
+	// Using forEachChild at security/nat/destination guarantees a DNAT `to`
+	// in ANY duplicate block at ANY level is caught. The inner rule-set
+	// iteration + narrow direct-`to` check is unchanged — the scope
+	// precision stays destination-only so the source-NAT `to` (#3096) is
+	// untouched. (compileNAT itself reads only the first `destination` per
+	// `nat`, so a duplicate `destination` WITHIN one `nat` is not currently
+	// compiler-reachable for the silent drop; the walk rejects it anyway —
+	// fail-closed and defensive against future compiler changes.)
+	err := forEachChild(nodes, "security", func(sec *Node) error {
+		return forEachChild(sec.Children, "nat", func(nat *Node) error {
+			return forEachChild(nat.Children, "destination", func(dst *Node) error {
+				for _, rs := range namedInstances(dst.FindChildren("rule-set")) {
+					if rs.node.FindChild("to") == nil {
+						continue
+					}
+					if err := emit(
+						"security nat destination rule-set %q: a `to` scope is not "+
+							"supported on a destination-NAT rule-set (Junos DNAT has only "+
+							"a `from` clause — the destination is translated on inbound, so "+
+							"there is no egress context; the `to` scope was silently ignored "+
+							"and the translation applied regardless of it) — remove it (#3444)",
+						rs.name); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		})
+	})
+	if err != nil {
+		return nil, err
 	}
 	return warnings, nil
+}
+
+// forEachChild invokes fn for every node in children whose Name() equals
+// name, stopping and propagating the first error fn returns. It is the
+// reference iterate-ALL-siblings primitive for the multi-level duplicate-
+// block bypass class (#3562): the Junos parser APPENDS a repeated block as a
+// sibling instead of merging it (parseStatements, parser.go) and the compiler
+// iterates siblings at each level it descends, so a strict-reject AST walk
+// that uses FindChild (first match) at ANY level it descends can be bypassed
+// by placing the offending stanza in a duplicate block. Descending with
+// forEachChild at every level closes that bypass. `children` is a `[]*Node`
+// so the same primitive covers the top-level roots slice and every
+// node.Children slice uniformly.
+func forEachChild(children []*Node, name string, fn func(*Node) error) error {
+	for _, c := range children {
+		if c.Name() != name {
+			continue
+		}
+		if err := fn(c); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/config/compiler_nat_dnat_to.go
+++ b/pkg/config/compiler_nat_dnat_to.go
@@ -1,0 +1,98 @@
+package config
+
+import "fmt"
+
+// compiler_nat_dnat_to.go carries the #3444 reject-at-commit gate for a
+// destination-NAT rule-set `to` scope.
+//
+// A Junos destination-NAT rule-set has only a `from` clause (zone |
+// interface | routing-instance). DNAT translates the destination address on
+// the inbound packet, so there is no egress / `to` context yet — only source
+// NAT (which has both `from` and `to`) and the routed forward path can scope
+// by an egress context. xpf's setSchema briefly advertised a `to` scope under
+// `security nat destination rule-set`, and compileNATDestination
+// Cartesian-expanded the collected `to` scopes onto each NATRuleSet
+// (ToZone/ToInterface/ToRoutingInstance). But the userspace snapshot builder
+// (pkg/dataplane/userspace/nat.go buildDestinationNATSnapshots) and the Rust
+// DNAT runtime (userspace-dp/src/nat/destination.rs) model ONLY the `from`
+// clause for DNAT — the DestinationNATRuleSnapshot wire struct intentionally
+// has no `to_*`. So a configured `to zone|interface|routing-instance` was
+// silently dropped: the translation applied regardless of the operator's
+// declared destination context, and the operator got no error. Admitting a
+// `to` scope that the running firewall does not enforce is a silent
+// functional lie, so this gate hard-rejects it at commit / commit-check and
+// warns (does not fail) on the tolerant load / peer-sync paths per the #1960
+// fail-closed-on-load doctrine.
+//
+// This is an AST pre-walk (not a SchemaValidate typed leaf) because
+// SchemaValidate is opt-in per known leaf and returns nil for unknown
+// keywords by design (schema_walk.go) — it cannot REJECT a stanza, and the
+// `to` keyword itself is legitimate elsewhere (source NAT rule-sets). The
+// `to` subtree has also been removed from the DNAT rule-set setSchema so the
+// CLI no longer offers it in completion; this gate covers the runtime
+// reject + the already-persisted lenient-load path. Detection is scoped to
+// `security nat destination rule-set` so the source-NAT `to` clause (a real
+// feature) is never touched. The walk runs on the group-expanded,
+// inactive-pruned tree (compileConfigWithOpts / compileConfigForNodeWithOpts
+// strip inactive subtrees and expand groups before compileExpanded), so an
+// apply-groups-inherited `to` is caught and an `inactive:` rule-set is
+// ignored for free.
+
+// validateDNATRuleSetToScopeAST walks the `security nat destination
+// rule-set` subtree of the group-expanded AST and rejects any rule-set
+// carrying a `to` scope.
+//
+// Strict path (commit / commit-check, lenient=false): the first offending
+// rule-set is a hard compile error, naming the exact rule-set.
+//
+// Lenient path (load / peer-sync, lenient=true): every offending rule-set is
+// returned as a warning and compilation continues. The `to` subtree is NOT
+// pruned — compileNATDestination no longer reads it (collectNATScopes with
+// wantTo=false), so leaving it in the cloned tree is harmless and the warning
+// is the operator signal.
+func validateDNATRuleSetToScopeAST(nodes []*Node, lenient bool) ([]string, error) {
+	var security *Node
+	for _, n := range nodes {
+		if n.Name() == "security" {
+			security = n
+			break
+		}
+	}
+	if security == nil {
+		return nil, nil
+	}
+	natNode := security.FindChild("nat")
+	if natNode == nil {
+		return nil, nil
+	}
+	dstNode := natNode.FindChild("destination")
+	if dstNode == nil {
+		return nil, nil
+	}
+
+	var warnings []string
+	emit := func(format string, args ...any) error {
+		msg := fmt.Sprintf(format, args...)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
+	for _, rs := range namedInstances(dstNode.FindChildren("rule-set")) {
+		if rs.node.FindChild("to") == nil {
+			continue
+		}
+		if err := emit(
+			"security nat destination rule-set %q: a `to` scope is not "+
+				"supported on a destination-NAT rule-set (Junos DNAT has only "+
+				"a `from` clause — the destination is translated on inbound, so "+
+				"there is no egress context; the `to` scope was silently ignored "+
+				"and the translation applied regardless of it) — remove it (#3444)",
+			rs.name); err != nil {
+			return nil, err
+		}
+	}
+	return warnings, nil
+}

--- a/pkg/config/compiler_nat_dnat_to.go
+++ b/pkg/config/compiler_nat_dnat_to.go
@@ -51,25 +51,6 @@ import "fmt"
 // wantTo=false), so leaving it in the cloned tree is harmless and the warning
 // is the operator signal.
 func validateDNATRuleSetToScopeAST(nodes []*Node, lenient bool) ([]string, error) {
-	var security *Node
-	for _, n := range nodes {
-		if n.Name() == "security" {
-			security = n
-			break
-		}
-	}
-	if security == nil {
-		return nil, nil
-	}
-	natNode := security.FindChild("nat")
-	if natNode == nil {
-		return nil, nil
-	}
-	dstNode := natNode.FindChild("destination")
-	if dstNode == nil {
-		return nil, nil
-	}
-
 	var warnings []string
 	emit := func(format string, args ...any) error {
 		msg := fmt.Sprintf(format, args...)
@@ -80,18 +61,40 @@ func validateDNATRuleSetToScopeAST(nodes []*Node, lenient bool) ([]string, error
 		return nil
 	}
 
-	for _, rs := range namedInstances(dstNode.FindChildren("rule-set")) {
-		if rs.node.FindChild("to") == nil {
+	// Iterate EVERY top-level `security` node, not just the first match.
+	// parseStatements APPENDS a repeated top-level block instead of merging
+	// it (parser.go) and compileExpanded processes every `security` root, so
+	// a config (e.g. a hierarchical LoadOverride input) with two `security {}`
+	// blocks where only the SECOND carries the DNAT `to` would bypass a
+	// first-match-only walk while the compiler still compiled the second
+	// block's rule-set with the `to` silently dropped (the original #3444
+	// bug). Mirror the compiler's root iteration so a DNAT `to` in ANY
+	// duplicate `security` block is caught.
+	for _, n := range nodes {
+		if n.Name() != "security" {
 			continue
 		}
-		if err := emit(
-			"security nat destination rule-set %q: a `to` scope is not "+
-				"supported on a destination-NAT rule-set (Junos DNAT has only "+
-				"a `from` clause — the destination is translated on inbound, so "+
-				"there is no egress context; the `to` scope was silently ignored "+
-				"and the translation applied regardless of it) — remove it (#3444)",
-			rs.name); err != nil {
-			return nil, err
+		natNode := n.FindChild("nat")
+		if natNode == nil {
+			continue
+		}
+		dstNode := natNode.FindChild("destination")
+		if dstNode == nil {
+			continue
+		}
+		for _, rs := range namedInstances(dstNode.FindChildren("rule-set")) {
+			if rs.node.FindChild("to") == nil {
+				continue
+			}
+			if err := emit(
+				"security nat destination rule-set %q: a `to` scope is not "+
+					"supported on a destination-NAT rule-set (Junos DNAT has only "+
+					"a `from` clause — the destination is translated on inbound, so "+
+					"there is no egress context; the `to` scope was silently ignored "+
+					"and the translation applied regardless of it) — remove it (#3444)",
+				rs.name); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return warnings, nil

--- a/pkg/config/compiler_nat_dnat_to_3444_test.go
+++ b/pkg/config/compiler_nat_dnat_to_3444_test.go
@@ -170,6 +170,145 @@ security {
 	}
 }
 
+// TestDNATRuleSetToScopeRejectedAcrossDuplicateNATBlocks proves the gate
+// iterates EVERY `nat` sibling under a security root, not just the first.
+// compileSecurity compiles every `nat` child (compiler_security.go), and the
+// parser APPENDS a repeated `nat {}` block as a sibling (parseStatements), so
+// ONE security root with a benign first `nat {}` plus a second `nat {
+// destination { rule-set RD ... to zone trust } }` would bypass a first-`nat`
+// walk while the compiler still compiled the second nat's rule-set with the
+// `to` silently dropped (the #3444 bypass, one level deeper). Reverting the
+// nat-level forEachChild back to FindChild-first makes strict CompileConfig
+// compile this clean → RED.
+func TestDNATRuleSetToScopeRejectedAcrossDuplicateNATBlocks(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS {
+                from zone trust;
+                rule R0 {
+                    then {
+                        source-nat interface;
+                    }
+                }
+            }
+        }
+    }
+    nat {
+        destination {
+            pool P1 {
+                address 10.0.30.100;
+            }
+            rule-set RD {
+                from zone untrust;
+                to zone trust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.5/32;
+                    }
+                    then {
+                        destination-nat pool P1;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	// Sanity: the single security root must carry TWO `nat` siblings (the
+	// bypass premise).
+	var natCount int
+	for _, n := range tree.Children {
+		if n.Name() == "security" {
+			for _, c := range n.Children {
+				if c.Name() == "nat" {
+					natCount++
+				}
+			}
+		}
+	}
+	if natCount < 2 {
+		t.Fatalf("expected 2 `nat` siblings under one security root (the bypass premise), got %d", natCount)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted a DNAT `to` scope in the SECOND of two nat blocks; want a strict reject (#3444 bypass)")
+	}
+	if !strings.Contains(err.Error(), "RD") || !strings.Contains(err.Error(), "#3444") {
+		t.Fatalf("reject error %q does not name the rule-set (RD) and #3444", err.Error())
+	}
+}
+
+// TestDNATRuleSetToScopeRejectedAcrossDuplicateDestinationBlocks proves the
+// gate also iterates every `destination` sibling within a `nat` block.
+// compileNAT itself reads only the FIRST `destination`, so a duplicate
+// `destination` within one `nat` is not currently compiler-reachable for the
+// silent drop — but the walk rejects it anyway (fail-closed: an operator who
+// authored a DNAT `to` is told it is unsupported, and the gate is defensive
+// against a future compiler that iterates destinations). Reverting the
+// destination-level forEachChild to FindChild-first makes strict CompileConfig
+// compile this clean → RED.
+func TestDNATRuleSetToScopeRejectedAcrossDuplicateDestinationBlocks(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        destination {
+            pool P0 {
+                address 10.0.30.99;
+            }
+            rule-set RBENIGN {
+                from zone untrust;
+                rule R0 {
+                    match {
+                        destination-address 198.51.100.1/32;
+                    }
+                    then {
+                        destination-nat pool P0;
+                    }
+                }
+            }
+        }
+        destination {
+            pool P1 {
+                address 10.0.30.100;
+            }
+            rule-set RD {
+                from zone untrust;
+                to zone trust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.5/32;
+                    }
+                    then {
+                        destination-nat pool P1;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted a DNAT `to` scope in the SECOND of two destination blocks; want a strict reject (#3444 bypass)")
+	}
+	if !strings.Contains(err.Error(), "RD") || !strings.Contains(err.Error(), "#3444") {
+		t.Fatalf("reject error %q does not name the rule-set (RD) and #3444", err.Error())
+	}
+}
+
 // TestDNATRuleSetFromOnlyStillCommits proves the no-regression case: a DNAT
 // rule-set with only a `from` clause (the legitimate Junos shape) commits
 // cleanly with no #3444 warning and the `from` scope survives.

--- a/pkg/config/compiler_nat_dnat_to_3444_test.go
+++ b/pkg/config/compiler_nat_dnat_to_3444_test.go
@@ -98,6 +98,78 @@ func TestDNATRuleSetToScopeLenientWarns(t *testing.T) {
 	}
 }
 
+// TestDNATRuleSetToScopeRejectedAcrossDuplicateSecurityBlocks proves the gate
+// inspects EVERY top-level `security` node, not just the first match. The
+// hierarchical parser (parseStatements) APPENDS a repeated top-level block
+// instead of merging it, and the compiler processes every `security` root, so
+// a config with two `security {}` blocks where only the SECOND carries the
+// DNAT `to` would bypass a first-match-only walk and silently drop+compile the
+// `to` (the original #3444 bug). This is reachable via LoadOverride, which
+// parses hierarchical input directly through NewParser
+// (configstore/store_command.go). NewParser is the CORRECT builder here — this
+// tests the hierarchical / LoadOverride path, not flat-set. Reverting the gate
+// to first-`security`-only makes strict CompileConfig compile this clean,
+// turning the assertion RED.
+func TestDNATRuleSetToScopeRejectedAcrossDuplicateSecurityBlocks(t *testing.T) {
+	cfgText := `
+security {
+    zones {
+        security-zone untrust {
+            interfaces {
+                ge-0/0/0.0;
+            }
+        }
+    }
+}
+security {
+    nat {
+        destination {
+            pool P1 {
+                address 10.0.30.100;
+            }
+            rule-set RD {
+                from zone untrust;
+                to zone trust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.5/32;
+                    }
+                    then {
+                        destination-nat pool P1;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	// Sanity: the parser must have produced TWO top-level `security` nodes
+	// (the bypass premise). If a future parser merges them, the bypass is
+	// gone and this guard documents why.
+	var secCount int
+	for _, n := range tree.Children {
+		if n.Name() == "security" {
+			secCount++
+		}
+	}
+	if secCount < 2 {
+		t.Fatalf("expected 2 top-level security blocks (the bypass premise), got %d", secCount)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("CompileConfig accepted a DNAT `to` scope in the SECOND of two security blocks; want a strict reject (#3444 bypass)")
+	}
+	if !strings.Contains(err.Error(), "RD") || !strings.Contains(err.Error(), "#3444") {
+		t.Fatalf("reject error %q does not name the rule-set (RD) and #3444", err.Error())
+	}
+}
+
 // TestDNATRuleSetFromOnlyStillCommits proves the no-regression case: a DNAT
 // rule-set with only a `from` clause (the legitimate Junos shape) commits
 // cleanly with no #3444 warning and the `from` scope survives.

--- a/pkg/config/compiler_nat_dnat_to_3444_test.go
+++ b/pkg/config/compiler_nat_dnat_to_3444_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #3444: a destination-NAT rule-set `to` scope. Junos DNAT
+// rule-sets have only a `from` clause — the destination is translated on
+// inbound, so there is no egress context. xpf briefly advertised a `to`
+// scope under `security nat destination rule-set` and Cartesian-expanded it
+// onto each NATRuleSet, but the userspace snapshot builder and the Rust DNAT
+// runtime model ONLY the `from` clause, so the `to` scope was silently
+// dropped and the translation applied regardless of it. The fix rejects a
+// DNAT `to` scope at strict commit (validateDNATRuleSetToScopeAST) and warns
+// (does not fail) on the tolerant load / peer-sync path (#1960), and stops
+// the compiler from stamping a phantom To* onto the typed NATRuleSet.
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath, never
+// NewParser (the parser merges newline-separated set lines into one giant
+// node).
+
+func buildDNATToTree(t *testing.T, scope string) *ConfigTree {
+	t.Helper()
+	return buildNATScopeTree(t,
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD "+scope,
+		"set security nat destination rule-set RD rule R1 match destination-address 198.51.100.5/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	)
+}
+
+// TestDNATRuleSetToScopeRejectedAtCommit proves the strict commit path hard-
+// rejects a DNAT rule-set `to` scope for every scope kind (zone | interface |
+// routing-instance). Reverting the gate (validateDNATRuleSetToScopeAST) makes
+// CompileConfig accept the config and these assertions go RED.
+func TestDNATRuleSetToScopeRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope string
+	}{
+		{"to zone", "to zone trust"},
+		{"to interface", "to interface ge-0/0/1.0"},
+		{"to routing-instance", "to routing-instance red"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildDNATToTree(t, tc.scope)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a DNAT rule-set %q scope; want a strict reject", tc.scope)
+			}
+			// The error must name the offending rule-set so the operator can
+			// find it, and cite the issue tag.
+			if !strings.Contains(err.Error(), "RD") || !strings.Contains(err.Error(), "#3444") {
+				t.Fatalf("reject error %q does not name the rule-set (RD) and #3444", err.Error())
+			}
+			if !strings.Contains(err.Error(), "destination") || !strings.Contains(err.Error(), "to") {
+				t.Fatalf("reject error %q does not identify a destination-NAT `to` scope", err.Error())
+			}
+		})
+	}
+}
+
+// TestDNATRuleSetToScopeLenientWarns proves the tolerant load / peer-sync path
+// (CompileConfigLenient) does NOT hard-fail on a DNAT `to` scope (so an
+// already-persisted config still boots, #1960), emits a warning, and the
+// rule-set still compiles with NO phantom To* stamped on the typed NATRuleSet
+// (the `to` scope was never enforceable for DNAT).
+func TestDNATRuleSetToScopeLenientWarns(t *testing.T) {
+	tree := buildDNATToTree(t, "to zone trust")
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-failed on a DNAT `to` scope: %v", err)
+	}
+	var found bool
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3444") && strings.Contains(w, "RD") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CompileConfigLenient emitted no #3444 DNAT `to` warning; warnings=%v", cfg.Warnings)
+	}
+	if cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) != 1 {
+		t.Fatalf("destination rule-set did not compile under lenient load")
+	}
+	rs := cfg.Security.NAT.Destination.RuleSets[0]
+	if rs.FromZone != "untrust" {
+		t.Fatalf("FromZone = %q, want untrust (the `from` scope must survive)", rs.FromZone)
+	}
+	// The `to` scope must NOT be carried onto the typed config — it is not
+	// enforceable for DNAT and would be a silent lie.
+	if rs.ToZone != "" || rs.ToInterface != "" || rs.ToRoutingInstance != "" {
+		t.Fatalf("DNAT rule-set carried a phantom To* scope: %+v", rs)
+	}
+}
+
+// TestDNATRuleSetFromOnlyStillCommits proves the no-regression case: a DNAT
+// rule-set with only a `from` clause (the legitimate Junos shape) commits
+// cleanly with no #3444 warning and the `from` scope survives.
+func TestDNATRuleSetFromOnlyStillCommits(t *testing.T) {
+	tree := buildNATScopeTree(t,
+		"set security nat destination pool P1 address 10.0.30.100",
+		"set security nat destination rule-set RD from zone untrust",
+		"set security nat destination rule-set RD rule R1 match destination-address 198.51.100.5/32",
+		"set security nat destination rule-set RD rule R1 then destination-nat pool P1",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig rejected a from-only DNAT rule-set: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3444") {
+			t.Fatalf("unexpected #3444 warning on a from-only DNAT rule-set: %q", w)
+		}
+	}
+	if cfg.Security.NAT.Destination == nil || len(cfg.Security.NAT.Destination.RuleSets) != 1 {
+		t.Fatalf("from-only DNAT rule-set did not compile")
+	}
+	rs := cfg.Security.NAT.Destination.RuleSets[0]
+	if rs.FromZone != "untrust" {
+		t.Fatalf("FromZone = %q, want untrust", rs.FromZone)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -301,16 +301,19 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		"destination": {desc: "Destination NAT configuration", children: map[string]*schemaNode{
 			"pool": {desc: "Destination NAT pool name", args: 1, valueHint: ValueHintPoolName, placeholder: "<pool-name>", children: nil},
 			"rule-set": {desc: "Destination NAT rule-set name", args: 1, placeholder: "<rule-set-name>", children: map[string]*schemaNode{
-				// #3096: from/to scope by zone | interface | routing-instance.
+				// #3096: `from` scope by zone | interface | routing-instance.
+				// #3444: a destination-NAT rule-set has only a `from` clause —
+				// DNAT translates the destination on inbound, so there is no
+				// egress / `to` context (unlike source NAT, which has both).
+				// The `to` subtree was removed here so completion no longer
+				// advertises it; a `to` scope under DNAT is rejected at strict
+				// commit by validateDNATRuleSetToScopeAST (it was silently
+				// dropped before the snapshot builder — the Rust DNAT runtime
+				// models only `from`).
 				"from": {desc: "Source of traffic to match", children: map[string]*schemaNode{
 					"zone":             {desc: "Source zone name", args: 1, multi: true, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
 					"interface":        {desc: "Ingress interface name", args: 1, multi: true, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
 					"routing-instance": {desc: "Ingress routing instance name", args: 1, multi: true, placeholder: "<routing-instance>", children: nil},
-				}},
-				"to": {desc: "Destination of traffic to match", children: map[string]*schemaNode{
-					"zone":             {desc: "Destination zone name", args: 1, multi: true, valueHint: ValueHintZoneName, placeholder: "<zone-name>", children: nil},
-					"interface":        {desc: "Egress interface name", args: 1, multi: true, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
-					"routing-instance": {desc: "Egress routing instance name", args: 1, multi: true, placeholder: "<routing-instance>", children: nil},
 				}},
 				"rule": {desc: "Destination NAT rule name", args: 1, placeholder: "<rule-name>", children: map[string]*schemaNode{
 					"match": {desc: "Match criteria", children: map[string]*schemaNode{


### PR DESCRIPTION
Closes #3444

## Problem
A destination-NAT rule-set could be authored with `to zone`, `to interface`, or `to routing-instance`. The schema advertised it and `compileNATDestination` Cartesian-expanded the `to` scopes onto each `NATRuleSet` (`ToZone`/`ToInterface`/`ToRoutingInstance`), but the snapshot builder (`buildDestinationNATSnapshots`) and the Rust DNAT runtime (`userspace-dp/src/nat/destination.rs`) model **only** the `from` clause — the `DestinationNATRuleSnapshot` wire struct intentionally has no `to_*`. So the `to` scope was silently dropped: the translation applied regardless of the operator's declared destination context, with no commit error.

Junos DNAT rule-sets have only a `from` clause (the destination is translated on inbound, so there is no egress context). Offering `to` and silently ignoring it is a misleading config that should fail at commit.

## Approach — strict-reject (per the issue's recommended fix)
DNAT `to` is not a real Junos feature and was silently ignored, so reject it at strict commit rather than carry an unenforceable field into the dataplane:

- Removed the `to` subtree from the DNAT rule-set `setSchema` (completion no longer offers it).
- `compileNATDestination` now collects only the `from` scope (`collectNATScopes(..., false)`) and expands per from-scope — no phantom `To*` on the typed `NATRuleSet`.
- New AST pre-walk `validateDNATRuleSetToScopeAST` (`compiler_nat_dnat_to.go`) hard-rejects any `to` scope under `security nat destination rule-set` at strict commit / commit-check, naming the rule-set.
- Per #1960 fail-closed-on-load, downgraded to a `cfg.Warnings` entry on the tolerant load / peer-sync paths (`lenientDNATToScope`) so an already-persisted / peer-synced config still boots. Runs on the group-expanded, inactive-pruned tree.

Detection is scoped to the destination subtree, so the source-NAT `to` clause (a real feature, #3096) is untouched. No wire change — the DNAT snapshot already omits `to_*`; this is a Go-only commit-time reject, Rust untouched. A future egress-scoped DNAT (after route resolution) remains a separate enhancement.

## Tests
- `pkg/config/compiler_nat_dnat_to_3444_test.go`:
  - `TestDNATRuleSetToScopeRejectedAtCommit` — strict reject for `to zone` / `to interface` / `to routing-instance`, asserts the error names the rule-set + #3444. **RED on reverting the gate.**
  - `TestDNATRuleSetToScopeLenientWarns` — lenient path does not hard-fail, emits a #3444 warning, compiles with the `from` scope surviving and **no phantom `To*`**.
  - `TestDNATRuleSetFromOnlyStillCommits` — from-only DNAT (legitimate Junos shape) commits with no warning (no regression).
- `go test ./pkg/config/ ./pkg/dataplane/userspace/` green; `gofmt` + `go vet` clean.

## RED-on-revert proof
Simulating a gate revert (emit warns instead of erroring) turns `TestDNATRuleSetToScopeRejectedAtCommit` RED for all three scope kinds ("CompileConfig accepted a DNAT rule-set ... scope; want a strict reject").

## Docs
`docs/config-schema.md` documents the reject under the fail-closed gate list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi