### PR TITLE
docs: pre-id-default-policy is Partial/inert, not Implemented (#3413)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-06-29 — #3413 doc accuracy: pre-id-default-policy is Partial/inert, not Implemented
+
+- **Timestamp**: 2026-06-29
+- **Action**: Corrected `docs/next-features/pre-id-default-policy.md`. The doc
+  claimed `Status: Implemented` and "Session init/close logging is now applied
+  to unknown-app sessions", contradicting the live commit-time WARN and closed
+  #2509. Verified against code: the stanza is PARSED + STORED
+  (pkg/config/compiler_security.go:226-237 → SecurityConfig.PreIDDefaultPolicy,
+  pkg/config/types_security.go:209-213) and schema-completable
+  (pkg/config/schema_security.go:757), but has NO userspace-dp consumer. The
+  only writer was the retired eBPF compiler (pkg/dataplane/compiler.go:1109-1116
+  packs into FlowConfigValue.AppFlags), fed to SetFlowConfig which is a no-op
+  stub on the userspace path (pkg/dataplane/loader.go:400). The legacy wiring
+  bpf/xdp/xdp_policy.c was deleted in #1476 (13fa1009e). A commit-time WARN
+  flags the inertness (pkg/config/compiler_validate_warn.go:859-882). No
+  pre-id/app_id==0 admit consumer exists in userspace-dp (the session-init/close
+  consumers are all the per-policy #2508 path). Changed Status to "Partial —
+  accepted-but-inert (#2509)", removed the false "logging is now applied" claim
+  and the stale eBPF wiring reference, added a "Why It Is Inert" section.
+  Doc-only change; no test needed (no Go/Rust behavior touched).
+- **File(s)**: docs/next-features/pre-id-default-policy.md, _Log.md
+
 ## 2026-06-29 — #3362 rebase fold: dedup host-inbound deny-counter declarations
 
 - **Timestamp**: 2026-06-29

--- a/docs/next-features/pre-id-default-policy.md
+++ b/docs/next-features/pre-id-default-policy.md
@@ -1,26 +1,68 @@
 # Next Feature: `security pre-id-default-policy`
 
-Date: 2026-03-02  
-Status: Implemented
+Date: 2026-03-02 (status corrected 2026-06-29, #3413)  
+Status: Partial — accepted-but-inert in the userspace dataplane (#2509)
 
 ## Config Evidence
-- Present in `/home/ps/git/xpf/vsrx.conf:21128` as `pre-id-default-policy { ... }`
+- Present in vSRX configs as `pre-id-default-policy { then log ...; }`
+- Junos syntax is accepted by the parser and config schema
 
 ## Current State
-- Parsed into `SecurityConfig.PreIDDefaultPolicy`: `pkg/config/compiler.go`
-- Wired into flow config/runtime flags: `pkg/dataplane/compiler.go`, `bpf/xdp/xdp_policy.c` (~~`dpdk_worker/policy.c`~~ — DPDK retired #1525)
-- Session init/close logging is now applied to unknown-app sessions when AppID is enabled
+- **Parsed and stored**: `pre-id-default-policy then log session-init/session-close`
+  is parsed into `SecurityConfig.PreIDDefaultPolicy.LogSessionInit` /
+  `LogSessionClose` (`pkg/config/compiler_security.go:226-237`,
+  type `pkg/config/types_security.go:209-213`).
+- **Schema-completable**: the stanza is in the config-mode set schema
+  (`pkg/config/schema_security.go:757`), so tab-completion and commit-check
+  validation accept it.
+- **No runtime consumer (inert)**: the logging flags have NO consumer in the
+  userspace dataplane after the eBPF retirement (#1373/#1476). The only reader
+  was the retired eBPF compiler, which packed the bits into
+  `FlowConfigValue.AppFlags` (`pkg/dataplane/compiler.go:1109-1116`) and wrote
+  them via `SetFlowConfig` — but `SetFlowConfig` is a no-op stub on the
+  userspace path (`pkg/dataplane/loader.go:400`,
+  `userspaceShimCompileDataplane.SetFlowConfig` returns `nil`), so this is a
+  dead write to a map that no longer exists. The legacy wiring
+  (`bpf/xdp/xdp_policy.c`) was deleted in #1476 (commit `13fa1009e`).
+- **Commit-time warning**: the operator is told at commit that the stanza is
+  inert — `validatePreIDDefaultPolicyLogWarnings`
+  (`pkg/config/compiler_validate_warn.go:859-882`) emits:
+  > security pre-id-default-policy `then log ...` is accepted for
+  > compatibility but is inert in the userspace dataplane (no
+  > pre-identification session-admit path exists to emit the RT_FLOW
+  > session log)
+
+## Why It Is Inert (#2509)
+On the userspace dataplane there is no pre-identification session-admit path:
+app-id is best-effort labeling of already-admitted sessions, not a "default
+policy admits the session before app-id resolves, then re-evaluate" pipeline.
+There is therefore no session on which to stamp the pre-ID log mode — unlike
+the per-policy #2508 path, which stamps the admitting policy's `then log
+session-init/session-close` flags onto the session at install
+(`userspace-dp/src/policy.rs`, `userspace-dp/src/session/entry.rs`). The
+stanza commits and is silently inert; #2509 (closed) is the source of truth
+for the missing consumer.
 
 ## Problem
-When application identification is in progress, vSRX can apply explicit pre-ID default handling. xpf now honors the configured logging behavior for unknown/pre-ID sessions instead of ignoring the stanza entirely.
+When application identification is in progress, vSRX can apply explicit
+pre-ID default handling (including session-init/session-close logging for
+unknown/pre-ID sessions). xpf parses and stores the stanza but does NOT yet
+honor the configured logging behavior — pre-ID unknown-app sessions are not
+logged. The config is accepted for compatibility and the operator is warned at
+commit time.
 
 ## Proposed Implementation Scope
 1. Treat `app_id == 0` while AppID is enabled as the unknown/pre-ID state.
-2. OR the configured `session-init` / `session-close` flags into new sessions in that state.
+2. OR the configured `session-init` / `session-close` flags into new sessions
+   in that state, emitting the RT_FLOW session log via the existing event
+   stream producer (mirror the per-policy #2508 stamping path).
 3. Preserve normal policy behavior for non-pre-ID sessions.
-4. Keep richer pre-ID transition/counter work as future follow-up if full DPI is added.
+4. Keep richer pre-ID transition/counter work as future follow-up if full DPI
+   is added.
 
 ## Acceptance Criteria
-- `session-init` and `session-close` logging under pre-ID policy occurs when configured.
+- `session-init` and `session-close` logging under pre-ID policy occurs when
+  configured (and the commit-time inert-warning is removed once wired).
 - No behavior change when `pre-id-default-policy` is not configured.
-- Scope is explicit: this is unknown/pre-ID logging parity, not full staged DPI policy enforcement.
+- Scope is explicit: this is unknown/pre-ID logging parity, not full staged DPI
+  policy enforcement.


### PR DESCRIPTION
Closes #3413

## Problem
`docs/next-features/pre-id-default-policy.md` claimed `Status: Implemented`
and "Session init/close logging is now applied to unknown-app sessions when
AppID is enabled". Both are false. The feature is accepted-but-inert on the
userspace dataplane — the doc directly contradicted the live commit-time WARN
and closed #2509, and still cited the retired eBPF program
`bpf/xdp/xdp_policy.c` (deleted in #1476) as the wiring evidence.

## True implementation state (file:line evidence)
- **Parsed + stored**: `pre-id-default-policy then log session-init/
  session-close` lands on `SecurityConfig.PreIDDefaultPolicy.LogSessionInit` /
  `LogSessionClose` — `pkg/config/compiler_security.go:226-237`; type
  `pkg/config/types_security.go:209-213`.
- **Schema-completable**: `pkg/config/schema_security.go:757`.
- **No runtime consumer (inert)**: the only reader was the retired eBPF
  compiler, which packs the bits into `FlowConfigValue.AppFlags`
  (`pkg/dataplane/compiler.go:1109-1116`) and writes them via `SetFlowConfig`
  — but `SetFlowConfig` is a no-op stub on the userspace path
  (`pkg/dataplane/loader.go:400`, `userspaceShimCompileDataplane.SetFlowConfig`
  returns `nil`). A grep of `userspace-dp/src` finds no pre-id / app_id-admit
  consumer; the `session-init`/`session-close` consumers there are all the
  per-policy #2508 path, not `pre-id-default-policy`. `bpf/xdp/xdp_policy.c`
  was deleted in #1476 (commit `13fa1009e`).
- **Commit-time WARN** confirms the inertness:
  `validatePreIDDefaultPolicyLogWarnings`
  (`pkg/config/compiler_validate_warn.go:859-882`).

So the config plane is complete (parse + store + schema + commit-warn) but the
dataplane consumer is absent → **Partial**, matching the #2507 loss-priority
accepted-but-inert pattern.

## What the doc said vs now says
- `Status: Implemented` → `Status: Partial — accepted-but-inert in the
  userspace dataplane (#2509)`.
- Removed "Session init/close logging is now applied to unknown-app sessions".
- Removed the stale `bpf/xdp/xdp_policy.c` / `pkg/dataplane/compiler.go`
  "wired into runtime flags" claim; replaced with the real config-plane cites
  and an explicit "no runtime consumer" note pointing at the validator WARN.
- Added a "Why It Is Inert (#2509)" section; corrected the Problem statement.
- Kept Proposed Implementation Scope / Acceptance Criteria as the future plan.

## Code gap (already tracked, not in this PR's scope)
The feature itself is genuinely inert at runtime — this is the state #2509
(closed) documents. No new follow-up issue is needed: implementing it is the
"Proposed Implementation Scope" in the doc (wire `app_id == 0` pre-ID sessions
into the per-policy #2508 RT_FLOW session-log producer). This PR only corrects
the doc.

## Test
Doc-only change; no Go/Rust behavior touched, so no test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi