### PR TITLE
api: fix Prometheus firewall-filter counter collector (#3459/#3461/#3462/#3463)

### DIFF
--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -200,10 +200,13 @@ under the daemon's errgroup. Nothing else imports this package.
     (rather than emitting a misleading `0`) for global, per-zone,
     per-policy, and per-filter reads, and bumps the monotonic
     `xpf_counter_read_errors_total` scrape-error counter, always emitted
-    (0 when healthy) for alerting. The descriptor Help text names all four
-    read surfaces (#3463), not global-only, so it matches this contract.
-    The error-counter SAMPLE is emitted LAST in `Collect`
-    (`emitCounterReadErrors`), AFTER the global/zone/policy/filter
+    (0 when healthy) for alerting. The same counter is ALSO bumped by the
+    pre-gate kernel-nftables host-inbound collector (`#3361`) when its
+    netlink read fails, so the descriptor Help text names every read surface
+    that increments it — global, zone, policy, and filter dataplane reads
+    PLUS the kernel-nftables host-inbound read (#3463), not global-only, so
+    it matches this contract. The error-counter SAMPLE is emitted LAST in
+    `Collect` (`emitCounterReadErrors`), AFTER the global/zone/policy/filter
     sub-collectors (and the pre-gate host-inbound collector) have run, so a
     read failure in any of them is reflected in THIS scrape's value rather
     than lagging one scrape behind (#3462). The per-filter collector also
@@ -212,7 +215,7 @@ under the daemon's errgroup. Nothing else imports this package.
     the CLI/gRPC text paths use), so the canonical metrics path does not
     report 0/stale while `show firewall filter` shows real hits (#3461); the
     per-term counter-slot stride is the shared
-    `dataplane.FilterTermExpansionCount` SSOT (#3459).
+    `config.FilterTermExpansionCount` SSOT (#3459).
   - **Text commands** print a `warning: ... counter read failed ...` line
     instead of a clean zero: `show security screen` / `show security
     alarms` / `show security flow statistics` / `show chassis cluster

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -200,7 +200,19 @@ under the daemon's errgroup. Nothing else imports this package.
     (rather than emitting a misleading `0`) for global, per-zone,
     per-policy, and per-filter reads, and bumps the monotonic
     `xpf_counter_read_errors_total` scrape-error counter, always emitted
-    (0 when healthy) for alerting.
+    (0 when healthy) for alerting. The descriptor Help text names all four
+    read surfaces (#3463), not global-only, so it matches this contract.
+    The error-counter SAMPLE is emitted LAST in `Collect`
+    (`emitCounterReadErrors`), AFTER the global/zone/policy/filter
+    sub-collectors (and the pre-gate host-inbound collector) have run, so a
+    read failure in any of them is reflected in THIS scrape's value rather
+    than lagging one scrape behind (#3462). The per-filter collector also
+    merges the userspace-dp helper-published `filter_term_counters` into
+    `xpf_filter_hits_total` (the same `BuildFirewallFilterTermCounterIndex`
+    the CLI/gRPC text paths use), so the canonical metrics path does not
+    report 0/stale while `show firewall filter` shows real hits (#3461); the
+    per-term counter-slot stride is the shared
+    `dataplane.FilterTermExpansionCount` SSOT (#3459).
   - **Text commands** print a `warning: ... counter read failed ...` line
     instead of a clean zero: `show security screen` / `show security
     alarms` / `show security flow statistics` / `show chassis cluster

--- a/pkg/api/filter_counters_metrics_test.go
+++ b/pkg/api/filter_counters_metrics_test.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/conntrack"
+	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// newFilterStore commits a config built from the given flat-set lines and
+// returns the store, so the filter collector's cfg.Firewall.Filters* and
+// cfg.PolicyOptions.PrefixLists are populated.
+func newFilterStore(t *testing.T, setLines []string) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if _, err := store.LoadSet(strings.Join(setLines, "\n")); err != nil {
+		t.Fatalf("LoadSet() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// filterHitsByTerm gathers xpf_filter_hits_total samples keyed by their term
+// label, with the sample value.
+func filterHitsByTerm(t *testing.T, c *xpfCollector, dp apiRuntimeDataPlane) map[string]float64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	c.collectFilterCounters(ch, dp)
+	close(ch)
+	out := map[string]float64{}
+	for m := range ch {
+		if !strings.Contains(m.Desc().String(), "xpf_filter_hits_total") {
+			continue
+		}
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("metric write: %v", err)
+		}
+		var term string
+		for _, l := range pb.GetLabel() {
+			if l.GetName() == "term" {
+				term = l.GetValue()
+			}
+		}
+		out[term] = pb.GetCounter().GetValue()
+	}
+	return out
+}
+
+// filterSlotDP serves per-slot filter counters (Packets == slot index + 1) so
+// a test can detect both an undercounted per-term sum and a drifted
+// ruleOffset. It deliberately does NOT implement Status(), so no userspace
+// merge runs — this isolates the #3459 expansion/stride path.
+type filterSlotDP struct {
+	*dataplane.Manager
+	apply *dataplane.ApplyResult
+}
+
+func (d *filterSlotDP) IsLoaded() bool                          { return true }
+func (d *filterSlotDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *filterSlotDP) ReadFilterConfig(uint32) (dataplane.FilterConfig, error) {
+	return dataplane.FilterConfig{RuleStart: 0}, nil
+}
+func (d *filterSlotDP) ReadFilterCounters(idx uint32) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{Packets: uint64(idx) + 1}, nil
+}
+
+// TestCollectFilterCountersExpandsPortsAndPrefixLists is the #3459 RED-on-revert
+// pin. Term t1 expands to nSrc(=2 prefixes) × nDst(=1) × nDstPorts(=2) ×
+// nSrcPorts(=1) = 4 dataplane rules, so it owns slots 0..3 and t2 owns slot 4.
+// With per-slot Packets == idx+1: t1 = 1+2+3+4 = 10, t2 = 5.
+//
+// FAIL-ON-REVERT: restoring the old `numRules = nSrc*nDst` (ignoring ports and
+// prefix-lists) makes t1 read only slot 0 (=1) and advance the offset by 1, so
+// t2 reads slot 1 (=2) — the wrong term. Both asserted values then go RED.
+func TestCollectFilterCountersExpandsPortsAndPrefixLists(t *testing.T) {
+	store := newFilterStore(t, []string{
+		"set policy-options prefix-list pl1 10.1.0.0/24",
+		"set policy-options prefix-list pl1 10.2.0.0/24",
+		"set firewall family inet filter fin term t1 from source-prefix-list pl1",
+		"set firewall family inet filter fin term t1 from destination-port 80",
+		"set firewall family inet filter fin term t1 from destination-port 443",
+		"set firewall family inet filter fin term t1 then accept",
+		"set firewall family inet filter fin term t2 then accept",
+	})
+	c := newCollector(&Server{store: store})
+	dp := &filterSlotDP{
+		Manager: dataplane.New(),
+		apply:   &dataplane.ApplyResult{FilterIDs: map[string]uint32{"inet:fin": 0}},
+	}
+
+	got := filterHitsByTerm(t, c, dp)
+	if got["t1"] != 10 {
+		t.Errorf("term t1 hit count = %v, want 10 (sum of its 4 expanded slots "+
+			"0..3); a wrong value means ports/prefix-list expansion was dropped", got["t1"])
+	}
+	if got["t2"] != 5 {
+		t.Errorf("term t2 hit count = %v, want 5 (slot 4); a wrong value means the "+
+			"running ruleOffset drifted and t2 read another term's slot", got["t2"])
+	}
+}
+
+// filterUserspaceDP publishes a per-term hit counter via helper Status() and
+// has NO eBPF apply result (LastApplyResult == nil) — modeling the userspace-dp
+// runtime where filter hits live only in the helper status.
+type filterUserspaceDP struct {
+	*dataplane.Manager
+	status dpuserspace.ProcessStatus
+}
+
+func (d *filterUserspaceDP) IsLoaded() bool                          { return true }
+func (d *filterUserspaceDP) LastApplyResult() *dataplane.ApplyResult { return nil }
+func (d *filterUserspaceDP) Status() (dpuserspace.ProcessStatus, error) {
+	return d.status, nil
+}
+
+// TestCollectFilterCountersMergesUserspaceCounters is the #3461 RED-on-revert
+// pin: the userspace helper publishes a filter-term counter, there is no eBPF
+// map path (cr == nil), and the collector must still emit xpf_filter_hits_total
+// carrying the helper-published value — exactly as the CLI/gRPC text paths do.
+//
+// FAIL-ON-REVERT: dropping the userspace merge (or restoring the
+// `if cr == nil { return }` early-out) emits NO sample for the term, so
+// got["t1"] is absent (0) and the assertion goes RED.
+func TestCollectFilterCountersMergesUserspaceCounters(t *testing.T) {
+	store := newFilterStore(t, []string{
+		"set firewall family inet filter fin term t1 from protocol tcp",
+		"set firewall family inet filter fin term t1 then accept",
+	})
+	c := newCollector(&Server{store: store})
+	dp := &filterUserspaceDP{
+		Manager: dataplane.New(),
+		status: dpuserspace.ProcessStatus{
+			FilterTermCounters: []dpuserspace.FirewallFilterTermCounterStatus{
+				{Family: "inet", FilterName: "fin", TermName: "t1", Packets: 777},
+			},
+		},
+	}
+
+	got := filterHitsByTerm(t, c, dp)
+	if got["t1"] != 777 {
+		t.Errorf("term t1 hit count = %v, want 777 (helper-published filter-term "+
+			"counter must merge into xpf_filter_hits_total even with no eBPF map path)", got["t1"])
+	}
+}
+
+// zoneErrScrapeDP reuses the fully-wired descriptorCoverageDP but fails the
+// per-zone counter reads, so a full Collect() bumps counterReadErrors AFTER
+// collectGlobalCounters has already run.
+type zoneErrScrapeDP struct {
+	*descriptorCoverageDP
+}
+
+func (d *zoneErrScrapeDP) ReadZoneCounters(uint16, int) (dataplane.CounterValue, error) {
+	return dataplane.CounterValue{}, errors.New("zone bridge degraded")
+}
+
+// TestCollectEmitsCounterReadErrorsAfterSubcollectors is the #3462
+// RED-on-revert pin. Global/interface/policy/filter reads SUCCEED and the
+// pre-gate host-inbound read is neutralized, so the ONLY counterReadErrors
+// bumps in the scrape come from the per-zone reads — which run AFTER
+// collectGlobalCounters. A full Collect() must therefore emit a NON-ZERO
+// xpf_counter_read_errors_total in the SAME scrape.
+//
+// FAIL-ON-REVERT: moving the emit back into collectGlobalCounters (before the
+// zone collector) makes the emitted sample read 0 — the zone failures land
+// after the sample was produced — so the > 0 assertion goes RED.
+func TestCollectEmitsCounterReadErrorsAfterSubcollectors(t *testing.T) {
+	// Neutralize the pre-gate kernel host-inbound read so it cannot bump the
+	// counter before collectGlobalCounters (which would mask the ordering bug).
+	orig := readHostInboundDenyCounters
+	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) { return nil, nil }
+	defer func() { readHostInboundDenyCounters = orig }()
+
+	store := newDescriptorCoverageStore(t)
+	srv := &Server{store: store, gc: conntrack.NewGC(nil, time.Minute), startTime: time.Now()}
+	srv.dp = &zoneErrScrapeDP{&descriptorCoverageDP{
+		Manager: dataplane.New(),
+		status:  dpuserspace.ProcessStatus{},
+		apply: &dataplane.ApplyResult{
+			ZoneIDs:   map[string]uint16{"trust": 1, "untrust": 2},
+			FilterIDs: map[string]uint32{"inet:fin": 0, "inet6:fin6": 100},
+		},
+	}}
+	c := newCollector(srv)
+
+	// Drive the real Collect() so the production ordering (not a test
+	// reconstruction) is what is exercised.
+	ch := make(chan prometheus.Metric)
+	done := make(chan struct{})
+	var errTotal float64
+	var saw bool
+	go func() {
+		for m := range ch {
+			if !strings.Contains(m.Desc().String(), "xpf_counter_read_errors_total") {
+				continue
+			}
+			var pb dto.Metric
+			if err := m.Write(&pb); err != nil {
+				t.Errorf("metric write: %v", err)
+				continue
+			}
+			saw = true
+			errTotal = pb.GetCounter().GetValue()
+		}
+		close(done)
+	}()
+	c.Collect(ch)
+	close(ch)
+	<-done
+
+	if !saw {
+		t.Fatal("xpf_counter_read_errors_total was not emitted by Collect()")
+	}
+	if errTotal <= 0 {
+		t.Errorf("xpf_counter_read_errors_total = %v in the scrape whose zone reads "+
+			"failed; want > 0 — the error sample must reflect a late (post-global) "+
+			"sub-collector failure in the SAME scrape (#3462)", errTotal)
+	}
+}

--- a/pkg/api/filter_counters_metrics_test.go
+++ b/pkg/api/filter_counters_metrics_test.go
@@ -159,6 +159,63 @@ func TestCollectFilterCountersMergesUserspaceCounters(t *testing.T) {
 	}
 }
 
+// filterUserspaceMapErrDP models the REAL userspace-dp production path: the
+// apply result IS populated (LastApplyResult carries FilterIDs), but the shim
+// has no eBPF filter_configs loaded, so ReadFilterConfig fails — hasMap stays
+// false and counterReadErrors is bumped per filter — while the helper status
+// carries the actual per-term hit counters.
+type filterUserspaceMapErrDP struct {
+	*dataplane.Manager
+	apply  *dataplane.ApplyResult
+	status dpuserspace.ProcessStatus
+}
+
+func (d *filterUserspaceMapErrDP) IsLoaded() bool                          { return true }
+func (d *filterUserspaceMapErrDP) LastApplyResult() *dataplane.ApplyResult { return d.apply }
+func (d *filterUserspaceMapErrDP) ReadFilterConfig(uint32) (dataplane.FilterConfig, error) {
+	return dataplane.FilterConfig{}, errors.New("filter_configs not loaded in shim")
+}
+func (d *filterUserspaceMapErrDP) Status() (dpuserspace.ProcessStatus, error) {
+	return d.status, nil
+}
+
+// TestCollectFilterCountersMergesUserspaceCountersWhenMapConfigUnavailable is
+// the #3461 REAL-PATH pin: a populated apply result (FilterIDs present) with a
+// failing ReadFilterConfig — exactly the userspace-dp runtime where the eBPF
+// filter_configs map is not loaded. The per-filter ReadFilterConfig failure
+// bumps counterReadErrors (hasMap=false), and the helper-published term counter
+// must still be emitted on xpf_filter_hits_total.
+//
+// FAIL-ON-REVERT: dropping the userspace merge leaves hasMap=false AND
+// userspaceOk unused, so no sample is emitted for the term — got["t1"] is
+// absent (0) and the value assertion goes RED. (The counterReadErrors bump is
+// the independent #3408 path and is asserted separately.)
+func TestCollectFilterCountersMergesUserspaceCountersWhenMapConfigUnavailable(t *testing.T) {
+	store := newFilterStore(t, []string{
+		"set firewall family inet filter fin term t1 from protocol tcp",
+		"set firewall family inet filter fin term t1 then accept",
+	})
+	c := newCollector(&Server{store: store})
+	dp := &filterUserspaceMapErrDP{
+		Manager: dataplane.New(),
+		apply:   &dataplane.ApplyResult{FilterIDs: map[string]uint32{"inet:fin": 0}},
+		status: dpuserspace.ProcessStatus{
+			FilterTermCounters: []dpuserspace.FirewallFilterTermCounterStatus{
+				{Family: "inet", FilterName: "fin", TermName: "t1", Packets: 555},
+			},
+		},
+	}
+
+	got := filterHitsByTerm(t, c, dp)
+	if got["t1"] != 555 {
+		t.Errorf("term t1 hit count = %v, want 555 (helper-published counter must "+
+			"merge even when the eBPF filter_configs map read fails)", got["t1"])
+	}
+	if c.counterReadErrors.Load() == 0 {
+		t.Error("counterReadErrors not bumped on the per-filter ReadFilterConfig failure")
+	}
+}
+
 // zoneErrScrapeDP reuses the fully-wired descriptorCoverageDP but fails the
 // per-zone counter reads, so a full Collect() bumps counterReadErrors AFTER
 // collectGlobalCounters has already run.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -37,14 +37,15 @@ type xpfCollector struct {
 	syncookieTotal           *prometheus.Desc
 	flowCacheTotal           *prometheus.Desc
 
-	// #3345/#3408: monotonic count of dataplane counter reads that failed
-	// during a scrape, across the global, per-zone, per-policy, and per-filter
-	// collectors. A failed read SKIPS emitting that counter's sample (so a
-	// degraded counter bridge does NOT report a misleading 0); this metric is
-	// the scrape-error signal an operator alerts on. Persisted on the collector
-	// so it accumulates across scrapes like a real counter. #3462: the SAMPLE
-	// is emitted last in Collect (emitCounterReadErrors), after all collectors
-	// that can bump it, so a failure this scrape is reflected this scrape.
+	// #3345/#3408: monotonic count of counter reads that failed during a
+	// scrape, across the global, per-zone, per-policy, and per-filter dataplane
+	// collectors AND the kernel-nftables host-inbound collector (#3361). A
+	// failed read SKIPS emitting that counter's sample (so a degraded counter
+	// bridge does NOT report a misleading 0); this metric is the scrape-error
+	// signal an operator alerts on. Persisted on the collector so it accumulates
+	// across scrapes like a real counter. #3462: the SAMPLE is emitted last in
+	// Collect (emitCounterReadErrors), after all collectors that can bump it, so
+	// a failure this scrape is reflected this scrape.
 	counterReadErrorsTotal *prometheus.Desc
 	counterReadErrors      atomic.Uint64
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -37,11 +37,14 @@ type xpfCollector struct {
 	syncookieTotal           *prometheus.Desc
 	flowCacheTotal           *prometheus.Desc
 
-	// #3345: monotonic count of global-counter map reads that failed during
-	// a scrape. A failed read SKIPS emitting that counter's sample (so a
-	// degraded counter bridge does NOT report a misleading 0); this metric
-	// is the scrape-error signal an operator alerts on. Persisted on the
-	// collector so it accumulates across scrapes like a real counter.
+	// #3345/#3408: monotonic count of dataplane counter reads that failed
+	// during a scrape, across the global, per-zone, per-policy, and per-filter
+	// collectors. A failed read SKIPS emitting that counter's sample (so a
+	// degraded counter bridge does NOT report a misleading 0); this metric is
+	// the scrape-error signal an operator alerts on. Persisted on the collector
+	// so it accumulates across scrapes like a real counter. #3462: the SAMPLE
+	// is emitted last in Collect (emitCounterReadErrors), after all collectors
+	// that can bump it, so a failure this scrape is reflected this scrape.
 	counterReadErrorsTotal *prometheus.Desc
 	counterReadErrors      atomic.Uint64
 
@@ -835,6 +838,11 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectZoneCounters(ch, dp)
 	c.collectPolicyCounters(ch, dp)
 	c.collectFilterCounters(ch, dp)
+	// #3462: emit the scrape-error counter AFTER global/zone/policy/filter
+	// (and the pre-gate host-inbound collector) have run, so a read failure in
+	// any of them is reflected in THIS scrape's xpf_counter_read_errors_total
+	// rather than lagging a scrape behind.
+	c.emitCounterReadErrors(ch)
 	c.collectSessionGauges(ch, dp)
 	c.collectNATPoolMetrics(ch, dp)
 	c.collectDHCPMetrics(ch)

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	xnft "github.com/psaab/xpf/pkg/nftables"
 )
 
@@ -33,8 +34,9 @@ var readHostInboundDenyCounters = xnft.ReadHostInboundDenyCounters
 // On a read failure the series is SKIPPED (no misleading 0) and
 // xpf_counter_read_errors_total is bumped, matching the #3345 contract: a missing
 // sample is distinguishable from a real zero. (The error-counter SAMPLE is
-// emitted by collectGlobalCounters; the bump here accumulates on the collector
-// so it surfaces on the next scrape that reaches the global counters.)
+// emitted last in Collect by emitCounterReadErrors (#3462); the bump here
+// accumulates on the collector and is reflected in the same scrape's emitted
+// value when the dataplane is loaded.)
 func (c *xpfCollector) collectHostInboundKernelDenies(ch chan<- prometheus.Metric) {
 	counts, err := readHostInboundDenyCounters()
 	if err != nil {
@@ -91,9 +93,18 @@ func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp api
 	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheMiss, "miss")
 	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheFlush, "flush")
 	emit(c.flowCacheTotal, dataplane.GlobalCtrFlowCacheInvalidate, "invalidate")
+}
 
-	// #3345: always emit the scrape-error counter (0 when healthy) so the
-	// signal is present for alerting whether or not any read failed.
+// emitCounterReadErrors emits the xpf_counter_read_errors_total scrape-error
+// sample. #3345: always emitted (0 when healthy) so the signal is present for
+// alerting whether or not any read failed. #3462: this MUST run AFTER every
+// sub-collector that can bump counterReadErrors (collectHostInboundKernelDenies,
+// collectGlobalCounters, collectZoneCounters, collectPolicyCounters,
+// collectFilterCounters) — Collect calls it last — so a zone/policy/filter read
+// that fails in THIS scrape is reflected in THIS scrape's value, not lagged by
+// one scrape (which it was when the sample was emitted from collectGlobalCounters
+// before those collectors ran).
+func (c *xpfCollector) emitCounterReadErrors(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.counterReadErrorsTotal, prometheus.CounterValue,
 		float64(c.counterReadErrors.Load()))
 }
@@ -263,10 +274,29 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 	if cfg == nil {
 		return
 	}
-	cr := dataplane.LastApplyResultOf(dp)
-	if cr == nil || cr.FilterIDs == nil {
-		return
+
+	// #3461: merge the userspace helper-published per-term hit counters
+	// (filter_term_counters) into xpf_filter_hits_total, exactly as the CLI
+	// (`show firewall filter`) and gRPC text paths do via
+	// BuildFirewallFilterTermCounterIndex. The userspace-dp runtime publishes
+	// filter hits HERE, not in the retired eBPF map, so without this merge the
+	// canonical metrics path reports 0/stale while the text commands show real
+	// hits. The userspace merge is independent of the eBPF apply result, so it
+	// must NOT be gated on cr/FilterIDs below.
+	var userspaceStatus *dpuserspace.ProcessStatus
+	if provider, ok := dp.(interface {
+		Status() (dpuserspace.ProcessStatus, error)
+	}); ok {
+		if status, err := provider.Status(); err == nil {
+			userspaceStatus = &status
+		}
 	}
+	userspaceCounters := dpuserspace.BuildFirewallFilterTermCounterIndex(userspaceStatus)
+
+	// The retired-eBPF/map counter path is gated on a compile result carrying
+	// filter IDs; it may be absent (a pure userspace dataplane) without
+	// suppressing the userspace merge above.
+	cr := dataplane.LastApplyResultOf(dp)
 
 	emitFilters := func(family string, filters map[string]*config.FirewallFilter) {
 		names := make([]string, 0, len(filters))
@@ -276,46 +306,66 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 		sort.Strings(names)
 		for _, name := range names {
 			filter := filters[name]
-			fid, ok := cr.FilterIDs[family+":"+name]
-			if !ok {
-				continue
-			}
-			fcfg, err := dp.ReadFilterConfig(fid)
-			if err != nil {
-				c.counterReadErrors.Add(1)
-				continue
-			}
-			ruleOffset := fcfg.RuleStart
-			for _, term := range filter.Terms {
-				nSrc := len(term.SourceAddresses)
-				if nSrc == 0 {
-					nSrc = 1
-				}
-				nDst := len(term.DestAddresses)
-				if nDst == 0 {
-					nDst = 1
-				}
-				numRules := uint32(nSrc * nDst)
-				var totalPkts uint64
-				termFailed := false
-				for i := uint32(0); i < numRules; i++ {
-					if ctrs, err := dp.ReadFilterCounters(ruleOffset + i); err == nil {
-						totalPkts += ctrs.Packets
+
+			// Resolve the map-counter span for this filter, if the compile
+			// result carries it.
+			var ruleOffset uint32
+			var hasMap bool
+			if cr != nil && cr.FilterIDs != nil {
+				if fid, ok := cr.FilterIDs[family+":"+name]; ok {
+					if fcfg, err := dp.ReadFilterConfig(fid); err == nil {
+						ruleOffset = fcfg.RuleStart
+						hasMap = true
 					} else {
+						// Skip the map path for this filter, but still surface
+						// any userspace-published term counters below.
 						c.counterReadErrors.Add(1)
-						termFailed = true
 					}
 				}
-				// Advance the offset regardless so later terms stay aligned.
-				ruleOffset += numRules
-				// #3408: on a read failure SKIP this term's sample (a missing
-				// sample, not a stale/partial 0) — matching the zone/policy
-				// collectors — and rely on the bumped counterReadErrors signal.
-				if termFailed {
+			}
+
+			for _, term := range filter.Terms {
+				// #3459: the per-term counter-slot stride is the shared SSOT
+				// dataplane.FilterTermExpansionCount (full src×dst×dstPort×
+				// srcPort cross-product, with prefix-list prefixes folded into
+				// src/dst) — NOT the old nSrc*nDst that ignored ports and
+				// prefix-lists and drifted later terms onto a neighbouring
+				// term's slots, mis-attributing the hit.
+				numRules := config.FilterTermExpansionCount(term, cfg.PolicyOptions.PrefixLists)
+				var totalPkts uint64
+				mapFailed := false
+				if hasMap {
+					for i := uint32(0); i < numRules; i++ {
+						if ctrs, err := dp.ReadFilterCounters(ruleOffset + i); err == nil {
+							totalPkts += ctrs.Packets
+						} else {
+							c.counterReadErrors.Add(1)
+							mapFailed = true
+						}
+					}
+					// Advance the offset regardless so later terms stay aligned.
+					ruleOffset += numRules
+				}
+
+				userspaceCounter, userspaceOk := userspaceCounters[dpuserspace.FirewallFilterTermCounterKey{
+					Family: family, FilterName: name, TermName: term.Name,
+				}]
+				if userspaceOk {
+					totalPkts += userspaceCounter.Packets
+				}
+
+				// #3408: on a map read failure with NO userspace signal, SKIP
+				// this term's sample (a missing sample, not a stale/partial 0)
+				// — matching the zone/policy collectors — and rely on the
+				// bumped counterReadErrors. A userspace-published counter is a
+				// real signal, so still emit when one is present (#3461).
+				if mapFailed && !userspaceOk {
 					continue
 				}
-				ch <- prometheus.MustNewConstMetric(c.filterHitsTotal, prometheus.CounterValue,
-					float64(totalPkts), name, family, term.Name)
+				if hasMap || userspaceOk {
+					ch <- prometheus.MustNewConstMetric(c.filterHitsTotal, prometheus.CounterValue,
+						float64(totalPkts), name, family, term.Name)
+				}
 			}
 		}
 	}

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -326,7 +326,7 @@ func (c *xpfCollector) collectFilterCounters(ch chan<- prometheus.Metric, dp api
 
 			for _, term := range filter.Terms {
 				// #3459: the per-term counter-slot stride is the shared SSOT
-				// dataplane.FilterTermExpansionCount (full src×dst×dstPort×
+				// config.FilterTermExpansionCount (full src×dst×dstPort×
 				// srcPort cross-product, with prefix-list prefixes folded into
 				// src/dst) — NOT the old nSrc*nDst that ignored ports and
 				// prefix-lists and drifted later terms onto a neighbouring

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -21,13 +21,18 @@ func newCollector(srv *Server) *xpfCollector {
 			"Total packets dropped.",
 			nil, nil,
 		),
-		// #3345: scrape-error signal for global-counter map reads. A failed
+		// #3345/#3408: scrape-error signal for dataplane counter reads across
+		// the global, per-zone, per-policy, and per-filter collectors. A failed
 		// read omits the affected counter sample instead of emitting a
-		// misleading 0, and bumps this monotonic counter so a degraded
-		// counter bridge is alertable rather than silently reported as zero.
+		// misleading 0, and bumps this monotonic counter so a degraded counter
+		// bridge is alertable rather than silently reported as zero. #3463: the
+		// descriptor text covers all four read surfaces (not global-only) so an
+		// operator runbook built on it does not misdiagnose a zone/policy/filter
+		// counter-bridge failure as global-only.
 		counterReadErrorsTotal: prometheus.NewDesc(
 			"xpf_counter_read_errors_total",
-			"Total global-counter map read failures during metric scrapes.",
+			"Total dataplane counter read failures during metric scrapes "+
+				"(global, zone, policy, and filter counters).",
 			nil, nil,
 		),
 		sessionsCreatedTotal: prometheus.NewDesc(

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -21,18 +21,21 @@ func newCollector(srv *Server) *xpfCollector {
 			"Total packets dropped.",
 			nil, nil,
 		),
-		// #3345/#3408: scrape-error signal for dataplane counter reads across
-		// the global, per-zone, per-policy, and per-filter collectors. A failed
-		// read omits the affected counter sample instead of emitting a
-		// misleading 0, and bumps this monotonic counter so a degraded counter
-		// bridge is alertable rather than silently reported as zero. #3463: the
-		// descriptor text covers all four read surfaces (not global-only) so an
-		// operator runbook built on it does not misdiagnose a zone/policy/filter
-		// counter-bridge failure as global-only.
+		// #3345/#3408: scrape-error signal for counter reads across the global,
+		// per-zone, per-policy, and per-filter dataplane collectors AND the
+		// kernel-nftables host-inbound collector (#3361, pre-gate). A failed read
+		// omits the affected counter sample instead of emitting a misleading 0,
+		// and bumps this monotonic counter so a degraded counter bridge is
+		// alertable rather than silently reported as zero. #3463: the descriptor
+		// text names every read surface that increments this counter — including
+		// the host-inbound kernel-nftables read — so an operator runbook built on
+		// it does not misdiagnose a zone/policy/filter or host-inbound counter
+		// failure as global-only.
 		counterReadErrorsTotal: prometheus.NewDesc(
 			"xpf_counter_read_errors_total",
-			"Total dataplane counter read failures during metric scrapes "+
-				"(global, zone, policy, and filter counters).",
+			"Total counter read failures during metric scrapes (global, zone, "+
+				"policy, and filter dataplane reads, plus kernel-nftables "+
+				"host-inbound reads).",
 			nil, nil,
 		),
 		sessionsCreatedTotal: prometheus.NewDesc(

--- a/pkg/api/stats_counter_error_test.go
+++ b/pkg/api/stats_counter_error_test.go
@@ -2,6 +2,11 @@
 // clean 0. REST returns 500; the Prometheus collector SKIPS the affected
 // sample (rather than emitting 0) and bumps xpf_counter_read_errors_total.
 //
+// #3462: collectGlobalCounters no longer EMITS xpf_counter_read_errors_total
+// itself — Collect emits it last via emitCounterReadErrors, after all
+// sub-collectors that can bump it. This test mirrors that order
+// (collectGlobalCounters then emitCounterReadErrors).
+//
 // FAIL-ON-REVERT: restoring `v, _ := dp.ReadGlobalCounter(idx)` in
 // globalStatsHandler / collectGlobalCounters makes REST return 200 with a
 // zero body and Prometheus emit the per-counter families as 0 with the error
@@ -55,6 +60,9 @@ func TestCollectGlobalCountersSkipsAndCountsReadErrors(t *testing.T) {
 
 	ch := make(chan prometheus.Metric, 64)
 	c.collectGlobalCounters(ch, dp)
+	// #3462: the error-total sample is emitted by emitCounterReadErrors (called
+	// last in Collect), not by collectGlobalCounters. Mirror that order here.
+	c.emitCounterReadErrors(ch)
 	close(ch)
 
 	var perCounterEmitted int

--- a/pkg/cli/cli_show_security_filters.go
+++ b/pkg/cli/cli_show_security_filters.go
@@ -122,9 +122,9 @@ func (c *CLI) showFirewallFilters() error {
 				fmt.Printf("    then %s\n", action)
 
 				// Sum counters across all expanded BPF rules for this term.
-				// Must match the cross-product in expandFilterTerm:
-				// nSrc * nDst * nDstPorts * nSrcPorts
-				numRules := filterTermExpansionCount(cfg, term)
+				// Stride comes from the shared SSOT (#3459) so CLI, gRPC, and
+				// Prometheus agree with the compiler's expandFilterTerm layout.
+				numRules := config.FilterTermExpansionCount(term, cfg.PolicyOptions.PrefixLists)
 				var totalPkts, totalBytes uint64
 				if hasCounters {
 					for i := uint32(0); i < numRules; i++ {
@@ -304,7 +304,7 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 		fmt.Printf("    then %s\n", action)
 
 		// Sum counters across all expanded BPF rules for this term
-		numRules := filterTermExpansionCount(cfg, term)
+		numRules := config.FilterTermExpansionCount(term, cfg.PolicyOptions.PrefixLists)
 		var totalPkts, totalBytes uint64
 		if hasCounters {
 			for i := uint32(0); i < numRules; i++ {
@@ -333,38 +333,4 @@ func (c *CLI) showFirewallFilter(name, requestedFamily string) error {
 		fmt.Printf("warning: filter counter read failed (hit counts may be incomplete): %v\n", readErr)
 	}
 	return nil
-}
-
-func filterTermExpansionCount(cfg *config.Config, term *config.FirewallFilterTerm) uint32 {
-	nSrc := len(term.SourceAddresses)
-	for _, ref := range term.SourcePrefixLists {
-		if !ref.Except {
-			if pl, ok := cfg.PolicyOptions.PrefixLists[ref.Name]; ok {
-				nSrc += len(pl.Prefixes)
-			}
-		}
-	}
-	if nSrc == 0 {
-		nSrc = 1
-	}
-	nDst := len(term.DestAddresses)
-	for _, ref := range term.DestPrefixLists {
-		if !ref.Except {
-			if pl, ok := cfg.PolicyOptions.PrefixLists[ref.Name]; ok {
-				nDst += len(pl.Prefixes)
-			}
-		}
-	}
-	if nDst == 0 {
-		nDst = 1
-	}
-	nDstPorts := len(term.DestinationPorts)
-	if nDstPorts == 0 {
-		nDstPorts = 1
-	}
-	nSrcPorts := len(term.SourcePorts)
-	if nSrcPorts == 0 {
-		nSrcPorts = 1
-	}
-	return uint32(nSrc * nDst * nDstPorts * nSrcPorts)
 }

--- a/pkg/config/firewall_filter_expand.go
+++ b/pkg/config/firewall_filter_expand.go
@@ -1,0 +1,52 @@
+package config
+
+// FilterTermExpansionCount returns the number of dataplane filter rules a
+// single firewall-filter term expands into: the cross-product
+// (literal source addresses + every source-prefix-list prefix) ×
+// (literal destination addresses + every destination-prefix-list prefix) ×
+// destination-ports × source-ports, each factor clamped to a minimum of 1
+// ("any").
+//
+// This is the SINGLE SOURCE OF TRUTH for the per-term counter-slot stride used
+// by every counter reader — CLI `show firewall filter`, the gRPC text mirror,
+// and the Prometheus xpf_filter_hits_total collector. A reader sums `count`
+// consecutive slots from the term's RuleStart offset and advances by the same
+// `count`, so the next term reads its OWN slots rather than a neighbour's
+// (#3459). It lives here, in the config package, because it is pure
+// config-field arithmetic with no dataplane dependency — all readers already
+// import config, and it keeps the eBPF-retirement import boundary clean.
+//
+// It counts ALL prefix-list prefixes regardless of the `except` modifier,
+// because the dataplane expansion (pkg/dataplane.expandFilterTerm) emits a
+// (negated) rule for an except prefix too — excluding them would undercount
+// the stride and drift the running offset. The drift-guard test
+// TestFilterTermExpansionCountMatchesExpand pins this == len(expandFilterTerm).
+func FilterTermExpansionCount(term *FirewallFilterTerm, prefixLists map[string]*PrefixList) uint32 {
+	nSrc := len(term.SourceAddresses)
+	for _, ref := range term.SourcePrefixLists {
+		if pl, ok := prefixLists[ref.Name]; ok {
+			nSrc += len(pl.Prefixes)
+		}
+	}
+	if nSrc == 0 {
+		nSrc = 1
+	}
+	nDst := len(term.DestAddresses)
+	for _, ref := range term.DestPrefixLists {
+		if pl, ok := prefixLists[ref.Name]; ok {
+			nDst += len(pl.Prefixes)
+		}
+	}
+	if nDst == 0 {
+		nDst = 1
+	}
+	nDstPorts := len(term.DestinationPorts)
+	if nDstPorts == 0 {
+		nDstPorts = 1
+	}
+	nSrcPorts := len(term.SourcePorts)
+	if nSrcPorts == 0 {
+		nSrcPorts = 1
+	}
+	return uint32(nSrc * nDst * nDstPorts * nSrcPorts)
+}

--- a/pkg/dataplane/compiler_filter_expansion_test.go
+++ b/pkg/dataplane/compiler_filter_expansion_test.go
@@ -1,0 +1,85 @@
+package dataplane
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestFilterTermExpansionCountMatchesExpand is the #3459 drift guard: the
+// public config.FilterTermExpansionCount (the SSOT every counter reader uses
+// to size and stride a term's counter slots) MUST equal len(expandFilterTerm)
+// — the actual rule layout the compiler installs. If a future change to
+// expandFilterTerm's cross-product is not mirrored there, the per-term hit
+// attribution drifts onto a neighbouring term's slots (the #3459 bug).
+//
+// The except-prefix-list case is the load-bearing one: expandFilterTerm emits
+// a (negated) rule for an except prefix, so the count must include it.
+func TestFilterTermExpansionCountMatchesExpand(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{
+		"src2": {Name: "src2", Prefixes: []string{"10.1.0.0/24", "10.2.0.0/24"}},
+		"dst3": {Name: "dst3", Prefixes: []string{"192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24"}},
+		"ex1":  {Name: "ex1", Prefixes: []string{"172.16.0.0/12"}},
+	}
+
+	cases := []struct {
+		name string
+		term *config.FirewallFilterTerm
+	}{
+		{
+			name: "bare term (any/any) -> 1 rule",
+			term: &config.FirewallFilterTerm{Name: "t", Action: "accept"},
+		},
+		{
+			name: "multi dest-port only",
+			term: &config.FirewallFilterTerm{
+				Name: "t", Action: "accept",
+				DestinationPorts: []string{"80", "443"},
+			},
+		},
+		{
+			name: "source-prefix-list (2) x dest-ports (2)",
+			term: &config.FirewallFilterTerm{
+				Name: "t", Action: "accept",
+				SourcePrefixLists: []config.PrefixListRef{{Name: "src2"}},
+				DestinationPorts:  []string{"80", "443"},
+			},
+		},
+		{
+			name: "literal src (1) + src-prefix-list (2) x dst-prefix-list (3)",
+			term: &config.FirewallFilterTerm{
+				Name: "t", Action: "accept",
+				SourceAddresses:   []string{"10.0.0.1/32"},
+				SourcePrefixLists: []config.PrefixListRef{{Name: "src2"}},
+				DestPrefixLists:   []config.PrefixListRef{{Name: "dst3"}},
+			},
+		},
+		{
+			name: "except prefix-list still contributes a (negated) rule",
+			term: &config.FirewallFilterTerm{
+				Name: "t", Action: "accept",
+				SourcePrefixLists: []config.PrefixListRef{{Name: "src2"}, {Name: "ex1", Except: true}},
+				DestinationPorts:  []string{"53"},
+				SourcePorts:       []string{"1024", "2048"},
+			},
+		},
+		{
+			name: "missing prefix-list reference contributes nothing",
+			term: &config.FirewallFilterTerm{
+				Name: "t", Action: "accept",
+				SourcePrefixLists: []config.PrefixListRef{{Name: "does-not-exist"}},
+			},
+		},
+	}
+
+	for _, fam := range []uint8{AFInet, AFInet6} {
+		for _, tc := range cases {
+			want := uint32(len(expandFilterTerm(tc.term, fam, nil, prefixLists, nil)))
+			got := config.FilterTermExpansionCount(tc.term, prefixLists)
+			if got != want {
+				t.Errorf("family=%d %s: FilterTermExpansionCount()=%d, len(expandFilterTerm)=%d",
+					fam, tc.name, got, want)
+			}
+		}
+	}
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -135,7 +135,7 @@ func (s *Server) showFirewall(cfg *config.Config, buf *strings.Builder) {
 				}
 				fmt.Fprintf(buf, "    then %s\n", action)
 
-				numRules := firewallFilterTermExpansionCount(cfg, term)
+				numRules := config.FilterTermExpansionCount(term, cfg.PolicyOptions.PrefixLists)
 				var totalPkts, totalBytes uint64
 				if hasCounters {
 					for i := uint32(0); i < numRules; i++ {
@@ -434,7 +434,7 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 					action = "accept"
 				}
 				fmt.Fprintf(buf, "    then %s\n", action)
-				numRules := firewallFilterTermExpansionCount(cfg, term)
+				numRules := config.FilterTermExpansionCount(term, cfg.PolicyOptions.PrefixLists)
 				var totalPkts, totalBytes uint64
 				if hasCounters {
 					for i := uint32(0); i < numRules; i++ {
@@ -465,40 +465,4 @@ func (s *Server) showFirewallFilter(req *pb.ShowTextRequest, cfg *config.Config,
 		}
 	}
 	return &pb.ShowTextResponse{Output: buf.String()}, nil
-}
-
-// firewallFilterTermExpansionCount returns the rule-expansion count
-// for a filter term (moved from server_show.go in #1700).
-func firewallFilterTermExpansionCount(cfg *config.Config, term *config.FirewallFilterTerm) uint32 {
-	nSrc := len(term.SourceAddresses)
-	for _, ref := range term.SourcePrefixLists {
-		if !ref.Except {
-			if pl, ok := cfg.PolicyOptions.PrefixLists[ref.Name]; ok {
-				nSrc += len(pl.Prefixes)
-			}
-		}
-	}
-	if nSrc == 0 {
-		nSrc = 1
-	}
-	nDst := len(term.DestAddresses)
-	for _, ref := range term.DestPrefixLists {
-		if !ref.Except {
-			if pl, ok := cfg.PolicyOptions.PrefixLists[ref.Name]; ok {
-				nDst += len(pl.Prefixes)
-			}
-		}
-	}
-	if nDst == 0 {
-		nDst = 1
-	}
-	nDstPorts := len(term.DestinationPorts)
-	if nDstPorts == 0 {
-		nDstPorts = 1
-	}
-	nSrcPorts := len(term.SourcePorts)
-	if nSrcPorts == 0 {
-		nSrcPorts = 1
-	}
-	return uint32(nSrc * nDst * nDstPorts * nSrcPorts)
 }


### PR DESCRIPTION
Fixes four coupled defects in the Prometheus collector's firewall-filter / scrape-error counter path, plus the duplicated term-expansion logic that was their root cause.

## What changed

**#3459 — wrong term hit attribution.** `collectFilterCounters` advanced each term's counter-slot read using `nSrc*nDst` only, ignoring source/destination ports and prefix-list expansion. Multi-port / prefix-list terms were undercounted AND the running `ruleOffset` drifted, so later terms read a neighbour's slots. The three duplicate stride implementations (CLI `filterTermExpansionCount`, gRPC `firewallFilterTermExpansionCount`, the inline Prometheus copy) are now one SSOT, `config.FilterTermExpansionCount`, computing the full `src × dst × dstPort × srcPort` cross-product with prefix-list prefixes folded into src/dst — counting `except` prefixes too, matching the compiler's `expandFilterTerm`. A drift-guard test in `pkg/dataplane` pins the SSOT == `len(expandFilterTerm)`. It lives in `pkg/config` (pure config arithmetic, no dataplane dep) so the CLI/gRPC show paths do not import `pkg/dataplane` and trip the #1451 legacy-import canary.

**#3461 — undercount on the userspace-dp runtime.** The Rust helper publishes per-term hit counters via `filter_term_counters`; CLI/gRPC merge them via `BuildFirewallFilterTermCounterIndex`, but Prometheus read only the retired eBPF map, so `xpf_filter_hits_total` reported 0/stale while the text commands showed real hits. The collector now performs the same merge, independent of the eBPF apply result (no longer gated on a compile result / FilterIDs), so a pure userspace dataplane exports its filter hits. The #3408 skip-on-read-error behavior is preserved.

**#3462 — degraded scrape lagged one scrape.** `xpf_counter_read_errors_total` was emitted inside `collectGlobalCounters` (runs first); the zone/policy/filter collectors bump the same atomic afterwards, so a failure was not reflected until the next scrape. The sample is now emitted last in `Collect` (`emitCounterReadErrors`), after every collector that can bump it.

**#3463 — descriptor/Help drift.** The descriptor still said "global-counter map reads" although #3401/#3408 widened the counter to cover zone/policy/filter reads. Updated the Help string, comments, and the README to name all four read surfaces.

## Closes
- Closes #3459
- Closes #3461
- Closes #3462
- Closes #3463

## Tests (each RED on revert of its fix — verified)
- `TestCollectFilterCountersExpandsPortsAndPrefixLists` — 2-prefix × 2-port term owns slots 0..3, next term owns slot 4 → t1=10, t2=5 (revert → 1, 2).
- `TestCollectFilterCountersMergesUserspaceCounters` — helper publishes 777 with no eBPF map path; sample must carry 777 (revert → absent/0).
- `TestCollectEmitsCounterReadErrorsAfterSubcollectors` — full `Collect()` whose only failing reads are per-zone must emit a non-zero error total in the same scrape (revert → 0).
- `TestFilterTermExpansionCountMatchesExpand` — drift guard SSOT == `len(expandFilterTerm)`.
- `stats_counter_error_test.go` updated to mirror the new emit location.

Validation: `go test ./pkg/config/ ./pkg/dataplane/ ./pkg/dataplane/userspace/ ./pkg/cli/ ./pkg/grpcapi/ ./pkg/api/` all pass (incl. the retirement-boundary canary); `go build ./cmd/xpfd/` clean; gofmt + go vet clean on changed Go files. Rebased onto current master.

## Not folded — #3464 (deferred)
#3464 (interface counter-read failures behave divergently across REST stats / REST inventory / gRPC / Prometheus) is intentionally **out of scope**: it is explicitly out of the #3345 security-counter contract and requires a new uniform interface-counter contract (`xpf_interface_counter_read_errors_total` + a structured `unavailable`/degraded field) applied across four surfaces — a distinct, larger change touching `stats.go`, `interfaces.go`, gRPC `GetInterfaces`, and the Prometheus interface collector. It deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi