### PR TITLE
config/nat: pin feed-only address-name accept across the SNAT/DNAT matrix (#3418)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-06-29 — #3418 NAT strict feed-only address-name: pin the carve-out across the full SNAT/DNAT matrix
+
+- **Timestamp**: 2026-06-29
+  - **Action**: #3418 (over-reject audit) — the H01 over-reject was already
+    fixed in master by the #3425 PR (commit 505793bed): the `feedBinding`
+    short-circuit in validateNATSourceAddressNameReferencesStrict's `nameError`
+    (compiler_validate_strict.go ~L5809-5831) accepts a NAT
+    `match {source,destination}-address-name` that names a feed-only
+    `security dynamic-address address-name` binding (no static address-book
+    duplicate). Root cause of the original over-reject: the pre-#3425 `defined`
+    closure consulted ONLY the static address book, so a feed-only name was
+    hard-rejected as "undefined" — contradicting the #3303 snapshot resolver
+    that unions feedOverlay[name]. The remaining #3418 L01 gap: the
+    strict-CompileConfig ACCEPT was pinned for only ONE of four combinations
+    (SNAT source, TestNATSourceAddressNameDirectFeedAccepted) — reverting the
+    carve-out would silently re-reject SNAT-dest / DNAT-source / DNAT-dest with
+    no failing test. Closed that gap with three additive feed-only-accept
+    CompileConfig tests. RED-on-revert verified: removing the feedBinding
+    short-circuit fails all four feed-accept tests with the exact #3418
+    "references undefined {source,destination}-address-name" error; the #2416 /
+    #3229 undefined-reference tests STILL pass in the reverted state (accepting
+    feed names is orthogonal to rejecting typos — no fail-open). The #3303
+    pkg/dataplane/userspace tests already cover the "snapshot carries feed
+    prefixes" half for all four paths. Test-only PR (the code fix shipped via
+    #3425). go test ./pkg/config ./pkg/cmdtree green; gofmt + go vet clean.
+  - **File(s)**: pkg/config/compiler_nat_address_name_feed_3418_test.go,
+    docs/config-schema.md, _Log.md
+
 ## 2026-06-29 — #3413 doc accuracy: pre-id-default-policy is Partial/inert, not Implemented
 
 - **Timestamp**: 2026-06-29

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -940,7 +940,12 @@ reserved for whole-dataplane selection where a rewrite shim
     member NESTED in an address-set stays poisoned by the static resolver
     (the anti-Option-C guardrail). Lenient load / peer-sync downgrades to a
     warning so an already-persisted or peer-synced config still boots
-    (#1960); the dataplane fails closed independently.
+    (#1960); the dataplane fails closed independently. **#3418** — the
+    feed carve-out is now pinned through the full `CompileConfig` strict
+    commit path for ALL FOUR SNAT/DNAT source/destination address-name
+    combinations (the #3303 snapshot tests call the builder directly and
+    bypass the strict validator, which is how the over-reject survived for
+    the three combinations the #3425 SNAT-source test did not cover).
   - `protocols router-advertisement interface` — typed the
     second-denominated leaves (`max/min-advertisement-interval`,
     `default-lifetime`, `link-mtu`; the latter was tightened from

--- a/pkg/config/compiler_nat_address_name_feed_3418_test.go
+++ b/pkg/config/compiler_nat_address_name_feed_3418_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"testing"
+)
+
+// #3418: the strict NAT commit validator
+// (validateNATSourceAddressNameReferencesStrict) must ACCEPT a NAT
+// `match {source,destination}-address-name <name>` that names a feed-only
+// `security dynamic-address address-name <name> profile feed-name <feed>`
+// binding with NO static `security address-book` duplicate. #3303/#3312
+// threaded the live dynamic-address feed overlay into the NAT snapshot builder
+// (resolveNATAddressNamePrefixes unions the static book with feedOverlay[name]),
+// so such a reference DOES carry prefixes at runtime — but the strict commit
+// gate originally only recognized static address-book names and hard-rejected
+// the feed-only name as "undefined", a post-#3303 contradiction that forced
+// operators to author a redundant static address-book object.
+//
+// The #3425 feed carve-out (the `feedBinding` short-circuit in `nameError`)
+// fixes the over-reject, and #3303's pkg/dataplane/userspace tests prove the
+// snapshot carries the feed prefixes for all four SNAT/DNAT source/dest paths.
+// But the strict-commit ACCEPT was only pinned for ONE of the four
+// combinations (SNAT source, TestNATSourceAddressNameDirectFeedAccepted) — the
+// reason the contradiction survived (#3418 L01): reverting the carve-out would
+// still leave SNAT-destination, DNAT-source, and DNAT-destination feed-only
+// references silently rejected with no failing test. These tests close that
+// gap across the full matrix.
+//
+// RED-on-revert: removing the `feedBinding(name)` short-circuit from
+// `nameError` makes `defined(name)` (static-book-only) return false for a
+// feed-only name, so CompileConfig hard-rejects it as undefined and every test
+// below fails. The complementary "genuinely-undefined reference is STILL
+// rejected" direction is anchored by the #2416 (source) and #3229
+// (destination) undefined-reference tests for both SNAT and DNAT, so accepting
+// feed-only names does NOT open a fail-open hole.
+//
+// All trees use ParseSetCommand + SetPath (buildTree), never NewParser (the
+// flat-set gotcha in CLAUDE.md), so the production strict validator is
+// exercised — the #3303 tests call buildSnapshotWithSchedulerState directly and
+// bypass CompileConfig, which is how the contradiction stayed invisible.
+
+// feedServerBinding returns the dynamic-address feed-server + address-name
+// binding lines for a feed-only name (no static address-book entry for it).
+func feedServerBinding(bindingName string) []string {
+	return []string{
+		"set security dynamic-address feed-server threat url https://feeds.example/list.txt",
+		"set security dynamic-address feed-server threat feed-name malware path /malware.txt",
+		"set security dynamic-address address-name " + bindingName + " profile feed-name malware",
+	}
+}
+
+// TestNATSNATDestinationAddressNameDirectFeedAccepted: an SNAT rule whose
+// `match destination-address-name` names a feed-only dynamic-address binding
+// must commit clean (#3418 / #3303 / #3425).
+func TestNATSNATDestinationAddressNameDirectFeedAccepted(t *testing.T) {
+	lines := append(feedServerBinding("bad-actors"),
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security nat source rule-set rs1 from zone trust",
+		"set security nat source rule-set rs1 to zone untrust",
+		"set security nat source rule-set rs1 rule r1 match destination-address-name bad-actors",
+		"set security nat source rule-set rs1 rule r1 then source-nat interface",
+	)
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("SNAT match destination-address-name referencing a direct "+
+			"dynamic-address feed binding must commit (#3418/#3303/#3425), got: %v", err)
+	}
+}
+
+// TestNATDNATSourceAddressNameDirectFeedAccepted: a DNAT rule whose
+// `match source-address-name` (the #2394 source constraint) names a feed-only
+// dynamic-address binding must commit clean (#3418 / #3303 / #3425).
+func TestNATDNATSourceAddressNameDirectFeedAccepted(t *testing.T) {
+	lines := append(feedServerBinding("bad-actors"),
+		"set security zones security-zone untrust",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match source-address-name bad-actors",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	)
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("DNAT match source-address-name referencing a direct "+
+			"dynamic-address feed binding must commit (#3418/#3303/#3425), got: %v", err)
+	}
+}
+
+// TestNATDNATDestinationAddressNameDirectFeedAccepted: a DNAT rule whose
+// `match destination-address-name` names a feed-only dynamic-address binding
+// must commit clean (#3418 / #3303 / #3425).
+func TestNATDNATDestinationAddressNameDirectFeedAccepted(t *testing.T) {
+	lines := append(feedServerBinding("bad-actors"),
+		"set security zones security-zone untrust",
+		"set security nat destination pool dp address 10.0.0.5",
+		"set security nat destination rule-set rs1 from zone untrust",
+		"set security nat destination rule-set rs1 rule r1 match destination-address-name bad-actors",
+		"set security nat destination rule-set rs1 rule r1 then destination-nat pool dp",
+	)
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("DNAT match destination-address-name referencing a direct "+
+			"dynamic-address feed binding must commit (#3418/#3303/#3425), got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #3418

## Summary

Issue #3418 reports an over-reject: the strict NAT commit validator rejected a `match {source,destination}-address-name <name>` that named a **feed-only** `security dynamic-address address-name` binding (no static `security address-book` duplicate), even though #3303/#3312 thread the live feed overlay into the snapshot builder so the reference resolves to feed prefixes at runtime.

**The H01 over-reject was already fixed in master** by the #3425 PR (commit `505793bed`): `validateNATSourceAddressNameReferencesStrict`'s `nameError` now short-circuits on a `feedBinding(name)` carve-out (`cfg.Security.DynamicAddress.AddressBindings`) before the static-book `defined` check — mirroring the `validatePolicyMatchAddressesStrict` feed carve-out (#3294).

### Over-reject root cause (origin/master, now fixed by #3425)
`pkg/config/compiler_validate_strict.go` — the pre-#3425 `defined` closure consulted ONLY `cfg.Security.AddressBook` (Addresses + AddressSets), never `cfg.Security.DynamicAddress.AddressBindings`, so a feed-only name fell through to `references undefined {source,destination}-address-name`.

### What this PR closes (#3418 L01)
The strict-`CompileConfig` ACCEPT was pinned for only **one of four** SNAT/DNAT source/destination combinations (SNAT source). The #3303 snapshot tests call `buildSnapshotWithSchedulerState` directly and bypass the strict validator — which is exactly why the contradiction survived. This PR adds three additive feed-only-accept `CompileConfig` tests for the uncovered combinations:

- `TestNATSNATDestinationAddressNameDirectFeedAccepted` — SNAT `match destination-address-name`
- `TestNATDNATSourceAddressNameDirectFeedAccepted` — DNAT `match source-address-name`
- `TestNATDNATDestinationAddressNameDirectFeedAccepted` — DNAT `match destination-address-name`

Each builds feed-server + dynamic-address binding + NAT rule via `ParseSetCommand`/`SetPath` (`buildTree`, not `NewParser`) so the production strict validator runs. The "snapshot carries feed prefixes" half is already covered for all four paths by the #3303 `pkg/dataplane/userspace` tests.

## RED-on-revert proof (both directions)

- **Feed-only now ACCEPTED:** removing the `feedBinding(name)` short-circuit from `nameError` fails **all four** feed-accept tests (the existing SNAT-source + the three added here) with the exact #3418 error: `references undefined {source,destination}-address-name "bad-actors"`.
- **Undefined STILL REJECTED (no fail-open):** with the carve-out reverted, the #2416 (source) and #3229 (destination) undefined-reference tests STILL pass — accepting feed names is orthogonal to rejecting typos, so no fail-open hole is opened.

## Tests
`go test ./pkg/config ./pkg/cmdtree` green; `gofmt` + `go vet` clean. Test-only change plus a `docs/config-schema.md` note (the code fix shipped via #3425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi