### PR TITLE
screen: enforce syn-flood timeout as per-zone half-open session window (#3527)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,7 @@ in git history; `git log -- bpf/xdp/ bpf/tc/` walks the deleted source.
 - **Firewall**: Stateful inspection, zone-based policies (including global policies), address books, application matching, multi-term apps, filtered session clearing
 - **NAT**: SNAT (interface + pool, address-persistent), DNAT (with hit counters), static 1:1, NAT64
 - **IPv4 + IPv6**: Dual-stack, DHCPv4/v6 clients, Router Advertisements
-- **Screen/IDS**: 11 checks (land, syn-flood, ping-death, teardrop, rate-limiting), SYN cookie flood protection (XDP-generated SYN-ACK cookies with source validation), SYN-flood sub-thresholds (#3315: per-source/per-destination caps on a no-eviction count-min sketch + log-only alarm-threshold; `timeout` maps to the half-open session window, tracked follow-up)
+- **Screen/IDS**: 11 checks (land, syn-flood, ping-death, teardrop, rate-limiting), SYN cookie flood protection (XDP-generated SYN-ACK cookies with source validation), SYN-flood sub-thresholds (#3315: per-source/per-destination caps on a no-eviction count-min sketch + log-only alarm-threshold; `timeout` ENFORCED in #3527 as a per-zone override of the half-open session window `tcp_opening_ns`)
 - **Routing**: FRR integration (static, OSPF, BGP, IS-IS, RIP), VRFs, GRE tunnels, export/redistribute, ECMP multipath, next-table + rib-group inter-VRF route leaking, route filtering by protocol/CIDR, probe-driven WAN failover (`services ip-monitoring` preferred-route injection, #1827)
 - **VLANs**: 802.1Q tagging, trunk ports
 - **IPsec**: strongSwan config generation, IKE proposals, gateway compilation, XFRM interfaces

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -32,10 +32,15 @@ the userspace dataplane admission boundary is in
   dropping. Memory per configured zone per worker is ~192 KiB
   (`ROWS*DST_COLS + ROWS*SRC_COLS` × 16 B); the Go compiler emits a
   commit-time advisory if `attack-threshold / source-threshold` exceeds
-  ~1000 (the regime where the sketch can over-throttle). `timeout` parses
-  and commits but is NOT yet enforced — it maps to the per-zone half-open
-  session window (`tcp_opening_ns`), a tracked follow-up; the compiler emits
-  a commit-time warning so the leaf is never silently inert.
+  ~1000 (the regime where the sketch can over-throttle). `timeout` is
+  ENFORCED (#3527, the #3315 follow-up): it is NOT a screen-rate control —
+  it maps to the per-zone half-open TCP session window (`tcp_opening_ns`,
+  20 s default), crossing the wire as `ScreenProfileSnapshot.syn_flood_timeout`
+  and applied as a per-ingress-zone override (`session_opening_overrides` →
+  `SessionTable::set_opening_overrides`), so a bare-SYN session in a screened
+  zone reaps on the operator's window instead of the global default. It is
+  node-local config-derived state (re-derived per HA node, never on the
+  session-sync wire); the #3315 accepted-but-inert commit warning is removed.
 - **Firewall filters**: policer (token bucket + three-color), lo0 filter,
   flexible match, port ranges, hit counters, logging, forwarding-class
   DSCP rewrite.

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -93,12 +93,25 @@ screen runtime:
   raises an out-of-band, ≤1/sec/zone screen ALARM event (RT_FLOW PERMIT, NOTICE
   severity, reason `syn-flood-alarm`) WITHOUT dropping the packet, like the
   scan-table-pressure alarm.
-- **`timeout`** — accepted and committed but NOT yet enforced. It maps to the
-  per-zone half-open session window (`SessionTimeouts.tcp_opening_ns`), a
-  session-layer surface that couples to session timeouts + HA sync and is split
-  to a tracked follow-up. The compiler emits a commit-time WARNING so the leaf is
-  never silently inert; the global half-open TCP timeout applies until the
-  follow-up lands.
+- **`timeout`** — ENFORCED (#3527; the #3315 tracked follow-up). It is NOT a
+  screen-rate control: it maps to the per-zone half-open TCP session window
+  (`SessionTimeouts.tcp_opening_ns`, 20 s default — the Junos
+  half-completed-connection queue). `timeout N` now crosses the wire
+  (`ScreenProfileSnapshot.syn_flood_timeout`, seconds) and the forwarding
+  builder turns it into a per-ingress-zone override of `tcp_opening_ns`
+  (`ForwardingState.session_opening_overrides` →
+  `SessionTable::set_opening_overrides`). A bare-SYN (OPENING / half-open)
+  session in a screened zone is then reaped on `N` seconds instead of the
+  global 20 s default — so a flood that stops is forgotten on the operator's
+  window, and a half-open never lingers longer than the configured queue
+  bound. `session_timeout_ns` consults the override ONLY on the OPENING branch
+  (never the established / closing / RST windows). HA composition (#3315 plan
+  §11.1): the override is config-derived and re-derived per node from the
+  snapshot — it does NOT travel on the session-sync wire. A peer-synced session
+  is imported ESTABLISHED, so its OPENING branch is never taken, and identical
+  config on both nodes yields the same map independently. The #3315 commit-time
+  "accepted but NOT yet enforced" WARNING is removed now that the leaf is
+  effective.
 
 Enforcement order (`screen/mod.rs`, inside the initial-SYN gate, after the
 validated-cookie bypass): (1) the aggregate `attack-threshold` (+

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -71,21 +71,21 @@ const (
 // it. We advise (never reject) so the config still commits.
 const synFloodSrcAttackRatioAdvisoryThreshold = 1000
 
-// validateScreenSynFloodSubThresholds emits WARNINGS (never a hard reject) for
-// SYN-flood sub-threshold leaves whose enforcement is incomplete or risky
-// (#3315):
+// validateScreenSynFloodSubThresholds emits a WARNING (never a hard reject) for
+// the one risky SYN-flood sub-threshold band (#3315):
 //
-//   - `timeout` parses into SynFloodConfig.Timeout and commits cleanly but is
-//     NOT yet enforced — it maps to the per-zone half-open session window
-//     (tcp_opening_ns), a session-layer surface split to a tracked follow-up.
-//     Without this warning the leaf is silently inert, which is exactly the
-//     configured-but-not-enforced trap #3315 fixes for the other leaves.
 //   - an attack-threshold orders of magnitude above source-threshold is the one
 //     pathological band where the per-source count-min sketch can false-throttle
 //     legitimate sources; advise the operator (per the converged plan §5b).
 //
-// Both fire on BOTH the strict and lenient compile paths: the values are valid
+// It fires on BOTH the strict and lenient compile paths: the values are valid
 // and parseable, the dataplane just cannot fully honour them.
+//
+// #3527: the `timeout` leaf NO LONGER warns. It is now enforced as a per-zone
+// override of the half-open session window (tcp_opening_ns) — see
+// pkg/dataplane/userspace/screens.go (SYNFloodTimeout) and the dataplane's
+// SessionTable opening overrides. The historical accepted-but-inert advisory
+// is removed now that the leaf is effective.
 func validateScreenSynFloodSubThresholds(cfg *Config) []string {
 	var warnings []string
 	names := make([]string, 0, len(cfg.Security.Screen))
@@ -99,14 +99,6 @@ func validateScreenSynFloodSubThresholds(cfg *Config) []string {
 			continue
 		}
 		sf := sp.TCP.SynFlood
-		if sf.Timeout > 0 {
-			warnings = append(warnings, fmt.Sprintf(
-				"security screen ids-option %s tcp syn-flood timeout %d is accepted "+
-					"but NOT yet enforced by the dataplane (it maps to the per-zone "+
-					"half-open session window, tracked as a follow-up to #3315); the "+
-					"global half-open TCP timeout applies until then",
-				name, sf.Timeout))
-		}
 		if sf.SourceThreshold > 0 && sf.AttackThreshold > 0 &&
 			sf.AttackThreshold/sf.SourceThreshold > synFloodSrcAttackRatioAdvisoryThreshold {
 			warnings = append(warnings, fmt.Sprintf(

--- a/pkg/config/screen_synflood_subthreshold_3315_test.go
+++ b/pkg/config/screen_synflood_subthreshold_3315_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 )
 
-// TestSynFloodTimeoutEmitsInertWarning asserts the #3315 commit-time advisory
-// for `syn-flood timeout`: the leaf parses and commits cleanly but is not yet
-// enforced by the dataplane (it maps to the per-zone half-open session window,
-// a tracked follow-up), so the compiler warns it is accepted-but-inert. Without
-// this the leaf is silently dead — exactly the configured-but-not-enforced trap
-// #3315 fixes for the source/destination/alarm leaves.
-func TestSynFloodTimeoutEmitsInertWarning(t *testing.T) {
+// TestSynFloodTimeoutNoLongerWarnsWhenEnforced is the #3527 inversion of the
+// retired #3315 inert-warning test. `syn-flood timeout` is now enforced as a
+// per-zone override of the half-open session window (tcp_opening_ns) — see
+// pkg/dataplane/userspace/screens.go (SYNFloodTimeout) and the dataplane's
+// SessionTable opening overrides — so the compiler MUST NOT emit the legacy
+// accepted-but-inert advisory. Reinstate the warning branch and this goes RED.
+func TestSynFloodTimeoutNoLongerWarnsWhenEnforced(t *testing.T) {
 	tree := buildTree(t, []string{
 		"set security screen ids-option p tcp syn-flood attack-threshold 2000",
 		"set security screen ids-option p tcp syn-flood timeout 20",
@@ -19,8 +19,16 @@ func TestSynFloodTimeoutEmitsInertWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("strict commit rejected a valid syn-flood timeout: %v", err)
 	}
-	if !hasWarningContaining(cfg.Warnings, "syn-flood timeout 20 is accepted but NOT yet enforced") {
-		t.Fatalf("expected a syn-flood timeout inert-warning, warnings=%v", cfg.Warnings)
+	if hasWarningContaining(cfg.Warnings, "syn-flood timeout") {
+		t.Fatalf("syn-flood timeout is now enforced (#3527) and must not warn, warnings=%v", cfg.Warnings)
+	}
+	if hasWarningContaining(cfg.Warnings, "NOT yet enforced") {
+		t.Fatalf("the inert-warning must be gone now that timeout is enforced, warnings=%v", cfg.Warnings)
+	}
+	// Sanity: the leaf still parses into the typed config so the snapshot
+	// builder can publish it.
+	if sf := cfg.Security.Screen["p"].TCP.SynFlood; sf == nil || sf.Timeout != 20 {
+		t.Fatalf("expected syn-flood timeout 20 parsed into typed config, got %+v", sf)
 	}
 }
 

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -4085,8 +4085,9 @@ func TestDeriveUserspaceCapabilitiesAllowsBasicScreenProfile(t *testing.T) {
 // hot-path enforcement — the per-destination/per-source cap drops and the
 // log-only alarm gate (and their RED-on-revert) live in the Rust screen runtime
 // tests (`cargo test --bin xpf-userspace-dp screen::`, userspace-dp/src/screen/
-// tests.rs). `timeout` is intentionally NOT on the wire (it maps to the session
-// half-open window, a tracked follow-up).
+// tests.rs). #3527: `timeout` now ALSO crosses the wire (SYNFloodTimeout) — it
+// maps to the per-zone half-open session window (tcp_opening_ns); the Rust
+// SessionTable opening-override tests guard the enforcement RED-on-revert.
 func TestBuildScreenSnapshotsSynFloodSubThresholds(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.Zones = map[string]*config.ZoneConfig{
@@ -4121,6 +4122,10 @@ func TestBuildScreenSnapshotsSynFloodSubThresholds(t *testing.T) {
 	if s.SYNFloodDstThreshold != 100 {
 		t.Errorf("SYNFloodDstThreshold = %d, want 100", s.SYNFloodDstThreshold)
 	}
+	// #3527: the half-open `timeout` now crosses the wire too.
+	if s.SYNFloodTimeout != 20 {
+		t.Errorf("SYNFloodTimeout = %d, want 20", s.SYNFloodTimeout)
+	}
 
 	// JSON round-trip: the additive fields serialize and decode unchanged.
 	blob, err := json.Marshal(s)
@@ -4132,7 +4137,7 @@ func TestBuildScreenSnapshotsSynFloodSubThresholds(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if back.SYNFloodAlarmThreshold != 1000 || back.SYNFloodSrcThreshold != 50 ||
-		back.SYNFloodDstThreshold != 100 {
+		back.SYNFloodDstThreshold != 100 || back.SYNFloodTimeout != 20 {
 		t.Errorf("round-trip lost sub-thresholds: %+v", back)
 	}
 
@@ -4144,7 +4149,7 @@ func TestBuildScreenSnapshotsSynFloodSubThresholds(t *testing.T) {
 		t.Fatalf("legacy decode: %v", err)
 	}
 	if legacy.SYNFloodAlarmThreshold != 0 || legacy.SYNFloodSrcThreshold != 0 ||
-		legacy.SYNFloodDstThreshold != 0 {
+		legacy.SYNFloodDstThreshold != 0 || legacy.SYNFloodTimeout != 0 {
 		t.Errorf("legacy snapshot must decode sub-thresholds as 0, got %+v", legacy)
 	}
 }

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -780,15 +780,21 @@ type ScreenProfileSnapshot struct {
 	// attack-threshold (SYNFloodThreshold above) used to cross the wire, so the
 	// other controls committed cleanly yet were operationally inert. These three
 	// carry the per-source / per-destination caps and the log-only alarm rate to
-	// the Rust dataplane. `timeout` is deliberately NOT serialized — it maps to
-	// the per-zone half-open session window (tcp_opening_ns), a session-layer
-	// surface split to a tracked follow-up; the compiler emits a commit-time
-	// warning so the leaf is never silently inert. Additive + omitempty: an old
-	// helper missing these decodes them as 0 (disabled), so version skew degrades
-	// safely (#1961 no-transit class).
+	// the Rust dataplane. Additive + omitempty: an old helper missing these
+	// decodes them as 0 (disabled), so version skew degrades safely (#1961
+	// no-transit class).
 	SYNFloodAlarmThreshold uint32 `json:"syn_flood_alarm_threshold,omitempty"`
 	SYNFloodDstThreshold   uint32 `json:"syn_flood_dst_threshold,omitempty"`
 	SYNFloodSrcThreshold   uint32 `json:"syn_flood_src_threshold,omitempty"`
+	// #3527: the Junos `syn-flood timeout` (SECONDS), the
+	// half-completed-connection queue window. Unlike the sub-thresholds above it
+	// is NOT a screen-rate control — it maps to the per-zone half-open TCP
+	// session window (tcp_opening_ns, 20 s default). The dataplane turns it into
+	// a per-ingress-zone override of tcp_opening_ns so a bare-SYN session in this
+	// zone is reaped on the operator's window instead of the global default. This
+	// closes the #3315 deferred leaf (the compiler no longer warns it is inert).
+	// Additive + omitempty: an old helper missing it decodes 0 (global default).
+	SYNFloodTimeout uint32 `json:"syn_flood_timeout,omitempty"`
 	// Advanced screen features for userspace dataplane
 	SessionLimitSrc   uint32 `json:"session_limit_src,omitempty"`
 	SessionLimitDst   uint32 `json:"session_limit_dst,omitempty"`

--- a/pkg/dataplane/userspace/screens.go
+++ b/pkg/dataplane/userspace/screens.go
@@ -47,9 +47,7 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 			// #3024 default guarantees AttackThreshold > 0 whenever a syn-flood
 			// screen is enabled, so this block is the single publish gate for
 			// every syn-flood control. alarm/source/destination are non-zero only
-			// when the operator configured them; `timeout` is not serialized
-			// (see ScreenProfileSnapshot — it maps to the session half-open
-			// window, a tracked follow-up, and the compiler warns it is inert).
+			// when the operator configured them.
 			if sp.TCP.SynFlood.AlarmThreshold > 0 {
 				snap.SYNFloodAlarmThreshold = uint32(sp.TCP.SynFlood.AlarmThreshold)
 			}
@@ -58,6 +56,13 @@ func buildScreenSnapshots(cfg *config.Config) []ScreenProfileSnapshot {
 			}
 			if sp.TCP.SynFlood.SourceThreshold > 0 {
 				snap.SYNFloodSrcThreshold = uint32(sp.TCP.SynFlood.SourceThreshold)
+			}
+			// #3527: carry `syn-flood timeout` (seconds) so the dataplane can
+			// enforce it as a per-zone override of the half-open session window
+			// (tcp_opening_ns). It maps to the session layer, not the screen-rate
+			// substrate above; closing the #3315 deferred leaf.
+			if sp.TCP.SynFlood.Timeout > 0 {
+				snap.SYNFloodTimeout = uint32(sp.TCP.SynFlood.Timeout)
 			}
 		}
 		if sp.LimitSession.SourceIPBased > 0 {

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -264,6 +264,33 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         snapshot.flow.udp_session_timeout,
         snapshot.flow.icmp_session_timeout,
     );
+    // #3527: per-screened-zone half-open (`tcp_opening_ns`) overrides from each
+    // zone's `syn-flood timeout`. The leaf maps to the Junos
+    // half-completed-connection queue window, NOT the screen-rate substrate
+    // (#3315 D5), so it is enforced at the session layer: a bare-SYN session in
+    // a screened zone reaps on this window instead of the 20 s default. Keyed
+    // by zone id (the same namespace `SessionMetadata.ingress_zone` carries),
+    // resolved via `zone_name_to_id` (built above). A timeout for a zone with no
+    // resolvable id (never assigned to an interface) is silently dropped — the
+    // override could never match a session anyway. Built only when at least one
+    // zone configures a non-zero timeout, so the common case is an empty map.
+    state.session_opening_overrides = snapshot
+        .screens
+        .iter()
+        .filter(|sp| sp.syn_flood_timeout > 0 && !sp.zone.is_empty())
+        .filter_map(|sp| {
+            state
+                .zone_name_to_id
+                .get(&sp.zone)
+                .copied()
+                .map(|zone_id| {
+                    (
+                        zone_id,
+                        crate::session::secs_to_ns_saturating(u64::from(sp.syn_flood_timeout)),
+                    )
+                })
+        })
+        .collect();
     state.source_nat_rules = parse_source_nat_rules_with_previous(
         &snapshot.source_nat_rules,
         previous.map(|state| state.source_nat_rules.as_slice()),

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -116,6 +116,13 @@ pub(in crate::afxdp) struct ForwardingState {
     /// an old Go binary) — sessions then keep app_id 0 (unknown).
     pub(in crate::afxdp) app_catalog: AppCatalog,
     pub(in crate::afxdp) session_timeouts: crate::session::SessionTimeouts,
+    /// #3527: per-ingress-zone override (zone id → ns) of the global half-open
+    /// (`tcp_opening_ns`) TCP window, built from each screened zone's
+    /// `syn-flood timeout`. Pushed onto the worker `SessionTable` via
+    /// `set_opening_overrides` alongside `session_timeouts`. Empty when no zone
+    /// configures a syn-flood timeout (the common case), byte-identical to
+    /// pre-#3527.
+    pub(in crate::afxdp) session_opening_overrides: FastMap<u16, u64>,
     pub(in crate::afxdp) policy: PolicyState,
     pub(in crate::afxdp) source_nat_rules: Vec<SourceNatRule>,
     pub(in crate::afxdp) static_nat: StaticNatTable,

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -401,6 +401,11 @@ pub(crate) fn worker_loop(
             screen_state.update_missing_profiles(new_forwarding.screen_missing_profiles.clone());
             screen_state.update_syn_cookie_master_key(new_forwarding.syn_cookie_master_key);
             sessions.set_timeouts(new_forwarding.session_timeouts);
+            // #3527: re-apply the per-screened-zone half-open overrides on every
+            // runtime forwarding-snapshot rotation. `set_opening_overrides` is a
+            // full replace, so a zone whose `syn-flood timeout` was removed
+            // drops out and reverts to the global default on the next install.
+            sessions.set_opening_overrides(new_forwarding.session_opening_overrides.clone());
             // #2134: re-derive the per-IP session-limit OFF-gate on every
             // runtime forwarding-snapshot rotation. A runtime ON->OFF
             // transition (operator removes `limit-session`) clears the

--- a/userspace-dp/src/afxdp/worker/loop_body/setup.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/setup.rs
@@ -125,6 +125,10 @@ pub(super) fn worker_loop_setup(
     screen_state.update_missing_profiles(forwarding.screen_missing_profiles.clone());
     screen_state.update_syn_cookie_master_key(forwarding.syn_cookie_master_key);
     sessions.set_timeouts(forwarding.session_timeouts);
+    // #3527: push the per-screened-zone half-open (`syn-flood timeout`)
+    // overrides next to `set_timeouts`. Empty in the common case (no zone
+    // configures a syn-flood timeout).
+    sessions.set_opening_overrides(forwarding.session_opening_overrides.clone());
     // #2134: drive the per-IP session-limit OFF-gate from the applied
     // screen profiles. Off when no zone configures `limit-session`, so
     // install/remove counter maintenance is skipped for the ~99% case.

--- a/userspace-dp/src/protocol/security.rs
+++ b/userspace-dp/src/protocol/security.rs
@@ -42,17 +42,27 @@ pub(crate) struct ScreenProfileSnapshot {
     /// additions. The Go compiler parses the full Junos syn-flood shape but only
     /// `syn_flood_threshold` (attack-threshold) used to cross the wire; these
     /// carry the log-only alarm rate and the per-destination / per-source SYN
-    /// rate caps so the dataplane can enforce them (`SynRateSketch`). `timeout`
-    /// is intentionally not on the wire (it maps to the session half-open window,
-    /// a tracked follow-up; the Go compiler warns it is inert). `#[serde(default)]`
-    /// keeps wire parity with an older Go control plane that omits the fields
-    /// (decode to 0 = disabled — #1961 skew tolerance).
+    /// rate caps so the dataplane can enforce them (`SynRateSketch`).
+    /// `#[serde(default)]` keeps wire parity with an older Go control plane that
+    /// omits the fields (decode to 0 = disabled — #1961 skew tolerance).
     #[serde(rename = "syn_flood_alarm_threshold", default)]
     pub syn_flood_alarm_threshold: u32,
     #[serde(rename = "syn_flood_dst_threshold", default)]
     pub syn_flood_dst_threshold: u32,
     #[serde(rename = "syn_flood_src_threshold", default)]
     pub syn_flood_src_threshold: u32,
+    /// #3527: the Junos `syn-flood timeout` (SECONDS), the half-completed-
+    /// connection queue window. It does NOT belong to the screen-rate
+    /// substrate above — it maps to the per-zone half-open TCP session window
+    /// (`SessionTimeouts.tcp_opening_ns`, 20 s default). The forwarding builder
+    /// turns it into a per-ingress-zone override of `tcp_opening_ns`
+    /// (`SessionTable::set_opening_overrides`) so a bare-SYN session in this
+    /// zone is reaped on the operator's window instead of the global default.
+    /// 0 = unset (global default). `#[serde(default)]` keeps wire parity with
+    /// an older Go control plane that omits the field (#1961 skew tolerance).
+    /// This closes the #3315 deferred leaf (#3527).
+    #[serde(rename = "syn_flood_timeout", default)]
+    pub syn_flood_timeout: u32,
     #[serde(rename = "session_limit_src", default)]
     pub session_limit_src: u32,
     #[serde(rename = "session_limit_dst", default)]

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -117,10 +117,27 @@ when configured on the ingress zone; this is the defense-in-depth /
 Junos-parity backstop for zones without it. It is the SYN-flood/half-open
 sibling of the #3046 RST-reap window and composes with the #3227 per-app
 idle timeout (which is the established idle value and never shortens or
-lengthens the opening window). The `tcp_opening_ns` window is not
-operator-configurable yet — held at the default on every construction
-path including `from_seconds` (a future config knob would set it there
-without touching the state machine).
+lengthens the opening window). The global `tcp_opening_ns` window is held
+at the default on every construction path including `from_seconds`; the
+per-zone override below (#3527) is the operator knob.
+
+**Per-zone half-open override (#3527 — Junos `syn-flood timeout`).** The
+Junos `tcp syn-flood timeout N` leaf does NOT belong to the screen-rate
+substrate (#3315 D5); it bounds the half-completed-connection queue, which
+maps to this OPENING window. The Go control plane carries it on the screen
+snapshot (`ScreenProfileSnapshot.syn_flood_timeout`, seconds) and the
+forwarding builder turns each screened zone's timeout into a per-ingress-
+zone override (`ForwardingState.session_opening_overrides`, zone id → ns),
+pushed onto the worker `SessionTable` via `set_opening_overrides` next to
+`set_timeouts` (at startup AND on every runtime snapshot rotation — a full
+replace, so removing the leaf reverts the zone to the global default).
+`session_timeout_ns` takes an `opening_override_ns` consulted ONLY on the
+OPENING branch (never the established / closing / RST windows): a bare-SYN
+session in a zone with `syn-flood timeout N` reaps `N` seconds after
+install instead of the global 20 s default, on all three timeout-selection
+sites (install, lookup-refresh, update_session). The override resolves from
+the entry's `ingress_zone`; an empty override map (no zone configures a
+timeout) is byte-identical to pre-#3527.
 
 **HA-sync interaction (#3152).** The `established` field is node-local
 derived state and is NOT carried on the cross-node session-sync wire (no
@@ -144,6 +161,16 @@ still holds end to end: the primary (the flood target) reaps its
 half-opens at `tcp_opening_ns` and emits a Close delta
 (`session/expire.rs`) that propagates to the standby, removing the synced
 copy promptly without the standby needing its own OPENING window.
+
+The #3527 per-zone opening override composes with this cleanly (the #3315
+plan §11.1 open question). Like `established`, the override is node-local
+derived state and does NOT cross the session-sync wire: it is re-derived
+per node from each node's config snapshot (HA requires identical config,
+so both build the same map). Because a peer-synced session is imported
+ESTABLISHED, its OPENING branch is never taken, so the override is
+irrelevant on the standby for synced sessions — `upsert_synced_with_origin`
+passes `None` explicitly. The override only governs locally-received
+bare-SYN floods on whichever node is forwarding.
 
 **RST vs FIN close (#3046).** A graceful FIN close keeps the full 30 s
 `TCP_CLOSING_TIMEOUT_NS` (TIME_WAIT-style window for half-closed /

--- a/userspace-dp/src/session/install.rs
+++ b/userspace-dp/src/session/install.rs
@@ -165,6 +165,11 @@ impl SessionTable {
                     &self.timeouts,
                     // #3227: per-application idle timeout override (None = global).
                     metadata.inactivity_timeout_ns,
+                    // #3527: the ingress zone's `syn-flood timeout` override of
+                    // the half-open window (None = global). Only consulted on
+                    // the OPENING branch, so a bare-SYN session in a screened
+                    // zone reaps on the operator's window.
+                    self.opening_override_for(metadata.ingress_zone),
                 ),
                 closing: matches!(protocol, PROTO_TCP) && is_closing(tcp_flags),
                 reset: matches!(protocol, PROTO_TCP) && has_rst(tcp_flags),
@@ -341,6 +346,14 @@ impl SessionTable {
                     &self.timeouts,
                     // #3227: per-application idle timeout override (None = global).
                     metadata.inactivity_timeout_ns,
+                    // #3527: a peer-synced session is imported ESTABLISHED, so
+                    // the OPENING branch is never taken and the per-zone
+                    // half-open override is irrelevant here. Passing `None`
+                    // (rather than re-deriving from this node's config) makes
+                    // explicit that the override never crosses the HA wire — it
+                    // is re-derived per node and only governs locally-received
+                    // bare-SYN floods (§11.1 of the #3315 plan).
+                    None,
                 ),
                 closing: matches!(protocol, PROTO_TCP) && is_closing(tcp_flags),
                 reset: matches!(protocol, PROTO_TCP) && has_rst(tcp_flags),

--- a/userspace-dp/src/session/lookup.rs
+++ b/userspace-dp/src/session/lookup.rs
@@ -44,6 +44,15 @@ impl SessionTable {
         // Pre-compute the timeout before borrowing &mut self.entries
         // so the inner block doesn't need to access self.timeouts.
         let timeouts = self.timeouts;
+        // #3527: resolve the per-zone half-open override the same way, by
+        // peeking the entry's ingress zone before the &mut borrow. Only
+        // consulted on the OPENING branch (a SYN retransmit on a still
+        // half-open session); ignored once the session is established.
+        let opening_override_ns = self
+            .entries
+            .get(handle as usize)
+            .map(|r| r.entry.metadata.ingress_zone)
+            .and_then(|zone| self.opening_override_for(zone));
         // Scope the &mut self.entries borrow so it ends BEFORE we
         // touch self.wheel via push_to_wheel. Without this scoping
         // the &mut record would conflict with the second &mut self
@@ -119,6 +128,8 @@ impl SessionTable {
                     entry.established,
                     &timeouts,
                     entry.metadata.inactivity_timeout_ns,
+                    // #3527: per-zone half-open override resolved above.
+                    opening_override_ns,
                 )
             };
             (

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -461,6 +461,21 @@ pub(crate) struct SessionTable {
     last_gc_ns: u64,
     max_sessions: usize,
     timeouts: SessionTimeouts,
+    /// #3527: per-screened-zone override of the global half-open
+    /// (`tcp_opening_ns`) TCP timeout window, keyed by ingress zone id. Built
+    /// from `security screen ids-option <p> tcp syn-flood timeout <N>` (the
+    /// Junos half-completed-connection queue window) and pushed alongside
+    /// `set_timeouts` from the worker's applied forwarding snapshot
+    /// (`set_opening_overrides`). When a bare-SYN OPENING session's ingress
+    /// zone has an entry here, `session_timeout_ns` reaps it at the override
+    /// instead of `DEFAULT_TCP_OPENING_TIMEOUT_NS`, so a per-zone syn-flood
+    /// `timeout` actually bounds how long that zone's half-opens linger. Config
+    /// is identical on both HA nodes, so this is re-derived per node from the
+    /// snapshot — it never crosses the session-sync wire (a synced session is
+    /// imported ESTABLISHED, so the opening branch is never taken for it; see
+    /// `upsert_synced_with_origin`). Empty = no zone configures a syn-flood
+    /// timeout, byte-identical to pre-#3527.
+    opening_overrides: FxHashMap<u16, u64>,
     epoch_counter: u64,
     expired: u64,
     create_drops: u64,
@@ -582,6 +597,9 @@ impl SessionTable {
             last_gc_ns: 0,
             max_sessions: DEFAULT_MAX_SESSIONS,
             timeouts: SessionTimeouts::default(),
+            // #3527: empty until a forwarding snapshot with a per-zone
+            // syn-flood timeout is applied via `set_opening_overrides`.
+            opening_overrides: FxHashMap::default(),
             epoch_counter: 0,
             expired: 0,
             create_drops: 0,
@@ -609,6 +627,30 @@ impl SessionTable {
     /// Update the configurable session timeouts.
     pub fn set_timeouts(&mut self, timeouts: SessionTimeouts) {
         self.timeouts = timeouts;
+    }
+
+    /// #3527: install the per-screened-zone half-open (`tcp_opening_ns`)
+    /// timeout overrides (zone id → ns), driven from each zone's `syn-flood
+    /// timeout`. Called at worker startup and on every runtime
+    /// forwarding-snapshot rotation, right next to `set_timeouts`. A full
+    /// replace (not a merge): a zone whose timeout was removed from the config
+    /// drops out of the new map and reverts to the global default on the next
+    /// install/refresh. Empty map = no per-zone override (global default for
+    /// every zone), the pre-#3527 behavior.
+    pub fn set_opening_overrides(&mut self, overrides: FxHashMap<u16, u64>) {
+        self.opening_overrides = overrides;
+    }
+
+    /// #3527: resolve the half-open opening-window override for an ingress
+    /// zone, or `None` to use the global `tcp_opening_ns`. The common case
+    /// (no zone configures a syn-flood timeout) is an empty map and a single
+    /// missed lookup.
+    #[inline]
+    fn opening_override_for(&self, ingress_zone: u16) -> Option<u64> {
+        if self.opening_overrides.is_empty() {
+            return None;
+        }
+        self.opening_overrides.get(&ingress_zone).copied()
     }
 
     /// #2134: drive the per-IP session-limit OFF-gate from the worker's
@@ -1020,6 +1062,9 @@ impl SessionTable {
         }
 
         let epoch = self.next_epoch();
+        // #3527: resolve the per-zone half-open override before borrowing the
+        // record mutably (the timeout selection below cannot re-borrow self).
+        let opening_override_ns = self.opening_override_for(metadata.ingress_zone);
         {
             let record = self
                 .entries
@@ -1070,6 +1115,10 @@ impl SessionTable {
                     record.entry.established,
                     &self.timeouts,
                     metadata.inactivity_timeout_ns,
+                    // #3527: opening-window override for an OPENING refresh
+                    // (a SYN retransmit on a still-half-open session). Ignored
+                    // once `established`.
+                    opening_override_ns,
                 )
             };
             // wheel_tick deliberately preserved (parity with restore_entry).
@@ -1660,12 +1709,22 @@ fn remove_owner_rg_index_entry(
 /// idle window. The per-app override and the established timeout apply only
 /// once the session is established. `established` is ignored for non-TCP
 /// protocols and for the closing branch.
+///
+/// #3527: `opening_override_ns` is the ingress zone's `syn-flood timeout`
+/// mapped to the half-open window (ns), or `None` for the global
+/// `tcp_opening_ns`. When `Some`, it replaces the OPENING-branch window ONLY
+/// (it is the half-completed-connection queue window, not an established idle
+/// timeout — it never touches the established / closing / RST branches). A
+/// half-open session in a zone with `syn-flood timeout N` therefore reaps `N`
+/// seconds after install instead of the 20 s default, so a flood that stops is
+/// forgotten on the operator's window. `None` is byte-identical to pre-#3527.
 fn session_timeout_ns(
     protocol: u8,
     tcp_flags: u8,
     established: bool,
     timeouts: &SessionTimeouts,
     app_override_ns: Option<u64>,
+    opening_override_ns: Option<u64>,
 ) -> u64 {
     match protocol {
         PROTO_TCP => {
@@ -1683,8 +1742,10 @@ fn session_timeout_ns(
                 // #3152: handshake-incomplete (OPENING / half-open) — the
                 // short opening window. The per-app override does NOT apply
                 // here (it is the established-session idle timeout); a
-                // half-open session reaps fast regardless.
-                timeouts.tcp_opening_ns
+                // half-open session reaps fast regardless. #3527: a per-zone
+                // `syn-flood timeout` overrides the global opening window for
+                // this zone's half-opens.
+                opening_override_ns.unwrap_or(timeouts.tcp_opening_ns)
             } else {
                 app_override_ns.unwrap_or(timeouts.tcp_established_ns)
             }

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -194,41 +194,92 @@ fn session_timeout_ns_honors_app_override() {
     let app = 30_000_000_000u64; // 30 s
 
     // ESTABLISHED TCP (ACK, not closing): override wins; None -> global.
-    assert_eq!(session_timeout_ns(PROTO_TCP, 0x10, true, &to, Some(app)), app);
+    // #3527: the opening override (6th arg) never touches the established branch.
+    assert_eq!(session_timeout_ns(PROTO_TCP, 0x10, true, &to, Some(app), None), app);
     assert_eq!(
-        session_timeout_ns(PROTO_TCP, 0x10, true, &to, None),
+        session_timeout_ns(PROTO_TCP, 0x10, true, &to, None, None),
         DEFAULT_TCP_SESSION_TIMEOUT_NS
     );
     // #3152: OPENING TCP (handshake incomplete): the short opening window,
     // regardless of any per-app override (which is the established idle value).
     assert_eq!(
-        session_timeout_ns(PROTO_TCP, crate::tcp_flags::TCP_SYN, false, &to, Some(app)),
+        session_timeout_ns(PROTO_TCP, crate::tcp_flags::TCP_SYN, false, &to, Some(app), None),
         DEFAULT_TCP_OPENING_TIMEOUT_NS
     );
     assert_eq!(
-        session_timeout_ns(PROTO_TCP, crate::tcp_flags::TCP_SYN, false, &to, None),
+        session_timeout_ns(PROTO_TCP, crate::tcp_flags::TCP_SYN, false, &to, None, None),
         DEFAULT_TCP_OPENING_TIMEOUT_NS
     );
     // UDP / ICMP: override wins; None -> global. `established` is ignored.
-    assert_eq!(session_timeout_ns(PROTO_UDP, 0, true, &to, Some(app)), app);
+    assert_eq!(session_timeout_ns(PROTO_UDP, 0, true, &to, Some(app), None), app);
     assert_eq!(
-        session_timeout_ns(PROTO_UDP, 0, true, &to, None),
+        session_timeout_ns(PROTO_UDP, 0, true, &to, None, None),
         DEFAULT_UDP_SESSION_TIMEOUT_NS
     );
-    assert_eq!(session_timeout_ns(PROTO_ICMP, 0, true, &to, Some(app)), app);
+    assert_eq!(session_timeout_ns(PROTO_ICMP, 0, true, &to, Some(app), None), app);
     assert_eq!(
-        session_timeout_ns(PROTO_ICMP, 0, true, &to, None),
+        session_timeout_ns(PROTO_ICMP, 0, true, &to, None, None),
         DEFAULT_ICMP_SESSION_TIMEOUT_NS
     );
     // Closing/RST TCP: the override never extends the short reap window
     // (and the closing branch is consulted before the OPENING branch).
     assert_eq!(
-        session_timeout_ns(PROTO_TCP, TCP_RST, false, &to, Some(app)),
+        session_timeout_ns(PROTO_TCP, TCP_RST, false, &to, Some(app), None),
         TCP_RST_TIMEOUT_NS
     );
     assert_eq!(
-        session_timeout_ns(PROTO_TCP, TCP_FIN, false, &to, Some(app)),
+        session_timeout_ns(PROTO_TCP, TCP_FIN, false, &to, Some(app), None),
         TCP_CLOSING_TIMEOUT_NS
+    );
+}
+
+/// #3527 unit: `session_timeout_ns` applies the per-zone half-open override
+/// ONLY on the OPENING branch. An established / closing / RST flow ignores it;
+/// a half-open (bare-SYN) flow reaps on the override, replacing the global
+/// `tcp_opening_ns`. `None` is byte-identical to pre-#3527.
+#[test]
+fn session_timeout_ns_honors_opening_override() {
+    let to = SessionTimeouts::default();
+    let zone_opening = 5_000_000_000u64; // 5 s syn-flood timeout
+    let app = 30_000_000_000u64; // 30 s established idle override
+
+    // OPENING TCP (bare SYN): the per-zone override replaces the 20 s default.
+    assert_eq!(
+        session_timeout_ns(PROTO_TCP, crate::tcp_flags::TCP_SYN, false, &to, None, Some(zone_opening)),
+        zone_opening,
+        "an OPENING half-open session must reap on the per-zone syn-flood timeout"
+    );
+    // The app (established) override does NOT leak into the opening window —
+    // the zone opening override still wins there.
+    assert_eq!(
+        session_timeout_ns(
+            PROTO_TCP,
+            crate::tcp_flags::TCP_SYN,
+            false,
+            &to,
+            Some(app),
+            Some(zone_opening),
+        ),
+        zone_opening
+    );
+    // None -> the global opening window (pre-#3527 behavior).
+    assert_eq!(
+        session_timeout_ns(PROTO_TCP, crate::tcp_flags::TCP_SYN, false, &to, None, None),
+        DEFAULT_TCP_OPENING_TIMEOUT_NS
+    );
+    // ESTABLISHED: the opening override must NOT touch the established window.
+    assert_eq!(
+        session_timeout_ns(PROTO_TCP, 0x10, true, &to, None, Some(zone_opening)),
+        DEFAULT_TCP_SESSION_TIMEOUT_NS
+    );
+    // Closing / RST: the opening override must NOT extend the short reap window.
+    assert_eq!(
+        session_timeout_ns(PROTO_TCP, TCP_FIN, false, &to, None, Some(zone_opening)),
+        TCP_CLOSING_TIMEOUT_NS
+    );
+    assert_eq!(
+        session_timeout_ns(PROTO_TCP, TCP_RST, false, &to, None, Some(zone_opening)),
+        TCP_RST_TIMEOUT_NS
     );
 }
 
@@ -1296,6 +1347,124 @@ fn half_open_session_reaps_at_opening_timeout() {
         table2.expire_stale_entries(advance).is_empty(),
         "an established session must survive past the short opening window on the \
          established timeout"
+    );
+}
+
+/// `metadata()` for a specific ingress zone id — used by the #3527 per-zone
+/// half-open override tests.
+fn metadata_with_zone(zone: u16) -> SessionMetadata {
+    SessionMetadata {
+        ingress_zone: zone,
+        ..metadata()
+    }
+}
+
+/// #3527 FAIL-ON-REVERT: a bare-SYN (half-open) session in a zone with a
+/// configured `syn-flood timeout` must reap on that per-zone window, not the
+/// 20 s global default. The override (5 s) is shorter than the global opening
+/// window, so the half-open reaps by 6 s while a control session in an
+/// un-screened zone (global 20 s window) survives. Revert the enforcement
+/// (`session_timeout_ns` ignores the override, or `set_opening_overrides`
+/// never reaches the install) and the override session inherits the 20 s
+/// default, surviving at 6 s — the `expired.len() == 1` assert goes RED.
+#[test]
+fn per_zone_syn_flood_timeout_reaps_half_open_on_override() {
+    const SCREENED_ZONE: u16 = 7;
+    let override_ns = 5 * WHEEL_TICK_NS; // 5 s syn-flood timeout
+    let install_ns = 1_000_000_000u64;
+    // Past the 5 s per-zone override, far short of the 20 s global default.
+    let advance = install_ns + 6 * WHEEL_TICK_NS;
+
+    let mut overrides = rustc_hash::FxHashMap::default();
+    overrides.insert(SCREENED_ZONE, override_ns);
+
+    // --- screened zone: install stamps the per-zone override at create time ---
+    let mut table = SessionTable::new();
+    table.set_opening_overrides(overrides.clone());
+    let key = key_v4();
+    assert!(table.install_with_protocol(
+        key.clone(),
+        decision(),
+        metadata_with_zone(SCREENED_ZONE),
+        install_ns,
+        PROTO_TCP,
+        TCP_SYN,
+    ));
+    let entry = table.entry_by_key(&key).expect("opening entry");
+    assert!(!entry.established, "a bare-SYN session must start OPENING");
+    assert_eq!(
+        entry.expires_after_ns, override_ns,
+        "a half-open session in a screened zone must reap on the per-zone \
+         syn-flood timeout, not the 20 s global default"
+    );
+    assert_ne!(
+        entry.expires_after_ns, DEFAULT_TCP_OPENING_TIMEOUT_NS,
+        "the per-zone override must replace the global opening window"
+    );
+    table.last_gc_ns = advance - SESSION_GC_INTERVAL_NS;
+    let expired = table.expire_stale_entries(advance);
+    assert_eq!(
+        expired.len(),
+        1,
+        "the half-open session must reap at the 5 s per-zone window by 6 s"
+    );
+    assert_eq!(expired[0].key, key);
+
+    // --- control: a half-open in an UNSCREENED zone survives past 6 s on the
+    //     20 s global default (proves the override is per-zone, not global) ---
+    let mut table2 = SessionTable::new();
+    table2.set_opening_overrides(overrides);
+    let key2 = key_v4();
+    assert!(table2.install_with_protocol(
+        key2.clone(),
+        decision(),
+        metadata_with_zone(SCREENED_ZONE + 1), // no override entry for this zone
+        install_ns,
+        PROTO_TCP,
+        TCP_SYN,
+    ));
+    assert_eq!(
+        table2.entry_by_key(&key2).expect("opening").expires_after_ns,
+        DEFAULT_TCP_OPENING_TIMEOUT_NS,
+        "an unscreened zone keeps the global opening window"
+    );
+    table2.last_gc_ns = advance - SESSION_GC_INTERVAL_NS;
+    assert!(
+        table2.expire_stale_entries(advance).is_empty(),
+        "a half-open in an unscreened zone must survive past 6 s on the 20 s default"
+    );
+}
+
+/// #3527: a SYN retransmit on a still-half-open session re-stamps the opening
+/// window from the per-zone override (the refresh path in lookup.rs), not the
+/// global default — so a stalled handshake in a screened zone keeps reaping on
+/// the operator's window across retransmits.
+#[test]
+fn per_zone_syn_flood_timeout_applies_on_opening_refresh() {
+    const SCREENED_ZONE: u16 = 9;
+    let override_ns = 5 * WHEEL_TICK_NS;
+    let now = 1_000_000_000u64;
+    let mut overrides = rustc_hash::FxHashMap::default();
+    overrides.insert(SCREENED_ZONE, override_ns);
+
+    let mut table = SessionTable::new();
+    table.set_opening_overrides(overrides);
+    let key = key_v4();
+    assert!(table.install_with_protocol(
+        key.clone(),
+        decision(),
+        metadata_with_zone(SCREENED_ZONE),
+        now,
+        PROTO_TCP,
+        TCP_SYN,
+    ));
+    // SYN retransmit (still OPENING, no ACK) — the refresh re-stamps the window.
+    assert!(table.lookup(&key, now + 1_000_000, TCP_SYN).is_some());
+    let entry = table.entry_by_key(&key).expect("still opening");
+    assert!(!entry.established, "a SYN retransmit keeps the session OPENING");
+    assert_eq!(
+        entry.expires_after_ns, override_ns,
+        "an OPENING refresh must re-stamp the per-zone override, not the global default"
     );
 }
 
@@ -2426,6 +2595,9 @@ fn reference_update_session(
             entry.established,
             &table.timeouts,
             entry.metadata.inactivity_timeout_ns,
+            // #3527: mirror update_session — resolve the per-zone half-open
+            // override so the reference parity sweep stays faithful.
+            table.opening_override_for(entry.metadata.ingress_zone),
         )
     };
     let created_ns = entry.created_ns;

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -952,6 +952,7 @@
     "syn_flood_dst_threshold": 0,
     "syn_flood_src_threshold": 0,
     "syn_flood_threshold": 0,
+    "syn_flood_timeout": 0,
     "syn_frag": false,
     "tcp_no_flag": false,
     "teardrop": false,


### PR DESCRIPTION
Closes #3527.

## Summary

`#3315` wired the SYN-flood `source-threshold` / `destination-threshold` /
`alarm-threshold` sub-thresholds across the userspace-dp boundary but
deliberately deferred the fifth leaf, **`timeout`**: in Junos it bounds the
half-completed-connection queue, which in this dataplane maps to the per-zone
**half-open TCP session window** (`SessionTimeouts.tcp_opening_ns`, 20 s
default), a session-layer surface — not the screen-rate substrate. Until now
the leaf parsed and committed cleanly but did nothing, and the compiler emitted
a commit-time "accepted but NOT yet enforced" advisory. This PR enforces it and
removes the advisory.

## Root cause (unenforced leaf)

- `pkg/config/compiler_security.go` parsed `timeout` into
  `SynFloodConfig.Timeout` (line ~1048) but `pkg/dataplane/userspace/screens.go`
  never published it on the wire, and `userspace-dp/src/session/mod.rs`
  `session_timeout_ns` used the **global** `timeouts.tcp_opening_ns` for the
  OPENING (half-open) branch with no per-zone path. So a bare-SYN session reaped
  on the global 20 s window regardless of `syn-flood timeout N`.

## Expiry mechanism (per-zone OPENING-window override)

- **Wire (additive, 2-sided):** `syn_flood_timeout` (seconds) added to the Go
  `ScreenProfileSnapshot` (`omitempty`) and the Rust mirror
  (`#[serde(default)]`). `protocol_wire_v1.json` regenerated (one additive
  `syn_flood_timeout: 0` key) and `wire_invariant_default_specimens` passes.
- **Forwarding builder:** `ForwardingState.session_opening_overrides`
  (zone id → ns) built from each screened zone's timeout, resolved via
  `zone_name_to_id`. Empty in the common case.
- **SessionTable:** new `opening_overrides` + `set_opening_overrides`, pushed
  alongside `set_timeouts` at worker startup **and** on every runtime
  forwarding-snapshot rotation (full replace → removing the leaf reverts the
  zone to the global default).
- **`session_timeout_ns`** gains an `opening_override_ns` arg consulted ONLY on
  the OPENING branch (never established / closing / RST). The install,
  lookup-refresh, and `update_session` sites resolve it from the entry's
  `ingress_zone`.

## HA composition (#3315 plan §11.1)

The override is config-derived and **re-derived per node** from the snapshot —
it never crosses the session-sync wire. A peer-synced session is imported
ESTABLISHED, so its OPENING branch is never taken; the synced-import site passes
`None` explicitly. HA requires identical config on both nodes, so the standby
builds the same map independently.

## Tests / RED-on-revert

- `session_timeout_ns_honors_opening_override` — override applies only on the
  OPENING branch.
- `per_zone_syn_flood_timeout_reaps_half_open_on_override` — a 5 s override
  reaps a half-open by 6 s; an unscreened-zone control survives on the 20 s
  default. Reverting the OPENING-branch enforcement → 20 s default → RED
  (verified: all three override tests fail, `left: 20000000000 / right:
  5000000000`).
- `per_zone_syn_flood_timeout_applies_on_opening_refresh` — a SYN retransmit
  re-stamps the override on the refresh path.
- Go: the #3315 inert-warning test inverted (must NOT warn now); the
  `buildScreenSnapshots` wire test asserts `SYNFloodTimeout` publishes +
  round-trips + decodes 0 from a legacy blob.

Validation: `cargo build` clean; Rust session (147) / forwarding_build /
protocol / screen / wire-invariant green; `go build ./...`, `go test ./pkg/config
./pkg/dataplane/userspace` green; gofmt + go vet clean. Rebased onto current
origin/master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi