### PR TITLE
daemon nftables: distinct hook-input priorities for lo0 + host-inbound base chains (#3364)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24223,3 +24223,34 @@ top.
 - **Timestamp**: 2026-06-30
   - **Action**: #3595 — fixed the release-binary link failure on a modern toolchain (gcc-15 / recent elfutils + zlib). Both libelf.a and libz.a ship a static `crc32` symbol; the userspace-dp helper links -lelf and -lz transitively via the static libbpf/libxdp/xsk_bridge archives, so rust-lld aborts the final link of `xpf-userspace-dp` with "duplicate symbol: crc32". The flag was committed nowhere in the tree (git grep allow-multiple-definition empty) — plain `make build-userspace-dp` / `make cluster-deploy` required RUSTFLAGS=-C link-arg=-Wl,--allow-multiple-definition set out of band (surfaced during the Campaign-8 final integration audit when cluster-deploy failed to link). Fix: carry the workaround in version control at repo-root .cargo/config.toml under [target.x86_64-unknown-linux-gnu] so cargo (invoked from repo-root cwd via --manifest-path, cwd-based config discovery) picks it up. Scoped to the host target: the bpfel-unknown-none userspace-xdp shim (its own userspace-xdp/.cargo/config.toml, pinned toolchain #1864) is a guaranteed no-op (target mismatch). The link-arg takes the first crc32 definition — benign, independent CRC implementations each self-contained. VALIDATION: built `cargo build --manifest-path userspace-dp/Cargo.toml --release` from the worktree repo-root with RUSTFLAGS UNSET (env -u RUSTFLAGS) — linked clean, produced the 7MB binary (rc=0); without the config the same invocation fails with duplicate-crc32 (reproduced as the campaign-audit deploy failure). No code change; no test impact (cargo test relinks identically).
   - **File(s)**: .cargo/config.toml, _Log.md
+- **Timestamp**: 2026-06-30
+  - **Action**: #3364 — gave the two daemon-generated local-delivery nftables
+    base chains DISTINCT hook-input priorities so their inter-chain evaluation
+    order is a deterministic product invariant. Both `inet xpf_lo0`
+    (`buildLo0FilterPayload`) and `inet xpf_hostinbound`
+    (`buildHostInboundFilterPayload`) in pkg/daemon/daemon_nft.go registered
+    `type filter hook input priority 0`. Two base chains on the SAME hook at an
+    IDENTICAL priority have implementation-defined inter-chain order in
+    netfilter, so which chain's reject/log/counter fired for a packet both match
+    was order-dependent and could vary silently across nft/kernel versions (a
+    `drop` stays terminal regardless, so this was never a permit bypass — only an
+    observability/determinism gap, audit codex-review-084 H5). Fix: two named
+    constants `nftLo0FilterPriority = 0` and `nftHostInboundPriority = 10`, both
+    still `hook input`. ORDERING DECISION: lo0 evaluates STRICTLY BEFORE
+    host-inbound (lower priority number). The lo0.0 input filter is the
+    operator's explicit, named, RE-wide control-plane firewall (authoritative
+    accept/reject/discard verdicts), so its operator-authored verdicts take
+    observable precedence; the zone host-inbound-traffic admission is the coarser
+    Junos default-deny backstop governing whatever lo0 did not already terminate
+    — the Junos lo0-filter-then-zone ordering the issue specifies. lo0 stays at
+    the conventional `filter` priority 0; host-inbound moves to 10 (well below the
+    conventional `security`=50 band). RED-on-revert proven: equalizing the
+    constants (host-inbound back to 0) turns BOTH
+    TestNftLocalDeliveryChainsDistinctPriority (parses the priority integer out of
+    each rendered payload, asserts lo0 < host-inbound + matches the constants) and
+    TestNftLocalDeliveryPriorityConstantsOrdered (constant-level guard) RED;
+    restored to green. go test ./pkg/daemon/... green; go build ./pkg/...
+    ./cmd/... green; gofmt + go vet clean on changed files. Doc:
+    pkg/daemon/README.md lo0 + host-inbound bullets document the distinct
+    priorities and the ordering rationale.
+  - **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/nft_chain_priority_test.go, pkg/daemon/README.md, _Log.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -283,6 +283,22 @@ never lock an operator out of a remote box it manages.
   name — appending one is an nft parse error that silently dropped the whole
   filter (#2069). `TestLo0FilterPayloadNftParses` parse-checks the real payload
   with `nft -c -f -` when nft is on PATH.
+  **Distinct hook-input priority (#3364):** `xpf_lo0` registers `type filter
+  hook input priority 0` (`nftLo0FilterPriority`) and `xpf_hostinbound`
+  registers the same hook at `priority 10` (`nftHostInboundPriority`). Two base
+  chains on the SAME hook at an IDENTICAL priority have implementation-defined
+  inter-chain evaluation order, so which chain's reject/log/counter fires for a
+  packet both match would be order-dependent (a `drop` stays terminal regardless,
+  so this was never a permit bypass — only an observability/determinism gap). The
+  spread makes `xpf_lo0` evaluate STRICTLY BEFORE `xpf_hostinbound`: the lo0.0
+  input filter is the operator's explicit, named, RE-wide control-plane firewall
+  (authoritative accept/reject/discard verdicts), so it takes observable
+  precedence over the coarser zone host-inbound default-deny backstop — the Junos
+  lo0-filter-then-zone ordering. `nft_chain_priority_test.go`
+  (`TestNftLocalDeliveryChainsDistinctPriority` /
+  `TestNftLocalDeliveryPriorityConstantsOrdered`) pins
+  `nftLo0FilterPriority < nftHostInboundPriority` and goes RED if the two are
+  equalized.
   **Fail-closed (#3392, mirroring host-inbound #3333):** `applyLo0Filter`
   RETURNS the apply/teardown error instead of swallowing it at WARN, and
   `applyConfigLocked` joins it (`lo0Err`) into the commit result alongside
@@ -394,7 +410,11 @@ never lock an operator out of a remote box it manages.
   to the kernel by the XDP shim before reaching userspace-dp, so
   `daemon_nft.go:applyHostInboundFilter` builds an `inet xpf_hostinbound`
   table (same atomic flush idiom as lo0) via `buildHostInboundFilterPayload`,
-  consuming `userspace.BuildZoneHostInboundViews(cfg)`. Per
+  consuming `userspace.BuildZoneHostInboundViews(cfg)`. The chain registers
+  `type filter hook input priority 10` (`nftHostInboundPriority`) — DISTINCT from
+  the `xpf_lo0` chain's `priority 0` so this host-inbound backstop evaluates
+  AFTER the operator's explicit lo0 input filter rather than at an
+  implementation-defined order relative to it (#3364, see the lo0 bullet). Per
   host-inbound-CONFIGURED zone it accepts the listed system-services/protocols
   to that zone's addresses and DROPs the rest; the userspace-dp LocalDelivery
   check (`forwarding/host_inbound.rs`) is the secondary path for the XSK-reaching

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -52,6 +52,40 @@ var nftDeleteTable = func(family, name string) ([]byte, error) {
 	return nftApplyPayload(payload)
 }
 
+// Base-chain hook-input priorities for the two daemon-generated local-delivery
+// nftables tables (#3364). Both register `type filter hook input`, but at
+// DISTINCT priorities so their inter-chain evaluation order is a deterministic
+// product invariant rather than implementation-defined. With two base chains at
+// an IDENTICAL hook/priority, netfilter's order between them is unspecified, so
+// which chain's reject/log/counter fires for a packet both would act on could
+// vary silently across nft/kernel versions (a `drop` stays terminal regardless,
+// so this was never a permit bypass — only an observability/determinism gap).
+//
+// Ordering: xpf_lo0 evaluates BEFORE xpf_hostinbound (lo0 has the strictly lower
+// priority number). The lo0.0 input filter is the operator's explicit, named,
+// RE-wide control-plane firewall — the authoritative statement of what is
+// permitted to the box, written with explicit accept/reject/discard verdicts.
+// The zone host-inbound-traffic admission is the coarser Junos default-deny
+// backstop. Running the explicit lo0 filter first lets its operator-authored
+// verdicts (and their reject messages / per-term effects) take observable
+// precedence, with host-inbound governing whatever lo0 did not already
+// terminate — the Junos lo0-filter-then-zone ordering. nftApplyPriorityInvariant
+// (nft_chain_priority_test.go) pins nftLo0FilterPriority < nftHostInboundPriority
+// so the spread cannot silently regress back to a shared priority.
+const (
+	// nftLo0FilterPriority is the `hook input` priority of the xpf_lo0 loopback
+	// input-filter base chain. 0 is the conventional `filter` priority (the lo0
+	// chain IS the operator's firewall filter); it is STRICTLY LESS THAN
+	// nftHostInboundPriority so lo0 evaluates first.
+	nftLo0FilterPriority = 0
+	// nftHostInboundPriority is the `hook input` priority of the xpf_hostinbound
+	// base chain. It is STRICTLY GREATER THAN nftLo0FilterPriority so the zone
+	// host-inbound default-deny backstop runs AFTER the lo0 input filter, and is
+	// kept well below the conventional `security` (50) / `srcnat` (100)
+	// priorities so it stays within the input-filter band.
+	nftHostInboundPriority = 10
+)
+
 // applyLo0Filter applies loopback filter rules for host-bound traffic.
 // Implements "interfaces lo0 unit 0 family inet filter input <name>" by
 // generating nftables rules from the named firewall filter.
@@ -114,7 +148,8 @@ func buildLo0FilterPayload(cfg *config.Config, filterV4, filterV6 string) string
 	rules = append(rules, "flush table inet xpf_lo0")
 	rules = append(rules, "table inet xpf_lo0 {")
 	rules = append(rules, "  chain input {")
-	rules = append(rules, "    type filter hook input priority 0; policy accept;")
+	// #3364: explicit distinct priority so lo0 evaluates BEFORE xpf_hostinbound.
+	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", nftLo0FilterPriority))
 
 	prefixLists := cfg.PolicyOptions.PrefixLists
 	if filterV4 != "" {
@@ -230,7 +265,9 @@ func hostInboundHasEnforceableView(views []dpuserspace.ZoneHostInboundView) bool
 // rebuild — every commit and every DHCP/DHCPv6 address change that re-renders
 // the table. Prometheus rate() handles the reset; documented on the metric.)
 //
-// Layout of `chain input` (type filter hook input priority 0; policy accept):
+// Layout of `chain input` (type filter hook input priority 10; policy accept —
+// distinct from the xpf_lo0 chain's priority 0 so this host-inbound backstop
+// evaluates AFTER the lo0 input filter, #3364):
 //  1. ct state established,related accept   — return/ongoing host traffic.
 //  2. meta l4proto { 50, 51 } accept — raw ESP/AH exemption for host-terminated
 //     IPsec (mirrors the userspace stage_ipsec_passthrough_check); the kernel
@@ -305,7 +342,8 @@ func buildHostInboundFilterPayload(views []dpuserspace.ZoneHostInboundView) stri
 		rules = append(rules, "  }")
 	}
 	rules = append(rules, "  chain input {")
-	rules = append(rules, "    type filter hook input priority 0; policy accept;")
+	// #3364: explicit distinct priority so host-inbound evaluates AFTER xpf_lo0.
+	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", nftHostInboundPriority))
 	rules = append(rules, "    ct state established,related accept")
 	// Raw ESP (50) / AH (51) are exempt from host-inbound enforcement so the
 	// kernel XFRM stack can decrypt host-terminated IPsec — mirroring the

--- a/pkg/daemon/nft_chain_priority_test.go
+++ b/pkg/daemon/nft_chain_priority_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// hookInputPriorityRe extracts the integer priority from a base-chain
+// definition line of the form `type filter hook input priority <N>; ...`.
+var hookInputPriorityRe = regexp.MustCompile(`type filter hook input priority (-?\d+);`)
+
+// nftHookInputPriority parses the single `type filter hook input priority <N>`
+// line out of an nft `-f -` payload and returns N. It fails the test if the
+// chain is not a `hook input` filter base chain or the priority is missing —
+// both are part of the #3364 invariant (the chains must stay base chains on the
+// SAME hook, differing only in priority).
+func nftHookInputPriority(t *testing.T, label, payload string) int {
+	t.Helper()
+	m := hookInputPriorityRe.FindStringSubmatch(payload)
+	if m == nil {
+		t.Fatalf("%s payload has no `type filter hook input priority <N>` base-chain line:\n%s", label, payload)
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("%s payload priority %q is not an integer: %v", label, m[1], err)
+	}
+	return n
+}
+
+// TestNftLocalDeliveryChainsDistinctPriority is the #3364 RED-on-revert proof:
+// the two daemon-generated local-delivery base chains (inet xpf_lo0 and inet
+// xpf_hostinbound) both register at `type filter hook input`, so they MUST carry
+// DISTINCT priorities or netfilter's inter-chain evaluation order between them is
+// implementation-defined (which chain's reject/log/counter fires for a packet
+// both match becomes order-dependent and can vary silently across nft/kernel
+// versions). The ordering is also load-bearing: the operator's explicit lo0
+// input filter (xpf_lo0) must evaluate BEFORE the zone host-inbound default-deny
+// backstop (xpf_hostinbound) — the Junos lo0-filter-then-zone semantics — so
+// lo0's priority must be STRICTLY LESS THAN host-inbound's.
+//
+// This goes RED the instant the two priorities are made equal again (the
+// strictly-less-than assertion fails), or if either chain is moved off
+// `hook input` (the parse fails), restoring the #3364 invariant as a test.
+func TestNftLocalDeliveryChainsDistinctPriority(t *testing.T) {
+	// lo0 payload: the chain header is emitted unconditionally, so a config with
+	// no resolvable filter still renders the base-chain line.
+	lo0Payload := buildLo0FilterPayload(&config.Config{}, "", "")
+	lo0Pri := nftHookInputPriority(t, "lo0", lo0Payload)
+
+	// host-inbound payload: likewise emits the base-chain header regardless of
+	// views. Use a representative enforced config so the rendered table is the
+	// real commit-time shape.
+	views := buildAndCheckViews(t, hostInboundTestConfig())
+	hiPayload := buildHostInboundFilterPayload(views)
+	hiPri := nftHookInputPriority(t, "host-inbound", hiPayload)
+
+	if lo0Pri == hiPri {
+		t.Fatalf("xpf_lo0 and xpf_hostinbound share hook-input priority %d — #3364 "+
+			"requires DISTINCT priorities so inter-chain evaluation order is "+
+			"deterministic (equal priority => implementation-defined ordering)", lo0Pri)
+	}
+	if lo0Pri >= hiPri {
+		t.Fatalf("xpf_lo0 priority %d must be STRICTLY LESS THAN xpf_hostinbound "+
+			"priority %d (#3364): the explicit lo0 input filter must evaluate "+
+			"BEFORE the zone host-inbound default-deny backstop "+
+			"(Junos lo0-filter-then-zone ordering)", lo0Pri, hiPri)
+	}
+
+	// The rendered payload priorities must match the named constants that
+	// document the invariant, so a future edit cannot silently desync the code
+	// from the constants.
+	if lo0Pri != nftLo0FilterPriority {
+		t.Errorf("lo0 payload priority %d != nftLo0FilterPriority %d", lo0Pri, nftLo0FilterPriority)
+	}
+	if hiPri != nftHostInboundPriority {
+		t.Errorf("host-inbound payload priority %d != nftHostInboundPriority %d", hiPri, nftHostInboundPriority)
+	}
+}
+
+// TestNftLocalDeliveryPriorityConstantsOrdered guards the invariant at the
+// constant level (independent of payload rendering): nftLo0FilterPriority must be
+// strictly less than nftHostInboundPriority (#3364). Equalizing the two
+// constants — the simplest way to reintroduce the bug — turns this RED directly.
+func TestNftLocalDeliveryPriorityConstantsOrdered(t *testing.T) {
+	if nftLo0FilterPriority >= nftHostInboundPriority {
+		t.Fatalf("nftLo0FilterPriority (%d) must be < nftHostInboundPriority (%d): "+
+			"the lo0 input filter must evaluate before the host-inbound backstop "+
+			"and the two base chains must carry distinct hook-input priorities (#3364)",
+			nftLo0FilterPriority, nftHostInboundPriority)
+	}
+}


### PR DESCRIPTION
## Summary

The two daemon-generated local-delivery nftables base chains both registered at `type filter hook input priority 0`:

- `inet xpf_lo0` (`buildLo0FilterPayload`) — the Junos `interfaces lo0 unit 0 family inet[6] filter input` loopback filter
- `inet xpf_hostinbound` (`buildHostInboundFilterPayload`) — the zone `host-inbound-traffic` admission backstop

Two base chains on the **same hook** at an **identical priority** have implementation-defined inter-chain evaluation order in netfilter. A `drop` in either chain is terminal regardless of order, so this was never a permit bypass — but when both chains match the same local-delivery packet, **which chain's reject / log / counter fires (and is observed) was order-dependent** and not guaranteed across nft / kernel versions. Operator-visible reject behavior and the #3361 host-inbound deny counters could vary silently (audit codex-review-084 H5).

## Fix

Assign explicit, distinct priorities via two named constants (both still `hook input`):

| Chain | Constant | Priority |
|-------|----------|----------|
| `inet xpf_lo0` | `nftLo0FilterPriority` | `0` |
| `inet xpf_hostinbound` | `nftHostInboundPriority` | `10` |

`0 < 10` makes the ordering a deterministic product invariant.

### Ordering decision: lo0 evaluates BEFORE host-inbound

`xpf_lo0` gets the strictly-lower priority number, so it evaluates first. The lo0.0 input filter is the operator's explicit, named, RE-wide control-plane firewall — the authoritative statement of what is permitted to the box, written with explicit `accept`/`reject`/`discard` verdicts. The zone `host-inbound-traffic` admission is the coarser **Junos default-deny backstop**. Running the operator's explicit lo0 filter first lets its verdicts (and their reject messages / per-term effects) take observable precedence, with host-inbound governing whatever lo0 did not already terminate — the Junos **lo0-filter-then-zone** ordering called out in the issue.

lo0 keeps the conventional `filter` priority 0; host-inbound moves to 10, well below the conventional `security` (50) / `srcnat` (100) priorities so it stays within the input-filter band.

## Tests (RED-on-revert)

`pkg/daemon/nft_chain_priority_test.go`:

- `TestNftLocalDeliveryChainsDistinctPriority` — parses the priority integer out of each rendered payload and asserts the chains are distinct, `lo0 < host-inbound`, both on `hook input`, and that the rendered values match the named constants.
- `TestNftLocalDeliveryPriorityConstantsOrdered` — guards the invariant at the constant level.

RED-on-revert proven by temporarily setting `nftHostInboundPriority = 0` (re-equalizing the chains): **both tests fail** with the distinct-priority / strictly-less-than messages, then pass once restored.

## Validation

- `go test ./pkg/daemon/...` — green
- `go build ./pkg/... ./cmd/...` — green
- `gofmt -l` + `go vet` — clean on changed files
- Docs: `pkg/daemon/README.md` lo0 + host-inbound bullets updated with the distinct priorities and ordering rationale

Closes #3364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi