### PR TITLE
daemon lo0 nft: mirror then-modifiers + faithful reject, warn on unrepresentable (#3445)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24254,3 +24254,42 @@ top.
     pkg/daemon/README.md lo0 + host-inbound bullets document the distinct
     priorities and the ordering rationale.
   - **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/nft_chain_priority_test.go, pkg/daemon/README.md, _Log.md
+
+- **Timestamp**: 2026-06-30
+  - **Action**: #3445 — lo0 input-filter `then` modifier nft-mirror support
+    policy + faithful reject. `nftRuleFromTerm` (now `nftRulesFromTerm`, returns
+    `[]string`) emitted only match predicates + a terminal verdict, reading only
+    `term.Action`; the non-terminating modifiers `Log`/`Count`/`Policer`/
+    `DSCPRewrite`/`ForwardingClass`/`LossPriority` were NEVER read, so every
+    modifier the compiler parses and userspace honors was silently dropped from
+    the kernel lo0 mirror — the PRIMARY enforcement for host-bound traffic (XDP
+    shim shunts it to the kernel). `reject` was lowered as a bare nft `reject`
+    (ICMP port-unreachable for ALL protocols incl. TCP), diverging from the
+    userspace reply synthesis. EXPLICIT per-modifier policy: HONOR what nft can
+    on a `hook input` chain — `then log`/`then syslog` -> nft `log prefix`,
+    `then count <name>` -> a NAMED nft counter (declared once in the table body;
+    `nftables.Lo0CounterName` sanitizes+prefixes to a bare-safe `xpflo0_*`
+    identifier per #3578 unquoted-decl/quoted-ref). WARN (not silently drop) on
+    what nft cannot faithfully honor on the host-inbound mirror — policer / dscp
+    rewrite / forwarding-class via the new `validateLo0FilterKernelMirror
+    Warnings` (commit-time, scoped to the lo0 input filter only, names
+    family/filter/term/modifier; loss-priority already covered globally by the
+    #2507 warning). REJECT (#3445 H10): faithful 2-rule lowering mirroring
+    userspace `poll_descriptor/reject_reply.rs` — `meta l4proto 6 reject with
+    tcp reset` then family-agnostic `reject with icmpx type admin-prohibited`
+    (icmpx selects ICMP/ICMPv6 from the packet). Fall-through modifier-only terms
+    now emit a NON-TERMINATING modifier rule (honored mods, no verdict) so
+    log/count fire while later terms stay reachable (#3427 reachability
+    preserved). Switched the lo0 payload from the `flush table` idiom to the
+    atomic `add table; delete table; table {...}` idiom (shared with
+    host-inbound) because `flush` does not delete named counter objects (would
+    collide on recommit). Validated nft syntax of every new construct with the
+    repo's nftables v1.1.6 .deb (`nft -c -f -`: parses; only the expected
+    no-CAP_NET_ADMIN netlink error). RED-on-revert proven for log, count,
+    faithful reject, and the commit warning (each reverted -> the matching test
+    goes RED, restored). go test ./pkg/daemon/... ./pkg/config/...
+    ./pkg/nftables/... green; go build ./pkg/... ./cmd/... green; gofmt + go vet
+    clean on changed files. Docs: pkg/daemon/README.md (new modifier-policy
+    bullet + updated #3427 fall-through bullet), docs/config-schema.md (#3445
+    subsection).
+  - **File(s)**: pkg/daemon/daemon_nft.go, pkg/daemon/lo0_filter_test.go, pkg/config/compiler_validate_warn.go, pkg/config/compiler_lo0_mirror_modifiers_3445_test.go, pkg/nftables/lo0_counters.go, pkg/daemon/README.md, docs/config-schema.md, _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2213,6 +2213,45 @@ reject still rejects, `TestFilterAction_Unknown_LenientWarns`,
 (`unknown_nonempty_action_fails_closed_discard`,
 `empty_action_falls_through_to_accept`).
 
+### #3445 — lo0 input-filter `then` modifiers: nft-mirror support policy (commit warning)
+
+The lo0.0 input filter (`interfaces lo0 unit 0 family inet[6] filter input
+<name>`) is mirrored onto a kernel nftables chain (`inet xpf_lo0`,
+`pkg/daemon/daemon_nft.go`) because the XDP shim shunts ordinary host-bound
+traffic to the Linux kernel before it reaches userspace-dp — so that chain is the
+PRIMARY enforcement of the lo0 filter for host traffic. Every non-terminating
+`then` modifier now has an explicit policy rather than being silently dropped
+from the mirror (the pre-fix action switch read only `term.Action`):
+
+- **Honored on the kernel mirror:** `then log` / `then syslog` → an nft `log`
+  statement; `then count <name>` → a NAMED nft counter. These commit with no
+  warning.
+- **Warned (cannot be faithfully honored on a `hook input` chain):**
+  `then policer` (Junos bandwidth+burst token bucket with a configurable
+  then-action; nft `limit` cannot reproduce it), `then dscp` (traffic-class
+  rewrite) and `then forwarding-class` (egress CoS selection is meaningless for
+  locally-delivered traffic). **`validateLo0FilterKernelMirrorWarnings`**
+  (`compiler_validate_warn.go`, wired into `ValidateConfig`) emits a commit
+  WARNING naming the family / filter / term / modifier so the operator knows the
+  kernel host-bound path will not enforce them (userspace remains authoritative
+  for whatever lo0-filtered traffic actually reaches the XSK). It is WARN-only —
+  these are valid Junos and a hard reject would brick a boot on a
+  previously-committed config — and SCOPED to the lo0 input filter (the same
+  modifier on an interface filter is userspace-enforced and not warned).
+  `then loss-priority` is already reported globally inert by
+  `validateFilterLossPriorityWarnings` (#2507), which subsumes the mirror gap.
+- **`reject`** is lowered to a faithful TCP-RST + ICMP/ICMPv6
+  administratively-prohibited pair mirroring the userspace reject-reply synthesis
+  (see `pkg/daemon/README.md` "lo0 input filter").
+
+Regression coverage: `pkg/config/compiler_lo0_mirror_modifiers_3445_test.go`
+(warns per modifier, commit-succeeds, scoped-no-false-positive,
+honored-modifiers-no-warn) and, on the nft-generation side,
+`pkg/daemon/lo0_filter_test.go` (`TestNftRuleFromTermLogMirror`,
+`TestNftRuleFromTermCountMirror`, the faithful-reject pair, shared-counter
+single-declaration). Like the other firewall-filter gates these are
+compiler/daemon-side, not typed `setSchema` leaves.
+
 ### #2545 — firewall-filter `from protocol`/`dscp`/`icmp-type`/`icmp-code` are multi-value (match-ANY)
 
 `protocol`, `dscp`/`traffic-class`, `icmp-type`, and `icmp-code` are all

--- a/pkg/config/compiler_lo0_mirror_modifiers_3445_test.go
+++ b/pkg/config/compiler_lo0_mirror_modifiers_3445_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLo0FilterKernelMirrorWarns proves #3445: a firewall filter bound to lo0
+// input that carries a `then` modifier the kernel nftables lo0 mirror cannot
+// faithfully honor (policer / dscp-rewrite / forwarding-class) commits
+// successfully but emits a commit WARNING naming the family/filter/term/modifier
+// — it is NOT silently dropped from the kernel mirror (the M04/M05/M06 gap).
+//
+// Fail-on-revert: removing the validateLo0FilterKernelMirrorWarnings call (or any
+// of its per-modifier appends) removes the warning(s) and this test fails.
+func TestLo0FilterKernelMirrorWarns(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set firewall policer p1 if-exceeding bandwidth-limit 1m",
+		"set firewall policer p1 if-exceeding burst-size-limit 15k",
+		"set firewall policer p1 then discard",
+		"set firewall family inet filter lo0in term rate from protocol tcp",
+		"set firewall family inet filter lo0in term rate then policer p1",
+		"set firewall family inet filter lo0in term mark from protocol udp",
+		"set firewall family inet filter lo0in term mark then dscp ef",
+		"set firewall family inet filter lo0in term mark then accept",
+		"set firewall family inet filter lo0in term fc from protocol tcp",
+		"set firewall family inet filter lo0in term fc then forwarding-class my-fc",
+		"set firewall family inet filter lo0in term fc then accept",
+		"set interfaces lo0 unit 0 family inet filter input lo0in",
+	})
+
+	warnings := ValidateConfig(cfg)
+
+	// modifier substring -> the term carrying it.
+	want := map[string]string{
+		"policer":          "rate",
+		"dscp":             "mark",
+		"forwarding-class": "fc",
+	}
+	for mod, term := range want {
+		found := false
+		for _, w := range warnings {
+			if strings.Contains(w, "kernel lo0 input mirror") &&
+				strings.Contains(w, "\""+term+"\"") && strings.Contains(w, mod) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected lo0 kernel-mirror warning for modifier %q on term %q, got: %v", mod, term, warnings)
+		}
+	}
+}
+
+// TestLo0FilterKernelMirrorCommitSucceeds confirms the warning never fail-closes
+// the commit: these modifiers are valid Junos and must be accepted (warn, never
+// reject) so a previously-committed config is never bricked.
+func TestLo0FilterKernelMirrorCommitSucceeds(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, line := range []string{
+		"set system dataplane-type userspace",
+		"set firewall policer p1 if-exceeding bandwidth-limit 1m",
+		"set firewall policer p1 if-exceeding burst-size-limit 15k",
+		"set firewall policer p1 then discard",
+		"set firewall family inet filter lo0in term rate from protocol tcp",
+		"set firewall family inet filter lo0in term rate then policer p1",
+		"set interfaces lo0 unit 0 family inet filter input lo0in",
+	} {
+		path, err := ParseSetCommand(line)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", line, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", line, err)
+		}
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("lo0 filter with a policer must commit (warn, not reject): %v", err)
+	}
+	if cfg.System.Lo0FilterInputV4 != "lo0in" {
+		t.Fatalf("expected lo0 input v4 filter binding, got %q", cfg.System.Lo0FilterInputV4)
+	}
+}
+
+// TestLo0FilterKernelMirrorNoFalsePositive confirms the warning is SCOPED to the
+// lo0 input filter: the same modifiers on a library filter NOT bound to lo0 input
+// (userspace remains the enforcement path there) emit no kernel-mirror warning.
+func TestLo0FilterKernelMirrorNoFalsePositive(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set firewall policer p1 if-exceeding bandwidth-limit 1m",
+		"set firewall policer p1 if-exceeding burst-size-limit 15k",
+		"set firewall policer p1 then discard",
+		"set firewall family inet filter notlo0 term rate from protocol tcp",
+		"set firewall family inet filter notlo0 term rate then policer p1",
+	})
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "kernel lo0 input mirror") {
+			t.Fatalf("unexpected lo0 kernel-mirror warning for a filter not bound to lo0 input: %q", w)
+		}
+	}
+}
+
+// TestLo0FilterKernelMirrorHonoredModifiersNoWarn confirms the modifiers the
+// kernel mirror DOES honor (then count / then log) do not produce a
+// cannot-honor warning when present on an lo0 input filter.
+func TestLo0FilterKernelMirrorHonoredModifiersNoWarn(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set firewall family inet filter lo0in term t from protocol tcp",
+		"set firewall family inet filter lo0in term t then count c1",
+		"set firewall family inet filter lo0in term t then log",
+		"set firewall family inet filter lo0in term t then accept",
+		"set interfaces lo0 unit 0 family inet filter input lo0in",
+	})
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "kernel lo0 input mirror") {
+			t.Fatalf("count/log are honored on the kernel mirror and must not warn: %q", w)
+		}
+	}
+}

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -817,6 +817,15 @@ func ValidateConfig(cfg *Config) []string {
 	// silently accept config the dataplane cannot enforce.
 	warnings = append(warnings, validateFilterLossPriorityWarnings(cfg)...)
 
+	// #3445: an lo0 INPUT filter is mirrored onto a kernel nftables chain
+	// (the PRIMARY enforcement for host-bound traffic the XDP shim shunts to the
+	// kernel). That chain honors match predicates + `then log` + `then count`
+	// but cannot faithfully honor the CoS / rate-control `then` modifiers
+	// (policer, dscp-rewrite, forwarding-class). Warn — naming each term+modifier
+	// — rather than silently dropping them from the kernel mirror. loss-priority
+	// is already covered by validateFilterLossPriorityWarnings above.
+	warnings = append(warnings, validateLo0FilterKernelMirrorWarnings(cfg)...)
+
 	// #3295: a firewall filter attached to an interface/lo0 input/output hook
 	// with no terminal catch-all term relies on xpf's implicit-accept of
 	// unmatched traffic — the deliberate divergence from Junos's implicit final
@@ -965,6 +974,78 @@ func validateFilterLossPriorityWarnings(cfg *Config) []string {
 	}
 	emit("inet", cfg.Firewall.FiltersInet)
 	emit("inet6", cfg.Firewall.FiltersInet6)
+	return warnings
+}
+
+// validateLo0FilterKernelMirrorWarnings emits a WARN-only commit-time message
+// for each term in an lo0 INPUT filter (`interfaces lo0 unit 0 family inet[6]
+// filter input <name>`) that carries a `then` modifier the kernel nftables lo0
+// mirror cannot faithfully honor (#3445).
+//
+// Ordinary host-bound traffic to a firewall interface IP / VRRP VIP is shunted
+// to the Linux kernel by the XDP shim before it reaches userspace-dp, so the
+// `inet xpf_lo0` nftables chain (pkg/daemon/daemon_nft.go) is the PRIMARY
+// enforcement of the lo0 input filter for that traffic. That chain honors the
+// match predicates plus `then log`/`then syslog` (nft `log`) and `then count`
+// (a named nft counter), but a `hook input` chain has no faithful expression for
+// these CoS / rate-control modifiers:
+//   - then policer <name>: a Junos policer is a bandwidth+burst token bucket
+//     with a configurable then-action (discard / loss-priority); nft `limit`
+//     cannot reproduce the bandwidth/burst mapping or the loss-priority action,
+//     so mirroring it would silently rate-limit host-bound traffic by a
+//     DIFFERENT rule than userspace. The kernel mirror does not enforce it.
+//   - then dscp <v> (traffic-class rewrite) / then forwarding-class <fc>: these
+//     select egress CoS, which is meaningless for traffic the kernel delivers
+//     LOCALLY (there is no egress queue for host-bound packets), so the kernel
+//     input mirror performs no rewrite / class selection.
+//
+// loss-priority is intentionally NOT repeated here: validateFilterLossPriority
+// Warnings (#2507) already reports it as globally inert (no per-packet consumer
+// in EITHER dataplane), which subsumes the kernel-mirror gap.
+//
+// It is never an error: these modifiers are valid Junos and a hard reject would
+// brick a boot on a previously-committed config; userspace remains authoritative
+// for whatever lo0-filtered traffic actually reaches the XSK. The warning names
+// the family, filter, term, and modifier so the operator knows the kernel
+// host-bound path will not enforce them.
+func validateLo0FilterKernelMirrorWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	var warnings []string
+	emit := func(family, filterName string, filter *FirewallFilter) {
+		if filterName == "" || filter == nil {
+			return
+		}
+		for _, term := range filter.Terms {
+			if term == nil {
+				continue
+			}
+			// Stable, deterministic per-term modifier order.
+			type mod struct{ kind, val string }
+			var mods []mod
+			if term.Policer != "" {
+				mods = append(mods, mod{"policer", term.Policer})
+			}
+			if term.DSCPRewrite != "" {
+				mods = append(mods, mod{"dscp (traffic-class rewrite)", term.DSCPRewrite})
+			}
+			if term.ForwardingClass != "" {
+				mods = append(mods, mod{"forwarding-class", term.ForwardingClass})
+			}
+			for _, m := range mods {
+				warnings = append(warnings, fmt.Sprintf(
+					"firewall family %s filter %q term %q `then %s %s` is accepted but "+
+						"the kernel lo0 input mirror (nftables xpf_lo0, the PRIMARY "+
+						"enforcement for host-bound traffic) cannot honor it; the modifier "+
+						"applies only to lo0-filtered traffic that reaches the userspace "+
+						"dataplane",
+					family, filterName, term.Name, m.kind, m.val))
+			}
+		}
+	}
+	emit("inet", cfg.System.Lo0FilterInputV4, cfg.Firewall.FiltersInet[cfg.System.Lo0FilterInputV4])
+	emit("inet6", cfg.System.Lo0FilterInputV6, cfg.Firewall.FiltersInet6[cfg.System.Lo0FilterInputV6])
 	return warnings
 }
 

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -314,18 +314,22 @@ never lock an operator out of a remote box it manages.
   success-no-error, idempotent add+delete teardown) and
   `daemon_apply_runtime_test.go:TestApplyConfigLockedSurfacesLo0Failure` (the
   commit-level `errors.Join` wiring proof).
-  **Per-term disposition mirrors userspace (#3427):** `nftRuleFromTerm` maps a
+  **Per-term disposition mirrors userspace (#3427):** `nftRulesFromTerm` maps a
   term's `then` action to the kernel verdict the SAME way the userspace lo0
   evaluator does (`pkg/dataplane/userspace/filters.go` `NextTerm =
   (term.NextTerm || term.Action == "") && term.RoutingInstance == ""`). A term
   with NO terminating action is a Junos FALL-THROUGH (explicit `then next term`
-  or a modifier-only term carrying only count/log/forwarding-class/dscp): it
-  emits NO rule (the kernel chain mirrors no counters/log, so the term has no
-  enforcement effect) and the subsequent terms run. The pre-fix code mapped an
-  empty action to a terminating `accept`, which SHADOWED every later
-  discard/reject term — a control-plane fail-OPEN diverging from userspace
-  (`from protocol tcp then next term` followed by `from destination-port 22 then
-  discard` accepted SSH at term 1, leaving the drop unreachable). A
+  or a modifier-only term): it emits no TERMINATING verdict and the subsequent
+  terms run. Pre-#3445 such a term emitted NOTHING; now it emits its honored
+  modifiers (`then log`/`then count`, see the modifier bullet below) as a
+  NON-TERMINATING rule (modifier statements, no verdict) so the per-term log /
+  count fires while the chain still falls through to later terms (nft continues
+  past any rule carrying no verdict). A fall-through term with no honored
+  modifier still emits nothing. The pre-#3427 code mapped an empty action to a
+  terminating `accept`, which SHADOWED every later discard/reject term — a
+  control-plane fail-OPEN diverging from userspace (`from protocol tcp then next
+  term` followed by `from destination-port 22 then discard` accepted SSH at term
+  1, leaving the drop unreachable). A
   `routing-instance` (PBR) term is explicitly NOT a fall-through: userspace sets
   `continue_term=false` when `routing_instance` is non-empty and the evaluator
   TERMINATES the matched term, returning its action — the empty-action
@@ -340,8 +344,51 @@ never lock an operator out of a remote box it manages.
   `TestLo0PayloadRoutingInstanceTerminatesAcceptNoOverDrop` (the over-drop
   counterexample).
 
+  **Non-terminating `then` modifier policy (#3445):** the kernel lo0 chain is
+  the PRIMARY enforcement for host-bound traffic, so a term's non-terminating
+  `then` modifiers must not silently diverge from userspace. The policy is
+  explicit per modifier — implement what nft can honor on a `hook input` chain,
+  and WARN at commit for what it cannot, never silently drop:
+  - **honored in nft:** `then log` / `then syslog` (both compile to `term.Log`)
+    → an nft `log prefix "xpf-lo0 <term>: "` statement (to journald), and
+    `then count <name>` → a NAMED nft counter (`counter name "<n>"`, the object
+    declared once in the table body by `buildLo0FilterPayload`; `nftables.
+    Lo0CounterName` sanitizes + prefixes the Junos name to a bare-safe `xpflo0_*`
+    identifier). nft executes a rule's statements left-to-right and the verdict
+    terminates, so these prepend the verdict; on a fall-through term they form a
+    NON-TERMINATING rule on their own (see the disposition bullet above).
+  - **warned, not mirrored:** `then policer` (a Junos bandwidth+burst token
+    bucket with a configurable then-action — nft `limit` cannot reproduce the
+    rate mapping or the loss-priority action), `then dscp` (traffic-class
+    rewrite) and `then forwarding-class` (egress CoS selection is meaningless for
+    locally-delivered host-bound traffic). `config.validateLo0FilterKernelMirror
+    Warnings` emits a commit WARNING naming the family/filter/term/modifier so the
+    operator knows the kernel host-bound path will not enforce them; userspace
+    stays authoritative for whatever lo0-filtered traffic actually reaches the
+    XSK. `then loss-priority` is already reported globally inert by
+    `validateFilterLossPriorityWarnings` (#2507), which subsumes the mirror gap.
+  - **`reject` (#3445 H10):** faithfully mirrors the userspace reject-reply
+    synthesis (`userspace-dp` `poll_descriptor/reject_reply.rs`) — a TCP RST for
+    TCP, an ICMP/ICMPv6 administratively-prohibited Destination Unreachable for
+    everything else. nft cannot pick the reply protocol within ONE rule, so a
+    reject term emits TWO: a TCP-only `reject with tcp reset`, then a
+    family-agnostic `reject with icmpx type admin-prohibited` (icmpx selects
+    ICMP vs ICMPv6 from the packet, so the same pair is correct in both rendering
+    passes). The pre-fix bare `reject` sent ICMP port-unreachable for ALL
+    protocols (including TCP) — a different wire response than userspace.
+  Because a term can now lower to zero, one, or two rules, the lo0 table uses the
+  atomic `add table; delete table; table { ... }` idiom (shared with the
+  host-inbound table) instead of the prior `flush table`: `flush` does not delete
+  named counter objects, so redeclaring a `then count` counter on the next commit
+  would collide ("File exists"). A consequence is the lo0 counters reset to zero
+  on every rebuild — nothing scrapes them, so there is no metric impact. Pinned by
+  `TestNftRuleFromTermLogMirror`, `TestNftRuleFromTermCountMirror`,
+  `TestLo0PayloadSharedCounterDeclaredOnce`, `TestNftRuleFromTermRejectVsDiscard`,
+  `TestNftRuleFromTermPrefixListExcept`, `TestLo0FilterPayloadFlushIdiom`, and (config
+  side) `compiler_lo0_mirror_modifiers_3445_test.go`.
+
   **Address / prefix-list lowering mirrors userspace (#3433):**
-  `nftRuleFromTerm` lowers each direction's `source-address` /
+  `nftRulesFromTerm` lowers each direction's `source-address` /
   `destination-address` + `source-prefix-list` / `destination-prefix-list`
   scope through the SHARED userspace resolver
   (`dpuserspace.ResolveFilterPrefixListAddrs`) so the kernel mirror uses the
@@ -366,7 +413,7 @@ never lock an operator out of a remote box it manages.
   `TestNftRuleFromTermWrongFamilyMatchesNothing`, and (config side)
   `firewall_address_literal_3433_test.go`.
 
-  **ICMP type/code lowering mirrors userspace (#3483):** `nftRuleFromTerm`
+  **ICMP type/code lowering mirrors userspace (#3483):** `nftRulesFromTerm`
   renders `icmp-type` and `icmp-code` as INDEPENDENT predicates, each gated
   only on its own value list — `icmp[v6] type <set>` when `len(ICMPTypes) > 0`
   and `icmp[v6] code <set>` when `len(ICMPCodes) > 0` (family selects `icmp`
@@ -382,7 +429,7 @@ never lock an operator out of a remote box it manages.
   multi-value, code-only) and `TestNftRuleFromTermICMPTypeCode`.
 
   **Protocol / DSCP lowering normalizes through the shared resolvers (#3436):**
-  `nftRuleFromTerm` resolves each `from protocol` token through the shared
+  `nftRulesFromTerm` resolves each `from protocol` token through the shared
   `appid.ProtocolNumber` SSOT (the same resolver the commit gate
   `filterProtocolResolvable` and the userspace matcher `ip_proto.rs` use) and
   emits the NUMERIC nft `l4proto` token (`meta l4proto 47`, set form

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -134,44 +134,77 @@ func (d *Daemon) applyLo0Filter(cfg *config.Config) error {
 // nft or the daemon apply path. Callers pass the already-resolved v4/v6 filter
 // names so the payload reflects exactly what applyLo0Filter would send.
 //
-// The leading three lines are the atomic flush idiom: create the table if it
-// does not yet exist (`table inet xpf_lo0` with no body — idempotent), flush
-// its contents, then redefine it. nft parses an `-f -` payload atomically, so
-// a syntax error on any line rejects the ENTIRE payload. The pre-#2069
-// `flush ruleset inet xpf_lo0` was NOT valid nft — `flush ruleset` takes at
-// most an OPTIONAL family (`flush ruleset [<family>]`), never a table name, so
-// the trailing table token was a parse error that rejected the whole ruleset
-// (incl. the real filter rules) and made the lo0 filter fail OPEN.
+// The leading two lines are the atomic delete+recreate idiom shared with the
+// host-inbound table: `add table` makes the table exist (idempotent), so the
+// following `delete table` always has a target whether or not it pre-existed,
+// removing the old chain AND its named counter OBJECTS; then a fresh
+// `table { ... }` body redeclares everything. This REPLACES the pre-#3445
+// create/`flush table`/redefine idiom because `flush table` empties rules but
+// does NOT delete named counter objects (#3445 attaches a named counter per
+// `then count`), so redeclaring them on the next commit would collide
+// ("File exists"); delete+recreate guarantees each counter is declared exactly
+// once and leaves no stale counter for a removed term. A consequence is that the
+// lo0 counters reset to zero on every rebuild (every commit / DHCP re-render) —
+// nothing scrapes them so there is no metric impact. nft parses an `-f -`
+// payload atomically, so a syntax error on any line rejects the ENTIRE payload.
+// (The pre-#2069 `flush ruleset inet xpf_lo0` was NOT valid nft and made the
+// filter fail OPEN; the delete+recreate idiom is unconditionally valid.)
 func buildLo0FilterPayload(cfg *config.Config, filterV4, filterV6 string) string {
-	var rules []string
-	rules = append(rules, "table inet xpf_lo0")
-	rules = append(rules, "flush table inet xpf_lo0")
-	rules = append(rules, "table inet xpf_lo0 {")
-	rules = append(rules, "  chain input {")
-	// #3364: explicit distinct priority so lo0 evaluates BEFORE xpf_hostinbound.
-	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", nftLo0FilterPriority))
-
 	prefixLists := cfg.PolicyOptions.PrefixLists
-	if filterV4 != "" {
-		if f, ok := cfg.Firewall.FiltersInet[filterV4]; ok {
-			for _, term := range f.Terms {
-				r := nftRuleFromTerm(term, "ip", prefixLists)
+
+	// Render the per-term rules first so the pre-pass can collect the named
+	// counter objects every `then count` rule references. nft requires each
+	// counter to be DECLARED in the table body before the chain references it, so
+	// the declarations are emitted ahead of the chain (mirroring the host-inbound
+	// table's pre-pass). Dedup on the object name so a counter shared by several
+	// terms (or by both the v4 and v6 lo0 filters, which land in the same inet
+	// table) is declared exactly once.
+	var ruleLines []string
+	var counters []string
+	seenCounter := map[string]bool{}
+	emit := func(f *config.FirewallFilter, family string) {
+		for _, term := range f.Terms {
+			for _, r := range nftRulesFromTerm(term, family, prefixLists) {
 				if r != "" {
-					rules = append(rules, "    "+r)
+					ruleLines = append(ruleLines, "    "+r)
 				}
 			}
+			if term != nil && term.Count != "" {
+				cn := xnft.Lo0CounterName(term.Count)
+				if !seenCounter[cn] {
+					seenCounter[cn] = true
+					counters = append(counters, cn)
+				}
+			}
+		}
+	}
+	if filterV4 != "" {
+		if f, ok := cfg.Firewall.FiltersInet[filterV4]; ok {
+			emit(f, "ip")
 		}
 	}
 	if filterV6 != "" {
 		if f, ok := cfg.Firewall.FiltersInet6[filterV6]; ok {
-			for _, term := range f.Terms {
-				r := nftRuleFromTerm(term, "ip6", prefixLists)
-				if r != "" {
-					rules = append(rules, "    "+r)
-				}
-			}
+			emit(f, "ip6")
 		}
 	}
+
+	var rules []string
+	rules = append(rules, "add table inet xpf_lo0")
+	rules = append(rules, "delete table inet xpf_lo0")
+	rules = append(rules, "table inet xpf_lo0 {")
+	for _, cn := range counters {
+		// The DECLARATION must be UNQUOTED (#3578): nft v1.1.6 rejects a quoted
+		// name in a counter declaration. Lo0CounterName returns a bare-safe nft
+		// identifier, so the unquoted declaration parses and matches the (quoted)
+		// reference object name byte-for-byte.
+		rules = append(rules, "  counter "+cn+" {")
+		rules = append(rules, "  }")
+	}
+	rules = append(rules, "  chain input {")
+	// #3364: explicit distinct priority so lo0 evaluates BEFORE xpf_hostinbound.
+	rules = append(rules, fmt.Sprintf("    type filter hook input priority %d; policy accept;", nftLo0FilterPriority))
+	rules = append(rules, ruleLines...)
 	rules = append(rules, "  }")
 	rules = append(rules, "}")
 
@@ -808,9 +841,24 @@ func nftAddrPredicate(field, family string, addrs []string, except, constrained 
 	return op + nftAddrSet(famAddrs), false
 }
 
-// nftRuleFromTerm converts a firewall filter term to an nftables rule string.
-// prefixLists is used to expand source-prefix-list and destination-prefix-list references.
-func nftRuleFromTerm(term *config.FirewallFilterTerm, family string, prefixLists map[string]*config.PrefixList) string {
+// nftRulesFromTerm converts a firewall filter term to the nftables rule lines
+// that mirror it onto the kernel lo0 input chain. It returns a slice because a
+// single term can lower to ZERO rules (a match-nothing or a pure fall-through
+// with no honored modifier), ONE rule (the common accept/discard/modifier-only
+// case), or TWO rules (a faithful `reject` — a TCP RST plus an ICMP/ICMPv6
+// admin-prohibited reply, #3445 H10). prefixLists expands source-prefix-list and
+// destination-prefix-list references.
+//
+// #3445 modifier policy: the `then` modifiers nft CAN honor on a `hook input`
+// chain are emitted (`then log`/`then syslog` -> nft `log`; `then count <name>`
+// -> a named nft `counter`). The modifiers nft CANNOT faithfully honor on the
+// host-inbound mirror (policer rate-limit, dscp-rewrite, forwarding-class,
+// loss-priority CoS marking) are NOT silently dropped here — a commit-time
+// WARNING names each such term+modifier (config.validateLo0FilterKernelMirror
+// Warnings for policer/dscp-rewrite/forwarding-class, and the pre-existing #2507
+// loss-priority warning), so the operator knows the kernel path will not enforce
+// them. See pkg/daemon/README.md "lo0 input filter".
+func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixLists map[string]*config.PrefixList) []string {
 	var parts []string
 
 	// Source / destination address + prefix-list lowering (#3433). Route both
@@ -830,7 +878,7 @@ func nftRuleFromTerm(term *config.FirewallFilterTerm, family string, prefixLists
 		term.SourceAddresses, term.SourcePrefixLists, prefixLists, "", term.Name, "source")
 	srcPred, srcMatchesNothing := nftAddrPredicate("saddr", family, srcAddrs, srcExcept, srcConstrained)
 	if srcMatchesNothing {
-		return ""
+		return nil
 	}
 	if srcPred != "" {
 		parts = append(parts, srcPred)
@@ -840,7 +888,7 @@ func nftRuleFromTerm(term *config.FirewallFilterTerm, family string, prefixLists
 		term.DestAddresses, term.DestPrefixLists, prefixLists, "", term.Name, "destination")
 	dstPred, dstMatchesNothing := nftAddrPredicate("daddr", family, dstAddrs, dstExcept, dstConstrained)
 	if dstMatchesNothing {
-		return ""
+		return nil
 	}
 	if dstPred != "" {
 		parts = append(parts, dstPred)
@@ -1021,31 +1069,103 @@ func nftRuleFromTerm(term *config.FirewallFilterTerm, family string, prefixLists
 	// must emit a TERMINATING accept (not skip): skipping would let a later
 	// deny term match and OVER-DROP legitimate host traffic on the
 	// kernel-primary lo0 chain. Userspace remains authoritative for the actual
-	// route-selection. Falls through to the action switch below (empty action ->
-	// default accept).
+	// route-selection. Falls through to the verdict emission below (empty action
+	// -> default accept).
+
+	// #3445: build the NON-TERMINATING modifier statements the kernel lo0 mirror
+	// can honor natively. nft executes a rule's statements left-to-right and the
+	// verdict terminates, so these prepend the verdict: a term renders as
+	// `<matches> log prefix "..." counter name "<n>" <verdict>`.
+	//   - then log / then syslog (both set term.Log) -> nft `log` (to journald),
+	//     with a stable prefix carrying the term name for operator correlation.
+	//   - then count <name> -> a NAMED nft counter so the kernel per-term match
+	//     count is observable (`nft list table inet xpf_lo0`). The object is
+	//     declared in the table body by buildLo0FilterPayload (nft requires the
+	//     declaration before the chain references it); the reference is quoted.
+	// policer / dscp-rewrite / forwarding-class / loss-priority are deliberately
+	// NOT emitted (they cannot be faithfully expressed on a host-inbound chain);
+	// they are surfaced as commit-time warnings instead (see the doc comment).
+	var mods []string
+	if term.Log {
+		mods = append(mods, `log prefix "`+nftLo0LogPrefix(term.Name)+`"`)
+	}
+	if term.Count != "" {
+		mods = append(mods, `counter name "`+xnft.Lo0CounterName(term.Count)+`"`)
+	}
+	match := strings.Join(parts, " ")
+	modStr := strings.Join(mods, " ")
+
+	// Fall-through (#3427): a term with NO terminating action (explicit `then
+	// next term` or a modifier-only term) APPLIES its modifiers and continues to
+	// the next term. Emit the honored modifiers as a NON-TERMINATING rule (no
+	// verdict) so the per-term log/count fires while later discard/reject terms
+	// stay reachable — nft falls through any rule that carries no verdict. With
+	// no honored modifier the term contributes nothing: return no rule (the
+	// pre-#3445 behavior), which keeps the subsequent terms reachable.
 	if (term.NextTerm || term.Action == "") && term.RoutingInstance == "" {
-		return ""
+		if modStr == "" {
+			return nil
+		}
+		return []string{joinNftFields(match, modStr)}
 	}
 
-	// Action: discard → drop (silent), reject → reject (ICMP unreachable),
-	// accept → accept. An empty action with a routing-instance set reaches here
-	// and takes the default accept (terminate-as-accept, mirroring userspace).
+	// reject (#3445 H10): faithfully mirror the userspace reject-reply synthesis
+	// (userspace-dp poll_descriptor/reject_reply.rs) — a TCP RST for TCP and an
+	// ICMP/ICMPv6 "administratively prohibited" Destination Unreachable for every
+	// other protocol. nft cannot select the reply protocol within ONE rule, so
+	// emit two: a TCP-only `reject with tcp reset`, then a family-agnostic
+	// `reject with icmpx type admin-prohibited` (icmpx selects ICMP vs ICMPv6
+	// from the actual packet, so the SAME pair is correct in both the ip and ip6
+	// rendering passes and needs no L3 qualifier). The pre-fix bare `reject` sent
+	// ICMP port-unreachable for ALL protocols (including TCP) — a different wire
+	// response than userspace. The honored modifiers ride BOTH rules; the rules
+	// are mutually exclusive by l4proto, so each matched packet is logged/counted
+	// exactly once.
+	if term.Action == "reject" {
+		return []string{
+			joinNftFields(match, "meta l4proto 6", modStr, "reject with tcp reset"),
+			joinNftFields(match, modStr, "reject with icmpx type admin-prohibited"),
+		}
+	}
+
+	// Terminating verdict: discard -> drop (silent), accept -> accept, and the
+	// empty-action-with-routing-instance PBR term -> terminate-as-accept (#3427).
 	// Any other explicit action is unexpected for a committed config; keep the
 	// historical accept default rather than emit garbage.
 	action := "accept"
-	switch term.Action {
-	case "discard":
+	if term.Action == "discard" {
 		action = "drop"
-	case "reject":
-		action = "reject"
-	case "accept":
-		action = "accept"
 	}
+	return []string{joinNftFields(match, modStr, action)}
+}
 
-	if len(parts) == 0 {
-		return action
+// joinNftFields joins the space-separated fragments of one nft rule (match
+// predicates, non-terminating modifier statements, and the trailing verdict),
+// skipping the empty fragments so a term with no match / no modifier renders as
+// a clean `<verdict>` rather than carrying stray leading spaces.
+func joinNftFields(fields ...string) string {
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f != "" {
+			out = append(out, f)
+		}
 	}
-	return strings.Join(parts, " ") + " " + action
+	return strings.Join(out, " ")
+}
+
+// nftLo0LogPrefix builds the `log prefix` string for a mirrored `then log` /
+// `then syslog` modifier (#3445). It carries the term name so an operator can
+// correlate a kernel lo0-filter log line with the configured term, stripping the
+// quote / backslash bytes that would break the quoted nft string and bounding
+// the length to stay within nft's log-prefix limit.
+func nftLo0LogPrefix(term string) string {
+	const maxLen = 64
+	safe := strings.NewReplacer(`"`, "", `\`, "").Replace(term)
+	p := "xpf-lo0 " + safe + ": "
+	if len(p) > maxLen {
+		p = p[:maxLen]
+	}
+	return p
 }
 
 // nftTCPFlagOrder lists the TCP flag bits in canonical low-to-high bit order

--- a/pkg/daemon/lo0_filter_test.go
+++ b/pkg/daemon/lo0_filter_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
+// nftRule renders a term to its single nft rule line, asserting the term lowers
+// to exactly one rule (the common accept / discard / fall-through-skip case) or
+// zero (returns ""). Multi-rule terms — a faithful `reject` (TCP RST + ICMP
+// admin-prohibited) and modifier-only fall-through terms (#3445) — are exercised
+// against nftRulesFromTerm directly. The single-rule assertion also guards
+// against an accidental extra rule slipping into a verdict term.
+func nftRule(t *testing.T, term *config.FirewallFilterTerm, family string, prefixLists map[string]*config.PrefixList) string {
+	t.Helper()
+	rules := nftRulesFromTerm(term, family, prefixLists)
+	switch len(rules) {
+	case 0:
+		return ""
+	case 1:
+		return rules[0]
+	default:
+		t.Fatalf("term %q lowered to %d rules, want <=1: %v", term.Name, len(rules), rules)
+		return ""
+	}
+}
+
 // lo0FilterTestConfig returns a config with a representative lo0 input filter
 // bound for both families, exercising the same buildLo0FilterPayload path that
 // applyLo0Filter uses at commit time.
@@ -54,12 +74,15 @@ func lo0FilterTestConfig() *config.Config {
 	return cfg
 }
 
-// TestLo0FilterPayloadFlushIdiom guards the #2069 fix: the nft `-f -` payload
-// must NOT use the invalid `flush ruleset <table>` form (a parse error that
-// rejected the whole ruleset and made the lo0 filter fail OPEN), and must use
-// the atomic create-if-absent + `flush table` idiom so the prior table is
-// reset before the new rules are installed. This test FAILS against the
-// pre-fix payload that began `flush ruleset inet xpf_lo0`.
+// TestLo0FilterPayloadFlushIdiom guards the #2069 fix and the #3445 idiom switch:
+// the nft `-f -` payload must NOT use the invalid `flush ruleset <table>` form (a
+// parse error that rejected the whole ruleset and made the lo0 filter fail OPEN),
+// and must use the atomic add+delete+recreate idiom (`add table; delete table;
+// table { ... }`). The pre-#3445 `flush table` idiom is gone because flush does
+// not delete named counter objects (#3445 attaches a named counter per `then
+// count`), so the delete+recreate idiom is required to redeclare them without a
+// "File exists" collision. This test FAILS against the pre-fix payload that began
+// `flush ruleset inet xpf_lo0`.
 func TestLo0FilterPayloadFlushIdiom(t *testing.T) {
 	cfg := lo0FilterTestConfig()
 	payload := buildLo0FilterPayload(cfg, cfg.System.Lo0FilterInputV4, cfg.System.Lo0FilterInputV6)
@@ -69,10 +92,10 @@ func TestLo0FilterPayloadFlushIdiom(t *testing.T) {
 		t.Errorf("payload uses invalid `flush ruleset` idiom (#2069 regression); a table name after `flush ruleset` is an nft parse error that rejects the entire payload:\n%s", payload)
 	}
 
-	// The correct atomic reset idiom must be present, in order.
+	// The atomic delete+recreate idiom must be present, in order.
 	wantLines := []string{
-		"table inet xpf_lo0",
-		"flush table inet xpf_lo0",
+		"add table inet xpf_lo0",
+		"delete table inet xpf_lo0",
 		"table inet xpf_lo0 {",
 	}
 	idx := 0
@@ -82,11 +105,15 @@ func TestLo0FilterPayloadFlushIdiom(t *testing.T) {
 		}
 	}
 	if idx != len(wantLines) {
-		t.Errorf("payload missing the create-if-absent + `flush table` idiom (got to line %d/%d):\n%s", idx, len(wantLines), payload)
+		t.Errorf("payload missing the add+delete+recreate idiom (got to line %d/%d):\n%s", idx, len(wantLines), payload)
+	}
+	// `add` must precede `delete` so the delete always has a target.
+	if strings.Index(payload, "add table") > strings.Index(payload, "delete table") {
+		t.Errorf("add must precede delete in the lo0 payload:\n%s", payload)
 	}
 
-	// The real filter rules must still be present (proves the flush idiom did
-	// not displace the rule body).
+	// The real filter rules must still be present (proves the idiom did not
+	// displace the rule body).
 	if !strings.Contains(payload, "th dport 22 accept") {
 		t.Errorf("payload missing the configured v4 allow-ssh rule:\n%s", payload)
 	}
@@ -264,7 +291,7 @@ func TestNftRuleFromTermPrefixListExpansion(t *testing.T) {
 		Action:           "accept",
 	}
 
-	rule := nftRuleFromTerm(term, "ip", prefixLists)
+	rule := nftRule(t, term, "ip", prefixLists)
 	// Should contain expanded CIDRs in nft set syntax
 	want := "ip saddr { 10.0.1.0/24, 10.0.2.0/24, 192.168.1.0/24 } meta l4proto 6 th dport 22 accept"
 	if rule != want {
@@ -290,10 +317,22 @@ func TestNftRuleFromTermPrefixListExcept(t *testing.T) {
 		Action:           "reject",
 	}
 
-	rule := nftRuleFromTerm(term, "ip", prefixLists)
-	want := "ip saddr != { 10.0.1.0/24, 10.0.2.0/24 } meta l4proto 6 th dport 22 reject"
-	if rule != want {
-		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
+	// #3445: a `then reject` now lowers to TWO faithful rules (TCP RST + ICMP
+	// admin-prohibited) mirroring the userspace reject-reply synthesis, so the
+	// except predicate must appear on BOTH.
+	rules := nftRulesFromTerm(term, "ip", prefixLists)
+	match := "ip saddr != { 10.0.1.0/24, 10.0.2.0/24 } meta l4proto 6 th dport 22"
+	want := []string{
+		match + " meta l4proto 6 reject with tcp reset",
+		match + " reject with icmpx type admin-prohibited",
+	}
+	if len(rules) != len(want) {
+		t.Fatalf("reject lowered to %d rules, want %d: %v", len(rules), len(want), rules)
+	}
+	for i := range want {
+		if rules[i] != want[i] {
+			t.Errorf("rule[%d]:\n  got:  %s\n  want: %s", i, rules[i], want[i])
+		}
 	}
 }
 
@@ -305,7 +344,6 @@ func TestNftRuleFromTermRejectVsDiscard(t *testing.T) {
 		wantAction string
 	}{
 		{"accept", "accept"},
-		{"reject", "reject"},
 		{"discard", "drop"},
 		// #3427: an empty action is a Junos fall-through (modifier-only term),
 		// NOT a terminating accept. The kernel mirror must skip it (emit "") so
@@ -319,9 +357,26 @@ func TestNftRuleFromTermRejectVsDiscard(t *testing.T) {
 			Name:   "test",
 			Action: tt.action,
 		}
-		rule := nftRuleFromTerm(term, "ip", prefixLists)
+		rule := nftRule(t, term, "ip", prefixLists)
 		if rule != tt.wantAction {
 			t.Errorf("action %q: got %q, want %q", tt.action, rule, tt.wantAction)
+		}
+	}
+
+	// #3445: `reject` lowers to a faithful TCP-RST + ICMP-admin-prohibited pair,
+	// not the pre-fix bare `reject` (which sent ICMP port-unreachable for ALL
+	// protocols including TCP — a different wire response than userspace).
+	reject := nftRulesFromTerm(&config.FirewallFilterTerm{Name: "test", Action: "reject"}, "ip", prefixLists)
+	wantReject := []string{
+		"meta l4proto 6 reject with tcp reset",
+		"reject with icmpx type admin-prohibited",
+	}
+	if len(reject) != len(wantReject) {
+		t.Fatalf("reject lowered to %d rules, want %d: %v", len(reject), len(wantReject), reject)
+	}
+	for i := range wantReject {
+		if reject[i] != wantReject[i] {
+			t.Errorf("reject rule[%d]: got %q, want %q", i, reject[i], wantReject[i])
 		}
 	}
 }
@@ -336,7 +391,7 @@ func TestNftRuleFromTermMultiplePorts(t *testing.T) {
 		Action:           "accept",
 	}
 
-	rule := nftRuleFromTerm(term, "ip", prefixLists)
+	rule := nftRule(t, term, "ip", prefixLists)
 	want := "meta l4proto 6 th dport { 80, 443 } accept"
 	if rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
@@ -352,7 +407,7 @@ func TestNftRuleFromTermSingleSourceAddr(t *testing.T) {
 		SourceAddresses: []string{"10.0.1.0/24"},
 		Action:          "accept",
 	}
-	if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != "ip saddr 10.0.1.0/24 accept" {
+	if rule := nftRule(t, term, "ip", prefixLists); rule != "ip saddr 10.0.1.0/24 accept" {
 		t.Errorf("v4 literal in ip chain: got %q, want %q", rule, "ip saddr 10.0.1.0/24 accept")
 	}
 }
@@ -373,7 +428,7 @@ func TestNftRuleFromTermWrongFamilyMatchesNothing(t *testing.T) {
 		SourceAddresses: []string{"10.0.1.0/24"},
 		Action:          "accept",
 	}
-	if rule := nftRuleFromTerm(term, "ip6", prefixLists); rule != "" {
+	if rule := nftRule(t, term, "ip6", prefixLists); rule != "" {
 		t.Errorf("wrong-family v4 literal in ip6 chain: got %q, want \"\" (match-nothing, #3433 H02)", rule)
 	}
 
@@ -383,7 +438,7 @@ func TestNftRuleFromTermWrongFamilyMatchesNothing(t *testing.T) {
 		SourceAddresses: []string{"2001:db8::/32"},
 		Action:          "discard",
 	}
-	if rule := nftRuleFromTerm(term6, "ip", prefixLists); rule != "" {
+	if rule := nftRule(t, term6, "ip", prefixLists); rule != "" {
 		t.Errorf("wrong-family v6 literal in ip chain: got %q, want \"\" (match-nothing, #3433 H02)", rule)
 	}
 }
@@ -494,7 +549,7 @@ func TestNftRuleFromTermAddressSemantics3433(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := nftRuleFromTerm(tt.term, tt.fam, pls)
+			got := nftRule(t, tt.term, tt.fam, pls)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
@@ -512,7 +567,7 @@ func TestNftRuleFromTermICMPTypeCode(t *testing.T) {
 		ICMPCodes: []int{0},
 		Action:    "discard",
 	}
-	rule := nftRuleFromTerm(term, "ip6", prefixLists)
+	rule := nftRule(t, term, "ip6", prefixLists)
 	want := "icmpv6 type 134 icmpv6 code 0 drop"
 	if rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
@@ -524,7 +579,7 @@ func TestNftRuleFromTermICMPTypeCode(t *testing.T) {
 		ICMPTypes: []int{5},
 		Action:    "discard",
 	}
-	rule2 := nftRuleFromTerm(term2, "ip", prefixLists)
+	rule2 := nftRule(t, term2, "ip", prefixLists)
 	want2 := "icmp type 5 drop"
 	if rule2 != want2 {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule2, want2)
@@ -551,7 +606,7 @@ func TestNftRuleFromTermICMPCodeOnly(t *testing.T) {
 		ICMPCodes: []int{4},
 		Action:    "discard",
 	}
-	ruleV4 := nftRuleFromTerm(v4, "ip", prefixLists)
+	ruleV4 := nftRule(t, v4, "ip", prefixLists)
 	wantV4 := "meta l4proto 1 icmp code 4 drop"
 	if ruleV4 != wantV4 {
 		t.Errorf("v4 code-only:\n  got:  %s\n  want: %s", ruleV4, wantV4)
@@ -567,7 +622,7 @@ func TestNftRuleFromTermICMPCodeOnly(t *testing.T) {
 		ICMPCodes: []int{1},
 		Action:    "discard",
 	}
-	ruleV6 := nftRuleFromTerm(v6, "ip6", prefixLists)
+	ruleV6 := nftRule(t, v6, "ip6", prefixLists)
 	wantV6 := "meta l4proto 58 icmpv6 code 1 drop"
 	if ruleV6 != wantV6 {
 		t.Errorf("v6 code-only:\n  got:  %s\n  want: %s", ruleV6, wantV6)
@@ -582,7 +637,7 @@ func TestNftRuleFromTermICMPCodeOnly(t *testing.T) {
 		ICMPCodes: []int{0, 4},
 		Action:    "discard",
 	}
-	ruleMulti := nftRuleFromTerm(multi, "ip", prefixLists)
+	ruleMulti := nftRule(t, multi, "ip", prefixLists)
 	wantMulti := "icmp code { 0, 4 } drop"
 	if ruleMulti != wantMulti {
 		t.Errorf("multi code-only:\n  got:  %s\n  want: %s", ruleMulti, wantMulti)
@@ -597,7 +652,7 @@ func TestNftRuleFromTermDSCP(t *testing.T) {
 		DSCPs:  []string{"ef"},
 		Action: "accept",
 	}
-	rule := nftRuleFromTerm(term, "ip", prefixLists)
+	rule := nftRule(t, term, "ip", prefixLists)
 	// #3436: the DSCP name resolves to its numeric value (ef == 46). nft's DSCP
 	// names are lowercase only and do not cover every xpf code point (e.g. `be`),
 	// so emitting the numeric value is unconditionally nft-safe.
@@ -607,7 +662,7 @@ func TestNftRuleFromTermDSCP(t *testing.T) {
 	}
 
 	// IPv6 traffic-class
-	rule6 := nftRuleFromTerm(term, "ip6", prefixLists)
+	rule6 := nftRule(t, term, "ip6", prefixLists)
 	want6 := "ip6 dscp 46 accept"
 	if rule6 != want6 {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule6, want6)
@@ -643,7 +698,7 @@ func TestNftRuleFromTermProtocolAliases(t *testing.T) {
 				Name: "p", Protocols: []string{c.proto}, Action: "accept",
 			}
 			want := c.want + " accept"
-			if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != want {
+			if rule := nftRule(t, term, "ip", prefixLists); rule != want {
 				t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 			}
 		})
@@ -660,7 +715,7 @@ func TestNftRuleFromTermProtocolMultiAliasSet(t *testing.T) {
 		Name: "p", Protocols: []string{"junos-gre", "tcp", "50"}, Action: "accept",
 	}
 	want := "meta l4proto { 47, 6, 50 } accept"
-	if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != want {
+	if rule := nftRule(t, term, "ip", prefixLists); rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
 }
@@ -689,7 +744,7 @@ func TestNftRuleFromTermDSCPNamesAndCase(t *testing.T) {
 				Name: "d", DSCPs: []string{c.dscp}, Action: "accept",
 			}
 			want := c.want + " accept"
-			if rule := nftRuleFromTerm(term, "ip", prefixLists); rule != want {
+			if rule := nftRule(t, term, "ip", prefixLists); rule != want {
 				t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 			}
 		})
@@ -700,7 +755,7 @@ func TestNftRuleFromTermDSCPNamesAndCase(t *testing.T) {
 		Name: "d", DSCPs: []string{"EF", "af21", "0"}, Action: "accept",
 	}
 	want := "ip dscp { 46, 18, 0 } accept"
-	if rule := nftRuleFromTerm(multi, "ip", prefixLists); rule != want {
+	if rule := nftRule(t, multi, "ip", prefixLists); rule != want {
 		t.Errorf("got:\n  %s\nwant:\n  %s", rule, want)
 	}
 }
@@ -748,7 +803,7 @@ func TestNftRuleFromTermTCPFlags(t *testing.T) {
 				TCPFlags:  c.flags,
 				Action:    "discard",
 			}
-			rule := nftRuleFromTerm(term, "ip", prefixLists)
+			rule := nftRule(t, term, "ip", prefixLists)
 			if rule != c.want {
 				t.Errorf("flags %v\n got:  %s\n want: %s", c.flags, rule, c.want)
 			}
@@ -774,7 +829,7 @@ func TestNftRuleFromTermPortExcept(t *testing.T) {
 		DestPortsExcept: []string{"22"},
 		Action:          "accept",
 	}
-	rule := nftRuleFromTerm(term, "ip", prefixLists)
+	rule := nftRule(t, term, "ip", prefixLists)
 	want := "meta l4proto 6 th dport != 22 accept"
 	if rule != want {
 		t.Errorf("dest-port-except single:\n got:  %s\n want: %s", rule, want)
@@ -787,7 +842,7 @@ func TestNftRuleFromTermPortExcept(t *testing.T) {
 		DestPortsExcept: []string{"80", "443"},
 		Action:          "accept",
 	}
-	rule2 := nftRuleFromTerm(term2, "ip", prefixLists)
+	rule2 := nftRule(t, term2, "ip", prefixLists)
 	want2 := "meta l4proto 6 th dport != { 80, 443 } accept"
 	if rule2 != want2 {
 		t.Errorf("dest-port-except multi:\n got:  %s\n want: %s", rule2, want2)
@@ -800,7 +855,7 @@ func TestNftRuleFromTermPortExcept(t *testing.T) {
 		SourcePortsExcept: []string{"123"},
 		Action:            "discard",
 	}
-	rule3 := nftRuleFromTerm(term3, "ip", prefixLists)
+	rule3 := nftRule(t, term3, "ip", prefixLists)
 	want3 := "meta l4proto 17 th sport != 123 drop"
 	if rule3 != want3 {
 		t.Errorf("source-port-except:\n got:  %s\n want: %s", rule3, want3)
@@ -821,13 +876,13 @@ func TestNftRuleFromTermFragment(t *testing.T) {
 		Action:     "discard",
 	}
 
-	rule := nftRuleFromTerm(term, "ip", prefixLists)
+	rule := nftRule(t, term, "ip", prefixLists)
 	want := "ip frag-off & 0x1fff != 0 drop"
 	if rule != want {
 		t.Errorf("ip4 fragment:\n got:  %s\n want: %s", rule, want)
 	}
 
-	rule6 := nftRuleFromTerm(term, "ip6", prefixLists)
+	rule6 := nftRule(t, term, "ip6", prefixLists)
 	want6 := "exthdr frag exists drop"
 	if rule6 != want6 {
 		t.Errorf("ip6 fragment:\n got:  %s\n want: %s", rule6, want6)
@@ -842,13 +897,18 @@ func TestNftRuleFromTermFragment(t *testing.T) {
 // NOT emit a terminating kernel verdict that shadows later discard/reject terms.
 // The kernel lo0 chain is the PRIMARY enforcement for host-bound traffic (the
 // XDP shim shunts it to the kernel before userspace), so a bare `accept` here is
-// a real control-plane fail-open. Each case asserts the term emits no rule and,
-// critically, no `accept`. RED before the fix (Action=="" returned "accept";
-// NextTerm was ignored entirely so it also returned "accept").
+// a real control-plane fail-open. A fall-through term WITHOUT a honored modifier
+// emits no rule; a fall-through term carrying `then log`/`then count` (#3445)
+// emits a NON-TERMINATING rule (the modifier statements, no verdict) so the
+// per-term log/count fires while later terms stay reachable. Every case asserts
+// no terminating verdict (no accept / drop / reject) is emitted. RED before the
+// #3427 fix (Action=="" returned "accept"; NextTerm was ignored so it also
+// returned "accept").
 func TestNftRuleFromTermFallThroughNoBareAccept(t *testing.T) {
 	prefixLists := map[string]*config.PrefixList{}
 
-	cases := []struct {
+	// Pure fall-through (no honored modifier): emits NO rule.
+	noRule := []struct {
 		name string
 		term *config.FirewallFilterTerm
 	}{
@@ -862,16 +922,6 @@ func TestNftRuleFromTermFallThroughNoBareAccept(t *testing.T) {
 			},
 		},
 		{
-			// H07: modifier-only term (count, no terminating action), scoped by
-			// a match. Action stays "" — the compiler leaves it empty.
-			name: "modifier-only-count",
-			term: &config.FirewallFilterTerm{
-				Name:      "t1",
-				Protocols: []string{"tcp"},
-				Count:     "tcp-seen",
-			},
-		},
-		{
 			// Bare `then next term` with no match — matches everything, falls
 			// through. Must not become an accept-all.
 			name: "next-term-no-match",
@@ -880,16 +930,50 @@ func TestNftRuleFromTermFallThroughNoBareAccept(t *testing.T) {
 				NextTerm: true,
 			},
 		},
+		{
+			// Modifier-only term whose only modifier is unrepresentable on the
+			// kernel mirror (forwarding-class) — nothing is honored, so no rule and
+			// (commit-time) a warning. Must not shadow later terms.
+			name: "modifier-only-unhonored",
+			term: &config.FirewallFilterTerm{
+				Name:            "t1",
+				Protocols:       []string{"tcp"},
+				ForwardingClass: "expedited-forwarding",
+			},
+		},
+	}
+	for _, c := range noRule {
+		for _, fam := range []string{"ip", "ip6"} {
+			rules := nftRulesFromTerm(c.term, fam, prefixLists)
+			if len(rules) != 0 {
+				t.Errorf("%s (%s): fall-through term emitted %v, want no rule", c.name, fam, rules)
+			}
+		}
 	}
 
-	for _, c := range cases {
-		for _, fam := range []string{"ip", "ip6"} {
-			rule := nftRuleFromTerm(c.term, fam, prefixLists)
-			if rule != "" {
-				t.Errorf("%s (%s): fall-through term emitted a rule %q, want \"\" (no terminating verdict)", c.name, fam, rule)
-			}
-			if strings.Contains(rule, "accept") {
-				t.Errorf("%s (%s): fall-through term emitted a terminating accept (fail-open #3427): %q", c.name, fam, rule)
+	// H07 / #3445: a modifier-only term carrying a HONORED modifier (count, log)
+	// emits a single NON-TERMINATING rule (the modifier statements, no verdict),
+	// so later discard/reject terms remain reachable.
+	for _, fam := range []string{"ip", "ip6"} {
+		term := &config.FirewallFilterTerm{
+			Name:      "t1",
+			Protocols: []string{"tcp"},
+			Count:     "tcp-seen",
+			Log:       true,
+		}
+		rules := nftRulesFromTerm(term, fam, prefixLists)
+		if len(rules) != 1 {
+			t.Fatalf("modifier-only-count+log (%s): got %d rules, want 1: %v", fam, len(rules), rules)
+		}
+		got := rules[0]
+		want := `meta l4proto 6 log prefix "xpf-lo0 t1: " counter name "xpflo0_tcp-seen"`
+		if got != want {
+			t.Errorf("modifier-only-count+log (%s):\n  got:  %s\n  want: %s", fam, got, want)
+		}
+		// Critically: no terminating verdict, so the term cannot shadow later terms.
+		for _, verdict := range []string{"accept", "drop", "reject"} {
+			if strings.Contains(got, verdict) {
+				t.Errorf("modifier-only fall-through (%s) emitted a terminating %q (fail-open #3427): %q", fam, verdict, got)
 			}
 		}
 	}
@@ -924,7 +1008,7 @@ func TestNftRuleFromTermRoutingInstanceTerminatesAccept(t *testing.T) {
 			SourceAddresses: []string{c.addr},
 			RoutingInstance: "mgmt",
 		}
-		rule := nftRuleFromTerm(term, c.fam, prefixLists)
+		rule := nftRule(t, term, c.fam, prefixLists)
 		if rule != c.want {
 			t.Errorf("routing-instance term (%s): got %q, want %q (terminate-as-accept, mirror userspace)", c.fam, rule, c.want)
 		}
@@ -992,5 +1076,108 @@ func TestLo0PayloadRoutingInstanceTerminatesAcceptNoOverDrop(t *testing.T) {
 	dropIdx := strings.Index(payload, "meta l4proto 6 drop")
 	if acceptIdx == -1 || (dropIdx != -1 && dropIdx < acceptIdx) {
 		t.Errorf("routing-instance accept must precede the deny term (first-match-wins) so legit traffic is not over-dropped:\n%s", payload)
+	}
+}
+
+// TestNftRuleFromTermLogMirror is the #3445 M02 RED-on-revert: a term carrying
+// `then log` / `then syslog` (both set term.Log) must emit an nft `log`
+// statement on the kernel lo0 mirror, BEFORE the verdict. The pre-fix action
+// switch never read term.Log, so the configured filter log was silently dropped
+// for host-bound traffic the kernel handles. Reverting the fix drops the `log`
+// fragment and fails this test.
+func TestNftRuleFromTermLogMirror(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+
+	// log on a terminating accept: `<match> log prefix "..." accept`.
+	term := &config.FirewallFilterTerm{
+		Name:             "log-ssh",
+		Protocols:        []string{"tcp"},
+		DestinationPorts: []string{"22"},
+		Log:              true,
+		Action:           "accept",
+	}
+	got := nftRule(t, term, "ip", prefixLists)
+	want := `meta l4proto 6 th dport 22 log prefix "xpf-lo0 log-ssh: " accept`
+	if got != want {
+		t.Errorf("log+accept:\n  got:  %s\n  want: %s", got, want)
+	}
+	if !strings.Contains(got, "log prefix") {
+		t.Errorf("term `then log` did not emit nft `log` (#3445 M02 regression): %q", got)
+	}
+
+	// log on a discard: the log fires before the drop.
+	dterm := &config.FirewallFilterTerm{Name: "log-drop", Log: true, Action: "discard"}
+	dgot := nftRule(t, dterm, "ip", prefixLists)
+	dwant := `log prefix "xpf-lo0 log-drop: " drop`
+	if dgot != dwant {
+		t.Errorf("log+discard:\n  got:  %s\n  want: %s", dgot, dwant)
+	}
+}
+
+// TestNftRuleFromTermCountMirror is the #3445 M03 RED-on-revert: a term carrying
+// `then count <name>` must emit a NAMED nft counter (`counter name "<n>"`) on the
+// rule AND the payload must DECLARE that counter object in the table body (nft
+// requires the declaration before the reference). The pre-fix action switch never
+// read term.Count, so the kernel counter stayed stale while the kernel enforced
+// the verdict. Reverting the fix drops the counter reference and the declaration.
+func TestNftRuleFromTermCountMirror(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+
+	term := &config.FirewallFilterTerm{
+		Name:             "count-ssh",
+		Protocols:        []string{"tcp"},
+		DestinationPorts: []string{"22"},
+		Count:            "ssh-hits",
+		Action:           "accept",
+	}
+	got := nftRule(t, term, "ip", prefixLists)
+	want := `meta l4proto 6 th dport 22 counter name "xpflo0_ssh-hits" accept`
+	if got != want {
+		t.Errorf("count+accept:\n  got:  %s\n  want: %s", got, want)
+	}
+
+	// Payload must declare the named counter object (unquoted) before the chain.
+	cfg := &config.Config{}
+	cfg.System.Lo0FilterInputV4 = "lo0-in"
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"lo0-in": {Name: "lo0-in", Terms: []*config.FirewallFilterTerm{term}},
+	}
+	payload := buildLo0FilterPayload(cfg, "lo0-in", "")
+	if !strings.Contains(payload, "  counter xpflo0_ssh-hits {") {
+		t.Errorf("payload missing the named counter DECLARATION (#3445 M03):\n%s", payload)
+	}
+	if !strings.Contains(payload, `counter name "xpflo0_ssh-hits"`) {
+		t.Errorf("payload missing the named counter REFERENCE (#3445 M03):\n%s", payload)
+	}
+	// The declaration must precede the chain reference.
+	declIdx := strings.Index(payload, "counter xpflo0_ssh-hits {")
+	refIdx := strings.Index(payload, `counter name "xpflo0_ssh-hits"`)
+	if declIdx == -1 || refIdx == -1 || declIdx > refIdx {
+		t.Errorf("counter declaration must precede its reference (nft requirement):\n%s", payload)
+	}
+}
+
+// TestLo0PayloadSharedCounterDeclaredOnce pins that a counter object referenced
+// by several terms (or by both the v4 and v6 lo0 filters, which share the inet
+// table) is DECLARED exactly once — a duplicate declaration is an nft "File
+// exists" hard error that rejects the whole atomic load (#3445).
+func TestLo0PayloadSharedCounterDeclaredOnce(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.System.Lo0FilterInputV4 = "v4"
+	cfg.System.Lo0FilterInputV6 = "v6"
+	cfg.Firewall.FiltersInet = map[string]*config.FirewallFilter{
+		"v4": {Name: "v4", Terms: []*config.FirewallFilterTerm{
+			{Name: "a", Protocols: []string{"tcp"}, Count: "shared", Action: "accept"},
+			{Name: "b", Protocols: []string{"udp"}, Count: "shared", Action: "discard"},
+		}},
+	}
+	cfg.Firewall.FiltersInet6 = map[string]*config.FirewallFilter{
+		"v6": {Name: "v6", Terms: []*config.FirewallFilterTerm{
+			{Name: "c", Count: "shared", Action: "accept"},
+		}},
+	}
+	payload := buildLo0FilterPayload(cfg, "v4", "v6")
+	if n := strings.Count(payload, "counter xpflo0_shared {"); n != 1 {
+		t.Errorf("shared counter declared %d times, want exactly 1 (duplicate is an nft hard error):\n%s", n, payload)
 	}
 }

--- a/pkg/nftables/lo0_counters.go
+++ b/pkg/nftables/lo0_counters.go
@@ -1,0 +1,27 @@
+package nftables
+
+// lo0CounterPrefix namespaces every named counter object attached to a kernel
+// lo0 input-filter rule (the `inet xpf_lo0` table) so the object is recognizably
+// xpf-managed and always begins with a letter. A bare nft identifier may not
+// start with a digit, but a Junos firewall-filter `then count <name>` may, so
+// the prefix also guarantees the declaration parses (#3445).
+const lo0CounterPrefix = "xpflo0_"
+
+// Lo0CounterName returns the nft named-counter object name that mirrors a
+// firewall-filter term's `then count <name>` modifier onto the kernel lo0 input
+// chain (#3445). The Junos counter name is passed through sanitizeNftIdent so
+// the result is a valid BARE nft identifier — the counter DECLARATION
+// (`counter <n> { }`) must be unquoted, which nft v1.1.6 requires (a quoted
+// declaration is a hard syntax error, #3578) — and prefixed so it can never
+// begin with a digit. The same string is referenced (quoted, `counter name
+// "<n>"`) on the rule, so declaration and reference match byte-for-byte.
+//
+// Two Junos count names that differ only in bytes outside [A-Za-z0-9_.-] (rare;
+// Junos count names are normally bare) sanitize to the same object and their
+// kernel counts merge. That is a counting artifact ONLY: the lo0 verdict rules
+// are independent of the counter object, so no forwarding or verdict effect can
+// change. Without sanitization an exotic name would make the whole atomic lo0
+// table fail to load, so the lossy name is strictly better than no mirror.
+func Lo0CounterName(name string) string {
+	return lo0CounterPrefix + sanitizeNftIdent(name)
+}


### PR DESCRIPTION
## Summary

Closes #3445.

The lo0.0 input filter is mirrored onto a kernel nftables chain
(`inet xpf_lo0`). Ordinary host-bound traffic is shunted to the Linux
kernel by the XDP shim before it reaches userspace-dp, so that chain is
the **PRIMARY** enforcement of the lo0 filter for host traffic.
`nftRuleFromTerm` emitted only match predicates + a terminal verdict and
read only `term.Action`, so every non-terminating `then` modifier the
compiler parses and userspace honors was **silently dropped** from the
kernel mirror, and `reject` was lowered as a bare nft `reject` that
diverged from the userspace reply synthesis (codex audit 094
M02-M07/H10). This defines and implements an **explicit per-modifier
support policy** — honor what nft can, warn (never silently drop) what it
can't.

## Per-modifier decision

| Modifier | Decision | nft lowering / rationale |
|---|---|---|
| `then log` / `then syslog` (M02) | **honor in nft** | `log prefix "xpf-lo0 <term>: "` (to journald) |
| `then count <name>` (M03) | **honor in nft** | NAMED nft `counter` (declared once in the table body; `nftables.Lo0CounterName` sanitizes+prefixes to a bare-safe `xpflo0_*` id, unquoted-decl/quoted-ref per #3578) |
| `then policer` (M04) | **warn** | a Junos bandwidth+burst token bucket with a configurable then-action; nft `limit` cannot reproduce the rate mapping or the loss-priority action |
| `then dscp` rewrite (M05) | **warn** | egress CoS rewrite is meaningless for locally-delivered host-bound traffic |
| `then forwarding-class` (M06) | **warn** | egress CoS selection is meaningless for locally-delivered host-bound traffic |
| `then loss-priority` (M07) | **warn (pre-existing)** | already reported globally inert by `validateFilterLossPriorityWarnings` (#2507), which subsumes the mirror gap |
| `reject` (H10) | **faithful 2-rule lowering** | `meta l4proto 6 ... reject with tcp reset` then family-agnostic `reject with icmpx type admin-prohibited` — mirrors userspace `poll_descriptor/reject_reply.rs` (TCP RST for TCP, ICMP/ICMPv6 admin-prohibited otherwise). The pre-fix bare `reject` sent ICMP port-unreachable for ALL protocols incl. TCP. |

The warn cases go through the new `config.validateLo0FilterKernelMirrorWarnings`
(wired into `ValidateConfig`, surfaced at commit), **scoped to the lo0 input
filter only**, naming family/filter/term/modifier. WARN-only — these are valid
Junos and a hard reject would brick a boot on a previously-committed config;
userspace stays authoritative for whatever lo0-filtered traffic reaches the XSK.

## Implementation notes

- `nftRuleFromTerm` -> `nftRulesFromTerm` returning `[]string` (a term now
  lowers to 0, 1, or 2 rules). A fall-through modifier-only term emits its
  honored modifiers as a **non-terminating** rule (no verdict) so log/count
  fire while later discard/reject terms stay reachable (#3427 preserved).
- The lo0 payload switches from the `flush table` idiom to the atomic
  `add table; delete table; table { ... }` idiom shared with the host-inbound
  table, because `flush` does not delete named counter objects (would collide
  on the next commit). The lo0 counters reset to zero on each rebuild — nothing
  scrapes them, no metric impact.

## Validation

- Every new nft construct validated with `nft -c -f -` (nftables v1.1.6): all
  parse (only the expected no-CAP_NET_ADMIN netlink error, never a syntax error).
- **RED-on-revert proven** for `then log`, `then count`, the faithful reject,
  and the commit warning (each fix reverted -> the matching test goes RED, then
  restored).
- `go test ./pkg/daemon/... ./pkg/config/... ./pkg/nftables/...` green;
  `go build ./pkg/... ./cmd/...` green; gofmt + go vet clean on changed files.

## Docs

- `pkg/daemon/README.md`: new "Non-terminating `then` modifier policy" bullet;
  updated #3427 fall-through bullet (modifier-only terms now emit a
  non-terminating rule; add/delete/recreate idiom).
- `docs/config-schema.md`: new #3445 subsection for the commit warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
