### PR TITLE
appid: nil-guard CatalogNames policy walk (fail closed, no panic)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-01 — #3622 appid CatalogNames nil-guards (fail-closed on tolerated config)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3622 — added nil-guards to `appid.CatalogNames` so a nil
+    `*config.ZonePairPolicies` entry or a nil `*config.Policy` entry (both
+    admitted by the tolerant-load path #1960) fails closed instead of
+    panicking the userspace app-catalog build. `runtime.go` now `continue`s
+    on `zpp == nil` in the `cfg.Security.Policies` loop and on `pol == nil`
+    in the `addPolicyApps` inner loop — matching the strict validation
+    walker (`compiler_validate_strict.go`), which already skips these nil
+    entries. Added `TestCatalogNamesNilEntriesFailClosed` (RED-on-revert:
+    reverting either guard makes the test's `recover()` re-raise the nil
+    deref → FAIL). Documented the nil-tolerance contract in
+    `pkg/appid/README.md`. Validation: `go test ./pkg/appid/...
+    ./pkg/config/...` green; `go build ./pkg/... ./cmd/...`, gofmt, go vet
+    clean.
+  - **File(s)**: pkg/appid/runtime.go, pkg/appid/runtime_test.go,
+    pkg/appid/README.md, _Log.md
+
 ## 2026-06-30 — #3605 static NAT: scope-differentiated rules coexist (Vec-per-key)
 
 - **Timestamp**: 2026-06-30

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -68,3 +68,10 @@ and resolves session display names from the dataplane's assigned `app_id`.
   runtime won't actually evaluate).
 - `CatalogNames` calls `config.ExpandApplicationSet` internally to
   flatten `application-set` aliases. Callers don't need to pre-expand.
+- `CatalogNames` is nil-tolerant on the policy walk (#3622): a nil
+  `*config.ZonePairPolicies` entry or a nil `*config.Policy` entry —
+  both admitted by the tolerant-load path (#1960) — is skipped rather
+  than dereferenced, so a partially-broken-but-tolerated config surfaces
+  a fail-closed result instead of panicking the app-catalog build. This
+  matches the strict validation walker (`compiler_validate_strict.go`),
+  which already `continue`s on the same nil entries.

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -57,6 +57,12 @@ func CatalogNames(cfg *config.Config, includeAll bool) ([]string, error) {
 
 	addPolicyApps := func(policies []*config.Policy) error {
 		for _, pol := range policies {
+			// #3622: a nil policy entry is admitted by the tolerant-load
+			// path (#1960) and must fail closed, not panic. Match the strict
+			// walker (compiler_validate_strict.go), which skips nil rules.
+			if pol == nil {
+				continue
+			}
 			for _, appName := range pol.Match.Applications {
 				if appName == "" || appName == "any" {
 					continue
@@ -78,6 +84,12 @@ func CatalogNames(cfg *config.Config, includeAll bool) ([]string, error) {
 	}
 
 	for _, zpp := range cfg.Security.Policies {
+		// #3622: a nil zone-pair entry is admitted by the tolerant-load
+		// path (#1960); skip it rather than deref zpp.Policies and panic.
+		// Matches the strict walker (compiler_validate_strict.go).
+		if zpp == nil {
+			continue
+		}
 		if err := addPolicyApps(zpp.Policies); err != nil {
 			return nil, err
 		}

--- a/pkg/appid/runtime_test.go
+++ b/pkg/appid/runtime_test.go
@@ -369,6 +369,58 @@ func TestBuildCatalogRejectsAppIDOverflow(t *testing.T) {
 	}
 }
 
+// TestCatalogNamesNilEntriesFailClosed is the #3622 RED-on-revert proof: a
+// config carrying a nil *ZonePairPolicies entry, a nil *Policy entry inside a
+// valid zone pair, and a nil *Policy entry in GlobalPolicies — all admitted by
+// the tolerant-load path (#1960) — must NOT panic CatalogNames. Before the
+// nil-guards in runtime.go this fixture panicked on the zpp.Policies /
+// pol.Match deref; the strict walker already skips these nil entries, and
+// CatalogNames must fail closed the same way. Reverting either guard turns this
+// test's recover() into a re-raise (the deferred t.Fatalf fires the panic
+// message), so it is RED-on-revert.
+func TestCatalogNamesNilEntriesFailClosed(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CatalogNames panicked on nil zone-pair/policy entries "+
+				"(must fail closed like the strict walker): %v", r)
+		}
+	}()
+
+	cfg := &config.Config{
+		Applications: config.ApplicationsConfig{
+			Applications: map[string]*config.Application{
+				"custom-web": {Name: "custom-web", Protocol: "tcp", DestinationPort: "8443"},
+			},
+		},
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{
+				nil, // nil zone-pair entry — must be skipped, not deref'd
+				{
+					Policies: []*config.Policy{
+						nil, // nil policy entry — must be skipped, not deref'd
+						{Match: config.PolicyMatch{Applications: []string{"custom-web"}}},
+					},
+				},
+			},
+			GlobalPolicies: []*config.Policy{
+				nil, // nil global-policy entry — must be skipped, not deref'd
+				{Match: config.PolicyMatch{Applications: []string{"junos-https"}}},
+			},
+		},
+	}
+
+	got, err := CatalogNames(cfg, false)
+	if err != nil {
+		t.Fatalf("CatalogNames() error = %v, want nil", err)
+	}
+	// The valid (non-nil) policy entries still resolve; the nil entries are
+	// silently skipped, so the surviving apps are exactly those two.
+	want := []string{"custom-web", "junos-https"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CatalogNames() = %v, want %v", got, want)
+	}
+}
+
 // catalogConfigWithNApps builds a config with n distinct TCP/80 applications,
 // each referenced by a single policy so CatalogNames(cfg, false) returns exactly
 // n names (AppID disabled keeps the catalog at the policy-referenced set rather


### PR DESCRIPTION
## Summary

Closes #3622.

`appid.CatalogNames` (`pkg/appid/runtime.go`) built the AppID catalog by ranging `cfg.Security.Policies` and their inner policies **without nil-guards**, so a nil `*config.ZonePairPolicies` entry (`zpp.Policies` deref) or a nil `*config.Policy` entry (`pol.Match` deref) **panicked** a runtime helper instead of failing closed. The tolerant-load path (#1960) intentionally admits partially-broken configs; a generated/lenient/test config producing a nil entry crashed the userspace app-catalog build rather than surfacing an actionable result.

## Fix

Match the strict validation walker (`compiler_validate_strict.go`, which already `continue`s on `zpp == nil` and `pol == nil`):

- `CatalogNames`: `if zpp == nil { continue }` in the `cfg.Security.Policies` loop.
- `addPolicyApps`: `if pol == nil { continue }` in the inner policy loop. `GlobalPolicies` routes through the same helper, so its nil entries are covered too.

## Test — RED on revert

`TestCatalogNamesNilEntriesFailClosed`: a fixture with a nil zone-pair entry, a nil policy entry, and a nil global-policy entry must return the two surviving apps with no error. Reverting either guard makes the test's `recover()` re-raise the nil deref → **FAIL**. Verified:

```
--- FAIL: TestCatalogNamesNilEntriesFailClosed (0.00s)
    runtime_test.go:384: CatalogNames panicked on nil zone-pair/policy entries
    (must fail closed like the strict walker): runtime error: invalid memory
    address or nil pointer dereference
```

## Validation

- `go test ./pkg/appid/... ./pkg/config/...` — green
- `go build ./pkg/... ./cmd/...` — clean
- `gofmt -l`, `go vet ./pkg/appid/...` — clean
- Documented the nil-tolerance contract in `pkg/appid/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi