### PR TITLE
userspace: snapshot summary policy_count counts RULES, not zone-pair sets (#3625)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-01 — #3625 snapshot summary policy_count counts RULES, not zone-pair sets
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3625 — `SnapshotSummary.PolicyCount` was
+    `len(cfg.Security.Policies)`, the number of zone-pair policy SETS, not
+    the number of enforced policy RULES. A config with one zone-pair set
+    holding N rules reported 1, and a global-only config (rules only in
+    `cfg.Security.GlobalPolicies`) reported 0 — a field named `policy_count`
+    that silently under-counted, hiding missing policy publication and
+    weakening cross-plane audits. FIX (Go-only; the Rust
+    `SnapshotSummary.policy_count` consumes the value unchanged, no wire
+    rename): derive `PolicyCount` from `len(policies)`, the built
+    `PolicyRuleSnapshot` slice, which `walkPolicyRuleSlots` populates with
+    one entry per configured rule across every zone-pair set plus global
+    policies (matching what `show security policies` iterates). Deriving it
+    from the built slice also makes the summary count equal the object
+    count the Rust plane decodes (folds L07 snapshot-integrity). RED-on-
+    revert test `TestSnapshotSummaryPolicyCountCountsRulesNotSets` (three
+    subtests): multi-rule-per-set (revert reports 1, want 3), global-only
+    (revert reports 0, want 2), mixed sets+global (revert reports 2, want
+    4); each also asserts `PolicyCount == len(snap.Policies)`. Validation:
+    `go test ./pkg/dataplane/userspace/... ./pkg/config/...` green;
+    `go build ./pkg/... ./cmd/...`, gofmt, go vet clean. No doc update —
+    no operator/protocol doc documents the SnapshotSummary field semantics;
+    the corrected contract is pinned in-code at builder.go.
+  - **File(s)**: pkg/dataplane/userspace/builder.go,
+    pkg/dataplane/userspace/manager_test.go, _Log.md
+
 ## 2026-07-01 — #3622 appid CatalogNames nil-guards (fail-closed on tolerated config)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -38,7 +38,6 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 			Userspace:     ucfg,
 		}, nil
 	}
-	policyCount := len(cfg.Security.Policies)
 	interfaces := buildInterfaceSnapshots(cfg)
 	// #2514: the address-book content-ID assignment and the policy
 	// snapshot builder (which consumes the same nameToID map) can return
@@ -116,7 +115,15 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 			DataplaneType:  cfg.System.DataplaneType,
 			InterfaceCount: len(cfg.Interfaces.Interfaces),
 			ZoneCount:      len(cfg.Security.Zones),
-			PolicyCount:    policyCount,
+			// #3625: PolicyCount is the total number of policy RULES the
+			// dataplane will enforce — one per built PolicyRuleSnapshot,
+			// spanning every zone-pair set's rules plus global policies.
+			// It was len(cfg.Security.Policies), the number of zone-pair
+			// policy SETS, so a global-only config reported 0 and a set
+			// holding N rules reported 1. Deriving it from the built
+			// `policies` slice also keeps the summary count equal to the
+			// object count the Rust plane decodes (snapshot-integrity).
+			PolicyCount:    len(policies),
 			SchedulerCount: len(cfg.Schedulers),
 			HAEnabled:      cfg.Chassis.Cluster != nil,
 		},

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2255,6 +2255,94 @@ func TestBuildSnapshotSummary(t *testing.T) {
 	}
 }
 
+// TestSnapshotSummaryPolicyCountCountsRulesNotSets pins the #3625 fix:
+// Summary.PolicyCount must reflect the number of enforced policy RULES,
+// not the number of zone-pair policy SETS.
+//
+// RED-on-revert: with the pre-#3625 policyCount := len(cfg.Security.Policies)
+//   - the multi-rule-per-set case reports 1 (one zone-pair set), want 3
+//   - the global-only case reports 0 (no zone-pair sets), want 2
+//
+// The invariant also equals len(snap.Policies), so the summary count never
+// drifts from the object count the Rust dataplane decodes (L07 integrity).
+func TestSnapshotSummaryPolicyCountCountsRulesNotSets(t *testing.T) {
+	mkPol := func(name string, action config.PolicyAction) *config.Policy {
+		return &config.Policy{
+			Name: name,
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: action,
+		}
+	}
+
+	t.Run("multiple rules in one zone-pair set", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.Policies = []*config.ZonePairPolicies{{
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Policies: []*config.Policy{
+				mkPol("r1", config.PolicyPermit),
+				mkPol("r2", config.PolicyPermit),
+				mkPol("r3", config.PolicyDeny),
+			},
+		}}
+		snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+		if err != nil {
+			t.Fatalf("buildSnapshot: %v", err)
+		}
+		if snap.Summary.PolicyCount != 3 {
+			t.Fatalf("PolicyCount = %d, want 3 (rules, not the single zone-pair set)", snap.Summary.PolicyCount)
+		}
+		if snap.Summary.PolicyCount != len(snap.Policies) {
+			t.Fatalf("PolicyCount = %d, want == len(Policies) = %d (summary must match decoded objects)",
+				snap.Summary.PolicyCount, len(snap.Policies))
+		}
+	})
+
+	t.Run("global-only config", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.GlobalPolicies = []*config.Policy{
+			mkPol("g1", config.PolicyPermit),
+			mkPol("g2", config.PolicyDeny),
+		}
+		snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+		if err != nil {
+			t.Fatalf("buildSnapshot: %v", err)
+		}
+		if snap.Summary.PolicyCount != 2 {
+			t.Fatalf("PolicyCount = %d, want 2 (global rules; zero zone-pair sets must not report 0)", snap.Summary.PolicyCount)
+		}
+		if snap.Summary.PolicyCount != len(snap.Policies) {
+			t.Fatalf("PolicyCount = %d, want == len(Policies) = %d (summary must match decoded objects)",
+				snap.Summary.PolicyCount, len(snap.Policies))
+		}
+	})
+
+	t.Run("mixed zone-pair sets and global", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Security.Policies = []*config.ZonePairPolicies{
+			{FromZone: "trust", ToZone: "untrust", Policies: []*config.Policy{mkPol("a1", config.PolicyPermit), mkPol("a2", config.PolicyDeny)}},
+			{FromZone: "dmz", ToZone: "untrust", Policies: []*config.Policy{mkPol("b1", config.PolicyPermit)}},
+		}
+		cfg.Security.GlobalPolicies = []*config.Policy{mkPol("g1", config.PolicyDeny)}
+		snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+		if err != nil {
+			t.Fatalf("buildSnapshot: %v", err)
+		}
+		// 2 + 1 zone-pair rules + 1 global rule = 4 (not 2 zone-pair sets).
+		if snap.Summary.PolicyCount != 4 {
+			t.Fatalf("PolicyCount = %d, want 4 (2+1 zone-pair rules + 1 global)", snap.Summary.PolicyCount)
+		}
+		if snap.Summary.PolicyCount != len(snap.Policies) {
+			t.Fatalf("PolicyCount = %d, want == len(Policies) = %d (summary must match decoded objects)",
+				snap.Summary.PolicyCount, len(snap.Policies))
+		}
+	})
+}
+
 func TestBuildSourceNATSnapshotsPopulatesPoolFields(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Security.NAT.AddressPersistent = true


### PR DESCRIPTION
## Summary

`SnapshotSummary.PolicyCount` (published as `policy_count` on the control-socket snapshot and decoded Rust-side as `SnapshotSummary.policy_count`) was computed as `len(cfg.Security.Policies)` in `pkg/dataplane/userspace/builder.go` — the number of zone-pair policy **SETS** (`ZonePairPolicies` entries), not the number of policy **rules** the dataplane enforces.

This under-counted two common config shapes:

- a zone-pair set holding N rules reported `1`
- a **global-only** config (rules only in `cfg.Security.GlobalPolicies`) reported `0`, even though effective global policies exist

A field named `policy_count` that actually means `zone_policy_set_count` hides missing policy publication and weakens cross-plane audits/telemetry.

## Fix

Go control plane only. Derive `PolicyCount` from `len(policies)`, the built `PolicyRuleSnapshot` slice. `walkPolicyRuleSlots` — the single source of truth for the runtime policy-ID namespace — emits exactly one snapshot per configured rule across every zone-pair set plus the global policies, which is the same set of rules `show security policies` iterates and what an operator expects.

Deriving the count from the built slice also keeps the summary count equal to the object count the Rust dataplane decodes (folds the **L07** snapshot-integrity concern). The Rust `SnapshotSummary.policy_count` consumes the value unchanged — no wire-contract rename.

## Corrected semantic

`policy_count` = total enforced policy **rules** = (sum of each zone-pair set's rules) + (global policies) = `len(snap.Policies)`.

## Test (RED on revert)

`TestSnapshotSummaryPolicyCountCountsRulesNotSets`, three subtests. Reverting to `len(cfg.Security.Policies)`:

| case | reverted (set count) | fixed (rule count) |
|------|----------------------|--------------------|
| multiple rules in one zone-pair set | 1 | **3** |
| global-only config | 0 | **2** |
| mixed sets + global | 2 | **4** |

Each subtest also asserts `PolicyCount == len(snap.Policies)` (summary matches decoded objects).

## Validation

- `go test ./pkg/dataplane/userspace/... ./pkg/config/...` green
- `go build ./pkg/... ./cmd/...`, `gofmt`, `go vet` clean

## Docs

No doc change — no operator/protocol doc documents the `SnapshotSummary` field semantics; the corrected contract is pinned in-code at `builder.go`.

Closes #3625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi