### PR TITLE
api/grpc: structured policy inventory exposes scheduler_name + inactive (#3624)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-01 — #3624 structured policy inventory exposes scheduler_name + inactive
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3624 — the structured policy inventory (REST
+    `PolicyInfo`/`PolicyRule`, gRPC `GetPolicies` `PolicyRule`) omitted a
+    policy's scheduler binding (`scheduler-name`) and its runtime scheduler
+    state. #3062 exposed both only on the human-readable TEXT policy-detail
+    surface (`State: inactive` + `Scheduler:` lines via
+    `policyDetailState` / `policyDetailStateSuffix`), so a structured audit
+    client displayed a time-gated, currently-dormant permit/deny as an
+    active allow/deny — the structured API disagreed with effective
+    dataplane behavior. FIX: added additive fields `scheduler_name` +
+    `inactive` to REST `PolicyRule` (JSON, both `omitempty`) and gRPC
+    `PolicyRule` (proto3 fields 19/20, regenerated with pinned
+    protoc-gen-go v1.36.11 + protoc-gen-go-grpc v1.6.1, no version bump).
+    Populated for zone-pair AND global policies from the EXISTING #3062
+    provider: `SchedulerName = rule.SchedulerName`;
+    `Inactive = haveSched && dpuserspace.PolicyInactive(rule.SchedulerName,
+    schedActive)` where the live state comes from
+    `Server.policySchedActiveFn` (REST) / `Server.policySchedulerActiveState`
+    (gRPC). Mirrors the text surface's FAIL-OPEN display: when live state
+    is unavailable, `inactive` stays false (unlike the fail-closed
+    match-policies simulator, #3414), keeping output bit-identical for
+    existing consumers. RED-on-revert tests (L10 gap): REST
+    `TestPoliciesHandlerExposesSchedulerBindingAndInactiveState` + gRPC
+    `TestGRPCGetPoliciesExposesSchedulerBindingAndInactiveState`, each with
+    inactive / active / state-unavailable subtests over zone-pair + global +
+    plain rules (plus REST omitempty-contract checks); blanking the
+    population makes `scheduler_name`/`inactive` go RED on both surfaces.
+    Validation: `go test ./pkg/api ./pkg/grpcapi ./pkg/config` green;
+    `go build ./pkg/... ./cmd/...`, gofmt, go vet (scoped) clean. Doc:
+    pkg/api/README.md policies bullet.
+  - **File(s)**: proto/xpf/v1/xpf.proto,
+    pkg/grpcapi/xpfv1/xpf.pb.go, pkg/api/types.go, pkg/api/security.go,
+    pkg/grpcapi/server_show_zones.go,
+    pkg/api/security_policy_scheduler_inventory_3624_test.go,
+    pkg/grpcapi/server_show_zones_scheduler_inventory_3624_test.go,
+    pkg/api/README.md, _Log.md
+
 ## 2026-07-01 — #3625 snapshot summary policy_count counts RULES, not zone-pair sets
 
 - **Timestamp**: 2026-07-01

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -60,7 +60,23 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     it, so a consumer joining an RT_FLOW event (`policy_id=0`) to the
     inventory found no row for the highest-priority rule. The gRPC
     `PolicyRule.policy_id` mirror is `optional uint32` (proto3 explicit
-    presence) for the same reason.
+    presence) for the same reason. Each rule also carries `scheduler_name`
+    and `inactive` (#3624) — the structured sibling of the #3062 TEXT
+    policy-detail surface (`State: inactive` + `Scheduler:` lines).
+    `scheduler_name` is the policy's configured `scheduler-name` (empty /
+    omitted for an always-on rule); `inactive` is true when the policy is
+    bound to a scheduler that is currently runtime-inactive — the dataplane
+    is skipping the rule right now. Both are populated for zone-pair AND
+    global policies from the same live-state provider the text surface uses
+    (`Server.policySchedActiveFn` / gRPC `policySchedulerActiveState`), and
+    like that surface they FAIL OPEN on the display: when live scheduler
+    state cannot be queried (accessor not wired, early boot, NoDataplane)
+    `inactive` stays false, so the output is unchanged for existing
+    consumers — this differs deliberately from the `match-policies`
+    simulator, which fails CLOSED (#3414). Without these an audit read a
+    time-gated, currently-dormant permit/deny as an active allow/deny, so
+    the structured API disagreed with effective dataplane behavior. The
+    gRPC mirror is `PolicyRule.scheduler_name` (19) / `inactive` (20).
   - `GET /api/v1/security/zones` enumerates security zones (`ZoneInfo`,
     types.go). The host-inbound admission set is surfaced distinctly
     (#3328): `host_inbound_configured` is the dataplane posture bit

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -131,6 +131,17 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 	// automation can join a policy_id back to a rule. The raw ordinal stays the
 	// counter handle below.
 	runtimeIDs := dpuserspace.RuntimePolicyIDs(cfg)
+	// #3624: live per-scheduler active-state, the same view the #3062 text
+	// policy-detail surface uses (cli_show_security.go / server_show_policies_
+	// text.go). haveSched gates the lookup: when the accessor is not wired or
+	// returns ok=false (early boot / NoDataplane) the inventory reports every
+	// rule active (inactive=false), matching the text surface's fail-open
+	// display rather than the fail-closed match-policies simulator (#3414).
+	var schedActive map[string]bool
+	var haveSched bool
+	if s.policySchedActiveFn != nil {
+		schedActive, haveSched = s.policySchedActiveFn()
+	}
 	var policySetID uint32
 	var result []PolicyInfo
 	for _, zpp := range cfg.Security.Policies {
@@ -175,6 +186,10 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				LogSessionClose:            rule.Log != nil && rule.Log.SessionClose,
 				PolicyID:                   dpuserspace.RuntimePolicyIndex(runtimeIDs, policySetID, uint32(i)),
 				RuleID:                     dpuserspace.StablePolicyRuleID(zpp.FromZone, zpp.ToZone, rule.Name),
+				// #3624: scheduler binding + runtime scheduler state, mirroring
+				// the #3062 text detail (Scheduler: line + State: inactive).
+				SchedulerName: rule.SchedulerName,
+				Inactive:      haveSched && dpuserspace.PolicyInactive(rule.SchedulerName, schedActive),
 			}
 			if pr.SrcAddresses == nil {
 				pr.SrcAddresses = []string{}
@@ -259,6 +274,9 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 				LogSessionClose:            rule.Log != nil && rule.Log.SessionClose,
 				PolicyID:                   dpuserspace.RuntimePolicyIndex(runtimeIDs, policySetID, uint32(i)),
 				RuleID:                     dpuserspace.StablePolicyRuleID("junos-global", "junos-global", rule.Name),
+				// #3624: scheduler binding + runtime scheduler state (see above).
+				SchedulerName: rule.SchedulerName,
+				Inactive:      haveSched && dpuserspace.PolicyInactive(rule.SchedulerName, schedActive),
 			}
 			if pr.SrcAddresses == nil {
 				pr.SrcAddresses = []string{}

--- a/pkg/api/security_policy_scheduler_inventory_3624_test.go
+++ b/pkg/api/security_policy_scheduler_inventory_3624_test.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3624: the REST security policy inventory (policiesHandler) dropped a policy's
+// scheduler binding (scheduler-name) and its runtime scheduler state. #3062
+// exposed both only on the human-readable TEXT policy-detail surface, so a
+// structured audit client reading /security/policies could not tell that a
+// permit/deny rule is time-gated, nor that it is currently runtime-inactive —
+// it displayed a dormant rule as an active allow/deny. PolicyRule now carries
+// scheduler_name + inactive, populated for zone-pair AND global policies from
+// the same #3062 provider (Server.policySchedActiveFn). These are the
+// fail-on-revert guards: drop the population in security.go and the assertions
+// below go RED.
+
+// schedInventoryAPIStore builds a config with a scheduled zone-pair permit
+// (bound to "workhours"), a plain always-on zone-pair permit, and a scheduled
+// global permit (also "workhours").
+func schedInventoryAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy sched-off {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+                scheduler-name workhours;
+            }
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        global {
+            policy g-sched-off {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// restInventoryRules issues GET /security/policies against s and returns the
+// rules indexed by name plus the raw per-rule JSON objects (for the omitempty
+// contract check).
+func restInventoryRules(t *testing.T, s *Server) (map[string]PolicyRule, map[string]map[string]json.RawMessage) {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Success bool         `json:"success"`
+		Data    []PolicyInfo `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	rules := map[string]PolicyRule{}
+	for _, pi := range resp.Data {
+		for _, r := range pi.Rules {
+			rules[r.Name] = r
+		}
+	}
+	var raw struct {
+		Data []struct {
+			Rules []map[string]json.RawMessage `json:"rules"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw response: %v", err)
+	}
+	rawByName := map[string]map[string]json.RawMessage{}
+	for _, pi := range raw.Data {
+		for _, r := range pi.Rules {
+			name := ""
+			_ = json.Unmarshal(r["name"], &name)
+			rawByName[name] = r
+		}
+	}
+	return rules, rawByName
+}
+
+func TestPoliciesHandlerExposesSchedulerBindingAndInactiveState(t *testing.T) {
+	store := schedInventoryAPIStore(t)
+
+	// Case A: live scheduler state present and the scheduler is INACTIVE. The
+	// scheduled zone-pair AND global rules must report their binding and be
+	// marked inactive; the plain rule stays active with no binding.
+	t.Run("scheduler inactive -> scheduler_name + inactive=true", func(t *testing.T) {
+		s := &Server{store: store}
+		s.policySchedActiveFn = func() (map[string]bool, bool) {
+			return map[string]bool{"workhours": false}, true
+		}
+		rules, raw := restInventoryRules(t, s)
+
+		so, ok := rules["sched-off"]
+		if !ok {
+			t.Fatalf("sched-off missing from REST inventory")
+		}
+		if so.SchedulerName != "workhours" {
+			t.Fatalf("sched-off scheduler_name = %q, want %q (REST dropped the scheduler binding — #3624 regression)",
+				so.SchedulerName, "workhours")
+		}
+		if !so.Inactive {
+			t.Fatalf("sched-off inactive = false, want true (scheduler inactive; REST dropped runtime state — #3624 regression)")
+		}
+
+		gso, ok := rules["g-sched-off"]
+		if !ok {
+			t.Fatalf("g-sched-off missing from REST inventory")
+		}
+		if gso.SchedulerName != "workhours" || !gso.Inactive {
+			t.Fatalf("g-sched-off scheduler_name=%q inactive=%v, want workhours/true (global path not plumbed — #3624)",
+				gso.SchedulerName, gso.Inactive)
+		}
+
+		pl, ok := rules["plain-allow"]
+		if !ok {
+			t.Fatalf("plain-allow missing from REST inventory")
+		}
+		if pl.SchedulerName != "" || pl.Inactive {
+			t.Fatalf("plain-allow scheduler_name=%q inactive=%v, want empty/false (unscheduled rule must not gain state)",
+				pl.SchedulerName, pl.Inactive)
+		}
+
+		// omitempty contract: the unscheduled rule must serialize neither key.
+		for _, k := range []string{"scheduler_name", "inactive"} {
+			if _, present := raw["plain-allow"][k]; present {
+				t.Fatalf("plain-allow serialized %q for an unset field; want omitted", k)
+			}
+		}
+		// The inactive scheduled rule must serialize both keys.
+		if _, present := raw["sched-off"]["scheduler_name"]; !present {
+			t.Fatalf("sched-off did not serialize scheduler_name")
+		}
+		if _, present := raw["sched-off"]["inactive"]; !present {
+			t.Fatalf("sched-off did not serialize inactive (true value must not be omitted)")
+		}
+	})
+
+	// Case B (positive control): scheduler ACTIVE -> binding still reported,
+	// inactive=false (omitted). Guards against over-marking every scheduled
+	// rule inactive.
+	t.Run("scheduler active -> scheduler_name kept, inactive=false", func(t *testing.T) {
+		s := &Server{store: store}
+		s.policySchedActiveFn = func() (map[string]bool, bool) {
+			return map[string]bool{"workhours": true}, true
+		}
+		rules, raw := restInventoryRules(t, s)
+		so := rules["sched-off"]
+		if so.SchedulerName != "workhours" {
+			t.Fatalf("sched-off scheduler_name = %q, want %q", so.SchedulerName, "workhours")
+		}
+		if so.Inactive {
+			t.Fatalf("sched-off inactive = true, want false (scheduler active)")
+		}
+		if _, present := raw["sched-off"]["inactive"]; present {
+			t.Fatalf("sched-off serialized inactive=false; want omitted (omitempty)")
+		}
+	})
+
+	// Case C (fail-open display): no live state (accessor not wired) -> the
+	// binding is still reported (config-derived) but inactive stays false,
+	// matching the #3062 text surface's fail-open display (State: enabled) and
+	// keeping the output bit-identical for existing consumers.
+	t.Run("state unavailable -> scheduler_name kept, inactive=false", func(t *testing.T) {
+		s := &Server{store: store}
+		rules := map[string]PolicyRule{}
+		got, _ := restInventoryRules(t, s)
+		for k, v := range got {
+			rules[k] = v
+		}
+		so := rules["sched-off"]
+		if so.SchedulerName != "workhours" {
+			t.Fatalf("sched-off scheduler_name = %q, want %q (binding is config-derived, always reported)",
+				so.SchedulerName, "workhours")
+		}
+		if so.Inactive {
+			t.Fatalf("sched-off inactive = true, want false (state unavailable must fail open on the DISPLAY surface)")
+		}
+	})
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -187,6 +187,21 @@ type PolicyRule struct {
 	// inventory always sets PolicyID, so it is always emitted (including 0).
 	PolicyID uint32 `json:"policy_id"`
 	RuleID   string `json:"rule_id,omitempty"`
+	// SchedulerName / Inactive expose the policy's scheduler binding and its
+	// runtime scheduler state (#3624), the structured sibling of the #3062
+	// TEXT policy-detail surface (State: inactive + Scheduler: lines).
+	// SchedulerName is the configured `scheduler-name` (empty for an
+	// always-on rule). Inactive is true when the policy is bound to a
+	// scheduler that is currently runtime-inactive — the dataplane is
+	// skipping the rule right now — mirroring the text "State: inactive"
+	// token. Without these an audit reads a time-gated, currently-dormant
+	// permit/deny as an active allow/deny, disagreeing with effective
+	// dataplane behavior. Both omitempty: empty/false for the common
+	// always-on rule, and (like the text surface) Inactive stays false when
+	// live scheduler state cannot be queried, so existing consumers see no
+	// change.
+	SchedulerName string `json:"scheduler_name,omitempty"`
+	Inactive      bool   `json:"inactive,omitempty"`
 }
 
 // SessionEntry holds a single session table entry.

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -119,6 +119,13 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 	// automation can join a policy_id back to a rule. The raw ordinal stays the
 	// counter handle below.
 	runtimeIDs := dpuserspace.RuntimePolicyIDs(cfg)
+	// #3624: live per-scheduler active-state, the same view the #3062 text
+	// policy-detail surface uses (server_show_policies_text.go). haveSched
+	// gates the lookup: when the provider is unavailable (early boot /
+	// NoDataplane) the inventory reports every rule active (inactive=false),
+	// matching the text surface's fail-open display rather than the
+	// fail-closed match-policies simulator (#3414).
+	schedActive, haveSched := s.policySchedulerActiveState()
 	var policySetID uint32
 	for _, zpp := range cfg.Security.Policies {
 		// #3476: skip a nil zone-pair set (tolerant / HA-sync path) while
@@ -164,6 +171,10 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				// the join key survives even at 0.
 				PolicyId: proto.Uint32(dpuserspace.RuntimePolicyIndex(runtimeIDs, policySetID, uint32(i))),
 				RuleId:   dpuserspace.StablePolicyRuleID(zpp.FromZone, zpp.ToZone, rule.Name),
+				// #3624: scheduler binding + runtime scheduler state, mirroring
+				// the #3062 text detail (State: inactive, Scheduler: <name>).
+				SchedulerName: rule.SchedulerName,
+				Inactive:      haveSched && dpuserspace.PolicyInactive(rule.SchedulerName, schedActive),
 			}
 			if pr.SrcAddresses == nil {
 				pr.SrcAddresses = []string{}
@@ -233,6 +244,9 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 				// #3623: proto3 explicit presence for the runtime id (see above).
 				PolicyId: proto.Uint32(dpuserspace.RuntimePolicyIndex(runtimeIDs, policySetID, uint32(i))),
 				RuleId:   dpuserspace.StablePolicyRuleID("junos-global", "junos-global", rule.Name),
+				// #3624: scheduler binding + runtime scheduler state (see above).
+				SchedulerName: rule.SchedulerName,
+				Inactive:      haveSched && dpuserspace.PolicyInactive(rule.SchedulerName, schedActive),
 			}
 			if pr.SrcAddresses == nil {
 				pr.SrcAddresses = []string{}

--- a/pkg/grpcapi/server_show_zones_scheduler_inventory_3624_test.go
+++ b/pkg/grpcapi/server_show_zones_scheduler_inventory_3624_test.go
@@ -1,0 +1,110 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3624: the gRPC structured policy inventory (GetPolicies / PolicyRule) dropped
+// a policy's scheduler binding (scheduler_name) and its runtime scheduler state
+// (inactive). #3062 exposed both only on the human-readable TEXT policy-detail
+// surface (server_show_policies_text.go), so a structured audit client driving
+// GetPolicies could not tell that a permit/deny rule is time-gated, nor that it
+// is currently runtime-inactive — it displayed a dormant rule as an active
+// allow/deny. PolicyRule now carries scheduler_name + inactive, populated for
+// zone-pair AND global policies from the same provider the text surface uses
+// (Server.policySchedulerActiveState). These are the fail-on-revert guards:
+// drop the population in server_show_zones.go (GetPolicies) and the assertions
+// below go RED.
+//
+// The store harness (schedulerPolicyServer) is shared with the #3062 text-detail
+// test: sched-off (scheduled zone-pair permit, "workhours"), plain-allow (plain
+// permit), g-sched-off (scheduled global permit, "workhours").
+
+func grpcInventoryRules(t *testing.T, s *Server) map[string]*pb.PolicyRule {
+	t.Helper()
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+	rules := map[string]*pb.PolicyRule{}
+	for _, pi := range resp.GetPolicies() {
+		for _, r := range pi.GetRules() {
+			rules[r.GetName()] = r
+		}
+	}
+	return rules
+}
+
+func TestGRPCGetPoliciesExposesSchedulerBindingAndInactiveState(t *testing.T) {
+	// Case A: live scheduler state present and INACTIVE. Scheduled zone-pair AND
+	// global rules report their binding and are marked inactive; the plain rule
+	// stays active with no binding.
+	t.Run("scheduler inactive -> scheduler_name + inactive=true", func(t *testing.T) {
+		s := schedulerPolicyServer(t, map[string]bool{"workhours": false}, true)
+		rules := grpcInventoryRules(t, s)
+
+		so := rules["sched-off"]
+		if so == nil {
+			t.Fatalf("sched-off missing from gRPC inventory")
+		}
+		if so.GetSchedulerName() != "workhours" {
+			t.Fatalf("sched-off scheduler_name = %q, want %q (gRPC dropped the scheduler binding — #3624 regression)",
+				so.GetSchedulerName(), "workhours")
+		}
+		if !so.GetInactive() {
+			t.Fatalf("sched-off inactive = false, want true (scheduler inactive; gRPC dropped runtime state — #3624 regression)")
+		}
+
+		gso := rules["g-sched-off"]
+		if gso == nil {
+			t.Fatalf("g-sched-off missing from gRPC inventory")
+		}
+		if gso.GetSchedulerName() != "workhours" || !gso.GetInactive() {
+			t.Fatalf("g-sched-off scheduler_name=%q inactive=%v, want workhours/true (global path not plumbed — #3624)",
+				gso.GetSchedulerName(), gso.GetInactive())
+		}
+
+		pl := rules["plain-allow"]
+		if pl == nil {
+			t.Fatalf("plain-allow missing from gRPC inventory")
+		}
+		if pl.GetSchedulerName() != "" || pl.GetInactive() {
+			t.Fatalf("plain-allow scheduler_name=%q inactive=%v, want empty/false (unscheduled rule must not gain state)",
+				pl.GetSchedulerName(), pl.GetInactive())
+		}
+	})
+
+	// Case B (positive control): scheduler ACTIVE -> binding reported,
+	// inactive=false. Guards against over-marking every scheduled rule inactive.
+	t.Run("scheduler active -> scheduler_name kept, inactive=false", func(t *testing.T) {
+		s := schedulerPolicyServer(t, map[string]bool{"workhours": true}, true)
+		rules := grpcInventoryRules(t, s)
+		so := rules["sched-off"]
+		if so.GetSchedulerName() != "workhours" {
+			t.Fatalf("sched-off scheduler_name = %q, want %q", so.GetSchedulerName(), "workhours")
+		}
+		if so.GetInactive() {
+			t.Fatalf("sched-off inactive = true, want false (scheduler active)")
+		}
+	})
+
+	// Case C (fail-open display): no provider -> binding still reported
+	// (config-derived) but inactive stays false, matching the #3062 text
+	// surface's fail-open display and keeping the output unchanged for existing
+	// consumers.
+	t.Run("no provider -> scheduler_name kept, inactive=false", func(t *testing.T) {
+		s := schedulerPolicyServer(t, nil, false)
+		rules := grpcInventoryRules(t, s)
+		so := rules["sched-off"]
+		if so.GetSchedulerName() != "workhours" {
+			t.Fatalf("sched-off scheduler_name = %q, want %q (binding is config-derived, always reported)",
+				so.GetSchedulerName(), "workhours")
+		}
+		if so.GetInactive() {
+			t.Fatalf("sched-off inactive = true, want false (no provider must fail open on the DISPLAY surface)")
+		}
+	})
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -2329,8 +2329,21 @@ type PolicyRule struct {
 	// distinguish "first policy, id 0" from "field unset" and dropped the join
 	// key for the highest-priority rule. `optional` restores presence: the
 	// inventory always sets policy_id, so it is always present (even at 0).
-	PolicyId      *uint32 `protobuf:"varint,17,opt,name=policy_id,json=policyId,proto3,oneof" json:"policy_id,omitempty"`
-	RuleId        string  `protobuf:"bytes,18,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	PolicyId *uint32 `protobuf:"varint,17,opt,name=policy_id,json=policyId,proto3,oneof" json:"policy_id,omitempty"`
+	RuleId   string  `protobuf:"bytes,18,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	// #3624: scheduler binding + runtime scheduler state, the structured
+	// sibling of the #3062 TEXT policy-detail surface. scheduler_name is the
+	// policy's configured `scheduler-name` (Junos scheduled policy); empty for
+	// an always-on rule. inactive is true when the policy is bound to a
+	// scheduler that is currently runtime-inactive, i.e. the dataplane is
+	// skipping the rule right now (mirrors the text "State: inactive" token).
+	// Without these a structured audit reads a time-gated, currently-dormant
+	// permit/deny as an active allow/deny, disagreeing with effective dataplane
+	// behavior. Both are additive; empty/false for the common always-on rule
+	// and (like the text surface) inactive stays false when live scheduler
+	// state cannot be queried, so the output is unchanged for existing clients.
+	SchedulerName string `protobuf:"bytes,19,opt,name=scheduler_name,json=schedulerName,proto3" json:"scheduler_name,omitempty"`
+	Inactive      bool   `protobuf:"varint,20,opt,name=inactive,proto3" json:"inactive,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2489,6 +2502,20 @@ func (x *PolicyRule) GetRuleId() string {
 		return x.RuleId
 	}
 	return ""
+}
+
+func (x *PolicyRule) GetSchedulerName() string {
+	if x != nil {
+		return x.SchedulerName
+	}
+	return ""
+}
+
+func (x *PolicyRule) GetInactive() bool {
+	if x != nil {
+		return x.Inactive
+	}
+	return false
 }
 
 type GetSessionsRequest struct {
@@ -7776,7 +7803,7 @@ const file_xpf_proto_rawDesc = "" +
 	"PolicyInfo\x12\x1b\n" +
 	"\tfrom_zone\x18\x01 \x01(\tR\bfromZone\x12\x17\n" +
 	"\ato_zone\x18\x02 \x01(\tR\x06toZone\x12(\n" +
-	"\x05rules\x18\x03 \x03(\v2\x12.xpf.v1.PolicyRuleR\x05rules\"\x93\x05\n" +
+	"\x05rules\x18\x03 \x03(\v2\x12.xpf.v1.PolicyRuleR\x05rules\"\xd6\x05\n" +
 	"\n" +
 	"PolicyRule\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
@@ -7798,7 +7825,9 @@ const file_xpf_proto_rawDesc = "" +
 	"\x10log_session_init\x18\x0f \x01(\bR\x0elogSessionInit\x12*\n" +
 	"\x11log_session_close\x18\x10 \x01(\bR\x0flogSessionClose\x12 \n" +
 	"\tpolicy_id\x18\x11 \x01(\rH\x00R\bpolicyId\x88\x01\x01\x12\x17\n" +
-	"\arule_id\x18\x12 \x01(\tR\x06ruleIdB\f\n" +
+	"\arule_id\x18\x12 \x01(\tR\x06ruleId\x12%\n" +
+	"\x0escheduler_name\x18\x13 \x01(\tR\rschedulerName\x12\x1a\n" +
+	"\binactive\x18\x14 \x01(\bR\binactiveB\f\n" +
 	"\n" +
 	"_policy_id\"\x9e\x04\n" +
 	"\x12GetSessionsRequest\x12\x14\n" +

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -318,6 +318,19 @@ message PolicyRule {
   // inventory always sets policy_id, so it is always present (even at 0).
   optional uint32 policy_id = 17;
   string rule_id = 18;
+  // #3624: scheduler binding + runtime scheduler state, the structured
+  // sibling of the #3062 TEXT policy-detail surface. scheduler_name is the
+  // policy's configured `scheduler-name` (Junos scheduled policy); empty for
+  // an always-on rule. inactive is true when the policy is bound to a
+  // scheduler that is currently runtime-inactive, i.e. the dataplane is
+  // skipping the rule right now (mirrors the text "State: inactive" token).
+  // Without these a structured audit reads a time-gated, currently-dormant
+  // permit/deny as an active allow/deny, disagreeing with effective dataplane
+  // behavior. Both are additive; empty/false for the common always-on rule
+  // and (like the text surface) inactive stays false when live scheduler
+  // state cannot be queried, so the output is unchanged for existing clients.
+  string scheduler_name = 19;
+  bool inactive = 20;
 }
 
 message GetSessionsRequest {


### PR DESCRIPTION
## Summary

Closes #3624.

The structured policy inventory (REST `PolicyInfo`/`PolicyRule`, gRPC
`GetPolicies` `PolicyRule`) omitted a policy's scheduler binding
(`scheduler-name`) and its runtime scheduler state. #3062 exposed both
only on the human-readable TEXT policy-detail surface (`State: inactive`
+ `Scheduler:` lines). A structured audit / automation client therefore
could not tell that a permit/deny rule is time-gated, nor that it is
currently runtime-inactive — it displayed a dormant rule as an active
allow/deny, so the structured API disagreed with effective dataplane
behavior (folds H07 scheduler_name omitted, H08 inactive state omitted,
L10 no scheduler API test).

## Changes

- **proto** (`proto/xpf/v1/xpf.proto`): add additive `PolicyRule` fields
  `scheduler_name = 19` and `inactive = 20` (new field numbers, no
  renumber). Regenerated with the pinned `protoc-gen-go v1.36.11` +
  `protoc-gen-go-grpc v1.6.1` (no version bump).
- **REST** (`pkg/api/types.go`): add `SchedulerName` / `Inactive` to
  `PolicyRule` (JSON, both `omitempty`).
- **population** (`pkg/api/security.go`, `pkg/grpcapi/server_show_zones.go`):
  populate both fields for zone-pair AND global policies from the
  EXISTING #3062 provider —
  `SchedulerName = rule.SchedulerName`,
  `Inactive = haveSched && dpuserspace.PolicyInactive(rule.SchedulerName, schedActive)`,
  where live state comes from `Server.policySchedActiveFn` (REST) /
  `Server.policySchedulerActiveState()` (gRPC).

### Fail-open display posture

Mirrors the #3062 text surface: when live scheduler state cannot be
queried (accessor not wired / early boot / NoDataplane) `inactive` stays
false, so output is bit-identical for existing consumers. This differs
deliberately from the `match-policies` simulator, which fails CLOSED
(#3414) — a diagnostic must not certify a scheduled permit the dataplane
is skipping, but the inventory is a display surface. `scheduler_name` is
config-derived so it is always reported. The synthetic implicit-default
row is untouched (not a scheduled policy).

## Tests (L10 — RED-on-revert)

- REST `TestPoliciesHandlerExposesSchedulerBindingAndInactiveState`
- gRPC `TestGRPCGetPoliciesExposesSchedulerBindingAndInactiveState`

Each has inactive / active / state-unavailable subtests over a scheduled
zone-pair permit + plain permit + scheduled global permit. The REST test
also asserts the omitempty JSON contract. Blanking the population makes
every `scheduler_name` assertion go RED on both surfaces (verified).

## Validation

- `go test ./pkg/api ./pkg/grpcapi ./pkg/config` — green
- `go build ./pkg/... ./cmd/...` — clean
- `gofmt` + `go vet` (scoped) — clean
- Doc: `pkg/api/README.md` policies bullet; `_Log.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
