### PR TITLE
appid: include NAT-only match-application refs in the runtime catalog

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-01 — #3626 appid catalog includes NAT-only match-application refs
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3626 — `appid.CatalogNames(cfg, false)` built the
+    compiled app catalog (application-identification DISABLED) by walking
+    ONLY security policy + global-policy `match application` references,
+    never source/destination-NAT rule `match application`. The strict
+    commit-time validator DOES walk NAT refs
+    (`compiler_validate_strict.go applicationsToValidateStrict`), so an app
+    referenced ONLY by a NAT rule validated fine but was omitted from the
+    runtime catalog — the dataplane could not resolve it and session
+    naming fell back to tuple/numeric. FIX: extended `CatalogNames` with a
+    NAT walk mirroring the strict validator (Source + Destination.RuleSets,
+    skip nil rule-sets/rules, scalar `rule.Match.Application`, static NAT
+    excluded); factored the per-reference resolution into one shared
+    `addAppRef` closure used by both the policy and NAT walks (L04).
+    Preserved the #3622 nil-guards and the appid-disabled footprint (only
+    genuinely-referenced apps, never `includeAll`). Added RED-on-revert
+    test `TestCatalogNamesIncludesNATOnlyAppRefs` and pinned the NAT parity
+    by adding a NAT-only reference to
+    `TestStrictValidationSetMatchesCatalogNames` (resolves the M02 unpinned
+    drift). Updated pkg/appid/README.md catalog-scope docs.
+  - **File(s)**: pkg/appid/runtime.go, pkg/appid/runtime_test.go,
+    pkg/appid/README.md, _Log.md
+
 ## 2026-07-01 — #3624 structured policy inventory exposes scheduler_name + inactive
 
 - **Timestamp**: 2026-07-01

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -9,9 +9,17 @@ and resolves session display names from the dataplane's assigned `app_id`.
 - `CatalogNames(cfg *config.Config, includeAll bool) ([]string, error)` — `runtime.go`.
   Returns the list of application names the compiler must lower
   into the `app_id` catalog. `includeAll=false` returns only
-  apps referenced by policies; `true` returns every defined app.
-  Returns an error if application-set expansion fails — callers must
-  handle it.
+  apps referenced by a security policy **or** a source/destination-NAT
+  rule's `match application` (#3626 — a NAT term consumes the referenced
+  app's port/proto too, so an app referenced ONLY by a NAT rule must
+  still be catalogued or the dataplane cannot resolve it and session
+  naming for that flow falls back to tuple/numeric); `true` returns every
+  defined app. The NAT walk mirrors the commit-time strict validator
+  (`config.applicationsToValidateStrict`) exactly — Source +
+  Destination.RuleSets, the scalar `rule.Match.Application`, static NAT
+  excluded (it carries no application match) — so the runtime catalog and
+  the strict gate agree on the referenced-app set. Returns an error if
+  application-set expansion fails — callers must handle it.
 - `BuildCatalog(cfg *config.Config) (Catalog, error)` — `catalog.go`.
   Returns the ordered application catalog: `Entries` (each carrying
   `AppID` + `(protocol, dst-port-range, src-port-range)` match rule)
@@ -67,7 +75,14 @@ and resolves session display names from the dataplane's assigned `app_id`.
   commit warning that flags policies relying on AppID matches that the
   runtime won't actually evaluate).
 - `CatalogNames` calls `config.ExpandApplicationSet` internally to
-  flatten `application-set` aliases. Callers don't need to pre-expand.
+  flatten `application-set` aliases (used for both policy and NAT
+  references). Callers don't need to pre-expand.
+- The policy walk and the NAT walk share ONE per-reference resolver
+  (`addAppRef`) inside `CatalogNames`, so the two reference paths cannot
+  diverge (#3626 L04). `TestStrictValidationSetMatchesCatalogNames`
+  pins the user-app subset of `CatalogNames(cfg, false)` to
+  `config.ApplicationsToValidateStrict` — its fixture now carries a
+  NAT-only reference so the parity covers the NAT walk too.
 - `CatalogNames` is nil-tolerant on the policy walk (#3622): a nil
   `*config.ZonePairPolicies` entry or a nil `*config.Policy` entry —
   both admitted by the tolerant-load path (#1960) — is skipped rather

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -55,6 +55,29 @@ func CatalogNames(cfg *config.Config, includeAll bool) ([]string, error) {
 		return sortedNames(names), nil
 	}
 
+	// addAppRef records one `match application` reference (from a security
+	// policy OR a NAT rule) into the catalog. An application-set is expanded to
+	// its members; a bare application name is recorded directly. "" / "any" is
+	// not a reference. This is the single per-reference resolver shared by the
+	// policy and NAT walks so the two paths cannot diverge (#3626 L04).
+	addAppRef := func(appName string) error {
+		if appName == "" || appName == "any" {
+			return nil
+		}
+		if _, isSet := cfg.Applications.ApplicationSets[appName]; isSet {
+			expanded, err := config.ExpandApplicationSet(appName, &cfg.Applications)
+			if err != nil {
+				return fmt.Errorf("expand application-set %q: %w", appName, err)
+			}
+			for _, expandedName := range expanded {
+				names[expandedName] = struct{}{}
+			}
+			return nil
+		}
+		names[appName] = struct{}{}
+		return nil
+	}
+
 	addPolicyApps := func(policies []*config.Policy) error {
 		for _, pol := range policies {
 			// #3622: a nil policy entry is admitted by the tolerant-load
@@ -64,20 +87,9 @@ func CatalogNames(cfg *config.Config, includeAll bool) ([]string, error) {
 				continue
 			}
 			for _, appName := range pol.Match.Applications {
-				if appName == "" || appName == "any" {
-					continue
+				if err := addAppRef(appName); err != nil {
+					return err
 				}
-				if _, isSet := cfg.Applications.ApplicationSets[appName]; isSet {
-					expanded, err := config.ExpandApplicationSet(appName, &cfg.Applications)
-					if err != nil {
-						return fmt.Errorf("expand application-set %q: %w", appName, err)
-					}
-					for _, expandedName := range expanded {
-						names[expandedName] = struct{}{}
-					}
-					continue
-				}
-				names[appName] = struct{}{}
 			}
 		}
 		return nil
@@ -96,6 +108,45 @@ func CatalogNames(cfg *config.Config, includeAll bool) ([]string, error) {
 	}
 	if err := addPolicyApps(cfg.Security.GlobalPolicies); err != nil {
 		return nil, err
+	}
+
+	// #3626: a source/destination-NAT rule's `match application <name>` also
+	// consumes the referenced app's port/proto (pkg/dataplane/userspace/nat.go
+	// appPortsFromSpec). An app referenced ONLY by a NAT rule — with no
+	// security policy referencing it — must still land in the compiled catalog,
+	// or the dataplane cannot resolve it and session naming for that flow falls
+	// back to tuple/numeric. Walk NAT rule references exactly as the strict
+	// validator does (compiler_validate_strict.go applicationsToValidateStrict:
+	// Source + Destination.RuleSets, skipping nil rule-sets/rules, the scalar
+	// rule.Match.Application) so the runtime catalog and the commit-time strict
+	// gate agree on the referenced-app set — TestStrictValidationSetMatches-
+	// CatalogNames pins the two walks together. Static NAT carries no
+	// application match, so only source and destination NAT are walked.
+	addNATRuleSet := func(rs *config.NATRuleSet) error {
+		if rs == nil {
+			return nil
+		}
+		for _, rule := range rs.Rules {
+			if rule == nil {
+				continue
+			}
+			if err := addAppRef(rule.Match.Application); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, rs := range cfg.Security.NAT.Source {
+		if err := addNATRuleSet(rs); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.Security.NAT.Destination != nil {
+		for _, rs := range cfg.Security.NAT.Destination.RuleSets {
+			if err := addNATRuleSet(rs); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return sortedNames(names), nil

--- a/pkg/appid/runtime_test.go
+++ b/pkg/appid/runtime_test.go
@@ -40,6 +40,67 @@ func TestCatalogNamesReferencedOnly(t *testing.T) {
 	}
 }
 
+// TestCatalogNamesIncludesNATOnlyAppRefs is the #3626 RED-on-revert proof.
+// With application-identification DISABLED, an application referenced ONLY by a
+// source- or destination-NAT rule's `match application` — with NO security
+// policy referencing it — must still land in the compiled catalog. Before the
+// fix CatalogNames walked only policies, so these apps were silently dropped
+// and the dataplane could not resolve them. Reverting the NAT walk in
+// CatalogNames turns this test RED (the NAT-only names disappear from the
+// result). It covers a direct source-NAT ref, a direct destination-NAT ref,
+// and a destination-NAT ref via an application-set (member expansion).
+func TestCatalogNamesIncludesNATOnlyAppRefs(t *testing.T) {
+	cfg := &config.Config{
+		Applications: config.ApplicationsConfig{
+			Applications: map[string]*config.Application{
+				"snat-app":   {Name: "snat-app", Protocol: "tcp", DestinationPort: "2222"},
+				"dnat-app":   {Name: "dnat-app", Protocol: "udp", DestinationPort: "3333"},
+				"set-member": {Name: "set-member", Protocol: "tcp", DestinationPort: "4444"},
+				"unused-app": {Name: "unused-app", Protocol: "tcp", DestinationPort: "9999"},
+			},
+			ApplicationSets: map[string]*config.ApplicationSet{
+				"nat-set": {Name: "nat-set", Applications: []string{"set-member"}},
+			},
+		},
+		Security: config.SecurityConfig{
+			NAT: config.NATConfig{
+				Source: []*config.NATRuleSet{
+					{Name: "srs", Rules: []*config.NATRule{
+						{Name: "sr1", Match: config.NATMatch{Application: "snat-app"}},
+						// nil rule must be skipped, not panic.
+						nil,
+					}},
+					// nil rule-set must be skipped, not panic.
+					nil,
+				},
+				Destination: &config.DestinationNATConfig{
+					RuleSets: []*config.NATRuleSet{
+						{Name: "drs", Rules: []*config.NATRule{
+							{Name: "dr1", Match: config.NATMatch{Application: "dnat-app"}},
+							{Name: "dr2", Match: config.NATMatch{Application: "nat-set"}},
+							// "any" / "" are not references.
+							{Name: "dr3", Match: config.NATMatch{Application: "any"}},
+							{Name: "dr4", Match: config.NATMatch{Application: ""}},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := CatalogNames(cfg, false)
+	if err != nil {
+		t.Fatalf("CatalogNames() error = %v", err)
+	}
+	// snat-app, dnat-app (direct NAT refs) and set-member (via nat-set) must be
+	// present; unused-app (referenced nowhere) and the "any"/"" pseudo-refs must
+	// not appear.
+	want := []string{"dnat-app", "set-member", "snat-app"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CatalogNames() = %v, want %v", got, want)
+	}
+}
+
 // TestStrictValidationSetMatchesCatalogNames is the #2185 drift guard
 // (independent review check #4). The compiler's commit-time strict-validation
 // walk (config.applicationsToValidateStrict, exposed as
@@ -52,11 +113,13 @@ func TestCatalogNamesReferencedOnly(t *testing.T) {
 // compiler copy, this fails — turning a silent commit-gate drift into a test
 // failure. It is a cross-check TEST, not a runtime coupling.
 //
-// Scope note (#2187): the strict walk also collects source/destination-NAT
-// `match application` references, which CatalogNames does not. This fixture
-// carries NO NAT rules, so the two walks still coincide here. Adding a NAT
-// reference to this fixture would (correctly) break the equality — the
-// NAT-reference path is exercised by the compiler-package tests instead.
+// Scope note (#2187 / #3626): the strict walk collects source/destination-NAT
+// `match application` references AND — since #3626 — so does CatalogNames. The
+// fixture now carries a NAT-only user-app reference ("nat-app", referenced by a
+// destination-NAT rule and by NO security policy) so the equality PINS the NAT
+// walk too: before #3626 CatalogNames dropped nat-app and this equality broke;
+// after #3626 both walks include it. The compiler-package tests exercise the
+// commit-gate side of the same NAT reference.
 func TestStrictValidationSetMatchesCatalogNames(t *testing.T) {
 	cfg := &config.Config{
 		Applications: config.ApplicationsConfig{
@@ -65,6 +128,8 @@ func TestStrictValidationSetMatchesCatalogNames(t *testing.T) {
 				"direct-app": {Name: "direct-app", Protocol: "tcp", DestinationPort: "8443"},
 				// referenced only via an application-set
 				"set-app": {Name: "set-app", Protocol: "udp", DestinationPort: "1234"},
+				// referenced ONLY by a destination-NAT rule (#3626)
+				"nat-app": {Name: "nat-app", Protocol: "tcp", DestinationPort: "2222"},
 				// not referenced anywhere — must appear in NEITHER walk
 				"unref-app": {Name: "unref-app", Protocol: "tcp", DestinationPort: "9000"},
 			},
@@ -81,6 +146,15 @@ func TestStrictValidationSetMatchesCatalogNames(t *testing.T) {
 					Policies: []*config.Policy{
 						{Match: config.PolicyMatch{Applications: []string{"direct-app"}}},
 						{Match: config.PolicyMatch{Applications: []string{"web-set"}}},
+					},
+				},
+			},
+			NAT: config.NATConfig{
+				Destination: &config.DestinationNATConfig{
+					RuleSets: []*config.NATRuleSet{
+						{Name: "rs", Rules: []*config.NATRule{
+							{Name: "r1", Match: config.NATMatch{Application: "nat-app"}},
+						}},
 					},
 				},
 			},
@@ -111,8 +185,14 @@ func TestStrictValidationSetMatchesCatalogNames(t *testing.T) {
 	if _, ok := strict["unref-app"]; ok {
 		t.Fatal("unreferenced app must not be in the strict-validation set")
 	}
-	if len(strict) != 2 {
-		t.Fatalf("expected exactly {direct-app, set-app} in strict set, got %v", sortedKeys(strict))
+	// nat-app is referenced ONLY by the destination-NAT rule; both walks must
+	// carry it (#3626). Before the fix CatalogNames omitted it and the
+	// DeepEqual above failed.
+	if _, ok := strict["nat-app"]; !ok {
+		t.Fatal("NAT-only app reference must be in the strict-validation set")
+	}
+	if len(strict) != 3 {
+		t.Fatalf("expected exactly {direct-app, nat-app, set-app} in strict set, got %v", sortedKeys(strict))
 	}
 }
 


### PR DESCRIPTION
Closes #3626

## Problem

When `application-identification` is disabled, `appid.CatalogNames(cfg, false)` (`pkg/appid/runtime.go`) built the compiled app catalog by walking ONLY security-policy and global-policy `match application` references (`addPolicyApps`). It never walked source/destination-NAT rule `match application` references. The strict commit-time validator DOES walk them (`pkg/config/compiler_validate_strict.go` `applicationsToValidateStrict`: `NAT.Source` + `NAT.Destination.RuleSets`, `addRef(rule.Match.Application)`).

So a config whose only reference to an application is a source/destination-NAT `match application` — with no security policy referencing it — validated fine but left that app out of the runtime catalog. The dataplane could not resolve it and session naming for that flow fell back to tuple/numeric.

## Fix

Extend `CatalogNames` to also collect NAT rule `match application` refs:

- Factored the per-reference resolution (application-set expansion vs a bare app name; `""`/`any` skipped) into one `addAppRef` closure now shared by both the policy walk and the NAT walk, so the two paths cannot diverge (L04).
- The NAT walk mirrors the strict validator's traversal exactly: `NAT.Source` + `NAT.Destination.RuleSets`, skipping nil rule-sets/rules, the scalar `rule.Match.Application`. Static NAT carries no application match and is not walked.
- Preserved the #3622 nil-guards and the appid-disabled footprint semantics (only genuinely-referenced apps, never the `includeAll` set — M10 stays deliberate).

## Tests

- `TestCatalogNamesIncludesNATOnlyAppRefs` — RED-on-revert proof: a direct source-NAT ref, a direct destination-NAT ref, and a destination-NAT ref via an application-set must all appear in `CatalogNames(cfg, false)`; `any`/`""` pseudo-refs and unreferenced apps must not. Also exercises nil rule/rule-set skip.
- `TestStrictValidationSetMatchesCatalogNames` — resolves the M02 unpinned drift: the fixture now carries a NAT-only user-app reference so the strict-vs-catalog equality PINS the NAT walk too. Updated the #2187 scope note that previously said the two walks intentionally diverged on NAT refs.

RED-on-revert confirmed by restoring the pre-fix `runtime.go` — both new/updated tests fail:
```
--- FAIL: TestCatalogNamesIncludesNATOnlyAppRefs
    CatalogNames() = [], want [dnat-app set-member snat-app]
--- FAIL: TestStrictValidationSetMatchesCatalogNames
    strict        = [direct-app nat-app set-app]
    catalog(user) = [direct-app set-app]
```

## Validation

- `go test ./pkg/appid/... ./pkg/config/...` — pass
- `go build ./pkg/... ./cmd/...` — clean
- `gofmt -l` + `go vet ./pkg/appid/...` — clean
- Updated `pkg/appid/README.md` catalog-scope docs + `_Log.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi