### PR TITLE
api,grpcapi: echo queried zones on all match-policies responses (#3627 M06)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-01 — #3627 M06 match-policies echoes queried zones on all responses
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3627 M06 (driveable) — the REST `/security/match`
+    handler and the gRPC `MatchPolicies` RPC echoed the queried
+    from-zone/to-zone only INDIRECTLY, via the #3331 `from_zone`/`to_zone`
+    fields that carry the MATCHED policy's SCOPE and are populated ONLY on a
+    positive match. A negative/default verdict (`!res.Matched`), the
+    host-inbound verdict (`HostInboundUnmatched`), and the no-active-config
+    fail-closed deny all OMITTED the queried zones, so a stored JSON/wire
+    diagnostic for a default-deny or host-inbound answer could not prove
+    which zone pair was tested without a separate copy of the request. FIX:
+    added additive `queried_from_zone`/`queried_to_zone` — REST JSON fields
+    on `MatchPoliciesResult` and gRPC `MatchPoliciesResponse` fields 13/14
+    (new numbers, no version bump; regenerated with the pinned toolchain
+    protoc v3.21.12 / protoc-gen-go v1.36.11 / protoc-gen-go-grpc 1.6.1) —
+    populated on EVERY return path (match, no-match/default, host-inbound,
+    nil-config). Kept DISTINCT from the #3331 matched-scope `from_zone`/
+    `to_zone` (they can differ for a wildcard-zone or global match). Part
+    B (M07/L02: per-dimension miss explanation + host-inbound service token)
+    is a design-fork, deferred — #3627 stays open for it. Added RED-on-revert
+    tests on both surfaces (`TestMatchPoliciesRESTEchoesQueriedZones`,
+    `TestMatchPoliciesRESTNilConfigEchoesQueriedZones`,
+    `TestMatchPoliciesEchoesQueriedZones`) and updated pkg/api/README.md +
+    pkg/grpcapi/README.md.
+  - **File(s)**: proto/xpf/v1/xpf.proto,
+    pkg/grpcapi/xpfv1/xpf.pb.go, pkg/grpcapi/server_cluster.go,
+    pkg/api/types.go, pkg/api/security.go,
+    pkg/api/security_matchpolicies_queried_zones_3627_test.go,
+    pkg/grpcapi/server_matchpolicies_queried_zones_3627_test.go,
+    pkg/api/README.md, pkg/grpcapi/README.md, _Log.md
+
 ## 2026-07-01 — #3626 appid catalog includes NAT-only match-application refs
 
 - **Timestamp**: 2026-07-01

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -492,7 +492,16 @@ under the daemon's errgroup. Nothing else imports this package.
   rule has runtime id 0; a plain `uint32`+`omitempty` dropped it, so a
   matched-first-policy answer was indistinguishable from an unmatched one
   (both encoded as absent). The gRPC `MatchPoliciesResponse.policy_id`
-  mirror is `optional uint32` for the same reason.
+  mirror is `optional uint32` for the same reason. #3627 M06: the response
+  ALSO echoes the queried zone pair on `queried_from_zone`/`queried_to_zone`
+  on EVERY answer — positive match, no-match/default, and host-inbound — so a
+  stored JSON diagnostic for a default-deny or host-inbound verdict proves
+  which zone pair produced it without a separate copy of the request URL.
+  These are the query context and are DISTINCT from `from_zone`/`to_zone`
+  (the matched policy's declared SCOPE, #3331, set only on a positive match):
+  for a wildcard-zone or global match the two can differ. The gRPC
+  `MatchPoliciesResponse.queried_from_zone`/`queried_to_zone` (fields 13/14)
+  mirror this.
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -437,7 +437,15 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		// Surface the explicit string AND the typed default_used bit (same SSOT
 		// renderer the gRPC surface uses).
 		nilRes := policymatch.Result{DefaultUsed: true, Action: config.PolicyDeny}
-		writeOK(w, MatchPoliciesResult{Action: nilRes.DisplayAction(), DefaultUsed: true})
+		writeOK(w, MatchPoliciesResult{
+			Action:      nilRes.DisplayAction(),
+			DefaultUsed: true,
+			// #3627 M06: echo the queried zone pair even on the no-config
+			// fail-closed default deny so a stored diagnostic proves which zone
+			// pair produced the verdict.
+			QueriedFromZone: r.URL.Query().Get("from_zone"),
+			QueriedToZone:   r.URL.Query().Get("to_zone"),
+		})
 		return
 	}
 
@@ -572,11 +580,24 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		writeOK(w, MatchPoliciesResult{
 			HostInboundUnmatched: true,
 			Action:               res.DisplayAction(),
+			// #3627 M06: echo the queried zone pair on the host-inbound path so
+			// the diagnostic names the tested zones (the host gate returns no
+			// matched-policy scope to fill FromZone/ToZone).
+			QueriedFromZone: fromZone,
+			QueriedToZone:   toZone,
 		})
 		return
 	}
 	if !res.Matched {
-		writeOK(w, MatchPoliciesResult{Action: res.DisplayAction(), DefaultUsed: res.DefaultUsed})
+		writeOK(w, MatchPoliciesResult{
+			Action:      res.DisplayAction(),
+			DefaultUsed: res.DefaultUsed,
+			// #3627 M06: echo the queried zone pair on the no-match/default path
+			// so a stored default-deny diagnostic proves which zone pair was
+			// tested (FromZone/ToZone carry matched-policy scope, unset here).
+			QueriedFromZone: fromZone,
+			QueriedToZone:   toZone,
+		})
 		return
 	}
 	matchedID := res.PolicyID
@@ -586,6 +607,11 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		Global:     res.Global,
 		FromZone:   res.FromZone,
 		ToZone:     res.ToZone,
+		// #3627 M06: also echo the queried zone pair on a positive match. It is
+		// the query context, distinct from FromZone/ToZone (the matched policy's
+		// declared scope), which can differ for a wildcard-zone or global match.
+		QueriedFromZone: fromZone,
+		QueriedToZone:   toZone,
 		// #3623: set the pointer only on a match (the two early returns above
 		// leave it nil), so a matched first policy (id 0) is emitted as
 		// "policy_id":0 rather than dropped and mistaken for no match.

--- a/pkg/api/security_matchpolicies_queried_zones_3627_test.go
+++ b/pkg/api/security_matchpolicies_queried_zones_3627_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+)
+
+// queriedZonesResponse decodes the REST /security/match envelope focusing on the
+// #3627 M06 queried-zone echo.
+type queriedZonesResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Matched              bool   `json:"matched"`
+		HostInboundUnmatched bool   `json:"host_inbound_unmatched"`
+		DefaultUsed          bool   `json:"default_used"`
+		QueriedFromZone      string `json:"queried_from_zone"`
+		QueriedToZone        string `json:"queried_to_zone"`
+	} `json:"data"`
+}
+
+func matchQueriedZones(t *testing.T, s *Server, q url.Values) queriedZonesResponse {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+	s.matchPoliciesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp queriedZonesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false; body: %s", rr.Body.String())
+	}
+	return resp
+}
+
+// TestMatchPoliciesRESTEchoesQueriedZones pins #3627 M06 on the REST surface:
+// the match-policies response must echo the QUERIED from-zone/to-zone on EVERY
+// answer — positive match, no-match/default, and host-inbound — so a stored
+// JSON diagnostic proves which zone pair was tested without also capturing the
+// request URL.
+//
+// RED-on-revert: dropping the QueriedFromZone/QueriedToZone assignment from any
+// of the return paths in matchPoliciesHandler zeroes the echoed field and the
+// corresponding assertion below fails.
+func TestMatchPoliciesRESTEchoesQueriedZones(t *testing.T) {
+	store := hostInboundAPIStore(t)
+	s := &Server{store: store}
+
+	// No-match / default: untrust->trust has no rule -> default deny.
+	dd := matchQueriedZones(t, s, url.Values{"from_zone": {"untrust"}, "to_zone": {"trust"}})
+	if dd.Data.Matched {
+		t.Fatalf("matched = true, want false (default deny)")
+	}
+	if !dd.Data.DefaultUsed {
+		t.Fatalf("default_used = false, want true")
+	}
+	if dd.Data.QueriedFromZone != "untrust" || dd.Data.QueriedToZone != "trust" {
+		t.Errorf("default path queried zones = %q->%q, want untrust->trust",
+			dd.Data.QueriedFromZone, dd.Data.QueriedToZone)
+	}
+
+	// Host-inbound: to-zone junos-host with no host policy -> local delivery.
+	hi := matchQueriedZones(t, s, url.Values{"from_zone": {"trust"}, "to_zone": {"junos-host"}})
+	if !hi.Data.HostInboundUnmatched {
+		t.Fatalf("host_inbound_unmatched = false, want true; got %+v", hi.Data)
+	}
+	if hi.Data.QueriedFromZone != "trust" || hi.Data.QueriedToZone != "junos-host" {
+		t.Errorf("host-inbound path queried zones = %q->%q, want trust->junos-host",
+			hi.Data.QueriedFromZone, hi.Data.QueriedToZone)
+	}
+
+	// Positive match: trust->untrust permit.
+	m := matchQueriedZones(t, s, url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}})
+	if !m.Data.Matched {
+		t.Fatalf("matched = false, want true (trust->untrust permit)")
+	}
+	if m.Data.QueriedFromZone != "trust" || m.Data.QueriedToZone != "untrust" {
+		t.Errorf("matched path queried zones = %q->%q, want trust->untrust",
+			m.Data.QueriedFromZone, m.Data.QueriedToZone)
+	}
+}
+
+// TestMatchPoliciesRESTNilConfigEchoesQueriedZones pins #3627 M06 on the
+// no-active-config fail-closed path: the deny (default) verdict must still echo
+// the queried zone pair.
+//
+// RED-on-revert: dropping the QueriedFromZone/QueriedToZone assignment from the
+// nil-config branch zeroes the echoed field and the assertion fails.
+func TestMatchPoliciesRESTNilConfigEchoesQueriedZones(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	s := &Server{store: store}
+	if store.ActiveConfig() != nil {
+		t.Skip("active config is not nil; nil-config path not exercised")
+	}
+
+	dd := matchQueriedZones(t, s, url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}})
+	if !dd.Data.DefaultUsed {
+		t.Fatalf("default_used = false, want true (no-config fail-closed default deny)")
+	}
+	if dd.Data.QueriedFromZone != "trust" || dd.Data.QueriedToZone != "untrust" {
+		t.Errorf("nil-config path queried zones = %q->%q, want trust->untrust",
+			dd.Data.QueriedFromZone, dd.Data.QueriedToZone)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -478,6 +478,16 @@ type MatchPoliciesResult struct {
 	// a client can branch on the posture without string-parsing. False for a
 	// concrete policy match and for HostInboundUnmatched.
 	DefaultUsed bool `json:"default_used,omitempty"`
+	// QueriedFromZone/QueriedToZone echo the zone pair the caller ASKED about
+	// (#3627 M06). Unlike FromZone/ToZone (the SCOPE of the MATCHED policy, set
+	// only on a positive match), these are populated on EVERY response —
+	// positive match, no-match/default, and host-inbound — so a stored JSON
+	// diagnostic for a default-deny or host-inbound verdict proves which zone
+	// pair was tested without also capturing the request URL. They are the query
+	// context, not a policy attribute; for a wildcard-zone or global match they
+	// can differ from FromZone/ToZone.
+	QueriedFromZone string `json:"queried_from_zone,omitempty"`
+	QueriedToZone   string `json:"queried_to_zone,omitempty"`
 }
 
 // ClearSessionsResult holds session clear results.

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -103,6 +103,17 @@ contract.
   `MatchPoliciesResult` carries the same `default_used` JSON field. The CLI
   `show security match-policies` renders its own multi-line, self-describing
   host-inbound block, so it never showed a blank verdict and is unchanged.
+- #3627 M06: the response echoes the queried zone pair on
+  `queried_from_zone`/`queried_to_zone` (proto fields 13/14) for EVERY answer —
+  positive match, no-match/default, and host-inbound. Before #3627 the queried
+  zones surfaced only indirectly via the #3331 `from_zone`/`to_zone`, which are
+  the matched policy's declared SCOPE and are set ONLY on a positive match; a
+  negative/default or host-inbound answer omitted them entirely, so a stored
+  diagnostic could not prove which zone pair was tested without a copy of the
+  request. The queried echo is the query context, DISTINCT from the matched
+  scope (for a wildcard-zone or global match the two can differ). The REST
+  `MatchPoliciesResult` carries the same `queried_from_zone`/`queried_to_zone`
+  JSON fields.
 - The `test policy` operational command (local `pkg/cli` + remote `cmd/cli`
   → ShowText `test-policy:` topic → `showTestPolicy`) carries the same
   source-port input (#3107). The topic adds a `srcport=` key alongside the

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -131,6 +131,11 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		return &pb.MatchPoliciesResponse{
 			Action:      nilRes.DisplayAction(),
 			DefaultUsed: true,
+			// #3627 M06: echo the queried zone pair even on the no-config
+			// fail-closed default deny so a stored diagnostic proves which
+			// zone pair produced the verdict.
+			QueriedFromZone: req.FromZone,
+			QueriedToZone:   req.ToZone,
 		}, nil
 	}
 
@@ -233,6 +238,11 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 			Matched:              false,
 			HostInboundUnmatched: true,
 			Action:               res.DisplayAction(),
+			// #3627 M06: echo the queried zone pair on the host-inbound path so
+			// the diagnostic names the tested zones (the host gate returns no
+			// matched-policy scope to fill from_zone/to_zone).
+			QueriedFromZone: req.FromZone,
+			QueriedToZone:   req.ToZone,
 		}, nil
 	}
 	if !res.Matched {
@@ -240,6 +250,11 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 			Matched:     false,
 			Action:      res.DisplayAction(),
 			DefaultUsed: res.DefaultUsed,
+			// #3627 M06: echo the queried zone pair on the no-match/default path
+			// so a stored default-deny diagnostic proves which zone pair was
+			// tested (from_zone/to_zone carry matched-policy scope, unset here).
+			QueriedFromZone: req.FromZone,
+			QueriedToZone:   req.ToZone,
 		}, nil
 	}
 	return &pb.MatchPoliciesResponse{
@@ -248,6 +263,12 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		Global:     res.Global,
 		FromZone:   res.FromZone,
 		ToZone:     res.ToZone,
+		// #3627 M06: also echo the queried zone pair on a positive match. It is
+		// the query context, distinct from from_zone/to_zone (the matched
+		// policy's declared scope), which can differ for a wildcard-zone or
+		// global match.
+		QueriedFromZone: req.FromZone,
+		QueriedToZone:   req.ToZone,
 		// #3623: proto3 explicit presence — set only on a match, so a matched
 		// first policy (runtime id 0) is distinguishable on the wire from an
 		// unmatched response (field absent). The two early returns above leave

--- a/pkg/grpcapi/server_matchpolicies_queried_zones_3627_test.go
+++ b/pkg/grpcapi/server_matchpolicies_queried_zones_3627_test.go
@@ -1,0 +1,75 @@
+package grpcapi
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestMatchPoliciesEchoesQueriedZones pins #3627 M06 on the gRPC surface: the
+// MatchPolicies response must echo the QUERIED from-zone/to-zone on EVERY
+// answer — positive match, no-match/default, and host-inbound — so a stored
+// diagnostic proves which zone pair was tested without a copy of the request.
+//
+// This is distinct from the #3331 from_zone/to_zone (the matched policy's
+// SCOPE, set only on a positive match). queried_from_zone/queried_to_zone are
+// the query context.
+//
+// RED-on-revert: dropping the QueriedFromZone/QueriedToZone assignment from any
+// of the three unmatched/matched return paths in server_cluster.go zeroes the
+// echoed field and the corresponding assertion below fails.
+func TestMatchPoliciesEchoesQueriedZones(t *testing.T) {
+	// hostInboundStore: trust->untrust permit, default deny, defined zones
+	// trust/untrust — enough to exercise host-inbound + no-match + match.
+	store := hostInboundStore(t)
+	s := &Server{store: store}
+
+	// No-match / default: untrust->trust has no rule -> default deny. The
+	// matched-scope from_zone/to_zone are empty here, but the queried pair must
+	// still be echoed.
+	dd, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "untrust", ToZone: "trust",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(default) error = %v", err)
+	}
+	if dd.Matched {
+		t.Fatalf("matched = true, want false (default deny)")
+	}
+	if dd.QueriedFromZone != "untrust" || dd.QueriedToZone != "trust" {
+		t.Errorf("default path queried zones = %q->%q, want untrust->trust",
+			dd.QueriedFromZone, dd.QueriedToZone)
+	}
+
+	// Host-inbound: to-zone junos-host with no host policy -> local delivery.
+	hi, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust", ToZone: "junos-host",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(host-inbound) error = %v", err)
+	}
+	if !hi.HostInboundUnmatched {
+		t.Fatalf("host_inbound_unmatched = false, want true; got %+v", hi)
+	}
+	if hi.QueriedFromZone != "trust" || hi.QueriedToZone != "junos-host" {
+		t.Errorf("host-inbound path queried zones = %q->%q, want trust->junos-host",
+			hi.QueriedFromZone, hi.QueriedToZone)
+	}
+
+	// Positive match: trust->untrust permit. The matched-scope from_zone/to_zone
+	// (#3331) AND the queried echo must both be populated and here coincide.
+	m, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone: "trust", ToZone: "untrust",
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies(match) error = %v", err)
+	}
+	if !m.Matched {
+		t.Fatalf("matched = false, want true (trust->untrust permit)")
+	}
+	if m.QueriedFromZone != "trust" || m.QueriedToZone != "untrust" {
+		t.Errorf("matched path queried zones = %q->%q, want trust->untrust",
+			m.QueriedFromZone, m.QueriedToZone)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -6502,9 +6502,20 @@ type MatchPoliciesResponse struct {
 	// so a client can branch on the posture without string-parsing. False for a
 	// concrete policy match and for host_inbound_unmatched (which has no
 	// default-policy fallback).
-	DefaultUsed   bool `protobuf:"varint,12,opt,name=default_used,json=defaultUsed,proto3" json:"default_used,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	DefaultUsed bool `protobuf:"varint,12,opt,name=default_used,json=defaultUsed,proto3" json:"default_used,omitempty"`
+	// queried_from_zone / queried_to_zone echo the zone pair the caller ASKED
+	// about (#3627 M06). Unlike from_zone/to_zone (which carry the SCOPE of the
+	// MATCHED policy and are set only on a positive match), these are populated on
+	// EVERY response — positive match, no-match/default, and host-inbound — so a
+	// stored diagnostic for a default-deny or host-inbound verdict proves which
+	// zone pair was tested without a separate copy of the request. They are the
+	// query context, not a policy attribute; for a wildcard-zone or global match
+	// they can differ from from_zone/to_zone (the matched policy's declared
+	// scope).
+	QueriedFromZone string `protobuf:"bytes,13,opt,name=queried_from_zone,json=queriedFromZone,proto3" json:"queried_from_zone,omitempty"`
+	QueriedToZone   string `protobuf:"bytes,14,opt,name=queried_to_zone,json=queriedToZone,proto3" json:"queried_to_zone,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *MatchPoliciesResponse) Reset() {
@@ -6619,6 +6630,20 @@ func (x *MatchPoliciesResponse) GetDefaultUsed() bool {
 		return x.DefaultUsed
 	}
 	return false
+}
+
+func (x *MatchPoliciesResponse) GetQueriedFromZone() string {
+	if x != nil {
+		return x.QueriedFromZone
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetQueriedToZone() string {
+	if x != nil {
+		return x.QueriedToZone
+	}
+	return ""
 }
 
 type GetNATRuleStatsRequest struct {
@@ -8149,7 +8174,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
-	"_icmp_code\"\xaf\x03\n" +
+	"_icmp_code\"\x83\x04\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -8164,7 +8189,9 @@ const file_xpf_proto_rawDesc = "" +
 	"\ato_zone\x18\n" +
 	" \x01(\tR\x06toZone\x12 \n" +
 	"\tpolicy_id\x18\v \x01(\rH\x00R\bpolicyId\x88\x01\x01\x12!\n" +
-	"\fdefault_used\x18\f \x01(\bR\vdefaultUsedB\f\n" +
+	"\fdefault_used\x18\f \x01(\bR\vdefaultUsed\x12*\n" +
+	"\x11queried_from_zone\x18\r \x01(\tR\x0fqueriedFromZone\x12&\n" +
+	"\x0fqueried_to_zone\x18\x0e \x01(\tR\rqueriedToZoneB\f\n" +
 	"\n" +
 	"_policy_id\"N\n" +
 	"\x16GetNATRuleStatsRequest\x12\x19\n" +

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -756,6 +756,17 @@ message MatchPoliciesResponse {
   // concrete policy match and for host_inbound_unmatched (which has no
   // default-policy fallback).
   bool default_used = 12;
+  // queried_from_zone / queried_to_zone echo the zone pair the caller ASKED
+  // about (#3627 M06). Unlike from_zone/to_zone (which carry the SCOPE of the
+  // MATCHED policy and are set only on a positive match), these are populated on
+  // EVERY response — positive match, no-match/default, and host-inbound — so a
+  // stored diagnostic for a default-deny or host-inbound verdict proves which
+  // zone pair was tested without a separate copy of the request. They are the
+  // query context, not a policy attribute; for a wildcard-zone or global match
+  // they can differ from from_zone/to_zone (the matched policy's declared
+  // scope).
+  string queried_from_zone = 13;
+  string queried_to_zone = 14;
 }
 
 // --- NAT rule counters ---


### PR DESCRIPTION
## Summary

Refs #3627 (part A / M06 — driveable).

The match-policies simulator (REST `GET /api/v1/security/match` and gRPC
`MatchPolicies`) echoed the queried zone pair only INDIRECTLY, via the
#3331 `from_zone`/`to_zone` fields. Those carry the MATCHED policy's
declared SCOPE and are set ONLY on a positive match. A negative/default
verdict, the host-inbound (`junos-host` local-delivery) verdict, and the
no-active-config fail-closed deny all OMITTED the queried zones — so a
stored JSON/wire diagnostic for a default-deny or host-inbound answer
could not prove which zone pair was tested without a separate copy of the
request.

## Fix

Add additive `queried_from_zone`/`queried_to_zone`:

- gRPC `MatchPoliciesResponse` fields 13/14 (new field numbers, no version
  bump; regenerated with the pinned toolchain protoc v3.21.12 /
  protoc-gen-go v1.36.11 / protoc-gen-go-grpc 1.6.1).
- REST `MatchPoliciesResult` JSON fields.

Both surfaces echo the exact zones the caller asked about on EVERY return
path — positive match, no-match/default, host-inbound, and no-active-config.
The queried echo is deliberately kept DISTINCT from `from_zone`/`to_zone`
(matched-policy scope, #3331), because the two differ for a wildcard-zone
or global match. Existing #3331 scope semantics on the positive-match path
are unchanged.

## Tests (RED-on-revert)

- `pkg/api`: `TestMatchPoliciesRESTEchoesQueriedZones` (match /
  no-match-default / host-inbound) and
  `TestMatchPoliciesRESTNilConfigEchoesQueriedZones` (no-active-config).
- `pkg/grpcapi`: `TestMatchPoliciesEchoesQueriedZones` (match /
  no-match-default / host-inbound).

Verified RED by stripping the `QueriedFromZone`/`QueriedToZone`
assignments from the handlers — all queried-zone assertions failed (empty
`""->""`), then passed again on restore. `go test ./pkg/api ./pkg/grpcapi`
green; `go build ./pkg/... ./cmd/...`, gofmt, and scoped `go vet` clean.

Docs updated: `pkg/api/README.md`, `pkg/grpcapi/README.md`, `_Log.md`.

## Scope / part B

This PR is part A only. Part B of #3627 (M07/L02: per-dimension miss
explanation + host-inbound service-token exposure) is a design-fork
requiring a design decision (an optional explain/debug flag on the hot
path) and is intentionally NOT built here. #3627 stays OPEN to track it —
hence `Refs #3627`, not `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
