### PR TITLE
docs(appid): fix stale ResolveSessionName signature in README

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,29 @@
+## 2026-07-01 — #3629 pkg/appid/README stale ResolveSessionName signature
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3629 (Codex review-122 M04, docs-only) — pkg/appid/README.md
+    documented `ResolveSessionName` with a stale signature missing the
+    `srcPort` parameter added in #3428:
+    `ResolveSessionName(appNames, cfg, proto, dstPort, appID)`. The actual
+    function is `ResolveSessionName(appNames map[uint16]string,
+    cfg *config.Config, proto uint8, srcPort, dstPort uint16, appID uint16)
+    string` (pkg/appid/runtime.go:162). srcPort is threaded through so the
+    tuple fallback (`resolveTupleFallback` -> `matchTuple`) can honor a
+    configured `source-port` constraint. FIX: aligned the README signature
+    with source and described the source-port fallback semantics — a
+    configured `source-port` and/or `destination-port` constraint must each
+    match (both when set), and `resolveTupleFallback`'s specificity
+    tie-break treats an app as port-constrained when source-port and/or
+    destination-port is set (matching the actual `app.DestinationPort != ""
+    || app.SourcePort != ""` test, #2578/#3428). Verified the other two
+    documented signatures (`CatalogNames`, `BuildCatalog`) already match
+    source; the `applicationsToValidateStrict` (unexported, commit-time
+    validator) vs `ApplicationsToValidateStrict` (exported, catalog test)
+    references are both correct in context. Pure doc-accuracy change, no
+    code touched. Validation: `go build ./pkg/appid/...` green; README
+    signatures diffed against `func` lines in pkg/appid/*.go.
+  - **File(s)**: pkg/appid/README.md, _Log.md
+
 ## 2026-07-01 — #3627 M06 match-policies echoes queried zones on all responses
 
 - **Timestamp**: 2026-07-01

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -30,21 +30,28 @@ and resolves session display names from the dataplane's assigned `app_id`.
   `pkg/dataplane/userspace` ships `Entries` to the Rust dataplane as
   the snapshot `app_catalog` field (#2008 M5); the dataplane stamps
   the matched `app_id` on each new session.
-- `ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, dstPort uint16, appID uint16) string` —
-  `runtime.go`. Lookup order: dataplane `app_id` (authoritative from
+- `ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, srcPort, dstPort uint16, appID uint16) string` —
+  `runtime.go`. `srcPort` is the session source port; it is threaded
+  through so the tuple fallback can honor a configured `source-port`
+  constraint (#3428). Lookup order: dataplane `app_id` (authoritative from
   BPF) → user-configured app tuple match (`resolveTupleFallback` →
   `matchTuple`) → narrow built-in fallback (`junos-http`, `junos-ssh`,
   …). Tuple matching requires the configured protocol to match; if the
-  app also sets a `destination-port` (single or `lo-hi` range), the port
-  must match too. A **protocol-only** custom app — one with a `protocol`
+  app also sets a `source-port` and/or a `destination-port` (single or
+  `lo-hi` range), each configured port constraint must match too — when
+  both are set the session's source AND destination port must satisfy
+  them (#3428; before that fix a `source-port`-scoped app was matched on
+  destination port alone, so any session to that dst-port was mislabeled
+  regardless of its source port). A **protocol-only** custom app — one with a `protocol`
   but no `destination-port`, e.g. a user-defined GRE/ESP/AH application —
   matches on protocol alone (#2548; before that fix `matchTuple`
   rejected an empty port, so protocol-only apps never matched and their
   sessions reported `UNKNOWN`). An app with neither protocol nor port is
   never a match-all. When several configured apps match the same tuple,
   `resolveTupleFallback` resolves deterministically by **specificity**: a
-  port-constrained app (`destination-port` set) wins over a protocol-only
-  app of the same protocol, with remaining ties broken by app name (#2578;
+  port-constrained app (`source-port` and/or `destination-port` set) wins
+  over a protocol-only app of the same protocol, with remaining ties
+  broken by app name (#2578;
   before that the map was iterated first-match, so a port-specific app
   could non-deterministically lose to a protocol-only sibling). This is a
   display-only label path — it does not affect policy enforcement, which


### PR DESCRIPTION
## Summary

`pkg/appid/README.md` documented `ResolveSessionName` with a stale
signature — it was missing the `srcPort` parameter added in #3428.

**Old (README, stale):**

    ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, dstPort uint16, appID uint16) string

**New (matches source — `pkg/appid/runtime.go:162`):**

    ResolveSessionName(appNames map[uint16]string, cfg *config.Config, proto uint8, srcPort, dstPort uint16, appID uint16) string

`srcPort` is threaded through so the tuple fallback
(`resolveTupleFallback` → `matchTuple`) can honor a configured
`source-port` constraint (#3428). The README omitted both the parameter
and the source-port fallback semantics.

## Changes

- Updated the `ResolveSessionName` signature to the current arity.
- Described the source-port fallback behavior: a configured `source-port`
  and/or `destination-port` constraint must each match (both when set),
  matching `matchTuple` (#3428).
- Updated the `resolveTupleFallback` specificity note — an app is
  "port-constrained" when `source-port` **and/or** `destination-port` is
  set, matching the actual `app.DestinationPort != "" || app.SourcePort != ""`
  test (#2578/#3428).

The other two documented signatures (`CatalogNames`, `BuildCatalog`)
were verified against source and already match — unchanged.

## Validation

- `go build ./pkg/appid/...` — green (no code touched; docs-only).
- README signatures diffed against the `func` declarations in
  `pkg/appid/*.go`:
  - `ResolveSessionName` → runtime.go:162 ✓
  - `CatalogNames` → runtime.go:42 ✓
  - `BuildCatalog` → catalog.go:59 ✓

Closes #3629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi