### PR TITLE
userspace-dp: emit a tuple-rich event for host-inbound denies (#3610)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-01 — #3610 host-inbound denies emit a tuple-rich RT_FLOW event
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3610 — host-inbound-traffic admission denies were accounted
+    only by the aggregate `host_inbound_denied_packets` counter (+ conflated
+    with `dbg.policy_deny`), with NO tuple-rich dataplane event, so operators
+    could not see WHICH control-plane flow was denied. Added
+    `emit_host_inbound_deny_event` (reuses the #3615 policy-deny event
+    machinery: same `PolicyDeny` wire kind / rate limiter / Go renderer, with a
+    distinct `RT_FLOW_CLOSE_REASON_HOST_INBOUND`=6 reason, action always DENY,
+    policy_id 0). Wired it into all three host-inbound deny arms (session-hit,
+    session-miss, #3292 flowless LocalDelivery). Split `dbg.policy_deny` →
+    `dbg.host_inbound_deny` at those arms (M07). Go: `closeReasonHostInbound`
+    (6) → "Denied by host-inbound-traffic"; POLICY_DENY structured formatter
+    now renders the on-wire reason (byte-identical "Rejected by policy" for a
+    transit deny). RED-on-revert poll-loop test proven (empty event channel on
+    revert). No wire fixture regen (reuses the existing reason byte, new value).
+  - **File(s)**: userspace-dp/src/afxdp/event_emit.rs,
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs,
+    userspace-dp/src/afxdp/types/runtime.rs,
+    userspace-dp/src/afxdp/worker/loop_body/debug_report.rs,
+    userspace-dp/src/afxdp/tests.rs, pkg/logging/ringbuf.go,
+    pkg/logging/host_inbound_deny_3610_test.go,
+    docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+
 ## 2026-07-01 — #3626 appid catalog includes NAT-only match-application refs
 
 - **Timestamp**: 2026-07-01

--- a/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
+++ b/docs/pr/1373-retire-ebpf-dataplane/plan-1379-dataplane-events.md
@@ -102,6 +102,21 @@ Current implementation status after the 2026-05-19 closeout slice:
   `MSG_FILTER_LOG`, the RT_FLOW reason byte carries the source label above;
   close events continue to interpret the same byte as a close reason. This is
   event-stream semantics, not a config-snapshot protocol field.
+- #3610 host-inbound deny: a host-bound (LocalDelivery) packet rejected by the
+  ingress zone's `host-inbound-traffic` admission gate now emits a tuple-rich
+  RT_FLOW deny event instead of being accounted only by the aggregate
+  `host_inbound_denied_packets` counter. It reuses the `MSG_POLICY_DENY` wire
+  kind (so it rides the same #3615 per-kind rate limiter, queue budget, and Go
+  RT_FLOW_SESSION_DENY renderer — no parallel emit path), but carries the
+  distinct reason byte `RT_FLOW_CLOSE_REASON_HOST_INBOUND` (6, ==
+  `closeReasonHostInbound`). The Go structured record renders `reason="Denied by
+  host-inbound-traffic"` for it, vs `reason="Rejected by policy"` for a transit
+  policy deny (reason 5). The action is always DENY (host-inbound is a silent
+  drop, never a reject) and `policy_id`/`egress_zone_id`/`owner_rg_id` are 0
+  (host-local, not policy-forwarded). It fires for BOTH flow-backed (session-hit
+  and session-miss) and flowless (#3292 non-first-fragment / no-L4) host-inbound
+  denies. The debug counter was split too: the deny bumps `dbg.host_inbound_deny`
+  rather than being conflated with `dbg.policy_deny` (Codex H06 + M07 + L04).
 - `pkg/dataplane/userspace/eventstream_test.go` includes a deterministic UDP
   syslog harness that feeds raw userspace policy-deny, screen-drop, and
   filter-log frames through the Go event-stream callback, `EventReader`, and

--- a/pkg/logging/host_inbound_deny_3610_test.go
+++ b/pkg/logging/host_inbound_deny_3610_test.go
@@ -1,0 +1,84 @@
+package logging
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// rawHostInboundDenyFrame builds a POLICY_DENY raw event frame (eventType 3)
+// carrying the #3610 host-inbound reason byte at [134]. This mirrors what the
+// userspace-dp emit_host_inbound_deny_event produces: the policy-deny wire kind
+// (so it reuses the #3615 event machinery) with the distinct
+// closeReasonHostInbound reason, action DENY, and no admitting policy id.
+func rawHostInboundDenyFrame(reason byte) []byte {
+	data := make([]byte, rawEventWireSize)
+	data[40] = 0x30 // src port 12345
+	data[41] = 0x39
+	data[42] = 0x00 // dst port 179 (BGP — a control-plane service)
+	data[43] = 0xb3
+	data[52] = eventTypePolicyDeny
+	data[53] = 6 // TCP
+	data[54] = actionDeny
+	data[55] = addrFamilyInet
+	copy(data[8:12], net.ParseIP("10.0.61.102").To4())
+	copy(data[24:28], net.ParseIP("10.255.0.1").To4())
+	data[134] = reason
+	return data
+}
+
+// TestHostInboundDenyReasonRendersDistinctly is the #3610 fail-on-revert: a
+// POLICY_DENY event whose reason byte is closeReasonHostInbound (6) must decode
+// to the distinct "Denied by host-inbound-traffic" reason and render it on the
+// structured RT_FLOW_SESSION_DENY record, so incident response can tell a
+// control-plane host-inbound drop apart from a transit security-policy deny.
+// The full 5-tuple must be present so the operator sees WHICH flow was dropped.
+//
+// Reverting closeReasonName (dropping the closeReasonHostInbound case) or the
+// formatStructuredMsg POLICY_DENY change (hardcoding "Rejected by policy") turns
+// this RED.
+func TestHostInboundDenyReasonRendersDistinctly(t *testing.T) {
+	rec, ok := DecodeRawEventRecord(rawHostInboundDenyFrame(closeReasonHostInbound))
+	if !ok {
+		t.Fatalf("DecodeRawEventRecord returned ok=false")
+	}
+	if rec.Type != "POLICY_DENY" {
+		t.Fatalf("record type = %q, want POLICY_DENY", rec.Type)
+	}
+	if rec.Reason != "Denied by host-inbound-traffic" {
+		t.Fatalf("host-inbound deny Reason = %q, want %q", rec.Reason, "Denied by host-inbound-traffic")
+	}
+
+	structured := formatStructuredMsg(rec, 6)
+	if !strings.Contains(structured, "RT_FLOW_SESSION_DENY") {
+		t.Fatalf("structured record is not an RT_FLOW_SESSION_DENY:\n%s", structured)
+	}
+	if !strings.Contains(structured, `reason="Denied by host-inbound-traffic"`) {
+		t.Fatalf("structured host-inbound deny missing the distinct reason:\n%s", structured)
+	}
+	// The tuple must be present so the operator can see WHICH flow was denied.
+	if !strings.Contains(structured, `source-address="10.0.61.102"`) ||
+		!strings.Contains(structured, `destination-address="10.255.0.1"`) ||
+		!strings.Contains(structured, `destination-port="179"`) {
+		t.Fatalf("structured host-inbound deny missing the denied 5-tuple:\n%s", structured)
+	}
+}
+
+// TestPolicyDenyReasonUnchanged is the byte-identical guard: a transit
+// security-policy deny (reason byte closeReasonPolicy = 5) must STILL render
+// reason="Rejected by policy" after #3610 generalized the formatter to read the
+// on-wire reason. If the formatter regressed to a wrong default or read the
+// wrong byte, this catches it.
+func TestPolicyDenyReasonUnchanged(t *testing.T) {
+	rec, ok := DecodeRawEventRecord(rawHostInboundDenyFrame(closeReasonPolicy))
+	if !ok {
+		t.Fatalf("DecodeRawEventRecord returned ok=false")
+	}
+	if rec.Reason != "Rejected by policy" {
+		t.Fatalf("policy deny Reason = %q, want %q", rec.Reason, "Rejected by policy")
+	}
+	structured := formatStructuredMsg(rec, 6)
+	if !strings.Contains(structured, `reason="Rejected by policy"`) {
+		t.Fatalf("transit policy deny reason regressed:\n%s", structured)
+	}
+}

--- a/pkg/logging/ringbuf.go
+++ b/pkg/logging/ringbuf.go
@@ -112,6 +112,14 @@ const (
 	closeReasonTCPRST  = 3
 	closeReasonAgeOut  = 4
 	closeReasonPolicy  = 5
+	// #3610: a host-inbound-traffic admission deny. Carried in the RT_FLOW
+	// reason byte on a POLICY_DENY event (the userspace-dp
+	// emit_host_inbound_deny_event rides the policy-deny wire kind with this
+	// distinct reason). Must equal the Rust RT_FLOW_CLOSE_REASON_HOST_INBOUND
+	// (userspace-dp/src/afxdp/event_emit.rs). Lets the structured
+	// RT_FLOW_SESSION_DENY record and operators tell a control-plane
+	// host-inbound drop apart from a transit security-policy deny.
+	closeReasonHostInbound = 6
 )
 
 const (
@@ -1098,6 +1106,17 @@ func formatStructuredMsg(rec EventRecord, protoNum uint8) string {
 			inIface, appName)
 
 	case "POLICY_DENY":
+		// #3610: render the on-wire reason instead of a hardcoded string. For a
+		// transit security-policy deny the reason byte is closeReasonPolicy, so
+		// rec.Reason is "Rejected by policy" — byte-identical to the prior output.
+		// For a host-inbound-traffic admission deny the byte is
+		// closeReasonHostInbound, so the record shows "Denied by
+		// host-inbound-traffic", letting incident response tell a control-plane
+		// host-inbound drop apart from a transit policy deny (was conflated).
+		reason := rec.Reason
+		if reason == "" {
+			reason = "Rejected by policy"
+		}
 		return fmt.Sprintf("RT_FLOW - RT_FLOW_SESSION_DENY "+
 			"[junos@2636.1.1.1.2.129 "+
 			"source-address=\"%s\" source-port=\"%s\" "+
@@ -1107,12 +1126,12 @@ func formatStructuredMsg(rec EventRecord, protoNum uint8) string {
 			"source-zone-name=\"%s\" destination-zone-name=\"%s\" "+
 			"session-id=\"%d\" "+
 			"packet-incoming-interface=\"%s\" application=\"%s\" "+
-			"reason=\"Rejected by policy\"]",
+			"reason=\"%s\"]",
 			srcIP, srcPort, dstIP, dstPort,
 			protoNum, policyName,
 			rec.InZoneName, rec.OutZoneName,
 			rec.SessionID,
-			inIface, appName)
+			inIface, appName, reason)
 
 	default:
 		return formatSyslogMsg(rec)
@@ -1340,6 +1359,10 @@ func closeReasonName(reason uint8) string {
 		return "aged out"
 	case closeReasonPolicy:
 		return "Rejected by policy"
+	case closeReasonHostInbound:
+		// #3610: a control-plane host-inbound-traffic admission deny (distinct
+		// from a transit security-policy deny).
+		return "Denied by host-inbound-traffic"
 	default:
 		return "N/A"
 	}

--- a/userspace-dp/src/afxdp/event_emit.rs
+++ b/userspace-dp/src/afxdp/event_emit.rs
@@ -10,6 +10,15 @@ const RT_FLOW_ACTION_DENY: u8 = 0;
 const RT_FLOW_ACTION_PERMIT: u8 = 1;
 const RT_FLOW_ACTION_REJECT: u8 = 2;
 const RT_FLOW_CLOSE_REASON_POLICY: u8 = 5;
+// #3610: a host-inbound-traffic admission deny (the ingress zone's
+// `host-inbound-traffic` gate rejecting a host-bound / control-plane packet) is
+// NOT a transit security-policy deny. It rides the SAME `PolicyDeny` event kind
+// / wire path (so it inherits the per-kind rate limiter, queue budget, and Go
+// RT_FLOW rendering — no parallel emit path), but carries this distinct reason
+// byte so the Go structured RT_FLOW_SESSION_DENY record and operators can tell a
+// control-plane host-inbound drop apart from a transit policy deny. Must equal
+// the Go `closeReasonHostInbound` (pkg/logging/ringbuf.go).
+const RT_FLOW_CLOSE_REASON_HOST_INBOUND: u8 = 6;
 const NS_PER_SEC: u64 = 1_000_000_000;
 
 const SCREEN_SYN_FLOOD: u32 = 1 << 0;
@@ -190,6 +199,77 @@ pub(super) fn emit_policy_deny_event(
         // #2470: stamp the dataplane DECISION instant (wall-clock Unix ns)
         // here at emit time so a backlogged Go-side delivery cannot skew the
         // logged event time to consumption time. `now_ns` is CLOCK_MONOTONIC.
+        timestamp_ns: crate::event_stream::mono_ns_to_wall_clock_unix_ns(now_ns),
+    };
+    let _ = event_stream.try_emit_dataplane_event_at(event, now_ns);
+}
+
+/// #3610: emit a tuple-rich RT_FLOW deny event for a host-inbound-traffic
+/// admission deny — a host-bound (LocalDelivery) packet rejected by the ingress
+/// zone's `host-inbound-traffic` gate. Before #3610 these drops were accounted
+/// only as aggregate counters (`host_inbound_denied_packets`) with no dataplane
+/// event, so operators could see THAT host-inbound denies happened but not who
+/// hit which control-plane service.
+///
+/// Reuses the #3615 policy-deny event machinery: the SAME
+/// `DataplaneEventKind::PolicyDeny` wire kind, per-kind rate limiter, queue
+/// budget, and Go RT_FLOW renderer / decoder — no parallel emit path is added.
+/// Only the reason byte (`RT_FLOW_CLOSE_REASON_HOST_INBOUND`) distinguishes it
+/// from a transit security-policy deny.
+///
+/// A host-inbound admission deny is ALWAYS a silent drop: there is no admitting/
+/// denying security policy and no reject reply is ever synthesized, so the action
+/// is unconditionally DENY, `policy_id`/`rule_id` are 0 (not a security policy),
+/// the egress "zone" is the firewall host itself (#3110 sentinel 0, matching the
+/// junos-host deny), `owner_rg_id` is 0 (host-local, not policy-forwarded), and
+/// the record carries no NAT translation. The 5-tuple, ingress zone, ingress
+/// ifindex, protocol, and resolved application come from the denied flow so an
+/// operator can see WHICH control-plane flow was dropped (issue #3610 / Codex
+/// H06 + L04). Cold path only (LocalDelivery deny).
+#[inline]
+pub(super) fn emit_host_inbound_deny_event(
+    event_stream: Option<&EventStreamWorkerHandle>,
+    flow: &SessionFlow,
+    meta: UserspaceDpMeta,
+    ingress_zone_id: u16,
+    app_id: u16,
+    now_ns: u64,
+) {
+    let Some(event_stream) = event_stream else {
+        return;
+    };
+    let event = DataplaneEventPayload {
+        kind: DataplaneEventKind::PolicyDeny,
+        addr_family: flow.forward_key.addr_family,
+        protocol: flow.forward_key.protocol,
+        // Host-inbound admission is a silent drop — never a reject.
+        action: RT_FLOW_ACTION_DENY,
+        src_ip: flow.src_ip,
+        dst_ip: flow.dst_ip,
+        src_port: flow.forward_key.src_port,
+        dst_port: flow.forward_key.dst_port,
+        // LocalDelivery applies no NAT to a host-bound packet.
+        nat_src_ip: None,
+        nat_dst_ip: None,
+        nat_src_port: 0,
+        nat_dst_port: 0,
+        ingress_zone_id,
+        // The egress "zone" is the firewall host itself; carry the #3110
+        // sentinel 0, same as the junos-host deny (see emit_junos_host_deny).
+        egress_zone_id: 0,
+        ingress_ifindex: ingress_ifindex_to_wire(meta.ingress_ifindex),
+        // Host-inbound admission is not a security policy — no policy/rule id.
+        policy_id: 0,
+        rule_id: 0,
+        term_id: 0,
+        reason: RT_FLOW_CLOSE_REASON_HOST_INBOUND,
+        // Host-local sessions are not policy-forwarded; owner_rg_id 0.
+        owner_rg_id: 0,
+        application_id: app_id,
+        filter_id: 0,
+        screen_id: 0,
+        // #2470: stamp the dataplane DECISION instant (wall-clock Unix ns) at
+        // emit time. `now_ns` is CLOCK_MONOTONIC.
         timestamp_ns: crate::event_stream::mono_ns_to_wall_clock_unix_ns(now_ns),
     };
     let _ = event_stream.try_emit_dataplane_event_at(event, now_ns);
@@ -747,6 +827,52 @@ mod tests {
             event.action, RT_FLOW_ACTION_DENY,
             "a suppressed reject must log DENY (silent drop), not REJECT"
         );
+    }
+
+    /// #3610 fail-on-revert: the host-inbound deny emitter builds a tuple-rich
+    /// RT_FLOW deny event that rides the `PolicyDeny` wire kind (so it reuses the
+    /// #3615 policy-deny event machinery) but carries the DISTINCT host-inbound
+    /// reason and an unconditional DENY action (host-inbound is always a silent
+    /// drop, never a reject). Reverting the reason back to the policy reason — or
+    /// the action away from DENY — makes these assertions fail; the event would
+    /// then be indistinguishable from a transit security-policy deny (the #3610
+    /// conflation the fix removes).
+    #[test]
+    fn host_inbound_deny_event_carries_host_inbound_reason() {
+        let (handle, rx) = unlimited_handle();
+        let flow = test_flow();
+
+        emit_host_inbound_deny_event(Some(&handle), &flow, test_meta(), 7, 0, mono_now_ns());
+
+        let event = rx
+            .try_recv()
+            .expect("host-inbound deny frame")
+            .decode_dataplane_event()
+            .expect("host-inbound deny payload");
+        assert_eq!(event.kind, DataplaneEventKind::PolicyDeny);
+        assert_eq!(event.action, RT_FLOW_ACTION_DENY);
+        assert_eq!(event.reason, RT_FLOW_CLOSE_REASON_HOST_INBOUND);
+        assert_ne!(
+            event.reason, RT_FLOW_CLOSE_REASON_POLICY,
+            "a host-inbound deny must NOT alias the transit policy-deny reason"
+        );
+        // No admitting/denying security policy on a host-inbound deny.
+        assert_eq!(event.policy_id, 0);
+        // Egress "zone" is the firewall host itself (#3110 sentinel 0).
+        assert_eq!(event.egress_zone_id, 0);
+        assert_eq!(event.ingress_zone_id, 7);
+        // Full tuple so an operator sees WHICH control-plane flow was denied.
+        assert_eq!(event.src_ip, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 10)));
+        assert_eq!(event.dst_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20)));
+        assert_eq!(event.src_port, 49152);
+        assert_eq!(event.dst_port, 443);
+        assert_eq!(event.ingress_ifindex, 42);
+        assert!(
+            event.timestamp_ns > 0,
+            "host-inbound deny event must carry a real wall-clock timestamp, got 0"
+        );
+        // Rides the policy-deny per-kind stats/rate-limiter — not a new channel.
+        assert_eq!(handle.dataplane_event_stats().policy_deny.sent, 1);
     }
 
     #[test]

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -162,6 +162,33 @@ fn emit_junos_host_deny(
     );
 }
 
+/// #3610: emit the tuple-rich host-inbound-traffic deny event for a host-bound
+/// packet rejected by the ingress zone's `host-inbound-traffic` admission gate.
+/// Resolves the application from the flow's destination (service) port with the
+/// same `resolve_policy_deny_app_id` the transit / junos-host deny path uses,
+/// then delegates to [`emit_host_inbound_deny_event`] (which reuses the #3615
+/// policy-deny event machinery with a distinct host-inbound reason). Shared by
+/// all three host-inbound deny arms: session-hit, session-miss, and the #3292
+/// flowless LocalDelivery arm — so every host-inbound drop emits an identical,
+/// tuple-rich record.
+fn emit_host_inbound_deny(
+    forwarding: &ForwardingState,
+    event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
+    flow: &SessionFlow,
+    meta: UserspaceDpMeta,
+    from_zone_id: u16,
+    now_ns: u64,
+) {
+    emit_host_inbound_deny_event(
+        event_stream,
+        flow,
+        meta,
+        from_zone_id,
+        resolve_policy_deny_app_id(&forwarding.app_catalog, flow, flow.forward_key.dst_port),
+        now_ns,
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 fn junos_host_policy_drops(
     forwarding: &ForwardingState,
@@ -286,7 +313,15 @@ fn flowless_local_delivery_verdict(
         meta,
         ingress_zone_override,
     ) {
-        None => return FlowlessLocalVerdict::HostInboundDeny,
+        None => {
+            // #3610: emit the tuple-rich host-inbound deny event before the
+            // silent flowless drop so an operator can see WHICH host-bound
+            // flowless flow (a non-first fragment / no-L4 packet) the zone
+            // host-inbound gate dropped. Reuses the policy-deny event machinery
+            // via the shared helper, identical to the flow-backed arms.
+            emit_host_inbound_deny(forwarding, event_stream, flow, meta, from_zone_id, now_ns);
+            return FlowlessLocalVerdict::HostInboundDeny;
+        }
         Some((action, lo0_log)) => {
             // #3615: flowless — no reply can be synthesized (a fragment has no
             // L4 header to build a RST/ICMP unreachable from), so emit the
@@ -918,7 +953,12 @@ pub(super) fn poll_binding_process_descriptor(
                                         resolved.origin,
                                     );
                                     telemetry.dbg.local += 1;
-                                    telemetry.dbg.policy_deny += 1;
+                                    // #3610/M07: account the host-inbound deny on
+                                    // its OWN debug counter, NOT `policy_deny` —
+                                    // conflating host-inbound drops with security-
+                                    // policy denies sent dataplane investigations
+                                    // down the wrong path.
+                                    telemetry.dbg.host_inbound_deny += 1;
                                     // #3326: account the host-inbound deny so
                                     // `GlobalCtrHostInboundDeny` (REST/Prometheus/
                                     // `show security flow statistics`) reflects the
@@ -926,6 +966,20 @@ pub(super) fn poll_binding_process_descriptor(
                                     // flushed into BindingLiveState.
                                     telemetry.counters.touched = true;
                                     telemetry.counters.host_inbound_denied_packets += 1;
+                                    // #3610: emit the tuple-rich host-inbound deny
+                                    // event so an operator can see WHICH host-bound
+                                    // flow was dropped (src/dst/proto/port + zone +
+                                    // ingress ifindex), not just an aggregate
+                                    // counter. Reuses the #3615 policy-deny event
+                                    // machinery with a distinct host-inbound reason.
+                                    emit_host_inbound_deny(
+                                        worker_ctx.forwarding,
+                                        worker_ctx.event_stream,
+                                        flow,
+                                        meta,
+                                        resolved.metadata.ingress_zone,
+                                        now_ns,
+                                    );
                                     binding.scratch.scratch_recycle.push(desc.addr);
                                     continue;
                                 }
@@ -1801,13 +1855,27 @@ pub(super) fn poll_binding_process_descriptor(
                                     // Host-inbound denied: silent drop, never
                                     // cached.
                                     telemetry.dbg.local += 1;
-                                    telemetry.dbg.policy_deny += 1;
+                                    // #3610/M07: own debug counter, not policy_deny.
+                                    telemetry.dbg.host_inbound_deny += 1;
                                     telemetry.counters.touched = true;
                                     // #3326: account the host-inbound deny so
                                     // `GlobalCtrHostInboundDeny` reflects the drop
                                     // (REST/Prometheus/`show security flow
                                     // statistics`).
                                     telemetry.counters.host_inbound_denied_packets += 1;
+                                    // #3610: emit the tuple-rich host-inbound deny
+                                    // event so an operator can see WHICH host-bound
+                                    // flow was dropped, not just an aggregate
+                                    // counter (reuses the policy-deny event
+                                    // machinery with a distinct host-inbound reason).
+                                    emit_host_inbound_deny(
+                                        worker_ctx.forwarding,
+                                        worker_ctx.event_stream,
+                                        flow,
+                                        meta,
+                                        from_zone_id,
+                                        now_ns,
+                                    );
                                     binding.scratch.scratch_recycle.push(desc.addr);
                                     continue;
                                 }
@@ -3186,7 +3254,12 @@ pub(super) fn poll_binding_process_descriptor(
                             FlowlessLocalVerdict::Deliver => {}
                             FlowlessLocalVerdict::HostInboundDeny => {
                                 telemetry.dbg.local += 1;
-                                telemetry.dbg.policy_deny += 1;
+                                // #3610/M07: own debug counter, not policy_deny.
+                                // The tuple-rich host-inbound deny event is emitted
+                                // inside `flowless_local_delivery_verdict` (co-
+                                // located with the decision, like the junos-host /
+                                // lo0 emits there).
+                                telemetry.dbg.host_inbound_deny += 1;
                                 telemetry.counters.touched = true;
                                 // #3326: account the host-inbound deny so
                                 // `GlobalCtrHostInboundDeny` reflects the drop.
@@ -5037,6 +5110,55 @@ mod flowless_local_delivery_tests {
             verdict(&fw, &flowless_flow(PROTO_TCP), flowless_meta(PROTO_TCP), ZONE),
             FlowlessLocalVerdict::HostInboundDeny,
         );
+    }
+
+    // #3610 fail-on-revert (flowless): a flowless host-bound packet denied by the
+    // zone host-inbound gate must ALSO emit the tuple-rich host-inbound deny
+    // event (the #3292 flowless LocalDelivery arm), not just return the verdict.
+    // Removing the `emit_host_inbound_deny` call in the `None => HostInboundDeny`
+    // branch drops the event → RED (empty channel).
+    #[test]
+    fn flowless_host_inbound_deny_emits_event() {
+        let (handle, rx) = crate::event_stream::test_worker_handle(
+            8,
+            crate::event_stream::DataplaneEventRateLimitConfig {
+                events_per_second: 0,
+                burst: 0,
+            },
+        );
+        let fw = fw_with_host_inbound(ZONE, &["ssh"], &[]);
+        let flow = flowless_flow(PROTO_TCP);
+        let v = flowless_local_delivery_verdict(
+            &fw,
+            Some(&handle),
+            flowless_extra(),
+            &flow,
+            flowless_meta(PROTO_TCP),
+            INGRESS_IF,
+            ZONE,
+            Some(ZONE),
+            64,
+            crate::afxdp::neighbor::monotonic_nanos(),
+        );
+        assert_eq!(v, FlowlessLocalVerdict::HostInboundDeny);
+
+        let event = rx
+            .try_recv()
+            .expect("#3610: flowless host-inbound deny must emit a tuple event")
+            .decode_dataplane_event()
+            .expect("host-inbound deny payload");
+        assert_eq!(
+            event.kind,
+            crate::event_stream::codec::DataplaneEventKind::PolicyDeny
+        );
+        // Distinct host-inbound reason (6), NOT the transit policy reason (5).
+        assert_eq!(event.reason, 6);
+        assert_eq!(event.action, 0, "host-inbound is a silent drop → DENY");
+        assert_eq!(event.policy_id, 0);
+        assert_eq!(event.ingress_zone_id, ZONE);
+        assert_eq!(event.src_ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9)));
+        assert_eq!(event.dst_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 99, 1)));
+        assert_eq!(handle.dataplane_event_stats().policy_deny.sent, 1);
     }
 
     // (b) NO over-gating: a flowless packet the zone DOES admit must still be

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -7063,6 +7063,123 @@ fn txn_run_descriptor_with_deliveries(
     (batch, dbg)
 }
 
+/// `txn_run_descriptor` with an event stream wired so a cold-path emit (deny /
+/// filter-log / host-inbound deny) can be observed on the returned receiver.
+/// Returns the batch + debug counters AND the event handle/receiver.
+fn txn_run_descriptor_capturing_events(
+    binding: &mut BindingWorker,
+    sessions: &mut SessionTable,
+    forwarding: &ForwardingState,
+    ha_state: &BTreeMap<i32, HAGroupRuntime>,
+    frame: &[u8],
+    meta: UserspaceDpMeta,
+) -> (
+    BatchCounters,
+    DebugPollCounters,
+    crate::event_stream::EventStreamWorkerHandle,
+    std::sync::mpsc::Receiver<crate::event_stream::codec::EventFrame>,
+) {
+    let meta_len = std::mem::size_of::<UserspaceDpMeta>();
+    let frame_offset = 128;
+    let meta_offset = frame_offset - meta_len;
+    let meta_bytes = unsafe {
+        std::slice::from_raw_parts((&meta as *const UserspaceDpMeta).cast::<u8>(), meta_len)
+    };
+    unsafe {
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(meta_offset, meta_len)
+            .expect("meta slice")
+            .copy_from_slice(meta_bytes);
+        binding
+            .umem
+            .area()
+            .slice_mut_unchecked(frame_offset, frame.len())
+            .expect("frame slice")
+            .copy_from_slice(frame);
+    }
+    binding.xsk.rx.push_for_test(XdpDesc {
+        addr: frame_offset as u64,
+        len: frame.len() as u32,
+        options: 0,
+    });
+
+    let ident = binding.identity();
+    let binding_lookup = WorkerBindingLookup::from_bindings(std::slice::from_ref(binding));
+    let mirror_targets = MirrorTargetMap::default();
+    let dynamic_neighbors = Arc::new(ShardedNeighborMap::default());
+    let shared_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_nat_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_forward_wire_sessions = Arc::new(Mutex::new(FastMap::default()));
+    let shared_owner_rg_indexes = SharedSessionOwnerRgIndexes::default();
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(BTreeMap::new()));
+    let recent_exceptions = Arc::new(Mutex::new(VecDeque::new()));
+    let last_resolution = Arc::new(Mutex::new(None));
+    let peer_worker_commands = Vec::new();
+    let dnat_fds = DnatTableFds::default();
+    let rg_epochs = std::array::from_fn(|_| AtomicU32::new(0));
+    let (event_handle, event_rx) = crate::event_stream::test_worker_handle(
+        8,
+        crate::event_stream::DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    let worker_ctx = WorkerContext {
+        ident: &ident,
+        binding_lookup: &binding_lookup,
+        mirror_targets: &mirror_targets,
+        forwarding,
+        ha_state,
+        dynamic_neighbors: &dynamic_neighbors,
+        neighbor_resolver: None,
+        shared_sessions: &shared_sessions,
+        shared_nat_sessions: &shared_nat_sessions,
+        shared_forward_wire_sessions: &shared_forward_wire_sessions,
+        shared_owner_rg_indexes: &shared_owner_rg_indexes,
+        slow_path: None,
+        event_stream: Some(&event_handle),
+        local_tunnel_deliveries: &local_tunnel_deliveries,
+        recent_exceptions: &recent_exceptions,
+        last_resolution: &last_resolution,
+        peer_worker_commands: &peer_worker_commands,
+        dnat_fds: &dnat_fds,
+        rg_epochs: &rg_epochs,
+        cold_path_sample_mask: 0xff,
+    };
+    let mut screen = ScreenState::new();
+    let mut batch = BatchCounters::default();
+    let mut dbg = DebugPollCounters::default();
+    let mut telemetry = TelemetryContext {
+        dbg: &mut dbg,
+        counters: &mut batch,
+    };
+    let area_ptr = binding.umem.area() as *const MmapArea;
+    poll_binding_process_descriptor(
+        binding,
+        0,
+        area_ptr,
+        1,
+        sessions,
+        &mut screen,
+        ValidationState {
+            snapshot_installed: true,
+            config_generation: 7,
+            fib_generation: 9,
+        },
+        crate::afxdp::neighbor::monotonic_nanos(),
+        123,
+        0,
+        0,
+        -1,
+        -1,
+        &worker_ctx,
+        &mut telemetry,
+    );
+    (batch, dbg, event_handle, event_rx)
+}
+
 fn txn_flow_cache_entries(binding: &BindingWorker) -> usize {
     binding.flow.flow_cache.entries.iter().flatten().count()
 }
@@ -8730,6 +8847,89 @@ fn poll_descriptor_host_inbound_deny_counts_local_delivery_session_miss() {
         0,
         "no host-local session may be cached for a host-inbound-denied flow"
     );
+}
+
+/// #3610 fail-on-revert (session-MISS, poll loop): a host-bound packet denied by
+/// the zone host-inbound admission gate must emit a tuple-rich RT_FLOW deny event
+/// — the #3615 policy-deny event kind carried with the DISTINCT host-inbound
+/// reason (6), not just the aggregate `host_inbound_denied_packets` counter — so
+/// an operator can see WHICH control-plane flow was dropped. Remove the
+/// `emit_host_inbound_deny` call in the session-MISS host-inbound `None` arm and
+/// this goes RED (empty event channel). Also pins the #3610/M07 debug-counter
+/// split: the deny bumps `dbg.host_inbound_deny`, NOT `dbg.policy_deny`.
+#[test]
+fn poll_descriptor_host_inbound_deny_emits_tuple_event_session_miss() {
+    let mut forwarding = build_forwarding_state(&gre_to_self_snapshot());
+    let zone_ids: Vec<u16> = forwarding.zone_id_to_name.keys().copied().collect();
+    assert!(!zone_ids.is_empty(), "fixture must define at least one zone");
+    for id in zone_ids {
+        forwarding
+            .zone_host_inbound
+            .insert(id, crate::afxdp::types::ZoneHostInbound::default());
+    }
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(10, 0, 61, 102),
+        Ipv4Addr::new(10, 255, 0, 1),
+        12345,
+        179,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(24, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+
+    let (batch, dbg, event_handle, event_rx) = txn_run_descriptor_capturing_events(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+    );
+
+    assert_eq!(dbg.local, 1, "packet must take the LocalDelivery arm");
+    assert_eq!(
+        batch.host_inbound_denied_packets, 1,
+        "the #3326 aggregate host-inbound deny counter must still fire"
+    );
+    // #3610/M07: the deny is accounted on its own debug counter, not policy_deny.
+    assert_eq!(
+        dbg.host_inbound_deny, 1,
+        "#3610/M07: host-inbound deny must bump dbg.host_inbound_deny"
+    );
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "#3610/M07: host-inbound deny must NOT be conflated with dbg.policy_deny"
+    );
+
+    let event = event_rx
+        .try_recv()
+        .expect("#3610: host-inbound deny must emit a tuple-rich event")
+        .decode_dataplane_event()
+        .expect("host-inbound deny payload");
+    assert_eq!(
+        event.kind,
+        crate::event_stream::codec::DataplaneEventKind::PolicyDeny
+    );
+    // Distinct host-inbound reason (6), NOT the transit policy-deny reason (5).
+    assert_eq!(event.reason, 6, "host-inbound deny reason byte");
+    assert_eq!(event.action, 0, "host-inbound is a silent drop → DENY");
+    assert_eq!(event.protocol, PROTO_TCP);
+    assert_eq!(event.src_ip, IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)));
+    assert_eq!(event.dst_ip, IpAddr::V4(Ipv4Addr::new(10, 255, 0, 1)));
+    assert_eq!(event.src_port, 12345);
+    assert_eq!(event.dst_port, 179);
+    assert_eq!(event.ingress_ifindex, 24);
+    assert_eq!(event.policy_id, 0, "host-inbound admission is not a policy");
+    assert!(
+        event.timestamp_ns > 0,
+        "poll-path host-inbound deny event must carry a real wall-clock timestamp"
+    );
+    // Rides the policy-deny per-kind stats, not a new event channel.
+    assert_eq!(event_handle.dataplane_event_stats().policy_deny.sent, 1);
 }
 
 /// #3326 GREEN companion: with NO host-inbound restriction (admit-all default),

--- a/userspace-dp/src/afxdp/types/runtime.rs
+++ b/userspace-dp/src/afxdp/types/runtime.rs
@@ -354,6 +354,11 @@ pub(in crate::afxdp) struct DebugPollCounters {
     pub(in crate::afxdp) neg_neigh_fast_fail: u64,
     #[allow(dead_code)]
     pub(in crate::afxdp) policy_deny: u64,
+    /// #3610/M07: host-inbound-traffic admission denies, split out of
+    /// `policy_deny` so a control-plane host-inbound drop is not conflated with a
+    /// transit security-policy deny in the periodic debug report.
+    #[allow(dead_code)]
+    pub(in crate::afxdp) host_inbound_deny: u64,
     #[allow(dead_code)]
     pub(in crate::afxdp) ha_inactive: u64,
     #[allow(dead_code)]

--- a/userspace-dp/src/afxdp/worker/loop_body/debug_report.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/debug_report.rs
@@ -51,6 +51,9 @@ pub(super) struct DbgCounters {
     /// #1651 B3: dead-host negative-cache fast-fail count.
     pub(super) neg_neigh_fast_fail: u64,
     pub(super) policy_deny: u64,
+    /// #3610/M07: host-inbound-traffic admission denies, distinct from
+    /// `policy_deny` (transit security-policy denies).
+    pub(super) host_inbound_deny: u64,
     pub(super) ha_inactive: u64,
     pub(super) no_egress_binding: u64,
     pub(super) build_fail: u64,
@@ -101,6 +104,7 @@ impl DbgCounters {
         self.missing_neigh += dbg_poll.missing_neigh;
         self.neg_neigh_fast_fail += dbg_poll.neg_neigh_fast_fail;
         self.policy_deny += dbg_poll.policy_deny;
+        self.host_inbound_deny += dbg_poll.host_inbound_deny;
         self.ha_inactive += dbg_poll.ha_inactive;
         self.no_egress_binding += dbg_poll.no_egress_binding;
         self.build_fail += dbg_poll.build_fail;
@@ -156,7 +160,7 @@ pub(super) fn emit_periodic_report(
     let secs = elapsed as f64 / 1_000_000_000.0;
     eprintln!(
         "DBG w{}: {:.1}s rx={} tx={} fwd={} local={} sess_hit={} sess_miss={} sess_create={} \
-         no_route={} miss_neigh={} neg_ff={} pol_deny={} ha_inact={} no_egress={} build_fail={} \
+         no_route={} miss_neigh={} neg_ff={} pol_deny={} hib_deny={} ha_inact={} no_egress={} build_fail={} \
          tx_err={} meta_err={} other={} enq_ok={} enq_ip={} enq_dir={} enq_cp={} sessions={} \
          DIR:trust_rx={}/wan_rx={}/t2w={}/w2t={} NAT:snat={}/dnat={}/none={}/bld_none={} RST:rx={}/tx={} \
          SIZE:rx_avg={}/rx_max={}/tx_avg={}/tx_max={}/rx_over={}/seg_miss={} \
@@ -176,6 +180,7 @@ pub(super) fn emit_periodic_report(
         dbg.missing_neigh,
         dbg.neg_neigh_fast_fail,
         dbg.policy_deny,
+        dbg.host_inbound_deny,
         dbg.ha_inactive,
         dbg.no_egress_binding,
         dbg.build_fail,


### PR DESCRIPTION
Closes #3610

## Problem

Host-inbound-traffic admission denies — a host-bound / control-plane
packet rejected by the ingress zone's `host-inbound-traffic` gate — were
accounted only by the aggregate `host_inbound_denied_packets` counter,
with **no** tuple-rich dataplane event. An operator could see THAT
host-inbound denies happened but not who hit which control-plane service
(src/dst IP, protocol, port, ingress zone/interface) — below the quality
of transit RT_FLOW policy-deny logging (Codex review 001, **H06** +
**L04**). The deny branches also bumped `dbg.policy_deny`, conflating
host-inbound drops with real security-policy denies (**M07**).

## Fix

Add `emit_host_inbound_deny_event`, a thin sibling of the #3615
`emit_policy_deny_event`. It **reuses the same event machinery** — the
`DataplaneEventKind::PolicyDeny` wire kind, the #3615 per-kind rate
limiter, queue budget, and the Go RT_FLOW renderer/decoder — so **no
parallel emit path** is added. Only a distinct reason byte
(`RT_FLOW_CLOSE_REASON_HOST_INBOUND` = 6) marks it apart from a transit
policy deny. A host-inbound admission deny is always a silent drop (no
admitting/denying security policy, no reject reply), so the action is
unconditionally DENY, `policy_id`/`egress_zone_id`/`owner_rg_id` are 0,
and the record carries no NAT translation. The 5-tuple, ingress zone,
ingress ifindex, protocol, and resolved application come from the denied
flow.

Wired into **all three** host-inbound deny arms via a shared
`emit_host_inbound_deny` helper:
- session-hit LocalDelivery (inline)
- session-miss LocalDelivery (inline)
- **flowless** LocalDelivery (#3292 non-first-fragment / no-L4) —
  emitted inside `flowless_local_delivery_verdict`, co-located with the
  decision like the junos-host / lo0 emits there.

**M07 counter split:** those arms now bump the new `dbg.host_inbound_deny`
(added to `DebugPollCounters`, `DbgCounters`, the accumulate fold, and
the periodic report as `hib_deny=`) instead of `dbg.policy_deny`. The
aggregate `host_inbound_denied_packets` counter is unchanged.

**Go rendering:** `closeReasonHostInbound` (6) → `"Denied by
host-inbound-traffic"`. The structured `RT_FLOW_SESSION_DENY` formatter
now renders the on-wire reason instead of a hardcoded string — for a
transit deny (reason 5) the output is byte-identical (`reason="Rejected
by policy"`), for a host-inbound deny it shows the distinct string.

No wire fixture regen: the change reuses the existing reason byte with a
new value, not a new wire field.

## Tests

- **Emitter unit test** (`event_emit.rs`): distinct reason + DENY action
  + full tuple, fail-on-revert.
- **Flowless verdict unit test**: event emitted on the #3292 arm.
- **Poll-loop fail-on-revert test** (`tests.rs`): drives the real
  `poll_binding_process_descriptor` session-miss host-inbound deny;
  asserts the tuple-rich event is emitted (RED / empty channel on
  revert — verified) AND the counter split.
- **Go**: fail-on-revert that a host-inbound-reason POLICY_DENY frame
  decodes + renders the distinct reason with the full 5-tuple, plus a
  byte-identical guard for transit policy denies.

Full `cargo test --release` (3332+ Rust tests) and `go test
./pkg/logging/ ./pkg/dataplane/...` green; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi