### PR TITLE
#3639: enforce to-zone junos-host GLOBAL (from-zone any) host-inbound policy

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-01 — #3639 enforce to-zone junos-host GLOBAL (from-zone any) host-inbound policy
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3639 (#3611 Piece B) — a GLOBAL `set security policies global
+    policy <p> match to-zone junos-host` (host-INBOUND) was REJECTED at commit
+    and, even if committed, the userspace host gate never consulted the global
+    tier, so the rule was inert. Fixed in ONE coupled change (indexing without
+    lifting is dead; lifting without indexing is a silent fail-open):
+    (1) Go — `validatePolicyZoneReferencesStrict` (compiler_validate_strict.go)
+    now lifts the `match to-zone junos-host` reject (host-INBOUND traverses the
+    AF_XDP LocalDelivery gate); the `match from-zone junos-host` reject
+    (host-ORIGINATED, kernel-TX path, #3611 Piece A) is KEPT.
+    (2) Rust — `evaluate_junos_host_policy_l3_aware` (policy.rs) now consults a
+    GLOBAL tier (global_indices filtered to `global_to_zone ==
+    Zone(JUNOS_HOST_ZONE_ID)`, gated by `global_from_zone.matches(from_id)`)
+    AFTER the exact `from-zone <ingress> to-zone junos-host` pair and the
+    `from-zone any to-zone junos-host` wildcard — most-specific-first, matching
+    transit-policy precedence. A global `match to-zone junos-host` also arms
+    `has_junos_host_rules` (the context rides in `match_to_zone`, not the
+    structural `to_zone`). No wire change (match_from_zone/match_to_zone already
+    flow Go→Rust since #3148). Also mirrored the global tier into the Go CLI
+    simulator `matchJunosHost` (pkg/policymatch) so `show security
+    match-policies` agrees with the dataplane. RED-on-revert tests: Go
+    (commit-accept of to-zone junos-host global), Rust + policymatch (global
+    deny governs host-inbound where no exact pair matches; exact pair still
+    wins over global).
+  - **File(s)**: pkg/config/compiler_validate_strict.go,
+    pkg/config/compiler_policy_global_zone_3148_test.go,
+    userspace-dp/src/policy.rs, userspace-dp/src/policy_tests.rs,
+    pkg/policymatch/policymatch.go, pkg/policymatch/junos_host_test.go,
+    docs/junos-cli-reference.md, docs/userspace-dataplane-architecture.md,
+    docs/config-schema.md, pkg/config/README.md, pkg/policymatch/README.md
+
 ## 2026-07-01 — #3610 host-inbound denies emit a tuple-rich RT_FLOW event
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2006,11 +2006,15 @@ reserved special token) and `build_global_zone_scope` (policy.rs) short-circuits
 would route through `resolve_policy_zone_id` → `None` → `Unresolved` and a
 `permit` global would silently over-restrict / a `deny` global silently no-op —
 a commit-vs-dataplane divergence on a security leaf. The reserved `junos-host`
-zone is the one special token that is NOT accepted here: a zone-scoped global
-policy is not evaluated on the host-bound (LocalDelivery) path, so
-`validatePolicyZoneReferencesStrict` hard-rejects `match from-zone junos-host` /
-`to-zone junos-host` at commit (rather than committing a silent never-match);
-real junos-host global-zone-context support is a follow-up.
+zone is direction-split (#3639 / #3611 Piece B): `match to-zone junos-host`
+(host-INBOUND) commits and IS enforced — host-bound traffic traverses the
+AF_XDP LocalDelivery gate and the dataplane consults the global tier there
+(`evaluate_junos_host_policy_l3_aware`, filtered to the junos-host egress
+scope, most-specific-after-exact-and-from-any). `match from-zone junos-host`
+(host-ORIGINATED) is still hard-rejected by `validatePolicyZoneReferencesStrict`
+at commit: locally generated traffic egresses via the kernel TX path, not the
+AF_XDP RX gate, so it could only ever silently never-match (#3611 Piece A,
+documented not built).
 
 **Zone-local address books in a scoped global (#3287).** A scoped global
 (`match from-zone <z>` / `match to-zone <z>`) resolves a zone-local

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -512,11 +512,15 @@ From zone: guest, To zone: lan
     cannot silently brick management/host traffic that does not match a deny
     rule. (The stricter Junos "any configured junos-host zone-pair implies a
     default-deny for that pair" posture is intentionally deferred.)
-  - **Scope:** `to-zone junos-host` (host-INBOUND) is enforced.
-    `from-zone junos-host` (host-ORIGINATED / locally-generated traffic) rules
-    are accepted and indexed but NOT yet consulted — locally-generated traffic
-    does not traverse the ingress LocalDelivery path; that direction is a
-    documented follow-up.
+  - **Scope:** `to-zone junos-host` (host-INBOUND) is enforced — as an exact
+    `from-zone <ingress> to-zone junos-host` pair, a `from-zone any to-zone
+    junos-host` wildcard, AND a GLOBAL `set security policies global policy <p>
+    match to-zone junos-host` (#3639 / #3611 Piece B). The three are consulted
+    most-specific-first (exact → from-any → global). `from-zone junos-host`
+    (host-ORIGINATED / locally-generated traffic) rules — zone-pair or global —
+    are NOT consulted: locally-generated traffic does not traverse the ingress
+    LocalDelivery path (it egresses via the kernel TX path), so that direction
+    is rejected at commit and remains a documented follow-up (#3611 Piece A).
 
 ### Filtering
 
@@ -669,8 +673,14 @@ Global policies:
   evaluated in the global ordering, AFTER the exact zone-pair and the `from-zone
   any` / `to-zone any` wildcard policies — it does not jump ahead of them. An
   omitted leaf and an explicit `match from-zone any` are identical (all zones);
-  an undefined match zone is rejected at commit, and `match from-zone junos-host`
-  / `to-zone junos-host` is rejected (not supported on a global policy).
+  an undefined match zone is rejected at commit. A `match to-zone junos-host`
+  global (host-INBOUND) commits and IS enforced on the LocalDelivery gate
+  (#3639 / #3611 Piece B) — consulted in the global tier, after the exact
+  `from-zone <ingress> to-zone junos-host` pair and the `from-zone any to-zone
+  junos-host` wildcard. A `match from-zone junos-host` global (host-ORIGINATED)
+  is still rejected: locally generated traffic egresses via the kernel TX path,
+  not the AF_XDP RX gate, so it could only ever silently never-match (#3611
+  Piece A, documented not built).
 - **#3286 — scope shown on EVERY inventory surface.** Before #3286 only the
   dataplane enforced the scope; the show/inventory surfaces dropped it and
   rendered scoped globals as all-zones. All surfaces now reflect the configured

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -632,10 +632,16 @@ fail-closed for an undefined zone). An OMITTED leaf and an explicit `any` both
 map to `Any` (all zones, the Junos implicit default) — `build_global_zone_scope`
 short-circuits `"any"` so it can never route to `Unresolved` and silently match
 nothing, keeping the dataplane in agreement with the Go commit gate (which
-exempts `any`). The reserved `junos-host` zone is hard-rejected as a global
-match context at commit (a zone-scoped global policy is not evaluated on the
-host-bound path, so it could only ever silently never-match — real junos-host
-global-zone support is a follow-up). The scope is checked as an extra predicate
+exempts `any`). The reserved `junos-host` zone is direction-split as a global
+match context (#3639 / #3611 Piece B): `match to-zone junos-host` (host-INBOUND)
+commits and IS enforced — `evaluate_junos_host_policy_l3_aware` consults the
+`global_indices` tier filtered to `global_to_zone == Zone(JUNOS_HOST_ZONE_ID)`,
+after the exact `from-zone <ingress> to-zone junos-host` pair and the `from-zone
+any to-zone junos-host` wildcard (a scoped global stays least-specific). `match
+from-zone junos-host` (host-ORIGINATED) stays hard-rejected at commit — locally
+generated traffic egresses via the kernel TX path, never the AF_XDP RX gate, so
+it could only ever silently never-match (#3611 Piece A, documented not built).
+The scope is checked as an extra predicate
 inside the `junos-global` tier loop, **in the same tier position** shown above:
 a zone-scoped global policy is NOT promoted ahead of the #3090 wildcard tiers.
 Precedence example — a `from-zone any to-zone untrust` wildcard (zone-pair

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -442,11 +442,13 @@ to-any merged in config order) → both-any → `junos-global` → default polic
 There is **no N×N hot-path expansion** — the wildcard tiers are FxHashMap O(1)
 probes (or a small Vec scan only when such rules exist), so a config with no
 wildcard policy pays only two empty-slice probes per cold-path evaluation. A
-`from-zone any to-zone junos-host` rule is also enforced on the host
-(LocalDelivery) path (`evaluate_junos_host_policy`); `to-zone any` /
-`from-zone any to-zone any` are intentionally NOT applied to host-bound traffic
-so a broad rule cannot silently brick the management lifeline (mirroring the
-existing no-global-on-host-path rule). Wildcard tiers live inside the
+`from-zone any to-zone junos-host` rule — and a GLOBAL `policy match to-zone
+junos-host` (#3639 / #3611 Piece B) — are also enforced on the host
+(LocalDelivery) path (`evaluate_junos_host_policy`, most-specific-first: exact →
+from-any → global); `to-zone any` / `from-zone any to-zone any` transit
+wildcards are intentionally NOT applied to host-bound traffic so a broad rule
+cannot silently brick the management lifeline (only a global explicitly scoped
+`to-zone junos-host` is consulted). Wildcard tiers live inside the
 `from_id != 0 && to_id != 0` guard, so an unzoned flow still falls through to
 the default action (#3110), exactly like a global policy. This lifts the #3018
 interim commit reject (`validatePolicyWildcardZoneStrict` and its

--- a/pkg/config/compiler_policy_global_zone_3148_test.go
+++ b/pkg/config/compiler_policy_global_zone_3148_test.go
@@ -134,25 +134,44 @@ func TestGlobalPolicyZoneContextStrictCommit(t *testing.T) {
 		}
 	})
 
-	// `junos-host` cannot be honored as a global match context (a zone-scoped
-	// global policy is not evaluated on the host-bound path), so it is
-	// hard-rejected at commit so the commit gate and the dataplane agree —
-	// rather than committing into a silent never-match. Fail-on-revert: drop the
-	// junos-host reject in validatePolicyZoneReferencesStrict and this commits.
-	t.Run("junos_host_zone_rejected", func(t *testing.T) {
-		for _, leaf := range []string{"from-zone", "to-zone"} {
-			cmds := append([]string{}, zoneDefs...)
-			cmds = append(cmds,
-				"set security policies global policy hostctx match "+leaf+" junos-host")
-			cmds = append(cmds, matchBody("hostctx")...)
-			tree := build3148Tree(t, cmds...)
-			_, err := CompileConfig(tree)
-			if err == nil {
-				t.Fatalf("CompileConfig accepted a global policy match %s junos-host; want a hard reject", leaf)
-			}
-			if !strings.Contains(err.Error(), "junos-host") || !strings.Contains(err.Error(), "not supported") {
-				t.Fatalf("match %s junos-host error = %v, want an unsupported-junos-host reject", leaf, err)
-			}
+	// #3639 / #3611 Piece B: a global `match from-zone junos-host`
+	// (host-ORIGINATED) stays hard-rejected — locally generated traffic egresses
+	// via the kernel TX path, never the AF_XDP RX gate, so it could only ever
+	// silently never-match. Fail-on-revert: drop the from-zone junos-host reject
+	// in validatePolicyZoneReferencesStrict and this commits.
+	t.Run("junos_host_from_zone_rejected", func(t *testing.T) {
+		cmds := append([]string{}, zoneDefs...)
+		cmds = append(cmds,
+			"set security policies global policy hostctx match from-zone junos-host")
+		cmds = append(cmds, matchBody("hostctx")...)
+		tree := build3148Tree(t, cmds...)
+		_, err := CompileConfig(tree)
+		if err == nil {
+			t.Fatal("CompileConfig accepted a global policy match from-zone junos-host; want a hard reject")
+		}
+		if !strings.Contains(err.Error(), "junos-host") || !strings.Contains(err.Error(), "not supported") {
+			t.Fatalf("match from-zone junos-host error = %v, want an unsupported-junos-host reject", err)
+		}
+	})
+
+	// #3639 / #3611 Piece B: a global `match to-zone junos-host` (host-INBOUND)
+	// is now SUPPORTED and commits cleanly — host-bound traffic traverses the
+	// AF_XDP LocalDelivery gate and the userspace dataplane consults the global
+	// tier there (evaluate_junos_host_policy_l3_aware). Fail-on-revert: restore
+	// the to-zone junos-host reject in validatePolicyZoneReferencesStrict and
+	// this commit turns into a hard error, so RED.
+	t.Run("junos_host_to_zone_commits", func(t *testing.T) {
+		cmds := append([]string{}, zoneDefs...)
+		cmds = append(cmds,
+			"set security policies global policy hostctx match to-zone junos-host")
+		cmds = append(cmds, matchBody("hostctx")...)
+		tree := build3148Tree(t, cmds...)
+		cfg, err := CompileConfig(tree)
+		if err != nil {
+			t.Fatalf("CompileConfig rejected a global policy match to-zone junos-host; want a clean commit (#3639): %v", err)
+		}
+		if len(cfg.Security.GlobalPolicies) != 1 || cfg.Security.GlobalPolicies[0].Match.ToZone != "junos-host" {
+			t.Fatalf("global match to-zone junos-host not preserved: %+v", cfg.Security.GlobalPolicies)
 		}
 	})
 

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -2712,24 +2712,28 @@ func validatePolicyZoneReferencesStrict(cfg *Config) error {
 		if pol == nil {
 			continue
 		}
-		// The reserved self-traffic zone `junos-host` cannot be honored as a
-		// global-policy from/to-zone match context: the userspace dataplane
-		// does NOT evaluate a zone-scoped global policy on the host-bound
-		// (LocalDelivery) path, so a `match from-zone junos-host` / `to-zone
-		// junos-host` global would commit but silently never match (a
-		// commit-vs-dataplane divergence on a security leaf). Reject it at
-		// commit so the two layers agree; real junos-host global-zone-context
-		// support is a follow-up. (`any` and the empty token stay exempt =
-		// all-zones, matching build_global_zone_scope in policy.rs.)
+		// The reserved self-traffic zone `junos-host` is direction-split for a
+		// global-policy match context (#3639, #3611 Piece B):
+		//
+		//   - `match to-zone junos-host` (host-INBOUND) IS supported and now
+		//     commits. Host-bound traffic traverses the AF_XDP LocalDelivery
+		//     gate, and the userspace dataplane consults the global tier there
+		//     (evaluate_junos_host_policy_l3_aware indexes global-scoped
+		//     junos-host rules — most-specific-after-exact-and-from-any). Commit
+		//     and the dataplane agree, so it is no longer rejected.
+		//   - `match from-zone junos-host` (host-ORIGINATED) stays rejected: the
+		//     firewall's own sockets egress via the kernel TX path, never the
+		//     AF_XDP RX gate, so a from-zone junos-host global would commit but
+		//     silently never match (the #3611 Piece A architectural limitation —
+		//     documented, not built). Reject it at commit so the two layers
+		//     agree.
+		//
+		// (`any` and the empty token stay exempt = all-zones, matching
+		// build_global_zone_scope in policy.rs.)
 		if pol.Match.FromZone == "junos-host" {
 			return fmt.Errorf(
-				"security policies global policy %q match from-zone %q is not supported (a zone-scoped global policy is not evaluated on the host-bound path, so it would silently never match); remove the junos-host match context (#3148)",
+				"security policies global policy %q match from-zone %q is not supported (host-originated traffic egresses via the kernel TX path, not the AF_XDP RX gate, so a from-zone junos-host global would silently never match); remove the junos-host match context (#3611 Piece A)",
 				pol.Name, pol.Match.FromZone)
-		}
-		if pol.Match.ToZone == "junos-host" {
-			return fmt.Errorf(
-				"security policies global policy %q match to-zone %q is not supported (a zone-scoped global policy is not evaluated on the host-bound path, so it would silently never match); remove the junos-host match context (#3148)",
-				pol.Name, pol.Match.ToZone)
 		}
 		if !defined(pol.Match.FromZone) {
 			return fmt.Errorf(

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -189,9 +189,11 @@ the CLI, which already requires both zones (#3355 H06).
 
 A `to-zone junos-host` query takes the separate **host gate** (#3285,
 `matchJunosHost` ↔ `evaluate_junos_host_policy`): exact `from-zone <ingress>
-to-zone junos-host` then `from-zone any to-zone junos-host`, with **no** global
-or default transit fallback (and `to-zone any` / `from-zone any to-zone any` are
-NOT pulled onto the host path). An unmatched host-bound flow returns
+to-zone junos-host`, then `from-zone any to-zone junos-host`, then a GLOBAL
+`policy match to-zone junos-host` (#3639 / #3611 Piece B) — most-specific-first,
+with **no** transit default fallback (and the transit `to-zone any` / `from-zone
+any to-zone any` wildcards are NOT pulled onto the host path; only a global
+explicitly scoped `to-zone junos-host` is). An unmatched host-bound flow returns
 `Result.HostInboundUnmatched` — no security *policy* governs it, never an
 inherited transit verdict. Local delivery is instead gated by
 host-inbound-traffic service admission, which post-#3405 DEFAULT-DENIES a zone

--- a/pkg/policymatch/junos_host_test.go
+++ b/pkg/policymatch/junos_host_test.go
@@ -111,6 +111,55 @@ func TestJunosHostGateNoTransitFallback(t *testing.T) {
 			q:           Query{FromZone: "trust", ToZone: "junos-host"},
 			wantMatched: true, wantName: "trust-host-permit", wantAction: config.PolicyPermit,
 		},
+		{
+			// #3639 / #3611 Piece B: a GLOBAL `match to-zone junos-host deny`
+			// IS applied on the host path (the direction lifted from the #3018
+			// commit reject), matching every ingress that has no exact / from-any
+			// junos-host pair.
+			name: "global to-zone junos-host deny matches host path",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "dmz"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "g-host-deny", Match: config.PolicyMatch{ToZone: "junos-host"}, Action: config.PolicyDeny},
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "dmz", ToZone: "junos-host"},
+			wantMatched: true, wantName: "g-host-deny", wantAction: config.PolicyDeny,
+		},
+		{
+			// Precedence: an exact zone-pair junos-host permit outranks a global
+			// to-zone junos-host deny (specific beats global).
+			name: "exact junos-host outranks global to-zone junos-host",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyDeny,
+				Zones:         zones("trust"),
+				Policies: []*config.ZonePairPolicies{
+					zonePair("trust", "junos-host", permit("trust-host-permit", config.PolicyMatch{})),
+				},
+				GlobalPolicies: []*config.Policy{
+					{Name: "g-host-deny", Match: config.PolicyMatch{ToZone: "junos-host"}, Action: config.PolicyDeny},
+				},
+			}, config.ApplicationsConfig{}),
+			q:           Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched: true, wantName: "trust-host-permit", wantAction: config.PolicyPermit,
+		},
+		{
+			// A global scoped `match from-zone dmz to-zone junos-host` is
+			// ingress-scoped: a trust-ingress host query does NOT match it →
+			// local delivery (HostInboundUnmatched), no implicit default-deny.
+			name: "global from-zone-scoped junos-host does not match other ingress",
+			cfg: cfgWith(config.SecurityConfig{
+				DefaultPolicy: config.PolicyPermit,
+				Zones:         zones("trust", "dmz"),
+				GlobalPolicies: []*config.Policy{
+					{Name: "g-dmz-host-deny", Match: config.PolicyMatch{FromZone: "dmz", ToZone: "junos-host"}, Action: config.PolicyDeny},
+				},
+			}, config.ApplicationsConfig{}),
+			q:             Query{FromZone: "trust", ToZone: "junos-host"},
+			wantMatched:   false,
+			wantHostUnmat: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -501,15 +501,17 @@ func Match(cfg *config.Config, q Query) Result {
 }
 
 // matchJunosHost mirrors the dataplane host gate evaluate_junos_host_policy
-// (policy.rs) for a `to-zone junos-host` query (#3285). It consults ONLY exact
-// `from-zone <ingress> to-zone junos-host` rules, then the
-// `from-zone any to-zone junos-host` wildcard — in that order. There is NO
-// implicit host default-deny and NO global / transit-default fallback: an
-// unmatched host-bound flow falls through to local delivery (the management
-// lifeline guarantee), so the simulator returns HostInboundUnmatched rather
-// than inheriting the transit global/default verdict. `to-zone any` and
-// `from-zone any to-zone any` are deliberately NOT pulled onto the host path,
-// matching the runtime gate.
+// (policy.rs) for a `to-zone junos-host` query (#3285). It consults, in Junos
+// most-specific-first order: exact `from-zone <ingress> to-zone junos-host`
+// rules, then the `from-zone any to-zone junos-host` wildcard, then a GLOBAL
+// policy `match to-zone junos-host` (#3639 / #3611 Piece B). There is NO
+// implicit host default-deny and NO transit-default fallback: an unmatched
+// host-bound flow falls through to local delivery (the management lifeline
+// guarantee), so the simulator returns HostInboundUnmatched rather than
+// inheriting the transit default verdict. `to-zone any` and `from-zone any
+// to-zone any` transit wildcards are deliberately NOT pulled onto the host
+// path, matching the runtime gate — only a global explicitly scoped to
+// `to-zone junos-host` is consulted.
 func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Result {
 	// #3355: evaluate_junos_host_policy returns None for from_id == 0 (the
 	// unknown/undefined ingress zone), mirroring the #3110 unzoned guard. An
@@ -542,8 +544,32 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 			}
 		}
 	}
+	// #3639 / #3611 Piece B: a GLOBAL policy `match to-zone junos-host`
+	// (host-INBOUND) governs host-bound traffic in the GLOBAL tier — consulted
+	// LAST, after the exact `from-zone <ingress> to-zone junos-host` pair and
+	// the `from-zone any to-zone junos-host` wildcard, mirroring the dataplane
+	// (evaluate_junos_host_policy_l3_aware) and transit-policy precedence (a
+	// global policy is least-specific and never jumps ahead of a zone-pair
+	// rule). The optional `match from-zone` scope still restricts by ingress
+	// zone (empty / "any" = every zone). We filter on Match.ToZone directly
+	// rather than globalScopeMatches because junos-host is not a defined zone in
+	// cfg.Security.Zones (globalScopeMatches would fail it closed). A `match
+	// from-zone junos-host` global (host-ORIGINATED) is rejected at commit and
+	// never reaches this host-inbound path (#3611 Piece A).
+	globalSetIdx := len(cfg.Security.Policies)
+	for sliceIdx, pol := range cfg.Security.GlobalPolicies {
+		if pol == nil || pol.Match.ToZone != JunosHostZone {
+			continue
+		}
+		if !globalScopeMatches(cfg, pol.Match.FromZone, q.FromZone) {
+			continue
+		}
+		if ruleMatches(cfg, q, pol) {
+			return matchedResult(ids, pol, true, pol.Match.FromZone, pol.Match.ToZone, globalSetIdx, sliceIdx)
+		}
+	}
 	// No host-bound rule matched: local delivery proceeds. Do NOT fall through
-	// to global/default — the dataplane host gate returns None here.
+	// to the transit default — the dataplane host gate returns None here.
 	return Result{HostInboundUnmatched: true}
 }
 

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -2242,7 +2242,18 @@ pub(crate) fn parse_policy_state_with_counters(
 
         // #3019: arm the LocalDelivery junos-host policy gate iff a rule
         // actually names the reserved self zone on either side.
-        if snap.from_zone == JUNOS_HOST_ZONE_NAME || snap.to_zone == JUNOS_HOST_ZONE_NAME {
+        //
+        // #3639: a GLOBAL policy carries its junos-host context out-of-band in
+        // `match_to_zone` (its structural `to_zone` stays "junos-global"), so a
+        // `global policy ... match to-zone junos-host` must ALSO arm the gate —
+        // otherwise `evaluate_junos_host_policy_l3_aware` short-circuits on
+        // `!has_junos_host_rules` and the global-tier host consult below never
+        // runs. `match_to_zone` is populated only for globals, so this can never
+        // fire for a plain zone-pair rule.
+        if snap.from_zone == JUNOS_HOST_ZONE_NAME
+            || snap.to_zone == JUNOS_HOST_ZONE_NAME
+            || snap.match_to_zone == JUNOS_HOST_ZONE_NAME
+        {
             state.has_junos_host_rules = true;
         }
 
@@ -2812,6 +2823,11 @@ fn resolve_policy_zone_id(
 
 /// #3019: evaluate a configured `to-zone junos-host` security policy for a
 /// host-bound (LocalDelivery) flow whose ingress (from) zone id is `from_id`.
+/// Consulted in Junos most-specific-first precedence: the exact `from-zone
+/// <ingress> to-zone junos-host` pair, then the `from-zone any to-zone
+/// junos-host` wildcard (#3090), then a GLOBAL policy `match to-zone
+/// junos-host` (#3639, least-specific — a scoped global stays a global and is
+/// never promoted ahead of a zone-pair rule).
 ///
 /// Junos ordering: host-inbound-traffic admission runs FIRST in the caller; a
 /// packet only reaches this gate after host-inbound has admitted it, so a
@@ -2832,10 +2848,11 @@ fn resolve_policy_zone_id(
 /// rule. The stricter Junos "configured zone-pair implies default-deny"
 /// posture is intentionally deferred (see docs/junos-cli-reference.md).
 ///
-/// `from-zone junos-host` (host-ORIGINATED) rules are indexed by the same name
-/// resolution but are NOT consulted here: locally-generated traffic does not
-/// traverse the ingress LocalDelivery path. That direction is a documented
-/// follow-up.
+/// `from-zone junos-host` (host-ORIGINATED) rules — whether zone-pair or a
+/// GLOBAL `match from-zone junos-host` — are NOT consulted here: locally
+/// generated traffic egresses via the kernel TX path and does not traverse the
+/// ingress LocalDelivery path. That direction is rejected at commit and is a
+/// documented follow-up (#3611 Piece A).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn evaluate_junos_host_policy(
     state: &PolicyState,
@@ -2936,6 +2953,43 @@ pub(crate) fn evaluate_junos_host_policy_l3_aware(
                 result.policy_counter_idx = (idx as u32).saturating_add(1);
                 return Some(result);
             }
+        }
+    }
+    // #3639: a GLOBAL policy `match to-zone junos-host` (host-INBOUND) governs
+    // host-bound traffic in the GLOBAL tier — evaluated LAST here, AFTER the
+    // exact `from-zone <ingress> to-zone junos-host` pair and the `from-zone any
+    // to-zone junos-host` wildcard, mirroring transit-policy precedence (a
+    // global policy is least-specific and is never promoted ahead of a
+    // zone-pair rule; see evaluate_policy_result_l3_aware). Only globals scoped
+    // to the junos-host EGRESS side are consulted; the optional `match
+    // from-zone` scope still restricts by ingress zone (Any = every zone, the
+    // `from-zone any to-zone junos-host` global the #3639 commit-reject lift
+    // enables). This is the enforcement half the reject lift is coupled with —
+    // lifting the commit reject without consulting here would re-open the exact
+    // silent fail-open the #3018/#3148 reject closed. A `from-zone junos-host`
+    // global (host-ORIGINATED) is NOT consulted: that direction never traverses
+    // the RX LocalDelivery gate and is rejected at commit (#3611 Piece A).
+    for &idx in &state.global_indices {
+        let rule = &state.rules[idx];
+        if rule.global_to_zone != GlobalZoneScope::Zone(JUNOS_HOST_ZONE_ID)
+            || !rule.global_from_zone.matches(from_id)
+        {
+            continue;
+        }
+        if let Some(mut result) = try_match_rule(
+            rule,
+            state,
+            src_ip,
+            dst_ip,
+            protocol,
+            src_port,
+            dst_port,
+            packet_icmp,
+            packet_len,
+            l4_present,
+        ) {
+            result.policy_counter_idx = (idx as u32).saturating_add(1);
+            return Some(result);
         }
     }
     None

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -4654,6 +4654,152 @@ fn from_zone_any_to_junos_host_blocks_host_inbound_from_any_zone() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// #3639 / #3611 Piece B: a GLOBAL policy `match to-zone junos-host`
+// (host-INBOUND) is enforced on the LocalDelivery gate, consulted in the
+// GLOBAL tier — AFTER the exact `from-zone <ingress> to-zone junos-host` pair
+// and the `from-zone any to-zone junos-host` wildcard. Coupled with the Go
+// commit-reject lift (a global to-zone junos-host now commits); indexing
+// without lifting is dead, lifting without indexing is a silent fail-open.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// A global `match to-zone junos-host deny` (no from-zone scope = from-any)
+/// governs host-bound traffic from EVERY ingress zone that no exact zone-pair
+/// junos-host policy matches. Also arms `has_junos_host_rules` (the global
+/// junos-host context rides in `match_to_zone`, not the structural `to_zone`).
+///
+/// RED-on-revert: remove the global-tier consult in
+/// `evaluate_junos_host_policy_l3_aware` (or the `match_to_zone` arming of
+/// `has_junos_host_rules`) and this global deny goes un-enforced → `None`.
+#[test]
+fn global_policy_to_zone_junos_host_denies_host_inbound_from_any_zone() {
+    let state = parse_policy_state(
+        "permit",
+        &[global_zone_rule("host-block", "", "junos-host", "deny")],
+        &test_zone_name_to_id(),
+    );
+    assert!(
+        state.has_junos_host_rules,
+        "a global match to-zone junos-host must arm the host gate"
+    );
+    for from in [TEST_LAN_ZONE_ID, TEST_WAN_ZONE_ID, TEST_UNTRUST_ZONE_ID, TEST_TRUST_ZONE_ID] {
+        let res = evaluate_junos_host_policy(
+            &state,
+            from,
+            "10.0.0.1".parse().expect("src"),
+            "10.0.0.2".parse().expect("dst"),
+            PROTO_TCP,
+            12345,
+            22,
+            None,
+            64,
+        );
+        assert_eq!(
+            res.map(|r| r.action),
+            Some(PolicyAction::Deny),
+            "global match to-zone junos-host deny must block host-inbound from zone {from}"
+        );
+    }
+}
+
+/// Precedence: an exact `from-zone trust to-zone junos-host permit` WINS over a
+/// global `match to-zone junos-host deny` for a trust-ingress host-bound flow
+/// (specific beats global, mirroring transit-policy precedence). For an ingress
+/// zone with NO exact junos-host pair (untrust), the global deny governs.
+///
+/// RED-on-revert: without the global-tier consult, the untrust flow returns
+/// `None` instead of the global Deny.
+#[test]
+fn exact_zone_pair_junos_host_wins_over_global_to_zone_junos_host() {
+    let state = parse_policy_state(
+        "permit",
+        &[
+            // Exact pair first in config order — most specific.
+            junos_host_deny_snapshot("permit"), // from-zone trust to-zone junos-host permit
+            global_zone_rule("host-block", "", "junos-host", "deny"),
+        ],
+        &test_zone_name_to_id(),
+    );
+    // trust ingress: the exact permit wins over the global deny.
+    let trust = evaluate_junos_host_policy(
+        &state,
+        TEST_TRUST_ZONE_ID,
+        "10.0.1.102".parse().expect("src"),
+        "10.0.1.1".parse().expect("dst"),
+        PROTO_TCP,
+        12345,
+        22,
+        None,
+        64,
+    );
+    assert_eq!(
+        trust.map(|r| r.action),
+        Some(PolicyAction::Permit),
+        "exact from-zone trust to-zone junos-host permit must win over the global deny"
+    );
+    // untrust ingress: no exact pair → the global deny governs.
+    let untrust = evaluate_junos_host_policy(
+        &state,
+        TEST_UNTRUST_ZONE_ID,
+        "10.0.2.102".parse().expect("src"),
+        "10.0.2.1".parse().expect("dst"),
+        PROTO_TCP,
+        12345,
+        22,
+        None,
+        64,
+    );
+    assert_eq!(
+        untrust.map(|r| r.action),
+        Some(PolicyAction::Deny),
+        "no exact junos-host pair for untrust → the global deny must govern"
+    );
+}
+
+/// A global `match from-zone trust to-zone junos-host deny` is ingress-scoped:
+/// it governs ONLY trust-ingress host-bound traffic; an untrust-ingress flow
+/// matches no junos-host rule and falls through (`None`, no implicit
+/// default-deny — the lifeline guarantee).
+#[test]
+fn global_from_zone_scope_restricts_junos_host_ingress() {
+    let state = parse_policy_state(
+        "permit",
+        &[global_zone_rule("host-block", "trust", "junos-host", "deny")],
+        &test_zone_name_to_id(),
+    );
+    let trust = evaluate_junos_host_policy(
+        &state,
+        TEST_TRUST_ZONE_ID,
+        "10.0.1.102".parse().expect("src"),
+        "10.0.1.1".parse().expect("dst"),
+        PROTO_TCP,
+        12345,
+        22,
+        None,
+        64,
+    );
+    assert_eq!(
+        trust.map(|r| r.action),
+        Some(PolicyAction::Deny),
+        "global match from-zone trust to-zone junos-host must deny trust-ingress host traffic"
+    );
+    let untrust = evaluate_junos_host_policy(
+        &state,
+        TEST_UNTRUST_ZONE_ID,
+        "10.0.2.102".parse().expect("src"),
+        "10.0.2.1".parse().expect("dst"),
+        PROTO_TCP,
+        12345,
+        22,
+        None,
+        64,
+    );
+    assert!(
+        untrust.is_none(),
+        "an untrust-ingress flow matches no from-zone trust junos-host global → None"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
 // #3148 global policy from-zone/to-zone match context.
 //
 // A Junos global policy may carry optional `match from-zone`/`match to-zone`


### PR DESCRIPTION
Closes #3639

## Summary (#3611 Piece B — buildable, host-INBOUND half)

A GLOBAL security policy `set security policies global policy <p> match to-zone junos-host` was **rejected at commit** by `validatePolicyZoneReferencesStrict`, and even if it had committed, the userspace host gate (`evaluate_junos_host_policy`) never consulted the global tier — so a from-any host-inbound policy could not be expressed or enforced. This fixes both halves of that coupled gap in one PR (indexing without lifting is dead; lifting without indexing is a silent fail-open).

## Both halves (coupled)

**Go — commit-gate lift** (`pkg/config/compiler_validate_strict.go`)
- `match to-zone junos-host` (host-INBOUND) now **commits**: host-bound traffic traverses the AF_XDP LocalDelivery gate, which the Rust half consults for global-scoped junos-host rules.
- `match from-zone junos-host` (host-ORIGINATED) stays **rejected**: locally generated traffic egresses via the kernel TX path, never the AF_XDP RX gate, so it could only ever silently never-match (#3611 Piece A — documented, not built).

**Rust — enforcement** (`userspace-dp/src/policy.rs`)
- `evaluate_junos_host_policy_l3_aware` now consults a GLOBAL tier (`global_indices` filtered to `global_to_zone == Zone(JUNOS_HOST_ZONE_ID)`, gated by `global_from_zone.matches(from_id)`) **after** the exact `from-zone <ingress> to-zone junos-host` pair and the `from-zone any to-zone junos-host` wildcard — most-specific-first, matching transit-policy precedence.
- A global `match to-zone junos-host` also arms `has_junos_host_rules` (context rides in `match_to_zone`, not the structural `to_zone`).

**Go CLI simulator** (`pkg/policymatch`) — mirrored the same global tier into `matchJunosHost` so `show security match-policies` reports the verdict the dataplane enforces.

## Precedence preserved
exact `from-zone <ingress> to-zone junos-host` → `from-zone any to-zone junos-host` → **global `match to-zone junos-host`** → fall-through (no implicit default-deny — the lifeline guarantee). Exact/from-any zone-pair wins over global (specific beats global). Transit `to-zone any` / `from-zone any to-zone any` wildcards remain NOT pulled onto the host path.

## No wire change
`match_from_zone` / `match_to_zone` already flow Go→Rust (#3148).

## RED-on-revert (both proven)
- **Go**: `junos_host_to_zone_commits` — restoring the reject turns the clean commit into a hard error (verified FAIL). `junos_host_from_zone_rejected` keeps the host-originated reject pinned.
- **Rust**: neutering the global-tier loop fails all 3 new tests — `global_policy_to_zone_junos_host_denies_host_inbound_from_any_zone`, `exact_zone_pair_junos_host_wins_over_global_to_zone_junos_host`, `global_from_zone_scope_restricts_junos_host_ingress` (verified FAIL).
- **policymatch**: global-deny governs host-inbound where no exact pair matches; exact pair still wins over global.

## Validation
- Full `cargo test --release` green (unfiltered).
- `go test ./pkg/config/... ./pkg/policymatch/... ./pkg/dataplane/... ./pkg/grpcapi/...` green.
- `go build ./pkg/... ./cmd/...`, gofmt, `go vet` clean.

Docs updated: `docs/junos-cli-reference.md`, `docs/userspace-dataplane-architecture.md`, `docs/config-schema.md`, `pkg/config/README.md`, `pkg/policymatch/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi