### PR TITLE
appid: unify enabled-catalog label precedence onto specificity (#3612)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24637,3 +24637,45 @@ top.
   - **File(s)**: pkg/policymatch/policymatch.go, pkg/policymatch/host_inbound_verdict_msg_3627_test.go, pkg/grpcapi/server_show_firewall.go, pkg/cli/cli_show_security.go, pkg/cli/cli_request.go, proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go, pkg/policymatch/README.md, pkg/grpcapi/README.md, _Log.md
   - **Action**: #3642 — egress interface `filter output` now matches the POST-NAT (on-wire) tuple. Root cause: the TX-selection / CoS output-filter evaluators keyed on the flow's PRE-NAT `forward_key` and selected the v4-vs-v6 filter by the INGRESS `meta.addr_family`. Junos applies an interface output filter AFTER NAT, so a term matching source/destination address or port silently matched the untranslated tuple for any SNAT'd/DNAT'd flow, and a NAT64 flow evaluated the wrong-family filter against a wrong-family key. FIX (2 dimensions): (A) at every TX-selection eval site that owns a NAT decision, pass the egress wire key `forward_wire_key(&flow.forward_key, decision.nat)` instead of the raw pre-NAT key — live forward builder (forward_request.rs), cached descriptor build (flow_cache.rs), ARP/NDP-resolved retransmit (neighbor_dispatch.rs), and the deferred re-resolve (tx/dispatch/cos.rs). `decision.nat` is apply-to-this-packet form (apply_nat_ipv4/6 write the same rewrite_src/dst to the frame regardless of direction), so `forward_wire_key` is correct for BOTH the forward leg and the reverse/reply leg — no separate reverse_wire_key needed (verified against rewrite_forwarded_frame_in_place). (B) `resolve_cos_tx_selection_internal` + `resolve_cached_cos_tx_selection` now derive the output-filter family (and the per-family tx-selection gate) from the (post-NAT) flow_key's addr_family, not meta.addr_family, so a NAT64 v6->v4 flow selects the v4 output filter against the v4 egress tuple. The stored PendingForwardRequest.flow_key stays the PRE-NAT key (CoS flow-bucket hashing / session glue unchanged — consistent with the in-place fast path). Family-from-key is monotone: it differs from meta only for a NAT64 wire key, which only the fixed sites pass. RED-on-revert (proven, restored): 4 tests flip RED when the fix is reverted — output_filter_matches_post_snat_source_forward_leg_3642, output_filter_matches_post_snat_dest_reverse_leg_3642, output_filter_matches_post_dnat_dest_3642 (build_live integration, each carries a pre-NAT counter-factual assert), output_filter_family_selected_by_egress_key_for_nat64_3642 (resolver family selection). FULL cargo test --release green (3341 lib + all integration binaries, 0 failed; NO wire/fixture change — this is match-key selection, not a new wire field). Docs: userspace-dp/src/filter/README.md (new #3642 paragraph), docs/cos-traffic-shaping.md (post-NAT bullet).
   - **File(s)**: userspace-dp/src/afxdp/forward_request.rs, userspace-dp/src/afxdp/tx/cos_classify.rs, userspace-dp/src/afxdp/flow_cache.rs, userspace-dp/src/afxdp/neighbor_dispatch.rs, userspace-dp/src/afxdp/tx/dispatch/cos.rs, userspace-dp/src/afxdp/tests.rs, userspace-dp/src/afxdp/tx/cos_classify_tests.rs, userspace-dp/src/filter/README.md, docs/cos-traffic-shaping.md, _Log.md
+- **Timestamp**: 2026-07-01
+  - **Action**: #3612 (Path A, /research-converged) — unified the AppID
+    application-LABEL precedence across the enabled/disabled paths. Root cause:
+    the AppID-ENABLED Rust catalog `AppCatalog::lookup_directional`
+    (userspace-dp/src/policy.rs) resolved overlapping app matches by LOWEST
+    app_id (`exact.min(scan_hit)`), which — because ids are assigned in
+    sorted-name order — means the alphabetically-first NAME wins, an arbitrary
+    tiebreak. The AppID-DISABLED Go fallback `resolveTupleFallback`
+    (pkg/appid/runtime.go, #2578) resolves by SPECIFICITY (port-constrained beats
+    protocol-only, then name). So the same 5-tuple could be labeled with a broad
+    protocol-only `aaa-tcp` when AppID was ON but the specific `zzz-https` when
+    OFF — a display/observability divergence (session show, RT_FLOW,
+    filter/deny logs); enforcement (`CompiledApplications::matches`) was never
+    affected. FIX: tagged `AppScanEntry` with `port_constrained`
+    (`!(dst_low==0 && dst_high==0 && src_low==0 && src_high==0)`, the wire mirror
+    of Go's `portBased = DestinationPort != "" || SourcePort != ""`), and changed
+    the `lookup_directional` tiebreak to the SAME binary specificity as the Go
+    fallback: port-constrained tier (exact_dst is always port-constrained + the
+    lowest-id port-constrained scan hit) wins over the protocol-only tier, lowest
+    id within a tier. Strictly additive for same-tier overlaps (byte-identical to
+    before). Pinned with a shared, self-describing cross-language parity fixture
+    (userspace-dp/tests/fixtures/appid_precedence_v1.json, user apps only per
+    plan scope note S1) consumed by BOTH Go `TestAppIDPrecedenceParityFixture`
+    (drives resolveTupleFallback + validates BuildCatalog reproduces the recorded
+    ids so a sort bug cannot hide) and Rust `app_catalog_precedence_parity_fixture`
+    (drives lookup_directional); both resolve every case to the same NAME. Added
+    Rust unit tests `app_catalog_prefers_port_constrained_over_protocol_only` +
+    `app_catalog_src_port_only_is_port_constrained`; updated the same-tier comment
+    on `app_catalog_overlap_lowest_id_wins`. RED-on-revert PROVEN: reverting the
+    tiebreak to lowest-id-regardless-of-tier turns the 3 new tests RED (parity
+    fixture: "app_id = 1, want 2") while the same-tier + all pre-existing
+    app_catalog tests stay GREEN; restored. OUT OF SCOPE (deferred adjacencies,
+    plan §9): S1 predefined-vs-builtinFallbacks set membership, S2
+    reverse-direction service-slot handling. Validation: FULL cargo test --release
+    green (3343 lib + all integration binaries, 0 failed; NO wire/fixture change —
+    label resolution is not a wire field); go build ./... + go vet
+    (pkg/appid, pkg/dataplane) clean; go test ./pkg/appid/... ./pkg/dataplane/...
+    ./pkg/grpcapi/... ./pkg/api/... green; gofmt clean. Docs: pkg/appid/README.md
+    (single precedence contract + parity fixture + S1/S2 deferrals),
+    docs/services-application-identification.md (session-create precedence note +
+    stale lookup() signature refresh to lookup_directional).
+  - **File(s)**: userspace-dp/src/policy.rs, userspace-dp/src/policy_tests.rs, userspace-dp/tests/fixtures/appid_precedence_v1.json, pkg/appid/precedence_parity_test.go, pkg/appid/README.md, docs/services-application-identification.md, _Log.md

--- a/docs/services-application-identification.md
+++ b/docs/services-application-identification.md
@@ -63,12 +63,28 @@ upfront what they're getting and not getting.
    catalog is compiled into `ForwardingState.app_catalog`
    (`AppCatalog` in `userspace-dp/src/policy.rs`). When a worker
    creates a new session (`poll_descriptor`), it calls
-   `AppCatalog::lookup(protocol, src_port, dst_port)` and the
-   resolved `app_id` (0 = no match) is stamped on the conntrack
-   session value in `publish_conntrack.rs` (previously hardcoded
-   to 0). The well-known service port is probed on both the src
-   and dst slot so the forward and reverse conntrack entries
-   resolve to the same `app_id`. **Note**: only the local
+   `AppCatalog::lookup_directional(protocol, src_port, dst_port,
+   is_reverse)` and the resolved `app_id` (0 = no match) is stamped
+   on the conntrack session value in `publish_conntrack.rs`
+   (previously hardcoded to 0). The well-known service port is the
+   DESTINATION on a forward-keyed flow and the SOURCE on a
+   reverse-keyed flow (`is_reverse` selects the slot, #3321), so the
+   forward and reverse conntrack entries resolve to the same
+   `app_id` without cross-slot probing. **Overlap precedence
+   (#3612):** when more than one catalogued app matches a tuple, the
+   winner is the more SPECIFIC one — a port-constrained entry
+   (destination and/or source port set) beats a bare protocol-only
+   entry — with ties broken by the lowest `app_id` (==
+   alphabetically-first name) within a tier. This is the SAME
+   binary-specificity rule the AppID-DISABLED Go fallback uses
+   (`resolveTupleFallback`, #2578), so the same 5-tuple is labeled
+   identically whether AppID is on or off; the shared fixture
+   `userspace-dp/tests/fixtures/appid_precedence_v1.json` pins the
+   two paths together (Go `TestAppIDPrecedenceParityFixture` + Rust
+   `app_catalog_precedence_parity_fixture`). Before #3612 the enabled
+   path tie-broke on lowest `app_id` regardless of specificity, so a
+   broad protocol-only app could shadow a specific port-based app on
+   the enabled path only. **Note**: only the local
    session-owner stamps `app_id` in the conntrack map (the same
    property as `alg_type`); an HA-synced session on the standby
    peer is not mirrored into the conntrack map, and a session

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -55,7 +55,27 @@ and resolves session display names from the dataplane's assigned `app_id`.
   before that the map was iterated first-match, so a port-specific app
   could non-deterministically lose to a protocol-only sibling). This is a
   display-only label path — it does not affect policy enforcement, which
-  uses the dataplane-assigned `app_id`. When AppID is **enabled** in
+  uses the dataplane-assigned `app_id`.
+
+  **Single precedence contract across the AppID knob (#3612):** the
+  AppID-ENABLED Rust catalog (`AppCatalog::lookup_directional` in
+  `userspace-dp/src/policy.rs`) resolves overlapping application labels by
+  the *same* binary-specificity rule — **port-constrained beats
+  protocol-only, then lowest `app_id` (== alphabetically-first name) within
+  a tier.** Before #3612 the enabled path tie-broke purely on lowest
+  `app_id` regardless of specificity, so the same 5-tuple could be labeled
+  with a broad protocol-only app when AppID was on but the specific
+  port-based app when AppID was off. Both paths now agree; the shared,
+  self-describing fixture
+  `userspace-dp/tests/fixtures/appid_precedence_v1.json` pins the agreement
+  (`TestAppIDPrecedenceParityFixture` here drives the disabled path;
+  `app_catalog_precedence_parity_fixture` in `policy_tests.rs` drives the
+  enabled path over the same cases). The divergence was
+  display/observability only — enforcement was never affected. Two adjacent
+  divergences are deferred out of #3612: the disabled path's non-user
+  fallback is a narrow hardcoded `builtinFallbacks` set rather than the full
+  predefined catalog the enabled path sees (S1), and the disabled path has
+  no reverse-direction service-slot model (S2). When AppID is **enabled** in
   `services.application-identification` and the dataplane has not
   assigned an `app_id` for the session (`appID == 0`), the function
   returns `UNKNOWN` rather than guessing from port heuristics. Used

--- a/pkg/appid/precedence_parity_test.go
+++ b/pkg/appid/precedence_parity_test.go
@@ -1,0 +1,152 @@
+package appid
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// precedenceFixture mirrors userspace-dp/tests/fixtures/appid_precedence_v1.json.
+// It is the shared, self-describing source of truth for the #3612 cross-language
+// application-label precedence parity: this Go test drives the AppID-DISABLED
+// fallback (resolveTupleFallback) and the Rust test
+// (policy_tests.rs::app_catalog_precedence_parity_fixture) drives the
+// AppID-ENABLED catalog (AppCatalog::lookup_directional) over the SAME cases.
+// Both MUST resolve every case to the same expected NAME, so the same 5-tuple is
+// labeled identically regardless of the services.application-identification knob.
+type precedenceFixture struct {
+	Version     int                    `json:"version"`
+	Description string                 `json:"description"`
+	Cases       []precedenceParityCase `json:"cases"`
+}
+
+type precedenceParityCase struct {
+	Name          string                    `json:"name"`
+	Note          string                    `json:"note"`
+	Apps          []precedenceParityApp     `json:"apps"`
+	Catalog       []precedenceParityCatalog `json:"catalog"`
+	Tuple         precedenceParityTuple     `json:"tuple"`
+	ExpectedAppID uint16                    `json:"expected_app_id"`
+	ExpectedName  string                    `json:"expected_name"`
+}
+
+type precedenceParityApp struct {
+	Name            string `json:"name"`
+	Protocol        string `json:"protocol"`
+	DestinationPort string `json:"destination_port"`
+	SourcePort      string `json:"source_port"`
+}
+
+type precedenceParityCatalog struct {
+	Name        string `json:"name"`
+	AppID       uint16 `json:"app_id"`
+	Protocol    uint8  `json:"protocol"`
+	DstPortLow  uint16 `json:"dst_port_low"`
+	DstPortHigh uint16 `json:"dst_port_high"`
+	SrcPortLow  uint16 `json:"src_port_low"`
+	SrcPortHigh uint16 `json:"src_port_high"`
+}
+
+type precedenceParityTuple struct {
+	Protocol  uint8  `json:"protocol"`
+	SrcPort   uint16 `json:"src_port"`
+	DstPort   uint16 `json:"dst_port"`
+	IsReverse bool   `json:"is_reverse"`
+}
+
+// TestAppIDPrecedenceParityFixture is the Go half of the #3612 parity guard.
+//
+// For every fixture case it (1) validates that appid.BuildCatalog reproduces the
+// exact (name -> app_id, ports) rows the fixture records — so the ids the Rust
+// side consumes are the REAL Go sort output and a sort bug cannot hide
+// identically in both languages — and (2) drives resolveTupleFallback (the
+// AppID-disabled label path) over the case tuple and asserts it resolves to the
+// fixture's expected_name, the same name the Rust ENABLED-path test asserts.
+func TestAppIDPrecedenceParityFixture(t *testing.T) {
+	path := filepath.Join("..", "..", "userspace-dp", "tests", "fixtures", "appid_precedence_v1.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	var fx precedenceFixture
+	if err := json.Unmarshal(raw, &fx); err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	if len(fx.Cases) == 0 {
+		t.Fatal("fixture carries no cases")
+	}
+
+	for _, tc := range fx.Cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			// Build the config: the fixture apps are USER apps (scope note S1),
+			// all referenced by one global policy so CatalogNames(cfg, false)
+			// returns exactly this set and BuildCatalog assigns ids 1..N in
+			// sorted-name order.
+			apps := map[string]*config.Application{}
+			appNames := make([]string, 0, len(tc.Apps))
+			for _, a := range tc.Apps {
+				apps[a.Name] = &config.Application{
+					Name:            a.Name,
+					Protocol:        a.Protocol,
+					DestinationPort: a.DestinationPort,
+					SourcePort:      a.SourcePort,
+				}
+				appNames = append(appNames, a.Name)
+			}
+			cfg := &config.Config{
+				Applications: config.ApplicationsConfig{Applications: apps},
+			}
+			// AppID DISABLED so resolveTupleFallback is the active label path
+			// and CatalogNames uses the referenced-app (includeAll=false) walk.
+			cfg.Services.ApplicationIdentification = false
+			cfg.Security.GlobalPolicies = []*config.Policy{
+				{Name: "parity-ref", Match: config.PolicyMatch{Applications: appNames}},
+			}
+
+			// (1) Validate the fixture's recorded ids/ports == the real Go
+			// BuildCatalog output. This pins the ids the Rust side trusts.
+			cat, err := BuildCatalog(cfg)
+			if err != nil {
+				t.Fatalf("BuildCatalog: %v", err)
+			}
+			byID := map[uint16]CatalogEntry{}
+			for _, e := range cat.Entries {
+				byID[e.AppID] = e
+			}
+			if len(cat.Entries) != len(tc.Catalog) {
+				t.Fatalf("catalog entry count = %d, fixture records %d", len(cat.Entries), len(tc.Catalog))
+			}
+			for _, want := range tc.Catalog {
+				if got := cat.AppNames[want.AppID]; got != want.Name {
+					t.Fatalf("BuildCatalog assigns app_id %d -> %q, fixture claims %q (Go sort drift)", want.AppID, got, want.Name)
+				}
+				got, ok := byID[want.AppID]
+				if !ok {
+					t.Fatalf("BuildCatalog produced no entry for app_id %d (%q)", want.AppID, want.Name)
+				}
+				if got.Name != want.Name || got.Protocol != want.Protocol ||
+					got.DstPortLow != want.DstPortLow || got.DstPortHigh != want.DstPortHigh ||
+					got.SrcPortLow != want.SrcPortLow || got.SrcPortHigh != want.SrcPortHigh {
+					t.Fatalf("catalog entry mismatch for %q: BuildCatalog %+v, fixture %+v", want.Name, got, want)
+				}
+			}
+
+			// (2) The AppID-disabled label path must resolve the case tuple to
+			// the fixture's expected name — the same name the Rust ENABLED-path
+			// test resolves via lookup_directional. Only forward tuples are in
+			// the fixture (resolveTupleFallback has no reverse model — S2).
+			if tc.Tuple.IsReverse {
+				t.Fatalf("fixture case %q is is_reverse=true; resolveTupleFallback only models forward flows", tc.Name)
+			}
+			got := resolveTupleFallback(tc.Tuple.Protocol, tc.Tuple.SrcPort, tc.Tuple.DstPort, cfg)
+			if got != tc.ExpectedName {
+				t.Fatalf("resolveTupleFallback(proto=%d src=%d dst=%d) = %q, want %q (must match the AppID-enabled Rust label)",
+					tc.Tuple.Protocol, tc.Tuple.SrcPort, tc.Tuple.DstPort, got, tc.ExpectedName)
+			}
+		})
+	}
+}

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -1523,9 +1523,12 @@ impl CompiledApplications {
 /// answers a boolean "does this 5-tuple match the policy's app set?"). Lookup is
 /// grouped by protocol, with exact single-destination-port entries in an O(1)
 /// map and everything else (ranges, port-0/"protocol-only" entries) in a
-/// per-protocol scan list. On overlap the first matching entry wins, which is
-/// the lowest `app_id` because the Go builder emits entries in sorted-name /
-/// ascending-id order; deterministic and stable across reloads.
+/// per-protocol scan list. On overlap the winner is chosen by SPECIFICITY first
+/// (a port-constrained entry beats a bare protocol-only one), then by lowest
+/// `app_id` within a tier (#3612). Lowest id == the alphabetically-first name
+/// because the Go builder emits entries in sorted-name / ascending-id order, so
+/// the result is deterministic and stable across reloads and matches the
+/// AppID-disabled Go fallback (`resolveTupleFallback`, #2578).
 #[derive(Clone, Debug, Default)]
 pub(crate) struct AppCatalog {
     by_protocol: FxHashMap<u8, AppProtoEntries>,
@@ -1537,8 +1540,10 @@ struct AppProtoEntries {
     /// source-port constraint (the common case).
     exact_dst: FxHashMap<u16, u16>,
     /// Entries needing a scan: a port range, a source-port constraint, or no
-    /// destination-port constraint at all (port-0 protocol-only entries). Kept
-    /// in catalog order so the first (lowest-id) match wins.
+    /// destination-port constraint at all (port-0 protocol-only entries). Each
+    /// entry is tagged `port_constrained` so `lookup_directional` can rank a
+    /// port-constrained overlap above a protocol-only one before falling back to
+    /// lowest app_id within a tier (#3612).
     scan: Vec<AppScanEntry>,
 }
 
@@ -1549,6 +1554,13 @@ struct AppScanEntry {
     dst_high: u16,
     src_low: u16,
     src_high: u16,
+    /// #3612: true iff this entry carries a destination AND/OR source port
+    /// constraint (i.e. it is NOT a bare protocol-only entry). Mirrors the
+    /// AppID-disabled Go fallback's `portBased` predicate
+    /// (`resolveTupleFallback`: `DestinationPort != "" || SourcePort != ""`)
+    /// so `lookup_directional` can rank a port-constrained overlap above a
+    /// protocol-only one identically to that path.
+    port_constrained: bool,
 }
 
 impl AppCatalog {
@@ -1569,12 +1581,21 @@ impl AppCatalog {
                 // "first match wins" rule for overlapping configs.
                 bucket.exact_dst.entry(e.dst_port_low).or_insert(e.app_id);
             } else {
+                // #3612: a scan entry is port-constrained unless ALL four port
+                // bounds are zero (a bare protocol-only entry). This is the wire
+                // mirror of the Go fallback's `portBased` — a `source-port`-only
+                // app (dst (0,0), src set) is port-constrained on both sides.
+                let port_constrained = !(e.dst_port_low == 0
+                    && e.dst_port_high == 0
+                    && e.src_port_low == 0
+                    && e.src_port_high == 0);
                 bucket.scan.push(AppScanEntry {
                     app_id: e.app_id,
                     dst_low: e.dst_port_low,
                     dst_high: e.dst_port_high,
                     src_low: e.src_port_low,
                     src_high: e.src_port_high,
+                    port_constrained,
                 });
             }
         }
@@ -1625,29 +1646,60 @@ impl AppCatalog {
         // (`from_snapshot` only routes src-unconstrained single-dst entries to
         // `exact_dst`), so an exact hit needs only the service port.
         let exact = bucket.exact_dst.get(&service_port).copied();
-        // Scan entries (ranges / source-constrained / protocol-only). Catalog
-        // order = ascending id.
+        // Scan entries (ranges / source-constrained / protocol-only).
+        //
+        // #3612: resolve overlaps by SPECIFICITY TIER first — a port-constrained
+        // entry (a destination and/or source port constraint) outranks a bare
+        // protocol-only entry — then by lowest app_id WITHIN a tier. This is the
+        // exact binary-specificity rule the AppID-disabled Go fallback already
+        // uses (`resolveTupleFallback`, #2578: `portBased` beats protocol-only,
+        // ties broken by name == lowest id in sorted-name order), so the same
+        // 5-tuple resolves to the same application label whether AppID is ON
+        // (this catalog) or OFF (the Go fallback). `exact_dst` entries are always
+        // port-constrained, so they participate in the port-constrained tier.
+        //
+        // Before #3612 the final tiebreak was a flat `exact.min(scan_hit)` —
+        // lowest app_id regardless of tier. Because ids are assigned in
+        // sorted-name order, that meant the alphabetically-first name won an
+        // overlap, letting a broad protocol-only `aaa-tcp` shadow a specific
+        // `zzz-https` on tcp/443. Within a single tier the result is unchanged
+        // (still the lowest id), so this is strictly additive for same-tier
+        // configs.
         let in_range = |low: u16, high: u16, p: u16| -> bool {
             // (0,0) means "no constraint".
             (low == 0 && high == 0) || (p >= low && p <= high)
         };
-        let mut scan_hit: Option<u16> = None;
+        let mut port_scan_hit: Option<u16> = None;
+        let mut proto_only_scan_hit: Option<u16> = None;
         for s in &bucket.scan {
             // Destination constraint is matched against the service slot and
             // the source constraint against the client slot — directional, no
             // cross-slot probing.
             let dst_ok = in_range(s.dst_low, s.dst_high, service_port);
             let src_ok = in_range(s.src_low, s.src_high, client_port);
-            if dst_ok && src_ok {
-                scan_hit = Some(s.app_id);
-                break;
+            if !(dst_ok && src_ok) {
+                continue;
             }
+            let slot = if s.port_constrained {
+                &mut port_scan_hit
+            } else {
+                &mut proto_only_scan_hit
+            };
+            // Keep the lowest app_id per tier. The Go builder emits entries in
+            // ascending-id order, but taking the min makes the tiebreak
+            // independent of scan order.
+            *slot = Some(slot.map_or(s.app_id, |cur| cur.min(s.app_id)));
         }
-        match (exact, scan_hit) {
-            (Some(a), Some(b)) => a.min(b),
-            (Some(a), None) | (None, Some(a)) => a,
-            (None, None) => 0,
-        }
+        // Port-constrained tier wins: combine the always-port-constrained exact
+        // hit with the port-constrained scan hit and take the lowest id. Fall
+        // back to the protocol-only tier only when no port-constrained entry
+        // matched the flow.
+        let port_based = match (exact, port_scan_hit) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            (None, None) => None,
+        };
+        port_based.or(proto_only_scan_hit).unwrap_or(0)
     }
 
     /// Forward-keyed convenience wrapper: the service port is the destination.

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -3638,17 +3638,96 @@ fn app_catalog_skips_zero_app_id() {
     assert_eq!(cat.lookup_forward(6, 51000, 443), 0);
 }
 
-// Overlapping entries: first/lowest app_id wins, deterministically (the Go
-// builder emits ascending ids in sorted-name order).
+// Overlapping entries WITHIN THE SAME specificity tier: the lowest app_id wins,
+// deterministically (the Go builder emits ascending ids in sorted-name order).
+// #3612 changed only the CROSS-tier tiebreak (port-constrained beats
+// protocol-only); same-tier overlaps are byte-identical to before — both cases
+// here are all-port-constrained, so they must stay green.
 #[test]
 fn app_catalog_overlap_lowest_id_wins() {
-    // Two apps both claiming tcp/80 — exact-port path.
+    // Two apps both claiming tcp/80 — exact-port path (both port-constrained).
     let cat = AppCatalog::from_snapshot(&[cat_entry(5, 6, 80, 80), cat_entry(11, 6, 80, 80)]);
     assert_eq!(cat.lookup_forward(6, 40000, 80), 5);
 
-    // Range vs exact overlap — lowest id still wins.
+    // Range vs exact overlap — both port-constrained, so lowest id still wins.
     let cat = AppCatalog::from_snapshot(&[cat_entry(2, 6, 8000, 8100), cat_entry(20, 6, 8050, 8050)]);
     assert_eq!(cat.lookup_forward(6, 40000, 8050), 2);
+}
+
+// #3612: the ENABLED catalog must rank a PORT-CONSTRAINED overlap ABOVE a bare
+// protocol-only one, even when the protocol-only app has the LOWER app_id (==
+// alphabetically-first name). Before the fix the final tiebreak was a flat
+// `exact.min(scan_hit)` (lowest id regardless of tier), so a broad protocol-only
+// `aaa-tcp` (id 1) shadowed a specific `zzz-https` (id 2) on tcp/443 — diverging
+// from the AppID-disabled Go fallback, which prefers the specific app (#2578).
+// Reverting the tier split to lowest-id makes each assertion return the
+// protocol-only id and fails this test.
+#[test]
+fn app_catalog_prefers_port_constrained_over_protocol_only() {
+    // protocol-only id 1 (tcp, no ports) + exact dst-port id 2 (tcp/443).
+    let cat = AppCatalog::from_snapshot(&[cat_entry(1, 6, 0, 0), cat_entry(2, 6, 443, 443)]);
+    assert_eq!(
+        cat.lookup_forward(6, 51000, 443),
+        2,
+        "exact dst-port app (id 2) must beat the protocol-only app (id 1) on tcp/443"
+    );
+    // A tcp flow to a NON-catalogued port still falls back to the protocol-only
+    // app (nothing port-constrained matches).
+    assert_eq!(
+        cat.lookup_forward(6, 51000, 8888),
+        1,
+        "protocol-only app resolves when no port-constrained entry matches"
+    );
+
+    // protocol-only id 1 + port-RANGE id 3 (both live in the scan list). The
+    // range is port-constrained, so it wins on a port inside the range despite
+    // the higher id.
+    let cat = AppCatalog::from_snapshot(&[cat_entry(1, 6, 0, 0), cat_entry(3, 6, 9000, 9100)]);
+    assert_eq!(
+        cat.lookup_forward(6, 40000, 9050),
+        3,
+        "port-range app (id 3) must beat the protocol-only app (id 1) inside the range"
+    );
+    assert_eq!(
+        cat.lookup_forward(6, 40000, 12345),
+        1,
+        "outside the range only the protocol-only app matches"
+    );
+}
+
+// #3612: a `source-port`-only app (destination unconstrained, source port set)
+// is PORT-CONSTRAINED on both the Rust and Go sides — its `port_constrained`
+// predicate mirrors the Go fallback's `portBased`
+// (`DestinationPort != "" || SourcePort != ""`). It must therefore beat a
+// protocol-only sibling with a lower id when the flow's client source port
+// matches. Reverting the tier split returns the protocol-only id.
+#[test]
+fn app_catalog_src_port_only_is_port_constrained() {
+    let cat = AppCatalog::from_snapshot(&[
+        cat_entry(1, 6, 0, 0), // protocol-only tcp
+        crate::AppCatalogEntry {
+            app_id: 2,
+            protocol: 6,
+            dst_port_low: 0,
+            dst_port_high: 0,
+            src_port_low: 5000,
+            src_port_high: 5000,
+        },
+    ]);
+    // Forward flow: client src=5000 (matches the source-port constraint), any
+    // dst. The source-port-only app (id 2) wins over the protocol-only app.
+    assert_eq!(
+        cat.lookup_forward(6, 5000, 80),
+        2,
+        "source-port-only app (id 2) is port-constrained and beats protocol-only (id 1)"
+    );
+    // A flow whose client source port does NOT match the constraint falls back
+    // to the protocol-only app.
+    assert_eq!(
+        cat.lookup_forward(6, 6000, 80),
+        1,
+        "non-matching source port falls back to the protocol-only app"
+    );
 }
 
 #[test]
@@ -3656,6 +3735,96 @@ fn app_catalog_empty_resolves_unknown() {
     let cat = AppCatalog::default();
     assert!(cat.is_empty());
     assert_eq!(cat.lookup_forward(6, 51000, 443), 0);
+}
+
+// #3612: cross-language precedence PARITY. This is the Rust half of the shared
+// fixture (`userspace-dp/tests/fixtures/appid_precedence_v1.json`); the Go half
+// is `pkg/appid.TestAppIDPrecedenceParityFixture`, which drives
+// `resolveTupleFallback` (the AppID-DISABLED path) over the SAME cases and
+// asserts the SAME expected name. This side drives the AppID-ENABLED catalog
+// (`AppCatalog::lookup_directional`). Both MUST resolve every case to the
+// fixture's `expected_name`, so the two paths cannot silently re-diverge.
+//
+// The fixture records each catalog row's `app_id` (the value the Go
+// `BuildCatalog` sort assigns — pinned on the Go side by the same test), so this
+// test does NOT re-implement the sort: it builds the catalog straight from the
+// recorded ids and resolves the id back to a name through the recorded id→name
+// map. A sort bug therefore cannot hide identically in both languages.
+#[test]
+fn app_catalog_precedence_parity_fixture() {
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("appid_precedence_v1.json");
+    let raw = std::fs::read_to_string(&fixture_path)
+        .unwrap_or_else(|e| panic!("read {}: {}", fixture_path.display(), e));
+    let doc: serde_json::Value =
+        serde_json::from_str(&raw).expect("appid_precedence_v1.json parses");
+
+    let cases = doc["cases"].as_array().expect("cases array");
+    assert!(!cases.is_empty(), "fixture must carry at least one case");
+
+    let u16f = |v: &serde_json::Value| -> u16 {
+        u16::try_from(v.as_u64().expect("numeric field")).expect("fits u16")
+    };
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+
+        // Build the catalog entries + id→name map straight from the recorded
+        // catalog rows (the Go BuildCatalog output; the Go test pins the ids).
+        let mut entries: Vec<crate::AppCatalogEntry> = Vec::new();
+        let mut id_to_name: std::collections::HashMap<u16, String> =
+            std::collections::HashMap::new();
+        for row in case["catalog"].as_array().expect("catalog array") {
+            let app_id = u16f(&row["app_id"]);
+            entries.push(crate::AppCatalogEntry {
+                app_id,
+                protocol: u8::try_from(row["protocol"].as_u64().expect("protocol"))
+                    .expect("protocol fits u8"),
+                dst_port_low: u16f(&row["dst_port_low"]),
+                dst_port_high: u16f(&row["dst_port_high"]),
+                src_port_low: u16f(&row["src_port_low"]),
+                src_port_high: u16f(&row["src_port_high"]),
+            });
+            if app_id != 0 {
+                id_to_name.insert(app_id, row["name"].as_str().expect("row name").to_string());
+            }
+        }
+
+        let cat = AppCatalog::from_snapshot(&entries);
+
+        let tuple = &case["tuple"];
+        let proto = u8::try_from(tuple["protocol"].as_u64().expect("tuple protocol"))
+            .expect("proto fits u8");
+        let src_port = u16f(&tuple["src_port"]);
+        let dst_port = u16f(&tuple["dst_port"]);
+        let is_reverse = tuple["is_reverse"].as_bool().expect("is_reverse");
+
+        let got_id = cat.lookup_directional(proto, src_port, dst_port, is_reverse);
+        let expected_id = u16f(&case["expected_app_id"]);
+        assert_eq!(
+            got_id, expected_id,
+            "case {name:?}: lookup_directional app_id = {got_id}, want {expected_id}"
+        );
+
+        // Resolve the id back to a name (0 == UNKNOWN == the empty string, which
+        // is how the show path renders a no-match on the disabled side).
+        let got_name = if got_id == 0 {
+            ""
+        } else {
+            id_to_name
+                .get(&got_id)
+                .unwrap_or_else(|| panic!("case {name:?}: id {got_id} absent from id→name map"))
+                .as_str()
+        };
+        let expected_name = case["expected_name"].as_str().expect("expected_name");
+        assert_eq!(
+            got_name, expected_name,
+            "case {name:?}: ENABLED-path label = {got_name:?}, want {expected_name:?} \
+             (must equal the DISABLED-path label the Go parity test asserts)"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/userspace-dp/tests/fixtures/appid_precedence_v1.json
+++ b/userspace-dp/tests/fixtures/appid_precedence_v1.json
@@ -1,0 +1,94 @@
+{
+  "version": 1,
+  "description": "Cross-language AppID application-label precedence parity fixture (#3612). Each case is resolved by BOTH the AppID-ENABLED Rust catalog (AppCatalog::lookup_directional in userspace-dp/src/policy.rs) and the AppID-DISABLED Go fallback (resolveTupleFallback in pkg/appid/runtime.go); both MUST agree on the resolved application NAME so the same 5-tuple is labeled identically regardless of the services.application-identification knob. The fixture is self-describing: `apps` is the operator config form (user apps ONLY, per the #3612 plan scope note S1 — do not add a predefined-only app), `catalog` is the expanded (app_id, protocol, port-range) rows appid.BuildCatalog assigns in sorted-name order (the Go test asserts BuildCatalog reproduces these ids so the Rust side does not re-implement the Go sort; a sort bug cannot hide identically in both sides), and `tuple` is a FORWARD-keyed session (is_reverse=false — the Go fallback has no reverse-direction model; reverse handling is the deferred S2 adjacency). expected_app_id 0 / expected_name \"\" means UNKNOWN (no match). Regenerate the Rust view via the code; this JSON is the single source of truth.",
+  "cases": [
+    {
+      "name": "protocol_only_loses_to_exact_port",
+      "note": "The canonical #3612 divergence: a broad protocol-only app (aaa-tcp, lowest id) must NOT shadow a specific dst-port app (zzz-https) on tcp/443. Pre-fix the ENABLED catalog returned the lowest id (aaa-tcp); the DISABLED fallback returned zzz-https. RED-on-revert.",
+      "apps": [
+        {"name": "aaa-tcp", "protocol": "tcp", "destination_port": "", "source_port": ""},
+        {"name": "zzz-https", "protocol": "tcp", "destination_port": "443", "source_port": ""}
+      ],
+      "catalog": [
+        {"name": "aaa-tcp", "app_id": 1, "protocol": 6, "dst_port_low": 0, "dst_port_high": 0, "src_port_low": 0, "src_port_high": 0},
+        {"name": "zzz-https", "app_id": 2, "protocol": 6, "dst_port_low": 443, "dst_port_high": 443, "src_port_low": 0, "src_port_high": 0}
+      ],
+      "tuple": {"protocol": 6, "src_port": 51000, "dst_port": 443, "is_reverse": false},
+      "expected_app_id": 2,
+      "expected_name": "zzz-https"
+    },
+    {
+      "name": "protocol_only_loses_to_range",
+      "note": "A port-RANGE app (mmm-range, higher id) beats a protocol-only app (aaa-any, lower id) on a port inside the range. RED-on-revert (lowest id would pick aaa-any).",
+      "apps": [
+        {"name": "aaa-any", "protocol": "tcp", "destination_port": "", "source_port": ""},
+        {"name": "mmm-range", "protocol": "tcp", "destination_port": "9000-9100", "source_port": ""}
+      ],
+      "catalog": [
+        {"name": "aaa-any", "app_id": 1, "protocol": 6, "dst_port_low": 0, "dst_port_high": 0, "src_port_low": 0, "src_port_high": 0},
+        {"name": "mmm-range", "app_id": 2, "protocol": 6, "dst_port_low": 9000, "dst_port_high": 9100, "src_port_low": 0, "src_port_high": 0}
+      ],
+      "tuple": {"protocol": 6, "src_port": 40000, "dst_port": 9050, "is_reverse": false},
+      "expected_app_id": 2,
+      "expected_name": "mmm-range"
+    },
+    {
+      "name": "same_tier_lowest_id_wins",
+      "note": "Both matches are port-constrained (a range aaa-range in the scan list AND an exact-port zzz-exact in the O(1) map). Within a tier the lowest id (== alphabetically-first name) still wins in BOTH paths — this proves the fix is strictly additive for same-tier overlaps (NOT red-on-revert).",
+      "apps": [
+        {"name": "aaa-range", "protocol": "tcp", "destination_port": "8000-8100", "source_port": ""},
+        {"name": "zzz-exact", "protocol": "tcp", "destination_port": "8050", "source_port": ""}
+      ],
+      "catalog": [
+        {"name": "aaa-range", "app_id": 1, "protocol": 6, "dst_port_low": 8000, "dst_port_high": 8100, "src_port_low": 0, "src_port_high": 0},
+        {"name": "zzz-exact", "app_id": 2, "protocol": 6, "dst_port_low": 8050, "dst_port_high": 8050, "src_port_low": 0, "src_port_high": 0}
+      ],
+      "tuple": {"protocol": 6, "src_port": 40000, "dst_port": 8050, "is_reverse": false},
+      "expected_app_id": 1,
+      "expected_name": "aaa-range"
+    },
+    {
+      "name": "src_port_only_is_port_constrained",
+      "note": "A source-port-only app (zzz-srcport, dst unconstrained) is port-constrained on both sides and beats a protocol-only sibling (aaa-proto, lower id) for a flow whose client source port matches. RED-on-revert (lowest id would pick aaa-proto).",
+      "apps": [
+        {"name": "aaa-proto", "protocol": "tcp", "destination_port": "", "source_port": ""},
+        {"name": "zzz-srcport", "protocol": "tcp", "destination_port": "", "source_port": "5000"}
+      ],
+      "catalog": [
+        {"name": "aaa-proto", "app_id": 1, "protocol": 6, "dst_port_low": 0, "dst_port_high": 0, "src_port_low": 0, "src_port_high": 0},
+        {"name": "zzz-srcport", "app_id": 2, "protocol": 6, "dst_port_low": 0, "dst_port_high": 0, "src_port_low": 5000, "src_port_high": 5000}
+      ],
+      "tuple": {"protocol": 6, "src_port": 5000, "dst_port": 80, "is_reverse": false},
+      "expected_app_id": 2,
+      "expected_name": "zzz-srcport"
+    },
+    {
+      "name": "single_exact_match",
+      "note": "No overlap sanity: only aaa-http matches tcp/80.",
+      "apps": [
+        {"name": "aaa-http", "protocol": "tcp", "destination_port": "80", "source_port": ""},
+        {"name": "bbb-ssh", "protocol": "tcp", "destination_port": "22", "source_port": ""}
+      ],
+      "catalog": [
+        {"name": "aaa-http", "app_id": 1, "protocol": 6, "dst_port_low": 80, "dst_port_high": 80, "src_port_low": 0, "src_port_high": 0},
+        {"name": "bbb-ssh", "app_id": 2, "protocol": 6, "dst_port_low": 22, "dst_port_high": 22, "src_port_low": 0, "src_port_high": 0}
+      ],
+      "tuple": {"protocol": 6, "src_port": 40000, "dst_port": 80, "is_reverse": false},
+      "expected_app_id": 1,
+      "expected_name": "aaa-http"
+    },
+    {
+      "name": "no_match_resolves_unknown",
+      "note": "No user app matches tcp/4321 (4321 is deliberately absent from the Go builtinFallbacks table — the S1 predefined-vs-builtin set gap is out of scope), so both paths resolve UNKNOWN (id 0 / empty name).",
+      "apps": [
+        {"name": "aaa-http", "protocol": "tcp", "destination_port": "80", "source_port": ""}
+      ],
+      "catalog": [
+        {"name": "aaa-http", "app_id": 1, "protocol": 6, "dst_port_low": 80, "dst_port_high": 80, "src_port_low": 0, "src_port_high": 0}
+      ],
+      "tuple": {"protocol": 6, "src_port": 40000, "dst_port": 4321, "is_reverse": false},
+      "expected_app_id": 0,
+      "expected_name": ""
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3612.

## Problem

AppID application-LABEL precedence diverged between the two code paths. With
AppID ENABLED, the Rust catalog `AppCatalog::lookup_directional`
(`userspace-dp/src/policy.rs`) resolved overlapping app matches by LOWEST
`app_id` (`exact.min(scan_hit)`). Because ids are assigned in sorted-name
order, that means the alphabetically-first NAME wins an overlap — an
arbitrary tiebreak. With AppID DISABLED, the Go fallback `resolveTupleFallback`
(`pkg/appid/runtime.go`, #2578) resolves by SPECIFICITY (a port-constrained
app beats a protocol-only app, ties broken by name).

Result: the same 5-tuple could be labeled with a broad protocol-only
`aaa-tcp` when AppID was ON but the specific `zzz-https` when OFF. Labels are
operator-facing security/forensic evidence (session display, RT_FLOW,
filter/deny logs, the `application <name>` show/clear filter), so a label
that flips with the knob erodes trust. xpf has no L7 DPI — both paths are the
same protocol+port tuple matcher, so there is no product reason to disagree.

## Fix (converged /research plan, Path A)

Unify the ENABLED path onto the DISABLED path's binary specificity:

- Tag `AppScanEntry` with `port_constrained`
  (`!(dst_low==0 && dst_high==0 && src_low==0 && src_high==0)`, the wire
  mirror of Go's `portBased = DestinationPort != "" || SourcePort != ""`).
- Change the `lookup_directional` tiebreak so the port-constrained tier
  (the always-port-constrained `exact_dst` hit + the lowest-id
  port-constrained scan hit) wins over the protocol-only tier, lowest id
  within a tier. Strictly additive for same-tier overlaps — byte-identical
  to before.

Enforcement (`CompiledApplications::matches`) is untouched; this is a
display/observability fix only. No wire/fixture change — label resolution is
not a wire field.

## Parity fixture

A shared, self-describing cross-language fixture
`userspace-dp/tests/fixtures/appid_precedence_v1.json` (user apps only per
plan scope note S1) is consumed by BOTH:

- Go `TestAppIDPrecedenceParityFixture` — drives `resolveTupleFallback`
  (disabled path) AND validates `BuildCatalog` reproduces the recorded ids,
  so the Rust side is not re-implementing the Go sort (a sort bug cannot hide
  identically in both languages).
- Rust `app_catalog_precedence_parity_fixture` — drives `lookup_directional`
  (enabled path).

Both resolve every case to the same NAME. Cases cover protocol-only vs
exact-port, protocol-only vs range, same-tier lowest-id, src-port-only
port-constrained, single-match, and no-match.

## RED-on-revert

Reverting the tiebreak to lowest-id-regardless-of-tier turns the 3 new tests
RED (parity fixture panics `app_id = 1, want 2`) while the same-tier
`app_catalog_overlap_lowest_id_wins` and all pre-existing app_catalog tests
stay GREEN. Verified, then restored.

## Out of scope (deferred, plan section 9)

- S1 — the disabled path's non-user fallback is the narrow hardcoded
  `builtinFallbacks` set, not the full predefined catalog the enabled path
  sees.
- S2 — reverse-direction service-slot handling (the disabled fallback has no
  reverse model).

## Validation

- Full `cargo test --release` green (3343 lib + all integration binaries, 0 failed).
- `go build ./...`, `go vet ./pkg/appid/... ./pkg/dataplane/...` clean.
- `go test ./pkg/appid/... ./pkg/dataplane/... ./pkg/grpcapi/... ./pkg/api/...` green.
- `gofmt` clean.
- Docs updated: `pkg/appid/README.md` (single precedence contract + parity
  fixture + S1/S2 deferrals), `docs/services-application-identification.md`
  (session-create precedence note; stale `lookup()` signature refreshed to
  `lookup_directional`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi