### PR TITLE
cmd/cli: render SSOT host-inbound verdict in remote match-policies (#3655)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24732,3 +24732,27 @@ top.
     docs/services-application-identification.md (session-create precedence note +
     stale lookup() signature refresh to lookup_directional).
   - **File(s)**: userspace-dp/src/policy.rs, userspace-dp/src/policy_tests.rs, userspace-dp/tests/fixtures/appid_precedence_v1.json, pkg/appid/precedence_parity_test.go, pkg/appid/README.md, docs/services-application-identification.md, _Log.md
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Fix #3655 — remote cmd/cli `show security match-policies` for an
+    unmatched host-inbound path (`to-zone junos-host`) still hard-coded the old
+    false-positive verdict "host-inbound: local delivery proceeds (transit
+    global/default-policy NOT applied)". #3647 corrected the local CLI / REST /
+    gRPC surfaces via the SSOT const but MISSED the remote client render. The old
+    literal read as an unconditional admit even though a no-stanza zone now
+    default-DENIES host-inbound (#3405). Replaced the hard-coded line in
+    `showMatchPolicies` with the shared `policymatch.HostInboundShowLine` (already
+    imported), so the remote client renders the SAME accurate host-inbound verdict
+    as every other transport ("host-inbound: local delivery subject to
+    host-inbound-traffic service admission (a zone with no host-inbound-traffic
+    stanza denies by default; transit global/default-policy NOT applied)"). Added
+    golden test TestShowMatchPoliciesHostInboundUsesSSOTString (asserts the render
+    uses HostInboundShowLine, not "local delivery proceeds"); RED-on-revert PROVEN
+    (restoring the literal fails the SSOT assertion). No doc change needed — the
+    policymatch/grpcapi READMEs already assert "The CLI / show / request surfaces
+    render the shared policymatch.HostInboundShowLine"; this fix makes the remote
+    client conform to the already-documented contract. Validation: go build
+    ./cmd/... ./pkg/... OK; go test ./cmd/cli/... ./pkg/policymatch/... green;
+    gofmt clean; go vet clean (the pre-existing monitor.go:159 protobuf-mutex-copy
+    warning is unrelated, present on origin/master).
+  - **File(s)**: cmd/cli/show.go, cmd/cli/show_matchpolicies_test.go, _Log.md

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -1143,8 +1143,15 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		fmt.Printf("    Action: %s\n", resp.Action)
 	} else if resp.HostInboundUnmatched {
 		// #3285: host-bound traffic — no transit global/default fallback.
+		// #3655: render the SSOT policymatch.HostInboundShowLine (as the local
+		// CLI / REST / gRPC surfaces already do post-#3647) instead of the old
+		// hard-coded "local delivery proceeds" wording. That literal read as an
+		// unconditional admit even though a no-stanza zone now default-DENIES
+		// host-inbound (#3405); the shared const states delivery is subject to
+		// host-inbound-traffic service admission so remote clients see the same
+		// accurate verdict as every other transport.
 		fmt.Printf("No matching to-zone junos-host policy for %s -> junos-host\n", req.FromZone)
-		fmt.Printf("  host-inbound: local delivery proceeds (transit global/default-policy NOT applied)\n")
+		fmt.Printf("  %s\n", policymatch.HostInboundShowLine)
 	} else {
 		// #3283: render the SERVER-provided default verdict (resp.Action carries
 		// "<action> (default)" from the configured default-policy), NOT a

--- a/cmd/cli/show_matchpolicies_test.go
+++ b/cmd/cli/show_matchpolicies_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+	"github.com/psaab/xpf/pkg/policymatch"
 )
 
 // TestShowMatchPoliciesRendersServerVerdict covers the #3283 drift on the REMOTE
@@ -40,6 +41,46 @@ func TestShowMatchPoliciesRendersServerVerdict(t *testing.T) {
 	}
 	if strings.Contains(out, "default deny") {
 		t.Fatalf("output still renders hard-coded 'default deny':\n%s", out)
+	}
+}
+
+// TestShowMatchPoliciesHostInboundUsesSSOTString covers the #3655 residual of
+// #3647 on the REMOTE CLI surface: `show security match-policies ... to-zone
+// junos-host` for an unmatched host path previously hard-coded
+// "local delivery proceeds", which read as an unconditional admit even though a
+// no-stanza zone now default-DENIES host-inbound (#3405). The remote client must
+// render the shared SSOT policymatch.HostInboundShowLine — the exact string the
+// local CLI / REST / gRPC surfaces already print post-#3647 — so a remote
+// operator never sees the false-positive verdict on a core troubleshooting
+// workflow.
+//
+// FAIL-ON-REVERT: restoring the hard-coded "local delivery proceeds" line makes
+// the HostInboundShowLine assertion fail (and the no-"local delivery proceeds"
+// assertion fail).
+func TestShowMatchPoliciesHostInboundUsesSSOTString(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		matchPoliciesResp: &pb.MatchPoliciesResponse{
+			Matched:              false,
+			HostInboundUnmatched: true,
+			Action:               policymatch.HostInboundActionString,
+		},
+	}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showMatchPolicies([]string{"from-zone", "trust", "to-zone", "junos-host"}); err != nil {
+			t.Fatalf("showMatchPolicies: %v", err)
+		}
+	})
+
+	if fake.matchPoliciesCalls != 1 {
+		t.Fatalf("MatchPolicies called %d times, want 1", fake.matchPoliciesCalls)
+	}
+	if !strings.Contains(out, policymatch.HostInboundShowLine) {
+		t.Fatalf("output missing SSOT HostInboundShowLine %q:\n%s", policymatch.HostInboundShowLine, out)
+	}
+	if strings.Contains(out, "local delivery proceeds") {
+		t.Fatalf("output still renders hard-coded 'local delivery proceeds':\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

The remote `cli` client's `show security match-policies ... to-zone junos-host`
for an unmatched host-inbound path still hard-coded the old, false-positive
verdict (`cmd/cli/show.go:~1147`):

    host-inbound: local delivery proceeds (transit global/default-policy NOT applied)

#3647 (issue #3646) corrected this wording on the **local CLI / REST / gRPC**
surfaces via the SSOT const `policymatch.HostInboundShowLine`, but the **remote
cmd/cli client render** was missed. For a no-stanza zone (now default-DENY per
#3405) and for any zone whose host-inbound service admission denies, "local
delivery proceeds" is an allow/deny diagnostic false positive on a core firewall
troubleshooting workflow — and it diverges from every other transport.

This is the residual of #3647 flagged as codex-review-123 H10, distinct from
#3627 (server-side queried-zone context) — a pure client-render miss.

## Fix

Replace the hard-coded line in `showMatchPolicies` with the shared
`policymatch.HostInboundShowLine` (`policymatch` was already imported), so the
remote client renders the same accurate verdict as the local CLI / REST / gRPC
surfaces:

    host-inbound: local delivery subject to host-inbound-traffic service
    admission (a zone with no host-inbound-traffic stanza denies by default;
    transit global/default-policy NOT applied)

**old → new string**
- old: `host-inbound: local delivery proceeds (transit global/default-policy NOT applied)`
- new: `policymatch.HostInboundShowLine`

No doc change needed: the `pkg/policymatch/README.md` and `pkg/grpcapi/README.md`
already assert that "the CLI / show / request surfaces render the shared
`policymatch.HostInboundShowLine`"; this change makes the remote client conform
to the already-documented contract.

## Test

Added golden test `TestShowMatchPoliciesHostInboundUsesSSOTString` (in
`cmd/cli/show_matchpolicies_test.go`) — drives `showMatchPolicies` with a
`HostInboundUnmatched` RPC response and asserts the render contains
`policymatch.HostInboundShowLine` and NOT `"local delivery proceeds"`.
**RED-on-revert proven**: restoring the literal fails the SSOT assertion.

## Validation
- `go build ./cmd/... ./pkg/...` OK
- `go test ./cmd/cli/... ./pkg/policymatch/...` green
- `gofmt` clean; `go vet` clean (the pre-existing `monitor.go:159`
  protobuf-mutex-copy warning is unrelated and present on origin/master)

Closes #3655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi