### PR TITLE
api,grpc,docs: align host_inbound_configured with #3405 default-deny

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-01 — #3653 align host_inbound_configured posture bit with #3405 dataplane default-deny
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3653 — REST (`pkg/api/security.go`) + gRPC
+    (`pkg/grpcapi/server_show_zones.go`) computed `HostInboundConfigured =
+    HostInboundTraffic != nil || len(InterfaceHostInbound) > 0`, so a no-stanza
+    configured zone reported `host_inbound_configured=false` carrying the
+    pre-#3405 "false = admit-all" semantics. But post-#3405 the dataplane
+    (`pkg/dataplane/userspace/zones.go:495`) sets `HostInboundConfigured=true`
+    UNCONDITIONALLY for every configured zone (a no-stanza zone default-DENIES
+    host-bound traffic). The API therefore reported "admit-all / not governed"
+    while runtime fail-closed default-DENIES — a contract disagreement an
+    auditor reads as an open management plane. FIX: both surfaces now set
+    `zi.HostInboundConfigured = true` (exact parity with the dataplane, which
+    is also gated on `zone != nil`). The admitted set — empty = deny-all —
+    lives in the split `host_inbound_system_services`/`host_inbound_protocols`
+    + per-interface override fields; no new field added (L03 enum deferred,
+    kept minimal per issue). Updated the stale H02 comments (api/types.go,
+    proto/xpf/v1/xpf.proto → regenerated comment-only pb.go with no wire
+    change, protocol.go ZoneSnapshot doc, the #3328 block comments in both
+    handlers) and M09 READMEs (pkg/api, pkg/grpcapi) to describe the
+    default-deny posture. Rewrote H03 tests: the `open` (no-stanza) zone now
+    asserts `configured=true` + empty token sets + no override — the
+    fail-on-revert guard (reverting to the config-shape formula reports false →
+    RED; proven on both surfaces). `go build ./pkg/... ./cmd/...`, `go vet`,
+    `go test ./pkg/api ./pkg/grpcapi ./pkg/config ./pkg/dataplane/userspace`
+    all green; gofmt clean on touched files.
+  - **File(s)**: pkg/api/security.go, pkg/api/types.go,
+    pkg/api/security_zone_hostinbound_3328_test.go, pkg/api/README.md,
+    pkg/grpcapi/server_show_zones.go,
+    pkg/grpcapi/server_show_zones_hostinbound_3328_test.go,
+    pkg/grpcapi/README.md, pkg/grpcapi/xpfv1/xpf.pb.go, proto/xpf/v1/xpf.proto,
+    pkg/dataplane/userspace/protocol.go, _Log.md
+
 ## 2026-07-01 — #3643 HIDE per-zone zone_counters + flood_counters dead surfaces
 
 - **Timestamp**: 2026-07-01

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -80,23 +80,27 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
   - `GET /api/v1/security/zones` enumerates security zones (`ZoneInfo`,
     types.go). The host-inbound admission set is surfaced distinctly
     (#3328): `host_inbound_configured` is the dataplane posture bit
-    (mirrors `ZoneSnapshot.HostInboundConfigured`, #3070/#3362) — true
-    when the zone declares a `host-inbound-traffic` stanza OR carries any
-    per-interface override. This lets automation tell apart the three
-    postures the dataplane actually models: no stanza
-    (`host_inbound_configured=false` → admit-all for host-bound traffic),
-    explicit empty stanza (`configured=true` with empty lists → deny-all),
-    and a populated set. `host_inbound_system_services` and
-    `host_inbound_protocols` carry the zone-level set split so a
-    system-service (ssh, ping, dhcp) is distinguishable from a routing
-    protocol (ospf, bgp). `interface_host_inbound` (omitted when none)
-    carries per-interface overrides (#3362); the effective set for an
-    interface is the union of the zone-level set and its override. The
-    legacy flattened `host_inbound_services` (services + protocols
-    concatenated) is retained as a back-compat alias. Before #3328 REST
-    exposed only the flattened list and no `configured` flag, so a
-    controller could not distinguish admit-all from deny-all — a
-    host-inbound / control-plane-protection posture ambiguity.
+    (mirrors `ZoneSnapshot.HostInboundConfigured`, #3070/#3362/#3405).
+    Post-#3405 EVERY configured security zone is host-inbound ENFORCING
+    (Junos default-deny parity), so this bit is `true` for every zone the
+    endpoint returns — it reports the dataplane truth, not config shape.
+    A zone with NO `host-inbound-traffic` stanza default-DENIES host-bound
+    traffic exactly like an explicit empty stanza; there is no admit-all
+    posture for a configured zone. The admitted set lives in
+    `host_inbound_system_services` and `host_inbound_protocols` (empty =
+    deny-all; kept split so a system-service such as ssh/ping/dhcp is
+    distinguishable from a routing protocol such as ospf/bgp), plus any
+    `interface_host_inbound` per-interface override (#3362, omitted when
+    none; the effective set for an interface is the union of the zone-level
+    set and its override). The legacy flattened `host_inbound_services`
+    (services + protocols concatenated) is retained as a back-compat alias.
+    Before #3653 the bit was re-derived from config shape and reported
+    `false` for a no-stanza zone — the pre-#3405 "false = admit-all"
+    reading, the OPPOSITE of the runtime default-deny, so an auditor read
+    the management plane as open when it is fail-closed. (Global
+    ICMP/ND/PMTUD accepts and lifeline interfaces fxp0/em0/fab* still
+    bypass the per-zone host-inbound deny.) Before #3328 REST exposed only
+    the flattened list and no `configured` flag at all.
   - `GET /api/v1/security/screen` enumerates the configured screen
     profiles. Each `ScreenInfo` carries the profile `name`, a `checks`
     string list, and a `thresholds` map (keyed by check name). The

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -45,9 +45,10 @@ func (s *Server) zonesHandler(w http.ResponseWriter, _ *http.Request) {
 
 		// Host-inbound services. #3328: surface the admission posture
 		// distinctly. HostInbound stays the flattened back-compat alias, but the
-		// split fields let automation tell a service apart from a protocol and —
-		// via HostInboundConfigured — tell "no stanza" (admit-all) apart from an
-		// explicit empty stanza (deny-all).
+		// split fields let automation tell a service (ssh, ping) apart from a
+		// protocol (ospf, bgp). Post-#3405 the admitted set — empty = deny-all —
+		// is the discriminating signal (HostInboundConfigured is true for every
+		// configured zone; see below).
 		if zone.HostInboundTraffic != nil {
 			zi.HostInbound = append(zi.HostInbound, zone.HostInboundTraffic.SystemServices...)
 			zi.HostInbound = append(zi.HostInbound, zone.HostInboundTraffic.Protocols...)
@@ -55,9 +56,18 @@ func (s *Server) zonesHandler(w http.ResponseWriter, _ *http.Request) {
 			zi.HostInboundProtocols = append(zi.HostInboundProtocols, zone.HostInboundTraffic.Protocols...)
 		}
 		// HostInboundConfigured mirrors ZoneSnapshot.HostInboundConfigured
-		// (#3070/#3362): the zone is host-inbound ENFORCING when it declares a
-		// zone-level stanza OR carries any per-interface override.
-		zi.HostInboundConfigured = zone.HostInboundTraffic != nil || len(zone.InterfaceHostInbound) > 0
+		// (#3070/#3362/#3405). Post-#3405 EVERY configured security zone is
+		// host-inbound ENFORCING (Junos default-deny parity): a zone with no
+		// `host-inbound-traffic` stanza default-DENIES host-bound traffic
+		// exactly like an explicit empty stanza. buildZoneSnapshots sets
+		// HostInboundConfigured=true unconditionally for every non-nil zone
+		// (dataplane/userspace/zones.go). Re-deriving the bit from config shape
+		// (stanza-or-override) reported false for a no-stanza zone — the API's
+		// own "false = admit-all" contract, the exact OPPOSITE of the runtime
+		// default-deny (#3653). Report the dataplane truth: enforcing. The
+		// admitted token set (which may be empty = deny-all) lives in the split
+		// fields below.
+		zi.HostInboundConfigured = true
 		for _, ref := range zone.SortedInterfaceHostInboundRefs() {
 			hib := zone.InterfaceHostInbound[ref]
 			zi.InterfaceHostInbound = append(zi.InterfaceHostInbound, ZoneInterfaceHostInbound{

--- a/pkg/api/security_zone_hostinbound_3328_test.go
+++ b/pkg/api/security_zone_hostinbound_3328_test.go
@@ -11,13 +11,23 @@ import (
 
 // #3328: the REST zone inventory flattened the host-inbound admission set into
 // one host_inbound_services list and never exposed whether a host-inbound
-// stanza was configured at all, so automation could not tell apart the three
-// dataplane postures: no stanza (admit-all), explicit empty stanza (deny-all),
-// and a populated set (split into system-services vs protocols). ZoneInfo now
-// carries host_inbound_configured, host_inbound_system_services,
-// host_inbound_protocols, and per-interface overrides (#3362). These are the
-// fail-on-revert guards: drop the population in zonesHandler and the assertions
-// below go RED.
+// stanza was configured at all. ZoneInfo now carries host_inbound_configured,
+// host_inbound_system_services, host_inbound_protocols, and per-interface
+// overrides (#3362).
+//
+// #3405/#3653: EVERY configured security zone is host-inbound ENFORCING (Junos
+// default-deny parity). The dataplane (dataplane/userspace/zones.go) sets
+// HostInboundConfigured=true unconditionally for every configured zone; a zone
+// with NO host-inbound-traffic stanza default-DENIES host-bound traffic exactly
+// like an explicit empty stanza. The REST/gRPC bit was re-derived from config
+// shape (stanza-or-override) and reported false for a no-stanza zone — the
+// pre-#3405 "false = admit-all" reading, the OPPOSITE of runtime. This test
+// pins four distinct concepts so the fix cannot regress: (1) the zone exists,
+// (2) enforcement posture — always true for a configured zone, (3) the
+// zone-level token set (system-services vs protocols, empty = deny-all), and
+// (4) the per-interface effective override. The `open` (no-stanza) assertion is
+// the fail-on-revert guard: reverting to the config-shape formula reports
+// configured=false for `open` and this test goes RED.
 
 // zoneHostInboundAPIStore builds a config exercising every host-inbound
 // posture:
@@ -28,7 +38,9 @@ import (
 //   - edge: NO zone-level stanza but a per-interface override on ge-0/0/9.0
 //     (enforcing via override → configured=true, empty zone lists, one
 //     interface entry),
-//   - open: NO host-inbound at all (admit-all → configured=false).
+//   - open: NO host-inbound at all. Post-#3405 this default-DENIES host-bound
+//     traffic (configured=true, empty lists) — indistinguishable in POSTURE
+//     from `locked`, matching the dataplane.
 func zoneHostInboundAPIStore(t *testing.T) *configstore.Store {
 	t.Helper()
 
@@ -122,28 +134,45 @@ func TestZonesHandlerSurfacesHostInboundPosture(t *testing.T) {
 		t.Fatalf("trust host_inbound_services (legacy alias) = %v, want 3 entries", got)
 	}
 
-	// locked: explicit empty stanza = deny-all. The whole point of #3328:
-	// configured=true distinguishes it from a zone with no stanza (open).
+	// locked: explicit empty stanza = deny-all, configured=true. Post-#3405 it
+	// has the same POSTURE as `open` (both deny-all); the two are still
+	// distinguishable by config shape only through the token/override fields,
+	// not this bit.
 	locked, ok := byName["locked"]
 	if !ok {
 		t.Fatalf("locked zone missing from REST inventory")
 	}
 	if !locked.HostInboundConfigured {
-		t.Fatalf("locked host_inbound_configured = false, want true (explicit empty stanza = deny-all; #3328 the no-stanza-vs-empty-stanza distinction)")
+		t.Fatalf("locked host_inbound_configured = false, want true (explicit empty stanza = deny-all)")
 	}
 	if len(locked.HostInboundSystemServices) != 0 || len(locked.HostInboundProtocols) != 0 {
 		t.Fatalf("locked host-inbound lists = %v/%v, want empty (deny-all)",
 			locked.HostInboundSystemServices, locked.HostInboundProtocols)
 	}
 
-	// open: no stanza at all = admit-all. configured MUST be false so it is
-	// distinguishable from locked.
+	// open: NO host-inbound stanza and NO per-interface override. Post-#3405
+	// this zone default-DENIES host-bound traffic just like `locked`, so the
+	// posture bit MUST be true — it mirrors the dataplane, which sets
+	// HostInboundConfigured=true for every configured zone. This is the
+	// fail-on-revert guard for #3653: the pre-#3405 config-shape formula
+	// (HostInboundTraffic != nil || len(InterfaceHostInbound) > 0) reports
+	// false here — the "false = admit-all" lie that contradicted runtime — so
+	// reverting the fix turns this RED.
 	open, ok := byName["open"]
 	if !ok {
 		t.Fatalf("open zone missing from REST inventory")
 	}
-	if open.HostInboundConfigured {
-		t.Fatalf("open host_inbound_configured = true, want false (no stanza = admit-all; #3328 must not collapse with the empty-stanza deny-all posture)")
+	if !open.HostInboundConfigured {
+		t.Fatalf("open host_inbound_configured = false, want true (#3405/#3653: a no-stanza configured zone default-DENIES host-bound traffic; the bit must mirror the dataplane, not the pre-#3405 admit-all reading)")
+	}
+	// A no-stanza zone carries no zone-level tokens and no override — the empty
+	// admitted set IS the deny-all, identical in shape to `locked`.
+	if len(open.HostInboundSystemServices) != 0 || len(open.HostInboundProtocols) != 0 {
+		t.Fatalf("open host-inbound lists = %v/%v, want empty (no-stanza default-deny)",
+			open.HostInboundSystemServices, open.HostInboundProtocols)
+	}
+	if len(open.InterfaceHostInbound) != 0 {
+		t.Fatalf("open interface_host_inbound = %v, want none", open.InterfaceHostInbound)
 	}
 
 	// edge: no zone-level stanza but a per-interface override. The zone is

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -87,13 +87,20 @@ type ZoneInfo struct {
 	// protocols concatenated. Kept as a back-compat alias (#3328); new
 	// consumers should read the split fields below.
 	HostInbound []string `json:"host_inbound_services"`
-	// HostInboundConfigured (#3328) records whether the zone is host-inbound
-	// ENFORCING: true when the zone declares a `host-inbound-traffic` stanza OR
-	// carries any per-interface override (#3362). Mirrors the dataplane posture
-	// bit (ZoneSnapshot.HostInboundConfigured): false = no stanza = default
-	// admit-all for host-bound traffic; true with EMPTY service/protocol lists
-	// = explicit deny-all. Without it an operator cannot distinguish "no
-	// stanza" (admit-all) from "empty stanza" (deny-all).
+	// HostInboundConfigured (#3328/#3405) records whether the zone is
+	// host-inbound ENFORCING. Post-#3405 EVERY configured security zone is
+	// enforcing (Junos default-deny parity), so this mirrors the dataplane
+	// posture bit (ZoneSnapshot.HostInboundConfigured) and is TRUE for every
+	// zone the inventory returns. A zone with NO `host-inbound-traffic` stanza
+	// default-DENIES host-bound traffic exactly like an explicit empty stanza
+	// (deny-all) — there is no admit-all posture for a configured zone. The
+	// admitted set lives in HostInboundSystemServices / HostInboundProtocols
+	// (empty = deny-all) plus any per-interface override in
+	// InterfaceHostInbound. Before #3653 this bit was re-derived from config
+	// shape and reported false for a no-stanza zone — the pre-#3405
+	// "false = admit-all" reading, contradicting the runtime default-deny.
+	// (Note: global ICMP/ND/PMTUD accepts and lifeline interfaces fxp0/em0/fab*
+	// still bypass the per-zone host-inbound deny; see zones.go.)
 	HostInboundConfigured bool `json:"host_inbound_configured"`
 	// HostInboundSystemServices / HostInboundProtocols (#3328) carry the
 	// ZONE-LEVEL admission set, kept distinct so automation can tell a

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -204,13 +204,15 @@ type ZoneSnapshot struct {
 	// SSH, ping, routing protocols on the box itself) was admitted regardless
 	// of the configured set — a security-boundary gap.
 	//
-	// HostInboundConfigured records whether the zone declared a
-	// host-inbound-traffic stanza at all. When false the dataplane preserves
-	// the historical admit-all behaviour for host-bound (local-delivery)
-	// traffic on this zone (a conservative, zero-regression default: zones
-	// that never opted into the feature are unaffected). When true the
-	// dataplane default-denies host-bound traffic whose system-service /
-	// protocol is not in the configured set (Junos host-inbound posture).
+	// HostInboundConfigured marks the zone host-inbound ENFORCING. Post-#3405
+	// buildZoneSnapshots sets it true for EVERY configured zone (Junos
+	// default-deny parity), so the Rust side default-denies host-bound
+	// (local-delivery) traffic whose system-service / protocol is not in the
+	// configured set — a zone with no `host-inbound-traffic` stanza carries an
+	// EMPTY set and thus deny-all. (Pre-#3405 a false here preserved the
+	// historical admit-all for a no-stanza zone; that no-opt-in admit-all was a
+	// management-plane exposure and is gone.) Global ICMP/ND/PMTUD accepts
+	// (#3171) and lifeline interfaces (fxp0/em0/fab*) still bypass this deny.
 	//
 	// The token slices mirror config.HostInboundTraffic verbatim (lower-cased,
 	// order-preserved). The Rust side classifies the tokens to L4 signatures

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -175,22 +175,27 @@ contract.
 - `GetZones` enumerates security zones (`ZoneInfo`). The host-inbound
   admission set is surfaced distinctly (#3328): `host_inbound_configured`
   is the dataplane posture bit (mirrors `ZoneSnapshot.HostInboundConfigured`,
-  #3070/#3362) — true when the zone declares a `host-inbound-traffic`
-  stanza OR carries any per-interface override. It lets a controller tell
-  apart the three postures the dataplane models: no stanza
-  (`configured=false` → admit-all for host-bound traffic), explicit empty
-  stanza (`configured=true` with empty lists → deny-all), and a populated
-  set. `host_inbound_system_services` / `host_inbound_protocols` carry the
-  zone-level set split (a service vs a routing protocol);
+  #3070/#3362/#3405). Post-#3405 EVERY configured security zone is
+  host-inbound ENFORCING (Junos default-deny parity), so this bit is `true`
+  for every zone the RPC returns — it reports the dataplane truth, not
+  config shape. A zone with NO `host-inbound-traffic` stanza default-DENIES
+  host-bound traffic exactly like an explicit empty stanza; there is no
+  admit-all posture for a configured zone. The admitted set lives in
+  `host_inbound_system_services` / `host_inbound_protocols` (empty =
+  deny-all; split so a service is distinguishable from a routing protocol);
   `interface_host_inbound` (repeated `InterfaceHostInbound`) carries
   per-interface overrides (#3362), the effective set being the union of
   the zone-level set and the override. The legacy `host_inbound_services`
   flattened list (services + protocols) is kept as a back-compat alias.
   The split projection is the SSOT-shared `ZoneConfig.SortedInterfaceHostInboundRefs`
   iteration the REST `GET /api/v1/security/zones` handler also uses. Before
-  #3328 this RPC exposed only the flattened list and no `configured` flag —
-  a host-inbound / control-plane-protection posture ambiguity for
-  automation.
+  #3653 the bit was re-derived from config shape and reported `false` for a
+  no-stanza zone — the pre-#3405 "false = admit-all" reading, the OPPOSITE
+  of the runtime default-deny, so a controller read the management plane as
+  open when it is fail-closed. (Global ICMP/ND/PMTUD accepts and lifeline
+  interfaces fxp0/em0/fab* still bypass the per-zone host-inbound deny.)
+  Before #3328 this RPC exposed only the flattened list and no `configured`
+  flag at all.
 - `GetScreen` enumerates the configured screen profiles. `ScreenInfo`
   carries `name`, the `checks` string list, and a `map<string,int64>
   thresholds`. The `checks` list and thresholds come from the shared

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -43,9 +43,10 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 		// #3328: surface the host-inbound admission posture distinctly. The
 		// legacy host_inbound_services list stays as a flattened back-compat
 		// alias (system-services + protocols), but the split fields below let
-		// automation tell a service apart from a protocol and — via
-		// host_inbound_configured — tell "no stanza" (admit-all) apart from an
-		// explicit empty stanza (deny-all).
+		// automation tell a service (ssh, ping) apart from a protocol (ospf,
+		// bgp). Post-#3405 the admitted set — empty = deny-all — is the
+		// discriminating signal (host_inbound_configured is true for every
+		// configured zone; see below).
 		if zone.HostInboundTraffic != nil {
 			zi.HostInboundServices = append(zi.HostInboundServices, zone.HostInboundTraffic.SystemServices...)
 			zi.HostInboundServices = append(zi.HostInboundServices, zone.HostInboundTraffic.Protocols...)
@@ -53,9 +54,18 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 			zi.HostInboundProtocols = append(zi.HostInboundProtocols, zone.HostInboundTraffic.Protocols...)
 		}
 		// host_inbound_configured mirrors ZoneSnapshot.HostInboundConfigured
-		// (#3070/#3362): the zone is host-inbound ENFORCING when it declares a
-		// zone-level stanza OR carries any per-interface override.
-		zi.HostInboundConfigured = zone.HostInboundTraffic != nil || len(zone.InterfaceHostInbound) > 0
+		// (#3070/#3362/#3405). Post-#3405 EVERY configured security zone is
+		// host-inbound ENFORCING (Junos default-deny parity): a zone with no
+		// `host-inbound-traffic` stanza default-DENIES host-bound traffic
+		// exactly like an explicit empty stanza. buildZoneSnapshots sets
+		// HostInboundConfigured=true unconditionally for every non-nil zone
+		// (dataplane/userspace/zones.go). Re-deriving the bit from config shape
+		// (stanza-or-override) reported false for a no-stanza zone — the API's
+		// own "false = admit-all" contract, the exact OPPOSITE of the runtime
+		// default-deny (#3653). Report the dataplane truth: enforcing. The
+		// admitted token set (which may be empty = deny-all) lives in the split
+		// fields below.
+		zi.HostInboundConfigured = true
 		for _, ref := range zone.SortedInterfaceHostInboundRefs() {
 			hib := zone.InterfaceHostInbound[ref]
 			zi.InterfaceHostInbound = append(zi.InterfaceHostInbound, &pb.InterfaceHostInbound{

--- a/pkg/grpcapi/server_show_zones_hostinbound_3328_test.go
+++ b/pkg/grpcapi/server_show_zones_hostinbound_3328_test.go
@@ -10,12 +10,18 @@ import (
 )
 
 // #3328: gRPC GetZones flattened the host-inbound admission set into one
-// host_inbound_services repeated field and exposed no host_inbound_configured,
-// so a controller could not distinguish no-stanza (admit-all) from an explicit
-// empty stanza (deny-all), nor a system-service from a routing protocol.
+// host_inbound_services repeated field and exposed no host_inbound_configured.
 // ZoneInfo now carries host_inbound_configured, host_inbound_system_services,
-// host_inbound_protocols, and interface_host_inbound (#3362). These are the
-// fail-on-revert guards.
+// host_inbound_protocols, and interface_host_inbound (#3362).
+//
+// #3405/#3653: EVERY configured security zone is host-inbound ENFORCING (Junos
+// default-deny parity). The dataplane (dataplane/userspace/zones.go) sets
+// HostInboundConfigured=true unconditionally; a zone with NO stanza
+// default-DENIES host-bound traffic exactly like an explicit empty stanza. The
+// RPC bit was re-derived from config shape and reported false for a no-stanza
+// zone — the pre-#3405 "false = admit-all" reading, the OPPOSITE of runtime.
+// The `open` (no-stanza) assertion is the fail-on-revert guard: reverting to
+// the config-shape formula reports configured=false and this test goes RED.
 
 func zoneHostInboundGRPCStore(t *testing.T) *configstore.Store {
 	t.Helper()
@@ -94,24 +100,40 @@ func TestGetZonesSurfacesHostInboundPosture(t *testing.T) {
 		t.Fatalf("trust host_inbound_services (legacy alias) = %v, want 3 entries", got)
 	}
 
+	// locked: explicit empty stanza = deny-all, configured=true. Post-#3405 it
+	// shares the deny-all POSTURE with `open`; the bit no longer distinguishes
+	// them (both true).
 	locked, ok := byName["locked"]
 	if !ok {
 		t.Fatal("locked zone missing")
 	}
 	if !locked.GetHostInboundConfigured() {
-		t.Fatal("locked host_inbound_configured = false, want true (explicit empty stanza = deny-all; the no-stanza-vs-empty-stanza distinction #3328)")
+		t.Fatal("locked host_inbound_configured = false, want true (explicit empty stanza = deny-all)")
 	}
 	if len(locked.GetHostInboundSystemServices()) != 0 || len(locked.GetHostInboundProtocols()) != 0 {
 		t.Fatalf("locked host-inbound lists = %v/%v, want empty (deny-all)",
 			locked.GetHostInboundSystemServices(), locked.GetHostInboundProtocols())
 	}
 
+	// open: NO host-inbound stanza and NO per-interface override. Post-#3405
+	// this zone default-DENIES host-bound traffic just like `locked`, so the
+	// posture bit MUST be true — it mirrors the dataplane, which sets
+	// HostInboundConfigured=true for every configured zone. Fail-on-revert
+	// guard for #3653: the pre-#3405 config-shape formula reports false here
+	// (the "false = admit-all" lie that contradicted runtime), turning this RED.
 	open, ok := byName["open"]
 	if !ok {
 		t.Fatal("open zone missing")
 	}
-	if open.GetHostInboundConfigured() {
-		t.Fatal("open host_inbound_configured = true, want false (no stanza = admit-all; #3328 must not collapse with the empty-stanza deny-all posture)")
+	if !open.GetHostInboundConfigured() {
+		t.Fatal("open host_inbound_configured = false, want true (#3405/#3653: a no-stanza configured zone default-DENIES host-bound traffic; the bit must mirror the dataplane, not the pre-#3405 admit-all reading)")
+	}
+	if len(open.GetHostInboundSystemServices()) != 0 || len(open.GetHostInboundProtocols()) != 0 {
+		t.Fatalf("open host-inbound lists = %v/%v, want empty (no-stanza default-deny)",
+			open.GetHostInboundSystemServices(), open.GetHostInboundProtocols())
+	}
+	if len(open.GetInterfaceHostInbound()) != 0 {
+		t.Fatalf("open interface_host_inbound = %v, want none", open.GetInterfaceHostInbound())
 	}
 
 	edge, ok := byName["edge"]

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -1910,13 +1910,19 @@ type ZoneInfo struct {
 	EgressBytes         uint64   `protobuf:"varint,9,opt,name=egress_bytes,json=egressBytes,proto3" json:"egress_bytes,omitempty"`
 	TcpRst              bool     `protobuf:"varint,10,opt,name=tcp_rst,json=tcpRst,proto3" json:"tcp_rst,omitempty"`
 	Description         string   `protobuf:"bytes,11,opt,name=description,proto3" json:"description,omitempty"`
-	// host_inbound_configured (#3328) records whether the zone is host-inbound
-	// ENFORCING: true when the zone declares a `host-inbound-traffic` stanza OR
-	// carries any per-interface override (#3362). This is the dataplane posture
-	// bit (ZoneSnapshot.HostInboundConfigured): false = no stanza = default
-	// admit-all for host-bound traffic; true with EMPTY lists = explicit
-	// deny-all. Without it an operator cannot distinguish "no stanza"
-	// (admit-all) from "empty stanza" (deny-all).
+	// host_inbound_configured (#3328/#3405) records whether the zone is
+	// host-inbound ENFORCING. Post-#3405 EVERY configured security zone is
+	// enforcing (Junos default-deny parity), so this is the dataplane posture
+	// bit (ZoneSnapshot.HostInboundConfigured) and is TRUE for every zone this
+	// RPC returns. A zone with NO `host-inbound-traffic` stanza default-DENIES
+	// host-bound traffic exactly like an explicit empty stanza (deny-all) —
+	// there is no admit-all posture for a configured zone. The admitted set
+	// lives in host_inbound_system_services / host_inbound_protocols (empty =
+	// deny-all) plus any per-interface override in interface_host_inbound.
+	// Before #3653 this was re-derived from config shape and reported false for
+	// a no-stanza zone — the pre-#3405 "false = admit-all" reading, the OPPOSITE
+	// of runtime. (Global ICMP/ND/PMTUD accepts and lifeline interfaces
+	// fxp0/em0/fab* still bypass the per-zone host-inbound deny.)
 	HostInboundConfigured bool `protobuf:"varint,12,opt,name=host_inbound_configured,json=hostInboundConfigured,proto3" json:"host_inbound_configured,omitempty"`
 	// host_inbound_system_services / host_inbound_protocols (#3328) carry the
 	// ZONE-LEVEL admission set, kept distinct so automation can tell a

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -227,13 +227,19 @@ message ZoneInfo {
   uint64 egress_bytes = 9;
   bool tcp_rst = 10;
   string description = 11;
-  // host_inbound_configured (#3328) records whether the zone is host-inbound
-  // ENFORCING: true when the zone declares a `host-inbound-traffic` stanza OR
-  // carries any per-interface override (#3362). This is the dataplane posture
-  // bit (ZoneSnapshot.HostInboundConfigured): false = no stanza = default
-  // admit-all for host-bound traffic; true with EMPTY lists = explicit
-  // deny-all. Without it an operator cannot distinguish "no stanza"
-  // (admit-all) from "empty stanza" (deny-all).
+  // host_inbound_configured (#3328/#3405) records whether the zone is
+  // host-inbound ENFORCING. Post-#3405 EVERY configured security zone is
+  // enforcing (Junos default-deny parity), so this is the dataplane posture
+  // bit (ZoneSnapshot.HostInboundConfigured) and is TRUE for every zone this
+  // RPC returns. A zone with NO `host-inbound-traffic` stanza default-DENIES
+  // host-bound traffic exactly like an explicit empty stanza (deny-all) —
+  // there is no admit-all posture for a configured zone. The admitted set
+  // lives in host_inbound_system_services / host_inbound_protocols (empty =
+  // deny-all) plus any per-interface override in interface_host_inbound.
+  // Before #3653 this was re-derived from config shape and reported false for
+  // a no-stanza zone — the pre-#3405 "false = admit-all" reading, the OPPOSITE
+  // of runtime. (Global ICMP/ND/PMTUD accepts and lifeline interfaces
+  // fxp0/em0/fab* still bypass the per-zone host-inbound deny.)
   bool host_inbound_configured = 12;
   // host_inbound_system_services / host_inbound_protocols (#3328) carry the
   // ZONE-LEVEL admission set, kept distinct so automation can tell a


### PR DESCRIPTION
## Problem

#3405 flipped host-inbound enforcement so that EVERY configured security
zone is host-inbound ENFORCING (Junos default-deny parity): a zone with no
`host-inbound-traffic` stanza now default-DENIES host-bound traffic. The
dataplane posture bit was updated to match — `pkg/dataplane/userspace/zones.go`
sets `HostInboundConfigured = true` unconditionally for every non-nil zone.

The REST (`pkg/api/security.go`) and gRPC (`server_show_zones.go`) inventory
posture bit was NOT updated. It still used the pre-#3405 config-shape formula:

```go
zi.HostInboundConfigured =
    zone.HostInboundTraffic != nil || len(zone.InterfaceHostInbound) > 0
```

so a configured zone with no stanza and no interface override reported
`host_inbound_configured=false`. Per the API's own field comments `false`
means "no stanza = admit-all" — the exact OPPOSITE of the runtime, which
default-DENIES. Automation/auditors reading the API concluded the management
plane was open when it is actually fail-closed. (codex-review-123 H01/H02/H03/M09.)

## Aligned semantic

`host_inbound_configured` now reports the **effective dataplane posture**:
every configured zone is host-inbound ENFORCING, so both surfaces set
`zi.HostInboundConfigured = true` (exact parity with the dataplane, which is
likewise gated on `zone != nil`). Post-#3405 there is no admit-all posture for
a configured zone — a no-stanza zone default-DENIES exactly like an explicit
empty stanza. The admitted token set (empty = deny-all) still lives in the
split `host_inbound_system_services` / `host_inbound_protocols` fields plus any
per-interface override, so no information is lost.

Kept minimal per the issue: **no new field** added. The L03
`host_inbound_source` enum is deferred — with the bit now truthful there is no
admit-all posture left to disambiguate; distinguishing stanza *source* is a
config-shape nicety the token/override fields already carry.

## Changes

- **H01 fix** — REST + gRPC compute `HostInboundConfigured = true` for every
  configured zone (mirrors `zones.go`).
- **H02 comments** — `pkg/api/types.go`, `proto/xpf/v1/xpf.proto` (comment-only;
  regenerated `xpf.pb.go` with **no wire change**), the `ZoneSnapshot` doc in
  `pkg/dataplane/userspace/protocol.go`, and the #3328 block comments in both
  handlers now describe the default-deny posture.
- **M09 docs** — `pkg/api/README.md` + `pkg/grpcapi/README.md` GetZones/zones
  sections rewritten to the #3405 contract (incl. the global ICMP/ND/PMTUD +
  lifeline-interface exceptions).
- **H03 tests** — rewrote the two guard tests around four distinct concepts
  (zone exists / enforcement posture / zone-level token set / per-interface
  override). The `open` no-stanza zone now asserts `configured=true` + empty
  token sets + no override.

## RED-on-revert proof

Reverting either surface to the config-shape formula reports
`host_inbound_configured=false` for the no-stanza `open` zone → both tests fail:

```
--- FAIL: TestZonesHandlerSurfacesHostInboundPosture
    open host_inbound_configured = false, want true (#3405/#3653: a no-stanza
    configured zone default-DENIES host-bound traffic ...)
--- FAIL: TestGetZonesSurfacesHostInboundPosture
    open host_inbound_configured = false, want true (#3405/#3653 ...)
```

## Validation

- `go build ./pkg/... ./cmd/...`, `go vet` — clean
- `go test ./pkg/api ./pkg/grpcapi ./pkg/config ./pkg/dataplane/userspace` — green
- gofmt clean on touched files
- Generated `xpf.pb.go` diff is comment-only (verified — no wire/field change)

Closes #3653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi