### PR TITLE
reject: build-feasibility before token/budget consume (#3656)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-01 — #3656 reject reply: build-feasibility BEFORE token/budget consume (H11/H12)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3656 — the reject/deny reply path consumed the shared #2472
+    `REJECT_BUCKET` rate-limit token AND counted the TX-frame budget drop
+    BEFORE it knew whether a reply frame could actually be built. So an
+    UNREPLYABLE frame (inbound TCP RST, inbound ICMP/ICMPv6 error, non-first
+    fragment, L2 group/broadcast, unparseable frame, ingress without a primary
+    of the inbound family) still (H11) drained the shared bucket — a flood of
+    such frames silently downgraded legitimate rejects to drops (cheap DoS) —
+    and (H12) counted a `*_reject_reply_budget_drops` for a reply that could
+    never exist, mis-attributing malformed/unreplyable traffic as TX queue
+    pressure. This was the residual of #3615 (which reordered the event emit +
+    per-source counter split but NOT the bucket/budget consume vs build).
+    FIX: reordered `enqueue_reject_reply` so reply-build FEASIBILITY runs first
+    (build → `Some(bytes)`); the TX-frame budget gate and
+    `allow_generated_error(Reject)` token consume are reached ONLY for a
+    buildable reply. An unreplyable frame is now a PLAIN drop consuming neither
+    the token nor a budget-drop counter. #3615's per-source counter attribution
+    (`policy_reject_*` / `filter_reject_*`) and #2238/#3035 output-filter
+    classify are preserved and still run after the gates. Orthogonal to #3618
+    (per-zone bucket design, deferred) — the shared bucket is unchanged; only
+    the CONSUMPTION ORDERING moved. No wire/counter format change (existing
+    counters, reordered increment points) → no fixture regen.
+  - **File(s)**: `userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs`
+    (reorder + 3 new fail-on-revert tests:
+    `unreplyable_reject_does_not_drain_bucket_3656`,
+    `unreplyable_reject_does_not_count_budget_drop_3656`,
+    `unreplyable_non_first_fragment_reject_untouched_3656`; augmented
+    `reject_reply_rate_limited_when_bucket_empty` to assert a rate-limited
+    buildable reply counts NO budget drop),
+    `userspace-dp/src/afxdp/poll_descriptor/filter.rs`
+    (`filter_terminal_budget_suppressed_reject_logs_deny` now drives a
+    parseable SYN — the old empty-frame case relied on the pre-#3656
+    suppress-before-parse ordering and is now correctly an unreplyable PLAIN
+    drop with no budget drop), `docs/pr/2089-reject-action/plan.md` (§4.2
+    #3656 consumption-ordering update note).
+  - **Validation**: targeted `cargo test --release reject_reply` = 21/21 pass;
+    RED-on-revert verified (all 3 new tests FAIL when build is moved back after
+    the gates); FULL `cargo test --release` = 3346 lib + 46/8/16/1 integration
+    tests, 0 failed.
+
 ## 2026-07-01 — #3643 HIDE per-zone zone_counters + flood_counters dead surfaces
 
 - **Timestamp**: 2026-07-01

--- a/docs/pr/2089-reject-action/plan.md
+++ b/docs/pr/2089-reject-action/plan.md
@@ -240,6 +240,39 @@ Behavior:
    build/budget failure return `false` (caller still recycles + drops
    — fail-closed).
 
+> **#3656 update (consumption ordering).** Steps 1-2 above are now
+> **reordered**: reply-build FEASIBILITY (step 2) runs BEFORE the
+> TX-frame budget gate and the #2472 `REJECT_BUCKET` token consumption
+> (step 1). The reject/deny path is now:
+>
+>   build (`build_reject_rst_frame` / `build_reject_icmp_unreachable`)
+>   → `Some(bytes)` proves an actual reply exists
+>   → TX-frame budget gate (counts `*_reject_reply_budget_drops`)
+>   → `allow_generated_error(Reject)` token consume
+>   → #2238/#3035 output-filter classify → enqueue.
+>
+> Rationale: a frame that can never produce a reply — an inbound TCP
+> RST, an inbound ICMP/ICMPv6 error, a non-first fragment, an L2
+> group/broadcast frame, an unparseable frame, or an ingress without a
+> primary of the inbound family — is a PLAIN drop. It must consume
+> **neither** the shared per-reason rate-limit token (H11: a flood of
+> unreplyable frames draining the shared `REJECT_BUCKET` would silently
+> downgrade legitimate subsequent rejects to drops — a cheap DoS)
+> **nor** a `*_reject_reply_budget_drops` counter (H12: mis-attributing
+> an impossible reply as TX queue pressure hides the true attack shape).
+> A budget drop / token consume / rate-limited count is now recorded
+> only for a reply that could actually have been built. This is the
+> residual of #3615 (which reordered the event emit + per-source counter
+> split but left the bucket/budget consume ahead of the build) and is
+> orthogonal to #3618 (per-zone bucket design) — the shared bucket is
+> unchanged; only the consumption ORDERING moves. The extra build under
+> budget/rate pressure is on the already-cold reject exception path.
+> Enforced by `enqueue_reject_reply` in
+> `userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs`; fail-on-revert
+> tests: `unreplyable_reject_does_not_drain_bucket_3656`,
+> `unreplyable_reject_does_not_count_budget_drop_3656`,
+> `unreplyable_non_first_fragment_reject_untouched_3656`.
+
 ### 4.3 Trigger sites
 
 There are three policy-deny code paths in

--- a/userspace-dp/src/afxdp/poll_descriptor/filter.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/filter.rs
@@ -886,8 +886,12 @@ mod filter_terminal_tests {
         }
     }
 
-    /// TX-frame budget exhausted → the reject reply is suppressed BEFORE the
-    /// frame is ever parsed, so an empty frame is fine here.
+    /// TX-frame budget exhausted → a BUILDABLE reject reply is suppressed and
+    /// counted as budget pressure. #3656: a budget drop is now attributed only
+    /// once reply-build feasibility is proven, so this must drive a real,
+    /// parseable TCP SYN (an unparseable/empty frame would be an unreplyable
+    /// PLAIN drop that counts NO budget drop — see
+    /// `unreplyable_reject_does_not_count_budget_drop_3656` in reject_reply.rs).
     #[test]
     fn filter_terminal_budget_suppressed_reject_logs_deny() {
         let (handle, rx) = event_handle();
@@ -895,9 +899,35 @@ mod filter_terminal_tests {
         let forwarding = ForwardingState::default();
         let mut counters = BatchCounters::default();
         let flow = v4_flow(PROTO_TCP);
+        // A reflected TCP RST is self-contained (build_reject_rst_frame reflects
+        // the inbound frame), so a minimal parseable SYN suffices to make the
+        // reply FEASIBLE before the budget gate suppresses it.
+        let src = Ipv4Addr::new(192, 0, 2, 10);
+        let dst = Ipv4Addr::new(198, 51, 100, 20);
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[
+            0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x36, 0xe4, 0x2b, 0xd5, 0x39, 0xe6, 0x08, 0x00,
+        ]);
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x28, 0x12, 0x34, 0x40, 0x00, 64, PROTO_TCP, 0x00, 0x00,
+        ]);
+        frame.extend_from_slice(&src.octets());
+        frame.extend_from_slice(&dst.octets());
+        frame.extend_from_slice(&49152u16.to_be_bytes());
+        frame.extend_from_slice(&22u16.to_be_bytes());
+        frame.extend_from_slice(&[
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, 0xfa, 0xf0, 0x00, 0x00,
+            0x00, 0x00,
+        ]);
         let meta = UserspaceDpMeta {
+            ingress_ifindex: 5,
+            l3_offset: 14,
+            l4_offset: 34,
+            payload_offset: 54,
             protocol: PROTO_TCP,
+            tcp_flags: 0x02,
             addr_family: libc::AF_INET as u8,
+            pkt_len: (frame.len() - 14) as u16,
             ..UserspaceDpMeta::default()
         };
         let drop = filter_terminal(
@@ -905,7 +935,7 @@ mod filter_terminal_tests {
             &forwarding,
             Some(&handle),
             5,
-            &[],
+            &frame,
             meta,
             &flow,
             &mut counters,

--- a/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs
@@ -222,6 +222,39 @@ fn enqueue_reject_reply(
     counters: &mut BatchCounters,
     source: RejectReplySource,
 ) -> bool {
+    // #3656: determine reply-build FEASIBILITY before consuming the shared
+    // REJECT_BUCKET token OR counting a TX-frame-budget drop. A frame that can
+    // NEVER produce a reply — an inbound TCP RST, an inbound ICMP/ICMPv6 error,
+    // a non-first fragment, an L2 group/broadcast frame, an unparseable frame,
+    // or an ingress without a primary of the inbound family — is a PLAIN drop.
+    // Building the reply first (a pure, side-effect-free reflection of the
+    // inbound frame) means such a frame consumes NEITHER the shared per-reason
+    // rate-limit token (H11: a flood of unreplyable frames must not drain the
+    // REJECT_BUCKET and starve legitimate rejects — a cheap DoS against active
+    // reject behavior) NOR a budget-drop counter (H12: an impossible reply
+    // must not be mis-attributed as TX queue pressure and hide the true attack
+    // shape). The token / budget are consumed only once `Some(bytes)` proves an
+    // actual reply exists. This is the residual of #3615, which reordered the
+    // event emit + per-source counter split but left the bucket/budget consume
+    // AHEAD of the build. Orthogonal to #3618 (per-zone bucket design) — the
+    // shared bucket is unchanged; only the CONSUMPTION ORDERING moves. The
+    // extra build under budget/rate pressure is on the already-cold reject
+    // exception path.
+    let bytes = if meta.protocol == PROTO_TCP {
+        build_reject_rst_frame(packet_frame)
+    } else {
+        build_reject_icmp_unreachable(packet_frame, meta, ingress_ifindex, forwarding)
+    };
+    let Some(bytes) = bytes else {
+        // Unreplyable: fail-closed to the silent drop the caller already
+        // performs. The REJECT_BUCKET token and the *_reject_reply_budget_drops
+        // counters are deliberately left untouched here (#3656 H11/H12).
+        return false;
+    };
+
+    // TX-frame budget gate (queue protection). Reached ONLY for a buildable
+    // reply, so a counted budget drop is truthful TX-frame pressure on a real
+    // reply — never a mis-attributed unreplyable frame (#3656 H12).
     if !syn_cookie_reply_budget_available(tx_pipeline) {
         counters.touched = true;
         // #3615 (L04): attribute the TX-frame-budget suppression to the
@@ -243,26 +276,16 @@ fn enqueue_reject_reply(
     // token bucket bounds the generated-error RATE so a flood of rejected
     // flows cannot be amplified into unbounded RST/ICMP backscatter. Both
     // policy and filter reject share this `Reject` bucket (a single emit
-    // path, per the RejectReplySource doc comment). On bucket-empty we
-    // fail-closed to the silent drop the caller already performs and bump the
-    // observable `Reject` rate-limited counter (inside
-    // `allow_generated_error`).
+    // path, per the RejectReplySource doc comment). #3656: the token is
+    // consumed ONLY for a buildable reply (feasibility is proven above), so a
+    // flood of unreplyable frames can no longer drain the shared bucket and
+    // starve legitimate rejects (H11). On bucket-empty we fail-closed to the
+    // silent drop the caller already performs and bump the observable `Reject`
+    // rate-limited counter (inside `allow_generated_error`).
     if !allow_generated_error(GeneratedErrorReason::Reject) {
         counters.touched = true;
         return false;
     }
-
-    let bytes = if meta.protocol == PROTO_TCP {
-        build_reject_rst_frame(packet_frame)
-    } else {
-        build_reject_icmp_unreachable(packet_frame, meta, ingress_ifindex, forwarding)
-    };
-    let Some(bytes) = bytes else {
-        // Unparseable frame, ingress without a primary of the inbound
-        // family, inbound RST/ICMP-error, or a non-first fragment:
-        // fail-closed to the silent drop the caller already performs.
-        return false;
-    };
 
     // #2238: classify the GENERATED reply (TCP RST or ICMP/ICMPv6
     // unreachable) by its OWN egress 5-tuple + egress interface — the
@@ -923,6 +946,13 @@ mod tests {
             rate_limited_count(GeneratedErrorReason::Reject) > before,
             "the rate-limited drop must bump the observable Reject counter"
         );
+        // #3656 H12: a REPLIABLE reply suppressed by the rate limiter is
+        // counted as rate-limited (above), NOT as TX-frame queue pressure — the
+        // budget gate passed, so no budget drop may be attributed to it.
+        assert_eq!(
+            counters.policy_reject_reply_budget_drops, 0,
+            "a rate-limited (buildable) reject must not count a budget drop"
+        );
         // Restore a full bucket so sibling tests in this binary are unaffected.
         reset_bucket_for_test(GeneratedErrorReason::Reject, 0);
     }
@@ -952,6 +982,197 @@ mod tests {
         assert!(!sent, "inbound RST must not be answered");
         assert_eq!(counters.policy_reject_sent, 0);
         assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3656 H11 fail-on-revert: a frame that can NEVER produce a reply (an
+    /// inbound TCP RST) must NOT consume a token from the shared REJECT_BUCKET.
+    /// Drives the reject path with the bucket EMPTY and the TX budget plentiful:
+    /// on the fixed code the reply-build feasibility check runs first, returns
+    /// None, and short-circuits BEFORE `allow_generated_error`, so the empty
+    /// bucket is never touched and its rate-limited counter does not advance.
+    /// On a revert (token consumed before feasibility), the empty-bucket deny
+    /// bumps the rate-limited counter — turning this RED. This is the H11 DoS:
+    /// a flood of unreplyable frames draining the shared bucket would silently
+    /// downgrade legitimate rejects to drops.
+    #[test]
+    fn unreplyable_reject_does_not_drain_bucket_3656() {
+        use super::cookie_reply::SYN_COOKIE_REPLY_PENDING_RESERVE;
+        use crate::afxdp::icmp_ratelimit::{
+            GeneratedErrorReason, allow_generated_error_at, global_bucket_test_lock,
+            rate_limited_count, reset_bucket_for_test,
+        };
+        let _g = global_bucket_test_lock();
+        // Pin the refill epoch to the far future then drain, so the call site's
+        // smaller monotonic `now_ns` yields zero refill and the bucket stays
+        // empty across the call (mirrors reject_reply_rate_limited_when_bucket_-
+        // empty). A denied `try_take` does not advance the epoch, so the empty
+        // state survives.
+        let far_future = u64::MAX / 2;
+        reset_bucket_for_test(GeneratedErrorReason::Reject, far_future);
+        while allow_generated_error_at(GeneratedErrorReason::Reject, far_future, 1000, 1000) {}
+        let before = rate_limited_count(GeneratedErrorReason::Reject);
+
+        // Inbound TCP RST => build_reject_rst_frame returns None (unreplyable).
+        let (mut frame, mut meta, flow) = tcp_v4_syn();
+        frame[14 + 20 + 13] = 0x04;
+        meta.tcp_flags = 0x04;
+        // TX budget plentiful — isolates the token-bucket behavior.
+        let mut pipeline = tx_pipeline(
+            SYN_COOKIE_REPLY_PENDING_RESERVE * 2,
+            SYN_COOKIE_REPLY_PENDING_RESERVE + 1,
+        );
+        let forwarding = ForwardingState::default();
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_policy_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(!sent, "inbound RST is unreplyable");
+        assert_eq!(counters.policy_reject_sent, 0);
+        assert_eq!(
+            rate_limited_count(GeneratedErrorReason::Reject),
+            before,
+            "an unreplyable frame must not consume a REJECT_BUCKET token (H11)"
+        );
+        // H12: and it must not be mis-attributed as TX-frame budget pressure.
+        assert_eq!(
+            counters.policy_reject_reply_budget_drops, 0,
+            "an unreplyable frame must not count a budget drop"
+        );
+        assert!(pipeline.pending_tx_local.is_empty());
+        reset_bucket_for_test(GeneratedErrorReason::Reject, 0);
+    }
+
+    /// #3656 H12 fail-on-revert: a frame that can never produce a reply must
+    /// NOT be counted as a TX-frame-budget drop. Drives the reject path with an
+    /// inbound TCP RST (unreplyable) and the TX budget EXHAUSTED (zero
+    /// max-pending). On the fixed code the reply-build feasibility check runs
+    /// FIRST, returns None, and short-circuits BEFORE the budget gate, so no
+    /// budget drop is counted for a reply that could never have existed. On a
+    /// revert (budget checked before feasibility), the exhausted budget bumps
+    /// `policy_reject_reply_budget_drops` here — hiding the true attack shape
+    /// as queue pressure — turning this RED.
+    #[test]
+    fn unreplyable_reject_does_not_count_budget_drop_3656() {
+        let (mut frame, mut meta, flow) = tcp_v4_syn();
+        // Inbound TCP RST => unreplyable.
+        frame[14 + 20 + 13] = 0x04;
+        meta.tcp_flags = 0x04;
+        // Zero max-pending => TX budget exhausted.
+        let mut pipeline = tx_pipeline(0, 64);
+        let forwarding = ForwardingState::default();
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_policy_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(!sent, "inbound RST is unreplyable");
+        assert_eq!(
+            counters.policy_reject_reply_budget_drops, 0,
+            "an unreplyable frame must not be mis-attributed as budget pressure (H12)"
+        );
+        assert_eq!(counters.policy_reject_sent, 0);
+        assert!(pipeline.pending_tx_local.is_empty());
+    }
+
+    /// #3656 fail-on-revert (non-first-fragment variant): a non-first IPv4
+    /// fragment has no transport header to quote, so `build_reject_icmp_-
+    /// unreachable` (`can_generate_icmp_error_reply`) returns None — the frame
+    /// is unreplyable. It must consume neither the shared REJECT_BUCKET token
+    /// nor a budget drop. Runs with the TX budget EXHAUSTED so a reverted
+    /// budget-before-feasibility order would count a budget drop (RED). The
+    /// FILTER entry point is exercised here to cover both counter families.
+    #[test]
+    fn unreplyable_non_first_fragment_reject_untouched_3656() {
+        use crate::afxdp::icmp_ratelimit::{
+            GeneratedErrorReason, allow_generated_error_at, global_bucket_test_lock,
+            rate_limited_count, reset_bucket_for_test,
+        };
+        let _g = global_bucket_test_lock();
+        // Empty the shared bucket (far-future epoch drain) so a reverted token-
+        // before-feasibility order would deny + bump the rate-limited counter.
+        let far_future = u64::MAX / 2;
+        reset_bucket_for_test(GeneratedErrorReason::Reject, far_future);
+        while allow_generated_error_at(GeneratedErrorReason::Reject, far_future, 1000, 1000) {}
+        let before = rate_limited_count(GeneratedErrorReason::Reject);
+
+        let client = std::net::Ipv4Addr::new(10, 0, 61, 102);
+        let server = std::net::Ipv4Addr::new(1, 1, 1, 1);
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
+        frame.extend_from_slice(&[0x36, 0xe4, 0x2b, 0xd5, 0x39, 0xe6]);
+        frame.extend_from_slice(&0x0800u16.to_be_bytes());
+        // IPv4 header with a non-zero fragment offset (0x0001) => non-first
+        // fragment => can_generate_icmp_error_reply() == false => build None.
+        frame.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x12, 0x34, 0x00, 0x01, 64, PROTO_ICMP, 0, 0,
+        ]);
+        frame.extend_from_slice(&client.octets());
+        frame.extend_from_slice(&server.octets());
+        frame.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]); // fragment payload
+        let meta = UserspaceDpMeta {
+            ingress_ifindex: 5,
+            l3_offset: 14,
+            l4_offset: 34,
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_ICMP,
+            pkt_len: (frame.len() - 14) as u16,
+            ..UserspaceDpMeta::default()
+        };
+        let flow = SessionFlow {
+            src_ip: std::net::IpAddr::V4(client),
+            dst_ip: std::net::IpAddr::V4(server),
+            forward_key: SessionKey {
+                addr_family: libc::AF_INET as u8,
+                protocol: PROTO_ICMP,
+                src_ip: std::net::IpAddr::V4(client),
+                dst_ip: std::net::IpAddr::V4(server),
+                src_port: 0,
+                dst_port: 0,
+            },
+        };
+        // Zero max-pending => TX budget exhausted (drives the H12 leg too).
+        let mut pipeline = tx_pipeline(0, 64);
+        // An egress primary would be needed to BUILD an ICMP unreachable, but a
+        // non-first fragment is rejected before the family build, so omit it.
+        let forwarding = ForwardingState::default();
+        let mut counters = BatchCounters::default();
+        let sent = enqueue_filter_reject_reply(
+            &mut pipeline,
+            &forwarding,
+            5,
+            &frame,
+            meta,
+            &flow,
+            &mut counters,
+        );
+        assert!(!sent, "a non-first fragment is unreplyable");
+        assert_eq!(counters.filter_reject_sent, 0);
+        assert_eq!(
+            counters.filter_reject_reply_budget_drops, 0,
+            "a non-first fragment must not count a filter budget drop (H12)"
+        );
+        assert_eq!(
+            counters.policy_reject_reply_budget_drops, 0,
+            "a non-first fragment must not count a policy budget drop (H12)"
+        );
+        assert_eq!(
+            rate_limited_count(GeneratedErrorReason::Reject),
+            before,
+            "a non-first fragment must not drain the REJECT_BUCKET (H11)"
+        );
+        assert!(pipeline.pending_tx_local.is_empty());
+        reset_bucket_for_test(GeneratedErrorReason::Reject, 0);
     }
 
     /// #3071: an ICMP echo (non-TCP) frame for the zone-tcp-rst tests. Reused


### PR DESCRIPTION
Closes #3656.

## Problem (H11/H12 — residual of #3615)

On master, `enqueue_reject_reply`
(`userspace-dp/src/afxdp/poll_descriptor/reject_reply.rs`) consumed the
shared #2472 `REJECT_BUCKET` rate-limit token and counted the TX-frame
budget drop BEFORE it knew whether a reply could actually be built:

```
budget gate (counts *_reject_reply_budget_drops)
  -> allow_generated_error(Reject)   // token CONSUMED here
  -> build_reject_rst_frame / build_reject_icmp_unreachable  // feasibility known only here
```

So a frame that can never produce a reply — an inbound TCP RST, an
inbound ICMP/ICMPv6 error, a non-first fragment, an L2 group/broadcast
frame, an unparseable frame, or an ingress without a primary of the
inbound family — still:

- **H11**: drained the shared `REJECT_BUCKET`. A flood of unreplyable
  frames starves the bucket and silently downgrades legitimate rejects
  to drops (a cheap DoS against active reject behavior).
- **H12**: counted a `*_reject_reply_budget_drops` for a reply that
  could never exist — mis-attributing malformed/unreplyable traffic as
  TX queue pressure and hiding the true attack shape.

#3615 reordered the event emit + split the suppression counters by
source, but left the bucket/budget consume ahead of build feasibility.

## Fix

Reorder so reply-build FEASIBILITY runs first:

```
build -> Some(bytes)               // an actual reply exists
  -> TX-frame budget gate          // counts *_reject_reply_budget_drops
  -> allow_generated_error(Reject) // token consume
  -> #2238/#3035 output-filter classify -> enqueue
```

An unreplyable frame is now a PLAIN drop consuming neither the token nor
a budget-drop counter. #3615's per-source counter attribution
(`policy_reject_*` / `filter_reject_*`) and the output-filter classify
are preserved and still run after the gates. Orthogonal to #3618
(per-zone bucket design, deferred) — the shared bucket is unchanged;
only the consumption ORDERING moves. No wire/counter format change
(existing counters, reordered increment points), so no fixture regen.

## Tests (fail-on-revert)

All three go RED when the build is moved back after the gates:

- `unreplyable_reject_does_not_drain_bucket_3656` (H11: inbound RST on an
  empty bucket does not bump the rate-limited counter)
- `unreplyable_reject_does_not_count_budget_drop_3656` (H12: inbound RST
  under an exhausted TX budget counts no budget drop)
- `unreplyable_non_first_fragment_reject_untouched_3656` (non-first
  fragment via the FILTER entry point touches neither counter family nor
  the bucket)
- augmented `reject_reply_rate_limited_when_bucket_empty` to assert a
  rate-limited BUILDABLE reply counts no budget drop (not queue pressure)

`filter_terminal_budget_suppressed_reject_logs_deny` relied on the
pre-#3656 suppress-before-parse ordering (empty frame + asserted budget
drop). Under the new order an empty/unparseable frame is a correct
unreplyable PLAIN drop, so the test now drives a parseable SYN to keep
exercising the budget-suppressed "logs DENY" path with a feasible reply.

## Validation

- Targeted `cargo test --release reject_reply` = 21/21 pass
- RED-on-revert verified for the three new tests
- Full `cargo test --release` green (3346 lib + integration tests, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi