### PR TITLE
reject observability: surface source-split sent/budget counters in status + Prometheus (#3657)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-01 — #3657 surface source-split reject reply/budget counters (status + Prometheus)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3657 (H13/H14/H15/M02/M08) — the #3615 per-source reject
+    counters on the wire (`policy_reject_sent`/`filter_reject_sent`,
+    `*_reply_budget_drops`, `*_output_filter_drops` on `BindingStatus`) were
+    only partially surfaced: `show ... status` printed the output-filter leg
+    but never the SENT nor the TX-frame reply-budget legs (a docs-contract
+    violation — `docs/junos-cli-reference.md` promised budget pressure is
+    counted per source), and Prometheus exposed only the source-neutral
+    aggregate `xpf_userspace_reject_rate_limited_total`. VERIFIED all four
+    SENT+BUDGET counters already exist on the wire and are incremented in
+    `reject_reply.rs` (no Rust change needed — cargo slot held by #3656), so
+    this PR is GO-READ-SIDE only. (1) `format/status.go`: aggregate + print two
+    new zero-suppressed lines — `Generated-reply sent: policy_reject=N
+    filter_reject=N` (H13 active reject SUCCESS volume) and `Generated-reply
+    budget drops: policy_reject=N filter_reject=N` (H14 TX-frame budget
+    suppression), leaving the existing output-filter `Generated-reply drops`
+    line intact. (2) Prometheus (`pkg/api`): new `emitRejectObservability`
+    helper sums per-binding and emits `xpf_userspace_reject_sent_total`,
+    `xpf_userspace_reject_reply_budget_drops_total`,
+    `xpf_userspace_reject_output_filter_drops_total`, each labeled
+    `source="policy"|"filter"`, unconditionally (0 is a real signal);
+    aggregate rate-limit kept for back-compat (H15/M02). (3) RED-on-revert
+    tests: `TestFormatStatusSummaryShowsRejectObservability` (+ zero-suppress
+    variant) and source-split assertions in `TestEmitUserspaceDynamicBufferMetrics`
+    (count 21->27) — both proven RED when the print/emit is neutralized (M08).
+    (4) reconciled `docs/junos-cli-reference.md` §reject-event-truthfulness to
+    describe the three-line split + the Prometheus series. DEFERRED: the reject
+    RATE-LIMIT drop leg itself is still source-neutral (single global-per-reason
+    bucket in `icmp_ratelimit.rs`) — attributing it needs a NEW Rust counter +
+    wire field, filed as #3661 (M02 Rust follow-up; carries the L04 counter-
+    registry note).
+  - **File(s)**: pkg/dataplane/userspace/format/status.go,
+    pkg/dataplane/userspace/format/status_test.go, pkg/api/metrics.go,
+    pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
+    pkg/api/metrics_test.go, docs/junos-cli-reference.md, _Log.md
+
 ## 2026-07-01 — #3643 HIDE per-zone zone_counters + flood_counters dead surfaces
 
 - **Timestamp**: 2026-07-01

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -297,11 +297,27 @@ From zone: guest, To zone: lan
     truthful `action deny` — the forensic log never claims an active reject
     that was not sent. Reply-free deny paths (non-first fragments with no L4
     header, the forward/output-filter path that has no reply synthesis pending
-    #3608) log `deny` for the same reason. Suppression is counted per source in
-    `show ... status`: `policy_reject`/`filter_reject` under the
-    `Generated-reply drops` line distinguish a policy `then reject` from a
-    firewall-filter `then reject` that was dropped by budget or an output
-    filter.
+    #3608) log `deny` for the same reason. Both SUCCESS and SUPPRESSION are
+    counted per source in `show ... status` (#3657), each split
+    `policy_reject`/`filter_reject` so a security-policy `then reject` is
+    never conflated with a firewall-filter `then reject`:
+
+    - `Generated-reply sent` — replies actually enqueued (active reject
+      volume; a zone `tcp-rst` counts under `policy_reject`).
+    - `Generated-reply budget drops` — replies suppressed because the
+      per-tick TX-frame budget was exhausted.
+    - `Generated-reply drops` — replies dropped by an egress output firewall
+      filter applied to the reflected reply's own tuple (`policy_reject` /
+      `filter_reject` legs, alongside `time_exceeded` / `syn_cookie` / `ptb`
+      / `classify_parse_errors`).
+
+    The global reject rate-limit bucket is separate and source-neutral
+    (`reject_rate_limited_total`; a single global-per-reason token bucket).
+    The same source-split legs are exported to Prometheus as
+    `xpf_userspace_reject_sent_total`,
+    `xpf_userspace_reject_reply_budget_drops_total`, and
+    `xpf_userspace_reject_output_filter_drops_total`, each labeled
+    `source="policy"|"filter"`.
   - **Default-deny posture (#3405):** EVERY configured security zone denies
     host-bound traffic by default (Junos/vSRX parity). A zone with interfaces
     but NO `host-inbound-traffic` stanza is treated exactly like an empty

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -326,6 +326,17 @@ type xpfCollector struct {
 	userspaceTimeExceededRateLimited *prometheus.Desc
 	userspacePacketTooBigRateLimited *prometheus.Desc
 	userspaceRejectRateLimited       *prometheus.Desc
+	// #3657 (H15/M02): source-split reject reply telemetry. The aggregate
+	// userspaceRejectRateLimited above stays for back-compat; these expose
+	// the #3615 per-BindingStatus sent / TX-frame reply-budget /
+	// egress output-filter drop legs, labeled source=policy|filter, so
+	// alerting can attribute reject SUCCESS vs SUPPRESSION to a security
+	// policy `then reject` or a firewall-filter `then reject`. (The
+	// rate-limit bucket itself is still source-neutral in the helper — a
+	// per-source split of it needs a Rust change, tracked separately.)
+	userspaceRejectSent              *prometheus.Desc
+	userspaceRejectReplyBudgetDrops  *prometheus.Desc
+	userspaceRejectOutputFilterDrops *prometheus.Desc
 	userspaceFlowCacheActiveFlows    *prometheus.Desc
 	userspaceFlowCacheCapacity       *prometheus.Desc
 	// #1379: daemon-side userspace event-stream transport counters.
@@ -647,6 +658,9 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.userspaceTimeExceededRateLimited
 	ch <- c.userspacePacketTooBigRateLimited
 	ch <- c.userspaceRejectRateLimited
+	ch <- c.userspaceRejectSent
+	ch <- c.userspaceRejectReplyBudgetDrops
+	ch <- c.userspaceRejectOutputFilterDrops
 	ch <- c.userspaceFlowCacheActiveFlows
 	ch <- c.userspaceFlowCacheCapacity
 	ch <- c.userspaceEventStreamFramesTotal

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1036,8 +1036,50 @@ func newCollector(srv *Server) *xpfCollector {
 				"ADDITION to the SYN-cookie TX-frame budget gate "+
 				"(which is queue protection, not a rate cap). A nonzero value "+
 				"flags a rejected-flow flood being clamped before it amplifies "+
-				"into unbounded RST/ICMP backscatter (#2472).",
+				"into unbounded RST/ICMP backscatter (#2472). Source-neutral: "+
+				"the rate-limit bucket is global-per-reason (#3657 M02 note — a "+
+				"per-source split needs a helper change).",
 			nil, nil,
+		),
+		// #3657 (H13/H15/M02): source-split reject reply telemetry. #3615
+		// wired the per-source sent / TX-frame reply-budget / egress
+		// output-filter legs onto BindingStatus; these expose them so
+		// alerting can tell policy-reject from filter-reject and success from
+		// suppression. Summed across bindings, labeled source=policy|filter,
+		// emitted unconditionally (a 0 is a real "no reject activity" signal).
+		userspaceRejectSent: prometheus.NewDesc(
+			"xpf_userspace_reject_sent_total",
+			"Locally-generated `reject` replies (TCP RST or ICMP/ICMPv6 "+
+				"administratively-prohibited unreachable) actually enqueued, "+
+				"split by source: a security-policy `then reject` "+
+				"(source=policy, includes a zone `tcp-rst`) vs a "+
+				"firewall-filter `then reject` (source=filter). This is the "+
+				"active reject SUCCESS volume — as important as the suppression "+
+				"counters for validating vSRX-style reject under load "+
+				"(#3615/#3657 H13).",
+			[]string{"source"}, nil,
+		),
+		userspaceRejectReplyBudgetDrops: prometheus.NewDesc(
+			"xpf_userspace_reject_reply_budget_drops_total",
+			"Locally-generated `reject` replies suppressed because the "+
+				"per-tick TX-frame budget was exhausted, split by source "+
+				"(policy vs firewall-filter). Budget pressure during a flood is "+
+				"exactly when a `reject` is silently downgraded to a truthful "+
+				"`deny`; the source split tells policy-reject starvation from "+
+				"filter-reject starvation and is distinct from the global "+
+				"rate-limit bucket (xpf_userspace_reject_rate_limited_total) "+
+				"and an egress output-filter drop (#3615 L04/#3657 H14/M02).",
+			[]string{"source"}, nil,
+		),
+		userspaceRejectOutputFilterDrops: prometheus.NewDesc(
+			"xpf_userspace_reject_output_filter_drops_total",
+			"Locally-generated `reject` replies dropped by an egress output "+
+				"firewall filter (terminal discard/reject or three-color "+
+				"policer) applied to the reflected reply's own egress tuple, "+
+				"split by source (policy vs firewall-filter). Distinguishes an "+
+				"operator-installed output filter suppressing a reject from a "+
+				"TX-frame budget or rate-limit drop (#3615 L05/#3657 H15/M02).",
+			[]string{"source"}, nil,
 		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -907,6 +907,24 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 			nil,
 			nil,
 		),
+		userspaceRejectSent: prometheus.NewDesc(
+			"xpf_userspace_reject_sent_total",
+			"reject replies sent by source",
+			[]string{"source"},
+			nil,
+		),
+		userspaceRejectReplyBudgetDrops: prometheus.NewDesc(
+			"xpf_userspace_reject_reply_budget_drops_total",
+			"reject reply tx-frame budget drops by source",
+			[]string{"source"},
+			nil,
+		),
+		userspaceRejectOutputFilterDrops: prometheus.NewDesc(
+			"xpf_userspace_reject_output_filter_drops_total",
+			"reject reply output-filter drops by source",
+			[]string{"source"},
+			nil,
+		),
 		userspaceFlowCacheActiveFlows: prometheus.NewDesc(
 			"xpf_userspace_flow_cache_active_flows",
 			"flow-cache active flows",
@@ -967,14 +985,28 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 				Interface:         "ge-0-0-1",
 				ActiveFlowCount:   9,
 				FlowCacheCapacity: 10,
+				// #3657: per-source reject reply legs, summed across
+				// bindings and emitted with source=policy|filter labels.
+				PolicyRejectSent:              5,
+				FilterRejectSent:              2,
+				PolicyRejectReplyBudgetDrops:  3,
+				FilterRejectReplyBudgetDrops:  1,
+				PolicyRejectOutputFilterDrops: 7,
+				FilterRejectOutputFilterDrops: 4,
 			},
 			{
-				Slot:              1,
-				QueueID:           1,
-				WorkerID:          3,
-				Interface:         "ge-0-0-2",
-				ActiveFlowCount:   3,
-				FlowCacheCapacity: 10,
+				Slot:                          1,
+				QueueID:                       1,
+				WorkerID:                      3,
+				Interface:                     "ge-0-0-2",
+				ActiveFlowCount:               3,
+				FlowCacheCapacity:             10,
+				PolicyRejectSent:              6,
+				FilterRejectSent:              8,
+				PolicyRejectReplyBudgetDrops:  9,
+				FilterRejectReplyBudgetDrops:  10,
+				PolicyRejectOutputFilterDrops: 11,
+				FilterRejectOutputFilterDrops: 12,
 			},
 		},
 	}
@@ -982,6 +1014,11 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	ch := make(chan prometheus.Metric)
 	go func() {
 		c.emitUserspaceDynamicBufferMetrics(ch, status)
+		// #3657: source-split reject reply telemetry is emitted by a
+		// dedicated helper off the same status; collect it here so the
+		// assertions below cover the sent / reply-budget / output-filter
+		// legs alongside the aggregate rate-limit counter.
+		c.emitRejectObservability(ch, status)
 		close(ch)
 	}()
 	var got []prometheus.Metric
@@ -995,9 +1032,10 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	// gre_encap_df_oversize_drops_total counter (= 17) + the #2782
 	// gre_decap_checksum_invalid_drops_total counter (= 18) + the #2472
 	// per-reason generated-error rate-limit trio (time_exceeded /
-	// packet_too_big / reject) = 21.
-	if len(got) != 21 {
-		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 21 metrics, got %d", len(got))
+	// packet_too_big / reject) = 21 + the #3657 source-split reject trio
+	// (sent / reply-budget / output-filter) × 2 sources = 27.
+	if len(got) != 27 {
+		t.Fatalf("emitUserspaceDynamicBufferMetrics: want 27 metrics, got %d", len(got))
 	}
 
 	assertGaugeClose(t, got, c.userspaceSessionTableEntries, nil, 77)
@@ -1031,6 +1069,18 @@ func TestEmitUserspaceDynamicBufferMetrics(t *testing.T) {
 	assertCounterClose(t, got, c.userspaceTimeExceededRateLimited, nil, 11)
 	assertCounterClose(t, got, c.userspacePacketTooBigRateLimited, nil, 12)
 	assertCounterClose(t, got, c.userspaceRejectRateLimited, nil, 13)
+	// #3657 (H15/M02): source-split reject reply telemetry, summed across
+	// the two bindings above and labeled source=policy|filter. Reverting the
+	// emitRejectObservability helper (or dropping the descriptors) turns
+	// these RED — the series would be absent entirely. sent: policy=5+6=11,
+	// filter=2+8=10; reply-budget: policy=3+9=12, filter=1+10=11;
+	// output-filter: policy=7+11=18, filter=4+12=16.
+	assertCounterClose(t, got, c.userspaceRejectSent, map[string]string{"source": "policy"}, 11)
+	assertCounterClose(t, got, c.userspaceRejectSent, map[string]string{"source": "filter"}, 10)
+	assertCounterClose(t, got, c.userspaceRejectReplyBudgetDrops, map[string]string{"source": "policy"}, 12)
+	assertCounterClose(t, got, c.userspaceRejectReplyBudgetDrops, map[string]string{"source": "filter"}, 11)
+	assertCounterClose(t, got, c.userspaceRejectOutputFilterDrops, map[string]string{"source": "policy"}, 18)
+	assertCounterClose(t, got, c.userspaceRejectOutputFilterDrops, map[string]string{"source": "filter"}, 16)
 	// #1861: install-refusal trio emitted unconditionally.
 	assertCounterClose(t, got, c.userspaceSessionCreateDrops, nil, 9)
 	assertCounterClose(t, got, c.userspaceSessionInstallAdmissionRefused, nil, 8)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -49,6 +49,39 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitNeighborColdStartCapture(ch, status)
 	c.emitWireguardTelemetry(ch, status)
 	c.emitPolicyContentRejected(ch, status)
+	c.emitRejectObservability(ch, status)
+}
+
+// emitRejectObservability exposes the #3657 source-split reject reply
+// telemetry: sent, TX-frame reply-budget drops, and egress output-filter
+// drops, each labeled source=policy|filter. These per-BindingStatus
+// counters (wired by #3615) are summed across bindings. The aggregate
+// xpf_userspace_reject_rate_limited_total is emitted elsewhere and stays
+// for back-compat; the per-source rate-limit bucket itself is still
+// source-neutral in the helper (single global-per-reason bucket) — a
+// source split of the rate-limit leg needs a helper change, tracked
+// separately. All six series are emitted unconditionally so a 0 is a real
+// "no reject activity" signal (alerting can distinguish policy-reject from
+// filter-reject starvation, and success from suppression).
+func (c *xpfCollector) emitRejectObservability(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	var policySent, filterSent uint64
+	var policyBudget, filterBudget uint64
+	var policyOutputFilter, filterOutputFilter uint64
+	for _, b := range status.Bindings {
+		policySent += b.PolicyRejectSent
+		filterSent += b.FilterRejectSent
+		policyBudget += b.PolicyRejectReplyBudgetDrops
+		filterBudget += b.FilterRejectReplyBudgetDrops
+		policyOutputFilter += b.PolicyRejectOutputFilterDrops
+		filterOutputFilter += b.FilterRejectOutputFilterDrops
+	}
+	emit := func(desc *prometheus.Desc, policy, filter uint64) {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, float64(policy), "policy")
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, float64(filter), "filter")
+	}
+	emit(c.userspaceRejectSent, policySent, filterSent)
+	emit(c.userspaceRejectReplyBudgetDrops, policyBudget, filterBudget)
+	emit(c.userspaceRejectOutputFilterDrops, policyOutputFilter, filterOutputFilter)
 }
 
 // emitPolicyContentRejected exposes the #3261 0/1 gauge: 1 while the last

--- a/pkg/dataplane/userspace/format/status.go
+++ b/pkg/dataplane/userspace/format/status.go
@@ -155,6 +155,15 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 	var synCookieOutputFilterDrops uint64
 	var ptbOutputFilterDrops uint64
 	var generatedReplyClassifyParseErrors uint64
+	// #3657 (H13/H14): per-source reject reply SUCCESS and TX-frame
+	// reply-budget suppression. #3615 wired these onto the BindingStatus
+	// wire struct (policy vs firewall-filter `then reject`) but the
+	// formatter never surfaced them; an operator could not see active
+	// reject volume nor the budget-pressure suppression the docs promise.
+	var policyRejectSent uint64
+	var filterRejectSent uint64
+	var policyRejectReplyBudgetDrops uint64
+	var filterRejectReplyBudgetDrops uint64
 	var snatPackets uint64
 	var dnatPackets uint64
 	var nat64Translations uint64
@@ -254,6 +263,10 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 		synCookieOutputFilterDrops += binding.SYNCookieOutputFilterDrops
 		ptbOutputFilterDrops += binding.PTBOutputFilterDrops
 		generatedReplyClassifyParseErrors += binding.GeneratedReplyClassifyParseErrors
+		policyRejectSent += binding.PolicyRejectSent
+		filterRejectSent += binding.FilterRejectSent
+		policyRejectReplyBudgetDrops += binding.PolicyRejectReplyBudgetDrops
+		filterRejectReplyBudgetDrops += binding.FilterRejectReplyBudgetDrops
 		snatPackets += binding.SNATPackets
 		dnatPackets += binding.DNATPackets
 		nat64Translations += binding.Nat64Translations
@@ -477,6 +490,24 @@ func FormatStatusSummary(status userspace.ProcessStatus) string {
 			timeExceededOutputFilterDrops, policyRejectOutputFilterDrops,
 			filterRejectOutputFilterDrops,
 			synCookieOutputFilterDrops, ptbOutputFilterDrops, generatedReplyClassifyParseErrors)
+	}
+	// #3657 (H13): active reject SUCCESS volume, split policy vs
+	// firewall-filter `then reject` (#3615). As important as the
+	// suppression counters for validating vSRX-style reject under load.
+	if policyRejectSent != 0 || filterRejectSent != 0 {
+		fmt.Fprintf(&b, "  Generated-reply sent:      policy_reject=%d filter_reject=%d\n",
+			policyRejectSent, filterRejectSent)
+	}
+	// #3657 (H14): TX-frame reply-budget suppression, split by source. The
+	// docs (junos-cli-reference.md) promise budget pressure is counted per
+	// source under the generated-reply status — a policy `then reject`
+	// silently downgraded to `deny` because the per-tick TX-frame budget was
+	// exhausted must be attributable, distinct from an egress output-filter
+	// drop (the "Generated-reply drops" line above) and the global reject
+	// rate-limit bucket (RejectRateLimitedTotal).
+	if policyRejectReplyBudgetDrops != 0 || filterRejectReplyBudgetDrops != 0 {
+		fmt.Fprintf(&b, "  Generated-reply budget drops: policy_reject=%d filter_reject=%d\n",
+			policyRejectReplyBudgetDrops, filterRejectReplyBudgetDrops)
 	}
 	fmt.Fprintf(&b, "  SNAT packets:              %d\n", snatPackets)
 	fmt.Fprintf(&b, "  DNAT packets:              %d\n", dnatPackets)

--- a/pkg/dataplane/userspace/format/status_test.go
+++ b/pkg/dataplane/userspace/format/status_test.go
@@ -209,6 +209,69 @@ func TestFormatStatusSummaryShowsNAT64Translations(t *testing.T) {
 	}
 }
 
+// #3657 (H13/H14): the status summary surfaces the per-source reject reply
+// SUCCESS ("Generated-reply sent") and the TX-frame reply-budget suppression
+// ("Generated-reply budget drops") counters wired onto BindingStatus by
+// #3615, alongside the existing egress output-filter "Generated-reply drops"
+// line. Before this the sent/budget legs were aggregated nowhere and never
+// printed — a docs-contract violation (junos-cli-reference.md promises budget
+// pressure is counted per source in `show ... status`). Reverting the
+// formatter drops the two new lines and turns this test RED.
+func TestFormatStatusSummaryShowsRejectObservability(t *testing.T) {
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{
+			{
+				Slot:                          0,
+				PolicyRejectSent:              5,
+				FilterRejectSent:              2,
+				PolicyRejectReplyBudgetDrops:  3,
+				FilterRejectReplyBudgetDrops:  1,
+				PolicyRejectOutputFilterDrops: 7,
+				FilterRejectOutputFilterDrops: 4,
+			},
+			{
+				Slot:                          1,
+				PolicyRejectSent:              6,
+				FilterRejectSent:              8,
+				PolicyRejectReplyBudgetDrops:  9,
+				FilterRejectReplyBudgetDrops:  10,
+				PolicyRejectOutputFilterDrops: 11,
+				FilterRejectOutputFilterDrops: 12,
+			},
+		},
+	}
+
+	out := FormatStatusSummary(status)
+	for _, want := range []string{
+		// #3615 output-filter leg (policy=18 filter=16) must remain split.
+		"Generated-reply drops:     time_exceeded=0 policy_reject=18 filter_reject=16 syn_cookie=0 ptb=0 classify_parse_errors=0",
+		// #3657 new SUCCESS line (policy=11 filter=10).
+		"Generated-reply sent:      policy_reject=11 filter_reject=10",
+		// #3657 new TX-frame budget suppression line (policy=12 filter=11).
+		"Generated-reply budget drops: policy_reject=12 filter_reject=11",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing reject observability %q:\n%s", want, out)
+		}
+	}
+}
+
+// #3657: the sent and budget-drop lines are suppressed entirely when their
+// counters are all zero, so a quiet firewall does not print noise rows (same
+// zero-suppression discipline as the SYN-cookie and output-filter lines).
+func TestFormatStatusSummaryHidesZeroRejectObservability(t *testing.T) {
+	status := userspace.ProcessStatus{
+		Bindings: []userspace.BindingStatus{{Slot: 0}},
+	}
+	out := FormatStatusSummary(status)
+	if strings.Contains(out, "Generated-reply sent:") {
+		t.Fatalf("summary printed reject sent row for all-zero counters:\n%s", out)
+	}
+	if strings.Contains(out, "Generated-reply budget drops:") {
+		t.Fatalf("summary printed reject budget-drop row for all-zero counters:\n%s", out)
+	}
+}
+
 func TestFormatSYNCookieCounterRows(t *testing.T) {
 	status := userspace.ProcessStatus{
 		Bindings: []userspace.BindingStatus{


### PR DESCRIPTION
Closes #3657 (H13/H14/H15/M02/M08). Refs #3615.

## Problem

#3615 wired per-source reject counters onto the `BindingStatus` wire
struct — `PolicyRejectSent`/`FilterRejectSent`,
`PolicyRejectReplyBudgetDrops`/`FilterRejectReplyBudgetDrops`,
`PolicyRejectOutputFilterDrops`/`FilterRejectOutputFilterDrops` — and the
helper's `reject_reply.rs` increments all of them. But the operator
surfaces only partially exposed them:

- **H14 (docs-contract violation):** `docs/junos-cli-reference.md` promises
  reject budget pressure is counted per source under the generated-reply
  status, but `format/status.go` only aggregated/printed the egress
  output-filter drop leg — never the reply-budget drops.
- **H13:** the SENT counters (active reject SUCCESS volume) were aggregated
  nowhere and never printed.
- **H15/M02:** Prometheus exposed only the source-neutral aggregate
  `xpf_userspace_reject_rate_limited_total`; no per-source sent / budget /
  output-filter series, so alerting could not tell policy-reject from
  filter-reject, nor success from suppression.

All four SENT+BUDGET counters already exist on the wire and are incremented
by the helper, so this PR is **Go read-side only** (no cargo / no
`userspace-dp` Rust edits).

## Change

**Status (`format/status.go`):** aggregate the four per-binding legs and
print two new zero-suppressed lines beside the existing output-filter
`Generated-reply drops` line:

```
  Generated-reply sent:      policy_reject=N filter_reject=N
  Generated-reply budget drops: policy_reject=N filter_reject=N
```

**Prometheus (`pkg/api`):** a new `emitRejectObservability` helper sums
per-binding and emits, unconditionally (0 is a real signal):

```
  xpf_userspace_reject_sent_total{source="policy"|"filter"}
  xpf_userspace_reject_reply_budget_drops_total{source=...}
  xpf_userspace_reject_output_filter_drops_total{source=...}
```

The source-neutral aggregate `reject_rate_limited_total` is kept for
back-compat (help text now notes the bucket is source-neutral).

**Docs:** reconciled the §reject-event-truthfulness (#3615) contract to
describe the three-line split + the new Prometheus series.

## Deferred (M02 Rust leg) — #3661

The reject RATE-LIMIT drop leg itself is still source-neutral (single
global-per-reason bucket in `icmp_ratelimit.rs`, `reject_reply.rs:250`).
Attributing it per source needs a NEW helper counter + wire field, so it
was split to #3661 (which also carries the L04 declarative-counter-registry
note) to avoid colliding with concurrent `reject_reply.rs` work (#3656).

## Tests (M08) — RED on revert

- `TestFormatStatusSummaryShowsRejectObservability` asserts the exact new
  status lines (+ retained split output-filter line); RED when the print
  blocks are reverted. `...HidesZeroRejectObservability` confirms
  zero-suppression.
- `TestEmitUserspaceDynamicBufferMetrics` now populates the reject legs and
  asserts all six source-labeled series; metric count moves 21 -> 27 and
  goes RED when the emit is reverted.

Both RED-on-revert paths verified locally. `go test ./pkg/api/...
./pkg/dataplane/...` green; `go build ./pkg/... ./cmd/...`, `gofmt`, `go
vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
