### PR TITLE
cli,grpc,remote-cli: render per-interface host-inbound overrides + default-deny posture in text views

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24790,3 +24790,11 @@ top.
     gofmt clean; go vet clean (the pre-existing monitor.go:159 protobuf-mutex-copy
     warning is unrelated, present on origin/master).
   - **File(s)**: cmd/cli/show.go, cmd/cli/show_matchpolicies_test.go, _Log.md
+
+## 2026-07-01 — #3654 per-interface host-inbound display
+
+- **Timestamp**: 2026-07-01
+- **Action**: Add shared host-inbound presenter (pkg/config) + wire 6 text surfaces to render per-interface host-inbound overrides, no-stanza default-deny posture (M03), and split system-services/protocols (M06)
+- **File(s)**: pkg/config/host_inbound_view.go (new), pkg/cli/cli_show_security_zones.go (H04), pkg/cli/cli_show_interfaces.go (H05), pkg/cli/cli_request.go (H06), pkg/grpcapi/server_show_zones_text.go (H07/H08), cmd/cli/show.go (H09), cmd/cli/nontty_test.go (GetZones fake stub)
+- **Action**: Add pkg/config presenter unit tests
+- **File(s)**: pkg/config/host_inbound_view_3654_test.go (new)

--- a/_Log.md
+++ b/_Log.md
@@ -24798,3 +24798,6 @@ top.
 - **File(s)**: pkg/config/host_inbound_view.go (new), pkg/cli/cli_show_security_zones.go (H04), pkg/cli/cli_show_interfaces.go (H05), pkg/cli/cli_request.go (H06), pkg/grpcapi/server_show_zones_text.go (H07/H08), cmd/cli/show.go (H09), cmd/cli/nontty_test.go (GetZones fake stub)
 - **Action**: Add pkg/config presenter unit tests
 - **File(s)**: pkg/config/host_inbound_view_3654_test.go (new)
+- **Timestamp**: 2026-07-01
+- **Action**: Add RED-on-revert golden tests for all 6 surfaces; regenerate ShowText golden for the new no-stanza posture line; document the #3654 display fix
+- **File(s)**: pkg/cli/host_inbound_display_3654_test.go (new), pkg/grpcapi/server_show_zones_hostinbound_display_3654_test.go (new), cmd/cli/show_zones_hostinbound_3654_test.go (new), pkg/grpcapi/testdata/server_show_golden.json (regenerated), docs/junos-cli-reference.md

--- a/cmd/cli/nontty_test.go
+++ b/cmd/cli/nontty_test.go
@@ -51,6 +51,20 @@ type fakeBpfrxClient struct {
 	// GetPolicies recorder (#3357 remote filtered/brief scoped-global coverage).
 	getPoliciesCalls int
 	getPoliciesResp  *pb.GetPoliciesResponse
+
+	// GetZones recorder (#3654 remote host-inbound override / posture coverage).
+	getZonesCalls int
+	getZonesResp  *pb.GetZonesResponse
+}
+
+func (f *fakeBpfrxClient) GetZones(
+	_ context.Context, _ *pb.GetZonesRequest, _ ...grpc.CallOption,
+) (*pb.GetZonesResponse, error) {
+	f.getZonesCalls++
+	if f.getZonesResp != nil {
+		return f.getZonesResp, nil
+	}
+	return &pb.GetZonesResponse{}, nil
 }
 
 func (f *fakeBpfrxClient) GetPolicies(

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/psaab/xpf/pkg/appid"
+	"github.com/psaab/xpf/pkg/config"
 	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
 	"github.com/psaab/xpf/pkg/policymatch"
 )
@@ -464,6 +465,30 @@ func (c *ctl) handleShowSecurity(args []string) error {
 	}
 }
 
+// zoneHostInboundView projects a gRPC ZoneInfo onto the shared host-inbound
+// presenter (#3654). The structured response already carries the split
+// system-services / protocols set and the per-interface overrides (#3328), so
+// the remote CLI renders exactly what the local and gRPC-text surfaces do. The
+// wire response cannot distinguish a no-stanza zone from an explicit empty
+// stanza (both are deny-all with empty lists post-#3405), so ZoneConfigured is
+// left false and the posture line reads "(no stanza)".
+func zoneHostInboundView(z *pb.ZoneInfo) config.HostInboundView {
+	v := config.HostInboundView{
+		ZoneSystemServices: z.GetHostInboundSystemServices(),
+		ZoneProtocols:      z.GetHostInboundProtocols(),
+	}
+	for _, ih := range z.GetInterfaceHostInbound() {
+		v.Interfaces = append(v.Interfaces, config.InterfaceHostInboundView{
+			Interface:               ih.GetInterface(),
+			SystemServices:          ih.GetSystemServices(),
+			Protocols:               ih.GetProtocols(),
+			EffectiveSystemServices: config.UnionHostInboundTokens(z.GetHostInboundSystemServices(), ih.GetSystemServices()),
+			EffectiveProtocols:      config.UnionHostInboundTokens(z.GetHostInboundProtocols(), ih.GetProtocols()),
+		})
+	}
+	return v
+}
+
 func (c *ctl) showZones() error {
 	resp, err := c.client.GetZones(c.ctx(), &pb.GetZonesRequest{})
 	if err != nil {
@@ -488,8 +513,19 @@ func (c *ctl) showZones() error {
 		if z.ScreenProfile != "" {
 			fmt.Printf("  Screen: %s\n", z.ScreenProfile)
 		}
-		if len(z.HostInboundServices) > 0 {
-			fmt.Printf("  Host-inbound services: %s\n", strings.Join(z.HostInboundServices, ", "))
+		// #3654 (H09/M03/M06): consume the structured split system-services /
+		// protocols and per-interface overrides from the gRPC response and
+		// render them through the SAME shared presenter the local/gRPC-text
+		// surfaces use, instead of collapsing everything into one legacy
+		// "Host-inbound services" line that dropped the service-vs-protocol
+		// split, the per-interface overrides, and the default-deny posture.
+		for _, line := range zoneHostInboundView(z).Render(config.HostInboundLabels{
+			Indent:         "  ",
+			Sep:            ", ",
+			ServicesLabel:  "Host-inbound system-services",
+			ProtocolsLabel: "Host-inbound protocols",
+		}) {
+			fmt.Println(line)
 		}
 		if z.IngressPackets > 0 || z.EgressPackets > 0 {
 			fmt.Println("  Traffic statistics:")

--- a/cmd/cli/show_zones_hostinbound_3654_test.go
+++ b/cmd/cli/show_zones_hostinbound_3654_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3654 (H09/M03/M06): the remote `cmd/cli show security zones` collapsed the
+// structured host-inbound admission set into one legacy "Host-inbound services"
+// line, dropping the service-vs-protocol split, the per-interface overrides
+// (interface_host_inbound), and the no-stanza default-deny posture. It now
+// consumes the split fields + overrides from the gRPC response and renders them
+// through the shared presenter.
+//
+// RED-on-revert: restoring the single `Host-inbound services` line (reading
+// only z.HostInboundServices) fails the split-field, override-block, and
+// posture-line assertions below.
+func TestShowZonesHostInbound3654(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		getZonesResp: &pb.GetZonesResponse{
+			Zones: []*pb.ZoneInfo{
+				{
+					Name:                      "trust",
+					HostInboundConfigured:     true,
+					HostInboundServices:       []string{"ssh", "ping", "ospf"},
+					HostInboundSystemServices: []string{"ssh", "ping"},
+					HostInboundProtocols:      []string{"ospf"},
+				},
+				{
+					Name:                  "edge",
+					HostInboundConfigured: true,
+					InterfaceHostInbound: []*pb.InterfaceHostInbound{
+						{Interface: "ge-0/0/9.0", Configured: true, SystemServices: []string{"https"}},
+					},
+				},
+				{
+					Name:                  "open",
+					HostInboundConfigured: true,
+				},
+			},
+		},
+	}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showZones(); err != nil {
+			t.Fatalf("showZones: %v", err)
+		}
+	})
+	if fake.getZonesCalls != 1 {
+		t.Fatalf("GetZones called %d times, want 1", fake.getZonesCalls)
+	}
+	for _, want := range []string{
+		// split fields (M06 — previously collapsed into one line)
+		"Host-inbound system-services: ssh, ping",
+		"Host-inbound protocols: ospf",
+		// per-interface override block (H09 — previously dropped)
+		"Host-inbound interface overrides:",
+		"ge-0/0/9.0:",
+		"override system-services: https",
+		"effective system-services: https",
+		// no-stanza default-deny posture (M03 — previously blank)
+		"Host-inbound: default deny (no stanza)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("remote show security zones missing %q\n%s", want, out)
+		}
+	}
+	// The legacy collapsed line must be gone.
+	if strings.Contains(out, "Host-inbound services:") {
+		t.Errorf("remote show security zones still renders legacy collapsed line\n%s", out)
+	}
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -492,6 +492,23 @@ From zone: guest, To zone: lan
     SSOT as the zone-level stanza (#3200), and management/cluster-control
     lifeline interfaces are excluded from the override exactly as from the
     zone-level deny scoping. (Distinct from #3328, which is the API-display gap.)
+  - **Per-interface host-inbound in the TEXT/CLI views (#3654):** the structured
+    REST/gRPC inventory (#3328) carried the per-interface override rows and the
+    split `system-services` / `protocols` sets, but every text surface used to
+    print ONLY the zone-level set — an interface with a narrower/wider effective
+    admission set than its zone was shown as if it inherited the zone set, and a
+    no-stanza zone printed nothing even though it default-DENIES (#3405). All six
+    surfaces now render the override and posture through one shared presenter
+    (`pkg/config/host_inbound_view.go`): `show security zones`, `show
+    interfaces`, `test security-zone interface`, the gRPC text `show security
+    zones` + interface diagnostic, and the remote `cmd/cli show security zones`.
+    Each shows the effective (zone UNION interface) admitted set, flags an
+    interface-local override, and prints an explicit `Host-inbound: default deny
+    (no stanza | empty stanza | interface override: deny-all)` line when the
+    effective set is empty so "not shown" can never be misread as "not
+    enforced". The remote CLI additionally consumes the split
+    system-services/protocols instead of the legacy flattened
+    "Host-inbound services" line.
   - **Lifeline set derived from cluster config (#3277):** the lifeline
     interfaces excluded from host-inbound deny scoping are no longer a fixed
     fxp0/em0/fab* hardcode. The set is now `fxp0` (always-mgmt) UNION the
@@ -760,6 +777,14 @@ Security zone: junos-host
 - `Interfaces bound: <N>` -- count of bound interfaces.
 - `Interfaces:` header, then each interface indented 4 spaces.
 - Empty `Interfaces:` line with no entries if none bound.
+- **Host-inbound (#3654):** `Allowed host-inbound traffic: <services>` /
+  `Allowed host-inbound protocols: <protocols>` for the zone-level set; a
+  `Host-inbound interface overrides:` block listing each interface's override
+  and its effective (zone UNION interface) admitted set; and a
+  `Host-inbound: default deny (no stanza)` line when the zone admits nothing and
+  declares no override (a no-stanza zone default-DENIES host-bound traffic
+  post-#3405). The gRPC text view labels the zone-level lines
+  `Host-inbound system-services:` / `Host-inbound protocols:`.
 - Blank line between zones.
 
 ---

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
 	dpformat "github.com/psaab/xpf/pkg/dataplane/userspace/format"
 	"github.com/psaab/xpf/pkg/diagcmd"
@@ -471,13 +472,17 @@ func (c *CLI) testSecurityZone(args []string) error {
 				if zone.ScreenProfile != "" {
 					fmt.Printf("  Screen:      %s\n", zone.ScreenProfile)
 				}
-				if zone.HostInboundTraffic != nil {
-					if len(zone.HostInboundTraffic.SystemServices) > 0 {
-						fmt.Printf("  Host-inbound services: %s\n", strings.Join(zone.HostInboundTraffic.SystemServices, ", "))
-					}
-					if len(zone.HostInboundTraffic.Protocols) > 0 {
-						fmt.Printf("  Host-inbound protocols: %s\n", strings.Join(zone.HostInboundTraffic.Protocols, ", "))
-					}
+				// #3654 (H06/M03): this DIAGNOSTIC is supposed to explain
+				// per-interface admission, so report the EFFECTIVE (zone UNION
+				// interface) set for THIS interface, flag an interface-local
+				// override, and print an explicit default-deny posture line.
+				for _, line := range zone.RenderInterfaceHostInbound(ifName, config.HostInboundLabels{
+					Indent:         "  ",
+					Sep:            ", ",
+					ServicesLabel:  "Host-inbound services",
+					ProtocolsLabel: "Host-inbound protocols",
+				}) {
+					fmt.Println(line)
 				}
 				return nil
 			}

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -120,6 +120,7 @@ func (c *CLI) showInterfaces(args []string) error {
 	type logicalIface struct {
 		zoneName string
 		zone     *config.ZoneConfig
+		ifaceRef string // zone-interface ref as authored (host-inbound override key, #3654)
 		physName string
 		unitNum  int
 		vlanID   int
@@ -145,6 +146,7 @@ func (c *CLI) showInterfaces(args []string) error {
 		logicals = append(logicals, logicalIface{
 			zoneName: ifaceZoneName[ifaceName],
 			zone:     zone,
+			ifaceRef: ifaceName,
 			physName: physName,
 			unitNum:  unitNum,
 			vlanID:   vlanID,
@@ -298,16 +300,25 @@ func (c *CLI) showInterfaces(args []string) error {
 
 			fmt.Printf("    Security: Zone: %s\n", li.zoneName)
 
-			// Host-inbound traffic services
-			if li.zone != nil && li.zone.HostInboundTraffic != nil {
-				hit := li.zone.HostInboundTraffic
-				if len(hit.SystemServices) > 0 {
-					fmt.Printf("    Allowed host-inbound traffic : %s\n",
-						strings.Join(hit.SystemServices, " "))
+			// Host-inbound traffic services (#3654 H05/M03): show the EFFECTIVE
+			// admitted set for THIS logical interface — the UNION of the zone
+			// set and any per-interface override — flag an interface-local
+			// override, and print an explicit default-deny posture line so a
+			// blank section is never misread as "not enforced".
+			if li.zone != nil {
+				svc, proto, overridden := li.zone.InterfaceHostInboundEffective(li.ifaceRef)
+				if overridden {
+					fmt.Println("    Host-inbound: interface-specific override (effective set below)")
 				}
-				if len(hit.Protocols) > 0 {
-					fmt.Printf("    Allowed host-inbound protocols: %s\n",
-						strings.Join(hit.Protocols, " "))
+				if len(svc) > 0 {
+					fmt.Printf("    Allowed host-inbound traffic : %s\n", strings.Join(svc, " "))
+				}
+				if len(proto) > 0 {
+					fmt.Printf("    Allowed host-inbound protocols: %s\n", strings.Join(proto, " "))
+				}
+				if len(svc) == 0 && len(proto) == 0 {
+					fmt.Printf("    Host-inbound: default deny (%s)\n",
+						config.HostInboundDenyReason(overridden, li.zone.HostInboundTraffic != nil))
 				}
 			}
 

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -60,15 +60,17 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 		for _, ifName := range zone.Interfaces {
 			fmt.Printf("    %s\n", ifName)
 		}
-		if zone.HostInboundTraffic != nil {
-			if len(zone.HostInboundTraffic.SystemServices) > 0 {
-				fmt.Printf("  Allowed host-inbound traffic: %s\n",
-					strings.Join(zone.HostInboundTraffic.SystemServices, " "))
-			}
-			if len(zone.HostInboundTraffic.Protocols) > 0 {
-				fmt.Printf("  Allowed host-inbound protocols: %s\n",
-					strings.Join(zone.HostInboundTraffic.Protocols, " "))
-			}
+		// #3654: render the zone-level admitted set, the no-stanza default-deny
+		// posture line, AND any per-interface host-inbound override through the
+		// shared config presenter so this surface can no longer hide overrides
+		// or a default-deny zone (H04/M03).
+		for _, line := range zone.HostInboundView().Render(config.HostInboundLabels{
+			Indent:         "  ",
+			Sep:            " ",
+			ServicesLabel:  "Allowed host-inbound traffic",
+			ProtocolsLabel: "Allowed host-inbound protocols",
+		}) {
+			fmt.Println(line)
 		}
 
 		// Per-zone traffic counters (xpf extension, not in Junos)

--- a/pkg/cli/host_inbound_display_3654_test.go
+++ b/pkg/cli/host_inbound_display_3654_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #3654: the local-CLI text surfaces (`show security zones`, `show interfaces`,
+// `test security-zone interface`) rendered ONLY the zone-level host-inbound set
+// and silently dropped the per-interface override (#3362) and the no-stanza
+// default-deny posture (#3405). These golden tests assert each surface now
+// surfaces the override and the posture line.
+//
+// RED-on-revert: routing the surfaces back through the old
+// `if zone.HostInboundTraffic != nil { ... }` block (no override iteration, no
+// posture line) drops the override block and the "default deny" line, failing
+// the matching assertions below.
+
+func hostInboundCLIStore(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services { ssh; ping; }
+                protocols { ospf; }
+            }
+        }
+        security-zone edge {
+            interfaces {
+                ge-0/0/9.0 {
+                    host-inbound-traffic { system-services { https; } }
+                }
+            }
+        }
+        security-zone plain {
+            interfaces {
+                ge-0/0/1.0;
+            }
+        }
+        security-zone open;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store} // dp nil: skip counter reads, exercise the display walk
+}
+
+func TestShowSecurityZonesHostInbound3654(t *testing.T) {
+	c := hostInboundCLIStore(t)
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(c.store.ActiveConfig(), false, ""); err != nil {
+			t.Fatalf("showZonesDisplay: %v", err)
+		}
+	})
+	for _, want := range []string{
+		// zone-level set preserved
+		"Allowed host-inbound traffic: ssh ping",
+		"Allowed host-inbound protocols: ospf",
+		// per-interface override block (H04 — previously hidden)
+		"Host-inbound interface overrides:",
+		"ge-0/0/9.0:",
+		"override system-services: https",
+		"effective system-services: https",
+		// no-stanza default-deny posture (M03 — previously blank)
+		"Host-inbound: default deny (no stanza)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("show security zones output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestTestSecurityZoneHostInbound3654(t *testing.T) {
+	// Overridden interface: the diagnostic must flag the override + effective set.
+	c := hostInboundCLIStore(t)
+	out := captureStdout(t, func() {
+		if err := c.testSecurityZone([]string{"interface", "ge-0/0/9.0"}); err != nil {
+			t.Fatalf("testSecurityZone: %v", err)
+		}
+	})
+	for _, want := range []string{
+		"Interface ge-0/0/9.0 belongs to zone: edge",
+		"Host-inbound interface override on ge-0/0/9.0:",
+		"effective host-inbound services: https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("test security-zone (override) output missing %q\n%s", want, out)
+		}
+	}
+
+	// No-stanza zone interface: default-deny posture line.
+	out = captureStdout(t, func() {
+		if err := c.testSecurityZone([]string{"interface", "ge-0/0/1.0"}); err != nil {
+			t.Fatalf("testSecurityZone: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Host-inbound: default deny (no stanza)") {
+		t.Errorf("test security-zone (no-stanza) output missing posture line\n%s", out)
+	}
+}
+
+func TestShowInterfacesHostInbound3654(t *testing.T) {
+	// show interfaces reaches the host-inbound block only for a PRESENT kernel
+	// interface, so bind the override to the always-present loopback.
+	if _, err := net.InterfaceByName("lo"); err != nil {
+		t.Skip("loopback interface not present; skipping show interfaces golden test")
+	}
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone lan {
+            interfaces {
+                lo {
+                    host-inbound-traffic { system-services { https; } }
+                }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	c := &CLI{store: store}
+	out := captureStdout(t, func() {
+		if err := c.showInterfaces(nil); err != nil {
+			t.Fatalf("showInterfaces: %v", err)
+		}
+	})
+	for _, want := range []string{
+		"Host-inbound: interface-specific override (effective set below)",
+		"Allowed host-inbound traffic : https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("show interfaces output missing %q\n%s", want, out)
+		}
+	}
+}

--- a/pkg/config/host_inbound_view.go
+++ b/pkg/config/host_inbound_view.go
@@ -1,0 +1,232 @@
+package config
+
+import "strings"
+
+// host_inbound_view.go is the shared presentation SSOT for a security zone's
+// host-inbound-traffic admission posture (#3654 L02). Before #3654 every text /
+// CLI surface (local `show security zones` / `show interfaces` / `test
+// security-zone interface`, gRPC text zones + interface diagnostic, and the
+// remote `cmd/cli` zone view) re-implemented the same ad-hoc "print the
+// zone-level HostInboundTraffic set" block and every one of them dropped the
+// per-interface override (#3362) and the no-stanza default-deny posture
+// (#3405). Routing all six through this one presenter keeps them from drifting
+// again and mirrors the structured REST/gRPC contract (#3328/#3405/#3653):
+// every configured zone is host-inbound ENFORCING, and the EFFECTIVE admission
+// set for an interface is the UNION of the zone-level set and its interface
+// override (Junos additive semantics).
+
+// UnionHostInboundTokens returns the effective host-inbound token set for the
+// combination of a zone-level list and a per-interface override list: the
+// zone-level tokens first in their authored order, then any override-only
+// tokens, with empties skipped and exact-duplicate tokens collapsed. This is
+// the display-side peer of the dataplane's unionHostInboundTokens
+// (dataplane/userspace/zones.go); it preserves the authored token case so the
+// text surfaces show tokens exactly as the structured API does (the dataplane
+// path lower-cases for map keying, a concern that does not apply to display).
+func UnionHostInboundTokens(zone, iface []string) []string {
+	seen := make(map[string]bool, len(zone)+len(iface))
+	out := make([]string, 0, len(zone)+len(iface))
+	add := func(src []string) {
+		for _, t := range src {
+			t = strings.TrimSpace(t)
+			if t == "" || seen[t] {
+				continue
+			}
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	add(zone)
+	add(iface)
+	return out
+}
+
+// HostInboundDenyReason returns the parenthetical explaining WHY a zone or
+// interface admits no host-inbound traffic, for the default-deny posture line
+// (#3654 M03). overridden marks that the interface declares its own
+// host-inbound-traffic stanza; zoneConfigured marks that a zone-level stanza is
+// present. All three cases default-DENY host-bound traffic post-#3405; the
+// wording only tells the operator which stanza produced the empty set.
+func HostInboundDenyReason(overridden, zoneConfigured bool) string {
+	switch {
+	case overridden:
+		return "interface override: deny-all"
+	case zoneConfigured:
+		return "empty stanza"
+	default:
+		return "no stanza"
+	}
+}
+
+// InterfaceHostInboundEffective returns the EFFECTIVE host-inbound admission set
+// for a single interface ref in the zone: the UNION of the zone-level set and
+// the per-interface override for ref (if any). overridden reports whether ref
+// declares its own host-inbound-traffic stanza (#3362). Used by the
+// interface-scoped surfaces (`show interfaces`, `test security-zone interface`,
+// gRPC interface diagnostic) which must show the effective set for ONE
+// interface rather than iterate the whole zone.
+func (z *ZoneConfig) InterfaceHostInboundEffective(ref string) (svc, proto []string, overridden bool) {
+	var zoneSvc, zoneProto []string
+	if z != nil && z.HostInboundTraffic != nil {
+		zoneSvc = z.HostInboundTraffic.SystemServices
+		zoneProto = z.HostInboundTraffic.Protocols
+	}
+	var ov *HostInboundTraffic
+	if z != nil {
+		ov = z.InterfaceHostInbound[ref]
+	}
+	if ov == nil {
+		return UnionHostInboundTokens(zoneSvc, nil), UnionHostInboundTokens(zoneProto, nil), false
+	}
+	return UnionHostInboundTokens(zoneSvc, ov.SystemServices),
+		UnionHostInboundTokens(zoneProto, ov.Protocols), true
+}
+
+// InterfaceHostInboundView is a single per-interface host-inbound override
+// (#3362) projected for display: the interface-local override tokens plus the
+// EFFECTIVE (zone-level UNION override) admitted set that actually reaches the
+// host on that interface.
+type InterfaceHostInboundView struct {
+	Interface               string
+	SystemServices          []string
+	Protocols               []string
+	EffectiveSystemServices []string
+	EffectiveProtocols      []string
+}
+
+// HostInboundView is the zone-scoped presentation view shared by the
+// zone-listing surfaces (`show security zones`, gRPC text zones, remote
+// cmd/cli). ZoneConfigured records whether a zone-level host-inbound-traffic
+// stanza is present (populated or explicit-empty); the zone-level admitted set
+// is in ZoneSystemServices / ZoneProtocols; Interfaces holds the per-interface
+// overrides in sorted order.
+type HostInboundView struct {
+	ZoneConfigured     bool
+	ZoneSystemServices []string
+	ZoneProtocols      []string
+	Interfaces         []InterfaceHostInboundView
+}
+
+// HostInboundView builds the presentation view for a zone from its typed
+// config. Nil-safe (returns a zero view for a nil zone).
+func (z *ZoneConfig) HostInboundView() HostInboundView {
+	v := HostInboundView{}
+	if z == nil {
+		return v
+	}
+	if z.HostInboundTraffic != nil {
+		v.ZoneConfigured = true
+		v.ZoneSystemServices = append([]string(nil), z.HostInboundTraffic.SystemServices...)
+		v.ZoneProtocols = append([]string(nil), z.HostInboundTraffic.Protocols...)
+	}
+	for _, ref := range z.SortedInterfaceHostInboundRefs() {
+		ov := z.InterfaceHostInbound[ref]
+		if ov == nil {
+			continue
+		}
+		v.Interfaces = append(v.Interfaces, InterfaceHostInboundView{
+			Interface:               ref,
+			SystemServices:          append([]string(nil), ov.SystemServices...),
+			Protocols:               append([]string(nil), ov.Protocols...),
+			EffectiveSystemServices: UnionHostInboundTokens(v.ZoneSystemServices, ov.SystemServices),
+			EffectiveProtocols:      UnionHostInboundTokens(v.ZoneProtocols, ov.Protocols),
+		})
+	}
+	return v
+}
+
+// RenderInterfaceHostInbound returns the host-inbound presentation block for
+// ONE interface ref in the zone (#3654 H06/H08 — the per-interface admission
+// diagnostic), one line per slice element with NO trailing newline. It shows
+// the zone-level admitted set and, when ref declares its own
+// host-inbound-traffic override, both a marker and the EFFECTIVE (zone UNION
+// interface) admitted set for that interface. A default-deny posture line is
+// emitted when the effective set is empty, so a blank section cannot be misread
+// as "not enforced".
+func (z *ZoneConfig) RenderInterfaceHostInbound(ref string, l HostInboundLabels) []string {
+	var zoneSvc, zoneProto []string
+	zoneConfigured := false
+	if z != nil && z.HostInboundTraffic != nil {
+		zoneConfigured = true
+		zoneSvc = z.HostInboundTraffic.SystemServices
+		zoneProto = z.HostInboundTraffic.Protocols
+	}
+	effSvc, effProto, overridden := z.InterfaceHostInboundEffective(ref)
+
+	join := func(toks []string) string {
+		if len(toks) == 0 {
+			return "(none)"
+		}
+		return strings.Join(toks, l.Sep)
+	}
+	var lines []string
+	if len(zoneSvc) > 0 {
+		lines = append(lines, l.Indent+l.ServicesLabel+": "+strings.Join(zoneSvc, l.Sep))
+	}
+	if len(zoneProto) > 0 {
+		lines = append(lines, l.Indent+l.ProtocolsLabel+": "+strings.Join(zoneProto, l.Sep))
+	}
+	if overridden {
+		lines = append(lines,
+			l.Indent+"Host-inbound interface override on "+ref+":",
+			l.Indent+"  effective "+strings.ToLower(l.ServicesLabel)+": "+join(effSvc),
+			l.Indent+"  effective "+strings.ToLower(l.ProtocolsLabel)+": "+join(effProto),
+		)
+	}
+	if len(effSvc) == 0 && len(effProto) == 0 {
+		lines = append(lines, l.Indent+"Host-inbound: default deny ("+
+			HostInboundDenyReason(overridden, zoneConfigured)+")")
+	}
+	return lines
+}
+
+// HostInboundLabels lets each zone-listing surface keep its established
+// zone-level line labels and token separator while sharing the presentation
+// logic for the per-interface override block and the default-deny posture line.
+type HostInboundLabels struct {
+	Indent         string // leading indent for each rendered line
+	Sep            string // token-list separator (" " or ", ")
+	ServicesLabel  string // zone-level system-services label
+	ProtocolsLabel string // zone-level protocols label
+}
+
+// Render returns the host-inbound presentation block for a zone (#3654), one
+// line per slice element with NO trailing newline. It emits, in order: the
+// zone-level system-services / protocols lines (when non-empty), an explicit
+// default-deny posture line when the zone admits nothing at the zone level AND
+// has no per-interface override (M03 — so a blank host-inbound section can
+// never be misread as "not enforced"), and one block per per-interface override
+// showing the interface-local tokens plus the effective (zone UNION interface)
+// admitted set (H04/H07/H09).
+func (v HostInboundView) Render(l HostInboundLabels) []string {
+	join := func(toks []string) string {
+		if len(toks) == 0 {
+			return "(none)"
+		}
+		return strings.Join(toks, l.Sep)
+	}
+	var lines []string
+	if len(v.ZoneSystemServices) > 0 {
+		lines = append(lines, l.Indent+l.ServicesLabel+": "+strings.Join(v.ZoneSystemServices, l.Sep))
+	}
+	if len(v.ZoneProtocols) > 0 {
+		lines = append(lines, l.Indent+l.ProtocolsLabel+": "+strings.Join(v.ZoneProtocols, l.Sep))
+	}
+	if len(v.ZoneSystemServices) == 0 && len(v.ZoneProtocols) == 0 && len(v.Interfaces) == 0 {
+		lines = append(lines, l.Indent+"Host-inbound: default deny ("+
+			HostInboundDenyReason(false, v.ZoneConfigured)+")")
+	}
+	if len(v.Interfaces) > 0 {
+		lines = append(lines, l.Indent+"Host-inbound interface overrides:")
+		for _, iface := range v.Interfaces {
+			lines = append(lines,
+				l.Indent+"  "+iface.Interface+":",
+				l.Indent+"    override system-services: "+join(iface.SystemServices),
+				l.Indent+"    override protocols: "+join(iface.Protocols),
+				l.Indent+"    effective system-services: "+join(iface.EffectiveSystemServices),
+				l.Indent+"    effective protocols: "+join(iface.EffectiveProtocols),
+			)
+		}
+	}
+	return lines
+}

--- a/pkg/config/host_inbound_view_3654_test.go
+++ b/pkg/config/host_inbound_view_3654_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3654: the shared host-inbound presentation SSOT. Every text/CLI surface
+// (local `show security zones` / `show interfaces` / `test security-zone
+// interface`, gRPC text zones + interface diagnostic, remote cmd/cli zones)
+// routes through these helpers so none can drift back to hiding per-interface
+// overrides (#3362) or the no-stanza default-deny posture (#3405). These unit
+// tests pin the view/union/render contract the surface golden tests build on.
+
+func TestUnionHostInboundTokens3654(t *testing.T) {
+	got := UnionHostInboundTokens([]string{"ssh", "ping"}, []string{"ping", "https", ""})
+	want := []string{"ssh", "ping", "https"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("UnionHostInboundTokens = %v, want %v (zone-first, dedup, empties skipped)", got, want)
+	}
+	if got := UnionHostInboundTokens(nil, nil); len(got) != 0 {
+		t.Fatalf("UnionHostInboundTokens(nil,nil) = %v, want empty", got)
+	}
+}
+
+func TestHostInboundDenyReason3654(t *testing.T) {
+	cases := []struct {
+		overridden, zoneConfigured bool
+		want                       string
+	}{
+		{true, false, "interface override: deny-all"},
+		{true, true, "interface override: deny-all"},
+		{false, true, "empty stanza"},
+		{false, false, "no stanza"},
+	}
+	for _, c := range cases {
+		if got := HostInboundDenyReason(c.overridden, c.zoneConfigured); got != c.want {
+			t.Errorf("HostInboundDenyReason(%v,%v) = %q, want %q", c.overridden, c.zoneConfigured, got, c.want)
+		}
+	}
+}
+
+func TestInterfaceHostInboundEffective3654(t *testing.T) {
+	z := &ZoneConfig{
+		HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}, Protocols: []string{"ospf"}},
+		InterfaceHostInbound: map[string]*HostInboundTraffic{
+			"ge-0/0/9.0": {SystemServices: []string{"https", "ssh"}},
+		},
+	}
+	// Overridden interface: effective = zone UNION override.
+	svc, proto, overridden := z.InterfaceHostInboundEffective("ge-0/0/9.0")
+	if !overridden {
+		t.Fatal("expected overridden=true for ge-0/0/9.0")
+	}
+	if strings.Join(svc, ",") != "ssh,https" {
+		t.Fatalf("effective svc = %v, want [ssh https]", svc)
+	}
+	if strings.Join(proto, ",") != "ospf" {
+		t.Fatalf("effective proto = %v, want [ospf]", proto)
+	}
+	// Non-overridden interface: effective = zone-level only, overridden=false.
+	svc, _, overridden = z.InterfaceHostInboundEffective("ge-0/0/0.0")
+	if overridden {
+		t.Fatal("expected overridden=false for a non-overriding interface")
+	}
+	if strings.Join(svc, ",") != "ssh" {
+		t.Fatalf("non-override svc = %v, want [ssh]", svc)
+	}
+}
+
+func TestHostInboundViewRender3654(t *testing.T) {
+	labels := HostInboundLabels{Indent: "  ", Sep: ", ", ServicesLabel: "Host-inbound system-services", ProtocolsLabel: "Host-inbound protocols"}
+
+	// Populated zone with a per-interface override.
+	z := &ZoneConfig{
+		HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}},
+		InterfaceHostInbound: map[string]*HostInboundTraffic{
+			"ge-0/0/9.0": {SystemServices: []string{"https"}},
+		},
+	}
+	out := strings.Join(z.HostInboundView().Render(labels), "\n")
+	for _, want := range []string{
+		"Host-inbound system-services: ssh",
+		"Host-inbound interface overrides:",
+		"ge-0/0/9.0:",
+		"override system-services: https",
+		"effective system-services: ssh, https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("populated+override render missing %q\n%s", want, out)
+		}
+	}
+
+	// No-stanza zone: explicit default-deny posture line.
+	out = strings.Join((&ZoneConfig{}).HostInboundView().Render(labels), "\n")
+	if !strings.Contains(out, "Host-inbound: default deny (no stanza)") {
+		t.Errorf("no-stanza render missing posture line\n%s", out)
+	}
+
+	// Empty-stanza zone: posture line distinguishes it.
+	z = &ZoneConfig{HostInboundTraffic: &HostInboundTraffic{}}
+	out = strings.Join(z.HostInboundView().Render(labels), "\n")
+	if !strings.Contains(out, "Host-inbound: default deny (empty stanza)") {
+		t.Errorf("empty-stanza render missing posture line\n%s", out)
+	}
+}
+
+func TestRenderInterfaceHostInbound3654(t *testing.T) {
+	labels := HostInboundLabels{Indent: "  ", Sep: ", ", ServicesLabel: "Host-inbound services", ProtocolsLabel: "Host-inbound protocols"}
+	z := &ZoneConfig{
+		HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}},
+		InterfaceHostInbound: map[string]*HostInboundTraffic{
+			"ge-0/0/9.0": {SystemServices: []string{"https"}},
+		},
+	}
+	// Overridden interface: shows zone-level, the override marker, and effective.
+	out := strings.Join(z.RenderInterfaceHostInbound("ge-0/0/9.0", labels), "\n")
+	for _, want := range []string{
+		"Host-inbound services: ssh",
+		"Host-inbound interface override on ge-0/0/9.0:",
+		"effective host-inbound services: ssh, https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("override diagnostic missing %q\n%s", want, out)
+		}
+	}
+	// A no-stanza zone interface: default-deny posture line.
+	out = strings.Join((&ZoneConfig{}).RenderInterfaceHostInbound("ge-0/0/0.0", labels), "\n")
+	if !strings.Contains(out, "Host-inbound: default deny (no stanza)") {
+		t.Errorf("no-stanza diagnostic missing posture line\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_show_zones_hostinbound_display_3654_test.go
+++ b/pkg/grpcapi/server_show_zones_hostinbound_display_3654_test.go
@@ -1,0 +1,109 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3654: the gRPC TEXT surfaces (ShowText "zones-detail" and the "test-zone:"
+// interface diagnostic) rendered ONLY the zone-level host-inbound set, dropping
+// the per-interface override (#3362) and the no-stanza default-deny posture
+// (#3405). These golden tests assert both now appear.
+//
+// RED-on-revert: routing the surfaces back through the old
+// `if zone.HostInboundTraffic != nil { ... }` block drops the override block
+// and the "default deny" posture line, failing the matching assertions.
+
+func hostInboundGRPCServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust {
+            host-inbound-traffic {
+                system-services { ssh; ping; }
+                protocols { ospf; }
+            }
+        }
+        security-zone edge {
+            interfaces {
+                ge-0/0/9.0 {
+                    host-inbound-traffic { system-services { https; } }
+                }
+            }
+        }
+        security-zone plain {
+            interfaces {
+                ge-0/0/1.0;
+            }
+        }
+        security-zone open;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+func TestShowTextZonesDetailHostInbound3654(t *testing.T) {
+	s := hostInboundGRPCServer(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "zones-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(zones-detail) error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{
+		"Host-inbound system-services: ssh, ping",
+		"Host-inbound protocols: ospf",
+		"Host-inbound interface overrides:",
+		"ge-0/0/9.0:",
+		"override system-services: https",
+		"effective system-services: https",
+		"Host-inbound: default deny (no stanza)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("gRPC text zones-detail missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestShowTextTestZoneHostInbound3654(t *testing.T) {
+	s := hostInboundGRPCServer(t)
+
+	// Overridden interface: flag the override + effective set.
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "test-zone:interface=ge-0/0/9.0"})
+	if err != nil {
+		t.Fatalf("ShowText(test-zone override) error = %v", err)
+	}
+	out := resp.GetOutput()
+	for _, want := range []string{
+		"Interface ge-0/0/9.0 belongs to zone: edge",
+		"Host-inbound interface override on ge-0/0/9.0:",
+		"effective host-inbound services: https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("gRPC text test-zone (override) missing %q\n%s", want, out)
+		}
+	}
+
+	// No-stanza zone interface: default-deny posture line.
+	resp, err = s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "test-zone:interface=ge-0/0/1.0"})
+	if err != nil {
+		t.Fatalf("ShowText(test-zone no-stanza) error = %v", err)
+	}
+	if out := resp.GetOutput(); !strings.Contains(out, "Host-inbound: default deny (no stanza)") {
+		t.Errorf("gRPC text test-zone (no-stanza) missing posture line\n%s", out)
+	}
+}

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -60,15 +60,18 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 		if zone.ScreenProfile != "" {
 			fmt.Fprintf(buf, "  Screen: %s\n", zone.ScreenProfile)
 		}
-		if zone.HostInboundTraffic != nil {
-			if len(zone.HostInboundTraffic.SystemServices) > 0 {
-				fmt.Fprintf(buf, "  Host-inbound system-services: %s\n",
-					strings.Join(zone.HostInboundTraffic.SystemServices, ", "))
-			}
-			if len(zone.HostInboundTraffic.Protocols) > 0 {
-				fmt.Fprintf(buf, "  Host-inbound protocols: %s\n",
-					strings.Join(zone.HostInboundTraffic.Protocols, ", "))
-			}
+		// #3654: render the zone-level admitted set, the no-stanza default-deny
+		// posture line, AND any per-interface host-inbound override through the
+		// shared config presenter (H07/M03) so gRPC text stays in lockstep with
+		// the local CLI and the structured inventory.
+		for _, line := range zone.HostInboundView().Render(config.HostInboundLabels{
+			Indent:         "  ",
+			Sep:            ", ",
+			ServicesLabel:  "Host-inbound system-services",
+			ProtocolsLabel: "Host-inbound protocols",
+		}) {
+			buf.WriteString(line)
+			buf.WriteString("\n")
 		}
 		// Traffic counters
 		if s.dp != nil && s.dp.IsLoaded() && zoneID > 0 {
@@ -223,13 +226,18 @@ func (s *Server) showTestZone(req *pb.ShowTextRequest, cfg *config.Config, buf *
 					if zone.ScreenProfile != "" {
 						fmt.Fprintf(buf, "  Screen:      %s\n", zone.ScreenProfile)
 					}
-					if zone.HostInboundTraffic != nil {
-						if len(zone.HostInboundTraffic.SystemServices) > 0 {
-							fmt.Fprintf(buf, "  Host-inbound services: %s\n", strings.Join(zone.HostInboundTraffic.SystemServices, ", "))
-						}
-						if len(zone.HostInboundTraffic.Protocols) > 0 {
-							fmt.Fprintf(buf, "  Host-inbound protocols: %s\n", strings.Join(zone.HostInboundTraffic.Protocols, ", "))
-						}
+					// #3654 (H08/M03): this is the per-interface admission
+					// DIAGNOSTIC, so report the EFFECTIVE (zone UNION interface)
+					// set for THIS interface and flag when it is governed by an
+					// interface-local override rather than only the zone set.
+					for _, line := range zone.RenderInterfaceHostInbound(ifName, config.HostInboundLabels{
+						Indent:         "  ",
+						Sep:            ", ",
+						ServicesLabel:  "Host-inbound services",
+						ProtocolsLabel: "Host-inbound protocols",
+					}) {
+						buf.WriteString(line)
+						buf.WriteString("\n")
 					}
 					found = true
 					break

--- a/pkg/grpcapi/testdata/server_show_golden.json
+++ b/pkg/grpcapi/testdata/server_show_golden.json
@@ -36,6 +36,6 @@
   "task": "Task: xpfd daemon\n  Goroutines: \u003cNUM\u003e\n  Memory allocated: \u003cSIZE\u003e\n  System memory: \u003cSIZE\u003e\n  GC cycles: \u003cNUM\u003e\n  Uptime: \u003cDUR\u003e\n",
   "test-policy:from=trust,to=untrust,src=10.0.1.1,dst=10.0.2.1,port=80,proto=tcp": "Policy match:\n  From zone: trust\n  To zone:   untrust\n  Policy:    p1\n  Action:    permit\n",
   "test-routing:dest=10.0.2.1": "Routing manager not available\n",
-  "test-zone:interface=ge-0-0-0.0": "Interface ge-0-0-0.0 belongs to zone: trust\n",
+  "test-zone:interface=ge-0-0-0.0": "Interface ge-0-0-0.0 belongs to zone: trust\n  Host-inbound: default deny (no stanza)\n",
   "vlans": "No VLANs configured\n"
 }


### PR DESCRIPTION
Closes #3654

## Problem

The structured REST/gRPC inventory has carried per-interface host-inbound
override rows (`interface_host_inbound`, #3328/#3362) and the split
`host_inbound_system_services` / `host_inbound_protocols` fields since #3328, but
every TEXT/CLI surface kept rendering ONLY the zone-level
`HostInboundTraffic` set:

- An interface governed by a narrower/wider effective admission set than its zone
  was displayed as if it inherited the zone set (H04–H09).
- A zone with no `host-inbound-traffic` stanza printed nothing even though it now
  default-DENIES host-bound traffic (#3405) — "not shown" was indistinguishable
  from "not enforced" (M03).
- The remote `cmd/cli` collapsed the split system-services/protocols into one
  legacy "Host-inbound services" line (M06).

Verified on master: no text renderer referenced `InterfaceHostInbound`.

## Fix

New shared presenter `pkg/config/host_inbound_view.go` — the single source of
truth for host-inbound display (L02): `UnionHostInboundTokens` (the display peer
of the dataplane's `unionHostInboundTokens`), `InterfaceHostInboundEffective`,
`HostInboundView.Render` (zone-scoped), and `RenderInterfaceHostInbound`
(interface-scoped diagnostic). All six surfaces now route through it:

| # | Surface | Presenter |
|---|---------|-----------|
| H04 | local `show security zones` | `HostInboundView.Render` |
| H05 | local `show interfaces` | `InterfaceHostInboundEffective` |
| H06 | local `test security-zone interface` | `RenderInterfaceHostInbound` |
| H07 | gRPC text `show security zones` | `HostInboundView.Render` |
| H08 | gRPC text interface diagnostic | `RenderInterfaceHostInbound` |
| H09 | remote `cmd/cli show security zones` | `HostInboundView.Render` (built from the gRPC response) |

- Each surface renders the per-interface override + its effective (zone UNION
  interface) admitted set.
- **M03:** an explicit `Host-inbound: default deny (no stanza | empty stanza |
  interface override: deny-all)` line is printed when the effective set is empty.
- **M06:** the remote CLI consumes the structured split fields + override rows.

## Tests (M07 gap)

RED-on-revert golden tests added for every surface (previously only the
structured `GetZones` had coverage): `pkg/config` presenter units, `pkg/cli`
(zones / interfaces / test-zone), `pkg/grpcapi` (ShowText zones-detail +
test-zone), `cmd/cli` (remote zones via a GetZones fake). Each fixture covers a
populated zone, a per-interface override, and a no-stanza zone. Reverting a
surface to the old zone-level-only block drops the override block + posture line
and fails the assertion (verified by temporarily reverting H04 → RED).

The `pkg/grpcapi` ShowText golden was regenerated: the `test-zone` diagnostic for
the fixture's no-stanza trust zone now correctly emits the posture line (the only
golden delta).

## Validation

- `go build ./...` clean
- `go test ./pkg/cli/... ./pkg/grpcapi/... ./cmd/cli/... ./pkg/config/...` green
- `gofmt` clean
- docs/junos-cli-reference.md updated

Note: #3658 (zone-detail global+default tiers) is a sibling that will edit
`show security zones detail` next; these changes are scoped to the
per-interface-override + posture + split display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi