### PR TITLE
cli: show global + default-policy tiers in 'show security zones detail' (#3658)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24879,3 +24879,17 @@ top.
 - **Timestamp**: 2026-07-01
 - **Action**: Add RED-on-revert golden tests for all 6 surfaces; regenerate ShowText golden for the new no-stanza posture line; document the #3654 display fix
 - **File(s)**: pkg/cli/host_inbound_display_3654_test.go (new), pkg/grpcapi/server_show_zones_hostinbound_display_3654_test.go (new), cmd/cli/show_zones_hostinbound_3654_test.go (new), pkg/grpcapi/testdata/server_show_golden.json (regenerated), docs/junos-cli-reference.md
+
+## 2026-07-01 — #3658 zone-detail policy summary tiers (M04/M05)
+
+- **Timestamp**: 2026-07-01
+- **Action**: Add SSOT predicate config.GlobalPolicyAppliesToZone (mirrors the runtime AND-combined GlobalZoneScope match) so the zone-detail summary can list the global tier for a zone
+- **File(s)**: pkg/config/types_security.go
+- **Action**: Extend the local-CLI `show security zones detail` policy summary to render all three evaluation tiers — [zone-pair], applicable [global] policies (M04), and the always-present [default] default-policy catch-all (M05) — replacing the bare "(no policies)"; add local policyActionStr + globalZoneScopeLabel helpers
+- **File(s)**: pkg/cli/cli_show_security_zones.go
+- **Action**: Mirror the same three-tier summary on the gRPC text zones-detail surface; add globalZoneScopeLabel helper
+- **File(s)**: pkg/grpcapi/server_show_zones_text.go, pkg/grpcapi/server_helpers.go
+- **Action**: Add RED-on-revert golden tests (CLI + gRPC) — a global-only zone shows the global tier + effective default-policy, scoped globals do not leak into unrelated zones, and the no-applicable-policy note still surfaces the default line
+- **File(s)**: pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go (new), pkg/grpcapi/server_show_zones_policy_tiers_3658_test.go (new)
+- **Action**: Document the detail-mode three-tier policy summary
+- **File(s)**: docs/junos-cli-reference.md, _Log.md

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -803,6 +803,36 @@ Security zone: junos-host
   `Host-inbound system-services:` / `Host-inbound protocols:`.
 - Blank line between zones.
 
+**`show security zones detail` policy summary (#3658).** In `detail` mode
+each zone gains a `Policy summary` block that lists the policies that decide
+the zone's transit, in the SAME precedence order the dataplane evaluates
+them (zone-pair, then global, then the implicit default-policy catch-all):
+
+```
+  Policy summary (evaluation order: zone-pair, global, default-policy):
+    [zone-pair] trust -> untrust: allow-web (permit)
+    [global] any -> untrust: block-bad (deny)
+    [default] default-policy: deny
+```
+
+- `[zone-pair] <from> -> <to>: <name> (<action>)` -- a from-zone/to-zone
+  policy referencing this zone (either side).
+- `[global] <from> -> <to>: <name> (<action>)` -- a GLOBAL policy that can
+  affect this zone (M04). An unscoped global prints `any` for both scopes;
+  a scoped global (`match from-zone`/`to-zone`, #3148) prints its zone scope.
+  A global is listed for a zone only when the zone can appear on either side
+  of a pair the global matches (`config.GlobalPolicyAppliesToZone`).
+- `[default] default-policy: <action>` -- the effective default-policy
+  catch-all is ALWAYS shown (M05), so a zone with no explicit rule reports
+  `default-policy: deny` / `permit` / `reject` rather than a bare
+  `(no policies)`, which hid whether unmatched transit is denied or permitted.
+- When a zone has no zone-pair AND no applicable global policy, the summary
+  prints `(no zone-pair or global policies affecting this zone)` above the
+  always-present `[default]` line.
+- The gRPC text `zones-detail` view renders the identical three-tier block;
+  both mirror the REST inventory global + synthetic default-policy rows
+  (`pkg/api/security.go`) and structured `GetPolicies` (#3363).
+
 ---
 
 ## Security: NAT Source Rule All

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -10,6 +10,34 @@ import (
 	"github.com/psaab/xpf/pkg/dataplane"
 )
 
+// policyActionStr renders a config.PolicyAction as its Junos then-token. It
+// mirrors the gRPC/REST policyActionStr (pkg/grpcapi/server_helpers.go,
+// pkg/api/security.go) so the zone-detail global + default-policy tier lines
+// (#3658) agree with every other policy surface. A compiled policy always
+// carries a valid terminal action; "unknown" is the defensive default.
+func policyActionStr(a config.PolicyAction) string {
+	switch a {
+	case config.PolicyPermit:
+		return "permit"
+	case config.PolicyDeny:
+		return "deny"
+	case config.PolicyReject:
+		return "reject"
+	default:
+		return "unknown"
+	}
+}
+
+// globalZoneScopeLabel renders a global policy's optional from/to-zone match
+// scope (#3148) for the zone-detail summary: an empty scope is the "any zone"
+// wildcard and prints as "any".
+func globalZoneScopeLabel(zone string) string {
+	if zone == "" {
+		return "any"
+	}
+	return zone
+}
+
 func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone string) error {
 	// Sort zone names for stable output
 	zoneNames := make([]string, 0, len(cfg.Security.Zones))
@@ -147,9 +175,17 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 				}
 			}
 
-			// Policy detail breakdown
-			fmt.Println("  Policy summary:")
-			totalPolicies := 0
+			// Policy detail breakdown. #3658 (M04/M05): the summary now spans
+			// all THREE tiers the runtime evaluates in order — zone-pair, then
+			// applicable GLOBAL policies, then the effective default-policy
+			// catch-all — so a zone-centric audit can no longer hide a global
+			// rule that permits/denies the zone's traffic (M04) nor collapse to
+			// a bare "(no policies)" that obscures whether unmatched transit is
+			// denied or permitted (M05). Parity with the REST inventory
+			// (pkg/api/security.go global + synthetic default rows) and gRPC
+			// GetPolicies (#3363).
+			fmt.Println("  Policy summary (evaluation order: zone-pair, global, default-policy):")
+			zonePairPolicies := 0
 			for _, zpp := range cfg.Security.Policies {
 				// #3476: skip a nil zone-pair set (tolerant / HA-sync config
 				// path the runtime walker skips) rather than dereferencing
@@ -164,22 +200,37 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 						if pol == nil {
 							continue
 						}
-						action := "permit"
-						switch pol.Action {
-						case 1:
-							action = "deny"
-						case 2:
-							action = "reject"
-						}
-						fmt.Printf("    %s -> %s: %s (%s)\n",
-							zpp.FromZone, zpp.ToZone, pol.Name, action)
-						totalPolicies++
+						fmt.Printf("    [zone-pair] %s -> %s: %s (%s)\n",
+							zpp.FromZone, zpp.ToZone, pol.Name,
+							policyActionStr(pol.Action))
+						zonePairPolicies++
 					}
 				}
 			}
-			if totalPolicies == 0 {
-				fmt.Println("    (no policies)")
+			globalPolicies := 0
+			for _, gp := range cfg.Security.GlobalPolicies {
+				// #3476-style defensiveness: skip a nil global rule.
+				if gp == nil {
+					continue
+				}
+				if !config.GlobalPolicyAppliesToZone(gp.Match, name) {
+					continue
+				}
+				fmt.Printf("    [global] %s -> %s: %s (%s)\n",
+					globalZoneScopeLabel(gp.Match.FromZone),
+					globalZoneScopeLabel(gp.Match.ToZone),
+					gp.Name, policyActionStr(gp.Action))
+				globalPolicies++
 			}
+			if zonePairPolicies == 0 && globalPolicies == 0 {
+				fmt.Println("    (no zone-pair or global policies affecting this zone)")
+			}
+			// M05: always surface the effective default-policy catch-all — the
+			// tier the runtime falls through to for unmatched transit — instead
+			// of hiding it behind "(no policies)".
+			fmt.Printf("    [default] %s: %s\n",
+				dataplane.DefaultPolicyName,
+				policyActionStr(cfg.Security.DefaultPolicy))
 		}
 
 		fmt.Println()

--- a/pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go
+++ b/pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3658 (M04/M05): the local-CLI `show security zones detail` policy summary
+// scanned only zone-pair policies. A zone with no zone-pair rule printed
+// "(no policies)" — hiding BOTH the applicable GLOBAL tier (a global policy
+// that permits/denies the zone's traffic, M04) AND the effective
+// default-policy catch-all that actually decides unmatched transit (M05). The
+// summary now renders all three tiers in evaluation order (zone-pair ->
+// global -> default-policy), mirroring the REST inventory + gRPC GetPolicies.
+//
+// These are the fail-on-revert guards: revert the global loop or the
+// unconditional default-policy line and the assertions go RED.
+
+// globalOnlyZoneCLIStore builds a config whose zone `dmz` has NO zone-pair
+// policy but is covered by an UNSCOPED global permit, plus a SCOPED global
+// (trust -> untrust) that must NOT leak into dmz's detail. default-policy is
+// deny-all so the catch-all line is materially different from "(no policies)".
+func globalOnlyZoneCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+        security-zone dmz;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy zone-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        global {
+            policy scoped-block {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy open-global {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        default-policy deny-all;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if len(cfg.Security.GlobalPolicies) != 2 {
+		t.Fatalf("GlobalPolicies len = %d, want 2", len(cfg.Security.GlobalPolicies))
+	}
+	return store
+}
+
+// zoneDetailBlock returns the "Security zone: <name>" ... block from a full
+// zone-detail render, up to the next zone header (blocks are blank-line
+// separated). Isolates one zone's summary so assertions do not cross-match
+// another zone's lines.
+func zoneDetailBlock(t *testing.T, out, zone string) string {
+	t.Helper()
+	marker := "Security zone: " + zone + "\n"
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		t.Fatalf("zone %q missing from zone-detail output:\n%s", zone, out)
+	}
+	rest := out[idx:]
+	// The next zone header follows a blank line; cut there so we keep only
+	// this zone's block.
+	if end := strings.Index(rest[len(marker):], "\nSecurity zone: "); end >= 0 {
+		rest = rest[:len(marker)+end]
+	}
+	return rest
+}
+
+// TestCLIZoneDetailGlobalOnlyZoneShowsGlobalAndDefault is the #3658 M04/M05
+// fail-on-revert guard: a zone with only a global policy must show the global
+// tier AND the effective default-policy catch-all — never a bare
+// "(no policies)".
+func TestCLIZoneDetailGlobalOnlyZoneShowsGlobalAndDefault(t *testing.T) {
+	store := globalOnlyZoneCLIStore(t)
+	c := &CLI{store: store} // dp nil: skip counters, exercise the policy summary
+	cfg := store.ActiveConfig()
+
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(cfg, true, "dmz"); err != nil {
+			t.Fatalf("showZonesDisplay(detail, dmz): %v", err)
+		}
+	})
+	block := zoneDetailBlock(t, out, "dmz")
+
+	// M05: the pre-fix bare "(no policies)" must be gone.
+	if strings.Contains(block, "(no policies)") {
+		t.Fatalf("dmz detail still prints bare \"(no policies)\" (M05 not fixed):\n%s", block)
+	}
+	// M04: the unscoped global that covers every zone must be listed as the
+	// global tier for dmz.
+	if !strings.Contains(block, "[global] any -> any: open-global (permit)") {
+		t.Fatalf("dmz detail missing unscoped global tier line (M04 not fixed):\n%s", block)
+	}
+	// The scoped trust->untrust global must NOT leak into dmz (applicability
+	// filter — config.GlobalPolicyAppliesToZone).
+	if strings.Contains(block, "scoped-block") {
+		t.Fatalf("dmz detail leaked scoped trust->untrust global scoped-block:\n%s", block)
+	}
+	// M05: the effective default-policy catch-all (deny) is surfaced.
+	if !strings.Contains(block, "[default] default-policy: deny") {
+		t.Fatalf("dmz detail missing effective default-policy line (M05 not fixed):\n%s", block)
+	}
+}
+
+// TestCLIZoneDetailAllTiersForZonePairZone verifies the full precedence stack
+// for a zone that has a zone-pair policy, an applicable scoped global, and an
+// applicable unscoped global — all three tiers plus the default line appear.
+func TestCLIZoneDetailAllTiersForZonePairZone(t *testing.T) {
+	store := globalOnlyZoneCLIStore(t)
+	c := &CLI{store: store}
+	cfg := store.ActiveConfig()
+
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(cfg, true, "untrust"); err != nil {
+			t.Fatalf("showZonesDisplay(detail, untrust): %v", err)
+		}
+	})
+	block := zoneDetailBlock(t, out, "untrust")
+
+	for _, want := range []string{
+		"[zone-pair] trust -> untrust: zone-allow (permit)",
+		"[global] trust -> untrust: scoped-block (deny)",
+		"[global] any -> any: open-global (permit)",
+		"[default] default-policy: deny",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("untrust detail missing %q:\n%s", want, block)
+		}
+	}
+}
+
+// scopedGlobalNoZonePairCLIStore builds a config with ONLY a scoped global
+// (trust -> untrust) and NO unscoped global, so a third zone `mgmt` has no
+// applicable policy of any tier. default-policy is permit-all here to prove the
+// catch-all reflects the configured action, not a hardcoded deny.
+func scopedGlobalNoZonePairCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+        security-zone mgmt;
+    }
+    policies {
+        global {
+            policy scoped-block {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+        }
+        default-policy permit-all;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestCLIZoneDetailNoApplicablePolicyStillShowsDefault verifies M05 for a zone
+// with zero applicable policies: the summary shows the "(no zone-pair or global
+// policies affecting this zone)" note AND the effective default-policy line —
+// and the scoped global does not leak into an unrelated zone.
+func TestCLIZoneDetailNoApplicablePolicyStillShowsDefault(t *testing.T) {
+	store := scopedGlobalNoZonePairCLIStore(t)
+	c := &CLI{store: store}
+	cfg := store.ActiveConfig()
+
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(cfg, true, "mgmt"); err != nil {
+			t.Fatalf("showZonesDisplay(detail, mgmt): %v", err)
+		}
+	})
+	block := zoneDetailBlock(t, out, "mgmt")
+
+	if strings.Contains(block, "scoped-block") {
+		t.Fatalf("mgmt detail leaked scoped trust->untrust global:\n%s", block)
+	}
+	if !strings.Contains(block, "(no zone-pair or global policies affecting this zone)") {
+		t.Fatalf("mgmt detail missing no-applicable-policy note:\n%s", block)
+	}
+	// M05: even with no explicit policy, the effective permit-all default is
+	// surfaced (materially different from a bare "(no policies)").
+	if !strings.Contains(block, "[default] default-policy: permit") {
+		t.Fatalf("mgmt detail missing effective permit-all default line:\n%s", block)
+	}
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -335,6 +335,27 @@ type PolicyMatch struct {
 	ToZone   string
 }
 
+// GlobalPolicyAppliesToZone reports whether a global policy with the given
+// match context can affect security zone `zone` — i.e. the global's from- or
+// to-zone scope can place `zone` on either side of an evaluated zone pair. An
+// empty FromZone/ToZone is the "any zone" wildcard (#3148, unscoped global).
+//
+// It mirrors the runtime AND-combined GlobalZoneScope match in the userspace
+// dataplane (userspace-dp/src/policy.rs: a global matches a packet iff its
+// from-scope matches the packet's from-zone AND its to-scope matches the
+// packet's to-zone): `zone` is a possible SOURCE when the from-scope is
+// any-or-`zone`, and a possible DESTINATION when the to-scope is any-or-`zone`.
+// Either possibility means the global can permit/deny some traffic that
+// involves `zone`, so it belongs in that zone's audit.
+//
+// Used by the zone-detail policy summary (#3658) to list the global tier the
+// runtime evaluates after zone-pair rules. Callers filter nil policies first.
+func GlobalPolicyAppliesToZone(m PolicyMatch, zone string) bool {
+	asSource := m.FromZone == "" || m.FromZone == zone
+	asDest := m.ToZone == "" || m.ToZone == zone
+	return asSource || asDest
+}
+
 // PolicyAction is the action to take when a policy matches.
 type PolicyAction int
 

--- a/pkg/grpcapi/server_helpers.go
+++ b/pkg/grpcapi/server_helpers.go
@@ -67,6 +67,17 @@ func policyActionStr(a config.PolicyAction) string {
 	}
 }
 
+// globalZoneScopeLabel renders a global policy's optional from/to-zone match
+// scope (#3148) for the zone-detail summary (#3658): an empty scope is the
+// "any zone" wildcard and prints as "any". Mirrors the local-CLI peer helper
+// in pkg/cli/cli_show_security_zones.go.
+func globalZoneScopeLabel(zone string) string {
+	if zone == "" {
+		return "any"
+	}
+	return zone
+}
+
 // protoName renders an IP protocol number as its canonical lowercase name,
 // falling back to the numeric form for an unnamed protocol. The named set is
 // owned by appid.ProtocolName (the #2949 SSOT) so gRPC, REST, and the catalog

--- a/pkg/grpcapi/server_show_zones_policy_tiers_3658_test.go
+++ b/pkg/grpcapi/server_show_zones_policy_tiers_3658_test.go
@@ -1,0 +1,123 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3658 (M04/M05): the gRPC-text `show security zones detail` policy summary
+// (showZonesDetail) scanned only zone-pair policies and printed "(no policies)"
+// for a zone with no zone-pair rule — hiding BOTH the applicable GLOBAL tier
+// (M04) and the effective default-policy catch-all (M05). The summary now spans
+// all three tiers in evaluation order (zone-pair -> global -> default-policy).
+//
+// This is the gRPC peer of the local-CLI fail-on-revert guard in
+// pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go.
+
+func policyTierGRPCServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+        security-zone dmz;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy zone-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        global {
+            policy scoped-block {
+                match {
+                    from-zone trust;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy open-global {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        default-policy deny-all;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+// zoneDetailBlock isolates one "Security zone: <name>" block from the full
+// zone-detail render so assertions do not cross-match another zone's lines.
+func zoneDetailBlock(t *testing.T, out, zone string) string {
+	t.Helper()
+	marker := "Zone: " + zone + "\n"
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		t.Fatalf("zone %q missing from zone-detail output:\n%s", zone, out)
+	}
+	rest := out[idx:]
+	if end := strings.Index(rest[len(marker):], "\nZone: "); end >= 0 {
+		rest = rest[:len(marker)+end]
+	}
+	return rest
+}
+
+// TestShowTextZonesDetailPolicyTiers3658 is the #3658 M04/M05 fail-on-revert
+// guard for the gRPC-text zone-detail surface.
+func TestShowTextZonesDetailPolicyTiers3658(t *testing.T) {
+	s := policyTierGRPCServer(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "zones-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(zones-detail) error = %v", err)
+	}
+	out := resp.GetOutput()
+
+	// dmz: no zone-pair, covered only by the unscoped global + default-policy.
+	dmz := zoneDetailBlock(t, out, "dmz")
+	if strings.Contains(dmz, "(no policies)") {
+		t.Errorf("dmz still prints bare \"(no policies)\" (M05 not fixed):\n%s", dmz)
+	}
+	if !strings.Contains(dmz, "[global] any -> any: open-global (permit)") {
+		t.Errorf("dmz missing unscoped global tier (M04 not fixed):\n%s", dmz)
+	}
+	if strings.Contains(dmz, "scoped-block") {
+		t.Errorf("dmz leaked scoped trust->untrust global (applicability filter):\n%s", dmz)
+	}
+	if !strings.Contains(dmz, "[default] default-policy: deny") {
+		t.Errorf("dmz missing effective default-policy line (M05 not fixed):\n%s", dmz)
+	}
+
+	// untrust: full precedence stack — zone-pair, scoped global, unscoped
+	// global, default.
+	untrust := zoneDetailBlock(t, out, "untrust")
+	for _, want := range []string{
+		"[zone-pair] trust -> untrust: zone-allow (permit)",
+		"[global] trust -> untrust: scoped-block (deny)",
+		"[global] any -> any: open-global (permit)",
+		"[default] default-policy: deny",
+	} {
+		if !strings.Contains(untrust, want) {
+			t.Errorf("untrust detail missing %q:\n%s", want, untrust)
+		}
+	}
+}

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -157,9 +157,16 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 				}
 			}
 		}
-		// Policy detail breakdown
-		buf.WriteString("  Policy summary:\n")
-		totalPolicies := 0
+		// Policy detail breakdown. #3658 (M04/M05): span all THREE tiers the
+		// runtime evaluates in order — zone-pair, applicable GLOBAL policies,
+		// then the effective default-policy catch-all — so this gRPC-text peer
+		// of the local-CLI renderer (pkg/cli/cli_show_security_zones.go) can no
+		// longer hide a global rule that affects the zone (M04) nor collapse to
+		// a bare "(no policies)" that obscures the unmatched-transit disposition
+		// (M05). Parity with REST (pkg/api/security.go) + gRPC GetPolicies
+		// (#3363).
+		buf.WriteString("  Policy summary (evaluation order: zone-pair, global, default-policy):\n")
+		zonePairPolicies := 0
 		for _, zpp := range cfg.Security.Policies {
 			// #3476: skip a nil zone-pair set rather than dereferencing
 			// zpp.FromZone.
@@ -173,22 +180,36 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 					if pol == nil {
 						continue
 					}
-					action := "permit"
-					switch pol.Action {
-					case 1:
-						action = "deny"
-					case 2:
-						action = "reject"
-					}
-					fmt.Fprintf(buf, "    %s -> %s: %s (%s)\n",
-						zpp.FromZone, zpp.ToZone, pol.Name, action)
-					totalPolicies++
+					fmt.Fprintf(buf, "    [zone-pair] %s -> %s: %s (%s)\n",
+						zpp.FromZone, zpp.ToZone, pol.Name,
+						policyActionStr(pol.Action))
+					zonePairPolicies++
 				}
 			}
 		}
-		if totalPolicies == 0 {
-			buf.WriteString("    (no policies)\n")
+		globalPolicies := 0
+		for _, gp := range cfg.Security.GlobalPolicies {
+			// #3476-style defensiveness: skip a nil global rule.
+			if gp == nil {
+				continue
+			}
+			if !config.GlobalPolicyAppliesToZone(gp.Match, name) {
+				continue
+			}
+			fmt.Fprintf(buf, "    [global] %s -> %s: %s (%s)\n",
+				globalZoneScopeLabel(gp.Match.FromZone),
+				globalZoneScopeLabel(gp.Match.ToZone),
+				gp.Name, policyActionStr(gp.Action))
+			globalPolicies++
 		}
+		if zonePairPolicies == 0 && globalPolicies == 0 {
+			buf.WriteString("    (no zone-pair or global policies affecting this zone)\n")
+		}
+		// M05: always surface the effective default-policy catch-all instead of
+		// hiding it behind "(no policies)".
+		fmt.Fprintf(buf, "    [default] %s: %s\n",
+			dataplane.DefaultPolicyName,
+			policyActionStr(cfg.Security.DefaultPolicy))
 		buf.WriteString("\n")
 	}
 	if readErr != nil {


### PR DESCRIPTION
Closes #3658

## Problem

The `show security zones detail` policy summary scanned ONLY the zone-pair
policy set and printed `(no policies)` for a zone with no zone-pair rule. That
hid the two other tiers the runtime actually evaluates:

- **M04 — applicable global policies.** A global policy (scoped via
  `match from-zone`/`to-zone`, #3148, or unscoped) can permit/deny a zone's
  traffic but was never listed in the zone-centric audit, even though the REST
  inventory already surfaces globals (`pkg/api/security.go`).
- **M05 — the effective default-policy catch-all.** `(no policies)` is
  materially different from `default-policy deny-all/permit-all`: it hid whether
  unmatched transit through the zone is denied or permitted. REST already emits a
  synthetic default-policy row (#3363).

## Fix

Both the local-CLI renderer (`pkg/cli/cli_show_security_zones.go`) and its
gRPC-text peer (`pkg/grpcapi/server_show_zones_text.go`) now render the summary
in the SAME precedence order the dataplane evaluates:

```
  Policy summary (evaluation order: zone-pair, global, default-policy):
    [zone-pair] trust -> untrust: allow-web (permit)
    [global] any -> untrust: block-bad (deny)
    [default] default-policy: deny
```

Tiers added:
- `[zone-pair]` — existing from/to-zone policies referencing the zone.
- `[global]` — global policies that can affect the zone (M04), filtered through
  the new SSOT predicate `config.GlobalPolicyAppliesToZone` (mirrors the runtime
  AND-combined `GlobalZoneScope` match in `userspace-dp/src/policy.rs`). An
  unscoped global prints `any` for both scopes; a scoped global prints its zone
  scope. A scoped global does not leak into an unrelated zone.
- `[default]` — the effective default-policy catch-all, ALWAYS shown (M05),
  reflecting the configured `permit-all`/`deny-all`/`reject-all`.

When a zone has neither a zone-pair nor an applicable global policy, the summary
prints `(no zone-pair or global policies affecting this zone)` above the
always-present `[default]` line, replacing the bare `(no policies)`.

Action strings route through the shared `policyActionStr` mapping so all policy
surfaces agree.

## RED-on-revert proof

Restoring the pre-fix summary in each surface (drop the global loop + the
unconditional default-policy line) makes the new tests fail:

- CLI: `dmz detail still prints bare "(no policies)" (M05 not fixed)` +
  `dmz detail missing unscoped global tier line (M04 not fixed)` + the
  all-tiers and no-applicable-policy assertions.
- gRPC: the same on the `zones-detail` ShowText surface.

With the fix in place all assertions pass.

## Tests / validation

- New guards: `pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go`,
  `pkg/grpcapi/server_show_zones_policy_tiers_3658_test.go` — global-only zone
  shows global + default, scoped globals do not leak, no-applicable-policy still
  shows default, full precedence stack for a zone-pair zone.
- `go test ./pkg/cli/... ./pkg/grpcapi/... ./pkg/config/... ./pkg/api/...` green.
- `go build ./pkg/... ./cmd/...` OK; `gofmt` clean; `go vet` clean on touched
  files (the pre-existing `pkg/cli/cli.go:503` unreachable-code warning is on
  origin/master).
- Doc updated: `docs/junos-cli-reference.md` documents the detail-mode
  three-tier policy summary.

Distinct from #3630 (KILLed — default-policy STRUCTURED representation was
already unambiguous). This is the local-CLI + gRPC-text zone-detail surface
showing the effective catch-all + global tier, not the structured repr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
