### PR TITLE
host-inbound: keep zone default-deny posture visible under a partial interface override (#3671)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,27 @@
+## 2026-07-01 — #3671 host-inbound zone posture survives a partial interface override (H08, #3654 residual; folds L03)
+
+- **Timestamp**: 2026-07-01
+- **Action**: Fix the shared host-inbound presenter — `HostInboundView.Render`
+  gated the zone-level `Host-inbound: default deny (...)` line on
+  `len(v.Interfaces) == 0`, so ANY per-interface override suppressed the zone
+  posture line even though that posture still governs every non-overridden
+  interface in the zone. Dropped the `len(v.Interfaces) == 0` clause so the
+  zone posture line is emitted whenever the zone-level service AND protocol
+  lists are both empty, regardless of overrides; the override block stays and
+  is rendered below the posture line as additional context. Because the fix is
+  in the shared presenter, it propagates to all six #3654 surfaces.
+- **File(s)**: pkg/config/host_inbound_view.go
+- **Action**: Add RED-on-revert tests at the presenter + a discriminating CLI
+  surface. Presenter: a no-stanza zone + an override renders BOTH the
+  default-deny posture line and the override block (and posture precedes the
+  override block); an empty-stanza zone + override shows the "empty stanza"
+  reason. Surface: `show security zones` filtered to the `edge` zone (override,
+  no zone stanza) — discriminating because the pre-existing #3654 test's
+  posture assertion was satisfied by the unrelated `open` zone.
+- **File(s)**: pkg/config/host_inbound_view_3654_test.go, pkg/cli/host_inbound_display_3654_test.go
+- **Action**: Document the #3671 residual fix in the CLI reference
+- **File(s)**: docs/junos-cli-reference.md, _Log.md
+
 ## 2026-07-01 — #3661 split reject RATE-LIMIT drop by source (Rust leg, M02 follow-up to #3657)
 
 - **Timestamp**: 2026-07-01

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -534,6 +534,15 @@ From zone: guest, To zone: lan
     enforced". The remote CLI additionally consumes the split
     system-services/protocols instead of the legacy flattened
     "Host-inbound services" line.
+  - **Zone posture survives a partial interface override (#3671):** the shared
+    zone presenter used to suppress the zone-level `Host-inbound: default deny
+    (...)` line whenever the zone had ANY per-interface override, even though the
+    zone posture still governs every NON-overridden interface. A zone with an
+    empty zone-level set and an override on one interface now renders BOTH the
+    zone default-deny posture line (governing the rest of the zone) AND the
+    override block below it — the override is additional context, never a
+    replacement for the zone posture. Because the fix is in the shared presenter
+    (`HostInboundView.Render`), it propagates to all six #3654 surfaces.
   - **Lifeline set derived from cluster config (#3277):** the lifeline
     interfaces excluded from host-inbound deny scoping are no longer a fixed
     fxp0/em0/fab* hardcode. The set is now `fxp0` (always-mgmt) UNION the

--- a/pkg/cli/host_inbound_display_3654_test.go
+++ b/pkg/cli/host_inbound_display_3654_test.go
@@ -111,6 +111,43 @@ func TestTestSecurityZoneHostInbound3654(t *testing.T) {
 	}
 }
 
+// TestShowSecurityZonesZonePostureWithOverride3671 is the surface-level peer of
+// the presenter test TestHostInboundViewRenderZonePostureWithOverride3671. The
+// `edge` zone in hostInboundCLIStore has an interface override but NO zone-level
+// host-inbound stanza; filtering `show security zones` to just that zone proves
+// the zone-level default-deny posture line is emitted alongside the override
+// block (#3671 / H08).
+//
+// This is discriminating where TestShowSecurityZonesHostInbound3654 is not: that
+// test's "default deny (no stanza)" assertion is satisfied by the unrelated
+// `open` zone, so it passes even with the #3671 bug present. Filtering to `edge`
+// removes that other source, so reverting the fix (the old
+// `&& len(v.Interfaces) == 0` guard) drops the posture line here and fails.
+func TestShowSecurityZonesZonePostureWithOverride3671(t *testing.T) {
+	c := hostInboundCLIStore(t)
+	out := captureStdout(t, func() {
+		if err := c.showZonesDisplay(c.store.ActiveConfig(), false, "edge"); err != nil {
+			t.Fatalf("showZonesDisplay: %v", err)
+		}
+	})
+	if strings.Contains(out, "Security zone: trust") || strings.Contains(out, "Security zone: open") {
+		t.Fatalf("filter to edge leaked another zone into output\n%s", out)
+	}
+	for _, want := range []string{
+		// zone-level default-deny posture — governs the non-overridden
+		// interfaces of edge and MUST remain visible despite the override
+		"Host-inbound: default deny (no stanza)",
+		// override block still rendered
+		"Host-inbound interface overrides:",
+		"ge-0/0/9.0:",
+		"override system-services: https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("edge zone (override, no zone stanza) output missing %q\n%s", want, out)
+		}
+	}
+}
+
 func TestShowInterfacesHostInbound3654(t *testing.T) {
 	// show interfaces reaches the host-inbound block only for a PRESENT kernel
 	// interface, so bind the override to the always-present loopback.

--- a/pkg/config/host_inbound_view.go
+++ b/pkg/config/host_inbound_view.go
@@ -193,11 +193,18 @@ type HostInboundLabels struct {
 // Render returns the host-inbound presentation block for a zone (#3654), one
 // line per slice element with NO trailing newline. It emits, in order: the
 // zone-level system-services / protocols lines (when non-empty), an explicit
-// default-deny posture line when the zone admits nothing at the zone level AND
-// has no per-interface override (M03 — so a blank host-inbound section can
-// never be misread as "not enforced"), and one block per per-interface override
-// showing the interface-local tokens plus the effective (zone UNION interface)
-// admitted set (H04/H07/H09).
+// default-deny posture line when the zone admits nothing at the zone level
+// (M03 — so a blank host-inbound section can never be misread as "not
+// enforced"), and one block per per-interface override showing the
+// interface-local tokens plus the effective (zone UNION interface) admitted set
+// (H04/H07/H09).
+//
+// The zone-level default-deny posture line is emitted regardless of whether any
+// per-interface override exists (#3671 / H08): the zone posture still governs
+// every NON-overridden interface in the zone, so a partial interface override
+// must not erase the visible default posture for the rest of the zone. The
+// override blocks are ADDITIONAL context printed below the zone posture, never a
+// replacement for it.
 func (v HostInboundView) Render(l HostInboundLabels) []string {
 	join := func(toks []string) string {
 		if len(toks) == 0 {
@@ -212,7 +219,13 @@ func (v HostInboundView) Render(l HostInboundLabels) []string {
 	if len(v.ZoneProtocols) > 0 {
 		lines = append(lines, l.Indent+l.ProtocolsLabel+": "+strings.Join(v.ZoneProtocols, l.Sep))
 	}
-	if len(v.ZoneSystemServices) == 0 && len(v.ZoneProtocols) == 0 && len(v.Interfaces) == 0 {
+	// The zone-level default-deny posture line is emitted whenever the zone
+	// admits nothing at the zone level, REGARDLESS of whether per-interface
+	// overrides exist (#3671 / H08). The zone posture governs every
+	// non-overridden interface, so a partial interface override must not
+	// suppress the visible zone posture; the override blocks below are
+	// additional context, not a replacement.
+	if len(v.ZoneSystemServices) == 0 && len(v.ZoneProtocols) == 0 {
 		lines = append(lines, l.Indent+"Host-inbound: default deny ("+
 			HostInboundDenyReason(false, v.ZoneConfigured)+")")
 	}

--- a/pkg/config/host_inbound_view_3654_test.go
+++ b/pkg/config/host_inbound_view_3654_test.go
@@ -105,6 +105,74 @@ func TestHostInboundViewRender3654(t *testing.T) {
 	}
 }
 
+// TestHostInboundViewRenderZonePostureWithOverride3671 pins the #3671 residual
+// fix (H08 / folds the L03 test gap): a zone with EMPTY zone-level host-inbound
+// lists but a per-interface override must STILL render the zone-level
+// default-deny posture line, because that posture governs every non-overridden
+// interface in the zone. The override block is additional context printed below
+// it, not a replacement for it.
+//
+// RED-on-revert: restoring the old `&& len(v.Interfaces) == 0` clause on the
+// posture guard suppresses the "Host-inbound: default deny (...)" line whenever
+// any interface override exists, failing the posture assertion here.
+func TestHostInboundViewRenderZonePostureWithOverride3671(t *testing.T) {
+	labels := HostInboundLabels{Indent: "  ", Sep: ", ", ServicesLabel: "Host-inbound system-services", ProtocolsLabel: "Host-inbound protocols"}
+
+	// A zone with no zone-level stanza at all, but an override on ONE interface.
+	// The zone default-deny posture (reason "no stanza") governs the other,
+	// non-overridden interfaces and must remain visible.
+	z := &ZoneConfig{
+		InterfaceHostInbound: map[string]*HostInboundTraffic{
+			"ge-0/0/9.0": {SystemServices: []string{"https"}},
+		},
+	}
+	lines := z.HostInboundView().Render(labels)
+	out := strings.Join(lines, "\n")
+	for _, want := range []string{
+		// zone-level default-deny posture line — MUST survive the override
+		"Host-inbound: default deny (no stanza)",
+		// override block still rendered below the posture line
+		"Host-inbound interface overrides:",
+		"ge-0/0/9.0:",
+		"override system-services: https",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("no-stanza zone + override render missing %q\n%s", want, out)
+		}
+	}
+	// Ordering: the zone posture line precedes the override block (posture is the
+	// baseline, overrides are additional context).
+	postureIdx, overrideIdx := -1, -1
+	for i, ln := range lines {
+		if strings.Contains(ln, "Host-inbound: default deny") {
+			postureIdx = i
+		}
+		if strings.Contains(ln, "Host-inbound interface overrides:") {
+			overrideIdx = i
+		}
+	}
+	if postureIdx < 0 || overrideIdx < 0 || postureIdx > overrideIdx {
+		t.Errorf("expected zone posture line before override block; posture=%d override=%d\n%s",
+			postureIdx, overrideIdx, out)
+	}
+
+	// An EXPLICIT-EMPTY zone stanza with an override: posture reason distinguishes
+	// it as "empty stanza" and still renders alongside the override block.
+	z = &ZoneConfig{
+		HostInboundTraffic: &HostInboundTraffic{},
+		InterfaceHostInbound: map[string]*HostInboundTraffic{
+			"ge-0/0/9.0": {SystemServices: []string{"https"}},
+		},
+	}
+	out = strings.Join(z.HostInboundView().Render(labels), "\n")
+	if !strings.Contains(out, "Host-inbound: default deny (empty stanza)") {
+		t.Errorf("empty-stanza zone + override render missing posture line\n%s", out)
+	}
+	if !strings.Contains(out, "Host-inbound interface overrides:") {
+		t.Errorf("empty-stanza zone + override render missing override block\n%s", out)
+	}
+}
+
 func TestRenderInterfaceHostInbound3654(t *testing.T) {
 	labels := HostInboundLabels{Indent: "  ", Sep: ", ", ServicesLabel: "Host-inbound services", ProtocolsLabel: "Host-inbound protocols"}
 	z := &ZoneConfig{


### PR DESCRIPTION
Closes #3671

## Problem
The shared host-inbound presenter added in #3654
(`pkg/config/host_inbound_view.go`, `HostInboundView.Render`) gated the
zone-level `Host-inbound: default deny (...)` posture line on
`len(v.ZoneSystemServices) == 0 && len(v.ZoneProtocols) == 0 && len(v.Interfaces) == 0`.

The `len(v.Interfaces) == 0` clause means: if a zone has ANY per-interface
host-inbound override, the zone-level default-deny posture line is NOT emitted —
even though that posture still governs every NON-overridden interface in the
zone. A zone with an empty zone-level set and an override on one interface
printed only the override block and nothing about its default posture, so for
the rest of the zone "not shown" read as "not enforced".

Host-inbound is a security boundary; a partial interface override must not erase
the visible default posture for the rest of the zone.

## Fix
Drop the `len(v.Interfaces) == 0` clause from the guard. The zone-level
default-deny line is now emitted whenever the zone-level service AND protocol
lists are both empty, regardless of whether interface overrides exist. The
override blocks are still rendered, below the posture line, as additional
context — never a replacement for it.

The fix is in the shared presenter, so it propagates to all six #3654 surfaces:
local `show security zones` / `show interfaces` / `test security-zone
interface`, the gRPC text zones + interface diagnostic, and the remote
`cmd/cli` zone view.

## Tests (folds the #3654 L03 gap)
- Presenter: `TestHostInboundViewRenderZonePostureWithOverride3671` — a no-stanza
  zone + one override renders BOTH the default-deny posture line and the override
  block (posture ordered before the override block); an explicit-empty-stanza
  zone + override reports the "empty stanza" reason.
- Surface: `TestShowSecurityZonesZonePostureWithOverride3671` — `show security
  zones` filtered to the `edge` zone (override, no zone stanza). Discriminating
  where the pre-existing `TestShowSecurityZonesHostInbound3654` is not: that
  test's posture assertion is satisfied by the unrelated `open` zone.

Both tests go RED when the old `&& len(v.Interfaces) == 0` guard clause is
restored (verified).

## Validation
- `go test ./pkg/config/... ./pkg/cli/... ./pkg/grpcapi/... ./cmd/cli/...` green
- `go build ./pkg/... ./cmd/...` clean
- gofmt + vet clean on touched files (pre-existing `pkg/cli/cli.go:503`
  unreachable-code vet note is unrelated)
- No surface golden fixture regressed from the added posture line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi