### PR TITLE
grpcapi: fix policy-detail text drift — (except) inversion, session-log modes, Index (#3667)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-01 — #3667 gRPC policy-detail text parity (except marker + session-log modes + Index)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3667 — the gRPC-rendered `show security policies detail`
+    text surface (showPoliciesDetail) had drifted from the local CLI
+    detail renderer. H01 (correctness): it printed
+    source-address-excluded / destination-address-excluded sets under a
+    plain `Source/Destination addresses:` header with NO `(except)`
+    marker — the OPPOSITE security meaning. H04: it collapsed the
+    independent session-init/session-close log modes into a bare `log`.
+    H05: it omitted the runtime policy `Index` needed to map an RT_FLOW /
+    policy-deny log line back to the detail row. Fixed all three in BOTH
+    the zone-pair and global blocks: `(except)` header annotation,
+    `Session log: at-create, at-close`, and `, Index: <N>` from the
+    RuntimePolicyIDs SSOT. Lifted shared helpers to prevent re-drift
+    (L04): `config.PolicyLog.SessionLogModes()`, reuse of the existing
+    `dpuserspace.RuntimePolicyIndex` (local CLI now delegates to it), and
+    a single `printAddrs` closure inside showPoliciesDetail.
+  - **File(s)**: pkg/grpcapi/server_show_policies_text.go,
+    pkg/config/types_security.go, pkg/dataplane/userspace/policies.go,
+    pkg/cli/cli_show_security.go
+  - **Action**: Adjust the #3062 scheduler-state gRPC detail test whose
+    active / no-provider assertions matched `action-type: Permit\n` (the
+    new `, Index: N` suffix breaks the trailing-newline match) to
+    `action-type: Permit, Index: `, which still proves no State suffix
+    was inserted between action-type and Index.
+  - **File(s)**: pkg/grpcapi/server_show_policies_scheduler_3062_test.go
+  - **Action**: Add the RED-on-revert golden test — excluded source +
+    excluded destination (zone-pair AND global), session-init-only,
+    session-close-only, both, plus the runtime Index value matched
+    against the SSOT. Verified RED against the origin/master renderer.
+  - **File(s)**: pkg/grpcapi/server_show_policies_text_exclusion_3667_test.go (new)
+  - **Action**: Document the gRPC text detail parity (#3667) under the
+    policy-detail match-inversion / session-log / Index notes.
+  - **File(s)**: docs/junos-cli-reference.md, _Log.md
+
 ## 2026-07-01 — #3661 split reject RATE-LIMIT drop by source (Rust leg, M02 follow-up to #3657)
 
 - **Timestamp**: 2026-07-01

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -641,6 +641,15 @@ Policy: log-control4, action-type: permit, services-offload:not-configured , Sta
     alongside the independent `log_session_init` / `log_session_close`
     modes and the runtime `policy_id` / `rule_id` (the latter joins a
     runtime event back to an inventory row).
+    - **gRPC text parity (#3667):** the gRPC-rendered
+      `show security policies detail` text surface annotates its
+      `      Source addresses (except):` / `      Destination addresses
+      (except):` headers the same way (both the zone-pair and global
+      blocks). Before #3667 that surface printed the excluded set under a
+      plain header — the OPPOSITE security meaning — while also collapsing
+      the log modes into a bare `log` and omitting the Index; it now prints
+      `Session log: at-create, at-close` and `, Index: <N>` (the runtime
+      policy ID) in the per-policy header, matching the local CLI.
 - **Application block:** 2-space indent for app name, 4-space for protocol details, 6-space for ports.
   - `IP protocol: tcp|udp|0, ALG: 0, Inactivity timeout: <seconds>`
   - `Source port range: [<low>-<high>]`

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -14,16 +14,13 @@ import (
 // runtimePolicyIndex returns the span-accumulated runtime/RT_FLOW policy ID for
 // the policy at (policySetID, sliceIndex), used as the displayed detail `Index`
 // so it matches the numeric policy ID the RT_FLOW/event path logs (#3063). It
-// falls back to the raw ordinal policySetID*MaxRulesPerPolicy + sliceIndex when
-// the lookup has no entry (e.g. a config the dataplane would reject for
-// MaxRulesPerPolicy overflow), which is byte-identical to the pre-#3063 value.
+// delegates to dpuserspace.RuntimePolicyIndex — the SSOT shared with the gRPC
+// text detail renderer (#3667) — which falls back to the raw ordinal
+// policySetID*MaxRulesPerPolicy + sliceIndex when the lookup has no entry.
 // This is a DISPLAY identity only — it is NOT the counter handle passed to
 // ReadPolicyCounters (that stays the raw ordinal; see policyRuleIDForCounter).
 func runtimePolicyIndex(ids map[[2]uint32]uint32, policySetID, sliceIndex uint32) uint32 {
-	if id, ok := ids[[2]uint32{policySetID, sliceIndex}]; ok {
-		return id
-	}
-	return policySetID*dataplane.MaxRulesPerPolicy + sliceIndex
+	return dpuserspace.RuntimePolicyIndex(ids, policySetID, sliceIndex)
 }
 
 func (c *CLI) showPoliciesHitCount(cfg *config.Config, fromZone, toZone string) error {
@@ -270,17 +267,8 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 				fmt.Printf("  Application: %s\n", app)
 				c.printAppDetail(cfg, app)
 			}
-			if pol.Log != nil {
-				parts := []string{}
-				if pol.Log.SessionInit {
-					parts = append(parts, "at-create")
-				}
-				if pol.Log.SessionClose {
-					parts = append(parts, "at-close")
-				}
-				if len(parts) > 0 {
-					fmt.Printf("  Session log: %s\n", strings.Join(parts, ", "))
-				}
+			if modes := pol.Log.SessionLogModes(); len(modes) > 0 {
+				fmt.Printf("  Session log: %s\n", strings.Join(modes, ", "))
 			}
 			seqNum++
 		}
@@ -340,17 +328,8 @@ func (c *CLI) showPoliciesDetail(cfg *config.Config, fromZone, toZone string) er
 				fmt.Printf("  Application: %s\n", app)
 				c.printAppDetail(cfg, app)
 			}
-			if pol.Log != nil {
-				parts := []string{}
-				if pol.Log.SessionInit {
-					parts = append(parts, "at-create")
-				}
-				if pol.Log.SessionClose {
-					parts = append(parts, "at-close")
-				}
-				if len(parts) > 0 {
-					fmt.Printf("  Session log: %s\n", strings.Join(parts, ", "))
-				}
+			if modes := pol.Log.SessionLogModes(); len(modes) > 0 {
+				fmt.Printf("  Session log: %s\n", strings.Join(modes, ", "))
 			}
 			seqNum++
 

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -371,6 +371,29 @@ type PolicyLog struct {
 	SessionClose bool
 }
 
+// SessionLogModes returns the enabled session-log trigger tokens in Junos
+// display order: "at-create" when SessionInit is set (log at session start)
+// and "at-close" when SessionClose is set (log at session teardown). A nil
+// receiver, or a log block with neither trigger enabled, returns nil so a
+// caller can gate the "Session log:" line on len()>0.
+//
+// This is the single source of truth for the session-log display token set
+// shared by the local CLI detail renderer and the gRPC text detail renderer
+// (#3667), so the two surfaces cannot drift on the at-create/at-close labels.
+func (l *PolicyLog) SessionLogModes() []string {
+	if l == nil {
+		return nil
+	}
+	var modes []string
+	if l.SessionInit {
+		modes = append(modes, "at-create")
+	}
+	if l.SessionClose {
+		modes = append(modes, "at-close")
+	}
+	return modes
+}
+
 // NATConfig holds NAT configuration.
 type NATConfig struct {
 	Source               []*NATRuleSet

--- a/pkg/dataplane/userspace/policies.go
+++ b/pkg/dataplane/userspace/policies.go
@@ -1206,7 +1206,9 @@ func StablePolicyRuleID(fromZone, toZone, ruleName string) string {
 // identity an inventory surface should report as policy_id so it matches the
 // numeric ID the RT_FLOW/event path logs; it is NOT the counter handle passed
 // to ReadPolicyCounters (callers keep passing the raw ordinal). Exported for
-// the REST/gRPC inventory surfaces (#3336); the CLI keeps its own copy.
+// the REST/gRPC inventory surfaces (#3336), the gRPC text detail renderer, and
+// the local CLI detail renderer (which now delegates here) so the Index column
+// cannot drift across surfaces (#3667).
 func RuntimePolicyIndex(ids map[[2]uint32]uint32, policySetID, sliceIndex uint32) uint32 {
 	if id, ok := ids[[2]uint32{policySetID, sliceIndex}]; ok {
 		return id

--- a/pkg/grpcapi/server_show_policies_scheduler_3062_test.go
+++ b/pkg/grpcapi/server_show_policies_scheduler_3062_test.go
@@ -98,8 +98,11 @@ func TestGRPCShowPoliciesDetailReflectsSchedulerInactive(t *testing.T) {
 	if !strings.Contains(out, "Policy: g-sched-off, action-type: Permit, State: inactive, Scheduler: workhours") {
 		t.Fatalf("gRPC detail missing inactive global scheduler-bound policy state:\n%s", out)
 	}
-	// The plain policy header must stay bit-identical (no State suffix).
-	if !strings.Contains(out, "Policy: plain-allow, action-type: Permit\n") {
+	// The plain policy header must stay suffix-free (no State suffix). The
+	// #3667 Index column follows action-type directly for an active policy, so
+	// matching "action-type: Permit, Index: " proves no State suffix was
+	// inserted between them.
+	if !strings.Contains(out, "Policy: plain-allow, action-type: Permit, Index: ") {
 		t.Fatalf("gRPC detail changed plain (active) policy header:\n%s", out)
 	}
 }
@@ -111,7 +114,7 @@ func TestGRPCShowPoliciesDetailActiveSchedulerNoSuffix(t *testing.T) {
 	var buf strings.Builder
 	s.showPoliciesDetail("", &buf)
 	out := buf.String()
-	if !strings.Contains(out, "Policy: sched-off, action-type: Permit\n") {
+	if !strings.Contains(out, "Policy: sched-off, action-type: Permit, Index: ") {
 		t.Fatalf("active scheduler policy should keep bit-identical header:\n%s", out)
 	}
 	if strings.Contains(out, "State: inactive") {
@@ -126,7 +129,7 @@ func TestGRPCShowPoliciesDetailNoProviderNoSuffix(t *testing.T) {
 	var buf strings.Builder
 	s.showPoliciesDetail("", &buf)
 	out := buf.String()
-	if !strings.Contains(out, "Policy: sched-off, action-type: Permit\n") {
+	if !strings.Contains(out, "Policy: sched-off, action-type: Permit, Index: ") {
 		t.Fatalf("no-provider fallback should keep bit-identical header:\n%s", out)
 	}
 	if strings.Contains(out, "State: inactive") {

--- a/pkg/grpcapi/server_show_policies_text.go
+++ b/pkg/grpcapi/server_show_policies_text.go
@@ -278,6 +278,32 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 	// it must honor the knob for cross-surface consistency.
 	statsEnabled := cfg.Security.PolicyStatsEnabled
 	schedActive, haveSched := s.policySchedulerActiveState()
+	// #3667 (H05): the displayed Index must equal the runtime/RT_FLOW policy ID
+	// so a remote operator can map a policy-deny/RT_FLOW log line (which carries
+	// the numeric policy ID) back to the detail row. RuntimePolicyIDs is the same
+	// SSOT the local CLI detail + REST/gRPC structured inventory key off.
+	runtimeIDs := dpuserspace.RuntimePolicyIDs(cfg)
+	// #3667 (H01, correctness): shared source/destination address renderer.
+	// When the match sense is inverted (source-address-excluded /
+	// destination-address-excluded) the header is annotated "(except)" so the
+	// gRPC text detail shows the SAME security meaning as the rule and the local
+	// CLI — the rule matches every address EXCEPT those listed. Printing the
+	// listed addresses under a plain header showed the OPPOSITE meaning.
+	printAddrs := func(label string, addrs []string, excluded bool) {
+		if excluded {
+			fmt.Fprintf(buf, "      %s (except):\n", label)
+		} else {
+			fmt.Fprintf(buf, "      %s:\n", label)
+		}
+		for _, addr := range addrs {
+			resolved := grpcResolveAddress(cfg, addr)
+			// #3358: unqualify a synthetic zone-local key (#3061,
+			// zone-local/<zone>/<name>) to the authored book name so the
+			// internal compiler token never leaks; resolution still keys off
+			// the qualified token (it is the global-book key).
+			fmt.Fprintf(buf, "        %s%s\n", config.DisplayAddressName(addr), resolved)
+		}
+	}
 	// #3408: surface a per-policy counter read failure as a warning AFTER all
 	// reads rather than silently omitting the session-statistics block.
 	var readErr error
@@ -313,40 +339,29 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			// the scheduler name. Active/non-scheduled policies stay
 			// bit-identical (no suffix), keeping the gRPC text plane in
 			// agreement with the CLI detail surface.
-			fmt.Fprintf(buf, "\n  Policy: %s, action-type: %s%s\n", pol.Name, capAction,
-				policyDetailStateSuffix(pol.SchedulerName, schedActive, haveSched))
+			fmt.Fprintf(buf, "\n  Policy: %s, action-type: %s%s, Index: %d\n", pol.Name, capAction,
+				policyDetailStateSuffix(pol.SchedulerName, schedActive, haveSched),
+				dpuserspace.RuntimePolicyIndex(runtimeIDs, policySetID, uint32(i)))
 			if pol.Description != "" {
 				fmt.Fprintf(buf, "    Description: %s\n", pol.Description)
 			}
 			fmt.Fprintf(buf, "    Match:\n")
 			fmt.Fprintf(buf, "      Source zone: %s\n", zpp.FromZone)
 			fmt.Fprintf(buf, "      Destination zone: %s\n", zpp.ToZone)
-			fmt.Fprintf(buf, "      Source addresses:\n")
-			for _, addr := range pol.Match.SourceAddresses {
-				resolved := grpcResolveAddress(cfg, addr)
-				// #3358: unqualify a synthetic zone-local key (#3061,
-				// zone-local/<zone>/<name>) to the authored book name so the
-				// internal compiler token never leaks; resolution still keys
-				// off the qualified token (it is the global-book key).
-				fmt.Fprintf(buf, "        %s%s\n", config.DisplayAddressName(addr), resolved)
-			}
-			fmt.Fprintf(buf, "      Destination addresses:\n")
-			for _, addr := range pol.Match.DestinationAddresses {
-				resolved := grpcResolveAddress(cfg, addr)
-				// #3358: unqualify a synthetic zone-local key (#3061,
-				// zone-local/<zone>/<name>) to the authored book name so the
-				// internal compiler token never leaks; resolution still keys
-				// off the qualified token (it is the global-book key).
-				fmt.Fprintf(buf, "        %s%s\n", config.DisplayAddressName(addr), resolved)
-			}
+			printAddrs("Source addresses", pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded)
+			printAddrs("Destination addresses", pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded)
 			fmt.Fprintf(buf, "      Applications:\n")
 			for _, app := range pol.Match.Applications {
 				fmt.Fprintf(buf, "        %s\n", app)
 			}
 			fmt.Fprintf(buf, "    Then:\n")
 			fmt.Fprintf(buf, "      %s\n", action)
-			if pol.Log != nil {
-				fmt.Fprintf(buf, "      log\n")
+			// #3667 (H04): surface the independent at-create/at-close session-log
+			// modes instead of a bare "log" so a remote operator can tell whether
+			// session starts, closes, or both are logged (different cost + audit
+			// meaning). SessionLogModes is the SSOT shared with the local CLI.
+			if modes := pol.Log.SessionLogModes(); len(modes) > 0 {
+				fmt.Fprintf(buf, "      Session log: %s\n", strings.Join(modes, ", "))
 			}
 			if pol.Count {
 				fmt.Fprintf(buf, "      count\n")
@@ -393,8 +408,9 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			capAction := strings.ToUpper(action[:1]) + action[1:]
 			ruleID := policySetID*dataplane.MaxRulesPerPolicy + uint32(i)
 			// #3062: scheduler-inactive global policy appends State: inactive.
-			fmt.Fprintf(buf, "\n  Policy: %s, action-type: %s%s\n", pol.Name, capAction,
-				policyDetailStateSuffix(pol.SchedulerName, schedActive, haveSched))
+			fmt.Fprintf(buf, "\n  Policy: %s, action-type: %s%s, Index: %d\n", pol.Name, capAction,
+				policyDetailStateSuffix(pol.SchedulerName, schedActive, haveSched),
+				dpuserspace.RuntimePolicyIndex(runtimeIDs, policySetID, uint32(i)))
 			if pol.Description != "" {
 				fmt.Fprintf(buf, "    Description: %s\n", pol.Description)
 			}
@@ -408,32 +424,20 @@ func (s *Server) showPoliciesDetail(filter string, buf *strings.Builder) {
 			if pol.Match.ToZone != "" {
 				fmt.Fprintf(buf, "      Destination zone: %s\n", pol.Match.ToZone)
 			}
-			fmt.Fprintf(buf, "      Source addresses:\n")
-			for _, addr := range pol.Match.SourceAddresses {
-				resolved := grpcResolveAddress(cfg, addr)
-				// #3358: unqualify a synthetic zone-local key (#3061,
-				// zone-local/<zone>/<name>) to the authored book name so the
-				// internal compiler token never leaks; resolution still keys
-				// off the qualified token (it is the global-book key).
-				fmt.Fprintf(buf, "        %s%s\n", config.DisplayAddressName(addr), resolved)
-			}
-			fmt.Fprintf(buf, "      Destination addresses:\n")
-			for _, addr := range pol.Match.DestinationAddresses {
-				resolved := grpcResolveAddress(cfg, addr)
-				// #3358: unqualify a synthetic zone-local key (#3061,
-				// zone-local/<zone>/<name>) to the authored book name so the
-				// internal compiler token never leaks; resolution still keys
-				// off the qualified token (it is the global-book key).
-				fmt.Fprintf(buf, "        %s%s\n", config.DisplayAddressName(addr), resolved)
-			}
+			printAddrs("Source addresses", pol.Match.SourceAddresses, pol.Match.SourceAddressExcluded)
+			printAddrs("Destination addresses", pol.Match.DestinationAddresses, pol.Match.DestinationAddressExcluded)
 			fmt.Fprintf(buf, "      Applications:\n")
 			for _, app := range pol.Match.Applications {
 				fmt.Fprintf(buf, "        %s\n", app)
 			}
 			fmt.Fprintf(buf, "    Then:\n")
 			fmt.Fprintf(buf, "      %s\n", action)
-			if pol.Log != nil {
-				fmt.Fprintf(buf, "      log\n")
+			// #3667 (H04): surface the independent at-create/at-close session-log
+			// modes instead of a bare "log" so a remote operator can tell whether
+			// session starts, closes, or both are logged (different cost + audit
+			// meaning). SessionLogModes is the SSOT shared with the local CLI.
+			if modes := pol.Log.SessionLogModes(); len(modes) > 0 {
+				fmt.Fprintf(buf, "      Session log: %s\n", strings.Join(modes, ", "))
 			}
 			if pol.Count {
 				fmt.Fprintf(buf, "      count\n")

--- a/pkg/grpcapi/server_show_policies_text_exclusion_3667_test.go
+++ b/pkg/grpcapi/server_show_policies_text_exclusion_3667_test.go
@@ -1,0 +1,183 @@
+package grpcapi
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// #3667: the gRPC-rendered `show security policies detail` text surface
+// (showPoliciesDetail, server_show_policies_text.go) had drifted from the local
+// CLI detail renderer. It dropped:
+//
+//   - H01 (correctness): the address-exclusion "(except)" marker, so an
+//     inverted (source-address-excluded / destination-address-excluded) rule
+//     rendered with the OPPOSITE security meaning — it printed the listed
+//     addresses as if they were the match set instead of the excepted set.
+//   - H04: the independent session-init / session-close log modes, collapsed
+//     into a bare "log".
+//   - H05: the runtime policy Index, needed to map an RT_FLOW / policy-deny log
+//     line back to the detail row.
+//
+// This is the fail-on-revert guard. The config below covers an excluded SOURCE
+// set, an excluded DESTINATION set (zone-pair AND global blocks), session-init
+// only, session-close only, and both, plus the Index column.
+
+func exclusion3667GRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    address-book {
+        global {
+            address bad-src 203.0.113.0/24;
+            address bad-dst 198.51.100.0/24;
+            address mgmt-net 10.0.0.0/8;
+        }
+    }
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy excl-src {
+                match {
+                    source-address bad-src;
+                    source-address-excluded;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    deny;
+                    log { session-init; }
+                }
+            }
+            policy excl-dst {
+                match {
+                    source-address any;
+                    destination-address bad-dst;
+                    destination-address-excluded;
+                    application any;
+                }
+                then {
+                    deny;
+                    log { session-close; }
+                }
+            }
+            policy both-log {
+                match { source-address any; destination-address any; application any; }
+                then {
+                    permit;
+                    log { session-init; session-close; }
+                }
+            }
+        }
+        global {
+            policy g-excl {
+                match {
+                    source-address any;
+                    destination-address mgmt-net;
+                    destination-address-excluded;
+                    application any;
+                }
+                then {
+                    deny;
+                    log { session-init; session-close; }
+                }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// lineContaining returns the first output line containing needle.
+func lineContaining(t *testing.T, out, needle string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	t.Fatalf("no line containing %q in output:\n%s", needle, out)
+	return ""
+}
+
+func TestGRPCShowPoliciesDetailTextExclusionLogAndIndex(t *testing.T) {
+	s := &Server{store: exclusion3667GRPCStore(t)}
+
+	var buf strings.Builder
+	s.showPoliciesDetail("", &buf)
+	out := buf.String()
+
+	// H01 (correctness): the inverted source set is annotated "(except)".
+	// On revert (printAddrs drops the excluded branch) the header prints the
+	// plain "Source addresses:" and the listed address reads as the match set —
+	// the OPPOSITE security meaning — so this goes RED.
+	if !strings.Contains(out, "Source addresses (except):") {
+		t.Fatalf("gRPC detail dropped the (except) source-exclusion marker "+
+			"(H01 correctness — inverted rule rendered as its opposite):\n%s", out)
+	}
+	// H01: the inverted destination set is annotated "(except)". Two policies
+	// use it (zone-pair excl-dst + global g-excl), proving BOTH blocks render
+	// the marker.
+	if got := strings.Count(out, "Destination addresses (except):"); got < 2 {
+		t.Fatalf("gRPC detail rendered %d destination (except) markers, want >=2 "+
+			"(zone-pair + global blocks — H01 correctness):\n%s", got, out)
+	}
+	// The global block specifically must carry the destination (except) marker.
+	if _, after, ok := strings.Cut(out, "Global policies:"); !ok ||
+		!strings.Contains(after, "Destination addresses (except):") {
+		t.Fatalf("global-policy block dropped the destination (except) marker (H01):\n%s", out)
+	}
+
+	// H04: session-init / session-close render as distinct modes, not a bare
+	// "log". On revert (bare "log") none of these appear -> RED.
+	if !strings.Contains(out, "Session log: at-create\n") {
+		t.Fatalf("gRPC detail missing session-init-only mode (H04):\n%s", out)
+	}
+	if !strings.Contains(out, "Session log: at-close\n") {
+		t.Fatalf("gRPC detail missing session-close-only mode (H04):\n%s", out)
+	}
+	if !strings.Contains(out, "Session log: at-create, at-close\n") {
+		t.Fatalf("gRPC detail missing both-modes session log (H04):\n%s", out)
+	}
+	// The collapsed bare "log" line must be gone entirely.
+	if strings.Contains(out, "\n      log\n") {
+		t.Fatalf("gRPC detail still emits the collapsed bare \"log\" line (H04):\n%s", out)
+	}
+
+	// H05: the header carries the runtime Index (the numeric ID the RT_FLOW /
+	// policy-deny path logs), from the RuntimePolicyIDs SSOT. Verify both the
+	// presence and that the value matches the SSOT, for a zone-pair AND a
+	// global policy. On revert (no Index) -> RED.
+	cfg := s.store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("active config is nil")
+	}
+	runtimeIDs := dpuserspace.RuntimePolicyIDs(cfg)
+	wantZP := dpuserspace.RuntimePolicyIndex(runtimeIDs, 0, 0)     // excl-src: set 0, slice 0
+	wantGlobal := dpuserspace.RuntimePolicyIndex(runtimeIDs, 1, 0) // g-excl: global set (== len(Policies)), slice 0
+	zpLine := lineContaining(t, out, "Policy: excl-src, action-type:")
+	if !strings.Contains(zpLine, fmt.Sprintf(", Index: %d", wantZP)) {
+		t.Fatalf("zone-pair policy header %q missing runtime Index %d (H05)", zpLine, wantZP)
+	}
+	gLine := lineContaining(t, out, "Policy: g-excl, action-type:")
+	if !strings.Contains(gLine, fmt.Sprintf(", Index: %d", wantGlobal)) {
+		t.Fatalf("global policy header %q missing runtime Index %d (H05)", gLine, wantGlobal)
+	}
+}


### PR DESCRIPTION
Closes #3667

## Problem
The gRPC-rendered `show security policies detail` text surface
(`pkg/grpcapi/server_show_policies_text.go` `showPoliciesDetail`,
dispatched at `server_show.go:303`) had drifted from the local
interactive CLI detail renderer (`pkg/cli/cli_show_security.go`), so a
remote/server operator saw strictly less than a local operator — and, in
one case, the OPPOSITE security meaning.

- **H01 (High, correctness):** address-exclusion `(except)` marker was
  dropped. The renderer printed `pol.Match.SourceAddresses` /
  `DestinationAddresses` raw even though the config carries
  `SourceAddressExcluded` / `DestinationAddressExcluded` and the runtime
  inverts the match. A rule authored as
  `source-address bad-host + source-address-excluded` means "any source
  EXCEPT bad-host", but the text detail printed
  `Source addresses: bad-host` — the inverted meaning, a permit/deny
  auditing hazard.
- **H04 (Medium):** session-init vs session-close collapsed into a bare
  `log`, so a remote operator could not tell whether session starts,
  closes, or both were logged.
- **H05 (Medium):** the runtime policy `Index` was omitted, so an
  operator could not map an RT_FLOW / policy-deny log line (which carries
  the numeric policy ID) back to the detail row.

## Fix
Bring `showPoliciesDetail` to parity with the local CLI in BOTH the
zone-pair and global blocks:

- annotate the header `Source addresses (except):` /
  `Destination addresses (except):` when the match sense is inverted;
- print `Session log: at-create, at-close` from the independent
  `SessionInit` / `SessionClose` modes;
- print `, Index: <N>` using the runtime policy ID.

To keep the surfaces from re-drifting (L04), shared logic is lifted into
SSOT helpers:

- `config.PolicyLog.SessionLogModes()` — the at-create/at-close token
  set, used by both the gRPC text and local CLI renderers;
- `dpuserspace.RuntimePolicyIndex` (already exported for the REST/gRPC
  inventory) now also sources the gRPC text Index; the local CLI's
  `runtimePolicyIndex` wrapper delegates to it instead of keeping its own
  copy;
- a single `printAddrs` closure inside `showPoliciesDetail` unifies the
  source/destination rendering across both blocks.

## Test (L01, RED-on-revert)
New golden `TestGRPCShowPoliciesDetailTextExclusionLogAndIndex` covers an
excluded source set, an excluded destination set (zone-pair AND global),
session-init-only / session-close-only / both, and the Index — with the
Index value matched against the `RuntimePolicyIDs` SSOT for a zone-pair
and a global policy. Confirmed RED against the origin/master renderer
(plain headers, bare `log`, no Index); GREEN with the fix.

The #3062 scheduler-state gRPC test is adjusted: its active / no-provider
assertions matched `action-type: Permit\n`, which the new `, Index: N`
suffix breaks; they now match `action-type: Permit, Index: ` (still
proving no State suffix was inserted between action-type and Index).

## Validation
- `go build ./pkg/... ./cmd/...`
- `go test ./pkg/grpcapi/... ./pkg/cli/... ./pkg/config/... ./pkg/dataplane/userspace/...` — all green
- `gofmt` clean on all changed files; `go vet` clean (only the
  pre-existing `pkg/cli/cli.go:503` unreachable-code warning remains)
- Docs updated: `docs/junos-cli-reference.md` policy-detail notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
