### PR TITLE
cmd/cli: surface GetPolicies error in show security zones + render dropped PolicyRule fields (#3669, #3672)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24963,3 +24963,17 @@ top.
 - **File(s)**: pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go (new), pkg/grpcapi/server_show_zones_policy_tiers_3658_test.go (new)
 - **Action**: Document the detail-mode three-tier policy summary
 - **File(s)**: docs/junos-cli-reference.md, _Log.md
+
+## 2026-07-01 — #3669 + #3672 remote CLI show.go fixes
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3669 (H03) — stop swallowing the GetPolicies RPC error in remote `show security zones` (showZones). Capture polErr; render zone bodies (GetZones succeeded) then return a wrapped "policy inventory unavailable" error so a control-plane failure exits non-zero instead of rendering zones as policy-free with exit 0
+- **File(s)**: cmd/cli/show.go
+- **Action**: #3672 (M01-M04) — extend the non-detail renderRule to surface the wire fields it dropped: src/dst "(except)" exclusion markers (source/destination_address_excluded), session log modes (Log: at-create, at-close / enabled), scheduler + inactive state (Scheduler: <name> (inactive) / Inactive: true), and count state (Hit count printed even at zero for a `then count` rule). Plain rules render byte-identically to before
+- **File(s)**: cmd/cli/show.go
+- **Action**: Add getPoliciesErr/getZonesErr injection to the fake gRPC client
+- **File(s)**: cmd/cli/nontty_test.go
+- **Action**: Add RED-on-revert tests — #3669 error surfacing + happy path; #3672 all-metadata rendering, inactive-without-scheduler, and plain-rule-unchanged
+- **File(s)**: cmd/cli/show_zones_polerr_3669_test.go (new), cmd/cli/show_policies_metadata_3672_test.go (new)
+- **Action**: Document both fixes in the CLI reference (remote non-detail renderer metadata; policy-inventory failure fails loud)
+- **File(s)**: docs/junos-cli-reference.md, _Log.md

--- a/cmd/cli/nontty_test.go
+++ b/cmd/cli/nontty_test.go
@@ -49,18 +49,24 @@ type fakeBpfrxClient struct {
 	matchPoliciesResp  *pb.MatchPoliciesResponse
 
 	// GetPolicies recorder (#3357 remote filtered/brief scoped-global coverage).
+	// getPoliciesErr injects an RPC failure (#3669 error-surfacing coverage).
 	getPoliciesCalls int
 	getPoliciesResp  *pb.GetPoliciesResponse
+	getPoliciesErr   error
 
 	// GetZones recorder (#3654 remote host-inbound override / posture coverage).
 	getZonesCalls int
 	getZonesResp  *pb.GetZonesResponse
+	getZonesErr   error
 }
 
 func (f *fakeBpfrxClient) GetZones(
 	_ context.Context, _ *pb.GetZonesRequest, _ ...grpc.CallOption,
 ) (*pb.GetZonesResponse, error) {
 	f.getZonesCalls++
+	if f.getZonesErr != nil {
+		return nil, f.getZonesErr
+	}
 	if f.getZonesResp != nil {
 		return f.getZonesResp, nil
 	}
@@ -71,6 +77,9 @@ func (f *fakeBpfrxClient) GetPolicies(
 	_ context.Context, _ *pb.GetPoliciesRequest, _ ...grpc.CallOption,
 ) (*pb.GetPoliciesResponse, error) {
 	f.getPoliciesCalls++
+	if f.getPoliciesErr != nil {
+		return nil, f.getPoliciesErr
+	}
 	if f.getPoliciesResp != nil {
 		return f.getPoliciesResp, nil
 	}

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -495,7 +495,16 @@ func (c *ctl) showZones() error {
 		return fmt.Errorf("%v", err)
 	}
 
-	polResp, _ := c.client.GetPolicies(c.ctx(), &pb.GetPoliciesRequest{})
+	// #3669: do NOT swallow the GetPolicies error. GetZones succeeded, so the
+	// zone bodies are valid and worth printing, but if the policy inventory RPC
+	// failed the per-zone "Policies:" references are silently omitted — which
+	// reads identically to "these zones have no policies". On a firewall a
+	// partial policy view must fail loud: an operator (or automation scraping
+	// exit status) must be able to tell a control-plane degradation apart from
+	// genuinely policy-free zones. We render the zones, then surface the error so
+	// the command exits non-zero (see main.go dispatch) and the degraded state
+	// is visible rather than reported as success.
+	polResp, polErr := c.client.GetPolicies(c.ctx(), &pb.GetPoliciesRequest{})
 
 	for _, z := range resp.Zones {
 		if z.Id > 0 {
@@ -553,6 +562,9 @@ func (c *ctl) showZones() error {
 
 		fmt.Println()
 	}
+	if polErr != nil {
+		return fmt.Errorf("policy inventory unavailable (zone policy references omitted): %w", polErr)
+	}
 	return nil
 }
 
@@ -566,10 +578,58 @@ func (c *ctl) showPoliciesFiltered(fromZone, toZone string) error {
 		if rule.Description != "" {
 			fmt.Printf("    Description: %s\n", rule.Description)
 		}
-		fmt.Printf("    Match: src=%v dst=%v app=%v\n",
-			rule.SrcAddresses, rule.DstAddresses, rule.Applications)
+		// #3672 (M01): annotate "(except)" when the match sense is inverted
+		// (source-address-excluded / destination-address-excluded). Without it
+		// an exclusive ("all EXCEPT these") match reads identical to an
+		// inclusive one, inverting the rule's reachability meaning. Mirrors the
+		// local CLI detail "(except)" annotation and the gRPC/REST inventory
+		// booleans.
+		src := fmt.Sprintf("%v", rule.SrcAddresses)
+		if rule.SourceAddressExcluded {
+			src += " (except)"
+		}
+		dst := fmt.Sprintf("%v", rule.DstAddresses)
+		if rule.DestinationAddressExcluded {
+			dst += " (except)"
+		}
+		fmt.Printf("    Match: src=%s dst=%s app=%v\n", src, dst, rule.Applications)
 		fmt.Printf("    Action: %s\n", rule.Action)
-		if rule.HitPackets > 0 || rule.HitBytes > 0 {
+		// #3672 (M02): surface per-rule session logging. The wire carries the
+		// independent init/close modes (#3336); the collapsed `log` bool alone
+		// made a logged permit indistinguishable from an unlogged one and hid
+		// init-only vs close-only. Mirrors the local CLI "Session log:
+		// at-create, at-close".
+		if rule.Log || rule.LogSessionInit || rule.LogSessionClose {
+			var modes []string
+			if rule.LogSessionInit {
+				modes = append(modes, "at-create")
+			}
+			if rule.LogSessionClose {
+				modes = append(modes, "at-close")
+			}
+			if len(modes) > 0 {
+				fmt.Printf("    Log: %s\n", strings.Join(modes, ", "))
+			} else {
+				fmt.Printf("    Log: enabled\n")
+			}
+		}
+		// #3672 (M03): surface scheduler binding and runtime-inactive state
+		// (#3624). A scheduled rule outside its active window prints
+		// "Action: permit" while the dataplane skips/denies it (scheduler
+		// fail-closed) — the inactive annotation makes that visible.
+		switch {
+		case rule.SchedulerName != "" && rule.Inactive:
+			fmt.Printf("    Scheduler: %s (inactive)\n", rule.SchedulerName)
+		case rule.SchedulerName != "":
+			fmt.Printf("    Scheduler: %s\n", rule.SchedulerName)
+		case rule.Inactive:
+			fmt.Printf("    Inactive: true\n")
+		}
+		// #3672 (M04): a "then count" rule prints its hit count even at zero, so
+		// counted-but-idle is distinguishable from not-counted. A rule with hits
+		// prints them regardless (unchanged); an uncounted idle rule prints
+		// nothing (unchanged).
+		if rule.Count || rule.HitPackets > 0 || rule.HitBytes > 0 {
 			fmt.Printf("    Hit count: %d packets, %d bytes\n", rule.HitPackets, rule.HitBytes)
 		}
 	}

--- a/cmd/cli/show_policies_metadata_3672_test.go
+++ b/cmd/cli/show_policies_metadata_3672_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3672: the remote `show security policies` (non-detail) renderRule printed
+// only name / description / raw addresses / action / hits, silently dropping
+// security-relevant metadata the gRPC PolicyRule already carries (#3336/#3623/
+// #3624):
+//
+//   - M01: source_address_excluded / destination_address_excluded — an
+//     exclusive ("all EXCEPT these") match read identical to an inclusive one,
+//     inverting reachability meaning.
+//   - M02: log / log_session_init / log_session_close — a logged permit was
+//     indistinguishable from an unlogged one; init-only vs close-only hidden.
+//   - M03: scheduler_name / inactive — a scheduled rule outside its window
+//     printed "Action: permit" with no inactive annotation while the runtime
+//     skipped/denied it.
+//   - M04: count — a "then count" rule with zero hits printed nothing, so
+//     counted-but-idle was indistinguishable from not-counted.
+//
+// These tests lock the default remote output and are the fail-on-revert guard.
+
+func metadataPoliciesResp() *pb.GetPoliciesResponse {
+	return &pb.GetPoliciesResponse{
+		Policies: []*pb.PolicyInfo{
+			{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Rules: []*pb.PolicyRule{
+					{
+						Name:                       "block-except",
+						Action:                     "deny",
+						SrcAddresses:               []string{"trusted-net"},
+						DstAddresses:               []string{"blocked-net"},
+						Applications:               []string{"any"},
+						SourceAddressExcluded:      true,
+						DestinationAddressExcluded: true,
+						Log:                        true,
+						LogSessionInit:             true,
+						LogSessionClose:            true,
+						SchedulerName:              "workhours",
+						Inactive:                   true,
+						Count:                      true,
+						// zero hits: HitPackets/HitBytes deliberately unset.
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestRenderRuleSurfacesAllMetadata drives showPoliciesFiltered over a rule with
+// every metadata bit set and asserts the non-detail view renders each field.
+//
+// FAIL-ON-REVERT: restoring the old renderRule (name/desc/raw addr/action/hits)
+// drops every one of these lines, so each assertion goes RED.
+func TestRenderRuleSurfacesAllMetadata(t *testing.T) {
+	fake := &fakeBpfrxClient{getPoliciesResp: metadataPoliciesResp()}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesFiltered("trust", "untrust"); err != nil {
+			t.Fatalf("showPoliciesFiltered: %v", err)
+		}
+	})
+
+	// M01: exclusion "(except)" marker on both src and dst.
+	if !strings.Contains(out, "src=[trusted-net] (except)") {
+		t.Errorf("source-address-excluded not annotated (except):\n%s", out)
+	}
+	if !strings.Contains(out, "dst=[blocked-net] (except)") {
+		t.Errorf("destination-address-excluded not annotated (except):\n%s", out)
+	}
+	// M02: session log modes.
+	if !strings.Contains(out, "Log: at-create, at-close") {
+		t.Errorf("log session-init/close modes not rendered:\n%s", out)
+	}
+	// M03: scheduler name + inactive annotation.
+	if !strings.Contains(out, "Scheduler: workhours (inactive)") {
+		t.Errorf("scheduler/inactive state not rendered:\n%s", out)
+	}
+	// M04: counted-but-idle rule shows a zero hit count.
+	if !strings.Contains(out, "Hit count: 0 packets, 0 bytes") {
+		t.Errorf("counted rule with zero hits did not render count state:\n%s", out)
+	}
+}
+
+// TestRenderRuleInactiveWithoutScheduler pins the standalone inactive
+// annotation for a rule marked inactive without a scheduler name.
+func TestRenderRuleInactiveWithoutScheduler(t *testing.T) {
+	fake := &fakeBpfrxClient{getPoliciesResp: &pb.GetPoliciesResponse{
+		Policies: []*pb.PolicyInfo{{
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Rules:    []*pb.PolicyRule{{Name: "r", Action: "permit", Inactive: true}},
+		}},
+	}}
+	c := &ctl{client: fake}
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesFiltered("trust", "untrust"); err != nil {
+			t.Fatalf("showPoliciesFiltered: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Inactive: true") {
+		t.Errorf("inactive-without-scheduler not rendered:\n%s", out)
+	}
+}
+
+// TestRenderRulePlainRuleUnchanged guards the common path: an ordinary rule with
+// no metadata bits set renders no exclusion marker, no Log/Scheduler/Inactive
+// line, and no zero hit-count line (byte-identical to the pre-#3672 output).
+func TestRenderRulePlainRuleUnchanged(t *testing.T) {
+	fake := &fakeBpfrxClient{getPoliciesResp: &pb.GetPoliciesResponse{
+		Policies: []*pb.PolicyInfo{{
+			FromZone: "trust",
+			ToZone:   "untrust",
+			Rules: []*pb.PolicyRule{{
+				Name:         "allow-web",
+				Action:       "permit",
+				SrcAddresses: []string{"any"},
+				DstAddresses: []string{"web"},
+				Applications: []string{"junos-http"},
+			}},
+		}},
+	}}
+	c := &ctl{client: fake}
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesFiltered("trust", "untrust"); err != nil {
+			t.Fatalf("showPoliciesFiltered: %v", err)
+		}
+	})
+	for _, unwanted := range []string{"(except)", "Log:", "Scheduler:", "Inactive:", "Hit count:"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("plain rule rendered unexpected %q:\n%s", unwanted, out)
+		}
+	}
+}

--- a/cmd/cli/show_zones_polerr_3669_test.go
+++ b/cmd/cli/show_zones_polerr_3669_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3669: the remote `show security zones` view discarded the GetPolicies error
+// (`polResp, _ := ...`) and still returned success. When the policy inventory
+// RPC failed, the per-zone "Policies:" references were silently omitted — which
+// reads identically to "these zones have no policies" — and the command exited
+// 0. On a firewall a partial policy view must fail loud so an operator (or
+// automation scraping exit status) can tell a control-plane degradation apart
+// from genuinely policy-free zones.
+//
+// FAIL-ON-REVERT: restoring `polResp, _ := c.client.GetPolicies(...)` (dropping
+// the error) makes showZones return nil, so the "expected non-nil error"
+// assertion goes RED.
+func TestShowZonesSurfacesGetPoliciesError(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		getZonesResp: &pb.GetZonesResponse{
+			Zones: []*pb.ZoneInfo{
+				{Name: "trust", Interfaces: []string{"ge-0-0-0"}},
+			},
+		},
+		getPoliciesErr: errors.New("rpc failure: connection refused"),
+	}
+	c := &ctl{client: fake}
+
+	var out string
+	var err error
+	out = captureStdout(t, func() {
+		err = c.showZones()
+	})
+
+	if err == nil {
+		t.Fatal("showZones returned nil error when GetPolicies failed; " +
+			"a swallowed policy-inventory failure renders zones as policy-free " +
+			"with exit 0 (#3669)")
+	}
+	if !strings.Contains(err.Error(), "policy inventory unavailable") {
+		t.Errorf("error = %q, want it to name the degraded policy inventory", err)
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("error = %q, want it to wrap the underlying RPC error", err)
+	}
+	// GetZones succeeded, so the zone body is still rendered (partial output is
+	// preserved — the failure is surfaced via the returned error, not by
+	// swallowing valid zone data).
+	if !strings.Contains(out, "Zone: trust") {
+		t.Errorf("zone body not rendered on policy-inventory failure:\n%s", out)
+	}
+}
+
+// TestShowZonesSucceedsWhenPolicyInventoryOK guards the happy path: when
+// GetPolicies succeeds the command returns nil and renders the policy
+// references, so the #3669 error-surfacing change does not regress the normal
+// case.
+func TestShowZonesSucceedsWhenPolicyInventoryOK(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		getZonesResp: &pb.GetZonesResponse{
+			Zones: []*pb.ZoneInfo{
+				{Name: "trust", Interfaces: []string{"ge-0-0-0"}},
+			},
+		},
+		getPoliciesResp: &pb.GetPoliciesResponse{
+			Policies: []*pb.PolicyInfo{
+				{
+					FromZone: "trust",
+					ToZone:   "untrust",
+					Rules:    []*pb.PolicyRule{{Name: "allow-web", Action: "permit"}},
+				},
+			},
+		},
+	}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showZones(); err != nil {
+			t.Fatalf("showZones returned error on the happy path: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Policies: from untrust (1 rules)") {
+		t.Errorf("expected policy references rendered for trust zone:\n%s", out)
+	}
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -759,6 +759,29 @@ Global policies:
   `... brief` prints the per-rule `match_from_zone`/`match_to_zone` (falling back
   to `*`/`*` only for an unscoped global) instead of the group `*`. The shared
   selection predicate is `policymatch.GlobalPolicyAppliesToZonePair`.
+- **#3672 — remote non-detail renderer surfaces per-rule metadata.** The remote
+  CLI `show security policies` (non-detail) `renderRule` (`cmd/cli/show.go`)
+  previously printed only name / description / raw addresses / action / hits,
+  silently dropping security-relevant fields the gRPC `PolicyRule` already
+  carries (#3336 / #3623 / #3624). It now renders, matching the local/gRPC-text
+  surfaces:
+  - **Match inversion (M01):** `src=[...] (except)` / `dst=[...] (except)` when
+    `source_address_excluded` / `destination_address_excluded` is set — an
+    exclusive ("all EXCEPT these") match no longer reads identical to an
+    inclusive one.
+  - **Session logging (M02):** `Log: at-create, at-close` from the independent
+    `log_session_init` / `log_session_close` modes (falls back to `Log: enabled`
+    when only the collapsed `log` bool is set). A logged permit is no longer
+    indistinguishable from an unlogged one.
+  - **Scheduler state (M03):** `Scheduler: <name> (inactive)` (or
+    `Scheduler: <name>` when active), and `Inactive: true` for a rule marked
+    inactive without a scheduler name — a scheduled rule outside its active
+    window is no longer shown as a plain `Action: permit`.
+  - **Count state (M04):** a `then count` rule prints `Hit count: 0 packets,
+    0 bytes` even when idle, so counted-but-idle is distinguishable from
+    not-counted. A plain rule with no metadata bits set renders byte-identically
+    to the pre-#3672 output (no `(except)` / `Log:` / `Scheduler:` /
+    `Inactive:` / zero `Hit count:` lines).
 
 ---
 
@@ -820,6 +843,16 @@ Security zone: junos-host
   post-#3405). The gRPC text view labels the zone-level lines
   `Host-inbound system-services:` / `Host-inbound protocols:`.
 - Blank line between zones.
+- **#3669 — policy-inventory failure fails loud (remote CLI).** The remote
+  `show security zones` (`cmd/cli/show.go`) issues a second RPC (`GetPolicies`)
+  to render each zone's `Policies:` reference line. It previously discarded that
+  RPC's error (`polResp, _ := ...`) and returned success, so a control-plane
+  degradation rendered the zones as policy-free with exit 0 —
+  indistinguishable from zones that genuinely have no policies. The zone bodies
+  (from the successful `GetZones`) are still printed, but the command now
+  surfaces the `GetPolicies` error (`policy inventory unavailable ...`) and
+  exits non-zero so an operator or automation can tell a degraded partial view
+  apart from a truly empty one.
 
 **`show security zones detail` policy summary (#3658).** In `detail` mode
 each zone gains a `Policy summary` block that lists the policies that decide


### PR DESCRIPTION
Two error-hygiene / observability fixes in the remote CLI `cmd/cli/show.go`, both from codex-review-125. Rendering/error-handling only — the wire already carries every field involved.

## #3669 (H03) — `show security zones` swallowed the GetPolicies error
`showZones` used `polResp, _ := c.client.GetPolicies(...)`, discarding the RPC error and still returning success. On a control-plane failure the per-zone `Policies:` reference section was silently omitted and the command exited 0 — indistinguishable from zones that genuinely have no policies. Automation scraping exit status treats the zones as unprotected.

**Fix:** capture the error, still render the zone bodies (GetZones succeeded, so the partial output is valid and useful), then return a wrapped `policy inventory unavailable ...` error after the zone loop so the command exits non-zero and the degradation is visible.

## #3672 (M01-M04) — non-detail `renderRule` dropped PolicyRule metadata
The brief renderer printed only name / description / raw addresses / action / hits, dropping fields the gRPC `PolicyRule` already carries (#3336 / #3623 / #3624):
- **M01** `source/destination_address_excluded` → `src=[...] (except)` / `dst=[...] (except)` (an exclusive match no longer reads identical to an inclusive one).
- **M02** `log` / `log_session_init` / `log_session_close` → `Log: at-create, at-close` (or `Log: enabled`).
- **M03** `scheduler_name` / `inactive` → `Scheduler: <name> (inactive)` / `Scheduler: <name>` / `Inactive: true`.
- **M04** `count` → `Hit count: 0 packets, 0 bytes` printed even for an idle `then count` rule.

A plain rule with no metadata bits renders byte-identically to before.

## Tests (fail-on-revert, via the fake gRPC client)
- `#3669`: a GetPolicies error makes `showZones` return a non-nil `policy inventory unavailable` error while still printing the zone body — reverting to `polResp, _` goes RED. Plus a happy-path guard.
- `#3672`: a policy with exclusion + log modes + inactive scheduler + count renders all four — reverting `renderRule` goes RED. Plus inactive-without-scheduler and plain-rule-unchanged guards.

## Validation
- `go build ./cmd/... ./pkg/...` clean
- `go test ./cmd/cli/... ./pkg/...` green
- `gofmt` clean; `go vet ./cmd/cli/...` clean (pre-existing `monitor.go:159` warning unrelated)
- RED-on-revert proven for both fixes.
- Docs: `docs/junos-cli-reference.md` updated for both surfaces.

Closes #3669
Closes #3672

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi