### PR TITLE
match-policies: convey address-exclusion flags + stable rule_id (#3668)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -24998,3 +24998,20 @@ top.
 - **File(s)**: pkg/cli/cli_show_security_zones_policy_tiers_3658_test.go (new), pkg/grpcapi/server_show_zones_policy_tiers_3658_test.go (new)
 - **Action**: Document the detail-mode three-tier policy summary
 - **File(s)**: docs/junos-cli-reference.md, _Log.md
+
+## 2026-07-01 — #3668 match-policies exclusion flags + stable rule_id
+
+- **Timestamp**: 2026-07-01
+- **Action**: STEP-0 nuance resolved — the matcher (ruleMatches -> matchAddr) is CORRECT; it already inverts the address test for source/destination-address-excluded rules. Issue is a RESPONSE reporting gap, not a matcher inversion. Fix is additive schema + rendering.
+- **Action**: Add SourceAddressExcluded / DestinationAddressExcluded / RuleID to policymatch.Result; populate in matchedResult (RuleID via dpuserspace.StablePolicyRuleID, global rules remapped to junos-global->junos-global identity like the inventory). Add SSOT ExceptSuffix helper.
+- **File(s)**: pkg/policymatch/policymatch.go
+- **Action**: Add additive proto fields source_address_excluded=15, destination_address_excluded=16, rule_id=17 to MatchPoliciesResponse; regenerate bindings with pinned protoc-gen-go v1.36.11 / protoc-gen-go-grpc v1.6.1 / protoc v3.21.12 (no version bump)
+- **File(s)**: proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go (regenerated)
+- **Action**: Add RuleID / SourceAddressExcluded / DestinationAddressExcluded to api.MatchPoliciesResult; populate in REST matchPoliciesHandler; populate the gRPC MatchPolicies response
+- **File(s)**: pkg/api/types.go, pkg/api/security.go, pkg/grpcapi/server_cluster.go
+- **Action**: Annotate "(except)" + print the stable Rule ID in the local and remote match-policies renderers
+- **File(s)**: pkg/cli/cli_show_security.go, cmd/cli/show.go
+- **Action**: Add RED-on-revert tests (matcher/gRPC/REST layers) proving the exclusion flags + rule_id are conveyed
+- **File(s)**: pkg/policymatch/excluded_response_3668_test.go (new), pkg/grpcapi/server_matchpolicies_exclusion_3668_test.go (new), pkg/api/security_matchpolicies_exclusion_3668_test.go (new)
+- **Action**: Document the new response fields
+- **File(s)**: pkg/api/README.md, pkg/grpcapi/README.md, pkg/policymatch/README.md, _Log.md

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -1167,14 +1167,23 @@ func (c *ctl) showMatchPolicies(args []string) error {
 		// back to the runtime policy / session-table ID / audit record when the
 		// same policy name repeats across zone pairs or global scope.
 		fmt.Printf("    Policy ID: %d\n", resp.GetPolicyId())
+		// #3668: also print the stable rule identity so a hit joins to the
+		// inventory / logs / tests even after a policy reorder shifts Policy ID.
+		if resp.GetRuleId() != "" {
+			fmt.Printf("    Rule ID: %s\n", resp.GetRuleId())
+		}
 		if resp.Global {
 			fmt.Printf("    Scope: global (match from-zone: %s, to-zone: %s)\n",
 				matchScopeZone(resp.FromZone), matchScopeZone(resp.ToZone))
 		} else {
 			fmt.Printf("    Scope: zone-pair (from-zone: %s, to-zone: %s)\n", resp.FromZone, resp.ToZone)
 		}
-		fmt.Printf("    Source addresses: %v\n", resp.SrcAddresses)
-		fmt.Printf("    Destination addresses: %v\n", resp.DstAddresses)
+		// #3668: annotate "(except)" for a source/destination-address-excluded
+		// rule so a positive verdict conveys the negation instead of reading as
+		// if the printed address list caused the match. Same SSOT suffix helper
+		// the local CLI uses, so the two surfaces cannot drift.
+		fmt.Printf("    Source addresses%s: %v\n", policymatch.ExceptSuffix(resp.GetSourceAddressExcluded()), resp.SrcAddresses)
+		fmt.Printf("    Destination addresses%s: %v\n", policymatch.ExceptSuffix(resp.GetDestinationAddressExcluded()), resp.DstAddresses)
 		fmt.Printf("    Applications: %v\n", resp.Applications)
 		fmt.Printf("    Action: %s\n", resp.Action)
 	} else if resp.HostInboundUnmatched {

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -541,7 +541,23 @@ under the daemon's errgroup. Nothing else imports this package.
   (the matched policy's declared SCOPE, #3331, set only on a positive match):
   for a wildcard-zone or global match the two can differ. The gRPC
   `MatchPoliciesResponse.queried_from_zone`/`queried_to_zone` (fields 13/14)
-  mirror this.
+  mirror this. #3668: on a MATCH the response also carries
+  `source_address_excluded`/`destination_address_excluded` and the stable
+  `rule_id`. The exclusion flags report whether the matched policy carries Junos
+  `source-address-excluded`/`destination-address-excluded` — the rule matches
+  every address EXCEPT those in `src_addresses`/`dst_addresses`. The shared
+  matcher already inverts the address test correctly; without the flags a
+  positive verdict against a source OUTSIDE an excluded set printed the excluded
+  list as if it were the reason for the match (backwards for an audit tool). The
+  renderers annotate the exclusion as `Source addresses (except): ...`. `rule_id`
+  is the stable `<from>-><to>/<name>` identity the inventory (`GetPolicies`), the
+  snapshot, and the event path carry (`dpuserspace.StablePolicyRuleID`), so a
+  simulator hit joins to the inventory row / logs / tests even after a policy
+  reorder shifts the numeric `policy_id`; a matched global policy uses the
+  `junos-global->junos-global/<name>` form, matching the inventory global rows.
+  All three are additive and set only on a positive match. The gRPC
+  `MatchPoliciesResponse.source_address_excluded`/`destination_address_excluded`
+  (fields 15/16) and `rule_id` (field 17) mirror this.
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -640,11 +640,17 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		// #3623: set the pointer only on a match (the two early returns above
 		// leave it nil), so a matched first policy (id 0) is emitted as
 		// "policy_id":0 rather than dropped and mistaken for no match.
-		PolicyID:     &matchedID,
-		Action:       res.DisplayAction(),
-		SrcAddresses: res.SrcAddresses,
-		DstAddresses: res.DstAddresses,
-		Applications: res.Applications,
+		PolicyID: &matchedID,
+		// #3668: the stable rule identity (inventory join key) + the
+		// address-exclusion flags so a positive verdict against a
+		// source/destination-address-excluded rule does not read backwards.
+		RuleID:                     res.RuleID,
+		Action:                     res.DisplayAction(),
+		SrcAddresses:               res.SrcAddresses,
+		DstAddresses:               res.DstAddresses,
+		SourceAddressExcluded:      res.SourceAddressExcluded,
+		DestinationAddressExcluded: res.DestinationAddressExcluded,
+		Applications:               res.Applications,
 	})
 }
 

--- a/pkg/api/security_matchpolicies_exclusion_3668_test.go
+++ b/pkg/api/security_matchpolicies_exclusion_3668_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// excludedAPIStore mirrors the gRPC excludedPolicyStore fixture: a trust->untrust
+// permit that is BOTH source-address-excluded and destination-address-excluded,
+// the #3668 negated-address case.
+func excludedAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    address-book {
+        global {
+            address bad-src 10.0.99.0/24;
+            address bad-dst 192.0.2.0/24;
+        }
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy exclude-permit {
+                match {
+                    source-address bad-src;
+                    source-address-excluded;
+                    destination-address bad-dst;
+                    destination-address-excluded;
+                    application any;
+                }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// exclusionResponse decodes the REST /security/match envelope including the
+// #3668 exclusion flags + stable rule_id.
+type exclusionResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Matched                    bool   `json:"matched"`
+		PolicyName                 string `json:"policy_name"`
+		RuleID                     string `json:"rule_id"`
+		SourceAddressExcluded      bool   `json:"source_address_excluded"`
+		DestinationAddressExcluded bool   `json:"destination_address_excluded"`
+	} `json:"data"`
+}
+
+// TestMatchPoliciesRESTCarriesExclusionAndRuleID pins #3668 on the REST surface:
+// the /security/match JSON must carry source_address_excluded /
+// destination_address_excluded and the stable rule_id, so a stored diagnostic
+// against a negated-address rule does not read backwards and can be joined to the
+// inventory.
+//
+// RED-on-revert: removing the RuleID/SourceAddressExcluded/DestinationAddress
+// Excluded field copies in matchPoliciesHandler (pkg/api/security.go) drops them
+// from the JSON and every assertion below fails. The matcher + gRPC tests pin the
+// other layers; this pins the REST mapping they do NOT exercise.
+func TestMatchPoliciesRESTCarriesExclusionAndRuleID(t *testing.T) {
+	store := excludedAPIStore(t)
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	q := url.Values{
+		"from_zone": {"trust"},
+		"to_zone":   {"untrust"},
+		// Source OUTSIDE bad-src, destination OUTSIDE bad-dst => the excluded
+		// rule matches.
+		"src_ip":   {"10.0.5.7"},
+		"dst_ip":   {"198.51.100.7"},
+		"protocol": {"tcp"},
+		"dst_port": {"80"},
+	}
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+	s.matchPoliciesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp exclusionResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success || !resp.Data.Matched {
+		t.Fatalf("expected a successful match; body: %s", rr.Body.String())
+	}
+	if !resp.Data.SourceAddressExcluded {
+		t.Errorf("source_address_excluded = false, want true; body: %s", rr.Body.String())
+	}
+	if !resp.Data.DestinationAddressExcluded {
+		t.Errorf("destination_address_excluded = false, want true; body: %s", rr.Body.String())
+	}
+	want := dpuserspace.StablePolicyRuleID("trust", "untrust", "exclude-permit")
+	if resp.Data.RuleID != want {
+		t.Errorf("rule_id = %q, want %q", resp.Data.RuleID, want)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -478,11 +478,29 @@ type MatchPoliciesResult struct {
 	// matched-first-policy answer look unmatched (both encoded as absent/0). A
 	// *uint32 is set only on a match, so its presence means "matched with this
 	// id" (emitted even at 0) and nil (omitted) means "no matched id".
-	PolicyID     *uint32  `json:"policy_id,omitempty"`
+	PolicyID *uint32 `json:"policy_id,omitempty"`
+	// RuleID is the stable "<from>-><to>/<name>" rule identity the inventory
+	// (GetPolicies) carries (#3668). PolicyID is the runtime/reorder-fragile
+	// numeric id; RuleID lets a match-policies hit be joined to the stable
+	// identifier used by inventory, logs, and tests even after a policy reorder.
+	// Present only on a positive match (a matched global policy uses the
+	// "junos-global->junos-global/<name>" form, matching inventory global rows).
+	RuleID       string   `json:"rule_id,omitempty"`
 	Action       string   `json:"action"`
 	SrcAddresses []string `json:"src_addresses,omitempty"`
 	DstAddresses []string `json:"dst_addresses,omitempty"`
-	Applications []string `json:"applications,omitempty"`
+	// SourceAddressExcluded / DestinationAddressExcluded report whether the
+	// matched policy carries Junos `source-address-excluded` /
+	// `destination-address-excluded` (#3668): the rule matches every address
+	// EXCEPT those in SrcAddresses/DstAddresses. Without them a positive verdict
+	// reads BACKWARDS — a match against a source OUTSIDE an excluded set prints
+	// the excluded list as if it were the reason for the match (the shared
+	// matcher already inverts correctly; only the response omitted the flag).
+	// Present (true) only when the modifier is set on a matched policy; false /
+	// omitted otherwise.
+	SourceAddressExcluded      bool     `json:"source_address_excluded,omitempty"`
+	DestinationAddressExcluded bool     `json:"destination_address_excluded,omitempty"`
+	Applications               []string `json:"applications,omitempty"`
 	// HostInboundUnmatched is true for a `to-zone junos-host` query that matched
 	// no host-bound policy (#3285): the dataplane host gate returns None (local
 	// delivery; no transit global/default fallback), so Action is not a

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -501,6 +501,11 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	// #3331: identify WHICH scoped/global policy matched so a verdict maps back
 	// to the runtime policy / session-table ID / audit record when names repeat.
 	fmt.Printf("    Policy ID: %d\n", res.PolicyID)
+	// #3668: also print the stable rule identity so a hit joins to the inventory /
+	// logs / tests even after a policy reorder shifts the numeric Policy ID.
+	if res.RuleID != "" {
+		fmt.Printf("    Rule ID: %s\n", res.RuleID)
+	}
 	if res.Global {
 		fmt.Printf("    Scope: global (match from-zone: %s, to-zone: %s)\n",
 			matchScopeZone(res.FromZone), matchScopeZone(res.ToZone))
@@ -510,8 +515,12 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 	if res.Description != "" {
 		fmt.Printf("    Description: %s\n", res.Description)
 	}
-	fmt.Printf("    Source addresses: %v\n", res.SrcAddresses)
-	fmt.Printf("    Destination addresses: %v\n", res.DstAddresses)
+	// #3668: annotate "(except)" when the matched rule carries
+	// source-address-excluded / destination-address-excluded — the shared matcher
+	// inverts correctly, but without the label a positive verdict against a
+	// source OUTSIDE an excluded set reads as if the excluded list caused it.
+	fmt.Printf("    Source addresses%s: %v\n", policymatch.ExceptSuffix(res.SourceAddressExcluded), res.SrcAddresses)
+	fmt.Printf("    Destination addresses%s: %v\n", policymatch.ExceptSuffix(res.DestinationAddressExcluded), res.DstAddresses)
 	fmt.Printf("    Applications: %v\n", res.Applications)
 	fmt.Printf("    Action: %s\n", policymatch.ActionString(res.Action))
 	return nil

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -117,6 +117,26 @@ contract.
   scope (for a wildcard-zone or global match the two can differ). The REST
   `MatchPoliciesResult` carries the same `queried_from_zone`/`queried_to_zone`
   JSON fields.
+- #3668: on a MATCH the response also carries `source_address_excluded` /
+  `destination_address_excluded` (proto fields 15/16) and the stable `rule_id`
+  (proto field 17), mirroring the inventory `PolicyRule` (fields 13/14/18). The
+  exclusion flags report whether the matched policy carries Junos
+  `source-address-excluded` / `destination-address-excluded` — the rule matches
+  every address EXCEPT those in `src_addresses`/`dst_addresses`. The shared
+  matcher (`matchAddr`) already inverts the address test correctly for the
+  excluded side; the flag is what stops a positive verdict from reading
+  BACKWARDS (before #3668 a hit against a source OUTSIDE an excluded set printed
+  the excluded list as if it caused the match — unsafe for a Junos-style
+  negated-address audit). `rule_id` is the stable `<from>-><to>/<name>` identity
+  the inventory `GetPolicies`, the snapshot, and the event path share
+  (`dpuserspace.StablePolicyRuleID`); a matched GLOBAL policy uses
+  `junos-global->junos-global/<name>` exactly like the inventory global rows, so
+  a simulator hit joins to the inventory / logs / tests even after a policy
+  reorder shifts the numeric `policy_id`. All three are additive, set only on a
+  positive match. The REST `MatchPoliciesResult` carries the same
+  `source_address_excluded`/`destination_address_excluded`/`rule_id` JSON
+  fields, and both CLI renderers annotate the exclusion as
+  `Source addresses (except): ...` plus a `Rule ID:` line.
 - The `test policy` operational command (local `pkg/cli` + remote `cmd/cli`
   → ShowText `test-policy:` topic → `showTestPolicy`) carries the same
   source-port input (#3107). The topic adds a `srcport=` key alongside the

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -273,11 +273,17 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		// first policy (runtime id 0) is distinguishable on the wire from an
 		// unmatched response (field absent). The two early returns above leave
 		// PolicyId unset for the unmatched / host-inbound cases.
-		PolicyId:     proto.Uint32(res.PolicyID),
-		Action:       res.DisplayAction(),
-		SrcAddresses: res.SrcAddresses,
-		DstAddresses: res.DstAddresses,
-		Applications: res.Applications,
+		PolicyId: proto.Uint32(res.PolicyID),
+		// #3668: the stable rule identity (inventory join key) + the
+		// source/destination address-exclusion flags so a positive verdict for a
+		// negated-address rule conveys the exclusion instead of reading backwards.
+		RuleId:                     res.RuleID,
+		SourceAddressExcluded:      res.SourceAddressExcluded,
+		DestinationAddressExcluded: res.DestinationAddressExcluded,
+		Action:                     res.DisplayAction(),
+		SrcAddresses:               res.SrcAddresses,
+		DstAddresses:               res.DstAddresses,
+		Applications:               res.Applications,
 	}, nil
 }
 

--- a/pkg/grpcapi/server_matchpolicies_exclusion_3668_test.go
+++ b/pkg/grpcapi/server_matchpolicies_exclusion_3668_test.go
@@ -1,0 +1,100 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// excludedPolicyStore commits a trust->untrust permit whose source-address is
+// source-address-excluded (matches every source EXCEPT 10.0.99.0/24) and whose
+// destination-address is destination-address-excluded (every dest EXCEPT
+// 192.0.2.0/24). Exactly the #3668 negated-address case.
+func excludedPolicyStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    address-book {
+        global {
+            address bad-src 10.0.99.0/24;
+            address bad-dst 192.0.2.0/24;
+        }
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy exclude-permit {
+                match {
+                    source-address bad-src;
+                    source-address-excluded;
+                    destination-address bad-dst;
+                    destination-address-excluded;
+                    application any;
+                }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesResponseCarriesExclusionAndRuleID pins #3668 on the gRPC
+// surface: a positive verdict against a source/destination-address-excluded rule
+// must set source_address_excluded / destination_address_excluded and carry the
+// stable rule_id inventory uses, so the answer does not read backwards and can be
+// joined to the inventory / logs / tests.
+//
+// RED-on-revert: before #3668 MatchPoliciesResponse had no exclusion/rule_id
+// fields; dropping the population in server_cluster.go (or reverting the proto)
+// zeroes them and every assertion below fails.
+func TestMatchPoliciesResponseCarriesExclusionAndRuleID(t *testing.T) {
+	store := excludedPolicyStore(t)
+	s := &Server{store: store}
+
+	// Source OUTSIDE bad-src and destination OUTSIDE bad-dst => the excluded rule
+	// matches. The printed src/dst list is the EXCLUDED set, so the flag is what
+	// prevents the verdict from reading as "matched because of bad-src".
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone:        "trust",
+		ToZone:          "untrust",
+		SourceIp:        "10.0.5.7",
+		DestinationIp:   "198.51.100.7",
+		Protocol:        "tcp",
+		DestinationPort: 80,
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies error = %v", err)
+	}
+	if !resp.Matched {
+		t.Fatalf("expected match, got %+v", resp)
+	}
+	if !resp.GetSourceAddressExcluded() {
+		t.Errorf("source_address_excluded = false, want true")
+	}
+	if !resp.GetDestinationAddressExcluded() {
+		t.Errorf("destination_address_excluded = false, want true")
+	}
+	want := dpuserspace.StablePolicyRuleID("trust", "untrust", "exclude-permit")
+	if resp.GetRuleId() != want {
+		t.Errorf("rule_id = %q, want %q", resp.GetRuleId(), want)
+	}
+}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -6525,8 +6525,32 @@ type MatchPoliciesResponse struct {
 	// scope).
 	QueriedFromZone string `protobuf:"bytes,13,opt,name=queried_from_zone,json=queriedFromZone,proto3" json:"queried_from_zone,omitempty"`
 	QueriedToZone   string `protobuf:"bytes,14,opt,name=queried_to_zone,json=queriedToZone,proto3" json:"queried_to_zone,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// #3668: match-inversion flags for the MATCHED policy, mirroring the
+	// inventory PolicyRule fields 13/14. source_address_excluded /
+	// destination_address_excluded are true when the matched rule carries
+	// Junos `source-address-excluded` / `destination-address-excluded`: the
+	// rule matches every address EXCEPT those in src_addresses/dst_addresses.
+	// Without them a positive match-policies verdict reads BACKWARDS — it prints
+	// the excluded address list as if the match happened BECAUSE of it, when the
+	// real reason is the opposite (the shared simulator matchAddr already inverts
+	// correctly; only the response omitted the flag). Additive; false (omitted)
+	// for a rule without the modifier and for the unmatched / host-inbound /
+	// default cases (which carry no matched policy). Set only when matched is
+	// true.
+	SourceAddressExcluded      bool `protobuf:"varint,15,opt,name=source_address_excluded,json=sourceAddressExcluded,proto3" json:"source_address_excluded,omitempty"`
+	DestinationAddressExcluded bool `protobuf:"varint,16,opt,name=destination_address_excluded,json=destinationAddressExcluded,proto3" json:"destination_address_excluded,omitempty"`
+	// #3668: rule_id is the stable "<from>-><to>/<name>" rule identity the
+	// inventory PolicyRule (field 18) and the snapshot/event path carry, computed
+	// by the shared dpuserspace.StablePolicyRuleID. policy_id (field 11) is the
+	// runtime/reorder-fragile numeric id; rule_id lets an operator join a
+	// simulator hit to the stable identifier used by inventory, logs, and tests
+	// even after a policy reorder. For a matched GLOBAL policy the identity uses
+	// "junos-global->junos-global/<name>" exactly like the inventory global rows.
+	// Additive; empty (omitted) for the unmatched / host-inbound / default cases.
+	// Set only when matched is true.
+	RuleId        string `protobuf:"bytes,17,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MatchPoliciesResponse) Reset() {
@@ -6653,6 +6677,27 @@ func (x *MatchPoliciesResponse) GetQueriedFromZone() string {
 func (x *MatchPoliciesResponse) GetQueriedToZone() string {
 	if x != nil {
 		return x.QueriedToZone
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetSourceAddressExcluded() bool {
+	if x != nil {
+		return x.SourceAddressExcluded
+	}
+	return false
+}
+
+func (x *MatchPoliciesResponse) GetDestinationAddressExcluded() bool {
+	if x != nil {
+		return x.DestinationAddressExcluded
+	}
+	return false
+}
+
+func (x *MatchPoliciesResponse) GetRuleId() string {
+	if x != nil {
+		return x.RuleId
 	}
 	return ""
 }
@@ -8185,7 +8230,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
-	"_icmp_code\"\x83\x04\n" +
+	"_icmp_code\"\x96\x05\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -8202,7 +8247,10 @@ const file_xpf_proto_rawDesc = "" +
 	"\tpolicy_id\x18\v \x01(\rH\x00R\bpolicyId\x88\x01\x01\x12!\n" +
 	"\fdefault_used\x18\f \x01(\bR\vdefaultUsed\x12*\n" +
 	"\x11queried_from_zone\x18\r \x01(\tR\x0fqueriedFromZone\x12&\n" +
-	"\x0fqueried_to_zone\x18\x0e \x01(\tR\rqueriedToZoneB\f\n" +
+	"\x0fqueried_to_zone\x18\x0e \x01(\tR\rqueriedToZone\x126\n" +
+	"\x17source_address_excluded\x18\x0f \x01(\bR\x15sourceAddressExcluded\x12@\n" +
+	"\x1cdestination_address_excluded\x18\x10 \x01(\bR\x1adestinationAddressExcluded\x12\x17\n" +
+	"\arule_id\x18\x11 \x01(\tR\x06ruleIdB\f\n" +
 	"\n" +
 	"_policy_id\"N\n" +
 	"\x16GetNATRuleStatsRequest\x12\x19\n" +

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -134,6 +134,25 @@ carries the matched policy's full identity:
   matched policy's `[policySetID, sliceIndex]` coordinates (a global policy's
   `policySetID` is `len(cfg.Security.Policies)`), so a verdict cross-references
   the session table / audit log even when policy names collide across scopes.
+- `RuleID` (#3668) — the stable `<from>-><to>/<name>` rule identity the
+  inventory (`GetPolicies`), the snapshot, and the event path share, computed by
+  the SSOT `dataplane/userspace.StablePolicyRuleID`. `PolicyID` is the runtime,
+  reorder-fragile numeric id; `RuleID` is the stable join key an operator uses to
+  tie a simulator hit to the inventory row / logs / tests even after a policy
+  reorder. A matched GLOBAL policy uses `junos-global->junos-global/<name>`
+  exactly like the inventory global rows — `matchedResult` remaps the global
+  branch's match-SCOPE zones to that reserved pair so the identities line up.
+- `SourceAddressExcluded` / `DestinationAddressExcluded` (#3668) — true when the
+  matched policy carries Junos `source-address-excluded` /
+  `destination-address-excluded`: the rule matches every address EXCEPT those in
+  `SrcAddresses`/`DstAddresses`. The matcher (`matchAddr`) already inverts the
+  address test correctly for the excluded side; these flags exist so the DISPLAY
+  does not read backwards. Before #3668 a positive verdict against a source
+  OUTSIDE an excluded set printed the excluded list with no negation marker,
+  implying the match happened BECAUSE of the excluded address when the real
+  reason is the opposite — unsafe for a Junos-style negated-address audit. The
+  CLI renderers annotate this as `Source addresses (except): ...` via the SSOT
+  `ExceptSuffix` helper.
 
 These are meaningful only on a concrete match (`Matched == true`); the
 default-policy and host-inbound verdicts leave them zero-valued.

--- a/pkg/policymatch/excluded_response_3668_test.go
+++ b/pkg/policymatch/excluded_response_3668_test.go
@@ -1,0 +1,169 @@
+package policymatch
+
+import (
+	"net"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// TestExcludedFlagsAndRuleIDOnMatch pins #3668 at the shared-matcher layer: a
+// positive verdict against a source-address-excluded / destination-address-
+// excluded policy must CONVEY the exclusion in Result.SourceAddressExcluded /
+// DestinationAddressExcluded and carry the stable Result.RuleID that the
+// inventory uses. Before #3668 Result had none of those fields, so a hit against
+// a source OUTSIDE the excluded set reported the excluded list with no negation
+// marker — reading as if the excluded address CAUSED the match.
+//
+// The matcher itself was already correct (matchAddr inverts for the excluded
+// side); this pins that the RESULT reports the flags a renderer needs.
+//
+// RED-on-revert: dropping the SourceAddressExcluded/DestinationAddressExcluded/
+// RuleID population in matchedResult (pkg/policymatch/policymatch.go) leaves them
+// zero-value and every assertion below fails.
+func TestExcludedFlagsAndRuleIDOnMatch(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Zones:         zones("trust", "untrust"),
+			Policies: []*config.ZonePairPolicies{
+				{
+					FromZone: "trust",
+					ToZone:   "untrust",
+					Policies: []*config.Policy{
+						{
+							Name:   "exclude-permit",
+							Action: config.PolicyPermit,
+							Match: config.PolicyMatch{
+								SourceAddresses:            []string{"10.0.99.0/24"},
+								SourceAddressExcluded:      true,
+								DestinationAddresses:       []string{"192.0.2.0/24"},
+								DestinationAddressExcluded: true,
+								Applications:               []string{"any"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Applications: config.ApplicationsConfig{},
+	}
+
+	// Source OUTSIDE the excluded 10.0.99.0/24 and destination OUTSIDE the
+	// excluded 192.0.2.0/24 => the excluded rule matches (matchAddr returns
+	// !rawMatched for the excluded side).
+	res := Match(cfg, Query{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		SrcIP:    net.ParseIP("10.0.5.7"),
+		DstIP:    net.ParseIP("198.51.100.7"),
+		Protocol: "tcp",
+		DstPort:  80,
+	})
+	if !res.Matched || res.Action != config.PolicyPermit {
+		t.Fatalf("expected permit match for a source/dest outside the excluded sets; res = %+v", res)
+	}
+	if !res.SourceAddressExcluded {
+		t.Errorf("SourceAddressExcluded = false, want true (matched rule is source-address-excluded)")
+	}
+	if !res.DestinationAddressExcluded {
+		t.Errorf("DestinationAddressExcluded = false, want true (matched rule is destination-address-excluded)")
+	}
+	// RuleID must equal the inventory's stable identity for this zone-pair rule.
+	want := dpuserspace.StablePolicyRuleID("trust", "untrust", "exclude-permit")
+	if res.RuleID != want {
+		t.Errorf("RuleID = %q, want %q", res.RuleID, want)
+	}
+}
+
+// TestNonExcludedRuleReportsNoExclusion confirms the flags are false for a
+// plain (non-excluded) matched rule, so an ordinary verdict never spuriously
+// prints "(except)". RuleID is still populated.
+func TestNonExcludedRuleReportsNoExclusion(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Zones:         zones("trust", "untrust"),
+			Policies: []*config.ZonePairPolicies{
+				{
+					FromZone: "trust",
+					ToZone:   "untrust",
+					Policies: []*config.Policy{
+						{
+							Name:   "plain-permit",
+							Action: config.PolicyPermit,
+							Match: config.PolicyMatch{
+								SourceAddresses:      []string{"any"},
+								DestinationAddresses: []string{"any"},
+								Applications:         []string{"any"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Applications: config.ApplicationsConfig{},
+	}
+
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	if !res.Matched {
+		t.Fatalf("expected match; res = %+v", res)
+	}
+	if res.SourceAddressExcluded || res.DestinationAddressExcluded {
+		t.Errorf("plain rule reported exclusion: src=%v dst=%v", res.SourceAddressExcluded, res.DestinationAddressExcluded)
+	}
+	if want := dpuserspace.StablePolicyRuleID("trust", "untrust", "plain-permit"); res.RuleID != want {
+		t.Errorf("RuleID = %q, want %q", res.RuleID, want)
+	}
+}
+
+// TestGlobalMatchRuleIDUsesJunosGlobal pins that a matched GLOBAL policy's RuleID
+// uses the reserved "junos-global->junos-global/<name>" identity the inventory
+// global rows use (pkg/api/security.go / pkg/grpcapi/server_show_zones.go), NOT
+// the policy's optional match-SCOPE zones — so a simulator hit joins to the same
+// inventory row. The exclusion flags also flow through the global branch.
+//
+// RED-on-revert: without the global -> junos-global RuleID remap in matchedResult
+// the RuleID would carry the match-scope zone ("trust->junos-global/..." here),
+// breaking the inventory join.
+func TestGlobalMatchRuleIDUsesJunosGlobal(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			DefaultPolicy: config.PolicyDeny,
+			Zones:         zones("trust", "untrust"),
+			GlobalPolicies: []*config.Policy{
+				{
+					Name:   "g-exclude",
+					Action: config.PolicyPermit,
+					Match: config.PolicyMatch{
+						SourceAddresses:       []string{"10.0.99.0/24"},
+						SourceAddressExcluded: true,
+						DestinationAddresses:  []string{"any"},
+						Applications:          []string{"any"},
+						FromZone:              "trust",
+					},
+				},
+			},
+		},
+		Applications: config.ApplicationsConfig{},
+	}
+
+	res := Match(cfg, Query{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		SrcIP:    net.ParseIP("10.0.5.7"), // outside the excluded set => matches
+		Protocol: "tcp",
+		DstPort:  80,
+	})
+	if !res.Matched || !res.Global {
+		t.Fatalf("expected global match; res = %+v", res)
+	}
+	if !res.SourceAddressExcluded {
+		t.Errorf("SourceAddressExcluded = false, want true on a global excluded rule")
+	}
+	want := dpuserspace.StablePolicyRuleID("junos-global", "junos-global", "g-exclude")
+	if res.RuleID != want {
+		t.Errorf("RuleID = %q, want %q (inventory global identity)", res.RuleID, want)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -323,12 +323,37 @@ type Result struct {
 	// MaxRulesPerPolicy, which cannot be applied anyway — see RuntimePolicyIDs).
 	PolicyID uint32
 
-	PolicyName   string
-	Description  string
-	Action       config.PolicyAction
+	PolicyName  string
+	Description string
+	Action      config.PolicyAction
+
+	// RuleID is the stable "<from>-><to>/<name>" rule identity the inventory
+	// (REST/gRPC GetPolicies) and the snapshot/event path carry, computed by the
+	// shared dpuserspace.StablePolicyRuleID (#3668). PolicyID above is the
+	// runtime/reorder-fragile numeric id; RuleID lets a match-policies verdict be
+	// joined to the stable identifier used by inventory, logs, and tests even
+	// after a policy reorder. For a matched GLOBAL policy it uses the
+	// "junos-global->junos-global/<name>" form exactly like the inventory global
+	// rows. Meaningful only when Matched is true; empty for the default-policy /
+	// host-inbound verdicts.
+	RuleID string
+
 	SrcAddresses []string
 	DstAddresses []string
-	Applications []string
+	// SourceAddressExcluded / DestinationAddressExcluded report whether the
+	// matched policy carries Junos `source-address-excluded` /
+	// `destination-address-excluded` (#3668): the rule matches every address
+	// EXCEPT those in SrcAddresses/DstAddresses. The shared matcher (ruleMatches
+	// -> matchAddr) already INVERTS the address test correctly for an excluded
+	// side; these flags exist so a positive verdict does not read backwards —
+	// without them a match against a source OUTSIDE an excluded set prints the
+	// excluded list as if it were the reason for the match. DISPLAY-ONLY, like
+	// SrcAddresses/DstAddresses; every re-match path reads pol.Match directly.
+	// Meaningful only when Matched is true; false for the default-policy /
+	// host-inbound verdicts.
+	SourceAddressExcluded      bool
+	DestinationAddressExcluded bool
+	Applications               []string
 }
 
 // HostInboundActionString is the operator-facing verdict rendered for a
@@ -637,15 +662,29 @@ func zoneKnown(cfg *config.Config, zone string) bool {
 // (a config that overflows MaxRulesPerPolicy and so cannot be applied) yields
 // PolicyID 0; the zone scope + name still disambiguate the verdict.
 func matchedResult(ids map[[2]uint32]uint32, pol *config.Policy, global bool, fromZone, toZone string, setIdx, sliceIdx int) Result {
+	// #3668: stamp the stable rule identity, mirroring the inventory EXACTLY. The
+	// inventory keys a zone-pair rule under its surrounding stanza zones and a
+	// GLOBAL rule under the reserved "junos-global"/"junos-global" pair
+	// (pkg/api/security.go, pkg/grpcapi/server_show_zones.go). fromZone/toZone
+	// here carry a global policy's optional match-SCOPE (empty = all zones), NOT
+	// that reserved pair, so a global rule must use the junos-global identity to
+	// join to the same inventory row.
+	ridFrom, ridTo := fromZone, toZone
+	if global {
+		ridFrom, ridTo = "junos-global", "junos-global"
+	}
 	return Result{
-		Matched:     true,
-		Global:      global,
-		FromZone:    fromZone,
-		ToZone:      toZone,
-		PolicyID:    ids[[2]uint32{uint32(setIdx), uint32(sliceIdx)}],
-		PolicyName:  pol.Name,
-		Description: pol.Description,
-		Action:      pol.Action,
+		Matched:                    true,
+		Global:                     global,
+		FromZone:                   fromZone,
+		ToZone:                     toZone,
+		PolicyID:                   ids[[2]uint32{uint32(setIdx), uint32(sliceIdx)}],
+		RuleID:                     dpuserspace.StablePolicyRuleID(ridFrom, ridTo, pol.Name),
+		PolicyName:                 pol.Name,
+		Description:                pol.Description,
+		Action:                     pol.Action,
+		SourceAddressExcluded:      pol.Match.SourceAddressExcluded,
+		DestinationAddressExcluded: pol.Match.DestinationAddressExcluded,
 		// #3358: a zone-local address book (#3061) is folded into the global
 		// book under the synthetic key zone-local/<zone>/<name>, and
 		// resolveZoneLocalAddressBooks already rewrote pol.Match.* to those
@@ -1110,6 +1149,19 @@ func normalizePortAlias(spec string) string {
 	default:
 		return spec
 	}
+}
+
+// ExceptSuffix returns " (except)" when a matched policy's address side carries
+// Junos source-address-excluded / destination-address-excluded, and "" otherwise
+// (#3668). It is the SSOT for the negated-address annotation shared by the local
+// CLI (pkg/cli) and remote CLI (cmd/cli) match-policies renderers, so the label
+// cannot drift between the two surfaces. The shared matcher already inverts the
+// address test correctly; this suffix keeps the DISPLAY from reading backwards.
+func ExceptSuffix(excluded bool) string {
+	if excluded {
+		return " (except)"
+	}
+	return ""
 }
 
 // ActionString renders a policy action token (permit/deny/reject).

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -778,6 +778,30 @@ message MatchPoliciesResponse {
   // scope).
   string queried_from_zone = 13;
   string queried_to_zone = 14;
+  // #3668: match-inversion flags for the MATCHED policy, mirroring the
+  // inventory PolicyRule fields 13/14. source_address_excluded /
+  // destination_address_excluded are true when the matched rule carries
+  // Junos `source-address-excluded` / `destination-address-excluded`: the
+  // rule matches every address EXCEPT those in src_addresses/dst_addresses.
+  // Without them a positive match-policies verdict reads BACKWARDS — it prints
+  // the excluded address list as if the match happened BECAUSE of it, when the
+  // real reason is the opposite (the shared simulator matchAddr already inverts
+  // correctly; only the response omitted the flag). Additive; false (omitted)
+  // for a rule without the modifier and for the unmatched / host-inbound /
+  // default cases (which carry no matched policy). Set only when matched is
+  // true.
+  bool source_address_excluded = 15;
+  bool destination_address_excluded = 16;
+  // #3668: rule_id is the stable "<from>-><to>/<name>" rule identity the
+  // inventory PolicyRule (field 18) and the snapshot/event path carry, computed
+  // by the shared dpuserspace.StablePolicyRuleID. policy_id (field 11) is the
+  // runtime/reorder-fragile numeric id; rule_id lets an operator join a
+  // simulator hit to the stable identifier used by inventory, logs, and tests
+  // even after a policy reorder. For a matched GLOBAL policy the identity uses
+  // "junos-global->junos-global/<name>" exactly like the inventory global rows.
+  // Additive; empty (omitted) for the unmatched / host-inbound / default cases.
+  // Set only when matched is true.
+  string rule_id = 17;
 }
 
 // --- NAT rule counters ---


### PR DESCRIPTION
Closes #3668

## Summary
The match-policies simulator (shared by REST `/security/match`, the gRPC
`MatchPolicies` RPC, and the CLI `show security match-policies` / `test policy`
commands) already INVERTS the address test correctly for a
`source-address-excluded` / `destination-address-excluded` rule — `matchAddr`
returns `!rawMatched` for the excluded side and fails closed on an
empty-across-both-families set (#2008/#3356). **The matcher was never wrong.**

The RESPONSE, however, exposed no exclusion flag, so a positive verdict read
BACKWARDS: query a source OUTSIDE a `source-address bad-host` +
`source-address-excluded` permit and the answer returned `matched=true` with
`src_addresses=[bad-host]`, implying the match happened BECAUSE the source was
bad-host when the real reason is the opposite. For a Junos-style negated-address
audit / change-validation tool that is unsafe (H02). Separately the response
carried only the runtime, reorder-fragile `policy_id`, not the stable `rule_id`
the inventory `PolicyRule` exposes, so a hit could not be joined to the stable
rule identity used by inventory, logs, and tests (M05).

## STEP-0 finding
The matcher is **correct** — this is a response reporting-completeness gap, not
a matcher inversion. `ruleMatches` (policymatch.go) passes
`pol.Match.SourceAddressExcluded` / `DestinationAddressExcluded` into `matchAddr`
which inverts correctly. Fix is purely additive schema + rendering; the matcher
is untouched.

## Changes (additive, end-to-end)
- `policymatch.Result` gains `SourceAddressExcluded` / `DestinationAddressExcluded`
  and `RuleID`, populated in `matchedResult`. `RuleID` uses the SSOT
  `dpuserspace.StablePolicyRuleID`; a matched GLOBAL policy is remapped to the
  `junos-global->junos-global` identity so it joins to the same inventory row.
  New SSOT `ExceptSuffix` helper renders `(except)` so the local/remote CLI
  surfaces cannot drift.
- proto `MatchPoliciesResponse` gains `source_address_excluded` (15),
  `destination_address_excluded` (16), `rule_id` (17) — additive, new numbers,
  mirroring inventory `PolicyRule` 13/14/18. Bindings regenerated with the pinned
  protoc-gen-go v1.36.11 / protoc-gen-go-grpc v1.6.1 / protoc v3.21.12 (no version
  bump). gRPC-only; never crosses the Go↔Rust control socket, so the userspace-dp
  wire fixture is unaffected.
- `api.MatchPoliciesResult` gains the three JSON fields; REST + gRPC handlers
  populate them on a positive match only.
- local (pkg/cli) + remote (cmd/cli) renderers annotate
  `Source addresses (except): ...` and print a `Rule ID:` line.

Folds L05 (inventory parity drift) partially by reusing the inventory's
`StablePolicyRuleID` SSOT and matching field semantics.

## Tests (RED-on-revert, verified)
- `pkg/policymatch/excluded_response_3668_test.go` — matcher-layer: exclusion
  flags + RuleID (zone-pair + global identity + non-excluded negative case).
- `pkg/grpcapi/server_matchpolicies_exclusion_3668_test.go` — gRPC response.
- `pkg/api/security_matchpolicies_exclusion_3668_test.go` — REST JSON.

Each was confirmed to fail when the field population is reverted (behavioral RED,
kept compiling), then restored to green.

`go build ./pkg/... ./cmd/...`, `gofmt`, and `go test ./pkg/policymatch/...
./pkg/api/... ./pkg/grpcapi/... ./pkg/cli/... ./cmd/cli/...` all pass. `go vet`
clean except two pre-existing tree-wide diagnostics documented in the Makefile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi