### PR TITLE
config: reject from-zone/to-zone swallowed onto a policy match tail (#3673)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-01 — #3673 policy-match tail guard rejects swallowed from-zone/to-zone
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3673 — extended the #3113/#3142 unsupported-match-leaf
+    tail scan (`validatePolicyMatchLeavesStrict`) to reject from-zone/
+    to-zone that collapse onto a supported multi:true leaf's tail
+    (application / source-address / destination-address) under a
+    ZONE-PAIR policy. Verified reachability with ParseSetCommand+SetPath
+    repros: under a zone-pair match from-zone/to-zone are NOT registered
+    siblings, so `match application any from-zone C` and `match
+    application [ from-zone bad ]` collapse the reserved keyword onto the
+    application leaf's tail (#2419), where it is consumed as a bogus
+    application operand. Today #3144 (undefined-app) and the address-
+    definedness gate reject the unknown token ONLY because it is not
+    defined — an operator who defines an application/address literally
+    named from-zone/to-zone satisfies those gates and the reserved
+    keyword commits silently as an operand (fail-open). Added
+    `swallowedStructuralMatchTokens` = {from-zone,to-zone}, a `report`
+    helper, and `emitSwallowed` (strict reject / lenient warn, #1960).
+    Global scope unaffected: there from-zone/to-zone ARE siblings, so the
+    collapse stops at them.
+  - **File(s)**: pkg/config/compiler_policy_match.go,
+    pkg/config/compiler_policy_match_3673_test.go, docs/config-schema.md,
+    _Log.md
+  - **Validation**: RED-on-revert confirmed (removing the guard →
+    "CompileConfig accepted a swallowed structural match keyword" — the
+    config commits; apps named from-zone/to-zone defined so #3144 passes
+    and only the #3673 gate can reject). Legit bracketed app list and
+    legit global from-zone/to-zone match context still commit. Lenient
+    path warns. `go test ./pkg/config/...` green; `go build ./pkg/...
+    ./cmd/...`; gofmt + go vet clean.
+
 ## 2026-07-01 — #3667 gRPC policy-detail text parity (except marker + session-log modes + Index)
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1984,6 +1984,27 @@ admits them through the #3113 unsupported-leaf gate for global scope and the
 gate still rejects them under a zone-pair policy). `compilePolicy` reads them
 into `Policy.Match.FromZone`/`.ToZone` (empty = all zones).
 
+**#3673 — the zone-context sibling of the #3142 tail escape.** Because
+from-zone/to-zone are NOT registered `match` siblings under a zone-pair policy,
+a flat-set or bracketed list that writes them after a value collapses them onto
+the preceding multi:true leaf's tail (the #2419 collapse) rather than making
+them a direct child — e.g. `match application any from-zone C` yields one
+`application` leaf whose tail carries `from-zone C`, and `match application
+[ from-zone bad ]` does the same. The #3113 direct-child scan never inspects the
+tail, so from-zone/to-zone are consumed as bogus application (or, on a
+source-address/destination-address tail, address) operands. The
+undefined-application gate (#3144) and the address-definedness gate reject the
+unknown token only because it is not defined — an operator who defines an
+application/address literally named `from-zone`/`to-zone` satisfies those gates
+and the reserved keyword commits silently as an operand (a fail-open).
+`validatePolicyMatchLeavesStrict` now also scans the collapsed tail for the
+`swallowedStructuralMatchTokens` set (from-zone/to-zone) and rejects a match
+there (strict on commit, warn on the tolerant load path — #1960), mirroring the
+#3142 `unsupportedPolicyMatchLeaves` tail scan. The global scope is unaffected:
+there from-zone/to-zone ARE siblings, so the collapse stops at them and they
+stay a legitimate direct-child match leaf. Coverage:
+`pkg/config/compiler_policy_match_3673_test.go`.
+
 On the wire the global policy keeps the `junos-global` sentinel on its
 structural from/to-zone (so the dataplane classifier keeps it in the global
 tier and preserves global config order) and carries the context on the additive

--- a/pkg/config/compiler_policy_match.go
+++ b/pkg/config/compiler_policy_match.go
@@ -120,14 +120,63 @@ var unsupportedPolicyMatchLeaves = map[string]bool{
 	"source-identity":     true,
 }
 
+// swallowedStructuralMatchTokens are structural policy `match` keywords that
+// are legitimate ONLY as their own match leaf, never as an operand of a
+// multi:true match leaf (application / source-address / destination-address).
+//
+// #3673 closes the sibling of the #3142 escape for the zone-context tokens.
+// Under a ZONE-PAIR policy match, from-zone/to-zone are NOT registered `match`
+// siblings (schema_security.go — the zone pair comes from the surrounding
+// from-zone/to-zone stanza, not a match dimension). A flat-set or bracketed
+// list that writes them after a value therefore collapses them onto the
+// preceding multi-value leaf's tail (the #2419 collapse): e.g.
+//
+//	set ... from-zone A to-zone B policy p match application any from-zone C
+//	set ... from-zone A to-zone B policy p match application [ junos-http from-zone ]
+//
+// both yield one `application` leaf whose tail carries from-zone (and its zone
+// operand). The #3113 direct-child scan sees only the supported `application`
+// leaf; from-zone/C are then consumed as bogus application operands.
+//
+// Today the undefined-application gate (#3144) and, for a source-address /
+// destination-address tail, the address-definedness gate reject the unknown
+// token — but ONLY because it is not a defined application/address. An operator
+// who defines an application (or address-book entry) literally named
+// "from-zone"/"to-zone" satisfies those gates, and the reserved keyword then
+// commits silently as a bogus operand (widening or disarming the policy — a
+// fail-open). from-zone/to-zone are never valid application or address values,
+// so a token from this set in a supported multi-value leaf's collapsed tail is
+// unambiguously a reserved match keyword masquerading as an operand and is
+// rejected exactly as the unsupported leaves above (extending #3113/#3142 to
+// the zone-context tokens).
+//
+// Reachable only under a ZONE-PAIR policy: under a GLOBAL policy match
+// from-zone/to-zone ARE registered siblings (#3148, globalOnlyPolicyMatchLeaves
+// above), so the flat-set/bracket collapse stops at them and they become their
+// own legitimate match leaf — this tail case cannot arise in global scope.
+var swallowedStructuralMatchTokens = map[string]bool{
+	"from-zone": true,
+	"to-zone":   true,
+}
+
 // validatePolicyMatchLeavesStrict walks the `security policies` subtree of
 // the group-expanded AST and rejects any policy whose `match` clause
 // carries a leaf the compiler does not enforce (see file header). Covers
 // both zone-pair and global policies.
 func validatePolicyMatchLeavesStrict(nodes []*Node, lenient bool) ([]string, error) {
 	var warnings []string
+	// report routes a formatted rejection through the strict/lenient split: a
+	// hard error on commit / commit-check, a collected warning on load /
+	// peer-sync (#1960 no-brick).
+	report := func(msg string) error {
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
 	emit := func(scope, policyName, leaf string) error {
-		msg := fmt.Sprintf(
+		return report(fmt.Sprintf(
 			"security policies %s policy %q match %q is not supported "+
 				"(xpf enforces only source-address, destination-address, "+
 				"source-address-excluded, destination-address-excluded, and "+
@@ -136,12 +185,25 @@ func validatePolicyMatchLeavesStrict(nodes []*Node, lenient bool) ([]string, err
 				"not intend — a fail-open) — remove the %q match criterion "+
 				"(#3113)",
 			scope, policyName, leaf, leaf,
-		)
-		if !lenient {
-			return fmt.Errorf("%s", msg)
-		}
-		warnings = append(warnings, msg)
-		return nil
+		))
+	}
+	// emitSwallowed rejects a structural match keyword (from-zone/to-zone)
+	// absorbed as an operand of a supported multi-value leaf's collapsed tail
+	// (#3673). `leaf` names the multi-value leaf that swallowed the keyword
+	// (application / source-address / destination-address); `tok` is the
+	// reserved keyword.
+	emitSwallowed := func(scope, policyName, leaf, tok string) error {
+		return report(fmt.Sprintf(
+			"security policies %s policy %q match %s absorbed the reserved "+
+				"match keyword %q as an operand (a flat-set or bracketed list "+
+				"collapsed a structural match keyword onto the %s leaf — the "+
+				"#2419 collapse); from-zone/to-zone are match context, never an "+
+				"application or address value, so the keyword is silently "+
+				"consumed as a bogus operand (widening or disarming the policy — "+
+				"a fail-open) — write %q as its own match leaf or remove it "+
+				"(#3673)",
+			scope, policyName, leaf, tok, leaf, tok,
+		))
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node, isGlobal bool) error {
@@ -170,6 +232,17 @@ func validatePolicyMatchLeavesStrict(nodes []*Node, lenient bool) ([]string, err
 				for _, tok := range firewallMatchValues(m) {
 					if unsupportedPolicyMatchLeaves[tok] {
 						if err := emit(scope, policyName, tok); err != nil {
+							return err
+						}
+					}
+					// #3673: from-zone/to-zone are not zone-pair match siblings,
+					// so they collapse onto this multi-value leaf's tail and are
+					// consumed as bogus application/address operands. Reject them
+					// as a reserved keyword masquerading as a value — the sibling
+					// of the #3142 unsupported-leaf tail escape for the
+					// zone-context tokens.
+					if swallowedStructuralMatchTokens[tok] {
+						if err := emitSwallowed(scope, policyName, leaf, tok); err != nil {
 							return err
 						}
 					}

--- a/pkg/config/compiler_policy_match_3673_test.go
+++ b/pkg/config/compiler_policy_match_3673_test.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #3673 (codex-review-125 finding M06): the #3142 tail-scan closed
+// the multi-value-leaf escape for the KNOWN unsupported match keywords
+// (dynamic-application / url-category / source-identity), but it did NOT reject
+// from-zone / to-zone collapsed onto the same tail. Under a ZONE-PAIR policy
+// match, from-zone/to-zone are NOT registered `match` siblings, so a flat-set
+// or bracketed list that writes them after a value collapses them onto the
+// preceding multi-value leaf's tail (the #2419 collapse) and they are consumed
+// as bogus application/address operands.
+//
+// The undefined-application gate (#3144) and the address-definedness gate
+// reject the unknown token today — but ONLY because it is not a defined
+// application/address. An operator who defines an application (or address-book
+// entry) literally named "from-zone"/"to-zone" satisfies those gates, and the
+// reserved keyword then commits silently as a bogus operand — the exact
+// "reserved keyword accepted as an operand" fail-open class #3113/#3142 exists
+// to reject. The #3673 fix extends validatePolicyMatchLeavesStrict's tail scan
+// to reject from-zone/to-zone in a supported multi-value leaf's collapsed tail.
+//
+// Flat-set / bracketed syntax MUST be built with ParseSetCommand/SetPath — the
+// bracket stripping and the flat-set token collapse only happen there.
+func build3673Tree(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestPolicyMatchSwallowedZoneTokenRejected is the primary fail-on-revert
+// anchor. Each case defines applications named "from-zone"/"to-zone" (and any
+// extra operand token) so the #3144 undefined-application gate and the
+// address-definedness gate are SATISFIED — the ONLY thing that can reject the
+// config is the #3673 swallowed-structural-token check. Reverting that check
+// makes every case COMMIT (the genuine fail-open: a reserved match keyword
+// silently consumed as an application/address operand), turning these RED.
+func TestPolicyMatchSwallowedZoneTokenRejected(t *testing.T) {
+	// Defining trust/untrust plus applications literally named from-zone/
+	// to-zone/bad removes every OTHER reason to reject, isolating the #3673 gate.
+	base := []string{
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set applications application from-zone protocol tcp destination-port 1",
+		"set applications application to-zone protocol tcp destination-port 2",
+		"set applications application bad protocol tcp destination-port 3",
+	}
+	cases := []struct {
+		name string
+		cmds []string
+		want string // substring expected in the commit error
+	}{
+		{
+			name: "flat-set from-zone swallowed onto application tail",
+			cmds: []string{
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application any from-zone bad",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match application absorbed the reserved match keyword "from-zone"`,
+		},
+		{
+			name: "flat-set to-zone swallowed onto application tail",
+			cmds: []string{
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application any to-zone bad",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match application absorbed the reserved match keyword "to-zone"`,
+		},
+		{
+			name: "bracketed from-zone swallowed onto application tail",
+			cmds: []string{
+				"set security policies from-zone trust to-zone untrust policy p match source-address any",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application [ from-zone bad ]",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match application absorbed the reserved match keyword "from-zone"`,
+		},
+		{
+			name: "flat-set from-zone swallowed onto source-address tail",
+			cmds: []string{
+				// from-zone/bad are also defined as address-book entries below so
+				// only the #3673 gate can reject the source-address tail.
+				"set security zones security-zone trust address-book address from-zone 10.0.0.1/32",
+				"set security zones security-zone trust address-book address bad 10.0.0.2/32",
+				"set security policies from-zone trust to-zone untrust policy p match source-address any from-zone bad",
+				"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+				"set security policies from-zone trust to-zone untrust policy p match application any",
+				"set security policies from-zone trust to-zone untrust policy p then permit",
+			},
+			want: `from-zone trust to-zone untrust policy "p" match source-address absorbed the reserved match keyword "from-zone"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := build3673Tree(t, append(append([]string{}, base...), tc.cmds...)...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a swallowed structural match keyword; want commit rejection (#3673)")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("CompileConfig error = %q, want substring %q", err.Error(), tc.want)
+			}
+			if !strings.Contains(err.Error(), "#3673") {
+				t.Fatalf("CompileConfig error = %q, want #3673 reference", err.Error())
+			}
+		})
+	}
+}
+
+// TestPolicyMatchSwallowedZoneTokenLenientWarns proves the tolerant load /
+// peer-sync path (CompileConfigLenient) does NOT hard-fail on the swallowed
+// zone token — it compiles and records a warning naming the keyword, so an
+// already-persisted config an older binary accepted still boots (#1960).
+func TestPolicyMatchSwallowedZoneTokenLenientWarns(t *testing.T) {
+	tree := build3673Tree(t,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set applications application from-zone protocol tcp destination-port 1",
+		"set applications application bad protocol tcp destination-port 3",
+		"set security policies from-zone trust to-zone untrust policy p match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p match application any from-zone bad",
+		"set security policies from-zone trust to-zone untrust policy p then permit",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient hard-failed on a swallowed zone token; want warn-and-boot: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3673") && strings.Contains(w, `keyword "from-zone"`) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("CompileConfigLenient warnings = %v, want a #3673 swallowed-zone-token warning", cfg.Warnings)
+	}
+}
+
+// TestPolicyMatchLegitimateAppListNotOverRejectedBy3673 proves the #3673 gate
+// does NOT over-reject legitimate application/address lists that happen to
+// collapse onto the same multi-value leaf. Real app names and the `any`
+// wildcard are never from-zone/to-zone, so a normal bracketed list still
+// commits — and a GLOBAL policy that legitimately carries from-zone/to-zone as
+// its own match context (a registered sibling, #3148) is untouched.
+func TestPolicyMatchLegitimateAppListNotOverRejectedBy3673(t *testing.T) {
+	t.Run("zone-pair bracketed application list", func(t *testing.T) {
+		tree := build3673Tree(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies from-zone trust to-zone untrust policy p match source-address any",
+			"set security policies from-zone trust to-zone untrust policy p match destination-address any",
+			"set security policies from-zone trust to-zone untrust policy p match application [ junos-http junos-https ]",
+			"set security policies from-zone trust to-zone untrust policy p then permit",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig over-rejected a legit bracketed application list: %v", err)
+		}
+	})
+	t.Run("global policy from-zone/to-zone match context still commits", func(t *testing.T) {
+		tree := build3673Tree(t,
+			"set security zones security-zone trust",
+			"set security zones security-zone untrust",
+			"set security policies global policy g match source-address any",
+			"set security policies global policy g match destination-address any",
+			"set security policies global policy g match application any",
+			"set security policies global policy g match from-zone trust",
+			"set security policies global policy g match to-zone untrust",
+			"set security policies global policy g then permit",
+		)
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("CompileConfig over-rejected a legit global from-zone/to-zone match context: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Closes #3673

## Summary

The #3113/#3142 unsupported-match-leaf gate closed the multi-value-leaf
escape for the KNOWN unsupported match keywords (`dynamic-application` /
`url-category` / `source-identity`) but did **not** reject `from-zone` /
`to-zone` collapsed onto the same tail.

Under a **zone-pair** policy `match`, `from-zone`/`to-zone` are NOT
registered `match` siblings (the zone pair comes from the surrounding
`from-zone`/`to-zone` stanza, not a match dimension). A flat-set or
bracketed list that writes them after a value therefore collapses them
onto the preceding `multi:true` leaf's tail (the #2419 collapse):

```
set ... policy p match application any from-zone C
set ... policy p match application [ from-zone bad ]
```

both yield one `application` leaf whose tail carries `from-zone` (and its
zone operand). The #3113 direct-child scan sees only the supported
`application` leaf, so `from-zone`/`C` are consumed as bogus application
operands (same on a `source-address`/`destination-address` tail).

## Reachability finding (verified with ParseSetCommand + SetPath repros)

- **Zone-pair scope is reachable.** `from-zone`/`to-zone` collapse onto
  the application (and source/destination-address) leaf tail via both
  flat-set and bracketed forms.
- **The plain case is already rejected — but by a later, less-specific
  gate.** Today #3144 (undefined application) and the address-definedness
  gate reject the swallowed token, but ONLY because it is not a defined
  application/address. An operator who defines an application/address-book
  entry literally named `from-zone`/`to-zone` **satisfies** those gates
  and the reserved keyword commits **silently** as a bogus operand — the
  true fail-open this PR closes. (Confirmed: with apps named
  `from-zone`/`to-zone` defined, the config committed clean before the
  fix.)
- **Global scope is NOT reachable (matches the issue caveat).** There
  `from-zone`/`to-zone` ARE registered siblings (#3148), so the collapse
  stops at them and they become their own legitimate match leaf.

## Fix

Extend `validatePolicyMatchLeavesStrict`'s tail scan to reject
`from-zone`/`to-zone` (`swallowedStructuralMatchTokens`) found in a
supported multi-value leaf's collapsed tail, alongside the existing
`unsupportedPolicyMatchLeaves` scan, with a tailored diagnostic. Strict
on commit / commit-check (hard reject); lenient on load / peer-sync
(warn so an already-persisted config still boots — #1960). The
strict/lenient routing is factored into a small `report` helper shared by
`emit` and the new `emitSwallowed`. Legit bracketed app lists and legit
global `from-zone`/`to-zone` match context are untouched.

## Validation

- **RED-on-revert proven:** removing the guard →
  `CompileConfig accepted a swallowed structural match keyword` (the
  config commits — the genuine fail-open). Tests define apps/address-book
  entries named `from-zone`/`to-zone`/`bad` so #3144 and the
  address-definedness gate pass and ONLY the #3673 gate can reject.
- Legit bracketed application list and legit global from-zone/to-zone
  match context still commit; lenient path warns.
- `go test ./pkg/config/...` green; `go build ./pkg/... ./cmd/...`;
  `gofmt` + `go vet` clean.

New test: `pkg/config/compiler_policy_match_3673_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
