### PR TITLE
REST /statistics/global: read kernel host-inbound counters like Prometheus (#3681)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-01 — #3681 REST /statistics/global host-inbound parity with Prometheus (H04/H05/L03/L07)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3681 — the REST /api/v1/statistics/global endpoint diverged
+    from the Prometheus collector on the kernel nftables host-inbound DROP
+    counters (the PRIMARY host-inbound enforcement signal). H04: the handler
+    503-gated on `dp.IsLoaded()` BEFORE reading the kernel counters, so a
+    config-only / degraded boot lost the host-inbound signal entirely, even
+    though the `inet xpf_hostinbound` chain drops control-plane traffic
+    independent of dataplane load (Prometheus reads it before its gate). H05:
+    a netlink read error was swallowed into a clean 0 (indistinguishable from
+    "healthy, no denies"). L03: the aggregate collapsed the per-zone/family
+    split. Fix: read the kernel counters BEFORE the dataplane gate via the same
+    `readHostInboundDenyCounters` package-var the collector uses; on an
+    unloaded dataplane return a PARTIAL 200 with `dataplane_degraded: true`
+    (503 gate now scoped to the userspace-dp counters); on a read failure set
+    `host_inbound_kernel_denies_unavailable` (the #3464 non-authoritative-marker
+    idiom) instead of reporting 0; add `host_inbound_kernel_deny_detail` with
+    the per-{zone,family} breakdown. Dropped the now-unused nftables import from
+    stats.go.
+  - **File(s)**: pkg/api/stats.go, pkg/api/types.go
+- **Action**: RED-on-revert tests (L07 gap): dp-unloaded still reports the
+  aggregate + per-zone/family detail (goes RED — 503 — on revert); an nft read
+  error marks Unavailable on both the unloaded and loaded paths (RED on revert);
+  a clean empty read (absent chain) does NOT mark Unavailable (false-positive
+  guard). Verified RED by reverting stats.go to origin/master.
+  - **File(s)**: pkg/api/stats_global_host_inbound_3681_test.go (new)
+- **Action**: Document the new response fields + the Prometheus-parity rationale
+  (H04 read-before-gate / partial 200, H05 unavailable-marker, L03 zone/family
+  split) and the one exception to the "read error -> HTTP 500" contract.
+  - **File(s)**: pkg/api/README.md, _Log.md
+
 ## 2026-07-01 — #3667 gRPC policy-detail text parity (except marker + session-log modes + Index)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -128,8 +128,36 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     `host_inbound_denies`. Before #3426 REST omitted both, so an automation
     client reading only REST could not see NAT64 translation volume or the
     host-inbound allow count even though gRPC and Prometheus
-    (`xpf_nat64_translations_total`) exposed them. A counter read failure
-    returns HTTP 500 (#3345), not a clean zero.
+    (`xpf_nat64_translations_total`) exposed them. A userspace-dp global
+    counter read failure returns HTTP 500 (#3345), not a clean zero.
+    The kernel nftables host-inbound DROP counters (the PRIMARY
+    host-inbound enforcement signal — `host_inbound_kernel_denies`, its
+    per-zone/family `host_inbound_kernel_deny_detail`, and the
+    `host_inbound_kernel_denies_unavailable` marker) are handled on a path
+    that mirrors the Prometheus collector rather than the userspace-dp
+    counters (#3681):
+    - **H04 (read before the gate):** the `inet xpf_hostinbound` chain is
+      installed by the daemon INDEPENDENT of dataplane load and keeps
+      dropping control-plane traffic on a config-only / degraded boot, so
+      these counters are read BEFORE the `dataplane not loaded` check —
+      matching `metrics_counters.go collectHostInboundKernelDenies`, which
+      runs before its own dataplane gate. On an unloaded dataplane the
+      endpoint returns a PARTIAL 200 with `dataplane_degraded: true` and the
+      kernel host-inbound counters populated, instead of the old blanket
+      503 that hid the host-inbound signal exactly when management-plane
+      exposure matters most. The 503 gate is now scoped to the
+      genuinely dataplane-dependent userspace counters.
+    - **H05 (unavailable != zero):** a netlink read failure sets
+      `host_inbound_kernel_denies_unavailable: true` (leaving the aggregate
+      and detail at their zero values but marked non-authoritative) rather
+      than silently reporting a misleading "0 denies" — the REST analogue of
+      the Prometheus skip-the-series + `xpf_counter_read_errors_total` bump,
+      and the same `Unavailable` idiom as per-interface counters (#3464). An
+      absent chain (no host-inbound stanza enforced) reads as a clean 0 with
+      no marker.
+    - **L03 (zone/family split):** `host_inbound_kernel_deny_detail` carries
+      the per-`{zone, family}` breakdown the aggregate scalar collapses,
+      matching the `xpf_host_inbound_kernel_denies_total` labels.
 - `GET /api/v1/events/stream` — Server-Sent Events stream of dataplane
   events. Backed by the `pkg/logging` event ring buffer; long-lived
   consumers must drain. `?category=` (and `?severity=` on
@@ -229,7 +257,13 @@ under the daemon's errgroup. Nothing else imports this package.
     a read error; gRPC `GetGlobalStats`, `GetZones`, and `GetPolicies`
     return `codes.Internal`. The error is checked AFTER the full response
     is built, so a failure on a late read (e.g. `RxPackets` after the
-    screen-detail loop, or any policy/zone in the loop) is covered.
+    screen-detail loop, or any policy/zone in the loop) is covered. The
+    kernel-nftables host-inbound counters on `/stats/global` are the one
+    exception: because they are dataplane-INDEPENDENT and read before the
+    load gate (#3681), a read failure there does NOT 500 the whole response
+    (which would hide the good userspace counters) — it sets the
+    `host_inbound_kernel_denies_unavailable` marker, the same non-authoritative
+    idiom as per-interface `unavailable` (#3464).
   - **Prometheus** (`metrics_counters.go`) OMITS the affected sample
     (rather than emitting a misleading `0`) for global, per-zone,
     per-policy, and per-filter reads, and bumps the monotonic

--- a/pkg/api/stats.go
+++ b/pkg/api/stats.go
@@ -6,12 +6,55 @@ import (
 	"sort"
 
 	"github.com/psaab/xpf/pkg/dataplane"
-	"github.com/psaab/xpf/pkg/nftables"
 )
 
 func (s *Server) globalStatsHandler(w http.ResponseWriter, _ *http.Request) {
+	var stats GlobalStats
+
+	// #3681 (H04/H05/L03): the kernel nftables host-inbound DROP counters are
+	// the PRIMARY host-inbound enforcement signal (distinct from the userspace-dp
+	// HostInboundDeny below — not a double count). The `inet xpf_hostinbound`
+	// chain is installed by the daemon INDEPENDENT of dataplane load state and
+	// keeps dropping control-plane traffic in a config-only / degraded boot, so
+	// read it BEFORE the dataplane gate — matching the Prometheus collector
+	// (collectHostInboundKernelDenies runs before its dataplane gate). Otherwise
+	// REST automation loses the host-inbound signal exactly when management-plane
+	// exposure matters most. `readHostInboundDenyCounters` is the same
+	// package-var indirection the collector uses, so this path is unit-testable
+	// without a live kernel.
+	//
+	// #3681 (H05): mirror the #3345 "counter unavailable != zero" contract — on a
+	// netlink read failure mark the aggregate Unavailable (its 0 is NOT
+	// authoritative) instead of silently reporting a misleading "0 denies". The
+	// Prometheus analogue omits the series and bumps xpf_counter_read_errors_total.
+	//
+	// #3681 (L03): keep the per-zone/family breakdown so the aggregate scalar's
+	// [zone, family] dimensions (WAN-v4 vs WAN-v6 vs unexpected-internal-zone —
+	// the incident-response signal) are not lost.
+	if kc, err := readHostInboundDenyCounters(); err != nil {
+		stats.HostInboundKernelDeniesUnavailable = true
+	} else {
+		for _, ctr := range kc {
+			stats.HostInboundKernelDenies += ctr.Packets
+			stats.HostInboundKernelDenyDetail = append(stats.HostInboundKernelDenyDetail,
+				HostInboundKernelDenyCount{
+					Zone:    ctr.Zone,
+					Family:  ctr.Family,
+					Packets: ctr.Packets,
+					Bytes:   ctr.Bytes,
+				})
+		}
+	}
+
+	// #3681 (H04): the userspace-dp global counters below genuinely require a
+	// loaded dataplane. On a degraded / config-only boot return a PARTIAL
+	// response (200) carrying the dataplane-independent kernel host-inbound
+	// counters read above plus an explicit DataplaneDegraded flag, instead of a
+	// blanket 503 that would hide the host-inbound signal. The scope of the gate
+	// is now exactly the counters that depend on the dataplane.
 	if s.dp == nil || !s.dp.IsLoaded() {
-		writeError(w, http.StatusServiceUnavailable, "dataplane not loaded")
+		stats.DataplaneDegraded = true
+		writeOK(w, stats)
 		return
 	}
 
@@ -28,42 +71,31 @@ func (s *Server) globalStatsHandler(w http.ResponseWriter, _ *http.Request) {
 		return v
 	}
 
-	stats := GlobalStats{
-		RxPackets:            readCounter(dataplane.GlobalCtrRxPackets),
-		TxPackets:            readCounter(dataplane.GlobalCtrTxPackets),
-		Drops:                readCounter(dataplane.GlobalCtrDrops),
-		SessionsCreated:      readCounter(dataplane.GlobalCtrSessionsNew),
-		SessionsClosed:       readCounter(dataplane.GlobalCtrSessionsClosed),
-		ScreenDrops:          readCounter(dataplane.GlobalCtrScreenDrops),
-		PolicyDenies:         readCounter(dataplane.GlobalCtrPolicyDeny),
-		NATAllocFails:        readCounter(dataplane.GlobalCtrNATAllocFail),
-		HostInboundDeny:      readCounter(dataplane.GlobalCtrHostInboundDeny),
-		HostInboundAllowed:   readCounter(dataplane.GlobalCtrHostInbound),
-		NAT64Translations:    readCounter(dataplane.GlobalCtrNAT64Xlate),
-		TCEgressPackets:      readCounter(dataplane.GlobalCtrTCEgressPackets),
-		FabricRedirects:      readCounter(dataplane.GlobalCtrFabricRedirect),
-		FabricFwdDrops:       readCounter(dataplane.GlobalCtrFabricFwdDrop),
-		FlowCacheHits:        readCounter(dataplane.GlobalCtrFlowCacheHit),
-		FlowCacheMisses:      readCounter(dataplane.GlobalCtrFlowCacheMiss),
-		FlowCacheFlushes:     readCounter(dataplane.GlobalCtrFlowCacheFlush),
-		FlowCacheInvalidates: readCounter(dataplane.GlobalCtrFlowCacheInvalidate),
-	}
+	stats.RxPackets = readCounter(dataplane.GlobalCtrRxPackets)
+	stats.TxPackets = readCounter(dataplane.GlobalCtrTxPackets)
+	stats.Drops = readCounter(dataplane.GlobalCtrDrops)
+	stats.SessionsCreated = readCounter(dataplane.GlobalCtrSessionsNew)
+	stats.SessionsClosed = readCounter(dataplane.GlobalCtrSessionsClosed)
+	stats.ScreenDrops = readCounter(dataplane.GlobalCtrScreenDrops)
+	stats.PolicyDenies = readCounter(dataplane.GlobalCtrPolicyDeny)
+	stats.NATAllocFails = readCounter(dataplane.GlobalCtrNATAllocFail)
+	stats.HostInboundDeny = readCounter(dataplane.GlobalCtrHostInboundDeny)
+	stats.HostInboundAllowed = readCounter(dataplane.GlobalCtrHostInbound)
+	stats.NAT64Translations = readCounter(dataplane.GlobalCtrNAT64Xlate)
+	stats.TCEgressPackets = readCounter(dataplane.GlobalCtrTCEgressPackets)
+	stats.FabricRedirects = readCounter(dataplane.GlobalCtrFabricRedirect)
+	stats.FabricFwdDrops = readCounter(dataplane.GlobalCtrFabricFwdDrop)
+	stats.FlowCacheHits = readCounter(dataplane.GlobalCtrFlowCacheHit)
+	stats.FlowCacheMisses = readCounter(dataplane.GlobalCtrFlowCacheMiss)
+	stats.FlowCacheFlushes = readCounter(dataplane.GlobalCtrFlowCacheFlush)
+	stats.FlowCacheInvalidates = readCounter(dataplane.GlobalCtrFlowCacheInvalidate)
+
 	if readErr != nil {
 		writeError(w, http.StatusInternalServerError,
 			"global counter read failed: "+readErr.Error())
 		return
 	}
 
-	// #3361: aggregate the kernel nftables host-inbound DROP counters (the
-	// PRIMARY host-inbound enforcement path, distinct from the userspace-dp
-	// HostInboundDeny above). Best-effort: a netlink read failure leaves the
-	// field 0 — the per-zone/family Prometheus metric is the canonical surface
-	// and omits the series on error rather than reporting a misleading 0.
-	if kc, err := nftables.ReadHostInboundDenyCounters(); err == nil {
-		for _, ctr := range kc {
-			stats.HostInboundKernelDenies += ctr.Packets
-		}
-	}
 	writeOK(w, stats)
 }
 

--- a/pkg/api/stats_global_host_inbound_3681_test.go
+++ b/pkg/api/stats_global_host_inbound_3681_test.go
@@ -1,0 +1,194 @@
+// #3681: REST /statistics/global must not diverge from the Prometheus collector
+// on the kernel nftables host-inbound DROP counters — the PRIMARY host-inbound
+// enforcement signal. The pre-#3681 handler (H04) 503-gated the whole endpoint
+// behind dp.IsLoaded() BEFORE reading the kernel counters, so a config-only /
+// degraded boot lost the host-inbound signal entirely; (H05) swallowed a netlink
+// read error into a clean 0 (indistinguishable from "healthy, no denies"); and
+// (L03) collapsed the per-zone/family split. Prometheus deliberately does the
+// opposite for all three (metrics_counters.go collectHostInboundKernelDenies,
+// read before its gate + skip-on-error + [zone,family] labels).
+//
+// These tests are the L07 fill: they exercise dp-unloaded and a mocked nft read
+// error through the REST handler.
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+	xnft "github.com/psaab/xpf/pkg/nftables"
+)
+
+// errNftRead models a genuine netlink read failure (permission/state), distinct
+// from the (nil, nil) "chain absent, no denies" case.
+var errNftRead = errors.New("nftables netlink: permission denied")
+
+func decodeGlobalStats(t *testing.T, rr *httptest.ResponseRecorder) GlobalStats {
+	t.Helper()
+	var resp struct {
+		Success bool        `json:"success"`
+		Data    GlobalStats `json:"data"`
+		Error   string      `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+	}
+	if !resp.Success {
+		t.Fatalf("response success=false err=%q body=%s", resp.Error, rr.Body.String())
+	}
+	return resp.Data
+}
+
+// TestGlobalStatsReportsKernelDeniesWhenDataplaneUnloaded is the H04 + L03
+// fail-on-revert proof. The kernel nft host-inbound chain drops control-plane
+// traffic independent of dataplane load, so with the dataplane UNLOADED the REST
+// endpoint must still report the aggregate + per-zone/family breakdown (as a
+// partial, DataplaneDegraded response) rather than a blanket 503.
+//
+// RED on revert: restoring the pre-#3681 `if s.dp == nil || !s.dp.IsLoaded() {
+// 503 }` guard at the TOP returns 503 before the kernel read, so decode fails /
+// no data — this test goes RED.
+func TestGlobalStatsReportsKernelDeniesWhenDataplaneUnloaded(t *testing.T) {
+	orig := readHostInboundDenyCounters
+	defer func() { readHostInboundDenyCounters = orig }()
+	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) {
+		return []xnft.HostInboundDenyCount{
+			{Zone: "wan", Family: "ip", Packets: 7, Bytes: 700},
+			{Zone: "wan", Family: "ip6", Packets: 3, Bytes: 300},
+		}, nil
+	}
+
+	s := &Server{} // dp intentionally nil — degraded / config-only boot.
+	rr := httptest.NewRecorder()
+	s.globalStatsHandler(rr, httptest.NewRequest("GET", "/api/v1/statistics/global", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (degraded boot must still expose the "+
+			"kernel host-inbound signal, not 503). body=%s", rr.Code, rr.Body.String())
+	}
+	data := decodeGlobalStats(t, rr)
+
+	if !data.DataplaneDegraded {
+		t.Error("DataplaneDegraded = false, want true on an unloaded dataplane")
+	}
+	if data.HostInboundKernelDeniesUnavailable {
+		t.Error("HostInboundKernelDeniesUnavailable = true on a CLEAN nft read")
+	}
+	if data.HostInboundKernelDenies != 10 {
+		t.Errorf("HostInboundKernelDenies = %d, want 10 (7+3)", data.HostInboundKernelDenies)
+	}
+	// L03: per-zone/family split preserved.
+	got := map[string]uint64{}
+	for _, d := range data.HostInboundKernelDenyDetail {
+		got[d.Zone+"/"+d.Family] = d.Packets
+	}
+	if got["wan/ip"] != 7 || got["wan/ip6"] != 3 {
+		t.Errorf("per-zone/family detail = %+v, want wan/ip=7 wan/ip6=3 (L03 split lost)", got)
+	}
+	// The dataplane-dependent counters are absent (0) on a degraded boot.
+	if data.RxPackets != 0 {
+		t.Errorf("RxPackets = %d, want 0 on unloaded dataplane", data.RxPackets)
+	}
+}
+
+// TestGlobalStatsKernelDenyReadErrorMarksUnavailableUnloaded is the H05
+// fail-on-revert proof for the degraded-boot path: a netlink read failure must
+// surface as HostInboundKernelDeniesUnavailable=true, NOT a misleading 0.
+//
+// RED on revert: the pre-#3681 `if ...; err == nil` swallow left the field 0 with
+// no marker, so a read failure was indistinguishable from "no denies" — the
+// Unavailable assertion goes RED.
+func TestGlobalStatsKernelDenyReadErrorMarksUnavailableUnloaded(t *testing.T) {
+	orig := readHostInboundDenyCounters
+	defer func() { readHostInboundDenyCounters = orig }()
+	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) {
+		return nil, errNftRead
+	}
+
+	s := &Server{} // dp nil — degraded boot AND nft read error.
+	rr := httptest.NewRecorder()
+	s.globalStatsHandler(rr, httptest.NewRequest("GET", "/api/v1/statistics/global", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. body=%s", rr.Code, rr.Body.String())
+	}
+	data := decodeGlobalStats(t, rr)
+	if !data.HostInboundKernelDeniesUnavailable {
+		t.Error("HostInboundKernelDeniesUnavailable = false on a FAILED nft read " +
+			"(a read error must not look like a clean 0 — #3345 contract)")
+	}
+	if data.HostInboundKernelDenies != 0 {
+		t.Errorf("HostInboundKernelDenies = %d, want 0 when unavailable", data.HostInboundKernelDenies)
+	}
+	if len(data.HostInboundKernelDenyDetail) != 0 {
+		t.Errorf("HostInboundKernelDenyDetail = %+v, want empty on read error", data.HostInboundKernelDenyDetail)
+	}
+}
+
+// TestGlobalStatsKernelDenyReadErrorMarksUnavailableLoaded proves the same H05
+// marker on the fully-loaded path: the userspace-dp global counters read fine
+// (200), but the kernel nft read failed, so the aggregate is marked Unavailable
+// rather than silently reported as 0.
+func TestGlobalStatsKernelDenyReadErrorMarksUnavailableLoaded(t *testing.T) {
+	orig := readHostInboundDenyCounters
+	defer func() { readHostInboundDenyCounters = orig }()
+	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) {
+		return nil, errNftRead
+	}
+
+	s := &Server{dp: &idxValueAPIDP{Manager: dataplane.New()}}
+	rr := httptest.NewRecorder()
+	s.globalStatsHandler(rr, httptest.NewRequest("GET", "/api/v1/statistics/global", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (loaded dp, only the kernel read failed). body=%s",
+			rr.Code, rr.Body.String())
+	}
+	data := decodeGlobalStats(t, rr)
+	if data.DataplaneDegraded {
+		t.Error("DataplaneDegraded = true on a LOADED dataplane")
+	}
+	if !data.HostInboundKernelDeniesUnavailable {
+		t.Error("HostInboundKernelDeniesUnavailable = false on a FAILED nft read")
+	}
+	// The userspace counter still reads its own index-derived value (proves the
+	// dataplane-dependent path still runs when only the kernel read failed).
+	wantRx := uint64(dataplane.GlobalCtrRxPackets)*1000 + 7
+	if data.RxPackets != wantRx {
+		t.Errorf("RxPackets = %d, want %d (loaded userspace counters must still read)",
+			data.RxPackets, wantRx)
+	}
+}
+
+// TestGlobalStatsKernelDenyCleanReadNoMarker guards against a false-positive
+// Unavailable marker: when the chain is absent the nft reader returns (nil, nil)
+// — no enforcement means no denies, not an error — so the aggregate is a real 0
+// and Unavailable stays false.
+func TestGlobalStatsKernelDenyCleanReadNoMarker(t *testing.T) {
+	orig := readHostInboundDenyCounters
+	defer func() { readHostInboundDenyCounters = orig }()
+	readHostInboundDenyCounters = func() ([]xnft.HostInboundDenyCount, error) {
+		return nil, nil
+	}
+
+	s := &Server{dp: &idxValueAPIDP{Manager: dataplane.New()}}
+	rr := httptest.NewRecorder()
+	s.globalStatsHandler(rr, httptest.NewRequest("GET", "/api/v1/statistics/global", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200. body=%s", rr.Code, rr.Body.String())
+	}
+	data := decodeGlobalStats(t, rr)
+	if data.HostInboundKernelDeniesUnavailable {
+		t.Error("HostInboundKernelDeniesUnavailable = true on a CLEAN empty read " +
+			"(absent chain is a real 0, not a read error)")
+	}
+	if data.HostInboundKernelDenies != 0 || len(data.HostInboundKernelDenyDetail) != 0 {
+		t.Errorf("aggregate=%d detail=%+v, want 0/empty on absent chain",
+			data.HostInboundKernelDenies, data.HostInboundKernelDenyDetail)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -32,20 +32,56 @@ type GlobalStats struct {
 	// host-inbound DROP counters across all zones/families (#3361). This is the
 	// PRIMARY host-inbound enforcement path and is DISTINCT from
 	// HostInboundDeny (the userspace-dp #3326 path) — they are not double
-	// counts. Best-effort: a netlink read failure leaves this 0 (the canonical
-	// per-zone/family signal is the xpf_host_inbound_kernel_denies_total
-	// Prometheus metric, which omits the series on a read error rather than
-	// reporting a misleading 0).
+	// counts. The kernel `inet xpf_hostinbound` chain is installed by the daemon
+	// INDEPENDENT of userspace-dp load state, so this field is populated even on
+	// a degraded / config-only boot (DataplaneDegraded=true) — matching the
+	// Prometheus xpf_host_inbound_kernel_denies_total series, which is collected
+	// before the dataplane gate (#3681).
 	HostInboundKernelDenies uint64 `json:"host_inbound_kernel_denies"`
-	HostInboundAllowed      uint64 `json:"host_inbound_allowed"`
-	NAT64Translations       uint64 `json:"nat64_translations"`
-	TCEgressPackets         uint64 `json:"tc_egress_packets"`
-	FabricRedirects         uint64 `json:"fabric_redirects"`
-	FabricFwdDrops          uint64 `json:"fabric_fwd_drops"`
-	FlowCacheHits           uint64 `json:"flow_cache_hits"`
-	FlowCacheMisses         uint64 `json:"flow_cache_misses"`
-	FlowCacheFlushes        uint64 `json:"flow_cache_flushes"`
-	FlowCacheInvalidates    uint64 `json:"flow_cache_invalidations"`
+	// HostInboundKernelDeniesUnavailable marks the aggregate above as NOT
+	// authoritative because the kernel nftables read FAILED (#3681 H05). Mirrors
+	// the InterfaceStats.Unavailable (#3464) idiom and the #3345
+	// "counter-unavailable != zero" contract: a netlink read failure must not be
+	// indistinguishable from "kernel host-inbound healthy, saw no denies". When
+	// set, HostInboundKernelDenies / HostInboundKernelDenyDetail are left at
+	// their zero values but do NOT reflect real traffic. Omitted (false) on a
+	// clean read. The Prometheus analogue omits the series and bumps
+	// xpf_counter_read_errors_total.
+	HostInboundKernelDeniesUnavailable bool `json:"host_inbound_kernel_denies_unavailable,omitempty"`
+	// HostInboundKernelDenyDetail is the per-zone/family breakdown of the kernel
+	// host-inbound DROP counters (#3681 L03), preserving the [zone, family]
+	// dimensions the aggregate scalar collapses. Mirrors the Prometheus
+	// xpf_host_inbound_kernel_denies_total {zone, family} labels — for incident
+	// response the WAN-v4 vs WAN-v6 vs unexpected-internal-zone split is the
+	// signal. Omitted when empty (no enforced host-inbound chain, or read
+	// unavailable).
+	HostInboundKernelDenyDetail []HostInboundKernelDenyCount `json:"host_inbound_kernel_deny_detail,omitempty"`
+	// DataplaneDegraded is true when the userspace dataplane is not loaded
+	// (config-only / degraded boot). The response is then PARTIAL (#3681 H04):
+	// the dataplane-independent kernel host-inbound counters above are still
+	// populated, but every userspace-dp global counter below is left at 0 and is
+	// NOT authoritative. Omitted (false) on a normally loaded dataplane, where
+	// the full counter set is returned.
+	DataplaneDegraded    bool   `json:"dataplane_degraded,omitempty"`
+	HostInboundAllowed   uint64 `json:"host_inbound_allowed"`
+	NAT64Translations    uint64 `json:"nat64_translations"`
+	TCEgressPackets      uint64 `json:"tc_egress_packets"`
+	FabricRedirects      uint64 `json:"fabric_redirects"`
+	FabricFwdDrops       uint64 `json:"fabric_fwd_drops"`
+	FlowCacheHits        uint64 `json:"flow_cache_hits"`
+	FlowCacheMisses      uint64 `json:"flow_cache_misses"`
+	FlowCacheFlushes     uint64 `json:"flow_cache_flushes"`
+	FlowCacheInvalidates uint64 `json:"flow_cache_invalidations"`
+}
+
+// HostInboundKernelDenyCount is one zone/family kernel nftables host-inbound
+// DROP counter (#3681 L03), the REST projection of nftables.HostInboundDenyCount
+// and the Prometheus xpf_host_inbound_kernel_denies_total {zone, family} series.
+type HostInboundKernelDenyCount struct {
+	Zone    string `json:"zone"`
+	Family  string `json:"family"` // "ip" or "ip6"
+	Packets uint64 `json:"packets"`
+	Bytes   uint64 `json:"bytes"`
 }
 
 // InterfaceStats holds per-interface counter values.


### PR DESCRIPTION
Closes #3681

## Problem
REST `/api/v1/statistics/global` diverged from the Prometheus collector on
the kernel nftables host-inbound DROP counters — the PRIMARY host-inbound
enforcement signal. The `inet xpf_hostinbound` chain is installed by the
daemon INDEPENDENT of userspace-dp load and keeps dropping control-plane
traffic on a config-only / degraded boot, yet the REST handler:

- **H04** 503-gated on `dp.IsLoaded()` BEFORE reading those counters, so
  REST automation lost the host-inbound signal exactly when management-plane
  exposure matters most. Prometheus reads the same counters BEFORE its own
  dataplane gate (`metrics_counters.go collectHostInboundKernelDenies`).
- **H05** swallowed a netlink read error into a clean `0` — indistinguishable
  from "kernel host-inbound healthy, saw no denies". Prometheus skips the
  series + bumps `xpf_counter_read_errors_total` (the #3345 contract).
- **L03** collapsed the per-zone/family split the Prometheus
  `xpf_host_inbound_kernel_denies_total {zone, family}` series keeps.

## Fix (aligned to Prometheus)
- **H04**: read the kernel counters before the load gate via the same
  `readHostInboundDenyCounters` package-var the collector uses. On an unloaded
  dataplane return a PARTIAL `200` with `dataplane_degraded: true` and the
  kernel counters populated, instead of a blanket `503`. The `503` gate is now
  scoped to the genuinely dataplane-dependent userspace-dp global counters.
- **H05**: a netlink read failure sets `host_inbound_kernel_denies_unavailable`
  (the #3464 non-authoritative-marker idiom) rather than a misleading `0`. An
  absent chain still reads as a clean `0` with no marker. A read error here does
  NOT `500` the whole response (which would hide the good userspace counters).
- **L03**: add `host_inbound_kernel_deny_detail` with the per-`{zone,family}`
  breakdown, matching the Prometheus labels.

## Tests (L07 gap)
New `stats_global_host_inbound_3681_test.go`:
- dp-unloaded still reports the aggregate + per-zone/family detail (RED on
  revert → old top-level 503).
- an nft read error marks Unavailable on both unloaded and loaded paths (RED on
  revert → old err-swallow leaves a bare 0).
- clean empty read (absent chain) does NOT mark Unavailable (false-positive
  guard).

Verified RED by reverting `stats.go` to `origin/master` — H04/H05 tests fail,
the guard passes.

## Validation
- `go test ./pkg/api/... -count=1` green
- `go build ./pkg/... ./cmd/...` clean
- `gofmt -l` clean, `go vet ./pkg/api/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
