### PR TITLE
Reject signed +80/+8 across diagnostic port/ICMP parsers (#3679)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25028,3 +25028,17 @@ top.
 - **File(s)**: cmd/cli/show_zones_polerr_3669_test.go (new), cmd/cli/show_policies_metadata_3672_test.go (new)
 - **Action**: Document both fixes in the CLI reference (remote non-detail renderer metadata; policy-inventory failure fails loud)
 - **File(s)**: docs/junos-cli-reference.md, _Log.md
+
+## 2026-07-01 — #3679 signed-port `+80`/`+8` residual across DIAGNOSTIC parsers (H06/H07/H08/L08)
+
+- **Timestamp**: 2026-07-01
+- **Action**: Add shared `config.ParseCanonicalUint(s)` — the exported canonical-form primitive (non-empty bare ASCII digits, rejects leading sign / whitespace). Refactor the #3606 `parseCanonicalPort` to delegate to it so commit-time and diagnostic parsers share ONE grammar (closes the L08 drift gap)
+- **File(s)**: pkg/config/compiler_applications.go
+- **Action**: H07/H08 — route the CLI/gRPC/test-policy `ParsePort` and `ParseICMPValue` diagnostic parsers through `config.ParseCanonicalUint` instead of `strconv.Atoi` (Atoi accepted `+80`→80 / `+8`→8). Empty/whitespace-unspecified contract preserved; range checks (ValidatePort / 0-255) unchanged
+- **File(s)**: pkg/policymatch/policymatch.go
+- **Action**: H06 — REST match-policies `queryIntStrict` (dst_port/src_port) parses via `config.ParseCanonicalUint`; `+80` (Atoi accepted as 80) now 400s. The historical `n < 0` guard is subsumed (canonical parse never returns negative)
+- **File(s)**: pkg/api/api.go
+- **Action**: L08 — RED-on-revert tests: `+80`/`+443`/`+0` rejected by ParsePort (covers CLI match-policies + test-policy); `+8`/`+0` rejected by ParseICMPValue (ICMP simulator); REST match-policies dst_port/src_port `+80` and icmp_type/icmp_code `+8` 400. Reverting the shared helper to bare Atoi turns all three surfaces (plus the #3606 config path) red — verified
+- **File(s)**: pkg/policymatch/port_test.go, pkg/policymatch/icmp_test.go, pkg/api/rest_filter_failclosed_test.go
+- **Action**: Document the canonical-form guarantee on the diagnostic surfaces
+- **File(s)**: pkg/policymatch/README.md, pkg/api/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -391,7 +391,11 @@ under the daemon's errgroup. Nothing else imports this package.
   cross-zone observability leak). `queryUint16Strict`/`queryIntStrict`
   (`api.go`) return `(0, false)` on a malformed non-empty value; the
   sessions/events `zone` filter and the policy-match `dst_port`/`src_port`
-  return HTTP 400 instead of zeroing the predicate. The session `protocol`
+  return HTTP 400 instead of zeroing the predicate. #3679: `queryIntStrict`
+  parses via `config.ParseCanonicalUint` rather than `strconv.Atoi`, so a
+  signed/non-canonical spelling (`dst_port=+80`, which `Atoi` accepted as `80`)
+  is rejected here exactly as the #3606 commit-time and dataplane port parsers
+  reject it — no commit-vs-diagnostic split. The session `protocol`
   filter (`sessions.go` `protoFilterMatches`) is case-insensitive AND
   accepts a numeric IP protocol number (`tcp`/`TCP`/`6` all match TCP),
   mirroring gRPC (`pkg/grpcapi` `protoFilterMatches`) and CLI. The event

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -126,18 +126,26 @@ func queryUint16Strict(r *http.Request, key string, def uint16) (uint16, bool) {
 }
 
 // queryIntStrict parses a non-negative int query parameter and FAILS
-// CLOSED on a malformed/negative non-empty value (#2934). An empty value
-// returns (def, true); a bad value returns (0, false) so the caller can
-// emit HTTP 400. Used for filter/predicate parameters (e.g. dst_port in
-// the policy-match simulator) where a bad value silently becoming the
-// default is a wildcard that yields a misleading verdict.
+// CLOSED on a malformed/negative/non-canonical non-empty value (#2934,
+// #3679). An empty value returns (def, true); a bad value returns
+// (0, false) so the caller can emit HTTP 400. Used for filter/predicate
+// parameters (e.g. dst_port in the policy-match simulator) where a bad
+// value silently becoming the default is a wildcard that yields a
+// misleading verdict.
+//
+// #3679: parsing routes through config.ParseCanonicalUint rather than
+// strconv.Atoi so a signed spelling ("+80" — Atoi accepted it as 80,
+// which then simulated port 80) is rejected here exactly as the #3606
+// commit-time and dataplane port parsers reject it. ParseCanonicalUint
+// requires a bare run of ASCII digits (no sign, no whitespace) and never
+// returns a negative value, so the historical n < 0 guard is subsumed.
 func queryIntStrict(r *http.Request, key string, def int) (int, bool) {
 	v := r.URL.Query().Get(key)
 	if v == "" {
 		return def, true
 	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 0 {
+	n, err := config.ParseCanonicalUint(v)
+	if err != nil {
 		return 0, false
 	}
 	return n, true

--- a/pkg/api/rest_filter_failclosed_test.go
+++ b/pkg/api/rest_filter_failclosed_test.go
@@ -196,6 +196,47 @@ func TestRESTPolicyMatchPortRange(t *testing.T) {
 	}
 }
 
+// TestRESTPolicyMatchSignedPort asserts the #3679 contract: a signed /
+// non-canonical port or ICMP token ("+80" / "+8") must 400, not silently parse
+// to the unsigned value the way strconv.Atoi did ("+80" -> 80). #3606 made the
+// commit-time and dataplane port parsers canonical; before #3679 the REST
+// match-policies simulator (queryIntStrict for dst_port/src_port via Atoi, and
+// ParseICMPValue for icmp_type/icmp_code) still accepted the signed spelling —
+// a commit-vs-diagnostic split that would report a verdict for a token the
+// platform rejects. The plain unsigned spelling still proceeds (HTTP 200).
+//
+// FAIL-ON-REVERT: restoring strconv.Atoi in queryIntStrict / ParseICMPValue
+// makes "+80"/"+8" parse and the handler return HTTP 200, flipping the want-400
+// signed cases red.
+func TestRESTPolicyMatchSignedPort(t *testing.T) {
+	s := &Server{store: newPolicyMatchStore(t)}
+
+	base := "/api/v1/security/policies/match?from_zone=trust&to_zone=untrust"
+	cases := []struct {
+		name string
+		url  string
+		want int
+	}{
+		{"dst_port signed", base + "&dst_port=%2B80", 400},
+		{"src_port signed", base + "&src_port=%2B80", 400},
+		{"dst_port signed zero", base + "&dst_port=%2B0", 400},
+		{"icmp_type signed", base + "&protocol=icmp&icmp_type=%2B8", 400},
+		{"icmp_code signed", base + "&protocol=icmp&icmp_code=%2B0", 400},
+		{"dst_port plain", base + "&dst_port=80", 200},
+		{"icmp_type plain", base + "&protocol=icmp&icmp_type=8", 200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.matchPoliciesHandler(rr, httptest.NewRequest("GET", tc.url, nil))
+			if rr.Code != tc.want {
+				t.Fatalf("%s: status = %d, want %d; body: %s",
+					tc.name, rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
 // TestRESTPolicyMatchProtocol asserts the #3108 contract for the policy-match
 // simulator: a non-empty but unknown/out-of-range protocol token must 400, not
 // silently become the "any protocol" wildcard (the shared matcher's matchApp

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -518,10 +518,40 @@ func resolveAppPort(spec string) string {
 	return spec
 }
 
-// parseCanonicalPort parses a canonical unsigned decimal port token. Unlike
+// ParseCanonicalUint parses a canonical unsigned decimal integer token. Unlike
 // strconv.Atoi — which accepts a leading '+' ("+80" -> 80) and a leading '-'
-// ("-80" -> -80) — it requires a bare run of ASCII decimal digits, with no sign
-// and no surrounding whitespace.
+// ("-80" -> -80) — it requires a non-empty bare run of ASCII decimal digits,
+// with no sign and no surrounding whitespace.
+//
+// It is the shared canonical-form primitive behind BOTH the #3606 commit-time
+// port parsers (parseCanonicalPort below) AND the #3679 diagnostic port / ICMP
+// parsers (policymatch.ParsePort / ParseICMPValue and the REST match-policies
+// queryIntStrict helper). Routing every numeric-token parser through this one
+// function keeps the config grammar, the dataplane canonical parser, and the
+// operator simulators from drifting on the sign / whitespace of a numeric token
+// — the residual the diagnostic surfaces carried after #3606 fixed only the
+// commit path.
+//
+// Callers still apply their own value-range check on the returned int; this
+// helper only enforces canonical FORM. A parsed value that overflows int
+// returns strconv's range error, exactly as Atoi would.
+func ParseCanonicalUint(s string) (int, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty numeric token")
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0, fmt.Errorf(
+				"non-canonical numeric token %q: only unsigned decimal digits are "+
+					"allowed (no leading sign or whitespace)", s)
+		}
+	}
+	return strconv.Atoi(s)
+}
+
+// parseCanonicalPort parses a canonical unsigned decimal port token. It is the
+// port-specific spelling of ParseCanonicalUint retained for the #3606
+// commit-time callers.
 //
 // Junos rejects a signed / non-canonical port, and the userspace dataplane's
 // port parsers do NOT agree on the sign, so accepting one at commit is a
@@ -532,22 +562,8 @@ func resolveAppPort(spec string) string {
 // parse_port_spec's u16 FromStr ACCEPTS "+80" as 80. The historical Atoi commit
 // gate accepted "+80", the capability gate rejected it, and the simulator
 // (portMatches) said it matched — a three-way split on a security leaf.
-//
-// Callers still apply their own value-range check on the returned int; this
-// helper only enforces canonical FORM. A parsed value that overflows int
-// returns strconv's range error, exactly as Atoi would.
 func parseCanonicalPort(s string) (int, error) {
-	if s == "" {
-		return 0, fmt.Errorf("empty port")
-	}
-	for i := 0; i < len(s); i++ {
-		if s[i] < '0' || s[i] > '9' {
-			return 0, fmt.Errorf(
-				"non-canonical port %q: only unsigned decimal digits are allowed "+
-					"(no leading sign or whitespace)", s)
-		}
-	}
-	return strconv.Atoi(s)
+	return ParseCanonicalUint(s)
 }
 
 // validatePortSpec checks that a port specification is valid.

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -32,9 +32,21 @@ across every surface:
   of a silent `strconv.Atoi` drop that coerced a malformed port to the `0`
   wildcard). An
   empty/whitespace token is unspecified `(0, nil)`; a non-empty token must parse
-  and pass `ValidatePort`; a malformed (`abc`), negative, or out-of-range token
-  is rejected. An explicit `0` is accepted as "unspecified" for parity with the
-  gRPC `int32` field, where proto3 cannot distinguish an unset scalar from `0`.
+  and pass `ValidatePort`; a malformed (`abc`), signed (`+80`/`-80`, #3679),
+  or out-of-range token is rejected. An explicit `0` is accepted as
+  "unspecified" for parity with the gRPC `int32` field, where proto3 cannot
+  distinguish an unset scalar from `0`.
+- `ParseICMPValue(string) (*uint8, error)` — for the CLI/REST/gRPC ICMP
+  `type`/`code` selector tokens. Empty/whitespace is unspecified `(nil, nil)`; a
+  non-empty token must be a canonical unsigned decimal in `0..255`; malformed,
+  signed (`+8`/`-8`, #3679), or out-of-range is rejected.
+- #3679: `ParsePort` and `ParseICMPValue` route their non-empty token through
+  `config.ParseCanonicalUint` — the same canonical-form primitive the #3606
+  commit-time and Rust dataplane port parsers use — so a signed spelling
+  (`strconv.Atoi` accepted `+80` as `80`) that the config grammar and dataplane
+  now reject can no longer be accepted on a diagnostic surface. This closes the
+  commit-vs-diagnostic split that made automated policy verification green for a
+  token the platform rejects.
 
 This is applied at ALL FOUR simulator surfaces (matching the thin-adapter list
 above), so "all surfaces validate the port" is literally true:

--- a/pkg/policymatch/icmp_test.go
+++ b/pkg/policymatch/icmp_test.go
@@ -189,4 +189,15 @@ func TestParseICMPValue(t *testing.T) {
 	if _, err := ParseICMPValue("abc"); err == nil {
 		t.Error("abc: want parse error")
 	}
+	// #3679 FAIL-ON-REVERT: strconv.Atoi accepts a leading '+', so the old
+	// parser read "+8" as ICMP echo-request (type 8) and "+0" as echo-reply.
+	// Routing through config.ParseCanonicalUint rejects the signed spelling,
+	// matching the canonical rule the commit-time / dataplane parsers enforce.
+	// Restoring Atoi flips these back to accepted and turns the cases red.
+	if _, err := ParseICMPValue("+8"); err == nil {
+		t.Error("+8: want canonical-form error (Atoi accepted it as 8)")
+	}
+	if _, err := ParseICMPValue("+0"); err == nil {
+		t.Error("+0: want canonical-form error (Atoi accepted it as 0)")
+	}
 }

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -95,18 +95,24 @@ func ValidatePort(port int) error {
 
 // ParsePort parses a simulator port token supplied as an operator string (the
 // CLI surface). An empty/whitespace token means "unspecified" and returns
-// (0, nil) — the wildcard behavior, unchanged. A non-empty token must parse to
-// an integer that ValidatePort accepts ([0, MaxPort]); a malformed ("abc"),
-// negative, or >MaxPort token is REJECTED with an error so it can never
-// silently degrade to the 0 wildcard (#3116). An explicit "0" is accepted as
-// "unspecified" for parity with the gRPC int field, where proto3 cannot
-// distinguish an unset scalar from 0.
+// (0, nil) — the wildcard behavior, unchanged. A non-empty token must be a
+// canonical unsigned decimal that ValidatePort accepts ([0, MaxPort]); a
+// malformed ("abc"), signed ("+80"/"-80", #3679), or >MaxPort token is REJECTED
+// with an error so it can never silently degrade to the 0 wildcard (#3116). An
+// explicit "0" is accepted as "unspecified" for parity with the gRPC int field,
+// where proto3 cannot distinguish an unset scalar from 0.
+//
+// #3679: this diagnostic parser routes through config.ParseCanonicalUint — the
+// same canonical-form primitive the #3606 commit-time and dataplane port
+// parsers use — so a signed spelling the config grammar and dataplane now reject
+// can no longer be accepted here (a commit-vs-diagnostic split that made
+// automated policy verification green for a token the platform rejects).
 func ParsePort(s string) (int, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return 0, nil
 	}
-	n, err := strconv.Atoi(s)
+	n, err := config.ParseCanonicalUint(s)
 	if err != nil {
 		return 0, fmt.Errorf("invalid port %q", s)
 	}
@@ -120,16 +126,22 @@ func ParsePort(s string) (int, error) {
 // into a *uint8 the simulator threads into Query.ICMPType / Query.ICMPCode. An
 // empty/whitespace token means "unspecified" and returns (nil, nil) — the
 // dimension is not constrained, the established wildcard behavior. A non-empty
-// token must parse to an integer in [0, 255] (the 8-bit ICMP type/code space);
-// a malformed, negative, or >255 token is REJECTED with an error so it can
-// never silently degrade to the nil wildcard. The pointer return distinguishes
-// "unspecified" from a valid 0 (ICMP type 0 = echo-reply, code 0 is common).
+// token must be a canonical unsigned decimal in [0, 255] (the 8-bit ICMP
+// type/code space); a malformed, signed ("+8"/"-8", #3679), or >255 token is
+// REJECTED with an error so it can never silently degrade to the nil wildcard.
+// The pointer return distinguishes "unspecified" from a valid 0 (ICMP type 0 =
+// echo-reply, code 0 is common).
+//
+// #3679: like ParsePort, this diagnostic parser routes through
+// config.ParseCanonicalUint so a signed spelling (Atoi accepted "+8" as
+// echo-request) is rejected, matching the canonical rule the commit-time and
+// dataplane parsers enforce.
 func ParseICMPValue(s string) (*uint8, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return nil, nil
 	}
-	n, err := strconv.Atoi(s)
+	n, err := config.ParseCanonicalUint(s)
 	if err != nil {
 		return nil, fmt.Errorf("invalid icmp type/code %q", s)
 	}

--- a/pkg/policymatch/port_test.go
+++ b/pkg/policymatch/port_test.go
@@ -40,6 +40,13 @@ func TestValidatePort(t *testing.T) {
 // FAIL-ON-REVERT: restoring `dstPort, _ = strconv.Atoi(token)` (ignoring the
 // error) makes "abc" and "" both become 0 with no error, flipping the want-error
 // "abc"/"70000"/"-1" cases red.
+//
+// #3679 FAIL-ON-REVERT: restoring strconv.Atoi in place of
+// config.ParseCanonicalUint makes the signed "+80"/"+0"/"+443" tokens parse as
+// 80/0/443 with no error — Atoi accepts a leading '+' — flipping the want-error
+// signed cases red. The CLI `show security match-policies` and `request security
+// test policy` port surfaces both funnel through ParsePort, so this unit case is
+// their RED-on-revert coverage.
 func TestParsePort(t *testing.T) {
 	cases := []struct {
 		in      string
@@ -56,6 +63,9 @@ func TestParsePort(t *testing.T) {
 		{"65536", 0, true},      // one past the top
 		{"-1", 0, true},         // negative
 		{"44a", 0, true},        // partial-numeric garbage
+		{"+80", 0, true},        // #3679 signed spelling (Atoi accepted as 80)
+		{"+443", 0, true},       // #3679 signed spelling
+		{"+0", 0, true},         // #3679 signed zero (Atoi accepted as 0)
 	}
 	for _, tc := range cases {
 		got, err := ParsePort(tc.in)


### PR DESCRIPTION
Closes #3679

## Problem

#3606 made port tokens canonical unsigned decimal at the four COMMIT-time
parsers (via `parseCanonicalPort`) and tightened the Rust `parse_port_spec`,
but the three DIAGNOSTIC parsers still used `strconv.Atoi`, which accepts a
leading `+` (`Atoi("+80") = 80`, `Atoi("+8") = 8`). The operator simulators
therefore accepted a signed spelling the config grammar and the dataplane
canonical parser now reject — a commit-vs-diagnostic split that could make
automated policy verification green for a token the platform no longer
supports.

- **H06** — REST `match-policies` port query: `pkg/api/api.go` `queryIntStrict`
  (`Atoi` + `n<0`, so `+80` passed). `GET .../match?...&destination_port=+80`
  simulated port 80.
- **H07** — CLI `match`/`test-policy` port token: `pkg/policymatch` `ParsePort`
  (`Atoi`). `+80` parsed as 80 on both `show security match-policies` and
  `request security test policy`.
- **H08** — ICMP type/code simulator: `pkg/policymatch` `ParseICMPValue`
  (`Atoi`). `icmp-type +8` accepted as echo-request.
- **L08** — the tables covered `-1` / out-of-range / malformed but not the
  `+N` case; `queryIntStrict` had no canonicality test at its boundary.

## Fix

Add `config.ParseCanonicalUint(s)` — the exported canonical-form primitive
(non-empty bare run of ASCII digits, no leading sign, no surrounding
whitespace). Refactor the #3606 `parseCanonicalPort` to delegate to it so the
commit-time and diagnostic parsers share ONE grammar and can no longer drift.

Route all three diagnostic parsers through it (`queryIntStrict`, `ParsePort`,
`ParseICMPValue`). The empty/whitespace-is-unspecified contract and the
downstream range checks (`ValidatePort`, the 0..255 ICMP bound) are unchanged;
only a signed/non-canonical non-empty token newly errors. The historical
`n < 0` guard in `queryIntStrict` is subsumed (a canonical parse never returns
a negative value).

## Tests (RED-on-revert, closes the L08 gap)

- `TestParsePort`: rejects `+80`/`+443`/`+0` (covers CLI match-policies +
  test-policy, which funnel through `ParsePort`).
- `TestParseICMPValue`: rejects `+8`/`+0` (ICMP simulator).
- `TestRESTPolicyMatchSignedPort`: REST handler 400s a percent-encoded signed
  `dst_port`/`src_port` (`%2B80`) and `icmp_type`/`icmp_code` (`%2B8`), and
  still 200s the plain unsigned spelling.

Reverting the shared `config.ParseCanonicalUint` helper to bare `strconv.Atoi`
turns all three diagnostic surfaces (and the #3606 config path) red — verified.

## Validation

- `go test ./pkg/config/... ./pkg/policymatch/... ./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/...` — green
- `go build ./pkg/... ./cmd/...` — clean
- `gofmt -l` clean, `go vet` clean on touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi