### PR TITLE
config: treat explicit "any" global scope as all-zones in zone-detail (#3680)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-01 — #3680 explicit-`any` global policies hidden from zone-detail
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3680 (H01/H02/L01) — `config.GlobalPolicyAppliesToZone`
+    (the #3658 zone-detail tier predicate) recognised only the empty
+    (omitted) global scope as the all-zones wildcard, not the explicit
+    Junos token `"any"`. So a global written `match from-zone any` /
+    `match to-zone any` (preserved verbatim by the compiler,
+    #3148, and enforced all-zones by the Rust runtime
+    `build_global_zone_scope`) was HIDDEN from every affected zone's
+    `show security zones detail` — a security-audit false negative.
+    H01: `GlobalPolicyAppliesToZone` now treats `""` and `"any"`
+    identically. L01: extracted `config.IsWildcardZone(s) = s=="" ||
+    s=="any"` as the single source of truth, shared by the config helper,
+    `policymatch.globalScopeMatches`, `policymatch.GlobalPolicyAppliesToZonePair`
+    (axis-wildcard arm only), and the `compiler_security.go` address-book
+    resolver — so the display/audit surfaces cannot drift from the runtime
+    again (that drift IS what produced H01). The zone-PAIR wildcard tiers
+    (#3090, `policymatch` lines 474-475) deliberately treat only explicit
+    `any` and are intentionally left untouched. H02: added local-CLI +
+    gRPC-text + config-unit fail-on-revert tests for explicit from-zone
+    any / to-zone any (RED when the `"any"` arm is dropped) plus a
+    no-over-inclusion guard for fully scoped globals.
+  - **File(s)**: pkg/config/types_security.go,
+    pkg/config/compiler_security.go, pkg/policymatch/policymatch.go,
+    pkg/config/global_policy_zone_scope_3680_test.go,
+    pkg/cli/cli_show_security_zones_explicit_any_3680_test.go,
+    pkg/grpcapi/server_show_zones_explicit_any_3680_test.go,
+    docs/junos-cli-reference.md
+
 ## 2026-07-01 — #3681 REST /statistics/global host-inbound parity with Prometheus (H04/H05/L03/L07)
 
 - **Timestamp**: 2026-07-01
@@ -29,6 +59,7 @@
   (H04 read-before-gate / partial 200, H05 unavailable-marker, L03 zone/family
   split) and the one exception to the "read error -> HTTP 500" contract.
   - **File(s)**: pkg/api/README.md, _Log.md
+
 ## 2026-07-01 — #3673 policy-match tail guard rejects swallowed from-zone/to-zone
 
 - **Timestamp**: 2026-07-01

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -881,7 +881,13 @@ them (zone-pair, then global, then the implicit default-policy catch-all):
   affect this zone (M04). An unscoped global prints `any` for both scopes;
   a scoped global (`match from-zone`/`to-zone`, #3148) prints its zone scope.
   A global is listed for a zone only when the zone can appear on either side
-  of a pair the global matches (`config.GlobalPolicyAppliesToZone`).
+  of a pair the global matches (`config.GlobalPolicyAppliesToZone`). Both the
+  omitted scope and the EXPLICIT Junos token `any` are the all-zones wildcard
+  on an axis -- `config.IsWildcardZone` is the single source of truth shared
+  with the `policymatch` selection helpers and the Rust runtime
+  (`build_global_zone_scope` maps both `""` and `"any"` to
+  `GlobalZoneScope::Any`), so an idiomatic `match from-zone any` / `to-zone
+  any` global is no longer hidden from the affected zones' detail (#3680).
 - `[default] default-policy: <action>` -- the effective default-policy
   catch-all is ALWAYS shown (M05), so a zone with no explicit rule reports
   `default-policy: deny` / `permit` / `reject` rather than a bare

--- a/pkg/cli/cli_show_security_zones_explicit_any_3680_test.go
+++ b/pkg/cli/cli_show_security_zones_explicit_any_3680_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3680: the #3658 zone-detail policy summary used config.GlobalPolicyAppliesToZone,
+// which recognised only the EMPTY (omitted) global scope as the all-zones
+// wildcard — not the EXPLICIT Junos token "any". So a global written
+// `match from-zone any` / `match to-zone any` (idiomatic Junos, preserved
+// verbatim by the compiler and enforced all-zones by the runtime) was HIDDEN
+// from every affected zone's `show security zones detail` — a security-audit
+// false negative on the exact surface #3658 added to prevent it.
+//
+// These are the local-CLI fail-on-revert guards: revert IsWildcardZone (or the
+// GlobalPolicyAppliesToZone callers) to the "" -only test and the explicit-any
+// assertions go RED (the global drops out of the affected zones' detail).
+
+// explicitAnyGlobalCLIStore builds a config with two EXPLICIT-any globals plus a
+// fully scoped global that must not over-include:
+//   - any-to-untrust: `from-zone any to-zone untrust` -> applies to every zone
+//     (any source) and to untrust (destination).
+//   - trust-to-any:   `from-zone trust to-zone any`   -> applies to trust
+//     (source) and every destination zone.
+//   - scoped-td:      `from-zone trust to-zone dmz`   -> ONLY trust and dmz.
+func explicitAnyGlobalCLIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+        security-zone dmz;
+    }
+    policies {
+        global {
+            policy any-to-untrust {
+                match {
+                    from-zone any;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy trust-to-any {
+                match {
+                    from-zone trust;
+                    to-zone any;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy scoped-td {
+                match {
+                    from-zone trust;
+                    to-zone dmz;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+        }
+        default-policy deny-all;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if len(cfg.Security.GlobalPolicies) != 3 {
+		t.Fatalf("GlobalPolicies len = %d, want 3", len(cfg.Security.GlobalPolicies))
+	}
+	// Confirm the compiler preserved the explicit "any" verbatim — the premise.
+	for _, p := range cfg.Security.GlobalPolicies {
+		if p.Name == "any-to-untrust" && p.Match.FromZone != "any" {
+			t.Fatalf("compiler dropped explicit from-zone any: %q", p.Match.FromZone)
+		}
+		if p.Name == "trust-to-any" && p.Match.ToZone != "any" {
+			t.Fatalf("compiler dropped explicit to-zone any: %q", p.Match.ToZone)
+		}
+	}
+	return store
+}
+
+func TestCLIZoneDetailExplicitAnyGlobalAppears3680(t *testing.T) {
+	store := explicitAnyGlobalCLIStore(t)
+	c := &CLI{store: store} // dp nil: skip counters, exercise the policy summary
+	cfg := store.ActiveConfig()
+
+	render := func(zone string) string {
+		out := captureStdout(t, func() {
+			if err := c.showZonesDisplay(cfg, true, zone); err != nil {
+				t.Fatalf("showZonesDisplay(detail, %s): %v", zone, err)
+			}
+		})
+		return zoneDetailBlock(t, out, zone)
+	}
+
+	// dmz has NO zone-pair rule. Both explicit-any globals must still surface:
+	//   - any-to-untrust: `any` source axis places dmz on the source side.
+	//   - trust-to-any:   `any` dest axis places dmz on the destination side.
+	dmz := render("dmz")
+	if !strings.Contains(dmz, "[global] any -> untrust: any-to-untrust (deny)") {
+		t.Errorf("dmz detail missing explicit from-zone-any global (hidden — #3680):\n%s", dmz)
+	}
+	if !strings.Contains(dmz, "[global] trust -> any: trust-to-any (deny)") {
+		t.Errorf("dmz detail missing explicit to-zone-any global (hidden — #3680):\n%s", dmz)
+	}
+	// The fully scoped trust->dmz global legitimately applies to dmz too.
+	if !strings.Contains(dmz, "[global] trust -> dmz: scoped-td (deny)") {
+		t.Errorf("dmz detail missing scoped trust->dmz global:\n%s", dmz)
+	}
+	if strings.Contains(dmz, "(no policies)") {
+		t.Errorf("dmz detail still prints bare \"(no policies)\":\n%s", dmz)
+	}
+
+	// untrust: destination of any-to-untrust and a destination of trust-to-any.
+	untrust := render("untrust")
+	if !strings.Contains(untrust, "[global] any -> untrust: any-to-untrust (deny)") {
+		t.Errorf("untrust detail missing explicit from-zone-any global:\n%s", untrust)
+	}
+	if !strings.Contains(untrust, "[global] trust -> any: trust-to-any (deny)") {
+		t.Errorf("untrust detail missing explicit to-zone-any global:\n%s", untrust)
+	}
+	// No over-inclusion: the fully scoped trust->dmz global must NOT show for
+	// untrust.
+	if strings.Contains(untrust, "scoped-td") {
+		t.Errorf("untrust detail over-included scoped trust->dmz global:\n%s", untrust)
+	}
+}

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -385,7 +385,7 @@ func resolveZoneLocalAddressBooks(sec *SecurityConfig) {
 	rewrite := func(zone string, tokens []string) {
 		// An empty or wildcard ("any") zone names no single zone-local book to
 		// resolve against, so leave such tokens for the global book.
-		if zone == "" || zone == "any" {
+		if IsWildcardZone(zone) {
 			return
 		}
 		for i, t := range tokens {

--- a/pkg/config/global_policy_zone_scope_3680_test.go
+++ b/pkg/config/global_policy_zone_scope_3680_test.go
@@ -1,0 +1,131 @@
+package config
+
+import "testing"
+
+// Tests for #3680: GlobalPolicyAppliesToZone (the #3658 zone-detail tier
+// predicate) must treat an EXPLICIT `match from-zone any` / `match to-zone any`
+// global exactly like an omitted (empty) scope — both are the all-zones
+// wildcard. Before the fix it only recognised the empty string, so an explicit
+// "any" global (idiomatic Junos) was hidden from every affected zone's
+// zone-detail summary even though the compiler preserves "any" verbatim and the
+// Rust runtime enforces it as all-zones.
+//
+// IsWildcardZone is the shared source of truth (L01): reverting it (or the
+// GlobalPolicyAppliesToZone callers) to the old "" -only test turns the
+// explicit-"any" assertions RED.
+
+func TestIsWildcardZone(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+	}{
+		{"", true},
+		{"any", true},
+		{"trust", false},
+		{"untrust", false},
+		{"junos-host", false},
+		{"Any", false}, // case-sensitive: only the reserved lowercase token
+	} {
+		if got := IsWildcardZone(tc.in); got != tc.want {
+			t.Errorf("IsWildcardZone(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestGlobalPolicyAppliesToZoneExplicitAny is the core #3680 fail-on-revert
+// guard. It compiles globals written with the EXPLICIT `any` token (not omitted
+// scope) and asserts GlobalPolicyAppliesToZone selects the right zones.
+func TestGlobalPolicyAppliesToZoneExplicitAny(t *testing.T) {
+	tree := build3148Tree(t,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security zones security-zone dmz",
+		// Explicit `from-zone any to-zone untrust`: applies to every SOURCE
+		// zone plus destination untrust.
+		"set security policies global policy any-to-untrust match from-zone any",
+		"set security policies global policy any-to-untrust match to-zone untrust",
+		"set security policies global policy any-to-untrust match source-address any",
+		"set security policies global policy any-to-untrust match destination-address any",
+		"set security policies global policy any-to-untrust match application any",
+		"set security policies global policy any-to-untrust then deny",
+		// Explicit `from-zone trust to-zone any`: applies to source trust plus
+		// every DESTINATION zone.
+		"set security policies global policy trust-to-any match from-zone trust",
+		"set security policies global policy trust-to-any match to-zone any",
+		"set security policies global policy trust-to-any match source-address any",
+		"set security policies global policy trust-to-any match destination-address any",
+		"set security policies global policy trust-to-any match application any",
+		"set security policies global policy trust-to-any then deny",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if len(cfg.Security.GlobalPolicies) != 2 {
+		t.Fatalf("GlobalPolicies = %d, want 2", len(cfg.Security.GlobalPolicies))
+	}
+	byName := map[string]PolicyMatch{}
+	for _, p := range cfg.Security.GlobalPolicies {
+		byName[p.Name] = p.Match
+	}
+	// Confirm the compiler preserved the explicit "any" verbatim (the whole
+	// premise of #3680 — the helper must cope with the stored "any").
+	if byName["any-to-untrust"].FromZone != "any" {
+		t.Fatalf("compiler did not preserve explicit from-zone any: %q", byName["any-to-untrust"].FromZone)
+	}
+	if byName["trust-to-any"].ToZone != "any" {
+		t.Fatalf("compiler did not preserve explicit to-zone any: %q", byName["trust-to-any"].ToZone)
+	}
+
+	// from-zone any / to-zone untrust: `any` on the source axis places EVERY
+	// zone on the source side, so it applies to trust, untrust and dmz. This is
+	// the exact case the pre-fix helper missed (asSource was false because
+	// "any" != "" and "any" != zone).
+	for _, z := range []string{"trust", "untrust", "dmz"} {
+		if !GlobalPolicyAppliesToZone(byName["any-to-untrust"], z) {
+			t.Errorf("GlobalPolicyAppliesToZone(from-zone any/to-zone untrust, %q) = false, want true (explicit-any hidden — #3680)", z)
+		}
+	}
+
+	// from-zone trust / to-zone any: `any` on the destination axis places every
+	// zone on the destination side, so it applies to trust, untrust and dmz.
+	for _, z := range []string{"trust", "untrust", "dmz"} {
+		if !GlobalPolicyAppliesToZone(byName["trust-to-any"], z) {
+			t.Errorf("GlobalPolicyAppliesToZone(from-zone trust/to-zone any, %q) = false, want true (explicit-any hidden — #3680)", z)
+		}
+	}
+}
+
+// TestGlobalPolicyAppliesToZoneScopedNoOverInclusion proves the fix does not
+// over-include: a fully scoped global (concrete from AND to zone, no wildcard)
+// applies ONLY to its two named zones, never to an unrelated third zone.
+func TestGlobalPolicyAppliesToZoneScopedNoOverInclusion(t *testing.T) {
+	tree := build3148Tree(t,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security zones security-zone dmz",
+		"set security policies global policy trust-untrust match from-zone trust",
+		"set security policies global policy trust-untrust match to-zone untrust",
+		"set security policies global policy trust-untrust match source-address any",
+		"set security policies global policy trust-untrust match destination-address any",
+		"set security policies global policy trust-untrust match application any",
+		"set security policies global policy trust-untrust then deny",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	if len(cfg.Security.GlobalPolicies) != 1 {
+		t.Fatalf("GlobalPolicies = %d, want 1", len(cfg.Security.GlobalPolicies))
+	}
+	m := cfg.Security.GlobalPolicies[0].Match
+	if !GlobalPolicyAppliesToZone(m, "trust") {
+		t.Error("scoped trust->untrust global should apply to trust")
+	}
+	if !GlobalPolicyAppliesToZone(m, "untrust") {
+		t.Error("scoped trust->untrust global should apply to untrust")
+	}
+	if GlobalPolicyAppliesToZone(m, "dmz") {
+		t.Error("scoped trust->untrust global must NOT apply to unrelated zone dmz (over-inclusion)")
+	}
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -335,10 +335,33 @@ type PolicyMatch struct {
 	ToZone   string
 }
 
+// IsWildcardZone reports whether a Junos GLOBAL-policy zone-scope token names
+// every zone (the all-zones wildcard). Two spellings are equivalent: the empty
+// string (an omitted `match from-zone`/`to-zone`, the historical unscoped
+// global) AND the explicit reserved token "any" (the idiomatic Junos wildcard).
+//
+// This is the single source of truth for the wildcard-scope test. It mirrors
+// the runtime build_global_zone_scope (userspace-dp/src/policy.rs), which maps
+// BOTH "" and "any" to GlobalZoneScope::Any, and it is shared by
+// GlobalPolicyAppliesToZone here and by the policymatch helpers
+// (globalScopeMatches, GlobalPolicyAppliesToZonePair) so the display/audit
+// surfaces cannot drift from the runtime — the exact drift that hid
+// explicit-"any" globals from zone-detail (#3680, was: only "" treated as
+// wildcard here while policymatch + the runtime also honoured "any").
+//
+// Note: this is the GLOBAL-policy scope wildcard. The zone-PAIR wildcard tiers
+// (#3090, policymatch from/to-any) deliberately treat ONLY the explicit "any"
+// as a wildcard — an empty zone-pair zone is not meaningful there — so those
+// sites do not use this helper.
+func IsWildcardZone(s string) bool {
+	return s == "" || s == "any"
+}
+
 // GlobalPolicyAppliesToZone reports whether a global policy with the given
 // match context can affect security zone `zone` — i.e. the global's from- or
 // to-zone scope can place `zone` on either side of an evaluated zone pair. An
-// empty FromZone/ToZone is the "any zone" wildcard (#3148, unscoped global).
+// empty or explicit-"any" FromZone/ToZone is the "any zone" wildcard (#3148
+// unscoped global, or #3680 idiomatic-Junos explicit any).
 //
 // It mirrors the runtime AND-combined GlobalZoneScope match in the userspace
 // dataplane (userspace-dp/src/policy.rs: a global matches a packet iff its
@@ -351,8 +374,8 @@ type PolicyMatch struct {
 // Used by the zone-detail policy summary (#3658) to list the global tier the
 // runtime evaluates after zone-pair rules. Callers filter nil policies first.
 func GlobalPolicyAppliesToZone(m PolicyMatch, zone string) bool {
-	asSource := m.FromZone == "" || m.FromZone == zone
-	asDest := m.ToZone == "" || m.ToZone == zone
+	asSource := IsWildcardZone(m.FromZone) || m.FromZone == zone
+	asDest := IsWildcardZone(m.ToZone) || m.ToZone == zone
 	return asSource || asDest
 }
 

--- a/pkg/grpcapi/server_show_zones_explicit_any_3680_test.go
+++ b/pkg/grpcapi/server_show_zones_explicit_any_3680_test.go
@@ -1,0 +1,114 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3680 (gRPC-text peer of the local-CLI guard): the zone-detail policy summary
+// used config.GlobalPolicyAppliesToZone, which recognised only the empty
+// (omitted) global scope as the all-zones wildcard — not the EXPLICIT Junos
+// token "any". A global written `match from-zone any` / `match to-zone any` was
+// therefore hidden from every affected zone's `show security zones detail`.
+//
+// Fail-on-revert: revert config.IsWildcardZone (or its GlobalPolicyAppliesToZone
+// callers) to the "" -only test and the explicit-any assertions go RED.
+
+func explicitAnyGlobalGRPCServer(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+        security-zone dmz;
+    }
+    policies {
+        global {
+            policy any-to-untrust {
+                match {
+                    from-zone any;
+                    to-zone untrust;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy trust-to-any {
+                match {
+                    from-zone trust;
+                    to-zone any;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+            policy scoped-td {
+                match {
+                    from-zone trust;
+                    to-zone dmz;
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then { deny; }
+            }
+        }
+        default-policy deny-all;
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+func TestShowTextZoneDetailExplicitAnyGlobal3680(t *testing.T) {
+	s := explicitAnyGlobalGRPCServer(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "zones-detail"})
+	if err != nil {
+		t.Fatalf("ShowText(zones-detail) error = %v", err)
+	}
+	out := resp.GetOutput()
+
+	// dmz has no zone-pair rule; both explicit-any globals must still surface.
+	dmz := zoneDetailBlock(t, out, "dmz")
+	if !strings.Contains(dmz, "[global] any -> untrust: any-to-untrust (deny)") {
+		t.Errorf("dmz detail missing explicit from-zone-any global (hidden — #3680):\n%s", dmz)
+	}
+	if !strings.Contains(dmz, "[global] trust -> any: trust-to-any (deny)") {
+		t.Errorf("dmz detail missing explicit to-zone-any global (hidden — #3680):\n%s", dmz)
+	}
+	if !strings.Contains(dmz, "[global] trust -> dmz: scoped-td (deny)") {
+		t.Errorf("dmz detail missing scoped trust->dmz global:\n%s", dmz)
+	}
+	if strings.Contains(dmz, "(no policies)") {
+		t.Errorf("dmz detail still prints bare \"(no policies)\":\n%s", dmz)
+	}
+
+	// untrust: destination of both explicit-any globals; the scoped trust->dmz
+	// global must NOT over-include here.
+	untrust := zoneDetailBlock(t, out, "untrust")
+	if !strings.Contains(untrust, "[global] any -> untrust: any-to-untrust (deny)") {
+		t.Errorf("untrust detail missing explicit from-zone-any global:\n%s", untrust)
+	}
+	if !strings.Contains(untrust, "[global] trust -> any: trust-to-any (deny)") {
+		t.Errorf("untrust detail missing explicit to-zone-any global:\n%s", untrust)
+	}
+	if strings.Contains(untrust, "scoped-td") {
+		t.Errorf("untrust detail over-included scoped trust->dmz global:\n%s", untrust)
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -621,7 +621,7 @@ func matchJunosHost(cfg *config.Config, q Query, ids map[[2]uint32]uint32) Resul
 // view shows exactly the globals the runtime enforces for that zone pair.
 func GlobalPolicyAppliesToZonePair(matchFrom, matchTo, filterFrom, filterTo string) bool {
 	axisApplies := func(scope, filter string) bool {
-		if filter == "" || scope == "" || scope == "any" {
+		if filter == "" || config.IsWildcardZone(scope) {
 			return true
 		}
 		return scope == filter
@@ -635,7 +635,7 @@ func GlobalPolicyAppliesToZonePair(matchFrom, matchTo, filterFrom, filterTo stri
 // undefined (typo'd, or reserved like junos-host) scope fails closed — it
 // matches nothing, never silently widening to all-zones.
 func globalScopeMatches(cfg *config.Config, scopeZone, flowZone string) bool {
-	if scopeZone == "" || scopeZone == "any" {
+	if config.IsWildcardZone(scopeZone) {
 		return true
 	}
 	if _, ok := cfg.Security.Zones[scopeZone]; !ok {


### PR DESCRIPTION
Closes #3680

## Problem (H01)

The #3658 `show security zones detail` policy summary lists the applicable
GLOBAL tier so a zone-centric audit cannot miss a global rule governing the
zone. Its gating helper `config.GlobalPolicyAppliesToZone` recognised only the
empty (omitted) `from-zone`/`to-zone` scope as the all-zones wildcard — NOT the
explicit Junos token `"any"`:

```go
asSource := m.FromZone == "" || m.FromZone == zone
asDest   := m.ToZone   == "" || m.ToZone   == zone
```

For a global `match from-zone any / to-zone untrust` against zone `trust`, both
axes evaluate false (`"any" != ""` and `"any" != "trust"`), so the global was
omitted. But the compiler preserves an explicit `any` verbatim (#3148) and the
Rust runtime `build_global_zone_scope` maps both `""` and `"any"` to
`GlobalZoneScope::Any` — the global IS enforced for every zone. An operator
running `show security zones detail <zone>` on an idiomatic explicit-`any`
config therefore saw NO applicable global deny/permit — a security-observability
false negative on the exact surface #3658 added to prevent it. `policymatch`
already treated `"any"` as a wildcard, so the two helpers had drifted.

## Fix (H01 + L01)

- **H01**: `GlobalPolicyAppliesToZone` now treats `""` and `"any"` identically
  on each axis, matching `policymatch` and the runtime.
- **L01**: extract `config.IsWildcardZone(s) = s == "" || s == "any"` as the
  single source of truth for the GLOBAL-policy wildcard-scope test. It is now
  shared by `GlobalPolicyAppliesToZone`, `policymatch.globalScopeMatches`,
  `policymatch.GlobalPolicyAppliesToZonePair` (the scope arm only — the empty
  display *filter* keeps its separate select-all meaning), and the
  `compiler_security.go` zone-local address-book resolver. Deduping the
  duplicated `"" || "any"` test removes the drift that produced H01.
- The zone-PAIR wildcard tiers (#3090, `policymatch` from/to-any) deliberately
  treat ONLY explicit `"any"` as a wildcard — an empty zone-pair zone is not
  meaningful there — so those sites are intentionally left unchanged.

## Tests (H02, fail-on-revert)

The #3658 tier tests exercised only omitted-scope and concrete scoped globals,
never explicit `any`. Added guards at three layers:

- `pkg/config`: `IsWildcardZone` table + `GlobalPolicyAppliesToZone` over a
  compiled config (built via `ParseSetCommand`+`SetPath`) with explicit
  `from-zone any` and `to-zone any` globals (every affected zone selected) plus
  a no-over-inclusion guard for a fully scoped global.
- `pkg/cli` + `pkg/grpcapi`: `show security zones detail` surfaces the
  explicit-`any` globals for the affected zones (a zone with no zone-pair rule
  still lists both), and a fully scoped `trust->dmz` global does not leak into
  `untrust`.

**RED-on-revert verified**: reducing `IsWildcardZone` to the `""`-only test
fails all three packages (explicit-`any` globals drop out of zone-detail);
restored to `"" || "any"`, all pass.

## Validation

- `go test ./pkg/config/... ./pkg/policymatch/... ./pkg/cli/... ./pkg/grpcapi/...` green
- `go build ./pkg/... ./cmd/...` clean; `gofmt` clean; `go vet` (only the
  pre-existing `pkg/cli/cli.go:503` unreachable-code warning, unrelated)

Docs: `docs/junos-cli-reference.md` zone-detail section notes both spellings are
the all-zones wildcard via the shared `IsWildcardZone` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
