### PR TITLE
Surface host-inbound lifeline exemption on zone views (#3682)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-01 — #3682 host-inbound lifeline exemption made operator-visible (M08/L05)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3682 — the host-inbound LIFELINE exemption (fxp0 / em0 / fab* /
+    configured chassis-cluster control+fabric interfaces are excluded from a
+    zone's host-inbound deny scoping and always admit host-bound traffic) was an
+    IMPLICIT policy exception with no operator-visible surface, so a zone-assigned
+    lifeline interface silently dropped out of the default-deny. Fix = VISIBILITY
+    only (exemption semantics unchanged): (1) hoisted the lifeline matcher to a
+    shared SSOT `pkg/config/lifeline.go` (`LifelineBaseName`,
+    `HostInboundLifelineSet`, `HostInboundLifelineInterface`) and made the
+    dataplane path (`pkg/dataplane/userspace/zones.go`) delegate to it, so
+    enforcement and display can never drift; (2) added `LifelineInterfaces` to the
+    shared presenter `HostInboundView` + a `HostInboundViewWithLifelines` builder,
+    and a lifeline-exempt render line in `Render` + a lifeline marker in
+    `RenderInterfaceHostInbound` (in place of the misleading default-deny line);
+    (3) routed the surfaces through it — `show security zones` (local CLI +
+    gRPC-text + remote CLI), `show interfaces` (CLI + gRPC), `test security-zone
+    interface` (CLI + gRPC); (4) added `lifeline_interfaces` to the structured
+    `GetZones` proto (regenerated) so the remote CLI + automation see it too.
+    Design follow-up flagged on the issue: em0/fab* is a base-name PREFIX match
+    (a broader `fab-foo` would be exempted; a standalone config naming an
+    interface em0/fabX gets a silent exception) — whether it should be EXACT /
+    role-gated is left as a design question, NOT changed here.
+  - **File(s)**: pkg/config/lifeline.go (new), pkg/config/host_inbound_view.go,
+    pkg/config/host_inbound_view_lifeline_3682_test.go (new),
+    pkg/config/host_inbound_view_3654_test.go,
+    pkg/dataplane/userspace/zones.go, pkg/cli/cli_show_security_zones.go,
+    pkg/cli/cli_show_interfaces.go, pkg/cli/cli_request.go,
+    pkg/grpcapi/server_show_zones_text.go, pkg/grpcapi/server_show_zones.go,
+    pkg/grpcapi/server_show_interfaces.go, cmd/cli/show.go,
+    proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go (regenerated),
+    docs/junos-cli-reference.md
+  - **Validation**: `go build ./pkg/... ./cmd/...` clean; `go test
+    ./pkg/config/... ./pkg/cli/... ./pkg/grpcapi/... ./pkg/dataplane/...` green;
+    RED-on-revert proven (neutering the two render blocks fails the three #3682
+    tests); gofmt clean; go vet clean on touched packages (the 2 remaining vet
+    diagnostics are pre-existing, in untouched files, documented in the Makefile).
+
 ## 2026-07-01 — #3681 REST /statistics/global host-inbound parity with Prometheus (H04/H05/L03/L07)
 
 - **Timestamp**: 2026-07-01

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -476,6 +476,10 @@ func zoneHostInboundView(z *pb.ZoneInfo) config.HostInboundView {
 	v := config.HostInboundView{
 		ZoneSystemServices: z.GetHostInboundSystemServices(),
 		ZoneProtocols:      z.GetHostInboundProtocols(),
+		// #3682: carry the lifeline-exempt interface list from the structured
+		// response so the remote CLI renders the same "excluded from
+		// host-inbound deny" line as the local and gRPC-text surfaces.
+		LifelineInterfaces: z.GetLifelineInterfaces(),
 	}
 	for _, ih := range z.GetInterfaceHostInbound() {
 		v.Interfaces = append(v.Interfaces, config.InterfaceHostInboundView{

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -343,6 +343,27 @@ From zone: guest, To zone: lan
     / PMTUD / established-session accepts precede every deny, so the default-deny
     cannot strand management or break HA. (All shipped reference configs already
     declare a `host-inbound-traffic` stanza per zone, so they are unaffected.)
+  - **Lifeline-exemption visibility (#3682):** the lifeline exclusion above is
+    an IMPLICIT policy exception — a zone-assigned interface whose base name is a
+    lifeline (`fxp0` / `em0` / `fab*`, plus a configured chassis-cluster
+    `control-interface` / `fabric-interface` / secondary fabric) is EXCLUDED from
+    that zone's host-inbound deny scoping and always admits host-bound traffic
+    regardless of the zone's admission set. Before #3682 no rendered zone view
+    told the operator this, so such an interface silently dropped out of the
+    default-deny. Every host-inbound surface now surfaces it: `show security
+    zones` (local, gRPC-text, remote CLI) prints a `Host-inbound lifeline-exempt
+    interfaces (management/fabric, bypass host-inbound deny): <ifaces>` line;
+    `show interfaces` and `test security-zone interface` print `Host-inbound:
+    lifeline-exempt (management/fabric, bypasses host-inbound deny)` in place of
+    the (misleading) default-deny line; and the structured `GetZones` gRPC adds a
+    `lifeline_interfaces` field. The matcher SSOT is `config.HostInboundLifeline*`
+    (`pkg/config/lifeline.go`), shared by the dataplane deny-scoping path and the
+    display presenter so enforcement and audit can never drift. This is a
+    VISIBILITY change only — the exemption semantics are unchanged. (Design
+    follow-up: the `em0`/`fab*` match is a base-name PREFIX, so a broader
+    interface literally named `fab-foo`, or a standalone config that merely names
+    an interface `em0`/`fabX` with no configured cluster role, is exempted too;
+    whether this should be an EXACT / role-gated match is tracked on #3682.)
   - **Host-inbound deny accounting (#3326):** a host-bound packet dropped by
     the `host-inbound-traffic` admission gate (a service/protocol not in the
     ingress zone's set) now increments the host-inbound deny counter, surfaced

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -476,12 +476,17 @@ func (c *CLI) testSecurityZone(args []string) error {
 				// per-interface admission, so report the EFFECTIVE (zone UNION
 				// interface) set for THIS interface, flag an interface-local
 				// override, and print an explicit default-deny posture line.
-				for _, line := range zone.RenderInterfaceHostInbound(ifName, config.HostInboundLabels{
-					Indent:         "  ",
-					Sep:            ", ",
-					ServicesLabel:  "Host-inbound services",
-					ProtocolsLabel: "Host-inbound protocols",
-				}) {
+				// #3682: also flag when THIS interface is a management /
+				// cluster-control lifeline excluded from host-inbound deny.
+				lifeline := config.HostInboundLifelineInterface(
+					ifName, config.HostInboundLifelineSet(cfg))
+				for _, line := range zone.RenderInterfaceHostInbound(ifName, lifeline,
+					config.HostInboundLabels{
+						Indent:         "  ",
+						Sep:            ", ",
+						ServicesLabel:  "Host-inbound services",
+						ProtocolsLabel: "Host-inbound protocols",
+					}) {
 					fmt.Println(line)
 				}
 				return nil

--- a/pkg/cli/cli_show_interfaces.go
+++ b/pkg/cli/cli_show_interfaces.go
@@ -307,6 +307,12 @@ func (c *CLI) showInterfaces(args []string) error {
 			// blank section is never misread as "not enforced".
 			if li.zone != nil {
 				svc, proto, overridden := li.zone.InterfaceHostInboundEffective(li.ifaceRef)
+				// #3682: a management / cluster-control lifeline interface is
+				// EXCLUDED from host-inbound deny scoping; flag it explicitly
+				// so the exemption is visible here rather than being masked by a
+				// (misleading) default-deny line.
+				lifeline := config.HostInboundLifelineInterface(
+					li.ifaceRef, config.HostInboundLifelineSet(cfg))
 				if overridden {
 					fmt.Println("    Host-inbound: interface-specific override (effective set below)")
 				}
@@ -316,7 +322,9 @@ func (c *CLI) showInterfaces(args []string) error {
 				if len(proto) > 0 {
 					fmt.Printf("    Allowed host-inbound protocols: %s\n", strings.Join(proto, " "))
 				}
-				if len(svc) == 0 && len(proto) == 0 {
+				if lifeline {
+					fmt.Println("    Host-inbound: lifeline-exempt (management/fabric, bypasses host-inbound deny)")
+				} else if len(svc) == 0 && len(proto) == 0 {
 					fmt.Printf("    Host-inbound: default deny (%s)\n",
 						config.HostInboundDenyReason(overridden, li.zone.HostInboundTraffic != nil))
 				}

--- a/pkg/cli/cli_show_security_zones.go
+++ b/pkg/cli/cli_show_security_zones.go
@@ -91,8 +91,11 @@ func (c *CLI) showZonesDisplay(cfg *config.Config, detail bool, filterZone strin
 		// #3654: render the zone-level admitted set, the no-stanza default-deny
 		// posture line, AND any per-interface host-inbound override through the
 		// shared config presenter so this surface can no longer hide overrides
-		// or a default-deny zone (H04/M03).
-		for _, line := range zone.HostInboundView().Render(config.HostInboundLabels{
+		// or a default-deny zone (H04/M03). #3682: the presenter also renders
+		// the management/cluster-control lifeline interfaces excluded from
+		// host-inbound deny scoping, so the implicit exemption is auditable.
+		for _, line := range zone.HostInboundViewWithLifelines(
+			config.HostInboundLifelineSet(cfg)).Render(config.HostInboundLabels{
 			Indent:         "  ",
 			Sep:            " ",
 			ServicesLabel:  "Allowed host-inbound traffic",

--- a/pkg/config/host_inbound_view.go
+++ b/pkg/config/host_inbound_view.go
@@ -1,6 +1,9 @@
 package config
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // host_inbound_view.go is the shared presentation SSOT for a security zone's
 // host-inbound-traffic admission posture (#3654 L02). Before #3654 every text /
@@ -105,11 +108,54 @@ type HostInboundView struct {
 	ZoneSystemServices []string
 	ZoneProtocols      []string
 	Interfaces         []InterfaceHostInboundView
+	// LifelineInterfaces lists the zone's interfaces that are management /
+	// cluster-control LIFELINES (fxp0 / em0 / fab* / configured
+	// control-interface / fabric-interface) and are therefore EXCLUDED from
+	// host-inbound deny scoping — their host-bound traffic is always admitted
+	// regardless of this zone's host-inbound-traffic set (#3682 observability
+	// L05). Sorted, deduplicated. Empty unless the view is built with the
+	// lifeline set via HostInboundViewWithLifelines. Rendered as an explicit
+	// exemption line so the implicit management-plane exception is auditable
+	// rather than silent.
+	LifelineInterfaces []string
 }
 
 // HostInboundView builds the presentation view for a zone from its typed
-// config. Nil-safe (returns a zero view for a nil zone).
+// config. Nil-safe (returns a zero view for a nil zone). The lifeline-exemption
+// section (#3682) is empty; use HostInboundViewWithLifelines to populate it.
 func (z *ZoneConfig) HostInboundView() HostInboundView {
+	return z.HostInboundViewWithLifelines(nil)
+}
+
+// HostInboundViewWithLifelines builds the zone presentation view and, in
+// addition to HostInboundView, records which of the zone's interfaces are
+// host-inbound LIFELINES (management / cluster-control interfaces excluded from
+// host-inbound deny scoping — #3682). lifelines is the config-derived lifeline
+// base-name set from HostInboundLifelineSet(cfg); a nil set still matches the
+// always-on fxp0/em0/fab* defaults so callers that only need the defaults may
+// pass nil. Nil-safe. The recorded interfaces make the implicit exemption
+// operator-visible on every zone view that routes through this presenter.
+func (z *ZoneConfig) HostInboundViewWithLifelines(lifelines map[string]bool) HostInboundView {
+	v := z.hostInboundViewBase()
+	if z == nil {
+		return v
+	}
+	seen := make(map[string]bool, len(z.Interfaces))
+	for _, ref := range z.Interfaces {
+		if !HostInboundLifelineInterface(ref, lifelines) || seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		v.LifelineInterfaces = append(v.LifelineInterfaces, ref)
+	}
+	sort.Strings(v.LifelineInterfaces)
+	return v
+}
+
+// hostInboundViewBase builds the zone-level + per-interface-override view
+// without the lifeline-exemption section. Nil-safe (returns a zero view for a
+// nil zone).
+func (z *ZoneConfig) hostInboundViewBase() HostInboundView {
 	v := HostInboundView{}
 	if z == nil {
 		return v
@@ -143,7 +189,14 @@ func (z *ZoneConfig) HostInboundView() HostInboundView {
 // interface) admitted set for that interface. A default-deny posture line is
 // emitted when the effective set is empty, so a blank section cannot be misread
 // as "not enforced".
-func (z *ZoneConfig) RenderInterfaceHostInbound(ref string, l HostInboundLabels) []string {
+//
+// #3682: lifeline reports whether ref is a management / cluster-control lifeline
+// (from HostInboundLifelineInterface). A lifeline interface is EXCLUDED from
+// host-inbound deny scoping, so in place of the (misleading) default-deny
+// posture line the diagnostic renders an explicit lifeline-exempt marker — the
+// operator sees WHY this interface admits host-bound traffic the zone set would
+// otherwise deny.
+func (z *ZoneConfig) RenderInterfaceHostInbound(ref string, lifeline bool, l HostInboundLabels) []string {
 	var zoneSvc, zoneProto []string
 	zoneConfigured := false
 	if z != nil && z.HostInboundTraffic != nil {
@@ -172,6 +225,15 @@ func (z *ZoneConfig) RenderInterfaceHostInbound(ref string, l HostInboundLabels)
 			l.Indent+"  effective "+strings.ToLower(l.ServicesLabel)+": "+join(effSvc),
 			l.Indent+"  effective "+strings.ToLower(l.ProtocolsLabel)+": "+join(effProto),
 		)
+	}
+	// #3682: a lifeline interface is excluded from host-inbound deny scoping, so
+	// its host-bound traffic is always admitted regardless of the zone/effective
+	// set. Render the exemption explicitly (in place of the default-deny line
+	// that would otherwise be misleading here) so the exception is auditable.
+	if lifeline {
+		lines = append(lines, l.Indent+"Host-inbound: lifeline-exempt "+
+			"(management/fabric, bypasses host-inbound deny)")
+		return lines
 	}
 	if len(effSvc) == 0 && len(effProto) == 0 {
 		lines = append(lines, l.Indent+"Host-inbound: default deny ("+
@@ -240,6 +302,17 @@ func (v HostInboundView) Render(l HostInboundLabels) []string {
 				l.Indent+"    effective protocols: "+join(iface.EffectiveProtocols),
 			)
 		}
+	}
+	// #3682 (L05): make the implicit management/cluster-control lifeline
+	// exemption operator-visible. Any zone interface whose base name is a
+	// lifeline (fxp0 / em0 / fab* / configured control-interface / fabric) is
+	// EXCLUDED from this zone's host-inbound deny scoping — its host-bound
+	// traffic is always admitted. Rendered so the exception is auditable rather
+	// than silently dropping out of default-deny.
+	if len(v.LifelineInterfaces) > 0 {
+		lines = append(lines,
+			l.Indent+"Host-inbound lifeline-exempt interfaces (management/fabric, "+
+				"bypass host-inbound deny): "+strings.Join(v.LifelineInterfaces, l.Sep))
 	}
 	return lines
 }

--- a/pkg/config/host_inbound_view_3654_test.go
+++ b/pkg/config/host_inbound_view_3654_test.go
@@ -182,7 +182,7 @@ func TestRenderInterfaceHostInbound3654(t *testing.T) {
 		},
 	}
 	// Overridden interface: shows zone-level, the override marker, and effective.
-	out := strings.Join(z.RenderInterfaceHostInbound("ge-0/0/9.0", labels), "\n")
+	out := strings.Join(z.RenderInterfaceHostInbound("ge-0/0/9.0", false, labels), "\n")
 	for _, want := range []string{
 		"Host-inbound services: ssh",
 		"Host-inbound interface override on ge-0/0/9.0:",
@@ -193,7 +193,7 @@ func TestRenderInterfaceHostInbound3654(t *testing.T) {
 		}
 	}
 	// A no-stanza zone interface: default-deny posture line.
-	out = strings.Join((&ZoneConfig{}).RenderInterfaceHostInbound("ge-0/0/0.0", labels), "\n")
+	out = strings.Join((&ZoneConfig{}).RenderInterfaceHostInbound("ge-0/0/0.0", false, labels), "\n")
 	if !strings.Contains(out, "Host-inbound: default deny (no stanza)") {
 		t.Errorf("no-stanza diagnostic missing posture line\n%s", out)
 	}

--- a/pkg/config/host_inbound_view_lifeline_3682_test.go
+++ b/pkg/config/host_inbound_view_lifeline_3682_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3682: the host-inbound LIFELINE exemption (management / cluster-control
+// interfaces excluded from host-inbound deny scoping) must be OPERATOR-VISIBLE.
+// Before #3682 a zone-assigned em0/fab*/fxp0 (or a configured control/fabric)
+// interface silently dropped out of the host-inbound default-deny with nothing
+// on any zone view to say so. These tests pin the visibility contract on the
+// shared presenter SSOT: the zone-view render emits a lifeline-exempt line, and
+// the per-interface diagnostic emits a lifeline-exempt marker in place of the
+// (misleading) default-deny line. They go RED if the exemption is made invisible
+// again (the render lines removed) — the exemption becomes silent once more.
+
+func TestHostInboundLifelineInterface3682(t *testing.T) {
+	def := HostInboundLifelineSet(nil)
+	// The always-on defaults plus fxp0 are lifelines regardless of config.
+	for _, name := range []string{"fxp0", "fxp0.0", "em0", "em0.0", "fab0", "fab0.0", "fab1.0"} {
+		if !HostInboundLifelineInterface(name, def) {
+			t.Errorf("HostInboundLifelineInterface(%q) = false, want true (default lifeline)", name)
+		}
+	}
+	// A regular data-plane interface is NOT a lifeline.
+	for _, name := range []string{"ge-0/0/0.0", "reth0.50", "xe-1/0/0.0", ""} {
+		if HostInboundLifelineInterface(name, def) {
+			t.Errorf("HostInboundLifelineInterface(%q) = true, want false", name)
+		}
+	}
+	// A configured chassis-cluster control-interface is added to the set (#3277).
+	cfg := &Config{}
+	cfg.Chassis.Cluster = &ClusterConfig{ControlInterface: "hb0", FabricInterface: "fabx0"}
+	set := HostInboundLifelineSet(cfg)
+	for _, name := range []string{"hb0", "hb0.0", "fabx0.0"} {
+		if !HostInboundLifelineInterface(name, set) {
+			t.Errorf("configured lifeline %q not matched", name)
+		}
+	}
+}
+
+// TestHostInboundViewLifelineExemptRendered3682 is the RED-on-revert proof: a
+// zone with an em0/fab* member must render the lifeline-exempt line in the zone
+// host-inbound view, and a zone without any lifeline member must NOT.
+func TestHostInboundViewLifelineExemptRendered3682(t *testing.T) {
+	labels := HostInboundLabels{
+		Indent: "  ", Sep: ", ",
+		ServicesLabel: "Host-inbound system-services", ProtocolsLabel: "Host-inbound protocols",
+	}
+	const marker = "Host-inbound lifeline-exempt interfaces (management/fabric, bypass host-inbound deny):"
+
+	// Zone that (mis)assigns em0 and fab0 alongside a regular data interface.
+	z := &ZoneConfig{
+		Interfaces:         []string{"ge-0/0/0.0", "em0.0", "fab0.0"},
+		HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}},
+	}
+	out := strings.Join(z.HostInboundViewWithLifelines(nil).Render(labels), "\n")
+	if !strings.Contains(out, marker) {
+		t.Fatalf("zone view missing lifeline-exempt line (exemption is invisible)\n%s", out)
+	}
+	// The exempt line must list the lifeline members and NOT the data interface.
+	for _, want := range []string{"em0.0", "fab0.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("lifeline-exempt line missing %q\n%s", want, out)
+		}
+	}
+	lifelineLine := ""
+	for _, l := range z.HostInboundViewWithLifelines(nil).Render(labels) {
+		if strings.Contains(l, marker) {
+			lifelineLine = l
+		}
+	}
+	if strings.Contains(lifelineLine, "ge-0/0/0.0") {
+		t.Errorf("data interface ge-0/0/0.0 wrongly listed as lifeline-exempt: %q", lifelineLine)
+	}
+
+	// A zone with only data interfaces must NOT render the lifeline line.
+	zd := &ZoneConfig{
+		Interfaces:         []string{"ge-0/0/0.0"},
+		HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}},
+	}
+	if out := strings.Join(zd.HostInboundViewWithLifelines(nil).Render(labels), "\n"); strings.Contains(out, marker) {
+		t.Errorf("no-lifeline zone wrongly rendered the exempt line\n%s", out)
+	}
+}
+
+// TestHostInboundViewLifelineFromClusterConfig3682 proves a configured
+// (non-default-named) control/fabric interface is surfaced too.
+func TestHostInboundViewLifelineFromClusterConfig3682(t *testing.T) {
+	labels := HostInboundLabels{Indent: "  ", Sep: ", "}
+	cfg := &Config{}
+	cfg.Chassis.Cluster = &ClusterConfig{ControlInterface: "hb0"}
+	z := &ZoneConfig{Interfaces: []string{"hb0.0", "ge-0/0/1.0"}}
+	out := strings.Join(z.HostInboundViewWithLifelines(HostInboundLifelineSet(cfg)).Render(labels), "\n")
+	if !strings.Contains(out, "hb0.0") ||
+		!strings.Contains(out, "lifeline-exempt interfaces") {
+		t.Fatalf("configured control-interface hb0.0 not surfaced as lifeline-exempt\n%s", out)
+	}
+}
+
+// TestRenderInterfaceHostInboundLifeline3682 pins the per-interface diagnostic:
+// a lifeline interface renders the exempt marker in place of the default-deny
+// line; a non-lifeline no-stanza interface still renders default-deny.
+func TestRenderInterfaceHostInboundLifeline3682(t *testing.T) {
+	labels := HostInboundLabels{Indent: "  ", Sep: ", ", ServicesLabel: "Host-inbound services", ProtocolsLabel: "Host-inbound protocols"}
+	const exempt = "Host-inbound: lifeline-exempt (management/fabric, bypasses host-inbound deny)"
+
+	z := &ZoneConfig{}
+	// lifeline=true: exempt marker, NO default-deny line.
+	out := strings.Join(z.RenderInterfaceHostInbound("em0.0", true, labels), "\n")
+	if !strings.Contains(out, exempt) {
+		t.Errorf("lifeline diagnostic missing exempt marker\n%s", out)
+	}
+	if strings.Contains(out, "default deny") {
+		t.Errorf("lifeline diagnostic must not show default-deny\n%s", out)
+	}
+	// lifeline=false, no stanza: default-deny line, NO exempt marker.
+	out = strings.Join(z.RenderInterfaceHostInbound("ge-0/0/0.0", false, labels), "\n")
+	if !strings.Contains(out, "Host-inbound: default deny (no stanza)") {
+		t.Errorf("non-lifeline diagnostic missing default-deny line\n%s", out)
+	}
+	if strings.Contains(out, exempt) {
+		t.Errorf("non-lifeline diagnostic must not show lifeline-exempt marker\n%s", out)
+	}
+}

--- a/pkg/config/lifeline.go
+++ b/pkg/config/lifeline.go
@@ -1,0 +1,83 @@
+package config
+
+import "strings"
+
+// lifeline.go is the SSOT for host-inbound LIFELINE interface matching (#3682).
+// Before #3682 the matcher lived privately in pkg/dataplane/userspace/zones.go
+// and drove the host-inbound deny-scoping decision, but no operator-visible zone
+// view could re-derive it, so a zone-assigned lifeline interface silently
+// dropped out of the host-inbound default-deny with nothing to render the
+// exemption. Hoisting the matcher here lets the shared host-inbound presenter
+// (host_inbound_view.go) surface the exemption on every text zone view while the
+// dataplane path keeps using the identical logic (userspace/zones.go now
+// delegates here) — one source of truth for both enforcement and display.
+
+// LifelineBaseName strips the unit suffix (".0") and surrounding whitespace from
+// a logical interface name, returning the bare device name used for lifeline
+// matching ("fxp0.0" -> "fxp0", "fab1.0" -> "fab1"). Returns "" for an empty
+// name.
+func LifelineBaseName(name string) string {
+	base := strings.TrimSpace(name)
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	return base
+}
+
+// HostInboundLifelineSet resolves the set of management / cluster-control
+// LIFELINE interface base names that must NEVER be subjected to a host-inbound
+// deny. It is the config-aware superset of the always-on defaults:
+//
+//   - fxp0 (out-of-band management) is always a lifeline.
+//   - The chassis-cluster control-interface and fabric interface(s) are added
+//     from config so an operator-renamed control link (e.g.
+//     `control-interface fxp1`) or a non-default fabric name is excluded too.
+//     This is the #3277 fix: the old matcher hardcoded fxp0/em0/fab* and so left
+//     a configured `control-interface fxp1` SUBJECT to host-inbound deny scoping
+//     -> potential heartbeat drop -> HA split-brain.
+//
+// em0 (the canonical cluster-control default name) and the fabric prefix fab*
+// stay matched unconditionally in HostInboundLifelineInterface so the canonical
+// default-named configs remain byte-identical (#3070/#3172/#3224 behavior is
+// preserved). A standalone config (no chassis-cluster stanza) contributes no
+// extra names here, so its only lifeline is fxp0 (em0/fab* are no-ops because
+// such interfaces are not present) — #1960.
+func HostInboundLifelineSet(cfg *Config) map[string]bool {
+	set := map[string]bool{"fxp0": true}
+	if cfg != nil && cfg.Chassis.Cluster != nil {
+		cc := cfg.Chassis.Cluster
+		for _, name := range []string{cc.ControlInterface, cc.FabricInterface, cc.Fabric1Interface} {
+			if base := LifelineBaseName(name); base != "" {
+				set[base] = true
+			}
+		}
+	}
+	return set
+}
+
+// HostInboundLifelineInterface reports whether the given logical interface name
+// is a management / cluster-control LIFELINE that must NEVER be subjected to a
+// host-inbound deny. The lifeline set is the config-derived set (fxp0 plus the
+// configured chassis-cluster control-interface / fabric interfaces, #3277) UNION
+// the always-on backward-compatible defaults em0 (cluster control plane /
+// heartbeat default name) and the fabric links (fab*). Denying host-bound
+// traffic on these would strand management or break HA. The base name (before
+// the unit suffix) is matched so "fxp0.0" / "em0.0" are caught too.
+//
+// #3682 design note (follow-up): the em0/fab* match is base-name-prefix based,
+// so a broader interface literally named "fab-foo" would also be exempted, and
+// a standalone config that merely happens to name an interface em0/fabX gets a
+// silent exception with no configured management/cluster role. Whether this
+// should be an EXACT / role-gated match rather than a prefix bypass is tracked
+// as a design question on the issue; #3682 changes VISIBILITY only, not the
+// matching semantics.
+func HostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
+	base := LifelineBaseName(name)
+	if base == "" {
+		return false
+	}
+	if lifelines[base] {
+		return true
+	}
+	return base == "em0" || strings.HasPrefix(base, "fab")
+}

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -40,66 +40,19 @@ type ZoneHostInboundView struct {
 	V6Addrs        []string // bare host IPv6 addresses (no prefix)
 }
 
-// lifelineBaseName strips the unit suffix (".0") and surrounding whitespace from
-// a logical interface name, returning the bare device name used for lifeline
-// matching ("fxp0.0" -> "fxp0", "fab1.0" -> "fab1"). Returns "" for an empty
-// name.
-func lifelineBaseName(name string) string {
-	base := strings.TrimSpace(name)
-	if i := strings.IndexByte(base, '.'); i >= 0 {
-		base = base[:i]
-	}
-	return base
-}
+// The host-inbound LIFELINE matcher is the SSOT in pkg/config (lifeline.go,
+// #3682) so the shared host-inbound presenter can render the exemption on the
+// operator-visible zone views. These thin wrappers keep the dataplane call sites
+// and the #3277 fail-on-revert tests reading against the local names while the
+// matching logic (fxp0 + configured control/fabric + em0/fab* defaults) lives in
+// exactly one place shared with display.
 
-// hostInboundLifelineSet resolves the set of management / cluster-control
-// LIFELINE interface base names that must NEVER be subjected to a host-inbound
-// deny. It is the config-aware superset of the always-on defaults:
-//
-//   - fxp0 (out-of-band management) is always a lifeline.
-//   - The chassis-cluster control-interface and fabric interface(s) are added
-//     from config so an operator-renamed control link (e.g.
-//     `control-interface fxp1`) or a non-default fabric name is excluded too.
-//     This is the #3277 fix: the old matcher hardcoded fxp0/em0/fab* and so left
-//     a configured `control-interface fxp1` SUBJECT to host-inbound deny scoping
-//     -> potential heartbeat drop -> HA split-brain.
-//
-// em0 (the canonical cluster-control default name) and the fabric prefix fab*
-// stay matched unconditionally in hostInboundLifelineInterface so the canonical
-// default-named configs remain byte-identical (#3070/#3172/#3224 behavior is
-// preserved). A standalone config (no chassis-cluster stanza) contributes no
-// extra names here, so its only lifeline is fxp0 (em0/fab* are no-ops because
-// such interfaces are not present) — #1960.
 func hostInboundLifelineSet(cfg *config.Config) map[string]bool {
-	set := map[string]bool{"fxp0": true}
-	if cfg != nil && cfg.Chassis.Cluster != nil {
-		cc := cfg.Chassis.Cluster
-		for _, name := range []string{cc.ControlInterface, cc.FabricInterface, cc.Fabric1Interface} {
-			if base := lifelineBaseName(name); base != "" {
-				set[base] = true
-			}
-		}
-	}
-	return set
+	return config.HostInboundLifelineSet(cfg)
 }
 
-// hostInboundLifelineInterface reports whether the given logical interface name
-// is a management / cluster-control LIFELINE that must NEVER be subjected to a
-// host-inbound deny. The lifeline set is the config-derived set (fxp0 plus the
-// configured chassis-cluster control-interface / fabric interfaces, #3277) UNION
-// the always-on backward-compatible defaults em0 (cluster control plane /
-// heartbeat default name) and the fabric links (fab*). Denying host-bound
-// traffic on these would strand management or break HA. The base name (before
-// the unit suffix) is matched so "fxp0.0" / "em0.0" are caught too.
 func hostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
-	base := lifelineBaseName(name)
-	if base == "" {
-		return false
-	}
-	if lifelines[base] {
-		return true
-	}
-	return base == "em0" || strings.HasPrefix(base, "fab")
+	return config.HostInboundLifelineInterface(name, lifelines)
 }
 
 // BuildZoneHostInboundViews returns one ZoneHostInboundView per configured

--- a/pkg/grpcapi/server_show_interfaces.go
+++ b/pkg/grpcapi/server_show_interfaces.go
@@ -277,6 +277,15 @@ func (s *Server) ShowInterfacesDetail(_ context.Context, req *pb.ShowInterfacesD
 					fmt.Fprintf(&buf, "    Allowed host-inbound protocols: %s\n", strings.Join(hit.Protocols, " "))
 				}
 			}
+			// #3682: flag a management / cluster-control lifeline interface,
+			// which is EXCLUDED from host-inbound deny scoping, so the implicit
+			// exemption is visible on this surface too.
+			if li.zone != nil {
+				ref := fmt.Sprintf("%s.%d", physName, li.unitNum)
+				if config.HostInboundLifelineInterface(ref, config.HostInboundLifelineSet(cfg)) {
+					fmt.Fprintln(&buf, "    Host-inbound: lifeline-exempt (management/fabric, bypasses host-inbound deny)")
+				}
+			}
 
 			// DHCP annotations
 			var unit *config.InterfaceUnit

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -75,6 +75,12 @@ func (s *Server) GetZones(_ context.Context, _ *pb.GetZonesRequest) (*pb.GetZone
 				Protocols:      append([]string{}, hib.Protocols...),
 			})
 		}
+		// #3682: surface the management / cluster-control lifeline interfaces
+		// EXCLUDED from this zone's host-inbound deny scoping (always-admitted),
+		// so the remote CLI and any structured consumer can render the implicit
+		// exemption instead of it being an invisible bypass.
+		zi.LifelineInterfaces = zone.HostInboundViewWithLifelines(
+			config.HostInboundLifelineSet(cfg)).LifelineInterfaces
 		if zi.Interfaces == nil {
 			zi.Interfaces = []string{}
 		}

--- a/pkg/grpcapi/server_show_zones_lifeline_3682_test.go
+++ b/pkg/grpcapi/server_show_zones_lifeline_3682_test.go
@@ -1,0 +1,82 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3682: the structured GetZones RPC must surface the management/cluster-control
+// LIFELINE interfaces that are EXCLUDED from a zone's host-inbound deny scoping,
+// so the remote CLI and automation can render the (otherwise invisible) implicit
+// exemption. This is the fail-on-revert guard for the wire propagation: dropping
+// the zi.LifelineInterfaces population in server_show_zones.go turns it RED.
+func lifelineZonesGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone mgmt {
+            host-inbound-traffic {
+                system-services {
+                    ssh;
+                }
+            }
+            interfaces {
+                em0.0;
+                ge-0/0/0.0;
+            }
+        }
+        security-zone trust {
+            interfaces {
+                ge-0/0/1.0;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestGetZonesSurfacesLifelineExemption3682(t *testing.T) {
+	s := &Server{store: lifelineZonesGRPCStore(t)}
+
+	resp, err := s.GetZones(context.Background(), &pb.GetZonesRequest{})
+	if err != nil {
+		t.Fatalf("GetZones() error = %v", err)
+	}
+	byName := map[string]*pb.ZoneInfo{}
+	for _, z := range resp.GetZones() {
+		byName[z.GetName()] = z
+	}
+
+	mgmt, ok := byName["mgmt"]
+	if !ok {
+		t.Fatal("mgmt zone missing from gRPC inventory")
+	}
+	got := mgmt.GetLifelineInterfaces()
+	if len(got) != 1 || got[0] != "em0.0" {
+		t.Fatalf("mgmt lifeline_interfaces = %v, want [em0.0] (the data interface ge-0/0/0.0 is NOT a lifeline)", got)
+	}
+
+	// A zone with only data interfaces exposes no lifeline exemption.
+	trust, ok := byName["trust"]
+	if !ok {
+		t.Fatal("trust zone missing")
+	}
+	if got := trust.GetLifelineInterfaces(); len(got) != 0 {
+		t.Fatalf("trust lifeline_interfaces = %v, want none", got)
+	}
+}

--- a/pkg/grpcapi/server_show_zones_text.go
+++ b/pkg/grpcapi/server_show_zones_text.go
@@ -63,8 +63,11 @@ func (s *Server) showZonesDetail(cfg *config.Config, buf *strings.Builder) {
 		// #3654: render the zone-level admitted set, the no-stanza default-deny
 		// posture line, AND any per-interface host-inbound override through the
 		// shared config presenter (H07/M03) so gRPC text stays in lockstep with
-		// the local CLI and the structured inventory.
-		for _, line := range zone.HostInboundView().Render(config.HostInboundLabels{
+		// the local CLI and the structured inventory. #3682: the presenter also
+		// renders the management/cluster-control lifeline interfaces excluded
+		// from host-inbound deny scoping so the implicit exemption is auditable.
+		for _, line := range zone.HostInboundViewWithLifelines(
+			config.HostInboundLifelineSet(cfg)).Render(config.HostInboundLabels{
 			Indent:         "  ",
 			Sep:            ", ",
 			ServicesLabel:  "Host-inbound system-services",
@@ -251,12 +254,17 @@ func (s *Server) showTestZone(req *pb.ShowTextRequest, cfg *config.Config, buf *
 					// DIAGNOSTIC, so report the EFFECTIVE (zone UNION interface)
 					// set for THIS interface and flag when it is governed by an
 					// interface-local override rather than only the zone set.
-					for _, line := range zone.RenderInterfaceHostInbound(ifName, config.HostInboundLabels{
-						Indent:         "  ",
-						Sep:            ", ",
-						ServicesLabel:  "Host-inbound services",
-						ProtocolsLabel: "Host-inbound protocols",
-					}) {
+					// #3682: also flag when THIS interface is a management /
+					// cluster-control lifeline excluded from host-inbound deny.
+					lifeline := config.HostInboundLifelineInterface(
+						ifName, config.HostInboundLifelineSet(cfg))
+					for _, line := range zone.RenderInterfaceHostInbound(ifName, lifeline,
+						config.HostInboundLabels{
+							Indent:         "  ",
+							Sep:            ", ",
+							ServicesLabel:  "Host-inbound services",
+							ProtocolsLabel: "Host-inbound protocols",
+						}) {
 						buf.WriteString(line)
 						buf.WriteString("\n")
 					}

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -1936,8 +1936,17 @@ type ZoneInfo struct {
 	// `host-inbound-traffic` stanza; the effective admission set for that
 	// interface is the UNION of the zone-level set above and its override.
 	InterfaceHostInbound []*InterfaceHostInbound `protobuf:"bytes,15,rep,name=interface_host_inbound,json=interfaceHostInbound,proto3" json:"interface_host_inbound,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// lifeline_interfaces (#3682) lists the zone's interfaces that are
+	// management / cluster-control LIFELINES (fxp0 / em0 / fab* / configured
+	// control-interface / fabric-interface) and are therefore EXCLUDED from this
+	// zone's host-inbound deny scoping — their host-bound traffic is always
+	// admitted regardless of the admission set above. Surfaced so the implicit
+	// management-plane exception is operator-visible and auditable rather than a
+	// silent bypass. Sorted, deduplicated; empty for a zone with no lifeline
+	// member. VISIBILITY only — the exemption semantics are unchanged.
+	LifelineInterfaces []string `protobuf:"bytes,16,rep,name=lifeline_interfaces,json=lifelineInterfaces,proto3" json:"lifeline_interfaces,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ZoneInfo) Reset() {
@@ -2071,6 +2080,13 @@ func (x *ZoneInfo) GetHostInboundProtocols() []string {
 func (x *ZoneInfo) GetInterfaceHostInbound() []*InterfaceHostInbound {
 	if x != nil {
 		return x.InterfaceHostInbound
+	}
+	return nil
+}
+
+func (x *ZoneInfo) GetLifelineInterfaces() []string {
+	if x != nil {
+		return x.LifelineInterfaces
 	}
 	return nil
 }
@@ -7850,7 +7866,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\x05value\x18\x02 \x01(\x04R\x05value:\x028\x01\"\x11\n" +
 	"\x0fGetZonesRequest\":\n" +
 	"\x10GetZonesResponse\x12&\n" +
-	"\x05zones\x18\x01 \x03(\v2\x10.xpf.v1.ZoneInfoR\x05zones\"\xff\x04\n" +
+	"\x05zones\x18\x01 \x03(\v2\x10.xpf.v1.ZoneInfoR\x05zones\"\xb0\x05\n" +
 	"\bZoneInfo\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\rR\x02id\x12%\n" +
@@ -7869,7 +7885,8 @@ const file_xpf_proto_rawDesc = "" +
 	"\x17host_inbound_configured\x18\f \x01(\bR\x15hostInboundConfigured\x12?\n" +
 	"\x1chost_inbound_system_services\x18\r \x03(\tR\x19hostInboundSystemServices\x124\n" +
 	"\x16host_inbound_protocols\x18\x0e \x03(\tR\x14hostInboundProtocols\x12R\n" +
-	"\x16interface_host_inbound\x18\x0f \x03(\v2\x1c.xpf.v1.InterfaceHostInboundR\x14interfaceHostInbound\"\x9b\x01\n" +
+	"\x16interface_host_inbound\x18\x0f \x03(\v2\x1c.xpf.v1.InterfaceHostInboundR\x14interfaceHostInbound\x12/\n" +
+	"\x13lifeline_interfaces\x18\x10 \x03(\tR\x12lifelineInterfaces\"\x9b\x01\n" +
 	"\x14InterfaceHostInbound\x12\x1c\n" +
 	"\tinterface\x18\x01 \x01(\tR\tinterface\x12\x1e\n" +
 	"\n" +

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -253,6 +253,15 @@ message ZoneInfo {
   // `host-inbound-traffic` stanza; the effective admission set for that
   // interface is the UNION of the zone-level set above and its override.
   repeated InterfaceHostInbound interface_host_inbound = 15;
+  // lifeline_interfaces (#3682) lists the zone's interfaces that are
+  // management / cluster-control LIFELINES (fxp0 / em0 / fab* / configured
+  // control-interface / fabric-interface) and are therefore EXCLUDED from this
+  // zone's host-inbound deny scoping — their host-bound traffic is always
+  // admitted regardless of the admission set above. Surfaced so the implicit
+  // management-plane exception is operator-visible and auditable rather than a
+  // silent bypass. Sorted, deduplicated; empty for a zone with no lifeline
+  // member. VISIBILITY only — the exemption semantics are unchanged.
+  repeated string lifeline_interfaces = 16;
 }
 
 // InterfaceHostInbound (#3328, #3362) is a per-interface host-inbound-traffic


### PR DESCRIPTION
Closes #3682

## Problem

The host-inbound LIFELINE set — `fxp0` / `em0` / `fab*` plus the configured
chassis-cluster `control-interface` and fabric interfaces — is excluded from a
zone's host-inbound deny scoping so management / cluster-control traffic is
always admitted (#3070/#3172/#3277). The exclusion is defensible for HA and
management survivability, but it was an **implicit** policy exception: a
zone-assigned lifeline interface silently dropped out of the default-deny
host-inbound enforcement (`pkg/dataplane/userspace/zones.go` `hostInboundLifeline*`
+ the `BuildZoneHostInboundViews` skip) and **no rendered zone view told the
operator**, so the exception was neither visible nor auditable. vSRX-style
posture should make management-plane exceptions explicit.

## Fix (visibility only — semantics unchanged)

- **SSOT**: hoist the lifeline matcher to `pkg/config/lifeline.go`
  (`LifelineBaseName` / `HostInboundLifelineSet` / `HostInboundLifelineInterface`)
  and have the dataplane deny-scoping path delegate to it, so enforcement and
  display can never drift.
- **Shared presenter** (`pkg/config/host_inbound_view.go`, the #3654 SSOT): add
  `LifelineInterfaces` + a `HostInboundViewWithLifelines` builder; `Render`
  emits `Host-inbound lifeline-exempt interfaces (management/fabric, bypass
  host-inbound deny): <ifaces>`, and `RenderInterfaceHostInbound` emits a
  lifeline-exempt marker in place of the misleading default-deny line.
- **Surfaces routed through it**: `show security zones` (local CLI, gRPC text,
  remote CLI), `show interfaces` (CLI + gRPC), `test security-zone interface`
  (CLI + gRPC).
- **Structured API**: add `lifeline_interfaces` to the `GetZones` `ZoneInfo`
  proto (regenerated), populate it, and consume it in the remote CLI so the
  structured path matches the text path.
- Doc bullet in `docs/junos-cli-reference.md`.

## Tests

- `TestHostInboundViewLifelineExemptRendered3682` (+ per-interface and
  cluster-config variants) — the RED-on-revert proof. Neutering the two render
  blocks fails all three #3682 config tests (verified).
- `TestGetZonesSurfacesLifelineExemption3682` — guards the structured wire field.
- `TestHostInboundLifelineInterface3682` — matcher contract.
- `go build ./pkg/... ./cmd/...` clean; `go test ./pkg/config/... ./pkg/cli/...
  ./pkg/grpcapi/... ./pkg/dataplane/...` green; gofmt + `go vet` clean on touched
  packages (the two remaining tree-wide vet diagnostics are pre-existing, in
  untouched files, documented in the Makefile).

## Design follow-up (NOT changed here — the issue's secondary design question)

The `em0` / `fab*` match is a base-name **prefix** (`strings.HasPrefix(base,
"fab")`) plus an unconditional `em0` literal. Two consequences worth a design
decision:

1. A broader interface literally named `fab-foo` would also be treated as a
   lifeline and exempted.
2. A standalone config (no chassis-cluster stanza) that merely happens to name
   an interface `em0` / `fabX` gets a silent host-inbound exception even though
   there is no configured management/cluster role.

Whether the `em0`/`fab*` bypass should become an **exact** match and/or be
**gated on an actual configured cluster/management role** (rather than base-name
alone) is left as a follow-up design question. This PR changes visibility only
and preserves the existing matching semantics so no enforcement behavior moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
