### PR TITLE
policy-simulator output parity: match-policies description + scheduler, gRPC-text global test-policy ID/scope (#3685 M04/M05/M06)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25174,3 +25174,43 @@ top.
 - **File(s)**: pkg/policymatch/port_test.go, pkg/policymatch/icmp_test.go, pkg/api/rest_filter_failclosed_test.go
 - **Action**: Document the canonical-form guarantee on the diagnostic surfaces
 - **File(s)**: pkg/policymatch/README.md, pkg/api/README.md, _Log.md
+
+## 2026-07-01 — #3685 policy-simulator output parity residuals (M04/M05/M06)
+
+- **Timestamp**: 2026-07-01
+- **Action**: M06 — add `SchedulerName` to `policymatch.Result`, populated from
+  `pol.SchedulerName` in `matchedResult`, so the match-policies verdict names the
+  scheduler time-gate controlling the rule (mirrors the #3624 inventory field). A
+  matched policy is by construction currently active (the live surfaces thread a
+  fail-closed `PolicyInactiveFn`), so a non-empty `SchedulerName` names the gate
+  admitting the rule now
+- **File(s)**: pkg/policymatch/policymatch.go
+- **Action**: M05/M06 — add `description` (field 18), `scheduler_name` (field 19),
+  and `scheduler_active` (field 20) to the proto `MatchPoliciesResponse`
+  (additive, no renumber; regen via pinned protoc 3.21.12 / protoc-gen-go
+  v1.36.11 / protoc-gen-go-grpc v1.6.1, no version bump). `MatchPoliciesResponse`
+  is gRPC-only (no Rust userspace-dp reference / no wire fixture) — confirmed, no
+  regen needed
+- **File(s)**: proto/xpf/v1/xpf.proto, pkg/grpcapi/xpfv1/xpf.pb.go (generated)
+- **Action**: M05/M06 — populate `Description` + `SchedulerName` +
+  `SchedulerActive` (= `res.SchedulerName != ""`, effective-active since a match
+  is currently active) on the REST `MatchPoliciesResult` (+ new JSON fields
+  `description`/`scheduler_name`/`scheduler_active`, all `omitempty`) and the gRPC
+  `MatchPoliciesResponse` positive-match paths
+- **File(s)**: pkg/api/types.go, pkg/api/security.go, pkg/grpcapi/server_cluster.go
+- **Action**: M04 — bring the gRPC-text `test policy` GLOBAL branch to parity with
+  `show security match-policies`: print `Policy ID`, `Scope: global (match
+  from-zone/to-zone)`, and `Description` (was name+action only). The gRPC-text
+  sibling of the #3674 local request-path gap (distinct renderer)
+- **File(s)**: pkg/grpcapi/server_show_firewall.go
+- **Action**: RED-on-revert tests — matcher carries Description + SchedulerName
+  (and non-scheduled leaves SchedulerName empty); REST + gRPC responses carry
+  description + scheduler_name + scheduler_active (non-scheduled/undescribed omit
+  them); gRPC-text global `test policy` shows ID + scope + description. Verified
+  each layer goes RED when its population/render is reverted
+- **File(s)**: pkg/policymatch/simulator_output_parity_3685_test.go (new),
+  pkg/api/security_matchpolicies_desc_sched_3685_test.go (new),
+  pkg/grpcapi/server_matchpolicies_desc_sched_3685_test.go (new)
+- **Action**: Document the new response fields (M05/M06) and the gRPC-text global
+  render (M04) in the API/gRPC references
+- **File(s)**: pkg/api/README.md, pkg/grpcapi/README.md, _Log.md

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -595,7 +595,24 @@ under the daemon's errgroup. Nothing else imports this package.
   `junos-global->junos-global/<name>` form, matching the inventory global rows.
   All three are additive and set only on a positive match. The gRPC
   `MatchPoliciesResponse.source_address_excluded`/`destination_address_excluded`
-  (fields 15/16) and `rule_id` (field 17) mirror this.
+  (fields 15/16) and `rule_id` (field 17) mirror this. #3685 M05/M06: on a MATCH
+  the response also carries the policy `description` and the scheduler binding.
+  `description` (M05) is the matched policy's `description` text — the same field
+  the inventory (`GetPolicies`) and the local `show security match-policies`
+  result carry over the SAME `policymatch.Result`; descriptions often hold
+  ticket / change-control context, so a match verdict without it was weaker than
+  the inventory / CLI answer. `scheduler_name`/`scheduler_active` (M06) name the
+  time-gate: `scheduler_name` is the policy's `scheduler-name` binding
+  (mirroring the inventory `PolicyRule` field, #3624), and `scheduler_active` is
+  the explicit effective-active flag. A positive match is by construction
+  currently active — the handler always threads a fail-closed
+  `PolicyInactiveFn` (#3414) that SKIPS a scheduler-inactive rule before it can
+  match — so a matched scheduled policy always reports `scheduler_active=true`;
+  it names the gate admitting the rule right now, not a rule that is gated off.
+  All three are additive and set only on a positive match; both scheduler fields
+  are omitted for a non-scheduled (always-on) policy. The gRPC
+  `MatchPoliciesResponse.description` (field 18), `scheduler_name` (field 19),
+  and `scheduler_active` (field 20) mirror these.
 - The SSE handler reads from `pkg/logging.EventBuffer`. The buffer is
   bounded; if a consumer stops reading, events are dropped silently — by
   design.

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -644,7 +644,19 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 		// #3668: the stable rule identity (inventory join key) + the
 		// address-exclusion flags so a positive verdict against a
 		// source/destination-address-excluded rule does not read backwards.
-		RuleID:                     res.RuleID,
+		RuleID: res.RuleID,
+		// #3685 M05: carry the matched policy's description (ticket / change
+		// context) so the match verdict is not weaker than the inventory /
+		// local CLI answers over the same policymatch.Result.
+		Description: res.Description,
+		// #3685 M06: name the scheduler time-gate and confirm it is currently
+		// admitting the rule. A positive match here is by construction active
+		// (inactiveFn above already skipped a scheduler-inactive rule, #3414),
+		// so SchedulerActive tracks whether the matched rule is scheduler-gated
+		// at all — true only for a scheduled policy, omitted for an always-on
+		// one.
+		SchedulerName:              res.SchedulerName,
+		SchedulerActive:            res.SchedulerName != "",
 		Action:                     res.DisplayAction(),
 		SrcAddresses:               res.SrcAddresses,
 		DstAddresses:               res.DstAddresses,

--- a/pkg/api/security_matchpolicies_desc_sched_3685_test.go
+++ b/pkg/api/security_matchpolicies_desc_sched_3685_test.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// descSchedAPIStore commits a trust->untrust PERMIT that carries BOTH a
+// `description` (ticket/change context, #3685 M05) and a `scheduler-name`
+// binding (#3685 M06), with default-policy deny. The scheduler "workhours"
+// is defined so the config compiles cleanly.
+func descSchedAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy allow-web {
+                description "CHG-4242 web access";
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// descSchedResponse decodes the REST /security/match envelope including the
+// #3685 description + scheduler binding/effective-state fields.
+type descSchedResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Matched         bool   `json:"matched"`
+		PolicyName      string `json:"policy_name"`
+		Description     string `json:"description"`
+		SchedulerName   string `json:"scheduler_name"`
+		SchedulerActive bool   `json:"scheduler_active"`
+	} `json:"data"`
+}
+
+// TestMatchPoliciesRESTCarriesDescriptionAndScheduler pins #3685 M05+M06 on the
+// REST surface: the /security/match JSON for a matched policy must carry the
+// policy `description` (M05) and the scheduler binding + effective-active flag
+// (M06), so a stored match verdict is not weaker than the inventory / local CLI
+// answer over the same policymatch.Result.
+//
+// RED-on-revert: removing the Description / SchedulerName / SchedulerActive
+// field copies from matchPoliciesHandler (pkg/api/security.go) drops them from
+// the JSON and every assertion below fails. Removing the SchedulerName copy in
+// policymatch.matchedResult also flips SchedulerName/SchedulerActive red (the
+// handler derives both from res.SchedulerName).
+func TestMatchPoliciesRESTCarriesDescriptionAndScheduler(t *testing.T) {
+	store := descSchedAPIStore(t)
+	s := &Server{store: store}
+	// The scheduler must be ACTIVE for the scheduled permit to match (the
+	// handler always threads a fail-closed PolicyInactiveFn, so a scheduled
+	// rule is skipped unless live active-state says otherwise).
+	s.policySchedActiveFn = func() (map[string]bool, bool) {
+		return map[string]bool{"workhours": true}, true
+	}
+
+	rr := httptest.NewRecorder()
+	q := url.Values{
+		"from_zone": {"trust"},
+		"to_zone":   {"untrust"},
+		"protocol":  {"tcp"},
+		"dst_port":  {"80"},
+	}
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+	s.matchPoliciesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp descSchedResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Success || !resp.Data.Matched {
+		t.Fatalf("expected a successful match; body: %s", rr.Body.String())
+	}
+	if resp.Data.Description != "CHG-4242 web access" {
+		t.Errorf("description = %q, want %q (M05); body: %s", resp.Data.Description, "CHG-4242 web access", rr.Body.String())
+	}
+	if resp.Data.SchedulerName != "workhours" {
+		t.Errorf("scheduler_name = %q, want %q (M06); body: %s", resp.Data.SchedulerName, "workhours", rr.Body.String())
+	}
+	if !resp.Data.SchedulerActive {
+		t.Errorf("scheduler_active = false, want true (M06 — a matched scheduled policy is currently active); body: %s", rr.Body.String())
+	}
+}
+
+// TestMatchPoliciesRESTNonScheduledOmitsSchedulerFields is the negative
+// control: a matched policy with NO description and NO scheduler binding must
+// leave description / scheduler_name / scheduler_active omitted (all zero), so
+// the new fields never manufacture a phantom time-gate for an always-on policy.
+func TestMatchPoliciesRESTNonScheduledOmitsSchedulerFields(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy plain-allow {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	s := &Server{store: store}
+
+	rr := httptest.NewRecorder()
+	q := url.Values{"from_zone": {"trust"}, "to_zone": {"untrust"}, "protocol": {"tcp"}, "dst_port": {"80"}}
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+q.Encode(), nil)
+	s.matchPoliciesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp descSchedResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body: %s", err, rr.Body.String())
+	}
+	if !resp.Data.Matched {
+		t.Fatalf("expected a match; body: %s", rr.Body.String())
+	}
+	if resp.Data.Description != "" || resp.Data.SchedulerName != "" || resp.Data.SchedulerActive {
+		t.Errorf("non-scheduled/undescribed match leaked fields: description=%q scheduler_name=%q scheduler_active=%v",
+			resp.Data.Description, resp.Data.SchedulerName, resp.Data.SchedulerActive)
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -521,10 +521,30 @@ type MatchPoliciesResult struct {
 	// identifier used by inventory, logs, and tests even after a policy reorder.
 	// Present only on a positive match (a matched global policy uses the
 	// "junos-global->junos-global/<name>" form, matching inventory global rows).
-	RuleID       string   `json:"rule_id,omitempty"`
-	Action       string   `json:"action"`
-	SrcAddresses []string `json:"src_addresses,omitempty"`
-	DstAddresses []string `json:"dst_addresses,omitempty"`
+	RuleID string `json:"rule_id,omitempty"`
+	// Description is the matched policy's `description` text (#3685 M05), the
+	// same field the inventory (GetPolicies) and the local `show security
+	// match-policies` result carry over the SAME policymatch.Result.
+	// Descriptions often hold ticket / change-control context, so a match
+	// verdict without it is weaker than the CLI and inventory answers. Present
+	// only on a positive match with a non-empty description.
+	Description string `json:"description,omitempty"`
+	// SchedulerName / SchedulerActive expose the matched policy's time-gate
+	// (#3685 M06). SchedulerName is the `scheduler-name` binding (mirroring the
+	// inventory PolicyRule field, #3624); SchedulerActive is the explicit
+	// effective-active flag — true when the matched policy is scheduler-gated
+	// AND currently active. A positive match is by construction currently active
+	// (the REST handler always threads a fail-closed PolicyInactiveFn that skips
+	// a scheduler-inactive rule before it can match, #3104/#3414), so a matched
+	// scheduled policy always reports SchedulerActive true; it names the gate
+	// admitting the rule right now. Both empty/false (omitted) for a
+	// non-scheduled (always-on) policy and for the unmatched / host-inbound /
+	// default cases.
+	SchedulerName   string   `json:"scheduler_name,omitempty"`
+	SchedulerActive bool     `json:"scheduler_active,omitempty"`
+	Action          string   `json:"action"`
+	SrcAddresses    []string `json:"src_addresses,omitempty"`
+	DstAddresses    []string `json:"dst_addresses,omitempty"`
 	// SourceAddressExcluded / DestinationAddressExcluded report whether the
 	// matched policy carries Junos `source-address-excluded` /
 	// `destination-address-excluded` (#3668): the rule matches every address

--- a/pkg/grpcapi/README.md
+++ b/pkg/grpcapi/README.md
@@ -137,6 +137,30 @@ contract.
   `source_address_excluded`/`destination_address_excluded`/`rule_id` JSON
   fields, and both CLI renderers annotate the exclusion as
   `Source addresses (except): ...` plus a `Rule ID:` line.
+- #3685 M05/M06: on a MATCH the response also carries the policy `description`
+  (proto field 18) and the scheduler binding `scheduler_name` (field 19) /
+  effective-active flag `scheduler_active` (field 20). `description` (M05) is the
+  matched policy's `description` text, the same field the inventory
+  (`GetPolicies`) and the local `show security match-policies` result carry over
+  the SAME `policymatch.Result`; a match verdict without it was weaker than the
+  inventory / CLI answer (descriptions often hold ticket / change-control
+  context). `scheduler_name` (M06) mirrors the inventory `PolicyRule` scheduler
+  binding (#3624); `scheduler_active` is the explicit effective-active flag. A
+  positive match is by construction currently active — `s.policyInactiveFn()` is
+  fail-closed (#3414) and SKIPS a scheduler-inactive rule before it can match —
+  so a matched scheduled policy always reports `scheduler_active=true`; it names
+  the gate admitting the rule right now. All three are additive, set only on a
+  positive match, and both scheduler fields are omitted for a non-scheduled
+  policy. The REST `MatchPoliciesResult` carries the same
+  `description`/`scheduler_name`/`scheduler_active` JSON fields.
+- #3685 M04: the gRPC-text `test policy` renderer (`server_show_firewall.go`,
+  the remote `cli` backend) prints the policy ID, the global match scope, and
+  the description for a GLOBAL match, mirroring `show security match-policies`.
+  Before #3685 the global branch printed only `Policy:`/`Action:`, dropping the
+  ID (session-table / audit join key when a global name collides with a
+  zone-pair name), the scope, and the description — the gRPC-text sibling of the
+  local request-path gap tracked in #3674 (`pkg/cli/cli_request.go`, a distinct
+  renderer). The zone-pair branch already printed the from/to zones.
 - The `test policy` operational command (local `pkg/cli` + remote `cmd/cli`
   → ShowText `test-policy:` topic → `showTestPolicy`) carries the same
   source-port input (#3107). The topic adds a `srcport=` key alongside the

--- a/pkg/grpcapi/server_cluster.go
+++ b/pkg/grpcapi/server_cluster.go
@@ -280,10 +280,21 @@ func (s *Server) MatchPolicies(_ context.Context, req *pb.MatchPoliciesRequest) 
 		RuleId:                     res.RuleID,
 		SourceAddressExcluded:      res.SourceAddressExcluded,
 		DestinationAddressExcluded: res.DestinationAddressExcluded,
-		Action:                     res.DisplayAction(),
-		SrcAddresses:               res.SrcAddresses,
-		DstAddresses:               res.DstAddresses,
-		Applications:               res.Applications,
+		// #3685 M05: the matched policy's description (ticket / change context),
+		// mirroring the inventory and local CLI result over the same
+		// policymatch.Result.
+		Description: res.Description,
+		// #3685 M06: name the scheduler time-gate and confirm it is currently
+		// admitting the rule. A positive match here is by construction active
+		// (policyInactiveFn already skipped a scheduler-inactive rule, #3414), so
+		// SchedulerActive is true only for a scheduled policy and omitted for an
+		// always-on one.
+		SchedulerName:   res.SchedulerName,
+		SchedulerActive: res.SchedulerName != "",
+		Action:          res.DisplayAction(),
+		SrcAddresses:    res.SrcAddresses,
+		DstAddresses:    res.DstAddresses,
+		Applications:    res.Applications,
 	}, nil
 }
 

--- a/pkg/grpcapi/server_matchpolicies_desc_sched_3685_test.go
+++ b/pkg/grpcapi/server_matchpolicies_desc_sched_3685_test.go
@@ -1,0 +1,161 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// descSchedGRPCStore commits a trust->untrust PERMIT carrying both a
+// `description` (#3685 M05) and a `scheduler-name` binding (#3685 M06), with
+// default-policy deny and the scheduler "workhours" defined.
+func descSchedGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+schedulers {
+    scheduler workhours {
+        daily;
+    }
+}
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy allow-web {
+                description "CHG-4242 web access";
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+                scheduler-name workhours;
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestMatchPoliciesResponseCarriesDescriptionAndScheduler pins #3685 M05+M06 on
+// the gRPC MatchPolicies surface: a positive verdict must carry the matched
+// policy's description (M05) and its scheduler binding + effective-active flag
+// (M06), mirroring the inventory and the local CLI result over the same
+// policymatch.Result.
+//
+// RED-on-revert: before #3685 MatchPoliciesResponse had no description /
+// scheduler_name / scheduler_active fields; dropping the population in
+// server_cluster.go (or reverting the proto additions) zeroes them and every
+// assertion below fails. Removing the SchedulerName copy in
+// policymatch.matchedResult also flips scheduler_name/scheduler_active red.
+func TestMatchPoliciesResponseCarriesDescriptionAndScheduler(t *testing.T) {
+	s := &Server{store: descSchedGRPCStore(t)}
+	// Provider present + scheduler ACTIVE so the scheduled permit matches (the
+	// simulator threads a fail-closed PolicyInactiveFn otherwise).
+	s.dp = &schedulerStateDP{Manager: dataplane.New(), active: map[string]bool{"workhours": true}}
+
+	resp, err := s.MatchPolicies(context.Background(), &pb.MatchPoliciesRequest{
+		FromZone:        "trust",
+		ToZone:          "untrust",
+		Protocol:        "tcp",
+		DestinationPort: 80,
+	})
+	if err != nil {
+		t.Fatalf("MatchPolicies error = %v", err)
+	}
+	if !resp.Matched {
+		t.Fatalf("expected match, got %+v", resp)
+	}
+	if resp.GetDescription() != "CHG-4242 web access" {
+		t.Errorf("description = %q, want %q (M05)", resp.GetDescription(), "CHG-4242 web access")
+	}
+	if resp.GetSchedulerName() != "workhours" {
+		t.Errorf("scheduler_name = %q, want %q (M06)", resp.GetSchedulerName(), "workhours")
+	}
+	if !resp.GetSchedulerActive() {
+		t.Errorf("scheduler_active = false, want true (M06 — a matched scheduled policy is currently active)")
+	}
+}
+
+// globalDescPolicyStore commits a GLOBAL described PERMIT (scoped to
+// from-zone trust) with default-policy deny, so a trust->untrust flow matches
+// the global rule. Used by the M04 gRPC-text `test policy` global-branch test.
+func globalDescPolicyStore(t *testing.T) *Server {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        global {
+            policy g-allow {
+                description "CHG-7 global allow";
+                match { source-address any; destination-address any; application any; from-zone trust; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &Server{store: store}
+}
+
+// TestShowTestPolicyGlobalCarriesIDScopeDescription pins #3685 M04: the
+// gRPC-text `test policy` renderer (server_show_firewall.go, the remote `cli`
+// backend) for a GLOBAL match must print the policy ID, the global match scope,
+// and the description — mirroring `show security match-policies` — instead of
+// the pre-#3685 name+action-only output.
+//
+// RED-on-revert: reverting the global branch to the two-line
+// "Policy:" / "Action:" form drops the "Policy ID:", "Scope:     global", and
+// "Description:" lines, flipping the Contains assertions red.
+func TestShowTestPolicyGlobalCarriesIDScopeDescription(t *testing.T) {
+	s := globalDescPolicyStore(t)
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{
+		Topic: "test-policy:from=trust,to=untrust,proto=tcp,port=80",
+	})
+	if err != nil {
+		t.Fatalf("ShowText error = %v", err)
+	}
+	out := resp.Output
+	if !strings.Contains(out, "Policy match (global):") {
+		t.Fatalf("output missing global match header:\n%s", out)
+	}
+	for _, want := range []string{
+		"Policy:    g-allow",
+		"Policy ID:",
+		"Scope:     global (match from-zone: trust, to-zone: any)",
+		"Description: CHG-7 global allow",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q (M04):\n%s", want, out)
+		}
+	}
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -289,6 +289,20 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 		case res.Matched && res.Global:
 			fmt.Fprintf(buf, "Policy match (global):\n")
 			fmt.Fprintf(buf, "  Policy:    %s\n", res.PolicyName)
+			// #3685 M04: identify WHICH global policy matched (ID + match scope
+			// + description), mirroring `show security match-policies`, so this
+			// gRPC-text `test policy` global verdict is not sparser than the
+			// show path over the SAME policymatch.Result. Before #3685 the
+			// global branch printed only name + action, dropping the policy ID
+			// (session-table / audit join key when global names collide with
+			// zone-pair names), the global match scope, and the description
+			// (ticket / change context).
+			fmt.Fprintf(buf, "  Policy ID: %d\n", res.PolicyID)
+			fmt.Fprintf(buf, "  Scope:     global (match from-zone: %s, to-zone: %s)\n",
+				globalZoneScopeLabel(res.FromZone), globalZoneScopeLabel(res.ToZone))
+			if res.Description != "" {
+				fmt.Fprintf(buf, "  Description: %s\n", res.Description)
+			}
 			fmt.Fprintf(buf, "  Action:    %s\n", policymatch.ActionString(res.Action))
 		case res.Matched:
 			fmt.Fprintf(buf, "Policy match:\n")

--- a/pkg/grpcapi/xpfv1/xpf.pb.go
+++ b/pkg/grpcapi/xpfv1/xpf.pb.go
@@ -6564,9 +6564,30 @@ type MatchPoliciesResponse struct {
 	// "junos-global->junos-global/<name>" exactly like the inventory global rows.
 	// Additive; empty (omitted) for the unmatched / host-inbound / default cases.
 	// Set only when matched is true.
-	RuleId        string `protobuf:"bytes,17,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	RuleId string `protobuf:"bytes,17,opt,name=rule_id,json=ruleId,proto3" json:"rule_id,omitempty"`
+	// #3685 M05: description is the matched policy's `description` text, the same
+	// field the inventory (GetPolicies) and the local `show security
+	// match-policies` result carry. Descriptions often hold ticket / change-
+	// control context, so a match verdict without it is weaker than the CLI and
+	// inventory answers over the SAME policymatch.Result. Additive; empty
+	// (omitted) for a policy with no description and for the unmatched /
+	// host-inbound / default cases. Set only when matched is true.
+	Description string `protobuf:"bytes,18,opt,name=description,proto3" json:"description,omitempty"`
+	// #3685 M06: scheduler_name / scheduler_active expose the matched policy's
+	// time-gate. scheduler_name is the `scheduler-name` binding (mirroring the
+	// inventory PolicyRule field, #3624); scheduler_active is the explicit
+	// effective-active flag — true when the matched policy is scheduler-gated AND
+	// currently active. A positive match is by construction currently active (the
+	// live simulator threads a fail-closed PolicyInactiveFn that skips a
+	// scheduler-inactive rule before it can match, #3104/#3414), so a matched
+	// scheduled policy always reports scheduler_active=true; it names the gate
+	// that is admitting the rule right now. Additive; both empty/false (omitted)
+	// for a non-scheduled (always-on) policy and for the unmatched / host-inbound
+	// / default cases. Set only when matched is true.
+	SchedulerName   string `protobuf:"bytes,19,opt,name=scheduler_name,json=schedulerName,proto3" json:"scheduler_name,omitempty"`
+	SchedulerActive bool   `protobuf:"varint,20,opt,name=scheduler_active,json=schedulerActive,proto3" json:"scheduler_active,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *MatchPoliciesResponse) Reset() {
@@ -6716,6 +6737,27 @@ func (x *MatchPoliciesResponse) GetRuleId() string {
 		return x.RuleId
 	}
 	return ""
+}
+
+func (x *MatchPoliciesResponse) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetSchedulerName() string {
+	if x != nil {
+		return x.SchedulerName
+	}
+	return ""
+}
+
+func (x *MatchPoliciesResponse) GetSchedulerActive() bool {
+	if x != nil {
+		return x.SchedulerActive
+	}
+	return false
 }
 
 type GetNATRuleStatsRequest struct {
@@ -8247,7 +8289,7 @@ const file_xpf_proto_rawDesc = "" +
 	"\n" +
 	"_icmp_typeB\f\n" +
 	"\n" +
-	"_icmp_code\"\x96\x05\n" +
+	"_icmp_code\"\x8a\x06\n" +
 	"\x15MatchPoliciesResponse\x12\x1f\n" +
 	"\vpolicy_name\x18\x01 \x01(\tR\n" +
 	"policyName\x12\x16\n" +
@@ -8267,7 +8309,10 @@ const file_xpf_proto_rawDesc = "" +
 	"\x0fqueried_to_zone\x18\x0e \x01(\tR\rqueriedToZone\x126\n" +
 	"\x17source_address_excluded\x18\x0f \x01(\bR\x15sourceAddressExcluded\x12@\n" +
 	"\x1cdestination_address_excluded\x18\x10 \x01(\bR\x1adestinationAddressExcluded\x12\x17\n" +
-	"\arule_id\x18\x11 \x01(\tR\x06ruleIdB\f\n" +
+	"\arule_id\x18\x11 \x01(\tR\x06ruleId\x12 \n" +
+	"\vdescription\x18\x12 \x01(\tR\vdescription\x12%\n" +
+	"\x0escheduler_name\x18\x13 \x01(\tR\rschedulerName\x12)\n" +
+	"\x10scheduler_active\x18\x14 \x01(\bR\x0fschedulerActiveB\f\n" +
 	"\n" +
 	"_policy_id\"N\n" +
 	"\x16GetNATRuleStatsRequest\x12\x19\n" +

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -339,6 +339,21 @@ type Result struct {
 	Description string
 	Action      config.PolicyAction
 
+	// SchedulerName is the `scheduler-name` binding of the matched policy
+	// (#3685 M06), the same value the inventory (REST/gRPC GetPolicies,
+	// #3624) carries. A matched policy is by construction currently ACTIVE —
+	// the live simulator surfaces always thread a non-nil
+	// Query.PolicyInactiveFn (dataplane/userspace.PolicyInactiveFn) that
+	// SKIPS a scheduler-inactive rule before it can match (#3104/#3414) — so a
+	// non-empty SchedulerName on a matched verdict names the time-gate that is
+	// controlling the rule right now, not a rule that is currently gated off.
+	// Empty for a non-scheduled (always-on) policy and for the
+	// default-policy / host-inbound verdicts. Populated from pol.SchedulerName
+	// in matchedResult; the offline (nil PolicyInactiveFn) simulator may report
+	// a scheduler name for a rule that is not runtime-active, but no live
+	// transport uses that mode.
+	SchedulerName string
+
 	// RuleID is the stable "<from>-><to>/<name>" rule identity the inventory
 	// (REST/gRPC GetPolicies) and the snapshot/event path carry, computed by the
 	// shared dpuserspace.StablePolicyRuleID (#3668). PolicyID above is the
@@ -686,15 +701,18 @@ func matchedResult(ids map[[2]uint32]uint32, pol *config.Policy, global bool, fr
 		ridFrom, ridTo = "junos-global", "junos-global"
 	}
 	return Result{
-		Matched:                    true,
-		Global:                     global,
-		FromZone:                   fromZone,
-		ToZone:                     toZone,
-		PolicyID:                   ids[[2]uint32{uint32(setIdx), uint32(sliceIdx)}],
-		RuleID:                     dpuserspace.StablePolicyRuleID(ridFrom, ridTo, pol.Name),
-		PolicyName:                 pol.Name,
-		Description:                pol.Description,
-		Action:                     pol.Action,
+		Matched:     true,
+		Global:      global,
+		FromZone:    fromZone,
+		ToZone:      toZone,
+		PolicyID:    ids[[2]uint32{uint32(setIdx), uint32(sliceIdx)}],
+		RuleID:      dpuserspace.StablePolicyRuleID(ridFrom, ridTo, pol.Name),
+		PolicyName:  pol.Name,
+		Description: pol.Description,
+		Action:      pol.Action,
+		// #3685 M06: carry the scheduler binding so a match-policies verdict
+		// names the time-gate controlling the rule, mirroring the inventory.
+		SchedulerName:              pol.SchedulerName,
 		SourceAddressExcluded:      pol.Match.SourceAddressExcluded,
 		DestinationAddressExcluded: pol.Match.DestinationAddressExcluded,
 		// #3358: a zone-local address book (#3061) is folded into the global

--- a/pkg/policymatch/simulator_output_parity_3685_test.go
+++ b/pkg/policymatch/simulator_output_parity_3685_test.go
@@ -1,0 +1,75 @@
+package policymatch
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestMatchResultCarriesDescriptionAndScheduler pins #3685 M05/M06 at the
+// simulator layer: a positive verdict against a policy that carries a
+// `description` and a `scheduler-name` binding must expose BOTH on the
+// policymatch.Result, so the REST/gRPC/CLI surfaces built over it can report
+// the ticket/change context (M05) and the time-gate controlling the rule (M06).
+//
+// RED-on-revert:
+//   - Removing `Description: pol.Description` from matchedResult drops the
+//     description and the Description assertion fails.
+//   - Removing the new `SchedulerName: pol.SchedulerName` copy from
+//     matchedResult drops the scheduler binding and the SchedulerName assertion
+//     fails.
+//
+// Description already round-tripped before #3685 (matchedResult set it), so its
+// assertion is a regression anchor; SchedulerName is the field #3685 adds.
+func TestMatchResultCarriesDescriptionAndScheduler(t *testing.T) {
+	pol := scheduled(permit("allow-web", config.PolicyMatch{Applications: []string{"any"}}), "workhours")
+	pol.Description = "CHG-4242-web-access"
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust", pol),
+		},
+	}, config.ApplicationsConfig{})
+
+	// The scheduler is ACTIVE so the scheduled permit matches (a positive match
+	// is by construction currently active — the live surfaces skip an inactive
+	// rule before it can match).
+	res := Match(cfg, Query{
+		FromZone:         "trust",
+		ToZone:           "untrust",
+		Protocol:         "tcp",
+		DstPort:          80,
+		PolicyInactiveFn: inactiveFnFor(map[string]bool{"workhours": true}),
+	})
+	if !res.Matched || res.Action != config.PolicyPermit || res.PolicyName != "allow-web" {
+		t.Fatalf("want permit by allow-web, got Matched=%v Action=%v PolicyName=%q",
+			res.Matched, res.Action, res.PolicyName)
+	}
+	if res.Description != "CHG-4242-web-access" {
+		t.Errorf("Description = %q, want %q (M05)", res.Description, "CHG-4242-web-access")
+	}
+	if res.SchedulerName != "workhours" {
+		t.Errorf("SchedulerName = %q, want %q (M06)", res.SchedulerName, "workhours")
+	}
+}
+
+// TestMatchResultNonScheduledHasEmptySchedulerName is the negative control: a
+// matched policy WITHOUT a scheduler binding must leave SchedulerName empty, so
+// a downstream surface can gate an effective-active flag on it (an always-on
+// policy is not "scheduler-active").
+func TestMatchResultNonScheduledHasEmptySchedulerName(t *testing.T) {
+	cfg := cfgWith(config.SecurityConfig{
+		DefaultPolicy: config.PolicyDeny,
+		Policies: []*config.ZonePairPolicies{
+			zonePair("trust", "untrust",
+				permit("plain-allow", config.PolicyMatch{Applications: []string{"any"}})),
+		},
+	}, config.ApplicationsConfig{})
+	res := Match(cfg, Query{FromZone: "trust", ToZone: "untrust", Protocol: "tcp", DstPort: 80})
+	if !res.Matched {
+		t.Fatalf("want match, got %+v", res)
+	}
+	if res.SchedulerName != "" {
+		t.Errorf("SchedulerName = %q, want empty for a non-scheduled policy", res.SchedulerName)
+	}
+}

--- a/proto/xpf/v1/xpf.proto
+++ b/proto/xpf/v1/xpf.proto
@@ -811,6 +811,27 @@ message MatchPoliciesResponse {
   // Additive; empty (omitted) for the unmatched / host-inbound / default cases.
   // Set only when matched is true.
   string rule_id = 17;
+  // #3685 M05: description is the matched policy's `description` text, the same
+  // field the inventory (GetPolicies) and the local `show security
+  // match-policies` result carry. Descriptions often hold ticket / change-
+  // control context, so a match verdict without it is weaker than the CLI and
+  // inventory answers over the SAME policymatch.Result. Additive; empty
+  // (omitted) for a policy with no description and for the unmatched /
+  // host-inbound / default cases. Set only when matched is true.
+  string description = 18;
+  // #3685 M06: scheduler_name / scheduler_active expose the matched policy's
+  // time-gate. scheduler_name is the `scheduler-name` binding (mirroring the
+  // inventory PolicyRule field, #3624); scheduler_active is the explicit
+  // effective-active flag — true when the matched policy is scheduler-gated AND
+  // currently active. A positive match is by construction currently active (the
+  // live simulator threads a fail-closed PolicyInactiveFn that skips a
+  // scheduler-inactive rule before it can match, #3104/#3414), so a matched
+  // scheduled policy always reports scheduler_active=true; it names the gate
+  // that is admitting the rule right now. Additive; both empty/false (omitted)
+  // for a non-scheduled (always-on) policy and for the unmatched / host-inbound
+  // / default cases. Set only when matched is true.
+  string scheduler_name = 19;
+  bool scheduler_active = 20;
 }
 
 // --- NAT rule counters ---


### PR DESCRIPTION
Closes #3685

## Summary

Three residual parity gaps in the policy-simulator OUTPUT surfaces, after
#3668 (rule_id + address-exclusion), #3627 (queried-zone echo), and #3624
(scheduler in the inventory). The match/test-policy diagnostics still dropped
fields the inventory and the local `show security match-policies` carry over the
SAME `policymatch.Result`.

## Fixes

**M05 — match-policies response dropped the policy DESCRIPTION.**
`policymatch.Result.Description` already existed but was absent from the REST
`MatchPoliciesResult` and the gRPC `MatchPoliciesResponse`. Descriptions often
hold ticket / change-control context, so a match verdict without it was weaker
than the inventory / CLI answer. Added `description` (REST JSON `omitempty`) and
proto field **18**, populated from `res.Description` on a positive match.

**M06 — match-policies response omitted the scheduler binding / effective
state.** #3624 added scheduler fields to the INVENTORY only. Added
`policymatch.Result.SchedulerName` (from `pol.SchedulerName`) and carried it plus
an explicit effective-active flag onto both responses: `scheduler_name` (proto
**19**) + `scheduler_active` (proto **20**) and the matching REST JSON fields.
`scheduler_active = (SchedulerName != "")` — a positive match is by construction
currently active (the handlers thread a fail-closed `PolicyInactiveFn`, #3414),
so a matched scheduled policy reports `scheduler_active=true` and names the gate
admitting it. Both scheduler fields are omitted for a non-scheduled policy.

**M04 — gRPC-text `test policy` global branch omitted the policy ID / scope /
description.** `server_show_firewall.go` printed only name + action for a GLOBAL
match. Brought it to parity with `show security match-policies` (Policy ID,
`Scope: global (match from-zone/to-zone)`, Description). This is the gRPC-text
sibling of the #3674 local request-path gap — a distinct renderer NOT covered by
that issue.

## Proto / wire

Proto additions are additive (no renumber); regenerated with the pinned
toolchain (protoc 3.21.12 / protoc-gen-go v1.36.11 / protoc-gen-go-grpc v1.6.1),
no version bump. `MatchPoliciesResponse` is gRPC-only — no Rust userspace-dp
reference and no Go↔Rust wire fixture — so no fixture regen was needed
(confirmed).

## Tests (RED-on-revert)

- `pkg/policymatch`: a matched described+scheduled policy carries Description +
  SchedulerName; a non-scheduled match leaves SchedulerName empty.
- `pkg/api`: the REST `/security/match` JSON carries description +
  scheduler_name + scheduler_active for a matched described+scheduled policy;
  a non-scheduled/undescribed match omits all three.
- `pkg/grpcapi`: the `MatchPoliciesResponse` carries the same three fields; the
  gRPC-text global `test policy` shows Policy ID + Scope + Description.

Each layer was verified to go RED when its population / render is reverted.
`go test ./pkg/policymatch/... ./pkg/api/... ./pkg/grpcapi/...` green;
`go build ./pkg/... ./cmd/...`, `gofmt`, and `go vet` clean.

Docs: `pkg/api/README.md` + `pkg/grpcapi/README.md` document the new response
fields (M05/M06) and the gRPC-text global render (M04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
