### PR TITLE
Remote CLI: show zones spans all policy tiers; filtered global scope reads "any" (#3683)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-01 — #3683 remote CLI show zones/policies display residuals (M01/M02)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3683 — fixed two remote-CLI (ctl binary) display residuals left
+    after the local / gRPC-text zone and policy surfaces were upgraded (#3658
+    tiers, #3331 scope labels, #3672 remote-policies).
+    - **M01**: the remote `show security zones` (non-detail) per-zone summary
+      built a compact `Policies: from <peer> (N rules)` line from ONLY the
+      zone-pair groups whose group zones matched the zone. The global group
+      (`GetPolicies` group zones `*`/`*`) and the synthetic default-policy row
+      (`-`/`-`, #3363) were BOTH hidden — an operator scraping the ctl binary
+      could miss an applicable global/default rule. `showZones` now renders the
+      SAME three-tier `Policy summary` block the local detail view
+      (`pkg/cli/cli_show_security_zones.go`) and gRPC text
+      (`pkg/grpcapi/server_show_zones_text.go`) use, filtering the global group
+      PER-RULE via `config.GlobalPolicyAppliesToZone` over the wire
+      `match_from_zone`/`match_to_zone` (#3148/#3680) and always closing with the
+      `[default]` catch-all (M05).
+    - **M02**: the remote FILTERED policy view (`showPoliciesFiltered`) hand-rolled
+      an all-zones global scope as `*`; it now routes both axes through the shared
+      `matchScopeZone` normalizer (empty -> `any`) so an unscoped global reads
+      `From zone: any, To zone: any` — the canonical Junos / local / gRPC model.
+  - **File(s)**: `cmd/cli/show.go` (showZones tiered renderer + showPoliciesFiltered
+    scope normalization), `cmd/cli/show_zones_tiers_3683_test.go` (new
+    RED-on-revert tests), `cmd/cli/show_zones_polerr_3669_test.go` (happy-path
+    assertion updated to the tiered format), `docs/junos-cli-reference.md`.
+
 ## 2026-07-01 — #3682 host-inbound lifeline exemption made operator-visible (M08/L05)
 
 - **Timestamp**: 2026-07-01

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -546,21 +546,70 @@ func (c *ctl) showZones() error {
 			fmt.Printf("    Output: %d packets, %d bytes\n", z.EgressPackets, z.EgressBytes)
 		}
 
+		// #3683 (M01): render all THREE policy tiers the runtime evaluates, in
+		// order — zone-pair, applicable global, then the effective
+		// default-policy catch-all — mirroring the local zone-detail summary
+		// (pkg/cli/cli_show_security_zones.go) and gRPC text
+		// (pkg/grpcapi/server_show_zones_text.go), both from #3658. The old
+		// remote summary listed ONLY zone-pair groups whose group-level zones
+		// matched the zone, so the "*"/"*" global group and the synthetic
+		// default-policy row (#3363) were both hidden — an operator scraping the
+		// ctl binary could miss a global or default-policy rule that governs the
+		// zone's transit.
 		if polResp != nil {
-			var refs []string
+			fmt.Println("  Policy summary (evaluation order: zone-pair, global, default-policy):")
+			zonePairPolicies := 0
+			globalPolicies := 0
+			var defaultName, defaultAction string
 			for _, pi := range polResp.Policies {
-				if pi.FromZone == z.Name || pi.ToZone == z.Name {
-					dir := "from"
-					peer := pi.ToZone
-					if pi.ToZone == z.Name {
-						dir = "to"
-						peer = pi.FromZone
+				switch {
+				case pi.FromZone == "-" && pi.ToZone == "-":
+					// #3363 synthetic default-policy row: from/to zone "-" with a
+					// single rule named dataplane.DefaultPolicyName. Captured here
+					// and printed last so it always closes the summary (M05),
+					// independent of its position in the response.
+					if len(pi.Rules) > 0 {
+						defaultName = pi.Rules[0].Name
+						defaultAction = pi.Rules[0].Action
 					}
-					refs = append(refs, fmt.Sprintf("%s %s (%d rules)", dir, peer, len(pi.Rules)))
+				case pi.FromZone == "*" && pi.ToZone == "*":
+					// #3357 global group: filter PER-RULE by the rule's scope
+					// (#3148 MatchFromZone/MatchToZone). A scoped global narrows
+					// the all-zones group to a zone pair; an unscoped or
+					// explicit-"any" scope is the all-zones wildcard
+					// (config.IsWildcardZone), so the global is listed whenever
+					// the zone can appear on either side of a pair it matches
+					// (config.GlobalPolicyAppliesToZone — the same predicate the
+					// local/gRPC-text tier renderers use).
+					for _, rule := range pi.Rules {
+						if !config.GlobalPolicyAppliesToZone(config.PolicyMatch{
+							FromZone: rule.MatchFromZone,
+							ToZone:   rule.MatchToZone,
+						}, z.Name) {
+							continue
+						}
+						fmt.Printf("    [global] %s -> %s: %s (%s)\n",
+							matchScopeZone(rule.MatchFromZone),
+							matchScopeZone(rule.MatchToZone),
+							rule.Name, rule.Action)
+						globalPolicies++
+					}
+				case pi.FromZone == z.Name || pi.ToZone == z.Name:
+					for _, rule := range pi.Rules {
+						fmt.Printf("    [zone-pair] %s -> %s: %s (%s)\n",
+							pi.FromZone, pi.ToZone, rule.Name, rule.Action)
+						zonePairPolicies++
+					}
 				}
 			}
-			if len(refs) > 0 {
-				fmt.Printf("  Policies: %s\n", strings.Join(refs, ", "))
+			if zonePairPolicies == 0 && globalPolicies == 0 {
+				fmt.Println("    (no zone-pair or global policies affecting this zone)")
+			}
+			// M05: always surface the effective default-policy catch-all when the
+			// inventory carries it, so unmatched-transit disposition is never
+			// hidden behind an absent "(no policies)" line.
+			if defaultName != "" {
+				fmt.Printf("    [default] %s: %s\n", defaultName, defaultAction)
 			}
 		}
 
@@ -644,20 +693,20 @@ func (c *ctl) showPoliciesFiltered(fromZone, toZone string) error {
 		// "*"/"*" zones dropped every scoped global from the filtered view — the
 		// exact command an operator uses to prove which rules govern a zone pair.
 		// Detect the global group and filter per-rule, rendering each rule under a
-		// header that shows its effective scope (falling back to "*"/"*").
+		// header that shows its effective scope (an unscoped/explicit-any axis is
+		// normalized to "any" via matchScopeZone — #3683 M02).
 		if pi.FromZone == "*" && pi.ToZone == "*" {
 			for _, rule := range pi.Rules {
 				if !policymatch.GlobalPolicyAppliesToZonePair(rule.MatchFromZone, rule.MatchToZone, fromZone, toZone) {
 					continue
 				}
-				gf, gt := "*", "*"
-				if rule.MatchFromZone != "" {
-					gf = rule.MatchFromZone
-				}
-				if rule.MatchToZone != "" {
-					gt = rule.MatchToZone
-				}
-				fmt.Printf("From zone: %s, To zone: %s\n", gf, gt)
+				// #3683 (M02): render the effective scope through matchScopeZone
+				// (the shared normalizer, empty -> "any") so an unscoped global
+				// prints "From zone: any, To zone: any" — the canonical Junos /
+				// local-CLI / gRPC model — instead of a hand-rolled "*" that reads
+				// like an internal wildcard rather than the explicit policy model.
+				fmt.Printf("From zone: %s, To zone: %s\n",
+					matchScopeZone(rule.MatchFromZone), matchScopeZone(rule.MatchToZone))
 				renderRule(rule)
 				fmt.Println()
 			}

--- a/cmd/cli/show_zones_polerr_3669_test.go
+++ b/cmd/cli/show_zones_polerr_3669_test.go
@@ -83,7 +83,10 @@ func TestShowZonesSucceedsWhenPolicyInventoryOK(t *testing.T) {
 			t.Fatalf("showZones returned error on the happy path: %v", err)
 		}
 	})
-	if !strings.Contains(out, "Policies: from untrust (1 rules)") {
-		t.Errorf("expected policy references rendered for trust zone:\n%s", out)
+	// #3683 (M01): the remote summary now renders the tiered "Policy summary"
+	// block (zone-pair / global / default), replacing the pre-#3683 compact
+	// "Policies: from <peer> (N rules)" refs line.
+	if !strings.Contains(out, "[zone-pair] trust -> untrust: allow-web (permit)") {
+		t.Errorf("expected zone-pair policy tier rendered for trust zone:\n%s", out)
 	}
 }

--- a/cmd/cli/show_zones_tiers_3683_test.go
+++ b/cmd/cli/show_zones_tiers_3683_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3683: two remote-CLI (ctl binary) display residuals after the local /
+// gRPC-text zone and policy surfaces were upgraded (#3658 tiers, #3331 scope
+// labels).
+//
+//   - M01: the remote `show security zones` per-zone summary built its policy
+//     refs ONLY from zone-pair groups whose group-level zones matched the zone.
+//     The global group is exposed with group zones "*"/"*" and the synthetic
+//     default-policy row (#3363) is not a zone-pair group, so NEITHER appeared
+//     in the per-zone summary — an operator scraping the ctl binary could miss
+//     an applicable global or default-policy rule.
+//   - M02: the remote FILTERED policy view hand-rolled an all-zones global scope
+//     as "*" instead of the canonical "any" the normalizer (matchScopeZone) and
+//     Junos / local / gRPC surfaces use.
+//
+// These tests are the fail-on-revert guards.
+
+// tieredZonesResp models GetZones with a single "trust" zone.
+func tieredZonesResp() *pb.GetZonesResponse {
+	return &pb.GetZonesResponse{
+		Zones: []*pb.ZoneInfo{
+			{Name: "trust", Interfaces: []string{"ge-0-0-0"}},
+		},
+	}
+}
+
+// tieredPoliciesResp models GetPolicies output carrying all three tiers the
+// runtime evaluates: a zone-pair set (trust->untrust), the global group "*"/"*"
+// with (a) an unscoped all-zones global, (b) a scoped global that DOES touch
+// trust (trust->dmz), and (c) a scoped global that does NOT touch trust
+// (dmz->untrust), plus the synthetic default-policy row ("-"/"-").
+func tieredPoliciesResp() *pb.GetPoliciesResponse {
+	return &pb.GetPoliciesResponse{
+		Policies: []*pb.PolicyInfo{
+			{
+				FromZone: "trust",
+				ToZone:   "untrust",
+				Rules:    []*pb.PolicyRule{{Name: "allow-web", Action: "permit"}},
+			},
+			{
+				FromZone: "*",
+				ToZone:   "*",
+				Rules: []*pb.PolicyRule{
+					{Name: "open-global", Action: "permit"},
+					{Name: "scoped-td", Action: "deny", MatchFromZone: "trust", MatchToZone: "dmz"},
+					{Name: "scoped-du", Action: "deny", MatchFromZone: "dmz", MatchToZone: "untrust"},
+				},
+			},
+			{
+				FromZone: "-",
+				ToZone:   "-",
+				Rules:    []*pb.PolicyRule{{Name: "default-policy", Action: "deny"}},
+			},
+		},
+	}
+}
+
+// TestShowZonesRendersGlobalAndDefaultTiers (M01): the remote `show security
+// zones` per-zone summary must list all three tiers the runtime evaluates —
+// zone-pair, applicable global (per-rule scope-filtered), and the
+// default-policy catch-all.
+//
+// FAIL-ON-REVERT: restoring the zone-pair-only refs (the pre-#3683
+// `pi.FromZone == z.Name || pi.ToZone == z.Name` compact "Policies:" line) drops
+// the global group ("*"/"*") and the synthetic default row ("-"/"-") entirely,
+// so the [global] and [default] assertions go RED.
+func TestShowZonesRendersGlobalAndDefaultTiers(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		getZonesResp:    tieredZonesResp(),
+		getPoliciesResp: tieredPoliciesResp(),
+	}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showZones(); err != nil {
+			t.Fatalf("showZones: %v", err)
+		}
+	})
+
+	// Tier 1: the zone-pair rule referencing trust.
+	if !strings.Contains(out, "[zone-pair] trust -> untrust: allow-web (permit)") {
+		t.Fatalf("remote zone summary dropped the zone-pair tier:\n%s", out)
+	}
+	// Tier 2: the unscoped (all-zones) global — HIDDEN before #3683 because the
+	// global group's "*"/"*" zones matched no zone. Rendered under "any -> any".
+	if !strings.Contains(out, "[global] any -> any: open-global (permit)") {
+		t.Fatalf("remote zone summary hid the unscoped global tier (M01 regression):\n%s", out)
+	}
+	// Tier 2 (scoped, applicable): trust->dmz places trust on the source axis.
+	if !strings.Contains(out, "[global] trust -> dmz: scoped-td (deny)") {
+		t.Fatalf("remote zone summary dropped a scoped global that touches trust:\n%s", out)
+	}
+	// Tier 2 (scoped, NON-applicable): dmz->untrust never involves trust, so it
+	// must be filtered out per-rule (config.GlobalPolicyAppliesToZone).
+	if strings.Contains(out, "scoped-du") {
+		t.Fatalf("remote zone summary leaked an off-zone scoped global (dmz->untrust):\n%s", out)
+	}
+	// Tier 3: the default-policy catch-all — HIDDEN before #3683 because the
+	// synthetic "-"/"-" row is not a zone-pair group.
+	if !strings.Contains(out, "[default] default-policy: deny") {
+		t.Fatalf("remote zone summary hid the default-policy tier (M01 regression):\n%s", out)
+	}
+}
+
+// TestShowZonesNoTransitPoliciesShowsDefaultOnly (M01/M05): a zone with no
+// zone-pair and no applicable global policy still surfaces the default-policy
+// catch-all under an explicit "(no zone-pair or global policies...)" line,
+// instead of an empty summary that hides whether unmatched transit is
+// denied/permitted.
+func TestShowZonesNoTransitPoliciesShowsDefaultOnly(t *testing.T) {
+	fake := &fakeBpfrxClient{
+		getZonesResp: &pb.GetZonesResponse{
+			Zones: []*pb.ZoneInfo{{Name: "isolated", Interfaces: []string{"ge-0-0-9"}}},
+		},
+		getPoliciesResp: &pb.GetPoliciesResponse{
+			Policies: []*pb.PolicyInfo{
+				// A scoped global bound to an unrelated pair (dmz->untrust) —
+				// must not be attributed to "isolated".
+				{
+					FromZone: "*",
+					ToZone:   "*",
+					Rules: []*pb.PolicyRule{
+						{Name: "scoped-du", Action: "deny", MatchFromZone: "dmz", MatchToZone: "untrust"},
+					},
+				},
+				{
+					FromZone: "-",
+					ToZone:   "-",
+					Rules:    []*pb.PolicyRule{{Name: "default-policy", Action: "permit"}},
+				},
+			},
+		},
+	}
+	c := &ctl{client: fake}
+
+	out := captureStdout(t, func() {
+		if err := c.showZones(); err != nil {
+			t.Fatalf("showZones: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "(no zone-pair or global policies affecting this zone)") {
+		t.Fatalf("expected the explicit no-transit-policies line:\n%s", out)
+	}
+	if !strings.Contains(out, "[default] default-policy: permit") {
+		t.Fatalf("expected the always-present default tier under permit-all:\n%s", out)
+	}
+	if strings.Contains(out, "scoped-du") {
+		t.Fatalf("off-zone scoped global leaked into an unrelated zone's summary:\n%s", out)
+	}
+}
+
+// TestShowPoliciesFilteredUnscopedGlobalRendersAny (M02): an all-zones
+// (unscoped) global rule must render its scope as "any", not the hand-rolled
+// internal wildcard "*", in the filtered policy view.
+//
+// FAIL-ON-REVERT: restoring the literal `gf, gt := "*", "*"` fallback prints
+// "From zone: *, To zone: *" for the unscoped global, so the "any" assertion
+// goes RED (and the "*" assertion catches the regression directly).
+func TestShowPoliciesFilteredUnscopedGlobalRendersAny(t *testing.T) {
+	fake := &fakeBpfrxClient{getPoliciesResp: &pb.GetPoliciesResponse{
+		Policies: []*pb.PolicyInfo{
+			{
+				FromZone: "*",
+				ToZone:   "*",
+				Rules: []*pb.PolicyRule{
+					{Name: "open-global", Action: "permit"},
+				},
+			},
+		},
+	}}
+	c := &ctl{client: fake}
+
+	// No from/to filter: the unscoped global is selected and its header must use
+	// the canonical "any" scope.
+	out := captureStdout(t, func() {
+		if err := c.showPoliciesFiltered("", ""); err != nil {
+			t.Fatalf("showPoliciesFiltered: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "From zone: any, To zone: any") {
+		t.Fatalf("unscoped global header not normalized to \"any\" (M02 regression):\n%s", out)
+	}
+	if strings.Contains(out, "From zone: *, To zone: *") {
+		t.Fatalf("unscoped global still renders the hand-rolled \"*\" wildcard (M02 regression):\n%s", out)
+	}
+	if !strings.Contains(out, "Rule: open-global") {
+		t.Fatalf("filtered view dropped the unscoped global rule:\n%s", out)
+	}
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -789,6 +789,14 @@ Global policies:
   `... brief` prints the per-rule `match_from_zone`/`match_to_zone` (falling back
   to `*`/`*` only for an unscoped global) instead of the group `*`. The shared
   selection predicate is `policymatch.GlobalPolicyAppliesToZonePair`.
+- **#3683 (M02) — remote FILTERED policy view normalizes the global scope to
+  `any`.** The remote `show security policies` (filtered) `showPoliciesFiltered`
+  (`cmd/cli/show.go`) hand-rolled an all-zones global scope as `*`, so an
+  unscoped global printed `From zone: *, To zone: *` while the local / gRPC /
+  Junos surfaces show `any`. It now renders each axis through the shared
+  `matchScopeZone` normalizer (empty -> `any`), so an unscoped global reads
+  `From zone: any, To zone: any` — the explicit policy model, not an internal
+  wildcard. A scoped global still prints its configured zone(s) unchanged.
 - **#3672 — remote non-detail renderer surfaces per-rule metadata.** The remote
   CLI `show security policies` (non-detail) `renderRule` (`cmd/cli/show.go`)
   previously printed only name / description / raw addresses / action / hits,
@@ -875,14 +883,26 @@ Security zone: junos-host
 - Blank line between zones.
 - **#3669 — policy-inventory failure fails loud (remote CLI).** The remote
   `show security zones` (`cmd/cli/show.go`) issues a second RPC (`GetPolicies`)
-  to render each zone's `Policies:` reference line. It previously discarded that
-  RPC's error (`polResp, _ := ...`) and returned success, so a control-plane
-  degradation rendered the zones as policy-free with exit 0 —
-  indistinguishable from zones that genuinely have no policies. The zone bodies
-  (from the successful `GetZones`) are still printed, but the command now
-  surfaces the `GetPolicies` error (`policy inventory unavailable ...`) and
-  exits non-zero so an operator or automation can tell a degraded partial view
-  apart from a truly empty one.
+  to render each zone's policy summary. It previously discarded that RPC's error
+  (`polResp, _ := ...`) and returned success, so a control-plane degradation
+  rendered the zones as policy-free with exit 0 — indistinguishable from zones
+  that genuinely have no policies. The zone bodies (from the successful
+  `GetZones`) are still printed, but the command now surfaces the `GetPolicies`
+  error (`policy inventory unavailable ...`) and exits non-zero so an operator
+  or automation can tell a degraded partial view apart from a truly empty one.
+- **#3683 (M01) — remote `show security zones` renders all three policy tiers.**
+  The remote (non-detail) summary previously built a compact
+  `Policies: from <peer> (N rules)` reference line from ONLY the zone-pair groups
+  whose group-level zones matched the zone. The global group is exposed by
+  `GetPolicies` with group zones `*`/`*` and the synthetic default-policy row
+  (#3363) with `-`/`-`, so NEITHER appeared in the per-zone summary — an operator
+  scraping the ctl binary could miss an applicable global or default-policy rule.
+  The summary now renders the SAME three-tier `Policy summary` block the local
+  detail view (`pkg/cli/cli_show_security_zones.go`) and gRPC text
+  (`pkg/grpcapi/server_show_zones_text.go`) use (see the block below), filtering
+  the global group PER-RULE by each rule's scope
+  (`config.GlobalPolicyAppliesToZone` over the wire `match_from_zone`/
+  `match_to_zone`, #3148/#3680) and always closing with the `[default]` catch-all.
 
 **`show security zones detail` policy summary (#3658).** In `detail` mode
 each zone gains a `Policy summary` block that lists the policies that decide
@@ -916,9 +936,10 @@ them (zone-pair, then global, then the implicit default-policy catch-all):
 - When a zone has no zone-pair AND no applicable global policy, the summary
   prints `(no zone-pair or global policies affecting this zone)` above the
   always-present `[default]` line.
-- The gRPC text `zones-detail` view renders the identical three-tier block;
-  both mirror the REST inventory global + synthetic default-policy rows
-  (`pkg/api/security.go`) and structured `GetPolicies` (#3363).
+- The gRPC text `zones-detail` view renders the identical three-tier block, and
+  the remote (ctl) `show security zones` non-detail summary now renders it too
+  (#3683 M01); all mirror the REST inventory global + synthetic default-policy
+  rows (`pkg/api/security.go`) and structured `GetPolicies` (#3363).
 
 ---
 


### PR DESCRIPTION
Closes #3683

Fixes two remote-CLI (ctl binary) display residuals left after the local /
gRPC-text zone and policy surfaces were upgraded (#3658 zone-detail tiers,
#3331 scope labels, #3672 remote per-rule policy metadata).

## M01 — remote `show security zones` omitted the global + default tiers

`showZones` (`cmd/cli/show.go`) built a compact `Policies: from <peer> (N
rules)` line from ONLY the zone-pair groups whose group-level zones matched the
zone. The global group is exposed by `GetPolicies` with group zones `*`/`*`, and
the synthetic default-policy row (#3363) with `-`/`-`; neither is a zone-pair
group, so BOTH were hidden. An operator scraping the ctl binary could miss an
applicable global or default-policy rule governing the zone's transit.

`showZones` now renders the SAME three-tier `Policy summary (evaluation order:
zone-pair, global, default-policy)` block the local zone-detail view
(`pkg/cli/cli_show_security_zones.go`) and gRPC text
(`pkg/grpcapi/server_show_zones_text.go`) emit. The global group is filtered
PER-RULE via `config.GlobalPolicyAppliesToZone` over the wire
`match_from_zone`/`match_to_zone` (#3148/#3680) — the same predicate the
local/gRPC-text renderers use — so a scoped global is attributed only to the
zones it can affect. The default row is captured and printed last so the
catch-all always closes the summary (M05).

## M02 — remote filtered policy view printed the global scope as `*`

`showPoliciesFiltered` hand-rolled an all-zones global scope as `*`, so an
unscoped global printed `From zone: *, To zone: *` while the local / gRPC /
Junos surfaces show `any`. It now routes both axes through the shared
`matchScopeZone` normalizer (empty -> `any`). A scoped global still prints its
configured zone(s) unchanged.

## Tests (RED-on-revert)

- `TestShowZonesRendersGlobalAndDefaultTiers` — asserts the `[zone-pair]`,
  `[global]` (unscoped -> `any -> any`, scoped -> its zones), and `[default]`
  tiers all render, and that an off-zone scoped global is filtered out per-rule.
  RED when the pre-#3683 zone-pair-only refs are restored.
- `TestShowZonesNoTransitPoliciesShowsDefaultOnly` — a zone with no applicable
  transit policy still shows the `(no zone-pair or global policies…)` line plus
  the always-present `[default]` tier.
- `TestShowPoliciesFilteredUnscopedGlobalRendersAny` — unscoped global reads
  `From zone: any, To zone: any`, never `*`/`*`. RED when the `*` fallback is
  restored.

Each fix verified RED-on-revert independently, then green together.
`go test ./cmd/cli/... ./pkg/...` passes; `go build ./cmd/... ./pkg/...` clean;
gofmt clean. `docs/junos-cli-reference.md` documents both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
