### PR TITLE
cli: render Policy ID / scope / description in local `test policy` (#3674)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -36,6 +36,34 @@
     pkg/grpcapi/server_helpers.go,
     pkg/grpcapi/server_show_zones_metadata_3684_test.go,
     docs/junos-cli-reference.md
+
+## 2026-07-01 — #3674 local `test policy` output at parity with `show security match-policies` (H10 / codex-127 M03)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3674 — the local operational `test policy` simulator
+    (`pkg/cli/cli_request.go` `testPolicy`) printed only the policy name +
+    action (and, for a global match, nothing but name + action with no scope),
+    while `show security match-policies` (`showMatchPolicies`) over the SAME
+    `policymatch.Result` already printed the Policy ID, scope, and description.
+    That made `test policy` the poorest of the four match-policies surfaces — an
+    operator could not correlate a verdict with the RT_FLOW / session-table
+    policy ID or tell whether a global vs zone-pair rule fired. Fix = rendering
+    only (no schema/wire change): added a small `printPolicyMatchIdentity(res)`
+    helper called from BOTH the global and zone-pair branches of `testPolicy`,
+    printing the stable runtime **Policy ID** (#3667 `RuntimePolicyIDs` SSOT),
+    **Rule ID** (#3668 stable inventory join key, when present), **Scope**
+    (`zone-pair`/`global`, reusing the shared `matchScopeZone` helper so an
+    unset global scope reads `any`), and the policy **Description**. All fields
+    come straight off `policymatch.Result`, so the local `test policy` surface
+    is now in lock-step with `showMatchPolicies` with no duplicated matcher
+    logic. The 2-space aligned label style matches the surrounding `test policy`
+    output. Added a RED-on-revert test (`testpolicy_idscope_3674_test.go`)
+    asserting both a zone-pair and a scoped-global match render Policy ID (value
+    checked against the RuntimePolicyIDs SSOT) + Rule ID + Scope + Description;
+    deleting the helper call flips it red. Documented in `pkg/cli/README.md`.
+  - **File(s)**: pkg/cli/cli_request.go, pkg/cli/testpolicy_idscope_3674_test.go
+    (new), pkg/cli/README.md, _Log.md
+
 ## 2026-07-01 — #3683 remote CLI show zones/policies display residuals (M01/M02)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -74,3 +74,17 @@ both the daemon-local CLI (xpfd in TTY mode) and the remote CLI
   `protocol` by name OR 0-255 number — instead of the stale, drifted
   `protocol <tcp|udp>`-only subset that hid the ICMP / source-port / non-TCP-UDP
   selectors from operators.
+- #3674: the local `test policy` (`testPolicy`) output now renders the SAME
+  identity fields `show security match-policies` (`showMatchPolicies`) already
+  prints over the shared `policymatch.Result` — the stable runtime **Policy ID**
+  (the RT_FLOW / session-table / audit ID from the #3667 `RuntimePolicyIDs`
+  SSOT), the **Rule ID** (#3668 stable inventory join key), the **Scope**
+  (`zone-pair (from-zone …, to-zone …)` or `global (match from-zone …, to-zone
+  …)`, rendered through the shared `matchScopeZone` helper so an unset global
+  scope reads `any`), and the policy **Description**. Both are thin adapters over
+  the one simulator, so a `test policy` verdict now correlates with the runtime
+  policy and identifies which scoped/global rule fired — previously the request
+  path printed only name + action (and, for a global match, name + action with no
+  scope), making it the poorest of the four match-policies surfaces. The
+  rendering is shared via `printPolicyMatchIdentity`; it is a display-only change,
+  no schema/wire impact.

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -324,12 +324,14 @@ func (c *CLI) testPolicy(args []string) error {
 	if res.Global {
 		fmt.Printf("Policy match (global):\n")
 		fmt.Printf("  Policy:    %s\n", res.PolicyName)
+		printPolicyMatchIdentity(res)
 		fmt.Printf("  Action:    %s\n", policymatch.ActionString(res.Action))
 		return nil
 	}
 	fmt.Printf("Policy match:\n")
 	fmt.Printf("  From zone: %s\n  To zone:   %s\n", fromZone, toZone)
 	fmt.Printf("  Policy:    %s\n", res.PolicyName)
+	printPolicyMatchIdentity(res)
 	fmt.Printf("  Action:    %s\n", policymatch.ActionString(res.Action))
 	if srcIP != "" {
 		fmt.Printf("  Source:    %s -> ", srcIP)
@@ -349,6 +351,39 @@ func (c *CLI) testPolicy(args []string) error {
 	}
 	fmt.Println()
 	return nil
+}
+
+// printPolicyMatchIdentity renders the shared PolicyID / RuleID / scope /
+// description block for the local `test policy` simulator (#3674). Before this,
+// the request-path output printed only the policy name + action (and for a
+// global match, nothing but name + action), while `show security match-policies`
+// over the SAME policymatch.Result already printed these identity fields. That
+// made `test policy` the poorest of the match-policies surfaces: an operator
+// could not correlate a verdict with the RT_FLOW / session-table policy ID or
+// tell whether a global vs zone-pair rule fired.
+//
+// All fields come straight off policymatch.Result (populated by the #3667
+// RuntimePolicyIDs SSOT), and the scope line reuses the shared matchScopeZone
+// helper (#3331), so this surface stays in lock-step with showMatchPolicies with
+// no duplicated logic. The 2-space aligned label style matches the surrounding
+// `test policy` output rather than the show path's 4-space sub-indent.
+func printPolicyMatchIdentity(res policymatch.Result) {
+	fmt.Printf("  Policy ID: %d\n", res.PolicyID)
+	// #3668: the stable rule identity joins a hit to the inventory / logs /
+	// tests even after a reorder shifts the numeric Policy ID.
+	if res.RuleID != "" {
+		fmt.Printf("  Rule ID:   %s\n", res.RuleID)
+	}
+	if res.Global {
+		fmt.Printf("  Scope:     global (match from-zone: %s, to-zone: %s)\n",
+			matchScopeZone(res.FromZone), matchScopeZone(res.ToZone))
+	} else {
+		fmt.Printf("  Scope:     zone-pair (from-zone: %s, to-zone: %s)\n",
+			res.FromZone, res.ToZone)
+	}
+	if res.Description != "" {
+		fmt.Printf("  Description: %s\n", res.Description)
+	}
 }
 
 // testRouting looks up a destination in the routing table.

--- a/pkg/cli/testpolicy_idscope_3674_test.go
+++ b/pkg/cli/testpolicy_idscope_3674_test.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+)
+
+// newIDScopePolicyCLI builds a committed store with one described zone-pair
+// permit policy (trust->untrust) and one described scoped-global permit policy
+// (match from-zone trust, no to-zone == any), plus a deny-all default. It is the
+// fixture for the #3674 parity assertions on the local `test policy` simulator.
+func newIDScopePolicyCLI(t *testing.T) *CLI {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy deny-all;
+        from-zone trust to-zone untrust {
+            policy zp-allow {
+                description "CHG-9 zone allow";
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+        global {
+            policy g-allow {
+                description "CHG-7 global allow";
+                match { source-address any; destination-address any; application any; from-zone untrust; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return &CLI{store: store}
+}
+
+// TestTestPolicyOutputCarriesIDScopeDescription pins #3674: the local
+// operational `test policy` simulator (pkg/cli/cli_request.go testPolicy) must
+// print the same Policy ID, scope, and description that `show security
+// match-policies` already renders over the SAME policymatch.Result, for BOTH a
+// zone-pair and a scoped-global match. Before #3674 the request path printed
+// only the policy name + action (and, for a global match, nothing but name +
+// action), making it the poorest of the match-policies surfaces — an operator
+// could not correlate a verdict with the RT_FLOW / session-table policy ID nor
+// tell whether a global vs zone-pair rule fired.
+//
+// FAIL-ON-REVERT: deleting the printPolicyMatchIdentity call (or the helper)
+// drops the "Policy ID:", "Scope:", and "Description:" lines, flipping every
+// assertion below red. The Policy ID value is additionally checked against the
+// shared RuntimePolicyIDs SSOT so a literal placeholder cannot pass.
+func TestTestPolicyOutputCarriesIDScopeDescription(t *testing.T) {
+	c := newIDScopePolicyCLI(t)
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	ids := dpuserspace.RuntimePolicyIDs(cfg)
+
+	// Zone-pair index of the trust->untrust set (sliceIdx 0 == its first/only
+	// policy) — the exact key RuntimePolicyIDs uses to stamp Result.PolicyID.
+	var zpSetIdx int
+	for i, zpp := range cfg.Security.Policies {
+		if zpp != nil && zpp.FromZone == "trust" && zpp.ToZone == "untrust" {
+			zpSetIdx = i
+		}
+	}
+	wantZoneID := ids[[2]uint32{uint32(zpSetIdx), 0}]
+	// Global policies live in a synthetic set keyed by len(Policies).
+	wantGlobalID := ids[[2]uint32{uint32(len(cfg.Security.Policies)), 0}]
+
+	t.Run("zone-pair", func(t *testing.T) {
+		var err error
+		out := captureStdout(t, func() {
+			err = c.testPolicy([]string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "destination-port", "80"})
+		})
+		if err != nil {
+			t.Fatalf("testPolicy() err = %v", err)
+		}
+		if !strings.Contains(out, "Policy match:") {
+			t.Fatalf("no zone-pair match; out = %q", out)
+		}
+		wants := []string{
+			fmt.Sprintf("Policy ID: %d", wantZoneID),
+			"Scope:     zone-pair (from-zone: trust, to-zone: untrust)",
+			"Description: CHG-9 zone allow",
+			"Rule ID:",
+		}
+		for _, w := range wants {
+			if !strings.Contains(out, w) {
+				t.Errorf("output missing %q\nfull output:\n%s", w, out)
+			}
+		}
+	})
+
+	t.Run("global", func(t *testing.T) {
+		// from-zone untrust to-zone trust misses the zone-pair tier (only
+		// trust->untrust exists) and falls through to the scoped global, whose
+		// match from-zone is untrust and to-zone is unset == any.
+		var err error
+		out := captureStdout(t, func() {
+			err = c.testPolicy([]string{"from-zone", "untrust", "to-zone", "trust", "protocol", "tcp", "destination-port", "80"})
+		})
+		if err != nil {
+			t.Fatalf("testPolicy() err = %v", err)
+		}
+		if !strings.Contains(out, "Policy match (global):") {
+			t.Fatalf("no global match; out = %q", out)
+		}
+		wants := []string{
+			fmt.Sprintf("Policy ID: %d", wantGlobalID),
+			"Scope:     global (match from-zone: untrust, to-zone: any)",
+			"Description: CHG-7 global allow",
+			"Rule ID:",
+		}
+		for _, w := range wants {
+			if !strings.Contains(out, w) {
+				t.Errorf("output missing %q\nfull output:\n%s", w, out)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes #3674

## Problem
The local operational `test policy` simulator (`pkg/cli/cli_request.go` `testPolicy`) printed only the policy name + action — and for a **global** match nothing but name + action with no scope — while `show security match-policies` (`showMatchPolicies`) over the **same** `policymatch.Result` already printed the Policy ID, scope, and description. That made `test policy` the poorest of the four match-policies surfaces: an operator could not correlate a verdict with the RT_FLOW / session-table policy ID, nor tell whether a global vs zone-pair rule fired.

## Fix (rendering only — no schema/wire change)
A small `printPolicyMatchIdentity(res)` helper is called from **both** the global and zone-pair branches of `testPolicy`. It prints, straight off `policymatch.Result`:

- **Policy ID** — the stable runtime ID from the #3667 `RuntimePolicyIDs` SSOT (the same ID feeding RT_FLOW / the session table / the audit record).
- **Rule ID** — the #3668 stable inventory join key, when present.
- **Scope** — `zone-pair (from-zone …, to-zone …)` or `global (match from-zone …, to-zone …)`, reusing the shared `matchScopeZone` helper so an unset global scope reads `any`.
- **Description** — the policy description.

No matcher logic is duplicated: `test policy` and `show security match-policies` are both thin adapters over the one `policymatch` simulator, and now render the same identity fields. The 2-space aligned label style matches the surrounding `test policy` output.

## SSOT reuse
- Fields read directly off `policymatch.Result` (populated by #3667 `RuntimePolicyIDs`).
- Scope rendered via the existing shared `matchScopeZone` helper (#3331) — no new scope logic.

## Test — RED on revert
`pkg/cli/testpolicy_idscope_3674_test.go` asserts both a zone-pair and a scoped-global match render **Policy ID** (value checked against the `RuntimePolicyIDs` SSOT, not a literal), **Rule ID**, **Scope**, and **Description**. Deleting the `printPolicyMatchIdentity` call drops those lines and flips the test red (verified).

## Validation
- `go test ./pkg/cli/...` — green
- `go build ./pkg/... ./cmd/...` — clean
- `gofmt` clean; `go vet` (only a pre-existing unrelated `cli.go:503` warning)
- RED-on-revert confirmed by removing the helper call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi