### PR TITLE
security inventory: surface default-policy log state on synthetic row (#3670)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,28 @@
+## 2026-07-01 — #3670 synthetic default-policy inventory row omits log state (H06)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3670 — the REST `/security/policies` and gRPC `GetPolicies`
+    synthetic default-policy catch-all row (`-`/`-`, named `default-policy`,
+    #3363) omitted the implicit default-policy's own RT_FLOW log intent, so
+    audit tooling read the default-deny/permit boundary as UNLOGGED while the
+    dataplane emits default-verdict session-init/close records. Populated the
+    synthetic row's `Log` / `LogSessionInit` / `LogSessionClose` from
+    `cfg.Security.DefaultPolicyLogSessionInit`/`Close` (compiled from
+    `security policies default-policy-log session-init`/`session-close`,
+    threaded to the dataplane via `ConfigSnapshot.DefaultLogSessionInit`/`Close`,
+    #3534) — the same log fields the configured rows expose (#3336). No proto
+    change (the `Log`/`log_session_init`/`log_session_close` fields already
+    exist on `pb.PolicyRule`).
+  - **File(s)**: pkg/api/security.go (defRule log fields),
+    pkg/grpcapi/server_show_zones.go (defRule log fields),
+    pkg/api/security_default_policy_log_3670_test.go (new RED-on-revert test),
+    pkg/grpcapi/server_show_zones_default_policy_log_3670_test.go (new
+    RED-on-revert test), pkg/api/README.md (default-policy row + log-state doc).
+  - **Validation**: new tests pass with the fix and go RED on source-revert
+    (log=false / omitempty session-mode keys absent); `go test ./pkg/api
+    ./pkg/grpcapi ./pkg/dataplane/userspace` green; `go build ./pkg/...
+    ./cmd/...`, gofmt, go vet clean.
+
 ## 2026-07-01 — #3684 zone-detail policy summary metadata completeness
 
 - **Timestamp**: 2026-07-01

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -77,6 +77,23 @@ liveness/readiness. Prometheus metrics endpoint. SSE event streams.
     time-gated, currently-dormant permit/deny as an active allow/deny, so
     the structured API disagreed with effective dataplane behavior. The
     gRPC mirror is `PolicyRule.scheduler_name` (19) / `inactive` (20).
+    A final synthetic `PolicyInfo` row with `from_zone="-"`/`to_zone="-"`
+    carries a single rule named `default-policy` (#3363) — the implicit
+    catch-all — with `policy_id` set to the reserved sentinel
+    (`0xFFFFFFFF`) and, when `policy-stats system-wide enable` is set, the
+    live hit counter read through the `DefaultPolicySentinelID` handle.
+    This row reflects the configured `default-policy` action and, since
+    #3670, its own RT_FLOW log intent: `log` / `log_session_init` /
+    `log_session_close` are populated from `default-policy-log
+    session-init`/`session-close` (compiled to
+    `Security.DefaultPolicyLogSessionInit`/`Close`, threaded to the
+    dataplane via `ConfigSnapshot.DefaultLogSessionInit`/`Close`, #3534) —
+    the same log fields the configured rows expose (#3336). Before #3670
+    the synthetic row omitted these, so audit tooling read the
+    default-deny/permit boundary — the most security-relevant fallback —
+    as unlogged while the dataplane was emitting default-verdict
+    session-init/close records. The gRPC `GetPolicies` default row is
+    identical (`PolicyRule.log` / `log_session_init` / `log_session_close`).
   - `GET /api/v1/security/zones` enumerates security zones (`ZoneInfo`,
     types.go). The host-inbound admission set is surfaced distinctly
     (#3328): `host_inbound_configured` is the dataplane posture bit

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -343,8 +343,18 @@ func (s *Server) policiesHandler(w http.ResponseWriter, _ *http.Request) {
 			SrcAddresses: []string{},
 			DstAddresses: []string{},
 			Applications: []string{},
-			PolicyID:     dataplane.DefaultPolicySentinelID,
-			RuleID:       dataplane.DefaultPolicyName,
+			// #3670: the implicit default-policy carries its own RT_FLOW log
+			// intent (DefaultPolicyLogSessionInit/Close, threaded to the
+			// dataplane via ConfigSnapshot.DefaultLogSessionInit/Close in the
+			// #3534 builder). Surface it on the synthetic row exactly as the
+			// configured rows expose Log/LogSessionInit/LogSessionClose (#3336)
+			// so audit tooling does not read the most security-relevant
+			// boundary as unlogged while the dataplane is emitting the records.
+			Log:             cfg.Security.DefaultPolicyLogSessionInit || cfg.Security.DefaultPolicyLogSessionClose,
+			LogSessionInit:  cfg.Security.DefaultPolicyLogSessionInit,
+			LogSessionClose: cfg.Security.DefaultPolicyLogSessionClose,
+			PolicyID:        dataplane.DefaultPolicySentinelID,
+			RuleID:          dataplane.DefaultPolicyName,
 		}
 		if statsEnabled && s.dp != nil && s.dp.IsLoaded() {
 			if ctrs, err := s.dp.ReadPolicyCounters(dataplane.DefaultPolicySentinelID); err == nil {

--- a/pkg/api/security_default_policy_log_3670_test.go
+++ b/pkg/api/security_default_policy_log_3670_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// #3670: the implicit default-policy carries its own RT_FLOW log intent
+// (default-policy-log session-init | session-close, compiled to
+// Security.DefaultPolicyLogSessionInit/Close and threaded to the dataplane via
+// ConfigSnapshot.DefaultLogSessionInit/Close in the #3534 builder). The REST
+// /security/policies inventory synthesizes a "-"/"-" default-policy catch-all
+// row, but that row omitted the log state — so audit tooling read the
+// most security-relevant boundary as UNLOGGED while the dataplane was emitting
+// default-verdict session-init/close records.
+//
+// This test commits a default-policy with both log modes and asserts the
+// synthetic row exposes log / log_session_init / log_session_close. RED-on-
+// revert: drop the log-field population on the defRule and the assertions below
+// fail (log false, the two omitempty session-mode keys absent).
+
+func defaultPolicyLogAPIStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy-log {
+            session-init;
+            session-close;
+        }
+        from-zone trust to-zone untrust {
+            policy allow-first {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestPoliciesHandlerDefaultPolicyRowExposesLogState(t *testing.T) {
+	store := defaultPolicyLogAPIStore(t)
+
+	// Sanity: the compiled config really carries both default-policy log modes;
+	// otherwise the test would silently pass without exercising the edge.
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if !cfg.Security.DefaultPolicyLogSessionInit || !cfg.Security.DefaultPolicyLogSessionClose {
+		t.Fatalf("fixture no longer sets both default-policy log modes: init=%v close=%v",
+			cfg.Security.DefaultPolicyLogSessionInit, cfg.Security.DefaultPolicyLogSessionClose)
+	}
+
+	s := &Server{store: store}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/policies", nil)
+	s.policiesHandler(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+
+	// Raw decode so an OMITTED omitempty session-mode key is distinguishable
+	// from a present-but-false one.
+	var raw struct {
+		Data []struct {
+			Rules []map[string]json.RawMessage `json:"rules"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal raw response: %v; body: %s", err, rr.Body.String())
+	}
+
+	var defRow map[string]json.RawMessage
+	for _, pi := range raw.Data {
+		for _, r := range pi.Rules {
+			name := ""
+			_ = json.Unmarshal(r["name"], &name)
+			if name == dataplane.DefaultPolicyName {
+				defRow = r
+			}
+		}
+	}
+	if defRow == nil {
+		t.Fatalf("REST inventory missing synthetic default-policy row (name=%q); body: %s",
+			dataplane.DefaultPolicyName, rr.Body.String())
+	}
+
+	// The collapsed `log` bool is always present (no omitempty); it must be true
+	// because at least one session-mode log is requested.
+	var logBool bool
+	if err := json.Unmarshal(defRow["log"], &logBool); err != nil {
+		t.Fatalf("default-policy row `log` not decodable: %v (raw %s)", err, string(defRow["log"]))
+	}
+	if !logBool {
+		t.Fatalf("default-policy row log=false, want true (#3670 regression: the "+
+			"synthetic row does not reflect the configured default-policy-log intent); body: %s",
+			rr.Body.String())
+	}
+
+	// The independent session-init / session-close modes must be present and
+	// true. With the fix reverted these omitempty keys are absent.
+	for _, key := range []string{"log_session_init", "log_session_close"} {
+		rawv, ok := defRow[key]
+		if !ok {
+			t.Fatalf("default-policy row omitted %q (#3670 regression: default-policy "+
+				"log mode not surfaced); body: %s", key, rr.Body.String())
+		}
+		var v bool
+		if err := json.Unmarshal(rawv, &v); err != nil {
+			t.Fatalf("default-policy row %q not decodable: %v (raw %s)", key, err, string(rawv))
+		}
+		if !v {
+			t.Fatalf("default-policy row %q = false, want true", key)
+		}
+	}
+}

--- a/pkg/grpcapi/server_show_zones.go
+++ b/pkg/grpcapi/server_show_zones.go
@@ -315,6 +315,17 @@ func (s *Server) GetPolicies(_ context.Context, _ *pb.GetPoliciesRequest) (*pb.G
 			SrcAddresses: []string{},
 			DstAddresses: []string{},
 			Applications: []string{},
+			// #3670: mirror the implicit default-policy's own RT_FLOW log intent
+			// (DefaultPolicyLogSessionInit/Close, threaded to the dataplane via
+			// ConfigSnapshot.DefaultLogSessionInit/Close in the #3534 builder)
+			// onto the synthetic row, using the same Log/LogSessionInit/
+			// LogSessionClose fields the configured rows set (#3336). Without
+			// this, structured automation reading GetPolicies sees the
+			// default-deny/permit boundary as unlogged while the dataplane emits
+			// default-verdict session-init/close records.
+			Log:             cfg.Security.DefaultPolicyLogSessionInit || cfg.Security.DefaultPolicyLogSessionClose,
+			LogSessionInit:  cfg.Security.DefaultPolicyLogSessionInit,
+			LogSessionClose: cfg.Security.DefaultPolicyLogSessionClose,
 			// #3623: presence-wrapped; the default row always carries the sentinel.
 			PolicyId: proto.Uint32(dataplane.DefaultPolicySentinelID),
 			RuleId:   dataplane.DefaultPolicyName,

--- a/pkg/grpcapi/server_show_zones_default_policy_log_3670_test.go
+++ b/pkg/grpcapi/server_show_zones_default_policy_log_3670_test.go
@@ -1,0 +1,101 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// #3670: the structured GetPolicies RPC synthesizes a "-"/"-" default-policy
+// catch-all row (#3363), but that row omitted the implicit default-policy's own
+// RT_FLOW log state (default-policy-log session-init | session-close, compiled
+// to Security.DefaultPolicyLogSessionInit/Close and threaded to the dataplane
+// via ConfigSnapshot.DefaultLogSessionInit/Close in the #3534 builder). Every
+// configured rule sets Log/LogSessionInit/LogSessionClose (#3336); the default
+// row did not, so structured automation read the most security-relevant
+// boundary as UNLOGGED while the dataplane emitted the records.
+//
+// RED-on-revert: drop the log-field population on the synthetic defRule and the
+// assertions below fail (GetLog false, GetLogSessionInit/Close false).
+
+func defaultPolicyLogGRPCStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        default-policy-log {
+            session-init;
+            session-close;
+        }
+        from-zone trust to-zone untrust {
+            policy allow-first {
+                match { source-address any; destination-address any; application any; }
+                then { permit; }
+            }
+        }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+func TestGetPoliciesDefaultPolicyRowExposesLogState(t *testing.T) {
+	store := defaultPolicyLogGRPCStore(t)
+
+	// Sanity: the compiled config carries both default-policy log modes.
+	cfg := store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+	if !cfg.Security.DefaultPolicyLogSessionInit || !cfg.Security.DefaultPolicyLogSessionClose {
+		t.Fatalf("fixture no longer sets both default-policy log modes: init=%v close=%v",
+			cfg.Security.DefaultPolicyLogSessionInit, cfg.Security.DefaultPolicyLogSessionClose)
+	}
+
+	s := &Server{store: store}
+	resp, err := s.GetPolicies(context.Background(), &pb.GetPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("GetPolicies() error = %v", err)
+	}
+
+	var defRule *pb.PolicyRule
+	for _, pi := range resp.GetPolicies() {
+		for _, r := range pi.GetRules() {
+			if r.GetName() == dataplane.DefaultPolicyName {
+				defRule = r
+			}
+		}
+	}
+	if defRule == nil {
+		t.Fatalf("GetPolicies() missing synthetic default-policy row (Name=%q)",
+			dataplane.DefaultPolicyName)
+	}
+
+	if !defRule.GetLog() {
+		t.Fatalf("default-policy row Log=false, want true (#3670 regression: the " +
+			"synthetic row does not reflect the configured default-policy-log intent)")
+	}
+	if !defRule.GetLogSessionInit() {
+		t.Fatalf("default-policy row LogSessionInit=false, want true (#3670 regression)")
+	}
+	if !defRule.GetLogSessionClose() {
+		t.Fatalf("default-policy row LogSessionClose=false, want true (#3670 regression)")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3670.

The REST `GET /api/v1/security/policies` and gRPC `GetPolicies` inventories
synthesize a default-policy catch-all row (`from_zone`/`to_zone` `-`/`-`, rule
named `default-policy`, sentinel policy id `0xFFFFFFFF`, #3363) so automation can
audit the implicit fallback verdict. That synthetic row carried only the action,
sentinel id, and hit counter — it **omitted the default-policy's own RT_FLOW log
intent**.

`default-policy` logging is a real, enforced feature: the config leaf
`security policies default-policy-log session-init|session-close` compiles to
`Security.DefaultPolicyLogSessionInit/Close` and is threaded to the dataplane via
`ConfigSnapshot.DefaultLogSessionInit/Close` (#3534), so the appliance emits
default-verdict session-init/close records. Because the synthetic inventory row
left the log fields zero, audit/inventory tooling read the default-deny/permit
boundary — the most security-relevant fallback — as **unlogged** while the
dataplane was logging it.

## Fix

Populate the synthetic row's `Log` / `LogSessionInit` / `LogSessionClose` from
`cfg.Security.DefaultPolicyLogSessionInit/Close` on **both** surfaces
(`pkg/api/security.go`, `pkg/grpcapi/server_show_zones.go`), reusing the same
fields the configured rows already expose (#3336). `Log` is the collapsed OR of
the two session-mode flags, matching the configured-row representation
(`rule.Log != nil`).

**No proto change** — `log` / `log_session_init` / `log_session_close` already
exist on `pb.PolicyRule`.

## Tests (RED-on-revert)

- `pkg/api/security_default_policy_log_3670_test.go` — commits a config with
  `default-policy-log session-init` + `session-close`, then asserts the synthetic
  default-policy row exposes the log state via **raw-JSON key presence** (so an
  `omitempty`-absent session-mode key is distinguishable from present-false).
- `pkg/grpcapi/server_show_zones_default_policy_log_3670_test.go` — same fixture,
  asserts `GetLog()` / `GetLogSessionInit()` / `GetLogSessionClose()`.

Both pass with the fix and go **RED on source-revert** (verified: `log=false`,
session-mode keys absent).

## Validation

- `go test ./pkg/api ./pkg/grpcapi ./pkg/dataplane/userspace` — green
- `go build ./pkg/... ./cmd/...`, `gofmt`, `go vet` — clean
- `pkg/api/README.md` updated (documents the synthetic default-policy row + its
  log state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi