### PR TITLE
userspace-dp: correct stale host-inbound comments to #3405 default-deny

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-01 — #3697 stale Rust host-inbound hot-path comments (default-deny drift; M06/L07)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3697 — three Rust userspace-dp host-inbound comments still
+    described the pre-#3405 semantics where a configured zone with no
+    `host-inbound-traffic` stanza is left absent from the snapshot and admits
+    all host-bound traffic. Post-#3405/#3653 the Go control plane sends
+    HostInboundConfigured=true for EVERY configured zone (security.go:70,
+    zones.go:448); a no-stanza zone ships an EMPTY token set = default-DENY, so
+    the absent -> admit-all branch now only applies to a zone not present in the
+    snapshot at all (legacy / truly-unconfigured). Corrected the three comments
+    to describe the #3405 default-deny reality (present-empty-set = deny vs
+    absent-entry = legacy admit-all), noted the lifeline-interface exemption
+    (fxp0/em0/fab*, #3682), and added a one-line pointer to the SSOT doc
+    docs/host-inbound-service-matrix.md (folds codex-review-128 L07). COMMENT-
+    ONLY: no logic change (verified via `git diff` — every added and removed
+    line is a comment). Validated with `cargo build --release` (clean, only
+    pre-existing warnings).
+  - **File(s)**: userspace-dp/src/afxdp/forwarding_build/zones.rs (comment),
+    userspace-dp/src/afxdp/types/forwarding.rs (comment),
+    userspace-dp/src/afxdp/poll_descriptor/mod.rs (comment).
+
 ## 2026-07-01 — #3670 synthetic default-policy inventory row omits log state (H06)
 
 - **Timestamp**: 2026-07-01

--- a/userspace-dp/src/afxdp/forwarding_build/zones.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/zones.rs
@@ -42,9 +42,19 @@ pub(super) fn populate_zones(snapshot: &ConfigSnapshot, state: &mut ForwardingSt
         // out-of-range guard.
         // zone_name_to_id is populated above by the shared SSOT helper.
         state.zone_id_to_name.insert(zone.id, zone.name.clone());
-        // #3070: build the host-inbound admission set for zones that declared a
-        // `host-inbound-traffic` stanza, keyed by the SAME validated id. Zones
-        // without a stanza are left absent → admit-all (pre-#3070 behaviour).
+        // #3070/#3405: build the host-inbound admission set keyed by the SAME
+        // validated id for every zone whose snapshot carries
+        // `host_inbound_configured`. Post-#3405 the Go control plane sends
+        // HostInboundConfigured=true for EVERY configured zone (security.go:70,
+        // zones.go:448), so a configured zone with NO `host-inbound-traffic`
+        // stanza is NOT left absent — it ships an EMPTY token set that inserts a
+        // default-`ZoneHostInbound` here (`admits()` -> false for every
+        // service/protocol => default-DENY, Junos parity). The absent-entry
+        // branch (`host_inbound_configured == false`) now only fires for a zone
+        // that is not in the snapshot at all (legacy / truly-unconfigured), for
+        // which the hot path keeps the pre-#3070 admit-all. Lifeline interfaces
+        // (fxp0/em0/fab*) are exempt because they never reach the AF_XDP
+        // local-delivery classifier (#3682). SSOT: docs/host-inbound-service-matrix.md.
         if zone.host_inbound_configured {
             state
                 .zone_host_inbound

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -1816,8 +1816,13 @@ pub(super) fn poll_binding_process_descriptor(
                         // firewall-local interface IP) whose system-service /
                         // protocol is not in the INGRESS zone's host-inbound set
                         // is denied (silent drop, Junos posture) and never cached.
-                        // A zone with no host-inbound stanza admits everything
-                        // (admit-all default), so existing configs are unaffected.
+                        // #3405: a CONFIGURED zone with no host-inbound stanza
+                        // default-DENIES host-bound traffic (it ships an EMPTY
+                        // token set, not admit-all). Admit-all now applies only
+                        // to a zone absent from the snapshot entirely (legacy /
+                        // truly-unconfigured). Lifeline interfaces (fxp0/em0/
+                        // fab*) never reach this local-delivery classifier
+                        // (#3682). SSOT: docs/host-inbound-service-matrix.md.
                         // A host-inbound DENY drops with NO lo0 side-effects (no
                         // reject reply, no lo0 counter/log) — before #3485 the lo0
                         // filter ran first, so a denied service still triggered its

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -197,12 +197,20 @@ pub(in crate::afxdp) struct ForwardingState {
         std::sync::Arc<crate::afxdp::cold_path_hist::ColdPathSlotMap>,
 }
 
-/// #3070: a zone's compiled host-inbound-traffic admission set. Built from the
-/// raw Junos `system-services` / `protocols` tokens on the wire
+/// #3070/#3405: a zone's compiled host-inbound-traffic admission set. Built from
+/// the raw Junos `system-services` / `protocols` tokens on the wire
 /// (`ZoneSnapshot`) at config-apply time (`zone_host_inbound_from_snapshot`),
-/// then read on the per-packet local-delivery admit path. A `ForwardingState`
-/// only holds a `ZoneHostInbound` for zones that declared a stanza; an absent
-/// entry means admit-all (the pre-#3070 behaviour) for that zone.
+/// then read on the per-packet local-delivery admit path. At the map level an
+/// absent `ZoneHostInbound` still means admit-all (the pre-#3070 behaviour) for
+/// that zone id — but that no longer describes a configured no-stanza zone.
+/// Post-#3405 the Go control plane sends HostInboundConfigured=true for EVERY
+/// configured zone (security.go:70, zones.go:448), so a zone with NO
+/// `host-inbound-traffic` stanza produces a PRESENT entry with an EMPTY token
+/// set (`admits()` -> false for every service/protocol => default-DENY, Junos
+/// parity). The absent-entry admit-all branch therefore now applies only to a
+/// zone not present in the snapshot at all (legacy / truly-unconfigured).
+/// Lifeline interfaces (fxp0/em0/fab*) never reach this classifier (#3682).
+/// SSOT for the token semantics: docs/host-inbound-service-matrix.md.
 ///
 /// Service tokens are classified to L4 signatures: TCP/UDP services contribute
 /// destination ports; ICMP-bearing services (ping, router-discovery) contribute


### PR DESCRIPTION
## Summary

Comment-only fix. Three Rust host-inbound hot-path comments in `userspace-dp`
still described the pre-#3405 semantics where a configured security zone with
no `host-inbound-traffic` stanza is left absent from the snapshot and admits
all host-bound traffic. That is no longer true post-#3405 / #3653.

The Go control plane now sends `HostInboundConfigured=true` for EVERY configured
zone (`pkg/api/security.go:70`, `pkg/dataplane/userspace/zones.go:448`). A
no-stanza configured zone ships an EMPTY token set, which the Rust classifier
inserts as a default `ZoneHostInbound` -> `admits()` returns false for every
service/protocol => **default-DENY** (Junos parity). The absent-entry admit-all
branch now only applies to a zone not present in the snapshot at all (legacy /
truly-unconfigured). The API/proto comments were already corrected
(#3328/#3405); these three Rust hot-path comments were missed — a
fail-open/fail-closed documentation drift on a security boundary.

## Sites corrected (comment-only, no logic change)

- `userspace-dp/src/afxdp/forwarding_build/zones.rs` — distinguish the
  present-empty-set default-deny path (`host_inbound_configured==true`, no
  stanza) from the absent-entry legacy admit-all path.
- `userspace-dp/src/afxdp/types/forwarding.rs` — keep the map-level
  "absent entry = admit-all" statement but clarify it no longer describes a
  configured no-stanza zone (which now produces a PRESENT empty-set entry =
  default-deny).
- `userspace-dp/src/afxdp/poll_descriptor/mod.rs` — replace the flatly-wrong
  "a zone with no host-inbound stanza admits everything" with the #3405
  default-deny reality.

Each site notes the lifeline-interface exemption (fxp0/em0/fab* never reach the
AF_XDP local-delivery classifier, #3682) and points at the SSOT doc
`docs/host-inbound-service-matrix.md` (folds codex-review-128 L07).

## Validation

- `cargo build --release` clean (only pre-existing warnings).
- **COMMENT-ONLY** — verified via `git diff` that every added and removed source
  line is a comment; no behavior change (the code was already correct, only the
  comments lied).

Folds codex-review-128 findings M06 and L07.

Closes #3697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi