### PR TITLE
host-inbound: surface the addressless-zone fail-open admit window (#3698)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25333,3 +25333,44 @@ top.
 - **Action**: Document the new response fields (M05/M06) and the gRPC-text global
   render (M04) in the API/gRPC references
 - **File(s)**: pkg/api/README.md, pkg/grpcapi/README.md, _Log.md
+
+## 2026-07-01 — #3698 addressless host-inbound zone fail-open admit window observability (folds codex-review-128 M02/L02)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3698 — a configured, host-inbound-ENFORCING zone whose
+    non-lifeline interfaces have no resolvable address yet (DHCP WAN before its
+    first lease, backup node before VIP install, or an unaddressed interface)
+    yields an empty address set, so `BuildZoneHostInboundViews` emits no deny
+    and `applyHostInboundFilter` scopes nothing — a transient, self-healing
+    fail-open admit window on host-inbound enforcement that was previously
+    SILENT (no log, no counter). Added observability WITHOUT changing the admit
+    semantics (an address-scoped nft deny cannot exist without an address).
+    Added `dpuserspace.AddresslessEnforcingZones(cfg)` as the SSOT: it reads the
+    scoped/unscoped decision back from `BuildZoneHostInboundViews` (the same
+    builder that drives nft emission, so the signal can never disagree with what
+    is enforced) and reports a zone iff it has a non-lifeline interface but no
+    address; scoped, lifeline-only (fxp0/em0/fab*), and interface-less zones are
+    excluded (low-noise). Daemon emits a state-TRANSITION log
+    (`logHostInboundAddresslessTransitions`): WARN on window entry, INFO on
+    recovery, deduped against the previous apply so repeated commits / DHCP
+    renewals do not flood. Added Prometheus gauge
+    `xpf_host_inbound_addressless_zones{zone}` (=1 per zone in the window,
+    absent when enforced), emitted BEFORE the dataplane gate (config-derived, so
+    it stays visible in a config-only / degraded boot; nil-store guarded).
+  - **File(s)**: pkg/dataplane/userspace/zones.go (AddresslessEnforcingZone type
+    + AddresslessEnforcingZones SSOT; #3698 doc on BuildZoneHostInboundViews),
+    pkg/daemon/daemon.go (hostInboundAddresslessZones state field),
+    pkg/daemon/daemon_nft.go (logHostInboundAddresslessTransitions + call in
+    applyHostInboundFilter), pkg/api/metrics.go (gauge desc field + Describe +
+    Collect before dataplane gate), pkg/api/metrics_descriptors.go (gauge NewDesc),
+    pkg/api/metrics_counters.go (collectHostInboundAddresslessZones, nil-store
+    guarded), docs/host-inbound-service-matrix.md (new "Addressless-zone
+    fail-open window" section)
+  - **Action**: RED-on-revert tests for all three surfaces (verified each goes
+    RED with the detection neutered, then restored green)
+  - **File(s)**: pkg/dataplane/userspace/zones_addressless_3698_test.go (SSOT:
+    addressless reported, scoped/lifeline/interface-less excluded, self-heal,
+    nil/empty), pkg/daemon/host_inbound_addressless_3698_test.go (WARN-once on
+    entry + dedup + INFO recovery via slog capture), pkg/api/
+    metrics_host_inbound_addressless_3698_test.go (gauge emitted with dataplane
+    unloaded, scoped zone absent, nil-store no-panic)

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -160,6 +160,45 @@ audits do not re-file them.
   near-nonexistent DNAT/static-NAT-to-113 path; both layers stop the prior
   plain-admit of 113.
 
+## Addressless-zone fail-open window (#3698)
+
+Host-inbound default-deny is scoped to a zone's firewall-local **addresses** —
+the nft chain matches `<fam> daddr <zone-addrs> ... drop`. A configured,
+host-inbound-enforcing zone whose non-lifeline interfaces have **no resolvable
+address yet** (a DHCP WAN before its first lease, a backup node before VIP
+install, or an interface the operator has not addressed) yields an EMPTY address
+set, so `BuildZoneHostInboundViews` emits no deny for it and
+`applyHostInboundFilter` scopes nothing. During that window, host-bound packets
+to a freshly-usable address on that interface can reach the kernel input path
+without the intended zone default-deny — a transient fail-open on a security
+boundary. The window **self-heals**: the DHCP lease-change and commit paths
+re-render the chain the moment an address appears (and VRRP VIPs are resolved
+from config, so a VIP-scoped zone is never in the window even on the backup
+node). An address-scoped nft deny cannot be installed without an address, so the
+window itself is accepted as unavoidable; #3698 makes it **observable** rather
+than silent.
+
+The SSOT for "which configured enforcing zones are currently in the window" is
+`dpuserspace.AddresslessEnforcingZones` (`pkg/dataplane/userspace/zones.go`). It
+reads the scoped/unscoped decision back from `BuildZoneHostInboundViews` — the
+same builder that drives the nft emission — so the signal can never disagree with
+what the daemon enforces. It reports a zone iff it has at least one **non-lifeline**
+interface assigned yet resolves no address; zones that are scoped, whose only
+interfaces are management/cluster-control lifelines (fxp0 / em0 / fab*), or that
+have no interfaces are deliberately NOT reported (low-noise).
+
+Two observability surfaces consume it:
+
+- **State-transition log** (`daemon_nft.go`, `logHostInboundAddresslessTransitions`).
+  A `WARN` is logged when a zone ENTERS the window and an `INFO` when it LEAVES
+  (an address appears). It logs only transitions — a zone that stays addressless
+  across repeated commits / DHCP renewals is logged once, not every apply.
+- **Prometheus gauge** `xpf_host_inbound_addressless_zones{zone}` (`pkg/api`).
+  Value `1` per zone currently in the window; the series is absent when the zone
+  is enforced. Emitted BEFORE the dataplane gate (config-derived, so it stays
+  visible in a config-only / degraded boot). Alert with e.g.
+  `max_over_time(xpf_host_inbound_addressless_zones[1h]) > 0`.
+
 ## Adding a new host-inbound service
 
 Adding or changing a token is a coordinated edit across all three surfaces so the

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -27,15 +27,16 @@ type xpfCollector struct {
 	// xpf_screen_drops_total above cannot answer "which screen fired?"; this
 	// labeled series can, now that the userspace bridge populates the per-reason
 	// GlobalCtrScreen* counters.
-	screenDropsByReasonTotal *prometheus.Desc
-	policyDeniesTotal        *prometheus.Desc
-	natAllocFailsTotal       *prometheus.Desc
-	nat64XlateTotal          *prometheus.Desc
-	hostInboundDeny          *prometheus.Desc
-	hostInboundKernelDenies  *prometheus.Desc
-	tcEgressPacketsTotal     *prometheus.Desc
-	syncookieTotal           *prometheus.Desc
-	flowCacheTotal           *prometheus.Desc
+	screenDropsByReasonTotal    *prometheus.Desc
+	policyDeniesTotal           *prometheus.Desc
+	natAllocFailsTotal          *prometheus.Desc
+	nat64XlateTotal             *prometheus.Desc
+	hostInboundDeny             *prometheus.Desc
+	hostInboundKernelDenies     *prometheus.Desc
+	hostInboundAddresslessZones *prometheus.Desc
+	tcEgressPacketsTotal        *prometheus.Desc
+	syncookieTotal              *prometheus.Desc
+	flowCacheTotal              *prometheus.Desc
 
 	// #3345/#3408: monotonic count of counter reads that failed during a
 	// scrape, across the global, per-zone, per-policy, and per-filter dataplane
@@ -517,6 +518,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nat64XlateTotal
 	ch <- c.hostInboundDeny
 	ch <- c.hostInboundKernelDenies
+	ch <- c.hostInboundAddresslessZones
 	ch <- c.tcEgressPacketsTotal
 	ch <- c.syncookieTotal
 	ch <- c.flowCacheTotal
@@ -852,6 +854,14 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	// exists to close). ReadHostInboundDenyCounters reads nft via netlink and has
 	// no dataplane dependency.
 	c.collectHostInboundKernelDenies(ch)
+
+	// #3698: configured host-inbound-enforcing zones currently in the transient
+	// fail-open admit window (a non-lifeline interface but no resolvable address
+	// yet, so no kernel host-inbound deny is scoped to them). Config-derived and
+	// independent of dataplane load, so emit it BEFORE the dataplane gate — the
+	// window can be open in a config-only / degraded boot too, and that is exactly
+	// when it must stay visible.
+	c.collectHostInboundAddresslessZones(ch)
 
 	dp := c.srv.dp
 	if dp == nil || !dp.IsLoaded() {

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -49,6 +49,30 @@ func (c *xpfCollector) collectHostInboundKernelDenies(ch chan<- prometheus.Metri
 	}
 }
 
+// collectHostInboundAddresslessZones emits xpf_host_inbound_addressless_zones
+// (#3698): a 1 per configured host-inbound-enforcing zone currently in the
+// transient fail-open admit window — it has a non-lifeline interface but no
+// resolvable address yet, so BuildZoneHostInboundViews yields an empty address
+// set and applyHostInboundFilter emits no deny for it. The series is present
+// only for zones IN the window (absent = enforced), matching the deny-counter
+// contract where a missing sample is meaningful. Config-derived (no dataplane
+// dependency), so Collect calls this BEFORE the dataplane gate. The SSOT for the
+// window is dpuserspace.AddresslessEnforcingZones, the same builder that drives
+// the daemon's state-transition warning log, so the metric and the log agree.
+func (c *xpfCollector) collectHostInboundAddresslessZones(ch chan<- prometheus.Metric) {
+	if c.srv == nil || c.srv.store == nil {
+		return
+	}
+	cfg := c.srv.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	for _, z := range dpuserspace.AddresslessEnforcingZones(cfg) {
+		ch <- prometheus.MustNewConstMetric(c.hostInboundAddresslessZones,
+			prometheus.GaugeValue, 1, z.Zone)
+	}
+}
+
 func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	// #3345: on a counter-read failure, SKIP emitting the sample instead of
 	// reporting a misleading 0, and bump xpf_counter_read_errors_total. A

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -100,6 +100,21 @@ func newCollector(srv *Server) *xpfCollector {
 				"xpf_host_inbound_denies_total path).",
 			[]string{"zone", "family"}, nil,
 		),
+		// #3698: 1 while a configured host-inbound-enforcing zone is in the
+		// transient fail-open admit window — it has a non-lifeline interface but
+		// no resolvable address yet (DHCP WAN before first lease, backup node
+		// before VIP install), so the kernel host-inbound chain emits no deny for
+		// it. A control-plane signal (config-derived, independent of dataplane
+		// load), emitted BEFORE the dataplane gate in Collect. The series is
+		// present only for zones currently in the window (absent = enforced), so
+		// `max_over_time(...)` alerts on any zone that ever fails open.
+		hostInboundAddresslessZones: prometheus.NewDesc(
+			"xpf_host_inbound_addressless_zones",
+			"1 while a configured host-inbound-enforcing zone has no resolvable "+
+				"address yet and is therefore omitted from host-inbound deny "+
+				"scoping (transient fail-open admit window), labeled by zone.",
+			[]string{"zone"}, nil,
+		),
 		tcEgressPacketsTotal: prometheus.NewDesc(
 			"xpf_tc_egress_packets_total",
 			"Total TC egress packets processed.",

--- a/pkg/api/metrics_host_inbound_addressless_3698_test.go
+++ b/pkg/api/metrics_host_inbound_addressless_3698_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// addresslessZoneStore builds a config with two enforcing zones: trust, whose
+// interface carries a static address (scoped by the host-inbound deny), and wan,
+// whose interface is DHCP with no static address and no live kernel lease in the
+// test (an empty address set → the transient fail-open admit window, #3698).
+func addresslessZoneStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	if err := store.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure() error = %v", err)
+	}
+	if err := store.LoadOverride(`
+interfaces {
+    ge-0/0/0 { unit 0 { family inet { address 10.0.1.10/24; } } }
+    ge-0/0/1 { unit 0 { family inet { dhcp; } } }
+}
+security {
+    zones {
+        security-zone trust { interfaces { ge-0/0/0.0; } }
+        security-zone wan { interfaces { ge-0/0/1.0; } }
+    }
+}
+`); err != nil {
+		t.Fatalf("LoadOverride() error = %v", err)
+	}
+	if _, err := store.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	return store
+}
+
+// TestHostInboundAddresslessZonesEmittedWhenDataplaneUnloaded is the #3698
+// fail-on-revert proof. The transient fail-open admit window is a config-derived
+// control-plane signal that can be open in a config-only / degraded boot, so
+// xpf_host_inbound_addressless_zones must be emitted even with the dataplane
+// unloaded. Collect must call collectHostInboundAddresslessZones BEFORE the
+// `dp == nil || !dp.IsLoaded()` gate; moving it below the gate makes this RED
+// (dp is nil here, so Collect returns before reaching it and the series vanishes).
+// Only the addressless zone (wan) is emitted — the scoped zone (trust) must NOT
+// appear, guarding the low-noise contract.
+func TestHostInboundAddresslessZonesEmittedWhenDataplaneUnloaded(t *testing.T) {
+	s := &Server{store: addresslessZoneStore(t)} // dp intentionally nil.
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	got := map[string]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "xpf_host_inbound_addressless_zones" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var zone string
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "zone" {
+					zone = l.GetValue()
+				}
+			}
+			got[zone] = m.GetGauge().GetValue()
+		}
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("xpf_host_inbound_addressless_zones series = %v, want exactly {wan:1} "+
+			"(config-only boot; collector must run BEFORE the dataplane gate)", got)
+	}
+	if got["wan"] != 1 {
+		t.Errorf("wan gauge = %v, want 1", got["wan"])
+	}
+	if _, ok := got["trust"]; ok {
+		t.Error("trust is statically addressed (scoped) — it must not appear in the addressless series")
+	}
+}
+
+// TestHostInboundAddresslessZonesNilStoreNoPanic guards the degraded path: a
+// Server with no store (early boot) must not panic when the collector runs
+// before the dataplane gate.
+func TestHostInboundAddresslessZonesNilStoreNoPanic(t *testing.T) {
+	c := newCollector(&Server{}) // store nil
+	ch := make(chan prometheus.Metric, 4)
+	c.collectHostInboundAddresslessZones(ch)
+	close(ch)
+	if n := len(ch); n != 0 {
+		t.Fatalf("emitted %d series with nil store, want 0", n)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -286,6 +286,16 @@ type Daemon struct {
 	// / commitAndApply paths without standing up the full dataplane.
 	applyBodyForTest func(*config.Config)
 
+	// hostInboundAddresslessZones is the set of configured host-inbound-
+	// enforcing zones observed in the transient fail-open admit window on the
+	// PREVIOUS apply (#3698): a zone with a non-lifeline interface but no
+	// resolvable address yet, so the daemon emits no host-inbound deny for it.
+	// applyHostInboundFilter diffs the current set against this to emit
+	// state-transition logs only (a zone ENTERING or LEAVING the window),
+	// keeping the warning low-noise across repeated commits / DHCP renewals.
+	// Written and read only under applySem in applyHostInboundFilter.
+	hostInboundAddresslessZones map[string]bool
+
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
 	mgmtVRFInterfaces map[string]bool

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -241,6 +241,16 @@ func buildLo0FilterPayload(cfg *config.Config, filterV4, filterV6 string) string
 // nft failure cannot brick startup; the next clean commit re-renders.
 func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	views := dpuserspace.BuildZoneHostInboundViews(cfg)
+	// #3698: surface the transient fail-open admit window. A configured
+	// host-inbound-enforcing zone whose non-lifeline interfaces have no
+	// resolvable address yet (DHCP WAN before its first lease, backup node before
+	// VIP install, or an unaddressed interface) contributes nothing to the deny
+	// scoping below, so host-bound traffic to a freshly-usable address can reach
+	// the kernel input path without the zone default-deny. The window self-heals
+	// once an address appears (the lease-change / commit paths re-render), but it
+	// is otherwise silent. Log only state TRANSITIONS (a zone entering/leaving the
+	// window) so repeated commits / DHCP renewals do not flood.
+	d.logHostInboundAddresslessTransitions(cfg)
 	if !hostInboundHasEnforceableView(views) {
 		// No host-inbound-configured zone with a resolvable address — nothing to
 		// enforce. Remove any stale table. nftDeleteTable is idempotent (an
@@ -261,6 +271,36 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	}
 	slog.Info("host-inbound filter applied", "zones", len(views))
 	return nil
+}
+
+// logHostInboundAddresslessTransitions emits a state-transition log whenever a
+// configured host-inbound-enforcing zone ENTERS or LEAVES the transient
+// fail-open admit window (#3698) — a zone with a non-lifeline interface but no
+// resolvable address yet, for which the kernel host-inbound chain emits no deny.
+// It compares the current addressless set against the set observed on the
+// previous apply (d.hostInboundAddresslessZones) so a zone that stays addressless
+// across repeated commits / DHCP renewals is logged once (on entry), not every
+// apply — the low-noise contract for a self-healing window. Runs under applySem
+// (the sole caller, applyHostInboundFilter, is invoked from applyConfigLocked),
+// so the map access needs no extra locking. The current window is also exported
+// as the xpf_host_inbound_addressless_zones gauge (pkg/api), which is scraped
+// from the active config independently of this log.
+func (d *Daemon) logHostInboundAddresslessTransitions(cfg *config.Config) {
+	current := make(map[string]bool)
+	for _, z := range dpuserspace.AddresslessEnforcingZones(cfg) {
+		current[z.Zone] = true
+		if !d.hostInboundAddresslessZones[z.Zone] {
+			slog.Warn("host-inbound zone has no address yet — host-inbound default-deny NOT enforced for it until an address appears (transient fail-open admit window)",
+				"zone", z.Zone, "interfaces", strings.Join(z.Interfaces, ","))
+		}
+	}
+	for zone := range d.hostInboundAddresslessZones {
+		if !current[zone] {
+			slog.Info("host-inbound zone now has an address — host-inbound default-deny enforced (fail-open admit window closed)",
+				"zone", zone)
+		}
+	}
+	d.hostInboundAddresslessZones = current
 }
 
 // hostInboundHasEnforceableView reports whether at least one view carries a

--- a/pkg/daemon/host_inbound_addressless_3698_test.go
+++ b/pkg/daemon/host_inbound_addressless_3698_test.go
@@ -1,0 +1,115 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// captureRecord is one slog record captured by capturingHandler.
+type captureRecord struct {
+	level slog.Level
+	msg   string
+	attrs map[string]string
+}
+
+type capturingHandler struct{ recs *[]captureRecord }
+
+func (h capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	attrs := map[string]string{}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	*h.recs = append(*h.recs, captureRecord{level: r.Level, msg: r.Message, attrs: attrs})
+	return nil
+}
+func (h capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// addresslessDaemonCfg builds a config with one zone (wan) whose interface has
+// no address (the #3698 fail-open window) and one zone (trust) with a static
+// address (scoped). withWANAddr controls whether wan's interface has resolved an
+// address yet, simulating a DHCP lease landing.
+func addresslessDaemonCfg(withWANAddr bool) *config.Config {
+	cfg := &config.Config{}
+	wan := &config.InterfaceUnit{Number: 0}
+	if withWANAddr {
+		wan.Addresses = []string{"203.0.113.9/24"}
+	}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.1.10/24"}},
+		}},
+		"ge-0-0-1": {Name: "ge-0-0-1", Units: map[int]*config.InterfaceUnit{0: wan}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"ge-0-0-0.0"}},
+		"wan":   {Name: "wan", Interfaces: []string{"ge-0-0-1.0"}},
+	}
+	return cfg
+}
+
+// TestLogHostInboundAddresslessTransitions is the #3698 fail-on-revert proof for
+// the daemon-side observability: an addressless enforcing zone logs a WARN once
+// on ENTRY (not every apply), and an INFO on RECOVERY when it gains an address.
+func TestLogHostInboundAddresslessTransitions(t *testing.T) {
+	var recs []captureRecord
+	prev := slog.Default()
+	slog.SetDefault(slog.New(capturingHandler{recs: &recs}))
+	defer slog.SetDefault(prev)
+
+	d := &Daemon{}
+
+	warnsFor := func(zone string) int {
+		n := 0
+		for _, r := range recs {
+			if r.level == slog.LevelWarn && r.attrs["zone"] == zone {
+				n++
+			}
+		}
+		return n
+	}
+	infosFor := func(zone string) int {
+		n := 0
+		for _, r := range recs {
+			if r.level == slog.LevelInfo && r.attrs["zone"] == zone {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Apply 1: wan is addressless → exactly one WARN for wan, none for trust.
+	d.logHostInboundAddresslessTransitions(addresslessDaemonCfg(false))
+	if warnsFor("wan") != 1 {
+		t.Fatalf("first apply: wan warns = %d, want 1", warnsFor("wan"))
+	}
+	if warnsFor("trust") != 0 {
+		t.Errorf("scoped trust zone must not warn, got %d", warnsFor("trust"))
+	}
+	if d.hostInboundAddresslessZones["wan"] != true {
+		t.Errorf("state not tracked: hostInboundAddresslessZones[wan] = %v", d.hostInboundAddresslessZones["wan"])
+	}
+
+	// Apply 2: still addressless → NO new WARN (state-transition dedup).
+	d.logHostInboundAddresslessTransitions(addresslessDaemonCfg(false))
+	if warnsFor("wan") != 1 {
+		t.Fatalf("second apply: wan warns = %d, want 1 (dedup — must not re-log a persisting window)", warnsFor("wan"))
+	}
+
+	// Apply 3: wan gains an address → one INFO recovery, no new WARN, state cleared.
+	d.logHostInboundAddresslessTransitions(addresslessDaemonCfg(true))
+	if infosFor("wan") != 1 {
+		t.Errorf("recovery: wan infos = %d, want 1 (window closed)", infosFor("wan"))
+	}
+	if warnsFor("wan") != 1 {
+		t.Errorf("recovery must not emit another warn, wan warns = %d", warnsFor("wan"))
+	}
+	if d.hostInboundAddresslessZones["wan"] {
+		t.Errorf("state not cleared after recovery: hostInboundAddresslessZones[wan] still set")
+	}
+}

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -89,7 +89,10 @@ func hostInboundLifelineInterface(name string, lifelines map[string]bool) bool {
 // live kernel address yet (e.g. a DHCP WAN before its first lease, or a backup
 // node before VIP install): it yields an empty address set, the daemon emits no
 // deny for it, and it self-heals once an address appears because the
-// lease-change / commit paths re-render.
+// lease-change / commit paths re-render. That transient fail-open admit window
+// is surfaced to operators by AddresslessEnforcingZones (#3698) — the daemon
+// logs a state-transition warning and exports xpf_host_inbound_addressless_zones
+// while the window is open, so it is no longer silent.
 func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 	if cfg == nil || len(cfg.Security.Zones) == 0 {
 		return nil
@@ -305,6 +308,90 @@ func BuildZoneHostInboundViews(cfg *config.Config) []ZoneHostInboundView {
 			V4Addrs:        g.v4,
 			V6Addrs:        g.v6,
 		})
+	}
+	return out
+}
+
+// AddresslessEnforcingZone names a configured host-inbound-ENFORCING security
+// zone that currently resolves NO firewall-local address across its non-lifeline
+// interfaces (#3698). Such a zone contributes nothing to the kernel-nft
+// host-inbound deny scoping (BuildZoneHostInboundViews yields an empty address
+// set for it, and applyHostInboundFilter emits no deny), so host-bound packets
+// to a freshly-usable address can reach the kernel input path without the zone's
+// intended default-deny — a transient fail-open admit window. The window
+// self-heals once an address is installed (DHCP lease / VRRP VIP / commit
+// re-render), but is otherwise SILENT; this type carries the machine-readable
+// signal the daemon logs and exports so the window is observable.
+type AddresslessEnforcingZone struct {
+	Zone string
+	// Interfaces are the non-lifeline interface refs assigned to the zone
+	// (exactly as authored under `security zones <z> interfaces <ref>`), sorted.
+	// At least one is present — a zone whose only interfaces are management /
+	// cluster-control lifelines (fxp0 / em0 / fab*) is NOT reported, since
+	// lifeline traffic is intentionally never host-inbound-denied.
+	Interfaces []string
+}
+
+// AddresslessEnforcingZones returns, in sorted zone order, the configured
+// host-inbound-enforcing zones currently in the transient fail-open admit window
+// (#3698): a zone that has at least one non-lifeline interface assigned yet
+// resolves NO firewall-local address (no static config address, no live kernel
+// address, no VRRP VIP). The "is this zone scoped by any address" decision is
+// read back from BuildZoneHostInboundViews itself — the exact same builder that
+// drives the nft emission — so this observability signal can never disagree with
+// what applyHostInboundFilter actually enforces (a zone is reported iff the
+// daemon emits no host-inbound deny for it).
+//
+// Excluded (NOT reported), so the signal stays low-noise and precise:
+//   - zones that resolve any address (static / DHCP-learned / VRRP VIP) — scoped;
+//   - zones whose only interfaces are lifelines (fxp0 / em0 / fab*) — lifeline
+//     traffic is never denied, so there is no fail-open to surface;
+//   - zones with no interfaces assigned — nothing to protect.
+func AddresslessEnforcingZones(cfg *config.Config) []AddresslessEnforcingZone {
+	if cfg == nil || len(cfg.Security.Zones) == 0 {
+		return nil
+	}
+	// A zone is "scoped" iff at least one of its views carries an address — the
+	// same condition applyHostInboundFilter uses (hostInboundHasEnforceableView)
+	// to decide whether it emits a deny. Reusing the builder guarantees the
+	// observability signal matches enforcement exactly.
+	scoped := make(map[string]bool)
+	for _, v := range BuildZoneHostInboundViews(cfg) {
+		if len(v.V4Addrs) > 0 || len(v.V6Addrs) > 0 {
+			scoped[v.Zone] = true
+		}
+	}
+	lifelines := hostInboundLifelineSet(cfg)
+	names := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var out []AddresslessEnforcingZone
+	for _, name := range names {
+		if scoped[name] {
+			continue
+		}
+		zone := cfg.Security.Zones[name]
+		if zone == nil {
+			continue
+		}
+		ifaces := make([]string, 0, len(zone.Interfaces))
+		seen := make(map[string]bool, len(zone.Interfaces))
+		for _, ref := range zone.Interfaces {
+			ref = strings.TrimSpace(ref)
+			if ref == "" || seen[ref] || hostInboundLifelineInterface(ref, lifelines) {
+				continue
+			}
+			seen[ref] = true
+			ifaces = append(ifaces, ref)
+		}
+		if len(ifaces) == 0 {
+			// Only lifeline (or no) interfaces — no fail-open window to report.
+			continue
+		}
+		sort.Strings(ifaces)
+		out = append(out, AddresslessEnforcingZone{Zone: name, Interfaces: ifaces})
 	}
 	return out
 }

--- a/pkg/dataplane/userspace/zones_addressless_3698_test.go
+++ b/pkg/dataplane/userspace/zones_addressless_3698_test.go
@@ -1,0 +1,107 @@
+// #3698: a configured host-inbound-ENFORCING zone whose non-lifeline interfaces
+// have no resolvable address yet (DHCP WAN before its first lease, backup node
+// before VIP install) is omitted from host-inbound deny scoping — a transient
+// fail-open admit window. AddresslessEnforcingZones is the SSOT that surfaces
+// that window so the daemon can log it and the API can export it. These tests
+// pin the precise set it reports and are fail-on-revert: drop the detection and
+// the addressless WAN stops surfacing; widen it and the scoped / lifeline / no-
+// interface zones start surfacing.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func addresslessCfg3698() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		// trust: statically addressed → scoped → NOT reported.
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.1.10/24"}},
+		}},
+		// wan: DHCP-pending — no static address, no live kernel address in the
+		// test → empty address set → reported.
+		"ge-0-0-1": {Name: "ge-0-0-1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0},
+		}},
+		// mgmt: fxp0 is a lifeline (never host-inbound-denied) → NOT reported even
+		// though it has no address.
+		"fxp0": {Name: "fxp0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0},
+		}},
+		// ha: no static address, but a configured VRRP VIP scopes the deny from
+		// config on both nodes → scoped → NOT reported.
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, VRRPGroups: map[string]*config.VRRPGroup{
+				"10.0.9.1/24": {VirtualAddresses: []string{"10.0.9.1"}},
+			}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"ge-0-0-0.0"}},
+		"wan":   {Name: "wan", Interfaces: []string{"ge-0-0-1.0"}},
+		"mgmt":  {Name: "mgmt", Interfaces: []string{"fxp0.0"}},
+		"ha":    {Name: "ha", Interfaces: []string{"reth0.0"}},
+		// empty: configured zone with NO interfaces → nothing to protect → NOT
+		// reported.
+		"empty": {Name: "empty"},
+	}
+	return cfg
+}
+
+func TestAddresslessEnforcingZones(t *testing.T) {
+	got := AddresslessEnforcingZones(addresslessCfg3698())
+
+	// Exactly one zone is in the fail-open window: wan (DHCP-pending, no address).
+	if len(got) != 1 {
+		t.Fatalf("AddresslessEnforcingZones = %+v, want exactly 1 (wan)", got)
+	}
+	if got[0].Zone != "wan" {
+		t.Fatalf("reported zone = %q, want wan", got[0].Zone)
+	}
+	if len(got[0].Interfaces) != 1 || got[0].Interfaces[0] != "ge-0-0-1.0" {
+		t.Errorf("wan interfaces = %v, want [ge-0-0-1.0]", got[0].Interfaces)
+	}
+
+	// Cross-check: the scoped, lifeline-only, and interface-less zones must NOT
+	// appear — the low-noise contract.
+	for _, z := range got {
+		switch z.Zone {
+		case "trust":
+			t.Error("trust is statically addressed (scoped) — must not be reported")
+		case "mgmt":
+			t.Error("mgmt has only the fxp0 lifeline — must not be reported")
+		case "ha":
+			t.Error("ha is scoped by its VRRP VIP — must not be reported")
+		case "empty":
+			t.Error("empty has no interfaces — must not be reported")
+		}
+	}
+}
+
+// TestAddresslessEnforcingZonesEmptyConfig guards the nil / no-zone fast paths.
+func TestAddresslessEnforcingZonesEmptyConfig(t *testing.T) {
+	if got := AddresslessEnforcingZones(nil); got != nil {
+		t.Errorf("nil cfg = %v, want nil", got)
+	}
+	if got := AddresslessEnforcingZones(&config.Config{}); got != nil {
+		t.Errorf("no-zone cfg = %v, want nil", got)
+	}
+}
+
+// TestAddresslessEnforcingZonesHealsOnAddress asserts the window closes once the
+// zone's interface gains an address — the self-heal path the daemon relies on to
+// clear its state-transition warning.
+func TestAddresslessEnforcingZonesHealsOnAddress(t *testing.T) {
+	cfg := addresslessCfg3698()
+	if len(AddresslessEnforcingZones(cfg)) != 1 {
+		t.Fatalf("precondition: wan should be addressless")
+	}
+	// Simulate the lease landing: give the wan unit an address.
+	cfg.Interfaces.Interfaces["ge-0-0-1"].Units[0].Addresses = []string{"203.0.113.5/24"}
+	if got := AddresslessEnforcingZones(cfg); len(got) != 0 {
+		t.Errorf("after address install = %+v, want empty (window closed)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3698.

A configured, host-inbound-**enforcing** zone whose non-lifeline interfaces
have no resolvable address yet (a DHCP WAN before its first lease, a backup
node before VIP install, or an unaddressed interface) yields an empty address
set. `BuildZoneHostInboundViews` emits no deny for it and `applyHostInboundFilter`
scopes nothing, so host-bound packets to a freshly-usable address can reach the
kernel input path without the zone default-deny — a transient, self-healing
fail-open admit window on a security boundary. It was previously **silent**: no
log, no counter.

This PR makes the window **observable** without changing the admit semantics (an
address-scoped nft deny cannot be installed without an address, so the window is
unavoidable — the ask is visibility, not a behavior change). Folds
codex-review-128 findings M02 and L02.

## What changed

- **SSOT** — `dpuserspace.AddresslessEnforcingZones(cfg)` (`pkg/dataplane/userspace/zones.go`).
  Reads the scoped/unscoped decision back from `BuildZoneHostInboundViews` (the
  same builder that drives the nft emission), so the signal can never disagree
  with what the daemon enforces. Reports a zone iff it has a non-lifeline
  interface but no resolvable address; scoped, lifeline-only (fxp0/em0/fab*),
  and interface-less zones are excluded (low-noise).
- **State-transition log** — `applyHostInboundFilter` calls
  `logHostInboundAddresslessTransitions` (`pkg/daemon/daemon_nft.go`): `WARN` on
  window entry, `INFO` on recovery, deduped against the previous apply so
  repeated commits / DHCP renewals don't flood.
- **Prometheus gauge** — `xpf_host_inbound_addressless_zones{zone}` (`pkg/api`),
  `1` per zone in the window, absent when enforced. Config-derived, emitted
  **before** the dataplane gate so it stays visible in a config-only / degraded
  boot (nil-store guarded). Alert: `max_over_time(xpf_host_inbound_addressless_zones[1h]) > 0`.
- **Docs** — new "Addressless-zone fail-open window" section in
  `docs/host-inbound-service-matrix.md`.

## Testing

- `go test ./pkg/dataplane/... ./pkg/config/... ./pkg/cli/... ./pkg/daemon/... ./pkg/api/...` — green.
- `go build ./...`, `go vet`, `gofmt` — clean on all touched files.
- Fail-on-revert verified on all three surfaces (SSOT, daemon log, gauge): each
  test goes RED with the detection neutered, then restored green.
  - `zones_addressless_3698_test.go` — addressless reported; scoped / lifeline /
    interface-less excluded; self-heal on address install; nil/empty configs.
  - `host_inbound_addressless_3698_test.go` — WARN once on entry + dedup + INFO
    recovery via an slog-capturing handler.
  - `metrics_host_inbound_addressless_3698_test.go` — gauge emitted with the
    dataplane unloaded (before-gate placement), scoped zone absent, nil-store
    no-panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
