### PR TITLE
policymatch: fail-closed strict selector parser for the policy simulator (#3696)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25348,3 +25348,14 @@ top.
 - **File(s)**: pkg/policymatch/policymatch.go, pkg/cli/cli_show_security.go,
   pkg/cli/cli_request.go, cmd/cli/show.go, cmd/cli/main.go,
   pkg/grpcapi/server_show_firewall.go, _Log.md
+
+- **Timestamp**: 2026-07-01
+- **Action**: Add RED-on-revert tests for the strict selector parser across all
+  surfaces (primitive + local show/test + remote show/test + gRPC ShowText);
+  document strict failure in the policymatch README and the Junos CLI reference
+  (M08). Verified RED-on-revert: reverting the impl fails the primitive build
+  and the local/remote/gRPC want-error cases.
+- **File(s)**: pkg/policymatch/selector_args_3696_test.go,
+  pkg/cli/query_strictness_3696_test.go, cmd/cli/query_strictness_3696_test.go,
+  pkg/grpcapi/server_testpolicy_strictness_3696_test.go,
+  pkg/policymatch/README.md, docs/junos-cli-reference.md, _Log.md

--- a/_Log.md
+++ b/_Log.md
@@ -25333,3 +25333,18 @@ top.
 - **Action**: Document the new response fields (M05/M06) and the gRPC-text global
   render (M04) in the API/gRPC references
 - **File(s)**: pkg/api/README.md, pkg/grpcapi/README.md, _Log.md
+
+## 2026-07-01 — #3696 policy-simulator strict selector parser (fail-closed)
+
+- **Timestamp**: 2026-07-01
+- **Action**: Add SSOT strict selector parser policymatch.ParseSelectorArgs +
+  SelectorArgs (+ .Query()); route all four CLI surfaces through it; harden the
+  gRPC ShowText test-policy bridge. A value-taking selector present without a
+  value, an unknown selector token, and an explicit-empty typed value are now
+  HARD ERRORS instead of silently widening the query to the wildcard. Value
+  validation (ParsePort/ParseICMPValue/ValidateProtocol/net.IP) folded into the
+  parser so the redundant per-surface checks are removed. Usage text (#3628
+  SSOT tail) documents the strict failure (M08).
+- **File(s)**: pkg/policymatch/policymatch.go, pkg/cli/cli_show_security.go,
+  pkg/cli/cli_request.go, cmd/cli/show.go, cmd/cli/main.go,
+  pkg/grpcapi/server_show_firewall.go, _Log.md

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -441,100 +441,27 @@ func (c *ctl) handleTest(args []string) error {
 }
 
 func (c *ctl) testPolicy(args []string) error {
-	var fromZone, toZone, srcIP, dstIP, proto string
-	var srcPort, dstPort int
-	var icmpType, icmpCode *uint8
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "from-zone":
-			if i+1 < len(args) {
-				i++
-				fromZone = args[i]
-			}
-		case "to-zone":
-			if i+1 < len(args) {
-				i++
-				toZone = args[i]
-			}
-		case "source-ip":
-			if i+1 < len(args) {
-				i++
-				srcIP = args[i]
-			}
-		case "destination-ip":
-			if i+1 < len(args) {
-				i++
-				dstIP = args[i]
-			}
-		case "source-port":
-			if i+1 < len(args) {
-				i++
-				// #3107: thread a source-port constraint into the shared
-				// matcher's Query.SrcPort term (previously inexpressible from
-				// the remote CLI, overmatching source-port-constrained apps).
-				// Validate via the shared helper (#3116) so a bad value errors
-				// instead of silently coercing to the 0 "any port" wildcard.
-				p, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid source-port: %w", err)
-				}
-				srcPort = p
-			}
-		case "destination-port":
-			if i+1 < len(args) {
-				i++
-				// #3116: reject a malformed/out-of-range port instead of
-				// silently coercing to the 0 "any port" wildcard (which the
-				// backend matcher treats as "no port constraint", yielding a
-				// verdict for a packet that cannot exist). Mirror the local
-				// CLI `test policy` invalid-port error.
-				p, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid destination-port: %w", err)
-				}
-				dstPort = p
-			}
-		case "protocol":
-			if i+1 < len(args) {
-				i++
-				proto = args[i]
-			}
-		case "icmp-type":
-			if i+1 < len(args) {
-				i++
-				// #3284: thread an ICMP/ICMPv6 type into the backend matcher so a
-				// type-constrained app term (junos-ping = type 8) is honored.
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-type: %w", err)
-				}
-				icmpType = v
-			}
-		case "icmp-code":
-			if i+1 < len(args) {
-				i++
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-code: %w", err)
-				}
-				icmpCode = v
-			}
-		}
+	// #3696: parse the selector grammar through the single strict SSOT parser
+	// (policymatch.ParseSelectorArgs) shared by all four CLI surfaces + the gRPC
+	// test-policy bridge. A value-taking selector present WITHOUT a value, an
+	// UNKNOWN selector token, an explicit-empty typed value, and a malformed
+	// IP / port / protocol / icmp value are HARD ERRORS instead of silently
+	// degrading to the wildcard — the remote CLI no longer builds a
+	// silently-widened test-policy topic. Per-value validation (#3116 / #3108 /
+	// #3284 / #1711) now lives in the parser.
+	sel, err := policymatch.ParseSelectorArgs(args)
+	if err != nil {
+		return err
 	}
+	fromZone, toZone, srcIP, dstIP, proto := sel.FromZone, sel.ToZone, sel.SrcIP, sel.DstIP, sel.Protocol
+	srcPort, dstPort := sel.SrcPort, sel.DstPort
+	icmpType, icmpCode := sel.ICMPType, sel.ICMPCode
 
 	if fromZone == "" || toZone == "" {
 		// #3628: shared SSOT selector list (policymatch) so the remote and local
 		// surfaces advertise the same complete selector set the parser accepts.
 		fmt.Println(policymatch.TestPolicyUsage)
 		return nil
-	}
-
-	// #3108: reject a non-empty but unknown/out-of-range protocol token locally
-	// (mirroring the local CLI `test policy`) rather than forwarding it to the
-	// backend where matchApp would short-circuit it to the "any protocol"
-	// wildcard and return a misleading verdict. An empty value is unspecified.
-	if err := policymatch.ValidateProtocol(proto); err != nil {
-		return fmt.Errorf("invalid protocol: %w", err)
 	}
 
 	topic := fmt.Sprintf("test-policy:from=%s,to=%s", fromZone, toZone)

--- a/cmd/cli/query_strictness_3696_test.go
+++ b/cmd/cli/query_strictness_3696_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRemotePolicySimulatorStrictParse is the #3696 RED-on-revert guard for the
+// REMOTE CLI `show security match-policies` and `test policy` surfaces. Both used
+// a per-surface `if i+1 < len(args)` loop with no default arm, so a value-taking
+// selector present WITHOUT a value silently widened the query and an unknown
+// selector token was silently dropped — the remote CLI then forwarded a broader
+// query than the operator typed to the typed MatchPolicies RPC / test-policy
+// topic. Both now route through the strict SSOT policymatch.ParseSelectorArgs and
+// fail closed BEFORE any RPC.
+//
+// FAIL-ON-REVERT: restoring the loose per-surface loop lets the malformed inputs
+// build a request/topic and dial the backend with no error, flipping the
+// want-error + no-RPC assertions red.
+func TestRemotePolicySimulatorStrictParse(t *testing.T) {
+	rejectCases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"missing value trailing selector", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port"}, "requires a value"},
+		{"unknown selector typo", []string{"from-zone", "trust", "to-zone", "untrust", "protcol", "tcp"}, "unknown selector"},
+		{"empty typed value", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port", ""}, "requires a value"},
+	}
+	for _, tc := range rejectCases {
+		t.Run("show/"+tc.name, func(t *testing.T) {
+			fake := &fakeBpfrxClient{}
+			c := &ctl{client: fake}
+			err := c.showMatchPolicies(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("showMatchPolicies(%v) err = %v, want %q", tc.args, err, tc.wantErr)
+			}
+			if fake.matchPoliciesCalls != 0 {
+				t.Fatalf("MatchPolicies issued %d times on malformed input; want 0", fake.matchPoliciesCalls)
+			}
+		})
+		t.Run("test/"+tc.name, func(t *testing.T) {
+			fake := &fakeBpfrxClient{}
+			c := &ctl{client: fake}
+			err := c.testPolicy(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("testPolicy(%v) err = %v, want %q", tc.args, err, tc.wantErr)
+			}
+			if fake.showTextCalls != 0 {
+				t.Fatalf("ShowText issued %d times on malformed input; want 0", fake.showTextCalls)
+			}
+		})
+	}
+
+	// Valid queries still reach the backend on both surfaces.
+	t.Run("show valid reaches RPC", func(t *testing.T) {
+		fake := &fakeBpfrxClient{}
+		c := &ctl{client: fake}
+		_ = captureStdout(t, func() {
+			if err := c.showMatchPolicies([]string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "destination-port", "443"}); err != nil {
+				t.Fatalf("valid showMatchPolicies err = %v", err)
+			}
+		})
+		if fake.matchPoliciesCalls != 1 {
+			t.Fatalf("MatchPolicies called %d times on valid input, want 1", fake.matchPoliciesCalls)
+		}
+		if got := fake.matchPoliciesReq; got == nil || got.FromZone != "trust" || got.Protocol != "tcp" || got.DestinationPort != 443 {
+			t.Fatalf("MatchPolicies req = %+v, want trust/tcp/443", got)
+		}
+	})
+	t.Run("test valid reaches RPC and builds a well-formed topic", func(t *testing.T) {
+		fake := &fakeBpfrxClient{}
+		c := &ctl{client: fake}
+		_ = captureStdout(t, func() {
+			if err := c.testPolicy([]string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "destination-port", "443"}); err != nil {
+				t.Fatalf("valid testPolicy err = %v", err)
+			}
+		})
+		if fake.showTextCalls != 1 {
+			t.Fatalf("ShowText called %d times on valid input, want 1", fake.showTextCalls)
+		}
+		// The client-built topic must be exactly what the hardened server-side
+		// parser accepts (round-trip: known keys, non-empty values).
+		for _, want := range []string{"from=trust", "to=untrust", "proto=tcp", "port=443"} {
+			if !strings.Contains(fake.showTextTopic, want) {
+				t.Fatalf("test-policy topic %q missing %q", fake.showTextTopic, want)
+			}
+		}
+	})
+}

--- a/cmd/cli/show.go
+++ b/cmd/cli/show.go
@@ -1172,95 +1172,43 @@ func (c *ctl) handleShowNAT(args []string) error {
 }
 
 func (c *ctl) showMatchPolicies(args []string) error {
-	req := &pb.MatchPoliciesRequest{}
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "from-zone":
-			if i+1 < len(args) {
-				i++
-				req.FromZone = args[i]
-			}
-		case "to-zone":
-			if i+1 < len(args) {
-				i++
-				req.ToZone = args[i]
-			}
-		case "source-ip":
-			if i+1 < len(args) {
-				i++
-				req.SourceIp = args[i]
-			}
-		case "destination-ip":
-			if i+1 < len(args) {
-				i++
-				req.DestinationIp = args[i]
-			}
-		case "destination-port":
-			if i+1 < len(args) {
-				i++
-				// #3354: route through the shared parser so a malformed/
-				// out-of-range port errors instead of silently coercing to the
-				// 0 wildcard (the old assign-on-success-only strconv.Atoi). This
-				// matches the local CLI + `test policy`, which already use
-				// policymatch.ParsePort, and mirrors the #3289 icmp-type fix.
-				v, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid destination-port: %w", err)
-				}
-				req.DestinationPort = int32(v)
-			}
-		case "source-port":
-			if i+1 < len(args) {
-				i++
-				v, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid source-port: %w", err)
-				}
-				req.SourcePort = int32(v)
-			}
-		case "protocol":
-			if i+1 < len(args) {
-				i++
-				req.Protocol = args[i]
-			}
-		case "icmp-type":
-			if i+1 < len(args) {
-				i++
-				// #3284: thread an ICMP/ICMPv6 type so a type-constrained app
-				// term (junos-ping = type 8) is honored by the backend matcher.
-				// Route through the shared validator so an invalid/out-of-range
-				// token errors instead of silently dropping to the unconstrained
-				// nil wildcard (mirrors every other surface).
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-type: %w", err)
-				}
-				if v != nil {
-					u := uint32(*v)
-					req.IcmpType = &u
-				}
-			}
-		case "icmp-code":
-			if i+1 < len(args) {
-				i++
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-code: %w", err)
-				}
-				if v != nil {
-					u := uint32(*v)
-					req.IcmpCode = &u
-				}
-			}
-		}
+	// #3696: parse the selector grammar through the single strict SSOT parser
+	// (policymatch.ParseSelectorArgs) shared by the local CLI, the remote CLI,
+	// and the gRPC test-policy bridge. A value-taking selector present WITHOUT a
+	// value, an UNKNOWN selector token, an explicit-empty typed value, and a
+	// malformed IP / port / protocol / icmp value are all HARD ERRORS — the
+	// remote CLI no longer forwards a silently-widened query to the typed
+	// MatchPolicies RPC. Per-value validation (#3354 / #3108 / #3284 / #1711)
+	// now lives in the parser, so this surface fails closed before any RPC.
+	sel, err := policymatch.ParseSelectorArgs(args)
+	if err != nil {
+		return err
 	}
 
-	if req.FromZone == "" || req.ToZone == "" {
+	if sel.FromZone == "" || sel.ToZone == "" {
 		// #3628: shared SSOT selector list (policymatch) — advertise every
 		// selector the request parser accepts, including icmp-type/icmp-code and
 		// protocol by name or number.
 		fmt.Println(policymatch.MatchPoliciesUsage)
 		return nil
+	}
+
+	req := &pb.MatchPoliciesRequest{
+		FromZone:        sel.FromZone,
+		ToZone:          sel.ToZone,
+		SourceIp:        sel.SrcIP,
+		DestinationIp:   sel.DstIP,
+		Protocol:        sel.Protocol,
+		SourcePort:      int32(sel.SrcPort),
+		DestinationPort: int32(sel.DstPort),
+	}
+	if sel.ICMPType != nil {
+		u := uint32(*sel.ICMPType)
+		req.IcmpType = &u
+	}
+	if sel.ICMPCode != nil {
+		u := uint32(*sel.ICMPCode)
+		req.IcmpCode = &u
 	}
 
 	resp, err := c.client.MatchPolicies(c.ctx(), req)

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -823,6 +823,44 @@ Global policies:
 
 ---
 
+## Security: Policy Simulator (match-policies / test policy)
+
+**Commands:** `show security match-policies from-zone <z> to-zone <z> [...]`
+and `test policy from-zone <z> to-zone <z> [...]` (both local and remote CLI).
+
+The 5-tuple policy simulator answers "which policy does this flow match?" over
+the same precedence the dataplane enforces. Selectors: `source-ip`,
+`destination-ip`, `source-port`, `destination-port`, `protocol <name|number>`,
+`icmp-type`, `icmp-code`. `from-zone` and `to-zone` are required; an OMITTED
+selector matches any.
+
+**Strict selector validation (#3696).** All four CLI surfaces (local + remote
+`show security match-policies` / `test policy`) and the gRPC `ShowText`
+`test-policy:` bridge reject malformed selector grammar rather than silently
+widening the query — a firewall diagnostic must answer the query the operator
+typed, not a broader one. All four CLI surfaces now share one strict grammar,
+`policymatch.ParseSelectorArgs`, the SSOT sibling of the #3439 (H5)
+session-filter fix:
+
+- a selector present WITHOUT a value (`... destination-port` with nothing after
+  it) is an error `selector "destination-port" requires a value` — previously it
+  left the port at 0 (the wildcard) and evaluated ALL ports;
+- an UNKNOWN / misspelled selector (`... protcol tcp`, or the plausible
+  abbreviation `... proto tcp`) is an error `unknown selector "protcol"` —
+  previously the token and its value were both silently dropped, yielding an
+  any-protocol verdict;
+- an explicit-empty typed value is an error, not the omitted-wildcard (M01);
+- malformed IP / port / protocol / icmp values still error through the shared
+  `ParsePort` / `ValidateProtocol` / `ParseICMPValue` / `net.ParseIP` validators
+  (#3116 / #3108 / #3284 / #1711).
+
+On the gRPC `test-policy:` text bridge a comma segment lacking `key=value`, an
+unknown key, or an explicit-empty typed value (`port=`) is reported as a
+diagnostic instead of being skipped; a bare `test-policy:` still reports the
+missing-from/to-zone message. A VALID query behaves exactly as before.
+
+---
+
 ## Security: Zones
 
 **Command:** `show security zones`

--- a/pkg/cli/cli_request.go
+++ b/pkg/cli/cli_request.go
@@ -178,82 +178,20 @@ func (c *CLI) testPolicy(args []string) error {
 		return nil
 	}
 
-	var fromZone, toZone, srcIP, dstIP, proto string
-	var srcPort, dstPort int
-	var icmpType, icmpCode *uint8
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "from-zone":
-			if i+1 < len(args) {
-				i++
-				fromZone = args[i]
-			}
-		case "to-zone":
-			if i+1 < len(args) {
-				i++
-				toZone = args[i]
-			}
-		case "source-ip":
-			if i+1 < len(args) {
-				i++
-				srcIP = args[i]
-			}
-		case "destination-ip":
-			if i+1 < len(args) {
-				i++
-				dstIP = args[i]
-			}
-		case "source-port":
-			if i+1 < len(args) {
-				i++
-				// #3107: the shared matcher supports a source-port term
-				// (policymatch.Query.SrcPort), but the CLI previously had no
-				// way to express it, so a source-port-constrained application
-				// was overmatched. Parse via the shared validator (#3116) so a
-				// malformed/out-of-range value errors instead of silently
-				// coercing to the 0 "any port" wildcard.
-				p, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid source-port: %w", err)
-				}
-				srcPort = p
-			}
-		case "destination-port":
-			if i+1 < len(args) {
-				i++
-				p, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid destination-port: %w", err)
-				}
-				dstPort = p
-			}
-		case "protocol":
-			if i+1 < len(args) {
-				i++
-				proto = args[i]
-			}
-		case "icmp-type":
-			if i+1 < len(args) {
-				i++
-				// #3284: thread an ICMP/ICMPv6 type into the shared matcher so a
-				// type-constrained app term (junos-ping = type 8) is honored.
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-type: %w", err)
-				}
-				icmpType = v
-			}
-		case "icmp-code":
-			if i+1 < len(args) {
-				i++
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-code: %w", err)
-				}
-				icmpCode = v
-			}
-		}
+	// #3696: parse through the single strict SSOT selector parser shared by all
+	// four CLI surfaces + the gRPC test-policy bridge. A value-taking selector
+	// with no value, an unknown selector token, an explicit-empty typed value,
+	// and a malformed IP / port / protocol / icmp value are HARD ERRORS instead
+	// of silently degrading to the wildcard — the simulator answers the query
+	// the operator typed, not a broader one. Per-value validation (#3116 /
+	// #3108 / #3284 / #1711) now lives in the parser.
+	sel, err := policymatch.ParseSelectorArgs(args)
+	if err != nil {
+		return err
 	}
+	fromZone, toZone, srcIP, dstIP, proto := sel.FromZone, sel.ToZone, sel.SrcIP, sel.DstIP, sel.Protocol
+	srcPort, dstPort := sel.SrcPort, sel.DstPort
+	icmpType, icmpCode := sel.ICMPType, sel.ICMPCode
 
 	if fromZone == "" || toZone == "" {
 		// #3628: shared SSOT selector list (policymatch) so the advertised
@@ -261,25 +199,6 @@ func (c *CLI) testPolicy(args []string) error {
 		// and protocol by name or number.
 		fmt.Println(policymatch.TestPolicyUsage)
 		return nil
-	}
-
-	// A non-empty but malformed source/destination IP would parse to
-	// nil and be treated as a wildcard by matchPolicyAddr, yielding a
-	// false-positive policy match (#1711). Reject it explicitly. An
-	// empty value still means "unspecified" (match any).
-	if srcIP != "" && net.ParseIP(srcIP) == nil {
-		return fmt.Errorf("invalid source-ip %q", srcIP)
-	}
-	if dstIP != "" && net.ParseIP(dstIP) == nil {
-		return fmt.Errorf("invalid destination-ip %q", dstIP)
-	}
-
-	// #3108: reject a non-empty but unknown/out-of-range protocol token
-	// ("tcpp", "999") instead of letting matchApp short-circuit it to the
-	// "any protocol" wildcard, which would yield a misleading verdict for a
-	// policy using `application any`. An empty value still means "unspecified".
-	if err := policymatch.ValidateProtocol(proto); err != nil {
-		return err
 	}
 
 	parsedSrc := net.ParseIP(srcIP)

--- a/pkg/cli/cli_show_security.go
+++ b/pkg/cli/cli_show_security.go
@@ -350,78 +350,23 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		return nil
 	}
 
-	// Parse arguments: from-zone <z> to-zone <z> source-ip <ip> destination-ip <ip>
-	//                   destination-port <p> protocol <proto>
-	var fromZone, toZone, srcIP, dstIP, proto string
-	var dstPort, srcPort int
-	var icmpType, icmpCode *uint8
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "from-zone":
-			if i+1 < len(args) {
-				i++
-				fromZone = args[i]
-			}
-		case "to-zone":
-			if i+1 < len(args) {
-				i++
-				toZone = args[i]
-			}
-		case "source-ip":
-			if i+1 < len(args) {
-				i++
-				srcIP = args[i]
-			}
-		case "destination-ip":
-			if i+1 < len(args) {
-				i++
-				dstIP = args[i]
-			}
-		case "destination-port":
-			if i+1 < len(args) {
-				i++
-				p, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid destination-port: %w", err)
-				}
-				dstPort = p
-			}
-		case "source-port":
-			if i+1 < len(args) {
-				i++
-				p, err := policymatch.ParsePort(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid source-port: %w", err)
-				}
-				srcPort = p
-			}
-		case "protocol":
-			if i+1 < len(args) {
-				i++
-				proto = args[i]
-			}
-		case "icmp-type":
-			if i+1 < len(args) {
-				i++
-				// #3284: honor ICMP/ICMPv6 type-constrained app terms
-				// (junos-ping = type 8).
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-type: %w", err)
-				}
-				icmpType = v
-			}
-		case "icmp-code":
-			if i+1 < len(args) {
-				i++
-				v, err := policymatch.ParseICMPValue(args[i])
-				if err != nil {
-					return fmt.Errorf("invalid icmp-code: %w", err)
-				}
-				icmpCode = v
-			}
-		}
+	// #3696: parse the selector grammar through the single strict SSOT parser
+	// (policymatch.ParseSelectorArgs) shared by all four CLI surfaces + the gRPC
+	// test-policy bridge. A value-taking selector present WITHOUT a value, an
+	// UNKNOWN selector token, an explicit-empty typed value, and a malformed
+	// IP / port / protocol / icmp value are all HARD ERRORS instead of silently
+	// degrading to the wildcard — a firewall policy simulator must answer the
+	// query the operator typed, not a broader one. The per-value validation
+	// (ParsePort / ParseICMPValue / ValidateProtocol / net.ParseIP, #3116 /
+	// #3108 / #3284 / #1711) is folded into the parser, so the redundant
+	// per-surface checks are gone.
+	sel, err := policymatch.ParseSelectorArgs(args)
+	if err != nil {
+		return err
 	}
+	fromZone, toZone, srcIP, dstIP, proto := sel.FromZone, sel.ToZone, sel.SrcIP, sel.DstIP, sel.Protocol
+	srcPort, dstPort := sel.SrcPort, sel.DstPort
+	icmpType, icmpCode := sel.ICMPType, sel.ICMPCode
 
 	if fromZone == "" || toZone == "" {
 		// #3628: the selector list is the shared SSOT in policymatch so all four
@@ -430,26 +375,6 @@ func (c *CLI) showMatchPolicies(cfg *config.Config, args []string) error {
 		// number), not the stale tcp|udp-only subset.
 		fmt.Println(policymatch.MatchPoliciesUsage)
 		return nil
-	}
-
-	// A non-empty but malformed source/destination IP would parse to
-	// nil and be treated as a wildcard by matchPolicyAddr, yielding a
-	// false-positive PERMIT verdict in the simulator (#1711). Reject it
-	// explicitly. An empty value still means "unspecified" (match any).
-	if srcIP != "" && net.ParseIP(srcIP) == nil {
-		return fmt.Errorf("invalid source-ip %q", srcIP)
-	}
-	if dstIP != "" && net.ParseIP(dstIP) == nil {
-		return fmt.Errorf("invalid destination-ip %q", dstIP)
-	}
-
-	// #3108: a non-empty but unknown/out-of-range protocol token ("tcpp",
-	// "999") must not silently become "any protocol" — matchApp short-circuits
-	// to match-any for an unresolvable protocol, yielding a misleading verdict
-	// for a policy using `application any`. An empty value still means
-	// "unspecified" (match any protocol).
-	if err := policymatch.ValidateProtocol(proto); err != nil {
-		return err
 	}
 
 	parsedSrc := net.ParseIP(srcIP)

--- a/pkg/cli/query_strictness_3696_test.go
+++ b/pkg/cli/query_strictness_3696_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLocalPolicySimulatorStrictParse is the #3696 RED-on-revert guard for the
+// LOCAL CLI `show security match-policies` and `test policy` surfaces. Both used
+// to parse selectors with a per-surface `if i+1 < len(args)` loop and no default
+// arm, so a value-taking selector present WITHOUT a value silently widened the
+// query to the wildcard and an unknown/misspelled selector token was silently
+// dropped. Both now route through the strict SSOT policymatch.ParseSelectorArgs.
+//
+// FAIL-ON-REVERT: restoring the loose per-surface loop makes the missing-value,
+// unknown-selector, and empty-typed-value cases return nil (a silently widened /
+// dropped query) instead of an error, flipping the want-error cases red.
+func TestLocalPolicySimulatorStrictParse(t *testing.T) {
+	c := newPolicyMatchCLIStore(t)
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string // "" = valid, want no error
+	}{
+		{"missing value trailing selector", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port"}, "requires a value"},
+		{"unknown selector typo", []string{"from-zone", "trust", "to-zone", "untrust", "protcol", "tcp"}, "unknown selector"},
+		{"empty typed value", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port", ""}, "requires a value"},
+		{"valid full query", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "destination-port", "443"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run("show/"+tc.name, func(t *testing.T) {
+			var err error
+			captureStdout(t, func() { err = c.showMatchPolicies(cfg, tc.args) })
+			checkStrict3696(t, "showMatchPolicies", tc.args, err, tc.wantErr)
+		})
+		t.Run("test/"+tc.name, func(t *testing.T) {
+			var err error
+			captureStdout(t, func() { err = c.testPolicy(tc.args) })
+			checkStrict3696(t, "testPolicy", tc.args, err, tc.wantErr)
+		})
+	}
+}
+
+func checkStrict3696(t *testing.T, fn string, args []string, err error, wantErr string) {
+	t.Helper()
+	if wantErr == "" {
+		if err != nil {
+			t.Fatalf("%s(%v) err = %v, want nil (valid query regressed)", fn, args, err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("%s(%v) err = nil, want %q (silent widen / drop)", fn, args, wantErr)
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Fatalf("%s(%v) err = %v, want substring %q", fn, args, err, wantErr)
+	}
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -176,57 +176,89 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 	var fromZone, toZone, srcIP, dstIP, proto string
 	var srcPort, dstPort int
 	var icmpType, icmpCode *uint8
-	var srcPortErr, portErr, protoErr, icmpTypeErr, icmpCodeErr error
-	for _, kv := range strings.Split(params, ",") {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		switch parts[0] {
-		case "from":
-			fromZone = parts[1]
-		case "to":
-			toZone = parts[1]
-		case "src":
-			srcIP = parts[1]
-		case "dst":
-			dstIP = parts[1]
-		case "srcport":
-			// #3107: a source-port constraint must thread into the shared
-			// matcher's Query.SrcPort term (previously inexpressible from the
-			// CLI `test policy` topic, overmatching source-port-constrained
-			// applications). Validate via the shared helper (#3116) so a
-			// malformed/out-of-range value reports an error instead of
-			// silently coercing to the 0 "any port" wildcard.
-			srcPort, srcPortErr = policymatch.ParsePort(parts[1])
-		case "port":
-			// #3116: a malformed/out-of-range port must NOT silently coerce to
-			// the 0 "any port" wildcard (the shared matcher gates the port term
-			// on dstPort > 0), which would yield a verdict for a packet that
-			// cannot exist. Route through the shared validator and report the
-			// error the way a bad src/dst is reported below.
-			dstPort, portErr = policymatch.ParsePort(parts[1])
-		case "proto":
-			// #3108: a non-empty but unknown/out-of-range protocol token must
-			// NOT silently coerce to the empty "any protocol" wildcard (the
-			// shared matcher's matchApp short-circuits to match-any for an
-			// unresolvable protocol), which would yield a verdict for traffic
-			// that cannot exist. Validate via the shared helper and report the
-			// error the way a bad port/src is reported below.
-			proto = parts[1]
-			protoErr = policymatch.ValidateProtocol(proto)
-		case "ictype":
-			// #3284: ICMP/ICMPv6 type so a type-constrained application term
-			// (junos-ping = type 8) is honored. Empty is unspecified (the term
-			// fails closed); a malformed/out-of-range value errors.
-			icmpType, icmpTypeErr = policymatch.ParseICMPValue(parts[1])
-		case "iccode":
-			icmpCode, icmpCodeErr = policymatch.ParseICMPValue(parts[1])
+	var srcPortErr, portErr, protoErr, icmpTypeErr, icmpCodeErr, parseErr error
+	// #3696: fail CLOSED on malformed selector grammar, the server-boundary
+	// sibling of the strict CLI parser (policymatch.ParseSelectorArgs). The old
+	// `if len(parts) != 2 { continue }` silently DROPPED any comma segment
+	// lacking a `key=value` — `...,port` left dstPort at the 0 wildcard and the
+	// simulator evaluated ALL ports — and the switch had no default arm, so an
+	// unknown key (`prot=tcp`) was ignored, leaving proto empty (any protocol).
+	// An explicit-empty typed value (`port=`) was likewise treated as omitted
+	// because ParsePort("") returns (0, nil), so the handler could not tell
+	// "key absent" (legit wildcard) from "key present, empty value" (malformed).
+	// A malformed segment, an unknown key, or an empty value is now a reported
+	// error, distinguishing key-absent from key-empty (M01). An entirely empty
+	// param string (bare `test-policy:`) still falls through to the
+	// missing-from/to-zone diagnostic below rather than reading as malformed.
+	if params != "" {
+		for _, kv := range strings.Split(params, ",") {
+			parts := strings.SplitN(kv, "=", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				if parseErr == nil {
+					parseErr = fmt.Errorf("malformed selector segment %q (expected key=value)", kv)
+				}
+				continue
+			}
+			switch parts[0] {
+			case "from":
+				fromZone = parts[1]
+			case "to":
+				toZone = parts[1]
+			case "src":
+				srcIP = parts[1]
+			case "dst":
+				dstIP = parts[1]
+			case "srcport":
+				// #3107: a source-port constraint must thread into the shared
+				// matcher's Query.SrcPort term (previously inexpressible from the
+				// CLI `test policy` topic, overmatching source-port-constrained
+				// applications). Validate via the shared helper (#3116) so a
+				// malformed/out-of-range value reports an error instead of
+				// silently coercing to the 0 "any port" wildcard.
+				srcPort, srcPortErr = policymatch.ParsePort(parts[1])
+			case "port":
+				// #3116: a malformed/out-of-range port must NOT silently coerce to
+				// the 0 "any port" wildcard (the shared matcher gates the port term
+				// on dstPort > 0), which would yield a verdict for a packet that
+				// cannot exist. Route through the shared validator and report the
+				// error the way a bad src/dst is reported below.
+				dstPort, portErr = policymatch.ParsePort(parts[1])
+			case "proto":
+				// #3108: a non-empty but unknown/out-of-range protocol token must
+				// NOT silently coerce to the empty "any protocol" wildcard (the
+				// shared matcher's matchApp short-circuits to match-any for an
+				// unresolvable protocol), which would yield a verdict for traffic
+				// that cannot exist. Validate via the shared helper and report the
+				// error the way a bad port/src is reported below.
+				proto = parts[1]
+				protoErr = policymatch.ValidateProtocol(proto)
+			case "ictype":
+				// #3284: ICMP/ICMPv6 type so a type-constrained application term
+				// (junos-ping = type 8) is honored. Empty is unspecified (the term
+				// fails closed); a malformed/out-of-range value errors.
+				icmpType, icmpTypeErr = policymatch.ParseICMPValue(parts[1])
+			case "iccode":
+				icmpCode, icmpCodeErr = policymatch.ParseICMPValue(parts[1])
+			default:
+				// #3696: an unknown selector key (e.g. `prot=tcp`, a plausible
+				// operator abbreviation of `proto`) must not be silently ignored,
+				// leaving that dimension at the wildcard.
+				if parseErr == nil {
+					parseErr = fmt.Errorf("unknown selector %q", parts[0])
+				}
+			}
 		}
 	}
 	switch {
 	case cfg == nil:
 		buf.WriteString("No active configuration\n")
+	case parseErr != nil:
+		// #3696: report malformed grammar (a segment lacking key=value, an
+		// unknown key, or an explicit-empty typed value) before evaluating, so a
+		// typo cannot silently widen the query. Checked before the from/to-zone
+		// diagnostic so a malformed selector is not masked by a legit-looking
+		// missing-zone message.
+		fmt.Fprintf(buf, "%v\n", parseErr)
 	case fromZone == "" || toZone == "":
 		buf.WriteString("Missing from/to zone parameters\n")
 	case srcPortErr != nil:

--- a/pkg/grpcapi/server_testpolicy_strictness_3696_test.go
+++ b/pkg/grpcapi/server_testpolicy_strictness_3696_test.go
@@ -1,0 +1,73 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestShowTestPolicyStrictGrammar is the #3696 RED-on-revert guard for the gRPC
+// ShowText "test-policy:" bridge (the server-boundary sibling of the strict CLI
+// parser). The old handler used `if len(parts) != 2 { continue }` and had no
+// default arm, so a comma segment lacking `key=value` was silently dropped
+// (`...,port` -> dstPort 0 -> all ports), an unknown key (`prot=tcp`) was
+// ignored (proto empty -> any protocol), and an explicit-empty typed value
+// (`port=`) read as omitted (ParsePort("") -> (0, nil)). Each silently widened
+// the query.
+//
+// FAIL-ON-REVERT: removing the malformed-segment / empty-value / default-arm
+// handling makes these inputs evaluate a widened query and print a "Policy
+// match" (or a default verdict) with no diagnostic, flipping the assertions red.
+func TestShowTestPolicyStrictGrammar(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+	cases := []struct {
+		name    string
+		topic   string
+		wantBad string // substring wanted in output; "" = want a Policy match
+	}{
+		{"missing = segment", "test-policy:from=trust,to=untrust,port", "malformed"},
+		{"unknown key", "test-policy:from=trust,to=untrust,prot=tcp", "unknown selector"},
+		{"empty typed value", "test-policy:from=trust,to=untrust,port=", "malformed"},
+		{"valid", "test-policy:from=trust,to=untrust,src=10.0.1.5,dst=10.0.1.6,proto=tcp", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: tc.topic})
+			if err != nil {
+				t.Fatalf("ShowText(%q) err = %v", tc.topic, err)
+			}
+			if tc.wantBad == "" {
+				if !strings.Contains(resp.Output, "Policy match") {
+					t.Fatalf("%s: output = %q, want a Policy match (valid grammar regressed)", tc.name, resp.Output)
+				}
+				return
+			}
+			if !strings.Contains(resp.Output, tc.wantBad) {
+				t.Fatalf("%s: output = %q, want a %q diagnostic", tc.name, resp.Output, tc.wantBad)
+			}
+			if strings.Contains(resp.Output, "Policy match") {
+				t.Fatalf("%s: malformed grammar produced a policy match (silent widen): %q", tc.name, resp.Output)
+			}
+		})
+	}
+}
+
+// TestShowTestPolicyBareTopicStillMissingZones proves a bare `test-policy:`
+// (empty params) is NOT reported as malformed grammar — it falls through to the
+// existing missing-from/to-zone diagnostic (the #3696 params!="" gate), so the
+// hardening does not turn a legitimate no-selector invocation into an error.
+func TestShowTestPolicyBareTopicStillMissingZones(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+	resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: "test-policy:"})
+	if err != nil {
+		t.Fatalf("ShowText(bare topic) err = %v", err)
+	}
+	if strings.Contains(resp.Output, "malformed") {
+		t.Fatalf("bare topic wrongly reported malformed: %q", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "Missing from/to zone") {
+		t.Fatalf("bare topic output = %q, want a missing-from/to-zone diagnostic", resp.Output)
+	}
+}

--- a/pkg/policymatch/README.md
+++ b/pkg/policymatch/README.md
@@ -109,6 +109,64 @@ before; only an explicitly-invalid protocol newly errors. Coverage:
 `test-policy:`), `pkg/cli/policymatch_protocol_test.go`, and
 `cmd/cli/testpolicy_protocol_test.go`.
 
+## Selector grammar strictness (#3696)
+
+The value validators above (#3116 port, #3108 protocol, #3284 icmp, #1711 IP)
+are only reached when the OUTER selector grammar actually delivers the token to
+them. Before #3696 each of the four CLI surfaces hand-maintained its own
+`for i := range args { switch args[i] {...} }` loop, and all four shared the two
+fail-OPEN defects the session-filter parser hit and #3439 (H5) fixed strictly:
+
+- a value-taking selector present WITHOUT a following value was guarded by
+  `if i+1 < len(args)` with no else, so a trailing selector left the field at its
+  zero/empty wildcard — `... destination-port` (no value) evaluated ALL
+  destination ports;
+- the switch had no `default:` arm, so an UNKNOWN/misspelled selector token (and
+  its value) were both silently skipped — `... protcol tcp` dropped both tokens
+  and yielded an any-protocol verdict.
+
+Because the shared matcher treats a zero port / empty protocol / nil icmp-type
+as "no constraint", either defect silently WIDENED the query: the operator got a
+permit/deny verdict for a BROADER set of traffic than they typed.
+
+The usage text was already a shared SSOT (#3628); the PARSING is now too:
+
+- `ParseSelectorArgs(args []string) (SelectorArgs, error)` — the single strict
+  grammar for the space-separated `from-zone <z> to-zone <z> [source-ip <ip>]
+  [destination-ip <ip>] [source-port <p>] [destination-port <p>]
+  [protocol <name|number>] [icmp-type <n>] [icmp-code <n>]` token vector. A
+  value-taking selector with no value (or an explicit-empty value — M01) errors
+  `selector "X" requires a value` (a `takeValue` helper mirroring
+  `cmd/cli/show.go` `parseFlowSessionArgs`); an unknown token errors
+  `unknown selector "X"` (default arm); every value routes through the existing
+  `ParsePort` / `ParseICMPValue` / `ValidateProtocol` / `net.ParseIP` validators.
+  A field left at its zero value therefore means the operator OMITTED it (legit
+  wildcard), never "present but silently dropped". `SelectorArgs.Query()` builds
+  a `policymatch.Query` (empty IP → nil `net.IP` wildcard) for the local/gRPC
+  in-process surfaces.
+
+This is applied at ALL FOUR CLI surfaces (mirroring the #3116 / #3108 wiring)
+plus the gRPC text bridge:
+
+- CLI `test policy` + `show security match-policies` (local `pkg/cli`) AND the
+  remote `cli` client (`cmd/cli`) — `ParseSelectorArgs` → a command error before
+  any RPC;
+- gRPC `ShowText` `test-policy:` (`showTestPolicy`) — the server-boundary sibling
+  hardened directly: a comma segment lacking `key=value`, an unknown key, or an
+  explicit-empty typed value (`port=`, indistinguishable from "key absent" under
+  the old `ParsePort("") == (0, nil)`) is reported as a `malformed selector
+  segment` / `unknown selector` diagnostic instead of being silently skipped. A
+  bare `test-policy:` (no params) still falls through to the missing-from/to-zone
+  diagnostic.
+
+A VALID query behaves exactly as before; only a missing value, an unknown
+selector, or an explicit-empty value newly errors. The #3628 usage tail now
+documents the strict failure. Coverage: `selector_args_3696_test.go` (the shared
+primitive), `pkg/cli/query_strictness_3696_test.go`,
+`cmd/cli/query_strictness_3696_test.go`, and
+`pkg/grpcapi/server_testpolicy_strictness_3696_test.go` (red-on-revert on every
+surface).
+
 ## The surface #3042 missed (#3103)
 
 The original #3042 consolidation routed the REST/gRPC `MatchPolicies` and CLI

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -208,6 +208,8 @@ const matchPoliciesUsageTail = ` from-zone <zone> to-zone <zone>
        [protocol <name|number>]   tcp, udp, icmp, icmp6, gre, esp, ospf, ... or 0-255
        [icmp-type <0-255>] [icmp-code <0-255>]
        from-zone and to-zone are required; an omitted selector matches any.
+       an unknown selector, or a selector given without a value, is an error
+       (the query is not silently widened to match traffic you did not type).
        examples:
          ... protocol tcp destination-port 443
          ... protocol udp source-port 53 destination-port 53
@@ -284,6 +286,189 @@ type Query struct {
 	// closed on a nil state map (#3414), so a scheduled policy is treated as
 	// inactive exactly as the dataplane treats it rather than certified active.
 	PolicyInactiveFn func(schedulerName string) bool
+}
+
+// SelectorArgs is the parsed, VALIDATED result of a policy-simulator selector
+// token vector — the space-separated `from-zone <z> to-zone <z> [source-ip
+// <ip>] [destination-ip <ip>] [source-port <p>] [destination-port <p>]
+// [protocol <name|number>] [icmp-type <n>] [icmp-code <n>]` grammar that all
+// four operator surfaces accept: the local CLI `show security match-policies`
+// and `test policy` (pkg/cli), and the remote CLI equivalents (cmd/cli).
+//
+// A "" SrcIP/DstIP/Protocol or a 0 SrcPort/DstPort means the operator OMITTED
+// that selector, the established wildcard — the corresponding match dimension
+// is unconstrained. A nil ICMPType/ICMPCode is likewise unspecified. These are
+// the ONLY wildcard signals: a selector that is PRESENT always carries a
+// validated value (ParseSelectorArgs rejects a present-but-valueless selector),
+// so a field left at its zero value here unambiguously means "omitted", never
+// "present but silently dropped".
+type SelectorArgs struct {
+	FromZone string
+	ToZone   string
+	SrcIP    string // "" = unspecified; non-empty is a net.ParseIP-validated literal
+	DstIP    string // "" = unspecified; non-empty is a net.ParseIP-validated literal
+	Protocol string // "" = unspecified; non-empty resolves via appid.ProtocolNumber
+	SrcPort  int    // 0 = unspecified
+	DstPort  int    // 0 = unspecified
+	ICMPType *uint8 // nil = unspecified
+	ICMPCode *uint8 // nil = unspecified
+}
+
+// ParseSelectorArgs is the SINGLE strict grammar for the policy-simulator
+// selector token vector (#3696). Before it, each of the four CLI surfaces
+// hand-maintained its own `for i := range args { switch args[i] {...} }` loop,
+// and all four shared the SAME two fail-OPEN defects the session-filter parser
+// hit and #3439 (H5) fixed strictly:
+//
+//   - a value-taking selector present WITHOUT a following value was guarded by
+//     `if i+1 < len(args)` with no else, so a trailing selector left the field
+//     at its zero/empty wildcard — `... destination-port` (no value) evaluated
+//     ALL destination ports and printed a verdict for a port the operator never
+//     typed;
+//   - the switch had no `default:` arm, so an UNKNOWN/misspelled selector token
+//     (and its value) were both silently skipped — `... protcol tcp` dropped
+//     both tokens and yielded an any-protocol verdict.
+//
+// Because the shared matcher treats a zero port / empty protocol / nil
+// icmp-type as "no constraint", either defect silently WIDENED the query: the
+// operator got a permit/deny verdict for a broader set of traffic than they
+// asked about, from a firewall diagnostic whose entire job is to answer
+// precisely which traffic a policy matches.
+//
+// ParseSelectorArgs fails CLOSED, mirroring cmd/cli parseFlowSessionArgs
+// (#3439): a value-taking selector without a value is an error; an empty value
+// (e.g. an explicit `""` token) is an error (a present selector must carry a
+// concrete value — M01); an unknown token is an error; and every value routes
+// through the existing ParsePort / ParseICMPValue / ValidateProtocol / net.IP
+// validators, so a malformed port / icmp / protocol / IP errors instead of
+// degrading to the wildcard. A field left at its zero value in the returned
+// SelectorArgs therefore means the operator OMITTED it (legit wildcard), never
+// "present but dropped". from-zone and to-zone are the only REQUIRED selectors;
+// they may be absent (the caller prints usage), but if present must carry a
+// value like any other selector.
+func ParseSelectorArgs(args []string) (SelectorArgs, error) {
+	var s SelectorArgs
+	// takeValue consumes the token following a value-taking selector, erroring
+	// when it is missing (trailing selector) or empty (present-but-valueless).
+	// Mirrors cmd/cli/show.go parseFlowSessionArgs (#3439 H5).
+	takeValue := func(i *int, kw string) (string, error) {
+		if *i+1 >= len(args) {
+			return "", fmt.Errorf("selector %q requires a value", kw)
+		}
+		*i++
+		v := strings.TrimSpace(args[*i])
+		if v == "" {
+			return "", fmt.Errorf("selector %q requires a value", kw)
+		}
+		return v, nil
+	}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "from-zone":
+			v, err := takeValue(&i, "from-zone")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			s.FromZone = v
+		case "to-zone":
+			v, err := takeValue(&i, "to-zone")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			s.ToZone = v
+		case "source-ip":
+			v, err := takeValue(&i, "source-ip")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			// A non-empty but malformed IP would parse to nil and be treated as
+			// a wildcard by the matcher, yielding a false-positive verdict
+			// (#1711). Reject it here so every surface fails closed identically.
+			if net.ParseIP(v) == nil {
+				return SelectorArgs{}, fmt.Errorf("invalid source-ip %q", v)
+			}
+			s.SrcIP = v
+		case "destination-ip":
+			v, err := takeValue(&i, "destination-ip")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			if net.ParseIP(v) == nil {
+				return SelectorArgs{}, fmt.Errorf("invalid destination-ip %q", v)
+			}
+			s.DstIP = v
+		case "source-port":
+			v, err := takeValue(&i, "source-port")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			p, err := ParsePort(v)
+			if err != nil {
+				return SelectorArgs{}, fmt.Errorf("invalid source-port: %w", err)
+			}
+			s.SrcPort = p
+		case "destination-port":
+			v, err := takeValue(&i, "destination-port")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			p, err := ParsePort(v)
+			if err != nil {
+				return SelectorArgs{}, fmt.Errorf("invalid destination-port: %w", err)
+			}
+			s.DstPort = p
+		case "protocol":
+			v, err := takeValue(&i, "protocol")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			if err := ValidateProtocol(v); err != nil {
+				return SelectorArgs{}, err
+			}
+			s.Protocol = v
+		case "icmp-type":
+			v, err := takeValue(&i, "icmp-type")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			t, err := ParseICMPValue(v)
+			if err != nil {
+				return SelectorArgs{}, fmt.Errorf("invalid icmp-type: %w", err)
+			}
+			s.ICMPType = t
+		case "icmp-code":
+			v, err := takeValue(&i, "icmp-code")
+			if err != nil {
+				return SelectorArgs{}, err
+			}
+			cc, err := ParseICMPValue(v)
+			if err != nil {
+				return SelectorArgs{}, fmt.Errorf("invalid icmp-code: %w", err)
+			}
+			s.ICMPCode = cc
+		default:
+			return SelectorArgs{}, fmt.Errorf("unknown selector %q", args[i])
+		}
+	}
+	return s, nil
+}
+
+// Query builds a policymatch.Query from parsed selectors. The caller-supplied
+// FeedOverlay and PolicyInactiveFn are left nil for the caller to populate.
+// An empty SrcIP/DstIP maps to a nil net.IP (the match-any wildcard); a
+// non-empty value is already net.ParseIP-validated by ParseSelectorArgs.
+func (s SelectorArgs) Query() Query {
+	return Query{
+		FromZone: s.FromZone,
+		ToZone:   s.ToZone,
+		SrcIP:    net.ParseIP(s.SrcIP),
+		DstIP:    net.ParseIP(s.DstIP),
+		Protocol: s.Protocol,
+		SrcPort:  s.SrcPort,
+		DstPort:  s.DstPort,
+		ICMPType: s.ICMPType,
+		ICMPCode: s.ICMPCode,
+	}
 }
 
 // Result is the simulator verdict.

--- a/pkg/policymatch/selector_args_3696_test.go
+++ b/pkg/policymatch/selector_args_3696_test.go
@@ -1,0 +1,123 @@
+package policymatch
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseSelectorArgsFailsClosed is the #3696 SSOT guard for the strict
+// selector parser shared by all four CLI surfaces + the gRPC test-policy
+// bridge. Before it, each surface hand-copied a `for i := range args { switch
+// args[i] {...} }` loop guarded by `if i+1 < len(args)` with no else and with
+// no default arm, so a value-taking selector present WITHOUT a value silently
+// stayed at the wildcard and an UNKNOWN selector token (and its value) were
+// silently dropped — either defect widened the firewall-policy query.
+//
+// FAIL-ON-REVERT: relaxing ParseSelectorArgs back to the loose "skip on
+// missing value / ignore unknown token" behavior makes the want-error cases
+// return nil (a silently widened / dropped query), flipping them red.
+func TestParseSelectorArgsFailsClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string // substring; "" = want no error
+	}{
+		// H01-H10: a value-taking selector present without a value must ERROR.
+		{"trailing from-zone", []string{"from-zone"}, "requires a value"},
+		{"trailing to-zone", []string{"from-zone", "trust", "to-zone"}, "requires a value"},
+		{"trailing destination-port", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port"}, "requires a value"},
+		{"trailing source-port", []string{"from-zone", "trust", "to-zone", "untrust", "source-port"}, "requires a value"},
+		{"trailing protocol", []string{"from-zone", "trust", "to-zone", "untrust", "protocol"}, "requires a value"},
+		{"trailing source-ip", []string{"from-zone", "trust", "to-zone", "untrust", "source-ip"}, "requires a value"},
+		{"trailing destination-ip", []string{"from-zone", "trust", "to-zone", "untrust", "destination-ip"}, "requires a value"},
+		{"trailing icmp-type", []string{"from-zone", "trust", "to-zone", "untrust", "icmp-type"}, "requires a value"},
+		{"trailing icmp-code", []string{"from-zone", "trust", "to-zone", "untrust", "icmp-code"}, "requires a value"},
+		// M01: an explicit-empty typed value must ERROR, not read as omitted.
+		{"empty destination-port", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port", ""}, "requires a value"},
+		{"empty protocol", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", ""}, "requires a value"},
+		{"empty from-zone", []string{"from-zone", "", "to-zone", "untrust"}, "requires a value"},
+		// Unknown / misspelled selector must ERROR, not silently drop.
+		{"unknown protcol typo", []string{"from-zone", "trust", "to-zone", "untrust", "protcol", "tcp"}, "unknown selector"},
+		{"unknown proto abbrev", []string{"from-zone", "trust", "to-zone", "untrust", "proto", "tcp"}, "unknown selector"},
+		{"unknown leading garbage", []string{"garbage", "from-zone", "trust"}, "unknown selector"},
+		// Value validators still fire through the parser.
+		{"invalid port", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port", "abc"}, "destination-port"},
+		{"invalid protocol", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcpp"}, "invalid protocol"},
+		{"invalid source-ip", []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.0.999"}, "invalid source-ip"},
+		{"invalid icmp-type", []string{"from-zone", "trust", "to-zone", "untrust", "icmp-type", "300"}, "icmp-type"},
+		// Valid queries still work.
+		{"empty args", nil, ""},
+		{"only zones", []string{"from-zone", "trust", "to-zone", "untrust"}, ""},
+		{"full valid", []string{
+			"from-zone", "trust", "to-zone", "untrust",
+			"source-ip", "10.0.1.1", "destination-ip", "10.0.2.1",
+			"source-port", "1024", "destination-port", "443",
+			"protocol", "tcp", "icmp-type", "8", "icmp-code", "0",
+		}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseSelectorArgs(tc.args)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ParseSelectorArgs(%v) err = %v, want nil", tc.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ParseSelectorArgs(%v) err = nil, want %q (silent widen / drop)", tc.args, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ParseSelectorArgs(%v) err = %v, want substring %q", tc.args, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestParseSelectorArgsPopulatesQuery proves a valid selector vector populates
+// every field and converts to a policymatch.Query with the IPs parsed and an
+// omitted IP mapped to a nil net.IP (the match-any wildcard) — the invariant the
+// four surfaces rely on when they route through the shared parser (#3696).
+func TestParseSelectorArgsPopulatesQuery(t *testing.T) {
+	sel, err := ParseSelectorArgs([]string{
+		"from-zone", "trust", "to-zone", "untrust",
+		"source-ip", "10.0.1.1", "destination-ip", "10.0.2.1",
+		"source-port", "1024", "destination-port", "443",
+		"protocol", "tcp", "icmp-type", "8", "icmp-code", "0",
+	})
+	if err != nil {
+		t.Fatalf("ParseSelectorArgs(valid) err = %v", err)
+	}
+	if sel.FromZone != "trust" || sel.ToZone != "untrust" {
+		t.Fatalf("zones = %q/%q, want trust/untrust", sel.FromZone, sel.ToZone)
+	}
+	if sel.SrcIP != "10.0.1.1" || sel.DstIP != "10.0.2.1" {
+		t.Fatalf("ips = %q/%q", sel.SrcIP, sel.DstIP)
+	}
+	if sel.SrcPort != 1024 || sel.DstPort != 443 {
+		t.Fatalf("ports = %d/%d, want 1024/443", sel.SrcPort, sel.DstPort)
+	}
+	if sel.Protocol != "tcp" {
+		t.Fatalf("protocol = %q, want tcp", sel.Protocol)
+	}
+	if sel.ICMPType == nil || *sel.ICMPType != 8 || sel.ICMPCode == nil || *sel.ICMPCode != 0 {
+		t.Fatalf("icmp = %v/%v, want 8/0", sel.ICMPType, sel.ICMPCode)
+	}
+
+	q := sel.Query()
+	if q.SrcIP == nil || q.SrcIP.String() != "10.0.1.1" {
+		t.Fatalf("Query SrcIP = %v, want 10.0.1.1", q.SrcIP)
+	}
+	if q.DstPort != 443 || q.Protocol != "tcp" {
+		t.Fatalf("Query = %+v, want DstPort 443 / tcp", q)
+	}
+
+	// An omitted IP maps to a nil net.IP (wildcard), never a non-nil zero IP.
+	empty, err := ParseSelectorArgs([]string{"from-zone", "trust", "to-zone", "untrust"})
+	if err != nil {
+		t.Fatalf("ParseSelectorArgs(zones only) err = %v", err)
+	}
+	if eq := empty.Query(); eq.SrcIP != nil || eq.DstIP != nil {
+		t.Fatalf("omitted IP should map to nil net.IP, got %v/%v", eq.SrcIP, eq.DstIP)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3696.

The `show security match-policies` / `test policy` query parsers on all
four operator surfaces plus the gRPC `ShowText` `test-policy:` text
bridge failed OPEN on malformed selector grammar: a value-taking
selector present WITHOUT a following value silently degraded to the
wildcard (`if i+1 < len(args)` with no else), and an unknown/misspelled
selector token was silently ignored (no `default:` arm). Because the
shared matcher treats a zero port / empty protocol / nil icmp-type as
"no constraint", either defect silently WIDENED the query — the operator
got a permit/deny verdict for a broader set of traffic than they typed,
from a firewall diagnostic whose entire job is to answer precisely which
traffic a policy matches. The inner value validators
(`ParsePort`/`ParseICMPValue`/`ValidateProtocol`) were never reached when
the outer grammar dropped the token. The session-filter parser hit the
exact same class and was fixed strictly in #3439 (H5); the policy
simulators were not.

## Root cause

Four hand-maintained parser copies. The usage text was already a shared
SSOT (#3628); the PARSING was not.

## Fix

Add a single strict grammar in `pkg/policymatch`:
`ParseSelectorArgs(args []string) (SelectorArgs, error)` (+ a `.Query()`
helper). It

- errors `selector "X" requires a value` when a value-taking selector
  has no following token OR an explicit-empty value (a `takeValue`
  helper mirroring `cmd/cli/show.go` `parseFlowSessionArgs`, #3439 H5) —
  an empty typed value can no longer read as the omitted-wildcard (M01);
- errors `unknown selector "X"` on any token outside the grammar
  (default arm) — `protcol tcp` / `proto tcp` no longer drop silently;
- routes every value through the existing `ParsePort` / `ParseICMPValue`
  / `ValidateProtocol` / `net.ParseIP` validators.

All four CLI surfaces route through it (SSOT — M07); the redundant
per-surface IP/port/proto checks are removed. The gRPC `ShowText`
`test-policy:` bridge is hardened as the server-boundary sibling: a comma
segment lacking `key=value`, an unknown key, or an explicit-empty typed
value (`port=`) is reported as an error instead of silently skipped
(distinguishing key-absent from key-present-empty); a bare `test-policy:`
still falls through to the missing-from/to-zone diagnostic.

Valid queries are unchanged.

## Surfaces fixed

- local `pkg/cli/cli_show_security.go` (`show security match-policies`)
- local `pkg/cli/cli_request.go` (`test policy`)
- remote `cmd/cli/show.go` (`show security match-policies`)
- remote `cmd/cli/main.go` (`test policy`)
- gRPC `pkg/grpcapi/server_show_firewall.go` (`ShowText` `test-policy:`)

## Tests (RED-on-revert, every surface)

- `pkg/policymatch/selector_args_3696_test.go` — the shared primitive.
- `pkg/cli/query_strictness_3696_test.go` — local show + test.
- `cmd/cli/query_strictness_3696_test.go` — remote show + test (asserts
  NO RPC / topic on malformed input).
- `pkg/grpcapi/server_testpolicy_strictness_3696_test.go` — ShowText
  bridge (malformed segment / unknown key / empty typed value + bare
  topic).

Verified RED-on-revert: restoring the pre-#3696 loose parsers fails the
primitive build and flips the local / remote / gRPC want-error cases.

## Docs (M08)

- `pkg/policymatch/README.md` — "Selector grammar strictness (#3696)".
- `docs/junos-cli-reference.md` — "Security: Policy Simulator" section
  with the strict-selector-validation note.
- The #3628 usage tail now documents the strict failure.

## Validation

`go build ./...`, `go vet`, and
`go test ./pkg/policymatch/... ./pkg/cli/... ./cmd/cli/... ./pkg/grpcapi/...`
all green.

Folds codex-review-128 findings H01-H10, M01, M07, M08, M09-M12, L04-L10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
