### PR TITLE
dataplane/ha: unify buildZoneSnapshots wire zone id onto StableZoneID (#3704)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-01 — #3704 review fold: CLI reloadSyslog zone-map was still positional (4th reverse-map)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Hostile review of PR #3707 found a fourth zone-id reverse-map
+    the #3704 unification missed: `pkg/cli/apply.go reloadSyslog` built the
+    syslog zone-id→name map POSITIONALLY (`znMap[uint16(i+1)] = name` over
+    sorted names). This is a LIVE display path — the daemon builds the embedded
+    CLI with its own shared `EventReader` (daemon_run.go), and `reloadSyslog`
+    runs UNCONDITIONALLY on every local-console commit/rollback (cli_config.go,
+    cli.go rollback) AFTER the daemon reconcile already published the name-hash
+    map via `applySyslogConfig`/`buildZoneIDs`. The positional write CLOBBERED
+    the shared reader with wrong ids, regressing local-TTY-console RT_FLOW
+    syslog zone-name rendering to `zone-N` (gRPC/remote/API commits were
+    correct). FIX: extract `syslogZoneNameMap(cfg)` keyed by
+    `config.StableZoneID(name)` — byte-identical to the daemon's map and
+    order-independent, so a shared reader always agrees (contrast: dropping the
+    write would depend on the daemon reconcile always running first). Removed
+    the now-unused `sort` import. Added RED-on-revert test
+    (`TestSyslogZoneNameMapUsesStableZoneID`): a 3-zone config → the reverse map
+    resolves each zone at its StableZoneID slot (goes RED — empty at the
+    name-hash key, populated at positional 1..N — on revert; verified by
+    temporarily restoring the positional keying).
+  - **File(s)**: pkg/cli/apply.go,
+    pkg/cli/apply_syslog_zonemap_3704_test.go (new), _Log.md
+  - **Validation**: `go test ./pkg/cli/... ./pkg/daemon/...` green;
+    `go build ./pkg/... ./cmd/...` OK; gofmt clean on changed files (the
+    cli.go:503 vet unreachable-code warning is pre-existing, not in this diff).
+
 ## 2026-07-01 — #3704 buildZoneSnapshots wire zone id unified onto StableZoneID (completes #3075)
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-01 — #3704 buildZoneSnapshots wire zone id unified onto StableZoneID (completes #3075)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3704 — #3075 moved the compiler/CLI/API/HA-fallback zone-id
+    namespace to the stable name-hash `config.StableZoneID`, but left the LIVE
+    dataplane wire builder `buildZoneSnapshots` (pkg/dataplane/userspace/zones.go)
+    on the legacy sorted-positional `uint16(i + 1)` — a third id call site the
+    #3075 sweep missed. For any >=2-zone config the wire (and thus every
+    session's stored IngressZone/EgressZone, the event-stream delta, and the
+    fabric zone-encoded MAC) diverged from the name-hash namespace everything
+    else uses, causing (a) wrong session zone-name display (positional session
+    id reverse-mapped through the name-hash map -> "zone-N" fallback) and (b)
+    defeated per-RG active/active session-sync ownership
+    (cluster.ShouldSyncZone queried the name-hash zoneRGMap with a positional
+    IngressZone -> always missed -> collapse to the global primary). Fix: assign
+    `config.StableZoneID(name)` in buildZoneSnapshots so the wire id equals
+    CompileResult.ZoneIDs / buildZoneIDs / buildZoneRGMap key by construction —
+    ONE namespace across the compiler, wire/session/HA path, per-RG map, and the
+    display reverse-map. The id is a pure function of the NAME, so a nil zone on
+    one HA peer can no longer shift another zone's id (Codex C131-M01). The Rust
+    side already consumed the wire id name-keyed
+    (zone_name_to_id_from_snapshot / populate_zones), so no dataplane change was
+    needed. Added three RED-on-revert Go tests (wire-id == StableZoneID,
+    session-display reverse-map, per-RG ownership lookup) + a daemon test tying
+    the real buildZoneRGMap + real cluster.ShouldSyncZone to the StableZoneID
+    key space. Validated: go test ./pkg/dataplane/... ./pkg/cluster/...
+    ./pkg/config/... ./pkg/daemon/... green; full `cargo test --release` green
+    (3347 lib + suites, one pre-existing timing-flaky event_stream backlog test
+    passed on rerun); go build ./... clean; RED-on-revert proven by temporarily
+    restoring uint16(i+1) (all three userspace tests failed). HA session-sync
+    change — PARENT must run `make test-failover` before merge.
+  - **File(s)**: pkg/dataplane/userspace/zones.go,
+    pkg/dataplane/userspace/zones_stable_id_3704_test.go (new),
+    pkg/daemon/per_rg_zoneid_3704_test.go (new),
+    userspace-dp/src/test_zone_ids.rs (doc comment),
+    docs/config-schema.md (#3704 note).
+
 ## 2026-07-01 — #3697 stale Rust host-inbound hot-path comments (default-deny drift; M06/L07)
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2070,6 +2070,28 @@ compute identical ids with zero synced/persisted state. The two duplicated
 positional maps (`pkg/dataplane.assignZoneIDs`, `pkg/daemon.buildZoneIDs`) both
 call this SSOT; an HA-symmetry test pins them byte-identical.
 
+**#3704 — live wire builder unified onto the SSOT.** #3075 converted
+`assignZoneIDs` / `buildZoneIDs` (and every CLI/API/HA-fallback consumer) to
+`StableZoneID`, but the LIVE dataplane wire builder
+`buildZoneSnapshots` (`pkg/dataplane/userspace/zones.go`) was a THIRD id call
+site it missed — it kept the legacy sorted-positional `uint16(i+1)`. For any
+`>= 2`-zone config the wire (and thus every session's stored
+`IngressZone`/`EgressZone`, the event-stream delta, and the fabric zone-encoded
+MAC) diverged from the name-hash namespace everything else uses. Two live
+regressions followed: session zone-name **display** reverse-mapped a positional
+session id through the name-hash map and missed (wrong `zone-N` labels), and
+`cluster.ShouldSyncZone(session.IngressZone)` queried the name-hash `zoneRGMap`
+(`pkg/daemon.buildZoneRGMap` key space) with a positional id and always missed —
+**per-RG active/active session-sync ownership collapsed to the global primary**.
+#3704 makes `buildZoneSnapshots` assign `config.StableZoneID(name)` too, so the
+wire id equals `CompileResult.ZoneIDs[name]` / `buildZoneIDs[name]` /
+`buildZoneRGMap` key by construction — one namespace across the compiler, the
+wire/session/HA path, the per-RG map, and the display reverse-map. The Rust side
+already consumed the wire id name-keyed (`zone_name_to_id_from_snapshot`,
+`populate_zones`), so no dataplane change was needed. Because the id is a pure
+function of the NAME, a nil zone entry on one HA peer can no longer shift another
+zone's id (Codex C131-M01).
+
 This replaces the legacy sorted `1..N` positional assignment, whose ids shifted
 whenever an earlier-sorting zone was added/removed and mis-mapped in-flight
 session / HA-delta / status metadata carrying an old numeric id (#3075).

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -7,7 +7,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dhcp"
@@ -16,24 +15,34 @@ import (
 	"github.com/psaab/xpf/pkg/logging"
 )
 
+// syslogZoneNameMap builds the zone-id -> name reverse map for structured
+// (RT_FLOW) syslog rendering. The zone-id namespace is the STABLE name-hash
+// config.StableZoneID(name) (#3075) — the SAME namespace the compiler installs
+// into the dataplane and the daemon publishes via applySyslogConfig /
+// buildZoneIDs (daemon_ha_userspace.go). This is load-bearing because the event
+// reader is SHARED with the daemon (daemon_run.go builds the embedded CLI with
+// d.eventReader) and reloadSyslog runs on every LOCAL-CONSOLE commit/rollback
+// AFTER the daemon reconcile already set the name-hash map: the previous
+// sorted-positional (i+1) assignment CLOBBERED the shared map with wrong ids,
+// regressing local-TTY commits to `zone-N` RT_FLOW rendering while
+// gRPC/remote/API commits stayed correct (#3704 follow-up). StableZoneID is a
+// pure function of the name, so this write is byte-identical to the daemon's
+// regardless of reconcile ordering.
+func syslogZoneNameMap(cfg *config.Config) map[uint16]string {
+	znMap := make(map[uint16]string, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		znMap[config.StableZoneID(name)] = name
+	}
+	return znMap
+}
+
 // reloadSyslog rebuilds the syslog client set and zone-name mapping from
 // the supplied config. Safe to call with a nil event reader.
 func (c *CLI) reloadSyslog(cfg *config.Config) {
 	if c.eventReader == nil {
 		return
 	}
-	// Update zone name mapping for structured log format
-	// Uses sorted zone names → sequential IDs (matches compiler order)
-	names := make([]string, 0, len(cfg.Security.Zones))
-	for name := range cfg.Security.Zones {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	znMap := make(map[uint16]string, len(names))
-	for i, name := range names {
-		znMap[uint16(i+1)] = name
-	}
-	c.eventReader.SetZoneNames(znMap)
+	c.eventReader.SetZoneNames(syslogZoneNameMap(cfg))
 
 	var clients []*logging.SyslogClient
 	for name, stream := range cfg.Security.Log.Streams {

--- a/pkg/cli/apply_syslog_zonemap_3704_test.go
+++ b/pkg/cli/apply_syslog_zonemap_3704_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestSyslogZoneNameMapUsesStableZoneID is the RED-on-revert guard for the #3704
+// follow-up: reloadSyslog (local-console commit/rollback path) builds the syslog
+// zone-id -> name reverse map keyed by the STABLE name-hash
+// config.StableZoneID(name), NOT by a sorted-positional (i+1) index.
+//
+// The event reader is SHARED with the daemon, whose applySyslogConfig /
+// buildZoneIDs publishes the name-hash map; reloadSyslog runs AFTER that on
+// every local-TTY commit. A positional map would clobber the shared reader with
+// wrong ids and regress RT_FLOW zone rendering to `zone-N`. Reverting
+// syslogZoneNameMap to `znMap[uint16(i+1)] = name` turns this RED: the
+// StableZoneID key would resolve to the wrong name (or be absent) and the
+// positional keys 1..N would be populated instead.
+func TestSyslogZoneNameMapUsesStableZoneID(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust":   {Name: "trust"},
+		"untrust": {Name: "untrust"},
+		"dmz":     {Name: "dmz"},
+	}
+
+	got := syslogZoneNameMap(cfg)
+
+	if len(got) != len(cfg.Security.Zones) {
+		t.Fatalf("map has %d entries, want %d (a StableZoneID collision or a dropped zone): %v",
+			len(got), len(cfg.Security.Zones), got)
+	}
+
+	// Exact-key assertion: each zone must resolve at its StableZoneID slot. Under
+	// the reverted positional (i+1) keying, StableZoneID(name) — a name-hash in
+	// [1, 65533] — almost never equals a small positional index, so got[id] would
+	// be "" and this fails, proving RED-on-revert.
+	for name := range cfg.Security.Zones {
+		id := config.StableZoneID(name)
+		if got[id] != name {
+			t.Fatalf("zone %q: map[StableZoneID=%d]=%q, want %q — the reverse map is NOT keyed by StableZoneID (positional-index regression, #3704)",
+				name, id, got[id], name)
+		}
+	}
+}

--- a/pkg/daemon/per_rg_zoneid_3704_test.go
+++ b/pkg/daemon/per_rg_zoneid_3704_test.go
@@ -1,0 +1,79 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestZoneRGMapKeyedByStableZoneID verifies the daemon/cluster side of the
+// #3704 contract: buildZoneRGMap keys on config.StableZoneID(name) (via
+// buildZoneIDs), the SAME namespace pkg/dataplane/userspace.buildZoneSnapshots
+// now stamps onto the live wire (and thus onto a session's IngressZone). A
+// session whose IngressZone carries that stable id therefore RESOLVES in the
+// zoneRGMap, so cluster.ShouldSyncZone consults per-RG ownership
+// (IsPrimaryForRGFn) instead of collapsing to the global primary.
+//
+// Before #3704 the wire/session id was sorted-positional while this map was
+// name-hash, so the lookup missed for every >=2-zone config and per-RG
+// active/active session-sync ownership silently degraded to the global primary
+// decision. This test locks the key space to StableZoneID and exercises the
+// real ShouldSyncZone against it.
+func TestZoneRGMapKeyedByStableZoneID(t *testing.T) {
+	cfg := &config.Config{
+		Security: config.SecurityConfig{
+			Zones: map[string]*config.ZoneConfig{
+				"trust":   {Name: "trust", Interfaces: []string{"reth0.0"}},
+				"untrust": {Name: "untrust", Interfaces: []string{"reth1.0"}},
+				"dmz":     {Name: "dmz", Interfaces: []string{"ge-0/0/2"}}, // no RG
+			},
+		},
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"reth0":    {Name: "reth0", RedundancyGroup: 1},
+				"reth1":    {Name: "reth1", RedundancyGroup: 2},
+				"ge-0/0/2": {Name: "ge-0/0/2"},
+			},
+		},
+	}
+
+	zoneIDs := buildZoneIDs(cfg)
+	rgMap := buildZoneRGMap(cfg, zoneIDs)
+
+	// The RETH zones must key on their STABLE name-hash id, not a positional id.
+	for _, tc := range []struct {
+		zone string
+		rg   int
+	}{
+		{"trust", 1},
+		{"untrust", 2},
+	} {
+		stable := config.StableZoneID(tc.zone)
+		if zoneIDs[tc.zone] != stable {
+			t.Errorf("buildZoneIDs[%q] = %d, want StableZoneID %d",
+				tc.zone, zoneIDs[tc.zone], stable)
+		}
+		if rg, ok := rgMap[stable]; !ok || rg != tc.rg {
+			t.Errorf("zoneRGMap[StableZoneID(%q)=%d] = (%d, %v), want (%d, true)",
+				tc.zone, stable, rg, ok, tc.rg)
+		}
+	}
+
+	// End-to-end: the real cluster.ShouldSyncZone, given a session IngressZone
+	// equal to the stable wire id, must consult per-RG ownership.
+	ss := cluster.NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.IsPrimaryFn = func() bool { return false }                  // NOT global primary
+	ss.IsPrimaryForRGFn = func(rgID int) bool { return rgID == 1 } // primary for RG 1 only
+	ss.SetZoneRGMap(rgMap)
+
+	// trust -> RG 1 (primary): syncs via per-RG ownership despite IsPrimaryFn=false.
+	if !ss.ShouldSyncZone(config.StableZoneID("trust")) {
+		t.Error("ShouldSyncZone(StableZoneID(trust)) = false; per-RG ownership " +
+			"for RG 1 was not consulted (namespace split would cause this)")
+	}
+	// untrust -> RG 2 (not primary): must NOT sync.
+	if ss.ShouldSyncZone(config.StableZoneID("untrust")) {
+		t.Error("ShouldSyncZone(StableZoneID(untrust)) = true; RG 2 is not primary")
+	}
+}

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -501,12 +501,36 @@ func buildZoneSnapshots(cfg *config.Config) []ZoneSnapshot {
 	for name := range cfg.Security.Zones {
 		names = append(names, name)
 	}
+	// Sorted only for a deterministic wire ORDER (stable snapshot/fixture
+	// output). The zone ID is NOT positional — see below.
 	sort.Strings(names)
 	out := make([]ZoneSnapshot, 0, len(names))
-	for i, name := range names {
+	for _, name := range names {
 		zs := ZoneSnapshot{
 			Name: name,
-			ID:   uint16(i + 1),
+			// #3704: the wire zone ID is the STABLE name-hash
+			// config.StableZoneID(name) — the SAME namespace the compiler
+			// (pkg/dataplane.assignZoneIDs -> CompileResult.ZoneIDs), the HA
+			// name fallback (pkg/daemon.buildZoneIDs), the zone→RG map
+			// (buildZoneRGMap key space), and every CLI/API session
+			// zone-name display use. Before #3704 this builder assigned a
+			// SORTED-POSITIONAL uint16(i+1), which #3075 (StableZoneID) left
+			// behind, splitting the live dataplane/session/HA wire ID
+			// namespace from the name-hash namespace everything else moved
+			// to. For any >=2-zone config the two disagreed, so: session
+			// zone-name display reverse-mapped a positional id through the
+			// name-hash map and missed (wrong "zone-N" labels), and
+			// SessionSync.ShouldSyncZone(session.IngressZone) queried the
+			// name-hash zoneRGMap with a positional id and always missed,
+			// collapsing per-RG active/active session-sync ownership to the
+			// global primary. Assigning StableZoneID here makes the wire ID
+			// equal CompileResult.ZoneIDs[name] by construction, so all four
+			// consumers share ONE namespace. The id is a pure function of the
+			// zone NAME (never the zone set, sort order, or a nil sibling), so
+			// a nil zone entry on one HA peer can no longer shift another
+			// zone's id (Codex C131-M01), and both peers plus a cold-booting
+			// node agree with zero synced/persisted state.
+			ID: config.StableZoneID(name),
 		}
 		// #3070: carry the zone's host-inbound-traffic admission set onto the
 		// wire so the dataplane can enforce it for host-bound (local-delivery)

--- a/pkg/dataplane/userspace/zones_stable_id_3704_test.go
+++ b/pkg/dataplane/userspace/zones_stable_id_3704_test.go
@@ -1,0 +1,154 @@
+// #3704: buildZoneSnapshots must stamp the STABLE name-hash zone id
+// (config.StableZoneID) onto the live dataplane wire — the SAME namespace the
+// compiler (pkg/dataplane.assignZoneIDs -> CompileResult.ZoneIDs), the HA name
+// fallback (pkg/daemon.buildZoneIDs), the zone->RG map (pkg/daemon.buildZoneRGMap
+// key space consumed by cluster.ShouldSyncZone), and every CLI/API session
+// zone-name display use.
+//
+// #3075 moved the compiler/CLI/API/HA namespace to StableZoneID but LEFT this
+// wire builder on the legacy SORTED-POSITIONAL uint16(i+1). For any >=2-zone
+// config the two namespaces split, which:
+//   - mis-mapped session zone-name display (positional session id reverse-mapped
+//     through the name-hash map -> "zone-N" fallback / wrong name), and
+//   - defeated per-RG active/active session-sync ownership (ShouldSyncZone looked
+//     up the name-hash zoneRGMap with a positional session IngressZone -> miss ->
+//     collapse to the global primary).
+//
+// These tests all go RED if buildZoneSnapshots is reverted to uint16(i+1): the
+// fixture names' StableZoneIDs are far from their sorted-positional indices.
+package userspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// threeZoneCfg is a >=2-zone fixture whose StableZoneIDs are all distinct and
+// none equal to their sorted-positional index (verified below), so a positional
+// revert flips every assertion in this file.
+func threeZoneCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		// sorted order: dmz(1), trust(2), untrust(3), wan(4)
+		"dmz":     {Name: "dmz"},
+		"trust":   {Name: "trust", Interfaces: []string{"reth0.0"}},
+		"untrust": {Name: "untrust", Interfaces: []string{"reth1.0"}},
+		"wan":     {Name: "wan"},
+	}
+	return cfg
+}
+
+// TestBuildZoneSnapshotsStableZoneID asserts the wire zone id equals
+// config.StableZoneID(name) for every zone (the #3704 fix), and that this is
+// NOT the legacy sorted-positional id (RED-on-revert guard).
+func TestBuildZoneSnapshotsStableZoneID(t *testing.T) {
+	cfg := threeZoneCfg()
+	snaps := buildZoneSnapshots(cfg)
+	if len(snaps) != len(cfg.Security.Zones) {
+		t.Fatalf("got %d zone snapshots, want %d", len(snaps), len(cfg.Security.Zones))
+	}
+
+	seen := make(map[uint16]string, len(snaps))
+	positionalDivergences := 0
+	for i, z := range snaps {
+		want := config.StableZoneID(z.Name)
+		if z.ID != want {
+			t.Errorf("zone %q: wire id = %d, want StableZoneID = %d "+
+				"(#3704: wire builder must use the name-hash namespace)",
+				z.Name, z.ID, want)
+		}
+		// The wire ids must be collision-free within a config for the
+		// reverse-map (display) and the zoneRGMap key space to be 1:1.
+		if prev, dup := seen[z.ID]; dup {
+			t.Errorf("zone id collision: %q and %q both = %d", prev, z.Name, z.ID)
+		}
+		seen[z.ID] = z.Name
+		// snaps is emitted in sorted-name order, so i+1 is exactly the legacy
+		// positional id this fix replaced. Confirm the fixture actually diverges
+		// so a positional revert is guaranteed to fail the assertion above.
+		if want != uint16(i+1) {
+			positionalDivergences++
+		}
+	}
+	if positionalDivergences == 0 {
+		t.Fatal("fixture no longer diverges from positional ids; the " +
+			"RED-on-revert guard is toothless — pick different zone names")
+	}
+}
+
+// TestBuildZoneSnapshotsSessionDisplayReverseMap models api/sessions.go's
+// zone-id -> name reverse map, which is built from the name-hash namespace
+// (CompileResult.ZoneIDs / config.StableZoneID). It then reverse-maps each
+// zone's WIRE id (what a session's stored IngressZone/EgressZone carries) and
+// asserts the name resolves — no "zone-N" fallback and no wrong-name collision.
+// On a positional-wire revert this lookup misses for every zone whose positional
+// index != StableZoneID (RED-on-revert).
+func TestBuildZoneSnapshotsSessionDisplayReverseMap(t *testing.T) {
+	cfg := threeZoneCfg()
+
+	// Namespace A: the display reverse map (api/sessions.go:600 builds
+	// zoneNames[id]=name from cr.ZoneIDs, i.e. config.StableZoneID).
+	zoneNames := make(map[uint16]string, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames[config.StableZoneID(name)] = name
+	}
+
+	// Namespace B: the wire ids a session actually carries.
+	for _, z := range buildZoneSnapshots(cfg) {
+		got, ok := zoneNames[z.ID]
+		if !ok {
+			t.Errorf("session-display miss for zone %q (wire id %d): would render "+
+				"the %q fallback instead of the name (#3704 namespace split)",
+				z.Name, z.ID, fmt.Sprintf("zone-%d", z.ID))
+			continue
+		}
+		if got != z.Name {
+			t.Errorf("session-display mis-attribution: wire id %d reverse-maps to "+
+				"%q, want %q", z.ID, got, z.Name)
+		}
+	}
+}
+
+// TestBuildZoneSnapshotsPerRGOwnershipLookup models the cluster.ShouldSyncZone
+// per-RG ownership lookup: `rgID, ok := s.zoneRGMap[session.IngressZone]`. The
+// zoneRGMap is keyed by the name-hash namespace (pkg/daemon.buildZoneRGMap keys
+// on buildZoneIDs = config.StableZoneID); the session's IngressZone is the WIRE
+// id from buildZoneSnapshots. For the RETH zones this lookup MUST hit so per-RG
+// ownership (IsPrimaryForRGFn) is consulted instead of collapsing to the global
+// primary. On a positional-wire revert the wire id is not a key in the
+// name-hash map -> ok=false -> per-RG ownership defeated (RED-on-revert).
+func TestBuildZoneSnapshotsPerRGOwnershipLookup(t *testing.T) {
+	cfg := threeZoneCfg()
+
+	// The zoneRGMap key space, exactly as pkg/daemon.buildZoneRGMap produces it:
+	// keyed by config.StableZoneID(name) for zones on a RETH interface.
+	zoneRGMap := map[uint16]int{
+		config.StableZoneID("trust"):   1, // trust -> reth0 -> RG 1
+		config.StableZoneID("untrust"): 2, // untrust -> reth1 -> RG 2
+	}
+
+	wireID := make(map[string]uint16)
+	for _, z := range buildZoneSnapshots(cfg) {
+		wireID[z.Name] = z.ID
+	}
+
+	for zone, wantRG := range map[string]int{"trust": 1, "untrust": 2} {
+		id, ok := wireID[zone]
+		if !ok {
+			t.Fatalf("zone %q missing from wire snapshot", zone)
+		}
+		rg, hit := zoneRGMap[id]
+		if !hit {
+			t.Errorf("per-RG ownership lookup MISSED for zone %q (session "+
+				"IngressZone=%d): wire-id namespace != zoneRGMap namespace, so "+
+				"ShouldSyncZone falls back to the global primary and per-RG "+
+				"active/active ownership collapses (#3704)", zone, id)
+			continue
+		}
+		if rg != wantRG {
+			t.Errorf("zone %q: per-RG lookup got RG %d, want %d", zone, rg, wantRG)
+		}
+	}
+}

--- a/userspace-dp/src/test_zone_ids.rs
+++ b/userspace-dp/src/test_zone_ids.rs
@@ -1,11 +1,15 @@
 //! #919: canonical zone-ID constants for test fixtures.
 //!
-//! Production zone IDs are assigned by the Go config compiler
-//! (`pkg/dataplane/userspace/snapshot.go:183-187`) starting at 1.
-//! These constants give test code stable, named IDs to use in
-//! `SessionMetadata` constructors and `zone_name_to_id` /
-//! `zone_id_to_name` test maps. They mirror the conventional zone
-//! names used across most test fixtures.
+//! Production zone IDs are assigned by the Go control plane as a STABLE
+//! name-hash (`config.StableZoneID`, FNV-1a fold into [1, 65533]) — the
+//! compiler (`pkg/dataplane.assignZoneIDs`), the live wire builder
+//! (`pkg/dataplane/userspace/zones.go:buildZoneSnapshots`, #3704), and the
+//! HA name fallback (`pkg/daemon.buildZoneIDs`) all agree by construction.
+//! These constants are ARBITRARY small ids for test code only; the dataplane
+//! reads whatever id the snapshot carries (name -> id via `zone_name_to_id`),
+//! so tests may use any distinct values. They give test code stable, named IDs
+//! for `SessionMetadata` constructors and `zone_name_to_id` / `zone_id_to_name`
+//! test maps, mirroring the conventional zone names used across most fixtures.
 //!
 //! Tests that construct a custom `ForwardingState` should populate
 //! `zone_name_to_id` and `zone_id_to_name` consistently with these


### PR DESCRIPTION
Closes #3704.

## Problem

#3075 adopted a stable name-hash zone id (`config.StableZoneID`, an FNV-1a
fold of the zone NAME into `[1, 65533]`) and converted the compiler
(`pkg/dataplane.assignZoneIDs` → `CompileResult.ZoneIDs`), the HA name
fallback (`pkg/daemon.buildZoneIDs`), the per-RG map key space
(`pkg/daemon.buildZoneRGMap`), and every CLI/API session zone-name display to
it — but left the LIVE dataplane wire builder `buildZoneSnapshots`
(`pkg/dataplane/userspace/zones.go`) on the legacy sorted-positional
`uint16(i + 1)`. That was a **third id call site** the #3075 sweep missed.

For any `>= 2`-zone config the positional index and the name hash produce
different numbers for the same zone, so the wire id (what the Rust dataplane
stamps into a session's `ingress_zone`/`egress_zone`, what rides the
event-stream delta, and what the fabric zone-encoded MAC carries) split from
the name-hash namespace everything else uses. Two live consequences:

1. **Session zone-name display was wrong.** `api/sessions.go` builds the
   id→name reverse map from `CompileResult.ZoneIDs` (name-hash), then
   reverse-maps a session's stored *positional* zone id through it → miss →
   `zone-N` fallback (or a wrong name on a hash collision).
2. **Per-RG active/active session-sync ownership was defeated.**
   `cluster.ShouldSyncZone(session.IngressZone)` looks up the name-hash
   `zoneRGMap` with the session's *positional* `IngressZone` → `ok=false` →
   falls back to the global `IsPrimaryFn`. `IsPrimaryForRGFn` was never
   consulted, so RETH/per-RG zone ownership collapsed to the global primary —
   an HA session-sync regression.

## Fix

`buildZoneSnapshots` now assigns `config.StableZoneID(name)`, so the wire id
equals `CompileResult.ZoneIDs[name]` / `buildZoneIDs[name]` / the
`buildZoneRGMap` key **by construction** — one namespace across the compiler,
the wire/session/HA path, the per-RG map, and the display reverse-map. The
emit set is unchanged (every configured zone name, nil-valued included,
exactly as `ZoneIDs`/`buildZoneIDs` enumerate). Because the id is a pure
function of the NAME, a nil zone on one HA peer can no longer shift another
zone's id (**Codex C131-M01**).

The Rust side already consumed the wire id name-keyed
(`zone_name_to_id_from_snapshot` / `populate_zones` read `zone.id` straight
off the snapshot), so **no dataplane change was needed**; a stale
`test_zone_ids.rs` doc comment ("starting at 1") is corrected to describe the
stable name-hash reality.

## Tests (RED-on-revert)

- `pkg/dataplane/userspace/zones_stable_id_3704_test.go`
  - wire id `== config.StableZoneID(name)` for every zone (+ collision-free, +
    fixture-diverges-from-positional guard)
  - session-display reverse-map resolves each zone's WIRE id to its name (no
    `zone-N` fallback)
  - per-RG ownership lookup: RETH zones' wire ids hit the name-hash-keyed
    `zoneRGMap`
- `pkg/daemon/per_rg_zoneid_3704_test.go` — exercises the **real**
  `buildZoneRGMap` + **real** `cluster.ShouldSyncZone`, proving the key space
  is `StableZoneID` and a session whose `IngressZone` carries that id resolves
  to per-RG ownership.

Verified RED-on-revert by temporarily restoring `uint16(i + 1)` — all three
userspace tests fail; the fix makes them green.

## Validation

- `go test ./pkg/dataplane/... ./pkg/cluster/... ./pkg/config/... ./pkg/daemon/...` — green
- `go build ./...` — clean
- full `cargo test --release` — green (3347 lib + suites; one pre-existing
  timing-flaky `event_stream` backlog test passed on rerun)

## ⚠️ Merge gate

This is an **HA session-sync** change. `make test-failover` MUST pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi