### PR TITLE
config: fix bracket/single-line list collapse on 4 security surfaces (#3703)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-01 — #3703 bracket/single-line list collapse on four security surfaces (#2419 class, unfixed leaves)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3703 — the #2419 bracketed/single-line list-collapse bug
+    recurred on four security config surfaces #2419 never converted: host-inbound
+    `system-services`/`protocols` (zone + #3362 per-iface), per-policy
+    `then log`, `default-policy-log`, and `pre-id-default-policy then log`. Each
+    was modeled as a CONTAINER (or nil-children non-multi leaf), so a bracket /
+    single-line list mis-nested the tail under the first token and the compiler
+    readers dropped everything after it — a dropped host-inbound service silently
+    NARROWS admission (can strand SSH/routing); a dropped `session-close` loses
+    audit records; a typo'd token silently no-ops instead of failing fast. FIX:
+    (schema) `hostInboundSchemaChildren` makes system-services/protocols
+    `args:1, multi:true, children:nil` (untyped; validated against the
+    host_inbound_tokens.go SSOT); `sessionLogModeLeaf` makes the three log
+    surfaces `multi:true, children:nil` typed ENUM leaves
+    (ValueEnumOf + ValidateEnum[session-init,session-close]). (compiler) all
+    readers accumulate every value via `firewallMatchValues` (Keys[1:] AND
+    .Children) across ALL sibling log leaves and create the target struct once
+    (never reset) so bracket, repeated-line, and hierarchical shapes all land
+    every value. (strict validation) host-inbound typos now reach the compiled
+    slice → rejected by the existing `validateHostInboundTokensStrict`; log typos
+    rejected at commit by `SchemaValidate`'s `validateMultiValueLeaf` enum check
+    (strict on commit, warn on tolerant load — #1960 no-brick). Value-slot `?`
+    completion preserved via valueExamples. Verified the bug on all six surfaces
+    (both harm directions) before/after; RED-on-revert tests added.
+  - **File(s)**: pkg/config/schema_security.go, pkg/config/compiler_security.go,
+    pkg/config/compiler_security_bracket_list_3703_test.go (new),
+    docs/config-schema.md, _Log.md
+  - **Validation**: `go test ./pkg/config/... ./pkg/configstore/...` green;
+    consumers `go test ./pkg/daemon/... ./pkg/dataplane/... ./pkg/api/...
+    ./pkg/cli/... ./pkg/cmdtree/...` green; `go build ./pkg/... ./cmd/...` OK;
+    gofmt + vet clean on changed files.
+
 ## 2026-07-01 — #3697 stale Rust host-inbound hot-path comments (default-deny drift; M06/L07)
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -130,6 +130,47 @@ resolved application (an application-set still expands to its members). Coverage
 `compiler_nat_match_multivalue_3431_test.go` (both AST shapes, all axes) and
 `nat_match_multivalue_3431_test.go` (snapshot expansion).
 
+**Security host-inbound and session-log surfaces are multi-value (#3703).** The
+same #2419 collapse class recurred on four security leaves that #2419 never
+converted, all modeled as CONTAINERS (or nil-children non-multi leaves) instead
+of `multi: true` value-tail leaves — so a bracket / single-line list mis-nested
+the tail under the first token and the compiler readers dropped everything after
+it, silently and with the dropped tokens (including typos) bypassing strict
+validation:
+
+- **host-inbound `system-services` / `protocols`** (zone level AND the #3362
+  per-interface override) — `hostInboundSchemaChildren` (`schema_security.go`)
+  makes both `args: 1, multi: true, children: nil` (untyped: the token allowlist
+  is the shared `host_inbound_tokens.go` SSOT). `parseHostInboundNode`
+  (`compiler_security.go`) reads every value via `firewallMatchValues`, so the
+  compiled `HostInboundTraffic.SystemServices/Protocols` slices carry the whole
+  list and `validateHostInboundTokensStrict` (already on the compiled slice)
+  rejects an unknown token at commit. A dropped host-inbound service silently
+  NARROWS admission (`system-services [ ssh netconf ]` → only `ssh`), which can
+  strand SSH / routing.
+- **per-policy `then log`, `default-policy-log`, and `pre-id-default-policy then
+  log`** — the shared `sessionLogModeLeaf` factory (`schema_security.go`) makes
+  each a `multi: true, children: nil` typed ENUM leaf
+  (`valueType: ValueEnumOf`, `validator: ValidateEnum([session-init,
+  session-close])`). Because it is a typed multi leaf, `SchemaValidate`
+  dispatches to `validateMultiValueLeaf`, which validates EVERY token (Keys[1:]
+  plus block-list children) — so an unknown log mode is REJECTED at commit
+  (strict) / warned on the tolerant load path (#1960 no-brick), closing the gap
+  that `validatePolicyLogActionStrict` (both-false only) and the
+  default-policy-log / pre-id WARN-only validators left open. The compiler
+  readers (`compilePolicy` `then log` arm, the `default-policy-log` arm, and the
+  `pre-id-default-policy` reader in `compiler_security.go`) accumulate every mode
+  via `firewallMatchValues` across ALL sibling `log` leaves and only CREATE the
+  target struct once (never reset), so both the bracket form
+  (`then log [ session-init session-close ]`) and the repeated-line form
+  (`then log session-init` + `then log session-close`, two sibling leaves) land
+  both flags. Dropping the container children does not lose `?` completion — the
+  two modes surface via `valueExamples`. A dropped `session-close` loses
+  session-duration / close audit records despite valid syntax. Coverage:
+  `compiler_security_bracket_list_3703_test.go` (all four surfaces, both harm
+  directions — tail-drop and typo-bypass — across bracket / repeated-line /
+  hierarchical shapes, plus the value-slot completion pin).
+
 ## Trailing-token arity on scalar value leaves (#3332)
 
 The mirror image of the multi-value contract is the **scalar** value leaf: a

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -218,12 +218,22 @@ func compileSecurity(node *Node, sec *SecurityConfig) error {
 		case "pre-id-default-policy":
 			sec.PreIDDefaultPolicy = &PreIDDefaultPolicy{}
 			if thenNode := child.FindChild("then"); thenNode != nil {
-				if logNode := thenNode.FindChild("log"); logNode != nil {
-					if logNode.FindChild("session-init") != nil {
-						sec.PreIDDefaultPolicy.LogSessionInit = true
-					}
-					if logNode.FindChild("session-close") != nil {
-						sec.PreIDDefaultPolicy.LogSessionClose = true
+				// #3703: multi-value session-log list leaf. Read every mode via
+				// the firewallMatchValues SSOT (Keys[1:] AND/OR one-per-child)
+				// across EVERY `log` leaf so a bracket `then log [ session-init
+				// session-close ]` keeps BOTH flags AND separate `then log
+				// session-init` / `then log session-close` lines (two sibling
+				// leaves) both land. The prior single FindChild lookup read only
+				// the first leaf and missed the tail (the #2419 collapse bug).
+				// Unknown tokens are rejected at commit by SchemaValidate.
+				for _, logNode := range thenNode.FindChildren("log") {
+					for _, mode := range firewallMatchValues(logNode) {
+						switch mode {
+						case "session-init":
+							sec.PreIDDefaultPolicy.LogSessionInit = true
+						case "session-close":
+							sec.PreIDDefaultPolicy.LogSessionClose = true
+						}
 					}
 				}
 			}
@@ -442,13 +452,16 @@ func parseHostInboundNode(n *Node) *HostInboundTraffic {
 	for _, hit := range n.Children {
 		switch hit.Name() {
 		case "system-services":
-			for _, svc := range hit.Children {
-				hib.SystemServices = append(hib.SystemServices, svc.Name())
-			}
+			// #3703: system-services is a multi-value value-tail leaf. A
+			// bracket / single-line / repeated list carries values as the
+			// leaf's Keys[1:] AND/OR one-per-child; read BOTH via the
+			// firewallMatchValues SSOT so every token reaches the compiled
+			// slice (reading only child.Name()/Keys[0] dropped all but the
+			// first list value — the #2419 collapse bug). The compiled slice
+			// is then token-validated by validateHostInboundTokensStrict.
+			hib.SystemServices = append(hib.SystemServices, firewallMatchValues(hit)...)
 		case "protocols":
-			for _, proto := range hit.Children {
-				hib.Protocols = append(hib.Protocols, proto.Name())
-			}
+			hib.Protocols = append(hib.Protocols, firewallMatchValues(hit)...)
 		}
 	}
 	return hib
@@ -535,11 +548,20 @@ func compilePolicies(node *Node, sec *SecurityConfig) error {
 		// lives in a sibling container because the `default-policy` enum leaf
 		// cannot carry `then` children (schema.go typed-leaf invariant).
 		if child.Name() == "default-policy-log" {
-			if child.FindChild("session-init") != nil {
-				sec.DefaultPolicyLogSessionInit = true
-			}
-			if child.FindChild("session-close") != nil {
-				sec.DefaultPolicyLogSessionClose = true
+			// #3703: multi-value session-log list leaf. Read every mode via the
+			// firewallMatchValues SSOT (Keys[1:] AND/OR one-per-child) so a
+			// bracket / single-line `default-policy-log [ session-init
+			// session-close ]` keeps BOTH flags; the prior FindChild lookups
+			// missed session-close when the bracket tail mis-nested it under
+			// session-init (the #2419 collapse bug). Unknown tokens are rejected
+			// at commit by SchemaValidate (the enum leaf validator).
+			for _, mode := range firewallMatchValues(child) {
+				switch mode {
+				case "session-init":
+					sec.DefaultPolicyLogSessionInit = true
+				case "session-close":
+					sec.DefaultPolicyLogSessionClose = true
+				}
 			}
 			continue
 		}
@@ -708,9 +730,24 @@ func compilePolicy(polInst struct {
 				pol.Action = PolicyReject
 				pol.terminalActions = append(pol.terminalActions, PolicyReject)
 			case "log":
-				pol.Log = &PolicyLog{}
-				for _, logOpt := range t.Children {
-					switch logOpt.Name() {
+				// #3703: `then log` is a multi-value session-log list leaf. A
+				// bracket / single-line list (`then log [ session-init
+				// session-close ]`) carries the modes as Keys[1:] AND/OR
+				// one-per-child; read BOTH via the firewallMatchValues SSOT so
+				// session-close is not dropped when it trails session-init in a
+				// bracket list (the #2419 collapse bug). Unknown tokens are
+				// rejected at commit by SchemaValidate (the enum leaf validator);
+				// a bare `then log` (no mode) is rejected by
+				// validatePolicyLogActionStrict (#3060). ACCUMULATE (create once,
+				// never reset): a multi-value leaf whose values arrive on SEPARATE
+				// flat-set lines (`then log session-init` + `then log
+				// session-close`) produces TWO sibling `log` leaves, so resetting
+				// pol.Log per node would drop the earlier flag.
+				if pol.Log == nil {
+					pol.Log = &PolicyLog{}
+				}
+				for _, mode := range firewallMatchValues(t) {
+					switch mode {
 					case "session-init":
 						pol.Log.SessionInit = true
 					case "session-close":

--- a/pkg/config/compiler_security_bracket_list_3703_test.go
+++ b/pkg/config/compiler_security_bracket_list_3703_test.go
@@ -1,0 +1,435 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #3703: the #2419 bracketed/single-line list-collapse bug recurred on
+// four security config surfaces that #2419 never converted — host-inbound
+// system-services/protocols, per-policy `then log`, `default-policy-log`, and
+// `pre-id-default-policy then log`. Each was modeled as a container (or
+// nil-children leaf) rather than a `multi:true` value-tail leaf, so a bracket /
+// single-line list dropped every value after the first (mis-nested the tail) and
+// the dropped tail — including typos — bypassed strict validation. The fix tags
+// each as a multi-value leaf, reads every value via the firewallMatchValues
+// SSOT, and rejects unknown tokens at commit (host-inbound via
+// validateHostInboundTokensStrict on the compiled slice; the log surfaces via
+// SchemaValidate's enum-leaf validator).
+//
+// Every RED-on-revert case below fails if the schema leaf is reverted to a
+// container / nil-children-non-multi leaf (the tail collapses / is silently
+// dropped again) or the compiler reader is reverted to Keys[0]/first-child only.
+//
+// IMPORTANT (per CLAUDE.md): flat-set syntax is built with ParseSetCommand +
+// tree.SetPath, never NewParser.
+
+func setTree3703(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+func equalStrs3703(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// host-inbound system-services / protocols
+// ---------------------------------------------------------------------------
+
+// TestHostInbound3703KeepsAllListValues is the primary host-inbound RED-on-revert
+// guard: a bracket list, a single-line list, repeated lines, and the
+// hierarchical block shape must ALL land every value. Reverting the schema
+// (children:nil non-multi container) or the reader (Keys[0]-only) drops
+// everything after the first token and this goes RED (a dropped host-inbound
+// service silently NARROWS admission — can strand SSH/routing).
+func TestHostInbound3703KeepsAllListValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		lines []string
+		svcs  []string
+		proto []string
+	}{
+		{
+			name: "bracket list",
+			lines: []string{
+				"set security zones security-zone trust interfaces ge-0/0/0",
+				"set security zones security-zone trust host-inbound-traffic system-services [ ssh http ]",
+				"set security zones security-zone trust host-inbound-traffic protocols [ ospf bgp ]",
+			},
+			svcs:  []string{"ssh", "http"},
+			proto: []string{"ospf", "bgp"},
+		},
+		{
+			name: "repeated flat-set lines",
+			lines: []string{
+				"set security zones security-zone trust interfaces ge-0/0/0",
+				"set security zones security-zone trust host-inbound-traffic system-services ssh",
+				"set security zones security-zone trust host-inbound-traffic system-services http",
+				"set security zones security-zone trust host-inbound-traffic protocols ospf",
+				"set security zones security-zone trust host-inbound-traffic protocols bgp",
+			},
+			svcs:  []string{"ssh", "http"},
+			proto: []string{"ospf", "bgp"},
+		},
+		{
+			name: "single value (negative control: not over-collapsed)",
+			lines: []string{
+				"set security zones security-zone trust interfaces ge-0/0/0",
+				"set security zones security-zone trust host-inbound-traffic system-services ssh",
+			},
+			svcs:  []string{"ssh"},
+			proto: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfig(setTree3703(t, tc.lines...))
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			z := cfg.Security.Zones["trust"]
+			if z == nil || z.HostInboundTraffic == nil {
+				t.Fatalf("trust zone host-inbound-traffic missing")
+			}
+			if !equalStrs3703(z.HostInboundTraffic.SystemServices, tc.svcs) {
+				t.Fatalf("system-services = %v, want %v (bracket/list tail dropped — #3703)",
+					z.HostInboundTraffic.SystemServices, tc.svcs)
+			}
+			if !equalStrs3703(z.HostInboundTraffic.Protocols, tc.proto) {
+				t.Fatalf("protocols = %v, want %v (bracket/list tail dropped — #3703)",
+					z.HostInboundTraffic.Protocols, tc.proto)
+			}
+		})
+	}
+}
+
+// TestHostInbound3703HierarchicalBlockShape confirms the hierarchical
+// `host-inbound-traffic { system-services { ssh; http; } }` block shape still
+// lands every value (the reader reads .Children too), so the multi-leaf change
+// does not regress the block spelling.
+func TestHostInbound3703HierarchicalBlockShape(t *testing.T) {
+	tree := parseHierarchical(t, `
+security {
+    zones {
+        security-zone trust {
+            interfaces ge-0/0/0;
+            host-inbound-traffic {
+                system-services { ssh; http; }
+                protocols { ospf; bgp; }
+            }
+        }
+    }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	z := cfg.Security.Zones["trust"]
+	if !equalStrs3703(z.HostInboundTraffic.SystemServices, []string{"ssh", "http"}) {
+		t.Fatalf("hierarchical system-services = %v, want [ssh http]", z.HostInboundTraffic.SystemServices)
+	}
+	if !equalStrs3703(z.HostInboundTraffic.Protocols, []string{"ospf", "bgp"}) {
+		t.Fatalf("hierarchical protocols = %v, want [ospf bgp]", z.HostInboundTraffic.Protocols)
+	}
+}
+
+// TestHostInbound3703PerInterfaceOverrideKeepsAllValues covers the #3362
+// per-interface override — its bracket list must also keep every value.
+func TestHostInbound3703PerInterfaceOverrideKeepsAllValues(t *testing.T) {
+	cfg, err := CompileConfig(setTree3703(t,
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic system-services [ ssh ping ]",
+		"set security zones security-zone trust interfaces ge-0/0/0 host-inbound-traffic protocols [ ospf bgp ]",
+	))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	hib := cfg.Security.Zones["trust"].InterfaceHostInbound["ge-0/0/0"]
+	if hib == nil {
+		t.Fatalf("per-interface host-inbound missing")
+	}
+	if !equalStrs3703(hib.SystemServices, []string{"ssh", "ping"}) {
+		t.Fatalf("per-iface system-services = %v, want [ssh ping] (#3703)", hib.SystemServices)
+	}
+	if !equalStrs3703(hib.Protocols, []string{"ospf", "bgp"}) {
+		t.Fatalf("per-iface protocols = %v, want [ospf bgp] (#3703)", hib.Protocols)
+	}
+}
+
+// TestHostInbound3703UnknownTokenRejectedAtCommit is the fail-fast RED-on-revert
+// guard: a typo in a bracket list is REJECTED at commit. Before #3703 the tail
+// (incl. the typo) was dropped before the compiled slice, so
+// validateHostInboundTokensStrict never saw it and the config committed narrower
+// than authored. With the collapse fixed, the typo reaches the compiled slice
+// and is rejected. Reverting the fix makes both cases compile clean and this
+// goes RED.
+func TestHostInbound3703UnknownTokenRejectedAtCommit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		line string
+		bad  string
+	}{
+		{"system-services typo in bracket", "set security zones security-zone trust host-inbound-traffic system-services [ ssh sssh ]", "sssh"},
+		{"protocols typo in bracket", "set security zones security-zone trust host-inbound-traffic protocols [ ospf notaproto ]", "notaproto"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CompileConfig(setTree3703(t,
+				"set security zones security-zone trust interfaces ge-0/0/0",
+				tc.line,
+			))
+			if err == nil {
+				t.Fatalf("CompileConfig accepted an unknown host-inbound token; want a strict reject (#3703)")
+			}
+			if !strings.Contains(err.Error(), tc.bad) {
+				t.Fatalf("reject error %q does not name the offending token %q", err.Error(), tc.bad)
+			}
+		})
+	}
+}
+
+// TestHostInbound3703LenientDowngradesUnknownToken confirms the #1960 no-brick
+// doctrine: on the tolerant load path the unknown token (now visible after the
+// collapse fix) downgrades to a warning instead of failing the load.
+func TestHostInbound3703LenientDowngradesUnknownToken(t *testing.T) {
+	cfg, err := CompileConfigLenient(setTree3703(t,
+		"set security zones security-zone trust interfaces ge-0/0/0",
+		"set security zones security-zone trust host-inbound-traffic system-services [ ssh sssh ]",
+	))
+	if err != nil {
+		t.Fatalf("CompileConfigLenient must not fail on an unknown host-inbound token (#1960 no-brick): %v", err)
+	}
+	// The known token still landed (collapse is fixed on both paths).
+	if got := cfg.Security.Zones["trust"].HostInboundTraffic.SystemServices; len(got) == 0 || got[0] != "ssh" {
+		t.Fatalf("lenient compile lost the valid token: %v", got)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "sssh") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient compile should warn about the unknown token, warnings=%v", cfg.Warnings)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// per-policy `then log`
+// ---------------------------------------------------------------------------
+
+// TestPolicyThenLog3703KeepsBothModes is the primary RED-on-revert guard for
+// per-policy `then log`: a bracket list, a two-line spelling, and the deny-
+// collapsed form must all set BOTH session flags. Reverting drops session-close
+// (audit records lost despite valid syntax).
+func TestPolicyThenLog3703KeepsBothModes(t *testing.T) {
+	base := []string{
+		"set security zones security-zone trust interfaces ge-0/0/0",
+		"set security zones security-zone untrust interfaces ge-0/0/1",
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match application any",
+		"set security policies from-zone trust to-zone untrust policy p1 then permit",
+	}
+	cases := []struct {
+		name string
+		log  []string
+	}{
+		{"bracket list", []string{"set security policies from-zone trust to-zone untrust policy p1 then log [ session-init session-close ]"}},
+		{"two lines", []string{
+			"set security policies from-zone trust to-zone untrust policy p1 then log session-init",
+			"set security policies from-zone trust to-zone untrust policy p1 then log session-close",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfig(setTree3703(t, append(append([]string(nil), base...), tc.log...)...))
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			log := cfg.Security.Policies[0].Policies[0].Log
+			if log == nil || !log.SessionInit || !log.SessionClose {
+				t.Fatalf("then log dropped a mode: %+v (want both true — #3703)", log)
+			}
+		})
+	}
+}
+
+// TestPolicyThenDenyLog3703BracketKeepsBothModes covers the deny-collapsed
+// bracket form `then deny log [ session-init session-close ]` (#3141 path).
+func TestPolicyThenDenyLog3703BracketKeepsBothModes(t *testing.T) {
+	cfg, err := CompileConfig(setTree3703(t,
+		"set security zones security-zone trust interfaces ge-0/0/0",
+		"set security zones security-zone untrust interfaces ge-0/0/1",
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match application any",
+		"set security policies from-zone trust to-zone untrust policy p1 then deny log [ session-init session-close ]",
+	))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	pol := cfg.Security.Policies[0].Policies[0]
+	if pol.Action != PolicyDeny {
+		t.Fatalf("Action = %v, want PolicyDeny", pol.Action)
+	}
+	if pol.Log == nil || !pol.Log.SessionInit || !pol.Log.SessionClose {
+		t.Fatalf("then deny log dropped a mode: %+v (want both true — #3703)", pol.Log)
+	}
+}
+
+// TestPolicyThenLog3703UnknownModeRejected is the fail-fast guard: a typo in the
+// `then log` bracket list is rejected at commit-check by SchemaValidate's
+// enum-leaf validator (the bracket tail no longer hides it). Reverting the multi
+// enum leaf back to a container makes the typo a silent no-op and this goes RED.
+func TestPolicyThenLog3703UnknownModeRejected(t *testing.T) {
+	tree := setTree3703(t,
+		"set security zones security-zone trust interfaces ge-0/0/0",
+		"set security zones security-zone untrust interfaces ge-0/0/1",
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match application any",
+		"set security policies from-zone trust to-zone untrust policy p1 then permit",
+		"set security policies from-zone trust to-zone untrust policy p1 then log [ session-init boguslog ]",
+	)
+	if err := SchemaValidate(tree, nil); err == nil {
+		t.Fatalf("SchemaValidate accepted an unknown then-log mode; want a strict reject (#3703)")
+	} else if !strings.Contains(err.Error(), "boguslog") {
+		t.Fatalf("reject error %q does not name the offending token", err.Error())
+	}
+	// The valid form must still pass (no over-reject).
+	ok := setTree3703(t,
+		"set security zones security-zone trust interfaces ge-0/0/0",
+		"set security zones security-zone untrust interfaces ge-0/0/1",
+		"set security policies from-zone trust to-zone untrust policy p1 then log [ session-init session-close ]",
+	)
+	if err := SchemaValidate(ok, nil); err != nil {
+		t.Fatalf("SchemaValidate rejected a valid then-log list (over-reject): %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// default-policy-log
+// ---------------------------------------------------------------------------
+
+// TestDefaultPolicyLog3703KeepsBothModes is the RED-on-revert guard for the
+// most security-relevant fallback path: `default-policy-log [ session-init
+// session-close ]` must set BOTH flags.
+func TestDefaultPolicyLog3703KeepsBothModes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		line []string
+	}{
+		{"bracket list", []string{"set security policies default-policy-log [ session-init session-close ]"}},
+		{"two lines", []string{
+			"set security policies default-policy-log session-init",
+			"set security policies default-policy-log session-close",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfig(setTree3703(t, append([]string{"set security policies default-policy permit-all"}, tc.line...)...))
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			if !cfg.Security.DefaultPolicyLogSessionInit || !cfg.Security.DefaultPolicyLogSessionClose {
+				t.Fatalf("default-policy-log dropped a mode: init=%v close=%v (want both — #3703)",
+					cfg.Security.DefaultPolicyLogSessionInit, cfg.Security.DefaultPolicyLogSessionClose)
+			}
+		})
+	}
+}
+
+// TestDefaultPolicyLog3703UnknownModeRejected is the fail-fast guard: an unknown
+// token in the default-policy-log list is rejected at commit-check (there was NO
+// strict validator for this surface before #3703 — only a warning).
+func TestDefaultPolicyLog3703UnknownModeRejected(t *testing.T) {
+	tree := setTree3703(t,
+		"set security policies default-policy permit-all",
+		"set security policies default-policy-log [ session-init bogusmode ]",
+	)
+	if err := SchemaValidate(tree, nil); err == nil {
+		t.Fatalf("SchemaValidate accepted an unknown default-policy-log mode; want a strict reject (#3703)")
+	} else if !strings.Contains(err.Error(), "bogusmode") {
+		t.Fatalf("reject error %q does not name the offending token", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// pre-id-default-policy then log
+// ---------------------------------------------------------------------------
+
+// TestPreIDDefaultPolicyLog3703KeepsBothModes is the RED-on-revert guard for
+// `pre-id-default-policy then log [ session-init session-close ]`.
+func TestPreIDDefaultPolicyLog3703KeepsBothModes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		line []string
+	}{
+		{"bracket list", []string{"set security pre-id-default-policy then log [ session-init session-close ]"}},
+		{"two lines", []string{
+			"set security pre-id-default-policy then log session-init",
+			"set security pre-id-default-policy then log session-close",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CompileConfig(setTree3703(t, tc.line...))
+			if err != nil {
+				t.Fatalf("CompileConfig: %v", err)
+			}
+			p := cfg.Security.PreIDDefaultPolicy
+			if p == nil || !p.LogSessionInit || !p.LogSessionClose {
+				t.Fatalf("pre-id-default-policy log dropped a mode: %+v (want both — #3703)", p)
+			}
+		})
+	}
+}
+
+// TestPreIDDefaultPolicyLog3703UnknownModeRejected is the fail-fast guard for the
+// pre-id surface (also had NO strict validator before #3703).
+func TestPreIDDefaultPolicyLog3703UnknownModeRejected(t *testing.T) {
+	tree := setTree3703(t,
+		"set security pre-id-default-policy then log [ session-init bogusmode ]",
+	)
+	if err := SchemaValidate(tree, nil); err == nil {
+		t.Fatalf("SchemaValidate accepted an unknown pre-id-default-policy log mode; want a strict reject (#3703)")
+	} else if !strings.Contains(err.Error(), "bogusmode") {
+		t.Fatalf("reject error %q does not name the offending token", err.Error())
+	}
+}
+
+// TestSessionLogModeCompletion3703 pins the value-slot completion: dropping the
+// container children (session-init/session-close) must NOT lose `?` completion —
+// the multi enum leaf surfaces both via valueExamples on every log surface.
+func TestSessionLogModeCompletion3703(t *testing.T) {
+	paths := [][]string{
+		{"security", "policies", "from-zone", "trust", "to-zone", "untrust", "policy", "p1", "then", "log"},
+		{"security", "policies", "default-policy-log"},
+		{"security", "pre-id-default-policy", "then", "log"},
+	}
+	for _, p := range paths {
+		results := CompleteSetPathWithValues(p, nil)
+		for _, want := range []string{"session-init", "session-close"} {
+			if !containsCompletionName(results, want) {
+				t.Fatalf("completion for %v missing %q; got %v", p, want, completionNames(results))
+			}
+		}
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -37,6 +37,65 @@ var (
 	syslogCategories = []string{"all", "firewall", "policy", "screen", "session"}
 )
 
+// securitySessionLogModes is the fixed set of session-logging tokens accepted
+// by every session-log LIST surface (#3703): the per-policy `then log`, the
+// deny-collapsed `then deny log`, `default-policy-log`, and
+// `pre-id-default-policy then log`. It is the SSOT shared by the schema
+// (sessionLogModeLeaf below) and the compiler readers (session log values are
+// accumulated via firewallMatchValues and matched against these tokens).
+var securitySessionLogModes = []string{"session-init", "session-close"}
+
+// sessionLogModeLeaf builds the shared multi-value enum leaf for a session-log
+// list surface (#3703). Before this the four surfaces modeled `log` /
+// `default-policy-log` as CONTAINERS with session-init / session-close
+// children, so a bracket / single-line list (`then log [ session-init
+// session-close ]`) mis-nested the tail under the first token and the compiler
+// readers dropped everything after session-init (the #2419 collapse class,
+// unfixed on these leaves). Modeled here as a `multi && children == nil` typed
+// enum leaf so:
+//   - SetPath collapses ALL list values onto the one leaf's Keys (ast_edit.go
+//     absorbs trailing non-sibling tokens for a multi value-tail leaf), and
+//   - SchemaValidate (validateMultiValueLeaf) rejects an UNKNOWN token at
+//     commit-check — strict on the operator commit path, downgraded to a
+//     warning on the tolerant load / peer-sync path (#1960 no-brick) — instead
+//     of the token being silently swallowed.
+//
+// children MUST stay nil: both the SetPath collapse (ast_edit.go:260) and the
+// validateMultiValueLeaf dispatch (schema_walk.go:256) key on children == nil.
+// The value-slot `?` completion surfaces the two modes via valueExamples, so
+// dropping the container children does not lose completion coverage.
+func sessionLogModeLeaf(desc string) *schemaNode {
+	return &schemaNode{
+		desc:          desc,
+		args:          1,
+		multi:         true,
+		valueType:     ValueEnumOf,
+		valueDesc:     "session-logging event",
+		valueExamples: securitySessionLogModes,
+		validator:     ValidateEnum(securitySessionLogModes),
+		placeholder:   "<session-init|session-close>",
+		children:      nil,
+	}
+}
+
+// hostInboundSchemaChildren builds the shared `host-inbound-traffic { ... }`
+// child set used at BOTH the zone level and the per-interface override (#3362,
+// #3703). system-services / protocols are multi-value value-tail leaves: a
+// bracket / single-line / repeated list collapses ALL tokens onto the leaf's
+// Keys (the #2419 contract) instead of dropping the tail, and
+// validateHostInboundTokensStrict rejects an unrecognized token at commit
+// against the host_inbound_tokens.go SSOT (strict on commit, warn on the
+// tolerant load path). children MUST stay nil so the SetPath collapse fires;
+// the leaves are intentionally UNTYPED (no schema validator) because the token
+// allowlist lives in the shared host_inbound_tokens.go SSOT the compiled-slice
+// validator reads, not in the schema.
+func hostInboundSchemaChildren() map[string]*schemaNode {
+	return map[string]*schemaNode{
+		"system-services": {desc: "System services", args: 1, multi: true, placeholder: "<service>", children: nil},
+		"protocols":       {desc: "Protocols", args: 1, multi: true, placeholder: "<protocol>", children: nil},
+	}
+}
+
 // policyThenSchemaChildren builds the `then` action subtree shared by
 // zone-pair (from-zone/to-zone) and global security policies. It is a
 // factory (not a shared package var) so the two scopes get independent
@@ -72,11 +131,13 @@ var (
 // equals the compiler's `then` switch token set for both scopes so a
 // future action leaf cannot drift back out of the schema.
 func policyThenSchemaChildren() map[string]*schemaNode {
+	// #3703: `then log` is a multi-value session-log LIST leaf (see
+	// sessionLogModeLeaf) — a bracket / single-line list must land ALL values
+	// (session-init AND session-close) on the one leaf and reject an unknown
+	// token at commit. It was a container whose bracket tail mis-nested and
+	// dropped everything after session-init.
 	logNode := func() *schemaNode {
-		return &schemaNode{desc: "Log session", children: map[string]*schemaNode{
-			"session-init":  {desc: "Log at session open", children: nil},
-			"session-close": {desc: "Log at session close", children: nil},
-		}}
+		return sessionLogModeLeaf("Log session")
 	}
 	return map[string]*schemaNode{
 		"permit": {desc: "Permit matching traffic", children: nil},
@@ -106,18 +167,12 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"interfaces": {desc: "Interfaces in this zone", wildcard: &schemaNode{
 				desc: "Interface name", valueHint: ValueHintInterfaceName, placeholder: "<interface-name>",
 				children: map[string]*schemaNode{
-					"host-inbound-traffic": {desc: "Per-interface host inbound traffic", children: map[string]*schemaNode{
-						"system-services": {desc: "System services", children: nil},
-						"protocols":       {desc: "Protocols", children: nil},
-					}},
+					"host-inbound-traffic": {desc: "Per-interface host inbound traffic", children: hostInboundSchemaChildren()},
 				},
 			}},
-			"tcp-rst": {desc: "Send TCP RST for denied traffic", children: nil},
-			"screen":  {desc: "Screen profile name", args: 1, placeholder: "<screen-name>", children: nil},
-			"host-inbound-traffic": {desc: "Host inbound traffic", children: map[string]*schemaNode{
-				"system-services": {desc: "System services", children: nil},
-				"protocols":       {desc: "Protocols", children: nil},
-			}},
+			"tcp-rst":              {desc: "Send TCP RST for denied traffic", children: nil},
+			"screen":               {desc: "Screen profile name", args: 1, placeholder: "<screen-name>", children: nil},
+			"host-inbound-traffic": {desc: "Host inbound traffic", children: hostInboundSchemaChildren()},
 			// #3061: zone-local address book. Same entry grammar as the
 			// global book (security address-book global) but attached
 			// directly under the zone (no `global` wrapper). A policy in
@@ -159,10 +214,12 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		// lives in this sibling container (mirroring pre-id-default-policy's
 		// session-init/session-close model). `session-init`/`session-close` are
 		// presence-only flags wired to ConfigSnapshot.DefaultLogSessionInit/Close.
-		"default-policy-log": {desc: "RT_FLOW session logging for the implicit default-policy verdict", children: map[string]*schemaNode{
-			"session-init":  {desc: "Emit an RT_FLOW session-init log on the default-policy verdict (default permit-all only)", children: nil},
-			"session-close": {desc: "Emit an RT_FLOW session-close log on the default-policy verdict (default permit-all only)", children: nil},
-		}},
+		// #3703: multi-value session-log LIST leaf (see sessionLogModeLeaf) so a
+		// bracket / single-line `default-policy-log [ session-init session-close ]`
+		// lands BOTH values and rejects an unknown token at commit. It was a
+		// container whose bracket tail mis-nested session-close under session-init
+		// and dropped it — losing the most security-relevant fallback-path audit.
+		"default-policy-log": sessionLogModeLeaf("RT_FLOW session logging for the implicit default-policy verdict"),
 		"from-zone": {desc: "From zone", args: 3, valueHint: ValueHintZoneName, midKeyword: "to-zone", midKeywordAt: 2, placeholder: "<zone-name>", children: map[string]*schemaNode{
 			"policy": {desc: "Policy name", args: 1, valueHint: ValueHintPolicyName, placeholder: "<policy-name>", children: map[string]*schemaNode{
 				"description": {desc: "Policy description", args: 1, scalar: true, placeholder: "<text>", children: nil},
@@ -767,10 +824,11 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 	}},
 	"pre-id-default-policy": {desc: "Default policy before application identification", children: map[string]*schemaNode{
 		"then": {desc: "Action", children: map[string]*schemaNode{
-			"log": {desc: "Logging options", children: map[string]*schemaNode{
-				"session-init":  {desc: "Log session creation", children: nil},
-				"session-close": {desc: "Log session close", children: nil},
-			}},
+			// #3703: multi-value session-log LIST leaf (see sessionLogModeLeaf)
+			// so a bracket `then log [ session-init session-close ]` lands BOTH
+			// values and rejects an unknown token at commit. It was a container
+			// whose bracket tail mis-nested and dropped the tail.
+			"log": sessionLogModeLeaf("Logging options"),
 		}},
 	}},
 }}


### PR DESCRIPTION
Closes #3703

## Problem

The #2419 flat-set bracketed-list-collapse bug recurred on four security
config surfaces #2419 never converted: host-inbound `system-services` /
`protocols` (zone level AND the #3362 per-interface override), per-policy
`then log`, `default-policy-log`, and `pre-id-default-policy then log`. Each
was modeled in `setSchema` as a CONTAINER (or a nil-children, non-multi
leaf), so a bracket / single-line list mis-nested the tail one node deeper
and the compiler readers only ever read the first token. Confirmed against
origin/master (6d3e109bc) before the fix:

- `system-services [ ssh http ]` -> `SystemServices ["ssh"]` (http lost)
- `then log [ session-init session-close ]` -> SessionInit only
- `default-policy-log [ session-init session-close ]` -> close flag lost
- `pre-id-default-policy then log [...]` -> tail dropped
- typos (`system-services [ ssh sssh ]`, `then log [ session-init bogus ]`)
  committed cleanly — the dropped tail bypassed strict validation

Harm runs both directions: a dropped host-inbound service silently NARROWS
admission (can strand SSH / routing); a dropped `session-close` loses audit
records; a swallowed typo defeats fail-fast validation on a security control.

## Fix

**Leaves converted to multi + readers fixed**

| surface | schema | reader |
|---|---|---|
| host-inbound `system-services` / `protocols` (zone + per-iface) | `hostInboundSchemaChildren`: `args:1, multi:true, children:nil` (untyped) | `parseHostInboundNode` -> `firewallMatchValues` |
| per-policy `then log` | `sessionLogModeLeaf`: `multi:true, children:nil`, `ValueEnumOf`+`ValidateEnum` | `compilePolicy` `then log` arm -> `firewallMatchValues`, create-once |
| `default-policy-log` | `sessionLogModeLeaf` | `compilePolicies` arm -> `firewallMatchValues` |
| `pre-id-default-policy then log` | `sessionLogModeLeaf` | pre-id reader -> `FindChildren("log")` + `firewallMatchValues` |

`children` stays nil so the SetPath collapse (`ast_edit.go`) and the
`validateMultiValueLeaf` dispatch (`schema_walk.go`) both fire; readers
accumulate `Keys[1:]` AND `.Children` and never reset the target struct, so
bracket, repeated-line, and hierarchical shapes all land every value.

**Strict validation added / restored**

- host-inbound typos now reach the compiled slice -> rejected by the existing
  `validateHostInboundTokensStrict` (SSOT `host_inbound_tokens.go`).
- the three log surfaces gain commit-time rejection of unknown tokens via
  `SchemaValidate` (`validateMultiValueLeaf` runs the enum validator) — strict
  on commit, downgraded to a warning on the tolerant load / peer-sync path
  (#1960 no-brick). Closes the gap `validatePolicyLogActionStrict` (both-false
  only) and the default-policy-log / pre-id WARN-only validators left open.

Value-slot `?` completion is preserved via `valueExamples`.

## RED-on-revert proof

Reverting `schema_security.go` + `compiler_security.go` to origin/master and
running the new tests turns 10 bug-catchers RED (tail-drop + typo-bypass on
every surface, both harm directions). The hierarchical-block, deny-collapsed,
and completion cases stay green as regression-safety controls.

## Tests / validation

- `go test ./pkg/config/... ./pkg/configstore/...` green
- consumers `go test ./pkg/daemon/... ./pkg/dataplane/... ./pkg/api/... ./pkg/cli/... ./pkg/cmdtree/...` green
- `go build ./pkg/... ./cmd/...` OK; gofmt + vet clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi