### PR TITLE
policymatch: reject duplicate selectors + comma-zone round-trip across CLI/gRPC/REST (#3709)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-01 — #3709 policy-simulator rejects DUPLICATE selectors (consistent fail-closed across CLI/gRPC/REST) + comma-in-zone round-trip
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3696 hardened the policy-match simulator against missing /
+    empty / unknown / malformed selectors but NONE of the surfaces rejected a
+    DUPLICATE selector. A copy/paste vector (`from-zone trust from-zone dmz`,
+    `source-port 80 source-port 443`) was accepted and one value silently won,
+    so the simulator certified an allow/deny verdict for a DIFFERENT packet than
+    the operator typed — and the surfaces disagreed on WHICH value won (CLI +
+    gRPC text topic last-win, REST first-win). FIX (fail-closed on ambiguity,
+    matching #3696):
+    1. `policymatch.ParseSelectorArgs` — a `seen` set in the shared `takeValue`
+       helper (every selector is value-taking and routes through it exactly
+       once) errors `selector %q specified more than once`. Covers all four CLI
+       surfaces (local + remote `show security match-policies` / `test policy`).
+    2. gRPC `showTestPolicy` (`server_show_firewall.go`) — a seen-key guard in
+       the comma/equals `key=value` loop reports the duplicate as a diagnostic
+       (set-once parseErr preserves an earlier unknown-selector error).
+    3. REST `matchPoliciesHandler` (`pkg/api/security.go`) — a `len(q[key]) > 1`
+       guard over the scalar selector keys returns HTTP 400 (r.URL.Query().Get
+       otherwise silently first-wins).
+    Also (H05/M05/M06) the comma-in-zone-name round-trip: config permits a zone
+    name with a comma/equals but the legacy `test-policy:` text topic cannot
+    carry it, so the REMOTE `test policy` (`cmd/cli/main.go`) now rejects an
+    un-round-trippable zone with a clear error pointing at `show security
+    match-policies` (typed RPC, no delimiter fragility) instead of silently
+    corrupting the query. Also (H06 no-config ordering) REST now validates
+    request grammar BEFORE the `cfg == nil` fail-closed verdict, so a malformed
+    boot-window query returns 400 consistently (was 200 pre-config, 400 post).
+  - **File(s)**: pkg/policymatch/policymatch.go,
+    pkg/grpcapi/server_show_firewall.go, pkg/api/security.go, cmd/cli/main.go,
+    docs/junos-cli-reference.md,
+    pkg/policymatch/selector_args_dup_3709_test.go (new),
+    pkg/cli/policymatch_dup_3709_test.go (new),
+    cmd/cli/policymatch_dup_3709_test.go (new),
+    pkg/grpcapi/server_testpolicy_dup_3709_test.go (new),
+    pkg/api/security_matchpolicies_dup_3709_test.go (new), _Log.md
+  - **Validation**: `go test ./pkg/policymatch/... ./pkg/cli/... ./cmd/cli/...
+    ./pkg/grpcapi/... ./pkg/api/...` green; `go build ./...`, gofmt, go vet
+    clean. RED-on-revert proven per guard: neutralizing the parser guard flips
+    the policymatch + pkg/cli + cmd/cli duplicate tests red; the comma-zone
+    guard, the gRPC seen-key guard, the REST duplicate guard, and the REST
+    no-config ordering each flip their surface test red and restore green.
+
 ## 2026-07-01 — #3704 review fold: CLI reloadSyslog zone-map was still positional (4th reverse-map)
 
 - **Timestamp**: 2026-07-01

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -464,6 +464,21 @@ func (c *ctl) testPolicy(args []string) error {
 		return nil
 	}
 
+	// #3709: the legacy `test-policy:` ShowText topic is a comma/equals-delimited
+	// key=value string, so a zone name that itself contains a comma or equals
+	// cannot round-trip — the server splits it into bogus segments and rejects
+	// or MISPARSES it. Config permits such a zone name (only exact reserved
+	// tokens are rejected in compiler_validate_strict.go reservedZoneNames), so
+	// rather than silently corrupt the query, fail closed here with a clear
+	// error pointing the operator at `show security match-policies`, which uses
+	// the typed MatchPolicies RPC and has no delimiter fragility. The local
+	// `test policy` (pkg/cli) evaluates such a zone directly and is unaffected.
+	for _, z := range []struct{ label, val string }{{"from-zone", fromZone}, {"to-zone", toZone}} {
+		if strings.ContainsAny(z.val, ",=") {
+			return fmt.Errorf("%s %q contains a comma or equals, which the 'test policy' topic cannot carry; use 'show security match-policies' instead", z.label, z.val)
+		}
+	}
+
 	topic := fmt.Sprintf("test-policy:from=%s,to=%s", fromZone, toZone)
 	if srcIP != "" {
 		topic += ",src=" + srcIP

--- a/cmd/cli/policymatch_dup_3709_test.go
+++ b/cmd/cli/policymatch_dup_3709_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRemotePolicySimulatorRejectsDuplicate is the #3709 RED-on-revert guard for
+// the REMOTE CLI `show security match-policies` and `test policy` surfaces. Both
+// route the selector vector through policymatch.ParseSelectorArgs, which now
+// rejects a DUPLICATE selector, so neither surface forwards an ambiguous (silent
+// last-win) query to the backend.
+//
+// FAIL-ON-REVERT: dropping the duplicate guard lets the malformed input build a
+// request/topic and dial the backend with no error, flipping the want-error +
+// no-RPC assertions red.
+func TestRemotePolicySimulatorRejectsDuplicate(t *testing.T) {
+	dupArgs := []string{"from-zone", "trust", "to-zone", "untrust", "source-port", "80", "source-port", "443"}
+
+	t.Run("show", func(t *testing.T) {
+		fake := &fakeBpfrxClient{}
+		c := &ctl{client: fake}
+		err := c.showMatchPolicies(dupArgs)
+		if err == nil || !strings.Contains(err.Error(), "specified more than once") {
+			t.Fatalf("showMatchPolicies(dup) err = %v, want a duplicate-selector error", err)
+		}
+		if fake.matchPoliciesCalls != 0 {
+			t.Fatalf("MatchPolicies issued %d times on duplicate input; want 0", fake.matchPoliciesCalls)
+		}
+	})
+	t.Run("test", func(t *testing.T) {
+		fake := &fakeBpfrxClient{}
+		c := &ctl{client: fake}
+		err := c.testPolicy(dupArgs)
+		if err == nil || !strings.Contains(err.Error(), "specified more than once") {
+			t.Fatalf("testPolicy(dup) err = %v, want a duplicate-selector error", err)
+		}
+		if fake.showTextCalls != 0 {
+			t.Fatalf("ShowText issued %d times on duplicate input; want 0", fake.showTextCalls)
+		}
+	})
+}
+
+// TestRemoteTestPolicyRejectsCommaZone is the #3709 RED-on-revert guard for the
+// comma-in-zone-name round-trip gap on the REMOTE `test policy` surface. Config
+// permits a zone name containing a comma (only exact reserved tokens are
+// rejected), but the legacy `test-policy:` ShowText topic is a comma/equals
+// delimited key=value string that cannot carry such a name — the server would
+// split it into bogus segments and misparse it. The surface now fails closed
+// with a clear error before dialing the backend, rather than silently corrupting
+// the query.
+//
+// FAIL-ON-REVERT: removing the delimiter guard lets testPolicy build a corrupted
+// topic and call ShowText, flipping the want-error + no-RPC assertions red.
+func TestRemoteTestPolicyRejectsCommaZone(t *testing.T) {
+	cases := [][]string{
+		{"from-zone", "trust,blue", "to-zone", "untrust"},
+		{"from-zone", "trust", "to-zone", "a=b"},
+	}
+	for _, args := range cases {
+		fake := &fakeBpfrxClient{}
+		c := &ctl{client: fake}
+		err := c.testPolicy(args)
+		if err == nil || !strings.Contains(err.Error(), "cannot carry") {
+			t.Fatalf("testPolicy(%v) err = %v, want a delimiter-round-trip error", args, err)
+		}
+		if fake.showTextCalls != 0 {
+			t.Fatalf("ShowText issued %d times on un-round-trippable zone; want 0", fake.showTextCalls)
+		}
+	}
+}

--- a/docs/junos-cli-reference.md
+++ b/docs/junos-cli-reference.md
@@ -859,6 +859,42 @@ unknown key, or an explicit-empty typed value (`port=`) is reported as a
 diagnostic instead of being skipped; a bare `test-policy:` still reports the
 missing-from/to-zone message. A VALID query behaves exactly as before.
 
+**Duplicate selectors are rejected (#3709).** A repeated selector (e.g.
+`... source-port 80 source-port 443` or `from-zone trust from-zone dmz`) is an
+error `selector "source-port" specified more than once` on ALL surfaces —
+`ParseSelectorArgs` (local + remote `show security match-policies` / `test
+policy`), the gRPC `test-policy:` bridge (`selector "from" specified more than
+once`), and REST `match-policies` (a repeated query parameter such as
+`?from_zone=trust&from_zone=dmz` returns HTTP 400). Before #3709 a duplicate
+silently WON: the CLI and gRPC surfaces last-won (the second value survived)
+while REST first-won (the first value survived), so the three surfaces returned
+an allow/deny verdict for a DIFFERENT packet than the operator typed, and even
+disagreed with each other on WHICH value applied. A policy simulator must answer
+the exact query, and there is no correct silent pick for a duplicate, so the
+ambiguity is a hard error (the fail-closed posture #3696 set for the rest of the
+grammar).
+
+**Comma-in-zone-name round-trip (#3709).** The config permits a zone name
+containing a comma or equals (only the exact reserved tokens are rejected in
+`compiler_validate_strict.go`). The legacy `test-policy:` ShowText topic is a
+comma/equals-delimited `key=value` string that cannot carry such a name, so the
+REMOTE `test policy` surface now fails closed with a clear error
+(`from-zone "trust,blue" contains a comma or equals, which the 'test policy'
+topic cannot carry; use 'show security match-policies' instead`) rather than
+silently corrupting the query into bogus segments. `show security
+match-policies` uses the typed `MatchPolicies` RPC with no delimiter fragility
+and handles the comma-bearing zone directly; the LOCAL `test policy` (which
+evaluates in-process, no serialization) is likewise unaffected.
+
+**No-config grammar ordering (#3709).** REST `match-policies` now validates
+request grammar (duplicate / missing-zone / malformed IP-port-protocol-icmp)
+BEFORE the no-active-config fail-closed default-deny verdict, so a malformed
+query returns HTTP 400 consistently whether or not a config is loaded. Before
+#3709 the `cfg == nil` branch returned 200 default-deny before any grammar
+check, so a malformed request (e.g. `dst_port=abc`) returned 200 during the
+boot window monitors poll but 400 once a config was active. A well-formed
+boot-window query still returns the 200 fail-closed default-deny.
+
 ---
 
 ## Security: Zones

--- a/pkg/api/security.go
+++ b/pkg/api/security.go
@@ -466,26 +466,34 @@ func parseEventZoneFilter(s string) (uint16, bool) {
 }
 
 func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
-	cfg := s.store.ActiveConfig()
-	if cfg == nil {
-		// #3375: no active config is the deterministic fail-closed default deny.
-		// Surface the explicit string AND the typed default_used bit (same SSOT
-		// renderer the gRPC surface uses).
-		nilRes := policymatch.Result{DefaultUsed: true, Action: config.PolicyDeny}
-		writeOK(w, MatchPoliciesResult{
-			Action:      nilRes.DisplayAction(),
-			DefaultUsed: true,
-			// #3627 M06: echo the queried zone pair even on the no-config
-			// fail-closed default deny so a stored diagnostic proves which zone
-			// pair produced the verdict.
-			QueriedFromZone: r.URL.Query().Get("from_zone"),
-			QueriedToZone:   r.URL.Query().Get("to_zone"),
-		})
-		return
+	// #3709: validate request grammar BEFORE the cfg == nil verdict so a
+	// malformed / duplicate / missing-zone query fails the SAME way during the
+	// boot window (no active config) as it does once a config is live. Before
+	// this, the cfg == nil branch returned 200 default-deny before ANY grammar
+	// check ran, so `dst_port=abc` or `?from_zone=a&from_zone=b` returned 200 at
+	// boot but 400 once a config existed — inconsistent validation during the
+	// exact window monitors poll.
+	q := r.URL.Query()
+
+	// #3709: reject a DUPLICATE scalar selector (e.g.
+	// `?from_zone=trust&from_zone=dmz`). r.URL.Query().Get returns the FIRST of
+	// repeated values, so REST silently FIRST-won while the CLI/gRPC surfaces
+	// LAST-won — the three surfaces disagreed on WHICH duplicate the simulator
+	// tested, each certifying a verdict for a packet the operator may not have
+	// typed. There is no correct silent pick, so a repeat is a 400, matching the
+	// strict CLI/gRPC parsers (policymatch.ParseSelectorArgs / showTestPolicy).
+	for _, key := range []string{
+		"from_zone", "to_zone", "src_ip", "dst_ip",
+		"src_port", "dst_port", "protocol", "icmp_type", "icmp_code",
+	} {
+		if len(q[key]) > 1 {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("selector %q specified more than once", key))
+			return
+		}
 	}
 
-	fromZone := r.URL.Query().Get("from_zone")
-	toZone := r.URL.Query().Get("to_zone")
+	fromZone := q.Get("from_zone")
+	toZone := q.Get("to_zone")
 
 	// #3355 (H06): the CLI surfaces (show security match-policies / test
 	// policy) require BOTH zones; REST accepted a missing zone and evaluated as
@@ -561,6 +569,27 @@ func (s *Server) matchPoliciesHandler(w http.ResponseWriter, r *http.Request) {
 	icmpCode, err := policymatch.ParseICMPValue(r.URL.Query().Get("icmp_code"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid icmp_code: "+err.Error())
+		return
+	}
+
+	cfg := s.store.ActiveConfig()
+	if cfg == nil {
+		// #3375: no active config is the deterministic fail-closed default deny.
+		// Surface the explicit string AND the typed default_used bit (same SSOT
+		// renderer the gRPC surface uses). #3709: reached only AFTER the grammar
+		// checks above, so a malformed / duplicate / missing-zone query returns
+		// 400 here too — the boot window is now grammar-consistent with the
+		// config-present path, not a 200 default-deny that skips validation.
+		nilRes := policymatch.Result{DefaultUsed: true, Action: config.PolicyDeny}
+		writeOK(w, MatchPoliciesResult{
+			Action:      nilRes.DisplayAction(),
+			DefaultUsed: true,
+			// #3627 M06: echo the queried zone pair even on the no-config
+			// fail-closed default deny so a stored diagnostic proves which zone
+			// pair produced the verdict.
+			QueriedFromZone: fromZone,
+			QueriedToZone:   toZone,
+		})
 		return
 	}
 

--- a/pkg/api/security_matchpolicies_dup_3709_test.go
+++ b/pkg/api/security_matchpolicies_dup_3709_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// matchStatus runs matchPoliciesHandler against a raw (possibly duplicate-keyed)
+// query string and returns the HTTP status + body without asserting 200, so the
+// #3709 fail-closed 400 paths can be checked.
+func matchStatus(t *testing.T, s *Server, rawQuery string) (int, string) {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/v1/security/match?"+rawQuery, nil)
+	s.matchPoliciesHandler(rr, req)
+	return rr.Code, rr.Body.String()
+}
+
+// TestMatchPoliciesRESTRejectsDuplicate is the #3709 RED-on-revert guard for the
+// REST surface. r.URL.Query().Get returns the FIRST of repeated values, so a
+// duplicate scalar selector (`?from_zone=trust&from_zone=dmz`) silently
+// FIRST-won while the CLI/gRPC surfaces last-won — the three disagreed on WHICH
+// duplicate the simulator tested. REST now rejects a repeated scalar selector
+// with 400.
+//
+// FAIL-ON-REVERT: removing the len(q[key]) > 1 guard makes the duplicate query
+// silently first-win and return 200, flipping the want-400 assertions red.
+func TestMatchPoliciesRESTRejectsDuplicate(t *testing.T) {
+	s := &Server{store: hostInboundAPIStore(t)}
+	cases := []string{
+		"from_zone=trust&from_zone=dmz&to_zone=untrust",
+		"from_zone=trust&to_zone=untrust&dst_port=80&dst_port=443",
+		"from_zone=trust&to_zone=untrust&protocol=tcp&protocol=udp",
+		"from_zone=trust&to_zone=untrust&src_ip=10.0.0.1&src_ip=10.0.0.2",
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			code, body := matchStatus(t, s, raw)
+			if code != 400 {
+				t.Fatalf("status = %d, want 400 (duplicate selector); body: %s", code, body)
+			}
+			if !strings.Contains(body, "specified more than once") {
+				t.Fatalf("body = %s, want a duplicate-selector error", body)
+			}
+		})
+	}
+
+	// A single occurrence of each selector still succeeds.
+	code, body := matchStatus(t, s, url.Values{
+		"from_zone": {"trust"}, "to_zone": {"untrust"}, "dst_port": {"443"},
+	}.Encode())
+	if code != 200 {
+		t.Fatalf("single-valued query status = %d, want 200; body: %s", code, body)
+	}
+}
+
+// TestMatchPoliciesRESTNilConfigGrammarOrdering is the #3709 RED-on-revert guard
+// for the no-config ordering gap: matchPoliciesHandler used to return 200
+// default-deny in the cfg == nil branch BEFORE any grammar validation, so a
+// malformed / duplicate query returned 200 at boot but 400 once a config
+// existed — inconsistent validation exactly when monitors poll. Grammar checks
+// now run BEFORE the cfg == nil verdict, so a malformed boot-window query returns
+// 400 identically.
+//
+// FAIL-ON-REVERT: moving the cfg == nil branch back above the grammar checks
+// makes these malformed boot-window queries return 200, flipping the want-400
+// assertions red.
+func TestMatchPoliciesRESTNilConfigGrammarOrdering(t *testing.T) {
+	store := newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf"))
+	s := &Server{store: store}
+	if store.ActiveConfig() != nil {
+		t.Skip("active config is not nil; nil-config path not exercised")
+	}
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"malformed dst_port", "from_zone=trust&to_zone=untrust&dst_port=abc"},
+		{"duplicate selector", "from_zone=trust&from_zone=dmz&to_zone=untrust"},
+		{"missing zones", "src_ip=10.0.0.1"},
+		{"invalid src_ip", "from_zone=trust&to_zone=untrust&src_ip=10.0.0.999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := matchStatus(t, s, tc.raw)
+			if code != 400 {
+				t.Fatalf("no-config %s: status = %d, want 400 (grammar before cfg==nil verdict); body: %s", tc.name, code, body)
+			}
+		})
+	}
+
+	// A well-formed boot-window query still returns the 200 fail-closed default
+	// deny (grammar-valid input is unaffected by the reorder).
+	code, body := matchStatus(t, s, "from_zone=trust&to_zone=untrust")
+	if code != 200 {
+		t.Fatalf("well-formed no-config query status = %d, want 200 default-deny; body: %s", code, body)
+	}
+}

--- a/pkg/cli/policymatch_dup_3709_test.go
+++ b/pkg/cli/policymatch_dup_3709_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLocalPolicySimulatorRejectsDuplicate is the #3709 RED-on-revert guard for
+// the LOCAL CLI `show security match-policies` and `test policy` surfaces. Both
+// route the selector vector through policymatch.ParseSelectorArgs, which now
+// rejects a DUPLICATE selector. Before the fix a repeated selector silently
+// LAST-won and the simulator certified a verdict for a different packet than the
+// operator typed.
+//
+// FAIL-ON-REVERT: dropping the duplicate guard in ParseSelectorArgs makes these
+// inputs return nil (with the last value applied) instead of an error, so both
+// surface assertions flip red.
+func TestLocalPolicySimulatorRejectsDuplicate(t *testing.T) {
+	c := newPolicyMatchCLIStore(t)
+	cfg := c.store.ActiveConfig()
+	if cfg == nil {
+		t.Fatal("ActiveConfig() = nil")
+	}
+
+	dupArgs := []string{"from-zone", "trust", "to-zone", "untrust", "source-port", "80", "source-port", "443"}
+
+	t.Run("show", func(t *testing.T) {
+		var err error
+		captureStdout(t, func() { err = c.showMatchPolicies(cfg, dupArgs) })
+		if err == nil || !strings.Contains(err.Error(), "specified more than once") {
+			t.Fatalf("showMatchPolicies(dup) err = %v, want a duplicate-selector error", err)
+		}
+	})
+	t.Run("test", func(t *testing.T) {
+		var err error
+		captureStdout(t, func() { err = c.testPolicy(dupArgs) })
+		if err == nil || !strings.Contains(err.Error(), "specified more than once") {
+			t.Fatalf("testPolicy(dup) err = %v, want a duplicate-selector error", err)
+		}
+	})
+}

--- a/pkg/grpcapi/server_show_firewall.go
+++ b/pkg/grpcapi/server_show_firewall.go
@@ -190,6 +190,13 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 	// error, distinguishing key-absent from key-empty (M01). An entirely empty
 	// param string (bare `test-policy:`) still falls through to the
 	// missing-from/to-zone diagnostic below rather than reading as malformed.
+	// #3709: reject a DUPLICATE selector key (e.g. `from=trust,from=dmz`). The
+	// switch below re-assigns fromZone/dstPort/... on a repeated key, silently
+	// LAST-WINning, so the gRPC-text simulator answered for a DIFFERENT packet
+	// than the operator typed — and it disagreed with REST (first-win) on WHICH
+	// value survived. There is no correct silent pick, so a repeat is a reported
+	// error, matching the strict CLI parser (policymatch.ParseSelectorArgs).
+	seen := make(map[string]bool)
 	if params != "" {
 		for _, kv := range strings.Split(params, ",") {
 			parts := strings.SplitN(kv, "=", 2)
@@ -199,6 +206,17 @@ func (s *Server) showTestPolicy(req *pb.ShowTextRequest, cfg *config.Config, buf
 				}
 				continue
 			}
+			if seen[parts[0]] {
+				// A duplicate KNOWN key last-wins below; a duplicate UNKNOWN key
+				// already recorded an "unknown selector" error on its first
+				// occurrence (parseErr is set-once), so this only overrides when
+				// no earlier grammar error was captured.
+				if parseErr == nil {
+					parseErr = fmt.Errorf("selector %q specified more than once", parts[0])
+				}
+				continue
+			}
+			seen[parts[0]] = true
 			switch parts[0] {
 			case "from":
 				fromZone = parts[1]

--- a/pkg/grpcapi/server_testpolicy_dup_3709_test.go
+++ b/pkg/grpcapi/server_testpolicy_dup_3709_test.go
@@ -1,0 +1,42 @@
+package grpcapi
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// TestShowTestPolicyRejectsDuplicate is the #3709 RED-on-revert guard for the
+// gRPC ShowText "test-policy:" bridge. The comma/equals key=value loop
+// re-assigned fromZone/dstPort/... on a repeated key, silently LAST-winning, so
+// a duplicate selector (e.g. `from=trust,from=dmz`) evaluated a DIFFERENT packet
+// than the operator typed — and disagreed with REST (first-win) on which value
+// survived. The handler now reports a duplicate-selector diagnostic instead.
+//
+// FAIL-ON-REVERT: removing the seen-key guard makes these topics silently
+// last-win and print a "Policy match" (or a default verdict) with no diagnostic,
+// flipping the assertions red.
+func TestShowTestPolicyRejectsDuplicate(t *testing.T) {
+	s := &Server{store: matchPoliciesTestStore(t)}
+	topics := []string{
+		"test-policy:from=trust,from=dmz,to=untrust",
+		"test-policy:from=trust,to=untrust,port=80,port=443",
+		"test-policy:from=trust,to=untrust,proto=tcp,proto=udp",
+	}
+	for _, topic := range topics {
+		t.Run(topic, func(t *testing.T) {
+			resp, err := s.ShowText(context.Background(), &pb.ShowTextRequest{Topic: topic})
+			if err != nil {
+				t.Fatalf("ShowText(%q) err = %v", topic, err)
+			}
+			if !strings.Contains(resp.Output, "specified more than once") {
+				t.Fatalf("output = %q, want a duplicate-selector diagnostic", resp.Output)
+			}
+			if strings.Contains(resp.Output, "Policy match") {
+				t.Fatalf("duplicate selector produced a policy match (silent last-win): %q", resp.Output)
+			}
+		})
+	}
+}

--- a/pkg/policymatch/policymatch.go
+++ b/pkg/policymatch/policymatch.go
@@ -348,10 +348,29 @@ type SelectorArgs struct {
 // value like any other selector.
 func ParseSelectorArgs(args []string) (SelectorArgs, error) {
 	var s SelectorArgs
+	// seen tracks which selector keywords have already been consumed so a
+	// DUPLICATE selector is rejected (#3709). Every simulator selector is
+	// value-taking and routes through takeValue exactly once per occurrence,
+	// so a keyword already in seen is an unambiguous duplicate.
+	seen := make(map[string]bool)
 	// takeValue consumes the token following a value-taking selector, erroring
-	// when it is missing (trailing selector) or empty (present-but-valueless).
-	// Mirrors cmd/cli/show.go parseFlowSessionArgs (#3439 H5).
+	// when the selector is REPEATED (#3709), when its value is missing (trailing
+	// selector), or when its value is empty (present-but-valueless). Mirrors
+	// cmd/cli/show.go parseFlowSessionArgs (#3439 H5).
 	takeValue := func(i *int, kw string) (string, error) {
+		// #3709: fail CLOSED on a duplicate selector (e.g. `source-port 80
+		// source-port 443` or `from-zone trust from-zone dmz`). Before this the
+		// switch below re-assigned the field on the second occurrence, silently
+		// LAST-WINning: the simulator returned an allow/deny verdict for a
+		// DIFFERENT packet than the operator typed. The gRPC text topic also
+		// last-won while REST first-won, so the three surfaces even disagreed on
+		// WHICH value survived. There is no correct silent pick for a duplicate,
+		// so the ambiguity is an error — the fail-closed posture #3696 set for
+		// the rest of this grammar.
+		if seen[kw] {
+			return "", fmt.Errorf("selector %q specified more than once", kw)
+		}
+		seen[kw] = true
 		if *i+1 >= len(args) {
 			return "", fmt.Errorf("selector %q requires a value", kw)
 		}

--- a/pkg/policymatch/selector_args_dup_3709_test.go
+++ b/pkg/policymatch/selector_args_dup_3709_test.go
@@ -1,0 +1,58 @@
+package policymatch
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseSelectorArgsRejectsDuplicate is the #3709 RED-on-revert guard for the
+// SSOT selector parser shared by all four CLI surfaces + the gRPC test-policy
+// bridge. Before it, a DUPLICATE selector (e.g. `source-port 80 source-port
+// 443` or `from-zone trust from-zone dmz`) was accepted and silently LAST-won:
+// the switch re-assigned the field on the second occurrence, so the simulator
+// returned an allow/deny verdict for a DIFFERENT packet than the operator typed.
+// The gRPC text topic last-won while REST first-won, so the three surfaces even
+// disagreed on WHICH value survived.
+//
+// FAIL-ON-REVERT: dropping the duplicate guard in takeValue makes every
+// want-error case below return nil with the LAST value silently applied,
+// flipping the assertions red.
+func TestParseSelectorArgsRejectsDuplicate(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string // substring; "" = want no error
+	}{
+		{"dup from-zone", []string{"from-zone", "trust", "from-zone", "dmz", "to-zone", "untrust"}, "specified more than once"},
+		{"dup to-zone", []string{"from-zone", "trust", "to-zone", "untrust", "to-zone", "dmz"}, "specified more than once"},
+		{"dup source-port", []string{"from-zone", "trust", "to-zone", "untrust", "source-port", "80", "source-port", "443"}, "specified more than once"},
+		{"dup destination-port", []string{"from-zone", "trust", "to-zone", "untrust", "destination-port", "80", "destination-port", "443"}, "specified more than once"},
+		{"dup protocol", []string{"from-zone", "trust", "to-zone", "untrust", "protocol", "tcp", "protocol", "udp"}, "specified more than once"},
+		{"dup source-ip", []string{"from-zone", "trust", "to-zone", "untrust", "source-ip", "10.0.0.1", "source-ip", "10.0.0.2"}, "specified more than once"},
+		{"dup destination-ip", []string{"from-zone", "trust", "to-zone", "untrust", "destination-ip", "10.0.0.1", "destination-ip", "10.0.0.2"}, "specified more than once"},
+		{"dup icmp-type", []string{"from-zone", "trust", "to-zone", "untrust", "icmp-type", "8", "icmp-type", "0"}, "specified more than once"},
+		{"dup icmp-code", []string{"from-zone", "trust", "to-zone", "untrust", "icmp-code", "0", "icmp-code", "1"}, "specified more than once"},
+		// A duplicate is an error even when the repeated VALUE is identical —
+		// the ambiguity is in the query shape, not the value.
+		{"dup identical value", []string{"from-zone", "trust", "to-zone", "untrust", "source-port", "443", "source-port", "443"}, "specified more than once"},
+		// A single occurrence of each selector is still accepted.
+		{"no duplicates", []string{"from-zone", "trust", "to-zone", "untrust", "source-port", "80", "destination-port", "443", "protocol", "tcp"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseSelectorArgs(tc.args)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ParseSelectorArgs(%v) err = %v, want nil", tc.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ParseSelectorArgs(%v) err = nil, want %q (silent last-win)", tc.args, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ParseSelectorArgs(%v) err = %v, want substring %q", tc.args, err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3709

## Problem

The #3696 strict selector parser hardened the policy-match simulator
against missing / empty / unknown / malformed selectors, but NONE of the
operator surfaces rejected a DUPLICATE selector. A copy/paste vector such
as `from-zone trust from-zone dmz` or `source-port 80 source-port 443`
was accepted and one value silently won, so the simulator certified an
allow/deny verdict for a DIFFERENT packet than the operator typed. Worse,
the surfaces disagreed on WHICH duplicate won:

- Local + remote CLI (`policymatch.ParseSelectorArgs`) — last-win.
- gRPC ShowText `test-policy:` bridge (`showTestPolicy`) — last-win.
- REST `match-policies` (`r.URL.Query().Get`) — first-win.

For a tool whose entire job is to prove policy behavior, a silent
wrong-packet verdict is a correctness bug. Fail-closed-on-ambiguity is
the right posture.

Two related gaps in the same fail-closed theme:

- The remote `test policy` serializes selectors into a comma/equals
  `test-policy:` text topic, which cannot round-trip a valid zone name
  that itself contains a comma or equals (config permits such a name —
  only exact reserved tokens are rejected in
  `compiler_validate_strict.go`). It misparsed the query into bogus
  segments instead of a clear error.
- REST `matchPoliciesHandler` returned 200 default-deny in the
  `cfg == nil` branch BEFORE any grammar validation, so a malformed query
  returned 200 during the boot window monitors poll but 400 once a config
  existed.

## Fix (fail-closed, consistent across all surfaces)

- `policymatch.ParseSelectorArgs` — a `seen` set in the shared
  `takeValue` helper (every selector is value-taking and routes through
  it exactly once) errors `selector %q specified more than once`. Covers
  all four CLI surfaces at once.
- gRPC `showTestPolicy` — a seen-key guard in the `key=value` loop reports
  the duplicate; set-once `parseErr` preserves an earlier unknown-selector
  error and a malformed segment does not poison the seen set.
- REST `matchPoliciesHandler` — a `len(q[key]) > 1` guard returns 400,
  and all grammar validation now runs BEFORE the `cfg == nil` verdict so
  a malformed boot-window query returns 400 consistently (a well-formed
  no-config query still returns the 200 fail-closed default-deny).
- Remote `test policy` (`cmd/cli`) — rejects an un-round-trippable
  comma/equals zone at the serialization boundary with a clear error
  pointing at `show security match-policies` (typed RPC, no delimiter
  fragility). Local `test policy` evaluates in-process and is unaffected.

A duplicate is an error even when the repeated value is identical — the
ambiguity is in the query shape, not the value.

## Tests (RED-on-revert, all surfaces)

- `pkg/policymatch` — every duplicate selector errors; a single
  occurrence still parses.
- `pkg/cli` — both local surfaces propagate the duplicate error.
- `cmd/cli` — both remote surfaces reject a duplicate and issue no RPC;
  a comma/equals zone errors before any RPC.
- `pkg/grpcapi` — the text topic reports the duplicate and produces no
  "Policy match".
- `pkg/api` — duplicate scalar params return 400; malformed / duplicate /
  missing-zone / invalid-IP queries return 400 even with no active
  config; a well-formed no-config query stays 200 default-deny.

Each guard was individually neutralized to confirm its surface test goes
red (last-win / first-win / 200-before-validation restored) and green on
restore.

## Validation

`go test ./pkg/policymatch/... ./pkg/cli/... ./cmd/cli/...
./pkg/grpcapi/... ./pkg/api/...` green; `go build ./...`, gofmt, go vet
clean on all changed files (pre-existing gofmt/vet flags on
`pkg/cli/cli.go` and `cmd/cli/monitor.go` are untouched by this PR).

Docs: `docs/junos-cli-reference.md` Policy Simulator section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
