### PR TITLE
lo0 kernel nftables mirror: fail closed on unknown terminating action + warn on PBR term (#3724 M08/M04)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25563,3 +25563,36 @@ top.
     entry + dedup + INFO recovery via slog capture), pkg/api/
     metrics_host_inbound_addressless_3698_test.go (gauge emitted with dataplane
     unloaded, scoped zone absent, nil-store no-panic)
+
+## 2026-07-01 — #3724 lo0 kernel nftables mirror fail-closed hardening (M08 + M04)
+
+- **Timestamp**: 2026-07-01
+- **Action**: M08 — make the kernel lo0 nftables mirror FAIL CLOSED for an
+  unknown / unhandled non-empty terminating action. `nftRulesFromTerm` mapped
+  any non-`discard` action to nft `accept` (fail-OPEN); the Rust filter compiler
+  maps an unknown action to `FilterAction::Discard`. On a tolerant load / peer
+  session-sync / mixed-version snapshot a future action string in `term.Action`
+  would be ADMITTED by the kernel-PRIMARY lo0 chain while userspace-dp drops it —
+  a control-plane fail-open. Replaced the default-accept with a switch:
+  discard→drop, accept/""(PBR)→accept, any other non-empty→drop + slog.Warn.
+- **File(s)**: pkg/daemon/daemon_nft.go (nftRulesFromTerm terminating-verdict
+  switch), pkg/daemon/lo0_filter_test.go
+  (TestNftRuleFromTermUnknownActionFailsClosed — RED on revert)
+- **Timestamp**: 2026-07-01
+- **Action**: M04 — emit a commit WARNING for a lo0 input-filter
+  `then routing-instance` (PBR) term. It terminates as accept on the kernel
+  mirror (verdict honored) but the kernel `hook input` chain cannot perform the
+  route selection; the operator was never told. Added a routing-instance append
+  to validateLo0FilterKernelMirrorWarnings.
+- **File(s)**: pkg/config/compiler_validate_warn.go
+  (validateLo0FilterKernelMirrorWarnings), pkg/config/
+  compiler_lo0_mirror_modifiers_3445_test.go
+  (TestLo0FilterKernelMirrorRoutingInstanceWarns — RED on revert)
+- **Timestamp**: 2026-07-01
+- **Action**: Documented the fail-closed invariant + M04 warning in the daemon
+  README lo0 filter section. Left M06/M07/M09 (log rate-limit / nft counter
+  merge / log-prefix control-byte sanitize) as noted follow-ups per issue. Both
+  RED-on-revert proofs verified; go test ./pkg/dataplane/... ./pkg/daemon/
+  ./pkg/config/ green; go build ./... green; gofmt + vet clean.
+- **File(s)**: pkg/daemon/README.md (lo0 input filter — unknown-action
+  fail-closed invariant + routing-instance warning)

--- a/pkg/config/compiler_lo0_mirror_modifiers_3445_test.go
+++ b/pkg/config/compiler_lo0_mirror_modifiers_3445_test.go
@@ -53,6 +53,40 @@ func TestLo0FilterKernelMirrorWarns(t *testing.T) {
 	}
 }
 
+// TestLo0FilterKernelMirrorRoutingInstanceWarns pins #3724 M04: a
+// routing-instance (policy-based routing) term on an lo0 input filter commits
+// successfully and terminates as accept on the kernel mirror (daemon_nft.go
+// terminate-as-accept), but the kernel `hook input` chain cannot perform the
+// route selection. It must emit a commit WARNING naming the term and the
+// routing-instance so the operator knows the PBR route selection is silently not
+// honored on the PRIMARY host-bound path.
+//
+// Fail-on-revert: removing the M04 routing-instance append in
+// validateLo0FilterKernelMirrorWarnings removes the warning and this test fails.
+func TestLo0FilterKernelMirrorRoutingInstanceWarns(t *testing.T) {
+	cfg := compileSetLinesT(t, []string{
+		"set system dataplane-type userspace",
+		"set routing-instances mgmt-ri instance-type forwarding",
+		"set firewall family inet filter lo0in term pbr from protocol tcp",
+		"set firewall family inet filter lo0in term pbr then routing-instance mgmt-ri",
+		"set interfaces lo0 unit 0 family inet filter input lo0in",
+	})
+
+	found := false
+	for _, w := range ValidateConfig(cfg) {
+		if strings.Contains(w, "kernel lo0 input mirror") &&
+			strings.Contains(w, `"pbr"`) &&
+			strings.Contains(w, "routing-instance mgmt-ri") &&
+			strings.Contains(w, "route selection") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected lo0 kernel-mirror routing-instance warning for term %q, got: %v", "pbr", ValidateConfig(cfg))
+	}
+}
+
 // TestLo0FilterKernelMirrorCommitSucceeds confirms the warning never fail-closes
 // the commit: these modifiers are valid Junos and must be accepted (warn, never
 // reject) so a previously-committed config is never bricked.

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -1042,6 +1042,26 @@ func validateLo0FilterKernelMirrorWarnings(cfg *Config) []string {
 						"dataplane",
 					family, filterName, term.Name, m.kind, m.val))
 			}
+			// #3724 M04: a routing-instance (policy-based routing) term terminates
+			// as ACCEPT on the kernel lo0 input mirror (daemon_nft.go
+			// terminate-as-accept, #3427). The accept VERDICT is honored, but the
+			// kernel `hook input` chain cannot perform the route-selection the term
+			// requests. Warn so the operator knows the PBR route selection is
+			// silently NOT performed on the primary host-bound path; userspace-dp
+			// remains authoritative for lo0-filtered traffic that reaches the XSK.
+			// Not folded into the mods loop above because that loop's message says
+			// the modifier "cannot be honored", whereas here the verdict IS honored
+			// and only the route selection is dropped.
+			if term.RoutingInstance != "" {
+				warnings = append(warnings, fmt.Sprintf(
+					"firewall family %s filter %q term %q `then routing-instance %s` "+
+						"terminates as accept on the kernel lo0 input mirror (nftables "+
+						"xpf_lo0, the PRIMARY enforcement for host-bound traffic): the "+
+						"verdict is honored but the kernel input hook cannot perform the "+
+						"route selection; policy-based routing applies only to "+
+						"lo0-filtered traffic that reaches the userspace dataplane",
+					family, filterName, term.Name, term.RoutingInstance))
+			}
 		}
 	}
 	emit("inet", cfg.System.Lo0FilterInputV4, cfg.Firewall.FiltersInet[cfg.System.Lo0FilterInputV4])

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -343,6 +343,21 @@ never lock an operator out of a remote box it manages.
   `TestLo0PayloadFallThroughDoesNotShadowDiscard`, and
   `TestLo0PayloadRoutingInstanceTerminatesAcceptNoOverDrop` (the over-drop
   counterexample).
+  **Unknown terminating action fails CLOSED (#3724 M08):** the terminating
+  verdict switch mirrors the Rust filter compiler
+  (`userspace-dp/src/filter/compiler.rs`) EXACTLY — `discard` → `drop`,
+  `accept` (and the empty-action routing-instance PBR term) → `accept`, and any
+  OTHER non-empty action → `drop`. An unknown / unhandled action cannot arrive
+  through the CLI commit path (`validateFilterActionsStrict` plus the
+  `UnknownActions` capture in `compileFilterThen` leave `term.Action == ""`), but
+  a tolerant load / peer session-sync / mixed-version snapshot can carry a future
+  action string directly in `term.Action`. The Rust compiler fails such a term
+  CLOSED to `FilterAction::Discard`; the kernel mirror — the PRIMARY host-bound
+  enforcement — MUST match, or it would ADMIT host-bound traffic userspace-dp
+  drops (a mixed-version control-plane fail-OPEN). The pre-#3724 default arm
+  rendered nft `accept` for any non-`discard` action; it now renders `drop` and
+  logs the drift. Pinned by `TestNftRuleFromTermUnknownActionFailsClosed`
+  (known accept/discard still map correctly; unknown actions render `drop`).
 
   **Non-terminating `then` modifier policy (#3445):** the kernel lo0 chain is
   the PRIMARY enforcement for host-bound traffic, so a term's non-terminating
@@ -367,6 +382,13 @@ never lock an operator out of a remote box it manages.
     stays authoritative for whatever lo0-filtered traffic actually reaches the
     XSK. `then loss-priority` is already reported globally inert by
     `validateFilterLossPriorityWarnings` (#2507), which subsumes the mirror gap.
+    **`then routing-instance` (#3724 M04):** a PBR term terminates as `accept` on
+    the kernel mirror (see the disposition bullet) — the verdict IS honored, but
+    the kernel `hook input` chain cannot perform the route selection the term
+    requests. `validateLo0FilterKernelMirrorWarnings` warns at commit that the PBR
+    route selection is silently not performed on the primary host-bound path
+    (userspace-dp stays authoritative for lo0-filtered traffic that reaches the
+    XSK). Pinned by `TestLo0FilterKernelMirrorRoutingInstanceWarns`.
   - **`reject` (#3445 H10):** faithfully mirrors the userspace reject-reply
     synthesis (`userspace-dp` `poll_descriptor/reject_reply.rs`) — a TCP RST for
     TCP, an ICMP/ICMPv6 administratively-prohibited Destination Unreachable for

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -1168,12 +1168,38 @@ func nftRulesFromTerm(term *config.FirewallFilterTerm, family string, prefixList
 		}
 	}
 
-	// Terminating verdict: discard -> drop (silent), accept -> accept, and the
-	// empty-action-with-routing-instance PBR term -> terminate-as-accept (#3427).
-	// Any other explicit action is unexpected for a committed config; keep the
-	// historical accept default rather than emit garbage.
-	action := "accept"
-	if term.Action == "discard" {
+	// Terminating verdict. Mirror the Rust filter compiler's action mapping
+	// (userspace-dp/src/filter/compiler.rs) EXACTLY so the kernel-PRIMARY lo0
+	// input chain can never diverge from the userspace evaluator on a matched
+	// terminating term:
+	//   - discard             -> drop   (silent)
+	//   - accept              -> accept
+	//   - ""  (routing-instance PBR terminate-as-accept, #3427) -> accept
+	//   - any OTHER non-empty -> drop   (FAIL CLOSED, #3724 M08)
+	//
+	// An unknown / unhandled NON-EMPTY action can only reach here from a tolerant
+	// load, a peer session-sync, or a mixed-version snapshot: the strict commit
+	// gate (validateFilterActionsStrict, plus the UnknownActions capture in
+	// compileFilterThen which leaves term.Action == "") rejects an unknown `then`
+	// token before it is ever persisted through the CLI path. The Rust compiler
+	// fails such a term CLOSED to FilterAction::Discard; the kernel mirror MUST
+	// match that. The pre-#3724 code defaulted the unknown case to nft `accept`,
+	// which fails OPEN on the primary host-bound enforcement path — the kernel
+	// would ADMIT host-bound traffic the operator's lo0 filter meant to drop
+	// while userspace-dp drops it (a mixed-version control-plane fail-open). Fail
+	// closed to `drop` and log the drift so the divergence is observable.
+	var action string
+	switch term.Action {
+	case "discard":
+		action = "drop"
+	case "accept", "":
+		// "" reaches here only for the routing-instance (PBR) term — a plain
+		// empty-action fall-through returned above. Its filter verdict is accept
+		// (userspace terminates-as-accept; route selection stays userspace-only).
+		action = "accept"
+	default:
+		slog.Warn("lo0 kernel nftables mirror: unknown terminating action, failing closed to drop (snapshot/version drift)",
+			"term", term.Name, "action", term.Action)
 		action = "drop"
 	}
 	return []string{joinNftFields(match, modStr, action)}

--- a/pkg/daemon/lo0_filter_test.go
+++ b/pkg/daemon/lo0_filter_test.go
@@ -381,6 +381,54 @@ func TestNftRuleFromTermRejectVsDiscard(t *testing.T) {
 	}
 }
 
+// TestNftRuleFromTermUnknownActionFailsClosed pins #3724 M08: an unknown /
+// unhandled NON-EMPTY terminating action on an lo0 filter term must render to
+// nft `drop`, NOT `accept`. The kernel lo0 chain is the PRIMARY enforcement for
+// host-bound traffic (the XDP shim shunts it to the kernel before userspace),
+// and the Rust filter compiler fails an unknown action CLOSED to
+// FilterAction::Discard (userspace-dp/src/filter/compiler.rs). An unknown
+// action cannot arrive through the CLI commit path (validateFilterActionsStrict
+// / the UnknownActions capture reject it, leaving term.Action == ""), but a
+// tolerant load / peer session-sync / mixed-version snapshot can carry a
+// future action string in term.Action directly. Rendering that to nft `accept`
+// is a mixed-version control-plane fail-open — the kernel would ADMIT host-bound
+// traffic userspace-dp drops. RED on revert: the pre-#3724 default arm rendered
+// `accept` for any non-discard action, so these rows asserted the fail-open and
+// would fail once fixed; they now assert the fail-closed `drop`. The known
+// accept/discard mappings are re-asserted so the fix does not over-drop.
+func TestNftRuleFromTermUnknownActionFailsClosed(t *testing.T) {
+	prefixLists := map[string]*config.PrefixList{}
+
+	tests := []struct {
+		name       string
+		action     string
+		wantAction string
+	}{
+		// Known terminating actions still map correctly.
+		{"known-accept", "accept", "accept"},
+		{"known-discard", "discard", "drop"},
+		// Unknown / future action strings a mixed-version snapshot could carry.
+		// All must FAIL CLOSED to drop (mirroring Rust FilterAction::Discard),
+		// never fail open to accept.
+		{"unknown-redirect", "redirect", "drop"},
+		{"unknown-sample", "sample-and-accept", "drop"},
+		{"unknown-garbage", "frobnicate", "drop"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			term := &config.FirewallFilterTerm{
+				Name:   tt.name,
+				Action: tt.action,
+			}
+			rule := nftRule(t, term, "ip", prefixLists)
+			if rule != tt.wantAction {
+				t.Errorf("action %q: got %q, want %q (unknown must fail CLOSED to drop, #3724 M08)", tt.action, rule, tt.wantAction)
+			}
+		})
+	}
+}
+
 func TestNftRuleFromTermMultiplePorts(t *testing.T) {
 	prefixLists := map[string]*config.PrefixList{}
 


### PR DESCRIPTION
Closes #3724

## Lead (M08): unknown terminating action failed open on the kernel-PRIMARY lo0 chain

The kernel lo0 nftables mirror (`inet xpf_lo0`, `pkg/daemon/daemon_nft.go`)
is the PRIMARY enforcement of the lo0 input filter for ordinary host-bound
traffic — the XDP shim shunts that traffic to the Linux kernel before
userspace-dp sees it, so a wrong terminating verdict here is real
control-plane mis-enforcement.

`nftRulesFromTerm` mapped any non-`discard` terminating action to nft
`accept` (an unconditional fail-open default):

```go
action := "accept"
if term.Action == "discard" { action = "drop" }
```

The Rust filter compiler (`userspace-dp/src/filter/compiler.rs`) maps an
unknown non-empty action string to `FilterAction::Discard`. The strict
commit gate (`validateFilterActionsStrict`, plus the `UnknownActions`
capture in `compileFilterThen` which leaves `term.Action == ""`) rejects an
unknown `then` token before it is ever persisted through the CLI path, so an
unknown non-empty `term.Action` can only arrive from a **tolerant load, a
peer session-sync, or a mixed-version snapshot**. In that case the kernel
lo0 chain would ADMIT host-bound traffic the operator's filter meant to drop
while userspace-dp drops it — a mixed-version fail-open on the control plane.

**Fix:** replace the default-accept with a switch that mirrors the Rust
action mapping exactly:

- `discard` → `drop`
- `accept` (and the empty-action routing-instance PBR terminate-as-accept, #3427) → `accept`
- any OTHER non-empty action → `drop` (**fail closed**) + `slog.Warn` recording the drift

The explicit accept/discard/reject and next-term/fall-through mappings are
preserved; the lifeline exemption (#3682) is untouched (it lives on the
host-inbound chain, not the lo0 renderer).

## M04: routing-instance PBR term got no operator warning

A lo0 `then routing-instance <x>` term terminates as accept on the kernel
mirror (the verdict is honored) but the kernel `hook input` chain cannot
perform the route selection. `validateLo0FilterKernelMirrorWarnings`
previously warned for policer / dscp-rewrite / forwarding-class only. Added
a routing-instance append (distinct message: verdict honored, route
selection not performed) so the operator is told the PBR side effect is
silently not honored on the primary host-bound path. WARN-only — never an
error, so a previously committed config is never bricked.

## Follow-ups (per issue, not in this PR)

M06 (mirrored-log rate limiter), M07 (nft counter merge into firewall
counter status), M09 (log-prefix control-byte sanitize) are left as noted
follow-ups.

## RED-on-revert proof

- `TestNftRuleFromTermUnknownActionFailsClosed` (`pkg/daemon`): unknown
  actions render `accept` on the pre-fix default → RED; known accept/discard
  re-asserted so the fix does not over-drop.
- `TestLo0FilterKernelMirrorRoutingInstanceWarns` (`pkg/config`): removing
  the M04 append leaves no routing-instance warning → RED.

Both verified RED with the fix reverted, then restored green.

## Validation

- `go test ./pkg/dataplane/... ./pkg/daemon/ ./pkg/config/` — green
- `go build ./...` — green
- `gofmt -l` + `go vet` on changed files — clean
- Docs: daemon README lo0 filter section updated (fail-closed invariant + PBR warning); `_Log.md` recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
