### PR TITLE
ddns/surface-a: gate the DHCP address source through IsPublicAddr (#3732)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25596,3 +25596,28 @@ top.
   ./pkg/config/ green; go build ./... green; gofmt + vet clean.
 - **File(s)**: pkg/daemon/README.md (lo0 input filter — unknown-action
   fail-closed invariant + routing-instance warning)
+
+## 2026-07-01 — #3732 DDNS Surface A DHCP source runs the IsPublicAddr public-address gate (fail-closed)
+
+- **Timestamp**: 2026-07-01
+- **Action**: Surface A router/interface DDNS applied the ddns.IsPublicAddr
+  globally-routable-unicast gate to the interface (selectInterfaceAddr), static
+  (staticUnitAddr), and checkip (parseCheckIPBody) address sources but NOT to
+  the DHCP source — a WAN handed a non-public DHCP lease (CGNAT 100.64/10,
+  RFC1918, ULA fc00::/7, documentation, other IANA special-purpose ranges)
+  published that unroutable/private address to public DNS, a security fail-open
+  and internal-addressing leak. FIX: the AddressSourceDHCP branch now runs the
+  valid lease address through ddns.IsPublicAddr; a non-public lease is a
+  DEFINITIVE "no publishable address of this family" (Addr invalid, ok=true) so
+  the engine WITHDRAWS any previously-published record rather than leaking a
+  private one, and warns once at slog.Warn (matching staticUnitAddr). A public
+  lease still publishes unchanged (no over-gating). Documented the
+  public-gate-on-all-sources invariant in the DDNS design plan §5.3.
+  RED-on-revert: removing the gate flips the v4-private / v4-CGNAT / v6-ULA
+  cases to publishing the private address (test fails); public cases stay green.
+  go test ./pkg/daemon/ ./pkg/ddns/ green; go build ./... green; gofmt + vet
+  clean.
+- **File(s)**: pkg/daemon/daemon_ddns_surface_a.go (AddressSourceDHCP branch),
+  pkg/daemon/daemon_ddns_surface_a_test.go
+  (TestSurfaceAObserverDHCPPublicGate — RED on revert),
+  docs/research/ddns-world-class/plan.md (§5.3 public-address gate invariant)

--- a/docs/research/ddns-world-class/plan.md
+++ b/docs/research/ddns-world-class/plan.md
@@ -414,6 +414,23 @@ SeenAt}` from ordered sources (inadyn idea #6), per configured binding:
 Selection is per-scope config: `address-source interface|dhcp|checkip`
 (default `interface`). v4 and v6 are observed and published independently.
 
+**Public-address gate — invariant across ALL Surface A sources.** Every
+address source runs its observed address through the SAME
+`ddns.IsPublicAddr` globally-routable-unicast predicate before it can be
+published, so a non-public address (RFC1918, CGNAT `100.64/10`, ULA
+`fc00::/7`, loopback, link-local, documentation, and every other IANA
+special-purpose range) is NEVER published to public DNS. The gate lives at:
+`parseCheckIPBody` (checkip, `pkg/ddns/checkip.go`), `selectInterfaceAddr`
+(interface, `pkg/daemon/daemon_ddns_surface_a.go`), and `staticUnitAddr`
+(static fallback, same file). The DHCP-lease source applies the same gate
+inline in the `AddressSourceDHCP` branch (#3732) — a WAN legitimately
+handed a CGNAT/RFC1918/ULA lease must not leak it. A non-public observation
+is treated as a DEFINITIVE "no publishable address of this family" (not a
+transient miss), so the engine WITHDRAWS any stale public record rather than
+leaving one pointing at an unroutable address — never publish a non-public
+address, never blackhole. Adding a new Surface A address source MUST route
+its observation through `ddns.IsPublicAddr` too.
+
 For **Surface B** the observation is the existing Kea-memfile lease parser
 (`pkg/dhcpserver/ddns_leases.go`) — unchanged, just emitting `ScopeKey`-
 tagged records.

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -304,6 +304,25 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 			if !a.IsValid() {
 				return ddns.AddressObservation{Source: ddns.AddressSourceDHCP}, true
 			}
+			// Public-address gate (#3732): a DHCP-learned WAN address is NOT
+			// guaranteed globally routable. CGNAT (100.64/10), RFC1918, ULA
+			// (fc00::/7), documentation, and other IANA special-purpose ranges
+			// are all legitimately handed out over DHCP. Publishing one to a
+			// public DNS provider leaks internal addressing AND points the
+			// A/AAAA record at an unroutable address. The interface
+			// (selectInterfaceAddr), static (staticUnitAddr), and checkip
+			// (parseCheckIPBody) sources all apply this SAME ddns.IsPublicAddr
+			// gate — the DHCP source was the one Surface A source that skipped
+			// it. A non-public lease is a DEFINITIVE "no publishable address of
+			// this family" (matching the interface source's non-public
+			// handling), so the engine WITHDRAWS any previously-published
+			// record rather than leaving a stale public one — never publish a
+			// non-public address, never blackhole.
+			if !ddns.IsPublicAddr(a) {
+				slog.Warn("surface-a: skipping non-public dhcp lease address",
+					"address", a.String(), "interface", linuxName)
+				return ddns.AddressObservation{Source: ddns.AddressSourceDHCP}, true
+			}
 			return ddns.AddressObservation{Addr: a, Source: ddns.AddressSourceDHCP}, true
 
 		default: // interface

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/ddns"
+	"github.com/psaab/xpf/pkg/dhcp"
 )
 
 // #2691 P2 daemon-level Surface A tests: scope construction from the committed
@@ -607,4 +608,89 @@ func TestForceDDNSUpdateOwnerGate(t *testing.T) {
 			t.Fatal("a node MASTER for >=1 RG must accept the force-now verb")
 		}
 	})
+}
+
+// TestSurfaceAObserverDHCPPublicGate is the #3732 fail-closed regression: the
+// DHCP address source must run its lease address through the SAME
+// ddns.IsPublicAddr gate the interface / static / checkip sources apply. A
+// non-public DHCP lease (RFC1918, CGNAT 100.64/10, ULA fc00::/7) must NOT be
+// published to public DNS — it becomes a DEFINITIVE "no address of this family"
+// observation (Addr invalid, ok=true) so the engine withdraws any stale record
+// rather than publishing an unroutable/private one. A globally-routable lease
+// still publishes unchanged (no over-gating).
+//
+// RED-on-revert: drop the ddns.IsPublicAddr gate from the DHCP branch and the
+// private / CGNAT / ULA cases below flip to publishing the private address
+// (obs.Addr becomes valid), failing this test.
+func TestSurfaceAObserverDHCPPublicGate(t *testing.T) {
+	store := testStoreWithSetConfig(t, []string{
+		"set interfaces ge-0/0/2 unit 0 family inet dynamic-dns provider p",
+		"set interfaces ge-0/0/2 unit 0 family inet dynamic-dns hostname wan.example.net",
+		"set interfaces ge-0/0/2 unit 0 family inet dynamic-dns address-source dhcp",
+		"set interfaces ge-0/0/2 unit 0 family inet6 dynamic-dns provider p",
+		"set interfaces ge-0/0/2 unit 0 family inet6 dynamic-dns hostname wan6.example.net",
+		"set interfaces ge-0/0/2 unit 0 family inet6 dynamic-dns address-source dhcp",
+		"set system services dynamic-dns provider p backend rfc2136",
+		"set system services dynamic-dns provider p update-server 192.0.2.53",
+	})
+	cfg := store.ActiveConfig()
+
+	ifc := cfg.Interfaces.Interfaces["ge-0/0/2"]
+	if ifc == nil || ifc.Units[0] == nil {
+		t.Fatalf("test config did not produce ge-0/0/2 unit 0")
+	}
+	linuxName := surfaceALinuxIfName(cfg, "ge-0/0/2", ifc.Units[0])
+
+	cases := []struct {
+		name     string
+		family   ddns.Family
+		af       dhcp.AddressFamily
+		lease    string // lease address (CIDR); "" ⇒ no lease seeded
+		wantPub  bool   // true ⇒ expect the address published
+		wantAddr string // expected published bare address when wantPub
+	}{
+		{"v4 private rfc1918 not published", ddns.FamilyV4, dhcp.AFInet, "192.168.7.10/24", false, ""},
+		{"v4 cgnat not published", ddns.FamilyV4, dhcp.AFInet, "100.64.5.10/24", false, ""},
+		{"v4 public published", ddns.FamilyV4, dhcp.AFInet, "8.8.8.8/24", true, "8.8.8.8"},
+		{"v6 ula not published", ddns.FamilyV6, dhcp.AFInet6, "fd12:3456::1/64", false, ""},
+		{"v6 public published", ddns.FamilyV6, dhcp.AFInet6, "2606:4700:4700::1111/64", true, "2606:4700:4700::1111"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := dhcp.NewManagerForTesting(nil)
+			if tc.lease != "" {
+				mgr.SeedLeaseForTesting(linuxName, tc.af,
+					&dhcp.Lease{Address: netip.MustParsePrefix(tc.lease)})
+			}
+			d := &Daemon{store: store, dhcp: mgr}
+			scope := ddns.SurfaceAScope{
+				Key: ddns.ScopeKey{
+					Family:    tc.family,
+					Interface: "ge-0/0/2",
+					Unit:      0,
+				},
+				Source: ddns.AddressSourceDHCP,
+				FQDN:   "wan.example.net",
+			}
+			obs, ok := d.surfaceAObserver(cfg)(scope)
+			if !ok {
+				t.Fatalf("DHCP observation must be definitive (ok=true); got ok=false")
+			}
+			if tc.wantPub {
+				if !obs.Addr.IsValid() {
+					t.Fatalf("public lease %s must be published; got no address", tc.lease)
+				}
+				if obs.Addr.String() != tc.wantAddr {
+					t.Fatalf("published address = %s, want %s", obs.Addr, tc.wantAddr)
+				}
+			} else {
+				if obs.Addr.IsValid() {
+					t.Fatalf("non-public lease %s must NOT be published; "+
+						"got %s (public gate bypassed — #3732 fail-open)",
+						tc.lease, obs.Addr)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Closes #3732.

Surface A router/interface DDNS ran the `ddns.IsPublicAddr`
globally-routable-unicast gate on the **interface**, **static**, and
**checkip** address sources, but the **DHCP-lease** source returned the
lease address with no such check. A WAN legitimately handed a non-public
DHCP lease — CGNAT (`100.64/10`), RFC1918, ULA (`fc00::/7`),
documentation, or any other IANA special-purpose range — therefore
published that unroutable/private address to public DNS via
`address-source dhcp`. This is a security fail-open (the class the
public-address invariant of #2776/#2774/#2975 was built to prevent) plus
a minor internal-addressing leak, and it was the one Surface A source
missing the gate.

## Fix (fail-closed)

The `AddressSourceDHCP` branch in `surfaceAObserver`
(`pkg/daemon/daemon_ddns_surface_a.go`) now runs the valid lease address
through `ddns.IsPublicAddr` before returning a publishable observation. A
non-public lease is treated as a DEFINITIVE "no publishable address of
this family" (`Addr` invalid, `ok=true`) — matching the interface
source's non-public handling — so the engine **withdraws** any
previously-published record rather than leaving a stale public record
pointing at an unroutable address (never publish a non-public address,
never blackhole). The skip is surfaced once at `slog.Warn`, matching the
static fallback. A globally-routable lease still publishes unchanged, so
there is **no over-gating**.

## Validation

- `TestSurfaceAObserverDHCPPublicGate` table test: v4 RFC1918, v4 CGNAT,
  v6 ULA leases are NOT published; a v4 public (`8.8.8.8`) and a v6 public
  (`2606:4700:4700::1111`) lease ARE published.
- **RED-on-revert:** removing the gate flips the three non-public cases to
  publishing the private address (test fails); the public cases stay green.
- `go test ./pkg/daemon/ ./pkg/ddns/` green; `go build ./...` green;
  `gofmt` + `go vet` clean on changed files.
- Documented the public-gate-on-all-sources invariant in the DDNS design
  plan (`docs/research/ddns-world-class/plan.md` §5.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi