### PR TITLE
ddns: fail closed when checkip source bind cannot be honored (#3733)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25674,3 +25674,32 @@ top.
   pkg/daemon/daemon_ddns_surface_a_test.go
   (TestSurfaceAObserverDHCPPublicGate — RED on revert),
   docs/research/ddns-world-class/plan.md (§5.3 public-address gate invariant)
+
+- **Timestamp**: 2026-07-01
+- **Action**: (#3733) DDNS checkip source-bind FAIL-CLOSED. Residual of #2846:
+  the Surface A checkip probe is bound to the provider's configured
+  source-address/interface/VRF so a multi-WAN scope egresses from its own
+  uplink, but the daemon's bind-error branch only LOGGED the failure and STILL
+  ran the probe with the UNBOUND default client — so the query egressed via the
+  kernel default route and returned the DEFAULT WAN's public IP, which was then
+  published for the wrong scope (the wrong-WAN publication class #2846 closed).
+  checkip is an address oracle → must be fail-closed. FIX: new
+  ddns.CheckIPBound(ctx, client, url, wantV4, allowlist, bindErr) centralizes
+  the invariant — bindErr != nil (a source was requested but could not be
+  honored) returns (zero, false): a TRANSIENT observation (no publish, never a
+  withdraw), never a default-route fallback. bindErr == nil (no source
+  requested) probes exactly as before → default-route deployments unchanged.
+  The gate is exact: resolveProviderBindConfig errors ONLY on a configured but
+  unparseable source-address; the other source-unavailable cases (address not
+  assigned, dest-iface/VRF down) surface as a DIAL error inside CheckIP which
+  already returns ok=false. Daemon threads berr through CheckIPBound and
+  rate-limits the fail-closed warning once per (provider, bind-error) via a new
+  surfaceACheckIPSourceBindWarned sync.Map. RED-on-revert verified: neutering
+  the bindErr gate makes the fail-closed test publish the wrong-WAN IP
+  93.184.216.34 (test fails); no-source + honored-source paths stay green. go
+  test ./pkg/ddns/... green; go build ./... green; gofmt + vet clean.
+- **File(s)**: pkg/ddns/checkip.go (CheckIPBound + NewCheckIPClient doc),
+  pkg/ddns/checkip_sourcebind_failclosed_3733_test.go (RED on revert),
+  pkg/daemon/daemon.go (surfaceACheckIPSourceBindWarned field),
+  pkg/daemon/daemon_ddns_surface_a.go (fail-closed observer wiring),
+  docs/research/ddns-world-class/plan.md (§5.3 checkip fail-closed invariant)

--- a/docs/research/ddns-world-class/plan.md
+++ b/docs/research/ddns-world-class/plan.md
@@ -431,6 +431,31 @@ leaving one pointing at an unroutable address — never publish a non-public
 address, never blackhole. Adding a new Surface A address source MUST route
 its observation through `ddns.IsPublicAddr` too.
 
+**checkip source-bind is FAIL-CLOSED — invariant (#2846 + #3733).** The
+checkip probe binds to the provider's configured source-address /
+destination-interface / routing-instance (#2846) so a multi-WAN scope's
+"what is my IP" query egresses from its OWN uplink, not the kernel default
+route. checkip is an address ORACLE: the IP it returns is published as the
+scope's A/AAAA record, so probing through the wrong egress returns a
+DIFFERENT WAN's public IP and republishes the wrong-WAN class #2846 closed.
+Therefore, when a source WAS requested but could NOT be honored, the probe
+MUST fail closed — never fall back to the default route. The gate lives in
+`ddns.CheckIPBound` (`pkg/ddns/checkip.go`): the daemon threads the
+source-bind resolution error (`SurfaceAManager.CheckIPClient`) through it,
+and a non-nil error yields `(zero, false)` — a TRANSIENT observation (no
+publish, never a withdraw), exactly like a checkip fetch miss. The gate is
+exact: `resolveProviderBindConfig` errors ONLY when a source-address is
+configured but does not parse (a source requested but unhonorable); the
+other "source unavailable" cases (address not currently assigned, dest-
+interface / VRF down) surface as a DIAL error inside `CheckIP`, which
+already returns `ok=false`. A scope with NO source configured is unchanged:
+`bindErr == nil`, so the probe uses the default route as before. The daemon
+rate-limits the fail-closed warning once per (provider, bind-error) via
+`surfaceACheckIPSourceBindWarned` so a persistent misconfig surfaces
+without flooding the per-tick observer. Fail-open to the default route
+remains acceptable for generic HTTP UPDATE backends (they carry a
+credential and target a fixed provider host); the checkip oracle does not.
+
 For **Surface B** the observation is the existing Kea-memfile lease parser
 (`pkg/dhcpserver/ddns_leases.go`) — unchanged, just emitting `ScopeKey`-
 tagged records.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -123,6 +123,13 @@ type Daemon struct {
 	// drop must not log every tick. Keyed by "<provider>\x00<allowlist-string>"
 	// so a corrected commit re-arms the warning.
 	surfaceACheckIPAllowlistWarned sync.Map
+	// surfaceACheckIPSourceBindWarned dedups the once-per-(provider,bind-error)
+	// runtime log emitted when the checkip probe fails CLOSED because a
+	// configured source-address/interface/VRF could not be honored (#3733). The
+	// observer runs per poll-tick, so a persistent misconfig must not log every
+	// tick. Keyed by "<provider>\x00<bind-error>" so a corrected commit re-arms
+	// the warning.
+	surfaceACheckIPSourceBindWarned sync.Map
 	// #2239 HA DHCP-server lease sync (PATH C). The push loop runs on the
 	// RG-MASTER, reads the active lease set (Kea control socket → memfile
 	// fallback), and replicates it over the cluster sync channel. The standby

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -124,11 +124,13 @@ type Daemon struct {
 	// so a corrected commit re-arms the warning.
 	surfaceACheckIPAllowlistWarned sync.Map
 	// surfaceACheckIPSourceBindWarned dedups the once-per-(provider,bind-error)
-	// runtime log emitted when the checkip probe fails CLOSED because a
-	// configured source-address/interface/VRF could not be honored (#3733). The
-	// observer runs per poll-tick, so a persistent misconfig must not log every
-	// tick. Keyed by "<provider>\x00<bind-error>" so a corrected commit re-arms
-	// the warning.
+	// runtime log emitted when the checkip probe fails CLOSED because the
+	// provider's configured source-address failed to parse (#3733). That parse
+	// failure is the ONLY bind-resolution error CheckIPClient returns; a dead
+	// destination-interface / VRF surfaces later as a dial error inside CheckIP
+	// (already ok=false), not here. The observer runs per poll-tick, so a
+	// persistent misconfig must not log every tick. Keyed by
+	// "<provider>\x00<bind-error>" so a corrected commit re-arms the warning.
 	surfaceACheckIPSourceBindWarned sync.Map
 	// #2239 HA DHCP-server lease sync (PATH C). The push loop runs on the
 	// RG-MASTER, reads the active lease set (Kea control socket → memfile

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -269,18 +269,30 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 			}
 			// Bind the checkip probe to the provider's configured source-address /
 			// interface / VRF (#2846) so it egresses from the same source as the
-			// DDNS updates — not the kernel default route. A malformed source-
-			// address yields the unbound default client (the commit warning already
-			// fired); the probe is a transient observation, never a withdraw.
-			// Reuse the manager's cached per-binding HTTP client (#2904) so the
-			// recurring checkip probe shares the keep-alive connection pool with the
-			// DNS-update path instead of rebuilding a transport every reconcile pass.
+			// DDNS updates — not the kernel default route. Reuse the manager's
+			// cached per-binding HTTP client (#2904) so the recurring checkip probe
+			// shares the keep-alive connection pool with the DNS-update path instead
+			// of rebuilding a transport every reconcile pass.
 			client, berr := d.surfaceA.CheckIPClient(scope.Provider)
 			if berr != nil {
-				slog.Warn("ddns surface-a: checkip source bind unusable; probing from default route",
-					"provider", scope.Provider.Name, "err", berr)
+				// FAIL-CLOSED (#3733): a source-address/interface/VRF WAS
+				// configured for this provider but could not be honored (e.g. a
+				// malformed source-address). checkip is an address oracle —
+				// falling back to the kernel default route would egress via a
+				// DIFFERENT WAN and return the WRONG WAN's public IP, republishing
+				// the wrong-WAN class #2846 closed. CheckIPBound (below) refuses to
+				// probe when berr != nil and returns ok=false: a TRANSIENT
+				// observation (no publish, never a withdraw). Log once per
+				// (provider, bind-error) so a persistent misconfig surfaces without
+				// flooding the per-tick observer.
+				key := scope.Provider.Name + "\x00" + berr.Error()
+				if _, dup := d.surfaceACheckIPSourceBindWarned.LoadOrStore(key, struct{}{}); !dup {
+					slog.Warn("ddns surface-a: checkip source bind unusable; "+
+						"skipping probe (fail-closed, not falling back to default route)",
+						"provider", scope.Provider.Name, "err", berr)
+				}
 			}
-			a, ok := ddns.CheckIP(ctx, client, scope.Provider.CheckIPURL, af4, allow)
+			a, ok := ddns.CheckIPBound(ctx, client, scope.Provider.CheckIPURL, af4, allow, berr)
 			if !ok {
 				return ddns.AddressObservation{}, false
 			}

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -275,16 +275,20 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 			// of rebuilding a transport every reconcile pass.
 			client, berr := d.surfaceA.CheckIPClient(scope.Provider)
 			if berr != nil {
-				// FAIL-CLOSED (#3733): a source-address/interface/VRF WAS
-				// configured for this provider but could not be honored (e.g. a
-				// malformed source-address). checkip is an address oracle —
-				// falling back to the kernel default route would egress via a
-				// DIFFERENT WAN and return the WRONG WAN's public IP, republishing
-				// the wrong-WAN class #2846 closed. CheckIPBound (below) refuses to
-				// probe when berr != nil and returns ok=false: a TRANSIENT
-				// observation (no publish, never a withdraw). Log once per
-				// (provider, bind-error) so a persistent misconfig surfaces without
-				// flooding the per-tick observer.
+				// FAIL-CLOSED (#3733): berr means the provider's configured
+				// source-address failed to parse (netip.ParseAddr) — it is the
+				// ONLY bind-resolution error CheckIPClient returns. A dead
+				// destination-interface / VRF does NOT surface here; that becomes
+				// a DIAL error inside CheckIPBound → CheckIP, already ok=false. So
+				// berr specifically = a malformed configured source-address the
+				// bind could not honor. checkip is an address oracle — falling back
+				// to the kernel default route would egress via a DIFFERENT WAN and
+				// return the WRONG WAN's public IP, republishing the wrong-WAN
+				// class #2846 closed. CheckIPBound (below) refuses to probe when
+				// berr != nil and returns ok=false: a TRANSIENT observation (no
+				// publish, never a withdraw). Log once per (provider, bind-error)
+				// so a persistent misconfig surfaces without flooding the per-tick
+				// observer.
 				key := scope.Provider.Name + "\x00" + berr.Error()
 				if _, dup := d.surfaceACheckIPSourceBindWarned.LoadOrStore(key, struct{}{}); !dup {
 					slog.Warn("ddns surface-a: checkip source bind unusable; "+

--- a/pkg/ddns/checkip.go
+++ b/pkg/ddns/checkip.go
@@ -66,13 +66,49 @@ func CheckIP(ctx context.Context, client *http.Client, urlStr string, wantV4 boo
 	return parseCheckIPBody(string(body), wantV4, allowlist)
 }
 
+// CheckIPBound runs the checkip probe through a source-bound HTTP client while
+// enforcing the FAIL-CLOSED source-bind invariant (#3733). bindErr is the
+// source-bind resolution error the caller got when building `client` (via
+// NewCheckIPClient / SurfaceAManager.CheckIPClient) — non-nil when a configured
+// source-address could not be honored, in which case `client` is the UNBOUND
+// default (kernel default route).
+//
+// checkip is an address ORACLE: it discovers the public IP that DNS will point
+// at. Probing through the wrong egress returns a DIFFERENT WAN's public IP, and
+// publishing it republishes exactly the wrong-WAN class #2846 closed. So when a
+// source WAS requested but could not be honored (bindErr != nil), the probe
+// MUST NOT fall back to the default route — it returns (zero, false): a
+// TRANSIENT observation (no publish, never a withdraw), matching CheckIP's own
+// miss semantics. When no source was requested (bindErr == nil — `client` is the
+// intended egress, whether source-bound or unbound-by-config), the probe runs
+// normally.
+//
+// The bindErr gate is exact: the source-bind resolver (resolveProviderBindConfig
+// → resolveBindConfig) returns an error ONLY when a source-address IS configured
+// but does not parse — i.e. a source was requested and could not be honored. A
+// source-address that resolves but is not currently assigned, or a destination-
+// interface / VRF that is down, surfaces later as a DIAL error inside CheckIP,
+// which already returns ok=false (fail-closed) on its own — so this gate is the
+// one residual fall-open the bind-error branch left open.
+func CheckIPBound(ctx context.Context, client *http.Client, urlStr string, wantV4 bool, allowlist []netip.Addr, bindErr error) (netip.Addr, bool) {
+	if bindErr != nil {
+		// Source requested but not honored: fail closed, never probe via the
+		// default route (would return the wrong WAN's public IP).
+		return netip.Addr{}, false
+	}
+	return CheckIP(ctx, client, urlStr, wantV4, allowlist)
+}
+
 // NewCheckIPClient builds the HTTP client a checkip probe should use, bound to
 // the provider's configured source-address / destination-interface / routing-
 // instance (#2846) so the external "what is my IP" query egresses from the SAME
 // source as the DDNS updates do — not the kernel default route. A malformed
 // source-address returns the unbound default client plus the error so the caller
-// can log it and degrade gracefully (a checkip miss is a transient observation,
-// never a withdraw). A nil provider yields the unbound default client, no error.
+// can log it and degrade gracefully. The caller MUST treat that error as
+// fail-closed for the checkip oracle (route the probe through CheckIPBound, which
+// refuses to fall back to the default route, #3733) — the returned unbound
+// client is only for callers whose fall-open is acceptable (generic HTTP update
+// backends). A nil provider yields the unbound default client, no error.
 func NewCheckIPClient(p *config.DDNSProvider) (*http.Client, error) {
 	return newProviderHTTPClient(p)
 }

--- a/pkg/ddns/checkip_sourcebind_failclosed_3733_test.go
+++ b/pkg/ddns/checkip_sourcebind_failclosed_3733_test.go
@@ -1,0 +1,95 @@
+package ddns
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// checkip_sourcebind_failclosed_3733_test.go: FAIL-ON-REVERT coverage for #3733
+// — the checkip probe is an address ORACLE, so a configured-but-unhonorable
+// source binding must fail CLOSED (no probe, no address) rather than falling
+// back to the kernel default route. Before #3733 the daemon logged a warning and
+// STILL probed with the unbound default client, returning the wrong WAN's public
+// IP (the class #2846 was meant to close). CheckIPBound centralizes the gate;
+// these tests go RED if it degrades back to CheckIP's fall-open behavior.
+
+// TestCheckIPBoundFailsClosedOnBindError proves that when a source was requested
+// but could not be honored (bindErr != nil), CheckIPBound does NOT contact the
+// checkip endpoint and returns ok=false — even though the (unbound) client WOULD
+// have successfully fetched a public IP. Goes RED on revert: without the bindErr
+// gate the server is hit and its address is returned/published (wrong WAN).
+func TestCheckIPBoundFailsClosedOnBindError(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		// A real, non-reserved public address the validity gate accepts — this
+		// is exactly the wrong-WAN IP that must NOT be published.
+		_, _ = w.Write([]byte("93.184.216.34\n"))
+	}))
+	defer srv.Close()
+
+	bindErr := errors.New("ddns: invalid source-address \"not-an-ip\": bad")
+	a, ok := CheckIPBound(context.Background(), srv.Client(), srv.URL, true, nil, bindErr)
+	if ok {
+		t.Fatalf("CheckIPBound with a bind error returned ok=true addr=%v; "+
+			"the checkip oracle must fail closed, never publish an IP obtained "+
+			"via the default route", a)
+	}
+	if a.IsValid() {
+		t.Fatalf("CheckIPBound fail-closed must return the zero addr, got %v", a)
+	}
+	if n := atomic.LoadInt32(&hits); n != 0 {
+		t.Fatalf("CheckIPBound with a bind error contacted the checkip endpoint "+
+			"%d time(s); it must not probe via the default route", n)
+	}
+}
+
+// TestCheckIPBoundNoSourceUsesDefaultRoute proves the no-source-configured path
+// is unchanged: bindErr == nil means the caller's client is the intended egress
+// (unbound-by-config), so the probe proceeds and returns the public IP. Goes RED
+// if the gate ever fails closed when no source was requested (would suppress
+// publishing for every default-route deployment).
+func TestCheckIPBoundNoSourceUsesDefaultRoute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("93.184.216.34\n"))
+	}))
+	defer srv.Close()
+
+	a, ok := CheckIPBound(context.Background(), srv.Client(), srv.URL, true, nil, nil)
+	if !ok || a.String() != "93.184.216.34" {
+		t.Fatalf("CheckIPBound(no source, bindErr=nil) = %v ok=%v; want 93.184.216.34 true", a, ok)
+	}
+}
+
+// TestCheckIPBoundAvailableSourceWorks proves that a configured source that
+// resolves cleanly (bindErr == nil, `client` is the bound client) still probes
+// and returns the public IP. This is the multi-WAN happy path #2846 established:
+// the fail-closed gate keys ONLY on the bind error, so an honored source is
+// never suppressed.
+func TestCheckIPBoundAvailableSourceWorks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("93.184.216.34\n"))
+	}))
+	defer srv.Close()
+
+	// A provider with a valid source-address resolves WITHOUT a bind error, so
+	// the caller passes bindErr=nil and the probe proceeds. Confirm the honored
+	// source really does resolve clean (the gate keys on the error, not on the
+	// presence of a source). The socket bind itself is covered by
+	// backend_bind_test.go and backend_http_sourcebind_2846_test.go; here the
+	// loopback test server stands in for the bound egress.
+	if _, err := newProviderHTTPClient(&config.DDNSProvider{Name: "p", SourceAddress: "127.0.0.2"}); err != nil {
+		t.Fatalf("a valid source-address must resolve without error, got %v", err)
+	}
+
+	a, ok := CheckIPBound(context.Background(), srv.Client(), srv.URL, true, nil, nil)
+	if !ok || a.String() != "93.184.216.34" {
+		t.Fatalf("CheckIPBound(honored source) = %v ok=%v; want 93.184.216.34 true", a, ok)
+	}
+}

--- a/pkg/ddns/checkip_sourcebind_failclosed_3733_test.go
+++ b/pkg/ddns/checkip_sourcebind_failclosed_3733_test.go
@@ -67,29 +67,39 @@ func TestCheckIPBoundNoSourceUsesDefaultRoute(t *testing.T) {
 	}
 }
 
-// TestCheckIPBoundAvailableSourceWorks proves that a configured source that
-// resolves cleanly (bindErr == nil, `client` is the bound client) still probes
-// and returns the public IP. This is the multi-WAN happy path #2846 established:
-// the fail-closed gate keys ONLY on the bind error, so an honored source is
-// never suppressed.
+// TestCheckIPBoundAvailableSourceWorks proves the multi-WAN happy path #2846
+// established: a configured source that resolves cleanly (bindErr == nil, and
+// `client` is an ACTUAL source-bound client, not the unbound default) still
+// probes and returns the public IP. The fail-closed gate keys ONLY on the bind
+// error, so an honored source is never suppressed. Distinct from
+// TestCheckIPBoundNoSourceUsesDefaultRoute (which threads the unbound default
+// client): here the probe egresses through a real source-bound *http.Client.
 func TestCheckIPBoundAvailableSourceWorks(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("93.184.216.34\n"))
 	}))
 	defer srv.Close()
 
-	// A provider with a valid source-address resolves WITHOUT a bind error, so
-	// the caller passes bindErr=nil and the probe proceeds. Confirm the honored
-	// source really does resolve clean (the gate keys on the error, not on the
-	// presence of a source). The socket bind itself is covered by
-	// backend_bind_test.go and backend_http_sourcebind_2846_test.go; here the
-	// loopback test server stands in for the bound egress.
-	if _, err := newProviderHTTPClient(&config.DDNSProvider{Name: "p", SourceAddress: "127.0.0.2"}); err != nil {
+	// Build the REAL bound client: source-address 127.0.0.1 is the loopback the
+	// httptest server listens on, so the source-bound socket connects to it
+	// successfully (v4 source, v4 dial — no #2901 family mismatch). A valid
+	// source-address resolves WITHOUT a bind error, so the caller passes
+	// bindErr=nil and the probe must proceed through the bound client.
+	client, err := newProviderHTTPClient(&config.DDNSProvider{Name: "p", SourceAddress: "127.0.0.1"})
+	if err != nil {
 		t.Fatalf("a valid source-address must resolve without error, got %v", err)
 	}
+	// Assert this really IS a source-bound client (installs a DialContext),
+	// unlike the unbound default the no-source test uses — so this case
+	// genuinely exercises "bound client + bindErr==nil still probes".
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok || tr.DialContext == nil {
+		t.Fatalf("expected a source-bound client with a DialContext, got %T (DialContext set=%v)",
+			client.Transport, ok && tr.DialContext != nil)
+	}
 
-	a, ok := CheckIPBound(context.Background(), srv.Client(), srv.URL, true, nil, nil)
+	a, ok := CheckIPBound(context.Background(), client, srv.URL, true, nil, nil)
 	if !ok || a.String() != "93.184.216.34" {
-		t.Fatalf("CheckIPBound(honored source) = %v ok=%v; want 93.184.216.34 true", a, ok)
+		t.Fatalf("CheckIPBound(honored bound source) = %v ok=%v; want 93.184.216.34 true", a, ok)
 	}
 }


### PR DESCRIPTION
Closes #3733

## Problem (security fail-open — residual of #2846)

The Surface A **checkip** probe is an address **oracle**: the public IP it
discovers is published as the scope's A/AAAA record. #2846 bound the probe to
the provider's configured source-address / interface / VRF so a multi-WAN
scope's "what is my IP" query egresses from its OWN uplink.

But the daemon's bind-error branch (`pkg/daemon/daemon_ddns_surface_a.go`) only
**logged** the failure and **still ran the probe with the unbound default
client** — so the query egressed via the kernel default route and returned the
**DEFAULT WAN's public IP**, which was then published for the wrong scope. On a
multi-WAN box a transient/misconfigured source bind makes checkip report WAN1's
public IP for a WAN2 scope. That reintroduces the wrong-WAN publication class
#2846 closed.

## Fix (fail-closed)

New `ddns.CheckIPBound(ctx, client, url, wantV4, allowlist, bindErr)` centralizes
the invariant:

- **`bindErr != nil`** (a source WAS requested but could not be honored) →
  returns `(zero, false)`: a **TRANSIENT observation** (no publish, never a
  withdraw), matching `CheckIP`'s own miss semantics. It does **not** fall back
  to the default route.
- **`bindErr == nil`** (no source requested, or an honored source) → probes
  exactly as before, so default-route deployments are unchanged.

The gate is **exact**: `resolveProviderBindConfig → resolveBindConfig` returns an
error **only** when a source-address is configured but does not parse (a source
requested but unhonorable). The other "source unavailable" cases (address not
currently assigned, dest-interface / VRF down) surface later as a **dial error**
inside `CheckIP`, which already returns `ok=false` — so this gate closes the one
residual fall-open the bind-error branch left.

The daemon threads `berr` through `CheckIPBound` and rate-limits the fail-closed
warning once per `(provider, bind-error)` via a new
`surfaceACheckIPSourceBindWarned` sync.Map so a persistent misconfig surfaces
without flooding the per-tick observer. Fall-open to the default route remains
acceptable for generic HTTP UPDATE backends (they carry a credential + fixed
host); the checkip oracle does not.

## RED-on-revert test

`pkg/ddns/checkip_sourcebind_failclosed_3733_test.go`:

- `TestCheckIPBoundFailsClosedOnBindError` — with a bind error the probe must
  NOT contact the checkip endpoint (hit counter == 0) and must return `ok=false`
  even though the unbound client WOULD fetch a public IP. **Verified RED on
  revert**: neutering the `bindErr` gate returns the wrong-WAN `93.184.216.34`
  and the test fails.
- `TestCheckIPBoundNoSourceUsesDefaultRoute` — `bindErr==nil` still probes and
  returns the address (no over-gating for default-route deployments).
- `TestCheckIPBoundAvailableSourceWorks` — an honored source (`bindErr==nil`)
  still probes; the gate keys on the error, not the presence of a source.

## Validation

- `go test ./pkg/ddns/...` green; `go build ./...` green.
- `gofmt` + `go vet` clean on changed files.
- RED-on-revert confirmed by neutering the `bindErr` gate.
- DDNS design plan §5.3 updated with the checkip source-bind fail-closed
  invariant; `_Log.md` entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
