### PR TITLE
userspace-dp policy: fail-closed on invalid ICMP application field combos

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,30 @@
+## 2026-07-01 — #3712 userspace-dp policy: fail-closed on invalid ICMP application field combos
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3712 (HIGH, security fail-open). The Rust policy snapshot
+    parser accepted two semantically-invalid ICMP application field combos and
+    compiled them into wrong-behaving terms: (A) `icmp-code` WITHOUT `icmp-type`
+    → `from_matches` only steers a term into `icmp_constraints` when
+    `icmp_type.is_some()`, so the term fell through to an empty-range
+    `range_terms` entry = protocol-only MATCH-ALL ICMP (the code silently
+    ignored — a permit widens fail-OPEN); (B) `icmp-type`/`icmp-code` on a
+    non-ICMP protocol → the term is pushed into `icmp_constraints` under the
+    non-ICMP protocol (losing any dst-port) and `matches` skips that arm for a
+    non-ICMP packet → the term NEVER matches, so a deny falls through to
+    default-permit (fail-OPEN). The Go strict commit gate
+    (`validateApplicationSpecsStrict`, #3348) rejects both at commit, but
+    `lenientApplicationSpecs` downgrades to a warning on the tolerant load /
+    HA peer-sync path, so a corrupt / hand-built / older-peer-synced snapshot
+    still reaches this helper — the only enforcement plane. FIX: `parse_applications`
+    records the first offending term; `parse_policy_state_with_counters` rejects
+    the whole snapshot with `SnapshotIntegrityError::InvalidApplicationIcmpFields`
+    (fail-closed, action-agnostic — the #2124/#3367/#3711 family). Non-ICMP-protocol
+    arm checked first; code-without-type arm applies once protocol is ICMP/ICMPv6.
+  - **File(s)**: userspace-dp/src/policy.rs (new SnapshotIntegrityError variant +
+    Display + ParsedApplications.invalid_icmp + parse_applications detection +
+    caller reject), userspace-dp/src/policy_tests.rs (5 tests, 3 RED-on-revert),
+    docs/config-schema.md (#3348 section — #3712 Rust backstop note)
+
 ## 2026-07-01 — #3709 policy-simulator rejects DUPLICATE selectors (consistent fail-closed across CLI/gRPC/REST) + comma-in-zone round-trip
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3016,13 +3016,46 @@ both are handled in `parseApplicationTerms` + the deferred strict gate):
   top-level path also records `UnknownICMP` so the malformed value is caught on
   the tolerant load path (which does not run `SchemaValidate`).
 
-No wire/Rust change: the snapshot already carries `ICMPType`/`ICMPCode` and the
-matcher already enforces `icmp_constraints` (#3020). Regression coverage:
+The snapshot already carries `ICMPType`/`ICMPCode` and the matcher already
+enforces `icmp_constraints` (#3020). Regression coverage:
 `pkg/config/compiler_application_junos_ping_3348_test.go` (alias echo type top-level
 + inline term, all-ICMP stays unconstrained, explicit grammar, explicit-over-alias,
 both strict guards) and the end-to-end matcher test
 `pkg/policymatch/app_junos_ping_3348_test.go` (custom `protocol junos-ping` permits
 type 8, denies 13/5).
+
+**#3712 — Rust snapshot-boundary fail-closed backstop for the two invalid ICMP
+combos.** The #3348 strict guards run at COMMIT, but `lenientApplicationSpecs`
+downgrades both to a `cfg.Warnings` entry on the tolerant load / HA peer-sync
+path — so a corrupt / hand-built / older-peer-synced snapshot can still carry an
+invalid combo to the userspace helper, the only enforcement plane. The pre-#3712
+Rust matcher turned each into a WRONG-behaving term rather than rejecting it:
+
+- **`icmp-code` without `icmp-type` → match-ALL ICMP (fail-OPEN).**
+  `CompiledApplications::from_matches` (`userspace-dp/src/policy.rs`) steers a
+  term into `icmp_constraints` ONLY when `icmp_type.is_some()`, so a
+  code-without-type ICMP term fell through to an empty-range `range_terms`
+  entry = protocol-only match-all; the `icmp_code` was silently dropped and a
+  narrow permit widened to every ICMP message.
+- **`icmp-type`/`icmp-code` on a non-ICMP protocol → never-match (fail-OPEN for
+  a deny).** The term was pushed into `icmp_constraints` under the non-ICMP
+  protocol (losing any destination-port), and `matches` skips that arm for a
+  non-ICMP packet, so the term never matched — a `deny tcp/80 icmp-type 8`
+  never applied and default-permit admitted the traffic.
+
+`parse_applications` now records the first offending term and
+`parse_policy_state_with_counters` rejects the whole snapshot with
+`SnapshotIntegrityError::InvalidApplicationIcmpFields { rule_id, application,
+reason }` (the preflight keeps the previous good state; a fresh boot keeps the
+default-deny `PolicyState`), consistent with the #2124/#3367/#3711 fail-closed
+family. The non-ICMP-protocol arm is checked first (any icmp field is
+meaningless there); the code-without-type arm applies once the protocol is
+ICMP/ICMPv6. Regression coverage: `userspace-dp/src/policy_tests.rs`
+(`icmp_code_without_type_rejects_whole_snapshot`,
+`non_icmp_term_with_icmp_type_rejects_whole_snapshot`,
+`non_icmp_term_with_icmp_code_rejects_whole_snapshot`,
+`valid_icmp_type_and_code_still_compiles_and_matches`,
+`valid_icmpv6_type_and_code_still_compiles`).
 
 ### #3352 / #3353 — unknown inline-`term` leaf + per-application `alg` validation
 

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -28,6 +28,41 @@ pub(crate) enum SnapshotIntegrityError {
     /// preflight keeps the previous good state) is action-agnostic: it never
     /// turns a deny into a pass nor a permit into match-any.
     UnrepresentableApplicationProtocol { rule_id: String },
+    /// #3712: a policy rule's application term carried a semantically-invalid
+    /// ICMP field combination that the pre-fix compiled matcher silently turned
+    /// into a WRONG-behaving term:
+    ///
+    ///   - `icmp-code` set with NO `icmp-type` (H04): `from_matches` steers a
+    ///     term into `icmp_constraints` ONLY when `icmp_type.is_some()`, so a
+    ///     code-without-type term fell through to a `range_terms` entry with
+    ///     EMPTY port ranges — a protocol-only MATCH-ALL for that ICMP protocol.
+    ///     The `icmp_code` was silently ignored, so an intended narrow rule
+    ///     (`type any, code 3`) widened to match every ICMP message. For a
+    ///     permit under default-deny that is a fail-OPEN (permits more than
+    ///     authored).
+    ///   - `icmp-type` / `icmp-code` set on a NON-ICMP protocol (H05):
+    ///     `from_matches` pushes the term into `icmp_constraints` under the
+    ///     non-ICMP protocol (e.g. TCP) because `icmp_type.is_some()`, and the
+    ///     exact-dst-port / range classification is skipped, so any real
+    ///     destination-port constraint is LOST. `matches` then skips the
+    ///     `icmp_constraints` arm for a non-ICMP packet (`packet_icmp` is None),
+    ///     so the term NEVER matches — a `deny tcp/80 icmp-type 8` never applies
+    ///     and default-permit admits the traffic (a security fail-OPEN).
+    ///
+    /// The Go STRICT commit gate (`validateApplicationSpecsStrict`, #3348) hard-
+    /// rejects BOTH combos at commit, but the tolerant load / peer-sync path
+    /// (`lenientApplicationSpecs`) downgrades them to warnings, so a corrupt /
+    /// hand-built / older-peer-synced snapshot can still carry them to this
+    /// helper — the only enforcement plane in the retired-eBPF world. Rejecting
+    /// the WHOLE snapshot (the preflight keeps the previous good state; a fresh
+    /// boot keeps the default-deny `PolicyState`) is action-agnostic, consistent
+    /// with the #2124/#3261/#3367/#3711 fail-closed family. `application` is the
+    /// term's name; `reason` describes which invalid combo was found.
+    InvalidApplicationIcmpFields {
+        rule_id: String,
+        application: String,
+        reason: &'static str,
+    },
     /// #3261: a policy rule carries the reserved `__unsupported_address__`
     /// sentinel in its source/destination address fields. The Go capability
     /// gate emits it when a policy names an address it cannot represent — an
@@ -439,6 +474,15 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "rule {:?} has an unrepresentable application term (unparseable protocol or port) — refusing to fail open by dropping it",
                 rule_id
+            ),
+            Self::InvalidApplicationIcmpFields {
+                rule_id,
+                application,
+                reason,
+            } => write!(
+                f,
+                "rule {:?} application term {:?} has an invalid ICMP field combination: {} — refusing to compile a wrong-behaving term (icmp-code without icmp-type matches ALL ICMP; icmp-type/code on a non-ICMP protocol never matches, so a deny falls through to default-permit)",
+                rule_id, application, reason
             ),
             Self::UnrepresentableAddress { rule_id } => write!(
                 f,
@@ -2334,6 +2378,20 @@ pub(crate) fn parse_policy_state_with_counters(
                 rule_id: rule_id.clone(),
             });
         }
+        // #3712: fail the whole snapshot closed when an application term carries a
+        // semantically-invalid ICMP field combination (icmp-code without
+        // icmp-type → match-all-ICMP fail-open; icmp-type/code on a non-ICMP
+        // protocol → never-match, letting a deny fall through to default-permit).
+        // The Go strict commit gate (#3348) is the primary defense; this is the
+        // helper-boundary backstop for the lenient / peer-sync / corrupt-snapshot
+        // path, consistent with the #2124/#3367/#3711 fail-closed family.
+        if let Some((application, reason)) = parsed.invalid_icmp {
+            return Err(SnapshotIntegrityError::InvalidApplicationIcmpFields {
+                rule_id: rule_id.clone(),
+                application,
+                reason,
+            });
+        }
         let applications = parsed.matches;
         let compiled_apps = CompiledApplications::from_matches(&applications);
 
@@ -3484,11 +3542,20 @@ fn parse_address(prefix: &str, out_v4: &mut Vec<PrefixV4>, out_v6: &mut Vec<Pref
 struct ParsedApplications {
     matches: Vec<ApplicationMatch>,
     dropped_any: bool,
+    /// #3712: the FIRST application term found with a semantically-invalid ICMP
+    /// field combination — `(application name, reason)`. `None` when every term
+    /// is well-formed. The caller fails the whole snapshot closed via
+    /// `SnapshotIntegrityError::InvalidApplicationIcmpFields`, naming the rule
+    /// (which `parse_applications` does not have). Detected regardless of
+    /// `dropped_any` so a rule mixing a bad-ICMP term with an unparseable one
+    /// still surfaces the ICMP diagnostic when protocol/port parse.
+    invalid_icmp: Option<(String, &'static str)>,
 }
 
 fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications {
     let mut out = Vec::with_capacity(terms.len());
     let mut dropped_any = false;
+    let mut invalid_icmp: Option<(String, &'static str)> = None;
     for term in terms {
         let Some(protocol) = parse_protocol(&term.protocol) else {
             dropped_any = true;
@@ -3502,6 +3569,24 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications
             dropped_any = true;
             continue;
         };
+        // #3712: reject the two semantically-invalid ICMP field combinations the
+        // compiled matcher (`from_matches`/`matches`) would otherwise turn into a
+        // wrong-behaving term. Record the FIRST offender; the caller rejects the
+        // whole snapshot fail-closed (see `InvalidApplicationIcmpFields`). The
+        // non-ICMP-protocol case is checked first because on a non-ICMP protocol
+        // ANY icmp field is meaningless (the term can never match), whereas the
+        // code-without-type case is only relevant once the protocol is ICMP.
+        if invalid_icmp.is_none() {
+            let icmp_family = protocol == PROTO_ICMP || protocol == PROTO_ICMPV6;
+            if (term.icmp_type.is_some() || term.icmp_code.is_some()) && !icmp_family {
+                invalid_icmp = Some((
+                    term.name.clone(),
+                    "icmp-type/icmp-code set on a non-ICMP protocol",
+                ));
+            } else if term.icmp_code.is_some() && term.icmp_type.is_none() {
+                invalid_icmp = Some((term.name.clone(), "icmp-code set without icmp-type"));
+            }
+        }
         out.push(ApplicationMatch {
             protocol,
             source_ports,
@@ -3520,6 +3605,7 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications
     ParsedApplications {
         matches: out,
         dropped_any,
+        invalid_icmp,
     }
 }
 

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -4317,6 +4317,150 @@ fn icmp_skew_old_snapshot_without_type_matches_all() {
 }
 
 // ---------------------------------------------------------------------------
+// #3712 — invalid ICMP application field combinations must FAIL CLOSED at the
+// Rust snapshot boundary. The Go strict commit gate (#3348) rejects both, but
+// the tolerant load / peer-sync path downgrades to a warning, so a corrupt /
+// hand-built / older-peer-synced snapshot can still carry them here — the only
+// enforcement plane. Two combos:
+//   - icmp-code WITHOUT icmp-type (H04): `from_matches` only steers a term into
+//     icmp_constraints when icmp_type.is_some(), so a code-without-type ICMP
+//     term becomes an empty-range range_terms entry = MATCH-ALL ICMP (the code
+//     silently ignored). A permit under default-deny then fails OPEN.
+//   - icmp-type/code on a NON-ICMP protocol (H05): the term is pushed into
+//     icmp_constraints under the non-ICMP protocol (losing any dst-port), and
+//     `matches` skips that arm for a non-ICMP packet → the term NEVER matches,
+//     so a `deny` falls through to default-permit (fail OPEN).
+// ---------------------------------------------------------------------------
+
+/// Build a one-term policy rule carrying arbitrary ICMP fields on `protocol`,
+/// for the #3712 fail-closed tests. `default_permit` traffic is admitted unless
+/// a matching rule denies it; the rule's own action is passed in.
+fn icmp_fields_rule(
+    rule_id: &str,
+    protocol: &str,
+    dst_port: &str,
+    icmp_type: Option<u8>,
+    icmp_code: Option<u8>,
+    action: &str,
+) -> PolicyRuleSnapshot {
+    PolicyRuleSnapshot {
+        rule_id: rule_id.to_string(),
+        name: rule_id.to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec![rule_id.to_string()],
+        application_terms: vec![PolicyApplicationSnapshot {
+            name: format!("app-{rule_id}"),
+            protocol: protocol.to_string(),
+            source_port: String::new(),
+            destination_port: dst_port.to_string(),
+            icmp_type,
+            icmp_code,
+            inactivity_timeout: None,
+        }],
+        action: action.to_string(),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn icmp_code_without_type_rejects_whole_snapshot() {
+    // H04 RED-on-revert: proto icmp, icmp_type=None, icmp_code=Some(3), permit,
+    // default deny. Pre-fix `from_matches` dropped the term into an empty-range
+    // range_terms entry (match-ALL ICMP), so parse succeeded (Ok) and a
+    // type-8/code-0 packet (which should NOT match `code 3`) was Permitted — a
+    // fail-open. The fix rejects the whole snapshot. Reverting the reject returns
+    // Ok(state) here, so this is non-tautological.
+    let store = PolicyCounterStore::default();
+    let bad = icmp_fields_rule("code-no-type", "icmp", "", None, Some(3), "permit");
+    let result =
+        parse_policy_state_with_counters("deny", &[bad], &test_zone_name_to_id(), &[], &store);
+    match result {
+        Err(SnapshotIntegrityError::InvalidApplicationIcmpFields {
+            rule_id,
+            application,
+            reason,
+        }) => {
+            assert_eq!(rule_id, "code-no-type");
+            assert_eq!(application, "app-code-no-type");
+            assert_eq!(reason, "icmp-code set without icmp-type");
+        }
+        other => panic!("expected InvalidApplicationIcmpFields, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_icmp_term_with_icmp_type_rejects_whole_snapshot() {
+    // H05 RED-on-revert: proto tcp, dst 80, icmp_type=Some(8), deny, default
+    // permit. Pre-fix the term was pushed into icmp_constraints under TCP (losing
+    // dst-port 80), and `matches` skipped it for a real (non-ICMP) TCP packet →
+    // the deny NEVER matched and default-permit admitted TCP/80 (a security
+    // fail-open). The fix rejects the whole snapshot. Reverting returns Ok(state),
+    // so this is non-tautological.
+    let store = PolicyCounterStore::default();
+    let bad = icmp_fields_rule("tcp-icmp-type", "tcp", "80", Some(8), None, "deny");
+    let result =
+        parse_policy_state_with_counters("permit", &[bad], &test_zone_name_to_id(), &[], &store);
+    match result {
+        Err(SnapshotIntegrityError::InvalidApplicationIcmpFields {
+            rule_id,
+            application,
+            reason,
+        }) => {
+            assert_eq!(rule_id, "tcp-icmp-type");
+            assert_eq!(application, "app-tcp-icmp-type");
+            assert_eq!(reason, "icmp-type/icmp-code set on a non-ICMP protocol");
+        }
+        other => panic!("expected InvalidApplicationIcmpFields, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_icmp_term_with_icmp_code_rejects_whole_snapshot() {
+    // H05 sibling: an icmp_code on a non-ICMP protocol (udp) is equally invalid
+    // and is caught by the non-ICMP-protocol arm (which fires for ANY icmp field
+    // on a non-ICMP protocol), before the code-without-type arm.
+    let store = PolicyCounterStore::default();
+    let bad = icmp_fields_rule("udp-icmp-code", "udp", "", None, Some(3), "deny");
+    let result =
+        parse_policy_state_with_counters("permit", &[bad], &test_zone_name_to_id(), &[], &store);
+    match result {
+        Err(SnapshotIntegrityError::InvalidApplicationIcmpFields { rule_id, reason, .. }) => {
+            assert_eq!(rule_id, "udp-icmp-code");
+            assert_eq!(reason, "icmp-type/icmp-code set on a non-ICMP protocol");
+        }
+        other => panic!("expected InvalidApplicationIcmpFields, got {other:?}"),
+    }
+}
+
+#[test]
+fn valid_icmp_type_and_code_still_compiles_and_matches() {
+    // Guard: a WELL-FORMED type+code constraint on an ICMP protocol must still
+    // compile AND honor the code (no false reject, no match-all). Rule: icmp
+    // type 3 code 1 permit, default deny.
+    let bad_free = icmp_fields_rule("dest-unreach-host", "icmp", "", Some(3), Some(1), "permit");
+    let state = parse_policy_state("deny", &[bad_free], &test_zone_name_to_id());
+    // Exact type+code → permit.
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 3, 1), PolicyAction::Permit);
+    // Same type, DIFFERENT code → must NOT match (proves code is honored, not
+    // ignored the way the H04 match-all bug ignored it) → default deny.
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 3, 2), PolicyAction::Deny);
+    // Different type → must NOT match → default deny.
+    assert_eq!(eval_icmp(&state, PROTO_ICMP, 8, 0), PolicyAction::Deny);
+}
+
+#[test]
+fn valid_icmpv6_type_and_code_still_compiles() {
+    // The icmpv6 protocol is equally a valid host for type/code constraints.
+    let store = PolicyCounterStore::default();
+    let good = icmp_fields_rule("v6-param", "icmpv6", "", Some(4), Some(1), "permit");
+    parse_policy_state_with_counters("deny", &[good], &test_zone_name_to_id(), &[], &store)
+        .expect("a well-formed icmpv6 type+code app must compile");
+}
+
+// ---------------------------------------------------------------------------
 // #3019: `to-zone junos-host` / `from-zone junos-host` self-traffic policy.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3712

## Problem
The Rust policy snapshot parser (`userspace-dp/src/policy.rs`) accepted two
semantically-invalid ICMP application field combinations and compiled each into
a wrong-behaving term — both fail-OPEN under the default policy:

- **Bug A (H04) — `icmp-code` WITHOUT `icmp-type` → matches ALL ICMP.**
  `CompiledApplications::from_matches` steers a term into `icmp_constraints`
  ONLY when `icmp_type.is_some()`, so a code-without-type ICMP term fell through
  to a `range_terms` entry with EMPTY port ranges = a protocol-only match-all.
  The `icmp_code` was silently ignored, so an intended narrow rule (`type any,
  code 3`) widened to every ICMP message.
- **Bug B (H05) — `icmp-type`/`icmp-code` on a NON-ICMP protocol → never
  matches.** The term is pushed into `icmp_constraints` under the non-ICMP
  protocol (e.g. TCP) because `icmp_type.is_some()`, and the exact-dst-port /
  range classification is skipped, so any real destination-port is lost.
  `matches` then skips the `icmp_constraints` arm for a non-ICMP packet
  (`packet_icmp` is None), so the term NEVER matches — a `deny tcp/80 icmp-type
  8` never applies and default-permit admits TCP/80.

## Why the Rust boundary is the backstop
The Go strict commit gate (`validateApplicationSpecsStrict`, #3348) hard-rejects
both combos at commit, but the tolerant load / HA peer-sync path
(`lenientApplicationSpecs`) downgrades them to warnings — so a corrupt /
hand-built / older-peer-synced snapshot can still carry them to this helper,
the only enforcement plane in the retired-eBPF world. Same posture as the #3711
malformed-literal backstop.

## Fix (fail-closed)
`parse_applications` records the first offending term `(name, reason)`;
`parse_policy_state_with_counters` rejects the WHOLE snapshot with the new
`SnapshotIntegrityError::InvalidApplicationIcmpFields { rule_id, application,
reason }`. Rejecting the whole snapshot (the preflight keeps the previous good
state; a fresh boot keeps the default-deny `PolicyState`) is action-agnostic,
consistent with the #2124/#3261/#3367/#3711 fail-closed family. The
non-ICMP-protocol arm is checked first (any icmp field is meaningless there);
the code-without-type arm applies once the protocol is ICMP/ICMPv6.

## Tests
`userspace-dp/src/policy_tests.rs`:
- 3 RED-on-revert reject tests: `icmp_code_without_type_rejects_whole_snapshot`,
  `non_icmp_term_with_icmp_type_rejects_whole_snapshot`,
  `non_icmp_term_with_icmp_code_rejects_whole_snapshot`.
- 2 positive guards: `valid_icmp_type_and_code_still_compiles_and_matches`
  (type 3 code 1 permitted; code 2 and type 8 denied — proves the code is
  honored, not ignored), `valid_icmpv6_type_and_code_still_compiles`.

**RED-on-revert verified:** with the reject disabled the three reject tests fail
and the debug output shows the exact bug shapes (empty-range `range_terms`
match-all for A; `icmp_constraints` under proto 6 with dst-port 80 lost for B).

Full `cargo test --release` green (3360 + all sub-targets, 0 failures). No
wire/fixture change (the new field is internal to `ParsedApplications`; the
error variant isn't serialized).

Doc: `docs/config-schema.md` #3348 section gains the #3712 Rust
snapshot-boundary backstop note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi