### PR TITLE
routing/PBR: FBF ip-rule mirror honors L4 predicates, fails closed on unrepresentable ones (#3730)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,45 @@
+## 2026-07-01 — #3730 routing/PBR: kernel FBF ip-rule mirror honors L4 predicates + fail-closed on unrepresentable ones
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3730 (MEDIUM, security fail-open widening on the kernel/XDP_PASS
+    path; folds H01/H02/M01-M07/M08/M10). The kernel filter-based-forwarding
+    ip-rule mirror (`buildPBRFromFilter`) derived rules from ONLY the DSCP +
+    source/destination address of a `then routing-instance` term and silently
+    dropped every L4/per-packet predicate. A port+address term (e.g.
+    `destination-port 443 destination-address 203.0.113.10/32 then
+    routing-instance blue`) collapsed to an address-only `to 203.0.113.10/32
+    lookup blue` rule that steered EVERY protocol/port to that host (over-steer,
+    fail-open); a port-only term hit the "no ip-rule-compatible criteria" branch
+    and emitted NO rule (silent under-steer no-op) — neither with a degraded
+    signal. FIX: (1) HONOR the predicates an `ip rule` CAN express — `protocol`
+    → `FRA_IP_PROTO`, `source-port` → `FRA_SPORT_RANGE`, `destination-port` →
+    `FRA_DPORT_RANGE` (via new `pbrTermL4` + folded into the DSCP × src × dst
+    cross-product; multi-value protocol/port sets expand to one rule per value; a
+    range maps to `[lo,hi]`). (2) DEGRADE-SIGNAL fail-closed for predicates an
+    `ip rule` genuinely cannot represent (`*-port-except`, `tcp-flags`,
+    `icmp-type`/`icmp-code`, `is-fragment`, `flexible-match-range`, unknown
+    protocol/proto-0, unparseable port, any unresolved `from` leaf): DROP the
+    whole term (fail-safe under-steer to the main table, never widen to
+    address-only) + record a degraded build error naming filter/term/predicate,
+    mirroring the #3430 DSCP-0 / except pattern. The daemon (`daemon_apply.go`
+    step 3d) already surfaces the returned error via `slog.Warn` (#3430 channel;
+    M08). Named/ranged ports resolve through a new `config.ResolveFilterPortRange`
+    that reuses the `junosServicePorts` SSOT so the kernel mirror and userspace
+    filter path resolve ports identically. RED-on-revert verified by stubbing
+    `pbrTermL4` to the pre-fix behavior: over-steer (address-only rule for
+    tcp-flags/icmp/frag/flex/except), under-steer (port-only 0 rules), protocol
+    not expanded, ports dropped, no degrade error — all new #3730 tests go RED.
+    go test ./pkg/routing/... ./pkg/config/... green; go build ./... green;
+    gofmt + vet clean.
+  - **File(s)**: pkg/routing/rules.go (PBRRule +IPProto/Sport/Dport, PBRPortRange,
+    pbrTermL4 + hasRealString, buildPBRFromFilter honor/degrade, pbrManager.Apply
+    emits FRA_IP_PROTO/SPORT/DPORT, BuildPBRRules doc support-matrix),
+    pkg/config/filter_match_resolve.go (ResolveFilterPortRange SSOT wrapper),
+    pkg/routing/routing_test.go (13 #3730 subtests, RED-on-revert),
+    pkg/daemon/daemon_apply.go (degraded-warn wording + comment),
+    docs/multi-wan.md (kernel-steering support matrix), pkg/routing/README.md
+    (FBF support-matrix note under the 31000 band)
+
 ## 2026-07-01 — #3712 userspace-dp policy: fail-closed on invalid ICMP application field combos
 
 - **Timestamp**: 2026-07-01

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -329,9 +329,18 @@ How it lands (the `instance-type forwarding` divergence fix):
   master routing) and the instance's kernel table stayed empty, so
   kernel-path FBF silently no-opped while the dataplane steered.
 - **Kernel steering**: the existing PBR machinery emits `ip rule`s
-  (priority band 31000+) matching the term's DSCP/addresses into the
-  instance's table — now populated, so the kernel slow path agrees
-  with the fast path.
+  (priority band 31000+) matching the term's addresses / DSCP /
+  `protocol` / `source-port` / `destination-port` into the instance's
+  table — now populated, so the kernel slow path agrees with the fast
+  path. Protocol and port predicates map onto `FRA_IP_PROTO`,
+  `FRA_SPORT_RANGE` and `FRA_DPORT_RANGE` (#3730). A term carrying a
+  predicate an `ip rule` cannot express (`*-port-except`, `tcp-flags`,
+  `icmp-type`/`icmp-code`, `is-fragment`, `flexible-match-range`, or a
+  DSCP-0 / non-empty address `except` match) FAILS CLOSED: the kernel
+  mirror drops the whole term (fail-safe under-steer to the main table)
+  and marks the build degraded rather than widening a constrained term
+  to an address-only rule that would steer traffic the operator
+  excluded. The userspace fast path still enforces the term exactly.
 - **Dataplane**: filter evaluation returns the term's
   routing-instance; the route lookup targets `ISP-B.inet.0` /
   `ISP-B.inet6.0`, where the snapshot builder files the instance's

--- a/pkg/config/filter_match_resolve.go
+++ b/pkg/config/filter_match_resolve.go
@@ -272,6 +272,35 @@ func resolveFilterPort(spec string) (string, bool) {
 	return strconv.Itoa(int(p)), true
 }
 
+// ResolveFilterPortRange resolves a single `from {source,destination}-port`
+// spec — a number, a Junos service name, or a `lo-hi` range of either — to a
+// numeric [lo,hi] port range for the kernel filter-based-forwarding ip-rule
+// mirror (pkg/routing, #3730). It reuses resolveFilterPort (the SSOT that the
+// compile path uses) so the kernel FBF mirror and the userspace filter path
+// resolve named/ranged ports identically. A single port yields lo==hi.
+//
+// ok=false for an unrecognized name or a malformed range so the caller FAILS
+// CLOSED (drops the steering rule + degrades) rather than widening the match.
+func ResolveFilterPortRange(spec string) (lo, hi uint16, ok bool) {
+	canon, ok := resolveFilterPort(spec)
+	if !ok {
+		return 0, 0, false
+	}
+	if i := strings.IndexByte(canon, '-'); i > 0 {
+		l, e1 := strconv.Atoi(canon[:i])
+		h, e2 := strconv.Atoi(canon[i+1:])
+		if e1 != nil || e2 != nil || l < 0 || h > 65535 || l > h {
+			return 0, 0, false
+		}
+		return uint16(l), uint16(h), true
+	}
+	n, err := strconv.Atoi(canon)
+	if err != nil || n < 0 || n > 65535 {
+		return 0, 0, false
+	}
+	return uint16(n), uint16(n), true
+}
+
 // resolveFilterPortTokens resolves every port token in a `from` port list to a
 // canonical numeric spec. A recognized token is rewritten to its numeric form
 // so the dataplane only ever sees numerics. An UNrecognized token is kept

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1098,12 +1098,17 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// 3d. Apply policy-based routing rules (ip rule) for firewall filter
 	// routing-instance (filter-based forwarding). Rules are derived only from
 	// filters attached as an interface input filter (#3430 H1); a degraded
-	// build (unrepresentable except / overflow) is surfaced but does not block
-	// the rest of the apply.
+	// build — an unrepresentable except set, a DSCP-0 match, an
+	// ip-rule-unrepresentable L4/per-packet predicate (port-except / tcp-flags /
+	// icmp / is-fragment / flex, #3730), or an overflow — is surfaced but does
+	// not block the rest of the apply. The degraded term is DROPPED (fail-safe
+	// under-steer to the main table), never widened to an address-only over-steer.
 	if d.routing != nil {
 		pbrRules, buildErr := routing.BuildPBRRules(cfg)
 		if buildErr != nil {
-			slog.Warn("PBR rule build degraded", "err", buildErr)
+			slog.Warn("PBR rule build degraded; some routing-instance filter terms "+
+				"are not mirrored to the kernel FBF path and fall back to the main "+
+				"table (userspace filter path still enforces them)", "err", buildErr)
 		}
 		if err := d.routing.ApplyPBRRules(pbrRules); err != nil {
 			slog.Warn("failed to apply PBR rules", "err", err)

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -115,7 +115,25 @@ delegate to the owning domain. Exported types:
 - `100–199`: next-table inter-VRF leaking (static routes with
   `next-table` directive). `nextTableRulePriority` in `rules.go`.
 - `31000–31999`: PBR (firewall-filter `routing-instance` action).
-  `pbrRulePriority` in `rules.go`.
+  `pbrRulePriority` in `rules.go`. **Kernel FBF support matrix (#3730):**
+  `BuildPBRRules` mirrors only the term `from` predicates an `ip rule` can
+  express — source/destination address + prefix-list, DSCP (non-zero),
+  `protocol` (`FRA_IP_PROTO`), `source-port` (`FRA_SPORT_RANGE`) and
+  `destination-port` (`FRA_DPORT_RANGE`); multi-value protocol/port sets
+  expand to one rule per value and a port range maps to a single `[lo,hi]`
+  range. A term carrying any predicate an `ip rule` cannot represent —
+  `source-port-except` / `destination-port-except`, `tcp-flags`,
+  `icmp-type` / `icmp-code`, `is-fragment`, `flexible-match-range`, a
+  DSCP-0 match, a non-empty address `except` set, an unknown protocol /
+  unparseable port, or any unresolved `from` leaf — FAILS CLOSED:
+  `buildPBRFromFilter` (via `pbrTermL4`) drops the whole term and records a
+  degraded build error. Honoring the address/protocol/port half while
+  silently dropping the rest would WIDEN the match and steer traffic the
+  operator constrained away (the #3730 over-steer); dropping the term is
+  the fail-safe under-steer (steered traffic falls back to the main table)
+  and the userspace filter path still enforces the term exactly. The
+  degraded error is returned to the daemon (`daemon_apply.go` step 3d) and
+  logged; the buildable rules are still installed.
 - `33000–33099`: rib-group inter-VRF leaking (`from all lookup
   <table>`). `ribGroupManager.Apply` only installs a leak rule when an
   instance's `interface-routes` rib-group imports a rib that resolves to

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -1146,6 +1146,261 @@ func TestBuildPBRRules(t *testing.T) {
 			t.Errorf("overflow must return a degraded build error")
 		}
 	})
+
+	// === #3730 L4/per-packet predicate coverage ===
+
+	// #3730 OVER-STEER (the security bug): a term constrained by BOTH an address
+	// AND a destination-port must NOT collapse to an address-only rule that
+	// steers every protocol/port to that host. The emitted ip rule MUST carry the
+	// dport selector. Pre-fix buildPBRFromFilter read only the address and dropped
+	// the port, so this asserted Dport was silently nil (RED on revert).
+	t.Run("3730 dest-port honored not over-steered", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "portsteer",
+			Terms: []*config.FirewallFilterTerm{
+				{
+					Name:             "https-to-att",
+					DestAddresses:    []string{"203.0.113.10/32"},
+					DestinationPorts: []string{"443"},
+					RoutingInstance:  "ATT",
+				},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if err != nil {
+			t.Fatalf("unexpected degraded error for a representable dport term: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("expected 1 PBR rule, got %d: %+v", len(rules), rules)
+		}
+		if rules[0].Dst != "203.0.113.10/32" {
+			t.Errorf("dst = %q, want 203.0.113.10/32", rules[0].Dst)
+		}
+		if rules[0].Dport == nil {
+			t.Fatal("#3730 over-steer: address+dest-port term must emit a dport selector, got nil (would steer ALL ports to the host)")
+		}
+		if rules[0].Dport.Lo != 443 || rules[0].Dport.Hi != 443 {
+			t.Errorf("dport = %s, want 443", rules[0].Dport)
+		}
+	})
+
+	// #3730 UNDER-STEER: a term with ONLY an L4 predicate (destination-port, no
+	// dscp/address) previously hit the "no ip-rule-compatible criteria" branch and
+	// emitted NO rule (silent no-op) even though the operator believed FBF was
+	// active. It must now emit a rule carrying the dport. RED on revert (0 rules).
+	t.Run("3730 port-only term now emits a rule", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "portonly",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "dns", DestinationPorts: []string{"53"}, RoutingInstance: "ATT"},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("port-only term must emit 1 rule (not a silent no-op), got %d", len(rules))
+		}
+		if rules[0].Dport == nil || rules[0].Dport.Lo != 53 || rules[0].Dport.Hi != 53 {
+			t.Errorf("expected dport 53, got %s", rules[0].Dport)
+		}
+		if rules[0].Src != "" || rules[0].Dst != "" || rules[0].TOSSet {
+			t.Errorf("port-only rule must carry no addr/dscp selector, got %+v", rules[0])
+		}
+	})
+
+	// #3730 protocol honored: `from protocol tcp` → IPProto 6. A multi-protocol
+	// set expands to one rule per protocol.
+	t.Run("3730 protocol honored and expanded", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "protosteer",
+			Terms: []*config.FirewallFilterTerm{
+				{
+					Name:            "tcp-udp",
+					Protocols:       []string{"tcp", "udp"},
+					DestAddresses:   []string{"198.51.100.0/24"},
+					RoutingInstance: "ATT",
+				},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rules) != 2 {
+			t.Fatalf("expected 2 rules (tcp + udp), got %d: %+v", len(rules), rules)
+		}
+		gotProto := map[int]bool{rules[0].IPProto: true, rules[1].IPProto: true}
+		if !gotProto[6] || !gotProto[17] {
+			t.Errorf("expected IPProto 6 (tcp) and 17 (udp), got %+v", rules)
+		}
+	})
+
+	// #3730 source-port range honored: `from source-port 1024-2048` → a single
+	// FRA_SPORT_RANGE [1024,2048].
+	t.Run("3730 source-port range honored", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "sportrange",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "ephem", SourcePorts: []string{"1024-2048"}, RoutingInstance: "ATT"},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rules) != 1 || rules[0].Sport == nil {
+			t.Fatalf("expected 1 rule with an sport range, got %+v", rules)
+		}
+		if rules[0].Sport.Lo != 1024 || rules[0].Sport.Hi != 2048 {
+			t.Errorf("sport = %s, want 1024-2048", rules[0].Sport)
+		}
+	})
+
+	// #3730 named port honored via the shared SSOT resolver (config.junosServicePorts).
+	t.Run("3730 named dest-port resolves", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "named",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "web", DestinationPorts: []string{"https"}, RoutingInstance: "ATT"},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rules) != 1 || rules[0].Dport == nil || rules[0].Dport.Lo != 443 {
+			t.Fatalf("named port `https` must resolve to 443, got %+v", rules)
+		}
+	})
+
+	// #3730 UNREPRESENTABLE predicates fail closed (degrade + drop, never widen).
+	// Each of these has no ip-rule selector; a rule honoring only the address
+	// would over-steer, so the whole term is dropped and the build is degraded.
+	t.Run("3730 unrepresentable predicates degrade not widen", func(t *testing.T) {
+		cases := []struct {
+			name string
+			term *config.FirewallFilterTerm
+		}{
+			{"tcp-flags", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				TCPFlags: []string{"syn"}, RoutingInstance: "ATT"}},
+			{"is-fragment", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				IsFragment: true, RoutingInstance: "ATT"}},
+			{"icmp-type", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				ICMPTypes: []int{8}, RoutingInstance: "ATT"}},
+			{"icmp-code", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				ICMPCodes: []int{0}, RoutingInstance: "ATT"}},
+			{"dest-port-except", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				DestPortsExcept: []string{"80"}, RoutingInstance: "ATT"}},
+			{"source-port-except", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				SourcePortsExcept: []string{"22"}, RoutingInstance: "ATT"}},
+			{"flex-match", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				FlexMatch: &config.FlexMatchConfig{ByteOffset: 4, BitLength: 8, Value: 1}, RoutingInstance: "ATT"}},
+			{"unknown-from", &config.FirewallFilterTerm{
+				Name: "t", DestAddresses: []string{"10.0.0.0/8"},
+				UnknownFrom: []string{"ttl"}, RoutingInstance: "ATT"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				filter := &config.FirewallFilter{Name: "u", Terms: []*config.FirewallFilterTerm{tc.term}}
+				rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+				if len(rules) != 0 {
+					t.Errorf("%s: unrepresentable predicate must emit 0 rules (no address-only over-steer), got %d: %+v",
+						tc.name, len(rules), rules)
+				}
+				if err == nil {
+					t.Errorf("%s: unrepresentable predicate must return a degraded build error", tc.name)
+				}
+			})
+		}
+	})
+
+	// #3730 an unparseable port / unknown protocol also fails closed.
+	t.Run("3730 unparseable port degrades", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "badport",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "t", DestinationPorts: []string{"not-a-port"}, DestAddresses: []string{"10.0.0.0/8"}, RoutingInstance: "ATT"},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if len(rules) != 0 {
+			t.Errorf("unparseable port must emit 0 rules, got %d", len(rules))
+		}
+		if err == nil {
+			t.Error("unparseable port must return a degraded build error")
+		}
+	})
+
+	// #3730 protocol 0 (HOPOPT) is not expressible (FRA_IP_PROTO>0 emit condition)
+	// → fail closed, mirroring the DSCP-0 handling.
+	t.Run("3730 protocol zero degrades", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "proto0",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "t", Protocols: []string{"0"}, DestAddresses: []string{"10.0.0.0/8"}, RoutingInstance: "ATT"},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if len(rules) != 0 {
+			t.Errorf("protocol 0 must emit 0 rules, got %d", len(rules))
+		}
+		if err == nil {
+			t.Error("protocol 0 must return a degraded build error")
+		}
+	})
+
+	// #3730 an address-only term still works unchanged (the honor path must not
+	// regress the representable-address case).
+	t.Run("3730 address-only unchanged", func(t *testing.T) {
+		filter := &config.FirewallFilter{
+			Name: "addronly",
+			Terms: []*config.FirewallFilterTerm{
+				{Name: "t", DestAddresses: []string{"10.5.0.0/16"}, RoutingInstance: "ATT"},
+			},
+		}
+		rules, err := BuildPBRRules(pbrTestConfig("inet", filter, instances, nil))
+		if err != nil {
+			t.Fatalf("address-only term must not degrade, got %v", err)
+		}
+		if len(rules) != 1 || rules[0].Dst != "10.5.0.0/16" {
+			t.Fatalf("expected 1 address-only rule, got %+v", rules)
+		}
+		if rules[0].IPProto != 0 || rules[0].Sport != nil || rules[0].Dport != nil {
+			t.Errorf("address-only rule must carry no L4 selector, got %+v", rules[0])
+		}
+	})
+
+	// #3730 apply leg: a rule carrying L4 selectors reaches the netlink rule with
+	// IPProto/Dport set. This pins the pbrManager.Apply wiring (RED if the Apply
+	// stops copying IPProto/Sport/Dport onto the netlink.Rule).
+	t.Run("3730 apply emits L4 selectors", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		p := &pbrManager{ops: ops}
+		if err := p.Apply([]PBRRule{
+			{Family: unix.AF_INET, IPProto: 6, Dport: &PBRPortRange{Lo: 443, Hi: 443}, TableID: 100, Instance: "vr"},
+		}); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		got := ops.rules[unix.AF_INET]
+		if len(got) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(got))
+		}
+		if got[0].IPProto != 6 {
+			t.Errorf("netlink rule IPProto = %d, want 6", got[0].IPProto)
+		}
+		if got[0].Dport == nil || got[0].Dport.Start != 443 || got[0].Dport.End != 443 {
+			t.Errorf("netlink rule Dport = %+v, want [443,443]", got[0].Dport)
+		}
+	})
 }
 
 // NOTE (#1918): the former TestProbeICMP asserted probeICMP("127.0.0.1")

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/psaab/xpf/pkg/appid"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -337,11 +338,46 @@ type PBRRule struct {
 	// the applier either skipped the rule (no address predicate) or widened
 	// it to ALL DSCP values (address predicate present). The rule emits a
 	// `tos` selector iff TOSSet is true.
-	TOSSet   bool
-	Src      string // source CIDR, "" = any (no `from` selector)
-	Dst      string // destination CIDR, "" = any (no `to` selector)
-	TableID  int    // target routing table
-	Instance string // routing instance name (for logging)
+	TOSSet bool
+	Src    string // source CIDR, "" = any (no `from` selector)
+	Dst    string // destination CIDR, "" = any (no `to` selector)
+	// IPProto, Sport and Dport mirror the L4 predicates a kernel `ip rule` CAN
+	// express (#3730): FRA_IP_PROTO, FRA_SPORT_RANGE and FRA_DPORT_RANGE. Before
+	// #3730 the FBF mirror emitted only the address/DSCP selectors and silently
+	// dropped every L4 predicate, so a port/protocol-constrained
+	// `then routing-instance` term either over-steered ALL address-matching
+	// traffic to the target VRF or no-opped — with no degraded signal. The
+	// builder now honors these; predicates an ip rule cannot represent
+	// (port-except, tcp-flags, icmp-type/code, is-fragment, flexible-match-range)
+	// fail closed (the whole term is dropped and the build is marked degraded)
+	// rather than widening the match.
+	IPProto  int           // IP protocol number, 0 = no protocol selector
+	Sport    *PBRPortRange // source-port range, nil = no source-port selector
+	Dport    *PBRPortRange // destination-port range, nil = no dest-port selector
+	TableID  int           // target routing table
+	Instance string        // routing instance name (for logging)
+}
+
+// PBRPortRange is a numeric [Lo,Hi] port range for the kernel FBF ip-rule
+// mirror. A single port has Lo==Hi. It maps 1:1 onto netlink's RulePortRange
+// (FRA_SPORT_RANGE / FRA_DPORT_RANGE) but stays netlink-free so the builder is
+// unit-testable without the kernel.
+type PBRPortRange struct {
+	Lo uint16
+	Hi uint16
+}
+
+// String renders the range as a single port ("443") or a low-high span
+// ("1024-2048"). A nil receiver renders as "" so it is safe to log an unset
+// selector directly.
+func (r *PBRPortRange) String() string {
+	if r == nil {
+		return ""
+	}
+	if r.Lo == r.Hi {
+		return strconv.Itoa(int(r.Lo))
+	}
+	return fmt.Sprintf("%d-%d", r.Lo, r.Hi)
 }
 
 // maxPBRRules bounds the number of ip rules the PBR builder/applier will
@@ -420,13 +456,28 @@ func (p *pbrManager) Apply(rules []PBRRule) error {
 			rule.Dst = dst
 		}
 
+		// Emit the L4 selectors the kernel ip rule supports (#3730). IPProto is
+		// written only when > 0 (the netlink FRA_IP_PROTO emit condition; 0 =
+		// "match any"). Sport/Dport map onto FRA_SPORT_RANGE / FRA_DPORT_RANGE.
+		if pbr.IPProto > 0 {
+			rule.IPProto = pbr.IPProto
+		}
+		if pbr.Sport != nil {
+			rule.Sport = netlink.NewRulePortRange(pbr.Sport.Lo, pbr.Sport.Hi)
+		}
+		if pbr.Dport != nil {
+			rule.Dport = netlink.NewRulePortRange(pbr.Dport.Lo, pbr.Dport.Hi)
+		}
+
 		if err := p.ops.RuleAdd(rule); err != nil {
 			errs = append(errs, fmt.Errorf("add PBR rule instance %s table %d: %w", pbr.Instance, pbr.TableID, err))
 			continue
 		}
 		slog.Info("PBR rule added",
 			"instance", pbr.Instance, "tos", pbr.TOS, "tos_set", pbr.TOSSet,
-			"src", pbr.Src, "dst", pbr.Dst, "table", pbr.TableID)
+			"src", pbr.Src, "dst", pbr.Dst, "ipproto", pbr.IPProto,
+			"sport", pbr.Sport.String(), "dport", pbr.Dport.String(),
+			"table", pbr.TableID)
 		prio++
 	}
 	// Desired rules are re-added; surface any clear/parse/add/overflow failure.
@@ -478,11 +529,30 @@ func (p *pbrManager) clear() error {
 // selector requires the kernel ifname mapping and is a separate change), so a
 // duplicate per attachment would be redundant.
 //
+// Kernel-mirror support matrix (#3730). An `ip rule` can only express a subset
+// of a firewall-filter term's `from` predicates, so the mirror is exact for the
+// representable ones and FAILS CLOSED for the rest:
+//
+//   - REPRESENTABLE (honored): source/destination address + prefix-list (FRA_SRC/
+//     FRA_DST), DSCP (rtmsg tos, DSCP-0 excepted — see below), `protocol`
+//     (FRA_IP_PROTO), `source-port` (FRA_SPORT_RANGE) and `destination-port`
+//     (FRA_DPORT_RANGE). Multi-value protocol/port sets expand to one ip rule per
+//     value; a port range maps to a single [lo,hi] rule range.
+//   - UNREPRESENTABLE (fail-closed, whole term dropped + degraded): a non-empty
+//     address `except` set, a DSCP-0 match (the netlink layer writes tos only when
+//     non-zero and a zero tos matches ANY DSCP), `source-port-except` /
+//     `destination-port-except` (no negated port selector), `tcp-flags`,
+//     `icmp-type` / `icmp-code`, `is-fragment`, `flexible-match-range`, and any
+//     unresolved / unenforceable `from` leaf. Emitting the address/protocol/port
+//     half while silently dropping these would WIDEN the match and steer traffic
+//     the operator constrained away (the #3730 over-steer); dropping the term is
+//     the fail-safe under-steer (steered traffic falls back to the main table),
+//     and the userspace filter path still enforces the term exactly.
+//
 // The returned error is non-nil when the build is DEGRADED: a term carries an
-// ip-rule-unrepresentable predicate (a non-empty address `except` set, or a
-// DSCP-0 match the netlink layer cannot express) or the expansion exceeds
-// maxPBRRules. The successfully-built rules are still returned so the caller
-// can install them and surface the degradation.
+// ip-rule-unrepresentable predicate (per the matrix above) or the expansion
+// exceeds maxPBRRules. The successfully-built rules are still returned so the
+// caller can install them and surface the degradation.
 func BuildPBRRules(cfg *config.Config) ([]PBRRule, error) {
 	if cfg == nil {
 		return nil, nil
@@ -571,7 +641,8 @@ func sortedKeys(m map[string]struct{}) []string {
 
 // buildPBRFromFilter extracts PBR rules from a single firewall filter.
 // The returned error slice carries per-term DEGRADED conditions (an
-// unrepresentable except set); the buildable rules are still returned.
+// unrepresentable except set, a DSCP-0 match, or an ip-rule-unrepresentable
+// L4/per-packet predicate — #3730); the buildable rules are still returned.
 func buildPBRFromFilter(filter *config.FirewallFilter, family int, tableIDs map[string]int, pls map[string]*config.PrefixList) ([]PBRRule, []error) {
 	var rules []PBRRule
 	var errs []error
@@ -584,6 +655,25 @@ func buildPBRFromFilter(filter *config.FirewallFilter, family int, tableIDs map[
 			slog.Warn("PBR: routing-instance not found",
 				"filter", filter.Name, "term", term.Name,
 				"instance", term.RoutingInstance)
+			continue
+		}
+
+		// Classify the term's L4/per-packet predicates against what a kernel ip
+		// rule can express (#3730). A predicate an ip rule cannot represent
+		// (port-except / tcp-flags / icmp / is-fragment / flex / unresolved from
+		// leaf, or an unknown protocol / unparseable port) fails CLOSED: the whole
+		// term is dropped so the mirror never widens a constrained steer to
+		// address-only. The representable predicates (protocol, source/destination
+		// port) are honored below via the cross-product.
+		protos, sports, dports, unrep := pbrTermL4(term)
+		if len(unrep) > 0 {
+			errs = append(errs, fmt.Errorf(
+				"PBR filter %s term %s carries filter predicate(s) [%s] that a kernel "+
+					"ip rule cannot represent (the FBF mirror steers on address / DSCP / "+
+					"protocol / port only); steering for this term is dropped (fail-safe "+
+					"under-steer to the main table) rather than widening the match — enforce "+
+					"it on the userspace filter path",
+				filter.Name, term.Name, strings.Join(unrep, ", ")))
 			continue
 		}
 
@@ -666,29 +756,151 @@ func buildPBRFromFilter(filter *config.FirewallFilter, family int, tableIDs map[
 		}
 		srcConstrained := !(len(srcs) == 1 && srcs[0] == "")
 		dstConstrained := !(len(dsts) == 1 && dsts[0] == "")
-		if !hasDSCP && !srcConstrained && !dstConstrained {
-			slog.Warn("PBR: filter term has routing-instance but no ip-rule-compatible criteria (dscp, source-address, destination-address)",
+		// A protocol / source-port / destination-port constraint is now an
+		// ip-rule-compatible criterion (#3730), so a term carrying only an L4
+		// predicate is no longer a no-op under-steer — it emits an ip rule with
+		// the L4 selector.
+		hasL4 := len(protos) > 0 || len(sports) > 0 || len(dports) > 0
+		if !hasDSCP && !srcConstrained && !dstConstrained && !hasL4 {
+			// A truly unconstrained `then routing-instance` term (no dscp, no
+			// address, no L4) would program `from all to all lookup <vr>`, which —
+			// the mirror has no iif selector (H03) — steers ALL traffic globally.
+			// Skip it (fail-safe under-steer), matching the pre-#3730 behavior.
+			slog.Warn("PBR: filter term has routing-instance but no ip-rule-compatible criteria (dscp, address, protocol, port)",
 				"filter", filter.Name, "term", term.Name)
 			continue
 		}
 
+		// Normalize each L4 dimension to a single "unset" entry when the term did
+		// not constrain it, so the cross-product still emits one rule per
+		// dscp × src × dst combination (IPProto 0 / nil port = no selector).
+		if len(protos) == 0 {
+			protos = []int{0}
+		}
+		if len(sports) == 0 {
+			sports = []*PBRPortRange{nil}
+		}
+		if len(dports) == 0 {
+			dports = []*PBRPortRange{nil}
+		}
+
 		for _, t := range toses {
-			for _, src := range srcs {
-				for _, dst := range dsts {
-					rules = append(rules, PBRRule{
-						Family:   family,
-						TOS:      t.tos,
-						TOSSet:   t.set,
-						Src:      src,
-						Dst:      dst,
-						TableID:  tableID,
-						Instance: term.RoutingInstance,
-					})
+			for _, proto := range protos {
+				for _, sp := range sports {
+					for _, dp := range dports {
+						for _, src := range srcs {
+							for _, dst := range dsts {
+								rules = append(rules, PBRRule{
+									Family:   family,
+									TOS:      t.tos,
+									TOSSet:   t.set,
+									IPProto:  proto,
+									Sport:    sp,
+									Dport:    dp,
+									Src:      src,
+									Dst:      dst,
+									TableID:  tableID,
+									Instance: term.RoutingInstance,
+								})
+							}
+						}
+					}
 				}
 			}
 		}
 	}
 	return rules, errs
+}
+
+// pbrTermL4 classifies a routing-instance term's L4 / per-packet `from`
+// predicates against what a kernel `ip rule` can express (#3730).
+//
+// It returns the REPRESENTABLE dimensions the caller folds into the ip-rule
+// cross-product — protos (FRA_IP_PROTO values), sports and dports
+// (FRA_SPORT_RANGE / FRA_DPORT_RANGE) — plus unrep, the list of predicates the
+// term carries that an ip rule CANNOT represent. A non-empty unrep means the
+// caller must FAIL CLOSED (drop the whole term + degrade); honoring the
+// representable half while dropping the rest would widen the steer beyond what
+// the operator authored (the #3730 over-steer). Unknown protocol names,
+// protocol 0 (HOPOPT, which the netlink FRA_IP_PROTO>0 emit condition cannot
+// express), and unparseable ports are also reported as unrep so they fail
+// closed rather than silently narrowing/widening the match.
+func pbrTermL4(term *config.FirewallFilterTerm) (protos []int, sports, dports []*PBRPortRange, unrep []string) {
+	// Predicates an ip rule has no selector for at all.
+	if hasRealString(term.SourcePortsExcept) {
+		unrep = append(unrep, "source-port-except")
+	}
+	if hasRealString(term.DestPortsExcept) {
+		unrep = append(unrep, "destination-port-except")
+	}
+	if len(term.TCPFlags) > 0 {
+		unrep = append(unrep, "tcp-flags")
+	}
+	if term.IsFragment {
+		unrep = append(unrep, "is-fragment")
+	}
+	if len(term.ICMPTypes) > 0 || len(term.UnknownICMPTypes) > 0 {
+		unrep = append(unrep, "icmp-type")
+	}
+	if len(term.ICMPCodes) > 0 || len(term.UnknownICMPCodes) > 0 {
+		unrep = append(unrep, "icmp-code")
+	}
+	if term.FlexMatch != nil || len(term.UnknownFlexMatch) > 0 {
+		unrep = append(unrep, "flexible-match-range")
+	}
+	for _, f := range term.UnknownFrom {
+		unrep = append(unrep, "unsupported from-match "+f)
+	}
+
+	// Representable: `from protocol` → one FRA_IP_PROTO value per protocol.
+	for _, p := range term.Protocols {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		n, ok := appid.ProtocolNumber(p)
+		if !ok || n == 0 {
+			unrep = append(unrep, fmt.Sprintf("protocol %q", p))
+			continue
+		}
+		protos = append(protos, int(n))
+	}
+
+	// Representable: `from source-port` / `from destination-port` → one
+	// FRA_SPORT_RANGE / FRA_DPORT_RANGE per port spec (a range maps to [lo,hi]).
+	for _, spec := range term.SourcePorts {
+		if strings.TrimSpace(spec) == "" {
+			continue
+		}
+		lo, hi, ok := config.ResolveFilterPortRange(spec)
+		if !ok {
+			unrep = append(unrep, fmt.Sprintf("source-port %q", spec))
+			continue
+		}
+		sports = append(sports, &PBRPortRange{Lo: lo, Hi: hi})
+	}
+	for _, spec := range term.DestinationPorts {
+		if strings.TrimSpace(spec) == "" {
+			continue
+		}
+		lo, hi, ok := config.ResolveFilterPortRange(spec)
+		if !ok {
+			unrep = append(unrep, fmt.Sprintf("destination-port %q", spec))
+			continue
+		}
+		dports = append(dports, &PBRPortRange{Lo: lo, Hi: hi})
+	}
+	return protos, sports, dports, unrep
+}
+
+// hasRealString reports whether the slice carries at least one non-empty
+// (trimmed) entry — the "constrained" test for a firewall-filter match list.
+func hasRealString(vals []string) bool {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // resolvePBRDirection resolves one direction (source or destination) of a


### PR DESCRIPTION
Closes #3730

## Problem

The kernel filter-based-forwarding (FBF) ip-rule mirror
(`buildPBRFromFilter`, `pkg/routing/rules.go`) derived a
`then routing-instance` term's ip rules from ONLY the DSCP +
source/destination address of the term and silently dropped every L4 /
per-packet `from` predicate (`protocol`, `source-port`,
`destination-port`, `*-port-except`, `tcp-flags`, `icmp-type`/`icmp-code`,
`is-fragment`, `flexible-match-range`). The userspace filter path enforces
all of them, so the two forwarding paths diverged silently:

1. **Over-steer (fail-open widening).** `from destination-port 443
   destination-address 203.0.113.10/32 then routing-instance blue`
   collapsed to an address-only `to 203.0.113.10/32 lookup blue` rule.
   Port 443 was dropped, so SSH, DNS, ICMP and every other protocol to
   that host was policy-routed into `blue` on the kernel/XDP_PASS path —
   with no degraded error.
2. **Under-steer (silent no-op).** A term with only an L4 predicate hit
   the "no ip-rule-compatible criteria" branch and emitted no rule AND no
   degraded error — the operator believed FBF was active.

The build-degraded machinery covered only the address-`except` /
DSCP-0 / overflow cases (#3430); there was no degraded path for an ignored
L4 predicate.

## Fix

Mirrors the existing #3430 DSCP-0 / except degrade pattern.

- **HONOR** the predicates a modern kernel `ip rule` CAN express:
  `protocol` → `FRA_IP_PROTO`, `source-port` → `FRA_SPORT_RANGE`,
  `destination-port` → `FRA_DPORT_RANGE`. A new `pbrTermL4` classifier
  resolves them and folds them into the DSCP × source × destination
  cross-product — a multi-value protocol/port set expands to one ip rule
  per value; a port range maps to a single `[lo,hi]` rule range. Named /
  ranged ports resolve through the new `config.ResolveFilterPortRange`
  (reuses the `junosServicePorts` SSOT, so the kernel mirror and the
  userspace path resolve ports identically).
- **DEGRADE-SIGNAL fail-closed** for any predicate an `ip rule` genuinely
  cannot represent (`*-port-except`, `tcp-flags`, `icmp-type`/`icmp-code`,
  `is-fragment`, `flexible-match-range`, unknown protocol / protocol 0
  HOPOPT, unparseable port, any unresolved `from` leaf): the whole term is
  DROPPED (fail-safe under-steer — steered traffic falls back to the main
  table, never widened to an address-only over-steer) and a degraded build
  error naming filter/term/predicate is recorded. The daemon
  (`daemon_apply.go` step 3d) surfaces the returned error via `slog.Warn`
  (the same #3430 channel; M08).

`PBRRule` gains `IPProto`/`Sport`/`Dport` (plus the netlink-free
`PBRPortRange`); `pbrManager.Apply` copies them onto the `netlink.Rule`
(`IPProto` emitted only when > 0). `BuildPBRRules` documents the full
kernel-mirror support matrix (M10); `docs/multi-wan.md` and
`pkg/routing/README.md` are updated to match.

H03 (no iif selector) is left as-is — it is documented deliberate design
at `rules.go`, not part of this fix.

## Tests / RED-on-revert

13 new `#3730` subtests in `pkg/routing/routing_test.go`. Verified RED on
revert by stubbing `pbrTermL4` to the pre-fix behavior: the over-steer
(address-only rule emitted for tcp-flags/icmp/frag/flex/except), the
under-steer (port-only term → 0 rules), the un-expanded protocol, the
dropped ports, and the missing degrade error all go RED. Address-only
terms and the #3430 DSCP-0/except/overflow cases stay green.

`go test ./pkg/routing/... ./pkg/config/...` green; `go build ./...`
green; `gofmt` + `go vet` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
