### PR TITLE
event-options: strict-validate within/trigger numerics at commit + engine fail-closed (#3751)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25744,3 +25744,41 @@ top.
   docs/research/ddns-world-class/plan.md (§5.3 checkip fail-closed invariant)
   **Action**: cluster-setup.sh — VM SR-IOV VFs use nictype:sriov (incus-managed) instead of raw type:pci passthrough with out-of-band host-PF VLAN/trust. Fixes the 2026-07-01 loss-cluster LAN de-isolation outage (host-PF VF VLAN was set once at create and cleared on host reboot / PF reset, reverting fw0/fw1 LAN VFs to an untagged trunk → cluster host cut off from the internet). incus now re-applies vlan=3667 (LAN) + security.mac_filtering=false (WAN trunk, RETH vMAC + guest VLAN tagging) on every VM start — durable across VM reboot AND host reboot, no systemd unit / no ip-link bolt-on. Live loss cluster reconfigured + verified (both nodes, failover both directions, 15.4 Gbps WAN forwarding, host→internet 0% loss).
   **File(s)**: test/incus/cluster-setup.sh
+
+- **Timestamp**: 2026-07-01
+  **Action**: #3751 — event-options within/trigger numeric strict-validation
+  (fail-open fix). compileEventOptions (compiler_services.go) parsed the
+  `within <seconds>` and `trigger (on|until) <count>` numerics with
+  strconv.Atoi and SILENTLY dropped the error → a typo coerced the field to 0,
+  and the engine's withinMatches treated a 0 threshold as an unconditional
+  match → a threshold-gated autonomous remediation silently became ALWAYS-FIRE
+  (H11). Also H12 (negative / huge / zero window; huge risked a time.Duration
+  overflow) and H13 (a single clause carrying both `trigger on` and
+  `trigger until`, ANDed into a nonsensical one-count band). FIX (two halves,
+  mirroring the #2141 attributes-match strict/lenient doctrine):
+  (a) commit-time strict validator validateEventOptionsWithinAST
+  (new pkg/config/event_options_within.go) — an AST pre-walk (the raw typo is
+  lost once coerced to 0; forEachChild over every top-level event-options block
+  per #3562) run inside compileExpanded on the group-expanded, inactive-pruned
+  tree. Rejects non-numeric / negative / zero / out-of-range within (1..86400 s)
+  and trigger count (1..1000000), an unknown trigger keyword (Junos `after`), a
+  within with no trigger, and the on+until combination. Strict on commit /
+  commit-check; downgraded to a cfg.Warnings entry on the tolerant load /
+  peer-sync paths (new compileOpts.lenientEventWithinTrigger, set in
+  CompileConfigLenient + CompileConfigForNodeLenient, #1960 no-brick).
+  (b) engine defense-in-depth — withinMatches (pkg/eventengine/engine.go) now
+  fails CLOSED on a within clause with no usable positive threshold (both
+  trigger on/until <=0) or a non-positive window, so a leftover 0 from an older
+  binary no longer over-fires; a policy with NO within clauses still fires on
+  every match (no temporal filter). RED-on-revert verified for BOTH halves
+  (stubbed validator → commit accepts the typos; stubbed engine guard →
+  0-threshold policy fires 10/10). go test ./pkg/config/... ./pkg/eventengine/...
+  green; downstream ./pkg/configstore/... ./pkg/daemon/... green; go build
+  ./... green; gofmt + vet clean. Schema desc/docs updated.
+  **File(s)**: pkg/config/event_options_within.go (new validator),
+  pkg/config/compiler.go (lenientEventWithinTrigger opt + call site),
+  pkg/config/schema_system.go (within/trigger desc ranges),
+  pkg/eventengine/engine.go (withinMatches fail-closed + header doc),
+  pkg/config/event_options_within_3751_test.go (new, RED-on-revert),
+  pkg/eventengine/engine_within_failclosed_3751_test.go (new, RED-on-revert),
+  docs/config-schema.md (#3751 validator entry)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1303,6 +1303,49 @@ reserved for whole-dataplane selection where a rewrite shim
   `pkg/config/host_inbound_tokens_test.go` (commit reject + accept + lenient
   downgrade) and `pkg/daemon/host_inbound_parity_test.go` (nft-matcher-domain
   == SSOT parity + zero-match-zone fail-closed).
+- **#3751 (event-options within/trigger numeric validation — fail-open typo):**
+  `event-options policy <name> within <seconds> { trigger (on|until) <count>; }`
+  gated a remediation on a temporal threshold, but `compileEventOptions`
+  (`compiler_services.go`) parsed the time-interval and the trigger count with
+  `strconv.Atoi` and SILENTLY DROPPED the error — a typo (`within bogus`,
+  `trigger on typo`) coerced the field to 0. The engine's `withinMatches`
+  (`pkg/eventengine`) then skipped both `> 0`-guarded trigger tests and
+  returned true, so the policy fired on EVERY matching event: a typo silently
+  converted a threshold-gated remediation (e.g. "rewrite the default route only
+  after 4 probe failures in 30s") into an UNCONDITIONAL one — the dangerous
+  fail-open direction. This folds H11 (typo→0→always-fire), H12 (negative /
+  absurdly-huge / zero window — the huge case also risked a `time.Duration`
+  overflow when multiplied by `time.Second`) and H13 (a single clause carrying
+  BOTH `trigger on` and `trigger until`, which the engine ANDs into an
+  almost-certainly-unintended narrow one-count band). Like
+  `validateDNATRuleSetToScopeAST` (#3444) this is an AST pre-walk
+  (`validateEventOptionsWithinAST`, `event_options_within.go`), NOT a
+  SchemaValidate typed leaf: the raw typo'd token is lost once the compiler
+  coerces it to 0, and the constraint spans a whole `within` clause (the
+  seconds slot AND the nested trigger keyword/count AND the on/until mutual
+  exclusion) — which a per-leaf validator cannot express, and SchemaValidate
+  returns nil for keywords it does not know so it cannot REJECT a malformed
+  trigger. The walk descends with `forEachChild` over EVERY top-level
+  `event-options` block (the #3562 duplicate-block discipline —
+  `event-options` is a top-level stanza) on the group-expanded, inactive-pruned
+  tree, so an apply-groups-inherited clause is validated and an `inactive:` one
+  is ignored. It rejects a non-numeric / negative / zero / out-of-range
+  `within` (`1..86400` seconds) or `trigger` count (`1..1000000`), an unknown
+  trigger keyword (Junos's unsupported `after`), a within clause with no
+  trigger (gates nothing), and the on+until combination. Strict on commit /
+  commit-check (hard-reject naming the policy + value); downgraded to a
+  `cfg.Warnings` entry on the tolerant load / peer-sync paths
+  (`lenientEventWithinTrigger`, #1960 no-brick) so an older-binary-persisted or
+  peer-synced config that silently accepted a coerced-to-0 clause still boots.
+  Defense-in-depth (#3751 second half): on that legacy boot the engine's
+  `withinMatches` now fails CLOSED (the policy does NOT fire) on a within
+  clause with no usable positive threshold — a leftover 0 no longer over-fires
+  — while a policy with NO within clauses at all still fires on every match
+  (no temporal filter). Regression coverage:
+  `pkg/config/event_options_within_3751_test.go` (both AST shapes: commit
+  reject per error class + accept + H13 + lenient downgrade) and
+  `pkg/eventengine/engine_within_failclosed_3751_test.go` (fire-only-after-N,
+  0-threshold + 0-window fail-closed, no-clause-still-fires).
 - **#1387 (DHCP dynamic-DNS — live rfc2136 backend):** added an opt-in
   `dynamic-dns` subtree under BOTH `services dhcp-local-server` and
   `services dhcpv6-local-server` (a single shared `config.DHCPDynamicDNSConfig`

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -1253,6 +1253,25 @@ type compileOpts struct {
 	// either way, now flagged. Same doctrine as
 	// lenientUnsupportedInterfaceStanzas.
 	lenientDNATToScope bool
+
+	// lenientEventWithinTrigger (#3751) downgrades the event-options
+	// within/trigger numeric gate (validateEventOptionsWithinAST) from a hard
+	// compile error to a cfg.Warnings entry. A non-numeric / negative / zero /
+	// out-of-range `within <seconds>` or `trigger (on|until) <count>` value,
+	// or a `within` clause carrying BOTH `trigger on` and `trigger until`, was
+	// previously accepted: compileEventOptions dropped the strconv.Atoi error
+	// and coerced the field to 0, and the engine's withinMatches then treated
+	// a 0 threshold as an unconditional match — a typo silently converted a
+	// threshold-gated remediation into an ALWAYS-FIRE one (fail-open). The
+	// strict commit / commit-check path hard-rejects so the operator error is
+	// visible (naming the policy and the exact value); the tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config an older binary silently accepted still BOOTS (#1960
+	// fail-closed-on-load class) — on that boot the engine's withinMatches
+	// fails CLOSED (does not fire) on a clause with no usable positive
+	// threshold, so the mis-arrived 0 no longer over-fires. Same doctrine as
+	// lenientEventAttributesMatch (its attributes-match sibling).
+	lenientEventWithinTrigger bool
 }
 
 // CompileConfig converts a parsed ConfigTree AST into a typed Config struct.
@@ -1353,6 +1372,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientPolicyCommunityRef:            true,
 		lenientVRRPVirtualAddress:            true,
 		lenientDNATToScope:                   true,
+		lenientEventWithinTrigger:            true,
 	})
 }
 
@@ -1515,6 +1535,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientPolicyCommunityRef:            true,
 		lenientVRRPVirtualAddress:            true,
 		lenientDNATToScope:                   true,
+		lenientEventWithinTrigger:            true,
 	})
 }
 
@@ -2858,6 +2879,27 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 			return nil, err
 		}
 	}
+
+	// #3751: event-options within/trigger numerics. compileEventOptions
+	// parsed the within time-interval and the trigger count with strconv.Atoi
+	// and SILENTLY dropped the error, so a typo (`within bogus`, `trigger on
+	// typo`) coerced the field to 0. The engine then treated a 0 threshold as
+	// an unconditional match — a threshold-gated remediation silently became
+	// ALWAYS-FIRE (fail-open). This gate rejects a non-numeric / negative /
+	// zero / out-of-range value and a within clause carrying both `trigger on`
+	// and `trigger until` (contradictory). It is an AST pre-walk (the raw
+	// typo'd token is lost once compileEventOptions coerces it to 0) run on
+	// the group-expanded, inactive-pruned tree so an apply-groups-inherited
+	// clause is caught and an inactive one is ignored. Strict (commit /
+	// commit-check): hard-reject naming the policy and value. Lenient (load /
+	// peer-sync): warn so an already-persisted or peer-synced config an older
+	// binary silently accepted still boots (#1960) — the engine's withinMatches
+	// then fails CLOSED on the leftover 0 threshold rather than over-firing.
+	withinWarnings, werr := validateEventOptionsWithinAST(tree.Children, opts.lenientEventWithinTrigger)
+	if werr != nil {
+		return nil, werr
+	}
+	cfg.Warnings = append(cfg.Warnings, withinWarnings...)
 
 	// #2074 IPsec VPN -> IKE gateway cross-reference. A VPN that
 	// references a gateway which is neither a defined gateway object nor a

--- a/pkg/config/event_options_within.go
+++ b/pkg/config/event_options_within.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// event_options_within.go carries the #3751 strict commit-time numeric
+// validation for an event-options policy `within <seconds> { trigger
+// (on|until) <count>; }` clause.
+//
+// BEFORE this gate compileEventOptions (compiler_services.go) parsed the
+// within time-interval and the trigger count with strconv.Atoi and SILENTLY
+// DROPPED the error, leaving the field at its zero value. A typo therefore
+// compiled cleanly: `within bogus { trigger on typo; }` became Seconds=0,
+// TriggerOn=0, TriggerUntil=0. The engine's withinMatches then skipped both
+// (> 0)-guarded trigger tests and returned true — the policy fired on EVERY
+// matching event. A typo in a temporal gate silently converted a
+// threshold-gated remediation (e.g. "only rewrite the default route after 4
+// probe failures in 30s") into an UNCONDITIONAL one (fires on the first
+// failure, forever) — the dangerous fail-open direction per the #2124
+// doctrine. This gate folds:
+//
+//   - H11: non-numeric within / trigger count → was coerced to 0 → always-fire.
+//   - H12: negative / absurdly-huge within → nonsensical window; a huge value
+//     also risks a time.Duration overflow when multiplied by time.Second in
+//     the engine (int64 ns overflows past ~9.2e9 s). The [1, 86400] cap
+//     forecloses the overflow entirely.
+//   - H13: a single within clause carrying BOTH `trigger on` and `trigger
+//     until` — the compiler fills both fields and the engine ANDs them into a
+//     narrow one-count band that is almost certainly unintended; it is never
+//     surfaced as ambiguous.
+//
+// Like validateDNATRuleSetToScopeAST (#3444) this is an AST pre-walk, not a
+// SchemaValidate typed leaf: the constraint spans a whole `within` clause (the
+// seconds slot AND the nested trigger keyword/count AND the mutual exclusion of
+// on/until), which a per-leaf validator cannot express, and SchemaValidate
+// returns nil for keywords it does not know so it cannot REJECT a malformed
+// trigger. The walk descends with forEachChild over EVERY top-level
+// `event-options` block (the #3562 duplicate-block discipline — event-options
+// is a top-level stanza and parseStatements appends a repeated block as a
+// sibling). It runs on the group-expanded, inactive-pruned tree, so an
+// apply-groups-inherited clause is validated and an `inactive:` clause is
+// ignored for free.
+//
+// Strict path (commit / commit-check, lenient=false): the first offending
+// clause is a hard compile error naming the policy and the exact value.
+//
+// Lenient path (load / peer-sync, lenient=true): every offending clause is
+// returned as a warning and compilation continues (#1960 fail-closed-on-load
+// doctrine) so an older-binary-persisted or peer-synced config that silently
+// accepted a coerced-to-0 clause still BOOTS. On that legacy boot the engine's
+// withinMatches fails CLOSED (does not fire) on a clause with no usable
+// positive threshold — the mis-arrived 0 no longer over-fires (#3751
+// defense-in-depth, pkg/eventengine/engine.go).
+
+const (
+	// minEventWithinSeconds / maxEventWithinSeconds bound a within
+	// time-interval. The upper bound (24h) also caps the time.Duration
+	// overflow window (H12): the engine multiplies Seconds by time.Second
+	// (1e9 ns), which overflows int64 past ~9.2e9 s — 86400 is far below it.
+	minEventWithinSeconds = 1
+	maxEventWithinSeconds = 86400
+
+	// minEventTriggerCount / maxEventTriggerCount bound a trigger event
+	// count. A count is a number of matching events in the window; it is not
+	// multiplied by a duration, so the upper bound is a sanity cap rather than
+	// an overflow guard.
+	minEventTriggerCount = 1
+	maxEventTriggerCount = 1_000_000
+)
+
+// eventTriggerSpec is one parsed `on <count>` or `until <count>` under a
+// within clause's `trigger` node.
+type eventTriggerSpec struct {
+	keyword  string // "on" or "until"
+	count    string // the raw count token as authored
+	hasCount bool   // false when the keyword carried no value token
+}
+
+// parseEventTriggerSpecs extracts every on/until spec from a `trigger` node,
+// covering BOTH AST shapes compileEventOptions reads:
+//
+//   - hierarchical leaf: Keys = ["trigger", "on", "3"] (or a pathological
+//     ["trigger", "on", "3", "until", "5"] / ["trigger", "on"] with no count).
+//   - flat set:          Keys = ["trigger"], Children = [{Keys:["on","3"]}, …].
+//
+// It also returns any keyword token that is neither `on` nor `until` (e.g.
+// Junos's unsupported `trigger after`) so the caller can reject it rather than
+// let the compiler silently drop it (→ TriggerOn/Until stay 0 → always-fire).
+func parseEventTriggerSpecs(trigNode *Node) (specs []eventTriggerSpec, unknown []string) {
+	// Hierarchical leaf form: keyword/value pairs after the "trigger" key.
+	keys := trigNode.Keys
+	for i := 1; i < len(keys); {
+		kw := keys[i]
+		if kw == "on" || kw == "until" {
+			if i+1 < len(keys) {
+				specs = append(specs, eventTriggerSpec{keyword: kw, count: keys[i+1], hasCount: true})
+				i += 2
+			} else {
+				specs = append(specs, eventTriggerSpec{keyword: kw})
+				i++
+			}
+			continue
+		}
+		unknown = append(unknown, kw)
+		i++
+	}
+
+	// Flat set form: each child is a keyword node with the count as its value.
+	for _, ch := range trigNode.Children {
+		if len(ch.Keys) == 0 {
+			continue
+		}
+		kw := ch.Keys[0]
+		if kw != "on" && kw != "until" {
+			unknown = append(unknown, kw)
+			continue
+		}
+		if v := nodeVal(ch); v != "" {
+			specs = append(specs, eventTriggerSpec{keyword: kw, count: v, hasCount: true})
+		} else {
+			specs = append(specs, eventTriggerSpec{keyword: kw})
+		}
+	}
+	return specs, unknown
+}
+
+// validateEventOptionsWithinAST walks the `event-options policy <name> within`
+// subtree of the group-expanded AST and validates each within clause's
+// time-interval and trigger count numerics. See the file header for the fail-
+// open class this closes and the strict/lenient split.
+func validateEventOptionsWithinAST(nodes []*Node, lenient bool) ([]string, error) {
+	var warnings []string
+	emit := func(format string, args ...any) error {
+		msg := fmt.Sprintf(format, args...)
+		if !lenient {
+			return fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+		return nil
+	}
+
+	// forEachChild descends EVERY top-level event-options block (the #3562
+	// duplicate-block discipline) so a within clause in a second appended
+	// event-options {} is not bypassed.
+	err := forEachChild(nodes, "event-options", func(eo *Node) error {
+		for _, pInst := range namedInstances(eo.FindChildren("policy")) {
+			for _, w := range pInst.node.FindChildren("within") {
+				if err := validateEventWithinClause(pInst.name, w, emit); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return warnings, nil
+}
+
+// validateEventWithinClause validates one `within <seconds> { trigger … }`
+// clause. emit returns a non-nil error on the strict path (stopping the walk)
+// and accumulates a warning on the lenient path (continuing).
+func validateEventWithinClause(policy string, w *Node, emit func(string, ...any) error) error {
+	// within time-interval — always the second key (nodeVal's child fallback
+	// would mis-read the `trigger` child as the value, so read Keys[1]
+	// directly).
+	secTok := ""
+	if len(w.Keys) >= 2 {
+		secTok = w.Keys[1]
+	}
+	if secTok == "" {
+		return emit("event-options policy %q within clause: missing time-interval "+
+			"<seconds> value", policy)
+	}
+	sec, err := strconv.Atoi(secTok)
+	if err != nil {
+		return emit("event-options policy %q within %q: time-interval is not a "+
+			"valid integer (expected %d..%d seconds)",
+			policy, secTok, minEventWithinSeconds, maxEventWithinSeconds)
+	}
+	if sec < minEventWithinSeconds || sec > maxEventWithinSeconds {
+		return emit("event-options policy %q within %d: time-interval out of range "+
+			"(expected %d..%d seconds)",
+			policy, sec, minEventWithinSeconds, maxEventWithinSeconds)
+	}
+
+	// trigger — a within clause with no trigger gates nothing; the engine
+	// would treat it as an unconditional match (fail-open), so require one.
+	trigNode := w.FindChild("trigger")
+	if trigNode == nil {
+		return emit("event-options policy %q within %d: missing a `trigger on|until "+
+			"<count>` (a within clause with no trigger gates nothing)",
+			policy, sec)
+	}
+
+	specs, unknown := parseEventTriggerSpecs(trigNode)
+	for _, kw := range unknown {
+		return emit("event-options policy %q within %d: unknown trigger keyword %q "+
+			"(expected `on` or `until`)", policy, sec, kw)
+	}
+	if len(specs) == 0 {
+		return emit("event-options policy %q within %d: trigger requires `on` or "+
+			"`until` with a <count>", policy, sec)
+	}
+
+	var haveOn, haveUntil bool
+	for _, s := range specs {
+		switch s.keyword {
+		case "on":
+			haveOn = true
+		case "until":
+			haveUntil = true
+		}
+	}
+	if haveOn && haveUntil {
+		// H13: on and until on one clause AND to a narrow one-count band in
+		// the engine — almost certainly unintended, never surfaced.
+		return emit("event-options policy %q within %d: trigger specifies both "+
+			"`on` and `until` (contradictory) — use exactly one", policy, sec)
+	}
+
+	for _, s := range specs {
+		if !s.hasCount || s.count == "" {
+			return emit("event-options policy %q within %d: trigger %s requires a "+
+				"<count> value", policy, sec, s.keyword)
+		}
+		n, err := strconv.Atoi(s.count)
+		if err != nil {
+			return emit("event-options policy %q within %d: trigger %s %q count is "+
+				"not a valid integer (expected %d..%d)",
+				policy, sec, s.keyword, s.count, minEventTriggerCount, maxEventTriggerCount)
+		}
+		if n < minEventTriggerCount || n > maxEventTriggerCount {
+			return emit("event-options policy %q within %d: trigger %s %d count out "+
+				"of range (expected %d..%d)",
+				policy, sec, s.keyword, n, minEventTriggerCount, maxEventTriggerCount)
+		}
+	}
+
+	return nil
+}

--- a/pkg/config/event_options_within_3751_test.go
+++ b/pkg/config/event_options_within_3751_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tests for #3751: event-options `within <seconds> { trigger (on|until)
+// <count>; }` numeric validation. Before the fix compileEventOptions dropped
+// the strconv.Atoi error and coerced a typo to 0, and the engine treated a 0
+// threshold as an unconditional match — a typo silently turned a
+// threshold-gated remediation into an ALWAYS-FIRE one (fail-open). The strict
+// commit path (CompileConfig) now hard-rejects a bad within/trigger numeric,
+// a within with no trigger, an unknown trigger keyword, and a within carrying
+// both `on` and `until`; the tolerant load path (CompileConfigLenient) warns.
+//
+// Flat-set syntax MUST be built with ParseSetCommand/SetPath, never NewParser
+// (the parser merges newline-separated set lines into one giant node).
+
+// buildEventWithinFlat builds a config tree from flat `set ...` lines.
+func buildEventWithinFlat(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		keys, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(keys); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// TestEventWithinValidAcceptedAtCommit proves a well-formed within/trigger
+// clause still commits — both trigger on and trigger until, in both AST
+// shapes. This is the guard that the new strict gate is not over-rejecting.
+func TestEventWithinValidAcceptedAtCommit(t *testing.T) {
+	// Hierarchical (NewParser) — two clauses, on and until, in range.
+	hier := `event-options {
+    policy P {
+        events ping_test_failed;
+        within 30 {
+            trigger on 3;
+        }
+        within 25 {
+            trigger until 4;
+        }
+    }
+}`
+	p := NewParser(hier)
+	tree, errs := p.Parse()
+	if errs != nil {
+		t.Fatalf("parse: %v", errs)
+	}
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("CompileConfig rejected a valid hierarchical within/trigger: %v", err)
+	}
+
+	// Flat set — on and until.
+	for _, trig := range []string{"trigger on 3", "trigger until 4"} {
+		flat := buildEventWithinFlat(t,
+			"set event-options policy P within 60 "+trig,
+		)
+		if _, err := CompileConfig(flat); err != nil {
+			t.Fatalf("CompileConfig rejected a valid flat within 60 %s: %v", trig, err)
+		}
+	}
+}
+
+// TestEventWithinRejectedAtCommit is the RED-on-revert core: every malformed
+// within/trigger numeric must be a strict-commit hard error. Reverting the
+// gate (validateEventOptionsWithinAST) makes CompileConfig ACCEPT these
+// (coercing the value to 0), so every subtest goes RED.
+func TestEventWithinRejectedAtCommit(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+		// substrings the error must contain (policy name + a value/keyword)
+		want []string
+	}{
+		{
+			// H11 — non-numeric within seconds.
+			name: "within non-numeric",
+			cmds: []string{"set event-options policy P within bogus trigger on 3"},
+			want: []string{"P", "bogus", "time-interval"},
+		},
+		{
+			// H11 — non-numeric trigger count.
+			name: "trigger count non-numeric",
+			cmds: []string{"set event-options policy P within 60 trigger on typo"},
+			want: []string{"P", "typo", "on"},
+		},
+		{
+			// H12 — negative within.
+			name: "within negative",
+			cmds: []string{"set event-options policy P within -5 trigger on 3"},
+			want: []string{"P", "time-interval", "range"},
+		},
+		{
+			// zero within (a 0 window is the coerced-typo value itself).
+			name: "within zero",
+			cmds: []string{"set event-options policy P within 0 trigger on 3"},
+			want: []string{"P", "range"},
+		},
+		{
+			// H12 — huge within (past the 86400 cap / duration-overflow guard).
+			name: "within huge",
+			cmds: []string{"set event-options policy P within 99999999999 trigger on 3"},
+			want: []string{"P", "range"},
+		},
+		{
+			// zero trigger count.
+			name: "trigger count zero",
+			cmds: []string{"set event-options policy P within 60 trigger on 0"},
+			want: []string{"P", "on", "range"},
+		},
+		{
+			// negative trigger count.
+			name: "trigger count negative",
+			cmds: []string{"set event-options policy P within 60 trigger until -1"},
+			want: []string{"P", "until", "range"},
+		},
+		{
+			// within clause with no trigger — gates nothing → fail-open.
+			name: "within no trigger",
+			cmds: []string{"set event-options policy P within 60"},
+			want: []string{"P", "trigger"},
+		},
+		{
+			// unknown trigger keyword (Junos `after` — unsupported here).
+			name: "trigger unknown keyword",
+			cmds: []string{"set event-options policy P within 60 trigger after 3"},
+			want: []string{"P", "after"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildEventWithinFlat(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("CompileConfig accepted a malformed within/trigger (%v); want a strict reject", tc.cmds)
+			}
+			for _, sub := range tc.want {
+				if !strings.Contains(err.Error(), sub) {
+					t.Fatalf("reject error %q missing expected substring %q", err.Error(), sub)
+				}
+			}
+		})
+	}
+}
+
+// TestEventWithinBothOnUntilRejected is H13: a single within clause carrying
+// BOTH trigger on and trigger until is contradictory (the engine ANDs them
+// into a narrow one-count band). Strict commit must reject it. Tested in both
+// AST shapes.
+func TestEventWithinBothOnUntilRejected(t *testing.T) {
+	// Flat set — trigger on 3 then trigger until 5 land as sibling children.
+	flat := buildEventWithinFlat(t,
+		"set event-options policy P within 60 trigger on 3",
+		"set event-options policy P within 60 trigger until 5",
+	)
+	_, err := CompileConfig(flat)
+	if err == nil {
+		t.Fatal("CompileConfig accepted a within clause with both trigger on and until; want reject (H13)")
+	}
+	for _, sub := range []string{"P", "on", "until"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Fatalf("H13 reject error %q missing %q", err.Error(), sub)
+		}
+	}
+
+	// Hierarchical — trigger on 3 until 5 collapse onto one trigger leaf.
+	hier := `event-options {
+    policy P {
+        within 60 {
+            trigger on 3 until 5;
+        }
+    }
+}`
+	p := NewParser(hier)
+	tree, errs := p.Parse()
+	if errs != nil {
+		t.Fatalf("parse: %v", errs)
+	}
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("CompileConfig accepted hierarchical trigger on N until M; want reject (H13)")
+	}
+}
+
+// TestEventWithinLenientDowngradesToWarning proves the tolerant load /
+// peer-sync path (CompileConfigLenient) does NOT reject a malformed clause an
+// older binary may have persisted — it downgrades to a cfg.Warnings entry so
+// the node still boots (#1960 fail-closed-on-load doctrine). The engine then
+// fails CLOSED on the leftover 0 threshold (TestWithin_ZeroThreshold_...).
+func TestEventWithinLenientDowngradesToWarning(t *testing.T) {
+	tree := buildEventWithinFlat(t,
+		"set event-options policy P within bogus trigger on 3",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a malformed within on the tolerant path: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "within") && strings.Contains(w, "P") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path did not emit a within warning; warnings=%v", cfg.Warnings)
+	}
+}

--- a/pkg/config/schema_system.go
+++ b/pkg/config/schema_system.go
@@ -872,8 +872,13 @@ var schemaSNMP = &schemaNode{desc: "SNMP configuration", children: map[string]*s
 var schemaEventOptions = &schemaNode{desc: "Event policies for automated configuration changes", children: map[string]*schemaNode{
 	"policy": {desc: "Event policy", args: 1, placeholder: "<policy-name>", children: map[string]*schemaNode{
 		"events": {desc: "Events that trigger this policy", children: nil},
-		"within": {desc: "Time window for trigger evaluation", args: 1, placeholder: "<seconds>", children: map[string]*schemaNode{
-			"trigger": {desc: "Trigger condition (on|until <count>)", children: nil},
+		// within/trigger numerics are strict-validated at commit by
+		// validateEventOptionsWithinAST (#3751), not a typed leaf: the
+		// constraint spans the whole clause (seconds + trigger keyword/count +
+		// on/until mutual exclusion). within is 1..86400 s; trigger count is
+		// 1..1000000. A typo previously coerced to 0 and always-fired.
+		"within": {desc: "Time window for trigger evaluation (1..86400 seconds)", args: 1, placeholder: "<seconds>", children: map[string]*schemaNode{
+			"trigger": {desc: "Trigger condition: on|until <count> (exactly one; count 1..1000000)", children: nil},
 		}},
 		"attributes-match": {desc: "Match event attributes (<event>.<attribute> matches <value>)", children: nil},
 		"then": {desc: "Actions when the policy triggers", children: map[string]*schemaNode{

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -17,6 +17,13 @@
 //     rejected at commit (config.ValidateEventAttributesMatchStrict); on the
 //     legacy lenient-load path the runtime matcher fails CLOSED (the policy
 //     does not fire) rather than dropping the constraint and over-firing.
+//   - #3751 fail-closed temporal gate: a `within <seconds> { trigger
+//     (on|until) <count>; }` numeric typo is rejected at commit
+//     (config.validateEventOptionsWithinAST); on the legacy lenient-load path
+//     a within clause with no usable positive threshold (a leftover 0 from an
+//     older binary that silently coerced the typo) fails CLOSED in
+//     withinMatches (the policy does not fire) rather than treating the 0 as
+//     an unconditional match and always-firing the remediation.
 //   - #2157 fail-safe queue: actions run on a single serialized worker
 //     goroutine (removing the cross-probe EnterConfigure race) with bounded
 //     backoff retry on a held config lock (configstore.ErrConfigLocked) and
@@ -859,6 +866,22 @@ func (e *Engine) withinMatches(pol *config.EventPolicy, rt *policyRuntime, event
 	timestamps := rt.windows[eventName]
 
 	for _, wc := range pol.WithinClauses {
+		// #3751 defense-in-depth: a within clause with no USABLE positive
+		// threshold (both trigger on/until absent or <= 0) — or a non-positive
+		// window — must fail CLOSED, not always-fire. Commit-time validation
+		// (config.validateEventOptionsWithinAST) rejects such a clause outright,
+		// so this belt only fires on a config that slipped through a TOLERANT
+		// load / peer-sync path (an older binary silently coerced a within/
+		// trigger typo to 0). Falling through to `return true` here would treat
+		// that mis-arrived 0 as an unconditional match — turning a threshold-
+		// gated remediation into an ALWAYS-FIRE one, the original fail-open. A
+		// policy with NO within clauses at all is handled above (return true) —
+		// that legitimately means "no temporal filter"; this guard is only for
+		// a within clause that exists but gates nothing.
+		if wc.Seconds <= 0 || (wc.TriggerOn <= 0 && wc.TriggerUntil <= 0) {
+			return false
+		}
+
 		window := time.Duration(wc.Seconds) * time.Second
 
 		// Count events within the window

--- a/pkg/eventengine/engine_within_failclosed_3751_test.go
+++ b/pkg/eventengine/engine_within_failclosed_3751_test.go
@@ -1,0 +1,125 @@
+package eventengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// Regression tests for #3751 (engine defense-in-depth half). The commit-time
+// gate (config.validateEventOptionsWithinAST) rejects a within/trigger numeric
+// typo, but an already-persisted config an older binary silently accepted can
+// still reach the engine with a within clause whose threshold was coerced to 0
+// (the strconv.Atoi error was dropped). withinMatches must fail CLOSED on such
+// a clause (the policy does NOT fire) rather than treating the 0 as an
+// unconditional match — the original always-fire fail-open.
+
+// feedEvents drives the real evaluate path count times on a deterministic
+// clock (one simulated second per event) and returns the number of times the
+// single configured policy triggered.
+func feedEvents(t *testing.T, pol *config.EventPolicy, count int) int {
+	t.Helper()
+	e := New(nil, nil)
+	defer e.Close()
+
+	base := time.Unix(1_700_000_000, 0)
+	var tick int64
+	e.nowFn = func() time.Time { return base.Add(time.Duration(tick) * time.Second) }
+	e.Apply([]*config.EventPolicy{pol})
+
+	triggered := 0
+	for tick = 0; tick < int64(count); tick++ {
+		got := e.evaluateEvent(rpm.Event{Name: pol.Events[0], TestOwner: "o", TestName: "t"})
+		triggered += len(got)
+	}
+	return triggered
+}
+
+// firstFireIndex drives count events and returns the 0-based index of the
+// FIRST event at which the policy triggered, or -1 if it never did.
+func firstFireIndex(t *testing.T, pol *config.EventPolicy, count int) int {
+	t.Helper()
+	e := New(nil, nil)
+	defer e.Close()
+
+	base := time.Unix(1_700_000_000, 0)
+	var tick int64
+	e.nowFn = func() time.Time { return base.Add(time.Duration(tick) * time.Second) }
+	e.Apply([]*config.EventPolicy{pol})
+
+	for tick = 0; tick < int64(count); tick++ {
+		got := e.evaluateEvent(rpm.Event{Name: pol.Events[0], TestOwner: "o", TestName: "t"})
+		if len(got) > 0 {
+			return int(tick)
+		}
+	}
+	return -1
+}
+
+// TestWithin_TriggerOnFiresOnlyAfterN_3751 proves a valid `within 30 { trigger
+// on 3 }` clause fires only once the 3rd matching event lands in the window —
+// NOT on the first. This is the positive control the fail-closed guard must
+// not disturb.
+func TestWithin_TriggerOnFiresOnlyAfterN_3751(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "on3",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 30, TriggerOn: 3}},
+	}
+	// Events at ticks 0,1,2 — the 3rd (index 2) reaches count 3 in a 30s
+	// window at 1 event/s.
+	if got := firstFireIndex(t, pol, 5); got != 2 {
+		t.Fatalf("trigger on 3 first fired at event index %d; want 2 (the 3rd event)", got)
+	}
+}
+
+// TestWithin_ZeroThresholdFailsClosed_3751 is the RED-on-revert core: a within
+// clause that exists but carries NO usable positive threshold (both TriggerOn
+// and TriggerUntil are 0 — the state a dropped strconv.Atoi error produced)
+// must NEVER fire. Reverting the withinMatches fail-closed guard makes the
+// clause fall through to `return true` and fire on EVERY event (the #3751
+// always-fire fail-open), so `triggered` becomes 10 and this fails.
+func TestWithin_ZeroThresholdFailsClosed_3751(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "coerced-zero-threshold",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 30}}, // TriggerOn/Until == 0
+	}
+	if got := feedEvents(t, pol, 10); got != 0 {
+		t.Fatalf("within clause with a 0 threshold fired %d times; must fail CLOSED "+
+			"(a coerced-typo threshold must not always-fire, #3751)", got)
+	}
+}
+
+// TestWithin_ZeroWindowFailsClosed_3751 covers the fully-coerced case (the
+// within seconds ALSO dropped to 0): a 0-second window with no threshold must
+// likewise fail closed.
+func TestWithin_ZeroWindowFailsClosed_3751(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "coerced-zero-window",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 0, TriggerOn: 0}},
+	}
+	if got := feedEvents(t, pol, 10); got != 0 {
+		t.Fatalf("within clause with a 0 window fired %d times; must fail CLOSED (#3751)", got)
+	}
+}
+
+// TestWithin_NoClausesStillFiresEveryEvent_3751 guards the boundary: a policy
+// with NO within clauses at all legitimately has no temporal filter and must
+// still fire on every matching event. The fail-closed guard is scoped to a
+// within clause that EXISTS but gates nothing — it must not swallow the
+// no-clause case.
+func TestWithin_NoClausesStillFiresEveryEvent_3751(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:   "no-within",
+		Events: []string{"ping_probe_failed"},
+		// No WithinClauses.
+	}
+	if got := feedEvents(t, pol, 4); got != 4 {
+		t.Fatalf("no-within policy fired %d/4 times; a policy with no temporal filter must "+
+			"fire on every matching event", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3751 (MAJOR fail-open). An event-options policy
`within <seconds> { trigger (on|until) <count>; }` clause gates an
autonomous `change-configuration` remediation on a temporal threshold.
`compileEventOptions` parsed the time-interval and the trigger count with
`strconv.Atoi` and **silently dropped the error**, coercing a typo to `0`;
the engine's `withinMatches` then treated a `0` threshold as an
unconditional match — so a typo (`within bogus`, `trigger on typo`)
silently converted a threshold-gated remediation into an **always-fire**
one. Folds H11 (typo→0→always-fire), H12 (negative / huge / zero window —
the huge case also risked a `time.Duration` overflow), and H13 (a single
clause carrying both `trigger on` and `trigger until`).

## Fix (two halves, mirroring the #2141 attributes-match strict/lenient doctrine)

**(a) Commit-time strict validation** — new
`validateEventOptionsWithinAST` (`pkg/config/event_options_within.go`), an
AST pre-walk (the raw typo is lost once the compiler coerces it to `0`;
`forEachChild` over every top-level `event-options` block per the #3562
duplicate-block discipline) run inside `compileExpanded` on the
group-expanded, inactive-pruned tree. Rejects a non-numeric / negative /
zero / out-of-range `within` (`1..86400` s) or `trigger` count
(`1..1000000`), an unknown trigger keyword (Junos's unsupported `after`), a
`within` with no trigger, and the `on`+`until` combination. Strict on
commit / commit-check; downgraded to a `cfg.Warnings` entry on the tolerant
load / peer-sync paths (new `compileOpts.lenientEventWithinTrigger`, set in
`CompileConfigLenient` + `CompileConfigForNodeLenient`) per the #1960
fail-closed-on-load doctrine so an older-binary-persisted config still
boots.

**(b) Engine defense-in-depth** — `withinMatches`
(`pkg/eventengine/engine.go`) now **fails CLOSED** on a within clause with
no usable positive threshold (both `TriggerOn`/`TriggerUntil` <= 0) or a
non-positive window, so a leftover `0` from an older binary no longer
over-fires. A policy with **no** within clauses at all still fires on every
match (no temporal filter), unchanged.

## Tests (RED on revert, both verified)

- `pkg/config/event_options_within_3751_test.go` — both AST shapes: a valid
  within/trigger commits; every malformed numeric / keyword / no-trigger is
  a strict reject; H13 in both shapes; the lenient path downgrades to a
  warning. Neutering the validator makes `CompileConfig` accept the typos →
  RED.
- `pkg/eventengine/engine_within_failclosed_3751_test.go` — `trigger on 3`
  fires only on the 3rd event; a 0-threshold and a 0-window clause never
  fire; a no-within policy still fires on every event. Neutering the guard
  makes the 0-threshold policy fire 10/10 → RED.

## Validation

`go test ./pkg/config/... ./pkg/eventengine/...` green; downstream
`./pkg/configstore/... ./pkg/daemon/...` green; `go build ./...` green;
`gofmt` + `go vet` clean. Existing `TestEventOptions`
(`within 30 { trigger until 4 }` / `within 25 { trigger on 3 }`) and the
`test/incus/xpf-test.conf` `within 60 { trigger on 1 }` fixture still
compile. Docs updated (`docs/config-schema.md` validator list + schema
descriptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
