### PR TITLE
eventengine: revalidate queued remediation before commit (policy existence + revision + cooldown) — #3750

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25824,3 +25824,43 @@ top.
   pkg/config/event_options_within_3751_test.go (new, RED-on-revert),
   pkg/eventengine/engine_within_failclosed_3751_test.go (new, RED-on-revert),
   docs/config-schema.md (#3751 validator entry)
+
+## 2026-07-01 — #3750 eventengine: revalidate queued remediation before commit (H1/H2/H3 fail-opens)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3750 (MAJOR, security fail-open + documented-invariant
+    violation; folds H1/H2/H3/L14). A pre-classified event-options remediation
+    (`plannedAction`) carried only policyName + typed plan; the worker committed
+    it with ZERO revalidation against live engine state, so under normal config-
+    lock contention (an operator holds the lock while an RPM event fires and the
+    worker retries on ErrConfigLocked) three fail-opens existed. H1: a policy
+    REMOVED by an operator commit while its action was queued still committed the
+    stale batch (Apply(nil) drops runtime/semRev but nothing invalidated the
+    in-flight action). H2: a same-name REDEFINE left the OLD queued command set to
+    commit under the new policy's name (no revision to compare). H3: the 30s
+    cooldown was CHECKED at evaluate but ARMED only after commit, and enqueue
+    dedups only when the queue is FULL — so two events for one policy both queue
+    while the worker is blocked; the worker committed the first, armed the
+    cooldown, then committed the second without re-checking (double-commit,
+    violating the documented "not more than once in any 30s window" invariant).
+    FIX: stamp each action with the policy's semantic revision as of the evaluate
+    that produced it (`plannedAction.semRev`, captured under e.mu in
+    evaluateEvent via new `triggeredPolicy`); revalidate it in `staleReason`
+    inside applyOnce right after EnterConfigure succeeds — while holding the
+    config lock, so no operator Apply can interleave until ExitConfigure. Drop
+    (do not touch the candidate) if the policy is absent (removed), the live
+    semRev mismatches (redefined), or the cooldown is now active; return the
+    `errStaleAction` sentinel. runAction counts it as dropped_stale and does NOT
+    retry. One gate for H1/H2/H3. Observability: new Stats.DroppedStale surfaced
+    on xpf_event_actions_dropped_total{reason="stale"}. VALIDATION: 5 new
+    RED-on-revert tests (removing the gate → H1/H2/H3 commit the stale batch and
+    go RED, verified); go test ./pkg/eventengine/... green (incl -race); go test
+    ./pkg/api/... green; go build ./... green; gofmt + vet clean. README +
+    metric descriptor updated.
+  - **File(s)**: pkg/eventengine/engine.go (plannedAction.semRev +
+    triggeredPolicy, evaluateEvent return type, HandleEvent stamp, runAction
+    stale branch, applyOnce staleReason gate + errStaleAction/staleErr, Stats +
+    counters, header doc), pkg/eventengine/README.md (revalidate-before-commit
+    section + metrics + cooldown gotcha), pkg/api/metrics_system.go (emit
+    reason="stale"), pkg/api/metrics_descriptors.go (dropped help text),
+    pkg/eventengine/engine_stale_revalidate_3750_test.go (new, RED-on-revert)

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -476,8 +476,13 @@ func newCollector(srv *Server) *xpfCollector {
 				"reason=lock_held: the config lock stayed held past the "+
 				"retry deadline. reason=queue_full: a newer same-policy "+
 				"action superseded this one, or the bounded action queue "+
-				"was full (#2157). A nonzero value means automated "+
-				"remediation was lost — investigate the lock holder.",
+				"was full (#2157). reason=stale: at commit time the policy had "+
+				"been removed or redefined, or its 30s cooldown was now active — "+
+				"the action was revalidated and dropped rather than committing a "+
+				"batch no active policy authorizes (#3750). A nonzero "+
+				"lock_held/queue_full value means automated remediation was "+
+				"lost — investigate the lock holder; stale is expected under "+
+				"operator config churn or duplicate events.",
 			[]string{"reason"}, nil,
 		),
 		eventAttributesInvalid: prometheus.NewDesc(

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -212,6 +212,8 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 			prometheus.CounterValue, float64(st.DroppedLockHeld), "lock_held")
 		ch <- prometheus.MustNewConstMetric(c.eventActionsDropped,
 			prometheus.CounterValue, float64(st.DroppedQueueFull), "queue_full")
+		ch <- prometheus.MustNewConstMetric(c.eventActionsDropped,
+			prometheus.CounterValue, float64(st.DroppedStale), "stale")
 		ch <- prometheus.MustNewConstMetric(c.eventAttributesInvalid,
 			prometheus.CounterValue, float64(st.AttributesInvalid))
 		ch <- prometheus.MustNewConstMetric(c.eventActionQueueDepth,

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -73,6 +73,47 @@ the queue, but the timestamp is written by the worker after a successful
 commit, so a dropped/rejected action does NOT consume the cooldown — the next
 legitimate trigger can retry.
 
+## Revalidate a queued action before commit (#3750)
+
+A pre-classified `plannedAction` sits in the worker queue (and may retry for up
+to 60 s on a held config lock) before it commits. Between enqueue and commit the
+policy set can change under an operator commit, and the cooldown can be armed by
+a sibling commit — so the action must be **revalidated against live engine state
+immediately before it commits**, not applied blind.
+
+Each action is stamped with the policy's **semantic revision as of the evaluate
+that produced it** (`plannedAction.semRev`, captured under `e.mu` in
+`evaluateEvent`). The worker's `applyOnce` calls `staleReason(a)` right after
+`EnterConfigure` succeeds — while it holds the config lock, so **no operator
+commit (hence no `Apply` that could remove or redefine the policy) can
+interleave** until `ExitConfigure`. If the action is stale it is dropped (the
+candidate is never touched), `applyOnce` returns the `errStaleAction` sentinel,
+and `runAction` counts it on `xpf_event_actions_dropped_total{reason="stale"}`
+and does **not** retry (staleness is terminal). Three fail-opens fold into this
+one gate:
+
+- **Policy removed (H1):** `e.semRev` has no entry for the policy. An operator
+  committed a config that dropped this event-options policy while its remediation
+  was queued/retrying; committing the stale batch would mutate config no active
+  policy authorizes. Dropped.
+- **Policy redefined (H2):** the live semantic revision differs from the action's
+  stamped `semRev`. A same-name redefinition changed the policy's meaning; the
+  OLD command set must not commit under the new definition. Dropped.
+- **Cooldown active (H3):** a successful commit of the SAME policy is within the
+  30 s cooldown window. The enqueue-time cooldown check in `evaluateEvent` races
+  the arm-on-commit timing (the cooldown is armed only after a commit, and
+  `enqueue` dedups a same-policy duplicate ONLY when the queue is full), so a
+  duplicate can slip into the queue while the worker is blocked. Re-enforcing the
+  cooldown here at commit time suppresses the within-window duplicate instead of
+  double-committing — restoring the documented "not more than once in any 30 s
+  window" invariant even under lock contention.
+
+Legitimate remediations are unaffected: distinct policies and a re-fire AFTER the
+cooldown elapses pass the gate and commit. Regression-locked (fail-on-revert) by
+`TestStale_*_3750` in `engine_stale_revalidate_3750_test.go` — removing the
+`staleReason` gate makes the removed/redefined/duplicate batches commit and the
+H1/H2/H3 tests go RED.
+
 ## attributes-match (regex, #2008 M7) — fail-closed at runtime (#2141)
 
 `attributes-match "<event>.<attribute> matches <pattern>"` filters policy
@@ -174,14 +215,20 @@ blocks a `commitFn` on `ctx.Done()` and asserts `Close()` aborts it with
 - `xpf_event_actions_committed_total`
 - `xpf_event_actions_rejected_total`
 - `xpf_event_actions_retried_total`
-- `xpf_event_actions_dropped_total{reason="lock_held"|"queue_full"}`
+- `xpf_event_actions_dropped_total{reason="lock_held"|"queue_full"|"stale"}`
+  (`stale` = revalidate-before-commit dropped a removed/redefined-policy or
+  within-cooldown action, #3750)
 - `xpf_event_attributes_match_invalid_total`
 - `xpf_event_action_queue_depth` (gauge)
 
 ## Gotchas
 
 - 30 s policy cooldown (`policyCooldown`, `engine.go`). The same policy will not
-  trigger more than once in any 30 s window. Armed on successful commit.
+  trigger more than once in any 30 s window. Armed on successful commit, CHECKED
+  both at evaluate (`evaluateEvent`) AND re-checked at commit (`staleReason`,
+  #3750) — the commit-time re-check is what holds the invariant when a duplicate
+  slips into the queue during lock contention (the evaluate-time check races the
+  arm-on-commit timing).
 - Temporal `within` clauses keep a sliding window of timestamps per
   (policy, event) pair, **pruned on every append** so a cooldown-suppressed
   event can never grow the window unbounded. This holds for the cases #2216

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -28,6 +28,16 @@
 //     goroutine (removing the cross-probe EnterConfigure race) with bounded
 //     backoff retry on a held config lock (configstore.ErrConfigLocked) and
 //     drop/retry/commit counters, instead of silently dropping on lock-held.
+//   - #3750 revalidate-before-commit: a pre-classified action carries the
+//     policy's semantic revision AS OF EVALUATE TIME. Immediately before it
+//     commits — under e.mu and while holding the config lock (EnterConfigure),
+//     so no operator commit can interleave — the worker revalidates it against
+//     live engine state and DROPS it (counted dropped_stale) if the policy was
+//     removed, was redefined (semRev mismatch), or is now inside its cooldown.
+//     This folds three fail-opens into one gate: a removed policy's stale batch,
+//     a same-name redefine's OLD command set, and a queued duplicate that raced
+//     the arm-on-commit cooldown all stop firing instead of mutating config no
+//     active policy authorizes.
 package eventengine
 
 import (
@@ -83,6 +93,7 @@ type Stats struct {
 	Retried           uint64 // retry attempts after a held config lock
 	DroppedQueueFull  uint64 // actions superseded/evicted because the queue was full
 	DroppedLockHeld   uint64 // actions dropped after the lock-retry deadline elapsed
+	DroppedStale      uint64 // actions dropped at commit: policy removed/redefined or cooldown active (#3750)
 	AttributesInvalid uint64 // runtime fail-closed: malformed/unknown attributes-match line
 	QueueDepth        int64  // currently queued actions
 }
@@ -94,6 +105,7 @@ type engineCounters struct {
 	retried           atomic.Uint64
 	droppedQueueFull  atomic.Uint64
 	droppedLockHeld   atomic.Uint64
+	droppedStale      atomic.Uint64
 	attributesInvalid atomic.Uint64
 	queueDepth        atomic.Int64
 }
@@ -110,11 +122,30 @@ type plannedOp struct {
 
 // plannedAction is a fully pre-classified remediation enqueued for the worker.
 // It carries no engine lock and no live runtime state — only the policy
-// identity and the typed plan, so the worker can apply it without re-reading
-// engine state (and a stale queued action for a now-removed policy is harmless).
+// identity (name + the semantic revision observed AT EVALUATE TIME) and the
+// typed plan. The worker applies the plan without re-reading it, but it DOES
+// revalidate the identity against live engine state immediately before commit
+// (#3750): a queued action for a policy that was removed, redefined, or is now
+// in its cooldown must NOT commit — it is dropped as stale. Before #3750 the
+// worker committed the batch unconditionally, so a removed/redefined policy's
+// stale command set still mutated config, and a cooldown-window duplicate
+// double-committed.
 type plannedAction struct {
 	policyName string
-	ops        []plannedOp
+	// semRev is the policy's semantic revision (policySemanticRevision) as of
+	// the evaluate that enqueued this action. The worker drops the action if the
+	// live revision no longer matches (policy redefined) or is absent (removed).
+	semRev string
+	ops    []plannedOp
+}
+
+// triggeredPolicy pairs a policy that should fire with the semantic revision its
+// runtime carried at evaluate time (#3750). evaluateEvent returns these so
+// HandleEvent can stamp each enqueued action with the revision the worker
+// revalidates against before committing.
+type triggeredPolicy struct {
+	pol    *config.EventPolicy
+	semRev string
 }
 
 // policyRuntime is the per-policy temporal/cooldown state. It is split from the
@@ -380,8 +411,8 @@ func policySemanticRevision(pol *config.EventPolicy) string {
 func (e *Engine) HandleEvent(ev rpm.Event) {
 	e.startOnce.Do(e.startWorker)
 	triggered := e.evaluateEvent(ev)
-	for _, pol := range triggered {
-		ops, ok := e.classifyPlan(pol)
+	for _, tp := range triggered {
+		ops, ok := e.classifyPlan(tp.pol)
 		if !ok {
 			// Malformed/unknown command: reject the whole batch before it can
 			// take a queue slot or a lock (#2139 pre-classify).
@@ -391,7 +422,10 @@ func (e *Engine) HandleEvent(ev rpm.Event) {
 		if len(ops) == 0 {
 			continue // nothing to do
 		}
-		e.enqueue(plannedAction{policyName: pol.Name, ops: ops})
+		// Stamp the action with the policy's semantic revision as of this
+		// evaluate (#3750) so the worker can revalidate it against live engine
+		// state before committing.
+		e.enqueue(plannedAction{policyName: tp.pol.Name, semRev: tp.semRev, ops: ops})
 	}
 }
 
@@ -424,6 +458,7 @@ func (e *Engine) Stats() Stats {
 		Retried:           e.counters.retried.Load(),
 		DroppedQueueFull:  e.counters.droppedQueueFull.Load(),
 		DroppedLockHeld:   e.counters.droppedLockHeld.Load(),
+		DroppedStale:      e.counters.droppedStale.Load(),
 		AttributesInvalid: e.counters.attributesInvalid.Load(),
 		QueueDepth:        e.counters.queueDepth.Load(),
 	}
@@ -542,6 +577,16 @@ func (e *Engine) runAction(a plannedAction) {
 				"policy", a.policyName, "commands", len(a.ops))
 			return
 		}
+		if errors.Is(err, errStaleAction) {
+			// #3750: the policy was removed/redefined, or a sibling commit armed
+			// the cooldown, while this action waited (on a held lock or in the
+			// queue). Drop it — do NOT commit a batch no active policy authorizes,
+			// and do NOT retry (the staleness is terminal for this action).
+			e.counters.droppedStale.Add(1)
+			slog.Info("event-options: remediation dropped (stale queued action)",
+				"policy", a.policyName, "err", err)
+			return
+		}
 		if errors.Is(err, configstore.ErrConfigLocked) {
 			if e.now().After(deadline) {
 				e.counters.droppedLockHeld.Add(1)
@@ -603,6 +648,19 @@ func (e *Engine) applyOnce(ctx context.Context, a plannedAction) error {
 		return err
 	}
 	// From here, any early return MUST ExitConfigure to discard the candidate.
+
+	// #3750 revalidate-before-commit: now that we hold the config lock, no
+	// operator commit — and therefore no Apply() that could remove or redefine
+	// the policy — can interleave until we ExitConfigure. Check the action's
+	// identity against live engine state and drop it (do NOT mutate the
+	// candidate) if the policy was removed, was redefined since it was enqueued,
+	// or is now inside its cooldown (a sibling commit armed it after this action
+	// was queued but before it ran). This folds H1/H2/H3 into one gate.
+	if reason := e.staleReason(a); reason != "" {
+		e.store.ExitConfigure()
+		return staleErr(reason)
+	}
+
 	for _, op := range a.ops {
 		if op.isDelete {
 			if err := e.store.Delete(op.delPath); err != nil {
@@ -653,6 +711,53 @@ func (e *Engine) applyOnce(ctx context.Context, a plannedAction) error {
 // errBatch builds a permanent (non-retryable) batch failure error.
 func errBatch(format string, args ...any) error {
 	return fmt.Errorf(format, args...)
+}
+
+// errStaleAction is the sentinel returned by applyOnce when the pre-classified
+// action is no longer valid to commit (#3750): its policy was removed or
+// redefined, or the policy's cooldown is now active. runAction recognizes it via
+// errors.Is, counts it as dropped_stale, and does NOT retry (staleness is
+// terminal for that action).
+var errStaleAction = errors.New("stale queued remediation")
+
+// staleErr wraps errStaleAction with a human-readable reason for logging.
+func staleErr(reason string) error {
+	return fmt.Errorf("%w: %s", errStaleAction, reason)
+}
+
+// staleReason revalidates a pre-classified action against live engine state
+// under e.mu (#3750) and returns a non-empty reason if it must NOT commit:
+//
+//   - "policy removed"   : e.semRev has no entry for the policy (H1). The
+//     operator committed a config that dropped this event-options policy while
+//     the action was queued/retrying; its stale command batch is unauthorized.
+//   - "policy redefined" : the live semantic revision differs from the one the
+//     action was stamped with at evaluate time (H2). A same-name redefinition
+//     changed the policy's meaning; the OLD command set must not commit.
+//   - "cooldown active"  : a successful commit of the SAME policy is within the
+//     30s cooldown window (H3). The enqueue-time cooldown check in evaluateEvent
+//     races the arm-on-commit timing, so a duplicate can slip into the queue
+//     while the worker is blocked; the cooldown is re-enforced here at commit
+//     time so a within-window duplicate is suppressed, not double-committed.
+//
+// The empty string means the action is safe to commit. Called by applyOnce
+// while it holds the config lock, so the check reflects the last committed Apply
+// and no operator commit can race it until ExitConfigure.
+func (e *Engine) staleReason(a plannedAction) string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	rev, ok := e.semRev[a.policyName]
+	if !ok {
+		return "policy removed"
+	}
+	if rev != a.semRev {
+		return "policy redefined"
+	}
+	if rt := e.runtime[a.policyName]; rt != nil && !rt.lastTrigger.IsZero() &&
+		e.now().Sub(rt.lastTrigger) < policyCooldown {
+		return "cooldown active"
+	}
+	return ""
 }
 
 // classifyPlan pre-parses a policy's ThenCommands into a typed plan WITHOUT
@@ -711,11 +816,11 @@ func (e *Engine) armCooldown(name string) {
 // perpetually-cooldown-suppressed event can never grow unbounded — SMR finding
 // 1) and CHECKS (does not arm) the cooldown; the cooldown is armed by the
 // worker on a successful commit.
-func (e *Engine) evaluateEvent(ev rpm.Event) []*config.EventPolicy {
+func (e *Engine) evaluateEvent(ev rpm.Event) []triggeredPolicy {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	var triggered []*config.EventPolicy
+	var triggered []triggeredPolicy
 	now := e.now()
 	for _, pol := range e.policies {
 		if pol == nil {
@@ -759,7 +864,9 @@ func (e *Engine) evaluateEvent(ev rpm.Event) []*config.EventPolicy {
 			"test-owner", ev.TestOwner,
 			"test-name", ev.TestName)
 
-		triggered = append(triggered, pol)
+		// Capture the policy's semantic revision under the same lock so the
+		// enqueued action can be revalidated against it before commit (#3750).
+		triggered = append(triggered, triggeredPolicy{pol: pol, semRev: e.semRev[pol.Name]})
 	}
 	return triggered
 }

--- a/pkg/eventengine/engine_stale_revalidate_3750_test.go
+++ b/pkg/eventengine/engine_stale_revalidate_3750_test.go
@@ -1,0 +1,262 @@
+package eventengine
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// Regression tests for #3750 (revalidate-before-commit). A pre-classified
+// remediation used to commit its plan with zero revalidation against live
+// engine state, opening three fail-opens whenever an operator held the config
+// lock while an RPM event fired (the worker retries on ErrConfigLocked). The
+// fix stamps each action with the policy's semantic revision at evaluate time
+// and revalidates it under e.mu inside applyOnce (after EnterConfigure, while
+// holding the config lock so no operator Apply can interleave): the action is
+// dropped as stale if the policy was removed, was redefined, or is now in its
+// cooldown.
+//
+// Each test uses the held-lock pattern to park the worker retrying an action,
+// mutates engine state, then releases the lock and asserts the queued action is
+// DROPPED rather than committed. All are fail-on-revert: removing the
+// staleReason gate in applyOnce makes the stale batch commit and each test goes
+// RED.
+
+// fastRetry configures a sub-millisecond backoff with a generous deadline so
+// the worker retries rapidly under a held lock and reacts promptly once the
+// lock releases, without ever hitting the lock-held drop deadline.
+func fastRetry(e *Engine) {
+	e.retryInitial = time.Millisecond
+	e.retryMax = 5 * time.Millisecond
+	e.retryDeadline = 10 * time.Second
+}
+
+// #3750 H1: an operator removes an event-options policy while its remediation
+// is queued/retrying under a held config lock. When the lock releases, the
+// worker must revalidate and DROP the stale action — NOT commit a batch that no
+// active policy authorizes.
+//
+// FAIL-ON-REVERT: without the staleReason gate the worker commits the removed
+// policy's command, so host-name becomes "should-not-apply" and Committed==1
+// (DroppedStale==0), failing the assertions below.
+func TestStale_RemovedPolicyDropsQueuedAction_3750(t *testing.T) {
+	s := newStore(t)
+	pol := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name should-not-apply"},
+	}
+	e := New(s, nil)
+	fastRetry(e)
+	defer e.Close()
+	e.Apply([]*config.EventPolicy{pol})
+
+	// Operator holds the config lock; the worker parks retrying the action.
+	if err := s.EnterConfigureSession("operator"); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "worker retrying under held lock", func() bool { return e.Stats().Retried >= 1 })
+
+	// Operator commits a config that REMOVES policy p (Apply(nil)) while the
+	// action is still in flight.
+	e.Apply(nil)
+
+	// Release the lock: the worker's next attempt enters configure, revalidates,
+	// and must drop the action (policy removed).
+	if !s.ExitConfigureSession("operator") {
+		t.Fatal("failed to release the held lock")
+	}
+	waitFor(t, "stale drop", func() bool { return e.Stats().DroppedStale >= 1 })
+
+	// Give any (wrongly) racing commit time to land, then assert it did not.
+	time.Sleep(50 * time.Millisecond)
+	if got := e.Stats().Committed; got != 0 {
+		t.Errorf("Committed=%d; a removed policy's queued action must not commit (#3750 H1)", got)
+	}
+	if got := s.ActiveConfig().System.HostName; got != "base" {
+		t.Errorf("host-name=%q; the removed policy's stale command must not apply (want unchanged 'base')", got)
+	}
+}
+
+// #3750 H2: a same-name policy redefinition (different ThenCommands → new
+// semantic revision) must invalidate the OLD queued command batch. The stale
+// action carries the pre-redefine revision; the worker drops it rather than
+// committing the old command set under the new policy's name.
+//
+// FAIL-ON-REVERT: without the gate the OLD batch commits, so host-name becomes
+// "OLD" and Committed==1, failing the assertions below.
+func TestStale_RedefinedPolicyDropsOldBatch_3750(t *testing.T) {
+	s := newStore(t)
+	old := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name OLD"},
+	}
+	e := New(s, nil)
+	fastRetry(e)
+	defer e.Close()
+	e.Apply([]*config.EventPolicy{old})
+
+	if err := s.EnterConfigureSession("operator"); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "worker retrying under held lock", func() bool { return e.Stats().Retried >= 1 })
+
+	// Redefine p in place: same name, different command set → revision changes.
+	redef := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name NEW"},
+	}
+	e.Apply([]*config.EventPolicy{redef})
+
+	if !s.ExitConfigureSession("operator") {
+		t.Fatal("failed to release the held lock")
+	}
+	waitFor(t, "stale drop", func() bool { return e.Stats().DroppedStale >= 1 })
+
+	time.Sleep(50 * time.Millisecond)
+	if got := e.Stats().Committed; got != 0 {
+		t.Errorf("Committed=%d; a redefined policy's OLD queued batch must not commit (#3750 H2)", got)
+	}
+	if got := s.ActiveConfig().System.HostName; got != "base" {
+		t.Errorf("host-name=%q; the stale OLD command set must not apply (want unchanged 'base'; 'OLD' means the pre-fix bug)", got)
+	}
+}
+
+// #3750 H3: the 30s cooldown must gate a QUEUED duplicate. The cooldown is
+// checked at evaluate but armed only on commit, and enqueue dedups only when the
+// queue is FULL — so two events for one policy both queue while the worker is
+// blocked on a held lock. When the lock releases the worker commits the first,
+// arms the cooldown, then must DROP the second (cooldown active) instead of
+// double-committing within the window.
+//
+// FAIL-ON-REVERT: without the gate the worker commits both queued actions, so
+// Committed==2 and DroppedStale==0, failing the assertions below.
+func TestStale_CooldownSuppressesQueuedDuplicate_3750(t *testing.T) {
+	s := newStore(t)
+	pol := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name remediated"},
+	}
+	e := New(s, nil)
+	fastRetry(e)
+	defer e.Close()
+	e.Apply([]*config.EventPolicy{pol})
+
+	// Operator holds the lock so the worker parks retrying action #1.
+	if err := s.EnterConfigureSession("operator"); err != nil {
+		t.Fatalf("hold lock: %v", err)
+	}
+
+	// Event #1: dequeued by the worker, now retrying under the held lock.
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "worker retrying action #1", func() bool { return e.Stats().Retried >= 1 })
+
+	// Event #2: evaluateEvent sees the cooldown UNARMED (arm-on-commit, and #1
+	// has not committed), so it enqueues a duplicate. The queue is not full, so
+	// enqueue does NOT dedup it — exactly the H3 setup.
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "duplicate queued", func() bool { return e.Stats().QueueDepth >= 1 })
+
+	// Release the lock: #1 commits and arms the cooldown; the single worker then
+	// dequeues #2 and revalidates it (cooldown now active) → drop as stale.
+	if !s.ExitConfigureSession("operator") {
+		t.Fatal("failed to release the held lock")
+	}
+	waitFor(t, "first commit", func() bool { return e.Stats().Committed >= 1 })
+	waitFor(t, "duplicate dropped stale", func() bool { return e.Stats().DroppedStale >= 1 })
+
+	// Give the worker time to (wrongly) commit the duplicate, then assert exactly
+	// one commit total.
+	time.Sleep(50 * time.Millisecond)
+	if got := e.Stats().Committed; got != 1 {
+		t.Errorf("Committed=%d; the cooldown must suppress the queued duplicate (want exactly 1, #3750 H3)", got)
+	}
+	if got := e.Stats().DroppedStale; got != 1 {
+		t.Errorf("DroppedStale=%d; want exactly 1 (the within-cooldown duplicate)", got)
+	}
+}
+
+// #3750: the gate must not suppress LEGITIMATE remediations. Two distinct
+// policies triggered together both commit (neither is a stale/duplicate), with
+// zero stale drops.
+func TestStale_DistinctRemediationsFlow_3750(t *testing.T) {
+	s := newStore(t)
+	p1 := &config.EventPolicy{Name: "p1", Events: []string{"e1"}, ThenCommands: []string{"set system host-name h1"}}
+	p2 := &config.EventPolicy{Name: "p2", Events: []string{"e2"}, ThenCommands: []string{"set system domain-name d2"}}
+	e := New(s, nil)
+	defer e.Close()
+	e.Apply([]*config.EventPolicy{p1, p2})
+
+	e.HandleEvent(rpm.Event{Name: "e1", TestOwner: "o", TestName: "t"})
+	e.HandleEvent(rpm.Event{Name: "e2", TestOwner: "o", TestName: "t"})
+
+	waitFor(t, "both commits", func() bool { return e.Stats().Committed >= 2 })
+	if got := e.Stats().DroppedStale; got != 0 {
+		t.Errorf("DroppedStale=%d; distinct legitimate policies must not be dropped as stale", got)
+	}
+	if got := s.ActiveConfig().System.HostName; got != "h1" {
+		t.Errorf("host-name=%q; p1 must commit 'h1'", got)
+	}
+	if got := s.ActiveConfig().System.DomainName; got != "d2" {
+		t.Errorf("domain-name=%q; p2 must commit 'd2'", got)
+	}
+}
+
+// #3750: a re-fire AFTER the cooldown elapses must commit again — the gate
+// suppresses only WITHIN-window duplicates, not a legitimate later trigger.
+// Uses an injected clock so the cooldown boundary is exercised deterministically.
+func TestStale_PostCooldownRefire_3750(t *testing.T) {
+	s := newStore(t)
+	pol := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name r"},
+	}
+	e := New(s, nil)
+	defer e.Close()
+
+	base := time.Unix(1_700_000_000, 0)
+	var mu sync.Mutex
+	cur := base
+	e.nowFn = func() time.Time { mu.Lock(); defer mu.Unlock(); return cur }
+	advance := func(d time.Duration) { mu.Lock(); cur = cur.Add(d); mu.Unlock() }
+
+	e.Apply([]*config.EventPolicy{pol})
+
+	// First trigger commits and arms the cooldown.
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "first commit", func() bool { return e.Stats().Committed >= 1 })
+	// Wait until the cooldown is observably ARMED (armCooldown runs on the worker
+	// just after the committed counter bumps) so the within-cooldown re-fire
+	// below cannot race an unarmed window.
+	waitFor(t, "cooldown armed", func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		rt := e.runtime["p"]
+		return rt != nil && !rt.lastTrigger.IsZero()
+	})
+
+	// A re-fire WITHIN the cooldown is suppressed at evaluate (never queued).
+	e.HandleEvent(eventFor("ping_test_failed"))
+	time.Sleep(20 * time.Millisecond)
+	if got := e.Stats().Committed; got != 1 {
+		t.Fatalf("Committed=%d; a within-cooldown re-fire must not commit", got)
+	}
+
+	// Advance past the 30s cooldown; the re-fire must now commit again and must
+	// NOT be dropped as stale.
+	advance(policyCooldown + time.Second)
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "post-cooldown commit", func() bool { return e.Stats().Committed >= 2 })
+	if got := e.Stats().DroppedStale; got != 0 {
+		t.Errorf("DroppedStale=%d; a legitimate post-cooldown re-fire must not be dropped as stale", got)
+	}
+}


### PR DESCRIPTION
Closes #3750

## Problem

A pre-classified event-options remediation (`plannedAction`) carried only the
policy name plus the typed command plan. The worker committed that plan with
**zero revalidation** against live engine state, so three fail-opens existed
whenever an operator held the config lock while an RPM event fired (the worker
retries on `configstore.ErrConfigLocked` — a normal contention window):

- **H1 — commits after policy removal:** an operator commit that removes an
  event-options policy drops its `runtime`/`semRev` (`Apply`), but nothing
  invalidated the already-queued/in-flight action, so it still committed the
  stale command batch afterward — automation the operator deleted still mutated
  config.
- **H2 — same-name redefine commits the OLD batch:** `plannedAction` had no
  revision, so a same-name redefinition left the OLD queued command set to
  commit under the new policy's name.
- **H3 — cooldown bypass:** the 30 s cooldown was CHECKED in `evaluateEvent` but
  ARMED only after commit, and `enqueue` dedups a same-policy duplicate ONLY
  when the queue is full. Two events for one policy both queue while the worker
  is blocked; the worker commits the first, arms the cooldown, then commits the
  second without re-checking — a back-to-back double-commit that violates the
  documented "not more than once in any 30 s window" invariant.

## Fix (one gate for H1/H2/H3)

Stamp each enqueued action with the policy's **semantic revision as of the
evaluate that produced it** (`plannedAction.semRev`, captured under `e.mu` in
`evaluateEvent` via the new `triggeredPolicy`), and **revalidate it immediately
before commit**. `staleReason` runs inside `applyOnce` right after
`EnterConfigure` succeeds — while the worker holds the config lock, so **no
operator commit (hence no `Apply` that could remove/redefine the policy) can
interleave** until `ExitConfigure`. It drops the action (the candidate is never
touched) when:

- the policy is absent → `reason="policy removed"` (H1)
- the live `semRev` mismatches → `reason="policy redefined"` (H2)
- the cooldown is now active → `reason="cooldown active"` (H3)

`applyOnce` returns the `errStaleAction` sentinel; `runAction` counts it as
`dropped_stale` and does **not** retry (staleness is terminal). Legitimate
remediations are unaffected — distinct policies and a post-cooldown re-fire pass
the gate and commit.

## Observability

New `Stats.DroppedStale`, surfaced on the existing
`xpf_event_actions_dropped_total` metric under `reason="stale"` (descriptor help
updated).

## Tests (RED-on-revert)

`engine_stale_revalidate_3750_test.go` (drives the real HandleEvent → worker
path via the held-lock pattern):

- `TestStale_RemovedPolicyDropsQueuedAction_3750` (H1)
- `TestStale_RedefinedPolicyDropsOldBatch_3750` (H2)
- `TestStale_CooldownSuppressesQueuedDuplicate_3750` (H3)
- `TestStale_DistinctRemediationsFlow_3750` (no false suppression)
- `TestStale_PostCooldownRefire_3750` (post-cooldown re-fire still commits)

Verified RED-on-revert: deleting the `staleReason` gate makes H1/H2/H3 commit
the stale batch and those three tests fail.

## Validation

- `go test ./pkg/eventengine/...` green (incl. `-race`)
- `go test ./pkg/api/...` green
- `go build ./...` green; `gofmt` + `go vet` clean
- README + metric descriptor updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi