### PR TITLE
ipmon: keep FIB consistent + self-heal on actuator failure (#3757)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -25786,3 +25786,37 @@ top.
   docs/research/ddns-world-class/plan.md (§5.3 checkip fail-closed invariant)
   **Action**: cluster-setup.sh — VM SR-IOV VFs use nictype:sriov (incus-managed) instead of raw type:pci passthrough with out-of-band host-PF VLAN/trust. Fixes the 2026-07-01 loss-cluster LAN de-isolation outage (host-PF VF VLAN was set once at create and cleared on host reboot / PF reset, reverting fw0/fw1 LAN VFs to an untagged trunk → cluster host cut off from the internet). incus now re-applies vlan=3667 (LAN) + security.mac_filtering=false (WAN trunk, RETH vMAC + guest VLAN tagging) on every VM start — durable across VM reboot AND host reboot, no systemd unit / no ip-link bolt-on. Live loss cluster reconfigured + verified (both nodes, failover both directions, 15.4 Gbps WAN forwarding, host→internet 0% loss).
   **File(s)**: test/incus/cluster-setup.sh
+
+- **Timestamp**: 2026-07-01
+  **Action**: #3757 — ip-monitoring route-overlay actuator: fix the split-FIB
+  fail-open (folds M1/H1/H2/H3). ROOT (M1): the ipmon engine cleared its
+  `dirtySince` bit BEFORE calling the actuator, and the actuator returned
+  nothing, so every consumer failure was invisible → no retry. FIX: the
+  actuator (`actuateRouteOverlay`/`actuateRouteOverlayLocked`) now returns a
+  `bool`; the engine `run()` loop clears the dirty bit ONLY after a converged
+  actuation and keeps it dirty (autonomous throttle-paced retry on the next
+  sweep) on any failure. Added a `dirtyGen` counter so a change landing
+  mid-actuation is preserved (last-writer-wins) instead of being cleared. H1
+  (split FIB): `applyFRRConfig` now returns the FRR error, distinguishing a
+  DEGRADED reload (#1880, additive vtysh -f applied — new routes live in the
+  kernel → treated as success, publish proceeds) from a HARD reload error
+  (frr manager contract: nothing converged, kernel still on old routes). On a
+  hard error the actuator ABORTS BEFORE publishing the userspace snapshot, so
+  kernel + dataplane FIB never diverge; it reports failure and stays dirty. H2
+  (publish error) and H3 (unconfirmed FIB bump) likewise report failure → the
+  engine retries autonomously (H3 no longer waits for a future unrelated
+  actuation). The full apply path keeps warn-and-continue on FRR errors
+  (`_ = d.applyFRRConfig(...)`). RED-on-revert PROVEN: neutering the H1 abort
+  makes `TestActuatorAbortsPublishOnHardFRRError` publish a divergent snapshot
+  (fails); reverting the M1 clear-only-on-success makes
+  `TestActuationFailureStaysDirtyUntilConverged` see attempts=1 (no retry,
+  fails). go test ./pkg/ipmon/... ./pkg/daemon/ green (incl. -race);
+  go build ./... green; gofmt + vet clean.
+  **File(s)**: pkg/ipmon/ipmon.go (dirtyGen + run() clear-on-success + actuate
+  func() bool + package doc), pkg/ipmon/ipmon_test.go (2 new self-heal tests +
+  func() bool call sites), pkg/ipmon/nexthop_test.go (func() bool call sites),
+  pkg/ipmon/README.md (consistency + self-heal section), pkg/daemon/daemon_ipmon.go
+  (applyFRRConfig returns error + actuator returns bool + H1 abort + file doc),
+  pkg/daemon/daemon_ipmon_test.go (H1 abort + degraded-publish RED-on-revert
+  tests), pkg/daemon/daemon_apply.go (explicit `_ =` on full-apply FRR error),
+  docs/multi-wan.md (consistency + autonomous self-heal bullet)

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -537,6 +537,21 @@ routing, and only on double fault).
 - Failover actuation is a differential frr-reload + one snapshot push
   per debounce window; detection time (probe interval × threshold)
   dominates end-to-end failover latency.
+- **Consistency + autonomous self-heal (#3757).** The actuator's two
+  consumers commit together or not at all: the FRR reload runs FIRST,
+  and a HARD FRR reload failure (the manager's "nothing converged"
+  outcome) ABORTS the actuation before the userspace snapshot is
+  published — so the kernel FIB and the dataplane FIB never diverge into
+  a split-brain (kernel on the old route, dataplane on the failover
+  route). A degraded reload (#1880, additive `vtysh -f` applied) is
+  treated as success because the new routes are already live in the
+  kernel. On any consumer failure (FRR reload, snapshot publish, or the
+  FIB-generation bump) the engine keeps the overlay **dirty** and
+  retries on the next throttle-paced sweep until it converges — recovery
+  is autonomous and does not wait for an unrelated commit, lease, or
+  probe transition. The dirty bit clears only after a fully consistent
+  actuation, and a change that lands mid-actuation is preserved
+  (last-writer-wins).
 - **Per-cycle transition evaluation (#2527).** An RPM test's pass/fail
   status is a per-test aggregate, evaluated once across the whole probe
   set (`probe-count` probes per cycle), Junos ip-monitoring style. The

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1067,7 +1067,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// preserves a still-valid injected failover route and drops
 	// removed/edited entries on the commit itself.
 	if d.frr != nil {
-		d.applyFRRConfig(d.assembleFRRConfig(cfg, commitOverlay))
+		// The full apply path deliberately warns-and-continues on an FRR
+		// reload error (a transient FRR hiccup must not fail an
+		// otherwise-valid operator commit; a boot-time re-apply
+		// reconverges FRR). The returned error is only consumed by the
+		// ip-monitoring routes-only actuator, which must not publish a
+		// divergent snapshot on a hard failure (#3757).
+		_ = d.applyFRRConfig(d.assembleFRRConfig(cfg, commitOverlay))
 	}
 
 	// 3b. Apply next-table policy routing rules (ip rule)

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -8,6 +8,7 @@
 //     routes-only actuator, so the two paths cannot drift and an
 //     unrelated operator commit can never wipe an active failover
 //     route (AGY r2-2).
+//
 //  2. actuateRouteOverlay — the routes-only actuator: under the SAME
 //     apply semaphore as operator commits it re-renders FRR, publishes
 //     the dataplane snapshot via PublishRouteOverlaySnapshot, and ONLY
@@ -17,6 +18,22 @@
 //     re-invalidate them — traffic would stay pinned to the dead
 //     uplink). It touches NOTHING else: no networkd, no ipsec, no RPM
 //     re-apply, no cluster/heartbeat paths.
+//
+//     Consistency + self-heal (#3757): the actuator returns a bool that
+//     the ipmon engine uses to decide whether to clear its dirty bit. A
+//     HARD FRR reload error means nothing converged (frr manager
+//     contract) — the kernel FIB still holds the previous routes — so
+//     the actuator ABORTS BEFORE publishing the userspace snapshot
+//     (never a split FIB, H1) and returns false. A snapshot-publish
+//     error (H2) or an unconfirmed FIB-generation bump (H3) likewise
+//     returns false. On any false return the engine keeps the state
+//     dirty and retries autonomously on the next throttle-paced sweep
+//     (M1); the dirty bit clears only after a fully consistent
+//     actuation. A DEGRADED FRR reload (#1880, additive vtysh -f
+//     applied) is deliberately treated as success: the new routes ARE
+//     live in the kernel, so publishing the matching snapshot keeps the
+//     two FIBs in agreement while the frr manager's own retry converges
+//     stale-config removal.
 package daemon
 
 import (
@@ -158,27 +175,38 @@ func (d *Daemon) assembleFRRConfig(cfg *config.Config, overlay []config.RouteOve
 // applyFRRConfig applies an assembled FullConfig and handles the
 // shared post-ApplyFull consistent-hash sysctl. Both the full apply
 // path and the actuator go through here.
-func (d *Daemon) applyFRRConfig(fc *frr.FullConfig) {
+//
+// Return contract (#3757): nil on success OR a DEGRADED reload (#1880,
+// additive vtysh -f applied — the new routes ARE live in the kernel
+// FIB and the frr manager's retry loop owns stale-config removal); the
+// underlying error on a HARD reload failure, where the frr manager
+// contract guarantees NOTHING converged and the kernel FIB still holds
+// the previous routes. The full apply path (an operator commit) ignores
+// the result — a transient FRR hiccup must not fail an otherwise-valid
+// commit, and a boot-time re-apply reconverges it — but the route-
+// overlay actuator uses it to avoid publishing a userspace snapshot on
+// top of an un-applied kernel FIB (which would split the FIB).
+func (d *Daemon) applyFRRConfig(fc *frr.FullConfig) error {
 	if d.frr == nil {
-		return
+		return nil
 	}
-	// Warn-and-continue on FRR reload problems: an FRR hiccup must not
-	// fail an otherwise-valid commit. Degraded (#1880) means the config
-	// WAS applied additively and the manager's retry loop owns
-	// convergence of stale-config removal; the gauge
-	// xpf_frr_reload_degraded is 1 until it converges.
+	var hardErr error
 	if err := d.frr.ApplyFull(fc); err != nil {
 		if errors.Is(err, frr.ErrFRRReloadDegraded) {
 			slog.Warn("FRR reload degraded: additive vtysh -f applied; stale-config removal deferred to the in-manager retry", "err", err)
 		} else {
 			slog.Warn("failed to apply FRR config", "err", err)
+			hardErr = err
 		}
 	}
 
-	// Set L4 ECMP hash when consistent-hash is configured.
+	// Set L4 ECMP hash when consistent-hash is configured. Independent of
+	// the reload outcome (an idempotent procfs knob); attempted even on a
+	// degraded/hard-failed reload so it is not stranded.
 	if fc.ConsistentHash {
 		setFibMultipathHashPolicy()
 	}
+	return hardErr
 }
 
 // setFibMultipathHashPolicy enables L4 (5-tuple) ECMP hashing by writing
@@ -204,34 +232,54 @@ func setFibMultipathHashPolicy() {
 // goroutine after debounce + throttle; the engine guarantees at most
 // one invocation in flight. It snapshots the overlay at run time
 // (last-writer-wins under flap storms).
-func (d *Daemon) actuateRouteOverlay() {
+// actuateRouteOverlay returns whether the overlay converged
+// consistently; the ipmon engine keeps the state dirty and retries when
+// it returns false (#3757).
+func (d *Daemon) actuateRouteOverlay() bool {
 	_ = d.applySem.Acquire(context.Background(), 1)
 	defer d.applySem.Release(1)
 
 	if d.store == nil {
-		return
+		return true // nothing to actuate — converged
 	}
 	cfg := d.store.ActiveConfig()
 	if cfg == nil {
-		return
+		return true
 	}
-	d.actuateRouteOverlayLocked(cfg)
+	return d.actuateRouteOverlayLocked(cfg)
 }
 
 // actuateRouteOverlayLocked is the actuator body; MUST be called with
 // d.applySem held. Split out so the publish-before-bump ordering is
-// directly testable.
-func (d *Daemon) actuateRouteOverlayLocked(cfg *config.Config) {
+// directly testable. Returns true only when kernel FRR and the
+// userspace snapshot are left in a consistent, converged state; a false
+// return signals the engine to keep the state dirty and retry (#3757).
+func (d *Daemon) actuateRouteOverlayLocked(cfg *config.Config) bool {
 	overlay := d.ipmonActiveOverlay()
 
-	// 1. Re-render FRR through the shared constructor.
-	d.applyFRRConfig(d.assembleFRRConfig(cfg, overlay))
+	// 1. Re-render FRR through the shared constructor. A HARD FRR reload
+	// error means NOTHING converged (frr manager contract) — the kernel
+	// FIB still holds the previous routes. Publishing the userspace
+	// snapshot now would split the FIB (#3757 H1): kernel on the old
+	// route, dataplane on the new one. Abort WITHOUT publishing and
+	// report failure so the engine keeps the state dirty and retries on
+	// the next sweep; the prior consistent kernel+snapshot state is
+	// preserved. A DEGRADED reload (#1880) returns nil here — the new
+	// routes are live, so the matching snapshot publish keeps the two
+	// FIBs in agreement.
+	if err := d.applyFRRConfig(d.assembleFRRConfig(cfg, overlay)); err != nil {
+		slog.Warn("ip-monitoring: FRR reload failed — NOT publishing the userspace snapshot (would split the FIB); staying dirty for retry",
+			"err", err)
+		return false
+	}
 
 	// 2. Publish the dataplane snapshot (routes-only partial republish,
 	// no Compile, no helper restart).
 	pub, ok := d.dp.(routeOverlayPublisher)
 	if !ok {
-		return
+		// No dataplane publisher (helperless): FRR is the only routing
+		// consumer and it converged — nothing more to do.
+		return true
 	}
 	var schedulerState map[string]bool
 	if d.scheduler != nil {
@@ -239,19 +287,20 @@ func (d *Daemon) actuateRouteOverlayLocked(cfg *config.Config) {
 	}
 	published, err := pub.PublishRouteOverlaySnapshot(cfg, overlay, schedulerState)
 	if err != nil {
-		// pendingFIBBump deliberately unchanged: a pending retry from
-		// an earlier bump failure stays pending across a failed
-		// publish.
-		slog.Warn("ip-monitoring: route overlay snapshot publish failed — NOT bumping FIB generation",
+		// #3757 H2: a transient publish failure keeps the state dirty for
+		// an autonomous retry (report failure). pendingFIBBump is
+		// deliberately unchanged: a pending retry from an earlier bump
+		// failure stays pending across a failed publish.
+		slog.Warn("ip-monitoring: route overlay snapshot publish failed — NOT bumping FIB generation; staying dirty for retry",
 			"err", err)
-		return
+		return false
 	}
 	if !published && !d.pendingFIBBump {
 		// Duplicate-skip (content unchanged) or helperless caching:
 		// the dataplane routes did not move and the previous bump was
 		// confirmed, so do not churn established-flow route caches
-		// with a FIB-generation bump (Codex PR #1843 MED).
-		return
+		// with a FIB-generation bump (Codex PR #1843 MED). Converged.
+		return true
 	}
 
 	// 3. Only after a REAL apply_snapshot success (or with an
@@ -261,16 +310,20 @@ func (d *Daemon) actuateRouteOverlayLocked(cfg *config.Config) {
 	// here, under d.applySem — no extra locking.
 	if _, err := pub.BumpFIBGeneration(); err != nil {
 		d.pendingFIBBump = true
-		slog.Warn("ip-monitoring: FIB generation bump unconfirmed — will retry on next actuation",
+		// #3757 H3: report failure so the engine keeps the state dirty
+		// and the bump retries autonomously on the next throttle-paced
+		// sweep — not only on a future unrelated actuation.
+		slog.Warn("ip-monitoring: FIB generation bump unconfirmed — staying dirty; will retry on next sweep",
 			"err", err)
-		return
+		return false
 	}
 	d.pendingFIBBump = false
 	if !published {
 		slog.Info("ip-monitoring: retried FIB generation bump after earlier failure")
-		return
+		return true
 	}
 	slog.Info("ip-monitoring route overlay actuated", "overlay_routes", len(overlay))
+	return true
 }
 
 // reconcileIPMon applies the committed ip-monitoring policy set to the

--- a/pkg/daemon/daemon_ipmon_test.go
+++ b/pkg/daemon/daemon_ipmon_test.go
@@ -1,11 +1,14 @@
 package daemon
 
 import (
+	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
+	"github.com/psaab/xpf/pkg/frr"
 	"github.com/psaab/xpf/pkg/ipmon"
 	"github.com/psaab/xpf/pkg/rpm"
 	"golang.org/x/sync/semaphore"
@@ -326,5 +329,71 @@ func TestActuatorPublishFailureKeepsPendingBump(t *testing.T) {
 	}
 	if !d.pendingFIBBump {
 		t.Fatal("pendingFIBBump lost across a failed publish")
+	}
+}
+
+// hardFailFRRExec makes BOTH the frr-reload.py primary AND the vtysh -f
+// additive fallback fail, so frr.Manager.ApplyFull returns a HARD
+// (non-degraded) error — the manager contract's "nothing converged"
+// case, where the kernel FIB still holds the previous routes.
+type hardFailFRRExec struct{}
+
+func (hardFailFRRExec) Vtysh(string) (string, error) { return "", nil }
+func (hardFailFRRExec) FrrReloadPy(context.Context, string) error {
+	return errors.New("frr-reload.py boom")
+}
+func (hardFailFRRExec) VtyshLoad(context.Context, string) ([]byte, error) {
+	return nil, errors.New("vtysh -f boom")
+}
+
+// TestActuatorAbortsPublishOnHardFRRError is the #3757 H1 regression: a
+// HARD FRR reload failure leaves the kernel FIB on the PREVIOUS routes
+// (frr manager contract: nothing converged). The actuator must NOT
+// publish the userspace snapshot on top — that would split the FIB
+// (kernel on the old route, dataplane on the failover route). It must
+// abort before the dataplane consumer, report failure so the ipmon
+// engine keeps the state dirty and retries, and leave pendingFIBBump
+// untouched. On revert (publish regardless of the FRR outcome) dp.calls
+// contains "publish" and this goes RED.
+func TestActuatorAbortsPublishOnHardFRRError(t *testing.T) {
+	dp := &fakeOverlayDP{}
+	d := &Daemon{
+		applySem: semaphore.NewWeighted(1),
+		frr:      frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), hardFailFRRExec{}),
+		dp:       dp,
+		ipmon:    failedIPMonEngine(t),
+	}
+
+	if ok := d.actuateRouteOverlayLocked(&config.Config{}); ok {
+		t.Fatal("actuator reported success on a hard FRR reload failure")
+	}
+	if len(dp.calls) != 0 {
+		t.Fatalf("calls = %v, want none: a divergent snapshot was published after a hard FRR failure (split FIB)", dp.calls)
+	}
+	if d.pendingFIBBump {
+		t.Fatal("pendingFIBBump set by an aborted actuation")
+	}
+}
+
+// TestActuatorPublishesOnDegradedFRR: a DEGRADED reload (#1880, the
+// additive vtysh -f fallback applied) leaves the new routes LIVE in the
+// kernel FIB, so — unlike a hard error — the actuator SHOULD publish the
+// matching userspace snapshot (both FIBs agree) and report success. This
+// pins the degraded/hard-error distinction so the H1 fix does not
+// over-abort on the deliberate warn-and-continue path.
+func TestActuatorPublishesOnDegradedFRR(t *testing.T) {
+	dp := &fakeOverlayDP{}
+	d := &Daemon{
+		applySem: semaphore.NewWeighted(1),
+		frr:      frr.NewForTest(filepath.Join(t.TempDir(), "frr.conf"), &frr.RecordingExecutor{ReloadErr: errors.New("frr-reload down")}),
+		dp:       dp,
+		ipmon:    failedIPMonEngine(t),
+	}
+
+	if ok := d.actuateRouteOverlayLocked(&config.Config{}); !ok {
+		t.Fatal("actuator reported failure on a DEGRADED (additive-applied) reload")
+	}
+	if len(dp.calls) != 2 || dp.calls[0] != "publish" || dp.calls[1] != "bump" {
+		t.Fatalf("calls = %v, want [publish bump] on a degraded reload", dp.calls)
 	}
 }

--- a/pkg/ipmon/README.md
+++ b/pkg/ipmon/README.md
@@ -43,6 +43,35 @@ apply semaphore as operator commits and bumps the FIB generation ONLY
 after a successful snapshot publish (ordering is load-bearing — see
 `actuateRouteOverlayLocked`).
 
+### Consistency + autonomous self-heal (#3757)
+
+The actuator returns a `bool`; the engine clears its dirty bit **only
+after** the actuator reports a fully consistent, converged actuation.
+Any consumer failure keeps the state dirty and the run loop retries
+autonomously on the next sweep, throttle-paced (at most one
+frr-reload + snapshot per throttle window), until it converges — no
+future config change is required to recover.
+
+- **Hard FRR reload error (H1):** the FRR manager contract guarantees
+  *nothing converged* — the kernel FIB still holds the previous routes
+  — so the actuator **aborts before publishing** the userspace
+  snapshot. Publishing on top would split the FIB (kernel on the old
+  route, dataplane on the failover route). Both FIBs stay on the last
+  consistent state and the retry re-applies once FRR recovers. A
+  **degraded** reload (#1880, additive `vtysh -f` applied) is *not* a
+  hard error: the new routes are live in the kernel, so the matching
+  snapshot publish keeps the two FIBs in agreement while the FRR
+  manager's own retry converges stale-config removal.
+- **Snapshot publish error (H2):** no FIB-generation bump, state stays
+  dirty, retried on the next sweep.
+- **Unconfirmed FIB-generation bump (H3):** `pendingFIBBump` is armed
+  *and* the actuation reports failure, so the bump retries on the next
+  autonomous sweep (not only on a future unrelated actuation).
+- **Dirty cleared only on success (M1):** the run loop snapshots a
+  `dirtyGen` before actuating and clears `dirtySince` only when the
+  actuation converged AND no newer change landed meanwhile
+  (last-writer-wins preserved).
+
 ## HA
 
 Overlay is runtime state, never config: it does not sync to the peer
@@ -88,7 +117,9 @@ FRR DHCP default route; see the RFC 2131 coupling rule in
 
 ## Entry points
 
-- `Engine`, `New(actuate func())`, `Start/Stop` — `ipmon.go`.
+- `Engine`, `New(actuate func() bool)`, `Start/Stop` — `ipmon.go`.
+  The actuator returns `true` on a consistent, converged actuation and
+  `false` to keep the state dirty for an autonomous retry (#3757).
 - `Apply(cfg, results)` — install committed policies, preserving FAIL
   state for surviving (name, probe) pairs.
 - `HandleTransition(rpm.Transition)` — the sensor input (wired to

--- a/pkg/ipmon/ipmon.go
+++ b/pkg/ipmon/ipmon.go
@@ -25,6 +25,15 @@
 // actuation per throttle window indefinitely — bounded and observable
 // via the per-policy transition counters.
 //
+// The dirty bit is cleared only AFTER the actuator reports a
+// consistent, converged result. A failed consumer (a hard FRR reload
+// error, a snapshot-publish error, or an unconfirmed FIB-generation
+// bump) keeps the state dirty and the loop retries autonomously at the
+// throttle cadence until it converges (#3757). Because a hard FRR
+// reload failure aborts the userspace snapshot publish, the kernel FIB
+// and the userspace FIB never diverge into a split-brain — both stay on
+// the last consistent state until the retry succeeds.
+//
 // The overlay is runtime state, never config: it does not sync to the
 // HA peer and re-derives from fresh probe results within seconds of a
 // takeover.
@@ -102,8 +111,20 @@ type Engine struct {
 
 	dirtySince    time.Time // zero = clean
 	lastActuation time.Time
+	// dirtyGen increments on every marked change (even while already
+	// dirty). The run loop snapshots it before actuating and clears the
+	// dirty bit only when it is unchanged AND the actuation converged —
+	// so a change that lands DURING an actuation (last-writer-wins) is
+	// not lost, and a failed actuation stays dirty for retry (#3757).
+	dirtyGen uint64
 
-	actuate func() // daemon route-overlay actuator; called WITHOUT mu held
+	// actuate is the daemon route-overlay actuator; called WITHOUT mu
+	// held. It returns true when the overlay converged consistently
+	// (kernel FRR AND the userspace snapshot committed together) and
+	// false when any consumer failed — a false return keeps the dirty
+	// bit set so the run loop retries autonomously on the next sweep
+	// (#3757).
+	actuate func() bool
 	// resolveNextHop resolves interface-typed next-hops at overlay
 	// computation (#1844). Set once via SetNextHopResolver before
 	// Start; nil ⇒ interface-typed candidates always skip (defensive —
@@ -121,8 +142,10 @@ type Engine struct {
 // New creates an engine. actuate is the daemon's routes-only actuator;
 // it is invoked from the engine's single run-loop goroutine (never
 // concurrently) and must read ActiveOverlay() itself so it always
-// publishes the freshest overlay.
-func New(actuate func()) *Engine {
+// publishes the freshest overlay. It returns true on a consistent,
+// converged actuation and false when a consumer failed — a false return
+// keeps the state dirty for an autonomous retry (#3757).
+func New(actuate func() bool) *Engine {
 	return &Engine{
 		policies:       make(map[string]*policyState),
 		failedTests:    make(map[string]map[string]bool),
@@ -502,7 +525,15 @@ func (e *Engine) evaluateLocked(now time.Time) bool {
 }
 
 func (e *Engine) markDirtyLocked(changed bool) {
-	if changed && e.dirtySince.IsZero() {
+	if !changed {
+		return
+	}
+	// Bump the generation on EVERY change so a change that lands while an
+	// actuation is in flight is visible to the run loop's post-actuate
+	// clear check (#3757 last-writer-wins), not just the first
+	// clean→dirty transition.
+	e.dirtyGen++
+	if e.dirtySince.IsZero() {
 		e.dirtySince = e.now()
 	}
 }
@@ -528,22 +559,46 @@ func (e *Engine) run() {
 
 		now := e.now()
 		fire := false
+		var actuatingGen uint64
 		if !e.dirtySince.IsZero() &&
 			now.Sub(e.dirtySince) >= e.debounce &&
 			now.Sub(e.lastActuation) >= e.throttle {
 			fire = true
-			e.dirtySince = time.Time{}
+			// #3757 (M1): snapshot the generation being actuated and
+			// advance lastActuation, but do NOT clear the dirty bit yet —
+			// it is cleared only after the actuator reports a consistent,
+			// converged result (below). Advancing lastActuation paces a
+			// failed actuation's retry to at most one per throttle window
+			// (bounded), never a hot loop.
+			actuatingGen = e.dirtyGen
 			e.lastActuation = now
 		}
-		wake := e.nextWakeLocked(now)
 		e.mu.Unlock()
 
-		if fire && e.actuate != nil {
-			// Outside the lock; the actuator reads ActiveOverlay()
-			// itself, so it publishes the freshest state
-			// (last-writer-wins under flap storms).
-			e.actuate()
+		if fire {
+			// Outside the lock; the actuator reads ActiveOverlay() itself,
+			// so it publishes the freshest state (last-writer-wins under
+			// flap storms). A nil actuator (tests that drive the state
+			// machine directly) is a converged no-op.
+			ok := true
+			if e.actuate != nil {
+				ok = e.actuate()
+			}
+			e.mu.Lock()
+			if ok && e.dirtyGen == actuatingGen {
+				// Converged, and no newer change arrived while the
+				// actuator ran: clear the dirty bit. A failed actuation
+				// (ok==false) OR a concurrent re-dirty (dirtyGen advanced)
+				// keeps dirtySince set so the next wake re-actuates
+				// autonomously (#3757 M1/H1/H2/H3).
+				e.dirtySince = time.Time{}
+			}
+			e.mu.Unlock()
 		}
+
+		e.mu.Lock()
+		wake := e.nextWakeLocked(e.now())
+		e.mu.Unlock()
 
 		if !timer.Stop() {
 			select {

--- a/pkg/ipmon/ipmon_test.go
+++ b/pkg/ipmon/ipmon_test.go
@@ -48,7 +48,7 @@ func (c *fakeClock) Advance(d time.Duration) {
 	c.mu.Unlock()
 }
 
-func newTestEngine(actuate func()) (*Engine, *fakeClock) {
+func newTestEngine(actuate func() bool) (*Engine, *fakeClock) {
 	e := New(actuate)
 	clock := &fakeClock{now: time.Unix(1000000, 0)}
 	e.now = clock.Now
@@ -233,7 +233,7 @@ func TestWinnerResolution(t *testing.T) {
 // per throttle window (§4.3 coalescing).
 func TestDebounceCoalescing(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() { actuations.Add(1) })
+	e := New(func() bool { actuations.Add(1); return true })
 	e.debounce = 20 * time.Millisecond
 	e.throttle = 60 * time.Millisecond
 	e.Apply(testPolicyConfig(), passResults())
@@ -272,11 +272,78 @@ func TestDebounceCoalescing(t *testing.T) {
 	}
 }
 
+// TestActuationFailureStaysDirtyUntilConverged is the #3757
+// M1/H1/H2/H3 regression: when the actuator reports failure the engine
+// must KEEP the state dirty and retry autonomously (throttle-paced),
+// then go quiescent once the actuation converges. On revert (dirty
+// cleared before/independent of the actuation result) a failing
+// actuator would fire exactly once — attempts stays 1 — and this goes
+// RED.
+func TestActuationFailureStaysDirtyUntilConverged(t *testing.T) {
+	var attempts atomic.Int32
+	var succeed atomic.Bool // false ⇒ actuation fails; flipped to self-heal
+	e := New(func() bool {
+		attempts.Add(1)
+		return succeed.Load()
+	})
+	e.debounce = 5 * time.Millisecond
+	e.throttle = 20 * time.Millisecond
+	e.Apply(testPolicyConfig(), passResults())
+	e.Start()
+	defer e.Stop()
+
+	// A probe failure marks the overlay dirty and actuates — but the
+	// actuator keeps failing, so the engine must retry on the next sweep.
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+
+	deadline := time.Now().Add(400 * time.Millisecond)
+	for attempts.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("attempts = %d while actuation kept failing, want autonomous retry (>=2)", got)
+	}
+
+	// Let the actuation converge; the retry loop must settle once the
+	// dirty bit clears.
+	succeed.Store(true)
+	time.Sleep(80 * time.Millisecond) // a few throttle windows to land + clear
+	settled := attempts.Load()
+	time.Sleep(160 * time.Millisecond) // several more windows
+	if extra := attempts.Load() - settled; extra > 1 {
+		t.Fatalf("actuation kept firing after convergence: +%d attempts, want quiescent", extra)
+	}
+}
+
+// TestSuccessfulActuationClearsDirty: a single stable failure with a
+// succeeding actuator actuates exactly once (the dirty bit clears on the
+// converged actuation and the loop parks) — no retry churn.
+func TestSuccessfulActuationClearsDirty(t *testing.T) {
+	var attempts atomic.Int32
+	e := New(func() bool { attempts.Add(1); return true })
+	e.debounce = 5 * time.Millisecond
+	e.throttle = 20 * time.Millisecond
+	e.Apply(testPolicyConfig(), passResults())
+	e.Start()
+	defer e.Stop()
+
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+	time.Sleep(60 * time.Millisecond)
+	first := attempts.Load()
+	if first < 1 {
+		t.Fatal("no actuation after a failure")
+	}
+	time.Sleep(200 * time.Millisecond) // ~10 throttle windows
+	if extra := attempts.Load() - first; extra > 0 {
+		t.Fatalf("converged actuation kept retrying: +%d attempts, want 0 (dirty cleared)", extra)
+	}
+}
+
 // TestPublishGatingBaseline: standby gating returns a nil overlay
 // (baseline) and re-enables on takeover.
 func TestPublishGatingBaseline(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() { actuations.Add(1) })
+	e := New(func() bool { actuations.Add(1); return true })
 	e.Apply(testPolicyConfig(), passResults())
 	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
 	if len(e.ActiveOverlay()) == 0 {
@@ -390,7 +457,7 @@ func TestFilterOverlayForConfig(t *testing.T) {
 // actuation (one spurious frr-reload per commit otherwise).
 func TestApplyWithoutOverlayChangeDoesNotActuate(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() { actuations.Add(1) })
+	e := New(func() bool { actuations.Add(1); return true })
 	e.debounce = 5 * time.Millisecond
 	e.throttle = 5 * time.Millisecond
 	e.Start()

--- a/pkg/ipmon/nexthop_test.go
+++ b/pkg/ipmon/nexthop_test.go
@@ -183,7 +183,7 @@ func TestStatusUnresolvedRoutes(t *testing.T) {
 // actuates.
 func TestNotifyNextHopChangeGate(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() { actuations.Add(1) })
+	e := New(func() bool { actuations.Add(1); return true })
 	e.debounce = 5 * time.Millisecond
 	e.throttle = 5 * time.Millisecond
 	r := &fakeResolver{}
@@ -221,7 +221,7 @@ func TestNotifyNextHopChangeGate(t *testing.T) {
 
 	// Literal-only FAILED policy: gateway churn must not actuate.
 	e2cnt := atomic.Int32{}
-	e2 := New(func() { e2cnt.Add(1) })
+	e2 := New(func() bool { e2cnt.Add(1); return true })
 	e2.debounce = 5 * time.Millisecond
 	e2.throttle = 5 * time.Millisecond
 	e2.Apply(testPolicyConfig(), passResults())
@@ -288,7 +288,7 @@ func TestFilterOverlayForConfigInterfaceTyped(t *testing.T) {
 // — one actuation path, last-writer-wins.
 func TestGatewayChangeCoalescesWithProbeTransition(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() { actuations.Add(1) })
+	e := New(func() bool { actuations.Add(1); return true })
 	e.debounce = 20 * time.Millisecond
 	e.throttle = 60 * time.Millisecond
 	r := &fakeResolver{}


### PR DESCRIPTION
Closes #3757

## Problem

The `services ip-monitoring` route-overlay actuator drove three stateful
consumers — FRR reload, userspace snapshot publish, FIB-generation bump —
with **no success/failure feedback** to the engine. Any consumer failure
left kernel routing and userspace forwarding disagreeing, with no
autonomous recovery. Folds M1 (root) + H1/H2/H3.

- **M1 (root):** `run()` cleared `dirtySince` **before** calling
  `actuate()`, and the actuator returned nothing — every failure path was
  invisible, so nothing retried.
- **H1 (split FIB):** a hard FRR reload error was swallowed while the
  userspace snapshot **still published** → kernel FIB (FRR-preferred
  routes) and userspace FIB diverge (split-brain), traffic mis-routed.
- **H2:** a snapshot publish error had no retry.
- **H3:** a FIB-bump failure retried only on a *future unrelated*
  actuation.

## Fix

Consistency + autonomous self-heal:

- The actuator now returns a `bool`. The engine's `run()` loop clears the
  dirty bit **only after** a converged actuation, and keeps it dirty
  (throttle-paced autonomous retry on the next sweep) on any failure. A
  new `dirtyGen` counter preserves last-writer-wins: a change that lands
  mid-actuation is not lost.
- `applyFRRConfig` returns the FRR error, distinguishing a **DEGRADED**
  reload (#1880, additive `vtysh -f` applied — new routes live in the
  kernel → treated as success, publish proceeds) from a **HARD** reload
  error (frr manager contract: nothing converged, kernel on old routes).
  On a hard error the actuator **aborts before publishing** the userspace
  snapshot, so the two FIBs never diverge — both stay on the last
  consistent state until the retry succeeds.
- H2/H3 report failure from the actuator → the engine retries
  autonomously (H3 no longer waits for a future unrelated actuation).
- The full apply path keeps its deliberate warn-and-continue (an operator
  commit must not fail on an FRR hiccup; a boot-time re-apply
  reconverges).

## Tests — RED on revert (verified both directions)

- `TestActuatorAbortsPublishOnHardFRRError` builds a real `frr.Manager`
  (`frr.NewForTest`) whose primary reload **and** `vtysh -f` fallback both
  fail (a hard error). Neutering the abort makes it publish a divergent
  snapshot → test fails. `TestActuatorPublishesOnDegradedFRR` pins the
  degraded path still publishing.
- `TestActuationFailureStaysDirtyUntilConverged` drives the run loop with
  a failing actuator, asserts autonomous retry, then quiescence once it
  converges. Reverting the clear-only-on-success logic makes it fire
  exactly once → test fails. `TestSuccessfulActuationClearsDirty` pins
  no retry-churn on a converged actuation.

## Validation

`go test ./pkg/ipmon/... ./pkg/daemon/` green (incl. `-race`);
`go build ./...` green; `gofmt` + `go vet` clean. Docs updated
(`pkg/ipmon/README.md`, `docs/multi-wan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
