### PR TITLE
policy scheduler: fallible + self-healing window-flip republish (fix stale-permit-after-window fail-open)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,66 @@
+## 2026-07-01 — #3780 policy scheduler: fallible + self-healing republish (fix stale-permit-after-window fail-open)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3780 (MEDIUM-HIGH, security fail-open: a scheduled PERMIT
+    left live after its schedule window closed, or a scheduled block that
+    never engaged). The policy scheduler republished the userspace
+    enforcement snapshot on a time-of-day window flip via a VOID
+    fire-and-forget path: `UpdatePolicyScheduleState` logged a warning and
+    returned on every failure (policy/address-book rebuild, protocol
+    disarm, `apply_snapshot`), the daemon caller ignored the result, and
+    the scheduler only re-fired `updateFn` on the NEXT state CHANGE (hours
+    away) — so a transient republish failure at a window close left the
+    OLD `inactive` bits (the permit) live indefinitely with no retry and
+    no alarm.
+    FIX (fallible + self-healing, no happy-path change):
+    (1) `UpdatePolicyScheduleState` now returns `error` across the
+    `dataplane.DataPlane` interface + both backends
+    (`pkg/dataplane/userspace/manager.go` real path, `maps_policy.go`
+    retired-eBPF best-effort → always nil, `legacy_dataplane.go` adapter).
+    The userspace path returns a wrapped error on each failure that did
+    NOT apply the new snapshot (protocol-refuse, policy rebuild,
+    address-book rebuild, disarm, `apply_snapshot`); no-op paths (no
+    snapshot / no helper) and a post-success status-sync warning return
+    nil.
+    (2) The scheduler (`pkg/scheduler/scheduler.go`) `updateFn` now returns
+    `error`; a non-nil result latches `republishPending`, and `evaluate`
+    re-fires on `changed || republishPending` so the transition is retried
+    on the scheduler's own 60 s tick until it converges (fail-safe toward
+    the schedule's intent). New `RepublishPending` / `RepublishFailureStatus`
+    accessors.
+    (3) The daemon (`daemon_scheduler.go`) `publishPolicyScheduleState` /
+    `updatePolicyScheduleStateLocked` propagate the error;
+    `recordSchedulerRepublishResult` latches a lock-free failure metric
+    (`schedulerRepublishFailing` + first-fail nanos on the Daemon) and logs
+    an ERROR on entry into failure / INFO on recovery; teardown/replace in
+    the reconciler clears it. Stale-epoch / ctx-cancel / nothing-to-publish
+    return nil (no spurious retry).
+    (4) New Prometheus gauges `xpf_scheduler_republish_failed` (0/1) and
+    `xpf_scheduler_republish_stale_seconds` (failure-streak age) wired
+    daemon → api.Config → collector (control-plane signal, emitted before
+    the dataplane gate like frr-reload-degraded).
+    VALIDATION: 3 RED-on-revert test files (scheduler self-heal retry;
+    daemon metric latch/clear + error propagation; userspace manager
+    error-on-publish-failure + no-op-converged). Verified RED on revert for
+    the scheduler re-fire condition and the manager error return (both go
+    FAIL when reverted to fire-and-forget), GREEN restored. go build ./...
+    green; go test ./pkg/scheduler/... ./pkg/daemon/... ./pkg/dataplane/...
+    ./pkg/api/... green; gofmt + vet clean; scheduler README updated
+    (republish self-heal section + metric names).
+  - **File(s)**: pkg/scheduler/scheduler.go, pkg/scheduler/README.md,
+    pkg/scheduler/scheduler_republish_3780_test.go (new),
+    pkg/scheduler/scheduler_test.go (updateFn signature),
+    pkg/dataplane/dataplane.go (interface), pkg/dataplane/maps_policy.go,
+    pkg/dataplane/userspace/manager.go,
+    pkg/dataplane/userspace/legacy_dataplane.go,
+    pkg/dataplane/userspace/manager_republish_3780_test.go (new),
+    pkg/daemon/daemon.go (atomics), pkg/daemon/daemon_scheduler.go,
+    pkg/daemon/daemon_apply.go, pkg/daemon/daemon_run.go (metric wiring),
+    pkg/daemon/policy_scheduler_apply_test.go +
+    pkg/daemon/daemon_scheduler_test.go (signatures),
+    pkg/daemon/daemon_scheduler_republish_3780_test.go (new),
+    pkg/api/server.go, pkg/api/metrics.go, pkg/api/metrics_descriptors.go.
+
 ## 2026-07-01 — #3730 routing/PBR: kernel FBF ip-rule mirror honors L4 predicates + fail-closed on unrepresentable ones
 
 - **Timestamp**: 2026-07-01

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -131,6 +131,14 @@ type xpfCollector struct {
 	neighborPeriodicAge *prometheus.Desc
 	frrReloadDegraded   *prometheus.Desc
 
+	// #3780: 0/1 gauge — 1 while the most recent scheduler-driven policy
+	// republish failed and has not yet converged (stale enforcement past
+	// a schedule window: a permit still forwarding, or a scheduled block
+	// that never engaged). schedulerRepublishStale is the age of that
+	// failure streak in seconds (0 when healthy).
+	schedulerRepublishFailed *prometheus.Desc
+	schedulerRepublishStale  *prometheus.Desc
+
 	// #1799: 0/1 gauge — 1 while the running active config failed to
 	// persist to disk and the configstore's background retry has not
 	// yet succeeded (restart would load a stale config).
@@ -572,6 +580,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.daemonMemRSS
 	ch <- c.neighborPeriodicAge
 	ch <- c.frrReloadDegraded
+	ch <- c.schedulerRepublishFailed
+	ch <- c.schedulerRepublishStale
 	ch <- c.configPersistDegraded
 	ch <- c.rollbackHistoryDegraded
 	ch <- c.userspacePolicyContentRejected
@@ -814,6 +824,23 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(c.frrReloadDegraded,
 			prometheus.GaugeValue, v)
+	}
+
+	// #3780: scheduler republish-failure is a control-plane signal (the
+	// policy scheduler runs even in config-only mode) — emit it BEFORE
+	// the dataplane gate so stale enforcement past a schedule window
+	// stays visible even when the dataplane is not loaded.
+	if c.srv.schedulerRepublishFailedFn != nil {
+		v := 0.0
+		if c.srv.schedulerRepublishFailedFn() {
+			v = 1
+		}
+		ch <- prometheus.MustNewConstMetric(c.schedulerRepublishFailed,
+			prometheus.GaugeValue, v)
+	}
+	if c.srv.schedulerRepublishStaleSecondsFn != nil {
+		ch <- prometheus.MustNewConstMetric(c.schedulerRepublishStale,
+			prometheus.GaugeValue, c.srv.schedulerRepublishStaleSecondsFn())
 	}
 
 	// #2050: dynamic-address feed staleness is a control-plane signal (the

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -407,6 +407,25 @@ func newCollector(srv *Server) *xpfCollector {
 				"removal is deferred while set (#1880).",
 			nil, nil,
 		),
+		schedulerRepublishFailed: prometheus.NewDesc(
+			"xpf_scheduler_republish_failed",
+			"1 while the most recent scheduler-driven policy republish "+
+				"failed and has not yet converged (#3780): stale "+
+				"enforcement is live past a schedule window — a scheduled "+
+				"permit may still be forwarding after its window closed, or "+
+				"a scheduled block never engaged. The daemon retries the "+
+				"transition autonomously on each scheduler tick; 0 when the "+
+				"enforcement snapshot is in sync with the schedule state.",
+			nil, nil,
+		),
+		schedulerRepublishStale: prometheus.NewDesc(
+			"xpf_scheduler_republish_stale_seconds",
+			"Seconds since the current scheduler-republish failure streak "+
+				"began (#3780); 0 when healthy. A climbing value means "+
+				"enforcement has been out of sync with the schedule window "+
+				"for that long while the daemon retries.",
+			nil, nil,
+		),
 		configPersistDegraded: prometheus.NewDesc(
 			"xpf_daemon_config_persist_degraded",
 			"1 while the running active configuration failed to persist "+

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -152,6 +152,20 @@ type Config struct {
 	// xpf_frr_reload_degraded gauge (0/1, no labels). Optional; if nil,
 	// the gauge is not emitted.
 	FRRReloadDegradedFn func() bool
+	// SchedulerRepublishFailedFn reports whether the most recent
+	// scheduler-driven policy republish failed and has not yet converged
+	// (#3780). A scheduler window transition republishes enforcement; a
+	// swallowed failure leaves stale enforcement live past the window (a
+	// permit still forwarding, or a scheduled block that never engaged).
+	// Backs the xpf_scheduler_republish_failed gauge (0/1, no labels).
+	// Optional; if nil, the gauge is not emitted.
+	SchedulerRepublishFailedFn func() bool
+	// SchedulerRepublishStaleSecondsFn returns how long the current
+	// scheduler-republish failure streak has gone unconverged, in
+	// seconds (0 when healthy) (#3780). Backs the
+	// xpf_scheduler_republish_stale_seconds gauge. Optional; if nil, the
+	// gauge is not emitted.
+	SchedulerRepublishStaleSecondsFn func() float64
 	// FeedsFn surfaces live dynamic-address feed status for the
 	// xpf_feed_seconds_since_last_success / xpf_feed_stale gauges (#2050).
 	// A feed that has never fetched successfully, or whose last-good
@@ -216,71 +230,75 @@ type Config struct {
 
 // Server is the HTTP API server.
 type Server struct {
-	httpServer                *http.Server
-	httpsServer               *http.Server
-	store                     *configstore.Store
-	dp                        apiRuntimeDataPlane
-	eventBuf                  *logging.EventBuffer
-	gc                        *conntrack.GC
-	routing                   *routing.Manager
-	frr                       *frr.Manager
-	ipsec                     *ipsec.Manager
-	dhcp                      *dhcp.Manager
-	vrrpMgr                   *vrrp.Manager
-	commitFn                  func(ctx context.Context, comment string) (*config.Config, error)
-	commitConfirmedFn         func(ctx context.Context, minutes int) (*config.Config, error)
-	compileHealthFn           func() CompileHealthSnapshot
-	configPersistDegradedFn   func() bool
-	rollbackHistoryDegradedFn func() bool
-	neighborPhaseAgeFn        func() map[string]float64
-	frrReloadDegradedFn       func() bool
-	ipmonStatusFn             func() []ipmon.PolicyStatus
-	eventActionStatsFn        func() eventengine.Stats
-	rpmPinFailedFn            func() float64
-	feedsFn                   func() map[string]feeds.FeedInfo
-	ddnsStatsFn               func() *dhcpserver.DDNSStats
-	surfaceAStatsFn           func() *ddns.SurfaceAStats
-	flowCollectorHealthFn     func() []flowexport.ExporterCollectorHealth
-	feedOverlayFn             func() map[string][]string
-	policySchedActiveFn       func() (map[string]bool, bool)
-	haActiveFn                func() bool
-	nodeIDFn                  func() int
-	clusterSessionFn          func() ClusterSessionService
-	startTime                 time.Time
+	httpServer                       *http.Server
+	httpsServer                      *http.Server
+	store                            *configstore.Store
+	dp                               apiRuntimeDataPlane
+	eventBuf                         *logging.EventBuffer
+	gc                               *conntrack.GC
+	routing                          *routing.Manager
+	frr                              *frr.Manager
+	ipsec                            *ipsec.Manager
+	dhcp                             *dhcp.Manager
+	vrrpMgr                          *vrrp.Manager
+	commitFn                         func(ctx context.Context, comment string) (*config.Config, error)
+	commitConfirmedFn                func(ctx context.Context, minutes int) (*config.Config, error)
+	compileHealthFn                  func() CompileHealthSnapshot
+	configPersistDegradedFn          func() bool
+	rollbackHistoryDegradedFn        func() bool
+	neighborPhaseAgeFn               func() map[string]float64
+	frrReloadDegradedFn              func() bool
+	schedulerRepublishFailedFn       func() bool
+	schedulerRepublishStaleSecondsFn func() float64
+	ipmonStatusFn                    func() []ipmon.PolicyStatus
+	eventActionStatsFn               func() eventengine.Stats
+	rpmPinFailedFn                   func() float64
+	feedsFn                          func() map[string]feeds.FeedInfo
+	ddnsStatsFn                      func() *dhcpserver.DDNSStats
+	surfaceAStatsFn                  func() *ddns.SurfaceAStats
+	flowCollectorHealthFn            func() []flowexport.ExporterCollectorHealth
+	feedOverlayFn                    func() map[string][]string
+	policySchedActiveFn              func() (map[string]bool, bool)
+	haActiveFn                       func() bool
+	nodeIDFn                         func() int
+	clusterSessionFn                 func() ClusterSessionService
+	startTime                        time.Time
 }
 
 // NewServer creates a new API server.
 func NewServer(cfg Config) *Server {
 	s := &Server{
-		store:                     cfg.Store,
-		dp:                        cfg.DP,
-		eventBuf:                  cfg.EventBuf,
-		gc:                        cfg.GC,
-		routing:                   cfg.Routing,
-		frr:                       cfg.FRR,
-		ipsec:                     cfg.IPsec,
-		dhcp:                      cfg.DHCP,
-		vrrpMgr:                   cfg.VRRPMgr,
-		commitFn:                  cfg.CommitFn,
-		commitConfirmedFn:         cfg.CommitConfirmedFn,
-		compileHealthFn:           cfg.CompileHealthFn,
-		configPersistDegradedFn:   cfg.ConfigPersistDegradedFn,
-		rollbackHistoryDegradedFn: cfg.RollbackHistoryDegradedFn,
-		neighborPhaseAgeFn:        cfg.NeighborPhaseAgeFn,
-		frrReloadDegradedFn:       cfg.FRRReloadDegradedFn,
-		ipmonStatusFn:             cfg.IPMonStatusFn,
-		eventActionStatsFn:        cfg.EventActionStatsFn,
-		rpmPinFailedFn:            cfg.RPMPinFailedFn,
-		feedsFn:                   cfg.FeedsFn,
-		ddnsStatsFn:               cfg.DDNSStatsFn,
-		surfaceAStatsFn:           cfg.SurfaceAStatsFn,
-		flowCollectorHealthFn:     cfg.FlowCollectorHealthFn,
-		feedOverlayFn:             cfg.FeedOverlayFn,
-		policySchedActiveFn:       cfg.PolicySchedulerActiveStateFn,
-		haActiveFn:                cfg.HAActiveFn,
-		nodeIDFn:                  cfg.NodeIDFn,
-		clusterSessionFn:          cfg.ClusterSessionFn,
-		startTime:                 time.Now(),
+		store:                            cfg.Store,
+		dp:                               cfg.DP,
+		eventBuf:                         cfg.EventBuf,
+		gc:                               cfg.GC,
+		routing:                          cfg.Routing,
+		frr:                              cfg.FRR,
+		ipsec:                            cfg.IPsec,
+		dhcp:                             cfg.DHCP,
+		vrrpMgr:                          cfg.VRRPMgr,
+		commitFn:                         cfg.CommitFn,
+		commitConfirmedFn:                cfg.CommitConfirmedFn,
+		compileHealthFn:                  cfg.CompileHealthFn,
+		configPersistDegradedFn:          cfg.ConfigPersistDegradedFn,
+		rollbackHistoryDegradedFn:        cfg.RollbackHistoryDegradedFn,
+		neighborPhaseAgeFn:               cfg.NeighborPhaseAgeFn,
+		frrReloadDegradedFn:              cfg.FRRReloadDegradedFn,
+		schedulerRepublishFailedFn:       cfg.SchedulerRepublishFailedFn,
+		schedulerRepublishStaleSecondsFn: cfg.SchedulerRepublishStaleSecondsFn,
+		ipmonStatusFn:                    cfg.IPMonStatusFn,
+		eventActionStatsFn:               cfg.EventActionStatsFn,
+		rpmPinFailedFn:                   cfg.RPMPinFailedFn,
+		feedsFn:                          cfg.FeedsFn,
+		ddnsStatsFn:                      cfg.DDNSStatsFn,
+		surfaceAStatsFn:                  cfg.SurfaceAStatsFn,
+		flowCollectorHealthFn:            cfg.FlowCollectorHealthFn,
+		feedOverlayFn:                    cfg.FeedOverlayFn,
+		policySchedActiveFn:              cfg.PolicySchedulerActiveStateFn,
+		haActiveFn:                       cfg.HAActiveFn,
+		nodeIDFn:                         cfg.NodeIDFn,
+		clusterSessionFn:                 cfg.ClusterSessionFn,
+		startTime:                        time.Now(),
 	}
 
 	mux := http.NewServeMux()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -211,32 +211,42 @@ type Daemon struct {
 	// bools distinguish "never reconciled" from "reconciled to the
 	// nil sentinel". The *ReconMu serialize the reconcile swap against
 	// shutdown's stopFlow/IPFIXExporter (both touch the cancel/wg).
-	flowBundle                 atomic.Pointer[exporterBundle]
-	flowHash                   [32]byte
-	flowHashSet                bool
-	flowCBOnce                 sync.Once
-	flowReconMu                sync.Mutex
-	ipfixBundlePtr             atomic.Pointer[ipfixBundle]
-	ipfixHash                  [32]byte
-	ipfixHashSet               bool
-	ipfixCBOnce                sync.Once
-	ipfixReconMu               sync.Mutex
-	dhcpRelay                  *dhcprelay.Manager
-	snmpAgent                  *snmp.Agent
-	lldpMgr                    *lldp.Manager
-	lldpApplied                *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
-	lldpApplyInit              bool             // true once reconcileLLDP has run at least once
-	scheduler                  *scheduler.Scheduler
-	schedulerCancel            context.CancelFunc
-	policySchedulerConfigHash  [32]byte
-	policySchedulerEpoch       atomic.Uint64
-	cluster                    *cluster.Manager
-	sessionSync                *cluster.SessionSync
-	syncBulkPrimed             atomic.Bool
-	syncPeerBulkPrimed         atomic.Bool
-	syncPeerConnected          atomic.Bool
-	lastStandbyNeighborRefresh atomic.Int64
-	neighborWarmupInFlight     atomic.Bool
+	flowBundle                atomic.Pointer[exporterBundle]
+	flowHash                  [32]byte
+	flowHashSet               bool
+	flowCBOnce                sync.Once
+	flowReconMu               sync.Mutex
+	ipfixBundlePtr            atomic.Pointer[ipfixBundle]
+	ipfixHash                 [32]byte
+	ipfixHashSet              bool
+	ipfixCBOnce               sync.Once
+	ipfixReconMu              sync.Mutex
+	dhcpRelay                 *dhcprelay.Manager
+	snmpAgent                 *snmp.Agent
+	lldpMgr                   *lldp.Manager
+	lldpApplied               *lldp.LLDPConfig // last effective LLDP config Apply()'d (#2372 diff-guard); nil = stopped
+	lldpApplyInit             bool             // true once reconcileLLDP has run at least once
+	scheduler                 *scheduler.Scheduler
+	schedulerCancel           context.CancelFunc
+	policySchedulerConfigHash [32]byte
+	policySchedulerEpoch      atomic.Uint64
+	// #3780: scheduler republish-failure observability.
+	// schedulerRepublishFailing is 1 while the most recent
+	// scheduler-driven policy republish failed and has not yet
+	// converged (stale enforcement past a schedule window);
+	// schedulerRepublishFirstFailNanos is the wall-clock start of the
+	// current failure streak (0 when healthy) for the stale-age gauge.
+	// Set in publishPolicyScheduleState, cleared on recovery or
+	// scheduler teardown; read lock-free by the metrics collector.
+	schedulerRepublishFailing        atomic.Bool
+	schedulerRepublishFirstFailNanos atomic.Int64
+	cluster                          *cluster.Manager
+	sessionSync                      *cluster.SessionSync
+	syncBulkPrimed                   atomic.Bool
+	syncPeerBulkPrimed               atomic.Bool
+	syncPeerConnected                atomic.Bool
+	lastStandbyNeighborRefresh       atomic.Int64
+	neighborWarmupInFlight           atomic.Bool
 	// #1780 Path A: per-phase supervision of runPeriodicNeighborResolution.
 	// Each periodic phase runs in a guarded goroutine so a hung netlink/probe
 	// syscall in one phase can never freeze the for-select loop (the observed

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1636,5 +1636,9 @@ func (d *Daemon) publishInitialPolicySchedulerStateLocked(cfg *config.Config, ac
 	if _, isUserspace := d.dp.(userspaceRuntimeModeReporter); isUserspace {
 		return
 	}
-	d.updatePolicyScheduleStateLocked(cfg, activeState)
+	// #3780: initial (eBPF-path) publish rides the apply transaction; a
+	// failure here is surfaced via the same republish-failure metric so
+	// it is not silently swallowed. The retired eBPF updater always
+	// reports success, so this is a no-op there today.
+	d.recordSchedulerRepublishResult(d.updatePolicyScheduleStateLocked(cfg, activeState))
 }

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1215,6 +1215,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 				}
 				return d.frr.ReloadDegraded()
 			},
+			// #3780: surface scheduler republish-failure so
+			// xpf_scheduler_republish_failed reads 1 (and
+			// xpf_scheduler_republish_stale_seconds climbs) while a
+			// scheduler window transition's republish has not converged —
+			// otherwise stale enforcement past the window is invisible to
+			// monitoring.
+			SchedulerRepublishFailedFn:       d.SchedulerRepublishFailed,
+			SchedulerRepublishStaleSecondsFn: d.SchedulerRepublishStaleSeconds,
 			// #1827: ip-monitoring policy state for the xpf_ipmon_*
 			// metric family.
 			IPMonStatusFn: func() []ipmon.PolicyStatus {

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -16,7 +16,7 @@ type policySchedulerActiveStateSetter interface {
 }
 
 type policyScheduleStateUpdater interface {
-	UpdatePolicyScheduleState(*config.Config, map[string]bool)
+	UpdatePolicyScheduleState(*config.Config, map[string]bool) error
 }
 
 // reconcilePolicySchedulerLocked runs under applySem. It makes the scheduler
@@ -38,6 +38,11 @@ func (d *Daemon) reconcilePolicySchedulerLockedAt(cfg *config.Config, now time.T
 		d.schedulerCancel = nil
 	}
 	d.scheduler = nil
+	// #3780: the scheduler set is being removed or replaced. Clear any
+	// stale republish-failure metric from the outgoing scheduler; a new
+	// scheduler's initial state is published by the fallible apply path,
+	// and a removed scheduler set has nothing left to converge.
+	d.clearSchedulerRepublishFailure()
 	epoch := d.policySchedulerEpoch.Add(1)
 
 	if !hasSchedulers {
@@ -45,8 +50,8 @@ func (d *Daemon) reconcilePolicySchedulerLockedAt(cfg *config.Config, now time.T
 		return nil
 	}
 
-	sched, activeState := scheduler.NewPrimed(cfg.Schedulers, func(activeState map[string]bool) {
-		d.publishPolicyScheduleState(epoch, activeState)
+	sched, activeState := scheduler.NewPrimed(cfg.Schedulers, func(activeState map[string]bool) error {
+		return d.publishPolicyScheduleState(epoch, activeState)
 	}, now)
 	d.scheduler = sched
 	d.policySchedulerConfigHash = hash
@@ -62,7 +67,7 @@ func (d *Daemon) policySchedulerActiveStateForApplyLocked(cfg *config.Config, no
 	if d.scheduler != nil && hash == d.policySchedulerConfigHash {
 		return d.scheduler.ActiveState()
 	}
-	_, activeState := scheduler.NewPrimed(cfg.Schedulers, func(map[string]bool) {}, now)
+	_, activeState := scheduler.NewPrimed(cfg.Schedulers, func(map[string]bool) error { return nil }, now)
 	return activeState
 }
 
@@ -117,26 +122,38 @@ func (d *Daemon) startPolicySchedulerLoopLocked() {
 	go d.scheduler.Run(ctx)
 }
 
-func (d *Daemon) publishPolicyScheduleState(epoch uint64, activeState map[string]bool) {
+// publishPolicyScheduleState is the scheduler's updateFn. It returns a
+// non-nil error only when a live scheduler-driven republish did NOT
+// converge, which the scheduler uses to retry autonomously on its next
+// tick and which recordSchedulerRepublishResult surfaces as the
+// xpf_scheduler_republish_failed metric (#3780). Shutdown / torn-down /
+// nothing-to-publish cases return nil (no retry, no alarm).
+func (d *Daemon) publishPolicyScheduleState(epoch uint64, activeState map[string]bool) error {
 	ctx := d.daemonCtx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		// Daemon context cancelled — the daemon is shutting down and the
+		// scheduler loop is stopping too. Nothing to retry.
 		slog.Warn("scheduler: failed to acquire apply semaphore", "err", err)
-		return
+		return nil
 	}
 	defer d.applySem.Release(1)
 
 	if epoch != d.policySchedulerEpoch.Load() {
-		return
+		// A reconcile replaced this scheduler instance; the new instance
+		// owns republish. Do not latch a retry on the dead one.
+		return nil
 	}
 	cfg := d.store.ActiveConfig()
 	if cfg == nil || d.dp == nil {
-		return
+		return nil
 	}
 	d.seedPolicySchedulerActiveStateLocked(activeState)
-	d.updatePolicyScheduleStateLocked(cfg, activeState)
+	err := d.updatePolicyScheduleStateLocked(cfg, activeState)
+	d.recordSchedulerRepublishResult(err)
+	return err
 }
 
 func (d *Daemon) seedPolicySchedulerActiveStateLocked(activeState map[string]bool) {
@@ -148,9 +165,9 @@ func (d *Daemon) seedPolicySchedulerActiveStateLocked(activeState map[string]boo
 	}
 }
 
-func (d *Daemon) updatePolicyScheduleStateLocked(cfg *config.Config, activeState map[string]bool) {
+func (d *Daemon) updatePolicyScheduleStateLocked(cfg *config.Config, activeState map[string]bool) error {
 	if d.dp == nil {
-		return
+		return nil
 	}
 	// Both in-tree backends satisfy policyScheduleStateUpdater
 	// directly: *dataplane.Manager via UpdatePolicyScheduleState in
@@ -159,6 +176,63 @@ func (d *Daemon) updatePolicyScheduleStateLocked(cfg *config.Config, activeState
 	// pkg/dataplane/userspace/legacy_dataplane.go:161. The legacyDP()
 	// fallback branch was dead code; removed in #1519.
 	if updater, ok := d.dp.(policyScheduleStateUpdater); ok {
-		updater.UpdatePolicyScheduleState(cfg, activeState)
+		return updater.UpdatePolicyScheduleState(cfg, activeState)
 	}
+	return nil
+}
+
+// recordSchedulerRepublishResult latches or clears the scheduler
+// republish-failure metric from a republish result (#3780). This is the
+// observability side of the scheduler self-heal: while a
+// scheduler-driven republish keeps failing, xpf_scheduler_republish_failed
+// reads 1 and xpf_scheduler_republish_stale_seconds climbs, so stale
+// enforcement (a permit still live past its window, or a block that never
+// engaged) is visible to monitoring instead of silent. The transition
+// itself is retried by the scheduler on its next tick.
+func (d *Daemon) recordSchedulerRepublishResult(err error) {
+	if err != nil {
+		if d.schedulerRepublishFailing.CompareAndSwap(false, true) {
+			d.schedulerRepublishFirstFailNanos.Store(time.Now().UnixNano())
+			slog.Error("scheduler: policy schedule republish FAILED; enforcement is stale (a permit may still be live past its window, or a scheduled block never engaged) — retrying on the next scheduler tick until it converges",
+				"err", err)
+		}
+		return
+	}
+	if d.schedulerRepublishFailing.CompareAndSwap(true, false) {
+		d.schedulerRepublishFirstFailNanos.Store(0)
+		slog.Info("scheduler: policy schedule republish recovered; enforcement is back in sync with the schedule window")
+	}
+}
+
+// clearSchedulerRepublishFailure resets the republish-failure metric.
+// Called when the scheduler set is torn down or replaced by a reconcile.
+func (d *Daemon) clearSchedulerRepublishFailure() {
+	if d.schedulerRepublishFailing.Swap(false) {
+		d.schedulerRepublishFirstFailNanos.Store(0)
+	}
+}
+
+// SchedulerRepublishFailed reports whether the most recent
+// scheduler-driven policy republish failed and has not yet converged
+// (#3780). Lock-free; safe for the metrics collector goroutine.
+func (d *Daemon) SchedulerRepublishFailed() bool {
+	return d.schedulerRepublishFailing.Load()
+}
+
+// SchedulerRepublishStaleSeconds returns how long the current
+// scheduler-republish failure streak has gone unconverged, in seconds
+// (0 when healthy) (#3780).
+func (d *Daemon) SchedulerRepublishStaleSeconds() float64 {
+	if !d.schedulerRepublishFailing.Load() {
+		return 0
+	}
+	first := d.schedulerRepublishFirstFailNanos.Load()
+	if first == 0 {
+		return 0
+	}
+	age := time.Now().UnixNano() - first
+	if age < 0 {
+		return 0
+	}
+	return time.Duration(age).Seconds()
 }

--- a/pkg/daemon/daemon_scheduler_republish_3780_test.go
+++ b/pkg/daemon/daemon_scheduler_republish_3780_test.go
@@ -1,0 +1,92 @@
+package daemon
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestUpdatePolicyScheduleStateLockedPropagatesError proves the daemon
+// plumbing carries the dataplane republish error back to the caller
+// (#3780). On revert the updater method is void and the daemon has no
+// error to act on → a failed scheduler-window republish is silently
+// dropped and the stale permit stays live.
+func TestUpdatePolicyScheduleStateLockedPropagatesError(t *testing.T) {
+	wantErr := errors.New("apply_snapshot failed")
+	dp := &runtimeOnlyPolicyUpdaterTestDP{updateErr: wantErr}
+	d := &Daemon{dp: dp}
+
+	err := d.updatePolicyScheduleStateLocked(&config.Config{}, map[string]bool{"workhours": false})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("updatePolicyScheduleStateLocked err = %v, want %v (a swallowed error is the #3780 fail-open)", err, wantErr)
+	}
+	if dp.updateCalls != 1 {
+		t.Fatalf("updater calls = %d, want 1", dp.updateCalls)
+	}
+
+	// Success path returns nil.
+	dp.updateErr = nil
+	if err := d.updatePolicyScheduleStateLocked(&config.Config{}, map[string]bool{"workhours": true}); err != nil {
+		t.Fatalf("successful update must return nil, got %v", err)
+	}
+}
+
+// TestSchedulerRepublishMetricLatchesAndClears verifies the
+// observability side of the #3780 self-heal: a failing scheduler
+// republish latches xpf_scheduler_republish_failed=1 and a climbing
+// stale-age, and both clear on recovery (or scheduler teardown).
+//
+// RED-on-revert: without recordSchedulerRepublishResult the metric stays
+// 0 while a permit is live past its window — the fail-open is invisible.
+func TestSchedulerRepublishMetricLatchesAndClears(t *testing.T) {
+	d := &Daemon{}
+
+	if d.SchedulerRepublishFailed() {
+		t.Fatal("fresh daemon must not report a republish failure")
+	}
+	if got := d.SchedulerRepublishStaleSeconds(); got != 0 {
+		t.Fatalf("stale seconds = %v, want 0 when healthy", got)
+	}
+
+	// First failure latches the gauge and records the streak start.
+	d.recordSchedulerRepublishResult(errors.New("boom"))
+	if !d.SchedulerRepublishFailed() {
+		t.Fatal("a failing republish must set xpf_scheduler_republish_failed=1")
+	}
+
+	// Backdate the streak start so the stale-age gauge is deterministic.
+	d.schedulerRepublishFirstFailNanos.Store(time.Now().Add(-3 * time.Second).UnixNano())
+	if got := d.SchedulerRepublishStaleSeconds(); got < 2 {
+		t.Fatalf("stale seconds = %v, want >= 2 while failing", got)
+	}
+
+	// A repeated failure must NOT reset the streak start (the age must
+	// keep climbing to show how long enforcement has been stale).
+	first := d.schedulerRepublishFirstFailNanos.Load()
+	d.recordSchedulerRepublishResult(errors.New("boom again"))
+	if d.schedulerRepublishFirstFailNanos.Load() != first {
+		t.Fatal("a repeated failure must not reset the failure-streak start")
+	}
+
+	// Recovery clears both.
+	d.recordSchedulerRepublishResult(nil)
+	if d.SchedulerRepublishFailed() {
+		t.Fatal("a successful republish must clear the failure gauge")
+	}
+	if got := d.SchedulerRepublishStaleSeconds(); got != 0 {
+		t.Fatalf("stale seconds = %v, want 0 after recovery", got)
+	}
+
+	// Scheduler teardown (config change removing/replacing schedulers)
+	// also clears the gauge.
+	d.recordSchedulerRepublishResult(errors.New("boom"))
+	d.clearSchedulerRepublishFailure()
+	if d.SchedulerRepublishFailed() {
+		t.Fatal("scheduler teardown must clear the republish-failure gauge")
+	}
+	if got := d.SchedulerRepublishStaleSeconds(); got != 0 {
+		t.Fatalf("stale seconds = %v, want 0 after teardown", got)
+	}
+}

--- a/pkg/daemon/daemon_scheduler_test.go
+++ b/pkg/daemon/daemon_scheduler_test.go
@@ -13,7 +13,7 @@ import (
 func TestStartPolicySchedulerLoopLockedWaitsForDaemonContext(t *testing.T) {
 	sched, _ := scheduler.NewPrimed(map[string]*config.SchedulerConfig{
 		"always": {Name: "always"},
-	}, func(map[string]bool) {}, time.Now())
+	}, func(map[string]bool) error { return nil }, time.Now())
 
 	d := &Daemon{scheduler: sched}
 	d.startPolicySchedulerLoopLocked()

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -22,6 +22,7 @@ type policySchedulerApplyTestDP struct {
 	deferStates     []bool
 	updateCalls     int
 	updateStateSeen map[string]bool
+	updateErr       error
 }
 
 func (d *policySchedulerApplyTestDP) Compile(*config.Config) (*dataplane.CompileResult, error) {
@@ -49,9 +50,10 @@ func (d *policySchedulerApplyTestDP) SetDeferWorkers(v bool) {
 	d.deferStates = append(d.deferStates, v)
 }
 
-func (d *policySchedulerApplyTestDP) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) {
+func (d *policySchedulerApplyTestDP) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) error {
 	d.updateCalls++
 	d.updateStateSeen = activeState
+	return d.updateErr
 }
 
 type userspacePolicySchedulerApplyTestDP struct {
@@ -124,11 +126,13 @@ type runtimeOnlyPolicyUpdaterTestDP struct {
 	runtimeOnlyApplyTestDP
 	updateCalls int
 	stateSeen   map[string]bool
+	updateErr   error
 }
 
-func (d *runtimeOnlyPolicyUpdaterTestDP) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) {
+func (d *runtimeOnlyPolicyUpdaterTestDP) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) error {
 	d.updateCalls++
 	d.stateSeen = copyPolicySchedulerApplyState(activeState)
+	return d.updateErr
 }
 
 func (d *userspacePolicySchedulerApplyTestDP) SetPolicySchedulerActiveState(activeState map[string]bool) {
@@ -218,7 +222,7 @@ func TestApplyConfigProtocolAbortPreservesExistingScheduler(t *testing.T) {
 			"old": {Name: "old"},
 		},
 	}
-	oldScheduler, oldState := scheduler.NewPrimed(oldCfg.Schedulers, func(map[string]bool) {}, testPolicySchedulerApplyNow())
+	oldScheduler, oldState := scheduler.NewPrimed(oldCfg.Schedulers, func(map[string]bool) error { return nil }, testPolicySchedulerApplyNow())
 	oldHash, _ := policySchedulerConfigHash(oldCfg)
 	dp := &policySchedulerApplyTestDP{
 		compileErr: dpuserspace.ErrPolicySchedulerProtocolIncompatible,

--- a/pkg/dataplane/dataplane.go
+++ b/pkg/dataplane/dataplane.go
@@ -263,7 +263,12 @@ type DataPlane interface {
 	SetPolicyRule(policySetID uint32, ruleIndex uint32, rule PolicyRule) error
 	ClearZonePairPolicies() error
 	SetDefaultPolicy(action uint8) error
-	UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool)
+	// UpdatePolicyScheduleState republishes enforcement for a scheduler
+	// window transition. It returns a non-nil error when the transition
+	// did NOT converge (the new inactive-bit view was not applied) so the
+	// caller can retry and surface the failure — a swallowed failure
+	// leaves stale enforcement live past the window (#3780).
+	UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool) error
 
 	// Address book
 	SetAddressBookEntry(cidr string, addressID uint32) error

--- a/pkg/dataplane/maps_policy.go
+++ b/pkg/dataplane/maps_policy.go
@@ -243,14 +243,20 @@ func (m *Manager) SetDefaultPolicy(action uint8) error {
 
 // UpdatePolicyScheduleState iterates policy rules and toggles the Active flag
 // based on scheduler state. Only rules whose scheduler state changed are updated.
-func (m *Manager) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) {
+//
+// #3780: this is the retired eBPF map path (the userspace backend shadows
+// it in pkg/dataplane/userspace/manager.go). It stays best-effort: the map
+// is direct-write, there is nothing to retry, and the eBPF backend never
+// runs at runtime. It always reports success (nil) so the daemon's
+// scheduler self-heal never spins on a dead path.
+func (m *Manager) UpdatePolicyScheduleState(_ *config.Config, activeState map[string]bool) error {
 	zm, ok := m.maps["policy_rules"]
 	if !ok {
-		return
+		return nil
 	}
 	result := m.LastCompileResult()
 	if result == nil {
-		return
+		return nil
 	}
 
 	for _, slot := range result.PolicyScheduleRuleSlots {
@@ -278,6 +284,7 @@ func (m *Manager) UpdatePolicyScheduleState(_ *config.Config, activeState map[st
 				"active", active)
 		}
 	}
+	return nil
 }
 
 // ReadPolicyCounters reads the per-CPU policy counter values and sums them.

--- a/pkg/dataplane/userspace/legacy_dataplane.go
+++ b/pkg/dataplane/userspace/legacy_dataplane.go
@@ -183,12 +183,15 @@ func (a *LegacyDataPlaneAdapter) Compile(cfg *config.Config) (*dataplane.Compile
 	return m.Compile(cfg)
 }
 
-func (a *LegacyDataPlaneAdapter) UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool) {
+func (a *LegacyDataPlaneAdapter) UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool) error {
 	m, err := a.managerOrErr()
 	if err != nil {
-		return
+		// #3780: no manager attached — nothing is enforcing, so there
+		// is no stale permit to converge. Report success so the daemon
+		// scheduler self-heal does not spin.
+		return nil
 	}
-	m.UpdatePolicyScheduleState(cfg, activeState)
+	return m.UpdatePolicyScheduleState(cfg, activeState)
 }
 
 func (a *LegacyDataPlaneAdapter) SetPolicySchedulerActiveState(activeState map[string]bool) {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -746,7 +746,7 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 // UpdatePolicyScheduleState republishes the userspace policy snapshot with one
 // coherent inactive-bit view. This shadows the embedded eBPF manager method;
 // scheduled userspace policies must not update the policy_rules BPF map.
-func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool) {
+func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[string]bool) error {
 	activeCopy := copyPolicySchedulerActiveState(activeState)
 
 	m.mu.Lock()
@@ -755,15 +755,21 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	m.policySchedulerActive = activeCopy
 	if cfg == nil {
 		if m.lastSnapshot == nil {
-			return
+			// #3780: no snapshot ever published — nothing to
+			// republish, and no live enforcement to go stale. The
+			// next full apply publishes the initial state. Converged.
+			return nil
 		}
 		cfg = m.lastSnapshot.Config
 	}
 	if cfg == nil || m.lastSnapshot == nil {
-		return
+		return nil
 	}
 	if m.proc == nil || m.proc.Process == nil {
-		return
+		// #3780: the helper is not running, so no snapshot is being
+		// enforced — there is no stale permit to converge. The helper
+		// restart path re-applies the last snapshot. Converged.
+		return nil
 	}
 
 	if err := m.ensureRequiredSnapshotProtocolLocked(cfg); err != nil {
@@ -772,7 +778,10 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 				"protocol_err", err, "err", disarmErr)
 		}
 		slog.Warn("userspace: refusing snapshot publish to incompatible helper", "err", err)
-		return
+		// #3780: the intended new inactive-bit view was NOT applied.
+		// Report failure so the daemon retries on the next scheduler
+		// tick and surfaces the stale-enforcement metric.
+		return fmt.Errorf("userspace: refusing snapshot publish to incompatible helper: %w", err)
 	}
 	next := *m.lastSnapshot
 	nextGeneration := m.generation + 1
@@ -794,7 +803,10 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	policies, err := buildPolicySnapshotsWithSchedulerStateAndFeeds(cfg, activeCopy, feedOverlay)
 	if err != nil {
 		slog.Warn("userspace: skipping policy-scheduler republish; retaining prior snapshot", "err", err)
-		return
+		// #3780: the prior snapshot is retained, which for a CLOSING
+		// window means the old permit stays live. Report failure so the
+		// transition is retried until the rebuild succeeds and converges.
+		return fmt.Errorf("userspace: policy snapshot rebuild for scheduler republish: %w", err)
 	}
 	next.Policies = policies
 	// #3261: the policies were rebuilt, so recompute the (feed-aware)
@@ -808,7 +820,8 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	books, _, err := buildAddressBookTableWithFeeds(cfg, feedOverlay)
 	if err != nil {
 		slog.Warn("userspace: skipping policy-scheduler republish; retaining prior snapshot", "err", err)
-		return
+		// #3780: same fail-safe as the policy rebuild above — retry.
+		return fmt.Errorf("userspace: address-book rebuild for scheduler republish: %w", err)
 	}
 	next.AddressBooks = books
 
@@ -819,11 +832,17 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 	// disarmBeforeUnsupportedPublishLocked). cfg is this snapshot's config.
 	if err := m.disarmBeforeUnsupportedPublishLocked(&publishSnap); err != nil {
 		slog.Warn("userspace: failed to disarm before unsupported-config policy scheduler publish", "err", err)
-		return
+		// #3780: disarm failed and the new snapshot was not published —
+		// report failure so the transition retries.
+		return fmt.Errorf("userspace: disarm before unsupported-config policy scheduler publish: %w", err)
 	}
 	if err := m.requestLocked(ControlRequest{Type: "apply_snapshot", Snapshot: &publishSnap}, &status); err != nil {
 		slog.Warn("userspace: failed to publish policy scheduler state", "err", err)
-		return
+		// #3780: THE fail-open path from the issue. apply_snapshot did
+		// not land, so the helper keeps the OLD inactive bits — a permit
+		// past its window stays live. Report failure so the daemon
+		// retries autonomously on the next scheduler tick.
+		return fmt.Errorf("userspace: publish policy scheduler snapshot: %w", err)
 	}
 	m.logWgEndpointSetTransitionLocked(&publishSnap, "policy-scheduler")
 	m.generation = nextGeneration
@@ -838,8 +857,13 @@ func (m *Manager) UpdatePolicyScheduleState(cfg *config.Config, activeState map[
 		m.lastSnapshotHash = h
 	}
 	if err := m.applyHelperStatusLocked(&status); err != nil {
+		// #3780: the snapshot DID land (generation bumped, lastSnapshot
+		// updated above) — the schedule transition converged. A status
+		// re-sync failure is observability only; do NOT force a retry
+		// that would churn an identical snapshot.
 		slog.Warn("userspace: failed to sync helper status after policy scheduler publish", "err", err)
 	}
+	return nil
 }
 
 // routeOverlaySnapshot returns a copy of the cached ip-monitoring

--- a/pkg/dataplane/userspace/manager_republish_3780_test.go
+++ b/pkg/dataplane/userspace/manager_republish_3780_test.go
@@ -1,0 +1,84 @@
+package userspace
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestUpdatePolicyScheduleStateReturnsErrorOnPublishFailure is the core
+// #3780 contract at the dataplane boundary: a failed apply_snapshot on a
+// scheduler window flip must be REPORTED (non-nil error), not swallowed.
+//
+// RED-on-revert: reverting the userspace manager to `slog.Warn(...);
+// return` (void) makes this return nil — the daemon never learns the
+// republish failed, never retries, and the helper keeps the OLD inactive
+// bits, so a scheduled permit stays live after its window closed.
+func TestUpdatePolicyScheduleStateReturnsErrorOnPublishFailure(t *testing.T) {
+	dir := t.TempDir()
+	// A control-socket path with nothing listening: requestLocked cannot
+	// connect, so the apply_snapshot publish fails.
+	controlSock := filepath.Join(dir, "no-listener.sock")
+
+	cfg := &config.Config{}
+	cfg.Security.Policies = []*config.ZonePairPolicies{{
+		FromZone: "trust",
+		ToZone:   "untrust",
+		Policies: []*config.Policy{{
+			Name:          "scheduled-allow",
+			SchedulerName: "workhours",
+			Match: config.PolicyMatch{
+				SourceAddresses:      []string{"any"},
+				DestinationAddresses: []string{"any"},
+				Applications:         []string{"any"},
+			},
+			Action: config.PolicyPermit,
+		}},
+	}}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours"},
+	}
+
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 7
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	err := m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false})
+	if err == nil {
+		t.Fatal("UpdatePolicyScheduleState must return an error when apply_snapshot fails (silent fail-open otherwise)")
+	}
+
+	// The prior snapshot generation must be RETAINED (not bumped) so the
+	// retry republishes cleanly from a consistent baseline.
+	if m.generation != 7 {
+		t.Fatalf("generation = %d, want 7 retained after a failed publish", m.generation)
+	}
+}
+
+// TestUpdatePolicyScheduleStateNoHelperReportsConverged verifies the
+// no-op paths report success (nil): with no helper process there is no
+// live enforcement to go stale, so the daemon self-heal must not spin.
+func TestUpdatePolicyScheduleStateNoHelperReportsConverged(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Schedulers = map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours"},
+	}
+
+	m := New()
+	// No m.proc, no m.lastSnapshot: nothing published, nothing to converge.
+	if err := m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false}); err != nil {
+		t.Fatalf("no-snapshot republish must report converged (nil), got %v", err)
+	}
+
+	// Snapshot present but helper not running: still a no-op success.
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{}, 1, 0)
+	if err := m.UpdatePolicyScheduleState(cfg, map[string]bool{"workhours": false}); err != nil {
+		t.Fatalf("helperless republish must report converged (nil), got %v", err)
+	}
+}

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -9,9 +9,10 @@ during specific windows.
 ## Entry points
 
 - `Scheduler` — `scheduler.go`.
-- `New(schedulers map[string]*config.SchedulerConfig, updateFn func(map[string]bool)) *Scheduler` —
-  `scheduler.go`. The `updateFn` callback fires only on state change,
-  not every tick.
+- `New(schedulers map[string]*config.SchedulerConfig, updateFn func(map[string]bool) error) *Scheduler` —
+  `scheduler.go`. The `updateFn` callback fires on state change **and**
+  while a prior republish is still pending (self-heal, see below), not
+  every tick.
 - `NewPrimed(..., now)` — constructor for daemon apply paths that need the
   initial active-state map without firing the callback while an external
   apply semaphore is already held.
@@ -21,6 +22,31 @@ during specific windows.
   scheduler's active flag.
 - `Update(schedulers map[string]*config.SchedulerConfig)` —
   `scheduler.go`.
+- `RepublishPending() bool` / `RepublishFailureStatus() (pending bool,
+  failures uint64, since time.Time)` — `scheduler.go`. Expose the #3780
+  self-heal state for tests and metrics.
+
+## Republish self-heal (#3780)
+
+`updateFn` returns an `error`. A window transition republishes
+enforcement (the daemon rebuilds and publishes the userspace policy
+snapshot with the new `inactive` bits); if that republish **fails**, the
+transition has NOT converged — a scheduled permit whose window just
+closed would keep forwarding (fail-open), or a scheduled block would never
+engage. A non-nil `updateFn` result latches an internal `republishPending`
+flag, and the NEXT evaluation tick re-fires `updateFn` with the current
+active state **even when the state did not change**, retrying on the
+scheduler's own throttle-paced 60 s sweep until it converges. A successful
+republish clears the flag. This replaces the previous fire-and-forget
+behavior where a swallowed republish failure left stale enforcement live
+until the next unrelated state change (which can be hours away).
+
+The daemon side surfaces the failure as the
+`xpf_scheduler_republish_failed` gauge (1 while a republish is pending)
+plus `xpf_scheduler_republish_stale_seconds` (age of the current failure
+streak), and logs an `ERROR` on the transition into failure. See
+`pkg/daemon/daemon_scheduler.go` (`publishPolicyScheduleState`,
+`recordSchedulerRepublishResult`).
 
 ## Callers
 
@@ -33,9 +59,13 @@ during specific windows.
 ## Gotchas
 
 - Evaluation interval is fixed at 60 s. Don't try to drive sub-minute
-  precision through this package.
+  precision through this package. This 60 s tick is also the retry cadence
+  for a failed republish (#3780).
 - `updateFn` receives the **full** active-state map, not just the
-  changed entries. Callers compute their own diff if they care.
+  changed entries. Callers compute their own diff if they care. It MUST
+  return a non-nil error only when a live republish did not converge (so
+  the retry latches); return nil for shutdown / nothing-to-publish so the
+  self-heal does not spin.
 - Daemon callers must publish scheduler changes while holding the daemon
   apply semaphore. Runtime scheduler callbacks take that semaphore before
   touching dataplane state so commits and time-window flips cannot publish

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -15,10 +15,26 @@ type Scheduler struct {
 	mu               sync.RWMutex
 	schedulers       map[string]*config.SchedulerConfig
 	active           map[string]bool
-	updateFn         func(activeState map[string]bool)
+	updateFn         func(activeState map[string]bool) error
 	lastEval         time.Time
 	lastWallUnixNano int64
 	unsafeUntil      time.Time
+
+	// #3780: republish self-heal. A scheduler window transition
+	// republishes the enforcement snapshot via updateFn. When that
+	// republish FAILS the transition has NOT converged — a scheduled
+	// permit whose window just closed would keep forwarding (fail-open),
+	// or a scheduled block would never engage. updateFn returning a
+	// non-nil error latches republishPending so the NEXT evaluate tick
+	// re-fires updateFn even when the active-state map did not change,
+	// retrying the transition on the scheduler's own throttle-paced
+	// 60 s sweep until it converges. republishFirstFail records when the
+	// current failure streak began (for stale-state age); republishFailures
+	// is the cumulative failure count. All guarded by mu.
+	republishPending   bool
+	republishFirstFail time.Time
+	republishFailures  uint64
+	lastRepublishErr   error
 }
 
 const (
@@ -30,7 +46,7 @@ const (
 // returns that map without firing updateFn from inside the constructor. Daemon
 // apply paths use this when they already hold their own serialization lock and
 // must publish the initial state as part of the same apply transaction.
-func NewPrimed(schedulers map[string]*config.SchedulerConfig, updateFn func(activeState map[string]bool), now time.Time) (*Scheduler, map[string]bool) {
+func NewPrimed(schedulers map[string]*config.SchedulerConfig, updateFn func(activeState map[string]bool) error, now time.Time) (*Scheduler, map[string]bool) {
 	s := &Scheduler{
 		schedulers: schedulers,
 		active:     make(map[string]bool),
@@ -43,7 +59,7 @@ func NewPrimed(schedulers map[string]*config.SchedulerConfig, updateFn func(acti
 // New creates a Scheduler with the given scheduler configs and update callback.
 // updateFn is called whenever any scheduler's active state changes, receiving
 // the current active state of all schedulers.
-func New(schedulers map[string]*config.SchedulerConfig, updateFn func(activeState map[string]bool)) *Scheduler {
+func New(schedulers map[string]*config.SchedulerConfig, updateFn func(activeState map[string]bool) error) *Scheduler {
 	s, _ := NewPrimed(schedulers, updateFn, time.Now())
 	// Preserve the historical constructor contract: New notifies on initial
 	// state. NewPrimed is the no-notify variant for callers that publish the
@@ -142,14 +158,60 @@ func (s *Scheduler) evaluate(now time.Time, notify bool) {
 	s.lastEval = now
 	s.lastWallUnixNano = now.UnixNano()
 
-	if !changed || !notify || s.updateFn == nil {
+	// #3780: fire on a state change OR when a prior republish is still
+	// pending. Re-firing on the pending flag is the self-heal: a
+	// window transition whose republish failed is retried on the next
+	// throttle-paced tick with the CURRENT active state, so the stale
+	// enforcement (a permit past its window / a block that never
+	// engaged) converges instead of persisting until the next unrelated
+	// state change hours away.
+	if (!changed && !s.republishPending) || !notify || s.updateFn == nil {
 		s.mu.Unlock()
 		return
 	}
 	cp := copyActiveState(newActive)
 	updateFn := s.updateFn
 	s.mu.Unlock()
-	updateFn(cp)
+	err := updateFn(cp)
+	s.mu.Lock()
+	s.recordRepublishResultLocked(err, now)
+	s.mu.Unlock()
+}
+
+// recordRepublishResultLocked latches or clears the republish self-heal
+// state from an updateFn result (#3780). MUST be called with s.mu held.
+func (s *Scheduler) recordRepublishResultLocked(err error, now time.Time) {
+	if err != nil {
+		if !s.republishPending {
+			s.republishFirstFail = now
+		}
+		s.republishPending = true
+		s.republishFailures++
+		s.lastRepublishErr = err
+		return
+	}
+	s.republishPending = false
+	s.republishFirstFail = time.Time{}
+	s.lastRepublishErr = nil
+}
+
+// RepublishPending reports whether the most recent scheduler-driven
+// republish failed and is awaiting an autonomous retry on the next tick
+// (#3780).
+func (s *Scheduler) RepublishPending() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.republishPending
+}
+
+// RepublishFailureStatus returns the pending flag, the cumulative
+// failure count, and the time the current failure streak began (zero
+// when not pending). Feeds the scheduler_republish_failed metric and
+// its stale-state age (#3780).
+func (s *Scheduler) RepublishFailureStatus() (pending bool, failures uint64, since time.Time) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.republishPending, s.republishFailures, s.republishFirstFail
 }
 
 func (s *Scheduler) wallClockDiscontinuousLocked(now time.Time) bool {
@@ -189,7 +251,10 @@ func (s *Scheduler) notifyActiveState() {
 	cp := copyActiveState(s.active)
 	updateFn := s.updateFn
 	s.mu.RUnlock()
-	updateFn(cp)
+	err := updateFn(cp)
+	s.mu.Lock()
+	s.recordRepublishResultLocked(err, time.Now())
+	s.mu.Unlock()
 }
 
 func copyActiveState(in map[string]bool) map[string]bool {

--- a/pkg/scheduler/scheduler_republish_3780_test.go
+++ b/pkg/scheduler/scheduler_republish_3780_test.go
@@ -1,0 +1,133 @@
+package scheduler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestScheduler_RepublishFailureRetriesUntilConverged is the #3780
+// self-heal contract. A scheduler window transition republishes
+// enforcement via updateFn. When that republish FAILS the transition has
+// not converged — a scheduled permit whose window just closed would keep
+// forwarding (fail-open). The scheduler must latch the failure and
+// re-fire updateFn on the NEXT tick even though the active-state map did
+// not change, retrying until it succeeds.
+//
+// RED-on-revert: reverting the `|| s.republishPending` re-fire (or
+// recordRepublishResultLocked) makes the retry never happen — the second
+// evaluate would not call updateFn (calls stays at 1) and the stale
+// permit would persist silently.
+func TestScheduler_RepublishFailureRetriesUntilConverged(t *testing.T) {
+	schedCfg := map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours", StartTime: "09:00:00", StopTime: "17:00:00"},
+	}
+
+	var (
+		calls     int
+		lastState map[string]bool
+		failing   = true
+	)
+	updateFn := func(state map[string]bool) error {
+		calls++
+		lastState = state
+		if failing {
+			return errors.New("republish failed")
+		}
+		return nil
+	}
+
+	// Prime inside the window (active). NewPrimed must not fire updateFn.
+	now := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	s, initial := NewPrimed(schedCfg, updateFn, now)
+	if !initial["workhours"] {
+		t.Fatalf("workhours should start active inside window, got %v", initial)
+	}
+	if calls != 0 {
+		t.Fatalf("NewPrimed must not fire updateFn, got %d calls", calls)
+	}
+	if s.RepublishPending() {
+		t.Fatal("fresh scheduler must not report a pending republish")
+	}
+
+	// Window closes at 17:00 → state flips to inactive. The first
+	// evaluate fires updateFn, which FAILS. The transition must stay
+	// pending for retry.
+	closeT := time.Date(2026, 2, 12, 17, 30, 0, 0, time.UTC)
+	s.evaluate(closeT, true)
+	if calls != 1 {
+		t.Fatalf("window close should fire updateFn once, got %d", calls)
+	}
+	if lastState["workhours"] {
+		t.Fatal("workhours should be inactive after the window closed")
+	}
+	if !s.RepublishPending() {
+		t.Fatal("a failed republish must leave the transition pending for retry (fail-open otherwise)")
+	}
+	pending, failures, since := s.RepublishFailureStatus()
+	if !pending || failures != 1 || since.IsZero() {
+		t.Fatalf("failure status = (pending=%v failures=%d since=%v), want (true, 1, non-zero)", pending, failures, since)
+	}
+
+	// Next tick: the active state did NOT change (still outside window),
+	// but because the prior republish failed, evaluate MUST re-fire
+	// updateFn. This is the self-heal that revert kills.
+	nextT := closeT.Add(1 * time.Minute)
+	s.evaluate(nextT, true)
+	if calls != 2 {
+		t.Fatalf("pending republish must be retried on the next tick even without a state change, got %d calls", calls)
+	}
+	if !s.RepublishPending() {
+		t.Fatal("a still-failing retry must stay pending")
+	}
+
+	// The transient failure clears; the retry converges and clears the
+	// pending flag.
+	failing = false
+	s.evaluate(nextT.Add(1*time.Minute), true)
+	if calls != 3 {
+		t.Fatalf("pending republish must fire again, got %d calls", calls)
+	}
+	if s.RepublishPending() {
+		t.Fatal("a successful republish must clear the pending flag")
+	}
+
+	// Converged steady state: no change, not pending → no further fires.
+	s.evaluate(nextT.Add(2*time.Minute), true)
+	if calls != 3 {
+		t.Fatalf("converged steady state must not re-fire updateFn, got %d calls", calls)
+	}
+}
+
+// TestScheduler_SuccessfulRepublishNeverLatchesPending guards the happy
+// path: a state change whose republish succeeds must not leave the
+// scheduler in a pending/retry state (which would churn an identical
+// snapshot every tick forever).
+func TestScheduler_SuccessfulRepublishNeverLatchesPending(t *testing.T) {
+	schedCfg := map[string]*config.SchedulerConfig{
+		"workhours": {Name: "workhours", StartTime: "09:00:00", StopTime: "17:00:00"},
+	}
+	var calls int
+	updateFn := func(map[string]bool) error {
+		calls++
+		return nil
+	}
+	now := time.Date(2026, 2, 12, 10, 0, 0, 0, time.UTC)
+	s, _ := NewPrimed(schedCfg, updateFn, now)
+
+	// Close the window: one successful republish, no pending.
+	s.evaluate(time.Date(2026, 2, 12, 17, 30, 0, 0, time.UTC), true)
+	if calls != 1 {
+		t.Fatalf("window close should fire once, got %d", calls)
+	}
+	if s.RepublishPending() {
+		t.Fatal("a successful republish must not latch pending")
+	}
+	// A subsequent no-change tick must not re-fire.
+	s.evaluate(time.Date(2026, 2, 12, 17, 31, 0, 0, time.UTC), true)
+	if calls != 1 {
+		t.Fatalf("no-change tick after a successful republish must not re-fire, got %d", calls)
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -162,9 +162,10 @@ func TestScheduler_InitialState(t *testing.T) {
 		"always-on": {Name: "always-on"}, // no times = always active
 	}
 
-	s := New(schedCfg, func(activeState map[string]bool) {
+	s := New(schedCfg, func(activeState map[string]bool) error {
 		called = true
 		state = activeState
+		return nil
 	})
 
 	if !called {
@@ -184,8 +185,9 @@ func TestScheduler_NewPrimedDoesNotNotifyInitialState(t *testing.T) {
 		"always-on": {Name: "always-on"},
 	}
 
-	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) {
+	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) error {
 		called = true
+		return nil
 	}, time.Date(2026, 2, 12, 14, 30, 0, 0, time.UTC))
 
 	if called {
@@ -209,8 +211,9 @@ func TestScheduler_WallClockBackwardStepFailsClosed(t *testing.T) {
 		},
 	}
 	now := time.Date(2026, 2, 12, 12, 0, 0, 0, time.UTC)
-	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) {
+	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) error {
 		lastState = activeState
+		return nil
 	}, now)
 	if !state["business-hours"] {
 		t.Fatal("initial state should be active")
@@ -238,8 +241,9 @@ func TestScheduler_WallClockBackwardStepStaysFailClosedUntilClockRecovers(t *tes
 		},
 	}
 	now := time.Date(2026, 2, 12, 12, 0, 0, 0, time.UTC)
-	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) {
+	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) error {
 		lastState = activeState
+		return nil
 	}, now)
 	if !state["business-hours"] {
 		t.Fatal("initial state should be active")
@@ -283,7 +287,7 @@ func TestScheduler_MonotonicAdvanceDoesNotFailClosed(t *testing.T) {
 		},
 	}
 	start := time.Now()
-	s, state := NewPrimed(schedCfg, func(map[string]bool) {}, start)
+	s, state := NewPrimed(schedCfg, func(map[string]bool) error { return nil }, start)
 	if !state["business-hours"] {
 		t.Fatal("initial state should be active")
 	}
@@ -303,7 +307,7 @@ func TestScheduler_ActiveState(t *testing.T) {
 	schedCfg := map[string]*config.SchedulerConfig{
 		"always-on": {Name: "always-on"},
 	}
-	s := New(schedCfg, func(activeState map[string]bool) {})
+	s := New(schedCfg, func(activeState map[string]bool) error { return nil })
 
 	state := s.ActiveState()
 	if !state["always-on"] {
@@ -322,8 +326,9 @@ func TestScheduler_Update(t *testing.T) {
 	schedCfg := map[string]*config.SchedulerConfig{
 		"always-on": {Name: "always-on"},
 	}
-	s := New(schedCfg, func(activeState map[string]bool) {
+	s := New(schedCfg, func(activeState map[string]bool) error {
 		lastState = activeState
+		return nil
 	})
 
 	// Update with new schedulers (removes always-on, adds another)


### PR DESCRIPTION
Closes #3780

## Problem

A time-of-day `scheduler`-bound security policy is enforcement, not
display. When a schedule window flips the daemon republishes the
userspace snapshot with new `inactive` bits — but that republish was
**fire-and-forget**:

- `UpdatePolicyScheduleState` was `void` and bailed with `slog.Warn(...);
  return` on every failure (policy/address-book rebuild, protocol disarm,
  the helper `apply_snapshot`) — `pkg/dataplane/userspace/manager.go`.
- the daemon caller ignored the result — `pkg/daemon/daemon_scheduler.go`
  (`updatePolicyScheduleStateLocked` / `publishPolicyScheduleState`).
- the scheduler only re-fired `updateFn` on the next state **change**.

So a transient failure at a window **close** left the OLD `inactive` bits
— the now-out-of-window **PERMIT** — live indefinitely with no retry and
no alarm (a security fail-open), and a scheduled block could likewise
never engage. The mitigating "next full apply surfaces it at commit"
comment does not apply to a time-driven transition: there is no commit,
and the next scheduler tick that changes state can be hours away.

## Fix (fallible + self-healing; happy path unchanged)

- **`UpdatePolicyScheduleState` returns `error`** across the
  `dataplane.DataPlane` interface and both backends. The userspace
  manager returns a wrapped error on each path that did **not** apply the
  new snapshot (protocol-refuse, policy rebuild, address-book rebuild,
  disarm, `apply_snapshot`); no-op paths (no snapshot / no helper) and a
  post-success status-sync warning return `nil` so the self-heal never
  spins. The retired-eBPF `maps_policy.go` path stays best-effort (always
  `nil`).

- **Scheduler self-heal** (`pkg/scheduler/scheduler.go`): `updateFn` now
  returns `error`; a non-nil result latches `republishPending`, and
  `evaluate` fires on `changed || republishPending` — so a failed
  transition is retried on the scheduler's own throttle-paced **60 s
  tick** with the current active state until it converges (fail-safe
  toward the schedule's intent). New `RepublishPending` /
  `RepublishFailureStatus` accessors.

- **Daemon** propagates the error through
  `publishPolicyScheduleState` / `updatePolicyScheduleStateLocked` and
  records it in `recordSchedulerRepublishResult`: a lock-free failing
  flag + first-failure timestamp, an `ERROR` log on entry into failure /
  `INFO` on recovery, cleared on scheduler teardown/replace. Stale-epoch,
  ctx-cancel and nothing-to-publish return `nil` (no spurious retry).

- **Metrics**: new Prometheus gauges `xpf_scheduler_republish_failed`
  (0/1) and `xpf_scheduler_republish_stale_seconds` (failure-streak age),
  wired daemon → `api.Config` → collector and emitted **before** the
  dataplane gate (a control-plane signal, like `xpf_frr_reload_degraded`)
  so stale enforcement past a window is visible even in config-only mode.

## Tests (RED-on-revert)

- **scheduler**: a failed republish on a window flip stays pending and is
  retried on the next tick even without a state change; a successful
  retry converges + clears; a successful republish never latches pending.
  Verified RED when the `|| republishPending` re-fire is reverted.
- **userspace manager**: `UpdatePolicyScheduleState` returns a non-nil
  error when `apply_snapshot` fails and retains the prior snapshot
  generation; no-helper / no-snapshot no-op paths report converged.
  Verified RED when the `apply_snapshot` error path is reverted to
  `slog.Warn`+`return nil`.
- **daemon**: error propagation through `updatePolicyScheduleStateLocked`;
  metric latch/clear + climbing stale-age; repeated failure does not
  reset the streak start; recovery/teardown clear it.

## Validation

- `go build ./...` green.
- `go test ./pkg/scheduler/... ./pkg/daemon/... ./pkg/dataplane/... ./pkg/api/...`
  green, including `-race` on the new scheduler/daemon tests and the
  `pkg/api` pedantic descriptor-coverage canary.
- `gofmt` + `go vet` clean on all touched files.
- Docs: `pkg/scheduler/README.md` republish self-heal section + `_Log.md`.

This is a Go control-plane change (policy scheduler); no dataplane
forwarding path or cargo build is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
