### PR TITLE
routing: aggregate & surface next-table + rib-group RuleAdd failures (#3731)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-01 — #3731 routing: next-table + rib-group Apply aggregate & surface RuleAdd failures (stop swallowing)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3731 (MEDIUM, silent loss of configured inter-VRF
+    forwarding). `nextTableManager.Apply` and `ribGroupManager.Apply`
+    called netlink `RuleAdd` best-effort — a per-rule add failure was
+    WARN-logged and the function returned only `clearErr` (i.e. `nil` on
+    the common path). After the up-front `clear()` had already removed the
+    previously-working leak rules, a transient `RuleAdd` failure (EEXIST /
+    ENOBUFS / racing reconcile) left inter-VRF route-leaking DOWN while
+    Apply reported success to the daemon apply loop. The #3430-hardened PBR
+    path already aggregates add failures with `errors.Join`; the two
+    sibling reconcilers were left swallowing.
+    FIX (mirror the PBR pattern, EEXIST-safe): both paths now collect each
+    `RuleAdd` failure into an `errs []error` (seeded with `clearErr`) while
+    still attempting every remaining desired rule (forward progress), and
+    return `errors.Join(errs...)`. The clean/idempotent re-apply is
+    unaffected — `clear()` removes the in-window rules before they are
+    re-added, so a re-apply never hits EEXIST and returns nil. rib-group
+    increments `prio` per add attempt regardless of success (the v4/v6 pair
+    reserves two slots as a unit — cap logic preserved).
+  - **File(s)**: pkg/routing/rules.go, pkg/routing/rules_test.go,
+    pkg/routing/README.md
+  - **Tests**: added `TestNextTableApplyAggregatesAddErrors`,
+    `TestNextTableApplyIdempotentReapply`, and
+    `TestRibGroupApplyAggregatesAddErrors` (v4-only / v6-only / both-family
+    subtests); added a per-family `addErrFamily` + `failAdd` helper to
+    `fakeRuleOps` so one family can fail while the sibling installs.
+    RED-on-revert verified: stashing the rules.go fix makes all three
+    aggregation tests fail (Apply returns nil). go test ./pkg/routing/...
+    green; go build ./... green; gofmt + vet clean.
+
 ## 2026-07-01 — #3780 policy scheduler: fallible + self-healing republish (fix stale-permit-after-window fail-open)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/routing/README.md
+++ b/pkg/routing/README.md
@@ -161,7 +161,7 @@ delegate to the owning domain. Exported types:
   (lower priority value = higher priority). PBR sits before main as
   well; rib-group sits after.
 
-### clear()/Apply error contract (#2273)
+### clear()/Apply error contract (#2273, #3430, #3731)
 
 Each reconciler's `Apply` is clear-then-re-add: `clear()` removes every
 rule in the manager's own priority window, then `Apply` re-installs the
@@ -184,10 +184,25 @@ desired set. `clear()` walks `[AF_INET, AF_INET6]`, calling `RuleList`
   clear error** so `pkg/daemon` (`daemon_apply.go` steps 3b–3d) observes
   it. The daemon currently logs Apply errors at WARN and continues; the
   change makes the failure visible (and lets a future caller retry)
-  without changing the daemon's apply sequencing. `RuleDel` failures on
-  individual rules remain debug-logged and do not fail `Apply` — a stale
-  rule that survives one delete is swept by the next pass and re-add uses
-  `NLM_F_CREATE|NLM_F_EXCL`, so a still-desired rule stays correct.
+  without changing the daemon's apply sequencing.
+- **Per-rule `RuleAdd` failures are aggregated and returned, never
+  swallowed (#3430 for PBR, #3731 for next-table + rib-group).** Each
+  reconciler collects every add failure with `errors.Join` while still
+  attempting every remaining desired rule (forward progress), then returns
+  the joined error alongside any clear error. Before #3731 the next-table
+  and rib-group `Apply` paths only WARN-logged a `RuleAdd` failure and
+  returned `clearErr` (i.e. `nil` on the common path): a transient netlink
+  add error (EEXIST from stale kernel/udev state, ENOBUFS, a racing
+  reconcile) *after* the up-front `clear()` had already removed the
+  working leak rules left inter-VRF leaking silently DOWN while `Apply`
+  reported success. A clean re-apply is unaffected: `clear()` removes the
+  in-window rules before they are re-added, so an idempotent re-apply does
+  not hit EEXIST — an already-cleared rule is re-added fresh and `Apply`
+  returns `nil`. `RuleDel` failures on individual next-table / rib-group
+  rules remain debug-logged and do not fail `Apply` — a stale rule that
+  survives one delete is swept by the next pass and re-add uses
+  `NLM_F_CREATE|NLM_F_EXCL`, so a still-desired rule stays correct (the
+  PBR `clear()` additionally aggregates its `RuleDel` failures, #3430 H3).
 
 ## Tunnel reconcile-in-place (#1884)
 

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -69,6 +69,20 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 		slog.Warn("failed to clear old next-table rules", "err", clearErr)
 	}
 
+	// Aggregate every failure (clear + per-rule add) and return it so the
+	// commit/apply outcome reflects a half-installed leak instead of
+	// reporting success after the up-front clear already removed the
+	// previously-working next-table rules (#3731). A per-rule RuleAdd error
+	// used to be logged and swallowed (Apply returned clearErr only), so a
+	// transient netlink failure after clear() left inter-VRF leaking DOWN
+	// with no signal to the daemon apply loop. This mirrors the #3430 PBR
+	// pattern (aggregate + errors.Join) already used below. The clear error,
+	// if any, is the first aggregated entry.
+	var errs []error
+	if clearErr != nil {
+		errs = append(errs, clearErr)
+	}
+
 	prio := nextTableRulePriority
 	for _, sr := range routes {
 		if sr.NextTable == "" {
@@ -112,18 +126,19 @@ func (n *nextTableManager) Apply(routes []*config.StaticRoute, instances []*conf
 		rule.Family = family
 
 		if err := n.ops.RuleAdd(rule); err != nil {
-			slog.Warn("failed to add next-table rule",
-				"destination", sr.Destination, "instance", sr.NextTable,
-				"table", tableID, "err", err)
+			errs = append(errs, fmt.Errorf(
+				"add next-table rule destination %s instance %s table %d: %w",
+				sr.Destination, sr.NextTable, tableID, err))
 			continue
 		}
 		slog.Info("next-table rule added",
 			"destination", sr.Destination, "instance", sr.NextTable, "table", tableID)
 		prio++
 	}
-	// Desired rules are re-added; surface any clear() list failure so the
-	// orphaned-rule window is observable rather than silently nil.
-	return clearErr
+	// Desired rules are re-added; surface any clear/add failure so a dropped
+	// leak rule (or the orphaned-rule window) is observable rather than
+	// silently nil (#3731 / #2273).
+	return errors.Join(errs...)
 }
 
 // clear removes all ip rules in the next-table priority range.
@@ -186,8 +201,21 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		slog.Warn("failed to clear old rib-group rules", "err", clearErr)
 	}
 
+	// Aggregate every failure (clear + per-rule add) and return it so a
+	// dropped leak rule is surfaced instead of reporting success after the
+	// up-front clear already removed the previously-working rules (#3731).
+	// A per-rule RuleAdd error used to be logged and swallowed (Apply
+	// returned clearErr only), so a transient netlink failure after clear()
+	// left inter-VRF leaking DOWN with no signal. This mirrors the #3430 PBR
+	// pattern (aggregate + errors.Join) already used below. The clear error,
+	// if any, is the first aggregated entry.
+	var errs []error
+	if clearErr != nil {
+		errs = append(errs, clearErr)
+	}
+
 	if len(ribGroups) == 0 || len(instances) == 0 {
-		return clearErr
+		return errors.Join(errs...)
 	}
 
 	// Build instance name → table ID map
@@ -271,8 +299,9 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		rule.Family = unix.AF_INET
 
 		if err := rg.ops.RuleAdd(rule); err != nil {
-			slog.Warn("failed to add rib-group IPv4 rule",
-				"instance", inst.Name, "table", sourceTable, "err", err)
+			errs = append(errs, fmt.Errorf(
+				"add rib-group IPv4 rule instance %s table %d: %w",
+				inst.Name, sourceTable, err))
 		} else {
 			slog.Info("rib-group rule added",
 				"instance", inst.Name, "table", sourceTable,
@@ -287,8 +316,9 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		rule6.Family = unix.AF_INET6
 
 		if err := rg.ops.RuleAdd(rule6); err != nil {
-			slog.Warn("failed to add rib-group IPv6 rule",
-				"instance", inst.Name, "table", sourceTable, "err", err)
+			errs = append(errs, fmt.Errorf(
+				"add rib-group IPv6 rule instance %s table %d: %w",
+				inst.Name, sourceTable, err))
 		} else {
 			slog.Info("rib-group rule added",
 				"instance", inst.Name, "table", sourceTable,
@@ -296,8 +326,10 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		}
 		prio++
 	}
-	// Desired rules are re-added; surface any clear() list failure.
-	return clearErr
+	// Desired rules are re-added; surface any clear/add failure so a dropped
+	// leak rule (or the orphaned-rule window) is observable rather than
+	// silently nil (#3731 / #2273).
+	return errors.Join(errs...)
 }
 
 // clear removes all ip rules in the rib-group priority range. Also

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -32,6 +32,14 @@ type fakeRuleOps struct {
 	// used to exercise the #3430 H3 add-failure aggregation in pbrManager.Apply.
 	addErr error
 
+	// addErrFamily injects a per-family RuleAdd failure, simulating a
+	// transient netlink error on one address family while the other
+	// succeeds. RuleAdd fails (without recording the rule) when
+	// addErrFamily[r.Family] is non-nil. Used to exercise the #3731
+	// next-table / rib-group add-failure aggregation with family isolation
+	// (a v4 add can fail while the sibling v6 add still installs).
+	addErrFamily map[int]error
+
 	// delErr, when non-nil, makes RuleDel fail without removing the rule —
 	// used to exercise the #3430 H3 clear-failure aggregation (a stale rule
 	// that cannot be deleted must surface as a non-nil Apply error).
@@ -51,6 +59,11 @@ func newFakeRuleOps() *fakeRuleOps {
 func (f *fakeRuleOps) RuleAdd(r *netlink.Rule) error {
 	if f.addErr != nil {
 		return f.addErr
+	}
+	if f.addErrFamily != nil {
+		if err := f.addErrFamily[r.Family]; err != nil {
+			return err
+		}
 	}
 	f.adds++
 	f.rules[r.Family] = append(f.rules[r.Family], *r)
@@ -90,6 +103,17 @@ func (f *fakeRuleOps) failList(family int, err error) {
 		f.listErr = map[int]error{}
 	}
 	f.listErr[family] = err
+}
+
+// failAdd arms RuleAdd(rule) to return err for rules in the given family
+// (without recording them). Used to recreate a transient per-family netlink
+// add failure so the #3731 aggregation can be exercised with one family
+// failing while the sibling family still installs.
+func (f *fakeRuleOps) failAdd(family int, err error) {
+	if f.addErrFamily == nil {
+		f.addErrFamily = map[int]error{}
+	}
+	f.addErrFamily[family] = err
 }
 
 // count returns the number of rules currently present for a family.
@@ -247,6 +271,68 @@ func TestRibGroupRulesApply_DefinedRibStillLeaks(t *testing.T) {
 	}
 }
 
+// TestRibGroupApplyAggregatesAddErrors is the #3731 fail-on-revert guard for
+// the rib-group reconciler. Each leaked table programs a v4 THEN a v6 ip rule;
+// a RuleAdd failure on either (or both) must be aggregated and returned rather
+// than logged-and-swallowed with Apply reporting nil (the pre-fix clearErr-only
+// return). The subtests pin v4-only, v6-only, and both-family failures — the
+// sibling family that DID install stays installed (forward progress) while
+// Apply still surfaces the error.
+//
+// Reverting ribGroupManager.Apply to the log-only branches + `return clearErr`
+// makes every subtest go RED (Apply returns nil).
+func TestRibGroupApplyAggregatesAddErrors(t *testing.T) {
+	ribGroups := map[string]*config.RibGroup{
+		"dmz-leak": {Name: "dmz-leak", ImportRibs: []string{"inet.0"}}, // main 254 != source
+	}
+	instances := []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "dmz-leak"},
+	}
+
+	t.Run("v4-only", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		ops.failAdd(unix.AF_INET, errors.New("netlink EPERM on v4"))
+		rg := &ribGroupManager{ops: ops}
+		if err := rg.Apply(ribGroups, instances); err == nil {
+			t.Fatal("Apply must return non-nil when the v4 leak rule fails (#3731)")
+		}
+		if ops.hasTable(unix.AF_INET, 101) {
+			t.Errorf("failed v4 leak rule must not be recorded, rules=%v", ops.rules[unix.AF_INET])
+		}
+		if !ops.hasTable(unix.AF_INET6, 101) {
+			t.Errorf("sibling v6 leak rule must still install (forward progress), rules=%v", ops.rules[unix.AF_INET6])
+		}
+	})
+
+	t.Run("v6-only", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		ops.failAdd(unix.AF_INET6, errors.New("netlink EPERM on v6"))
+		rg := &ribGroupManager{ops: ops}
+		if err := rg.Apply(ribGroups, instances); err == nil {
+			t.Fatal("Apply must return non-nil when the v6 leak rule fails (#3731)")
+		}
+		if !ops.hasTable(unix.AF_INET, 101) {
+			t.Errorf("sibling v4 leak rule must still install (forward progress), rules=%v", ops.rules[unix.AF_INET])
+		}
+		if ops.hasTable(unix.AF_INET6, 101) {
+			t.Errorf("failed v6 leak rule must not be recorded, rules=%v", ops.rules[unix.AF_INET6])
+		}
+	})
+
+	t.Run("both-family", func(t *testing.T) {
+		ops := newFakeRuleOps()
+		ops.addErr = errors.New("netlink ENOBUFS")
+		rg := &ribGroupManager{ops: ops}
+		if err := rg.Apply(ribGroups, instances); err == nil {
+			t.Fatal("Apply must return non-nil when both leak rules fail (#3731)")
+		}
+		if ops.count(unix.AF_INET) != 0 || ops.count(unix.AF_INET6) != 0 {
+			t.Errorf("no leak rule should be recorded, v4=%d v6=%d",
+				ops.count(unix.AF_INET), ops.count(unix.AF_INET6))
+		}
+	})
+}
+
 // TestNextTableRulesApply_Fake exercises nextTableManager over a fake,
 // asserting a next-table directive becomes an ip rule pointing at the
 // target instance's table.
@@ -279,6 +365,81 @@ func TestNextTableRulesApply_Fake(t *testing.T) {
 	}
 	if got := ops.count(unix.AF_INET6); got != 1 {
 		t.Errorf("expected 1 IPv6 rule, got %d", got)
+	}
+}
+
+// TestNextTableApplyAggregatesAddErrors is the #3731 fail-on-revert guard for
+// the next-table reconciler. A per-rule RuleAdd failure after the up-front
+// clear() must be aggregated and returned — not logged-and-swallowed with Apply
+// still reporting nil (the pre-fix clearErr-only return). Before the fix a
+// transient netlink add error left the inter-VRF leak DOWN while Apply told the
+// daemon apply loop "success".
+//
+// Reverting nextTableManager.Apply to `continue` + `return clearErr` makes this
+// test go RED (Apply returns nil).
+func TestNextTableApplyAggregatesAddErrors(t *testing.T) {
+	routes := []*config.StaticRoute{
+		{Destination: "10.20.0.0/16", NextTable: "dmz-vr"},
+		{Destination: "2001:db8::/32", NextTable: "dmz-vr"},
+	}
+	instances := []*config.RoutingInstanceConfig{{Name: "dmz-vr", TableID: 101}}
+
+	// Both-family failure: every RuleAdd fails, no rule recorded, Apply
+	// surfaces the aggregated error.
+	ops := newFakeRuleOps()
+	ops.addErr = errors.New("netlink ENOBUFS")
+	nt := &nextTableManager{ops: ops}
+	if err := nt.Apply(routes, instances); err == nil {
+		t.Fatal("Apply must return a non-nil error when RuleAdd fails (#3731)")
+	}
+	if ops.count(unix.AF_INET) != 0 || ops.count(unix.AF_INET6) != 0 {
+		t.Errorf("no rule should have been recorded, v4=%d v6=%d",
+			ops.count(unix.AF_INET), ops.count(unix.AF_INET6))
+	}
+
+	// Single-family failure: forward progress preserved — the v4 add fails
+	// (error aggregated) while the sibling v6 rule still installs, and Apply
+	// still returns the aggregated error rather than swallowing it.
+	ops2 := newFakeRuleOps()
+	ops2.failAdd(unix.AF_INET, errors.New("netlink EPERM on v4"))
+	nt2 := &nextTableManager{ops: ops2}
+	if err := nt2.Apply(routes, instances); err == nil {
+		t.Fatal("Apply must return non-nil when the v4 add fails (#3731)")
+	}
+	if ops2.count(unix.AF_INET) != 0 {
+		t.Errorf("failed v4 rule must not be recorded, got %d", ops2.count(unix.AF_INET))
+	}
+	if ops2.count(unix.AF_INET6) != 1 {
+		t.Errorf("sibling v6 rule must still install (forward progress), got %d", ops2.count(unix.AF_INET6))
+	}
+}
+
+// TestNextTableApplyIdempotentReapply pins that the #3731 aggregation does not
+// regress the clean path: a first apply returns nil, and re-applying the same
+// config (clear-then-add) still returns nil with a stable rule set. The
+// re-apply cannot EEXIST because clear() removes the prior in-window rules
+// before they are re-added — an already-present rule is handled as success, not
+// an error (matching the #3430 PBR path, which likewise clears then re-adds).
+func TestNextTableApplyIdempotentReapply(t *testing.T) {
+	ops := newFakeRuleOps()
+	nt := &nextTableManager{ops: ops}
+	routes := []*config.StaticRoute{
+		{Destination: "10.20.0.0/16", NextTable: "dmz-vr"},
+		{Destination: "2001:db8::/32", NextTable: "dmz-vr"},
+	}
+	instances := []*config.RoutingInstanceConfig{{Name: "dmz-vr", TableID: 101}}
+
+	if err := nt.Apply(routes, instances); err != nil {
+		t.Fatalf("clean Apply must return nil, got %v", err)
+	}
+	if got := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6); got != 2 {
+		t.Fatalf("expected 2 rules after clean apply, got %d", got)
+	}
+	if err := nt.Apply(routes, instances); err != nil {
+		t.Fatalf("idempotent re-apply must return nil, got %v", err)
+	}
+	if got := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6); got != 2 {
+		t.Fatalf("re-apply must keep a stable rule set, got %d", got)
 	}
 }
 


### PR DESCRIPTION
Closes #3731.

## Problem

The next-table and rib-group inter-VRF route-leak reconcilers in
`pkg/routing/rules.go` called netlink `RuleAdd` best-effort: a per-rule
add failure was WARN-logged and the function returned only `clearErr`
(i.e. `nil` on the common path).

Both `Apply` paths are clear-then-re-add: `clear()` removes the rules in
the manager's priority window up front, then the desired set is re-added.
So after `clear()` had already removed the previously-working leak rules,
a transient `RuleAdd` failure (EEXIST from stale kernel/udev state,
ENOBUFS, a racing reconcile) left inter-VRF route-leaking silently DOWN
while `Apply` reported success to the daemon apply loop. Only an
ephemeral per-rule warn recorded it.

The #3430-hardened PBR path already aggregates its add failures with
`errors.Join` and returns non-nil; next-table and rib-group were left
inconsistent, swallowing the add error (codex-review-156 H04/H05).

### Evidence (pre-fix origin/master)
- next-table: `rules.go` logged the RuleAdd error + `continue`, `Apply`
  returned `clearErr` only.
- rib-group: IPv4 and IPv6 RuleAdd errors were log-only; `Apply` returned
  `clearErr` only (and at the empty-config early return).

## Fix

Mirror the PBR pattern (#3430) in both reconcilers. Each `Apply` now
seeds an `errs` slice with `clearErr`, appends every `RuleAdd` failure
(wrapped with destination/instance/table context) while still attempting
every remaining desired rule so forward progress is preserved, and
returns `errors.Join(errs...)`.

- A single-family add failure still installs the sibling family's rule.
- A clean or idempotent re-apply is unaffected: `clear()` removes the
  in-window rules before they are re-added, so a re-apply never hits
  EEXIST and `Apply` returns `nil` — an already-cleared rule is re-added
  fresh (matching the PBR path, which likewise clears then re-adds).
- rib-group keeps incrementing `prio` per add attempt regardless of
  success — each v4/v6 pair reserves two priority slots as a unit,
  preserving the #1706 cap.

## Tests (RED-on-revert verified)

- `TestNextTableApplyAggregatesAddErrors` — both-family failure (Apply
  non-nil, nothing recorded) + single-family failure (v4 fails, v6 still
  installs, Apply non-nil).
- `TestNextTableApplyIdempotentReapply` — clean apply nil, re-apply nil,
  stable rule set.
- `TestRibGroupApplyAggregatesAddErrors` — v4-only / v6-only /
  both-family subtests.
- Added a per-family `addErrFamily` map + `failAdd` helper to
  `fakeRuleOps` so one address family can fail `RuleAdd` while the sibling
  installs.

Reverting the `rules.go` fix (keeping the tests) makes all three
aggregation tests fail — `Apply` returns `nil` where it must be non-nil.

## Validation
- `go test ./pkg/routing/...` green
- `go build ./...` green
- `gofmt` clean, `go vet ./pkg/routing/...` clean
- README `clear()/Apply error contract` section + `_Log.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi