### PR TITLE
firewall filters: gate cross-field terms the matcher can never satisfy (#3723)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -93,6 +93,53 @@
     pkg/daemon/daemon_scheduler_republish_3780_test.go (new),
     pkg/api/server.go, pkg/api/metrics.go, pkg/api/metrics_descriptors.go.
 
+## 2026-07-01 — #3723 firewall-filter cross-field gate: reject never-match discard/reject terms (fail-closed)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3723 (HIGH, security fail-open / vSRX-parity; folds
+    codex-review-154 H01/H02/H03/M01/M02/M03). A stateless firewall-filter `from`
+    block could combine a `protocol` (or inet6 `next-header`) with an L4 predicate
+    the dataplane matcher can NEVER satisfy for that protocol — a port on a
+    non-port-bearing protocol (gre/esp/icmp/... — only TCP/UDP carry extracted
+    ports per `ip_proto::has_l4_ports`), tcp-flags on a non-TCP protocol (udp/...),
+    or icmp-type/icmp-code on a non-ICMP protocol (tcp/udp/...). The term compiled
+    cleanly but became a never-match at runtime (`engine/matching.rs`: `port_match`
+    tests port 0 for a non-port proto, `per_packet_l4_matches` gates tcp-flags on
+    protocol==TCP and icmp on ICMP/ICMPv6). Because an xpf filter falls through to
+    the implicit ACCEPT on no-match, a `then discard`/`reject` over such a pair was
+    silently dead → the traffic was admitted (fail-OPEN). The application path had
+    this gate (#3373 port / #3348 icmp / #3506 / #3712 Rust); the stateless-FILTER
+    path never did. FIX: (a) COMMIT gate `validateFilterCrossFieldStrict`
+    (`compiler_validate_strict.go`), the filter mirror of the app gate, reusing the
+    shared `protocolIsPortBearing`/`protocolIsICMPFamily` SSOT + a new
+    `protocolIsTCP` (stricter than port-bearing — UDP is port-bearing but not TCP);
+    rejects ports on any non-port-bearing proto (H01/M01 mixed list/M02
+    next-header), tcp-flags on any non-TCP proto (H02), icmp-type/code on any
+    non-ICMP proto (H03), and icmp-code without icmp-type (M03, mirror #3506). Fires
+    only when a protocol is PRESENT (a port/tcp-flags/icmp with no protocol is
+    enforceable for a FILTER — the matcher self-gates), except M03. Lenient
+    downgrade to a warning on the tolerant load/peer-sync path
+    (`lenientFilterCrossField`, #1960 no-brick). (b) Rust backstop: `parse_term`
+    (`filter/compiler.rs`) rejects the whole snapshot with
+    `SnapshotIntegrityError::UnsatisfiableFilterCrossField` (reconcile preflight
+    keeps prior good state) — defense-in-depth like #2505/#3367/#3406. RED-on-revert
+    verified BOTH sides (neuter the Go call → 6 subtests RED; neuter the parse_term
+    guard → 5 Rust rejection tests RED). Full `cargo test --release` green (3371 lib
+    + 46 + others, 0 failed); `go test ./pkg/config/...` green; `go build ./...`,
+    gofmt, vet clean. The #2545 multi-value test was split into satisfiable
+    per-protocol terms (its synthetic icmp-type-on-tcp term was exactly the
+    never-match shape this gate rejects) with unchanged accumulation coverage.
+  - **File(s)**: pkg/config/compiler_validate_strict.go
+    (validateFilterCrossFieldStrict + firstIncompatibleProtocol + protocolIsTCP),
+    pkg/config/compiler.go (lenientFilterCrossField option + wiring after
+    validateFilterProtocolsStrict), pkg/config/firewall_crossfield_3723_test.go
+    (H01/H02/H03/M01/M02/M03 + lenient-warn + positive controls + L12 cross-package
+    canary), pkg/config/firewall_multivalue_2545_test.go (split into satisfiable
+    terms), userspace-dp/src/policy.rs (UnsatisfiableFilterCrossField variant +
+    Display), userspace-dp/src/filter/compiler.rs (parse_term cross-field backstop),
+    userspace-dp/src/filter/tests.rs (filter_crossfield_3723_* incl. L06 runtime
+    never-match guard), docs/config-schema.md (cross-field satisfiability section)
+
 ## 2026-07-01 — #3730 routing/PBR: kernel FBF ip-rule mirror honors L4 predicates + fail-closed on unrepresentable ones
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -333,6 +333,72 @@ Fail-on-revert: `TestFilterICMPTypeNameResolves{V4,V6}_3205`,
 `TestFilterNamedPortExceptResolves_3205` in
 `pkg/config/firewall_symbolic_match_3205_test.go`.
 
+### `firewall ... from` cross-field satisfiability — port/tcp-flags/icmp must match the protocol (#3723)
+
+A firewall-filter `from` block can combine a `protocol` (or the inet6
+`next-header`) with an L4 predicate the dataplane matcher can never satisfy for
+that protocol. Such a term compiled cleanly but became a **never-match** at
+runtime, and because an xpf filter falls through to an implicit **ACCEPT** on
+no-match, a `then discard` / `then reject` written over such a pair was silently
+dead — the traffic it was meant to drop was admitted by a later permit or the
+implicit accept (a **fail-OPEN**). Junos rejects these combinations at commit,
+so accepting them was also a config-language parity gap. This is the
+stateless-filter mirror of the application cross-field gate (#3373 port /
+#3348 icmp).
+
+The offending pairs (matcher behavior in `userspace-dp/src/filter/engine/
+matching.rs`):
+
+- **port on a non-port-bearing protocol** — `port_match` tests the constrained
+  port set against the extracted L4 port, which is `0` for any protocol the
+  dataplane does not extract ports for (only TCP/UDP — `ip_proto::has_l4_ports`).
+  So `from protocol gre; destination-port 80` (also esp/ah/ospf/vrrp/icmp/...,
+  and numeric 47) never matches (H01).
+- **tcp-flags on a non-TCP protocol** — `per_packet_l4_matches` returns false
+  when the packet protocol is not TCP, so `from protocol udp; tcp-flags syn`
+  never matches. UDP is port-bearing but still not TCP, so the tcp-flags arm
+  uses the stricter `protocolIsTCP` predicate, not `protocolIsPortBearing` (H02).
+- **icmp-type/icmp-code on a non-ICMP protocol** — the icmp arms return false for
+  a non-ICMP(v6) packet, so `from protocol tcp; icmp-type echo-request` never
+  matches (H03).
+
+`validateFilterCrossFieldStrict` (`compiler_validate_strict.go`) **rejects at
+commit** any term that combines these, reusing the same SSOT the application
+gate uses — `protocolIsPortBearing` / `protocolIsICMPFamily` (plus the new
+`protocolIsTCP` for the tcp-flags arm). Handling of the folded findings:
+
+- **mixed protocol list (M01)** — if ANY protocol token in a bracket list such
+  as `from protocol [ tcp gre ]` is incompatible with the predicate, the term is
+  rejected (a single configured deny that only enforces on the compatible
+  protocol and silently never-matches the rest).
+- **inet6 next-header (M02)** — `compileFilterFrom` routes both `protocol` and
+  `next-header` into `term.Protocols`, so the gate covers `family inet6` filters
+  with no extra code.
+- **icmp-code without icmp-type (M03)** — rejected, mirroring the #3348/#3506
+  application reject: a code-only term constrains the code while the type stays
+  unconstrained, matching a broader ICMP set than a Junos config implies
+  (icmp-code 0 is common across many types).
+
+The gate fires **only when a protocol is PRESENT**. A port / tcp-flags / icmp
+match with NO protocol is legitimate and enforceable for a FILTER (unlike an
+application, whose matcher keys on protocol+port): the filter matcher matches
+the port on whatever port-bearing packet arrives, and the tcp-flags/icmp arms
+self-gate on the packet protocol. The only no-protocol exception is M03
+(icmp-code-without-type), which is rejected regardless.
+
+On the tolerant load / peer-sync path the error is downgraded to a warning
+(`lenientFilterCrossField`, #1960 no-brick). The Rust snapshot builder is the
+fail-closed backstop: `parse_term` rejects the whole snapshot with
+`SnapshotIntegrityError::UnsatisfiableFilterCrossField` (the reconcile preflight
+keeps the previous good filter state) so a leniently-loaded / drifted never-match
+term never silently forwards — the same defense-in-depth as the #2505/#3367/#3406
+filter backstops. Fail-on-revert: `pkg/config/firewall_crossfield_3723_test.go`
+(including the L12 cross-package canary that pins the application and filter gates
+to the shared port-bearing / ICMP-family / TCP SSOT) and the
+`filter_crossfield_3723_*` tests in `userspace-dp/src/filter/tests.rs` (including
+an L06 runtime guard that drives the real matcher over a fabricated gre+port term
+to prove it falls through to Accept).
+
 #### Ports must be a canonical unsigned decimal (#3606)
 
 A numeric port token must be a plain unsigned decimal — no leading sign

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -428,6 +428,22 @@ type compileOpts struct {
 	// constraint, never silently "protocol 0"). Same doctrine as
 	// lenientApplicationSpecs.
 	lenientFilterProtocols bool
+	// lenientFilterCrossField (#3723) downgrades the firewall-filter cross-field
+	// satisfiability gate (validateFilterCrossFieldStrict) from a hard compile
+	// error to a cfg.Warnings entry. The strict commit / commit-check path
+	// hard-rejects a term whose `from` block combines a port with a non-port
+	// protocol (gre/esp/icmp/...), tcp-flags with a non-TCP protocol, or
+	// icmp-type/icmp-code with a non-ICMP protocol (and an icmp-code with no
+	// icmp-type) — cross-field pairs the dataplane matcher can never satisfy, so
+	// a `then discard`/`reject` term silently NEVER matches and the traffic is
+	// admitted by the implicit accept (fail-OPEN). The tolerant load / peer-sync
+	// paths downgrade to a warning so an already-persisted or peer-synced config
+	// carrying such a term still BOOTS (#1960 no-brick); the Rust snapshot
+	// builder's UnsatisfiableFilterCrossField backstop then rejects the whole
+	// snapshot (fail closed) so the never-match term never silently forwards.
+	// Same doctrine as lenientFilterProtocols; mirrors the application
+	// cross-field gate (#3373/#3348, lenientApplicationSpecs).
+	lenientFilterCrossField bool
 	// lenientFilterActions (#2399 finding 032-16) downgrades the
 	// firewall-filter `then` action gate (validateFilterActionsStrict) from a
 	// hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1319,6 +1335,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientApplicationSpecs:              true,
 		lenientApplicationNameCollisions:     true,
 		lenientFilterProtocols:               true,
+		lenientFilterCrossField:              true,
 		lenientFilterActions:                 true,
 		lenientFilterMatchValues:             true,
 		lenientFlexMatch:                     true,
@@ -1482,6 +1499,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientApplicationSpecs:              true,
 		lenientApplicationNameCollisions:     true,
 		lenientFilterProtocols:               true,
+		lenientFilterCrossField:              true,
 		lenientFilterActions:                 true,
 		lenientFilterMatchValues:             true,
 		lenientFlexMatch:                     true,
@@ -2654,6 +2672,30 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientFilterProtocols {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("firewall filter protocol (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3723 firewall-filter cross-field satisfiability gate. Strict on commit /
+	// commit-check (hard-reject a term whose `from` block combines a port with a
+	// non-port protocol, tcp-flags with a non-TCP protocol, or icmp-type/code with
+	// a non-ICMP protocol — or an icmp-code with no icmp-type). Such a term
+	// compiles cleanly but the dataplane matcher (userspace-dp engine/matching.rs)
+	// can NEVER satisfy the cross-field pair, so a `then discard`/`reject` term
+	// silently never matches and the traffic is admitted by the implicit accept
+	// (fail-OPEN) — the stateless-filter mirror of the application cross-field gate
+	// #3373/#3348. Runs AFTER validateFilterProtocolsStrict so a truly unknown
+	// protocol token is reported by that gate first. Lenient on load / peer-sync
+	// (warn so an already-persisted or peer-synced config still boots — #1960
+	// no-brick; the Rust UnsatisfiableFilterCrossField backstop then fails the
+	// whole snapshot closed independently). Runs on the fully-compiled *Config so
+	// the typed term list (Protocols + ports + tcp-flags + icmp populated by
+	// compileFilterFrom, covering both `protocol` and `next-header`) is available.
+	if err := validateFilterCrossFieldStrict(cfg); err != nil {
+		if opts.lenientFilterCrossField {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("firewall filter cross-field (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -4076,6 +4076,166 @@ func validateFilterProtocolsStrict(cfg *Config) error {
 	return check("inet6", cfg.Firewall.FiltersInet6)
 }
 
+// firstIncompatibleProtocol returns the first NON-EMPTY protocol token in a
+// firewall-filter term's protocol list for which pred returns false, plus true;
+// or ("", false) when every present token satisfies pred (or none is present).
+// Empty / whitespace-only tokens are skipped — they are placeholders, not a real
+// protocol constraint (mirroring validateFilterProtocolsStrict). Because it
+// reports the FIRST failing token, a mixed bracket list such as
+// `from protocol [ tcp gre ]` is rejected on `gre` (the #3723 M01 partial-
+// enforce case: one configured deny that only enforces on the compatible
+// protocol and silently never-matches the rest).
+func firstIncompatibleProtocol(protocols []string, pred func(string) bool) (string, bool) {
+	for _, p := range protocols {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if !pred(p) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// validateFilterCrossFieldStrict hard-rejects any firewall-filter term whose
+// `from` block combines a protocol-specific L4 predicate with a `protocol`
+// (or the inet6 `next-header`) that cannot carry it — the stateless-filter
+// mirror of the application cross-field gate #3373/#3348 in
+// validateApplicationSpecsStrict. #3723 (codex-review-154 H01/H02/H03/M01/M02/M03).
+//
+// The firewall-filter matcher (userspace-dp engine/matching.rs) keys each L4
+// predicate on the packet's actual L4 shape:
+//
+//   - port_match tests the constrained port set against the extracted L4 port,
+//     which is 0 for every protocol the dataplane does not extract ports for
+//     (only TCP/UDP — ip_proto.rs has_l4_ports); so `from protocol gre;
+//     destination-port 80` can NEVER match (H01);
+//   - per_packet_l4_matches returns false for a tcp-flags term whenever the
+//     packet protocol is not TCP, so `from protocol udp; tcp-flags syn` can
+//     never match (H02);
+//   - the icmp-type / icmp-code arms return false for a non-ICMP(v6) packet, so
+//     `from protocol tcp; icmp-type echo-request` can never match (H03).
+//
+// A never-match term is a SILENT FAIL-OPEN for a `then discard` / `then reject`:
+// an xpf filter falls through to an implicit ACCEPT on no-match (the #3427
+// no-catchall class), so the drop the operator wrote is dead and the traffic is
+// admitted by a later permit or the implicit accept. Junos rejects these
+// cross-field combinations at commit, so accepting them is also a config-language
+// parity gap — xpf can express a term the dataplane cannot faithfully enforce.
+//
+// The gate reuses the same protocolIsPortBearing / protocolIsICMPFamily SSOT the
+// application gate uses (plus protocolIsTCP for the tcp-flags arm), so the two
+// compatibility gates stay aligned (the TestApplicationAndFilterCrossFieldGates-
+// UseSharedSSOT canary pins that). It fires only when a protocol is PRESENT: a
+// port / tcp-flags / icmp match with NO protocol is legitimate and enforceable
+// for a FILTER (unlike an application, whose matcher keys on protocol+port, a
+// filter matches the port on whatever L4-port-bearing packet arrives and the
+// tcp-flags/icmp arms self-gate on the packet protocol). next-header (the inet6
+// spelling) is covered because compileFilterFrom routes BOTH protocol and
+// next-header into term.Protocols (M02).
+//
+// The one exception that fires WITHOUT a protocol is icmp-code without
+// icmp-type (M03): the matcher constrains the code independently of the type, so
+// a code-only term matches a broader ICMP set than a Junos config implies
+// (icmp-code 0 is common across many types). Junos couples code to type, and the
+// application gate rejects the same shape (#3506), so mirror it here.
+//
+// The walk is deterministic (filters sorted by name, terms in config order) so
+// the first-reported error is stable across runs, matching the other filter
+// strict gates. On the tolerant load / peer-sync path the caller downgrades the
+// returned error to a warning (#1960 no-brick); the Rust snapshot builder's
+// UnsatisfiableFilterCrossField backstop then fails the whole snapshot closed so
+// a leniently-loaded never-match term never silently forwards.
+func validateFilterCrossFieldStrict(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	check := func(family string, filters map[string]*FirewallFilter) error {
+		names := make([]string, 0, len(filters))
+		for name := range filters {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			filter := filters[name]
+			if filter == nil {
+				continue
+			}
+			for _, term := range filter.Terms {
+				if term == nil {
+					continue
+				}
+				// H01 / M01 / M02: a source-port / destination-port match (or the
+				// negated *-except lists) requires a port-bearing transport
+				// (TCP/UDP). If ANY protocol token is non-port-bearing the term is a
+				// never-match on that protocol.
+				hasPorts := len(term.SourcePorts) > 0 || len(term.DestinationPorts) > 0 ||
+					len(term.SourcePortsExcept) > 0 || len(term.DestPortsExcept) > 0
+				if hasPorts {
+					if proto, bad := firstIncompatibleProtocol(term.Protocols, protocolIsPortBearing); bad {
+						return fmt.Errorf(
+							"firewall family %s filter %q term %q: a source-port/destination-port "+
+								"match is set with protocol %q, which does not carry L4 ports — "+
+								"source-port/destination-port are valid only on tcp/udp (the "+
+								"dataplane keys port terms on the packet's ports, which are always 0 "+
+								"for a non-port protocol, so the term would never match; a "+
+								"`then discard`/`reject` then fails OPEN. Remove the port or change "+
+								"the protocol)",
+							family, name, term.Name, proto)
+					}
+				}
+				// H02: a tcp-flags match requires TCP. If ANY protocol token is not
+				// TCP the term is a never-match on that protocol.
+				if len(term.TCPFlags) > 0 {
+					if proto, bad := firstIncompatibleProtocol(term.Protocols, protocolIsTCP); bad {
+						return fmt.Errorf(
+							"firewall family %s filter %q term %q: a tcp-flags match is set with "+
+								"protocol %q, which is not TCP — tcp-flags is valid only on tcp (the "+
+								"dataplane matches tcp-flags only when the packet protocol is TCP, so "+
+								"the term would never match; a `then discard`/`reject` then fails "+
+								"OPEN. Remove tcp-flags or set protocol tcp)",
+							family, name, term.Name, proto)
+					}
+				}
+				// H03: an icmp-type / icmp-code match requires ICMP/ICMPv6. If ANY
+				// protocol token is not an ICMP protocol the term is a never-match on
+				// that protocol.
+				if len(term.ICMPTypes) > 0 || len(term.ICMPCodes) > 0 {
+					if proto, bad := firstIncompatibleProtocol(term.Protocols, protocolIsICMPFamily); bad {
+						return fmt.Errorf(
+							"firewall family %s filter %q term %q: an icmp-type/icmp-code match is "+
+								"set with protocol %q, which is not an ICMP protocol — icmp-type/"+
+								"icmp-code are valid only on icmp/icmpv6 (the dataplane matches them "+
+								"only when the packet is ICMP/ICMPv6, so the term would never match; a "+
+								"`then discard`/`reject` then fails OPEN. Remove the constraint or set "+
+								"protocol icmp/icmpv6)",
+							family, name, term.Name, proto)
+					}
+				}
+				// M03: an icmp-code with no icmp-type constrains the code while the
+				// type stays unconstrained — a code-only term matches a broader ICMP
+				// set than a Junos config implies (icmp-code 0 is common across many
+				// types). Junos couples code to type; the application gate rejects the
+				// same shape (#3506). Mirror it here.
+				if len(term.ICMPCodes) > 0 && len(term.ICMPTypes) == 0 {
+					return fmt.Errorf(
+						"firewall family %s filter %q term %q: icmp-code is set without "+
+							"icmp-type; an ICMP code is meaningful only together with a type "+
+							"(icmp-code 0 is common across many types, so a code-only match is "+
+							"broader than a Junos config implies). Set icmp-type as well, or "+
+							"remove icmp-code",
+						family, name, term.Name)
+				}
+			}
+		}
+		return nil
+	}
+	if err := check("inet", cfg.Firewall.FiltersInet); err != nil {
+		return err
+	}
+	return check("inet6", cfg.Firewall.FiltersInet6)
+}
+
 // validateFilterActionsStrict hard-rejects any firewall-filter term whose
 // `then` block carries a token that is neither a recognized terminating action
 // (accept/reject/discard) nor a recognized modifier (count/log/syslog/
@@ -4887,6 +5047,27 @@ func protocolIsPortBearing(token string) bool {
 		// ports (ip_proto.rs has_l4_ports).
 		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
 			return n == 6 || n == 17
+		}
+		return false
+	}
+}
+
+// protocolIsTCP reports whether a protocol token names TCP — the only protocol
+// on which a firewall-filter `from tcp-flags` match is enforceable (#3723). The
+// dataplane matcher (userspace-dp engine/matching.rs per_packet_l4_matches)
+// returns false for a tcp-flags term whenever the packet protocol is not
+// PROTO_TCP, so tcp-flags on any other protocol — including UDP, which IS
+// port-bearing — can never match. It is a stricter predicate than
+// protocolIsPortBearing (which also accepts UDP): tcp-flags implies the TCP
+// family specifically. Recognizes the tcp name, the junos-tcp-any alias, and
+// the numeric protocol number 6.
+func protocolIsTCP(token string) bool {
+	switch strings.ToLower(strings.TrimSpace(token)) {
+	case "tcp", "junos-tcp-any":
+		return true
+	default:
+		if n, err := strconv.Atoi(strings.TrimSpace(token)); err == nil {
+			return n == 6
 		}
 		return false
 	}

--- a/pkg/config/firewall_crossfield_3723_test.go
+++ b/pkg/config/firewall_crossfield_3723_test.go
@@ -1,0 +1,398 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3723: the stateless firewall-filter compile path accepted several cross-field
+// combinations the Rust dataplane matcher can never satisfy, so a `then discard`
+// / `then reject` term silently became a never-match. Because an xpf filter falls
+// through to an implicit ACCEPT on no-match, the drop the operator wrote was dead
+// and the traffic was admitted — a fail-OPEN. validateFilterCrossFieldStrict is
+// the stateless-filter mirror of the application cross-field gate (#3373/#3348)
+// and rejects the offending term at commit.
+//
+// FAIL-ON-REVERT: remove the validateFilterCrossFieldStrict invocation (or the
+// function's reject) and every strict-path case below goes RED — CompileConfig
+// accepts a never-match discard term (accepted + never-matches + implicit-accept)
+// instead of erroring.
+
+// H01 / M01 / M02: a source-port / destination-port match on a NON-port-bearing
+// protocol is a never-match. Cover several protocols, both directions, both
+// families, the *-except lists, and a mixed bracket list.
+func TestFilterPortOnNonPortProtocolRejected_3723(t *testing.T) {
+	cases := []struct {
+		name  string
+		cmds  []string
+		proto string // token that must appear in the error
+	}{
+		{
+			name: "gre_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol gre",
+				"set firewall family inet filter f term t from destination-port 80",
+				"set firewall family inet filter f term t then discard",
+			},
+			proto: "gre",
+		},
+		{
+			name: "esp_sport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol esp",
+				"set firewall family inet filter f term t from source-port 4500",
+				"set firewall family inet filter f term t then reject",
+			},
+			proto: "esp",
+		},
+		{
+			name: "icmp_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol icmp",
+				"set firewall family inet filter f term t from destination-port 8",
+				"set firewall family inet filter f term t then discard",
+			},
+			proto: "icmp",
+		},
+		{
+			name: "numeric_gre_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol 47",
+				"set firewall family inet filter f term t from destination-port 80",
+				"set firewall family inet filter f term t then discard",
+			},
+			proto: "47",
+		},
+		{
+			// M01: a mixed bracket list — tcp is port-bearing, gre is not. A
+			// single configured deny that only enforces on tcp and silently
+			// never-matches gre must be rejected on gre.
+			name: "mixed_list_tcp_gre_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol [ tcp gre ]",
+				"set firewall family inet filter f term t from destination-port 80",
+				"set firewall family inet filter f term t then discard",
+			},
+			proto: "gre",
+		},
+		{
+			// M02: inet6 next-header is the IPv6 spelling of protocol; it routes
+			// into term.Protocols so it inherits the identical hazard.
+			name: "inet6_nextheader_esp_dport",
+			cmds: []string{
+				"set firewall family inet6 filter f6 term t from next-header esp",
+				"set firewall family inet6 filter f6 term t from destination-port 80",
+				"set firewall family inet6 filter f6 term t then discard",
+			},
+			proto: "esp",
+		},
+		{
+			// The negated *-port-except list carries the same hazard.
+			name: "gre_dport_except",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol gre",
+				"set firewall family inet filter f term t from destination-port-except 80",
+				"set firewall family inet filter f term t then discard",
+			},
+			proto: "gre",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildFilterTree(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("term with a port on non-port protocol %q must be rejected at commit (#3723)", tc.proto)
+			}
+			if !strings.Contains(err.Error(), tc.proto) ||
+				!strings.Contains(err.Error(), "port") {
+				t.Fatalf("error %q must name the port match and protocol %q", err, tc.proto)
+			}
+			// Tolerant path downgrades to a warning (#1960 no-brick); the Rust
+			// backstop fails the snapshot closed independently.
+			if _, lerr := CompileConfigLenient(tree); lerr != nil {
+				t.Fatalf("lenient path must not hard-fail on the cross-field term: %v", lerr)
+			}
+		})
+	}
+}
+
+// H02: tcp-flags on a NON-TCP protocol is a never-match. UDP is port-bearing but
+// still not TCP, so it must be rejected — proving tcp-flags uses the stricter
+// protocolIsTCP predicate, not protocolIsPortBearing.
+func TestFilterTCPFlagsOnNonTCPProtocolRejected_3723(t *testing.T) {
+	cases := []struct {
+		name, proto string
+	}{
+		{"udp", "udp"},
+		{"icmp", "icmp"},
+		{"gre", "gre"},
+		{"numeric_udp", "17"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildFilterTree(t,
+				"set firewall family inet filter f term t from protocol "+tc.proto,
+				"set firewall family inet filter f term t from tcp-flags syn",
+				"set firewall family inet filter f term t then discard",
+			)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatalf("tcp-flags on non-TCP protocol %q must be rejected at commit (#3723)", tc.proto)
+			}
+			if !strings.Contains(err.Error(), tc.proto) ||
+				!strings.Contains(err.Error(), "tcp-flags") {
+				t.Fatalf("error %q must name tcp-flags and protocol %q", err, tc.proto)
+			}
+			if _, lerr := CompileConfigLenient(tree); lerr != nil {
+				t.Fatalf("lenient path must not hard-fail on the cross-field term: %v", lerr)
+			}
+		})
+	}
+}
+
+// H03: icmp-type / icmp-code on a NON-ICMP protocol is a never-match.
+func TestFilterICMPOnNonICMPProtocolRejected_3723(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{
+			name: "tcp_icmptype",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol tcp",
+				"set firewall family inet filter f term t from icmp-type echo-request",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			name: "udp_icmpcode",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol udp",
+				"set firewall family inet filter f term t from icmp-type 3",
+				"set firewall family inet filter f term t from icmp-code 0",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildFilterTree(t, tc.cmds...)
+			_, err := CompileConfig(tree)
+			if err == nil {
+				t.Fatal("icmp-type/icmp-code on a non-ICMP protocol must be rejected at commit (#3723)")
+			}
+			if !strings.Contains(err.Error(), "icmp") {
+				t.Fatalf("error %q must name the icmp match", err)
+			}
+			if _, lerr := CompileConfigLenient(tree); lerr != nil {
+				t.Fatalf("lenient path must not hard-fail on the cross-field term: %v", lerr)
+			}
+		})
+	}
+}
+
+// M03: an icmp-code with NO icmp-type is broader than a Junos config implies
+// (icmp-code 0 is common across types). Mirror the #3506 application reject.
+func TestFilterICMPCodeWithoutTypeRejected_3723(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from protocol icmp",
+		"set firewall family inet filter f term t from icmp-code 0",
+		"set firewall family inet filter f term t then discard",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("icmp-code without icmp-type must be rejected at commit (#3723 M03)")
+	}
+	if !strings.Contains(err.Error(), "icmp-code") ||
+		!strings.Contains(err.Error(), "icmp-type") {
+		t.Fatalf("error %q must explain the icmp-code-without-icmp-type coupling", err)
+	}
+	if _, lerr := CompileConfigLenient(tree); lerr != nil {
+		t.Fatalf("lenient path must not hard-fail on the icmp-code-only term: %v", lerr)
+	}
+}
+
+// Positive controls — a same-protocol (satisfiable) term must STILL compile and
+// keep its match fields, proving the gate is scoped to genuinely-unsatisfiable
+// cross-field pairs, not to every L4 predicate.
+func TestFilterCrossFieldSatisfiableAccepted_3723(t *testing.T) {
+	cases := []struct {
+		name string
+		cmds []string
+	}{
+		{
+			name: "tcp_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol tcp",
+				"set firewall family inet filter f term t from destination-port 22",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			name: "udp_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol udp",
+				"set firewall family inet filter f term t from destination-port 53",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			name: "tcp_tcpflags",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol tcp",
+				"set firewall family inet filter f term t from tcp-flags syn",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			name: "icmp_icmptype",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol icmp",
+				"set firewall family inet filter f term t from icmp-type echo-request",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			name: "icmp_type_and_code",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol icmp",
+				"set firewall family inet filter f term t from icmp-type 3",
+				"set firewall family inet filter f term t from icmp-code 0",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			name: "inet6_nextheader_icmp6_type",
+			cmds: []string{
+				"set firewall family inet6 filter f6 term t from next-header icmp6",
+				"set firewall family inet6 filter f6 term t from icmp-type echo-request",
+				"set firewall family inet6 filter f6 term t then discard",
+			},
+		},
+		{
+			name: "mixed_list_tcp_udp_dport",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol [ tcp udp ]",
+				"set firewall family inet filter f term t from destination-port 80",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			// A port with NO protocol is legitimate for a FILTER (the matcher
+			// matches the port on whatever L4-port-bearing packet arrives). The
+			// gate fires only when an incompatible protocol is PRESENT.
+			name: "dport_no_protocol",
+			cmds: []string{
+				"set firewall family inet filter f term t from destination-port 80",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			// tcp-flags with NO protocol is enforceable — the matcher self-gates
+			// on the packet protocol being TCP.
+			name: "tcpflags_no_protocol",
+			cmds: []string{
+				"set firewall family inet filter f term t from tcp-flags syn",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+		{
+			// A non-port protocol with NO port is fine — the protocol alone is
+			// enforceable.
+			name: "gre_no_port",
+			cmds: []string{
+				"set firewall family inet filter f term t from protocol gre",
+				"set firewall family inet filter f term t then discard",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := buildFilterTree(t, tc.cmds...)
+			if _, err := CompileConfig(tree); err != nil {
+				t.Fatalf("satisfiable term must compile cleanly: %v", err)
+			}
+		})
+	}
+}
+
+// The lenient path must record a downgrade WARNING (not just avoid failing) so
+// an operator syncing a legacy config can see the term is inert.
+func TestFilterCrossFieldLenientWarns_3723(t *testing.T) {
+	tree := buildFilterTree(t,
+		"set firewall family inet filter f term t from protocol gre",
+		"set firewall family inet filter f term t from destination-port 80",
+		"set firewall family inet filter f term t then discard",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile must not hard-fail: %v", err)
+	}
+	warned := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "cross-field") && strings.Contains(w, "gre") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected a cross-field downgrade warning naming gre, got %v", cfg.Warnings)
+	}
+}
+
+// L12 cross-package canary: the application cross-field gate (#3373/#3348) and
+// the firewall-filter cross-field gate (#3723) MUST reason about protocol/L4
+// compatibility with the SAME SSOT helpers (protocolIsPortBearing /
+// protocolIsICMPFamily), plus protocolIsTCP for the tcp-flags arm. If a future
+// refactor changes one helper's verdict for a protocol, both gates move
+// together — this pin fails if the port-bearing / ICMP-family classification
+// they share ever diverges from the tcp-flags subset relationship.
+func TestApplicationAndFilterCrossFieldGatesUseSharedSSOT_3723(t *testing.T) {
+	// Representative protocol tokens spanning port / TCP-only / ICMP / neither.
+	tokens := []string{
+		"tcp", "udp", "icmp", "icmpv6", "icmp6", "gre", "esp", "ah",
+		"ospf", "vrrp", "sctp", "junos-tcp-any", "junos-udp-any",
+		"junos-ping", "6", "17", "1", "58", "47", "132",
+	}
+	for _, tok := range tokens {
+		// Invariant 1: every TCP token is port-bearing (tcp-flags implies a
+		// port-bearing transport), but not every port-bearing token is TCP (UDP).
+		if protocolIsTCP(tok) && !protocolIsPortBearing(tok) {
+			t.Fatalf("protocol %q is TCP but not port-bearing — the tcp-flags gate would "+
+				"reject a term the port gate accepts, an SSOT split", tok)
+		}
+		// Invariant 2: TCP and ICMP-family are disjoint (a token cannot be both,
+		// else a tcp-flags+icmp-type term would have no consistent verdict).
+		if protocolIsTCP(tok) && protocolIsICMPFamily(tok) {
+			t.Fatalf("protocol %q classified as BOTH TCP and ICMP-family — cross-field "+
+				"verdicts would be inconsistent", tok)
+		}
+		// Invariant 3: an ICMP-family token is never port-bearing (a port on ICMP
+		// is a never-match; both gates must agree it is not port-bearing).
+		if protocolIsICMPFamily(tok) && protocolIsPortBearing(tok) {
+			t.Fatalf("protocol %q classified as BOTH ICMP-family and port-bearing — the "+
+				"port gate and icmp gate would disagree", tok)
+		}
+	}
+
+	// And prove both gates actually FIRE on the shared classification for the
+	// same protocol: an ICMP protocol carrying a port is rejected by BOTH the
+	// application gate and the firewall-filter gate.
+	appCfg := &Config{}
+	appCfg.Services.ApplicationIdentification = true
+	appCfg.Applications.Applications = map[string]*Application{
+		"BAD": {Name: "BAD", Protocol: "icmp", DestinationPort: "80"},
+	}
+	if err := validateApplicationSpecsStrict(appCfg); err == nil {
+		t.Fatal("application gate must reject a port on icmp (shared #3373 SSOT)")
+	}
+	filterCfg := &Config{}
+	filterCfg.Firewall.FiltersInet = map[string]*FirewallFilter{
+		"f": {Name: "f", Terms: []*FirewallFilterTerm{
+			{Name: "t", Protocols: []string{"icmp"}, DestinationPorts: []string{"80"}, Action: "discard"},
+		}},
+	}
+	if err := validateFilterCrossFieldStrict(filterCfg); err == nil {
+		t.Fatal("firewall-filter gate must reject a port on icmp (shared #3723 SSOT)")
+	}
+}

--- a/pkg/config/firewall_multivalue_2545_test.go
+++ b/pkg/config/firewall_multivalue_2545_test.go
@@ -13,17 +13,29 @@ import "testing"
 //
 // FAIL-ON-REVERT: with the pre-fix scalar last-write-wins compiler these tests
 // fail — e.g. Protocols would carry only "udp" (length 1), not [tcp, udp].
+//
+// #3723: protocol/dscp accumulation and icmp-type/icmp-code accumulation are
+// split into SEPARATE terms so each is a SATISFIABLE cross-field combination
+// (the cross-field gate rejects a never-match term such as icmp-type on protocol
+// tcp). The multi-value coverage is unchanged — every criterion is still
+// exercised repeated within one `from` block, just on a protocol that carries it.
 
 func TestFirewallFilterMultiValueHierarchical(t *testing.T) {
 	input := `firewall {
     family inet {
         filter mv {
-            term t {
+            term proto {
                 from {
                     protocol tcp;
                     protocol udp;
                     dscp ef;
                     dscp af43;
+                }
+                then discard;
+            }
+            term icmp {
+                from {
+                    protocol icmp;
                     icmp-type 8;
                     icmp-type 0;
                     icmp-code 3;
@@ -43,27 +55,29 @@ func TestFirewallFilterMultiValueHierarchical(t *testing.T) {
 		t.Fatalf("compile error: %v", err)
 	}
 	f := cfg.Firewall.FiltersInet["mv"]
-	if f == nil || len(f.Terms) != 1 {
-		t.Fatalf("expected 1 term, got %#v", f)
+	if f == nil || len(f.Terms) != 2 {
+		t.Fatalf("expected 2 terms, got %#v", f)
 	}
-	term := f.Terms[0]
-	assertStrSet(t, "protocol", term.Protocols, []string{"tcp", "udp"})
-	assertStrSet(t, "dscp", term.DSCPs, []string{"ef", "af43"})
-	assertIntSet(t, "icmp-type", term.ICMPTypes, []int{8, 0})
-	assertIntSet(t, "icmp-code", term.ICMPCodes, []int{3, 4})
+	protoTerm, icmpTerm := f.Terms[0], f.Terms[1]
+	assertStrSet(t, "protocol", protoTerm.Protocols, []string{"tcp", "udp"})
+	assertStrSet(t, "dscp", protoTerm.DSCPs, []string{"ef", "af43"})
+	assertIntSet(t, "icmp-type", icmpTerm.ICMPTypes, []int{8, 0})
+	assertIntSet(t, "icmp-code", icmpTerm.ICMPCodes, []int{3, 4})
 }
 
 func TestFirewallFilterMultiValueFlatSet(t *testing.T) {
 	cmds := []string{
-		"set firewall family inet filter mv term t from protocol tcp",
-		"set firewall family inet filter mv term t from protocol udp",
-		"set firewall family inet filter mv term t from dscp ef",
-		"set firewall family inet filter mv term t from dscp af43",
-		"set firewall family inet filter mv term t from icmp-type 8",
-		"set firewall family inet filter mv term t from icmp-type 0",
-		"set firewall family inet filter mv term t from icmp-code 3",
-		"set firewall family inet filter mv term t from icmp-code 4",
-		"set firewall family inet filter mv term t then discard",
+		"set firewall family inet filter mv term proto from protocol tcp",
+		"set firewall family inet filter mv term proto from protocol udp",
+		"set firewall family inet filter mv term proto from dscp ef",
+		"set firewall family inet filter mv term proto from dscp af43",
+		"set firewall family inet filter mv term proto then discard",
+		"set firewall family inet filter mv term icmp from protocol icmp",
+		"set firewall family inet filter mv term icmp from icmp-type 8",
+		"set firewall family inet filter mv term icmp from icmp-type 0",
+		"set firewall family inet filter mv term icmp from icmp-code 3",
+		"set firewall family inet filter mv term icmp from icmp-code 4",
+		"set firewall family inet filter mv term icmp then discard",
 	}
 	tree := &ConfigTree{}
 	for _, cmd := range cmds {
@@ -80,14 +94,14 @@ func TestFirewallFilterMultiValueFlatSet(t *testing.T) {
 		t.Fatalf("compile error: %v", err)
 	}
 	f := cfg.Firewall.FiltersInet["mv"]
-	if f == nil || len(f.Terms) != 1 {
-		t.Fatalf("expected 1 term, got %#v", f)
+	if f == nil || len(f.Terms) != 2 {
+		t.Fatalf("expected 2 terms, got %#v", f)
 	}
-	term := f.Terms[0]
-	assertStrSet(t, "protocol", term.Protocols, []string{"tcp", "udp"})
-	assertStrSet(t, "dscp", term.DSCPs, []string{"ef", "af43"})
-	assertIntSet(t, "icmp-type", term.ICMPTypes, []int{8, 0})
-	assertIntSet(t, "icmp-code", term.ICMPCodes, []int{3, 4})
+	protoTerm, icmpTerm := f.Terms[0], f.Terms[1]
+	assertStrSet(t, "protocol", protoTerm.Protocols, []string{"tcp", "udp"})
+	assertStrSet(t, "dscp", protoTerm.DSCPs, []string{"ef", "af43"})
+	assertIntSet(t, "icmp-type", icmpTerm.ICMPTypes, []int{8, 0})
+	assertIntSet(t, "icmp-code", icmpTerm.ICMPCodes, []int{3, 4})
 }
 
 // TestFirewallFilterMultiValueBracketList covers the bracket-list shape

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -548,6 +548,74 @@ fn parse_term(
             }
         }
     }
+    // #3723: cross-field satisfiability backstop. A term whose resolved protocol
+    // constraint is PRESENT but INCOMPATIBLE with a co-configured L4 predicate is
+    // a NEVER-MATCH: the matcher (engine/matching.rs) keys ports on the extracted
+    // L4 port (0 for a non-port protocol — only TCP/UDP carry ports per
+    // ip_proto::has_l4_ports), gates tcp-flags on protocol==TCP, and gates
+    // icmp-type/code on ICMP/ICMPv6. Because a filter falls through to the implicit
+    // ACCEPT on no-match, a `then discard`/`reject` term over such a pair silently
+    // fails OPEN. The Go commit gate (validateFilterCrossFieldStrict, #3723) is the
+    // primary defense — a committed config never carries such a term — so this is
+    // the helper-boundary backstop for a corrupt / hand-built / version-drifted or
+    // leniently-loaded snapshot, consistent with the #2505/#3367/#3406 fail-closed
+    // family. Rejecting the whole snapshot (the reconcile preflight keeps the
+    // previous good filter state) is action-agnostic. An EMPTY protocol list is
+    // the legitimate "no protocol constraint" case: a port / tcp-flags / icmp
+    // predicate with no protocol is enforceable for a FILTER (the matcher matches
+    // the port on whatever port-bearing packet arrives, and the tcp-flags/icmp
+    // arms self-gate on the packet protocol), so it is NOT an error.
+    if !protocols.is_empty() {
+        let ports_present = snap.source_ports.iter().any(|p| port_is_real(p))
+            || snap.destination_ports.iter().any(|p| port_is_real(p))
+            || snap.source_ports_except.iter().any(|p| port_is_real(p))
+            || snap.destination_ports_except.iter().any(|p| port_is_real(p));
+        if ports_present {
+            if let Some(&proto) = protocols
+                .iter()
+                .find(|&&p| !crate::ip_proto::has_l4_ports(p))
+            {
+                return Err(SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+                    family: filter_family.to_string(),
+                    filter: filter_name.to_string(),
+                    term: snap.name.clone(),
+                    predicate: "port",
+                    protocol: proto,
+                });
+            }
+        }
+        let tcp_flags_present =
+            snap.tcp_flags.is_some_and(|m| m != 0) || snap.tcp_flags_forbidden.is_some_and(|m| m != 0);
+        if tcp_flags_present {
+            if let Some(&proto) = protocols
+                .iter()
+                .find(|&&p| p != crate::ip_proto::PROTO_TCP)
+            {
+                return Err(SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+                    family: filter_family.to_string(),
+                    filter: filter_name.to_string(),
+                    term: snap.name.clone(),
+                    predicate: "tcp-flags",
+                    protocol: proto,
+                });
+            }
+        }
+        let icmp_present = !snap.icmp_types.is_empty() || !snap.icmp_codes.is_empty();
+        if icmp_present {
+            if let Some(&proto) = protocols
+                .iter()
+                .find(|&&p| p != crate::ip_proto::PROTO_ICMP && p != crate::ip_proto::PROTO_ICMPV6)
+            {
+                return Err(SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+                    family: filter_family.to_string(),
+                    filter: filter_name.to_string(),
+                    term: snap.name.clone(),
+                    predicate: "icmp-type/code",
+                    protocol: proto,
+                });
+            }
+        }
+    }
     // #2622: a direction's port scope is either the positive `source-port` /
     // `destination-port` list OR the negated `source-port-except` /
     // `destination-port-except` list (Junos treats them as mutually exclusive).

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -4929,6 +4929,245 @@ fn tcp_flags_unparseable_error_names_the_family_for_reused_filter_names() {
     }
 }
 
+// =====================================================================
+// #3723: firewall-filter CROSS-FIELD satisfiability backstop. A term whose
+// resolved protocol constraint is PRESENT but incompatible with a
+// co-configured L4 predicate (a port on a non-port-bearing protocol,
+// tcp-flags on a non-TCP protocol, or icmp-type/code on a non-ICMP protocol)
+// is a NEVER-MATCH. Because a filter falls through to the implicit ACCEPT on
+// no-match, a `then discard`/`reject` term over such a pair silently fails
+// OPEN. The Go commit gate (validateFilterCrossFieldStrict) is the primary
+// defense; parse_filter_state is the helper-boundary backstop that rejects the
+// whole snapshot (fail closed) for a leniently-loaded / drifted snapshot.
+// =====================================================================
+
+// Build a single-term `discard` filter with an arbitrary cross-field shape.
+fn crossfield_filter(
+    family: &str,
+    protocols: Vec<String>,
+    dst_ports: Vec<String>,
+    tcp_flags: Option<u8>,
+    icmp_types: Vec<u8>,
+) -> Result<FilterState, SnapshotIntegrityError> {
+    parse_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "f".into(),
+            family: family.into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "x".into(),
+                protocols,
+                destination_ports: dst_ports,
+                tcp_flags,
+                icmp_types,
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+        &[],
+        "",
+        "",
+    )
+}
+
+#[test]
+fn filter_crossfield_3723_port_on_nonport_protocol_rejected() {
+    // H01: a destination-port on a non-port-bearing protocol (gre) is a
+    // never-match. The backstop rejects the whole snapshot rather than compile a
+    // silently-inert discard. Reverting the parse_term guard returns Ok here, so
+    // this is non-tautological.
+    let err = crossfield_filter("inet", vec!["gre".into()], vec!["80".into()], None, vec![])
+        .expect_err("a port on gre must fail the build closed");
+    match err {
+        SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+            family,
+            filter,
+            term,
+            predicate,
+            protocol,
+        } => {
+            assert_eq!(family, "inet");
+            assert_eq!(filter, "f");
+            assert_eq!(term, "x");
+            assert_eq!(predicate, "port");
+            assert_eq!(protocol, crate::ip_proto::PROTO_GRE);
+        }
+        other => panic!("expected UnsatisfiableFilterCrossField, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_crossfield_3723_tcpflags_on_nontcp_rejected() {
+    // H02: tcp-flags on a non-TCP protocol (udp — port-bearing but NOT TCP) is a
+    // never-match.
+    let err = crossfield_filter("inet", vec!["udp".into()], vec![], Some(0x02), vec![])
+        .expect_err("tcp-flags on udp must fail the build closed");
+    match err {
+        SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+            predicate, protocol, ..
+        } => {
+            assert_eq!(predicate, "tcp-flags");
+            assert_eq!(protocol, PROTO_UDP);
+        }
+        other => panic!("expected UnsatisfiableFilterCrossField, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_crossfield_3723_icmp_on_nonicmp_rejected() {
+    // H03: an icmp-type on a non-ICMP protocol (tcp) is a never-match.
+    let err = crossfield_filter("inet", vec!["tcp".into()], vec![], None, vec![8])
+        .expect_err("icmp-type on tcp must fail the build closed");
+    match err {
+        SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+            predicate, protocol, ..
+        } => {
+            assert_eq!(predicate, "icmp-type/code");
+            assert_eq!(protocol, PROTO_TCP);
+        }
+        other => panic!("expected UnsatisfiableFilterCrossField, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_crossfield_3723_mixed_list_rejected() {
+    // M01: a mixed protocol list [tcp gre] with a port only enforces on tcp and
+    // silently never-matches gre. The backstop rejects on the incompatible gre.
+    let err = crossfield_filter(
+        "inet",
+        vec!["tcp".into(), "gre".into()],
+        vec!["80".into()],
+        None,
+        vec![],
+    )
+    .expect_err("a mixed port-bearing/non-port list with a port must fail closed");
+    match err {
+        SnapshotIntegrityError::UnsatisfiableFilterCrossField {
+            predicate, protocol, ..
+        } => {
+            assert_eq!(predicate, "port");
+            assert_eq!(protocol, crate::ip_proto::PROTO_GRE);
+        }
+        other => panic!("expected UnsatisfiableFilterCrossField, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_crossfield_3723_family_named_for_reused_names() {
+    // Filter names can be reused across families; the diagnostic must name the
+    // family carrying the never-match term (M02: next-header lowers into
+    // protocols, so an inet6 esp+port term hits the same backstop).
+    let err = crossfield_filter("inet6", vec!["esp".into()], vec!["80".into()], None, vec![])
+        .expect_err("an inet6 port-on-esp term must fail closed");
+    match err {
+        SnapshotIntegrityError::UnsatisfiableFilterCrossField { family, .. } => {
+            assert_eq!(family, "inet6");
+        }
+        other => panic!("expected UnsatisfiableFilterCrossField, got {other:?}"),
+    }
+}
+
+#[test]
+fn filter_crossfield_3723_satisfiable_compiles() {
+    // Positive controls — a satisfiable same-protocol term must still compile.
+    crossfield_filter("inet", vec!["tcp".into()], vec!["22".into()], None, vec![])
+        .expect("tcp + port compiles");
+    crossfield_filter("inet", vec!["udp".into()], vec!["53".into()], None, vec![])
+        .expect("udp + port compiles");
+    crossfield_filter("inet", vec!["tcp".into()], vec![], Some(0x02), vec![])
+        .expect("tcp + tcp-flags compiles");
+    crossfield_filter("inet", vec!["icmp".into()], vec![], None, vec![8])
+        .expect("icmp + icmp-type compiles");
+    crossfield_filter(
+        "inet",
+        vec!["tcp".into(), "udp".into()],
+        vec!["80".into()],
+        None,
+        vec![],
+    )
+    .expect("a fully port-bearing mixed list compiles");
+}
+
+#[test]
+fn filter_crossfield_3723_no_protocol_is_enforceable() {
+    // A port / tcp-flags / icmp predicate with NO protocol is legitimate and
+    // enforceable for a FILTER (the matcher matches the port on whatever
+    // port-bearing packet arrives, and the tcp-flags/icmp arms self-gate on the
+    // packet protocol). The backstop must NOT reject these.
+    crossfield_filter("inet", vec![], vec!["80".into()], None, vec![])
+        .expect("port with no protocol is enforceable");
+    crossfield_filter("inet", vec![], vec![], Some(0x02), vec![])
+        .expect("tcp-flags with no protocol is enforceable");
+    crossfield_filter("inet", vec![], vec![], None, vec![8])
+        .expect("icmp-type with no protocol is enforceable");
+}
+
+#[test]
+fn filter_crossfield_3723_never_match_fails_open_at_runtime() {
+    // L06 runtime guard: FABRICATE the never-match term the backstop normally
+    // prevents (protocol gre + destination-port 80) and prove it matches NOTHING,
+    // documenting the fail-OPEN #3723 closes — the operator's `then discard` is
+    // dead and the traffic is admitted by the implicit accept. Built by cloning a
+    // valid gre discard term (compiled without a port) and overriding the port
+    // fields, so it exercises the REAL matcher (engine/matching.rs) end to end.
+    let state = filter_for_protocol("gre").expect("gre discard term compiles");
+    let base = state
+        .filters
+        .get("inet:f")
+        .expect("filter compiled")
+        .terms
+        .first()
+        .expect("one term")
+        .clone();
+    let never = FilterTerm {
+        dest_ports: PortMatcher::Single(80),
+        dest_port_constrained: true,
+        counter: Arc::new(FilterTermCounter::default()),
+        ..base
+    };
+    let mut filter: Filter = (**state.filters.get("inet:f").unwrap()).clone();
+    filter.terms = vec![never];
+    let mut st = FilterState::default();
+    st.filters.insert("inet:f".into(), Arc::new(filter));
+
+    // A GRE packet carries no L4 ports (dst_port 0): protocol matches gre, but
+    // port 0 != 80 -> no match -> Accept (the discard never fires).
+    let gre = evaluate_filter(
+        &st,
+        "inet:f",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        crate::ip_proto::PROTO_GRE,
+        0,
+        0,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        gre.action,
+        FilterAction::Accept,
+        "gre+port term never matches a gre packet (port 0) — the discard fails OPEN"
+    );
+
+    // A TCP:80 packet: protocol gre != tcp -> no match -> Accept.
+    let tcp = evaluate_filter(
+        &st,
+        "inet:f",
+        v4(10, 0, 0, 1),
+        v4(10, 0, 0, 2),
+        PROTO_TCP,
+        1000,
+        80,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        tcp.action,
+        FilterAction::Accept,
+        "gre+port term never matches a tcp:80 packet (protocol mismatch) — the discard fails OPEN"
+    );
+}
+
 #[test]
 fn protocol_2505_unresolvable_fails_closed_not_match_all() {
     // A non-empty list with an unresolvable token must reject the whole

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -278,6 +278,33 @@ pub(crate) enum SnapshotIntegrityError {
         term: String,
         length: u8,
     },
+    /// #3723: a firewall-filter term combined a resolved `protocol` (or the inet6
+    /// `next-header`) with an L4 predicate the matcher can NEVER satisfy for that
+    /// protocol — a source/destination-port with a non-port-bearing protocol
+    /// (only TCP/UDP carry extracted ports, ip_proto.rs has_l4_ports), a tcp-flags
+    /// match with a non-TCP protocol, or an icmp-type/icmp-code match with a
+    /// non-ICMP(v6) protocol. The matcher (engine/matching.rs) keys ports on the
+    /// extracted L4 port (0 for a non-port protocol), gates tcp-flags on
+    /// protocol==TCP, and gates icmp-type/code on ICMP/ICMPv6, so such a term is a
+    /// NEVER-MATCH. Because a filter falls through to the implicit ACCEPT on
+    /// no-match (the #3427 no-catchall class), a `then discard`/`reject` term over
+    /// such a pair is silently dead and the traffic is admitted — a fail-OPEN.
+    /// The Go commit gate (`validateFilterCrossFieldStrict`, #3723) is the primary
+    /// defense — a freshly committed config can never carry such a term — so this
+    /// is the helper-boundary backstop for a corrupt / hand-built / version-drifted
+    /// or leniently-loaded snapshot, consistent with the #2505/#3367/#3406
+    /// fail-closed family. Rejecting the whole snapshot (the reconcile preflight
+    /// keeps the previous good filter state) is action-agnostic. `predicate` names
+    /// the offending L4 dimension ("port" / "tcp-flags" / "icmp-type/code") and
+    /// `protocol` is the incompatible IANA number. `family` (inet / inet6) is
+    /// carried because filter names can be reused across families.
+    UnsatisfiableFilterCrossField {
+        family: String,
+        filter: String,
+        term: String,
+        predicate: &'static str,
+        protocol: u8,
+    },
     /// #3296: an interface (or lo0) snapshot named a NON-EMPTY firewall filter
     /// (`filter_input_v4/v6` / `filter_output_v4/v6`, or the lo0 host-bound
     /// filter) that is not present in the compiled filter table. The pre-fix
@@ -575,6 +602,17 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "firewall family {:?} filter {:?} term {:?} has a flexible-match-range byte length {} outside the representable 1..=4 range — refusing to truncate it to a 4-byte window (which would broaden the match)",
                 family, filter, term, length
+            ),
+            Self::UnsatisfiableFilterCrossField {
+                family,
+                filter,
+                term,
+                predicate,
+                protocol,
+            } => write!(
+                f,
+                "firewall family {:?} filter {:?} term {:?} combines a {} match with protocol {} that cannot carry it — refusing to compile a never-match term (a then discard/reject over it fails open, admitting the traffic via the implicit accept)",
+                family, filter, term, predicate, protocol
             ),
             Self::MissingFilterRef {
                 interface,


### PR DESCRIPTION
Closes #3723

## Problem

A stateless firewall-filter `from` block could combine a `protocol` (or the
inet6 `next-header`) with an L4 predicate the dataplane matcher can never satisfy
for that protocol:

- a **port** on a non-port-bearing protocol (gre/esp/ah/ospf/vrrp/icmp/..., or a
  numeric like 47) — only TCP/UDP carry extracted ports (`ip_proto::has_l4_ports`);
- **tcp-flags** on a non-TCP protocol (udp/...);
- **icmp-type/icmp-code** on a non-ICMP protocol (tcp/udp/...).

Such a term compiled cleanly but became a **never-match** at runtime
(`userspace-dp/src/filter/engine/matching.rs`: `port_match` tests the port against
`0` for a non-port protocol; `per_packet_l4_matches` gates tcp-flags on
`protocol == PROTO_TCP` and icmp-type/code on ICMP/ICMPv6). Because an xpf filter
falls through to an **implicit ACCEPT** on no-match, a `then discard` / `then reject`
written over such a pair was silently dead — the traffic it was meant to drop was
admitted by a later permit or the implicit accept (a **fail-OPEN**). Junos rejects
these combinations at commit, so this was also a config-language parity gap.

The application path already had this gate (#3373 port / #3348 icmp / #3506, and
#3712 hardened the Rust application boundary). The stateless-FILTER path never got
the equivalent gate.

## Fix (fail-closed, both layers)

**(a) Commit gate** — `validateFilterCrossFieldStrict`
(`pkg/config/compiler_validate_strict.go`), the filter mirror of the application
cross-field gate, reusing the shared `protocolIsPortBearing` / `protocolIsICMPFamily`
SSOT plus a new `protocolIsTCP` (stricter than port-bearing, since UDP is
port-bearing but not TCP). It rejects at commit:

- ports (positive or `*-except`) when a protocol is present and **any** token is
  non-port-bearing — **H01**, mixed bracket list **M01**, inet6 `next-header` **M02**
  (both `protocol` and `next-header` route into `term.Protocols`);
- tcp-flags when a protocol is present and **any** token is not TCP — **H02**;
- icmp-type/icmp-code when a protocol is present and **any** token is not
  ICMP/ICMPv6 — **H03**;
- icmp-code with no icmp-type — **M03**, mirroring the #3506 application reject.

The gate fires **only when a protocol is present**: a port / tcp-flags / icmp match
with no protocol is legitimate and enforceable for a filter (the matcher matches the
port on whatever port-bearing packet arrives and the tcp-flags/icmp arms self-gate on
the packet protocol) — unlike an application, whose matcher keys on protocol+port.
The tolerant load / peer-sync path downgrades to a warning
(`lenientFilterCrossField`, #1960 no-brick).

**(b) Rust snapshot backstop** — `parse_term` (`userspace-dp/src/filter/compiler.rs`)
rejects the whole snapshot with `SnapshotIntegrityError::UnsatisfiableFilterCrossField`
(the reconcile preflight keeps the previous good filter state), so a leniently-loaded
/ drifted never-match term never silently forwards — defense-in-depth consistent with
the #2505/#3367/#3406 filter backstops.

## Tests

- `pkg/config/firewall_crossfield_3723_test.go` — every finding (H01/H02/H03/M01/M02/M03),
  both families, both directions, the `*-except` lists, the lenient-path warning,
  positive controls (satisfiable same-protocol terms and protocol-less predicates still
  compile), and an **L12 cross-package canary** pinning the application and filter gates to
  the shared port-bearing / ICMP-family / TCP SSOT.
- `userspace-dp/src/filter/tests.rs` — `filter_crossfield_3723_*`: the offending snapshots
  are rejected with the correct predicate/protocol/family; satisfiable and protocol-less
  terms still compile; plus an **L06 runtime guard** that fabricates the never-match term the
  backstop prevents (gre + dst port 80) and drives the real matcher to prove a gre packet and
  a tcp:80 packet both fall through to Accept — the fail-OPEN this closes.
- The #2545 multi-value test is split into satisfiable per-protocol terms (its synthetic
  icmp-type-on-tcp term was exactly the never-match shape this gate rejects) with unchanged
  accumulation coverage.

**RED-on-revert verified both sides**: neutering the Go call turns 6 subtests RED; neutering
the `parse_term` guard turns the 5 Rust rejection tests RED.

**Validation**: full `cargo test --release` green (3371 lib + 46 + others, 0 failed);
`go test ./pkg/config/...` green; `go build ./...`, gofmt, vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi