### PR TITLE
flowexport: per-collector flow-server source-address (fix family-wide LWW collapse) + expose source in health surfaces

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26017,3 +26017,43 @@ top.
     section + metrics + cooldown gotcha), pkg/api/metrics_system.go (emit
     reason="stale"), pkg/api/metrics_descriptors.go (dropped help text),
     pkg/eventengine/engine_stale_revalidate_3750_test.go (new, RED-on-revert)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3745 — flow-server per-collector source-address (was
+    family-wide last-writer-wins); expose source in health surfaces. Root
+    cause: compileSamplingFamily collapsed every flow-server-nested
+    source-address into ONE family-wide SamplingFamily.SourceAddress
+    (last-writer-wins by AST order) and the flowexport resolver applied
+    that single value to every collector — so two same-family collectors
+    could not each bind their own source (wrong/failed dial), and the
+    health surfaces could not identify which source-bound connection
+    failed. FIX: add FlowServer.SourceAddress (per-collector); the compiler
+    stores each nested value on its FlowServer and keeps the output-level
+    `source-address` as the per-family default; the flowexport resolver
+    (collectInstanceVersionCollectors) computes the EFFECTIVE bind per
+    collector (nested override else family default else inline-jflow
+    default). Surface the resolved source: collectorConn.srcAddr +
+    CollectorHealth.SourceAddress (json source_address), CLI/gRPC
+    `show flow-monitoring statistics` `... source <src>`, the config-view
+    collector lines, and a new `source` label on the
+    xpf_flow_export_collector_* Prometheus metrics. Default (no source)
+    behavior unchanged. VALIDATION: RED-on-revert proven by temporarily
+    reverting the manager resolver (both collectors -> "" ) and the
+    compiler collapse (192.168.1.200 LWW overwrote .100 -> RED), then
+    restored. go test -count=1 ./pkg/config/... ./pkg/flowexport/...
+    ./pkg/api/... ./pkg/cli/... ./pkg/grpcapi/... all green; go build ./...
+    green; gofmt clean; vet clean (the one cli.go:503 unreachable-code
+    warning is pre-existing on origin/master, untouched file).
+  - **File(s)**: pkg/config/types_system.go (FlowServer.SourceAddress +
+    SamplingFamily doc), pkg/config/compiler_services.go (per-collector
+    store + output-level default), pkg/flowexport/manager.go (effective
+    per-collector source resolution), pkg/flowexport/transport.go
+    (collectorConn.srcAddr + CollectorHealth.SourceAddress + health()),
+    pkg/cli/cli_show_flow.go, pkg/cli/cli_show_routing.go,
+    pkg/grpcapi/server_show_flow.go, pkg/grpcapi/server_show_forwarding.go
+    (surfaces), pkg/api/metrics_system.go + metrics_descriptors.go (source
+    label), pkg/config/compiler_sampling_source_address_test.go +
+    pkg/config/parser_security_test.go (updated semantics + RED test),
+    pkg/flowexport/per_collector_source_3745_test.go (new RED-on-revert),
+    docs/config-schema.md, docs/feature-coverage.md,
+    pkg/flowexport/README.md (docs)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2658,16 +2658,27 @@ the value sits in a single typed slot:
     (#2605) — the **output-level** flow-export source-address: the standard
     Junos hierarchy where `source-address` is a sibling of `flow-server`
     directly under `output { ... }` (not nested inside a flow-server). It is
-    the per-output default that every flow-server in that family inherits.
-    A `source-address` nested INSIDE an individual flow-server is the
-    per-collector override and **wins** over the output-level default
-    (more-specific precedence); both resolve into the single per-family
-    `SamplingFamily.SourceAddress`, which `pkg/flowexport` applies as the
-    local bind address of every collector in that family. The output-level
-    value also seeds `inline-jflow`'s source when inline-jflow sets none. The
-    output-level form was previously dropped silently (no compile error and no
-    completion entry) — `compileSamplingFamily` only read the
-    flow-server-nested / inline-jflow-nested forms before #2605.
+    the per-output default that every flow-server in that family inherits and
+    is stored on the per-family `SamplingFamily.SourceAddress`. The
+    output-level value also seeds `inline-jflow`'s source when inline-jflow
+    sets none. The output-level form was previously dropped silently (no
+    compile error and no completion entry) — `compileSamplingFamily` only
+    read the flow-server-nested / inline-jflow-nested forms before #2605.
+  - `forwarding-options sampling … output flow-server <addr> source-address
+    <src>` (#3745) — the **per-collector** override, nested inside an
+    individual flow-server. It is stored PER COLLECTOR on
+    `FlowServer.SourceAddress` and **wins** over the output-level default
+    for THAT collector only. `pkg/flowexport` resolves the effective bind
+    per collector (`collectInstanceVersionCollectors`: nested override else
+    the family default else the inline-jflow default), so two collectors of
+    the same family can each pin their own source. Before #3745 the nested
+    value was collapsed into the single family-wide
+    `SamplingFamily.SourceAddress` (last-writer-wins across servers of the
+    same family), so a second same-family collector could not bind its own
+    configured source and dialed with the wrong bind. The resolved
+    per-collector source is surfaced in the health surfaces (CLI `... source
+    <src>`, REST `source_address`, and the `source` label on the
+    `xpf_flow_export_collector_*` Prometheus metrics).
   - `forwarding-options allow-dataplane-sleep` (#2008 H13 Stage 1) — a
     presence-only flag (no value, `children: nil`). Previously accepted via the
     no-schema-match fall-through and silently dropped; now a typed leaf that

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -141,6 +141,15 @@ the userspace dataplane admission boundary is in
   (`show flow-monitoring statistics`, REST `/api/v1/services/flow-exporters`,
   `xpf_flow_export_collector_*` Prometheus metrics — a collector going
   unreachable surfaces write_failures + a state-change warn, #2464).
+  Per-collector source-address bind: a `flow-server <addr> {
+  source-address <src>; }` pins THAT collector's local bind independently,
+  so two collectors of the same family can each dial with their own
+  source; a bare `source-address` under `output` is the per-output
+  default every flow-server inherits. The effective source is resolved
+  per collector, not collapsed to one family-wide value (#3745), and is
+  surfaced in every health surface (`... source <src>` in the CLI,
+  `source_address` in the REST JSON, and the `source` label on the
+  `xpf_flow_export_collector_*` metrics).
 - **Prometheus metrics** (`/metrics` endpoint).
 - **SNMP**: system + ifTable MIB.
 - **RPM probes**, dynamic address feeds.

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1726,27 +1726,27 @@ func newCollector(srv *Server) *xpfCollector {
 		flowExportCollectorWriteAttemptsTotal: prometheus.NewDesc(
 			"xpf_flow_export_collector_write_attempts_total",
 			"Total NetFlow v9 / IPFIX UDP write attempts per collector.",
-			[]string{"protocol", "collector"}, nil,
+			[]string{"protocol", "collector", "source"}, nil,
 		),
 		flowExportCollectorWriteFailuresTotal: prometheus.NewDesc(
 			"xpf_flow_export_collector_write_failures_total",
 			"Total NetFlow v9 / IPFIX UDP write failures per collector (a climbing value while attempts climb means the collector is unreachable and flow records are being silently dropped).",
-			[]string{"protocol", "collector"}, nil,
+			[]string{"protocol", "collector", "source"}, nil,
 		),
 		flowExportCollectorHealthy: prometheus.NewDesc(
 			"xpf_flow_export_collector_healthy",
 			"1 when the last write to this flow-export collector succeeded, 0 when the last write failed.",
-			[]string{"protocol", "collector"}, nil,
+			[]string{"protocol", "collector", "source"}, nil,
 		),
 		flowExportCollectorLastSuccessSeconds: prometheus.NewDesc(
 			"xpf_flow_export_collector_last_success_timestamp_seconds",
 			"Unix timestamp of the last successful write to this flow-export collector (0 if none yet).",
-			[]string{"protocol", "collector"}, nil,
+			[]string{"protocol", "collector", "source"}, nil,
 		),
 		flowExportCollectorLastFailureSeconds: prometheus.NewDesc(
 			"xpf_flow_export_collector_last_failure_timestamp_seconds",
 			"Unix timestamp of the last failed write to this flow-export collector (0 if none yet).",
-			[]string{"protocol", "collector"}, nil,
+			[]string{"protocol", "collector", "source"}, nil,
 		),
 	}
 }

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -126,34 +126,38 @@ func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
 // protocol {netflow-v9,ipfix} and the collector address — both bounded
 // (one series per configured flow-server). These counters make a
 // silently-unreachable collector observable: write_failures climbs while
-// write_attempts climbs, healthy drops to 0, and last_success ages.
+// write_attempts climbs, healthy drops to 0, and last_success ages. The
+// source label carries the per-collector local bind address (#3745), so
+// two same-family collectors that bind distinct sources are distinct
+// series and a source-bound failure is attributable; it is "" when the OS
+// selected the source.
 func (c *xpfCollector) collectFlowExportMetrics(ch chan<- prometheus.Metric) {
 	if c.srv.flowCollectorHealthFn == nil {
 		return
 	}
 	for _, h := range c.srv.flowCollectorHealthFn() {
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorWriteAttemptsTotal,
-			prometheus.CounterValue, float64(h.WriteAttempts), h.Protocol, h.Address)
+			prometheus.CounterValue, float64(h.WriteAttempts), h.Protocol, h.Address, h.SourceAddress)
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorWriteFailuresTotal,
-			prometheus.CounterValue, float64(h.WriteFailures), h.Protocol, h.Address)
+			prometheus.CounterValue, float64(h.WriteFailures), h.Protocol, h.Address, h.SourceAddress)
 		healthy := 0.0
 		if h.Healthy {
 			healthy = 1
 		}
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorHealthy,
-			prometheus.GaugeValue, healthy, h.Protocol, h.Address)
+			prometheus.GaugeValue, healthy, h.Protocol, h.Address, h.SourceAddress)
 		var lastSuccess float64
 		if !h.LastSuccessTime.IsZero() {
 			lastSuccess = float64(h.LastSuccessTime.Unix())
 		}
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorLastSuccessSeconds,
-			prometheus.GaugeValue, lastSuccess, h.Protocol, h.Address)
+			prometheus.GaugeValue, lastSuccess, h.Protocol, h.Address, h.SourceAddress)
 		var lastFailure float64
 		if !h.LastFailureTime.IsZero() {
 			lastFailure = float64(h.LastFailureTime.Unix())
 		}
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorLastFailureSeconds,
-			prometheus.GaugeValue, lastFailure, h.Protocol, h.Address)
+			prometheus.GaugeValue, lastFailure, h.Protocol, h.Address, h.SourceAddress)
 	}
 }
 

--- a/pkg/cli/cli_show_flow.go
+++ b/pkg/cli/cli_show_flow.go
@@ -1166,7 +1166,14 @@ func (c *CLI) showFlowMonitoring() error {
 					} else if fs.VersionIPFIXTemplate != "" {
 						tmplStr = fmt.Sprintf(" (ipfix template: %s)", fs.VersionIPFIXTemplate)
 					}
-					fmt.Printf("    Collector: %s%s%s\n", fs.Address, portStr, tmplStr)
+					// Per-collector source-address override (#3745): the
+					// effective bind is this value when set, else the
+					// family output-level default shown above.
+					srcStr := ""
+					if fs.SourceAddress != "" {
+						srcStr = fmt.Sprintf(" source %s", fs.SourceAddress)
+					}
+					fmt.Printf("    Collector: %s%s%s%s\n", fs.Address, portStr, srcStr, tmplStr)
 				}
 			}
 			showSamplingFamily("inet", inst.FamilyInet)
@@ -1206,6 +1213,9 @@ func (c *CLI) showFlowMonitoringStatistics() error {
 			state = "DOWN"
 		}
 		line := fmt.Sprintf("  Collector %s (%s)", h.Address, h.Protocol)
+		if h.SourceAddress != "" {
+			line += fmt.Sprintf(" source %s", h.SourceAddress)
+		}
 		if h.Instance != "" {
 			line += fmt.Sprintf(" instance %s", h.Instance)
 		}

--- a/pkg/cli/cli_show_routing.go
+++ b/pkg/cli/cli_show_routing.go
@@ -1080,6 +1080,10 @@ func (c *CLI) showForwardingOptions() error {
 					if fs.VersionIPFIXTemplate != "" {
 						fmt.Printf("      IPFIX template: %s\n", fs.VersionIPFIXTemplate)
 					}
+					// Per-collector source-address override (#3745).
+					if fs.SourceAddress != "" {
+						fmt.Printf("      Source address: %s\n", fs.SourceAddress)
+					}
 				}
 				if fam.SourceAddress != "" {
 					fmt.Printf("    Source address: %s\n", fam.SourceAddress)

--- a/pkg/config/compiler_sampling_source_address_test.go
+++ b/pkg/config/compiler_sampling_source_address_test.go
@@ -2,16 +2,18 @@ package config
 
 import "testing"
 
-// #2605: in Junos/vSRX the flow-export `source-address` lives directly
-// under `forwarding-options sampling family <af> output` (a sibling of
-// flow-server) — the standard hierarchy. compileSamplingFamily
-// previously only read `source-address` NESTED inside an individual
-// flow-server (and inside inline-jflow), so an output-level
-// source-address was silently dropped (no compile error). These tests
-// drive the production flat-set path (ParseSetCommand + SetPath via
-// buildTree, never NewParser per CLAUDE.md) and assert the precedence:
-// a flow-server-nested source-address (more specific) wins over the
-// output-level default; the output-level value is the fallback.
+// #2605 + #3745: in Junos/vSRX the flow-export `source-address` lives at
+// TWO hierarchies under `forwarding-options sampling family <af> output`:
+// directly under `output` (a sibling of flow-server — the per-output
+// default, #2605) and nested inside an individual flow-server (the
+// per-collector override, #3745). These tests drive the production
+// flat-set path (ParseSetCommand + SetPath via buildTree, never
+// NewParser per CLAUDE.md) and assert that the output-level default is
+// recorded on SamplingFamily.SourceAddress while each nested override is
+// recorded PER COLLECTOR on FlowServer.SourceAddress — NOT collapsed into
+// one family-wide value (the pre-#3745 last-writer-wins bug). The
+// effective per-collector bind (nested override else family default) is
+// resolved in the flowexport manager (collectInstanceVersionCollectors).
 
 // sampleFamilyInet compiles the given set lines and returns the inet
 // SamplingFamily for instance "i1", failing the test if any layer is
@@ -55,32 +57,48 @@ func TestSamplingOutputLevelSourceAddress(t *testing.T) {
 	}
 }
 
-// TestSamplingFlowServerSourceAddressStillWorks confirms the legacy
-// flow-server-nested source-address path is unchanged.
+// TestSamplingFlowServerSourceAddressStillWorks confirms the
+// flow-server-nested source-address is tracked PER COLLECTOR on the
+// FlowServer (#3745), not collapsed into the family-wide default. With
+// only a nested source configured, the family default stays empty and
+// the per-collector FlowServer.SourceAddress carries the value.
 func TestSamplingFlowServerSourceAddressStillWorks(t *testing.T) {
 	fam := sampleFamilyInet(t, []string{
 		"set forwarding-options sampling instance i1 input rate 100",
 		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.100 port 2055",
 		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.100 source-address 10.0.0.2",
 	})
-	if fam.SourceAddress != "10.0.0.2" {
-		t.Errorf("flow-server-nested source-address: got %q, want 10.0.0.2", fam.SourceAddress)
+	if len(fam.FlowServers) != 1 {
+		t.Fatalf("expected one flow-server, got %+v", fam.FlowServers)
+	}
+	if fam.FlowServers[0].SourceAddress != "10.0.0.2" {
+		t.Errorf("per-collector flow-server source-address: got %q, want 10.0.0.2", fam.FlowServers[0].SourceAddress)
+	}
+	// The output-level family default is untouched by a nested source.
+	if fam.SourceAddress != "" {
+		t.Errorf("family default source-address: got %q, want empty (nested source must not collapse into it)", fam.SourceAddress)
 	}
 }
 
 // TestSamplingNestedSourceAddressWinsOverOutputDefault asserts the
 // precedence decision: when BOTH an output-level default and a
-// flow-server-nested source-address are present, the more-specific
-// flow-server-nested value wins. The assertion is order-independent —
-// the output-level line is intentionally placed AFTER the nested line.
+// flow-server-nested source-address are present, the family default is
+// recorded on SamplingFamily.SourceAddress and the more-specific nested
+// override is recorded on FlowServer.SourceAddress (#3745). The effective
+// per-collector bind (nested-wins) is resolved in the flowexport manager.
+// The assertion is order-independent — the output-level line is placed
+// AFTER the nested line on purpose.
 func TestSamplingNestedSourceAddressWinsOverOutputDefault(t *testing.T) {
 	fam := sampleFamilyInet(t, []string{
 		"set forwarding-options sampling instance i1 input rate 100",
 		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.100 source-address 10.0.0.2",
 		"set forwarding-options sampling instance i1 family inet output source-address 10.0.0.1",
 	})
-	if fam.SourceAddress != "10.0.0.2" {
-		t.Errorf("nested-wins-over-output-default: got %q, want 10.0.0.2", fam.SourceAddress)
+	if fam.SourceAddress != "10.0.0.1" {
+		t.Errorf("output-level family default: got %q, want 10.0.0.1", fam.SourceAddress)
+	}
+	if len(fam.FlowServers) != 1 || fam.FlowServers[0].SourceAddress != "10.0.0.2" {
+		t.Errorf("per-collector nested override: got %+v, want SourceAddress 10.0.0.2", fam.FlowServers)
 	}
 }
 
@@ -129,5 +147,45 @@ func TestSamplingOutputLevelSourceAddressFeedsInlineJflow(t *testing.T) {
 	})
 	if fam2.InlineJflowSourceAddress != "10.0.0.9" {
 		t.Errorf("explicit inline-jflow source-address must win: got %q, want 10.0.0.9", fam2.InlineJflowSourceAddress)
+	}
+}
+
+// TestSamplingPerCollectorSourceAddressNotCollapsed is the #3745
+// fix-confirming RED-on-revert test: two flow-servers of the SAME family,
+// each carrying its OWN nested source-address, must each retain its own
+// source on FlowServer.SourceAddress. Before #3745 the compiler collapsed
+// both nested sources into a single family-wide SamplingFamily.SourceAddress
+// (last-writer-wins by AST order), so both collectors bound the last source.
+//
+// RED-on-revert: reverting compiler_services.go to write flowServerSrc
+// (one string) instead of per-collector fs.SourceAddress makes the two
+// FlowServer.SourceAddress values identical (empty, with the family value
+// holding the last source) and this test fails.
+func TestSamplingPerCollectorSourceAddressNotCollapsed(t *testing.T) {
+	fam := sampleFamilyInet(t, []string{
+		"set forwarding-options sampling instance i1 input rate 100",
+		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.100 port 2055",
+		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.100 source-address 10.0.0.2",
+		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.200 port 2055",
+		"set forwarding-options sampling instance i1 family inet output flow-server 192.168.1.200 source-address 10.0.0.3",
+	})
+	if len(fam.FlowServers) != 2 {
+		t.Fatalf("expected two flow-servers, got %d: %+v", len(fam.FlowServers), fam.FlowServers)
+	}
+	// Index by collector address so the assertion is AST-order-independent.
+	got := map[string]string{}
+	for _, fs := range fam.FlowServers {
+		got[fs.Address] = fs.SourceAddress
+	}
+	if got["192.168.1.100"] != "10.0.0.2" {
+		t.Errorf("collector 192.168.1.100 source: got %q, want 10.0.0.2 (collapsed to family LWW before #3745)", got["192.168.1.100"])
+	}
+	if got["192.168.1.200"] != "10.0.0.3" {
+		t.Errorf("collector 192.168.1.200 source: got %q, want 10.0.0.3 (collapsed to family LWW before #3745)", got["192.168.1.200"])
+	}
+	// The family-wide default must stay empty — neither nested source
+	// leaked into it.
+	if fam.SourceAddress != "" {
+		t.Errorf("family default source-address: got %q, want empty (per-collector sources must not collapse into it)", fam.SourceAddress)
 	}
 }

--- a/pkg/config/compiler_services.go
+++ b/pkg/config/compiler_services.go
@@ -1391,17 +1391,20 @@ func compileSamplingFamily(node *Node) *SamplingFamily {
 		return sf
 	}
 
-	// Precedence for the per-family flow-server source-address.
-	// Junos accepts `source-address` at TWO hierarchies under
-	// `output`: directly under `output` (the per-output default that
-	// every flow-server inherits) and nested inside an individual
-	// flow-server (the per-collector override). SamplingFamily carries
-	// ONE per-family SourceAddress (manager.go applies fam.SourceAddress
-	// to every collector), so we resolve precedence here: a
-	// flow-server-nested source-address wins over the output-level
-	// default. Tracked separately so the result is independent of the
-	// order the children appear in the AST (#2605).
-	var outputLevelSrc, flowServerSrc string
+	// Junos accepts `source-address` at TWO hierarchies under `output`:
+	// directly under `output` (the per-output default that every
+	// flow-server inherits) and nested inside an individual flow-server
+	// (the per-collector override). The output-level default is tracked
+	// here and stored as the family-wide SamplingFamily.SourceAddress
+	// (#2605); each flow-server-nested value is tracked PER COLLECTOR on
+	// FlowServer.SourceAddress (#3745) so multiple collectors of the same
+	// family each keep their own source. The effective per-collector bind
+	// (nested override else family default) is resolved in the flowexport
+	// manager, not collapsed to one family-wide value here. Before #3745
+	// the nested value overwrote a single family-wide string
+	// (last-writer-wins across servers), so two collectors with distinct
+	// nested sources both bound the last one in AST order.
+	var outputLevelSrc string
 
 	for _, child := range outputNode.Children {
 		switch child.Name() {
@@ -1457,9 +1460,12 @@ func compileSamplingFamily(node *Node) *SamplingFamily {
 							}
 						}
 					case "source-address":
-						// Per-collector override (flow-server-nested);
-						// wins over the output-level default below.
-						flowServerSrc = nodeVal(prop)
+						// Per-collector override (flow-server-nested).
+						// Stored PER COLLECTOR (#3745) so multiple
+						// flow-servers of the same family each keep their
+						// own source; the manager resolves the effective
+						// bind (this override else the family default).
+						fs.SourceAddress = nodeVal(prop)
 					}
 				}
 				sf.FlowServers = append(sf.FlowServers, fs)
@@ -1478,12 +1484,12 @@ func compileSamplingFamily(node *Node) *SamplingFamily {
 		}
 	}
 
-	// Resolve the flow-server source-address precedence: a
-	// flow-server-nested value (more specific) wins over the
-	// output-level default; the output-level value is the fallback.
-	if flowServerSrc != "" {
-		sf.SourceAddress = flowServerSrc
-	} else if outputLevelSrc != "" {
+	// The output-level source-address is the family-wide default bind
+	// (the per-output default every flow-server inherits). Per-collector
+	// nested overrides live on FlowServer.SourceAddress; the flowexport
+	// manager computes the effective bind per collector (nested override
+	// else this default). #2605 (output-level) + #3745 (per-collector).
+	if outputLevelSrc != "" {
 		sf.SourceAddress = outputLevelSrc
 	}
 

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -918,8 +918,12 @@ forwarding-options {
 	if !inst.FamilyInet.InlineJflow {
 		t.Error("expected inline-jflow for inet")
 	}
-	if inst.FamilyInet.SourceAddress != "192.168.99.1" {
-		t.Errorf("source-address: got %q, want 192.168.99.1", inst.FamilyInet.SourceAddress)
+	// #3745: a flow-server-nested source-address is tracked PER COLLECTOR
+	// on the FlowServer, not collapsed into the family-wide default. The
+	// family default stays empty (no output-level source configured here);
+	// the nested value is asserted on the flow-server below.
+	if inst.FamilyInet.SourceAddress != "" {
+		t.Errorf("family source-address: got %q, want empty (nested source must not collapse into it)", inst.FamilyInet.SourceAddress)
 	}
 	if len(inst.FamilyInet.FlowServers) != 1 {
 		t.Fatalf("expected 1 flow server for inet, got %d", len(inst.FamilyInet.FlowServers))
@@ -930,6 +934,11 @@ forwarding-options {
 	}
 	if fs.Port != 4739 {
 		t.Errorf("flow-server port: got %d", fs.Port)
+	}
+	// #3745: the flow-server-nested source-address is recorded on the
+	// per-collector FlowServer, not the family-wide SamplingFamily.
+	if fs.SourceAddress != "192.168.99.1" {
+		t.Errorf("flow-server source-address: got %q, want 192.168.99.1", fs.SourceAddress)
 	}
 	if fs.Version9Template != "v9-tmpl" {
 		t.Errorf("flow-server template: got %q", fs.Version9Template)

--- a/pkg/config/types_system.go
+++ b/pkg/config/types_system.go
@@ -879,6 +879,18 @@ type SamplingInstance struct {
 }
 
 // SamplingFamily holds per-AF sampling output configuration.
+//
+// SourceAddress is the OUTPUT-LEVEL default source-address (the
+// `source-address` sibling of `flow-server` under `output { ... }`) —
+// the per-output default every flow-server inherits when it declares no
+// nested source of its own. It is NOT the resolved per-collector bind:
+// a flow-server-nested `source-address` (FlowServer.SourceAddress) is a
+// per-collector override that wins over this default, and the effective
+// bind is computed PER COLLECTOR in the flowexport resolver
+// (collectInstanceVersionCollectors), not collapsed to one family-wide
+// value. Before #3745 the nested source was collapsed into this single
+// field (last-writer-wins across servers of the same family), so two
+// collectors with distinct nested sources both bound the last one.
 type SamplingFamily struct {
 	FlowServers              []*FlowServer
 	SourceAddress            string
@@ -909,6 +921,16 @@ type FlowServer struct {
 	Version              string // "version9" | "version-ipfix" | "" (unbound)
 	Version9Template     string
 	VersionIPFIXTemplate string
+	// SourceAddress is the per-collector local bind address configured as
+	// `flow-server <addr> { source-address <src>; }` (#3745). It is the
+	// per-collector OVERRIDE of the output-level default
+	// (SamplingFamily.SourceAddress): the flowexport resolver binds THIS
+	// collector's socket to this source when set, else falls back to the
+	// family default. Empty ("") means inherit the family/output default.
+	// Before #3745 this value was collapsed into the one family-wide
+	// SamplingFamily.SourceAddress (last-writer-wins), so a second
+	// collector could not bind its own configured source.
+	SourceAddress string
 }
 
 // Flow-server per-collector export version selectors (FlowServer.Version).

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -276,11 +276,14 @@ The package is split by responsibility (#1988):
 - `transport.go` — shared collector connection management
   (`collectorConns`: dial / fan-out write / close) and the per-family
   batch accumulator (`flowBatch`) used by both exporters. `dialCollectors`
-  surfaces any `SourceAddress`/destination resolve error (a misconfigured
-  source-address is never silently dropped to an OS-chosen bind) and, on
-  any mid-loop resolve or dial failure, closes the connections opened
-  earlier in the loop before returning — no descriptor leak on partial
-  failure.
+  binds each connection to its per-collector `CollectorConfig.SourceAddress`
+  (the resolved bind — #3745), surfaces any `SourceAddress`/destination
+  resolve error (a misconfigured source-address is never silently dropped
+  to an OS-chosen bind) and, on any mid-loop resolve or dial failure,
+  closes the connections opened earlier in the loop before returning — no
+  descriptor leak on partial failure. Each `collectorConn` records its
+  `srcAddr` so the health snapshot can attribute a failure to the specific
+  source-bound connection.
 
 ## Header sequence number — v9 vs IPFIX (#2609)
 
@@ -309,9 +312,12 @@ used to be invisible — every failed UDP write in `writeAll` was
 `slog.Debug`-logged and dropped while the exporter kept counting
 "exported", so an operator got no warning that records were being lost.
 Each `collectorConn` now tracks `WriteAttempts`, `WriteFailures`,
-`LastError`/`LastErrorTime`, `LastFailureTime`, `LastSuccessTime`, and a
-`Healthy` flag (atomic counters + a mutex-guarded snapshot, race-safe
-against a concurrent status reader). The export DATA path is unchanged:
+`LastError`/`LastErrorTime`, `LastFailureTime`, `LastSuccessTime`, a
+`Healthy` flag, and the `SourceAddress` (local bind) the connection was
+dialed with (#3745 — so two same-family collectors that pin distinct
+sources are distinguishable in every surface). These are atomic counters
+plus a mutex-guarded snapshot, race-safe against a concurrent status
+reader. The export DATA path is unchanged:
 writes are still attempted to every collector and failures are still
 non-fatal — this is additive observability.
 
@@ -329,12 +335,16 @@ The snapshot is surfaced through `Exporter.CollectorHealth()` /
 `ExporterCollectorHealth`) on four surfaces:
 - **Prometheus** — `xpf_flow_export_collector_{write_attempts_total,
   write_failures_total,healthy,last_success_timestamp_seconds,
-  last_failure_timestamp_seconds}`, labeled `{protocol,collector}`
-  (emitted before the dataplane gate — exporters are control-plane).
-- **REST** — `GET /api/v1/services/flow-exporters`.
+  last_failure_timestamp_seconds}`, labeled `{protocol,collector,source}`
+  (the `source` label carries the per-collector local bind — #3745 — and
+  is `""` when the OS selected it; emitted before the dataplane gate —
+  exporters are control-plane).
+- **REST** — `GET /api/v1/services/flow-exporters` (the JSON carries
+  `source_address`, omitted when empty).
 - **gRPC / CLI show** — `show flow-monitoring statistics` (gRPC ShowText
   topic `flow-monitoring-statistics`; both the remote `cli` binary and
-  the in-daemon interactive CLI).
+  the in-daemon interactive CLI) — the collector line prints
+  `... source <src>` for a source-bound collector (#3745).
 
 ## Entry points
 

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -205,7 +205,18 @@ func collectInstanceVersionCollectors(inst *config.SamplingInstance, version str
 				// IPv6 flow collectors never dial (#2183).
 				addr = net.JoinHostPort(fs.Address, strconv.Itoa(fs.Port))
 			}
-			srcAddr := fam.SourceAddress
+			// Effective per-collector source-address (#3745): a
+			// flow-server-nested source-address (fs.SourceAddress) is the
+			// per-collector override and wins; else the family output-level
+			// default (fam.SourceAddress); else the inline-jflow default.
+			// Resolving here — instead of applying one family-wide value to
+			// every collector — lets two same-family collectors each bind
+			// their own configured source (the pre-#3745 last-writer-wins
+			// bug bound all collectors to the last nested source).
+			srcAddr := fs.SourceAddress
+			if srcAddr == "" {
+				srcAddr = fam.SourceAddress
+			}
 			if srcAddr == "" {
 				srcAddr = fam.InlineJflowSourceAddress
 			}

--- a/pkg/flowexport/per_collector_source_3745_test.go
+++ b/pkg/flowexport/per_collector_source_3745_test.go
@@ -1,0 +1,139 @@
+package flowexport
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestBuildExportConfig_PerCollectorSourceAddress is the #3745
+// fix-confirming RED-on-revert test at the flowexport resolver level: two
+// flow-servers of the SAME family, each carrying its own per-collector
+// FlowServer.SourceAddress, must each dial with its OWN configured source
+// bind. Before #3745 the compiler collapsed the two nested sources into
+// one family-wide SamplingFamily.SourceAddress (last-writer-wins) and the
+// resolver applied that single value to every collector, so both
+// collectors bound the same (last) source — a wrong / failed dial for the
+// first collector.
+//
+// RED-on-revert: reverting collectInstanceVersionCollectors to
+// `srcAddr := fam.SourceAddress` (ignoring fs.SourceAddress) makes both
+// collectors carry the same source (empty here, since the per-collector
+// values live only on the FlowServer) and this test fails.
+func TestBuildExportConfig_PerCollectorSourceAddress(t *testing.T) {
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"test": {
+					Name: "test",
+					FamilyInet: &config.SamplingFamily{
+						FlowServers: []*config.FlowServer{
+							{Address: "10.0.0.100", Port: 2055, SourceAddress: "10.0.0.2"},
+							{Address: "10.0.0.200", Port: 2055, SourceAddress: "10.0.0.3"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ec := BuildExportConfig(v9Svc(), fo)
+	if ec == nil {
+		t.Fatal("expected non-nil ExportConfig")
+	}
+	if len(ec.Collectors) != 2 {
+		t.Fatalf("expected 2 collectors, got %d: %+v", len(ec.Collectors), ec.Collectors)
+	}
+	// Index the resolved collectors by destination so the assertion is
+	// order-independent.
+	got := map[string]string{}
+	for _, c := range ec.Collectors {
+		got[c.Address] = c.SourceAddress
+	}
+	if got["10.0.0.100:2055"] != "10.0.0.2" {
+		t.Errorf("collector 10.0.0.100 source = %q, want 10.0.0.2 (collapsed to family LWW before #3745)", got["10.0.0.100:2055"])
+	}
+	if got["10.0.0.200:2055"] != "10.0.0.3" {
+		t.Errorf("collector 10.0.0.200 source = %q, want 10.0.0.3 (collapsed to family LWW before #3745)", got["10.0.0.200:2055"])
+	}
+}
+
+// TestBuildExportConfig_PerCollectorSourceOverridesFamilyDefault confirms
+// the precedence in the resolver: a per-collector FlowServer.SourceAddress
+// overrides the family output-level default, while a flow-server WITHOUT a
+// nested source inherits the family default (#3745). This proves the
+// default (no per-collector source) path is unchanged.
+func TestBuildExportConfig_PerCollectorSourceOverridesFamilyDefault(t *testing.T) {
+	fo := &config.ForwardingOptionsConfig{
+		Sampling: &config.SamplingConfig{
+			Instances: map[string]*config.SamplingInstance{
+				"test": {
+					Name: "test",
+					FamilyInet: &config.SamplingFamily{
+						// Family output-level default bind.
+						SourceAddress: "10.0.0.1",
+						FlowServers: []*config.FlowServer{
+							// Overrides the family default.
+							{Address: "10.0.0.100", Port: 2055, SourceAddress: "10.0.0.9"},
+							// No nested source -> inherits the family default.
+							{Address: "10.0.0.200", Port: 2055},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ec := BuildExportConfig(v9Svc(), fo)
+	if ec == nil {
+		t.Fatal("expected non-nil ExportConfig")
+	}
+	got := map[string]string{}
+	for _, c := range ec.Collectors {
+		got[c.Address] = c.SourceAddress
+	}
+	if got["10.0.0.100:2055"] != "10.0.0.9" {
+		t.Errorf("overriding collector source = %q, want 10.0.0.9", got["10.0.0.100:2055"])
+	}
+	if got["10.0.0.200:2055"] != "10.0.0.1" {
+		t.Errorf("inheriting collector source = %q, want family default 10.0.0.1", got["10.0.0.200:2055"])
+	}
+}
+
+// TestCollectorHealth_ExposesSourceAddress proves the per-collector source
+// bind is surfaced in the write-health snapshot (#3745): dialCollectors
+// records each connection's source bind and health() returns it in
+// CollectorHealth.SourceAddress, so the CLI / REST / Prometheus surfaces
+// can identify which source-bound connection failed.
+//
+// RED-on-revert: dropping the srcAddr plumbing (collectorConn.srcAddr or
+// the CollectorHealth.SourceAddress assignment in health()) makes the
+// returned SourceAddress empty and this test fails.
+func TestCollectorHealth_ExposesSourceAddress(t *testing.T) {
+	// dialCollectors dials real UDP sockets; a source bind to a loopback
+	// address the kernel owns resolves and dials without any collector
+	// being up (UDP connect does not handshake).
+	cc, err := dialCollectors([]CollectorConfig{
+		{Address: "127.0.0.1:2055", SourceAddress: "127.0.0.1"},
+		{Address: "127.0.0.1:2056"}, // no source -> OS-selected
+	})
+	if err != nil {
+		t.Fatalf("dialCollectors: %v", err)
+	}
+	defer cc.close()
+
+	h := cc.health()
+	if len(h) != 2 {
+		t.Fatalf("expected 2 health entries, got %d", len(h))
+	}
+	got := map[string]string{}
+	for _, e := range h {
+		got[e.Address] = e.SourceAddress
+	}
+	if got["127.0.0.1:2055"] != "127.0.0.1" {
+		t.Errorf("source-bound collector health source = %q, want 127.0.0.1", got["127.0.0.1:2055"])
+	}
+	if got["127.0.0.1:2056"] != "" {
+		t.Errorf("auto-source collector health source = %q, want empty", got["127.0.0.1:2056"])
+	}
+}

--- a/pkg/flowexport/transport.go
+++ b/pkg/flowexport/transport.go
@@ -25,6 +25,11 @@ import (
 type collectorConn struct {
 	conn net.Conn
 	addr string
+	// srcAddr is the local bind (source) address this connection was
+	// dialed with ("" = OS-selected). Surfaced in the health snapshot so
+	// an operator can tell which source-bound connection failed when two
+	// same-family collectors bind distinct sources (#3745).
+	srcAddr string
 
 	attempts atomic.Uint64
 	failures atomic.Uint64
@@ -61,7 +66,13 @@ type ExporterCollectorHealth struct {
 // state, returned by collectorConns.health() and surfaced through the
 // status response, Prometheus metrics, and the show command (#2464).
 type CollectorHealth struct {
-	Address         string    `json:"address"`
+	Address string `json:"address"`
+	// SourceAddress is the local bind (source) address this collector's
+	// connection was dialed with; empty when the OS selected it. It
+	// disambiguates two same-family collectors that bind distinct
+	// sources (#3745) so a source-bound connection failure is
+	// identifiable in the CLI / REST / Prometheus surfaces.
+	SourceAddress   string    `json:"source_address,omitempty"`
 	WriteAttempts   uint64    `json:"write_attempts"`
 	WriteFailures   uint64    `json:"write_failures"`
 	Healthy         bool      `json:"healthy"`
@@ -134,7 +145,7 @@ func dialCollectors(collectors []CollectorConfig) (*collectorConns, error) {
 		}
 		// A collector starts healthy (optimistic) so the FIRST failed write
 		// is the unhealthy edge that warns (#2464).
-		cc.conns = append(cc.conns, &collectorConn{conn: conn, addr: c.Address, healthy: true})
+		cc.conns = append(cc.conns, &collectorConn{conn: conn, addr: c.Address, srcAddr: c.SourceAddress, healthy: true})
 	}
 	return cc, nil
 }
@@ -203,6 +214,7 @@ func (cc *collectorConns) health() []CollectorHealth {
 		c.mu.Lock()
 		out = append(out, CollectorHealth{
 			Address:         c.addr,
+			SourceAddress:   c.srcAddr,
 			WriteAttempts:   c.attempts.Load(),
 			WriteFailures:   c.failures.Load(),
 			Healthy:         c.healthy,

--- a/pkg/grpcapi/server_show_flow.go
+++ b/pkg/grpcapi/server_show_flow.go
@@ -65,6 +65,9 @@ func (s *Server) showFlowMonitoringStatistics(buf *strings.Builder) {
 			state = "DOWN"
 		}
 		fmt.Fprintf(buf, "  Collector %s (%s)", h.Address, h.Protocol)
+		if h.SourceAddress != "" {
+			fmt.Fprintf(buf, " source %s", h.SourceAddress)
+		}
 		if h.Instance != "" {
 			fmt.Fprintf(buf, " instance %s", h.Instance)
 		}

--- a/pkg/grpcapi/server_show_forwarding.go
+++ b/pkg/grpcapi/server_show_forwarding.go
@@ -118,6 +118,10 @@ func (s *Server) showForwardingOptions(cfg *config.Config, buf *strings.Builder)
 						if fs.Version9Template != "" {
 							fmt.Fprintf(buf, "      Version 9 template: %s\n", fs.Version9Template)
 						}
+						// Per-collector source-address override (#3745).
+						if fs.SourceAddress != "" {
+							fmt.Fprintf(buf, "      Source address: %s\n", fs.SourceAddress)
+						}
 					}
 					if fam.SourceAddress != "" {
 						fmt.Fprintf(buf, "    Source address: %s\n", fam.SourceAddress)


### PR DESCRIPTION
## Summary

Closes #3745.

A NetFlow/IPFIX `flow-server` carrying a nested `source-address` (the
per-collector local-bind override) was collapsed into ONE family-wide
value and applied to EVERY collector in that family. With two
flow-servers of the same family each declaring their own nested
source-address, the last one in AST order won and was bound to all
collectors, so a collector could dial with the wrong source bind
(failed dial, or wrong routing/ACL path). The health/status surfaces
also could not show which source-bound connection failed.

## Root cause

- `pkg/config/compiler_services.go` (`compileSamplingFamily`) accumulated
  every flow-server-nested `source-address` into a single `flowServerSrc`
  string and stored it as the per-family `SamplingFamily.SourceAddress`
  (last-writer-wins by AST order).
- `pkg/flowexport/manager.go` (`collectInstanceVersionCollectors`) applied
  that one `fam.SourceAddress` to every collector in the family.

## Fix

- Add `FlowServer.SourceAddress`. The compiler stores each nested
  `source-address` on its own `FlowServer` and keeps the output-level
  `source-address` (the standard Junos sibling of `flow-server` under
  `output`) as the per-family default on `SamplingFamily.SourceAddress`.
- `collectInstanceVersionCollectors` computes the EFFECTIVE bind PER
  collector: flow-server-nested override wins, else the family
  output-level default, else the inline-jflow default. Two same-family
  collectors now each bind their own configured source.
- Surface the resolved source everywhere:
  - `collectorConn.srcAddr` + `CollectorHealth.SourceAddress`
    (json `source_address`, omitempty) → REST is automatic.
  - CLI / gRPC `show flow-monitoring statistics`: `... source <src>`.
  - CLI / gRPC forwarding-config view: per-collector source line.
  - Prometheus `xpf_flow_export_collector_*` metrics gain a `source`
    label (`""` when OS-selected).

Default behavior (no source configured) is unchanged.

## Tests (RED-on-revert proven)

- Compiler: `TestSamplingPerCollectorSourceAddressNotCollapsed` — two
  same-family flow-servers with distinct nested sources each keep their
  own `FlowServer.SourceAddress`; RED on revert to the family-wide
  collapse (verified: `192.168.1.200` overwrote `192.168.1.100`).
- Manager: `TestBuildExportConfig_PerCollectorSourceAddress` /
  `...OverridesFamilyDefault` — each collector dials its own source; a
  no-nested-source flow-server inherits the family default. RED on revert
  to `srcAddr := fam.SourceAddress` (verified: both collectors → `""`).
- Health: `TestCollectorHealth_ExposesSourceAddress`.
- Updated the pre-existing `TestSamplingFlowServerSourceAddressStillWorks`,
  `TestSamplingNestedSourceAddressWinsOverOutputDefault`, and
  `TestFlowMonitoringConfig` to the new per-collector semantics.

`go test -count=1 ./pkg/config/... ./pkg/flowexport/... ./pkg/api/...
./pkg/cli/... ./pkg/grpcapi/...` all green; `go build ./...` green;
gofmt clean. (The lone `pkg/cli/cli.go:503` vet unreachable-code warning
pre-exists on origin/master in an untouched file.)

## Docs

`docs/config-schema.md` (per-collector vs output-level precedence),
`docs/feature-coverage.md`, `pkg/flowexport/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
