### PR TITLE
flowexport: label Prometheus collector metrics by instance+template (#3741)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26104,3 +26104,27 @@ top.
     pkg/flowexport/per_collector_source_3745_test.go (new RED-on-revert),
     docs/config-schema.md, docs/feature-coverage.md,
     pkg/flowexport/README.md (docs)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3741 — flowexport Prometheus collector metrics
+    under-labeled. The `xpf_flow_export_collector_*` family declared only
+    `{protocol, collector, source}` labels, but FlowCollectorHealth()
+    returns MULTIPLE health rows per (protocol, collector) pair — one per
+    template group, per family-disjoint sampling instance. Two such rows
+    collapsed onto an IDENTICAL labelset, so a PEDANTIC registry rejects
+    the duplicate series (scrape error) and a plain gather silently
+    collapses / hides the failing group. Added the `instance` + `template`
+    labels (ExporterCollectorHealth already carries them) to all five
+    descriptors AND the emission, giving each distinct group a unique
+    labelset. Label set is now `{protocol, instance, template, collector,
+    source}`. Two RED-on-revert tests: distinct-labelset-per-group (two
+    rows sharing protocol+collector+source but differing by
+    instance/template must gather without a duplicate error and both
+    groups' distinct values survive) and a descriptor↔emission label
+    canary (every sample carries exactly the five labels). Verified RED on
+    revert (duplicate-series Gather error + missing-label failures);
+    pkg/api go test green; go build ./... green; gofmt + vet clean.
+  - **File(s)**: pkg/api/metrics_descriptors.go (5 descriptor label
+    sets + doc), pkg/api/metrics_system.go (emission + collect doc),
+    pkg/api/metrics_flowexport_test.go (2 new RED-on-revert tests),
+    docs/feature-coverage.md (instance/template label doc)

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -149,7 +149,13 @@ the userspace dataplane admission boundary is in
   per collector, not collapsed to one family-wide value (#3745), and is
   surfaced in every health surface (`... source <src>` in the CLI,
   `source_address` in the REST JSON, and the `source` label on the
-  `xpf_flow_export_collector_*` metrics).
+  `xpf_flow_export_collector_*` metrics). The Prometheus family is also
+  labeled by `instance` and `template` (#3741): the daemon returns one
+  health row per template group / family-disjoint sampling instance, so
+  two groups that share a single collector address stay distinct series —
+  without those labels the rows collide on an identical `{protocol,
+  collector, source}` labelset and Prometheus either rejects the duplicate
+  (scrape error) or silently collapses the failing group.
 - **Prometheus metrics** (`/metrics` endpoint).
 - **SNMP**: system + ifTable MIB.
 - **RPM probes**, dynamic address feeds.

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1725,28 +1725,28 @@ func newCollector(srv *Server) *xpfCollector {
 		// #2464: per-collector flow-export write-health.
 		flowExportCollectorWriteAttemptsTotal: prometheus.NewDesc(
 			"xpf_flow_export_collector_write_attempts_total",
-			"Total NetFlow v9 / IPFIX UDP write attempts per collector.",
-			[]string{"protocol", "collector", "source"}, nil,
+			"Total NetFlow v9 / IPFIX UDP write attempts per collector. Labeled by instance and template as well as collector and source, so two template groups / family-disjoint instances that share one collector address stay distinct series (#3741).",
+			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
 		flowExportCollectorWriteFailuresTotal: prometheus.NewDesc(
 			"xpf_flow_export_collector_write_failures_total",
-			"Total NetFlow v9 / IPFIX UDP write failures per collector (a climbing value while attempts climb means the collector is unreachable and flow records are being silently dropped).",
-			[]string{"protocol", "collector", "source"}, nil,
+			"Total NetFlow v9 / IPFIX UDP write failures per collector (a climbing value while attempts climb means the collector is unreachable and flow records are being silently dropped). Labeled by instance and template as well as collector and source, so a failing template group sharing a collector address is attributable, not hidden (#3741).",
+			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
 		flowExportCollectorHealthy: prometheus.NewDesc(
 			"xpf_flow_export_collector_healthy",
-			"1 when the last write to this flow-export collector succeeded, 0 when the last write failed.",
-			[]string{"protocol", "collector", "source"}, nil,
+			"1 when the last write to this flow-export collector succeeded, 0 when the last write failed. Labeled by instance and template as well as collector and source (#3741).",
+			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
 		flowExportCollectorLastSuccessSeconds: prometheus.NewDesc(
 			"xpf_flow_export_collector_last_success_timestamp_seconds",
-			"Unix timestamp of the last successful write to this flow-export collector (0 if none yet).",
-			[]string{"protocol", "collector", "source"}, nil,
+			"Unix timestamp of the last successful write to this flow-export collector (0 if none yet). Labeled by instance and template as well as collector and source (#3741).",
+			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
 		flowExportCollectorLastFailureSeconds: prometheus.NewDesc(
 			"xpf_flow_export_collector_last_failure_timestamp_seconds",
-			"Unix timestamp of the last failed write to this flow-export collector (0 if none yet).",
-			[]string{"protocol", "collector", "source"}, nil,
+			"Unix timestamp of the last failed write to this flow-export collector (0 if none yet). Labeled by instance and template as well as collector and source (#3741).",
+			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
 	}
 }

--- a/pkg/api/metrics_flowexport_test.go
+++ b/pkg/api/metrics_flowexport_test.go
@@ -136,3 +136,177 @@ func TestFlowExportCollectorMetricsOmittedWhenUnwired(t *testing.T) {
 		}
 	}
 }
+
+// TestFlowExportCollectorMetricsDistinctLabelsetPerGroup pins #3741: the
+// daemon legitimately returns MULTIPLE FlowCollectorHealth rows for the
+// SAME (protocol, collector, source) triple — one per template group, one
+// per family-disjoint sampling instance. Before this fix the descriptor
+// carried only {protocol, collector, source}, so those rows collapsed to
+// an IDENTICAL labelset: a PEDANTIC registry rejects the duplicate series
+// (scrape error) and a plain gather silently collapses the failing group,
+// hiding a partial flow-export failure. The instance + template labels
+// make each group a distinct series.
+//
+// FAIL-ON-REVERT: drop instance/template from the descriptor + emission
+// and the two rows below share one labelset →
+// prometheus.NewPedanticRegistry().Gather() returns a duplicate-series
+// error and this test fails. It also asserts BOTH groups' distinct values
+// survive (the "silently collapses / hides the failing group" half).
+func TestFlowExportCollectorMetricsDistinctLabelsetPerGroup(t *testing.T) {
+	s := &Server{
+		flowCollectorHealthFn: func() []flowexport.ExporterCollectorHealth {
+			return []flowexport.ExporterCollectorHealth{
+				// Same protocol + collector address + source, different
+				// template group. Group "t-healthy" is up; "t-failing" is
+				// down — the failing group must remain attributable.
+				{
+					Protocol: "netflow-v9",
+					Instance: "sampler",
+					Template: "t-healthy",
+					CollectorHealth: flowexport.CollectorHealth{
+						Address:       "10.0.0.9:2055",
+						SourceAddress: "10.0.0.2",
+						WriteAttempts: 200,
+						WriteFailures: 0,
+						Healthy:       true,
+					},
+				},
+				{
+					Protocol: "netflow-v9",
+					Instance: "sampler",
+					Template: "t-failing",
+					CollectorHealth: flowexport.CollectorHealth{
+						Address:       "10.0.0.9:2055",
+						SourceAddress: "10.0.0.2",
+						WriteAttempts: 200,
+						WriteFailures: 200,
+						Healthy:       false,
+					},
+				},
+			}
+		},
+	}
+	// PEDANTIC registry: this is the instrument that turns a duplicate
+	// labelset into a Gather() error (the scrape-breaking half of #3741).
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("pedantic Gather() returned an error — two health rows that "+
+			"share (protocol, collector, source) but differ by "+
+			"instance/template collided on one labelset (the #3741 "+
+			"duplicate-series bug). Error: %v", err)
+	}
+
+	// byTemplate returns the value of `name` for the given template label.
+	byTemplate := func(name, template string) (float64, bool) {
+		for _, mf := range mfs {
+			if mf.GetName() != name {
+				continue
+			}
+			for _, m := range mf.GetMetric() {
+				var tmpl string
+				for _, lp := range m.GetLabel() {
+					if lp.GetName() == "template" {
+						tmpl = lp.GetValue()
+					}
+				}
+				if tmpl != template {
+					continue
+				}
+				if g := m.GetGauge(); g != nil {
+					return g.GetValue(), true
+				}
+				if ctr := m.GetCounter(); ctr != nil {
+					return ctr.GetValue(), true
+				}
+			}
+		}
+		return 0, false
+	}
+
+	// Both distinct groups must survive as separate series (the failing
+	// group is not collapsed / hidden).
+	if v, ok := byTemplate("xpf_flow_export_collector_healthy", "t-healthy"); !ok || v != 1 {
+		t.Errorf("healthy group healthy = %v (ok=%v), want 1 — the healthy "+
+			"template group is missing or was overwritten", v, ok)
+	}
+	if v, ok := byTemplate("xpf_flow_export_collector_healthy", "t-failing"); !ok || v != 0 {
+		t.Errorf("failing group healthy = %v (ok=%v), want 0 — the FAILING "+
+			"template group is hidden (collapsed onto the healthy row)", v, ok)
+	}
+	if v, ok := byTemplate("xpf_flow_export_collector_write_failures_total", "t-failing"); !ok || v != 200 {
+		t.Errorf("failing group write_failures = %v (ok=%v), want 200", v, ok)
+	}
+}
+
+// TestFlowExportCollectorMetricsLabelSet is the descriptor↔emission label
+// canary for #3741: every sample in the xpf_flow_export_collector_* family
+// must carry EXACTLY {protocol, instance, template, collector, source}.
+// The emitted label NAMES come from the *prometheus.Desc (so a descriptor
+// that drops a label fails here), and MustNewConstMetric would panic if
+// the emission supplied the wrong VALUE arity — so this asserts the two
+// sides agree.
+func TestFlowExportCollectorMetricsLabelSet(t *testing.T) {
+	s := &Server{
+		flowCollectorHealthFn: func() []flowexport.ExporterCollectorHealth {
+			return []flowexport.ExporterCollectorHealth{
+				{
+					Protocol: "ipfix",
+					Instance: "inst",
+					Template: "tmpl",
+					CollectorHealth: flowexport.CollectorHealth{
+						Address:       "10.0.0.1:4739",
+						SourceAddress: "10.0.0.2",
+						WriteAttempts: 1,
+						Healthy:       true,
+					},
+				},
+			}
+		},
+	}
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	wantLabels := map[string]bool{
+		"protocol": true, "instance": true, "template": true,
+		"collector": true, "source": true,
+	}
+	families := map[string]bool{
+		"xpf_flow_export_collector_write_attempts_total":           true,
+		"xpf_flow_export_collector_write_failures_total":           true,
+		"xpf_flow_export_collector_healthy":                        true,
+		"xpf_flow_export_collector_last_success_timestamp_seconds": true,
+		"xpf_flow_export_collector_last_failure_timestamp_seconds": true,
+	}
+	seen := map[string]bool{}
+	for _, mf := range mfs {
+		if !families[mf.GetName()] {
+			continue
+		}
+		seen[mf.GetName()] = true
+		for _, m := range mf.GetMetric() {
+			got := map[string]bool{}
+			for _, lp := range m.GetLabel() {
+				got[lp.GetName()] = true
+			}
+			if len(got) != len(wantLabels) {
+				t.Errorf("%s has %d labels %v, want %d %v", mf.GetName(),
+					len(got), got, len(wantLabels), wantLabels)
+			}
+			for l := range wantLabels {
+				if !got[l] {
+					t.Errorf("%s missing label %q (labels=%v)", mf.GetName(), l, got)
+				}
+			}
+		}
+	}
+	for f := range families {
+		if !seen[f] {
+			t.Errorf("family %q not emitted", f)
+		}
+	}
+}

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -123,41 +123,46 @@ func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
 // from the per-collector NetFlow v9 / IPFIX write-health snapshot
 // (#2464). The family is omitted entirely when no FlowCollectorHealthFn
 // is wired or when no flow export is configured (empty slice). Labels:
-// protocol {netflow-v9,ipfix} and the collector address — both bounded
-// (one series per configured flow-server). These counters make a
-// silently-unreachable collector observable: write_failures climbs while
-// write_attempts climbs, healthy drops to 0, and last_success ages. The
-// source label carries the per-collector local bind address (#3745), so
-// two same-family collectors that bind distinct sources are distinct
-// series and a source-bound failure is attributable; it is "" when the OS
-// selected the source.
+// protocol {netflow-v9,ipfix}, instance, template, the collector address,
+// and source — all bounded (one series per configured flow-server group).
+// These counters make a silently-unreachable collector observable:
+// write_failures climbs while write_attempts climbs, healthy drops to 0,
+// and last_success ages. The source label carries the per-collector local
+// bind address (#3745), so two same-family collectors that bind distinct
+// sources are distinct series and a source-bound failure is attributable;
+// it is "" when the OS selected the source. The instance + template
+// labels (#3741) disambiguate MULTIPLE health rows that share one
+// (protocol, collector) pair — one per template group, per family-disjoint
+// instance — which the daemon legitimately returns; without them the two
+// rows collide on an identical labelset, and Prometheus either rejects the
+// duplicate series (scrape error) or silently collapses the failing group.
 func (c *xpfCollector) collectFlowExportMetrics(ch chan<- prometheus.Metric) {
 	if c.srv.flowCollectorHealthFn == nil {
 		return
 	}
 	for _, h := range c.srv.flowCollectorHealthFn() {
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorWriteAttemptsTotal,
-			prometheus.CounterValue, float64(h.WriteAttempts), h.Protocol, h.Address, h.SourceAddress)
+			prometheus.CounterValue, float64(h.WriteAttempts), h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorWriteFailuresTotal,
-			prometheus.CounterValue, float64(h.WriteFailures), h.Protocol, h.Address, h.SourceAddress)
+			prometheus.CounterValue, float64(h.WriteFailures), h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 		healthy := 0.0
 		if h.Healthy {
 			healthy = 1
 		}
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorHealthy,
-			prometheus.GaugeValue, healthy, h.Protocol, h.Address, h.SourceAddress)
+			prometheus.GaugeValue, healthy, h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 		var lastSuccess float64
 		if !h.LastSuccessTime.IsZero() {
 			lastSuccess = float64(h.LastSuccessTime.Unix())
 		}
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorLastSuccessSeconds,
-			prometheus.GaugeValue, lastSuccess, h.Protocol, h.Address, h.SourceAddress)
+			prometheus.GaugeValue, lastSuccess, h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 		var lastFailure float64
 		if !h.LastFailureTime.IsZero() {
 			lastFailure = float64(h.LastFailureTime.Unix())
 		}
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorLastFailureSeconds,
-			prometheus.GaugeValue, lastFailure, h.Protocol, h.Address, h.SourceAddress)
+			prometheus.GaugeValue, lastFailure, h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 	}
 }
 


### PR DESCRIPTION
## Summary

The `xpf_flow_export_collector_*` Prometheus family declared only
`{protocol, collector, source}` labels, but `FlowCollectorHealth()`
returns MULTIPLE health rows for the same `(protocol, collector)` pair —
one per NetFlow v9 / IPFIX **template group** and one per family-disjoint
**sampling instance**. Two such rows collapsed onto an identical labelset:
`prometheus.MustNewConstMetric` was called twice on the same descriptor
with the same label values, so a pedantic-gather scrape rejects the
duplicate series (scrape error) and a plain gather silently collapses one
row onto the other. A partial flow-export failure — one failing template
group sharing a collector address — became either scrape-breaking or
invisible.

## Root cause (verified on current origin/master)

- `pkg/api/metrics_descriptors.go` ~1726-1749: all five
  `xpf_flow_export_collector_*` descriptors declared `{protocol, collector, source}`.
- `pkg/api/metrics_system.go` `collectFlowExportMetrics`: emitted only
  `(h.Protocol, h.Address, h.SourceAddress)` — `Instance`/`Template` dropped.
- `pkg/daemon/daemon_flowexport.go` `FlowCollectorHealth()`: annotates each
  row with `Instance` + `Template`; `pkg/flowexport/transport.go`
  `ExporterCollectorHealth` carries `Instance` + `Template` + `CollectorHealth`.

## Fix

Add `instance` + `template` to all five descriptors AND the emission
(confirmed `source` from #3745 is already present). Label set is now
`{protocol, instance, template, collector, source}` — bounded cardinality
(one series per configured flow-server group). Descriptor and emission stay
in lockstep (`MustNewConstMetric` panics on a value/label-arity mismatch;
the descriptor-coverage canary asserts the checked-collector
`Describe()⊇Collect()` contract).

## Tests (both RED on revert)

- `TestFlowExportCollectorMetricsDistinctLabelsetPerGroup` — two health rows
  sharing `protocol+collector+source` but differing by `instance/template`
  gather through a **PEDANTIC** registry with no duplicate-series error, and
  BOTH groups' distinct values survive (the failing group is not hidden). On
  revert the two rows collide → `Gather()` returns the duplicate-series error.
- `TestFlowExportCollectorMetricsLabelSet` — descriptor↔emission label canary:
  every sample carries exactly `{protocol, instance, template, collector,
  source}`.

RED-on-revert proof (labels stripped back to `{protocol, collector, source}`):
```
* collected metric "xpf_flow_export_collector_write_attempts_total" {...} was collected before with the same name and label values
... (5 families) ...
xpf_flow_export_collector_healthy has 3 labels ... want 5 ... missing label "instance" / "template"
```

## Validation

- `go test ./pkg/api/...` green (incl. descriptor-coverage canary + 2 new tests)
- `go build ./...` green; `gofmt` + `go vet` clean
- Observability doc `docs/feature-coverage.md` updated

Closes #3741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi