### PR TITLE
ddns/surface-a: seed cache + renumber log from AddrText (#3734)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,33 @@
+## 2026-07-01 — #3734 ddns Surface A: seedFromStore + renumber log read AddrText (not the always-empty Address) → no restart republish storm, renumber leaves a trace
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3734 (MEDIUM, folds codex-review-157 H04+M02). A Surface A
+    router record stores its published rdata in `AddrText`; the keying
+    `Address` field is `""` (Surface A keys ownership on `{scope, fixed
+    identity, ""}`, #2691 P2). Two places read the empty `Address`:
+    (H04) `seedFromStore` on restart parsed `r.Address` → `ParseAddr("")`
+    errored → nothing seeded → the first post-restart reconcile saw every
+    owned record as changed (empty→current) and republished — a write-storm
+    proportional to the scope count (provider ban/rate-limit risk).
+    (M02) the WAN-renumber "replaced record address" log read
+    `prevOwned.Address` (always `""`) so it never fired — a renumber left no
+    operational trace.
+    FIX: `seedFromStore` seeds `lastAddr` from `AddrText` (fallback `Address`
+    for a legacy lease-shape entry) AND baselines `lastPublished` at the
+    restart instant — seeding `lastAddr` alone is insufficient because
+    `lastPublished` left zero makes `refreshDue` immediately true and
+    republishes anyway; baselining it makes the first unchanged reconcile a
+    counted skip and measures the forced-refresh floor from the restart. The
+    renumber log now reads `prevOwned.AddrText` (same fallback).
+    Two RED-on-revert tests: `TestSurfaceARestartSeedsFromAddrTextNoRepublishStorm`
+    (restart → 0 upserts on an unchanged record, still 1 on a real change;
+    RED = 1 spurious republish on revert) and `TestSurfaceARenumberLogReadsAddrText`
+    (captures slog, asserts `old=<AddrText>`; RED = empty log on revert).
+    Both verified RED with the fix reverted. `go test ./pkg/ddns/... ./pkg/daemon/`
+    green; build/vet/gofmt clean. Doc: docs/research/ddns-world-class/plan.md §5.5.
+  - **File(s)**: pkg/ddns/surface_a.go, pkg/ddns/surface_a_test.go,
+    docs/research/ddns-world-class/plan.md, _Log.md
+
 ## 2026-07-01 — #3742 flowexport: build-before-swap reconcile (transient NewExporter failure no longer disables export; no SESSION_CLOSE lost in the swap window)
 
 - **Timestamp**: 2026-07-01

--- a/docs/research/ddns-world-class/plan.md
+++ b/docs/research/ddns-world-class/plan.md
@@ -493,6 +493,26 @@ Per-scope state (extends the existing durable store):
 - **Startup seed** (inadyn idea #5): seed the cache from disk; if absent,
   optionally a live DNS lookup of the FQDN to avoid a redundant first-boot
   update (gated by config to avoid a leak in air-gapped setups).
+  - **Surface A seed reads AddrText, baselines publishedAt (#3734/H04).**
+    A Surface A router record stores its published rdata in `AddrText`
+    (`Address` is `""` — Surface A keys ownership on `{scope, fixed
+    identity, ""}`). `seedFromStore` therefore seeds `lastAddr` from
+    `AddrText` (falling back to `Address` only for a legacy lease-shape
+    entry) AND seeds `lastPublished` to the RESTART instant. Seeding
+    `lastAddr` alone is not enough: with `lastPublished` left zero
+    `refreshDue` is immediately true, so every owned scope republishes on
+    the first post-restart pass — a write-storm proportional to the scope
+    count (the exact provider ban/rate-limit risk this cache exists to
+    prevent). Baselining `publishedAt` at the restart makes the first
+    unchanged reconcile a counted skip; the record re-asserts only once the
+    forced-refresh floor elapses FROM the restart. The pre-fix code parsed
+    the empty `Address`, errored, and seeded nothing (both `lastAddr` and
+    `lastPublished` zero) → guaranteed storm.
+  - **Renumber (WAN address change) log reads AddrText (#3734/M02).** The
+    "replaced record address" transition log reads the previous owned
+    record's `AddrText` for the old address (same `""`-Address caveat);
+    reading `Address` yielded `""` so the log never fired and a WAN
+    renumber left no operational trace.
 - **Forced-refresh decoupled from poll** (inadyn idea #7): the existing
   30s reconcile re-asserts *desired state* but MUST NOT send a wire
   update every 30s; a per-scope `forced-refresh` (default e.g. 24h) is the

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -512,19 +512,45 @@ func newSurfaceARFC2136(p *config.DDNSProvider, _ string) (DNSUpdater, error) {
 
 // seedFromStore rebuilds the in-memory runtime cache from the durable ownership
 // store (inadyn idea #5, plan §5.5): a restart must not blast a redundant
-// update for an address that has not changed. Each owned record seeds
-// lastAddr; lastPublished is left zero so the FIRST post-restart reconcile,
-// if the address is unchanged, still satisfies change-detection (addr matches)
-// and the forced-refresh floor is measured from the restart (a benign at-most-
-// one wire refresh on the first forced interval after a restart). Caller need
-// not hold the mutex (constructor-only).
+// update for an address that has not changed. Each owned record seeds BOTH
+// lastAddr (so change-detection sees the unchanged address as unchanged) AND
+// lastPublished, set to the restart instant, so the forced-refresh floor is
+// measured from the restart: the FIRST post-restart reconcile of an unchanged
+// record is a counted skip (no wire traffic) and the record re-asserts only
+// once the forced-refresh interval elapses from the restart. Leaving
+// lastPublished zero would make refreshDue immediately true and republish
+// every owned scope on the first pass — a restart write-storm proportional to
+// the scope count, the exact provider ban/rate-limit risk the cache exists to
+// avoid (#3734/H04).
+//
+// The published rdata lives in AddrText for a Surface A router record; the
+// keying Address field is "" (Surface A keys ownership on {scope, fixed
+// identity, ""}, #2691 P2). Seed from AddrText and only fall back to the
+// Address field for any legacy lease-shape entry that predates AddrText — a
+// pre-fix restart parsed the empty Address, errored, and seeded NOTHING, which
+// is exactly the storm this fixes. An unparseable/empty value seeds no runtime
+// entry (the scope re-publishes on its first reconcile — safe). Caller need not
+// hold the mutex (constructor-only).
 func (m *SurfaceAManager) seedFromStore() {
+	// Restart baseline for the forced-refresh floor. m.now is set by both
+	// constructors before seedFromStore runs; the nil guard is defensive.
+	var restart time.Time
+	if m.now != nil {
+		restart = m.now()
+	}
 	for _, r := range m.state.all() {
-		a, err := netip.ParseAddr(r.Address)
+		text := r.AddrText
+		if text == "" {
+			text = r.Address
+		}
+		a, err := netip.ParseAddr(text)
 		if err != nil {
 			continue
 		}
-		m.runtime[r.scopeOf().scopePrefix()] = &surfaceAState{lastAddr: a.Unmap()}
+		m.runtime[r.scopeOf().scopePrefix()] = &surfaceAState{
+			lastAddr:      a.Unmap(),
+			lastPublished: restart,
+		}
 	}
 }
 
@@ -935,7 +961,15 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 	prevOwned, hadPrev := m.state.get(key, surfaceAIdentity, "")
 	prevAddr := ""
 	if hadPrev {
-		prevAddr = prevOwned.Address
+		// The previously-published rdata lives in AddrText for a Surface A record
+		// (Address is the "" scope key, #2691 P2). Reading Address here always
+		// yielded "" so the "replaced record address" renumber log below never
+		// fired — a WAN renumber left no operational trace (#3734/M02). Prefer
+		// AddrText; fall back to Address only for a legacy lease-shape entry.
+		prevAddr = prevOwned.AddrText
+		if prevAddr == "" {
+			prevAddr = prevOwned.Address
+		}
 	}
 
 	// Write-ahead the ownership intent BEFORE the wire add (#2662): a crash

--- a/pkg/ddns/surface_a_test.go
+++ b/pkg/ddns/surface_a_test.go
@@ -1,11 +1,14 @@
 package ddns
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/netip"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -603,5 +606,105 @@ func TestSurfaceAAbsentStateFirstBootStandaloneWrites(t *testing.T) {
 	}
 	if got := len(fu.upserts); got != 1 {
 		t.Fatalf("first-boot standalone node must publish its record, got %d upserts", got)
+	}
+}
+
+// TestSurfaceARestartSeedsFromAddrTextNoRepublishStorm is the #3734 (H04)
+// fail-on-revert proof. On restart seedFromStore must rebuild the runtime cache
+// from the durable ownership store's AddrText field — where a Surface A record's
+// published rdata lives (Address is "" for a Surface A record, #2691 P2) — AND
+// baseline lastPublished at the restart instant, so the FIRST post-restart
+// reconcile of an UNCHANGED record is a counted SKIP, not a redundant wire
+// republish. Reverting the fix (parse the empty Address, leave lastPublished
+// zero) seeds NOTHING and makes refreshDue immediately true, so every owned
+// scope republishes on the first pass — the restart write-storm proportional to
+// the scope count (provider ban/rate-limit risk) — and this test goes RED. A
+// genuinely CHANGED address must still republish (the seed must not
+// over-suppress a real renumber).
+func TestSurfaceARestartSeedsFromAddrTextNoRepublishStorm(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "iface-ddns.json")
+	now := time.Unix(1_700_000_000, 0)
+	clock := func() time.Time { return now }
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	// Pre-restart: publish 203.0.113.5 so the durable store records an owned
+	// Surface A entry.
+	fu1 := newFakeUpdater()
+	m1 := newSurfaceAManagerForTesting(statePath, fu1, clock)
+	if err := m1.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("pre-restart publish: %v", err)
+	}
+	if got := len(fu1.upserts); got != 1 {
+		t.Fatalf("pre-restart must publish once, got %d", got)
+	}
+	// Prove the on-disk shape the seed must read: AddrText carries the rdata,
+	// Address is empty. If this shape ever changes, the seed logic must too.
+	owned, ok := m1.state.get(sc.effectiveKey(), surfaceAIdentity, "")
+	if !ok || owned.AddrText != "203.0.113.5" || owned.Address != "" {
+		t.Fatalf("stored record must carry rdata in AddrText with Address empty; got %+v (ok=%v)", owned, ok)
+	}
+
+	// Restart: a fresh manager loads the SAME durable store and seeds the runtime
+	// cache. An UNCHANGED reconcile must NOT touch the wire.
+	fu2 := newFakeUpdater()
+	m2 := newSurfaceAManagerForTesting(statePath, fu2, clock)
+	if err := m2.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("post-restart unchanged reconcile: %v", err)
+	}
+	if got := len(fu2.upserts); got != 0 {
+		t.Fatalf("post-restart unchanged record must NOT republish (storm); got %d upserts", got)
+	}
+	if st := m2.Stats(); st.Skipped != 1 {
+		t.Fatalf("post-restart unchanged record must be a counted skip; stats=%+v", st)
+	}
+
+	// A genuinely CHANGED address after restart must still republish.
+	if err := m2.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("198.51.100.7"), nil, nil); err != nil {
+		t.Fatalf("post-restart changed reconcile: %v", err)
+	}
+	if got := fu2.upsertNames(); len(got) != 1 || got[0] != "wan.example.net=198.51.100.7" {
+		t.Fatalf("changed address after restart must republish; got %v", got)
+	}
+}
+
+// TestSurfaceARenumberLogReadsAddrText is the #3734 (M02) fail-on-revert proof.
+// On a WAN renumber (same FQDN, new address) publishLocked must log the
+// "replaced record address" transition with the OLD address read from the
+// previous owned record's AddrText. Reverting to prevOwned.Address (always "" for
+// a Surface A record) makes prevAddr "" so the log never fires → this test goes
+// RED (a renumber leaves no operational trace).
+func TestSurfaceARenumberLogReadsAddrText(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "iface-ddns.json")
+	now := time.Unix(1_700_000_000, 0)
+	clock := func() time.Time { return now }
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	fu := newFakeUpdater()
+	m := newSurfaceAManagerForTesting(statePath, fu, clock)
+
+	// Establish ownership at the old address (logs "published record").
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, nil); err != nil {
+		t.Fatalf("initial publish: %v", err)
+	}
+
+	// Capture the default slog output for the renumber pass only.
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(prev)
+
+	// Renumber: same FQDN, new address → replace in place.
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("198.51.100.7"), nil, nil); err != nil {
+		t.Fatalf("renumber publish: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "replaced record address") {
+		t.Fatalf("renumber must log the replacement transition; log=%q", out)
+	}
+	if !strings.Contains(out, "old=203.0.113.5") || !strings.Contains(out, "new=198.51.100.7") {
+		t.Fatalf("renumber log must carry old (from AddrText) + new address; log=%q", out)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #3734 (codex-review-157 H04 + M02, same root cause).

A Surface A router record stores its published rdata in the `AddrText`
field; the keying `Address` field is `""` because Surface A keys
ownership on `{scope, fixed identity, ""}` (#2691 P2). Two places read
the always-empty `Address` field instead of `AddrText`, so both silently
no-op.

### H04 — restart republish storm
On restart `seedFromStore` parsed `r.Address`, so `ParseAddr("")` errored
and **nothing** was seeded into the runtime cache. The first post-restart
reconcile then saw every owned record's address as changed
(`zero → current`) and drove a redundant wire UPDATE for each — a provider
write-storm proportional to the Surface A scope count, the exact ban /
rate-limit risk the cache exists to avoid.

Seeding `lastAddr` alone is not sufficient: with `lastPublished` left
zero, `refreshDue` is immediately true and the record republishes anyway.
`seedFromStore` now seeds `lastAddr` from `AddrText` (falling back to
`Address` only for a legacy lease-shape entry) **and** baselines
`lastPublished` at the restart instant, so the first unchanged reconcile
is a counted skip and the forced-refresh floor is measured from the
restart.

### M02 — renumber invisible in the log
The WAN-renumber "replaced record address" transition read
`prevOwned.Address` (always `""`), so `prevAddr` stayed `""` and the log
never fired. It now reads `prevOwned.AddrText` (same fallback).

## RED-on-revert tests
- `TestSurfaceARestartSeedsFromAddrTextNoRepublishStorm` — publish, rebuild
  a fresh manager on the same durable store (restart), assert the unchanged
  record is a counted skip (0 wire upserts) while a genuinely changed
  address still republishes. Reverting the seed → 1 spurious republish
  (RED, verified).
- `TestSurfaceARenumberLogReadsAddrText` — capture slog, assert the
  renumber logs `old=<AddrText>`. Reverting to `Address` → empty log
  (RED, verified).

## Validation
- `go test ./pkg/ddns/... ./pkg/daemon/` — green
- `go build ./...`, `go vet ./pkg/ddns/...`, `gofmt` — clean
- Both RED-on-revert proofs confirmed RED with the fix reverted

Doc: `docs/research/ddns-world-class/plan.md` §5.5 startup seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi