### PR TITLE
flowexport: resolve route-mask off the EventReader session-close callback (#3743)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28,6 +28,43 @@
   - **File(s)**: pkg/ddns/surface_a.go, pkg/ddns/surface_a_test.go,
     docs/research/ddns-world-class/plan.md, _Log.md
 
+## 2026-07-01 — #3743 flowexport: route-mask FIB lookup moved OFF the EventReader session-close callback (async background populate; no synchronous netlink on the hot path)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3743 (MEDIUM, codex-review-158 H10). Route-mask
+    resolution (#2866) issued an `RTM_GETROUTE` netlink syscall
+    SYNCHRONOUSLY inside the EventReader session-close callback
+    (`flowExportCallback`/`ipfixExportCallback` → `ExportSessionClose` →
+    `resolveMasks` → `routeMaskCache.resolve` → `fibMatchMask` on a cache
+    miss). On a miss the netlink round-trip stalled the event reader and
+    every callback behind it (incl. the trace writer); high destination-IP
+    churn thrashed the cache and turned close handling into a netlink-bound
+    path. FIX: `resolve()` never calls netlink on the caller's goroutine —
+    a fresh cache HIT returns the cached prefix length; a MISS returns the
+    safe default (0,false) IMMEDIATELY and schedules a bounded, deduplicated
+    BACKGROUND lookup (`scheduleLookupLocked` → `populate` → `storeLocked`)
+    that warms the cache for the next flow to that prefix. `pending` dedups
+    concurrent misses per IP; `inflight` caps concurrency at
+    `defaultRouteMaskInflight` (32) so a slow netlink socket cannot spawn
+    unbounded goroutines (over-cap misses just return the default and retry
+    on a later flow). Approximate mask (0) on the FIRST flow to a new prefix
+    is the accepted trade-off vs blocking the shared event reader; the
+    common per-host/per-subnet aggregate resolves correctly on the 2nd flow.
+    #3744 (route-mask VRF/table/source-blindness) is a separate design item,
+    out of scope. Tests: 3 RED-on-revert pins
+    (`TestRouteMaskResolveMissDoesNotLookupSynchronously`,
+    `TestExportSessionCloseDoesNotBlockOnFIBLookup` end-to-end,
+    `TestRouteMaskCacheAsyncPopulateAndHit`); the bound/expired-first evict
+    tests now drive `storeLocked` directly (the background populate path).
+    Verified RED on revert to synchronous lookup (both no-block tests time
+    out / return wrong value); `go test -race ./pkg/flowexport/...` +
+    `go test ./pkg/daemon/` green; `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/flowexport/routemask.go (async off-callback resolve +
+    scheduleLookupLocked/populate/storeLocked + inflight/pending fields +
+    defaultRouteMaskInflight), pkg/flowexport/srcmask_dstmask_test.go (3 new
+    RED-on-revert tests + evict tests via storeLocked), pkg/flowexport/README.md
+    (#3743 async off-callback doc)
+
 ## 2026-07-01 — #3742 flowexport: build-before-swap reconcile (transient NewExporter failure no longer disables export; no SESSION_CLOSE lost in the swap window)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -242,6 +242,35 @@ still at the cap, clears the map — a simple hard ceiling rather than
 per-entry LRU bookkeeping for a syscall-amortization cache. The bound is
 pinned by `TestRouteMaskCacheBounded` (inserting >cap distinct keys keeps
 `len(entries)` <= cap; removing the bound flips it RED).
+
+**#3743 — the FIB lookup runs OFF the EventReader callback.** `resolve()`
+is called from `ExportSessionClose`, which runs inside the EventReader
+session-close callback (`daemon_flowexport.go` `flowExportCallback` /
+`ipfixExportCallback`). A *synchronous* `RTM_GETROUTE` there stalls the
+event reader — and every other callback behind it, including the trace
+writer — for the netlink round-trip; under high destination-IP churn the
+cache thrashes and close handling becomes a netlink-bound path. So a cache
+miss no longer blocks: `resolve()` returns the safe default (mask 0,
+`ok=false`) immediately and schedules a bounded, deduplicated **background**
+lookup (`scheduleLookupLocked` → `populate`) that warms the cache for the
+NEXT flow to that prefix. A `pending` set dedups concurrent misses for the
+same IP; `inflight` caps concurrent lookups at `defaultRouteMaskInflight`
+(32) so a slow/loaded netlink socket cannot spawn unbounded goroutines —
+once the cap is hit, further misses just return the default and are retried
+on a later flow. An approximate mask (0) on the first flow to a new prefix
+is the accepted trade-off for never blocking the shared event-reader path;
+the common per-host / per-subnet aggregate resolves correctly from the warm
+cache on the second flow onward. Pinned by
+`TestRouteMaskResolveMissDoesNotLookupSynchronously` (a miss with a blocking
+lookup returns the default, not the lookup's value),
+`TestExportSessionCloseDoesNotBlockOnFIBLookup` (end-to-end: a blocking FIB
+lookup does not stall `ExportSessionClose`) and
+`TestRouteMaskCacheAsyncPopulateAndHit` (miss → default → background
+populate → warm hit). Reverting to the synchronous lookup-in-`resolve`
+flips these RED (the first two by blocking / returning the wrong value).
+Note #3744 (route-mask being VRF/table/source-blind) is a separate design
+item and out of scope here.
+
 `Exporter` / `IPFIXExporter` carry a `MaskResolver` func (defaulted by
 `NewExporter`/`NewIPFIXExporter` to `NewRouteMaskResolver`; nil on a
 zero-value exporter → masks stay 0, the pre-#2866 behaviour and the test
@@ -270,9 +299,13 @@ The package is split by responsibility (#1988):
 - `ipfix.go` — IPFIX (v10) template/record encoding and the
   `IPFIXExporter` that drives it.
 - `routemask.go` — the `MaskResolver` func type and
-  `NewRouteMaskResolver` (#2866): a TTL-cached FIB longest-prefix-match
-  lookup that resolves a flow's `srcMask`/`dstMask` (route prefix length)
-  at export time, plus the `resolveMasks` helper both exporters call.
+  `NewRouteMaskResolver` (#2866): a TTL-cached, size-bounded FIB
+  longest-prefix-match lookup that resolves a flow's `srcMask`/`dstMask`
+  (route prefix length) at export time, plus the `resolveMasks` helper both
+  exporters call. The netlink `RTM_GETROUTE` runs on a bounded background
+  goroutine, never on the EventReader callback that calls `resolve()`
+  (#3743): a cache miss returns the default and warms the cache for the next
+  flow.
 - `transport.go` — shared collector connection management
   (`collectorConns`: dial / fan-out write / close) and the per-family
   batch accumulator (`flowBatch`) used by both exporters. `dialCollectors`

--- a/pkg/flowexport/routemask.go
+++ b/pkg/flowexport/routemask.go
@@ -33,6 +33,18 @@ type MaskResolver func(ip net.IP) (mask uint8, ok bool)
 // distinct src/dst prefixes for any realistic flow mix yet a hard ceiling.
 const routeMaskCacheMax = 8192
 
+// defaultRouteMaskInflight bounds the number of concurrent BACKGROUND FIB
+// lookups (#3743). resolve() runs inside the EventReader session-close
+// callback; a synchronous RTM_GETROUTE netlink round-trip there stalls the
+// event reader and every other callback behind it (including the trace writer)
+// under netlink latency, and high destination-IP churn turns close handling
+// into a netlink-bound path. So a cache miss no longer blocks: it schedules the
+// lookup on a background goroutine and returns the default immediately. This
+// ceiling caps how many such lookups run at once, so a slow/loaded netlink
+// socket under churn cannot spawn unbounded goroutines — once it is reached,
+// further misses just return the default and are retried on a later flow.
+const defaultRouteMaskInflight = 32
+
 // routeMaskCache caches FIB-match results for a short TTL so the per-flow
 // session-close export path does not issue an RTM_GETROUTE netlink syscall for
 // every record. Flows to the same destination/source prefix are common
@@ -47,8 +59,19 @@ type routeMaskCache struct {
 	// deterministic resolver without touching the kernel routing table.
 	lookup func(ip net.IP) (uint8, bool)
 
-	mu      sync.Mutex
-	entries map[string]routeMaskEntry
+	// maxInflight bounds concurrent background FIB lookups (#3743). 0 selects
+	// defaultRouteMaskInflight. See scheduleLookupLocked.
+	maxInflight int
+
+	mu       sync.Mutex
+	entries  map[string]routeMaskEntry
+	pending  map[string]struct{} // keys with a background lookup in flight (dedup)
+	inflight int                 // count of background lookups currently running
+
+	// afterPopulate, when non-nil, is invoked after each background lookup has
+	// stored its result. Test-only seam for deterministic assertions; nil in
+	// production (the resolve() fast path never touches it).
+	afterPopulate func()
 }
 
 type routeMaskEntry struct {
@@ -66,15 +89,25 @@ func NewRouteMaskResolver(ttl time.Duration) MaskResolver {
 		ttl = 10 * time.Second
 	}
 	c := &routeMaskCache{
-		ttl:     ttl,
-		maxSize: routeMaskCacheMax,
-		lookup:  fibMatchMask,
-		entries: make(map[string]routeMaskEntry),
+		ttl:         ttl,
+		maxSize:     routeMaskCacheMax,
+		maxInflight: defaultRouteMaskInflight,
+		lookup:      fibMatchMask,
+		entries:     make(map[string]routeMaskEntry),
+		pending:     make(map[string]struct{}),
 	}
 	return c.resolve
 }
 
-// resolve implements MaskResolver with caching.
+// resolve implements MaskResolver with caching. It NEVER issues the netlink
+// FIB lookup on the calling goroutine (#3743): resolve() runs inside the
+// EventReader session-close callback, so a synchronous RTM_GETROUTE round-trip
+// would serialize the event reader (and every callback behind it) behind
+// netlink latency. On a fresh cache hit it returns the cached prefix length; on
+// a miss it schedules a bounded, deduplicated background lookup that warms the
+// cache for the NEXT flow to this prefix and returns the safe default (0,
+// false) now. An approximate mask on the first flow to a new prefix is the
+// accepted trade-off for never blocking the shared event-reader path.
 func (c *routeMaskCache) resolve(ip net.IP) (uint8, bool) {
 	if ip == nil {
 		return 0, false
@@ -88,18 +121,71 @@ func (c *routeMaskCache) resolve(ip net.IP) (uint8, bool) {
 
 	c.mu.Lock()
 	if e, found := c.entries[key]; found && now.Before(e.expires) {
+		mask, ok := e.mask, e.ok
 		c.mu.Unlock()
-		return e.mask, e.ok
+		return mask, ok
 	}
+	// Cache miss (or expired): schedule the FIB lookup off this goroutine and
+	// return the default now — do NOT block the callback on netlink.
+	c.scheduleLookupLocked(key, ip16)
 	c.mu.Unlock()
+	return 0, false
+}
 
+// scheduleLookupLocked starts a background FIB lookup for key (the 16-byte
+// string form of an IP) unless one is already in flight for it (dedup) or the
+// concurrent-lookup cap is reached (backpressure — the miss is retried on a
+// later flow rather than piling up goroutines behind a slow netlink socket).
+// ip16 is copied because the caller's slice may be reused after resolve()
+// returns. The caller holds c.mu. #3743.
+func (c *routeMaskCache) scheduleLookupLocked(key string, ip16 net.IP) {
+	if c.lookup == nil {
+		return
+	}
+	if c.pending == nil {
+		c.pending = make(map[string]struct{})
+	}
+	if _, inFlight := c.pending[key]; inFlight {
+		return
+	}
+	limit := c.maxInflight
+	if limit <= 0 {
+		limit = defaultRouteMaskInflight
+	}
+	if c.inflight >= limit {
+		return
+	}
+	c.pending[key] = struct{}{}
+	c.inflight++
+	ipCopy := append(net.IP(nil), ip16...)
+	go c.populate(key, ipCopy)
+}
+
+// populate runs a single background FIB lookup and stores the result so the
+// next flow to this prefix resolves from the warm cache. It is the goroutine
+// body scheduled by scheduleLookupLocked; the netlink round-trip happens here,
+// entirely off the EventReader callback path. #3743.
+func (c *routeMaskCache) populate(key string, ip net.IP) {
 	mask, ok := c.lookup(ip)
-
+	now := time.Now()
 	c.mu.Lock()
+	c.storeLocked(key, mask, ok, now)
+	delete(c.pending, key)
+	if c.inflight > 0 {
+		c.inflight--
+	}
+	after := c.afterPopulate
+	c.mu.Unlock()
+	if after != nil {
+		after()
+	}
+}
+
+// storeLocked bounds the cache then inserts a resolved entry. The caller holds
+// c.mu.
+func (c *routeMaskCache) storeLocked(key string, mask uint8, ok bool, now time.Time) {
 	c.evictLocked(key, now)
 	c.entries[key] = routeMaskEntry{mask: mask, ok: ok, expires: now.Add(c.ttl)}
-	c.mu.Unlock()
-	return mask, ok
 }
 
 // evictLocked bounds the cache before an insert. It is a no-op until the map is

--- a/pkg/flowexport/srcmask_dstmask_test.go
+++ b/pkg/flowexport/srcmask_dstmask_test.go
@@ -2,6 +2,7 @@ package flowexport
 
 import (
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -164,36 +165,134 @@ func TestIPFIXSrcDstMaskPopulated(t *testing.T) {
 	}
 }
 
-// TestRouteMaskCacheResolves checks the cache wrapper returns the lookup's
-// result, caches it (a second call with a deliberately changed lookup still
-// returns the cached value within TTL), and handles a default-route /0 as a
-// successful resolve (ok=true) distinct from a miss (ok=false).
-func TestRouteMaskCacheResolves(t *testing.T) {
-	calls := 0
+// TestRouteMaskResolveMissDoesNotLookupSynchronously is the #3743 fail-on-
+// revert pin at the cache layer: resolve() runs inside the EventReader
+// session-close callback, so a cache MISS must NOT perform the netlink FIB
+// lookup on the caller's goroutine. The injected lookup blocks until the test
+// releases it; resolve() must still return the default (0,false) immediately.
+// Reverting to the pre-#3743 synchronous "lookup inside resolve" makes resolve()
+// block on the channel and return the lookup's sentinel (24,true) instead —
+// flipping this RED (and, end-to-end, blocking the whole callback path, which
+// TestExportSessionCloseDoesNotBlockOnFIBLookup pins).
+func TestRouteMaskResolveMissDoesNotLookupSynchronously(t *testing.T) {
+	release := make(chan struct{})
 	c := &routeMaskCache{
-		ttl:     time.Hour,
-		entries: make(map[string]routeMaskEntry),
+		ttl:         time.Hour,
+		maxInflight: 4,
+		entries:     make(map[string]routeMaskEntry),
+		pending:     make(map[string]struct{}),
 	}
 	c.lookup = func(net.IP) (uint8, bool) {
+		<-release // a synchronous caller would block here
+		return 24, true
+	}
+	got, ok := c.resolve(net.IPv4(192, 0, 2, 1))
+	if got != 0 || ok {
+		t.Fatalf("cache-miss resolve = %d,%v want 0,false (synchronous netlink on the callback path)", got, ok)
+	}
+	close(release) // let the scheduled background lookup finish and exit
+}
+
+// TestRouteMaskCacheAsyncPopulateAndHit checks the two-phase #3743 behaviour:
+// the first resolve to a new prefix misses (returns the default) and schedules
+// a background lookup; once that lookup completes, a subsequent resolve HITS
+// with the real mask without issuing another syscall. It also verifies a
+// default-route /0 is cached as a successful resolve (ok=true), distinct from a
+// miss (ok=false).
+func TestRouteMaskCacheAsyncPopulateAndHit(t *testing.T) {
+	done := make(chan struct{}, 1)
+	var mu sync.Mutex
+	calls := 0
+	c := &routeMaskCache{
+		ttl:         time.Hour,
+		maxInflight: 4,
+		entries:     make(map[string]routeMaskEntry),
+		pending:     make(map[string]struct{}),
+	}
+	c.lookup = func(net.IP) (uint8, bool) {
+		mu.Lock()
 		calls++
+		mu.Unlock()
 		return 16, true
 	}
+	c.afterPopulate = func() { done <- struct{}{} }
+
 	ip := net.IPv4(192, 0, 2, 1)
+	if m, ok := c.resolve(ip); m != 0 || ok {
+		t.Fatalf("first resolve = %d,%v want 0,false (miss default)", m, ok)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background lookup never populated the cache")
+	}
+	// Swap the lookup to a sentinel: a genuine cache HIT must not call it.
+	c.lookup = func(net.IP) (uint8, bool) { mu.Lock(); calls++; mu.Unlock(); return 99, true }
 	if m, ok := c.resolve(ip); m != 16 || !ok {
-		t.Fatalf("first resolve = %d,%v want 16,true", m, ok)
+		t.Fatalf("warm resolve = %d,%v want 16,true (cache not populated / hit path broken)", m, ok)
 	}
-	// Swap the lookup; within TTL the cached value must win (no new call).
-	c.lookup = func(net.IP) (uint8, bool) { calls++; return 99, true }
-	if m, ok := c.resolve(ip); m != 16 || !ok {
-		t.Fatalf("cached resolve = %d,%v want 16,true (cache miss?)", m, ok)
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("lookup called %d times, want 1 (hit path issued a syscall)", got)
 	}
-	if calls != 1 {
-		t.Fatalf("lookup called %d times, want 1 (cache not used)", calls)
+
+	// A default-route match (/0) caches as a successful resolve (ok=true).
+	c.lookup = func(net.IP) (uint8, bool) { return 0, true }
+	dip := net.IPv4(203, 0, 113, 1)
+	if m, ok := c.resolve(dip); m != 0 || ok {
+		t.Fatalf("default-route first resolve = %d,%v want 0,false (miss default)", m, ok)
 	}
-	// nil IP -> miss without a lookup.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("default-route background lookup never populated the cache")
+	}
+	if m, ok := c.resolve(dip); m != 0 || !ok {
+		t.Fatalf("default-route warm resolve = %d,%v want 0,true (default route not cached as a hit)", m, ok)
+	}
+
+	// nil IP -> miss without scheduling a lookup.
 	if m, ok := c.resolve(nil); m != 0 || ok {
 		t.Fatalf("nil IP resolve = %d,%v want 0,false", m, ok)
 	}
+}
+
+// TestExportSessionCloseDoesNotBlockOnFIBLookup is the #3743 end-to-end pin:
+// ExportSessionClose is invoked from the EventReader session-close callback, so
+// it must never block on the route-mask FIB lookup. The exporter is wired to a
+// routeMaskCache whose FIB lookup blocks until released; ExportSessionClose must
+// return promptly regardless. Reverting resolve() to a synchronous lookup makes
+// ExportSessionClose block on the netlink round-trip -> this test times out RED.
+func TestExportSessionCloseDoesNotBlockOnFIBLookup(t *testing.T) {
+	release := make(chan struct{})
+	c := &routeMaskCache{
+		ttl:         time.Hour,
+		maxInflight: 8,
+		entries:     make(map[string]routeMaskEntry),
+		pending:     make(map[string]struct{}),
+	}
+	c.lookup = func(net.IP) (uint8, bool) {
+		<-release
+		return 24, true
+	}
+	e := Exporter{MaskResolver: c.resolve}
+	rec, sd := closeRecordForMask(false)
+
+	done := make(chan struct{})
+	go func() {
+		e.ExportSessionClose(rec, sd)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// good: returned without waiting for the blocked FIB lookup.
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("ExportSessionClose blocked on the synchronous FIB lookup (netlink on the callback path)")
+	}
+	close(release) // let the background lookups finish and exit
 }
 
 // TestRouteMaskCacheBounded is a fail-on-revert pin for the cache size bound.
@@ -204,40 +303,37 @@ func TestRouteMaskCacheResolves(t *testing.T) {
 // the cache (no extra lookup), so the bound does not break the hit path.
 func TestRouteMaskCacheBounded(t *testing.T) {
 	const maxSize = 64
-	calls := 0
 	c := &routeMaskCache{
 		ttl:     time.Hour, // long TTL: entries never expire during the test,
 		maxSize: maxSize,   // so the bound is enforced purely by the size cap.
 		entries: make(map[string]routeMaskEntry),
 	}
-	c.lookup = func(net.IP) (uint8, bool) { calls++; return 24, true }
+	// storeLocked is the map-insert path the background populate goroutine uses
+	// (#3743). Drive it directly so the size bound is exercised deterministically
+	// without goroutines/timing.
+	insert := func(ip net.IP) {
+		c.mu.Lock()
+		c.storeLocked(string(ip.To16()), 24, true, time.Now())
+		c.mu.Unlock()
+	}
 
 	// Insert far more distinct keys than the cap. Each is a fresh IPv4 address.
 	const inserts = maxSize * 10
 	for i := 0; i < inserts; i++ {
 		ip := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i))
-		c.resolve(ip)
+		insert(ip)
 		if got := len(c.entries); got > maxSize {
 			t.Fatalf("after %d inserts len(entries) = %d, want <= %d (cache unbounded — leak)",
 				i+1, got, maxSize)
 		}
 	}
-	if calls != inserts {
-		t.Fatalf("lookup called %d times, want %d (one per distinct insert)", calls, inserts)
-	}
 
-	// A repeated key within TTL must still hit the cache (no new lookup), even
-	// after the churn above evicted older entries.
-	before := calls
+	// A freshly inserted key within TTL must still resolve from the cache (the
+	// hit path returns it without a lookup), even after the churn above.
 	ip := net.IPv4(192, 0, 2, 7)
+	insert(ip)
 	if m, ok := c.resolve(ip); m != 24 || !ok {
-		t.Fatalf("warm insert = %d,%v want 24,true", m, ok)
-	}
-	if m, ok := c.resolve(ip); m != 24 || !ok {
-		t.Fatalf("warm hit = %d,%v want 24,true", m, ok)
-	}
-	if calls != before+1 {
-		t.Fatalf("repeated key triggered %d lookups, want 1 (hit path broken)", calls-before)
+		t.Fatalf("warm resolve = %d,%v want 24,true (hit path broken)", m, ok)
 	}
 	if len(c.entries) > maxSize {
 		t.Fatalf("final len(entries) = %d, want <= %d", len(c.entries), maxSize)
@@ -269,8 +365,12 @@ func TestRouteMaskCacheEvictsExpiredFirst(t *testing.T) {
 	}
 
 	// A new key at the cap should purge the expired entries (not clear the
-	// whole map), leaving the live entry + the newcomer.
-	c.resolve(net.IPv4(203, 0, 113, 9))
+	// whole map), leaving the live entry + the newcomer. Drive storeLocked
+	// directly — the background populate path (#3743) that would call it.
+	newIP := net.IPv4(203, 0, 113, 9)
+	c.mu.Lock()
+	c.storeLocked(string(newIP.To16()), 16, true, time.Now())
+	c.mu.Unlock()
 	if _, ok := c.entries[string(live.To16())]; !ok {
 		t.Fatalf("live entry was wiped — expired-first purge did not run")
 	}


### PR DESCRIPTION
Closes #3743

## Problem

Route-mask resolution (#2866) issued an `RTM_GETROUTE` netlink syscall
**synchronously inside the EventReader session-close callback**:

`flowExportCallback`/`ipfixExportCallback` (daemon_flowexport.go) →
`ExportSessionClose` → `resolveMasks` → `routeMaskCache.resolve` →
`fibMatchMask` (`netlink.RouteGetWithOptions`, RTM_GETROUTE) on a cache
miss.

That callback runs on the event reader's single processing goroutine, so a
netlink round-trip per cache miss stalls the event reader and every other
callback behind it (including the trace writer). The 10s TTL cache bounds
the syscall *rate*, but a miss is still a synchronous netlink round-trip on
the hot close path, and under high destination-IP churn the cache thrashes
→ close handling becomes a netlink-bound path with unbounded latency and
backpressure (can back up SESSION_CLOSE processing and drop events).

## Fix

Move the FIB lookup **off** the callback goroutine (`pkg/flowexport/routemask.go`):

- `resolve()` serves a fresh cache **hit** directly (unchanged) and, on a
  **miss**, returns the safe default (mask `0`, `ok=false`) immediately
  while scheduling a bounded, deduplicated **background** lookup that warms
  the cache for the next flow to that prefix.
- `scheduleLookupLocked` starts one goroutine per newly-missed IP; a
  `pending` set dedups concurrent misses for the same key, and an
  `inflight` counter caps concurrency at `defaultRouteMaskInflight` (32) so
  a slow/loaded netlink socket cannot spawn unbounded goroutines — over-cap
  misses just return the default and retry on a later flow.
- `populate` runs the single netlink lookup entirely off the callback path
  and stores via `storeLocked` (reusing the existing `evictLocked` size
  bound). Background goroutines are short-lived and self-terminate — no
  lifecycle/Close plumbing, and reconcile cannot leak them.

An approximate mask (`0`) on the **first** flow to a new prefix is the
accepted trade-off for never blocking the shared event-reader path; the
common per-host/per-subnet aggregate resolves correctly from the warm cache
on the second flow onward. The cache-hit case (the overwhelming majority)
is unchanged.

Scope: this removes the synchronous-netlink-in-callback blocking only.
#3744 (route-mask being VRF/table/source-blind) is a **separate** design
item and intentionally out of scope.

## Tests (RED-on-revert)

- `TestRouteMaskResolveMissDoesNotLookupSynchronously` — a cache miss with a
  lookup that blocks on a channel must still return the default immediately.
- `TestExportSessionCloseDoesNotBlockOnFIBLookup` — end-to-end: with a
  blocking FIB lookup, `ExportSessionClose` (the call the callback makes)
  returns promptly.
- `TestRouteMaskCacheAsyncPopulateAndHit` — miss → default → background
  populate → warm hit; default-route `/0` caches as `ok=true`.
- Bound / expired-first evict tests now drive `storeLocked` directly (the
  background populate insert path).

**Verified RED on revert:** reverting `resolve()` to the synchronous
lookup-in-callback makes both no-block tests block → time out (30s FAIL).

**Green:** `go test -race ./pkg/flowexport/...` and `go test ./pkg/daemon/`
pass; `go build ./...`, `gofmt`, and `go vet` clean. (`pkg/flowexport/netflow.go`
has a pre-existing gofmt diff on origin/master; not touched by this PR.)

Module doc updated: `pkg/flowexport/README.md` (#2866 section + routemask.go
file-layout entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi