### PR TITLE
ddns/surface-a: observe address off the manager mutex + honor the reconcile ctx (#3736)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-07-01 — #3736 ddns Surface A: run the checkip address observation UNLOCKED + with the reconcile ctx (observation residual of #2778)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3736 (MEDIUM, folds codex-review-157 H05+H06). #2778 moved
+    provider Upsert/Delete off `m.mu` via `providerIO`, but the per-scope
+    ADDRESS OBSERVATION was left under the lock — and for the checkip source
+    that observation is a blocking external HTTP GET (up to 10s). It also
+    used `context.Background()`, so it ignored the reconcile/shutdown ctx.
+    Impact: N checkip scopes with a black-holed endpoint held `m.mu` up to
+    N*10s, wedging `StatusViews`/`Stats`/other-scope reconcile; shutdown hung
+    behind an in-flight probe.
+    FIX (a): added `SurfaceAManager.observeIO` (mirrors `providerIO`) and
+    `reconcileScopeLocked` now runs `observe(ctx, sc)` with `m.mu` RELEASED —
+    the observation only READS external state (netlink/DHCP/HTTP), reconcile
+    is serialized by the daemon (`surfaceAReconcileInFlight`), and ownership
+    is re-read under the re-acquired lock before any decision; the backoff
+    window is still checked UNDER the lock BEFORE the probe.
+    FIX (b): threaded `context.Context` into the `AddressObserver` signature;
+    the daemon observer's checkip branch now derives its 10s bound from the
+    reconcile ctx (`context.WithTimeout(ctx, ...)`), so a shutdown/pass
+    cancel aborts an in-flight probe promptly (`doRequest` already applies
+    `req.WithContext`).
+    Three RED-on-revert tests: `TestSurfaceALockNotHeldDuringObserve`
+    (concurrent StatusViews/Stats proceed while a blocking observe is in
+    flight; RED = they block under the held lock),
+    `TestSurfaceAObserveHonorsReconcileContextCancel` (engine threads the
+    ctx; RED = Reconcile hangs after cancel), and
+    `TestSurfaceAObserverCheckIPHonorsReconcileContext` (daemon; a
+    short-deadline ctx aborts the probe to a hung httptest endpoint; RED =
+    blocks 10s on `context.Background`). `go test -race ./pkg/ddns/...
+    ./pkg/daemon/` green; `go build ./...`, gofmt, vet clean. Updated the
+    observation lock/ctx invariant in `docs/research/ddns-world-class/plan.md`
+    §5.3.
+  - **File(s)**: pkg/ddns/surface_a.go,
+    pkg/daemon/daemon_ddns_surface_a.go,
+    pkg/ddns/surface_a_observe_lockio_3736_test.go,
+    pkg/daemon/daemon_ddns_surface_a_test.go, pkg/ddns/surface_a_test.go,
+    pkg/ddns/surface_a_rfc2136_test.go,
+    pkg/ddns/surface_a_httpcache_reap_2956_test.go,
+    pkg/ddns/surface_a_http_test.go,
+    pkg/ddns/surface_a_withdraw_backoff_2813_test.go,
+    docs/research/ddns-world-class/plan.md, _Log.md
+
 ## 2026-07-01 — #3734 ddns Surface A: seedFromStore + renumber log read AddrText (not the always-empty Address) → no restart republish storm, renumber leaves a trace
 
 - **Timestamp**: 2026-07-01

--- a/docs/research/ddns-world-class/plan.md
+++ b/docs/research/ddns-world-class/plan.md
@@ -456,6 +456,29 @@ without flooding the per-tick observer. Fail-open to the default route
 remains acceptable for generic HTTP UPDATE backends (they carry a
 credential and target a fixed provider host); the checkip oracle does not.
 
+**Observation runs UNLOCKED, with the reconcile context — invariant
+(#3736, the observation residual of #2778).** The engine invokes the
+`AddressObserver` with the manager mutex `m.mu` RELEASED (via
+`SurfaceAManager.observeIO`, mirroring `providerIO` for provider I/O) and
+threads the reconcile/pass `context.Context` into it. Both matter only for
+the checkip source, whose observation is a blocking external HTTP GET (up
+to `surfaceACheckIPTimeout` = 10s): (1) holding `m.mu` across that probe
+would block `StatusViews`/`Stats` and serialize every OTHER scope's
+reconcile behind a slow/black-holed checkip endpoint — for N checkip
+scopes with a hung endpoint the lock would be held up to N*10s; (2) the
+daemon observer now derives the per-probe timeout from the reconcile ctx
+(`context.WithTimeout(ctx, ...)`, NOT `context.Background()`), so a daemon
+shutdown / pass-deadline cancel aborts an in-flight probe promptly instead
+of hanging behind it. The observation only READS external state (netlink /
+DHCP / HTTP), never manager state, and reconcile passes are serialized by
+the daemon (`surfaceAReconcileInFlight`), so dropping the lock for the
+round-trip is safe: no concurrent pass mutates `m.runtime`/`m.state`, and
+the engine re-reads ownership under the re-acquired lock before any
+publish/withdraw decision. The per-scope error-backoff window is checked
+UNDER the lock BEFORE the observation, so a backed-off scope never issues
+the HTTP probe. Adding a new blocking address source MUST keep the
+observation on this unlocked, ctx-bound path.
+
 For **Surface B** the observation is the existing Kea-memfile lease parser
 (`pkg/dhcpserver/ddns_leases.go`) — unchanged, just emitting `ScopeKey`-
 tagged records.

--- a/pkg/daemon/daemon_ddns_surface_a.go
+++ b/pkg/daemon/daemon_ddns_surface_a.go
@@ -232,7 +232,7 @@ func (d *Daemon) buildSurfaceAScopes(cfg *config.Config) []ddns.SurfaceAScope {
 // "definitively no address" (interface down / lease gone) — the engine
 // withdraws.
 func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
-	return func(scope ddns.SurfaceAScope) (ddns.AddressObservation, bool) {
+	return func(ctx context.Context, scope ddns.SurfaceAScope) (ddns.AddressObservation, bool) {
 		ifName := scope.Key.Interface
 		un := scope.Key.Unit
 		af4 := scope.Key.Family == ddns.FamilyV4
@@ -251,7 +251,13 @@ func (d *Daemon) surfaceAObserver(cfg *config.Config) ddns.AddressObserver {
 			if scope.Provider == nil || scope.Provider.CheckIPURL == "" {
 				return ddns.AddressObservation{}, false
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), surfaceACheckIPTimeout)
+			// Bound the single probe by surfaceACheckIPTimeout BUT derive it from
+			// the reconcile ctx, not context.Background() (#3736): a daemon
+			// shutdown / pass-deadline cancel now aborts an in-flight checkip
+			// promptly instead of hanging up to the full 10s. The engine already
+			// runs this observer with the manager mutex released, so a slow probe
+			// no longer blocks StatusViews/Stats/other scopes either.
+			ctx, cancel := context.WithTimeout(ctx, surfaceACheckIPTimeout)
 			defer cancel()
 			allow, badAllow := ddns.ParseAllowlistChecked(scope.Provider.CheckIPAllowlist)
 			if len(badAllow) > 0 {

--- a/pkg/daemon/daemon_ddns_surface_a_test.go
+++ b/pkg/daemon/daemon_ddns_surface_a_test.go
@@ -1,11 +1,15 @@
 package daemon
 
 import (
+	"context"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -673,7 +677,7 @@ func TestSurfaceAObserverDHCPPublicGate(t *testing.T) {
 				Source: ddns.AddressSourceDHCP,
 				FQDN:   "wan.example.net",
 			}
-			obs, ok := d.surfaceAObserver(cfg)(scope)
+			obs, ok := d.surfaceAObserver(cfg)(context.Background(), scope)
 			if !ok {
 				t.Fatalf("DHCP observation must be definitive (ok=true); got ok=false")
 			}
@@ -692,5 +696,71 @@ func TestSurfaceAObserverDHCPPublicGate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestSurfaceAObserverCheckIPHonorsReconcileContext is the #3736 fail-on-revert
+// proof for the checkip source: the per-probe timeout MUST derive from the
+// reconcile/pass context, not context.Background(). A checkip endpoint that
+// black-holes (accepts the connection but never responds) is probed while the
+// caller's ctx carries a short deadline. With the fix the derived context is
+// context.WithTimeout(ctx, ...), so the parent's deadline fires and the probe
+// aborts promptly (a transient miss, ok=false). Revert to
+// context.WithTimeout(context.Background(), surfaceACheckIPTimeout) and the
+// parent deadline is ignored — the probe blocks on the hung endpoint for the
+// full 10s and the bounded wait below fires t.Fatal.
+func TestSurfaceAObserverCheckIPHonorsReconcileContext(t *testing.T) {
+	// A checkip endpoint that black-holes: it accepts the request and blocks
+	// until the client cancels (the fix) or the test tears down (a revert).
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-done:
+		}
+	}))
+	// Cleanups run LIFO: close(done) first so any blocked handler unblocks, THEN
+	// srv.Close() (which waits for in-flight handlers) can return.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(done) })
+
+	d := &Daemon{surfaceA: ddns.NewSurfaceAManager()}
+	cfg := &config.Config{}
+	scope := ddns.SurfaceAScope{
+		Key: ddns.ScopeKey{
+			Family:    ddns.FamilyV4,
+			Interface: "ge-0/0/2",
+			Unit:      0,
+		},
+		Source: ddns.AddressSourceCheckIP,
+		FQDN:   "wan.example.net",
+		Provider: &config.DDNSProvider{
+			Name:       "corp",
+			CheckIPURL: srv.URL,
+		},
+	}
+
+	// A reconcile ctx with a short deadline; the in-flight probe must inherit it.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	type result struct {
+		obs ddns.AddressObservation
+		ok  bool
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		obs, ok := d.surfaceAObserver(cfg)(ctx, scope)
+		resCh <- result{obs, ok}
+	}()
+
+	select {
+	case r := <-resCh:
+		if r.ok {
+			t.Fatalf("a checkip probe aborted by the reconcile ctx must be a transient miss (ok=false); got ok=true addr=%v", r.obs.Addr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkip observer ignored the reconcile ctx deadline and blocked on the hung endpoint " +
+			"(context.Background regression, #3736)")
 	}
 }

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -142,7 +142,14 @@ type AddressObservation struct {
 // memfile parser. ok=false means the address could not be observed this cycle
 // (transient) — the engine then leaves the scope untouched (no withdraw on a
 // transient observation failure, the never-blackhole rule).
-type AddressObserver func(scope SurfaceAScope) (AddressObservation, bool)
+//
+// ctx is the reconcile/pass context (#3736): the checkip address source
+// performs a blocking external HTTP GET, and threading ctx lets that probe
+// inherit the pass deadline and abort promptly on daemon shutdown instead of
+// hanging up to its own fixed timeout. The engine invokes the observer with
+// m.mu RELEASED (see reconcileScopeLocked) so a slow/black-holed checkip
+// endpoint cannot block StatusViews/Stats or serialize other scopes.
+type AddressObserver func(ctx context.Context, scope SurfaceAScope) (AddressObservation, bool)
 
 // surfaceAState is the per-scope runtime engine state (plan §5.5): the
 // last-published address + time (change-detection + forced-refresh) and the
@@ -567,6 +574,27 @@ func (m *SurfaceAManager) providerIO(fn func() error) error {
 	return fn()
 }
 
+// observeIO runs the per-scope address observation with m.mu RELEASED (#3736,
+// the observation residual of #2778). For a checkip source the observer
+// performs a blocking external HTTP GET (up to ~10s); holding the manager mutex
+// across it would block StatusViews/Stats and serialize every OTHER scope's
+// reconcile behind a slow/black-holed checkip endpoint — the exact lock
+// discipline #2778 established for provider Upsert/Delete, which observation was
+// left out of. The observation only READS external state (netlink / DHCP /
+// HTTP), never manager state, so nothing under the lock is needed for the
+// round-trip; the caller re-reads m.state/m.runtime after the lock is
+// re-acquired before making any publish/withdraw decision. The daemon
+// serializes reconcile passes (surfaceAReconcileInFlight), so no concurrent
+// pass mutates m.runtime/m.state while the lock is dropped here — only the
+// read-only StatusViews/Stats callers may run, which is the whole point.
+// Panic-safe: the lock is re-acquired even if fn panics, keeping Reconcile's
+// deferred Unlock balanced.
+func (m *SurfaceAManager) observeIO(fn func()) {
+	m.mu.Unlock()
+	defer m.mu.Lock()
+	fn()
+}
+
 // Reconcile drives one Surface A reconcile pass over the configured scopes
 // (plan §5.5/§5.6). For each scope it: observes the current address; applies
 // the per-RG HA gate; runs change-detection + forced-refresh + error backoff;
@@ -770,7 +798,17 @@ func (m *SurfaceAManager) reconcileScopeLocked(ctx context.Context, sc SurfaceAS
 		return nil
 	}
 
-	obs, ok := observe(sc)
+	// Observe the scope's current address with m.mu RELEASED and the reconcile
+	// ctx threaded (#3736): for a checkip source `observe` is a blocking external
+	// HTTP GET, so holding the mutex across it would block StatusViews/Stats and
+	// serialize other scopes behind a hung endpoint, and ignoring ctx would hang
+	// shutdown behind an in-flight probe. The backoff-window check above already
+	// ran under the lock, so a backed-off scope never reaches this HTTP call.
+	var (
+		obs AddressObservation
+		ok  bool
+	)
+	m.observeIO(func() { obs, ok = observe(ctx, sc) })
 	if !ok {
 		// Transient observation failure: leave the scope untouched (never
 		// withdraw on a transient — the never-blackhole rule, plan §8.2).

--- a/pkg/ddns/surface_a_http_test.go
+++ b/pkg/ddns/surface_a_http_test.go
@@ -382,7 +382,7 @@ func TestStatusViewsSurfacesPendingAndPublished(t *testing.T) {
 		TTL:    300,
 		Source: AddressSourceDHCP,
 	}
-	noObserve := func(SurfaceAScope) (AddressObservation, bool) { return AddressObservation{}, false }
+	noObserve := func(context.Context, SurfaceAScope) (AddressObservation, bool) { return AddressObservation{}, false }
 	if err := m.Reconcile(context.Background(), []SurfaceAScope{published, pending}, noObserve, nil, nil); err != nil {
 		t.Fatalf("Reconcile pending: %v", err)
 	}

--- a/pkg/ddns/surface_a_httpcache_reap_2956_test.go
+++ b/pkg/ddns/surface_a_httpcache_reap_2956_test.go
@@ -144,7 +144,7 @@ func TestSurfaceAReconcileReapsSupersededHTTPClients(t *testing.T) {
 			t.Fatalf("resolveBackend pass %d: %v", i, err)
 		}
 		catalog := map[string]*config.DDNSProvider{"p": p}
-		err := m.Reconcile(ctx, nil, func(SurfaceAScope) (AddressObservation, bool) {
+		err := m.Reconcile(ctx, nil, func(context.Context, SurfaceAScope) (AddressObservation, bool) {
 			return AddressObservation{}, false
 		}, nil, catalog)
 		if err != nil {

--- a/pkg/ddns/surface_a_observe_lockio_3736_test.go
+++ b/pkg/ddns/surface_a_observe_lockio_3736_test.go
@@ -1,0 +1,152 @@
+package ddns
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+// surface_a_observe_lockio_3736_test.go: #3736 — the per-scope ADDRESS
+// OBSERVATION (the checkip source performs a blocking external HTTP GET) must
+// run with the manager mutex RELEASED and with the reconcile context threaded,
+// the observation residual #2778 left behind. These are the fail-on-revert
+// proofs: revert the observeIO lock-release and the "concurrent StatusViews/
+// Stats proceed while observe is in flight" waits HANG; revert the ctx
+// threading in reconcileScopeLocked and the ctx-cancel wait HANGS.
+
+// blockingObserver signals entry on `entered` then blocks the observe call until
+// `release` is closed (or the reconcile ctx is cancelled). Deterministic:
+// channels, no sleeps. It mirrors blockingUpdater, but for the observe seam.
+type blockingObserver struct {
+	entered chan struct{}
+	release chan struct{}
+	addr    netip.Addr
+}
+
+func (b *blockingObserver) observe(ctx context.Context, _ SurfaceAScope) (AddressObservation, bool) {
+	b.entered <- struct{}{}
+	select {
+	case <-b.release:
+		return AddressObservation{Addr: b.addr, Source: AddressSourceDHCP}, true
+	case <-ctx.Done():
+		return AddressObservation{}, false
+	}
+}
+
+// TestSurfaceALockNotHeldDuringObserve proves m.mu is released while the address
+// observation is in flight (#3736). A blocking observer holds the observe call
+// open (as a slow/black-holed checkip HTTP GET would); concurrently a
+// StatusViews() and a Stats() call (both take m.mu) MUST complete. If the lock
+// were held across the observation — the pre-#3736 behaviour — these reads block
+// until release and the bounded waits fire t.Fatal (fail-on-revert).
+func TestSurfaceALockNotHeldDuringObserve(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	bo := &blockingObserver{
+		entered: make(chan struct{}, 1),
+		release: make(chan struct{}),
+		addr:    netip.MustParseAddr("203.0.113.5"),
+	}
+
+	reconcileDone := make(chan struct{})
+	go func() {
+		_ = m.Reconcile(context.Background(), []SurfaceAScope{sc}, bo.observe, nil, nil)
+		close(reconcileDone)
+	}()
+
+	// Wait until the observation is actually in flight (the lock, if held across
+	// observe, would be held now).
+	select {
+	case <-bo.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer never started")
+	}
+
+	// While the observation is blocked, a StatusViews() (which takes m.mu) MUST
+	// proceed. If the lock were held across the observation this read would block
+	// and the bounded wait fires — the fail-on-revert assertion.
+	statusDone := make(chan []SurfaceAStatusView, 1)
+	go func() { statusDone <- m.StatusViews([]SurfaceAScope{sc}) }()
+	select {
+	case <-statusDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StatusViews blocked while the address observation was in flight — lock held across observe (#3736 regression)")
+	}
+
+	// Same for Stats().
+	statsDone := make(chan SurfaceAStats, 1)
+	go func() { statsDone <- m.Stats() }()
+	select {
+	case <-statsDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stats blocked while the address observation was in flight — lock held across observe (#3736 regression)")
+	}
+
+	// Release the observation and let the pass complete.
+	close(bo.release)
+	select {
+	case <-reconcileDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile did not finish after the observer released")
+	}
+
+	// Happy path preserved: the observed address is still applied under the lock.
+	ups := fu.upsertNames()
+	if len(ups) != 1 || ups[0] != "wan.example.net=203.0.113.5" {
+		t.Fatalf("expected the observed address to be published, got %v", ups)
+	}
+	if st := m.Stats(); st.UpsertOK != 1 || st.Scopes != 1 {
+		t.Fatalf("stats after release: %+v", st)
+	}
+}
+
+// TestSurfaceAObserveHonorsReconcileContextCancel proves the engine threads the
+// reconcile/pass context into the observer (#3736) so a shutdown/pass-deadline
+// cancel aborts an in-flight observation promptly instead of hanging. The
+// observer returns ok=false (a transient miss) ONLY when it sees ctx.Done(); if
+// reconcileScopeLocked passed context.Background() (or dropped the ctx) instead
+// of the reconcile ctx, the cancel below would never reach the observer and
+// Reconcile would hang — fail-on-revert.
+func TestSurfaceAObserveHonorsReconcileContextCancel(t *testing.T) {
+	fu := newFakeUpdater()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceATestManager(t, fu, func() time.Time { return now })
+	sc := surfaceAScope("wan.example.net", FamilyV4, 0)
+
+	entered := make(chan struct{}, 1)
+	observe := func(ctx context.Context, _ SurfaceAScope) (AddressObservation, bool) {
+		entered <- struct{}{}
+		<-ctx.Done()
+		return AddressObservation{}, false
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reconcileDone := make(chan error, 1)
+	go func() {
+		reconcileDone <- m.Reconcile(ctx, []SurfaceAScope{sc}, observe, nil, nil)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observer never started")
+	}
+	cancel()
+	select {
+	case err := <-reconcileDone:
+		if err != nil {
+			t.Fatalf("Reconcile after ctx cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile did not observe the ctx cancel — engine did not thread the reconcile context into the observer (#3736 regression)")
+	}
+
+	// A ctx-cancelled transient observation (ok=false) must never touch the wire.
+	if got := len(fu.upserts); got != 0 {
+		t.Fatalf("a ctx-cancelled transient observation must not publish; got %d upserts", got)
+	}
+}

--- a/pkg/ddns/surface_a_rfc2136_test.go
+++ b/pkg/ddns/surface_a_rfc2136_test.go
@@ -153,7 +153,7 @@ func TestSurfaceARealBackendWithdrawOnAddressLoss(t *testing.T) {
 		t.Fatal("zone must hold the record before withdraw")
 	}
 	// Address definitively lost.
-	lost := func(SurfaceAScope) (AddressObservation, bool) {
+	lost := func(context.Context, SurfaceAScope) (AddressObservation, bool) {
 		return AddressObservation{Source: AddressSourceInterface}, true
 	}
 	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, lost, nil, catalog); err != nil {

--- a/pkg/ddns/surface_a_test.go
+++ b/pkg/ddns/surface_a_test.go
@@ -48,7 +48,7 @@ func surfaceAScope(fqdn string, family Family, rg int) SurfaceAScope {
 // fixedObserver returns a single address for every scope.
 func fixedObserver(addr string) AddressObserver {
 	a := netip.MustParseAddr(addr)
-	return func(SurfaceAScope) (AddressObservation, bool) {
+	return func(context.Context, SurfaceAScope) (AddressObservation, bool) {
 		return AddressObservation{Addr: a, Source: AddressSourceDHCP}, true
 	}
 }
@@ -210,7 +210,7 @@ func TestSurfaceATransientObservationDoesNotWithdraw(t *testing.T) {
 	}
 	// Transient observation failure (ok=false): NEVER withdraw (the
 	// never-blackhole rule).
-	transient := func(SurfaceAScope) (AddressObservation, bool) {
+	transient := func(context.Context, SurfaceAScope) (AddressObservation, bool) {
 		return AddressObservation{}, false
 	}
 	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, transient, nil, nil); err != nil {

--- a/pkg/ddns/surface_a_withdraw_backoff_2813_test.go
+++ b/pkg/ddns/surface_a_withdraw_backoff_2813_test.go
@@ -98,7 +98,7 @@ func TestSurfaceAWithdrawBacksOffAddressLoss(t *testing.T) {
 
 	// Observer now reports a definitive "no address" (ok=true, invalid Addr) →
 	// the engine withdraws the previously-published record.
-	lost := func(SurfaceAScope) (AddressObservation, bool) {
+	lost := func(context.Context, SurfaceAScope) (AddressObservation, bool) {
 		return AddressObservation{Source: AddressSourceDHCP}, true
 	}
 


### PR DESCRIPTION
## Summary

Closes #3736 (codex-review-157 H05/H06). #2778 moved provider
Upsert/Delete off `SurfaceAManager.mu` (via `providerIO`) but left the
per-scope ADDRESS OBSERVATION under the lock. For the checkip source that
observation is a blocking external HTTP GET (up to the 10s
`surfaceACheckIPTimeout`), and it derived that timeout from
`context.Background()`, so it ignored the reconcile/shutdown context.

**Impact:** with N checkip scopes and a black-holed checkip endpoint the
manager mutex was held for up to N*10s, wedging `StatusViews`/`Stats` and
every other scope's reconcile behind the probe; shutdown/failover hung
behind an in-flight probe because it never observed ctx cancellation. This
violated the lock discipline #2778 established for provider I/O.

## Fix

- **(a) Observe unlocked.** New `SurfaceAManager.observeIO` (mirrors
  `providerIO`); `reconcileScopeLocked` now runs `observe(ctx, sc)` with
  `m.mu` RELEASED. The observation only READS external state
  (netlink/DHCP/HTTP), never manager state; the daemon serializes reconcile
  passes (`surfaceAReconcileInFlight`) so no concurrent pass mutates
  `m.runtime`/`m.state` while the lock is dropped, and ownership is re-read
  under the re-acquired lock before any publish/withdraw decision. The
  per-scope error-backoff window is still checked UNDER the lock BEFORE the
  probe, so a backed-off scope never issues the HTTP call.
- **(b) Thread the reconcile ctx.** `AddressObserver` now takes a
  `context.Context`. The daemon observer's checkip branch derives its
  per-probe timeout from the reconcile ctx
  (`context.WithTimeout(ctx, ...)`) instead of `context.Background()`, so a
  daemon shutdown / pass-deadline cancel aborts an in-flight checkip
  promptly (`doRequest` already applies `req.WithContext`).

## RED-on-revert tests (all three verified RED with the fix reverted)

- `TestSurfaceALockNotHeldDuringObserve` — a blocking observer holds the
  observation open while concurrent `StatusViews()`/`Stats()` (both take
  `m.mu`) must complete. Revert the `observeIO` unlock → they block, bounded
  waits fire.
- `TestSurfaceAObserveHonorsReconcileContextCancel` — the engine threads
  the reconcile ctx into the observer. Revert to `context.Background()` /
  drop the ctx → `Reconcile` hangs after cancel.
- `TestSurfaceAObserverCheckIPHonorsReconcileContext` (daemon) — a
  short-deadline ctx aborts an in-flight probe to a hung `httptest`
  endpoint. Revert to `context.Background()` → blocks the full 10s, 2s
  bound fires.

## Validation

`go test -race ./pkg/ddns/... ./pkg/daemon/` green; `go build ./...`,
`gofmt`, `go vet` clean. Concurrency fix — run under `-race`. Updated the
observation lock/ctx invariant in
`docs/research/ddns-world-class/plan.md` §5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
