### PR TITLE
userspace-dp: table-scope the local-delivery decision for NAT/DNAT external targets (#3769)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-07-01 — #3769 userspace-dp: table-scope the local-delivery DECISION for NAT/DNAT external targets (cross-VRF leak + ifindex-0)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3769 (HIGH, VRF isolation / zone + HA-RG mis-attribution;
+    residual of #3151). Static-NAT external IPs and DNAT destination IPs
+    are inserted into the GLOBAL `local_v4`/`local_v6` sets with no
+    table/VRF attribution (they have no connected route). #3151 made only
+    the local-delivery ifindex ATTRIBUTION table-scoped; the membership
+    DECISION stayed global, so a packet in VRF A destined to a NAT/DNAT
+    address owned in VRF B hit the global `local_v*` membership and
+    short-circuited to `LocalDelivery` (with ifindex 0), bypassing the
+    VRF-A FIB + zone/security-policy + HA-RG owner check
+    (`owner_rg_for_flow(egress_ifindex)`).
+    FIX: carry per-external-IP table ownership. New
+    `ForwardingState.local_nat_tables_v4/v6: FastMap<Ip, FastSet<String>>`
+    populated in `forwarding_build` from each NAT/DNAT rule's `from
+    routing-instance` (converted to a canonical route table via
+    `connected_route_tables`) — via new `StaticNatTable::external_ips_scoped`
+    and `DnatTable::destination_ips_scoped` (the latter now also backs
+    `destination_ips` so the two views cannot drift). The
+    `lookup_forwarding_resolution_inner_ecmp` shortcut now delivers locally
+    ONLY when THIS table owns the address (interface owns it here — the
+    #3151 connected scan matched — OR a NAT/DNAT rule in this
+    routing-instance owns it); an address owned only in another table falls
+    through to the route lookup. This also generalizes #3151 to a
+    single-owner interface IP (present in exactly one VRF). L5: a
+    NAT/DNAT-only external target has no interface, so its LocalDelivery
+    carries ifindex 0 legitimately — now GATED on table ownership and
+    counted by the new `LOCAL_DELIVERY_IFINDEX0` diagnostic atomic.
+  - **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs,
+    userspace-dp/src/afxdp/forwarding/mod.rs,
+    userspace-dp/src/afxdp/forwarding_build/mod.rs,
+    userspace-dp/src/nat/static_nat.rs,
+    userspace-dp/src/nat/destination.rs,
+    userspace-dp/src/afxdp/forwarding/tests.rs,
+    userspace-dp/src/afxdp/forwarding/README.md
+  - **Tests**: added (forwarding/tests.rs)
+    `static_nat_local_delivery_is_table_scoped_no_cross_vrf_leak`,
+    `dnat_local_delivery_is_table_scoped_no_cross_vrf_leak`,
+    `nat_local_delivery_v6_is_table_scoped_no_cross_vrf_leak`,
+    `nat_local_delivery_default_vrf_unchanged_and_counts_ifindex0`,
+    `interface_local_delivery_single_vrf_no_cross_vrf_leak`. RED-on-revert
+    verified: forcing the pre-#3769 global membership (`if true || ...`)
+    fails the three v4 cross-VRF assertions; the existing #3151 test still
+    passes (it uses the same IP in BOTH VRFs, so its table-scoped ifindex
+    is unaffected — proving the new tests catch what #3151 cannot).
+
 ## 2026-07-01 — #3761 ip-monitoring: honest status/metrics (UNKNOWN vs PASS, applied vs desired, suppressed vs unresolved)
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -11,22 +11,27 @@
     short-circuited to `LocalDelivery` (with ifindex 0), bypassing the
     VRF-A FIB + zone/security-policy + HA-RG owner check
     (`owner_rg_for_flow(egress_ifindex)`).
-    FIX: carry per-external-IP table ownership. New
-    `ForwardingState.local_nat_tables_v4/v6: FastMap<Ip, FastSet<String>>`
-    populated in `forwarding_build` from each NAT/DNAT rule's `from
-    routing-instance` (converted to a canonical route table via
-    `connected_route_tables`) — via new `StaticNatTable::external_ips_scoped`
-    and `DnatTable::destination_ips_scoped` (the latter now also backs
+    FIX: carry per-address table ownership. New
+    `ForwardingState.local_tables_v4/v6: FastMap<Ip, FastSet<String>>` with
+    an insert paired to EVERY `local_v*` insert — interface HOST addresses
+    in `populate_interfaces` (keyed by `.addr()`, NOT the masked connected
+    prefix), NAT/DNAT externals in `forwarding_build` from each rule's
+    `from routing-instance` (canonical table via `connected_route_tables`),
+    fed by new `StaticNatTable::external_ips_scoped` and
+    `DnatTable::destination_ips_scoped` (the latter now also backs
     `destination_ips` so the two views cannot drift). The
     `lookup_forwarding_resolution_inner_ecmp` shortcut now delivers locally
-    ONLY when THIS table owns the address (interface owns it here — the
-    #3151 connected scan matched — OR a NAT/DNAT rule in this
-    routing-instance owns it); an address owned only in another table falls
-    through to the route lookup. This also generalizes #3151 to a
-    single-owner interface IP (present in exactly one VRF). L5: a
-    NAT/DNAT-only external target has no interface, so its LocalDelivery
-    carries ifindex 0 legitimately — now GATED on table ownership and
-    counted by the new `LOCAL_DELIVERY_IFINDEX0` diagnostic atomic.
+    ONLY when the RESOLVING table is in the address's owning set; an address
+    owned only in another table falls through to the route lookup. The
+    membership DECISION deliberately does NOT use the connected scan — a
+    NAT-only IP has no connected route, and `ConnectedRouteV*` stores the
+    MASKED network so `prefix.addr() == host` matches only a /32 (a non-/32
+    interface IP would wrongly fall through). The connected scan is retained
+    for the ifindex ATTRIBUTION only (the #3151 /32-HA case). This
+    generalizes #3151 to a single-owner interface IP (present in exactly one
+    VRF). L5: a NAT-only external target (or a non-/32 interface IP) has no
+    exact connected match → ifindex 0, now reached ONLY when the table owns
+    the address, counted by the new `LOCAL_DELIVERY_IFINDEX0` diagnostic.
   - **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs,
     userspace-dp/src/afxdp/forwarding/mod.rs,
     userspace-dp/src/afxdp/forwarding_build/mod.rs,

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,37 @@
+## 2026-07-01 — #3769 fold (review MINOR): empty from-routing-instance NAT external = table-agnostic wildcard
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Hostile review of PR #3799 flagged a MINOR attribution
+    asymmetry. The NAT matchers' `scope_ok` treats an EMPTY
+    `from_routing_instance` as a WILDCARD (matches ANY ingress
+    routing-instance; `nat/destination.rs`, `nat/static_nat.rs`,
+    `nat/source.rs`), and the common `from zone` / `from interface`
+    inbound-DNAT rule leaves the routing instance empty
+    (`compiler_nat.go`). My first cut attributed an empty-scope external IP
+    to `inet.0` only (via `connected_route_tables("")`), over-isolating it
+    when its zone lives in a non-default VRF (latent — pre-routing DNAT
+    translates the dst before the table-scoped shortcut, so no happy-path
+    blackhole, but an UN-translated external IP in a non-default VRF was
+    mis-isolated).
+    FIX: new table-agnostic `ForwardingState.local_nat_any_table_v4/v6`
+    sets. `forwarding_build` routes an empty-scope NAT/DNAT external into
+    those (wildcard); a NAMED instance keeps the exact-table attribution in
+    `local_tables_v*` (correct cross-VRF isolation, unchanged). The
+    local-delivery DECISION treats a `local_nat_any_table_v*` member as
+    owned in EVERY resolving table. Interface host addresses are never
+    wildcarded.
+  - **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs,
+    userspace-dp/src/afxdp/forwarding/mod.rs,
+    userspace-dp/src/afxdp/forwarding_build/mod.rs,
+    userspace-dp/src/afxdp/forwarding/tests.rs,
+    userspace-dp/src/afxdp/forwarding/README.md
+  - **Tests**: added `unscoped_nat_local_delivery_is_wildcard_across_vrfs`
+    (unscoped static-NAT + DNAT externals must LocalDeliver in None /
+    inet.0 / tenant-a.inet.0). RED-on-revert: forcing `wildcard = false`
+    (empty scope → inet.0 only) makes the tenant-a assertion NoRoute →
+    RED, while the named-VRF isolation tests and the default-VRF test still
+    pass. Full `cargo test --release` green.
+
 ## 2026-07-01 — #3769 userspace-dp: table-scope the local-delivery DECISION for NAT/DNAT external targets (cross-VRF leak + ifindex-0)
 
 - **Timestamp**: 2026-07-01

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -58,6 +58,26 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
     (`owner_rg_for_flow(egress_ifindex)`). The default routing-instance
     (`inet.0`/`inet6.0`) case still matches default-table connected
     routes.
+  - **Local-delivery DECISION is table-scoped too (#3769).** #3151 fixed
+    the ifindex ATTRIBUTION but the membership DECISION stayed global:
+    `local_v[46]` is a global set, and it also carries NAT/DNAT external
+    targets (static-NAT external IPs + DNAT destination IPs) that have NO
+    connected route, so their owning routing-instance was lost. A packet
+    in VRF A destined to a NAT/DNAT address owned in VRF B hit the global
+    `local_v[46]` membership and short-circuited to `LocalDelivery` (with
+    ifindex 0), bypassing the VRF-A FIB + zone/policy + HA-RG owner check.
+    The build now records per-external-IP table ownership in
+    `local_nat_tables_v[46]` (each NAT/DNAT rule's `from routing-instance`
+    → canonical table via `connected_route_tables`), and the shortcut
+    delivers locally ONLY when THIS table owns the address — an interface
+    owns it here (connected scan matched) OR a NAT/DNAT rule in this
+    routing-instance owns it. An address owned only in another table falls
+    through to the route lookup (VRF-A FIB). This also generalizes #3151
+    to a single-owner interface IP (the same IP in exactly one VRF, not
+    both). **L5:** a NAT/DNAT-only external target has no interface, so its
+    LocalDelivery carries ifindex 0 legitimately — now GATED on table
+    ownership and counted by the `LOCAL_DELIVERY_IFINDEX0` diagnostic; a
+    genuine interface address always carries its real ifindex.
 - **ECMP: all next-hops retained, dead ones skipped (#2389), per-FLOW
   spread (#2734).** A static route keeps EVERY configured next-hop
   (`RouteEntryV4::next_hops: Vec<RouteNextHopV4>`). `select_route_next_hop`

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -61,23 +61,30 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
   - **Local-delivery DECISION is table-scoped too (#3769).** #3151 fixed
     the ifindex ATTRIBUTION but the membership DECISION stayed global:
     `local_v[46]` is a global set, and it also carries NAT/DNAT external
-    targets (static-NAT external IPs + DNAT destination IPs) that have NO
-    connected route, so their owning routing-instance was lost. A packet
-    in VRF A destined to a NAT/DNAT address owned in VRF B hit the global
-    `local_v[46]` membership and short-circuited to `LocalDelivery` (with
-    ifindex 0), bypassing the VRF-A FIB + zone/policy + HA-RG owner check.
-    The build now records per-external-IP table ownership in
-    `local_nat_tables_v[46]` (each NAT/DNAT rule's `from routing-instance`
-    → canonical table via `connected_route_tables`), and the shortcut
-    delivers locally ONLY when THIS table owns the address — an interface
-    owns it here (connected scan matched) OR a NAT/DNAT rule in this
-    routing-instance owns it. An address owned only in another table falls
-    through to the route lookup (VRF-A FIB). This also generalizes #3151
-    to a single-owner interface IP (the same IP in exactly one VRF, not
-    both). **L5:** a NAT/DNAT-only external target has no interface, so its
-    LocalDelivery carries ifindex 0 legitimately — now GATED on table
-    ownership and counted by the `LOCAL_DELIVERY_IFINDEX0` diagnostic; a
-    genuine interface address always carries its real ifindex.
+    targets (static-NAT external IPs + DNAT destination IPs). The
+    connected scan cannot recover the owning table for the DECISION —
+    a NAT-only IP has no connected route at all, and `ConnectedRouteV*`
+    stores the MASKED network address so `prefix.addr() == host` matches
+    only a /32/128 interface. A packet in VRF A destined to a local
+    address owned only in VRF B therefore hit the global `local_v[46]`
+    membership and short-circuited to `LocalDelivery`, bypassing the
+    VRF-A FIB + zone/policy + HA-RG owner check. The build now records
+    per-address table ownership in `local_tables_v[46]` (a `FastMap<Ip,
+    FastSet<table>>` with an insert paired to EVERY `local_v*` insert:
+    interface host addresses in `populate_interfaces`, keyed by the host
+    `.addr()`; NAT/DNAT externals in the `forwarding_build` late-stage
+    append, keyed by the rule's `from routing-instance` → canonical table
+    via `connected_route_tables`). The shortcut delivers locally ONLY
+    when the RESOLVING table is in that owning set; an address owned only
+    in another table falls through to the route lookup (VRF-A FIB). This
+    also generalizes #3151 to a single-owner interface IP (present in
+    exactly one VRF, not the same IP in both). The ifindex ATTRIBUTION
+    still uses the table-scoped connected scan (the /32-HA case).
+    **L5:** a NAT-only external target (or a non-/32 interface IP whose
+    ingress-interface resolution was bypassed) has no exact connected
+    match, so its LocalDelivery carries ifindex 0 — now reached ONLY when
+    the table genuinely owns the address, and counted by the
+    `LOCAL_DELIVERY_IFINDEX0` diagnostic atomic.
 - **ECMP: all next-hops retained, dead ones skipped (#2389), per-FLOW
   spread (#2734).** A static route keeps EVERY configured next-hop
   (`RouteEntryV4::next_hops: Vec<RouteNextHopV4>`). `select_route_next_hop`

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -80,6 +80,16 @@ Route metadata crosses the Go→Rust snapshot boundary as `RouteSnapshot`
     also generalizes #3151 to a single-owner interface IP (present in
     exactly one VRF, not the same IP in both). The ifindex ATTRIBUTION
     still uses the table-scoped connected scan (the /32-HA case).
+    **Empty-scope = wildcard:** a NAT/DNAT rule whose `from
+    routing-instance` is empty is a wildcard `scope_ok` matches against
+    ANY ingress routing-instance (and the common `from zone` / `from
+    interface` inbound-DNAT rule leaves it empty — `compiler_nat.go`).
+    Its external IP is recorded in the table-agnostic
+    `local_nat_any_table_v[46]` set (treated as owned in EVERY table by
+    the DECISION), NOT attributed to `inet.0` only — otherwise an external
+    whose zone lives in a non-default VRF would be over-isolated. Interface
+    host addresses are never wildcarded (an interface IP lives in exactly
+    one VRF).
     **L5:** a NAT-only external target (or a non-/32 interface IP whose
     ingress-interface resolution was bypassed) has no exact connected
     match, so its LocalDelivery carries ifindex 0 — now reached ONLY when

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -13,6 +13,19 @@ const DEFAULT_V4_TABLE: &str = "inet.0";
 const DEFAULT_V6_TABLE: &str = "inet6.0";
 const MAX_NEXT_TABLE_DEPTH: usize = 8;
 
+/// #3769: count of `LocalDelivery` resolutions returned with `local_ifindex ==
+/// 0` — i.e. a NAT/DNAT-only local target (no interface owns the address, so
+/// the table-scoped connected scan cannot attribute an ifindex). This is
+/// legitimate for a NAT/DNAT external IP owned in the resolving table (the NAT
+/// subsystem owns it, there is no interface), but downstream zone / security-
+/// policy / HA-RG-owner selection then operate on ifindex 0, so the count is
+/// exposed as a diagnostic. A steadily climbing value on a router with per-VRF
+/// NAT is expected; a climbing value that correlates with mis-attributed
+/// sessions is the signal to inspect. `LocalDelivery` for a genuine interface
+/// address always carries the real ifindex and does NOT bump this.
+pub(in crate::afxdp) static LOCAL_DELIVERY_IFINDEX0: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 pub(super) fn classify_metadata(
     meta: UserspaceDpMeta,
     validation: ValidationState,
@@ -1150,23 +1163,47 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                 // connected scan by the canonical ingress table; the default
                 // routing-instance (inet.0) case still matches default-table
                 // connected routes.
-                let local_ifindex = state
+                let iface_ifindex = state
                     .connected_v4
                     .iter()
                     .find(|entry| entry.table == table && entry.prefix.addr() == ip)
-                    .map(|entry| entry.ifindex)
-                    .unwrap_or(0);
-                return ForwardingResolution {
-                    disposition: ForwardingDisposition::LocalDelivery,
-                    local_ifindex,
-                    egress_ifindex: local_ifindex,
-                    tx_ifindex: local_ifindex,
-                    tunnel_endpoint_id: 0,
-                    next_hop: None,
-                    neighbor_mac: None,
-                    src_mac: None,
-                    tx_vlan_id: 0,
-                };
+                    .map(|entry| entry.ifindex);
+                // #3769: the local-delivery DECISION is now table-scoped too,
+                // not just the ifindex attribution. `local_v4` is a GLOBAL
+                // membership set, so a NAT/DNAT external IP owned in VRF B (or
+                // an interface IP owned only in another routing-instance) would
+                // otherwise short-circuit a VRF-A packet to LocalDelivery,
+                // bypassing the VRF-A FIB + zone/policy + HA-RG owner check.
+                // Deliver locally only when THIS table owns the address:
+                //   - an interface owns it here (connected scan matched), OR
+                //   - a static-NAT/DNAT rule in this routing-instance owns it.
+                let nat_owned_in_table = state
+                    .local_nat_tables_v4
+                    .get(&ip)
+                    .is_some_and(|tables| tables.contains(&table));
+                if iface_ifindex.is_some() || nat_owned_in_table {
+                    let local_ifindex = iface_ifindex.unwrap_or(0);
+                    if local_ifindex == 0 {
+                        // #3769 L5: NAT/DNAT-only local target — no interface
+                        // owns the address, so ifindex 0 is unavoidable but is
+                        // now gated on table ownership. Count it for diagnostics.
+                        LOCAL_DELIVERY_IFINDEX0
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    return ForwardingResolution {
+                        disposition: ForwardingDisposition::LocalDelivery,
+                        local_ifindex,
+                        egress_ifindex: local_ifindex,
+                        tx_ifindex: local_ifindex,
+                        tunnel_endpoint_id: 0,
+                        next_hop: None,
+                        neighbor_mac: None,
+                        src_mac: None,
+                        tx_vlan_id: 0,
+                    };
+                }
+                // Owned in a DIFFERENT table only (cross-VRF) — fall through to
+                // the VRF-A route lookup instead of leaking to LocalDelivery.
             }
             lookup_forwarding_resolution_v4(
                 state,
@@ -1185,23 +1222,40 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
             if state.local_v6.contains(&ip) {
                 // #3151: table-scoped local-delivery attribution (see the v4
                 // branch above and the #2388 route-path connected scan).
-                let local_ifindex = state
+                let iface_ifindex = state
                     .connected_v6
                     .iter()
                     .find(|entry| entry.table == table && entry.prefix.addr() == ip)
-                    .map(|entry| entry.ifindex)
-                    .unwrap_or(0);
-                return ForwardingResolution {
-                    disposition: ForwardingDisposition::LocalDelivery,
-                    local_ifindex,
-                    egress_ifindex: local_ifindex,
-                    tx_ifindex: local_ifindex,
-                    tunnel_endpoint_id: 0,
-                    next_hop: None,
-                    neighbor_mac: None,
-                    src_mac: None,
-                    tx_vlan_id: 0,
-                };
+                    .map(|entry| entry.ifindex);
+                // #3769: table-scoped local-delivery DECISION (see the v4
+                // branch). A NAT/DNAT external IP owned in another VRF, or an
+                // interface IP owned only in another routing-instance, must not
+                // short-circuit a VRF-A packet to LocalDelivery.
+                let nat_owned_in_table = state
+                    .local_nat_tables_v6
+                    .get(&ip)
+                    .is_some_and(|tables| tables.contains(&table));
+                if iface_ifindex.is_some() || nat_owned_in_table {
+                    let local_ifindex = iface_ifindex.unwrap_or(0);
+                    if local_ifindex == 0 {
+                        // #3769 L5: NAT/DNAT-only local target, ifindex 0 gated
+                        // on table ownership; counted for diagnostics.
+                        LOCAL_DELIVERY_IFINDEX0
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    return ForwardingResolution {
+                        disposition: ForwardingDisposition::LocalDelivery,
+                        local_ifindex,
+                        egress_ifindex: local_ifindex,
+                        tx_ifindex: local_ifindex,
+                        tunnel_endpoint_id: 0,
+                        next_hop: None,
+                        neighbor_mac: None,
+                        src_mac: None,
+                        tx_vlan_id: 0,
+                    };
+                }
+                // Owned in a DIFFERENT table only (cross-VRF) — fall through.
             }
             lookup_forwarding_resolution_v6(
                 state,

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1163,30 +1163,44 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                 // connected scan by the canonical ingress table; the default
                 // routing-instance (inet.0) case still matches default-table
                 // connected routes.
-                let iface_ifindex = state
-                    .connected_v4
-                    .iter()
-                    .find(|entry| entry.table == table && entry.prefix.addr() == ip)
-                    .map(|entry| entry.ifindex);
                 // #3769: the local-delivery DECISION is now table-scoped too,
-                // not just the ifindex attribution. `local_v4` is a GLOBAL
-                // membership set, so a NAT/DNAT external IP owned in VRF B (or
-                // an interface IP owned only in another routing-instance) would
-                // otherwise short-circuit a VRF-A packet to LocalDelivery,
-                // bypassing the VRF-A FIB + zone/policy + HA-RG owner check.
-                // Deliver locally only when THIS table owns the address:
-                //   - an interface owns it here (connected scan matched), OR
-                //   - a static-NAT/DNAT rule in this routing-instance owns it.
-                let nat_owned_in_table = state
-                    .local_nat_tables_v4
+                // not just the #3151 ifindex attribution. `local_v4` is a
+                // GLOBAL membership set, so a NAT/DNAT external IP owned in
+                // VRF B (or an interface IP owned only in another
+                // routing-instance) would otherwise short-circuit a VRF-A
+                // packet to LocalDelivery, bypassing the VRF-A FIB +
+                // zone/policy + HA-RG owner check. `local_tables_v4` records,
+                // per local address, the tables that own it (paired with every
+                // `local_v4` insert); deliver locally only when the RESOLVING
+                // table is one of them. NOTE: the membership DECISION cannot
+                // use the connected scan — `ConnectedRouteV4` stores the MASKED
+                // network address, so `prefix.addr() == host` matches only a
+                // /32 (and never a NAT-only IP, which has no connected route).
+                if !state
+                    .local_tables_v4
                     .get(&ip)
-                    .is_some_and(|tables| tables.contains(&table));
-                if iface_ifindex.is_some() || nat_owned_in_table {
-                    let local_ifindex = iface_ifindex.unwrap_or(0);
+                    .is_some_and(|tables| tables.contains(&table))
+                {
+                    // Owned in a DIFFERENT table only (cross-VRF) — fall
+                    // through to the VRF-A route lookup instead of leaking to
+                    // LocalDelivery.
+                } else {
+                    // #3151: ifindex attribution stays via the table-scoped
+                    // connected scan (the /32-HA case). A NAT-only external IP
+                    // or a non-/32 interface host IP has no exact connected
+                    // match → ifindex 0 (unchanged pre-#3769 behaviour), now
+                    // reached only when the table genuinely owns the address.
+                    let local_ifindex = state
+                        .connected_v4
+                        .iter()
+                        .find(|entry| entry.table == table && entry.prefix.addr() == ip)
+                        .map(|entry| entry.ifindex)
+                        .unwrap_or(0);
                     if local_ifindex == 0 {
-                        // #3769 L5: NAT/DNAT-only local target — no interface
-                        // owns the address, so ifindex 0 is unavoidable but is
-                        // now gated on table ownership. Count it for diagnostics.
+                        // #3769 L5: table-owned local target with no interface
+                        // ifindex (NAT-only, or a non-/32 interface IP whose
+                        // ingress-interface path was bypassed). Gated on table
+                        // ownership; counted for diagnostics.
                         LOCAL_DELIVERY_IFINDEX0
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     }
@@ -1202,8 +1216,6 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                         tx_vlan_id: 0,
                     };
                 }
-                // Owned in a DIFFERENT table only (cross-VRF) — fall through to
-                // the VRF-A route lookup instead of leaking to LocalDelivery.
             }
             lookup_forwarding_resolution_v4(
                 state,
@@ -1222,24 +1234,31 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
             if state.local_v6.contains(&ip) {
                 // #3151: table-scoped local-delivery attribution (see the v4
                 // branch above and the #2388 route-path connected scan).
-                let iface_ifindex = state
-                    .connected_v6
-                    .iter()
-                    .find(|entry| entry.table == table && entry.prefix.addr() == ip)
-                    .map(|entry| entry.ifindex);
                 // #3769: table-scoped local-delivery DECISION (see the v4
                 // branch). A NAT/DNAT external IP owned in another VRF, or an
                 // interface IP owned only in another routing-instance, must not
-                // short-circuit a VRF-A packet to LocalDelivery.
-                let nat_owned_in_table = state
-                    .local_nat_tables_v6
+                // short-circuit a VRF-A packet to LocalDelivery. `local_v6`
+                // membership alone is global; gate on `local_tables_v6`.
+                if !state
+                    .local_tables_v6
                     .get(&ip)
-                    .is_some_and(|tables| tables.contains(&table));
-                if iface_ifindex.is_some() || nat_owned_in_table {
-                    let local_ifindex = iface_ifindex.unwrap_or(0);
+                    .is_some_and(|tables| tables.contains(&table))
+                {
+                    // Owned in a DIFFERENT table only (cross-VRF) — fall
+                    // through to the route lookup.
+                } else {
+                    // #3151: ifindex attribution via the table-scoped connected
+                    // scan (matches a /128 host; a NAT-only or non-/128 IP →
+                    // ifindex 0, now reached only when this table owns the IP).
+                    let local_ifindex = state
+                        .connected_v6
+                        .iter()
+                        .find(|entry| entry.table == table && entry.prefix.addr() == ip)
+                        .map(|entry| entry.ifindex)
+                        .unwrap_or(0);
                     if local_ifindex == 0 {
-                        // #3769 L5: NAT/DNAT-only local target, ifindex 0 gated
-                        // on table ownership; counted for diagnostics.
+                        // #3769 L5: table-owned local target, no interface
+                        // ifindex; gated on table ownership, counted.
                         LOCAL_DELIVERY_IFINDEX0
                             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     }
@@ -1255,7 +1274,6 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                         tx_vlan_id: 0,
                     };
                 }
-                // Owned in a DIFFERENT table only (cross-VRF) — fall through.
             }
             lookup_forwarding_resolution_v6(
                 state,

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1176,11 +1176,16 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                 // use the connected scan — `ConnectedRouteV4` stores the MASKED
                 // network address, so `prefix.addr() == host` matches only a
                 // /32 (and never a NAT-only IP, which has no connected route).
-                if !state
-                    .local_tables_v4
-                    .get(&ip)
-                    .is_some_and(|tables| tables.contains(&table))
-                {
+                // #3769: an UNSCOPED NAT/DNAT external (`local_nat_any_table_v4`)
+                // is table-agnostic (mirrors `scope_ok`'s empty-instance
+                // wildcard); a named-VRF / interface address must match the
+                // resolving table exactly.
+                let owned_here = state.local_nat_any_table_v4.contains(&ip)
+                    || state
+                        .local_tables_v4
+                        .get(&ip)
+                        .is_some_and(|tables| tables.contains(&table));
+                if !owned_here {
                     // Owned in a DIFFERENT table only (cross-VRF) — fall
                     // through to the VRF-A route lookup instead of leaking to
                     // LocalDelivery.
@@ -1238,12 +1243,15 @@ pub(super) fn lookup_forwarding_resolution_inner_ecmp(
                 // branch). A NAT/DNAT external IP owned in another VRF, or an
                 // interface IP owned only in another routing-instance, must not
                 // short-circuit a VRF-A packet to LocalDelivery. `local_v6`
-                // membership alone is global; gate on `local_tables_v6`.
-                if !state
-                    .local_tables_v6
-                    .get(&ip)
-                    .is_some_and(|tables| tables.contains(&table))
-                {
+                // membership alone is global; gate on `local_tables_v6` (plus
+                // the unscoped-wildcard `local_nat_any_table_v6`, see the v4
+                // branch).
+                let owned_here = state.local_nat_any_table_v6.contains(&ip)
+                    || state
+                        .local_tables_v6
+                        .get(&ip)
+                        .is_some_and(|tables| tables.contains(&table));
+                if !owned_here {
                     // Owned in a DIFFERENT table only (cross-VRF) — fall
                     // through to the route lookup.
                 } else {

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2768,7 +2768,7 @@ fn local_delivery_v6_is_table_scoped_no_cross_vrf_leak() {
 /// packet resolved in a DIFFERENT VRF hit the global membership and
 /// short-circuited to LocalDelivery (ifindex 0), bypassing that VRF's FIB +
 /// zone/policy + HA-RG owner check. After #3769 only the owning VRF delivers
-/// locally. Revert (remove the `local_nat_tables_v4` table gate on the
+/// locally. Revert (remove the `local_tables_v4` table gate on the
 /// membership shortcut) → tenant-a resolves LocalDelivery → RED.
 #[test]
 fn static_nat_local_delivery_is_table_scoped_no_cross_vrf_leak() {
@@ -2891,7 +2891,7 @@ fn dnat_local_delivery_is_table_scoped_no_cross_vrf_leak() {
 }
 
 /// #3769 (v6): a static-NAT external IPv6 owned in tenant-b must not
-/// local-deliver a tenant-a packet. Revert the `local_nat_tables_v6` gate → RED.
+/// local-deliver a tenant-a packet. Revert the `local_tables_v6` gate → RED.
 #[test]
 fn nat_local_delivery_v6_is_table_scoped_no_cross_vrf_leak() {
     let snapshot = crate::ConfigSnapshot {

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2761,6 +2761,278 @@ fn local_delivery_v6_is_table_scoped_no_cross_vrf_leak() {
     assert_eq!(resolved_a.local_ifindex, 301);
 }
 
+/// #3769: the local-delivery DECISION (not merely the ifindex ATTRIBUTION
+/// #3151) must be table-scoped for a static-NAT external IP, which has NO
+/// connected route so its owning routing-instance was previously lost. The
+/// external IP is inserted into the GLOBAL `local_v4` set; before #3769 a
+/// packet resolved in a DIFFERENT VRF hit the global membership and
+/// short-circuited to LocalDelivery (ifindex 0), bypassing that VRF's FIB +
+/// zone/policy + HA-RG owner check. After #3769 only the owning VRF delivers
+/// locally. Revert (remove the `local_nat_tables_v4` table gate on the
+/// membership shortcut) → tenant-a resolves LocalDelivery → RED.
+#[test]
+fn static_nat_local_delivery_is_table_scoped_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        static_nat_rules: vec![crate::StaticNATRuleSnapshot {
+            name: "web".to_string(),
+            from_routing_instance: "tenant-b".to_string(),
+            external_ip: "203.0.113.10".to_string(),
+            internal_ip: "192.168.1.10".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    let ext = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 10));
+
+    // The external IP is a member of the GLOBAL local set (precondition —
+    // otherwise the shortcut is never reached and the test proves nothing).
+    assert!(
+        state.local_v4.contains(&Ipv4Addr::new(203, 0, 113, 10)),
+        "static-NAT external IP must be a global local-delivery member",
+    );
+
+    // Owning VRF (tenant-b): the NAT subsystem owns the external IP →
+    // LocalDelivery, ifindex 0 (no interface owns a NAT external IP; #3769 L5
+    // gates this ifindex-0 delivery on table ownership).
+    let owner = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        ext,
+        Some("tenant-b.inet.0"),
+    );
+    assert_eq!(
+        owner.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "NAT external IP must local-deliver in its OWN routing-instance",
+    );
+    assert_eq!(
+        owner.local_ifindex, 0,
+        "a NAT-only external IP has no interface → ifindex 0 (gated, counted)",
+    );
+
+    // Cross-VRF (tenant-a): NOT owned here → must NOT leak to LocalDelivery;
+    // it follows the tenant-a FIB (no route → NoRoute).
+    let cross = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        ext,
+        Some("tenant-a.inet.0"),
+    );
+    assert_ne!(
+        cross.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "a VRF-A packet to a NAT address owned only in VRF-B must NOT \
+         short-circuit to LocalDelivery (#3769 cross-VRF leak)",
+    );
+    assert_eq!(
+        cross.disposition,
+        ForwardingDisposition::NoRoute,
+        "tenant-a has no route for the tenant-b NAT external IP",
+    );
+
+    // Default table (None → inet.0): also not the owner → no leak.
+    let dflt =
+        lookup_forwarding_resolution_in_table_with_dynamic(&state, &neighbors, ext, None);
+    assert_ne!(
+        dflt.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "default-table packet to a tenant-b NAT external IP must not leak",
+    );
+}
+
+/// #3769 (DNAT): identical table-scoped local-delivery guarantee for a DNAT
+/// destination IP owned by a rule in tenant-b. Revert the table gate →
+/// tenant-a leaks to LocalDelivery → RED.
+#[test]
+fn dnat_local_delivery_is_table_scoped_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        destination_nat_rules: vec![crate::DestinationNATRuleSnapshot {
+            name: "web-dnat".to_string(),
+            from_routing_instance: "tenant-b".to_string(),
+            destination_address: "198.51.100.20".to_string(),
+            destination_port: 443,
+            protocol: "tcp".to_string(),
+            pool_address: "10.0.61.102".to_string(),
+            pool_port: 8443,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    let dst = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 20));
+
+    let owner = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        dst,
+        Some("tenant-b.inet.0"),
+    );
+    assert_eq!(
+        owner.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "DNAT destination IP must local-deliver in its owning VRF",
+    );
+
+    let cross = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        dst,
+        Some("tenant-a.inet.0"),
+    );
+    assert_eq!(
+        cross.disposition,
+        ForwardingDisposition::NoRoute,
+        "cross-VRF packet to a DNAT destination owned in tenant-b must \
+         follow the tenant-a FIB, not LocalDelivery (#3769)",
+    );
+}
+
+/// #3769 (v6): a static-NAT external IPv6 owned in tenant-b must not
+/// local-deliver a tenant-a packet. Revert the `local_nat_tables_v6` gate → RED.
+#[test]
+fn nat_local_delivery_v6_is_table_scoped_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        static_nat_rules: vec![crate::StaticNATRuleSnapshot {
+            name: "web6".to_string(),
+            from_routing_instance: "tenant-b".to_string(),
+            external_ip: "2001:db8:ff::10".to_string(),
+            internal_ip: "2001:db8:1::10".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    let ext: IpAddr = "2001:db8:ff::10".parse().unwrap();
+
+    let owner = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        ext,
+        Some("tenant-b.inet6.0"),
+    );
+    assert_eq!(owner.disposition, ForwardingDisposition::LocalDelivery);
+    assert_eq!(owner.local_ifindex, 0);
+
+    let cross = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        ext,
+        Some("tenant-a.inet6.0"),
+    );
+    assert_ne!(
+        cross.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "v6 NAT external IP owned in tenant-b must not local-deliver a \
+         tenant-a packet (#3769)",
+    );
+}
+
+/// #3769: default routing-instance (from-routing-instance "") behaviour is
+/// unchanged — a default-VRF NAT external IP still LocalDelivers in inet.0 —
+/// and the ifindex-0 diagnostic counter advances for the NAT-only delivery.
+#[test]
+fn nat_local_delivery_default_vrf_unchanged_and_counts_ifindex0() {
+    let snapshot = crate::ConfigSnapshot {
+        static_nat_rules: vec![crate::StaticNATRuleSnapshot {
+            name: "web-default".to_string(),
+            from_routing_instance: String::new(), // default instance
+            external_ip: "203.0.113.50".to_string(),
+            internal_ip: "192.168.1.50".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    let ext = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 50));
+
+    let before = LOCAL_DELIVERY_IFINDEX0.load(std::sync::atomic::Ordering::Relaxed);
+    // Default table via explicit inet.0 and via None both deliver locally.
+    for table in [Some("inet.0"), None] {
+        let r = lookup_forwarding_resolution_in_table_with_dynamic(
+            &state, &neighbors, ext, table,
+        );
+        assert_eq!(
+            r.disposition,
+            ForwardingDisposition::LocalDelivery,
+            "default-VRF NAT external IP must local-deliver in the default table",
+        );
+        assert_eq!(r.local_ifindex, 0, "NAT-only external IP → ifindex 0");
+    }
+    let after = LOCAL_DELIVERY_IFINDEX0.load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        after >= before + 2,
+        "ifindex-0 LocalDelivery counter must advance for NAT-only delivery \
+         (before={before}, after={after})",
+    );
+}
+
+/// #3769: the table-scoped DECISION also fixes the interface-address residual
+/// #3151 left — an interface IP owned in ONLY ONE routing-instance must not
+/// LocalDeliver a packet resolved in a DIFFERENT instance (the #3151 test used
+/// the SAME IP in BOTH VRFs; here it exists in tenant-b only). Before #3769 the
+/// global `local_v4` membership short-circuited the tenant-a packet to
+/// LocalDelivery with ifindex 0; after #3769 it falls through to the tenant-a
+/// FIB. Revert the decision gate → tenant-a LocalDelivery → RED.
+#[test]
+fn interface_local_delivery_single_vrf_no_cross_vrf_leak() {
+    let snapshot = crate::ConfigSnapshot {
+        zones: vec![crate::ZoneSnapshot {
+            name: "zb".to_string(),
+            id: TEST_UNTRUST_ZONE_ID,
+            tcp_rst: false,
+            ..Default::default()
+        }],
+        interfaces: vec![crate::InterfaceSnapshot {
+            name: "ge-0/0/1.90".to_string(),
+            zone: "zb".to_string(),
+            routing_instance: "tenant-b".to_string(),
+            linux_name: "ge-0-0-1.90".to_string(),
+            ifindex: 202,
+            hardware_addr: "02:00:00:00:00:b2".to_string(),
+            addresses: vec![crate::InterfaceAddressSnapshot {
+                family: "inet".to_string(),
+                address: "10.0.0.1/32".to_string(),
+                scope: 0,
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+    // Owning VRF (tenant-b): interface owns it → LocalDelivery with the real
+    // ifindex (unchanged #3151 attribution).
+    let owner = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        ip,
+        Some("tenant-b.inet.0"),
+    );
+    assert_eq!(owner.disposition, ForwardingDisposition::LocalDelivery);
+    assert_eq!(owner.local_ifindex, 202);
+
+    // Cross-VRF (tenant-a): the interface IP is not owned here → no leak.
+    let cross = lookup_forwarding_resolution_in_table_with_dynamic(
+        &state,
+        &neighbors,
+        ip,
+        Some("tenant-a.inet.0"),
+    );
+    assert_ne!(
+        cross.disposition,
+        ForwardingDisposition::LocalDelivery,
+        "an interface IP owned only in tenant-b must not local-deliver a \
+         tenant-a packet (#3769 generalizes #3151)",
+    );
+}
+
 /// #2389: a static route with two next-hops must retain BOTH in the FIB
 /// (equal-cost), and a dead first next-hop must fall back to a live
 /// alternate. Revert the build to `next_hops.first()` → only one candidate

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -3033,6 +3033,67 @@ fn interface_local_delivery_single_vrf_no_cross_vrf_leak() {
     );
 }
 
+/// #3769 (review MINOR): an UNSCOPED NAT/DNAT rule (`from routing-instance`
+/// empty — the common `from zone` / `from interface` inbound-DNAT case) is a
+/// WILDCARD that `scope_ok` matches against ANY ingress routing-instance.
+/// Attributing its external IP to `inet.0` only would over-isolate it when the
+/// ingress zone lives in a non-default VRF. The external IP must resolve as
+/// locally-owned in a NAMED VRF too (via `local_nat_any_table_v*`), NOT fall
+/// through to NoRoute. Revert (route the empty scope through
+/// `connected_route_tables("")` → inet.0 only) → this goes NoRoute in
+/// tenant-a → RED. The named-VRF isolation tests above must still hold.
+#[test]
+fn unscoped_nat_local_delivery_is_wildcard_across_vrfs() {
+    let snapshot = crate::ConfigSnapshot {
+        static_nat_rules: vec![crate::StaticNATRuleSnapshot {
+            name: "web-unscoped".to_string(),
+            from_zone: "untrust".to_string(), // zone-scoped → RI left empty
+            from_routing_instance: String::new(),
+            external_ip: "203.0.113.77".to_string(),
+            internal_ip: "192.168.1.77".to_string(),
+            ..Default::default()
+        }],
+        destination_nat_rules: vec![crate::DestinationNATRuleSnapshot {
+            name: "dnat-unscoped".to_string(),
+            from_zone: "untrust".to_string(),
+            from_routing_instance: String::new(),
+            destination_address: "198.51.100.88".to_string(),
+            destination_port: 443,
+            protocol: "tcp".to_string(),
+            pool_address: "10.0.61.88".to_string(),
+            pool_port: 8443,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let neighbors = Arc::new(ShardedNeighborMap::new());
+    let ext = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 77));
+    let dnat = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 88));
+
+    // Unscoped externals must local-deliver in EVERY table: the default table
+    // AND a named non-default VRF (mirrors `scope_ok`'s wildcard).
+    for table in [None, Some("inet.0"), Some("tenant-a.inet.0")] {
+        let r = lookup_forwarding_resolution_in_table_with_dynamic(
+            &state, &neighbors, ext, table,
+        );
+        assert_eq!(
+            r.disposition,
+            ForwardingDisposition::LocalDelivery,
+            "unscoped static-NAT external must local-deliver in table {table:?} \
+             (wildcard), not fall through to NoRoute (#3769 review MINOR)",
+        );
+        let d = lookup_forwarding_resolution_in_table_with_dynamic(
+            &state, &neighbors, dnat, table,
+        );
+        assert_eq!(
+            d.disposition,
+            ForwardingDisposition::LocalDelivery,
+            "unscoped DNAT destination must local-deliver in table {table:?} (wildcard)",
+        );
+    }
+}
+
 /// #2389: a static route with two next-hops must retain BOTH in the FIB
 /// (equal-cost), and a dead first next-hop must fall back to a live
 /// alternate. Revert the build to `next_hops.first()` → only one candidate

--- a/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/interfaces.rs
@@ -151,6 +151,16 @@ pub(super) fn populate_interfaces(
                         state.interface_nat_v4.insert(v4.addr(), iface.ifindex);
                     } else {
                         state.local_v4.insert(v4.addr());
+                        // #3769: record the interface host address's owning
+                        // table for the table-scoped local-delivery DECISION.
+                        // Keyed by the HOST `.addr()`, NOT the (masked)
+                        // connected prefix, so a non-/32 interface IP is
+                        // recognised as locally-owned in its own VRF.
+                        state
+                            .local_tables_v4
+                            .entry(v4.addr())
+                            .or_default()
+                            .insert(connected_table_v4.clone());
                     }
                     state.connected_v4.push(ConnectedRouteV4 {
                         prefix: PrefixV4::from_net(v4),
@@ -167,6 +177,13 @@ pub(super) fn populate_interfaces(
                         state.interface_nat_v6.insert(v6.addr(), iface.ifindex);
                     } else {
                         state.local_v6.insert(v6.addr());
+                        // #3769: record the interface host address's owning
+                        // table (see the v4 arm).
+                        state
+                            .local_tables_v6
+                            .entry(v6.addr())
+                            .or_default()
+                            .insert(connected_table_v6.clone());
                     }
                     state.connected_v6.push(ConnectedRouteV6 {
                         prefix: PrefixV6::from_net(v6),

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -402,28 +402,41 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // breaking inbound firewall delivery for all NAT traffic. (#1342
     // AGY r1 finding #2.)
 
-    // Add static NAT external IPs as local delivery targets so inbound
-    // traffic destined to external IPs is recognized by the firewall.
-    for ext_ip in state.static_nat.external_ips() {
-        match ext_ip {
-            std::net::IpAddr::V4(v4) => {
-                state.local_v4.insert(*v4);
-            }
-            std::net::IpAddr::V6(v6) => {
-                state.local_v6.insert(*v6);
-            }
-        }
+    // Add static NAT external IPs and DNAT destination IPs as local-delivery
+    // targets so inbound traffic destined to those IPs is recognized by the
+    // firewall. #3769: each IP carries its owning rule's `from
+    // routing-instance` scope; record it (converted to a canonical route
+    // table via `connected_route_tables`) in `local_nat_tables_v*` so the
+    // local-delivery shortcut is gated on the RESOLVING table — a packet in
+    // VRF A to a NAT/DNAT address owned only in VRF B no longer short-circuits
+    // to LocalDelivery, it follows the VRF-A FIB + zone/policy. The scoped IPs
+    // are collected into an owned buffer first so the immutable borrow of the
+    // NAT tables ends before the mutable `state.local_*` inserts.
+    let mut nat_local_targets: Vec<(std::net::IpAddr, String)> = Vec::new();
+    for (ip, instance) in state.static_nat.external_ips_scoped() {
+        nat_local_targets.push((ip, instance.to_string()));
     }
-
-    // Add DNAT destination IPs as local delivery targets so traffic
-    // to those IPs is recognized as locally-destined and processed.
-    for dst_ip in state.dnat_table.destination_ips() {
-        match dst_ip {
+    for (ip, instance) in state.dnat_table.destination_ips_scoped() {
+        nat_local_targets.push((ip, instance.to_string()));
+    }
+    for (ip, instance) in nat_local_targets {
+        let (table_v4, table_v6) = interfaces::connected_route_tables(&instance);
+        match ip {
             std::net::IpAddr::V4(v4) => {
                 state.local_v4.insert(v4);
+                state
+                    .local_nat_tables_v4
+                    .entry(v4)
+                    .or_default()
+                    .insert(table_v4);
             }
             std::net::IpAddr::V6(v6) => {
                 state.local_v6.insert(v6);
+                state
+                    .local_nat_tables_v6
+                    .entry(v6)
+                    .or_default()
+                    .insert(table_v6);
             }
         }
     }

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -406,7 +406,7 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // targets so inbound traffic destined to those IPs is recognized by the
     // firewall. #3769: each IP carries its owning rule's `from
     // routing-instance` scope; record it (converted to a canonical route
-    // table via `connected_route_tables`) in `local_nat_tables_v*` so the
+    // table via `connected_route_tables`) in `local_tables_v*` so the
     // local-delivery shortcut is gated on the RESOLVING table — a packet in
     // VRF A to a NAT/DNAT address owned only in VRF B no longer short-circuits
     // to LocalDelivery, it follows the VRF-A FIB + zone/policy. The scoped IPs
@@ -424,19 +424,11 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         match ip {
             std::net::IpAddr::V4(v4) => {
                 state.local_v4.insert(v4);
-                state
-                    .local_nat_tables_v4
-                    .entry(v4)
-                    .or_default()
-                    .insert(table_v4);
+                state.local_tables_v4.entry(v4).or_default().insert(table_v4);
             }
             std::net::IpAddr::V6(v6) => {
                 state.local_v6.insert(v6);
-                state
-                    .local_nat_tables_v6
-                    .entry(v6)
-                    .or_default()
-                    .insert(table_v6);
+                state.local_tables_v6.entry(v6).or_default().insert(table_v6);
             }
         }
     }

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -405,13 +405,17 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     // Add static NAT external IPs and DNAT destination IPs as local-delivery
     // targets so inbound traffic destined to those IPs is recognized by the
     // firewall. #3769: each IP carries its owning rule's `from
-    // routing-instance` scope; record it (converted to a canonical route
-    // table via `connected_route_tables`) in `local_tables_v*` so the
+    // routing-instance` scope. A NAMED instance records the specific canonical
+    // route table (via `connected_route_tables`) in `local_tables_v*` so the
     // local-delivery shortcut is gated on the RESOLVING table — a packet in
     // VRF A to a NAT/DNAT address owned only in VRF B no longer short-circuits
-    // to LocalDelivery, it follows the VRF-A FIB + zone/policy. The scoped IPs
-    // are collected into an owned buffer first so the immutable borrow of the
-    // NAT tables ends before the mutable `state.local_*` inserts.
+    // to LocalDelivery. An EMPTY instance is a WILDCARD (`scope_ok` matches it
+    // against any ingress routing-instance, and `from zone`/`from interface`
+    // rules leave it empty); attributing it to `inet.0` only would over-isolate
+    // an external IP whose zone lives in a non-default VRF, so it goes into the
+    // table-agnostic `local_nat_any_table_v*` set instead. The scoped IPs are
+    // collected into an owned buffer first so the immutable borrow of the NAT
+    // tables ends before the mutable `state.local_*` inserts.
     let mut nat_local_targets: Vec<(std::net::IpAddr, String)> = Vec::new();
     for (ip, instance) in state.static_nat.external_ips_scoped() {
         nat_local_targets.push((ip, instance.to_string()));
@@ -420,15 +424,24 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
         nat_local_targets.push((ip, instance.to_string()));
     }
     for (ip, instance) in nat_local_targets {
+        let wildcard = instance.is_empty();
         let (table_v4, table_v6) = interfaces::connected_route_tables(&instance);
         match ip {
             std::net::IpAddr::V4(v4) => {
                 state.local_v4.insert(v4);
-                state.local_tables_v4.entry(v4).or_default().insert(table_v4);
+                if wildcard {
+                    state.local_nat_any_table_v4.insert(v4);
+                } else {
+                    state.local_tables_v4.entry(v4).or_default().insert(table_v4);
+                }
             }
             std::net::IpAddr::V6(v6) => {
                 state.local_v6.insert(v6);
-                state.local_tables_v6.entry(v6).or_default().insert(table_v6);
+                if wildcard {
+                    state.local_nat_any_table_v6.insert(v6);
+                } else {
+                    state.local_tables_v6.entry(v6).or_default().insert(table_v6);
+                }
             }
         }
     }

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -14,6 +14,24 @@ use super::*;
 pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) local_v4: FastSet<Ipv4Addr>,
     pub(in crate::afxdp) local_v6: FastSet<Ipv6Addr>,
+    /// #3769: table (VRF) attribution for the NAT/DNAT-only local-delivery
+    /// targets that `local_v4`/`local_v6` also carry. `local_v*` is a GLOBAL
+    /// membership set ("some subsystem answers for this IP somewhere"); an
+    /// interface address's owning table is recoverable from `connected_v*`
+    /// (#2388 table-scoped), but a static-NAT external IP or a DNAT
+    /// destination IP has NO connected route, so before #3769 its owning
+    /// routing-instance was lost — a packet in VRF A destined to a NAT/DNAT
+    /// address owned in VRF B hit the global `local_v*` membership and
+    /// short-circuited to `LocalDelivery`, skipping the VRF-A FIB + zone /
+    /// security-policy + HA-RG owner classification (#3151 fixed only the
+    /// ifindex ATTRIBUTION, not the membership DECISION). These maps record,
+    /// per external IP, the set of canonical route tables (from each NAT/DNAT
+    /// rule's `from routing-instance`) that own it, so the local-delivery
+    /// shortcut in `lookup_forwarding_resolution_inner_ecmp` is gated on the
+    /// resolving table. Built alongside the `local_v*` NAT append in
+    /// `forwarding_build`.
+    pub(in crate::afxdp) local_nat_tables_v4: FastMap<Ipv4Addr, FastSet<String>>,
+    pub(in crate::afxdp) local_nat_tables_v6: FastMap<Ipv6Addr, FastSet<String>>,
     /// #3182: EVERY configured interface address, decoupled from the
     /// NAT-aware `local_v*` exclusion. `local_v4`/`local_v6` drop the IP of
     /// any interface whose zone is an interface-mode-SNAT `to_zone`

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -14,24 +14,29 @@ use super::*;
 pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) local_v4: FastSet<Ipv4Addr>,
     pub(in crate::afxdp) local_v6: FastSet<Ipv6Addr>,
-    /// #3769: table (VRF) attribution for the NAT/DNAT-only local-delivery
-    /// targets that `local_v4`/`local_v6` also carry. `local_v*` is a GLOBAL
-    /// membership set ("some subsystem answers for this IP somewhere"); an
-    /// interface address's owning table is recoverable from `connected_v*`
-    /// (#2388 table-scoped), but a static-NAT external IP or a DNAT
-    /// destination IP has NO connected route, so before #3769 its owning
-    /// routing-instance was lost — a packet in VRF A destined to a NAT/DNAT
-    /// address owned in VRF B hit the global `local_v*` membership and
-    /// short-circuited to `LocalDelivery`, skipping the VRF-A FIB + zone /
-    /// security-policy + HA-RG owner classification (#3151 fixed only the
-    /// ifindex ATTRIBUTION, not the membership DECISION). These maps record,
-    /// per external IP, the set of canonical route tables (from each NAT/DNAT
-    /// rule's `from routing-instance`) that own it, so the local-delivery
-    /// shortcut in `lookup_forwarding_resolution_inner_ecmp` is gated on the
-    /// resolving table. Built alongside the `local_v*` NAT append in
-    /// `forwarding_build`.
-    pub(in crate::afxdp) local_nat_tables_v4: FastMap<Ipv4Addr, FastSet<String>>,
-    pub(in crate::afxdp) local_nat_tables_v6: FastMap<Ipv6Addr, FastSet<String>>,
+    /// #3769: table (VRF) attribution for the local-delivery DECISION.
+    /// `local_v4`/`local_v6` are GLOBAL membership sets ("some subsystem
+    /// answers for this IP somewhere"); before #3769 the local-delivery
+    /// shortcut in `lookup_forwarding_resolution_inner_ecmp` keyed the
+    /// DECISION on that global membership, so a packet in VRF A destined to a
+    /// local address owned only in VRF B short-circuited to `LocalDelivery`,
+    /// skipping the VRF-A FIB + zone/security-policy + HA-RG owner
+    /// classification. #3151 table-scoped only the ifindex ATTRIBUTION, and
+    /// only via the connected-route scan — which cannot recover a NAT/DNAT
+    /// external IP's owning routing-instance (no connected route) nor a
+    /// non-/32 interface host IP (`ConnectedRouteV*` stores the MASKED network
+    /// address, so `prefix.addr() == host` matches only a /32). These maps
+    /// record, for EVERY `local_v*` member (interface host address AND
+    /// static-NAT/DNAT external IP), the set of canonical route tables that
+    /// own it, so the shortcut is gated on the resolving table. Every
+    /// `local_v*` insert has a paired `local_tables_v*` insert: interface
+    /// addresses in `populate_interfaces` (keyed by the host `.addr()`, not
+    /// the connected prefix), NAT/DNAT externals in the `forwarding_build`
+    /// late-stage NAT append. The connected scan is still used for the
+    /// ifindex ATTRIBUTION (the #3151 /32-HA case); the membership DECISION
+    /// now uses these maps.
+    pub(in crate::afxdp) local_tables_v4: FastMap<Ipv4Addr, FastSet<String>>,
+    pub(in crate::afxdp) local_tables_v6: FastMap<Ipv6Addr, FastSet<String>>,
     /// #3182: EVERY configured interface address, decoupled from the
     /// NAT-aware `local_v*` exclusion. `local_v4`/`local_v6` drop the IP of
     /// any interface whose zone is an interface-mode-SNAT `to_zone`

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -29,14 +29,31 @@ pub(in crate::afxdp) struct ForwardingState {
     /// record, for EVERY `local_v*` member (interface host address AND
     /// static-NAT/DNAT external IP), the set of canonical route tables that
     /// own it, so the shortcut is gated on the resolving table. Every
-    /// `local_v*` insert has a paired `local_tables_v*` insert: interface
-    /// addresses in `populate_interfaces` (keyed by the host `.addr()`, not
-    /// the connected prefix), NAT/DNAT externals in the `forwarding_build`
-    /// late-stage NAT append. The connected scan is still used for the
-    /// ifindex ATTRIBUTION (the #3151 /32-HA case); the membership DECISION
-    /// now uses these maps.
+    /// `local_v*` insert has a paired `local_tables_v*` / `local_nat_any_table_v*`
+    /// insert: interface addresses in `populate_interfaces` (keyed by the host
+    /// `.addr()`, not the connected prefix), NAT/DNAT externals in the
+    /// `forwarding_build` late-stage NAT append. The connected scan is still
+    /// used for the ifindex ATTRIBUTION (the #3151 /32-HA case); the membership
+    /// DECISION now uses these maps.
+    ///
+    /// A named-routing-instance NAT/DNAT rule (or an interface) records the
+    /// specific canonical table here — that is the correct cross-VRF
+    /// isolation. An UNSCOPED (`from routing-instance` empty) NAT/DNAT rule is
+    /// a WILDCARD that `scope_ok` matches against ANY ingress routing-instance
+    /// (`nat/destination.rs`, `nat/static_nat.rs`, `nat/source.rs`) — and the
+    /// common `from zone` / `from interface` inbound-DNAT rule leaves the
+    /// routing instance empty (`compiler_nat.go`). Attributing such an external
+    /// IP to `inet.0` only (via `connected_route_tables("")`) would
+    /// over-isolate it when its zone lives in a non-default VRF, so the
+    /// wildcard case goes into `local_nat_any_table_v*` instead — a
+    /// table-agnostic membership set the local-delivery DECISION treats as
+    /// owned in EVERY table, mirroring `scope_ok`'s empty-instance wildcard.
+    /// Interface host addresses are NEVER wildcarded (an interface IP genuinely
+    /// lives in exactly one VRF).
     pub(in crate::afxdp) local_tables_v4: FastMap<Ipv4Addr, FastSet<String>>,
     pub(in crate::afxdp) local_tables_v6: FastMap<Ipv6Addr, FastSet<String>>,
+    pub(in crate::afxdp) local_nat_any_table_v4: FastSet<Ipv4Addr>,
+    pub(in crate::afxdp) local_nat_any_table_v6: FastSet<Ipv6Addr>,
     /// #3182: EVERY configured interface address, decoupled from the
     /// NAT-aware `local_v*` exclusion. `local_v4`/`local_v6` drop the IP of
     /// any interface whose zone is an interface-mode-SNAT `to_zone`

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -884,15 +884,40 @@ impl DnatTable {
     /// large block is still fully translated — only on-segment proxy-ARP is
     /// bounded.
     pub(crate) fn destination_ips(&self) -> impl Iterator<Item = IpAddr> {
-        // Deduplicate by collecting unique dst_ip values.
+        // Deduplicate by collecting unique dst_ip values. #3769: implemented
+        // on top of `destination_ips_scoped` so the set of registered local
+        // IPs (and the block-expansion bound) can never drift between the two
+        // views.
         let mut seen: FxHashMap<IpAddr, ()> = FxHashMap::default();
-        for key in self.entries.keys() {
-            seen.entry(key.dst_ip).or_insert(());
+        for (ip, _instance) in self.destination_ips_scoped() {
+            seen.entry(ip).or_insert(());
+        }
+        seen.into_keys()
+    }
+
+    /// #3769: like [`destination_ips`], but pairs each destination IP with the
+    /// `from routing-instance` scope of the owning DNAT rule ("" = the default
+    /// instance / global). The forwarding-state builder converts the routing
+    /// instance to a canonical route table and records the attribution in
+    /// `local_nat_tables_v*`, so the local-delivery shortcut is gated on the
+    /// resolving VRF rather than the global `local_v*` membership (the #3769
+    /// cross-VRF local-delivery leak). Not deduplicated — a destination IP can
+    /// legitimately be owned by DNAT rules in more than one routing-instance;
+    /// the builder inserts into a per-IP set of tables. The same
+    /// `MAX_LOCAL_PREFIX_HOSTS`-bounded prefix expansion as `destination_ips`
+    /// is applied so on-segment proxy-ARP/ND parity is preserved.
+    pub(crate) fn destination_ips_scoped(&self) -> Vec<(IpAddr, &str)> {
+        let mut out: Vec<(IpAddr, &str)> = Vec::new();
+        for (key, entries) in &self.entries {
+            for entry in entries {
+                out.push((key.dst_ip, entry.from_routing_instance.as_ref()));
+            }
         }
         for slots in self.prefix_entries.values() {
             for slot in slots {
+                let instance = slot.entry.from_routing_instance.as_ref();
                 if let Some(net) = slot.network() {
-                    seen.entry(net).or_insert(());
+                    out.push((net, instance));
                 }
                 match (slot.v4, slot.v6) {
                     (Some(p), _) => {
@@ -902,7 +927,7 @@ impl DnatTable {
                                 Ipv4Net::new(p.addr(), p.prefix_len())
                             {
                                 for host in net.hosts() {
-                                    seen.entry(IpAddr::V4(host)).or_insert(());
+                                    out.push((IpAddr::V4(host), instance));
                                 }
                             }
                         }
@@ -916,7 +941,7 @@ impl DnatTable {
                                 Ipv6Net::new(p.addr(), p.prefix_len())
                             {
                                 for host in net.hosts() {
-                                    seen.entry(IpAddr::V6(host)).or_insert(());
+                                    out.push((IpAddr::V6(host), instance));
                                 }
                             }
                         }
@@ -925,7 +950,7 @@ impl DnatTable {
                 }
             }
         }
-        seen.into_keys()
+        out
     }
 }
 

--- a/userspace-dp/src/nat/destination.rs
+++ b/userspace-dp/src/nat/destination.rs
@@ -899,7 +899,7 @@ impl DnatTable {
     /// `from routing-instance` scope of the owning DNAT rule ("" = the default
     /// instance / global). The forwarding-state builder converts the routing
     /// instance to a canonical route table and records the attribution in
-    /// `local_nat_tables_v*`, so the local-delivery shortcut is gated on the
+    /// `local_tables_v*`, so the local-delivery shortcut is gated on the
     /// resolving VRF rather than the global `local_v*` membership (the #3769
     /// cross-VRF local-delivery leak). Not deduplicated — a destination IP can
     /// legitimately be owned by DNAT rules in more than one routing-instance;

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -764,7 +764,7 @@ impl StaticNatTable {
     /// `from routing-instance` scope of the owning rule ("" = the default
     /// instance / global). The forwarding-state builder converts the routing
     /// instance to a canonical route table and records the table attribution
-    /// in `local_nat_tables_v*`, so the local-delivery shortcut is gated on the
+    /// in `local_tables_v*`, so the local-delivery shortcut is gated on the
     /// resolving VRF instead of the global `local_v*` membership. A single
     /// external IP may appear more than once (per port mapping AND per
     /// split-horizon scope, #3605); every (IP, instance) pair is yielded and

--- a/userspace-dp/src/nat/static_nat.rs
+++ b/userspace-dp/src/nat/static_nat.rs
@@ -759,4 +759,26 @@ impl StaticNatTable {
             .map(|(ip, _)| ip)
             .chain(self.blocks.iter().map(|b| &b.external.base))
     }
+
+    /// #3769: like [`external_ips`], but pairs each external IP with the
+    /// `from routing-instance` scope of the owning rule ("" = the default
+    /// instance / global). The forwarding-state builder converts the routing
+    /// instance to a canonical route table and records the table attribution
+    /// in `local_nat_tables_v*`, so the local-delivery shortcut is gated on the
+    /// resolving VRF instead of the global `local_v*` membership. A single
+    /// external IP may appear more than once (per port mapping AND per
+    /// split-horizon scope, #3605); every (IP, instance) pair is yielded and
+    /// the builder de-duplicates by inserting into a set.
+    pub(crate) fn external_ips_scoped(&self) -> Vec<(IpAddr, &str)> {
+        let mut out = Vec::new();
+        for ((ip, _port), entries) in &self.dnat {
+            for entry in entries {
+                out.push((*ip, entry.from_routing_instance.as_str()));
+            }
+        }
+        for block in &self.blocks {
+            out.push((block.external.base, block.from_routing_instance.as_str()));
+        }
+        out
+    }
 }


### PR DESCRIPTION
## Summary

Closes #3769 (HIGH — VRF-isolation break; residual of #3151).

Static-NAT external IPs and DNAT destination IPs are registered as
local-delivery targets by inserting them into the **global** `local_v4` /
`local_v6` sets. #3151 table-scoped only the local-delivery **ifindex
attribution** (via the connected-route scan); the membership **decision**
stayed global. So a packet arriving in VRF A destined to a NAT/DNAT
address owned in VRF B hit the global `local_v*` membership shortcut in
`lookup_forwarding_resolution_inner_ecmp` and returned `LocalDelivery`
with ifindex 0, **bypassing the VRF-A FIB, the zone/security-policy
classification, and the HA redundancy-group owner check**
(`owner_rg_for_flow(egress_ifindex)`) — a cross-VRF local-delivery leak
plus an ifindex-0 mis-attribution (L5).

## Root cause (verified)

- `forwarding_build/mod.rs` late-stage loops insert `static_nat.external_ips()`
  and `dnat_table.destination_ips()` into the global `local_v*` with no
  table attribution.
- `forwarding/mod.rs` `lookup_forwarding_resolution_inner_ecmp` keyed the
  `LocalDelivery` decision on `local_v4.contains(&ip)` (global); only the
  ifindex attribution was table-scoped (#3151). NAT-only IPs have no
  connected route, and `ConnectedRouteV*` stores the **masked network**
  address (`from_net` = `addr & mask`), so `prefix.addr() == host` matches
  only a /32 — which is why the connected scan can't drive the decision.

## Fix

- New `ForwardingState.local_tables_v4/v6: FastMap<Ip, FastSet<table>>`
  with an insert paired to **every** `local_v*` insert: interface host
  addresses in `populate_interfaces` (keyed by the host `.addr()`),
  NAT/DNAT externals in the `forwarding_build` append (keyed by each
  rule's `from routing-instance` → canonical table via
  `connected_route_tables`).
- New `StaticNatTable::external_ips_scoped` / `DnatTable::destination_ips_scoped`
  yield `(IP, from-routing-instance)`; `destination_ips` is reimplemented
  on top of `destination_ips_scoped` so the two views cannot drift.
- The local-delivery shortcut now delivers locally **only when the
  resolving table owns the address**; otherwise it falls through to the
  route lookup (VRF-A FIB). Generalizes #3151 to a single-owner interface
  IP (present in exactly one VRF).
- **L5**: the ifindex attribution keeps the table-scoped connected scan
  (the /32-HA case). A NAT-only / non-/32 IP still resolves ifindex 0, but
  now only when the table genuinely owns the address, and it is counted by
  the new `LOCAL_DELIVERY_IFINDEX0` diagnostic atomic.

## Tests (RED-on-revert verified)

Added to `userspace-dp/src/afxdp/forwarding/tests.rs`:
`static_nat_local_delivery_is_table_scoped_no_cross_vrf_leak`,
`dnat_local_delivery_is_table_scoped_no_cross_vrf_leak`,
`nat_local_delivery_v6_is_table_scoped_no_cross_vrf_leak`,
`nat_local_delivery_default_vrf_unchanged_and_counts_ifindex0`,
`interface_local_delivery_single_vrf_no_cross_vrf_leak`.

Forcing the pre-#3769 global membership fails the three v4 cross-VRF
assertions, while the existing #3151 same-IP-both-VRFs test still passes
(its table-scoped ifindex is unaffected) — proving the new tests catch
the residual #3151 could not.

Full `cargo test --release` is green: **3376 passed, 0 failed**.

## Docs

`userspace-dp/src/afxdp/forwarding/README.md` (local-delivery section);
`_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
