### PR TITLE
ip-monitoring: advance cached route overlay only after publish succeeds

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-01 — #3760 ip-monitoring: advance the cached desired overlay ONLY after apply_snapshot succeeds (mutate-after-publish)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3760 (MEDIUM, codex-review-160 H6). `PublishRouteOverlaySnapshot`
+    assigned `m.routeOverlay = cloneRouteOverlay(overlay)` at the TOP of the
+    function (manager.go:957), before the `ensureRequiredSnapshotProtocol`
+    /`disarmBeforeUnsupportedPublish`/`apply_snapshot` publish. On any of those
+    failures the function returned an error with `m.routeOverlay` already
+    advanced to the never-published overlay while `m.lastSnapshot`/
+    `m.lastSnapshotHash` stayed at the prior baseline → the cache lied about
+    what is live. A later full apply reads `routeOverlaySnapshot()` and rebuilds
+    routes against the failed overlay, defeating desired-vs-applied
+    observability and risking a real failover route being suppressed as
+    "already published".
+    FIX (mutate-after-success, mirrors #3766/#3742/#3757): build routes against
+    a local `desiredOverlay := cloneRouteOverlay(overlay)` and commit
+    `m.routeOverlay = desiredOverlay` via a deferred hook keyed on the named
+    return `err` — so all nil-error returns (no-published-snapshot cache,
+    helper-not-running cache, duplicate-skip, and successful publish) advance
+    the cache, while the three error returns leave it at the last-applied
+    baseline. On a rejected publish the #3757 dirty-retry re-passes the same
+    overlay, rebuilds identical routes, mismatches the still-old
+    `lastSnapshotHash`, and re-publishes. `policySchedulerActive` mutation left
+    as-is (out of scope for H6).
+    TEST: `TestPublishRouteOverlaySnapshotFailureKeepsBaseline` — toggle-fail
+    control server; after a rejected publish asserts (a) the cache stays at the
+    last-applied overlay A, (b) a full apply rebuilds A's route (not the failed
+    B), (c) the recovered retry re-publishes B and advances the cache once.
+    RED on revert (cache advances to unpublished B). `go test -race` green.
+  - **File(s)**: pkg/dataplane/userspace/manager.go,
+    pkg/dataplane/userspace/route_overlay_test.go, docs/multi-wan.md, _Log.md
+
 ## 2026-07-01 — #3734 ddns Surface A: seedFromStore + renumber log read AddrText (not the always-empty Address) → no restart republish storm, renumber leaves a trace
 
 - **Timestamp**: 2026-07-01

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -551,7 +551,15 @@ routing, and only on double fault).
   is autonomous and does not wait for an unrelated commit, lease, or
   probe transition. The dirty bit clears only after a fully consistent
   actuation, and a change that lands mid-actuation is preserved
-  (last-writer-wins).
+  (last-writer-wins). The manager's cached desired overlay
+  (`m.routeOverlay`, read by every full snapshot build) is advanced
+  **only after `apply_snapshot` succeeds** (#3760, mutate-after-success
+  like #3766/#3742): a rejected publish leaves the cache at the
+  last-applied overlay, so the retry above rebuilds the same routes, sees
+  a content-hash mismatch against the still-old published snapshot, and
+  re-publishes — the cache never records an overlay the dataplane never
+  accepted, and a full apply during the dirty window rebuilds routes that
+  match what is actually live rather than the failed target.
 - **Per-cycle transition evaluation (#2527).** An RPM test's pass/fail
   status is a per-test aggregate, evaluated once across the whole probe
   set (`probe-count` probes per cycle), Junos ip-monitoring style. The

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -954,7 +954,26 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.routeOverlay = cloneRouteOverlay(overlay)
+	// #3760: do NOT advance the cached desired overlay before the publish
+	// is known not to have failed. buildRouteSnapshots below builds
+	// against this local copy; m.routeOverlay is committed only on a
+	// non-error return (deferred commit). A failed apply_snapshot
+	// therefore leaves m.routeOverlay at the last-applied baseline, so
+	// the next actuator sweep rebuilds the same new routes, sees a hash
+	// mismatch against the still-old lastSnapshotHash, and re-publishes
+	// (#3757 dirty-retry contract). Mirrors the mutate-after-success
+	// pattern (#3766/#3742/#3757): the cache never records an overlay the
+	// dataplane never accepted. The nil-error early returns below
+	// (no published snapshot yet, helper not running) still commit the
+	// overlay so the next full apply carries it; the duplicate-skip
+	// return commits a content-equivalent overlay.
+	desiredOverlay := cloneRouteOverlay(overlay)
+	defer func() {
+		if err == nil {
+			m.routeOverlay = desiredOverlay
+		}
+	}()
+
 	if schedulerState != nil {
 		m.policySchedulerActive = copyPolicySchedulerActiveState(schedulerState)
 	}
@@ -966,8 +985,8 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 		cfg = m.lastSnapshot.Config
 	}
 	if cfg == nil || m.lastSnapshot == nil {
-		// No published snapshot yet: the overlay is cached and the
-		// next full apply will carry it.
+		// No published snapshot yet: the overlay is cached (deferred
+		// commit) and the next full apply will carry it.
 		return false, nil
 	}
 	if m.proc == nil || m.proc.Process == nil {
@@ -988,7 +1007,7 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 	next.FIBGeneration = m.readFIBGeneration()
 	next.GeneratedAt = time.Now().UTC()
 	next.Config = cfg
-	next.Routes = buildRouteSnapshots(cfg, next.Interfaces, m.routeOverlay)
+	next.Routes = buildRouteSnapshots(cfg, next.Interfaces, desiredOverlay)
 
 	// Duplicate-publish skip: identical content (e.g. the actuator ran
 	// twice for the same overlay) does not need a control-socket
@@ -1024,7 +1043,7 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 		slog.Warn("userspace: failed to sync helper status after route overlay publish", "err", err)
 	}
 	slog.Info("userspace: route overlay snapshot published",
-		"generation", next.Generation, "overlay_routes", len(m.routeOverlay))
+		"generation", next.Generation, "overlay_routes", len(desiredOverlay))
 	return true, nil
 }
 

--- a/pkg/dataplane/userspace/route_overlay_test.go
+++ b/pkg/dataplane/userspace/route_overlay_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -283,5 +284,167 @@ func TestPublishRouteOverlaySnapshotWithoutHelper(t *testing.T) {
 	got := m.routeOverlaySnapshot()
 	if len(got) != 1 || got[0].NextHop != "172.16.80.1" {
 		t.Fatalf("overlay not cached: %+v", got)
+	}
+}
+
+// overlayControlServerToggle behaves like overlayControlServer but its
+// apply_snapshot handling can be flipped to fail (OK:false) via the
+// returned setter, so a publish failure can be exercised. All requests
+// are still forwarded on the returned channel.
+func overlayControlServerToggle(t *testing.T, dir string) (string, chan ControlRequest, func(bool)) {
+	t.Helper()
+	controlSock := filepath.Join(dir, "control.sock")
+	ln, err := net.Listen("unix", controlSock)
+	if err != nil {
+		t.Fatalf("listen control socket: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	reqCh := make(chan ControlRequest, 8)
+	var mu sync.Mutex
+	fail := false
+	setFail := func(f bool) {
+		mu.Lock()
+		fail = f
+		mu.Unlock()
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req ControlRequest
+			if err := json.NewDecoder(conn).Decode(&req); err == nil {
+				reqCh <- req
+				mu.Lock()
+				failNow := fail
+				mu.Unlock()
+				if failNow && req.Type == "apply_snapshot" {
+					_ = json.NewEncoder(conn).Encode(ControlResponse{
+						OK:    false,
+						Error: "simulated apply_snapshot failure",
+					})
+				} else {
+					gen := uint64(0)
+					fib := uint32(0)
+					if req.Snapshot != nil {
+						gen = req.Snapshot.Generation
+						fib = req.Snapshot.FIBGeneration
+					}
+					_ = json.NewEncoder(conn).Encode(ControlResponse{
+						OK: true,
+						Status: &ProcessStatus{
+							Enabled:                true,
+							LastSnapshotGeneration: gen,
+							LastFIBGeneration:      fib,
+						},
+					})
+				}
+			}
+			conn.Close()
+		}
+	}()
+	return controlSock, reqCh, setFail
+}
+
+// TestPublishRouteOverlaySnapshotFailureKeepsBaseline is the #3760
+// regression: a failed apply_snapshot must NOT advance the cached
+// desired overlay. Before the fix, m.routeOverlay was assigned at the
+// top of PublishRouteOverlaySnapshot, so a helper rejection left the
+// cache recording an overlay the dataplane never accepted. A later full
+// apply reads that cache (routeOverlaySnapshot) and rebuilds routes
+// against the never-published overlay — the cache lies about what is
+// live, and the desired-vs-applied observability is defeated.
+//
+// RED-on-revert: reverting the mutate-after-success fix makes the cache
+// advance to the failed overlay B, so assertions (a)/(b) below fail.
+func TestPublishRouteOverlaySnapshotFailureKeepsBaseline(t *testing.T) {
+	dir := t.TempDir()
+	controlSock, reqCh, setFail := overlayControlServerToggle(t, dir)
+
+	cfg := overlayTestConfig()
+	m := New()
+	m.proc = &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}}
+	m.cfg.ControlSocket = controlSock
+	m.generation = 7
+	m.lastSnapshot, _ = buildSnapshot(cfg, config.UserspaceConfig{ControlSocket: controlSock}, 7, 0)
+	if h, ok := snapshotContentHash(m.lastSnapshot); ok {
+		m.lastSnapshotHash = h
+	}
+	m.lastStatus.ConfigSnapshotProtocolVersion = ProtocolVersion
+
+	// Establish a real applied baseline: publish overlay A successfully.
+	overlayA := []config.RouteOverlayEntry{
+		{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
+	}
+	published, err := m.PublishRouteOverlaySnapshot(cfg, overlayA, nil)
+	if err != nil || !published {
+		t.Fatalf("baseline publish: published=%v err=%v", published, err)
+	}
+	<-reqCh // drain the baseline apply_snapshot
+	genAfterBaseline := m.generation
+
+	// The helper now rejects the next apply_snapshot. Publishing overlay B
+	// must fail AND leave the cache at the last-applied baseline A.
+	setFail(true)
+	overlayB := []config.RouteOverlayEntry{
+		{Destination: "0.0.0.0/0", NextHop: "172.16.80.2", Policy: "wan-failover"},
+	}
+	published, err = m.PublishRouteOverlaySnapshot(cfg, overlayB, nil)
+	if err == nil {
+		t.Fatal("expected publish failure, got nil error")
+	}
+	if published {
+		t.Fatal("failed publish reported published=true")
+	}
+	<-reqCh // drain the rejected apply_snapshot attempt
+
+	// (a) The cached desired overlay must still be A: the never-applied B
+	//     must not have advanced the cache (the #3760 divergence).
+	got := m.routeOverlaySnapshot()
+	if len(got) != 1 || got[0].NextHop != "172.16.80.1" {
+		t.Fatalf("cache advanced to the unpublished overlay after a failed publish: %+v (want last-applied A 172.16.80.1)", got)
+	}
+	// The generation must not have advanced on a failed publish.
+	if m.generation != genAfterBaseline {
+		t.Fatalf("generation advanced on a failed publish: %d -> %d", genAfterBaseline, m.generation)
+	}
+
+	// (b) A full apply reads the cached overlay; it must rebuild A's route,
+	//     matching what the dataplane actually has — NOT the failed B.
+	snap, _ := buildSnapshotWithSchedulerState(cfg, config.UserspaceConfig{}, 9, 0, nil, m.routeOverlaySnapshot(), m.feedSnapshotOverlay())
+	for _, r := range snap.Routes {
+		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" {
+			if len(r.NextHops) != 1 || r.NextHops[0] != "172.16.80.1" {
+				t.Fatalf("full apply rebuilt routes from the unpublished overlay: %+v (want A 172.16.80.1)", r.NextHops)
+			}
+		}
+	}
+
+	// (c) With the helper healthy again, the next attempt re-publishes the
+	//     change B, because the cache is still at baseline A and the
+	//     content hash differs from the last-published snapshot. If the
+	//     failed publish had advanced the cache, a full-apply diff could
+	//     suppress B as "already published".
+	setFail(false)
+	published, err = m.PublishRouteOverlaySnapshot(cfg, overlayB, nil)
+	if err != nil {
+		t.Fatalf("retry publish after recovery: %v", err)
+	}
+	if !published {
+		t.Fatal("retry after recovery did not re-publish the change")
+	}
+	select {
+	case req := <-reqCh:
+		if req.Type != "apply_snapshot" {
+			t.Fatalf("retry request = %q, want apply_snapshot", req.Type)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry did not publish an apply_snapshot")
+	}
+	// The cache has now advanced exactly once, to B.
+	got = m.routeOverlaySnapshot()
+	if len(got) != 1 || got[0].NextHop != "172.16.80.2" {
+		t.Fatalf("cache did not advance to B after a successful retry: %+v", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #3760 (codex-review-160 H6, MEDIUM state-consistency).

`PublishRouteOverlaySnapshot` (`pkg/dataplane/userspace/manager.go`)
mutated the cached desired overlay **before** the publish could fail:

```go
m.routeOverlay = cloneRouteOverlay(overlay)   // line 957, at the top
...
if err := m.ensureRequiredSnapshotProtocolLocked(cfg); err != nil { return false, ... }  // failure path
if err := m.disarmBeforeUnsupportedPublishLocked(&next); err != nil { return false, err } // failure path
if err := m.requestLocked(...apply_snapshot...); err != nil { return false, ... }         // publish failure
```

On any of those failures the function returned an error with
`m.routeOverlay` already advanced to the never-published overlay, while
`m.lastSnapshot` / `m.lastSnapshotHash` still held the prior baseline.
The cache then lied about what the dataplane actually has: a later full
apply reads `routeOverlaySnapshot()` and rebuilds routes against an
overlay the helper never accepted — defeating desired-vs-applied
observability and risking a real failover route being suppressed as
"already published".

## Fix

Mutate-after-success, mirroring #3766 / #3742 / #3757:

- Build the routes-only republish against a local `desiredOverlay` copy.
- Commit `m.routeOverlay = desiredOverlay` **only on a non-error return**,
  via a deferred hook keyed on the named return `err`.

All nil-error returns still advance the cache — the no-published-snapshot
and helper-not-running paths cache the overlay for the next full apply,
the duplicate-skip return commits a content-equivalent overlay, and the
successful publish advances once. The three error returns leave the cache
at the last-applied baseline, so the #3757 dirty-retry re-passes the same
overlay, rebuilds identical routes, mismatches the still-old
`lastSnapshotHash`, and re-publishes. `policySchedulerActive` mutation is
left in place (out of scope for H6).

## Test (RED on revert)

`TestPublishRouteOverlaySnapshotFailureKeepsBaseline` drives a
toggle-fail control server. After a rejected `apply_snapshot` it asserts:

- (a) the cache stays at the last-applied overlay A;
- (b) a full snapshot build rebuilds A's route, not the failed B;
- (c) the recovered retry re-publishes B and advances the cache exactly once.

Reverting the fix (committing the overlay unconditionally) makes the test
go RED — the cache advances to the unpublished overlay B.

## Validation

- `go build ./...`, `go vet ./pkg/dataplane/userspace/`, `gofmt` — clean.
- `go test -race ./pkg/dataplane/userspace/` — pass.
- `go test ./pkg/daemon/` (actuator consumer) — pass.
- Doc: `docs/multi-wan.md` #3757 consistency bullet extended with the
  cache-baseline invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi