### PR TITLE
ip-monitoring: idempotent lifecycle + hold-down recompute + honest status (#3761 #3762 #3763)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-01 — #3763 ip-monitoring: recompute pending-recovery deadline when hold-down changes mid-recovery
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3763 (MEDIUM, codex-review-160 M7+L6). Apply preserved
+    prev.pendingRecoveryAt verbatim whenever (policy name, MatchRPMProbe)
+    survived a commit, ignoring a changed HoldDownSecs. A policy recovering
+    under a 300s hold-down that the operator lowered to 10s during incident
+    response still waited the old 300s deadline — operator intent ignored
+    until a restart. FIX: pendingRecoveryAt encodes recoveryStart + oldHold,
+    so the new deadline = pendingRecoveryAt + (newHold - oldHold) credits the
+    elapsed time. Preserve verbatim only when hold-down is unchanged; recompute
+    when it changed; drop to zero (recover at the next evaluate) when lowered to
+    0. Also kick the run loop when a still-pending deadline moved even if the
+    FAIL/recover state itself did not change, so nextWakeLocked re-arms against
+    the new (possibly shortened) deadline instead of sleeping to the stale one.
+    RED-on-revert test (TestHoldDownRecomputeOnConfigChange, fakeClock): lower
+    below elapsed → recover now; lower to a still-future deadline → recover at
+    the NEW earlier deadline; raise → stay pending past the OLD deadline;
+    unchanged → deadline preserved verbatim.
+  - **File(s)**: pkg/ipmon/ipmon.go (Apply recompute + kick),
+    pkg/ipmon/ipmon_test.go (TestHoldDownRecomputeOnConfigChange)
+
 ## 2026-07-01 — #3762 ip-monitoring: idempotent engine lifecycle (double Start no-op, Stop before/without Start safe)
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-01 — #3761 ip-monitoring: honest status/metrics (UNKNOWN vs PASS, applied vs desired, suppressed vs unresolved)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3761 (MEDIUM, codex-review-160 H7+H8+M9+M10+L12).
+    Status/metrics reported health/success for non-converged states,
+    hiding the failover-failure modes that need alerts. FIXES:
+    - H7: added `PolicyStatus.Known` (true once ≥1 RPM result for the
+      policy's probe is observed). `FormatStatus` renders `Status:
+      UNKNOWN` before any probe result instead of `PASS`.
+    - H8: engine now tracks `appliedOverlay` — the last CONVERGED
+      actuation's overlay (set in run() only when actuate()==true and no
+      newer change landed). `RoutesApplied()` and
+      `xpf_ipmon_routes_applied` report ACTUALLY-applied; added
+      `xpf_ipmon_routes_desired` for the winner-resolved intent.
+      `PolicyStatus.AppliedRoutes` carries the per-policy applied subset.
+    - M9: `UnresolvedRoutes` is now a typed `[]UnresolvedRoute`
+      (routing-instance, destination, tracked unit, metric, reason).
+    - M10: added `SuppressedRoutes []SuppressedRoute` — resolvable
+      candidates that lost winner resolution, shown as "suppressed by
+      policy <name>", distinct from unresolved. computeOverlayLocked
+      refactored to keep all resolvable candidates per key and attribute
+      losers to the winner after selection.
+    - L12: documented routes_applied/routes_desired/unresolved_next_hops
+      + the UNKNOWN/APPLIED/PENDING/suppressed/unresolved status rows in
+      docs/multi-wan.md and pkg/ipmon/README.md.
+    RED-on-revert tests: TestUnknownStatusNotReportedAsPass (H7),
+    TestRoutesAppliedReflectsActuationNotDesired (H8, -race),
+    TestUnresolvedAndSuppressedDetail (M9+M10). Verified RED on revert
+    (display PASS-not-UNKNOWN, applied==desired-while-failing, missing
+    suppressed/unresolved rows). go test ./pkg/ipmon/... (-race),
+    ./pkg/api/, ./pkg/daemon/ green.
+  - **File(s)**: pkg/ipmon/ipmon.go (types, appliedOverlay,
+    computeOverlayLocked refactor, Status, RoutesApplied, run),
+    pkg/ipmon/display.go (UNKNOWN + applied/pending/suppressed/unresolved
+    rows), pkg/api/metrics_system.go (applied-from-AppliedRoutes +
+    routes_desired), pkg/api/metrics.go + metrics_descriptors.go (new
+    gauge), pkg/ipmon/ipmon_test.go, pkg/ipmon/nexthop_test.go,
+    pkg/api/metrics_descriptor_coverage_test.go, docs/multi-wan.md,
+    pkg/ipmon/README.md
+
 ## 2026-07-01 — #3763 ip-monitoring: recompute pending-recovery deadline when hold-down changes mid-recovery
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,23 @@
+## 2026-07-01 — #3762 ip-monitoring: idempotent engine lifecycle (double Start no-op, Stop before/without Start safe)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3762 (MEDIUM, codex-review-160 H9+H10). The exported ipmon
+    Engine lifecycle was not idempotent. Start just did `go e.run()` with no
+    guard; run() defers close(e.done), so a second Start spawned a second
+    goroutine and the second deferred close(done) panicked ("close of closed
+    channel") after Stop (H9). Stop closed e.stop then blocked on `<-e.done`
+    unconditionally, so a Stop before/without Start (a common startup
+    error-unwind path) deadlocked forever — no run loop exists to close done
+    (H10). FIX: track `started`/`stopped` under mu. Start is a no-op if already
+    started or stopped (run() spawned at most once). Stop flips stopped and
+    closes e.stop exactly once, and waits on e.done ONLY when a run loop was
+    actually started; a Start after Stop is a no-op. RED-on-revert test
+    (TestLifecycleIdempotent, -race): reverting to `go e.run()` panics on the
+    second Start's close(done); reverting Stop deadlocks the Stop-before-Start
+    goroutine past a 2s timeout.
+  - **File(s)**: pkg/ipmon/ipmon.go (Engine.started/stopped + Start/Stop),
+    pkg/ipmon/ipmon_test.go (TestLifecycleIdempotent)
+
 ## 2026-07-01 — #3760 ip-monitoring: advance the cached desired overlay ONLY after apply_snapshot succeeds (mutate-after-publish)
 
 - **Timestamp**: 2026-07-01

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -479,9 +479,34 @@ clear can match sessions allocated from the other pool.
 ## Observability
 
 - `show services ip-monitoring status` (local CLI, remote CLI, gRPC).
+  Per-policy `Status:` is `FAIL`, `PASS`, or **`UNKNOWN`** — a policy
+  whose probe has not produced a single result yet reads `UNKNOWN`, not
+  `PASS` (#3761 H7). "No probe has run" is not "the uplink is healthy":
+  reading `PASS` would mask exactly the startup/probe-outage window that
+  needs an alert. Route-Action rows carry a per-route state:
+  - `APPLIED` — live in both the kernel and userspace FIBs.
+  - `PENDING` — desired (this policy won the prefix) but the actuation
+    has not converged yet (or is failing, #3757).
+  - `suppressed by policy <name>` — a resolvable candidate that lost
+    winner resolution to a lower-metric (or lexicographically-earlier)
+    policy for the same prefix (#3761 M10) — distinct from unresolved.
+  - `unresolved (<reason>) — skipped` — an interface-typed candidate
+    with no DHCP-learned next-hop (#1844/#3761 M9), reported with its
+    routing-instance and tracked unit, not just the prefix.
 - Prometheus: `xpf_ipmon_policy_failed{policy}`,
   `xpf_ipmon_policy_transitions_total{policy}`,
-  `xpf_ipmon_routes_applied`.
+  `xpf_ipmon_routes_applied`, `xpf_ipmon_routes_desired`,
+  `xpf_ipmon_unresolved_next_hops`.
+  - `xpf_ipmon_routes_applied` counts routes **actually applied** — the
+    last CONVERGED actuation's overlay live in the FIBs (#3761 H8), NOT
+    the desired set. `xpf_ipmon_routes_desired` counts what the engine
+    WANTS injected. A sustained `desired > applied` gap flags a failover
+    that is desired but has not converged (a stuck FRR reload, snapshot
+    publish, or FIB-generation bump — #3757).
+  - `xpf_ipmon_unresolved_next_hops` counts interface-typed failover
+    routes skipped for a missing DHCP gateway (#1844); non-zero during a
+    failover means the backup uplink's lease is missing and its route is
+    NOT injected.
 - Transitions log at Info; per-probe detail at Debug.
 
 ## HA model (chassis cluster)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -168,6 +168,7 @@ type xpfCollector struct {
 	ipmonPolicyFailed       *prometheus.Desc
 	ipmonPolicyTransitions  *prometheus.Desc
 	ipmonRoutesApplied      *prometheus.Desc
+	ipmonRoutesDesired      *prometheus.Desc
 	ipmonUnresolvedNextHops *prometheus.Desc
 
 	// #1895: count of RPM next-hop probe pins whose kernel fwmark
@@ -588,6 +589,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.ipmonPolicyFailed
 	ch <- c.ipmonPolicyTransitions
 	ch <- c.ipmonRoutesApplied
+	ch <- c.ipmonRoutesDesired
 	ch <- c.ipmonUnresolvedNextHops
 	ch <- c.rpmPinInstallFailures
 	ch <- c.eventActionsCommitted

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -420,9 +420,16 @@ func TestCollectorDescriptorCoverage(t *testing.T) {
 				Routes: []config.RouteOverlayEntry{
 					{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
 				},
+				// #3761 H8: an applied route so xpf_ipmon_routes_applied
+				// emits a non-zero value distinct from routes_desired.
+				AppliedRoutes: []config.RouteOverlayEntry{
+					{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
+				},
 				// #1844: a skipped interface-typed route, so the
 				// unresolved-next-hops gauge emits a non-zero value.
-				UnresolvedRoutes: []string{"10.0.0.0/8"},
+				UnresolvedRoutes: []ipmon.UnresolvedRoute{
+					{Destination: "10.0.0.0/8", NextHopInterface: "ge-0-0-3.0", Reason: "no DHCP gateway"},
+				},
 			}}
 		},
 		// #1387 inc-2: wire a non-nil DDNS stats source so the

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -553,8 +553,22 @@ func newCollector(srv *Server) *xpfCollector {
 		),
 		ipmonRoutesApplied: prometheus.NewDesc(
 			"xpf_ipmon_routes_applied",
-			"Number of ip-monitoring preferred routes currently applied "+
-				"(after winner resolution, #1827).",
+			"Number of ip-monitoring preferred routes ACTUALLY applied — "+
+				"the size of the last CONVERGED actuation's overlay that is "+
+				"live in both the kernel and userspace FIBs (#1827, #3761). "+
+				"Diverges below xpf_ipmon_routes_desired while an actuation "+
+				"is pending or the FRR/snapshot/FIB actuation keeps failing "+
+				"(#3757): a persistent gap flags a failover that is desired "+
+				"but not converged.",
+			nil, nil,
+		),
+		ipmonRoutesDesired: prometheus.NewDesc(
+			"xpf_ipmon_routes_desired",
+			"Number of ip-monitoring preferred routes the engine WANTS "+
+				"injected right now (winner-resolved overlay across FAILED "+
+				"policies, #3761). Compare with xpf_ipmon_routes_applied: a "+
+				"sustained desired>applied gap means the actuator has not "+
+				"converged the failover routes.",
 			nil, nil,
 		),
 		ipmonUnresolvedNextHops: prometheus.NewDesc(

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -185,6 +185,7 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 	// #1827: services ip-monitoring policy state.
 	if c.srv.ipmonStatusFn != nil {
 		routesApplied := 0
+		routesDesired := 0
 		unresolved := 0
 		for _, ps := range c.srv.ipmonStatusFn() {
 			failed := 0.0
@@ -195,7 +196,13 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue, failed, ps.Name)
 			ch <- prometheus.MustNewConstMetric(c.ipmonPolicyTransitions,
 				prometheus.CounterValue, float64(ps.Transitions), ps.Name)
-			routesApplied += len(ps.Routes)
+			// #3761 H8: routes_applied must reflect what is ACTUALLY live
+			// in the FIBs (the last converged actuation), not the desired
+			// overlay — a failed FRR/snapshot/FIB actuation must not read
+			// as applied. routes_desired exposes the winner-resolved
+			// intent separately.
+			routesApplied += len(ps.AppliedRoutes)
+			routesDesired += len(ps.Routes)
 			// #1844: Status() recomputes the overlay (including the
 			// resolver skips), so the gauge is current on every scrape
 			// without requiring an actuation.
@@ -203,6 +210,8 @@ func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {
 		}
 		ch <- prometheus.MustNewConstMetric(c.ipmonRoutesApplied,
 			prometheus.GaugeValue, float64(routesApplied))
+		ch <- prometheus.MustNewConstMetric(c.ipmonRoutesDesired,
+			prometheus.GaugeValue, float64(routesDesired))
 		ch <- prometheus.MustNewConstMetric(c.ipmonUnresolvedNextHops,
 			prometheus.GaugeValue, float64(unresolved))
 	}

--- a/pkg/ipmon/README.md
+++ b/pkg/ipmon/README.md
@@ -93,8 +93,36 @@ this wrong by construction. Resolved entries carry the gateway in
 `RouteOverlayEntry.NextHop` (plus the lease key in
 `NextHopInterface`), so FRR render and the snapshot builder are
 unchanged. Skipped candidates surface as
-`PolicyStatus.UnresolvedRoutes` (shown by `FormatStatus` and exported
-as `xpf_ipmon_unresolved_next_hops`).
+`PolicyStatus.UnresolvedRoutes` (a typed `UnresolvedRoute` with the
+routing-instance, tracked unit, metric, and reason — shown by
+`FormatStatus` and exported as `xpf_ipmon_unresolved_next_hops`).
+
+## Status truth model (#3761)
+
+`Status`/`FormatStatus`/metrics distinguish converged truth from intent:
+
+- **UNKNOWN vs PASS (H7).** `PolicyStatus.Known` is false until the
+  policy's probe has produced at least one result. `FormatStatus`
+  renders `Status: UNKNOWN` in that window — never `PASS`. An operator
+  reading `PASS` would assume failover protection is active when no
+  probe has run.
+- **Applied vs desired (H8).** `PolicyStatus.Routes` is the DESIRED
+  winner-resolved overlay (what the engine wants injected).
+  `PolicyStatus.AppliedRoutes` is the subset of the last CONVERGED
+  actuation's overlay owned by the policy — what is actually live in the
+  kernel + userspace FIBs. The engine records `appliedOverlay` only when
+  the run loop confirms a consistent actuation (`actuate()==true` and no
+  newer change landed), so it holds the last good state across a
+  failing/pending actuation (#3757). `RoutesApplied()` and
+  `xpf_ipmon_routes_applied` report applied; `xpf_ipmon_routes_desired`
+  reports desired. A sustained `desired > applied` gap means the
+  actuator has not converged the failover routes.
+- **Suppressed vs unresolved (M9/M10).** A FAILED policy's resolvable
+  candidate that lost winner resolution to another policy is reported in
+  `PolicyStatus.SuppressedRoutes` (`suppressed by policy <name>`),
+  distinct from an interface-typed candidate skipped for a missing
+  next-hop (`UnresolvedRoutes`). Neither reads as a bare "(none
+  applied)".
 
 `NotifyNextHopChange` is the DHCP gateway-change trigger (wired to
 `dhcp.New`'s `onGatewayChange` hook): it marks the overlay dirty only

--- a/pkg/ipmon/display.go
+++ b/pkg/ipmon/display.go
@@ -4,7 +4,18 @@ import (
 	"fmt"
 	"io"
 	"time"
+
+	"github.com/psaab/xpf/pkg/config"
 )
+
+// riName renders a routing-instance for display, defaulting the empty
+// (main) instance to inet.0.
+func riName(ri string) string {
+	if ri == "" {
+		return "inet.0"
+	}
+	return ri
+}
 
 // FormatStatus renders `show services ip-monitoring status` so the
 // local CLI and the gRPC text-show surface stay byte-identical.
@@ -14,41 +25,69 @@ func FormatStatus(w io.Writer, statuses []PolicyStatus) {
 		return
 	}
 	for _, ps := range statuses {
+		// #3761 H7: an unknown health (no probe result yet) is NOT PASS —
+		// reporting PASS would tell an operator failover protection is
+		// active and healthy when no probe has run.
 		state := "PASS"
-		if ps.Failed {
+		switch {
+		case ps.Failed:
 			state = "FAIL"
+		case !ps.Known:
+			state = "UNKNOWN"
 		}
 		fmt.Fprintf(w, "Policy - %s (Status: %s)\n", ps.Name, state)
 		fmt.Fprintf(w, "  RPM Probes:\n")
 		fmt.Fprintf(w, "    Probe name           Test Name        Address          Status\n")
 		fmt.Fprintf(w, "    ---------------------- --------------- ---------------- ---------\n")
 		if len(ps.FailingTests) == 0 {
-			fmt.Fprintf(w, "    %-22s %-15s %-16s %s\n", ps.Probe, "*", "-", "PASS")
+			rowStatus := "PASS"
+			if !ps.Known {
+				rowStatus = "UNKNOWN"
+			}
+			fmt.Fprintf(w, "    %-22s %-15s %-16s %s\n", ps.Probe, "*", "-", rowStatus)
 		} else {
 			for _, test := range ps.FailingTests {
 				fmt.Fprintf(w, "    %-22s %-15s %-16s %s\n", ps.Probe, test, "-", "FAIL")
 			}
 		}
-		fmt.Fprintf(w, "  Route-Action%s:\n", pluralSuffix(len(ps.Routes)))
-		if len(ps.Routes) == 0 {
+
+		// #3761 H8/M9/M10: distinguish APPLIED (live in the FIB) from
+		// PENDING (desired, actuation not yet converged), SUPPRESSED (lost
+		// winner resolution to another policy), and UNRESOLVED (no DHCP
+		// next-hop). A bare "(none applied)" hid all three apart.
+		appliedKey := func(r config.RouteOverlayEntry) string {
+			return r.RoutingInstance + "|" + r.Destination + "|" + r.NextHop
+		}
+		applied := make(map[string]bool, len(ps.AppliedRoutes))
+		for _, r := range ps.AppliedRoutes {
+			applied[appliedKey(r)] = true
+		}
+		rows := len(ps.Routes) + len(ps.SuppressedRoutes) + len(ps.UnresolvedRoutes)
+		fmt.Fprintf(w, "  Route-Action%s:\n", pluralSuffix(rows))
+		if rows == 0 {
 			fmt.Fprintf(w, "    (none applied)\n")
 		} else {
 			fmt.Fprintf(w, "    route-instance    route             next-hop         state\n")
-			fmt.Fprintf(w, "    ----------------- ----------------- ---------------- -------------\n")
+			fmt.Fprintf(w, "    ----------------- ----------------- ---------------- --------------------\n")
 			for _, r := range ps.Routes {
-				inst := r.RoutingInstance
-				if inst == "" {
-					inst = "inet.0"
+				st := "PENDING"
+				if applied[appliedKey(r)] {
+					st = "APPLIED"
 				}
-				fmt.Fprintf(w, "    %-17s %-17s %-16s %s\n", inst, r.Destination, r.NextHop, "APPLIED")
+				fmt.Fprintf(w, "    %-17s %-17s %-16s %s\n", riName(r.RoutingInstance), r.Destination, r.NextHop, st)
 			}
-		}
-		// #1844: interface-typed routes whose DHCP gateway is currently
-		// unknown (no lease) are skipped from the overlay — surface
-		// them so the operator sees WHY a failed policy applied
-		// nothing.
-		for _, dest := range ps.UnresolvedRoutes {
-			fmt.Fprintf(w, "    %-17s next-hop unresolved (no DHCP gateway) — skipped\n", dest)
+			for _, s := range ps.SuppressedRoutes {
+				fmt.Fprintf(w, "    %-17s %-17s %-16s suppressed by policy %s\n",
+					riName(s.RoutingInstance), s.Destination, s.NextHop, s.WinnerPolicy)
+			}
+			// #1844/#3761 M9: interface-typed routes whose DHCP gateway is
+			// currently unknown are skipped from the overlay — surface the
+			// routing-instance + tracked unit + reason so the operator sees
+			// WHICH unit is missing, not just the prefix.
+			for _, u := range ps.UnresolvedRoutes {
+				fmt.Fprintf(w, "    %-17s %-17s %-16s unresolved (%s) — skipped\n",
+					riName(u.RoutingInstance), u.Destination, u.NextHopInterface, u.Reason)
+			}
 		}
 		if !ps.Since.IsZero() {
 			fmt.Fprintf(w, "  Last state change: %s\n", ps.Since.Format("2006-01-02 15:04:05"))

--- a/pkg/ipmon/ipmon.go
+++ b/pkg/ipmon/ipmon.go
@@ -260,6 +260,12 @@ func (e *Engine) Apply(cfg *config.IPMonitoringConfig, results []*rpm.ProbeResul
 	// and after the policy swap — a no-op commit (or any commit with
 	// zero policies) must not schedule a routes-only FRR reload.
 	overlayBefore := e.activeOverlayLocked()
+	// recomputedHold is set when a surviving policy's hold-down value
+	// changed while a recovery was pending (#3763): the run loop must be
+	// kicked even when the FAIL/recover state itself did not change, so it
+	// re-derives its wake timer against the NEW (possibly shortened)
+	// deadline instead of sleeping to the stale one.
+	recomputedHold := false
 	next := make(map[string]*policyState)
 	if cfg != nil {
 		for name, pol := range cfg.Policies {
@@ -270,8 +276,29 @@ func (e *Engine) Apply(cfg *config.IPMonitoringConfig, results []*rpm.ProbeResul
 			if prev, ok := e.policies[name]; ok && prev.cfg.MatchRPMProbe == pol.MatchRPMProbe {
 				st.failed = prev.failed
 				st.since = prev.since
-				st.pendingRecoveryAt = prev.pendingRecoveryAt
 				st.transitions = prev.transitions
+				// #3763: a running recovery hold-down must honor a
+				// hold-down value the operator changes mid-recovery.
+				// pendingRecoveryAt encodes recoveryStart + oldHold, so
+				// the new deadline is recoveryStart + newHold =
+				// pendingRecoveryAt + (newHold - oldHold). Preserve it
+				// verbatim only when hold-down is unchanged; recompute
+				// (crediting elapsed time) when it changed; drop it when
+				// hold-down was lowered to 0 so evaluateLocked recovers
+				// at once. Lowering shortens a pending recovery, raising
+				// extends it — operator intent honored without a restart.
+				if prev.cfg.HoldDownSecs == pol.HoldDownSecs {
+					st.pendingRecoveryAt = prev.pendingRecoveryAt
+				} else if !prev.pendingRecoveryAt.IsZero() {
+					oldHold := time.Duration(prev.cfg.HoldDownSecs) * time.Second
+					newHold := time.Duration(pol.HoldDownSecs) * time.Second
+					if newHold > 0 {
+						st.pendingRecoveryAt = prev.pendingRecoveryAt.Add(newHold - oldHold)
+					}
+					// newHold == 0: leave pendingRecoveryAt zero — the
+					// evaluateLocked below recovers immediately.
+					recomputedHold = true
+				}
 			}
 			next[name] = st
 		}
@@ -287,7 +314,10 @@ func (e *Engine) Apply(cfg *config.IPMonitoringConfig, results []*rpm.ProbeResul
 	}
 	e.markDirtyLocked(changed)
 	e.mu.Unlock()
-	if changed {
+	if changed || recomputedHold {
+		// recomputedHold with changed==false means a still-pending
+		// recovery's deadline moved (typically shortened): wake the loop
+		// so nextWakeLocked re-arms against the new deadline (#3763).
 		e.kickLoop()
 	}
 }

--- a/pkg/ipmon/ipmon.go
+++ b/pkg/ipmon/ipmon.go
@@ -137,6 +137,16 @@ type Engine struct {
 	kick chan struct{}
 	stop chan struct{}
 	done chan struct{}
+
+	// started / stopped guard the run-loop lifecycle (#3762). Both are
+	// read and written only under mu. started flips true on the first
+	// Start (a later Start is a no-op — never a second run() goroutine,
+	// which would double-close(done) and panic). stopped flips true on
+	// the first Stop and closes e.stop exactly once; a Stop before Start
+	// returns without waiting on e.done (no run loop exists to close it),
+	// and a Start after Stop is a no-op.
+	started bool
+	stopped bool
 }
 
 // New creates an engine. actuate is the daemon's routes-only actuator;
@@ -204,20 +214,39 @@ func (e *Engine) NotifyNextHopChange() {
 	}
 }
 
-// Start launches the actuation loop.
+// Start launches the actuation loop. It is idempotent (#3762 H9): a
+// second Start — or a Start after Stop — is a no-op, so the run() loop
+// is spawned at most once. A second goroutine would each defer
+// close(e.done) and the second close would panic.
 func (e *Engine) Start() {
+	e.mu.Lock()
+	if e.started || e.stopped {
+		e.mu.Unlock()
+		return
+	}
+	e.started = true
+	e.mu.Unlock()
 	go e.run()
 }
 
-// Stop terminates the actuation loop.
+// Stop terminates the actuation loop. It is safe to call before Start,
+// without Start, or more than once (#3762 H10): the first call closes
+// e.stop exactly once, and only a Stop that follows a real Start waits
+// on e.done — a Stop with no run loop returns immediately instead of
+// blocking forever on a channel nothing will ever close.
 func (e *Engine) Stop() {
-	select {
-	case <-e.stop:
-		return // already stopped
-	default:
+	e.mu.Lock()
+	if e.stopped {
+		e.mu.Unlock()
+		return
 	}
+	e.stopped = true
+	started := e.started
+	e.mu.Unlock()
 	close(e.stop)
-	<-e.done
+	if started {
+		<-e.done
+	}
 }
 
 // Apply installs a new policy set, preserving FAIL state for policies

--- a/pkg/ipmon/ipmon.go
+++ b/pkg/ipmon/ipmon.go
@@ -60,23 +60,68 @@ const (
 	DefaultThrottle = 3 * time.Second
 )
 
+// UnresolvedRoute describes a FAILED policy's interface-typed preferred
+// route that was skipped from the overlay because its next-hop could not
+// be resolved (no DHCP lease/gateway, or no resolver wired) — #1844,
+// #3761 M9. It carries enough context for an operator to tell WHICH DHCP
+// unit / routing-instance is missing, not just the destination prefix.
+type UnresolvedRoute struct {
+	RoutingInstance  string
+	Destination      string
+	NextHopInterface string
+	Metric           int
+	Reason           string // e.g. "no DHCP gateway", "no next-hop resolver"
+}
+
+// SuppressedRoute describes a FAILED policy's resolvable candidate that
+// lost winner resolution to another policy for the same
+// (routing-instance, prefix) — #3761 M10. It is distinct from an
+// unresolved route: the candidate WAS usable, but a lower-metric (or
+// lexicographically-earlier) policy won the prefix. Surfacing it keeps a
+// deterministic loser from reading as an unresolved/buggy route.
+type SuppressedRoute struct {
+	RoutingInstance string
+	Destination     string
+	NextHop         string
+	Metric          int
+	WinnerPolicy    string
+}
+
 // PolicyStatus is the per-policy view for show/metrics.
 type PolicyStatus struct {
-	Name              string
-	Probe             string
-	Failed            bool
+	Name   string
+	Probe  string
+	Failed bool
+	// Known is true once at least one RPM result for the policy's probe
+	// has been observed (#3761 H7). While false the policy's health is
+	// UNKNOWN — status/metrics must NOT report it as PASS, because "no
+	// probe has run" is not "the uplink is healthy".
+	Known             bool
 	Since             time.Time // last state-change time (zero = never evaluated)
 	FailingTests      []string
 	HoldDownSecs      int
 	PendingRecoveryAt time.Time // non-zero while a recovery hold-down is running
-	Routes            []config.RouteOverlayEntry
-	// UnresolvedRoutes lists destination prefixes of this policy whose
-	// interface-typed next-hop candidate was skipped at overlay
-	// computation (no DHCP lease / no gateway, #1844). Populated only
-	// while the policy is FAILED; sorted. Feeds the
+	// Routes is the DESIRED winner-resolved overlay for this policy — the
+	// routes the engine WANTS injected right now given current FAIL
+	// state. It is not necessarily what is live in the FIB; see
+	// AppliedRoutes.
+	Routes []config.RouteOverlayEntry
+	// AppliedRoutes is the subset of the last CONVERGED actuation's
+	// overlay owned by this policy — what is actually live in both the
+	// kernel and userspace FIBs (#3761 H8). It diverges from Routes while
+	// an actuation is pending or the actuator is failing to converge
+	// (#3757). Feeds the honest xpf_ipmon_routes_applied gauge.
+	AppliedRoutes []config.RouteOverlayEntry
+	// UnresolvedRoutes lists this policy's interface-typed candidates
+	// skipped at overlay computation (no DHCP lease/gateway, #1844).
+	// Populated only while the policy is FAILED; sorted. Feeds the
 	// xpf_ipmon_unresolved_next_hops gauge and `show services
 	// ip-monitoring status`.
-	UnresolvedRoutes []string
+	UnresolvedRoutes []UnresolvedRoute
+	// SuppressedRoutes lists this policy's resolvable candidates that
+	// lost winner resolution to another policy (#3761 M10). Populated
+	// only while the policy is FAILED; sorted.
+	SuppressedRoutes []SuppressedRoute
 	Transitions      uint64
 }
 
@@ -111,6 +156,13 @@ type Engine struct {
 
 	dirtySince    time.Time // zero = clean
 	lastActuation time.Time
+	// appliedOverlay is the overlay snapshot from the last CONVERGED
+	// actuation — what is actually live in the FIBs (#3761 H8). It is
+	// updated ONLY when the run loop confirms a consistent actuation
+	// (actuator returned true AND no newer change landed), so it holds
+	// the last good state across a failing/pending actuation instead of
+	// reporting the desired overlay as applied.
+	appliedOverlay []config.RouteOverlayEntry
 	// dirtyGen increments on every marked change (even while already
 	// dirty). The run loop snapshots it before actuating and clears the
 	// dirty bit only when it is unchanged AND the actuation converged —
@@ -380,26 +432,40 @@ func (e *Engine) activeOverlayLocked() []config.RouteOverlayEntry {
 	return overlay
 }
 
+// overlayDetail carries the non-winner outcomes of one overlay
+// computation, keyed by policy name, so status/metrics can report WHY a
+// FAILED policy's candidate is not in the applied overlay (#3761 M9+M10).
+type overlayDetail struct {
+	// unresolved: interface-typed candidates skipped for want of a
+	// resolved next-hop (no DHCP lease/gateway, or no resolver wired).
+	unresolved map[string][]UnresolvedRoute
+	// suppressed: resolvable candidates that lost winner resolution to
+	// another policy for the same (routing-instance, prefix).
+	suppressed map[string][]SuppressedRoute
+}
+
 // computeOverlayLocked is the pure overlay computation: winner
 // resolution per (routing-instance, canonical prefix) across FAILED
 // policies, with interface-typed next-hops resolved through the
 // injected resolver BEFORE the winner comparison (#1844 plan §4.2 —
 // an unresolvable winner must let a resolvable losing candidate win;
 // resolving after selection gets that wrong by construction). The
-// second return value maps policy name → sorted destination prefixes
-// whose interface-typed candidate was skipped (no lease/gateway, or
-// nil resolver); nil when nothing was skipped.
-func (e *Engine) computeOverlayLocked() ([]config.RouteOverlayEntry, map[string][]string) {
+// second return value reports, per policy, the interface-typed
+// candidates skipped for lack of a resolved next-hop and the resolvable
+// candidates that lost the prefix to another policy (#3761 M9+M10).
+func (e *Engine) computeOverlayLocked() ([]config.RouteOverlayEntry, overlayDetail) {
+	var detail overlayDetail
 	if !e.publishEnabled {
-		return nil, nil
+		return nil, detail
 	}
 	type candidate struct {
 		metric int
 		policy string
 		entry  config.RouteOverlayEntry
 	}
-	best := make(map[string]candidate)
-	var unresolved map[string][]string
+	// Keep ALL resolvable candidates per key so losers can be attributed
+	// to the winner after selection (M10), not just the current best.
+	byKey := make(map[string][]candidate)
 	for name, st := range e.policies {
 		if !st.failed {
 			continue
@@ -416,18 +482,28 @@ func (e *Engine) computeOverlayLocked() ([]config.RouteOverlayEntry, map[string]
 					gw, ok = e.resolveNextHop(pr.NextHopInterface)
 				}
 				if !ok {
-					// Skip BEFORE the best[key] comparison so a
-					// resolvable losing candidate can win the prefix.
-					if unresolved == nil {
-						unresolved = make(map[string][]string)
+					// Skip BEFORE winner selection so a resolvable losing
+					// candidate can win the prefix.
+					reason := "no DHCP gateway"
+					if e.resolveNextHop == nil {
+						reason = "no next-hop resolver"
 					}
-					unresolved[name] = append(unresolved[name], dest)
+					if detail.unresolved == nil {
+						detail.unresolved = make(map[string][]UnresolvedRoute)
+					}
+					detail.unresolved[name] = append(detail.unresolved[name], UnresolvedRoute{
+						RoutingInstance:  pr.RoutingInstance,
+						Destination:      dest,
+						NextHopInterface: pr.NextHopInterface,
+						Metric:           pr.PreferredMetric,
+						Reason:           reason,
+					})
 					continue
 				}
 				nextHop = gw
 			}
 			key := pr.RoutingInstance + "|" + dest
-			cand := candidate{
+			byKey[key] = append(byKey[key], candidate{
 				metric: pr.PreferredMetric,
 				policy: name,
 				entry: config.RouteOverlayEntry{
@@ -438,23 +514,41 @@ func (e *Engine) computeOverlayLocked() ([]config.RouteOverlayEntry, map[string]
 					Metric:           pr.PreferredMetric,
 					Policy:           name,
 				},
-			}
-			ex, ok := best[key]
-			if !ok || cand.metric < ex.metric ||
-				(cand.metric == ex.metric && cand.policy < ex.policy) {
-				best[key] = cand
-			}
+			})
 		}
 	}
-	for _, dests := range unresolved {
-		sort.Strings(dests)
+	for _, u := range detail.unresolved {
+		sortUnresolved(u)
 	}
-	if len(best) == 0 {
-		return nil, unresolved
+	if len(byKey) == 0 {
+		return nil, detail
 	}
-	out := make([]config.RouteOverlayEntry, 0, len(best))
-	for _, c := range best {
-		out = append(out, c.entry)
+	out := make([]config.RouteOverlayEntry, 0, len(byKey))
+	for _, cands := range byKey {
+		// Winner: lowest metric, tie-break lexicographic policy name.
+		win := 0
+		for i := 1; i < len(cands); i++ {
+			if cands[i].metric < cands[win].metric ||
+				(cands[i].metric == cands[win].metric && cands[i].policy < cands[win].policy) {
+				win = i
+			}
+		}
+		out = append(out, cands[win].entry)
+		for i, c := range cands {
+			if i == win {
+				continue
+			}
+			if detail.suppressed == nil {
+				detail.suppressed = make(map[string][]SuppressedRoute)
+			}
+			detail.suppressed[c.policy] = append(detail.suppressed[c.policy], SuppressedRoute{
+				RoutingInstance: c.entry.RoutingInstance,
+				Destination:     c.entry.Destination,
+				NextHop:         c.entry.NextHop,
+				Metric:          c.metric,
+				WinnerPolicy:    cands[win].policy,
+			})
+		}
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].RoutingInstance != out[j].RoutingInstance {
@@ -462,7 +556,28 @@ func (e *Engine) computeOverlayLocked() ([]config.RouteOverlayEntry, map[string]
 		}
 		return out[i].Destination < out[j].Destination
 	})
-	return out, unresolved
+	for _, s := range detail.suppressed {
+		sortSuppressed(s)
+	}
+	return out, detail
+}
+
+func sortUnresolved(u []UnresolvedRoute) {
+	sort.Slice(u, func(i, j int) bool {
+		if u[i].RoutingInstance != u[j].RoutingInstance {
+			return u[i].RoutingInstance < u[j].RoutingInstance
+		}
+		return u[i].Destination < u[j].Destination
+	})
+}
+
+func sortSuppressed(s []SuppressedRoute) {
+	sort.Slice(s, func(i, j int) bool {
+		if s[i].RoutingInstance != s[j].RoutingInstance {
+			return s[i].RoutingInstance < s[j].RoutingInstance
+		}
+		return s[i].Destination < s[j].Destination
+	})
 }
 
 // Status returns the per-policy view, with each policy's currently
@@ -471,10 +586,14 @@ func (e *Engine) Status() []PolicyStatus {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	overlay, unresolved := e.computeOverlayLocked()
+	overlay, detail := e.computeOverlayLocked()
 	byPolicy := make(map[string][]config.RouteOverlayEntry)
 	for _, entry := range overlay {
 		byPolicy[entry.Policy] = append(byPolicy[entry.Policy], entry)
+	}
+	appliedByPolicy := make(map[string][]config.RouteOverlayEntry)
+	for _, entry := range e.appliedOverlay {
+		appliedByPolicy[entry.Policy] = append(appliedByPolicy[entry.Policy], entry)
 	}
 
 	names := make([]string, 0, len(e.policies))
@@ -486,15 +605,19 @@ func (e *Engine) Status() []PolicyStatus {
 	out := make([]PolicyStatus, 0, len(names))
 	for _, name := range names {
 		st := e.policies[name]
+		_, known := e.failedTests[st.cfg.MatchRPMProbe]
 		ps := PolicyStatus{
 			Name:              name,
 			Probe:             st.cfg.MatchRPMProbe,
 			Failed:            st.failed,
+			Known:             known,
 			Since:             st.since,
 			HoldDownSecs:      st.cfg.HoldDownSecs,
 			PendingRecoveryAt: st.pendingRecoveryAt,
 			Routes:            byPolicy[name],
-			UnresolvedRoutes:  unresolved[name],
+			AppliedRoutes:     appliedByPolicy[name],
+			UnresolvedRoutes:  detail.unresolved[name],
+			SuppressedRoutes:  detail.suppressed[name],
 			Transitions:       st.transitions,
 		}
 		for test, failed := range e.failedTests[st.cfg.MatchRPMProbe] {
@@ -508,11 +631,15 @@ func (e *Engine) Status() []PolicyStatus {
 	return out
 }
 
-// RoutesApplied returns the number of overlay routes currently applied.
+// RoutesApplied returns the number of overlay routes ACTUALLY applied —
+// the size of the last converged actuation's overlay (#3761 H8), not the
+// desired overlay. It is 0 until the first actuation converges and holds
+// the last good value across a failing/pending actuation. Use
+// len(ActiveOverlay()) for the DESIRED count.
 func (e *Engine) RoutesApplied() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return len(e.activeOverlayLocked())
+	return len(e.appliedOverlay)
 }
 
 // seedResultsLocked rebuilds per-test fail state from a results
@@ -651,6 +778,11 @@ func (e *Engine) run() {
 				// keeps dirtySince set so the next wake re-actuates
 				// autonomously (#3757 M1/H1/H2/H3).
 				e.dirtySince = time.Time{}
+				// The actuator just published this overlay consistently
+				// (dirtyGen unchanged ⇒ the overlay is exactly what it
+				// read via ActiveOverlay); record it as the applied state
+				// so status/metrics report applied, not desired (#3761 H8).
+				e.appliedOverlay = e.activeOverlayLocked()
 			}
 			e.mu.Unlock()
 		}

--- a/pkg/ipmon/ipmon_test.go
+++ b/pkg/ipmon/ipmon_test.go
@@ -1,6 +1,8 @@
 package ipmon
 
 import (
+	"bytes"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -409,6 +411,160 @@ func TestSuccessfulActuationClearsDirty(t *testing.T) {
 	time.Sleep(200 * time.Millisecond) // ~10 throttle windows
 	if extra := attempts.Load() - first; extra > 0 {
 		t.Fatalf("converged actuation kept retrying: +%d attempts, want 0 (dirty cleared)", extra)
+	}
+}
+
+// TestUnknownStatusNotReportedAsPass is the #3761 H7 regression: a
+// configured policy with no probe result yet is UNKNOWN, not PASS.
+// Reporting PASS tells an operator failover protection is active and
+// healthy when no probe has run. On revert (Known absent / display
+// always PASS) the display carries "Status: PASS" and the UNKNOWN
+// assertion goes RED.
+func TestUnknownStatusNotReportedAsPass(t *testing.T) {
+	e, _ := newTestEngine(nil)
+	e.Apply(testPolicyConfig(), nil) // no probe results seeded yet
+
+	st := e.Status()
+	if len(st) != 1 {
+		t.Fatalf("want 1 policy, got %d", len(st))
+	}
+	if st[0].Known {
+		t.Fatal("policy reported Known before any probe result")
+	}
+	if st[0].Failed {
+		t.Fatal("policy should not be FAILED with no probe results")
+	}
+
+	var buf bytes.Buffer
+	FormatStatus(&buf, st)
+	out := buf.String()
+	if !strings.Contains(out, "Status: UNKNOWN") {
+		t.Fatalf("no-probe-data policy not rendered UNKNOWN:\n%s", out)
+	}
+	if strings.Contains(out, "Status: PASS") {
+		t.Fatalf("unknown-health policy rendered as PASS:\n%s", out)
+	}
+
+	// Once a passing result lands the policy is Known and PASS.
+	e.HandleTransition(transition("WAN", "wan-a", "pass", passResults()))
+	st = e.Status()
+	if !st[0].Known {
+		t.Fatal("policy still Unknown after a probe result")
+	}
+	buf.Reset()
+	FormatStatus(&buf, st)
+	if !strings.Contains(buf.String(), "Status: PASS") {
+		t.Fatalf("known-passing policy not rendered PASS:\n%s", buf.String())
+	}
+}
+
+// TestRoutesAppliedReflectsActuationNotDesired is the #3761 H8
+// regression: xpf_ipmon_routes_applied / RoutesApplied() must reflect
+// what actually converged into the FIBs, not the desired overlay. While
+// the actuator keeps failing, nothing is applied even though the desired
+// overlay is non-empty. On revert (RoutesApplied returns the desired
+// count) the "applied == 0 while failing" assertion goes RED.
+func TestRoutesAppliedReflectsActuationNotDesired(t *testing.T) {
+	var succeed atomic.Bool // false ⇒ actuator fails
+	e := New(func() bool { return succeed.Load() })
+	e.debounce = 5 * time.Millisecond
+	e.throttle = 10 * time.Millisecond
+	e.Apply(testPolicyConfig(), passResults())
+	e.Start()
+	defer e.Stop()
+
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+	if len(e.ActiveOverlay()) != 2 {
+		t.Fatalf("desired overlay = %d, want 2", len(e.ActiveOverlay()))
+	}
+
+	// Actuator failing → nothing converged → nothing applied.
+	time.Sleep(80 * time.Millisecond)
+	if got := e.RoutesApplied(); got != 0 {
+		t.Fatalf("RoutesApplied = %d while actuation failing, want 0 (applied != desired)", got)
+	}
+	for _, ps := range e.Status() {
+		if len(ps.AppliedRoutes) != 0 {
+			t.Fatalf("AppliedRoutes = %+v while actuation failing, want none", ps.AppliedRoutes)
+		}
+	}
+
+	// Let it converge; applied catches up to desired.
+	succeed.Store(true)
+	deadline := time.Now().Add(400 * time.Millisecond)
+	for e.RoutesApplied() != 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := e.RoutesApplied(); got != 2 {
+		t.Fatalf("RoutesApplied = %d after convergence, want 2", got)
+	}
+}
+
+// TestUnresolvedAndSuppressedDetail is the #3761 M9+M10 regression:
+// unresolved (no DHCP next-hop) and suppressed (lost winner resolution)
+// candidates are reported distinctly and with detail, not collapsed into
+// a bare "(none applied)". On revert (UnresolvedRoutes []string, no
+// SuppressedRoutes) this fails to compile / the display lacks the
+// distinct rows.
+func TestUnresolvedAndSuppressedDetail(t *testing.T) {
+	cfg := &config.IPMonitoringConfig{Policies: map[string]*config.IPMonitoringPolicy{
+		"a-policy": {
+			Name: "a-policy", MatchRPMProbe: "P1",
+			PreferredRoutes: []*config.PreferredRoute{
+				{Destination: "0.0.0.0/0", NextHop: "10.0.0.1", PreferredMetric: 10},
+			},
+		},
+		"b-policy": {
+			Name: "b-policy", MatchRPMProbe: "P1",
+			PreferredRoutes: []*config.PreferredRoute{
+				{Destination: "0.0.0.0/0", NextHop: "10.0.0.2", PreferredMetric: 20},
+			},
+		},
+		"c-policy": {
+			Name: "c-policy", MatchRPMProbe: "P1",
+			PreferredRoutes: []*config.PreferredRoute{
+				{Destination: "192.0.2.0/24", NextHopInterface: "ge-0-0-3.0", PreferredMetric: 10},
+			},
+		},
+	}}
+	e, _ := newTestEngine(nil)
+	e.SetNextHopResolver(func(string) (string, bool) { return "", false }) // never resolves
+	results := []*rpm.ProbeResult{{ProbeName: "P1", TestName: "t", LastStatus: "fail"}}
+	e.Apply(cfg, results)
+
+	byName := map[string]PolicyStatus{}
+	for _, ps := range e.Status() {
+		byName[ps.Name] = ps
+	}
+
+	// a-policy wins the default route on the lower metric.
+	if len(byName["a-policy"].Routes) != 1 {
+		t.Fatalf("a-policy should win the default route: %+v", byName["a-policy"])
+	}
+	// b-policy is suppressed by a-policy, not applied and not unresolved.
+	b := byName["b-policy"]
+	if len(b.Routes) != 0 {
+		t.Fatalf("b-policy should not win: %+v", b.Routes)
+	}
+	if len(b.SuppressedRoutes) != 1 || b.SuppressedRoutes[0].WinnerPolicy != "a-policy" {
+		t.Fatalf("b-policy suppressed detail wrong: %+v", b.SuppressedRoutes)
+	}
+	// c-policy's interface-typed candidate is unresolved with detail.
+	ur := byName["c-policy"].UnresolvedRoutes
+	if len(ur) != 1 || ur[0].Destination != "192.0.2.0/24" ||
+		ur[0].NextHopInterface != "ge-0-0-3.0" || ur[0].Reason == "" {
+		t.Fatalf("c-policy unresolved detail wrong: %+v", ur)
+	}
+
+	var buf bytes.Buffer
+	FormatStatus(&buf, e.Status())
+	out := buf.String()
+	if !strings.Contains(out, "suppressed by policy a-policy") {
+		t.Fatalf("display missing suppressed detail:\n%s", out)
+	}
+	if !strings.Contains(out, "192.0.2.0/24") || !strings.Contains(out, "unresolved") ||
+		!strings.Contains(out, "ge-0-0-3.0") {
+		t.Fatalf("display missing unresolved detail:\n%s", out)
 	}
 }
 

--- a/pkg/ipmon/ipmon_test.go
+++ b/pkg/ipmon/ipmon_test.go
@@ -339,6 +339,42 @@ func TestSuccessfulActuationClearsDirty(t *testing.T) {
 	}
 }
 
+// TestLifecycleIdempotent is the #3762 regression: the exported engine
+// lifecycle must be idempotent. A second Start must be a no-op (H9 — on
+// revert it spawns a second run() goroutine whose deferred close(e.done)
+// panics after Stop), and Stop must be safe before/without Start (H10 —
+// on revert it blocks forever on <-e.done because no run loop exists to
+// close it).
+func TestLifecycleIdempotent(t *testing.T) {
+	// H9: double Start does not spawn a second goroutine (no double
+	// close(done) panic), and repeated Stop is safe.
+	e := New(func() bool { return true })
+	e.debounce = time.Millisecond
+	e.throttle = time.Millisecond
+	e.Start()
+	e.Start() // no-op; on revert a second run() → panic on Stop
+	time.Sleep(10 * time.Millisecond)
+	e.Stop()
+	e.Stop() // idempotent, no panic
+
+	// H10: Stop before Start must return promptly, not deadlock.
+	e2 := New(func() bool { return true })
+	stopReturned := make(chan struct{})
+	go func() {
+		e2.Stop()
+		close(stopReturned)
+	}()
+	select {
+	case <-stopReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop before Start deadlocked (H10)")
+	}
+	// A Start after Stop must be a no-op (no run loop, no panic) and a
+	// further Stop stays safe.
+	e2.Start()
+	e2.Stop()
+}
+
 // TestPublishGatingBaseline: standby gating returns a nil overlay
 // (baseline) and re-enables on takeover.
 func TestPublishGatingBaseline(t *testing.T) {

--- a/pkg/ipmon/ipmon_test.go
+++ b/pkg/ipmon/ipmon_test.go
@@ -164,6 +164,79 @@ func TestRecoveryHoldDown(t *testing.T) {
 	}
 }
 
+// TestHoldDownRecomputeOnConfigChange is the #3763 regression: changing
+// the hold-down value while a recovery is pending must recompute the
+// pending-recovery deadline (crediting the time already elapsed), so a
+// lowered hold-down shortens the pending recovery and a raised one
+// extends it — without a restart. On revert (pendingRecoveryAt preserved
+// verbatim) the old deadline stays in force and each scenario goes RED.
+func TestHoldDownRecomputeOnConfigChange(t *testing.T) {
+	enterRecovery := func(holdSecs int) (*Engine, *fakeClock) {
+		cfg := testPolicyConfig()
+		cfg.Policies["wan-failover"].HoldDownSecs = holdSecs
+		e, clock := newTestEngine(nil)
+		e.Apply(cfg, passResults())
+		e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+		e.HandleTransition(transition("WAN", "wan-a", "pass", passResults()))
+		if e.Status()[0].PendingRecoveryAt.IsZero() {
+			t.Fatalf("setup: no pending recovery under hold-down %ds", holdSecs)
+		}
+		return e, clock
+	}
+	reapply := func(e *Engine, holdSecs int) {
+		cfg := testPolicyConfig()
+		cfg.Policies["wan-failover"].HoldDownSecs = holdSecs
+		e.Apply(cfg, passResults())
+	}
+	evalNow := func(e *Engine) {
+		e.mu.Lock()
+		e.evaluateLocked(e.now())
+		e.mu.Unlock()
+	}
+
+	// Lower below elapsed time → recover immediately (the incident-
+	// response scenario: 300s hold, 50s elapsed, drop to 10s).
+	e, clock := enterRecovery(300)
+	clock.Advance(50 * time.Second)
+	reapply(e, 10)
+	if e.Status()[0].Failed {
+		t.Fatal("hold-down lowered below elapsed time did not recover")
+	}
+
+	// Lower to a still-future deadline → shortens but stays pending, then
+	// recovers at the NEW (earlier) deadline, well before the old one.
+	e, clock = enterRecovery(300)
+	clock.Advance(50 * time.Second) // T0+50
+	reapply(e, 100)                 // new deadline T0+100 (was T0+300)
+	if !e.Status()[0].Failed {
+		t.Fatal("recovered too early after shortening to a still-future deadline")
+	}
+	clock.Advance(51 * time.Second) // T0+101: past the new deadline, before the old
+	evalNow(e)
+	if e.Status()[0].Failed {
+		t.Fatal("did not recover at the shortened deadline (old deadline still in force)")
+	}
+
+	// Raise extends: 10s hold, 5s elapsed, raise to 100s → stays pending
+	// past the OLD 10s deadline.
+	e, clock = enterRecovery(10)
+	clock.Advance(5 * time.Second)
+	reapply(e, 100)                 // new deadline T0+100
+	clock.Advance(10 * time.Second) // T0+15: past the OLD deadline
+	evalNow(e)
+	if !e.Status()[0].Failed {
+		t.Fatal("recovered at the OLD short deadline after hold-down was raised")
+	}
+
+	// Unchanged hold-down preserves the running deadline verbatim.
+	e, _ = enterRecovery(300)
+	before := e.Status()[0].PendingRecoveryAt
+	reapply(e, 300)
+	if got := e.Status()[0].PendingRecoveryAt; !got.Equal(before) {
+		t.Fatalf("unchanged hold-down moved the deadline: %v -> %v", before, got)
+	}
+}
+
 // TestWinnerResolution verifies the §4.1 corrected semantics: among
 // multiple injected routes for the same prefix, lowest preferred-metric
 // wins; tie-break lexicographic policy name; withdrawal of the winner

--- a/pkg/ipmon/nexthop_test.go
+++ b/pkg/ipmon/nexthop_test.go
@@ -135,7 +135,7 @@ func TestNilResolverSkips(t *testing.T) {
 		t.Fatalf("overlay = %+v with nil resolver, want nil", overlay)
 	}
 	st := e.Status()
-	if len(st) != 1 || len(st[0].UnresolvedRoutes) != 1 || st[0].UnresolvedRoutes[0] != "0.0.0.0/0" {
+	if len(st) != 1 || len(st[0].UnresolvedRoutes) != 1 || st[0].UnresolvedRoutes[0].Destination != "0.0.0.0/0" {
 		t.Fatalf("status = %+v, want one unresolved route", st)
 	}
 }


### PR DESCRIPTION
Three coupled `services ip-monitoring` fixes from codex-review-160,
combined in one PR because they all touch `pkg/ipmon/ipmon.go` +
display/metrics (combining avoids self-conflict). Each is an independent
commit with a RED-on-revert test.

## #3762 — idempotent engine lifecycle (H9 + H10)
`Start` was a bare `go e.run()` and `run()` defers `close(e.done)`, so a
second `Start` spawned a second goroutine and the second deferred
`close(done)` panicked ("close of closed channel") after `Stop` (H9).
`Stop` closed `e.stop` then blocked unconditionally on `<-e.done`, so a
`Stop` before/without `Start` deadlocked forever (H10). Fix: `started`/
`stopped` guarded under the mutex — `Start` is a no-op when already
started or stopped, `Stop` closes `e.stop` once and waits on `e.done`
only when a run loop was actually started.

## #3763 — hold-down pending-recovery recompute (M7 + L6)
`Apply` preserved `pendingRecoveryAt` verbatim whenever `(name, probe)`
survived a commit, ignoring a changed `HoldDownSecs`. A policy
recovering under a 300s hold-down that the operator lowered to 10s mid-
incident still waited the old 300s deadline. Fix: recompute the deadline
as `pendingRecoveryAt + (newHold - oldHold)` (credits elapsed time) when
hold-down changed; drop to zero (recover next evaluate) when lowered to
0; kick the run loop so it re-arms its wake against the new deadline.

## #3761 — honest status/metrics (H7 + H8 + M9 + M10 + L12)
- **H7:** `PolicyStatus.Known`; `FormatStatus` renders `UNKNOWN` (not
  `PASS`) before any probe result.
- **H8:** engine tracks `appliedOverlay` (last converged actuation);
  `xpf_ipmon_routes_applied` now reflects actually-applied, new
  `xpf_ipmon_routes_desired` reflects intent. A sustained
  `desired > applied` gap flags a failover that has not converged.
- **M9:** `UnresolvedRoutes` is a typed `[]UnresolvedRoute` (routing-
  instance, tracked unit, metric, reason).
- **M10:** new `SuppressedRoutes` — resolvable candidates that lost
  winner resolution, shown as "suppressed by policy <name>", distinct
  from unresolved. Route-Action rows carry APPLIED / PENDING /
  suppressed / unresolved state.
- **L12:** documented in `docs/multi-wan.md` + `pkg/ipmon/README.md`.

## Validation
- `TestLifecycleIdempotent` (-race), `TestHoldDownRecomputeOnConfigChange`,
  `TestUnknownStatusNotReportedAsPass`,
  `TestRoutesAppliedReflectsActuationNotDesired` (-race),
  `TestUnresolvedAndSuppressedDetail` — each verified **RED on revert**.
- `go test -race ./pkg/ipmon/...`, `go test ./pkg/api/... ./pkg/daemon/
  ./pkg/grpcapi/ ./pkg/cli/` green; `go build ./...`, `gofmt`, `vet`
  clean.

Closes #3761
Closes #3762
Closes #3763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi