### PR TITLE
flowexport: stable per-group SourceID/Observation Domain ID (#3740)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26505,3 +26505,34 @@ top.
     backend_http_test.go (TestDyndns2ServerEndpointParsing), pkg/config/
     compiler_p3_http_providers_test.go (TestP3Dyndns2ServerMalformedWarns
     + TestDDNSDyndns2ServerValidLockstep), pkg/ddns/README.md (#3737 note)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3740 — stable per-group NetFlow v9 SourceID / IPFIX
+    Observation Domain ID. The resolvers start one exporter per
+    (sampling-instance, template) group but every exporter hardcoded
+    SourceID/ODID = 1 and reuses template IDs 256/257, so two groups to
+    one collector present an identical RFC decode key → template
+    redefinitions + interleaved sequence streams (false loss/restart).
+    #3745's per-collector source-address does not fix it by default.
+    Fix (Option A, converged /research plan): new pure helper
+    `stableExporterID(protocol, instance, template)` — FNV-1a 64 over
+    "protocol|instance|template", xor-folded to 32 bits, mapped into
+    [1, 0xFFFFFFFF], mirroring config.StableTunnelEndpointID (#1873).
+    NewExporter stamps it as the v9 SourceID; NewIPFIXExporter as the
+    IPFIX ODID. Template IDs stay 256/257 (a unique ODID restores the
+    RFC scoping key). HA-symmetric: pure function of config-synced
+    fields, nothing node-specific → both cluster nodes compute the same
+    id → failover never presents a new observation domain. Degenerate
+    default (empty instance AND template) keeps id=1 to preserve the
+    pre-#3740 wire + existing unit tests. One-time upgrade churn:
+    named/multi-group deployments see ODID/SourceID 1→hash once (release
+    noted). RED-on-revert verified (constant-1 → distinct-per-group
+    assertions fail; degenerate-default still passes). go test
+    ./pkg/flowexport/... ./pkg/daemon/... green; go build ./... green;
+    gofmt + vet clean.
+  - **File(s)**: pkg/flowexport/exporterid.go (new helper),
+    pkg/flowexport/netflow.go (NewExporter SourceID),
+    pkg/flowexport/ipfix.go (NewIPFIXExporter ODID),
+    pkg/flowexport/exporter_id_3740_test.go (new RED-on-revert +
+    HA-symmetry + degenerate-default tests),
+    pkg/flowexport/README.md ("Exporter identity" section + file layout)

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -298,6 +298,9 @@ The package is split by responsibility (#1988):
   that drives it.
 - `ipfix.go` — IPFIX (v10) template/record encoding and the
   `IPFIXExporter` that drives it.
+- `exporterid.go` — `stableExporterID(protocol, instance, template)`
+  (#3740): the stable, nonzero 32-bit per-group id used as the v9 SourceID
+  / IPFIX Observation Domain ID. See "Exporter identity" below.
 - `routemask.go` — the `MaskResolver` func type and
   `NewRouteMaskResolver` (#2866): a TTL-cached, size-bounded FIB
   longest-prefix-match lookup that resolves a flow's `srcMask`/`dstMask`
@@ -337,6 +340,69 @@ exporters MUST NOT share the same rule:
   the header sequence, which loss/sequence-tracking collectors (pmacct,
   Elastiflow) read as packet loss or an exporter restart. Pinned by
   `TestIPFIXTemplateRefreshPreservesSequenceNumber` (fail-on-revert).
+
+## Exporter identity — SourceID / Observation Domain ID (#3740)
+
+The resolvers start **one exporter per (sampling-instance, template)
+group** (`ResolveV9TemplateGroups` / `ResolveIPFIXTemplateGroups`), but
+every exporter previously hardcoded the NetFlow v9 header **SourceID**
+(RFC 3954 §5.1) and the IPFIX header **Observation Domain ID** (RFC 7011
+§3.1) to `1`, and every group reuses template IDs 256/257. Two groups
+pointed at the SAME collector therefore presented an identical RFC decode
+key — `(exporter source IP, SourceID/ODID, templateID)` — so the collector
+saw template **redefinitions** (256 under one group vs another) and two
+**interleaved sequence streams** under one observation domain, read as
+packet loss or an exporter restart. #3745's per-collector source-address
+does not fix this by default: auto/identical source-address yields the
+same source IP, and SourceID stayed 1 for both.
+
+Each exporter now derives a **stable, nonzero 32-bit id** from its config
+identity via `stableExporterID(protocol, instance, template)`
+(`exporterid.go`): FNV-1a 64 over `"protocol|instance|template"`,
+xor-folded to 32 bits, mapped into `[1, 0xFFFFFFFF]`. It mirrors
+`config.StableTunnelEndpointID` (#1873). `NewExporter` stamps it as the v9
+SourceID; `NewIPFIXExporter` as the IPFIX Observation Domain ID.
+
+- **Template IDs stay 256/257.** A unique ODID/SourceID restores the RFC
+  scoping key, so 256 under ODID-A is a different template from 256 under
+  ODID-B — no per-group template-ID allocator needed.
+- **Per-exporter sequence counters stay** (now correct: each group has its
+  own observation domain, so its own sequence stream).
+- **HA symmetry (load-bearing).** Flow export is NOT gated on RG
+  mastership (`reconcileFlowExporters` has no master/standby guard), so
+  both cluster nodes run exporters from the same synced config. The id is
+  a pure function of config-synced fields (protocol/instance/template) and
+  of NOTHING node-specific, so both nodes compute the IDENTICAL id for a
+  group and a failover never presents the collector a new observation
+  domain — the same argument #1873 relies on.
+- **Protocol tag** (`"netflow9"` vs `"ipfix"`) is folded in so a v9 and an
+  IPFIX group with the same instance/template never share a value
+  (belt-and-braces; a flow-server binds one version per #2136).
+- **Degenerate-default guard.** A hand-built `ExportConfig{}` with no
+  instance AND no template (the singular `Build*` helpers and several unit
+  tests) keeps SourceID/ODID = `1`, preserving the pre-#3740 wire for the
+  unnamed single-default deployment. Real multi-group configs always carry
+  a non-empty `InstanceName` (sampling instances are named), so they
+  always get distinct hashed ids.
+
+**One-time upgrade churn (release note).** For any *named* or *multi-group*
+deployment the SourceID/ODID changes from `1` to the hashed value the
+first time this build runs. This is the intended, collector-visible
+correctness change: a collector sees a **new observation domain** once,
+and any dashboards/filters keyed on `ODID=1` (or `SourceID=1`) must be
+updated to the new per-group id. The truly-degenerate unnamed default
+(empty instance + template) stays at `1`. This is a NetFlow/IPFIX
+**wire-value** change to the external collector only — it is NOT an
+internal Go↔Rust snapshot wire change (no `protocol_wire_v1.json` regen).
+
+Fail-on-revert pins (`exporter_id_3740_test.go`, loopback UDP):
+`TestNetflowV9SourceIDDistinctPerGroup` /
+`TestIPFIXObservationDomainDistinctPerGroup` (two same-collector groups
+differing only in template, and only in instance, emit distinct ids —
+restoring the constant `1` flips them RED),
+`TestStableExporterIDDegenerateDefault` (the all-empty default stays 1),
+and `TestStableExporterIDHASymmetry` (deterministic id + protocol
+disambiguation).
 
 ## Per-collector write-health (#2464)
 

--- a/pkg/flowexport/exporter_id_3740_test.go
+++ b/pkg/flowexport/exporter_id_3740_test.go
@@ -1,0 +1,247 @@
+package flowexport
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// #3740 regression guard. Two exporter groups pointed at the SAME collector
+// but differing in their config identity (template name, or sampling-instance
+// name) MUST present DISTINCT NetFlow v9 SourceID (RFC 3954 §5.1) and IPFIX
+// Observation Domain ID (RFC 7011 §3.1) values. Before the fix both hardcoded
+// 1, so two groups to one collector collided on the RFC decode key -- template
+// redefinitions + interleaved sequence streams under one observation domain.
+//
+// Revert stableExporterID to a constant 1 (or restore `sourceID: 1` in
+// NewExporter / NewIPFIXExporter) and the DISTINCT assertions below go RED:
+// both streams carry the same id again.
+
+// loopbackUDP returns a listening UDP collector on 127.0.0.1 and its address.
+func loopbackUDP(t *testing.T) (net.PacketConn, string) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	return pc, pc.LocalAddr().String()
+}
+
+func readOne(t *testing.T, pc net.PacketConn) []byte {
+	t.Helper()
+	buf := make([]byte, 2048)
+	if err := pc.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	n, _, err := pc.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("ReadFrom (collector got no packet): %v", err)
+	}
+	if n < 20 {
+		t.Fatalf("short flow packet: %d bytes", n)
+	}
+	return buf[:n]
+}
+
+func mkRec() []FlowRecord {
+	return []FlowRecord{{
+		SrcIP:     net.IPv4(10, 0, 0, 1),
+		DstIP:     net.IPv4(10, 0, 0, 2),
+		SrcPort:   1234,
+		DstPort:   80,
+		Protocol:  6,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}}
+}
+
+// v9SourceID reads the NetFlow v9 header SourceID (offset 16..20, big-endian).
+func v9SourceID(pkt []byte) uint32 { return binary.BigEndian.Uint32(pkt[16:20]) }
+
+// ipfixODID reads the IPFIX header Observation Domain ID (offset 12..16, BE).
+func ipfixODID(pkt []byte) uint32 { return binary.BigEndian.Uint32(pkt[12:16]) }
+
+func TestNetflowV9SourceIDDistinctPerGroup(t *testing.T) {
+	pc, addr := loopbackUDP(t)
+	defer pc.Close()
+
+	// Two groups to the SAME collector, differing ONLY in TemplateName, under
+	// one shared (non-empty) sampling instance.
+	ecA := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: addr}},
+		InstanceName: "inst0",
+		TemplateName: "tmplA",
+	}
+	ecB := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: addr}},
+		InstanceName: "inst0",
+		TemplateName: "tmplB",
+	}
+	eA, err := NewExporter(ecA)
+	if err != nil {
+		t.Fatalf("NewExporter A: %v", err)
+	}
+	defer eA.Close()
+	eB, err := NewExporter(ecB)
+	if err != nil {
+		t.Fatalf("NewExporter B: %v", err)
+	}
+	defer eB.Close()
+
+	eA.sendRecords(mkRec())
+	idA := v9SourceID(readOne(t, pc))
+	eB.sendRecords(mkRec())
+	idB := v9SourceID(readOne(t, pc))
+
+	if idA == 0 || idB == 0 {
+		t.Fatalf("SourceID must be nonzero: A=%d B=%d", idA, idB)
+	}
+	if idA == idB {
+		t.Fatalf("v9 SourceID collision: group A (tmplA) and group B (tmplB) "+
+			"to the same collector both emitted SourceID=%d (#3740)", idA)
+	}
+
+	// A second axis: differ ONLY in InstanceName. Also distinct.
+	ecC := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: addr}},
+		InstanceName: "instX",
+		TemplateName: "tmplA",
+	}
+	eC, err := NewExporter(ecC)
+	if err != nil {
+		t.Fatalf("NewExporter C: %v", err)
+	}
+	defer eC.Close()
+	eC.sendRecords(mkRec())
+	idC := v9SourceID(readOne(t, pc))
+	if idC == idA {
+		t.Fatalf("v9 SourceID collision on instance axis: instX and inst0 "+
+			"(same template) both emitted SourceID=%d (#3740)", idC)
+	}
+}
+
+func TestIPFIXObservationDomainDistinctPerGroup(t *testing.T) {
+	pc, addr := loopbackUDP(t)
+	defer pc.Close()
+
+	ecA := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: addr}},
+		InstanceName: "inst0",
+		TemplateName: "tmplA",
+	}
+	ecB := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: addr}},
+		InstanceName: "inst0",
+		TemplateName: "tmplB",
+	}
+	eA, err := NewIPFIXExporter(ecA)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter A: %v", err)
+	}
+	defer eA.Close()
+	eB, err := NewIPFIXExporter(ecB)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter B: %v", err)
+	}
+	defer eB.Close()
+
+	eA.sendRecords(mkRec())
+	idA := ipfixODID(readOne(t, pc))
+	eB.sendRecords(mkRec())
+	idB := ipfixODID(readOne(t, pc))
+
+	if idA == 0 || idB == 0 {
+		t.Fatalf("ODID must be nonzero: A=%d B=%d", idA, idB)
+	}
+	if idA == idB {
+		t.Fatalf("IPFIX Observation Domain ID collision: group A (tmplA) and "+
+			"group B (tmplB) to the same collector both emitted ODID=%d (#3740)", idA)
+	}
+
+	ecC := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: addr}},
+		InstanceName: "instX",
+		TemplateName: "tmplA",
+	}
+	eC, err := NewIPFIXExporter(ecC)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter C: %v", err)
+	}
+	defer eC.Close()
+	eC.sendRecords(mkRec())
+	idC := ipfixODID(readOne(t, pc))
+	if idC == idA {
+		t.Fatalf("IPFIX ODID collision on instance axis: instX and inst0 "+
+			"(same template) both emitted ODID=%d (#3740)", idC)
+	}
+}
+
+// TestStableExporterIDDegenerateDefault: the truly-degenerate hand-built
+// ExportConfig{} (no instance AND no template) keeps SourceID/ODID = 1, so the
+// singular Build* helpers and the pre-#3740 unnamed single-default deployment
+// are on the pre-existing wire.
+func TestStableExporterIDDegenerateDefault(t *testing.T) {
+	if got := stableExporterID("netflow9", "", ""); got != 1 {
+		t.Fatalf("degenerate default (netflow9) = %d, want 1", got)
+	}
+	if got := stableExporterID("ipfix", "", ""); got != 1 {
+		t.Fatalf("degenerate default (ipfix) = %d, want 1", got)
+	}
+
+	// End-to-end: a default-group exporter (empty instance + template) stamps 1.
+	pcV9, addrV9 := loopbackUDP(t)
+	defer pcV9.Close()
+	eV9, err := NewExporter(&ExportConfig{Collectors: []CollectorConfig{{Address: addrV9}}})
+	if err != nil {
+		t.Fatalf("NewExporter default: %v", err)
+	}
+	defer eV9.Close()
+	eV9.sendRecords(mkRec())
+	if id := v9SourceID(readOne(t, pcV9)); id != 1 {
+		t.Fatalf("default-group v9 SourceID = %d, want 1", id)
+	}
+
+	pcIP, addrIP := loopbackUDP(t)
+	defer pcIP.Close()
+	eIP, err := NewIPFIXExporter(&ExportConfig{Collectors: []CollectorConfig{{Address: addrIP}}})
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter default: %v", err)
+	}
+	defer eIP.Close()
+	eIP.sendRecords(mkRec())
+	if id := ipfixODID(readOne(t, pcIP)); id != 1 {
+		t.Fatalf("default-group IPFIX ODID = %d, want 1", id)
+	}
+}
+
+// TestStableExporterIDHASymmetry: the id is a pure function of config-synced
+// inputs and of NOTHING node-specific, so both cluster nodes ("node0"/"node1"
+// builds) compute the SAME id for a given group -- a failover never presents
+// the collector a new observation domain. Determinism across repeated
+// evaluation stands in for the two builds (there is no node input to vary).
+func TestStableExporterIDHASymmetry(t *testing.T) {
+	cases := []struct{ proto, inst, tmpl string }{
+		{"netflow9", "inst0", "tmplA"},
+		{"netflow9", "instX", ""},
+		{"ipfix", "inst0", "tmplB"},
+		{"ipfix", "", "onlytmpl"},
+	}
+	for _, c := range cases {
+		node0 := stableExporterID(c.proto, c.inst, c.tmpl)
+		node1 := stableExporterID(c.proto, c.inst, c.tmpl)
+		if node0 != node1 {
+			t.Fatalf("HA asymmetry for (%s,%s,%s): node0=%d node1=%d",
+				c.proto, c.inst, c.tmpl, node0, node1)
+		}
+		if node0 == 0 {
+			t.Fatalf("id must be nonzero for (%s,%s,%s)", c.proto, c.inst, c.tmpl)
+		}
+	}
+
+	// The protocol tag disambiguates a v9 and an IPFIX group with an identical
+	// instance/template (belt-and-braces; #2136 keeps them from co-pointing).
+	if stableExporterID("netflow9", "inst0", "tmplA") == stableExporterID("ipfix", "inst0", "tmplA") {
+		t.Fatal("netflow9 and ipfix groups with identical instance/template share an id")
+	}
+}

--- a/pkg/flowexport/exporterid.go
+++ b/pkg/flowexport/exporterid.go
@@ -1,0 +1,57 @@
+package flowexport
+
+import "hash/fnv"
+
+// stableExporterID maps an exporter group's config identity
+// (protocol, sampling-instance name, referenced template name) to a
+// stable, nonzero 32-bit id used as the NetFlow v9 header SourceID
+// (RFC 3954 §5.1) and the IPFIX header Observation Domain ID
+// (RFC 7011 §3.1). It mirrors config.StableTunnelEndpointID / #1873:
+// FNV-1a 64 over "protocol|instance|template", xor-folded to 32 bits,
+// mapped into [1, 0xFFFFFFFF].
+//
+// WHY (#3740): the resolvers start one exporter per (instance,
+// template) group (ResolveV9TemplateGroups / ResolveIPFIXTemplateGroups),
+// but every exporter previously stamped SourceID / ObservationID = 1.
+// Two groups pointed at the SAME collector then present an identical RFC
+// decode key — (exporter source IP, SourceID/ODID, templateID) — with
+// template IDs 256/257 shared too, so the collector sees template
+// redefinitions and two interleaved sequence streams under one domain
+// (false loss / restart reports). A unique per-group id restores the
+// RFC scoping key; template IDs 256/257 can stay conventional because
+// 256 under ODID-A is a different template from 256 under ODID-B.
+//
+// HA symmetry (the load-bearing constraint): flow export is NOT gated on
+// RG mastership — both cluster nodes run exporters from the same synced
+// config. Because the id is a pure function of config-synced fields
+// (protocol/instance/template) and of NOTHING node-specific, both nodes
+// compute the IDENTICAL id for a given group, so a failover never
+// presents the collector a new observation domain. This is the same
+// HA-symmetry argument #1873 relies on, satisfied by construction.
+//
+// The protocol tag ("netflow9" vs "ipfix") is folded in so a v9 group
+// and an IPFIX group with the same instance/template never share a value
+// (belt-and-braces; a flow-server binds one version per #2136, so they
+// never actually co-point).
+//
+// Degenerate-default guard: a hand-built ExportConfig{} (the singular
+// Build* helpers and several unit tests) carries no instance AND no
+// template. That truly-degenerate single-default deployment keeps the
+// historical SourceID/ODID = 1 (some collectors treat ODID 0 specially,
+// and this preserves the pre-#3740 wire for the unnamed default). Real
+// multi-group configs always carry a non-empty InstanceName (sampling
+// instances are named), so they always get distinct hashed ids.
+func stableExporterID(protocol, instance, template string) uint32 {
+	if instance == "" && template == "" {
+		return 1
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(protocol))
+	_, _ = h.Write([]byte{'|'})
+	_, _ = h.Write([]byte(instance))
+	_, _ = h.Write([]byte{'|'})
+	_, _ = h.Write([]byte(template))
+	s := h.Sum64()
+	folded := uint32(s) ^ uint32(s>>32)
+	return folded%0xFFFFFFFF + 1
+}

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -538,8 +538,13 @@ type IPFIXExporter struct {
 // would fork the counter, re-seeding the sampling cadence (#2224).
 func NewIPFIXExporter(cfg *ExportConfig) (*IPFIXExporter, error) {
 	e := &IPFIXExporter{
-		cfg:          cfg,
-		sourceID:     1,
+		cfg: cfg,
+		// #3740: stable per-group Observation Domain ID (RFC 7011 §3.1)
+		// derived from the config identity so two same-collector groups no
+		// longer collide on ODID=1 (template redefinitions + interleaved
+		// sequence streams). HA-symmetric (pure function of config-synced
+		// fields — both cluster nodes compute the same ODID).
+		sourceID:     stableExporterID("ipfix", cfg.InstanceName, cfg.TemplateName),
 		includeDir:   cfg.IncludeFlowDir,
 		templateSet:  encodeIPFIXTemplateSetDir(cfg.IncludeFlowDir),
 		MaskResolver: NewRouteMaskResolver(0),

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -516,9 +516,12 @@ type Exporter struct {
 // callback so there is exactly one counter per exporter.
 func NewExporter(cfg *ExportConfig) (*Exporter, error) {
 	e := &Exporter{
-		cfg:          cfg,
-		bootTime:     time.Now(),
-		sourceID:     1,
+		cfg:      cfg,
+		bootTime: time.Now(),
+		// #3740: stable per-group SourceID (RFC 3954 §5.1) derived from the
+		// config identity so two same-collector groups no longer collide on
+		// SourceID=1. HA-symmetric (pure function of config-synced fields).
+		sourceID:     stableExporterID("netflow9", cfg.InstanceName, cfg.TemplateName),
 		fieldsV4:     buildTemplateFieldsV4(cfg.V9TemplateOpts),
 		fieldsV6:     buildTemplateFieldsV6(cfg.V9TemplateOpts),
 		MaskResolver: NewRouteMaskResolver(0),
@@ -594,10 +597,10 @@ func (e *Exporter) ExportSessionClose(rec logging.EventRecord, evt SessionCloseD
 		DstMask:   dstMask,
 		// #2749: ingress ifindex (SNMP ifIndex) -> NetFlow IE 10; plus the
 		// re-introduced srcTos (IE 5) / tcpFlags (IE 6) / OutputSNMP (IE 14).
-		InIf:       evt.InIf,
-		TOS:        evt.TOS,
-		TCPFlags:   evt.TCPFlags,
-		OutIf:      evt.OutIf,
+		InIf:     evt.InIf,
+		TOS:      evt.TOS,
+		TCPFlags: evt.TCPFlags,
+		OutIf:    evt.OutIf,
 		// #3270: flowDirection (IE 61), derived from sampling-direction in the
 		// daemon callback. Encoded only when the group enabled flow-dir.
 		Direction:  evt.Direction,


### PR DESCRIPTION
Closes #3740

## Problem

The flow-export resolvers start **one exporter per (sampling-instance,
template) group** (`ResolveV9TemplateGroups` / `ResolveIPFIXTemplateGroups`),
but every exporter hardcoded the NetFlow v9 header **SourceID** (RFC 3954
§5.1) and the IPFIX header **Observation Domain ID** (RFC 7011 §3.1) to
`1` (`netflow.go` NewExporter, `ipfix.go` NewIPFIXExporter), and every
group reuses template IDs 256/257. Two groups pointed at the **same
collector** therefore present an identical RFC decode key —
`(exporter source IP, SourceID/ODID, templateID)` — so the collector sees
template **redefinitions** and two **interleaved sequence streams** under
one observation domain, decoded as packet loss / exporter restart.

#3745's per-collector source-address does not mitigate by default:
auto/identical source-address yields the same source IP, and SourceID
stayed `1` for both groups.

## Fix (Option A — converged /research plan)

New pure helper `stableExporterID(protocol, instance, template) uint32`
(`pkg/flowexport/exporterid.go`), mirroring `config.StableTunnelEndpointID`
(#1873): FNV-1a 64 over `"protocol|instance|template"`, xor-folded to 32
bits, mapped into `[1, 0xFFFFFFFF]`. `NewExporter` stamps it as the v9
SourceID; `NewIPFIXExporter` as the IPFIX Observation Domain ID.

- **Template IDs stay 256/257** — a unique ODID/SourceID restores the RFC
  scoping key, so 256 under ODID-A ≠ 256 under ODID-B. No template-ID
  allocator needed.
- **Per-exporter sequence counters stay** (now correct under a unique id).
- **HA-symmetric:** flow export is NOT gated on RG mastership, so both
  cluster nodes run exporters from the same synced config. The id is a
  pure function of config-synced fields (protocol/instance/template) and
  of nothing node-specific → both nodes compute the identical id → a
  failover never presents the collector a new observation domain. Same
  argument #1873 relies on.
- **Protocol tag** disambiguates a v9 vs an IPFIX group with identical
  instance/template (belt-and-braces; #2136 keeps them from co-pointing).
- **Degenerate-default guard:** a hand-built `ExportConfig{}` with no
  instance AND no template keeps SourceID/ODID = `1`, preserving the
  pre-#3740 wire for the unnamed single-default deployment + existing unit
  tests. Real multi-group configs always carry a non-empty `InstanceName`.

This changes the ODID/SourceID **value** on the NetFlow/IPFIX wire to the
external collector (intended — it is the fix). It is NOT an internal
Go↔Rust snapshot wire change (no `protocol_wire_v1.json` regen).

## One-time upgrade churn (release note)

For any **named** or **multi-group** deployment the SourceID/ODID changes
from `1` to the hashed value the first time this build runs — a collector
sees a **new observation domain** once, and dashboards/filters keyed on
`ODID=1` (or `SourceID=1`) must be updated. The truly-degenerate unnamed
default (empty instance + template) stays at `1`.

## Tests

`pkg/flowexport/exporter_id_3740_test.go` (loopback UDP, reuses the
`ipfix_seqnum_test.go` harness shape):

- `TestNetflowV9SourceIDDistinctPerGroup` /
  `TestIPFIXObservationDomainDistinctPerGroup` — two same-collector groups
  differing only in template (shared non-empty instance), plus a second
  axis differing only in instance, emit **distinct nonzero** ids read off
  the wire (v9 SourceID @ header 16..20, IPFIX ODID @ header 12..16).
  **RED-on-revert verified:** forcing `stableExporterID` to a constant `1`
  flips both distinct-per-group tests RED while the degenerate-default
  test stays green.
- `TestStableExporterIDDegenerateDefault` — the all-empty default stamps
  `1` end-to-end (v9 + IPFIX).
- `TestStableExporterIDHASymmetry` — deterministic id across repeated
  evaluation (stands in for node0/node1 builds computing the same id) +
  protocol-tag disambiguation.

`go test ./pkg/flowexport/... ./pkg/daemon/...` green; `go build ./...`
green; `gofmt` + `go vet` clean.

## Docs

`pkg/flowexport/README.md` — new "Exporter identity — SourceID /
Observation Domain ID (#3740)" section (collision, fix, template-IDs
rationale, HA symmetry, degenerate-default guard, upgrade churn) +
`exporterid.go` in the file layout. `_Log.md` entry (2026-07-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
