### PR TITLE
host-inbound: fail-closed duplicate host-local-address gate + observability (#3718 Option B)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,50 @@
+## 2026-07-01 — #3718 host-inbound: fail-closed duplicate host-local-address gate + runtime reporter/metric (Option B)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3718 (HIGH, codex-review-153 H01/M02/M03/M04/M09). The kernel
+    host-inbound nftables chain matches DESTINATION ADDRESS ONLY (no ingress
+    predicate) over a single global `inet xpf_hostinbound` chain, so two zones
+    resolving the SAME firewall-local address (dup interface addr, dup VRRP VIP,
+    or same addr across routing-instances) emit two daddr-keyed blocks in
+    zone-sort order and the earlier-sorting zone decides the packet — and can
+    disagree with the already-ingress-scoped userspace-dp host_inbound_admits
+    path (split-brain). No duplicate-local-address gate existed. Implemented the
+    converged /research plan's Option B (fail-closed gate + observability);
+    Option A (kernel iifname ingress-scope) and Option C (per-VRF chains) are
+    deferred follow-ons documented on the issue + in
+    docs/host-inbound-service-matrix.md.
+    - COMMIT-TIME: `validateDuplicateHostLocalAddressStrict`
+      (pkg/config/dup_host_local_address.go) hard-rejects a config where the same
+      (family, host address) — interface addr OR VRRP VIP — is
+      host-inbound-reachable from >1 DISTINCT effective host-inbound token set.
+      Keys on differing sets via the shared `CanonicalHostInboundTokenSig`, NOT
+      ">1 zone", so an identical-service dup is allowed (no false positive);
+      lifeline ifaces (fxp0/em0/fab*) excluded. Covers IPv4/IPv6/VRRP/cross-zone
+      M04. Lenient downgrade to cfg.Warnings on the tolerant path
+      (lenientDuplicateHostLocalAddress, #1960). Wired in compiler.go after
+      validateHostInboundTokensStrict.
+    - RUNTIME: `AmbiguousHostInboundAddresses` (pkg/dataplane/userspace/zones.go,
+      mirrors #3698 AddresslessEnforcingZones) reads BuildZoneHostInboundViews;
+      `xpf_host_inbound_ambiguous_addresses{address,family}` gauge (pkg/api,
+      emitted before the dataplane gate); daemon state-transition log
+      `logHostInboundAmbiguousTransitions` (pkg/daemon/daemon_nft.go, WARN on
+      entry / INFO on recovery; ambiguity is NOT self-healing).
+    - TESTS (RED-on-revert proven by neutering each layer): config matrix
+      (v4/v6/VRRP reject + identical-service/same-zone/lifeline/distinct allow +
+      commit-reject/lenient-warn wiring), userspace reporter, api metric
+      (before-gate), daemon log transitions. go test ./pkg/config/...
+      ./pkg/dataplane/... ./pkg/api/... ./pkg/daemon/ green; go build ./...;
+      gofmt+vet clean.
+  - **File(s)**: pkg/config/dup_host_local_address.go (new),
+    pkg/config/dup_host_local_address_3718_test.go (new), pkg/config/compiler.go,
+    pkg/dataplane/userspace/zones.go,
+    pkg/dataplane/userspace/zones_ambiguous_3718_test.go (new),
+    pkg/api/metrics.go, pkg/api/metrics_descriptors.go,
+    pkg/api/metrics_counters.go,
+    pkg/api/metrics_host_inbound_ambiguous_3718_test.go (new),
+    pkg/daemon/daemon.go, pkg/daemon/daemon_nft.go,
+    pkg/daemon/host_inbound_ambiguous_3718_test.go (new),
+    docs/host-inbound-service-matrix.md, docs/config-schema.md
 ## 2026-07-01 — #3769 fold (review MINOR): empty from-routing-instance NAT external = table-agnostic wildcard
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -171,6 +171,35 @@ validation:
   directions — tail-drop and typo-bypass — across bracket / repeated-line /
   hierarchical shapes, plus the value-slot completion pin).
 
+## Duplicate host-local-address fail-closed gate (#3718, Option B)
+
+Beyond the per-leaf token allowlist above, host-inbound admission has a
+**cross-field** commit-time gate. The kernel host-inbound nftables chain matches
+on **destination address only** (no ingress-interface / VRF predicate) over a
+single global input chain, so two security zones that resolve the SAME
+firewall-local address (a duplicated interface address, a duplicated VRRP VIP, or
+the same address reused across routing-instances) emit two rule blocks keyed on
+the same `daddr` in zone-sort order — the earlier-sorting zone decides the packet
+regardless of ingress, and can even disagree with the ingress-scoped userspace-dp
+path (split-brain). `validateDuplicateHostLocalAddressStrict`
+(`compiler_validate` group, `dup_host_local_address.go`) **rejects at commit /
+commit-check** a config where the same `(family, host address)` — interface
+address OR VRRP VIP — is host-inbound-reachable from more than one **distinct
+effective host-inbound token set**. It keys on *differing* sets (via the shared
+`config.CanonicalHostInboundTokenSig`), NOT merely ">1 zone", so a deliberate
+duplicate with **identical** service sets across its zones is allowed (no false
+positive), and management/cluster-control lifeline interfaces (fxp0 / em0 / fab*)
+are excluded. Lenient downgrade to a `cfg.Warnings` entry on the tolerant load /
+peer-sync path (`lenientDuplicateHostLocalAddress`, #1960 no-brick); the runtime
+`dpuserspace.AmbiguousHostInboundAddresses` reporter + the
+`xpf_host_inbound_ambiguous_addresses` gauge surface any tolerantly-loaded
+ambiguity (it is NOT self-healing). The kernel `iifname` ingress-scope fix
+(Option A) and per-VRF host-inbound chains (Option C) are deferred follow-ons —
+see `docs/host-inbound-service-matrix.md`. Coverage:
+`dup_host_local_address_3718_test.go` (config), `zones_ambiguous_3718_test.go`
+(reporter), `metrics_host_inbound_ambiguous_3718_test.go` (metric),
+`host_inbound_ambiguous_3718_test.go` (daemon log transitions).
+
 ## Trailing-token arity on scalar value leaves (#3332)
 
 The mirror image of the multi-value contract is the **scalar** value leaf: a

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -228,6 +228,77 @@ Two observability surfaces consume it:
   visible in a config-only / degraded boot). Alert with e.g.
   `max_over_time(xpf_host_inbound_addressless_zones[1h]) > 0`.
 
+## Duplicate host-local-address ambiguity (#3718, Option B)
+
+The kernel host-inbound chain matches on **destination address only** — every
+rule is `<fam> daddr <zone-addrs> ...` with **no** ingress-interface / VRF / zone
+predicate, over a **single global** `inet xpf_hostinbound` input chain
+(`emitHostInboundZone`, `pkg/daemon/daemon_nft.go`). So when two security zones
+resolve the **same** firewall-local address — a duplicated interface address, a
+duplicated VRRP VIP, or the same address reused across routing-instances (a zone
+is not VRF-scoped in xpf, so overlapping-VRF reuse surfaces as the cross-zone
+case) — they emit two rule blocks keyed on the same `daddr`, in zone-sort order,
+and the **earlier-sorting zone decides the packet** regardless of which zone /
+interface the traffic actually ingresses. A zero-service zone emits only a
+terminal catch-all `drop` for the address, so if it sorts first it drops every
+host-bound service the other zone opened (or the inverse admits what the owning
+zone denied). Worse, the userspace-dp secondary path (`host_inbound_admits`,
+`forwarding/host_inbound.rs`) is **already ingress-zone scoped**, so the kernel
+`daddr` path and the userspace path can render **opposite** verdicts on the same
+packet — a kernel/userspace split-brain.
+
+This is caught fail-closed at commit and surfaced at runtime:
+
+- **Commit-time gate** `config.validateDuplicateHostLocalAddressStrict`
+  (`pkg/config/dup_host_local_address.go`) hard-rejects a config where the same
+  `(family, host address)` — an interface address OR a VRRP VIP — is
+  host-inbound-reachable from **more than one distinct effective host-inbound
+  token set**. It keys on differing token sets, NOT merely ">1 zone", so it does
+  **not** false-positive on a deliberate duplicate: the same address in two zones
+  with **identical** host-inbound service sets renders the same block twice
+  (order-independent, both paths agree) and is allowed; only a differing set (two
+  zones with different `host-inbound-traffic`, or one zone with differing #3362
+  per-interface overrides) is rejected. Covers IPv4 (H01), IPv6 (M02), VRRP VIPs
+  (M03), and the cross-zone subset of same-address-across-routing-instances
+  (M04). Management / cluster-control lifeline interfaces (fxp0 / em0 / fab*) are
+  excluded, mirroring the deny scoping. On the tolerant load / peer-sync path the
+  rejection is downgraded to a `cfg.Warnings` entry (`lenientDuplicateHostLocalAddress`)
+  so an already-persisted or peer-synced config an older binary accepted still
+  boots (#1960 no-brick).
+- **Runtime SSOT** `dpuserspace.AmbiguousHostInboundAddresses`
+  (`pkg/dataplane/userspace/zones.go`) reads the scopes back from
+  `BuildZoneHostInboundViews` (the same builder that drives nft emission), using
+  the shared `config.CanonicalHostInboundTokenSig` so it can never disagree with
+  the commit gate on what counts as a differing set. Unlike the addressless
+  window above, an ambiguity is **NOT self-healing** — it stands until the config
+  is fixed.
+- **State-transition log** (`daemon_nft.go`,
+  `logHostInboundAmbiguousTransitions`): a `WARN` on ENTRY, an `INFO` on RECOVERY,
+  logged once per transition (not every apply).
+- **Prometheus gauge** `xpf_host_inbound_ambiguous_addresses{address,family}`
+  (`pkg/api`), value `1` per ambiguous address, emitted BEFORE the dataplane gate
+  so it stays visible in a config-only / degraded boot. Alert with
+  `max_over_time(xpf_host_inbound_ambiguous_addresses[1h]) > 0`.
+
+### Deferred follow-ons
+
+Option B rejects the ambiguity fail-closed; it does **not** yet make the kernel
+path ingress-scoped. Two follow-ons are tracked on #3718:
+
+- **Option A — kernel `iifname` ingress-scope**: emit host-inbound rules with an
+  `iifname` (ingress netdev / VRF) predicate so the ingress zone disambiguates
+  the `daddr`, matching the Junos model and ending the split-brain with the
+  already-ingress-scoped userspace path. Deferred: `iifname` must enumerate every
+  ingress netdev for a zone (physical, `.0` units, VLAN subinterfaces, VRF
+  members, `lo` for locally-generated traffic, HA/fabric paths) or a legitimate
+  management packet fails closed and locks out the box — it needs the
+  netdev-enumeration audit + loss-cluster lab validation (VLAN units + a VRRP
+  failover).
+- **Option C — per-VRF host-inbound chains**: separate per-routing-instance input
+  chains so the same address can be **intentionally** reused across VRFs with
+  distinct host-inbound policies (which Option B rejects). A larger architectural
+  fork; deferred until there is demand.
+
 ## Adding a new host-inbound service
 
 Adding or changing a token is a coordinated edit across all three surfaces so the

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -34,6 +34,7 @@ type xpfCollector struct {
 	hostInboundDeny             *prometheus.Desc
 	hostInboundKernelDenies     *prometheus.Desc
 	hostInboundAddresslessZones *prometheus.Desc
+	hostInboundAmbiguousAddrs   *prometheus.Desc
 	tcEgressPacketsTotal        *prometheus.Desc
 	syncookieTotal              *prometheus.Desc
 	flowCacheTotal              *prometheus.Desc
@@ -528,6 +529,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.hostInboundDeny
 	ch <- c.hostInboundKernelDenies
 	ch <- c.hostInboundAddresslessZones
+	ch <- c.hostInboundAmbiguousAddrs
 	ch <- c.tcEgressPacketsTotal
 	ch <- c.syncookieTotal
 	ch <- c.flowCacheTotal
@@ -891,6 +893,13 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	// window can be open in a config-only / degraded boot too, and that is exactly
 	// when it must stay visible.
 	c.collectHostInboundAddresslessZones(ch)
+
+	// #3718 (Option B): firewall-local addresses reachable from multiple zones
+	// with differing host-inbound service sets (order-dependent kernel verdict).
+	// Config-derived and independent of dataplane load — and, unlike the
+	// addressless window, NOT self-healing — so emit it BEFORE the dataplane gate
+	// so it stays visible in a config-only / degraded boot too.
+	c.collectHostInboundAmbiguousAddresses(ch)
 
 	dp := c.srv.dp
 	if dp == nil || !dp.IsLoaded() {

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -73,6 +73,35 @@ func (c *xpfCollector) collectHostInboundAddresslessZones(ch chan<- prometheus.M
 	}
 }
 
+// collectHostInboundAmbiguousAddresses emits xpf_host_inbound_ambiguous_addresses
+// (#3718 Option B): a 1 per firewall-local address that is
+// host-inbound-reachable from more than one security zone with DIFFERING
+// host-inbound service/protocol sets. The kernel host-inbound chain matches
+// destination address only (no ingress predicate) over a single global input
+// chain, so the admission verdict for such an address is order-dependent (the
+// earlier-sorting zone wins) and can disagree with the ingress-scoped
+// userspace-dp path. The strict commit gate
+// (config.validateDuplicateHostLocalAddressStrict) rejects this; a tolerant /
+// peer-synced load (#1960) can slip one through, and unlike the addressless
+// window it is NOT self-healing — so this series stays present until the config
+// is fixed. Config-derived (no dataplane dependency), so Collect calls this
+// BEFORE the dataplane gate, matching the addressless-zone signal above. The
+// SSOT is dpuserspace.AmbiguousHostInboundAddresses, the same builder the daemon
+// logs from, so the metric and the log agree.
+func (c *xpfCollector) collectHostInboundAmbiguousAddresses(ch chan<- prometheus.Metric) {
+	if c.srv == nil || c.srv.store == nil {
+		return
+	}
+	cfg := c.srv.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	for _, a := range dpuserspace.AmbiguousHostInboundAddresses(cfg) {
+		ch <- prometheus.MustNewConstMetric(c.hostInboundAmbiguousAddrs,
+			prometheus.GaugeValue, 1, a.Address, a.Family)
+	}
+}
+
 func (c *xpfCollector) collectGlobalCounters(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
 	// #3345: on a counter-read failure, SKIP emitting the sample instead of
 	// reporting a misleading 0, and bump xpf_counter_read_errors_total. A

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -115,6 +115,27 @@ func newCollector(srv *Server) *xpfCollector {
 				"scoping (transient fail-open admit window), labeled by zone.",
 			[]string{"zone"}, nil,
 		),
+		// #3718 (Option B): 1 per firewall-local address that is
+		// host-inbound-reachable from more than one security zone with DIFFERING
+		// host-inbound service/protocol sets. The kernel host-inbound nftables
+		// chain matches on destination address only (no ingress predicate) over a
+		// single global input chain, so such an address's admission verdict is
+		// decided order-dependently by whichever zone sorts first, and can
+		// disagree with the ingress-scoped userspace-dp path (split-brain). The
+		// strict commit gate hard-rejects this; a tolerant / peer-synced load
+		// (#1960) can slip one through, and unlike the addressless window it is
+		// NOT self-healing — so this control-plane signal (config-derived,
+		// emitted BEFORE the dataplane gate) stays 1 until the ambiguity is
+		// resolved. Absent = no ambiguous address.
+		hostInboundAmbiguousAddrs: prometheus.NewDesc(
+			"xpf_host_inbound_ambiguous_addresses",
+			"1 per firewall-local address that is host-inbound-reachable from "+
+				"multiple security zones with differing host-inbound service/"+
+				"protocol sets, making the kernel destination-address-only "+
+				"host-inbound verdict order-dependent (#3718), labeled by "+
+				"address and family.",
+			[]string{"address", "family"}, nil,
+		),
 		tcEgressPacketsTotal: prometheus.NewDesc(
 			"xpf_tc_egress_packets_total",
 			"Total TC egress packets processed.",

--- a/pkg/api/metrics_host_inbound_ambiguous_3718_test.go
+++ b/pkg/api/metrics_host_inbound_ambiguous_3718_test.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// ambiguousHostInboundStore builds a store whose ACTIVE config a tolerant load
+// accepts but the strict commit gate would reject (#3718 Option B): the same
+// IPv4 (192.0.2.1) on two interfaces in two zones with DIFFERING host-inbound
+// sets (aaa default-deny, zzz ssh). The kernel host-inbound verdict for
+// 192.0.2.1 is then order-dependent. Commit() runs the STRICT path and would
+// reject this, so the store is seeded via a persisted DB + tolerant Load() —
+// modeling a peer-synced / older-binary config that slipped one through, exactly
+// the case the runtime metric exists to surface (the ambiguity is NOT
+// self-healing).
+func ambiguousHostInboundStore(t *testing.T) *configstore.Store {
+	t.Helper()
+	dir := t.TempDir()
+	// Built via flat-set commands (the parser merges hierarchical newlines, so
+	// set-command construction is the reliable form for a multi-stanza fixture).
+	lines := []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 192.0.2.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 192.0.2.1/24",
+		"set security zones security-zone aaa interfaces ge-0/0/0.0",
+		"set security zones security-zone zzz interfaces ge-0/0/1.0",
+		"set security zones security-zone zzz host-inbound-traffic system-services ssh",
+	}
+	tree := &config.ConfigTree{}
+	for _, l := range lines {
+		p, err := config.ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(p); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	// Sanity: it must be strict-REJECTED (proving the gate is live) yet
+	// lenient-ACCEPTED (so a tolerant Load promotes it to the active config).
+	if _, err := config.CompileConfig(tree); err == nil {
+		t.Fatal("precondition: ambiguous config compiled cleanly on the STRICT path; the #3718 gate must reject it")
+	}
+	if _, err := config.CompileConfigLenient(tree); err != nil {
+		t.Fatalf("precondition: ambiguous config must compile on the tolerant path (warning, not error): %v", err)
+	}
+
+	db, err := configstore.NewDB(filepath.Join(dir, ".configdb"))
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	db.SetWriterVersion("test-1.0")
+	if err := db.WriteActive(tree); err != nil {
+		t.Fatalf("WriteActive: %v", err)
+	}
+
+	store := newConfigStore(t, filepath.Join(dir, "xpf.conf"))
+	if err := store.Load(); err != nil {
+		t.Fatalf("tolerant Load() of the seeded DB must succeed: %v", err)
+	}
+	if store.ActiveConfig() == nil {
+		t.Fatal("ActiveConfig() nil after tolerant Load of a lenient-compilable config")
+	}
+	return store
+}
+
+// TestHostInboundAmbiguousAddressesEmittedWhenDataplaneUnloaded is the #3718
+// fail-on-revert proof: the ambiguity is a config-derived control-plane signal
+// that can be open in a config-only / degraded boot AND is NOT self-healing, so
+// xpf_host_inbound_ambiguous_addresses must be emitted even with the dataplane
+// unloaded. Collect must call collectHostInboundAmbiguousAddresses BEFORE the
+// `dp == nil || !dp.IsLoaded()` gate; moving it below makes this RED (dp is nil
+// here, so Collect returns before reaching it and the series vanishes).
+func TestHostInboundAmbiguousAddressesEmittedWhenDataplaneUnloaded(t *testing.T) {
+	s := &Server{store: ambiguousHostInboundStore(t)} // dp intentionally nil.
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(newCollector(s))
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	type key struct{ addr, family string }
+	got := map[key]float64{}
+	for _, mf := range mfs {
+		if mf.GetName() != "xpf_host_inbound_ambiguous_addresses" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			var k key
+			for _, l := range m.GetLabel() {
+				switch l.GetName() {
+				case "address":
+					k.addr = l.GetValue()
+				case "family":
+					k.family = l.GetValue()
+				}
+			}
+			got[k] = m.GetGauge().GetValue()
+		}
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("xpf_host_inbound_ambiguous_addresses series = %v, want exactly {192.0.2.1/inet:1} "+
+			"(config-only boot; collector must run BEFORE the dataplane gate)", got)
+	}
+	if v := got[key{addr: "192.0.2.1", family: "inet"}]; v != 1 {
+		t.Errorf("192.0.2.1/inet gauge = %v, want 1", v)
+	}
+}
+
+// TestHostInboundAmbiguousAddressesNilStoreNoPanic guards the degraded path: a
+// Server with no store must not panic when the collector runs before the
+// dataplane gate.
+func TestHostInboundAmbiguousAddressesNilStoreNoPanic(t *testing.T) {
+	c := newCollector(&Server{}) // store nil
+	ch := make(chan prometheus.Metric, 4)
+	c.collectHostInboundAmbiguousAddresses(ch)
+	close(ch)
+	if n := len(ch); n != 0 {
+		t.Fatalf("emitted %d series with nil store, want 0", n)
+	}
+}

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -819,6 +819,23 @@ type compileOpts struct {
 	// zone so it too fails CLOSED), so a leniently-loaded bad config is inert
 	// and consistent. Same doctrine as lenientPolicyZoneRefs.
 	lenientHostInboundTokens bool
+	// lenientDuplicateHostLocalAddress (#3718 Option B) downgrades the
+	// duplicate host-local-address gate (validateDuplicateHostLocalAddressStrict)
+	// from a hard compile error to a cfg.Warnings entry. The strict commit /
+	// commit-check path hard-rejects a firewall-local address (interface address
+	// or VRRP VIP) that is host-inbound-reachable from more than one security
+	// zone with DIFFERING host-inbound service/protocol sets — the kernel
+	// host-inbound nftables chain matches destination address only (no ingress
+	// predicate), so the admission verdict for such an address is decided
+	// order-dependently by whichever zone sorts first, and can disagree with the
+	// ingress-scoped userspace-dp path (split-brain). The tolerant load /
+	// peer-sync paths downgrade to a warning so an already-persisted or
+	// peer-synced config an older binary accepted still BOOTS (#1960 no-brick);
+	// on that path the ambiguity is NOT self-healing, so the runtime reporter
+	// (dataplane/userspace.AmbiguousHostInboundAddresses) and the
+	// xpf_host_inbound_ambiguous_addresses metric are the operator's signal. Same
+	// doctrine as lenientZoneInterfaceMembership.
+	lenientDuplicateHostLocalAddress bool
 	// lenientDestNATAddresses (#2396) downgrades the destination-NAT
 	// destination-address gate (validateDestinationNATAddressesStrict) from a
 	// hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1362,6 +1379,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientAddressBookNames:              true,
 		lenientZoneInterfaceMembership:       true,
 		lenientHostInboundTokens:             true,
+		lenientDuplicateHostLocalAddress:     true,
 		lenientDestNATAddresses:              true,
 		lenientRPMSourceAddress:              true,
 		lenientRPMLinkLocalZone:              true,
@@ -1526,6 +1544,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientAddressBookNames:              true,
 		lenientZoneInterfaceMembership:       true,
 		lenientHostInboundTokens:             true,
+		lenientDuplicateHostLocalAddress:     true,
 		lenientDestNATAddresses:              true,
 		lenientRPMSourceAddress:              true,
 		lenientRPMLinkLocalZone:              true,
@@ -2453,6 +2472,30 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		if opts.lenientHostInboundTokens {
 			cfg.Warnings = append(cfg.Warnings,
 				fmt.Sprintf("host-inbound-traffic token (downgraded to warning on tolerant path): %v", err))
+		} else {
+			return nil, err
+		}
+	}
+
+	// #3718 (Option B) duplicate host-local-address gate. Strict on commit /
+	// commit-check (hard-reject a firewall-local interface address or VRRP VIP
+	// that is host-inbound-reachable from more than one security zone with
+	// DIFFERING host-inbound service/protocol sets — the kernel host-inbound
+	// nftables chain matches destination address only over a single global input
+	// chain, so the admission verdict is decided order-dependently by whichever
+	// zone sorts first and can disagree with the ingress-scoped userspace-dp path
+	// (split-brain)); lenient on load / peer-sync (warn so an already-persisted
+	// or peer-synced config still boots — #1960 no-brick; the runtime reporter
+	// AmbiguousHostInboundAddresses + the xpf_host_inbound_ambiguous_addresses
+	// metric surface the ambiguity, which is NOT self-healing on that path). Runs
+	// AFTER the host-inbound token gate so a token typo still wins the
+	// first-error slot. Option A (kernel iifname ingress-scope) and Option C
+	// (per-VRF host-inbound chains) are deferred follow-ons — see
+	// docs/host-inbound-traffic.md.
+	if err := validateDuplicateHostLocalAddressStrict(cfg); err != nil {
+		if opts.lenientDuplicateHostLocalAddress {
+			cfg.Warnings = append(cfg.Warnings,
+				fmt.Sprintf("duplicate host-local address (downgraded to warning on tolerant path): %v", err))
 		} else {
 			return nil, err
 		}

--- a/pkg/config/dup_host_local_address.go
+++ b/pkg/config/dup_host_local_address.go
@@ -1,0 +1,346 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+)
+
+// dup_host_local_address.go is the commit-time fail-closed gate for #3718
+// (Option B): a firewall-local address (a configured interface address or a
+// VRRP VIP) that is host-inbound-reachable from more than one security zone
+// with DIFFERING host-inbound service/protocol sets.
+//
+// Why it matters: the kernel host-inbound nftables chain
+// (pkg/daemon/daemon_nft.go emitHostInboundZone) matches on DESTINATION ADDRESS
+// ONLY — it carries no ingress-interface / VRF / zone predicate, and there is a
+// single global `inet xpf_hostinbound` input chain. So when two zones resolve
+// the SAME local address they emit two rule blocks keyed on the same daddr, in
+// zone-sort order, and the earlier-sorting zone decides the packet regardless
+// of which zone / interface the traffic actually ingresses. A zero-service zone
+// emits only a terminal catch-all drop for the address, so if it sorts first it
+// drops every host-bound service the other zone opened (or the inverse admits
+// what the owning zone denied). Worse, the userspace-dp secondary path
+// (forwarding/host_inbound.rs host_inbound_admits) is ALREADY ingress-zone
+// scoped, so the kernel daddr path and the userspace path can render OPPOSITE
+// verdicts on the same packet — a genuine split-brain. Neither is gated by any
+// existing strict validator (validateZoneInterfaceMembershipStrict enforces
+// interface OWNERSHIP uniqueness, not ADDRESS uniqueness), so a strict-valid
+// config reaches this ambiguity.
+//
+// This is Option B of the converged #3718 research plan: fail closed at commit
+// on the ambiguous case and expose it at runtime (see
+// dataplane/userspace.AmbiguousHostInboundAddresses + the
+// xpf_host_inbound_ambiguous_addresses metric). Option A (an iifname / ingress
+// predicate on the kernel chain — the semantically-correct Junos model, and
+// what host_inbound_admits already does) and Option C (per-VRF host-inbound
+// chains that would SUPPORT deliberate overlapping address space) are deferred
+// follow-ons: Option A carries a management-lockout regression risk that needs
+// the netdev-enumeration audit + loss-cluster lab validation, and Option C is a
+// larger architectural fork. See docs/host-inbound-traffic.md.
+//
+// The gate keys on "same (family, host address) contributing to >1 DISTINCT
+// effective host-inbound token set", NOT merely ">1 zone", so it does NOT
+// false-positive on a deliberate duplicate:
+//   - same address in two zones with IDENTICAL host-inbound service sets renders
+//     the same accept+drop block twice — order-independent, both paths agree, so
+//     it is allowed;
+//   - same address in one zone dedups to a single block — allowed;
+//   - differing verdicts arise from two zones with different host-inbound sets
+//     OR one zone with per-interface #3362 overrides that differ, and only those
+//     are rejected.
+// It covers IPv4 (H01) + IPv6 (M02) static interface addresses AND VRRP VIPs
+// (M03), and the cross-zone subset of same-address-across-routing-instances
+// (M04) — a zone is not VRF-scoped in xpf, so overlapping-VRF address reuse
+// surfaces as the cross-zone case here (intentional overlap needs Option C to
+// be SUPPORTED; Option B rejects it fail-closed). Management / cluster-control
+// lifeline interfaces (fxp0 / em0 / fab* / configured control+fabric) are
+// excluded, mirroring the runtime deny-scoping, so a shared management address
+// is never flagged.
+//
+// Strict on the commit / commit-check path (CompileConfig — hard-reject);
+// downgraded to a cfg.Warnings entry on the tolerant load / peer-sync paths
+// (CompileConfigLenient / CompileConfigForNodeLenient, flag
+// lenientDuplicateHostLocalAddress) so an already-persisted or peer-synced
+// config an older binary accepted still BOOTS (#1960 no-brick). On that tolerant
+// path the ambiguity is NOT self-healing — the kernel emits an order-dependent
+// rule — so AmbiguousHostInboundAddresses + the metric are the operator's
+// runtime signal. Iteration is fully sorted so the first-reported error is
+// deterministic across runs.
+
+// CanonicalHostInboundTokenSig returns a canonical, order-independent signature
+// of an EFFECTIVE host-inbound admission set (system-services ∪ protocols),
+// lower-cased, trimmed, de-duplicated, and sorted within each list. It is the
+// SSOT for comparing "do these two host-inbound scopes admit the same set" and
+// is shared by the commit-time gate here and the runtime reporter
+// (dataplane/userspace.AmbiguousHostInboundAddresses) so the two paths can never
+// disagree on what counts as a DIFFERING service set. The two lists are joined
+// with a separator that can never appear in a token, so an empty set (Junos
+// default-deny) has a stable distinct signature.
+func CanonicalHostInboundTokenSig(svc, proto []string) string {
+	norm := func(in []string) string {
+		seen := make(map[string]bool, len(in))
+		out := make([]string, 0, len(in))
+		for _, t := range in {
+			t = strings.ToLower(strings.TrimSpace(t))
+			if t == "" || seen[t] {
+				continue
+			}
+			seen[t] = true
+			out = append(out, t)
+		}
+		sort.Strings(out)
+		return strings.Join(out, ",")
+	}
+	return norm(svc) + "\x1f" + norm(proto)
+}
+
+// hostLocalAddrFamily normalizes a "ip/prefix" or bare-IP string to its bare
+// host IP plus the Junos family name ("inet" / "inet6"). Returns "", "" if the
+// value is unparseable.
+func hostLocalAddrFamily(s string) (host, family string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	var ip net.IP
+	if parsed, _, err := net.ParseCIDR(s); err == nil && parsed != nil {
+		ip = parsed
+	} else if parsed := net.ParseIP(s); parsed != nil {
+		ip = parsed
+	} else {
+		return "", ""
+	}
+	if ip.To4() != nil {
+		return ip.String(), "inet"
+	}
+	return ip.String(), "inet6"
+}
+
+// buildZoneInterfaceMapLocal builds the logical-interface-key -> zone lookup the
+// same way pkg/dataplane/userspace.buildInterfaceZoneMap does (first-writer-wins
+// over the SORTED zone names, base/unit expansion via zoneIfaceLogicalKeys).
+// pkg/config cannot import pkg/dataplane, so it is rebuilt locally here; the
+// key-expansion SSOT (zoneIfaceLogicalKeys) is shared, so the two stay aligned.
+func buildZoneInterfaceMapLocal(cfg *Config) map[string]string {
+	if cfg == nil || len(cfg.Security.Zones) == 0 {
+		return nil
+	}
+	out := make(map[string]string)
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, name)
+	}
+	sort.Strings(zoneNames)
+	for _, zn := range zoneNames {
+		zone := cfg.Security.Zones[zn]
+		if zone == nil {
+			continue
+		}
+		for _, iface := range zone.Interfaces {
+			if iface == "" {
+				continue
+			}
+			for _, key := range zoneIfaceLogicalKeys(cfg, iface) {
+				if _, ok := out[key]; !ok {
+					out[key] = zn
+				}
+			}
+		}
+	}
+	return out
+}
+
+// buildHostInboundOverrideMapLocal mirrors
+// pkg/dataplane/userspace.buildInterfaceHostInboundMap: per-interface
+// host-inbound overrides (#3362) keyed by the interface ref, with a bare
+// physical ref expanded to each of its configured units. Rebuilt locally
+// because pkg/config cannot import pkg/dataplane.
+func buildHostInboundOverrideMapLocal(cfg *Config) map[string]*HostInboundTraffic {
+	if cfg == nil || len(cfg.Security.Zones) == 0 {
+		return nil
+	}
+	out := make(map[string]*HostInboundTraffic)
+	zoneNames := make([]string, 0, len(cfg.Security.Zones))
+	for name := range cfg.Security.Zones {
+		zoneNames = append(zoneNames, name)
+	}
+	sort.Strings(zoneNames)
+	for _, zn := range zoneNames {
+		zone := cfg.Security.Zones[zn]
+		if zone == nil || len(zone.InterfaceHostInbound) == 0 {
+			continue
+		}
+		refs := make([]string, 0, len(zone.InterfaceHostInbound))
+		for ref := range zone.InterfaceHostInbound {
+			refs = append(refs, ref)
+		}
+		sort.Strings(refs)
+		for _, ref := range refs {
+			hib := zone.InterfaceHostInbound[ref]
+			if ref == "" || hib == nil {
+				continue
+			}
+			if _, ok := out[ref]; !ok {
+				out[ref] = hib
+			}
+			if strings.Contains(ref, ".") {
+				continue // logical unit ref: exact match only
+			}
+			if ifCfg := cfg.Interfaces.Interfaces[ref]; ifCfg != nil {
+				for unitNum := range ifCfg.Units {
+					un := fmt.Sprintf("%s.%d", ref, unitNum)
+					if _, ok := out[un]; !ok {
+						out[un] = hib
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// effectiveHostInboundSigLocal returns the canonical signature of the EFFECTIVE
+// host-inbound admission set for one interface unit: the zone-level set UNION
+// the per-interface override (#3362, Junos additive), canonicalized. It mirrors
+// pkg/dataplane/userspace.unionHostInboundTokens feeding
+// CanonicalHostInboundTokenSig, so the commit gate and the runtime reporter
+// classify the same unit identically.
+func effectiveHostInboundSigLocal(zone *ZoneConfig, override *HostInboundTraffic) string {
+	var svc, proto []string
+	if zone != nil && zone.HostInboundTraffic != nil {
+		svc = append(svc, zone.HostInboundTraffic.SystemServices...)
+		proto = append(proto, zone.HostInboundTraffic.Protocols...)
+	}
+	if override != nil {
+		svc = append(svc, override.SystemServices...)
+		proto = append(proto, override.Protocols...)
+	}
+	return CanonicalHostInboundTokenSig(svc, proto)
+}
+
+// validateDuplicateHostLocalAddressStrict implements the #3718 Option B
+// commit-time gate documented at the top of this file. It returns the first
+// (in sorted family+address order) firewall-local address that is
+// host-inbound-reachable from more than one security zone / effective
+// host-inbound token set with DIFFERING admission, naming the address and the
+// contributing zones.
+func validateDuplicateHostLocalAddressStrict(cfg *Config) error {
+	if cfg == nil || len(cfg.Security.Zones) == 0 {
+		return nil
+	}
+	lifelines := HostInboundLifelineSet(cfg)
+	zoneByIface := buildZoneInterfaceMapLocal(cfg)
+	overrideByIface := buildHostInboundOverrideMapLocal(cfg)
+
+	// Per (family, host IP): the set of distinct effective token signatures and
+	// the zones contributing them.
+	type claim struct {
+		sigs  map[string]bool
+		zones map[string]bool
+	}
+	claims := make(map[string]*claim)
+	record := func(family, host, zone, sig string) {
+		key := family + "\x00" + host
+		c := claims[key]
+		if c == nil {
+			c = &claim{sigs: make(map[string]bool), zones: make(map[string]bool)}
+			claims[key] = c
+		}
+		c.sigs[sig] = true
+		c.zones[zone] = true
+	}
+
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for name := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, name)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		ifc := cfg.Interfaces.Interfaces[ifName]
+		if ifc == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(ifc.Units))
+		for un := range ifc.Units {
+			unitNums = append(unitNums, un)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := ifc.Units[un]
+			if unit == nil {
+				continue
+			}
+			unitName := fmt.Sprintf("%s.%d", ifName, un)
+			if HostInboundLifelineInterface(unitName, lifelines) {
+				continue
+			}
+			zoneName := zoneByIface[unitName]
+			if zoneName == "" {
+				zoneName = zoneByIface[ifName]
+			}
+			if zoneName == "" {
+				continue
+			}
+			zone := cfg.Security.Zones[zoneName]
+			if zone == nil {
+				continue
+			}
+			override := overrideByIface[unitName]
+			if override == nil {
+				override = overrideByIface[ifName]
+			}
+			sig := effectiveHostInboundSigLocal(zone, override)
+
+			for _, a := range unit.Addresses {
+				if host, family := hostLocalAddrFamily(a); host != "" {
+					record(family, host, zoneName, sig)
+				}
+			}
+			vgKeys := make([]string, 0, len(unit.VRRPGroups))
+			for k := range unit.VRRPGroups {
+				vgKeys = append(vgKeys, k)
+			}
+			sort.Strings(vgKeys)
+			for _, k := range vgKeys {
+				vg := unit.VRRPGroups[k]
+				if vg == nil {
+					continue
+				}
+				for _, vip := range vg.VirtualAddresses {
+					if host, family := hostLocalAddrFamily(vip); host != "" {
+						record(family, host, zoneName, sig)
+					}
+				}
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(claims))
+	for k := range claims {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		c := claims[k]
+		if len(c.sigs) < 2 {
+			continue
+		}
+		parts := strings.SplitN(k, "\x00", 2)
+		family, host := parts[0], parts[1]
+		famLabel := "IPv4"
+		if family == "inet6" {
+			famLabel = "IPv6"
+		}
+		zones := make([]string, 0, len(c.zones))
+		for z := range c.zones {
+			zones = append(zones, z)
+		}
+		sort.Strings(zones)
+		return fmt.Errorf(
+			"host-local %s address %s is host-inbound-reachable from multiple security zones (%s) with DIFFERING host-inbound service/protocol sets; the kernel host-inbound nftables chain matches destination address only (no ingress-interface predicate) and uses a single global input chain, so the host-inbound admission verdict for this address is decided order-dependently by whichever zone sorts first — a zone-isolation failure, and the kernel path can even disagree with the ingress-scoped userspace-dp path (split-brain). Give the address a single host-inbound policy: assign it to one zone, or make the host-inbound-traffic service/protocol sets identical across the zones that share it (#3718)",
+			famLabel, host, strings.Join(zones, ", "))
+	}
+	return nil
+}

--- a/pkg/config/dup_host_local_address_3718_test.go
+++ b/pkg/config/dup_host_local_address_3718_test.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3718 (Option B): a firewall-local address (interface address or VRRP VIP)
+// that is host-inbound-reachable from more than one security zone with DIFFERING
+// host-inbound service/protocol sets makes the kernel destination-address-only
+// host-inbound verdict order-dependent (the earlier-sorting zone decides the
+// packet) and can disagree with the ingress-scoped userspace-dp path. These
+// tests pin the commit-time gate (validateDuplicateHostLocalAddressStrict) and
+// are fail-on-revert: neuter the validator (return nil) and the reject cases go
+// GREEN-then-RED here; the negatives guard against over-rejecting a deliberate
+// identical-service duplicate.
+
+// dupHostLocalZone builds a config with two static interface addresses. The two
+// zones' host-inbound service sets are supplied by the caller so a single helper
+// drives both the ambiguous (differing) and unambiguous (identical) cases.
+func dupHostLocalZone(addrA, addrB string, svcA, svcB []string) *Config {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{addrA}},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{addrB}},
+		}},
+	}
+	zoneA := &ZoneConfig{Name: "aaa", Interfaces: []string{"ge-0/0/0.0"}}
+	if svcA != nil {
+		zoneA.HostInboundTraffic = &HostInboundTraffic{SystemServices: svcA}
+	}
+	zoneB := &ZoneConfig{Name: "zzz", Interfaces: []string{"ge-0/0/1.0"}}
+	if svcB != nil {
+		zoneB.HostInboundTraffic = &HostInboundTraffic{SystemServices: svcB}
+	}
+	cfg.Security.Zones = map[string]*ZoneConfig{"aaa": zoneA, "zzz": zoneB}
+	return cfg
+}
+
+// TestDupHostLocalV4DifferingServicesRejected is the core H01 fail-on-revert:
+// the SAME IPv4 in two zones whose host-inbound sets differ (aaa default-deny,
+// zzz ssh) must be rejected, naming the address and both zones.
+func TestDupHostLocalV4DifferingServicesRejected(t *testing.T) {
+	cfg := dupHostLocalZone("192.0.2.1/24", "192.0.2.1/24", nil, []string{"ssh"})
+	err := validateDuplicateHostLocalAddressStrict(cfg)
+	if err == nil {
+		t.Fatal("expected rejection of a duplicate IPv4 host-local address across zones with differing host-inbound sets, got nil")
+	}
+	for _, want := range []string{"192.0.2.1", "aaa", "zzz"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// TestDupHostLocalV4IdenticalServicesAllowed guards against a false positive on
+// a deliberate duplicate: the same IPv4 in two zones with IDENTICAL host-inbound
+// sets renders the same block twice (order-independent) and must be allowed.
+func TestDupHostLocalV4IdenticalServicesAllowed(t *testing.T) {
+	cfg := dupHostLocalZone("192.0.2.1/24", "192.0.2.1/24", []string{"ssh"}, []string{"ssh"})
+	if err := validateDuplicateHostLocalAddressStrict(cfg); err != nil {
+		t.Fatalf("identical-service duplicate must be allowed (no order-dependence), got: %v", err)
+	}
+}
+
+// TestDupHostLocalDistinctAddressesAllowed: two DIFFERENT addresses, one per
+// zone, is the ordinary case and must never be flagged.
+func TestDupHostLocalDistinctAddressesAllowed(t *testing.T) {
+	cfg := dupHostLocalZone("192.0.2.1/24", "192.0.2.2/24", nil, []string{"ssh"})
+	if err := validateDuplicateHostLocalAddressStrict(cfg); err != nil {
+		t.Fatalf("distinct addresses must be allowed, got: %v", err)
+	}
+}
+
+// TestDupHostLocalV6DifferingServicesRejected covers M02 (IPv6 parity): the same
+// IPv6 in two zones with differing host-inbound sets is rejected as IPv6.
+func TestDupHostLocalV6DifferingServicesRejected(t *testing.T) {
+	cfg := dupHostLocalZone("2001:db8::1/64", "2001:db8::1/64", nil, []string{"ssh"})
+	err := validateDuplicateHostLocalAddressStrict(cfg)
+	if err == nil {
+		t.Fatal("expected rejection of a duplicate IPv6 host-local address across zones, got nil")
+	}
+	for _, want := range []string{"2001:db8::1", "IPv6", "aaa", "zzz"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// TestDupHostLocalVRRPVIPDifferingServicesRejected covers M03: the SAME VRRP VIP
+// configured under two units in two zones with differing host-inbound sets is
+// rejected — the most realistic case (a copy-paste VIP error during HA setup).
+func TestDupHostLocalVRRPVIPDifferingServicesRejected(t *testing.T) {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.2/24"}, VRRPGroups: map[string]*VRRPGroup{
+				"10.0.0.2/24": {ID: 1, VirtualAddresses: []string{"10.0.0.1"}},
+			}},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.3/24"}, VRRPGroups: map[string]*VRRPGroup{
+				"10.0.0.3/24": {ID: 2, VirtualAddresses: []string{"10.0.0.1"}},
+			}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*ZoneConfig{
+		"aaa": {Name: "aaa", Interfaces: []string{"ge-0/0/0.0"}},
+		"zzz": {Name: "zzz", Interfaces: []string{"ge-0/0/1.0"},
+			HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	err := validateDuplicateHostLocalAddressStrict(cfg)
+	if err == nil {
+		t.Fatal("expected rejection of a duplicate VRRP VIP across zones with differing host-inbound sets, got nil")
+	}
+	if !strings.Contains(err.Error(), "10.0.0.1") {
+		t.Fatalf("error %q does not name the VIP 10.0.0.1", err.Error())
+	}
+}
+
+// TestDupHostLocalSameZoneNotFlagged: the same address on two interfaces in the
+// SAME zone resolves to one effective host-inbound set (one block) — no
+// order-dependence — so it must be allowed.
+func TestDupHostLocalSameZoneNotFlagged(t *testing.T) {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"ge-0/0/0": {Name: "ge-0/0/0", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"ge-0/0/0.0", "ge-0/0/1.0"},
+			HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	if err := validateDuplicateHostLocalAddressStrict(cfg); err != nil {
+		t.Fatalf("same-zone duplicate address must be allowed, got: %v", err)
+	}
+}
+
+// TestDupHostLocalLifelineExcluded: a shared management address on lifeline
+// interfaces (fxp0) is never host-inbound-denied, so it must not be flagged even
+// across zones with differing sets.
+func TestDupHostLocalLifelineExcluded(t *testing.T) {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"fxp0": {Name: "fxp0", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*ZoneConfig{
+		"mgmt": {Name: "mgmt", Interfaces: []string{"fxp0.0"}},
+		"zzz": {Name: "zzz", Interfaces: []string{"ge-0/0/1.0"},
+			HostInboundTraffic: &HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	// Only one non-lifeline zone contributes the address, so it maps to a single
+	// scope — not ambiguous.
+	if err := validateDuplicateHostLocalAddressStrict(cfg); err != nil {
+		t.Fatalf("lifeline (fxp0) address must be excluded from the dup gate, got: %v", err)
+	}
+}
+
+// TestDupHostLocalCommitRejectsAndLenientWarns proves the compiler wiring: the
+// STRICT commit path hard-rejects an ambiguous duplicate, and the tolerant load
+// path downgrades it to a warning so an already-persisted config still boots
+// (#1960 no-brick). This is the end-to-end fail-on-revert for the dispatch in
+// compiler.go.
+func TestDupHostLocalCommitRejectsAndLenientWarns(t *testing.T) {
+	lines := []string{
+		"set interfaces ge-0/0/0 unit 0 family inet address 192.0.2.1/24",
+		"set interfaces ge-0/0/1 unit 0 family inet address 192.0.2.1/24",
+		"set security zones security-zone aaa interfaces ge-0/0/0.0",
+		"set security zones security-zone zzz interfaces ge-0/0/1.0",
+		"set security zones security-zone zzz host-inbound-traffic system-services ssh",
+	}
+	tree := buildTree(t, lines)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("strict commit must reject a duplicate host-local address across zones with differing host-inbound sets")
+	} else if !strings.Contains(err.Error(), "192.0.2.1") {
+		t.Fatalf("strict error %q does not name the address", err.Error())
+	}
+
+	tree2 := buildTree(t, lines)
+	cfg, err := CompileConfigLenient(tree2)
+	if err != nil {
+		t.Fatalf("lenient compile must not fail on a duplicate host-local address: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "duplicate host-local address (downgraded to warning on tolerant path)") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a downgraded duplicate-host-local-address warning, got warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -326,6 +326,19 @@ type Daemon struct {
 	// Written and read only under applySem in applyHostInboundFilter.
 	hostInboundAddresslessZones map[string]bool
 
+	// hostInboundAmbiguousAddrs is the set of firewall-local addresses observed
+	// on the PREVIOUS apply that are host-inbound-reachable from more than one
+	// security zone with DIFFERING host-inbound service/protocol sets (#3718
+	// Option B), keyed as "<family>|<addr>". The kernel host-inbound chain
+	// matches destination address only, so such an address's admission verdict
+	// is decided order-dependently by whichever zone sorts first (and can
+	// disagree with the ingress-scoped userspace-dp path). The strict commit gate
+	// rejects this; a tolerant / peer-synced load (#1960) can slip one through,
+	// and unlike the addressless window it is NOT self-healing.
+	// applyHostInboundFilter diffs the current set against this to emit
+	// state-transition logs only. Written and read only under applySem.
+	hostInboundAmbiguousAddrs map[string]bool
+
 	// mgmtVRFInterfaces tracks interfaces bound to the management VRF (vrf-mgmt).
 	// Used by collectDHCPRoutes to exclude management routes from FRR.
 	mgmtVRFInterfaces map[string]bool

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -251,6 +251,13 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	// is otherwise silent. Log only state TRANSITIONS (a zone entering/leaving the
 	// window) so repeated commits / DHCP renewals do not flood.
 	d.logHostInboundAddresslessTransitions(cfg)
+	// #3718 (Option B): a firewall-local address reachable from >1 zone with
+	// DIFFERING host-inbound sets makes the kernel destination-address-only
+	// verdict order-dependent (and can disagree with the ingress-scoped
+	// userspace-dp path). The strict commit gate rejects this, but a tolerant /
+	// peer-synced load can slip one through, and it is NOT self-healing — so log
+	// the state transition and export it as xpf_host_inbound_ambiguous_addresses.
+	d.logHostInboundAmbiguousTransitions(cfg)
 	if !hostInboundHasEnforceableView(views) {
 		// No host-inbound-configured zone with a resolvable address — nothing to
 		// enforce. Remove any stale table. nftDeleteTable is idempotent (an
@@ -301,6 +308,41 @@ func (d *Daemon) logHostInboundAddresslessTransitions(cfg *config.Config) {
 		}
 	}
 	d.hostInboundAddresslessZones = current
+}
+
+// logHostInboundAmbiguousTransitions emits a state-transition log whenever a
+// firewall-local address ENTERS or LEAVES the #3718 ambiguity set — an address
+// host-inbound-reachable from more than one security zone with DIFFERING
+// host-inbound service/protocol sets. The kernel host-inbound chain matches on
+// destination address only (no ingress predicate) over a single global input
+// chain, so such an address's admission verdict is order-dependent (the
+// earlier-sorting zone decides the packet) and can disagree with the
+// ingress-scoped userspace-dp path — a zone-isolation failure. The strict commit
+// gate (config.validateDuplicateHostLocalAddressStrict) rejects this; a tolerant
+// / peer-synced load (#1960) can slip one through, and unlike the addressless
+// window it does NOT self-heal, so the warning stands until the operator fixes
+// the config. It compares against the set observed on the previous apply
+// (d.hostInboundAmbiguousAddrs) so a persisting ambiguity is logged once (on
+// entry), not every apply. Runs under applySem (via applyHostInboundFilter), so
+// the map access needs no extra locking. The current set is also exported as the
+// xpf_host_inbound_ambiguous_addresses gauge (pkg/api), scraped independently.
+func (d *Daemon) logHostInboundAmbiguousTransitions(cfg *config.Config) {
+	current := make(map[string]bool)
+	for _, a := range dpuserspace.AmbiguousHostInboundAddresses(cfg) {
+		key := a.Family + "|" + a.Address
+		current[key] = true
+		if !d.hostInboundAmbiguousAddrs[key] {
+			slog.Warn("host-inbound address is reachable from multiple zones with differing host-inbound sets — the kernel destination-address-only verdict is order-dependent and may disagree with the ingress-scoped userspace path (zone-isolation failure); assign the address to one zone or make the host-inbound sets identical (#3718)",
+				"address", a.Address, "family", a.Family, "zones", strings.Join(a.Zones, ","))
+		}
+	}
+	for key := range d.hostInboundAmbiguousAddrs {
+		if !current[key] {
+			slog.Info("host-inbound address ambiguity resolved — the address no longer has an order-dependent host-inbound verdict",
+				"address", key)
+		}
+	}
+	d.hostInboundAmbiguousAddrs = current
 }
 
 // hostInboundHasEnforceableView reports whether at least one view carries a

--- a/pkg/daemon/host_inbound_ambiguous_3718_test.go
+++ b/pkg/daemon/host_inbound_ambiguous_3718_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// ambiguousDaemonCfg builds a config where the SAME IPv4 (192.0.2.1) is carried
+// by two interfaces in two zones. When differ is true the two zones' host-inbound
+// sets DIFFER (aaa default-deny, zzz ssh) — the #3718 ambiguity; when false they
+// are IDENTICAL (both ssh) — a deliberate duplicate that must NOT be reported.
+func ambiguousDaemonCfg(differ bool) *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+		"ge-0-0-1": {Name: "ge-0-0-1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+	}
+	aaa := &config.ZoneConfig{Name: "aaa", Interfaces: []string{"ge-0-0-0.0"}}
+	if !differ {
+		aaa.HostInboundTraffic = &config.HostInboundTraffic{SystemServices: []string{"ssh"}}
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"aaa": aaa,
+		"zzz": {Name: "zzz", Interfaces: []string{"ge-0-0-1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	return cfg
+}
+
+// TestLogHostInboundAmbiguousTransitions is the #3718 fail-on-revert proof for
+// the daemon-side observability: an ambiguous host-local address logs a WARN once
+// on ENTRY (not every apply), and an INFO on RECOVERY once the ambiguity is
+// resolved. An identical-service duplicate must never warn.
+func TestLogHostInboundAmbiguousTransitions(t *testing.T) {
+	var recs []captureRecord
+	prev := slog.Default()
+	slog.SetDefault(slog.New(capturingHandler{recs: &recs}))
+	defer slog.SetDefault(prev)
+
+	d := &Daemon{}
+
+	warnsFor := func(addr string) int {
+		n := 0
+		for _, r := range recs {
+			if r.level == slog.LevelWarn && r.attrs["address"] == addr {
+				n++
+			}
+		}
+		return n
+	}
+	infos := func() int {
+		n := 0
+		for _, r := range recs {
+			if r.level == slog.LevelInfo && r.msg == "host-inbound address ambiguity resolved — the address no longer has an order-dependent host-inbound verdict" {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Apply 1: ambiguous → exactly one WARN for the address.
+	d.logHostInboundAmbiguousTransitions(ambiguousDaemonCfg(true))
+	if warnsFor("192.0.2.1") != 1 {
+		t.Fatalf("first apply: warns = %d, want 1", warnsFor("192.0.2.1"))
+	}
+	if !d.hostInboundAmbiguousAddrs["inet|192.0.2.1"] {
+		t.Errorf("state not tracked: hostInboundAmbiguousAddrs missing inet|192.0.2.1")
+	}
+
+	// Apply 2: still ambiguous → NO new WARN (state-transition dedup).
+	d.logHostInboundAmbiguousTransitions(ambiguousDaemonCfg(true))
+	if warnsFor("192.0.2.1") != 1 {
+		t.Fatalf("second apply: warns = %d, want 1 (dedup — must not re-log a persisting ambiguity)", warnsFor("192.0.2.1"))
+	}
+
+	// Apply 3: services made identical → one INFO recovery, no new WARN, state cleared.
+	d.logHostInboundAmbiguousTransitions(ambiguousDaemonCfg(false))
+	if infos() != 1 {
+		t.Errorf("recovery: infos = %d, want 1 (ambiguity resolved)", infos())
+	}
+	if warnsFor("192.0.2.1") != 1 {
+		t.Errorf("recovery must not emit another warn, warns = %d", warnsFor("192.0.2.1"))
+	}
+	if d.hostInboundAmbiguousAddrs["inet|192.0.2.1"] {
+		t.Errorf("state not cleared after recovery: inet|192.0.2.1 still set")
+	}
+}

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -396,6 +396,101 @@ func AddresslessEnforcingZones(cfg *config.Config) []AddresslessEnforcingZone {
 	return out
 }
 
+// AmbiguousHostInboundAddress names a firewall-local address that is
+// host-inbound-reachable from more than one security zone / effective
+// host-inbound token set with DIFFERING admission (#3718 Option B). The kernel
+// host-inbound nftables chain matches on destination address ONLY (no
+// ingress-interface predicate) over a single global input chain, so such an
+// address's admission verdict is decided order-dependently by whichever zone
+// sorts first — and the kernel path can disagree with the ingress-scoped
+// userspace-dp host_inbound_admits path (split-brain). The commit-time gate
+// (config.validateDuplicateHostLocalAddressStrict) hard-rejects this on the
+// strict path, but a tolerant / peer-synced load (#1960) can slip one through;
+// this type carries the machine-readable runtime signal the daemon logs and the
+// API exports (xpf_host_inbound_ambiguous_addresses) so the ambiguity — which is
+// NOT self-healing — is observable rather than silent.
+type AmbiguousHostInboundAddress struct {
+	// Address is the bare firewall-local host IP (no prefix).
+	Address string
+	// Family is the Junos family name: "inet" (IPv4) or "inet6" (IPv6).
+	Family string
+	// Zones are the distinct security zones that render a host-inbound rule
+	// block for Address, sorted. At least two are present when the ambiguity is
+	// cross-zone; a same-zone-only entry (differing #3362 per-interface
+	// overrides on the same address) carries the single zone.
+	Zones []string
+}
+
+// AmbiguousHostInboundAddresses returns, in sorted (family, address) order, the
+// firewall-local addresses that are host-inbound-reachable from more than one
+// DISTINCT effective host-inbound token set (#3718 Option B). The set of scopes
+// per address is read back from BuildZoneHostInboundViews — the exact same
+// builder that drives the kernel nft emission — so the observability signal can
+// never disagree with what is actually rendered: an address is reported iff the
+// builder produces two rule blocks for it whose EFFECTIVE admission differs
+// (config.CanonicalHostInboundTokenSig, the shared SSOT the commit-time gate
+// also uses).
+//
+// A duplicated address with IDENTICAL host-inbound service sets across its zones
+// is NOT reported — it renders the same accept+drop block twice (order-
+// independent, both paths agree), so it is a deliberate-duplicate false-positive
+// the low-noise contract avoids. Management / cluster-control lifeline
+// interfaces (fxp0 / em0 / fab*) contribute no address (they are excluded from
+// deny scoping), so a shared management address never surfaces here either.
+func AmbiguousHostInboundAddresses(cfg *config.Config) []AmbiguousHostInboundAddress {
+	if cfg == nil || len(cfg.Security.Zones) == 0 {
+		return nil
+	}
+	type acc struct {
+		sigs  map[string]bool
+		zones map[string]bool
+	}
+	byAddr := make(map[string]*acc)
+	record := func(family, addr, sig, zone string) {
+		key := family + "\x00" + addr
+		a := byAddr[key]
+		if a == nil {
+			a = &acc{sigs: make(map[string]bool), zones: make(map[string]bool)}
+			byAddr[key] = a
+		}
+		a.sigs[sig] = true
+		a.zones[zone] = true
+	}
+	for _, v := range BuildZoneHostInboundViews(cfg) {
+		sig := config.CanonicalHostInboundTokenSig(v.SystemServices, v.Protocols)
+		for _, a := range v.V4Addrs {
+			record("inet", a, sig, v.Zone)
+		}
+		for _, a := range v.V6Addrs {
+			record("inet6", a, sig, v.Zone)
+		}
+	}
+	keys := make([]string, 0, len(byAddr))
+	for k := range byAddr {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var out []AmbiguousHostInboundAddress
+	for _, k := range keys {
+		a := byAddr[k]
+		if len(a.sigs) < 2 {
+			continue
+		}
+		parts := strings.SplitN(k, "\x00", 2)
+		zones := make([]string, 0, len(a.zones))
+		for z := range a.zones {
+			zones = append(zones, z)
+		}
+		sort.Strings(zones)
+		out = append(out, AmbiguousHostInboundAddress{
+			Address: parts[1],
+			Family:  parts[0],
+			Zones:   zones,
+		})
+	}
+	return out
+}
+
 // unionHostInboundTokens returns the EFFECTIVE host-inbound system-service and
 // protocol token sets for an interface (#3362): the zone-level set UNION the
 // per-interface override, lower-cased, trimmed, and de-duplicated, with

--- a/pkg/dataplane/userspace/zones_ambiguous_3718_test.go
+++ b/pkg/dataplane/userspace/zones_ambiguous_3718_test.go
@@ -1,0 +1,107 @@
+// #3718 (Option B): AmbiguousHostInboundAddresses is the runtime SSOT that
+// surfaces a firewall-local address reachable from multiple zones with DIFFERING
+// host-inbound service sets — the kernel destination-address-only host-inbound
+// verdict is then order-dependent and can disagree with the ingress-scoped
+// userspace-dp path. It reads BuildZoneHostInboundViews (the same builder that
+// drives nft emission) so the signal matches what is actually rendered. These
+// tests are fail-on-revert: drop the detection and the ambiguous address stops
+// surfacing; widen it and the identical-service / same-zone deliberate
+// duplicates start surfacing.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestAmbiguousHostInboundAddressesDifferingServices: the same IPv4 in two zones
+// with differing host-inbound sets (aaa default-deny, zzz ssh) is reported, with
+// both zones listed.
+func TestAmbiguousHostInboundAddressesDifferingServices(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+		"ge-0-0-1": {Name: "ge-0-0-1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"aaa": {Name: "aaa", Interfaces: []string{"ge-0-0-0.0"}},
+		"zzz": {Name: "zzz", Interfaces: []string{"ge-0-0-1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	got := AmbiguousHostInboundAddresses(cfg)
+	if len(got) != 1 {
+		t.Fatalf("AmbiguousHostInboundAddresses = %+v, want exactly 1", got)
+	}
+	if got[0].Address != "192.0.2.1" || got[0].Family != "inet" {
+		t.Fatalf("reported = %+v, want 192.0.2.1/inet", got[0])
+	}
+	if len(got[0].Zones) != 2 || got[0].Zones[0] != "aaa" || got[0].Zones[1] != "zzz" {
+		t.Errorf("zones = %v, want [aaa zzz]", got[0].Zones)
+	}
+}
+
+// TestAmbiguousHostInboundAddressesIdenticalServicesNotReported guards the
+// low-noise contract: identical host-inbound sets render the same block twice
+// (order-independent) and must NOT be reported.
+func TestAmbiguousHostInboundAddressesIdenticalServicesNotReported(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+		"ge-0-0-1": {Name: "ge-0-0-1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"192.0.2.1/24"}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"aaa": {Name: "aaa", Interfaces: []string{"ge-0-0-0.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+		"zzz": {Name: "zzz", Interfaces: []string{"ge-0-0-1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	if got := AmbiguousHostInboundAddresses(cfg); len(got) != 0 {
+		t.Fatalf("identical-service duplicate must not be reported, got: %+v", got)
+	}
+}
+
+// TestAmbiguousHostInboundAddressesVRRPVIP: a duplicate VRRP VIP across zones
+// with differing sets is reported (M03), resolved from config on both nodes.
+func TestAmbiguousHostInboundAddressesVRRPVIP(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.2/24"}, VRRPGroups: map[string]*config.VRRPGroup{
+				"10.0.0.2/24": {ID: 1, VirtualAddresses: []string{"10.0.0.1"}},
+			}},
+		}},
+		"reth1": {Name: "reth1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.0.3/24"}, VRRPGroups: map[string]*config.VRRPGroup{
+				"10.0.0.3/24": {ID: 2, VirtualAddresses: []string{"10.0.0.1"}},
+			}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"aaa": {Name: "aaa", Interfaces: []string{"reth0.0"}},
+		"zzz": {Name: "zzz", Interfaces: []string{"reth1.0"},
+			HostInboundTraffic: &config.HostInboundTraffic{SystemServices: []string{"ssh"}}},
+	}
+	got := AmbiguousHostInboundAddresses(cfg)
+	if len(got) != 1 || got[0].Address != "10.0.0.1" {
+		t.Fatalf("AmbiguousHostInboundAddresses = %+v, want [10.0.0.1]", got)
+	}
+}
+
+// TestAmbiguousHostInboundAddressesEmpty guards the nil / no-zone fast paths.
+func TestAmbiguousHostInboundAddressesEmpty(t *testing.T) {
+	if got := AmbiguousHostInboundAddresses(nil); got != nil {
+		t.Errorf("nil cfg = %v, want nil", got)
+	}
+	if got := AmbiguousHostInboundAddresses(&config.Config{}); got != nil {
+		t.Errorf("no-zone cfg = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
Closes #3718

## Summary

Implements **Option B** of the converged #3718 research plan: a fail-closed
commit-time gate plus a runtime reporter/metric/log for the host-inbound
duplicate-local-address ambiguity. **Option A (kernel `iifname` ingress-scope)
and Option C (per-VRF host-inbound chains) are deferred follow-ons** per the
research plan and are documented on the issue and in
`docs/host-inbound-service-matrix.md`.

## The bug

The kernel host-inbound nftables chain matches on **destination address only**
(no ingress-interface / VRF predicate) over a single global `inet xpf_hostinbound`
input chain (`emitHostInboundZone`, `pkg/daemon/daemon_nft.go`). So two security
zones that resolve the **same** firewall-local address — a duplicated interface
address, a duplicated VRRP VIP, or the same address reused across
routing-instances (a zone is not VRF-scoped in xpf → the cross-zone case) — emit
two rule blocks keyed on the same `daddr` in zone-sort order, and the
**earlier-sorting zone decides the packet** regardless of ingress. A zero-service
zone emits only a terminal catch-all `drop`, so it can drop every host-bound
service the other zone opened. The userspace-dp secondary path
(`host_inbound_admits`) is **already ingress-zone scoped**, so the kernel `daddr`
path and the userspace path can render **opposite** verdicts on the same packet —
a split-brain. No duplicate-local-address gate existed
(`validateZoneInterfaceMembershipStrict` enforces interface OWNERSHIP uniqueness,
not ADDRESS uniqueness), so the ambiguity is reachable with a strict-valid config
(H01/M02/M03/M04/M09).

## What changed

- **Commit-time gate** `validateDuplicateHostLocalAddressStrict`
  (`pkg/config/dup_host_local_address.go`, wired in `compiler.go` after the
  host-inbound token gate): hard-rejects a config where the same
  `(family, host address)` — interface address OR VRRP VIP — is
  host-inbound-reachable from more than one **distinct effective host-inbound
  token set**. Keys on *differing* sets (shared `CanonicalHostInboundTokenSig`),
  NOT merely ">1 zone", so an **identical-service** duplicate is allowed (no false
  positive). Covers IPv4/IPv6/VRRP VIP/cross-zone M04; lifeline interfaces
  (fxp0/em0/fab*) excluded. Lenient downgrade to `cfg.Warnings` on the tolerant
  load / peer-sync path (`lenientDuplicateHostLocalAddress`, #1960 no-brick).
- **Runtime reporter** `dpuserspace.AmbiguousHostInboundAddresses`
  (`pkg/dataplane/userspace/zones.go`, mirroring the #3698 `AddresslessEnforcingZones`
  pattern) — reads scopes back from `BuildZoneHostInboundViews`, so it can never
  disagree with what nft renders. Unlike the #3698 addressless window, an
  ambiguity is **NOT self-healing**.
- **Prometheus gauge** `xpf_host_inbound_ambiguous_addresses{address,family}`
  (`pkg/api`), emitted **before** the dataplane gate (config-derived; visible in a
  degraded boot).
- **Daemon state-transition log** `logHostInboundAmbiguousTransitions`
  (`pkg/daemon/daemon_nft.go`): WARN on entry, INFO on recovery, once per
  transition.

## RED-on-revert proof

Each layer's tests were confirmed to go **RED when the implementation is
neutered** and **GREEN when restored**:

- `pkg/config/dup_host_local_address_3718_test.go` — dup v4/v6 across zones with
  differing sets **rejected**; dup VRRP VIP **rejected**; identical-service /
  same-zone / distinct / lifeline **allowed**; commit-rejects + lenient-warns
  wiring. (Neutering the validator → 4 reject/wiring tests fail.)
- `pkg/dataplane/userspace/zones_ambiguous_3718_test.go` — reporter flags a
  differing-service dup (v4 + VRRP VIP), skips an identical-service dup. (Neutering
  the reporter → the flag tests fail.)
- `pkg/api/metrics_host_inbound_ambiguous_3718_test.go` — the gauge series is
  emitted with the dataplane unloaded (before-gate proof), fixtured via a
  tolerantly-loaded DB that the strict path rejects.
- `pkg/daemon/host_inbound_ambiguous_3718_test.go` — WARN-once / INFO-recovery
  transitions.

## Validation

`go build ./...`; `go vet`; `gofmt` clean; `go test ./pkg/config/...
./pkg/dataplane/... ./pkg/api/... ./pkg/daemon/` all green. Rebased onto current
`origin/master` (auto-merged the additive metrics changes; `_Log.md` union-merged)
and re-verified build + tests. Docs updated: `docs/host-inbound-service-matrix.md`
(new section + deferred Option A/C) and `docs/config-schema.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
