### PR TITLE
flowexport: VRF-scope the route-mask lookup by ingress ifindex + count unresolved masks (#3744)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26583,3 +26583,35 @@ top.
     pkg/flowexport/exporter_id_3740_test.go (new RED-on-revert +
     HA-symmetry + degenerate-default tests),
     pkg/flowexport/README.md ("Exporter identity" section + file layout)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3744 — VRF-scope the flowexport route-mask lookup by the
+    flow's ingress ifindex + count unresolved masks. The #2866/#3743
+    NetFlow IE 9/13 (IPv6 29/30) / IPFIX prefix-length route masks were
+    resolved by a VRF/table-blind FIB lookup (main table only) that also
+    discarded the `ok` bit, so a multi-VRF/routing-instance flow's mask
+    resolved in the wrong table and a genuine miss exported as a bogus /0.
+    Option A: MaskResolver gains an `ifindex`; fibMatchMask sets
+    RouteGetOptions.IifIndex (>0) → kernel input-path lookup follows
+    l3mdev enslavement into the flow's VRF table; resolveMasks scopes both
+    halves by the ingress instance (InIf, OutIf fallback, then global
+    table = bit-identical no-op for single-VRF). Async #3743 cache key
+    widened ip16 → (ifindex, ip16) via routeMaskKey so per-VRF masks don't
+    collide (non-blocking-callback/inflight-cap/dedup/size-cap invariants
+    unchanged). Option B: per-exporter routeMaskUnresolved atomic counter +
+    RouteMaskUnresolved() accessor (mirrors EstimatedDurations); the u8
+    wire IE has no sentinel room, so an unresolved half exports 0 but is
+    surfaced out-of-band. Residual documented: pure fwmark/`ip rule` PBR
+    is NOT covered (mark not on the close event); VRF/routing-instance IS.
+    RED-on-revert verified for all three mechanisms (IP-only key,
+    table-blind resolveMasks, dropped miss count → the new pins fail). go
+    test ./pkg/flowexport/... green incl -race; go build ./... green;
+    gofmt + vet clean.
+  - **File(s)**: pkg/flowexport/routemask.go (MaskResolver ifindex,
+    routeMaskKey (ifindex,IP) cache key, resolveMasks ingress scoping +
+    miss count, fibMatchMask IifIndex), pkg/flowexport/netflow.go +
+    pkg/flowexport/ipfix.go (routeMaskUnresolved counter + accessor + call
+    sites pass InIf/OutIf), pkg/flowexport/srcmask_dstmask_test.go
+    (existing #2866/#3743 pins updated for new signatures),
+    pkg/flowexport/routemask_vrf_test.go (new #3744 RED-on-revert pins),
+    pkg/flowexport/README.md (#3744 section + file-layout bullet)

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -268,8 +268,63 @@ lookup does not stall `ExportSessionClose`) and
 `TestRouteMaskCacheAsyncPopulateAndHit` (miss → default → background
 populate → warm hit). Reverting to the synchronous lookup-in-`resolve`
 flips these RED (the first two by blocking / returning the wrong value).
-Note #3744 (route-mask being VRF/table/source-blind) is a separate design
-item and out of scope here.
+
+**#3744 — the route-mask lookup is scoped to the flow's VRF table and an
+unresolved lookup is counted.** Before #3744 the FIB lookup was
+VRF/table-blind: `fibMatchMask` issued `RouteGetWithOptions(ip,
+{FIBMatch:true})` with no interface, so it always resolved against the
+**main** table, and `resolveMasks` discarded the `ok` bit. In a multi-VRF
+/ routing-instance deployment every flow's mask was therefore looked up in
+the wrong table (a leaked or per-instance prefix resolved to the wrong
+length, often `/0`), and a genuine miss was exported as a bogus `/0`
+indistinguishable from a real default-route match.
+
+*Scoping (Option A).* The SESSION_CLOSE event already carries the
+ingress/egress ifindex (#2615/#2749 → `SessionCloseData.InIf`/`OutIf`),
+and xpf enslaves interfaces to real l3mdev VRF master devices
+(`pkg/routing/vrf.go`), so each interface's ifindex selects a distinct
+kernel table. `MaskResolver` now takes an `ifindex`; `fibMatchMask` sets
+`RouteGetOptions.IifIndex` when it is >0, which makes the kernel perform
+an *input-path* route lookup that follows l3mdev enslavement into the
+interface's VRF table. `resolveMasks(r, srcIP, dstIP, inIf, outIf)` scopes
+**both** the source and destination half by the **ingress** instance
+(`inIf`): Junos attributes the session to the ingress routing-instance and
+next-table / rib-group leaked routes to the destination appear in that
+ingress table. When the dataplane reported no ingress attribution
+(`inIf==0`) it falls back to `outIf`, then to the global table
+(`inIf==outIf==0`) — bit-identical to the pre-#3744 main-table lookup, so
+single-VRF / default deployments are a no-op. The async #3743 cache key
+widens from the 16-byte IP to `(ifindex, IP)` (`routeMaskKey`) so per-VRF
+masks for the same host address do not collide; the non-blocking-callback,
+bounded-inflight, dedup and size-cap invariants are unchanged.
+
+*Unresolved bit (Option B).* The wire field is a `u8` prefix length
+(0..128) with no room for an "unresolved" sentinel a collector would
+understand, so an unresolved lookup is surfaced **out-of-band**:
+`resolveMasks` returns the number of halves that did not resolve, and each
+exporter accumulates them into a `routeMaskUnresolved atomic.Uint64`
+(`RouteMaskUnresolved()` accessor, mirroring `EstimatedDurations`). Since
+#3797 the first flow to any cold `(ifindex, prefix)` key resolves `0`
+while the background lookup warms, so a nonzero counter is expected in
+steady state; a value climbing in lockstep with exported flows is the only
+operator-visible signal that an exported mask-`0` is *unresolved* versus a
+real default-route `/0`.
+
+*Documented residual.* Pure fwmark / `ip rule` PBR (`pkg/routing/rules.go`)
+selects a table by mark or source address, and the mark is **not** carried
+on the SESSION_CLOSE event, so an ifindex-scoped lookup cannot reproduce a
+mark-only PBR decision. The dominant multi-table case — VRF /
+routing-instance — IS covered; carrying the fwmark is a separate future
+item if demand appears.
+
+Pinned by `TestRouteMaskLookupScopedByIfindex` (same dst IP → different
+mask per ingress ifindex, `(ifindex,IP)` key does not collide across
+VRFs), `TestResolveMasksScopesByIngressInstance` (both halves scope by
+`inIf`, fall back to `outIf`, then to the global table),
+`TestResolveMasksMissCount` and `TestExporterRouteMaskUnresolvedCounter`
+(an unresolved half increments the counter and still exports `0`, no
+sentinel). Reverting the `(ifindex,IP)` key, the ingress scoping, or the
+miss count flips one of these RED.
 
 `Exporter` / `IPFIXExporter` carry a `MaskResolver` func (defaulted by
 `NewExporter`/`NewIPFIXExporter` to `NewRouteMaskResolver`; nil on a
@@ -308,7 +363,10 @@ The package is split by responsibility (#1988):
   exporters call. The netlink `RTM_GETROUTE` runs on a bounded background
   goroutine, never on the EventReader callback that calls `resolve()`
   (#3743): a cache miss returns the default and warms the cache for the next
-  flow.
+  flow. The lookup is scoped to the flow's VRF table by the ingress ifindex
+  and the cache is keyed by `(ifindex, IP)` (#3744); an unresolved lookup is
+  counted into each exporter's `routeMaskUnresolved`
+  (`RouteMaskUnresolved()`).
 - `transport.go` — shared collector connection management
   (`collectorConns`: dial / fan-out write / close) and the per-family
   batch accumulator (`flowBatch`) used by both exporters. `dialCollectors`

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -530,6 +530,10 @@ type IPFIXExporter struct {
 	// #2465: see Exporter.estimatedDurations — count of close flows whose
 	// StartTime fell back to the packet-count heuristic (no real creation ts).
 	estimatedDurations atomic.Uint64
+	// #3744: see Exporter.routeMaskUnresolved — count of route-mask halves
+	// exported as an unresolved 0 (no FIB route / cold cache) rather than a
+	// real matched-route prefix length.
+	routeMaskUnresolved atomic.Uint64
 }
 
 // NewIPFIXExporter creates a new IPFIX exporter. cfg is held by pointer
@@ -597,8 +601,12 @@ func (e *IPFIXExporter) ExportSessionClose(rec logging.EventRecord, evt SessionC
 		evt.SrcIP, evt.DstIP, evt.SrcPort, evt.DstPort,
 		evt.NATSrcIP, evt.NATDstIP, evt.NATSrcPort, evt.NATDstPort)
 	// #2866: resolve src/dst route prefix lengths from the FIB (0/0 with no
-	// resolver wired).
-	srcMask, dstMask := resolveMasks(e.MaskResolver, evt.SrcIP, evt.DstIP)
+	// resolver wired). #3744: scope to the flow's ingress VRF table (evt.InIf,
+	// evt.OutIf fallback) and count any unresolved half.
+	srcMask, dstMask, maskMisses := resolveMasks(e.MaskResolver, evt.SrcIP, evt.DstIP, evt.InIf, evt.OutIf)
+	if maskMisses > 0 {
+		e.routeMaskUnresolved.Add(maskMisses)
+	}
 	fr := FlowRecord{
 		SrcIP:      evt.SrcIP,
 		DstIP:      evt.DstIP,
@@ -641,6 +649,13 @@ func (e *IPFIXExporter) Stats() (flows, packets uint64) {
 // real session-creation timestamp.
 func (e *IPFIXExporter) EstimatedDurations() uint64 {
 	return e.estimatedDurations.Load()
+}
+
+// RouteMaskUnresolved returns the count of exported route-mask halves (#3744)
+// exported as an unresolved 0 rather than a real matched-route prefix length.
+// See Exporter.RouteMaskUnresolved.
+func (e *IPFIXExporter) RouteMaskUnresolved() uint64 {
+	return e.routeMaskUnresolved.Load()
 }
 
 // CollectorHealth returns a per-collector write-health snapshot (#2464).

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -506,6 +506,16 @@ type Exporter struct {
 	// operator-visible signal that the dataplane is not stamping creation
 	// times (e.g. all closes arriving via the explicit-delete / HA-purge path).
 	estimatedDurations atomic.Uint64
+	// #3744: count of route-mask HALVES (src and/or dst) that did not resolve
+	// to a FIB route at export time — the mask was exported as an unresolved 0
+	// rather than a real matched-route prefix length. Since #3743 the FIRST
+	// flow to any cold (ifindex,prefix) key resolves 0 while the background
+	// lookup warms, so a nonzero value is expected in steady state; a value
+	// climbing in lockstep with exportedFlows means masks are chronically
+	// unresolved (no route / churn faster than the TTL / wrong VRF scope) —
+	// the only operator-visible signal that an exported mask-0 is unresolved
+	// versus a real default-route /0.
+	routeMaskUnresolved atomic.Uint64
 }
 
 // NewExporter creates a new NetFlow v9 exporter. cfg is held by pointer
@@ -581,7 +591,13 @@ func (e *Exporter) ExportSessionClose(rec logging.EventRecord, evt SessionCloseD
 		evt.NATSrcIP, evt.NATDstIP, evt.NATSrcPort, evt.NATDstPort)
 	// #2866: resolve src/dst route prefix lengths (NetFlow IE 9/13, IPv6 IE
 	// 29/30) from the FIB. Masks default to 0 when no resolver is wired.
-	srcMask, dstMask := resolveMasks(e.MaskResolver, evt.SrcIP, evt.DstIP)
+	// #3744: scope the lookup to the flow's ingress VRF table (evt.InIf, with
+	// evt.OutIf as a fallback) and count any unresolved half so an exported
+	// mask-0 can be told apart from a real default-route /0.
+	srcMask, dstMask, maskMisses := resolveMasks(e.MaskResolver, evt.SrcIP, evt.DstIP, evt.InIf, evt.OutIf)
+	if maskMisses > 0 {
+		e.routeMaskUnresolved.Add(maskMisses)
+	}
 	fr := FlowRecord{
 		SrcIP:     evt.SrcIP,
 		DstIP:     evt.DstIP,
@@ -618,6 +634,13 @@ func (e *Exporter) ExportSessionClose(rec logging.EventRecord, evt SessionCloseD
 // real session-creation timestamp.
 func (e *Exporter) EstimatedDurations() uint64 {
 	return e.estimatedDurations.Load()
+}
+
+// RouteMaskUnresolved returns the count of exported route-mask halves (#3744)
+// that did not resolve to a FIB route and were exported as an unresolved 0
+// rather than a real matched-route prefix length. See routeMaskUnresolved.
+func (e *Exporter) RouteMaskUnresolved() uint64 {
+	return e.routeMaskUnresolved.Load()
 }
 
 // Stats returns export statistics.

--- a/pkg/flowexport/routemask.go
+++ b/pkg/flowexport/routemask.go
@@ -9,7 +9,13 @@ import (
 )
 
 // MaskResolver returns the prefix length (subnet mask, in bits) of the FIB
-// longest-prefix-match route for an IP, plus whether a mask was resolved.
+// longest-prefix-match route for an IP, plus whether a mask was resolved. The
+// lookup is scoped to the flow's routing table by ifindex (#3744): the ingress
+// interface selects the l3mdev VRF table the flow was actually forwarded in, so
+// a multi-VRF/routing-instance flow's mask is resolved in ITS table, not the
+// global one. ifindex==0 (no attribution) falls back to the global/main table,
+// the pre-#3744 behaviour and a bit-identical no-op for single-VRF/default
+// deployments where the main table IS the flow's table.
 //
 // #2866: NetFlow v9 srcMask (IE 9) / dstMask (IE 13) and the IPv6 variants
 // (IE 29 / IE 30) are the prefix lengths of the routing-table entries that
@@ -21,16 +27,18 @@ import (
 //
 // The bool return lets a caller distinguish "resolved to /0 (default route)"
 // from "no route / resolver unavailable"; the exporters write the resolved
-// length on either true OR a 0 from a successful default-route match, and
-// leave the field at 0 only when no resolver is wired (zero-value exporter).
-type MaskResolver func(ip net.IP) (mask uint8, ok bool)
+// length on either true OR a 0 from a successful default-route match, and count
+// an unresolved (!ok) lookup so an operator can see how often an exported mask
+// is an unresolved-0 (route absent / cold cache) versus a real default-route /0.
+type MaskResolver func(ip net.IP, ifindex int) (mask uint8, ok bool)
 
-// routeMaskCacheMax bounds the number of distinct IPs the cache retains. The
-// TTL bounds the syscall RATE; this bounds the FOOTPRINT. On an internet-facing
-// firewall the destination-IP cardinality is effectively unbounded, so without
-// a size cap the map would grow for the daemon's lifetime (~50-70 B/entry) — a
-// slow leak. 8192 entries (~0.5 MB worst case) is far above the working set of
-// distinct src/dst prefixes for any realistic flow mix yet a hard ceiling.
+// routeMaskCacheMax bounds the number of distinct (ifindex,IP) keys the cache
+// retains. The TTL bounds the syscall RATE; this bounds the FOOTPRINT. On an
+// internet-facing firewall the destination-IP cardinality is effectively
+// unbounded, so without a size cap the map would grow for the daemon's lifetime
+// (~50-70 B/entry) — a slow leak. 8192 entries (~0.5 MB worst case) is far above
+// the working set of distinct src/dst prefixes for any realistic flow mix yet a
+// hard ceiling.
 const routeMaskCacheMax = 8192
 
 // defaultRouteMaskInflight bounds the number of concurrent BACKGROUND FIB
@@ -45,28 +53,41 @@ const routeMaskCacheMax = 8192
 // further misses just return the default and are retried on a later flow.
 const defaultRouteMaskInflight = 32
 
+// routeMaskKey is the cache key: the flow's routing table (selected by the
+// ingress ifindex, #3744) plus the 16-byte IP being resolved. Keying on
+// ifindex as well as IP is what keeps a VRF-A result from being served to a
+// VRF-B flow to the same destination — the same host address can have a
+// different matching-route prefix length in each VRF's table. ifindex 0 (no
+// attribution → global table) is its own key, so single-VRF/default flows share
+// one keyspace exactly as before #3744.
+type routeMaskKey struct {
+	ifindex uint32
+	ip      string // 16-byte string form of the IP (net.IP.To16())
+}
+
 // routeMaskCache caches FIB-match results for a short TTL so the per-flow
 // session-close export path does not issue an RTM_GETROUTE netlink syscall for
 // every record. Flows to the same destination/source prefix are common
 // (per-host or per-subnet aggregates), so a small TTL cache collapses the
 // syscall rate dramatically while keeping the mask fresh across routing
-// changes. The cache is keyed by the 16-byte IP representation and bounded at
+// changes. The cache is keyed by (ifindex, 16-byte IP) and bounded at
 // routeMaskCacheMax entries.
 type routeMaskCache struct {
 	ttl     time.Duration
 	maxSize int
 	// lookup is the FIB query; a package var/field so tests can inject a
-	// deterministic resolver without touching the kernel routing table.
-	lookup func(ip net.IP) (uint8, bool)
+	// deterministic resolver without touching the kernel routing table. The
+	// ifindex scopes the lookup to that interface's VRF table (#3744).
+	lookup func(ip net.IP, ifindex int) (uint8, bool)
 
 	// maxInflight bounds concurrent background FIB lookups (#3743). 0 selects
 	// defaultRouteMaskInflight. See scheduleLookupLocked.
 	maxInflight int
 
 	mu       sync.Mutex
-	entries  map[string]routeMaskEntry
-	pending  map[string]struct{} // keys with a background lookup in flight (dedup)
-	inflight int                 // count of background lookups currently running
+	entries  map[routeMaskKey]routeMaskEntry
+	pending  map[routeMaskKey]struct{} // keys with a background lookup in flight (dedup)
+	inflight int                       // count of background lookups currently running
 
 	// afterPopulate, when non-nil, is invoked after each background lookup has
 	// stored its result. Test-only seam for deterministic assertions; nil in
@@ -93,8 +114,8 @@ func NewRouteMaskResolver(ttl time.Duration) MaskResolver {
 		maxSize:     routeMaskCacheMax,
 		maxInflight: defaultRouteMaskInflight,
 		lookup:      fibMatchMask,
-		entries:     make(map[string]routeMaskEntry),
-		pending:     make(map[string]struct{}),
+		entries:     make(map[routeMaskKey]routeMaskEntry),
+		pending:     make(map[routeMaskKey]struct{}),
 	}
 	return c.resolve
 }
@@ -105,10 +126,13 @@ func NewRouteMaskResolver(ttl time.Duration) MaskResolver {
 // would serialize the event reader (and every callback behind it) behind
 // netlink latency. On a fresh cache hit it returns the cached prefix length; on
 // a miss it schedules a bounded, deduplicated background lookup that warms the
-// cache for the NEXT flow to this prefix and returns the safe default (0,
-// false) now. An approximate mask on the first flow to a new prefix is the
-// accepted trade-off for never blocking the shared event-reader path.
-func (c *routeMaskCache) resolve(ip net.IP) (uint8, bool) {
+// cache for the NEXT flow to this (ifindex, prefix) key and returns the safe
+// default (0, false) now. An approximate mask on the first flow to a new prefix
+// is the accepted trade-off for never blocking the shared event-reader path.
+//
+// ifindex scopes the lookup to the flow's l3mdev VRF table (#3744); it is part
+// of the cache key so per-VRF masks do not collide.
+func (c *routeMaskCache) resolve(ip net.IP, ifindex int) (uint8, bool) {
 	if ip == nil {
 		return 0, false
 	}
@@ -116,7 +140,7 @@ func (c *routeMaskCache) resolve(ip net.IP) (uint8, bool) {
 	if ip16 == nil {
 		return 0, false
 	}
-	key := string(ip16)
+	key := routeMaskKey{ifindex: uint32(ifindex), ip: string(ip16)}
 	now := time.Now()
 
 	c.mu.Lock()
@@ -127,23 +151,23 @@ func (c *routeMaskCache) resolve(ip net.IP) (uint8, bool) {
 	}
 	// Cache miss (or expired): schedule the FIB lookup off this goroutine and
 	// return the default now — do NOT block the callback on netlink.
-	c.scheduleLookupLocked(key, ip16)
+	c.scheduleLookupLocked(key, ip16, ifindex)
 	c.mu.Unlock()
 	return 0, false
 }
 
-// scheduleLookupLocked starts a background FIB lookup for key (the 16-byte
-// string form of an IP) unless one is already in flight for it (dedup) or the
-// concurrent-lookup cap is reached (backpressure — the miss is retried on a
-// later flow rather than piling up goroutines behind a slow netlink socket).
-// ip16 is copied because the caller's slice may be reused after resolve()
-// returns. The caller holds c.mu. #3743.
-func (c *routeMaskCache) scheduleLookupLocked(key string, ip16 net.IP) {
+// scheduleLookupLocked starts a background FIB lookup for key unless one is
+// already in flight for it (dedup) or the concurrent-lookup cap is reached
+// (backpressure — the miss is retried on a later flow rather than piling up
+// goroutines behind a slow netlink socket). ip16 is copied because the caller's
+// slice may be reused after resolve() returns. ifindex scopes the FIB lookup to
+// the flow's VRF table (#3744). The caller holds c.mu. #3743.
+func (c *routeMaskCache) scheduleLookupLocked(key routeMaskKey, ip16 net.IP, ifindex int) {
 	if c.lookup == nil {
 		return
 	}
 	if c.pending == nil {
-		c.pending = make(map[string]struct{})
+		c.pending = make(map[routeMaskKey]struct{})
 	}
 	if _, inFlight := c.pending[key]; inFlight {
 		return
@@ -158,15 +182,15 @@ func (c *routeMaskCache) scheduleLookupLocked(key string, ip16 net.IP) {
 	c.pending[key] = struct{}{}
 	c.inflight++
 	ipCopy := append(net.IP(nil), ip16...)
-	go c.populate(key, ipCopy)
+	go c.populate(key, ipCopy, ifindex)
 }
 
 // populate runs a single background FIB lookup and stores the result so the
-// next flow to this prefix resolves from the warm cache. It is the goroutine
-// body scheduled by scheduleLookupLocked; the netlink round-trip happens here,
-// entirely off the EventReader callback path. #3743.
-func (c *routeMaskCache) populate(key string, ip net.IP) {
-	mask, ok := c.lookup(ip)
+// next flow to this (ifindex, prefix) key resolves from the warm cache. It is
+// the goroutine body scheduled by scheduleLookupLocked; the netlink round-trip
+// happens here, entirely off the EventReader callback path. #3743.
+func (c *routeMaskCache) populate(key routeMaskKey, ip net.IP, ifindex int) {
+	mask, ok := c.lookup(ip, ifindex)
 	now := time.Now()
 	c.mu.Lock()
 	c.storeLocked(key, mask, ok, now)
@@ -183,7 +207,7 @@ func (c *routeMaskCache) populate(key string, ip net.IP) {
 
 // storeLocked bounds the cache then inserts a resolved entry. The caller holds
 // c.mu.
-func (c *routeMaskCache) storeLocked(key string, mask uint8, ok bool, now time.Time) {
+func (c *routeMaskCache) storeLocked(key routeMaskKey, mask uint8, ok bool, now time.Time) {
 	c.evictLocked(key, now)
 	c.entries[key] = routeMaskEntry{mask: mask, ok: ok, expires: now.Add(c.ttl)}
 }
@@ -191,12 +215,12 @@ func (c *routeMaskCache) storeLocked(key string, mask uint8, ok bool, now time.T
 // evictLocked bounds the cache before an insert. It is a no-op until the map is
 // at the size cap; at the cap it first drops every expired entry (cheap, and it
 // usually recovers headroom on a busy cache because TTLs are short), and if the
-// map is STILL at the cap (a burst of distinct live IPs) it clears the whole
+// map is STILL at the cap (a burst of distinct live keys) it clears the whole
 // map. Clearing is the simplest hard bound — it sacrifices the warm set for one
 // cold round of syscalls rather than tracking per-entry LRU, which is not worth
 // the bookkeeping for a syscall-amortization cache. maxSize<=0 disables the
 // bound (used only by tests). The caller holds c.mu.
-func (c *routeMaskCache) evictLocked(key string, now time.Time) {
+func (c *routeMaskCache) evictLocked(key routeMaskKey, now time.Time) {
 	if c.maxSize <= 0 || len(c.entries) < c.maxSize {
 		return
 	}
@@ -215,18 +239,44 @@ func (c *routeMaskCache) evictLocked(key string, now time.Time) {
 	}
 }
 
-// resolveMasks returns the src/dst route prefix lengths for a flow using r.
-// A nil resolver (zero-value exporter) yields 0/0 — the pre-#2866 behaviour.
-// A resolver miss (no matching route) also yields 0 for that half. A
-// successful match to a default route legitimately yields 0; that is the real
-// matched-route prefix length, not "unpopulated".
-func resolveMasks(r MaskResolver, srcIP, dstIP net.IP) (srcMask, dstMask uint8) {
+// resolveMasks returns the src/dst route prefix lengths for a flow using r,
+// plus the count of halves that did NOT resolve (0, 1, or 2). Both halves are
+// scoped to the flow's INGRESS routing instance (#3744): the session belongs to
+// the ingress routing-instance and next-table / rib-group leaked routes to the
+// destination appear in that ingress table, so the ingress ifindex (inIf)
+// selects the table for BOTH the source and destination lookup. When the
+// dataplane could not attribute an ingress interface (inIf==0) the egress
+// interface (outIf) is used as a best-effort scope before falling back to the
+// global table.
+//
+// A nil resolver (zero-value exporter) yields 0/0 with 0 misses — the pre-#2866
+// behaviour, where the feature is simply off (not an "unresolved" condition).
+// A resolver miss (no matching route / cold cache) yields 0 for that half AND
+// increments the returned miss count: the u8 wire field (0..128) has no room for
+// an "unresolved" sentinel a collector would understand, so the miss is surfaced
+// out-of-band via a counter (#3744) rather than silently exported as a bogus /0.
+// A successful match to a default route legitimately yields 0 with no miss; that
+// is the real matched-route prefix length, not "unpopulated".
+func resolveMasks(r MaskResolver, srcIP, dstIP net.IP, inIf, outIf uint32) (srcMask, dstMask uint8, misses uint64) {
 	if r == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
-	srcMask, _ = r(srcIP)
-	dstMask, _ = r(dstIP)
-	return srcMask, dstMask
+	scope := int(inIf)
+	if scope == 0 {
+		// No ingress attribution: fall back to the egress interface's table
+		// rather than the global table (still better VRF locality than table 0).
+		scope = int(outIf)
+	}
+	var srcOK, dstOK bool
+	srcMask, srcOK = r(srcIP, scope)
+	dstMask, dstOK = r(dstIP, scope)
+	if !srcOK {
+		misses++
+	}
+	if !dstOK {
+		misses++
+	}
+	return srcMask, dstMask, misses
 }
 
 // fibMatchMask queries the kernel FIB for the longest-prefix-match route to ip
@@ -234,8 +284,19 @@ func resolveMasks(r MaskResolver, srcIP, dstIP net.IP) (srcMask, dstMask uint8) 
 // kernel report the actual matching FIB entry (with its Dst prefix) rather than
 // echoing the queried host as a /32 or /128, so a default-route match returns
 // the real /0.
-func fibMatchMask(ip net.IP) (uint8, bool) {
-	routes, err := netlink.RouteGetWithOptions(ip, &netlink.RouteGetOptions{FIBMatch: true})
+//
+// ifindex>0 sets RTA_IIF, which makes the kernel perform an INPUT route lookup
+// as if the packet arrived on that interface — that follows l3mdev enslavement
+// into the interface's VRF table (#3744), so the mask is resolved in the flow's
+// own routing instance rather than the main table. ifindex==0 omits RTA_IIF and
+// keeps the pre-#3744 main-table output-route lookup, bit-identical for
+// single-VRF/default deployments.
+func fibMatchMask(ip net.IP, ifindex int) (uint8, bool) {
+	opts := &netlink.RouteGetOptions{FIBMatch: true}
+	if ifindex > 0 {
+		opts.IifIndex = ifindex
+	}
+	routes, err := netlink.RouteGetWithOptions(ip, opts)
 	if err != nil || len(routes) == 0 {
 		return 0, false
 	}

--- a/pkg/flowexport/routemask_vrf_test.go
+++ b/pkg/flowexport/routemask_vrf_test.go
@@ -1,0 +1,198 @@
+package flowexport
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// #3744 fail-on-revert pins: the route-mask lookup must be scoped to the flow's
+// routing table by the INGRESS ifindex (the l3mdev VRF the flow was forwarded
+// in), and an UNRESOLVED lookup must be counted rather than silently exported as
+// a bogus /0. Before #3744 the resolver was VRF/table-blind (a global-table
+// lookup) and discarded the ok bit, so a multi-VRF flow's mask resolved in the
+// wrong table and an unresolved lookup was indistinguishable from a real
+// default-route /0.
+
+// warmKey resolves key (ip, ifindex) once (cold miss → schedules the background
+// populate), waits for the populate to land, and returns the warm result. The
+// cache's afterPopulate seam signals completion deterministically without
+// depending on wall-clock timing.
+func warmKey(t *testing.T, c *routeMaskCache, done <-chan struct{}, ip net.IP, ifindex int) (uint8, bool) {
+	t.Helper()
+	if m, ok := c.resolve(ip, ifindex); m != 0 || ok {
+		t.Fatalf("cold resolve(%v,%d) = %d,%v want 0,false (miss default)", ip, ifindex, m, ok)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("background lookup for (%v,%d) never populated the cache", ip, ifindex)
+	}
+	return c.resolve(ip, ifindex)
+}
+
+// TestRouteMaskLookupScopedByIfindex pins Option A: the SAME destination IP
+// resolves to DIFFERENT prefix lengths in different VRF tables (selected by
+// ingress ifindex), and the cache keys on (ifindex, IP) so a VRF-A result is
+// never served to a VRF-B flow. Reverting to the pre-#3744 IP-only key (or a
+// lookup that ignores ifindex) serves VRF-A's mask to the VRF-B resolve → RED.
+func TestRouteMaskLookupScopedByIfindex(t *testing.T) {
+	const (
+		ifVRFA         = 11
+		ifVRFB         = 22
+		maskVRFA uint8 = 24
+		maskVRFB uint8 = 30
+	)
+	done := make(chan struct{}, 8)
+	c := &routeMaskCache{
+		ttl:         time.Hour,
+		maxInflight: 8,
+		entries:     make(map[routeMaskKey]routeMaskEntry),
+		pending:     make(map[routeMaskKey]struct{}),
+	}
+	// Same dst IP, different matched-route prefix length per VRF table. A
+	// table-blind lookup (revert) cannot distinguish these.
+	c.lookup = func(_ net.IP, ifindex int) (uint8, bool) {
+		switch ifindex {
+		case ifVRFA:
+			return maskVRFA, true
+		case ifVRFB:
+			return maskVRFB, true
+		default:
+			return 0, false
+		}
+	}
+	c.afterPopulate = func() { done <- struct{}{} }
+
+	dst := net.IPv4(203, 0, 113, 5)
+
+	if m, ok := warmKey(t, c, done, dst, ifVRFA); m != maskVRFA || !ok {
+		t.Fatalf("VRF-A warm resolve = %d,%v want %d,true (ifindex scope dropped)", m, ok, maskVRFA)
+	}
+	if m, ok := warmKey(t, c, done, dst, ifVRFB); m != maskVRFB || !ok {
+		t.Fatalf("VRF-B warm resolve = %d,%v want %d,true (cache key collision across VRFs)", m, ok, maskVRFB)
+	}
+	// Re-resolving VRF-A must still return VRF-A's mask — the VRF-B populate
+	// must not have clobbered it (proves the key includes ifindex).
+	if m, ok := c.resolve(dst, ifVRFA); m != maskVRFA || !ok {
+		t.Fatalf("VRF-A re-resolve = %d,%v want %d,true (VRF-B populate collided onto VRF-A key)", m, ok, maskVRFA)
+	}
+}
+
+// TestResolveMasksScopesByIngressInstance pins that resolveMasks scopes BOTH the
+// src and dst lookup by the ingress ifindex (inIf), with outIf as the fallback
+// only when inIf is 0. Reverting to a table-blind resolveMasks (no ifindex
+// argument, or scoping by the wrong interface) changes the ifindex the resolver
+// observes → RED.
+func TestResolveMasksScopesByIngressInstance(t *testing.T) {
+	var seen []int
+	r := func(_ net.IP, ifindex int) (uint8, bool) {
+		seen = append(seen, ifindex)
+		return 24, true
+	}
+	src := net.IPv4(10, 0, 0, 1)
+	dst := net.IPv4(10, 0, 0, 2)
+
+	// inIf set: both halves scoped by inIf, never outIf.
+	seen = nil
+	resolveMasks(r, src, dst, 7, 9)
+	if len(seen) != 2 || seen[0] != 7 || seen[1] != 7 {
+		t.Fatalf("with inIf=7 outIf=9, resolver saw ifindexes %v, want [7 7] (ingress-instance scope)", seen)
+	}
+
+	// inIf==0: fall back to outIf for both halves (better than the global table).
+	seen = nil
+	resolveMasks(r, src, dst, 0, 9)
+	if len(seen) != 2 || seen[0] != 9 || seen[1] != 9 {
+		t.Fatalf("with inIf=0 outIf=9, resolver saw ifindexes %v, want [9 9] (egress fallback)", seen)
+	}
+
+	// inIf==0 && outIf==0: unscoped global-table lookup (single-VRF/default).
+	seen = nil
+	resolveMasks(r, src, dst, 0, 0)
+	if len(seen) != 2 || seen[0] != 0 || seen[1] != 0 {
+		t.Fatalf("with inIf=0 outIf=0, resolver saw ifindexes %v, want [0 0] (global fallback)", seen)
+	}
+}
+
+// TestResolveMasksMissCount pins Option B at the helper layer: resolveMasks
+// returns the number of halves (0, 1, 2) that did NOT resolve. A revert that
+// discards the ok bit reports 0 misses on an unresolved lookup → RED.
+func TestResolveMasksMissCount(t *testing.T) {
+	src := net.IPv4(10, 0, 0, 1)
+	dst := net.IPv4(10, 0, 0, 2)
+
+	// Both resolve → 0 misses (a default-route /0 with ok=true is NOT a miss).
+	both := func(_ net.IP, _ int) (uint8, bool) { return 0, true }
+	if _, _, m := resolveMasks(both, src, dst, 0, 0); m != 0 {
+		t.Fatalf("both-resolve misses = %d, want 0 (default-route /0 is a real resolve)", m)
+	}
+
+	// Dst misses only → 1.
+	srcOnly := func(ip net.IP, _ int) (uint8, bool) {
+		if ip.Equal(src) {
+			return 24, true
+		}
+		return 0, false
+	}
+	if _, _, m := resolveMasks(srcOnly, src, dst, 0, 0); m != 1 {
+		t.Fatalf("one-miss misses = %d, want 1", m)
+	}
+
+	// Both miss → 2.
+	none := func(_ net.IP, _ int) (uint8, bool) { return 0, false }
+	if _, _, m := resolveMasks(none, src, dst, 0, 0); m != 2 {
+		t.Fatalf("both-miss misses = %d, want 2", m)
+	}
+}
+
+// TestExporterRouteMaskUnresolvedCounter pins Option B end-to-end: an unresolved
+// lookup increments the exporter's RouteMaskUnresolved counter (the only signal
+// that an exported mask-0 is unresolved, not a real default route) while the
+// wire field is still exported as 0 (the u8 IE has no sentinel room). Reverting
+// the counter leaves RouteMaskUnresolved at 0 for a genuinely unresolved flow.
+func TestExporterRouteMaskUnresolvedCounter(t *testing.T) {
+	rec, sd := closeRecordForMask(false)
+
+	// Resolver: src resolves (/24), dst is unresolved (no route). One miss.
+	partial := func(ip net.IP, _ int) (uint8, bool) {
+		if ip.Equal(sd.SrcIP) {
+			return testSrcMask, true
+		}
+		return 0, false
+	}
+
+	t.Run("netflow", func(t *testing.T) {
+		e := Exporter{MaskResolver: partial}
+		e.ExportSessionClose(rec, sd)
+		if got := e.RouteMaskUnresolved(); got != 1 {
+			t.Fatalf("RouteMaskUnresolved = %d, want 1 (dst unresolved not counted)", got)
+		}
+		recs, _ := e.batch.drain()
+		if len(recs) != 1 {
+			t.Fatalf("drained %d records, want 1", len(recs))
+		}
+		if recs[0].SrcMask != testSrcMask {
+			t.Fatalf("srcMask = %d, want %d (resolved half lost)", recs[0].SrcMask, testSrcMask)
+		}
+		if recs[0].DstMask != 0 {
+			t.Fatalf("dstMask = %d, want 0 (unresolved half must export 0, not a sentinel)", recs[0].DstMask)
+		}
+	})
+
+	t.Run("ipfix", func(t *testing.T) {
+		e := IPFIXExporter{MaskResolver: partial}
+		e.ExportSessionClose(rec, sd)
+		if got := e.RouteMaskUnresolved(); got != 1 {
+			t.Fatalf("RouteMaskUnresolved = %d, want 1 (dst unresolved not counted)", got)
+		}
+	})
+
+	t.Run("both-resolved-no-miss", func(t *testing.T) {
+		e := Exporter{MaskResolver: maskResolverFor(sd.SrcIP, sd.DstIP)}
+		e.ExportSessionClose(rec, sd)
+		if got := e.RouteMaskUnresolved(); got != 0 {
+			t.Fatalf("RouteMaskUnresolved = %d, want 0 (both halves resolved)", got)
+		}
+	})
+}

--- a/pkg/flowexport/srcmask_dstmask_test.go
+++ b/pkg/flowexport/srcmask_dstmask_test.go
@@ -37,7 +37,7 @@ const (
 // and the test dst IP -> testDstMask, mirroring a FIB that has a /24 covering
 // the source and a /30 covering the destination.
 func maskResolverFor(srcIP, dstIP net.IP) MaskResolver {
-	return func(ip net.IP) (uint8, bool) {
+	return func(ip net.IP, _ int) (uint8, bool) {
 		switch {
 		case ip.Equal(srcIP):
 			return testSrcMask, true
@@ -179,14 +179,14 @@ func TestRouteMaskResolveMissDoesNotLookupSynchronously(t *testing.T) {
 	c := &routeMaskCache{
 		ttl:         time.Hour,
 		maxInflight: 4,
-		entries:     make(map[string]routeMaskEntry),
-		pending:     make(map[string]struct{}),
+		entries:     make(map[routeMaskKey]routeMaskEntry),
+		pending:     make(map[routeMaskKey]struct{}),
 	}
-	c.lookup = func(net.IP) (uint8, bool) {
+	c.lookup = func(net.IP, int) (uint8, bool) {
 		<-release // a synchronous caller would block here
 		return 24, true
 	}
-	got, ok := c.resolve(net.IPv4(192, 0, 2, 1))
+	got, ok := c.resolve(net.IPv4(192, 0, 2, 1), 0)
 	if got != 0 || ok {
 		t.Fatalf("cache-miss resolve = %d,%v want 0,false (synchronous netlink on the callback path)", got, ok)
 	}
@@ -206,10 +206,10 @@ func TestRouteMaskCacheAsyncPopulateAndHit(t *testing.T) {
 	c := &routeMaskCache{
 		ttl:         time.Hour,
 		maxInflight: 4,
-		entries:     make(map[string]routeMaskEntry),
-		pending:     make(map[string]struct{}),
+		entries:     make(map[routeMaskKey]routeMaskEntry),
+		pending:     make(map[routeMaskKey]struct{}),
 	}
-	c.lookup = func(net.IP) (uint8, bool) {
+	c.lookup = func(net.IP, int) (uint8, bool) {
 		mu.Lock()
 		calls++
 		mu.Unlock()
@@ -218,7 +218,7 @@ func TestRouteMaskCacheAsyncPopulateAndHit(t *testing.T) {
 	c.afterPopulate = func() { done <- struct{}{} }
 
 	ip := net.IPv4(192, 0, 2, 1)
-	if m, ok := c.resolve(ip); m != 0 || ok {
+	if m, ok := c.resolve(ip, 0); m != 0 || ok {
 		t.Fatalf("first resolve = %d,%v want 0,false (miss default)", m, ok)
 	}
 	select {
@@ -227,8 +227,8 @@ func TestRouteMaskCacheAsyncPopulateAndHit(t *testing.T) {
 		t.Fatal("background lookup never populated the cache")
 	}
 	// Swap the lookup to a sentinel: a genuine cache HIT must not call it.
-	c.lookup = func(net.IP) (uint8, bool) { mu.Lock(); calls++; mu.Unlock(); return 99, true }
-	if m, ok := c.resolve(ip); m != 16 || !ok {
+	c.lookup = func(net.IP, int) (uint8, bool) { mu.Lock(); calls++; mu.Unlock(); return 99, true }
+	if m, ok := c.resolve(ip, 0); m != 16 || !ok {
 		t.Fatalf("warm resolve = %d,%v want 16,true (cache not populated / hit path broken)", m, ok)
 	}
 	mu.Lock()
@@ -239,9 +239,9 @@ func TestRouteMaskCacheAsyncPopulateAndHit(t *testing.T) {
 	}
 
 	// A default-route match (/0) caches as a successful resolve (ok=true).
-	c.lookup = func(net.IP) (uint8, bool) { return 0, true }
+	c.lookup = func(net.IP, int) (uint8, bool) { return 0, true }
 	dip := net.IPv4(203, 0, 113, 1)
-	if m, ok := c.resolve(dip); m != 0 || ok {
+	if m, ok := c.resolve(dip, 0); m != 0 || ok {
 		t.Fatalf("default-route first resolve = %d,%v want 0,false (miss default)", m, ok)
 	}
 	select {
@@ -249,12 +249,12 @@ func TestRouteMaskCacheAsyncPopulateAndHit(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("default-route background lookup never populated the cache")
 	}
-	if m, ok := c.resolve(dip); m != 0 || !ok {
+	if m, ok := c.resolve(dip, 0); m != 0 || !ok {
 		t.Fatalf("default-route warm resolve = %d,%v want 0,true (default route not cached as a hit)", m, ok)
 	}
 
 	// nil IP -> miss without scheduling a lookup.
-	if m, ok := c.resolve(nil); m != 0 || ok {
+	if m, ok := c.resolve(nil, 0); m != 0 || ok {
 		t.Fatalf("nil IP resolve = %d,%v want 0,false", m, ok)
 	}
 }
@@ -270,10 +270,10 @@ func TestExportSessionCloseDoesNotBlockOnFIBLookup(t *testing.T) {
 	c := &routeMaskCache{
 		ttl:         time.Hour,
 		maxInflight: 8,
-		entries:     make(map[string]routeMaskEntry),
-		pending:     make(map[string]struct{}),
+		entries:     make(map[routeMaskKey]routeMaskEntry),
+		pending:     make(map[routeMaskKey]struct{}),
 	}
-	c.lookup = func(net.IP) (uint8, bool) {
+	c.lookup = func(net.IP, int) (uint8, bool) {
 		<-release
 		return 24, true
 	}
@@ -306,14 +306,14 @@ func TestRouteMaskCacheBounded(t *testing.T) {
 	c := &routeMaskCache{
 		ttl:     time.Hour, // long TTL: entries never expire during the test,
 		maxSize: maxSize,   // so the bound is enforced purely by the size cap.
-		entries: make(map[string]routeMaskEntry),
+		entries: make(map[routeMaskKey]routeMaskEntry),
 	}
 	// storeLocked is the map-insert path the background populate goroutine uses
 	// (#3743). Drive it directly so the size bound is exercised deterministically
 	// without goroutines/timing.
 	insert := func(ip net.IP) {
 		c.mu.Lock()
-		c.storeLocked(string(ip.To16()), 24, true, time.Now())
+		c.storeLocked(routeMaskKey{ip: string(ip.To16())}, 24, true, time.Now())
 		c.mu.Unlock()
 	}
 
@@ -332,7 +332,7 @@ func TestRouteMaskCacheBounded(t *testing.T) {
 	// hit path returns it without a lookup), even after the churn above.
 	ip := net.IPv4(192, 0, 2, 7)
 	insert(ip)
-	if m, ok := c.resolve(ip); m != 24 || !ok {
+	if m, ok := c.resolve(ip, 0); m != 24 || !ok {
 		t.Fatalf("warm resolve = %d,%v want 24,true (hit path broken)", m, ok)
 	}
 	if len(c.entries) > maxSize {
@@ -348,17 +348,17 @@ func TestRouteMaskCacheEvictsExpiredFirst(t *testing.T) {
 	c := &routeMaskCache{
 		ttl:     time.Hour,
 		maxSize: maxSize,
-		entries: make(map[string]routeMaskEntry),
+		entries: make(map[routeMaskKey]routeMaskEntry),
 	}
-	c.lookup = func(net.IP) (uint8, bool) { return 16, true }
+	c.lookup = func(net.IP, int) (uint8, bool) { return 16, true }
 
 	past := time.Now().Add(-time.Hour)
 	// Fill to the cap: 1 live entry + (maxSize-1) already-expired entries.
 	live := net.IPv4(10, 0, 0, 1)
-	c.entries[string(live.To16())] = routeMaskEntry{mask: 16, ok: true, expires: time.Now().Add(time.Hour)}
+	c.entries[routeMaskKey{ip: string(live.To16())}] = routeMaskEntry{mask: 16, ok: true, expires: time.Now().Add(time.Hour)}
 	for i := 0; i < maxSize-1; i++ {
 		ip := net.IPv4(10, 0, 1, byte(i))
-		c.entries[string(ip.To16())] = routeMaskEntry{mask: 16, ok: true, expires: past}
+		c.entries[routeMaskKey{ip: string(ip.To16())}] = routeMaskEntry{mask: 16, ok: true, expires: past}
 	}
 	if len(c.entries) != maxSize {
 		t.Fatalf("setup len = %d, want %d", len(c.entries), maxSize)
@@ -369,9 +369,9 @@ func TestRouteMaskCacheEvictsExpiredFirst(t *testing.T) {
 	// directly — the background populate path (#3743) that would call it.
 	newIP := net.IPv4(203, 0, 113, 9)
 	c.mu.Lock()
-	c.storeLocked(string(newIP.To16()), 16, true, time.Now())
+	c.storeLocked(routeMaskKey{ip: string(newIP.To16())}, 16, true, time.Now())
 	c.mu.Unlock()
-	if _, ok := c.entries[string(live.To16())]; !ok {
+	if _, ok := c.entries[routeMaskKey{ip: string(live.To16())}]; !ok {
 		t.Fatalf("live entry was wiped — expired-first purge did not run")
 	}
 	if len(c.entries) > maxSize {
@@ -380,10 +380,14 @@ func TestRouteMaskCacheEvictsExpiredFirst(t *testing.T) {
 }
 
 // TestResolveMasksNilResolver pins the pre-#2866 fallback: a zero-value
-// exporter (nil resolver) leaves both masks 0.
+// exporter (nil resolver) leaves both masks 0 and reports 0 misses — the
+// feature is simply off, not "unresolved".
 func TestResolveMasksNilResolver(t *testing.T) {
-	s, d := resolveMasks(nil, net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 2))
+	s, d, misses := resolveMasks(nil, net.IPv4(10, 0, 0, 1), net.IPv4(10, 0, 0, 2), 0, 0)
 	if s != 0 || d != 0 {
 		t.Fatalf("nil resolver masks = %d/%d, want 0/0", s, d)
+	}
+	if misses != 0 {
+		t.Fatalf("nil resolver misses = %d, want 0 (feature off, not a miss)", misses)
 	}
 }


### PR DESCRIPTION
Closes #3744

## Problem

The NetFlow IE 9/13 (IPv6 IE 29/30) and IPFIX prefix-length route masks
(#2866) were resolved by a **VRF/table-blind** FIB lookup that also
**discarded the resolved bit**:

- `fibMatchMask` issued `RouteGetWithOptions(ip, {FIBMatch:true})` with no
  interface, so it always resolved against the **main** table.
- `resolveMasks` dropped both `ok` bits, so a miss returned `0` —
  indistinguishable from a real default-route `/0`.

In a multi-VRF / routing-instance deployment every flow's mask was
therefore looked up in the wrong table (a leaked or per-instance prefix
resolved to the wrong length, often `/0`), and a genuine miss was exported
as a bogus `/0`. Observability-only impact (prefix aggregation at the
collector); single-VRF / default deployments are unaffected because the
main table IS the flow's table.

The converged research plan (issue comment) refuted the original fix
note's premise: the forwarding context we need is **already on the close
event** — the ingress/egress ifindex (#2615/#2749 →
`SessionCloseData.InIf/OutIf`). No new SESSION_CLOSE wire field is needed.

## Fix (Option A + B, one PR)

**A — scope the lookup by the flow's ingress ifindex.** xpf enslaves
interfaces to real l3mdev VRF master devices (`pkg/routing/vrf.go`), so an
ifindex selects a distinct kernel table. `MaskResolver` now takes an
`ifindex`; `fibMatchMask` sets `RouteGetOptions.IifIndex` (>0) so the
kernel performs an input-path lookup that follows l3mdev enslavement into
the VRF table. `resolveMasks(r, srcIP, dstIP, inIf, outIf)` scopes **both**
halves by the **ingress** instance (`inIf`) — Junos attributes the session
to the ingress routing-instance and next-table / rib-group leaked routes
appear there — falling back to `outIf` when there is no ingress
attribution, then to the global table (`inIf==outIf==0`, bit-identical to
the pre-change behaviour). The async #3743/#3797 cache key widens from the
16-byte IP to `(ifindex, IP)` so per-VRF masks for the same host address
do not collide; the non-blocking-callback / bounded-inflight / dedup /
size-cap invariants are unchanged.

**B — preserve the resolved bit.** The wire field is a `u8` prefix length
(0..128) with no room for an "unresolved" sentinel, so an unresolved
lookup is surfaced **out-of-band**: `resolveMasks` returns the count of
unresolved halves, and each exporter accumulates it into a
`routeMaskUnresolved atomic.Uint64` (`RouteMaskUnresolved()` accessor,
mirroring `EstimatedDurations`). Since #3797 the first flow to any cold
`(ifindex, prefix)` key resolves `0` while the background lookup warms, so
a nonzero counter is expected in steady state; a value climbing in
lockstep with exported flows is the only operator-visible signal that an
exported mask-`0` is unresolved versus a real default-route `/0`.

## Documented residual

Pure fwmark / `ip rule` PBR (`pkg/routing/rules.go`) selects a table by
mark or source and the mark is **not** carried on the close event, so an
ifindex-scoped lookup cannot reproduce a mark-only PBR decision. The
dominant multi-table case — VRF / routing-instance — IS covered; carrying
the fwmark is a separate future item if demand appears. Documented in
`pkg/flowexport/README.md`.

## Tests (all fail-on-revert, `-race` for the async cache)

- `TestRouteMaskLookupScopedByIfindex` — the same dst IP resolves to
  different masks per ingress ifindex and the `(ifindex,IP)` cache key does
  not collide across VRFs.
- `TestResolveMasksScopesByIngressInstance` — both halves scope by `inIf`,
  fall back to `outIf`, then to the global table.
- `TestResolveMasksMissCount` / `TestExporterRouteMaskUnresolvedCounter` —
  an unresolved half increments the counter and still exports `0` (no
  sentinel).
- Existing #2866/#3743 pins updated for the new resolver/cache signatures.

**RED-on-revert verified** by temporarily reverting each mechanism against
the committed baseline: IP-only cache key → `TestRouteMaskLookupScopedByIfindex`
RED; table-blind `resolveMasks` → `TestResolveMasksScopesByIngressInstance`
RED; dropped miss count → `TestResolveMasksMissCount` +
`TestExporterRouteMaskUnresolvedCounter` RED.

`go test ./pkg/flowexport/... ./pkg/daemon/...` green (incl `-race`);
`go build ./...` green; `gofmt` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
