### PR TITLE
userspace-dp: invalidate flow cache on session reap (#3776)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,47 @@
+## 2026-07-01 — #3776: flow-cache invalidation on session reap (incomplete #2220 closure)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The per-worker flow-cache keepalive shipped for #2220 (PR
+    #2233, `touch_if_stale` on cache hit) only protects ACTIVELY-forwarding
+    flows. #2220's OWN suggested GC-path `invalidate_slot` was never
+    implemented, so the worker expiry loop
+    (`afxdp/worker/loop_body/mod.rs`) reaped sessions and released their
+    SNAT allocation WITHOUT touching the flow cache. An idle-then-resume
+    flow whose session was GC'd left a surviving `RewriteDescriptor` that
+    kept forwarding on the same 5-tuple — a stateful-firewall bypass (no
+    policy re-eval, no session install, no `show security flow session`
+    row, not HA-synced) — via a SNAT port that
+    `release_source_nat_allocation` may already have re-handed to another
+    flow (NAT-port reuse). Verified: expiry loop had no `invalidate_slot`
+    (only RST teardown `worker/lifecycle.rs:231-235` + neighbor fall-through
+    `flow_cache_hit.rs:125` did); cache `lookup_counted` checks only
+    key+config/fib-gen+RG-epoch+lease, never session liveness
+    (`flow_cache.rs:820-857`).
+    FIX: extracted the reap side-effects into `reap_expired_sessions`
+    (SNAT release + BPF map/conntrack delete + flow-cache invalidate) and
+    call it from the expiry loop. For every reaped entry it now calls
+    `flow_cache.invalidate_slot(&key, binding.ifindex)` on EVERY binding of
+    the owning worker (same-thread; cache is per-binding worker-owned).
+    Safe/precise because the session table is keyed by 5-tuple ALONE (≤1
+    live session per key) and `invalidate_slot` matches key AND ingress —
+    on a non-owning binding it no-ops or drops a stale same-tuple slot,
+    never a live entry. Forward + reverse each reap as their own
+    `ExpiredSession` → both directions covered. Reap path only (~1/s GC) →
+    no per-packet cost, keepalive fast path unchanged. FIN-closed sessions
+    flow through the same wheel (short closing timeout) → covered;
+    config/RG-lifecycle removals already invalidate via generation/epoch
+    stamp checks.
+    Tests (RED-on-revert verified — deleting the invalidate loop fails all
+    3): `reaped_session_flow_cache_slot_is_invalidated` (H1 bypass),
+    `reaped_snat_descriptor_is_not_reused` (H2 SNAT reuse),
+    `live_flow_survives_reap_of_a_different_flow` (no collateral
+    invalidation / keepalive-path preserved). Full `cargo test --release`
+    green.
+  - **File(s)**: userspace-dp/src/afxdp/worker/loop_body/mod.rs
+    (reap_expired_sessions helper + call site + reap_flow_cache_tests),
+    userspace-dp/src/session/README.md ("Flow-cache invalidation on reap
+    (#3776)" section)
+
 ## 2026-07-01 — #3769 fold (review MINOR): empty from-routing-instance NAT external = table-agnostic wildcard
 
 - **Timestamp**: 2026-07-01

--- a/userspace-dp/src/afxdp/worker/loop_body/mod.rs
+++ b/userspace-dp/src/afxdp/worker/loop_body/mod.rs
@@ -724,24 +724,15 @@ pub(crate) fn worker_loop(
         // SAME node and the standby gauge stays 0.
         let local_expired =
             count_local_session_expiries(expired_entries.iter().map(|e| e.origin));
-        for expired_entry in expired_entries {
-            release_source_nat_allocation(
-                &forwarding.source_nat_rules,
-                &expired_entry.key,
-                expired_entry.decision.nat,
-                expired_entry.metadata.is_reverse,
-                loop_now_ns,
-            );
-            delete_session_map_entry_for_removed_session_with_origin(
-                session_map_fd,
-                &expired_entry.key,
-                expired_entry.decision,
-                &expired_entry.metadata,
-                expired_entry.origin,
-                conntrack_v4_fd,
-                conntrack_v6_fd,
-            );
-        }
+        reap_expired_sessions(
+            &mut bindings,
+            &expired_entries,
+            forwarding.as_ref(),
+            session_map_fd,
+            conntrack_v4_fd,
+            conntrack_v6_fd,
+            loop_now_ns,
+        );
         if local_expired > 0 {
             if let Some(binding) = bindings.first() {
                 binding
@@ -1308,6 +1299,77 @@ pub(crate) fn worker_loop(
     heartbeat.store(monotonic_nanos(), Ordering::Relaxed);
 }
 
+/// #3776: apply the per-worker teardown side effects for every session the GC
+/// wheel reaped this sweep — release its SNAT allocation, delete its BPF
+/// redirect/conntrack entries, AND invalidate the per-worker flow-cache slot(s)
+/// that back it.
+///
+/// The flow-cache invalidation is the half of #2220 that was never shipped.
+/// #2220 (PR #2233) added only the keepalive: on a cache HIT the hot path
+/// touches the backing session so an ACTIVELY-forwarding flow's session cannot
+/// be reaped out from under a live cache entry. It does not cover a flow that
+/// idles PAST its timeout — the GC reaps the session and releases its SNAT
+/// port, but the flow-cache slot survives (config/fib generation, RG epoch, and
+/// RG lease are all unchanged, and the slot is not LRU-evicted). If traffic
+/// later resumes on the same 5-tuple it HITS the surviving `RewriteDescriptor`
+/// and is forwarded WITHOUT a live session — a stateful-firewall bypass (no
+/// policy re-evaluation, no session install, no `show security flow session`
+/// row, not HA-synced) — and via a SNAT port that `release_source_nat_allocation`
+/// may already have handed to a different flow (NAT-port reuse / reverse-path
+/// collision). Evicting the slot here forces the next packet to MISS the cache
+/// and re-run full session lookup/creation + policy (fail-closed: no forwarding
+/// without a live session, no stale-SNAT reuse via a surviving descriptor).
+/// Mirrors the RST-teardown eviction in `worker/lifecycle.rs`.
+///
+/// Cache ownership: the flow cache is per-binding and worker-owned, and this
+/// runs on the owning worker's GC sweep, so the eviction is a same-thread
+/// mutation — no cross-thread flush is needed. We invalidate on EVERY binding of
+/// this worker because a reaped session does not carry the ingress ifindex the
+/// cache is keyed on. That is both safe and precise: the session table is keyed
+/// by the 5-tuple ALONE, so at most one live session — hence at most one VALID
+/// descriptor — can exist for a given key, and `invalidate_slot` only drops a
+/// slot whose key AND ingress_ifindex both match. On a non-owning binding the
+/// call therefore either no-ops or drops a STALE prior-flow slot with the same
+/// tuple (which should go anyway); it can never drop another live flow's entry.
+/// Forward and reverse directions are each their own `ExpiredSession` with their
+/// own key, so both directions' slots are covered. This is the reap path
+/// (bounded by the ~1/s GC sweep), so it adds no per-packet cost and does not
+/// regress the #2220 keepalive fast path.
+fn reap_expired_sessions(
+    bindings: &mut [BindingWorker],
+    expired_entries: &[crate::session::ExpiredSession],
+    forwarding: &ForwardingState,
+    session_map_fd: c_int,
+    conntrack_v4_fd: c_int,
+    conntrack_v6_fd: c_int,
+    now_ns: u64,
+) {
+    for expired_entry in expired_entries {
+        release_source_nat_allocation(
+            &forwarding.source_nat_rules,
+            &expired_entry.key,
+            expired_entry.decision.nat,
+            expired_entry.metadata.is_reverse,
+            now_ns,
+        );
+        delete_session_map_entry_for_removed_session_with_origin(
+            session_map_fd,
+            &expired_entry.key,
+            expired_entry.decision,
+            &expired_entry.metadata,
+            expired_entry.origin,
+            conntrack_v4_fd,
+            conntrack_v6_fd,
+        );
+        for binding in bindings.iter_mut() {
+            binding
+                .flow
+                .flow_cache
+                .invalidate_slot(&expired_entry.key, binding.ifindex);
+        }
+    }
+}
+
 /// #2428: count only the create-counted LOCAL-origin expired sessions for
 /// the `session_expires` counter (which the Go control plane reads as
 /// `GlobalCtrSessionsClosed`).
@@ -1355,6 +1417,261 @@ fn count_local_session_expiries(
             | SessionOrigin::WorkerLocalImport => false,
         })
         .count() as u64
+}
+
+#[cfg(test)]
+mod reap_flow_cache_tests {
+    //! #3776: the GC reap path must invalidate the per-worker flow-cache
+    //! slot(s) backing every session it reaps, so a packet that resumes on the
+    //! same 5-tuple after the idle timeout MISSES the cache and re-runs full
+    //! session lookup/creation + policy — instead of being forwarded via a
+    //! stale `RewriteDescriptor` with no live session (stateful-firewall
+    //! bypass) and a SNAT port that may now belong to a different flow
+    //! (NAT-port reuse). These tests drive the production `reap_expired_sessions`
+    //! helper the expiry loop calls; deleting its `invalidate_slot` loop turns
+    //! `reaped_session_flow_cache_slot_is_invalidated` and
+    //! `reaped_snat_descriptor_is_not_reused` RED.
+    use super::*;
+    use crate::nat::NatDecision;
+    use crate::session::{
+        ExpiredSession, SessionDecision, SessionKey, SessionMetadata, SessionOrigin,
+    };
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const REAP_INGRESS_IF: i32 = 24;
+
+    fn reap_rg_epochs() -> [AtomicU32; MAX_RG_EPOCHS] {
+        std::array::from_fn(|_| AtomicU32::new(0))
+    }
+
+    fn reap_key(src_port: u16) -> SessionKey {
+        SessionKey {
+            addr_family: libc::AF_INET as u8,
+            protocol: PROTO_TCP,
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 0, 61, 102)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)),
+            src_port,
+            dst_port: 443,
+        }
+    }
+
+    fn reap_metadata() -> SessionMetadata {
+        SessionMetadata {
+            ingress_zone: 1,
+            egress_zone: 2,
+            owner_rg_id: 1,
+            fabric_ingress: false,
+            is_reverse: false,
+            nat64_reverse: None,
+            log_session_init: false,
+            log_session_close: false,
+            policy_id: 0,
+            inactivity_timeout_ns: None,
+            policy_counter_idx: 0,
+            policy_counter: None,
+        }
+    }
+
+    fn reap_resolution() -> ForwardingResolution {
+        ForwardingResolution {
+            disposition: ForwardingDisposition::ForwardCandidate,
+            local_ifindex: 0,
+            egress_ifindex: 12,
+            tx_ifindex: 12,
+            tunnel_endpoint_id: 0,
+            next_hop: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1))),
+            neighbor_mac: Some([0, 1, 2, 3, 4, 5]),
+            src_mac: Some([6, 7, 8, 9, 10, 11]),
+            tx_vlan_id: 0,
+        }
+    }
+
+    fn reap_decision(snat_port: Option<u16>) -> SessionDecision {
+        SessionDecision {
+            resolution: reap_resolution(),
+            nat: NatDecision {
+                rewrite_src: snat_port.map(|_| IpAddr::V4(Ipv4Addr::new(172, 16, 80, 8))),
+                rewrite_src_port: snat_port,
+                ..NatDecision::default()
+            },
+        }
+    }
+
+    fn insert_cache_entry(binding: &mut BindingWorker, key: &SessionKey, snat_port: Option<u16>) {
+        let decision = reap_decision(snat_port);
+        binding.flow.flow_cache.insert(FlowCacheEntry {
+            key: key.clone(),
+            ingress_ifindex: REAP_INGRESS_IF,
+            descriptor: RewriteDescriptor {
+                dst_mac: [0; 6],
+                src_mac: [0; 6],
+                fabric_redirect: false,
+                tx_vlan_id: 0,
+                ether_type: 0x0800,
+                rewrite_src_ip: decision.nat.rewrite_src,
+                rewrite_dst_ip: None,
+                rewrite_src_port: decision.nat.rewrite_src_port,
+                rewrite_dst_port: None,
+                ip_csum_delta: 0,
+                l4_csum_delta: 0,
+                egress_ifindex: 12,
+                tx_ifindex: 12,
+                target_binding_index: None,
+                input_filter_log: None,
+                tx_selection: CachedTxSelectionDescriptor::default(),
+                nat64: false,
+                nptv6: false,
+                apply_nat_on_fabric: false,
+            },
+            decision,
+            metadata: reap_metadata(),
+            stamp: FlowCacheStamp {
+                config_generation: 1,
+                fib_generation: 1,
+                owner_rg_id: 1,
+                owner_rg_epoch: 0,
+                owner_rg_lease_until: 0,
+            },
+            observed_bytes: 0,
+            last_used_epoch: 0,
+            neighbor_mac_epoch: 0,
+        });
+    }
+
+    fn cache_hits(
+        binding: &mut BindingWorker,
+        key: &SessionKey,
+        rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
+    ) -> bool {
+        binding
+            .flow
+            .flow_cache
+            .lookup(
+                key,
+                FlowCacheLookup {
+                    ingress_ifindex: REAP_INGRESS_IF,
+                    config_generation: 1,
+                    fib_generation: 1,
+                },
+                0,
+                rg_epochs,
+            )
+            .is_some()
+    }
+
+    fn expired(key: SessionKey, snat_port: Option<u16>) -> ExpiredSession {
+        ExpiredSession {
+            key,
+            decision: reap_decision(snat_port),
+            metadata: reap_metadata(),
+            origin: SessionOrigin::ForwardFlow,
+        }
+    }
+
+    // #3776 H1: a packet that resumes on a reaped flow's 5-tuple must MISS the
+    // cache. Without the GC-path `invalidate_slot` the descriptor survives the
+    // reap and the resumed packet is forwarded with no live session — the
+    // stateful-firewall bypass. RED on revert (the entry survives, `cache_hits`
+    // stays true after the reap).
+    #[test]
+    fn reaped_session_flow_cache_slot_is_invalidated() {
+        let rg_epochs = reap_rg_epochs();
+        let forwarding = ForwardingState::default();
+        let mut binding = BindingWorker::new_for_mirror_test(0, 0, REAP_INGRESS_IF, 0);
+        let key = reap_key(12345);
+        insert_cache_entry(&mut binding, &key, None);
+        assert!(
+            cache_hits(&mut binding, &key, &rg_epochs),
+            "precondition: an active flow's descriptor is cached and hits"
+        );
+
+        reap_expired_sessions(
+            std::slice::from_mut(&mut binding),
+            &[expired(key.clone(), None)],
+            &forwarding,
+            -1,
+            -1,
+            -1,
+            1_000_000_000,
+        );
+
+        assert!(
+            !cache_hits(&mut binding, &key, &rg_epochs),
+            "#3776: a packet on a reaped flow's tuple must MISS the cache so it \
+             re-runs full session lookup + policy (no sessionless forward)"
+        );
+        assert_eq!(
+            binding.flow.flow_cache.entries.iter().flatten().count(),
+            0,
+            "#3776: the reaped flow's cache slot must be evicted"
+        );
+    }
+
+    // #3776 H2: the SNAT-bearing descriptor of a reaped flow must not survive to
+    // re-drive a translation whose port `release_source_nat_allocation` just
+    // returned to the pool. RED on revert (the SNAT descriptor keeps hitting).
+    #[test]
+    fn reaped_snat_descriptor_is_not_reused() {
+        let rg_epochs = reap_rg_epochs();
+        let forwarding = ForwardingState::default();
+        let mut binding = BindingWorker::new_for_mirror_test(0, 0, REAP_INGRESS_IF, 0);
+        let key = reap_key(23456);
+        insert_cache_entry(&mut binding, &key, Some(20001));
+        assert!(cache_hits(&mut binding, &key, &rg_epochs));
+
+        reap_expired_sessions(
+            std::slice::from_mut(&mut binding),
+            &[expired(key.clone(), Some(20001))],
+            &forwarding,
+            -1,
+            -1,
+            -1,
+            1_000_000_000,
+        );
+
+        assert!(
+            !cache_hits(&mut binding, &key, &rg_epochs),
+            "#3776: a released-SNAT descriptor must not survive the reap and \
+             re-SNAT to a port now owned by a different flow"
+        );
+    }
+
+    // A flow that is NOT reaped this sweep must keep hitting the cache — the
+    // #2220 keepalive fast path is preserved, the reap targets only the reaped
+    // key, and there is no collateral invalidation.
+    #[test]
+    fn live_flow_survives_reap_of_a_different_flow() {
+        let rg_epochs = reap_rg_epochs();
+        let forwarding = ForwardingState::default();
+        let mut binding = BindingWorker::new_for_mirror_test(0, 0, REAP_INGRESS_IF, 0);
+        let reaped = reap_key(30001);
+        let live = reap_key(30002);
+        insert_cache_entry(&mut binding, &reaped, None);
+        insert_cache_entry(&mut binding, &live, None);
+        assert!(cache_hits(&mut binding, &reaped, &rg_epochs));
+        assert!(cache_hits(&mut binding, &live, &rg_epochs));
+
+        reap_expired_sessions(
+            std::slice::from_mut(&mut binding),
+            &[expired(reaped.clone(), None)],
+            &forwarding,
+            -1,
+            -1,
+            -1,
+            1_000_000_000,
+        );
+
+        assert!(
+            !cache_hits(&mut binding, &reaped, &rg_epochs),
+            "the reaped flow's slot is evicted"
+        );
+        assert!(
+            cache_hits(&mut binding, &live, &rg_epochs),
+            "a still-live flow's slot must survive the reap of a different flow \
+             (no keepalive/hot-path regression, no collateral invalidation)"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -250,6 +250,44 @@ ever being touched, then be reaped while still forwarding (an HA Close
 delta to the peer + BPF redirect-key deletion + a stale flow-cache
 descriptor out-living its session). UDP (60 s) was the most exposed.
 
+## Flow-cache invalidation on reap (#3776)
+
+The #2220 keepalive only protects an ACTIVELY-forwarding flow — the cache
+hit is what refreshes the session. It does nothing for a flow that idles
+PAST its timeout: the GC wheel reaps the session and
+`release_source_nat_allocation` returns its SNAT port to the pool, but
+the flow-cache slot survives (config/fib generation, RG epoch, and RG
+lease are all unchanged, and the slot is not LRU-evicted). If traffic
+later resumes on the same 5-tuple it HITS the surviving
+`RewriteDescriptor` and is forwarded WITHOUT a live session — a
+stateful-firewall bypass (no policy re-evaluation, no session install, no
+`show security flow session` row, not HA-synced) — and via a SNAT port
+that may already have been re-handed to a different flow (NAT-port reuse /
+reverse-path collision). This was the half of #2220 that was never
+shipped.
+
+`reap_expired_sessions` (`afxdp/worker/loop_body/mod.rs`) now closes it:
+for every entry the GC sweep reaps it calls
+`flow_cache.invalidate_slot(&key, binding.ifindex)` on every binding of
+the owning worker, mirroring the RST-teardown eviction in
+`afxdp/worker/lifecycle.rs`. The next packet on that tuple then MISSES the
+cache and re-runs full session lookup/creation + policy (fail-closed: no
+forwarding without a live session, no stale-SNAT reuse). Because the flow
+cache is per-binding and worker-owned and the sweep runs on the owning
+worker, this is a same-thread mutation — no cross-thread flush. Invalidating
+on every binding is safe and precise: the session table is keyed by the
+5-tuple ALONE, so at most one live session (hence at most one valid
+descriptor) exists per key, and `invalidate_slot` drops only a slot whose
+key AND ingress_ifindex both match — on a non-owning binding it either
+no-ops or evicts a stale prior-flow slot with the same tuple, never
+another live flow's entry. Forward and reverse are each their own
+`ExpiredSession` with their own key, so both directions are covered. The
+work is bounded by the ~1/s GC sweep, so it adds no per-packet cost and
+does not regress the keepalive fast path. Config/RG-lifecycle removals
+already invalidate via the generation/epoch stamp checks
+(`flow_cache.rs` lookup); the reap path is the gap those checks do not
+cover because a plain idle-timeout reap bumps neither.
+
 ## Per-session byte/packet accounting (#2501)
 
 Each `SessionEntry` carries a `SessionCounters` (`fwd_packets`, `fwd_bytes`,


### PR DESCRIPTION
## Summary

Closes #3776.

The per-worker flow-cache keepalive shipped for #2220 (PR #2233,
`touch_if_stale` on cache hit) only protects an **actively-forwarding**
flow — the cache hit itself refreshes the backing session. #2220's own
suggested fix also called for invalidating the flow-cache slot in the
session GC path, and **that half was never implemented**. The worker
expiry loop (`afxdp/worker/loop_body/mod.rs`) reaped sessions, deleted
their BPF redirect/conntrack entries, and **released their SNAT
allocation** without ever touching the flow cache.

### The bug

A flow that idles PAST its timeout gets its session reaped and its SNAT
port returned to the pool, but the flow-cache slot survives (config/fib
generation, RG epoch, RG lease all unchanged; not LRU-evicted). When
traffic resumes on the same 5-tuple it HITS the surviving
`RewriteDescriptor` and is forwarded **without a live session**:

- **Stateful-firewall bypass** — no policy re-evaluation, no session
  install, no `show security flow session` row, not HA-synced.
- **NAT-port reuse** — `release_source_nat_allocation` may already have
  re-handed the SNAT port to a different flow (reverse-path collision).

Cache lookup validates only key + config/fib-generation + RG epoch + RG
lease, never session liveness; `touch_if_stale`/`account_packet` both
silently no-op on a missing session, so a gone session is invisible to
the hit path.

## Fix

Extract the reap side effects into `reap_expired_sessions` (SNAT release
+ BPF map/conntrack delete + flow-cache invalidate) and call it from the
expiry loop. For every reaped entry it now calls
`flow_cache.invalidate_slot(&key, binding.ifindex)` on every binding of
the owning worker, mirroring the RST-teardown eviction in
`worker/lifecycle.rs`. The next packet on that tuple then MISSES the
cache and re-runs full session lookup/creation + policy — fail-closed.

**Correctness / ownership:** the flow cache is per-binding and
worker-owned and the sweep runs on the owning worker, so this is a
same-thread mutation (no cross-thread flush). Invalidating on every
binding is safe and precise: the session table is keyed by the 5-tuple
alone, so at most one live session (hence one valid descriptor) exists
per key, and `invalidate_slot` drops only a slot whose key AND
ingress_ifindex both match — on a non-owning binding it no-ops or evicts
a stale prior-flow slot, never a live entry. Forward + reverse each reap
as their own `ExpiredSession` (both directions covered). FIN-closed
sessions flow through the same wheel (short closing timeout) → covered;
config/RG-lifecycle removals already invalidate via the generation/epoch
stamp checks. Bounded by the ~1/s GC sweep → no per-packet cost, no
keepalive-fast-path regression.

## Tests (RED-on-revert verified)

Deleting the `invalidate_slot` loop fails all three:

- `reaped_session_flow_cache_slot_is_invalidated` — H1 stateful bypass
- `reaped_snat_descriptor_is_not_reused` — H2 SNAT reuse
- `live_flow_survives_reap_of_a_different_flow` — no collateral
  invalidation; keepalive path preserved

Full `cargo test --release` green (3380 lib + all integration binaries,
0 failed).

## Docs

`userspace-dp/src/session/README.md` gains a "Flow-cache invalidation on
reap (#3776)" section under the #2220 keepalive discussion.

## Validation note

Touches the session GC/reap path (session-sync-adjacent). Recommend
`make test-failover` on the loss userspace cluster before merge to
confirm no failover regression, though the change is reap-path only and
does not alter the sync/delta emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
