### PR TITLE
flowexport: IPFIX RFC 5103 biflow reverse counters (PEN 29305) (#3746)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,48 @@
+## 2026-07-01 — #3746 flowexport: IPFIX RFC 5103 biflow reverse counters (PEN 29305); NetFlow v9 reverse deferred
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3746 (codex-review-158 H12, converged /research plan Option A).
+    The reverse (server→client) session byte/packet counters have been produced
+    end-to-end since #2501 (decoded to `EventRecord.RevSessionPkts`/
+    `.RevSessionBytes`) and are in scope at IPFIX export time, but the FlowRecord
+    build wired only the FORWARD counts, so collectors under-reported the larger
+    half of asymmetric bi-directional flows. Implemented the IPFIX half: encode
+    the reverse volume as RFC 5103 biflow reverse Information Elements
+    `reverseOctetDeltaCount` (IE 1) + `reversePacketDeltaCount` (IE 2) under the
+    reverse Private Enterprise Number 29305 — the codebase's FIRST enterprise IEs.
+    - `ipfixField` gained an `enterprise uint32` column (0 = IANA). The Template
+      Set encoder now sizes an enterprise field specifier at 8 bytes (elementID
+      with the 0x8000 enterprise bit + a 4-byte PEN) while IANA specs stay 4
+      bytes (`ipfixFieldSpecsLen`/`encodeIPFIXFieldSpec`); the DATA record encodes
+      the reverse counts as plain 8-byte u64. Reverse IEs spliced after the
+      forward CoS/egress block and before the post-NAT trailer (post-NAT stays
+      last per #2526; flowDirection #3270 still just before post-NAT). Template
+      IDs 256/257 reused (content grows once); record sizes v4 70→86, v6 118→134
+      (with flow-dir 87/135).
+    - `FlowRecord` gained `RevPackets`/`RevBytes`; `ExportSessionClose` sets them
+      from `rec.RevSessionPkts`/`.RevSessionBytes` (already in scope — no
+      SessionCloseData plumbing). NetFlow v9 leaves them unused (no standard
+      reverse element).
+    - Tests (`ipfix_biflow_test.go`): full Template Set decode asserting the two
+      reverse IEs carry the enterprise bit + PEN 29305 + length 8 (base AND
+      flow-dir templates) with Template-Set-length integrity (catches an 8-byte
+      specifier off-by-one), a record round-trip of >2^32 reverse sentinels, the
+      ExportSessionClose plumbing pin, and a loopback-UDP real-wire pin.
+      RED-on-revert verified (all four fail with the reverse IEs removed).
+      Updated the enterprise-aware Template-Set walkers in
+      `dropped_fields_test.go` / `flowdir_test.go` and the record-size pins in
+      `postnat_test.go` / `flowdir_test.go`.
+    - Docs: `pkg/flowexport/README.md` drops the stale "#2501 counters are 0"
+      caveats, documents the biflow reverse IEs / enterprise-IE template
+      encoding, and records the NetFlow v9 reverse-direction DEFER (no standard
+      single-record path).
+  - **File(s)**: pkg/flowexport/ipfix.go, pkg/flowexport/manager.go,
+    pkg/flowexport/ipfix_biflow_test.go (new), pkg/flowexport/dropped_fields_test.go,
+    pkg/flowexport/flowdir_test.go, pkg/flowexport/postnat_test.go,
+    pkg/flowexport/README.md, _Log.md
+  - **Validation**: `go test ./pkg/flowexport/...` green; `go build ./...`;
+    gofmt + go vet clean; RED-on-revert confirmed.
+
 ## 2026-07-01 — #3718 host-inbound: fail-closed duplicate host-local-address gate + runtime reporter/metric (Option B)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -32,9 +32,12 @@ it into a `Type:"SESSION_CLOSE"` `EventRecord` via
 HA delta is unchanged and emitted as a 1:1 pair with the type-14 frame —
 the RT_FLOW frame is additive, not a replacement, so HA session sync is
 unaffected. The record carries the real 5-tuple, NAT translated tuple,
-zones, and protocol; the byte/packet volume counters are 0 because the
-AF_XDP forwarding path does not yet maintain per-session accounting — that
-is the follow-up tracked in **#2501**.
+zones, and protocol. Since **#2501** (CLOSED) the AF_XDP forwarding path
+maintains per-session accounting, so the frame carries the real forward AND
+reverse byte/packet volume counters (both were 0 before #2501). The forward
+counts populate the standard IANA `octetDeltaCount`/`packetDeltaCount`; the
+reverse (server→client) counts are exported by IPFIX as the RFC 5103 biflow
+reverse IEs — see "#3746 — biflow reverse volume (IPFIX)" below.
 
 **#2465 — the exported flow StartTime is now the real session-creation
 time, not a packet-count guess.** Before #2465 the NetFlow v9 / IPFIX
@@ -58,8 +61,9 @@ synthesized close from a path that carried no creation instant (the
 explicit clear-session / NAT-remap delete glue and the HA tunnel-remap
 purge, which do not have the originating entry in hand). Each fallback
 bumps a per-exporter `EstimatedDurations()` counter so operators can see
-how often the heuristic is still in play. The byte/packet **volume**
-counters remain 0 pending #2501 — only the timing is now real.
+how often the heuristic is still in play. (Since #2501 the byte/packet
+**volume** counters are real too — the forward direction on the standard
+IANA counters and the reverse direction on the #3746 biflow reverse IEs.)
 
 **#2853 — the flow StartTime keeps MILLISECOND resolution.** #2465's
 `created` field is integer Unix **seconds** (offset 108, u32), so every
@@ -102,17 +106,19 @@ RFC 8158) are appended LAST in every template:
 | postNATDestinationIPv6Address | 282 | ipv6Address | 16 | v6 |
 
 NetFlow v9 reuses the same IANA element type IDs in its template
-FlowSet. With the #2613 drop and the #2749 re-adds of `ingressInterface`
+FlowSet. With the #2613 drop, the #2749 re-adds of `ingressInterface`
 (IE 10, 4B), `ipClassOfService` (IE 5, 1B), `tcpControlBits` (IE 6, 2B) and
-`egressInterface` (IE 14, 4B) the IPv4 IPFIX record is 70 bytes (45 pre-NAT
-body + 2 src/dst mask + 4 ingressInterface + 7 CoS/egress + 12 post-NAT) and
-the IPv6 record is 118 bytes (69 + 2 + 4 + 7 + 36); the NetFlow v9 record
+`egressInterface` (IE 14, 4B), and the #3746 biflow reverse counters
+(2×8B, IPFIX only) the IPv4 IPFIX record is 86 bytes (45 pre-NAT
+body + 2 src/dst mask + 4 ingressInterface + 7 CoS/egress + 16 biflow
+reverse + 12 post-NAT) and the IPv6 record is 134 bytes (69 + 2 + 4 + 7 + 16
++ 36); the NetFlow v9 record
 sizes derive from the template via `recordSize` (4-byte padded, 64 v4 / 112
-v6 — NetFlow `tcpFlags` is 1B not 2B), so they track the template
-automatically. #3270: with `export-extension flow-dir` the templates splice in
-`flowDirection` (IE 61, 1B) before the post-NAT trailer — the IPFIX record
-grows to 71 (v4) / 119 (v6); the v9 record absorbs the byte into its existing
-4-byte padding (`ipfixRecordSize(isV6, includeDir)` /
+v6 — NetFlow `tcpFlags` is 1B not 2B; v9 carries no reverse element), so they
+track the template automatically. #3270: with `export-extension flow-dir` the
+templates splice in `flowDirection` (IE 61, 1B) before the post-NAT trailer —
+the IPFIX record grows to 87 (v4) / 135 (v6); the v9 record absorbs the byte
+into its existing 4-byte padding (`ipfixRecordSize(isV6, includeDir)` /
 `buildTemplateFieldsV4/V6` carry the flag).
 The init-time
 assertion in `ipfix.go` pins the BASE `ipfixRecordSizeV4/V6` to the sum of their
@@ -131,8 +137,7 @@ collector always receives a usable tuple, matching Junos/vSRX (which
 always emits the post-NAT fields). The address and port halves fall back
 independently, so an address-only or port-only translation reports the
 translated half and the pre-NAT other half. A collector distinguishes a
-NAT'd flow from a non-NAT'd flow by post != pre. Volume counters remain 0
-pending #2501.
+NAT'd flow from a non-NAT'd flow by post != pre.
 
 **#2613 — stop advertising fields the close path cannot populate.** The
 templates previously advertised `ipClassOfService`/SrcTos (5),
@@ -339,6 +344,63 @@ by 2 bytes (v4 61→63, v6 109→111). Presence-with-real-value is pinned by
 the encoded record carries the resolved prefix length, not zero — a
 deterministic injected resolver keeps the test free of a kernel-FIB
 dependency).
+
+**#3746 — biflow reverse volume (IPFIX).** Since #2501 the SESSION_CLOSE
+frame carries the reverse (server→client) byte/packet counters — decoded to
+`logging.EventRecord.RevSessionPkts` / `.RevSessionBytes`
+(`pkg/logging/ringbuf.go`) — but the exporters wired only the forward counts
+into the standard `octetDeltaCount` (IE 1) / `packetDeltaCount` (IE 2), so a
+collector systematically under-reported the larger half of an asymmetric flow
+(small request / large download). The IPFIX exporter now also emits the
+reverse direction as the **RFC 5103 biflow reverse Information Elements**:
+`reverseOctetDeltaCount` (IE 1) and `reversePacketDeltaCount` (IE 2), both
+under the reverse **Private Enterprise Number 29305**.
+
+These are the codebase's first **enterprise** IEs. `ipfixField` gained an
+`enterprise uint32` column (0 = IANA, unchanged). In the **Template Set** an
+enterprise field specifier is 8 bytes — the element ID with the top bit
+(`0x8000`) set, the 2-byte length, and the 4-byte PEN (RFC 7011 §3.2) — while
+IANA specifiers stay 4 bytes; the template encoder sizes and writes each
+accordingly (`ipfixFieldSpecsLen` / `encodeIPFIXFieldSpec`). The template
+record's field **count** is unchanged (each enterprise IE is one field). In
+the **Data Record** the reverse counts are plain 8-byte unsigned64 values, so
+the record grows by 16 bytes (v4 70→86, v6 118→134). The two reverse IEs are
+spliced after the forward CoS/egress block and before the post-NAT trailer, so
+the #2526 post-NAT tuple stays last and the #3270 `flowDirection` byte (when
+`export-extension flow-dir` is set) still sits just before the post-NAT block.
+Template IDs stay **256/257** — the content grows once (like #2526/#2749/#2866)
+and a collector re-learns the template on the next refresh; an unknown-PEN
+collector simply skips the 8-byte field via the template-declared length
+(RFC 7011 §8), so the change is backward-safe. The #3740 stable
+SourceID/ODID and the #2609 sequence-across-refresh behaviour are untouched
+(still one record per session).
+
+The counters are **always present** (like the #2526 post-NAT tuple), not
+opt-in: they are core accounting data and skippable by a collector that does
+not implement PEN 29305. Fail-on-revert pins in `ipfix_biflow_test.go`:
+`TestIPFIXTemplateCarriesBiflowReverseIEs` (the two reverse IEs decode from
+the template with the enterprise bit + PEN 29305 + length 8, in both the base
+and flow-dir templates, and the Template Set length matches the bytes walked —
+catching an off-by-one in the 8-byte specifier sizing),
+`TestIPFIXRecordCarriesBiflowReverseCounts` (the encoded record carries the
+reverse packet/byte counts at the reverse IEs' offset),
+`TestIPFIXExportSessionCloseWiresReverseCounts` (the `EventRecord` reverse
+counters reach the `FlowRecord`), and `TestIPFIXBiflowReverseWireLoopback`
+(the IEs + counts survive the real exporter UDP wire path). Removing the
+reverse IEs flips all four RED.
+
+**NetFlow v9 reverse direction — DEFERRED.** NetFlow v9 (RFC 3954) has no
+standard reverse element and no enterprise/PEN namespace, so there is no
+in-record, single-record way to carry the reverse direction. The two
+non-standard alternatives each break a deliberate design choice: a second
+reversed-tuple record contradicts the one-record-per-session / initiator-tuple
+anchor the #3270 flow-dir semantics rely on (and would be low-fidelity — the
+dataplane tracks no reverse-direction post-NAT tuple or ToS), and summing both
+directions into `octetDeltaCount` corrupts that IE's per-direction semantics.
+So **v9 exports the initiator-direction volume only; use IPFIX for
+bidirectional accounting.** `FlowRecord.RevPackets`/`RevBytes` are populated
+for both exporters but consumed only by IPFIX. See the converged research plan
+on #3746.
 
 ## File layout
 

--- a/pkg/flowexport/dropped_fields_test.go
+++ b/pkg/flowexport/dropped_fields_test.go
@@ -58,7 +58,9 @@ func TestIPFIXTemplateDroppedFieldsAbsent(t *testing.T) {
 		}
 	}
 
-	// Also walk the encoded bytes (the wire the collector parses).
+	// Also walk the encoded bytes (the wire the collector parses). #3746: field
+	// specifiers are 4 bytes (IANA) or 8 bytes (enterprise: element-ID top bit
+	// set + a 4-byte PEN), so mask the enterprise bit and advance by width.
 	ts := encodeIPFIXTemplateSet()
 	off := 4 // skip set header
 	for off+4 <= len(ts) {
@@ -66,11 +68,16 @@ func TestIPFIXTemplateDroppedFieldsAbsent(t *testing.T) {
 		count := int(binary.BigEndian.Uint16(ts[off : off+2]))
 		off += 2
 		for i := 0; i < count && off+4 <= len(ts); i++ {
-			eid := binary.BigEndian.Uint16(ts[off : off+2])
+			raw := binary.BigEndian.Uint16(ts[off : off+2])
+			eid := raw & 0x7fff
 			if name, bad := dropped[eid]; bad {
 				t.Errorf("dropped IPFIX IE %s (%d) found in encoded template set", name, eid)
 			}
-			off += 4
+			if raw&0x8000 != 0 {
+				off += 8
+			} else {
+				off += 4
+			}
 		}
 	}
 }

--- a/pkg/flowexport/flowdir_test.go
+++ b/pkg/flowexport/flowdir_test.go
@@ -182,21 +182,22 @@ func TestIPFIXTemplateFlowDirConditional(t *testing.T) {
 	}
 }
 
-// TestIPFIXRecordSizeWithDir pins the concrete with-dir record sizes the issue
-// specifies: IPFIX V4 71 / V6 119.
+// TestIPFIXRecordSizeWithDir pins the concrete with-dir record sizes: base
+// (#3746 added the 16-byte biflow reverse counters) + 1 flow-dir byte —
+// IPFIX V4 87 / V6 135.
 func TestIPFIXRecordSizeWithDir(t *testing.T) {
-	if got := ipfixRecordSize(false, true); got != 71 {
-		t.Errorf("ipfixRecordSize(v4, dir) = %d, want 71", got)
+	if got := ipfixRecordSize(false, true); got != 87 {
+		t.Errorf("ipfixRecordSize(v4, dir) = %d, want 87", got)
 	}
-	if got := ipfixRecordSize(true, true); got != 119 {
-		t.Errorf("ipfixRecordSize(v6, dir) = %d, want 119", got)
+	if got := ipfixRecordSize(true, true); got != 135 {
+		t.Errorf("ipfixRecordSize(v6, dir) = %d, want 135", got)
 	}
 	// Build-time invariant: with-dir template field-length sum equals size.
-	if sum := ipfixSumLen(ipfixTemplateFieldsV4(true)); sum != 71 {
-		t.Errorf("sum(ipfixTemplateFieldsV4(dir)) = %d, want 71", sum)
+	if sum := ipfixSumLen(ipfixTemplateFieldsV4(true)); sum != 87 {
+		t.Errorf("sum(ipfixTemplateFieldsV4(dir)) = %d, want 87", sum)
 	}
-	if sum := ipfixSumLen(ipfixTemplateFieldsV6(true)); sum != 119 {
-		t.Errorf("sum(ipfixTemplateFieldsV6(dir)) = %d, want 119", sum)
+	if sum := ipfixSumLen(ipfixTemplateFieldsV6(true)); sum != 135 {
+		t.Errorf("sum(ipfixTemplateFieldsV6(dir)) = %d, want 135", sum)
 	}
 	// Encoded template byte-walk: IE 61 advertised with includeDir.
 	ts := encodeIPFIXTemplateSetDir(true)
@@ -209,7 +210,10 @@ func TestIPFIXRecordSizeWithDir(t *testing.T) {
 }
 
 // templateSetHasIE walks an encoded IPFIX template set and reports whether the
-// given element ID is advertised in any template record.
+// given element ID is advertised in any template record. #3746: field
+// specifiers are 4 bytes for an IANA IE and 8 bytes for an enterprise IE
+// (top bit of the element ID set + a 4-byte PEN), so the walk masks the
+// enterprise bit for the comparison and advances by the specifier width.
 func templateSetHasIE(ts []byte, ie uint16) bool {
 	off := 4 // skip set header
 	for off+4 <= len(ts) {
@@ -217,10 +221,16 @@ func templateSetHasIE(ts []byte, ie uint16) bool {
 		count := int(binary.BigEndian.Uint16(ts[off : off+2]))
 		off += 2
 		for i := 0; i < count && off+4 <= len(ts); i++ {
-			if binary.BigEndian.Uint16(ts[off:off+2]) == ie {
+			raw := binary.BigEndian.Uint16(ts[off : off+2])
+			enterprise := raw&0x8000 != 0
+			if raw&0x7fff == ie {
 				return true
 			}
-			off += 4
+			if enterprise {
+				off += 8
+			} else {
+				off += 4
+			}
 		}
 	}
 	return false

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -49,7 +49,29 @@ const (
 	ipfixPostNapatDestTransportPort    = 228
 	ipfixPostNatSourceIPv6Address      = 281
 	ipfixPostNatDestinationIPv6Address = 282
+	// #3746: RFC 5103 biflow reverse counters. The reverse of an IANA IE is
+	// expressed with the SAME element ID under the reverse Private Enterprise
+	// Number 29305, so reverseOctetDeltaCount reuses IE 1 (octetDeltaCount) and
+	// reversePacketDeltaCount reuses IE 2 (packetDeltaCount). In the Template
+	// Set an enterprise field specifier sets the top (enterprise) bit of the
+	// element ID and appends the 4-byte PEN (RFC 7011 §3.2); the Data Record
+	// value is a plain 8-byte unsigned64. Confirmed against the IANA "IPFIX
+	// Entities" registry and RFC 5103.
+	ipfixReverseOctetDeltaCount  = 1
+	ipfixReversePacketDeltaCount = 2
 )
+
+// ipfixReversePEN is the RFC 5103 reverse Private Enterprise Number. An IPFIX
+// enterprise Information Element carries it in the Template Set field
+// specifier (RFC 7011 §3.2); a collector that does not grok 29305 skips the
+// field using the template-declared length (RFC 7011 §8) — no corruption.
+const ipfixReversePEN uint32 = 29305
+
+// ipfixEnterpriseBit is the top bit of an IPFIX Information Element identifier
+// that marks a field specifier as enterprise-scoped (RFC 7011 §3.2). When set,
+// the field specifier is 8 bytes (2B elementID|bit, 2B length, 4B PEN) instead
+// of the 4-byte IANA form.
+const ipfixEnterpriseBit uint16 = 0x8000
 
 // IPFIX Set IDs (RFC 7011 Section 3.3.2).
 const (
@@ -64,10 +86,16 @@ const (
 	ipfixTemplateIDv6 = 257
 )
 
-// ipfixField defines a template field with IANA element ID and length.
+// ipfixField defines a template field. enterprise is 0 for a standard IANA
+// Information Element (4-byte Template Set field specifier) and the Private
+// Enterprise Number for an RFC 7011 §3.2 enterprise IE (8-byte specifier:
+// elementID|0x8000, length, 4-byte PEN). The Data Record value length is
+// `length` in both cases (#3746 added the first enterprise IEs — the RFC 5103
+// biflow reverse counters under PEN 29305).
 type ipfixField struct {
-	elementID uint16
-	length    uint16
+	elementID  uint16
+	length     uint16
+	enterprise uint32
 }
 
 // #2749: the IPFIX templates advertise ipClassOfService (5), tcpControlBits
@@ -82,26 +110,26 @@ type ipfixField struct {
 
 // ipfixTemplateV4 defines the IPv4 IPFIX base template fields (flow-dir absent).
 var ipfixTemplateV4 = []ipfixField{
-	{ipfixSourceIPv4Address, 4},
-	{ipfixDestinationIPv4Address, 4},
-	{ipfixSourceTransportPort, 2},
-	{ipfixDestinationTransportPort, 2},
-	{ipfixProtocolIdentifier, 1},
-	{ipfixPacketDeltaCount, 8},
-	{ipfixOctetDeltaCount, 8},
-	{ipfixFlowStartMilliseconds, 8},
-	{ipfixFlowEndMilliseconds, 8},
+	{ipfixSourceIPv4Address, 4, 0},
+	{ipfixDestinationIPv4Address, 4, 0},
+	{ipfixSourceTransportPort, 2, 0},
+	{ipfixDestinationTransportPort, 2, 0},
+	{ipfixProtocolIdentifier, 1, 0},
+	{ipfixPacketDeltaCount, 8, 0},
+	{ipfixOctetDeltaCount, 8, 0},
+	{ipfixFlowStartMilliseconds, 8, 0},
+	{ipfixFlowEndMilliseconds, 8, 0},
 	// #2866: src/dst route prefix lengths (IE 9 / IE 13) populated with the
 	// FIB longest-prefix-match mask. Placed in the same slot as the NetFlow
 	// v9 srcMask/dstMask (after FlowEnd, before ingressInterface) so the two
 	// protocols keep a parallel record layout.
-	{ipfixSourceIPv4PrefixLength, 1},
-	{ipfixDestIPv4PrefixLength, 1},
+	{ipfixSourceIPv4PrefixLength, 1, 0},
+	{ipfixDestIPv4PrefixLength, 1, 0},
 	// #2749: ingressInterface (IE 10) re-introduced with a REAL value — the
 	// ingress ifindex on the SESSION_CLOSE frame since #2615. Placed before
 	// the post-NAT tuple so the latter stays the trailing block (#2526
 	// invariant).
-	{ipfixIngressInterface, 4},
+	{ipfixIngressInterface, 4, 0},
 	// #2749: class-of-service + egress interface re-introduced with REAL
 	// values from the extended SESSION_CLOSE frame ([144:152]).
 	// ipClassOfService (IE 5, 1B) = forward DSCP<<2; tcpControlBits (IE 6, 2B,
@@ -110,43 +138,56 @@ var ipfixTemplateV4 = []ipfixField{
 	// tuple so the latter stays the trailing block (#2526). #3270: flowDirection
 	// (IE 61) is spliced in here by ipfixTemplateFieldsV4 when flow-dir is
 	// enabled; it is NOT in this base slice.
-	{ipfixIPClassOfService, 1},
-	{ipfixTCPControlBits, 2},
-	{ipfixEgressInterface, 4},
+	{ipfixIPClassOfService, 1, 0},
+	{ipfixTCPControlBits, 2, 0},
+	{ipfixEgressInterface, 4, 0},
+	// #3746: RFC 5103 biflow reverse counters (enterprise PEN 29305, 8B each).
+	// reversePacketDeltaCount (IE 2) then reverseOctetDeltaCount (IE 1),
+	// mirroring the forward packets-then-bytes layout above. Placed after the
+	// forward CoS/egress block and before the post-NAT trailing block so #2526
+	// keeps the post-NAT tuple last. These are the first enterprise IEs in the
+	// template, so each occupies an 8-byte field specifier in the Template Set.
+	{ipfixReversePacketDeltaCount, 8, ipfixReversePEN},
+	{ipfixReverseOctetDeltaCount, 8, ipfixReversePEN},
 	// #2526: post-NAT (translated) tuple, appended last.
-	{ipfixPostNatSourceIPv4Address, 4},
-	{ipfixPostNatDestinationIPv4Address, 4},
-	{ipfixPostNapatSourceTransportPort, 2},
-	{ipfixPostNapatDestTransportPort, 2},
+	{ipfixPostNatSourceIPv4Address, 4, 0},
+	{ipfixPostNatDestinationIPv4Address, 4, 0},
+	{ipfixPostNapatSourceTransportPort, 2, 0},
+	{ipfixPostNapatDestTransportPort, 2, 0},
 }
 
 // ipfixTemplateV6 defines the IPv6 IPFIX template fields.
 var ipfixTemplateV6 = []ipfixField{
-	{ipfixSourceIPv6Address, 16},
-	{ipfixDestinationIPv6Address, 16},
-	{ipfixSourceTransportPort, 2},
-	{ipfixDestinationTransportPort, 2},
-	{ipfixProtocolIdentifier, 1},
-	{ipfixPacketDeltaCount, 8},
-	{ipfixOctetDeltaCount, 8},
-	{ipfixFlowStartMilliseconds, 8},
-	{ipfixFlowEndMilliseconds, 8},
+	{ipfixSourceIPv6Address, 16, 0},
+	{ipfixDestinationIPv6Address, 16, 0},
+	{ipfixSourceTransportPort, 2, 0},
+	{ipfixDestinationTransportPort, 2, 0},
+	{ipfixProtocolIdentifier, 1, 0},
+	{ipfixPacketDeltaCount, 8, 0},
+	{ipfixOctetDeltaCount, 8, 0},
+	{ipfixFlowStartMilliseconds, 8, 0},
+	{ipfixFlowEndMilliseconds, 8, 0},
 	// #2866: src/dst route prefix lengths (IPv6 variants IE 29 / IE 30).
-	{ipfixSourceIPv6PrefixLength, 1},
-	{ipfixDestIPv6PrefixLength, 1},
+	{ipfixSourceIPv6PrefixLength, 1, 0},
+	{ipfixDestIPv6PrefixLength, 1, 0},
 	// #2749: ingressInterface (IE 10) — see the V4 template note.
-	{ipfixIngressInterface, 4},
+	{ipfixIngressInterface, 4, 0},
 	// #2749: ipClassOfService (IE 5) / tcpControlBits (IE 6) / egressInterface
 	// (IE 14) — see the V4 template note.
-	{ipfixIPClassOfService, 1},
-	{ipfixTCPControlBits, 2},
-	{ipfixEgressInterface, 4},
+	{ipfixIPClassOfService, 1, 0},
+	{ipfixTCPControlBits, 2, 0},
+	{ipfixEgressInterface, 4, 0},
+	// #3746: RFC 5103 biflow reverse counters (PEN 29305, 8B each) — see the
+	// V4 template note. Family-agnostic; the same IEs precede the post-NAT
+	// trailer here.
+	{ipfixReversePacketDeltaCount, 8, ipfixReversePEN},
+	{ipfixReverseOctetDeltaCount, 8, ipfixReversePEN},
 	// #2526: post-NAT (translated) tuple, appended last. v6 addresses use the
 	// 16-byte RFC 8158 elements; ports reuse the family-agnostic 227/228.
-	{ipfixPostNatSourceIPv6Address, 16},
-	{ipfixPostNatDestinationIPv6Address, 16},
-	{ipfixPostNapatSourceTransportPort, 2},
-	{ipfixPostNapatDestTransportPort, 2},
+	{ipfixPostNatSourceIPv6Address, 16, 0},
+	{ipfixPostNatDestinationIPv6Address, 16, 0},
+	{ipfixPostNapatSourceTransportPort, 2, 0},
+	{ipfixPostNapatDestTransportPort, 2, 0},
 }
 
 // ipfixRecordSizeV4 is the byte size of a single IPv4 IPFIX data record.
@@ -155,9 +196,12 @@ var ipfixTemplateV6 = []ipfixField{
 // (4+4+2+2) = 12 → 57. #2749 re-added ingressInterface (IE 10, 4B) with a
 // real value → 61. #2866 added srcMask+dstMask (IE 9/13, 1B each) → 63.
 // #2749 re-added ipClassOfService(1)+tcpControlBits(2)+egressInterface(4) = 7
-// with real values → 70.
-// 4+4+2+2+1+8+8+8+8 + 1+1 + 4 + 1+2+4 + 4+4+2+2 = 70
-const ipfixRecordSizeV4 = 70
+// with real values → 70. #3746 added the RFC 5103 biflow reverse counters
+// (reversePacketDeltaCount + reverseOctetDeltaCount, 8B each) → 86. The
+// enterprise IEs are 8-byte DATA values (only their Template Set field
+// specifiers are wider).
+// 4+4+2+2+1+8+8+8+8 + 1+1 + 4 + 1+2+4 + 8+8 + 4+4+2+2 = 86
+const ipfixRecordSizeV4 = 86
 
 // ipfixRecordSizeV6 is the byte size of a single IPv6 IPFIX data record.
 // #2613 dropped the same 12 unpopulated bytes from the former 117. pre-NAT
@@ -165,9 +209,10 @@ const ipfixRecordSizeV4 = 70
 // ingressInterface (IE 10, 4B) with a real value → 109. #2866 added the IPv6
 // srcMask+dstMask (IE 29/30, 1B each) → 111.
 // #2749 re-added ipClassOfService(1)+tcpControlBits(2)+egressInterface(4) = 7
-// with real values → 118.
-// 16+16+2+2+1+8+8+8+8 + 1+1 + 4 + 1+2+4 + 16+16+2+2 = 118
-const ipfixRecordSizeV6 = 118
+// with real values → 118. #3746 added the RFC 5103 biflow reverse counters
+// (8B each) → 134.
+// 16+16+2+2+1+8+8+8+8 + 1+1 + 4 + 1+2+4 + 8+8 + 16+16+2+2 = 134
+const ipfixRecordSizeV6 = 134
 
 // ipfixRecordSizeV4 / V6 must equal the sum of their (base) template field
 // lengths. A drift between the template (what the collector parses) and the
@@ -203,9 +248,45 @@ func ipfixSpliceFlowDir(base []ipfixField) []ipfixField {
 	}
 	out := make([]ipfixField, 0, len(base)+1)
 	out = append(out, base[:idx]...)
-	out = append(out, ipfixField{ipfixFlowDirection, 1})
+	out = append(out, ipfixField{ipfixFlowDirection, 1, 0})
 	out = append(out, base[idx:]...)
 	return out
+}
+
+// ipfixFieldSpecLen returns the encoded Template Set field-specifier width for
+// f: 8 bytes for an enterprise IE (elementID|0x8000, length, 4-byte PEN;
+// RFC 7011 §3.2), 4 bytes for a standard IANA IE. Note this is the TEMPLATE
+// specifier width, not the DATA record value length (which is f.length in both
+// cases) — #3746.
+func ipfixFieldSpecLen(f ipfixField) int {
+	if f.enterprise != 0 {
+		return 8
+	}
+	return 4
+}
+
+// ipfixFieldSpecsLen sums the Template Set field-specifier widths of fs.
+func ipfixFieldSpecsLen(fs []ipfixField) int {
+	n := 0
+	for _, f := range fs {
+		n += ipfixFieldSpecLen(f)
+	}
+	return n
+}
+
+// encodeIPFIXFieldSpec writes f's Template Set field specifier at b[off:] and
+// returns the next offset. An enterprise IE (RFC 7011 §3.2) sets the top bit of
+// the Information Element identifier and appends the 4-byte PEN (#3746).
+func encodeIPFIXFieldSpec(b []byte, off int, f ipfixField) int {
+	if f.enterprise != 0 {
+		binary.BigEndian.PutUint16(b[off:off+2], f.elementID|ipfixEnterpriseBit)
+		binary.BigEndian.PutUint16(b[off+2:off+4], f.length)
+		binary.BigEndian.PutUint32(b[off+4:off+8], f.enterprise)
+		return off + 8
+	}
+	binary.BigEndian.PutUint16(b[off:off+2], f.elementID)
+	binary.BigEndian.PutUint16(b[off+2:off+4], f.length)
+	return off + 4
 }
 
 // ipfixTemplateFieldsV4 returns the IPv4 IPFIX template fields, splicing in
@@ -276,8 +357,11 @@ func encodeIPFIXTemplateSet() []byte {
 func encodeIPFIXTemplateSetDir(includeDir bool) []byte {
 	v4 := ipfixTemplateFieldsV4(includeDir)
 	v6 := ipfixTemplateFieldsV6(includeDir)
-	// Set header (4 bytes) + 2 template record headers (4 each) + field specifiers (4 each)
-	totalLen := 4 + (4 + len(v4)*4) + (4 + len(v6)*4)
+	// Set header (4 bytes) + 2 template record headers (4 each) + field
+	// specifiers (4 bytes each IANA IE, 8 bytes each enterprise IE — #3746).
+	// The template record header carries the FIELD COUNT (len), which is
+	// unchanged; only the per-specifier byte width differs.
+	totalLen := 4 + (4 + ipfixFieldSpecsLen(v4)) + (4 + ipfixFieldSpecsLen(v6))
 
 	b := make([]byte, totalLen)
 	off := 0
@@ -292,9 +376,7 @@ func encodeIPFIXTemplateSetDir(includeDir bool) []byte {
 	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(len(v4)))
 	off += 4
 	for _, f := range v4 {
-		binary.BigEndian.PutUint16(b[off:off+2], f.elementID) // no enterprise bit
-		binary.BigEndian.PutUint16(b[off+2:off+4], f.length)
-		off += 4
+		off = encodeIPFIXFieldSpec(b, off, f)
 	}
 
 	// IPv6 template record header
@@ -302,9 +384,7 @@ func encodeIPFIXTemplateSetDir(includeDir bool) []byte {
 	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(len(v6)))
 	off += 4
 	for _, f := range v6 {
-		binary.BigEndian.PutUint16(b[off:off+2], f.elementID)
-		binary.BigEndian.PutUint16(b[off+2:off+4], f.length)
-		off += 4
+		off = encodeIPFIXFieldSpec(b, off, f)
 	}
 
 	return b
@@ -408,6 +488,15 @@ func encodeIPFIXRecordV4(b []byte, off int, r FlowRecord, includeDir bool) int {
 	off += 2
 	binary.BigEndian.PutUint32(b[off:off+4], r.OutIf)
 	off += 4
+	// #3746: RFC 5103 biflow reverse counters (PEN 29305) — 8-byte unsigned64
+	// DATA values (the enterprise bit + PEN live only in the Template Set).
+	// reversePacketDeltaCount (IE 2) then reverseOctetDeltaCount (IE 1), matching
+	// the template order. Written before the flow-dir byte so the base and
+	// flow-dir templates both agree with the encoder.
+	binary.BigEndian.PutUint64(b[off:off+8], r.RevPackets)
+	off += 8
+	binary.BigEndian.PutUint64(b[off:off+8], r.RevBytes)
+	off += 8
 	// #3270: flowDirection (IE 61, unsigned8) — 0 ingress / 1 egress, derived
 	// from the per-zone sampling-direction. Written only when the template
 	// advertises it (includeDir), before the post-NAT trailer.
@@ -479,6 +568,12 @@ func encodeIPFIXRecordV6(b []byte, off int, r FlowRecord, includeDir bool) int {
 	off += 2
 	binary.BigEndian.PutUint32(b[off:off+4], r.OutIf)
 	off += 4
+	// #3746: RFC 5103 biflow reverse counters (PEN 29305) — see
+	// encodeIPFIXRecordV4.
+	binary.BigEndian.PutUint64(b[off:off+8], r.RevPackets)
+	off += 8
+	binary.BigEndian.PutUint64(b[off:off+8], r.RevBytes)
+	off += 8
 	// #3270: flowDirection (IE 61, unsigned8) — see encodeIPFIXRecordV4.
 	if includeDir {
 		b[off] = r.Direction
@@ -608,13 +703,20 @@ func (e *IPFIXExporter) ExportSessionClose(rec logging.EventRecord, evt SessionC
 		e.routeMaskUnresolved.Add(maskMisses)
 	}
 	fr := FlowRecord{
-		SrcIP:      evt.SrcIP,
-		DstIP:      evt.DstIP,
-		SrcPort:    evt.SrcPort,
-		DstPort:    evt.DstPort,
-		Protocol:   evt.Protocol,
-		Packets:    rec.SessionPkts,
-		Bytes:      rec.SessionBytes,
+		SrcIP:    evt.SrcIP,
+		DstIP:    evt.DstIP,
+		SrcPort:  evt.SrcPort,
+		DstPort:  evt.DstPort,
+		Protocol: evt.Protocol,
+		Packets:  rec.SessionPkts,
+		Bytes:    rec.SessionBytes,
+		// #3746: RFC 5103 biflow reverse (server→client) volume. Since #2501
+		// the SESSION_CLOSE frame carries the reverse counters (decoded to
+		// rec.RevSessionPkts/RevSessionBytes); they are encoded as the reverse
+		// IPFIX IEs (PEN 29305). Already in scope here — no SessionCloseData
+		// plumbing needed.
+		RevPackets: rec.RevSessionPkts,
+		RevBytes:   rec.RevSessionBytes,
 		StartTime:  startTime,
 		EndTime:    rec.Time,
 		IsIPv6:     evt.IsIPv6,

--- a/pkg/flowexport/ipfix_biflow_test.go
+++ b/pkg/flowexport/ipfix_biflow_test.go
@@ -1,0 +1,302 @@
+package flowexport
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// #3746 fail-on-revert pins for the RFC 5103 biflow reverse Information
+// Elements now exported by the IPFIX encoder: reverseOctetDeltaCount (IE 1)
+// and reversePacketDeltaCount (IE 2), both under the reverse Private Enterprise
+// Number 29305.
+//
+// These tests decode the emitted Template Set and Data Record off the wire and
+// assert:
+//   - the two reverse IEs appear in BOTH the v4 and v6 templates with the
+//     enterprise bit set, PEN 29305, and length 8 (an enterprise field
+//     specifier is 8 bytes, not 4);
+//   - the Template Set header length equals the bytes actually consumed by the
+//     walk (an off-by-one in the 8-byte enterprise-specifier sizing would drift
+//     the set length and corrupt every following template);
+//   - the encoded Data Record carries the reverse packet/byte counts as 8-byte
+//     unsigned64 values at the reverse IEs' data offset.
+//
+// Reverting the reverse IEs (removing them from the template AND the encoder)
+// flips these RED: the templateEnterpriseIEs walk finds no PEN-29305 fields and
+// the data round-trip reads the wrong bytes / a shorter record.
+
+// The reverse element IDs and PEN, asserted as literals independent of the
+// package constants so a typo'd constant cannot make the test agree with itself.
+const (
+	wantReverseOctetIE  uint16 = 1
+	wantReversePacketIE uint16 = 2
+	wantReversePEN      uint32 = 29305
+)
+
+// ipfixSpec is one decoded Template Set field specifier.
+type ipfixSpec struct {
+	elementID  uint16
+	length     uint16
+	enterprise uint32 // 0 for an IANA IE
+}
+
+// decodeTemplateRecords walks an encoded IPFIX Template Set and returns, per
+// template record, the template ID and its field specifiers. It fully handles
+// the 4-byte IANA vs 8-byte enterprise (RFC 7011 §3.2) specifier widths and
+// fails the test on any length drift, which is the load-bearing integrity check
+// for the enterprise-specifier sizing.
+func decodeTemplateRecords(t *testing.T, ts []byte) map[uint16][]ipfixSpec {
+	t.Helper()
+	if len(ts) < 4 {
+		t.Fatalf("template set too short: %d bytes", len(ts))
+	}
+	setID := binary.BigEndian.Uint16(ts[0:2])
+	if setID != ipfixSetIDTemplate {
+		t.Fatalf("set ID = %d, want %d (template set)", setID, ipfixSetIDTemplate)
+	}
+	setLen := int(binary.BigEndian.Uint16(ts[2:4]))
+	if setLen != len(ts) {
+		t.Fatalf("template set header length = %d, want %d (encoded length) — enterprise specifier sizing drift", setLen, len(ts))
+	}
+
+	out := make(map[uint16][]ipfixSpec)
+	off := 4
+	for off+4 <= len(ts) {
+		tmplID := binary.BigEndian.Uint16(ts[off : off+2])
+		count := int(binary.BigEndian.Uint16(ts[off+2 : off+4]))
+		off += 4
+		specs := make([]ipfixSpec, 0, count)
+		for i := 0; i < count; i++ {
+			if off+4 > len(ts) {
+				t.Fatalf("template %d: ran off the end at field %d/%d (specifier width drift)", tmplID, i, count)
+			}
+			raw := binary.BigEndian.Uint16(ts[off : off+2])
+			length := binary.BigEndian.Uint16(ts[off+2 : off+4])
+			off += 4
+			var pen uint32
+			if raw&0x8000 != 0 {
+				if off+4 > len(ts) {
+					t.Fatalf("template %d: enterprise field missing PEN", tmplID)
+				}
+				pen = binary.BigEndian.Uint32(ts[off : off+4])
+				off += 4
+			}
+			specs = append(specs, ipfixSpec{elementID: raw & 0x7fff, length: length, enterprise: pen})
+		}
+		out[tmplID] = specs
+	}
+	if off != len(ts) {
+		t.Fatalf("template walk consumed %d bytes, set is %d — specifier width drift", off, len(ts))
+	}
+	return out
+}
+
+// findSpec returns the specifier with the given (elementID, enterprise), which
+// is required because a reverse IE reuses the forward IE's element ID (IE 1 / 2)
+// and is distinguished ONLY by the enterprise PEN.
+func findSpec(specs []ipfixSpec, elementID uint16, enterprise uint32) (ipfixSpec, bool) {
+	for _, s := range specs {
+		if s.elementID == elementID && s.enterprise == enterprise {
+			return s, true
+		}
+	}
+	return ipfixSpec{}, false
+}
+
+// TestIPFIXTemplateCarriesBiflowReverseIEs decodes both the base template and
+// the flow-dir template and asserts the two reverse IEs are advertised as
+// enterprise fields under PEN 29305.
+func TestIPFIXTemplateCarriesBiflowReverseIEs(t *testing.T) {
+	for _, includeDir := range []bool{false, true} {
+		ts := encodeIPFIXTemplateSetDir(includeDir)
+		tmpls := decodeTemplateRecords(t, ts)
+
+		for _, tmplID := range []uint16{ipfixTemplateIDv4, ipfixTemplateIDv6} {
+			specs, ok := tmpls[tmplID]
+			if !ok {
+				t.Fatalf("includeDir=%v: template %d missing from set", includeDir, tmplID)
+			}
+			// reverseOctetDeltaCount (IE 1, PEN 29305, 8B).
+			if s, ok := findSpec(specs, wantReverseOctetIE, wantReversePEN); !ok {
+				t.Errorf("includeDir=%v tmpl %d: reverseOctetDeltaCount (IE %d, PEN %d) absent",
+					includeDir, tmplID, wantReverseOctetIE, wantReversePEN)
+			} else if s.length != 8 {
+				t.Errorf("includeDir=%v tmpl %d: reverseOctetDeltaCount length = %d, want 8", includeDir, tmplID, s.length)
+			}
+			// reversePacketDeltaCount (IE 2, PEN 29305, 8B).
+			if s, ok := findSpec(specs, wantReversePacketIE, wantReversePEN); !ok {
+				t.Errorf("includeDir=%v tmpl %d: reversePacketDeltaCount (IE %d, PEN %d) absent",
+					includeDir, tmplID, wantReversePacketIE, wantReversePEN)
+			} else if s.length != 8 {
+				t.Errorf("includeDir=%v tmpl %d: reversePacketDeltaCount length = %d, want 8", includeDir, tmplID, s.length)
+			}
+			// The forward octet/packet IEs (same element IDs, IANA) must still
+			// be present as NON-enterprise fields — the reverse IEs must not
+			// have displaced them.
+			if _, ok := findSpec(specs, ipfixOctetDeltaCount, 0); !ok {
+				t.Errorf("includeDir=%v tmpl %d: forward octetDeltaCount (IANA IE 1) missing", includeDir, tmplID)
+			}
+			if _, ok := findSpec(specs, ipfixPacketDeltaCount, 0); !ok {
+				t.Errorf("includeDir=%v tmpl %d: forward packetDeltaCount (IANA IE 2) missing", includeDir, tmplID)
+			}
+		}
+	}
+}
+
+// ipfixReverseDataOffset returns the byte offset of the reverse IE with the
+// given element ID within a DATA record body, walking the template by data
+// value length (f.length) and matching on the enterprise PEN.
+func ipfixReverseDataOffset(fields []ipfixField, elementID uint16) (int, bool) {
+	off := 0
+	for _, f := range fields {
+		if f.elementID == elementID && f.enterprise == ipfixReversePEN {
+			return off, true
+		}
+		off += int(f.length)
+	}
+	return 0, false
+}
+
+// TestIPFIXRecordCarriesBiflowReverseCounts encodes a record with distinct
+// reverse packet/byte sentinels (both > 2^32 to prove the full 8-byte u64
+// round-trip) and asserts they land at the reverse IEs' data offset.
+func TestIPFIXRecordCarriesBiflowReverseCounts(t *testing.T) {
+	const (
+		revPkts  uint64 = 0x0000_00AA_BBCC_DDEE // 733007751150
+		revBytes uint64 = 0x1122_3344_5566_7788
+	)
+	now := time.Unix(1_700_000_000, 0)
+	for _, tc := range []struct {
+		name   string
+		v6     bool
+		fields []ipfixField
+	}{
+		{"v4", false, ipfixTemplateV4},
+		{"v6", true, ipfixTemplateV6},
+	} {
+		rec := FlowRecord{
+			SrcPort: 40000, DstPort: 80, Protocol: 6,
+			Packets: 10, Bytes: 5000,
+			RevPackets: revPkts, RevBytes: revBytes,
+			StartTime: now, EndTime: now, IsIPv6: tc.v6,
+		}
+		if tc.v6 {
+			rec.SrcIP = net.ParseIP("fd00::1")
+			rec.DstIP = net.ParseIP("2001:db8::200")
+		} else {
+			rec.SrcIP = net.IPv4(10, 0, 1, 100)
+			rec.DstIP = net.IPv4(172, 16, 80, 200)
+		}
+		rec.NATSrcIP = rec.SrcIP
+		rec.NATDstIP = rec.DstIP
+
+		pktOff, ok := ipfixReverseDataOffset(tc.fields, ipfixReversePacketDeltaCount)
+		if !ok {
+			t.Fatalf("%s: template missing reversePacketDeltaCount", tc.name)
+		}
+		octOff, ok := ipfixReverseDataOffset(tc.fields, ipfixReverseOctetDeltaCount)
+		if !ok {
+			t.Fatalf("%s: template missing reverseOctetDeltaCount", tc.name)
+		}
+
+		ds := encodeIPFIXDataSet([]FlowRecord{rec})
+		// 4-byte set header precedes the record body.
+		if gotPkts := binary.BigEndian.Uint64(ds[4+pktOff : 4+pktOff+8]); gotPkts != revPkts {
+			t.Errorf("%s: encoded reversePacketDeltaCount = %#x, want %#x (encoder write reverted)", tc.name, gotPkts, revPkts)
+		}
+		if gotBytes := binary.BigEndian.Uint64(ds[4+octOff : 4+octOff+8]); gotBytes != revBytes {
+			t.Errorf("%s: encoded reverseOctetDeltaCount = %#x, want %#x (encoder write reverted)", tc.name, gotBytes, revBytes)
+		}
+	}
+}
+
+// TestIPFIXExportSessionCloseWiresReverseCounts pins the ExportSessionClose
+// plumbing: the reverse counters on the SESSION_CLOSE EventRecord
+// (rec.RevSessionPkts / rec.RevSessionBytes, produced since #2501) must reach
+// the FlowRecord the exporter batches. Reverting the RevPackets/RevBytes
+// assignment leaves them 0.
+func TestIPFIXExportSessionCloseWiresReverseCounts(t *testing.T) {
+	rec, sd := closeRecordForMask(false)
+	rec.RevSessionPkts = 4242
+	rec.RevSessionBytes = 9_000_000
+
+	var e IPFIXExporter
+	e.ExportSessionClose(rec, sd)
+	v4recs, _ := e.batch.drain()
+	if len(v4recs) != 1 {
+		t.Fatalf("drained %d records, want 1", len(v4recs))
+	}
+	if v4recs[0].RevPackets != 4242 || v4recs[0].RevBytes != 9_000_000 {
+		t.Fatalf("FlowRecord reverse = pkts %d / bytes %d, want 4242 / 9000000 (ExportSessionClose plumbing reverted)",
+			v4recs[0].RevPackets, v4recs[0].RevBytes)
+	}
+}
+
+// TestIPFIXBiflowReverseWireLoopback exercises the full exporter wire path
+// (NewIPFIXExporter -> sendTemplates / sendRecords) over a loopback UDP
+// collector, mirroring the #2609 sequence-number harness, and asserts the
+// reverse IEs survive on the real wire in BOTH the template and the data
+// record.
+func TestIPFIXBiflowReverseWireLoopback(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	defer pc.Close()
+
+	ec := &ExportConfig{Collectors: []CollectorConfig{{Address: pc.LocalAddr().String()}}}
+	e, err := NewIPFIXExporter(ec)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	defer e.Close()
+
+	readPkt := func() []byte {
+		buf := make([]byte, 4096)
+		if err := pc.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		n, _, err := pc.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("collector read: %v", err)
+		}
+		return buf[:n]
+	}
+
+	// 1) Template packet: 16-byte IPFIX header precedes the template set.
+	e.sendTemplates()
+	tpkt := readPkt()
+	if len(tpkt) < 16 {
+		t.Fatalf("short template packet: %d bytes", len(tpkt))
+	}
+	tmpls := decodeTemplateRecords(t, tpkt[16:])
+	specs := tmpls[ipfixTemplateIDv4]
+	if _, ok := findSpec(specs, wantReverseOctetIE, wantReversePEN); !ok {
+		t.Error("wire template: reverseOctetDeltaCount (PEN 29305) absent")
+	}
+	if _, ok := findSpec(specs, wantReversePacketIE, wantReversePEN); !ok {
+		t.Error("wire template: reversePacketDeltaCount (PEN 29305) absent")
+	}
+
+	// 2) Data packet: reverse counts round-trip on the real wire.
+	const revPkts, revBytes uint64 = 0xAABBCCDD, 0x1_0000_0002
+	e.sendRecords([]FlowRecord{{
+		SrcIP: net.IPv4(10, 0, 0, 1), DstIP: net.IPv4(10, 0, 0, 2),
+		SrcPort: 1000, DstPort: 80, Protocol: 6,
+		Packets: 3, Bytes: 300, RevPackets: revPkts, RevBytes: revBytes,
+		StartTime: time.Now(), EndTime: time.Now(),
+	}})
+	dpkt := readPkt()
+	// 16-byte IPFIX header + 4-byte set header precede the record body.
+	body := dpkt[16+4:]
+	pktOff, _ := ipfixReverseDataOffset(ipfixTemplateV4, ipfixReversePacketDeltaCount)
+	octOff, _ := ipfixReverseDataOffset(ipfixTemplateV4, ipfixReverseOctetDeltaCount)
+	if got := binary.BigEndian.Uint64(body[pktOff : pktOff+8]); got != revPkts {
+		t.Errorf("wire reversePacketDeltaCount = %#x, want %#x", got, revPkts)
+	}
+	if got := binary.BigEndian.Uint64(body[octOff : octOff+8]); got != revBytes {
+		t.Errorf("wire reverseOctetDeltaCount = %#x, want %#x", got, revBytes)
+	}
+}

--- a/pkg/flowexport/manager.go
+++ b/pkg/flowexport/manager.go
@@ -731,11 +731,18 @@ type FlowRecord struct {
 	OutIf     uint32
 	Packets   uint64
 	Bytes     uint64
-	StartTime time.Time
-	EndTime   time.Time
-	SrcMask   uint8
-	DstMask   uint8
-	IsIPv6    bool
+	// #3746: RFC 5103 biflow reverse (server→client) volume. Encoded ONLY by
+	// the IPFIX exporter as the reverse Information Elements
+	// reversePacketDeltaCount / reverseOctetDeltaCount under PEN 29305; NetFlow
+	// v9 has no standard reverse element and leaves these unused (v9 exports the
+	// initiator-direction volume only — see pkg/flowexport/README.md).
+	RevPackets uint64
+	RevBytes   uint64
+	StartTime  time.Time
+	EndTime    time.Time
+	SrcMask    uint8
+	DstMask    uint8
+	IsIPv6     bool
 	// #2526: post-NAT (translated) tuple — RFC 5103 / RFC 8158. These are
 	// ALWAYS populated by ExportSessionClose: when the flow carried no NAT
 	// the converter copies the pre-NAT tuple here (post == pre), matching

--- a/pkg/flowexport/postnat_test.go
+++ b/pkg/flowexport/postnat_test.go
@@ -34,10 +34,10 @@ func TestIPFIXTemplateV4_PostNATFields(t *testing.T) {
 	n := len(ipfixTemplateV4)
 	got := ipfixTemplateV4[n-4:]
 	want := []ipfixField{
-		{wantElemPostNatSrcIPv4, 4},
-		{wantElemPostNatDstIPv4, 4},
-		{wantElemPostNapatSrc, 2},
-		{wantElemPostNapatDst, 2},
+		{wantElemPostNatSrcIPv4, 4, 0},
+		{wantElemPostNatDstIPv4, 4, 0},
+		{wantElemPostNapatSrc, 2, 0},
+		{wantElemPostNapatDst, 2, 0},
 	}
 	for i := range want {
 		if got[i] != want[i] {
@@ -52,8 +52,8 @@ func TestIPFIXTemplateV4_PostNATFields(t *testing.T) {
 	if sum != ipfixRecordSizeV4 {
 		t.Fatalf("ipfixRecordSizeV4 = %d, want sum(template) = %d", ipfixRecordSizeV4, sum)
 	}
-	if ipfixRecordSizeV4 != 70 {
-		t.Fatalf("ipfixRecordSizeV4 = %d, want 70 (pre-NAT 45 + 2 src/dst mask (#2866) + 4 ingressInterface (#2749) + 7 CoS/egress (#2749: ipClassOfService 1 + tcpControlBits 2 + egressInterface 4) + 12 post-NAT)", ipfixRecordSizeV4)
+	if ipfixRecordSizeV4 != 86 {
+		t.Fatalf("ipfixRecordSizeV4 = %d, want 86 (pre-NAT 45 + 2 src/dst mask (#2866) + 4 ingressInterface (#2749) + 7 CoS/egress (#2749: ipClassOfService 1 + tcpControlBits 2 + egressInterface 4) + 16 biflow reverse (#3746) + 12 post-NAT)", ipfixRecordSizeV4)
 	}
 }
 
@@ -61,10 +61,10 @@ func TestIPFIXTemplateV6_PostNATFields(t *testing.T) {
 	n := len(ipfixTemplateV6)
 	got := ipfixTemplateV6[n-4:]
 	want := []ipfixField{
-		{wantElemPostNatSrcIPv6, 16},
-		{wantElemPostNatDstIPv6, 16},
-		{wantElemPostNapatSrc, 2},
-		{wantElemPostNapatDst, 2},
+		{wantElemPostNatSrcIPv6, 16, 0},
+		{wantElemPostNatDstIPv6, 16, 0},
+		{wantElemPostNapatSrc, 2, 0},
+		{wantElemPostNapatDst, 2, 0},
 	}
 	for i := range want {
 		if got[i] != want[i] {
@@ -78,8 +78,8 @@ func TestIPFIXTemplateV6_PostNATFields(t *testing.T) {
 	if sum != ipfixRecordSizeV6 {
 		t.Fatalf("ipfixRecordSizeV6 = %d, want sum(template) = %d", ipfixRecordSizeV6, sum)
 	}
-	if ipfixRecordSizeV6 != 118 {
-		t.Fatalf("ipfixRecordSizeV6 = %d, want 118 (pre-NAT 69 + 2 src/dst mask (#2866) + 4 ingressInterface (#2749) + 7 CoS/egress (#2749) + 36 post-NAT)", ipfixRecordSizeV6)
+	if ipfixRecordSizeV6 != 134 {
+		t.Fatalf("ipfixRecordSizeV6 = %d, want 134 (pre-NAT 69 + 2 src/dst mask (#2866) + 4 ingressInterface (#2749) + 7 CoS/egress (#2749) + 16 biflow reverse (#3746) + 36 post-NAT)", ipfixRecordSizeV6)
 	}
 }
 


### PR DESCRIPTION
Closes #3746

## Summary

The reverse (server->client) session byte/packet counters have been
produced end-to-end since #2501 and are in scope at IPFIX export time
(decoded to `EventRecord.RevSessionPkts` / `.RevSessionBytes`), but the
`FlowRecord` build wired only the forward counts — so collectors
systematically under-reported the larger half of an asymmetric
bi-directional flow.

**IPFIX biflow: done.** Encode the reverse volume as the RFC 5103 biflow
reverse Information Elements `reverseOctetDeltaCount` (IE 1) and
`reversePacketDeltaCount` (IE 2), both under the reverse Private
Enterprise Number **29305** (Option A of the converged /research plan).

**NetFlow v9 reverse: deferred.** v9 has no standard reverse element and
no enterprise/PEN namespace, and the two non-standard alternatives each
break a deliberate design choice (second-record breaks the
one-record-per-session / initiator-anchor #3270 relies on and is
low-fidelity; summing corrupts `octetDeltaCount` per-direction
semantics). v9 exports the initiator-direction volume only; use IPFIX for
bidirectional accounting. Documented in the README.

## Enterprise-IE template change (first in the codebase)

- `ipfixField` gains an `enterprise uint32` column (0 = IANA, unchanged).
- The Template Set encoder sizes an enterprise field specifier at **8
  bytes** (elementID with the `0x8000` enterprise bit + a 4-byte PEN,
  RFC 7011 §3.2) while IANA specifiers stay 4 bytes
  (`ipfixFieldSpecsLen` / `encodeIPFIXFieldSpec`); the field **count** in
  the template record header is unchanged.
- The Data Record encodes the reverse counts as plain 8-byte u64, so the
  record grows 16 bytes: **v4 70→86, v6 118→134** (with flow-dir 87/135).
- Reverse IEs spliced after the forward CoS/egress block and before the
  post-NAT trailer, so the #2526 post-NAT tuple stays last and the #3270
  `flowDirection` byte still sits just before it.
- Template IDs **256/257 reused** (content grows once, like
  #2526/#2749/#2866); a collector re-learns on the next refresh and an
  unknown-PEN collector skips the field via the template-declared length
  (RFC 7011 §8) — backward-safe. #3740 SourceID/ODID and #2609
  sequence-across-refresh are untouched (still one record per session).
- `FlowRecord` gains `RevPackets`/`RevBytes`; `ExportSessionClose` sets
  them from `rec.RevSessionPkts` / `.RevSessionBytes` (already in scope,
  no `SessionCloseData` plumbing). Always-present, like the #2526
  post-NAT tuple.

## Tests (RED-on-revert verified)

`ipfix_biflow_test.go`:
- **TestIPFIXTemplateCarriesBiflowReverseIEs** — full Template Set decode
  (handling 4-byte IANA vs 8-byte enterprise specifiers); asserts both
  reverse IEs carry the enterprise bit + PEN 29305 + length 8 in the base
  AND flow-dir templates, the forward IANA IE 1/2 are still present, and
  the Template Set header length equals the bytes walked (catches an
  8-byte-specifier off-by-one).
- **TestIPFIXRecordCarriesBiflowReverseCounts** — round-trips >2^32
  reverse sentinels at the reverse IEs' data offset (matched on PEN,
  since IE 1/2 collide with the forward counters).
- **TestIPFIXExportSessionCloseWiresReverseCounts** — the
  `EventRecord` → `FlowRecord` plumbing.
- **TestIPFIXBiflowReverseWireLoopback** — the real exporter UDP wire
  path.

Removing the reverse IEs flips all four RED (confirmed). Also updated the
enterprise-aware Template-Set walkers in `dropped_fields_test.go` /
`flowdir_test.go` and the record-size pins in `postnat_test.go` /
`flowdir_test.go`.

## Validation

`go test ./pkg/flowexport/...` green; `go build ./...`; `gofmt` + `go vet`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
