### PR TITLE
flowexport: advertise IPFIX 1-in-N sampling via Options Template (#3748b)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-01 — #3748 (sub-part b): IPFIX sampler Options Template + record
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The IPFIX exporter never advertised its 1-in-N sampling
+    rate: `ipfixSetIDOptionsTemplate` (Set ID 3) was a bare constant and
+    `sendTemplates` emitted DATA templates (256/257) only, so a collector
+    could not learn N to scale the sampled record count. Added a sampler
+    Options Template (Set ID 3, template ID 258) + Options Data Record (Set
+    ID 258) advertising PSAMP systematic count-based sampling
+    (`selectorAlgorithm`=1 IE 304, `samplingPacketInterval`=1 IE 305,
+    `samplingPacketSpace`=N-1 IE 306), scoped by `observationDomainId` (IE
+    149) = the group's #3740 stable ODID. `sendTemplates` now emits the
+    options message on the SAME refresh cadence for sampled groups
+    (`SamplingRate > 1`, matching the `ShouldExport` gate); unsampled /
+    export-all groups (rate 0/1) advertise nothing (collector assumes
+    1-in-1), keeping the #2609 refresh sequence bit-identical there. The
+    Options Data Record rides a Set ID ≥ 256 so it advances the header
+    Sequence Number by one (RFC 7011 §3.1), consistent with `sendRecords`
+    and the #2609 convention. Documented the semantic nuance: xpf samples
+    1-in-N at SESSION-RECORD granularity (per SESSION_CLOSE), NOT 1-in-N
+    packets like Junos jflow — a collector scales the record COUNT by N but
+    must NOT multiply per-record `octetDeltaCount` (which is already the full
+    per-session volume). Sub-part (a) active-timeout interim records is
+    DEFERRED per the converged /research plan (multi-surface Rust+Go+wire+HA,
+    test-failover-gated).
+  - **File(s)**: pkg/flowexport/ipfix.go (new IE/set constants, options
+    template + data encoders, `ipfixOptionsSamplerRecordSize` build-time pin,
+    exporter `emitSampler`/`optionsTemplateSet`/`optionsDataSet`,
+    `sendSamplerOptions`), pkg/flowexport/ipfix_sampler_test.go (new: decode +
+    wire-loopback + degenerate-rate + RED-on-revert), pkg/flowexport/README.md,
+    docs/feature-coverage.md, _Log.md.
+  - **Validation**: `go test ./pkg/flowexport/...` green (existing + 4 new
+    tests); `go build ./...`, `gofmt -l`, `go vet ./pkg/flowexport/` clean.
+    RED-on-revert proven: disabling the `sendSamplerOptions` call times out
+    the wire-loopback message-2 read.
+
 ## 2026-07-01 — #3776: flow-cache invalidation on session reap (incomplete #2220 closure)
 
 - **Timestamp**: 2026-07-01

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -137,7 +137,14 @@ the userspace dataplane admission boundary is in
 
 - **Syslog**: facility/severity/category filtering, structured RT_FLOW
   format, TCP/TLS transport, event mode local file.
-- **NetFlow v9 / IPFIX**: 1-in-N sampling, per-collector write-health
+- **NetFlow v9 / IPFIX**: 1-in-N sampling (IPFIX advertises the rate to
+  collectors via a sampler Options Template — Set ID 3, template 258,
+  `selectorAlgorithm`/`samplingPacketInterval`/`samplingPacketSpace`, scoped by
+  the group's Observation Domain ID; #3748. Note: xpf samples 1-in-N at
+  session-record granularity, so a collector scales the record COUNT by N but
+  must not multiply per-record volume — each record carries the full
+  per-session byte/packet counts. Active-timeout interim records are deferred,
+  #3748 sub-part a), per-collector write-health
   (`show flow-monitoring statistics`, REST `/api/v1/services/flow-exporters`,
   `xpf_flow_export_collector_*` Prometheus metrics — a collector going
   unreachable surfaces write_failures + a state-change warn, #2464).

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -402,6 +402,74 @@ bidirectional accounting.** `FlowRecord.RevPackets`/`RevBytes` are populated
 for both exporters but consumed only by IPFIX. See the converged research plan
 on #3746.
 
+**#3748 (sub-part b) — IPFIX sampler Options Template + record.** Before
+#3748 `ipfixSetIDOptionsTemplate` (Set ID 3) was a bare constant: the IPFIX
+exporter emitted DATA templates (256/257) only and never advertised the
+sampling rate, so a collector receiving 1-in-N-sampled records could not
+learn N and could not scale the sampled record count. The exporter now emits,
+on the SAME template-refresh cadence, an **Options Template** (Set ID 3,
+template ID **258** — distinct from the 256/257 data IDs) and an **Options
+Data Record** (Set ID 258) carrying the sampling configuration as PSAMP
+systematic count-based sampling (RFC 5477 / IANA "IPFIX Entities"):
+
+| Field | IE | Len | Role | Value |
+|-------|----|----|------|-------|
+| `observationDomainId` | 149 | 4 | **scope** | the group's stable ODID (#3740) |
+| `selectorAlgorithm` | 304 | 2 | option | `1` (systematic count-based) |
+| `samplingPacketInterval` | 305 | 4 | option | `1` |
+| `samplingPacketSpace` | 306 | 4 | option | `N-1` |
+
+The record is scoped by `observationDomainId` (IE 149) — the group's #3740
+ODID, which also stamps the message header — so the sampling config binds to
+this observation domain. `encodeIPFIXOptionsTemplateSet` /
+`encodeIPFIXOptionsSamplerDataSet` build the two sets; `sendSamplerOptions`
+packages them into one IPFIX Message (template first, then its data record).
+The `ipfixOptionsSamplerRecordSize` (14) is pinned against the field slices at
+build time (same discipline as the #2526 data-record pins), so a
+template/encoder drift panics at init.
+
+**Emitted only for sampled groups (`SamplingRate > 1`).** This matches the
+`ShouldExport` gate exactly. An unsampled / export-all group (rate 0 or 1)
+advertises **nothing** — a collector then correctly assumes 1-in-1 — which
+also keeps the #2609 template-refresh sequence behaviour bit-identical for the
+common unsampled case. The Options Template and record are precomputed once at
+construction (`emitSampler` / `optionsTemplateSet` / `optionsDataSet`) since
+the rate and ODID are fixed per group.
+
+**Sequence-number accounting.** The Options Data Record rides a Set with ID
+≥ 256, so it is a **Data Record** and advances the header Sequence Number by
+one (RFC 7011 §3.1) — a sequence-tracking collector counts it, so skipping the
+increment would look like the loss #2609 fixed. `sendSamplerOptions` captures
+the current cumulative count for the message header, then increments, exactly
+as `sendRecords` does. The template-only data-template refresh still carries
+the cumulative count without advancing it (#2609 unchanged).
+
+**SEMANTIC NUANCE — record-granularity sampling, not packet sampling.** xpf
+samples **1-in-N at SESSION-RECORD granularity**: `ShouldExport` applies the
+modulo per SESSION_CLOSE event, NOT 1-in-N packets in the datapath the way
+Junos jflow does. Advertising interval=1 / space=N-1 lets a collector scale
+the sampled **record COUNT** by N (correct), but each exported record already
+carries the **full per-session** `octetDeltaCount` / `packetDeltaCount`, so a
+collector must **NOT** additionally multiply the per-record volume by N —
+doing so double-counts. This is documented on `sendSamplerOptions` too.
+
+Fail-on-revert pins in `ipfix_sampler_test.go`:
+`TestIPFIXOptionsTemplateSetDecode` (Set ID 3, template 258, one scope field =
+IE 149, option IEs 304/305/306 with correct lengths + set-length integrity),
+`TestIPFIXOptionsSamplerDataSetDecode` (interval=1 / space=N-1 across sampled
+and degenerate rates), `TestIPFIXSamplerOptionsWireLoopback` (the real
+exporter UDP path emits the options message after the data template, scope ==
+header ODID, rate = N-1, and the record advances the sequence by one), and
+`TestIPFIXSamplerOptionsAbsentWhenUnsampled` (rate 0/1 emit no options
+message). Removing the sampler emission flips these RED.
+
+**Sub-part (a) — active-timeout interim records — DEFERRED.** The related gap
+that a configured `flow-active-timeout` emits no interim records (long-lived
+flows under-report in-progress volume) is a separate, multi-surface
+Rust + Go + wire + HA change with a delta-accounting invariant and must be its
+own `make test-failover`-gated PR. It is NOT implemented here; the converged
+design is recorded on #3748.
+
 ## File layout
 
 The package is split by responsibility (#1988):

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -73,6 +73,31 @@ const ipfixReversePEN uint32 = 29305
 // of the 4-byte IANA form.
 const ipfixEnterpriseBit uint16 = 0x8000
 
+// #3748: PSAMP sampling Information Elements (RFC 5477 / the IANA "IPFIX
+// Entities" registry) carried by the Options Data Record that advertises the
+// group's 1-in-N sampling configuration to a collector.
+const (
+	// observationDomainId (IE 149, unsigned32) — the SCOPE field of the
+	// sampler Options Template. Its value is the group's stable Observation
+	// Domain ID (#3740), which also stamps the message header, so the record
+	// scopes the sampling config to this observation domain.
+	ipfixObservationDomainID = 149
+	// selectorAlgorithm (IE 304, unsigned16) — the PSAMP selection method.
+	ipfixSelectorAlgorithm = 304
+	// samplingPacketInterval (IE 305, unsigned32) — number of consecutive
+	// units selected (1 for 1-in-N systematic count-based sampling).
+	ipfixSamplingPacketInterval = 305
+	// samplingPacketSpace (IE 306, unsigned32) — number of units skipped
+	// between selections (N-1 for 1-in-N).
+	ipfixSamplingPacketSpace = 306
+)
+
+// ipfixSelectorAlgorithmSystematicCount is the IANA "PSAMP Selection Method"
+// registry value for Systematic count-based Sampling (RFC 5476): select
+// samplingPacketInterval units, then skip samplingPacketSpace units. xpf's
+// 1-in-N is expressed as interval=1, space=N-1 (#3748).
+const ipfixSelectorAlgorithmSystematicCount uint16 = 1
+
 // IPFIX Set IDs (RFC 7011 Section 3.3.2).
 const (
 	ipfixSetIDTemplate        = 2
@@ -84,6 +109,10 @@ const (
 const (
 	ipfixTemplateIDv4 = 256
 	ipfixTemplateIDv6 = 257
+	// #3748: the sampler Options Template ID. Distinct from the 256/257 data
+	// template IDs so a collector never confuses the options record with a
+	// flow record.
+	ipfixOptionsTemplateIDSampler = 258
 )
 
 // ipfixField defines a template field. enterprise is 0 for a standard IANA
@@ -390,6 +419,101 @@ func encodeIPFIXTemplateSetDir(includeDir bool) []byte {
 	return b
 }
 
+// #3748: the sampler Options Template scope + option fields (RFC 7011 §4 /
+// RFC 5477). The single scope field (observationDomainId, IE 149) binds the
+// record to an Observation Domain; the option fields carry the sampling
+// configuration. All are standard IANA IEs (4-byte Template Set specifiers).
+var (
+	ipfixOptionsSamplerScope = []ipfixField{
+		{ipfixObservationDomainID, 4, 0},
+	}
+	ipfixOptionsSamplerFields = []ipfixField{
+		{ipfixSelectorAlgorithm, 2, 0},
+		{ipfixSamplingPacketInterval, 4, 0},
+		{ipfixSamplingPacketSpace, 4, 0},
+	}
+)
+
+// ipfixOptionsSamplerRecordSize is the byte size of the sampler Options Data
+// Record: observationDomainId(4) + selectorAlgorithm(2) + samplingPacketInterval(4)
+// + samplingPacketSpace(4) = 14. Pinned against the field slices at build time so
+// a template/encoder drift panics at init (#3748), mirroring the #2526 data-record
+// pins.
+const ipfixOptionsSamplerRecordSize = 14
+
+var _ = func() struct{} {
+	if ipfixSumLen(ipfixOptionsSamplerScope)+ipfixSumLen(ipfixOptionsSamplerFields) != ipfixOptionsSamplerRecordSize {
+		panic("ipfixOptionsSamplerRecordSize != sum(scope+option fields)")
+	}
+	return struct{}{}
+}()
+
+// encodeIPFIXOptionsTemplateSet builds the sampler Options Template Set (Set ID
+// 3, RFC 7011 §3.4.2.2). The Options Template Record header is 6 bytes —
+// Template ID, Field Count, Scope Field Count — unlike the 4-byte Data Template
+// Record header. Field Count is scope + option fields; Scope Field Count is the
+// number of leading scope fields (#3748).
+func encodeIPFIXOptionsTemplateSet() []byte {
+	scope := ipfixOptionsSamplerScope
+	opts := ipfixOptionsSamplerFields
+	// Set header (4) + Options Template Record header (6) + field specifiers.
+	totalLen := 4 + 6 + ipfixFieldSpecsLen(scope) + ipfixFieldSpecsLen(opts)
+
+	b := make([]byte, totalLen)
+	off := 0
+
+	// Set header: Set ID = 3 (Options Template Set), Length.
+	binary.BigEndian.PutUint16(b[off:off+2], ipfixSetIDOptionsTemplate)
+	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(totalLen))
+	off += 4
+
+	// Options Template Record header: Template ID, Field Count, Scope Field Count.
+	binary.BigEndian.PutUint16(b[off:off+2], ipfixOptionsTemplateIDSampler)
+	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(len(scope)+len(opts)))
+	binary.BigEndian.PutUint16(b[off+4:off+6], uint16(len(scope)))
+	off += 6
+
+	for _, f := range scope {
+		off = encodeIPFIXFieldSpec(b, off, f)
+	}
+	for _, f := range opts {
+		off = encodeIPFIXFieldSpec(b, off, f)
+	}
+	return b
+}
+
+// encodeIPFIXOptionsSamplerDataSet builds the sampler Options Data Set (a Data
+// Set whose Set ID equals the Options Template ID, 258). It carries one record
+// scoped to odid, advertising 1-in-N systematic count-based sampling as
+// interval=1 / space=samplingRate-1. samplingRate <= 1 (unsampled) yields
+// space=0 (1-in-1), but callers only emit this set when sampling is active (see
+// IPFIXExporter.emitSampler) (#3748).
+func encodeIPFIXOptionsSamplerDataSet(odid uint32, samplingRate int) []byte {
+	var space uint32
+	if samplingRate > 1 {
+		space = uint32(samplingRate - 1)
+	}
+	totalLen := 4 + ipfixOptionsSamplerRecordSize
+	b := make([]byte, totalLen)
+	off := 0
+
+	// Set header: Set ID = Options Template ID (>= 256, so this is a Data Set).
+	binary.BigEndian.PutUint16(b[off:off+2], ipfixOptionsTemplateIDSampler)
+	binary.BigEndian.PutUint16(b[off+2:off+4], uint16(totalLen))
+	off += 4
+
+	// Record: observationDomainId (scope), then the option fields.
+	binary.BigEndian.PutUint32(b[off:off+4], odid)
+	off += 4
+	binary.BigEndian.PutUint16(b[off:off+2], ipfixSelectorAlgorithmSystematicCount)
+	off += 2
+	binary.BigEndian.PutUint32(b[off:off+4], 1) // samplingPacketInterval = 1
+	off += 4
+	binary.BigEndian.PutUint32(b[off:off+4], space) // samplingPacketSpace = N-1
+	off += 4
+	return b
+}
+
 // encodeIPFIXDataSet builds an IPFIX data set from a batch of records with the
 // base (flow-dir absent) layout. Retained for callers/tests.
 func encodeIPFIXDataSet(records []FlowRecord) []byte {
@@ -609,6 +733,16 @@ type IPFIXExporter struct {
 	// (IE 61) is present (#3270).
 	includeDir bool
 
+	// #3748: sampler Options Template (Set ID 3) + Options Data Record (Set ID
+	// 258) advertising the group's 1-in-N sampling rate. Precomputed at
+	// construction (rate is fixed per group) and re-sent on the template-refresh
+	// cadence. emitSampler gates emission on SamplingRate > 1 — an unsampled
+	// group (rate 0/1, export-all) advertises nothing (a collector then assumes
+	// 1-in-1, which is correct), matching the ShouldExport sampling gate.
+	emitSampler        bool
+	optionsTemplateSet []byte
+	optionsDataSet     []byte
+
 	mu    sync.Mutex
 	seq   uint32 // cumulative data record count
 	conns *collectorConns
@@ -636,17 +770,28 @@ type IPFIXExporter struct {
 // embeds the live 1-in-N sampleCounter (atomic.Uint64) and copying it
 // would fork the counter, re-seeding the sampling cadence (#2224).
 func NewIPFIXExporter(cfg *ExportConfig) (*IPFIXExporter, error) {
+	// #3740: stable per-group Observation Domain ID (RFC 7011 §3.1) derived
+	// from the config identity so two same-collector groups no longer collide
+	// on ODID=1 (template redefinitions + interleaved sequence streams).
+	// HA-symmetric (pure function of config-synced fields — both cluster nodes
+	// compute the same ODID). Also the scope value of the #3748 sampler record.
+	sourceID := stableExporterID("ipfix", cfg.InstanceName, cfg.TemplateName)
 	e := &IPFIXExporter{
-		cfg: cfg,
-		// #3740: stable per-group Observation Domain ID (RFC 7011 §3.1)
-		// derived from the config identity so two same-collector groups no
-		// longer collide on ODID=1 (template redefinitions + interleaved
-		// sequence streams). HA-symmetric (pure function of config-synced
-		// fields — both cluster nodes compute the same ODID).
-		sourceID:     stableExporterID("ipfix", cfg.InstanceName, cfg.TemplateName),
+		cfg:          cfg,
+		sourceID:     sourceID,
 		includeDir:   cfg.IncludeFlowDir,
 		templateSet:  encodeIPFIXTemplateSetDir(cfg.IncludeFlowDir),
 		MaskResolver: NewRouteMaskResolver(0),
+	}
+
+	// #3748: advertise the 1-in-N sampling rate via an Options Template +
+	// Options Data Record only when the group is actually sampled (rate > 1),
+	// matching the ShouldExport gate. Precompute both (the rate and ODID are
+	// fixed per group) so the refresh path just re-sends the bytes.
+	if cfg.SamplingRate > 1 {
+		e.emitSampler = true
+		e.optionsTemplateSet = encodeIPFIXOptionsTemplateSet()
+		e.optionsDataSet = encodeIPFIXOptionsSamplerDataSet(sourceID, cfg.SamplingRate)
 	}
 
 	conns, err := dialCollectors(cfg.Collectors)
@@ -797,6 +942,55 @@ func (e *IPFIXExporter) sendTemplates() {
 	encodeIPFIXHeaderInto(pkt[:16], hdr)
 	copy(pkt[16:], e.templateSet)
 	e.conns.writeAll(pkt, "ipfix template send failed")
+
+	// #3748: on the same refresh cadence, advertise the 1-in-N sampling
+	// configuration (Options Template + Options Data Record) for sampled groups.
+	if e.emitSampler {
+		e.sendSamplerOptions()
+	}
+}
+
+// sendSamplerOptions emits the sampler Options Template Set (Set ID 3, template
+// ID 258) followed by its Options Data Record (Set ID 258) in one IPFIX Message,
+// advertising the group's 1-in-N sampling rate as PSAMP systematic count-based
+// sampling (#3748). Called on the template-refresh cadence for sampled groups.
+//
+// SEMANTIC NUANCE (documented in README): xpf samples 1-in-N at SESSION-RECORD
+// granularity — ShouldExport applies the modulo per SESSION_CLOSE event, not
+// 1-in-N packets in the datapath as Junos jflow does. Advertising interval=1 /
+// space=N-1 lets a collector scale the sampled RECORD COUNT by N (correct), but
+// each exported record already carries the full per-session octet/packet volume,
+// so a collector must NOT additionally multiply octetDeltaCount by N.
+//
+// The Options Data Record is a Data Record (it rides a Set with ID >= 256), so
+// it advances the header Sequence Number by one, consistent with the #2609
+// convention in sendRecords: capture the current cumulative count for THIS
+// message's header, then increment for the record it carries. A collector that
+// tracks sequence numbers counts this record too, so skipping the increment
+// would look like the loss #2609 fixed.
+func (e *IPFIXExporter) sendSamplerOptions() {
+	body := make([]byte, 0, len(e.optionsTemplateSet)+len(e.optionsDataSet))
+	body = append(body, e.optionsTemplateSet...)
+	body = append(body, e.optionsDataSet...)
+
+	e.mu.Lock()
+	seq := e.seq
+	e.seq++ // the Options Data Record counts toward the sequence (RFC 7011 §3.1)
+	e.mu.Unlock()
+
+	now := time.Now()
+	hdr := ipfixHeader{
+		Version:        10,
+		Length:         uint16(16 + len(body)),
+		ExportTime:     uint32(now.Unix()),
+		SequenceNumber: seq,
+		ObservationID:  e.sourceID,
+	}
+
+	pkt := make([]byte, 16+len(body))
+	encodeIPFIXHeaderInto(pkt[:16], hdr)
+	copy(pkt[16:], body)
+	e.conns.writeAll(pkt, "ipfix options template send failed")
 }
 
 func (e *IPFIXExporter) flushBatches() {

--- a/pkg/flowexport/ipfix_sampler_test.go
+++ b/pkg/flowexport/ipfix_sampler_test.go
@@ -1,0 +1,331 @@
+package flowexport
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// #3748 fail-on-revert pins for the IPFIX sampler Options Template (Set ID 3,
+// template ID 258) + Options Data Record that advertises the group's 1-in-N
+// sampling configuration (PSAMP systematic count-based sampling, RFC 5477).
+//
+// Before #3748 ipfixSetIDOptionsTemplate (Set ID 3) was a bare constant: no
+// options template and no sampler record were ever built or sent, so a
+// collector could not learn the sampling rate and could not scale the sampled
+// record count by N.
+//
+// The IE numbers/set IDs are asserted as literals independent of the package
+// constants so a typo'd constant cannot make a test agree with itself.
+const (
+	wantOptionsSetID          uint16 = 3
+	wantOptionsTemplateID     uint16 = 258
+	wantObservationDomainIDIE uint16 = 149
+	wantSelectorAlgorithmIE   uint16 = 304
+	wantSamplingIntervalIE    uint16 = 305
+	wantSamplingSpaceIE       uint16 = 306
+	wantSystematicCountAlgo   uint16 = 1
+)
+
+// decodeOptionsTemplateRecord walks an Options Template Set (Set ID 3, RFC 7011
+// §3.4.2.2) and returns the template ID, scope field count, and the ordered
+// field specifiers (scope fields first). The Options Template Record header is
+// 6 bytes (Template ID, Field Count, Scope Field Count). It fails the test on
+// any length drift, which is the integrity check for the 6-byte header sizing.
+func decodeOptionsTemplateRecord(t *testing.T, ts []byte) (tmplID, scopeCount uint16, specs []ipfixSpec) {
+	t.Helper()
+	if len(ts) < 10 {
+		t.Fatalf("options template set too short: %d bytes", len(ts))
+	}
+	setID := binary.BigEndian.Uint16(ts[0:2])
+	if setID != wantOptionsSetID {
+		t.Fatalf("set ID = %d, want %d (options template set)", setID, wantOptionsSetID)
+	}
+	setLen := int(binary.BigEndian.Uint16(ts[2:4]))
+	if setLen != len(ts) {
+		t.Fatalf("options template set header length = %d, want %d (encoded length)", setLen, len(ts))
+	}
+	tmplID = binary.BigEndian.Uint16(ts[4:6])
+	fieldCount := int(binary.BigEndian.Uint16(ts[6:8]))
+	scopeCount = binary.BigEndian.Uint16(ts[8:10])
+	off := 10
+	for i := 0; i < fieldCount; i++ {
+		if off+4 > len(ts) {
+			t.Fatalf("options template: ran off the end at field %d/%d", i, fieldCount)
+		}
+		raw := binary.BigEndian.Uint16(ts[off : off+2])
+		length := binary.BigEndian.Uint16(ts[off+2 : off+4])
+		off += 4
+		var pen uint32
+		if raw&0x8000 != 0 {
+			if off+4 > len(ts) {
+				t.Fatalf("options template: enterprise field missing PEN")
+			}
+			pen = binary.BigEndian.Uint32(ts[off : off+4])
+			off += 4
+		}
+		specs = append(specs, ipfixSpec{elementID: raw & 0x7fff, length: length, enterprise: pen})
+	}
+	if off != len(ts) {
+		t.Fatalf("options template walk consumed %d bytes, set is %d — header sizing drift", off, len(ts))
+	}
+	return tmplID, scopeCount, specs
+}
+
+// TestIPFIXOptionsTemplateSetDecode decodes the encoder output directly (no
+// wire) and pins the sampler Options Template shape: Set ID 3, template ID 258,
+// exactly one scope field (observationDomainId, IE 149) followed by the three
+// PSAMP option fields (selectorAlgorithm 304, samplingPacketInterval 305,
+// samplingPacketSpace 306) with the correct lengths.
+func TestIPFIXOptionsTemplateSetDecode(t *testing.T) {
+	ts := encodeIPFIXOptionsTemplateSet()
+	tmplID, scopeCount, specs := decodeOptionsTemplateRecord(t, ts)
+	if tmplID != wantOptionsTemplateID {
+		t.Errorf("options template ID = %d, want %d", tmplID, wantOptionsTemplateID)
+	}
+	if scopeCount != 1 {
+		t.Errorf("scope field count = %d, want 1", scopeCount)
+	}
+	// The distinct template ID must not collide with the data templates.
+	if wantOptionsTemplateID == ipfixTemplateIDv4 || wantOptionsTemplateID == ipfixTemplateIDv6 {
+		t.Fatalf("options template ID %d collides with a data template ID", wantOptionsTemplateID)
+	}
+	want := []ipfixSpec{
+		{elementID: wantObservationDomainIDIE, length: 4},
+		{elementID: wantSelectorAlgorithmIE, length: 2},
+		{elementID: wantSamplingIntervalIE, length: 4},
+		{elementID: wantSamplingSpaceIE, length: 4},
+	}
+	if len(specs) != len(want) {
+		t.Fatalf("field count = %d, want %d (%v)", len(specs), len(want), specs)
+	}
+	for i, w := range want {
+		if specs[i].elementID != w.elementID || specs[i].length != w.length || specs[i].enterprise != 0 {
+			t.Errorf("field[%d] = %+v, want elementID=%d length=%d enterprise=0", i, specs[i], w.elementID, w.length)
+		}
+	}
+}
+
+// TestIPFIXOptionsSamplerDataSetDecode pins the Options Data Record encoding
+// across the sampled and degenerate (unsampled) rates: interval is always 1 and
+// space is N-1 for 1-in-N (0 for the degenerate rate<=1 case).
+func TestIPFIXOptionsSamplerDataSetDecode(t *testing.T) {
+	const odid uint32 = 0xDEADBEEF
+	cases := []struct {
+		rate      int
+		wantSpace uint32
+	}{
+		{rate: 100, wantSpace: 99},
+		{rate: 2, wantSpace: 1},
+		{rate: 1, wantSpace: 0}, // degenerate: 1-in-1 (no sampling)
+		{rate: 0, wantSpace: 0}, // degenerate: export-all
+	}
+	for _, c := range cases {
+		ds := encodeIPFIXOptionsSamplerDataSet(odid, c.rate)
+		if len(ds) != 4+ipfixOptionsSamplerRecordSize {
+			t.Fatalf("rate %d: data set len = %d, want %d", c.rate, len(ds), 4+ipfixOptionsSamplerRecordSize)
+		}
+		if setID := binary.BigEndian.Uint16(ds[0:2]); setID != wantOptionsTemplateID {
+			t.Errorf("rate %d: data set ID = %d, want %d (== options template ID)", c.rate, setID, wantOptionsTemplateID)
+		}
+		if setLen := int(binary.BigEndian.Uint16(ds[2:4])); setLen != len(ds) {
+			t.Errorf("rate %d: data set header length = %d, want %d", c.rate, setLen, len(ds))
+		}
+		rec := ds[4:]
+		if got := binary.BigEndian.Uint32(rec[0:4]); got != odid {
+			t.Errorf("rate %d: observationDomainId scope = %#x, want %#x", c.rate, got, odid)
+		}
+		if got := binary.BigEndian.Uint16(rec[4:6]); got != wantSystematicCountAlgo {
+			t.Errorf("rate %d: selectorAlgorithm = %d, want %d (systematic count-based)", c.rate, got, wantSystematicCountAlgo)
+		}
+		if got := binary.BigEndian.Uint32(rec[6:10]); got != 1 {
+			t.Errorf("rate %d: samplingPacketInterval = %d, want 1", c.rate, got)
+		}
+		if got := binary.BigEndian.Uint32(rec[10:14]); got != c.wantSpace {
+			t.Errorf("rate %d: samplingPacketSpace = %d, want %d (N-1)", c.rate, got, c.wantSpace)
+		}
+	}
+}
+
+// TestIPFIXSamplerOptionsWireLoopback exercises the real exporter wire path
+// (NewIPFIXExporter -> sendTemplates) over a loopback UDP collector for a
+// SAMPLED group, mirroring the #2609 harness, and asserts:
+//   - sendTemplates emits the data template set (message 1) THEN a second
+//     message carrying the sampler Options Template (Set ID 3) + Options Data
+//     Record (Set ID 258);
+//   - the options record scope (observationDomainId) equals the group's ODID
+//     (== the message header ObservationID);
+//   - the advertised rate is systematic count-based, interval=1, space=N-1;
+//   - the Options Data Record advances the header Sequence Number by exactly one
+//     (it is a Data Record; #2609 convention).
+//
+// RED-on-revert: dropping the sampler emission from sendTemplates makes the
+// message-2 read time out (no options message) -> t.Fatalf, and the decode
+// asserts on Set ID 3 / template 258 / the sampler IEs never run.
+func TestIPFIXSamplerOptionsWireLoopback(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("ListenPacket: %v", err)
+	}
+	defer pc.Close()
+
+	const rate = 100
+	ec := &ExportConfig{
+		Collectors:   []CollectorConfig{{Address: pc.LocalAddr().String()}},
+		InstanceName: "samp-inst", // non-default -> real hashed ODID (#3740)
+		TemplateName: "t1",
+		SamplingRate: rate,
+	}
+	e, err := NewIPFIXExporter(ec)
+	if err != nil {
+		t.Fatalf("NewIPFIXExporter: %v", err)
+	}
+	defer e.Close()
+
+	readPkt := func() []byte {
+		buf := make([]byte, 4096)
+		if err := pc.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		n, _, err := pc.ReadFrom(buf)
+		if err != nil {
+			t.Fatalf("collector read (expected the #3748 sampler options message): %v", err)
+		}
+		return buf[:n]
+	}
+
+	e.sendTemplates()
+
+	// Message 1: the data template set (Set ID 2).
+	p1 := readPkt()
+	if len(p1) < 18 {
+		t.Fatalf("short template packet: %d bytes", len(p1))
+	}
+	if setID := binary.BigEndian.Uint16(p1[16:18]); setID != ipfixSetIDTemplate {
+		t.Fatalf("message 1 first set ID = %d, want %d (data template set)", setID, ipfixSetIDTemplate)
+	}
+
+	// Message 2: sampler Options Template Set + Options Data Set.
+	p2 := readPkt()
+	if len(p2) < 16+10 {
+		t.Fatalf("short options packet: %d bytes", len(p2))
+	}
+	if ver := binary.BigEndian.Uint16(p2[0:2]); ver != 10 {
+		t.Fatalf("options message version = %d, want 10", ver)
+	}
+	if msgLen := int(binary.BigEndian.Uint16(p2[2:4])); msgLen != len(p2) {
+		t.Fatalf("options message header length = %d, want %d", msgLen, len(p2))
+	}
+	msgSeq := binary.BigEndian.Uint32(p2[8:12])
+	msgODID := binary.BigEndian.Uint32(p2[12:16])
+	if msgODID != e.sourceID {
+		t.Fatalf("options message ObservationID = %#x, want %#x (group ODID)", msgODID, e.sourceID)
+	}
+	if msgSeq != 0 {
+		t.Fatalf("options message sequence = %d, want 0 (no prior data records)", msgSeq)
+	}
+
+	body := p2[16:]
+	optsTmplLen := int(binary.BigEndian.Uint16(body[2:4]))
+	if optsTmplLen <= 0 || optsTmplLen > len(body) {
+		t.Fatalf("options template set length = %d, body = %d", optsTmplLen, len(body))
+	}
+	optsTmpl := body[:optsTmplLen]
+	optsData := body[optsTmplLen:]
+
+	// --- Options Template (Set ID 3) ---
+	tmplID, scopeCount, specs := decodeOptionsTemplateRecord(t, optsTmpl)
+	if tmplID != wantOptionsTemplateID {
+		t.Errorf("wire options template ID = %d, want %d", tmplID, wantOptionsTemplateID)
+	}
+	if scopeCount != 1 {
+		t.Errorf("wire scope field count = %d, want 1", scopeCount)
+	}
+	if len(specs) < 1 || specs[0].elementID != wantObservationDomainIDIE {
+		t.Errorf("wire scope field = %+v, want observationDomainId (IE %d)", specs, wantObservationDomainIDIE)
+	}
+	for _, ie := range []uint16{wantSelectorAlgorithmIE, wantSamplingIntervalIE, wantSamplingSpaceIE} {
+		if _, ok := findSpec(specs, ie, 0); !ok {
+			t.Errorf("wire options template missing sampler IE %d", ie)
+		}
+	}
+
+	// --- Options Data Record (Set ID 258) ---
+	if len(optsData) != 4+ipfixOptionsSamplerRecordSize {
+		t.Fatalf("wire options data set len = %d, want %d", len(optsData), 4+ipfixOptionsSamplerRecordSize)
+	}
+	if setID := binary.BigEndian.Uint16(optsData[0:2]); setID != wantOptionsTemplateID {
+		t.Errorf("wire options data set ID = %d, want %d", setID, wantOptionsTemplateID)
+	}
+	rec := optsData[4:]
+	if got := binary.BigEndian.Uint32(rec[0:4]); got != e.sourceID {
+		t.Errorf("wire options record scope ODID = %#x, want %#x", got, e.sourceID)
+	}
+	if got := binary.BigEndian.Uint16(rec[4:6]); got != wantSystematicCountAlgo {
+		t.Errorf("wire selectorAlgorithm = %d, want %d", got, wantSystematicCountAlgo)
+	}
+	if got := binary.BigEndian.Uint32(rec[6:10]); got != 1 {
+		t.Errorf("wire samplingPacketInterval = %d, want 1", got)
+	}
+	if got := binary.BigEndian.Uint32(rec[10:14]); got != rate-1 {
+		t.Errorf("wire samplingPacketSpace = %d, want %d (N-1)", got, rate-1)
+	}
+
+	// The Options Data Record is a Data Record: it advanced the counter by one.
+	e.mu.Lock()
+	seq := e.seq
+	e.mu.Unlock()
+	if seq != 1 {
+		t.Fatalf("cumulative sequence after sampler options = %d, want 1 "+
+			"(the Options Data Record counts toward the sequence; #2609 convention)", seq)
+	}
+}
+
+// TestIPFIXSamplerOptionsAbsentWhenUnsampled pins the degenerate handling: an
+// export-all group (SamplingRate 0/1) must NOT emit any sampler options — a
+// collector then correctly assumes 1-in-1. sendTemplates emits only the data
+// template message; a second read times out.
+func TestIPFIXSamplerOptionsAbsentWhenUnsampled(t *testing.T) {
+	for _, rate := range []int{0, 1} {
+		pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("ListenPacket: %v", err)
+		}
+		ec := &ExportConfig{
+			Collectors:   []CollectorConfig{{Address: pc.LocalAddr().String()}},
+			SamplingRate: rate,
+		}
+		e, err := NewIPFIXExporter(ec)
+		if err != nil {
+			pc.Close()
+			t.Fatalf("NewIPFIXExporter: %v", err)
+		}
+		if e.emitSampler {
+			t.Errorf("rate %d: emitSampler = true, want false (unsampled)", rate)
+		}
+		if e.optionsTemplateSet != nil || e.optionsDataSet != nil {
+			t.Errorf("rate %d: precomputed sampler options must be nil when unsampled", rate)
+		}
+
+		e.sendTemplates()
+
+		// Message 1: the data template set.
+		buf := make([]byte, 4096)
+		if err := pc.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		if _, _, err := pc.ReadFrom(buf); err != nil {
+			t.Fatalf("rate %d: collector got no data template: %v", rate, err)
+		}
+		// No message 2: a short read must time out.
+		if err := pc.SetReadDeadline(time.Now().Add(200 * time.Millisecond)); err != nil {
+			t.Fatalf("SetReadDeadline: %v", err)
+		}
+		if n, _, err := pc.ReadFrom(buf); err == nil {
+			t.Errorf("rate %d: unexpected second packet (%d bytes) — unsampled group must not emit sampler options", rate, n)
+		}
+		e.Close()
+		pc.Close()
+	}
+}


### PR DESCRIPTION
Closes #3748

Implements **sub-part (b)** of #3748 — the IPFIX Options Template +
sampler record. Sub-part (a) (active-timeout interim records) is
**DEFERRED** per the converged /research plan on the issue (a
multi-surface Rust + Go + wire + HA change with a delta-accounting
invariant that needs its own `make test-failover`-gated PR).

## The gap

`ipfixSetIDOptionsTemplate` (Set ID 3) was a bare constant;
`sendTemplates` emitted only the DATA templates (256/257) and no sampler
record was ever built. A collector receiving 1-in-N-sampled session
records could not learn N, so it could not scale the sampled record
count. The rate is known (`ExportConfig.SamplingRate` from
`inst.InputRate`) and #3740 gives each group a stable Observation Domain
ID to use as the options-record scope.

## What this does

Emits, on the same template-refresh cadence, a sampler **Options
Template** (Set ID 3, template ID **258** — distinct from 256/257) plus
an **Options Data Record** (Set ID 258) advertising PSAMP systematic
count-based sampling (RFC 5477 / IANA "IPFIX Entities"):

| Field | IE | Role | Value |
|-------|----|------|-------|
| `observationDomainId` | 149 | scope | group's #3740 stable ODID (== header ODID) |
| `selectorAlgorithm` | 304 | option | `1` (systematic count-based) |
| `samplingPacketInterval` | 305 | option | `1` |
| `samplingPacketSpace` | 306 | option | `N-1` |

- **Gated on `SamplingRate > 1`** (matches the `ShouldExport` gate). An
  unsampled / export-all group (rate 0 or 1) advertises nothing — a
  collector then correctly assumes 1-in-1 — keeping the #2609
  template-refresh sequence behaviour bit-identical there.
- **Sequence accounting:** the Options Data Record rides a Set ID ≥ 256,
  so it is a Data Record and advances the header Sequence Number by one
  (RFC 7011 §3.1), consistent with `sendRecords` / the #2609 convention.
- **Build-time pin:** `ipfixOptionsSamplerRecordSize` (14) is pinned
  against the field slices at init (same discipline as the #2526
  data-record pins).
- Options template + record precomputed once at construction (rate/ODID
  fixed per group).

## Semantic nuance (documented)

xpf samples **1-in-N at SESSION-RECORD granularity** (`ShouldExport`
modulo per SESSION_CLOSE), **not** 1-in-N packets in the datapath the way
Junos jflow does. Advertising interval=1 / space=N-1 lets a collector
scale the sampled **record COUNT** by N (correct), but each record
already carries the full per-session `octetDeltaCount` /
`packetDeltaCount`, so a collector must **NOT** additionally multiply
per-record volume by N. Documented in `sendSamplerOptions`, the
`pkg/flowexport` README, and `docs/feature-coverage.md`.

## Tests (`ipfix_sampler_test.go`)

- `TestIPFIXOptionsTemplateSetDecode` — Set ID 3, template 258, one scope
  field (IE 149), option IEs 304/305/306 with correct lengths +
  set-length integrity.
- `TestIPFIXOptionsSamplerDataSetDecode` — interval=1 / space=N-1 across
  sampled and degenerate (rate 0/1) rates.
- `TestIPFIXSamplerOptionsWireLoopback` — real exporter UDP path: the
  options message follows the data template, scope == header ODID,
  rate = N-1, and the record advances the sequence by one.
- `TestIPFIXSamplerOptionsAbsentWhenUnsampled` — rate 0/1 emit no options
  message.

**RED-on-revert proven:** disabling the `sendSamplerOptions` call in
`sendTemplates` times out the wire-loopback message-2 read.

## Validation

- `go test ./pkg/flowexport/...` green (existing #2609/#3740/#3746 tests +
  4 new).
- `go build ./...`, `gofmt -l`, `go vet ./pkg/flowexport/` clean.
- No HA impact (each node's exporters are config-synced and compute the
  same ODID; sampler metadata is identical on both nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
