### PR TITLE
ddns/surface-a: provider-aware adoption guard + orphan alarm (#3735 PLAN-READY half)

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -118,6 +118,7 @@ type xpfCollector struct {
 	surfaceADDNSDeletesTotal *prometheus.Desc
 	surfaceADDNSSkippedTotal *prometheus.Desc
 	surfaceADDNSScopes       *prometheus.Desc
+	surfaceADDNSOrphaned     *prometheus.Desc
 	surfaceADDNSDegraded     *prometheus.Desc
 
 	// System metrics
@@ -574,6 +575,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.surfaceADDNSDeletesTotal
 	ch <- c.surfaceADDNSSkippedTotal
 	ch <- c.surfaceADDNSScopes
+	ch <- c.surfaceADDNSOrphaned
 	ch <- c.surfaceADDNSDegraded
 	ch <- c.sysCPUUser
 	ch <- c.sysCPUSystem

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -375,6 +375,16 @@ func newCollector(srv *Server) *xpfCollector {
 			"Current number of Surface A DDNS records this node owns in DNS.",
 			nil, nil,
 		),
+		surfaceADDNSOrphaned: prometheus.NewDesc(
+			"xpf_ddns_surface_a_orphaned",
+			"Current number of Surface A DDNS records stale at a PREVIOUS provider "+
+				"endpoint that a provider identity change (rename to a different "+
+				"endpoint / in-place server-zone edit / removed binding after an edit) "+
+				"left un-withdrawable through the current catalog (#3735). Non-zero "+
+				"means an old record needs MANUAL operator cleanup — auto-withdrawal is "+
+				"deferred (old creds are redacted and the old endpoint is usually gone).",
+			nil, nil,
+		),
 		surfaceADDNSDegraded: prometheus.NewDesc(
 			"xpf_ddns_surface_a_degraded",
 			"1 when the Surface A DDNS ownership state is unloadable and the "+

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -112,6 +112,8 @@ func (c *xpfCollector) collectSurfaceADDNSMetrics(ch chan<- prometheus.Metric) {
 		float64(st.SkippedNoBackend), "no-backend")
 	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSScopes, prometheus.GaugeValue,
 		float64(st.Scopes))
+	ch <- prometheus.MustNewConstMetric(c.surfaceADDNSOrphaned, prometheus.GaugeValue,
+		float64(st.Orphaned))
 	var degraded float64
 	if st.Degraded {
 		degraded = 1

--- a/pkg/ddns/state.go
+++ b/pkg/ddns/state.go
@@ -207,6 +207,31 @@ type ownedRecord struct {
 	// from the JSON when false; an absent value (older stores, fully-published
 	// records) degrades to "settled", the safe default.
 	PTRPending bool `json:"ptr_pending,omitempty"`
+	// BackendFingerprint is a STABLE, NON-SECRET fingerprint of the provider
+	// backend ENDPOINT this record was published through (#3735): a hash of the
+	// backend TYPE + server/host + zone + hosted-zone + region + generic URL
+	// template, computed by backendFingerprint (surface_a.go). It carries NO
+	// credentials (TSIGSecret / Password / APIToken / AWSSecretAccessKey are all
+	// config.Secret and are deliberately excluded), so persisting it does NOT
+	// reopen the #2053 plaintext-secret-on-disk disclosure class — nothing
+	// sensitive is ever hashed in or written out.
+	//
+	// Its sole purpose is to make a provider IDENTITY change DETECTABLE so the
+	// old record is not silently mishandled: a provider RENAME to a different
+	// endpoint (H01), an in-place server/zone edit under the same provider name
+	// (H02), or a removed-binding withdraw after a provider edit (H03). When the
+	// stored fingerprint no longer matches the current provider's, the record was
+	// published at a DIFFERENT endpoint than the one now configured for the same
+	// scope/name — so it cannot be adopted-in-place, overwritten, or withdrawn
+	// through the current catalog without either losing cleanup authority or
+	// deleting at the WRONG endpoint. The reconciler then KEEPS ownership and
+	// raises a loud operator alarm (auto-withdrawal of the old endpoint is
+	// DEFERRED — the old creds are redacted config.Secret and the old endpoint is
+	// usually decommissioned; see the pkg/ddns README + #3735). Omitted from the
+	// JSON when empty; an absent value (a pre-#3735 store, or a nil-provider test)
+	// degrades to "unknown" and is compared as "cannot determine a mismatch" —
+	// never a false alarm.
+	BackendFingerprint string `json:"backend_fingerprint,omitempty"`
 	// Scope is the ScopeKey this record belongs to (#2691 P1b, plan §5.4). It
 	// is the per-family / per-interface / per-RG / per-routing-instance scope
 	// the record was published under, so two scopes for the same name+address

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"net/http"
 	"net/netip"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -186,6 +188,40 @@ type surfaceAState struct {
 	withdrawUnsupported bool
 }
 
+// surfaceAOrphan records a DDNS record this node published at a PREVIOUS provider
+// endpoint that a provider IDENTITY change has left stale and un-withdrawable
+// through the current catalog (#3735). It is the durable-alarm payload behind the
+// operator surfaces (Prometheus gauge + StatusViews row + slog.Warn): what name
+// and address are stale, which provider owned it, and the old vs new endpoint
+// fingerprint. Auto-withdrawal of the record is DEFERRED (the old endpoint's
+// credentials are redacted config.Secret and the endpoint is usually
+// decommissioned), so it is surfaced LOUDLY for MANUAL operator cleanup instead
+// of being silently dropped (H01), overwritten (H02), or deleted at the wrong
+// endpoint (H03).
+type surfaceAOrphan struct {
+	FQDN           string
+	Address        string // the published rdata now stale at the old endpoint
+	Provider       string // the owning PolicyID (provider name) at publish time
+	Interface      string // the owning scope's interface
+	Unit           int    // the owning scope's unit
+	Family         int    // 4/6 — the owning scope's family (deterministic status sort)
+	OldFingerprint string // the endpoint the record was published through
+	NewFingerprint string // the current provider's endpoint ("" = provider gone)
+	Reason         string // human-readable cause (one of orphanReason*)
+	FirstSeen      time.Time
+}
+
+// orphanReason* are the operator-facing explanations attached to a surfaceAOrphan
+// and its StatusViews row (#3735). They all resolve to the same required action:
+// the old record must be cleaned up by hand.
+const (
+	orphanReasonProviderGone = "provider removed from catalog; old record stale at previous endpoint — manual cleanup required"
+
+	orphanReasonEndpointChanged = "provider endpoint changed; old record stale at previous endpoint — manual cleanup required"
+
+	orphanReasonEndpointChangedInPlace = "provider endpoint changed in place; old record stale at previous endpoint — manual cleanup required"
+)
+
 // Surface A scope status states for the operator view (#2843). A configured
 // scope is rendered with exactly one of these so the operator sees every
 // configured scope and its health, not only the successfully-owned ones.
@@ -210,6 +246,14 @@ const (
 	// is NO LONGER configured (the binding was removed); the next reconcile will
 	// withdraw it. Surfaced so a wedged withdraw is visible, not silent.
 	SurfaceAStateWithdrawPending = "withdraw-pending"
+	// SurfaceAStateOrphaned — a record this node published at a PREVIOUS provider
+	// endpoint that a provider identity change (rename to a different endpoint /
+	// in-place server-zone edit / removed binding after an edit) left stale and
+	// un-withdrawable through the current catalog (#3735). Ownership is KEPT and
+	// the record is surfaced LOUDLY (LastError carries the manual-cleanup reason)
+	// because auto-withdrawal is deferred (the old creds are redacted and the old
+	// endpoint is usually gone). The operator must clean the stale record by hand.
+	SurfaceAStateOrphaned = "orphaned"
 )
 
 // SurfaceAStatusView is a read-only projection of one Surface A scope's
@@ -271,6 +315,26 @@ type SurfaceAManager struct {
 	// the durable store (seedFromStore) so a restart does not blast a redundant
 	// update for an unchanged address (inadyn idea #5, plan §5.5).
 	runtime map[string]*surfaceAState
+
+	// orphans tracks records this node published at a PREVIOUS provider endpoint
+	// that a provider identity change (rename to a different endpoint / in-place
+	// server-zone edit / removed binding after an edit) has left stale and
+	// un-withdrawable through the CURRENT catalog (#3735). It is keyed by
+	// orphanKey (the owned record's scope prefix + FQDN + address) so a given
+	// orphaned record contributes exactly one entry. It is the operator-visible
+	// half of the fingerprint alarm: `xpf_ddns_surface_a_orphaned`, a distinct
+	// `SurfaceAStateOrphaned` StatusViews row, and a single loud slog.Warn per
+	// entry (noteOrphan is idempotent by key so it does not re-warn every sweep).
+	//
+	// It is NOT persisted: the H01/H03 orphans are re-derived every reconcile
+	// from the durable owned record + the provider catalog (self-healing across
+	// restart — the alarm re-fires once), while the H02 in-place-mutation orphan
+	// is in-memory-until-restart because the OLD endpoint identity is intentionally
+	// NOT persisted (persisting the old backend's creds to reach it is the
+	// DEFERRED auto-cleanup half, blocked by the #2053 secret contract — see the
+	// README). Auto-withdrawal of the orphaned record is DEFERRED; the alarm tells
+	// the operator to clean it up by hand.
+	orphans map[string]surfaceAOrphan
 
 	// forceRefresh is the operator force-now latch (#3276): when set, the NEXT
 	// reconcile pass treats every configured scope as refresh-due, re-asserting
@@ -341,6 +405,7 @@ func NewSurfaceAManager() *SurfaceAManager {
 		degraded:       degraded,
 		degradedReason: reason,
 		runtime:        map[string]*surfaceAState{},
+		orphans:        map[string]surfaceAOrphan{},
 		httpClients:    newHTTPClientCache(),
 		now:            time.Now,
 	}
@@ -370,6 +435,7 @@ func newSurfaceAManagerForTesting(statePath string, backend DNSUpdater, now func
 		degraded:       degraded,
 		degradedReason: reason,
 		runtime:        map[string]*surfaceAState{},
+		orphans:        map[string]surfaceAOrphan{},
 		backend:        backend,
 		now:            now,
 	}
@@ -691,20 +757,38 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 		noteErr(m.reconcileScopeLocked(ctx, sc, observe, now, force))
 	}
 
-	// liveRR is the set of {FQDN, AddrText} that a STILL-CONFIGURED scope owns
-	// after Pass 1 — the exact name+rdata that is (or will be) live at the
-	// provider. A Pass 2 withdraw issues an EXACT-RR delete (name+type+rdata), so
-	// withdrawing a record whose name+rdata equals a live RR would REMOVE the live
-	// RR. This is the #2903 on-disk MIGRATION case: a pre-#2903 store has the
-	// Surface A record under an FQDN-LESS scope prefix, while the configured scope
-	// now keys under the FQDN-bearing prefix — both carry the SAME name+address.
-	// Pass 1 (re)published under the new prefix; Pass 2 must NOT then exact-RR
-	// delete the same name+address. Skip the wire delete but still drop the stale
-	// old-prefix ownership entry (adopt-in-place — no blackhole, no orphan).
-	liveRR := make(map[string]struct{}, len(desired))
+	// liveByPolicy / liveByFP describe the {FQDN, AddrText} records a STILL-
+	// CONFIGURED scope owns after Pass 1 — the exact name+rdata that is (or will
+	// be) live at the provider — keyed by PROVIDER IDENTITY so the #2903 adoption
+	// guard is provider-AWARE (#3735). A Pass 2 withdraw issues an EXACT-RR delete
+	// (name+type+rdata), so withdrawing a record whose name+rdata equals a live RR
+	// would REMOVE the live RR. The #2903 on-disk MIGRATION case (a pre-#2903 store
+	// keyed under an FQDN-LESS scope prefix; the configured scope now keys under the
+	// FQDN-bearing prefix — SAME provider, name and address) must therefore be
+	// ADOPTED in place, not exact-RR deleted.
+	//
+	// The pre-#3735 guard keyed liveRR only on {FQDN, AddrText}, so it ALSO adopted
+	// a genuine PROVIDER RENAME (prov-A → prov-B, same name+addr) — silently
+	// dropping the old-provider ownership WITHOUT a wire delete and orphaning the
+	// record at provider A (the codex-157 H01 bug). Keying on provider identity
+	// closes that: an old record is adopted only when a still-configured record
+	// with the SAME name+addr shares its PROVIDER NAME (the #2903 same-provider
+	// migration — PolicyID is unchanged and present on both the FQDN-less and the
+	// FQDN-bearing record) OR its non-empty backend FINGERPRINT (a pure rename to
+	// the SAME endpoint — no real orphan exists, so no false alarm). A genuine
+	// rename to a DIFFERENT endpoint matches neither axis, so it is no longer
+	// silently adopted — it becomes a real withdraw candidate that the Pass-2
+	// classifier turns into a KEEP-ownership + loud orphan alarm.
+	liveByPolicy := make(map[string]struct{}, len(desired))
+	liveByFP := make(map[string]struct{}, len(desired))
 	for _, owned := range m.state.all() {
-		if _, stillConfigured := desired[owned.scopeOf().scopePrefix()]; stillConfigured {
-			liveRR[owned.FQDN+"|"+owned.AddrText] = struct{}{}
+		osc := owned.scopeOf()
+		if _, stillConfigured := desired[osc.scopePrefix()]; !stillConfigured {
+			continue
+		}
+		liveByPolicy[osc.PolicyID+"\x00"+owned.FQDN+"\x00"+owned.AddrText] = struct{}{}
+		if owned.BackendFingerprint != "" {
+			liveByFP[owned.BackendFingerprint+"\x00"+owned.FQDN+"\x00"+owned.AddrText] = struct{}{}
 		}
 	}
 
@@ -717,22 +801,29 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 	// SurfaceAScope is gone (#2691 P2 MAJOR-2 fix: a removed-binding withdraw
 	// MUST send a real DNS DELETE, not silently drop ownership and orphan the RR).
 	for _, owned := range m.state.all() {
-		sid := owned.scopeOf().scopePrefix()
+		osc := owned.scopeOf()
+		sid := osc.scopePrefix()
 		if _, stillConfigured := desired[sid]; stillConfigured {
 			continue
 		}
-		if !admit(owned.scopeOf()) {
+		if !admit(osc) {
 			continue
 		}
-		if _, live := liveRR[owned.FQDN+"|"+owned.AddrText]; live {
-			// The exact name+rdata is owned by a still-configured scope (the #2903
-			// on-disk migration from an FQDN-less prefix to an FQDN-bearing one).
-			// An exact-RR delete here would remove the live RR — adopt in place:
-			// drop the stale old-prefix ownership entry, no wire delete.
-			slog.Debug("ddns surface-a: stale-prefix ownership adopted by a configured FQDN scope; dropping without a wire delete",
-				"fqdn", owned.FQDN, "addr", owned.AddrText)
-			m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
-			delete(m.runtime, owned.scopeOf().scopePrefix())
+		// Provider-aware adopt-in-place (#2903 migration / same-endpoint rename,
+		// #3735): the exact name+rdata is still owned by a configured scope with
+		// the SAME provider identity (same PolicyID, or same non-empty endpoint
+		// fingerprint). An exact-RR delete here would remove the just-published
+		// live RR — adopt in place: drop the stale old-prefix ownership entry, no
+		// wire delete, no orphan alarm.
+		liveName := owned.FQDN + "\x00" + owned.AddrText
+		_, adoptByPolicy := liveByPolicy[osc.PolicyID+"\x00"+liveName]
+		_, adoptByFP := liveByFP[owned.BackendFingerprint+"\x00"+liveName]
+		if adoptByPolicy || (owned.BackendFingerprint != "" && adoptByFP) {
+			slog.Debug("ddns surface-a: stale-prefix ownership adopted by a configured same-provider scope; dropping without a wire delete",
+				"fqdn", owned.FQDN, "addr", owned.AddrText, "provider", osc.PolicyID)
+			m.state.delete(osc, owned.Identity, owned.Address)
+			delete(m.runtime, sid)
+			m.clearOrphan(owned)
 			continue
 		}
 		// Per-scope error backoff for the gone-from-config withdraw (#2813): a
@@ -755,17 +846,35 @@ func (m *SurfaceAManager) Reconcile(ctx context.Context, scopes []SurfaceAScope,
 			// RR stays operator-visible) and do not re-attempt the wire delete.
 			continue
 		}
+		// #3735: classify whether the record's ORIGINAL endpoint is reachable
+		// through the current catalog BEFORE any backoff/withdraw. A provider that
+		// is gone (H01: renamed to a different endpoint / removed) or whose endpoint
+		// fingerprint no longer matches (H03: in-place server/zone edit) is
+		// un-withdrawable — issuing a delete would either no-op or hit the WRONG
+		// endpoint and false-success-drop ownership. KEEP ownership and raise a loud
+		// operator alarm ONCE (noteOrphan is idempotent), never a wrong-endpoint
+		// delete. Auto-withdrawal of the old record is DEFERRED (the old creds are
+		// redacted config.Secret and the old endpoint is usually gone) — the alarm
+		// tells the operator to clean it up by hand.
+		backend, status, err := m.classifyOwnedBackend(owned, catalog)
+		switch status {
+		case ownedBackendProviderGone:
+			m.noteOrphan(owned, "", orphanReasonProviderGone, now)
+			continue
+		case ownedBackendEndpointChanged:
+			m.noteOrphan(owned, backendFingerprint(catalog[osc.PolicyID]), orphanReasonEndpointChanged, now)
+			continue
+		}
+		if err != nil {
+			m.recordScopeError(rt, owned.FQDN, 0, err, now)
+			noteErr(err)
+			continue
+		}
 		if !rt.nextEligible.IsZero() && now.Before(rt.nextEligible) {
 			// Still inside the error-backoff window — skip the wire delete this pass.
 			m.backedOff++
 			slog.Debug("ddns surface-a: gone-from-config scope in withdraw backoff; skipping this pass",
 				"fqdn", owned.FQDN, "next-eligible", rt.nextEligible)
-			continue
-		}
-		backend, err := m.backendForOwned(owned, catalog)
-		if err != nil {
-			m.recordScopeError(rt, owned.FQDN, 0, err, now)
-			noteErr(err)
 			continue
 		}
 		noteErr(m.withdrawScopeLocked(ctx, owned, backend, rt, owned.FQDN, 0, now))
@@ -1010,17 +1119,36 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 		}
 	}
 
+	// Non-secret backend fingerprint for this publish (#3735). Stored on the owned
+	// record so a later provider identity change is detectable, and compared here
+	// against the previous publish's fingerprint to catch an IN-PLACE provider
+	// mutation (H02): the scope key {PolicyID, FQDN} is unchanged (server/zone/
+	// creds are not in the key), so this scope is NEVER a Pass-2 withdraw candidate;
+	// the republish would overwrite the same ownership key with the NEW endpoint and
+	// silently orphan the record at the OLD endpoint. When the stored and current
+	// fingerprints both resolve and differ, the old endpoint's record is stale and
+	// un-withdrawable (the catalog now resolves this provider to the new endpoint),
+	// so raise the SAME loud operator alarm instead of silently overwriting. We
+	// still publish the new record (the operator wants it live at the new endpoint);
+	// auto-withdrawal of the old one is DEFERRED (redacted creds / decommissioned
+	// endpoint) — the alarm tells the operator to clean it up by hand.
+	fp := backendFingerprint(sc.Provider)
+	if hadPrev && prevOwned.BackendFingerprint != "" && fp != "" && prevOwned.BackendFingerprint != fp {
+		m.noteOrphan(prevOwned, fp, orphanReasonEndpointChangedInPlace, now)
+	}
+
 	// Write-ahead the ownership intent BEFORE the wire add (#2662): a crash
 	// after the add finds the record owned and the next reconcile converges it.
 	ow := ownedRecord{
-		Family:      familyInt(addr),
-		Identity:    surfaceAIdentity,
-		Address:     "", // key on scope+FQDN; rdata lives in AddrText below
-		FQDN:        rec.FQDN,
-		ForwardType: rec.ForwardType,
-		PTRName:     "",
-		TTL:         ttl,
-		AddrText:    addr.String(),
+		Family:             familyInt(addr),
+		Identity:           surfaceAIdentity,
+		Address:            "", // key on scope+FQDN; rdata lives in AddrText below
+		FQDN:               rec.FQDN,
+		ForwardType:        rec.ForwardType,
+		PTRName:            "",
+		TTL:                ttl,
+		AddrText:           addr.String(),
+		BackendFingerprint: fp,
 	}.withScope(key)
 	m.state.put(ow)
 	if err := m.state.save(); err != nil {
@@ -1107,7 +1235,7 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 // (binding removed, or address lost) through the GIVEN backend, then drops the
 // ownership entry. Caller holds m.mu and is responsible for resolving the LIVE
 // backend (Pass 1 from the live scope via backendFor, Pass 2 from the provider
-// catalog via backendForOwned) so the delete actually reaches the wire — a nil/
+// catalog via classifyOwnedBackend) so the delete actually reaches the wire — a nil/
 // no-op backend would orphan the RR (#2691 P2 MAJOR-2). A delete is re-derived
 // from the EXACT owned tuple (the sole-delete-authority boundary, shared with
 // the lease path): Surface A never deletes a name it did not record.
@@ -1135,6 +1263,7 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 			"fqdn", owned.FQDN, "addr", owned.AddrText, "err", err)
 		m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
 		delete(m.runtime, owned.scopeOf().scopePrefix())
+		m.clearOrphan(owned)
 		return nil
 	}
 	if isNopUpdater(backend) {
@@ -1175,6 +1304,7 @@ func (m *SurfaceAManager) withdrawOwnedLocked(ctx context.Context, owned ownedRe
 	}
 	m.state.delete(owned.scopeOf(), owned.Identity, owned.Address)
 	delete(m.runtime, owned.scopeOf().scopePrefix())
+	m.clearOrphan(owned)
 	slog.Info("ddns surface-a: withdrew record", "fqdn", owned.FQDN, "addr", owned.AddrText)
 	return nil
 }
@@ -1191,32 +1321,155 @@ func (m *SurfaceAManager) backendFor(sc SurfaceAScope) (DNSUpdater, error) {
 	return m.newBackend(sc.Provider, sc.FQDN, sc.TTL)
 }
 
-// backendForOwned resolves the live Backend for a WITHDRAW of an owned record
-// whose binding was REMOVED from config, so there is no live SurfaceAScope to
-// read the provider from (#2691 P2 MAJOR-2). It REBUILDS the SAME backend the
-// publish used by looking the owned record's provider (scope.PolicyID) up in the
-// still-committed provider catalog and feeding it through newBackend — so a
+// backendFingerprint returns a STABLE, NON-SECRET fingerprint of a provider's
+// backend ENDPOINT IDENTITY — the backend TYPE plus the server / zone /
+// hosted-zone / region / generic URL template (#3735). It deliberately EXCLUDES
+// every credential (TSIGSecret / Password / APIToken / AWSSecretAccessKey — all
+// config.Secret) and every non-endpoint field, so persisting it on the durable
+// ownedRecord does NOT reopen the #2053 plaintext-secret-on-disk class: no secret
+// is ever hashed in or written out. A change in this fingerprint between the
+// stored ownership and the current provider means the record was published at a
+// DIFFERENT endpoint than the one now configured for the same scope/name — the
+// H01/H02/H03 signal. Returns "" for a nil provider (fingerprint unknown —
+// compared as "cannot determine a mismatch", never a false alarm). The empty
+// backend token normalizes to "rfc2136" to match resolveSurfaceABackend's default
+// so an explicit `backend rfc2136` and the implicit default share a fingerprint.
+func backendFingerprint(p *config.DDNSProvider) string {
+	if p == nil {
+		return ""
+	}
+	backend := p.Backend
+	if backend == "" {
+		backend = "rfc2136" // resolveSurfaceABackend's default
+	}
+	// Length-prefixed, order-fixed, credential-free tuple so no pair of adjacent
+	// fields can alias across the boundary (a value cannot inject the separator).
+	var sb strings.Builder
+	writeField := func(s string) { fmt.Fprintf(&sb, "%d:%s|", len(s), s) }
+	writeField(backend)
+	writeField(p.UpdateServer) // rfc2136 target
+	writeField(p.Server)       // dyndns2 endpoint override
+	writeField(p.Zone)         // cloudflare zone
+	writeField(p.HostedZoneID) // route53 hosted zone
+	writeField(p.AWSRegion)    // route53 region
+	writeField(p.URLTemplate)  // generic endpoint template (%u/%p are placeholders, not live creds)
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(sb.String()))
+	return fmt.Sprintf("fp1-%016x", h.Sum64())
+}
+
+// ownedBackendStatus classifies whether an owned record's ORIGINAL publish
+// endpoint can be rebuilt from the CURRENT provider catalog for a withdraw
+// (#3735). Only ownedBackendOK is safe to issue a wire delete against — the other
+// two mean the old endpoint is unreachable through the current config, so a
+// withdraw would either no-op (provider gone) or, worse, delete at the WRONG
+// endpoint and false-success-drop ownership (endpoint changed).
+type ownedBackendStatus int
+
+const (
+	// ownedBackendOK — the provider is present and its endpoint fingerprint still
+	// matches (or one side is unknown, so no mismatch can be proven): the returned
+	// backend reaches the record's original endpoint. Safe to withdraw.
+	ownedBackendOK ownedBackendStatus = iota
+	// ownedBackendProviderGone — the record's provider (scope.PolicyID) is no
+	// longer in the catalog (H01: renamed/removed): the old endpoint cannot be
+	// rebuilt (no server/creds), so the record is orphaned.
+	ownedBackendProviderGone
+	// ownedBackendEndpointChanged — the provider is present but its endpoint
+	// fingerprint no longer matches the record's stored fingerprint (H03: an
+	// in-place server/zone edit after the binding was removed): rebuilding from the
+	// catalog reaches the NEW endpoint, so a withdraw there would delete at the
+	// wrong place / no-op and false-success-drop ownership. The record is orphaned.
+	ownedBackendEndpointChanged
+)
+
+// classifyOwnedBackend resolves the live backend for a WITHDRAW of an owned
+// record whose binding is gone from config (#2691 P2 MAJOR-2), and classifies
+// whether that backend actually reaches the record's ORIGINAL endpoint (#3735 —
+// the provider-aware successor to the old backendForOwned). It REBUILDS the same
+// backend the publish used by looking the owned record's provider (scope.PolicyID)
+// up in the still-committed catalog and feeding it through newBackend — so a
 // removed-binding withdraw sends a real DNS DELETE instead of orphaning the RR.
-// The static `backend` field (test injection) wins when set; when no factory and
-// no static backend are available the no-op is returned (and withdrawOwnedLocked
-// treats it as a failure that keeps ownership for retry, never a false success).
-func (m *SurfaceAManager) backendForOwned(owned ownedRecord, catalog map[string]*config.DDNSProvider) (DNSUpdater, error) {
+// The static `backend` field (test injection) always wins and is ownedBackendOK
+// (a fixed test backend is the single endpoint). A missing provider is
+// ownedBackendProviderGone; a present-but-fingerprint-mismatched provider is
+// ownedBackendEndpointChanged — both keep ownership + alarm rather than issuing a
+// wrong-endpoint delete / false-success drop.
+func (m *SurfaceAManager) classifyOwnedBackend(owned ownedRecord, catalog map[string]*config.DDNSProvider) (DNSUpdater, ownedBackendStatus, error) {
 	if m.backend != nil {
-		return m.backend, nil
+		return m.backend, ownedBackendOK, nil
 	}
 	if m.newBackend == nil {
-		return nopUpdater{}, nil
+		return nopUpdater{}, ownedBackendProviderGone, nil
 	}
 	policyID := owned.scopeOf().PolicyID
 	prov := catalog[policyID]
 	if prov == nil {
-		// The provider was removed alongside the binding: no credentials/server
-		// to rebuild the backend, so the RR cannot be withdrawn this cycle.
-		slog.Warn("ddns surface-a: owned record's provider is no longer in the catalog; cannot withdraw",
-			"fqdn", owned.FQDN, "provider", policyID)
-		return nopUpdater{}, nil
+		// The provider was removed alongside the binding (or renamed to a new
+		// name): no credentials/server to rebuild the backend, so the RR cannot be
+		// withdrawn — orphaned.
+		return nopUpdater{}, ownedBackendProviderGone, nil
 	}
-	return m.newBackend(prov, owned.FQDN, owned.TTL)
+	// A provider identity change under the SAME name (H03) keeps the PolicyID but
+	// points at a DIFFERENT endpoint. Compare the stored fingerprint with the
+	// current provider's; a proven mismatch means the catalog no longer describes
+	// the endpoint this record lives at, so a withdraw here would hit the wrong
+	// server (or no-op and false-success-drop ownership). Both fingerprints must
+	// be non-empty to prove a mismatch (an unknown/pre-#3735 fingerprint is never
+	// a false alarm).
+	if owned.BackendFingerprint != "" {
+		if cur := backendFingerprint(prov); cur != "" && cur != owned.BackendFingerprint {
+			return nopUpdater{}, ownedBackendEndpointChanged, nil
+		}
+	}
+	b, err := m.newBackend(prov, owned.FQDN, owned.TTL)
+	return b, ownedBackendOK, err
+}
+
+// orphanKey is the stable m.orphans map key for an owned record (#3735): its
+// scope prefix + published name + address. A given orphaned record contributes
+// exactly one entry regardless of how many reconcile passes re-observe it.
+func orphanKey(owned ownedRecord) string {
+	return owned.scopeOf().scopePrefix() + "|" + owned.FQDN + "|" + owned.AddrText
+}
+
+// noteOrphan records (once) that an owned record is stale at a PREVIOUS provider
+// endpoint and cannot be withdrawn automatically (#3735), and emits a single loud
+// operator alarm. It is idempotent by orphanKey so a re-derived orphan (every
+// reconcile re-classifies the still-owned H01/H03 records) does not re-warn each
+// sweep. newFP is the current provider's endpoint fingerprint ("" when the
+// provider is gone from the catalog). Caller holds m.mu.
+func (m *SurfaceAManager) noteOrphan(owned ownedRecord, newFP, reason string, now time.Time) {
+	if m.orphans == nil {
+		m.orphans = map[string]surfaceAOrphan{}
+	}
+	key := orphanKey(owned)
+	if _, ok := m.orphans[key]; ok {
+		return // already alarmed — do not re-warn every sweep
+	}
+	osc := owned.scopeOf()
+	m.orphans[key] = surfaceAOrphan{
+		FQDN:           owned.FQDN,
+		Address:        owned.AddrText,
+		Provider:       osc.PolicyID,
+		Interface:      osc.Interface,
+		Unit:           osc.Unit,
+		Family:         int(osc.Family),
+		OldFingerprint: owned.BackendFingerprint,
+		NewFingerprint: newFP,
+		Reason:         reason,
+		FirstSeen:      now,
+	}
+	slog.Warn("ddns surface-a: provider identity changed; OLD record ORPHANED at the previous endpoint and cannot be withdrawn automatically — MANUAL CLEANUP REQUIRED",
+		"fqdn", owned.FQDN, "addr", owned.AddrText, "provider", owned.scopeOf().PolicyID,
+		"old-endpoint", owned.BackendFingerprint, "new-endpoint", newFP, "reason", reason)
+}
+
+// clearOrphan drops any orphan alarm for an owned record (#3735) — called when
+// the record is cleanly adopted-in-place or withdrawn, so a later genuine
+// re-orphan re-alarms. A delete on an absent key is a no-op.
+func (m *SurfaceAManager) clearOrphan(owned ownedRecord) {
+	delete(m.orphans, orphanKey(owned))
 }
 
 // recordScopeError records a failure on a scope and advances its flat error
@@ -1359,10 +1612,16 @@ func (m *SurfaceAManager) StatusViews(scopes []SurfaceAScope) []SurfaceAStatusVi
 
 	// Orphaned ownership: a record for a scope no longer configured. The next
 	// reconcile (Pass 2) withdraws it; surface it as withdraw-pending so a wedged
-	// teardown is not invisible.
+	// teardown is not invisible. A record the reconciler has flagged as a #3735
+	// provider-change ORPHAN (stale at a previous endpoint, un-withdrawable) is
+	// covered by the dedicated orphan rows below instead — skip it here so it is
+	// not double-listed as merely withdraw-pending.
 	for _, r := range m.state.all() {
 		sc := r.scopeOf()
 		if _, ok := configured[sc.scopePrefix()]; ok {
+			continue
+		}
+		if _, isOrphan := m.orphans[orphanKey(r)]; isOrphan {
 			continue
 		}
 		v := SurfaceAStatusView{
@@ -1380,6 +1639,28 @@ func (m *SurfaceAManager) StatusViews(scopes []SurfaceAScope) []SurfaceAStatusVi
 			v.LastErrorAt = rt.lastErrAt
 		}
 		out = append(out, v)
+	}
+
+	// #3735 orphan alarm rows: a record stale at a PREVIOUS provider endpoint that
+	// a provider identity change (rename to a different endpoint / in-place
+	// server-zone edit / removed binding after an edit) left un-withdrawable
+	// through the current catalog. Ownership is KEPT; the row is the operator-
+	// visible half of the alarm (LastError carries the manual-cleanup reason). It
+	// is emitted for BOTH a gone-from-config record (H01/H03 — skipped above) and a
+	// still-configured scope whose OLD endpoint was orphaned by an in-place mutation
+	// (H02 — the healthy published row for the new endpoint also appears).
+	for _, o := range m.orphans {
+		out = append(out, SurfaceAStatusView{
+			Interface:   o.Interface,
+			Unit:        o.Unit,
+			Family:      o.Family,
+			FQDN:        o.FQDN,
+			Provider:    o.Provider,
+			Published:   o.Address,
+			State:       SurfaceAStateOrphaned,
+			LastError:   o.Reason,
+			LastErrorAt: o.FirstSeen,
+		})
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -1401,6 +1682,15 @@ type SurfaceAStats struct {
 	Skipped          uint64
 	BackedOff        uint64
 	SkippedNoBackend uint64
+	// Orphaned is the count of records this node published at a PREVIOUS provider
+	// endpoint that a provider identity change (rename / in-place mutation /
+	// removed binding after an edit) left stale and un-withdrawable through the
+	// current catalog (#3735). Each is surfaced as a SurfaceAStateOrphaned
+	// StatusViews row and drives the `xpf_ddns_surface_a_orphaned` gauge. A
+	// non-zero value means an old record needs MANUAL operator cleanup
+	// (auto-withdrawal is deferred — the old creds are redacted and the old
+	// endpoint is usually decommissioned).
+	Orphaned int
 	// Degraded is the FAIL-CLOSED alarm (#2971): the ownership state file could
 	// not be loaded (corrupt / unsupported-version / unreadable), so Reconcile
 	// refuses every publish/withdraw until the operator resolves it.
@@ -1436,6 +1726,7 @@ func (m *SurfaceAManager) Stats() SurfaceAStats {
 		Skipped:          m.skipped,
 		BackedOff:        m.backedOff,
 		SkippedNoBackend: m.skippedNoBackend,
+		Orphaned:         len(m.orphans),
 		Degraded:         m.degraded,
 		DegradedReason:   m.degradedReason,
 	}

--- a/pkg/ddns/surface_a_provider_change_3735_test.go
+++ b/pkg/ddns/surface_a_provider_change_3735_test.go
@@ -1,0 +1,447 @@
+package ddns
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3735 fail-on-revert proofs: a provider IDENTITY change (rename to a different
+// endpoint / in-place server-zone edit / removed binding after an edit) must not
+// silently mishandle the record the OLD provider published. The durable
+// ownedRecord now carries a NON-SECRET backend fingerprint, the #2903 adoption
+// guard is provider-AWARE, and an un-withdrawable old record is KEPT + alarmed
+// (never silently adopted, overwritten, or deleted at the wrong endpoint). These
+// drive the manager through the PRODUCTION wiring (newBackend set, m.backend nil)
+// with a per-endpoint fake so a delete at the WRONG endpoint is observable.
+
+// endpointRegistry hands out a distinct fakeUpdater per backend endpoint
+// (keyed by the provider's UpdateServer), so a test can assert exactly which
+// endpoint received an upsert or a delete — the crux of the H03 false-success
+// check (a withdraw must not land at the mutated NEW endpoint).
+type endpointRegistry struct {
+	mu sync.Mutex
+	by map[string]*fakeUpdater
+}
+
+func newEndpointRegistry() *endpointRegistry { return &endpointRegistry{by: map[string]*fakeUpdater{}} }
+
+func (r *endpointRegistry) get(ep string) *fakeUpdater {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	u := r.by[ep]
+	if u == nil {
+		u = newFakeUpdater()
+		r.by[ep] = u
+	}
+	return u
+}
+
+// newSurfaceAProviderChangeManager builds a manager with PRODUCTION wiring: only
+// newBackend is set (m.backend stays nil), and it resolves a per-endpoint fake
+// keyed on the provider's UpdateServer. So a publish/withdraw actually routes to
+// the endpoint the provider names — the same resolution production does.
+func newSurfaceAProviderChangeManager(t *testing.T, reg *endpointRegistry, now func() time.Time) *SurfaceAManager {
+	t.Helper()
+	dir := t.TempDir()
+	st, err := loadDDNSState(filepath.Join(dir, "iface-ddns.json"))
+	if err != nil {
+		t.Fatalf("loadDDNSState: %v", err)
+	}
+	return &SurfaceAManager{
+		state:   st,
+		runtime: map[string]*surfaceAState{},
+		orphans: map[string]surfaceAOrphan{},
+		now:     now,
+		newBackend: func(p *config.DDNSProvider, _ string, _ int) (DNSUpdater, error) {
+			return reg.get(p.UpdateServer), nil
+		},
+	}
+}
+
+// providerScope builds a Surface A scope bound to a provider whose backend
+// endpoint (UpdateServer) is `server` and whose provider name (PolicyID) is
+// `policyID`. The same *DDNSProvider must also be placed in the reconcile catalog
+// so the fingerprint matches on both the publish and withdraw sides.
+func providerScope(policyID, server, fqdn string) (SurfaceAScope, *config.DDNSProvider) {
+	prov := &config.DDNSProvider{Name: policyID, Backend: "rfc2136", UpdateServer: server}
+	sc := SurfaceAScope{
+		Key: ScopeKey{
+			Family:    FamilyV4,
+			Interface: "ge-0-0-2",
+			Unit:      50,
+			PolicyID:  policyID,
+			FQDN:      fqdn,
+		},
+		FQDN:     fqdn,
+		TTL:      300,
+		Source:   AddressSourceInterface,
+		Provider: prov,
+	}
+	return sc, prov
+}
+
+func orphanRow(views []SurfaceAStatusView) *SurfaceAStatusView {
+	for i := range views {
+		if views[i].State == SurfaceAStateOrphaned {
+			return &views[i]
+		}
+	}
+	return nil
+}
+
+// H01 — a provider RENAME to a DIFFERENT endpoint (prov-a -> prov-b, same
+// FQDN+addr) must NOT be silently adopted by the provider-blind #2903 guard.
+// Before #3735 liveRR keyed only on {FQDN, AddrText}, so the prov-b republish
+// made the old prov-a record's {FQDN, addr} "live" and the guard dropped prov-a
+// ownership WITHOUT a wire delete — orphaning the record at provider A with no
+// trace. Now the old record is KEPT and a loud orphan alarm fires.
+//
+// FAIL-ON-REVERT: revert the provider-aware liveByPolicy/liveByFP guard (back to
+// {FQDN, AddrText}) and prov-a is adopted again — Orphaned drops to 0 and Scopes
+// drops to 1, so the assertions below go RED.
+func TestSurfaceAProviderRenameDifferentEndpointOrphans(t *testing.T) {
+	reg := newEndpointRegistry()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAProviderChangeManager(t, reg, func() time.Time { return now })
+
+	scA, provA := providerScope("prov-a", "ns-a.example.net:53", "wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scA}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov-a": provA}); err != nil {
+		t.Fatalf("publish via prov-a: %v", err)
+	}
+	if got := len(reg.get("ns-a.example.net:53").upserts); got != 1 {
+		t.Fatalf("prov-a endpoint must have the initial publish; upserts=%d", got)
+	}
+
+	// Operator renames the provider stanza: prov-a is GONE, prov-b (a DIFFERENT
+	// endpoint) now owns the same FQDN+address.
+	scB, provB := providerScope("prov-b", "ns-b.example.net:53", "wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scB}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov-b": provB}); err != nil {
+		t.Fatalf("republish via prov-b: %v", err)
+	}
+
+	// No exact-RR delete anywhere: the old endpoint is un-withdrawable (prov-a
+	// gone), and the new endpoint's live RR must not be deleted.
+	if got := len(reg.get("ns-a.example.net:53").deletes); got != 0 {
+		t.Fatalf("no delete may reach the departed prov-a endpoint; deletes=%d", got)
+	}
+	if got := len(reg.get("ns-b.example.net:53").deletes); got != 0 {
+		t.Fatalf("the live RR at prov-b must not be exact-RR deleted; deletes=%d", got)
+	}
+	st := m.Stats()
+	if st.Orphaned != 1 {
+		t.Fatalf("a provider rename to a different endpoint must raise exactly one orphan alarm; stats=%+v", st)
+	}
+	if st.Scopes != 2 {
+		t.Fatalf("the old prov-a ownership must be KEPT (orphaned) alongside the new prov-b record; scopes=%d", st.Scopes)
+	}
+	views := m.StatusViews([]SurfaceAScope{scB})
+	row := orphanRow(views)
+	if row == nil || row.FQDN != "wan.example.net" || row.Provider != "prov-a" {
+		t.Fatalf("an orphaned status row naming the OLD provider must be surfaced; views=%+v", views)
+	}
+	if !strings.Contains(row.LastError, "manual cleanup required") {
+		t.Fatalf("the orphan row must carry the manual-cleanup reason; got %q", row.LastError)
+	}
+}
+
+// A provider rename to the SAME endpoint (prov-a -> prov-b, identical
+// server/zone) is a pure name change with NO real orphan: the fingerprint axis
+// adopts it in place (no wire delete, no false alarm). This guards the liveByFP
+// adoption axis specifically.
+//
+// FAIL-ON-REVERT: remove the fingerprint adoption axis (liveByFP) and this
+// same-endpoint rename is no longer adopted — it becomes a spurious orphan
+// (Orphaned==1), so the Orphaned==0 assertion goes RED.
+func TestSurfaceAProviderRenameSameEndpointAdoptsNoAlarm(t *testing.T) {
+	reg := newEndpointRegistry()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAProviderChangeManager(t, reg, func() time.Time { return now })
+
+	scA, provA := providerScope("prov-a", "ns-shared.example.net:53", "wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scA}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov-a": provA}); err != nil {
+		t.Fatalf("publish via prov-a: %v", err)
+	}
+	// Rename only the provider NAME; the endpoint is identical.
+	scB, provB := providerScope("prov-b", "ns-shared.example.net:53", "wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scB}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov-b": provB}); err != nil {
+		t.Fatalf("republish via prov-b: %v", err)
+	}
+	if got := len(reg.get("ns-shared.example.net:53").deletes); got != 0 {
+		t.Fatalf("a same-endpoint rename must adopt in place, not delete the live RR; deletes=%d", got)
+	}
+	st := m.Stats()
+	if st.Orphaned != 0 {
+		t.Fatalf("a same-endpoint rename is not an orphan (no false alarm); stats=%+v", st)
+	}
+	if st.Scopes != 1 {
+		t.Fatalf("the stale prov-a ownership must be adopted/dropped, leaving one record; scopes=%d", st.Scopes)
+	}
+}
+
+// H02 — an IN-PLACE provider mutation (same provider NAME, different endpoint)
+// keeps the scope key, so the scope is never a Pass-2 withdraw candidate; the
+// republish overwrites ownership with the NEW endpoint and orphans the record at
+// the OLD endpoint. publishLocked now detects the fingerprint change and alarms
+// while still publishing the new record.
+//
+// FAIL-ON-REVERT: remove the publishLocked fingerprint compare and the mutation
+// is silent — Orphaned stays 0, so the assertion goes RED.
+func TestSurfaceAProviderInPlaceMutationOrphansOldEndpoint(t *testing.T) {
+	reg := newEndpointRegistry()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAProviderChangeManager(t, reg, func() time.Time { return now })
+
+	scOld, provOld := providerScope("prov", "ns-a.example.net:53", "wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scOld}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov": provOld}); err != nil {
+		t.Fatalf("initial publish: %v", err)
+	}
+
+	// Edit the provider's server in place (same PolicyID); force a republish so
+	// the unchanged address still re-asserts the wire record.
+	scNew, provNew := providerScope("prov", "ns-b.example.net:53", "wan.example.net")
+	m.ForceRefresh()
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scNew}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov": provNew}); err != nil {
+		t.Fatalf("republish after in-place mutation: %v", err)
+	}
+
+	if got := len(reg.get("ns-b.example.net:53").upserts); got != 1 {
+		t.Fatalf("the new endpoint must receive the re-asserted record; upserts=%d", got)
+	}
+	if got := len(reg.get("ns-a.example.net:53").deletes); got != 0 {
+		t.Fatalf("the old endpoint's record must NOT be auto-withdrawn (deferred); deletes=%d", got)
+	}
+	st := m.Stats()
+	if st.Orphaned != 1 {
+		t.Fatalf("an in-place provider mutation must raise exactly one orphan alarm; stats=%+v", st)
+	}
+	views := m.StatusViews([]SurfaceAScope{scNew})
+	if orphanRow(views) == nil {
+		t.Fatalf("the in-place mutation orphan must be operator-visible; views=%+v", views)
+	}
+	// The healthy published row for the new endpoint is still present.
+	var published bool
+	for _, v := range views {
+		if v.State == SurfaceAStatePublished {
+			published = true
+		}
+	}
+	if !published {
+		t.Fatalf("the new-endpoint record must still be published; views=%+v", views)
+	}
+}
+
+// H03 — a removed-binding withdraw AFTER an in-place provider edit must NOT be
+// issued at the mutated NEW endpoint (a delete the new server accepts as a
+// no-op success, false-success-dropping ownership while the OLD record stays
+// live). classifyOwnedBackend now compares fingerprints and treats a mismatch as
+// un-withdrawable: KEEP ownership + alarm, no wrong-endpoint delete.
+//
+// FAIL-ON-REVERT: drop the fingerprint mismatch check (rebuild from the current
+// catalog like the old backendForOwned) and the withdraw lands at ns-b — the
+// ns-b delete count becomes 1, ownership is dropped (Scopes==0), and Orphaned
+// stays 0, so every assertion below goes RED.
+func TestSurfaceARemovedBindingWithdrawWrongEndpointOrphans(t *testing.T) {
+	reg := newEndpointRegistry()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAProviderChangeManager(t, reg, func() time.Time { return now })
+
+	scOld, provOld := providerScope("prov", "ns-a.example.net:53", "wan.example.net")
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{scOld}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov": provOld}); err != nil {
+		t.Fatalf("initial publish: %v", err)
+	}
+
+	// The binding is removed AND the provider was edited in place to a new
+	// endpoint. The catalog still has "prov", but it now points at ns-b.
+	provNew := &config.DDNSProvider{Name: "prov", Backend: "rfc2136", UpdateServer: "ns-b.example.net:53"}
+	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov": provNew}); err != nil {
+		t.Fatalf("removed-binding reconcile must not churn an error (terminal orphan): %v", err)
+	}
+
+	if got := len(reg.get("ns-b.example.net:53").deletes); got != 0 {
+		t.Fatalf("H03: a withdraw must NOT be issued at the mutated new endpoint; ns-b deletes=%d", got)
+	}
+	st := m.Stats()
+	if st.DeleteOK != 0 {
+		t.Fatalf("H03: no delete may be counted as success; stats=%+v", st)
+	}
+	if st.Scopes != 1 {
+		t.Fatalf("H03: ownership must be KEPT (no false-success drop); scopes=%d", st.Scopes)
+	}
+	if st.Orphaned != 1 {
+		t.Fatalf("H03: a wrong-endpoint withdraw must raise exactly one orphan alarm; stats=%+v", st)
+	}
+}
+
+// The legitimate #2903 on-disk migration (FQDN-less prefix -> FQDN-bearing
+// prefix, SAME provider) must STILL adopt in place with a real provider carrying
+// a fingerprint — proving the provider-aware guard does not regress the migration
+// path via the PolicyID axis when a fingerprint is present on the new record.
+func TestSurfaceAFQDNMigrationStillAdoptsWithFingerprint(t *testing.T) {
+	reg := newEndpointRegistry()
+	now := time.Unix(1_700_000_000, 0)
+	m := newSurfaceAProviderChangeManager(t, reg, func() time.Time { return now })
+
+	sc, prov := providerScope("prov", "ns.example.net:53", "wan.example.net")
+
+	// Seed a pre-#2903 ownership record: SAME provider + name + address, but keyed
+	// under the FQDN-LESS scope prefix and with NO stored fingerprint (older store).
+	legacyKey := sc.Key
+	legacyKey.FQDN = ""
+	m.state.put(ownedRecord{
+		Family:      4,
+		Identity:    surfaceAIdentity,
+		Address:     "",
+		FQDN:        "wan.example.net",
+		ForwardType: "A",
+		TTL:         300,
+		AddrText:    "203.0.113.5",
+	}.withScope(legacyKey))
+	if err := m.state.save(); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov": prov}); err != nil {
+		t.Fatalf("post-upgrade reconcile: %v", err)
+	}
+	if got := len(reg.get("ns.example.net:53").deletes); got != 0 {
+		t.Fatalf("the #2903 migration must not delete the live RR; deletes=%d", got)
+	}
+	st := m.Stats()
+	if st.Orphaned != 0 {
+		t.Fatalf("the same-provider migration must not false-alarm; stats=%+v", st)
+	}
+	if st.Scopes != 1 {
+		t.Fatalf("after migration exactly one record must remain owned; scopes=%d", st.Scopes)
+	}
+}
+
+// backendFingerprint is a STABLE, NON-SECRET endpoint fingerprint (#3735): it
+// changes with any endpoint-identity field and is INVARIANT to every credential
+// (the #2053 no-secret-on-disk property) and to non-endpoint transport fields.
+func TestBackendFingerprintStableAndSecretFree(t *testing.T) {
+	if backendFingerprint(nil) != "" {
+		t.Fatalf("nil provider must fingerprint to the empty string")
+	}
+	base := &config.DDNSProvider{
+		Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53",
+	}
+	if backendFingerprint(base) != backendFingerprint(&config.DDNSProvider{
+		Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53",
+	}) {
+		t.Fatalf("identical endpoint identity must fingerprint identically")
+	}
+
+	// An explicit `backend rfc2136` and the implicit default share a fingerprint.
+	if backendFingerprint(&config.DDNSProvider{Name: "p", UpdateServer: "ns.example.net:53"}) !=
+		backendFingerprint(&config.DDNSProvider{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53"}) {
+		t.Fatalf("empty backend must normalize to rfc2136 in the fingerprint")
+	}
+
+	// Every endpoint-identity field must move the fingerprint.
+	endpointChanges := []*config.DDNSProvider{
+		{Name: "p", Backend: "dyndns2", UpdateServer: "ns.example.net:53"},  // backend type
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns2.example.net:53"}, // server
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", Zone: "z"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", HostedZoneID: "Z"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", AWSRegion: "us-east-1"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", Server: "http://ep"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", URLTemplate: "http://ep/%h"},
+	}
+	baseFP := backendFingerprint(base)
+	for i, p := range endpointChanges {
+		if backendFingerprint(p) == baseFP {
+			t.Fatalf("endpoint change #%d must alter the fingerprint", i)
+		}
+	}
+
+	// Every CREDENTIAL / non-endpoint transport field must NOT move it (the #2053
+	// no-secret contract: the fingerprint must be persistable without disclosing a
+	// secret and without depending on one).
+	secretVariants := []*config.DDNSProvider{
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", TSIGSecret: config.Secret("hunter2")},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", Password: config.Secret("hunter2")},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", APIToken: config.Secret("tok")},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", AWSSecretAccessKey: config.Secret("sk")},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", Username: "u"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", TSIGKeyName: "k"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", AWSAccessKeyID: "AKIA"},
+		{Name: "p", Backend: "rfc2136", UpdateServer: "ns.example.net:53", SourceAddress: "203.0.113.9"},
+		{Name: "different-name", Backend: "rfc2136", UpdateServer: "ns.example.net:53"},
+	}
+	for i, p := range secretVariants {
+		if backendFingerprint(p) != baseFP {
+			t.Fatalf("credential/non-endpoint field #%d must NOT alter the fingerprint", i)
+		}
+	}
+}
+
+// The fingerprint is persisted on the owned record but NO secret is: the state
+// file must contain the fingerprint and must NOT contain the provider's TSIG
+// secret (the #2053 posture is unchanged by #3735).
+func TestSurfaceAFingerprintPersistedNoSecretOnDisk(t *testing.T) {
+	reg := newEndpointRegistry()
+	now := time.Unix(1_700_000_000, 0)
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "iface-ddns.json")
+	st, err := loadDDNSState(statePath)
+	if err != nil {
+		t.Fatalf("loadDDNSState: %v", err)
+	}
+	m := &SurfaceAManager{
+		state:   st,
+		runtime: map[string]*surfaceAState{},
+		orphans: map[string]surfaceAOrphan{},
+		now:     func() time.Time { return now },
+		newBackend: func(p *config.DDNSProvider, _ string, _ int) (DNSUpdater, error) {
+			return reg.get(p.UpdateServer), nil
+		},
+	}
+	prov := &config.DDNSProvider{
+		Name: "prov", Backend: "rfc2136", UpdateServer: "ns.example.net:53",
+		TSIGKeyName: "k", TSIGAlgorithm: "hmac-sha256", TSIGSecret: config.Secret("SUPERSECRETKEY=="),
+	}
+	sc := SurfaceAScope{
+		Key:      ScopeKey{Family: FamilyV4, Interface: "ge-0-0-2", Unit: 50, PolicyID: "prov", FQDN: "wan.example.net"},
+		FQDN:     "wan.example.net",
+		TTL:      300,
+		Source:   AddressSourceInterface,
+		Provider: prov,
+	}
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil,
+		map[string]*config.DDNSProvider{"prov": prov}); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	owned, ok := m.state.get(sc.effectiveKey(), surfaceAIdentity, "")
+	if !ok || owned.BackendFingerprint == "" || owned.BackendFingerprint != backendFingerprint(prov) {
+		t.Fatalf("the owned record must store the provider fingerprint; got %q", owned.BackendFingerprint)
+	}
+
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state file: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, owned.BackendFingerprint) {
+		t.Fatalf("the state file must persist the fingerprint")
+	}
+	if strings.Contains(body, "SUPERSECRETKEY==") {
+		t.Fatalf("#2053: the TSIG secret must NOT be written to the ownership state file")
+	}
+}

--- a/pkg/ddns/surface_a_rfc2136_test.go
+++ b/pkg/ddns/surface_a_rfc2136_test.go
@@ -196,9 +196,15 @@ func TestSurfaceARealBackendWithdrawOnConfigRemoval(t *testing.T) {
 	}
 }
 
-// MINOR M1: if the provider was removed from the catalog too, withdraw cannot
-// reach the wire — it must NOT claim success (no DeleteOK), must NOT drop
-// ownership (keep the RR cleanable), and must surface an error.
+// MINOR M1 + #3735: if the provider was removed from the catalog too
+// (rename/removal), the withdraw cannot reach the old endpoint. It must still NOT
+// claim success (no DeleteOK) and NOT drop ownership (keep the RR cleanable), but
+// pre-#3735 it churned a recurring reconcile error every sweep. #3735 recognizes
+// this as a TERMINAL orphan: a single loud operator alarm fires (Stats.Orphaned +
+// a SurfaceAStateOrphaned status row) and the wire delete is not re-attempted —
+// the record stays owned and operator-visible for MANUAL cleanup (auto-withdrawal
+// is deferred: the old creds are redacted config.Secret and the old endpoint is
+// usually decommissioned).
 func TestSurfaceARealBackendWithdrawNoProviderKeepsOwnership(t *testing.T) {
 	srv := newFakeDNSServer(t, nil)
 	srv.setStateful(true)
@@ -209,11 +215,19 @@ func TestSurfaceARealBackendWithdrawNoProviderKeepsOwnership(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 	// Binding AND provider both gone: empty scopes + empty catalog.
-	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, map[string]*config.DDNSProvider{}); err == nil {
-		t.Fatal("withdraw with no resolvable provider must surface an error, not silently succeed")
+	if err := m.Reconcile(context.Background(), nil, fixedObserver("203.0.113.5"), nil, map[string]*config.DDNSProvider{}); err != nil {
+		t.Fatalf("provider-gone withdraw must not churn a reconcile error (terminal orphan alarm): %v", err)
 	}
-	if st := m.Stats(); st.DeleteOK != 0 || st.Scopes != 1 {
+	st := m.Stats()
+	if st.DeleteOK != 0 || st.Scopes != 1 {
 		t.Fatalf("an unresolvable withdraw must not claim success nor drop ownership; stats=%+v", st)
+	}
+	if st.Orphaned != 1 {
+		t.Fatalf("#3735: a provider-gone withdraw must raise exactly one orphan alarm; stats=%+v", st)
+	}
+	views := m.StatusViews(nil)
+	if len(views) != 1 || views[0].State != SurfaceAStateOrphaned || views[0].FQDN != "wan.example.net" {
+		t.Fatalf("#3735: a provider-gone orphan must surface a SurfaceAStateOrphaned status row; got %+v", views)
 	}
 }
 


### PR DESCRIPTION
Closes #3735 (PLAN-READY half per the /research plan; guaranteed auto-cleanup DEFERRED — the old provider's withdraw isn't reliably issuable because old creds are `config.Secret` redacted-on-marshal per #2053, and the old endpoint is often decommissioned).

## Problem
The durable `ownedRecord` stores only the provider NAME, never a self-contained delete descriptor. So a provider rename/identity-change is silently orphaned by the provider-blind #2903 adoption guard (record kept live at the old provider, no trace).

## Fix (correctness + honest alarm, NO secret persistence)
- Non-secret backend **fingerprint** on `ownedRecord` (provider-type + hostname + zone + endpoint-host; no credentials) so a genuine provider change is detectable.
- Provider-**aware** adoption guard: the legitimate #2903 same-provider migration still adopts; a genuine provider change does not silently orphan.
- On a detected change where the old record can't be cleanly withdrawn: **keep ownership + loud orphan alarm** (status row + stats) so the operator can clean up manually.

## Validation
`go test ./pkg/ddns/...` green; `go build ./...`, gofmt, vet clean. Test `TestSurfaceAProviderRenameDifferentEndpointOrphans` (RED-on-revert by construction: without the guard the old record is silently orphaned → no alarm).

Note: the impl commit + test were finished across a transient API-529 interruption; both build and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)