### PR TITLE
nat: reject reversed application port range instead of narrowing (#3726)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26740,3 +26740,31 @@ top.
     (existing #2866/#3743 pins updated for new signatures),
     pkg/flowexport/routemask_vrf_test.go (new #3744 RED-on-revert pins),
     pkg/flowexport/README.md (#3744 section + file-layout bullet)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3726 — NAT `appPortsFromSpec` rejects a reversed
+    application port range instead of narrowing it to the low port.
+    Root cause: `appPortsFromSpec` (pkg/dataplane/userspace/nat.go)
+    expanded a `lo-hi` range only when `hi > lo`; the else arm returned
+    `[]int{lo}`, so a REVERSED range ("200-100", lo>hi) silently
+    narrowed to an EXACT match on the low port (200) rather than a
+    never-match. Strict commit rejects lo>hi; this is the #1960
+    tolerant-load / peer-sync backstop (same threat model as
+    #3429/#3437/#3446/#3491). Fix part 1: a reversed range (hi<lo)
+    returns nil (hi==lo still returns the single exact port; valid
+    lo<hi still expands). Fix part 2 (DNAT): the app-term builder lost
+    the "port configured" signal, so a nil port slice fell through to
+    the wildcard match-any-port default (destination_port==0) — a
+    fail-OPEN widening (also hit an out-of-range 70000-80000 app spec).
+    Added `dstPortConfigured` to `appTerm` and OR'd it into
+    `portConfigured` so a configured-but-empty app destination-port
+    fails CLOSED (emits no snapshot). SNAT already failed closed via
+    the #3429/#3491 never-match sentinel. RED-on-revert proven per half:
+    reverting appPortsFromSpec → 3 reversed tests RED; reverting the
+    DNAT guard → DNAT reversed test RED with destination_port=0
+    wildcard. go test ./pkg/dataplane/userspace/ + ./pkg/config/... +
+    ./pkg/dataplane/ green; go build ./... green; gofmt + vet clean.
+  - **File(s)**: pkg/dataplane/userspace/nat.go (appPortsFromSpec
+    reversed-range reject; appTerm.dstPortConfigured + portConfigured
+    guard), pkg/dataplane/userspace/nat_reversed_port_range_3726_test.go
+    (new RED-on-revert pins), docs/userspace-dnat-plan.md (§13b)

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -667,6 +667,45 @@ the source-NAT range fields carry; an older Go binary omits it and the newer
 helper falls back to the per-port `destination_port` expansion such a binary
 still emits.
 
+## 13b. Reversed application port range fails closed (#3726)
+
+`appPortsFromSpec` (`pkg/dataplane/userspace/nat.go`) expands an application's
+`source-port` / `destination-port` spec into concrete ports for the NAT match
+terms. For a `lo-hi` range it expanded only when `hi > lo`; for every other case
+it returned `[]int{lo}` — so a REVERSED range (`200-100`, `lo > hi`) silently
+narrowed to an EXACT match on the low port (200) instead of a never-match. The
+`hi == lo` case (e.g. `100-100`) legitimately returns `[lo]`.
+
+- **H04** — a reversed application `destination-port` referenced by a source- or
+  destination-NAT rule translated traffic on port 200 (the low bound), even
+  though the configured range is invalid and can never match a real flow.
+
+Strict commit rejects `lo > hi` (`pkg/config` range validation), so this is the
+#1960 tolerant-load / peer-sync backstop — the same accepted threat model as
+§13 (#3446) and the source-port / ICMP work (#3437 / #3491).
+
+- **Helper fix (`appPortsFromSpec`).** A reversed range (`hi < lo`) returns `nil`
+  (not `[]int{lo}`), so the caller sees "configured but unrepresentable" and
+  fails CLOSED. `hi == lo` keeps its single exact port; valid `lo < hi` ranges
+  expand unchanged.
+
+- **Source-NAT** already failed closed on this signal: `buildSourceNATAppTerms`
+  emits the `natNeverMatchPortRange` sentinel when a non-empty spec coalesces to
+  nothing (the #3429 / #3491 guard), so a reversed range now yields the
+  never-match `{Low:1, High:0}` term instead of an exact-200 match.
+
+- **Destination-NAT** needed a matching guard. The app-term builder stored the
+  coalesced ports but LOST the "a port was configured" signal, so a `nil` port
+  slice fell through to the wildcard match-any-port default (`destination_port
+  == 0`) — a fail-OPEN that widened the rule to every port (the same latent gap
+  hit an all-out-of-range `70000-80000` app spec). The `appTerm` now carries
+  `dstPortConfigured` (true when the application named a non-empty
+  destination-port), and the port-filtering loop treats a configured-but-empty
+  term as `portConfigured` → it emits NO snapshot for that term (the rule
+  installs nothing and does not translate), matching the §13 fail-closed
+  posture. A valid or `hi==lo` app destination-port still publishes its exact
+  DNAT entry.
+
 ## 14. DNAT pool port/address validation (#3450)
 
 A destination-NAT **pool**'s translated `port` and `address` had NO strict

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -579,6 +579,17 @@ func appPortsFromSpec(spec string) []int {
 			}
 			return ports
 		}
+		if hi < lo {
+			// #3726: a REVERSED range ("200-100", lo>hi) is invalid — it can
+			// never match any port. Return nil (not []int{lo}) so the caller
+			// treats it as "configured but unrepresentable" and fails CLOSED
+			// via the never-match sentinel, rather than silently narrowing the
+			// NAT rule to an exact match on the low port. Strict commit already
+			// rejects lo>hi (pkg/config range validation); this hardens the
+			// #1960 tolerant-load / peer-sync backstop. The hi==lo case below
+			// is a legitimate single exact port.
+			return nil
+		}
 		return []int{int(lo)}
 	}
 	p, err := strconv.ParseUint(spec, 10, 16)
@@ -788,6 +799,15 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 				srcPorts []NatPortRangeWire
 				icmpType *uint8
 				icmpCode *uint8
+				// dstPortConfigured records that the application specified a
+				// non-empty destination-port spec, even if it coalesced to no
+				// representable port (all out of 1..65535, or a reversed
+				// "200-100" range rejected by appPortsFromSpec, #3726). The
+				// port-filtering loop below reads this so a configured-but-
+				// unrepresentable app destination-port fails CLOSED (never
+				// match) instead of widening to the wildcard match-any-port
+				// term — the DNAT analog of the source-NAT #3429/#3491 guard.
+				dstPortConfigured bool
 			}
 			var appTerms []appTerm
 
@@ -800,11 +820,12 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 					srcPorts = []NatPortRangeWire{natNeverMatchPortRange}
 				}
 				return appTerm{
-					proto:    a.Protocol,
-					ports:    appPortsFromSpec(a.DestinationPort),
-					srcPorts: srcPorts,
-					icmpType: a.ICMPType,
-					icmpCode: a.ICMPCode,
+					proto:             a.Protocol,
+					ports:             appPortsFromSpec(a.DestinationPort),
+					srcPorts:          srcPorts,
+					icmpType:          a.ICMPType,
+					icmpCode:          a.ICMPCode,
+					dstPortConfigured: a.DestinationPort != "",
 				}
 			}
 
@@ -905,7 +926,13 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 				portRanges := coalescePortRanges(term.ports)
 				// Did this rule CONFIGURE a destination-port at all? A configured
 				// port that survived to no valid value must not become wildcard.
-				portConfigured := len(term.ports) > 0 ||
+				// #3726: term.dstPortConfigured is true when the application named
+				// a destination-port that coalesced to nothing (all out of
+				// 1..65535, or a reversed "200-100" range now rejected by
+				// appPortsFromSpec). Without this the app term's empty ports
+				// slipped through to the wildcard match-any-port default — a
+				// fail-open that widened the DNAT rule to every port.
+				portConfigured := len(term.ports) > 0 || term.dstPortConfigured ||
 					(explicitFallback && (rule.Match.DestinationPort != 0 || len(rule.Match.InvalidDestinationPorts) > 0))
 				if len(portRanges) == 0 {
 					switch {

--- a/pkg/dataplane/userspace/nat_reversed_port_range_3726_test.go
+++ b/pkg/dataplane/userspace/nat_reversed_port_range_3726_test.go
@@ -1,0 +1,140 @@
+// #3726: appPortsFromSpec must REJECT a reversed application port range
+// ("200-100", lo>hi) rather than silently narrowing it to an exact match on the
+// low port ([200]). A reversed range can never match any port, so it must fail
+// CLOSED — source NAT emits the never-match sentinel, destination NAT emits no
+// snapshot (no translation) — instead of translating traffic to the low port.
+//
+// The equal-bound case (hi==lo, e.g. "100-100") is a legitimate single exact
+// port and must be preserved. Valid ranges (lo<hi) still expand.
+//
+// Strict commit already rejects lo>hi (pkg/config range validation); these
+// guard the #1960 tolerant-load / peer-sync backstop, the same accepted threat
+// model as #3429 / #3437 / #3446 / #3491.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestAppPortsFromSpecRejectsReversedRange is the direct unit test on the
+// helper. RED-on-revert: the pre-fix helper returned []int{lo} for lo>hi.
+func TestAppPortsFromSpecRejectsReversedRange(t *testing.T) {
+	if got := appPortsFromSpec("200-100"); len(got) != 0 {
+		t.Fatalf("appPortsFromSpec(\"200-100\") = %+v, want nil (reversed range rejected, NOT narrowed to [200])", got)
+	}
+	// hi == lo is a legitimate single exact port.
+	if got := appPortsFromSpec("100-100"); len(got) != 1 || got[0] != 100 {
+		t.Fatalf("appPortsFromSpec(\"100-100\") = %+v, want [100] (equal-bound single port)", got)
+	}
+	// A single bare port is unchanged.
+	if got := appPortsFromSpec("443"); len(got) != 1 || got[0] != 443 {
+		t.Fatalf("appPortsFromSpec(\"443\") = %+v, want [443]", got)
+	}
+	// A valid ascending range still expands inclusively.
+	if got := appPortsFromSpec("100-102"); len(got) != 3 || got[0] != 100 || got[2] != 102 {
+		t.Fatalf("appPortsFromSpec(\"100-102\") = %+v, want [100 101 102]", got)
+	}
+}
+
+// Source NAT: an application whose destination-port is a reversed range must
+// emit the never-match sentinel, NOT an exact match on the low port and NOT an
+// empty (unconstrained) list. RED-on-revert: the pre-fix helper returned [200],
+// so MatchApplications[0].Ports coalesced to {200,200} (exact match on 200).
+func TestBuildSourceNATSnapshotsAppReversedDestPortFailsClosed(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Applications.Applications = map[string]*config.Application{
+		"rev": {Name: "rev", Protocol: "tcp", DestinationPort: "200-100"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name:  "r1",
+				Match: config.NATMatch{Application: "rev"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	apps := buildSourceNATSnapshots(cfg, nil)[0].MatchApplications
+	if len(apps) != 1 {
+		t.Fatalf("MatchApplications = %+v, want 1 term", apps)
+	}
+	want := []NatPortRangeWire{natNeverMatchPortRange}
+	if len(apps[0].Ports) != len(want) || apps[0].Ports[0] != want[0] {
+		t.Fatalf("term ports = %+v, want one never-match range %+v (reversed range fails closed, NOT exact-low-port [200])",
+			apps[0].Ports, want)
+	}
+}
+
+// Source NAT over-reject control: an equal-bound "100-100" is a legitimate
+// single exact port and must still compile to {100,100}.
+func TestBuildSourceNATSnapshotsAppEqualDestPortStaysExact(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Applications.Applications = map[string]*config.Application{
+		"eq": {Name: "eq", Protocol: "tcp", DestinationPort: "100-100"},
+	}
+	cfg.Security.NAT.Source = []*config.NATRuleSet{
+		{
+			Name:     "rs",
+			FromZone: "lan",
+			ToZone:   "wan",
+			Rules: []*config.NATRule{{
+				Name:  "r1",
+				Match: config.NATMatch{Application: "eq"},
+				Then:  config.NATThen{Type: config.NATSource, Interface: true},
+			}},
+		},
+	}
+	apps := buildSourceNATSnapshots(cfg, nil)[0].MatchApplications
+	if len(apps) != 1 {
+		t.Fatalf("MatchApplications = %+v, want 1 term", apps)
+	}
+	want := []NatPortRangeWire{{Low: 100, High: 100}}
+	if len(apps[0].Ports) != len(want) || apps[0].Ports[0] != want[0] {
+		t.Fatalf("term ports = %+v, want %+v (equal-bound single port preserved)", apps[0].Ports, want)
+	}
+}
+
+// Destination NAT: an application whose destination-port is a reversed range
+// must fail CLOSED — emit NO snapshot so the rule installs nothing and does not
+// translate. RED-on-revert covers BOTH halves of the fix:
+//   - revert appPortsFromSpec (returns [200]): the term carries an exact port
+//     200 and a snapshot with DestinationPort=200 is emitted (len 1).
+//   - revert the dstPortConfigured guard (term.ports nil, no configured
+//     signal): the term falls through to the wildcard match-any-port default
+//     and a snapshot with DestinationPort=0 is emitted (len 1).
+//
+// Either regression makes len(snaps) == 1, so the len==0 assertion goes RED.
+func TestBuildDNATSnapshotAppReversedDestPortFailsClosed(t *testing.T) {
+	cfg := dnatAppConfig("rev", &config.Application{
+		Name:            "rev",
+		Protocol:        "tcp",
+		DestinationPort: "200-100",
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 0 {
+		t.Fatalf("DNAT snapshots = %+v, want none (reversed app destination-port fails closed: no exact-low-port match, no wildcard match-any-port)", snaps)
+	}
+}
+
+// Destination NAT over-reject control: an equal-bound "100-100" is a legitimate
+// single exact port and must still publish the DNAT rule with DestinationPort
+// 100 (not dropped, not widened).
+func TestBuildDNATSnapshotAppEqualDestPortStaysExact(t *testing.T) {
+	cfg := dnatAppConfig("eq", &config.Application{
+		Name:            "eq",
+		Protocol:        "tcp",
+		DestinationPort: "100-100",
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("DNAT snapshots = %d, want 1 (equal-bound single port preserved)", len(snaps))
+	}
+	if snaps[0].DestinationPort != 100 {
+		t.Fatalf("DNAT DestinationPort = %d, want 100 (equal-bound single exact port)", snaps[0].DestinationPort)
+	}
+}


### PR DESCRIPTION
Closes #3726

## Problem

`appPortsFromSpec` (`pkg/dataplane/userspace/nat.go`) expands an
application's `source-port` / `destination-port` spec into concrete
ports for the NAT match terms. For a `lo-hi` range it expanded only when
`hi > lo`; every other case returned `[]int{lo}`. A REVERSED range
(`"200-100"`, `lo > hi`) therefore silently narrowed to an EXACT match
on the low port (200) instead of a never-match — so a misconfigured
reversed NAT port range translated real traffic on port 200. The
`hi == lo` case (e.g. `"100-100"`) legitimately returns the single port.

Strict commit rejects `lo > hi` (`pkg/config` range validation), so this
is the #1960 tolerant-load / peer-sync backstop — the same accepted
threat model as #3429 / #3437 / #3446 / #3491. This is DISTINCT from the
direct-match / pool grammar fixes (#3446 / #3450) and the dropped
source-port / ICMP constraint fixes (#3437 / #3491); it is the NAT
application-port helper residual (codex-review-155 H04).

## Fix (two parts)

1. **`appPortsFromSpec`** — a reversed range (`hi < lo`) returns `nil`
   (not `[]int{lo}`) so the caller treats it as "configured but
   unrepresentable" and fails CLOSED. `hi == lo` keeps its single exact
   port; valid `lo < hi` ranges expand unchanged.

2. **Destination NAT app-term builder** — the term stored the coalesced
   ports but lost the "a destination-port was configured" signal, so a
   `nil` port slice fell through to the wildcard match-any-port default
   (`destination_port == 0`) — a **fail-OPEN** that widened the DNAT rule
   to every port (the same gap also hit an all-out-of-range
   `"70000-80000"` app spec). `appTerm` now carries `dstPortConfigured`
   (true when the application named a non-empty destination-port), OR'd
   into `portConfigured`, so a configured-but-empty app destination-port
   emits NO snapshot (the rule installs nothing and does not translate)
   — the §13 fail-closed posture.

Source NAT already failed closed on this signal via the #3429 / #3491
never-match sentinel (`natNeverMatchPortRange`), so a reversed
source-NAT app destination-port now yields the `{Low:1, High:0}`
never-match term instead of an exact-200 match.

## Validation

RED-on-revert proven **per half**:
- Revert the `appPortsFromSpec` change → the three reversed-range tests
  go RED (the helper returns `[200]`, SNAT coalesces to `{200,200}`,
  DNAT emits `destination_port=200`).
- Revert the DNAT `dstPortConfigured` guard → `TestBuildDNATSnapshotApp
  ReversedDestPortFailsClosed` goes RED with `destination_port=0` (the
  wildcard fail-open).
- Equal-bound (`"100-100"`) and single-port controls stay green
  (no over-reject).

`go test ./pkg/dataplane/userspace/`, `./pkg/config/...`,
`./pkg/dataplane/` all green; `go build ./...` green; `gofmt` + `go vet`
clean.

Docs: `docs/userspace-dnat-plan.md` §13b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi