### PR TITLE
ddns: value-specific self-owned publish (Cloudflare H11 + RFC 2136 M08)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-01 — #3739: DDNS Surface A value-specific self-owned publish
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The Surface A self-owned publish path clobbered a
+    co-resident FOREIGN A/AAAA at a shared name. Cloudflare (H11) PATCHed
+    `recs[0]` (an API-ordering artifact) to xpf's address; RFC 2136 (M08)
+    `RemoveRRset`d the WHOLE A/AAAA set before inserting. Both now do a
+    VALUE-SPECIFIC in-place replace that touches ONLY xpf's own value.
+    ENABLER: threaded the previously-published rdata to the backend via a
+    new `LeaseDNSRecord.PrevAddr` field, set in `publishLocked` from the
+    prevAddr it already computed (seeded across restart from the durable
+    store's `AddrText`). Cloudflare `UpsertLease`: list all rows, no-op if a
+    row already carries the new value, else PATCH the row carrying `PrevAddr`
+    in place, else POST a new record (never `recs[0]`). RFC 2136
+    `sendAddSelfOwned`: when `selfOwnedPrevAddr` is valid and differs from
+    the new value, pair an EXACT-RR delete (`Remove`, CLASS=NONE) of xpf's
+    prior rdata with the insert, in ONE atomic UPDATE (no-blackhole
+    preserved); Insert-only on first publish / same-value re-publish. Added
+    helpers `rrAddr` + `prevSelfOwnedRR`. Route 53 (M07) DEFERRED per the
+    converged /research plan — whole-RRSet UPSERT with no per-value op / no
+    CAS would need a new SigV4 ListResourceRecordSets GET + a racy RMW; its
+    DELETE already fails safe. Documented all three in `pkg/ddns/README.md`.
+  - **Files**: `pkg/ddns/backend.go` (PrevAddr field),
+    `pkg/ddns/surface_a.go` (thread PrevAddr into rec),
+    `pkg/ddns/backend_cloudflare.go` (value-specific UpsertLease, dropped
+    findRecord), `pkg/ddns/backend_rfc2136.go` (selfOwnedPrevAddr +
+    value-specific sendAddSelfOwned + helpers),
+    `pkg/ddns/backend_cloudflare_test.go` (ordered fake + 2 RED-on-revert
+    tests + PrevAddr on the renumber case),
+    `pkg/ddns/surface_a_rfc2136_test.go` (co-resident foreign-survives test),
+    `pkg/ddns/README.md`.
+  - **Validation**: `go test -race ./pkg/ddns/...` green; RED-on-revert
+    proven for both providers (revert Cloudflare → recs[0] and RFC 2136 →
+    RemoveRRset each make the new tests fail deterministically);
+    `go build ./...`, `go vet ./pkg/ddns/...`, `gofmt -l` clean;
+    `go test ./pkg/dhcpserver/...` (lease-path consumer) green.
+
 ## 2026-07-01 — #3748 (sub-part b): IPFIX sampler Options Template + record
 
 - **Timestamp**: 2026-07-01

--- a/pkg/ddns/README.md
+++ b/pkg/ddns/README.md
@@ -23,7 +23,7 @@ moved with its assertions intact.
 | `surface_a.go` | Surface A router/interface-address publish engine (`SurfaceAManager`): change-detection, forced-refresh wire floor, the `ForceRefresh()` operator force-now latch (#3276), per-scope error backoff, per-RG HA gate, the backend factory `productionSurfaceABackend` (#2691 P2/P3). **Operator-hostname intent (#2779):** the publish path (`surfaceAName` → `sanitizeFQDN`) lower-cases + strips non-LDH characters + drops empty-sanitizing labels. For a *router-owned* Surface A record the hostname is operator intent (the operator types the exact public name), so a name that sanitization would STRUCTURALLY change is now a **commit error** (`config.ValidateDDNSHostname` on the typed `interfaces … dynamic-dns hostname` leaf) instead of a silent rewrite to a different DNS name — e.g. `wan_1.example.net` is rejected at commit rather than published as `wan1.example.net`. Case-folding and a single trailing dot are accepted (benign DNS canonicalizations). Every name that PASSES the commit check is a fixed point of `sanitizeFQDN` (cross-package contract test `surface_a_hostname_2779_test.go`), so the published name equals operator intent. |
 | `backend_http.go` | Shared HTTP-backend discipline (#2691 P3): hardened `http.Client` (TLS-verified, bounded timeout), capped body read, `classifyHTTPStatus`, `queryEscape`, the `errHTTPAuth`/`errHTTPRateLimited` verdicts. **Source binding (#2846):** `newHTTPClientBound(bindConfig)` installs the SAME `backend_bind.go` source/interface/VRF `Dialer` (via `Transport.DialContext`) so the HTTP backends + checkip egress from the operator-configured `source-address` / `destination-interface` / `routing-instance` — not the kernel default route. `newHTTPClient()` is the no-bind alias (unbound default, behaviour unchanged). `resolveProviderBindConfig`/`newProviderHTTPClient` adapt a `config.DDNSProvider`'s leaves onto `resolveBindConfig`; a malformed `source-address` is a hard error so the backend constructor degrades to no-op (fail-open, mirrors rfc2136). |
 | `backend_dyndns2.go` | dyndns2 backend (#2691 P3): one impl behind many provider names (`dyndns2Endpoints`), `good`/`nochg`/`badauth`/`abuse`/`911`/`nohost` verdict parsing. |
-| `backend_cloudflare.go` | Cloudflare API backend (#2691 P3): Bearer token, zone-id resolve → find → PATCH/POST/DELETE record. **Withdraw is content-scoped (#2770):** `DeleteLease` lists EVERY record for the FQDN+type and deletes only the rows whose `content` equals the owned address (`rec.Addr.Unmap().String()`), removing ALL such duplicates. It never deletes a row with a different value (a human/automation changed it after xpf published — an ownership conflict that is a success no-op), honouring the Surface A sole-delete-authority boundary that Route 53 / RFC 2136 also enforce. `recs[0]` is an API-ordering artifact, not ownership. |
+| `backend_cloudflare.go` | Cloudflare API backend (#2691 P3): Bearer token, zone-id resolve → list → PATCH/POST/DELETE record. **Upsert is value-specific (#3739 H11):** `UpsertLease` lists EVERY A/AAAA at the name and touches ONLY xpf's own row — a row already carrying the new value is a no-op, else the row carrying xpf's PREVIOUS value (`rec.PrevAddr`) is PATCHed in place, else a new record is POSTed. It NEVER PATCHes `recs[0]` (an API-ordering artifact), so a co-resident FOREIGN A/AAAA a human set on the same name is never rewritten to xpf's address. **Withdraw is content-scoped (#2770):** `DeleteLease` lists EVERY record for the FQDN+type and deletes only the rows whose `content` equals the owned address (`rec.Addr.Unmap().String()`), removing ALL such duplicates. It never deletes a row with a different value (a human/automation changed it after xpf published — an ownership conflict that is a success no-op), honouring the Surface A sole-delete-authority boundary that RFC 2136 also enforces (Route 53 replaces the whole RRSet on upsert — see the P2 note). `recs[0]` is an API-ordering artifact, not ownership. |
 | `backend_dyndns2.go` | dyndns2 backend (#2691 P3): one impl behind many provider names (`dyndns2Endpoints`), `good`/`nochg`/`badauth`/`abuse`/`911`/`nohost` verdict parsing. **Withdraw (#2772):** `DeleteLease` issues the same update GET with `offline=YES` (the de-facto dyndns2 withdraw verb) and parses the body verdict; a provider failure returns a non-nil error so the engine keeps ownership for retry (was a silent no-op that orphaned the public record). **DuckDNS is NOT here (#2960):** DuckDNS is not dyndns2-protocol-compatible, so it has its own `backend_duckdns.go`; `duckdns` was removed from `dyndns2Endpoints`. **Server validation (#3737):** `resolveDyndns2Endpoint` decides full-URL vs bare-host on the `://` delimiter, parses the URL with `url.Parse`, compares the scheme with `strings.EqualFold` (case-INSENSITIVE per RFC 3986 §3.1, so `HTTPS://host` is accepted — the old case-sensitive `HasPrefix` misclassified it as a bare host and produced a doubly-suffixed malformed URL), and requires a non-empty `Hostname()` in BOTH cases so a hostless value (`http://`, `https:///nic/update`, `:8080`) fails at construction (manager falls back to no-op) instead of only at the first publish. This is the SAME discipline as checkip's `validateCheckIPURL` (#2842) and generic's `validateGenericURLTemplate` (#2841). A malformed `server` is also warned at commit by `config.validateSurfaceADDNSWarnings` (mirror `ddnsDyndns2ServerValid`, RedactURL'd in the message). |
 | `backend_duckdns.go` | DuckDNS backend (#2960): its OWN backend, not a dyndns2 alias. `UpsertLease` issues `GET /update?domains=<label>&token=<tok>&ip=<v4>` (or `&ipv6=<v6>` for AAAA) — the token is a QUERY param (the DuckDNS auth model), not HTTP Basic; the `domains` value is the bare subdomain label (`duckdnsDomain` strips a trailing dot + a `.duckdns.org` suffix). Success is the literal `OK` body (`KO` ⇒ hard auth/config error, `errHTTPAuth`); dyndns2's `good`/`nochg` is NOT a DuckDNS success. **Withdraw (#2960):** `DeleteLease` sends `&clear=true` (the DuckDNS clear verb, not dyndns2's `offline=YES`); DuckDNS clear has no per-family form, so it removes BOTH the A and the AAAA for the domain. The body verdict is parsed like an upsert, so a failed clear keeps ownership for retry. The token comes from the `api-token` leaf (reused from cloudflare). The endpoint defaults to `https://www.duckdns.org/update` and is `server`-overridable for test/mocking. **One family per name (#2960):** the DuckDNS update API has no per-family verb — omitting `ip=`/`ipv6=` makes DuckDNS AUTO-DETECT and SET that family ("If you do not specify the IP address, then it will be detected", duckdns.org/spec.jsp), so a v6-only update overwrites the A. Surface A scopes are per-family with no per-FQDN coalescing, so a dual-stack DuckDNS name has two scopes that clobber each other's A/AAAA on every reconcile. The supported topology is therefore ONE family per DuckDNS name; binding the same DuckDNS name on both `inet` and `inet6` is flagged at commit by `config.validateSurfaceADDNSWarnings`. |
 | `backend_cloudflare.go` | Cloudflare API backend (#2691 P3): Bearer token, zone-id resolve → find → PATCH/POST/DELETE record. |
@@ -403,20 +403,45 @@ its OWN learned address — on top of the SAME spine, without forking the engine
   the SAME `ScopeKey` ownership primitive, the SAME source/VRF binding
   (`backend_bind.go`, via `DHCPDynamicDNSConfig` as the transport carrier), and
   the SAME write-ahead durability discipline.
-- **Self-owned forward ADD = atomic in-place replace** (`rfc2136Updater.selfOwned`
-  → `sendAddSelfOwned`). A router record has NO DHCID (the firewall IS the
-  authoritative owner of its OWN configured FQDN). The lease path's two
-  prerequisites — name-not-in-use (Attempt A) and DHCID-match (Attempt B) — both
-  REFUSE a pre-existing name when there is no DHCID, which would pin a self-record
-  at its first address forever (the #2691 P2 MAJOR-1 bug). So a self-owned
-  forward add is a SINGLE RFC 2136 UPDATE that, in one message, `RemoveRRset`s our
-  forward type at our name (CLASS=ANY, our type only — co-resident records of a
-  DIFFERENT type are never touched) and `Insert`s the new rdata. The server
-  applies both atomically: a same-address forced-refresh deletes-then-re-adds the
-  identical RR (a no-op net change that SUCCEEDS), and an address change replaces
-  the rdata with NO withdraw-then-add blackhole gap. (Third-party case: the
-  firewall owns the name; two firewalls pointed at the same self-record FQDN is an
-  operator misconfig — the per-RG HA gate prevents the in-cluster two-writer case.)
+- **Self-owned forward ADD = atomic VALUE-SPECIFIC in-place replace**
+  (`rfc2136Updater.selfOwned` → `sendAddSelfOwned`). A router record has NO DHCID
+  (the firewall IS the authoritative owner of its OWN configured FQDN). The lease
+  path's two prerequisites — name-not-in-use (Attempt A) and DHCID-match (Attempt
+  B) — both REFUSE a pre-existing name when there is no DHCID, which would pin a
+  self-record at its first address forever (the #2691 P2 MAJOR-1 bug). So a
+  self-owned forward add is a SINGLE RFC 2136 UPDATE that publishes the new rdata
+  and, when the PREVIOUS published value is known (threaded via `LeaseDNSRecord.
+  PrevAddr` from `publishLocked`, seeded across restart from the durable store's
+  `AddrText`), pairs it with an EXACT-RR delete (RFC 2136 §2.5.4, CLASS=NONE) of
+  ONLY xpf's OWN prior value. **#3739 (M08):** this replaced the old
+  `RemoveRRset` (CLASS=ANY delete of the WHOLE A/AAAA set at the name), which
+  destroyed a CO-RESIDENT FOREIGN A/AAAA a human/other appliance had set on the
+  same name. The value-specific replace touches only xpf's own value, so a foreign
+  record now SURVIVES. The server applies delete+insert atomically: a same-address
+  forced-refresh is an idempotent `Insert`-only no-op (nothing to delete); an
+  address change is `Remove(old)`+`Insert(new)` with NO withdraw-then-add
+  blackhole gap; a first publish (or a lost prior value) is `Insert`-only
+  (additive — coexists with any foreign RR rather than clobbering the name). It
+  still never touches a DIFFERENT record TYPE at the name and never issues a
+  delete-RRset/delete-name. (Third-party case: two firewalls pointed at the same
+  self-record FQDN now COEXIST — each manages only its own value — rather than
+  fighting; the per-RG HA gate prevents the in-cluster two-writer case.)
+- **Per-provider co-resident behaviour on publish (#3739).** The value-specific
+  publish above is implemented for the two backends whose protocol supports a
+  single-value operation: **Cloudflare** (per-record-id `PATCH`/`POST`, #3739 H11)
+  and **RFC 2136** (exact-RR delete + insert, #3739 M08). Both touch ONLY xpf's
+  own value, so a co-resident foreign A/AAAA at a shared name survives.
+  **Route 53 is DEFERRED (M07).** `ChangeResourceRecordSets` `UPSERT` replaces the
+  ENTIRE RRSet at name+type — it has no per-value add/remove and no
+  compare-and-swap. Preserving a co-resident foreign value would require a NEW
+  SigV4-signed `ListResourceRecordSets` GET plus a read-modify-write with a
+  genuine race window (no CAS). That is disproportionate risk for the
+  low-reachability shared-name case, and the Route 53 DELETE path already fails
+  SAFE (a delete of a shared RRSet fails `InvalidChangeBatch` "not found" →
+  idempotent no-op, `r53DeleteAlreadyGone`, #2771). So Route 53 still
+  whole-RRSet-replaces on publish; the dedicated-name norm (a single, xpf-owned A)
+  is unaffected. If driven later, the RMW gates behind the same `PrevAddr` and
+  accepts the single-writer race.
 - **Withdraw rebuilds the live backend** (the #2691 P2 MAJOR-2 fix). An
   address-loss withdraw (Pass 1) resolves the backend from the live
   `SurfaceAScope` (`backendFor`); a config-removal withdraw (Pass 2, where the

--- a/pkg/ddns/backend.go
+++ b/pkg/ddns/backend.go
@@ -40,6 +40,18 @@ type LeaseDNSRecord struct {
 	// pre-existing third-party RR). NOT part of the published forward/reverse
 	// RR set; carried alongside it only to derive the ownership marker.
 	ClientID string
+	// PrevAddr is the PREVIOUS published rdata for a SELF-OWNED Surface A
+	// record (#3739), threaded from publishLocked (seeded across a restart from
+	// the durable store's AddrText). It lets a self-owned backend do a
+	// VALUE-SPECIFIC in-place replace — touch ONLY xpf's own prior value and add
+	// the new one — instead of clobbering the whole name / RRset, which would
+	// destroy a co-resident FOREIGN A/AAAA at a shared name. Zero (invalid) on a
+	// first publish or when the prior value is genuinely unknown; the backend
+	// then does an ADDITIVE insert/create that coexists with any foreign record
+	// (strictly better than clobbering it). Ignored on the DHCP-lease path (that
+	// path re-derives the exact delete from the owned tuple + DHCID) and by
+	// non-self-owned backends.
+	PrevAddr netip.Addr
 	// KeepForwardDHCID, when true on a DeleteLease, tells the replace-owned
 	// RFC 2136 backend to delete the forward A/AAAA but NOT the shared RFC 4701
 	// DHCID — because ANOTHER owned record still shares this FQDN+ClientID

--- a/pkg/ddns/backend_cloudflare.go
+++ b/pkg/ddns/backend_cloudflare.go
@@ -194,30 +194,26 @@ func (b *cloudflareBackend) listRecords(ctx context.Context, zoneID, rtype, fqdn
 	return recs, nil
 }
 
-// findRecord returns ONE existing A/AAAA record for the FQDN+type to update, or
-// (zero, false) when none exists. It prefers the row whose content already
-// equals wantContent (so a re-publish is a no-op) and otherwise returns the
-// first record (the row to PATCH to the new content). Used only by the upsert
-// path — the delete path re-derives ownership from content and must NOT
-// collapse to a single record.
-func (b *cloudflareBackend) findRecord(ctx context.Context, zoneID, rtype, fqdn, wantContent string) (cfRecord, bool, error) {
-	recs, err := b.listRecords(ctx, zoneID, rtype, fqdn)
-	if err != nil {
-		return cfRecord{}, false, err
-	}
-	if len(recs) == 0 {
-		return cfRecord{}, false, nil
-	}
-	for _, rec := range recs {
-		if rec.Content == wantContent {
-			return rec, true, nil
-		}
-	}
-	return recs[0], true, nil
-}
-
-// UpsertLease publishes the A/AAAA: resolve zone id, find the record, PATCH its
-// content if present else POST a new one.
+// UpsertLease publishes the A/AAAA with a VALUE-SPECIFIC in-place replace
+// (#3739): resolve zone id, list every A/AAAA at the name, and touch ONLY the
+// row xpf owns — never a co-resident FOREIGN value at a shared name. recs[0] is
+// an API-ordering artifact, not a statement of ownership (mirrors the
+// content-scoped DELETE, #2770). The precedence is:
+//
+//  1. A row already carrying the NEW content → no write (idempotent re-publish;
+//     extra ban-avoidance on top of the engine's change-detection).
+//  2. Else a row carrying xpf's PREVIOUS published value (rec.PrevAddr) → PATCH
+//     that row in place. This is the renumber of xpf's OWN record; the foreign
+//     row (if any) is left untouched.
+//  3. Else no xpf-owned row exists at this name → POST a NEW record. Any foreign
+//     record at the name survives (never PATCH recs[0], which would rewrite a
+//     foreign value to xpf's address — the #3739 H11 bug).
+//
+// Degenerate cases stay correct: a first publish (no prev, empty name) POSTs;
+// a first publish onto a name that already carries only a foreign record also
+// POSTs (coexist, do not clobber). If xpf's prior value is genuinely unknown
+// (PrevAddr lost) on a renumber, a new row is POSTed and the old xpf row leaks —
+// acceptable, and strictly better than clobbering a foreign record.
 func (b *cloudflareBackend) UpsertLease(ctx context.Context, rec LeaseDNSRecord) error {
 	zoneID, err := b.resolveZoneID(ctx)
 	if err != nil {
@@ -229,9 +225,23 @@ func (b *cloudflareBackend) UpsertLease(ctx context.Context, rec LeaseDNSRecord)
 	if ttl <= 0 {
 		ttl = 1 // Cloudflare TTL=1 means "automatic".
 	}
-	existing, found, err := b.findRecord(ctx, zoneID, rec.ForwardType, name, content)
+	recs, err := b.listRecords(ctx, zoneID, rec.ForwardType, name)
 	if err != nil {
 		return err
+	}
+	var prevContent string
+	if rec.PrevAddr.IsValid() {
+		prevContent = rec.PrevAddr.Unmap().String()
+	}
+	prevID := ""
+	for _, r := range recs {
+		if r.Content == content {
+			// Already correct — no write.
+			return nil
+		}
+		if prevContent != "" && r.Content == prevContent {
+			prevID = r.ID
+		}
 	}
 	payload := map[string]any{
 		"type":    rec.ForwardType,
@@ -239,15 +249,12 @@ func (b *cloudflareBackend) UpsertLease(ctx context.Context, rec LeaseDNSRecord)
 		"content": content,
 		"ttl":     ttl,
 	}
-	if found {
-		if existing.Content == content {
-			// Already correct — no write (extra ban-avoidance on top of the
-			// engine's change-detection).
-			return nil
-		}
-		_, err = b.do(ctx, http.MethodPatch, "/zones/"+zoneID+"/dns_records/"+existing.ID, payload)
+	if prevID != "" {
+		// Renumber xpf's OWN row in place — never a foreign row.
+		_, err = b.do(ctx, http.MethodPatch, "/zones/"+zoneID+"/dns_records/"+prevID, payload)
 		return err
 	}
+	// No xpf-owned row to update — create a new one alongside any foreign record.
 	_, err = b.do(ctx, http.MethodPost, "/zones/"+zoneID+"/dns_records", payload)
 	return err
 }

--- a/pkg/ddns/backend_cloudflare_test.go
+++ b/pkg/ddns/backend_cloudflare_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -23,6 +24,11 @@ type cfFakeAPI struct {
 	zoneID   string
 	// records keyed by id.
 	records map[string]cfRecord
+	// order is the record ids in insertion order, so the GET handler returns a
+	// DETERMINISTIC list (real Cloudflare order is arbitrary, but a stable test
+	// order lets a test fix which row is recs[0] — the ordering artifact the
+	// value-specific #3739 fix must NOT rely on).
+	order   []string
 	nextID  int
 	patched int
 	posted  int
@@ -62,7 +68,8 @@ func (f *cfFakeAPI) handler() http.Handler {
 			name := r.URL.Query().Get("name")
 			rtype := r.URL.Query().Get("type")
 			var out []cfRecord
-			for _, rec := range f.records {
+			for _, id := range f.order {
+				rec := f.records[id]
 				if rec.Name == name && rec.Type == rtype {
 					out = append(out, rec)
 				}
@@ -75,6 +82,7 @@ func (f *cfFakeAPI) handler() http.Handler {
 			rec.ID = "rec" + itoa(f.nextID)
 			f.nextID++
 			f.records[rec.ID] = rec
+			f.order = append(f.order, rec.ID)
 			f.ok(w, rec)
 		case r.Method == http.MethodPatch && strings.HasPrefix(r.URL.Path, "/zones/"+f.zoneID+"/dns_records/"):
 			f.patched++
@@ -89,6 +97,12 @@ func (f *cfFakeAPI) handler() http.Handler {
 			f.deleted++
 			id := strings.TrimPrefix(r.URL.Path, "/zones/"+f.zoneID+"/dns_records/")
 			delete(f.records, id)
+			for i, oid := range f.order {
+				if oid == id {
+					f.order = append(f.order[:i], f.order[i+1:]...)
+					break
+				}
+			}
 			f.ok(w, map[string]string{"id": id})
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -140,12 +154,17 @@ func TestCloudflareCreateThenUpdate(t *testing.T) {
 	if fake.posted != 1 || fake.patched != 0 {
 		t.Fatalf("unchanged content must not write: posted=%d patched=%d", fake.posted, fake.patched)
 	}
-	// New address → PATCH (update existing).
-	if err := b.UpsertLease(context.Background(), hostRecord(t, "wan.example.net", "203.0.113.9")); err != nil {
+	// New address → PATCH (update existing). Production threads the previous
+	// published value (rec.PrevAddr, #3739) so the renumber patches xpf's OWN
+	// row in place rather than creating a second record. Without PrevAddr the
+	// value-specific path would (correctly) POST a new row and leak the old one.
+	renum := hostRecord(t, "wan.example.net", "203.0.113.9")
+	renum.PrevAddr = netip.MustParseAddr("203.0.113.5")
+	if err := b.UpsertLease(context.Background(), renum); err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if fake.patched != 1 {
-		t.Fatalf("address change must patch: patched=%d", fake.patched)
+	if fake.patched != 1 || fake.posted != 1 {
+		t.Fatalf("address change must patch xpf's own row, not create: patched=%d posted=%d", fake.patched, fake.posted)
 	}
 	// Verify the live record content.
 	var live cfRecord
@@ -154,6 +173,81 @@ func TestCloudflareCreateThenUpdate(t *testing.T) {
 	}
 	if live.Content != "203.0.113.9" {
 		t.Fatalf("record content not updated: %q", live.Content)
+	}
+}
+
+// TestCloudflareRenumberPatchesOnlyOwnedRow is the #3739 H11 fail-on-revert for
+// a RENUMBER on a SHARED name: the FQDN carries a FOREIGN A a human set plus
+// xpf's own A. A publish of xpf's NEW address (with PrevAddr = xpf's prior value)
+// must PATCH only xpf's own row and leave the foreign value intact. The fake
+// returns records in insertion order and the foreign row is seeded FIRST, so
+// recs[0] is the FOREIGN row: reverting UpsertLease to the old content-blind
+// "PATCH recs[0]" rewrites the foreign value to xpf's address → this goes RED.
+func TestCloudflareRenumberPatchesOnlyOwnedRow(t *testing.T) {
+	fake := newCFFakeAPI(t)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	b := newCFTestBackend(t, srv, fake)
+
+	const fqdn = "wan.example.net"
+	// Foreign row FIRST (so it is recs[0]) + xpf's own prior value.
+	foreignA := fake.seedRecord("A", fqdn, "198.51.100.20")
+	ownedA := fake.seedRecord("A", fqdn, "203.0.113.5")
+
+	rec := hostRecord(t, fqdn, "203.0.113.9")
+	rec.PrevAddr = netip.MustParseAddr("203.0.113.5") // xpf's prior value
+	if err := b.UpsertLease(context.Background(), rec); err != nil {
+		t.Fatalf("renumber: %v", err)
+	}
+	// Exactly one PATCH (xpf's own row), no POST.
+	if fake.patched != 1 || fake.posted != 0 {
+		t.Fatalf("renumber must patch xpf's own row only: patched=%d posted=%d", fake.patched, fake.posted)
+	}
+	// xpf's row now carries the new value.
+	if got := fake.records[ownedA].Content; got != "203.0.113.9" {
+		t.Fatalf("xpf row not renumbered: content=%q", got)
+	}
+	// The FOREIGN value must survive untouched (the #3739 clobber).
+	if got := fake.records[foreignA].Content; got != "198.51.100.20" {
+		t.Fatalf("foreign A was clobbered on renumber: content=%q (want 198.51.100.20)", got)
+	}
+}
+
+// TestCloudflareFirstPublishOntoForeignName is the #3739 H11 fail-on-revert for a
+// FIRST publish onto a name that already carries only a FOREIGN A (no xpf row,
+// no PrevAddr). The value-specific upsert must POST a new record and leave the
+// foreign one intact. Reverting to the old "found → PATCH recs[0]" rewrites the
+// sole (foreign) row to xpf's address → this goes RED (foreign clobbered, and a
+// POST that should have happened did not).
+func TestCloudflareFirstPublishOntoForeignName(t *testing.T) {
+	fake := newCFFakeAPI(t)
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+	b := newCFTestBackend(t, srv, fake)
+
+	const fqdn = "wan.example.net"
+	foreignA := fake.seedRecord("A", fqdn, "198.51.100.20")
+
+	// No PrevAddr — a genuine first publish onto a name a human already populated.
+	if err := b.UpsertLease(context.Background(), hostRecord(t, fqdn, "203.0.113.9")); err != nil {
+		t.Fatalf("first publish onto foreign name: %v", err)
+	}
+	if fake.posted != 1 || fake.patched != 0 {
+		t.Fatalf("first publish onto a foreign name must POST, not PATCH: posted=%d patched=%d", fake.posted, fake.patched)
+	}
+	// The foreign value must survive.
+	if got := fake.records[foreignA].Content; got != "198.51.100.20" {
+		t.Fatalf("foreign A was clobbered on first publish: content=%q (want 198.51.100.20)", got)
+	}
+	// xpf's new value now coexists.
+	var haveNew bool
+	for _, r := range fake.records {
+		if r.Content == "203.0.113.9" {
+			haveNew = true
+		}
+	}
+	if !haveNew {
+		t.Fatal("xpf's new A was not created alongside the foreign record")
 	}
 }
 
@@ -186,6 +280,7 @@ func (f *cfFakeAPI) seedRecord(rtype, name, content string) string {
 	id := "seed" + itoa(f.nextID)
 	f.nextID++
 	f.records[id] = cfRecord{ID: id, Type: rtype, Name: name, Content: content}
+	f.order = append(f.order, id)
 	return id
 }
 

--- a/pkg/ddns/backend_rfc2136.go
+++ b/pkg/ddns/backend_rfc2136.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -126,6 +127,18 @@ type rfc2136Updater struct {
 	// work under its mutex, so per-call mutation of this stateless-config
 	// backend is safe). Empty ⇒ no DHCID (name-not-in-use guard only).
 	dhcidClientID string
+
+	// selfOwnedPrevAddr is the PREVIOUS published rdata for the self-owned
+	// forward record currently being upserted (#3739), carried alongside the
+	// record like dhcidClientID. sendAddSelfOwned uses it to do a VALUE-SPECIFIC
+	// replace — an exact-RR delete of xpf's OWN prior value paired with the
+	// insert of the new one, in ONE atomic UPDATE — so a co-resident FOREIGN
+	// A/AAAA at a shared name survives (instead of the old delete-RRset that
+	// destroyed every same-type record at the name). Invalid ⇒ first publish or
+	// unknown prior value ⇒ Insert-only (additive, coexists with any foreign RR).
+	// Set at the top of UpsertLease and only consulted on the self-owned A/AAAA
+	// path; ignored by the DHCP-lease path (selfOwned=false) and by PTR adds.
+	selfOwnedPrevAddr netip.Addr
 
 	// selfOwned marks a backend that publishes the FIREWALL'S OWN records
 	// (Surface A router/interface-address publish, #2691 P2), as opposed to a
@@ -354,6 +367,7 @@ func canonicalReverseZone(ptrName string) string {
 // lease's reconcile result; a PTR NOTAUTH/REFUSED is a counted skip.
 func (u *rfc2136Updater) UpsertLease(ctx context.Context, rec LeaseDNSRecord) error {
 	u.dhcidClientID = rec.ClientID
+	u.selfOwnedPrevAddr = rec.PrevAddr // #3739: value-specific self-owned replace
 	forwardRR, err := u.forwardRR(rec)
 	if err != nil {
 		return err
@@ -785,22 +799,33 @@ func (u *rfc2136Updater) sendAddOwned(ctx context.Context, zone string, rr dns.R
 // (forced-refresh) deletes-then-re-adds the identical RR (a no-op net change
 // that SUCCEEDS), and an address change replaces the rdata atomically.
 //
-// Exact-RR / co-resident safety: the delete is scoped to OUR forward type (A
-// for a v4 record, AAAA for a v6 record) at OUR exact name only — it never
-// touches a different RR type at the name (e.g. a co-resident MX/TXT) and never
-// issues a delete-name. The third-party case: if an operator points two
-// firewalls' Surface-A FQDNs at the SAME name they will fight (each replaces the
-// other's A) — that is an operator misconfiguration (the per-RG HA gate already
-// prevents the in-cluster two-writer case), and is strictly the documented
-// "self-owned name" contract; this backend never adopts or deletes a DIFFERENT
-// record TYPE, so a co-resident non-A/AAAA record at the name is never harmed.
+// Exact-RR / co-resident safety (#3739): the replace is now VALUE-SPECIFIC. When
+// the previous published value is known (u.selfOwnedPrevAddr, threaded from the
+// manager) and differs from the new one, the message pairs an EXACT-RR delete of
+// xpf's OWN prior rdata (RFC 2136 §2.5.4, CLASS=NONE) with the insert of the new
+// rdata — so a CO-RESIDENT FOREIGN A/AAAA at a shared name SURVIVES (the old
+// whole-RRset delete destroyed every same-type record at the name). Both ops are
+// in the SAME UPDATE, so the replace stays atomic and no-blackhole. When the
+// prior value is unknown (first publish) or equal to the new one, the message is
+// Insert-only — additive, coexisting with any foreign RR (a same-value re-publish
+// is an idempotent no-op). It never touches a different RR type at the name and
+// never issues a delete-name/delete-RRset. The third-party case: if an operator
+// points two firewalls' Surface-A FQDNs at the SAME name their records now
+// COEXIST (each only manages its own value) rather than fighting — non-destructive
+// by design; the per-RG HA gate still prevents the in-cluster two-writer case.
 func (u *rfc2136Updater) sendAddSelfOwned(ctx context.Context, zone string, rr dns.RR) error {
 	m := new(dns.Msg)
 	m.SetUpdate(dns.Fqdn(zone))
-	// RemoveRRset deletes the entire RRset of rr's type at rr's name (CLASS=ANY,
-	// TTL=0, empty rdata) — our prior A/AAAA value(s), if any. Applied in the
-	// SAME message as the Insert below, so the replace is atomic.
-	m.RemoveRRset([]dns.RR{rr})
+	// Value-specific replace: remove ONLY xpf's own prior rdata (exact-RR delete)
+	// when it is known and differs from the new value. Skipped on a first publish
+	// (invalid prev) or a same-value re-publish (Insert is idempotent).
+	if prev := u.selfOwnedPrevAddr.Unmap(); prev.IsValid() {
+		if cur, ok := rrAddr(rr); !ok || cur != prev {
+			if prevRR, ok := prevSelfOwnedRR(prev, rr); ok {
+				m.Remove([]dns.RR{prevRR})
+			}
+		}
+	}
 	m.Insert([]dns.RR{rr})
 	resp, err := u.exchange(ctx, m)
 	if err != nil {
@@ -812,6 +837,58 @@ func (u *rfc2136Updater) sendAddSelfOwned(ctx context.Context, zone string, rr d
 	default:
 		return rcodeError(resp.Rcode)
 	}
+}
+
+// rrAddr extracts the netip.Addr rdata from an A/AAAA RR (ok=false for any other
+// type or an unparseable address). Used by the self-owned value-specific replace
+// to compare xpf's previous value against the new one.
+func rrAddr(rr dns.RR) (netip.Addr, bool) {
+	switch v := rr.(type) {
+	case *dns.A:
+		if a, ok := netip.AddrFromSlice(v.A.To4()); ok {
+			return a.Unmap(), true
+		}
+	case *dns.AAAA:
+		if a, ok := netip.AddrFromSlice(v.AAAA.To16()); ok {
+			return a.Unmap(), true
+		}
+	}
+	return netip.Addr{}, false
+}
+
+// prevSelfOwnedRR builds the exact-RR-delete RR for xpf's PREVIOUS self-owned
+// value (#3739), matching the name/TTL and the forward TYPE of the record being
+// published. ok=false when prev's family does not match cur's type — a
+// cross-family delete is never emitted (a Surface A scope is family-fixed, so
+// this is belt-and-suspenders, never a normal case).
+func prevSelfOwnedRR(prev netip.Addr, cur dns.RR) (dns.RR, bool) {
+	prev = prev.Unmap()
+	if !prev.IsValid() {
+		return nil, false
+	}
+	name := cur.Header().Name
+	ttl := cur.Header().Ttl
+	switch cur.(type) {
+	case *dns.A:
+		if !prev.Is4() {
+			return nil, false
+		}
+		a4 := prev.As4()
+		return &dns.A{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl},
+			A:   net.IP(a4[:]),
+		}, true
+	case *dns.AAAA:
+		if !prev.Is6() {
+			return nil, false
+		}
+		a16 := prev.As16()
+		return &dns.AAAA{
+			Hdr:  dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: ttl},
+			AAAA: net.IP(a16[:]),
+		}, true
+	}
+	return nil, false
 }
 
 // sendRemove issues an exact-RR delete (RFC 2136 §2.5.4 via miekg Remove,

--- a/pkg/ddns/surface_a.go
+++ b/pkg/ddns/surface_a.go
@@ -1119,6 +1119,17 @@ func (m *SurfaceAManager) publishLocked(ctx context.Context, sc SurfaceAScope, a
 		}
 	}
 
+	// Thread the previously-published rdata to the backend (#3739) so a
+	// self-owned publish can do a VALUE-SPECIFIC in-place replace — touch only
+	// xpf's own prior value, never a co-resident FOREIGN record at a shared
+	// name. On a first publish (or a lost prior value) PrevAddr stays invalid and
+	// the backend does an additive insert/create instead of clobbering the name.
+	if prevAddr != "" {
+		if pa, perr := netip.ParseAddr(prevAddr); perr == nil {
+			rec.PrevAddr = pa.Unmap()
+		}
+	}
+
 	// Non-secret backend fingerprint for this publish (#3735). Stored on the owned
 	// record so a later provider identity change is detectable, and compared here
 	// against the previous publish's fingerprint to catch an IN-PLACE provider

--- a/pkg/ddns/surface_a_rfc2136_test.go
+++ b/pkg/ddns/surface_a_rfc2136_test.go
@@ -110,6 +110,56 @@ func TestSurfaceARealBackendReplacesOnAddressChange(t *testing.T) {
 	}
 }
 
+// #3739 (M08): a co-resident FOREIGN A at the self-owned name must SURVIVE both
+// the first publish and a later renumber. The old sendAddSelfOwned did a
+// delete-RRset (CLASS=ANY) of the whole A set before inserting, destroying any
+// foreign value; the value-specific replace now removes ONLY xpf's own prior
+// rdata (exact-RR delete) so the foreign record is never collateral. Reverting
+// sendAddSelfOwned to RemoveRRset makes the first zoneHas(foreign) assertion RED
+// (the foreign A is wiped on the first publish).
+func TestSurfaceARealBackendPreservesForeignRecord(t *testing.T) {
+	srv := newFakeDNSServer(t, nil)
+	srv.setStateful(true)
+	m := newSurfaceAManagerRealBackend(t, srv)
+	catalog := map[string]*config.DDNSProvider{"corp-2136": {Name: "corp-2136", Backend: "rfc2136"}}
+	sc := realScope("wan.example.net")
+
+	// A human/other appliance already published a FOREIGN A at the shared name.
+	const foreign = "198.51.100.20"
+	srv.seedRR(aRR("wan.example.net", foreign))
+
+	// First publish (no prior xpf value ⇒ Insert-only, additive): xpf's A must
+	// coexist with the foreign one — neither is destroyed.
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.5"), nil, catalog); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", foreign)) {
+		t.Fatal("M08: a co-resident FOREIGN A must survive xpf's first publish (Insert-only, not delete-RRset)")
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("xpf's own A must be published alongside the foreign record")
+	}
+
+	// Renumber xpf's own value: Remove(old-xpf)+Insert(new-xpf) in one atomic
+	// UPDATE. The foreign A survives; the OLD xpf value is gone; the NEW is live.
+	m.now = func() time.Time { return time.Unix(1_700_000_060, 0) }
+	if err := m.Reconcile(context.Background(), []SurfaceAScope{sc}, fixedObserver("203.0.113.9"), nil, catalog); err != nil {
+		t.Fatalf("renumber: %v", err)
+	}
+	if !srv.zoneHas(aRR("wan.example.net", foreign)) {
+		t.Fatal("M08: the foreign A must survive an xpf renumber (exact-RR delete of only xpf's prior value)")
+	}
+	if !srv.zoneHas(aRR("wan.example.net", "203.0.113.9")) {
+		t.Fatal("renumber must publish the NEW xpf value")
+	}
+	if srv.zoneHas(aRR("wan.example.net", "203.0.113.5")) {
+		t.Fatal("renumber must remove xpf's OWN prior value (203.0.113.5)")
+	}
+	if st := m.Stats(); st.UpsertFail != 0 {
+		t.Fatalf("no publish should have failed; got UpsertFail=%d", st.UpsertFail)
+	}
+}
+
 // MAJOR-1: a same-address forced-refresh of an existing name must succeed.
 func TestSurfaceARealBackendForcedRefreshSucceeds(t *testing.T) {
 	srv := newFakeDNSServer(t, nil)


### PR DESCRIPTION
Closes #3739

## Problem

The Surface A **self-owned** publish path clobbered a co-resident FOREIGN
A/AAAA at a shared name (never the DHCP-lease path — Cloudflare/RFC2136
self-owned only):

- **Cloudflare (H11)** — `UpsertLease` PATCHed `recs[0]` (an API-ordering
  artifact) to xpf's address, overwriting whatever row the API listed first,
  often a foreign value. (DELETE was already content-scoped, #2770.)
- **RFC 2136 (M08)** — `sendAddSelfOwned` `RemoveRRset`d the WHOLE A/AAAA set
  (CLASS=ANY) at the name before inserting, destroying every same-type record
  a human/other appliance had set there.

## Fix — value-specific in-place replace

**Enabler:** `publishLocked` already computes `prevAddr` (seeded across restart
from the durable store's `AddrText`) but used it only for the renumber log. It
is now threaded to the backend via a new `LeaseDNSRecord.PrevAddr` field.

- **Cloudflare** `UpsertLease`: list every A/AAAA at the name; no-op if a row
  already carries the new value; else PATCH the row whose content == `PrevAddr`
  in place; else POST a new record. Never PATCHes `recs[0]`, so a foreign row
  is never rewritten. `findRecord` (recs[0] fallback) removed.
- **RFC 2136** `sendAddSelfOwned`: when the prior value is known and differs,
  pair an EXACT-RR delete (`Remove`, §2.5.4, CLASS=NONE) of xpf's own prior
  rdata with the insert of the new value in ONE atomic UPDATE — foreign RR
  survives, no-blackhole preserved. First publish / same-value republish is
  Insert-only (additive).

Degenerate cases stay correct (first publish POSTs/Insert-only; a lost prior
value POSTs a new row and the old xpf value leaks — strictly better than
clobbering foreign).

## Route 53 (M07) — DEFERRED (per the converged /research plan)

`ChangeResourceRecordSets` `UPSERT` replaces the entire RRSet at name+type and
has no per-value op and no compare-and-swap. Value preservation would need a
NEW SigV4-signed `ListResourceRecordSets` GET plus a read-modify-write with a
genuine race window — disproportionate for the low-reachability shared-name
case, and the Route 53 DELETE path already fails safe (#2771). Documented as a
known limitation in `pkg/ddns/README.md`; the RMW follow-on gates behind the
same `PrevAddr` if driven later.

## Tests (RED-on-revert)

- Cloudflare fake API now returns records in insertion order (deterministic
  `recs[0]`). `TestCloudflareRenumberPatchesOnlyOwnedRow` and
  `TestCloudflareFirstPublishOntoForeignName` both go RED when `UpsertLease` is
  reverted to `recs[0]` PATCH; the foreign value is clobbered.
- `TestSurfaceARealBackendPreservesForeignRecord` drives the real RFC 2136
  backend through the manager (exercising the PrevAddr threading end to end);
  goes RED when `sendAddSelfOwned` is reverted to `RemoveRRset`.
- Existing self-owned / single-A / no-prev cases still pass.

## Validation

- `go test -race ./pkg/ddns/...` green (RED-on-revert proven for both providers).
- `go build ./...`, `go vet ./pkg/ddns/...`, `gofmt -l` clean.
- `go test ./pkg/dhcpserver/...` (lease-path consumer) green — lease path is
  `selfOwned=false` and sets no `PrevAddr`, so it is unaffected.
- No cluster/dataplane path involved — no test-failover needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi