### PR TITLE
flowexport: bound the export batch queue + drop/depth visibility (#3747)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26805,3 +26805,39 @@ top.
     reversed-range reject; appTerm.dstPortConfigured + portConfigured
     guard), pkg/dataplane/userspace/nat_reversed_port_range_3726_test.go
     (new RED-on-revert pins), docs/userspace-dnat-plan.md (§13b)
+
+- **Timestamp**: 2026-07-01
+  **Action**: #3747 — bound the flowexport batch queue (`flowBatch`) and
+    add drop/depth visibility. The per-family export accumulator
+    (`transport.go` `flowBatch.v4/v6`) was UNBOUNDED: `add` appended
+    with no cap and the batch drained ONLY from the exporter `Run`
+    goroutine (100ms ticker). A stopped/stalled drain (reconcile window,
+    slow/blocked collector, SESSION_CLOSE storm) let it grow with the
+    close-event rate → unbounded memory growth (DoS/OOM) with no depth or
+    drop counter. Fix: bound each family at `defaultFlowBatchCap` (65536
+    records); on overflow DROP the incoming record (drop-newest, O(1),
+    never blocks the event-reader flow-close callback) and increment an
+    atomic `dropped` counter; track a `maxDepth` high-water mark. Chose
+    drop-newest over drop-oldest: O(1) with no slice-shift/realloc churn,
+    non-blocking, happy-path append unchanged; forensic value of which
+    end is dropped is symmetric in a near-contemporaneous close storm.
+    Surfaced via `Exporter`/`IPFIXExporter` `BatchDepth/BatchMaxDepth/
+    BatchDropped` accessors → `Daemon.FlowExportBatchStats()` →
+    Prometheus family `xpf_flow_export_batch_{depth,max_depth,
+    dropped_total}` labeled {protocol,instance,template} (mirrors the
+    #2464 CollectorHealth wiring). RED-on-revert: reverting the source
+    (keeping the test) fails to compile — the bounded API (capOverride /
+    Dropped / MaxDepth / depth) does not exist pre-fix; behavioral pins
+    assert drops-above-cap, no-drop-below-cap, per-family independence,
+    high-water survives drain, and a -race concurrent producer/drain
+    accounting invariant (drained+dropped == offered). go test -race
+    ./pkg/flowexport/... + ./pkg/api/... green; ./pkg/daemon/... green;
+    go build ./... green; gofmt + vet clean on touched files.
+  - **File(s)**: pkg/flowexport/transport.go (bounded flowBatch +
+    dropped/maxDepth atomics + depth/Dropped/MaxDepth + ExporterBatchStats),
+    pkg/flowexport/netflow.go + pkg/flowexport/ipfix.go (Batch* accessors),
+    pkg/flowexport/flowbatch_bounded_test.go (new RED-on-revert pins),
+    pkg/daemon/daemon_flowexport.go (FlowExportBatchStats), pkg/daemon/daemon_run.go
+    (wire FlowExportBatchStatsFn), pkg/api/server.go + metrics.go +
+    metrics_descriptors.go + metrics_system.go (xpf_flow_export_batch_* family),
+    pkg/flowexport/README.md (Bounded export batch section)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -515,6 +515,15 @@ type xpfCollector struct {
 	flowExportCollectorHealthy            *prometheus.Desc
 	flowExportCollectorLastSuccessSeconds *prometheus.Desc
 	flowExportCollectorLastFailureSeconds *prometheus.Desc
+
+	// #3747: per-exporter pending-batch queue depth / high-water / drop count.
+	// The export batch was unbounded; a stalled or overrun drain grew memory
+	// without bound and silently. These surface the backlog and any bounded
+	// drops. Labels: protocol {netflow-v9,ipfix}, instance, template (bounded
+	// — one series per configured flow-server group).
+	flowExportBatchDepth        *prometheus.Desc
+	flowExportBatchMaxDepth     *prometheus.Desc
+	flowExportBatchDroppedTotal *prometheus.Desc
 }
 
 func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -792,6 +801,9 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.flowExportCollectorHealthy
 	ch <- c.flowExportCollectorLastSuccessSeconds
 	ch <- c.flowExportCollectorLastFailureSeconds
+	ch <- c.flowExportBatchDepth
+	ch <- c.flowExportBatchMaxDepth
+	ch <- c.flowExportBatchDroppedTotal
 }
 
 func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1793,5 +1793,22 @@ func newCollector(srv *Server) *xpfCollector {
 			"Unix timestamp of the last failed write to this flow-export collector (0 if none yet). Labeled by instance and template as well as collector and source (#3741).",
 			[]string{"protocol", "instance", "template", "collector", "source"}, nil,
 		),
+
+		// #3747: per-exporter pending-batch queue observability.
+		flowExportBatchDepth: prometheus.NewDesc(
+			"xpf_flow_export_batch_depth",
+			"Current number of flow records pending in the export batch for this group (both families combined). Normally near 0 — the exporter drains every 100ms; a sustained nonzero value means the drain cannot keep up (stalled export goroutine, slow/unreachable collector, or a SESSION_CLOSE storm) (#3747).",
+			[]string{"protocol", "instance", "template"}, nil,
+		),
+		flowExportBatchMaxDepth: prometheus.NewDesc(
+			"xpf_flow_export_batch_max_depth",
+			"High-water mark of the pending export batch depth for this group since the exporter started. Captures a transient backlog even after a later drain empties the queue (#3747).",
+			[]string{"protocol", "instance", "template"}, nil,
+		),
+		flowExportBatchDroppedTotal: prometheus.NewDesc(
+			"xpf_flow_export_batch_dropped_total",
+			"Total flow records dropped because the pending export batch was at its per-family capacity (#3747). Before #3747 the batch was unbounded and a stalled/overrun drain grew memory without bound; it now drops (drop-newest) and counts. A climbing value means export records are being lost to a drain that cannot keep up.",
+			[]string{"protocol", "instance", "template"}, nil,
+		),
 	}
 }

--- a/pkg/api/metrics_system.go
+++ b/pkg/api/metrics_system.go
@@ -166,6 +166,29 @@ func (c *xpfCollector) collectFlowExportMetrics(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.flowExportCollectorLastFailureSeconds,
 			prometheus.GaugeValue, lastFailure, h.Protocol, h.Instance, h.Template, h.Address, h.SourceAddress)
 	}
+	c.collectFlowExportBatchMetrics(ch)
+}
+
+// collectFlowExportBatchMetrics emits the xpf_flow_export_batch_* family from
+// the per-exporter pending-batch queue stats (#3747). The family is omitted
+// entirely when no FlowExportBatchStatsFn is wired or when no flow export is
+// configured (empty slice). Labels: protocol {netflow-v9,ipfix}, instance,
+// template — one series per configured flow-server group (bounded). The
+// export batch used to be unbounded: a stalled/overrun drain grew memory
+// without bound and silently. depth / max_depth expose the backlog and
+// dropped_total exposes the bounded drops that now replace that growth.
+func (c *xpfCollector) collectFlowExportBatchMetrics(ch chan<- prometheus.Metric) {
+	if c.srv.flowExportBatchStatsFn == nil {
+		return
+	}
+	for _, s := range c.srv.flowExportBatchStatsFn() {
+		ch <- prometheus.MustNewConstMetric(c.flowExportBatchDepth,
+			prometheus.GaugeValue, float64(s.Depth), s.Protocol, s.Instance, s.Template)
+		ch <- prometheus.MustNewConstMetric(c.flowExportBatchMaxDepth,
+			prometheus.GaugeValue, float64(s.MaxDepth), s.Protocol, s.Instance, s.Template)
+		ch <- prometheus.MustNewConstMetric(c.flowExportBatchDroppedTotal,
+			prometheus.CounterValue, float64(s.Dropped), s.Protocol, s.Instance, s.Template)
+	}
 }
 
 func (c *xpfCollector) collectSystemMetrics(ch chan<- prometheus.Metric) {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -192,6 +192,13 @@ type Config struct {
 	// last-error/last-success state are surfaced here. Optional; if nil (or
 	// it returns nil), the family is omitted.
 	FlowCollectorHealthFn func() []flowexport.ExporterCollectorHealth
+	// FlowExportBatchStatsFn surfaces the per-exporter pending-batch queue
+	// stats (current depth, high-water depth, dropped-at-capacity count) for
+	// the xpf_flow_export_batch_* metric family (#3747). The export batch used
+	// to be unbounded: a stalled/overrun drain grew memory without bound and
+	// with no depth or drop visibility. Optional; if nil (or it returns nil),
+	// the family is omitted.
+	FlowExportBatchStatsFn func() []flowexport.ExporterBatchStats
 	// FeedOverlayFn returns the live dynamic-address feed-prefix overlay
 	// (#2049): an address-name -> union-of-feed-CIDRs map for the active
 	// config, the same view the AF_XDP helper enforces. It is consulted by
@@ -257,6 +264,7 @@ type Server struct {
 	ddnsStatsFn                      func() *dhcpserver.DDNSStats
 	surfaceAStatsFn                  func() *ddns.SurfaceAStats
 	flowCollectorHealthFn            func() []flowexport.ExporterCollectorHealth
+	flowExportBatchStatsFn           func() []flowexport.ExporterBatchStats
 	feedOverlayFn                    func() map[string][]string
 	policySchedActiveFn              func() (map[string]bool, bool)
 	haActiveFn                       func() bool
@@ -293,6 +301,7 @@ func NewServer(cfg Config) *Server {
 		ddnsStatsFn:                      cfg.DDNSStatsFn,
 		surfaceAStatsFn:                  cfg.SurfaceAStatsFn,
 		flowCollectorHealthFn:            cfg.FlowCollectorHealthFn,
+		flowExportBatchStatsFn:           cfg.FlowExportBatchStatsFn,
 		feedOverlayFn:                    cfg.FeedOverlayFn,
 		policySchedActiveFn:              cfg.PolicySchedulerActiveStateFn,
 		haActiveFn:                       cfg.HAActiveFn,

--- a/pkg/daemon/daemon_flowexport.go
+++ b/pkg/daemon/daemon_flowexport.go
@@ -595,3 +595,40 @@ func (d *Daemon) FlowCollectorHealth() []flowexport.ExporterCollectorHealth {
 	}
 	return out
 }
+
+// FlowExportBatchStats returns the pending-batch queue stats (current depth,
+// high-water depth, dropped-at-capacity count) for every running NetFlow v9
+// and IPFIX exporter group (#3747). The slice is empty when no flow export is
+// configured. Safe to call concurrently with reconcile and the export-flush
+// goroutines: it reads the live bundles lock-free and each exporter exposes
+// its batch counters as atomics / a mutex-guarded depth read. Surfaced through
+// the daemon to REST/Prometheus so a stalled or overrun export drain (which
+// used to grow memory without bound and silently) is now observable.
+func (d *Daemon) FlowExportBatchStats() []flowexport.ExporterBatchStats {
+	var out []flowexport.ExporterBatchStats
+	if b := d.flowBundle.Load(); b != nil {
+		for _, g := range b.groups {
+			out = append(out, flowexport.ExporterBatchStats{
+				Protocol: "netflow-v9",
+				Instance: g.ec.InstanceName,
+				Template: g.ec.TemplateName,
+				Depth:    g.exp.BatchDepth(),
+				MaxDepth: g.exp.BatchMaxDepth(),
+				Dropped:  g.exp.BatchDropped(),
+			})
+		}
+	}
+	if b := d.ipfixBundlePtr.Load(); b != nil {
+		for _, g := range b.groups {
+			out = append(out, flowexport.ExporterBatchStats{
+				Protocol: "ipfix",
+				Instance: g.ec.InstanceName,
+				Template: g.ec.TemplateName,
+				Depth:    g.exp.BatchDepth(),
+				MaxDepth: g.exp.BatchMaxDepth(),
+				Dropped:  g.exp.BatchDropped(),
+			})
+		}
+	}
+	return out
+}

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1306,6 +1306,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 			// #2464: per-collector NetFlow v9 / IPFIX write-health for the
 			// xpf_flow_export_collector_* family + /services/flow-exporters.
 			FlowCollectorHealthFn: d.FlowCollectorHealth,
+			// #3747: per-exporter pending-batch queue depth / high-water /
+			// dropped-at-capacity count for the xpf_flow_export_batch_* family.
+			FlowExportBatchStatsFn: d.FlowExportBatchStats,
 			// #3419 M6: report whether this node is the active cluster member
 			// for RG0 so the REST session view's ha_active field matches the
 			// gRPC contract (server_sessions.go IsLocalPrimary(0)). Standalone

--- a/pkg/flowexport/README.md
+++ b/pkg/flowexport/README.md
@@ -633,6 +633,42 @@ The snapshot is surfaced through `Exporter.CollectorHealth()` /
   the in-daemon interactive CLI) — the collector line prints
   `... source <src>` for a source-bound collector (#3745).
 
+## Bounded export batch + drop visibility (#3747)
+
+`ExportSessionClose` does not write to the collector inline — it queues the
+`FlowRecord` into the per-family accumulator `flowBatch` (`v4`/`v6`), which the
+exporter `Run` goroutine drains every 100 ms and hands to the send path. Before
+#3747 `flowBatch.add` appended without any bound and the batch was drained
+ONLY from `Run`, so if `Run` was stopped or stalled — the reconcile window
+(the exporter briefly swapped out), a blocked/slow collector write, or a
+`SESSION_CLOSE` storm (scan / failover) outrunning the 100 ms flush — the
+queue grew with the close-event rate: unbounded memory growth (a DoS / OOM
+risk) with no depth or drop visibility to diagnose it.
+
+The batch is now **bounded per family** by `defaultFlowBatchCap` (65 536
+records/family; a test-only `capOverride` makes the drop path reachable). When
+the target family is at capacity `add` **drops the incoming record**
+(drop-newest) and increments an atomic `dropped` counter rather than growing
+the slice. Drop-newest is deliberate: it is O(1) with no slice shift or
+reallocation churn under sustained overflow, it never blocks the caller, and it
+leaves the happy path (below cap) a plain append. Crucially the flow-close
+callback runs on the event-reader path, so `add` MUST NOT block — dropping a
+record is strictly preferable to backpressuring into the session reap/close
+path. Which end is dropped barely matters for forensic value in a close storm
+(all closes are near-contemporaneous); O(1) non-blocking does. A `maxDepth`
+high-water mark records the worst-case backlog so a transient stall is visible
+after a later drain empties the queue.
+
+The counters are surfaced through `Exporter`/`IPFIXExporter`
+`BatchDepth()` / `BatchMaxDepth()` / `BatchDropped()` →
+`Daemon.FlowExportBatchStats()` (annotated with protocol / instance / template
+via `ExporterBatchStats`) as the Prometheus family
+`xpf_flow_export_batch_{depth,max_depth,dropped_total}`, labeled
+`{protocol,instance,template}` (one bounded series per configured flow-server
+group; emitted before the dataplane gate — exporters are control-plane). A
+climbing `dropped_total`, or a sustained nonzero `depth`, is the operator
+signal that the export drain cannot keep up.
+
 ## Entry points
 
 NetFlow v9:
@@ -862,7 +898,9 @@ moment any caller sampled off the copy (#2224).
   configure the collector to handle template re-resolution.
 - Two batches are maintained inside `flowBatch` (`v4` and `v6`, split
   by family, not by zone — `transport.go`). Both flush on a 100 ms
-  ticker or on shutdown.
+  ticker or on shutdown. Each is **bounded** at `defaultFlowBatchCap`
+  records; overflow drops (drop-newest) and increments `dropped` rather
+  than growing without bound (#3747 — see "Bounded export batch" above).
 - `BuildSamplingZones` resolves a zone's interface references
   (`parseIfaceRef`, `manager.go`) into (physical-name, unit) pairs to
   decide which zones have sampling enabled. The unit suffix is parsed

--- a/pkg/flowexport/flowbatch_bounded_test.go
+++ b/pkg/flowexport/flowbatch_bounded_test.go
@@ -1,0 +1,219 @@
+package flowexport
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestFlowBatchDropsAboveCap proves the export batch is BOUNDED (#3747):
+// once a per-family batch is at capacity, further add()s are dropped
+// (drop-newest) and counted rather than growing the slice without bound.
+//
+// FAIL-ON-REVERT: before #3747 add() appended unconditionally, so the batch
+// grew to the full number of records offered (unbounded memory growth) and
+// there was no Dropped()/capOverride API at all — the reverted code neither
+// compiles this test nor caps the depth.
+func TestFlowBatchDropsAboveCap(t *testing.T) {
+	const capN = 4
+	b := &flowBatch{capOverride: capN}
+
+	// Offer 3x the capN of IPv4 records.
+	const offered = capN * 3
+	for i := 0; i < offered; i++ {
+		b.add(FlowRecord{IsIPv6: false})
+	}
+
+	if got := b.depth(); got != capN {
+		t.Fatalf("depth after overflow = %d, want capN %d (queue grew past the bound)", got, capN)
+	}
+	if got := b.Dropped(); got != offered-capN {
+		t.Fatalf("Dropped() = %d, want %d (offered %d, capN %d)", got, offered-capN, offered, capN)
+	}
+
+	// drain returns exactly the capN-many retained records, then the queue
+	// is empty and depth is 0.
+	v4, v6 := b.drain()
+	if len(v4) != capN || len(v6) != 0 {
+		t.Fatalf("drain returned v4=%d v6=%d, want v4=%d v6=0", len(v4), len(v6), capN)
+	}
+	if got := b.depth(); got != 0 {
+		t.Fatalf("depth after drain = %d, want 0", got)
+	}
+	// Drops are cumulative — draining does not reset the counter.
+	if got := b.Dropped(); got != offered-capN {
+		t.Fatalf("Dropped() after drain = %d, want %d (must be cumulative)", got, offered-capN)
+	}
+}
+
+// TestFlowBatchBelowCapNeverDrops proves the happy path (queue below the capN)
+// is unchanged: every offered record is retained and nothing is dropped.
+func TestFlowBatchBelowCapNeverDrops(t *testing.T) {
+	const capN = 8
+	b := &flowBatch{capOverride: capN}
+
+	const offered = capN - 1
+	for i := 0; i < offered; i++ {
+		b.add(FlowRecord{IsIPv6: false})
+	}
+	if got := b.Dropped(); got != 0 {
+		t.Fatalf("Dropped() = %d, want 0 for a below-capN workload", got)
+	}
+	if got := b.depth(); got != offered {
+		t.Fatalf("depth = %d, want %d (below-capN workload lost records)", got, offered)
+	}
+	if got := b.MaxDepth(); got != offered {
+		t.Fatalf("MaxDepth() = %d, want %d", got, offered)
+	}
+	v4, _ := b.drain()
+	if len(v4) != offered {
+		t.Fatalf("drain returned %d records, want %d", len(v4), offered)
+	}
+}
+
+// TestFlowBatchCapIsPerFamily proves the v4 and v6 caps are independent: an
+// IPv4 overflow does not consume the IPv6 budget (they are split slices).
+func TestFlowBatchCapIsPerFamily(t *testing.T) {
+	const capN = 3
+	b := &flowBatch{capOverride: capN}
+
+	// Overflow v4 while filling v6 to exactly capN (no v6 drop).
+	for i := 0; i < capN*2; i++ {
+		b.add(FlowRecord{IsIPv6: false})
+	}
+	for i := 0; i < capN; i++ {
+		b.add(FlowRecord{IsIPv6: true})
+	}
+
+	if got := b.Dropped(); got != capN {
+		t.Fatalf("Dropped() = %d, want %d (only the v4 overflow should drop)", got, capN)
+	}
+	v4, v6 := b.drain()
+	if len(v4) != capN {
+		t.Fatalf("v4 retained %d, want %d", len(v4), capN)
+	}
+	if len(v6) != capN {
+		t.Fatalf("v6 retained %d, want %d (v6 must not be starved by the v4 overflow)", len(v6), capN)
+	}
+}
+
+// TestFlowBatchMaxDepthHighWater proves MaxDepth() captures the peak backlog
+// even after a later drain empties the queue — the after-the-fact signal that
+// a transient stall built a backlog (#3747).
+func TestFlowBatchMaxDepthHighWater(t *testing.T) {
+	const capN = 16
+	b := &flowBatch{capOverride: capN}
+
+	for i := 0; i < 5; i++ {
+		b.add(FlowRecord{IsIPv6: false})
+	}
+	for i := 0; i < 4; i++ {
+		b.add(FlowRecord{IsIPv6: true})
+	}
+	// Peak combined depth is 9.
+	if got := b.MaxDepth(); got != 9 {
+		t.Fatalf("MaxDepth() = %d, want 9", got)
+	}
+	b.drain()
+	if got := b.depth(); got != 0 {
+		t.Fatalf("depth after drain = %d, want 0", got)
+	}
+	if got := b.MaxDepth(); got != 9 {
+		t.Fatalf("MaxDepth() after drain = %d, want 9 (high-water must survive drain)", got)
+	}
+}
+
+// TestFlowBatchConcurrentAddDrainBounded exercises the bounded queue under a
+// concurrent producer/drain race (run with -race). Every offered record is
+// accounted for exactly once — either dropped at capacity or drained — and the
+// depth never exceeds 2x capN (per-family capN x two families).
+func TestFlowBatchConcurrentAddDrainBounded(t *testing.T) {
+	const capPerFamily = 128
+	b := &flowBatch{capOverride: capPerFamily}
+
+	const producers = 8
+	const perProducer = 4000
+	const total = producers * perProducer
+
+	var drained atomic.Uint64
+	stop := make(chan struct{})
+
+	var dwg sync.WaitGroup
+	dwg.Add(1)
+	go func() {
+		defer dwg.Done()
+		for {
+			v4, v6 := b.drain()
+			drained.Add(uint64(len(v4) + len(v6)))
+			if d := b.depth(); d > 2*capPerFamily {
+				t.Errorf("observed depth %d exceeds bound %d", d, 2*capPerFamily)
+			}
+			select {
+			case <-stop:
+				// One final drain to sweep whatever landed after the last loop.
+				v4, v6 := b.drain()
+				drained.Add(uint64(len(v4) + len(v6)))
+				return
+			default:
+			}
+		}
+	}()
+
+	var pwg sync.WaitGroup
+	for p := 0; p < producers; p++ {
+		pwg.Add(1)
+		go func(p int) {
+			defer pwg.Done()
+			for i := 0; i < perProducer; i++ {
+				b.add(FlowRecord{IsIPv6: (i & 1) == 0})
+			}
+		}(p)
+	}
+	pwg.Wait()
+	close(stop)
+	dwg.Wait()
+
+	// Sweep anything left behind by the drainer's exit race.
+	v4, v6 := b.drain()
+	drained.Add(uint64(len(v4) + len(v6)))
+
+	if got := drained.Load() + b.Dropped(); got != total {
+		t.Fatalf("accounting: drained %d + dropped %d = %d, want total %d",
+			drained.Load(), b.Dropped(), got, total)
+	}
+}
+
+// TestExporterBatchAccessorsSurfaceDrops proves the per-exporter accessors
+// (BatchDepth / BatchMaxDepth / BatchDropped) surface the bounded-batch
+// counters for BOTH the NetFlow v9 and IPFIX exporters (#3747).
+func TestExporterBatchAccessorsSurfaceDrops(t *testing.T) {
+	const capN = 2
+	const offered = 5
+
+	nf := &Exporter{}
+	nf.batch.capOverride = capN
+	for i := 0; i < offered; i++ {
+		nf.batch.add(FlowRecord{IsIPv6: false})
+	}
+	if got := nf.BatchDepth(); got != capN {
+		t.Fatalf("netflow BatchDepth() = %d, want %d", got, capN)
+	}
+	if got := nf.BatchMaxDepth(); got != capN {
+		t.Fatalf("netflow BatchMaxDepth() = %d, want %d", got, capN)
+	}
+	if got := nf.BatchDropped(); got != offered-capN {
+		t.Fatalf("netflow BatchDropped() = %d, want %d", got, offered-capN)
+	}
+
+	ip := &IPFIXExporter{}
+	ip.batch.capOverride = capN
+	for i := 0; i < offered; i++ {
+		ip.batch.add(FlowRecord{IsIPv6: true})
+	}
+	if got := ip.BatchDepth(); got != capN {
+		t.Fatalf("ipfix BatchDepth() = %d, want %d", got, capN)
+	}
+	if got := ip.BatchDropped(); got != offered-capN {
+		t.Fatalf("ipfix BatchDropped() = %d, want %d", got, offered-capN)
+	}
+}

--- a/pkg/flowexport/ipfix.go
+++ b/pkg/flowexport/ipfix.go
@@ -905,6 +905,17 @@ func (e *IPFIXExporter) RouteMaskUnresolved() uint64 {
 	return e.routeMaskUnresolved.Load()
 }
 
+// BatchDepth returns the current number of flow records pending in the export
+// batch (both families combined). See Exporter.BatchDepth (#3747).
+func (e *IPFIXExporter) BatchDepth() uint64 { return e.batch.depth() }
+
+// BatchMaxDepth returns the high-water mark of the pending batch depth (#3747).
+func (e *IPFIXExporter) BatchMaxDepth() uint64 { return e.batch.MaxDepth() }
+
+// BatchDropped returns the cumulative count of flow records dropped because
+// the export batch was at capacity. See Exporter.BatchDropped (#3747).
+func (e *IPFIXExporter) BatchDropped() uint64 { return e.batch.Dropped() }
+
 // CollectorHealth returns a per-collector write-health snapshot (#2464).
 func (e *IPFIXExporter) CollectorHealth() []CollectorHealth {
 	return e.conns.health()

--- a/pkg/flowexport/netflow.go
+++ b/pkg/flowexport/netflow.go
@@ -643,6 +643,21 @@ func (e *Exporter) RouteMaskUnresolved() uint64 {
 	return e.routeMaskUnresolved.Load()
 }
 
+// BatchDepth returns the current number of flow records pending in the export
+// batch (both families combined). Normally near 0 — the Run goroutine drains
+// every 100ms; a sustained nonzero value means the drain cannot keep up
+// (stalled Run / slow collector / close storm) (#3747).
+func (e *Exporter) BatchDepth() uint64 { return e.batch.depth() }
+
+// BatchMaxDepth returns the high-water mark of the pending batch depth (#3747).
+func (e *Exporter) BatchMaxDepth() uint64 { return e.batch.MaxDepth() }
+
+// BatchDropped returns the cumulative count of flow records dropped because
+// the export batch was at capacity (#3747). A climbing value means records
+// are being lost to a stalled/overrun drain rather than growing memory
+// without bound.
+func (e *Exporter) BatchDropped() uint64 { return e.batch.Dropped() }
+
 // Stats returns export statistics.
 func (e *Exporter) Stats() (flows, packets uint64) {
 	return e.exportedFlows.Load(), e.exportedPkts.Load()

--- a/pkg/flowexport/transport.go
+++ b/pkg/flowexport/transport.go
@@ -235,25 +235,86 @@ func (cc *collectorConns) close() {
 	}
 }
 
+// defaultFlowBatchCap bounds the number of pending flow records held per
+// address family before add() starts dropping (#3747). The batch is drained
+// every 100ms by the exporter Run goroutine, so under normal operation the
+// depth stays well below this; the cap only bites when the drain is STOPPED
+// or STALLED — the reconcile window (Run swapped out), a blocked/slow
+// collector write, or a SESSION_CLOSE storm (scan / failover) outrunning the
+// 100ms flush. Before #3747 add() appended without bound, so a stalled drain
+// let the batch grow with the close-event rate → unbounded memory growth
+// (DoS / OOM) with no depth or drop visibility. At the current FlowRecord
+// size (~a few hundred bytes with its net.IP backing arrays) this cap bounds
+// each family to tens of MB — a bounded, counted drop instead of an OOM.
+const defaultFlowBatchCap = 65536
+
 // flowBatch accumulates flow records pending export, split by address
 // family. The export loop drains it on a periodic ticker (and on
 // shutdown) and hands each non-empty slice to the protocol-specific
 // send path. The split is by family, not by zone.
+//
+// The queue is BOUNDED per family (#3747): add() rejects a record once the
+// target family is at capacity and counts the drop, so a stopped/stalled
+// drain can no longer grow the batch without bound. dropped / maxDepth are
+// atomics so the status/metrics accessors read them without contending on mu.
 type flowBatch struct {
 	mu sync.Mutex
 	v4 []FlowRecord
 	v6 []FlowRecord
+	// capOverride is the per-family record cap; 0 means defaultFlowBatchCap.
+	// Only tests set it (to a small value that makes the drop path reachable).
+	capOverride int
+	// dropped counts records rejected because the target family batch was at
+	// capacity. Monotonic; surfaced through Dropped() for status/CLI/REST and
+	// the xpf_flow_export_batch_dropped_total metric (#3747).
+	dropped atomic.Uint64
+	// maxDepth is the high-water mark of len(v4)+len(v6) observed by add().
+	// It captures the worst-case backlog even after a later drain empties the
+	// queue, so a transient stall is still visible after the fact (#3747).
+	maxDepth atomic.Uint64
 }
 
-// add queues a record into the appropriate per-family batch.
-func (b *flowBatch) add(fr FlowRecord) {
-	b.mu.Lock()
-	if fr.IsIPv6 {
-		b.v6 = append(b.v6, fr)
-	} else {
-		b.v4 = append(b.v4, fr)
+// batchCap returns the effective per-family record cap.
+func (b *flowBatch) batchCap() int {
+	if b.capOverride > 0 {
+		return b.capOverride
 	}
+	return defaultFlowBatchCap
+}
+
+// add queues a record into the appropriate per-family batch. When the target
+// family is already at capacity the record is DROPPED (drop-newest) and the
+// dropped counter is incremented rather than growing the batch without bound
+// (#3747).
+//
+// Drop-newest (reject the incoming record) is chosen over drop-oldest
+// deliberately: it is O(1) with no slice shift or reallocation churn under
+// sustained overflow, it never blocks the caller, and it leaves the happy
+// path (below cap) a plain append — unchanged. The flow-close callback that
+// calls add() runs on the event-reader path, so it MUST NOT block: dropping a
+// record is strictly preferable to backpressuring into the session reap/close
+// path. Which end is dropped barely matters for forensic value in a close
+// storm (all closes are near-contemporaneous); O(1) non-blocking does.
+func (b *flowBatch) add(fr FlowRecord) {
+	capN := b.batchCap()
+	b.mu.Lock()
+	dst := &b.v4
+	if fr.IsIPv6 {
+		dst = &b.v6
+	}
+	if len(*dst) >= capN {
+		b.mu.Unlock()
+		b.dropped.Add(1)
+		return
+	}
+	*dst = append(*dst, fr)
+	depth := uint64(len(b.v4) + len(b.v6))
 	b.mu.Unlock()
+	// maxDepth is written only here; adds are serialized by mu, so the
+	// load-then-store cannot race another writer (readers only Load()).
+	if depth > b.maxDepth.Load() {
+		b.maxDepth.Store(depth)
+	}
 }
 
 // drain atomically removes and returns the accumulated v4 and v6
@@ -266,4 +327,39 @@ func (b *flowBatch) drain() (v4, v6 []FlowRecord) {
 	b.v6 = nil
 	b.mu.Unlock()
 	return v4, v6
+}
+
+// depth returns the current number of records pending across both families.
+func (b *flowBatch) depth() uint64 {
+	b.mu.Lock()
+	d := uint64(len(b.v4) + len(b.v6))
+	b.mu.Unlock()
+	return d
+}
+
+// Dropped returns the cumulative count of records dropped because a family
+// batch was at capacity (#3747).
+func (b *flowBatch) Dropped() uint64 { return b.dropped.Load() }
+
+// MaxDepth returns the high-water mark of the combined pending depth (#3747).
+func (b *flowBatch) MaxDepth() uint64 { return b.maxDepth.Load() }
+
+// ExporterBatchStats is one exporter's pending-batch queue stats (#3747),
+// annotated with the protocol family, sampling instance, and template group
+// it belongs to — the same identity the per-collector health snapshot carries
+// (#2464). It is the cross-package shape surfaced through the daemon to REST
+// status, gRPC show, and the Prometheus collector so an operator can see the
+// export backlog depth and any dropped records. It lives here (not pkg/daemon)
+// so pkg/api and pkg/grpcapi — which must not import pkg/daemon — can name the
+// return type of the injected accessor callback.
+type ExporterBatchStats struct {
+	Protocol string `json:"protocol"`
+	Instance string `json:"instance"`
+	Template string `json:"template"`
+	// Depth is the current combined (v4+v6) pending record count.
+	Depth uint64 `json:"depth"`
+	// MaxDepth is the high-water mark of the combined pending depth.
+	MaxDepth uint64 `json:"max_depth"`
+	// Dropped is the cumulative count of records dropped at capacity.
+	Dropped uint64 `json:"dropped"`
 }


### PR DESCRIPTION
## Summary

Closes #3747.

The per-family flow-export accumulator `flowBatch` (`pkg/flowexport/transport.go`, `v4`/`v6`) was **unbounded**. `flowBatch.add` appended with no cap, and the batch was drained **only** by the exporter `Run` goroutine on its 100 ms ticker. If `Run` was stopped or stalled — the reconcile window (exporter briefly swapped out), a blocked/slow collector write, or a `SESSION_CLOSE` storm (scan / failover) outrunning the flush — `ExportSessionClose` kept appending and memory grew with the close-event rate: unbounded growth (a DoS / OOM risk) with no depth or drop visibility (codex-review-158 H08/M15).

## Fix

- **Bound each per-family batch** at `defaultFlowBatchCap` (65536 records; a test-only `capOverride` makes the drop path reachable).
- On overflow, **drop the incoming record (drop-newest)** and increment an atomic `dropped` counter instead of growing the slice. Track a `maxDepth` high-water mark so a transient stall stays visible after a later drain.
- **Drop-newest rationale** (documented in code + README): O(1) with no slice-shift/realloc churn under sustained overflow, never blocks the caller, and leaves the happy path (below cap) a plain append. The flow-close callback runs on the event-reader path, so `add` MUST NOT block — a drop is strictly preferable to backpressuring the session reap/close path. Which end is dropped is symmetric in forensic value during a near-contemporaneous close storm.
- **Visibility**: `Exporter`/`IPFIXExporter` `BatchDepth()` / `BatchMaxDepth()` / `BatchDropped()` accessors (mirroring the existing `EstimatedDurations` / `RouteMaskUnresolved` pattern) → `Daemon.FlowExportBatchStats()` → Prometheus family `xpf_flow_export_batch_{depth,max_depth,dropped_total}` labeled `{protocol,instance,template}` (one bounded series per flow-server group; mirrors the #2464 CollectorHealth wiring).

The happy path (queue below cap) is unchanged.

## Tests (RED on revert)

`pkg/flowexport/flowbatch_bounded_test.go`:
- Reverting the source while keeping the test **fails to compile** — the bounded API (`capOverride` / `Dropped` / `MaxDepth` / `depth`) does not exist pre-fix. Verified by restoring `origin/master`'s transport/netflow/ipfix and re-running: `unknown field capOverride` / `b.Dropped undefined` … `[build failed]`.
- Behavioral pins: drops-above-cap with a cumulative counter; **no drop below cap** (happy path); per-family cap independence (v4 overflow doesn't starve v6); high-water survives drain; per-exporter accessors surface the counters for both protocols; and a **`-race`** concurrent producer/drain accounting invariant (`drained + dropped == offered`, depth ≤ 2× cap).

## Validation

- `go test -race ./pkg/flowexport/... ./pkg/api/...` — green
- `go test ./pkg/daemon/...` — green
- `go build ./...` — green
- `gofmt` + `go vet` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi