### PR TITLE
ip-monitoring: non-blocking shutdown + interface-scoped IPv6 link-local preferred-route (#3758 #3759)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26768,3 +26768,27 @@ top.
     reversed-range reject; appTerm.dstPortConfigured + portConfigured
     guard), pkg/dataplane/userspace/nat_reversed_port_range_3726_test.go
     (new RED-on-revert pins), docs/userspace-dnat-plan.md (§13b)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3758 — ip-monitoring: non-blocking daemon shutdown.
+    `actuateRouteOverlay` acquired the apply semaphore with
+    `context.Background()`, so an in-flight actuation blocked behind a
+    wedged/held apply could hold the ipmon run loop off its stop case
+    forever — and `ipmon.Stop()` (daemon teardown) hung on `e.done`.
+    Threaded a cancellable actuation context through the engine:
+    `New` creates it, the run loop passes it to `actuate(ctx)`, and
+    `Stop()` cancels it BEFORE waiting on `e.done` so a blocked
+    actuation aborts promptly. `actuateRouteOverlay(ctx)` now uses
+    `applySem.Acquire(ctx, 1)` and, on cancel, returns false WITHOUT
+    touching FRR or the userspace snapshot (no half-actuation). Actuate
+    signature `func() bool` → `func(context.Context) bool` (all engine
+    tests updated). RED-on-revert proven both layers: reverting the
+    daemon Acquire to context.Background() → daemon test hangs 2 s RED;
+    removing the Stop cancel → engine test hangs 2 s RED. go test -race
+    ./pkg/ipmon/... ./pkg/daemon/ green.
+  - **File(s)**: pkg/ipmon/ipmon.go (actuateCtx/actuateCancel fields,
+    New, Stop, run loop, actuate signature), pkg/daemon/daemon_ipmon.go
+    (actuateRouteOverlay ctx param + Acquire(ctx)), pkg/ipmon/ipmon_test.go
+    + pkg/ipmon/nexthop_test.go (signature sweep + TestStopAbortsBlockedActuation),
+    pkg/daemon/daemon_ipmon_test.go (TestActuateRouteOverlayAbortsOnContextCancel),
+    docs/multi-wan.md (non-blocking shutdown bullet)

--- a/_Log.md
+++ b/_Log.md
@@ -26792,3 +26792,34 @@ top.
     + pkg/ipmon/nexthop_test.go (signature sweep + TestStopAbortsBlockedActuation),
     pkg/daemon/daemon_ipmon_test.go (TestActuateRouteOverlayAbortsOnContextCancel),
     docs/multi-wan.md (non-blocking shutdown bullet)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3759 — ip-monitoring: interface-scoped IPv6 link-local
+    preferred-route next-hop. A literal link-local next-hop
+    (`preferred-route route ::/0 next-hop fe80::1`) committed cleanly but
+    rendered a scopeless `ipv6 route ::/0 fe80::1`, which FRR rejects —
+    the failover route silently failed to install. Root cause: the
+    overlay reuses `generateStaticRouteInTable` + `IPv6NextHopInterfaces`
+    but the overlay's PreferredRoutes were NEVER fed into
+    `inferIPv6StaticNextHopInterfaces`, so the map was always absent for
+    the failover gateway. Fix: pass the overlay to the inference
+    (`inferIPv6StaticNextHopInterfaces(cfg, overlay)` in assembleFRRConfig)
+    and resolve each overlay literal v6 next-hop through the SAME
+    connected-prefix / synthetic-fe80::/64 pipeline as static routes,
+    keyed by the VRF the render uses (`""` for master + forwarding
+    instances, `vrf-<name>` for virtual-router). Matches static-route
+    handling (#2452): resolves on a single IPv6 interface, stays
+    unresolved (FRR-rejected, operator must disambiguate) when ambiguous.
+    Chose the attach-scope option over commit-reject because the routing
+    code (static routes) attaches scope via this exact map and never
+    rejects link-local at commit. RED-on-revert proven: reverting the
+    inference-body overlay loop → direct inference tests RED; reverting
+    the assembleFRRConfig call-site → assemble test RED. go test
+    ./pkg/daemon/ ./pkg/frr/ green.
+  - **File(s)**: pkg/daemon/daemon_run.go (inferIPv6StaticNextHopInterfaces
+    overlay arg + resolution loop), pkg/daemon/daemon_ipmon.go (call site),
+    pkg/daemon/ipv6_static_nexthop_test.go (overlay link-local + forwarding
+    + nil-control tests; static callers → nil), pkg/daemon/daemon_ipmon_test.go
+    (TestAssembleFRRConfigResolvesOverlayLinkLocal),
+    pkg/frr/preferred_routes_test.go (render contract test),
+    docs/multi-wan.md + pkg/frr/README.md (link-local overlay next-hop)

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -285,6 +285,25 @@ Semantics (verified against Junos in the plan's research rounds):
   `routing-instance` target must exist (PR-2 lifted the PR-1b
   rejection of `instance-type forwarding` targets — see the FBF
   section below).
+- **IPv6 link-local preferred-route next-hops (#3759).** A literal IPv6
+  link-local next-hop (`fe80::…`, the common IPv6 WAN gateway form) has
+  no meaning to FRR without an interface scope — FRR rejects a scopeless
+  `ipv6 route ::/0 fe80::1`. The overlay renders through the same
+  `generateStaticRouteInTable` + `IPv6NextHopInterfaces` machinery as
+  configured statics, so a preferred-route link-local next-hop is now
+  fed through `inferIPv6StaticNextHopInterfaces` and gets its interface
+  scope attached exactly like a static route (#2452): resolved to the
+  box's sole IPv6 interface when unambiguous, keyed by the same VRF the
+  render uses (`""` for the master table and `instance-type forwarding`
+  targets, `vrf-<name>` for a virtual-router instance). A global-unicast
+  next-hop resolves by longest-prefix as usual (bare when it matches no
+  connected subnet — FRR accepts a scopeless global next-hop). When the
+  box has multiple IPv6 interfaces the link-local next-hop is ambiguous
+  and stays unresolved — identical to a static route: FRR then rejects
+  it, and the operator must disambiguate. The userspace-snapshot overlay
+  still carries the bare next-hop address (a wire-protocol
+  `addr@iface` convention is a follow-up); the kernel FIB path — where
+  the failover route actually installs — is the one this fix repairs.
 
 ## Per-policy uplink selection — FBF composition (PR-2)
 

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -585,6 +585,19 @@ routing, and only on double fault).
   re-publishes — the cache never records an overlay the dataplane never
   accepted, and a full apply during the dirty window rebuilds routes that
   match what is actually live rather than the failed target.
+- **Non-blocking shutdown (#3758).** The actuator is optional
+  infrastructure and must never wedge daemon shutdown. It runs from the
+  engine's single run-loop goroutine, which can only observe the stop
+  signal *after* the synchronous actuator returns — so a blocked
+  actuation (waiting on the apply semaphore held by an unrelated apply,
+  or on a wedged FRR reload) would otherwise hold shutdown hostage.
+  `ipmon.Stop()` cancels the engine's actuation context **before** it
+  waits for the run loop to exit; the actuator threads that context into
+  `applySem.Acquire`, so a shutdown aborts the wait promptly. A
+  cancelled actuation returns "not converged" **without** touching FRR or
+  the userspace snapshot (no half-actuation): if the daemon is still up
+  the engine keeps the overlay dirty and re-actuates on the next sweep,
+  and if it is shutting down the run loop reaches its stop case at once.
 - **Per-cycle transition evaluation (#2527).** An RPM test's pass/fail
   status is a per-test aggregate, evaluated once across the whole probe
   set (`probe-count` probes per cycle), Junos ip-monitoring style. The

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -139,7 +139,7 @@ func (d *Daemon) assembleFRRConfig(cfg *config.Config, overlay []config.RouteOve
 		InterfaceBandwidths:   ifaceBandwidths,
 		InterfacePointToPoint: ifaceP2P,
 		RethMap:               cfg.RethToPhysical(),
-		IPv6NextHopInterfaces: inferIPv6StaticNextHopInterfaces(cfg),
+		IPv6NextHopInterfaces: inferIPv6StaticNextHopInterfaces(cfg, overlay),
 		ClusterMode:           d.cluster != nil,
 		PreferredRoutes:       overlay,
 	}

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -235,8 +235,20 @@ func setFibMultipathHashPolicy() {
 // actuateRouteOverlay returns whether the overlay converged
 // consistently; the ipmon engine keeps the state dirty and retries when
 // it returns false (#3757).
-func (d *Daemon) actuateRouteOverlay() bool {
-	_ = d.applySem.Acquire(context.Background(), 1)
+//
+// ctx is the engine's actuation context (cancelled on ipmon.Stop, i.e.
+// daemon shutdown/reconcile). It is threaded into the apply-semaphore
+// acquire so a shutdown aborts a wait that would otherwise wedge the
+// ipmon run loop — and, through it, shutdown — behind an in-flight
+// apply that never releases the semaphore (#3758). On cancellation the
+// actuator returns false WITHOUT touching FRR or the userspace snapshot
+// (no half-actuation): the engine keeps the state dirty and re-actuates
+// on the next sweep if the daemon is still up, and shutdown proceeds
+// otherwise.
+func (d *Daemon) actuateRouteOverlay(ctx context.Context) bool {
+	if err := d.applySem.Acquire(ctx, 1); err != nil {
+		return false
+	}
 	defer d.applySem.Release(1)
 
 	if d.store == nil {

--- a/pkg/daemon/daemon_ipmon_test.go
+++ b/pkg/daemon/daemon_ipmon_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
@@ -395,5 +396,49 @@ func TestActuatorPublishesOnDegradedFRR(t *testing.T) {
 	}
 	if len(dp.calls) != 2 || dp.calls[0] != "publish" || dp.calls[1] != "bump" {
 		t.Fatalf("calls = %v, want [publish bump] on a degraded reload", dp.calls)
+	}
+}
+
+// TestActuateRouteOverlayAbortsOnContextCancel is the #3758 regression
+// at the exact bug line: actuateRouteOverlay acquires the apply
+// semaphore with the ENGINE's actuation context (cancelled on ipmon
+// shutdown), not context.Background(). When an unrelated apply holds
+// applySem, the actuator blocks in Acquire — and a shutdown, which
+// cancels that context, must abort the wait promptly rather than hang
+// the ipmon run loop (and, through it, daemon shutdown) behind the
+// wedged apply. This test holds applySem, launches the actuator so it
+// blocks in Acquire, and asserts a context cancel unblocks it with a
+// clean (false, no half-actuation) return. On revert (Acquire uses
+// context.Background()) the cancel has no effect, the goroutine stays
+// blocked, and the watchdog timeout fires — RED.
+func TestActuateRouteOverlayAbortsOnContextCancel(t *testing.T) {
+	d := &Daemon{applySem: semaphore.NewWeighted(1)}
+
+	// An unrelated apply holds the semaphore for the whole test.
+	if err := d.applySem.Acquire(context.Background(), 1); err != nil {
+		t.Fatalf("seed Acquire: %v", err)
+	}
+	defer d.applySem.Release(1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool, 1)
+	go func() { done <- d.actuateRouteOverlay(ctx) }()
+
+	// It must be blocked in Acquire (semaphore held) — not returned yet.
+	select {
+	case <-done:
+		t.Fatal("actuateRouteOverlay returned while applySem was held (did not block on Acquire)")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// A shutdown cancels the actuation context — Acquire must abort.
+	cancel()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("actuateRouteOverlay returned true after ctx cancel; must abort (false) without actuating")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("actuateRouteOverlay did not abort on ctx cancel (#3758 shutdown-hang regression)")
 	}
 }

--- a/pkg/daemon/daemon_ipmon_test.go
+++ b/pkg/daemon/daemon_ipmon_test.go
@@ -131,6 +131,35 @@ func TestAssembleFRRConfigCarriesOverlay(t *testing.T) {
 	}
 }
 
+// TestAssembleFRRConfigResolvesOverlayLinkLocal is the #3759 wiring
+// check at the assembler: assembleFRRConfig must feed the overlay it is
+// handed into inferIPv6StaticNextHopInterfaces so a link-local
+// preferred-route next-hop carries an interface scope into the FRR
+// render. On revert (the overlay is not passed to the inference) the
+// map entry is absent and the assertion fails.
+func TestAssembleFRRConfigResolvesOverlayLinkLocal(t *testing.T) {
+	d := &Daemon{}
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/3": {
+					Units: map[int]*config.InterfaceUnit{
+						50: {Addresses: []string{"2001:559:8585:50::8/64"}},
+					},
+				},
+			},
+		},
+	}
+	overlay := []config.RouteOverlayEntry{
+		{Destination: "::/0", NextHop: "fe80::1", Policy: "wan-failover"},
+	}
+
+	fc := d.assembleFRRConfig(cfg, overlay)
+	if got := fc.IPv6NextHopInterfaces[""]["fe80::1"]; got != "ge-0-0-3.50" {
+		t.Fatalf("IPv6NextHopInterfaces[\"\"][fe80::1] = %q, want ge-0-0-3.50 (overlay not fed into inference, #3759)", got)
+	}
+}
+
 // TestAssembleFRRConfigForwardingInstanceTable (#1827 PR-2): forwarding
 // instances map to InstanceConfig{VRFName: "", TableID: <kernel table>}
 // so FRR renders their statics with `table <id>` instead of polluting

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -1927,7 +1927,7 @@ var linkLocalV6Net = func() *net.IPNet {
 	return n
 }()
 
-func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]string {
+func inferIPv6StaticNextHopInterfaces(cfg *config.Config, overlay []config.RouteOverlayEntry) map[string]map[string]string {
 	type connectedPrefix struct {
 		net       *net.IPNet
 		ifName    string
@@ -2159,6 +2159,42 @@ func inferIPv6StaticNextHopInterfaces(cfg *config.Config) map[string]map[string]
 		}
 		addRoutes(vrfName, ri.StaticRoutes)
 		addRoutes(vrfName, ri.Inet6StaticRoutes)
+	}
+
+	// #3759: feed the ip-monitoring effective-route overlay's literal
+	// next-hops through the SAME resolution as configured statics. The
+	// overlay renders via generateStaticRouteInTable with this exact
+	// IPv6NextHopInterfaces map (renderPreferredRoutes), so a link-local
+	// preferred-route next-hop (fe80::…, common for an IPv6 WAN gateway)
+	// needs an interface scope attached here — FRR rejects a scopeless
+	// `ipv6 route ::/0 fe80::1`. Previously the overlay entries were never
+	// fed in, so the map was always absent for the failover gateway and the
+	// route silently failed to install exactly when a link went down. The
+	// per-entry VRF key must match what renderPreferredRoutes passes to
+	// generateStaticRouteInTable: "" for the master table AND for
+	// instance-type forwarding (which renders via `table <id>`, vrfName ==
+	// ""), "vrf-<name>" for a virtual-router instance. A global-unicast
+	// next-hop resolves by longest-prefix as usual (bare if it matches no
+	// connected subnet — FRR accepts a scopeless global next-hop); an
+	// ambiguous or unresolvable link-local stays unresolved, exactly like a
+	// static route (the operator must add a disambiguating interface).
+	for _, entry := range overlay {
+		if entry.NextHop == "" || !strings.Contains(entry.NextHop, ":") {
+			continue
+		}
+		vrfName := ""
+		if entry.RoutingInstance != "" {
+			vrfName = "vrf-" + entry.RoutingInstance
+			for _, ri := range cfg.RoutingInstances {
+				if ri != nil && ri.Name == entry.RoutingInstance {
+					if ri.InstanceType == "forwarding" {
+						vrfName = ""
+					}
+					break
+				}
+			}
+		}
+		setResolved(vrfName, entry.NextHop, resolve(connectedByVRF[vrfName], entry.NextHop))
 	}
 	return resolved
 }

--- a/pkg/daemon/ipv6_static_nexthop_test.go
+++ b/pkg/daemon/ipv6_static_nexthop_test.go
@@ -49,7 +49,7 @@ func TestInferIPv6StaticNextHopInterfaces(t *testing.T) {
 		},
 	}
 
-	got := inferIPv6StaticNextHopInterfaces(cfg)
+	got := inferIPv6StaticNextHopInterfaces(cfg, nil)
 	if got[""]["2001:559:8585:50::1"] != "reth0.50" {
 		t.Fatalf("default route next-hop interface = %q, want reth0.50", got[""]["2001:559:8585:50::1"])
 	}
@@ -100,7 +100,7 @@ func TestInferIPv6StaticNextHopInterfaces_ByVRFAndDeterministicTieBreak(t *testi
 		},
 	}
 
-	got := inferIPv6StaticNextHopInterfaces(cfg)
+	got := inferIPv6StaticNextHopInterfaces(cfg, nil)
 	if got[""]["2001:db8:1::100"] != "reth0.10" {
 		t.Fatalf("global tie-break interface = %q, want reth0.10", got[""]["2001:db8:1::100"])
 	}
@@ -136,7 +136,7 @@ func TestInferIPv6StaticNextHopInterfaces_LinkLocalSingleInterface(t *testing.T)
 		},
 	}
 
-	got := inferIPv6StaticNextHopInterfaces(cfg)
+	got := inferIPv6StaticNextHopInterfaces(cfg, nil)
 	if got[""]["fe80::1"] != "ge-0-0-3.50" {
 		t.Fatalf("link-local next-hop interface = %q, want ge-0-0-3.50", got[""]["fe80::1"])
 	}
@@ -173,7 +173,7 @@ func TestInferIPv6StaticNextHopInterfaces_LinkLocalMultipleAmbiguous(t *testing.
 		},
 	}
 
-	got := inferIPv6StaticNextHopInterfaces(cfg)
+	got := inferIPv6StaticNextHopInterfaces(cfg, nil)
 	if iface := got[""]["fe80::1"]; iface != "" {
 		t.Fatalf("ambiguous link-local next-hop interface = %q, want \"\" (refuse to guess)", iface)
 	}
@@ -211,7 +211,7 @@ func TestInferIPv6StaticNextHopInterfaces_LinkLocalExplicitQualifier(t *testing.
 		},
 	}
 
-	got := inferIPv6StaticNextHopInterfaces(cfg)
+	got := inferIPv6StaticNextHopInterfaces(cfg, nil)
 	if iface, ok := got[""]["fe80::1"]; ok {
 		t.Fatalf("qualified link-local next-hop should not be in inference map, got %q", iface)
 	}
@@ -257,8 +257,82 @@ func TestInferIPv6StaticNextHopInterfaces_VRRPVIPSubnet(t *testing.T) {
 		},
 	}
 
-	got := inferIPv6StaticNextHopInterfaces(cfg)
+	got := inferIPv6StaticNextHopInterfaces(cfg, nil)
 	if got[""]["2001:559:8585:50::254"] != "reth0.50" {
 		t.Fatalf("VIP-subnet next-hop interface = %q, want reth0.50", got[""]["2001:559:8585:50::254"])
+	}
+}
+
+// TestInferIPv6StaticNextHopInterfaces_IPMonOverlayLinkLocal is the
+// #3759 regression: an ip-monitoring preferred-route overlay entry with
+// a literal IPv6 link-local next-hop (fe80::…, the common IPv6 WAN
+// gateway form) must be fed through the SAME inference as configured
+// statics so it renders WITH an interface scope. Before the fix the
+// overlay entries were never passed to inferIPv6StaticNextHopInterfaces,
+// so IPv6NextHopInterfaces[""][fe80::1] was absent and FRR received a
+// scopeless `ipv6 route ::/0 fe80::1` — which it rejects, silently
+// dropping the failover route. On revert (overlay arg dropped / not
+// fed) the link-local lookup below returns "" and the test goes RED.
+// A global-unicast overlay next-hop resolves by longest-prefix as
+// before (proving the normal path still works).
+func TestInferIPv6StaticNextHopInterfaces_IPMonOverlayLinkLocal(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/3": {
+					Units: map[int]*config.InterfaceUnit{
+						50: {Addresses: []string{"2001:559:8585:50::8/64"}},
+					},
+				},
+			},
+		},
+	}
+	overlay := []config.RouteOverlayEntry{
+		{Destination: "::/0", NextHop: "fe80::1", Policy: "wan-failover"},
+		{Destination: "2001:db8::/48", NextHop: "2001:559:8585:50::1", Policy: "wan-failover"},
+	}
+
+	got := inferIPv6StaticNextHopInterfaces(cfg, overlay)
+	if got[""]["fe80::1"] != "ge-0-0-3.50" {
+		t.Fatalf("overlay link-local next-hop interface = %q, want ge-0-0-3.50 (scopeless → FRR-rejected route, #3759)", got[""]["fe80::1"])
+	}
+	if got[""]["2001:559:8585:50::1"] != "ge-0-0-3.50" {
+		t.Fatalf("overlay global next-hop interface = %q, want ge-0-0-3.50", got[""]["2001:559:8585:50::1"])
+	}
+
+	// Control: a nil overlay leaves the link-local unresolved (the
+	// pre-fix behavior — no configured static names fe80::1).
+	if iface := inferIPv6StaticNextHopInterfaces(cfg, nil)[""]["fe80::1"]; iface != "" {
+		t.Fatalf("nil-overlay link-local = %q, want \"\" (only the overlay names it)", iface)
+	}
+}
+
+// TestInferIPv6StaticNextHopInterfaces_IPMonOverlayForwardingInstance
+// pins the VRF-key contract: an overlay entry targeting an
+// instance-type forwarding routing-instance renders via `table <id>`
+// with vrfName == "" (renderPreferredRoutes), so its next-hop scope
+// must be keyed under "" — NOT "vrf-<name>" — to be found at render.
+func TestInferIPv6StaticNextHopInterfaces_IPMonOverlayForwardingInstance(t *testing.T) {
+	cfg := &config.Config{
+		Interfaces: config.InterfacesConfig{
+			Interfaces: map[string]*config.InterfaceConfig{
+				"ge-0/0/3": {
+					Units: map[int]*config.InterfaceUnit{
+						50: {Addresses: []string{"2001:559:8585:50::8/64"}},
+					},
+				},
+			},
+		},
+		RoutingInstances: []*config.RoutingInstanceConfig{
+			{Name: "ISP-B", InstanceType: "forwarding", TableID: 100, Interfaces: []string{"ge-0/0/3.50"}},
+		},
+	}
+	overlay := []config.RouteOverlayEntry{
+		{RoutingInstance: "ISP-B", Destination: "::/0", NextHop: "fe80::1", Policy: "fbf"},
+	}
+
+	got := inferIPv6StaticNextHopInterfaces(cfg, overlay)
+	if got[""]["fe80::1"] != "ge-0-0-3.50" {
+		t.Fatalf("forwarding-instance overlay link-local scope = %q under key \"\", want ge-0-0-3.50", got[""]["fe80::1"])
 	}
 }

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -97,7 +97,12 @@ also carries operator content:
   FRR. The map is built by `inferIPv6StaticNextHopInterfaces`
   (`pkg/daemon/daemon_run.go`); `generateStaticRoute` uses an explicit
   `NextHopEntry.Interface` first and falls back to this map only for an
-  unqualified next-hop.
+  unqualified next-hop. It also resolves the **ip-monitoring overlay's**
+  literal next-hops (`RouteOverlayEntry.NextHop`, passed as the second
+  argument, #3759) so a link-local preferred-route next-hop renders with
+  the same interface scope as a static route — `renderPreferredRoutes`
+  looks the scope up under the same VRF key the render uses (`""` for
+  master + `instance-type forwarding`, `vrf-<name>` otherwise).
 - **Link-local (`fe80::/64`) static next-hops (#2452).** A link-local
   next-hop is interface-scoped and FRR rejects `ipv6 route <dst> fe80::x`
   without a trailing `<iface>`. Link-local addresses are never declared

--- a/pkg/frr/preferred_routes_test.go
+++ b/pkg/frr/preferred_routes_test.go
@@ -104,3 +104,41 @@ func TestApplyFullPreferredRoutesOnly(t *testing.T) {
 		t.Fatalf("withdrawn overlay still present:\n%s", data)
 	}
 }
+
+// TestApplyFullPreferredRoutesLinkLocalScope is the #3759 render
+// contract: an ip-monitoring overlay entry with a link-local next-hop
+// renders as a DISTANCE-1 static WITH the interface scope supplied via
+// IPv6NextHopInterfaces (the map the daemon now populates from the
+// overlay). FRR rejects a scopeless `ipv6 route ::/0 fe80::1`; with the
+// scope it installs the failover route. A global-address overlay
+// next-hop with no map entry still renders (bare, which FRR accepts).
+func TestApplyFullPreferredRoutesLinkLocalScope(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "frr.conf")
+	os.WriteFile(confPath, []byte("log syslog informational\n"), 0644)
+
+	m := &Manager{frrConf: confPath, exec: &fakeExecutor{}}
+	fc := &FullConfig{
+		IPv6NextHopInterfaces: map[string]map[string]string{"": {"fe80::1": "ge-0-0-3.50"}},
+		PreferredRoutes: []config.RouteOverlayEntry{
+			{Destination: "::/0", NextHop: "fe80::1", Policy: "wan-failover"},
+			{Destination: "2001:db8::/48", NextHop: "2001:db8:80::1", Policy: "wan-failover"},
+		},
+	}
+	if err := m.ApplyFull(fc); err != nil {
+		t.Fatalf("ApplyFull: %v", err)
+	}
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+
+	if !strings.Contains(got, "ipv6 route ::/0 fe80::1 ge-0-0-3.50 1\n") {
+		t.Errorf("link-local overlay route missing interface scope in:\n%s", got)
+	}
+	// Global next-hop with no map entry renders bare (FRR-valid).
+	if !strings.Contains(got, "ipv6 route 2001:db8::/48 2001:db8:80::1 1\n") {
+		t.Errorf("global overlay route missing/altered in:\n%s", got)
+	}
+}

--- a/pkg/ipmon/ipmon.go
+++ b/pkg/ipmon/ipmon.go
@@ -40,6 +40,7 @@
 package ipmon
 
 import (
+	"context"
 	"log/slog"
 	"net"
 	"slices"
@@ -175,8 +176,13 @@ type Engine struct {
 	// (kernel FRR AND the userspace snapshot committed together) and
 	// false when any consumer failed — a false return keeps the dirty
 	// bit set so the run loop retries autonomously on the next sweep
-	// (#3757).
-	actuate func() bool
+	// (#3757). It is passed e.actuateCtx (cancelled on Stop) so a
+	// shutdown aborts a blocked actuation instead of wedging the run
+	// loop behind an in-flight apply that never releases (#3758): the
+	// actuator MUST thread the context into any blocking wait (the
+	// apply semaphore, FRR reload) and, on cancellation, abort cleanly
+	// (return false) WITHOUT half-actuating.
+	actuate func(ctx context.Context) bool
 	// resolveNextHop resolves interface-typed next-hops at overlay
 	// computation (#1844). Set once via SetNextHopResolver before
 	// Start; nil ⇒ interface-typed candidates always skip (defensive —
@@ -189,6 +195,14 @@ type Engine struct {
 	kick chan struct{}
 	stop chan struct{}
 	done chan struct{}
+
+	// actuateCtx is cancelled by Stop (its cancel is actuateCancel) so
+	// an in-flight actuation blocked on the apply semaphore or an FRR
+	// reload aborts promptly on shutdown/reconcile instead of holding
+	// the run loop off its stop case forever (#3758). Created in New,
+	// cancelled exactly once in Stop under mu.
+	actuateCtx    context.Context
+	actuateCancel context.CancelFunc
 
 	// started / stopped guard the run-loop lifecycle (#3762). Both are
 	// read and written only under mu. started flips true on the first
@@ -204,10 +218,14 @@ type Engine struct {
 // New creates an engine. actuate is the daemon's routes-only actuator;
 // it is invoked from the engine's single run-loop goroutine (never
 // concurrently) and must read ActiveOverlay() itself so it always
-// publishes the freshest overlay. It returns true on a consistent,
-// converged actuation and false when a consumer failed — a false return
-// keeps the state dirty for an autonomous retry (#3757).
-func New(actuate func() bool) *Engine {
+// publishes the freshest overlay. It receives a context (cancelled on
+// Stop) that it MUST thread into any blocking wait so a shutdown aborts
+// a blocked actuation (#3758). It returns true on a consistent,
+// converged actuation and false when a consumer failed or the context
+// was cancelled — a false return keeps the state dirty for an
+// autonomous retry (#3757).
+func New(actuate func(ctx context.Context) bool) *Engine {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Engine{
 		policies:       make(map[string]*policyState),
 		failedTests:    make(map[string]map[string]bool),
@@ -219,6 +237,8 @@ func New(actuate func() bool) *Engine {
 		kick:           make(chan struct{}, 1),
 		stop:           make(chan struct{}),
 		done:           make(chan struct{}),
+		actuateCtx:     ctx,
+		actuateCancel:  cancel,
 	}
 }
 
@@ -286,6 +306,14 @@ func (e *Engine) Start() {
 // e.stop exactly once, and only a Stop that follows a real Start waits
 // on e.done — a Stop with no run loop returns immediately instead of
 // blocking forever on a channel nothing will ever close.
+//
+// Stop cancels e.actuateCtx BEFORE waiting on e.done (#3758): the run
+// loop can only observe e.stop AFTER the synchronous actuator returns,
+// so if an actuation is blocked (on the apply semaphore or an FRR
+// reload) the wait on e.done would hang forever. Cancelling the
+// context first unblocks that actuation so the loop can reach its stop
+// case promptly. The cancel happens under mu (once, guarded by
+// e.stopped) so it races neither a second Stop nor the run loop.
 func (e *Engine) Stop() {
 	e.mu.Lock()
 	if e.stopped {
@@ -294,6 +322,7 @@ func (e *Engine) Stop() {
 	}
 	e.stopped = true
 	started := e.started
+	e.actuateCancel()
 	e.mu.Unlock()
 	close(e.stop)
 	if started {
@@ -768,7 +797,7 @@ func (e *Engine) run() {
 			// machine directly) is a converged no-op.
 			ok := true
 			if e.actuate != nil {
-				ok = e.actuate()
+				ok = e.actuate(e.actuateCtx)
 			}
 			e.mu.Lock()
 			if ok && e.dirtyGen == actuatingGen {

--- a/pkg/ipmon/ipmon_test.go
+++ b/pkg/ipmon/ipmon_test.go
@@ -2,6 +2,7 @@ package ipmon
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -50,7 +51,7 @@ func (c *fakeClock) Advance(d time.Duration) {
 	c.mu.Unlock()
 }
 
-func newTestEngine(actuate func() bool) (*Engine, *fakeClock) {
+func newTestEngine(actuate func(context.Context) bool) (*Engine, *fakeClock) {
 	e := New(actuate)
 	clock := &fakeClock{now: time.Unix(1000000, 0)}
 	e.now = clock.Now
@@ -308,7 +309,7 @@ func TestWinnerResolution(t *testing.T) {
 // per throttle window (§4.3 coalescing).
 func TestDebounceCoalescing(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() bool { actuations.Add(1); return true })
+	e := New(func(context.Context) bool { actuations.Add(1); return true })
 	e.debounce = 20 * time.Millisecond
 	e.throttle = 60 * time.Millisecond
 	e.Apply(testPolicyConfig(), passResults())
@@ -357,7 +358,7 @@ func TestDebounceCoalescing(t *testing.T) {
 func TestActuationFailureStaysDirtyUntilConverged(t *testing.T) {
 	var attempts atomic.Int32
 	var succeed atomic.Bool // false ⇒ actuation fails; flipped to self-heal
-	e := New(func() bool {
+	e := New(func(context.Context) bool {
 		attempts.Add(1)
 		return succeed.Load()
 	})
@@ -395,7 +396,7 @@ func TestActuationFailureStaysDirtyUntilConverged(t *testing.T) {
 // converged actuation and the loop parks) — no retry churn.
 func TestSuccessfulActuationClearsDirty(t *testing.T) {
 	var attempts atomic.Int32
-	e := New(func() bool { attempts.Add(1); return true })
+	e := New(func(context.Context) bool { attempts.Add(1); return true })
 	e.debounce = 5 * time.Millisecond
 	e.throttle = 20 * time.Millisecond
 	e.Apply(testPolicyConfig(), passResults())
@@ -466,7 +467,7 @@ func TestUnknownStatusNotReportedAsPass(t *testing.T) {
 // count) the "applied == 0 while failing" assertion goes RED.
 func TestRoutesAppliedReflectsActuationNotDesired(t *testing.T) {
 	var succeed atomic.Bool // false ⇒ actuator fails
-	e := New(func() bool { return succeed.Load() })
+	e := New(func(context.Context) bool { return succeed.Load() })
 	e.debounce = 5 * time.Millisecond
 	e.throttle = 10 * time.Millisecond
 	e.Apply(testPolicyConfig(), passResults())
@@ -577,7 +578,7 @@ func TestUnresolvedAndSuppressedDetail(t *testing.T) {
 func TestLifecycleIdempotent(t *testing.T) {
 	// H9: double Start does not spawn a second goroutine (no double
 	// close(done) panic), and repeated Stop is safe.
-	e := New(func() bool { return true })
+	e := New(func(context.Context) bool { return true })
 	e.debounce = time.Millisecond
 	e.throttle = time.Millisecond
 	e.Start()
@@ -587,7 +588,7 @@ func TestLifecycleIdempotent(t *testing.T) {
 	e.Stop() // idempotent, no panic
 
 	// H10: Stop before Start must return promptly, not deadlock.
-	e2 := New(func() bool { return true })
+	e2 := New(func(context.Context) bool { return true })
 	stopReturned := make(chan struct{})
 	go func() {
 		e2.Stop()
@@ -608,7 +609,7 @@ func TestLifecycleIdempotent(t *testing.T) {
 // (baseline) and re-enables on takeover.
 func TestPublishGatingBaseline(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() bool { actuations.Add(1); return true })
+	e := New(func(context.Context) bool { actuations.Add(1); return true })
 	e.Apply(testPolicyConfig(), passResults())
 	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
 	if len(e.ActiveOverlay()) == 0 {
@@ -722,7 +723,7 @@ func TestFilterOverlayForConfig(t *testing.T) {
 // actuation (one spurious frr-reload per commit otherwise).
 func TestApplyWithoutOverlayChangeDoesNotActuate(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() bool { actuations.Add(1); return true })
+	e := New(func(context.Context) bool { actuations.Add(1); return true })
 	e.debounce = 5 * time.Millisecond
 	e.throttle = 5 * time.Millisecond
 	e.Start()
@@ -765,5 +766,52 @@ func TestApplyWithoutOverlayChangeDoesNotActuate(t *testing.T) {
 	time.Sleep(60 * time.Millisecond)
 	if got := actuations.Load(); got == before {
 		t.Fatal("overlay-changing spec edit did not actuate")
+	}
+}
+
+// TestStopAbortsBlockedActuation is the #3758 regression: a shutdown
+// (ipmon.Stop, via the daemon teardown) must abort an in-flight
+// actuation that is blocked on a wait — the apply semaphore held by
+// an unrelated apply, or a wedged FRR reload — instead of wedging the
+// run loop off its stop case forever. The run loop calls the actuator
+// synchronously and can only observe e.stop AFTER the actuator
+// returns, so Stop cancels the actuation context BEFORE waiting on
+// e.done. This test drives one actuation whose actuator blocks until
+// its context is cancelled; Stop must then return promptly. On revert
+// (Stop does not cancel the context, or the actuator ignores it) the
+// actuation never unblocks, run() never returns, and Stop hangs on
+// e.done — the watchdog timeout below fires and the test goes RED.
+func TestStopAbortsBlockedActuation(t *testing.T) {
+	entered := make(chan struct{})
+	var once sync.Once
+	e := New(func(ctx context.Context) bool {
+		once.Do(func() { close(entered) })
+		<-ctx.Done() // block until Stop cancels the actuation context
+		return false // aborted: do not half-actuate
+	})
+	e.debounce = time.Millisecond
+	e.throttle = time.Millisecond
+	e.Apply(testPolicyConfig(), passResults())
+	e.Start()
+
+	// Drive one actuation and wait until the actuator is blocked inside.
+	e.HandleTransition(transition("WAN", "wan-a", "fail", passResults()))
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		e.Stop()
+		t.Fatal("actuator was never entered")
+	}
+
+	// Stop must return promptly even though the actuation is blocked.
+	done := make(chan struct{})
+	go func() {
+		e.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ipmon.Stop hung behind a blocked actuation (#3758 shutdown-hang regression)")
 	}
 }

--- a/pkg/ipmon/nexthop_test.go
+++ b/pkg/ipmon/nexthop_test.go
@@ -1,6 +1,7 @@
 package ipmon
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -183,7 +184,7 @@ func TestStatusUnresolvedRoutes(t *testing.T) {
 // actuates.
 func TestNotifyNextHopChangeGate(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() bool { actuations.Add(1); return true })
+	e := New(func(context.Context) bool { actuations.Add(1); return true })
 	e.debounce = 5 * time.Millisecond
 	e.throttle = 5 * time.Millisecond
 	r := &fakeResolver{}
@@ -221,7 +222,7 @@ func TestNotifyNextHopChangeGate(t *testing.T) {
 
 	// Literal-only FAILED policy: gateway churn must not actuate.
 	e2cnt := atomic.Int32{}
-	e2 := New(func() bool { e2cnt.Add(1); return true })
+	e2 := New(func(context.Context) bool { e2cnt.Add(1); return true })
 	e2.debounce = 5 * time.Millisecond
 	e2.throttle = 5 * time.Millisecond
 	e2.Apply(testPolicyConfig(), passResults())
@@ -288,7 +289,7 @@ func TestFilterOverlayForConfigInterfaceTyped(t *testing.T) {
 // — one actuation path, last-writer-wins.
 func TestGatewayChangeCoalescesWithProbeTransition(t *testing.T) {
 	var actuations atomic.Int32
-	e := New(func() bool { actuations.Add(1); return true })
+	e := New(func(context.Context) bool { actuations.Add(1); return true })
 	e.debounce = 20 * time.Millisecond
 	e.throttle = 60 * time.Millisecond
 	r := &fakeResolver{}


### PR DESCRIPTION
Two coupled ip-monitoring fixes (both touch `pkg/ipmon` + `daemon_ipmon`
+ the shared FRR overlay path), one PR to avoid self-conflict.

## #3758 — non-blocking daemon shutdown

`actuateRouteOverlay` acquired the apply semaphore with
`context.Background()`. The ipmon engine calls the actuator
synchronously from its single run-loop goroutine and can only observe
the stop signal AFTER the actuator returns, so an actuation blocked
behind an unrelated held apply (or a wedged FRR reload) wedged the run
loop off its stop case — and `ipmon.Stop()` (daemon teardown) hung on
`e.done`, possibly forever. Control-plane restart is part of failover
recovery, so an optional route-overlay actuator must not be able to
wedge it.

Fix: thread a cancellable actuation context through the engine (created
in `New`, passed to `actuate(ctx)` by the run loop, cancelled by
`Stop()` **before** it waits on `e.done`). `actuateRouteOverlay(ctx)`
acquires with `applySem.Acquire(ctx, 1)` and, on cancel, returns "not
converged" WITHOUT touching FRR or the userspace snapshot (no
half-actuation). Actuate signature `func() bool` → `func(context.Context) bool`.

## #3759 — interface-scoped IPv6 link-local preferred-route

A literal IPv6 link-local preferred-route next-hop
(`route ::/0 next-hop fe80::1`) committed cleanly but rendered a
scopeless `ipv6 route ::/0 fe80::1`, which FRR rejects — the failover
route silently failed to install (IPv6 WAN gateways are commonly
link-local). The overlay renders through the same
`generateStaticRouteInTable` + `IPv6NextHopInterfaces` machinery as
static routes, but the overlay's next-hops were never fed into
`inferIPv6StaticNextHopInterfaces`.

Fix: feed the overlay into the inference
(`inferIPv6StaticNextHopInterfaces(cfg, overlay)`), resolving each
overlay literal IPv6 next-hop through the same connected-prefix +
synthetic `fe80::/64` pipeline as static routes (#2452), keyed by the
VRF the render uses. Mirrors how the routing code already handles
link-local next-hops (attach scope via the map; no commit-reject —
static routes have none). Resolves on a single IPv6 interface; an
ambiguous one stays unresolved exactly like a static route.

## Validation

- `go test -race ./pkg/ipmon/... ./pkg/daemon/... ./pkg/frr/...` green;
  `go build ./...` green; gofmt + vet clean on touched files.
- **RED-on-revert per issue:**
  - #3758: reverting the daemon `Acquire` to `context.Background()`
    hangs the daemon test 2 s (RED); removing the `Stop` cancel hangs
    the engine test 2 s (RED).
  - #3759: reverting the inference-body overlay loop reds the direct
    inference tests; reverting the `assembleFRRConfig` call-site reds
    the assembler test; the FRR render test proves the scoped
    `ipv6 route ::/0 fe80::1 ge-0-0-3.50 1` line.

Closes #3758
Closes #3759

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi