### PR TITLE
route-snapshot: dedupe by discard+preference, deterministic sort, surface RuleList error (#3770 #3772)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26894,3 +26894,41 @@ top.
     (wire FlowExportBatchStatsFn), pkg/api/server.go + metrics.go +
     metrics_descriptors.go + metrics_system.go (xpf_flow_export_batch_* family),
     pkg/flowexport/README.md (Bounded export batch section)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Fix #3770 + #3772 in the pkg/dataplane/userspace route-snapshot
+    builder (codex-review-161 H8/M10/M7 + M9/M8), one PR / two commits.
+    #3770: (H8) the dedupe key omitted Discard and Preference, so a discard
+    route and a normal route to the same prefix, or two routes differing only
+    in preference (a static next-table route vs. its preference-0 ip-rule
+    mirror), collided and one was silently dropped before the Rust FIB saw it
+    — added both fields to the key. (M10) the final sort was sort.Slice
+    (unstable) keyed only on Table/Family/Destination, so once same-prefix
+    routes coexist their order tracked non-deterministic build inputs and
+    churned the snapshot — switched to sort.SliceStable with a TOTAL order
+    (next-hops, next-table, discard, preference tie-breakers). (M7) the
+    ip-monitoring overlay route was built with no Preference (default 0),
+    diverging from the documented Static/1 (preference 1) FRR render — now
+    stamps Preference: 1. #3772: (M9) a netlink.RuleList failure was swallowed
+    with `continue`, dropping every route-leak snapshot for that family while
+    the kernel/FRR leak path stayed up — buildRouteSnapshots now returns an
+    error (indirected via a ruleListFn seam) surfaced through builder.go and
+    manager.go so the apply path fails closed and retains prior state (mirrors
+    #3731). (M8) canonicalRoutePrefix returned the raw string on a parse
+    failure despite its "returns empty" doc and the caller's skip guard — now
+    returns "" so a malformed overlay destination is skipped, not injected as
+    a garbage FIB prefix. RED-on-revert tests added for all five: discard +
+    connected survive dedupe; distinct-preference survive dedupe; sort order
+    is identical regardless of input order; overlay carries preference 1;
+    RuleList error is surfaced; canonicalRoutePrefix returns "" and the
+    overlay skips an unparseable destination. go test ./pkg/dataplane/... +
+    ./pkg/routing/... green; go build ./... green; gofmt + vet clean.
+  - **File(s)**: pkg/dataplane/userspace/routes.go (dedupe key, SliceStable
+    total-order sort, overlay Preference:1, ruleListFn seam + surfaced error,
+    canonicalRoutePrefix ""), pkg/dataplane/userspace/builder.go +
+    pkg/dataplane/userspace/manager.go (propagate the route-build error),
+    pkg/dataplane/userspace/routes_dedupe_3770_test.go (new),
+    pkg/dataplane/userspace/routes_rulelist_3772_test.go (new),
+    pkg/dataplane/userspace/{route_overlay,fbf_snapshot,routes_fib_metadata,manager}_test.go
+    (2-value call updates), docs/userspace-dataplane-architecture.md +
+    docs/multi-wan.md (route-snapshot invariants)

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -264,7 +264,9 @@ Semantics (verified against Junos in the plan's research rounds):
   withdrawn.
 - The injected route has **route preference 1** (`Static/1`) — that is
   what makes it "preferred" over static (AD 5) and DHCP (AD 200)
-  routes.
+  routes. The userspace route snapshot now stamps this preference on the
+  overlay `RouteSnapshot` too (#3770 M7); before, the snapshot route
+  defaulted to preference 0 and diverged from the FRR distance-1 render.
 - `preferred-metric` is the tie-break **among injected routes for the
   same prefix** (two policies in FAIL both injecting 0/0): lowest
   metric wins, then lexicographic policy name. The engine resolves the

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -801,6 +801,39 @@ ConfigSnapshot {
 }
 ```
 
+**Route-snapshot construction invariants (`buildRouteSnapshots`,
+`pkg/dataplane/userspace/routes.go`).** The builder derives the `routes`
+section from config statics, connected prefixes, and the kernel ip-rule
+mirror (rib-group / next-table leaks), then folds the ip-monitoring
+overlay. Four correctness invariants (#3770/#3772):
+
+- **Dedupe by full identity.** The per-route dedupe key is
+  `Table|Family|Destination|NextHops|NextTable|Discard|Preference`. A
+  discard (blackhole) route and a normal route to the same prefix are
+  DISTINCT decisions, and two routes differing only in preference (a
+  static next-table route vs. its preference-0 ip-rule mirror) must both
+  reach the Rust FIB so `sort_routes` (`fib.rs`) can apply its
+  preference tie-break. Omitting Discard/Preference from the key
+  (pre-#3770) silently dropped one of a colliding pair.
+- **Deterministic emission order.** The final sort is `SliceStable` over
+  a TOTAL order — Table, Family, Destination, then NextHops, NextTable,
+  Discard, Preference. Once same-prefix routes coexist, a partial
+  comparator + unstable sort let their order track non-deterministic
+  build inputs (map iteration, kernel ip-rule order), churning the
+  snapshot hash and re-installing the FIB for an unchanged config.
+- **ip-rule read is fail-closed.** A `netlink.RuleList` failure is
+  SURFACED as a build error (not swallowed), so the apply path retains
+  the prior dataplane state instead of shipping a partial snapshot that
+  drops every route-leak route for that family while the kernel/FRR leak
+  path stays up. This mirrors #3731's surface-don't-swallow contract on
+  the RuleAdd (write) side.
+- **Overlay carries Static/1.** The ip-monitoring overlay route is
+  emitted at route preference 1 (the documented `Static/1`,
+  `PreferredRoute` contract in `pkg/config/types_system.go`), matching
+  the FRR managed-section distance-1 render. An unparseable overlay
+  destination is skipped (`canonicalRoutePrefix` returns `""`) rather
+  than injected verbatim as a garbage FIB prefix.
+
 **Dynamic-address feed overlay (#2049).** The snapshot's address books carry
 the live `security dynamic-address` feed prefixes, not just the static
 `security address-book`. The daemon joins each `address-name ... profile

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -68,6 +68,13 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 	if err != nil {
 		return nil, err
 	}
+	// #3772 (M9): a kernel ip-rule enumeration failure fails the snapshot
+	// closed so the apply path retains the prior dataplane state rather
+	// than shipping a snapshot missing every route-leak route.
+	routes, err := buildRouteSnapshots(cfg, interfaces, routeOverlay)
+	if err != nil {
+		return nil, err
+	}
 	return &ConfigSnapshot{
 		Version:         ProtocolVersion,
 		Generation:      generation,
@@ -81,7 +88,7 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 		Fabrics:         buildFabricSnapshots(cfg),
 		TunnelEndpoints: buildTunnelEndpointSnapshots(cfg, interfaces),
 		Neighbors:       buildNeighborSnapshots(cfg),
-		Routes:          buildRouteSnapshots(cfg, interfaces, routeOverlay),
+		Routes:          routes,
 		Flow:            buildFlowSnapshot(cfg),
 		DefaultPolicy:   policyActionString(cfg.Security.DefaultPolicy),
 		// #3534: thread the implicit-default-policy RT_FLOW log selection to the

--- a/pkg/dataplane/userspace/fbf_snapshot_test.go
+++ b/pkg/dataplane/userspace/fbf_snapshot_test.go
@@ -55,7 +55,10 @@ func fbfTestConfig() *config.Config {
 // land in `<ri>.inet.0` / `<ri>.inet6.0` — the table the Rust PBR
 // lookup targets — and never in the master tables.
 func TestFBFForwardingInstanceRouteSnapshots(t *testing.T) {
-	routes := buildRouteSnapshots(fbfTestConfig(), nil, nil)
+	routes, err := buildRouteSnapshots(fbfTestConfig(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var v4, v6 *RouteSnapshot
 	for i := range routes {
@@ -116,7 +119,10 @@ func TestFBFOverlayIntoForwardingInstance(t *testing.T) {
 	overlay := []config.RouteOverlayEntry{
 		{RoutingInstance: "ISP-B", Destination: "0.0.0.0/0", NextHop: "172.16.80.254", Policy: "wan-failover"},
 	}
-	routes := buildRouteSnapshots(fbfTestConfig(), nil, overlay)
+	routes, err := buildRouteSnapshots(fbfTestConfig(), nil, overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var defaults []RouteSnapshot
 	for _, r := range routes {

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -1007,7 +1007,14 @@ func (m *Manager) PublishRouteOverlaySnapshot(cfg *config.Config, overlay []conf
 	next.FIBGeneration = m.readFIBGeneration()
 	next.GeneratedAt = time.Now().UTC()
 	next.Config = cfg
-	next.Routes = buildRouteSnapshots(cfg, next.Interfaces, desiredOverlay)
+	// #3772 (M9): a transient ip-rule enumeration failure aborts the
+	// overlay publish (fail-closed). The deferred commit above leaves
+	// m.routeOverlay at the last-applied baseline on a non-nil err, so the
+	// next actuator sweep rebuilds and re-publishes (#3757 dirty-retry).
+	next.Routes, err = buildRouteSnapshots(cfg, next.Interfaces, desiredOverlay)
+	if err != nil {
+		return false, fmt.Errorf("build route overlay snapshot: %w", err)
+	}
 
 	// Duplicate-publish skip: identical content (e.g. the actuator ran
 	// twice for the same overlay) does not need a control-socket

--- a/pkg/dataplane/userspace/manager_test.go
+++ b/pkg/dataplane/userspace/manager_test.go
@@ -2539,7 +2539,10 @@ func TestBuildRouteSnapshotsNormalizesFamilyFromDestination(t *testing.T) {
 			},
 		},
 	}
-	routes := buildRouteSnapshots(cfg, nil, nil)
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(routes) != 2 {
 		t.Fatalf("len(routes) = %d, want 2", len(routes))
 	}
@@ -2552,7 +2555,7 @@ func TestBuildRouteSnapshotsNormalizesFamilyFromDestination(t *testing.T) {
 }
 
 func TestBuildRouteSnapshotsIncludesConnectedPrefixes(t *testing.T) {
-	routes := buildRouteSnapshots(&config.Config{}, []InterfaceSnapshot{
+	routes, err := buildRouteSnapshots(&config.Config{}, []InterfaceSnapshot{
 		{
 			Name: "reth1.0",
 			Addresses: []InterfaceAddressSnapshot{
@@ -2562,6 +2565,9 @@ func TestBuildRouteSnapshotsIncludesConnectedPrefixes(t *testing.T) {
 			},
 		},
 	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(routes) != 2 {
 		t.Fatalf("len(routes) = %d, want 2", len(routes))
 	}

--- a/pkg/dataplane/userspace/route_overlay_test.go
+++ b/pkg/dataplane/userspace/route_overlay_test.go
@@ -38,7 +38,10 @@ func TestRouteOverlayWholeEntryReplacement(t *testing.T) {
 	overlay := []config.RouteOverlayEntry{
 		{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
 	}
-	routes := buildRouteSnapshots(cfg, nil, overlay)
+	routes, err := buildRouteSnapshots(cfg, nil, overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var defaults []RouteSnapshot
 	for _, r := range routes {
@@ -73,7 +76,10 @@ func TestRouteOverlayWholeEntryReplacement(t *testing.T) {
 	riOverlay := []config.RouteOverlayEntry{
 		{RoutingInstance: "ISP-B", Destination: "0.0.0.0/0", NextHop: "10.9.99.1", Policy: "p"},
 	}
-	routes = buildRouteSnapshots(cfg, nil, riOverlay)
+	routes, err = buildRouteSnapshots(cfg, nil, riOverlay)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, r := range routes {
 		if r.Table == "ISP-B.inet.0" && r.Destination == "0.0.0.0/0" {
 			if len(r.NextHops) != 1 || r.NextHops[0] != "10.9.99.1" {
@@ -86,7 +92,10 @@ func TestRouteOverlayWholeEntryReplacement(t *testing.T) {
 	}
 
 	// Withdrawal (nil overlay) restores the config routes.
-	routes = buildRouteSnapshots(cfg, nil, nil)
+	routes, err = buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, r := range routes {
 		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" && len(r.NextHops) != 2 {
 			t.Fatalf("withdrawn overlay left residue: %+v", r)

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -1,6 +1,7 @@
 package userspace
 
 import (
+	"fmt"
 	"net"
 	"slices"
 	"sort"
@@ -23,7 +24,18 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 	out := make([]RouteSnapshot, 0)
 	seen := make(map[string]struct{})
 	addSnapshot := func(snap RouteSnapshot) {
-		key := snap.Table + "|" + snap.Family + "|" + snap.Destination + "|" + strings.Join(snap.NextHops, ",") + "|" + snap.NextTable
+		// #3770 (H8): the dedupe key MUST include Discard and Preference.
+		// A discard (blackhole) route and a normal route to the same prefix
+		// are DISTINCT forwarding decisions — omitting Discard let one
+		// silently hide the other. Two routes differing only in preference
+		// (e.g. a static next-table route at its configured preference and
+		// the kernel ip-rule mirror at preference 0) collided on the old key
+		// and the second was dropped before the Rust FIB could apply its
+		// preference tie-break (fib.rs sort_routes).
+		key := fmt.Sprintf("%s|%s|%s|%s|%s|%t|%d",
+			snap.Table, snap.Family, snap.Destination,
+			strings.Join(snap.NextHops, ","), snap.NextTable,
+			snap.Discard, snap.Preference)
 		if _, ok := seen[key]; ok {
 			return
 		}
@@ -141,14 +153,39 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 
 	out = applyRouteOverlay(out, overlay)
 
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Table != out[j].Table {
-			return out[i].Table < out[j].Table
+	// #3770 (M10): stable sort with a TOTAL order. The old comparator
+	// keyed only on Table/Family/Destination, so two same-prefix routes
+	// (distinct after the H8 dedupe fix, e.g. a next-table leak and its
+	// ip-rule mirror, or a discard and a connected route) compared equal
+	// and their relative order followed the non-deterministic build input
+	// order (map iteration, kernel ip-rule order) under an UNSTABLE sort —
+	// producing spurious snapshot-to-snapshot diffs and ECMP-member churn
+	// that re-installed the FIB for no config change. Tie-break on
+	// next-hops, next-table, discard, then preference so the wire order is
+	// a deterministic function of content alone.
+	sort.SliceStable(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		if a.Table != b.Table {
+			return a.Table < b.Table
 		}
-		if out[i].Family != out[j].Family {
-			return out[i].Family < out[j].Family
+		if a.Family != b.Family {
+			return a.Family < b.Family
 		}
-		return out[i].Destination < out[j].Destination
+		if a.Destination != b.Destination {
+			return a.Destination < b.Destination
+		}
+		an, bn := strings.Join(a.NextHops, ","), strings.Join(b.NextHops, ",")
+		if an != bn {
+			return an < bn
+		}
+		if a.NextTable != b.NextTable {
+			return a.NextTable < b.NextTable
+		}
+		if a.Discard != b.Discard {
+			// Non-discard (false) sorts before discard (true).
+			return b.Discard
+		}
+		return a.Preference < b.Preference
 	})
 	return out
 }
@@ -175,6 +212,12 @@ func applyRouteOverlay(routes []RouteSnapshot, overlay []config.RouteOverlayEntr
 			Family:      family,
 			Destination: dest,
 			NextHops:    []string{entry.NextHop},
+			// #3770 (M7): the ip-monitoring overlay injects the documented
+			// Static/1 route (route preference 1, PreferredRoute contract in
+			// pkg/config/types_system.go). Leaving it at 0 made the Rust FIB
+			// sort it as MORE preferred than the documented value and diverged
+			// from the FRR managed-section render (distance-1 static).
+			Preference: 1,
 		}
 	}
 	out := make([]RouteSnapshot, 0, len(routes)+len(replaced))

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -12,14 +12,27 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// ruleListFn is the netlink ip-rule enumerator, indirected so tests can
+// inject a transient failure and assert it is surfaced (#3772 M9).
+var ruleListFn = netlink.RuleList
+
 // buildRouteSnapshots derives the helper FIB from config statics,
 // connected prefixes, and ip-rule leak rules, then applies the
 // ip-monitoring route overlay (#1827 PR-1b): each overlay entry
 // REPLACES the entire (table, family, prefix) entry set — never merges
 // next-hops — so an ECMP half-override is impossible by construction.
-func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, overlay []config.RouteOverlayEntry) []RouteSnapshot {
+//
+// It returns an error when the kernel ip-rule enumeration fails (#3772
+// M9): the synthetic rib-group / next-table leak routes are derived from
+// the live ip-rule table, so a transient RuleList failure must fail the
+// whole snapshot build closed (the apply path then retains the prior
+// dataplane state) rather than silently emitting a PARTIAL snapshot that
+// drops every route-leak route for that family while the kernel/FRR leak
+// path stays up — a divergence with no signal. Mirrors #3731's
+// surface-don't-swallow contract on the RuleAdd (write) side.
+func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, overlay []config.RouteOverlayEntry) ([]RouteSnapshot, error) {
 	if cfg == nil {
-		return nil
+		return nil, nil
 	}
 	out := make([]RouteSnapshot, 0)
 	seen := make(map[string]struct{})
@@ -124,9 +137,12 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 		}
 	}
 	for _, family := range []int{syscall.AF_INET, syscall.AF_INET6} {
-		rules, err := netlink.RuleList(family)
+		rules, err := ruleListFn(family)
 		if err != nil {
-			continue
+			// #3772 (M9): do NOT swallow. A partial snapshot missing this
+			// family's route-leak routes would blackhole or policy-bypass
+			// inter-VRF traffic that the kernel/FRR still routes.
+			return nil, fmt.Errorf("route snapshot: list ip-rules for family %d: %w", family, err)
 		}
 		for _, rule := range rules {
 			if rule.Dst == nil || rule.Table <= 0 {
@@ -187,7 +203,7 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 		}
 		return a.Preference < b.Preference
 	})
-	return out
+	return out, nil
 }
 
 // applyRouteOverlay folds the winner-resolved ip-monitoring overlay
@@ -249,12 +265,17 @@ func overlayTableFamily(entry config.RouteOverlayEntry) (string, string) {
 	return table, family
 }
 
-// canonicalRoutePrefix mask-normalizes a CIDR for overlay matching;
-// returns "" for unparseable strings (left untouched).
+// canonicalRoutePrefix mask-normalizes a CIDR for overlay matching and
+// returns "" when the input does not parse as a CIDR (#3772 M8). The
+// caller in applyRouteOverlay treats "" as "skip this entry", so an
+// overlay destination that fails to parse is dropped rather than being
+// injected into the FIB verbatim as a garbage prefix. Previously the
+// function returned the raw string, contradicting this contract and its
+// own doc comment, and let a malformed overlay destination through.
 func canonicalRoutePrefix(s string) string {
 	_, n, err := net.ParseCIDR(s)
 	if err != nil || n == nil {
-		return s
+		return ""
 	}
 	return n.String()
 }

--- a/pkg/dataplane/userspace/routes_dedupe_3770_test.go
+++ b/pkg/dataplane/userspace/routes_dedupe_3770_test.go
@@ -28,7 +28,10 @@ func TestRouteSnapshotDedupeKeepsDiscardAndConnected(t *testing.T) {
 		},
 	}
 
-	routes := buildRouteSnapshots(cfg, ifaces, nil)
+	routes, err := buildRouteSnapshots(cfg, ifaces, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var haveDiscard, haveConnected bool
 	count := 0
@@ -58,7 +61,10 @@ func TestRouteSnapshotDedupeKeepsDistinctPreference(t *testing.T) {
 		{Destination: "10.5.0.0/16", NextTable: "blue.inet.0", Preference: 5},
 		{Destination: "10.5.0.0/16", NextTable: "blue.inet.0", Preference: 0},
 	}
-	routes := buildRouteSnapshots(cfg, nil, nil)
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	count := 0
 	for _, r := range routes {
 		if r.Table == "inet.0" && r.Destination == "10.5.0.0/16" && r.NextTable == "blue.inet.0" {
@@ -90,8 +96,14 @@ func TestRouteSnapshotSortIsDeterministic(t *testing.T) {
 		{Destination: "10.5.0.0/16", NextTable: "aaa.inet.0"},
 	}
 
-	got1 := buildRouteSnapshots(forward, nil, nil)
-	got2 := buildRouteSnapshots(reverse, nil, nil)
+	got1, err := buildRouteSnapshots(forward, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, err := buildRouteSnapshots(reverse, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(got1, got2) {
 		t.Fatalf("route order depends on input order (non-deterministic):\n forward=%+v\n reverse=%+v", got1, got2)
 	}
@@ -116,7 +128,10 @@ func TestRouteOverlayCarriesStaticPreference(t *testing.T) {
 	overlay := []config.RouteOverlayEntry{
 		{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
 	}
-	routes := buildRouteSnapshots(cfg, nil, overlay)
+	routes, err := buildRouteSnapshots(cfg, nil, overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	found := false
 	for _, r := range routes {

--- a/pkg/dataplane/userspace/routes_dedupe_3770_test.go
+++ b/pkg/dataplane/userspace/routes_dedupe_3770_test.go
@@ -1,0 +1,133 @@
+package userspace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// TestRouteSnapshotDedupeKeepsDiscardAndConnected verifies #3770 H8: a
+// discard (blackhole) static route and a connected route to the SAME
+// prefix are DISTINCT forwarding decisions and must both survive the
+// dedupe. Before the fix the dedupe key omitted Discard, so the two
+// collided on Table|Family|Destination|NextHops|NextTable and the
+// second-inserted one was silently dropped, hiding a real route.
+func TestRouteSnapshotDedupeKeepsDiscardAndConnected(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.0.1.0/24", Discard: true},
+	}
+	ifaces := []InterfaceSnapshot{
+		{
+			Name: "ge-0-0-1",
+			Addresses: []InterfaceAddressSnapshot{
+				{Family: "inet", Address: "10.0.1.5/24", Scope: int(netlink.SCOPE_UNIVERSE)},
+			},
+		},
+	}
+
+	routes := buildRouteSnapshots(cfg, ifaces, nil)
+
+	var haveDiscard, haveConnected bool
+	count := 0
+	for _, r := range routes {
+		if r.Table == "inet.0" && r.Family == "inet" && r.Destination == "10.0.1.0/24" {
+			count++
+			if r.Discard {
+				haveDiscard = true
+			} else {
+				haveConnected = true
+			}
+		}
+	}
+	if count != 2 || !haveDiscard || !haveConnected {
+		t.Fatalf("routes for 10.0.1.0/24: count=%d haveDiscard=%v haveConnected=%v, want both a discard and a connected entry (%+v)",
+			count, haveDiscard, haveConnected, routes)
+	}
+}
+
+// TestRouteSnapshotDedupeKeepsDistinctPreference verifies #3770 H8 for
+// preference: two routes to the same prefix and next-table differing
+// ONLY in preference are distinct and both survive so the Rust FIB can
+// apply its preference tie-break.
+func TestRouteSnapshotDedupeKeepsDistinctPreference(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.5.0.0/16", NextTable: "blue.inet.0", Preference: 5},
+		{Destination: "10.5.0.0/16", NextTable: "blue.inet.0", Preference: 0},
+	}
+	routes := buildRouteSnapshots(cfg, nil, nil)
+	count := 0
+	for _, r := range routes {
+		if r.Table == "inet.0" && r.Destination == "10.5.0.0/16" && r.NextTable == "blue.inet.0" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("distinct-preference routes for 10.5.0.0/16 = %d, want 2 (%+v)", count, routes)
+	}
+}
+
+// TestRouteSnapshotSortIsDeterministic verifies #3770 M10: the emitted
+// order is a deterministic function of route CONTENT, not of the build
+// input order. Two same-prefix routes that differ only in next-table
+// tie on the old Table/Family/Destination comparator; under the old
+// UNSTABLE sort their order tracked the input slice order, so an
+// unchanged config could churn the snapshot. Building the same content
+// with the two entries in opposite input order must yield an identical
+// snapshot.
+func TestRouteSnapshotSortIsDeterministic(t *testing.T) {
+	forward := &config.Config{}
+	forward.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.5.0.0/16", NextTable: "aaa.inet.0"},
+		{Destination: "10.5.0.0/16", NextTable: "bbb.inet.0"},
+	}
+	reverse := &config.Config{}
+	reverse.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.5.0.0/16", NextTable: "bbb.inet.0"},
+		{Destination: "10.5.0.0/16", NextTable: "aaa.inet.0"},
+	}
+
+	got1 := buildRouteSnapshots(forward, nil, nil)
+	got2 := buildRouteSnapshots(reverse, nil, nil)
+	if !reflect.DeepEqual(got1, got2) {
+		t.Fatalf("route order depends on input order (non-deterministic):\n forward=%+v\n reverse=%+v", got1, got2)
+	}
+	// The tie-break is lexicographic on next-table: aaa before bbb.
+	var order []string
+	for _, r := range got1 {
+		if r.Table == "inet.0" && r.Destination == "10.5.0.0/16" {
+			order = append(order, r.NextTable)
+		}
+	}
+	if len(order) != 2 || order[0] != "aaa.inet.0" || order[1] != "bbb.inet.0" {
+		t.Fatalf("next-table tie-break order = %v, want [aaa.inet.0 bbb.inet.0]", order)
+	}
+}
+
+// TestRouteOverlayCarriesStaticPreference verifies #3770 M7: the
+// ip-monitoring overlay route is injected at the documented Static/1
+// preference (route preference 1), matching the FRR managed-section
+// distance-1 static, not the default 0.
+func TestRouteOverlayCarriesStaticPreference(t *testing.T) {
+	cfg := &config.Config{}
+	overlay := []config.RouteOverlayEntry{
+		{Destination: "0.0.0.0/0", NextHop: "172.16.80.1", Policy: "wan-failover"},
+	}
+	routes := buildRouteSnapshots(cfg, nil, overlay)
+
+	found := false
+	for _, r := range routes {
+		if r.Table == "inet.0" && r.Destination == "0.0.0.0/0" {
+			found = true
+			if r.Preference != 1 {
+				t.Fatalf("overlay route preference = %d, want 1 (Static/1)", r.Preference)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("overlay default route not found in %+v", routes)
+	}
+}

--- a/pkg/dataplane/userspace/routes_fib_metadata_test.go
+++ b/pkg/dataplane/userspace/routes_fib_metadata_test.go
@@ -16,7 +16,10 @@ func TestRouteSnapshotCarriesPreference(t *testing.T) {
 		{Destination: "203.0.113.0/24", Preference: 50, NextHops: []config.NextHopEntry{{Address: "172.16.50.1"}}},
 		{Destination: "198.51.100.0/24", Preference: 5, NextHops: []config.NextHopEntry{{Address: "172.16.50.2"}}},
 	}
-	routes := buildRouteSnapshots(cfg, nil, nil)
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	got := map[string]int{}
 	for _, r := range routes {
@@ -43,7 +46,10 @@ func TestRouteSnapshotRetainsAllECMPNextHops(t *testing.T) {
 			{Address: "172.16.50.2", Interface: "ge-0/0/2"},
 		}},
 	}
-	routes := buildRouteSnapshots(cfg, nil, nil)
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var found *RouteSnapshot
 	for i := range routes {

--- a/pkg/dataplane/userspace/routes_rulelist_3772_test.go
+++ b/pkg/dataplane/userspace/routes_rulelist_3772_test.go
@@ -1,0 +1,83 @@
+package userspace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// TestBuildRouteSnapshotsSurfacesRuleListError verifies #3772 M9: a
+// netlink RuleList failure is SURFACED as a build error, not swallowed.
+// Swallowing it dropped every route-leak (rib-group / next-table)
+// snapshot for that family while the kernel/FRR leak path stayed up,
+// diverging the userspace FIB with no signal. On revert (the old
+// `if err != nil { continue }`) buildRouteSnapshots returns a nil error
+// and a partial snapshot.
+func TestBuildRouteSnapshotsSurfacesRuleListError(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) {
+		return nil, errors.New("simulated netlink RuleList failure")
+	}
+
+	cfg := &config.Config{}
+	if _, err := buildRouteSnapshots(cfg, nil, nil); err == nil {
+		t.Fatal("buildRouteSnapshots swallowed a RuleList failure; want a surfaced error")
+	}
+}
+
+// TestBuildRouteSnapshotsRuleListSuccessNoError confirms the happy path
+// still returns a nil error when the ip-rule enumeration succeeds.
+func TestBuildRouteSnapshotsRuleListSuccessNoError(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(int) ([]netlink.Rule, error) { return nil, nil }
+
+	cfg := &config.Config{}
+	cfg.RoutingOptions.StaticRoutes = []*config.StaticRoute{
+		{Destination: "10.0.0.0/8", NextHops: []config.NextHopEntry{{Address: "10.1.1.1"}}},
+	}
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("len(routes) = %d, want 1", len(routes))
+	}
+}
+
+// TestCanonicalRoutePrefixEmptyOnUnparseable verifies #3772 M8: the
+// function returns "" for an unparseable prefix (matching its doc
+// comment and the caller's skip guard) and the canonical string for a
+// valid CIDR.
+func TestCanonicalRoutePrefixEmptyOnUnparseable(t *testing.T) {
+	if got := canonicalRoutePrefix("not-a-cidr"); got != "" {
+		t.Fatalf("canonicalRoutePrefix(bad) = %q, want \"\"", got)
+	}
+	if got := canonicalRoutePrefix("10.0.0.5/24"); got != "10.0.0.0/24" {
+		t.Fatalf("canonicalRoutePrefix(10.0.0.5/24) = %q, want 10.0.0.0/24", got)
+	}
+}
+
+// TestRouteOverlaySkipsUnparseableDestination verifies #3772 M8 end to
+// end: a malformed overlay destination is SKIPPED rather than injected
+// into the FIB as a garbage prefix. On revert (canonicalRoutePrefix
+// returns the raw string) the "garbage" destination enters the overlay
+// map and appears as a synthetic route.
+func TestRouteOverlaySkipsUnparseableDestination(t *testing.T) {
+	cfg := &config.Config{}
+	overlay := []config.RouteOverlayEntry{
+		{Destination: "garbage", NextHop: "1.2.3.4", Policy: "p"},
+	}
+	routes, err := buildRouteSnapshots(cfg, nil, overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range routes {
+		if r.Destination == "garbage" {
+			t.Fatalf("unparseable overlay destination entered the FIB: %+v", r)
+		}
+	}
+}


### PR DESCRIPTION
Fixes two coupled route-snapshot defects in the `pkg/dataplane/userspace`
route-emission builder (`routes.go` `buildRouteSnapshots` / `applyRouteOverlay`),
found by codex-review-161. One commit per issue.

## #3770 — dedupe/sort correctness

- **H8 — dedupe key omitted Discard + Preference.** A discard (blackhole)
  route and a normal route to the same prefix, or two routes differing only
  in preference (a static next-table route vs. its preference-0 ip-rule
  mirror), collided on `Table|Family|Destination|NextHops|NextTable` and one
  was silently dropped before the Rust FIB could apply its preference
  tie-break. Fix: include Discard and Preference in the key so both are
  DISTINCT.
- **M10 — unstable sort, no tie-breakers.** `sort.Slice` keyed only on
  Table/Family/Destination, so once same-prefix routes coexist their order
  tracked non-deterministic build inputs (map iteration, kernel ip-rule
  order) and churned the snapshot / re-installed the FIB for an unchanged
  config. Fix: `sort.SliceStable` with a TOTAL order (next-hops, next-table,
  discard, preference tie-breakers).
- **M7 — overlay dropped Static/1 preference.** The ip-monitoring overlay
  route was built with no Preference (default 0), diverging from the
  documented `Static/1` (preference 1) and the FRR distance-1 render. Fix:
  set `Preference: 1`.

## #3772 — RuleList swallow + comment

- **M9 — RuleList failure silently dropped all route-leak snapshots.**
  `netlink.RuleList` errors were swallowed with `continue`, so a transient
  failure omitted every rib-group / next-table leak route for that family
  while the kernel/FRR leak path stayed up — the userspace FIB diverged with
  no signal. Fix: `buildRouteSnapshots` now returns an error (netlink
  enumerator indirected via a `ruleListFn` seam) surfaced through
  `builder.go` and `manager.go`; the apply path fails closed and retains
  prior state (mirrors #3731's surface-don't-swallow contract).
- **M8 — canonicalRoutePrefix contract mismatch.** The doc comment and the
  `applyRouteOverlay` caller (`if dest == "" { continue }`) both expect `""`
  for an unparseable prefix, but the code returned the raw string, so a
  malformed overlay destination was injected verbatim as a garbage FIB
  prefix. Fix: return `""` on parse failure, aligning code to comment +
  caller.

## Validation

`go test ./pkg/dataplane/... ./pkg/routing/...` green; `go build ./...` green;
gofmt + vet clean on all touched files. Each fix has a RED-on-revert test:
discard + connected survive dedupe, distinct-preference survive dedupe, sort
order identical regardless of input order, overlay carries preference 1
(#3770); an injected RuleList error is surfaced, canonicalRoutePrefix returns
"" and the overlay skips an unparseable destination (#3772). Docs updated in
`docs/userspace-dataplane-architecture.md` and `docs/multi-wan.md`.

Closes #3770
Closes #3772

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi