### PR TITLE
event-options: day-2 engine start + event-name attribute scope + audit desc + RPM callback ordering (#3752 #3753 #3754 #3755)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,19 @@
+## 2026-07-01 — #3753: event-options attributes-match honors event-name prefix
+
+- **Timestamp**: 2026-07-01
+  - **Action**: attributes-match parsing dropped the `<event>.` prefix, so a
+    constraint written for one event of a multi-event policy gated EVERY event.
+    `ParseEventAttributesMatch` now returns eventName; the runtime matcher
+    (`attributesMatch`) skips a constraint whose event prefix != the current
+    event, and the strict commit validator rejects a prefix not in the
+    policy's events. RED-on-revert tests: eventengine
+    TestAttributesMatch_EventNamePrefixScopesConstraint /
+    _PerEventScopingBothDirections; config
+    TestValidateEventAttributesMatchStrict_EventNameScope.
+  - **File(s)**: pkg/config/event_options_match.go,
+    pkg/config/event_options_match_test.go, pkg/eventengine/engine.go,
+    pkg/eventengine/engine_test.go, pkg/eventengine/README.md
+
 ## 2026-07-01 — #3739: DDNS Surface A value-specific self-owned publish
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-01 — #3752: event-options engine day-2 first-enable start
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The engine was constructed at boot ONLY when the boot config
+    already had a policy, so enabling the FIRST event-options policy on a
+    running daemon left d.eventEngine nil and the day-2 apply
+    (`if d.eventEngine != nil`) was a silent no-op — inert until restart.
+    Added initEventEngine (construct unconditionally at boot, register RPM
+    callback, write-once pointer, mirrors LLDP/dhcpRelay) + reconcileEventOptions
+    (Apply on boot and every day-2 commit). applyConfigLocked step 17 and the
+    boot block now call these. Engine.PolicyCount accessor for the tests.
+    RED-on-revert: TestInitEventEngineConstructsUnconditionally /
+    TestReconcileEventOptionsDay2Enable.
+  - **File(s)**: pkg/eventengine/engine.go (PolicyCount),
+    pkg/daemon/daemon_apply.go (initEventEngine, reconcileEventOptions, step 17),
+    pkg/daemon/daemon_run.go (boot wiring),
+    pkg/daemon/daemon_eventoptions_reconcile_test.go (new)
+
 ## 2026-07-01 — #3754: event-options remediation commit audit description
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-01 — #3755: RPM first probe cycle event reaches event-options
+
+- **Timestamp**: 2026-07-01
+  - **Action**: RPM probes ran their first cycle immediately, before the
+    event-options callback was registered (SetEventCallback ran later at boot),
+    so the first cycle's events were dropped (fireEvent no-op on nil callback).
+    Fix: moved initEventEngine (which registers the RPM event callback) BEFORE
+    the boot applyConfig/reconcileRPM in daemon_run.go — callback wired before
+    probes start. Belt: rpm.Manager buffers events fired while onEvent==nil
+    (bounded maxBufferedEvents) and replays them FIFO on SetEventCallback;
+    added HasEventCallback accessor. RED-on-revert:
+    TestFireEventBufferedUntilCallbackRegistered (rpm) +
+    TestInitEventEngineRegistersRPMCallbackBeforeProbes (daemon).
+  - **File(s)**: pkg/rpm/rpm.go, pkg/rpm/event_buffer_3755_test.go,
+    pkg/rpm/README.md, pkg/daemon/daemon_run.go,
+    pkg/daemon/daemon_eventoptions_reconcile_test.go,
+    pkg/eventengine/README.md
+
 ## 2026-07-01 — #3752: event-options engine day-2 first-enable start
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,16 @@
+## 2026-07-01 — #3754: event-options remediation commit audit description
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Autonomous remediation committed with an empty comment, so the
+    mutation was unattributed in commit/rollback history. plannedAction now
+    carries the triggering event/owner/test (stamped in HandleEvent);
+    applyOnce builds `event-options policy <name>: <event>/<owner>/<test>
+    (<n> commands)` via remediationDescription and threads it into commitFn
+    AND the standalone CommitWithDescription branch. RED-on-revert test:
+    TestRemediation_CommitCarriesAuditDescription.
+  - **File(s)**: pkg/eventengine/engine.go,
+    pkg/eventengine/engine_integration_test.go, pkg/eventengine/README.md
+
 ## 2026-07-01 — #3753: event-options attributes-match honors event-name prefix
 
 - **Timestamp**: 2026-07-01

--- a/pkg/config/event_options_match.go
+++ b/pkg/config/event_options_match.go
@@ -43,28 +43,35 @@ func EventAttributesFieldKnown(field string) bool {
 }
 
 // ParseEventAttributesMatch splits a raw attributes-match line of the form
-// "<event>.<field> matches <pattern>" into its field name and regex pattern.
-// It returns ok=false when the line is not a well-formed match expression
-// (no " matches " separator, or no "." in the field spec). The returned
-// field is the last dot-separated component of the left-hand side (the
-// attribute name), mirroring the event_name.attribute Junos spelling.
-func ParseEventAttributesMatch(attr string) (field, pattern string, ok bool) {
+// "<event>.<field> matches <pattern>" into its event name, field name, and
+// regex pattern. It returns ok=false when the line is not a well-formed match
+// expression (no " matches " separator, or no "." in the field spec). The
+// returned field is the LAST dot-separated component of the left-hand side
+// (the attribute name); eventName is everything BEFORE it — the event this
+// constraint is scoped to, per the Junos event_name.attribute spelling.
+//
+// #3753: the event-name prefix was previously discarded, so a constraint
+// written for one event of a multi-event policy incorrectly gated EVERY event
+// in the policy. Callers that scope by event (the runtime matcher, the strict
+// commit validator) now honor eventName.
+func ParseEventAttributesMatch(attr string) (eventName, field, pattern string, ok bool) {
 	parts := strings.SplitN(attr, eventAttributesMatchSep, 2)
 	if len(parts) != 2 {
-		return "", "", false
+		return "", "", "", false
 	}
 	fieldSpec := strings.TrimSpace(parts[0])
 	pattern = strings.TrimSpace(parts[1])
 
 	dotIdx := strings.LastIndex(fieldSpec, ".")
 	if dotIdx < 0 {
-		return "", "", false
+		return "", "", "", false
 	}
+	eventName = strings.TrimSpace(fieldSpec[:dotIdx])
 	field = fieldSpec[dotIdx+1:]
-	if field == "" || pattern == "" {
-		return "", "", false
+	if eventName == "" || field == "" || pattern == "" {
+		return "", "", "", false
 	}
-	return field, pattern, true
+	return eventName, field, pattern, true
 }
 
 // EventAttributesMatchPattern returns the regex pattern of a well-formed
@@ -72,8 +79,20 @@ func ParseEventAttributesMatch(attr string) (field, pattern string, ok bool) {
 // ParseEventAttributesMatch for callers that only need the pattern (e.g.
 // building the engine's compiled-regex cache).
 func EventAttributesMatchPattern(attr string) (pattern string, ok bool) {
-	_, pattern, ok = ParseEventAttributesMatch(attr)
+	_, _, pattern, ok = ParseEventAttributesMatch(attr)
 	return pattern, ok
+}
+
+// eventNameInPolicy reports whether eventName is one of the policy's declared
+// events (#3753). An attributes-match line scoped to an event the policy does
+// not list can never apply, so the strict commit validator rejects it.
+func eventNameInPolicy(eventName string, events []string) bool {
+	for _, e := range events {
+		if e == eventName {
+			return true
+		}
+	}
+	return false
 }
 
 // ValidateEventAttributesMatch checks that every event-options policy
@@ -110,6 +129,10 @@ func ValidateEventAttributesMatch(cfg *Config) error {
 //     <pattern>" (no " matches " separator, or no "." in the left-hand
 //     field spec). The lenient/runtime code previously skipped such a line,
 //     silently DROPPING the constraint and broadening the policy.
+//   - an <event> prefix that is not one of the policy's declared events
+//     (#3753). A constraint scoped to an event the policy never lists can
+//     never apply; left unchecked (and combined with the old prefix-dropping
+//     parse) it silently gated the wrong event.
 //   - a <field> name not in EventAttributesKnownFields (a typo such as
 //     "test-ower"). An unknown field can never be satisfied against an
 //     rpm.Event, so the matcher dropped it and broadened the policy.
@@ -127,12 +150,18 @@ func ValidateEventAttributesMatchStrict(cfg *Config) error {
 			continue
 		}
 		for _, attr := range pol.AttributesMatch {
-			field, pattern, ok := ParseEventAttributesMatch(attr)
+			eventName, field, pattern, ok := ParseEventAttributesMatch(attr)
 			if !ok {
 				return fmt.Errorf(
 					"event-options policy %q attributes-match %q: malformed match "+
 						"expression (expected \"<event>.<field> matches <pattern>\")",
 					pol.Name, attr)
+			}
+			if !eventNameInPolicy(eventName, pol.Events) {
+				return fmt.Errorf(
+					"event-options policy %q attributes-match %q: event %q is not one "+
+						"of the policy's events %v (the constraint would never apply)",
+					pol.Name, attr, eventName, pol.Events)
 			}
 			if !EventAttributesFieldKnown(field) {
 				return fmt.Errorf(

--- a/pkg/config/event_options_match_test.go
+++ b/pkg/config/event_options_match_test.go
@@ -11,24 +11,25 @@ import (
 func TestEventAttributesMatch_ParseLine(t *testing.T) {
 	cases := []struct {
 		in        string
+		wantEvent string
 		wantField string
 		wantPat   string
 		wantOK    bool
 	}{
-		{`ping_test_failed.test-owner matches ^Comcast$`, "test-owner", "^Comcast$", true},
-		{`ping_test_failed.test-name matches .*down`, "test-name", ".*down", true},
+		{`ping_test_failed.test-owner matches ^Comcast$`, "ping_test_failed", "test-owner", "^Comcast$", true},
+		{`ping_test_failed.test-name matches .*down`, "ping_test_failed", "test-name", ".*down", true},
 		// no separator
-		{`ping_test_failed.test-owner Comcast`, "", "", false},
+		{`ping_test_failed.test-owner Comcast`, "", "", "", false},
 		// no dot in field spec
-		{`testowner matches Comcast`, "", "", false},
+		{`testowner matches Comcast`, "", "", "", false},
 		// empty pattern
-		{`ping_test_failed.test-owner matches `, "", "", false},
+		{`ping_test_failed.test-owner matches `, "", "", "", false},
 	}
 	for _, c := range cases {
-		field, pat, ok := ParseEventAttributesMatch(c.in)
-		if ok != c.wantOK || field != c.wantField || pat != c.wantPat {
-			t.Errorf("ParseEventAttributesMatch(%q) = (%q,%q,%v); want (%q,%q,%v)",
-				c.in, field, pat, ok, c.wantField, c.wantPat, c.wantOK)
+		event, field, pat, ok := ParseEventAttributesMatch(c.in)
+		if ok != c.wantOK || event != c.wantEvent || field != c.wantField || pat != c.wantPat {
+			t.Errorf("ParseEventAttributesMatch(%q) = (%q,%q,%q,%v); want (%q,%q,%q,%v)",
+				c.in, event, field, pat, ok, c.wantEvent, c.wantField, c.wantPat, c.wantOK)
 		}
 	}
 }
@@ -139,24 +140,54 @@ func TestEventAttributesMatch_UnknownFieldRejectedAtCommit(t *testing.T) {
 // (unit-level) and accepts a well-formed known-field line.
 func TestValidateEventAttributesMatchStrict_Direct(t *testing.T) {
 	good := &Config{EventOptions: []*EventPolicy{
-		{Name: "ok", AttributesMatch: []string{`ev.test-owner matches ^a+b*$`}},
+		{Name: "ok", Events: []string{"ev"}, AttributesMatch: []string{`ev.test-owner matches ^a+b*$`}},
 	}}
 	if err := ValidateEventAttributesMatchStrict(good); err != nil {
 		t.Fatalf("valid line rejected by strict validator: %v", err)
 	}
 
 	malformed := &Config{EventOptions: []*EventPolicy{
-		{Name: "m", AttributesMatch: []string{`no separator here`}},
+		{Name: "m", Events: []string{"ev"}, AttributesMatch: []string{`no separator here`}},
 	}}
 	if err := ValidateEventAttributesMatchStrict(malformed); err == nil {
 		t.Fatal("strict validator accepted a malformed line")
 	}
 
 	unknown := &Config{EventOptions: []*EventPolicy{
-		{Name: "u", AttributesMatch: []string{`ev.bogus matches ^x$`}},
+		{Name: "u", Events: []string{"ev"}, AttributesMatch: []string{`ev.bogus matches ^x$`}},
 	}}
 	if err := ValidateEventAttributesMatchStrict(unknown); err == nil {
 		t.Fatal("strict validator accepted an unknown field")
+	}
+}
+
+// #3753: an attributes-match line scoped to an event the policy does NOT
+// declare is rejected at strict commit (it can never apply, and the old
+// prefix-dropping parse silently gated the wrong event). RED-on-revert:
+// without the eventNameInPolicy check the out-of-scope constraint is accepted.
+func TestValidateEventAttributesMatchStrict_EventNameScope(t *testing.T) {
+	// event_b IS declared: accepted.
+	inScope := &Config{EventOptions: []*EventPolicy{{
+		Name:            "p",
+		Events:          []string{"ping_test_failed", "ping_test_completed"},
+		AttributesMatch: []string{`ping_test_completed.test-owner matches ^x$`},
+	}}}
+	if err := ValidateEventAttributesMatchStrict(inScope); err != nil {
+		t.Fatalf("in-scope event prefix rejected: %v", err)
+	}
+
+	// ping_probe_failed is NOT one of the policy's events: rejected.
+	outOfScope := &Config{EventOptions: []*EventPolicy{{
+		Name:            "p",
+		Events:          []string{"ping_test_failed", "ping_test_completed"},
+		AttributesMatch: []string{`ping_probe_failed.test-owner matches ^x$`},
+	}}}
+	err := ValidateEventAttributesMatchStrict(outOfScope)
+	if err == nil {
+		t.Fatal("strict validator accepted an attributes-match scoped to an event not in the policy")
+	}
+	if !strings.Contains(err.Error(), "ping_probe_failed") {
+		t.Fatalf("commit error %q does not name the out-of-scope event", err)
 	}
 }
 

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -19,6 +19,7 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	dpuserspace "github.com/psaab/xpf/pkg/dataplane/userspace"
+	"github.com/psaab/xpf/pkg/eventengine"
 	"github.com/psaab/xpf/pkg/ipsec"
 	"github.com/psaab/xpf/pkg/lldp"
 	"github.com/psaab/xpf/pkg/routing"
@@ -1365,10 +1366,15 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// d.daemonCtx so the TX/RX goroutines outlive this apply call.
 	d.reconcileLLDP(cfg)
 
-	// 17. Update event-options policies (RPM-driven failover)
-	if d.eventEngine != nil {
-		d.eventEngine.Apply(cfg.EventOptions)
-	}
+	// 17. Reconcile event-options policies (RPM-driven failover). Before
+	// #3752 this was a bare `if d.eventEngine != nil { Apply }`, and the
+	// engine was constructed at boot ONLY when the boot config already had
+	// policies — so committing the FIRST event-options policy on a running
+	// daemon (day-2) left d.eventEngine nil and the policy inert until a
+	// restart. The engine is now constructed unconditionally at boot
+	// (daemon_run.go, mirroring LLDP/dhcpRelay); reconcileEventOptions runs
+	// here on every day-2 commit so a first-enable takes effect immediately.
+	d.reconcileEventOptions(cfg)
 
 	// 17b. Reconcile RPM probes (#1827 PR-1a). Config-hash-gated: the
 	// probe set (and the probe next-hop pin rules) is re-applied only
@@ -1618,6 +1624,54 @@ func (d *Daemon) reconcileLLDP(cfg *config.Config) {
 		ctx = context.Background()
 	}
 	d.lldpMgr.Apply(ctx, want)
+}
+
+// initEventEngine constructs the event-options engine and registers the RPM
+// event callback (#3752). Like the LLDP manager and the DHCP relay manager, it
+// is created UNCONDITIONALLY at boot — not gated on the boot config already
+// carrying an event-options policy — so:
+//
+//   - the d.eventEngine pointer is written exactly ONCE at boot and read-only
+//     thereafter, keeping the lock-free reads on the `Stats()` metric/CLI
+//     handler goroutines race-free (the same pointer-race discipline #2372
+//     established for d.lldpMgr); and
+//   - a day-2 commit enabling the FIRST event-options policy takes effect
+//     immediately via reconcileEventOptions, instead of being inert until a
+//     daemon restart (the #3752 defect).
+//
+// The engine routes its remediation commit through d.commitAndApply so it
+// serializes with HTTP/gRPC commits under d.applySem (#846). Event-options
+// changes do not sync to the peer — the engine fires independently on each
+// node from that node's local RPM events. Idempotent: a second call is a no-op.
+func (d *Daemon) initEventEngine() {
+	if d.eventEngine != nil {
+		return
+	}
+	d.eventEngine = eventengine.New(d.store, func(ctx context.Context, comment string) (*config.Config, error) {
+		return d.commitAndApply(ctx, comment, false)
+	})
+	if d.rpm != nil {
+		d.rpm.SetEventCallback(d.eventEngine.HandleEvent)
+	}
+	slog.Info("event-options engine constructed")
+}
+
+// reconcileEventOptions applies the committed event-options policy set to the
+// engine on every commit (#3752). The engine is constructed once at boot
+// (initEventEngine); this only ever calls Apply, which RECONCILES per-policy
+// runtime state (carrying cooldown/window memory forward for unchanged
+// policies, #2140). It NEVER reassigns the pointer. A nil cfg (or empty policy
+// set) applies zero policies — a no-op that also clears a removed set.
+func (d *Daemon) reconcileEventOptions(cfg *config.Config) {
+	if d.eventEngine == nil {
+		// Defensive: boot wiring constructs the engine before any reconcile.
+		return
+	}
+	var policies []*config.EventPolicy
+	if cfg != nil {
+		policies = cfg.EventOptions
+	}
+	d.eventEngine.Apply(policies)
 }
 
 // lldpConfigEqual reports whether two effective LLDP configs are equivalent for

--- a/pkg/daemon/daemon_eventoptions_reconcile_test.go
+++ b/pkg/daemon/daemon_eventoptions_reconcile_test.go
@@ -1,0 +1,107 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// eventOptionsCfg builds a *config.Config carrying the named event-options
+// policies (each a single-event, single-command remediation).
+func eventOptionsCfg(names ...string) *config.Config {
+	cfg := &config.Config{}
+	for _, name := range names {
+		cfg.EventOptions = append(cfg.EventOptions, &config.EventPolicy{
+			Name:         name,
+			Events:       []string{"ping_test_failed"},
+			ThenCommands: []string{"set system host-name " + name},
+		})
+	}
+	return cfg
+}
+
+// bootEventDaemon wires a Daemon the way daemon_run.go wires it for the event
+// engine: an RPM manager and a configstore exist, then initEventEngine
+// constructs the engine unconditionally.
+func bootEventDaemon(t *testing.T) *Daemon {
+	t.Helper()
+	d := &Daemon{
+		daemonCtx: context.Background(),
+		rpm:       rpm.New(),
+		store:     newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+	}
+	d.initEventEngine()
+	return d
+}
+
+// TestInitEventEngineConstructsUnconditionally is the fail-on-revert pin for
+// the #3752 root cause: the engine must be constructed at boot even when the
+// boot config carries NO event-options policy. The pre-fix boot gated
+// construction on len(cfg.EventOptions) > 0, so a daemon that booted policy-
+// less left d.eventEngine nil and every day-2 apply (`if d.eventEngine != nil`)
+// was a silent no-op.
+//
+// If initEventEngine is reverted to gate on a non-empty policy set, this goes
+// RED (engine nil) — as does the day-2 test below (PolicyCount stays 0).
+func TestInitEventEngineConstructsUnconditionally(t *testing.T) {
+	d := bootEventDaemon(t)
+	if d.eventEngine == nil {
+		t.Fatal("initEventEngine did not construct the engine at boot")
+	}
+	if got := d.eventEngine.PolicyCount(); got != 0 {
+		t.Fatalf("engine loaded %d policies at boot with an empty config; want 0", got)
+	}
+}
+
+// TestReconcileEventOptionsDay2Enable is the fail-on-revert pin for #3752.
+//
+// A daemon booted with NO event-options policy (engine constructed, zero
+// policies) then receives a day-2 commit enabling the FIRST policy. The
+// reconcile must load it into the engine so the policy is live — the exact
+// scenario that was inert until a restart before the fix.
+func TestReconcileEventOptionsDay2Enable(t *testing.T) {
+	d := bootEventDaemon(t)
+
+	// Boot reconcile with no policies (models a policy-less boot).
+	d.reconcileEventOptions(eventOptionsCfg())
+	if got := d.eventEngine.PolicyCount(); got != 0 {
+		t.Fatalf("policy-less boot loaded %d policies; want 0", got)
+	}
+
+	// Day-2 commit enables the first policy — it MUST take effect now.
+	d.reconcileEventOptions(eventOptionsCfg("wan-failover"))
+	if got := d.eventEngine.PolicyCount(); got != 1 {
+		t.Fatalf("day-2 first-enable loaded %d policies; want 1 (#3752: the "+
+			"engine must start on a day-2 enable, not only at boot)", got)
+	}
+
+	// A second day-2 commit adding another policy reconciles to two.
+	d.reconcileEventOptions(eventOptionsCfg("wan-failover", "lan-failover"))
+	if got := d.eventEngine.PolicyCount(); got != 2 {
+		t.Fatalf("day-2 add loaded %d policies; want 2", got)
+	}
+
+	// Removing all policies reconciles back to zero without tearing the engine.
+	d.reconcileEventOptions(eventOptionsCfg())
+	if got := d.eventEngine.PolicyCount(); got != 0 {
+		t.Fatalf("policy removal left %d policies; want 0", got)
+	}
+	if d.eventEngine == nil {
+		t.Fatal("reconcile must never reassign/clear the engine pointer")
+	}
+	d.eventEngine.Close()
+}
+
+// reconcileEventOptions must tolerate a nil config (bootstrap / no-active-
+// config paths call it as a safety net).
+func TestReconcileEventOptionsNilConfig(t *testing.T) {
+	d := bootEventDaemon(t)
+	d.reconcileEventOptions(nil)
+	if got := d.eventEngine.PolicyCount(); got != 0 {
+		t.Fatalf("nil config loaded %d policies; want 0", got)
+	}
+	d.eventEngine.Close()
+}

--- a/pkg/daemon/daemon_eventoptions_reconcile_test.go
+++ b/pkg/daemon/daemon_eventoptions_reconcile_test.go
@@ -95,6 +95,29 @@ func TestReconcileEventOptionsDay2Enable(t *testing.T) {
 	d.eventEngine.Close()
 }
 
+// TestInitEventEngineRegistersRPMCallbackBeforeProbes pins the #3755 ordering
+// guarantee at the boot-wiring level: initEventEngine (called before
+// reconcileRPM starts probes) registers the RPM event callback, so the first
+// probe cycle's events reach the event engine instead of firing into a nil
+// callback. If the callback registration is dropped from initEventEngine, or
+// initEventEngine is not run before probes start, HasEventCallback stays false.
+func TestInitEventEngineRegistersRPMCallbackBeforeProbes(t *testing.T) {
+	d := &Daemon{
+		daemonCtx: context.Background(),
+		rpm:       rpm.New(),
+		store:     newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+	}
+	if d.rpm.HasEventCallback() {
+		t.Fatal("RPM event callback set before initEventEngine")
+	}
+	d.initEventEngine()
+	if !d.rpm.HasEventCallback() {
+		t.Fatal("initEventEngine did not register the RPM event callback " +
+			"(the first probe cycle's events would be dropped, #3755)")
+	}
+	d.eventEngine.Close()
+}
+
 // reconcileEventOptions must tolerate a nil config (bootstrap / no-active-
 // config paths call it as a safety net).
 func TestReconcileEventOptionsNilConfig(t *testing.T) {

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -964,20 +964,16 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.reconcileLLDP(cfg)
 	}
 
-	// Start event-options engine if configured.
-	if cfg := d.store.ActiveConfig(); cfg != nil && len(cfg.EventOptions) > 0 {
-		// #846: route through commitAndApply so the engine's commit
-		// serializes with HTTP/gRPC commits under d.applySem.
-		// Event-options changes don't sync to peer (the engine fires
-		// independently on each node based on local RPM events).
-		d.eventEngine = eventengine.New(d.store, func(ctx context.Context, comment string) (*config.Config, error) {
-			return d.commitAndApply(ctx, comment, false)
-		})
-		d.eventEngine.Apply(cfg.EventOptions)
-		if d.rpm != nil {
-			d.rpm.SetEventCallback(d.eventEngine.HandleEvent)
-		}
-		slog.Info("event-options engine started", "policies", len(cfg.EventOptions))
+	// Start the event-options engine. The engine is constructed
+	// UNCONDITIONALLY at boot (not gated on the boot config already having a
+	// policy), mirroring d.lldpMgr / d.dhcpRelay: the d.eventEngine pointer is
+	// written once here and read-only thereafter (race-free Stats() reads), and
+	// reconcileEventOptions — which runs here and on every day-2 commit
+	// (applyConfigLocked step 17) — makes enabling the FIRST policy on a running
+	// daemon take effect immediately instead of only after a restart (#3752).
+	d.initEventEngine()
+	if cfg := d.store.ActiveConfig(); cfg != nil {
+		d.reconcileEventOptions(cfg)
 	}
 
 	// Start DHCP relay. The Manager is always created (not gated on a

--- a/pkg/daemon/daemon_run.go
+++ b/pkg/daemon/daemon_run.go
@@ -468,6 +468,18 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.ipmon = ipmon.New(d.actuateRouteOverlay)
 	d.rpm.SetTransitionCallback(d.ipmon.HandleTransition)
 
+	// Construct the event-options engine and register its RPM event callback
+	// HERE — BEFORE the first applyConfig runs reconcileRPM and starts the
+	// probe goroutines (#3755). runProbeLoop runs its FIRST cycle immediately,
+	// so a ping_probe_failed / ping_test_failed / ping_test_completed emitted by
+	// that first cycle would be dropped (fireEvent is a no-op while onEvent is
+	// nil) if the callback were installed later — a boot-time failover edge the
+	// automation exists to handle, lost for long test-interval values. Wiring
+	// the callback before probes start closes that gap; rpm additionally buffers
+	// any event fired before a callback exists and replays it on registration,
+	// as a belt against a future reorder. Idempotent (write-once pointer).
+	d.initEventEngine()
+
 	// Create the DHCP manager eagerly, beside the ipmon engine (#1844
 	// plan §4.3, AGY r2-1/r2-2): d.dhcp is write-once at boot and
 	// read-only thereafter — the engine's run-loop goroutine (via the
@@ -964,14 +976,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 		d.reconcileLLDP(cfg)
 	}
 
-	// Start the event-options engine. The engine is constructed
-	// UNCONDITIONALLY at boot (not gated on the boot config already having a
-	// policy), mirroring d.lldpMgr / d.dhcpRelay: the d.eventEngine pointer is
-	// written once here and read-only thereafter (race-free Stats() reads), and
-	// reconcileEventOptions — which runs here and on every day-2 commit
-	// (applyConfigLocked step 17) — makes enabling the FIRST policy on a running
-	// daemon take effect immediately instead of only after a restart (#3752).
-	d.initEventEngine()
+	// Event-options engine safety net. The engine was already constructed and
+	// its RPM callback registered earlier (initEventEngine, before probes
+	// started, #3755), and the boot applyConfig reconciled the policy set via
+	// applyConfigLocked step 17. This mirrors the reconcileRPM/reconcileLLDP
+	// boot safety nets above: it covers the bootstrap-mode path where the boot
+	// applyConfig was suppressed, so a bootstrap-exit still loads any policies.
+	// reconcileEventOptions is idempotent (Apply reconciles state), so a repeat
+	// on the normal path is harmless (#3752).
 	if cfg := d.store.ActiveConfig(); cfg != nil {
 		d.reconcileEventOptions(cfg)
 	}

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -46,6 +46,17 @@ A `delete` of a missing path is a **tolerated exception** (logged at Debug):
 Junos `change-configuration` semantics, and a missing delete target is not a
 half-applied batch.
 
+**Audit description (#3754):** the remediation commit carries a deterministic
+description — `event-options policy <name>: <event>/<owner>/<test> (<n>
+commands)` — built by `remediationDescription` from the triggering-event
+context captured on the `plannedAction` at evaluate time. It is threaded into
+both the `CommitFn` (daemon `commitAndApply` → `CommitWithDescription`) and the
+standalone `store.CommitWithDescription` branch, so an autonomous config
+mutation lands in commit/rollback history ATTRIBUTED to the policy and event
+that made it — not as an anonymous unattributed commit. Regression-locked by
+`TestRemediation_CommitCarriesAuditDescription` (fail-on-revert: reverting to
+`commitFn(ctx, "")` leaves the comment empty and the test goes RED).
+
 ## Cooldown / window state survives a config reload (#2140)
 
 Per-policy temporal state (sliding `within` windows + last-trigger time) is

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -25,6 +25,24 @@ temporal `within` windows) and triggers commit-and-apply actions.
 
 `pkg/config`, `pkg/configstore`, `pkg/rpm`.
 
+## Daemon lifecycle (#3752 / #3755)
+
+The daemon constructs the engine UNCONDITIONALLY at boot (`initEventEngine`,
+`pkg/daemon`), mirroring the LLDP manager and DHCP relay: the `d.eventEngine`
+pointer is written once and read-only thereafter (race-free `Stats()` reads),
+and `reconcileEventOptions` applies the committed policy set at boot and on
+every day-2 commit. Because the engine always exists, enabling the FIRST
+event-options policy on a running daemon takes effect immediately instead of
+being inert until a restart (#3752 — the old code constructed the engine only
+when the boot config already had a policy).
+
+`initEventEngine` also registers the RPM event callback BEFORE `reconcileRPM`
+starts the probe goroutines. RPM runs each probe's first cycle immediately, so
+a `ping_probe_failed`/`ping_test_failed`/`ping_test_completed` from that first
+cycle would otherwise fire into a nil callback and be lost (#3755); registering
+first closes the gap, and `pkg/rpm` additionally buffers-and-replays any event
+fired before a callback exists as a belt against a future reorder.
+
 ## Transactional batch (#2139)
 
 A `change-configuration` action's `then` commands are applied as an

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -126,6 +126,18 @@ triggering on a **regex** match of `<pattern>` against the event attribute
   `config.EventAttributesKnownFields` (the single source of truth consumed by
   both the commit-time validator and the runtime matcher — a drift-guard test
   keeps them identical).
+- **Event-name scoping (#3753):** the `<event>.` prefix scopes the constraint
+  to a single event of a multi-event policy. The runtime matcher applies a
+  constraint ONLY when the current event equals its prefix, so
+  `attributes-match "event_a.test-owner matches ^X$"` on a policy with
+  `events [ event_a event_b ]` gates event_a alone and leaves event_b
+  unconstrained (and vice-versa). Before this the prefix was dropped and the
+  constraint gated EVERY event. The strict commit validator additionally
+  rejects a prefix that is not one of the policy's declared events (it could
+  never apply). Regression-locked by
+  `TestAttributesMatch_EventNamePrefixScopesConstraint` /
+  `TestAttributesMatch_PerEventScopingBothDirections` (eventengine) and
+  `TestValidateEventAttributesMatchStrict_EventNameScope` (config).
 - **Strict at commit (#2141):** `config.ValidateEventAttributesMatchStrict`
   rejects at commit not only an uncompilable regex (#2008 M7) but also a
   malformed line (no ` matches ` / no `.`) and an unknown `<field>` name. These

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -464,6 +464,16 @@ func (e *Engine) Close() {
 	e.workerWG.Wait()
 }
 
+// PolicyCount returns the number of event-options policies the engine
+// currently has loaded. It is the observable seam for the daemon reconcile
+// tests (#3752): after the first policy is enabled on a running daemon the
+// engine must hold it, so a day-2 enable actually takes effect.
+func (e *Engine) PolicyCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.policies)
+}
+
 // Stats returns a snapshot of the observable counters (#2157), surfaced to
 // pkg/api for the xpf_event_actions_* metric family.
 func (e *Engine) Stats() Stats {

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -899,11 +899,22 @@ func (e *Engine) eventMatches(pol *config.EventPolicy, ev rpm.Event) bool {
 // by the boot-time lenient-compile warning plus the AttributesInvalid counter.
 func (e *Engine) attributesMatch(pol *config.EventPolicy, ev rpm.Event) bool {
 	for _, attr := range pol.AttributesMatch {
-		field, pattern, ok := config.ParseEventAttributesMatch(attr)
+		eventName, field, pattern, ok := config.ParseEventAttributesMatch(attr)
 		if !ok {
 			// Malformed line that slipped through a lenient load: fail closed.
 			e.flagAttributesInvalid(pol.Name, attr, "malformed match expression")
 			return false
+		}
+
+		// #3753: the constraint is scoped to a specific event name. Only apply
+		// it when the CURRENT event IS that event; a constraint written for a
+		// DIFFERENT event of a multi-event policy must NOT gate this event
+		// (before this the prefix was dropped, so `event_a.test-owner ...`
+		// incorrectly gated event_b too — and vice-versa). Commit-time
+		// validation guarantees eventName is one of the policy's events, so an
+		// out-of-scope prefix here can only be a legacy lenient-load config.
+		if eventName != ev.Name {
+			continue
 		}
 
 		if !config.EventAttributesFieldKnown(field) {

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -136,7 +136,14 @@ type plannedAction struct {
 	// the evaluate that enqueued this action. The worker drops the action if the
 	// live revision no longer matches (policy redefined) or is absent (removed).
 	semRev string
-	ops    []plannedOp
+	// Triggering-event context, captured at evaluate time so the worker can
+	// stamp a deterministic audit description on the remediation commit (#3754).
+	// A security appliance that mutates its own config autonomously must record
+	// in commit/rollback history WHICH policy fired and WHY.
+	event     string
+	testOwner string
+	testName  string
+	ops       []plannedOp
 }
 
 // triggeredPolicy pairs a policy that should fire with the semantic revision its
@@ -424,8 +431,16 @@ func (e *Engine) HandleEvent(ev rpm.Event) {
 		}
 		// Stamp the action with the policy's semantic revision as of this
 		// evaluate (#3750) so the worker can revalidate it against live engine
-		// state before committing.
-		e.enqueue(plannedAction{policyName: tp.pol.Name, semRev: tp.semRev, ops: ops})
+		// state before committing, plus the triggering-event context (#3754)
+		// for the remediation commit's audit description.
+		e.enqueue(plannedAction{
+			policyName: tp.pol.Name,
+			semRev:     tp.semRev,
+			event:      ev.Name,
+			testOwner:  ev.TestOwner,
+			testName:   ev.TestName,
+			ops:        ops,
+		})
 	}
 }
 
@@ -691,21 +706,37 @@ func (e *Engine) applyOnce(ctx context.Context, a plannedAction) error {
 		return errBatch("commit-check: %v", err)
 	}
 
+	// #3754: stamp a deterministic audit description so the autonomous
+	// remediation lands in commit/rollback history attributed to the policy and
+	// its triggering event, not as an anonymous unattributed commit.
+	desc := remediationDescription(a)
 	if e.commitFn == nil {
-		// Standalone (tests): just commit; no apply.
-		if _, err := e.store.Commit(); err != nil {
+		// Standalone (tests): just commit; no apply. Still record the
+		// description so the journal/history attribution is identical to the
+		// daemon path.
+		if _, err := e.store.CommitWithDescription(desc); err != nil {
 			e.store.ExitConfigure()
 			return errBatch("commit: %v", err)
 		}
 		e.store.ExitConfigure()
 		return nil
 	}
-	if _, err := e.commitFn(ctx, ""); err != nil {
+	if _, err := e.commitFn(ctx, desc); err != nil {
 		e.store.ExitConfigure()
 		return errBatch("commit: %v", err)
 	}
 	e.store.ExitConfigure()
 	return nil
+}
+
+// remediationDescription builds the deterministic audit string stamped on an
+// autonomous event-options remediation commit (#3754). It names the policy,
+// the triggering event/owner/test, and the command-batch size so an operator
+// reading commit/rollback history can tell which policy mutated the config and
+// why.
+func remediationDescription(a plannedAction) string {
+	return fmt.Sprintf("event-options policy %s: %s/%s/%s (%d commands)",
+		a.policyName, a.event, a.testOwner, a.testName, len(a.ops))
 }
 
 // errBatch builds a permanent (non-retryable) batch failure error.

--- a/pkg/eventengine/engine_integration_test.go
+++ b/pkg/eventengine/engine_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -313,6 +314,84 @@ func TestRetry_TimerStoppedOnEngineStop(t *testing.T) {
 	if !got {
 		t.Fatal("retry backoff timer was NOT stopped on stopCh — a plain" +
 			" time.After leaks its runtime timer until the backoff elapses (#2890)")
+	}
+}
+
+// #3754: an autonomous remediation commit must carry a deterministic audit
+// description naming the policy and its triggering event, so an operator can
+// tell from commit/rollback history WHICH event policy mutated the config and
+// WHY. Before the fix the engine committed with an empty comment
+// (commitFn(ctx, "")), landing the mutation in history as an ordinary
+// unattributed commit.
+//
+// FAIL-ON-REVERT: this test captures the comment threaded into commitFn and
+// asserts it names the policy, the event, and the command count. Reverting to
+// commitFn(ctx, "") makes the captured comment empty and the test goes RED.
+func TestRemediation_CommitCarriesAuditDescription(t *testing.T) {
+	s := newStore(t)
+	pol := &config.EventPolicy{
+		Name:         "wan-failover",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name remediated"},
+	}
+
+	var mu sync.Mutex
+	var gotComment string
+	commitFn := func(ctx context.Context, comment string) (*config.Config, error) {
+		mu.Lock()
+		gotComment = comment
+		mu.Unlock()
+		// Promote the candidate so the engine's arm-on-commit path runs like
+		// the real daemon commitAndApply would.
+		return s.Commit()
+	}
+
+	e := New(s, commitFn)
+	defer e.Close()
+	e.Apply([]*config.EventPolicy{pol})
+
+	e.HandleEvent(rpm.Event{Name: "ping_test_failed", TestOwner: "Comcast", TestName: "wan"})
+	waitFor(t, "committed counter", func() bool { return e.Stats().Committed >= 1 })
+
+	mu.Lock()
+	comment := gotComment
+	mu.Unlock()
+
+	if comment == "" {
+		t.Fatal("remediation commit carried an empty comment; the audit " +
+			"description was not threaded (#3754)")
+	}
+	for _, want := range []string{"wan-failover", "ping_test_failed", "Comcast", "wan"} {
+		if !strings.Contains(comment, want) {
+			t.Errorf("audit description %q does not contain %q", comment, want)
+		}
+	}
+}
+
+// #3754: the standalone (no-commitFn) path also records the description in the
+// commit journal — the attribution is identical regardless of whether the
+// daemon commitAndApply hook is wired.
+func TestRemediation_StandaloneCommitDescription(t *testing.T) {
+	s := newStore(t)
+	pol := &config.EventPolicy{
+		Name:         "p",
+		Events:       []string{"ping_test_failed"},
+		ThenCommands: []string{"set system host-name x", "set system domain-name y"},
+	}
+	e := New(s, nil)
+	defer e.Close()
+	e.Apply([]*config.EventPolicy{pol})
+
+	e.HandleEvent(eventFor("ping_test_failed"))
+	waitFor(t, "committed counter", func() bool { return e.Stats().Committed >= 1 })
+
+	got := remediationDescription(plannedAction{
+		policyName: "p", event: "ping_test_failed", testOwner: "owner", testName: "tname",
+		ops: []plannedOp{{}, {}},
+	})
+	want := "event-options policy p: ping_test_failed/owner/tname (2 commands)"
+	if got != want {
+		t.Fatalf("remediationDescription = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/eventengine/engine_test.go
+++ b/pkg/eventengine/engine_test.go
@@ -170,6 +170,72 @@ func TestAttributesMatch_RegexCachedAtApply(t *testing.T) {
 	}
 }
 
+// #3753: an attributes-match constraint carries an event-name prefix that
+// SCOPES it to a single event of a multi-event policy. The constraint must
+// apply ONLY when the current event is that event; a constraint written for
+// event_a must NOT gate event_b (and vice-versa).
+//
+// RED-on-revert: before the fix the parser dropped the "event_a." prefix, so
+// attributesMatch applied the test-owner=^owner$ constraint to EVERY event.
+// event_b arriving with test-owner="other" would then be rejected (the
+// event_a-scoped constraint wrongly gated it) — this test's event_b/other
+// assertion goes RED.
+func TestAttributesMatch_EventNamePrefixScopesConstraint(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:            "p",
+		Events:          []string{"event_a", "event_b"},
+		AttributesMatch: []string{"event_a.test-owner matches ^owner$"},
+	}
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	// event_a IS scoped by the constraint.
+	if !e.attributesMatch(pol, rpm.Event{Name: "event_a", TestOwner: "owner"}) {
+		t.Error("event_a with matching owner must match (constraint applies to event_a)")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "event_a", TestOwner: "other"}) {
+		t.Error("event_a with non-matching owner must NOT match (constraint gates event_a)")
+	}
+
+	// event_b is NOT scoped by an event_a constraint: it must pass regardless
+	// of the test-owner value. This is the discriminating assertion.
+	if !e.attributesMatch(pol, rpm.Event{Name: "event_b", TestOwner: "other"}) {
+		t.Error("event_b must NOT be gated by an event_a-scoped constraint (#3753)")
+	}
+	if !e.attributesMatch(pol, rpm.Event{Name: "event_b", TestOwner: "owner"}) {
+		t.Error("event_b must match irrespective of an event_a-scoped constraint (#3753)")
+	}
+}
+
+// #3753 vice-versa: with a constraint scoped to each of two events, each
+// constraint gates ONLY its own event.
+func TestAttributesMatch_PerEventScopingBothDirections(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:   "p",
+		Events: []string{"event_a", "event_b"},
+		AttributesMatch: []string{
+			"event_a.test-owner matches ^a-owner$",
+			"event_b.test-name matches ^b-name$",
+		},
+	}
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	// event_a is gated by the a-owner constraint only; the b-name constraint
+	// (scoped to event_b) must be skipped for event_a.
+	if !e.attributesMatch(pol, rpm.Event{Name: "event_a", TestOwner: "a-owner", TestName: "irrelevant"}) {
+		t.Error("event_a must match on the a-owner constraint alone; the event_b constraint must not apply")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "event_a", TestOwner: "wrong"}) {
+		t.Error("event_a with wrong owner must be gated")
+	}
+	// event_b is gated by the b-name constraint only.
+	if !e.attributesMatch(pol, rpm.Event{Name: "event_b", TestOwner: "irrelevant", TestName: "b-name"}) {
+		t.Error("event_b must match on the b-name constraint alone; the event_a constraint must not apply")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "event_b", TestName: "wrong"}) {
+		t.Error("event_b with wrong name must be gated")
+	}
+}
+
 // Multiple attributes-match lines must ALL match (AND semantics) — one
 // failing constraint blocks the policy.
 func TestAttributesMatch_AllMustMatch(t *testing.T) {

--- a/pkg/rpm/README.md
+++ b/pkg/rpm/README.md
@@ -18,7 +18,14 @@ pins probes to devices/next-hops via `SO_BINDTODEVICE` / `SO_MARK`.
 - `Apply(ctx context.Context, cfg *config.RPMConfig)` — `rpm.go`.
 - `StopAll()` — `rpm.go`.
 - `Results()` — `rpm.go`.
-- `SetEventCallback(fn)` — `rpm.go`.
+- `SetEventCallback(fn)` — `rpm.go`. Registers the event-options callback.
+  Events emitted BEFORE a callback is registered (a first probe cycle that ran
+  before wiring) are buffered and REPLAYED to `fn` on registration, in FIFO
+  order, so a boot-time failover edge is not dropped (#3755). The buffer is
+  bounded (`maxBufferedEvents`) and stays empty on the normal daemon boot
+  because the callback is wired before any probe starts.
+- `HasEventCallback()` — `rpm.go` (#3755). Reports whether an event callback is
+  registered (boot-ordering test seam).
 - `SetTransitionCallback(fn)` — `rpm.go` (#1827).
 - `SetRethMap(map[string]string)` — `rpm.go` (#1827). RETH → physical
   member translation for `destination-interface` resolution.
@@ -46,6 +53,13 @@ pins probes to devices/next-hops via `SO_BINDTODEVICE` / `SO_MARK`.
 
 ## Gotchas
 
+- **The first probe cycle runs immediately** (`runProbeLoop` before the ticker
+  loop), so a `ping_probe_failed` / `ping_test_failed` / `ping_test_completed`
+  can be emitted the instant `Apply` starts a probe. The daemon wires the
+  event-options callback BEFORE `reconcileRPM` starts probes; as a belt,
+  `fireEvent` buffers any event fired while `onEvent` is nil and
+  `SetEventCallback` replays it, so a boot-time failover edge is never dropped
+  (#3755). Regression-locked by `TestFireEventBufferedUntilCallbackRegistered`.
 - **icmp-ping sends a real ICMP echo since #1827** (raw socket, id/seq
   matching, 3 s timeout). The pre-#1827 prober never put a packet on
   the wire (raw-IP dial + UDP connect fallback — a route-existence

--- a/pkg/rpm/event_buffer_3755_test.go
+++ b/pkg/rpm/event_buffer_3755_test.go
@@ -1,0 +1,97 @@
+package rpm
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestFireEventBufferedUntilCallbackRegistered is the fail-on-revert pin for
+// #3755. RPM probes start immediately (runProbeLoop runs the first cycle at
+// once), so a probe-failed / test-failed / test-completed event can be emitted
+// before the event-options callback is registered. Those first-cycle events
+// must NOT be lost: they are buffered and replayed to the callback the moment
+// it is installed.
+//
+// RED-on-revert: without the buffer+replay, fireEvent drops events while
+// onEvent is nil and SetEventCallback delivers nothing — got is empty.
+func TestFireEventBufferedUntilCallbackRegistered(t *testing.T) {
+	m := New()
+
+	// First probe cycle fires before any callback exists.
+	m.fireEvent("ping_probe_failed", "WAN", "t")
+	m.fireEvent("ping_test_failed", "WAN", "t")
+
+	var mu sync.Mutex
+	var got []Event
+	m.SetEventCallback(func(ev Event) {
+		mu.Lock()
+		got = append(got, ev)
+		mu.Unlock()
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("buffered first-cycle events not replayed on registration: "+
+			"got %d, want 2 (#3755 boot-time failover edge dropped)", len(got))
+	}
+	if got[0].Name != "ping_probe_failed" || got[1].Name != "ping_test_failed" {
+		t.Fatalf("replay order wrong (want FIFO): %+v", got)
+	}
+	// The buffer must be drained after replay so a later event is not
+	// re-delivered from the buffer.
+	if n := len(m.bufferedEvents); n != 0 {
+		t.Fatalf("buffer not drained after replay: %d entries remain", n)
+	}
+}
+
+// Once a callback is registered, events are delivered live (not buffered).
+func TestFireEventDeliveredLiveAfterRegistration(t *testing.T) {
+	m := New()
+	var mu sync.Mutex
+	var got []Event
+	m.SetEventCallback(func(ev Event) {
+		mu.Lock()
+		got = append(got, ev)
+		mu.Unlock()
+	})
+
+	m.fireEvent("ping_test_failed", "WAN", "t")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 {
+		t.Fatalf("live event not delivered: got %d, want 1", len(got))
+	}
+	if n := len(m.bufferedEvents); n != 0 {
+		t.Fatalf("live event was buffered instead of delivered: %d buffered", n)
+	}
+}
+
+// The pre-registration buffer is bounded so a callback that never arrives
+// (event-options never configured) cannot grow it without limit.
+func TestFireEventBufferBounded(t *testing.T) {
+	m := New()
+	for i := 0; i < maxBufferedEvents*3; i++ {
+		m.fireEvent("ping_probe_failed", "WAN", "t")
+	}
+	m.mu.Lock()
+	n := len(m.bufferedEvents)
+	m.mu.Unlock()
+	if n > maxBufferedEvents {
+		t.Fatalf("event buffer unbounded: %d entries > cap %d", n, maxBufferedEvents)
+	}
+}
+
+// HasEventCallback tracks registration state (used by daemon boot-ordering
+// tests).
+func TestHasEventCallback(t *testing.T) {
+	m := New()
+	if m.HasEventCallback() {
+		t.Fatal("fresh manager reports a callback registered")
+	}
+	m.SetEventCallback(func(Event) {})
+	if !m.HasEventCallback() {
+		t.Fatal("callback not reported after registration")
+	}
+}

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -142,6 +142,16 @@ type Manager struct {
 	onEvent      EventCallback
 	onTransition TransitionCallback
 
+	// bufferedEvents holds events fired BEFORE an event-options callback was
+	// registered (#3755). The first probe cycle runs immediately when Apply
+	// starts a probe, so a probe-failed/test-failed/test-completed event can be
+	// emitted before SetEventCallback installs onEvent (boot ordering, or any
+	// late registration). Rather than drop that boot-time failover edge, the
+	// events are buffered and REPLAYED to the callback the moment it is
+	// registered. Bounded by maxBufferedEvents so a permanently-absent callback
+	// (event-options never configured) cannot grow it without limit.
+	bufferedEvents []Event
+
 	// rethMap translates Junos RETH names to physical members for
 	// destination-interface resolution (set by the daemon in cluster
 	// mode before Apply).
@@ -194,11 +204,41 @@ type Manager struct {
 	resolveTarget func(ctx context.Context, target string, opts probeSockOpts) (*net.IPAddr, error)
 }
 
-// SetEventCallback registers a callback for RPM events.
+// maxBufferedEvents bounds the pre-registration event buffer (#3755) so a
+// callback that never arrives cannot grow it without limit. The buffer only
+// holds the small burst a first probe cycle can produce before the callback is
+// installed; in the normal daemon boot the callback is registered before any
+// probe starts (initEventEngine precedes reconcileRPM), so it stays empty.
+const maxBufferedEvents = 64
+
+// SetEventCallback registers a callback for RPM events. Any events buffered
+// before a callback existed (a first probe cycle that ran before the
+// event-options callback was wired) are REPLAYED to the new callback in FIFO
+// order, so a boot-time failover edge is not lost (#3755). The replay runs
+// OUTSIDE m.mu because the callback (eventengine.HandleEvent) takes its own
+// locks; holding m.mu across it would invert the lock order.
 func (m *Manager) SetEventCallback(fn EventCallback) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.onEvent = fn
+	var replay []Event
+	if fn != nil && len(m.bufferedEvents) > 0 {
+		replay = m.bufferedEvents
+		m.bufferedEvents = nil
+	}
+	m.mu.Unlock()
+
+	for _, ev := range replay {
+		fn(ev)
+	}
+}
+
+// HasEventCallback reports whether an event-options callback is currently
+// registered. Used by the daemon boot-ordering tests to assert the callback is
+// wired before RPM probes start (#3755).
+func (m *Manager) HasEventCallback() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.onEvent != nil
 }
 
 // SetTransitionCallback registers a callback for per-test pass/fail
@@ -270,12 +310,21 @@ func (m *Manager) PinInstallFailureCount() int {
 }
 
 func (m *Manager) fireEvent(name, owner, testName string) {
-	m.mu.RLock()
+	ev := Event{Name: name, TestOwner: owner, TestName: testName}
+	m.mu.Lock()
 	fn := m.onEvent
-	m.mu.RUnlock()
-	if fn != nil {
-		fn(Event{Name: name, TestOwner: owner, TestName: testName})
+	if fn == nil {
+		// No event-options callback yet: buffer the event so a first-cycle
+		// failover edge is not lost, and replayed when a callback registers
+		// (#3755). Bounded — drop once the cap is reached.
+		if len(m.bufferedEvents) < maxBufferedEvents {
+			m.bufferedEvents = append(m.bufferedEvents, ev)
+		}
+		m.mu.Unlock()
+		return
 	}
+	m.mu.Unlock()
+	fn(ev)
 }
 
 func (m *Manager) fireTransition(owner, testName, status string) {


### PR DESCRIPTION
Fixes four coupled event-options subsystem bugs from codex-review-159, one commit per issue.

## #3752 (H5) — day-2 enable never started the engine
The engine was constructed at boot ONLY when the boot config already carried a policy, and the day-2 apply was a bare `if d.eventEngine != nil { Apply }`. Enabling the FIRST event-options policy on a running daemon never constructed the engine → the policy was inert until a restart. Fix: `initEventEngine` constructs the engine UNCONDITIONALLY at boot (write-once pointer, mirrors LLDP/dhcpRelay) and `reconcileEventOptions` applies the policy set at boot and on every day-2 commit (applyConfigLocked step 17). RED-on-revert: `TestInitEventEngineConstructsUnconditionally`, `TestReconcileEventOptionsDay2Enable`.

## #3753 (H4) — attributes-match ignored the event-name prefix
`ParseEventAttributesMatch` discarded the `<event>.` prefix, so a constraint scoped to one event of a multi-event policy gated EVERY event (and vice-versa). Fix: the parser now returns `eventName`; the runtime matcher applies a constraint only when the current event equals its prefix; the strict commit validator rejects a prefix not in the policy's declared events (lenient LOAD downgrades to a warning). RED-on-revert: `TestAttributesMatch_EventNamePrefixScopesConstraint`, `TestAttributesMatch_PerEventScopingBothDirections`, `TestValidateEventAttributesMatchStrict_EventNameScope`.

## #3754 (H10) — remediation commit had no audit description
The autonomous remediation committed with an empty comment, landing in commit/rollback history unattributed. Fix: `plannedAction` carries the triggering-event context; `applyOnce` stamps `event-options policy <name>: <event>/<owner>/<test> (<n> commands)` into both the daemon commitFn path and the standalone `CommitWithDescription` branch. RED-on-revert: `TestRemediation_CommitCarriesAuditDescription`.

## #3755 (H6) — RPM first probe cycle ran before the callback was registered
Probes run their first cycle immediately; the event-options callback was registered later at boot, so the first cycle's events fired into a nil callback and were lost. Fix: `initEventEngine` (which registers the RPM callback) now runs BEFORE the boot `reconcileRPM` starts probes; as a belt, `pkg/rpm` buffers events fired while no callback exists (bounded) and replays them FIFO on registration. RED-on-revert: `TestFireEventBufferedUntilCallbackRegistered`, `TestInitEventEngineRegistersRPMCallbackBeforeProbes`.

## Validation
- Each fix independently confirmed RED-on-revert (simulated pre-fix logic → the pinning test fails).
- `go test ./pkg/eventengine/... ./pkg/config/... ./pkg/daemon/ ./pkg/rpm/...` green; `-race` green on eventengine + rpm.
- `go build ./...` green; gofmt + vet clean on all touched files.
- Module docs updated: `pkg/eventengine/README.md` (daemon lifecycle, event-name scoping, audit description) and `pkg/rpm/README.md` (first-cycle buffering).

Closes #3752
Closes #3753
Closes #3754
Closes #3755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi