### PR TITLE
ipmon: publish overlay when primary for ANY data RG (#3764 Layer-1)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27146,3 +27146,35 @@ top.
   dual-stack commit warning), pkg/ddns/backend_dualstack_withdraw_3738_test.go (new),
   pkg/config/compiler_p3_http_providers_test.go (dyndns2 dual-stack warning test),
   pkg/ddns/README.md (per-family-withdraw column + dual-stack sibling-preserve section)
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3764 Layer-1 — gate ip-monitoring overlay publication on
+  IsLocalPrimaryAny() instead of primaryship of the lowest data RG. The publish
+  gate `ipmonPublishAllowed` (pkg/daemon/daemon_ipmon.go) previously returned
+  `d.cluster.IsLocalPrimary(lowestDataRG(cfg))` — a single node-wide boolean
+  keyed to the LOWEST data RG. In a multi-data-RG active/active cluster with
+  split primaryship (RG1 primary on node A, RG2 primary on node B), node B (the
+  owner+forwarder of RG2 traffic) had the WHOLE overlay suppressed because it is
+  not primary for RG1, so the RG2 failover route was never injected on the only
+  node that would use it — a functional failover MISS for RG2. Probe HA gating is
+  already per-RG (filterRPMForHAGating / rpmProbeGatingRGs, daemon_rpm.go), so a
+  node only genuinely FAILs the policies whose RG it owns; publishing whenever
+  primary for ANY RG is therefore both safe and precise (node B publishes its
+  RG2 overlay, node A its RG1 overlay, a true standby publishes nothing). This is
+  COMPLETE for RETH-bound probes. Zero regression for the single-data-RG common
+  case: IsLocalPrimaryAny() is identical to IsLocalPrimary(lowestDataRG) there.
+  Layer-2 (per-policy publish allow-set for UNBOUND in-scope probes, or a
+  commit-check requiring HA-gated probes to bind a RETH) is DEFERRED per the
+  converged /research plan. RED-on-revert: new TestIPMonPublishAllowedAnyPrimary
+  split-primary subtest asserts publish=true on the RG2-primary node; reverting
+  the gate to IsLocalPrimary(lowestDataRG) makes it fire (verified). Single-RG
+  primary/secondary subtests assert the new gate == the old gate (equivalence /
+  no-regression guard); the standby (primary-for-none) subtest stays suppressed.
+  go test ./pkg/daemon/ ./pkg/cluster/... green; go build ./... green; gofmt+vet
+  clean. test-failover note: HA gating change; the single-data-RG loss cluster is
+  unaffected by design (IsLocalPrimaryAny==IsLocalPrimary(theOnlyRG) there), so
+  the split-primary path is unit-covered and a unit test suffices.
+- **File(s)**: pkg/daemon/daemon_ipmon.go (ipmonPublishAllowed gate swap + doc
+  comment), pkg/daemon/daemon_ipmon_test.go (TestIPMonPublishAllowedAnyPrimary +
+  ipmonCluster/ipmonClusterCfg helpers; cluster import), docs/multi-wan.md (HA
+  model publication section — per-any-RG semantics, Layer-2 residual deferred)

--- a/docs/multi-wan.md
+++ b/docs/multi-wan.md
@@ -538,12 +538,32 @@ referenced by an ip-monitoring policy or (b) bound via
 are gated — they run only on the node that is primary for the data RG
 (uplink addresses are VRRP VIPs; a standby probe would fail
 structurally). All other RPM probes keep run-everywhere behavior.
-Overlay publication follows the same gate. Known v1 coarseness: the
-publication gate keys on primaryship of the LOWEST data RG only — in
-a multi-data-RG cluster with split primaryship, per-policy/per-RETH
-publication gating is not yet differentiated (probe gating IS
-per-probe). Overlay publication gating refinement rides the later
-program PRs if a split-RG deployment materializes. The overlay is
+Overlay publication follows primaryship. The publish gate is
+`IsLocalPrimaryAny()` (#3764): a node publishes the overlay while it is
+primary for ANY data RG. Because probe HA gating is already per-RG (a
+gated probe runs only on the node primary for its RETH's RG), a node
+only ever genuinely FAILs the policies whose RG it owns, so
+"publish-if-primary-for-any-RG" is precise: in a multi-data-RG cluster
+with split primaryship (RG1 primary on node A, RG2 primary on node B),
+node B publishes its RG2 failover route (the one it owns and detects as
+failed) and node A publishes its RG1 route; a true standby (primary for
+nothing) publishes nothing. This is COMPLETE for RETH-bound probes.
+
+Pre-#3764 the gate keyed on primaryship of the LOWEST data RG only,
+which suppressed the ENTIRE overlay on any node not primary for that
+lowest RG — node B never injected the RG2 route it owned (a functional
+failover MISS for RG2). With a single data RG (the common case)
+`IsLocalPrimaryAny()` is identical to `IsLocalPrimary(lowestDataRG)`, so
+there is zero regression.
+
+Residual v1 coarseness (Layer 2, DEFERRED): an in-scope probe with NO
+RETH binding falls back to the lowest data RG in `rpmProbeGatingRGs`, so
+per-policy publish attribution is still not differentiated for such
+unbound probes. The tracked refinement is a per-policy publish allow-set
+(daemon resolves each policy → its probe's gating RG → `IsLocalPrimary`)
+or a commit-check requiring HA-gated probes to bind a RETH; it rides a
+later PR only if a split-RG deployment with unbound probes materializes.
+The overlay is
 runtime state and never syncs — on takeover the new primary publishes the
 config baseline, runs a fresh probe cycle, and re-derives the overlay
 from fresh results (at most one fast probe cycle of config-default

--- a/pkg/daemon/daemon_ipmon.go
+++ b/pkg/daemon/daemon_ipmon.go
@@ -355,12 +355,33 @@ func (d *Daemon) reconcileIPMon(cfg *config.Config) {
 
 // ipmonPublishAllowed implements §4.4 primary-only overlay
 // publication: standalone nodes always publish; cluster nodes publish
-// only while primary for the data RG.
+// while primary for ANY data RG.
+//
+// The gate is IsLocalPrimaryAny() rather than IsLocalPrimary of the
+// lowest data RG (#3764). Probe HA gating is already per-RG
+// (filterRPMForHAGating / rpmProbeGatingRGs) — a gated probe runs only
+// on the node that is primary for its RETH's RG — so a node only ever
+// genuinely FAILs the policies whose RG it owns. Publishing whenever
+// this node is primary for ANY RG is therefore both safe and precise:
+// in a multi-data-RG cluster with split primaryship (RG1 primary on
+// node A, RG2 primary on node B), node B publishes its RG2 overlay and
+// node A publishes its RG1 overlay, while a true standby (primary for
+// nothing) still publishes nothing. Keying on the lowest data RG alone
+// suppressed the ENTIRE overlay on any node that was not primary for
+// that lowest RG — so node B never injected the RG2 failover route it
+// genuinely owns and detects as failed (a functional failover MISS for
+// RG2). With a single data RG (the common case) IsLocalPrimaryAny() is
+// identical to IsLocalPrimary(lowestDataRG), so there is zero regression.
+//
+// This is complete for RETH-bound probes. The residual — an in-scope
+// probe with NO RETH binding, which rpmProbeGatingRGs defaults to the
+// lowest data RG — is deferred (Layer 2: a per-policy publish allow-set,
+// or a commit-check requiring HA-gated probes to bind a RETH).
 func (d *Daemon) ipmonPublishAllowed(cfg *config.Config) bool {
 	if d.cluster == nil || cfg == nil || cfg.Chassis.Cluster == nil {
 		return true
 	}
-	return d.cluster.IsLocalPrimary(lowestDataRG(cfg))
+	return d.cluster.IsLocalPrimaryAny()
 }
 
 // reconcileIPMonGating re-evaluates HA gating after an RG transition:

--- a/pkg/daemon/daemon_ipmon_test.go
+++ b/pkg/daemon/daemon_ipmon_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/psaab/xpf/pkg/cluster"
 	"github.com/psaab/xpf/pkg/config"
 	"github.com/psaab/xpf/pkg/dataplane"
 	"github.com/psaab/xpf/pkg/frr"
@@ -470,4 +471,117 @@ func TestActuateRouteOverlayAbortsOnContextCancel(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("actuateRouteOverlay did not abort on ctx cancel (#3758 shutdown-hang regression)")
 	}
+}
+
+// ipmonCluster builds a single-node (no-peer) cluster.Manager for node 0
+// in cluster mode (ControlInterface set) with the given redundancy
+// groups. Single-node election promotes a Preempt=true RG to PRIMARY and
+// holds a Preempt=false RG at SECONDARY (no peer heartbeat), which lets a
+// test express split primaryship deterministically.
+func ipmonCluster(rgs ...*config.RedundancyGroup) *cluster.Manager {
+	m := cluster.NewManager(0, 1)
+	m.UpdateConfig(&config.ClusterConfig{
+		RethCount:        len(rgs),
+		ControlInterface: "control0",
+		RedundancyGroups: rgs,
+	})
+	return m
+}
+
+// ipmonClusterCfg builds a minimal *config.Config whose chassis cluster
+// declares data RGs with the given IDs — enough for lowestDataRG(cfg)
+// and the ipmonPublishAllowed gate.
+func ipmonClusterCfg(ids ...int) *config.Config {
+	cfg := &config.Config{}
+	rgs := make([]*config.RedundancyGroup, len(ids))
+	for i, id := range ids {
+		rgs[i] = &config.RedundancyGroup{ID: id}
+	}
+	cfg.Chassis.Cluster = &config.ClusterConfig{RedundancyGroups: rgs}
+	return cfg
+}
+
+// TestIPMonPublishAllowedAnyPrimary pins the #3764 fix: overlay
+// publication is gated on IsLocalPrimaryAny(), not primaryship of the
+// lowest data RG. Probe HA gating is already per-RG, so a node only
+// genuinely FAILs the policies whose RG it owns — publishing whenever
+// primary for ANY RG is precise (node B injects its RG2 route) and has
+// zero regression for the single-data-RG common case.
+func TestIPMonPublishAllowedAnyPrimary(t *testing.T) {
+	// Split-primary two-data-RG cluster: node 0 SECONDARY for RG1 (the
+	// lowest data RG) and PRIMARY for RG2. The publish gate must be
+	// ENABLED so node 0 injects the RG2 failover route it genuinely owns
+	// and detects as failed. Pre-#3764 keyed on IsLocalPrimary(lowestRG)
+	// = IsLocalPrimary(1) = false, suppressing the WHOLE overlay here —
+	// this assertion goes RED on revert.
+	t.Run("split-primary publishes for the owned RG", func(t *testing.T) {
+		d := &Daemon{cluster: ipmonCluster(
+			&config.RedundancyGroup{ID: 1, NodePriorities: map[int]int{0: 100}, Preempt: false},
+			&config.RedundancyGroup{ID: 2, NodePriorities: map[int]int{0: 200}, Preempt: true},
+		)}
+		if d.cluster.IsLocalPrimary(1) {
+			t.Fatal("setup: node must be SECONDARY for RG1 (lowest data RG)")
+		}
+		if !d.cluster.IsLocalPrimary(2) {
+			t.Fatal("setup: node must be PRIMARY for RG2")
+		}
+		cfg := ipmonClusterCfg(1, 2)
+		if got := lowestDataRG(cfg); got != 1 {
+			t.Fatalf("setup: lowestDataRG = %d, want 1", got)
+		}
+		if !d.ipmonPublishAllowed(cfg) {
+			t.Fatal("split-primary: publish gate must be ENABLED for the RG2-primary node (RED on revert to the lowest-RG gate)")
+		}
+	})
+
+	// Single-data-RG cluster (the common case): the new gate must be
+	// IDENTICAL to the old IsLocalPrimary(lowestDataRG) gate — asserted as
+	// an explicit equivalence for both primary and secondary, so any
+	// regression that diverges the two surfaces here.
+	t.Run("single-data-RG has zero regression", func(t *testing.T) {
+		cfg := ipmonClusterCfg(1)
+
+		dp := &Daemon{cluster: ipmonCluster(
+			&config.RedundancyGroup{ID: 1, NodePriorities: map[int]int{0: 200}, Preempt: true},
+		)}
+		if got, want := dp.ipmonPublishAllowed(cfg), dp.cluster.IsLocalPrimary(lowestDataRG(cfg)); got != want {
+			t.Fatalf("single-RG primary: publish=%v, IsLocalPrimary(lowest)=%v — must be equivalent", got, want)
+		}
+		if !dp.ipmonPublishAllowed(cfg) {
+			t.Fatal("single-RG primary: publish must be enabled")
+		}
+
+		ds := &Daemon{cluster: ipmonCluster(
+			&config.RedundancyGroup{ID: 1, NodePriorities: map[int]int{0: 100}, Preempt: false},
+		)}
+		if got, want := ds.ipmonPublishAllowed(cfg), ds.cluster.IsLocalPrimary(lowestDataRG(cfg)); got != want {
+			t.Fatalf("single-RG secondary: publish=%v, IsLocalPrimary(lowest)=%v — must be equivalent", got, want)
+		}
+		if ds.ipmonPublishAllowed(cfg) {
+			t.Fatal("single-RG secondary: publish must be suppressed")
+		}
+	})
+
+	// True standby (primary for NO data RG): publication stays suppressed
+	// under both the old and new gate.
+	t.Run("standby primary-for-none stays suppressed", func(t *testing.T) {
+		d := &Daemon{cluster: ipmonCluster(
+			&config.RedundancyGroup{ID: 1, NodePriorities: map[int]int{0: 100}, Preempt: false},
+			&config.RedundancyGroup{ID: 2, NodePriorities: map[int]int{0: 100}, Preempt: false},
+		)}
+		if d.cluster.IsLocalPrimaryAny() {
+			t.Fatal("setup: node must be primary for NO RG")
+		}
+		if d.ipmonPublishAllowed(ipmonClusterCfg(1, 2)) {
+			t.Fatal("standby (primary for no RG): publish must be suppressed")
+		}
+	})
+
+	// Standalone (no cluster manager): always publish.
+	t.Run("standalone always publishes", func(t *testing.T) {
+		d := &Daemon{}
+		if !d.ipmonPublishAllowed(&config.Config{}) {
+			t.Fatal("standalone: publish must always be allowed")
+		}
+	})
 }


### PR DESCRIPTION
Closes #3764

## Layer-1 (this PR) — publish-gate-any-primary

The ip-monitoring overlay publication gate keyed on primaryship of the
**lowest** data RG only: `ipmonPublishAllowed` returned
`d.cluster.IsLocalPrimary(lowestDataRG(cfg))`, a single node-wide boolean
(`pkg/daemon/daemon_ipmon.go`).

In a multi-data-RG active/active cluster with split primaryship (RG1
primary on node A, RG2 primary on node B), node B — which **owns and
forwards** RG2 traffic — had the *entire* overlay suppressed because it
is not primary for the lowest RG (RG1). Its RG2 failover route was
therefore never injected on the only node that would use it: a
functional failover **miss** for RG2 (traffic stays pinned to the dead
uplink).

### Fix

Swap the gate to `d.cluster.IsLocalPrimaryAny()` (one line + doc
comment). Rationale: probe HA gating is **already per-RG**
(`filterRPMForHAGating` / `rpmProbeGatingRGs` in `daemon_rpm.go`) — a
gated probe runs only on the node primary for its RETH's RG, so a node
only ever genuinely FAILs the policies whose RG it owns. Publishing
whenever primary for **any** RG is thus safe and precise: node B
publishes its RG2 overlay, node A publishes its RG1 overlay, a true
standby (primary for nothing) publishes nothing.

- **Complete for RETH-bound probes.**
- **Zero regression for the common single-data-RG case**:
  `IsLocalPrimaryAny()` is identical to `IsLocalPrimary(lowestDataRG)`
  when there is one data RG.
- `IsLocalPrimaryAny()` is the established "primary for any RG"
  predicate already used elsewhere in the daemon — no new cluster API.

### Test — RED on revert

`TestIPMonPublishAllowedAnyPrimary` builds a two-data-RG single-node
cluster where election makes node 0 **secondary for RG1** (lowest) and
**primary for RG2**, and asserts the publish gate is ENABLED. Reverting
the gate to `IsLocalPrimary(lowestDataRG)` fails this subtest (verified).
Additional subtests: single-data-RG primary/secondary assert the new
gate == the old gate (explicit no-regression equivalence guard); the
standby (primary-for-none) subtest stays suppressed; standalone always
publishes.

### Validation

- `go test ./pkg/daemon/ ./pkg/cluster/...` green
- `go build ./...` green; `gofmt` + `go vet` clean
- RED-on-revert proven on the split-primary subtest.

**test-failover note:** this is an HA gating change, but the
single-data-RG loss cluster is unaffected by design
(`IsLocalPrimaryAny == IsLocalPrimary(theOnlyRG)` there), so the
split-primary path is unit-covered and a unit test on the gating
suffices.

## Deferred (per the converged /research plan on #3764)

- **Layer-2** — per-policy publish allow-set for an in-scope probe with
  **no RETH binding** (which `rpmProbeGatingRGs` defaults to the lowest
  data RG), i.e. `SetPublishAllowedPolicies(map[string]bool)`.
- **Fix-direction #2** — a commit-check requiring HA-gated ip-monitoring
  probes to bind a RETH (`destination-interface`/`source-address`), so
  the lowest-RG fallback never applies for a multi-data-RG uplink.

Both stay deferred behind Layer-1 unless a split-RG deployment with
unbound probes is actually requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi