### PR TITLE
routes/forwarding: IPv6 ip-rule next-table targets the v6 table (#3768)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,31 @@
+## 2026-07-01 — #3768: IPv6 ip-rule next-table emitted the v4 table (blackhole)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The userspace-FIB ip-rule route-leak emitter built every
+    next-table name as `<inst>.inet.0` before the AF_INET/AF_INET6 loop and
+    reused it for the IPv6 pass, so an IPv6 leak emitted
+    `NextTable:"blue.inet.0"` instead of `blue.inet6.0`. The Rust FIB keys
+    `routes_v6` by `canonical_route_table(table,true)="blue.inet6.0"`, so the
+    v6 next-table recursion missed → NoRoute → leaked IPv6 inter-VRF traffic
+    blackholed (H6). Fix: key the table-id map on the bare instance name and
+    derive the family suffix inside the loop. Rust half (mutually-masking):
+    M5 canonicalizes the recursive next-table name for the current family
+    before lookup (routes.go H6 + this together restore v6 leaks); M6 adds a
+    per-resolution visited-table set so an A→B→A cross-table next-table cycle
+    is rejected at first revisit instead of burning MAX_NEXT_TABLE_DEPTH. The
+    public `lookup_forwarding_resolution_v4/v6` keep their signatures (many
+    callers incl. tunnel-underlay sub-resolution); recursion moved to a
+    private `_inner` variant carrying the visited set. RED-on-revert:
+    TestIPRuleLeakNextTablePerFamily (Go, v6→blue.inet6.0);
+    forwarding_v6_next_table_canonicalizes_inet_form_on_recursion (Rust,
+    NoRoute on M5 revert) + forwarding_resolution_rejects_cross_table_next_
+    table_cycle (Rust, M6 guard).
+  - **File(s)**: pkg/dataplane/userspace/routes.go,
+    pkg/dataplane/userspace/routes_ipv6_nexttable_3768_test.go,
+    userspace-dp/src/afxdp/forwarding/mod.rs,
+    userspace-dp/src/afxdp/forwarding/tests.rs,
+    docs/userspace-dataplane-architecture.md
+
 ## 2026-07-01 — #3755: RPM first probe cycle event reaches event-options
 
 - **Timestamp**: 2026-07-01

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -833,6 +833,21 @@ overlay. Four correctness invariants (#3770/#3772):
   the FRR managed-section distance-1 render. An unparseable overlay
   destination is skipped (`canonicalRoutePrefix` returns `""`) rather
   than injected verbatim as a garbage FIB prefix.
+- **ip-rule leak `NextTable` is family-specific (#3768 H6).** Each
+  synthetic ip-rule leak snapshot targets the routing-instance table for
+  the RULE's address family: an IPv4 leak points at `<inst>.inet.0`, an
+  IPv6 leak at `<inst>.inet6.0`. The builder keys the table-id map on the
+  bare instance name and derives the family suffix inside the AF_INET /
+  AF_INET6 loop. The pre-#3768 emitter baked `<inst>.inet.0` once and
+  reused it for the v6 pass, so an IPv6 leak targeted the instance's IPv4
+  table; the Rust FIB keys `routes_v6` by `canonical_route_table(table,
+  true) = "<inst>.inet6.0"`, so the v6 next-table recursion missed and
+  the leaked IPv6 route blackholed. Defense-in-depth: the Rust recursion
+  also `canonical_route_table`s the next-table name for the current
+  family before lookup, and a per-resolution visited-table set rejects an
+  A→B→A cross-table next-table cycle (formerly only a direct self-loop
+  was caught, so a two-table cycle burned to `MAX_NEXT_TABLE_DEPTH`)
+  (#3768 M5+M6, `userspace-dp/src/afxdp/forwarding/mod.rs`).
 
 **Dynamic-address feed overlay (#2049).** The snapshot's address books carry
 the live `security dynamic-address` feed prefixes, not just the static

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -130,10 +130,22 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 	// route leaking (rib-groups, next-table). These rules send traffic
 	// matching a destination prefix to a different routing table.
 	// Without these, the userspace FIB can't cross-reference VRF tables.
-	tableIDToName := make(map[int]string)
+	//
+	// #3768 (H6): key the map on the BARE routing-instance name and derive
+	// the family-specific next-table name (".inet.0" vs ".inet6.0") per
+	// family INSIDE the loop below. The old map baked in "<inst>.inet.0"
+	// unconditionally and the AF_INET6 pass reused it verbatim, so an IPv6
+	// ip-rule leaking e.g. 2001:db8:1::/48 into instance "blue" emitted
+	// RouteSnapshot{Table:"inet6.0", Family:"inet6", NextTable:"blue.inet.0"}.
+	// The Rust FIB keys routes_v6 as canonical_route_table(table, true) =
+	// "blue.inet6.0", so the v6 next-table recursion into "blue.inet.0"
+	// missed -> NoRoute -> leaked IPv6 traffic blackholed. Note that
+	// normalizeRouteSnapshotFamily canonicalizes static-route tables but is
+	// NOT applied to these synthetic ip-rule leak snapshots.
+	tableIDToInst := make(map[int]string)
 	for _, inst := range cfg.RoutingInstances {
 		if inst != nil && inst.TableID > 0 {
-			tableIDToName[inst.TableID] = inst.Name + ".inet.0"
+			tableIDToInst[inst.TableID] = inst.Name
 		}
 	}
 	for _, family := range []int{syscall.AF_INET, syscall.AF_INET6} {
@@ -148,21 +160,23 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 			if rule.Dst == nil || rule.Table <= 0 {
 				continue
 			}
-			tableName, ok := tableIDToName[rule.Table]
+			instName, ok := tableIDToInst[rule.Table]
 			if !ok {
 				continue
 			}
 			familyStr := "inet"
 			mainTable := "inet.0"
+			nextTable := instName + ".inet.0"
 			if family == syscall.AF_INET6 {
 				familyStr = "inet6"
 				mainTable = "inet6.0"
+				nextTable = instName + ".inet6.0"
 			}
 			addSnapshot(RouteSnapshot{
 				Table:       mainTable,
 				Family:      familyStr,
 				Destination: rule.Dst.String(),
-				NextTable:   tableName,
+				NextTable:   nextTable,
 			})
 		}
 	}

--- a/pkg/dataplane/userspace/routes_ipv6_nexttable_3768_test.go
+++ b/pkg/dataplane/userspace/routes_ipv6_nexttable_3768_test.go
@@ -1,0 +1,87 @@
+package userspace
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// #3768 (H6): the synthetic ip-rule route-leak snapshots must derive the
+// next-table name from the ROUTE's address family. An IPv6 leak into a
+// routing-instance targets "<inst>.inet6.0" (the v6 table the Rust FIB
+// keys routes_v6 by); an IPv4 leak targets "<inst>.inet.0". The pre-fix
+// emitter built "<inst>.inet.0" once and reused it for the v6 pass, so a
+// leaked IPv6 route pointed at the instance's IPv4 table -> the v6
+// recursion missed -> the leak blackholed.
+//
+// This test installs a routing-instance and an ip-rule per family (the
+// kernel/FRR leak mirror) and asserts each family's leak snapshot carries
+// the correct main table, family, and next-table. On revert the v6
+// next-table is emitted as "blue.inet.0" and the v6 assertion fails RED
+// while the v4 assertion still passes (no regression).
+func TestIPRuleLeakNextTablePerFamily(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+
+	const tableID = 100
+	_, v4Dst, err := net.ParseCIDR("10.20.30.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, v6Dst, err := net.ParseCIDR("2001:db8:1::/48")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ruleListFn = func(family int) ([]netlink.Rule, error) {
+		switch family {
+		case syscall.AF_INET:
+			return []netlink.Rule{{Dst: v4Dst, Table: tableID}}, nil
+		case syscall.AF_INET6:
+			return []netlink.Rule{{Dst: v6Dst, Table: tableID}}, nil
+		}
+		return nil, nil
+	}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "blue", TableID: tableID},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	var v4Leak, v6Leak *RouteSnapshot
+	for i := range routes {
+		r := &routes[i]
+		if r.NextTable == "" {
+			continue
+		}
+		switch r.Destination {
+		case "10.20.30.0/24":
+			v4Leak = r
+		case "2001:db8:1::/48":
+			v6Leak = r
+		}
+	}
+
+	if v4Leak == nil {
+		t.Fatal("no IPv4 ip-rule leak snapshot emitted")
+	}
+	if v4Leak.Table != "inet.0" || v4Leak.Family != "inet" || v4Leak.NextTable != "blue.inet.0" {
+		t.Fatalf("v4 leak = %+v, want Table=inet.0 Family=inet NextTable=blue.inet.0", *v4Leak)
+	}
+
+	if v6Leak == nil {
+		t.Fatal("no IPv6 ip-rule leak snapshot emitted")
+	}
+	// The RED-on-revert assertion: pre-#3768 this was "blue.inet.0".
+	if v6Leak.Table != "inet6.0" || v6Leak.Family != "inet6" || v6Leak.NextTable != "blue.inet6.0" {
+		t.Fatalf("v6 leak = %+v, want Table=inet6.0 Family=inet6 NextTable=blue.inet6.0 "+
+			"(pre-#3768 H6 emitted NextTable=blue.inet.0 -> Rust routes_v6 miss -> blackhole)", *v6Leak)
+	}
+}

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -1592,6 +1592,33 @@ pub(super) fn lookup_forwarding_resolution_v4(
     allow_tunnels: bool,
     ecmp_flow_hash: Option<u64>,
 ) -> ForwardingResolution {
+    // #3768 (M6): each top-level resolution starts a fresh visited-table
+    // chain for A->B->A next-table cycle detection. The tunnel-underlay
+    // sub-resolution (resolve_tunnel_outer) also enters through this public
+    // wrapper, so it correctly starts its own independent chain.
+    let mut visited: Vec<String> = Vec::new();
+    lookup_forwarding_resolution_v4_inner(
+        state,
+        dynamic_neighbors,
+        ip,
+        table,
+        depth,
+        allow_tunnels,
+        ecmp_flow_hash,
+        &mut visited,
+    )
+}
+
+fn lookup_forwarding_resolution_v4_inner(
+    state: &ForwardingState,
+    dynamic_neighbors: Option<&Arc<ShardedNeighborMap>>,
+    ip: Ipv4Addr,
+    table: &str,
+    depth: usize,
+    allow_tunnels: bool,
+    ecmp_flow_hash: Option<u64>,
+    visited: &mut Vec<String>,
+) -> ForwardingResolution {
     if depth >= MAX_NEXT_TABLE_DEPTH {
         return ForwardingResolution {
             disposition: ForwardingDisposition::NextTableUnsupported,
@@ -1669,8 +1696,21 @@ pub(super) fn lookup_forwarding_resolution_v4(
                 };
             }
             if !route.next_table.is_empty() {
-                let next_table_name = route.next_table.as_str();
-                if next_table_name == table {
+                // #3768 (M5): canonicalize the recursive next-table name for
+                // THIS address family before loop detection and recursion.
+                // routes_v4 is keyed by canonical_route_table(table, false),
+                // so a v4 next-table string is already canonical here; the
+                // canonicalization is defense-in-depth (a stale/mis-derived
+                // "<inst>.inet6.0" on the v4 side would otherwise miss). The
+                // symmetric v6 site is where this actually rewrites (see the
+                // Go #3768 H6 fix + the v6 lookup below).
+                let next_table_name = canonical_route_table(&route.next_table, false);
+                // #3768 (M6): reject a next-table that revisits the current
+                // table (direct self-loop) OR any table already on this
+                // resolution's chain (A->B->A cross-table cycle). Without the
+                // visited set an A->B->A cycle burned to MAX_NEXT_TABLE_DEPTH
+                // on every packet and masked the config defect.
+                if next_table_name == table || visited.iter().any(|t| t == &next_table_name) {
                     return ForwardingResolution {
                         disposition: ForwardingDisposition::NextTableUnsupported,
                         local_ifindex: 0,
@@ -1683,9 +1723,8 @@ pub(super) fn lookup_forwarding_resolution_v4(
                         tx_vlan_id: 0,
                     };
                 }
-                // Clone needed: the recursive call borrows `state` again.
-                let next_table_name = route.next_table.clone();
-                return lookup_forwarding_resolution_v4(
+                visited.push(table.to_string());
+                return lookup_forwarding_resolution_v4_inner(
                     state,
                     dynamic_neighbors,
                     ip,
@@ -1693,6 +1732,7 @@ pub(super) fn lookup_forwarding_resolution_v4(
                     depth + 1,
                     allow_tunnels,
                     ecmp_flow_hash,
+                    visited,
                 );
             }
             // #2389/#2734: select one equal-cost next-hop, skipping a dead
@@ -1770,6 +1810,31 @@ pub(super) fn lookup_forwarding_resolution_v6(
     allow_tunnels: bool,
     ecmp_flow_hash: Option<u64>,
 ) -> ForwardingResolution {
+    // #3768 (M6): fresh visited-table chain per top-level resolution (see
+    // the v4 wrapper).
+    let mut visited: Vec<String> = Vec::new();
+    lookup_forwarding_resolution_v6_inner(
+        state,
+        dynamic_neighbors,
+        ip,
+        table,
+        depth,
+        allow_tunnels,
+        ecmp_flow_hash,
+        &mut visited,
+    )
+}
+
+fn lookup_forwarding_resolution_v6_inner(
+    state: &ForwardingState,
+    dynamic_neighbors: Option<&Arc<ShardedNeighborMap>>,
+    ip: Ipv6Addr,
+    table: &str,
+    depth: usize,
+    allow_tunnels: bool,
+    ecmp_flow_hash: Option<u64>,
+    visited: &mut Vec<String>,
+) -> ForwardingResolution {
     if depth >= MAX_NEXT_TABLE_DEPTH {
         return ForwardingResolution {
             disposition: ForwardingDisposition::NextTableUnsupported,
@@ -1843,8 +1908,17 @@ pub(super) fn lookup_forwarding_resolution_v6(
                 };
             }
             if !route.next_table.is_empty() {
-                let next_table_name = route.next_table.as_str();
-                if next_table_name == table {
+                // #3768 (M5): canonicalize the recursive next-table name for
+                // the v6 family before loop detection + recursion. routes_v6
+                // is keyed by canonical_route_table(table, true) =
+                // "<inst>.inet6.0"; canonicalizing here rewrites a
+                // "<inst>.inet.0" next-table string (e.g. a pre-#3768-H6 Go
+                // snapshot, or a next_table authored in v4 form) onto the v6
+                // table so the lookup hits instead of blackholing.
+                let next_table_name = canonical_route_table(&route.next_table, true);
+                // #3768 (M6): self-loop + A->B->A cross-table cycle guard
+                // (see the v4 site).
+                if next_table_name == table || visited.iter().any(|t| t == &next_table_name) {
                     return ForwardingResolution {
                         disposition: ForwardingDisposition::NextTableUnsupported,
                         local_ifindex: 0,
@@ -1857,8 +1931,8 @@ pub(super) fn lookup_forwarding_resolution_v6(
                         tx_vlan_id: 0,
                     };
                 }
-                let next_table_name = route.next_table.clone();
-                return lookup_forwarding_resolution_v6(
+                visited.push(table.to_string());
+                return lookup_forwarding_resolution_v6_inner(
                     state,
                     dynamic_neighbors,
                     ip,
@@ -1866,6 +1940,7 @@ pub(super) fn lookup_forwarding_resolution_v6(
                     depth + 1,
                     allow_tunnels,
                     ecmp_flow_hash,
+                    visited,
                 );
             }
             // #2389/#2734: select one equal-cost next-hop, skipping a dead

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -2353,6 +2353,81 @@ fn forwarding_resolution_rejects_next_table_loop() {
     );
 }
 
+// #3768 (M5): the v6 next-table recursion must canonicalize the next-table
+// name for the v6 family before looking it up. Here the v6 leak route
+// carries its next-table in the WRONG v4 form ("blue.inet.0") — exactly
+// what the pre-#3768-H6 Go emitter produced. routes_v6 is keyed as
+// "blue.inet6.0", so without canonicalization the recursion into
+// "blue.inet.0" misses -> NoRoute -> the leaked IPv6 route blackholes. With
+// the M5 fix the recursion rewrites "blue.inet.0" -> "blue.inet6.0" and the
+// lookup hits the VRF v6 table. On revert of M5 this asserts RED (NoRoute
+// instead of ForwardCandidate).
+#[test]
+fn forwarding_v6_next_table_canonicalizes_inet_form_on_recursion() {
+    let mut snapshot = forwarding_snapshot_with_next_table(true);
+    // routes[2] is the v6 leak: inet6.0 -> next_table blue.inet6.0. Rewrite
+    // it to the v4-form name a pre-H6 snapshot would carry.
+    assert_eq!(snapshot.routes[2].table, "inet6.0");
+    assert_eq!(snapshot.routes[2].next_table, "blue.inet6.0");
+    snapshot.routes[2].next_table = "blue.inet.0".to_string();
+
+    let state = build_forwarding_state(&snapshot);
+    let resolved = lookup_forwarding_resolution(
+        &state,
+        IpAddr::V6("2606:4700:4700::1111".parse().expect("ipv6")),
+    );
+    assert_eq!(
+        resolved.disposition,
+        ForwardingDisposition::ForwardCandidate,
+        "v6 next-table in .inet.0 form must canonicalize to the v6 VRF table"
+    );
+    assert_eq!(resolved.egress_ifindex, 12);
+    assert_eq!(
+        resolved.next_hop,
+        Some(IpAddr::V6("2001:559:8585:50::1".parse().expect("v6 nh")))
+    );
+}
+
+// #3768 (M6): an A->B->A cross-table next-table cycle is rejected as
+// NextTableUnsupported via the per-resolution visited-table set. The
+// pre-fix guard only caught a direct self-loop (next == current table), so
+// a two-table cycle recursed until MAX_NEXT_TABLE_DEPTH. This asserts the
+// terminal disposition and that resolution terminates (no hang / panic);
+// the visited set makes it terminate at the first revisit rather than
+// burning the full depth budget.
+#[test]
+fn forwarding_resolution_rejects_cross_table_next_table_cycle() {
+    let snapshot = ConfigSnapshot {
+        routes: vec![
+            crate::RouteSnapshot {
+                table: "inet.0".to_string(),
+                family: "inet".to_string(),
+                destination: "0.0.0.0/0".to_string(),
+                next_hops: vec![],
+                discard: false,
+                next_table: "red.inet.0".to_string(),
+                preference: 0,
+            },
+            crate::RouteSnapshot {
+                table: "red.inet.0".to_string(),
+                family: "inet".to_string(),
+                destination: "0.0.0.0/0".to_string(),
+                next_hops: vec![],
+                discard: false,
+                next_table: "inet.0".to_string(),
+                preference: 0,
+            },
+        ],
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    let resolved = lookup_forwarding_resolution(&state, IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)));
+    assert_eq!(
+        resolved.disposition,
+        ForwardingDisposition::NextTableUnsupported
+    );
+}
+
 #[test]
 fn tx_binding_resolution_prefers_bind_ifindex_for_vlan_units() {
     let state = build_forwarding_state(&nat_snapshot());


### PR DESCRIPTION
Closes #3768

## Problem

The userspace-FIB ip-rule route-leak emitter built every next-table name
as `<inst>.inet.0` once, before the AF_INET/AF_INET6 loop, and reused
that string verbatim for the IPv6 pass. An IPv6 ip rule leaking a prefix
into routing-instance `blue` therefore emitted:

    RouteSnapshot{Table:"inet6.0", Family:"inet6", NextTable:"blue.inet.0"}

The Rust FIB keys `routes_v6` by `canonical_route_table(table, true)` =
`blue.inet6.0`, so the v6 next-table recursion into `blue.inet.0` missed
-> `NoRoute` -> **leaked IPv6 inter-VRF traffic blackholed**. The v4 path
was already correct (`routes_v4` keyed as `blue.inet.0`).

This is codex-review-161's mutually-masking cluster H6 (Go) + M5 (Rust) +
M6 (Rust fold): fixing either end restores IPv6 leaks, but both were
wrong today.

## Fix

- **H6 (Go, `pkg/dataplane/userspace/routes.go`)**: key the table-id map
  on the bare routing-instance name and derive the family-specific
  next-table suffix inside the loop — `<inst>.inet.0` for AF_INET,
  `<inst>.inet6.0` for AF_INET6. The main-table name and family string
  were already family-correct; only `NextTable` was wrong.
- **M5 (Rust, `userspace-dp/src/afxdp/forwarding/mod.rs`)**: canonicalize
  the recursive next-table name for the current address family
  (`canonical_route_table(next, is_ipv6)`) before loop detection and
  recursion, matching how `forwarding_build/fib.rs` keys the per-family
  tables and how the ENTRY table is already canonicalized. No-op for a
  canonical same-family string; a correctness fix for a cross-family /
  stale one (e.g. a pre-H6 snapshot).
- **M6 (Rust)**: the loop guard only caught a direct self-loop
  (`next == current table`); an A->B->A cross-table cycle recursed to
  `MAX_NEXT_TABLE_DEPTH` on every packet and hid the config defect. Carry
  a per-resolution visited-table set and reject a next-table already on
  the chain. The public `lookup_forwarding_resolution_v4/v6` keep their
  signatures (many callers, incl. the tunnel-underlay sub-resolution which
  correctly starts a fresh chain); the recursion moves to a private
  `_inner` variant carrying the visited set.

The kernel/FRR leak side (`pkg/routing/rules.go`) uses numeric table IDs,
not `.inet.0`/`.inet6.0` symbolic names, so it has no analogous bug — the
defect is confined to the userspace FIB snapshot + Rust recursion, exactly
as the issue scopes it.

## Tests (RED-on-revert)

- `TestIPRuleLeakNextTablePerFamily` (Go): installs a routing-instance
  and an ip-rule per family; asserts the v6 leak targets `blue.inet6.0`
  (RED on revert -> `blue.inet.0`) and the v4 leak still targets
  `blue.inet.0` (no regression).
- `forwarding_v6_next_table_canonicalizes_inet_form_on_recursion` (Rust):
  a v6 leak whose next-table is in the wrong `blue.inet.0` form still
  resolves to `ForwardCandidate`; verified RED (`NoRoute`) on revert of
  the M5 canonicalization.
- `forwarding_resolution_rejects_cross_table_next_table_cycle` (Rust):
  an A->B->A two-table cycle terminates as `NextTableUnsupported` via the
  visited set (M6 guard; behavioral — both paths terminate, the set makes
  it terminate at first revisit rather than at the depth budget).

## Validation

- `go build ./...`, `go vet`, `gofmt` clean on the touched files.
- `go test ./pkg/dataplane/userspace/ ./pkg/routing/... ./pkg/frr/...` green.
- `cargo test --release` forwarding module (112) + frame module (321) green.

Not session-sync / VRRP / failover code — no `test-failover` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi