### PR TITLE
event-options: edge-triggered trigger-on, inclusive trigger-until, static-string attributes (#3756 bounded)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,20 @@
+## 2026-07-01 — #3756 M1: `trigger on` is edge-triggered (crossing, not level)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: `within { trigger on N }` was LEVEL-triggered — withinMatches
+    returned true for every event with count>=N, so a sustained failing level
+    re-remediated every 30s cooldown. Pinned to the Junos EDGE reading: a
+    per-(policy,event) latch (policyRuntime.onLatched) set after the crossing
+    fires (only AFTER the cooldown check passes, so a suppressed crossing is not
+    consumed) and re-armed by withinMatches when the in-window count drops below
+    N. policyHasTriggerOn gates the latch to trigger-on policies only.
+    RED-on-revert: TestEdgeTriggerOn_SustainedLevelFiresOnce_3756 (level fires 9
+    vs edge 1), _ReArmsAfterDroppingBelow_3756 (5 vs 2),
+    _CooldownDoesNotConsumeCrossing_3756 (guards latch-after-cooldown ordering).
+  - **File(s)**: pkg/eventengine/engine.go,
+    pkg/eventengine/engine_edge_trigger_3756_test.go,
+    pkg/eventengine/README.md
+
 ## 2026-07-01 — #3755: RPM first probe cycle event reaches event-options
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,21 @@
+## 2026-07-01 — #3756 M2: `trigger until N` is the inclusive N-th (dead-config fix)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The event is appended to the window BEFORE withinMatches, and
+    the until boundary was `count >= wc.TriggerUntil`, so the N-th matching
+    event (count==N) returned false and never fired — `until 1` could NEVER
+    fire (count==1 on the first event), a dead-config bug; `until N` fired only
+    on events 1..N-1. Changed the boundary to `count > wc.TriggerUntil` so
+    `until N` fires inclusively through the N-th event then stops at N+1
+    (Junos "trigger UNTIL the event has been received N times"). One-char
+    change plus comment. RED-on-revert: TestInclusiveUntil_One_FiresOnce_3756
+    (never fires on >=), _Two_FiresThroughSecond_3756 (1 vs 2);
+    _BelowThresholdKeepsFiring_3756 is the never-reaches-N control (green both
+    ways).
+  - **File(s)**: pkg/eventengine/engine.go,
+    pkg/eventengine/engine_inclusive_until_3756_test.go,
+    pkg/eventengine/README.md
+
 ## 2026-07-01 — #3756 M1: `trigger on` is edge-triggered (crossing, not level)
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-01 — #3756 H14: attributes-match static per-test string fields
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Widened attributes-match to key on the three STATIC per-test
+    config strings target / routing-instance / destination-interface (already
+    in scope at every rpm fireEvent site). rpm.Event gained Target /
+    RoutingInstance / DestinationInterface; fireEvent now takes *config.RPMTest
+    and populates them (3 call sites + the buffered-events path get them for
+    free). Added the fields to config.EventAttributesKnownFields (SSOT), the
+    strict-commit error message, and the engine attributesMatch switch (drift
+    guard TestEventAttributesKnownFields_MatchesRuntimeSwitch updated in
+    lockstep). #3753 event-name scoping and #2141 fail-closed preserved.
+    Numeric (rtt/jitter/loss) + failure-reason surface DEFERRED (design
+    recorded in feature-gaps M7). RED-on-revert: TestAttributesMatch_
+    {Target,RoutingInstance,DestinationInterface}Field_3756 (fail-closed
+    "unresolvable field" without the switch cases) + the strict-validator loop
+    in TestValidateEventAttributesMatchStrict_Direct.
+  - **File(s)**: pkg/rpm/rpm.go, pkg/rpm/event_buffer_3755_test.go,
+    pkg/config/event_options_match.go, pkg/config/event_options_match_test.go,
+    pkg/eventengine/engine.go, pkg/eventengine/engine_test.go,
+    pkg/eventengine/README.md, docs/feature-gaps.md
+
 ## 2026-07-01 — #3756 M2: `trigger until N` is the inclusive N-th (dead-config fix)
 
 - **Timestamp**: 2026-07-01

--- a/docs/feature-gaps.md
+++ b/docs/feature-gaps.md
@@ -1153,10 +1153,23 @@ Tier-2 gaps from the `#2008` parity audit researched in
   (`config.ParseEventAttributesMatch`) is shared between the compiler and the
   engine so they cannot drift. **Behavior-change note:** this is NOT
   behavior-preserving for a stored literal containing regex metacharacters —
-  but regex IS the correct Junos behavior. The supported attribute set stays
-  `test-owner` / `test-name` (the only fields on `rpm.Event`); widening the
-  field surface is deferred until more attributes are exposed. See
-  `pkg/eventengine/README.md`.
+  but regex IS the correct Junos behavior. **#3756 H14 (bounded parity, DONE):**
+  the supported attribute set now also includes the three STATIC per-test config
+  strings `target`, `routing-instance`, and `destination-interface` (they are
+  stable identifiers already in scope at every `rpm.fireEvent` call site, so no
+  hot-path cost and no new taxonomy). This lets a policy match "all probes to
+  target X" or "all probes in routing-instance Y". Added to
+  `config.EventAttributesKnownFields` (SSOT), the `rpm.Event` struct, and the
+  `attributesMatch` runtime switch (kept identical by the drift-guard test).
+  **Also pinned (#3756 M1/M2):** `within { trigger on N }` is EDGE-triggered
+  (fires on the crossing, re-arms below N) and `within { trigger until N }` is
+  the INCLUSIVE N-th (the `until 1` dead-config bug is fixed) — see
+  `pkg/eventengine/README.md`. **Still DEFERRED (design recorded, low demand):**
+  numeric attributes (`rtt` / `jitter` / loss-threshold — regex-over-a-number
+  needs a canonical string FORMAT decision) and a `failure-reason` taxonomy (rpm
+  has no failure classifier today — timeout vs unreachable vs setup-error would
+  need a new reason enum). Neither is a fail-open hole; both are additive parity
+  surface gated on a concrete request. See `pkg/eventengine/README.md`.
 - **H13 Stage 1 `forwarding-options allow-dataplane-sleep`** — DONE
   (schema + field + commit warning). The leaf was previously accepted as a
   no-schema-match fall-through and silently dropped by

--- a/pkg/config/event_options_match.go
+++ b/pkg/config/event_options_match.go
@@ -33,6 +33,11 @@ const eventAttributesMatchSep = " matches "
 var EventAttributesKnownFields = map[string]struct{}{
 	"test-owner": {},
 	"test-name":  {},
+	// Static per-test config strings (#3756 H14). Stable identifiers already in
+	// scope at every rpm fireEvent site; no hot-path cost, no new taxonomy.
+	"target":                {},
+	"routing-instance":      {},
+	"destination-interface": {},
 }
 
 // EventAttributesFieldKnown reports whether field is a recognized
@@ -166,7 +171,8 @@ func ValidateEventAttributesMatchStrict(cfg *Config) error {
 			if !EventAttributesFieldKnown(field) {
 				return fmt.Errorf(
 					"event-options policy %q attributes-match %q: unknown field %q "+
-						"(known fields: test-owner, test-name)",
+						"(known fields: test-owner, test-name, target, "+
+						"routing-instance, destination-interface)",
 					pol.Name, attr, field)
 			}
 			if _, err := regexp.Compile(pattern); err != nil {

--- a/pkg/config/event_options_match_test.go
+++ b/pkg/config/event_options_match_test.go
@@ -159,6 +159,22 @@ func TestValidateEventAttributesMatchStrict_Direct(t *testing.T) {
 	if err := ValidateEventAttributesMatchStrict(unknown); err == nil {
 		t.Fatal("strict validator accepted an unknown field")
 	}
+
+	// #3756 H14: the three new static per-test fields are accepted at strict
+	// commit. RED-on-revert: without them in EventAttributesKnownFields the
+	// strict validator rejects a policy keyed on target / routing-instance /
+	// destination-interface as an unknown field.
+	for _, field := range []string{"target", "routing-instance", "destination-interface"} {
+		newField := &Config{EventOptions: []*EventPolicy{
+			{Name: "n", Events: []string{"ev"}, AttributesMatch: []string{`ev.` + field + ` matches ^x$`}},
+		}}
+		if err := ValidateEventAttributesMatchStrict(newField); err != nil {
+			t.Fatalf("strict validator rejected known field %q (#3756 H14): %v", field, err)
+		}
+		if !EventAttributesFieldKnown(field) {
+			t.Errorf("field %q missing from EventAttributesKnownFields SSOT (#3756 H14)", field)
+		}
+	}
 }
 
 // #3753: an attributes-match line scoped to an event the policy does NOT

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -262,6 +262,25 @@ blocks a `commitFn` on `ctx.Done()` and asserts `Close()` aborts it with
 - `xpf_event_attributes_match_invalid_total`
 - `xpf_event_action_queue_depth` (gauge)
 
+## Temporal `within` trigger semantics (#3756)
+
+`within <seconds> { trigger on N }` / `{ trigger until N }` are pinned to the
+Junos reading in `withinMatches` (`engine.go`):
+
+- **`trigger on N` is EDGE-triggered** — the policy fires on the threshold
+  CROSSING (the in-window count first reaching N), NOT on every event while the
+  count stays at or above N. A per-`(policy, event)` latch (`policyRuntime.
+  onLatched`) records that a crossing already fired; it is set in
+  `evaluateEvent` only AFTER the cooldown check passes (a cooldown-suppressed
+  crossing is not consumed) and re-armed (cleared) by `withinMatches` the moment
+  the count drops back below N. Rationale: the 30 s cooldown alone only
+  THROTTLES a sustained failing level — it would re-remediate an unchanged
+  condition every cooldown, which is harmful for a non-idempotent then-batch and
+  spams commit/rollback history. Regression-locked by
+  `TestEdgeTriggerOn_*_3756`. Only a policy carrying a `trigger on` clause
+  latches (`policyHasTriggerOn`); a no-within or `trigger until` policy is
+  unaffected.
+
 ## Gotchas
 
 - 30 s policy cooldown (`policyCooldown`, `engine.go`). The same policy will not

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -280,6 +280,14 @@ Junos reading in `withinMatches` (`engine.go`):
   `TestEdgeTriggerOn_*_3756`. Only a policy carrying a `trigger on` clause
   latches (`policyHasTriggerOn`); a no-within or `trigger until` policy is
   unaffected.
+- **`trigger until N` fires through the INCLUSIVE N-th event**, then stops
+  (Junos "trigger UNTIL the event has been received N times" — the N-th
+  occurrence is the last that fires). The current event is appended to the
+  window BEFORE the check, so the N-th matching event makes `count == N`; the
+  boundary is `count > N` (not `>=`). This fixed a dead-config bug: with `>=`,
+  `until 1` made the first event `count == 1 >= 1` and NEVER fired, and
+  `until N` fired only on events 1..N-1. Regression-locked by
+  `TestInclusiveUntil_*_3756`.
 
 ## Gotchas
 

--- a/pkg/eventengine/README.md
+++ b/pkg/eventengine/README.md
@@ -151,10 +151,16 @@ triggering on a **regex** match of `<pattern>` against the event attribute
 
 - Unanchored patterns are substring matches (`Com` matches `Comcast`); anchor
   with `^...$` for an exact match.
-- Supported attributes are `test-owner` and `test-name`, defined once in
+- Supported attributes are `test-owner`, `test-name`, and (since #3756 H14) the
+  static per-test config strings `target`, `routing-instance`, and
+  `destination-interface`. They are defined once in
   `config.EventAttributesKnownFields` (the single source of truth consumed by
-  both the commit-time validator and the runtime matcher — a drift-guard test
-  keeps them identical).
+  both the commit-time validator and the runtime matcher — a drift-guard test,
+  `TestEventAttributesKnownFields_MatchesRuntimeSwitch`, keeps them identical)
+  and resolved from the `rpm.Event` populated at every `fireEvent` call site.
+  This lets a policy key on "all probes to target X" or "all probes in
+  routing-instance Y". Numeric attributes (`rtt`, `jitter`, loss threshold) and
+  a `failure-reason` taxonomy remain deferred — see `docs/feature-gaps.md` M7.
 - **Event-name scoping (#3753):** the `<event>.` prefix scopes the constraint
   to a single event of a multi-event policy. The runtime matcher applies a
   constraint ONLY when the current event equals its prefix, so

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -1107,8 +1107,16 @@ func (e *Engine) withinMatches(pol *config.EventPolicy, rt *policyRuntime, event
 		}
 
 		if wc.TriggerUntil > 0 {
-			// "trigger until N" — stop triggering once N events reached in window
-			if count >= wc.TriggerUntil {
+			// "trigger until N" fires through the INCLUSIVE N-th event, then
+			// stops (#3756 M2). Junos reads it as "trigger UNTIL the event has
+			// been received N times" — the N-th occurrence is the LAST that
+			// fires. The event is appended to the window BEFORE this check
+			// (evaluateEvent), so the N-th matching event already makes
+			// count==N; using `>=` here made count==N return false, so the N-th
+			// never fired and `until 1` (count==1 on the first event) could
+			// NEVER fire at all — a dead-config bug. `>` fires on 1..N and stops
+			// at N+1.
+			if count > wc.TriggerUntil {
 				return false
 			}
 		}

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -165,10 +165,20 @@ type policyRuntime struct {
 	// means "never triggered". Armed by the worker after a successful commit,
 	// not at evaluate time (#2157 SMR finding 3).
 	lastTrigger time.Time
+	// event name -> edge latch for a `within { trigger on N }` clause
+	// (#3756 M1). Set (true) after the policy fires on a threshold CROSSING;
+	// cleared (re-armed) by withinMatches the moment the in-window count drops
+	// back below N. So a SUSTAINED above-threshold level fires the remediation
+	// ONCE per crossing instead of re-firing every cooldown (Junos `trigger on`
+	// is edge-, not level-triggered).
+	onLatched map[string]bool
 }
 
 func newPolicyRuntime() *policyRuntime {
-	return &policyRuntime{windows: make(map[string][]time.Time)}
+	return &policyRuntime{
+		windows:   make(map[string][]time.Time),
+		onLatched: make(map[string]bool),
+	}
 }
 
 // Engine evaluates event-options policies against RPM events.
@@ -899,6 +909,16 @@ func (e *Engine) evaluateEvent(ev rpm.Event) []triggeredPolicy {
 			continue
 		}
 
+		// #3756 M1: arm the edge latch for this crossing so a sustained
+		// above-threshold level does not re-fire every cooldown. Set only
+		// AFTER the cooldown check passed — a cooldown-suppressed crossing is
+		// NOT treated as already-fired, so the next event past the cooldown
+		// still fires. Cleared by withinMatches when the count drops back
+		// below the trigger-on threshold (re-arm).
+		if policyHasTriggerOn(pol) {
+			rt.onLatched[ev.Name] = true
+		}
+
 		slog.Info("event-options policy triggered",
 			"policy", pol.Name,
 			"event", ev.Name,
@@ -1013,6 +1033,18 @@ func (e *Engine) flagAttributesInvalid(policy, attr, reason string) {
 	}
 }
 
+// policyHasTriggerOn reports whether the policy carries any `within { trigger
+// on N }` clause. Only such a policy participates in the #3756 M1 edge latch;
+// a no-within policy (or a `trigger until` policy) is unaffected.
+func policyHasTriggerOn(pol *config.EventPolicy) bool {
+	for _, wc := range pol.WithinClauses {
+		if wc != nil && wc.TriggerOn > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // withinMatches evaluates temporal trigger clauses against the policy's runtime
 // window.
 // "within N { trigger on M }" — fires when M events happen within N seconds.
@@ -1052,10 +1084,26 @@ func (e *Engine) withinMatches(pol *config.EventPolicy, rt *policyRuntime, event
 		}
 
 		if wc.TriggerOn > 0 {
-			// "trigger on N" — must have at least N events in window
+			// "trigger on N" is EDGE-triggered (#3756 M1): it fires on the
+			// threshold CROSSING, not on every event while the level stays at
+			// or above N. Junos `trigger on` re-arms only after the count drops
+			// back below N; the 30s cooldown alone only THROTTLES a sustained
+			// level (re-remediating it every cooldown), which is harmful for a
+			// non-idempotent then-batch and spams commit/rollback history.
 			if count < wc.TriggerOn {
+				// Dropped below the threshold: re-arm so the next crossing
+				// fires again.
+				rt.onLatched[eventName] = false
 				return false
 			}
+			if rt.onLatched[eventName] {
+				// Level still at/above N and this crossing already fired:
+				// suppress until the count drops below N (re-arm above).
+				return false
+			}
+			// count >= N and not yet latched: this IS the crossing — pass.
+			// evaluateEvent sets the latch only AFTER the cooldown check
+			// passes, so a cooldown-suppressed crossing is not consumed.
 		}
 
 		if wc.TriggerUntil > 0 {

--- a/pkg/eventengine/engine.go
+++ b/pkg/eventengine/engine.go
@@ -990,6 +990,12 @@ func (e *Engine) attributesMatch(pol *config.EventPolicy, ev rpm.Event) bool {
 			value = ev.TestOwner
 		case "test-name":
 			value = ev.TestName
+		case "target":
+			value = ev.Target
+		case "routing-instance":
+			value = ev.RoutingInstance
+		case "destination-interface":
+			value = ev.DestinationInterface
 		default:
 			// Known to config but not yet resolvable on rpm.Event. The SSOT
 			// and this switch are kept identical by a drift-guard test, so

--- a/pkg/eventengine/engine_edge_trigger_3756_test.go
+++ b/pkg/eventengine/engine_edge_trigger_3756_test.go
@@ -1,0 +1,125 @@
+package eventengine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/rpm"
+)
+
+// Regression tests for #3756 M1: `within { trigger on N }` is EDGE-triggered
+// (fires on the threshold CROSSING) rather than LEVEL-triggered (firing on
+// every above-threshold event, throttled only by the 30s cooldown). Junos
+// `trigger on` re-arms only after the in-window count drops back below N.
+//
+// These drive the real evaluate path (evaluateEvent) on a deterministic clock.
+// evaluateEvent does not arm the cooldown (that is the worker's job on a
+// successful commit), so without a worker the PRE-M1 level code fires on EVERY
+// above-threshold event — the "re-fire every cooldown" behavior in its most
+// visible form. The edge latch fixes that regardless of the cooldown.
+
+// feedEventsAtTicks drives one event per supplied tick (simulated seconds) and
+// returns the total number of triggers.
+func feedEventsAtTicks(t *testing.T, pol *config.EventPolicy, ticks []int64) int {
+	t.Helper()
+	e := New(nil, nil)
+	defer e.Close()
+
+	base := time.Unix(1_700_000_000, 0)
+	var cur int64
+	e.nowFn = func() time.Time { return base.Add(time.Duration(cur) * time.Second) }
+	e.Apply([]*config.EventPolicy{pol})
+
+	triggered := 0
+	for _, cur = range ticks {
+		triggered += len(e.evaluateEvent(rpm.Event{Name: pol.Events[0], TestOwner: "o", TestName: "t"}))
+	}
+	return triggered
+}
+
+// A SUSTAINED above-threshold level must fire the remediation exactly ONCE (on
+// the crossing), not on every subsequent event while the level holds.
+//
+// RED-on-revert: the pre-M1 level code returns true for every event with
+// count>=N, so all 9 post-crossing events also fire — total 9 instead of 1.
+func TestEdgeTriggerOn_SustainedLevelFiresOnce_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "on2",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 300, TriggerOn: 2}},
+	}
+	// 10 events, one per second, all inside the 300s window: the count climbs
+	// to 2 at tick 1 (the crossing) and stays >=2 through tick 9.
+	ticks := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	if got := feedEventsAtTicks(t, pol, ticks); got != 1 {
+		t.Fatalf("sustained above-threshold level fired %d times; `trigger on` is "+
+			"edge-triggered and must fire exactly ONCE per crossing (#3756 M1)", got)
+	}
+}
+
+// After the count drops back below N the latch re-arms, so a subsequent
+// crossing fires AGAIN. This proves the latch is not a one-shot.
+//
+// RED-on-revert: the pre-M1 level code fires on ticks 1,2,3,4 and 11 (every
+// above-threshold event) — total 5 — instead of the edge total 2 (one fire per
+// crossing at ticks 1 and 11).
+func TestEdgeTriggerOn_ReArmsAfterDroppingBelow_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "on2-rearm",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 5, TriggerOn: 2}},
+	}
+	// First burst 0..4 crosses at tick 1 (fire once, latched). By tick 10 the
+	// 0..4 timestamps have aged out of the 5s window, so tick 10 sees count=1
+	// (< 2 → re-arm), and tick 11 crosses again (fire once).
+	ticks := []int64{0, 1, 2, 3, 4, 10, 11}
+	if got := feedEventsAtTicks(t, pol, ticks); got != 2 {
+		t.Fatalf("re-arm scenario fired %d times; want exactly 2 (one per crossing) — "+
+			"edge trigger must suppress the sustained middle events yet re-fire "+
+			"after the count drops below N and crosses again (#3756 M1)", got)
+	}
+}
+
+// A crossing suppressed by an ACTIVE cooldown must NOT be treated as
+// already-fired: the latch is set only after the cooldown check passes, so once
+// the cooldown clears the still-held level fires exactly once. This guards the
+// evaluateEvent ordering (latch-after-cooldown).
+//
+// RED-on-regression: if the latch were set before/independent of the cooldown
+// check, the crossing would be consumed during suppression and NEVER fire
+// (total 0). If edge were reverted to level, it would fire on every post-
+// cooldown event (many). Exactly-1 is the correct edge+cooldown interaction.
+func TestEdgeTriggerOn_CooldownDoesNotConsumeCrossing_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "on2-cooldown",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 300, TriggerOn: 2}},
+	}
+	e := New(nil, nil)
+	defer e.Close()
+
+	base := time.Unix(1_700_000_000, 0)
+	var cur int64
+	e.nowFn = func() time.Time { return base.Add(time.Duration(cur) * time.Second) }
+	e.Apply([]*config.EventPolicy{pol})
+
+	// Pre-arm the cooldown anchor to base (as if a commit had just occurred),
+	// so the crossing at tick 1 lands inside the 30s cooldown and is suppressed.
+	e.mu.Lock()
+	e.runtime["on2-cooldown"].lastTrigger = base
+	e.mu.Unlock()
+
+	triggered := 0
+	// Feed one event per second across the cooldown boundary (30s). The crossing
+	// (tick 1) and every event through tick 29 are cooldown-suppressed; tick 31
+	// is past the 30s cooldown and must fire — the crossing was NOT consumed.
+	for _, cur = range []int64{0, 1, 2, 3, 4, 5, 10, 20, 29, 31, 32, 33} {
+		triggered += len(e.evaluateEvent(rpm.Event{Name: "ping_probe_failed", TestOwner: "o", TestName: "t"}))
+	}
+	if triggered != 1 {
+		t.Fatalf("edge+cooldown interaction fired %d times; a cooldown-suppressed "+
+			"crossing must not be consumed — it fires exactly once when the "+
+			"cooldown clears (#3756 M1)", triggered)
+	}
+}

--- a/pkg/eventengine/engine_inclusive_until_3756_test.go
+++ b/pkg/eventengine/engine_inclusive_until_3756_test.go
@@ -1,0 +1,80 @@
+package eventengine
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// Regression tests for #3756 M2: `within { trigger until N }` fires through the
+// INCLUSIVE N-th matching event, then stops. The event is appended to the
+// window BEFORE withinMatches runs, so the N-th event makes count==N. The old
+// boundary (`count >= N`) treated count==N as "stop", so:
+//   - `until 1` never fired at all (the first event already makes count==1) — a
+//     genuine dead-config bug.
+//   - `until N` fired only on events 1..N-1 instead of 1..N.
+// The fix (`count > N`) fires on 1..N and stops at N+1.
+//
+// These reuse feedEvents/firstFireIndex from engine_within_failclosed_3751_test.go.
+
+// countTriggersAcross drives count events and returns the number that fired.
+func countTriggersAcross(t *testing.T, pol *config.EventPolicy, count int) int {
+	t.Helper()
+	return feedEvents(t, pol, count)
+}
+
+// `trigger until 1` must fire on the FIRST event (exactly once), then stop.
+//
+// RED-on-revert: with the old `count >= 1` boundary the first event makes
+// count==1 -> 1>=1 -> return false -> NEVER fires; firstFireIndex returns -1.
+func TestInclusiveUntil_One_FiresOnce_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "until1",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 300, TriggerUntil: 1}},
+	}
+	if got := firstFireIndex(t, pol, 5); got != 0 {
+		t.Fatalf("`trigger until 1` first fired at event index %d; want 0 — the "+
+			"first event is the inclusive N=1th and MUST fire (#3756 M2 dead-config bug)", got)
+	}
+	// It fires exactly once (event 1); event 2 makes count==2 > 1 -> stops.
+	if got := countTriggersAcross(t, pol, 5); got != 1 {
+		t.Fatalf("`trigger until 1` fired %d times across 5 events; want exactly 1 "+
+			"(the inclusive N-th, then stop)", got)
+	}
+}
+
+// `trigger until 2` fires on events 1 and 2 (inclusive of the 2nd), then stops.
+//
+// RED-on-revert: the old `count >= 2` boundary fired only on event 1 (count==1)
+// and stopped at event 2 (count==2 >= 2), so the total was 1, not 2.
+func TestInclusiveUntil_Two_FiresThroughSecond_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "until2",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 300, TriggerUntil: 2}},
+	}
+	if got := countTriggersAcross(t, pol, 6); got != 2 {
+		t.Fatalf("`trigger until 2` fired %d times across 6 events; want exactly 2 "+
+			"(events 1 and 2, inclusive of the 2nd; the 3rd makes count==3 > 2 and stops) (#3756 M2)", got)
+	}
+}
+
+// The 2216A never-reaches-threshold guard for trigger-until is preserved: an
+// until clause whose window never accumulates N events keeps firing (it never
+// reaches the stop boundary). Here `until 100` within a 30s window at 1 event/s
+// caps the count near 30, well below 100, so EVERY event fires. This confirms
+// the boundary shift did not accidentally suppress the below-threshold case.
+func TestInclusiveUntil_BelowThresholdKeepsFiring_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:          "until100",
+		Events:        []string{"ping_probe_failed"},
+		WithinClauses: []*config.EventWithin{{Seconds: 30, TriggerUntil: 100}},
+	}
+	// At 1 event/s within a 30s window the count never exceeds ~31 < 100, so
+	// every one of the 20 events is below the stop boundary and fires.
+	if got := countTriggersAcross(t, pol, 20); got != 20 {
+		t.Fatalf("`trigger until 100` fired %d/20 events; a window that never "+
+			"reaches N must keep firing on every event (#3756 M2)", got)
+	}
+}

--- a/pkg/eventengine/engine_test.go
+++ b/pkg/eventengine/engine_test.go
@@ -116,10 +116,17 @@ func TestAttributesMatch_MalformedLineFailsClosed(t *testing.T) {
 // matcher (i.e. a policy matching ^anything against that field with the right
 // event value must be able to return true), and an unknown field must fail.
 func TestEventAttributesKnownFields_MatchesRuntimeSwitch(t *testing.T) {
-	// The matcher resolves test-owner and test-name; assert exactly those are
-	// the known fields. If a field is added to the SSOT, this test forces the
-	// matcher switch to be updated in lockstep.
-	want := map[string]bool{"test-owner": true, "test-name": true}
+	// The matcher resolves these fields; assert exactly this set is the known
+	// fields. If a field is added to the SSOT, this test forces the matcher
+	// switch to be updated in lockstep (#3756 H14 added the three static
+	// per-test strings target / routing-instance / destination-interface).
+	want := map[string]bool{
+		"test-owner":            true,
+		"test-name":             true,
+		"target":                true,
+		"routing-instance":      true,
+		"destination-interface": true,
+	}
 	if len(config.EventAttributesKnownFields) != len(want) {
 		t.Fatalf("known-field set %v has unexpected size; runtime switch resolves %v",
 			config.EventAttributesKnownFields, want)
@@ -233,6 +240,73 @@ func TestAttributesMatch_PerEventScopingBothDirections(t *testing.T) {
 	}
 	if e.attributesMatch(pol, rpm.Event{Name: "event_b", TestName: "wrong"}) {
 		t.Error("event_b with wrong name must be gated")
+	}
+}
+
+// #3756 H14: the three new static per-test fields (target, routing-instance,
+// destination-interface) resolve against the corresponding rpm.Event field and
+// regex-match like test-owner/test-name.
+//
+// RED-on-revert: before H14 these fields are absent from the SSOT and the
+// matcher switch, so a policy keyed on them fails CLOSED (unknown field →
+// policy never matches) — the match assertions below go RED (attributesMatch
+// returns false for a matching value).
+func TestAttributesMatch_TargetField_3756(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.target matches ^192\\.0\\.2\\.1$")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", Target: "192.0.2.1"}) {
+		t.Error("target field should match the event Target")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", Target: "192.0.2.2"}) {
+		t.Error("target field should NOT match a different Target")
+	}
+}
+
+func TestAttributesMatch_RoutingInstanceField_3756(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.routing-instance matches ^ISP-B$")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", RoutingInstance: "ISP-B"}) {
+		t.Error("routing-instance field should match the event RoutingInstance")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", RoutingInstance: "ISP-A"}) {
+		t.Error("routing-instance field should NOT match a different RoutingInstance")
+	}
+}
+
+func TestAttributesMatch_DestinationInterfaceField_3756(t *testing.T) {
+	pol := policyWithMatch("p", "ping_test_failed",
+		"ping_test_failed.destination-interface matches ^ge-0/0/1$")
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", DestinationInterface: "ge-0/0/1"}) {
+		t.Error("destination-interface field should match the event DestinationInterface")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", DestinationInterface: "ge-0/0/2"}) {
+		t.Error("destination-interface field should NOT match a different DestinationInterface")
+	}
+}
+
+// The new fields honor the #3753 event-name scoping: a constraint keyed on one
+// event of a multi-event policy must not gate a DIFFERENT event.
+func TestAttributesMatch_NewFieldsEventScoped_3756(t *testing.T) {
+	pol := &config.EventPolicy{
+		Name:            "p",
+		Events:          []string{"ping_test_failed", "ping_test_completed"},
+		AttributesMatch: []string{"ping_test_failed.target matches ^10\\.0\\.0\\.1$"},
+	}
+	e := newTestEngine(t, []*config.EventPolicy{pol})
+
+	// ping_test_failed IS scoped by the target constraint.
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", Target: "10.0.0.1"}) {
+		t.Error("scoped event must match its target constraint")
+	}
+	if e.attributesMatch(pol, rpm.Event{Name: "ping_test_failed", Target: "10.0.0.2"}) {
+		t.Error("scoped event must be gated by a non-matching target")
+	}
+	// ping_test_completed is NOT scoped by a ping_test_failed constraint.
+	if !e.attributesMatch(pol, rpm.Event{Name: "ping_test_completed", Target: "10.0.0.9"}) {
+		t.Error("a ping_test_failed-scoped target constraint must not gate ping_test_completed (#3753)")
 	}
 }
 

--- a/pkg/rpm/event_buffer_3755_test.go
+++ b/pkg/rpm/event_buffer_3755_test.go
@@ -3,6 +3,8 @@ package rpm
 import (
 	"sync"
 	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
 )
 
 // TestFireEventBufferedUntilCallbackRegistered is the fail-on-revert pin for
@@ -18,8 +20,8 @@ func TestFireEventBufferedUntilCallbackRegistered(t *testing.T) {
 	m := New()
 
 	// First probe cycle fires before any callback exists.
-	m.fireEvent("ping_probe_failed", "WAN", "t")
-	m.fireEvent("ping_test_failed", "WAN", "t")
+	m.fireEvent("ping_probe_failed", "WAN", &config.RPMTest{Name: "t"})
+	m.fireEvent("ping_test_failed", "WAN", &config.RPMTest{Name: "t"})
 
 	var mu sync.Mutex
 	var got []Event
@@ -56,7 +58,7 @@ func TestFireEventDeliveredLiveAfterRegistration(t *testing.T) {
 		mu.Unlock()
 	})
 
-	m.fireEvent("ping_test_failed", "WAN", "t")
+	m.fireEvent("ping_test_failed", "WAN", &config.RPMTest{Name: "t"})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -73,7 +75,7 @@ func TestFireEventDeliveredLiveAfterRegistration(t *testing.T) {
 func TestFireEventBufferBounded(t *testing.T) {
 	m := New()
 	for i := 0; i < maxBufferedEvents*3; i++ {
-		m.fireEvent("ping_probe_failed", "WAN", "t")
+		m.fireEvent("ping_probe_failed", "WAN", &config.RPMTest{Name: "t"})
 	}
 	m.mu.Lock()
 	n := len(m.bufferedEvents)

--- a/pkg/rpm/rpm.go
+++ b/pkg/rpm/rpm.go
@@ -114,6 +114,13 @@ type Event struct {
 	Name      string // "ping_test_failed", "ping_probe_failed", "ping_test_completed"
 	TestOwner string // probe name (matches attributes-match test-owner)
 	TestName  string // test name (matches attributes-match test-name)
+	// Static per-test config strings exposed to attributes-match (#3756 H14).
+	// They are stable identifiers already in scope at every fireEvent call
+	// site, so an operator can key remediation on "all probes to target X" or
+	// "all probes in routing-instance Y" without a new attribute taxonomy.
+	Target               string // test target IP/hostname (attributes-match target)
+	RoutingInstance      string // test routing-instance ("" = master) (routing-instance)
+	DestinationInterface string // egress-interface pin (destination-interface)
 }
 
 // EventCallback is called when RPM probes generate events.
@@ -309,8 +316,19 @@ func (m *Manager) PinInstallFailureCount() int {
 	return len(m.pinFailed)
 }
 
-func (m *Manager) fireEvent(name, owner, testName string) {
-	ev := Event{Name: name, TestOwner: owner, TestName: testName}
+// fireEvent builds an rpm.Event for event-options matching. It takes the whole
+// *config.RPMTest so the static per-test strings (test-name, target,
+// routing-instance, destination-interface) are populated for attributes-match
+// (#3756 H14) at every call site. test is always non-nil from runSingleTest;
+// the nil guard is defensive.
+func (m *Manager) fireEvent(name, owner string, test *config.RPMTest) {
+	ev := Event{Name: name, TestOwner: owner}
+	if test != nil {
+		ev.TestName = test.Name
+		ev.Target = test.Target
+		ev.RoutingInstance = test.RoutingInstance
+		ev.DestinationInterface = test.DestinationInterface
+	}
 	m.mu.Lock()
 	fn := m.onEvent
 	if fn == nil {
@@ -535,7 +553,7 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 			// Probe-level failure event stays per-probe — it is an
 			// eventengine signal and does not drive ip-monitoring
 			// routes (which key off fireTransition only).
-			m.fireEvent("ping_probe_failed", probeName, test.Name)
+			m.fireEvent("ping_probe_failed", probeName, test)
 			if hitLimit {
 				break
 			}
@@ -588,14 +606,14 @@ func (m *Manager) runSingleTest(ctx context.Context, probeName string, test *con
 		}
 		m.mu.Unlock()
 		if status == "fail" {
-			m.fireEvent("ping_test_failed", probeName, test.Name)
+			m.fireEvent("ping_test_failed", probeName, test)
 		}
 		m.fireTransition(probeName, test.Name, status)
 	}
 
 	// Fire test completed if all probes passed
 	if failures == 0 && successes > 0 {
-		m.fireEvent("ping_test_completed", probeName, test.Name)
+		m.fireEvent("ping_test_completed", probeName, test)
 	}
 }
 


### PR DESCRIPTION
Closes #3756

Implements the PLAN-READY bounded subset of the converged /research plan
for event-options parity (three coupled pieces, one PR). The DEFERRED
numeric/failure-reason surface is out of scope and documented as such.

## M1 — `trigger on N` is edge-triggered

`within { trigger on N }` was LEVEL-triggered: withinMatches returned
true for every matching event once the in-window count reached N, so the
30s cooldown only THROTTLED a sustained failing level and re-remediated
the same unchanged condition every cooldown (harmful for a non-idempotent
then-batch; spams commit/rollback history). Pinned to the Junos EDGE
reading via a per-(policy,event) latch (`policyRuntime.onLatched`): set
after the crossing fires — only AFTER the cooldown check passes, so a
cooldown-suppressed crossing is not consumed — and re-armed by
withinMatches the moment the count drops back below N.

RED-on-revert (level): `TestEdgeTriggerOn_SustainedLevelFiresOnce_3756`
(level fires 9 vs edge 1), `_ReArmsAfterDroppingBelow_3756` (5 vs 2),
`_CooldownDoesNotConsumeCrossing_3756` (guards latch-after-cooldown).

## M2 — `trigger until N` is the inclusive N-th (dead-config fix)

The triggering event is appended to the window BEFORE withinMatches, and
the boundary was `count >= N`, so the N-th event (count==N) returned false
and never fired — `trigger until 1` could NEVER fire (a dead-config bug),
and `until N` fired only on events 1..N-1. Changed to `count > N`: `until
N` fires inclusively through the N-th event then stops at N+1 (Junos
"trigger UNTIL the event has been received N times").

RED-on-revert (`>=`): `TestInclusiveUntil_One_FiresOnce_3756` (never fires
under `>=`), `_Two_FiresThroughSecond_3756` (1 vs 2);
`_BelowThresholdKeepsFiring_3756` is the never-reaches-N control (green
both ways).

## H14 — attributes-match static per-test string fields

Widened `attributes-match` to key on `target`, `routing-instance`, and
`destination-interface` (in addition to `test-owner` / `test-name`) —
stable per-test config strings already in scope at every rpm `fireEvent`
site, so no hot-path cost and no new taxonomy. `rpm.Event` gained the
fields; `fireEvent` now takes `*config.RPMTest` and populates them (all
three call sites + the buffered-events path). Added to
`config.EventAttributesKnownFields` (SSOT), the strict-commit error
message, and the `attributesMatch` switch (drift-guard test updated in
lockstep). #3753 event-name scoping and #2141 fail-closed preserved.

RED-on-revert (attribute unavailable → fail closed):
`TestAttributesMatch_{Target,RoutingInstance,DestinationInterface}Field_3756`,
`_NewFieldsEventScoped_3756`, and the strict-validator loop in
`TestValidateEventAttributesMatchStrict_Direct`.

## Deferred (documented, not in scope)

Per the converged plan, the numeric attributes (`rtt` / `jitter` /
loss-threshold — regex-over-a-number needs a canonical string FORMAT
decision) and a `failure-reason` taxonomy (rpm has no failure classifier
today) remain a recorded parity gap in `docs/feature-gaps.md` M7. Neither
is a fail-open hole; both are additive surface gated on a concrete request.

## Validation

`go build ./...`, `gofmt`, `go vet`, and `go test ./pkg/eventengine/...
./pkg/rpm/... ./pkg/config/...` (plus daemon/grpcapi/cli) all green. The
#3751 fail-closed and #3815 (H13 on+until, day-2, event-name scope)
behavior is preserved. Docs updated: `pkg/eventengine/README.md`,
`docs/feature-gaps.md` M7, `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi