### PR TITLE
appid: no false junos-ping label on non-echo ICMP — Go-only interim (Closes #3781)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -54,6 +54,40 @@
   - **File(s)**: pkg/eventengine/engine.go,
     pkg/eventengine/engine_edge_trigger_3756_test.go,
     pkg/eventengine/README.md
+
+## 2026-07-01 — #3781: ICMP AppID label ignored type/code (false junos-ping)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: The AppID LABEL catalog is L3/L4-only — `pkg/appid.CatalogEntry`
+    and `BuildCatalog` never read `app.ICMPType`/`ICMPCode`, so a type-constrained
+    ICMP app (junos-ping = icmp type 8) shipped a protocol-only catalog row that
+    matched EVERY ICMP type. A non-echo ICMP (dest-unreachable/timestamp/ND) that
+    correctly fell to default-deny was logged in RT_FLOW / `show security flow
+    session` with `application=junos-ping` — a false label (MEDIUM log-integrity;
+    the echo-only verdict engine, #3020, was already correct — NOT a match
+    fail-open). Go-only INTERIM per the converged #3781 /research plan (Part 1,
+    no wire change): `icmpTypeConstrained(app)` gates BuildCatalog to DROP the
+    over-matching protocol-only ICMP row for a type/code-constrained app while
+    KEEPING its `AppNames[id]=name` row + CONSUMING the id (AppNames parity with
+    compileApplications preserved — appid_catalog_parity_test.go). The dropped
+    entry means the helper never stamps that id, so such ICMP resolves to an
+    honest UNKNOWN (or junos-icmp-all when referenced) instead of a false label.
+    Same skip in `resolveTupleFallback` (runtime.go) for the AppID-disabled
+    show/session-name path. A protocol-only ICMP app (junos-icmp-all, user app
+    with no type) and non-ICMP apps are unaffected; protocol_wire_v1.json is
+    byte-identical (no field added, one fewer Entries element). The
+    type/code-aware catalog WIRE + Rust classifier (Part 2 tier-1) and the
+    session-close/show HA-sync persistence (tier-2) are DEFERRED per the plan.
+    Updated TestAppCatalogParityOnTolerantLoadPortEdges to allow the deliberate
+    dangling-but-inert AppNames id for type-constrained ICMP apps. RED-on-revert:
+    TestBuildCatalogTypeConstrainedICMPDropsOverMatchingRow,
+    TestBuildCatalogTypeConstrainedICMPHonestUnknown,
+    TestResolveTupleFallbackSkipsTypeConstrainedICMP (all RED with the guards
+    removed — junos-ping ships a row / a non-echo ICMP labels junos-ping).
+  - **File(s)**: pkg/appid/catalog.go, pkg/appid/runtime.go,
+    pkg/appid/catalog_icmp_3781_test.go,
+    pkg/dataplane/appid_catalog_parity_test.go, pkg/appid/README.md
+
 ## 2026-07-01 — #3768: IPv6 ip-rule next-table emitted the v4 table (blackhole)
 
 - **Timestamp**: 2026-07-01

--- a/pkg/appid/README.md
+++ b/pkg/appid/README.md
@@ -147,3 +147,46 @@ the bad entry — never MISLABEL a session as a wrong-but-plausible application:
   skew) resolved to the malformed name instead of `UNKNOWN`. Both producers are
   fixed identically; `TestAppCatalogParityOnTolerantLoadPortEdges` pins them
   byte-identical and dangling-free.
+
+## ICMP type/code labeling (#3781 interim)
+
+The catalog wire (`AppCatalogEntrySnapshot`, `CatalogEntry`) is **L3/L4 only** —
+it has no ICMP type/code fields — so a catalog row for an ICMP application
+matches on protocol alone (a `(0,0)` destination-port pair). Policy MATCHING for
+`junos-ping`/`junos-pingv6` is echo-only (`PolicyApplicationSnapshot.icmp_type`,
+#3020), but the AppID LABEL catalog was not: an ICMP application that carries an
+`icmp-type`/`icmp-code` constraint still shipped a protocol-only row that matched
+**every** ICMP type. A non-echo ICMP (destination-unreachable, timestamp,
+ICMPv6 ND) that correctly fell to default-deny was then LOGGED in RT_FLOW /
+`show security flow session` with `application=junos-ping` — a false label. The
+verdict engine was correct; only the audit label was wrong (log-integrity, not a
+match fail-open).
+
+**Interim (Go-only, no wire change):**
+
+- `icmpTypeConstrained(app)` (`catalog.go`) reports whether an application has an
+  ICMP/ICMPv6 type or code constraint.
+- `BuildCatalog` (`catalog.go`) DROPS the over-matching protocol-only
+  `CatalogEntry` for such an app, but KEEPS its `AppNames[app_id] = name` row and
+  still CONSUMES the id — so the `AppNames` byte-identical parity with
+  `compileApplications` (`appid_catalog_parity_test.go`) is preserved. The
+  dropped entry means the helper never stamps that id, so the name is inert: a
+  non-echo (or echo) ICMP resolves to an honest `UNKNOWN` — or to
+  `junos-icmp-all` when a protocol-only ICMP app is also referenced — instead of
+  a false `junos-ping` label. An ICMP app WITHOUT a type/code constraint
+  (`junos-icmp-all`, a user protocol-only ICMP app) is unaffected.
+- `resolveTupleFallback` (`runtime.go`) skips a type-constrained ICMP app on the
+  AppID-disabled show/session-name path for the same reason (`matchTuple` is
+  protocol+port only, blind to ICMP type/code).
+- The protocol wire (`protocol_wire_v1.json`) is byte-identical: no field was
+  added, one fewer `Entries` element is shipped.
+
+**Deferred follow-up (per the #3781 /research plan):** the fully type/code-aware
+catalog is a two-sided wire change (`icmp_type`/`icmp_code` as `*uint8`
+omitempty on the Go snapshot + `Option<u8>` on the Rust `AppCatalogEntry`, with a
+Go↔Rust decode parity test) plus a type/code-aware `lookup*` in the Rust
+classifier and the deny/create label sites. Tier-2 (session close / `show
+security flow session` re-derivation, which crosses the HA session-sync wire) is
+a separate deliberate change requiring `test-failover`. The interim guarantees
+NO FALSE LABEL (honest `UNKNOWN`), NOT positive echo classification — that
+arrives with the deferred wire work.

--- a/pkg/appid/catalog.go
+++ b/pkg/appid/catalog.go
@@ -151,24 +151,49 @@ func BuildCatalog(cfg *config.Config) (Catalog, error) {
 			// the malformed name instead of UNKNOWN. compileApplications is
 			// fixed the same way to keep the two AppNames maps byte-identical
 			// (appid_catalog_parity_test.go).
+			//
+			// #3781: the id->name row is recorded here EVEN for a
+			// type-constrained ICMP app whose over-matching CatalogEntry is
+			// dropped below, because compileApplications also records that app's
+			// AppNames row (it too is "emittable" — an ICMP app has an empty,
+			// non-inverted port range). Keeping the row in lock-step preserves
+			// the AppNames parity contract; the dropped entry simply means the
+			// helper never stamps that id, so the name is inert (resolves for no
+			// live session) rather than a false label.
 			cat.AppNames[appID] = name
 
-			// Omitted protocol means "any L4"; compileApplications installs
-			// both TCP and UDP entries (ICMP is excluded from that fan-out).
-			protos := []uint8{proto}
-			if proto == 0 && app.Protocol != "icmp" {
-				protos = []uint8{6, 17}
-			}
-			for _, p := range protos {
-				cat.Entries = append(cat.Entries, CatalogEntry{
-					Name:        name,
-					AppID:       appID,
-					Protocol:    p,
-					DstPortLow:  dstLow,
-					DstPortHigh: dstHigh,
-					SrcPortLow:  srcLow,
-					SrcPortHigh: srcHigh,
-				})
+			// #3781 interim (log-integrity): an ICMP/ICMPv6 application that
+			// carries a type/code constraint (e.g. junos-ping = icmp type 8)
+			// cannot express that constraint on the L3/L4-only catalog wire, so a
+			// protocol-only row would match EVERY ICMP message type. A non-echo
+			// ICMP (destination-unreachable, timestamp, ICMPv6 ND) that correctly
+			// falls to default-deny would then be stamped with the ping app label
+			// even though the echo-only verdict engine never matched it. Until the
+			// type/code-aware catalog wire lands (DEFERRED per the #3781 /research
+			// plan), drop the over-matching row: the AppNames id is still recorded
+			// above and consumed below, so such ICMP resolves to an honest UNKNOWN
+			// (or junos-icmp-all, when a protocol-only ICMP app is also referenced)
+			// rather than a false type-constrained label. An ICMP app WITHOUT a
+			// type/code constraint (junos-icmp-all, a user protocol-only ICMP app)
+			// is unaffected and still ships its protocol-only row.
+			if !icmpTypeConstrained(app) {
+				// Omitted protocol means "any L4"; compileApplications installs
+				// both TCP and UDP entries (ICMP is excluded from that fan-out).
+				protos := []uint8{proto}
+				if proto == 0 && app.Protocol != "icmp" {
+					protos = []uint8{6, 17}
+				}
+				for _, p := range protos {
+					cat.Entries = append(cat.Entries, CatalogEntry{
+						Name:        name,
+						AppID:       appID,
+						Protocol:    p,
+						DstPortLow:  dstLow,
+						DstPortHigh: dstHigh,
+						SrcPortLow:  srcLow,
+						SrcPortHigh: srcHigh,
+					})
+				}
 			}
 		}
 		nextID++
@@ -320,6 +345,25 @@ func ProtocolName(p uint8) string {
 	default:
 		return ""
 	}
+}
+
+// icmpTypeConstrained reports whether an application carries an ICMP/ICMPv6
+// type or code constraint (e.g. junos-ping = icmp type 8, predefined.go). Such
+// an app's L3/L4 match rule — the catalog CatalogEntry and the display tuple
+// fallback — is protocol-only (the catalog wire has no icmp type/code fields,
+// #3781), so a protocol-only row / tuple match would over-match EVERY ICMP
+// message type and falsely label a non-echo ICMP (destination-unreachable,
+// timestamp, ICMPv6 ND) that correctly fell to default-deny as the ping app.
+//
+// The strict commit gate (validateApplicationSpecsStrict, #3348) rejects a code
+// without a type and a type on a non-ICMP protocol, so on the strict path a set
+// ICMPCode implies a set ICMPType. This predicate also treats a stray
+// code-only app (admissible on the tolerant-load path) as constrained so no
+// over-broad ICMP label leaks there either. The fully type/code-aware catalog
+// wire + classifier is DEFERRED per the #3781 /research plan; this is the
+// Go-only interim that removes the false label immediately.
+func icmpTypeConstrained(app *config.Application) bool {
+	return app != nil && (app.ICMPType != nil || app.ICMPCode != nil)
 }
 
 // catalogProtocolNumber resolves a protocol to its byte for the app-id catalog,

--- a/pkg/appid/catalog_icmp_3781_test.go
+++ b/pkg/appid/catalog_icmp_3781_test.go
@@ -1,0 +1,179 @@
+package appid
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// u8 is a local pointer helper for the ICMP type/code fields (config uses u8p).
+func u8(v uint8) *uint8 { return &v }
+
+// icmpRefConfig builds a config whose single policy references every named
+// application (predefined names included), so CatalogNames(cfg, false) returns
+// exactly that referenced set. Predefined apps (junos-ping, junos-icmp-all)
+// resolve via config.ResolveApplication even though they are not in the
+// user Applications map.
+func icmpRefConfig(userApps map[string]*config.Application, refs ...string) *config.Config {
+	return &config.Config{
+		Applications: config.ApplicationsConfig{Applications: userApps},
+		Security: config.SecurityConfig{
+			Policies: []*config.ZonePairPolicies{
+				{Policies: []*config.Policy{{Match: config.PolicyMatch{Applications: refs}}}},
+			},
+		},
+	}
+}
+
+// TestBuildCatalogTypeConstrainedICMPDropsOverMatchingRow is the #3781
+// fail-on-revert guard for the catalog builder. An ICMP/ICMPv6 application that
+// carries a type/code constraint (predefined junos-ping = icmp type 8, or a
+// user-defined app with icmp-type set) MUST NOT ship a protocol-only
+// CatalogEntry — that row would match EVERY ICMP type and falsely stamp a
+// non-echo ICMP that fell to default-deny with the ping app label. The interim
+// fix drops the row while KEEPING the app_id->name row (AppNames parity with
+// compileApplications). A protocol-only ICMP app (junos-icmp-all, a user app
+// with no type) and a non-ICMP app are unaffected. Reverting the
+// icmpTypeConstrained guard re-emits junos-ping's over-matching ICMP row and
+// turns this RED.
+func TestBuildCatalogTypeConstrainedICMPDropsOverMatchingRow(t *testing.T) {
+	cfg := icmpRefConfig(map[string]*config.Application{
+		// user-defined type-constrained ICMP app (echo-request only)
+		"my-echo": {Name: "my-echo", Protocol: "icmp", ICMPType: u8(8)},
+		// user-defined type+code-constrained ICMPv6 app
+		"my-na": {Name: "my-na", Protocol: "icmpv6", ICMPType: u8(136), ICMPCode: u8(0)},
+		// user-defined protocol-only ICMP app — unaffected
+		"my-icmp-any": {Name: "my-icmp-any", Protocol: "icmp"},
+		// non-ICMP app — unaffected
+		"my-web": {Name: "my-web", Protocol: "tcp", DestinationPort: "80"},
+	},
+		"junos-ping", "junos-icmp-all", "my-echo", "my-na", "my-icmp-any", "my-web")
+
+	cat, err := BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+
+	// The type-constrained ICMP apps drop their over-matching row but KEEP the
+	// AppNames id (parity contract with compileApplications).
+	for _, name := range []string{"junos-ping", "my-echo", "my-na"} {
+		if got := entriesForName(cat, name); len(got) != 0 {
+			t.Fatalf("type-constrained ICMP app %q shipped %d catalog row(s) %+v; a protocol-only ICMP row over-matches every type and mislabels non-echo ICMP (#3781)", name, len(got), got)
+		}
+		if _, ok := appIDForName(cat, name); !ok {
+			t.Fatalf("type-constrained ICMP app %q must keep its AppNames row so the app_id sequence stays in lock-step with compileApplications (parity)", name)
+		}
+	}
+
+	// The protocol-only ICMP apps still ship their protocol-only row (proto 1),
+	// unaffected by the interim.
+	for _, name := range []string{"junos-icmp-all", "my-icmp-any"} {
+		got := entriesForName(cat, name)
+		if len(got) != 1 {
+			t.Fatalf("protocol-only ICMP app %q shipped %d rows, want 1 (must be unaffected)", name, len(got))
+		}
+		if got[0].Protocol != 1 || got[0].DstPortLow != 0 || got[0].DstPortHigh != 0 {
+			t.Fatalf("protocol-only ICMP app %q entry = %+v, want icmp(1) 0/0", name, got[0])
+		}
+	}
+
+	// The non-ICMP app is untouched.
+	web := entriesForName(cat, "my-web")
+	if len(web) != 1 || web[0].Protocol != 6 || web[0].DstPortLow != 80 || web[0].DstPortHigh != 80 {
+		t.Fatalf("my-web entry = %+v, want tcp(6) 80/80 (must be unaffected)", web)
+	}
+
+	// Every SHIPPED CatalogEntry still resolves to its AppNames row (no
+	// stampable entry points at a wrong or missing name).
+	for _, e := range cat.Entries {
+		if cat.AppNames[e.AppID] != e.Name {
+			t.Fatalf("catalog entry app_id=%d name=%q but AppNames[%d]=%q", e.AppID, e.Name, e.AppID, cat.AppNames[e.AppID])
+		}
+	}
+}
+
+// TestBuildCatalogTypeConstrainedICMPHonestUnknown proves the interim's
+// guarantee: NO FALSE LABEL. Because the interim does NOT add the deferred
+// type/code-aware catalog match, junos-ping's id is never stamped on any
+// session (its row is dropped), so a session carrying an app_id that no shipped
+// entry stamps resolves to UNKNOWN via the show path — never to junos-ping.
+// This is the "honest UNKNOWN over a false label" bar; positive echo
+// classification is deferred with the wire work.
+func TestBuildCatalogTypeConstrainedICMPHonestUnknown(t *testing.T) {
+	cfg := icmpRefConfig(nil, "junos-ping", "junos-icmp-all")
+	cfg.Services.ApplicationIdentification = false // catalog resolution, not fallback
+
+	cat, err := BuildCatalog(cfg)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+
+	pingID, ok := appIDForName(cat, "junos-ping")
+	if !ok {
+		t.Fatal("junos-ping must retain an AppNames row for parity")
+	}
+	// No shipped CatalogEntry carries junos-ping's id — the helper can never
+	// stamp it, so the name is inert (resolves for no live session).
+	for _, e := range cat.Entries {
+		if e.AppID == pingID {
+			t.Fatalf("junos-ping id=%d has a shipped catalog entry %+v; the interim must ship none so no session is stamped junos-ping (#3781)", pingID, e)
+		}
+	}
+	// junos-icmp-all DOES have a stampable protocol-only row.
+	icmpAllID, ok := appIDForName(cat, "junos-icmp-all")
+	if !ok {
+		t.Fatal("junos-icmp-all missing from AppNames")
+	}
+	stamped := false
+	for _, e := range cat.Entries {
+		if e.AppID == icmpAllID {
+			stamped = true
+		}
+	}
+	if !stamped {
+		t.Fatal("junos-icmp-all must keep its protocol-only catalog row (unaffected by the interim)")
+	}
+}
+
+// TestResolveTupleFallbackSkipsTypeConstrainedICMP is the #3781 fail-on-revert
+// guard for the Go display/session-name tuple fallback (AppID-disabled path).
+// matchTuple is protocol + port only, so a type-constrained ICMP app would
+// otherwise match EVERY ICMP session and false-label it. A non-echo ICMP must
+// resolve to a protocol-only ICMP app when one is referenced, or to empty
+// (honest UNKNOWN), never to the type-constrained app. Reverting the
+// icmpTypeConstrained skip in resolveTupleFallback turns this RED.
+func TestResolveTupleFallbackSkipsTypeConstrainedICMP(t *testing.T) {
+	// Case 1: only a type-constrained ICMP app is defined. An ICMP session must
+	// NOT be labeled with it (no protocol-only fallback to fall back to).
+	cfg := &config.Config{}
+	cfg.Services.ApplicationIdentification = false
+	cfg.Applications.Applications = map[string]*config.Application{
+		"my-echo": {Name: "my-echo", Protocol: "icmp", ICMPType: u8(8)},
+	}
+	// Non-echo ICMP (type 3 destination-unreachable). srcPort/dstPort are the
+	// L4 tuple; ICMP has none, so both are 0. appID 0 (unstamped) forces the
+	// tuple fallback.
+	if got := ResolveSessionName(nil, cfg, 1, 0, 0, 0); got == "my-echo" {
+		t.Fatalf("non-echo ICMP resolved to %q via the tuple fallback; a type-constrained ICMP app must not label arbitrary ICMP (#3781)", got)
+	}
+	// An echo (type 8) likewise gets no positive label from the interim (that
+	// is the deferred type-aware match) — the guarantee is only NO FALSE LABEL.
+	if got := ResolveSessionName(nil, cfg, 1, 0, 0, 0); got != "" && got != Unknown {
+		t.Fatalf("type-constrained ICMP app produced label %q; the interim renders honest UNKNOWN/empty, not a false or positive label", got)
+	}
+
+	// Case 2: a protocol-only ICMP app is also defined. The honest label for any
+	// ICMP session is the protocol-only app, NOT the type-constrained one — even
+	// though "my-echo" sorts before "my-icmp-any" (the tie-break the revert would
+	// otherwise win).
+	cfg.Applications.Applications["my-icmp-any"] = &config.Application{Name: "my-icmp-any", Protocol: "icmp"}
+	if got := ResolveSessionName(nil, cfg, 1, 0, 0, 0); got != "my-icmp-any" {
+		t.Fatalf("ICMP session resolved to %q, want my-icmp-any (protocol-only); the type-constrained my-echo must be skipped (#3781)", got)
+	}
+
+	// Case 3: a non-ICMP tuple app is unaffected — tcp/80 still resolves.
+	cfg.Applications.Applications["my-web"] = &config.Application{Name: "my-web", Protocol: "tcp", DestinationPort: "80"}
+	if got := ResolveSessionName(nil, cfg, 6, 12345, 80, 0); got != "my-web" {
+		t.Fatalf("tcp/80 session resolved to %q, want my-web (non-ICMP unaffected)", got)
+	}
+}

--- a/pkg/appid/runtime.go
+++ b/pkg/appid/runtime.go
@@ -208,6 +208,17 @@ func resolveTupleFallback(proto uint8, srcPort, dstPort uint16, cfg *config.Conf
 		best := ""
 		bestPortBased := false
 		for name, app := range cfg.Applications.Applications {
+			// #3781 interim (log-integrity): a type/code-constrained ICMP app
+			// (icmp-type/icmp-code set) match-alls every ICMP type here because
+			// matchTuple is protocol + port only (blind to the ICMP type/code).
+			// Skip it so a non-echo ICMP resolves to an honest UNKNOWN (or a
+			// protocol-only ICMP app when one is referenced) on the AppID-disabled
+			// show/session-name path rather than a false type-constrained label.
+			// The type/code-aware match is DEFERRED with the catalog wire per the
+			// #3781 /research plan. A protocol-only ICMP app is unaffected.
+			if icmpTypeConstrained(app) {
+				continue
+			}
 			if !matchTuple(proto, srcPort, dstPort, app.Protocol, app.SourcePort, app.DestinationPort) {
 				continue
 			}

--- a/pkg/dataplane/appid_catalog_parity_test.go
+++ b/pkg/dataplane/appid_catalog_parity_test.go
@@ -181,12 +181,27 @@ func TestAppCatalogParityOnTolerantLoadPortEdges(t *testing.T) {
 
 	// M04: no dangling name at an id that stamps no catalog entry, in EITHER
 	// direction. The malformed apps (badsrc/revrange/nope) must not appear.
+	//
+	// #3781 exception: ApplicationIdentification=true above pulls in the full
+	// predefined catalog, including the type-constrained ICMP apps junos-ping
+	// (icmp type 8) and junos-pingv6 (icmpv6 type 128). The interim DELIBERATELY
+	// keeps their AppNames row (for byte-identical parity with
+	// compileApplications, asserted above) while DROPPING the over-matching
+	// protocol-only ICMP catalog entry so a non-echo ICMP is not false-labeled.
+	// Their id is therefore a SAFE dangling id: no shipped catalog entry carries
+	// it, so the helper can never stamp it and it resolves for no live session —
+	// unlike a malformed app, whose dangling name is a genuine mislabel risk.
+	// Skip type-constrained ICMP apps here; every other dangling id is still a
+	// bug.
 	stamped := map[uint16]bool{}
 	for _, e := range cat.Entries {
 		stamped[e.AppID] = true
 	}
 	for id, name := range result.AppNames {
 		if !stamped[id] {
+			if app, ok := config.ResolveApplication(name, cfg.Applications.Applications); ok && (app.ICMPType != nil || app.ICMPCode != nil) {
+				continue // #3781: intentionally dangling-but-inert type-constrained ICMP app
+			}
 			t.Fatalf("live AppNames[%d]=%q has no catalog entry to stamp it — a skewed app_id would resolve to it instead of UNKNOWN (M04)", id, name)
 		}
 		if name == "bbb-badsrc" || name == "ccc-revrange" || name == "zzz-nope" {


### PR DESCRIPTION
## Closes #3781

MEDIUM log-integrity fix (NOT a match fail-open). Go-only INTERIM per the
converged #3781 /research plan (Part 1, no wire change).

### The bug

The AppID **label** catalog is L3/L4-only — `pkg/appid.CatalogEntry` +
`BuildCatalog` never read `app.ICMPType`/`ICMPCode`. So a type-constrained ICMP
application (`junos-ping` = icmp type 8, `junos-pingv6` = icmpv6 type 128)
shipped a protocol-only catalog row that matched **every** ICMP type. A non-echo
ICMP (destination-unreachable, timestamp, ICMPv6 ND) that correctly fell to
default-deny was then LOGGED in RT_FLOW / `show security flow session` with
`application=junos-ping`, even though it never matched `junos-ping`. The
echo-only verdict engine (`PolicyApplicationSnapshot.icmp_type`, #3020) was
already correct — only the audit label was wrong.

### The interim fix (Go only, no wire change)

- `icmpTypeConstrained(app)` (`pkg/appid/catalog.go`) reports whether an
  application carries an ICMP/ICMPv6 type or code constraint.
- **`BuildCatalog`** DROPS the over-matching protocol-only `CatalogEntry` for
  such an app but KEEPS its `AppNames[app_id]=name` row and CONSUMES the id — so
  the `AppNames` byte-identical parity with `compileApplications`
  (`appid_catalog_parity_test.go`) is preserved. The dropped entry means the
  helper never stamps that id, so a non-echo (or echo) ICMP resolves to an honest
  **UNKNOWN** — or to `junos-icmp-all` when a protocol-only ICMP app is also
  referenced — instead of a false `junos-ping` label.
- **`resolveTupleFallback`** (`pkg/appid/runtime.go`) skips a type-constrained
  ICMP app on the AppID-disabled show/session-name path for the same reason
  (`matchTuple` is protocol+port only, blind to ICMP type/code).
- An ICMP app WITHOUT a type/code constraint (`junos-icmp-all`, a user
  protocol-only ICMP app) and non-ICMP apps are unaffected.

`protocol_wire_v1.json` is **byte-identical** — no field added; one fewer
`Entries` element is shipped for a type-constrained ICMP app.

### Guarantee

The interim's bar is **NO FALSE LABEL** (honest UNKNOWN), **NOT** positive echo
classification. Positive echo matching needs the deferred type/code-aware
catalog and is intentionally out of scope here.

### Deferred follow-up (per the /research plan)

The fully type/code-aware catalog is a two-sided wire change
(`icmp_type`/`icmp_code` as `*uint8` omitempty on the Go snapshot + `Option<u8>`
on the Rust `AppCatalogEntry`, with a Go↔Rust decode parity test) plus a
type/code-aware `lookup*` in the Rust classifier and the deny/create label
sites. Tier-2 (session close / `show security flow session` re-derivation, which
crosses the HA session-sync wire) is a separate deliberate change requiring
`test-failover`.

### RED-on-revert (verified by disabling both guards)

- `TestBuildCatalogTypeConstrainedICMPDropsOverMatchingRow` — junos-ping ships a
  protocol-only ICMP row.
- `TestBuildCatalogTypeConstrainedICMPHonestUnknown` — junos-ping id has a
  stampable catalog entry.
- `TestResolveTupleFallbackSkipsTypeConstrainedICMP` — a non-echo ICMP is labeled
  the type-constrained app.

### Validation

`go test ./pkg/appid/... ./pkg/dataplane/...` green (including the parity test);
`go build ./...`; `gofmt`; `go vet` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
