### PR TITLE
userspace-dp: gate bump_fib_generation (version + monotonicity + persist) (#3767)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -88,6 +88,45 @@
     pkg/appid/catalog_icmp_3781_test.go,
     pkg/dataplane/appid_catalog_parity_test.go, pkg/appid/README.md
 
+## 2026-07-01 — #3767: bump_fib_generation had no protocol-version / monotonicity / persist guards
+
+- **Timestamp**: 2026-07-01
+  - **Action**: `bump_fib_generation` is a control message that mutates
+    dataplane validation state (status + stored snapshot + worker FIB
+    generation) but, unlike `apply_snapshot`, carried none of apply's guards.
+    Fixed three defects flagged by codex-review-161. **H4 (version gate):**
+    the handler checked only snapshot presence — a mixed-version / corrupt
+    client (version=0) was accepted and mutated validation. Added a
+    `snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION` reject mirroring
+    `apply`, and stamped `Version: ProtocolVersion` onto the Go bump snapshot
+    (`Manager.BumpFIBGeneration`) so legitimate route-only bumps still pass.
+    **H5 (monotonicity):** `Coordinator::bump_fib_generation` had no
+    monotonicity check, but flow-cache validation is EQUALITY based
+    (`entry.stamp.fib_generation != lookup.fib_generation`), not monotone —
+    so publishing an OLD/reused generation (stale/duplicate/corrupt message,
+    or a reset shim counter) revived cache entries a prior bump invalidated,
+    reusing a forwarding decision after a route withdrawal / failover. The
+    method now refuses a value strictly lower than the current in-memory
+    `validation.fib_generation` (returns bool; handler fails closed on
+    refusal). The full-snapshot transition path (`refresh_runtime_snapshot` /
+    reconcile `apply_snapshot`) assigns validation directly and is NOT gated,
+    so a legitimate config reset still lands. **M2 (persist):** an accepted
+    bump now sets `persist_state` so the on-disk status + snapshot advance
+    with the bump — previously RAM-only, so a bump to gen N left persisted
+    state at gen N-1 and a restart booted from a stale FIB generation.
+    RED-on-revert: bump_fib_generation_rejects_wrong_protocol_version (H4),
+    bump_fib_generation_rejects_generation_rollback (H5),
+    bump_fib_generation_persists_bumped_generation (M2) — all three fail
+    against pre-fix behavior. Full cargo test --release green (3388 lib +
+    46/8/16/1); go test ./pkg/dataplane/userspace green. Not session-sync
+    state (fib-generation is forwarding-state), so no test-failover required.
+  - **File(s)**: userspace-dp/src/server/handlers/snapshot.rs,
+    userspace-dp/src/server/handlers/mod.rs,
+    userspace-dp/src/afxdp/coordinator/mod.rs,
+    userspace-dp/src/server/tests.rs,
+    pkg/dataplane/userspace/manager.go,
+    docs/flow-cache-simplification.md, _Log.md
+
 ## 2026-07-01 — #3768: IPv6 ip-rule next-table emitted the v4 table (blackhole)
 
 - **Timestamp**: 2026-07-01

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -482,6 +482,49 @@ at the live epoch survives a same-MAC refresh and is evicted on a MAC change.
 Neutralizing either `mac_change_epoch.fetch_add` turns the change/eviction
 assertions RED.
 
+## FIB-generation bump gating (#3767)
+
+The `fib_generation` half of the validation stamp is invalidated cheaply by a
+lightweight `bump_fib_generation` control message (the Go
+`Manager.BumpFIBGeneration` route-only overlay path — no full snapshot
+rebuild). Because flow-cache validation is **equality** based
+(`entry.stamp.fib_generation != lookup.fib_generation` in `flow_cache.rs`),
+NOT monotone, the bump verb needs the same guards a full `apply_snapshot`
+carries. Before #3767 it had none — it checked only snapshot presence. Three
+gates were added (handler `server/handlers/snapshot.rs::bump_fib`, coordinator
+`afxdp/coordinator/mod.rs::bump_fib_generation`):
+
+- **Protocol-version gate (H4).** `bump_fib` now rejects
+  `snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION`, mirroring `apply`.
+  A mixed-version / corrupt client (which serializes `version = 0`) can no
+  longer mutate validation state. The Go `Manager.BumpFIBGeneration` now
+  stamps the bump snapshot with `ProtocolVersion` so a legitimate route-only
+  bump still passes.
+- **Monotonicity gate (H5).** `Coordinator::bump_fib_generation` refuses a
+  value strictly lower than the current in-memory `validation.fib_generation`
+  and returns `false`; the handler then reports `ok = false` and mutates
+  nothing. A route-only overlay bump is monotone by construction on the Go
+  side (the shim counter only increments), so a lower value is a
+  stale/duplicate/corrupt message or a reset shim counter. Reviving it would
+  make cache entries a prior bump already invalidated MATCH validation again,
+  reusing a forwarding decision after a route withdrawal / failover. A full
+  snapshot generation transition assigns `self.validation` directly through
+  `refresh_runtime_snapshot` / reconcile `apply_snapshot` and is intentionally
+  NOT gated here, so a legitimate config-transition reset still lands.
+- **Persist gate (M2).** An accepted bump now sets `persist_state`, so the
+  on-disk `status.last_fib_generation` + `snapshot.fib_generation` advance
+  with the bump. Previously they were mutated in RAM only, so a route-only
+  bump to gen N left the persisted state at gen N-1 and a helper/host restart
+  booted from a stale FIB generation the control plane already considered
+  applied.
+
+Validation (`server/tests.rs`): `bump_fib_generation_rejects_wrong_protocol_version`
+(H4 — fail-on-revert), `bump_fib_generation_rejects_generation_rollback`
+(H5 — fail-on-revert; status / stored snapshot / worker FIB gen all stay at
+the last accepted value), and `bump_fib_generation_persists_bumped_generation`
+(M2 — fail-on-revert; the persisted state a restart boots from carries the
+bumped generation).
+
 ## Recommended Next Step
 
 Implement Phase 1 next:

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -1291,6 +1291,11 @@ func (m *Manager) BumpFIBGeneration() (uint32, error) {
 	if err := m.requestLocked(ControlRequest{
 		Type: "bump_fib_generation",
 		Snapshot: &ConfigSnapshot{
+			// #3767 H4: the helper now version-gates bump_fib_generation
+			// exactly like apply_snapshot. Stamp the protocol version so a
+			// legitimate route-only bump is accepted; an unversioned (0)
+			// message is rejected as a mixed-version / corrupt client.
+			Version:       ProtocolVersion,
 			FIBGeneration: newGen,
 		},
 	}, &status); err != nil {

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -800,11 +800,43 @@ impl Coordinator {
         self.nat_counters.clear();
     }
 
+    /// Current in-memory FIB generation (the value flow-cache lookups
+    /// validate against). Read by the `bump_fib_generation` control handler
+    /// to build a rollback-rejection error and by tests.
+    pub fn fib_generation(&self) -> u32 {
+        self.validation.fib_generation
+    }
+
     /// Bump just the FIB generation counter without a full snapshot rebuild.
     /// Workers will invalidate flow cache entries with stale FIB generations.
-    pub fn bump_fib_generation(&mut self, fib_generation: u32) {
+    ///
+    /// #3767 (H5): flow-cache validation is EQUALITY based, not monotone —
+    /// `flow_cache.rs` treats an entry as stale only when
+    /// `entry.stamp.fib_generation != lookup.fib_generation`. So publishing an
+    /// OLD or reused generation (a stale/duplicate/corrupt control message, or
+    /// a shim counter that was reset to a lower value) would make cache
+    /// entries that a prior bump already invalidated MATCH validation again,
+    /// reviving a forwarding decision after a route withdrawal / failover.
+    ///
+    /// A lightweight route-only overlay bump is monotone by construction on
+    /// the Go side (`Manager.BumpFIBGeneration` increments the shim counter),
+    /// so a value strictly lower than the current in-memory generation is
+    /// never legitimate here — reject it and leave `self.validation` and the
+    /// shared validation Arc untouched. A full-snapshot generation transition
+    /// runs through `refresh_runtime_snapshot`, which assigns `self.validation`
+    /// directly and is intentionally NOT gated by this monotonicity check, so
+    /// a legitimate config-transition reset still lands.
+    ///
+    /// Returns `true` when the bump was applied, `false` when it was refused
+    /// as a rollback.
+    #[must_use]
+    pub fn bump_fib_generation(&mut self, fib_generation: u32) -> bool {
+        if fib_generation < self.validation.fib_generation {
+            return false;
+        }
         self.validation.fib_generation = fib_generation;
         self.shared_validation.store(Arc::new(self.validation));
+        true
     }
 }
 

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -142,9 +142,12 @@ pub(crate) fn handle_stream(
             "update_neighbors" => {
                 neighbors::update(&mut guard, request.neighbors.as_ref(), neighbor_replace)
             }
-            "bump_fib_generation" => {
-                snapshot::bump_fib(&mut guard, request.snapshot.as_ref(), &mut response)
-            }
+            "bump_fib_generation" => snapshot::bump_fib(
+                &mut guard,
+                request.snapshot.as_ref(),
+                &mut response,
+                &mut persist_state,
+            ),
             "clear_policy_counters" => {
                 guard.afxdp.clear_policy_counters();
                 refresh_status(&mut guard);

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -195,6 +195,7 @@ pub(super) fn bump_fib(
     guard: &mut ServerState,
     snapshot: Option<&ConfigSnapshot>,
     response: &mut ControlResponse,
+    persist_state: &mut bool,
 ) {
     // Lightweight FIB generation bump without a full snapshot.
     // Updates the generation counter so workers invalidate stale
@@ -205,10 +206,45 @@ pub(super) fn bump_fib(
         response.error = "missing snapshot".to_string();
         return;
     };
+    // #3767 H4: version gate, mirroring `apply` above. bump_fib mutates
+    // dataplane validation state (status + stored snapshot + worker FIB
+    // generation), so a mixed-version / corrupt client (which serializes
+    // version=0) must be rejected BEFORE any mutation, exactly as a full
+    // apply_snapshot is. The Go `Manager.BumpFIBGeneration` now stamps the
+    // bump snapshot with the protocol version so a legitimate bump passes.
+    if snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION {
+        response.ok = false;
+        response.error = format!(
+            "unsupported snapshot protocol version {} (want {})",
+            snapshot.version, CONFIG_SNAPSHOT_PROTOCOL_VERSION
+        );
+        return;
+    }
+    // #3767 H5: refuse a generation ROLLBACK. Flow-cache validation is
+    // equality based, so publishing a strictly-lower fib_generation would
+    // revive cache entries a prior bump already invalidated (see
+    // Coordinator::bump_fib_generation). The coordinator owns the
+    // monotonicity invariant and leaves its validation state untouched on
+    // refusal; fail closed here too — do NOT advance the reported status /
+    // stored snapshot and do NOT persist.
+    if !guard.afxdp.bump_fib_generation(snapshot.fib_generation) {
+        response.ok = false;
+        response.error = format!(
+            "fib generation rollback rejected: {} < current {}",
+            snapshot.fib_generation,
+            guard.afxdp.fib_generation()
+        );
+        return;
+    }
     guard.status.last_fib_generation = snapshot.fib_generation;
     if let Some(ref mut snap) = guard.snapshot {
         snap.fib_generation = snapshot.fib_generation;
     }
-    guard.afxdp.bump_fib_generation(snapshot.fib_generation);
     refresh_status(guard);
+    // #3767 M2: persist the accepted bump. Previously bump_fib mutated
+    // guard.status.last_fib_generation and guard.snapshot.fib_generation in
+    // RAM only (no persist_state), so a route-only overlay bump to gen N left
+    // the on-disk state at gen N-1 — a helper/host restart then booted from a
+    // stale FIB generation the control plane already considered applied.
+    *persist_state = true;
 }

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -71,6 +71,34 @@ fn run_request(state: Arc<Mutex<ServerState>>, request: ControlRequest) -> Contr
     response
 }
 
+/// Like `run_request` but drives against a caller-supplied `state_file`
+/// and does NOT remove it, so a test can assert what the handler persisted
+/// to disk (used by the #3767 M2 bump-persistence test).
+fn run_request_on_file(
+    state: Arc<Mutex<ServerState>>,
+    request: ControlRequest,
+    state_file: &str,
+) -> ControlResponse {
+    let (mut client, server) =
+        std::os::unix::net::UnixStream::pair().expect("control socket pair");
+    let running = Arc::new(AtomicBool::new(true));
+    let handle = {
+        let state_file = state_file.to_string();
+        std::thread::spawn(move || handle_stream(server, &state_file, state, running))
+    };
+
+    serde_json::to_writer(&mut client, &request).expect("write request");
+    std::io::Write::write_all(&mut client, b"\n").expect("newline");
+
+    let response: ControlResponse =
+        serde_json::from_reader(std::io::BufReader::new(client)).expect("read response");
+    handle
+        .join()
+        .expect("handler thread")
+        .expect("handler result");
+    response
+}
+
 fn req(request_type: &str) -> ControlRequest {
     ControlRequest {
         request_type: request_type.to_string(),
@@ -572,6 +600,176 @@ fn bump_fib_generation_updates_status_and_stored_snapshot() {
         7,
         "bump must rewrite the stored snapshot's fib_generation"
     );
+}
+
+/// #3767 H4: bump_fib_generation must version-gate exactly like
+/// apply_snapshot. A mixed-version / corrupt client (version != protocol)
+/// must be REJECTED before mutating any validation state — status,
+/// stored snapshot, and worker FIB generation all stay at the prior value.
+#[test]
+fn bump_fib_generation_rejects_wrong_protocol_version() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+    // Seed a stored snapshot at fib_generation 1.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 1,
+            fib_generation: 1,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    let worker_fib_before = state.lock().expect("state").afxdp.fib_generation();
+    let mut request = req("bump_fib_generation");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION - 1,
+        fib_generation: 7,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request(state.clone(), request);
+    assert!(!response.ok, "wrong-version bump must be rejected");
+    assert!(
+        response
+            .error
+            .contains("unsupported snapshot protocol version"),
+        "unexpected error: {}",
+        response.error
+    );
+    let guard = state.lock().expect("state");
+    assert_eq!(
+        guard.status.last_fib_generation, 1,
+        "rejected bump must not advance last_fib_generation"
+    );
+    assert_eq!(
+        guard.snapshot.as_ref().expect("stored snapshot").fib_generation,
+        1,
+        "rejected bump must not rewrite the stored snapshot"
+    );
+    assert_eq!(
+        guard.afxdp.fib_generation(),
+        worker_fib_before,
+        "rejected bump must not advance the worker FIB generation"
+    );
+}
+
+/// #3767 H5: bump_fib_generation must refuse a generation ROLLBACK. Flow-
+/// cache validation is equality based, so publishing a strictly-lower
+/// fib_generation would revive cache entries a prior bump invalidated
+/// (stale forwarding after a route withdrawal / failover). The rejected
+/// bump must leave status, stored snapshot, and worker FIB generation at
+/// the last accepted value.
+#[test]
+fn bump_fib_generation_rejects_generation_rollback() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+    // Seed a stored snapshot at fib_generation 5.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 1,
+            fib_generation: 5,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // A forward bump to 7 is accepted (monotone).
+    {
+        let mut request = req("bump_fib_generation");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            fib_generation: 7,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request(state.clone(), request).ok);
+    }
+    // A rollback to 3 (< current 7) must be refused.
+    let mut request = req("bump_fib_generation");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        fib_generation: 3,
+        generated_at: chrono::Utc::now(),
+        ..ConfigSnapshot::default()
+    });
+    let response = run_request(state.clone(), request);
+    assert!(!response.ok, "rollback bump must be rejected");
+    assert!(
+        response.error.contains("fib generation rollback rejected"),
+        "unexpected error: {}",
+        response.error
+    );
+    let guard = state.lock().expect("state");
+    assert_eq!(
+        guard.status.last_fib_generation, 7,
+        "rejected rollback must not lower last_fib_generation"
+    );
+    assert_eq!(
+        guard.snapshot.as_ref().expect("stored snapshot").fib_generation,
+        7,
+        "rejected rollback must not rewrite the stored snapshot"
+    );
+    assert_eq!(
+        guard.afxdp.fib_generation(),
+        7,
+        "rejected rollback must not revive an old worker FIB generation"
+    );
+}
+
+/// #3767 M2: an accepted bump_fib_generation must PERSIST the new
+/// generation. Previously the handler mutated status + stored snapshot in
+/// RAM only (no persist_state), so a route-only overlay bump to gen N left
+/// the on-disk state at gen N-1 and a restart booted from a stale FIB
+/// generation the control plane already considered applied.
+#[test]
+fn bump_fib_generation_persists_bumped_generation() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+    let state_file = unique_state_file("bump-persist");
+    // Seed apply persists the state file at fib_generation 1.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 1,
+            fib_generation: 1,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    // Route-only bump to 7.
+    {
+        let mut request = req("bump_fib_generation");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            fib_generation: 7,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    // The on-disk state a restart would boot from must carry gen 7, not the
+    // seed apply's stale gen 1.
+    let bytes = std::fs::read(&state_file).expect("read persisted state file");
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("parse persisted state file");
+    assert_eq!(
+        persisted["snapshot"]["fib_generation"].as_u64(),
+        Some(7),
+        "persisted snapshot must carry the bumped fib_generation"
+    );
+    assert_eq!(
+        persisted["status"]["last_fib_generation"].as_u64(),
+        Some(7),
+        "persisted status must carry the bumped fib_generation"
+    );
+    let _ = std::fs::remove_file(&state_file);
 }
 
 // --- apply_snapshot integrity preflight (#1606 / #1642 class) -----------


### PR DESCRIPTION
Closes #3767.

`bump_fib_generation` mutates dataplane validation state (status +
stored snapshot + worker FIB generation) but, unlike `apply_snapshot`,
carried none of apply's guards. codex-review-161 flagged three defects
(cluster H4 + H5 + M2, same handler / same coordinator method).

## H4 — no protocol-version gate

`server/handlers/snapshot.rs::bump_fib` checked only snapshot presence;
it never checked `snapshot.version != CONFIG_SNAPSHOT_PROTOCOL_VERSION`
the way `apply` does. A mixed-version / corrupt client with version=0
was accepted and mutated status + stored snapshot + worker validation
FIB generation.

Fix: reject a wrong protocol version, mirroring `apply`. The Go
`Manager.BumpFIBGeneration` now stamps the bump snapshot with
`ProtocolVersion` (previously it sent `&ConfigSnapshot{FIBGeneration:
newGen}` with version=0), so a legitimate route-only bump still passes
the new gate — without this, every real bump would be rejected and FIB
invalidation would silently stop.

## H5 — accepts generation rollback (revives stale flow-cache decisions)

`Coordinator::bump_fib_generation` had no monotonicity check. Flow-cache
validation is EQUALITY based, not monotone
(`flow_cache.rs`: `entry.stamp.fib_generation != lookup.fib_generation`),
so publishing an OLD `fib_generation` (stale / duplicate / buggy control
message, or a shim counter reset to a lower value) makes
previously-invalidated cache entries match validation again → cached
forwarding reused after a route withdrawal / failover route change.

Fix: refuse a value strictly lower than the current in-memory
`validation.fib_generation` (the method returns `bool`; the handler
fails closed on refusal, mutating nothing). A route-only overlay bump is
monotone by construction on the Go side (the shim counter only
increments). The full-snapshot generation transition path
(`refresh_runtime_snapshot` / reconcile `apply_snapshot`) assigns
`self.validation` directly and is intentionally NOT gated, so a
legitimate config-transition reset still lands.

## M2 — bump is not persisted

The handler mutated `guard.status.last_fib_generation` and
`guard.snapshot.fib_generation` in RAM only; it had no `persist_state`
parameter. After a route-only overlay bump to gen N, a helper/host
restart booted from persisted gen N-1 → a stale FIB generation the
control plane already considered applied.

Fix: an accepted bump now sets `persist_state`, so the persisted status
+ snapshot advance with the bump.

## Tests (RED-on-revert)

At the real `handle_stream` call site (`server/tests.rs`):

- `bump_fib_generation_rejects_wrong_protocol_version` (H4)
- `bump_fib_generation_rejects_generation_rollback` (H5 — the accepted
  forward bump lands, the rollback is refused, and status / stored
  snapshot / worker FIB gen all stay at the last accepted value)
- `bump_fib_generation_persists_bumped_generation` (M2 — the on-disk
  state a restart would boot from carries the bumped generation)

All three were verified RED against pre-fix behavior. Full
`cargo test --release` green (3388 lib + 46/8/16/1 harness tests, 0
failed); `go test ./pkg/dataplane/userspace/` green.

fib-generation is forwarding state, not session-sync state, so this does
not warrant `make test-failover`.

Doc: `docs/flow-cache-simplification.md` gains a "FIB-generation bump
gating (#3767)" section next to the existing validation-model and #3048
neighbor-MAC-change coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
