### PR TITLE
config: type the qualified-next-hop preference leaf at the commit gate (#3827)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-01 — #3827: type the qualified-next-hop `preference` leaf (Go commit gate)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: #3771/#3826 follow-up (Low). The route-level `preference` leaf
+    is typed `ValueInteger` + `ValidateInteger(0, maxWireI32)` at the Go commit
+    boundary (#3771), but the `qualified-next-hop <addr> preference <n>` leaf
+    (schema_routing.go) was UNTYPED. The compiler folds a qualified-next-hop
+    preference into the same `route.Preference` i32 wire field
+    (compiler_routing.go), so a negative / i32-overflow preference expressed
+    via the qualified-next-hop syntax bypassed the primary Go gate and was
+    caught only by the Rust `RoutePreferenceOutOfRange` backstop — an opaque
+    snapshot rejection with retained-prior-state instead of a commit error
+    naming the leaf. FIX: mirror the exact route-level typing onto the qnh
+    `preference` leaf (reuse the existing `maxWireI32` const). Go-only, no wire
+    change. RED-on-revert: reverting the typing makes negative / overflow qnh
+    preferences accept again, so the reject assertions fire RED (verified by
+    temporarily reverting: `-1` accepted, tests FAIL). Valid qnh
+    preference/metric/interface still commit. `go test ./pkg/config/...` green,
+    `go build ./...` green, gofmt + vet clean.
+  - **File(s)**: pkg/config/schema_routing.go,
+    pkg/config/schema_route_qnh_preference_3827_test.go, docs/config-schema.md
+
 ## 2026-07-01 — #3756 H14: attributes-match static per-test string fields
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3540,7 +3540,23 @@ of installing silently and then vanishing from the dataplane.
   link-local form above, both shapes); `discard` / `reject` / `next-table` /
   `qualified-next-hop ... interface ...` are declared children of the `route`
   node, so a no-next-hop blackhole/leak route and the link-local-IPv6
-  qualified-next-hop form still commit. `preference` is likewise declared.
+  qualified-next-hop form still commit.
+- **preference (#3771, #3827)** — BOTH the route-level `preference` leaf
+  (#3771) AND the `qualified-next-hop <addr> preference <n>` leaf (#3827) are
+  typed `ValueInteger` + `ValidateInteger(0, maxWireI32)`: a non-negative
+  administrative distance representable on the i32 wire field the compiler
+  folds every preference into (`route.Preference`, compiler_routing.go). A
+  negative (would sort ahead of every route in the Rust FIB tie-break),
+  non-numeric, or i32-overflowing preference is a commit error naming the
+  leaf. This is the primary gate; the Rust helper backstops the wire bound
+  (`RoutePreferenceOutOfRange`) with a fail-closed snapshot rejection for a
+  corrupt / version-drifted snapshot. Typing the qualified-next-hop leaf
+  (#3827) closed the completeness gap where a bad preference expressed via the
+  qualified-next-hop syntax skipped the Go gate and reached only the opaque
+  Rust backstop (retained-prior-state instead of a commit diagnostic).
+  Fail-on-revert tests: `pkg/config/schema_route_preference_3771_test.go`
+  (route-level) and `pkg/config/schema_route_qnh_preference_3827_test.go`
+  (qualified-next-hop).
 
 Before #2448 both leaves were accepted untyped: the Rust FIB builder
 (`userspace-dp forwarding_build/fib.rs populate_routes`) soft-skips a

--- a/pkg/config/schema_route_qnh_preference_3827_test.go
+++ b/pkg/config/schema_route_qnh_preference_3827_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3827 (Low, #3771/#3826 follow-up): the qualified-next-hop `preference`
+// leaf is a typed integer bounded to [0, 2147483647] at the Go commit
+// boundary, mirroring the route-level `preference` leaf (#3771). The
+// compiler folds a qualified-next-hop preference into the same route.Preference
+// i32 wire field (compiler_routing.go), so an untyped qnh preference let a
+// negative / i32-overflow value slip past the primary Go gate and land on the
+// Rust snapshot backstop (RoutePreferenceOutOfRange) — an opaque
+// snapshot-rejection with retained-prior-state instead of a clean commit error
+// naming the leaf.
+//
+// FAIL-ON-REVERT: dropping the `valueType: ValueInteger, validator:
+// ValidateInteger(0, maxWireI32)` on the qualified-next-hop `preference` leaf
+// makes the untyped leaf accept any token again, so the negative/overflow
+// reject assertions below fire RED.
+func TestStaticRouteQualifiedNextHopPreference_SchemaGate(t *testing.T) {
+	reject := func(val string) {
+		t.Helper()
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 0.0.0.0/0 qualified-next-hop 192.168.1.1 preference "+val)
+		if err := SchemaValidate(tree, nil); err == nil {
+			t.Fatalf("qualified-next-hop preference %q: expected SchemaValidate to reject, got nil", val)
+		}
+	}
+	accept := func(val string) {
+		t.Helper()
+		tree := flatTreeFromSets(t,
+			"set routing-options static route 0.0.0.0/0 qualified-next-hop 192.168.1.1 preference "+val)
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("qualified-next-hop preference %q: expected SchemaValidate to accept, got %v", val, err)
+		}
+	}
+	// Negative (the primary-gate gap), non-numeric, and i32-overflow reject.
+	for _, val := range []string{"-1", "-2147483648", "notanumber", "2147483648", "4294967295"} {
+		reject(val)
+	}
+	// 0 (most-preferred) and normal values through the i32 ceiling accept.
+	for _, val := range []string{"0", "1", "5", "100", "2147483647"} {
+		accept(val)
+	}
+}
+
+// #3827: the reject error names the offending value so the operator sees which
+// qualified-next-hop preference was out of range (commit-time diagnostic, not
+// the opaque Rust snapshot rejection).
+func TestStaticRouteQualifiedNextHopPreference_NegativeErrorMentionsValue(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set routing-options static route ::/0 qualified-next-hop 2001:db8::1 preference -7")
+	err := SchemaValidate(tree, nil)
+	if err == nil {
+		t.Fatal("expected a negative qualified-next-hop preference to be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "-7") {
+		t.Fatalf("error %q must name the out-of-range value -7", err.Error())
+	}
+}
+
+// #3827: a valid qualified-next-hop preference (with interface + metric
+// siblings) still commits — the typing tightens the value slot without
+// breaking the surrounding qualified-next-hop grammar.
+func TestStaticRouteQualifiedNextHopPreference_ValidCommits(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set routing-options static route 10.0.0.0/24 qualified-next-hop 192.168.1.1 preference 10",
+		"set routing-options static route 10.0.0.0/24 qualified-next-hop 192.168.1.1 metric 20",
+		"set routing-options static route 10.0.0.0/24 qualified-next-hop 192.168.1.1 interface ge-0-0-0")
+	if err := SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("valid qualified-next-hop preference/metric/interface: SchemaValidate rejected: %v", err)
+	}
+}

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -84,9 +84,17 @@ func staticRouteNode() *schemaNode {
 					"interface": {desc: "Egress interface for this next-hop", args: 1, placeholder: "<interface-name>", children: nil},
 				}},
 			"qualified-next-hop": {desc: "Qualified next-hop", args: 1, placeholder: "<gateway>", children: map[string]*schemaNode{
-				"interface":  {desc: "Egress interface", args: 1, placeholder: "<interface-name>", children: nil},
-				"preference": {desc: "Preference", args: 1, placeholder: "<value>", children: nil},
-				"metric":     {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
+				"interface": {desc: "Egress interface", args: 1, placeholder: "<interface-name>", children: nil},
+				// #3827 (Low): the qualified-next-hop preference folds into
+				// route.Preference (compiler_routing.go), the same i32 wire field
+				// gated for the route-level `preference` leaf. Mirror that typing
+				// so a negative / i32-overflow value is rejected at commit (naming
+				// the leaf) instead of only tripping the Rust snapshot backstop
+				// (RoutePreferenceOutOfRange) with retained-prior-state.
+				"preference": {desc: "Preference", args: 1, placeholder: "<value>",
+					valueType: ValueInteger, valueDesc: "Route preference / administrative distance (0..2147483647; lower = more preferred, default 5)",
+					valueExamples: []string{"5", "100"}, validator: ValidateInteger(0, maxWireI32), children: nil},
+				"metric": {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
 			}},
 			"discard":    {desc: "Discard (blackhole) route", children: nil},
 			"reject":     {desc: "Reject route (send ICMP unreachable)", children: nil},


### PR DESCRIPTION
Closes #3827

## Problem

Follow-up from the #3826 (#3771) hostile review, finding 3 (Low). The
route-level `preference` leaf is typed `ValueInteger` +
`ValidateInteger(0, maxWireI32)` at the Go commit boundary (#3771), so a
negative / i32-overflow route preference is rejected at commit. But the
`qualified-next-hop <addr> preference <n>` schema leaf
(`schema_routing.go`, in `staticRouteNode()`) remained **untyped**.

The compiler folds a qualified-next-hop preference into the same
`route.Preference` i32 wire field (`compiler_routing.go`), so a negative
/ overflowing preference expressed via the qualified-next-hop syntax
**bypassed the primary Go gate** and was caught only by the Rust
`RoutePreferenceOutOfRange` backstop (#3826) — a fail-closed *snapshot
rejection* (stale forwarding retained) instead of a clean commit-time
error naming the bad leaf.

**Severity: Low.** No security invariant broken (no negative preference
reaches the live FIB — the Rust backstop fail-closes). This is a
primary-gate *completeness* gap.

## Fix

Mirror the exact route-level typing onto the qualified-next-hop
`preference` leaf (`schema_routing.go`), reusing the existing
`maxWireI32` const. A negative / non-numeric / i32-overflow value is now
rejected at commit (naming the leaf) while `0..2147483647` and the
surrounding `interface` / `metric` siblings still commit. **Go-only, no
wire change.**

## Tests (RED-on-revert)

`pkg/config/schema_route_qnh_preference_3827_test.go` (uses
`ParseSetCommand` + `SetPath` per the flat-set testing rule):

- `TestStaticRouteQualifiedNextHopPreference_SchemaGate` — qnh preference
  `-1` / `-2147483648` / `notanumber` / `2147483648` / `4294967295`
  reject at commit; `0` / `1` / `5` / `100` / `2147483647` accept.
- `TestStaticRouteQualifiedNextHopPreference_NegativeErrorMentionsValue`
  — the reject error names the offending value (`-7`).
- `TestStaticRouteQualifiedNextHopPreference_ValidCommits` — a valid
  preference with `metric` + `interface` siblings still commits.

**RED-on-revert verified:** temporarily reverting the typing makes the
untyped leaf accept any token again — `-1` accepted, the reject
assertions fire RED. Re-applying the typing returns all green.

## Validation

- `go test ./pkg/config/...` — green
- `go build ./...` — green
- `gofmt` + `go vet ./pkg/config/` — clean

## Docs

`docs/config-schema.md`: corrected the "what is NOT rejected" bullet
(preference was no longer merely declared) and added a dedicated
preference bullet covering both the route-level (#3771) and
qualified-next-hop (#3827) typed gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
