### PR TITLE
userspace-dp: cold-path histogram slot for wildcard/global-only policies (#3783)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27526,3 +27526,36 @@ top.
   pkg/config/schema_validators.go (maxWireI32),
   pkg/config/schema_route_preference_3771_test.go (commit-gate tests),
   userspace-dp/src/afxdp/forwarding/README.md, userspace-dp/src/FEATURES.md
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3783 — cold-path latency histogram slot coverage for
+  wildcard/global-only policies. `PolicyState::configured_zone_pairs()`
+  (the input to `ColdPathSlotMap`) enumerated ONLY the exact
+  `zone_pair_index` keys, so a catch-all deployment (`from-zone any
+  to-zone <z>` / `to-zone any` / `from-zone any to-zone any` /
+  `security policies global`) produced zero exact pairs — the concrete
+  `(from,to)` a packet traverses had no slot and the #1635 first-packet
+  latency sample was silently dropped on the `lookup_slot` miss (dark
+  telemetry for the common vSRX design). Fix: added
+  `PolicyState.concrete_zone_ids` (the non-zero/non-reserved zone-id
+  universe from `zone_name_to_id`, captured at parse time) and reworked
+  `configured_zone_pairs()` to emit two tiers — exact pairs FIRST (slot
+  priority), then the concrete pairs each wildcard/global scope can match
+  (from-any → every `(f,Z)`; to-any → every `(F,t)`; both-any →
+  cross-product; `junos-global` → cross-product narrowed by its
+  `GlobalZoneScope`). Config-derived + deterministic → HA-symmetric slot
+  layout (histogram counts are per-node local telemetry, not wire-synced;
+  no session-sync/wire change → no test-failover needed). Surplus past 255
+  slots still handled by `ColdPathSlotMap::build`'s `overflow_active`;
+  exact pairs win because assigned first. Added 6 tests (2 end-to-end
+  through `parse_policy_state → configured_zone_pairs → ColdPathSlotMap →
+  lookup_slot` in cold_path_hist.rs, 4 semantics in policy_tests.rs);
+  verified RED-on-revert (5 fail on the old exact-only body, exact-only
+  no-regression test stays green). Full `cargo test --release` green
+  (3404 lib + aux binaries, 0 failed).
+- **File(s)**: userspace-dp/src/policy.rs (concrete_zone_ids field +
+  Default + parse populate + configured_zone_pairs two-tier rewrite),
+  userspace-dp/src/afxdp/cold_path_hist.rs (ColdPathSlotMap doc + 2
+  end-to-end tests), userspace-dp/src/policy_tests.rs (4 semantics tests),
+  docs/userspace-dataplane-architecture.md (#3783 histogram-slot-coverage
+  paragraph)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -645,6 +645,32 @@ probes per cold-path evaluation — no N×N materialization of concrete pairs. A
 deliberately not applied to host-bound traffic to preserve the management
 lifeline guarantee. This lifted the #3018 interim commit reject.
 
+**Cold-path histogram slot coverage for wildcard/global policies (#3783).**
+The first-packet latency histogram (#1635, sparse slot map since #3075) is
+keyed at record time on the CONCRETE `(from_zone_id, to_zone_id)` a packet
+traverses (`poll_descriptor::lookup_slot`), and its slot set comes from
+`PolicyState::configured_zone_pairs()`. That function originally enumerated
+ONLY the exact `zone_pair_index` keys, so a deployment whose only rules are
+`from-zone any to-zone <z>` / `to-zone any` / `from-zone any to-zone any` or
+`security policies global` produced ZERO exact pairs — the concrete pair a
+packet actually took had no slot and the latency sample was silently dropped,
+dark-ing the instrument for exactly the catch-all designs operators commonly
+deploy. `configured_zone_pairs()` now emits two tiers: (1) the exact pairs
+FIRST (they keep slot priority so a mixed config never starves a named pair),
+then (2) the concrete pairs the wildcard/global scopes can match, materialized
+from the snapshot's concrete-zone universe (`PolicyState::concrete_zone_ids`,
+every non-zero non-reserved id in `zone_name_to_id`) constrained by each scope —
+`from-zone any to-zone Z` → every `(f, Z)`; `to-zone any from-zone F` →
+every `(F, t)`; both-any → the full cross-product; a `junos-global` rule → the
+cross-product narrowed by its `match from-zone`/`to-zone` `GlobalZoneScope`
+(#3148). The expansion is config-derived and deterministic, so both HA nodes
+build the identical slot map from the identical config (the histogram counts
+are per-node local telemetry scraped via status/Prometheus — not wire-synced —
+but the slot LAYOUT stays symmetric). If the union exceeds the 255-slot
+capacity the surplus is dropped by `ColdPathSlotMap::build` and surfaced via its
+`overflow_active` flag; exact pairs are assigned first, so they win under
+pressure.
+
 **Global policy zone context (#3148).** A Junos global policy may carry optional
 `match { from-zone <z>; to-zone <z>; }` to scope it to one zone pair (or one
 wildcard side) instead of every zone pair. Such a rule keeps the

--- a/userspace-dp/src/afxdp/cold_path_hist.rs
+++ b/userspace-dp/src/afxdp/cold_path_hist.rs
@@ -145,6 +145,15 @@ pub(in crate::afxdp) fn zone_pair_packed_key(from_zone_id: u16, to_zone_id: u16)
 /// removed). A miss (pair absent) means no slot assigned (capacity
 /// exhausted); the sample is dropped at the hot path.
 ///
+/// The map is built from `PolicyState::configured_zone_pairs()`, which
+/// (#3783) enumerates not only the EXACT configured zone-pairs but also the
+/// concrete pairs implied by the `from-zone any` / `to-zone any` / both-any
+/// wildcard tiers (#3090) and by `junos-global` rules (#3148). Without that
+/// expansion a wildcard/global-only deployment (the common vSRX catch-all
+/// design) produced no exact pairs, so the concrete `(from, to)` a packet
+/// traverses had no slot and its first-packet latency sample was silently
+/// dropped — the histogram went dark for exactly those configs.
+///
 /// `inverse[slot]` is the reverse map used by the status path to emit
 /// per-zone-pair labels for the sparse wire encoding.
 #[derive(Clone, Debug)]
@@ -1289,6 +1298,126 @@ mod tests {
     fn lookup_slot_returns_none_for_unmapped_pair() {
         let (map, _) = ColdPathSlotMap::build(None, &[(1u16, 2u16)]);
         assert_eq!(lookup_slot(&map, 9, 9), None);
+    }
+
+    // === #3783: wildcard / global-only policy histogram slot coverage ===
+
+    /// A deployment whose ONLY policies are `from-zone any to-zone <z>` and a
+    /// `security policies global` rule produces ZERO exact zone-pair entries.
+    /// The cold-path recorder keys on the CONCRETE ingress/egress zone-ids a
+    /// packet traverses (`poll_descriptor::lookup_slot`), so before #3783 the
+    /// slot map had no slot for `(trust, untrust)` and the first-packet
+    /// latency sample was silently dropped. This drives the real pipeline
+    /// (`parse_policy_state` → `configured_zone_pairs` → `ColdPathSlotMap`) and
+    /// asserts the concrete pairs the wildcard/global tiers match DO resolve a
+    /// slot. RED on revert: the pre-#3783 `configured_zone_pairs` returns the
+    /// empty exact set, so every `lookup_slot` below returns `None`.
+    #[test]
+    fn cold_path_slot_assigned_for_wildcard_and_global_only_policy() {
+        use crate::protocol::PolicyRuleSnapshot;
+        use rustc_hash::FxHashMap;
+
+        const TRUST: u16 = crate::test_zone_ids::TEST_TRUST_ZONE_ID;
+        const UNTRUST: u16 = crate::test_zone_ids::TEST_UNTRUST_ZONE_ID;
+        const DMZ: u16 = crate::test_zone_ids::TEST_DMZ_ZONE_ID;
+
+        let mut zone_name_to_id: FxHashMap<String, u16> = FxHashMap::default();
+        zone_name_to_id.insert("trust".to_string(), TRUST);
+        zone_name_to_id.insert("untrust".to_string(), UNTRUST);
+        zone_name_to_id.insert("dmz".to_string(), DMZ);
+
+        let rules = vec![
+            // from-zone any to-zone untrust — single-wildcard tier, no exact pair.
+            PolicyRuleSnapshot {
+                name: "wild-out".to_string(),
+                from_zone: "any".to_string(),
+                to_zone: "untrust".to_string(),
+                source_addresses: vec!["any".to_string()],
+                destination_addresses: vec!["any".to_string()],
+                applications: vec!["any".to_string()],
+                action: "permit".to_string(),
+                ..Default::default()
+            },
+            // Unscoped junos-global permit — matches every concrete pair.
+            PolicyRuleSnapshot {
+                name: "glob".to_string(),
+                from_zone: "junos-global".to_string(),
+                to_zone: "junos-global".to_string(),
+                source_addresses: vec!["any".to_string()],
+                destination_addresses: vec!["any".to_string()],
+                applications: vec!["any".to_string()],
+                action: "permit".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let state = crate::policy::parse_policy_state("deny", &rules, &zone_name_to_id);
+        let pairs = state.configured_zone_pairs();
+        let (map, zeroed) = ColdPathSlotMap::build(None, &pairs);
+        assert!(zeroed.is_empty(), "fresh build zeroes nothing");
+
+        // trust->untrust: matched by BOTH the from-any and the global rule.
+        assert!(
+            lookup_slot(&map, TRUST, UNTRUST).is_some(),
+            "trust->untrust (wildcard + global) must have a cold-path slot"
+        );
+        // dmz->trust: matched ONLY by the unscoped global.
+        assert!(
+            lookup_slot(&map, DMZ, TRUST).is_some(),
+            "dmz->trust (global-only) must have a cold-path slot"
+        );
+        // untrust->untrust intrazone: covered by from-any to-zone untrust.
+        assert!(
+            lookup_slot(&map, UNTRUST, UNTRUST).is_some(),
+            "untrust->untrust (from-any to-zone untrust) must have a cold-path slot"
+        );
+    }
+
+    /// A `security policies global match { from-zone trust; to-zone untrust; }`
+    /// rule (#3148 scoped global) must expand to EXACTLY its pinned pair — not
+    /// the full concrete cross-product — so it gets a slot without needlessly
+    /// broadening the slot map. A pair outside the scope stays unmapped.
+    #[test]
+    fn cold_path_slot_scoped_global_pins_single_pair() {
+        use crate::protocol::PolicyRuleSnapshot;
+        use rustc_hash::FxHashMap;
+
+        const TRUST: u16 = crate::test_zone_ids::TEST_TRUST_ZONE_ID;
+        const UNTRUST: u16 = crate::test_zone_ids::TEST_UNTRUST_ZONE_ID;
+        const DMZ: u16 = crate::test_zone_ids::TEST_DMZ_ZONE_ID;
+
+        let mut zone_name_to_id: FxHashMap<String, u16> = FxHashMap::default();
+        zone_name_to_id.insert("trust".to_string(), TRUST);
+        zone_name_to_id.insert("untrust".to_string(), UNTRUST);
+        zone_name_to_id.insert("dmz".to_string(), DMZ);
+
+        let rules = vec![PolicyRuleSnapshot {
+            name: "scoped-glob".to_string(),
+            from_zone: "junos-global".to_string(),
+            to_zone: "junos-global".to_string(),
+            match_from_zone: "trust".to_string(),
+            match_to_zone: "untrust".to_string(),
+            source_addresses: vec!["any".to_string()],
+            destination_addresses: vec!["any".to_string()],
+            applications: vec!["any".to_string()],
+            action: "permit".to_string(),
+            ..Default::default()
+        }];
+
+        let state = crate::policy::parse_policy_state("deny", &rules, &zone_name_to_id);
+        let pairs = state.configured_zone_pairs();
+        let (map, _z) = ColdPathSlotMap::build(None, &pairs);
+
+        assert!(
+            lookup_slot(&map, TRUST, UNTRUST).is_some(),
+            "scoped global's pinned pair must have a slot"
+        );
+        // Not in scope — must stay unmapped (no over-broadening).
+        assert_eq!(
+            lookup_slot(&map, DMZ, TRUST),
+            None,
+            "a pair outside the scoped global's match context must NOT get a slot"
+        );
     }
 
     #[test]

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -2038,6 +2038,18 @@ pub(crate) struct PolicyState {
     both_any_indices: Vec<usize>,
     /// Indices of global rules (from_zone or to_zone = "junos-global").
     global_indices: Vec<usize>,
+    /// #3783: the concrete (interface-assignable) zone-id universe for THIS
+    /// snapshot — every non-zero, non-reserved id in `zone_name_to_id`, sorted
+    /// and deduplicated. A wildcard (`from-zone any` / `to-zone any`) or an
+    /// unscoped `junos-global` policy has no EXACT `(from,to)` pair, so the
+    /// concrete pair a packet actually traverses would have no cold-path
+    /// latency histogram slot; `configured_zone_pairs` materializes those pairs
+    /// from this universe constrained by each wildcard/global scope so the
+    /// #1635 histogram is not dark for the common vSRX catch-all design.
+    /// Config-derived and deterministic, so both HA nodes derive the identical
+    /// slot map from the identical config (the histogram is local per-node
+    /// telemetry — not wire-synced — but its slot layout stays symmetric).
+    concrete_zone_ids: Vec<u16>,
     /// #1606: deduplicated address-book table. Rules reference
     /// books by dense `u32` index (`PolicyRule::source_book_idxs`).
     pub(crate) books: Vec<BookEntry>,
@@ -2096,6 +2108,9 @@ impl Default for PolicyState {
             to_any_index: FxHashMap::default(),
             both_any_indices: Vec::new(),
             global_indices: Vec::new(),
+            // #3783: the Default state carries no zones, so the wildcard/global
+            // histogram-slot expansion has an empty concrete-zone universe.
+            concrete_zone_ids: Vec::new(),
             books: Vec::new(),
             book_id_to_idx: FxHashMap::default(),
             has_junos_host_rules: false,
@@ -2237,23 +2252,121 @@ impl PolicyState {
         }
     }
 
-    /// #1635: the set of concrete `(from_zone_id, to_zone_id)` pairs the
-    /// configured policy distinguishes, used to build the cold-path
-    /// histogram's direct slot map. Returns a deduplicated, sorted Vec
-    /// for deterministic slot assignment. Pairs that reference the
-    /// `junos-global` sentinel zone-id are excluded — global rules don't
-    /// name a concrete zone-pair and would over-broaden the slot map.
+    /// #1635/#3783: the set of concrete `(from_zone_id, to_zone_id)` pairs the
+    /// configured policy can distinguish, used to build the cold-path
+    /// histogram's direct slot map. The recording site
+    /// (`poll_descriptor::lookup_slot`) keys on the CONCRETE ingress/egress
+    /// zone-ids a packet traverses, so every concrete pair a configured policy
+    /// can match MUST appear here or its first-packet latency sample is
+    /// silently dropped on a slot-map miss.
+    ///
+    /// Two tiers, in slot-priority order:
+    ///
+    ///   1. EXACT `zone_pair_index` pairs (the historical set). Emitted FIRST
+    ///      so a mixed config never starves an explicitly-named pair of its
+    ///      slot behind a large wildcard expansion.
+    ///   2. #3783 wildcard/global expansion — the concrete pairs implied by the
+    ///      `from-zone any` / `to-zone any` / `from-zone any to-zone any`
+    ///      tiers (#3090) and by `junos-global` rules (#3148), each constrained
+    ///      by its scope and materialized against `concrete_zone_ids`. Without
+    ///      this a catch-all-only deployment (`from-zone any to-zone <z>` /
+    ///      `security policies global`) produced ZERO exact pairs, so the
+    ///      histogram was dark for exactly the common vSRX catch-all design.
+    ///
+    /// Reserved sentinels (`junos-host` / `junos-global`, id
+    /// `>= ZONE_ID_RESERVED_MIN`) and the id-0 unknown-zone are excluded on both
+    /// tiers — they never form a transit zone-pair the histogram measures. The
+    /// two tiers are each individually sorted and mutually disjoint, so slot
+    /// assignment is deterministic (HA-symmetric — both nodes derive the
+    /// identical slot map from the identical config). If the union exceeds the
+    /// 255-slot capacity the surplus is dropped by `ColdPathSlotMap::build`
+    /// (its `overflow_active` flag surfaces the starvation to operators) —
+    /// exact pairs win because they are assigned first.
     pub(crate) fn configured_zone_pairs(&self) -> Vec<(u16, u16)> {
-        let mut pairs: Vec<(u16, u16)> = self
+        use std::collections::BTreeSet;
+
+        // A concrete, addressable transit zone id: non-zero and outside the
+        // reserved sentinel range.
+        #[inline]
+        fn is_concrete(id: u16) -> bool {
+            id != 0 && id < ZONE_ID_RESERVED_MIN
+        }
+
+        // Tier 1: exact configured pairs (historical behavior).
+        let exact: BTreeSet<(u16, u16)> = self
             .zone_pair_index
             .keys()
             .map(|&key| (((key >> 16) & 0xffff) as u16, (key & 0xffff) as u16))
-            .filter(|&(from, to)| {
-                from < ZONE_ID_RESERVED_MIN && to < ZONE_ID_RESERVED_MIN
-            })
+            .filter(|&(from, to)| is_concrete(from) && is_concrete(to))
             .collect();
-        pairs.sort_unstable();
-        pairs.dedup();
+
+        // The concrete-zone universe a wildcard `any` / unscoped-global side
+        // can resolve to at runtime.
+        let concrete: Vec<u16> = self
+            .concrete_zone_ids
+            .iter()
+            .copied()
+            .filter(|&z| is_concrete(z))
+            .collect();
+
+        // Tier 2: expand the wildcard/global scopes into the concrete pairs
+        // they match. Kept in a separate set so tier-1 retains slot priority.
+        let mut wildcard: BTreeSet<(u16, u16)> = BTreeSet::new();
+
+        // `from-zone any to-zone <Z>`: any concrete ingress zone -> Z.
+        for &to_id in self.from_any_index.keys() {
+            if !is_concrete(to_id) {
+                continue;
+            }
+            for &from in &concrete {
+                wildcard.insert((from, to_id));
+            }
+        }
+        // `to-zone any from-zone <F>`: F -> any concrete egress zone.
+        for &from_id in self.to_any_index.keys() {
+            if !is_concrete(from_id) {
+                continue;
+            }
+            for &to in &concrete {
+                wildcard.insert((from_id, to));
+            }
+        }
+        // `from-zone any to-zone any`: every concrete pair.
+        if !self.both_any_indices.is_empty() {
+            for &from in &concrete {
+                for &to in &concrete {
+                    wildcard.insert((from, to));
+                }
+            }
+        }
+        // `junos-global` rules, each scoped by its optional `match from-zone` /
+        // `match to-zone` context (#3148). `Any` expands to the full concrete
+        // universe; a concrete `Zone(id)` pins that side; a reserved
+        // `Zone(id)` (junos-host) contributes no transit pair.
+        for &idx in &self.global_indices {
+            let rule = &self.rules[idx];
+            let expand_side = |scope: GlobalZoneScope| -> Vec<u16> {
+                match scope {
+                    GlobalZoneScope::Any => concrete.clone(),
+                    GlobalZoneScope::Zone(z) if is_concrete(z) => vec![z],
+                    GlobalZoneScope::Zone(_) => Vec::new(),
+                }
+            };
+            let from_ids = expand_side(rule.global_from_zone);
+            let to_ids = expand_side(rule.global_to_zone);
+            for &from in &from_ids {
+                for &to in &to_ids {
+                    wildcard.insert((from, to));
+                }
+            }
+        }
+
+        // Exact pairs first (slot priority), then the additional wildcard/global
+        // pairs not already covered by an exact pair. Both halves are sorted
+        // (BTreeSet), so the whole assignment is deterministic and HA-symmetric.
+        let mut pairs: Vec<(u16, u16)> = Vec::with_capacity(exact.len() + wildcard.len());
+        pairs.extend(exact.iter().copied());
+        pairs.extend(wildcard.into_iter().filter(|p| !exact.contains(p)));
         pairs
     }
 }
@@ -2299,6 +2412,21 @@ pub(crate) fn parse_policy_state_with_counters(
             action: default_policy.to_string(),
         })?
     };
+    // #3783: capture the concrete (interface-assignable) zone-id universe from
+    // the incoming snapshot's zone table so `configured_zone_pairs` can
+    // materialize the concrete pairs that a wildcard/global-only policy will
+    // actually match — otherwise those pairs get no cold-path histogram slot
+    // and their first-packet latency samples are silently dropped. Reserved
+    // sentinels (junos-host / junos-global, id >= ZONE_ID_RESERVED_MIN) and the
+    // id-0 "unknown zone" are excluded — they never form a transit zone-pair.
+    let mut concrete_zone_ids: Vec<u16> = zone_name_to_id
+        .values()
+        .copied()
+        .filter(|&id| id != 0 && id < ZONE_ID_RESERVED_MIN)
+        .collect();
+    concrete_zone_ids.sort_unstable();
+    concrete_zone_ids.dedup();
+
     let mut state = PolicyState {
         default_action,
         rules: Vec::with_capacity(rules.len()),
@@ -2307,6 +2435,9 @@ pub(crate) fn parse_policy_state_with_counters(
         to_any_index: FxHashMap::default(),
         both_any_indices: Vec::new(),
         global_indices: Vec::new(),
+        // #3783: the concrete-zone universe backing the wildcard/global
+        // histogram-slot expansion (computed above from `zone_name_to_id`).
+        concrete_zone_ids,
         books: Vec::with_capacity(address_books.len()),
         book_id_to_idx: FxHashMap::default(),
         // #3019: armed below if any rule names the `junos-host` self zone.

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -6162,3 +6162,137 @@ fn parse_port_spec_rejects_signed_3606() {
         }])
     );
 }
+
+// === #3783: configured_zone_pairs wildcard/global histogram-slot expansion ===
+
+/// A `from-zone any to-zone untrust` wildcard has no exact zone-pair entry, so
+/// the cold-path histogram would have no slot for the concrete pair a packet
+/// traverses. `configured_zone_pairs` (the slot-map input) must materialize
+/// EVERY concrete `from -> untrust` pair, and nothing with another to-zone
+/// (the wildcard is to-zone-pinned).
+#[test]
+fn configured_zone_pairs_expands_from_any_wildcard() {
+    let zmap = test_zone_name_to_id();
+    let rule = PolicyRuleSnapshot {
+        name: "wild".to_string(),
+        from_zone: "any".to_string(),
+        to_zone: "untrust".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let state = parse_policy_state("deny", &[rule], &zmap);
+    let pairs = state.configured_zone_pairs();
+    for &from in &[
+        TEST_LAN_ZONE_ID,
+        TEST_WAN_ZONE_ID,
+        TEST_TRUST_ZONE_ID,
+        TEST_UNTRUST_ZONE_ID,
+        TEST_SFMIX_ZONE_ID,
+    ] {
+        assert!(
+            pairs.contains(&(from, TEST_UNTRUST_ZONE_ID)),
+            "missing {from}->untrust in {pairs:?}"
+        );
+    }
+    assert!(
+        pairs.iter().all(|&(_, to)| to == TEST_UNTRUST_ZONE_ID),
+        "from-any is to-zone-pinned; unexpected to-zone in {pairs:?}"
+    );
+}
+
+/// `from-zone any to-zone any` must expand to the full concrete cross-product
+/// so every zone-pair a packet can traverse gets a histogram slot.
+#[test]
+fn configured_zone_pairs_expands_both_any() {
+    let zmap = test_zone_name_to_id();
+    let rule = PolicyRuleSnapshot {
+        name: "catch-all".to_string(),
+        from_zone: "any".to_string(),
+        to_zone: "any".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let state = parse_policy_state("deny", &[rule], &zmap);
+    let pairs = state.configured_zone_pairs();
+    // 5 concrete zones ⇒ 25 pairs.
+    assert_eq!(
+        pairs.len(),
+        25,
+        "both-any ⇒ full 5x5 cross-product: {pairs:?}"
+    );
+    assert!(pairs.contains(&(TEST_TRUST_ZONE_ID, TEST_UNTRUST_ZONE_ID)));
+    assert!(pairs.contains(&(TEST_SFMIX_ZONE_ID, TEST_LAN_ZONE_ID)));
+}
+
+/// A scoped `junos-global` policy (`match from-zone trust; to-zone untrust;`)
+/// expands to EXACTLY its pinned pair — not the full cross-product — while an
+/// unscoped global expands to every concrete pair.
+#[test]
+fn configured_zone_pairs_global_scope_semantics() {
+    let zmap = test_zone_name_to_id();
+
+    let scoped = PolicyRuleSnapshot {
+        name: "scoped".to_string(),
+        from_zone: "junos-global".to_string(),
+        to_zone: "junos-global".to_string(),
+        match_from_zone: "trust".to_string(),
+        match_to_zone: "untrust".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let state = parse_policy_state("deny", &[scoped], &zmap);
+    assert_eq!(
+        state.configured_zone_pairs(),
+        vec![(TEST_TRUST_ZONE_ID, TEST_UNTRUST_ZONE_ID)],
+        "scoped global expands to exactly its pinned pair"
+    );
+
+    let unscoped = PolicyRuleSnapshot {
+        name: "unscoped".to_string(),
+        from_zone: "junos-global".to_string(),
+        to_zone: "junos-global".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let state = parse_policy_state("deny", &[unscoped], &zmap);
+    assert_eq!(
+        state.configured_zone_pairs().len(),
+        25,
+        "unscoped global ⇒ full 5x5 cross-product"
+    );
+}
+
+/// No regression for the pure exact-pair case: an exact zone-pair policy still
+/// yields exactly its one pair, with no wildcard-style broadening.
+#[test]
+fn configured_zone_pairs_exact_only_not_overbroadened() {
+    let zmap = test_zone_name_to_id();
+    let rule = PolicyRuleSnapshot {
+        name: "exact".to_string(),
+        from_zone: "trust".to_string(),
+        to_zone: "untrust".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let state = parse_policy_state("deny", &[rule], &zmap);
+    assert_eq!(
+        state.configured_zone_pairs(),
+        vec![(TEST_TRUST_ZONE_ID, TEST_UNTRUST_ZONE_ID)],
+        "exact-only config yields exactly its one pair"
+    );
+}


### PR DESCRIPTION
Closes #3783

## Problem

The #1635 cold-path first-packet latency histogram (sparse slot map
since #3075) records into a slot resolved at packet time by the
**concrete** `(from_zone_id, to_zone_id)` a flow traverses
(`poll_descriptor::lookup_slot`). But the slot set came from
`PolicyState::configured_zone_pairs()`, which enumerated **only** the
exact `zone_pair_index` keys (`userspace-dp/src/policy.rs`).

A deployment whose only rules are `from-zone any to-zone <z>`,
`to-zone any`, `from-zone any to-zone any`, or `security policies global`
produces **zero** exact zone-pair entries, so the concrete pair a packet
actually took had no slot → `lookup_slot` missed → the latency sample was
silently dropped. The instrument that is meant to prove first-packet
policy health was dark for exactly the catch-all designs operators
commonly deploy.

## Fix

- Add `PolicyState.concrete_zone_ids` — the concrete
  (interface-assignable) zone-id universe captured at parse time (every
  non-zero, non-reserved id in `zone_name_to_id`).
- Rework `configured_zone_pairs()` into two slot-priority tiers:
  1. **Exact** `zone_pair_index` pairs first (so a mixed config never
     starves an explicitly-named pair of its slot behind a large wildcard
     expansion).
  2. The concrete pairs each wildcard/global scope can match, expanded
     against `concrete_zone_ids`: `from-any to-zone Z` → every `(f, Z)`;
     `to-any from-zone F` → every `(F, t)`; both-any → the full
     cross-product; a `junos-global` rule → the cross-product narrowed by
     its `GlobalZoneScope` match context (#3148). Reserved sentinels and
     the id-0 unknown-zone are excluded on both tiers.

The two tiers are individually sorted (`BTreeSet`) and mutually disjoint,
so slot assignment is deterministic and **HA-symmetric** — both nodes
derive the identical slot map from the identical config. The histogram
counts are per-node local telemetry (scraped via status/Prometheus, not
wire-synced), so only the slot **layout** needs to agree, and it does; no
session-sync/wire change → no failover exposure. Surplus past the
255-slot capacity is still dropped by `ColdPathSlotMap::build` (its
`overflow_active` flag surfaces the starvation); exact pairs win because
they are assigned first.

## Tests

- **`cold_path_hist.rs`** — end-to-end through the real pipeline
  (`parse_policy_state → configured_zone_pairs → ColdPathSlotMap →
  lookup_slot`): a from-any + unscoped-global-only config resolves a slot
  for `trust→untrust`, `dmz→trust`, and `untrust→untrust` (intrazone); a
  scoped global resolves ONLY its pinned pair and leaves out-of-scope
  pairs unmapped.
- **`policy_tests.rs`** — `configured_zone_pairs` semantics: from-any
  expansion, both-any full cross-product, scoped-vs-unscoped global, and a
  no-regression check that an exact-only config still yields exactly its
  one pair.
- **RED-on-revert verified**: reverting `configured_zone_pairs` to the
  old exact-only body fails all 5 wildcard/global tests while the
  exact-only no-regression test stays green.
- Full `cargo test --release` green (3404 lib + aux binaries, 0 failed).

## Docs

`docs/userspace-dataplane-architecture.md` — new #3783 paragraph in the
policy/wildcard section; `ColdPathSlotMap` module doc updated; `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
