### PR TITLE
userspace-dp: fail closed on swallowed reconcile build failure (#3789)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27559,3 +27559,47 @@ top.
   end-to-end tests), userspace-dp/src/policy_tests.rs (4 semantics tests),
   docs/userspace-dataplane-architecture.md (#3783 histogram-slot-coverage
   paragraph)
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3789 — full-reconcile + same-plan-needs-reconcile legs now
+  fail closed on a swallowed non-policy build failure (M1 sibling of
+  #3766/#2484). Before this change `Coordinator::reconcile` returned `()`,
+  so the control-socket `apply_snapshot` handler could not distinguish an
+  aborted reconcile from a successful one. On the non-same-plan full-apply
+  leg and the same-plan `needs_reconcile` (deferred-binding) leg the
+  handler stored the incoming snapshot as the boot baseline, set
+  `persist_state`, and acked `ok=true` even when the reconcile aborted in
+  the pre-teardown preflight (a non-policy integrity build fault, or a
+  missing / unopenable mandatory pin). Prior forwarding stayed correct
+  (#2440/#2484 keep it live), but a REJECTED snapshot was persisted +
+  acked positive. Fix: `reconcile` (and `reconcile_status_bindings`) now
+  return `Result<(), ReconcileError>` (`Integrity(SnapshotIntegrityError)`
+  from the policy preflight / `build_reconcile_forwarding`, or
+  `MapSetup(stage)` for a mandatory-pin abort). Both handler legs mirror
+  #3766: on `Err`, restore the prior snapshot (+ `status.bindings` on the
+  full-apply leg) and the bumped status fields (last_snapshot_generation /
+  last_fib_generation / last_snapshot_at / capabilities), report
+  `ok=false`, and do NOT persist. The already-accepted-snapshot callers
+  (set_queue_state / set_binding_state / rebind / set_forwarding_state)
+  explicitly discard the outcome (no new snapshot to reject).
+  `build_reconcile_forwarding` now returns the concrete
+  `SnapshotIntegrityError` (was `Err(())`). Added 4 tests (2 coordinator:
+  typed Integrity / MapSetup Err + prior-generation preserved; 2 handler:
+  full-apply + same-plan-needs-reconcile fail-closed, RED-on-revert
+  proven) and retargeted the pre-existing main_tests defer-clear test
+  (which previously codified the swallow) to assert the fail-closed abort.
+  Full `cargo test --release` green (3408 lib pass / 2 pre-existing ignored
+  / 0 failed, plus 46+8+16+1 in the other targets).
+- **File(s)**: userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+  (ReconcileError enum + Display, reconcile -> Result, early-return
+  mapping), userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+  (build_reconcile_forwarding -> Result<_, SnapshotIntegrityError>),
+  userspace-dp/src/afxdp/coordinator/mod.rs + userspace-dp/src/afxdp/mod.rs
+  (ReconcileError re-exports), userspace-dp/src/server/helpers.rs
+  (reconcile_status_bindings -> Result), userspace-dp/src/server/handlers/
+  {snapshot,queue,binding,rebind,forwarding}.rs (observe / discard result),
+  userspace-dp/src/afxdp/coordinator/tests.rs + userspace-dp/src/server/
+  tests.rs (new tests; let _ on existing reconcile calls),
+  userspace-dp/src/main_tests.rs (renamed + retargeted defer-clear test),
+  docs/userspace-dataplane-architecture.md + userspace-dp/src/server/
+  README.md (#3789 handler-observes-outcome doc)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -279,6 +279,59 @@ fail) using the `bpf_map::pin` sentinel-path test seam
 (`TEST_MAP_PIN_OK` / `TEST_MAP_PIN_FAIL`) so the ordering is exercised
 without real bpffs pins.
 
+##### Control-plane handler observes the reconcile outcome (#3789)
+
+The invariants above keep the *data plane* fail-closed: on a pre-teardown
+abort the prior workers + forwarding + published generation stay live. But
+`Coordinator::reconcile` returned `()`, so the control-socket
+`apply_snapshot` handler could not tell an aborted reconcile from a
+successful one. On the two legs that drive the FULL reconcile —
+
+- the **non-same-plan full-apply** branch
+  (`server/handlers/snapshot.rs`), and
+- the **same-plan `needs_reconcile`** branch (deferred-binding
+  reconcile after a `defer_workers` clear) —
+
+the handler stored the incoming snapshot as the boot baseline, set
+`persist_state`, and acked `ok=true` regardless of whether the reconcile
+actually applied it. A snapshot that passed the policy preflight but
+aborted the reconcile (a non-policy integrity build fault, or a missing /
+unopenable mandatory pin) was therefore **persisted as a rejected boot
+baseline and acked positive** — the M1 class #3766 fixed only for the
+same-plan *refresh* leg (`refresh_runtime_snapshot`).
+
+#3789 closes this: `reconcile` (and the `reconcile_status_bindings`
+helper) now return `Result<(), ReconcileError>`
+(`coordinator/reconcile/mod.rs`), where `ReconcileError::Integrity`
+carries the `SnapshotIntegrityError` from the policy preflight or
+`build_reconcile_forwarding`, and `ReconcileError::MapSetup` carries the
+`last_reconcile_stage` descriptor for a mandatory-pin abort. Both
+handler legs now mirror #3766's pattern: install the new snapshot for the
+reconcile, and on `Err` **restore** the prior snapshot (+ the full-apply
+leg also restores `status.bindings`) and the bumped status-reporting
+fields (`last_snapshot_generation` / `last_fib_generation` /
+`last_snapshot_at` / `capabilities`), report `ok=false`, and do NOT set
+`persist_state`. Because the reconcile aborts *before* teardown, the
+restore is a status/bookkeeping rollback — the data plane never moved. The
+sibling control-socket handlers that reconcile the ALREADY-accepted stored
+snapshot (`set_queue_state`, `set_binding_state`, `rebind`,
+`set_forwarding_state`) explicitly discard the outcome: they introduce no
+new snapshot to reject.
+
+Regression coverage: `coordinator/tests.rs`
+(`reconcile_build_failure_returns_integrity_err_and_keeps_prior_generation_3789`,
+`reconcile_missing_pin_returns_map_setup_err_3789` — the reconcile now
+returns the typed error) and `server/tests.rs`
+(`apply_snapshot_full_reconcile_build_failure_rejects_and_keeps_prior_3789`,
+`apply_snapshot_same_plan_needs_reconcile_build_failure_rejects_and_keeps_prior_3789`
+— fail-on-revert: reverting the handler to ignore the reconcile result
+makes `ok=false` / prior-snapshot-kept assertions flip). The
+`main_tests.rs`
+`apply_snapshot_same_plan_clearing_defer_workers_reconcile_abort_fails_closed_3789`
+test (renamed from `…_reconciles_bindings`, which previously codified the
+swallow) now asserts the deferred-binding reconcile is triggered but the
+missing-pin abort fails closed.
+
 #### Per-Packet Processing Pipeline
 
 ```

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -15,6 +15,10 @@ mod tunnel_supervision;
 mod wg_control;
 mod worker_manager;
 pub(crate) use bpf_maps::BpfMaps;
+// #3789: the full-`reconcile` abort outcome, so `server/helpers.rs`
+// (`reconcile_status_bindings`) and the control-socket handler can name
+// the fallible return type.
+pub(crate) use reconcile::ReconcileError;
 // #1890: re-import the split-out CoS builders at coordinator scope so
 // pre-split references keep resolving unchanged — `status.rs` and
 // `tests.rs` reach them through `use super::*`, and

--- a/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/mod.rs
@@ -21,6 +21,45 @@ pub(super) mod reset;
 pub(super) mod snapshot;
 pub(super) mod teardown;
 
+/// #3789: the outcome of a full-`reconcile` that aborted in one of the
+/// PRE-TEARDOWN legs (policy preflight, mandatory-map preflight, or the
+/// `build_reconcile_forwarding` integrity build). Before this change
+/// `reconcile` returned `()` and the control-socket `apply_snapshot`
+/// handler could not tell an aborted reconcile from a successful one — so
+/// on the non-same-plan full-apply leg and the same-plan
+/// `needs_reconcile` leg it stored the rejected snapshot as the boot
+/// baseline, set `persist_state`, and acked `ok=true` (the M1 class #3766
+/// fixed for the same-plan *refresh* leg). Returning the failure lets the
+/// handler mirror #3766: report `ok=false`, restore the prior snapshot +
+/// status fields, and NOT persist.
+///
+/// Every variant is raised ONLY by a pre-teardown early return, where
+/// #2440/#2484 keep the prior workers + forwarding + published generation
+/// fully live. The handler restore is therefore a status/bookkeeping
+/// rollback, not a forwarding recovery — the data plane never moved.
+#[derive(Debug)]
+pub(crate) enum ReconcileError {
+    /// A snapshot integrity fault surfaced by the top-of-reconcile policy
+    /// preflight or by the pre-teardown forwarding build
+    /// (`build_reconcile_forwarding`: invalid interface address, CoS
+    /// queue, NAT64 / NPTv6 / filter rule, ...).
+    Integrity(crate::policy::SnapshotIntegrityError),
+    /// A mandatory BPF map pin was missing or its FD failed to open
+    /// (`preflight_map_fds`), or `apply_snapshot` returned `None`
+    /// (defensively unreachable post-#2484). Carries the
+    /// `last_reconcile_stage` descriptor for the control-plane error.
+    MapSetup(String),
+}
+
+impl std::fmt::Display for ReconcileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReconcileError::Integrity(err) => write!(f, "{err}"),
+            ReconcileError::MapSetup(stage) => write!(f, "map setup failed ({stage})"),
+        }
+    }
+}
+
 /// State preserved across `stop_inner(false)` that the later phases
 /// need to consume. `had_live_workers` lives entirely inside
 /// `teardown.rs` (it gates the 500ms mlx5 quiesce sleep alongside the
@@ -96,7 +135,7 @@ impl Coordinator {
         snapshot: Option<&ConfigSnapshot>,
         bindings: &mut [BindingStatus],
         ring_entries: usize,
-    ) {
+    ) -> Result<(), ReconcileError> {
         self.reconcile_calls += 1;
         self.last_reconcile_stage = "start".to_string();
         // #1606 (AGY r2 finding 4.2): policy-integrity preflight
@@ -129,7 +168,9 @@ impl Coordinator {
                     err
                 );
                 self.last_reconcile_stage = format!("snapshot_integrity_error: {}", err);
-                return;
+                // #3789: surface the reject so the control handler fails
+                // closed instead of persisting the rejected snapshot.
+                return Err(ReconcileError::Integrity(err));
             }
         }
         // #2440 fail-open partial-apply fix: open the mandatory BPF map
@@ -154,7 +195,9 @@ impl Coordinator {
                 None => {
                     // last_reconcile_stage + per-binding last_error set
                     // inside preflight_map_fds. No teardown, no publish.
-                    return;
+                    // #3789: surface the reject (missing / unopenable
+                    // mandatory pin) so the handler fails closed.
+                    return Err(ReconcileError::MapSetup(self.last_reconcile_stage.clone()));
                 }
             };
             // #2484 fail-open partial-apply fix (completes the #2440/#2444
@@ -178,11 +221,14 @@ impl Coordinator {
             // before teardown.
             match snapshot::build_reconcile_forwarding(self, snap) {
                 Ok(forwarding) => fds.forwarding = forwarding,
-                Err(()) => {
+                Err(err) => {
                     // last_reconcile_stage = "snapshot_integrity_error" set
                     // inside build_reconcile_forwarding. No teardown, no
                     // publish: prior generation + workers stay live.
-                    return;
+                    // #3789: surface the integrity error so the control
+                    // handler fails closed on the full-reconcile legs
+                    // instead of persisting the rejected snapshot.
+                    return Err(ReconcileError::Integrity(err));
                 }
             }
             Some(fds)
@@ -219,7 +265,9 @@ impl Coordinator {
             // stage so the operator-visible state is consistent on return.
             self.refresh_bindings(bindings);
             self.last_reconcile_stage = "no_snapshot".to_string();
-            return;
+            // #3789: a config-cleared / shutdown teardown is a successful
+            // reconcile (the caller intentionally passed no snapshot).
+            return Ok(());
         };
         // SAFETY: preflight_fds is Some whenever snapshot is Some (both
         // gated on the same `snapshot` Option above).
@@ -240,7 +288,12 @@ impl Coordinator {
             &mut preserved.synced_sessions,
             fds,
         ) else {
-            return;
+            // #2484: defensively unreachable — the build already succeeded
+            // in the pre-teardown preflight and apply_snapshot reuses it.
+            // #3789: still surface a reject rather than a false ok if it
+            // ever fires (teardown already ran here, so this is a
+            // fail-closed backstop, not a prior-state restore).
+            return Err(ReconcileError::MapSetup(self.last_reconcile_stage.clone()));
         };
         bringup::bring_up_workers(
             self,
@@ -251,5 +304,6 @@ impl Coordinator {
             preserved.synced_sessions,
         );
         self.refresh_bindings(bindings);
+        Ok(())
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -199,8 +199,10 @@ pub(super) fn preflight_map_fds(
 /// stash on `ReconcileSnapshotFds::forwarding` (build-once, reused by
 /// `apply_snapshot`). On an integrity error sets
 /// `coord.last_reconcile_stage = "snapshot_integrity_error"` (matching the
-/// descriptive-stage pattern) and returns `Err(())`; the orchestrator
-/// aborts WITHOUT teardown or publish.
+/// descriptive-stage pattern) and returns `Err(SnapshotIntegrityError)`
+/// (#3789: was `Err(())`); the orchestrator aborts WITHOUT teardown or
+/// publish and wraps the error in `ReconcileError::Integrity` for the
+/// control-plane handler.
 ///
 /// MUST run before `tear_down`: it reads `Some(&coord.forwarding)` as the
 /// build's "previous" arg (WG engine reuse, NAT counter carry-over, cold-
@@ -208,7 +210,7 @@ pub(super) fn preflight_map_fds(
 pub(super) fn build_reconcile_forwarding(
     coord: &mut Coordinator,
     snapshot: &ConfigSnapshot,
-) -> Result<ForwardingState, ()> {
+) -> Result<ForwardingState, crate::policy::SnapshotIntegrityError> {
     match build_forwarding_state_with_policy_counters_and_previous(
         snapshot,
         &coord.policy_counters,
@@ -222,7 +224,11 @@ pub(super) fn build_reconcile_forwarding(
                 "xpf-userspace-dp: snapshot integrity error during reconcile preflight: {} — keeping previous forwarding state + workers",
                 err
             );
-            Err(())
+            // #3789: return the concrete integrity error (was `()`) so the
+            // orchestrator can surface it to the control-plane handler,
+            // which fails closed instead of persisting the rejected
+            // snapshot.
+            Err(err)
         }
     }
 }

--- a/userspace-dp/src/afxdp/coordinator/tests.rs
+++ b/userspace-dp/src/afxdp/coordinator/tests.rs
@@ -1638,7 +1638,7 @@ fn reconcile_with_none_snapshot_reaches_no_snapshot_early_exit() {
         rx_packets: 42,
         ..BindingStatus::default()
     }];
-    coordinator.reconcile(None, &mut bindings, 64);
+    let _ = coordinator.reconcile(None, &mut bindings, 64);
     assert_eq!(coordinator.last_reconcile_stage, "no_snapshot");
     assert_eq!(coordinator.reconcile_calls, 1);
     assert!(
@@ -1704,7 +1704,7 @@ fn reconcile_none_snapshot_refreshes_bindings_clearing_reset_survivor_fields() {
         ..BindingStatus::default()
     }];
 
-    coordinator.reconcile(None, &mut bindings, 64);
+    let _ = coordinator.reconcile(None, &mut bindings, 64);
 
     assert_eq!(coordinator.last_reconcile_stage, "no_snapshot");
     // The reset-survivor fields must now be cleared by the teardown
@@ -1768,7 +1768,7 @@ fn reconcile_none_snapshot_refreshes_bindings_clearing_reset_survivor_fields() {
 fn teardown_quiesce_skipped_when_no_live_workers() {
     let mut coordinator = Coordinator::new();
     let mut bindings: Vec<BindingStatus> = Vec::new();
-    coordinator.reconcile(None, &mut bindings, 64);
+    let _ = coordinator.reconcile(None, &mut bindings, 64);
     assert_eq!(
         coordinator.last_quiesce_ms, 0,
         "no live workers => no mlx5 quiesce"
@@ -1795,7 +1795,7 @@ fn teardown_quiesce_skipped_on_no_snapshot_even_with_live_workers() {
         "precondition: a live worker handle is seeded (had_live_workers == true)"
     );
     let mut bindings: Vec<BindingStatus> = Vec::new();
-    coordinator.reconcile(None, &mut bindings, 64);
+    let _ = coordinator.reconcile(None, &mut bindings, 64);
     assert_eq!(
         coordinator.last_reconcile_stage, "no_snapshot",
         "None snapshot reaches the no_snapshot early-exit"
@@ -1839,7 +1839,7 @@ fn teardown_quiesce_fires_when_live_workers_and_snapshot_rebinds() {
     let mut snap = fail_open_snapshot(1);
     snap.map_pins.sessions = format!("{TEST_MAP_PIN_OK}sessions");
     let mut bindings: Vec<BindingStatus> = Vec::new();
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
     assert_eq!(
         coordinator.last_quiesce_ms, 500,
         "#2522: live workers + a rebinding snapshot MUST still pay the mlx5 EBUSY quiesce"
@@ -3193,7 +3193,7 @@ fn reconcile_mandatory_map_open_failure_keeps_prior_generation_published() {
     // fds) and `sessions` to fail its open, so the failure is isolated
     // to the third mandatory open. The optional maps (conntrack/dnat)
     // are empty so they are never opened.
-    coordinator.reconcile(Some(&fail_open_snapshot(8)), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&fail_open_snapshot(8)), &mut bindings, 64);
 
     // The reconcile aborted at the session-map open.
     assert!(
@@ -3265,7 +3265,7 @@ fn reconcile_missing_session_pin_keeps_prior_generation_published() {
     let mut snap = fail_open_snapshot(12);
     snap.map_pins.sessions = String::new();
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert_eq!(
         coordinator.last_reconcile_stage, "missing_session_pin",
@@ -3301,13 +3301,97 @@ fn reconcile_all_mandatory_maps_open_advances_published_generation() {
     // the preflight passes and the reconcile proceeds to publish.
     let mut snap = fail_open_snapshot(2);
     snap.map_pins.sessions = format!("{TEST_MAP_PIN_OK}sessions");
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert_eq!(
         coordinator.validation.config_generation, 2,
         "a fully-openable snapshot must advance the published generation"
     );
     assert_eq!((**coordinator.shared_validation.load()).config_generation, 2);
+}
+
+/// #3789: a snapshot that PASSES the policy preflight and opens every
+/// mandatory map, but FAILS the pre-teardown forwarding build (here an
+/// unparseable interface address), must return
+/// `Err(ReconcileError::Integrity(_))` — NOT the old `()` that silently
+/// swallowed the reject — while leaving the prior published generation
+/// intact (build fails BEFORE teardown, #2484). This is the coordinator-
+/// level half of the fix: the control-plane handler relies on this Err to
+/// fail closed on the full-apply / same-plan-needs-reconcile legs.
+///
+/// Fail-on-revert: before #3789 `reconcile` returned `()` and
+/// `build_reconcile_forwarding` discarded the error to `()`; the
+/// `matches!(..., Err(ReconcileError::Integrity(_)))` assertion cannot be
+/// expressed against a `()` return, so reverting the signature re-breaks
+/// the handler's ability to observe the reject.
+#[test]
+fn reconcile_build_failure_returns_integrity_err_and_keeps_prior_generation_3789() {
+    let mut coordinator = Coordinator::new();
+    let prior = ValidationState {
+        snapshot_installed: true,
+        config_generation: 7,
+        fib_generation: 3,
+    };
+    coordinator.validation = prior;
+    coordinator.shared_validation.store(Arc::new(prior));
+
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+
+    // All three mandatory pins open (sentinel-OK) so the preflight passes
+    // and control reaches the fallible `build_reconcile_forwarding`.
+    let mut snap = fail_open_snapshot(8);
+    snap.map_pins.sessions = format!("{TEST_MAP_PIN_OK}sessions");
+    // An unparseable interface address (/33 is invalid for IPv4) makes the
+    // forwarding build fail with a non-policy integrity error.
+    snap.interfaces = vec![crate::protocol::snapshot::InterfaceSnapshot {
+        name: "ge-0/0/0".to_string(),
+        linux_name: "ge-0-0-0".to_string(),
+        ifindex: 10,
+        addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+            family: "inet".to_string(),
+            address: "10.0.0.0/33".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }];
+
+    let result = coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    assert!(
+        matches!(result, Err(ReconcileError::Integrity(_))),
+        "a non-policy forwarding-build failure must surface as Err(Integrity), got {result:?}"
+    );
+    assert_eq!(
+        coordinator.validation.config_generation, 7,
+        "the rejected build must not advance the published generation"
+    );
+    assert_eq!(
+        (**coordinator.shared_validation.load()).config_generation,
+        7,
+        "the rejected build must not advance the worker-visible generation"
+    );
+}
+
+/// #3789: the mandatory-map preflight failure surfaces as
+/// `Err(ReconcileError::MapSetup(..))` (not `()`), carrying the
+/// `last_reconcile_stage` descriptor, so the handler can fail closed on
+/// an unopenable-pin reject too (the #2440 sibling of the build reject).
+#[test]
+fn reconcile_missing_pin_returns_map_setup_err_3789() {
+    let mut coordinator = Coordinator::new();
+    let mut bindings: Vec<BindingStatus> = Vec::new();
+    let mut snap = fail_open_snapshot(3);
+    // Sessions pin empty -> preflight_map_fds aborts at missing_session_pin.
+    snap.map_pins.sessions = String::new();
+
+    let result = coordinator.reconcile(Some(&snap), &mut bindings, 64);
+
+    match result {
+        Err(ReconcileError::MapSetup(stage)) => {
+            assert_eq!(stage, "missing_session_pin", "unexpected stage: {stage}");
+        }
+        other => panic!("expected Err(MapSetup(missing_session_pin)), got {other:?}"),
+    }
 }
 
 /// #3402: a FRESH-BOOT snapshot ships its zones AND a concrete-zone policy in
@@ -3373,7 +3457,7 @@ fn reconcile_fresh_boot_concrete_zone_policy_passes_preflight_3402() {
         ..Default::default()
     }];
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert!(
         !coordinator
@@ -3428,7 +3512,7 @@ fn reconcile_policy_references_undefined_zone_still_fails_closed_3402() {
         ..Default::default()
     }];
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert!(
         coordinator
@@ -3506,7 +3590,7 @@ fn reconcile_snapshot_integrity_error_preserves_prior_generation_and_state() {
         ..Default::default()
     }];
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert_eq!(
         coordinator.last_reconcile_stage, "snapshot_integrity_error",
@@ -3611,7 +3695,7 @@ fn reconcile_present_conntrack_pin_open_failure_keeps_prior_generation() {
     let mut snap = mandatory_ok_snapshot(31);
     snap.map_pins.conntrack_v4 = format!("{TEST_MAP_PIN_FAIL}conntrack_v4");
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert!(
         coordinator
@@ -3671,7 +3755,7 @@ fn reconcile_present_dnat_pin_open_failure_keeps_prior_generation() {
     let mut snap = mandatory_ok_snapshot(41);
     snap.map_pins.dnat_table = format!("{TEST_MAP_PIN_FAIL}dnat_table");
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert!(
         coordinator
@@ -3721,7 +3805,7 @@ fn reconcile_empty_optional_pins_advance_published_generation() {
     assert!(snap.map_pins.dnat_table.is_empty());
     assert!(snap.map_pins.dnat_table_v6.is_empty());
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert_eq!(
         coordinator.validation.config_generation, 51,
@@ -3756,7 +3840,7 @@ fn reconcile_present_optional_pins_open_ok_advance_generation() {
     snap.map_pins.dnat_table = format!("{TEST_MAP_PIN_OK}dnat_table");
     snap.map_pins.dnat_table_v6 = format!("{TEST_MAP_PIN_OK}dnat_table_v6");
 
-    coordinator.reconcile(Some(&snap), &mut bindings, 64);
+    let _ = coordinator.reconcile(Some(&snap), &mut bindings, 64);
 
     assert_eq!(
         coordinator.validation.config_generation, 61,

--- a/userspace-dp/src/afxdp/mod.rs
+++ b/userspace-dp/src/afxdp/mod.rs
@@ -435,6 +435,10 @@ mod worker_queue;
 #[path = "worker_runtime.rs"]
 mod worker_runtime;
 pub use self::coordinator::Coordinator;
+// #3789: re-export the full-reconcile abort outcome into afxdp scope so
+// the control-plane server (`server/helpers.rs` + `handlers/snapshot.rs`)
+// can name `afxdp::ReconcileError` on `reconcile_status_bindings`.
+pub(crate) use self::coordinator::ReconcileError;
 // #2962: the lock-free owner-RG export wait handle. The control-socket
 // dispatcher (server/handlers) names this as the return type of
 // kick_owner_rg_export so it can run the blocking ack-wait off the

--- a/userspace-dp/src/main_tests.rs
+++ b/userspace-dp/src/main_tests.rs
@@ -1749,8 +1749,17 @@ fn run_control_request(
     response
 }
 
+/// #3789: clearing `defer_workers` on a same-plan apply TRIGGERS the
+/// deferred-binding reconcile (`debug_reconcile_calls` 0 -> 1). When that
+/// reconcile aborts in the pre-teardown preflight — here the test snapshot
+/// carries no map pins, so it stops at `missing_xsk_pin` — the
+/// full-reconcile handler leg now FAILS CLOSED: it reports `ok=false` and
+/// keeps the prior deferred (gen-1) snapshot as the boot baseline. Before
+/// #3789 `afxdp.reconcile` returned `()`, the handler swallowed the abort,
+/// stored the rejected gen-2 (defer_workers=false) snapshot, and acked
+/// ok=true — the M1 class #3766 fixed only for the same-plan *refresh* leg.
 #[test]
-fn apply_snapshot_same_plan_clearing_defer_workers_reconciles_bindings() {
+fn apply_snapshot_same_plan_clearing_defer_workers_reconcile_abort_fails_closed_3789() {
     let state = Arc::new(Mutex::new(ServerState {
         status: ProcessStatus {
             workers: 1,
@@ -1830,19 +1839,36 @@ fn apply_snapshot_same_plan_clearing_defer_workers_reconciles_bindings() {
             ..ControlRequest::default()
         },
     );
-    assert!(response.ok, "unexpected error: {}", response.error);
+    // #3789: the aborted deferred-binding reconcile must fail closed.
+    assert!(
+        !response.ok,
+        "an aborted deferred-binding reconcile must fail closed (#3789), got ok=true"
+    );
+    assert!(
+        response.error.contains("missing_xsk_pin"),
+        "unexpected error: {}",
+        response.error
+    );
     let status = response.status.expect("status response");
+    // The reconcile WAS triggered (the point of clearing defer_workers) and
+    // aborted at the missing mandatory pin.
     assert_eq!(status.debug_reconcile_calls, 1);
     assert_eq!(status.debug_reconcile_stage, "missing_xsk_pin");
-    assert!(
-        !state
-            .lock()
-            .expect("state poisoned")
-            .snapshot
-            .as_ref()
-            .expect("snapshot")
-            .defer_workers
-    );
+    // #3789: the rejected gen-2 snapshot must NOT overwrite the boot
+    // baseline — the prior deferred (gen-1, defer_workers=true) snapshot
+    // stays stored.
+    {
+        let guard = state.lock().expect("state poisoned");
+        let stored = guard.snapshot.as_ref().expect("snapshot");
+        assert_eq!(
+            stored.generation, 1,
+            "a rejected apply must keep the prior snapshot as the boot baseline"
+        );
+        assert!(
+            stored.defer_workers,
+            "a rejected apply must keep the prior deferred snapshot intact"
+        );
+    }
 
     let _ = std::fs::remove_file(&state_file);
 }

--- a/userspace-dp/src/server/README.md
+++ b/userspace-dp/src/server/README.md
@@ -162,9 +162,18 @@ queues. See PR #1243's kill record for why i40e doesn't reshape.
 ## Gotchas
 
 - `reconcile_status_bindings` has two arms. When `should_run_afxdp`
-  holds it runs `Coordinator::reconcile` then surfaces the result. When
-  it does NOT (forwarding disarmed / unsupported) it `stop()`s every
-  worker and then routes the per-binding status through
+  holds it runs `Coordinator::reconcile` and returns its
+  `Result<(), afxdp::ReconcileError>` (#3789): a pre-teardown abort
+  (integrity build fault or a missing / unopenable mandatory pin) surfaces
+  as `Err`, and the `apply_snapshot` handler's full-apply /
+  same-plan-`needs_reconcile` legs fail closed on it — restoring the prior
+  snapshot + status fields and reporting `ok=false` instead of persisting
+  the rejected snapshot (see `docs/userspace-dataplane-architecture.md`,
+  "Control-plane handler observes the reconcile outcome"). The
+  already-accepted-snapshot callers (`set_queue_state`, `set_binding_state`,
+  `rebind`, `set_forwarding_state`) discard the outcome. When
+  `should_run_afxdp` does NOT hold (forwarding disarmed / unsupported) it
+  `stop()`s every worker and then routes the per-binding status through
   `refresh_bindings` — which sends each now-workerless slot through
   `zero_unbound_slot`, clearing the FULL survivor set
   (`socket_ifindex`/`socket_queue_id`/`socket_bind_flags`,

--- a/userspace-dp/src/server/handlers/binding.rs
+++ b/userspace-dp/src/server/handlers/binding.rs
@@ -29,7 +29,11 @@ pub(super) fn set(
         binding.armed = binding_req.armed && binding_req.registered;
         binding.last_change = Some(Utc::now());
         if registration_changed {
-            reconcile_status_bindings(guard);
+            // #3789: re-binds the ALREADY-ACCEPTED stored snapshot (a
+            // binding registration toggle, not a new config), so a build
+            // reject cannot introduce a rejected snapshot here — discard
+            // the outcome explicitly.
+            let _ = reconcile_status_bindings(guard);
             wait_for_binding_settle(guard, Duration::from_secs(2));
         }
         refresh_status(guard);

--- a/userspace-dp/src/server/handlers/forwarding.rs
+++ b/userspace-dp/src/server/handlers/forwarding.rs
@@ -31,7 +31,12 @@ pub(super) fn set(
     }
     guard.status.forwarding_armed = forwarding_req.armed;
     set_bindings_forwarding_armed(&mut guard.status, forwarding_req.armed);
-    reconcile_status_bindings(guard);
+    // #3789: arming/disarming reconciles the ALREADY-ACCEPTED stored
+    // snapshot (a forwarding-state toggle, not a new config). A build
+    // reject here would surface via the per-binding last_error, and there
+    // is no newly-supplied snapshot to reject — discard the outcome
+    // explicitly.
+    let _ = reconcile_status_bindings(guard);
     if forwarding_req.armed {
         wait_for_binding_settle(guard, Duration::from_secs(2));
     }

--- a/userspace-dp/src/server/handlers/queue.rs
+++ b/userspace-dp/src/server/handlers/queue.rs
@@ -36,7 +36,11 @@ pub(super) fn set(
     }
     if found {
         if registration_changed {
-            reconcile_status_bindings(guard);
+            // #3789: this reconcile re-binds the ALREADY-ACCEPTED stored
+            // snapshot (a queue registration toggle, not a new config), so
+            // a build reject cannot introduce a rejected snapshot here —
+            // discard the outcome explicitly.
+            let _ = reconcile_status_bindings(guard);
             wait_for_binding_settle(guard, Duration::from_secs(2));
         }
         refresh_status(guard);

--- a/userspace-dp/src/server/handlers/rebind.rs
+++ b/userspace-dp/src/server/handlers/rebind.rs
@@ -43,7 +43,11 @@ pub(super) fn handle(guard: &mut ServerState, persist_state: &mut bool) {
         binding.ready = false;
         binding.last_error.clear();
     }
-    reconcile_status_bindings(guard);
+    // #3789: rebind re-creates the AF_XDP sockets for the ALREADY-ACCEPTED
+    // stored snapshot after a link DOWN/UP cycle — it does not introduce a
+    // new config, so a reconcile reject cannot persist a rejected snapshot
+    // here. Discard the outcome explicitly.
+    let _ = reconcile_status_bindings(guard);
     refresh_status(guard);
     *persist_state = true;
     eprintln!(

--- a/userspace-dp/src/server/handlers/snapshot.rs
+++ b/userspace-dp/src/server/handlers/snapshot.rs
@@ -105,8 +105,33 @@ pub(super) fn apply(
         );
         if needs_reconcile {
             eprintln!("CTRL_REQ: same-plan apply_snapshot reconciling deferred bindings");
-            guard.snapshot = Some(snapshot);
-            reconcile_status_bindings(guard);
+            // #3789: the deferred-binding reconcile runs the FALLIBLE
+            // pre-teardown build (build_reconcile_forwarding). A snapshot
+            // that passed the policy preflight above can still fail a
+            // non-policy integrity check (invalid interface address, CoS
+            // queue, NAT64 / NPTv6 rule, ...) or a mandatory-map open.
+            // Per #2440/#2484 the reconcile aborts BEFORE teardown, so the
+            // prior workers + forwarding + generation stay live. Mirror the
+            // same-plan refresh leg (#3766): install the new snapshot for
+            // the reconcile, but on failure restore the prior snapshot +
+            // status fields, report ok=false, and do NOT persist — a
+            // rejected snapshot must never become the boot baseline nor be
+            // acked ok=true.
+            let prev_snapshot = std::mem::replace(&mut guard.snapshot, Some(snapshot));
+            if let Err(err) = reconcile_status_bindings(guard) {
+                guard.snapshot = prev_snapshot;
+                guard.status.last_snapshot_generation = prev_last_snapshot_generation;
+                guard.status.last_fib_generation = prev_last_fib_generation;
+                guard.status.last_snapshot_at = prev_last_snapshot_at;
+                guard.status.capabilities = prev_capabilities;
+                response.ok = false;
+                response.error = format!("snapshot integrity error: {}", err);
+                eprintln!(
+                    "CTRL_REQ: same-plan apply_snapshot rejected (integrity build): {} — keeping previous state",
+                    err
+                );
+                return;
+            }
         } else {
             // #1866 (PR-review Codex r1 F1 + r2): refresh_runtime_snapshot
             // reconciles WG control threads for the running case
@@ -172,7 +197,7 @@ pub(super) fn apply(
                 .afxdp
                 .prune_local_tunnel_sources_for_snapshot(&snapshot);
         }
-        guard.snapshot = Some(snapshot);
+        let prev_snapshot = std::mem::replace(&mut guard.snapshot, Some(snapshot));
         let replanned = replan_queues(
             guard.snapshot.as_ref(),
             guard.status.workers,
@@ -183,8 +208,29 @@ pub(super) fn apply(
             eprintln!(
                 "CTRL_REQ: apply_snapshot defer_workers=true — skipping worker spawn (RETH MAC pending)"
             );
-        } else {
-            reconcile_status_bindings(guard);
+        } else if let Err(err) = reconcile_status_bindings(guard) {
+            // #3789: full-reconcile leg fail-closed (the #2484 domain, out
+            // of #3766's same-plan-refresh scope). reconcile_status_bindings
+            // ran the fallible pre-teardown build; on a non-policy integrity
+            // failure — or a missing / unopenable mandatory map pin — the
+            // reconcile aborted BEFORE teardown (#2440/#2484), so the prior
+            // workers + forwarding + generation are still live. Restore the
+            // prior snapshot, bindings, and status-reporting fields, report
+            // ok=false, and do NOT persist — the rejected snapshot must not
+            // become the boot baseline nor be acked ok=true.
+            guard.snapshot = prev_snapshot;
+            guard.status.bindings = existing_bindings;
+            guard.status.last_snapshot_generation = prev_last_snapshot_generation;
+            guard.status.last_fib_generation = prev_last_fib_generation;
+            guard.status.last_snapshot_at = prev_last_snapshot_at;
+            guard.status.capabilities = prev_capabilities;
+            response.ok = false;
+            response.error = format!("snapshot integrity error: {}", err);
+            eprintln!(
+                "CTRL_REQ: apply_snapshot rejected (integrity build): {} — keeping previous state",
+                err
+            );
+            return;
         }
         refresh_status(guard);
         *persist_state = true;

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -520,7 +520,9 @@ pub(crate) fn parse_session_sync_mac(value: &str) -> Result<Option<[u8; 6]>, Str
     Ok(Some(out))
 }
 
-pub(crate) fn reconcile_status_bindings(state: &mut ServerState) {
+pub(crate) fn reconcile_status_bindings(
+    state: &mut ServerState,
+) -> Result<(), afxdp::ReconcileError> {
     if !should_run_afxdp(&state.status) {
         state.afxdp.stop();
         // #2794: route the disarmed-forwarding teardown through
@@ -542,15 +544,21 @@ pub(crate) fn reconcile_status_bindings(state: &mut ServerState) {
         let mut bindings = std::mem::take(&mut state.status.bindings);
         state.afxdp.refresh_bindings(&mut bindings);
         state.status.bindings = bindings;
-        return;
+        // A disarmed reconcile is a stop/teardown — always successful.
+        return Ok(());
     }
     let snapshot = state.snapshot.clone();
     let ring_entries = state.status.ring_entries;
     let mut bindings = std::mem::take(&mut state.status.bindings);
-    state
+    // #3789: propagate the reconcile outcome. A pre-teardown abort
+    // (integrity / mandatory-map failure) leaves the prior workers +
+    // forwarding + generation live (#2440/#2484); the caller uses the
+    // Err to fail closed instead of persisting a rejected snapshot.
+    let result = state
         .afxdp
         .reconcile(snapshot.as_ref(), &mut bindings, ring_entries);
     state.status.bindings = bindings;
+    result
 }
 
 pub(crate) fn should_run_afxdp(status: &ProcessStatus) -> bool {

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -909,6 +909,210 @@ fn apply_snapshot_same_plan_build_failure_rejects_and_keeps_prior_3766() {
     );
 }
 
+/// Sentinel-OK map pins for the ARMED reconcile legs. The literal mirrors
+/// `afxdp::TEST_MAP_PIN_OK` (pub(in crate::afxdp), not reachable here); the
+/// `#[cfg(test)]` seam in `OwnedFd::open_bpf_map` short-circuits these to a
+/// dummy fd so the reconcile passes `preflight_map_fds` and reaches the
+/// fallible forwarding build without a real bpffs.
+fn ok_map_pins() -> crate::protocol::snapshot::MapPins {
+    crate::protocol::snapshot::MapPins {
+        xsk: "test-map-pin-ok://xsk".to_string(),
+        heartbeat: "test-map-pin-ok://heartbeat".to_string(),
+        sessions: "test-map-pin-ok://sessions".to_string(),
+        ..Default::default()
+    }
+}
+
+fn forwarding_caps() -> UserspaceCapabilities {
+    UserspaceCapabilities {
+        forwarding_supported: true,
+        ..Default::default()
+    }
+}
+
+/// A tunnel interface is excluded from the binding plan, so applies that
+/// differ only in this interface's ADDRESS share a plan key. `address`
+/// controls whether the forwarding build succeeds ("10.0.0.1/24") or fails
+/// ("10.0.0.0/33", unparseable — a NON-policy integrity fault).
+fn tunnel_iface_3789(address: &str) -> crate::protocol::snapshot::InterfaceSnapshot {
+    crate::protocol::snapshot::InterfaceSnapshot {
+        name: "gr-0/0/0".to_string(),
+        linux_name: "gr-0-0-0".to_string(),
+        ifindex: 4300,
+        tunnel: true,
+        hardware_addr: "02:00:00:00:43:00".to_string(),
+        addresses: vec![crate::protocol::snapshot::InterfaceAddressSnapshot {
+            family: "inet".to_string(),
+            address: address.to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+/// #3789 fail-closed FULL-APPLY leg (the non-same-plan branch, the #2484
+/// domain out of #3766's same-plan-refresh scope): an ARMED
+/// forwarding-supported helper's first apply takes the else full-apply
+/// leg -> reconcile_status_bindings -> the fallible afxdp.reconcile. A
+/// snapshot that passes the policy preflight but whose forwarding build
+/// FAILS (unparseable interface address) must report ok=false, NOT store
+/// the rejected snapshot as the boot baseline, and NOT advance the
+/// reported generation.
+///
+/// Fail-on-revert: before #3789 `afxdp.reconcile` returned () and the
+/// handler unconditionally stored the snapshot, refreshed status, and set
+/// persist_state=true -> response.ok stayed true (M1), the rejected
+/// snapshot became guard.snapshot, and last_snapshot_generation advanced.
+/// Every assertion below flips.
+#[test]
+fn apply_snapshot_full_reconcile_build_failure_rejects_and_keeps_prior_3789() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+
+    // Armed so the reconcile takes the real afxdp.reconcile path (not the
+    // disarmed stop arm). forwarding_supported comes from the snapshot.
+    let state = new_state(ProcessStatus {
+        forwarding_armed: true,
+        ..ProcessStatus::default()
+    });
+
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 5,
+        fib_generation: 5,
+        generated_at: chrono::Utc::now(),
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![tunnel_iface_3789("10.0.0.0/33")],
+        ..ConfigSnapshot::default()
+    });
+
+    let response = run_request(state.clone(), request);
+    assert!(
+        !response.ok,
+        "a full-apply reconcile whose forwarding build fails must report ok=false"
+    );
+    assert!(
+        response.error.contains("snapshot integrity error"),
+        "unexpected error: {}",
+        response.error
+    );
+
+    let guard = state.lock().expect("state");
+    assert!(
+        guard.snapshot.is_none(),
+        "rejected snapshot must not be stored as the boot baseline"
+    );
+    assert_eq!(
+        guard.status.last_snapshot_generation, 0,
+        "rejected full-apply must not bump last_snapshot_generation"
+    );
+    assert_eq!(
+        guard.status.last_fib_generation, 0,
+        "rejected full-apply must not bump last_fib_generation"
+    );
+}
+
+/// #3789 fail-closed SAME-PLAN NEEDS-RECONCILE leg: when the prior apply
+/// deferred workers, the next same-plan apply reconciles the deferred
+/// bindings via afxdp.reconcile (NOT the same-plan refresh leg #3766
+/// fixed). A build failure on that reconcile must restore the prior
+/// (deferred) snapshot, report ok=false, and NOT advance the generation.
+///
+/// Fail-on-revert: pre-#3789 this leg stored the snapshot then called
+/// reconcile_status_bindings (returning ()) and fell through to
+/// refresh_status + persist_state=true with ok=true — so the rejected
+/// gen-2 snapshot overwrote the gen-1 baseline and last_snapshot_generation
+/// advanced to 2. The generation/defer_workers assertions flip.
+#[test]
+fn apply_snapshot_same_plan_needs_reconcile_build_failure_rejects_and_keeps_prior_3789() {
+    use crate::{ConfigSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+
+    // Prior snapshot deferred workers -> previous_defer_workers=true makes
+    // same_plan_apply_needs_binding_reconcile return true on the next
+    // (non-defer) same-plan apply. Tunnel-only interface set -> the plan
+    // key is address-independent, so gen-1 and gen-2 are same-plan.
+    let prior = ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 1,
+        fib_generation: 1,
+        generated_at: chrono::Utc::now(),
+        defer_workers: true,
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![tunnel_iface_3789("10.0.0.1/24")],
+        ..ConfigSnapshot::default()
+    };
+
+    // Armed + supported + one runnable binding (registered, ifindex>0) so
+    // the needs-reconcile runnable_bindings>0 gate holds.
+    let status = ProcessStatus {
+        forwarding_armed: true,
+        capabilities: forwarding_caps(),
+        last_snapshot_generation: 1,
+        last_fib_generation: 1,
+        bindings: vec![BindingStatus {
+            slot: 0,
+            registered: true,
+            ifindex: 10,
+            ..BindingStatus::default()
+        }],
+        ..ProcessStatus::default()
+    };
+
+    let state = Arc::new(Mutex::new(ServerState {
+        status,
+        snapshot: Some(prior),
+        afxdp: afxdp::Coordinator::new(),
+        state_writer: Arc::new(StateWriter::new()),
+    }));
+
+    // New same-plan apply: defer_workers=false, unparseable address -> the
+    // deferred-binding reconcile's forwarding build fails.
+    let mut request = req("apply_snapshot");
+    request.snapshot = Some(ConfigSnapshot {
+        version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+        generation: 2,
+        fib_generation: 2,
+        generated_at: chrono::Utc::now(),
+        defer_workers: false,
+        capabilities: forwarding_caps(),
+        map_pins: ok_map_pins(),
+        interfaces: vec![tunnel_iface_3789("10.0.0.0/33")],
+        ..ConfigSnapshot::default()
+    });
+
+    let response = run_request(state.clone(), request);
+    assert!(
+        !response.ok,
+        "a same-plan needs-reconcile apply whose build fails must report ok=false"
+    );
+    assert!(
+        response.error.contains("snapshot integrity error"),
+        "unexpected error: {}",
+        response.error
+    );
+
+    let guard = state.lock().expect("state");
+    assert_eq!(
+        guard.snapshot.as_ref().map(|s| s.generation),
+        Some(1),
+        "the rejected snapshot must not overwrite the persisted baseline"
+    );
+    assert!(
+        guard.snapshot.as_ref().is_some_and(|s| s.defer_workers),
+        "the prior (deferred) snapshot must be restored intact"
+    );
+    assert_eq!(
+        guard.status.last_snapshot_generation, 1,
+        "rejected same-plan needs-reconcile must not bump last_snapshot_generation"
+    );
+    assert_eq!(
+        guard.status.last_fib_generation, 1,
+        "rejected same-plan needs-reconcile must not bump last_fib_generation"
+    );
+}
+
 // --- set_binding_state / set_queue_state error arms ---------------------
 
 #[test]
@@ -1192,7 +1396,8 @@ fn reconcile_disarmed_clears_full_stale_binding_survivors() {
 
     {
         let mut guard = state.lock().expect("state");
-        reconcile_status_bindings(&mut guard);
+        // #3789: disarmed reconcile is a teardown — always Ok.
+        reconcile_status_bindings(&mut guard).expect("disarmed reconcile is infallible");
     }
 
     let guard = state.lock().expect("state");


### PR DESCRIPTION
Closes #3789.

## Problem

#3766 made the same-plan snapshot *refresh* leg fail-closed, but two
adjacent control-socket `apply_snapshot` legs still drove the FULL
reconcile through `Coordinator::reconcile`, which returned `()` and
swallowed a non-policy build failure:

- the non-same-plan **full-apply** branch (`server/handlers/snapshot.rs`), and
- the same-plan **`needs_reconcile`** branch (deferred-binding reconcile
  after a `defer_workers` clear).

Both call `reconcile_status_bindings` → `afxdp.reconcile`. Prior
forwarding stayed correct (per #2440/#2484 the reconcile aborts BEFORE
teardown and keeps the prior workers + forwarding + published generation
live), **but** the handler still stored `guard.snapshot` = the rejected
snapshot as the boot baseline, set `persist_state`, and reported
`ok=true`. A snapshot that passed the policy preflight but aborted the
reconcile — a non-policy integrity build fault, or a missing / unopenable
mandatory pin — was therefore **persisted as a rejected boot baseline and
acked positive** (the M1 class #3766 fixed only for the refresh leg).

## Fix

- `Coordinator::reconcile` now returns `Result<(), ReconcileError>`
  (`coordinator/reconcile/mod.rs`). `ReconcileError::Integrity` carries the
  `SnapshotIntegrityError` from the policy preflight or
  `build_reconcile_forwarding`; `ReconcileError::MapSetup` carries the
  `last_reconcile_stage` descriptor for a mandatory-pin abort.
  `build_reconcile_forwarding` returns the concrete `SnapshotIntegrityError`
  (was `Err(())`); the no-snapshot teardown returns `Ok(())`.
- `reconcile_status_bindings` propagates the `Result` (the disarmed stop
  arm is always `Ok`).
- Both `apply_snapshot` legs mirror #3766: install the new snapshot for the
  reconcile, and on `Err` restore the prior snapshot (the full-apply leg
  also restores `status.bindings`) plus the bumped status-reporting fields
  (`last_snapshot_generation` / `last_fib_generation` / `last_snapshot_at`
  / `capabilities`), report `ok=false`, and do NOT persist. The reconcile
  aborts before teardown, so this is a status/bookkeeping rollback — the
  data plane never moved.
- The handlers that reconcile the ALREADY-accepted stored snapshot
  (`set_queue_state`, `set_binding_state`, `rebind`, `set_forwarding_state`)
  explicitly discard the outcome: they introduce no new snapshot to reject.

Preserves the #3786 integrity-first / #2484 build-before-teardown / #2440
fail-closed-map-FD invariants — a build failure retains prior state, never
blackholes.

## Tests

Coordinator-level: `reconcile_build_failure_returns_integrity_err_and_keeps_prior_generation_3789`
(build fault → `Err(Integrity)` + prior generation kept),
`reconcile_missing_pin_returns_map_setup_err_3789` (→ `Err(MapSetup)`).

Handler-level (fail-on-revert):
`apply_snapshot_full_reconcile_build_failure_rejects_and_keeps_prior_3789`
and `apply_snapshot_same_plan_needs_reconcile_build_failure_rejects_and_keeps_prior_3789`
— reverting the handler to ignore the reconcile result flips both to RED
(verified: `ok=false` / prior-snapshot-kept assertions fail).

Retargeted the pre-existing `main_tests` defer-clear test (renamed
`…_reconciles_bindings` → `…_reconcile_abort_fails_closed_3789`): it
previously codified the swallow (stored gen-2 + acked ok=true despite the
reconcile aborting at `missing_xsk_pin`); it now asserts the reconcile is
triggered but the missing-pin abort fails closed.

Full `cargo test --release` green (3408 lib pass / 2 pre-existing ignored /
0 failed, plus 46+8+16+1 in the other test targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
