### PR TITLE
fabric: count + name skipped fabric links, persist refresh (#3773)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27559,3 +27559,61 @@ top.
   end-to-end tests), userspace-dp/src/policy_tests.rs (4 semantics tests),
   docs/userspace-dataplane-architecture.md (#3783 histogram-slot-coverage
   paragraph)
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3773 (codex-161 M13+L4) — fabric-link build/refresh
+  observability + persistence. M13: `populate_fabrics`
+  (afxdp/forwarding_build/fib.rs) and `resolve_fabric_links_from_snapshots`
+  (afxdp/forwarding/mod.rs) silently `continue`'d over a fabric link with a
+  malformed peer/local MAC or peer address — no counter, log, or status, so
+  an HA cross-chassis fabric link that silently failed to install was
+  invisible. Introduced a SHARED `build_fabric_link_or_skip` classifier used
+  by both passes; a skip is now COUNTED into two cumulative diagnostic
+  atomics — `FABRIC_LINK_SKIPPED_MALFORMED` (invalid parent ifindex /
+  unparseable peer address / non-empty unparseable local|peer MAC) vs
+  `FABRIC_LINK_UNRESOLVED_PEER` (empty MAC awaiting neighbor/interface
+  resolution — the expected late-resolution `SyncFabricState` transient) —
+  RECORDED by name in `ForwardingState.fabric_skips`, and named once-per-
+  change in the journal by `log_fabric_skip_transition`
+  (coordinator/mod.rs, mirrors log_wg_endpoint_set_transition; wired into
+  snapshot_refresh + reconcile + refresh_fabric_links; snapshot_refresh
+  prunes a skip whose parent was re-added by the preserved-fabric merge).
+  Both atomics surface in status (ProcessStatus + refresh_status via new
+  Coordinator accessors) and Prometheus
+  (`xpf_userspace_fabric_link_{skipped_malformed,unresolved_peer}_total`).
+  Fabric is an HA optimization → skipped-with-visibility, NOT
+  fail-closed-whole-snapshot. L4: the `update_fabrics` handler
+  (server/handlers/mod.rs) was the only mutating verb that neither updated
+  the stored snapshot nor set persist_state, so late-resolved MACs lived
+  only in RAM and the published state file (Go `show` surface) kept stale
+  apply-time MACs; it now folds the resolved FabricSnapshots into the stored
+  snapshot + persists ONLY when the set changed (no 30s churn). Restart
+  continuity documented: the helper starts snapshot:None and never
+  self-restores — the Go daemon re-applies + re-runs populateFabricFwd
+  within seconds; the persisted set is the observability snapshot, not the
+  restore source. Added 5 Rust M13 tests (forwarding/tests.rs) + 2 L4
+  handler tests (server/tests.rs) + 1 Go wire round-trip test
+  (protocol_test.go); all RED-on-revert. Regenerated protocol_wire_v1.json
+  (2 new ProcessStatus keys). FULL `cargo test --release` green.
+- **File(s)**: userspace-dp/src/afxdp/types/forwarding.rs (FabricSkipReason
+  + FabricLinkSkip + ForwardingState.fabric_skips),
+  userspace-dp/src/afxdp/forwarding/mod.rs (2 atomics + record_fabric_skip +
+  build_fabric_link_or_skip + resolve_fabric_links_from_snapshots return
+  skips), userspace-dp/src/afxdp/forwarding_build/fib.rs (populate_fabrics),
+  userspace-dp/src/afxdp/coordinator/mod.rs (log_fabric_skip_transition),
+  userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs (refresh_fabric_links
+  + main-path prune/log), userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs,
+  userspace-dp/src/afxdp/coordinator/status.rs (2 accessors),
+  userspace-dp/src/protocol/control.rs (2 status fields),
+  userspace-dp/src/protocol/snapshot.rs (FabricSnapshot PartialEq),
+  userspace-dp/src/server/handlers/mod.rs (L4 persist),
+  userspace-dp/src/server/helpers.rs (refresh_status),
+  userspace-dp/src/server/lifecycle.rs (ProcessStatus init),
+  userspace-dp/src/afxdp/forwarding/tests.rs (5 tests),
+  userspace-dp/src/server/tests.rs (2 tests),
+  userspace-dp/tests/fixtures/protocol_wire_v1.json (regen),
+  pkg/dataplane/userspace/protocol.go (2 mirror fields),
+  pkg/dataplane/userspace/protocol_test.go (wire round-trip test),
+  pkg/api/metrics.go + metrics_descriptors.go + metrics_userspace.go
+  (2 Prometheus counters), docs/fabric-cross-chassis-fwd.md,
+  userspace-dp/src/afxdp/forwarding/README.md

--- a/docs/fabric-cross-chassis-fwd.md
+++ b/docs/fabric-cross-chassis-fwd.md
@@ -242,3 +242,80 @@ wheel's job, not the sweep's (see `pkg/cluster/README.md` and
 `userspace-dp/src/session/README.md` "Standby retention"). This keeps
 #270's empty-sweep back-off and avoids the >1/s control-socket contention
 CLAUDE.md warns against.
+
+## Fabric-link build/refresh observability + persistence (#3773)
+
+A fabric redirect can only fire if a `FabricLink` was actually built for
+the parent interface. Two resolution passes build them:
+
+- **snapshot build** — `populate_fabrics`
+  (`userspace-dp/src/afxdp/forwarding_build/fib.rs`), run for every
+  `build_forwarding_state` (config apply + route-churn `bump_fib`).
+- **runtime refresh** — `resolve_fabric_links_from_snapshots`
+  (`userspace-dp/src/afxdp/forwarding/mod.rs`), driven by the Go daemon's
+  `SyncFabricState`/`refreshFabricFwd` (`update_fabrics` control verb) once
+  ARP/NDP resolves the peer MAC that was unresolved at initial build.
+
+### M13 — skipped fabric links are counted + named (was a silent `continue`)
+
+Before #3773 each pass dropped a fabric link on a bare `continue` when
+`parent_ifindex <= 0`, the `peer_address` was unparseable, the `local_mac`
+was unresolvable, or the `peer_mac` was unresolvable — **no counter, log,
+or status**. An HA cross-chassis fabric link that silently failed to
+install (and therefore silently did not forward) was invisible; the
+operator had no way to see an unresolved fabric.
+
+Both passes now route the skip-vs-install decision through the shared
+`build_fabric_link_or_skip` classifier, which partitions skips into two
+cumulative diagnostic atomics (`forwarding/mod.rs`):
+
+- **`FABRIC_LINK_SKIPPED_MALFORMED`** — an invalid parent ifindex, an
+  unparseable peer address, or a **non-empty** local/peer MAC string that
+  failed to parse. A config/environment fault that will not self-heal.
+  Surfaced as `xpf_userspace_fabric_link_skipped_malformed_total`.
+- **`FABRIC_LINK_UNRESOLVED_PEER`** — an **empty** peer/local MAC field
+  still awaiting neighbor/interface resolution: the expected transient of
+  the late-resolution `SyncFabricState` path (peer MAC empty until ARP/NDP
+  resolves). Briefly non-zero at startup is normal; a persistently
+  climbing value means a fabric peer is not resolving. Surfaced as
+  `xpf_userspace_fabric_link_unresolved_peer_total`.
+
+Fabric is an HA *optimization*, not enforcement, so a malformed link is
+**skipped-with-visibility, not fail-closed-whole-snapshot** — the rest of
+the forwarding state still applies (a single bad fabric stanza must not
+blackhole the whole dataplane). This mirrors the #3771 M12
+`NEIGHBOR_UNKNOWN_STATE_SKIPPED` diagnostic-atomic pattern.
+
+The counters quantify; a named journal line qualifies. Each build/refresh
+records its skips (by fabric name + reason) in
+`ForwardingState.fabric_skips`, and `log_fabric_skip_transition`
+(`coordinator/mod.rs`, mirroring `log_wg_endpoint_set_transition`) emits
+`fabric skip set changed (<path>): [...] => [...]` **only when the set
+changes** — so a persistently unresolved/malformed fabric logs ONCE when
+it first appears (or changes reason), not on every 30s `SyncFabricState`
+tick or route-churn `bump_fib`. The `snapshot-refresh` path prunes a skip
+whose parent was re-added by the preserved-fabric merge (a link kept from
+the prior resolved set is not reported as skipped).
+
+### L4 — the `update_fabrics` refresh is now persisted
+
+`update_fabrics` (`server/handlers/mod.rs`) was the only mutating control
+verb that neither updated the stored snapshot nor set `persist_state`, so
+a late-resolved peer/local MAC lived **only** in the coordinator's
+in-memory forwarding state. The published state file (read by the Go
+control plane's `show` surface, and the last record a consumer sees) kept
+the stale apply-time (unresolved) fabric MACs.
+
+The handler now folds the freshly-resolved `FabricSnapshot`s into the
+stored snapshot and flags a write **only when the set actually changed**
+— so the 30s periodic refresh does not rewrite the state file on every
+unchanged tick.
+
+**Restart continuity is explicit and is provided by the Go control plane,
+not this file.** The helper starts with `snapshot: None`
+(`server/lifecycle.rs`) and never self-restores from the state file; on
+restart the daemon re-applies the full snapshot and re-runs
+`populateFabricFwd` (500 ms fast retries → 30 s periodic), which
+re-resolves and re-syncs the fabric MACs within seconds. The persisted
+fabric set is therefore the **observability snapshot** (so `show` reflects
+the resolved truth), not the restore source.

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -483,6 +483,10 @@ type xpfCollector struct {
 	neighborNetlinkRedumpUpsertsTotal       *prometheus.Desc
 	neighborPendingKeys                     *prometheus.Desc
 	negNeighKeys                            *prometheus.Desc
+	// #3773 (M13): fabric-link skip diagnostics — malformed value vs
+	// unresolved (empty) peer/local MAC.
+	fabricLinkSkippedMalformedTotal *prometheus.Desc
+	fabricLinkUnresolvedPeerTotal   *prometheus.Desc
 	// #1865: operator-visible WireGuard telemetry — per-tunnel
 	// handshake/encap/decap counters + drop reasons from the helper's
 	// wg_tunnels status rows. Label sets: {tunnel} (+ role / direction
@@ -780,6 +784,8 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.neighborNetlinkRedumpUpsertsTotal
 	ch <- c.neighborPendingKeys
 	ch <- c.negNeighKeys
+	ch <- c.fabricLinkSkippedMalformedTotal
+	ch <- c.fabricLinkUnresolvedPeerTotal
 	ch <- c.wgHandshakesCompletedTotal
 	ch <- c.wgHandshakeInitiationsCreatedTotal
 	ch <- c.wgHandshakeInitiationBuildFailuresTotal

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -1681,6 +1681,17 @@ func newCollector(srv *Server) *xpfCollector {
 			"Keys currently held in the per-binding negative neighbor caches, summed across bindings (gauge; lazy-TTL upper bound — an expired entry stays counted until its next access) (#1771 §2.6).",
 			nil, nil,
 		),
+		// #3773 (M13): fabric-link skip diagnostics.
+		fabricLinkSkippedMalformedTotal: prometheus.NewDesc(
+			"xpf_userspace_fabric_link_skipped_malformed_total",
+			"HA cross-chassis fabric links skipped during a forwarding build/refresh because a value was MALFORMED: an invalid parent ifindex, an unparseable peer address, or a non-empty local/peer MAC string that failed to parse. Non-zero (especially climbing) is a fabric config/environment fault an operator must fix; the helper journal names which fabric and why. Before #3773 these were silent (no counter, log, or status) (#3773 M13).",
+			nil, nil,
+		),
+		fabricLinkUnresolvedPeerTotal: prometheus.NewDesc(
+			"xpf_userspace_fabric_link_unresolved_peer_total",
+			"HA cross-chassis fabric links skipped during a forwarding build/refresh because a peer or local MAC was UNRESOLVED: an EMPTY MAC field still awaiting neighbor/interface resolution (the expected late-resolution SyncFabricState transient). Briefly non-zero at startup is normal; a persistently climbing value means a fabric peer is not resolving. A distinct, non-malformed state vs xpf_userspace_fabric_link_skipped_malformed_total (#3773 M13).",
+			nil, nil,
+		),
 		// #1865: per-tunnel WireGuard telemetry. The tunnel label is
 		// the tunnel interface NAME (stable across commits — #1873
 		// positional ids renumber and are never a label). Counters

--- a/pkg/api/metrics_neighbor_latency_test.go
+++ b/pkg/api/metrics_neighbor_latency_test.go
@@ -169,3 +169,32 @@ func TestEmitNeighborPhase3CountersAndGauges(t *testing.T) {
 	assertGaugeClose(t, got, c.neighborPendingKeys, nil, 3)
 	assertGaugeClose(t, got, c.negNeighKeys, nil, 1)
 }
+
+// #3773 (M13): value + type pin for the fabric-link skip counters emitted by
+// emitFabricSkipCounters. Both are CounterValue; a mixup or a dropped emit
+// fails this test. fail-on-revert: removing the emit leaves `got` without the
+// series and assertCounterClose fails.
+func TestEmitFabricSkipCounters(t *testing.T) {
+	newDesc := func(name string) *prometheus.Desc {
+		return prometheus.NewDesc(name, name, nil, nil)
+	}
+	c := &xpfCollector{
+		fabricLinkSkippedMalformedTotal: newDesc(
+			"xpf_userspace_fabric_link_skipped_malformed_total"),
+		fabricLinkUnresolvedPeerTotal: newDesc(
+			"xpf_userspace_fabric_link_unresolved_peer_total"),
+	}
+	status := dpuserspace.ProcessStatus{
+		FabricLinkSkippedMalformedTotal: 6,
+		FabricLinkUnresolvedPeerTotal:   2,
+	}
+	ch := make(chan prometheus.Metric, 8)
+	c.emitFabricSkipCounters(ch, status)
+	close(ch)
+	var got []prometheus.Metric
+	for m := range ch {
+		got = append(got, m)
+	}
+	assertCounterClose(t, got, c.fabricLinkSkippedMalformedTotal, nil, 6)
+	assertCounterClose(t, got, c.fabricLinkUnresolvedPeerTotal, nil, 2)
+}

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -50,6 +50,27 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitWireguardTelemetry(ch, status)
 	c.emitPolicyContentRejected(ch, status)
 	c.emitRejectObservability(ch, status)
+	c.emitFabricSkipCounters(ch, status)
+}
+
+// emitFabricSkipCounters exposes the #3773 (M13) fabric-link skip
+// diagnostics: a fabric link dropped during a forwarding build/refresh for a
+// MALFORMED value (invalid parent ifindex / unparseable peer address /
+// non-empty unparseable local|peer MAC) vs an UNRESOLVED peer/local MAC (empty
+// MAC awaiting neighbor/interface resolution — the expected SyncFabricState
+// transient). Both emitted unconditionally so a 0 is a real "no fabric
+// skipped" signal rather than an absent series.
+func (c *xpfCollector) emitFabricSkipCounters(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	ch <- prometheus.MustNewConstMetric(
+		c.fabricLinkSkippedMalformedTotal,
+		prometheus.CounterValue,
+		float64(status.FabricLinkSkippedMalformedTotal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fabricLinkUnresolvedPeerTotal,
+		prometheus.CounterValue,
+		float64(status.FabricLinkUnresolvedPeerTotal),
+	)
 }
 
 // emitRejectObservability exposes the #3657 source-split reject reply
@@ -355,18 +376,6 @@ func (c *xpfCollector) emitNeighborWarmCounters(ch chan<- prometheus.Metric, sta
 		c.negNeighKeys,
 		prometheus.GaugeValue,
 		float64(status.NegNeighKeys),
-	)
-	// #3773 (M13): fabric-link skip diagnostics. Emitted unconditionally so a
-	// 0 is a real "no fabric skipped" signal rather than an absent series.
-	ch <- prometheus.MustNewConstMetric(
-		c.fabricLinkSkippedMalformedTotal,
-		prometheus.CounterValue,
-		float64(status.FabricLinkSkippedMalformedTotal),
-	)
-	ch <- prometheus.MustNewConstMetric(
-		c.fabricLinkUnresolvedPeerTotal,
-		prometheus.CounterValue,
-		float64(status.FabricLinkUnresolvedPeerTotal),
 	)
 	// #1772: neighbor/ARP resolution LATENCY telemetry.
 	c.emitNeighborLatencyHistograms(ch, status)

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -356,6 +356,18 @@ func (c *xpfCollector) emitNeighborWarmCounters(ch chan<- prometheus.Metric, sta
 		prometheus.GaugeValue,
 		float64(status.NegNeighKeys),
 	)
+	// #3773 (M13): fabric-link skip diagnostics. Emitted unconditionally so a
+	// 0 is a real "no fabric skipped" signal rather than an absent series.
+	ch <- prometheus.MustNewConstMetric(
+		c.fabricLinkSkippedMalformedTotal,
+		prometheus.CounterValue,
+		float64(status.FabricLinkSkippedMalformedTotal),
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.fabricLinkUnresolvedPeerTotal,
+		prometheus.CounterValue,
+		float64(status.FabricLinkUnresolvedPeerTotal),
+	)
 	// #1772: neighbor/ARP resolution LATENCY telemetry.
 	c.emitNeighborLatencyHistograms(ch, status)
 }

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -1564,6 +1564,20 @@ type ProcessStatus struct {
 	// non-WG deployments and for older helpers (key omitted on the
 	// Rust side when no tunnel is configured).
 	WgTunnels []WgTunnelStatus `json:"wg_tunnels,omitempty"`
+	// #3773 (M13): fabric-link skip diagnostics. FabricLinkSkippedMalformed
+	// counts fabric links dropped during a forwarding build/refresh for a
+	// MALFORMED value (invalid parent ifindex, unparseable peer address, or a
+	// non-empty local/peer MAC that failed to parse) — a config/environment
+	// fault the operator must fix. FabricLinkUnresolvedPeer counts links
+	// dropped because a peer/local MAC was UNRESOLVED (an empty MAC field
+	// awaiting neighbor/interface resolution — the expected late-resolution
+	// SyncFabricState transient). Distinct counters so a benign unresolved
+	// peer is not conflated with a genuine misconfiguration. Both surfaced as
+	// xpf_userspace_fabric_link_skipped_malformed_total and
+	// xpf_userspace_fabric_link_unresolved_peer_total. Omitempty for wire
+	// compat with older helpers (default 0).
+	FabricLinkSkippedMalformedTotal uint64 `json:"fabric_link_skipped_malformed_total,omitempty"`
+	FabricLinkUnresolvedPeerTotal   uint64 `json:"fabric_link_unresolved_peer_total,omitempty"`
 }
 
 // WgPeerStatus mirrors the Rust WgPeerStatus in

--- a/pkg/dataplane/userspace/protocol_test.go
+++ b/pkg/dataplane/userspace/protocol_test.go
@@ -1562,6 +1562,52 @@ func TestProcessStatusNeighborPhase3CountersRoundTrip(t *testing.T) {
 	}
 }
 
+// #3773 (M13): wire pin for the fabric-link skip diagnostic counters. The Rust
+// helper serializes these via serde renames in
+// userspace-dp/src/protocol/control.rs; a key rename on either side silently
+// decodes as zero, so pin both tags here and verify the pre-#3773 (keys
+// absent) payload defaults to zero.
+func TestProcessStatusFabricSkipCountersRoundTrip(t *testing.T) {
+	in := ProcessStatus{
+		FabricLinkSkippedMalformedTotal: 4,
+		FabricLinkUnresolvedPeerTotal:   9,
+	}
+	raw, err := json.Marshal(&in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("unmarshal obj: %v", err)
+	}
+	for _, key := range []string{
+		"fabric_link_skipped_malformed_total",
+		"fabric_link_unresolved_peer_total",
+	} {
+		if _, ok := obj[key]; !ok {
+			t.Fatalf("wire key %q missing from ProcessStatus JSON: %s", key, string(raw))
+		}
+	}
+
+	var back ProcessStatus
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal ProcessStatus: %v", err)
+	}
+	if back.FabricLinkSkippedMalformedTotal != in.FabricLinkSkippedMalformedTotal ||
+		back.FabricLinkUnresolvedPeerTotal != in.FabricLinkUnresolvedPeerTotal {
+		t.Fatalf("round-trip mismatch: got %+v, want %+v", back, in)
+	}
+
+	// Pre-#3773 helper payload (keys absent) must decode to zero.
+	var legacy ProcessStatus
+	if err := json.Unmarshal([]byte(`{}`), &legacy); err != nil {
+		t.Fatalf("unmarshal legacy ProcessStatus: %v", err)
+	}
+	if legacy.FabricLinkSkippedMalformedTotal != 0 || legacy.FabricLinkUnresolvedPeerTotal != 0 {
+		t.Fatalf("legacy decode must zero-default fabric-skip fields: %+v", legacy)
+	}
+}
+
 // #2375: wire pin for the pending_neigh distinct-hop capacity-drop
 // counter. Mirrors the Rust
 // process_status_pending_neigh_capacity_drops_roundtrip test — a rename

--- a/userspace-dp/src/afxdp/coordinator/mod.rs
+++ b/userspace-dp/src/afxdp/coordinator/mod.rs
@@ -167,6 +167,42 @@ pub(in crate::afxdp) fn log_wg_endpoint_set_transition(
     }
 }
 
+/// #3773 (M13): stable, order-independent summary of a fabric-skip set for
+/// transition logging (`name:reason`, sorted). Empty when no fabric link was
+/// skipped — the common healthy case.
+fn fabric_skip_set_summary(skips: &[FabricLinkSkip]) -> String {
+    let mut items: Vec<String> = skips
+        .iter()
+        .map(|s| format!("{}:{}", s.name, s.reason.as_str()))
+        .collect();
+    items.sort();
+    items.join(", ")
+}
+
+/// #3773 (M13): log a fabric-skip-set transition between two forwarding
+/// states, mirroring `log_wg_endpoint_set_transition`. Silent when the skip set
+/// is unchanged (the common case, including the healthy empty=>empty), so a
+/// PERSISTENTLY malformed/unresolved fabric logs ONCE when it first appears (or
+/// changes reason) rather than on every 30s `SyncFabricState` refresh / route
+/// churn `bump_fib` — state-transition cadence per the logging rules. Names
+/// each skipped fabric and why, so an operator triaging a dead HA
+/// cross-chassis path has a journal line instead of a silent skip. The
+/// cumulative `FABRIC_LINK_SKIPPED_MALFORMED` / `FABRIC_LINK_UNRESOLVED_PEER`
+/// atomics (status/Prometheus) quantify it in parallel.
+pub(in crate::afxdp) fn log_fabric_skip_transition(
+    path: &str,
+    old: &[FabricLinkSkip],
+    new: &[FabricLinkSkip],
+) {
+    let old_set = fabric_skip_set_summary(old);
+    let new_set = fabric_skip_set_summary(new);
+    if old_set != new_set {
+        eprintln!(
+            "xpf-userspace-dp: fabric skip set changed ({path}): [{old_set}] => [{new_set}]"
+        );
+    }
+}
+
 pub struct Coordinator {
     pub(crate) bpf_maps: BpfMaps,
     pub(crate) slow_path: Option<Arc<SlowPathReinjector>>,

--- a/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
+++ b/userspace-dp/src/afxdp/coordinator/reconcile/snapshot.rs
@@ -301,6 +301,15 @@ pub(super) fn apply_snapshot(
     // #1866 D3: WG endpoint-set transition log at the reconcile apply
     // boundary (mirrors refresh_runtime_snapshot).
     super::super::log_wg_endpoint_set_transition("reconcile", &coord.forwarding, &new_forwarding);
+    // #3773 (M13): fabric-skip transition log at the reconcile apply boundary
+    // (mirrors the WG log). `coord.forwarding` was defaulted by
+    // `stop_inner(false)`, so this names the reconcile build's skipped fabric
+    // links; the cumulative malformed/unresolved atomics quantify them.
+    super::super::log_fabric_skip_transition(
+        "reconcile",
+        &coord.forwarding.fabric_skips,
+        &new_forwarding.fabric_skips,
+    );
     // #1873 R-D: the purge diff runs against the tunnel-owner map
     // captured BEFORE teardown (AGY code r3) — stop_inner(false) has
     // already defaulted coord.forwarding, so diffing the live state

--- a/userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs
+++ b/userspace-dp/src/afxdp/coordinator/snapshot_refresh.rs
@@ -20,18 +20,49 @@ impl super::Coordinator {
     /// shared Arc-backed state used by workers, so refreshed fabric links
     /// become visible to workers as soon as the new values are published.
     pub fn refresh_fabric_links(&mut self, snapshots: &[crate::FabricSnapshot]) {
-        let new_fabrics = resolve_fabric_links_from_snapshots(
+        let (new_fabrics, new_skips) = resolve_fabric_links_from_snapshots(
             snapshots,
             &self.forwarding.egress,
             &self.neighbors.dynamic,
         );
-        if !new_fabrics.is_empty() {
+        // Mirror the pre-#3773 gate: only REPLACE the fabric set when at least
+        // one link resolved this pass, so an all-unresolved refresh keeps the
+        // working set (from a prior SyncFabricState) instead of wiping it.
+        let replace = !new_fabrics.is_empty();
+        // #3773 (M13): the skip list is pruned against whichever fabric set is
+        // FINAL — a link kept from the prior resolved set is not reported as
+        // "skipped" for the operator even if THIS pass could not re-resolve it
+        // (its counter already bumped inside the resolver; the pruning only
+        // governs the named status/log surface, not the cumulative atomics).
+        let final_parents: Vec<i32> = if replace {
+            new_fabrics.iter().map(|f| f.parent_ifindex).collect()
+        } else {
+            self.forwarding
+                .fabrics
+                .iter()
+                .map(|f| f.parent_ifindex)
+                .collect()
+        };
+        let pruned: Vec<FabricLinkSkip> = new_skips
+            .into_iter()
+            .filter(|s| !final_parents.contains(&s.parent_ifindex))
+            .collect();
+        log_fabric_skip_transition("fabric-refresh", &self.forwarding.fabric_skips, &pruned);
+        let skips_changed = self.forwarding.fabric_skips != pruned;
+        if replace {
             self.forwarding.fabrics = new_fabrics.clone();
+            self.forwarding.fabric_skips = pruned;
             self.ha.fabrics.store(Arc::new(new_fabrics));
             // Also update shared_forwarding so workers see the new fabric
             // links for fabric redirect resolution. Without this, workers
             // use the snapshot's forwarding state which may have empty fabrics
             // if the peer MAC wasn't resolved at snapshot time.
+            self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
+        } else if skips_changed {
+            // Nothing resolved this pass, but the skip diagnostics changed —
+            // publish the updated (named) skip set without disturbing the
+            // preserved working fabric links.
+            self.forwarding.fabric_skips = pruned;
             self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
         }
     }
@@ -122,6 +153,9 @@ impl super::Coordinator {
         // may not include them if the peer MAC wasn't resolved at
         // snapshot build time. Always keep the better-resolved set.
         let preserved_fabrics = self.forwarding.fabrics.clone();
+        // #3773 (M13): capture the prior fabric-skip set so the post-merge
+        // transition log fires only when the named skip set actually changes.
+        let old_fabric_skips = self.forwarding.fabric_skips.clone();
         // #3766: build the new forwarding state FIRST, before ANY
         // self-mutation. The policy preflight above only validates
         // POLICY state; a non-policy integrity fault surfaces only here.
@@ -246,6 +280,26 @@ impl super::Coordinator {
                 }
             }
         }
+        // #3773 (M13): the new build's `populate_fabrics` recorded its skips in
+        // `self.forwarding.fabric_skips`. After the preserved-fabric merge
+        // above, prune any skip whose parent is now present in the final
+        // fabric set (a link kept from the prior resolved set is not reported
+        // as skipped), then log the transition against the prior skip set —
+        // once per change, not per route-churn `bump_fib`.
+        let final_parents: Vec<i32> = self
+            .forwarding
+            .fabrics
+            .iter()
+            .map(|f| f.parent_ifindex)
+            .collect();
+        self.forwarding
+            .fabric_skips
+            .retain(|s| !final_parents.contains(&s.parent_ifindex));
+        log_fabric_skip_transition(
+            "snapshot-refresh",
+            &old_fabric_skips,
+            &self.forwarding.fabric_skips,
+        );
         self.shared_validation.store(Arc::new(self.validation));
         self.ha.forwarding.store(Arc::new(self.forwarding.clone()));
         // #1432 S2a (Copilot C1): reconcile WG control threads on every

--- a/userspace-dp/src/afxdp/coordinator/status.rs
+++ b/userspace-dp/src/afxdp/coordinator/status.rs
@@ -15,6 +15,22 @@ impl super::Coordinator {
         (entries, generation)
     }
 
+    /// #3773 (M13): cumulative count of fabric links skipped for a MALFORMED
+    /// value (invalid parent ifindex / unparseable peer address / a NON-EMPTY
+    /// unparseable local|peer MAC). Surfaced as
+    /// `xpf_userspace_fabric_link_skipped_malformed_total`.
+    pub fn fabric_link_skipped_malformed_total(&self) -> u64 {
+        crate::afxdp::forwarding::FABRIC_LINK_SKIPPED_MALFORMED.load(Ordering::Relaxed)
+    }
+
+    /// #3773 (M13): cumulative count of fabric links skipped for an UNRESOLVED
+    /// peer/local MAC (an EMPTY MAC field awaiting neighbor/interface
+    /// resolution — the expected late-resolution transient). Surfaced as
+    /// `xpf_userspace_fabric_link_unresolved_peer_total`.
+    pub fn fabric_link_unresolved_peer_total(&self) -> u64 {
+        crate::afxdp::forwarding::FABRIC_LINK_UNRESOLVED_PEER.load(Ordering::Relaxed)
+    }
+
     /// #710: sum of `no_owner_binding_drops` across every binding's
     /// `BindingLiveState`. The per-binding increment site lives in
     /// `apply_worker_shaped_tx_requests` and mechanically lands on

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -167,6 +167,21 @@ next-hops, preference 0). The wire specimen lives in
       snapshot-refresh manager-key set, the `update_neighbors` handler,
       and `parse_neighbor_entries` share the same gate so an installed
       neighbor is never pruned as a stale key.
+    - **Fabric-link skips (#3773 M13).** `build_fabric_link_or_skip` is the
+      SHARED classifier for both fabric-resolution passes
+      (`populate_fabrics` snapshot build, `resolve_fabric_links_from_snapshots`
+      runtime refresh). A skipped fabric link is no longer a silent
+      `continue`: it is counted by the `FABRIC_LINK_SKIPPED_MALFORMED`
+      (invalid parent ifindex / unparseable peer address / non-empty
+      unparseable local|peer MAC) or `FABRIC_LINK_UNRESOLVED_PEER` (empty MAC
+      awaiting neighbor/interface resolution — the expected `SyncFabricState`
+      transient) diagnostic atomic, recorded by name in
+      `ForwardingState.fabric_skips`, and named once-per-change in the journal
+      by `log_fabric_skip_transition`. Both atomics surface in status/Prometheus
+      (`xpf_userspace_fabric_link_{skipped_malformed,unresolved_peer}_total`).
+      Fabric is an HA optimization, so a malformed link is
+      skipped-with-visibility, NOT fail-closed-whole-snapshot. See
+      `docs/fabric-cross-chassis-fwd.md`.
 
 ## Where it sits
 

--- a/userspace-dp/src/afxdp/forwarding/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding/mod.rs
@@ -77,6 +77,105 @@ pub(super) fn canonical_route_table(table: &str, is_ipv6: bool) -> String {
 pub(in crate::afxdp) static NEIGHBOR_UNKNOWN_STATE_SKIPPED: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+/// #3773 (M13): count of fabric links skipped during a forwarding
+/// build/refresh because a value was MALFORMED — `parent_ifindex <= 0`, an
+/// unparseable `peer_address`, or a NON-EMPTY local/peer MAC string that failed
+/// to parse. Before #3773 each was a bare `continue` with no signal, so an HA
+/// cross-chassis fabric link that silently failed to install (and therefore
+/// silently did not forward) was invisible. A non-zero — especially a steadily
+/// climbing — value is a config/environment fault the operator must fix; the
+/// paired `log_fabric_skip_transition` journal line names which fabric and why.
+/// Bumps once per malformed fabric per build/refresh pass, in both
+/// `populate_fabrics` (snapshot build) and `resolve_fabric_links_from_snapshots`
+/// (runtime refresh). Surfaced in status/Prometheus
+/// (`xpf_userspace_fabric_link_skipped_malformed_total`).
+pub(in crate::afxdp) static FABRIC_LINK_SKIPPED_MALFORMED: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// #3773 (M13): count of fabric links skipped during a forwarding
+/// build/refresh because the peer or local MAC could not be resolved YET — an
+/// EMPTY MAC field with no neighbor (peer) or interface (local) MAC available.
+/// This is the EXPECTED transient of the late-resolution `SyncFabricState` path
+/// (`FabricSnapshot.peer_mac` is empty until ARP/NDP resolves the peer). A
+/// briefly non-zero value at startup is normal; a PERSISTENTLY non-zero value
+/// means a fabric peer is not resolving (peer down, wrong sync IP, L2 broken) —
+/// a distinct, non-malformed state per the issue's intent (an unresolved-peer
+/// state is fine; a SILENT skip is not). Surfaced in status/Prometheus
+/// (`xpf_userspace_fabric_link_unresolved_peer_total`).
+pub(in crate::afxdp) static FABRIC_LINK_UNRESOLVED_PEER: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// #3773 (M13): bump the appropriate cumulative counter for a skipped fabric
+/// link and return the named `FabricLinkSkip` record (for the ForwardingState
+/// skip list + the transition log). Malformed reasons bump
+/// `FABRIC_LINK_SKIPPED_MALFORMED`; unresolved-MAC reasons bump
+/// `FABRIC_LINK_UNRESOLVED_PEER`.
+fn record_fabric_skip(fabric: &crate::FabricSnapshot, reason: FabricSkipReason) -> FabricLinkSkip {
+    if reason.is_malformed() {
+        FABRIC_LINK_SKIPPED_MALFORMED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    } else {
+        FABRIC_LINK_UNRESOLVED_PEER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    FabricLinkSkip {
+        name: fabric.name.clone(),
+        parent_ifindex: fabric.parent_ifindex,
+        reason,
+    }
+}
+
+/// #3773 (M13): SHARED fabric-link classifier for both build paths
+/// (`populate_fabrics` and `resolve_fabric_links_from_snapshots`). Each caller
+/// resolves the peer address + local/peer MACs through its own iface/neighbor
+/// context, then hands the resolved `Option`s here; this centralizes the
+/// skip-vs-install decision AND the counter/record so the two paths cannot
+/// drift. Returns the installable `FabricLink` or a counted `FabricLinkSkip`.
+/// Checks proceed in the pre-#3773 order (parent → peer address → local MAC →
+/// peer MAC) so the FIRST failing reason is reported. An EMPTY MAC field is an
+/// UNRESOLVED skip (transient); a NON-EMPTY MAC field that still resolved to
+/// `None` is a MALFORMED skip (the string failed to parse).
+pub(in crate::afxdp) fn build_fabric_link_or_skip(
+    fabric: &crate::FabricSnapshot,
+    peer_addr: Option<std::net::IpAddr>,
+    local_mac: Option<[u8; 6]>,
+    peer_mac: Option<[u8; 6]>,
+) -> Result<FabricLink, FabricLinkSkip> {
+    if fabric.parent_ifindex <= 0 {
+        return Err(record_fabric_skip(
+            fabric,
+            FabricSkipReason::InvalidParentIfindex,
+        ));
+    }
+    let Some(peer_addr) = peer_addr else {
+        return Err(record_fabric_skip(
+            fabric,
+            FabricSkipReason::UnparseablePeerAddress,
+        ));
+    };
+    let Some(local_mac) = local_mac else {
+        let reason = if fabric.local_mac.trim().is_empty() {
+            FabricSkipReason::UnresolvedLocalMac
+        } else {
+            FabricSkipReason::MalformedLocalMac
+        };
+        return Err(record_fabric_skip(fabric, reason));
+    };
+    let Some(peer_mac) = peer_mac else {
+        let reason = if fabric.peer_mac.trim().is_empty() {
+            FabricSkipReason::UnresolvedPeerMac
+        } else {
+            FabricSkipReason::MalformedPeerMac
+        };
+        return Err(record_fabric_skip(fabric, reason));
+    };
+    Ok(FabricLink {
+        parent_ifindex: fabric.parent_ifindex,
+        overlay_ifindex: fabric.overlay_ifindex,
+        peer_addr,
+        peer_mac,
+        local_mac,
+    })
+}
+
 /// #3771 (M12): three-way classification of a kernel neighbor state string for
 /// FIB installation.
 ///
@@ -441,34 +540,33 @@ pub(super) fn resolve_fabric_links_from_snapshots(
     snapshots: &[crate::FabricSnapshot],
     egress: &FastMap<i32, EgressInterface>,
     dynamic_neighbors: &Arc<ShardedNeighborMap>,
-) -> Vec<FabricLink> {
+) -> (Vec<FabricLink>, Vec<FabricLinkSkip>) {
     let mut out = Vec::with_capacity(snapshots.len());
+    let mut skips = Vec::new();
     for fabric in snapshots {
-        if fabric.parent_ifindex <= 0 {
-            continue;
-        }
-        let Ok(peer_addr) = fabric.peer_address.parse::<IpAddr>() else {
-            continue;
-        };
+        // Resolve the same inputs the pre-#3773 code did, then classify /
+        // count the skip-vs-install decision through the shared helper so this
+        // runtime-refresh path and `populate_fabrics` cannot diverge (#3773
+        // M13). The peer-MAC neighbor lookup keys on the parsed peer address,
+        // so it is gated on a successful parse; an unparseable address is
+        // reported as `UnparseablePeerAddress` regardless of the MAC fields.
+        let peer_addr = fabric.peer_address.parse::<IpAddr>().ok();
         let local_mac = parse_mac(&fabric.local_mac)
             .or_else(|| egress.get(&fabric.parent_ifindex).map(|e| e.src_mac));
-        let Some(local_mac) = local_mac else { continue };
-        let peer_mac = parse_mac(&fabric.peer_mac).or_else(|| {
-            dynamic_neighbors
-                .get(&(fabric.overlay_ifindex, peer_addr))
-                .or_else(|| dynamic_neighbors.get(&(fabric.parent_ifindex, peer_addr)))
-                .map(|e| e.mac)
+        let peer_mac = peer_addr.and_then(|addr| {
+            parse_mac(&fabric.peer_mac).or_else(|| {
+                dynamic_neighbors
+                    .get(&(fabric.overlay_ifindex, addr))
+                    .or_else(|| dynamic_neighbors.get(&(fabric.parent_ifindex, addr)))
+                    .map(|e| e.mac)
+            })
         });
-        let Some(peer_mac) = peer_mac else { continue };
-        out.push(FabricLink {
-            parent_ifindex: fabric.parent_ifindex,
-            overlay_ifindex: fabric.overlay_ifindex,
-            peer_addr,
-            peer_mac,
-            local_mac,
-        });
+        match build_fabric_link_or_skip(fabric, peer_addr, local_mac, peer_mac) {
+            Ok(link) => out.push(link),
+            Err(skip) => skips.push(skip),
+        }
     }
-    out
+    (out, skips)
 }
 
 pub(super) fn resolve_fabric_redirect(

--- a/userspace-dp/src/afxdp/forwarding/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding/tests.rs
@@ -4015,3 +4015,132 @@ fn select_route_next_hop_consistent_under_liveness_flip_between_passes() {
         "selected next-hop must be a real candidate from the snapshot",
     );
 }
+
+// ---------------------------------------------------------------------------
+// #3773 (M13): fabric-link skip classification. Before #3773 populate_fabrics
+// dropped a fabric link with a malformed peer/local MAC or peer address on a
+// bare `continue` — no counter, log, or status — so an HA cross-chassis fabric
+// link that silently failed to install (and therefore silently did not
+// forward) was invisible to the operator. These tests assert the deterministic
+// per-build `fabric_skips` record (race-free) plus the cumulative diagnostic
+// atomic (`> before`, safe for a monotonic counter under parallel tests).
+// fail-on-revert: reinstating the bare `continue` leaves `fabric_skips` empty
+// and bumps no counter → RED.
+// ---------------------------------------------------------------------------
+
+fn fabric_snapshot_template() -> FabricSnapshot {
+    FabricSnapshot {
+        name: "fab0".into(),
+        parent_interface: "ge-0/0/0".into(),
+        parent_linux_name: "ge-0-0-0".into(),
+        parent_ifindex: 21,
+        overlay_linux_name: "fab0".into(),
+        overlay_ifindex: 101,
+        rx_queues: 2,
+        peer_address: "10.99.13.2".into(),
+        local_mac: "02:bf:72:ff:00:01".into(),
+        peer_mac: "00:aa:bb:cc:dd:ee".into(),
+    }
+}
+
+#[test]
+fn fabric_link_well_formed_installs_with_no_skip() {
+    let mut snapshot = nat_snapshot();
+    snapshot.fabrics = vec![fabric_snapshot_template()];
+    let state = build_forwarding_state(&snapshot);
+    assert_eq!(state.fabrics.len(), 1, "a well-formed fabric must install");
+    assert!(
+        state.fabric_skips.is_empty(),
+        "a well-formed fabric must not be recorded as skipped: {:?}",
+        state.fabric_skips
+    );
+}
+
+#[test]
+fn fabric_link_malformed_peer_mac_is_skipped_and_counted() {
+    let before = crate::afxdp::forwarding::FABRIC_LINK_SKIPPED_MALFORMED
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let mut snapshot = nat_snapshot();
+    let mut fab = fabric_snapshot_template();
+    fab.peer_mac = "not-a-mac".into(); // NON-EMPTY but unparseable
+    snapshot.fabrics = vec![fab];
+    let state = build_forwarding_state(&snapshot);
+    assert!(
+        state.fabrics.is_empty(),
+        "a fabric with a malformed peer MAC must not install"
+    );
+    assert_eq!(state.fabric_skips.len(), 1, "the skip must be recorded");
+    assert_eq!(state.fabric_skips[0].name, "fab0");
+    assert_eq!(
+        state.fabric_skips[0].reason,
+        FabricSkipReason::MalformedPeerMac
+    );
+    assert!(state.fabric_skips[0].reason.is_malformed());
+    let after = crate::afxdp::forwarding::FABRIC_LINK_SKIPPED_MALFORMED
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        after > before,
+        "a malformed fabric must bump FABRIC_LINK_SKIPPED_MALFORMED"
+    );
+}
+
+#[test]
+fn fabric_link_invalid_parent_ifindex_is_skipped_malformed() {
+    let mut snapshot = nat_snapshot();
+    let mut fab = fabric_snapshot_template();
+    fab.parent_ifindex = 0; // unusable parent netdev index
+    snapshot.fabrics = vec![fab];
+    let state = build_forwarding_state(&snapshot);
+    assert!(state.fabrics.is_empty());
+    assert_eq!(state.fabric_skips.len(), 1);
+    assert_eq!(
+        state.fabric_skips[0].reason,
+        FabricSkipReason::InvalidParentIfindex
+    );
+    assert!(state.fabric_skips[0].reason.is_malformed());
+}
+
+#[test]
+fn fabric_link_unparseable_peer_address_is_skipped_malformed() {
+    let mut snapshot = nat_snapshot();
+    let mut fab = fabric_snapshot_template();
+    fab.peer_address = "not-an-ip".into();
+    snapshot.fabrics = vec![fab];
+    let state = build_forwarding_state(&snapshot);
+    assert!(state.fabrics.is_empty());
+    assert_eq!(state.fabric_skips.len(), 1);
+    assert_eq!(
+        state.fabric_skips[0].reason,
+        FabricSkipReason::UnparseablePeerAddress
+    );
+}
+
+#[test]
+fn fabric_link_empty_peer_mac_is_skipped_as_unresolved_peer() {
+    let before = crate::afxdp::forwarding::FABRIC_LINK_UNRESOLVED_PEER
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let mut snapshot = nat_snapshot();
+    let mut fab = fabric_snapshot_template();
+    // EMPTY peer MAC + a peer address with no matching neighbor entry: the
+    // expected late-resolution transient (awaiting ARP/NDP), classified
+    // UNRESOLVED rather than malformed.
+    fab.peer_mac = String::new();
+    snapshot.fabrics = vec![fab];
+    let state = build_forwarding_state(&snapshot);
+    assert!(state.fabrics.is_empty());
+    assert_eq!(state.fabric_skips.len(), 1);
+    assert_eq!(
+        state.fabric_skips[0].reason,
+        FabricSkipReason::UnresolvedPeerMac
+    );
+    assert!(
+        !state.fabric_skips[0].reason.is_malformed(),
+        "an empty (unresolved) peer MAC is a distinct non-malformed state"
+    );
+    let after = crate::afxdp::forwarding::FABRIC_LINK_UNRESOLVED_PEER
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        after > before,
+        "an unresolved fabric peer must bump FABRIC_LINK_UNRESOLVED_PEER"
+    );
+}

--- a/userspace-dp/src/afxdp/forwarding_build/fib.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/fib.rs
@@ -226,34 +226,31 @@ pub(super) fn populate_fabrics(
     iface_ctx: &IfaceIndex,
 ) {
     for fabric in &snapshot.fabrics {
-        if fabric.parent_ifindex <= 0 {
-            continue;
-        }
-        let Ok(peer_addr) = fabric.peer_address.parse::<IpAddr>() else {
-            continue;
-        };
+        // #3773 (M13): resolve the peer address + local/peer MAC through the
+        // build-time iface/neighbor context, then classify the skip-vs-install
+        // decision through the SHARED helper so this snapshot-build path and
+        // the runtime-refresh path (`resolve_fabric_links_from_snapshots`)
+        // stay in lockstep. A skipped link is COUNTED (malformed vs
+        // unresolved-peer) and RECORDED by name in `state.fabric_skips` — no
+        // more silent `continue`.
+        let peer_addr = fabric.peer_address.parse::<IpAddr>().ok();
         let local_mac = parse_mac(&fabric.local_mac)
             .or_else(|| iface_ctx.mac_by_ifindex.get(&fabric.parent_ifindex).copied());
-        let Some(local_mac) = local_mac else {
-            continue;
-        };
-        let peer_mac = parse_mac(&fabric.peer_mac).or_else(|| {
-            state
-                .neighbors
-                .get(&(fabric.overlay_ifindex, peer_addr))
-                .or_else(|| state.neighbors.get(&(fabric.parent_ifindex, peer_addr)))
-                .map(|entry| entry.mac)
+        let peer_mac = peer_addr.and_then(|addr| {
+            parse_mac(&fabric.peer_mac).or_else(|| {
+                state
+                    .neighbors
+                    .get(&(fabric.overlay_ifindex, addr))
+                    .or_else(|| state.neighbors.get(&(fabric.parent_ifindex, addr)))
+                    .map(|entry| entry.mac)
+            })
         });
-        let Some(peer_mac) = peer_mac else {
-            continue;
-        };
-        state.fabrics.push(FabricLink {
-            parent_ifindex: fabric.parent_ifindex,
-            overlay_ifindex: fabric.overlay_ifindex,
-            peer_addr,
-            peer_mac,
-            local_mac,
-        });
+        match crate::afxdp::forwarding::build_fabric_link_or_skip(
+            fabric, peer_addr, local_mac, peer_mac,
+        ) {
+            Ok(link) => state.fabrics.push(link),
+            Err(skip) => state.fabric_skips.push(skip),
+        }
     }
 }
 

--- a/userspace-dp/src/afxdp/types/forwarding.rs
+++ b/userspace-dp/src/afxdp/types/forwarding.rs
@@ -141,6 +141,23 @@ pub(in crate::afxdp) struct ForwardingState {
     pub(in crate::afxdp) egress: FastMap<i32, EgressInterface>,
     pub(in crate::afxdp) ingress_logical_ifindex: FastMap<(i32, u16), i32>,
     pub(in crate::afxdp) fabrics: Vec<FabricLink>,
+    /// #3773 (M13): fabric links this build/refresh pass SKIPPED because a
+    /// value was malformed (`parent_ifindex <= 0`, an unparseable
+    /// `peer_address`, or a NON-EMPTY unparseable local/peer MAC) or because
+    /// the peer/local MAC could not be resolved yet (an EMPTY MAC field
+    /// awaiting neighbor/interface resolution — the expected transient of the
+    /// late-resolution `SyncFabricState` path). Before #3773 each skip was a
+    /// bare `continue` with no counter, log, or status, so an HA cross-chassis
+    /// fabric link that silently failed to install was invisible to the
+    /// operator. Populated by `populate_fabrics` (snapshot build) and
+    /// `resolve_fabric_links_from_snapshots` (runtime refresh); each push also
+    /// bumps the cumulative `FABRIC_LINK_SKIPPED_MALFORMED` /
+    /// `FABRIC_LINK_UNRESOLVED_PEER` diagnostic atomics surfaced in
+    /// status/Prometheus, and a transition (`log_fabric_skip_transition`)
+    /// names the link in the journal. This list is the most-recent
+    /// resolution pass's skips — the coordinator prunes an entry whose
+    /// parent is re-added by the preserved-fabric merge (snapshot_refresh).
+    pub(in crate::afxdp) fabric_skips: Vec<FabricLinkSkip>,
     pub(in crate::afxdp) allow_dns_reply: bool,
     pub(in crate::afxdp) allow_embedded_icmp: bool,
     /// `security alg <proto> disable` bitfield (#2008 H3/H4): bit 0 DNS,
@@ -702,6 +719,73 @@ pub(in crate::afxdp) struct FabricLink {
     pub(in crate::afxdp) peer_addr: IpAddr,
     pub(in crate::afxdp) peer_mac: [u8; 6],
     pub(in crate::afxdp) local_mac: [u8; 6],
+}
+
+/// #3773 (M13): why a configured fabric link was skipped during a forwarding
+/// build/refresh pass. `is_malformed()` partitions the reasons into the two
+/// cumulative counters: a MALFORMED value (an unusable parent ifindex, an
+/// unparseable peer address, or a NON-EMPTY MAC string that fails to parse) vs
+/// an UNRESOLVED peer/local MAC (an EMPTY MAC field still awaiting neighbor /
+/// interface resolution — the expected transient the late-resolution
+/// `SyncFabricState` path fills in). A persistently non-zero UNRESOLVED count
+/// is a distinct, benign-until-persistent state; a non-zero MALFORMED count is
+/// a config/environment fault an operator must fix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) enum FabricSkipReason {
+    /// `parent_ifindex <= 0` — the fabric parent netdev index is unusable.
+    InvalidParentIfindex,
+    /// `peer_address` does not parse as an IP address.
+    UnparseablePeerAddress,
+    /// A NON-EMPTY `local_mac` string failed to parse (and no parent-ifindex
+    /// MAC fallback was available).
+    MalformedLocalMac,
+    /// An EMPTY `local_mac` with no resolvable parent-ifindex MAC — awaiting
+    /// interface MAC resolution.
+    UnresolvedLocalMac,
+    /// A NON-EMPTY `peer_mac` string failed to parse (and no neighbor entry
+    /// resolved it).
+    MalformedPeerMac,
+    /// An EMPTY `peer_mac` with no resolved neighbor — awaiting ARP/NDP
+    /// resolution (the common startup transient).
+    UnresolvedPeerMac,
+}
+
+impl FabricSkipReason {
+    /// True for a malformed value (a config/environment fault that will not
+    /// self-heal), false for an unresolved-but-well-formed peer/local MAC (the
+    /// expected late-resolution transient).
+    pub(in crate::afxdp) fn is_malformed(self) -> bool {
+        matches!(
+            self,
+            FabricSkipReason::InvalidParentIfindex
+                | FabricSkipReason::UnparseablePeerAddress
+                | FabricSkipReason::MalformedLocalMac
+                | FabricSkipReason::MalformedPeerMac
+        )
+    }
+
+    pub(in crate::afxdp) fn as_str(self) -> &'static str {
+        match self {
+            FabricSkipReason::InvalidParentIfindex => "invalid-parent-ifindex",
+            FabricSkipReason::UnparseablePeerAddress => "unparseable-peer-address",
+            FabricSkipReason::MalformedLocalMac => "malformed-local-mac",
+            FabricSkipReason::UnresolvedLocalMac => "unresolved-local-mac",
+            FabricSkipReason::MalformedPeerMac => "malformed-peer-mac",
+            FabricSkipReason::UnresolvedPeerMac => "unresolved-peer-mac",
+        }
+    }
+}
+
+/// #3773 (M13): a skipped fabric link, named for operator diagnostics.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(in crate::afxdp) struct FabricLinkSkip {
+    /// The configured fabric name (`FabricSnapshot.name`, e.g. `fab0`).
+    pub(in crate::afxdp) name: String,
+    /// The parent netdev ifindex the skip pertained to (`<= 0` for an
+    /// `InvalidParentIfindex` skip). Used by the preserved-fabric merge to
+    /// prune a skip whose parent was re-added from the prior resolved set.
+    pub(in crate::afxdp) parent_ifindex: i32,
+    pub(in crate::afxdp) reason: FabricSkipReason,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/userspace-dp/src/protocol/control.rs
+++ b/userspace-dp/src/protocol/control.rs
@@ -569,6 +569,23 @@ pub(crate) struct ProcessStatus {
     /// Monotonic timestamp (secs) of the last HA flow cache flush (#312).
     #[serde(rename = "last_cache_flush_at", default)]
     pub last_cache_flush_at: u64,
+    /// #3773 (M13): cumulative count of fabric links skipped during a
+    /// forwarding build/refresh because a value was MALFORMED — an invalid
+    /// parent ifindex, an unparseable peer address, or a NON-EMPTY local/peer
+    /// MAC string that failed to parse. A non-zero (especially climbing) value
+    /// is a fabric config/environment fault an operator must fix; the helper
+    /// journal names which fabric and why. Additive / defaulted for
+    /// mixed-version compat.
+    #[serde(rename = "fabric_link_skipped_malformed_total", default)]
+    pub fabric_link_skipped_malformed_total: u64,
+    /// #3773 (M13): cumulative count of fabric links skipped because the peer
+    /// or local MAC was UNRESOLVED — an EMPTY MAC field still awaiting
+    /// neighbor/interface resolution (the expected late-resolution
+    /// `SyncFabricState` transient). Briefly non-zero at startup is normal; a
+    /// PERSISTENTLY climbing value means a fabric peer is not resolving. A
+    /// distinct, non-malformed state per #3773.
+    #[serde(rename = "fabric_link_unresolved_peer_total", default)]
+    pub fabric_link_unresolved_peer_total: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -418,7 +418,7 @@ pub(crate) struct ZoneSnapshot {
     pub tcp_rst: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 pub(crate) struct FabricSnapshot {
     pub name: String,
     #[serde(rename = "parent_interface", default)]

--- a/userspace-dp/src/server/handlers/mod.rs
+++ b/userspace-dp/src/server/handlers/mod.rs
@@ -136,6 +136,33 @@ pub(crate) fn handle_stream(
             "update_fabrics" => {
                 if let Some(fabrics) = request.fabrics.as_ref() {
                     guard.afxdp.refresh_fabric_links(fabrics);
+                    // #3773 (L4): PERSIST the resolved fabric set. Before #3773
+                    // this arm was the ONLY mutating handler that neither
+                    // updated the persisted snapshot nor set `persist_state`, so
+                    // the late-resolved peer/local MACs from the SyncFabricState
+                    // path lived only in the coordinator's in-memory forwarding
+                    // state — the published state file (read by the Go control
+                    // plane's `show` surface) kept the stale apply-time fabric
+                    // MACs, and any consumer of the last-written state saw them
+                    // too. Fold the freshly-resolved FabricSnapshots into the
+                    // stored snapshot (the persisted SSOT) so `show` reflects the
+                    // truth, and flag a write ONLY when the set actually changed
+                    // — the 30s periodic SyncFabricState refresh must not rewrite
+                    // the state file on every unchanged tick.
+                    //
+                    // Restart continuity is provided by the Go control plane, not
+                    // this file: the helper starts with `snapshot: None`
+                    // (lifecycle.rs) and never self-restores; on restart the
+                    // daemon re-applies the full snapshot and re-runs
+                    // populateFabricFwd (500ms fast retries → 30s periodic), which
+                    // re-resolves and re-syncs the fabric MACs. The persisted set
+                    // is the observability snapshot, not the restore source.
+                    if let Some(snapshot) = guard.snapshot.as_mut() {
+                        if snapshot.fabrics != *fabrics {
+                            snapshot.fabrics = fabrics.clone();
+                            persist_state = true;
+                        }
+                    }
                     refresh_status(&mut guard);
                 }
             }

--- a/userspace-dp/src/server/helpers.rs
+++ b/userspace-dp/src/server/helpers.rs
@@ -315,6 +315,14 @@ pub(crate) fn refresh_status(state: &mut ServerState) {
             es_stats.dataplane_events.session_create.dropped;
     }
     state.status.last_cache_flush_at = state.afxdp.last_cache_flush_at();
+    // #3773 (M13): surface the cumulative fabric-skip diagnostic atomics so an
+    // operator (and Prometheus) sees a silently-unresolved HA cross-chassis
+    // fabric link. Malformed = a config/environment fault; unresolved-peer =
+    // the expected late-resolution transient (distinct counter).
+    state.status.fabric_link_skipped_malformed_total =
+        state.afxdp.fabric_link_skipped_malformed_total();
+    state.status.fabric_link_unresolved_peer_total =
+        state.afxdp.fabric_link_unresolved_peer_total();
 }
 
 pub(crate) fn forwarding_unsupported_error(cap: &UserspaceCapabilities) -> String {

--- a/userspace-dp/src/server/lifecycle.rs
+++ b/userspace-dp/src/server/lifecycle.rs
@@ -299,6 +299,8 @@ pub(crate) fn run() -> Result<(), String> {
             event_stream_session_create_sent: 0,
             event_stream_session_create_dropped: 0,
             last_cache_flush_at: 0,
+            fabric_link_skipped_malformed_total: 0,
+            fabric_link_unresolved_peer_total: 0,
         },
         snapshot: None,
         afxdp: {

--- a/userspace-dp/src/server/tests.rs
+++ b/userspace-dp/src/server/tests.rs
@@ -1437,3 +1437,131 @@ fn export_owner_rg_does_not_hold_state_lock_during_ack_wait() {
     assert!(export_resp.ok, "export failed: {}", export_resp.error);
     ack_thread.join().expect("ack thread");
 }
+
+/// #3773 (L4): an `update_fabrics` that CHANGES the fabric set must fold the
+/// freshly-resolved FabricSnapshots into the STORED snapshot AND persist. The
+/// helper starts with `snapshot: None` and never self-restores, so the
+/// published state file (read by the Go control plane's `show` surface, and
+/// the last-written record a consumer sees) is the observability SSOT. Before
+/// #3773 the `update_fabrics` arm neither updated the stored snapshot nor set
+/// `persist_state`, so a late-resolved peer/local MAC from the SyncFabricState
+/// path lived only in the coordinator's in-memory forwarding state — the
+/// persisted fabrics kept the stale apply-time (unresolved) values.
+/// fail-on-revert: dropping the snapshot fold + `persist_state` leaves the
+/// persisted `snapshot.fabrics` at the empty apply-time set (RED).
+#[test]
+fn update_fabrics_persists_resolved_fabric_set() {
+    use crate::{ConfigSnapshot, FabricSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let state = new_state(ProcessStatus::default());
+    let state_file = unique_state_file("fabric-persist");
+    // Seed an apply_snapshot with NO fabrics (initial build before the peer
+    // MAC resolved). This persists the state file with an empty fabric set.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 1,
+            fib_generation: 1,
+            generated_at: chrono::Utc::now(),
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    // SyncFabricState resolves a peer MAC and pushes it via update_fabrics.
+    let resolved = FabricSnapshot {
+        name: "fab0".into(),
+        parent_interface: "ge-0/0/0".into(),
+        parent_linux_name: "ge-0-0-0".into(),
+        parent_ifindex: 21,
+        overlay_linux_name: "fab0".into(),
+        overlay_ifindex: 101,
+        rx_queues: 2,
+        peer_address: "10.99.13.2".into(),
+        local_mac: "02:bf:72:ff:00:01".into(),
+        peer_mac: "00:aa:bb:cc:dd:ee".into(),
+    };
+    {
+        let mut request = req("update_fabrics");
+        request.fabrics = Some(vec![resolved.clone()]);
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    // The stored (in-RAM) snapshot must now carry the resolved fabric.
+    assert_eq!(
+        state
+            .lock()
+            .expect("state")
+            .snapshot
+            .as_ref()
+            .expect("stored snapshot")
+            .fabrics,
+        vec![resolved.clone()],
+        "update_fabrics must fold the resolved fabric into the stored snapshot"
+    );
+    // The on-disk state a `show` reads (and the last record a restart-time
+    // consumer sees) must carry the resolved peer MAC, not the empty
+    // apply-time set.
+    let bytes = std::fs::read(&state_file).expect("read persisted state file");
+    let persisted: serde_json::Value =
+        serde_json::from_slice(&bytes).expect("parse persisted state file");
+    assert_eq!(
+        persisted["snapshot"]["fabrics"][0]["peer_mac"].as_str(),
+        Some("00:aa:bb:cc:dd:ee"),
+        "persisted snapshot must carry the resolved fabric peer MAC (#3773 L4)"
+    );
+    let _ = std::fs::remove_file(&state_file);
+}
+
+/// #3773 (L4): an `update_fabrics` whose fabric set is UNCHANGED from the
+/// stored snapshot must NOT rewrite the state file — the 30s periodic
+/// SyncFabricState refresh must not churn the disk on every unchanged tick.
+#[test]
+fn update_fabrics_unchanged_set_does_not_rewrite_state_file() {
+    use crate::{ConfigSnapshot, FabricSnapshot, CONFIG_SNAPSHOT_PROTOCOL_VERSION};
+    let resolved = FabricSnapshot {
+        name: "fab0".into(),
+        parent_interface: "ge-0/0/0".into(),
+        parent_linux_name: "ge-0-0-0".into(),
+        parent_ifindex: 21,
+        overlay_linux_name: "fab0".into(),
+        overlay_ifindex: 101,
+        rx_queues: 2,
+        peer_address: "10.99.13.2".into(),
+        local_mac: "02:bf:72:ff:00:01".into(),
+        peer_mac: "00:aa:bb:cc:dd:ee".into(),
+    };
+    let state = new_state(ProcessStatus::default());
+    let state_file = unique_state_file("fabric-nochurn");
+    // Seed a snapshot that ALREADY carries the resolved fabric.
+    {
+        let mut request = req("apply_snapshot");
+        request.snapshot = Some(ConfigSnapshot {
+            version: CONFIG_SNAPSHOT_PROTOCOL_VERSION,
+            generation: 1,
+            fib_generation: 1,
+            generated_at: chrono::Utc::now(),
+            fabrics: vec![resolved.clone()],
+            ..ConfigSnapshot::default()
+        });
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    let before = std::fs::metadata(&state_file)
+        .expect("state file exists after seed apply")
+        .modified()
+        .expect("mtime");
+    // A same-set update_fabrics: nothing changed, so no rewrite.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    {
+        let mut request = req("update_fabrics");
+        request.fabrics = Some(vec![resolved.clone()]);
+        assert!(run_request_on_file(state.clone(), request, &state_file).ok);
+    }
+    let after = std::fs::metadata(&state_file)
+        .expect("state file still exists")
+        .modified()
+        .expect("mtime");
+    assert_eq!(
+        before, after,
+        "an unchanged update_fabrics must not rewrite the state file"
+    );
+    let _ = std::fs::remove_file(&state_file);
+}

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -816,6 +816,8 @@
     "event_stream_session_create_dropped": 0,
     "event_stream_session_create_sent": 0,
     "event_stream_write_stalls": 0,
+    "fabric_link_skipped_malformed_total": 0,
+    "fabric_link_unresolved_peer_total": 0,
     "fabrics": [],
     "filter_term_counters": [],
     "flow_cache_capacity": 0,


### PR DESCRIPTION
## Summary

Closes #3773 (codex-review-161 cluster M13+L4 — fabric build/refresh observability).

Fabric cross-chassis forwarding (HA) can only fire if a `FabricLink` was actually built for the parent interface. Before this change both fabric-resolution passes dropped a link on a bare `continue` — **no counter, log, or status** — so an HA cross-chassis fabric link that silently failed to install (and therefore silently did not forward) was invisible to the operator, and the runtime `update_fabrics` refresh was volatile.

### M13 — count + name skipped fabric links (was a silent `continue`)

`populate_fabrics` (`fib.rs`, snapshot build) and `resolve_fabric_links_from_snapshots` (`forwarding/mod.rs`, runtime refresh) now route the skip-vs-install decision through a **shared `build_fabric_link_or_skip` classifier** that partitions skips into two cumulative diagnostic atomics:

- **`FABRIC_LINK_SKIPPED_MALFORMED`** — invalid parent ifindex, unparseable peer address, or a **non-empty** local/peer MAC that failed to parse. A config/environment fault that will not self-heal.
- **`FABRIC_LINK_UNRESOLVED_PEER`** — an **empty** peer/local MAC field awaiting neighbor/interface resolution (the expected late-resolution `SyncFabricState` transient). A distinct, non-malformed state per the issue's intent (*an unresolved-peer state is fine; a silent skip is not*).

Each skip is recorded by fabric name + reason in `ForwardingState.fabric_skips`; `log_fabric_skip_transition` (mirrors `log_wg_endpoint_set_transition`; wired into snapshot_refresh, reconcile, refresh_fabric_links) names it in the journal **only when the skip set changes** — so a persistently unresolved/malformed fabric logs once, not on every 30s refresh or route-churn `bump_fib`. Both atomics surface in `ProcessStatus` and Prometheus (`xpf_userspace_fabric_link_skipped_malformed_total` / `xpf_userspace_fabric_link_unresolved_peer_total`).

Fabric is an HA **optimization**, not enforcement, so a malformed link is **skipped-with-visibility, NOT fail-closed-whole-snapshot** — a single bad fabric stanza must not blackhole the dataplane. Mirrors the #3771 M12 `NEIGHBOR_UNKNOWN_STATE_SKIPPED` pattern.

### L4 — persist the `update_fabrics` refresh

The `update_fabrics` handler was the only mutating control verb that neither updated the stored snapshot nor set `persist_state`, so late-resolved MACs lived only in RAM and the published state file (the Go control plane's `show` surface) kept stale apply-time MACs. It now folds the resolved `FabricSnapshot`s into the stored snapshot and persists **only when the set changed** (no 30s state-file churn).

**Restart continuity is explicit and unchanged**: the helper starts `snapshot: None` and never self-restores — the Go daemon re-applies the full snapshot and re-runs `populateFabricFwd` within seconds. The persisted set is the observability snapshot, not the restore source (documented).

## Tests (all RED-on-revert)

- 5 Rust M13 classification tests (`forwarding/tests.rs`) — deterministic `fabric_skips` record + cumulative atomic (malformed peer MAC, invalid parent, unparseable peer addr, empty→unresolved, well-formed installs).
- 2 L4 handler tests (`server/tests.rs`) — resolved set persisted; unchanged set does not rewrite the file.
- 1 Go wire round-trip test + 1 Prometheus emit test pin the two new status tags/series.
- Regenerated `protocol_wire_v1.json` (2 new `ProcessStatus` keys).
- **Full `cargo test --release` green (3415 lib + aux, 0 failed); full `go test ./...` green (53 pkgs).**

## Test-failover note

Fabric is HA cross-chassis, but this change is purely observability + persisted-state accuracy — no session-sync/wire-forwarding semantics change (the two new status fields are additive/defaulted; forwarding behavior is byte-identical for well-formed links). No `test-failover` regression expected; the loss-cluster smoke was not run for this observability-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
