### PR TITLE
userspace-dp: make NAT hit-counter clear atomic vs post-clear increment (#3830)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,35 @@
+## 2026-07-01 — #3830: NAT hit-counter clear post-clear increment race
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Follow-up to #3829 (#3782). `NatRuleCounter::reset` (the
+    operator `clear` of per-rule NAT hit counters) zeroed with `store(0)`, the
+    same clobber class #3782 fixed in `PolicyRuleCounter::reset`: a per-flow
+    cold-path `add` (relaxed `fetch_add`) landing in the same instant as a
+    clear was unconditionally overwritten to zero, so the clear silently ate a
+    real post-clear hit. Narrower than #3782 — the NAT counter increments once
+    per-flow on the cold path with NO coalescer and NO generation/epoch guard,
+    so there is no pending-batch replay to fence — but the same store(0)
+    primitive. Fix mirrors #3782: `reset()` observes the pre-clear totals and
+    removes exactly that amount with an atomic `fetch_sub` via a new
+    `subtract_observed` seam instead of `store(0)`. Increment and clear are now
+    both RMWs on the same atomic and serialize in the modification order, so a
+    concurrent post-clear `fetch_add` survives (no lost update). Per-flow
+    increment path (`add`) UNCHANGED — still a cheap relaxed `fetch_add`. No
+    lock/seqcount added (consistent with #3451). `subtract_observed` cannot
+    underflow: increments are monotonic and `reset` is the sole subtractor,
+    called under the `NatCounterStore` registry mutex so clears are serialized.
+    RED-on-revert: nat_counter_clear_preserves_concurrent_post_clear_hit_3830
+    drives the observe -> concurrent-add -> subtract interleaving
+    deterministically through the real subtraction seam; restoring store(0) in
+    subtract_observed fails it (post-clear packets 1 -> 0). A second test
+    (nat_counter_clear_zeroes_when_uncontended_3830) locks the normal
+    `NatCounterStore::clear` -> reset path zeroing both fields exactly. Full
+    `cargo test --release` green (3417 lib + 46 + 8 + 16 + 1, 0 failed).
+    Scope: per-rule NAT hit-counter accuracy (observability), Rust-only, no
+    wire change — NOT enforcement/HA session-sync, so no test-failover impact.
+  - **File(s)**: userspace-dp/src/nat/mod.rs,
+    userspace-dp/src/nat/tests.rs
+
 ## 2026-07-01 — #3782: clear security policies hit-count post-clear race
 
 - **Timestamp**: 2026-07-01

--- a/userspace-dp/src/nat/mod.rs
+++ b/userspace-dp/src/nat/mod.rs
@@ -116,6 +116,23 @@ impl NatDecision {
 /// `PolicyRuleCounter` pattern (policy.rs). `add` is the only mutation on
 /// the increment side: a single `fetch_add(1)` for packets plus a
 /// conditional bytes add, no allocation, no lock.
+///
+/// #3830 — `reset` (operator `clear` of NAT hit counters) removes the
+/// observed pre-clear total with an atomic `fetch_sub` rather than a
+/// `store(0)`. A `store(0)` unconditionally overwrites the field, so a
+/// per-flow `add` (the cold-path relaxed `fetch_add`) landing in the same
+/// instant as a `clear` would be clobbered — the clear silently ate a real
+/// post-clear hit. `fetch_sub(observed)` subtracts only the amount `reset`
+/// read: because both the increment and the subtraction are atomic RMWs on
+/// the same location they serialize in the modification order (no lost
+/// update), so a concurrent post-clear increment survives. This mirrors the
+/// #3782 `PolicyRuleCounter::reset` fix; it is NARROWER here — the NAT
+/// counter increments once per-flow on the cold path with no coalescer and
+/// no generation/epoch guard, so there is no pending-batch replay to fence.
+/// Like the policy counter it keeps the write side off a lock/seqcount
+/// (#3451); the only residual is a bounded ns-scale attribution skew for a
+/// count landing exactly at the clear instant, consistent with the
+/// advisory-telemetry eventual-consistency contract these counters accept.
 #[derive(Debug, Default)]
 pub(crate) struct NatRuleCounter {
     packets: AtomicU64,
@@ -135,8 +152,42 @@ impl NatRuleCounter {
     }
 
     fn reset(&self) {
-        self.packets.store(0, Ordering::Relaxed);
-        self.bytes.store(0, Ordering::Relaxed);
+        // #3830: observe the current (pre-clear) totals, then remove EXACTLY
+        // that amount with an atomic `fetch_sub` rather than `store(0)`.
+        //
+        // A `store(0)` unconditionally overwrites the field, so a legitimate
+        // per-flow hit recorded by a worker on the cold path in the same
+        // instant as this clear (a relaxed `fetch_add` via `add`) would be
+        // clobbered — the clear silently ate a real post-clear packet.
+        // `fetch_sub(observed)` subtracts only the pre-clear amount we read:
+        // whatever a concurrent worker `fetch_add`s survives, because both
+        // are atomic RMWs on the same location and serialize in the
+        // modification order (no lost update). See the type doc and #3782
+        // (`PolicyRuleCounter::reset`, the same clobber class).
+        let observed_packets = self.packets.load(Ordering::Relaxed);
+        let observed_bytes = self.bytes.load(Ordering::Relaxed);
+        self.subtract_observed(observed_packets, observed_bytes);
+    }
+
+    /// #3830: remove exactly `observed_*` from the shared totals with atomic
+    /// `fetch_sub`s rather than a `store(0)` (see [`reset`](Self::reset) for
+    /// why). Split out as the clear's subtraction step so the reset/increment
+    /// interleaving can be driven deterministically in tests: the invariant is
+    /// that a concurrent post-clear `add` applied between the observation in
+    /// `reset` and this call is preserved, not wiped.
+    ///
+    /// `observed_*` is always `<=` the current total — the cold-path increment
+    /// only ever `fetch_add`s (monotonic) and `reset` is the sole subtractor,
+    /// called from `NatCounterStore::clear` under the registry mutex so clears
+    /// are serialized — therefore neither `fetch_sub` can underflow.
+    #[inline]
+    fn subtract_observed(&self, observed_packets: u64, observed_bytes: u64) {
+        if observed_packets != 0 {
+            self.packets.fetch_sub(observed_packets, Ordering::Relaxed);
+        }
+        if observed_bytes != 0 {
+            self.bytes.fetch_sub(observed_bytes, Ordering::Relaxed);
+        }
     }
 
     pub(crate) fn snapshot(&self, counter_id: u32) -> NatRuleCounterStatus {

--- a/userspace-dp/src/nat/tests.rs
+++ b/userspace-dp/src/nat/tests.rs
@@ -7708,3 +7708,81 @@ fn dnat_destination_port_range_3449() {
         );
     }
 }
+
+// #3830: `clear` of the per-rule NAT hit counters (`NatCounterStore::clear` ->
+// `NatRuleCounter::reset`) must not WIPE a per-flow increment recorded in the
+// same instant as the clear. `reset` observes the pre-clear total, then
+// `fetch_sub`s exactly that amount instead of `store(0)`, so a concurrent
+// post-clear cold-path `add` survives — both are atomic RMWs on the same
+// location and serialize in the modification order (no lost update). Mirrors
+// the #3782 `PolicyRuleCounter` fix; narrower here (per-flow cold-path
+// increment, no coalescer/generation to fence).
+//
+// Drives the reset/increment interleaving deterministically through the real
+// subtraction seam (`subtract_observed`): a live two-thread race would be
+// non-deterministic. RED-on-revert: restoring `packets.store(0)` /
+// `bytes.store(0)` in `subtract_observed` (or collapsing `reset` back to
+// `store(0)`) wipes the concurrent post-clear increment (1 -> 0) and fails
+// the packet/byte assertions.
+#[test]
+fn nat_counter_clear_preserves_concurrent_post_clear_hit_3830() {
+    use std::sync::Arc;
+    use std::sync::atomic::Ordering;
+
+    let counter = Arc::new(NatRuleCounter::default());
+
+    // Pre-clear traffic already folded into the shared atomics: 100 translated
+    // flows, 64 bytes on each trigger packet (the per-flow semantic).
+    for _ in 0..100 {
+        counter.add(64);
+    }
+
+    // === reset() stage 1: OBSERVE the pre-clear totals — exactly what reset()
+    // reads before its subtraction. ===
+    let observed_packets = counter.packets.load(Ordering::Relaxed);
+    let observed_bytes = counter.bytes.load(Ordering::Relaxed);
+    assert_eq!(observed_packets, 100, "observed pre-clear packet total");
+    assert_eq!(observed_bytes, 100 * 64, "observed pre-clear byte total");
+
+    // === Concurrent cold-path worker: a LEGITIMATE post-clear translated flow
+    // is counted in the window between reset's observation and its
+    // subtraction. ===
+    counter.add(64);
+
+    // === reset() stage 2: subtract the observed pre-clear amount. fetch_sub
+    // removes only the pre-clear 100 pkts / 6400 B; a store(0) here would wipe
+    // the counter INCLUDING the concurrent post-clear 1 pkt / 64 B. ===
+    counter.subtract_observed(observed_packets, observed_bytes);
+
+    let snap = counter.snapshot(7);
+    assert_eq!(
+        snap.packets, 1,
+        "post-clear NAT hit wiped by clear — a store(0) clobbered the \
+         concurrent post-clear increment (#3830)"
+    );
+    assert_eq!(
+        snap.bytes, 64,
+        "post-clear NAT bytes wiped by clear (#3830)"
+    );
+    assert_eq!(snap.counter_id, 7, "snapshot echoes the counter id");
+}
+
+// #3830: with NO concurrent increment, a `clear` still zeroes both fields
+// exactly (the fetch_sub path is not a regression of the normal clear).
+// Exercises the full operator path: `NatCounterStore::clear` -> reset.
+#[test]
+fn nat_counter_clear_zeroes_when_uncontended_3830() {
+    let store = NatCounterStore::default();
+    let counter = store.rule_counter(42).expect("non-zero id yields a counter");
+    counter.add(64);
+    counter.add(1500);
+    let before = counter.snapshot(42);
+    assert_eq!(before.packets, 2, "two flows counted");
+    assert_eq!(before.bytes, 64 + 1500, "byte total accumulated");
+
+    store.clear();
+
+    let after = counter.snapshot(42);
+    assert_eq!(after.packets, 0, "clear zeroes packets when uncontended");
+    assert_eq!(after.bytes, 0, "clear zeroes bytes when uncontended");
+}


### PR DESCRIPTION
## Summary

Closes #3830. Follow-up flagged by the #3829 (#3782) engineer.

`NatRuleCounter::reset` (the operator `clear` of per-rule NAT hit
counters, reached via `NatCounterStore::clear`) zeroed with
`packets.store(0)` / `bytes.store(0)`. A `store(0)` unconditionally
overwrites the field, so a legitimate cold-path `add()` — a relaxed
`fetch_add` fired once when a new translated session is installed —
landing in the same instant as a clear was clobbered to zero: the clear
silently ate a real post-clear hit.

This is the same `store(0)`-clobbers-concurrent-increment class that
#3782/#3829 fixed in `PolicyRuleCounter::reset`, but **narrower**: the NAT
counter increments once per-flow on the cold path with NO coalescer and NO
generation/epoch guard, so the pending-batch replay window that made #3782
reproducible does not exist here. The residual race is the much narrower
per-flow increment landing exactly at the clear instant.

## Fix (mirrors #3782 `subtract_observed`)

`userspace-dp/src/nat/mod.rs` — `reset()` no longer stores zero. It
observes the current pre-clear totals and removes exactly that amount with
an atomic `fetch_sub` via a new `subtract_observed` seam. Because both the
hot-path increment (`fetch_add`) and the clear (`fetch_sub`) are RMWs on
the same atomic, they serialize in the modification order with no lost
update — a concurrent post-clear increment survives. `subtract_observed`
cannot underflow: increments are monotonic and `reset` is the sole
subtractor, called under the `NatCounterStore` registry mutex so clears
are serialized.

- Per-flow increment path (`add`) **unchanged** — still a cheap relaxed
  `fetch_add`.
- No lock/seqcount added (consistent with #3451).
- Rust-only, no wire change.

## Tests

- `nat_counter_clear_preserves_concurrent_post_clear_hit_3830` drives the
  observe → concurrent-`add` → subtract interleaving deterministically
  through the real subtraction seam (a live two-thread race would be
  non-deterministic). **RED-on-revert verified**: restoring `store(0)` in
  `subtract_observed` wipes the concurrent post-clear hit (1 → 0) and fails
  the test.
- `nat_counter_clear_zeroes_when_uncontended_3830` locks the normal
  `NatCounterStore::clear` → `reset` path zeroing both fields exactly.
- Full `cargo test --release` green (3417 lib + 46 + 8 + 16 + 1, 0 failed).

## Scope / test-failover

Per-rule NAT hit-counter accuracy (observability). NOT enforcement or HA
session-sync, no wire change — `test/failover` not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi