### PR TITLE
host-inbound: report addressless fail-open per interface/family (#3710)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,44 @@
+## 2026-07-01 — #3710: host-inbound addressless observability per-interface/per-family
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Refine the #3698 addressless host-inbound fail-open reporter.
+    `AddresslessEnforcingZones` collapses to ZONE granularity — a zone is
+    marked "scoped" (and stays silent) the moment ANY interface resolves an
+    address in EITHER family. But enforcement is per-destination-address and
+    per-family (the kernel chain emits `<fam> daddr <set> ... drop` separately
+    for inet and inet6), so a MIXED zone still carries real fail-open windows
+    the zone-level view cannot express: (1) a DHCP-pending interface beside a
+    statically-addressed sibling; (2) the IPv6 side of a dual-stack edge whose
+    v6 lease lands after its v4. Added `AddresslessEnforcingInterfaces` (SSOT
+    in `pkg/dataplane/userspace/zones.go`) reporting `{zone, interface-unit,
+    family, reason}` at unit+family granularity. It reports a non-lifeline unit
+    in a configured enforcing zone when a family has a DHCP/DHCPv6 client
+    configured but resolves NO address in that family, using the SAME static /
+    live-kernel + configured-VRRP-VIP resolution `BuildZoneHostInboundViews`
+    scopes the deny with. Only `dhcp-pending` is reported — static addrs and
+    VIPs are config-injected regardless of link/lease state, so they never open
+    a per-interface window; gating on a configured DHCP client (not "any family
+    with no address") keeps it low-noise (an IPv4-only interface is NOT flagged
+    addressless in inet6). Wired a daemon state-transition logger
+    (`logHostInboundAddresslessIfaceTransitions`, WARN on entry / INFO on
+    recovery, transitions only, new `hostInboundAddresslessIfaces` diff field)
+    and a Prometheus gauge
+    `xpf_host_inbound_addressless_interfaces{zone,interface,family,reason}`
+    emitted BEFORE the dataplane gate. The zone-level
+    `xpf_host_inbound_addressless_zones` is unchanged (coarser compatibility
+    aggregate). Observability-only, no enforcement change. Go-only (no
+    Rust/cargo). RED-on-revert: `TestAddresslessEnforcingInterfaces` — a mixed
+    zone surfaces `trust/ge-0-0-1.0/inet` + `dual/ge-0-0-2.0/inet6`; collapsing
+    the reporter to zone-granularity (skip a unit whose zone resolves any addr)
+    yields empty and fails the test. Low-noise + self-heal + IPv4-only-no-v6 +
+    empty-config cases also pinned. `go test ./pkg/dataplane/... ./pkg/api/...
+    ./pkg/daemon/` green; `go build ./...`, gofmt, vet clean.
+  - **File(s)**: pkg/dataplane/userspace/zones.go,
+    pkg/dataplane/userspace/zones_addressless_iface_3710_test.go,
+    pkg/daemon/daemon.go, pkg/daemon/daemon_nft.go, pkg/api/metrics.go,
+    pkg/api/metrics_descriptors.go, pkg/api/metrics_counters.go,
+    docs/host-inbound-service-matrix.md, _Log.md
+
 ## 2026-07-01 — #3830: NAT hit-counter clear post-clear increment race
 
 - **Timestamp**: 2026-07-01

--- a/docs/host-inbound-service-matrix.md
+++ b/docs/host-inbound-service-matrix.md
@@ -228,6 +228,52 @@ Two observability surfaces consume it:
   visible in a config-only / degraded boot). Alert with e.g.
   `max_over_time(xpf_host_inbound_addressless_zones[1h]) > 0`.
 
+### Per-interface / per-family refinement (#3710)
+
+The zone-level signal above **collapses**: `AddresslessEnforcingZones` marks a
+zone "scoped" (and stays silent) the moment ANY of its interfaces resolves an
+address in EITHER family. But host-inbound ENFORCEMENT is per-destination-address
+and per-family — the kernel chain emits `<fam> daddr <set> ... drop` separately
+for `inet` and `inet6` — so a **MIXED** zone can still carry a real fail-open
+window the zone-level view cannot express:
+
+- **Mixed-interface zone**: `trust` has `ge-0-0-0.0` (static `192.0.2.1`) and
+  `ge-0-0-1.0` (DHCP WAN, lease pending). The addressed sibling makes the zone
+  scoped, so #3698 never surfaces `ge-0-0-1.0`'s window.
+- **Mixed-family interface**: `ge-0-0-2.0` has a static/DHCP v4 address but its v6
+  lease (DHCPv6) has not landed. `len(v.V4Addrs) > 0` marks the zone scoped, so
+  the IPv6 side entering the same window is invisible — dual-stack edges commonly
+  bring the two families up at different times.
+
+`dpuserspace.AddresslessEnforcingInterfaces` (`pkg/dataplane/userspace/zones.go`)
+surfaces the window at `{zone, interface-unit, family}` granularity. It reports a
+non-lifeline logical unit assigned to a configured enforcing zone when, for a
+family, the unit has a **DHCP / DHCPv6 client** configured (`family inet { dhcp; }`
+/ `family inet6 { dhcpv6; }` / `dhcpv6-client`) but currently resolves **no
+address** in that family — using the same static / live-kernel address resolution
+plus configured VRRP VIPs that `BuildZoneHostInboundViews` scopes the deny with.
+
+Only the `dhcp-pending` reason is reported: a static address or a VRRP VIP is
+injected into the enforced deny from config regardless of link/lease state, so it
+never opens a per-interface window. Gating on a configured DHCP client (rather
+than "any family with no address") keeps the signal low-noise — an IPv4-only
+interface is **not** flagged as addressless in `inet6`, because it never intends
+to acquire a v6 address. The window self-heals the instant the lease lands, like
+the zone-level signal.
+
+Two observability surfaces consume it (mirroring #3698):
+
+- **State-transition log** (`daemon_nft.go`,
+  `logHostInboundAddresslessIfaceTransitions`). A `WARN` on ENTRY, an `INFO` on
+  RECOVERY, transitions only.
+- **Prometheus gauge**
+  `xpf_host_inbound_addressless_interfaces{zone,interface,family,reason}`
+  (`pkg/api`). Value `1` per open window; absent when the family is enforced.
+  Emitted BEFORE the dataplane gate. The zone-level
+  `xpf_host_inbound_addressless_zones` remains as a coarser compatibility
+  aggregate — this per-interface series is strictly more sensitive and is exported
+  alongside it, not in place of it.
+
 ## Per-interface override precedence (#3362, #3720)
 
 Host-inbound-traffic can be authored at three granularities, and the EFFECTIVE

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -34,6 +34,7 @@ type xpfCollector struct {
 	hostInboundDeny             *prometheus.Desc
 	hostInboundKernelDenies     *prometheus.Desc
 	hostInboundAddresslessZones *prometheus.Desc
+	hostInboundAddresslessIface *prometheus.Desc
 	hostInboundAmbiguousAddrs   *prometheus.Desc
 	tcEgressPacketsTotal        *prometheus.Desc
 	syncookieTotal              *prometheus.Desc
@@ -543,6 +544,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.hostInboundDeny
 	ch <- c.hostInboundKernelDenies
 	ch <- c.hostInboundAddresslessZones
+	ch <- c.hostInboundAddresslessIface
 	ch <- c.hostInboundAmbiguousAddrs
 	ch <- c.tcEgressPacketsTotal
 	ch <- c.syncookieTotal
@@ -913,6 +915,14 @@ func (c *xpfCollector) Collect(ch chan<- prometheus.Metric) {
 	// window can be open in a config-only / degraded boot too, and that is exactly
 	// when it must stay visible.
 	c.collectHostInboundAddresslessZones(ch)
+
+	// #3710: the per-interface/per-family refinement of the addressless-zone
+	// signal above. A MIXED zone collapses to "scoped" at zone granularity the
+	// moment ANY interface resolves ANY address, hiding a DHCP-pending unit beside
+	// an addressed sibling, or the v6 side of a dual-stack edge whose v6 lease
+	// lands after v4. Config-derived and independent of dataplane load, so emit it
+	// BEFORE the dataplane gate like the zone-level signal.
+	c.collectHostInboundAddresslessInterfaces(ch)
 
 	// #3718 (Option B): firewall-local addresses reachable from multiple zones
 	// with differing host-inbound service sets (order-dependent kernel verdict).

--- a/pkg/api/metrics_counters.go
+++ b/pkg/api/metrics_counters.go
@@ -73,6 +73,32 @@ func (c *xpfCollector) collectHostInboundAddresslessZones(ch chan<- prometheus.M
 	}
 }
 
+// collectHostInboundAddresslessInterfaces emits
+// xpf_host_inbound_addressless_interfaces (#3710): a 1 per {zone, interface-unit,
+// family} in the transient host-inbound fail-open admit window at
+// per-interface/per-family granularity — a non-lifeline unit with a DHCP/DHCPv6
+// client configured for the family but no resolved address in it yet. This is the
+// refinement of collectHostInboundAddresslessZones above: the zone-level series
+// goes silent for a MIXED zone the moment any interface resolves any address,
+// hiding a DHCP-pending unit beside an addressed sibling (or the v6 side of a
+// dual-stack edge whose v6 lease lands after v4). Config-derived (no dataplane
+// dependency), so Collect calls this BEFORE the dataplane gate. The SSOT is
+// dpuserspace.AddresslessEnforcingInterfaces, the same builder the daemon logs
+// from, so the metric and the log agree.
+func (c *xpfCollector) collectHostInboundAddresslessInterfaces(ch chan<- prometheus.Metric) {
+	if c.srv == nil || c.srv.store == nil {
+		return
+	}
+	cfg := c.srv.store.ActiveConfig()
+	if cfg == nil {
+		return
+	}
+	for _, i := range dpuserspace.AddresslessEnforcingInterfaces(cfg) {
+		ch <- prometheus.MustNewConstMetric(c.hostInboundAddresslessIface,
+			prometheus.GaugeValue, 1, i.Zone, i.Interface, i.Family, i.Reason)
+	}
+}
+
 // collectHostInboundAmbiguousAddresses emits xpf_host_inbound_ambiguous_addresses
 // (#3718 Option B): a 1 per firewall-local address that is
 // host-inbound-reachable from more than one security zone with DIFFERING

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -115,6 +115,24 @@ func newCollector(srv *Server) *xpfCollector {
 				"scoping (transient fail-open admit window), labeled by zone.",
 			[]string{"zone"}, nil,
 		),
+		// #3710: the per-interface/per-family refinement of the addressless-zone
+		// signal above. 1 while a non-lifeline logical unit in a configured
+		// host-inbound-enforcing zone has a DHCP/DHCPv6 client configured for a
+		// family but has not yet resolved an address in that family — a transient
+		// fail-open window that the zone-level series hides whenever an addressed
+		// sibling interface (or the other family) already scopes the zone.
+		// Config-derived, independent of dataplane load, emitted BEFORE the
+		// dataplane gate. Present only while the window is open (absent =
+		// enforced), labeled by zone, interface (logical unit), family and reason.
+		hostInboundAddresslessIface: prometheus.NewDesc(
+			"xpf_host_inbound_addressless_interfaces",
+			"1 while a non-lifeline interface unit in a configured host-inbound-"+
+				"enforcing zone has a DHCP/DHCPv6 client for a family but no "+
+				"resolved address in that family yet (per-interface/per-family "+
+				"transient fail-open admit window, #3710), labeled by zone, "+
+				"interface, family and reason.",
+			[]string{"zone", "interface", "family", "reason"}, nil,
+		),
 		// #3718 (Option B): 1 per firewall-local address that is
 		// host-inbound-reachable from more than one security zone with DIFFERING
 		// host-inbound service/protocol sets. The kernel host-inbound nftables

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -326,6 +326,17 @@ type Daemon struct {
 	// Written and read only under applySem in applyHostInboundFilter.
 	hostInboundAddresslessZones map[string]bool
 
+	// hostInboundAddresslessIfaces is the set of {zone, interface-unit, family}
+	// host-inbound fail-open windows observed on the PREVIOUS apply (#3710), keyed
+	// as "<zone>|<iface>|<family>". This is the per-interface/per-family refinement
+	// of hostInboundAddresslessZones: a DHCP/DHCPv6 client on a non-lifeline unit
+	// with no resolved address in that family yet, which the zone-level signal
+	// hides in a MIXED zone (a DHCP-pending unit beside a statically-addressed
+	// sibling, or the v6 side of a dual-stack edge whose v6 lease lands after v4).
+	// applyHostInboundFilter diffs the current set against this to emit
+	// state-transition logs only. Written and read only under applySem.
+	hostInboundAddresslessIfaces map[string]bool
+
 	// hostInboundAmbiguousAddrs is the set of firewall-local addresses observed
 	// on the PREVIOUS apply that are host-inbound-reachable from more than one
 	// security zone with DIFFERING host-inbound service/protocol sets (#3718

--- a/pkg/daemon/daemon_nft.go
+++ b/pkg/daemon/daemon_nft.go
@@ -251,6 +251,13 @@ func (d *Daemon) applyHostInboundFilter(cfg *config.Config) error {
 	// is otherwise silent. Log only state TRANSITIONS (a zone entering/leaving the
 	// window) so repeated commits / DHCP renewals do not flood.
 	d.logHostInboundAddresslessTransitions(cfg)
+	// #3710: the zone-level signal above collapses a MIXED zone (some interfaces
+	// addressed, some not; or one family up before the other) to "scoped" the
+	// moment ANY interface resolves ANY address, hiding the per-interface /
+	// per-family fail-open windows that enforcement (per-daddr, per-family) can
+	// still leave open. Log those at unit+family granularity so the operator sees
+	// WHICH interface/family is in the window, not just that a whole zone is.
+	d.logHostInboundAddresslessIfaceTransitions(cfg)
 	// #3718 (Option B): a firewall-local address reachable from >1 zone with
 	// DIFFERING host-inbound sets makes the kernel destination-address-only
 	// verdict order-dependent (and can disagree with the ingress-scoped
@@ -308,6 +315,41 @@ func (d *Daemon) logHostInboundAddresslessTransitions(cfg *config.Config) {
 		}
 	}
 	d.hostInboundAddresslessZones = current
+}
+
+// logHostInboundAddresslessIfaceTransitions emits a state-transition log whenever
+// a {zone, interface-unit, family} ENTERS or LEAVES the transient host-inbound
+// fail-open admit window at per-interface/per-family granularity (#3710). The
+// zone-level logHostInboundAddresslessTransitions above marks a zone scoped (and
+// stays silent) as soon as ANY of its interfaces resolves ANY address in EITHER
+// family, so a MIXED zone hides the gap: a DHCP-pending interface beside a
+// statically-addressed sibling, or the IPv6 side of a dual-stack edge whose v6
+// lease lands after its v4. Enforcement is per-destination-address and per-family
+// (the kernel chain emits `<fam> daddr <set> ... drop` separately for inet and
+// inet6), so those finer gaps are real fail-open windows the zone-level collapse
+// cannot express. It compares the current per-interface set against the set
+// observed on the previous apply (d.hostInboundAddresslessIfaces) so a unit that
+// stays DHCP-pending across repeated commits / renewals is logged once (on
+// entry), not every apply. Runs under applySem (via applyHostInboundFilter), so
+// the map access needs no extra locking. The current set is also exported as the
+// xpf_host_inbound_addressless_interfaces gauge (pkg/api), scraped independently.
+func (d *Daemon) logHostInboundAddresslessIfaceTransitions(cfg *config.Config) {
+	current := make(map[string]bool)
+	for _, i := range dpuserspace.AddresslessEnforcingInterfaces(cfg) {
+		key := i.Zone + "|" + i.Interface + "|" + i.Family
+		current[key] = true
+		if !d.hostInboundAddresslessIfaces[key] {
+			slog.Warn("host-inbound interface has no address in this family yet — host-inbound default-deny NOT enforced for it until a lease arrives (transient fail-open admit window); the zone-level signal is hidden by an addressed sibling / family",
+				"zone", i.Zone, "interface", i.Interface, "family", i.Family, "reason", i.Reason)
+		}
+	}
+	for key := range d.hostInboundAddresslessIfaces {
+		if !current[key] {
+			slog.Info("host-inbound interface now has an address in this family — host-inbound default-deny enforced (fail-open admit window closed)",
+				"key", key)
+		}
+	}
+	d.hostInboundAddresslessIfaces = current
 }
 
 // logHostInboundAmbiguousTransitions emits a state-transition log whenever a

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -408,6 +408,187 @@ func AddresslessEnforcingZones(cfg *config.Config) []AddresslessEnforcingZone {
 	return out
 }
 
+// AddresslessDHCPPending is the only fail-open reason the per-interface reporter
+// emits (#3710). Static and VRRP-VIP addresses are injected into the enforced
+// deny set from config regardless of link/lease state (see
+// BuildZoneHostInboundViews), so they never leave a per-interface fail-open
+// window. The only per-interface/per-family transient gap that materializes is a
+// DHCP / DHCPv6 client that has not yet acquired a lease in that family — the
+// window the issue documents (DHCP WAN before its first lease; a dual-stack edge
+// whose v6 lease lands after v4).
+const AddresslessDHCPPending = "dhcp-pending"
+
+// AddresslessEnforcingInterface names a single {zone, interface-unit, family}
+// that is in the transient host-inbound fail-open admit window (#3710) at a finer
+// granularity than AddresslessEnforcingZones (#3698). The zone-level signal marks
+// a zone "scoped" (and stays silent) the moment ANY of its interfaces resolves an
+// address in EITHER family, so a MIXED zone hides the gap: a DHCP-pending
+// interface beside a statically-addressed sibling, or the IPv6 side of a
+// dual-stack interface whose v6 lease has not landed while its v4 already has.
+// Host-inbound ENFORCEMENT is per-destination-address and per-family (the kernel
+// chain emits `<fam> daddr <set> ... drop` separately for inet and inet6), so
+// those per-interface/per-family gaps are real fail-open windows the zone-level
+// collapse cannot express. This type carries the refined signal.
+type AddresslessEnforcingInterface struct {
+	// Zone is the configured security zone the interface is assigned to.
+	Zone string
+	// Interface is the logical unit ref (e.g. "ge-0-0-1.0"), the granularity at
+	// which host-inbound addresses, DHCP clients and VRRP VIPs are configured.
+	Interface string
+	// Family is the Junos family whose lease is pending: "inet" (IPv4) or
+	// "inet6" (IPv6).
+	Family string
+	// Reason is why the family currently resolves no address. Always
+	// AddresslessDHCPPending today (the only per-interface transient window this
+	// builder can produce); carried as a field so alerts can group on it and so a
+	// future reason (should one become observable) is additive.
+	Reason string
+}
+
+// AddresslessEnforcingInterfaces returns, in sorted (zone, interface, family)
+// order, the per-interface/per-family host-inbound fail-open windows (#3710) that
+// the zone-level AddresslessEnforcingZones (#3698) collapses away. An entry is
+// reported for a non-lifeline logical unit assigned to a configured
+// host-inbound-enforcing zone when, for a family, the unit has a DHCP / DHCPv6
+// client configured (`family inet { dhcp; }` / `family inet6 { dhcpv6; }` /
+// dhcpv6-client) but currently resolves NO address in that family across the same
+// resolution BuildZoneHostInboundViews scopes the kernel deny with: static /
+// live-kernel addresses (interface snapshots) plus configured VRRP VIPs.
+//
+// Only DHCP-pending is reported (see AddresslessDHCPPending): a static address or
+// a VRRP VIP is scoped into the enforced deny from config regardless of link or
+// lease state, so it never opens a per-interface window. Gating on a configured
+// DHCP client (rather than "any family with no address") is what keeps the signal
+// low-noise: an IPv4-only interface is NOT reported as addressless in inet6,
+// because it never intends to acquire a v6 address, so there is no window to
+// surface. The window self-heals the moment the lease lands (the resolved family
+// set gains the address and the entry disappears), exactly like the zone-level
+// signal.
+//
+// The zone-level xpf_host_inbound_addressless_zones remains a coarser
+// compatibility aggregate (a zone with ANY address in ANY family is silent
+// there); this per-interface signal is strictly more sensitive by design and is
+// exported alongside it, not in place of it.
+func AddresslessEnforcingInterfaces(cfg *config.Config) []AddresslessEnforcingInterface {
+	if cfg == nil || len(cfg.Security.Zones) == 0 || len(cfg.Interfaces.Interfaces) == 0 {
+		return nil
+	}
+	lifelines := hostInboundLifelineSet(cfg)
+	zoneByIface := buildInterfaceZoneMap(cfg)
+
+	// Per-unit resolved-family presence, from the SAME sources
+	// BuildZoneHostInboundViews scopes the kernel deny with: the interface
+	// snapshots (static config addresses merged with live kernel addresses) and
+	// the configured VRRP VIPs. A family present here is already covered by the
+	// deny, so it is NOT a fail-open window.
+	hasFam := make(map[string]map[string]bool)
+	mark := func(name, family string) {
+		m := hasFam[name]
+		if m == nil {
+			m = make(map[string]bool, 2)
+			hasFam[name] = m
+		}
+		m[family] = true
+	}
+	for _, snap := range buildInterfaceSnapshots(cfg) {
+		for _, a := range snap.Addresses {
+			if hostIPFromCIDR(a.Address) != "" {
+				mark(snap.Name, a.Family)
+			}
+		}
+	}
+	ifNames := make([]string, 0, len(cfg.Interfaces.Interfaces))
+	for n := range cfg.Interfaces.Interfaces {
+		ifNames = append(ifNames, n)
+	}
+	sort.Strings(ifNames)
+	for _, ifName := range ifNames {
+		iface := cfg.Interfaces.Interfaces[ifName]
+		if iface == nil {
+			continue
+		}
+		for un, unit := range iface.Units {
+			if unit == nil {
+				continue
+			}
+			unitName := fmt.Sprintf("%s.%d", ifName, un)
+			for _, vg := range unit.VRRPGroups {
+				if vg == nil {
+					continue
+				}
+				for _, vip := range vg.VirtualAddresses {
+					host := hostIPFromCIDR(vip)
+					if host == "" {
+						continue
+					}
+					if strings.Contains(host, ":") {
+						mark(unitName, "inet6")
+					} else {
+						mark(unitName, "inet")
+					}
+				}
+			}
+		}
+	}
+
+	var out []AddresslessEnforcingInterface
+	for _, ifName := range ifNames {
+		iface := cfg.Interfaces.Interfaces[ifName]
+		if iface == nil {
+			continue
+		}
+		unitNums := make([]int, 0, len(iface.Units))
+		for un := range iface.Units {
+			unitNums = append(unitNums, un)
+		}
+		sort.Ints(unitNums)
+		for _, un := range unitNums {
+			unit := iface.Units[un]
+			if unit == nil {
+				continue
+			}
+			unitName := fmt.Sprintf("%s.%d", ifName, un)
+			if hostInboundLifelineInterface(unitName, lifelines) {
+				continue
+			}
+			zoneName := zoneByIface[unitName]
+			if zoneName == "" {
+				continue
+			}
+			if zone := cfg.Security.Zones[zoneName]; zone == nil {
+				continue
+			}
+			// inet: a v4 DHCP client with no resolved v4 address yet.
+			if unit.DHCP && !hasFam[unitName]["inet"] {
+				out = append(out, AddresslessEnforcingInterface{
+					Zone: zoneName, Interface: unitName,
+					Family: "inet", Reason: AddresslessDHCPPending,
+				})
+			}
+			// inet6: a v6 DHCP client with no resolved v6 address yet. xpfd
+			// disables IPv6 RA on every managed interface, so DHCPv6 (stateful or
+			// the dhcpv6-client stanza) is the only dynamic v6 path — SLAAC is not
+			// a separate case (see BuildZoneHostInboundViews).
+			if (unit.DHCPv6 || unit.DHCPv6Client != nil) && !hasFam[unitName]["inet6"] {
+				out = append(out, AddresslessEnforcingInterface{
+					Zone: zoneName, Interface: unitName,
+					Family: "inet6", Reason: AddresslessDHCPPending,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Zone != out[j].Zone {
+			return out[i].Zone < out[j].Zone
+		}
+		if out[i].Interface != out[j].Interface {
+			return out[i].Interface < out[j].Interface
+		}
+		return out[i].Family < out[j].Family
+	})
+	return out
+}
+
 // AmbiguousHostInboundAddress names a firewall-local address that is
 // host-inbound-reachable from more than one security zone / effective
 // host-inbound token set with DIFFERING admission (#3718 Option B). The kernel

--- a/pkg/dataplane/userspace/zones_addressless_iface_3710_test.go
+++ b/pkg/dataplane/userspace/zones_addressless_iface_3710_test.go
@@ -1,0 +1,169 @@
+// #3710: AddresslessEnforcingZones (#3698) reports the host-inbound fail-open
+// admit window at ZONE granularity — a zone is silent the moment ANY of its
+// interfaces resolves an address in EITHER family. Host-inbound ENFORCEMENT is
+// per-destination-address and per-family, so a MIXED zone (a DHCP-pending
+// interface beside a statically-addressed sibling, or the v6 side of a
+// dual-stack edge whose v6 lease lands after v4) still has a real per-interface /
+// per-family fail-open window that the zone-level collapse cannot express.
+// AddresslessEnforcingInterfaces surfaces that finer detail. These tests are
+// fail-on-revert: collapse the reporter back to zone granularity and the mixed
+// cases stop surfacing; the fully-addressed / lifeline / static / VIP cases must
+// stay silent (the low-noise contract).
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// mixedZoneCfg3710 builds a config that exercises every arm of the per-interface
+// reporter: a mixed zone (addressed sibling + DHCP-pending sibling), a mixed
+// dual-stack interface (static v4 + DHCPv6-pending v6), a fully-addressed zone, a
+// DHCP lifeline (fxp0) that must stay silent, and a VIP-scoped zone.
+func mixedZoneCfg3710() *config.Config {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		// trust: two units. ge-0-0-0.0 is statically addressed; ge-0-0-1.0 is a
+		// DHCP WAN with no lease yet. The addressed sibling makes the ZONE scoped
+		// (#3698 stays silent), so ge-0-0-1.0's window is only visible per
+		// interface.
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.1.10/24"}},
+		}},
+		"ge-0-0-1": {Name: "ge-0-0-1", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, DHCP: true},
+		}},
+		// dual: static v4 present, v6 via DHCPv6 pending. inet resolves (scopes the
+		// zone), so #3698 is silent; the inet6 window is per-family only.
+		"ge-0-0-2": {Name: "ge-0-0-2", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, Addresses: []string{"10.0.2.10/24"}, DHCPv6: true},
+		}},
+		// mgmt: fxp0 is a lifeline and DHCP — must NEVER be reported.
+		"fxp0": {Name: "fxp0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, DHCP: true},
+		}},
+		// ha: no static address, DHCP configured, but a configured VRRP VIP scopes
+		// the deny from config on both nodes — the inet family resolves, so no
+		// inet window; there is no v6 client, so no inet6 window.
+		"reth0": {Name: "reth0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, DHCP: true, VRRPGroups: map[string]*config.VRRPGroup{
+				"10.0.9.1/24": {VirtualAddresses: []string{"10.0.9.1"}},
+			}},
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"ge-0-0-0.0", "ge-0-0-1.0"}},
+		"dual":  {Name: "dual", Interfaces: []string{"ge-0-0-2.0"}},
+		"mgmt":  {Name: "mgmt", Interfaces: []string{"fxp0.0"}},
+		"ha":    {Name: "ha", Interfaces: []string{"reth0.0"}},
+	}
+	return cfg
+}
+
+func TestAddresslessEnforcingInterfaces(t *testing.T) {
+	got := AddresslessEnforcingInterfaces(mixedZoneCfg3710())
+
+	// Exactly two per-interface/per-family windows are open:
+	//   trust / ge-0-0-1.0 / inet  (DHCP WAN, no lease — hidden by addressed sibling)
+	//   dual  / ge-0-0-2.0 / inet6 (DHCPv6 pending — hidden by the resolved v4)
+	type key struct{ zone, iface, family, reason string }
+	want := map[key]bool{
+		{"trust", "ge-0-0-1.0", "inet", AddresslessDHCPPending}: true,
+		{"dual", "ge-0-0-2.0", "inet6", AddresslessDHCPPending}: true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("AddresslessEnforcingInterfaces = %+v, want exactly %d entries %v", got, len(want), want)
+	}
+	for _, g := range got {
+		k := key{g.Zone, g.Interface, g.Family, g.Reason}
+		if !want[k] {
+			t.Errorf("unexpected per-interface window %+v", g)
+		}
+		delete(want, k)
+	}
+	for k := range want {
+		t.Errorf("missing per-interface window %+v", k)
+	}
+}
+
+// TestAddresslessEnforcingInterfacesSorted pins the deterministic (zone,
+// interface, family) ordering the metric / log rely on for stable output.
+func TestAddresslessEnforcingInterfacesSorted(t *testing.T) {
+	got := AddresslessEnforcingInterfaces(mixedZoneCfg3710())
+	if len(got) < 2 {
+		t.Fatalf("precondition: expected >=2 windows, got %+v", got)
+	}
+	for i := 1; i < len(got); i++ {
+		a, b := got[i-1], got[i]
+		if a.Zone > b.Zone ||
+			(a.Zone == b.Zone && a.Interface > b.Interface) ||
+			(a.Zone == b.Zone && a.Interface == b.Interface && a.Family > b.Family) {
+			t.Errorf("not sorted at %d: %+v then %+v", i, a, b)
+		}
+	}
+}
+
+// TestAddresslessEnforcingInterfacesLowNoise proves the entries that must stay
+// SILENT: a lifeline, a statically-addressed unit, a VIP-scoped unit, and the
+// resolved family of a dual-stack edge.
+func TestAddresslessEnforcingInterfacesLowNoise(t *testing.T) {
+	for _, g := range AddresslessEnforcingInterfaces(mixedZoneCfg3710()) {
+		switch {
+		case g.Interface == "fxp0.0":
+			t.Error("fxp0 is a lifeline (DHCP but never host-inbound-denied) — must not be reported")
+		case g.Interface == "ge-0-0-0.0":
+			t.Error("ge-0-0-0.0 is statically addressed — must not be reported")
+		case g.Interface == "reth0.0":
+			t.Error("reth0.0 inet is scoped by its VRRP VIP from config — must not be reported")
+		case g.Interface == "ge-0-0-2.0" && g.Family == "inet":
+			t.Error("ge-0-0-2.0 inet is statically addressed — only its inet6 side is in the window")
+		}
+	}
+}
+
+// TestAddresslessEnforcingInterfacesHealsOnLease asserts each window closes once
+// the pending family resolves an address — the self-heal path the daemon relies
+// on to clear its state-transition warning.
+func TestAddresslessEnforcingInterfacesHealsOnLease(t *testing.T) {
+	cfg := mixedZoneCfg3710()
+	if len(AddresslessEnforcingInterfaces(cfg)) != 2 {
+		t.Fatalf("precondition: expected 2 windows")
+	}
+	// The DHCP WAN lease lands (v4) and the DHCPv6 lease lands (v6).
+	cfg.Interfaces.Interfaces["ge-0-0-1"].Units[0].Addresses = []string{"203.0.113.5/24"}
+	cfg.Interfaces.Interfaces["ge-0-0-2"].Units[0].Addresses = []string{"10.0.2.10/24", "2001:db8:2::10/64"}
+	if got := AddresslessEnforcingInterfaces(cfg); len(got) != 0 {
+		t.Errorf("after leases install = %+v, want empty (all windows closed)", got)
+	}
+}
+
+// TestAddresslessEnforcingInterfacesIPv4OnlyNoV6Noise proves the low-noise gate:
+// an IPv4-only interface (no v6 client configured) is NOT reported as addressless
+// in inet6 — it never intends to acquire a v6 address, so there is no window.
+func TestAddresslessEnforcingInterfacesIPv4OnlyNoV6Noise(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Interfaces.Interfaces = map[string]*config.InterfaceConfig{
+		"ge-0-0-0": {Name: "ge-0-0-0", Units: map[int]*config.InterfaceUnit{
+			0: {Number: 0, DHCP: true}, // v4 DHCP only, no v6 client
+		}},
+	}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust", Interfaces: []string{"ge-0-0-0.0"}},
+	}
+	got := AddresslessEnforcingInterfaces(cfg)
+	if len(got) != 1 || got[0].Family != "inet" {
+		t.Fatalf("IPv4-only DHCP = %+v, want exactly [trust ge-0-0-0.0 inet]", got)
+	}
+}
+
+// TestAddresslessEnforcingInterfacesEmptyConfig guards the nil / no-zone /
+// no-interface fast paths.
+func TestAddresslessEnforcingInterfacesEmptyConfig(t *testing.T) {
+	if got := AddresslessEnforcingInterfaces(nil); got != nil {
+		t.Errorf("nil cfg = %v, want nil", got)
+	}
+	if got := AddresslessEnforcingInterfaces(&config.Config{}); got != nil {
+		t.Errorf("no-zone cfg = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3710.

The #3698 addressless host-inbound reporter (`AddresslessEnforcingZones`)
collapses the fail-open admit window to **zone** granularity: it marks a zone
"scoped" — and stays silent — the moment ANY of the zone's interfaces resolves
an address in EITHER family. Host-inbound ENFORCEMENT, however, is
per-destination-address and per-family (the kernel chain emits
`<fam> daddr <set> ... drop` separately for `inet` and `inet6`), so a **MIXED**
zone still carries a real fail-open window the zone-level view cannot express:

1. **Mixed-interface zone** — a DHCP-pending interface beside a
   statically-addressed sibling; the sibling's address scopes the zone, so
   #3698 never surfaces the DHCP interface's window.
2. **Mixed-family interface** — the IPv6 side of a dual-stack edge whose v6
   lease lands after its v4; `len(V4Addrs) > 0` marks the zone scoped, so the
   pending v6 side is invisible.

## Change (Go-only, observability-only — no Rust/cargo, no enforcement change)

- **`pkg/dataplane/userspace/zones.go`** — new `AddresslessEnforcingInterfaces`
  reporting `{zone, interface-unit, family, reason}`. It reports a non-lifeline
  logical unit in a configured host-inbound-enforcing zone when a family has a
  DHCP/DHCPv6 client configured but currently resolves **no address** in that
  family, using the same static / live-kernel + configured-VRRP-VIP resolution
  `BuildZoneHostInboundViews` scopes the deny with (so it agrees with
  enforcement). Only the `dhcp-pending` reason is emitted — static addrs and
  VIPs are config-injected regardless of link/lease state, so they never open a
  per-interface window; gating on a configured DHCP client (not "any family with
  no address") keeps it low-noise (an IPv4-only interface is not flagged as
  addressless in `inet6`).
- **`pkg/daemon/daemon_nft.go` / `daemon.go`** —
  `logHostInboundAddresslessIfaceTransitions` (WARN on entry / INFO on
  recovery, transitions only, new `hostInboundAddresslessIfaces` diff field),
  called from `applyHostInboundFilter`.
- **`pkg/api/`** — Prometheus gauge
  `xpf_host_inbound_addressless_interfaces{zone,interface,family,reason}`,
  emitted before the dataplane gate. The zone-level
  `xpf_host_inbound_addressless_zones` is unchanged (coarser compatibility
  aggregate); this per-interface series is strictly more sensitive and exported
  alongside it.
- **`docs/host-inbound-service-matrix.md`** — new "Per-interface / per-family
  refinement (#3710)" subsection.

## Tests

`pkg/dataplane/userspace/zones_addressless_iface_3710_test.go`:

- **RED-on-revert**: `TestAddresslessEnforcingInterfaces` — a mixed zone
  surfaces `trust/ge-0-0-1.0/inet` + `dual/ge-0-0-2.0/inet6`. Collapsing the
  reporter back to zone granularity (skip a unit whose zone resolves any
  address) yields empty output and fails the test — verified.
- Low-noise (lifeline / static / VIP / resolved-family stay silent), sorted
  ordering, self-heal on lease, IPv4-only-no-v6-noise, and nil/empty-config
  cases pinned.

`go test ./pkg/dataplane/... ./pkg/api/... ./pkg/daemon/` green; `go build
./...`, `gofmt`, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
