### PR TITLE
userspace-dp: carry to-zone junos-host permit log/policy-id onto the local-delivery session (#3706)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27782,3 +27782,35 @@ top.
   userspace-dp/src/afxdp/forwarding/README.md (#3706 permit-metadata
   propagation section), userspace-dp/src/session/README.md (#3706 host-local
   policy-id exception)
+
+## 2026-07-02 — #3706 review fold: no double-count on the established host-local hit path
+
+- **Timestamp**: 2026-07-02
+- **Action**: #3706 hostile-review fold (one blocking MINOR, observability-only,
+  PR-introduced). The MISS-install stamp of a bound `policy_counter` onto a
+  junos-host permit host-local session made the generic session-HIT counter
+  (`poll_descriptor/mod.rs` ~:808, `resolve_session_hit_counter` ->
+  `record_policy_hit_counter`) count each established host-local permit packet,
+  while the mandatory `to-zone junos-host` session-HIT teardown re-eval
+  (`junos_host_local_policy` -> `junos_host_policy_eval` ->
+  `evaluate_junos_host_policy_l3_aware` -> `try_match_rule`, policy.rs:3736
+  `rule.hit_counter.add`) ALSO counted the same packet — DOUBLE-counting every
+  established host-local permit packet (2N for N hits). LocalDelivery sessions
+  are not flow-cached, so the flow-cache replay path never deduped it. Pre-#3706
+  the generic site was a no-op for host-local (`resolve_session_hit_counter(None,
+  0)` -> None), so the established count came solely from the re-eval (once).
+  Transit counts once (no per-hit re-eval). Fix: gate the generic session-HIT
+  `record_policy_hit_counter` on `resolved.decision.resolution.disposition !=
+  ForwardingDisposition::LocalDelivery` — the LocalDelivery path already counts
+  exactly once via its mandatory junos-host re-eval, byte-identical to pre-#3706
+  host-local counting; transit is untouched. The #3706 permit attribution
+  (policy_id / log flags / the bound counter handle for close-time
+  re-resolution + HA sync) stays stamped. Added a fail-on-revert test
+  (`poll_descriptor_junos_host_permit_established_hit_counts_once`): drive 1 SYN
+  miss + 3 established ACK hits, assert the admitting rule's packet counter == 4
+  (removing the `!= LocalDelivery` guard reads 7 -> RED, verified). Full
+  `cargo test --release` green.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs (session-HIT
+  `record_policy_hit_counter` gated on non-LocalDelivery), userspace-dp/src/
+  afxdp/tests.rs (established-hit exactly-once fail-on-revert test), userspace-dp/
+  src/afxdp/forwarding/README.md (#3706 exactly-once hit-counting note)

--- a/_Log.md
+++ b/_Log.md
@@ -27734,3 +27734,51 @@ top.
   userspace-dp/src/main_tests.rs (renamed + retargeted defer-clear test),
   docs/userspace-dataplane-architecture.md + userspace-dp/src/server/
   README.md (#3789 handler-observes-outcome doc)
+
+## 2026-07-01 — #3706 to-zone junos-host `then permit log` now stamps the local-delivery session (codex-163)
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3706 — a `from-zone <z> to-zone junos-host then permit log
+  session-init session-close` policy admitted host-bound traffic but its
+  logging + policy attribution were DISCARDED on the local-delivery
+  (host-inbound / junos-host) forwarding path. Root cause: the flow-backed
+  junos-host gate wrapper (`junos_host_policy_eval` in
+  `poll_descriptor/mod.rs`) returned `None` on `PolicyAction::Permit`, so the
+  caller treated a matched permit identically to "no host policy" and the
+  session-MISS local-delivery install hardcoded `log_session_init: false`,
+  `log_session_close: false`, `policy_id: 0`, `policy_counter_idx: 0`,
+  `policy_counter: None`. Host-bound management permit sessions were therefore
+  unlogged (no RT_FLOW SESSION_CREATE/CLOSE) and unattributable (policy id 0),
+  a vSRX session-to-policy parity gap. Distinct from #3611 (junos-host
+  enforcement / global context) and #3639 (to-zone junos-host GLOBAL matching)
+  — those are about MATCHING; this is about propagating the PERMIT result
+  metadata into the installed local session. Fix: `junos_host_policy_eval` now
+  returns the FULL `PolicyEvaluationResult` (permit as well as deny/reject);
+  the flow-backed gate `junos_host_policy_drops` was renamed
+  `junos_host_local_policy` and now returns a `JunosHostLocalPolicy` verdict
+  (`Dropped` / `Permit(result)` / `NoMatch`). On a matching PERMIT the
+  session-MISS install stamps the admitting policy's `then log` selection,
+  `policy_id`, and per-rule hit-counter handle (bound once via
+  `hit_counter_by_idx`, #3322-stable) onto the local session + published
+  conntrack row — parity with the transit permit path. The session-HIT path
+  keeps only the `Dropped` check (the session is already installed with the
+  miss-time permit metadata); the flowless (`l4_present = false`) arm never
+  installs a session, so a flowless permit delivers with no metadata to carry
+  (only deny/reject drives the flowless filter drop). `NoMatch` keeps the
+  default no-policy host-local metadata (byte-identical to pre-#3706). Added
+  two fail-on-revert AF_XDP session-MISS tests: a `then permit log
+  session-init session-close` session installs with both log flags + a
+  non-zero admitting `policy_id` (4242) + a non-zero counter handle (goes RED
+  on revert), and a permit WITHOUT `then log` installs with both log flags
+  OFF (no over-log) while still carrying the admitting policy id. Full
+  `cargo test --release` green.
+- **File(s)**: userspace-dp/src/afxdp/poll_descriptor/mod.rs
+  (`junos_host_policy_eval` returns full result; new `JunosHostLocalPolicy`
+  enum; `junos_host_policy_drops` -> `junos_host_local_policy`; flowless arm
+  permit handling; session-MISS install stamps permit metadata; session-HIT
+  `Dropped` match; doc comments), userspace-dp/src/afxdp/tests.rs (two #3706
+  fail-on-revert tests + `junos_host_local_delivery_permit_snapshot` /
+  `run_junos_host_permit_local_delivery` helpers),
+  userspace-dp/src/afxdp/forwarding/README.md (#3706 permit-metadata
+  propagation section), userspace-dp/src/session/README.md (#3706 host-local
+  policy-id exception)

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -451,6 +451,21 @@ session, so a flowless permit simply delivers with no metadata to carry.
 0, no counter) — the historical host-local behavior for a genuinely
 unattributed local session.
 
+**Exactly-once hit counting (#3706).** The LocalDelivery session-HIT path
+re-evaluates the junos-host policy on every packet (the mandatory teardown
+re-check), and that re-eval's `try_match_rule` counts the packet against the
+admitting rule's hit counter — as it did pre-#3706, when a host-local session
+carried no bound counter and the generic session-hit
+`record_policy_hit_counter` was a no-op (`resolve_session_hit_counter(None, 0)`
+→ `None`). Because #3706 now stamps a bound counter onto a junos-host permit
+session, the generic session-hit counter site would count a SECOND time, so
+`poll_descriptor` skips it for `LocalDelivery` (the `!= LocalDelivery` guard) and
+lets the per-hit junos-host re-eval be the single counter. Transit has no per-hit
+re-eval and counts solely at the generic site, so both paths count exactly once
+(the bound counter is still stamped for close-time `policy_id` re-resolution and
+HA sync). The first (miss) packet counts once via the session-MISS junos-host
+gate's `try_match_rule`.
+
 `policy::evaluate_junos_host_policy` resolves the reserved `junos-host` zone
 name to `JUNOS_HOST_ZONE_ID` (`u16::MAX-1`, the bottom of the reserved range,
 never on the wire because zone ids are u8) and looks up the

--- a/userspace-dp/src/afxdp/forwarding/README.md
+++ b/userspace-dp/src/afxdp/forwarding/README.md
@@ -428,10 +428,28 @@ stay consistent.
 Host-bound (LocalDelivery) traffic is also subject to the Junos
 `from-zone <z> to-zone junos-host` security policy. Junos order is
 **host-inbound admission FIRST, then security policy** — so the
-`junos_host_policy_drops` gate runs immediately AFTER `host_inbound_admits`
+`junos_host_local_policy` gate runs immediately AFTER `host_inbound_admits`
 at BOTH local-delivery sites in `poll_descriptor` (session miss and session
 hit). A packet host-inbound already rejected never reaches policy, so a
 `to-zone junos-host then permit` cannot re-admit it.
+
+**Permit metadata propagation (#3706).** `junos_host_local_policy` returns a
+`JunosHostLocalPolicy` verdict — `Dropped` (deny/reject), `Permit(result)`, or
+`NoMatch`. On a matching PERMIT the session-MISS install stamps the admitting
+policy's `then log session-init`/`session-close` selection, its `policy_id`, and
+its per-rule hit-counter handle onto the installed host-local session (and the
+published conntrack row) — exactly like a transit permit, so a
+`to-zone junos-host then permit log session-init session-close` session emits the
+RT_FLOW SESSION_CREATE/CLOSE records and is attributable to the admitting policy.
+Before #3706 the gate collapsed to a bare `bool` and discarded the permit result,
+so host-bound permit sessions installed with both log flags off, `policy_id` 0,
+and no counter handle (unlogged + unattributable). The session-HIT path only
+needs the `Dropped` verdict (the session is already installed with the miss-time
+permit metadata); the flowless (`l4_present = false`) arm never installs a
+session, so a flowless permit simply delivers with no metadata to carry.
+`NoMatch` keeps the default no-policy host-local metadata (log off, `policy_id`
+0, no counter) — the historical host-local behavior for a genuinely
+unattributed local session.
 
 `policy::evaluate_junos_host_policy` resolves the reserved `junos-host` zone
 name to `JUNOS_HOST_ZONE_ID` (`u16::MAX-1`, the bottom of the reserved range,

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -801,11 +801,35 @@ pub(super) fn poll_binding_process_descriptor(
                         // handle over the positional idx so a live policy
                         // reorder cannot re-attribute this established flow's
                         // packets to a different rule.
-                        if let Some(counter) = worker_ctx.forwarding.policy.resolve_session_hit_counter(
-                            resolved.metadata.policy_counter.as_ref(),
-                            resolved.metadata.policy_counter_idx,
-                        ) {
-                            crate::policy::record_policy_hit_counter(counter, desc.len as u64);
+                        //
+                        // #3706: EXCEPT on the LocalDelivery (host-bound) path.
+                        // A host-local session re-evaluates the `to-zone
+                        // junos-host` policy on EVERY hit (the mandatory teardown
+                        // re-check below), and that re-eval's `try_match_rule`
+                        // already counts this packet against the admitting rule's
+                        // hit counter — exactly as it did pre-#3706, when a
+                        // host-local session carried no bound counter and this
+                        // line was a no-op (`resolve_session_hit_counter(None, 0)`
+                        // -> None). Now that a junos-host permit stamps a bound
+                        // counter (#3706), counting HERE too would double-count
+                        // every established host-local permit packet. Transit has
+                        // no per-hit policy re-eval, so it counts solely here.
+                        // Gate on disposition so the count fires exactly once on
+                        // both paths (parity with transit) while the #3706 permit
+                        // attribution — policy_id / log flags / the bound counter
+                        // handle used for close-time re-resolution + HA sync —
+                        // stays stamped on the session.
+                        if resolved.decision.resolution.disposition
+                            != ForwardingDisposition::LocalDelivery
+                        {
+                            if let Some(counter) =
+                                worker_ctx.forwarding.policy.resolve_session_hit_counter(
+                                    resolved.metadata.policy_counter.as_ref(),
+                                    resolved.metadata.policy_counter_idx,
+                                )
+                            {
+                                crate::policy::record_policy_hit_counter(counter, desc.len as u64);
+                            }
                         }
                         flow_cache_install_failed = resolved.install_failed;
                         if resolved.created {

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -72,27 +72,31 @@ fn policy_packet_icmp(packet_frame: &[u8], meta: UserspaceDpMeta) -> Option<(u8,
 /// host-bound (LocalDelivery) path. MUST be called AFTER `host_inbound_admits`
 /// (Junos order: host-inbound-traffic admission first, then security policy),
 /// so a `then permit` can never re-admit what host-inbound already rejected.
+/// The gate itself is [`junos_host_local_policy`], which returns a
+/// [`JunosHostLocalPolicy`] verdict (drop / permit-with-metadata / no-match);
+/// [`junos_host_policy_eval`] is the reply-FREE evaluation core it and the
+/// flowless arm share.
 ///
-/// Returns `true` iff the packet must be DROPPED — a `to-zone junos-host` rule
-/// MATCHED with `deny`/`reject`. On a deny/reject it emits the policy-deny
-/// RT_FLOW (mirroring the transit deny path) and synthesizes a `reject` / zone
-/// `tcp-rst` reply. Returns `false` (continue local delivery) when no
-/// junos-host policy is configured, none matches, or a matching rule permits —
-/// preserving pre-#3019 host-bound behavior so management traffic is never
-/// newly denied (the lifeline guarantee). Cold path only (LocalDelivery).
 /// #3019/#3292: evaluate the configured `to-zone junos-host` security policy for
 /// a host-bound (LocalDelivery) packet and, on a matching deny/reject, emit the
 /// policy-deny RT_FLOW. This is the reply-FREE core shared by both the
-/// flow-backed [`junos_host_policy_drops`] (which adds the synthesized
-/// reject/tcp-rst reply) and the flowless LocalDelivery arm (#3292, which can
-/// emit no reply — a fragment has no L4 header to build a RST from).
+/// flow-backed [`junos_host_local_policy`] gate (which adds the synthesized
+/// reject/tcp-rst reply on a deny/reject and surfaces a permit's metadata) and
+/// the flowless LocalDelivery arm (#3292, which can emit no reply — a fragment
+/// has no L4 header to build a RST from).
 ///
 /// `l4_present = false` routes through the l3-aware junos-host evaluation so a
 /// port-bearing application term fails closed for a flowless packet; the
-/// flow-backed wrapper passes `true` (byte-identical to pre-#3292). Returns
-/// `Some(action)` when a junos-host rule matched deny/reject (caller drops);
-/// `None` when no junos-host policy is configured, none matches, or a match
-/// permits (caller continues local delivery).
+/// flow-backed wrapper passes `true` (byte-identical to pre-#3292).
+///
+/// #3706: returns the FULL [`PolicyEvaluationResult`] of a matching junos-host
+/// rule — permit as well as deny/reject — so the local-delivery session-install
+/// path can stamp a matching PERMIT's `then log` selection, admitting
+/// `policy_id`, and hit-counter handle onto the installed host-bound session
+/// (parity with the transit permit path). `None` means no junos-host policy is
+/// configured or none matched; the caller then keeps the default no-policy
+/// local-session metadata. Callers that only gate (drop on deny/reject) inspect
+/// `result.action` themselves.
 #[allow(clippy::too_many_arguments)]
 fn junos_host_policy_eval(
     forwarding: &ForwardingState,
@@ -101,8 +105,8 @@ fn junos_host_policy_eval(
     packet_len: u64,
     l4_present: bool,
     packet_icmp: Option<(u8, u8)>,
-) -> Option<(PolicyAction, u32)> {
-    let result = crate::policy::evaluate_junos_host_policy_l3_aware(
+) -> Option<crate::policy::PolicyEvaluationResult> {
+    crate::policy::evaluate_junos_host_policy_l3_aware(
         &forwarding.policy,
         from_zone_id,
         flow.src_ip,
@@ -113,11 +117,30 @@ fn junos_host_policy_eval(
         packet_icmp,
         packet_len,
         l4_present,
-    )?;
-    match result.action {
-        PolicyAction::Permit => None,
-        action @ (PolicyAction::Deny | PolicyAction::Reject) => Some((action, result.policy_id)),
-    }
+    )
+}
+
+/// #3706: verdict of the flow-backed `to-zone junos-host` security-policy gate
+/// on the local-delivery (host-inbound) path, returned by
+/// [`junos_host_local_policy`]. The pre-#3706 gate collapsed to a bare `bool`
+/// (dropped?) and discarded a matching permit's metadata, so a
+/// `to-zone junos-host then permit log` session installed with no log flags and
+/// `policy_id` 0 — unlogged and unattributable.
+enum JunosHostLocalPolicy {
+    /// A matching junos-host `deny`/`reject` dropped the host-bound packet (the
+    /// reject/tcp-rst reply was enqueued and the policy-deny RT_FLOW emitted).
+    /// The caller recycles the frame and skips session install.
+    Dropped,
+    /// A matching junos-host policy PERMITTED the host-bound flow. Carries the
+    /// full evaluation result so the session-install path stamps the policy's
+    /// `then log session-init/session-close` selection, admitting `policy_id`,
+    /// and per-rule hit-counter handle onto the installed local session +
+    /// published conntrack row (#3706), matching the transit permit path.
+    Permit(crate::policy::PolicyEvaluationResult),
+    /// No junos-host policy matched (none configured, or none matched). The
+    /// caller continues local delivery with the default no-policy metadata
+    /// (byte-identical to pre-#3706 host-local behavior).
+    NoMatch,
 }
 
 /// #3019/#3292/#3615: emit the junos-host (`to-zone junos-host`) policy-deny
@@ -191,7 +214,7 @@ fn emit_host_inbound_deny(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn junos_host_policy_drops(
+fn junos_host_local_policy(
     forwarding: &ForwardingState,
     event_stream: Option<&crate::event_stream::EventStreamWorkerHandle>,
     tx_pipeline: &mut crate::afxdp::worker::WorkerTxPipeline,
@@ -203,7 +226,7 @@ fn junos_host_policy_drops(
     from_zone_id: u16,
     packet_len: u64,
     now_ns: u64,
-) -> bool {
+) -> JunosHostLocalPolicy {
     let policy_icmp = policy_packet_icmp(packet_frame, meta);
     match junos_host_policy_eval(
         forwarding,
@@ -214,7 +237,14 @@ fn junos_host_policy_drops(
         true,
         policy_icmp,
     ) {
-        Some((action, policy_id)) => {
+        // #3706: a matching PERMIT carries its `then log` selection, admitting
+        // policy_id, and hit-counter handle back to the caller so the installed
+        // host-bound session is logged + attributed like a transit permit.
+        Some(result) if matches!(result.action, PolicyAction::Permit) => {
+            JunosHostLocalPolicy::Permit(result)
+        }
+        Some(result) => {
+            let action = result.action;
             // #3615: enqueue the reject/tcp-rst reply FIRST, then emit the
             // junos-host deny with the ACTUAL reply outcome so a suppressed
             // reject logs the truthful DENY.
@@ -235,14 +265,14 @@ fn junos_host_policy_drops(
                 flow,
                 meta,
                 from_zone_id,
-                policy_id,
+                result.policy_id,
                 action,
                 reject_reply_enqueued,
                 now_ns,
             );
-            true
+            JunosHostLocalPolicy::Dropped
         }
-        None => false,
+        None => JunosHostLocalPolicy::NoMatch,
     }
 }
 
@@ -340,22 +370,28 @@ fn flowless_local_delivery_verdict(
     // l4_present = false. A matching deny/reject is a SILENT flowless drop — a
     // fragment has no L4 header to synthesize a RST/ICMP reject from, so #3615
     // logs the truthful DENY (reject_reply_enqueued = false) for observability.
-    if let Some((action, policy_id)) =
+    // #3706: the eval now returns a matching PERMIT too; a flowless fragment is
+    // NEVER installed as a session (this synthetic L3 tuple is evaluation- and
+    // logging-only), so a permit simply falls through to Deliver with no
+    // metadata to carry — only a deny/reject drives the flowless filter drop.
+    if let Some(result) =
         junos_host_policy_eval(forwarding, flow, from_zone_id, packet_len, false, packet_icmp)
     {
-        emit_junos_host_deny(
-            forwarding,
-            event_stream,
-            flow,
-            meta,
-            from_zone_id,
-            policy_id,
-            action,
-            // Flowless: no reply is ever synthesized.
-            false,
-            now_ns,
-        );
-        return FlowlessLocalVerdict::Filtered;
+        if !matches!(result.action, PolicyAction::Permit) {
+            emit_junos_host_deny(
+                forwarding,
+                event_stream,
+                flow,
+                meta,
+                from_zone_id,
+                result.policy_id,
+                result.action,
+                // Flowless: no reply is ever synthesized.
+                false,
+                now_ns,
+            );
+            return FlowlessLocalVerdict::Filtered;
+        }
     }
     FlowlessLocalVerdict::Deliver
 }
@@ -1037,21 +1073,27 @@ pub(super) fn poll_binding_process_descriptor(
                         // purge. Runs AFTER host-inbound admission (Junos order).
                         // A matching deny/reject drops + emits the policy-deny
                         // RT_FLOW; permit / no-match continue. No-op unless a
-                        // junos-host policy is configured.
+                        // junos-host policy is configured. #3706: the session is
+                        // already installed (with the miss-time permit metadata),
+                        // so only the DROP verdict matters here — a permit /
+                        // no-match leaves the established session untouched.
                         if resolved.decision.resolution.disposition
                             == ForwardingDisposition::LocalDelivery
-                            && junos_host_policy_drops(
-                                worker_ctx.forwarding,
-                                worker_ctx.event_stream,
-                                &mut binding.tx_pipeline,
-                                binding.ifindex,
-                                packet_frame,
-                                telemetry.counters,
-                                flow,
-                                meta,
-                                resolved.metadata.ingress_zone,
-                                desc.len as u64,
-                                now_ns,
+                            && matches!(
+                                junos_host_local_policy(
+                                    worker_ctx.forwarding,
+                                    worker_ctx.event_stream,
+                                    &mut binding.tx_pipeline,
+                                    binding.ifindex,
+                                    packet_frame,
+                                    telemetry.counters,
+                                    flow,
+                                    meta,
+                                    resolved.metadata.ingress_zone,
+                                    desc.len as u64,
+                                    now_ns,
+                                ),
+                                JunosHostLocalPolicy::Dropped
                             )
                         {
                             delete_terminal_filtered_session(
@@ -1914,15 +1956,21 @@ pub(super) fn poll_binding_process_descriptor(
                                 }
                             }
                         }
-                        // #3019: `to-zone junos-host` security policy on the
-                        // session-MISS local-delivery path, AFTER host-inbound
-                        // admission (Junos order). A matching junos-host deny/
-                        // reject drops the host-bound packet (and emits the
-                        // policy-deny RT_FLOW + reject/tcp-rst reply); a permit
-                        // or no-match continues to local delivery unchanged.
-                        // No-op unless a junos-host policy is configured.
-                        if resolution.disposition == ForwardingDisposition::LocalDelivery
-                            && junos_host_policy_drops(
+                        // #3019/#3706: `to-zone junos-host` security policy on
+                        // the session-MISS local-delivery path, AFTER
+                        // host-inbound admission (Junos order). A matching
+                        // junos-host deny/reject drops the host-bound packet
+                        // (and emits the policy-deny RT_FLOW + reject/tcp-rst
+                        // reply); a matching PERMIT is carried forward so its
+                        // `then log` selection + admitting policy id + counter
+                        // handle can be stamped onto the installed session
+                        // (#3706); a no-match continues to local delivery with
+                        // the default no-policy metadata. No-op unless a
+                        // junos-host policy is configured.
+                        let junos_host_outcome = if resolution.disposition
+                            == ForwardingDisposition::LocalDelivery
+                        {
+                            junos_host_local_policy(
                                 worker_ctx.forwarding,
                                 worker_ctx.event_stream,
                                 &mut binding.tx_pipeline,
@@ -1935,7 +1983,10 @@ pub(super) fn poll_binding_process_descriptor(
                                 desc.len as u64,
                                 now_ns,
                             )
-                        {
+                        } else {
+                            JunosHostLocalPolicy::NoMatch
+                        };
+                        if matches!(junos_host_outcome, JunosHostLocalPolicy::Dropped) {
                             telemetry.dbg.local += 1;
                             telemetry.dbg.policy_deny += 1;
                             telemetry.counters.touched = true;
@@ -1952,6 +2003,44 @@ pub(super) fn poll_binding_process_descriptor(
                                 meta.tcp_flags,
                             )
                         {
+                            // #3706: a matching `to-zone junos-host then permit
+                            // [log ...]` policy admitted this host-bound flow, so
+                            // stamp its log selection, admitting policy id, and
+                            // per-rule hit-counter handle onto the installed
+                            // session — parity with the transit permit path. The
+                            // #2508/#3056/#3073 comments below ("host-local
+                            // sessions are not policy-forwarded, so they carry no
+                            // log / policy id / counter") predate junos-host
+                            // permit-policy matching and are true ONLY for a
+                            // no-match host-local session; an explicit permit DOES
+                            // have an admitting policy + logging selection.
+                            let (
+                                host_log_session_init,
+                                host_log_session_close,
+                                host_policy_id,
+                                host_policy_counter_idx,
+                            ) = match &junos_host_outcome {
+                                JunosHostLocalPolicy::Permit(result) => (
+                                    result.log_session_init,
+                                    result.log_session_close,
+                                    result.policy_id,
+                                    result.policy_counter_idx,
+                                ),
+                                // No junos-host policy matched: default no-policy
+                                // host-local metadata (byte-identical to
+                                // pre-#3706). Dropped never reaches here.
+                                _ => (false, false, 0, 0),
+                            };
+                            // #3706/#3322: bind the admitting rule's shared hit
+                            // counter here, where `host_policy_counter_idx` still
+                            // indexes the rule that admitted this flow, so a later
+                            // live policy reorder cannot re-point the count.
+                            // `hit_counter_by_idx(0)` is None (the no-match case).
+                            let host_policy_counter = worker_ctx
+                                .forwarding
+                                .policy
+                                .hit_counter_by_idx(host_policy_counter_idx)
+                                .cloned();
                             let local_metadata = SessionMetadata {
                                 ingress_zone: from_zone_id,
                                 egress_zone: to_zone_id,
@@ -1963,20 +2052,25 @@ pub(super) fn poll_binding_process_descriptor(
                                 // BPF session map so subsequent established packets bypass
                                 // userspace and return directly to the kernel.
                                 nat64_reverse: None,
-                                // #2508: firewall-local (host-destined) sessions are
-                                // not policy-forwarded, so they carry no per-policy
-                                // `then log` selection.
-                                log_session_init: false,
-                                log_session_close: false,
-                                // #3056: host-local sessions are not policy-forwarded,
-                                // so they carry no admitting policy ID.
-                                policy_id: 0,
+                                // #2508/#3706: a matching `to-zone junos-host then
+                                // permit log` policy's per-policy RT_FLOW SYSLOG
+                                // selection (a no-match host-local session carries
+                                // none, so both stay false).
+                                log_session_init: host_log_session_init,
+                                log_session_close: host_log_session_close,
+                                // #3056/#3706: the admitting junos-host policy's ID
+                                // so the live-session BPF-compat publish and the
+                                // SESSION_CREATE/CLOSE RT_FLOW records reference the
+                                // policy that admitted the host-bound flow (0 only
+                                // for a no-match host-local session).
+                                policy_id: host_policy_id,
                                 // #3227: host-local sessions are not policy-app-matched.
                                 inactivity_timeout_ns: None,
-                                // #3073: host-local sessions are not policy-forwarded,
-                                // so they carry no per-rule hit counter.
-                                policy_counter_idx: 0,
-                                policy_counter: None,
+                                // #3073/#3706: the admitting junos-host rule's
+                                // hit-counter handle (0 / None for a no-match
+                                // host-local session).
+                                policy_counter_idx: host_policy_counter_idx,
+                                policy_counter: host_policy_counter,
                             };
                             if install_helper_local_session_on_miss(
                                 sessions,

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -9713,6 +9713,103 @@ fn poll_descriptor_junos_host_permit_no_log_local_delivery_no_overlog() {
     );
 }
 
+/// #3706 fail-on-revert (established session-HIT double-count): a
+/// `to-zone junos-host then permit` host-local session must count each packet
+/// against the admitting rule's hit counter EXACTLY ONCE — parity with transit.
+/// The #3706 MISS-install stamps a bound `policy_counter`, and the LocalDelivery
+/// session-HIT path ALSO re-evaluates the junos-host policy on every hit (the
+/// mandatory teardown re-check), whose `try_match_rule` counts the packet.
+/// Counting at the generic session-hit `record_policy_hit_counter` site TOO
+/// would double-count every established host-local permit packet (2N for N
+/// hits). This drives 1 SYN (miss) + 3 established ACKs (hits) and asserts the
+/// rule's packet counter == 4. Remove the `!= LocalDelivery` guard on the
+/// session-hit counter and this goes RED (reads 7).
+#[test]
+fn poll_descriptor_junos_host_permit_established_hit_counts_once() {
+    // No `then log`; policy id 55. Counting is orthogonal to the log flags.
+    let snapshot = junos_host_local_delivery_permit_snapshot(false, false, 55);
+    let forwarding = build_forwarding_state(&snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    // `stable_policy_rule_id` for a rule with no explicit rule_id is
+    // "<from>-><to>/<name>". The fixture rule is lan -> junos-host / host-permit-log.
+    let rule_id = "lan->junos-host/host-permit-log";
+    let hit_packets = |f: &ForwardingState| -> u64 {
+        f.policy
+            .counter_snapshots()
+            .into_iter()
+            .find(|c| c.rule_id == rule_id)
+            .map(|c| c.packets)
+            .unwrap_or_else(|| panic!("missing policy counter for {rule_id}"))
+    };
+
+    // Packet 1: SYN => session MISS => install. The miss-site junos-host
+    // re-eval counts this first packet once (cold path).
+    let syn = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(10, 0, 61, 102),
+        Ipv4Addr::new(10, 255, 0, 1),
+        12345,
+        179,
+        TCP_FLAG_SYN,
+    );
+    let syn_meta = txn_meta_v4(24, TCP_FLAG_SYN, (syn.len() - 14) as u16);
+    let (_b, dbg) = txn_run_descriptor(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &syn,
+        syn_meta,
+    );
+    assert_eq!(dbg.local, 1, "SYN must take the LocalDelivery arm");
+    assert_eq!(
+        sessions.len(),
+        1,
+        "the permitted SYN must install one host-local session"
+    );
+    assert_eq!(
+        hit_packets(&forwarding),
+        1,
+        "the miss SYN counts once against the admitting rule (cold path)"
+    );
+
+    // Packets 2..=4: pure ACKs (0x10) on the SAME 5-tuple => session HIT. Each
+    // must count exactly once (via the mandatory junos-host teardown re-eval).
+    let ack = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(10, 0, 61, 102),
+        Ipv4Addr::new(10, 255, 0, 1),
+        12345,
+        179,
+        0x10_u8,
+    );
+    let ack_meta = txn_meta_v4(24, 0x10_u8, (ack.len() - 14) as u16);
+    for i in 0..3 {
+        let (_b, dbg) = txn_run_descriptor(
+            &mut binding,
+            &mut sessions,
+            &forwarding,
+            &ha_state,
+            &ack,
+            ack_meta,
+        );
+        assert_eq!(
+            dbg.session_hit, 1,
+            "established ACK #{i} must hit the installed host-local session"
+        );
+    }
+
+    assert_eq!(
+        hit_packets(&forwarding),
+        4,
+        "#3706: 1 miss + 3 established hits must count EXACTLY 4 packets against \
+         the admitting junos-host rule; double-counting the session-hit path \
+         reads 7 (the pre-fix regression)"
+    );
+}
+
 /// #3326 LITERAL fail-on-revert (session-MISS): a host-bound packet denied by
 /// the zone host-inbound admission gate must increment the
 /// `host_inbound_denied_packets` batch counter (which `syncBPFCountersLocked`

--- a/userspace-dp/src/afxdp/tests.rs
+++ b/userspace-dp/src/afxdp/tests.rs
@@ -9561,6 +9561,158 @@ fn poll_descriptor_no_junos_host_policy_local_delivery_unchanged_session_miss() 
     assert!(rx.try_recv().is_err());
 }
 
+/// #3019: gre_to_self_snapshot extended with a `from-zone lan to-zone
+/// junos-host then permit` policy carrying an explicit `then log` selection and
+/// a non-zero admitting `policy_id` — the #3706 fixture. `log_init`/`log_close`
+/// drive the policy's Junos `then log session-init`/`session-close` selection.
+fn junos_host_local_delivery_permit_snapshot(
+    log_init: bool,
+    log_close: bool,
+    policy_id: u32,
+) -> ConfigSnapshot {
+    let mut snapshot = gre_to_self_snapshot();
+    snapshot.policies.push(PolicyRuleSnapshot {
+        name: "host-permit-log".to_string(),
+        from_zone: "lan".to_string(),
+        to_zone: "junos-host".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        application_terms: Vec::new(),
+        action: "permit".to_string(),
+        log_session_init: log_init,
+        log_session_close: log_close,
+        policy_id,
+        ..Default::default()
+    });
+    snapshot
+}
+
+/// #3706 helper: run the session-MISS LocalDelivery descriptor for a host-bound
+/// TCP/179 SYN under `snapshot` and return the metadata of the single installed
+/// host-local session (log flags, admitting policy id, hit-counter handle),
+/// asserting exactly one session was cached and it was not policy-denied.
+fn run_junos_host_permit_local_delivery(snapshot: &ConfigSnapshot) -> (bool, bool, u32, u32) {
+    let forwarding = build_forwarding_state(snapshot);
+    let ha_state = txn_ha_state();
+    let mut binding = BindingWorker::new_for_mirror_test(0, 0, 24, 0);
+    binding.interface = Arc::<str>::from("reth1.0");
+    let mut sessions = SessionTable::new();
+
+    let frame = build_txn_tcp_syn_frame_v4(
+        Ipv4Addr::new(10, 0, 61, 102),
+        Ipv4Addr::new(10, 255, 0, 1),
+        12345,
+        179,
+        TCP_FLAG_SYN,
+    );
+    let meta = txn_meta_v4(24, TCP_FLAG_SYN, (frame.len() - 14) as u16);
+
+    let (tx, rx) = mpsc::sync_channel(8);
+    let wake = Arc::new(TunnelWake::new().expect("eventfd"));
+    let mut deliveries = BTreeMap::new();
+    deliveries.insert(77, LocalTunnelDelivery { tx, wake });
+    let local_tunnel_deliveries = Arc::new(ArcSwap::from_pointee(deliveries));
+
+    let (_batch, dbg) = txn_run_descriptor_with_deliveries(
+        &mut binding,
+        &mut sessions,
+        &forwarding,
+        &ha_state,
+        &frame,
+        meta,
+        &local_tunnel_deliveries,
+    );
+    let _ = rx;
+
+    assert_eq!(dbg.local, 1, "packet must take the LocalDelivery arm");
+    assert_eq!(
+        dbg.policy_deny, 0,
+        "a to-zone junos-host permit must NOT policy-deny the host-bound flow"
+    );
+    assert_eq!(
+        sessions.len(),
+        1,
+        "a permitted host-bound flow must cache exactly one host-local session"
+    );
+    let mut seen = None;
+    sessions.iter_with_origin(|_key, _decision, md, _origin| {
+        seen = Some((
+            md.log_session_init,
+            md.log_session_close,
+            md.policy_id,
+            md.policy_counter_idx,
+        ));
+    });
+    seen.expect("a host-local session must be installed for a permitted flow")
+}
+
+/// #3706 LITERAL fail-on-revert (session-MISS): a `from-zone lan to-zone
+/// junos-host then permit log session-init session-close` policy admits a
+/// host-bound flow, and the installed local-delivery session MUST carry BOTH
+/// log flags, the admitting `policy_id`, and a non-zero hit-counter handle.
+/// Before #3706 the junos-host permit gate discarded its
+/// [`PolicyEvaluationResult`], so the session installed with
+/// `log_session_init`/`log_session_close = false`, `policy_id = 0`, and
+/// `policy_counter_idx = 0` — the host-bound management session was unlogged and
+/// unattributable. Revert the `JunosHostLocalPolicy::Permit` stamp (drop the
+/// permit result on the local-delivery path) and this test goes RED, while
+/// `poll_descriptor_junos_host_permit_no_log_local_delivery_no_overlog` stays
+/// GREEN (a bare permit must not over-log).
+#[test]
+fn poll_descriptor_junos_host_permit_log_stamps_local_delivery_session_miss() {
+    let snapshot = junos_host_local_delivery_permit_snapshot(true, true, 4242);
+    let (log_init, log_close, policy_id, counter_idx) =
+        run_junos_host_permit_local_delivery(&snapshot);
+
+    assert!(
+        log_init,
+        "#3706: to-zone junos-host `then permit log session-init` must stamp \
+         log_session_init on the installed host-local session (was false)"
+    );
+    assert!(
+        log_close,
+        "#3706: `then permit log session-close` must stamp log_session_close \
+         on the installed host-local session (was false)"
+    );
+    assert_eq!(
+        policy_id, 4242,
+        "#3706: the admitting junos-host policy id must be stamped so the \
+         SESSION_CREATE/CLOSE RT_FLOW record attributes the flow (was the 0 \
+         sentinel)"
+    );
+    assert_ne!(
+        counter_idx, 0,
+        "#3706: the admitting junos-host rule's 1-based hit-counter handle must \
+         be stamped (was the 0 no-counter sentinel)"
+    );
+}
+
+/// #3706 GREEN pair (session-MISS): a `to-zone junos-host then permit` policy
+/// with NO `then log` clause installs the host-local session but MUST NOT set
+/// either log flag — proving the #3706 stamp propagates the policy's ACTUAL log
+/// selection and does not blanket-log every permitted host-bound flow. The
+/// admitting policy id is still stamped for attribution parity with transit.
+#[test]
+fn poll_descriptor_junos_host_permit_no_log_local_delivery_no_overlog() {
+    let snapshot = junos_host_local_delivery_permit_snapshot(false, false, 77);
+    let (log_init, log_close, policy_id, _counter_idx) =
+        run_junos_host_permit_local_delivery(&snapshot);
+
+    assert!(
+        !log_init,
+        "a permit WITHOUT `then log` must not set log_session_init (no over-log)"
+    );
+    assert!(
+        !log_close,
+        "a permit WITHOUT `then log` must not set log_session_close (no over-log)"
+    );
+    assert_eq!(
+        policy_id, 77,
+        "the admitting junos-host policy id is stamped even without `then log`"
+    );
+}
+
 /// #3326 LITERAL fail-on-revert (session-MISS): a host-bound packet denied by
 /// the zone host-inbound admission gate must increment the
 /// `host_inbound_denied_packets` batch counter (which `syncBPFCountersLocked`

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -611,8 +611,13 @@ The ID is consumed at three surfaces:
    rather than misparsing.
 
 `0` stays the legitimate value for a session with no admitting policy
-(host-local, neighbor-seed, fabric-return, tunnel sync-import, flow-cache
-replay seed).
+(neighbor-seed, fabric-return, tunnel sync-import, flow-cache replay seed, and a
+host-local session that matched NO `to-zone junos-host` policy). #3706 narrowed
+the host-local case: a host-bound session admitted by an explicit
+`to-zone junos-host then permit` policy now stamps that policy's real `policy_id`
+(and its `then log` selection + hit-counter handle) at the session-MISS
+local-delivery install, exactly like a transit permit — so only a genuinely
+unattributed host-local session still carries `0`.
 
 #### Re-resolution at the local publish surfaces (#3395)
 


### PR DESCRIPTION
## Summary

A `from-zone <z> to-zone junos-host then permit log session-init session-close`
policy that admits host-bound traffic never applied its logging and published
policy identity as `0`. The junos-host permit path already computes a full
`PolicyEvaluationResult` (log flags + `policy_id`), but the local-delivery
wrapper discarded it on Permit, so host-bound management sessions were unlogged
and unattributable — a vSRX RT_FLOW / session-to-policy parity gap.

Closes #3706.

## Root cause (file:line, current origin/master)

- `userspace-dp/src/afxdp/poll_descriptor/mod.rs` — `junos_host_policy_eval`
  returned `None` on `PolicyAction::Permit`, collapsing a matched permit into
  the "no matching host policy" case and discarding the full result.
- The session-MISS local-delivery install hardcoded `log_session_init: false`,
  `log_session_close: false`, `policy_id: 0`, `policy_counter_idx: 0`,
  `policy_counter: None` and published conntrack with that metadata. The
  `#2508`/`#3056`/`#3073` "host-local sessions are not policy-forwarded"
  comments predate junos-host permit-policy matching and were over-broad.

## Fix

- `junos_host_policy_eval` now returns the full `PolicyEvaluationResult`
  (permit as well as deny/reject).
- The flow-backed gate `junos_host_policy_drops` → `junos_host_local_policy`,
  returning a `JunosHostLocalPolicy` verdict (`Dropped` / `Permit(result)` /
  `NoMatch`).
- On a matching PERMIT, the session-MISS install stamps the admitting policy's
  `then log` selection, `policy_id`, and per-rule hit-counter handle (bound once
  via `hit_counter_by_idx`, #3322-stable) onto the installed host-local session
  and the published conntrack row — parity with the transit permit path.
- Session-HIT path keeps only the `Dropped` check (the session is already
  installed with the miss-time permit metadata); the flowless
  (`l4_present = false`) arm never installs a session, so a flowless permit
  delivers unchanged and only a deny/reject drives its filter drop.
- `NoMatch` keeps the default no-policy host-local metadata (byte-identical to
  pre-#3706).

Pure Rust: no Go change — the Go snapshot already carries `log_session_init`/
`log_session_close`/`policy_id` for junos-host rules (same as transit), and the
consumer surfaces (RT_FLOW SESSION_CREATE/CLOSE, `show security flow session`,
REST/gRPC) read the session metadata generically.

## Tests (fail-on-revert)

- `poll_descriptor_junos_host_permit_log_stamps_local_delivery_session_miss` —
  a `then permit log session-init session-close` session installs with BOTH log
  flags set, a non-zero admitting `policy_id` (4242), and a non-zero counter
  handle. Goes RED when the `Permit` stamp is reverted (verified).
- `poll_descriptor_junos_host_permit_no_log_local_delivery_no_overlog` — GREEN
  pair: a permit WITHOUT `then log` installs with both log flags off (no
  over-log) while still carrying the admitting policy id.

Full `cargo test --release` green (lib 3419 passed / 0 failed / 2 pre-existing
ignored; 46+8+16+1 in the other targets).

## Docs

- `userspace-dp/src/afxdp/forwarding/README.md` — junos-host section updated for
  the renamed gate + `JunosHostLocalPolicy` verdict + permit metadata propagation.
- `userspace-dp/src/session/README.md` — narrowed the "policy_id 0 is legitimate
  for host-local" note.
- `_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi