### PR TITLE
Quarantine lenient StableZoneID collisions so the dataplane never merges two zones (#3719)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -26,7 +26,10 @@
     zones publish with id 53547). `go test ./pkg/config/... ./pkg/dataplane/...
     ./pkg/cli/... ./pkg/api/... ./pkg/daemon/...` green; gofmt/vet clean.
     Rust defense-in-depth `SnapshotIntegrityError::DuplicateZoneId` backstop
-    deferred to the helper build (needs cargo).
+    added (`zones::reject_duplicate_zone_ids` before `populate_zones` in
+    `build_forwarding_state`, + regression
+    `build_forwarding_state_rejects_duplicate_zone_ids`) — NEEDS cargo
+    build/test validation (Rust engineer holds the cargo slot).
   - **File(s)**: pkg/config/zoneid.go, pkg/config/zoneid_test.go,
     pkg/dataplane/userspace/zones.go, pkg/dataplane/userspace/builder.go,
     pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/manager_ha.go,
@@ -34,7 +37,10 @@
     pkg/dataplane/userspace/zones_collision_3719_test.go, pkg/cli/apply.go,
     pkg/cli/apply_syslog_zonemap_3704_test.go, pkg/api/metrics.go,
     pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
-    docs/config-schema.md
+    userspace-dp/src/policy.rs,
+    userspace-dp/src/afxdp/forwarding_build/zones.rs,
+    userspace-dp/src/afxdp/forwarding_build/mod.rs,
+    userspace-dp/src/afxdp/forwarding_build/tests.rs, docs/config-schema.md
 
 ## 2026-07-01 — #3710: host-inbound addressless observability per-interface/per-family
 

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,41 @@
+## 2026-07-01 — #3719: lenient StableZoneID collision quarantine (zone-isolation fail-closed)
+
+- **Timestamp**: 2026-07-01
+  - **Action**: Fix the HIGH zone-identity isolation hole (#3719, codex-153
+    H02/M08/L09/L13). #3075/#3704 moved the zone-id namespace to the stable
+    name-hash `config.StableZoneID` and the STRICT commit path rejects a
+    collision, but the LENIENT path (tolerant load / peer-sync / a config a
+    pre-#3075 binary persisted) only WARNED while every downstream builder still
+    published BOTH colliding zones with the same id — merging two security zones
+    in the dataplane (the Rust id-keyed maps let the later zone overwrite the
+    earlier's reverse name / host-inbound set / tcp-rst bit; both zones'
+    interfaces/policies resolved to one id). Added `config.QuarantinedZoneNames`
+    (SSOT: keeps the sorted-first name per id, quarantines the rest) +
+    `config.StableZoneIDOwner`. New `quarantineCollidingZones` pass in
+    `pkg/dataplane/userspace/zones.go` runs in `buildSnapshot` BEFORE publish:
+    drops the later-sorting colliding `ZoneSnapshot`, unzones its interfaces
+    (`Zone=""` → default-deny), and drops its policies (a dangling policy→zone
+    ref would trip the Rust `UnresolvableZoneReference` preflight and brick a
+    fresh boot). Rest of config still loads (#1960 no-brick). Reverse maps
+    (`zoneNameByID`, `syslogZoneNameMap`) resolve a colliding id to the survivor
+    deterministically. Surfaced via loud one-shot `slog.Error`,
+    `ProcessStatus.ZoneIDCollisions`, and the `xpf_userspace_zone_id_collision`
+    0/1 gauge. Refined the lenient warning wording (L13) to state the zone is
+    QUARANTINED and isolation is DEGRADED. Verified colliding pair z174/z214
+    (both fold to 53547). RED-on-revert proven (neutralizing the pass → both
+    zones publish with id 53547). `go test ./pkg/config/... ./pkg/dataplane/...
+    ./pkg/cli/... ./pkg/api/... ./pkg/daemon/...` green; gofmt/vet clean.
+    Rust defense-in-depth `SnapshotIntegrityError::DuplicateZoneId` backstop
+    deferred to the helper build (needs cargo).
+  - **File(s)**: pkg/config/zoneid.go, pkg/config/zoneid_test.go,
+    pkg/dataplane/userspace/zones.go, pkg/dataplane/userspace/builder.go,
+    pkg/dataplane/userspace/manager.go, pkg/dataplane/userspace/manager_ha.go,
+    pkg/dataplane/userspace/protocol.go,
+    pkg/dataplane/userspace/zones_collision_3719_test.go, pkg/cli/apply.go,
+    pkg/cli/apply_syslog_zonemap_3704_test.go, pkg/api/metrics.go,
+    pkg/api/metrics_descriptors.go, pkg/api/metrics_userspace.go,
+    docs/config-schema.md
+
 ## 2026-07-01 — #3710: host-inbound addressless observability per-interface/per-family
 
 - **Timestamp**: 2026-07-01

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,34 @@
+## 2026-07-02 — #3719: review MAJOR fix — quarantine scrub must drop scoped-global match-zones
+
+- **Timestamp**: 2026-07-02
+  - **Action**: Hostile review of PR #3837 found a boot-brick defeating the
+    #1960 no-brick intent. `quarantineCollidingZones` dropped policies only by
+    `FromZone`/`ToZone`, but a GLOBAL policy keeps `FromZone/ToZone ==
+    "junos-global"` and carries its concrete match-zone out-of-band in
+    `MatchFromZone`/`MatchToZone` (#3148, policies.go:416-417). A config with a
+    StableZoneID collision AND a scoped global policy `match from-zone <the
+    quarantined zone>` survived the scrub with a dangling match-zone; the Rust
+    `build_global_zone_scope` (policy.rs:1071-1077) resolves every rule's
+    match-zone → `UnresolvableZoneReference` → `?` → WHOLE-snapshot reject →
+    default-deny brick on fresh boot. Fixed: the policy drop loop now also drops
+    a policy when `MatchFromZone` OR `MatchToZone` is quarantined (empty and
+    "junos-global" are never quarantine keys, so inert for zone-pair/unscoped).
+    Added Go regressions `TestQuarantineDropsScopedGlobalPolicyOnQuarantinedZone`
+    + `TestBuildSnapshotDropsDanglingGlobalMatchZone` (both RED-on-revert when
+    the match-zone check is removed) and Rust regressions through
+    `build_forwarding_state`:
+    `build_forwarding_state_global_policy_with_unresolvable_match_zone_bricks`
+    (dangling match-zone → UnresolvableZoneReference = the brick the scrub
+    prevents) + `build_forwarding_state_global_policy_scoped_to_published_zone_builds`
+    (post-scrub shape builds clean). Lifeline caveat (secondary, non-blocking):
+    left the quarantine loser a pure function of the sorted name (HA-symmetric,
+    reused by lifeline-context-free reverse-map callers) — a quarantined mgmt
+    zone does NOT strand management because lifeline interfaces (fxp0/em0/fab*)
+    never reach the AF_XDP local-delivery classifier (#3682) + loud alarm.
+  - **File(s)**: pkg/dataplane/userspace/zones.go,
+    pkg/dataplane/userspace/zones_collision_3719_test.go,
+    userspace-dp/src/afxdp/forwarding_build/tests.rs, _Log.md
+
 ## 2026-07-01 — #3719: lenient StableZoneID collision quarantine (zone-isolation fail-closed)
 
 - **Timestamp**: 2026-07-01

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2328,8 +2328,11 @@ is paged until one zone is renamed. Regression coverage:
 (`TestBuildSnapshotQuarantinesCollidingZone` — RED-on-revert), and
 `pkg/cli/apply_syslog_zonemap_3704_test.go`
 (`TestSyslogZoneNameMapCollisionResolvesToSurvivor`). A defense-in-depth Rust
-`SnapshotIntegrityError::DuplicateZoneId` backstop (reject a snapshot that still
-carries duplicate ids before any map population) is tracked for the helper build.
+backstop `SnapshotIntegrityError::DuplicateZoneId` (`zones::reject_duplicate_zone_ids`,
+called before `populate_zones` in `build_forwarding_state`) rejects a snapshot
+that STILL carries two different zones under one nonzero non-reserved id — the
+helper-boundary guard for a corrupt / version-drifted snapshot that bypassed the
+Go quarantine (regression `build_forwarding_state_rejects_duplicate_zone_ids`).
 
 **`MaxUsableZoneID`** is now `ZoneIDReservedMin-1` (65533) — the pigeonhole bound
 of the u16 stable-hash space, not the old 255-id u8 wire limit (**#2391

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2295,6 +2295,42 @@ id (strict on commit/commit-check; lenient warning on load/peer-sync), using the
 three-view (View 1 pre-expansion union + node0/node1 `${node}` expansion) union
 discipline so the verdict is identical on both cluster nodes.
 
+**#3719 — lenient-path collision QUARANTINE (runtime enforcement of the
+warning).** The strict gate rejects a collision, but the lenient path only
+**warned** while every downstream builder still published BOTH colliding zones
+with the same numeric id. Two `ZoneSnapshot`s sharing an id merge two security
+zones in the dataplane: the Rust id-keyed maps
+(`zone_id_to_name` / `zone_host_inbound` / `zone_tcp_rst`, `populate_zones`) let
+the later zone overwrite the earlier's reverse name, host-inbound admission set,
+and tcp-rst bit, and both zones' interfaces/policies resolve to one id — a
+zone-isolation failure the lenient warning falsely claimed was quarantined.
+`config.QuarantinedZoneNames` (`zoneid.go`) is the SSOT that, for each id claimed
+by more than one name, keeps the **sorted-first** name (the survivor) and
+quarantines the rest. It is a pure function of the name set, so both HA nodes and
+a cold-booting node agree. The userspace builder's `quarantineCollidingZones`
+(`pkg/dataplane/userspace/zones.go`) applies it to the built snapshot BEFORE
+publish: it **drops** the quarantined `ZoneSnapshot`, **unzones** any interface
+bound to it (`Zone=""` → default-deny, fail closed), and **drops** any policy
+whose from/to zone is quarantined (leaving a dangling policy→zone reference would
+trip the Rust `UnresolvableZoneReference` preflight and reject the WHOLE snapshot
+— a brick on a fresh boot). The rest of the config still loads (#1960 no-brick).
+The id→name reverse maps resolve a colliding id to the survivor deterministically
+(`config.StableZoneIDOwner`; `pkg/cli/apply.go:syslogZoneNameMap`,
+`pkg/dataplane/userspace/manager_ha.go:zoneNameByID`) rather than to whichever
+name won a map-iteration race. The quarantine is surfaced to the operator as a
+loud one-shot `slog.Error` naming both zones, on `ProcessStatus.ZoneIDCollisions`
+(`show`), and as the `xpf_userspace_zone_id_collision` 0/1 gauge, so an operator
+is paged until one zone is renamed. Regression coverage:
+`pkg/config/zoneid_test.go` (`TestQuarantinedZoneNamesDropsLaterColliding`,
+`TestStableZoneIDOwnerReturnsSurvivor`,
+`TestZoneIDCollisionLenientWarningStatesQuarantine`),
+`pkg/dataplane/userspace/zones_collision_3719_test.go`
+(`TestBuildSnapshotQuarantinesCollidingZone` — RED-on-revert), and
+`pkg/cli/apply_syslog_zonemap_3704_test.go`
+(`TestSyslogZoneNameMapCollisionResolvesToSurvivor`). A defense-in-depth Rust
+`SnapshotIntegrityError::DuplicateZoneId` backstop (reject a snapshot that still
+carries duplicate ids before any map population) is tracked for the helper build.
+
 **`MaxUsableZoneID`** is now `ZoneIDReservedMin-1` (65533) — the pigeonhole bound
 of the u16 stable-hash space, not the old 255-id u8 wire limit (**#2391
 superseded**). The forwarding builder still rejects any id `>= ZONE_ID_RESERVED_MIN`

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -164,6 +164,12 @@ type xpfCollector struct {
 	// while the helper rejected the snapshot) so it is observable.
 	userspacePolicyContentRejected *prometheus.Desc
 
+	// #3719: 1 while the most recent userspace snapshot quarantined a security
+	// zone whose StableZoneID collided with another zone's (lenient / HA-sync /
+	// pre-#3075-persisted path). Zone isolation is degraded until one zone is
+	// renamed.
+	userspaceZoneIDCollision *prometheus.Desc
+
 	// #1827: services ip-monitoring observability. #1844 adds the
 	// unresolved interface-typed next-hop gauge (preferred routes of
 	// FAILED policies skipped from the overlay for lack of a
@@ -605,6 +611,7 @@ func (c *xpfCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.configPersistDegraded
 	ch <- c.rollbackHistoryDegraded
 	ch <- c.userspacePolicyContentRejected
+	ch <- c.userspaceZoneIDCollision
 	ch <- c.ipmonPolicyFailed
 	ch <- c.ipmonPolicyTransitions
 	ch <- c.ipmonRoutesApplied

--- a/pkg/api/metrics_descriptors.go
+++ b/pkg/api/metrics_descriptors.go
@@ -506,6 +506,20 @@ func newCollector(srv *Server) *xpfCollector {
 				"re-commit. 0 when the last build was fully representable.",
 			nil, nil,
 		),
+		userspaceZoneIDCollision: prometheus.NewDesc(
+			"xpf_userspace_zone_id_collision",
+			"1 while the most recently built userspace snapshot QUARANTINED "+
+				"one or more security zones because two zone names fold to the "+
+				"same StableZoneID (#3719). The strict commit path rejects a "+
+				"collision; this fires only on the lenient / HA-sync / "+
+				"pre-#3075-persisted path, where the later-sorting zone is "+
+				"dropped from the dataplane (its interfaces unzoned, its "+
+				"traffic denied) so two zones never share an id. The dataplane "+
+				"is fail-closed, but zone isolation is DEGRADED (the "+
+				"quarantined zone forwards nothing) until an operator renames "+
+				"one zone and re-commits. 0 when every zone has a distinct id.",
+			nil, nil,
+		),
 		rpmPinInstallFailures: prometheus.NewDesc(
 			"xpf_rpm_probe_pin_install_failures",
 			"Number of RPM next-hop probe pins whose kernel fwmark rule / "+

--- a/pkg/api/metrics_userspace.go
+++ b/pkg/api/metrics_userspace.go
@@ -49,6 +49,7 @@ func (c *xpfCollector) collectUserspaceStatus(ch chan<- prometheus.Metric, dp ap
 	c.emitNeighborColdStartCapture(ch, status)
 	c.emitWireguardTelemetry(ch, status)
 	c.emitPolicyContentRejected(ch, status)
+	c.emitZoneIDCollision(ch, status)
 	c.emitRejectObservability(ch, status)
 	c.emitFabricSkipCounters(ch, status)
 }
@@ -120,6 +121,20 @@ func (c *xpfCollector) emitPolicyContentRejected(ch chan<- prometheus.Metric, st
 		v = 1.0
 	}
 	ch <- prometheus.MustNewConstMetric(c.userspacePolicyContentRejected, prometheus.GaugeValue, v)
+}
+
+// emitZoneIDCollision exposes the #3719 0/1 gauge: 1 while the last userspace
+// snapshot build quarantined one or more security zones whose StableZoneID
+// collided (lenient / HA-sync / pre-#3075-persisted path). The dataplane is
+// fail-closed (the later-sorting zone is dropped, never merged), but zone
+// isolation is degraded until one zone is renamed. Emitted unconditionally so 0
+// is a real "all zones distinct" signal, not an absent series.
+func (c *xpfCollector) emitZoneIDCollision(ch chan<- prometheus.Metric, status dpuserspace.ProcessStatus) {
+	v := 0.0
+	if len(status.ZoneIDCollisions) > 0 {
+		v = 1.0
+	}
+	ch <- prometheus.MustNewConstMetric(c.userspaceZoneIDCollision, prometheus.GaugeValue, v)
 }
 
 // emitWireguardTelemetry exposes the #1865 per-WG-tunnel telemetry

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -29,8 +29,22 @@ import (
 // pure function of the name, so this write is byte-identical to the daemon's
 // regardless of reconcile ordering.
 func syslogZoneNameMap(cfg *config.Config) map[uint16]string {
-	znMap := make(map[uint16]string, len(cfg.Security.Zones))
+	names := make([]string, 0, len(cfg.Security.Zones))
 	for name := range cfg.Security.Zones {
+		names = append(names, name)
+	}
+	// #3719: under a StableZoneID collision two zone names fold to the same id,
+	// and the dataplane installs only the sorted-first (the survivor
+	// config.QuarantinedZoneNames keeps). Skip the quarantined zone so the
+	// reverse map names the id after the zone actually installed rather than
+	// whichever name won a map-iteration overwrite race — RT_FLOW/syslog would
+	// otherwise render the wrong zone for the surviving zone's traffic.
+	quarantined := config.QuarantinedZoneNames(names)
+	znMap := make(map[uint16]string, len(names))
+	for _, name := range names {
+		if _, drop := quarantined[name]; drop {
+			continue
+		}
 		znMap[config.StableZoneID(name)] = name
 	}
 	return znMap

--- a/pkg/cli/apply_syslog_zonemap_3704_test.go
+++ b/pkg/cli/apply_syslog_zonemap_3704_test.go
@@ -45,3 +45,29 @@ func TestSyslogZoneNameMapUsesStableZoneID(t *testing.T) {
 		}
 	}
 }
+
+// TestSyslogZoneNameMapCollisionResolvesToSurvivor (#3719): when two zone names
+// fold to the same StableZoneID the reverse map must resolve the shared id to
+// the SURVIVOR (the sorted-first zone the dataplane installed), never to the
+// QUARANTINED later-sorting zone — otherwise RT_FLOW/syslog would render the
+// survivor's traffic under the wrong (quarantined) zone name. Reverting
+// syslogZoneNameMap to the unconditional overwrite makes the result depend on
+// map-iteration order (nondeterministic; can name z214).
+func TestSyslogZoneNameMapCollisionResolvesToSurvivor(t *testing.T) {
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"z174": {Name: "z174"},
+		"z214": {Name: "z214"},
+	}
+	got := syslogZoneNameMap(cfg)
+	id := config.StableZoneID("z174")
+	if got[id] != "z174" {
+		t.Fatalf("collision id %d resolves to %q, want the survivor z174 (never the quarantined z214)", id, got[id])
+	}
+	if len(got) != 1 {
+		t.Fatalf("map has %d entries for a colliding pair, want 1 (the survivor only): %v", len(got), got)
+	}
+}

--- a/pkg/config/zoneid.go
+++ b/pkg/config/zoneid.go
@@ -165,8 +165,87 @@ func validateZoneIDCollisionAST(tree *ConfigTree, lenient bool) ([]string, error
 		if !lenient {
 			return nil, fmt.Errorf("security zones: %s", msg)
 		}
-		warnings = append(warnings, msg+
-			"; the later-sorting zone is NOT installed in the dataplane")
+		// #3719: the lenient path keeps booting but QUARANTINES the
+		// later-sorting zone (QuarantinedZoneNames) so the dataplane never
+		// receives two zones sharing a numeric id. Word the warning so the
+		// operator knows the box is running in a degraded zone-isolation state:
+		// the quarantined zone is dropped from the dataplane, its interfaces are
+		// unzoned, and its traffic is denied until one zone is renamed.
+		warnings = append(warnings, fmt.Sprintf("%s; the later-sorting zone %q is QUARANTINED"+
+			" (dropped from the dataplane, its interfaces unzoned and its traffic denied) —"+
+			" zone isolation is DEGRADED until one zone is renamed", msg, name))
 	}
 	return warnings, nil
+}
+
+// QuarantinedZoneNames returns the set of security-zone names that MUST NOT be
+// installed in the dataplane because their StableZoneID collides with an
+// earlier (alphabetically-sorted) zone's id. For each numeric id claimed by
+// more than one name, the sorted-FIRST name keeps the id and every later name
+// that folds to the same id is quarantined.
+//
+// This is the RUNTIME enforcement of the promise the lenient collision warning
+// (validateZoneIDCollisionAST) already makes — "the later-sorting zone is NOT
+// installed in the dataplane" — so the dataplane never receives two zones that
+// share a numeric id. Publishing both would MERGE two security zones: one
+// zone's interfaces, policies, counters, host-inbound admission set, and
+// tcp-rst bit would stand in for the other (#3719 — the wire builder, the Rust
+// id-keyed maps, and the id→name reverse maps all key on the numeric id). The
+// STRICT commit path REJECTS a collision outright; the LENIENT path (tolerant
+// load / peer-sync / a config a pre-#3075 binary persisted with no collision
+// check) keeps booting but quarantines the colliding zone here, preserving the
+// #1960 no-brick intent — the rest of the config still loads and only the
+// later-sorting colliding zone is dropped.
+//
+// The decision is a pure function of the zone-name SET (StableZoneID is a pure
+// function of the name and the sorted tie-break is deterministic), so both HA
+// nodes and a cold-booting node compute the IDENTICAL quarantine set from the
+// identical config — the same HA-symmetry guarantee StableZoneID itself carries.
+// Returns nil when no id collides (the common case).
+func QuarantinedZoneNames(names []string) map[string]struct{} {
+	if len(names) < 2 {
+		return nil
+	}
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+	owner := make(map[uint16]string, len(sorted))
+	var quarantined map[string]struct{}
+	for _, name := range sorted {
+		id := StableZoneID(name)
+		if existing, taken := owner[id]; taken {
+			if existing == name {
+				// Defensive: a duplicated name in the input slice is the same
+				// zone, not a collision (map-keyed callers never hit this).
+				continue
+			}
+			if quarantined == nil {
+				quarantined = make(map[string]struct{})
+			}
+			quarantined[name] = struct{}{}
+			continue
+		}
+		owner[id] = name
+	}
+	return quarantined
+}
+
+// StableZoneIDOwner returns the security-zone name that OWNS a given numeric
+// zone id among names — the sorted-first name that folds to id, i.e. the zone
+// that survives QuarantinedZoneNames. It returns "" when no name in names folds
+// to id. Callers building an id→name reverse map (syslog RT_FLOW rendering, HA
+// session-delta naming) use this so a collision resolves deterministically to
+// the SAME surviving zone the dataplane actually installed, never to a
+// quarantined zone that the wire builder dropped (#3719).
+func StableZoneIDOwner(names []string, id uint16) string {
+	owner := ""
+	for _, name := range names {
+		if StableZoneID(name) != id {
+			continue
+		}
+		if owner == "" || name < owner {
+			owner = name
+		}
+	}
+	return owner
 }

--- a/pkg/config/zoneid_test.go
+++ b/pkg/config/zoneid_test.go
@@ -142,3 +142,77 @@ func TestZoneIDNoFalsePositiveOnOrdinaryZones(t *testing.T) {
 		t.Fatalf("strict commit rejected an ordinary 3-zone config: %v", err)
 	}
 }
+
+// #3719: QuarantinedZoneNames is the runtime SSOT the lenient-path builders use
+// to enforce the collision warning's promise. For a colliding pair it must
+// quarantine the LATER-sorting zone and keep the earlier one (which owns the
+// id), so the dataplane never receives two zones sharing an id. Reverting the
+// quarantine (returning nil / empty) makes this RED.
+func TestQuarantinedZoneNamesDropsLaterColliding(t *testing.T) {
+	if StableZoneID("z174") != StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	q := QuarantinedZoneNames([]string{"z214", "z174"}) // deliberately unsorted input
+	if _, dropped := q["z214"]; !dropped {
+		t.Fatalf("QuarantinedZoneNames did not quarantine the later-sorting colliding zone z214: %v", q)
+	}
+	if _, dropped := q["z174"]; dropped {
+		t.Fatalf("QuarantinedZoneNames wrongly quarantined the earlier-sorting survivor z174: %v", q)
+	}
+	if len(q) != 1 {
+		t.Fatalf("QuarantinedZoneNames returned %d entries, want exactly 1 (only z214): %v", len(q), q)
+	}
+}
+
+// The common case: distinct-folding names yield no quarantine (nil), and a
+// single zone can never collide.
+func TestQuarantinedZoneNamesNoFalsePositive(t *testing.T) {
+	if q := QuarantinedZoneNames([]string{"trust", "untrust", "dmz"}); len(q) != 0 {
+		t.Fatalf("QuarantinedZoneNames quarantined an ordinary distinct-folding set: %v", q)
+	}
+	if q := QuarantinedZoneNames([]string{"trust"}); len(q) != 0 {
+		t.Fatalf("QuarantinedZoneNames quarantined a single zone: %v", q)
+	}
+}
+
+// StableZoneIDOwner resolves a colliding id to the sorted-first (survivor) name
+// — the zone the dataplane actually installed — so id->name reverse maps never
+// name a quarantined zone.
+func TestStableZoneIDOwnerReturnsSurvivor(t *testing.T) {
+	id := StableZoneID("z174")
+	owner := StableZoneIDOwner([]string{"z214", "z174"}, id)
+	if owner != "z174" {
+		t.Fatalf("StableZoneIDOwner(%d) = %q, want the sorted-first survivor z174", id, owner)
+	}
+	if got := StableZoneIDOwner([]string{"z174", "z214"}, 1); got != "" {
+		t.Fatalf("StableZoneIDOwner for an unclaimed id = %q, want empty", got)
+	}
+}
+
+// #3719 (L13): the lenient warning must state that the later-sorting zone is
+// QUARANTINED and that isolation is degraded — the wording must not merely say
+// "not installed" while the runtime published both (the pre-fix contradiction).
+func TestZoneIDCollisionLenientWarningStatesQuarantine(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone z174",
+		"set security zones security-zone z214",
+	})
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient rejected a colliding zone pair: %v", err)
+	}
+	var warn string
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "collision") && strings.Contains(w, "z214") {
+			warn = w
+		}
+	}
+	if warn == "" {
+		t.Fatalf("no zone-id collision warning naming z214: %v", cfg.Warnings)
+	}
+	for _, want := range []string{"QUARANTINED", "z174", "z214", "DEGRADED"} {
+		if !strings.Contains(warn, want) {
+			t.Fatalf("lenient warning %q does not mention %q", warn, want)
+		}
+	}
+}

--- a/pkg/dataplane/userspace/builder.go
+++ b/pkg/dataplane/userspace/builder.go
@@ -75,7 +75,7 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 	if err != nil {
 		return nil, err
 	}
-	return &ConfigSnapshot{
+	snap := &ConfigSnapshot{
 		Version:         ProtocolVersion,
 		Generation:      generation,
 		FIBGeneration:   fibGeneration,
@@ -134,7 +134,23 @@ func buildSnapshotWithSchedulerStateAndNATCounters(cfg *config.Config, ucfg conf
 			SchedulerCount: len(cfg.Schedulers),
 			HAEnabled:      cfg.Chassis.Cluster != nil,
 		},
-	}, nil
+	}
+	// #3719: enforce the StableZoneID zone-isolation invariant BEFORE the
+	// snapshot is published. On the lenient / HA-sync / pre-#3075-persisted
+	// path two zone names can fold to the same numeric id; publishing both
+	// merges two security zones in the dataplane. quarantineCollidingZones
+	// drops the later-sorting colliding zone (and unzones its interfaces / drops
+	// its policies so no dangling reference bricks the helper preflight),
+	// leaving the rest of the config intact (#1960 no-brick). The stashed
+	// collisions ride up to ApplyConfig, which fires the operator alarm and
+	// stamps the status/metric.
+	snap.zoneIDCollisions = quarantineCollidingZones(snap)
+	if len(snap.zoneIDCollisions) > 0 {
+		// Keep the operator-facing counts equal to what is actually published.
+		snap.Summary.ZoneCount = len(snap.Zones)
+		snap.Summary.PolicyCount = len(snap.Policies)
+	}
+	return snap, nil
 }
 
 // snapshotContentHash computes a SHA-256 hash over the stable content of a

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -165,7 +165,14 @@ type Manager struct {
 	// (ForwardingSupported=true while the helper rejected the snapshot) is
 	// observable. nil/empty means the last build was fully representable.
 	lastSnapshotRejectReasons []string
-	policySchedulerActive     map[string]bool
+	// lastZoneIDCollisions holds the #3719 diagnostic: the zones the most
+	// recent snapshot build QUARANTINED because their StableZoneID collided
+	// with an earlier-sorting zone. Set under m.mu at every full snapshot
+	// build, surfaced via ProcessStatus.ZoneIDCollisions and the
+	// xpf_userspace_zone_id_collision gauge. nil/empty means no active
+	// collision.
+	lastZoneIDCollisions  []string
+	policySchedulerActive map[string]bool
 	// routeOverlay is the ip-monitoring effective-route overlay
 	// (#1827 PR-1b). Cached so the FULL apply path
 	// (buildSnapshotWithSchedulerState in ApplyConfig) preserves the
@@ -412,6 +419,35 @@ func (m *Manager) recordPolicyContentRejectionLocked(reasons []string) {
 	}
 }
 
+// recordZoneIDCollisionsLocked stores the #3719 zone-id-collision diagnostic
+// from the last snapshot build and fires a one-shot operator alarm on a
+// transition (per the logging rules — NOT per apply). A collision reaches this
+// only on the LENIENT path (a tolerant load, an HA sync from an un-upgraded
+// peer, or a config a pre-#3075 binary persisted); the strict commit path
+// rejects it. The builder already QUARANTINED the later-sorting colliding zone
+// (dropped from the wire, its interfaces unzoned, its policies removed), so the
+// dataplane is fail-closed and never merges two zones — but zone isolation is
+// DEGRADED (the quarantined zone forwards nothing) until an operator renames
+// one zone, so this is a loud Error naming both zones.
+func (m *Manager) recordZoneIDCollisionsLocked(collisions []ZoneIDCollision) {
+	had := len(m.lastZoneIDCollisions) > 0
+	msgs := make([]string, 0, len(collisions))
+	for _, c := range collisions {
+		msgs = append(msgs, c.String())
+	}
+	now := len(msgs) > 0
+	m.lastZoneIDCollisions = msgs
+	switch {
+	case now && !had:
+		slog.Error(
+			"userspace: security-zone id collision — two zone names fold to the same StableZoneID; the later-sorting zone is QUARANTINED (dropped from the dataplane, its interfaces unzoned and its traffic denied) so two zones never share an id. Zone isolation is DEGRADED until one zone is renamed and the config re-committed.",
+			"collisions", msgs,
+		)
+	case had && !now:
+		slog.Info("userspace: security-zone id collision cleared; all zones install with distinct ids")
+	}
+}
+
 func copyPolicySchedulerActiveState(activeState map[string]bool) map[string]bool {
 	if activeState == nil {
 		return nil
@@ -589,6 +625,10 @@ func (m *Manager) Compile(cfg *config.Config) (*dataplane.CompileResult, error) 
 	// for this class; the reject retains previous-good (or leaves the fresh-boot
 	// default-deny), never fail-open.
 	m.recordPolicyContentRejectionLocked(snap.Capabilities.PolicyContentRejected)
+	// #3719: record + alarm any StableZoneID collision the builder quarantined
+	// (lenient / HA-sync / pre-#3075-persisted path). The colliding zone was
+	// already dropped from snap; this surfaces the degraded-isolation state.
+	m.recordZoneIDCollisionsLocked(snap.zoneIDCollisions)
 	m.clusterHA = cfg != nil && cfg.Chassis.Cluster != nil
 	m.seedHAGroupInventoryLocked(cfg)
 	prevPlanKey := snapshotBindingPlanKey(m.lastSnapshot)
@@ -1179,6 +1219,10 @@ func (m *Manager) recordHelperStatusLocked(status *ProcessStatus) {
 	// observable in `show`/metrics even though the helper reports the
 	// previous-good capabilities.
 	status.LastSnapshotRejectReasons = append([]string(nil), m.lastSnapshotRejectReasons...)
+	// #3719: stamp the manager-owned zone-id-collision diagnostic (the helper
+	// cannot carry it — the colliding zone was dropped before the wire) so the
+	// degraded zone-isolation state is observable in `show`/metrics.
+	status.ZoneIDCollisions = append([]string(nil), m.lastZoneIDCollisions...)
 	if m.eventStream != nil {
 		es := m.eventStream.Status()
 		status.EventStream = &es

--- a/pkg/dataplane/userspace/manager_ha.go
+++ b/pkg/dataplane/userspace/manager_ha.go
@@ -1158,14 +1158,25 @@ func (m *Manager) zoneNameByID(zoneID uint16) string {
 	if zoneID == 0 {
 		return ""
 	}
-	if cr := m.bpfShim.LastCompileResult(); cr != nil {
-		for name, id := range cr.ZoneIDs {
-			if id == zoneID {
-				return name
-			}
+	cr := m.bpfShim.LastCompileResult()
+	if cr == nil {
+		return ""
+	}
+	// #3719: a StableZoneID collision maps two zone names to the same id in
+	// ZoneIDs. The dataplane installs only the sorted-FIRST name (the survivor
+	// config.QuarantinedZoneNames keeps), so resolve deterministically to that
+	// name instead of returning whichever name a map-iteration coin flip yields
+	// — which could name the QUARANTINED zone that forwards nothing.
+	owner := ""
+	for name, id := range cr.ZoneIDs {
+		if id != zoneID {
+			continue
+		}
+		if owner == "" || name < owner {
+			owner = name
 		}
 	}
-	return ""
+	return owner
 }
 
 func nativeUint32ToIP(v uint32) net.IP {

--- a/pkg/dataplane/userspace/protocol.go
+++ b/pkg/dataplane/userspace/protocol.go
@@ -132,6 +132,14 @@ type ConfigSnapshot struct {
 	// sampling (256× CPU cost) — operator must pass both
 	// --cold-path-sample-mask 0 and --enable-cold-path-1-in-1-sampling.
 	ColdPathSampleMask *uint64 `json:"cold_path_sample_mask,omitempty"`
+	// zoneIDCollisions is the manager-facing (#3719) record of every security
+	// zone the snapshot builder QUARANTINED because its StableZoneID collided
+	// with an earlier-sorting zone. It is unexported so it never rides the wire
+	// or perturbs the snapshot hash (JSON ignores unexported fields), yet it
+	// carries the diagnostic from the pure builder up to ApplyConfig, which
+	// stamps it onto ProcessStatus.ZoneIDCollisions and fires the one-shot
+	// operator alarm. Empty means no collision (the common case).
+	zoneIDCollisions []ZoneIDCollision
 }
 
 // AddressBookSnapshot is #1606: one row of the deduplicated address-book
@@ -1261,14 +1269,25 @@ type ProcessStatus struct {
 	// as xpf_userspace_policy_content_rejected so the Go/Rust status skew
 	// (ForwardingSupported=true while the helper rejected the snapshot) is
 	// observable.
-	LastSnapshotRejectReasons []string  `json:"last_snapshot_reject_reasons,omitempty"`
-	LastSnapshotGeneration    uint64    `json:"last_snapshot_generation"`
-	LastFIBGeneration         uint32    `json:"last_fib_generation,omitempty"`
-	LastSnapshotAt            time.Time `json:"last_snapshot_at,omitempty"`
-	InterfaceAddresses        int       `json:"interface_addresses,omitempty"`
-	NeighborEntries           int       `json:"neighbor_entries,omitempty"`
-	SessionTableEntries       uint64    `json:"session_table_entries,omitempty"`
-	MaxSessions               uint64    `json:"max_sessions,omitempty"`
+	LastSnapshotRejectReasons []string `json:"last_snapshot_reject_reasons,omitempty"`
+	// ZoneIDCollisions is the manager-owned (#3719) diagnostic listing every
+	// security zone the last snapshot build QUARANTINED because its StableZoneID
+	// collided with an earlier-sorting zone. The strict commit path rejects a
+	// collision, but a lenient/HA-sync/pre-#3075-persisted config keeps booting
+	// with the colliding zone dropped from the dataplane (fail-closed: its
+	// interfaces are unzoned and its traffic denied) so two zones never share a
+	// numeric id. Like LastSnapshotRejectReasons it is stamped by
+	// recordHelperStatusLocked from m.lastZoneIDCollisions (the helper cannot
+	// carry it), surfaced as xpf_userspace_zone_id_collision so an operator is
+	// paged until one zone is renamed. Empty means no active collision.
+	ZoneIDCollisions       []string  `json:"zone_id_collisions,omitempty"`
+	LastSnapshotGeneration uint64    `json:"last_snapshot_generation"`
+	LastFIBGeneration      uint32    `json:"last_fib_generation,omitempty"`
+	LastSnapshotAt         time.Time `json:"last_snapshot_at,omitempty"`
+	InterfaceAddresses     int       `json:"interface_addresses,omitempty"`
+	NeighborEntries        int       `json:"neighbor_entries,omitempty"`
+	SessionTableEntries    uint64    `json:"session_table_entries,omitempty"`
+	MaxSessions            uint64    `json:"max_sessions,omitempty"`
 	// #1760: aggregate NAT reverse-key displacement events summed across
 	// the per-worker session tables -- the latent 1:N collision (#1758)
 	// made observable. Near-precise upper bound on live collisions (counts

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -1017,6 +1017,16 @@ func quarantineCollidingZones(snap *ConfigSnapshot) []ZoneIDCollision {
 	// Unzone interfaces bound to a quarantined zone. An unzoned interface
 	// matches no zone policy -> default-deny (fail closed), and it removes the
 	// dangling interface->zone reference from the snapshot.
+	//
+	// Lifeline note (#3719 review, secondary): if the operator's management zone
+	// happens to be the later-sorting collider it is quarantined and its
+	// interfaces are unzoned. This does NOT strand management, because lifeline
+	// interfaces (fxp0/em0/fab*) never reach the AF_XDP local-delivery
+	// classifier (#3682) — their host-bound traffic is served by the kernel
+	// path regardless of zone — and the loud operator alarm names both zones. We
+	// deliberately keep the quarantine loser purely a function of the sorted
+	// name (HA-symmetric, and reused by the reverse-map callers that have no
+	// lifeline context) rather than making it lifeline-aware.
 	for i := range snap.Interfaces {
 		if _, drop := quarantined[snap.Interfaces[i].Zone]; drop {
 			snap.Interfaces[i].Zone = ""
@@ -1024,15 +1034,28 @@ func quarantineCollidingZones(snap *ConfigSnapshot) []ZoneIDCollision {
 	}
 	// Drop policies whose from/to zone is quarantined so the snapshot carries no
 	// dangling policy->zone reference (which the Rust UnresolvableZoneReference
-	// preflight would reject wholesale). A global rule keeps FromZone/ToZone ==
-	// "junos-global" and is never quarantined.
+	// preflight would reject wholesale — a whole-snapshot brick on a fresh boot,
+	// the exact failure this quarantine exists to prevent). This MUST include a
+	// scoped GLOBAL policy's out-of-band match-zone: a global rule keeps
+	// FromZone/ToZone == "junos-global" (never quarantined) but carries its
+	// concrete `match from-zone`/`to-zone` in MatchFromZone/MatchToZone (#3148,
+	// policies.go). The Rust build_global_zone_scope resolves those against the
+	// published zone table for EVERY rule, so a global policy scoped to a
+	// quarantined zone would leave a dangling match-zone and brick the snapshot
+	// (#3719 review). Empty ("" — the zone-pair case) and "junos-global" are
+	// never keys in the quarantine set, so they never match here.
 	if len(snap.Policies) > 0 {
+		refsQuarantinedZone := func(p PolicyRuleSnapshot) bool {
+			for _, z := range [...]string{p.FromZone, p.ToZone, p.MatchFromZone, p.MatchToZone} {
+				if _, drop := quarantined[z]; drop {
+					return true
+				}
+			}
+			return false
+		}
 		keptPol := snap.Policies[:0]
 		for _, p := range snap.Policies {
-			if _, drop := quarantined[p.FromZone]; drop {
-				continue
-			}
-			if _, drop := quarantined[p.ToZone]; drop {
+			if refsQuarantinedZone(p) {
 				continue
 			}
 			keptPol = append(keptPol, p)

--- a/pkg/dataplane/userspace/zones.go
+++ b/pkg/dataplane/userspace/zones.go
@@ -946,6 +946,108 @@ func buildZoneSnapshots(cfg *config.Config) []ZoneSnapshot {
 	return out
 }
 
+// ZoneIDCollision records one StableZoneID collision the snapshot builder
+// resolved by QUARANTINING the later-sorting zone (#3719). Survivor keeps the
+// numeric ID and stays installed; Quarantined is dropped from the wire (its
+// interfaces are unzoned and its policies removed) so the dataplane never
+// receives two zones sharing an id. Both names fold to ID.
+type ZoneIDCollision struct {
+	ID          uint16
+	Survivor    string
+	Quarantined string
+}
+
+// String renders a ZoneIDCollision for the operator alarm and status output.
+func (c ZoneIDCollision) String() string {
+	return fmt.Sprintf(
+		"zone %q QUARANTINED: StableZoneID %d collides with zone %q — rename one zone (#3719)",
+		c.Quarantined, c.ID, c.Survivor)
+}
+
+// quarantineCollidingZones enforces the StableZoneID zone-isolation invariant on
+// a built snapshot: it removes every zone whose numeric id collides with an
+// earlier-sorting zone's id, UNZONES any interface bound to a quarantined zone,
+// and DROPS any policy whose from/to zone is quarantined, so the published
+// snapshot is internally consistent and the dataplane never receives two zones
+// that share an id (#3719). Publishing both would merge two security zones — the
+// Rust id-keyed maps (zone_id_to_name / zone_host_inbound / zone_tcp_rst) would
+// have the later zone overwrite the earlier's reverse name, host-inbound set,
+// and tcp-rst bit, and both zones' interfaces/policies would resolve to one id.
+//
+// The strict commit path REJECTS a collision (config.validateZoneIDCollisionAST,
+// #3075). This is the fail-closed backstop for the LENIENT path — a tolerant
+// load, an HA config-sync from an un-upgraded peer, or a config a pre-#3075
+// binary persisted with no collision check. It preserves the #1960 no-brick
+// intent: only the later-sorting colliding zone is dropped; the rest of the
+// config still loads. Dropping the zone but LEAVING its policies would trip the
+// Rust helper's UnresolvableZoneReference preflight and reject the WHOLE snapshot
+// (a brick on a fresh boot), so the scrub is coordinated across zones,
+// interfaces, and policies.
+//
+// The quarantine set is config.QuarantinedZoneNames over the snapshot's own zone
+// names — a pure function of the name set, so both HA nodes and a cold-booting
+// node resolve the identical set. Returns the collisions it resolved, sorted for
+// deterministic operator output (nil in the common no-collision case).
+func quarantineCollidingZones(snap *ConfigSnapshot) []ZoneIDCollision {
+	if snap == nil || len(snap.Zones) < 2 {
+		return nil
+	}
+	names := make([]string, 0, len(snap.Zones))
+	for _, z := range snap.Zones {
+		names = append(names, z.Name)
+	}
+	quarantined := config.QuarantinedZoneNames(names)
+	if len(quarantined) == 0 {
+		return nil
+	}
+	collisions := make([]ZoneIDCollision, 0, len(quarantined))
+	kept := snap.Zones[:0]
+	for _, z := range snap.Zones {
+		if _, drop := quarantined[z.Name]; drop {
+			collisions = append(collisions, ZoneIDCollision{
+				ID:          z.ID,
+				Survivor:    config.StableZoneIDOwner(names, z.ID),
+				Quarantined: z.Name,
+			})
+			continue
+		}
+		kept = append(kept, z)
+	}
+	snap.Zones = kept
+	// Unzone interfaces bound to a quarantined zone. An unzoned interface
+	// matches no zone policy -> default-deny (fail closed), and it removes the
+	// dangling interface->zone reference from the snapshot.
+	for i := range snap.Interfaces {
+		if _, drop := quarantined[snap.Interfaces[i].Zone]; drop {
+			snap.Interfaces[i].Zone = ""
+		}
+	}
+	// Drop policies whose from/to zone is quarantined so the snapshot carries no
+	// dangling policy->zone reference (which the Rust UnresolvableZoneReference
+	// preflight would reject wholesale). A global rule keeps FromZone/ToZone ==
+	// "junos-global" and is never quarantined.
+	if len(snap.Policies) > 0 {
+		keptPol := snap.Policies[:0]
+		for _, p := range snap.Policies {
+			if _, drop := quarantined[p.FromZone]; drop {
+				continue
+			}
+			if _, drop := quarantined[p.ToZone]; drop {
+				continue
+			}
+			keptPol = append(keptPol, p)
+		}
+		snap.Policies = keptPol
+	}
+	sort.Slice(collisions, func(i, j int) bool {
+		if collisions[i].ID != collisions[j].ID {
+			return collisions[i].ID < collisions[j].ID
+		}
+		return collisions[i].Quarantined < collisions[j].Quarantined
+	})
+	return collisions
+}
+
 // lowerTokens returns a lower-cased, trimmed copy of the host-inbound token
 // slice (system-services / protocols). Empty/whitespace tokens are dropped.
 // The Rust classifier lower-cases on its side too, but normalizing here keeps

--- a/pkg/dataplane/userspace/zones_collision_3719_test.go
+++ b/pkg/dataplane/userspace/zones_collision_3719_test.go
@@ -1,0 +1,169 @@
+// #3719: on the lenient / HA-sync / pre-#3075-persisted path two security zone
+// names can fold to the same StableZoneID. Before this fix buildZoneSnapshots
+// published BOTH with the same numeric id, and the Rust id-keyed maps merged the
+// two zones (one zone's reverse name / host-inbound set / tcp-rst bit / counters
+// stood in for the other) — a zone-isolation failure the lenient warning falsely
+// claimed was quarantined. quarantineCollidingZones now DROPS the later-sorting
+// colliding zone from the wire (and unzones its interfaces / drops its policies
+// so no dangling reference bricks the helper preflight), matching the warning.
+//
+// These tests go RED if the quarantine pass is removed from buildSnapshot (both
+// colliding zones publish with the same id) — the H02/M08 regression they guard.
+package userspace
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestQuarantineCollidingZonesDropsAndScrubs exercises the pass directly on a
+// hand-built snapshot carrying the verified colliding pair z174/z214 plus a
+// distinct zone. It must drop the later-sorting zone (z214), keep the survivor
+// (z174) and the distinct zone, unzone z214's interface, drop z214's policy, and
+// report the collision — leaving no two zones sharing an id.
+func TestQuarantineCollidingZonesDropsAndScrubs(t *testing.T) {
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	collideID := config.StableZoneID("z174")
+	snap := &ConfigSnapshot{
+		Zones: []ZoneSnapshot{
+			{Name: "trust", ID: config.StableZoneID("trust")},
+			{Name: "z174", ID: config.StableZoneID("z174")},
+			{Name: "z214", ID: config.StableZoneID("z214")},
+		},
+		Interfaces: []InterfaceSnapshot{
+			{Name: "ge-0-0-0.0", Zone: "z174"},
+			{Name: "ge-0-0-1.0", Zone: "z214"},
+			{Name: "ge-0-0-2.0", Zone: "trust"},
+		},
+		Policies: []PolicyRuleSnapshot{
+			{Name: "p-survivor", FromZone: "z174", ToZone: "trust"},
+			{Name: "p-quarantined-from", FromZone: "z214", ToZone: "trust"},
+			{Name: "p-quarantined-to", FromZone: "trust", ToZone: "z214"},
+			{Name: "p-global", FromZone: "junos-global", ToZone: "junos-global"},
+		},
+	}
+
+	collisions := quarantineCollidingZones(snap)
+
+	// The colliding zone is dropped; the survivor + distinct zone remain.
+	names := map[string]uint16{}
+	for _, z := range snap.Zones {
+		if prev, dup := names[z.Name]; dup {
+			t.Fatalf("zone %q appears twice (%d, %d)", z.Name, prev, z.ID)
+		}
+		names[z.Name] = z.ID
+	}
+	if _, ok := names["z214"]; ok {
+		t.Fatalf("quarantined zone z214 still published: %v", names)
+	}
+	if _, ok := names["z174"]; !ok {
+		t.Fatalf("survivor zone z174 was dropped: %v", names)
+	}
+	if _, ok := names["trust"]; !ok {
+		t.Fatalf("distinct zone trust was dropped: %v", names)
+	}
+	// The core invariant: no two published zones share a numeric id.
+	seen := map[uint16]string{}
+	for n, id := range names {
+		if prev, dup := seen[id]; dup {
+			t.Fatalf("two zones share id %d after quarantine: %q and %q", id, prev, n)
+		}
+		seen[id] = n
+	}
+
+	// z214's interface is unzoned (fail closed); the others keep their zone.
+	byIface := map[string]string{}
+	for _, i := range snap.Interfaces {
+		byIface[i.Name] = i.Zone
+	}
+	if z := byIface["ge-0-0-1.0"]; z != "" {
+		t.Fatalf("interface in quarantined zone still bound to %q, want unzoned", z)
+	}
+	if z := byIface["ge-0-0-0.0"]; z != "z174" {
+		t.Fatalf("survivor-zone interface lost its binding: %q", z)
+	}
+	if z := byIface["ge-0-0-2.0"]; z != "trust" {
+		t.Fatalf("distinct-zone interface lost its binding: %q", z)
+	}
+
+	// Policies referencing z214 (from OR to) are dropped; survivor + global kept.
+	polNames := map[string]bool{}
+	for _, p := range snap.Policies {
+		polNames[p.Name] = true
+	}
+	if polNames["p-quarantined-from"] || polNames["p-quarantined-to"] {
+		t.Fatalf("policy referencing quarantined zone z214 survived: %v", polNames)
+	}
+	if !polNames["p-survivor"] || !polNames["p-global"] {
+		t.Fatalf("non-colliding policy was wrongly dropped: %v", polNames)
+	}
+
+	// The collision is reported with the survivor + quarantined names and id.
+	if len(collisions) != 1 {
+		t.Fatalf("got %d collisions, want 1: %v", len(collisions), collisions)
+	}
+	c := collisions[0]
+	if c.ID != collideID || c.Survivor != "z174" || c.Quarantined != "z214" {
+		t.Fatalf("collision record = %+v, want {ID:%d Survivor:z174 Quarantined:z214}", c, collideID)
+	}
+}
+
+// TestBuildSnapshotQuarantinesCollidingZone drives the REAL publish path
+// (buildSnapshot): a config with the colliding pair must yield a snapshot that
+// publishes neither zone twice under one id, drops the later-sorting zone, and
+// records the collision on the (unexported) diagnostic the manager reads. On a
+// revert (buildZoneSnapshots emits both) this fails: two ZoneSnapshots carry id
+// 53547.
+func TestBuildSnapshotQuarantinesCollidingZone(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"trust": {Name: "trust"},
+		"z174":  {Name: "z174"},
+		"z214":  {Name: "z214"},
+	}
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 0, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	seen := map[uint16]string{}
+	var haveZ214 bool
+	for _, z := range snap.Zones {
+		if z.Name == "z214" {
+			haveZ214 = true
+		}
+		if prev, dup := seen[z.ID]; dup {
+			t.Fatalf("two published zones share id %d: %q and %q (#3719 quarantine reverted?)", z.ID, prev, z.Name)
+		}
+		seen[z.ID] = z.Name
+	}
+	if haveZ214 {
+		t.Fatalf("later-sorting colliding zone z214 was published, want quarantined")
+	}
+	if len(snap.zoneIDCollisions) != 1 {
+		t.Fatalf("snap.zoneIDCollisions = %v, want exactly one collision", snap.zoneIDCollisions)
+	}
+	c := snap.zoneIDCollisions[0]
+	if c.Survivor != "z174" || c.Quarantined != "z214" {
+		t.Fatalf("collision = %+v, want survivor z174 / quarantined z214", c)
+	}
+}
+
+// TestBuildSnapshotNoCollisionPublishesAll: the common case is untouched — an
+// ordinary distinct-folding zone set publishes every zone and records no
+// collision (no false positive).
+func TestBuildSnapshotNoCollisionPublishesAll(t *testing.T) {
+	cfg := threeZoneCfg()
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 0, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	if len(snap.Zones) != len(cfg.Security.Zones) {
+		t.Fatalf("published %d zones, want %d (quarantine false positive?)", len(snap.Zones), len(cfg.Security.Zones))
+	}
+	if len(snap.zoneIDCollisions) != 0 {
+		t.Fatalf("recorded a collision on a distinct-folding set: %v", snap.zoneIDCollisions)
+	}
+}

--- a/pkg/dataplane/userspace/zones_collision_3719_test.go
+++ b/pkg/dataplane/userspace/zones_collision_3719_test.go
@@ -151,6 +151,99 @@ func TestBuildSnapshotQuarantinesCollidingZone(t *testing.T) {
 	}
 }
 
+// TestQuarantineDropsScopedGlobalPolicyOnQuarantinedZone (review MAJOR): a
+// GLOBAL policy keeps FromZone/ToZone == "junos-global" but carries its concrete
+// `match from-zone`/`to-zone` out-of-band in MatchFromZone/MatchToZone (#3148).
+// If the match-zone is the quarantined zone, the scrub MUST drop the policy too
+// — otherwise a dangling match-zone reaches the Rust build_global_zone_scope,
+// which returns UnresolvableZoneReference and rejects the WHOLE snapshot (a
+// fresh-boot brick, the exact failure the quarantine prevents). RED-on-revert:
+// without the MatchFromZone/MatchToZone check the two global rules survive.
+func TestQuarantineDropsScopedGlobalPolicyOnQuarantinedZone(t *testing.T) {
+	if config.StableZoneID("z174") != config.StableZoneID("z214") {
+		t.Fatalf("test premise broken: z174/z214 no longer collide under the frozen fold")
+	}
+	snap := &ConfigSnapshot{
+		Zones: []ZoneSnapshot{
+			{Name: "z174", ID: config.StableZoneID("z174")},
+			{Name: "z214", ID: config.StableZoneID("z214")},
+		},
+		Policies: []PolicyRuleSnapshot{
+			{Name: "g-scoped-from-quarantined", FromZone: "junos-global", ToZone: "junos-global", MatchFromZone: "z214"},
+			{Name: "g-scoped-to-quarantined", FromZone: "junos-global", ToZone: "junos-global", MatchToZone: "z214"},
+			{Name: "g-scoped-survivor", FromZone: "junos-global", ToZone: "junos-global", MatchFromZone: "z174"},
+			{Name: "g-unscoped", FromZone: "junos-global", ToZone: "junos-global"},
+		},
+	}
+	quarantineCollidingZones(snap)
+
+	// No published policy may reference the quarantined zone in ANY zone slot —
+	// including the out-of-band global match-zone.
+	published := map[string]uint16{}
+	for _, z := range snap.Zones {
+		published[z.Name] = z.ID
+	}
+	for _, p := range snap.Policies {
+		for _, z := range []string{p.MatchFromZone, p.MatchToZone} {
+			if z == "" {
+				continue
+			}
+			if _, ok := published[z]; !ok {
+				t.Fatalf("policy %q keeps a dangling match-zone %q absent from published zones — Rust build_global_zone_scope would brick the snapshot", p.Name, z)
+			}
+		}
+	}
+	kept := map[string]bool{}
+	for _, p := range snap.Policies {
+		kept[p.Name] = true
+	}
+	if kept["g-scoped-from-quarantined"] || kept["g-scoped-to-quarantined"] {
+		t.Fatalf("a global policy scoped to the quarantined zone survived: %v", kept)
+	}
+	if !kept["g-scoped-survivor"] || !kept["g-unscoped"] {
+		t.Fatalf("a non-colliding global policy was wrongly dropped: %v", kept)
+	}
+}
+
+// TestBuildSnapshotDropsDanglingGlobalMatchZone drives the REAL publish path: a
+// config with a StableZoneID collision AND a scoped global policy whose
+// `match from-zone` is the quarantined zone must yield a snapshot with NO policy
+// referencing an unpublished zone (so feeding it to the Rust preflight cannot
+// brick). RED-on-revert: without the match-zone scrub the built snapshot carries
+// a global rule whose MatchFromZone == "z214" (dropped from Zones).
+func TestBuildSnapshotDropsDanglingGlobalMatchZone(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.Zones = map[string]*config.ZoneConfig{
+		"z174": {Name: "z174"},
+		"z214": {Name: "z214"},
+	}
+	cfg.Security.GlobalPolicies = []*config.Policy{
+		{
+			Name:   "g-scoped-quarantined",
+			Match:  config.PolicyMatch{FromZone: "z214", Applications: []string{"any"}},
+			Action: config.PolicyPermit,
+		},
+	}
+	snap, err := buildSnapshot(cfg, config.UserspaceConfig{}, 0, 0)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	published := map[string]bool{}
+	for _, z := range snap.Zones {
+		published[z.Name] = true
+	}
+	for _, p := range snap.Policies {
+		for _, z := range []string{p.FromZone, p.ToZone, p.MatchFromZone, p.MatchToZone} {
+			if z == "" || z == "junos-global" {
+				continue
+			}
+			if !published[z] {
+				t.Fatalf("published policy %q references unpublished zone %q — the Rust preflight would reject the whole snapshot (brick)", p.Name, z)
+			}
+		}
+	}
+}
+
 // TestBuildSnapshotNoCollisionPublishesAll: the common case is untouched — an
 // ordinary distinct-folding zone set publishes every zone and records no
 // collision (no false positive).

--- a/userspace-dp/src/afxdp/forwarding_build/mod.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/mod.rs
@@ -205,6 +205,13 @@ pub(super) fn build_forwarding_state_with_policy_counters_and_previous(
     let mut state = ForwardingState::default();
     let (excluded_local_v4, excluded_local_v6) = nat_translated_local_exclusions(snapshot);
 
+    // #3719 (H03): fail CLOSED if two security zones share a numeric id before
+    // any id-keyed map is populated — populate_zones would otherwise let the
+    // later zone overwrite the earlier's reverse name / host-inbound set /
+    // tcp-rst bit, merging two zones. The Go control plane quarantines a
+    // StableZoneID collision on the lenient path, so a clean snapshot never
+    // trips this; this is the helper-boundary backstop.
+    zones::reject_duplicate_zone_ids(snapshot)?;
     zones::populate_zones(snapshot, &mut state);
     // #2410: fail CLOSED on a tunnel TTL outside 0..=255 instead of
     // narrowing it with an unchecked `as u8` cast that would wrap

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1848,6 +1848,82 @@ fn build_forwarding_state_rejects_reserved_zone_ids() {
     );
 }
 
+/// #3719 (H03/L04): two DIFFERENT zones carrying the same nonzero non-reserved
+/// id must fail the snapshot CLOSED before any id-keyed map is populated —
+/// otherwise populate_zones lets the later zone overwrite the earlier's
+/// zone_id_to_name / host-inbound / tcp-rst entries, merging two security zones.
+/// The Go control plane quarantines the collision before the wire; this is the
+/// helper-boundary backstop. Removing reject_duplicate_zone_ids (or its call in
+/// build_forwarding_state) turns this RED — the build succeeds and one id maps
+/// to a single merged zone.
+#[test]
+fn build_forwarding_state_rejects_duplicate_zone_ids() {
+    use crate::ZoneSnapshot;
+    // z174 and z214 both fold to config.StableZoneID 53547 (the verified
+    // collision pair); here we stamp the shared id explicitly.
+    let snapshot = ConfigSnapshot {
+        zones: vec![
+            ZoneSnapshot {
+                name: "z174".into(),
+                id: 53547,
+                ..Default::default()
+            },
+            ZoneSnapshot {
+                name: "z214".into(),
+                id: 53547,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let err = try_build_forwarding_state_with_policy_counters(
+        &snapshot,
+        &crate::policy::PolicyCounterStore::default(),
+    )
+    .expect_err("two zones sharing a numeric id must fail closed");
+    match err {
+        crate::policy::SnapshotIntegrityError::DuplicateZoneId { id, first, second } => {
+            assert_eq!(id, 53547);
+            assert_eq!(first, "z174");
+            assert_eq!(second, "z214");
+        }
+        other => panic!("expected DuplicateZoneId, got {other:?}"),
+    }
+}
+
+/// #3719: a zone id repeated only within the RESERVED range (or with id 0) is
+/// skipped by populate_zones and must NOT be treated as a collision — the gate
+/// mirrors populate_zones' skip set, so it must not over-reject.
+#[test]
+fn build_forwarding_state_reserved_duplicate_ids_are_not_collisions() {
+    use crate::ZoneSnapshot;
+    let snapshot = ConfigSnapshot {
+        zones: vec![
+            ZoneSnapshot {
+                name: "resv-a".into(),
+                id: crate::policy::ZONE_ID_RESERVED_MIN,
+                ..Default::default()
+            },
+            ZoneSnapshot {
+                name: "resv-b".into(),
+                id: crate::policy::ZONE_ID_RESERVED_MIN,
+                ..Default::default()
+            },
+            ZoneSnapshot {
+                name: "ok".into(),
+                id: 7,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    // Both reserved zones are skipped (never installed); "ok" builds cleanly.
+    let state = build_forwarding_state(&snapshot);
+    assert_eq!(state.zone_name_to_id.get("ok").copied(), Some(7));
+    assert!(state.zone_name_to_id.get("resv-a").is_none());
+    assert!(state.zone_name_to_id.get("resv-b").is_none());
+}
+
 /// #921: ifindex_to_zone_id is populated at config build time
 /// from the snapshot's per-interface zone NAME via zone_name_to_id.
 #[test]

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -1924,6 +1924,84 @@ fn build_forwarding_state_reserved_duplicate_ids_are_not_collisions() {
     assert!(state.zone_name_to_id.get("resv-b").is_none());
 }
 
+/// #3719 review MAJOR: a scoped `junos-global` policy carries its concrete
+/// match-zone out-of-band in `match_from_zone`/`match_to_zone`. If the Go
+/// quarantine's match-zone scrub were reverted, a global policy referencing the
+/// QUARANTINED (dropped) zone would reach the helper with a dangling match-zone;
+/// `build_global_zone_scope` resolves it against the published zone table, misses,
+/// and returns `UnresolvableZoneReference` (#3402), which propagates via `?` and
+/// rejects the WHOLE snapshot — a fresh-boot brick, the exact failure the
+/// quarantine exists to prevent. This pins that boundary behavior: the Go scrub
+/// MUST drop such a policy so this dangling reference never reaches the wire.
+#[test]
+fn build_forwarding_state_global_policy_with_unresolvable_match_zone_bricks() {
+    let snapshot = ConfigSnapshot {
+        // z214 was quarantined/dropped; only the survivor z174 is published.
+        zones: vec![crate::ZoneSnapshot {
+            name: "z174".into(),
+            id: 53547,
+            ..Default::default()
+        }],
+        policies: vec![crate::PolicyRuleSnapshot {
+            name: "g-scoped-quarantined".into(),
+            from_zone: "junos-global".into(),
+            to_zone: "junos-global".into(),
+            match_from_zone: "z214".into(), // dangling — not in the zone table
+            source_addresses: vec!["any".into()],
+            destination_addresses: vec!["any".into()],
+            applications: vec!["any".into()],
+            action: "permit".into(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let err = try_build_forwarding_state_with_policy_counters(
+        &snapshot,
+        &crate::policy::PolicyCounterStore::default(),
+    )
+    .expect_err("a dangling global match-zone must fail the snapshot closed");
+    match err {
+        crate::policy::SnapshotIntegrityError::UnresolvableZoneReference { zone, .. } => {
+            assert_eq!(zone, "z214");
+        }
+        other => panic!("expected UnresolvableZoneReference, got {other:?}"),
+    }
+}
+
+/// The clean post-quarantine shape: the z214-scoped global policy was dropped by
+/// the Go quarantine, leaving only a global policy scoped to the SURVIVING zone
+/// z174. `build_forwarding_state` resolves it and builds with no
+/// `SnapshotIntegrityError` — no brick. Together with the test above this is the
+/// end-to-end guard: the scrubbed snapshot builds; the un-scrubbed one rejects.
+#[test]
+fn build_forwarding_state_global_policy_scoped_to_published_zone_builds() {
+    let snapshot = ConfigSnapshot {
+        zones: vec![crate::ZoneSnapshot {
+            name: "z174".into(),
+            id: 53547,
+            ..Default::default()
+        }],
+        policies: vec![crate::PolicyRuleSnapshot {
+            name: "g-scoped-survivor".into(),
+            from_zone: "junos-global".into(),
+            to_zone: "junos-global".into(),
+            match_from_zone: "z174".into(),
+            source_addresses: vec!["any".into()],
+            destination_addresses: vec!["any".into()],
+            applications: vec!["any".into()],
+            action: "permit".into(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let state = try_build_forwarding_state_with_policy_counters(
+        &snapshot,
+        &crate::policy::PolicyCounterStore::default(),
+    )
+    .expect("a global policy scoped to a published zone must build without a brick");
+    assert_eq!(state.zone_name_to_id.get("z174").copied(), Some(53547));
+}
+
 /// #921: ifindex_to_zone_id is populated at config build time
 /// from the snapshot's per-interface zone NAME via zone_name_to_id.
 #[test]

--- a/userspace-dp/src/afxdp/forwarding_build/zones.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/zones.rs
@@ -8,10 +8,59 @@
 
 use super::super::*;
 
+/// #3719 (H03): reject a snapshot in which two DIFFERENT security zones share
+/// the same nonzero, non-reserved numeric zone id, BEFORE `populate_zones`
+/// touches any id-keyed map. Two zone names can fold to the same
+/// `config.StableZoneID`; publishing both would let the later zone silently
+/// overwrite the earlier's `zone_id_to_name` / `zone_host_inbound` /
+/// `zone_tcp_rst` entries below — merging two security zones under one id (a
+/// zone-isolation failure). The Go control plane already QUARANTINES the
+/// later-sorting colliding zone before it reaches the wire
+/// (`config.QuarantinedZoneNames` -> `quarantineCollidingZones`,
+/// pkg/dataplane/userspace/zones.go), so a clean snapshot never trips this; this
+/// is the helper-boundary backstop for a corrupt / hand-built / version-drifted
+/// snapshot, consistent with the #3402 / #3771 fail-closed family. Rejecting the
+/// whole snapshot keeps the previous good forwarding state (a fresh boot keeps
+/// the default-deny), never merging two zones.
+///
+/// The skip set mirrors `populate_zones`: an id of 0, an empty name, or an id in
+/// the reserved range (`>= ZONE_ID_RESERVED_MIN`) is never installed, so it is
+/// not a collision. Duplicate entries with the SAME name are the same zone, not
+/// a collision. The first differing-name duplicate wins the error, naming both.
+pub(super) fn reject_duplicate_zone_ids(
+    snapshot: &ConfigSnapshot,
+) -> Result<(), crate::policy::SnapshotIntegrityError> {
+    let mut owner: std::collections::HashMap<u16, &str> =
+        std::collections::HashMap::with_capacity(snapshot.zones.len());
+    for zone in &snapshot.zones {
+        if zone.id == 0
+            || zone.name.is_empty()
+            || zone.id >= crate::policy::ZONE_ID_RESERVED_MIN
+        {
+            continue;
+        }
+        match owner.get(&zone.id) {
+            Some(&first) if first != zone.name.as_str() => {
+                return Err(crate::policy::SnapshotIntegrityError::DuplicateZoneId {
+                    id: zone.id,
+                    first: first.to_string(),
+                    second: zone.name.clone(),
+                });
+            }
+            Some(_) => {}
+            None => {
+                owner.insert(zone.id, zone.name.as_str());
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Populate `state.zone_name_to_id` / `state.zone_id_to_name`.
 /// Must run before any other pass that resolves zone names
 /// (interfaces addresses pass, interfaces egress pass,
-/// `parse_policy_state_with_counters`).
+/// `parse_policy_state_with_counters`). Callers MUST run
+/// `reject_duplicate_zone_ids` first so no two zones share an id.
 pub(super) fn populate_zones(snapshot: &ConfigSnapshot, state: &mut ForwardingState) {
     // #3402: build the name→id map from the shared SSOT so the apply-time
     // integrity preflight (which has no live forwarding state yet) resolves

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -534,6 +534,29 @@ pub(crate) enum SnapshotIntegrityError {
         ip: String,
         family: String,
     },
+    /// #3719 (H03): two DIFFERENT security zones in the same snapshot carried the
+    /// same nonzero, non-reserved numeric zone id. #3075/#3704 made the zone id a
+    /// stable name-hash (`config.StableZoneID`); two zone names can fold to the
+    /// same id, and publishing both would let the later zone silently overwrite
+    /// the earlier's `zone_id_to_name` / `zone_host_inbound` / `zone_tcp_rst`
+    /// entries in `populate_zones` — MERGING two security zones under one id (one
+    /// zone's interfaces / policies / counters / host-inbound set stand in for the
+    /// other, a zone-isolation failure). The Go control plane QUARANTINES the
+    /// later-sorting colliding zone before it reaches the wire
+    /// (`config.QuarantinedZoneNames` -> `quarantineCollidingZones`,
+    /// pkg/dataplane/userspace/zones.go), so a clean snapshot never trips this; it
+    /// is the helper-boundary backstop for a corrupt / hand-built /
+    /// version-drifted snapshot, consistent with the #3402 `UnresolvableZoneReference`
+    /// and #3771 fail-closed family. Rejecting the WHOLE snapshot keeps the
+    /// previous good forwarding state (a fresh boot keeps the default-deny) and
+    /// never merges two zones. Ids of 0, an empty name, or the reserved range are
+    /// skipped by `populate_zones` (never installed) and so are NOT treated as
+    /// collisions.
+    DuplicateZoneId {
+        id: u16,
+        first: String,
+        second: String,
+    },
 }
 
 impl std::fmt::Display for SnapshotIntegrityError {
@@ -770,6 +793,11 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "neighbor {:?} on interface {:?} declares family {:?} that does not match the address family of its IP — refusing to install it under a contradicting family",
                 ip, interface, family
+            ),
+            Self::DuplicateZoneId { id, first, second } => write!(
+                f,
+                "security zones {:?} and {:?} share numeric zone id {} — publishing both would merge two zones; rename one zone (#3719)",
+                first, second, id
             ),
         }
     }


### PR DESCRIPTION
Closes #3719

## Problem

#3075/#3704 moved the whole zone-id namespace to the stable name-hash
`config.StableZoneID` (FNV-1a fold into `[1, 65533]`). The STRICT commit path
rejects two zone names that fold to the same id, but the LENIENT path — a
tolerant load, an HA config-sync from an un-upgraded peer, or a config a
pre-#3075 binary persisted with no collision check — only **warned** while every
downstream builder still published BOTH colliding zones with the same numeric
id.

Two `ZoneSnapshot`s sharing an id **merge two security zones** in the dataplane:
`populate_zones` lets the later zone overwrite the earlier's `zone_id_to_name` /
`zone_host_inbound` / `zone_tcp_rst` entries, and both zones' interfaces and
policies resolve to one id — one zone's traffic is attributed to the other. The
lenient warning falsely claimed the later zone was "NOT installed" (codex-153
H02/M08/L09/L13).

## Fix (Go — the runtime hole)

- **`config.QuarantinedZoneNames`** (SSOT): for each id claimed by >1 name, keep
  the sorted-first name (survivor), quarantine the rest. Pure function of the
  name set → HA-symmetric. `config.StableZoneIDOwner` resolves a colliding id to
  the survivor for reverse maps.
- **`quarantineCollidingZones`** runs in `buildSnapshot` BEFORE publish: drops
  the quarantined `ZoneSnapshot`, unzones its interfaces (`Zone=""` →
  default-deny, fail closed), and drops its policies. Dropping the zone but
  leaving its policies would trip the Rust `UnresolvableZoneReference` preflight
  and reject the whole snapshot (a brick on fresh boot), so the scrub is
  coordinated across zones/interfaces/policies. The rest of the config still
  loads (#1960 no-brick).
- **Reverse maps** (`syslogZoneNameMap`, `zoneNameByID`) resolve a colliding id
  to the survivor deterministically, not a map-iteration coin flip.
- **Observability**: loud one-shot `slog.Error` naming both zones,
  `ProcessStatus.ZoneIDCollisions` (`show`), and the
  `xpf_userspace_zone_id_collision` 0/1 gauge. The lenient warning wording now
  states the zone is QUARANTINED and isolation is DEGRADED.

## Defense-in-depth (Rust — needs cargo validation)

`SnapshotIntegrityError::DuplicateZoneId` + `zones::reject_duplicate_zone_ids`
(before `populate_zones`) reject a corrupt/version-drifted snapshot that still
carries two zones under one id. **This Rust-only commit needs `cargo`
build/test validation** — the Go fix in the first commit is independently
complete and verified.

## Validation

- Verified colliding pair `z174`/`z214` (both fold to 53547).
- **RED-on-revert proven**: neutralizing `quarantineCollidingZones` publishes
  both zones with id 53547 and `TestBuildSnapshotQuarantinesCollidingZone`
  fails.
- `go test ./pkg/config/... ./pkg/dataplane/... ./pkg/cli/... ./pkg/api/...
  ./pkg/daemon/...` green; `gofmt` and `go vet` clean.
- Zone-id publish is HA-adjacent (the zone id is synced), so `make test-failover`
  is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi