### PR TITLE
filter: range-check DSCP wire fields to 0..=63 (fail closed)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27814,3 +27814,42 @@ top.
   `record_policy_hit_counter` gated on non-LocalDelivery), userspace-dp/src/
   afxdp/tests.rs (established-hit exactly-once fail-on-revert test), userspace-dp/
   src/afxdp/forwarding/README.md (#3706 exactly-once hit-counting note)
+
+- **Timestamp**: 2026-07-01
+- **Action**: #3715 — range-check firewall-filter DSCP wire fields to the 6-bit
+  0..=63 range in the userspace-dp filter compiler (fail-closed backstop). The
+  Rust snapshot decode did NOT range-check the two DSCP wire fields against
+  their semantic 0..63 range, inconsistent with the file's own #3406 fail-closed
+  posture. Bug A (rewrite): `parse_term` computed
+  `snap.dscp_rewrite.map(|v| v & 0x3f)` — a corrupt byte like 110 was MASKED to
+  46 (EF), actively marking traffic with a code point the operator never authored
+  (untrusted traffic could land in EF). Bug B (match): `build_u6_match_bitmap`
+  silently SKIPPED any `dscp_values` entry >= 64 while `dscp_match_enabled`
+  stayed true — a `[46, 64]` term appeared to carry two selectors but matched
+  only EF (fail-WIDE / silently-wrong). The Go commit gate
+  (`validateFilterDSCPStrict`, #3309) already bounds both tokens to a code-point
+  name or 0..63 and the Go builder only emits 0..63, so a committed config never
+  produces an out-of-range value — the gap is purely the helper-boundary decode
+  for a corrupt / hand-built / version-drifted / mixed-version snapshot. Fix:
+  added a non-mutating preflight range check in `parse_term` (mirroring the
+  #3406 flex_match length check) that rejects any `dscp_values` entry >= 64
+  (dimension "match") or a `dscp_rewrite` >= 64 (dimension "rewrite") via a new
+  `SnapshotIntegrityError::FilterDSCPOutOfRange { family, filter, term,
+  dimension, value }` variant; removed the `& 0x3f` mask so a valid 0..=63
+  rewrite is carried verbatim. No wire field changed (dscp_values stays Vec<u8>,
+  dscp_rewrite stays Option<u8>) — no protocol_wire_v1.json regen. RED-on-revert
+  tests: `dscp_rewrite_out_of_range_fails_closed_not_masked` (Some(110) rejected,
+  proves NOT masked to 46) and `dscp_match_out_of_range_fails_closed_not_dropped`
+  ([46,64] rejected, in-range set still compiles); both verified RED with the
+  fix reverted (mask restored + preflight removed) and GREEN with it. Also L10:
+  reworded the stale `validateFilterDSCPStrict` doc comment ("a leniently-loaded
+  match widens") to distinguish the match half (fail-closed marker #3406 +
+  numeric range #3715) from the rewrite half (warn/no-op name, fail-closed
+  numeric #3715). Full `cargo test --release` green (3422 lib + integration
+  binaries, 0 failed); `go build ./...`, `go vet ./pkg/config/...`,
+  `go test ./pkg/config/...` green; gofmt clean.
+- **File(s)**: userspace-dp/src/policy.rs (new FilterDSCPOutOfRange variant +
+  Display), userspace-dp/src/filter/compiler.rs (preflight DSCP range check +
+  removed & 0x3f mask), userspace-dp/src/filter/tests.rs (two RED-on-revert
+  tests), userspace-dp/src/filter/README.md (#3715 backstop doc + test list),
+  pkg/config/compiler_validate_strict.go (L10 stale-comment reword)

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -4852,10 +4852,21 @@ func validateFilterRoutingInstanceConflictStrict(cfg *Config) error {
 //
 // The walk is deterministic (filters sorted by name, terms in config order). On
 // the tolerant load / peer-sync path the caller downgrades the returned error to
-// a warning (#1960 no-brick); the snapshot builder drops the bad token
-// independently (a leniently-loaded match widens, a rewrite no-ops) — but the
-// operator never reaches that state through a commit. Mirrors
-// validateFilterMatchValuesStrict.
+// a warning (#1960 no-brick); the snapshot builder then handles the bad token
+// independently, and the two DSCP halves behave DIFFERENTLY there (L10, #3715):
+//
+//   - MATCH: an unresolvable `from dscp` NAME is dropped and the term is marked
+//     dscp_match_unrepresentable, which the Rust filter compiler FAILS CLOSED on
+//     (SnapshotIntegrityError::UnrepresentableFilterDSCP, #3406) — it does NOT
+//     silently widen. A raw numeric value >= 64 is likewise failed closed
+//     (FilterDSCPOutOfRange, #3715) rather than silently dropped from the bitmap.
+//   - REWRITE: an unresolvable `then dscp` NAME warn/no-ops (CoS-only, no match
+//     widening), and a raw numeric value >= 64 is failed closed by the Rust
+//     compiler (FilterDSCPOutOfRange, #3715) rather than masked into a different
+//     valid code point.
+//
+// The operator never reaches any of those states through a commit — this gate is
+// the primary defense. Mirrors validateFilterMatchValuesStrict.
 func validateFilterDSCPStrict(cfg *Config) error {
 	if cfg == nil {
 		return nil

--- a/userspace-dp/src/filter/README.md
+++ b/userspace-dp/src/filter/README.md
@@ -586,6 +586,20 @@ match/action widening:
   unresolvable rewrite is CoS-only (no match/action widening), so it is NOT failed
   closed — the Go builder emits NO rewrite and a `slog.Warn` so the lost CoS marking
   is operator-visible (failing forwarding over a cosmetic marking would be worse).
+- **Raw DSCP wire value out of the 6-bit 0..=63 range (#3715):** a `dscp_values`
+  entry >= 64 (match) or a `dscp_rewrite` byte >= 64 (rewrite) can only arrive from
+  a corrupt / hand-built / version-drifted snapshot — the Go commit gate
+  (`validateFilterDSCPStrict`) and the builder both bound DSCP to a code-point name
+  or 0..63. `parse_term` raises `SnapshotIntegrityError::FilterDSCPOutOfRange` for
+  either. Unlike the `dscp_match_unrepresentable` marker above (which fires after the
+  Go builder has already DROPPED an unresolvable NAME), the raw numeric value is
+  directly visible on the wire, so the range check is done in Rust without a Go-side
+  marker. Pre-fix the MATCH value was silently SKIPPED by `build_u6_match_bitmap`
+  (`value < 64` guard) while `dscp_match_enabled` stayed true → a `[46, 64]` term
+  matched only EF (fail-WIDE / silently-wrong); the REWRITE value was MASKED with
+  `& 0x3f`, turning e.g. 110 into 46 (EF) → traffic marked with a code point the
+  operator never authored. BOTH now fail the snapshot closed (the reconcile preflight
+  keeps the previous good filter state), so neither mis-applies.
 - **Mixed positive + `*-port-except` in one direction (104-M05):** the Rust
   compiler already resolves this positive-wins (the except list is dropped — a
   fail-SAFE narrowing, see "Negated port match" below), but the pre-#3406 drop was
@@ -593,7 +607,9 @@ match/action widening:
   address-except warning (#3359), so the dropped except set is operator-visible.
 
 Tests: `icmp_type_unrepresentable_marker_*`, `icmp_code_unrepresentable_marker_*`,
-`dscp_match_unrepresentable_marker_*`, `flex_match_oversized_width_*` (Rust) and
+`dscp_match_unrepresentable_marker_*`, `dscp_match_out_of_range_fails_closed_not_dropped`,
+`dscp_rewrite_out_of_range_fails_closed_not_masked`, `flex_match_oversized_width_*`
+(Rust) and
 `TestFilterSnapshot{ICMP,DSCPMatch,DSCPRewrite,FlexMatchOversizedWidth,MixedPortExcept}*`
 (Go) (fail-on-revert).
 

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -464,6 +464,38 @@ fn parse_term(
             term: snap.name.clone(),
         });
     }
+    // #3715: DSCP is a 6-bit field (0..=63). A raw wire value >= 64 can only
+    // arrive from a corrupt / hand-built / version-drifted snapshot — the Go
+    // commit gate (validateFilterDSCPStrict) and the snapshot builder both bound
+    // DSCP to a code-point name or 0..63. A `dscp_values` entry >= 64 is silently
+    // SKIPPED by build_u6_match_bitmap (its `value < 64` guard) while
+    // dscp_match_enabled stays true — the term then matches only the in-range
+    // subset (fail-WIDE / silently-wrong); a `dscp_rewrite` >= 64 was MASKED with
+    // & 0x3f below, turning e.g. 110 into 46 (EF) and marking traffic with a code
+    // point the operator never authored. Range-check both here, in the
+    // non-mutating preflight, and fail the snapshot closed (the reconcile preflight
+    // keeps the previous good filter state), mirroring the #3406 flex_match length
+    // check above.
+    if let Some(&value) = snap.dscp_values.iter().find(|&&v| v > 63) {
+        return Err(SnapshotIntegrityError::FilterDSCPOutOfRange {
+            family: filter_family.to_string(),
+            filter: filter_name.to_string(),
+            term: snap.name.clone(),
+            dimension: "match",
+            value,
+        });
+    }
+    if let Some(value) = snap.dscp_rewrite {
+        if value > 63 {
+            return Err(SnapshotIntegrityError::FilterDSCPOutOfRange {
+                family: filter_family.to_string(),
+                filter: filter_name.to_string(),
+                term: snap.name.clone(),
+                dimension: "rewrite",
+                value,
+            });
+        }
+    }
     // #3406: a present flex_match whose byte length is outside 1..=4 is
     // unrepresentable (the value/mask wire fields are u32). The pre-fix Go builder
     // capped an oversized width to 4 and still emitted the term, so only the
@@ -685,7 +717,11 @@ fn parse_term(
             FilterAction::Discard
         }
     };
-    let dscp_rewrite = snap.dscp_rewrite.map(|value| value & 0x3f);
+    // #3715: no `& 0x3f` mask — the preflight above already rejected any
+    // dscp_rewrite >= 64, so the value is a valid 0..=63 code point verbatim.
+    // Masking would silently turn a corrupt byte (e.g. 110) into a DIFFERENT
+    // valid code point (46 = EF).
+    let dscp_rewrite = snap.dscp_rewrite;
 
     Ok(FilterTerm {
         id,

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -5375,6 +5375,90 @@ fn dscp_match_unrepresentable_marker_fails_closed_not_match_all() {
 }
 
 #[test]
+fn dscp_rewrite_out_of_range_fails_closed_not_masked() {
+    // #3715 RED-on-revert (Bug A): a `then dscp` REWRITE wire value outside the
+    // 0..=63 6-bit range must reject the whole snapshot — NOT be masked into a
+    // different valid code point. Pre-fix `parse_term` computed
+    // `snap.dscp_rewrite.map(|v| v & 0x3f)`, so 110 & 0x3f == 46 (EF): a corrupt
+    // byte actively marked traffic with a code point the operator never authored.
+    // Reverting the preflight range check (and restoring the mask) makes this
+    // compile Ok with dscp_rewrite == Some(46).
+    let err = filter_with_marked_term("inet", |t| t.dscp_rewrite = Some(110))
+        .expect_err("an out-of-range dscp rewrite must fail the build closed");
+    match err {
+        SnapshotIntegrityError::FilterDSCPOutOfRange {
+            family,
+            filter,
+            term,
+            dimension,
+            value,
+        } => {
+            assert_eq!(family, "inet");
+            assert_eq!(filter, "f");
+            assert_eq!(term, "marked");
+            assert_eq!(dimension, "rewrite");
+            assert_eq!(value, 110, "the error must carry the raw offending byte, not 110 & 0x3f");
+        }
+        other => panic!("expected FilterDSCPOutOfRange, got {other:?}"),
+    }
+    // A rewrite at the top of the valid range (63) still compiles verbatim.
+    let ok = filter_with_marked_term("inet", |t| t.dscp_rewrite = Some(63))
+        .expect("a valid 0..=63 dscp rewrite must compile");
+    assert_eq!(
+        ok.filters
+            .get("inet:f")
+            .expect("filter compiled")
+            .terms
+            .first()
+            .expect("one term")
+            .dscp_rewrite,
+        Some(63),
+        "a valid rewrite must be carried verbatim (no masking)"
+    );
+}
+
+#[test]
+fn dscp_match_out_of_range_fails_closed_not_dropped() {
+    // #3715 RED-on-revert (Bug B): a `from dscp` MATCH wire value >= 64 must reject
+    // the whole snapshot. Pre-fix `build_u6_match_bitmap` silently SKIPPED any value
+    // >= 64 (its `value < 64` guard) while `dscp_match_enabled` stayed true — a term
+    // carrying [46, 64] appeared to match two selectors but silently matched only EF
+    // (fail-WIDE / silently-wrong). Reverting the preflight range check makes this
+    // compile Ok with the 64 dropped from the bitmap. inet6 names the family to
+    // prove it is carried (filter names can be reused across families).
+    let err = filter_with_marked_term("inet6", |t| t.dscp_values = vec![46, 64])
+        .expect_err("an out-of-range dscp match value must fail the build closed");
+    match err {
+        SnapshotIntegrityError::FilterDSCPOutOfRange {
+            family,
+            dimension,
+            value,
+            ..
+        } => {
+            assert_eq!(family, "inet6");
+            assert_eq!(dimension, "match");
+            assert_eq!(value, 64, "the error must carry the first out-of-range value");
+        }
+        other => panic!("expected FilterDSCPOutOfRange, got {other:?}"),
+    }
+    // The boundary value 63 is in range; a fully in-range match set compiles and
+    // keeps the DSCP match enabled.
+    let ok = filter_with_marked_term("inet", |t| t.dscp_values = vec![0, 46, 63])
+        .expect("a fully in-range dscp match set must compile");
+    let term = ok
+        .filters
+        .get("inet:f")
+        .expect("filter compiled")
+        .terms
+        .first()
+        .expect("one term");
+    assert!(
+        term.dscp_match_enabled,
+        "an in-range dscp match set must keep the DSCP match enabled"
+    );
+}
+
+#[test]
 fn flex_match_oversized_width_fails_closed_not_truncated() {
     // #3406 RED-on-revert: a present flex_match whose byte `length` is outside
     // 1..=4 (the value/mask wire fields are u32) must reject the whole snapshot.

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -278,6 +278,36 @@ pub(crate) enum SnapshotIntegrityError {
         term: String,
         length: u8,
     },
+    /// #3715: a firewall-filter term carried a raw DSCP wire value outside the
+    /// semantic 0..=63 range (DSCP is a 6-bit field). `dimension` is "match" for a
+    /// `snap.dscp_values` entry >= 64 and "rewrite" for a `snap.dscp_rewrite` byte
+    /// >= 64; `value` is the offending byte. Unlike the `dscp_match_unrepresentable`
+    /// marker (#3406) — which the Go control plane sets after it has already dropped
+    /// an unresolvable code-point NAME — a raw numeric value >= 64 is directly
+    /// visible on the wire (`dscp_values` is Vec<u8>, `dscp_rewrite` is Option<u8>),
+    /// so the range check happens HERE without a Go-side marker. The Go commit gate
+    /// (`validateFilterDSCPStrict`, #3309) bounds both tokens to a code-point name or
+    /// 0..63 and the Go builder (`filters.go`) only ever emits 0..63, so a committed
+    /// config never produces an out-of-range value; this is the helper-boundary
+    /// backstop for a corrupt / hand-built / version-drifted / mixed-version
+    /// snapshot, consistent with the #2505/#3367/#3406 fail-closed family.
+    ///
+    /// Pre-fix the MATCH value was silently dropped by `build_u6_match_bitmap` (its
+    /// `value < 64` guard skipped it) while `dscp_match_enabled` stayed true — a term
+    /// that appears to carry two selectors then matched only the in-range subset
+    /// (fail-WIDE / silently-wrong). The REWRITE value was MASKED with `& 0x3f`,
+    /// turning e.g. 110 into 46 (EF) — actively marking traffic with a code point the
+    /// operator never authored (untrusted traffic could land in EF). Rejecting the
+    /// whole snapshot (the reconcile preflight keeps the previous good filter state)
+    /// never mis-applies. `family` (inet / inet6) is carried because filter names can
+    /// be reused across families.
+    FilterDSCPOutOfRange {
+        family: String,
+        filter: String,
+        term: String,
+        dimension: &'static str,
+        value: u8,
+    },
     /// #3723: a firewall-filter term combined a resolved `protocol` (or the inet6
     /// `next-header`) with an L4 predicate the matcher can NEVER satisfy for that
     /// protocol — a source/destination-port with a non-port-bearing protocol
@@ -653,6 +683,17 @@ impl std::fmt::Display for SnapshotIntegrityError {
                 f,
                 "firewall family {:?} filter {:?} term {:?} has a flexible-match-range byte length {} outside the representable 1..=4 range — refusing to truncate it to a 4-byte window (which would broaden the match)",
                 family, filter, term, length
+            ),
+            Self::FilterDSCPOutOfRange {
+                family,
+                filter,
+                term,
+                dimension,
+                value,
+            } => write!(
+                f,
+                "firewall family {:?} filter {:?} term {:?} has a {} dscp/traffic-class value {} outside the 0..=63 6-bit range — refusing to mask it into a different valid code point (rewrite) or silently drop it from the match bitmap (match)",
+                family, filter, term, dimension, value
             ),
             Self::UnsatisfiableFilterCrossField {
                 family,


### PR DESCRIPTION
Closes #3715

## Problem
The userspace-dp firewall-filter compiler did not range-check the two DSCP wire fields against their semantic 0..63 range (DSCP is a 6-bit field), inconsistent with this file's own #3406 fail-closed posture (it already rejects `dscp_match_unrepresentable` and range-checks `flex_match.length`).

- **Bug A (rewrite, H01):** `parse_term` computed `snap.dscp_rewrite.map(|v| v & 0x3f)`. A corrupt byte like `110` was **masked** to `46` (EF) — not a no-op, not a fail-closed drop, but an active re-mark of traffic with a code point the operator never authored (untrusted traffic could land in EF).
- **Bug B (match, H02):** `build_u6_match_bitmap` silently **skipped** any `dscp_values` entry `>= 64` while `dscp_match_enabled` stayed true. A `[46, 64]` term appeared to carry two selectors but matched only EF — fail-WIDE / silently-wrong.

The Go commit gate (`validateFilterDSCPStrict`, #3309) already bounds both the `from dscp` match token and the `then dscp` rewrite token to a code-point name or 0..63, and the Go snapshot builder only ever emits 0..63, so **a committed config never produces an out-of-range value**. The gap is purely the helper-boundary decode for a corrupt / hand-built / version-drifted / mixed-version snapshot — the same class the #3406 / #3367 backstops guard.

## Fix
- Add a non-mutating preflight range check in `parse_term` (mirroring the #3406 flex_match length check) that rejects any `dscp_values` entry `>= 64` (dimension `"match"`) or a `dscp_rewrite >= 64` (dimension `"rewrite"`) via a new `SnapshotIntegrityError::FilterDSCPOutOfRange { family, filter, term, dimension, value }`.
- Remove the `& 0x3f` mask so a valid 0..=63 rewrite is carried verbatim.
- Unlike the `dscp_match_unrepresentable` marker (set by the Go builder after it has already dropped an unresolvable NAME), a raw numeric value `>= 64` is directly visible on the wire, so the range check is done in Rust **without a Go-side marker**.
- **No wire field changed** (`dscp_values` stays `Vec<u8>`, `dscp_rewrite` stays `Option<u8>`) — no `protocol_wire_v1.json` regeneration.
- L10: reworded the stale `validateFilterDSCPStrict` doc comment ("a leniently-loaded match widens") to distinguish the match half (fail-closed marker #3406 + fail-closed numeric range #3715) from the rewrite half (warn/no-op on an unresolvable name, fail-closed on an out-of-range numeric).

## Go / Rust
- **Rust** (dataplane decode backstop): the fix. `userspace-dp/src/policy.rs`, `userspace-dp/src/filter/compiler.rs`.
- **Go**: no functional change — the commit gate already covers 0..63. Only the L10 doc comment was refreshed (`pkg/config/compiler_validate_strict.go`).

## Tests (RED-on-revert)
- `dscp_rewrite_out_of_range_fails_closed_not_masked`: `Some(110)` is rejected and the error carries `value=110`, proving it is **not** masked to `Some(46)`; a rewrite of 63 still compiles verbatim.
- `dscp_match_out_of_range_fails_closed_not_dropped`: `[46, 64]` is rejected with dimension `"match"` value 64; a fully in-range set `[0, 46, 63]` still compiles with the DSCP match enabled.

Both verified **RED** with the fix reverted (mask restored + preflight removed) and **GREEN** with it.

## Validation
- Full `cargo test --release` green (3422 lib tests + integration binaries, 0 failed).
- `go build ./...`, `go vet ./pkg/config/...`, `go test ./pkg/config/...` green; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi