### PR TITLE
policy: reject duplicate rule_id / policy_id at snapshot parse (#3713)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27853,3 +27853,37 @@ top.
   removed & 0x3f mask), userspace-dp/src/filter/tests.rs (two RED-on-revert
   tests), userspace-dp/src/filter/README.md (#3715 backstop doc + test list),
   pkg/config/compiler_validate_strict.go (L10 stale-comment reword)
+
+## 2026-07-02
+
+- **Timestamp**: 2026-07-02
+- **Action**: #3713 — reject duplicate policy rule_id / policy_id at snapshot
+  parse (fail closed). The Rust policy snapshot parser had NO uniqueness guard
+  for rule_id or policy_id (it already hard-fails duplicate address-book ids).
+  Two rules with the same stable rule_id (an identical explicit wire rule_id, or
+  an identical synthesized `from->to/name` key from a duplicate policy name in a
+  zone pair) SHARE one Arc<PolicyRuleCounter> (rule_hit_counter is get-or-insert
+  keyed by rule_id) so counter_snapshots() collapses two rows onto one total
+  (hit-count mis-attribution); a duplicate policy_id overwrites the
+  last-writer-wins rule_id_to_policy_id map so an existing session re-resolves
+  (#3395 live-row refresh / RT_FLOW SESSION_CLOSE) to the WRONG policy. Fix: a
+  non-mutating preflight in parse_policy_state_with_counters (FIRST validation,
+  before the book loop / rule loop) rejects a duplicate resolved rule_id
+  (DuplicateRuleId) and a duplicate non-sentinel policy_id (DuplicatePolicyId,
+  M01) BEFORE any per-rule counter is allocated (L14 — no transient counter for a
+  rejected snapshot). Mirrors DuplicateAddressBookId + the #2124/#3261/#3367/#3711
+  fail-closed family; keeps the previous good forwarding state. The reserved
+  implicit-default sentinel (DEFAULT_POLICY_SENTINEL_ID, u32::MAX) is excluded
+  from the policy_id check; policy_id 0 (the valid first-policy id) is checked
+  normally. Rust-only — the Go builder (walkPolicyRuleSlots) already assigns
+  unique positional ids by construction, and the Rust parser is the only
+  enforcement plane in the retired-eBPF world for a corrupt / hand-built /
+  mixed-version HA peer-sync snapshot. RED-on-revert tests:
+  duplicate_synthesized_rule_id_fails_closed, duplicate_explicit_wire_rule_id_
+  fails_closed, duplicate_policy_id_fails_closed (all Err on fix, Ok on revert)
+  + distinct_rules_get_distinct_hit_counters (distinct Arcs, no shared counter).
+- **File(s)**: userspace-dp/src/policy.rs (two new SnapshotIntegrityError
+  variants + Display arms + preflight in parse_policy_state_with_counters),
+  userspace-dp/src/policy_tests.rs (4 tests),
+  docs/userspace-dataplane-architecture.md (duplicate rule-identity fail-closed
+  paragraph)

--- a/_Log.md
+++ b/_Log.md
@@ -27887,3 +27887,20 @@ top.
   userspace-dp/src/policy_tests.rs (4 tests),
   docs/userspace-dataplane-architecture.md (duplicate rule-identity fail-closed
   paragraph)
+
+- **Timestamp**: 2026-07-02 (refinement)
+- **Action**: #3713 — the full cargo test surfaced 23 pre-existing fixtures that
+  build multiple rules all leaving policy_id at its omitempty zero-value (0);
+  they tripped DuplicatePolicyId{0}. policy_id is `omitempty` on the wire, so 0
+  is BOTH the valid first-policy id AND the "unspecified" value a
+  pre-#3056/#3057 producer or an older HA peer leaves on every rule. Rejecting
+  duplicate-0 would fail-close a legitimate older-peer / hand-built (all-zero)
+  snapshot — an availability regression during a rolling upgrade, not the
+  aliasing corruption M01 targets. Fix: exclude 0 from the policy_id duplicate
+  check (alongside the u32::MAX sentinel); a genuine collision of two distinct
+  rules on a real assigned NON-ZERO positional policy_id is still caught. Added
+  omitempty_zero_policy_ids_still_parse (RED if the `!= 0` exclusion is removed).
+  The DuplicateRuleId check (primary H06 fix) was clean — zero rule_id failures.
+- **File(s)**: userspace-dp/src/policy.rs (0-exclusion + comments),
+  userspace-dp/src/policy_tests.rs (omitempty guard test),
+  docs/userspace-dataplane-architecture.md (0-exclusion rationale)

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -699,11 +699,17 @@ builder (`walkPolicyRuleSlots`) assigns each policy a distinct positional
 `policy_id` (`policy_set_id * MAX_RULES_PER_POLICY + rule_index`) and a distinct
 stable `rule_id` by construction, so a clean commit never trips these; they are
 the helper-boundary backstop for a corrupt / hand-built / mixed-version HA
-peer-sync snapshot. The reserved implicit-default sentinel
-(`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`) is never carried by a configured rule
-and is excluded from the `policy_id` check (M01); `policy_id` 0 is the valid
-first-policy id and is checked normally. Rejecting the whole snapshot mirrors
-`DuplicateAddressBookId` and keeps the previous good forwarding state.
+peer-sync snapshot. The `policy_id` check (M01) excludes two values: the
+reserved implicit-default sentinel (`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`),
+never carried by a configured rule; and `0`, the `omitempty` wire zero-value
+that is simultaneously the valid FIRST-policy id AND the "unspecified" value a
+pre-`policy_id` (pre-#3056/#3057) producer or an older HA peer leaves on EVERY
+rule — rejecting a duplicate `0` would fail-close a legitimate older-peer /
+hand-built (all-zero) snapshot, an availability regression during a rolling
+upgrade rather than the aliasing corruption this guards. A genuine collision of
+two distinct rules on a real assigned (non-zero) positional `policy_id` is still
+caught. Rejecting the whole snapshot mirrors `DuplicateAddressBookId` and keeps
+the previous good forwarding state.
 
 **Wildcard zone tiers (#3090).** A policy whose `from-zone` or `to-zone` is the
 Junos wildcard `any` is indexed into one of three dedicated lists alongside the

--- a/docs/userspace-dataplane-architecture.md
+++ b/docs/userspace-dataplane-architecture.md
@@ -678,6 +678,33 @@ snapshot only ever emits parseable, family-separated literals / `any` / family
 wildcards, so these rejects guard against a corrupt / hand-built / mixed-version
 HA peer-sync snapshot; the preflight keeps the previous good forwarding state.
 
+**Duplicate rule-identity fail-closed (#3713).** `parse_policy_state_with_counters`
+preflights rule-identity uniqueness BEFORE it allocates any per-rule hit counter
+or builds a `PolicyRule` entry — the FIRST validation in the function, so no
+transient counter is get-or-inserted into the shared `PolicyCounterStore` for a
+snapshot that is then rejected. Two failure modes are rejected:
+`SnapshotIntegrityError::DuplicateRuleId` when two rules resolve to the same
+stable `rule_id` (`stable_policy_rule_id` returns an explicit wire `rule_id`
+verbatim, else the synthesized `from->to/name` key — an identical explicit id or
+a duplicate policy name in one zone pair collides), and
+`SnapshotIntegrityError::DuplicatePolicyId` when two rules carry the same
+positional `policy_id`. Both alias the runtime identity: `rule_id` is the
+get-or-insert key for `PolicyCounterStore::rule_hit_counter`, so a duplicate
+would make two rules SHARE one `Arc<PolicyRuleCounter>` and `counter_snapshots()`
+would emit two rows with the same id and the same collapsed totals (hit-count
+mis-attribution); `policy_id` is the RT_FLOW / `SESSION_CLOSE` / display join key
+AND the last-writer-wins value in `rule_id_to_policy_id`, so a duplicate lets an
+existing session re-resolve (#3395 live-row refresh) to the WRONG policy. The Go
+builder (`walkPolicyRuleSlots`) assigns each policy a distinct positional
+`policy_id` (`policy_set_id * MAX_RULES_PER_POLICY + rule_index`) and a distinct
+stable `rule_id` by construction, so a clean commit never trips these; they are
+the helper-boundary backstop for a corrupt / hand-built / mixed-version HA
+peer-sync snapshot. The reserved implicit-default sentinel
+(`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`) is never carried by a configured rule
+and is excluded from the `policy_id` check (M01); `policy_id` 0 is the valid
+first-policy id and is checked normally. Rejecting the whole snapshot mirrors
+`DuplicateAddressBookId` and keeps the previous good forwarding state.
+
 **Wildcard zone tiers (#3090).** A policy whose `from-zone` or `to-zone` is the
 Junos wildcard `any` is indexed into one of three dedicated lists alongside the
 exact `zone_pair_index`: **from-any** (key = concrete to-zone id), **to-any**

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -16,6 +16,33 @@ use std::sync::{Arc, Mutex};
 pub(crate) enum SnapshotIntegrityError {
     AddressBookIdZero,
     DuplicateAddressBookId(u32),
+    /// #3713: two policy rules resolved to the SAME stable rule identity
+    /// (`stable_policy_rule_id`) — either an identical explicit wire `rule_id`
+    /// (corrupt / mixed-version producer) or an identical synthesized
+    /// `from->to/name` key (a duplicate policy name in one zone pair). The
+    /// rule_id is the get-or-insert key for `PolicyCounterStore::rule_hit_counter`,
+    /// so two rules with the same id SHARE one `Arc<PolicyRuleCounter>`:
+    /// `counter_snapshots()` then emits two rows with the same id and the same
+    /// collapsed totals (hit-count mis-attribution), and it is also the RT_FLOW /
+    /// session / display join key, so an incident-response surface joins the
+    /// wrong rule. Rejecting the WHOLE snapshot (the preflight keeps the previous
+    /// good state; a fresh boot keeps the default-deny `PolicyState`) mirrors
+    /// `DuplicateAddressBookId` and the #2124/#3261/#3367/#3711 fail-closed
+    /// family. A normal Go snapshot assigns each policy a distinct positional
+    /// identity, so this guards a corrupt / hand-built / mixed-version HA
+    /// peer-sync snapshot.
+    DuplicateRuleId { rule_id: String },
+    /// #3713: two policy rules carry the SAME positional `policy_id`. The Go
+    /// builder assigns `policy_set_id * MAX_RULES_PER_POLICY + rule_index`
+    /// (`walkPolicyRuleSlots`), which is unique per rule by construction, so a
+    /// duplicate is a corrupt / mixed-version snapshot. `policy_id` is the
+    /// RT_FLOW / `SESSION_CLOSE` / display join key AND the value stored in
+    /// `rule_id_to_policy_id` (last-writer-wins), so a duplicate lets an existing
+    /// session re-resolve (#3395 live-row refresh) to the WRONG policy — wrong
+    /// attribution during incident response. The reserved implicit-default
+    /// sentinel (`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`) is never carried by a
+    /// configured rule and is excluded from the check (M01).
+    DuplicatePolicyId { policy_id: u32 },
     UnknownAddressBookId { rule_id: String, book_id: u32 },
     /// #2124: a policy rule has at least one `application_terms` entry that
     /// failed to parse (unrepresentable protocol or malformed port). Dropping a
@@ -573,6 +600,16 @@ impl std::fmt::Display for SnapshotIntegrityError {
             Self::DuplicateAddressBookId(id) => {
                 write!(f, "duplicate address_books.id={}", id)
             }
+            Self::DuplicateRuleId { rule_id } => write!(
+                f,
+                "duplicate policy rule_id {:?} — two rules resolve to the same stable identity (identical explicit rule_id or duplicate policy name in a zone pair); refusing to fail open by sharing one hit counter and aliasing the RT_FLOW/session/display join key",
+                rule_id
+            ),
+            Self::DuplicatePolicyId { policy_id } => write!(
+                f,
+                "duplicate policy_id {} — two rules carry the same positional policy id (corrupt/mixed-version snapshot); refusing to fail open by letting a session re-resolve to the wrong policy",
+                policy_id
+            ),
             Self::UnknownAddressBookId { rule_id, book_id } => write!(
                 f,
                 "rule {:?} references unknown address book id={}",
@@ -2453,6 +2490,45 @@ pub(crate) fn parse_policy_state_with_counters(
             action: default_policy.to_string(),
         })?
     };
+    // #3713: preflight rule-identity uniqueness BEFORE allocating any per-rule
+    // hit counter (`counter_store.rule_hit_counter`) or building a PolicyRule
+    // entry. The Rust parser is the ONLY enforcement plane in the retired-eBPF
+    // world; a corrupt / hand-built / mixed-version-HA-peer snapshot can carry
+    // two rules that resolve to an identical stable `rule_id` (an identical
+    // explicit wire rule_id, or an identical synthesized `from->to/name` key
+    // from a duplicate policy name in a zone pair) or an identical positional
+    // `policy_id`. Both alias the runtime identity: the rule_id is the
+    // get-or-insert key for `rule_hit_counter` (two rules would SHARE one
+    // `Arc<PolicyRuleCounter>` and collapse their totals onto one row), and the
+    // policy_id is the RT_FLOW / SESSION_CLOSE / display join key AND the
+    // last-writer-wins value in `rule_id_to_policy_id` (a duplicate lets an
+    // existing session re-resolve to the WRONG policy). Rejecting the WHOLE
+    // snapshot (this preflight is non-mutating, so the store keeps the previous
+    // good state; a fresh boot keeps the default-deny PolicyState) mirrors
+    // `DuplicateAddressBookId` and the #2124/#3261/#3367/#3711 fail-closed
+    // family. Run FIRST so no transient counter is observed for a snapshot that
+    // is then rejected (L14). The reserved implicit-default sentinel
+    // (`DEFAULT_POLICY_SENTINEL_ID`) is never carried by a configured rule and
+    // is excluded from the policy_id check (M01).
+    {
+        let mut seen_rule_ids: FxHashSet<String> = FxHashSet::default();
+        seen_rule_ids.reserve(rules.len());
+        let mut seen_policy_ids: FxHashSet<u32> = FxHashSet::default();
+        seen_policy_ids.reserve(rules.len());
+        for snap in rules {
+            let rule_id = stable_policy_rule_id(snap);
+            if !seen_rule_ids.insert(rule_id.clone()) {
+                return Err(SnapshotIntegrityError::DuplicateRuleId { rule_id });
+            }
+            if snap.policy_id != DEFAULT_POLICY_SENTINEL_ID
+                && !seen_policy_ids.insert(snap.policy_id)
+            {
+                return Err(SnapshotIntegrityError::DuplicatePolicyId {
+                    policy_id: snap.policy_id,
+                });
+            }
+        }
+    }
     // #3783: capture the concrete (interface-assignable) zone-id universe from
     // the incoming snapshot's zone table so `configured_zone_pairs` can
     // materialize the concrete pairs that a wildcard/global-only policy will

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -39,9 +39,13 @@ pub(crate) enum SnapshotIntegrityError {
     /// RT_FLOW / `SESSION_CLOSE` / display join key AND the value stored in
     /// `rule_id_to_policy_id` (last-writer-wins), so a duplicate lets an existing
     /// session re-resolve (#3395 live-row refresh) to the WRONG policy — wrong
-    /// attribution during incident response. The reserved implicit-default
-    /// sentinel (`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`) is never carried by a
-    /// configured rule and is excluded from the check (M01).
+    /// attribution during incident response. Two values are excluded from the
+    /// check (M01): the reserved implicit-default sentinel
+    /// (`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`), never carried by a configured
+    /// rule; and `0`, the `omitempty` wire zero-value that is both the valid
+    /// FIRST-policy id AND the "unspecified" value a pre-policy_id producer or
+    /// older HA peer leaves on every rule — rejecting duplicate-0 would
+    /// fail-close a legitimate older-peer / hand-built (all-zero) snapshot.
     DuplicatePolicyId { policy_id: u32 },
     UnknownAddressBookId { rule_id: String, book_id: u32 },
     /// #2124: a policy rule has at least one `application_terms` entry that
@@ -2507,9 +2511,11 @@ pub(crate) fn parse_policy_state_with_counters(
     // good state; a fresh boot keeps the default-deny PolicyState) mirrors
     // `DuplicateAddressBookId` and the #2124/#3261/#3367/#3711 fail-closed
     // family. Run FIRST so no transient counter is observed for a snapshot that
-    // is then rejected (L14). The reserved implicit-default sentinel
-    // (`DEFAULT_POLICY_SENTINEL_ID`) is never carried by a configured rule and
-    // is excluded from the policy_id check (M01).
+    // is then rejected (L14). The policy_id check (M01) excludes the reserved
+    // implicit-default sentinel (`DEFAULT_POLICY_SENTINEL_ID`) and the
+    // `omitempty` zero-value 0 (both the valid first-policy id AND the
+    // "unspecified" value an older/pre-policy_id producer leaves on every rule);
+    // see the per-value rationale at the check below.
     {
         let mut seen_rule_ids: FxHashSet<String> = FxHashSet::default();
         seen_rule_ids.reserve(rules.len());
@@ -2520,7 +2526,22 @@ pub(crate) fn parse_policy_state_with_counters(
             if !seen_rule_ids.insert(rule_id.clone()) {
                 return Err(SnapshotIntegrityError::DuplicateRuleId { rule_id });
             }
-            if snap.policy_id != DEFAULT_POLICY_SENTINEL_ID
+            // M01: only a real, ASSIGNED positional policy_id is checked for
+            // uniqueness. Two values are excluded:
+            //   - DEFAULT_POLICY_SENTINEL_ID (u32::MAX): the implicit default,
+            //     never carried by a configured rule.
+            //   - 0: the `omitempty` wire zero-value. It is simultaneously the
+            //     valid FIRST-policy id AND the "unspecified" value a
+            //     pre-policy_id (pre-#3056/#3057) producer or an older HA peer
+            //     leaves on EVERY rule. Rejecting a duplicate 0 would fail-close
+            //     a legitimate older-peer / hand-built snapshot that simply
+            //     omits policy_id (all-zero) — an availability regression during
+            //     a rolling upgrade, not the aliasing corruption this guards.
+            // A genuine collision of two DISTINCT rules on a real assigned
+            // (non-zero) positional policy_id is still caught: that is the
+            // RT_FLOW / SESSION_CLOSE / display join-key aliasing M01 targets.
+            if snap.policy_id != 0
+                && snap.policy_id != DEFAULT_POLICY_SENTINEL_ID
                 && !seen_policy_ids.insert(snap.policy_id)
             {
                 return Err(SnapshotIntegrityError::DuplicatePolicyId {

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -6296,3 +6296,135 @@ fn configured_zone_pairs_exact_only_not_overbroadened() {
         "exact-only config yields exactly its one pair"
     );
 }
+
+#[test]
+fn duplicate_synthesized_rule_id_fails_closed() {
+    // #3713: two rules with the SAME (from,to,name) synthesize the identical
+    // stable rule_id (`lan->wan/dup`) even though they carry DISTINCT positional
+    // policy_ids. Without the preflight both rules would get-or-insert the SAME
+    // Arc<PolicyRuleCounter> keyed by that rule_id, so counter_snapshots() would
+    // emit two rows with one collapsed total (hit-count mis-attribution).
+    // Reverting the fix returns Ok(state) with two rules sharing a counter, so
+    // this Err assertion is non-tautological (RED on revert).
+    let store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &[permit_snapshot("dup", 0), permit_snapshot("dup", 1)],
+        &test_zone_name_to_id(),
+        &[],
+        &store,
+    );
+    match result {
+        Err(SnapshotIntegrityError::DuplicateRuleId { rule_id }) => {
+            assert_eq!(rule_id, "lan->wan/dup");
+        }
+        other => panic!("expected DuplicateRuleId, got {other:?}"),
+    }
+}
+
+#[test]
+fn duplicate_explicit_wire_rule_id_fails_closed() {
+    // #3713: two rules with DISTINCT names/zone-pairs but the SAME explicit wire
+    // rule_id (a corrupt / mixed-version producer). stable_policy_rule_id returns
+    // the explicit rule_id verbatim, so both resolve to "wire-dup" and would
+    // share one hit counter and alias the RT_FLOW/session join key. Distinct
+    // policy_ids ensure the rule_id check (not the policy_id check) fires.
+    let store = PolicyCounterStore::default();
+    let a = PolicyRuleSnapshot {
+        rule_id: "wire-dup".to_string(),
+        name: "alpha".to_string(),
+        policy_id: 10,
+        from_zone: "lan".to_string(),
+        to_zone: "wan".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let b = PolicyRuleSnapshot {
+        rule_id: "wire-dup".to_string(),
+        name: "bravo".to_string(),
+        policy_id: 11,
+        from_zone: "trust".to_string(),
+        to_zone: "untrust".to_string(),
+        source_addresses: vec!["any".to_string()],
+        destination_addresses: vec!["any".to_string()],
+        applications: vec!["any".to_string()],
+        action: "permit".to_string(),
+        ..Default::default()
+    };
+    let result =
+        parse_policy_state_with_counters("deny", &[a, b], &test_zone_name_to_id(), &[], &store);
+    match result {
+        Err(SnapshotIntegrityError::DuplicateRuleId { rule_id }) => {
+            assert_eq!(rule_id, "wire-dup");
+        }
+        other => panic!("expected DuplicateRuleId, got {other:?}"),
+    }
+}
+
+#[test]
+fn duplicate_policy_id_fails_closed() {
+    // #3713 (M01): two rules with DISTINCT stable rule_ids (`lan->wan/p1`,
+    // `lan->wan/p2`) but the SAME positional policy_id (7). The Go builder
+    // assigns a unique policy_id per rule by construction; a duplicate is a
+    // corrupt / mixed-version snapshot. Without the reject, the last-writer-wins
+    // rule_id_to_policy_id map would let an existing session re-resolve to the
+    // wrong policy (#3395 live-row refresh). Reverting the fix returns Ok(state),
+    // so this Err assertion is non-tautological (RED on revert).
+    let store = PolicyCounterStore::default();
+    let result = parse_policy_state_with_counters(
+        "deny",
+        &[permit_snapshot("p1", 7), permit_snapshot("p2", 7)],
+        &test_zone_name_to_id(),
+        &[],
+        &store,
+    );
+    match result {
+        Err(SnapshotIntegrityError::DuplicatePolicyId { policy_id }) => {
+            assert_eq!(policy_id, 7);
+        }
+        other => panic!("expected DuplicatePolicyId, got {other:?}"),
+    }
+}
+
+#[test]
+fn distinct_rules_get_distinct_hit_counters() {
+    // #3713 positive control: two genuinely distinct rules (distinct stable
+    // rule_id AND distinct policy_id, including the valid first-policy id 0 which
+    // is NOT the u32::MAX sentinel) still parse cleanly and each gets its OWN
+    // hit-counter Arc — no shared/mis-attributed counting. This guards the
+    // preflight against over-rejecting a legitimate multi-rule snapshot.
+    let store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &[permit_snapshot("p1", 0), permit_snapshot("p2", 1)],
+        &test_zone_name_to_id(),
+        &[],
+        &store,
+    )
+    .expect("two distinct rules must parse cleanly");
+    assert_eq!(state.rules.len(), 2, "both distinct rules retained");
+    assert_ne!(
+        state.rules[0].rule_id, state.rules[1].rule_id,
+        "distinct rule_ids"
+    );
+    assert_ne!(
+        state.rules[0].policy_id, state.rules[1].policy_id,
+        "distinct policy_ids"
+    );
+    assert!(
+        !Arc::ptr_eq(&state.rules[0].hit_counter, &state.rules[1].hit_counter),
+        "distinct rules must NOT share one Arc<PolicyRuleCounter>"
+    );
+    // counter_snapshots() emits one row per distinct rule id (plus the reserved
+    // default-policy row), never two rows collapsed onto one shared total.
+    let ids: Vec<String> = state
+        .counter_snapshots()
+        .into_iter()
+        .map(|c| c.rule_id)
+        .collect();
+    assert!(ids.contains(&"lan->wan/p1".to_string()));
+    assert!(ids.contains(&"lan->wan/p2".to_string()));
+}

--- a/userspace-dp/src/policy_tests.rs
+++ b/userspace-dp/src/policy_tests.rs
@@ -6428,3 +6428,33 @@ fn distinct_rules_get_distinct_hit_counters() {
     assert!(ids.contains(&"lan->wan/p1".to_string()));
     assert!(ids.contains(&"lan->wan/p2".to_string()));
 }
+
+#[test]
+fn omitempty_zero_policy_ids_still_parse() {
+    // #3713 (M01) availability guard: `policy_id` is an `omitempty` wire u32, so
+    // a pre-policy_id (pre-#3056/#3057) producer or an older HA peer leaves it
+    // at 0 on EVERY rule. Two DISTINCT rules (distinct stable rule_ids) that
+    // both carry policy_id 0 must still parse — rejecting duplicate-0 would
+    // fail-close a legitimate older-peer / hand-built snapshot during a rolling
+    // upgrade. The DuplicatePolicyId check applies only to real assigned
+    // (non-zero, non-sentinel) positional ids. If the `!= 0` exclusion is
+    // removed this test goes RED (Err(DuplicatePolicyId { policy_id: 0 })).
+    let store = PolicyCounterStore::default();
+    let state = parse_policy_state_with_counters(
+        "deny",
+        &[permit_snapshot("a", 0), permit_snapshot("b", 0)],
+        &test_zone_name_to_id(),
+        &[],
+        &store,
+    )
+    .expect("all-zero omitempty policy_ids on distinct rules must still parse");
+    assert_eq!(state.rules.len(), 2);
+    assert_ne!(
+        state.rules[0].rule_id, state.rules[1].rule_id,
+        "distinct rule_ids keep distinct counters even at policy_id 0"
+    );
+    assert!(
+        !Arc::ptr_eq(&state.rules[0].hit_counter, &state.rules[1].hit_counter),
+        "distinct-rule_id rules never share a counter"
+    );
+}


### PR DESCRIPTION
Closes #3713

## Problem

The Rust policy snapshot parser (`parse_policy_state_with_counters`) had
NO uniqueness guard for a rule's stable `rule_id` or its positional
`policy_id`, even though it already hard-fails duplicate address-book ids
(`DuplicateAddressBookId`). A corrupt / hand-built / mixed-version HA
peer-sync snapshot could carry two rules that resolve to an identical
identity, and both aliases corrupt runtime state:

- **`rule_id` (H06):** it is the get-or-insert key for
  `PolicyCounterStore::rule_hit_counter`, so two rules with the same
  stable id — an identical explicit wire `rule_id`, or an identical
  synthesized `from->to/name` key from a duplicate policy name in one
  zone pair — SHARE one `Arc<PolicyRuleCounter>`. `counter_snapshots()`
  then emits two rows with the same id and the same collapsed totals
  (hit-count mis-attribution), and the same id is the RT_FLOW / session /
  display join key. A duplicate `rule_id` also last-writer-wins the
  `rule_id_to_policy_id` map.
- **`policy_id` (M01):** it is the RT_FLOW / `SESSION_CLOSE` / display
  join key, so a duplicate lets an existing session re-resolve (#3395
  live-row refresh) to the WRONG policy during incident response.

## Fix

Rust-only. A non-mutating rule-identity preflight in
`parse_policy_state_with_counters`, run as the FIRST validation (before
the book loop / rule loop), rejects:

- a duplicate resolved `rule_id` → new
  `SnapshotIntegrityError::DuplicateRuleId`;
- a duplicate real, ASSIGNED (non-zero, non-sentinel) `policy_id` → new
  `SnapshotIntegrityError::DuplicatePolicyId`.

Running before any per-rule counter is allocated means no transient
counter is get-or-inserted into the shared store for a snapshot that is
then rejected (L14). Rejecting the whole snapshot keeps the previous
good forwarding state (a fresh boot keeps the default-deny
`PolicyState`) — action-agnostic, mirroring `DuplicateAddressBookId` and
the #2124/#3261/#3367/#3711 fail-closed family.

The `policy_id` check excludes two values: the reserved implicit-default
sentinel (`DEFAULT_POLICY_SENTINEL_ID`, `u32::MAX`), and `0` — the
`omitempty` wire zero-value that is simultaneously the valid FIRST-policy
id AND the "unspecified" value a pre-`policy_id` (pre-#3056/#3057)
producer or an older HA peer leaves on EVERY rule. Rejecting a duplicate
`0` would fail-close a legitimate older-peer / hand-built (all-zero)
snapshot — an availability regression during a rolling upgrade, not the
aliasing corruption M01 guards. A genuine collision of two distinct
rules on a real assigned non-zero positional `policy_id` is still caught.

The Go builder (`walkPolicyRuleSlots`) already assigns each policy a
distinct positional `policy_id` and a distinct stable `rule_id` by
construction, so a clean commit never trips these; the Rust parser is the
only enforcement plane in the retired-eBPF world for a corrupt /
mixed-version snapshot. No wire-format change.

## Tests (RED on revert)

- `duplicate_synthesized_rule_id_fails_closed` — two rules with the same
  `from->to/name` (distinct policy_ids) → `DuplicateRuleId`.
- `duplicate_explicit_wire_rule_id_fails_closed` — two rules with
  distinct names but the same explicit wire `rule_id` → `DuplicateRuleId`.
- `duplicate_policy_id_fails_closed` — two distinct-`rule_id` rules
  sharing policy_id 7 → `DuplicatePolicyId`.
- `distinct_rules_get_distinct_hit_counters` — two genuinely distinct
  rules each get their OWN `Arc<PolicyRuleCounter>` (no shared /
  mis-attributed counting); policy_id 0 accepted.
- `omitempty_zero_policy_ids_still_parse` — two distinct rules both at
  policy_id 0 (older-peer / omitempty) still parse; RED if the `!= 0`
  exclusion is removed.

Full `cargo test --release`: 3427 passed, 0 failed (all groups green).
`go build ./...`, `go vet ./pkg/config/... ./pkg/dataplane/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
