### PR TITLE
userspace-dp: clamp per-application inactivity_timeout to 86400 s (#3714)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -27979,3 +27979,33 @@ top.
 - **File(s)**: userspace-dp/src/policy.rs (0-exclusion + comments),
   userspace-dp/src/policy_tests.rs (omitempty guard test),
   docs/userspace-dataplane-architecture.md (0-exclusion rationale)
+- **Timestamp**: 2026-07-02
+- **Action**: #3714 — clamp per-application inactivity_timeout to the Go/vSRX
+  86400 s commit bound in the Rust dataplane. Defect: the Rust policy path
+  accepted any u32 `inactivity_timeout` from a snapshot; the sole seconds→ns
+  conversion authority `session::app_inactivity_timeout_ns`
+  (`userspace-dp/src/session/mod.rs`) only saturated at the huge
+  `MAX_SESSION_TIMEOUT_NS` (~292 yr) overflow guard, so a corrupt / mixed-
+  version wire value (e.g. `4294967295`, from `PolicyApplicationSnapshot.
+  inactivity_timeout` OR the HA `SessionSyncRequest.inactivity_timeout`) stamped
+  an effectively never-expiring idle timeout (~136 yr) — diverging session GC
+  from the Go commit-time contract (`appTimeoutMax = 86400`,
+  `pkg/config/compiler_applications.go`, which REJECTS >86400 at commit). Fix:
+  added `APP_INACTIVITY_TIMEOUT_MAX_SECS = 86400` const and clamp the seconds
+  value via `s.min(APP_INACTIVITY_TIMEOUT_MAX_SECS)` before the ns conversion in
+  `app_inactivity_timeout_ns`. Chosen as the single chokepoint because BOTH the
+  local config-snapshot policy match and the HA session-sync receive funnel
+  through it, and the sync-SEND seconds is derived from the stamped ns — so the
+  clamp bounds every value that persists on a session or rides the sync wire.
+  Pure runtime backstop, no wire field changed (no protocol_wire_v1.json regen).
+  RED-on-revert test `app_inactivity_timeout_ns_clamps_to_go_commit_bound_3714`
+  (u32::MAX and 86401 clamp to 86400 s in ns; 86400/30 pass through exactly;
+  0/None → None) — verified RED with the clamp reverted, GREEN with it. Rust-
+  only (no Go change; the Go 86400 gate already exists). Not session-sync-
+  behavior-changing: legit values (≤86400) are unaffected on both send and
+  receive, so no test-failover regression risk (clamp only alters corrupt
+  >86400 wire values, which a well-formed peer never emits).
+- **File(s)**: userspace-dp/src/session/mod.rs (const +
+  app_inactivity_timeout_ns clamp + doc), userspace-dp/src/policy.rs
+  (parse_applications cross-reference comment), userspace-dp/src/session/tests.rs
+  (RED-on-revert unit test), userspace-dp/src/session/README.md (#3714 bound doc)

--- a/userspace-dp/src/policy.rs
+++ b/userspace-dp/src/policy.rs
@@ -4063,6 +4063,12 @@ fn parse_applications(terms: &[PolicyApplicationSnapshot]) -> ParsedApplications
             // compiled matcher so a session admitted by this term can stamp it.
             // A 0 seconds value collapses to None (use-global) so the override
             // is only set when the operator configured a positive timeout.
+            // #3714: the upper bound (86400 s, mirroring the Go `appTimeoutMax`
+            // commit gate) is enforced at the single seconds→ns conversion
+            // authority `session::app_inactivity_timeout_ns`, which every value
+            // that persists on a session or rides the sync wire funnels through
+            // — so a corrupt/mixed-version `4294967295` here is clamped before
+            // it can stamp a never-expiring idle timeout.
             inactivity_timeout: term.inactivity_timeout.filter(|&t| t > 0),
         });
     }

--- a/userspace-dp/src/session/README.md
+++ b/userspace-dp/src/session/README.md
@@ -67,7 +67,16 @@ term carries it. It rides the wire on `PolicyApplicationSnapshot.
 inactivity_timeout` (seconds, omitempty — 0/absent = use-global), is
 surfaced by the matcher as `PolicyEvaluationResult.inactivity_timeout`,
 and is stamped at install onto `SessionMetadata.inactivity_timeout_ns`
-(seconds->ns, saturating). `session_timeout_ns` then prefers that override
+(seconds->ns, saturating). **Bound (#3714):** `app_inactivity_timeout_ns`
+first clamps the seconds value to `APP_INACTIVITY_TIMEOUT_MAX_SECS`
+(86400 s) — the runtime backstop mirroring the Go commit gate
+`appTimeoutMax` (`pkg/config/compiler_applications.go`, which rejects
+`inactivity-timeout > 86400` at commit). Because that conversion is the
+single authority both the config-snapshot path and the HA session-sync
+receive funnel through, a corrupt / mixed-version wire value (e.g.
+`4294967295`) is clamped rather than stamping an effectively
+never-expiring idle timeout that would diverge session GC from the
+commit-time contract. `session_timeout_ns` then prefers that override
 for the established TCP / UDP / ICMP idle window on install AND on every
 real-traffic refresh (`lookup.rs` / `update_session`), so the conntrack
 GC ages the flow out on the app's value. It deliberately does NOT extend

--- a/userspace-dp/src/session/mod.rs
+++ b/userspace-dp/src/session/mod.rs
@@ -188,17 +188,42 @@ pub(crate) fn secs_to_ns_saturating(secs: u64) -> u64 {
         .min(MAX_SESSION_TIMEOUT_NS)
 }
 
+/// #3714: upper bound (in SECONDS) on a per-application inactivity timeout,
+/// mirroring the Go commit-time gate `appTimeoutMax = 86400`
+/// (`pkg/config/compiler_applications.go`). Go rejects a custom
+/// `set applications application <a> inactivity-timeout <n>` with `n > 86400`
+/// at commit, so a well-formed snapshot never carries a larger value; this
+/// const is the runtime backstop that clamps a corrupt / mixed-version wire
+/// value (config-snapshot `PolicyApplicationSnapshot.inactivity_timeout` OR the
+/// HA `SessionSyncRequest.inactivity_timeout`) so a bogus `4294967295` cannot
+/// stamp an effectively never-expiring idle timeout — diverging session GC from
+/// the commit-time contract. This is the per-application analogue of the
+/// `MAX_SESSION_TIMEOUT_SECS` overflow backstop above: the Go side is the
+/// operator-facing reject, this bound is the dataplane's clamp. Keep the two
+/// values in lockstep with the Go `appTimeoutMax`.
+pub(crate) const APP_INACTIVITY_TIMEOUT_MAX_SECS: u32 = 86400;
+
 /// #3227: convert a matched application's per-application inactivity timeout
 /// (`PolicyEvaluationResult.inactivity_timeout`, in SECONDS) to the nanosecond
 /// session override stamped on `SessionMetadata.inactivity_timeout_ns`. `None`
 /// (or 0 seconds) maps to `None` (use the global per-protocol timeout — the
-/// historical behavior); a positive value saturates at `MAX_SESSION_TIMEOUT_NS`
-/// exactly like a configured global timeout, so a pathological config cannot
-/// wrap into a tiny window.
+/// historical behavior); a positive value is first clamped to
+/// `APP_INACTIVITY_TIMEOUT_MAX_SECS` (#3714 — mirrors the Go 86400 s commit
+/// gate so a corrupt/mixed-version wire value can't produce a never-expiring
+/// session) and then saturates at `MAX_SESSION_TIMEOUT_NS`, so a pathological
+/// config cannot wrap into a tiny window.
+///
+/// This is the single seconds→ns conversion authority for BOTH ingress paths —
+/// the local config-snapshot policy match (`parse_applications` →
+/// `PolicyEvaluationResult`) and the HA session-sync receive
+/// (`SessionSyncRequest.inactivity_timeout`) — so clamping here bounds every
+/// value that persists on a session or rides the sync wire to a peer.
 #[inline]
 pub(crate) fn app_inactivity_timeout_ns(secs: Option<u32>) -> Option<u64> {
     match secs {
-        Some(s) if s > 0 => Some(secs_to_ns_saturating(u64::from(s))),
+        Some(s) if s > 0 => Some(secs_to_ns_saturating(u64::from(
+            s.min(APP_INACTIVITY_TIMEOUT_MAX_SECS),
+        ))),
         _ => None,
     }
 }

--- a/userspace-dp/src/session/tests.rs
+++ b/userspace-dp/src/session/tests.rs
@@ -2406,6 +2406,51 @@ fn from_seconds_saturates_u64_max() {
     assert!(t.tcp_established_ns > DEFAULT_TCP_SESSION_TIMEOUT_NS);
 }
 
+/// #3714: a per-application inactivity timeout must be clamped to the Go
+/// `appTimeoutMax` (86400 s) before the seconds→ns conversion. The Go compiler
+/// rejects `inactivity-timeout > 86400` at commit, so a well-formed snapshot
+/// never carries a larger value; a corrupt / mixed-version wire value (e.g.
+/// `4294967295`) must NOT stamp an effectively never-expiring idle timeout.
+/// Reverting the `s.min(APP_INACTIVITY_TIMEOUT_MAX_SECS)` clamp makes the two
+/// over-bound assertions go RED (they would return the raw seconds in ns).
+#[test]
+fn app_inactivity_timeout_ns_clamps_to_go_commit_bound_3714() {
+    let max_ns = u64::from(APP_INACTIVITY_TIMEOUT_MAX_SECS) * 1_000_000_000;
+
+    // The pin: a corrupt u32::MAX snapshot value must clamp to 86400 s, NOT
+    // stamp ~136 years (4294967295 * 1e9 ns) of retention.
+    assert_eq!(
+        app_inactivity_timeout_ns(Some(u32::MAX)),
+        Some(max_ns),
+        "u32::MAX inactivity_timeout must clamp to the 86400 s commit bound"
+    );
+    // One second over the bound clamps to exactly the bound.
+    assert_eq!(
+        app_inactivity_timeout_ns(Some(APP_INACTIVITY_TIMEOUT_MAX_SECS + 1)),
+        Some(max_ns),
+        "86401 s must clamp to the 86400 s commit bound"
+    );
+
+    // No regression at/under the bound: exact conversion, no clamp artifacts.
+    assert_eq!(
+        app_inactivity_timeout_ns(Some(APP_INACTIVITY_TIMEOUT_MAX_SECS)),
+        Some(max_ns),
+        "the exact 86400 s bound converts exactly (in range)"
+    );
+    assert_eq!(
+        app_inactivity_timeout_ns(Some(30)),
+        Some(30 * 1_000_000_000),
+        "a normal 30 s app timeout converts exactly, unaffected by the clamp"
+    );
+    // 0 / None keep meaning "use the global per-protocol timeout".
+    assert_eq!(
+        app_inactivity_timeout_ns(Some(0)),
+        None,
+        "0 s means use-global (None), not the clamp bound"
+    );
+    assert_eq!(app_inactivity_timeout_ns(None), None, "None stays None");
+}
+
 #[test]
 fn from_seconds_zero_still_defaults_after_saturation() {
     // 0 must remain "use the default", unaffected by the saturation helper.


### PR DESCRIPTION
## Summary

Closes #3714.

The Rust policy path accepted any `u32` `inactivity_timeout` from a config snapshot, while the Go compiler caps a custom application timeout at `appTimeoutMax = 86400` seconds (`pkg/config/compiler_applications.go`), rejecting anything larger at commit. The sole seconds→ns conversion authority `session::app_inactivity_timeout_ns` (`userspace-dp/src/session/mod.rs`) only saturated at the huge `MAX_SESSION_TIMEOUT_NS` overflow guard (~292 years), so a corrupt / mixed-version wire value (e.g. `4294967295`) stamped an effectively never-expiring idle timeout (~136 years) on a matching session — diverging session GC from the commit-time contract and inflating state retention under attack or config corruption (codex-review-152 M03).

## Defect (file:line)

- Rust ingress accepts an unbounded value: `parse_applications` (`userspace-dp/src/policy.rs` ~L3975) does `term.inactivity_timeout.filter(|&t| t > 0)` — collapses 0 → use-global but applies **no** upper bound.
- The seconds→ns conversion `app_inactivity_timeout_ns` (`userspace-dp/src/session/mod.rs` ~L199) only saturated at `MAX_SESSION_TIMEOUT_NS` (`i64::MAX/1e9` s), never at the per-application 86400 s contract bound.
- Go side already enforces the bound: `appTimeoutMax = 86400` (`pkg/config/compiler_applications.go:23`), rejected at commit.

## Fix

Added `APP_INACTIVITY_TIMEOUT_MAX_SECS = 86400` and clamp the seconds value (`s.min(APP_INACTIVITY_TIMEOUT_MAX_SECS)`) before the ns conversion in `app_inactivity_timeout_ns`. This is the single chokepoint that **both** the local config-snapshot policy match (`parse_applications` → `PolicyEvaluationResult`) **and** the HA session-sync receive (`SessionSyncRequest.inactivity_timeout` → `server/helpers.rs`) funnel through; the sync-**send** seconds is derived from the stamped ns, so the clamp bounds every value that persists on a session or rides the sync wire. It is the per-application analogue of the existing `MAX_SESSION_TIMEOUT_SECS` backstop — Go is the operator-facing reject, this const is the dataplane's runtime clamp.

No wire field changed (no `protocol_wire_v1.json` regeneration). Rust-only — no Go change (the Go gate already exists).

## Validation

- RED-on-revert test `app_inactivity_timeout_ns_clamps_to_go_commit_bound_3714`: asserts `u32::MAX` and `86401` clamp to 86400 s (in ns); `86400` and `30` s pass through exactly; `0`/`None` → `None` (use-global). **Verified RED** with the clamp reverted (`assertion failed: u32::MAX inactivity_timeout must clamp to the 86400 s commit bound`) and GREEN with it.
- Full `cargo test --release` green: 3498 passed, 0 failed.
- `session/README.md` timeout doc updated with the #3714 bound.

## Failover note

Not session-sync-behavior-changing for a well-formed peer: legitimate values (≤ 86400) are unaffected on both send and receive; the clamp only alters corrupt/mixed-version `> 86400` wire values a well-formed peer never emits. No `test-failover` regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi