### PR TITLE
filter: reword stale port-except fail-OPEN comments to match #3205 fail-closed matcher (#3716)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28009,3 +28009,30 @@ top.
   app_inactivity_timeout_ns clamp + doc), userspace-dp/src/policy.rs
   (parse_applications cross-reference comment), userspace-dp/src/session/tests.rs
   (RED-on-revert unit test), userspace-dp/src/session/README.md (#3714 bound doc)
+
+- **Timestamp**: 2026-07-02
+- **Action**: #3716 doc-accuracy — reword stale port-except fail-OPEN comments
+  to match the #3205 fail-CLOSED matcher; add a positive-wins boundary pin test.
+  ROOT: two invariant comments (Rust `filter/mod.rs`, Go `compiler_firewall.go`)
+  and one design doc (`docs/config-schema.md`) still described the pre-#3205
+  port-except fail-OPEN behavior ("an except term whose port list ALL fails to
+  parse means match all ports except {} = match ALL"). The code has fail-CLOSED
+  since #3205: `port_match` (userspace-dp/src/filter/engine/matching.rs:310-316)
+  returns `false` for `constrained && PortMatcher::Any` in BOTH the positive AND
+  the except direction — the term matches NOTHING, never all-ports. VERIFIED the
+  code is fail-closed before touching anything; this is COMMENT-vs-code drift, no
+  behavior change. Reworded `mod.rs` struct invariant (164-176) and the Go
+  `destination-port-except` case comment to state fail-CLOSED + contrast the
+  ADDRESS empty-except path (which legitimately keeps match-ALL). Fixed the
+  mirrored stale claim in `docs/config-schema.md`. Bug C (H06, positive+except
+  snapshot): made the `filter/compiler.rs` positive-wins selection contract
+  explicit (references the #3297 Go strict gate `validateFilterPortExceptStrict`
+  that rejects both-present at commit; positive-wins is a deliberate narrowing,
+  never a widening, so fail-safe without a SnapshotIntegrityError) and added a
+  RED-on-revert pin test `port_both_positive_and_except_positive_wins_3716`
+  (port 9999 → Accept under positive-wins, would DISCARD under except-wins).
+- **File(s)**: userspace-dp/src/filter/mod.rs (struct invariant reword),
+  pkg/config/compiler_firewall.go (destination-port-except comment reword),
+  docs/config-schema.md (mirrored stale claim + test list),
+  userspace-dp/src/filter/compiler.rs (positive-wins contract comment),
+  userspace-dp/src/filter/tests.rs (#3716 positive-wins pin test)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -2632,20 +2632,33 @@ positive port slices, both AST shapes).
 (`filter/compiler.rs`) selects ONE port spec list per direction — the
 positive list if it carries real entries, otherwise the `-except` list — and
 sets a per-direction `source_port_except` / `dest_port_except` inversion flag
-on `FilterTerm` (positive wins if both are somehow present). The matcher
-`port_match` (`filter/engine/matching.rs`) now evaluates
-`matcher.matches(port) XOR except`, mirroring the address `nets_match_v4` /
-`nets_match_v6` `except` semantics: an except term whose port list ALL
-fails to parse means "match all ports except {}" = match ALL (vs the
-positive all-malformed fail-closed = match NOTHING). The wire specimen
-`userspace-dp/tests/fixtures/protocol_wire_v1.json` was regenerated for the
-two new fields. Regression coverage:
+on `FilterTerm`. A positive port match and its `*-port-except` counterpart are
+mutually exclusive in the same direction; the Go commit gate
+`validateFilterPortExceptStrict` (#3297) rejects a term carrying both, and the
+Rust compiler resolves a drifted/leniently-loaded snapshot that has both as
+positive-wins (the except list is ignored — a deliberate narrowing, never a
+widening). The matcher `port_match` (`filter/engine/matching.rs`) evaluates
+`matcher.matches(port) XOR except` for a RESOLVED port set, mirroring the
+address `nets_match_v4` / `nets_match_v6` `except` inversion. #3205 hardened
+the all-malformed case: an except term whose port list ALL fails to parse
+(constrained + empty `PortMatcher::Any`) FAILS CLOSED = match NOTHING in BOTH
+directions — NOT "match all ports except {}" = match ALL. A port scope has no
+prefix-list indirection, so `constrained + Any` can only mean every token was
+unparseable; `validateFilterMatchValuesStrict` rejects such a term at commit,
+making the fail-closed matcher defense-in-depth on the tolerant load / peer-
+sync path. (The empty-except = match-ALL semantic still applies to the ADDRESS
+path, where an empty prefix-list scope is reachable and legitimate.) The wire
+specimen `userspace-dp/tests/fixtures/protocol_wire_v1.json` was regenerated
+for the two new fields. Regression coverage:
 `pkg/config/firewall_port_except_2622_test.go` (hierarchical + flat-set
 bracket list + inet6, fail-on-revert) and the Rust matcher
 `destination_port_except_negation` / `source_port_except_negation`
 (a port IN the except list does NOT match; a port NOT in it DOES —
-fail-on-revert). Scope: ports only; `packet-length` from the same
-review-039 finding is NOT implemented here.
+fail-on-revert), plus `destination_port_except_unresolved_fails_closed_3205` /
+`destination_port_except_resolved_name_matches_3205` (#3205 fail-closed) and
+`port_both_positive_and_except_positive_wins_3716` (#3716 positive-wins
+boundary pin). Scope: ports only; `packet-length` from the same review-039
+finding is NOT implemented here.
 
 ### #2053 — Config secret redaction at JSON/YAML marshal time
 

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -307,8 +307,15 @@ func compileFilterFrom(node *Node, term *FirewallFilterTerm, family string) {
 			// #2622 negated port match: match all destination ports EXCEPT
 			// these. Multi-value/bracket-list, same accumulation as the
 			// positive destination-port case. #3205: resolve named ports and
-			// record unresolved tokens — an unresolved except port that slips
-			// through fails OPEN (matches all ports) in the dataplane.
+			// record unresolved tokens. An unresolved except port is
+			// hard-rejected at commit by validateFilterMatchValuesStrict, so an
+			// operator never reaches the dataplane with one. If a leniently
+			// loaded / peer-synced snapshot still carries an unresolved token,
+			// the Rust dataplane now fails CLOSED: port_match returns false for
+			// a constrained term with an empty PortMatcher::Any in BOTH
+			// directions, so the except term matches NOTHING (not all ports).
+			// Pre-#3205 this except case failed OPEN — an unresolved except port
+			// matched every port, including the one it was meant to exclude.
 			term.DestPortsExcept = append(term.DestPortsExcept, resolveFilterPortTokens(firewallMatchValues(child), term)...)
 		case "source-port-except":
 			term.SourcePortsExcept = append(term.SourcePortsExcept, resolveFilterPortTokens(firewallMatchValues(child), term)...)

--- a/userspace-dp/src/filter/compiler.rs
+++ b/userspace-dp/src/filter/compiler.rs
@@ -650,12 +650,22 @@ fn parse_term(
     }
     // #2622: a direction's port scope is either the positive `source-port` /
     // `destination-port` list OR the negated `source-port-except` /
-    // `destination-port-except` list (Junos treats them as mutually exclusive).
-    // Build ONE PortMatcher per direction from whichever list carries entries,
-    // and set `*_port_except` when the except list is the source. If both are
-    // somehow present, the positive list builds the matcher and the except list
-    // is ignored (positive wins) — the except flag stays false so the positive
-    // set is honored verbatim.
+    // `destination-port-except` list (Junos treats them as mutually exclusive,
+    // and the Go commit gate `validateFilterPortExceptStrict` — #3297 — rejects
+    // a term that carries both). Build ONE PortMatcher per direction from
+    // whichever list carries entries, and set `*_port_except` when the except
+    // list is the source.
+    //
+    // #3716 positive-wins boundary contract: because #3297 rejects both-present
+    // at commit, this only fires for a hand-built / version-drifted / leniently
+    // loaded snapshot. When it does, the positive list builds the matcher and
+    // the except list is IGNORED (positive wins) — the except flag stays false
+    // so the positive set is honored verbatim. That is a deliberate NARROWING
+    // (the term matches only the positive ports, strictly tighter than the
+    // operator-authored except would have been), never a widening, so it is
+    // fail-safe at the Rust boundary even without a SnapshotIntegrityError. The
+    // status is pinned by `port_both_positive_and_except_positive_wins_3716` in
+    // tests.rs so a future change to this selection is caught.
     let source_port_except = snap.source_ports.iter().all(|p| !port_is_real(p))
         && snap.source_ports_except.iter().any(|p| port_is_real(p));
     let dest_port_except = snap.destination_ports.iter().all(|p| !port_is_real(p))

--- a/userspace-dp/src/filter/mod.rs
+++ b/userspace-dp/src/filter/mod.rs
@@ -161,10 +161,21 @@ pub(crate) struct FilterTerm {
     // matches every port NOT in the source/dest port set:
     // `(port ∈ ranges) XOR except`. The except port list builds the SAME
     // PortMatcher and sets `*_port_constrained`; only the inversion differs.
-    // When the except list is non-empty but ALL entries fail to parse
-    // (PortMatcher::Any while constrained), the term means "match all ports
-    // except {}" = match ALL — handled in port_match. Only meaningful when the
-    // direction is `*_port_constrained`.
+    // #3205 FAIL-CLOSED: when the except list is non-empty but ALL entries fail
+    // to parse (`PortMatcher::Any` while constrained), the term matches NOTHING
+    // — NOT "match all ports except {}" = match ALL. `port_match`
+    // (engine/matching.rs) returns false for `constrained && PortMatcher::Any`
+    // in BOTH the positive and the except direction, so an unresolved
+    // `destination-port-except <name>` can never invert an empty set into
+    // match-ALL (that was the pre-#3205 fail-OPEN hole that accepted the very
+    // port it was meant to exclude). This intentionally DIFFERS from the ADDRESS
+    // empty-except path (`nets_match_v4`/`nets_match_v6`, which returns `except`
+    // → match-ALL): a port scope has no prefix-list indirection, so
+    // `constrained && Any` can ONLY mean every token was unparseable — never a
+    // legitimately empty scope — whereas an empty address prefix-list scope IS
+    // reachable and legitimate and keeps the Junos "match all except {}" =
+    // match-ALL semantic. Only meaningful when the direction is
+    // `*_port_constrained`.
     pub(crate) source_port_except: bool,
     pub(crate) dest_port_except: bool,
     pub(crate) dscp_bitmap: u64,

--- a/userspace-dp/src/filter/tests.rs
+++ b/userspace-dp/src/filter/tests.rs
@@ -7826,3 +7826,98 @@ fn destination_port_except_resolved_name_matches_3205() {
         "port 9999 is NOT excepted, must match the discard term"
     );
 }
+
+// === #3716: a snapshot carrying BOTH a positive and an except port list for
+// one direction resolves POSITIVE-WINS at the Rust boundary ===
+//
+// The Go commit gate `validateFilterPortExceptStrict` (#3297) rejects a term
+// that sets both `destination-port` and `destination-port-except`, so a
+// committed config never reaches the dataplane in this shape. A hand-built /
+// version-drifted / leniently-loaded snapshot still can, and the compiler
+// (filter/compiler.rs) resolves it deterministically as POSITIVE-WINS: the
+// positive list builds the matcher and the except list is IGNORED (the except
+// inversion flag stays false). That is a deliberate NARROWING — the term
+// matches only the positive ports, strictly tighter than the operator-authored
+// except would have been — never a widening, so it is fail-safe at the Rust
+// boundary even without a SnapshotIntegrityError.
+//
+// FAIL-ON-REVERT: change the compiler's selection to except-wins (make the
+// except list win, or set the except flag, when both are present) and the
+// port-9999 assertion below flips from Accept to Discard -> RED.
+#[test]
+fn port_both_positive_and_except_positive_wins_3716() {
+    let state = make_filter_state(
+        &[FirewallFilterSnapshot {
+            name: "f".into(),
+            family: "inet".into(),
+            terms: vec![FirewallTermSnapshot {
+                name: "discard-both".into(),
+                protocols: vec!["tcp".into()],
+                // Both lists on the same direction (Junos-invalid; the #3297 Go
+                // gate rejects it, so only a drifted snapshot lands here).
+                // Positive wins: matcher = {22}, the except list is IGNORED.
+                destination_ports: vec!["22".into()],
+                destination_ports_except: vec!["443".into()],
+                action: "discard".into(),
+                ..Default::default()
+            }],
+        }],
+        &[],
+    );
+    // Port 22 IS in the positive set -> the term matches -> discard.
+    let r = evaluate_filter(
+        &state,
+        "inet:f",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        54321,
+        22,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Discard,
+        "positive-wins: port 22 is in the positive set, must match the discard term"
+    );
+    // Port 9999 is NOT in the positive set {22} -> no match -> implicit accept.
+    // Under except-wins (match every port != 443) this would DISCARD -> RED.
+    let r = evaluate_filter(
+        &state,
+        "inet:f",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        54321,
+        9999,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Accept,
+        "positive-wins: port 9999 is NOT in the positive set {{22}} and the except \
+         list is IGNORED, so the term does NOT match — a revert to except-wins \
+         (match every port except 443) would DISCARD this (#3716)"
+    );
+    // The (ignored) except entry 443 is also not in the positive set {22}, so it
+    // too falls through to implicit accept — confirming the except list is dropped.
+    let r = evaluate_filter(
+        &state,
+        "inet:f",
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
+        PROTO_TCP,
+        54321,
+        443,
+        0,
+        TermMatchExtra::default(),
+    );
+    assert_eq!(
+        r.action,
+        FilterAction::Accept,
+        "positive-wins: the except entry 443 is IGNORED; 443 is not in the positive \
+         set {{22}} so the term does not match"
+    );
+}


### PR DESCRIPTION
Closes #3716

## Summary
Two invariant comments and one design doc still described the **pre-#3205**
port-except fail-OPEN behavior — the OPPOSITE security rule from the code, which
has failed **closed** since #3205. In a security appliance a maintainer reading
these could "fix" the code back to the fail-open. This is a doc-accuracy fix:
**the code is already correct and is not changed.**

### Verified fail-closed (before touching anything)
`port_match` at `userspace-dp/src/filter/engine/matching.rs:310-316` returns
`false` for a constrained term with an empty `PortMatcher::Any` in **both** the
positive and the except direction:

```rust
fn port_match(constrained: bool, except: bool, matcher: &PortMatcher, port: u16) -> bool {
    if constrained && matches!(matcher, PortMatcher::Any) {
        return false; // #3205: fail CLOSED both ways
    }
    matcher.matches(port) ^ except
}
```

So an unresolved `destination-port-except <name>` can never invert an empty set
into match-ALL. The existing `destination_port_except_unresolved_fails_closed_3205`
test guards this. This is comment-vs-code drift, not a live fail-open.

## Changes
- **`userspace-dp/src/filter/mod.rs` (H04)** — the `*_port_except` struct
  invariant said a constrained empty except set means "match all ports except {}
  = match ALL". Reworded to state fail-CLOSED (match NOTHING both directions) and
  contrast the ADDRESS empty-except path (`nets_match_v4`/`nets_match_v6`), which
  legitimately keeps the Junos match-ALL semantic because an empty prefix-list
  scope is reachable whereas a port scope has no prefix-list indirection
  (M10/L15).
- **`pkg/config/compiler_firewall.go` (H05)** — the `destination-port-except`
  comment claimed an unresolved except port "fails OPEN (matches all ports) in
  the dataplane". Reworded: commit is gated by `validateFilterMatchValuesStrict`;
  a leniently-loaded / peer-synced unresolved token now fails CLOSED in Rust;
  pre-#3205 it failed open.
- **`docs/config-schema.md`** — fixed the mirrored "match all ports except {} =
  match ALL" claim and extended the test-coverage list.
- **`userspace-dp/src/filter/compiler.rs` + `tests.rs` (H06)** — made the
  positive-wins boundary contract explicit (references the #3297 Go strict gate
  `validateFilterPortExceptStrict` that rejects both-present at commit;
  positive-wins is a deliberate narrowing, never a widening, so fail-safe without
  a `SnapshotIntegrityError`) and added a RED-on-revert pin test
  `port_both_positive_and_except_positive_wins_3716`.

## Testing
- `cargo test --release` (full, unfiltered): 3433 + 46 + 8 + 16 + 1 passed, 0 failed.
- `port_both_positive_and_except_positive_wins_3716` verified RED-on-revert by
  temporarily forcing except-wins selection (port 9999 flips Accept -> Discard).
- `go test ./pkg/config/ -run 'Filter|PortExcept|Firewall'` — ok.

No code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi