### PR TITLE
firewall: read both AST shapes for prefix-list-ref leaf (#3843)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28036,3 +28036,27 @@ top.
   docs/config-schema.md (mirrored stale claim + test list),
   userspace-dp/src/filter/compiler.rs (positive-wins contract comment),
   userspace-dp/src/filter/tests.rs (#3716 positive-wins pin test)
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3843 — fix HIGH fail-open: a firewall-filter term with a
+  HIERARCHICAL single-name `source/destination-prefix-list <name>;` leaf (the
+  `load merge`/config-file shape, where the name rides on `child.Keys[1]` with
+  ZERO children) had its scoping constraint SILENTLY DROPPED —
+  `compileFilterFrom` iterated only `child.Children` and never read
+  `child.Keys[1]`, so the term compiled UNSCOPED (implicit match-all) yet passed
+  strict commit cleanly. Same for `destination-prefix-list`. This is the #2419
+  dual-AST-shape class on the prefix-list-ref leaf (distinct from the #2506
+  dataplane-snapshot resolver). FIX: new helper `firewallPrefixListRefs` reads
+  BOTH `child.Keys[1:]` (single-name / flat leaf, grouping each `<name>
+  [except]` pair) AND `child.Children` (block / flat-set), so the scope survives
+  every shape; an unresolvable name is then hard-rejected by
+  `validateFirewallPrefixListReferencesStrict` (#2506), making a dropped scope
+  impossible (fail-closed). RED-on-revert test proven: reverting the
+  `child.Keys[1:]` read makes all four single-name assertions go RED (scope →
+  nil refs; undefined `source-prefix-list ghost;` silently accepted). Flat-set +
+  block-form shapes still scope correctly. go test ./pkg/config/... green; go
+  build ./... green; gofmt + vet clean.
+- **File(s)**: pkg/config/compiler_firewall.go (firewallPrefixListRefs helper +
+  rewired source/destination-prefix-list cases),
+  pkg/config/compiler_prefix_list_hier_leaf_3843_test.go (new RED-on-revert
+  tests), docs/config-schema.md (dual-AST prefix-list-ref note)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -108,6 +108,33 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**Firewall-filter `source/destination-prefix-list` refs are dual-AST too
+(#3843).** These `from` leaves are NOT `multi: true` value-tails — each
+reference carries an optional trailing `except` modifier, so they compile
+through a dedicated helper `firewallPrefixListRefs` (`compiler_firewall.go`)
+rather than `firewallMatchValues`. The helper reads BOTH shapes and groups each
+`<name> [except]` pair:
+
+- **hierarchical single-name leaf** `source-prefix-list plX;` /
+  `source-prefix-list plX except;` — the name(s) ride on `child.Keys[1:]` with
+  ZERO children (the `load merge` / config-file shape).
+- **hierarchical block** `source-prefix-list { pl1; pl2 except; }` and
+  **flat-set** `set ... source-prefix-list plX except` — one child node per
+  referenced list (`child.Children`).
+
+Before #3843 the `source/destination-prefix-list` case iterated only
+`child.Children`, so the single-name leaf shape had its scope SILENTLY DROPPED:
+the term compiled with NO prefix-list refs (implicit match-all) yet passed
+strict commit cleanly — a HIGH fail-open (the #2419 dual-AST class on the
+prefix-list-ref leaf, distinct from the #2506 dataplane-snapshot resolver).
+Because the dropped ref never reached `term.SourcePrefixLists`, the
+`validateFirewallPrefixListReferencesStrict` gate (#2506) had nothing to check
+and an undefined name also slipped through. Reading `child.Keys[1:]` guarantees
+the scope survives; an unresolvable name is then hard-rejected at commit, so a
+dropped scope is impossible. Coverage:
+`compiler_prefix_list_hier_leaf_3843_test.go` (single-name source/dest/except +
+undefined-reject fail-on-revert, plus block / flat-set regression guards).
+
 **NAT `match` axes are multi-value (#3431).** The source/destination NAT rule
 `match` leaves `application`, `protocol` (DNAT), `source-address-name`, and
 `destination-address-name` are all `multi: true` (alongside the already-plural

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -253,6 +253,55 @@ func firewallMatchValues(child *Node) []string {
 	return vals
 }
 
+// firewallPrefixListRefs extracts every prefix-list reference carried by a
+// firewall-filter `from source-prefix-list` / `destination-prefix-list` match
+// node, across BOTH parser AST shapes (#3843 — the prefix-list-ref instance of
+// the #2419 dual-shape class):
+//
+//   - hierarchical single-name leaf  `source-prefix-list plX;`
+//     → Keys=["source-prefix-list","plX"], no children
+//     hierarchical single-name+except `source-prefix-list plX except;`
+//     → Keys=["source-prefix-list","plX","except"], no children
+//   - hierarchical block             `source-prefix-list { pl1; pl2 except; }`
+//     → one child node per name (child.Keys=["pl1"] / ["pl2","except"])
+//   - flat set command               `set ... source-prefix-list plX except`
+//     → one child node (child.Keys=["plX"] / ["plX","except"])
+//
+// The single-name leaf shape was SILENTLY DROPPED before #3843: the caller only
+// iterated child.Children and never read child.Keys[1], so a `load merge`/config-
+// file term compiled with NO prefix-list scope (implicit match-all) yet passed
+// strict commit cleanly — a fail-open. Reading BOTH child.Keys[1:] AND
+// child.Children guarantees the scope survives every shape; an unresolvable name
+// is still hard-rejected by validateFirewallPrefixListReferencesStrict, so a
+// dropped scope is impossible (fail-closed).
+func firewallPrefixListRefs(child *Node) []PrefixListRef {
+	var refs []PrefixListRef
+	// A token slice is a sequence of `<name> [except]` groups: an `except`
+	// modifier attaches to the prefix-list name immediately preceding it.
+	appendTokens := func(tokens []string) {
+		for i := 0; i < len(tokens); {
+			name := tokens[i]
+			i++
+			if name == "" {
+				continue
+			}
+			ref := PrefixListRef{Name: name}
+			if i < len(tokens) && tokens[i] == "except" {
+				ref.Except = true
+				i++
+			}
+			refs = append(refs, ref)
+		}
+	}
+	// Single-name / flat leaf shape: the name(s) ride on this node's own Keys.
+	appendTokens(child.Keys[1:])
+	// Block / flat-set shape: one child node per referenced prefix-list.
+	for _, plNode := range child.Children {
+		appendTokens(plNode.Keys)
+	}
+	return refs
+}
+
 // compileFilterFrom compiles a firewall-filter term's `from` match block. The
 // family ("inet" / "inet6") selects the ICMPv4 vs ICMPv6 icmp-type name table
 // when resolving symbolic icmp-type values (#3205).
@@ -285,22 +334,14 @@ func compileFilterFrom(node *Node, term *FirewallFilterTerm, family string) {
 			// unresolved token for the strict commit gate (fail closed).
 			term.DestinationPorts = append(term.DestinationPorts, resolveFilterPortTokens(firewallMatchValues(child), term)...)
 		case "source-prefix-list":
-			// Block form: source-prefix-list { mgmt-hosts except; }
-			for _, plNode := range child.Children {
-				ref := PrefixListRef{Name: plNode.Keys[0]}
-				if len(plNode.Keys) >= 2 && plNode.Keys[1] == "except" {
-					ref.Except = true
-				}
-				term.SourcePrefixLists = append(term.SourcePrefixLists, ref)
-			}
+			// #3843: read BOTH the single-name leaf shape
+			// (`source-prefix-list plX;` → child.Keys[1:]) AND the block /
+			// flat-set shape (`source-prefix-list { plX except; }` /
+			// `set ... source-prefix-list plX` → child.Children). Iterating
+			// only child.Children silently dropped the leaf-shape scope.
+			term.SourcePrefixLists = append(term.SourcePrefixLists, firewallPrefixListRefs(child)...)
 		case "destination-prefix-list":
-			for _, plNode := range child.Children {
-				ref := PrefixListRef{Name: plNode.Keys[0]}
-				if len(plNode.Keys) >= 2 && plNode.Keys[1] == "except" {
-					ref.Except = true
-				}
-				term.DestPrefixLists = append(term.DestPrefixLists, ref)
-			}
+			term.DestPrefixLists = append(term.DestPrefixLists, firewallPrefixListRefs(child)...)
 		case "source-port":
 			term.SourcePorts = append(term.SourcePorts, resolveFilterPortTokens(firewallMatchValues(child), term)...)
 		case "destination-port-except":

--- a/pkg/config/compiler_prefix_list_hier_leaf_3843_test.go
+++ b/pkg/config/compiler_prefix_list_hier_leaf_3843_test.go
@@ -1,0 +1,215 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3843: a firewall-filter term with a HIERARCHICAL single-name
+// `source-prefix-list <name>;` / `destination-prefix-list <name>;` leaf (the
+// shape produced by `load merge` / a config file, where the name rides on
+// child.Keys[1] with ZERO children) had its scoping constraint SILENTLY DROPPED
+// — compileFilterFrom iterated only child.Children and never read child.Keys[1].
+// The term then compiled UNSCOPED (implicit match-all) and passed strict commit
+// cleanly, a HIGH fail-open. This is the #2419 dual-AST-shape class on the
+// prefix-list-ref leaf (distinct from the #2506 dataplane-snapshot resolver).
+//
+// Fail-on-revert: firewallPrefixListRefs now reads BOTH child.Keys[1:] (the
+// single-name leaf) AND child.Children (block / flat-set). Reverting that helper
+// to a child.Children-only iteration makes every assertion below go RED — the
+// scoped refs vanish and the undefined-reference reject disappears (the term
+// silently becomes match-all).
+
+// compileParsedHier parses a HIERARCHICAL config text (the load-merge /
+// config-file shape, NOT flat-set) and compiles it. The #3843 bug-triggering
+// AST — a single-name `source-prefix-list plX;` leaf carrying the name on
+// child.Keys[1] with no children — is ONLY produced by NewParser, so the test
+// MUST use the parser, never ParseSetCommand/SetPath (which yields a child node).
+func compileParsedHier(t *testing.T, text string) (*Config, error) {
+	t.Helper()
+	parser := NewParser(text)
+	tree, errs := parser.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	return CompileConfig(tree)
+}
+
+func TestPrefixListHierSingleNameSourceScoped3843(t *testing.T) {
+	cfg, err := compileParsedHier(t, `policy-options {
+    prefix-list plX {
+        10.1.0.0/16;
+    }
+}
+firewall {
+    family inet {
+        filter f {
+            term t {
+                from {
+                    source-prefix-list plX;
+                }
+                then discard;
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	term := cfg.Firewall.FiltersInet["f"].Terms[0]
+	if len(term.SourcePrefixLists) != 1 || term.SourcePrefixLists[0].Name != "plX" {
+		t.Fatalf("hierarchical single-name source-prefix-list scope DROPPED "+
+			"(fail-open — term became match-all): got %#v, want one ref to plX",
+			term.SourcePrefixLists)
+	}
+	if term.SourcePrefixLists[0].Except {
+		t.Error("except must be false for a clean single-name leaf")
+	}
+}
+
+func TestPrefixListHierSingleNameSourceExcept3843(t *testing.T) {
+	cfg, err := compileParsedHier(t, `policy-options {
+    prefix-list plX {
+        10.1.0.0/16;
+    }
+}
+firewall {
+    family inet {
+        filter f {
+            term t {
+                from {
+                    source-prefix-list plX except;
+                }
+                then accept;
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	term := cfg.Firewall.FiltersInet["f"].Terms[0]
+	if len(term.SourcePrefixLists) != 1 || term.SourcePrefixLists[0].Name != "plX" {
+		t.Fatalf("single-name source-prefix-list except scope DROPPED: got %#v, want one ref to plX",
+			term.SourcePrefixLists)
+	}
+	if !term.SourcePrefixLists[0].Except {
+		t.Error("except modifier lost on the single-name leaf")
+	}
+}
+
+func TestPrefixListHierSingleNameDestScoped3843(t *testing.T) {
+	cfg, err := compileParsedHier(t, `policy-options {
+    prefix-list plY {
+        2001:db8::/32;
+    }
+}
+firewall {
+    family inet6 {
+        filter f6 {
+            term t {
+                from {
+                    destination-prefix-list plY;
+                }
+                then discard;
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	term := cfg.Firewall.FiltersInet6["f6"].Terms[0]
+	if len(term.DestPrefixLists) != 1 || term.DestPrefixLists[0].Name != "plY" {
+		t.Fatalf("hierarchical single-name destination-prefix-list scope DROPPED "+
+			"(fail-open): got %#v, want one ref to plY", term.DestPrefixLists)
+	}
+	if term.DestPrefixLists[0].Except {
+		t.Error("except must be false for a clean single-name leaf")
+	}
+}
+
+// TestPrefixListHierSingleNameUndefinedRejected3843 is the strongest fail-open
+// witness: before #3843 the single-name leaf's name was dropped entirely, so a
+// term referencing an UNDEFINED prefix-list carried no ref, the strict gate had
+// nothing to check, and the term committed cleanly as match-all. With the fix
+// the ref survives and validateFirewallPrefixListReferencesStrict rejects it.
+func TestPrefixListHierSingleNameUndefinedRejected3843(t *testing.T) {
+	_, err := compileParsedHier(t, `firewall {
+    family inet {
+        filter f {
+            term t {
+                from {
+                    source-prefix-list ghost;
+                }
+                then accept;
+            }
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("undefined single-name source-prefix-list must be REJECTED at commit; " +
+			"pre-#3843 the scope was silently dropped so the term became match-all and " +
+			"committed cleanly (fail-open)")
+	}
+	if !strings.Contains(err.Error(), "undefined source-prefix-list") ||
+		!strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("error = %v, want it to name the undefined source-prefix-list ghost", err)
+	}
+}
+
+// TestPrefixListShapesStillWork3843 locks in that the flat-set and hierarchical
+// block shapes (which already worked via child.Children) keep scoping correctly
+// after the helper rewrite.
+func TestPrefixListShapesStillWork3843(t *testing.T) {
+	// Flat-set shape (child node per name).
+	flat := buildTree(t, []string{
+		"set policy-options prefix-list mgmt 10.0.0.0/8",
+		"set firewall family inet filter ff term t from source-prefix-list mgmt except",
+		"set firewall family inet filter ff term t then discard",
+	})
+	cfg, err := CompileConfig(flat)
+	if err != nil {
+		t.Fatalf("flat-set compile: %v", err)
+	}
+	term := cfg.Firewall.FiltersInet["ff"].Terms[0]
+	if len(term.SourcePrefixLists) != 1 || term.SourcePrefixLists[0].Name != "mgmt" ||
+		!term.SourcePrefixLists[0].Except {
+		t.Fatalf("flat-set source-prefix-list ref = %#v, want one except ref to mgmt", term.SourcePrefixLists)
+	}
+
+	// Hierarchical block shape (two positive names; mixing a positive and an
+	// `except` prefix-list in one direction is the #3359 mutex, rejected).
+	cfg, err = compileParsedHier(t, `policy-options {
+    prefix-list pl1 { 10.0.0.0/8; }
+    prefix-list pl2 { 172.16.0.0/12; }
+}
+firewall {
+    family inet {
+        filter fb {
+            term t {
+                from {
+                    source-prefix-list {
+                        pl1;
+                        pl2;
+                    }
+                }
+                then discard;
+            }
+        }
+    }
+}`)
+	if err != nil {
+		t.Fatalf("block-form compile: %v", err)
+	}
+	term = cfg.Firewall.FiltersInet["fb"].Terms[0]
+	if len(term.SourcePrefixLists) != 2 {
+		t.Fatalf("block-form refs = %#v, want two", term.SourcePrefixLists)
+	}
+	if term.SourcePrefixLists[0].Name != "pl1" || term.SourcePrefixLists[0].Except {
+		t.Errorf("block-form ref[0] = %#v, want pl1 no-except", term.SourcePrefixLists[0])
+	}
+	if term.SourcePrefixLists[1].Name != "pl2" || term.SourcePrefixLists[1].Except {
+		t.Errorf("block-form ref[1] = %#v, want pl2 no-except", term.SourcePrefixLists[1])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a HIGH fail-open (fable-review-161 F-001): a firewall-filter term with a **hierarchical single-name** `source-prefix-list <name>;` / `destination-prefix-list <name>;` leaf — the shape produced by `load merge` or a config file, where the name rides on `child.Keys[1]` with **zero children** — had its scoping constraint **silently dropped**. `compileFilterFrom`'s `source/destination-prefix-list` case iterated only `child.Children` and never read `child.Keys[1]`, so the term compiled with no prefix-list references (implicit match-all) yet passed strict commit cleanly. Because the dropped reference never reached `term.SourcePrefixLists`/`DestPrefixLists`, the #2506 undefined-reference gate also had nothing to check — so even a typo'd/undefined prefix-list slipped through.

This is the #2419 dual-AST-shape class applied to the prefix-list-ref leaf specifically (distinct from #2506, which fixed prefix-list refs dropped in the dataplane snapshot).

## The three AST shapes

| Shape | Example | AST | Pre-fix |
|-------|---------|-----|---------|
| hierarchical single-name leaf | `source-prefix-list plX;` | `Keys=["source-prefix-list","plX"]`, 0 children | **DROPPED** |
| hierarchical block | `source-prefix-list { plX except; }` | one child node per name | worked |
| flat-set command | `set ... source-prefix-list plX` | one child node | worked |

## Fix

New helper `firewallPrefixListRefs` (`compiler_firewall.go`) reads **both** `child.Keys[1:]` (single-name / flat leaf, grouping each `<name> [except]` pair so `except` attaches to the preceding name) **and** `child.Children` (block / flat-set), then accumulates. Both the source and destination cases route through it, mirroring `firewallMatchValues` / the #2419 fix. A dropped scope is now impossible: an unresolvable name is hard-rejected at commit by the existing #2506 gate (`validateFirewallPrefixListReferencesStrict`) — fail-closed.

## Validation

- New `pkg/config/compiler_prefix_list_hier_leaf_3843_test.go`: single-name source, single-name+except source, single-name destination (inet6), and undefined-single-name reject.
- **RED-on-revert proven**: reverting the `child.Keys[1:]` read makes all four single-name assertions go RED — the scope collapses to nil refs and the undefined `source-prefix-list ghost;` term silently commits as match-all.
- Block-form and flat-set shapes re-asserted to still scope correctly.
- `go test ./pkg/config/...` green; `go build ./...` green; `gofmt` + `go vet` clean.
- `docs/config-schema.md` documents the dual-AST prefix-list-ref contract.

Closes #3843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
