### PR TITLE
policy: accumulate across duplicate inner match/then blocks (#3842)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-07-03 — #3842: policy dup inner match/then blocks silently dropped (HIGH fail-open)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-review-161 F-006. A security policy term with
+    DUPLICATE inner `match {}` or `then {}` blocks — the shape `load
+    merge`/`load override` yields (parseStatements appends a repeated block at
+    every level; flat-set SetPath merges so cannot produce it) — had the SECOND
+    block silently dropped. `compilePolicy` (compiler_security.go) read only the
+    first block via `FindChild("match")`/`FindChild("then")`, and the six strict
+    policy gates used the same first-block read, so an L7 application/address
+    constraint or a `then reject`/`deny` in the duplicate block was discarded and
+    the policy WIDENED with a clean commit (a HIGH security fail-open), with the
+    gates never validating the second block either. #3562/#3377 fixed top-level
+    duplicate `security`/`policies` blocks and duplicate action NODES within one
+    then block, but not duplicate inner match/then BLOCKS under one term.
+  - **Fix**: Added three shared accumulate helpers in `compiler_security.go` —
+    `policyMatchChildren` (children of every `match {}`), `policyThenChildren`
+    (children of every `then {}`), `policyThenActionNodes(pol, action)` (every
+    permit/deny/reject node across every `then {}`, composing with the #3377
+    per-then-block two-node handling). Routed the compiler (`compilePolicy`) and
+    all six gates through them: `validatePolicyMatchLeavesStrict` (#3113),
+    `validatePolicyRequiredMatchStrict` (#3044), `validatePolicyThenPermitStrict`
+    (#3114), `validatePolicyThenRejectStrict` (#3115),
+    `validatePolicyThenDenyStrict` (#3141). Junos merge semantics: every block is
+    enforced AND validated. Two blocks with conflicting terminal actions
+    (`then { permit }` + `then { reject }`) now feed two `pol.terminalActions`
+    and are rejected by the #3043 conflicting-terminal-action gate at commit (the
+    fail-closed floor) instead of the second being dropped into a fail-open
+    permit.
+  - **Validation**: New `compiler_policy_dup_block_3842_test.go` — six tests
+    (compiler accumulate, conflicting-then-block reject, second-block
+    unsupported-leaf #3113 + lenient-warn, second-block unsupported-modifier
+    #3114, split required dimensions merged, single-block regression guard).
+    Proved RED-on-revert by reverting the helpers to first-block-only: all five
+    assertive tests go RED, the single-block guard stays green. `go test
+    ./pkg/config/...` green, `go build ./...` clean, gofmt + vet clean.
+  - **File(s)**: pkg/config/compiler_security.go,
+    pkg/config/compiler_policy_match.go,
+    pkg/config/compiler_policy_missing_match.go,
+    pkg/config/compiler_policy_then.go,
+    pkg/config/compiler_policy_dup_block_3842_test.go, docs/config-schema.md,
+    _Log.md
+
 ## 2026-07-02 — #3719: review MAJOR fix — quarantine scrub must drop scoped-global match-zones
 
 - **Timestamp**: 2026-07-02

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1349,6 +1349,40 @@ reserved for whole-dataplane selection where a rewrite shim
   `pkg/config/compiler_dup_flow_subblock_3566_test.go` (per-validator
   RED-on-revert subtests duplicating each descended level — `flow`,
   `traceoptions`, `file`, `log` — built with `NewParser`).
+- **#3842 (the innermost sibling of #3562/#3566 — duplicate `match {}`/`then {}`
+  blocks UNDER ONE policy term):** #3562/#3566 fixed the duplicate-block bypass
+  at the `security`/`policies`/`flow` container levels, but the per-policy check
+  itself still read only the FIRST inner `match {}` / `then {}` block via
+  `polNode.FindChild("match")` / `FindChild("then")` — both in the COMPILER
+  (`compilePolicy`, `compiler_security.go`) and in the six strict policy gates.
+  A policy term with a DUPLICATE inner `match {}` or `then {}` block — the shape
+  `LoadMerge`/`LoadOverride` yields, since `parseStatements` appends a repeated
+  block at EVERY level (it cannot be produced by flat-set `SetPath`, which
+  merges the block) — had the SECOND block silently DROPPED: an L7 `application`
+  constraint, an address constraint, or a `then reject`/`deny` in the duplicate
+  block was discarded, WIDENING the policy with a clean commit (a HIGH security
+  fail-open), and the gates never validated it either. The fix ACCUMULATES over
+  all blocks via three shared helpers in `compiler_security.go` —
+  `policyMatchChildren` (children of every `match {}`), `policyThenChildren`
+  (children of every `then {}`), and `policyThenActionNodes(pol, action)` (every
+  permit/deny/reject node across every `then {}`, composing with the #3377
+  per-then-block two-node handling). The compiler and all six gates
+  (`validatePolicyMatchLeavesStrict` #3113, `validatePolicyRequiredMatchStrict`
+  #3044, `validatePolicyThenPermitStrict` #3114, `validatePolicyThenRejectStrict`
+  #3115, `validatePolicyThenDenyStrict` #3141) now read through these helpers, so
+  every block is enforced AND validated — Junos merge semantics. Two blocks with
+  CONFLICTING terminal actions (`then { permit }` + `then { reject }`) surface as
+  two `pol.terminalActions` and are rejected by the #3043 conflicting-terminal-
+  action gate at commit (the fail-closed floor) rather than the second being
+  dropped into a fail-open permit. RULE OF THUMB (restated for the leaf level):
+  the per-instance body of a strict walk must also union same-named repeated
+  BLOCKS (`match`/`then`) — a `FindChild`-first read of an inner block is the
+  same bypass one level deeper. Regression coverage:
+  `pkg/config/compiler_policy_dup_block_3842_test.go` (compiler accumulate,
+  conflicting-then-block reject, second-block unsupported-leaf #3113 and
+  unsupported-modifier #3114 rejection incl. the lenient-warn surface, split
+  required dimensions merged, single-block regression guard — built with
+  `NewParser` for the `LoadOverride` shape).
 - **#3473 (duplicate security-policy names — strict commit gate):**
   `validateDuplicatePolicyNamesStrict` (`compiler_validate_strict.go`)
   hard-rejects two security policies that share a name within the same

--- a/pkg/config/compiler_policy_dup_block_3842_test.go
+++ b/pkg/config/compiler_policy_dup_block_3842_test.go
@@ -1,0 +1,385 @@
+package config
+
+// #3842: a security policy term with DUPLICATE inner `match {}` or `then {}`
+// blocks — the shape produced by `load merge` / `load override` (and by a
+// hierarchical config that authors two blocks), since parseStatements APPENDS
+// a repeated block rather than merging it — had the SECOND block silently
+// dropped. compilePolicy (compiler_security.go) read only the first block via
+// FindChild("match")/FindChild("then"), and the six strict policy gates
+// (validatePolicyMatchLeavesStrict #3113, validatePolicyRequiredMatchStrict
+// #3044, validatePolicyThenPermitStrict #3114, validatePolicyThenRejectStrict
+// #3115, validatePolicyThenDenyStrict #3141 — plus the compiler itself) all
+// used the same FindChild-first read, so the second block was neither enforced
+// nor validated. Net: an L7 application constraint, an address constraint, or a
+// deny/reject in a duplicated block was discarded and the policy WIDENED with a
+// clean commit — a HIGH security fail-open. #3562/#3377 fixed top-level
+// duplicate `security`/`policies` blocks and duplicate action NODES within one
+// then block, but NOT duplicate inner match/then BLOCKS under one term.
+//
+// The fix accumulates across ALL match/then blocks (policyMatchChildren /
+// policyThenChildren / policyThenActionNodes) in both the compiler and every
+// gate, so the second block is enforced AND validated. Where two blocks carry
+// conflicting terminal actions the #3043 conflicting-terminal-action gate
+// rejects the commit (the fail-closed floor) instead of the compiler silently
+// dropping one into a fail-open permit.
+//
+// These tests build the DUPLICATE-BLOCK hierarchical shape with NewParser (a
+// genuine brace config, not flat-set — the CLAUDE.md "use SetPath, never
+// NewParser" rule targets flat-set syntax; a hierarchical duplicate-block
+// config is exactly what load merge/override yields and cannot be produced via
+// SetPath, which merges blocks). Each test asserts a precondition that the
+// parse really produced two blocks, so it proves the bypass, not a merged node
+// the old read already handled. Reverting the accumulate fix turns each RED.
+
+import (
+	"strings"
+	"testing"
+)
+
+// parseDupBlockTree parses a hierarchical config and returns the tree.
+func parseDupBlockTree(t *testing.T, cfg string) *ConfigTree {
+	t.Helper()
+	tree, perrs := NewParser(cfg).Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse: %v", perrs)
+	}
+	return tree
+}
+
+// zonePairPolicyNode locates the from-zone trust to-zone untrust policy `name`
+// AST node so a test can assert the duplicate-block precondition.
+func zonePairPolicyNode(t *testing.T, tree *ConfigTree, name string) *Node {
+	t.Helper()
+	sec := tree.FindChild("security")
+	if sec == nil {
+		t.Fatal("no security node")
+	}
+	pols := sec.FindChild("policies")
+	if pols == nil {
+		t.Fatal("no policies node")
+	}
+	fz := pols.FindChild("from-zone")
+	if fz == nil {
+		t.Fatal("no from-zone node")
+	}
+	for _, p := range fz.FindChildren("policy") {
+		if len(p.Keys) >= 2 && p.Keys[1] == name {
+			return p
+		}
+	}
+	t.Fatalf("policy %q not found", name)
+	return nil
+}
+
+// TestPolicyDupMatchBlockAccumulated_3842 is the compiler-accumulate proof: a
+// deny policy whose `application` constraint is split across TWO `match {}`
+// blocks (junos-http in the first, junos-https in a second block) must deny
+// BOTH. Dropping the second block (FindChild-first) leaves junos-https
+// un-denied — a fail-open. Reverting compilePolicy's match read to
+// FindChild-first turns Applications into [junos-http] only and this goes RED.
+func TestPolicyDupMatchBlockAccumulated_3842(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application junos-http;
+                }
+                then {
+                    deny;
+                }
+                match {
+                    application junos-https;
+                }
+            }
+        }
+    }
+}`
+	tree := parseDupBlockTree(t, cfg)
+	polNode := zonePairPolicyNode(t, tree, "p")
+	if n := len(polNode.FindChildren("match")); n != 2 {
+		t.Fatalf("precondition: expected 2 match blocks (the #3842 dup-block shape), got %d", n)
+	}
+
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	pol := findZonePairPolicy(t, c, "trust", "untrust", "p")
+
+	if !containsStr(pol.Match.Applications, "junos-http") ||
+		!containsStr(pol.Match.Applications, "junos-https") {
+		t.Fatalf("Match.Applications = %v, want BOTH junos-http and junos-https "+
+			"(second match block dropped — the #3842 fail-open widening)",
+			pol.Match.Applications)
+	}
+	if pol.Action != PolicyDeny {
+		t.Fatalf("Action = %v, want deny", pol.Action)
+	}
+}
+
+// TestPolicyDupThenBlockConflictRejected_3842 proves two `then {}` blocks with
+// CONFLICTING terminal actions (permit in the first, reject in a second block)
+// are rejected at commit via the #3043 conflicting-terminal-action gate — the
+// fail-closed floor. Reverting compilePolicy's then read to FindChild-first
+// sees only the first `then { permit }`, so the commit SUCCEEDS as an
+// unconditional permit (the reject silently dropped — a fail-open) and this
+// goes RED.
+func TestPolicyDupThenBlockConflictRejected_3842(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+                then {
+                    reject;
+                }
+            }
+        }
+    }
+}`
+	tree := parseDupBlockTree(t, cfg)
+	polNode := zonePairPolicyNode(t, tree, "p")
+	if n := len(polNode.FindChildren("then")); n != 2 {
+		t.Fatalf("precondition: expected 2 then blocks (the #3842 dup-block shape), got %d", n)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("compile accepted two conflicting then blocks; want commit rejection " +
+			"(second then block silently dropped into a fail-open permit — #3842)")
+	}
+	if !strings.Contains(err.Error(), "conflicting terminal actions") {
+		t.Fatalf("error = %q, want conflicting-terminal-actions rejection", err.Error())
+	}
+	if !strings.Contains(err.Error(), "permit") || !strings.Contains(err.Error(), "reject") {
+		t.Fatalf("error = %q, want both permit and reject named", err.Error())
+	}
+}
+
+// TestPolicyDupMatchBlockUnsupportedLeafRejected_3842 proves the #3113
+// unsupported-match-leaf gate inspects the SECOND `match {}` block: an
+// unsupported `dynamic-application` leaf carried only by a duplicate match
+// block is rejected at commit. Reverting the gate's match read to
+// FindChild-first sees only the first (valid) block, the compiler drops the
+// unsupported leaf silently, the commit SUCCEEDS, and this goes RED.
+func TestPolicyDupMatchBlockUnsupportedLeafRejected_3842(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+                match {
+                    dynamic-application junos:FTP;
+                }
+            }
+        }
+    }
+}`
+	tree := parseDupBlockTree(t, cfg)
+	polNode := zonePairPolicyNode(t, tree, "p")
+	if n := len(polNode.FindChildren("match")); n != 2 {
+		t.Fatalf("precondition: expected 2 match blocks, got %d", n)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("compile accepted an unsupported match leaf in a second match block; " +
+			"want #3113 rejection (leaf silently dropped/widened — #3842)")
+	}
+	if !strings.Contains(err.Error(), "#3113") ||
+		!strings.Contains(err.Error(), "dynamic-application") {
+		t.Fatalf("error = %q, want #3113 dynamic-application rejection", err.Error())
+	}
+
+	// Lenient (load / peer-sync) path: the gate must WARN about the second
+	// block, not silently boot — proving the accumulate fix also covers the
+	// #1960 fail-closed-on-load surface.
+	lc, lerr := CompileConfigLenient(tree)
+	if lerr != nil {
+		t.Fatalf("lenient compile returned hard error (should warn + boot): %v", lerr)
+	}
+	if !containsSub(lc.Warnings, "dynamic-application") {
+		t.Fatalf("lenient warnings = %v, want a dynamic-application warning "+
+			"for the second match block", lc.Warnings)
+	}
+}
+
+// TestPolicyDupThenBlockUnsupportedModifierRejected_3842 proves the #3114
+// then-permit gate inspects a permit modifier carried by a SECOND `then {}`
+// block. A bare `then { permit }` plus a second `then { permit
+// application-services ... }` is rejected at commit with the specific #3114
+// diagnostic. Reverting the gate's then read to FindChild-first sees only the
+// first bare permit and misses the modifier; on revert the compiler also reads
+// only the first then block, so no conflict and no #3114 — RED.
+func TestPolicyDupThenBlockUnsupportedModifierRejected_3842(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application any;
+                }
+                then {
+                    permit;
+                }
+                then {
+                    permit {
+                        application-services {
+                            utm-policy strict-web;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`
+	tree := parseDupBlockTree(t, cfg)
+	polNode := zonePairPolicyNode(t, tree, "p")
+	if n := len(polNode.FindChildren("then")); n != 2 {
+		t.Fatalf("precondition: expected 2 then blocks, got %d", n)
+	}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("compile accepted an unsupported then-permit modifier in a second " +
+			"then block; want #3114 rejection (#3842)")
+	}
+	if !strings.Contains(err.Error(), "#3114") ||
+		!strings.Contains(err.Error(), "application-services") {
+		t.Fatalf("error = %q, want #3114 application-services rejection", err.Error())
+	}
+}
+
+// TestPolicyDupMatchBlockSplitDimensionsAccepted_3842 proves the #3044
+// required-match gate UNIONS the required dimensions across blocks: a policy
+// whose source/destination-address live in one block and application in a
+// second (as a load merge would split them) is COMPLETE once merged and
+// commits. Reverting the gate's match read to FindChild-first sees only the
+// first block, reports `application` missing, and spuriously REJECTS — so this
+// goes RED (a hard error) on revert.
+func TestPolicyDupMatchBlockSplitDimensionsAccepted_3842(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                }
+                then {
+                    permit;
+                }
+                match {
+                    application junos-http;
+                }
+            }
+        }
+    }
+}`
+	tree := parseDupBlockTree(t, cfg)
+	polNode := zonePairPolicyNode(t, tree, "p")
+	if n := len(polNode.FindChildren("match")); n != 2 {
+		t.Fatalf("precondition: expected 2 match blocks, got %d", n)
+	}
+
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile rejected a policy whose required dimensions are split "+
+			"across two match blocks (should merge to complete — #3842): %v", err)
+	}
+	pol := findZonePairPolicy(t, c, "trust", "untrust", "p")
+	if !containsStr(pol.Match.Applications, "junos-http") {
+		t.Fatalf("Match.Applications = %v, want junos-http (from second match block)",
+			pol.Match.Applications)
+	}
+}
+
+// TestPolicySingleMatchThenBlockUnchanged_3842 is the regression guard: the
+// common single-block policy compiles bit-identically after the accumulate
+// change (FindChildren over one block == the old FindChild read).
+func TestPolicySingleMatchThenBlockUnchanged_3842(t *testing.T) {
+	cfg := `security {
+    zones {
+        security-zone trust;
+        security-zone untrust;
+    }
+    policies {
+        from-zone trust to-zone untrust {
+            policy p {
+                match {
+                    source-address any;
+                    destination-address any;
+                    application junos-http;
+                }
+                then {
+                    permit;
+                }
+            }
+        }
+    }
+}`
+	tree := parseDupBlockTree(t, cfg)
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	pol := findZonePairPolicy(t, c, "trust", "untrust", "p")
+	if pol.Action != PolicyPermit {
+		t.Fatalf("Action = %v, want permit", pol.Action)
+	}
+	if len(pol.Match.Applications) != 1 || pol.Match.Applications[0] != "junos-http" {
+		t.Fatalf("Match.Applications = %v, want [junos-http]", pol.Match.Applications)
+	}
+	if len(pol.Match.SourceAddresses) != 1 || pol.Match.SourceAddresses[0] != "any" {
+		t.Fatalf("Match.SourceAddresses = %v, want [any]", pol.Match.SourceAddresses)
+	}
+}
+
+// containsStr reports whether s is in xs.
+func containsStr(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/compiler_policy_match.go
+++ b/pkg/config/compiler_policy_match.go
@@ -207,11 +207,13 @@ func validatePolicyMatchLeavesStrict(nodes []*Node, lenient bool) ([]string, err
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node, isGlobal bool) error {
-		matchNode := polNode.FindChild("match")
-		if matchNode == nil {
-			return nil
-		}
-		for _, m := range matchNode.Children {
+		// #3842: inspect EVERY `match {}` block (policyMatchChildren), not just
+		// the first via FindChild. A duplicate inner match block (load merge/
+		// override appends a second `match` child) is compiled by compilePolicy
+		// and can carry an unsupported leaf; a FindChild-first walk here never
+		// validated it, so the second block's leaf was silently dropped and the
+		// policy widened with a clean commit.
+		for _, m := range policyMatchChildren(polNode) {
 			leaf := m.Name()
 			// #3148: from-zone/to-zone are supported match context for a
 			// global policy only; under a zone-pair policy they fall through

--- a/pkg/config/compiler_policy_missing_match.go
+++ b/pkg/config/compiler_policy_missing_match.go
@@ -106,11 +106,17 @@ func validatePolicyRequiredMatchStrict(nodes []*Node, lenient bool) ([]string, e
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
+		// #3842: union the dimensions across EVERY `match {}` block
+		// (policyMatchChildren), not just the first via FindChild. Junos merges
+		// duplicate match blocks, so a policy whose required dimensions are
+		// split across two blocks (e.g. source/destination-address in one,
+		// application in a load-merged second) is complete once merged — a
+		// FindChild-first read saw only the first block and would either
+		// spuriously reject a complete policy or, symmetrically, let a widened
+		// one through depending on which block came first.
 		present := map[string]bool{}
-		if matchNode := polNode.FindChild("match"); matchNode != nil {
-			for _, m := range matchNode.Children {
-				present[m.Name()] = true
-			}
+		for _, m := range policyMatchChildren(polNode) {
+			present[m.Name()] = true
 		}
 		var missing []string
 		for _, req := range requiredPolicyMatchLeaves {

--- a/pkg/config/compiler_policy_then.go
+++ b/pkg/config/compiler_policy_then.go
@@ -98,23 +98,21 @@ func validatePolicyThenPermitStrict(nodes []*Node, lenient bool) ([]string, erro
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
-		thenNode := polNode.FindChild("then")
-		if thenNode == nil {
-			return nil
-		}
 		// A bare `then permit` (a `permit` node with no modifier tokens) is
 		// fully supported. Only `then permit <modifier>` carries an
-		// unsupported modifier. ALL `then permit` nodes are inspected
-		// (FindChildren, not FindChild): a flat-set `set ... then permit`
-		// followed by `set ... then permit application-services X` produces
-		// TWO separate `permit` nodes, and a FindChild-first gate would see
-		// only the (valid) bare node first and miss the unsupported modifier
-		// on the second. collapsedThenActionTokens flattens each node's
-		// modifier tokens across all three parser groupings (flat-onto-permit,
-		// collapsed-child, nested). The supported permit-modifier set is empty
-		// (supportedPolicyThenPermitChildren), so any token is unsupported;
-		// report the first per offending node.
-		for _, permitNode := range thenNode.FindChildren("permit") {
+		// unsupported modifier. ALL `then permit` nodes across ALL `then {}`
+		// blocks are inspected (policyThenActionNodes): a flat-set
+		// `set ... then permit` followed by `set ... then permit
+		// application-services X` produces TWO separate `permit` nodes (the
+		// #3377 two-node split), and #3842 adds the DUPLICATE inner `then {}`
+		// block case (load merge/override appends a second `then` child) — a
+		// FindChild-first gate saw only the first then block / bare node and
+		// missed the unsupported modifier on the second. collapsedThenAction-
+		// Tokens flattens each node's modifier tokens across all three parser
+		// groupings (flat-onto-permit, collapsed-child, nested). The supported
+		// permit-modifier set is empty (supportedPolicyThenPermitChildren), so
+		// any token is unsupported; report the first per offending node.
+		for _, permitNode := range policyThenActionNodes(polNode, "permit") {
 			for _, tok := range collapsedThenActionTokens(permitNode) {
 				if supportedPolicyThenPermitChildren[tok] {
 					continue
@@ -253,22 +251,19 @@ func validatePolicyThenRejectStrict(nodes []*Node, lenient bool) ([]string, erro
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
-		thenNode := polNode.FindChild("then")
-		if thenNode == nil {
-			return nil
-		}
 		// A bare `then reject` (a `reject` node with no modifier tokens) is
 		// fully supported. Only `then reject <modifier>` (a reject profile or
 		// a packet-type reject like tcp-reset) carries an unsupported
-		// modifier. ALL `then reject` nodes are inspected (FindChildren, not
-		// FindChild) for the same two-node split reason as the permit gate:
-		// `set ... then reject` then `set ... then reject profile X` produces
-		// TWO separate `reject` nodes. collapsedThenActionTokens flattens each
-		// node's modifier tokens across all three parser groupings. The
-		// supported reject-modifier set is empty
+		// modifier. ALL `then reject` nodes across ALL `then {}` blocks are
+		// inspected (policyThenActionNodes) for the same two-node split reason
+		// as the permit gate — `set ... then reject` then `set ... then reject
+		// profile X` produces TWO separate `reject` nodes — plus the #3842
+		// duplicate inner `then {}` block case. collapsedThenActionTokens
+		// flattens each node's modifier tokens across all three parser
+		// groupings. The supported reject-modifier set is empty
 		// (supportedPolicyThenRejectChildren), so any token is unsupported;
 		// report the first per offending node.
-		for _, rejectNode := range thenNode.FindChildren("reject") {
+		for _, rejectNode := range policyThenActionNodes(polNode, "reject") {
 			for _, tok := range collapsedThenActionTokens(rejectNode) {
 				if supportedPolicyThenRejectChildren[tok] {
 					continue
@@ -455,11 +450,12 @@ func validatePolicyThenDenyStrict(nodes []*Node, lenient bool) ([]string, error)
 	}
 
 	checkPolicy := func(scope, policyName string, polNode *Node) error {
-		thenNode := polNode.FindChild("then")
-		if thenNode == nil {
-			return nil
-		}
-		denyNodes := thenNode.FindChildren("deny")
+		// #3842: union `then deny` nodes across ALL `then {}` blocks
+		// (policyThenActionNodes), not just the first via FindChild — a
+		// duplicate inner then block (load merge/override) carries deny
+		// modifiers the compiler applies but a FindChild-first gate never
+		// validated.
+		denyNodes := policyThenActionNodes(polNode, "deny")
 		if len(denyNodes) == 0 {
 			return nil
 		}

--- a/pkg/config/compiler_security.go
+++ b/pkg/config/compiler_security.go
@@ -642,6 +642,59 @@ func normalizePolicyAddrTokens(toks []string) []string {
 	return out
 }
 
+// policyMatchChildren returns the children of EVERY `match {}` block under a
+// security-policy term, flattened in declaration order. #3842: a policy
+// loaded via `load merge` / `load override` (or a hierarchical config that
+// authors two blocks) carries DUPLICATE inner `match {}` blocks as SEPARATE
+// children — parseStatements APPENDS a repeated block, it does not merge it
+// (parser.go) — and Junos merges duplicate match blocks. Reading only the
+// first via FindChild("match") silently DROPS the second block's constraints,
+// WIDENING the policy with a clean commit (a security fail-open) AND hiding
+// the second block from the strict match gates. The compiler (compilePolicy)
+// and the strict match gates (validatePolicyMatchLeavesStrict #3113/#3142/
+// #3673, validatePolicyRequiredMatchStrict #3044) all accumulate over this
+// helper so every match block is both enforced and validated. #3562/#3377
+// closed the top-level duplicate-`security`/`policies` and duplicate-action-
+// node cases; this closes the duplicate inner match/then blocks under one
+// term.
+func policyMatchChildren(polNode *Node) []*Node {
+	var out []*Node
+	for _, mn := range polNode.FindChildren("match") {
+		out = append(out, mn.Children...)
+	}
+	return out
+}
+
+// policyThenChildren is the `then {}` sibling of policyMatchChildren (#3842):
+// the children of EVERY `then {}` block under a policy term, flattened in
+// order. compilePolicy accumulates the terminal action / log / count over all
+// then blocks, so a second `then { reject; }` after a first `then { permit; }`
+// contributes a SECOND terminal action that the #3043 conflicting-terminal-
+// action gate rejects at commit (the fail-closed floor) instead of being
+// silently dropped into a fail-open permit.
+func policyThenChildren(polNode *Node) []*Node {
+	var out []*Node
+	for _, tn := range polNode.FindChildren("then") {
+		out = append(out, tn.Children...)
+	}
+	return out
+}
+
+// policyThenActionNodes returns every `then` action node named `action`
+// (permit / deny / reject) across ALL `then {}` blocks under a policy term.
+// The then-action reject gates (validatePolicyThenPermitStrict #3114,
+// validatePolicyThenRejectStrict #3115, validatePolicyThenDenyStrict #3141)
+// use it so a modifier carried by a DUPLICATE `then {}` block is inspected,
+// not only the first block's action nodes (#3842). It composes with the
+// existing per-then-block FindChildren(action) two-node handling (#3377).
+func policyThenActionNodes(polNode *Node, action string) []*Node {
+	var out []*Node
+	for _, tn := range polNode.FindChildren("then") {
+		out = append(out, tn.FindChildren(action)...)
+	}
+	return out
+}
+
 // compilePolicy extracts a Policy from a named policy instance.
 func compilePolicy(polInst struct {
 	name string
@@ -649,9 +702,12 @@ func compilePolicy(polInst struct {
 }) *Policy {
 	pol := &Policy{Name: polInst.name}
 
-	matchNode := polInst.node.FindChild("match")
-	if matchNode != nil {
-		for _, m := range matchNode.Children {
+	// #3842: accumulate across ALL `match {}` blocks (policyMatchChildren) —
+	// a duplicate inner match block must contribute its constraints, never be
+	// silently dropped by a FindChild-first read (a fail-open widening).
+	matchChildren := policyMatchChildren(polInst.node)
+	if len(matchChildren) > 0 {
+		for _, m := range matchChildren {
 			switch m.Name() {
 			case "source-address":
 				if len(m.Keys) >= 2 {
@@ -703,9 +759,14 @@ func compilePolicy(polInst struct {
 		}
 	}
 
-	thenNode := polInst.node.FindChild("then")
-	if thenNode != nil {
-		for _, t := range thenNode.Children {
+	// #3842: accumulate across ALL `then {}` blocks (policyThenChildren) so a
+	// duplicate inner then block's terminal action / log / count is enforced.
+	// Two terminal actions from two then blocks feed pol.terminalActions and
+	// are rejected by the #3043 conflicting-terminal-action gate at commit
+	// (fail-closed) rather than the second being silently dropped (fail-open).
+	thenChildren := policyThenChildren(polInst.node)
+	if len(thenChildren) > 0 {
+		for _, t := range thenChildren {
 			switch t.Name() {
 			case "permit":
 				pol.Action = PolicyPermit


### PR DESCRIPTION
Closes #3842

## Problem (HIGH, security fail-open)

A security policy term with DUPLICATE inner `match {}` or `then {}`
blocks — the shape `load merge` / `load override` yields (parseStatements
APPENDS a repeated block at every level; flat-set `SetPath` merges the
block, so it cannot produce this) — had the SECOND block silently
dropped. `compilePolicy` (`compiler_security.go:652,706`) read only the
first block via `FindChild("match")` / `FindChild("then")`, and the six
strict policy gates used the same first-block read.

Net: an L7 `application` constraint, an address constraint, or a
`then reject`/`deny` in the duplicated block was discarded, WIDENING the
policy with a clean commit — a fail-open — and the gates never validated
the second block either.

`#3562`/`#3377` fixed top-level duplicate `security`/`policies` blocks and
duplicate action NODES within one then block, but NOT duplicate inner
match/then BLOCKS under one policy term.

## Fix

Three shared accumulate helpers in `compiler_security.go`:

- `policyMatchChildren` — children of EVERY `match {}` block
- `policyThenChildren` — children of EVERY `then {}` block
- `policyThenActionNodes(pol, action)` — every permit/deny/reject node
  across every `then {}` (composes with the `#3377` per-then-block
  two-node `FindChildren` handling)

The compiler (`compilePolicy`) and all six gates read through these, so
every block is enforced AND validated (Junos merge semantics):
`validatePolicyMatchLeavesStrict` (#3113),
`validatePolicyRequiredMatchStrict` (#3044),
`validatePolicyThenPermitStrict` (#3114),
`validatePolicyThenRejectStrict` (#3115),
`validatePolicyThenDenyStrict` (#3141).

Two blocks with conflicting terminal actions (`then { permit }` +
`then { reject }`) now feed two `pol.terminalActions` and are rejected by
the `#3043` conflicting-terminal-action gate at commit (the fail-closed
floor) rather than the second being dropped into a fail-open permit.

Single-block policies are bit-identical (FindChildren over one block ==
the old FindChild read).

## Tests (RED-on-revert)

`pkg/config/compiler_policy_dup_block_3842_test.go`, built with
`NewParser` (the hierarchical / `LoadOverride` shape). Each asserts a
precondition that the parse produced two blocks:

- compiler accumulate: deny policy with `application` split across two
  match blocks denies BOTH apps
- conflicting then blocks (permit + reject) rejected at commit (#3043)
- unsupported `dynamic-application` in a second match block rejected by
  #3113 (+ lenient-warn surface)
- unsupported `then permit application-services` in a second then block
  rejected by #3114
- required dimensions split across two match blocks merge to complete
- single-block regression guard

RED-on-revert verified by reverting the three helpers to
first-block-only: all five assertive tests fail; the guard passes.

`go test ./pkg/config/...` green, `go build ./...` clean, gofmt + vet
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi