### PR TITLE
config: delete only the named member of a multi-value bracket-list leaf (#3846)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28060,3 +28060,32 @@ top.
   rewired source/destination-prefix-list cases),
   pkg/config/compiler_prefix_list_hier_leaf_3843_test.go (new RED-on-revert
   tests), docs/config-schema.md (dual-AST prefix-list-ref note)
+
+- **Timestamp**: 2026-07-03
+- **Action**: Fix #3846 — `delete ... <multi-leaf> <member>` deleted the WHOLE
+  bracket-list, not just the member (config-integrity fail-wide). On a
+  `multi: true` value-list leaf holding a bracket list (`from protocol
+  [ tcp udp icmp ]`, policy match source-/destination-address/application,
+  host-inbound-traffic system-services/protocols), `delete ... from protocol
+  tcp` prefix-matched the leaf by its first key in `removeMatchingNode`/
+  `keysMatch` and dropped the ENTIRE list; a NON-FIRST member
+  (`delete ... protocol udp`) matched nothing and was undeletable. This is the
+  delete-side counterpart of the #2419 multi-value-leaf read class. FIX:
+  `deletePath` now intercepts value-list multi-leaves (`multi: true`,
+  `children: nil`, `args == 1`) and routes them to new helper
+  `removeMultiLeafMembers`, which drops ONLY the named member(s) — reading BOTH
+  the flat `Keys[1:]` shape and the child-node shape, mirroring
+  `firewallMatchValues` on the read side — removes the leaf only once emptied,
+  and still clears the whole leaf on a bare `delete ... from protocol` (no
+  member). The `args == 1` gate keeps keyed multi entries (`address <name>
+  <prefix>`, args 2; named containers `interfaces <name>`) on whole-node delete
+  semantics. RED-on-revert proven: disabling the intercept empties the whole
+  list on the first member delete, errors on a non-first member, and takes
+  sibling members with the host-inbound-services / policy-match member deletes.
+  go test ./pkg/config/... green; go build ./... green; gofmt + vet clean (the
+  two gofmt-flagged files login_password_test.go / static_nat_zone_test.go are
+  pre-existing, not touched here).
+- **File(s)**: pkg/config/ast_edit.go (deletePath intercept +
+  removeMultiLeafMembers helper), pkg/config/delete_multi_leaf_member_3846_test.go
+  (new RED-on-revert tests), docs/config-schema.md (delete-side member-delete
+  contract note)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -108,6 +108,37 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**Delete-side contract: `delete` a member, not the whole list (#3846).**
+The read-side accumulate rule above has a mirror on the edit side. A
+`delete ... from protocol tcp` on a bracket-list leaf must remove ONLY the
+named member (`tcp`), leaving `[ udp icmp ]` intact — NOT prefix-match the
+leaf by its first key and drop the whole list. Before #3846 `deletePath`
+(`ast_edit.go`) fell straight into `removeMatchingNode`/`keysMatch`, whose
+prefix match deleted the entire node on `delete ... protocol tcp` (udp +
+icmp silently gone) and left a NON-FIRST member undeletable
+(`delete ... protocol udp` matched nothing and errored) — a
+config-integrity fail-wide and potential fail-open (a removed match
+constraint widens the term). `deletePath` now intercepts value-list
+multi-leaves (`multi: true`, `children: nil`, `args == 1`) and routes them
+to `removeMultiLeafMembers`, which:
+
+- with trailing member token(s), drops ONLY those members — reading BOTH
+  the flat `Keys[1:]` shape and the child-node shape, exactly mirroring
+  `firewallMatchValues` on the read side — and removes the leaf entirely
+  only once it is emptied of all members;
+- with NO trailing member (`delete ... from protocol`), still clears the
+  whole leaf (via `removeMatchingNode`);
+- reports a member that is not present as not-found, matching
+  `removeMatchingNode`'s contract.
+
+The `args == 1` gate keeps keyed multi entries on whole-node delete
+semantics: `address <name> <prefix>` (`args: 2`) and named containers with
+children such as `interfaces <name>` are untouched, so `delete ... address
+a1` still removes that whole entry, not just its name token. Covered by
+`pkg/config/delete_multi_leaf_member_3846_test.go` (firewall `from
+protocol`, host-inbound-traffic `system-services`, policy match
+`source-address`, and the keyed-entry `address` non-regression).
+
 **Firewall-filter `source/destination-prefix-list` refs are dual-AST too
 (#3843).** These `from` leaves are NOT `multi: true` value-tails — each
 reference carries an optional trailing `except` modifier, so they compile

--- a/pkg/config/ast_edit.go
+++ b/pkg/config/ast_edit.go
@@ -356,6 +356,27 @@ func deletePath(current *[]*Node, path []string, schema *schemaNode, i int) erro
 		return removeMatchingNode(current, leafKeys)
 	}
 
+	// Value-list multi-leaf (a `multi: true` leaf with a single value slot and
+	// no children): the bracket-list class fixed on the read side in #2419 —
+	// `from protocol [ tcp udp icmp ]`, policy match
+	// source-/destination-address/application, host-inbound-traffic
+	// system-services/protocols, apply-groups, domain-search, and friends. The
+	// leaf carries its members on Keys[1:] AND/OR one child node per member
+	// (the dual AST shape). A `delete ... protocol tcp` names a MEMBER of the
+	// list, not the whole node — remove ONLY that member and keep the rest,
+	// mirroring firewallMatchValues on the read side. A bare `delete ...
+	// protocol` (no trailing member) still clears the whole leaf. Without this
+	// branch removeMatchingNode prefix-matches the leaf by its first key and
+	// deletes the ENTIRE list (a config-integrity fail-wide, #3846), and a
+	// non-first member is undeletable.
+	//
+	// Gate on args == 1 so keyed multi entries (address <name> <prefix>,
+	// args == 2; named containers with children such as `interfaces <name>`)
+	// keep whole-node delete semantics.
+	if childSchema.multi && childSchema.children == nil && childSchema.args == 1 {
+		return removeMultiLeafMembers(current, keyword, path[i+1:])
+	}
+
 	// Consume keyword + extra args as this node's keys.
 	nodeKeyCount := 1 + childSchema.args
 	if i+nodeKeyCount > len(path) {
@@ -497,6 +518,71 @@ func removeMatchingNode(nodes *[]*Node, targetKeys []string) error {
 		}
 	}
 	return fmt.Errorf("path not found: no node matching %q", strings.Join(targetKeys, " "))
+}
+
+// removeMultiLeafMembers implements member-specific deletion for a value-list
+// multi-leaf (a `multi: true` leaf with no children and a single value slot —
+// e.g. `from protocol [ tcp udp icmp ]`). keyword is the leaf's first key
+// ("protocol"); members are the trailing tokens naming individual values to
+// drop.
+//
+//   - members empty  → delete the whole leaf (mirrors removeMatchingNode's
+//     prefix match), so `delete ... from protocol` still clears the list.
+//   - members named  → drop ONLY those values from every node whose first key
+//     is keyword, reading BOTH the flat Keys[1:] shape (bracket list / flat
+//     set) AND the child-node shape (hierarchical block) — the #2419 dual AST
+//     shape. A node left with no values is removed entirely.
+//
+// Returns an error when no named member was found anywhere (mirroring
+// removeMatchingNode's not-found contract), so deleting a member that is not
+// present is reported rather than silently succeeding.
+func removeMultiLeafMembers(nodes *[]*Node, keyword string, members []string) error {
+	if len(members) == 0 {
+		return removeMatchingNode(nodes, []string{keyword})
+	}
+	drop := make(map[string]bool, len(members))
+	for _, m := range members {
+		drop[m] = true
+	}
+	removedAny := false
+	out := (*nodes)[:0]
+	for _, n := range *nodes {
+		if len(n.Keys) == 0 || n.Keys[0] != keyword {
+			out = append(out, n)
+			continue
+		}
+		// Flat / bracket shape: members ride on Keys[1:].
+		newKeys := append([]string(nil), n.Keys[:1]...)
+		for _, v := range n.Keys[1:] {
+			if drop[v] {
+				removedAny = true
+				continue
+			}
+			newKeys = append(newKeys, v)
+		}
+		// Block shape: one child node per member.
+		newChildren := n.Children[:0]
+		for _, c := range n.Children {
+			if len(c.Keys) >= 1 && drop[c.Keys[0]] {
+				removedAny = true
+				continue
+			}
+			newChildren = append(newChildren, c)
+		}
+		// Leaf/container emptied of all members: drop it entirely.
+		if len(newKeys) == 1 && len(newChildren) == 0 {
+			continue
+		}
+		n.Keys = newKeys
+		n.Children = newChildren
+		out = append(out, n)
+	}
+	*nodes = out
+	if !removedAny {
+		return fmt.Errorf("path not found: no member %q of %q",
+			strings.Join(members, " "), keyword)
+	}
+	return nil
 }
 
 // keysMatch returns true if nodeKeys starts with all elements of targetKeys.

--- a/pkg/config/delete_multi_leaf_member_3846_test.go
+++ b/pkg/config/delete_multi_leaf_member_3846_test.go
@@ -1,0 +1,243 @@
+package config
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestDeleteMultiLeafMember_3846 pins the delete-side counterpart of the #2419
+// multi-value-leaf class. On a `multi: true` value-list leaf that holds a
+// bracket list (`from protocol [ tcp udp icmp ]`, policy match values,
+// host-inbound-services), `delete ... from protocol tcp` must remove ONLY the
+// named member and keep the rest — before #3846 it prefix-matched the leaf by
+// its first key and deleted the WHOLE list (a config-integrity fail-wide), and
+// a non-first member was undeletable.
+//
+// fail-on-revert: reverting removeMultiLeafMembers makes every "member
+// survives" assertion RED (the whole bracket list disappears on the first
+// member delete; a non-first member delete errors "path not found").
+
+// buildTree3846 applies a slice of `set ...` commands via ParseSetCommand+SetPath —
+// the ONLY correct way to exercise flat-set / bracket-list shapes (NewParser
+// merges newline-separated set lines into one giant node).
+func buildTree3846(t *testing.T, cmds ...string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	return tree
+}
+
+// firewallProtocols reads the compiled `from protocol` match values for a
+// firewall-filter term via the compiler (the read side, firewallMatchValues).
+func firewallProtocols(t *testing.T, tree *ConfigTree, filter, term string) []string {
+	t.Helper()
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	f := cfg.Firewall.FiltersInet[filter]
+	if f == nil {
+		t.Fatalf("filter %q not found", filter)
+	}
+	for _, tm := range f.Terms {
+		if tm.Name == term {
+			got := append([]string(nil), tm.Protocols...)
+			sort.Strings(got)
+			return got
+		}
+	}
+	t.Fatalf("term %q not found in filter %q", term, filter)
+	return nil
+}
+
+func mustDelete(t *testing.T, tree *ConfigTree, cmd string) {
+	t.Helper()
+	path, err := ParseSetCommand(cmd)
+	if err != nil {
+		t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+	}
+	if err := tree.DeletePath(path); err != nil {
+		t.Fatalf("DeletePath(%q): %v", cmd, err)
+	}
+}
+
+func TestDeleteMultiLeafMember_FirewallProtocol(t *testing.T) {
+	base := "set firewall family inet filter F term T from protocol [ tcp udp icmp ]"
+	accept := "set firewall family inet filter F term T then accept"
+
+	// (1) delete first member -> [udp icmp] survive.
+	t.Run("delete-first-member", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDelete(t, tree, "delete firewall family inet filter F term T from protocol tcp")
+		got := firewallProtocols(t, tree, "F", "T")
+		if want := []string{"icmp", "udp"}; !equalStrs3846(got, want) {
+			t.Fatalf("after delete tcp: protocols = %v, want %v (whole list was wrongly deleted before #3846)", got, want)
+		}
+	})
+
+	// (2) delete a NON-FIRST member -> only udp removed (was undeletable before #3846).
+	t.Run("delete-non-first-member", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDelete(t, tree, "delete firewall family inet filter F term T from protocol udp")
+		got := firewallProtocols(t, tree, "F", "T")
+		if want := []string{"icmp", "tcp"}; !equalStrs3846(got, want) {
+			t.Fatalf("after delete udp: protocols = %v, want %v", got, want)
+		}
+	})
+
+	// (3) delete the last-remaining member -> whole leaf gone, term has no protocol match.
+	t.Run("delete-only-member-clears-leaf", func(t *testing.T) {
+		tree := buildTree3846(t, "set firewall family inet filter F term T from protocol tcp", accept)
+		mustDelete(t, tree, "delete firewall family inet filter F term T from protocol tcp")
+		got := firewallProtocols(t, tree, "F", "T")
+		if len(got) != 0 {
+			t.Fatalf("after delete only member: protocols = %v, want empty", got)
+		}
+		if strings.Contains(tree.FormatSet(), "from protocol") {
+			t.Fatalf("emptied leaf should be removed; FormatSet still has `from protocol`:\n%s", tree.FormatSet())
+		}
+	})
+
+	// (4) whole-leaf delete (no trailing member) still clears the list.
+	t.Run("delete-whole-leaf-no-member", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDelete(t, tree, "delete firewall family inet filter F term T from protocol")
+		got := firewallProtocols(t, tree, "F", "T")
+		if len(got) != 0 {
+			t.Fatalf("after delete whole leaf: protocols = %v, want empty", got)
+		}
+	})
+
+	// (5) deleting a member that is not present is an error (not-found contract).
+	t.Run("delete-absent-member-errors", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		path, _ := ParseSetCommand("delete firewall family inet filter F term T from protocol gre")
+		if err := tree.DeletePath(path); err == nil {
+			t.Fatal("deleting an absent member should return an error")
+		}
+		// The list is untouched by the failed delete.
+		got := firewallProtocols(t, tree, "F", "T")
+		if want := []string{"icmp", "tcp", "udp"}; !equalStrs3846(got, want) {
+			t.Fatalf("after failed delete: protocols = %v, want %v", got, want)
+		}
+	})
+
+	// (6) multiple members in one bracketed delete are all removed.
+	t.Run("delete-multiple-members", func(t *testing.T) {
+		tree := buildTree3846(t, base, accept)
+		mustDelete(t, tree, "delete firewall family inet filter F term T from protocol [ tcp icmp ]")
+		got := firewallProtocols(t, tree, "F", "T")
+		if want := []string{"udp"}; !equalStrs3846(got, want) {
+			t.Fatalf("after delete [tcp icmp]: protocols = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestDeleteMultiLeafMember_HostInboundServices exercises the same fix on a
+// security-zone host-inbound-traffic system-services value list.
+func TestDeleteMultiLeafMember_HostInboundServices(t *testing.T) {
+	tree := buildTree3846(t,
+		"set security zones security-zone trust host-inbound-traffic system-services [ ssh ping https ]",
+	)
+	mustDelete(t, tree, "delete security zones security-zone trust host-inbound-traffic system-services ssh")
+
+	out := tree.FormatSet()
+	if strings.Contains(out, "system-services ssh") {
+		t.Fatalf("ssh should be gone:\n%s", out)
+	}
+	for _, want := range []string{"https", "ping"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("host-inbound-services %q should survive deleting ssh:\n%s", want, out)
+		}
+	}
+
+	// Non-first member removable too.
+	mustDelete(t, tree, "delete security zones security-zone trust host-inbound-traffic system-services https")
+	out = tree.FormatSet()
+	if strings.Contains(out, "https") {
+		t.Fatalf("https should be gone:\n%s", out)
+	}
+	if !strings.Contains(out, "ping") {
+		t.Fatalf("ping should survive:\n%s", out)
+	}
+}
+
+// TestDeleteMultiLeafMember_PolicyMatch exercises the fix on a security policy
+// match value list (source-address).
+func TestDeleteMultiLeafMember_PolicyMatch(t *testing.T) {
+	tree := buildTree3846(t,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set security address-book global address a1 10.0.1.0/24",
+		"set security address-book global address a2 10.0.2.0/24",
+		"set security address-book global address a3 10.0.3.0/24",
+		"set security policies from-zone trust to-zone untrust policy p1 match source-address [ a1 a2 a3 ]",
+		"set security policies from-zone trust to-zone untrust policy p1 match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy p1 match application any",
+		"set security policies from-zone trust to-zone untrust policy p1 then permit",
+	)
+	mustDelete(t, tree, "delete security policies from-zone trust to-zone untrust policy p1 match source-address a2")
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	var pol *Policy
+	for _, pr := range cfg.Security.Policies {
+		if pr.FromZone == "trust" && pr.ToZone == "untrust" {
+			for _, p := range pr.Policies {
+				if p.Name == "p1" {
+					pol = p
+				}
+			}
+		}
+	}
+	if pol == nil {
+		t.Fatal("policy p1 not found")
+	}
+	got := append([]string(nil), pol.Match.SourceAddresses...)
+	sort.Strings(got)
+	if want := []string{"a1", "a3"}; !equalStrs3846(got, want) {
+		t.Fatalf("after delete source-address a2: source-addresses = %v, want %v", got, want)
+	}
+}
+
+// TestDeleteMultiLeafMember_KeyedEntriesUnaffected asserts the args==2 keyed
+// multi entry (address <name> <prefix>) keeps whole-node delete semantics: the
+// #3846 member branch must NOT touch it (deleting `address a1` removes that
+// whole entry, not just the name token).
+func TestDeleteMultiLeafMember_KeyedEntriesUnaffected(t *testing.T) {
+	tree := buildTree3846(t,
+		"set security address-book global address a1 10.0.1.0/24",
+		"set security address-book global address a2 10.0.2.0/24",
+	)
+	mustDelete(t, tree, "delete security address-book global address a1")
+	out := tree.FormatSet()
+	if strings.Contains(out, "address a1") {
+		t.Fatalf("address a1 should be fully deleted:\n%s", out)
+	}
+	if !strings.Contains(out, "address a2 10.0.2.0/24") {
+		t.Fatalf("address a2 should survive intact:\n%s", out)
+	}
+}
+
+func equalStrs3846(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #3846

## Problem

`delete ... from protocol tcp` on a `multi: true` value-list leaf that holds a
bracket list (`from protocol [ tcp udp icmp ]`, policy match
source-/destination-address/application, host-inbound-traffic
system-services/protocols) PREFIX-MATCHED the leaf by its first key in
`removeMatchingNode`/`keysMatch` (`ast_edit.go`) and deleted the **whole list** —
`udp` + `icmp` silently vanished. Worse, a **non-first member** was undeletable:
`delete ... from protocol udp` matched no node and errored.

An operator narrowing a firewall/policy match by removing one protocol instead
widened it by dropping the entire constraint — a config-integrity fail-wide and
potential fail-open. This is the delete-side counterpart of the #2419
multi-value-leaf read class (which fixed the compile/read side).

## Fix

`deletePath` now intercepts value-list multi-leaves (`multi: true`,
`children: nil`, `args == 1`) before the generic node consume/remove and routes
them to a new helper `removeMultiLeafMembers`, which:

- with trailing member token(s), drops **only** those members — reading BOTH the
  flat `Keys[1:]` shape (bracket list / flat set) AND the child-node shape
  (hierarchical block), mirroring `firewallMatchValues` on the read side — and
  removes the leaf entirely only once it is emptied of all members;
- with **no** trailing member (`delete ... from protocol`), still clears the
  whole leaf;
- reports a member that is not present as not-found (matching
  `removeMatchingNode`'s contract).

The `args == 1` gate keeps keyed multi entries on whole-node delete semantics:
`address <name> <prefix>` (`args: 2`) and named containers with children such as
`interfaces <name>` are untouched, so `delete ... address a1` still removes that
entry, not just its name token.

## Tests (RED-on-revert)

`pkg/config/delete_multi_leaf_member_3846_test.go`:

- firewall `from protocol [ tcp udp icmp ]`: delete first member → `[udp icmp]`
  survive; delete non-first member → only `udp` removed; delete only member →
  whole leaf gone; delete whole leaf (no member) → cleared; absent member →
  error; bracketed multi-member delete → all removed
- host-inbound-traffic `system-services` member delete
- policy match `source-address` member delete
- keyed-entry `address <name> <prefix>` non-regression (whole-node delete)

With the intercept disabled, the whole list is emptied on the first member
delete, a non-first-member delete errors, and the host-inbound-services /
policy-match member deletes take the sibling members with them — every "member
survives" assertion goes red.

Validation: `go test ./pkg/config/... ./pkg/configstore/... ./pkg/cli/...
./pkg/grpcapi/...` green; `go build ./...` green; `gofmt` + `go vet` clean.

Docs: `docs/config-schema.md` gains a "Delete-side contract" note under the
multi-value-leaf section; `_Log.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi