### PR TITLE
ipsec: map Junos auth-algorithm to valid strongSwan integrity token (#3851)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28132,3 +28132,40 @@ top.
   removeMultiLeafMembers helper), pkg/config/delete_multi_leaf_member_3846_test.go
   (new RED-on-revert tests), docs/config-schema.md (delete-side member-delete
   contract note)
+
+## 2026-07-03 — #3851 ipsec normalizeAuthAlg strongSwan integrity-token mapping
+- **Timestamp**: 2026-07-03
+- **Action**: Fix `normalizeAuthAlg` (pkg/ipsec/ike.go) so a canonical Junos
+  ESP auth-algorithm name maps to a strongSwan-VALID integrity keyword instead
+  of a dash-stripped token charon rejects. The old body did
+  `ReplaceAll(name,"hmac-","")` + `ReplaceAll(name,"-","")`, so
+  `hmac-sha-256-128` -> `sha256128` and `hmac-sha1-96` -> `sha196`; neither is
+  in strongSwan's proposal_keywords_static.txt, so charon rejected the whole
+  ESP proposal and the tunnel silently never loaded (HIGH, fable-161 F-017).
+  New impl collapses the name (drop hmac-, drop dashes, lowercase) then matches
+  the base SHA/MD5 family (sha512/sha384/sha256/sha224/sha1/md5), covering the
+  Junos truncation-length suffixes (-128/-192/-256/-96), the IKE short forms
+  (sha-256/sha1/md5), and already-normalized swanctl tokens (idempotent).
+  Unknown names fall through to the collapsed token (historical behaviour).
+  AES-GCM path unaffected (callers take the gcmPRF branch for AEAD).
+- **Tests corrected (they PINNED the broken form)**: the assertion strings
+  `aes256-sha256128-modp2048` -> `aes256-sha256-modp2048` in ipsec_test.go
+  (TestGenerateConfig_WithProposal, TestBuildESPProposal, _PFSOverride,
+  TestGenerateConfig_GatewayReference, TestBuildIKEProposal,
+  TestGenerateConfig_IKEChain), dhgroup_roundtrip_test.go
+  (TestPhase2DHGroupParseRenderRoundTrip), swanctl_render_test.go
+  (TestBuildESPProposal_JunosGCMSuffix / _JunosGCMSuffixAndPRF non-gcm cases);
+  the GCM negative assertion in TestGenerateConfig_GCMNoAuth updated
+  `sha256128-modp2048` -> `sha256-modp2048`. Added
+  TestNormalizeAuthAlg_JunosToStrongSwan (full Junos->keyword table + asserts
+  each output is in the strongSwan integrity keyword set) and
+  TestBuildProposals_IntegTokenStrongSwanValid (assembled ESP/IKE proposal
+  string carries a strongSwan-valid integrity token).
+- **RED-on-revert proven**: reverting normalizeAuthAlg to the naive
+  dash-strip fails TestNormalizeAuthAlg_JunosToStrongSwan (returns "sha256128")
+  plus the 8 corrected pin tests. go test -count=1 ./pkg/ipsec/... green;
+  go build ./... green; gofmt + vet clean.
+- **File(s)**: pkg/ipsec/ike.go (normalizeAuthAlg rewrite + resolveESPSettings
+  comment), pkg/ipsec/ipsec_test.go, pkg/ipsec/dhgroup_roundtrip_test.go,
+  pkg/ipsec/swanctl_render_test.go (corrected pins + new tests),
+  pkg/ipsec/README.md (#3851 integrity-token mapping bullet)

--- a/pkg/ipsec/README.md
+++ b/pkg/ipsec/README.md
@@ -299,6 +299,27 @@ all files stay in `package ipsec`, so the public API is unchanged.
   ESP render was valid — the canonicalization just makes the ICV
   explicit in the generated config. Already-suffixed forms (e.g.
   `aes256gcm128`) pass through unchanged.
+- **ESP/IKE integrity-token mapping (#3851).** `normalizeAuthAlg`
+  (`ike.go`) maps a Junos `authentication-algorithm` name to the
+  strongSwan integrity keyword charon actually accepts. Junos names an
+  ESP integrity algorithm with an explicit HMAC truncation length
+  (`hmac-sha-256-128`, `hmac-sha1-96`, `hmac-md5-96`,
+  `hmac-sha-384-192`, `hmac-sha-512-256`), but strongSwan's proposal
+  keyword table names the BASE algorithm only (`sha256`, `sha1`, `md5`,
+  `sha384`, `sha512`) and derives the RFC-mandated truncation
+  internally. The truncation suffix must be MAPPED away, not
+  dash-stripped: the old normalizer did `ReplaceAll(name, "-", "")`, so
+  `hmac-sha-256-128` rendered as `sha256128` and `hmac-sha1-96` as
+  `sha196` — neither is a token in
+  `proposal_keywords_static.txt`, so charon rejected the ENTIRE ESP
+  proposal and the tunnel silently never loaded. The current mapping
+  collapses the name (drop `hmac-`, drop dashes) then matches the base
+  SHA/MD5 family, so every Junos spelling — the ESP truncated forms, the
+  IKE short forms (`sha-256`, `sha1`, `md5`), and already-normalized
+  swanctl tokens (idempotent) — yields a valid keyword. AEAD (GCM)
+  proposals never reach this function: the builders take the `gcmPRF`
+  branch for AEAD ciphers (GCM carries its own ICV, no separate
+  integrity algorithm), so this fix does not touch the GCM path.
 - **swanctl double-quote / backslash escaping (#2126).** Free-text
   values interpolated inside a swanctl double-quoted string — the PSK
   `secret = "..."` and the `id = "..."` / `certs = "..."` lines — are

--- a/pkg/ipsec/dhgroup_roundtrip_test.go
+++ b/pkg/ipsec/dhgroup_roundtrip_test.go
@@ -41,7 +41,7 @@ func TestPhase2DHGroupParseRenderRoundTrip(t *testing.T) {
 		t.Fatalf("parsed DHGroup = %d, want 14 (group14 must not be dropped)", prop.DHGroup)
 	}
 	got := buildESPProposal(prop, 0)
-	const want = "aes256-sha256128-modp2048"
+	const want = "aes256-sha256-modp2048"
 	if got != want {
 		t.Errorf("rendered ESP proposal = %q, want %q", got, want)
 	}

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -104,14 +104,16 @@ func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, 
 			// requires an integrity algorithm, so the fallback includes
 			// both a cipher and integrity in addition to the modp term. The
 			// string is built directly with swanctl's canonical keyword
-			// spellings (aes256 / sha256 / modp<bits>) rather than via
-			// buildESPProposal: buildESPProposal's hmac-sha-256-128
-			// normalization emits the non-canonical "sha256128" token,
-			// which strongSwan's proposal parser does not recognize (its
+			// spellings (aes256 / sha256 / modp<bits>). This is now the
+			// same integrity keyword buildESPProposal produces —
+			// normalizeAuthAlg maps hmac-sha-256-128 to the strongSwan base
+			// keyword "sha256" (#3851), not the invalid dash-stripped
+			// "sha256128" that strongSwan's proposal parser rejects (its
 			// keyword table has only "sha256"/"sha2_256" for
-			// AUTH_HMAC_SHA2_256_128) and would reject the whole proposal.
-			// (The normal-path "sha256128" spelling is a separate
-			// pre-existing concern tracked outside #2073.)
+			// AUTH_HMAC_SHA2_256_128). This fallback keeps the direct
+			// spelling because the proposal reference dangles (there is no
+			// proposal object to hand to buildESPProposal), not because the
+			// builder is unsafe.
 			//
 			// formatDHGroup renders the PFS group with its canonical
 			// swanctl keyword: modp<bits> for the MODP groups
@@ -251,12 +253,60 @@ func gcmPRF(authAlg string) string {
 	}
 }
 
-// normalizeAuthAlg maps a Junos authentication-algorithm name to its
-// swanctl integrity token (hmac-sha-256 -> sha256).
+// normalizeAuthAlg maps a Junos authentication-algorithm name to the
+// swanctl/charon integrity token that strongSwan actually accepts.
+//
+// Junos names an ESP integrity algorithm with an explicit HMAC
+// truncation length: hmac-sha-256-128, hmac-sha1-96, hmac-md5-96,
+// hmac-sha-384-192, hmac-sha-512-256. strongSwan's proposal keyword
+// table names the BASE algorithm only (sha256, sha1, md5, sha384,
+// sha512) and derives the RFC-mandated truncation internally. The Junos
+// truncation suffix must therefore be mapped away, NOT dash-stripped: a
+// naive strings.ReplaceAll(authAlg, "-", "") on hmac-sha-256-128 yields
+// "sha256128", which is not a token in strongSwan's
+// proposal_keywords_static.txt, so charon rejects the ENTIRE ESP/IKE
+// proposal and the tunnel silently never loads (#3851).
+//
+// The IKE (Phase 1) config layer feeds the shorter Junos spellings
+// (sha-256, sha1, md5) with no truncation suffix, and swanctl tokens
+// (sha256) can also arrive already normalized; all collapse to the same
+// canonical token here, so the function is idempotent.
+//
+// AEAD (GCM) proposals never reach this function — the callers take the
+// gcmPRF() branch for AEAD ciphers, which carry their own ICV and no
+// separate integrity algorithm.
 func normalizeAuthAlg(authAlg string) string {
-	a := strings.ReplaceAll(authAlg, "hmac-", "")
+	// Collapse every Junos/swanctl spelling to one comparable token:
+	// drop the hmac- prefix and all dashes. hmac-sha-256-128 ->
+	// "sha256128", sha-256 -> "sha256", sha256 -> "sha256".
+	a := strings.ToLower(authAlg)
+	a = strings.ReplaceAll(a, "hmac-", "")
 	a = strings.ReplaceAll(a, "-", "")
-	return a
+
+	// Map the collapsed token (with any truncation-length suffix) to the
+	// strongSwan base-algorithm keyword. Longer SHA-2 digests are matched
+	// before sha1 so no truncation suffix can be misread.
+	switch {
+	case a == "":
+		return ""
+	case strings.HasPrefix(a, "sha512"):
+		return "sha512"
+	case strings.HasPrefix(a, "sha384"):
+		return "sha384"
+	case strings.HasPrefix(a, "sha256"):
+		return "sha256"
+	case strings.HasPrefix(a, "sha224"):
+		return "sha224"
+	case strings.HasPrefix(a, "sha1"):
+		return "sha1"
+	case strings.HasPrefix(a, "md5"):
+		return "md5"
+	default:
+		// Unknown algorithm: return the collapsed token unchanged rather
+		// than inventing a spelling. This preserves the historical
+		// behaviour for any name outside the known SHA/MD5 family.
+		return a
+	}
 }
 
 // buildIKEProposalFromIKE builds a swanctl IKE proposal string from an IKE proposal.

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -70,7 +70,7 @@ func TestGenerateConfig_WithProposal(t *testing.T) {
 		},
 	}
 	got := m.generateConfig(cfg)
-	if !strings.Contains(got, "esp_proposals = aes256-sha256128-modp2048") {
+	if !strings.Contains(got, "esp_proposals = aes256-sha256-modp2048") {
 		t.Errorf("unexpected esp_proposals in: %s", got)
 	}
 }
@@ -94,8 +94,10 @@ func TestGenerateConfig_GCMNoAuth(t *testing.T) {
 		},
 	}
 	got := m.generateConfig(cfg)
-	// GCM mode should skip auth algorithm
-	if strings.Contains(got, "sha256128-modp2048") {
+	// GCM mode should skip auth algorithm — no integrity token is emitted
+	// for an AEAD cipher (the caller takes the gcmPRF branch, not
+	// normalizeAuthAlg), so the strongSwan integrity keyword must be absent.
+	if strings.Contains(got, "sha256-modp2048") {
 		t.Errorf("GCM should not include auth alg: %s", got)
 	}
 	if !strings.Contains(got, "esp_proposals = aes256gcm128-modp2048") {
@@ -155,7 +157,7 @@ func TestBuildESPProposal(t *testing.T) {
 		{
 			"aes-sha256-dh14",
 			&config.IPsecProposal{EncryptionAlg: "aes256-cbc", AuthAlg: "hmac-sha256-128", DHGroup: 14},
-			"aes256-sha256128-modp2048",
+			"aes256-sha256-modp2048",
 		},
 		{
 			"defaults",
@@ -187,8 +189,8 @@ func TestBuildESPProposal_PFSOverride(t *testing.T) {
 		DHGroup:       2,
 	}
 	got := buildESPProposal(prop, 14)
-	if got != "aes256-sha256128-modp2048" {
-		t.Fatalf("buildESPProposal() with PFS override = %q, want aes256-sha256128-modp2048", got)
+	if got != "aes256-sha256-modp2048" {
+		t.Fatalf("buildESPProposal() with PFS override = %q, want aes256-sha256-modp2048", got)
 	}
 }
 
@@ -378,11 +380,11 @@ func TestGenerateConfig_GatewayReference(t *testing.T) {
 		t.Errorf("gateway local address not resolved: %s", got)
 	}
 	// Should have IKE proposals from gateway's ike-policy
-	if !strings.Contains(got, "proposals = aes256-sha256128-modp2048") {
+	if !strings.Contains(got, "proposals = aes256-sha256-modp2048") {
 		t.Errorf("IKE proposals not generated: %s", got)
 	}
 	// Should have ESP proposals from VPN's ipsec-policy
-	if !strings.Contains(got, "esp_proposals = aes256-sha256128-modp2048") {
+	if !strings.Contains(got, "esp_proposals = aes256-sha256-modp2048") {
 		t.Errorf("ESP proposals not generated: %s", got)
 	}
 }
@@ -419,7 +421,7 @@ func TestBuildIKEProposal(t *testing.T) {
 		{
 			"aes-sha256-dh14",
 			&config.IPsecProposal{EncryptionAlg: "aes256-cbc", AuthAlg: "hmac-sha256-128", DHGroup: 14},
-			"aes256-sha256128-modp2048",
+			"aes256-sha256-modp2048",
 		},
 		{
 			"defaults",
@@ -539,7 +541,7 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 		{"local identity", `id = "@vpn.example.com"`},
 		{"remote identity", `id = "203.0.113.1"`},
 		{"IKE proposal", "proposals = aes256-sha256-modp2048"},
-		{"ESP proposal", "esp_proposals = aes256-sha256128-modp2048"},
+		{"ESP proposal", "esp_proposals = aes256-sha256-modp2048"},
 		{"copy DF", "copy_df = yes"},
 		{"start action", "start_action = start"},
 		{"DPD action", "dpd_action = restart"},

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -58,10 +58,12 @@ func TestBuildESPProposal_JunosGCMSuffix(t *testing.T) {
 			"aes256gcm128-modp2048",
 		},
 		{
-			// Non-GCM CBC path stays byte-identical to the old behavior.
-			"non-gcm cbc unchanged",
+			// Non-GCM CBC path: the Junos truncation suffix (-128) maps to
+			// the strongSwan base integrity keyword sha256, NOT the invalid
+			// dash-stripped "sha256128" (#3851).
+			"non-gcm cbc integ",
 			&config.IPsecProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha256-128", DHGroup: 14},
-			"aes256-sha256128-modp2048",
+			"aes256-sha256-modp2048",
 		},
 	}
 	for _, tt := range tests {
@@ -101,7 +103,7 @@ func TestBuildIKEProposal_JunosGCMSuffixAndPRF(t *testing.T) {
 		{
 			"non-gcm cbc unchanged",
 			&config.IPsecProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha256-128", DHGroup: 14},
-			"aes256-sha256128-modp2048",
+			"aes256-sha256-modp2048",
 		},
 	}
 	for _, tt := range tests {
@@ -481,5 +483,107 @@ func assertBalancedSecretQuotes(t *testing.T, cfg string) {
 		case term != len(val)-1:
 			t.Errorf("secret value terminates before end of line (unescaped interior quote): %q", val)
 		}
+	}
+}
+
+// strongSwanIntegKeywords is the set of integrity-algorithm proposal
+// keywords that strongSwan/charon actually accepts (the short spellings
+// from src/libstrongswan/crypto/proposal/proposal_keywords_static.txt).
+// A token outside this set makes charon reject the WHOLE proposal, so the
+// tunnel silently never loads — the #3851 failure mode.
+var strongSwanIntegKeywords = map[string]bool{
+	"md5":    true,
+	"sha1":   true,
+	"sha224": true,
+	"sha256": true,
+	"sha384": true,
+	"sha512": true,
+}
+
+// TestNormalizeAuthAlg_JunosToStrongSwan is the #3851 regression: every
+// canonical Junos authentication-algorithm spelling — including the
+// explicit HMAC truncation-length suffix Junos uses for ESP
+// (hmac-sha-256-128, hmac-sha1-96, ...) — must map to a strongSwan-VALID
+// base integrity keyword. The pre-fix normalizer dash-stripped the name
+// and produced "sha256128"/"sha196"/"md596", which are NOT strongSwan
+// keywords, so charon rejected the ESP proposal and the tunnel never
+// loaded. This table pins the VALID output; it goes RED on revert (the
+// old code returns the invalid dash-stripped token, which is not in
+// strongSwanIntegKeywords).
+func TestNormalizeAuthAlg_JunosToStrongSwan(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		// Junos ESP spellings with explicit truncation length.
+		{"hmac-sha-256-128", "sha256"},
+		{"hmac-sha256-128", "sha256"},
+		{"hmac-sha-384-192", "sha384"},
+		{"hmac-sha-512-256", "sha512"},
+		{"hmac-sha1-96", "sha1"},
+		{"hmac-sha-1-96", "sha1"},
+		{"hmac-md5-96", "md5"},
+		// Junos ESP spellings without a truncation suffix.
+		{"hmac-sha-256", "sha256"},
+		{"hmac-sha-384", "sha384"},
+		{"hmac-sha-512", "sha512"},
+		{"hmac-sha1", "sha1"},
+		{"hmac-md5", "md5"},
+		// Junos IKE (Phase 1) short spellings.
+		{"sha-256", "sha256"},
+		{"sha-384", "sha384"},
+		{"sha-512", "sha512"},
+		{"sha1", "sha1"},
+		{"sha-1", "sha1"},
+		{"md5", "md5"},
+		// Already-normalized swanctl tokens are idempotent.
+		{"sha256", "sha256"},
+		{"sha384", "sha384"},
+		{"sha512", "sha512"},
+		// Case-insensitive.
+		{"HMAC-SHA-256-128", "sha256"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := normalizeAuthAlg(tt.in)
+			if got != tt.want {
+				t.Fatalf("normalizeAuthAlg(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if !strongSwanIntegKeywords[got] {
+				t.Fatalf("normalizeAuthAlg(%q) = %q, which is NOT a strongSwan integrity keyword (charon would reject the whole proposal)", tt.in, got)
+			}
+		})
+	}
+}
+
+// TestBuildProposals_IntegTokenStrongSwanValid asserts that the assembled
+// ESP and IKE proposal STRINGS carry a strongSwan-valid integrity token
+// for the canonical Junos ESP auth-algorithm name that shipped broken.
+// The whole proposal string must parse: aes256-sha256-modp2048, not
+// aes256-sha256128-modp2048 (which charon rejects wholesale).
+func TestBuildProposals_IntegTokenStrongSwanValid(t *testing.T) {
+	espProp := &config.IPsecProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256-128", DHGroup: 14}
+	if got, want := buildESPProposal(espProp, 0), "aes256-sha256-modp2048"; got != want {
+		t.Fatalf("buildESPProposal() = %q, want %q", got, want)
+	}
+	assertProposalIntegValid(t, buildESPProposal(espProp, 0))
+
+	ikeProp := &config.IKEProposal{EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14}
+	if got, want := buildIKEProposalFromIKE(ikeProp), "aes256-sha256-modp2048"; got != want {
+		t.Fatalf("buildIKEProposalFromIKE() = %q, want %q", got, want)
+	}
+	assertProposalIntegValid(t, buildIKEProposalFromIKE(ikeProp))
+}
+
+// assertProposalIntegValid checks that a rendered non-AEAD proposal of the
+// form <enc>-<integ>-<dh> carries an integrity token strongSwan accepts.
+func assertProposalIntegValid(t *testing.T, proposal string) {
+	t.Helper()
+	parts := strings.Split(proposal, "-")
+	if len(parts) != 3 {
+		t.Fatalf("proposal %q not in <enc>-<integ>-<dh> form", proposal)
+	}
+	if integ := parts[1]; !strongSwanIntegKeywords[integ] {
+		t.Fatalf("proposal %q carries integrity token %q that strongSwan does not accept — charon would reject the whole proposal", proposal, integ)
 	}
 }


### PR DESCRIPTION
Closes #3851

## Problem

`normalizeAuthAlg` (`pkg/ipsec/ike.go`) mapped a canonical Junos ESP
`authentication-algorithm` name to a strongSwan-INVALID integrity keyword.
It stripped the `hmac-` prefix and then every dash, leaving the Junos HMAC
truncation-length suffix stuck to the base name:

| Junos name         | old output (invalid) | correct strongSwan keyword |
|--------------------|----------------------|----------------------------|
| `hmac-sha-256-128` | `sha256128`          | `sha256`                   |
| `hmac-sha256-128`  | `sha256128`          | `sha256`                   |
| `hmac-sha-384-192` | `sha384192`          | `sha384`                   |
| `hmac-sha-512-256` | `sha512256`          | `sha512`                   |
| `hmac-sha1-96`     | `sha196`             | `sha1`                     |
| `hmac-md5-96`      | `md596`              | `md5`                      |

strongSwan's proposal keyword table (`proposal_keywords_static.txt`) names
the **base** algorithm only and derives the RFC truncation internally. A
single unrecognized token makes charon reject the **entire** ESP/IKE
proposal, so any tunnel using a Junos-canonical `hmac-sha-*-*` /
`hmac-sha1-96` / `hmac-md5-96` auth-algorithm silently never loaded (HIGH,
fable-review-161 F-017). Only the #2073 dangling-proposal fallback was
hardcoded to the correct `sha256`; the normal render path stayed broken —
and the tests **pinned the broken spelling**, which is why the bug shipped
green.

## Fix

Rewrite `normalizeAuthAlg` to map, not dash-strip: collapse the input
(lowercase, drop `hmac-`, drop dashes) to one comparable token, then map to
the strongSwan base keyword by matching the SHA/MD5 family (longer SHA-2
digests first so a truncation suffix can never be misread). Covers the
Junos ESP truncated forms, the Junos IKE short forms (`sha-256`, `sha1`,
`md5`), and already-normalized swanctl tokens (idempotent). Unknown names
fall through to the collapsed token (historical behaviour).

AES-GCM is untouched — the builders take the `gcmPRF` branch for AEAD
ciphers (GCM carries its own ICV, no separate integrity algorithm), so
`normalizeAuthAlg` is never called on the GCM path.

## Tests

- Corrected the eight assertions that pinned `aes256-sha256128-modp2048` to
  `aes256-sha256-modp2048` (ipsec_test.go, dhgroup_roundtrip_test.go,
  swanctl_render_test.go); the GCM negative assertion now checks the valid
  `sha256-modp2048` token.
- Added `TestNormalizeAuthAlg_JunosToStrongSwan` (full Junos→keyword table +
  asserts each output is in the strongSwan integrity keyword set) and
  `TestBuildProposals_IntegTokenStrongSwanValid` (assembled ESP/IKE proposal
  string carries a valid integrity token).

**RED-on-revert verified:** reverting `normalizeAuthAlg` to the naive
dash-strip fails the new table test (`normalizeAuthAlg("hmac-sha-256-128")`
returns the invalid `sha256128`) plus the eight corrected pin tests.
`go test -count=1 ./pkg/ipsec/...` green; `go build ./...` green; gofmt +
vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
