### PR TITLE
config: symmetric backslash/newline escape in quoteKey (fix Format→Parse round-trip corruption)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28169,3 +28169,33 @@ top.
   comment), pkg/ipsec/ipsec_test.go, pkg/ipsec/dhgroup_roundtrip_test.go,
   pkg/ipsec/swanctl_render_test.go (corrected pins + new tests),
   pkg/ipsec/README.md (#3851 integrity-token mapping bullet)
+
+## 2026-07-03 — #3854 quoteKey symmetric backslash/newline escape (fable-161 F-005)
+
+- **Timestamp**: 2026-07-03
+- **Action**: Fix `quoteKey` Format→Parse round-trip corruption. The lexer's
+  `readString` un-escapes exactly `\"`→`"`, `\\`→`\`, `\n`→newline, but
+  `quoteKey` escaped only `"` — so any value with a backslash before `n`/`"`/`\`
+  (e.g. an IKE PSK `ascii-text`) corrupted on every Format→Parse cycle, silently
+  diverging the HA standby's config (config sync = Format→wire→Parse) and
+  corrupting rollback slots serialized via Format.
+- **Fix**: replaced the quote-only `strings.ReplaceAll` with a package-level
+  single-pass `keyEscaper = strings.NewReplacer(`\`→`\\`, `"`→`\"`, "\n"→`\n`)`
+  whose emitted escape set is EXACTLY the lexer's decode set. Single pass ⇒
+  backslash escaped before the quote it may precede (no `\"`→`\\"` double-process);
+  no over-escape of bytes the lexer passes through verbatim (e.g. `\t`).
+- **Tests (RED-on-revert)**: added `quotekey_roundtrip_3854_test.go` —
+  `TestQuoteKeyLexerSymmetry3854` (unit: quoteKey→lexer symmetric per value),
+  `TestFormatParseRoundTrip3854` (integration over the real Format→Parse path,
+  incl. an IKE-PSK-like `secret\with\backslashes` + backslash-before-n/quote +
+  double-backslash + newline + kitchen-sink), `TestFormatParseIdempotent3854`.
+  Verified RED on a temporary revert to the quote-only escape (Format→Parse
+  corrupted `pass\node`→`pass<newline>ode`, double-backslash lost a `\`,
+  backslash-quote truncated), GREEN with the fix.
+- **Validation**: go test ./pkg/config/... green; consumer pkgs
+  ./pkg/configstore/... + ./pkg/cluster/... green; go build ./... green;
+  gofmt + vet clean.
+- **File(s)**: pkg/config/ast.go (keyEscaper + quoteKey),
+  pkg/config/quotekey_roundtrip_3854_test.go (new),
+  docs/config-schema.md (Quoted-value escape round-trip contract subsection),
+  _Log.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -585,6 +585,31 @@ is exactly the repetition). The ordered list lands in `PolicyTerm.ASPathPrepend
 `TestGeneratePolicyOptions_ASPathPrepend` in
 `pkg/frr/policy_as_path_prepend_2892_test.go` (render).
 
+### Quoted-value escape round-trip contract (#3854)
+
+When a key or value contains a character that is not a bare Junos identifier
+byte (`isIdentChar` in `lexer.go` — anything outside letters/digits/`-_./:*+%=,<>`),
+`Format`/`FormatSet` wrap it in double quotes via `quoteKey` (`ast.go`). The set
+of characters `quoteKey` escapes MUST exactly match the set the lexer's
+`readString` un-escapes on parse, or the config does not round-trip. The lexer
+decodes exactly three sequences — `\"` → `"`, `\\` → `\`, and `\n` → newline —
+and preserves any other `\X` verbatim. `quoteKey` therefore escapes exactly
+those three characters (backslash, double-quote, newline) via the single-pass
+`keyEscaper` (`strings.NewReplacer(`\`→`\\`, `"`→`\"`, "\n"→`\n`)). Backslash is
+escaped first (in the same pass) so `\"` cannot double-process into `\\"`.
+
+This symmetry guarantees `Format(Parse(x)) == x` and `Parse(Format(x)) == x` for
+every value — critically an IKE pre-shared-key `ascii-text` (or any string leaf)
+containing a backslash. Before #3854 `quoteKey` escaped only `"`, so a value like
+`P@ss\next` (backslash before `n`) was corrupted on every `Format→Parse` cycle:
+HA config sync (which is `Format→wire→Parse`) silently diverged the standby's PSK
+so IPsec failed to re-establish on failover, and rollback slots serialized via
+`Format` round-tripped to a different, possibly invalid config. Do NOT add escapes
+for characters the lexer does not interpret (e.g. `\t`) — that would over-escape
+and break the symmetry in the other direction. Pinned by
+`pkg/config/quotekey_roundtrip_3854_test.go` (`TestQuoteKeyLexerSymmetry3854`,
+`TestFormatParseRoundTrip3854`, `TestFormatParseIdempotent3854`).
+
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 
 The dual-AST contract above covers a single leaf carrying a bracketed list

--- a/pkg/config/ast.go
+++ b/pkg/config/ast.go
@@ -73,16 +73,28 @@ func (n *Node) QuotedKeyPath() string {
 	return strings.Join(parts, " ")
 }
 
+// keyEscaper escapes exactly the characters that the lexer's readString
+// (pkg/config/lexer.go) un-escapes on parse: backslash, double-quote, and
+// newline. The mapping is symmetric — the set of sequences emitted here is
+// identical to the set the lexer decodes — so Format(Parse(x)) == x and
+// Parse(Format(x)) == x for every value, including IKE pre-shared keys and
+// other string leaves that contain a backslash (the #3854 corruption). It is
+// a single-pass Replacer, so backslash is escaped before (never after) the
+// quote it may precede: `\"` never double-processes into `\\"`. Do not add
+// escapes for characters the lexer does not interpret (e.g. `\t`), or the
+// round-trip would over-escape and diverge.
+var keyEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
+
 // quoteKey wraps a key in double quotes if it contains characters that
-// are not valid in bare Junos identifiers.
+// are not valid in bare Junos identifiers, escaping backslash, quote, and
+// newline so the quoted form round-trips symmetrically through the lexer.
 func quoteKey(s string) string {
 	if s == "" {
 		return `""`
 	}
 	for i := 0; i < len(s); i++ {
 		if !isIdentChar(s[i]) {
-			// Escape any internal quotes.
-			return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+			return `"` + keyEscaper.Replace(s) + `"`
 		}
 	}
 	return s

--- a/pkg/config/quotekey_roundtrip_3854_test.go
+++ b/pkg/config/quotekey_roundtrip_3854_test.go
@@ -1,0 +1,181 @@
+package config
+
+// Round-trip property test for quoteKey ↔ lexer symmetry (#3854,
+// fable-review-161 F-005).
+//
+// quoteKey (ast.go) is the sole quoting function for every Format output
+// path (QuotedKeyPath, joinQuotedKeys). The lexer's readString (lexer.go)
+// un-escapes exactly three sequences on parse: `\"` -> `"`, `\\` -> `\`,
+// and `\n` -> newline. Before #3854 quoteKey escaped only `"`, so any value
+// containing a backslash immediately before `n`, `"`, or another backslash
+// was CORRUPTED by every Format->Parse cycle: Format emitted the raw
+// backslash and the lexer then re-interpreted it. That silently diverged
+// the HA standby's config (config sync is Format->wire->Parse — e.g. an IKE
+// pre-shared-key `ascii-text` with a backslash) and corrupted rollback
+// slots serialized via Format.
+//
+// The fix makes the emitted escape set EXACTLY match the lexer's decode set
+// (`\`, `"`, newline), so Format(Parse(x)) == x and Parse(Format(x)) == x
+// for all values. This test asserts that round-trip identity and its
+// idempotence over values containing backslashes, quotes, and newlines. It
+// goes RED on any revert that drops the backslash (or newline) escape.
+
+import "testing"
+
+// roundTripValues are string leaf values that MUST survive a
+// Format->Parse round-trip byte-for-byte. Several are chosen so the raw
+// backslash they carry sits immediately before a lexer-significant byte
+// (`n`, `"`, `\`) — those are the ones the pre-#3854 quoteKey corrupted, so
+// this slice is what makes the test RED on revert.
+var roundTripValues = []struct {
+	name  string
+	value string
+}{
+	// The issue's IKE PSK example. `\w`/`\b` are lexer default-case bytes,
+	// so this particular value happened to survive the old code; kept for
+	// provenance coverage.
+	{"ike-psk-backslashes", `secret\with\backslashes`},
+	// Backslash immediately before 'n': old code emitted `\n`, which the
+	// lexer decoded to a literal newline -> corruption (RED on revert).
+	{"backslash-before-n", `pass\node`},
+	// A realistic IKE PSK whose backslash precedes 'n'.
+	{"ike-psk-backslash-n", `P@ss\w0rd\next`},
+	// Two consecutive backslashes: old code emitted `\\`, decoded back to a
+	// single backslash -> a backslash is silently lost (RED on revert).
+	{"double-backslash", `back\\slash`},
+	// Backslash immediately before a quote: old code emitted `\` then `\"`,
+	// decoded as `\` then string-terminating `"` -> truncation (RED).
+	{"backslash-before-quote", `quote\"inside`},
+	// A bare embedded quote (handled even by the old code) — regression
+	// guard that escaping backslash first did not break quote escaping.
+	{"bare-quote", `has"quote`},
+	// A literal newline byte. Symmetric under both old and new code (the
+	// lexer preserves a literal newline), but the new code emits it as the
+	// escaped `\n` — assert it still round-trips to the same newline.
+	{"literal-newline", "line1\nline2"},
+	// Every special byte at once, plus structural chars that only survive
+	// because the value is quoted.
+	{"kitchen-sink", "a\\b\"c\nd{e}f;g"},
+	// Empty value must stay empty ("" <-> "").
+	{"empty", ""},
+}
+
+// leafValueTree wraps a value as the trailing key of a single hierarchical
+// leaf, mirroring how a real config value (e.g. an IKE pre-shared-key) is
+// stored in the AST.
+func leafValueTree(value string) *ConfigTree {
+	return &ConfigTree{Children: []*Node{
+		{Keys: []string{"security"}, Children: []*Node{
+			{Keys: []string{"ike"}, Children: []*Node{
+				{Keys: []string{"policy", "ike-pol"}, Children: []*Node{
+					{Keys: []string{"pre-shared-key", "ascii-text", value}, IsLeaf: true},
+				}},
+			}},
+		}},
+	}}
+}
+
+// findPSKLeaf walks the tree for the leaf whose first key is
+// "pre-shared-key". The parser collapses `pre-shared-key ascii-text
+// "value"` onto one leaf's Keys, so the value is that leaf's trailing key.
+func findPSKLeaf(nodes []*Node) *Node {
+	for _, n := range nodes {
+		if len(n.Keys) > 0 && n.Keys[0] == "pre-shared-key" {
+			return n
+		}
+		if found := findPSKLeaf(n.Children); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// extractLeafValue returns the trailing key of the pre-shared-key leaf, or
+// fails the test if the tree shape is not what Format->Parse should yield.
+func extractLeafValue(t *testing.T, tree *ConfigTree) string {
+	t.Helper()
+	node := findPSKLeaf(tree.Children)
+	if node == nil {
+		t.Fatalf("pre-shared-key leaf not found after round-trip")
+	}
+	if len(node.Keys) < 2 {
+		t.Fatalf("pre-shared-key leaf has too few keys: %v", node.Keys)
+	}
+	return node.Keys[len(node.Keys)-1]
+}
+
+// TestQuoteKeyLexerSymmetry3854 is the unit-level RED signal: the bytes
+// quoteKey emits must lex back to the original value. This directly pins
+// quoteKey's escape set to the lexer's decode set.
+func TestQuoteKeyLexerSymmetry3854(t *testing.T) {
+	for _, tc := range roundTripValues {
+		if tc.value == "" {
+			continue // "" lexes as an empty string token; covered below.
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			quoted := quoteKey(tc.value)
+			tok := NewLexer(quoted).Next()
+			if tok.Type == TokenError {
+				t.Fatalf("quoteKey(%q)=%q lexed to error token %q", tc.value, quoted, tok.Value)
+			}
+			if tok.Value != tc.value {
+				t.Fatalf("quoteKey->lexer not symmetric: quoteKey(%q)=%q lexed back to %q",
+					tc.value, quoted, tok.Value)
+			}
+		})
+	}
+}
+
+// TestFormatParseRoundTrip3854 is the integration-level assertion over the
+// real HA config-sync path: build a tree with a special value, Format it to
+// text, and re-Parse the text. The recovered value must be byte-identical.
+func TestFormatParseRoundTrip3854(t *testing.T) {
+	for _, tc := range roundTripValues {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := leafValueTree(tc.value)
+
+			text := tree.Format()
+			parsed, errs := NewParser(text).Parse()
+			if len(errs) != 0 {
+				t.Fatalf("Parse(Format(%q)) returned errors %v\nformatted:\n%s", tc.value, errs, text)
+			}
+			got := extractLeafValue(t, parsed)
+			if got != tc.value {
+				t.Fatalf("Format->Parse corrupted value: original %q != round-tripped %q\nformatted:\n%s",
+					tc.value, got, text)
+			}
+		})
+	}
+}
+
+// TestFormatParseIdempotent3854 asserts the round-trip reaches a fixed
+// point: Parse(Format(x)) reconstructs a tree whose Format output is stable
+// across further cycles. A non-symmetric escape would drift the text on each
+// cycle (or fail to parse), so identical Format output across three cycles
+// is the idempotence guarantee.
+func TestFormatParseIdempotent3854(t *testing.T) {
+	for _, tc := range roundTripValues {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := leafValueTree(tc.value)
+
+			f1 := tree.Format()
+			p2, errs := NewParser(f1).Parse()
+			if len(errs) != 0 {
+				t.Fatalf("cycle 1 parse errors %v\n%s", errs, f1)
+			}
+			f2 := p2.Format()
+			p3, errs := NewParser(f2).Parse()
+			if len(errs) != 0 {
+				t.Fatalf("cycle 2 parse errors %v\n%s", errs, f2)
+			}
+			f3 := p3.Format()
+
+			if f1 != f2 {
+				t.Fatalf("Format not a fixed point after one round-trip:\n--- f1 ---\n%s\n--- f2 ---\n%s", f1, f2)
+			}
+			if f2 != f3 {
+				t.Fatalf("Format not idempotent across cycles:\n--- f2 ---\n%s\n--- f3 ---\n%s", f2, f3)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`quoteKey` (`pkg/config/ast.go`) — the sole quoting function for every `Format`/`FormatSet` output path (`QuotedKeyPath`, `joinQuotedKeys`) — escaped embedded double-quotes but **never backslashes or newlines**, while the lexer's `readString` (`pkg/config/lexer.go`) un-escapes three sequences on parse: `\"` → `"`, `\\` → `\`, `\n` → newline.

The two sides were asymmetric, so any value carrying a backslash immediately before `n`, `"`, or another backslash was **corrupted on every `Format→Parse` cycle** — Format emitted a raw backslash and the lexer re-interpreted it.

### Impact (fable-review-161 F-005 — HIGH, HA config-integrity divergence)

- An IKE pre-shared-key `ascii-text` (or any string leaf) containing a backslash round-trips to a **different** value.
- HA config sync is `Format→wire→Parse`, so the standby silently receives a **diverged PSK** → IPsec fails to re-establish on failover.
- Rollback slots serialized via `Format` round-trip to a different, possibly **uncommittable** config.

## Fix (`pkg/config/ast.go`)

Replaced the quote-only `strings.ReplaceAll` with a package-level **single-pass** replacer whose emitted escape set is **exactly** the lexer's decode set:

```go
var keyEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
```

- Single `Replacer` pass ⇒ backslash is escaped **before** the quote it may precede, so `\"` never double-processes into `\\"`.
- Does **not** over-escape bytes the lexer passes through verbatim (e.g. `\t` stays `\t`), preserving symmetry in both directions.

This makes `Format(Parse(x)) == x` **and** `Parse(Format(x)) == x` for every value.

## Escape set ↔ lexer (symmetric)

| Value byte | quoteKey emits | lexer `readString` decodes |
|---|---|---|
| `\` | `\\` | `\\` → `\` |
| `"` | `\"` | `\"` → `"` |
| newline | `\n` | `\n` → newline |
| anything else (`\t`, …) | verbatim | `\X` preserved verbatim |

## Tests — RED on revert (`pkg/config/quotekey_roundtrip_3854_test.go`)

- `TestQuoteKeyLexerSymmetry3854` — unit: `NewLexer(quoteKey(v)).Next().Value == v`.
- `TestFormatParseRoundTrip3854` — the real `Format→Parse` path over backslash/quote/newline values, incl. an IKE-PSK-like `secret\with\backslashes`, backslash-before-`n`/`"`, double-backslash, literal newline, and a kitchen-sink.
- `TestFormatParseIdempotent3854` — `Format` is a fixed point across cycles.

Verified **RED** against a temporary revert to the quote-only escape (`Format→Parse` corrupted `pass\node` → `pass<newline>ode`, double-backslash lost a `\`, backslash-quote truncated) and **GREEN** with the fix.

## Validation

- `go test ./pkg/config/...` green
- consumer packages `./pkg/configstore/...` (rollback serialization) + `./pkg/cluster/...` (config sync) green
- `go build ./...` green; `gofmt` + `go vet` clean
- Documented the escape round-trip contract in `docs/config-schema.md`.

Closes #3854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi