### PR TITLE
schedulers: descend into daily/per-day windows + fail closed on empty window (#3849)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28234,3 +28234,44 @@ top.
   pkg/config/quotekey_roundtrip_3854_test.go (new),
   docs/config-schema.md (Quoted-value escape round-trip contract subsection),
   _Log.md
+
+## 2026-07-03 — #3849 policy time-range scheduler daily/per-day descend + fail-closed
+- **Timestamp**: 2026-07-03
+- **Action**: #3849 (fable-review-161 F-014) — policy time-range scheduler
+  `daily { start-time/stop-time }` descend + fail-closed empty window. HIGH
+  fail-open: `compileSchedulers` (compiler_system.go) only read
+  `start-time`/`stop-time` as DIRECT children of `scheduler <name>`, never
+  descending into the Junos `daily {}` container (nor the `monday`..`sunday`
+  arms), so `StartTime`/`StopTime` were left EMPTY and the runtime evaluator
+  `isWithinWindow` (pkg/scheduler) returned always-true for an empty window —
+  a policy `scheduler-name <s>` scoped to business hours permitted traffic
+  24/7. The stanza was also absent from `setSchema` (F-013), so flat-set
+  scheduler config packed onto one leaf and was dropped. FIX: (1)
+  `compileSchedulers` descends into `daily {}` + per-day containers via
+  `schedulerWindowFromNode` for both AST shapes, reading start-time/stop-time/
+  all-day/exclude; `SchedulerConfig` gains `AllDay` + `Days` (per-weekday
+  overrides). (2) new top-level `schemaSchedulers` (schema_schedulers.go,
+  registered in schema.go) groups flat-set into the nested AST; time/date
+  slots typed (ValueTimeOfDay/ValueDate + ValidateTimeOfDay/ValidateDate) so a
+  malformed window is rejected at commit. (3) `isWithinWindow` rewritten
+  fail-closed: an absent window (no daily, no applicable per-day, no date-only
+  range) is INACTIVE, never always-on; per-day overrides win over daily;
+  half-specified windows fail closed. (4) config hash (daemon_scheduler.go)
+  hashes AllDay + Days so per-day edits re-evaluate. RED-on-revert PROVEN for
+  both cores: reverting the daily descend blanks StartTime/StopTime
+  (TestCompileSchedulerDailyBlockHierarchical/FlatSet RED); reverting the
+  empty-window guard makes the empty scheduler always-active
+  (TestIsWithinWindow_NoWindowFailsClosed RED). go test ./... green; go build
+  ./... green; gofmt + vet clean.
+- **File(s)**: pkg/config/compiler_system.go (compileSchedulers descend +
+  schedulerWindowFromNode), pkg/config/types_security.go (AllDay + Days +
+  SchedulerDayWindow), pkg/config/schema_schedulers.go (new top-level schema),
+  pkg/config/schema.go (register schedulers), pkg/config/value_type.go
+  (ValueTimeOfDay/ValueDate), pkg/config/schema_validators.go
+  (ValidateTimeOfDay/ValidateDate), pkg/scheduler/scheduler.go (fail-closed
+  isWithinWindow + per-day), pkg/daemon/daemon_scheduler.go (hash new fields),
+  pkg/config/compiler_schedulers_3849_test.go (new),
+  pkg/scheduler/scheduler_3849_test.go (new),
+  pkg/scheduler/scheduler_test.go + pkg/daemon/policy_scheduler_apply_test.go
+  (updated for fail-closed semantics), pkg/scheduler/README.md +
+  docs/config-schema.md (docs)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3805,3 +3805,48 @@ whole pool stanza (address, port, persistent-nat) was unmodeled, so
   `pool_snat_persistent_any_remote_host_reuses_everywhere`,
   `pool_snat_persistent_permit_empty_string_falls_back_to_legacy_bool`
   (`userspace-dp/src/nat/tests.rs`).
+
+### #3849 — Policy time-range `schedulers` daily/per-day window descend + fail-closed
+
+The top-level `[edit schedulers]` policy time-range stanza compiled
+`start-time`/`stop-time` only as DIRECT children of `scheduler <name>`, so
+the actual Junos shape — `daily { start-time X; stop-time Y; }` (and the
+`monday`..`sunday` day arms) — left `StartTime`/`StopTime` EMPTY. The
+runtime evaluator (`pkg/scheduler.isWithinWindow`) then treated an empty
+window as always-active, so a policy `scheduler-name <s>` scoped to
+business hours actually permitted traffic 24/7 (HIGH, fail-open;
+fable-review-161 F-014). The stanza was also ABSENT from `setSchema`
+(F-013), so flat-set `set schedulers scheduler X daily start-time ...`
+packed the whole line onto one leaf node and the compiler dropped it.
+
+- **compiler** — `compileSchedulers` (`compiler_system.go`) descends into
+  the `daily {}` container AND each `monday`..`sunday` container via
+  `schedulerWindowFromNode`, reading `start-time`/`stop-time`/`all-day`/
+  `exclude` for BOTH the hierarchical and flat-set AST shapes. The legacy
+  direct-child `start-time`/`stop-time` shape still compiles unchanged.
+- **typed model** — `SchedulerConfig` gains `AllDay bool` (`daily
+  all-day`) and `Days map[string]*SchedulerDayWindow` (per-weekday
+  overrides keyed by lowercase weekday name); a weekday override wins over
+  the daily window, `Exclude` forces a day closed (`types_security.go`).
+- **schema** — a new top-level `schedulers` entry
+  (`schema_schedulers.go`, registered in `schema.go`) makes SetPath group
+  flat-set scheduler config into the nested AST the hierarchical parser
+  produces. The `start-time`/`stop-time` slots are `ValueTimeOfDay` +
+  `ValidateTimeOfDay`, and `start-date`/`stop-date` are `ValueDate` +
+  `ValidateDate`, so a malformed window is rejected at commit (the
+  fail-closed-at-commit half). Unknown keywords stay lenient
+  (`schema_walk.go`), so no valid scheduler config is newly rejected.
+- **fail-closed runtime** — `isWithinWindow` no longer returns
+  always-true on an empty window. A scheduler that resolves to NO window
+  for a given instant (no daily window, no applicable per-day override,
+  no date-only range) returns `false`. A policy bound to a window that
+  failed to compile now DENIES, matching the firewall's fail-closed
+  posture. "Always active" is expressed by omitting `scheduler-name` or
+  using `daily all-day`. The existing
+  `validatePolicySchedulerReferencesStrict` commit check (an undefined
+  `scheduler-name` is already rejected) is complementary and unchanged.
+- **tests** — compile descend (both shapes) + commit rejection:
+  `pkg/config/compiler_schedulers_3849_test.go`; runtime fail-closed +
+  per-day evaluation: `pkg/scheduler/scheduler_3849_test.go` and the
+  updated `pkg/scheduler/scheduler_test.go`
+  (`TestIsWithinWindow_NoWindowFailsClosed`).

--- a/pkg/config/compiler_schedulers_3849_test.go
+++ b/pkg/config/compiler_schedulers_3849_test.go
@@ -1,0 +1,213 @@
+package config_test
+
+// #3849: compileSchedulers must descend into the Junos `daily { start-time;
+// stop-time; }` container and the per-day (monday..sunday) containers.
+// Before the fix the `daily` arm only set the recurrence flag, leaving
+// StartTime/StopTime empty, and the runtime evaluator then fell open to
+// always-active. These tests pin the compile-side descend for both AST
+// shapes; the runtime fail-closed half is pinned in pkg/scheduler.
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func compileHier(t *testing.T, input string) *config.Config {
+	t.Helper()
+	p := config.NewParser(input)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg
+}
+
+func compileFlat(t *testing.T, cmds ...string) *config.Config {
+	t.Helper()
+	tree := &config.ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := config.ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	cfg, err := config.CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	return cfg
+}
+
+// TestCompileSchedulerDailyBlockHierarchical is the core RED-on-revert: a
+// `daily { start-time 09:00:00; stop-time 17:00:00; }` block must populate
+// StartTime/StopTime. Reverting the daily descend leaves them empty and this
+// goes RED.
+func TestCompileSchedulerDailyBlockHierarchical(t *testing.T) {
+	cfg := compileHier(t, `schedulers {
+    scheduler biz {
+        daily {
+            start-time 09:00:00;
+            stop-time 17:00:00;
+        }
+    }
+}`)
+	s := cfg.Schedulers["biz"]
+	if s == nil {
+		t.Fatal("scheduler biz not compiled")
+	}
+	if s.StartTime != "09:00:00" {
+		t.Errorf("StartTime = %q, want 09:00:00 (daily block not descended)", s.StartTime)
+	}
+	if s.StopTime != "17:00:00" {
+		t.Errorf("StopTime = %q, want 17:00:00 (daily block not descended)", s.StopTime)
+	}
+	if !s.Daily {
+		t.Error("Daily flag not set for a daily{} block")
+	}
+}
+
+// TestCompileSchedulerDailyBlockFlatSet pins the flat-set shape. Before
+// #3849/F-013 (schedulers absent from setSchema) SetPath packed the whole
+// `set` line onto one leaf and the compiler dropped it entirely.
+func TestCompileSchedulerDailyBlockFlatSet(t *testing.T) {
+	cfg := compileFlat(t,
+		"set schedulers scheduler biz daily start-time 09:00:00",
+		"set schedulers scheduler biz daily stop-time 17:00:00",
+	)
+	s := cfg.Schedulers["biz"]
+	if s == nil {
+		t.Fatal("scheduler biz not compiled from flat-set")
+	}
+	if s.StartTime != "09:00:00" || s.StopTime != "17:00:00" {
+		t.Errorf("flat-set daily window = %q..%q, want 09:00:00..17:00:00", s.StartTime, s.StopTime)
+	}
+}
+
+// TestCompileSchedulerDayOfWeek pins per-day (monday..sunday) descend in both
+// shapes.
+func TestCompileSchedulerDayOfWeek(t *testing.T) {
+	hier := compileHier(t, `schedulers {
+    scheduler week {
+        monday {
+            start-time 08:00:00;
+            stop-time 12:00:00;
+        }
+        friday {
+            exclude;
+        }
+    }
+}`)
+	s := hier.Schedulers["week"]
+	if s == nil {
+		t.Fatal("scheduler week not compiled")
+	}
+	mon := s.Days["monday"]
+	if mon == nil {
+		t.Fatal("monday window not compiled")
+	}
+	if mon.StartTime != "08:00:00" || mon.StopTime != "12:00:00" {
+		t.Errorf("monday window = %q..%q, want 08:00:00..12:00:00", mon.StartTime, mon.StopTime)
+	}
+	fri := s.Days["friday"]
+	if fri == nil || !fri.Exclude {
+		t.Errorf("friday exclude not compiled: %+v", fri)
+	}
+
+	flat := compileFlat(t,
+		"set schedulers scheduler week monday start-time 08:00:00",
+		"set schedulers scheduler week monday stop-time 12:00:00",
+	)
+	fs := flat.Schedulers["week"]
+	if fs == nil || fs.Days["monday"] == nil {
+		t.Fatalf("flat-set day-of-week not compiled: %+v", fs)
+	}
+	if fs.Days["monday"].StartTime != "08:00:00" {
+		t.Errorf("flat-set monday start = %q, want 08:00:00", fs.Days["monday"].StartTime)
+	}
+}
+
+// TestCompileSchedulerDailyAllDay pins `daily all-day` in both shapes.
+func TestCompileSchedulerDailyAllDay(t *testing.T) {
+	hier := compileHier(t, `schedulers {
+    scheduler always {
+        daily all-day;
+    }
+}`)
+	if s := hier.Schedulers["always"]; s == nil || !s.AllDay {
+		t.Fatalf("hierarchical daily all-day not compiled: %+v", s)
+	}
+
+	flat := compileFlat(t, "set schedulers scheduler always daily all-day")
+	if s := flat.Schedulers["always"]; s == nil || !s.AllDay {
+		t.Fatalf("flat-set daily all-day not compiled: %+v", s)
+	}
+}
+
+// TestCompileSchedulerLegacyDirectChildren pins backward compatibility with
+// the pre-#3849 simplified shape where start-time/stop-time are direct
+// children of the scheduler (no daily block).
+func TestCompileSchedulerLegacyDirectChildren(t *testing.T) {
+	cfg := compileHier(t, `schedulers {
+    scheduler legacy {
+        start-time 09:00:00;
+        stop-time 17:00:00;
+        daily;
+    }
+}`)
+	s := cfg.Schedulers["legacy"]
+	if s == nil {
+		t.Fatal("scheduler legacy not compiled")
+	}
+	if s.StartTime != "09:00:00" || s.StopTime != "17:00:00" {
+		t.Errorf("legacy direct-child window = %q..%q, want 09:00:00..17:00:00", s.StartTime, s.StopTime)
+	}
+}
+
+// TestSchemaRejectsBadSchedulerTime is the commit-time fail-closed half: a
+// malformed start-time is rejected at commit (SchemaValidate) instead of
+// silently zeroing the window.
+func TestSchemaRejectsBadSchedulerTime(t *testing.T) {
+	p := config.NewParser(`schedulers {
+    scheduler biz {
+        daily {
+            start-time 9am;
+            stop-time 17:00:00;
+        }
+    }
+}`)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if err := config.SchemaValidate(tree, nil); err == nil {
+		t.Fatal("SchemaValidate accepted an invalid start-time (9am); expected commit rejection")
+	}
+}
+
+// TestSchemaAcceptsValidScheduler ensures a well-formed scheduler passes the
+// commit gate.
+func TestSchemaAcceptsValidScheduler(t *testing.T) {
+	p := config.NewParser(`schedulers {
+    scheduler biz {
+        daily {
+            start-time 09:00:00;
+            stop-time 17:00:00;
+        }
+    }
+}`)
+	tree, errs := p.Parse()
+	if len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	if err := config.SchemaValidate(tree, nil); err != nil {
+		t.Fatalf("SchemaValidate rejected a valid scheduler: %v", err)
+	}
+}

--- a/pkg/config/compiler_system.go
+++ b/pkg/config/compiler_system.go
@@ -1068,6 +1068,11 @@ func parseSNMPv3UserKeys(keys []string, user *SNMPv3User) {
 	}
 }
 
+var schedulerWeekdays = map[string]struct{}{
+	"monday": {}, "tuesday": {}, "wednesday": {}, "thursday": {},
+	"friday": {}, "saturday": {}, "sunday": {},
+}
+
 func compileSchedulers(node *Node, cfg *Config) error {
 	if cfg.Schedulers == nil {
 		cfg.Schedulers = make(map[string]*SchedulerConfig)
@@ -1077,23 +1082,92 @@ func compileSchedulers(node *Node, cfg *Config) error {
 		sched := &SchedulerConfig{Name: inst.name}
 
 		for _, prop := range inst.node.Children {
-			switch prop.Name() {
-			case "start-time":
+			name := prop.Name()
+			switch {
+			case name == "start-time":
+				// Legacy simplified shape: start-time/stop-time as direct
+				// children of the scheduler (the daily window).
 				sched.StartTime = nodeVal(prop)
-			case "stop-time":
+			case name == "stop-time":
 				sched.StopTime = nodeVal(prop)
-			case "start-date":
+			case name == "start-date":
 				sched.StartDate = nodeVal(prop)
-			case "stop-date":
+			case name == "stop-date":
 				sched.StopDate = nodeVal(prop)
-			case "daily":
+			case name == "daily":
 				sched.Daily = true
+				// Junos hierarchical shape:
+				//   daily { start-time X; stop-time Y; }
+				//   daily all-day;  /  daily { exclude; }
+				// A bare `daily;` leaf carries no window and only flips the
+				// recurrence flag. Descend to read the daily window (#3849 —
+				// previously this branch ignored the block, leaving the
+				// window empty so isWithinWindow fell open to always-active).
+				if win, ok := schedulerWindowFromNode(prop); ok {
+					if win.StartTime != "" {
+						sched.StartTime = win.StartTime
+					}
+					if win.StopTime != "" {
+						sched.StopTime = win.StopTime
+					}
+					sched.AllDay = win.AllDay
+				}
+			default:
+				if _, ok := schedulerWeekdays[name]; ok {
+					if win, ok := schedulerWindowFromNode(prop); ok {
+						if sched.Days == nil {
+							sched.Days = make(map[string]*SchedulerDayWindow)
+						}
+						w := win
+						sched.Days[name] = &w
+					}
+				}
 			}
 		}
 
 		cfg.Schedulers[inst.name] = sched
 	}
 	return nil
+}
+
+// schedulerWindowFromNode extracts a time window from a `daily` or weekday
+// container node inside a scheduler. It handles both AST shapes and returns
+// ok=false when the node is a bare flag with no recognized window statement
+// (e.g. a plain `daily;`), so the caller can leave the window unset.
+func schedulerWindowFromNode(n *Node) (SchedulerDayWindow, bool) {
+	var win SchedulerDayWindow
+	found := false
+
+	// Flat leaf shape where the keyword rides on the node's own Keys, e.g.
+	// hierarchical `daily all-day;` parses to Keys=["daily","all-day"].
+	if len(n.Keys) >= 2 {
+		switch n.Keys[1] {
+		case "all-day":
+			win.AllDay = true
+			found = true
+		case "exclude":
+			win.Exclude = true
+			found = true
+		}
+	}
+
+	for _, c := range n.Children {
+		switch c.Name() {
+		case "start-time":
+			win.StartTime = nodeVal(c)
+			found = true
+		case "stop-time":
+			win.StopTime = nodeVal(c)
+			found = true
+		case "all-day":
+			win.AllDay = true
+			found = true
+		case "exclude":
+			win.Exclude = true
+			found = true
+		}
+	}
+	return win, found
 }
 
 func compileChassis(node *Node, ch *ChassisConfig) error {

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -154,6 +154,7 @@ var setSchema = &schemaNode{children: map[string]*schemaNode{
 	"groups":             {desc: "Configuration groups", wildcard: &schemaNode{desc: "Group name", placeholder: "<group-name>"}}, // wildcard children set in init()
 	"apply-groups":       {desc: "Groups from which to inherit configuration data", args: 1, multi: true, placeholder: "<group-name>", children: nil},
 	"security":           schemaSecurity,
+	"schedulers":         schemaSchedulers,
 	"interfaces":         schemaInterfaces,
 	"applications":       schemaApplications,
 	"routing-options":    schemaRoutingOptions,

--- a/pkg/config/schema_schedulers.go
+++ b/pkg/config/schema_schedulers.go
@@ -1,0 +1,106 @@
+package config
+
+// schemaSchedulers models the top-level `[edit schedulers]` policy
+// time-range stanza (F-013 — previously absent from setSchema, so flat-set
+// `set schedulers scheduler X daily start-time ...` packed the whole line
+// onto ONE leaf node and the compiler dropped it). Adding it here makes
+// SetPath group flat-set scheduler config into the same nested AST the
+// hierarchical parser produces, so compileSchedulers descends into the
+// `daily {}`/weekday containers for both shapes.
+//
+// The time/date value slots are typed (ValueTimeOfDay/ValueDate) so a
+// malformed window is rejected at commit — the fail-closed half of #3849.
+var schemaSchedulerDay = &schemaNode{
+	desc: "Time window for this day (start-time/stop-time, all-day, or exclude)",
+	children: map[string]*schemaNode{
+		"start-time": {
+			desc:          "Window start time (24-hour HH:MM:SS)",
+			args:          1,
+			placeholder:   "<HH:MM:SS>",
+			valueType:     ValueTimeOfDay,
+			valueDesc:     "Time of day the window opens (24-hour HH:MM:SS)",
+			valueExamples: []string{"09:00:00", "17:30:00", "22:00:00"},
+			validator:     ValidateTimeOfDay,
+			children:      nil,
+		},
+		"stop-time": {
+			desc:          "Window stop time (24-hour HH:MM:SS; exclusive)",
+			args:          1,
+			placeholder:   "<HH:MM:SS>",
+			valueType:     ValueTimeOfDay,
+			valueDesc:     "Time of day the window closes (24-hour HH:MM:SS)",
+			valueExamples: []string{"17:00:00", "06:00:00"},
+			validator:     ValidateTimeOfDay,
+			children:      nil,
+		},
+		"all-day": {desc: "Active for the entire day", children: nil},
+		"exclude": {desc: "Never active on this day", children: nil},
+	},
+}
+
+var schemaSchedulers = &schemaNode{
+	desc: "Policy time-range schedulers ([edit schedulers])",
+	children: map[string]*schemaNode{
+		"scheduler": {
+			desc:        "Named scheduler bound to a policy via scheduler-name",
+			args:        1,
+			multi:       true,
+			placeholder: "<scheduler-name>",
+			children: map[string]*schemaNode{
+				// Legacy simplified shape: start-time/stop-time as direct
+				// children of the scheduler (the daily window).
+				"start-time": {
+					desc:          "Daily window start time (24-hour HH:MM:SS)",
+					args:          1,
+					placeholder:   "<HH:MM:SS>",
+					valueType:     ValueTimeOfDay,
+					valueDesc:     "Time of day the daily window opens (24-hour HH:MM:SS)",
+					valueExamples: []string{"09:00:00", "17:30:00"},
+					validator:     ValidateTimeOfDay,
+					children:      nil,
+				},
+				"stop-time": {
+					desc:          "Daily window stop time (24-hour HH:MM:SS; exclusive)",
+					args:          1,
+					placeholder:   "<HH:MM:SS>",
+					valueType:     ValueTimeOfDay,
+					valueDesc:     "Time of day the daily window closes (24-hour HH:MM:SS)",
+					valueExamples: []string{"17:00:00", "06:00:00"},
+					validator:     ValidateTimeOfDay,
+					children:      nil,
+				},
+				"start-date": {
+					desc:          "Calendar range start date (YYYY-MM-DD)",
+					args:          1,
+					placeholder:   "<YYYY-MM-DD>",
+					valueType:     ValueDate,
+					valueDesc:     "First date the scheduler is active (YYYY-MM-DD)",
+					valueExamples: []string{"2026-03-01"},
+					validator:     ValidateDate,
+					children:      nil,
+				},
+				"stop-date": {
+					desc:          "Calendar range stop date (YYYY-MM-DD; inclusive)",
+					args:          1,
+					placeholder:   "<YYYY-MM-DD>",
+					valueType:     ValueDate,
+					valueDesc:     "Last date the scheduler is active (YYYY-MM-DD, inclusive)",
+					valueExamples: []string{"2026-03-31"},
+					validator:     ValidateDate,
+					children:      nil,
+				},
+				// Junos day containers. `daily` applies to every weekday with
+				// no specific override; a weekday container overrides `daily`
+				// for that day. All share the same window sub-schema.
+				"daily":     schemaSchedulerDay,
+				"monday":    schemaSchedulerDay,
+				"tuesday":   schemaSchedulerDay,
+				"wednesday": schemaSchedulerDay,
+				"thursday":  schemaSchedulerDay,
+				"friday":    schemaSchedulerDay,
+				"saturday":  schemaSchedulerDay,
+				"sunday":    schemaSchedulerDay,
+			},
+		},
+	},
+}

--- a/pkg/config/schema_validators.go
+++ b/pkg/config/schema_validators.go
@@ -971,3 +971,33 @@ func ValidateSyslogSourceInterface(raw string, _ *Config) error {
 	}
 	return nil
 }
+
+// ValidateTimeOfDay accepts a scheduler time-of-day in HH:MM:SS 24-hour
+// form (the exact layout the runtime evaluator parses,
+// pkg/scheduler.parseTimeOfDay). Rejecting a malformed time at commit is the
+// fail-closed half of #3849: an unparseable start-time/stop-time must never
+// reach the compiler and silently zero the window (which the old evaluator
+// then treated as always-active).
+func ValidateTimeOfDay(raw string, _ *Config) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("missing value (expected a time of day, e.g. 09:00:00)")
+	}
+	if _, err := time.Parse("15:04:05", trimmed); err != nil {
+		return fmt.Errorf("invalid time of day %q (expected 24-hour HH:MM:SS, e.g. 09:00:00 or 17:30:00)", raw)
+	}
+	return nil
+}
+
+// ValidateDate accepts a scheduler calendar date in YYYY-MM-DD form (the
+// layout the runtime evaluator parses in withinDateRange).
+func ValidateDate(raw string, _ *Config) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("missing value (expected a date, e.g. 2026-03-01)")
+	}
+	if _, err := time.Parse("2006-01-02", trimmed); err != nil {
+		return fmt.Errorf("invalid date %q (expected YYYY-MM-DD, e.g. 2026-03-01)", raw)
+	}
+	return nil
+}

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -7,13 +7,46 @@ import "sort"
 // feeds, and the [edit schedulers] policy time-range scheduler.
 
 // SchedulerConfig defines a time-based policy scheduler.
+//
+// The time-of-day window (StartTime/StopTime) is the "daily" window: it
+// applies to every weekday that does not have a specific override in Days.
+// A weekday present in Days overrides the daily window for that day (Junos
+// per-day scheduling). AllDay marks the daily window as active for the whole
+// day (`daily all-day`). StartDate/StopDate bound the scheduler to a calendar
+// range.
+//
+// Fail-closed invariant (#3849): a scheduler that resolves to NO window for a
+// given instant (no daily window, no applicable per-day window, and no
+// date-only range) is INACTIVE, not always-on. The runtime evaluator
+// (pkg/scheduler.isWithinWindow) must never treat an absent window as
+// always-permit — a policy `scheduler-name` scoped to a window that failed to
+// compile must deny, not permit around the clock.
 type SchedulerConfig struct {
 	Name      string
-	StartTime string // "HH:MM:SS"
-	StopTime  string // "HH:MM:SS"
+	StartTime string // daily-window start "HH:MM:SS"
+	StopTime  string // daily-window stop "HH:MM:SS"
 	StartDate string // "YYYY-MM-DD" (optional)
 	StopDate  string // "YYYY-MM-DD" (optional)
-	Daily     bool   // recur daily
+	Daily     bool   // `daily` recurrence keyword present
+	AllDay    bool   // `daily all-day` — active the entire day
+
+	// Days holds per-weekday overrides keyed by lowercase weekday name
+	// ("monday".."sunday"). A present entry overrides the daily window for
+	// that weekday. nil/empty when the scheduler has no per-day arms.
+	Days map[string]*SchedulerDayWindow
+}
+
+// SchedulerDayWindow is a single day's time window inside a scheduler — the
+// body of a `daily { ... }` or a `monday { ... }` (..`sunday`) container.
+// A day is active when AllDay is set, or when the current time-of-day falls
+// within [StartTime, StopTime); Exclude forces the day inactive. An empty
+// window (no times, no all-day, no exclude) is treated as CLOSED by the
+// runtime evaluator (#3849 fail-closed).
+type SchedulerDayWindow struct {
+	StartTime string // "HH:MM:SS"
+	StopTime  string // "HH:MM:SS"
+	AllDay    bool   // active the entire day
+	Exclude   bool   // never active this day
 }
 
 // DynamicAddressConfig defines dynamic address feed servers and address-name bindings.

--- a/pkg/config/value_type.go
+++ b/pkg/config/value_type.go
@@ -77,6 +77,14 @@ const (
 	// ValidateDDNSHostname — a name the publish path would silently
 	// rewrite is rejected at commit.
 	ValueHostname
+	// ValueTimeOfDay is a Junos scheduler time-of-day in HH:MM:SS 24-hour
+	// form (e.g. 09:00:00). Validated by ValidateTimeOfDay so an
+	// unparseable start-time/stop-time is rejected at commit instead of
+	// silently zeroing the scheduler window (#3849 fail-closed).
+	ValueTimeOfDay
+	// ValueDate is a Junos scheduler calendar date in YYYY-MM-DD form
+	// (e.g. 2026-03-01). Validated by ValidateDate.
+	ValueDate
 )
 
 // Placeholder returns the angle-bracket placeholder name shown in `?`
@@ -113,6 +121,10 @@ func (v ValueType) Placeholder() string {
 		return "<dh-group>"
 	case ValueHostname:
 		return "<fqdn>"
+	case ValueTimeOfDay:
+		return "<HH:MM:SS>"
+	case ValueDate:
+		return "<YYYY-MM-DD>"
 	}
 	return ""
 }

--- a/pkg/daemon/daemon_scheduler.go
+++ b/pkg/daemon/daemon_scheduler.go
@@ -93,15 +93,39 @@ func policySchedulerConfigHash(cfg *config.Config) ([32]byte, bool) {
 		writePolicySchedulerHashString(h, sched.StopTime)
 		writePolicySchedulerHashString(h, sched.StartDate)
 		writePolicySchedulerHashString(h, sched.StopDate)
-		if sched.Daily {
-			_, _ = h.Write([]byte{1})
-		} else {
-			_, _ = h.Write([]byte{0})
+		writePolicySchedulerHashBool(h, sched.Daily)
+		writePolicySchedulerHashBool(h, sched.AllDay)
+		// Per-day windows, hashed in a stable weekday order so a change to
+		// any per-day arm forces a scheduler re-evaluation.
+		dayNames := make([]string, 0, len(sched.Days))
+		for day := range sched.Days {
+			dayNames = append(dayNames, day)
+		}
+		sort.Strings(dayNames)
+		for _, day := range dayNames {
+			writePolicySchedulerHashString(h, day)
+			win := sched.Days[day]
+			if win == nil {
+				writePolicySchedulerHashString(h, "<nil>")
+				continue
+			}
+			writePolicySchedulerHashString(h, win.StartTime)
+			writePolicySchedulerHashString(h, win.StopTime)
+			writePolicySchedulerHashBool(h, win.AllDay)
+			writePolicySchedulerHashBool(h, win.Exclude)
 		}
 	}
 	var out [32]byte
 	copy(out[:], h.Sum(nil))
 	return out, true
+}
+
+func writePolicySchedulerHashBool(h interface{ Write([]byte) (int, error) }, b bool) {
+	if b {
+		_, _ = h.Write([]byte{1})
+	} else {
+		_, _ = h.Write([]byte{0})
+	}
 }
 
 func writePolicySchedulerHashString(h interface{ Write([]byte) (int, error) }, s string) {

--- a/pkg/daemon/policy_scheduler_apply_test.go
+++ b/pkg/daemon/policy_scheduler_apply_test.go
@@ -354,7 +354,11 @@ func TestPolicySchedulerInitialPublishSkipsUserspaceLegacyMapUpdate(t *testing.T
 func testPolicySchedulerApplyConfig() *config.Config {
 	return &config.Config{
 		Schedulers: map[string]*config.SchedulerConfig{
-			"workhours": {Name: "workhours"},
+			// AllDay = always active (`daily all-day`). Post-#3849 an empty
+			// scheduler fails CLOSED, so this test — which asserts the seeded
+			// active state reaches compile as active=true — pins an
+			// explicitly always-on window.
+			"workhours": {Name: "workhours", AllDay: true},
 		},
 		Security: config.SecurityConfig{
 			Policies: []*config.ZonePairPolicies{{

--- a/pkg/scheduler/README.md
+++ b/pkg/scheduler/README.md
@@ -26,6 +26,41 @@ during specific windows.
   failures uint64, since time.Time)` — `scheduler.go`. Expose the #3780
   self-heal state for tests and metrics.
 
+## Time-window model (#3849)
+
+A `config.SchedulerConfig` resolves to at most one window per instant:
+
+- **Daily window** — `StartTime`/`StopTime` (the body of a Junos
+  `daily { start-time X; stop-time Y; }` block, or the legacy simplified
+  shape where `start-time`/`stop-time` are direct children of the
+  scheduler). `AllDay` marks the daily window active for the whole day
+  (`daily all-day`).
+- **Per-day overrides** — `Days["monday".."sunday"]`. A weekday present in
+  `Days` overrides the daily window for that weekday; its `Exclude` flag
+  forces the day inactive, `AllDay` forces it active. Days without an
+  override fall back to the daily window.
+- **Date range** — `StartDate`/`StopDate` gate the whole scheduler to a
+  calendar range (inclusive of the stop date). A scheduler with only a
+  date range (no time-of-day window) is active for the entire range.
+
+`compileSchedulers` (`pkg/config/compiler_system.go`) reads all of these
+for both the hierarchical and flat-set AST shapes; the flat-set grammar is
+grouped by the `schedulers` entry in `setSchema`
+(`pkg/config/schema_schedulers.go`), and the `start-time`/`stop-time` /
+`start-date`/`stop-date` value slots are typed so a malformed window is
+rejected at commit (`ValidateTimeOfDay` / `ValidateDate`).
+
+**Fail-closed invariant (#3849 — security).** `isWithinWindow` treats an
+ABSENT window as **inactive**, never always-on. A scheduler that resolves
+to no window for a given instant — no daily window, no applicable per-day
+override, and no date-only range — returns `false`. Before #3849 the
+`daily {}` block was never descended (so `StartTime`/`StopTime` stayed
+empty) and an empty window returned `true`, so a policy `scheduler-name`
+scoped to business hours actually permitted traffic 24/7 (fail-open). A
+window that fails to compile now DENIES, matching the firewall's
+fail-closed posture. To express "always active", omit `scheduler-name`
+from the policy or use `daily all-day`.
+
 ## Republish self-heal (#3780)
 
 `updateFn` returns an `error`. A window transition republishes

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -266,49 +267,122 @@ func copyActiveState(in map[string]bool) map[string]bool {
 }
 
 // isWithinWindow determines whether now falls within the time window defined
-// by sched. It returns true (active) if no times are configured.
+// by sched.
+//
+// Fail-closed (#3849): an ABSENT window is INACTIVE, never always-on. A
+// scheduler that resolves to no window at all — no daily window, no per-day
+// window for today, and no date-only range — returns false. This is the
+// security half of the fix: a policy `scheduler-name` bound to a window that
+// failed to compile (or was left empty) must DENY, not permit 24/7. The old
+// "no times configured => active" shortcut was the fail-open bug.
 func isWithinWindow(now time.Time, sched *config.SchedulerConfig) bool {
-	if sched.StartTime == "" && sched.StopTime == "" {
-		return true
+	// Date-range gate (outer). A configured calendar range that now falls
+	// outside of closes the scheduler regardless of any time-of-day window.
+	inRange, ok := withinDateRange(now, sched)
+	if !ok {
+		return false // unparseable date -> fail closed
+	}
+	if !inRange {
+		return false
 	}
 
-	// Check date range if configured.
+	// Resolve the window that applies to today (a per-day override wins over
+	// the daily window).
+	win, have := effectiveDayWindow(sched, now.Weekday())
+	if !have {
+		// No time-of-day window applies today. A scheduler scoped ONLY by a
+		// date range (no daily/per-day time restriction) is active for the
+		// entire range; anything else has no window and fails CLOSED.
+		if schedulerHasDateRange(sched) && !schedulerHasTimeWindow(sched) {
+			return true
+		}
+		return false
+	}
+
+	if win.Exclude {
+		return false
+	}
+	if win.AllDay {
+		return true
+	}
+	// A half-specified window (only one of start/stop) is unparseable ->
+	// fail closed.
+	if win.StartTime == "" || win.StopTime == "" {
+		slog.Warn("scheduler: incomplete time window, failing closed",
+			"name", sched.Name, "start", win.StartTime, "stop", win.StopTime)
+		return false
+	}
+	return withinTimeOfDay(now, sched.Name, win.StartTime, win.StopTime)
+}
+
+// withinDateRange reports whether now is inside sched's calendar range.
+// ok is false when a configured date fails to parse (caller fails closed).
+func withinDateRange(now time.Time, sched *config.SchedulerConfig) (inRange, ok bool) {
 	if sched.StartDate != "" {
 		startDate, err := time.Parse("2006-01-02", sched.StartDate)
 		if err != nil {
 			slog.Warn("scheduler: invalid start date", "name", sched.Name, "date", sched.StartDate, "err", err)
-			return false
+			return false, false
 		}
 		if now.Before(startDate) {
-			return false
+			return false, true
 		}
 	}
 	if sched.StopDate != "" {
 		stopDate, err := time.Parse("2006-01-02", sched.StopDate)
 		if err != nil {
 			slog.Warn("scheduler: invalid stop date", "name", sched.Name, "date", sched.StopDate, "err", err)
-			return false
+			return false, false
 		}
-		// StopDate is inclusive: the scheduler is active through the entire stop date.
+		// StopDate is inclusive: active through the entire stop date.
 		if now.After(stopDate.AddDate(0, 0, 1)) {
-			return false
+			return false, true
 		}
 	}
+	return true, true
+}
 
-	// If only date range is set (no times), active for the entire date range.
-	if sched.StartTime == "" && sched.StopTime == "" {
-		return true
+// effectiveDayWindow resolves the window applying to weekday wd: a per-day
+// override if one exists, otherwise the scheduler's daily window. have is
+// false when neither is configured.
+func effectiveDayWindow(sched *config.SchedulerConfig, wd time.Weekday) (config.SchedulerDayWindow, bool) {
+	if len(sched.Days) > 0 {
+		if win := sched.Days[strings.ToLower(wd.String())]; win != nil {
+			return *win, true
+		}
 	}
+	if sched.AllDay || sched.StartTime != "" || sched.StopTime != "" {
+		return config.SchedulerDayWindow{
+			StartTime: sched.StartTime,
+			StopTime:  sched.StopTime,
+			AllDay:    sched.AllDay,
+		}, true
+	}
+	return config.SchedulerDayWindow{}, false
+}
 
-	// Parse start and stop times of day.
-	startTOD, err := parseTimeOfDay(sched.StartTime)
+// schedulerHasTimeWindow reports whether the scheduler carries any
+// time-of-day restriction (daily window or per-day arms).
+func schedulerHasTimeWindow(sched *config.SchedulerConfig) bool {
+	return sched.AllDay || sched.StartTime != "" || sched.StopTime != "" || len(sched.Days) > 0
+}
+
+func schedulerHasDateRange(sched *config.SchedulerConfig) bool {
+	return sched.StartDate != "" || sched.StopDate != ""
+}
+
+// withinTimeOfDay reports whether now's clock time falls within
+// [start, stop), handling overnight (wraparound) windows. An unparseable
+// bound fails closed.
+func withinTimeOfDay(now time.Time, name, start, stop string) bool {
+	startTOD, err := parseTimeOfDay(start)
 	if err != nil {
-		slog.Warn("scheduler: invalid start time", "name", sched.Name, "time", sched.StartTime, "err", err)
+		slog.Warn("scheduler: invalid start time", "name", name, "time", start, "err", err)
 		return false
 	}
-	stopTOD, err := parseTimeOfDay(sched.StopTime)
+	stopTOD, err := parseTimeOfDay(stop)
 	if err != nil {
-		slog.Warn("scheduler: invalid stop time", "name", sched.Name, "time", sched.StopTime, "err", err)
+		slog.Warn("scheduler: invalid stop time", "name", name, "time", stop, "err", err)
 		return false
 	}
 

--- a/pkg/scheduler/scheduler_3849_test.go
+++ b/pkg/scheduler/scheduler_3849_test.go
@@ -1,0 +1,104 @@
+package scheduler
+
+// #3849 runtime evaluation of per-day (monday..sunday) windows and the
+// daily/per-day interaction. The compile-side descend is pinned in
+// pkg/config; these pin the evaluator honoring what the compiler produced.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+func dayWin(start, stop string) *config.SchedulerDayWindow {
+	return &config.SchedulerDayWindow{StartTime: start, StopTime: stop}
+}
+
+// 2026-03-02 is a Monday; 2026-03-03 a Tuesday.
+var monNoon = time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+var tueNoon = time.Date(2026, 3, 3, 12, 0, 0, 0, time.UTC)
+
+func TestIsWithinWindow_PerDay_MondayOnly(t *testing.T) {
+	sched := &config.SchedulerConfig{
+		Name: "mon-only",
+		Days: map[string]*config.SchedulerDayWindow{
+			"monday": dayWin("08:00:00", "17:00:00"),
+		},
+	}
+	if !isWithinWindow(monNoon, sched) {
+		t.Error("Monday noon should be active for a monday 08:00-17:00 window")
+	}
+	// Tuesday has no arm and there is no daily fallback -> closed.
+	if isWithinWindow(tueNoon, sched) {
+		t.Error("Tuesday should be inactive for a monday-only scheduler (fail closed)")
+	}
+	// Monday but outside the window.
+	monEvening := time.Date(2026, 3, 2, 20, 0, 0, 0, time.UTC)
+	if isWithinWindow(monEvening, sched) {
+		t.Error("Monday 8pm should be outside the 08:00-17:00 window")
+	}
+}
+
+func TestIsWithinWindow_PerDay_OverridesDaily(t *testing.T) {
+	// Daily window 09:00-17:00, but Monday is a shorter 09:00-12:00.
+	sched := &config.SchedulerConfig{
+		Name:      "override",
+		StartTime: "09:00:00",
+		StopTime:  "17:00:00",
+		Days: map[string]*config.SchedulerDayWindow{
+			"monday": dayWin("09:00:00", "12:00:00"),
+		},
+	}
+	// Monday 14:00 falls in the daily window but OUTSIDE the monday override.
+	monAfternoon := time.Date(2026, 3, 2, 14, 0, 0, 0, time.UTC)
+	if isWithinWindow(monAfternoon, sched) {
+		t.Error("Monday 14:00 should follow the monday override (09-12), not the daily window")
+	}
+	// Tuesday 14:00 has no override, so the daily window (09-17) applies.
+	tueAfternoon := time.Date(2026, 3, 3, 14, 0, 0, 0, time.UTC)
+	if !isWithinWindow(tueAfternoon, sched) {
+		t.Error("Tuesday 14:00 should follow the daily window (09-17)")
+	}
+}
+
+func TestIsWithinWindow_PerDay_Exclude(t *testing.T) {
+	// Daily all-day, but Monday explicitly excluded.
+	sched := &config.SchedulerConfig{
+		Name:   "holiday",
+		AllDay: true,
+		Days: map[string]*config.SchedulerDayWindow{
+			"monday": {Exclude: true},
+		},
+	}
+	if isWithinWindow(monNoon, sched) {
+		t.Error("Monday must be inactive when explicitly excluded, even with daily all-day")
+	}
+	if !isWithinWindow(tueNoon, sched) {
+		t.Error("Tuesday should follow the daily all-day window")
+	}
+}
+
+func TestIsWithinWindow_PerDay_AllDay(t *testing.T) {
+	sched := &config.SchedulerConfig{
+		Name: "mon-allday",
+		Days: map[string]*config.SchedulerDayWindow{
+			"monday": {AllDay: true},
+		},
+	}
+	if !isWithinWindow(time.Date(2026, 3, 2, 3, 0, 0, 0, time.UTC), sched) {
+		t.Error("Monday all-day should be active at 3am")
+	}
+	if isWithinWindow(tueNoon, sched) {
+		t.Error("Tuesday should be inactive (no arm, no daily) for a monday-all-day scheduler")
+	}
+}
+
+// TestIsWithinWindow_HalfWindowFailsClosed pins that a window missing one
+// bound is treated as closed, not always-on.
+func TestIsWithinWindow_HalfWindowFailsClosed(t *testing.T) {
+	sched := &config.SchedulerConfig{Name: "half", StartTime: "09:00:00"} // no StopTime
+	if isWithinWindow(monNoon, sched) {
+		t.Error("a half-specified window (start without stop) must fail closed")
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7,11 +7,26 @@ import (
 	"github.com/psaab/xpf/pkg/config"
 )
 
-func TestIsWithinWindow_NoTimes(t *testing.T) {
-	sched := &config.SchedulerConfig{Name: "always"}
+// TestIsWithinWindow_NoWindowFailsClosed pins the #3849 fail-open fix: a
+// scheduler with NO window at all (no daily time, no per-day arm, no date
+// range) must be INACTIVE, not always-on. Reverting isWithinWindow to the old
+// "no times configured => active" shortcut goes RED here.
+func TestIsWithinWindow_NoWindowFailsClosed(t *testing.T) {
 	now := time.Date(2026, 2, 12, 14, 30, 0, 0, time.UTC)
-	if !isWithinWindow(now, sched) {
-		t.Error("no times configured should always be active")
+	if isWithinWindow(now, &config.SchedulerConfig{Name: "empty"}) {
+		t.Error("empty scheduler (no window) must fail closed (inactive), not run 24/7")
+	}
+	// A bare `daily;` recurrence flag with no time window is still no window.
+	if isWithinWindow(now, &config.SchedulerConfig{Name: "bare-daily", Daily: true}) {
+		t.Error("bare daily flag with no window must fail closed (inactive)")
+	}
+}
+
+// TestIsWithinWindow_AllDay pins `daily all-day` = always active.
+func TestIsWithinWindow_AllDay(t *testing.T) {
+	now := time.Date(2026, 2, 12, 3, 0, 0, 0, time.UTC)
+	if !isWithinWindow(now, &config.SchedulerConfig{Name: "all", AllDay: true}) {
+		t.Error("daily all-day should be active at any time")
 	}
 }
 
@@ -159,7 +174,7 @@ func TestScheduler_InitialState(t *testing.T) {
 	var state map[string]bool
 
 	schedCfg := map[string]*config.SchedulerConfig{
-		"always-on": {Name: "always-on"}, // no times = always active
+		"always-on": {Name: "always-on", AllDay: true}, // all-day = always active
 	}
 
 	s := New(schedCfg, func(activeState map[string]bool) error {
@@ -182,7 +197,7 @@ func TestScheduler_InitialState(t *testing.T) {
 func TestScheduler_NewPrimedDoesNotNotifyInitialState(t *testing.T) {
 	var called bool
 	schedCfg := map[string]*config.SchedulerConfig{
-		"always-on": {Name: "always-on"},
+		"always-on": {Name: "always-on", AllDay: true},
 	}
 
 	s, state := NewPrimed(schedCfg, func(activeState map[string]bool) error {
@@ -305,7 +320,7 @@ func TestScheduler_MonotonicAdvanceDoesNotFailClosed(t *testing.T) {
 
 func TestScheduler_ActiveState(t *testing.T) {
 	schedCfg := map[string]*config.SchedulerConfig{
-		"always-on": {Name: "always-on"},
+		"always-on": {Name: "always-on", AllDay: true},
 	}
 	s := New(schedCfg, func(activeState map[string]bool) error { return nil })
 
@@ -324,7 +339,7 @@ func TestScheduler_ActiveState(t *testing.T) {
 func TestScheduler_Update(t *testing.T) {
 	var lastState map[string]bool
 	schedCfg := map[string]*config.SchedulerConfig{
-		"always-on": {Name: "always-on"},
+		"always-on": {Name: "always-on", AllDay: true},
 	}
 	s := New(schedCfg, func(activeState map[string]bool) error {
 		lastState = activeState
@@ -333,7 +348,7 @@ func TestScheduler_Update(t *testing.T) {
 
 	// Update with new schedulers (removes always-on, adds another)
 	s.Update(map[string]*config.SchedulerConfig{
-		"new-sched": {Name: "new-sched"},
+		"new-sched": {Name: "new-sched", AllDay: true},
 	})
 
 	if !lastState["new-sched"] {


### PR DESCRIPTION
Closes #3849 (fable-review-161 F-014).

## Defect (HIGH, fail-open)

`compileSchedulers` (`pkg/config/compiler_system.go`) read
`start-time`/`stop-time` only as DIRECT children of `scheduler <name>`,
never descending into the Junos `daily { start-time X; stop-time Y; }`
container (nor the `monday`..`sunday` day arms). So `StartTime`/`StopTime`
were left EMPTY, and the runtime evaluator `isWithinWindow`
(`pkg/scheduler`) returned always-true for an empty window — a policy
`scheduler-name <s>` scoped to business hours actually permitted traffic
**24/7** instead of only in-window.

The stanza was also absent from `setSchema` (F-013), so a flat-set
`set schedulers scheduler X daily start-time ...` packed the whole line
onto one leaf node and the compiler dropped it entirely.

## Fix

- **Compiler descend** — `compileSchedulers` descends into the `daily {}`
  container AND each weekday container via `schedulerWindowFromNode`,
  reading `start-time`/`stop-time`/`all-day`/`exclude` for BOTH the
  hierarchical and flat-set AST shapes. The legacy direct-child shape
  still compiles unchanged.
- **Typed model** — `SchedulerConfig` gains `AllDay` (`daily all-day`)
  and `Days` (per-weekday overrides). A weekday override wins over the
  daily window; `Exclude` forces a day closed.
- **Flat-set / F-013** — new top-level `schemaSchedulers`
  (`schema_schedulers.go`, registered in `schema.go`) groups flat-set
  config into the nested AST. Time/date slots are typed
  (`ValueTimeOfDay`/`ValueDate` + `ValidateTimeOfDay`/`ValidateDate`) so a
  malformed window is **rejected at commit** (fail-closed-at-commit).
  Unknown keywords stay lenient (`schema_walk.go`), so no valid config is
  newly rejected.
- **Fail-closed runtime** — `isWithinWindow` no longer returns
  always-true on an empty window. A scheduler resolving to NO window for a
  given instant (no daily window, no applicable per-day override, no
  date-only range) is INACTIVE. A window that fails to compile now DENIES,
  matching the firewall's fail-closed posture. "Always active" = omit
  `scheduler-name` or use `daily all-day`.
- **Hash** — `policySchedulerConfigHash` hashes `AllDay` + per-day windows
  so per-day edits re-evaluate.

## RED-on-revert (proven)

- Reverting the daily descend blanks `StartTime`/`StopTime` →
  `TestCompileSchedulerDailyBlockHierarchical` / `...FlatSet` go RED.
- Reverting the empty-window guard (old `return true`) →
  `TestIsWithinWindow_NoWindowFailsClosed` goes RED.

## Validation

`go build ./...`, `go vet`, `gofmt` clean; `go test ./...` green
(full suite). New tests: `pkg/config/compiler_schedulers_3849_test.go`,
`pkg/scheduler/scheduler_3849_test.go`; updated
`pkg/scheduler/scheduler_test.go` +
`pkg/daemon/policy_scheduler_apply_test.go` for the fail-closed
semantics. Docs: `pkg/scheduler/README.md` (Time-window model),
`docs/config-schema.md` (#3849 entry).

Go-only change (no dataplane/cargo). The existing
`validatePolicySchedulerReferencesStrict` commit check (an undefined
`scheduler-name` is already rejected) is complementary and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi