### PR TITLE
usdp DNAT: honor rule match destination-port alongside application (#3857)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28234,3 +28234,39 @@ top.
   pkg/config/quotekey_roundtrip_3854_test.go (new),
   docs/config-schema.md (Quoted-value escape round-trip contract subsection),
   _Log.md
+
+## 2026-07-03 — #3857 DNAT `match application` + `match destination-port` fail-open
+
+- **Timestamp**: 2026-07-03
+- **Action**: Fix HIGH fail-open (fable-161 F-018): a DNAT rule with BOTH
+  `match application` AND `match destination-port` mishandled the rule-level
+  destination-port on the lenient / HA peer-sync decode path — (a) an
+  invalid/unrepresentable rule dest-port present alongside an application
+  WIDENED to the wildcard `[0,0]` port (bypassing the #3446 dport guard), (b) a
+  valid rule dest-port was DROPPED (the application's own port / a wildcard
+  won), (c) a multi-value rule dest-port list collapsed to the singular first
+  port. The source-NAT builder handled all three correctly.
+- **Fix**: `buildDestinationNATSnapshotsWithFeeds` now treats the explicit
+  rule-level `match destination-port` as authoritative for the destination-port
+  axis on EVERY resolved application term. Resolve the rule port list once
+  (`ruleDstPorts` = plural `DestinationPorts`, fallback to scalar
+  `DestinationPort` for a mixed-version peer; `ruleDstPortConfigured` also trips
+  on non-empty `InvalidDestinationPorts`) and, when configured, use it in place
+  of the application's own destination-port on each term. Application still
+  constrains protocol / source-port / ICMP type-code (#3437). Full multi-value
+  list preserved; a configured-but-unrepresentable value fails CLOSED via the
+  existing `portConfigured` → emit-no-snapshot branch (never `[0,0]`). Removed
+  the stray singular-port switch case and the now-dead `explicitFallback` flag.
+  Go-only — no Rust change (Rust `l4_extra_matches` already AND-checks the port
+  ranges + exact port and preserves the `low > high` never-match sentinel).
+- **Tests (RED-on-revert)**: `nat_dnat_app_dport_3857_test.go` — 6 defect
+  tests (invalid/out-of-range dport + app → 0 snapshots; valid dport overrides
+  app port; scalar-only peer-sync dport honored; multi-port kept with/without
+  app port) + 1 regression guard (app-only path unchanged). Crafted-NATMatch
+  lenient/peer-sync path. Verified 6/6 RED on a temporary `git show
+  origin/master` revert of nat.go, GREEN with the fix.
+- **Validation**: go test ./pkg/dataplane/... green; go build ./... green;
+  gofmt + go vet clean.
+- **File(s)**: pkg/dataplane/userspace/nat.go,
+  pkg/dataplane/userspace/nat_dnat_app_dport_3857_test.go (new),
+  docs/userspace-dnat-plan.md (§13c), _Log.md

--- a/docs/userspace-dnat-plan.md
+++ b/docs/userspace-dnat-plan.md
@@ -706,6 +706,57 @@ Strict commit rejects `lo > hi` (`pkg/config` range validation), so this is the
   posture. A valid or `hi==lo` app destination-port still publishes its exact
   DNAT entry.
 
+## 13c. Rule `match destination-port` + `match application` (#3857)
+
+A DNAT rule that configured BOTH `match application` AND a rule-level `match
+destination-port` mishandled the port on the lenient / HA peer-sync decode path
+(`buildDestinationNATSnapshotsWithFeeds`, `nat.go`). Before #3857 the rule-level
+`match destination-port` was consulted ONLY on the no-application explicit-match
+path; when an application was ALSO present the builder read the application's own
+destination-port for the term and reached the rule-level port through a stray
+switch case that read only the SINGULAR first port. Three fail modes resulted
+(fable-161 F-018, the source-NAT builder handled all three correctly):
+
+- **F-018a (fail-open)** — a port-less application (`protocol tcp`, no
+  destination-port) combined with an INVALID / unrepresentable rule
+  destination-port (a non-numeric token on `InvalidDestinationPorts`, or an
+  out-of-range numeric) fell through to the wildcard match-any-port default
+  (`destination_port == 0`), WIDENING the rule to every port — the exact
+  fail-open the #3446 guard (§13) closes, re-opened on the mixed-version /
+  corrupt-snapshot path.
+- **F-018b** — a VALID rule destination-port was DROPPED when an application was
+  present (the application's own port, or a wildcard, won), so the operator's
+  explicit `match destination-port` had no effect.
+- **F-018c** — a MULTI-value rule destination-port list collapsed to the
+  singular first port (the switch case read `rule.Match.DestinationPort`, not the
+  full `DestinationPorts` list).
+
+Strict commit rejects an out-of-range / non-numeric rule `match
+destination-port` (`validateNATMatchDestinationPortStrict`), so this is the
+#1960 tolerant-load / peer-sync backstop — the same accepted threat model as §13
+/ §13a / §13b.
+
+**Builder fix.** The explicit rule-level `match destination-port` is now
+authoritative for the destination-port axis and applies to EVERY resolved
+application term. The builder resolves the rule's port list once
+(`ruleDstPorts`, the plural `DestinationPorts`, falling back to the scalar
+`DestinationPort` a mixed-version peer may carry alone; `ruleDstPortConfigured`
+also trips on a non-empty `InvalidDestinationPorts`) and, when configured, uses
+it in place of the application's own destination-port on each term. The
+application still constrains protocol / source-port / ICMP type-code (the #3437
+axes) — only the destination-port is taken from the explicit rule match. The
+full multi-value list is preserved (each port coalesces to its own compact wire
+range), and a configured-but-unrepresentable value trips the same
+`portConfigured` → emit-no-snapshot fail-closed branch used by §13 / §13b, so
+the rule matches NOTHING instead of widening to `[0,0]`. The stray singular-port
+switch case is removed; a port-less application with no rule destination-port
+still emits the genuine wildcard entry, unchanged.
+
+**Wire.** No new wire field and no Rust change — the Rust `l4_extra_matches`
+(`nat/destination.rs`) already AND-checks `match_destination_ports` and the
+exact `destination_port`, preserving the `low > high` never-match sentinel. The
+builder simply emits correct port ranges (or omits the rule).
+
 ## 14. DNAT pool port/address validation (#3450)
 
 A destination-NAT **pool**'s translated `port` and `address` had NO strict

--- a/pkg/dataplane/userspace/nat.go
+++ b/pkg/dataplane/userspace/nat.go
@@ -896,11 +896,13 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 			//   - No application configured: use the explicit match grammar
 			//     (protocol + destination-port). DNAT `match` grammar has no
 			//     source-port or ICMP type/code, so those axes stay unconstrained
-			//     on the explicit-match fallback term. #3446: this fallback sets
-			//     explicitFallback so the port-filtering loop below can tell a
+			//     on the explicit-match fallback term. The term carries the
+			//     rule's destination-port list directly; #3857 additionally
+			//     resolves the rule-level destination-port below (ruleDstPorts /
+			//     ruleDstPortConfigured) so the port-filtering loop can tell a
 			//     configured-but-unresolved destination-port from a genuine
-			//     wildcard and fail closed.
-			explicitFallback := false
+			//     wildcard and fail closed — for BOTH this path and the
+			//     application-present path.
 			if len(appTerms) == 0 {
 				if appConfigured {
 					appTerms = []appTerm{{srcPorts: []NatPortRangeWire{natNeverMatchPortRange}}}
@@ -917,9 +919,33 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 					for _, proto := range protos {
 						appTerms = append(appTerms, appTerm{proto: proto, ports: rule.Match.DestinationPorts})
 					}
-					explicitFallback = true
 				}
 			}
+
+			// #3857: an explicit rule-level `match destination-port` is
+			// authoritative for the DNAT destination-port axis and applies to
+			// EVERY resolved application term. Before #3857 the rule-level port
+			// was consulted ONLY on the no-application explicit-match path
+			// (explicitFallback); with an application ALSO present the builder
+			// (a) dropped a VALID rule destination-port (the application's own
+			// port, or a match-any wildcard, won), (b) collapsed a multi-value
+			// list to the singular first port, and (c) — for a port-less
+			// application — WIDENED an invalid/unrepresentable token to the
+			// wildcard [0,0] port, a fail-open that bypassed the #3446 dport
+			// guard on the lenient / HA peer-sync decode path. Resolve the
+			// rule's port list once here (the plural, falling back to the scalar
+			// a mixed-version peer may carry alone) and, when configured, use it
+			// in place of the application's own destination-port on every term.
+			// The application still constrains protocol / source-port / ICMP
+			// type-code; only the destination-port axis is taken from the
+			// explicit rule match. A configured-but-unrepresentable value fails
+			// CLOSED below (the rule is omitted), exactly like the no-application
+			// path and the source-NAT builder — it never widens to [0,0].
+			ruleDstPorts := rule.Match.DestinationPorts
+			if len(ruleDstPorts) == 0 && rule.Match.DestinationPort != 0 {
+				ruleDstPorts = []int{rule.Match.DestinationPort}
+			}
+			ruleDstPortConfigured := len(ruleDstPorts) > 0 || len(rule.Match.InvalidDestinationPorts) > 0
 
 			for _, term := range appTerms {
 				// #3446: a `match destination-port` that was configured but
@@ -943,25 +969,40 @@ func buildDestinationNATSnapshotsWithFeeds(cfg *config.Config, natCounterIDs map
 				// #3437 MatchSourcePorts handling). coalescePortRanges drops
 				// out-of-range values; an all-invalid configured port therefore
 				// coalesces to nothing and is failed CLOSED below.
-				portRanges := coalescePortRanges(term.ports)
-				// Did this rule CONFIGURE a destination-port at all? A configured
+				// #3857: the explicit rule-level `match destination-port`
+				// overrides the application's own destination-port on this term.
+				// term.ports (the application's destination-port) is used only
+				// when the rule did NOT configure `match destination-port`. On
+				// the no-application explicit-match path term.ports already IS
+				// rule.Match.DestinationPorts, so the override is a no-op there.
+				termPorts := term.ports
+				termDstPortConfigured := term.dstPortConfigured
+				if ruleDstPortConfigured {
+					termPorts = ruleDstPorts
+					termDstPortConfigured = true
+				}
+				portRanges := coalescePortRanges(termPorts)
+				// Did this term CONFIGURE a destination-port at all? A configured
 				// port that survived to no valid value must not become wildcard.
 				// #3726: term.dstPortConfigured is true when the application named
 				// a destination-port that coalesced to nothing (all out of
-				// 1..65535, or a reversed "200-100" range now rejected by
-				// appPortsFromSpec). Without this the app term's empty ports
-				// slipped through to the wildcard match-any-port default — a
-				// fail-open that widened the DNAT rule to every port.
-				portConfigured := len(term.ports) > 0 || term.dstPortConfigured ||
-					(explicitFallback && (rule.Match.DestinationPort != 0 || len(rule.Match.InvalidDestinationPorts) > 0))
+				// 1..65535, or a reversed "200-100" range rejected by
+				// appPortsFromSpec). #3857: termDstPortConfigured is also true
+				// when the rule pinned an explicit `match destination-port` (a
+				// numeric out-of-range, or non-numeric token on
+				// InvalidDestinationPorts). Without this the empty ports slip
+				// through to the wildcard match-any-port default — a fail-open
+				// that widens the DNAT rule to every port.
+				portConfigured := len(termPorts) > 0 || termDstPortConfigured
 				if len(portRanges) == 0 {
 					switch {
-					case rule.Match.DestinationPort >= 1 && rule.Match.DestinationPort <= 65535:
-						p := uint16(rule.Match.DestinationPort)
-						portRanges = []NatPortRangeWire{{Low: p, High: p}}
 					case portConfigured:
 						// Configured but no valid port → fail closed: emit no
 						// snapshot for this term so the rule matches nothing.
+						// #3857: this now also catches an invalid/unrepresentable
+						// rule-level `match destination-port` present ALONGSIDE an
+						// application, which previously widened to the [0,0]
+						// wildcard via the removed singular-port switch case.
 						continue
 					default:
 						// Genuine wildcard (no port match): a [0,0] range maps to

--- a/pkg/dataplane/userspace/nat_dnat_app_dport_3857_test.go
+++ b/pkg/dataplane/userspace/nat_dnat_app_dport_3857_test.go
@@ -1,0 +1,200 @@
+// #3857: DNAT rule with BOTH `match application` AND `match destination-port`.
+// The lenient / HA peer-sync snapshot builder must treat the explicit rule-level
+// `match destination-port` as authoritative on the destination-port axis:
+//
+//	(a) an INVALID / unrepresentable rule destination-port present alongside an
+//	    application must FAIL CLOSED (rule omitted) — it must NOT widen to the
+//	    wildcard [0,0] port (which bypasses the #3446 dport guard, a fail-open);
+//	(b) a VALID rule destination-port must be HONORED alongside the application
+//	    (not dropped in favor of the application's own port or a wildcard);
+//	(c) a MULTI-value rule destination-port list must keep EVERY port (not
+//	    collapse to the singular first port).
+//
+// These exercise the lenient/peer-sync decode path by constructing the NATMatch
+// directly (a crafted snapshot that skipped the strict commit gate), including
+// the scalar-only DestinationPort a mixed-version peer may carry alone.
+//
+// RED-on-revert: restoring the pre-#3857 builder (application's port wins /
+// singular-port switch case / [0,0] wildcard fallback) turns each of these RED.
+package userspace
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// dnatAppPortConfig builds a DNAT rule-set whose single rule references the
+// named application AND carries the given rule-level NATMatch destination-port
+// fields. The application is registered so ResolveApplication succeeds.
+func dnatAppPortConfig(appName string, app *config.Application, match config.NATMatch) *config.Config {
+	cfg := &config.Config{}
+	cfg.Applications.Applications = map[string]*config.Application{appName: app}
+	if match.DestinationAddress == "" {
+		match.DestinationAddress = "203.0.113.10"
+	}
+	match.Application = appName
+	cfg.Security.NAT.Destination = &config.DestinationNATConfig{
+		Pools: map[string]*config.NATPool{
+			"p1": {Name: "p1", Address: "192.168.1.10"},
+		},
+		RuleSets: []*config.NATRuleSet{
+			{
+				Name:     "rs",
+				FromZone: "untrust",
+				Rules: []*config.NATRule{{
+					Name:  "r1",
+					Match: match,
+					Then:  config.NATThen{Type: config.NATDestination, PoolName: "p1"},
+				}},
+			},
+		},
+	}
+	return cfg
+}
+
+func snapDstPorts(snaps []DestinationNATRuleSnapshot) []int {
+	out := make([]int, 0, len(snaps))
+	for _, s := range snaps {
+		out = append(out, int(s.DestinationPort))
+	}
+	sort.Ints(out)
+	return out
+}
+
+// (a) A port-less TCP application + an INVALID rule destination-port
+// (non-numeric token preserved on InvalidDestinationPorts) must fail CLOSED:
+// the rule is omitted. RED-on-revert: the removed [0,0] wildcard fallback
+// emits one wildcard snapshot (DestinationPort=0) = match every port.
+func TestBuildDNATSnapshotAppPlusInvalidDportFailsClosed_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("tcp-any", &config.Application{
+		Name:     "tcp-any",
+		Protocol: "tcp", // port-less: application does not pin a destination-port
+	}, config.NATMatch{
+		InvalidDestinationPorts: []string{"httpp"}, // configured but unparseable
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 0 {
+		t.Fatalf("invalid rule dest-port + application must match nothing, got %d snapshot(s): %+v",
+			len(snaps), snaps)
+	}
+}
+
+// (a') An out-of-range numeric rule destination-port alongside an application
+// must also fail CLOSED (not wrap, not widen). RED-on-revert: the singular
+// switch case rejected 70000 but the default branch then widened to [0,0].
+func TestBuildDNATSnapshotAppPlusOutOfRangeDportFailsClosed_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("tcp-any", &config.Application{
+		Name:     "tcp-any",
+		Protocol: "tcp",
+	}, config.NATMatch{
+		DestinationPorts: []int{70000},
+		DestinationPort:  70000,
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 0 {
+		t.Fatalf("out-of-range rule dest-port + application must match nothing, got %d: %+v",
+			len(snaps), snaps)
+	}
+}
+
+// (b) A valid rule destination-port must be HONORED even when the application
+// pins its OWN destination-port. RED-on-revert: the application's port (80) won
+// and the operator's explicit `match destination-port 8080` was dropped.
+func TestBuildDNATSnapshotRuleDportOverridesAppPort_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("http-80", &config.Application{
+		Name:            "http-80",
+		Protocol:        "tcp",
+		DestinationPort: "80",
+	}, config.NATMatch{
+		DestinationPorts: []int{8080},
+		DestinationPort:  8080,
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	if snaps[0].DestinationPort != 8080 {
+		t.Fatalf("DestinationPort = %d, want 8080 (explicit rule dest-port honored, not the app's 80)",
+			snaps[0].DestinationPort)
+	}
+}
+
+// (b') Peer-sync / mixed-version path: a snapshot that carries ONLY the scalar
+// DestinationPort (plural list empty) must still honor it over the app's port.
+// RED-on-revert: with an app that pins its own port, the app's port won.
+func TestBuildDNATSnapshotScalarOnlyRuleDportHonored_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("http-80", &config.Application{
+		Name:            "http-80",
+		Protocol:        "tcp",
+		DestinationPort: "80",
+	}, config.NATMatch{
+		DestinationPort: 8080, // scalar only — plural list empty (older peer)
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	if snaps[0].DestinationPort != 8080 {
+		t.Fatalf("DestinationPort = %d, want 8080 (scalar-only rule dest-port honored)",
+			snaps[0].DestinationPort)
+	}
+}
+
+// (c) A multi-value rule destination-port list must keep EVERY port. Uses a
+// port-less application so the ports come solely from the rule. RED-on-revert:
+// the singular switch case emitted only the first port (8080).
+func TestBuildDNATSnapshotMultiDportKeepsAllWithApp_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("tcp-any", &config.Application{
+		Name:     "tcp-any",
+		Protocol: "tcp",
+	}, config.NATMatch{
+		DestinationPorts: []int{8080, 8443},
+		DestinationPort:  8080,
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	got := snapDstPorts(snaps)
+	want := []int{8080, 8443}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("dest ports = %v, want %v (multi-port list must not collapse to first)", got, want)
+	}
+}
+
+// (b+c) A valid multi-value rule destination-port overrides an application that
+// ALSO pins its own port, keeping every rule port. RED-on-revert: the app's
+// single port (80) won and the multi-value rule list was dropped.
+func TestBuildDNATSnapshotMultiDportOverridesAppPort_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("http-80", &config.Application{
+		Name:            "http-80",
+		Protocol:        "tcp",
+		DestinationPort: "80",
+	}, config.NATMatch{
+		DestinationPorts: []int{8080, 8443},
+		DestinationPort:  8080,
+	})
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	got := snapDstPorts(snaps)
+	want := []int{8080, 8443}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("dest ports = %v, want %v (rule dest-port overrides app port, keeps all)", got, want)
+	}
+}
+
+// Regression guard: an application that pins its own destination-port with NO
+// rule-level `match destination-port` is UNCHANGED — the app's port is honored
+// and the fix must not over-reject or override it.
+func TestBuildDNATSnapshotAppPortUnchangedWithoutRuleDport_3857(t *testing.T) {
+	cfg := dnatAppPortConfig("http-80", &config.Application{
+		Name:            "http-80",
+		Protocol:        "tcp",
+		DestinationPort: "80",
+	}, config.NATMatch{}) // no rule-level destination-port
+	snaps := buildDestinationNATSnapshots(cfg, nil)
+	if len(snaps) != 1 {
+		t.Fatalf("len(snaps) = %d, want 1", len(snaps))
+	}
+	if snaps[0].DestinationPort != 80 {
+		t.Fatalf("DestinationPort = %d, want 80 (application port preserved)", snaps[0].DestinationPort)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3857 (fable-161 F-018, HIGH fail-open bypassing #3446).

A destination-NAT rule that configured BOTH `match application` AND a rule-level
`match destination-port` mishandled the port on the lenient / HA peer-sync
snapshot decode path (`buildDestinationNATSnapshotsWithFeeds`, `pkg/dataplane/userspace/nat.go`):

- **(a) fail-open** — a port-less application combined with an INVALID /
  unrepresentable rule destination-port WIDENED to the wildcard `[0,0]` port
  (match-any-port), translating traffic on ports the operator never intended —
  the exact widening the #3446 dport guard closes, re-opened on the
  mixed-version / corrupt-snapshot path.
- **(b)** a VALID rule destination-port was DROPPED when an application was also
  present (the application's own port, or a wildcard, won).
- **(c)** a MULTI-value rule destination-port list collapsed to the singular
  first port.

The source-NAT builder already handled all three correctly.

## Fix

The explicit rule-level `match destination-port` is now authoritative for the
destination-port axis and applies to EVERY resolved application term. The rule's
port list is resolved once (`ruleDstPorts` — the plural `DestinationPorts`,
falling back to the scalar `DestinationPort` a mixed-version peer may carry
alone; `ruleDstPortConfigured` also trips on a non-empty
`InvalidDestinationPorts`) and, when configured, is used in place of the
application's own destination-port on each term. The application still
constrains protocol / source-port / ICMP type-code (the #3437 axes). The full
multi-value list is preserved, and a configured-but-unrepresentable value fails
CLOSED via the existing `portConfigured` → emit-no-snapshot branch (§13 / #3446
posture) instead of widening to `[0,0]`. The stray singular-port switch case and
the now-dead `explicitFallback` flag are removed.

## Go-only — no wire / no Rust change

The Rust `l4_extra_matches` (`nat/destination.rs`) already AND-checks
`match_destination_ports` and the exact `destination_port` and preserves the
`low > high` never-match sentinel, so emitting correct port ranges (or omitting
the rule) is sufficient. No `cargo` run required.

## Tests (RED-on-revert)

`nat_dnat_app_dport_3857_test.go` exercises the lenient/peer-sync path (crafted
`NATMatch`):

- invalid and out-of-range rule dest-port + application → 0 snapshots (fail
  closed, not `[0,0]`);
- a valid rule dest-port overrides the application's own port;
- a scalar-only peer-sync dest-port is honored;
- a multi-value list keeps every port, with and without an application port;
- a regression guard proving the application-only path is unchanged.

Six defect tests verified **RED** against `origin/master` and **GREEN** with the
fix (the 7th, the app-only regression guard, is green on both).

## Validation

- `go test ./pkg/dataplane/...` green
- `go build ./...` green
- `gofmt` + `go vet` clean

## Docs

`docs/userspace-dnat-plan.md` §13c documents the fail modes, the builder fix,
and the no-wire-change / no-Rust-change conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
