### PR TITLE
config: make deterministic (CGNAT) NAT configurable via flat-set (#3864)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28401,3 +28401,36 @@ top.
   pkg/scheduler/scheduler_test.go + pkg/daemon/policy_scheduler_apply_test.go
   (updated for fail-closed semantics), pkg/scheduler/README.md +
   docs/config-schema.md (docs)
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3864 — deterministic (CGNAT) source NAT was un-configurable via
+  flat-set. The documented CGNAT quick-start (`set ... port deterministic
+  block-size N` + `... host address X` on SEPARATE `set` lines) was spuriously
+  rejected "deterministic block-size must be > 0" / "host address required":
+  the sibling `port deterministic ...` leaves overwrote each other last-wins in
+  `compiler_nat.go` and the host address was never read off Keys (`port`
+  unmodeled in `schema_security.go`). FIX: (1) model `port deterministic {
+  block-size; host address }` + `port range` as a container sub-stanza in
+  setSchema so the flat-set tokens GROUP onto ONE `port` node (and tab-complete
+  + typed block-size validation); (2) rewrite the compiler `port` case to read
+  block-size/host/range from BOTH the flat-set (Keys) AND hierarchical
+  (children) shapes and ACCUMULATE into a single DeterministicNATConfig instead
+  of resetting per sibling (the #2419 dual-AST-shape class) — new helpers
+  applyDeterministicKeys/applyDeterministicChildren/applyDeterministicHost only
+  write present fields. The genuine capacity/missing-field validation is
+  UNCHANGED (a real missing block-size / host / over-subscribed pool is still
+  rejected). RED-on-revert PROVEN: reverting the two source files (tests kept)
+  makes the flat-set doc config + reversed-order + range + IPv6 tests go RED
+  with the spurious "block-size must be > 0" / "host address required", while
+  the hierarchical-preserved and the two genuine-incomplete guards stay GREEN
+  (pre-existing-correct). DOC FIX: the doc's own IPv4 example was arithmetically
+  over-subscribed (/22 = 1024 hosts > 128 blocks → genuine capacity reject in
+  BOTH forms); corrected to /25 (128 hosts fit the 128 blocks) so the quick-
+  start actually commits clean, added the hierarchical equivalent + the
+  grouping note. go test ./pkg/config/... + ./pkg/dataplane/... green; go build
+  ./... green; gofmt + vet clean.
+- **File(s)**: pkg/config/schema_security.go (model `port` container),
+  pkg/config/compiler_nat.go (dual-shape accumulate + 3 helpers),
+  pkg/config/deterministic_nat_flatset_3864_test.go (new, 7 tests),
+  docs/deterministic-nat-cgnat.md (/22→/25 fix + hier example + grouping +
+  impl map), docs/config-schema.md (port now modeled note)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -314,8 +314,9 @@ degrades to a no-op rather than a surprise rejection. It exempts:
 - **`args == 0`** — a childless, untyped, zero-arg node is AMBIGUOUS between
   a presence-only flag (`dhcp`) and a deliberately-OPAQUE leaf whose subtree
   the compiler reads despite no schema children (`tcp-mss <mode> <value>`,
-  #1979; the unmodeled NAT pool `address`/`port`/`host` leaves). The screen
-  flag subset (`tcp land`, …) is handled by #3411 instead.
+  #1979; the unmodeled NAT pool `address`/`host` leaves — `port` is now a
+  modeled container for its `deterministic`/`range` sub-stanzas, #3864). The
+  screen flag subset (`tcp land`, …) is handled by #3411 instead.
 
 A quoted multi-word value (`description "trust zone"`) arrives as ONE token,
 so it is unaffected — only an UNQUOTED trailing token (`description trust

--- a/docs/deterministic-nat-cgnat.md
+++ b/docs/deterministic-nat-cgnat.md
@@ -17,7 +17,7 @@ overhead.
 ```
 set security nat source pool CGNAT-POOL address 203.0.113.1/32 to 203.0.113.4/32
 set security nat source pool CGNAT-POOL port deterministic block-size 2016
-set security nat source pool CGNAT-POOL port deterministic host address 100.64.0.0/22
+set security nat source pool CGNAT-POOL port deterministic host address 100.64.0.0/25
 set security nat source pool CGNAT-POOL port range low 1024 high 65535
 ```
 
@@ -26,7 +26,35 @@ This allocates:
 - Port range 1024-65535 = 64512 ports per IP
 - Block size 2016 = 32 blocks per IP
 - 4 IPs x 32 blocks = 128 subscriber slots
-- 100.64.0.0/22 = 1024 hosts (must fit within 128 blocks -- validated at compile)
+- 100.64.0.0/25 = 128 hosts (must fit within the 128 blocks -- validated at
+  compile: `totalBlocks >= subscriberCount`). A larger prefix such as
+  `/22` (1024 hosts) is rejected `insufficient capacity (128 blocks) for
+  1024 subscribers` -- widen the pool (more public IPs) or shrink the
+  block-size to add blocks.
+
+The four `set` lines above are entered in flat-set order; `block-size` and
+`host address` are SEPARATE `set` lines under the same `port deterministic`
+sub-stanza and GROUP onto one pool (#3864). The equivalent hierarchical
+block form also compiles:
+
+```
+security {
+    nat {
+        source {
+            pool CGNAT-POOL {
+                address 203.0.113.1/32 to 203.0.113.4/32;
+                port {
+                    range low 1024 high 65535;
+                    deterministic {
+                        block-size 2016;
+                        host address 100.64.0.0/25;
+                    }
+                }
+            }
+        }
+    }
+}
+```
 
 ### IPv6 Subscribers / NAPT64 (Deterministic Mode 2)
 
@@ -166,7 +194,8 @@ public IPs). `MAX_NAT_POOL_IPS` correspondingly increased to 8192.
 | Component | Change |
 |-----------|--------|
 | `pkg/config/types.go` | `DeterministicNATConfig` struct, `PoolUtilizationAlarmConfig` |
-| `pkg/config/compiler.go` | Parse deterministic port config (hierarchical + flat set), address ranges (`addr1/32 to addr2/32`), validation |
+| `pkg/config/compiler_nat.go` | Parse deterministic port config (hierarchical + flat set, accumulated across both AST shapes, #3864), address ranges (`addr1/32 to addr2/32`), capacity validation |
+| `pkg/config/schema_security.go` | Models `port deterministic { block-size; host address }` so the flat-set sub-stanza GROUPS + tab-completes (#3864) |
 | `pkg/dataplane/compiler.go` | Compile deterministic fields to `NATPoolConfig`, mode 1 vs mode 2 dispatch |
 | `pkg/dataplane/types.go` | `NATPoolConfig` extended with deterministic fields |
 | `pkg/api/metrics.go` | `xpf_nat_pool_deterministic_info` Prometheus gauge |

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -1014,6 +1014,79 @@ func expandAddressRange(low, high string) ([]string, error) {
 	return result, nil
 }
 
+// applyDeterministicKeys reads deterministic CGNAT sub-tokens from a flat-set
+// key slice that begins immediately AFTER the "deterministic" keyword, e.g.
+// ["block-size","2016"] or ["host","address","100.64.0.0/22"] or ["host","X"].
+// Only fields that are present are written, so the caller can invoke it
+// repeatedly across sibling `port deterministic ...` leaves and the values
+// ACCUMULATE rather than overwrite last-wins (#3864; #2419 dual-AST-shape).
+func applyDeterministicKeys(det *DeterministicNATConfig, keys []string) {
+	for i := 0; i < len(keys); i++ {
+		switch keys[i] {
+		case "block-size":
+			if i+1 < len(keys) {
+				if n, err := strconv.Atoi(keys[i+1]); err == nil {
+					det.BlockSize = n
+				}
+			}
+		case "host":
+			// "host address X" (canonical) or the tolerant "host X".
+			if i+1 < len(keys) && keys[i+1] == "address" {
+				if i+2 < len(keys) {
+					det.HostAddress = keys[i+2]
+				}
+			} else if i+1 < len(keys) {
+				det.HostAddress = keys[i+1]
+			}
+		}
+	}
+}
+
+// applyDeterministicChildren reads deterministic CGNAT sub-fields from the
+// CHILDREN of a `deterministic` container node (the hierarchical /
+// schema-grouped shape, `deterministic { block-size N; host address X }`).
+// Like applyDeterministicKeys it only writes present fields so mixed/repeated
+// shapes accumulate into a single config (#3864).
+func applyDeterministicChildren(det *DeterministicNATConfig, detNode *Node) {
+	// The deterministic node may itself carry trailing flat-set tokens
+	// (e.g. Keys=["deterministic","block-size","2016"]).
+	if len(detNode.Keys) > 1 {
+		applyDeterministicKeys(det, detNode.Keys[1:])
+	}
+	for _, c := range detNode.Children {
+		switch c.Name() {
+		case "block-size":
+			if v := nodeVal(c); v != "" {
+				if n, err := strconv.Atoi(v); err == nil {
+					det.BlockSize = n
+				}
+			}
+		case "host":
+			applyDeterministicHost(det, c)
+		}
+	}
+}
+
+// applyDeterministicHost reads the subscriber CIDR from a `host` node in any
+// of its shapes: the flat leaf Keys=["host","address","X"], the hierarchical
+// `host { address X }`, or the tolerant bare `host X`. It never records the
+// literal keyword "address" as the value (#3864).
+func applyDeterministicHost(det *DeterministicNATConfig, hostNode *Node) {
+	if len(hostNode.Keys) >= 3 && hostNode.Keys[1] == "address" {
+		det.HostAddress = hostNode.Keys[2]
+		return
+	}
+	if addr := hostNode.FindChild("address"); addr != nil {
+		if v := nodeVal(addr); v != "" {
+			det.HostAddress = v
+			return
+		}
+	}
+	if len(hostNode.Keys) == 2 {
+		det.HostAddress = hostNode.Keys[1]
+	}
+}
+
 func compileNATSource(node *Node, sec *SecurityConfig) error {
 	// Global flags
 	if node.FindChild("address-persistent") != nil {
@@ -1054,7 +1127,37 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 					}
 				}
 			case "port":
-				// "port range low N high M" or "port N"
+				// Port block configuration for a source pool. Supported
+				// AST shapes (#3864, #2419 dual-AST-shape):
+				//
+				//   flat leaf  : Keys=["port","range","low",N,"high",M]
+				//                Keys=["port",N]
+				//                Keys=["port","deterministic","block-size",N]
+				//                Keys=["port","deterministic","host","address",X]
+				//   hierarchical / schema-grouped: one `port` container
+				//                (schema_security.go groups the flat-set
+				//                tokens) with `range`/`deterministic`
+				//                children — `port { range low N high M;
+				//                deterministic { block-size N; host address
+				//                X } }`.
+				//
+				// Deterministic block-size and host address arrive on
+				// SEPARATE flat-set `set` lines; before #3864 each sibling
+				// `port deterministic ...` leaf reset pool.Deterministic to
+				// a fresh struct (last-wins) and the host address was never
+				// read off Keys, so the documented CGNAT quick-start was
+				// spuriously rejected ("block-size must be > 0" / "host
+				// address required"). Deterministic fields are now
+				// ACCUMULATED into a single config across every shape and
+				// sibling, writing only fields that are present.
+				ensureDet := func() *DeterministicNATConfig {
+					if pool.Deterministic == nil {
+						pool.Deterministic = &DeterministicNATConfig{}
+					}
+					return pool.Deterministic
+				}
+
+				// Port range / single value — flat leaf shapes.
 				if len(prop.Keys) >= 6 && prop.Keys[1] == "range" &&
 					prop.Keys[2] == "low" && prop.Keys[4] == "high" {
 					if v, err := strconv.Atoi(prop.Keys[3]); err == nil {
@@ -1063,69 +1166,46 @@ func compileNATSource(node *Node, sec *SecurityConfig) error {
 					if v, err := strconv.Atoi(prop.Keys[5]); err == nil {
 						pool.PortHigh = v
 					}
-				} else if v := nodeVal(prop); v != "" {
-					if n, err := strconv.Atoi(v); err == nil {
+				} else if len(prop.Keys) == 2 && prop.Keys[1] != "range" &&
+					prop.Keys[1] != "deterministic" {
+					// "port N" single value.
+					if n, err := strconv.Atoi(prop.Keys[1]); err == nil {
 						pool.PortLow = n
 						pool.PortHigh = n
 					}
 				}
-				// Check for deterministic port config (hierarchical)
-				for _, portChild := range prop.Children {
-					if portChild.Name() == "deterministic" {
-						detCfg := &DeterministicNATConfig{}
-						for _, detProp := range portChild.Children {
-							switch detProp.Name() {
-							case "block-size":
-								if v := nodeVal(detProp); v != "" {
-									if n, err := strconv.Atoi(v); err == nil {
-										detCfg.BlockSize = n
-									}
-								}
-							case "host":
-								// "host address 100.64.0.0/22"
-								if len(detProp.Keys) >= 3 && detProp.Keys[1] == "address" {
-									detCfg.HostAddress = detProp.Keys[2]
-								} else if v := nodeVal(detProp); v != "" {
-									detCfg.HostAddress = v
-								}
-								for _, hc := range detProp.Children {
-									if hc.Name() == "address" {
-										if v := nodeVal(hc); v != "" {
-											detCfg.HostAddress = v
-										}
-									}
-								}
-							}
-						}
-						pool.Deterministic = detCfg
-					}
-				}
-				// Flat set: "port deterministic block-size 2016"
+
+				// Deterministic — flat leaf: Keys=["port","deterministic",...].
 				if len(prop.Keys) >= 2 && prop.Keys[1] == "deterministic" {
-					detCfg := &DeterministicNATConfig{}
-					for i := 2; i < len(prop.Keys); i++ {
-						if prop.Keys[i] == "block-size" && i+1 < len(prop.Keys) {
-							if n, err := strconv.Atoi(prop.Keys[i+1]); err == nil {
-								detCfg.BlockSize = n
+					applyDeterministicKeys(ensureDet(), prop.Keys[2:])
+				}
+
+				// Children — hierarchical / schema-grouped `port { ... }`.
+				for _, pc := range prop.Children {
+					switch pc.Name() {
+					case "range":
+						// range low N high M
+						if len(pc.Keys) >= 5 && pc.Keys[1] == "low" &&
+							pc.Keys[3] == "high" {
+							if v, err := strconv.Atoi(pc.Keys[2]); err == nil {
+								pool.PortLow = v
+							}
+							if v, err := strconv.Atoi(pc.Keys[4]); err == nil {
+								pool.PortHigh = v
+							}
+						}
+					case "deterministic":
+						applyDeterministicChildren(ensureDet(), pc)
+					default:
+						// Bare numeric child: `port N` grouped under a
+						// modeled container becomes port { N }.
+						if pc.IsLeaf && len(pc.Keys) == 1 {
+							if n, err := strconv.Atoi(pc.Keys[0]); err == nil {
+								pool.PortLow = n
+								pool.PortHigh = n
 							}
 						}
 					}
-					// host address from children
-					for _, portChild := range prop.Children {
-						if portChild.Name() == "host" {
-							if len(portChild.Keys) >= 3 && portChild.Keys[1] == "address" {
-								detCfg.HostAddress = portChild.Keys[2]
-							}
-							for _, hc := range portChild.Children {
-								if hc.Name() == "address" {
-									if v := nodeVal(hc); v != "" {
-										detCfg.HostAddress = v
-									}
-								}
-							}
-						}
-					}
-					pool.Deterministic = detCfg
 				}
 			case "persistent-nat":
 				// #2823: default is target-host-port (the pre-#2823

--- a/pkg/config/deterministic_nat_flatset_3864_test.go
+++ b/pkg/config/deterministic_nat_flatset_3864_test.go
@@ -1,0 +1,211 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3864: deterministic (CGNAT) source NAT was un-configurable via flat-set.
+// The block-size and host address arrive on SEPARATE `set` lines; before the
+// fix each sibling `port deterministic ...` leaf reset pool.Deterministic to a
+// fresh struct (last-wins) and the host address was never read off Keys, so
+// the documented quick-start was spuriously rejected ("deterministic
+// block-size must be > 0" / "deterministic host address required") while the
+// hierarchical block form worked. The fix models `port deterministic { ... }`
+// in setSchema (flat-set grouping + completion) AND accumulates the
+// deterministic fields across BOTH the flat-set (Keys) and hierarchical
+// (children) shapes in compiler_nat.go (the #2419 dual-AST-shape class).
+//
+// All tests drive the production ParseSetCommand + SetPath path (buildTree)
+// per the CLAUDE.md flat-set gotcha — never NewParser for flat-set.
+
+// deterministicNAT builds a source-pool config. hostPrefix "" omits the host
+// line (genuine-incomplete case); blockSize "" omits the block-size line.
+func deterministicNATLines(blockSize, hostPrefix string) []string {
+	base := "set security nat source pool CGNAT-POOL "
+	lines := []string{
+		"set security zones security-zone trust",
+		base + "address 203.0.113.1/32 to 203.0.113.4/32",
+		base + "port range low 1024 high 65535",
+	}
+	if blockSize != "" {
+		lines = append(lines, base+"port deterministic block-size "+blockSize)
+	}
+	if hostPrefix != "" {
+		lines = append(lines, base+"port deterministic host address "+hostPrefix)
+	}
+	return lines
+}
+
+// TestDeterministicNATFlatSetCommits is the #3864 FAIL-ON-REVERT proof: the
+// documented CGNAT quick-start, entered as flat-set with block-size and host
+// on separate `set` lines, must COMMIT CLEAN and compile the deterministic
+// mapping. Pre-fix the sibling `port deterministic ...` leaves overwrote each
+// other (last-wins) and the host was never parsed off Keys, so this config was
+// spuriously rejected "deterministic block-size must be > 0". 100.64.0.0/25 =
+// 128 hosts fits the 4-IP x 32-block = 128 block capacity exactly.
+func TestDeterministicNATFlatSetCommits(t *testing.T) {
+	cfg, err := CompileConfig(buildTree(t, deterministicNATLines("2016", "100.64.0.0/25")))
+	if err != nil {
+		t.Fatalf("documented flat-set CGNAT quick-start must commit clean (#3864); got: %v", err)
+	}
+	det := poolDeterministic(t, cfg, "CGNAT-POOL")
+	if det.BlockSize != 2016 {
+		t.Fatalf("block-size must be read off the flat-set leaf: want 2016, got %d", det.BlockSize)
+	}
+	if det.HostAddress != "100.64.0.0/25" {
+		t.Fatalf("host address must be read off the flat-set Keys: want 100.64.0.0/25, got %q", det.HostAddress)
+	}
+}
+
+// TestDeterministicNATFlatSetReversedOrder proves the accumulate is
+// order-independent: host line BEFORE the block-size line must also commit
+// clean (pre-fix this reversed order was rejected "deterministic host address
+// required" because the block-size leaf overwrote the host leaf's struct).
+func TestDeterministicNATFlatSetReversedOrder(t *testing.T) {
+	base := "set security nat source pool CGNAT-POOL "
+	lines := []string{
+		"set security zones security-zone trust",
+		base + "address 203.0.113.1/32 to 203.0.113.4/32",
+		base + "port deterministic host address 100.64.0.0/25",
+		base + "port deterministic block-size 2016",
+		base + "port range low 1024 high 65535",
+	}
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("reversed-order flat-set CGNAT config must commit clean (#3864); got: %v", err)
+	}
+	det := poolDeterministic(t, cfg, "CGNAT-POOL")
+	if det.BlockSize != 2016 || det.HostAddress != "100.64.0.0/25" {
+		t.Fatalf("reversed order must still accumulate both fields, got block-size=%d host=%q",
+			det.BlockSize, det.HostAddress)
+	}
+}
+
+// TestDeterministicNATFlatSetReadsRange proves the modeled `port` container
+// still parses `port range low N high M` (a non-default range) after the
+// grouping change, so the range did not regress into a dropped nested leaf.
+func TestDeterministicNATFlatSetReadsRange(t *testing.T) {
+	base := "set security nat source pool CGNAT-POOL "
+	lines := []string{
+		"set security zones security-zone trust",
+		base + "address 203.0.113.1/32 to 203.0.113.32/32",
+		base + "port range low 2000 high 40000",
+		base + "port deterministic block-size 1000",
+		base + "port deterministic host address 100.64.0.0/25",
+	}
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("config must compile: %v", err)
+	}
+	pool := sourcePool(t, cfg, "CGNAT-POOL")
+	if pool.PortLow != 2000 || pool.PortHigh != 40000 {
+		t.Fatalf("port range must be read from the modeled container: want 2000-40000, got %d-%d",
+			pool.PortLow, pool.PortHigh)
+	}
+}
+
+// TestDeterministicNATMissingBlockSizeRejected is the genuine-incomplete guard:
+// a deterministic config with a host but NO block-size is STILL rejected. The
+// #3864 fix repairs only the SPURIOUS rejection of a well-formed config — a
+// truly incomplete config must keep failing.
+func TestDeterministicNATMissingBlockSizeRejected(t *testing.T) {
+	_, err := CompileConfig(buildTree(t, deterministicNATLines("", "100.64.0.0/25")))
+	if err == nil {
+		t.Fatal("deterministic config missing block-size must be rejected (#3864 must not weaken validation)")
+	}
+	if !strings.Contains(err.Error(), "block-size must be > 0") {
+		t.Fatalf("error must name the missing block-size, got: %v", err)
+	}
+}
+
+// TestDeterministicNATMissingHostRejected is the sibling genuine-incomplete
+// guard: a deterministic config with a block-size but NO host is STILL
+// rejected.
+func TestDeterministicNATMissingHostRejected(t *testing.T) {
+	_, err := CompileConfig(buildTree(t, deterministicNATLines("2016", "")))
+	if err == nil {
+		t.Fatal("deterministic config missing host address must be rejected (#3864 must not weaken validation)")
+	}
+	if !strings.Contains(err.Error(), "host address required") {
+		t.Fatalf("error must name the missing host address, got: %v", err)
+	}
+}
+
+// TestDeterministicNATHierarchicalPreserved proves the genuine hierarchical
+// (brace) block form still compiles and parses both fields — the flat-set fix
+// must not regress the pre-existing hierarchical path.
+func TestDeterministicNATHierarchicalPreserved(t *testing.T) {
+	blockCfg := `security {
+  zones { security-zone trust; }
+  nat {
+    source {
+      pool CGNAT-POOL {
+        address 203.0.113.1/32 to 203.0.113.4/32;
+        port {
+          range low 1024 high 65535;
+          deterministic {
+            block-size 2016;
+            host address 100.64.0.0/25;
+          }
+        }
+      }
+    }
+  }
+}`
+	p := NewParser(blockCfg)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("parse errors: %v", perrs)
+	}
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("hierarchical CGNAT block form must still compile: %v", err)
+	}
+	det := poolDeterministic(t, cfg, "CGNAT-POOL")
+	if det.BlockSize != 2016 || det.HostAddress != "100.64.0.0/25" {
+		t.Fatalf("hierarchical form must parse both fields, got block-size=%d host=%q",
+			det.BlockSize, det.HostAddress)
+	}
+}
+
+// TestDeterministicNATIPv6DocExample proves the documented IPv6/NAPT64 flat-set
+// quick-start commits clean (8 IPs, /32 host prefix).
+func TestDeterministicNATIPv6DocExample(t *testing.T) {
+	base := "set security nat source pool CGNAT64-POOL "
+	lines := []string{
+		"set security zones security-zone trust",
+		base + "address 203.0.113.1/32 to 203.0.113.8/32",
+		base + "port deterministic block-size 2016",
+		base + "port deterministic host address 2001:db8::/32",
+	}
+	cfg, err := CompileConfig(buildTree(t, lines))
+	if err != nil {
+		t.Fatalf("documented IPv6 CGNAT quick-start must commit clean (#3864); got: %v", err)
+	}
+	det := poolDeterministic(t, cfg, "CGNAT64-POOL")
+	if det.BlockSize != 2016 || det.HostAddress != "2001:db8::/32" {
+		t.Fatalf("IPv6 flat-set must accumulate both fields, got block-size=%d host=%q",
+			det.BlockSize, det.HostAddress)
+	}
+}
+
+func sourcePool(t *testing.T, cfg *Config, name string) *NATPool {
+	t.Helper()
+	for _, p := range cfg.Security.NAT.SourcePools {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("source pool %q not found", name)
+	return nil
+}
+
+func poolDeterministic(t *testing.T, cfg *Config, name string) *DeterministicNATConfig {
+	t.Helper()
+	pool := sourcePool(t, cfg, name)
+	if pool.Deterministic == nil {
+		t.Fatalf("pool %q: deterministic config not parsed (nil)", name)
+	}
+	return pool.Deterministic
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -302,15 +302,44 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 	}},
 	"nat": {desc: "Network Address Translation", children: map[string]*schemaNode{
 		"source": {desc: "Source NAT configuration", children: map[string]*schemaNode{
-			// #2823: the pool body is a container. Only the persistent-nat
-			// subtree is modeled here (commit-check + completion for the
-			// three-way `permit` enum); other pool leaves (address, port,
-			// host) are unmodeled and left to the compiler per the
+			// #2823: the pool body is a container. The persistent-nat and
+			// port (#3864) subtrees are modeled here (commit-check +
+			// completion + flat-set grouping); the remaining pool leaves
+			// (address, host) are unmodeled and left to the compiler per the
 			// opt-in-gate contract (schema_walk.go: unknown keywords return
 			// nil). The container also keeps SetPath grouping intact —
 			// trailing tokens always descend, and a bare `pool <name>` still
 			// emits a leaf.
+			//
+			// #3864: `port deterministic { block-size N; host address X }`
+			// (CGNAT) is modeled so the documented flat-set quick-start
+			// GROUPS onto a single `port` container instead of emitting
+			// competing sibling `port deterministic ...` leaves that the
+			// compiler read last-wins (block-size and host arrive on
+			// separate `set` lines). The compiler (compiler_nat.go) still
+			// accepts the un-modeled flat-leaf shape and ACCUMULATES across
+			// both shapes, so an old on-disk config keeps compiling.
 			"pool": {desc: "Source NAT pool name", args: 1, valueHint: ValueHintPoolName, placeholder: "<pool-name>", children: map[string]*schemaNode{
+				"port": {desc: "Source pool port block configuration", children: map[string]*schemaNode{
+					// `range low <lo> high <hi>` — the low/high tokens
+					// collapse onto this one multi leaf (Keys=["range",
+					// "low",lo,"high",hi]); the compiler reads them off Keys.
+					"range": {desc: "Explicit source port range for the pool", multi: true, children: nil},
+					"deterministic": {desc: "Deterministic (CGNAT) port block allocation", children: map[string]*schemaNode{
+						"block-size": {
+							desc:          "Ports allocated per subscriber block",
+							args:          1,
+							valueType:     ValueInteger,
+							valueDesc:     "Block size in ports",
+							valueExamples: []string{"2016"},
+							validator:     ValidateInteger(1, 65535),
+							children:      nil,
+						},
+						"host": {desc: "Subscriber host address range", children: map[string]*schemaNode{
+							"address": {desc: "Subscriber CIDR prefix", args: 1, placeholder: "<prefix>", children: nil},
+						}},
+					}},
+				}},
 				"persistent-nat": {desc: "Persistent NAT bindings", children: map[string]*schemaNode{
 					"permit": {
 						desc:          "Remote-host reuse scope for persistent bindings",


### PR DESCRIPTION
## Summary

Closes #3864 (fable-review-161 F-002).

Deterministic (CGNAT) source NAT could not be committed in flat-set form. The documented quick-start —

```
set security nat source pool P port deterministic block-size 2016
set security nat source pool P port deterministic host address 100.64.0.0/25
```

— was spuriously rejected at commit with `deterministic block-size must be > 0` (or, in the reverse order, `deterministic host address required`), while the hierarchical brace form compiled. The project's own documented quick-start hard-failed commit with a gaslighting error.

## Root cause (the #2419 dual-AST-shape class, two sites)

- **`schema_security.go`** left `port` unmodeled, so each flat-set line emitted a SEPARATE sibling `port deterministic ...` leaf on the pool instead of grouping onto one node.
- **`compiler_nat.go`** read each sibling leaf independently and did `pool.Deterministic = &DeterministicNATConfig{...}`, so the second leaf OVERWROTE the first (last-wins) — `block-size` and `host` arrive on different `set` lines and can never both survive. The host address was also never read off the leaf `Keys` (only off children).

## Fix

- **Model** `port { range ...; deterministic { block-size N; host address X } }` as a container sub-stanza in `setSchema`. SetPath now GROUPS the flat-set tokens onto one `port` node; `block-size` gets typed commit-check + value-slot `?` completion; the sub-stanza tab-completes.
- **Rewrite** the compiler `port` case to read block-size / host / range from BOTH the flat-set (`Keys`) and hierarchical (children) shapes and ACCUMULATE into a single `DeterministicNATConfig`, writing only present fields so sibling / mixed shapes merge instead of clobbering. New helpers `applyDeterministicKeys` / `applyDeterministicChildren` / `applyDeterministicHost`.

The genuine validation is unchanged — a real missing block-size, missing host, or over-subscribed pool (`insufficient capacity`) is still rejected on both paths. Old on-disk configs in the un-modeled flat-leaf shape still compile.

## Doc fix

The doc's own IPv4 example was arithmetically over-subscribed (`100.64.0.0/22` = 1024 hosts against a 4-IP × 32-block = 128-block pool → a genuine `insufficient capacity` reject in BOTH forms). Corrected to `/25` (128 hosts, fits the 128 blocks) so the quick-start actually commits clean, plus the equivalent hierarchical block form and the grouping note.

## RED-on-revert proof

Reverting the two source files (tests kept) makes the flat-set doc config, reversed line order, non-default range, and IPv6/NAPT64 tests go RED with the spurious `block-size must be > 0` / `host address required`, while:
- the hierarchical-preserved test stays GREEN (pre-existing-correct path), and
- the two genuine-incomplete guards (missing block-size / missing host) stay GREEN (validation not weakened).

## Validation

- `go test ./pkg/config/...` + `./pkg/dataplane/...` green
- `go build ./...` green
- `gofmt` + `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi