### PR TITLE
daemon: re-sync rolled-back config to peer on commit-confirmed timeout (#3868)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28442,3 +28442,31 @@ top.
   pkg/scheduler/scheduler_test.go + pkg/daemon/policy_scheduler_apply_test.go
   (updated for fail-closed semantics), pkg/scheduler/README.md +
   docs/config-schema.md (docs)
+- **Timestamp**: 2026-07-03
+- **Action**: Fix #3868 (fable-161 F-150) — HA config divergence on a
+  commit-confirmed TIMEOUT. The standby receives the unconfirmed config (C2)
+  via config-sync `SyncApply` (arms NO confirm timer → permanent active), but
+  `executeConfirmedRollback` reverted only the LOCAL node to the prior confirmed
+  config (C1) and never pushed the rollback to the peer → nodes diverged
+  (primary=C1, standby=C2); a failover served the abandoned C2. FIX: the
+  confirm-timeout rollback path (daemon_apply.go, non-nil `prevCfg` branch, after
+  `PromoteRollback` + apply) now calls `d.resyncRolledBackConfigToPeer()` which
+  runs the same `d.syncConfigToPeer()` push a normal commit uses — reading the
+  now-promoted active (C1) via `ShowActive` and queuing it to the peer. Peer-
+  absent is self-guarded (nil cluster/sessionSync, not RG0 primary, config-sync
+  disabled, or no active TCP conn all no-op); reverse-sync-on-reconnect retries.
+  The nil-`prevCfg` (first-commit → bootstrap) branch deliberately does NOT
+  re-sync (reverted empty tree carries no config-sync stanza; a bootstrap node
+  is not the RG0 authority). Split into `resyncRolledBackConfigToPeer` +
+  `resyncPeerForTest` seam (the real push needs a live TCP transport) so the
+  rollback is unit-testable. RED-on-revert PROVEN: removing the resync call
+  makes TestExecuteConfirmedRollbackResyncsPeer fail "got 0 calls". Sibling of
+  #3865/#3861 (store-side timer clear) — this is the daemon-HA half.
+  go test ./pkg/daemon/... ./pkg/cluster/... green; go build ./... green;
+  gofmt + vet clean. test-failover WARRANTED (HA config convergence) — flagged
+  for batch validation.
+- **File(s)**: pkg/daemon/daemon_apply.go (executeConfirmedRollback resync +
+  resyncRolledBackConfigToPeer helper + nil-branch note), pkg/daemon/daemon.go
+  (resyncPeerForTest seam field), pkg/daemon/rollback_resync_test.go (new
+  RED-on-revert + peer-absent tests), docs/ha-cluster-test-plan.md (TC-5b
+  commit-confirmed timeout convergence scenario)

--- a/docs/ha-cluster-test-plan.md
+++ b/docs/ha-cluster-test-plan.md
@@ -542,6 +542,46 @@ printf 'show configuration security policies from-zone lan to-zone wan | display
 - Policy `test-sync` appears on fw1 within seconds
 - fw1 shows config as read-only (secondary cannot modify)
 
+### TC-5b: Commit-Confirmed Timeout Converges Both Nodes (#3868)
+
+**Objective:** Verify that when a `commit confirmed` is left to TIME OUT, BOTH
+nodes revert to the prior confirmed config — the standby must not be stranded on
+the abandoned unconfirmed config.
+
+Background: config sync is unidirectional (primary → secondary) and the standby
+applies a synced config via `SyncApply`, which arms **no** confirm timer — it
+holds the pushed config as its permanent active. So an unconfirmed `commit
+confirmed` on the primary is replicated to the standby immediately. On the
+confirm-timeout the primary's `executeConfirmedRollback` reverts its own store
+(`PromoteRollback`) AND now re-syncs the rolled-back config to the peer
+(`syncConfigToPeer`), so the standby converges too. Without the re-sync the
+nodes diverge (primary=C1, standby=C2) and a failover would serve the abandoned
+C2. The re-sync self-guards peer-absent (nil cluster/sessionSync, not RG0
+primary, config-sync disabled, or no active TCP conn all no-op); the existing
+reverse-sync-on-reconnect retries when the peer returns.
+
+```bash
+# 1. On fw0 (primary), commit-confirmed a distinctive change WITHOUT confirming:
+printf 'configure\nset security policies from-zone lan to-zone wan policy test-confirm match source-address any destination-address any application any then permit\ncommit confirmed 1\nexit\nexit\n' | incus exec xpf-fw0 -- cli
+
+# 2. Immediately verify the UNCONFIRMED policy replicated to fw1:
+printf 'show configuration security policies from-zone lan to-zone wan | display set\nexit\n' | incus exec xpf-fw1 -- cli   # test-confirm present
+
+# 3. Do NOT confirm. Wait for the 1-minute timeout to fire on fw0.
+sleep 75
+
+# 4. Verify BOTH nodes reverted (test-confirm GONE on fw0 AND fw1):
+printf 'show configuration security policies from-zone lan to-zone wan | display set\nexit\n' | incus exec xpf-fw0 -- cli
+printf 'show configuration security policies from-zone lan to-zone wan | display set\nexit\n' | incus exec xpf-fw1 -- cli
+```
+
+**Pass criteria:**
+- After step 2, `test-confirm` is present on BOTH fw0 and fw1.
+- After the timeout (step 4), `test-confirm` is absent on BOTH fw0 and fw1 — the
+  standby converged to the rolled-back config, no divergence.
+- A subsequent failover serves the rolled-back (confirmed) config, not the
+  abandoned one.
+
 ### TC-6: Session Synchronization
 
 **Objective:** Verify active sessions are synced to secondary for hitless failover.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -316,6 +316,16 @@ type Daemon struct {
 	// / commitAndApply paths without standing up the full dataplane.
 	applyBodyForTest func(*config.Config)
 
+	// resyncPeerForTest, when non-nil, replaces the real
+	// d.syncConfigToPeer() call the commit-confirmed timeout rollback
+	// makes to converge the standby onto the rolled-back config (#3868).
+	// Test-only seam: the production peer re-sync path (syncConfigToPeer
+	// -> pushConfigToPeer -> SessionSync.QueueConfig) needs a live TCP
+	// transport, so rollback_resync_test.go injects this to observe that
+	// executeConfirmedRollback re-syncs the C1 rollback target after
+	// PromoteRollback.
+	resyncPeerForTest func()
+
 	// hostInboundAddresslessZones is the set of configured host-inbound-
 	// enforcing zones observed in the transient fail-open admit window on the
 	// PREVIOUS apply (#3698): a zone with a non-lifeline interface but no

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -355,6 +355,13 @@ func (d *Daemon) executeConfirmedRollback(gen uint64) {
 		slog.Warn("commit confirmed (first commit) timed out; rolling back to BOOTSTRAP mode " +
 			"(removing interface/FRR/dataplane takeover, keeping the management lifeline)")
 		d.enterBootstrapMode()
+		// #3868: no peer re-sync here. This branch reverts a FIRST commit on a
+		// fresh store to the empty tree + bootstrap mode; the reverted active
+		// carries no chassis-cluster/config-sync stanza, so syncConfigToPeer ->
+		// pushConfigToPeer would no-op anyway (and a bootstrap node is not the
+		// RG0 config authority). The divergence #3868 fixes is the NON-nil
+		// rollback target below, where the standby holds a real abandoned
+		// config (C2) as permanent active.
 		return
 	}
 	// #1956 V-3/OQ-15.2: the non-nil rollback target is applied
@@ -372,7 +379,36 @@ func (d *Daemon) executeConfirmedRollback(gen uint64) {
 	if err := d.applyConfigLocked(context.Background(), prevCfg); err != nil {
 		slog.Error("commit confirmed auto-rollback dataplane apply failed", "err", err)
 	}
+	// #3868: RE-SYNC the rolled-back config (C1) to the cluster peer. The
+	// standby already received the unconfirmed config (C2) via config-sync
+	// SyncApply, which arms NO confirm timer, so it holds C2 as its PERMANENT
+	// active. PromoteRollback above reverted only THIS node's store to C1;
+	// without this push the nodes DIVERGE (primary=C1, standby=C2) and a
+	// failover would serve the abandoned C2. syncConfigToPeer reads the
+	// now-promoted active (C1) via ShowActive and queues it, exactly like a
+	// normal commit's sync. It self-guards the peer-absent/disconnected case
+	// (nil cluster/sessionSync, not RG0 primary, config-sync disabled, or no
+	// active TCP conn all no-op); the existing reverse-sync-on-reconnect
+	// retries when the peer comes back. Runs under d.applySem (held above),
+	// after PromoteRollback, so the pushed text is always the rollback target.
+	d.resyncRolledBackConfigToPeer()
 	slog.Warn("commit confirmed timed out, configuration rolled back")
+}
+
+// resyncRolledBackConfigToPeer pushes the just-promoted rollback-target config
+// to the cluster peer after a commit-confirmed timeout (#3868). Split out so
+// the confirm-timeout rollback path is unit-testable without a live cluster
+// transport: rollback_resync_test.go injects d.resyncPeerForTest to observe the
+// call; production leaves it nil and the real syncConfigToPeer runs. MUST be
+// called with d.applySem held and AFTER PromoteRollback so d.store.ShowActive()
+// (read inside syncConfigToPeer -> pushConfigToPeer) reflects the rolled-back
+// config, not the abandoned unconfirmed one.
+func (d *Daemon) resyncRolledBackConfigToPeer() {
+	if d.resyncPeerForTest != nil {
+		d.resyncPeerForTest()
+		return
+	}
+	d.syncConfigToPeer()
 }
 
 // applyConfigLocked runs the actual reconcile pipeline. MUST be

--- a/pkg/daemon/rollback_resync_test.go
+++ b/pkg/daemon/rollback_resync_test.go
@@ -1,0 +1,90 @@
+// #3868: HA config divergence on a commit-confirmed TIMEOUT.
+//
+// The standby receives the unconfirmed config (C2) via config-sync SyncApply,
+// which arms NO confirm timer, so it holds C2 as its PERMANENT active. When the
+// confirm window expires, executeConfirmedRollback (PromoteRollback) reverts
+// ONLY the local node's store to the prior confirmed config (C1). Before this
+// fix it never pushed the rollback to the peer, so the nodes DIVERGED
+// (primary=C1, standby=C2) and a failover would serve the abandoned C2.
+//
+// These tests pin the fix: the confirm-timeout rollback must re-sync the
+// rolled-back config (C1) to the peer, and must self-guard the peer-absent case
+// (nil cluster/sessionSync — no crash).
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestExecuteConfirmedRollbackResyncsPeer proves executeConfirmedRollback
+// re-syncs the rolled-back config to the cluster peer, AFTER the store has been
+// promoted back to the rollback target. RED-on-revert: dropping the
+// d.resyncRolledBackConfigToPeer() call leaves the seam uncalled (calls==0) and
+// the standby stuck on the abandoned config — exactly the #3868 divergence.
+func TestExecuteConfirmedRollbackResyncsPeer(t *testing.T) {
+	s, gen := newRollbackTestStore(t) // active=B pending, rollback target=A
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s}
+	d.applyBodyForTest = func(_ *config.Config) {}
+
+	var (
+		calls        int
+		syncedConfig string
+	)
+	// The real peer-resync path (syncConfigToPeer -> pushConfigToPeer ->
+	// SessionSync.QueueConfig) needs a live TCP transport, so observe the call
+	// through the injected seam. Read ShowActive() at call time — this is
+	// exactly the text pushConfigToPeer would queue, so it proves the re-sync
+	// carries the rolled-back config (C1 = host-name A), not the abandoned one.
+	d.resyncPeerForTest = func() {
+		calls++
+		syncedConfig = d.store.ShowActive()
+	}
+
+	d.executeConfirmedRollback(gen)
+
+	// Local store must have rolled back to A.
+	if got := s.ActiveConfig().System.HostName; got != "A" {
+		t.Fatalf("after rollback local active host-name = %q, want A", got)
+	}
+	// The peer re-sync must have fired exactly once.
+	if calls != 1 {
+		t.Fatalf("executeConfirmedRollback must re-sync the rolled-back config to the peer "+
+			"exactly once; got %d calls (standby would keep the abandoned config — #3868)", calls)
+	}
+	// It must have pushed the rollback target C1 (host-name A), not the
+	// abandoned unconfirmed C2 (host-name B) — proving the re-sync happens
+	// AFTER PromoteRollback.
+	if !strings.Contains(syncedConfig, "host-name A") {
+		t.Fatalf("peer re-sync pushed the wrong config; want the rolled-back C1 (host-name A), "+
+			"got:\n%s", syncedConfig)
+	}
+	if strings.Contains(syncedConfig, "host-name B") {
+		t.Fatalf("peer re-sync pushed the abandoned unconfirmed C2 (host-name B) — re-sync ran "+
+			"BEFORE PromoteRollback:\n%s", syncedConfig)
+	}
+}
+
+// TestExecuteConfirmedRollbackResyncPeerAbsent proves the confirm-timeout
+// rollback re-sync self-guards when there is no peer: with nil
+// cluster/sessionSync (and no test seam) the real syncConfigToPeer path runs
+// and must no-op cleanly — no panic — while the local store still rolls back.
+// The existing reverse-sync-on-reconnect converges the peer when it returns.
+func TestExecuteConfirmedRollbackResyncPeerAbsent(t *testing.T) {
+	s, gen := newRollbackTestStore(t) // active=B pending, rollback target=A
+	// No cluster, no sessionSync, no resyncPeerForTest seam: exercises the real
+	// syncConfigToPeer nil-guard.
+	d := &Daemon{applySem: semaphore.NewWeighted(1), store: s}
+	d.applyBodyForTest = func(_ *config.Config) {}
+
+	// Must not panic even though the real peer-resync path runs with no peer.
+	d.executeConfirmedRollback(gen)
+
+	if got := s.ActiveConfig().System.HostName; got != "A" {
+		t.Fatalf("after rollback (peer absent) local active host-name = %q, want A", got)
+	}
+}


### PR DESCRIPTION
## Problem

On a `commit confirmed` that **times out**, `executeConfirmedRollback`
(`pkg/daemon/daemon_apply.go`) reverted only the LOCAL node's store to the prior
confirmed config (C1) via `PromoteRollback` and never pushed the rollback to the
cluster peer. But the standby had already received the unconfirmed config (C2)
through config sync `SyncApply` — which arms **no** confirm timer — so the
standby holds C2 as its PERMANENT active. After the timeout the nodes DIVERGED
(primary=C1, standby=C2) and a failover would serve the abandoned,
auto-rolled-back C2.

Sequence: (1) `commit confirmed 5` on primary → C2 syncs to standby (permanent,
no timer); (2) operator does not confirm; (3) at T+5 the primary rolls back to
C1; (4) primary=C1, standby=C2 — diverged; (5) failover serves C2.

## Fix

The confirm-timeout rollback path (the non-nil `prevCfg` branch, after
`PromoteRollback` + the dataplane re-apply) now re-syncs the rolled-back config
to the peer via the same `d.syncConfigToPeer()` push a normal commit uses.
`syncConfigToPeer` reads the now-promoted active (C1) via `ShowActive` and queues
it, so the standby converges onto C1. The push:

- **self-guards peer-absent/disconnected** (nil cluster/sessionSync, not RG0
  primary, config-sync disabled, or no active TCP conn all no-op); the existing
  reverse-sync-on-reconnect retries when the peer returns.
- runs under `d.applySem` (held by the executor) and strictly **after**
  `PromoteRollback`, so the pushed text is always the rollback target C1, never
  the abandoned config.

The nil-`prevCfg` branch (first commit on a fresh store → bootstrap mode)
deliberately does **not** re-sync: the reverted empty tree carries no
chassis-cluster/config-sync stanza (push no-ops) and a bootstrap node is not the
RG0 authority. Manual `rollback N` + commit is unaffected — it flows through
`commitAndApply`, which already syncs; `executeConfirmedRollback` is the only
`PromoteRollback` caller in the daemon.

Split into `resyncRolledBackConfigToPeer()` + a `resyncPeerForTest` seam because
the real path (`syncConfigToPeer -> pushConfigToPeer -> SessionSync.QueueConfig`)
needs a live TCP transport and cannot be observed in a pure unit test.

Sibling of #3865/#3861 (the store-side confirm-timer clear) — this is the
daemon-HA convergence half. Provenance: fable-review-161 F-150.

## Tests

`pkg/daemon/rollback_resync_test.go` (new):

- `TestExecuteConfirmedRollbackResyncsPeer` — proves the executor re-syncs the C1
  rollback target to the peer exactly once, **after** `PromoteRollback` (asserts
  the pushed text is `host-name A`, not the abandoned `B`). **RED-on-revert
  verified**: dropping the resync call leaves the seam uncalled (`got 0 calls`).
- `TestExecuteConfirmedRollbackResyncPeerAbsent` — proves the real
  `syncConfigToPeer` nil-guard: with no cluster/sessionSync the rollback still
  reverts locally and does not panic.

## Validation

- `go test ./pkg/daemon/... ./pkg/cluster/...` green
- `go build ./...` green; `gofmt` + `go vet` clean
- **test-failover WARRANTED** (HA config convergence) — flagged for batch
  validation.

Closes #3868

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
