### PR TITLE
logging/syslog: tear down stream on a partial frame to resync collector (#3874)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28500,3 +28500,43 @@ top.
   pkg/config/deterministic_nat_flatset_3864_test.go (new, 7 tests),
   docs/deterministic-nat-cgnat.md (/22→/25 fix + hier example + grouping +
   impl map), docs/config-schema.md (port now modeled note)
+
+## 2026-07-03
+
+- **Timestamp**: 2026-07-03 14:35
+- **Action**: #3874 — syslog stream (TCP/TLS) partial-frame teardown to
+  resync the collector's RFC 6587 octet-count parser. A `conn.Write` on a
+  stream transport can return `0 < n < len(b)` (a truncated frame on the
+  wire) when the write deadline expires or the peer resets mid-frame. The
+  timeout branch at syslog.go returned WITHOUT closing (deliberate per
+  #2287, which avoided a re-entrant close deadlock), so the NEXT frame's
+  bytes concatenated onto the truncated one → the collector's octet-count
+  length parser desynced permanently — audit/forensics channel corruption
+  exactly under incident load. FIX: `streamWrite` now reads the byte count
+  and, on a PARTIAL write (`0 < n < len(b)`), tears the conn down
+  (`conn.Close()`; `conn=nil`). The next `Send` sees `conn==nil`, treats
+  it as a non-timeout write failure, and the existing cooldown-gated
+  reconnect path dials a fresh, correctly-counted stream (the resync). A
+  clean 0-byte timeout (`n==0`) wrote nothing and stays drop-without-close
+  per #2287 — only a partial write closes. The fix lives in `streamWrite`
+  so it covers BOTH `Send` (octet-counted) and `SendBinary` (self-framing
+  length at `[3:5]`), both of which desync on truncation. WHY it does NOT
+  reintroduce the #2285 re-entrant deadlock: `net.Conn.Close`/`*tls.Conn.Close`
+  is a pure syscall that never routes back through
+  slog→SyslogSlogHandler.Handle→SyslogClient.Send, so it cannot re-lock
+  `s.mu` on the sending goroutine; and it is not the #2287 stall hazard
+  (close is cheap — no dial, no second writeTimeout; the reconnect is
+  deferred to the next Send via the conn==nil path). RED-on-revert PROVEN:
+  reverting `streamWrite` to `_, err := conn.Write(b); return err` makes
+  TestPartialWriteTearsDownStreamToResync fail (`closes=0, want 1`) — the
+  corrupt conn stays up and frame 2 concatenates onto the truncated frame
+  1. TestCleanTimeoutDoesNotCloseConn (0-byte timeout does not close/dial),
+  TestPartialWriteConnErrorTearsDown (non-timeout reset mid-frame), and
+  TestPartialWriteNoReentrantDeadlock (slog-default-wired client, 3s guard)
+  all green. `go test ./pkg/logging/... -race` green; `go build ./...`
+  green; gofmt + vet clean.
+- **File(s)**: pkg/logging/syslog.go (streamWrite partial-write teardown +
+  doc comment), pkg/logging/syslog_partial_frame_3874_test.go (new, 4 tests
+  + partialFrameConn/recordingBufConn/closeCountingTimeoutConn mocks +
+  parseOctetFrame collector parser), pkg/logging/README.md (partial-frame
+  teardown #3874 bullet)

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -86,6 +86,32 @@ connectionless and exempt:
   event reader (~2× plus a dial). Only a *genuine connection error*
   (broken pipe / ECONNRESET, non-timeout) triggers the reconnect+retry
   path below.
+- **Partial-frame teardown (#3874).** A stream `conn.Write` can return
+  `0 < n < len(b)` — some but not all of the framed record reached the
+  wire — when the deadline expires (or the peer resets) mid-write. Both
+  stream framings are corrupted by a truncated write: the RFC 6587
+  octet-count prefix (`<len> <msg>`) and the self-framing binary record
+  (length at offset `[3:5]`) both tell the collector to expect `len`
+  bytes, so a truncated frame leaves the collector's length parser
+  mid-record. If the connection stayed up, the NEXT frame's bytes would
+  concatenate onto the truncated one and the parser would mis-frame every
+  subsequent message — a **permanent desync of the audit/forensics
+  channel**, exactly under incident load (slow writes / a backpressured
+  collector, when the logs matter most). A half-written octet-counted
+  frame is unrecoverable in-stream, so `streamWrite` tears the connection
+  down (`conn=nil`) whenever `0 < n < len(b)`; the next `Send` sees
+  `conn==nil`, treats it as a non-timeout write failure, and the
+  cooldown-gated reconnect path dials a fresh, correctly-counted stream
+  (the resync). A **clean 0-byte timeout** (`n==0`) wrote nothing, cannot
+  desync the collector, and stays drop-without-close per #2287 — only a
+  partial write closes. Closing the raw conn here does NOT reintroduce
+  the #2285 re-entrant deadlock: `net.Conn.Close` (and `*tls.Conn.Close`)
+  is a pure syscall that never routes back through the
+  slog→`SyslogSlogHandler.Handle`→`SyslogClient.Send` path, so it cannot
+  re-lock `s.mu` on the sending goroutine. It is also NOT the #2287 stall
+  hazard: the close is cheap (no dial, no second `writeTimeout`) — the
+  reconnect happens on the next `Send` via the `conn==nil` path, so the
+  worst-case in-`Send` stall stays one `writeTimeout`.
 - **Reconnect cooldown.** A non-timeout write failure on a stream
   transport attempts one reconnect, gated by `reconnectCooldown`
   (default `defaultReconnectCooldown`, 1s). If the previous reconnect

--- a/pkg/logging/syslog.go
+++ b/pkg/logging/syslog.go
@@ -528,6 +528,32 @@ func (s *SyslogClient) writeMsg(line string) error {
 // A deadline expiry surfaces as a timeout error (os.ErrDeadlineExceeded);
 // callers treat it as a write failure and drop the message. Called with mu
 // held; conn is non-nil.
+//
+// Partial-frame teardown (#3874). A stream write can return 0 < n < len(b) —
+// some but not all of the framed record reached the wire — when the deadline
+// expires (or the peer resets) mid-write. Both stream framings are corrupted
+// by a truncated write: the RFC 6587 octet-count prefix ("<len> <msg>") and
+// the self-framing binary record (length at offset [3:5]) both tell the
+// collector to expect `len` bytes, so a truncated frame leaves the collector's
+// length parser mid-record. If the connection stayed up, the NEXT frame's
+// bytes would concatenate onto the truncated one and the parser would
+// mis-frame every subsequent message — a permanent desync of the
+// audit/forensics channel, exactly under incident load (slow writes). A
+// half-written octet-counted frame is unrecoverable in-stream; the only
+// correct recovery is close+reconnect so the next frame starts a fresh,
+// correctly-counted stream. So on a partial write we tear the conn down here
+// (conn=nil); the next Send sees conn==nil, treats it as a non-timeout write
+// failure, and the existing cooldown-gated reconnect path dials a fresh
+// stream. A clean 0-byte timeout (n==0) wrote nothing, cannot desync the
+// collector, and stays drop-without-close per #2287.
+//
+// Closing the raw conn here does NOT reintroduce the #2285 re-entrant
+// deadlock: net.Conn.Close() (and *tls.Conn.Close) is a pure syscall that
+// never routes back through slog/SyslogSlogHandler.Handle/SyslogClient.Send,
+// so it cannot re-lock s.mu on this goroutine. It is also NOT the #2287 stall
+// hazard: we only close (cheap) — we do NOT dial or re-arm a second
+// writeTimeout in this branch; the reconnect happens on the next Send via the
+// conn==nil path, so the worst-case in-Send stall stays one writeTimeout.
 func (s *SyslogClient) streamWrite(b []byte) error {
 	if s.writeTimeout > 0 {
 		// Best-effort: if SetWriteDeadline is unsupported by the conn it
@@ -535,7 +561,15 @@ func (s *SyslogClient) streamWrite(b []byte) error {
 		// without the bound). Real TCP/TLS conns always support it.
 		_ = s.conn.SetWriteDeadline(s.now().Add(s.writeTimeout))
 	}
-	_, err := s.conn.Write(b)
+	n, err := s.conn.Write(b)
+	if n > 0 && n < len(b) {
+		// A truncated frame is on the wire and the stream is now unrecoverable
+		// (see the doc comment). Discard the corrupt conn so the next Send
+		// reconnects and resyncs; leaving it up would concatenate the next
+		// frame onto the truncated one and permanently desync the collector.
+		s.conn.Close()
+		s.conn = nil
+	}
 	return err
 }
 

--- a/pkg/logging/syslog_partial_frame_3874_test.go
+++ b/pkg/logging/syslog_partial_frame_3874_test.go
@@ -1,0 +1,327 @@
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// partialFrameConn models a stream conn whose FIRST Write truncates: the write
+// deadline expires (or the peer resets) after only `prefix` bytes reach the
+// wire, returning 0 < n < len(b) — a partial write. Subsequent Writes succeed
+// fully (the transient slow-write has passed). It records every byte the
+// "collector" received in order, plus write/close counts, so a test can assert
+// that (a) the corrupt conn is torn down after a truncated frame and (b) no
+// later frame concatenates onto the truncated one. When reset==true the first
+// write's error is a non-timeout connection error instead of a deadline expiry.
+type partialFrameConn struct {
+	mu     sync.Mutex
+	got    []byte
+	writes int
+	closes int
+	prefix int
+	reset  bool
+}
+
+func (c *partialFrameConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writes++
+	if c.writes == 1 {
+		n := c.prefix
+		if n > len(b) {
+			n = len(b)
+		}
+		c.got = append(c.got, b[:n]...)
+		if c.reset {
+			return n, errors.New("connection reset by peer")
+		}
+		return n, os.ErrDeadlineExceeded
+	}
+	c.got = append(c.got, b...)
+	return len(b), nil
+}
+
+func (c *partialFrameConn) Read(_ []byte) (int, error) { return 0, nil }
+func (c *partialFrameConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closes++
+	return nil
+}
+func (c *partialFrameConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (c *partialFrameConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (c *partialFrameConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *partialFrameConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *partialFrameConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+func (c *partialFrameConn) snapshot() (got []byte, writes, closes int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.got...), c.writes, c.closes
+}
+
+// parseOctetFrame parses a single RFC 6587 octet-counted frame ("<len> <msg>")
+// from the front of b, mimicking the collector's length parser. It returns the
+// message bytes and the number of stream bytes the frame consumed, or an error
+// if the declared length does not match the bytes present (a truncated frame —
+// exactly the desync a partial write would cause if left on the wire).
+func parseOctetFrame(b []byte) (msg []byte, consumed int, err error) {
+	sp := bytes.IndexByte(b, ' ')
+	if sp <= 0 {
+		return nil, 0, errors.New("no octet-count prefix")
+	}
+	n, err := strconv.Atoi(string(b[:sp]))
+	if err != nil {
+		return nil, 0, err
+	}
+	body := b[sp+1:]
+	if len(body) < n {
+		return nil, 0, errors.New("truncated frame: declared length exceeds bytes present")
+	}
+	return body[:n], sp + 1 + n, nil
+}
+
+// TestPartialWriteTearsDownStreamToResync is the #3874 fix-on-revert proof.
+//
+// A stream write that returns 0 < n < len (a partial octet-counted frame on the
+// wire) must tear the connection down so the NEXT frame starts a fresh,
+// correctly-counted stream — never concatenated onto the truncated one. On
+// revert (streamWrite ignores the short write, Send's timeout branch drops
+// without closing) the conn stays up and the second frame appends to the
+// truncated first frame, permanently desyncing the collector's length parser.
+func TestPartialWriteTearsDownStreamToResync(t *testing.T) {
+	var dialCount int
+	corrupt := &partialFrameConn{prefix: 5} // first frame truncated to 5 bytes
+	fresh := &recordingBufConn{}
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.20:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      30 * time.Millisecond,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              corrupt,
+		dialFn: func() (net.Conn, error) {
+			dialCount++
+			return fresh, nil
+		},
+	}
+
+	// Frame 1: partial write → truncated frame on the wire → the fix must close
+	// the corrupt conn (dropped, not retried in place — #2287 preserved).
+	if err := c.Send(SyslogInfo, "first message that truncates mid-frame"); err == nil {
+		t.Fatal("expected the partial/timeout write to fail Send")
+	}
+	got1, writes1, closes1 := corrupt.snapshot()
+	if closes1 != 1 {
+		t.Fatalf("partial write must tear the corrupt conn down: closes=%d, want 1 "+
+			"(#3874 desync-on-revert)", closes1)
+	}
+	if writes1 != 1 {
+		t.Fatalf("timeout drop must not retry the write in place: writes=%d, want 1", writes1)
+	}
+
+	// Frame 2: conn was torn down (conn==nil), so this reconnects to a FRESH
+	// stream and writes a complete, correctly-counted frame there.
+	if err := c.Send(SyslogInfo, "second message on the resynced stream"); err != nil {
+		t.Fatalf("expected the second frame to land on a reconnected stream, got %v", err)
+	}
+	if dialCount != 1 {
+		t.Fatalf("partial-write teardown must force one reconnect for the next frame: "+
+			"dials=%d, want 1 (revert: 0 — frame 2 concatenates onto the truncated frame)", dialCount)
+	}
+
+	// The corrupt conn must have received ONLY the truncated first frame — the
+	// second frame must NOT have concatenated onto it.
+	if len(got1) != 5 {
+		t.Fatalf("corrupt conn received %d bytes; want exactly the 5-byte truncated "+
+			"prefix (revert: truncated frame 1 + full frame 2 concatenated → desync)", len(got1))
+	}
+
+	// The fresh stream must carry exactly one valid octet-counted frame with no
+	// leftover — the collector reads it cleanly from the start.
+	freshBytes := fresh.bytes()
+	msg, consumed, err := parseOctetFrame(freshBytes)
+	if err != nil {
+		t.Fatalf("fresh stream is not a clean octet-counted frame: %v", err)
+	}
+	if consumed != len(freshBytes) {
+		t.Fatalf("fresh stream has trailing bytes after one frame: consumed %d of %d",
+			consumed, len(freshBytes))
+	}
+	if !bytes.Contains(msg, []byte("second message on the resynced stream")) {
+		t.Fatalf("fresh frame does not carry the second message: %q", msg)
+	}
+}
+
+// TestPartialWriteConnErrorTearsDown covers the non-timeout partial write (a
+// peer reset mid-frame, 0<n<len with a connection error). The corrupt conn must
+// still be torn down; the reconnect+retry path then lands the frame on a fresh
+// stream. This guards the desync for the conn-error branch too, not just the
+// deadline branch.
+func TestPartialWriteConnErrorTearsDown(t *testing.T) {
+	var dialCount int
+	corrupt := &partialFrameConn{prefix: 3, reset: true}
+	fresh := &recordingBufConn{}
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.21:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      defaultWriteTimeout,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              corrupt,
+		dialFn: func() (net.Conn, error) {
+			dialCount++
+			return fresh, nil
+		},
+	}
+
+	// A non-timeout partial write reconnects+retries within the same Send.
+	if err := c.Send(SyslogInfo, "reset mid-frame message"); err != nil {
+		t.Fatalf("expected reconnect+retry to land the frame, got %v", err)
+	}
+	_, _, closes := corrupt.snapshot()
+	if closes < 1 {
+		t.Fatalf("partial conn-error write must tear the corrupt conn down: closes=%d", closes)
+	}
+	if dialCount != 1 {
+		t.Fatalf("expected exactly one reconnect for the retry, got %d dials", dialCount)
+	}
+	msg, consumed, err := parseOctetFrame(fresh.bytes())
+	if err != nil || consumed != len(fresh.bytes()) {
+		t.Fatalf("retried frame is not a single clean octet-counted frame: err=%v consumed=%d/%d",
+			err, consumed, len(fresh.bytes()))
+	}
+	if !bytes.Contains(msg, []byte("reset mid-frame message")) {
+		t.Fatalf("retried frame does not carry the message: %q", msg)
+	}
+}
+
+// TestCleanTimeoutDoesNotCloseConn asserts the #2287 clean-timeout property is
+// preserved: a write that returns (0, deadline-exceeded) wrote nothing, cannot
+// desync the collector, and must NOT close the conn (no reconnect, no dial).
+// Only a PARTIAL write (0<n<len) tears the stream down. This is the boundary
+// that keeps the #3874 fix from over-closing on every slow-server timeout.
+func TestCleanTimeoutDoesNotCloseConn(t *testing.T) {
+	var dialCount int
+	conn := &closeCountingTimeoutConn{}
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.22:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      30 * time.Millisecond,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              conn,
+		dialFn: func() (net.Conn, error) {
+			dialCount++
+			return &recordingBufConn{}, nil
+		},
+	}
+	err := c.Send(SyslogInfo, "clean zero-byte timeout")
+	if err == nil || !isTimeout(err) {
+		t.Fatalf("expected a timeout error, got %v", err)
+	}
+	if conn.closes != 0 {
+		t.Fatalf("a clean 0-byte timeout must NOT close the conn (#2287): closes=%d", conn.closes)
+	}
+	if dialCount != 0 {
+		t.Fatalf("a clean 0-byte timeout must NOT reconnect (#2287): dials=%d", dialCount)
+	}
+}
+
+// TestPartialWriteNoReentrantDeadlock proves the #3874 close-under-lock path
+// does not reintroduce the #2285/#2287 re-entrant deadlock. The failing client
+// is wired as slog.Default() (a SyslogSlogHandler) AND used on the event path,
+// so the drop warning routes back into the same client. A partial write closes
+// the conn under s.mu; the emit-after-unlock + handler re-entrancy guard must
+// keep Send returning promptly.
+func TestPartialWriteNoReentrantDeadlock(t *testing.T) {
+	c := &SyslogClient{
+		hostname:          "test",
+		remoteAddr:        "203.0.113.23:514",
+		protocol:          "tcp",
+		Facility:          FacilityLocal0,
+		writeTimeout:      30 * time.Millisecond,
+		reconnectCooldown: defaultReconnectCooldown,
+		conn:              &partialFrameConn{prefix: 4},
+		// After the corrupt conn is torn down, the drop-warning re-entry hits a
+		// nil conn → reconnect; keep that dial failing so it drops (no infinite
+		// fresh streams) and every path terminates.
+		dialFn: func() (net.Conn, error) { return nil, errors.New("down") },
+	}
+	h := NewSyslogSlogHandler(slog.NewTextHandler(io.Discard, nil))
+	h.SetClients([]*SyslogClient{c})
+	withSlogDefault(t, h)
+
+	done := make(chan struct{})
+	go func() {
+		_ = c.Send(SyslogInfo, "event-path message that truncates then drops")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Send did not return — closing the partial-write conn under s.mu " +
+			"reintroduced the #2285 re-entrant deadlock")
+	}
+}
+
+// recordingBufConn is a net.Conn that appends every written byte to an in-order
+// buffer and always succeeds. Used as the "fresh" reconnected stream so a test
+// can parse the exact bytes the collector would receive after a resync.
+type recordingBufConn struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (c *recordingBufConn) Write(b []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf = append(c.buf, b...)
+	return len(b), nil
+}
+func (c *recordingBufConn) bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]byte(nil), c.buf...)
+}
+func (c *recordingBufConn) Read(_ []byte) (int, error)         { return 0, nil }
+func (c *recordingBufConn) Close() error                       { return nil }
+func (c *recordingBufConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (c *recordingBufConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (c *recordingBufConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *recordingBufConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *recordingBufConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// closeCountingTimeoutConn returns (0, deadline-exceeded) on every Write — a
+// clean 0-byte timeout — and counts Close calls so a test can assert the
+// #3874 fix does NOT close on a clean timeout.
+type closeCountingTimeoutConn struct {
+	writes int
+	closes int
+}
+
+func (c *closeCountingTimeoutConn) Write(_ []byte) (int, error) {
+	c.writes++
+	return 0, os.ErrDeadlineExceeded
+}
+func (c *closeCountingTimeoutConn) Read(_ []byte) (int, error) { return 0, nil }
+func (c *closeCountingTimeoutConn) Close() error {
+	c.closes++
+	return nil
+}
+func (c *closeCountingTimeoutConn) LocalAddr() net.Addr                { return dummyAddr{} }
+func (c *closeCountingTimeoutConn) RemoteAddr() net.Addr               { return dummyAddr{} }
+func (c *closeCountingTimeoutConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *closeCountingTimeoutConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *closeCountingTimeoutConn) SetWriteDeadline(_ time.Time) error { return nil }


### PR DESCRIPTION
## Summary

Closes #3874 (fable-review-161 F-151, HIGH — audit/forensics channel corruption under load).

The syslog TCP/TLS client frames records with RFC 6587 octet-counting (`<len> <msg>`). A stream `conn.Write` can return `0 < n < len(b)` — a **partial frame on the wire** — when the write deadline expires (or the peer resets) mid-write. `streamWrite` discarded the byte count (`_, err := conn.Write(b)`), and the write-timeout branch in `Send` returned **without closing** (deliberate per #2287, which avoided a re-entrant-close deadlock). So the next frame's bytes concatenated onto the truncated one and the collector's octet-count length parser **desynced permanently**, mis-framing every subsequent message — exactly under incident load (slow writes / backpressured collector, when the logs matter most).

## Fix (`pkg/logging/syslog.go` — `streamWrite`)

`streamWrite` now reads the byte count and, on a **partial write** (`0 < n < len(b)`), tears the connection down (`conn.Close(); conn=nil`). The next `Send` sees `conn==nil`, treats it as a non-timeout write failure, and the existing cooldown-gated reconnect path dials a **fresh, correctly-counted stream** — the collector reads the next frame cleanly from the start of a new connection. A half-written octet-counted frame is unrecoverable in-stream; close+reconnect is the only correct recovery.

- A **clean 0-byte timeout** (`n==0`) wrote nothing, cannot desync the collector, and stays **drop-without-close per #2287** — only a partial write closes.
- Placed in `streamWrite`, so it covers **both** `Send` (octet-counted) and `SendBinary` (self-framing, length at `[3:5]`) — a truncated write corrupts either framing.

### Why this does NOT reintroduce the #2285 re-entrant deadlock

The close runs under `s.mu`, but `net.Conn.Close` / `*tls.Conn.Close` is a **pure syscall** that never routes back through slog → `SyslogSlogHandler.Handle` → `SyslogClient.Send`, so it cannot re-lock `s.mu` on the sending goroutine (unlike the drop warning's `slog.Warn`, which is still emitted *after* the `Unlock`). It is also **not the #2287 stall hazard**: the close is cheap — no dial and no second `writeTimeout` are armed in this branch; the reconnect is deferred to the next `Send` via the `conn==nil` path, so the worst-case in-`Send` stall stays one `writeTimeout`.

## Tests (`pkg/logging/syslog_partial_frame_3874_test.go`)

- **`TestPartialWriteTearsDownStreamToResync`** — RED-on-revert proof. A partial write closes the corrupt conn and forces one reconnect so the second frame lands as a single clean octet-counted frame on a fresh stream (verified with a collector-style `parseOctetFrame`). Reverting `streamWrite` to the pre-fix body fails it: `closes=0, want 1` — the corrupt conn stays up and frame 2 concatenates onto the truncated frame 1.
- **`TestCleanTimeoutDoesNotCloseConn`** — a 0-byte timeout does not close or reconnect (#2287 boundary preserved; no over-close).
- **`TestPartialWriteConnErrorTearsDown`** — a non-timeout reset mid-frame also tears down and retries onto a fresh stream.
- **`TestPartialWriteNoReentrantDeadlock`** — the failing client is wired as `slog.Default()` and used on the event path; a 3s guard proves closing under `s.mu` does not deadlock.

## Validation

- `go test ./pkg/logging/... -race` green
- `go build ./...` green; `gofmt` + `go vet` clean
- RED-on-revert verified (reverting only the `streamWrite` body fails `TestPartialWriteTearsDownStreamToResync`)
- Docs: `pkg/logging/README.md` gains a **partial-frame teardown (#3874)** bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
