### PR TITLE
routing: BGP AS fallback + floating qualified-next-hop + next-hop ECMP list (#3870/#3871/#3872)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28475,3 +28475,22 @@ top.
   pkg/config/deterministic_nat_flatset_3864_test.go (new, 7 tests),
   docs/deterministic-nat-cgnat.md (/22→/25 fix + hier example + grouping +
   impl map), docs/config-schema.md (port now modeled note)
+
+## 2026-07-03 — routing: BGP AS fallback + floating qualified-next-hop + next-hop ECMP list (#3870/#3871/#3872)
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3870 (F-009) — BGP `router bgp` gated on `BGPConfig.LocalAS > 0`
+  (policy_render.go) which only `protocols bgp local-as` set, so the canonical
+  vSRX placement `routing-options autonomous-system <N>` + `protocols bgp`
+  rendered NO BGP at all, silently. FIX: `resolveBGPAutonomousSystem(cfg)` in
+  compiler_routing.go, called post-child-loop in compiler.go (order-independent),
+  fills LocalAS from the global autonomous-system when local-as is omitted;
+  local-as still wins; per-instance BGP inherits the instance's own
+  routing-options AS if set else the global one (new
+  RoutingInstanceConfig.AutonomousSystem field). RED-on-revert PROVEN: without
+  the resolver LocalAS=0 (no `router bgp`); local-as-override + no-AS cases stay
+  GREEN (pre-existing behavior).
+- **File(s)**: pkg/config/compiler.go (post-loop resolver call),
+  pkg/config/compiler_routing.go (resolveBGPAutonomousSystem + capture instance
+  AS), pkg/config/types_routing.go (RoutingInstanceConfig.AutonomousSystem),
+  pkg/config/compiler_bgp_as_3870_test.go (new, 4 tests), pkg/frr/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -28494,3 +28494,27 @@ top.
   pkg/config/compiler_routing.go (resolveBGPAutonomousSystem + capture instance
   AS), pkg/config/types_routing.go (RoutingInstanceConfig.AutonomousSystem),
   pkg/config/compiler_bgp_as_3870_test.go (new, 4 tests), pkg/frr/README.md
+
+## 2026-07-03 — #3871 (F-008): floating qualified-next-hop per-NH preference/metric
+
+- **Timestamp**: 2026-07-03
+- **Action**: A static `qualified-next-hop <gw> { preference N; metric M; }`
+  (Junos floating static) had its per-NH preference/metric dropped (folded to a
+  single route-level Preference), so config_render rendered all next-hops at
+  equal cost → floating static became equal-cost ECMP over the backup. FIX:
+  carry Preference/HasPreference/Metric/HasMetric PER-NextHopEntry
+  (types_routing.go); compiler reads qualified-next-hop preference/metric from
+  children + inline keys (compiler_routing.go, both the hierarchical-children
+  handler and the fully-inline route-keys branch); renderer emits each next-hop
+  at its own admin distance (config_render.go — primary at route-level 5,
+  qualified at 250). FRR installs the lower-distance primary and floats the
+  backup in only when the primary is down. Metric carried but NOT rendered (FRR
+  static CLI has no metric field). Plain next-hop list stays equal-cost ECMP
+  (no per-NH preference) — distinct from the floating backup. RED-on-revert
+  PROVEN: renderer revert → both at distance 5; compiler revert → qualified
+  HasPreference/HasMetric false.
+- **File(s)**: pkg/config/types_routing.go (NextHopEntry per-NH pref/metric),
+  pkg/config/compiler_routing.go (qualified-next-hop parse, 2 shapes),
+  pkg/frr/config_render.go (per-NH distance),
+  pkg/config/compiler_qualified_nexthop_3871_test.go (new, 2 tests),
+  pkg/frr/static_floating_3871_test.go (new, 2 tests), pkg/frr/README.md

--- a/_Log.md
+++ b/_Log.md
@@ -28638,3 +28638,35 @@ top.
   + partialFrameConn/recordingBufConn/closeCountingTimeoutConn mocks +
   parseOctetFrame collector parser), pkg/logging/README.md (partial-frame
   teardown #3874 bullet)
+
+## 2026-07-03 — PR #3879 hostile-review folds: #3872 delete-side + 2 MINORs
+
+- **Timestamp**: 2026-07-03
+- **Action**: MAJOR (delete-side fail-wide, the #3846 class the PR cites). The
+  read/render side of #3872 next-hop ECMP was fixed but the DELETE side was
+  not: the removeMultiLeafMembers gate was `multi && children == nil && args
+  == 1`, and next-hop has an `interface` child so it was EXCLUDED → fell
+  through to removeMatchingNode (prefix match) → `delete ... next-hop <gw>` on
+  a `[ a b ]` list deleted the WHOLE leaf → route left with 0 next-hops → FRR
+  rendered Null0 (blackholed the healthy path); a non-first member was
+  undeletable. FIX: (1) gate flip `multi && (children == nil || valueList) &&
+  args == 1` mirroring the read side; (2) removeMultiLeafMembers gains a
+  modifierChildren param — for a valueList node the children are MODIFIERS of
+  the gateway (not droppable members), and dropping the last gateway removes
+  the WHOLE entry (gateway + interface) rather than a gateway-less container;
+  (3) renderer emits Null0 ONLY for an explicit `discard` — a non-discard
+  0-next-hop route renders NOTHING (not a Null0 blackhole). MINOR 1: doc that a
+  metric-only qualified-next-hop (no preference) does NOT float (FRR statics
+  have no metric field). MINOR 2: fixed the stale schema comment that said the
+  qualified preference "folds into route.Preference" (#3871 removed that fold).
+  RED-on-revert PROVEN: reverting the gate → whole leaf deleted (0 next-hops) +
+  non-first undeletable; reverting the renderer → 0-next-hop route renders
+  Null0. Full go test ./pkg/config/... ./pkg/frr/... green. NOTE: pre-existing
+  master canary failure TestNoDirectOsWriteFile (daemon_flow.go archiveConfig,
+  from master #9d14a1720) is unrelated to this PR.
+- **File(s)**: pkg/config/ast_edit.go (delete gate flip + removeMultiLeafMembers
+  modifierChildren), pkg/frr/config_render.go (Null0 only for discard),
+  pkg/config/schema_routing.go (MINOR 2 stale comment + metric note),
+  pkg/frr/README.md (MINOR 1 metric-only-doesn't-float),
+  pkg/config/delete_static_nexthop_3872_test.go (new, 5 tests),
+  pkg/frr/static_empty_route_3872_test.go (new, 2 tests)

--- a/_Log.md
+++ b/_Log.md
@@ -28518,3 +28518,31 @@ top.
   pkg/frr/config_render.go (per-NH distance),
   pkg/config/compiler_qualified_nexthop_3871_test.go (new, 2 tests),
   pkg/frr/static_floating_3871_test.go (new, 2 tests), pkg/frr/README.md
+
+## 2026-07-03 — #3872 (F-010): static next-hop bracket list = ECMP multipath
+
+- **Timestamp**: 2026-07-03
+- **Action**: A static route `next-hop [ gw1 gw2 ]` (canonical Junos ECMP)
+  collapsed to a single next-hop — the schema leaf was not multi and the
+  compiler read one address — so multipath was silently lost. FIX: make the
+  next-hop leaf `multi: true, valueList: true` (schema_routing.go) so the
+  bracket list collapses onto one leaf (Keys=[next-hop gw1 gw2]) in both AST
+  shapes; the compiler reads Keys[1:] and installs every gateway equal-cost
+  (compiler_routing.go, children handler + inline branch + isRouteInlineKeyword
+  helper). NEW schemaNode.valueList flag + ast_edit.go absorber change: a multi
+  leaf WITH modifier children absorbs a value list ONLY when it opts in
+  (valueList) — so the many CoS multi+children named containers are UNCHANGED
+  (a broad absorber change first broke TestValidateCoSOversubscription*; the
+  surgical flag fixed it). The `interface` modifier child still walks for the
+  IPv6 link-local single-gateway form. Composes with #3871: plain list =
+  equal-cost (no per-NH preference), qualified-next-hop = floating backup.
+  RED-on-revert PROVEN: reverting the multi/valueList schema collapses the
+  bracket list to only the first gateway; single next-hop + interface-modifier
+  + block-parse forms stay GREEN. Full `go test ./...` green.
+- **File(s)**: pkg/config/schema.go (valueList field),
+  pkg/config/ast_edit.go (valueList-gated child-aware absorber),
+  pkg/config/schema_routing.go (next-hop multi+valueList),
+  pkg/config/compiler_routing.go (multi-address read + isRouteInlineKeyword),
+  pkg/config/compiler_static_nexthop_list_3872_test.go (new, 5 tests),
+  pkg/frr/static_ecmp_list_3872_test.go (new), docs/config-schema.md,
+  pkg/frr/README.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -108,6 +108,28 @@ allowed-ips folds are covered by the `security-nat-static-multi-zone` and
 `interfaces-wireguard-allowed-ips-multi` dual-AST fixtures plus
 `TestWireguardAllowedIPsBracketList{FlatSet,Hierarchical}`.
 
+**`valueList` — a bracketed value list on a multi leaf that ALSO has a
+modifier child (#3872).** The bracket-absorption above fires only for a
+`multi: true` leaf with `children: nil`. The static-route `next-hop` leaf is
+the exception: it is `multi: true` (so `next-hop [ gw1 gw2 ]` — canonical Junos
+ECMP — collapses onto ONE leaf `Keys=[next-hop gw1 gw2]` and the compiler
+installs every gateway as an equal-cost next-hop) BUT it also declares an
+`interface` modifier child for the IPv6 link-local form
+(`next-hop fe80::1 interface reth0.50`). A plain `multi` leaf with children
+would stay a container and never absorb the list; a plain-container leaf would
+mis-nest the second gateway as an orphan child. `next-hop` therefore sets
+`valueList: true`, which tells `SetPath` (`ast_edit.go`) to absorb a trailing
+value list (tokens that are neither a sibling nor a known child) onto the leaf
+while STILL descending into the container when the next token names the
+`interface` child. Only `next-hop` sets it; every other `multi`+children node
+(the CoS named containers) is unchanged — the guard `children == nil ||
+valueList` keeps them on the container path. The compiler reads every gateway
+from `Keys[1:]` (skipping an inline `interface <if>` pair) plus the `interface`
+child. This is DISTINCT from a `qualified-next-hop`, which is a separate
+floating-backup leaf carrying its own per-next-hop preference (#3871): a plain
+`next-hop` list is equal-cost ECMP, a `qualified-next-hop` is a distance-N
+backup.
+
 **Delete-side contract: `delete` a member, not the whole list (#3846).**
 The read-side accumulate rule above has a mirror on the edit side. A
 `delete ... from protocol tcp` on a bracket-list leaf must remove ONLY the

--- a/pkg/config/ast_edit.go
+++ b/pkg/config/ast_edit.go
@@ -393,9 +393,15 @@ func deletePath(current *[]*Node, path []string, schema *schemaNode, i int) erro
 	//
 	// Gate on args == 1 so keyed multi entries (address <name> <prefix>,
 	// args == 2; named containers with children such as `interfaces <name>`)
-	// keep whole-node delete semantics.
-	if childSchema.multi && childSchema.children == nil && childSchema.args == 1 {
-		return removeMultiLeafMembers(current, keyword, path[i+1:])
+	// keep whole-node delete semantics. The valueList opt-in (#3872 static
+	// `next-hop`) extends member-delete to a multi leaf that ALSO carries
+	// modifier children (its `interface`), mirroring the read/render-side gate
+	// flip: without this, `delete ... next-hop <gw>` prefix-matched and deleted
+	// the WHOLE next-hop leaf, so deleting one gateway of a `[ a b ]` ECMP list
+	// silently blackholed the healthy other path (Null0), and a non-first
+	// member was undeletable — the exact #3846 delete-side fail-wide.
+	if childSchema.multi && (childSchema.children == nil || childSchema.valueList) && childSchema.args == 1 {
+		return removeMultiLeafMembers(current, keyword, path[i+1:], childSchema.valueList)
 	}
 
 	// Consume keyword + extra args as this node's keys.
@@ -542,22 +548,31 @@ func removeMatchingNode(nodes *[]*Node, targetKeys []string) error {
 }
 
 // removeMultiLeafMembers implements member-specific deletion for a value-list
-// multi-leaf (a `multi: true` leaf with no children and a single value slot —
-// e.g. `from protocol [ tcp udp icmp ]`). keyword is the leaf's first key
-// ("protocol"); members are the trailing tokens naming individual values to
-// drop.
+// multi-leaf. keyword is the leaf's first key ("protocol", "next-hop"); members
+// are the trailing tokens naming individual values to drop.
 //
 //   - members empty  → delete the whole leaf (mirrors removeMatchingNode's
 //     prefix match), so `delete ... from protocol` still clears the list.
 //   - members named  → drop ONLY those values from every node whose first key
 //     is keyword, reading BOTH the flat Keys[1:] shape (bracket list / flat
-//     set) AND the child-node shape (hierarchical block) — the #2419 dual AST
-//     shape. A node left with no values is removed entirely.
+//     set) AND, for a plain value-list leaf, the child-node shape (hierarchical
+//     block) — the #2419 dual AST shape. A node left with no values is removed
+//     entirely.
+//
+// modifierChildren distinguishes the two node classes:
+//   - false — a plain value-list leaf (children == nil, e.g. `from protocol
+//     [ tcp udp icmp ]`): child nodes ARE list members and are droppable.
+//   - true  — a valueList leaf that ALSO declares MODIFIER children (#3872
+//     static `next-hop <gw> { interface <if> }`): the children are modifiers
+//     OF the value, never members, so they are never matched against the drop
+//     set. When every value on Keys[1:] is dropped, the WHOLE entry — the
+//     gateway AND its interface modifier — is removed, rather than left as a
+//     gateway-less next-hop container that would render Null0/blackhole.
 //
 // Returns an error when no named member was found anywhere (mirroring
 // removeMatchingNode's not-found contract), so deleting a member that is not
 // present is reported rather than silently succeeding.
-func removeMultiLeafMembers(nodes *[]*Node, keyword string, members []string) error {
+func removeMultiLeafMembers(nodes *[]*Node, keyword string, members []string, modifierChildren bool) error {
 	if len(members) == 0 {
 		return removeMatchingNode(nodes, []string{keyword})
 	}
@@ -580,6 +595,18 @@ func removeMultiLeafMembers(nodes *[]*Node, keyword string, members []string) er
 				continue
 			}
 			newKeys = append(newKeys, v)
+		}
+		if modifierChildren {
+			// valueList node: children are MODIFIERS of the value, not members.
+			// Drop the whole entry (gateway + interface modifier) once every
+			// gateway on Keys[1:] is gone — a next-hop with no gateway is
+			// meaningless and would render Null0.
+			if len(newKeys) == 1 {
+				continue
+			}
+			n.Keys = newKeys
+			out = append(out, n)
+			continue
 		}
 		// Block shape: one child node per member.
 		newChildren := n.Children[:0]

--- a/pkg/config/ast_edit.go
+++ b/pkg/config/ast_edit.go
@@ -257,46 +257,67 @@ func (t *ConfigTree) SetPath(path []string) error {
 		//     `destination-port 20000 to 20003` is handled the same way:
 		//     none of "20000", "to", "20003" are siblings, so all land on
 		//     the one leaf.
-		if childSchema.children == nil && childSchema.multi && i < len(path) {
+		// A multi leaf collapses a trailing value list onto ONE node. This
+		// runs for a plain multi leaf (children == nil, the #2419 case) and,
+		// via the valueList opt-in, for a multi leaf that ALSO declares
+		// modifier children (the #3872 static `next-hop [ a b ]`, whose only
+		// child is the `interface` modifier). A multi leaf WITH children that
+		// does NOT opt in (every CoS named container) is untouched — the guard
+		// keeps it on the container path below, exactly as before.
+		if childSchema.multi && (childSchema.children == nil || childSchema.valueList) && i < len(path) {
 			nextToken := path[i]
 			_, nextIsSibling := schema.children[nextToken]
 			if !nextIsSibling && schema.wildcard != nil {
 				nextIsSibling = true
 			}
-			if !nextIsSibling {
-				// Trailing values for this leaf: absorb every following
-				// token that is not a sibling keyword so the flat-set list
-				// collapses onto one node, matching the hierarchical AST.
-				// (case (b) only runs when schema.wildcard == nil — the
-				// wildcard check above forces nextIsSibling=true otherwise.)
-				nodeKeys = append([]string(nil), nodeKeys...)
-				for i < len(path) {
-					if _, sib := schema.children[path[i]]; sib {
+			// When the next token names a known child of THIS node (only
+			// possible for a valueList node — plain multi leaves have no
+			// children, so indexing a nil map yields ok == false), the
+			// occurrence is a CONTAINER: fall through to the container path so
+			// the modifier attaches as a child rather than being absorbed as a
+			// bogus extra value.
+			if _, nextIsChild := childSchema.children[nextToken]; !nextIsChild {
+				if !nextIsSibling {
+					// Trailing values for this leaf: absorb every following
+					// token that is neither a sibling keyword nor a known
+					// child so the flat-set list collapses onto one node,
+					// matching the hierarchical AST. (case (b) only runs when
+					// schema.wildcard == nil — the wildcard check above forces
+					// nextIsSibling=true otherwise.)
+					nodeKeys = append([]string(nil), nodeKeys...)
+					for i < len(path) {
+						if _, sib := schema.children[path[i]]; sib {
+							break
+						}
+						if _, ch := childSchema.children[path[i]]; ch {
+							break
+						}
+						nodeKeys = append(nodeKeys, path[i])
+						i++
+					}
+				}
+				// Dedup: skip if exact leaf already exists.
+				dup := false
+				for _, n := range *current {
+					if n.IsLeaf && keysEqual(n.Keys, nodeKeys) {
+						dup = true
 						break
 					}
-					nodeKeys = append(nodeKeys, path[i])
-					i++
 				}
-			}
-			// Dedup: skip if exact leaf already exists.
-			dup := false
-			for _, n := range *current {
-				if n.IsLeaf && keysEqual(n.Keys, nodeKeys) {
-					dup = true
-					break
+				if !dup {
+					*current = append(*current, &Node{
+						Keys:   append([]string(nil), nodeKeys...),
+						IsLeaf: true,
+					})
 				}
+				if i >= len(path) {
+					return nil
+				}
+				// Don't descend — continue at same level for next sibling.
+				continue
 			}
-			if !dup {
-				*current = append(*current, &Node{
-					Keys:   append([]string(nil), nodeKeys...),
-					IsLeaf: true,
-				})
-			}
-			if i >= len(path) {
-				return nil
-			}
-			// Don't descend — continue at same level for next sibling.
-			continue
+			// nextIsChild: fall through to the container path so the modifier
+			// child (e.g. `interface`) attaches under this node.
 		}
 
 		// This is a container (or a leaf with trailing value tokens).

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -2072,6 +2072,12 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		}
 	}
 
+	// #3870: resolve the BGP local-AS from `routing-options
+	// autonomous-system` when `protocols bgp local-as` was omitted. Runs
+	// after the child loop so both routing-options and protocols/
+	// routing-instances are populated regardless of their order under root.
+	resolveBGPAutonomousSystem(cfg)
+
 	// Extract lo0 filter input from parsed interfaces into SystemConfig.
 	if lo0 := cfg.Interfaces.Interfaces["lo0"]; lo0 != nil {
 		if u0 := lo0.Units[0]; u0 != nil {

--- a/pkg/config/compiler_bgp_as_3870_test.go
+++ b/pkg/config/compiler_bgp_as_3870_test.go
@@ -1,0 +1,105 @@
+package config
+
+import "testing"
+
+func compileSets3870(t *testing.T, cmds []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range cmds {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+// The canonical vSRX placement sets the BGP AS at routing-options
+// autonomous-system, with NO `protocols bgp local-as`. The FRR renderer gates
+// `router bgp` on BGPConfig.LocalAS > 0, so this must resolve LocalAS from the
+// global autonomous-system. RED-on-revert: LocalAS stays 0 → no `router bgp`
+// block renders at all (#3870).
+func TestBGPAutonomousSystemFeedsLocalAS_3870(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options autonomous-system 65001",
+		"set protocols bgp group G peer-as 65002",
+		"set protocols bgp group G neighbor 10.0.0.2 peer-as 65002",
+	})
+	if c.Protocols.BGP == nil {
+		t.Fatal("Protocols.BGP is nil; expected a compiled BGP block")
+	}
+	if got := c.Protocols.BGP.LocalAS; got != 65001 {
+		t.Fatalf("BGP LocalAS = %d, want 65001 (resolved from routing-options autonomous-system)", got)
+	}
+}
+
+// `protocols bgp local-as` is the more specific override and MUST win over the
+// global routing-options autonomous-system (Junos precedence).
+func TestBGPLocalASOverridesAutonomousSystem_3870(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options autonomous-system 65001",
+		"set protocols bgp local-as 65099",
+		"set protocols bgp group G neighbor 10.0.0.2 peer-as 65002",
+	})
+	if c.Protocols.BGP == nil {
+		t.Fatal("Protocols.BGP is nil")
+	}
+	if got := c.Protocols.BGP.LocalAS; got != 65099 {
+		t.Fatalf("BGP LocalAS = %d, want 65099 (local-as overrides autonomous-system)", got)
+	}
+}
+
+// A per-instance BGP without local-as inherits the GLOBAL routing-options
+// autonomous-system (Junos inheritance), and an instance-level
+// autonomous-system overrides the global one.
+func TestBGPInstanceInheritsAutonomousSystem_3870(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options autonomous-system 65001",
+		"set routing-instances RED instance-type virtual-router",
+		"set routing-instances RED protocols bgp group G peer-as 65010",
+		"set routing-instances RED protocols bgp group G neighbor 10.1.0.2",
+		"set routing-instances BLUE instance-type virtual-router",
+		"set routing-instances BLUE routing-options autonomous-system 65055",
+		"set routing-instances BLUE protocols bgp group G peer-as 65020",
+		"set routing-instances BLUE protocols bgp group G neighbor 10.2.0.2",
+	})
+	var red, blue *RoutingInstanceConfig
+	for _, ri := range c.RoutingInstances {
+		switch ri.Name {
+		case "RED":
+			red = ri
+		case "BLUE":
+			blue = ri
+		}
+	}
+	if red == nil || red.BGP == nil {
+		t.Fatal("instance RED BGP not compiled")
+	}
+	if got := red.BGP.LocalAS; got != 65001 {
+		t.Fatalf("RED BGP LocalAS = %d, want 65001 (inherited from global autonomous-system)", got)
+	}
+	if blue == nil || blue.BGP == nil {
+		t.Fatal("instance BLUE BGP not compiled")
+	}
+	if got := blue.BGP.LocalAS; got != 65055 {
+		t.Fatalf("BLUE BGP LocalAS = %d, want 65055 (instance-level autonomous-system override)", got)
+	}
+}
+
+// No routing-options autonomous-system and no local-as → LocalAS stays 0
+// (no `router bgp` renders), the pre-existing behavior, unchanged.
+func TestBGPNoASLeavesLocalASZero_3870(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set protocols bgp group G neighbor 10.0.0.2 peer-as 65002",
+	})
+	if c.Protocols.BGP != nil && c.Protocols.BGP.LocalAS != 0 {
+		t.Fatalf("BGP LocalAS = %d, want 0 when neither local-as nor autonomous-system is set", c.Protocols.BGP.LocalAS)
+	}
+}

--- a/pkg/config/compiler_qualified_nexthop_3871_test.go
+++ b/pkg/config/compiler_qualified_nexthop_3871_test.go
@@ -1,0 +1,67 @@
+package config
+
+import "testing"
+
+func findStaticRoute3871(t *testing.T, routes []*StaticRoute, dest string) *StaticRoute {
+	t.Helper()
+	for _, r := range routes {
+		if r.Destination == dest {
+			return r
+		}
+	}
+	t.Fatalf("static route %s not found", dest)
+	return nil
+}
+
+// A floating static: a primary next-hop plus a `qualified-next-hop <gw>
+// { preference N; metric M; }` backup. The qualified next-hop MUST carry its
+// own per-next-hop preference/metric, not fold into the route-level
+// Preference. RED-on-revert: the qualified preference/metric are dropped
+// (both next-hops equal-cost) (#3871).
+func TestQualifiedNextHopCarriesPerNHPreference_3871(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.5.0.0/16 next-hop 10.0.0.1",
+		"set routing-options static route 10.5.0.0/16 qualified-next-hop 10.0.0.2 preference 250",
+		"set routing-options static route 10.5.0.0/16 qualified-next-hop 10.0.0.2 metric 7",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.5.0.0/16")
+	if len(r.NextHops) != 2 {
+		t.Fatalf("NextHops = %d, want 2 (primary + qualified backup): %+v", len(r.NextHops), r.NextHops)
+	}
+	var primary, qualified *NextHopEntry
+	for i := range r.NextHops {
+		switch r.NextHops[i].Address {
+		case "10.0.0.1":
+			primary = &r.NextHops[i]
+		case "10.0.0.2":
+			qualified = &r.NextHops[i]
+		}
+	}
+	if primary == nil || qualified == nil {
+		t.Fatalf("expected next-hops 10.0.0.1 (primary) + 10.0.0.2 (qualified): %+v", r.NextHops)
+	}
+	if primary.HasPreference {
+		t.Errorf("primary next-hop should have no per-NH preference (uses route-level), got %d", primary.Preference)
+	}
+	if !qualified.HasPreference || qualified.Preference != 250 {
+		t.Errorf("qualified next-hop Preference = %d (has=%v), want 250 (has=true)", qualified.Preference, qualified.HasPreference)
+	}
+	if !qualified.HasMetric || qualified.Metric != 7 {
+		t.Errorf("qualified next-hop Metric = %d (has=%v), want 7 (has=true)", qualified.Metric, qualified.HasMetric)
+	}
+}
+
+// A plain multi next-hop list must NOT acquire any per-next-hop preference —
+// it is equal-cost ECMP, kept distinct from the floating qualified backup.
+func TestPlainNextHopHasNoPerNHPreference_3871(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.6.0.0/16 next-hop 10.0.0.1",
+		"set routing-options static route 10.6.0.0/16 next-hop 10.0.0.2",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.6.0.0/16")
+	for _, nh := range r.NextHops {
+		if nh.HasPreference || nh.HasMetric {
+			t.Errorf("plain next-hop %s must have no per-NH preference/metric: %+v", nh.Address, nh)
+		}
+	}
+}

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -171,10 +171,35 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 					if i+1 < len(routeInst.node.Keys) {
 						i++
 						nh := NextHopEntry{Address: routeInst.node.Keys[i]}
-						// Check for "interface <name>" following the address
-						if i+2 < len(routeInst.node.Keys) && routeInst.node.Keys[i+1] == "interface" {
+						// Consume trailing modifiers in the fully-inline form:
+						// "qualified-next-hop <gw> interface <if> preference <n>
+						// metric <m>" (#3871). Each modifier carries its own
+						// per-next-hop preference/metric — the floating backup's
+						// admin distance — never folded into the route level.
+						for i+2 < len(routeInst.node.Keys) {
+							kw := routeInst.node.Keys[i+1]
+							val := routeInst.node.Keys[i+2]
+							consumed := true
+							switch kw {
+							case "interface":
+								nh.Interface = val
+							case "preference":
+								if n, err := strconv.Atoi(val); err == nil {
+									nh.Preference = n
+									nh.HasPreference = true
+								}
+							case "metric":
+								if n, err := strconv.Atoi(val); err == nil {
+									nh.Metric = n
+									nh.HasMetric = true
+								}
+							default:
+								consumed = false
+							}
+							if !consumed {
+								break
+							}
 							i += 2
-							nh.Interface = routeInst.node.Keys[i]
 						}
 						route.NextHops = append(route.NextHops, nh)
 					}
@@ -220,17 +245,47 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 					}
 				}
 			case "qualified-next-hop":
+				// A qualified-next-hop is a FLOATING backup: it carries its own
+				// preference (admin distance) and optional metric, kept
+				// PER-next-hop rather than folded into the route-level
+				// Preference (#3871). preference/metric/interface arrive as
+				// nested children (canonical separate `set` lines and the
+				// hierarchical brace form) or as inline keys (single-line block
+				// parse), so read both shapes.
 				nh := NextHopEntry{}
 				nh.Address = nodeVal(prop)
-				// Check for "interface <name>" among remaining keys
-				for j := 2; j < len(prop.Keys)-1; j++ {
-					if prop.Keys[j] == "interface" {
+				// Inline keys: "qualified-next-hop <gw> interface <if> preference <n> metric <m>".
+				for j := 2; j+1 < len(prop.Keys); j++ {
+					switch prop.Keys[j] {
+					case "interface":
 						nh.Interface = prop.Keys[j+1]
+					case "preference":
+						if n, err := strconv.Atoi(prop.Keys[j+1]); err == nil {
+							nh.Preference = n
+							nh.HasPreference = true
+						}
+					case "metric":
+						if n, err := strconv.Atoi(prop.Keys[j+1]); err == nil {
+							nh.Metric = n
+							nh.HasMetric = true
+						}
 					}
 				}
-				// Also check children for flat set syntax
+				// Child nodes (flat-set separate lines + hierarchical brace form).
 				if ifNode := prop.FindChild("interface"); ifNode != nil {
 					nh.Interface = nodeVal(ifNode)
+				}
+				if pNode := prop.FindChild("preference"); pNode != nil {
+					if n, err := strconv.Atoi(nodeVal(pNode)); err == nil {
+						nh.Preference = n
+						nh.HasPreference = true
+					}
+				}
+				if mNode := prop.FindChild("metric"); mNode != nil {
+					if n, err := strconv.Atoi(nodeVal(mNode)); err == nil {
+						nh.Metric = n
+						nh.HasMetric = true
+					}
 				}
 				route.NextHops = append(route.NextHops, nh)
 			case "next-table":

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -306,6 +306,10 @@ func compileRoutingInstances(node *Node, cfg *Config) error {
 				}
 				ri.StaticRoutes = ro.StaticRoutes
 				ri.Inet6StaticRoutes = ro.Inet6StaticRoutes
+				// #3870: capture the instance-level autonomous-system so a
+				// per-instance BGP that omits local-as can inherit it (falling
+				// back to the global routing-options AS in resolveBGPAutonomousSystem).
+				ri.AutonomousSystem = ro.AutonomousSystem
 				// Parse interface-routes rib-group
 				if irNode := prop.FindChild("interface-routes"); irNode != nil {
 					if rgNode := irNode.FindChild("rib-group"); rgNode != nil {
@@ -376,6 +380,40 @@ func compileRoutingInstances(node *Node, cfg *Config) error {
 		}
 	}
 	return nil
+}
+
+// resolveBGPAutonomousSystem fills a BGP local-AS from `routing-options
+// autonomous-system` when `protocols bgp local-as` was not set (#3870).
+//
+// Junos accepts the BGP AS at TWO hierarchy points: the global
+// `routing-options autonomous-system <N>` (the canonical vSRX placement) and
+// the more specific `protocols bgp local-as <N>` override. The FRR renderer
+// gates `router bgp` on BGPConfig.LocalAS > 0 (policy_render.go), and only
+// `local-as` populated LocalAS — so a config that set the AS only at
+// routing-options rendered NO `router bgp` block at all, silently. This
+// resolves the Junos precedence into LocalAS after the whole tree is compiled
+// (routing-options and protocols may appear in either order under the root):
+// local-as wins if present, else the global autonomous-system. Per-instance
+// BGP inherits the instance's own routing-options autonomous-system if set,
+// else the global one. Must run AFTER both compileRoutingOptions and
+// compileProtocols/compileRoutingInstances have populated cfg.
+func resolveBGPAutonomousSystem(cfg *Config) {
+	globalAS := cfg.RoutingOptions.AutonomousSystem
+	if bgp := cfg.Protocols.BGP; bgp != nil && bgp.LocalAS == 0 && globalAS > 0 {
+		bgp.LocalAS = globalAS
+	}
+	for _, ri := range cfg.RoutingInstances {
+		if ri.BGP == nil || ri.BGP.LocalAS != 0 {
+			continue
+		}
+		as := ri.AutonomousSystem // instance-level override
+		if as == 0 {
+			as = globalAS // inherit the global autonomous-system
+		}
+		if as > 0 {
+			ri.BGP.LocalAS = as
+		}
+	}
 }
 
 func compilePolicyOptions(node *Node, po *PolicyOptionsConfig) error {

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -138,6 +138,18 @@ func compileRoutingOptions(node *Node, ro *RoutingOptionsConfig) error {
 	return nil
 }
 
+// isRouteInlineKeyword reports whether tok is a static-route clause keyword in
+// the fully-inline route-keys form (`route <dst> next-hop a b qualified-next-hop
+// ...`). Used to bound a multi-value next-hop gateway run (#3872) so it stops
+// at the next clause instead of swallowing a following keyword as a gateway.
+func isRouteInlineKeyword(tok string) bool {
+	switch tok {
+	case "next-hop", "qualified-next-hop", "next-table", "discard", "reject", "preference", "metric", "interface":
+		return true
+	}
+	return false
+}
+
 // compileStaticRoutes parses static route entries from a "static" node,
 // appending to and returning the updated slice.
 func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRoute {
@@ -158,7 +170,11 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 			for i := 2; i < len(routeInst.node.Keys); i++ {
 				switch routeInst.node.Keys[i] {
 				case "next-hop":
-					if i+1 < len(routeInst.node.Keys) {
+					// Absorb a collapsed bracket list `next-hop [ a b ]` in the
+					// fully-inline form: consume consecutive gateway tokens
+					// until the next route keyword, installing each as an
+					// equal-cost next-hop (#3872).
+					for i+1 < len(routeInst.node.Keys) && !isRouteInlineKeyword(routeInst.node.Keys[i+1]) {
 						i++
 						route.NextHops = append(route.NextHops, NextHopEntry{Address: routeInst.node.Keys[i]})
 					}
@@ -220,22 +236,39 @@ func compileStaticRoutes(staticNode *Node, existing []*StaticRoute) []*StaticRou
 		for _, prop := range routeInst.node.Children {
 			switch prop.Name() {
 			case "next-hop":
-				nh := NextHopEntry{}
-				nh.Address = nodeVal(prop)
-				// Check children for interface (needed for IPv6 link-local next-hops)
+				// #3872: `next-hop [ gw1 gw2 ]` is canonical Junos ECMP — the
+				// bracket list collapses onto Keys=["next-hop", gw1, gw2, ...]
+				// in both AST shapes (multi leaf). Read EVERY gateway and
+				// install each as an equal-cost next-hop; reading only Keys[1]
+				// silently dropped all but the first. A single-gateway form may
+				// carry an `interface <if>` modifier (IPv6 link-local), inline
+				// on the keys (`next-hop fe80::1 interface reth0.50`) or as a
+				// child node — that egress interface applies to the gateway(s).
+				var addrs []string
+				iface := ""
+				for j := 1; j < len(prop.Keys); j++ {
+					if prop.Keys[j] == "interface" {
+						if j+1 < len(prop.Keys) {
+							iface = prop.Keys[j+1]
+							j++
+						}
+						continue
+					}
+					addrs = append(addrs, prop.Keys[j])
+				}
+				// Child interface (hierarchical + flat-set container shapes).
 				for _, child := range prop.Children {
 					if child.Name() == "interface" {
-						nh.Interface = nodeVal(child)
+						iface = nodeVal(child)
 					}
 				}
-				// Also check inline keys: "next-hop fe80::50 interface reth0.50"
-				// has all in Keys rather than Children.
-				for j := 2; j < len(prop.Keys)-1; j++ {
-					if prop.Keys[j] == "interface" {
-						nh.Interface = prop.Keys[j+1]
-					}
+				if len(addrs) == 0 && iface != "" {
+					// interface-only next-hop (unnumbered) — keep one entry.
+					route.NextHops = append(route.NextHops, NextHopEntry{Interface: iface})
 				}
-				route.NextHops = append(route.NextHops, nh)
+				for _, a := range addrs {
+					route.NextHops = append(route.NextHops, NextHopEntry{Address: a, Interface: iface})
+				}
 			case "discard":
 				route.Discard = true
 			case "preference":

--- a/pkg/config/compiler_static_nexthop_list_3872_test.go
+++ b/pkg/config/compiler_static_nexthop_list_3872_test.go
@@ -1,0 +1,105 @@
+package config
+
+import "testing"
+
+func nhAddrs3872(nhs []NextHopEntry) []string {
+	out := make([]string, 0, len(nhs))
+	for _, nh := range nhs {
+		out = append(out, nh.Address)
+	}
+	return out
+}
+
+// A canonical Junos ECMP list `next-hop [ gw1 gw2 ]` must install EVERY
+// gateway as an equal-cost next-hop. RED-on-revert: only the first gateway is
+// compiled (multipath silently lost) (#3872).
+func TestStaticNextHopBracketListECMP_3872(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.1.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 ]",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.1.0.0/16")
+	got := nhAddrs3872(r.NextHops)
+	if len(got) != 2 || got[0] != "10.0.0.1" || got[1] != "10.0.0.2" {
+		t.Fatalf("next-hops = %v, want [10.0.0.1 10.0.0.2] (equal-cost ECMP)", got)
+	}
+	for _, nh := range r.NextHops {
+		if nh.HasPreference {
+			t.Errorf("plain ECMP next-hop %s must not carry a per-NH preference", nh.Address)
+		}
+	}
+}
+
+// A three-gateway list also keeps every gateway.
+func TestStaticNextHopBracketListThree_3872(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.2.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 10.0.0.3 ]",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.2.0.0/16")
+	got := nhAddrs3872(r.NextHops)
+	want := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+	if len(got) != len(want) {
+		t.Fatalf("next-hops = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("next-hops = %v, want %v", got, want)
+		}
+	}
+}
+
+// A single next-hop still compiles to exactly one entry (no regression).
+func TestStaticSingleNextHopUnchanged_3872(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 0.0.0.0/0 next-hop 10.0.0.254",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "0.0.0.0/0")
+	if got := nhAddrs3872(r.NextHops); len(got) != 1 || got[0] != "10.0.0.254" {
+		t.Fatalf("next-hops = %v, want [10.0.0.254]", got)
+	}
+}
+
+// The IPv6 link-local `next-hop <gw> interface <if>` modifier still walks as a
+// child — multi + valueList must NOT swallow the interface as a bogus gateway.
+func TestStaticNextHopInterfaceModifierPreserved_3872(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 2001:db8::/32 next-hop fe80::1 interface reth0.50",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "2001:db8::/32")
+	if len(r.NextHops) != 1 {
+		t.Fatalf("NextHops = %d, want 1: %+v", len(r.NextHops), r.NextHops)
+	}
+	nh := r.NextHops[0]
+	if nh.Address != "fe80::1" || nh.Interface != "reth0.50" {
+		t.Fatalf("next-hop = {Address:%q Interface:%q}, want {fe80::1 reth0.50}", nh.Address, nh.Interface)
+	}
+}
+
+// #3872 composes with #3871: a plain next-hop list AND a qualified-next-hop
+// backup on the same route stay distinct — the list is equal-cost (no per-NH
+// preference), the qualified entry is the floating backup (preference 250).
+func TestStaticNextHopListComposesWithQualified_3872(t *testing.T) {
+	c := compileSets3870(t, []string{
+		"set routing-options static route 10.3.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 ]",
+		"set routing-options static route 10.3.0.0/16 qualified-next-hop 10.0.0.9 preference 250",
+	})
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.3.0.0/16")
+	var backup *NextHopEntry
+	equalCost := 0
+	for i := range r.NextHops {
+		switch r.NextHops[i].Address {
+		case "10.0.0.1", "10.0.0.2":
+			if r.NextHops[i].HasPreference {
+				t.Errorf("plain ECMP next-hop %s must not carry a per-NH preference", r.NextHops[i].Address)
+			}
+			equalCost++
+		case "10.0.0.9":
+			backup = &r.NextHops[i]
+		}
+	}
+	if equalCost != 2 {
+		t.Fatalf("want 2 equal-cost next-hops, got %d: %+v", equalCost, r.NextHops)
+	}
+	if backup == nil || !backup.HasPreference || backup.Preference != 250 {
+		t.Fatalf("qualified backup 10.0.0.9 preference = want 250 floating, got %+v", backup)
+	}
+}

--- a/pkg/config/delete_static_nexthop_3872_test.go
+++ b/pkg/config/delete_static_nexthop_3872_test.go
@@ -1,0 +1,115 @@
+package config
+
+import "testing"
+
+// applySetsDeletes3872 applies `set ...` then `delete ...` commands (prefix
+// each command with its verb) via ParseSetCommand + SetPath/DeletePath, then
+// compiles.
+func applySetsDeletes3872(t *testing.T, sets []string, deletes []string) *Config {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, cmd := range sets {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", cmd, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", cmd, err)
+		}
+	}
+	for _, cmd := range deletes {
+		path, err := ParseSetCommand(cmd)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(delete %q): %v", cmd, err)
+		}
+		if err := tree.DeletePath(path); err != nil {
+			t.Fatalf("DeletePath(%q): %v", cmd, err)
+		}
+	}
+	c, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return c
+}
+
+// Deleting ONE gateway of a `next-hop [ a b ]` ECMP list must remove only that
+// gateway and keep the healthy other path — NOT delete the whole leaf and
+// leave the route with 0 next-hops (which renders Null0 blackhole). RED-on-
+// revert: the whole next-hop leaf is deleted, route blackholed (#3872 delete
+// side, the #3846 class).
+func TestDeleteStaticNextHopFirstMember_3872(t *testing.T) {
+	c := applySetsDeletes3872(t,
+		[]string{"set routing-options static route 10.1.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 ]"},
+		[]string{"routing-options static route 10.1.0.0/16 next-hop 10.0.0.1"},
+	)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.1.0.0/16")
+	got := nhAddrs3872(r.NextHops)
+	if len(got) != 1 || got[0] != "10.0.0.2" {
+		t.Fatalf("after delete 10.0.0.1: next-hops = %v, want [10.0.0.2] (healthy path must survive; whole route was blackholed before the fix)", got)
+	}
+}
+
+// Deleting a NON-FIRST gateway also works (was "path not found" before).
+func TestDeleteStaticNextHopNonFirstMember_3872(t *testing.T) {
+	c := applySetsDeletes3872(t,
+		[]string{"set routing-options static route 10.1.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 ]"},
+		[]string{"routing-options static route 10.1.0.0/16 next-hop 10.0.0.2"},
+	)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.1.0.0/16")
+	got := nhAddrs3872(r.NextHops)
+	if len(got) != 1 || got[0] != "10.0.0.1" {
+		t.Fatalf("after delete 10.0.0.2: next-hops = %v, want [10.0.0.1]", got)
+	}
+}
+
+// Deleting an interface-qualified gateway drops the WHOLE entry (gateway + its
+// interface modifier), not a gateway-less next-hop container.
+func TestDeleteStaticNextHopInterfaceQualified_3872(t *testing.T) {
+	c := applySetsDeletes3872(t,
+		[]string{
+			"set routing-options static route 2001:db8::/32 next-hop fe80::1 interface reth0.50",
+			"set routing-options static route 2001:db8::/32 next-hop fe80::2 interface reth0.51",
+		},
+		[]string{"routing-options static route 2001:db8::/32 next-hop fe80::1"},
+	)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "2001:db8::/32")
+	if len(r.NextHops) != 1 {
+		t.Fatalf("after delete fe80::1: NextHops = %d, want 1 (whole entry dropped): %+v", len(r.NextHops), r.NextHops)
+	}
+	nh := r.NextHops[0]
+	if nh.Address != "fe80::2" || nh.Interface != "reth0.51" {
+		t.Fatalf("surviving next-hop = {Address:%q Interface:%q}, want {fe80::2 reth0.51}", nh.Address, nh.Interface)
+	}
+}
+
+// Deleting the LAST gateway leaves the route with 0 next-hops — which must NOT
+// render a Null0 blackhole. RED-on-revert: the route renders Null0 (fail-wide).
+func TestDeleteStaticNextHopLastMember_3872(t *testing.T) {
+	c := applySetsDeletes3872(t,
+		[]string{"set routing-options static route 10.1.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 ]"},
+		[]string{
+			"routing-options static route 10.1.0.0/16 next-hop 10.0.0.1",
+			"routing-options static route 10.1.0.0/16 next-hop 10.0.0.2",
+		},
+	)
+	r := findStaticRoute3871(t, c.RoutingOptions.StaticRoutes, "10.1.0.0/16")
+	if len(r.NextHops) != 0 {
+		t.Fatalf("after deleting both gateways: NextHops = %v, want none", nhAddrs3872(r.NextHops))
+	}
+}
+
+// Deleting a member that is not present is reported (not silently succeeding).
+func TestDeleteStaticNextHopAbsentMemberErrors_3872(t *testing.T) {
+	tree := &ConfigTree{}
+	for _, cmd := range []string{"set routing-options static route 10.1.0.0/16 next-hop [ 10.0.0.1 10.0.0.2 ]"} {
+		path, _ := ParseSetCommand(cmd)
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath: %v", err)
+		}
+	}
+	path, _ := ParseSetCommand("routing-options static route 10.1.0.0/16 next-hop 10.9.9.9")
+	if err := tree.DeletePath(path); err == nil {
+		t.Fatal("deleting an absent next-hop member should error (not-found contract)")
+	}
+}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -32,17 +32,27 @@ package config
 // schemaNode defines a container keyword in the Junos config hierarchy.
 // It tells SetPath how to group flat path tokens into the correct tree structure.
 type schemaNode struct {
-	args         int                    // extra tokens consumed as part of this node's key
-	children     map[string]*schemaNode // known container children
-	wildcard     *schemaNode            // matches any keyword not in children (for dynamic names)
-	multi        bool                   // true = multiple leaf values allowed (e.g. source-address); false = replace on set
-	scalar       bool                   // true = fixed-arity scalar value leaf (keyword + exactly `args` value tokens, NO body); rejects trailing tokens at commit (#3332). Opt-in; see isScalarValueLeaf.
-	valueHint    ValueHint              // hint for dynamic value completion (when args > 0)
-	desc         string                 // description shown in completion help
-	placeholder  string                 // Junos-style placeholder (e.g., "<interface-name>")
-	midKeyword   string                 // fixed keyword in the middle of args (e.g., "to-zone")
-	midKeywordAt int                    // 1-based arg position where midKeyword appears (e.g., 2 for "from-zone X to-zone Y")
-	compoundKey  bool                   // children form compound key (e.g., "family inet6" → Keys=["family","inet6"])
+	args     int                    // extra tokens consumed as part of this node's key
+	children map[string]*schemaNode // known container children
+	wildcard *schemaNode            // matches any keyword not in children (for dynamic names)
+	multi    bool                   // true = multiple leaf values allowed (e.g. source-address); false = replace on set
+	// valueList opts a multi leaf that ALSO declares modifier children into
+	// bracket-list value absorption (#3872 static `next-hop [ a b ]`). By
+	// default the SetPath absorber only collapses a trailing value list onto a
+	// multi leaf when children == nil (ast_edit.go); a multi leaf WITH children
+	// (e.g. the CoS named containers) stays a container. valueList lets such a
+	// node absorb trailing tokens that are neither a sibling NOR a known child
+	// (the bracket list) while STILL descending into the container when the
+	// next token names a known child (the `interface` modifier). Only next-hop
+	// sets it; every other multi+children node is unchanged.
+	valueList    bool
+	scalar       bool      // true = fixed-arity scalar value leaf (keyword + exactly `args` value tokens, NO body); rejects trailing tokens at commit (#3332). Opt-in; see isScalarValueLeaf.
+	valueHint    ValueHint // hint for dynamic value completion (when args > 0)
+	desc         string    // description shown in completion help
+	placeholder  string    // Junos-style placeholder (e.g., "<interface-name>")
+	midKeyword   string    // fixed keyword in the middle of args (e.g., "to-zone")
+	midKeywordAt int       // 1-based arg position where midKeyword appears (e.g., 2 for "from-zone X to-zone Y")
+	compoundKey  bool      // children form compound key (e.g., "family inet6" → Keys=["family","inet6"])
 
 	// Typed-leaf metadata (#1319). The zero value (valueType==ValueAny,
 	// validator==nil) is the legacy behaviour: any string accepted, no

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -97,15 +97,23 @@ func staticRouteNode() *schemaNode {
 				}},
 			"qualified-next-hop": {desc: "Qualified next-hop", args: 1, placeholder: "<gateway>", children: map[string]*schemaNode{
 				"interface": {desc: "Egress interface", args: 1, placeholder: "<interface-name>", children: nil},
-				// #3827 (Low): the qualified-next-hop preference folds into
-				// route.Preference (compiler_routing.go), the same i32 wire field
-				// gated for the route-level `preference` leaf. Mirror that typing
-				// so a negative / i32-overflow value is rejected at commit (naming
-				// the leaf) instead of only tripping the Rust snapshot backstop
+				// The qualified-next-hop preference is carried PER next-hop
+				// (NextHopEntry.Preference, #3871) so the qualified gateway
+				// renders as a FLOATING backup at its own admin distance — it is
+				// NO LONGER folded into the single route-level preference (that
+				// fold was the #3871 bug: it made every next-hop equal-cost).
+				// The typing is still the same i32 wire field gated for the
+				// route-level `preference` leaf (#3827): a negative / i32-
+				// overflow value is rejected at commit (naming the leaf) instead
+				// of only tripping the Rust snapshot backstop
 				// (RoutePreferenceOutOfRange) with retained-prior-state.
 				"preference": {desc: "Preference", args: 1, placeholder: "<value>",
 					valueType: ValueInteger, valueDesc: "Route preference / administrative distance (0..2147483647; lower = more preferred, default 5)",
 					valueExamples: []string{"5", "100"}, validator: ValidateInteger(0, maxWireI32), children: nil},
+				// metric is carried per next-hop (NextHopEntry.Metric, #3871) but
+				// NOT rendered — FRR's static-route CLI has no metric field, so a
+				// metric-only qualified-next-hop (no preference) does NOT float;
+				// preference is what creates the floating backup.
 				"metric": {desc: "Metric", args: 1, placeholder: "<value>", children: nil},
 			}},
 			"discard":    {desc: "Discard (blackhole) route", children: nil},

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -77,7 +77,19 @@ func staticRouteNode() *schemaNode {
 			// through the presence-only modifier path, so the value token
 			// after `interface` was rejected as `unknown modifier` (#2448
 			// over-rejection regression).
-			"next-hop": {desc: "Next-hop gateway (IP, ip@interface, or interface name)", args: 1, placeholder: "<gateway>",
+			// #3872: next-hop is a multi + valueList leaf so a canonical Junos
+			// ECMP list `next-hop [ gw1 gw2 ]` collapses onto ONE leaf
+			// (Keys=["next-hop", gw1, gw2]) in BOTH the block-parse and
+			// flat-set SetPath shapes, matching the #2419 multi-value pattern;
+			// the compiler reads Keys[1:] and installs every gateway as an
+			// equal-cost next-hop. valueList lets this multi leaf keep its
+			// `interface` MODIFIER child: SetPath descends into the container
+			// for the single-gateway IPv6 link-local form
+			// (`next-hop fe80::1 interface reth0.50`) and absorbs the value
+			// list otherwise (ast_edit.go). A qualified-next-hop backup is a
+			// SEPARATE leaf (floating, per-NH preference, #3871), kept distinct
+			// from this equal-cost list.
+			"next-hop": {desc: "Next-hop gateway (IP, ip@interface, or interface name)", args: 1, multi: true, valueList: true, placeholder: "<gateway>",
 				keyValueType: ValueIPAddress, keyValueDesc: "next-hop IP address, ip@interface, or interface name",
 				keyValueExamples: []string{"192.168.1.1", "2001:db8::1"}, keyValidator: ValidateStaticNextHop,
 				children: map[string]*schemaNode{

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -505,18 +505,23 @@ func (tc *TunnelConfig) WgHasEndpoint() bool {
 
 // RoutingInstanceConfig represents a VRF-based routing instance.
 type RoutingInstanceConfig struct {
-	Name                      string
-	Description               string
-	InstanceType              string         // "virtual-router" or "vrf"
-	Interfaces                []string       // interfaces belonging to this instance
-	StaticRoutes              []*StaticRoute // per-instance static routes
-	Inet6StaticRoutes         []*StaticRoute // per-instance rib inet6.0 static routes
-	OSPF                      *OSPFConfig    // per-instance OSPF (optional)
-	OSPFv3                    *OSPFv3Config  // per-instance OSPFv3 (optional)
-	BGP                       *BGPConfig     // per-instance BGP (optional)
-	RIP                       *RIPConfig     // per-instance RIP (optional)
-	ISIS                      *ISISConfig    // per-instance IS-IS (optional)
-	TableID                   int            // Linux kernel routing table number (auto-assigned)
-	InterfaceRoutesRibGroup   string         // interface-routes { rib-group inet <name>; }
-	InterfaceRoutesRibGroupV6 string         // interface-routes { rib-group inet6 <name>; }
+	Name              string
+	Description       string
+	InstanceType      string         // "virtual-router" or "vrf"
+	Interfaces        []string       // interfaces belonging to this instance
+	StaticRoutes      []*StaticRoute // per-instance static routes
+	Inet6StaticRoutes []*StaticRoute // per-instance rib inet6.0 static routes
+	OSPF              *OSPFConfig    // per-instance OSPF (optional)
+	OSPFv3            *OSPFv3Config  // per-instance OSPFv3 (optional)
+	BGP               *BGPConfig     // per-instance BGP (optional)
+	RIP               *RIPConfig     // per-instance RIP (optional)
+	ISIS              *ISISConfig    // per-instance IS-IS (optional)
+	// AutonomousSystem is this instance's `routing-options autonomous-system`
+	// (#3870). When the instance's BGP omits `local-as`, the BGP AS is
+	// resolved from this instance-level AS if set, else the GLOBAL
+	// routing-options autonomous-system (Junos inheritance). 0 = unset.
+	AutonomousSystem          uint32
+	TableID                   int    // Linux kernel routing table number (auto-assigned)
+	InterfaceRoutesRibGroup   string // interface-routes { rib-group inet <name>; }
+	InterfaceRoutesRibGroupV6 string // interface-routes { rib-group inet6 <name>; }
 }

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -164,6 +164,26 @@ type RibGroup struct {
 type NextHopEntry struct {
 	Address   string // IP address (e.g. "10.0.1.1" or "fe80::1")
 	Interface string // outgoing interface (for IPv6 link-local)
+	// Preference is this next-hop's own administrative distance, carried from
+	// a `qualified-next-hop <gw> { preference N; }` (#3871 — the Junos
+	// FLOATING-static idiom: a primary next-hop plus a less-preferred backup).
+	// Valid only when HasPreference. A plain `next-hop` leaves HasPreference
+	// false and renders at the ROUTE-level distance (StaticRoute.Preference),
+	// so plain `next-hop [ a b ]` stays equal-cost ECMP while a qualified
+	// backup renders at its own higher distance and installs only when the
+	// primary next-hop is down. Folding the qualified preference into the
+	// single route-level Preference (the pre-#3871 behavior) rendered every
+	// next-hop at equal cost, so the floating static load-balanced over the
+	// backup instead of preferring the primary.
+	Preference    int
+	HasPreference bool
+	// Metric is this next-hop's `qualified-next-hop <gw> { metric M; }` value
+	// (#3871). Carried in the typed config for parity/display; FRR's static
+	// route CLI (`ip route NET GW [DISTANCE]`) has no per-route metric field,
+	// so the floating behavior is expressed entirely through the per-next-hop
+	// admin distance (Preference), not Metric. Valid only when HasMetric.
+	Metric    int
+	HasMetric bool
 }
 
 // StaticRoute defines a single static route.

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -117,6 +117,19 @@ also carries operator content:
   interfaces and no qualifier the next-hop is genuinely ambiguous — the
   inference refuses to guess (leaves it unresolved) rather than route to the
   wrong link, and the operator must add an interface qualifier.
+- **Static `next-hop [ a b ]` ECMP list (#3872).** A static route's
+  `next-hop [ gw1 gw2 ]` is the canonical Junos ECMP spelling — multiple
+  next-hops = equal-cost multipath. The schema `next-hop` leaf is `multi:
+  true, valueList: true` (`schema_routing.go`) so the bracket list collapses
+  onto one leaf in both AST shapes, and the compiler
+  (`compileStaticRoutes`) reads EVERY gateway from `Keys[1:]` (plus separate
+  `next-hop` statements). Each gateway becomes a `NextHopEntry`, and
+  `generateStaticRouteInTable` emits one `ip route` line per next-hop → FRR
+  installs equal-cost multipath. Before #3872 the leaf was a plain container
+  and the compiler read a single address, so `next-hop [ a b ]` silently
+  installed only the first gateway. A plain list carries NO per-next-hop
+  preference (all equal-cost) — kept distinct from the floating
+  `qualified-next-hop` backup below.
 - **Floating static via `qualified-next-hop` (#3871).** A static route's
   `qualified-next-hop <gw> { preference N; metric M; }` is the Junos floating-
   static idiom — a primary next-hop plus a LESS-preferred backup that installs

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -161,6 +161,20 @@ also carries operator content:
   the FRR-invalid `redistribute direct`, failing the reload) — matching the
   policy-term `FromProtocols` normalization and keeping the commit gate's
   acceptance of `direct` honest.
+- **BGP local-AS resolves from `routing-options autonomous-system` (#3870).**
+  `generateProtocols` gates the `router bgp <N>` block on `BGPConfig.LocalAS
+  > 0`, and ONLY `protocols bgp local-as` populated `LocalAS`. A canonical
+  vSRX config that declares the AS at the global `routing-options
+  autonomous-system <N>` (the standard Junos placement) — with `protocols
+  bgp` but no `local-as` — therefore rendered NO `router bgp` block at all,
+  silently, and BGP never came up. `resolveBGPAutonomousSystem`
+  (`compiler_routing.go`), run once after the whole tree compiles (so
+  `routing-options` and `protocols` may appear in either order), fills
+  `LocalAS` from the global `autonomous-system` when `local-as` was omitted;
+  `local-as` still WINS when present (Junos precedence). A per-routing-instance
+  BGP without `local-as` inherits the instance's own `routing-options
+  autonomous-system` if set, else the global one. No AS anywhere leaves
+  `LocalAS == 0` and renders no `router bgp`, unchanged.
 - **A BGP neighbor's peer-as (remote-as) is validated at commit (#2963).**
   `peer-as` is optional in the parser/compiler, so a neighbor authored
   without one (and without an inherited group `peer-as`) keeps a zero

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -148,7 +148,10 @@ also carries operator content:
   (#3872) — kept distinct: no per-next-hop preference. FRR's static-route CLI
   has no metric field, so `NextHopEntry.Metric` is carried in the typed config
   (parity/display) but not emitted — the floating behavior is entirely the
-  per-next-hop distance.
+  per-next-hop distance. A metric-ONLY `qualified-next-hop <gw> { metric M; }`
+  (no `preference`) therefore does NOT float: with `HasPreference == false` it
+  renders at the route-level distance, equal-cost with the primary — a
+  `preference` is REQUIRED to make a qualified-next-hop a floating backup.
 - **VRRP-VIP-only subnets (#2452 secondary).** A bondless-RETH member that
   carries only a VRRP virtual address (no matching `unit.Addresses` entry)
   also contributes its VIP subnet as a connected prefix, so a static

--- a/pkg/frr/README.md
+++ b/pkg/frr/README.md
@@ -117,6 +117,25 @@ also carries operator content:
   interfaces and no qualifier the next-hop is genuinely ambiguous — the
   inference refuses to guess (leaves it unresolved) rather than route to the
   wrong link, and the operator must add an interface qualifier.
+- **Floating static via `qualified-next-hop` (#3871).** A static route's
+  `qualified-next-hop <gw> { preference N; metric M; }` is the Junos floating-
+  static idiom — a primary next-hop plus a LESS-preferred backup that installs
+  only when the primary is down. `generateStaticRouteInTable` renders each
+  next-hop with its OWN admin distance: a next-hop carrying a per-next-hop
+  preference (`NextHopEntry.HasPreference`, set by the compiler from the
+  qualified-next-hop's `preference` child/inline key) uses that distance; a
+  plain next-hop uses the route-level `StaticRoute.Preference` (default 5). So
+  `next-hop 10.0.0.1` + `qualified-next-hop 10.0.0.2 preference 250` emits
+  `ip route <dst> 10.0.0.1 5` and `ip route <dst> 10.0.0.2 250` — FRR installs
+  the distance-5 primary and floats the distance-250 backup in only when the
+  primary's next-hop is unresolvable. Before #3871 the qualified preference was
+  folded into a single route-level `Preference`, so every next-hop rendered at
+  equal cost and the floating static became equal-cost ECMP that load-balanced
+  over the backup. A plain `next-hop [ a b ]` bracket LIST is equal-cost ECMP
+  (#3872) — kept distinct: no per-next-hop preference. FRR's static-route CLI
+  has no metric field, so `NextHopEntry.Metric` is carried in the typed config
+  (parity/display) but not emitted — the floating behavior is entirely the
+  per-next-hop distance.
 - **VRRP-VIP-only subnets (#2452 secondary).** A bondless-RETH member that
   carries only a VRRP virtual address (no matching `unit.Addresses` entry)
   also contributes its VIP subnet as a connected prefix, so a static

--- a/pkg/frr/config_render.go
+++ b/pkg/frr/config_render.go
@@ -113,13 +113,22 @@ func (m *Manager) generateStaticRouteInTable(sr *config.StaticRoute, vrfName str
 		vrfPart = fmt.Sprintf(" table %d", tableID)
 	}
 
-	// Discard or no next-hops: single Null0 line.
-	if sr.Discard || len(sr.NextHops) == 0 {
+	// Explicit discard (blackhole) route: single Null0 line.
+	if sr.Discard {
 		nexthop := "Null0"
 		if sr.Preference > 0 {
 			return fmt.Sprintf("%s route %s %s %d%s\n", prefix, sr.Destination, nexthop, sr.Preference, vrfPart)
 		}
 		return fmt.Sprintf("%s route %s %s%s\n", prefix, sr.Destination, nexthop, vrfPart)
+	}
+
+	// A non-discard route with NO next-hops is incomplete — e.g. every gateway
+	// of an ECMP `next-hop [ a b ]` list was deleted (#3872 delete-side). Render
+	// NOTHING rather than a Null0 blackhole: silently blackholing traffic that
+	// would otherwise fall through to a default / more-specific route is a
+	// fail-wide. (An explicit `discard` above still renders Null0.)
+	if len(sr.NextHops) == 0 {
+		return ""
 	}
 
 	// One line per next-hop → FRR creates ECMP.

--- a/pkg/frr/config_render.go
+++ b/pkg/frr/config_render.go
@@ -160,8 +160,20 @@ func (m *Manager) generateStaticRouteInTable(sr *config.StaticRoute, vrfName str
 		default:
 			continue
 		}
-		if sr.Preference > 0 {
-			fmt.Fprintf(&b, "%s route %s %s %d%s\n", prefix, sr.Destination, nexthop, sr.Preference, vrfPart)
+		// Per-next-hop admin distance (#3871): a qualified-next-hop carries
+		// its own preference (HasPreference) and renders as a FLOATING backup
+		// at that distance; a plain next-hop uses the route-level distance so
+		// a `next-hop [ a b ]` list stays equal-cost ECMP. FRR installs the
+		// lowest-distance reachable next-hop and fails over to the higher-
+		// distance one only when the primary is down. FRR's static-route CLI
+		// has no metric field, so nh.Metric is not emitted — the floating
+		// behavior comes entirely from the distance.
+		dist := sr.Preference
+		if nh.HasPreference {
+			dist = nh.Preference
+		}
+		if dist > 0 {
+			fmt.Fprintf(&b, "%s route %s %s %d%s\n", prefix, sr.Destination, nexthop, dist, vrfPart)
 		} else {
 			fmt.Fprintf(&b, "%s route %s %s%s\n", prefix, sr.Destination, nexthop, vrfPart)
 		}

--- a/pkg/frr/static_ecmp_list_3872_test.go
+++ b/pkg/frr/static_ecmp_list_3872_test.go
@@ -1,0 +1,32 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// A plain multi next-hop list renders EVERY gateway as an equal-cost line so
+// FRR installs multipath. RED-on-revert: only the first gateway is compiled,
+// so only one line renders (multipath lost) (#3872).
+func TestStaticNextHopListRendersECMP_3872(t *testing.T) {
+	m := New()
+	sr := &config.StaticRoute{
+		Destination: "10.1.0.0/16",
+		Preference:  5,
+		NextHops: []config.NextHopEntry{
+			{Address: "10.0.0.1"},
+			{Address: "10.0.0.2"},
+		},
+	}
+	got := m.generateStaticRoute(sr, "", nil, nil)
+	for _, want := range []string{
+		"ip route 10.1.0.0/16 10.0.0.1 5\n",
+		"ip route 10.1.0.0/16 10.0.0.2 5\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing equal-cost ECMP line %q\n got: %q", want, got)
+		}
+	}
+}

--- a/pkg/frr/static_empty_route_3872_test.go
+++ b/pkg/frr/static_empty_route_3872_test.go
@@ -1,0 +1,28 @@
+package frr
+
+import (
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// A non-discard route with 0 next-hops (e.g. every ECMP gateway was deleted,
+// #3872 delete side) must render NOTHING — NOT a Null0 blackhole. RED-on-
+// revert: renders "ip route <dst> Null0 5" (blackhole).
+func TestZeroNextHopRouteNotBlackholed_3872(t *testing.T) {
+	m := New()
+	sr := &config.StaticRoute{Destination: "10.1.0.0/16", Preference: 5}
+	if got := m.generateStaticRoute(sr, "", nil, nil); got != "" {
+		t.Fatalf("0-next-hop non-discard route rendered %q, want \"\" (must not blackhole)", got)
+	}
+}
+
+// An EXPLICIT discard route still renders Null0 (unchanged).
+func TestExplicitDiscardStillNull0_3872(t *testing.T) {
+	m := New()
+	sr := &config.StaticRoute{Destination: "10.0.99.0/24", Discard: true}
+	want := "ip route 10.0.99.0/24 Null0\n"
+	if got := m.generateStaticRoute(sr, "", nil, nil); got != want {
+		t.Fatalf("discard route = %q, want %q", got, want)
+	}
+}

--- a/pkg/frr/static_floating_3871_test.go
+++ b/pkg/frr/static_floating_3871_test.go
@@ -1,0 +1,57 @@
+package frr
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// A floating static renders the primary next-hop at the route-level distance
+// and the qualified-next-hop at its OWN (higher) distance, so FRR installs the
+// primary and floats the backup in only when the primary is down. RED-on-
+// revert: both next-hops render at equal cost → equal-cost ECMP over the
+// backup (#3871).
+func TestFloatingStaticQualifiedNextHopDistance_3871(t *testing.T) {
+	m := New()
+	sr := &config.StaticRoute{
+		Destination: "10.5.0.0/16",
+		Preference:  5, // route-level default (Junos static preference 5)
+		NextHops: []config.NextHopEntry{
+			{Address: "10.0.0.1"}, // primary
+			{Address: "10.0.0.2", Preference: 250, HasPreference: true}, // floating backup
+		},
+	}
+	got := m.generateStaticRoute(sr, "", nil, nil)
+	wantPrimary := "ip route 10.5.0.0/16 10.0.0.1 5\n"
+	wantBackup := "ip route 10.5.0.0/16 10.0.0.2 250\n"
+	if !strings.Contains(got, wantPrimary) {
+		t.Errorf("missing primary at distance 5.\n got: %q", got)
+	}
+	if !strings.Contains(got, wantBackup) {
+		t.Errorf("missing floating backup at distance 250.\n got: %q", got)
+	}
+}
+
+// A plain multi next-hop list renders every gateway at the SAME route-level
+// distance — equal-cost ECMP — with no per-next-hop distance divergence.
+func TestPlainNextHopListEqualCost_3871(t *testing.T) {
+	m := New()
+	sr := &config.StaticRoute{
+		Destination: "10.6.0.0/16",
+		Preference:  5,
+		NextHops: []config.NextHopEntry{
+			{Address: "10.0.0.1"},
+			{Address: "10.0.0.2"},
+		},
+	}
+	got := m.generateStaticRoute(sr, "", nil, nil)
+	for _, want := range []string{
+		"ip route 10.6.0.0/16 10.0.0.1 5\n",
+		"ip route 10.6.0.0/16 10.0.0.2 5\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing equal-cost line %q\n got: %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
Three coupled routing fixes from fable-review-161, combined in one PR because
they all touch `pkg/config/compiler_routing.go` + `schema_routing.go` +
`pkg/frr` (combining avoids a 3-way conflict). Each is a separate commit.

## #3870 (F-009) — BGP local-AS from `routing-options autonomous-system`
`router bgp` was gated on `BGPConfig.LocalAS > 0`, which only `protocols bgp
local-as` set. A canonical vSRX config that declares the AS at the global
`routing-options autonomous-system <N>` rendered NO `router bgp` block at all,
silently. `resolveBGPAutonomousSystem(cfg)` (run once post-compile, order-
independent) fills LocalAS from the global AS when `local-as` is omitted;
`local-as` still wins; per-instance BGP inherits the instance's own
`routing-options autonomous-system` if set, else the global one.

## #3871 (F-008) — floating `qualified-next-hop` per-next-hop preference/metric
A `qualified-next-hop <gw> { preference N; metric M; }` (Junos floating static)
had its per-next-hop preference/metric folded into a single route-level
`Preference`, so every next-hop rendered equal-cost and the floating static
load-balanced over the backup. Preference/metric are now carried PER
`NextHopEntry`; the renderer emits each next-hop at its own admin distance
(primary at route-level 5, qualified at 250) so FRR floats the backup in only
when the primary is down. FRR static routes have no metric field, so Metric is
carried but not emitted — the floating behavior is entirely the distance.

## #3872 (F-010) — static `next-hop [ a b ]` ECMP list
`next-hop [ gw1 gw2 ]` (canonical Junos ECMP) collapsed to one gateway. The
leaf is now `multi: true, valueList: true` so the bracket list collapses onto
one leaf and the compiler installs every gateway equal-cost. A new opt-in
`schemaNode.valueList` flag scopes the SetPath value-list absorber so the many
CoS `multi`+children named containers are unchanged; the `interface` modifier
child still walks for the IPv6 link-local form.

## How they compose
- plain `next-hop [ a b ]` list → equal-cost ECMP (no per-next-hop preference)
- `qualified-next-hop` → floating backup (per-next-hop distance)
- `routing-options autonomous-system` → BGP local-AS fallback

## Validation
`go test ./...` green; `go build ./...`; gofmt + vet clean. Each of the three
commits builds and tests clean independently (verified via detached
worktrees). RED-on-revert proven for each fix (BGP LocalAS→0/no `router bgp`;
qualified backup renders equal-cost; bracket list collapses to first gateway).

Closes #3870
Closes #3871
Closes #3872

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi