### PR TITLE
routing: leak rib-group interface routes per-prefix before main (#3876)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,55 @@
+## 2026-07-03 — #3876: rib-group interface-route import was a no-op (shadowed by default route) — per-prefix leak before main
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-016 (HIGH, advertised feature no-op). The
+    rib-group `interface-routes` import installed `ip rule from all lookup
+    <sourceTable> pref 33000`, which sat AFTER main (32766) so any main-table
+    default route shadowed it (silent no-op in every real deployment) AND leaked
+    the WHOLE source table (over-broad vs Junos, which leaks only connected
+    routes). The Dst-less rule was also skipped by the userspace snapshot builder
+    → leak absent from BOTH FIBs. Implemented CONVERGED PLAN Option 2 (per-prefix
+    dst-rules), Phase 1 (import into main).
+  - **Fix**: Replaced the blanket rule with one `ip rule to <connected-prefix>
+    lookup <sourceTable> pref 30000` per connected prefix of the source
+    instance (band 30000-30999, BEFORE main + PBR). Specific imported prefixes
+    now win over the default route. The per-prefix rules carry a Dst, so the
+    existing userspace snapshot loop (routes.go, rule.Dst != nil → table→instance
+    NextTable) auto-captures them into inet.0 — the leak is now in both FIBs; the
+    Dst==nil skip is unchanged (a from-all rule can't be a per-prefix leak).
+    clear() now scans the new 30000-30999 window PLUS the legacy 33000-33099
+    blanket + 200-299 windows so an in-place upgrade removes the stale broken
+    blanket rule. Connected prefixes derived via new SSOT
+    `config.RibGroupConnectedPrefixes` / `config.ConnectedNetworkPrefix` (shared
+    with the userspace FIB connected-route builder), plumbed through
+    `ApplyRibGroupRules` from daemon_apply.go step 3c. Cap
+    `maxRibGroupLeakRules = 1000` with degraded-Apply error. Commit-time WARNs
+    (validateRibGroupLeakWarnings) fail-loud on the un-leakable residuals:
+    DHCP-only / unaddressed source (no enumerable static prefix) and VRF→VRF
+    import targets (Phase 2 deferral). Window warn updated to the per-prefix
+    budget. Route-copy (Option 1) + VRF→VRF install deferred (warned).
+  - **File(s)**: `pkg/routing/rules.go` (per-prefix Apply + ribGroupLeaksIntoMain
+    + splitConnectedPrefixesByFamily + clear() 3-window + constants),
+    `pkg/routing/routing.go` (ApplyRibGroupRules signature),
+    `pkg/config/types_routing.go` (ConnectedNetworkPrefix),
+    `pkg/config/compiler_routing.go` (RibGroupConnectedPrefixes + ribTargetKind),
+    `pkg/config/compiler_validate_warn.go` (validateRibGroupLeakWarnings +
+    per-prefix window warn), `pkg/dataplane/userspace/routes.go` (shared helper
+    + Dst==nil comment), `pkg/daemon/daemon_apply.go` (plumb prefixes),
+    `pkg/routing/rules_test.go`, `pkg/config/compiler_routing_rules_test.go`,
+    `pkg/config/ribgroup_leak_warn_3876_test.go`,
+    `pkg/dataplane/userspace/routes_ribgroup_leak_3876_test.go` (tests),
+    `docs/rib-group-route-leaking.md`, `docs/feature-coverage.md` (docs).
+  - **Validation**: `go build ./...`; `go test ./pkg/routing/... ./pkg/config/...
+    ./pkg/dataplane/... ./pkg/daemon/...` green; gofmt + vet clean. RED-on-revert
+    verified for all four legs: (a) moving the band to 33000 (after main) fails
+    the pref<32766 assertion; (b) Dst-bearing capture + Dst-less skip pinned in
+    userspace snapshot tests; (c) dropping the 33000 window from clear() leaves
+    the stale blanket rule; (d) neutering the warn drops the VRF→VRF /
+    no-enumerable-prefix diagnostics. Cluster forwarding smoke (iperf through a
+    leaked path with a default route present) NOT run — flagged for operator
+    validation; test-failover not required (routing/forwarding only, no
+    session-sync/VRRP path).
+
 ## 2026-07-03 — #3863: WireGuard tunnel local identity never validated at commit (HIGH silent VPN outage)
 
 - **Timestamp**: 2026-07-03

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -86,7 +86,11 @@ the userspace dataplane admission boundary is in
 
 - **FRR integration**: static, OSPF, BGP, IS-IS, RIP, ECMP multipath,
   export/redistribute.
-- **VRFs** with inter-VRF route leaking (next-table + rib-group).
+- **VRFs** with inter-VRF route leaking (next-table + rib-group). The
+  `interface-routes rib-group` import into the main table leaks each source
+  instance's connected (interface) routes per-prefix so a specific imported
+  prefix wins over a main-table default route — see
+  `docs/rib-group-route-leaking.md` (#3876).
 - **GRE tunnels**, XFRM interfaces, PBR (policy-based routing).
 - **Probe-driven WAN failover** (`services ip-monitoring` preferred-route
   injection, #1827).

--- a/docs/rib-group-route-leaking.md
+++ b/docs/rib-group-route-leaking.md
@@ -1,0 +1,104 @@
+# rib-group interface-route leaking (#3876)
+
+Junos `routing-instances <ri> { routing-options { interface-routes { rib-group
+inet <rg>; } } }` with a `rib-groups { <rg> { import-rib [ <ri>.inet.0 inet.0 ];
+} }` installs the source instance's **direct/interface (connected)** routes into
+every secondary rib in the import list. xpf realizes the **import-into-main**
+case (the common one) with Linux policy-routing rules.
+
+## Mechanism (Phase 1: import into main)
+
+For each source routing instance whose `interface-routes` rib-group imports the
+**main table** (`inet.0` / `inet6.0`), the daemon installs one ip rule **per
+connected prefix** of that instance:
+
+```
+ip rule to <connected-prefix> lookup <sourceTable> pref 30000
+```
+
+These rules sit at priority band **30000-30999**, which is **BEFORE** the main
+table's rule (32766) and before the PBR band (31000-31999). Because the rule
+matches a *specific* destination prefix, a main-table **default route no longer
+shadows it** — a lookup for the leaked prefix consults the source instance's
+table (where the connected route lives), while everything else still falls
+through to main.
+
+- Source: `pkg/routing/rules.go` — `ribGroupManager.Apply` +
+  `ribGroupLeaksIntoMain`; band constant `ribGroupLeakRulePriority = 30000`,
+  cap `maxRibGroupLeakRules = 1000`.
+- Connected-prefix derivation: `config.RibGroupConnectedPrefixes`
+  (`pkg/config/compiler_routing.go`), which walks each instance's member
+  interface units and masks their static addresses to network prefixes via
+  the shared `config.ConnectedNetworkPrefix`. The **same** helper backs the
+  userspace FIB's connected-route builder
+  (`pkg/dataplane/userspace/routes.go`), so the leaked ip-rule set matches the
+  connected routes actually installed in the source table.
+- Plumbing: `pkg/daemon/daemon_apply.go` step 3c passes the derived prefix map
+  into `Manager.ApplyRibGroupRules`.
+
+### Both FIBs, by construction
+
+The per-prefix rules carry a `Dst`, so the userspace snapshot builder's
+existing `rule.Dst != nil` + table→instance loop auto-captures each as a
+`NextTable` leak into the main table (`pkg/dataplane/userspace/routes.go`) —
+putting the leak into the **userspace FIB** as well as the kernel FIB.
+
+## Why the pre-#3876 behavior was a no-op
+
+The old applier installed a single blanket rule per leaking source table:
+
+```
+ip rule from all lookup <sourceTable> pref 33000
+```
+
+This was broken two ways:
+
+1. **Shadowed by any default route** — priority 33000 sits *after* main
+   (32766), so a main-table default route matched first and the rule was never
+   consulted. In any deployment carrying a default route (i.e. essentially all
+   of them) the advertised feature was a silent no-op.
+2. **Over-broad** — `from all lookup <sourceTable>` leaked the *entire* source
+   table as a catch-all fall-through, far broader than Junos, which leaks only
+   the interface/connected routes.
+
+The blanket rule was also `Dst`-less, so the userspace snapshot builder skipped
+it — the leak was absent from **both** FIBs.
+
+### Upgrade cleanup
+
+`ribGroupManager.clear()` scans three priority windows on every reconcile: the
+current `[30000, 31000)` per-prefix band, the legacy `[33000, 33100)` blanket
+band, and the original `[200, 300)` band. An in-place binary upgrade therefore
+**removes the stale pref-33000 blanket rule** so the box is never left with the
+broken blanket rule alongside the new per-prefix rules.
+
+## Fail-loud diagnostics (commit-time warnings)
+
+`config.ValidateConfig` (`validateRibGroupLeakWarnings`) warns — rather than
+silently no-op — for the cases Phase 1 cannot fully realize:
+
+- **No enumerable static connected prefix**: a source instance whose rib-group
+  imports main but whose member interfaces carry no static address (DHCP-only /
+  unaddressed). No ip rule is installed because there is no static prefix to
+  enumerate at commit.
+- **VRF→VRF import target**: a rib-group importing another instance's rib (not
+  main). Phase 1 leaks only into the main table; a non-main import target is not
+  yet installed.
+
+The window warn (`validateRoutingRuleWindowWarnings`) additionally flags a
+config that would leak more than `maxRibGroupLeakRules` (1000) connected
+prefixes.
+
+## Deferred (Phase 2 and beyond)
+
+- **VRF→VRF import targets** — need `iif`-scoped rules or true route-copy;
+  warned + deferred.
+- **route-copy (Option 1)** — installing real copies of the source's direct
+  routes into the target table (à la FRR `import`) would give
+  `show route table inet.0` cosmetic parity but requires a new churn-tracking
+  reconciler that collides with FRR's ownership of the managed section. It is
+  forwarding-equivalent to the per-prefix rules for the dataplane and is
+  deferred entirely.
+- **Dynamically learned (DHCP) source addresses** — per-prefix cannot enumerate
+  them at commit; warned now, would need Phase-2 route-copy or a runtime
+  address-watch.

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -968,3 +968,92 @@ func parsePolicyTermInlineKeys(term *PolicyTerm, keys []string) {
 		}
 	}
 }
+
+// mainRIBTableID is the Linux main routing table (RT_TABLE_MAIN). It mirrors
+// pkg/routing.mainTableID; the two MUST agree on which import-rib targets are
+// "main" so the commit-time warn and the runtime applier classify a rib-group
+// import the same way (#3876).
+const mainRIBTableID = 254
+
+// ribTargetKind classifies a rib-group import-rib name against a source
+// instance for the #3876 per-prefix leak. It mirrors pkg/routing.resolveRibTable
+// (via ribInstanceFromName, the shared exact-suffix matcher) and returns:
+//   - "main": the main table (inet.0 / inet6.0) — the Phase-1 leak target.
+//   - "self": the source instance's own rib (no leak needed).
+//   - "vrf":  another DEFINED instance's rib — a VRF→VRF import, deferred to
+//     Phase 2 (warned, not installed).
+//   - "unknown": an unresolvable name (the strict gate rejects it at commit;
+//     the applier skips it — #2226).
+func ribTargetKind(ribName, selfInstance string, definedInstances map[string]bool) string {
+	if ribName == "inet.0" || ribName == "inet6.0" {
+		return "main"
+	}
+	if instance, ok := ribInstanceFromName(ribName); ok {
+		if instance == selfInstance {
+			return "self"
+		}
+		if definedInstances[instance] {
+			return "vrf"
+		}
+	}
+	return "unknown"
+}
+
+// RibGroupConnectedPrefixes derives, per source routing instance carrying an
+// interface-routes rib-group, the connected network prefixes eligible for the
+// #3876 per-prefix leak. For each instance member interface (e.g.
+// "ge-0/0/1.0") it resolves the physical interface + unit and collects the
+// masked network prefix of every static address on that unit via
+// ConnectedNetworkPrefix — the SAME derivation the userspace FIB uses for
+// connected routes, so the leaked ip-rule set matches the connected routes in
+// the source table.
+//
+// DHCP-only units carry no static Addresses (the lease is learned at runtime)
+// and contribute no enumerable prefix; the commit-time warn
+// (validateRibGroupLeakWarnings) surfaces that so the leak is fail-loud rather
+// than a silent no-op. The map is keyed by routing-instance name with v4 and
+// v6 prefixes mixed (the applier splits by family). Shared by the daemon
+// applier input and the config warn path so the two never drift.
+func RibGroupConnectedPrefixes(cfg *Config) map[string][]string {
+	out := make(map[string][]string)
+	if cfg == nil {
+		return out
+	}
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil || ri.Name == "" {
+			continue
+		}
+		if ri.InterfaceRoutesRibGroup == "" && ri.InterfaceRoutesRibGroupV6 == "" {
+			continue
+		}
+		var prefixes []string
+		for _, member := range ri.Interfaces {
+			base, unitTok, hasUnit := strings.Cut(member, ".")
+			unitNum := 0
+			if hasUnit {
+				n, err := strconv.Atoi(unitTok)
+				if err != nil {
+					continue
+				}
+				unitNum = n
+			}
+			ifc := cfg.Interfaces.Interfaces[base]
+			if ifc == nil {
+				continue
+			}
+			unit := ifc.Units[unitNum]
+			if unit == nil {
+				continue
+			}
+			for _, addr := range unit.Addresses {
+				if prefix, _, ok := ConnectedNetworkPrefix(addr); ok {
+					prefixes = append(prefixes, prefix)
+				}
+			}
+		}
+		if len(prefixes) > 0 {
+			out[ri.Name] = prefixes
+		}
+	}
+	return out
+}

--- a/pkg/config/compiler_routing_rules_test.go
+++ b/pkg/config/compiler_routing_rules_test.go
@@ -1,15 +1,53 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-// TestValidateRoutingRuleWindowWarnings covers the #1706 commit-time
-// warnings that pair with the applier's fixed next-table / rib-group
-// ip-rule priority windows. The warning fires only when the config
-// exceeds the window the applier can program; at or below the limit it
-// stays silent.
+// mkLeakingInstance builds a config with ONE routing-instance that imports
+// the main table via an interface-routes rib-group and carries n static
+// connected prefixes on its member interface unit. family selects v4 ("inet")
+// or v6 ("inet6") addresses (and the corresponding rib-group field), so the
+// #3876 per-prefix window warn can be exercised on either family.
+func mkLeakingInstance(n int, family string) *Config {
+	cfg := &Config{}
+	addrs := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		if family == "inet6" {
+			addrs = append(addrs, fmt.Sprintf("2001:db8:%x::1/64", i))
+		} else {
+			addrs = append(addrs, fmt.Sprintf("10.%d.%d.1/24", i/256, i%256))
+		}
+	}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: addrs},
+		}},
+	}
+	cfg.RoutingOptions.RibGroups = map[string]*RibGroup{
+		"leak": {Name: "leak", ImportRibs: []string{"inet.0", "inet6.0"}},
+	}
+	ri := &RoutingInstanceConfig{
+		Name:       "dmz-vr",
+		TableID:    101,
+		Interfaces: []string{"ge-0/0/1.0"},
+	}
+	if family == "inet6" {
+		ri.InterfaceRoutesRibGroupV6 = "leak"
+	} else {
+		ri.InterfaceRoutesRibGroup = "leak"
+	}
+	cfg.RoutingInstances = []*RoutingInstanceConfig{ri}
+	return cfg
+}
+
+// TestValidateRoutingRuleWindowWarnings covers the commit-time warnings that
+// pair with the applier's fixed next-table / rib-group ip-rule priority
+// windows. The warning fires only when the config exceeds the window the
+// applier can program; at or below the limit it stays silent. The rib-group
+// window is now PER CONNECTED PREFIX (#3876, 1000-rule window).
 func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
 	mkNextTableRoutes := func(n int) []*StaticRoute {
 		routes := make([]*StaticRoute, n)
@@ -17,13 +55,6 @@ func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
 			routes[i] = &StaticRoute{Destination: "10.0.0.0/8", NextTable: "vr"}
 		}
 		return routes
-	}
-	mkRibGroupInstances := func(n int) []*RoutingInstanceConfig {
-		insts := make([]*RoutingInstanceConfig, n)
-		for i := range insts {
-			insts[i] = &RoutingInstanceConfig{InterfaceRoutesRibGroup: "leak"}
-		}
-		return insts
 	}
 
 	t.Run("next-table at limit is silent", func(t *testing.T) {
@@ -50,30 +81,29 @@ func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
 	})
 
 	t.Run("rib-group at limit is silent", func(t *testing.T) {
-		cfg := &Config{RoutingInstances: mkRibGroupInstances(50)}
+		cfg := mkLeakingInstance(1000, "inet")
 		got := validateRoutingRuleWindowWarnings(cfg)
 		if len(got) != 0 {
-			t.Fatalf("expected no warning at 50 rib-group instances, got %v", got)
+			t.Fatalf("expected no warning at 1000 leaked prefixes, got %v", got)
 		}
 	})
 
 	t.Run("rib-group over limit warns", func(t *testing.T) {
-		cfg := &Config{RoutingInstances: mkRibGroupInstances(51)}
+		cfg := mkLeakingInstance(1001, "inet")
 		got := validateRoutingRuleWindowWarnings(cfg)
 		if len(got) != 1 || !strings.Contains(got[0], "rib-group") {
 			t.Fatalf("expected a rib-group over-limit warning, got %v", got)
 		}
-		if !strings.Contains(got[0], "51") {
-			t.Errorf("warning should report the count 51, got %q", got[0])
+		if !strings.Contains(got[0], "1001") {
+			t.Errorf("warning should report the prefix count 1001, got %q", got[0])
 		}
 	})
 
 	t.Run("instances with no rib-group reference are not counted", func(t *testing.T) {
-		insts := make([]*RoutingInstanceConfig, 60)
-		for i := range insts {
-			insts[i] = &RoutingInstanceConfig{} // no rib-group reference
-		}
-		cfg := &Config{RoutingInstances: insts}
+		// An addressed instance with NO rib-group reference contributes no
+		// leaked prefixes and must not warn.
+		cfg := mkLeakingInstance(1001, "inet")
+		cfg.RoutingInstances[0].InterfaceRoutesRibGroup = ""
 		got := validateRoutingRuleWindowWarnings(cfg)
 		if len(got) != 0 {
 			t.Fatalf("instances without a rib-group reference must not warn, got %v", got)
@@ -81,11 +111,7 @@ func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
 	})
 
 	t.Run("v6-only rib-group reference is counted", func(t *testing.T) {
-		insts := make([]*RoutingInstanceConfig, 51)
-		for i := range insts {
-			insts[i] = &RoutingInstanceConfig{InterfaceRoutesRibGroupV6: "leak6"}
-		}
-		cfg := &Config{RoutingInstances: insts}
+		cfg := mkLeakingInstance(1001, "inet6")
 		got := validateRoutingRuleWindowWarnings(cfg)
 		if len(got) != 1 || !strings.Contains(got[0], "rib-group") {
 			t.Fatalf("expected a rib-group over-limit warning for v6-only refs, got %v", got)
@@ -99,14 +125,10 @@ func TestValidateRoutingRuleWindowWarnings(t *testing.T) {
 // ValidateConfig were dropped, the operator would lose the warning even
 // though the helper-level tests above still pass.
 func TestValidateConfigSurfacesRoutingRuleWindowWarnings(t *testing.T) {
-	cfg := &Config{}
+	cfg := mkLeakingInstance(1001, "inet")
 	for i := 0; i < 101; i++ {
 		cfg.RoutingOptions.StaticRoutes = append(cfg.RoutingOptions.StaticRoutes,
 			&StaticRoute{Destination: "10.0.0.0/8", NextTable: "vr"})
-	}
-	for i := 0; i < 51; i++ {
-		cfg.RoutingInstances = append(cfg.RoutingInstances,
-			&RoutingInstanceConfig{InterfaceRoutesRibGroup: "leak"})
 	}
 
 	warnings := ValidateConfig(cfg)

--- a/pkg/config/compiler_validate_warn.go
+++ b/pkg/config/compiler_validate_warn.go
@@ -786,6 +786,12 @@ func ValidateConfig(cfg *Config) []string {
 	// commit time so the operator sees it before applying.
 	warnings = append(warnings, validateRoutingRuleWindowWarnings(cfg)...)
 
+	// #3876: warn when an interface-routes rib-group import cannot be fully
+	// realized by the Phase-1 per-prefix leak (no enumerable static connected
+	// prefix, or a VRF→VRF import target that Phase 1 does not install) so the
+	// operator sees a fail-loud diagnostic rather than a silent no-op.
+	warnings = append(warnings, validateRibGroupLeakWarnings(cfg)...)
+
 	// #1387: DHCP dynamic-DNS live-backend validation. Increment 2 wired the
 	// live RFC 2136 backend, so the increment-1 "no records are published"
 	// deferred-backend warning is retired. The warnings here flag a config
@@ -1805,28 +1811,110 @@ func validateRoutingRuleWindowWarnings(cfg *Config) []string {
 			nextTableRoutes, nextTableWindow))
 	}
 
-	// rib-group: the applier walks routing-instances and programs two ip
-	// rules (v4+v6) per source table that references an interface-routes
-	// rib-group. Window of 100 priorities fits 50 such tables.
-	const ribGroupTableLimit = 50
-	ribGroupInstances := 0
-	for _, inst := range cfg.RoutingInstances {
-		if inst == nil {
-			continue
-		}
-		if inst.InterfaceRoutesRibGroup != "" || inst.InterfaceRoutesRibGroupV6 != "" {
-			ribGroupInstances++
-		}
+	// rib-group (#3876): the applier now programs one ip rule PER CONNECTED
+	// PREFIX of each source instance whose interface-routes rib-group imports
+	// the main table, into a fixed window of maxRibGroupLeakRules (1000)
+	// priorities that clear() scans. Count the connected prefixes the applier
+	// would leak and warn if they exceed the window (an over-count against
+	// pkg/routing.maxRibGroupLeakRules — kept in lockstep here).
+	const ribGroupLeakLimit = 1000
+	leakPrefixes := 0
+	for _, prefixes := range RibGroupConnectedPrefixes(cfg) {
+		leakPrefixes += len(prefixes)
 	}
-	if ribGroupInstances > ribGroupTableLimit {
+	if leakPrefixes > ribGroupLeakLimit {
 		warnings = append(warnings, fmt.Sprintf(
-			"routing-options: %d routing-instances reference an interface-routes "+
-				"rib-group, but only %d leaking tables can be programmed as ip rules "+
-				"(two priorities each); instances beyond the limit will be ignored at "+
-				"apply time. Reduce the number of rib-group-leaking instances.",
-			ribGroupInstances, ribGroupTableLimit))
+			"routing-options: interface-routes rib-group would leak %d connected "+
+				"prefixes as ip rules, but only %d can be programmed; prefixes beyond "+
+				"the limit will be ignored at apply time. Reduce the number of "+
+				"rib-group-leaked interface prefixes.",
+			leakPrefixes, ribGroupLeakLimit))
 	}
 
+	return warnings
+}
+
+// validateRibGroupLeakWarnings emits commit-time warnings for
+// interface-routes rib-group imports the #3876 Phase-1 per-prefix leak
+// cannot fully realize, so the operator sees a fail-loud diagnostic instead
+// of a silent no-op:
+//
+//   - A source instance whose rib-group imports the main table but has NO
+//     enumerable static connected prefix (DHCP-only / unaddressed member
+//     interfaces): the leak installs no ip rule because there is no static
+//     prefix to enumerate at commit. (Runtime route-copy for dynamically
+//     learned addresses is the deferred Phase-2 mechanism.)
+//   - A rib-group importing a NON-MAIN (VRF→VRF) rib: Phase 1 leaks only into
+//     the main table; a VRF→VRF import target is not yet installed (Phase 2).
+//
+// The strict import-rib reference gate
+// (validateRibGroupImportRibReferencesStrict) is unchanged; these are
+// additional non-fatal WARN diagnostics.
+func validateRibGroupLeakWarnings(cfg *Config) []string {
+	if cfg == nil {
+		return nil
+	}
+	ribGroups := cfg.RoutingOptions.RibGroups
+	if len(ribGroups) == 0 {
+		return nil
+	}
+	definedInstances := make(map[string]bool, len(cfg.RoutingInstances))
+	for _, ri := range cfg.RoutingInstances {
+		if ri != nil && ri.Name != "" {
+			definedInstances[ri.Name] = true
+		}
+	}
+	connected := RibGroupConnectedPrefixes(cfg)
+
+	var warnings []string
+	for _, ri := range cfg.RoutingInstances {
+		if ri == nil || ri.Name == "" {
+			continue
+		}
+		// Classify the union of this instance's v4 + v6 rib-group imports.
+		importsMain := false
+		var vrfTargets []string
+		seenVRF := make(map[string]bool)
+		for _, rgName := range []string{ri.InterfaceRoutesRibGroup, ri.InterfaceRoutesRibGroupV6} {
+			if rgName == "" {
+				continue
+			}
+			rgDef, ok := ribGroups[rgName]
+			if !ok {
+				continue // unknown group — the reference gate/warn covers it
+			}
+			for _, ribName := range rgDef.ImportRibs {
+				switch ribTargetKind(ribName, ri.Name, definedInstances) {
+				case "main":
+					importsMain = true
+				case "vrf":
+					if !seenVRF[ribName] {
+						seenVRF[ribName] = true
+						vrfTargets = append(vrfTargets, ribName)
+					}
+				}
+			}
+		}
+
+		if importsMain && len(connected[ri.Name]) == 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"routing-instance %q: interface-routes rib-group imports the main "+
+					"table but the instance has no enumerable static connected prefix "+
+					"(DHCP-only or unaddressed member interfaces); no leak ip rule is "+
+					"installed. Configure a static interface address to leak, or note "+
+					"that dynamically learned addresses are not leaked (Phase 2).",
+				ri.Name))
+		}
+		if len(vrfTargets) > 0 {
+			sort.Strings(vrfTargets)
+			warnings = append(warnings, fmt.Sprintf(
+				"routing-instance %q: interface-routes rib-group imports non-main "+
+					"rib(s) [%s] (VRF→VRF import); this is not yet installed and takes "+
+					"no effect — only imports into the main table (inet.0/inet6.0) leak "+
+					"interface routes today (Phase 2 deferral).",
+				ri.Name, strings.Join(vrfTargets, ", ")))
+		}
+	}
 	return warnings
 }
 

--- a/pkg/config/ribgroup_leak_warn_3876_test.go
+++ b/pkg/config/ribgroup_leak_warn_3876_test.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// ribGroupLeakConfig builds a config with one routing instance whose
+// interface-routes rib-group imports the ribs named by importRibs. The
+// instance owns one member interface unit carrying the given static
+// addresses (empty = DHCP-only / unaddressed).
+func ribGroupLeakConfig(importRibs, addrs []string) *Config {
+	cfg := &Config{}
+	cfg.Interfaces.Interfaces = map[string]*InterfaceConfig{
+		"ge-0/0/1": {Name: "ge-0/0/1", Units: map[int]*InterfaceUnit{
+			0: {Number: 0, Addresses: addrs},
+		}},
+	}
+	cfg.RoutingOptions.RibGroups = map[string]*RibGroup{
+		"leak": {Name: "leak", ImportRibs: importRibs},
+	}
+	cfg.RoutingInstances = []*RoutingInstanceConfig{
+		{
+			Name:                    "dmz-vr",
+			TableID:                 101,
+			Interfaces:              []string{"ge-0/0/1.0"},
+			InterfaceRoutesRibGroup: "leak",
+		},
+	}
+	return cfg
+}
+
+// TestRibGroupLeakWarnsVRFtoVRF is the #3876 fail-on-revert warn guard: an
+// interface-routes rib-group whose import target is another instance's rib
+// (a VRF→VRF import, not main) must WARN at commit that Phase 1 does not
+// install it — a fail-loud diagnostic rather than a silent no-op.
+//
+// RED-on-revert: dropping validateRibGroupLeakWarnings (or its vrf-target
+// branch) removes the warning.
+func TestRibGroupLeakWarnsVRFtoVRF(t *testing.T) {
+	cfg := ribGroupLeakConfig([]string{"other-vr.inet.0"}, []string{"10.0.30.1/24"})
+	// A second defined instance so other-vr.inet.0 resolves as a real VRF rib.
+	cfg.RoutingInstances = append(cfg.RoutingInstances,
+		&RoutingInstanceConfig{Name: "other-vr", TableID: 102})
+
+	warns := validateRibGroupLeakWarnings(cfg)
+	joined := strings.Join(warns, "\n")
+	if !strings.Contains(joined, "VRF→VRF") || !strings.Contains(joined, "other-vr.inet.0") {
+		t.Fatalf("expected a VRF→VRF import warning naming other-vr.inet.0, got: %q", joined)
+	}
+}
+
+// TestRibGroupLeakWarnsNoEnumerablePrefix is the #3876 fail-on-revert warn
+// guard for a DHCP-only / unaddressed source: a rib-group importing main but
+// with no enumerable static connected prefix installs no ip rule, so the
+// operator must be warned rather than left with a silent no-op.
+func TestRibGroupLeakWarnsNoEnumerablePrefix(t *testing.T) {
+	// Imports main (inet.0) but the member unit carries no static address.
+	cfg := ribGroupLeakConfig([]string{"inet.0"}, nil)
+
+	warns := validateRibGroupLeakWarnings(cfg)
+	joined := strings.Join(warns, "\n")
+	if !strings.Contains(joined, "no enumerable static connected prefix") {
+		t.Fatalf("expected a no-enumerable-prefix warning, got: %q", joined)
+	}
+}
+
+// TestRibGroupLeakNoWarnHappyPath pins that a well-formed import-into-main
+// with a static connected prefix produces NO warning (guards against an
+// over-eager warn that would cry wolf on every valid rib-group).
+func TestRibGroupLeakNoWarnHappyPath(t *testing.T) {
+	cfg := ribGroupLeakConfig([]string{"dmz-vr.inet.0", "inet.0"}, []string{"10.0.30.1/24"})
+	if warns := validateRibGroupLeakWarnings(cfg); len(warns) != 0 {
+		t.Fatalf("expected no rib-group leak warnings for a valid import-into-main, got: %v", warns)
+	}
+}
+
+// TestRibGroupConnectedPrefixes verifies the SSOT prefix derivation: a
+// leaking instance's member-unit static addresses are masked to their
+// network prefixes (host + link-local skipped), matching the userspace FIB.
+func TestRibGroupConnectedPrefixes(t *testing.T) {
+	cfg := ribGroupLeakConfig([]string{"inet.0"}, []string{
+		"10.0.30.1/24",      // → 10.0.30.0/24
+		"2001:db8:30::1/64", // → 2001:db8:30::/64
+		"192.0.2.5/32",      // host route → skipped
+		"fe80::1/64",        // link-local → skipped
+	})
+	got := RibGroupConnectedPrefixes(cfg)["dmz-vr"]
+	want := map[string]bool{"10.0.30.0/24": true, "2001:db8:30::/64": true}
+	if len(got) != len(want) {
+		t.Fatalf("RibGroupConnectedPrefixes = %v, want %v", got, want)
+	}
+	for _, p := range got {
+		if !want[p] {
+			t.Errorf("unexpected leaked prefix %q (host/link-local should be skipped)", p)
+		}
+	}
+}
+
+// TestConnectedNetworkPrefix pins the shared address→network derivation used
+// by both the rib-group leak and the userspace FIB.
+func TestConnectedNetworkPrefix(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantPrefix string
+		wantFamily string
+		wantOK     bool
+	}{
+		{"10.0.30.1/24", "10.0.30.0/24", "inet", true},
+		{"2001:db8:30::1/64", "2001:db8:30::/64", "inet6", true},
+		{"192.0.2.5/32", "", "inet", false},     // host route
+		{"2001:db8::1/128", "", "inet6", false}, // host route
+		{"fe80::1/64", "", "inet6", false},      // link-local
+		{"0.0.0.0/0", "", "inet", false},        // default route
+		{"garbage", "", "", false},              // unparseable
+	}
+	for _, c := range cases {
+		prefix, family, ok := ConnectedNetworkPrefix(c.in)
+		if ok != c.wantOK || prefix != c.wantPrefix {
+			t.Errorf("ConnectedNetworkPrefix(%q) = (%q, %q, %v), want (%q, _, %v)",
+				c.in, prefix, family, ok, c.wantPrefix, c.wantOK)
+		}
+		if c.wantOK && family != c.wantFamily {
+			t.Errorf("ConnectedNetworkPrefix(%q) family = %q, want %q", c.in, family, c.wantFamily)
+		}
+	}
+}

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -160,6 +160,41 @@ type RibGroup struct {
 	ImportRibs []string // import-rib [ rib1 rib2 ... ]
 }
 
+// ConnectedNetworkPrefix converts an interface address in CIDR form
+// (e.g. "10.0.1.1/24" or "2001:db8::1/64") to its masked network prefix
+// ("10.0.1.0/24"), applying the connected-route skip rules shared by the
+// userspace FIB connected-route builder (pkg/dataplane/userspace,
+// connectedPrefixesForInterface) and the rib-group per-prefix leak
+// (pkg/routing, #3876). Both callers derive the SAME prefix set from an
+// address so the ip rules the leak installs match the connected routes the
+// FIB actually carries in the source table.
+//
+// A host address (/32 IPv4, /128 IPv6), a default route (/0), and an IPv6
+// link-local address carry no leakable connected network and return
+// ok=false. family is "inet" or "inet6". Unparseable input returns ok=false.
+func ConnectedNetworkPrefix(cidr string) (prefix, family string, ok bool) {
+	ip, network, err := net.ParseCIDR(strings.TrimSpace(cidr))
+	if err != nil || network == nil {
+		return "", "", false
+	}
+	ones, bits := network.Mask.Size()
+	if ones <= 0 || ones == bits {
+		// Default route (/0) or a host route (/32, /128) — no connected
+		// network prefix to leak.
+		return "", "", false
+	}
+	if ip.To4() == nil {
+		family = "inet6"
+		if ip.IsLinkLocalUnicast() {
+			return "", "inet6", false
+		}
+	} else {
+		family = "inet"
+	}
+	network.IP = ip.Mask(network.Mask)
+	return network.String(), family, true
+}
+
 // NextHopEntry defines a single next-hop for a static route.
 type NextHopEntry struct {
 	Address   string // IP address (e.g. "10.0.1.1" or "fe80::1")

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1131,9 +1131,15 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 		}
 	}
 
-	// 3c. Apply rib-group route leaking rules (ip rule)
+	// 3c. Apply rib-group route leaking rules (ip rule). #3876: the leak is
+	// now per connected prefix (`ip rule to <prefix> lookup <sourceTable>`
+	// BEFORE main) so an imported interface route wins over a main-table
+	// default route. The connected prefixes are derived from the config
+	// addresses on each source instance's member interface units, using the
+	// same derivation the userspace FIB uses for connected routes.
 	if d.routing != nil && len(cfg.RoutingOptions.RibGroups) > 0 {
-		if err := d.routing.ApplyRibGroupRules(cfg.RoutingOptions.RibGroups, cfg.RoutingInstances); err != nil {
+		connectedPrefixes := config.RibGroupConnectedPrefixes(cfg)
+		if err := d.routing.ApplyRibGroupRules(cfg.RoutingOptions.RibGroups, cfg.RoutingInstances, connectedPrefixes); err != nil {
 			slog.Warn("failed to apply rib-group rules", "err", err)
 		}
 	}

--- a/pkg/dataplane/userspace/routes.go
+++ b/pkg/dataplane/userspace/routes.go
@@ -157,6 +157,13 @@ func buildRouteSnapshots(cfg *config.Config, interfaces []InterfaceSnapshot, ove
 			return nil, fmt.Errorf("route snapshot: list ip-rules for family %d: %w", family, err)
 		}
 		for _, rule := range rules {
+			// A Dst-less rule (`from all lookup <table>`) cannot be
+			// represented as a per-prefix NextTable leak (it would mean
+			// "leak the whole table"), so it is skipped here. The rib-group
+			// import leak installs per-prefix `to <prefix> lookup
+			// <sourceTable>` rules (pkg/routing, #3876) that DO carry a Dst,
+			// so they are auto-captured by this loop as NextTable leaks into
+			// main — no change to this skip is needed for the fix.
 			if rule.Dst == nil || rule.Table <= 0 {
 				continue
 			}
@@ -349,23 +356,19 @@ func connectedPrefixesForInterface(iface InterfaceSnapshot) ([]string, []string)
 		if addr.Scope != 0 && addr.Scope != int(netlink.SCOPE_UNIVERSE) {
 			continue
 		}
-		ip, network, err := net.ParseCIDR(addr.Address)
-		if err != nil || network == nil {
+		// Mask-to-network + skip-host + skip-link-local is factored into
+		// config.ConnectedNetworkPrefix so the rib-group per-prefix leak
+		// (pkg/routing, #3876) derives the identical connected-prefix set
+		// from the config addresses and the ip rules it installs match the
+		// connected routes this FIB carries in the source table.
+		prefix, family, ok := config.ConnectedNetworkPrefix(addr.Address)
+		if !ok {
 			continue
 		}
-		ones, bits := network.Mask.Size()
-		if ones <= 0 || ones == bits {
-			continue
-		}
-		network.IP = ip.Mask(network.Mask)
-		prefix := network.String()
-		switch addr.Family {
+		switch family {
 		case "inet":
 			v4 = append(v4, prefix)
 		case "inet6":
-			if ip.IsLinkLocalUnicast() {
-				continue
-			}
 			v6 = append(v6, prefix)
 		}
 	}

--- a/pkg/dataplane/userspace/routes_ribgroup_leak_3876_test.go
+++ b/pkg/dataplane/userspace/routes_ribgroup_leak_3876_test.go
@@ -1,0 +1,112 @@
+package userspace
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/vishvananda/netlink"
+)
+
+// mustCIDR parses a CIDR and returns the *net.IPNet, failing the test on
+// error. Used to build the Dst of an injected ip rule.
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil || n == nil {
+		t.Fatalf("ParseCIDR(%q): %v", s, err)
+	}
+	return n
+}
+
+// TestBuildRouteSnapshotsCapturesRibGroupPerPrefixLeak is the #3876
+// userspace-FIB half of the fix. The rib-group import leak now installs
+// per-prefix `ip rule to <connected-prefix> lookup <sourceTable>` rules (see
+// pkg/routing). Those rules carry a Dst, so the snapshot builder's existing
+// (rule.Dst != nil + table→instance) loop must auto-capture them as a
+// NextTable leak into the main table — putting the leak into the userspace
+// FIB, not just the kernel FIB.
+//
+// RED-on-revert: with the pre-#3876 `from all lookup <sourceTable>` blanket
+// rule (Dst==nil) the loop skips it (routes.go), so no NextTable snapshot is
+// produced and the leak is absent from the userspace FIB.
+func TestBuildRouteSnapshotsCapturesRibGroupPerPrefixLeak(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+
+	// Per-prefix leak rules into the dmz-vr table (101): one v4, one v6.
+	ruleListFn = func(family int) ([]netlink.Rule, error) {
+		switch family {
+		case syscall.AF_INET:
+			return []netlink.Rule{{Dst: mustCIDR(t, "10.0.30.0/24"), Table: 101, Priority: 30000}}, nil
+		case syscall.AF_INET6:
+			return []netlink.Rule{{Dst: mustCIDR(t, "2001:db8:30::/64"), Table: 101, Priority: 30001}}, nil
+		}
+		return nil, nil
+	}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+
+	findNextTable := func(family, dest, nextTable string) bool {
+		for _, r := range routes {
+			if r.Table == "inet.0" && family == "inet" &&
+				r.Destination == dest && r.NextTable == nextTable {
+				return true
+			}
+			if r.Table == "inet6.0" && family == "inet6" &&
+				r.Destination == dest && r.NextTable == nextTable {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !findNextTable("inet", "10.0.30.0/24", "dmz-vr.inet.0") {
+		t.Errorf("expected an IPv4 NextTable leak into inet.0 for 10.0.30.0/24 → dmz-vr.inet.0, routes=%+v", routes)
+	}
+	if !findNextTable("inet6", "2001:db8:30::/64", "dmz-vr.inet6.0") {
+		t.Errorf("expected an IPv6 NextTable leak into inet6.0 for 2001:db8:30::/64 → dmz-vr.inet6.0, routes=%+v", routes)
+	}
+}
+
+// TestBuildRouteSnapshotsSkipsDstlessRibGroupRule pins that a legacy
+// `from all lookup <table>` (Dst==nil) rule is NOT turned into a NextTable
+// leak — a whole-table fall-through cannot be represented as a per-prefix
+// NextTable route, so it is correctly skipped (routes.go Dst==nil guard). The
+// #3876 fix keeps that skip and relies on the per-prefix rules (which DO carry
+// a Dst) instead.
+func TestBuildRouteSnapshotsSkipsDstlessRibGroupRule(t *testing.T) {
+	orig := ruleListFn
+	t.Cleanup(func() { ruleListFn = orig })
+	ruleListFn = func(family int) ([]netlink.Rule, error) {
+		if family == syscall.AF_INET {
+			// Legacy blanket rule: no Dst.
+			return []netlink.Rule{{Table: 101, Priority: 33000}}, nil
+		}
+		return nil, nil
+	}
+
+	cfg := &config.Config{}
+	cfg.RoutingInstances = []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101},
+	}
+
+	routes, err := buildRouteSnapshots(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRouteSnapshots: %v", err)
+	}
+	for _, r := range routes {
+		if r.NextTable == "dmz-vr.inet.0" {
+			t.Fatalf("a Dst-less blanket rule must NOT produce a NextTable leak, got %+v", r)
+		}
+	}
+}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -173,8 +173,12 @@ func (m *Manager) ApplyNextTableRules(routes []*config.StaticRoute, instances []
 }
 
 // ApplyRibGroupRules creates ip rules implementing rib-group route leaking.
-func (m *Manager) ApplyRibGroupRules(ribGroups map[string]*config.RibGroup, instances []*config.RoutingInstanceConfig) error {
-	return m.ribGroup.Apply(ribGroups, instances)
+// connectedPrefixes is keyed by routing-instance name and holds each source
+// instance's connected network prefixes (v4+v6 mixed); the per-prefix leak
+// rules (#3876) are installed for the prefixes of instances whose
+// interface-routes rib-group imports the main table.
+func (m *Manager) ApplyRibGroupRules(ribGroups map[string]*config.RibGroup, instances []*config.RoutingInstanceConfig, connectedPrefixes map[string][]string) error {
+	return m.ribGroup.Apply(ribGroups, instances, connectedPrefixes)
 }
 
 // ApplyPBRRules creates ip rules implementing policy-based routing.

--- a/pkg/routing/rules.go
+++ b/pkg/routing/rules.go
@@ -29,10 +29,38 @@ type ruleOps interface {
 // Lower values = higher priority. We use 100-199 range for next-table rules.
 const nextTableRulePriority = 100
 
-// ribGroupRulePriority is the base priority for rib-group ip rules.
-// Must be AFTER the main table (32766) so VRF routes supplement rather
-// than override main table routing. We use 33000-33099 range.
+// ribGroupRulePriority is the LEGACY base priority for the pre-#3876
+// rib-group `from all lookup <sourceTable>` blanket rules. It sat AFTER the
+// main table (32766), so any main-table default route was matched first and
+// the rule was never consulted — the rib-group import leak was a silent
+// no-op in every deployment carrying a default route (#3876). It is retained
+// ONLY so clear() removes any stale rule an in-place upgrade left behind; no
+// new rule is programmed in this window.
 const ribGroupRulePriority = 33000
+
+// ribGroupLeakRulePriority is the base priority for the #3876 rib-group
+// per-prefix import leak rules: `ip rule to <connected-prefix> lookup
+// <sourceTable>`. It sits BEFORE the main table (32766) and before PBR
+// (31000-31999) so a specific imported connected prefix wins over a
+// main-table default route — the fix for the #3876 shadow-by-default no-op.
+// We use the 30000-30999 range (maxRibGroupLeakRules priorities).
+const ribGroupLeakRulePriority = 30000
+
+// maxRibGroupLeakRules bounds the number of per-prefix rib-group leak ip
+// rules the applier installs, matching the ribGroupLeakRulePriority window
+// clear() scans ([ribGroupLeakRulePriority, ribGroupLeakRulePriority+1000)).
+// A larger connected-prefix set is truncated and reported as a degraded
+// apply (mirroring maxPBRRules) rather than programming a rule the clear()
+// pass could not later remove. ValidateConfig emits a commit-time warning
+// before this cap is reached.
+const maxRibGroupLeakRules = 1000
+
+// mainTableID is the Linux main routing table (RT_TABLE_MAIN). The #3876
+// Phase-1 leak targets ONLY main: an interface-routes rib-group whose
+// import-rib list resolves to this table has its source instance's
+// connected prefixes leaked into main. Non-main (VRF→VRF) import targets are
+// deferred to Phase 2 and warned at commit.
+const mainTableID = 254
 
 // pbrRulePriority is the base priority for policy-based routing ip rules.
 // BEFORE the main table (32766) so the kernel also honors PBR for XDP_PASS'd
@@ -179,19 +207,36 @@ type ribGroupManager struct {
 
 // Apply creates Linux policy routing rules (ip rule) for rib-group route
 // leaking. When a routing instance has interface-routes with a rib-group
-// reference, the instance's routes are leaked to other tables listed in
-// the rib-group's import-rib list.
+// that imports the main table, the instance's CONNECTED (interface) routes
+// are leaked into main so main-table lookups reach them.
+//
+// #3876: this is done PER CONNECTED PREFIX with a rule that sits BEFORE the
+// main table (priority < 32766), so a specific imported prefix wins over a
+// main-table default route:
+//
+//	ip rule to <connected-prefix> lookup <sourceTable> pref 30000
+//
+// This replaces the pre-#3876 `from all lookup <sourceTable> pref 33000`
+// blanket rule, which (a) sat AFTER main so any default route shadowed it —
+// making the leak a silent no-op — and (b) leaked the WHOLE source table as
+// a catch-all fall-through rather than just the interface routes Junos
+// leaks. The per-prefix rules also carry a Dst, so the userspace FIB
+// snapshot builder auto-captures them as NextTable leaks into main (see
+// pkg/dataplane/userspace/routes.go) — the pre-#3876 Dst-less rule was
+// skipped there too, so the leak was absent from BOTH FIBs.
+//
+// connectedPrefixes is keyed by routing-instance name and holds that
+// instance's connected network prefixes (v4 and v6 mixed), derived from the
+// config addresses on its member interface units via
+// config.ConnectedNetworkPrefix — the SAME derivation the userspace FIB uses
+// for connected routes, so the leaked prefix set matches the connected
+// routes in the source table.
 //
 // Both IPv4 (InterfaceRoutesRibGroup) and IPv6 (InterfaceRoutesRibGroupV6)
-// rib-groups are handled. For each source table that needs leaking, both
-// IPv4 and IPv6 ip rules are created.
-//
-// For example, if dmz-vr (table 101) has interface-routes rib-group "dmz-leak",
-// and dmz-leak has import-rib [ dmz-vr.inet.0 inet.0 ], then an ip rule is
-// created to make table 101 visible to main table lookups:
-//
-//	ip rule add from all lookup 101 pref 33000
-func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instances []*config.RoutingInstanceConfig) error {
+// rib-groups are handled. Non-main (VRF→VRF) import targets are deferred to
+// Phase 2 and warned at commit (pkg/config); this applier installs nothing
+// for them.
+func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instances []*config.RoutingInstanceConfig, connectedPrefixes map[string][]string) error {
 	// Clean up old rib-group rules. As with next-table, a failed per-family
 	// list does not abort the apply; the clear error is captured and
 	// returned at the end (or at the early-return below) so the caller can
@@ -224,107 +269,96 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 		tableIDs[inst.Name] = inst.TableID
 	}
 
-	// Track which source tables we've already added rules for
-	// (avoid duplicate rules if multiple rib-groups reference the same table)
+	// Track which source tables we've already added rules for (avoid
+	// duplicate rules if two instances share a table ID).
 	leakedTables := make(map[int]bool)
 
-	prio := ribGroupRulePriority
+	prio := ribGroupLeakRulePriority
+	capped := false
 	for _, inst := range instances {
-		// Collect all rib-group names referenced by this instance (inet + inet6)
-		rgNames := []string{inst.InterfaceRoutesRibGroup, inst.InterfaceRoutesRibGroupV6}
-
-		sourceTable := inst.TableID
-		needsLeak := false
-		for _, rgName := range rgNames {
-			if rgName == "" {
-				continue
-			}
-			rgDef, ok := ribGroups[rgName]
-			if !ok {
-				slog.Warn("interface-routes references unknown rib-group",
-					"instance", inst.Name, "rib-group", rgName)
-				continue
-			}
-			for _, ribName := range rgDef.ImportRibs {
-				targetTable, ok := resolveRibTable(ribName, tableIDs)
-				if !ok {
-					// Unknown / undefined rib name: do NOT treat it as
-					// a (non-source) target table — that would set
-					// needsLeak and install an `ip rule from all lookup
-					// <sourceTable>` for a rib that does not exist,
-					// silently leaking the source table into the main
-					// lookup (#2226). Skip it; warn for visibility. The
-					// strict commit-time gate normally rejects this
-					// before apply, but a tolerantly-loaded / peer-synced
-					// config can still reach here.
-					slog.Warn("rib-group import-rib references unknown rib; skipping (not leaking)",
-						"instance", inst.Name, "rib-group", rgName, "import-rib", ribName)
-					continue
-				}
-				if targetTable != sourceTable {
-					needsLeak = true
-					break
-				}
-			}
-			if needsLeak {
-				break
-			}
+		if capped {
+			break
 		}
-		if !needsLeak {
+		sourceTable := inst.TableID
+
+		// Phase 1 leaks ONLY into main. A rib-group whose import-ribs resolve
+		// only to non-main tables (VRF→VRF) installs nothing here and is
+		// warned at commit (Phase 2 deferral). Family gating: the v4
+		// rib-group leaks v4 connected prefixes, the v6 rib-group leaks v6.
+		leakV4 := ribGroupLeaksIntoMain(inst.InterfaceRoutesRibGroup, ribGroups, tableIDs, inst.Name)
+		leakV6 := ribGroupLeaksIntoMain(inst.InterfaceRoutesRibGroupV6, ribGroups, tableIDs, inst.Name)
+		if !leakV4 && !leakV6 {
 			continue
 		}
-
 		if leakedTables[sourceTable] {
 			continue
 		}
-
-		// Each leaked table consumes TWO priorities (IPv4 then IPv6).
-		// clear() only scans [ribGroupRulePriority, ribGroupRulePriority+100),
-		// so a pair that would place the IPv6 rule (prio+1) at or beyond the
-		// upper bound must be rejected as a unit — otherwise it leaks
-		// permanently across applies. Stop before marking the table leaked
-		// so a capped table is not recorded as done. ValidateConfig emits a
-		// commit-time warning before this point is ever reached.
-		if prio+1 >= ribGroupRulePriority+100 {
-			slog.Warn("rib-group rule limit reached; ignoring further leaking tables",
-				"limit", 100, "instance", inst.Name, "table", sourceTable)
-			break
-		}
 		leakedTables[sourceTable] = true
 
-		// Add IPv4 rule
-		rule := netlink.NewRule()
-		rule.Table = sourceTable
-		rule.Priority = prio
-		rule.Family = unix.AF_INET
-
-		if err := rg.ops.RuleAdd(rule); err != nil {
-			errs = append(errs, fmt.Errorf(
-				"add rib-group IPv4 rule instance %s table %d: %w",
-				inst.Name, sourceTable, err))
-		} else {
-			slog.Info("rib-group rule added",
-				"instance", inst.Name, "table", sourceTable,
-				"family", "inet", "pref", prio)
+		v4, v6 := splitConnectedPrefixesByFamily(connectedPrefixes[inst.Name])
+		var toInstall []struct {
+			prefix string
+			family int
 		}
-		prio++
-
-		// Add IPv6 rule
-		rule6 := netlink.NewRule()
-		rule6.Table = sourceTable
-		rule6.Priority = prio
-		rule6.Family = unix.AF_INET6
-
-		if err := rg.ops.RuleAdd(rule6); err != nil {
-			errs = append(errs, fmt.Errorf(
-				"add rib-group IPv6 rule instance %s table %d: %w",
-				inst.Name, sourceTable, err))
-		} else {
-			slog.Info("rib-group rule added",
-				"instance", inst.Name, "table", sourceTable,
-				"family", "inet6", "pref", prio)
+		if leakV4 {
+			for _, p := range v4 {
+				toInstall = append(toInstall, struct {
+					prefix string
+					family int
+				}{p, unix.AF_INET})
+			}
 		}
-		prio++
+		if leakV6 {
+			for _, p := range v6 {
+				toInstall = append(toInstall, struct {
+					prefix string
+					family int
+				}{p, unix.AF_INET6})
+			}
+		}
+
+		for _, lr := range toInstall {
+			// Hard-cap at the priority window clear() scans. A rule at or
+			// beyond the upper bound would never be removed on a later apply
+			// and would leak permanently. ValidateConfig warns before this
+			// point is reached; mirror the maxPBRRules/next-table caps.
+			if prio >= ribGroupLeakRulePriority+maxRibGroupLeakRules {
+				errs = append(errs, fmt.Errorf(
+					"rib-group leak rule limit (%d) reached; connected prefixes beyond "+
+						"the limit are not leaked — reduce the number of interface-routes "+
+						"rib-group prefixes", maxRibGroupLeakRules))
+				capped = true
+				break
+			}
+			_, dst, err := net.ParseCIDR(lr.prefix)
+			if err != nil || dst == nil {
+				errs = append(errs, fmt.Errorf(
+					"rib-group leak: parse connected prefix %q instance %s: %w",
+					lr.prefix, inst.Name, err))
+				continue
+			}
+			rule := netlink.NewRule()
+			rule.Dst = dst
+			rule.Table = sourceTable
+			rule.Priority = prio
+			rule.Family = lr.family
+
+			familyStr := "inet"
+			if lr.family == unix.AF_INET6 {
+				familyStr = "inet6"
+			}
+			if err := rg.ops.RuleAdd(rule); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"add rib-group leak rule prefix %s instance %s table %d family %s: %w",
+					lr.prefix, inst.Name, sourceTable, familyStr, err))
+				prio++
+				continue
+			}
+			slog.Info("rib-group leak rule added",
+				"instance", inst.Name, "prefix", lr.prefix,
+				"table", sourceTable, "family", familyStr, "pref", prio)
+			prio++
+		}
 	}
 	// Desired rules are re-added; surface any clear/add failure so a dropped
 	// leak rule (or the orphaned-rule window) is observable rather than
@@ -332,8 +366,61 @@ func (rg *ribGroupManager) Apply(ribGroups map[string]*config.RibGroup, instance
 	return errors.Join(errs...)
 }
 
-// clear removes all ip rules in the rib-group priority range. Also
-// cleans up legacy rules from the old 200-299 range.
+// ribGroupLeaksIntoMain reports whether the named interface-routes rib-group
+// imports the main table — the #3876 Phase-1 target for per-prefix connected-
+// route leaking. It returns false for an empty name, an undefined group, or a
+// group whose import-ribs resolve only to non-main tables (a VRF→VRF import,
+// deferred to Phase 2 and warned at commit). Unresolvable import-ribs are
+// skipped (never treated as a main-table hit) — the #2226 fail-closed guard.
+func ribGroupLeaksIntoMain(rgName string, ribGroups map[string]*config.RibGroup, tableIDs map[string]int, instName string) bool {
+	if rgName == "" {
+		return false
+	}
+	rgDef, ok := ribGroups[rgName]
+	if !ok {
+		slog.Warn("interface-routes references unknown rib-group",
+			"instance", instName, "rib-group", rgName)
+		return false
+	}
+	for _, ribName := range rgDef.ImportRibs {
+		targetTable, ok := resolveRibTable(ribName, tableIDs)
+		if !ok {
+			slog.Warn("rib-group import-rib references unknown rib; skipping (not leaking)",
+				"instance", instName, "rib-group", rgName, "import-rib", ribName)
+			continue
+		}
+		if targetTable == mainTableID {
+			return true
+		}
+	}
+	return false
+}
+
+// splitConnectedPrefixesByFamily partitions a mixed connected-prefix list
+// (as carried in ApplyRibGroupRules' connectedPrefixes map) into v4 and v6
+// by literal ':' presence — the same family test the userspace route
+// snapshot uses.
+func splitConnectedPrefixesByFamily(prefixes []string) (v4, v6 []string) {
+	for _, p := range prefixes {
+		if strings.Contains(p, ":") {
+			v6 = append(v6, p)
+		} else {
+			v4 = append(v4, p)
+		}
+	}
+	return v4, v6
+}
+
+// clear removes all ip rules in the rib-group priority ranges. It scans
+// THREE windows so an in-place binary upgrade removes stale rules from every
+// generation of this reconciler:
+//   - [ribGroupLeakRulePriority, +maxRibGroupLeakRules): the current #3876
+//     per-prefix leak window (30000-30999).
+//   - [ribGroupRulePriority, +100): the pre-#3876 `from all lookup <table>`
+//     blanket window (33000-33099). Removing these on reconcile is what
+//     prevents an upgrade from leaving a shadowed-by-default blanket rule
+//     behind alongside the new per-prefix rules.
+//   - [200, 300): the original legacy window.
 //
 // Per-family RuleList dump failures are aggregated and returned rather
 // than swallowed; see the rationale on nextTableManager.clear (#2273).
@@ -346,9 +433,10 @@ func (rg *ribGroupManager) clear() error {
 			continue
 		}
 		for _, r := range rules {
-			inCurrent := r.Priority >= ribGroupRulePriority && r.Priority < ribGroupRulePriority+100
+			inCurrent := r.Priority >= ribGroupLeakRulePriority && r.Priority < ribGroupLeakRulePriority+maxRibGroupLeakRules
+			inOldBlanket := r.Priority >= ribGroupRulePriority && r.Priority < ribGroupRulePriority+100
 			inLegacy := r.Priority >= 200 && r.Priority < 300
-			if inCurrent || inLegacy {
+			if inCurrent || inOldBlanket || inLegacy {
 				if err := rg.ops.RuleDel(&r); err != nil {
 					slog.Debug("failed to delete stale rib-group rule",
 						"priority", r.Priority, "err", err)
@@ -1124,7 +1212,7 @@ func dscpToTOS(dscp string) uint8 {
 // that reaches apply via the tolerant load / peer-sync path.
 func resolveRibTable(ribName string, tableIDs map[string]int) (int, bool) {
 	if ribName == "inet.0" || ribName == "inet6.0" {
-		return 254, true // main table
+		return mainTableID, true // main table
 	}
 	// Parse "<instance>.inet.0" or "<instance>.inet6.0" with an EXACT family
 	// suffix — a loose ".inet" substring match would accept malformed names

--- a/pkg/routing/rules_test.go
+++ b/pkg/routing/rules_test.go
@@ -129,11 +129,26 @@ func (f *fakeRuleOps) hasTable(family, table int) bool {
 	return false
 }
 
+// findDstRule returns the first rule in the family whose table and masked
+// destination prefix match — the #3876 per-prefix leak rule shape.
+func (f *fakeRuleOps) findDstRule(family, table int, dst string) (netlink.Rule, bool) {
+	for _, r := range f.rules[family] {
+		if r.Table == table && r.Dst != nil && r.Dst.String() == dst {
+			return r, true
+		}
+	}
+	return netlink.Rule{}, false
+}
+
 // TestRibGroupRulesApply_Fake exercises ribGroupManager over a fake
-// ruleOps, asserting the leak rules are programmed for the source table
-// — the exact ip-rule-creation path the old test suite could not reach
-// without netlink. Constructs the domain manager directly, NOT the whole
-// routing.Manager.
+// ruleOps, asserting the #3876 PER-PREFIX leak rules are programmed for the
+// source table. Each rule must carry a Dst (the connected prefix) and sit at
+// a priority BEFORE the main table (< 32766) so a specific imported prefix
+// wins over a main-table default route.
+//
+// RED-on-revert: reverting to the pre-#3876 `from all lookup <sourceTable>
+// pref 33000` blanket rule makes this fail — the rule carries no Dst
+// (findDstRule misses) and sits at 33000 > 32766 (shadowed by default).
 func TestRibGroupRulesApply_Fake(t *testing.T) {
 	ops := newFakeRuleOps()
 	rg := &ribGroupManager{ops: ops}
@@ -150,20 +165,40 @@ func TestRibGroupRulesApply_Fake(t *testing.T) {
 	}
 	instances := []*config.RoutingInstanceConfig{
 		{Name: "tunnel-vr", TableID: 100, InterfaceRoutesRibGroup: "self-only"},
-		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "dmz-leak"},
+		{Name: "dmz-vr", TableID: 101,
+			InterfaceRoutesRibGroup:   "dmz-leak",
+			InterfaceRoutesRibGroupV6: "dmz-leak"},
+	}
+	connected := map[string][]string{
+		"dmz-vr": {"10.0.30.0/24", "2001:db8:30::/64"},
+		// tunnel-vr present but must not leak (self-only imports no main rib).
+		"tunnel-vr": {"10.0.99.0/24"},
 	}
 
-	if err := rg.Apply(ribGroups, instances); err != nil {
+	if err := rg.Apply(ribGroups, instances, connected); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 
-	// dmz-vr (table 101) leaks → one IPv4 + one IPv6 rule for table 101.
-	if !ops.hasTable(unix.AF_INET, 101) {
-		t.Errorf("expected IPv4 leak rule for table 101, rules=%v", ops.rules[unix.AF_INET])
+	// dmz-vr (table 101) leaks its connected prefixes into main → one
+	// per-prefix rule per family, each with a Dst, each BEFORE main.
+	v4, ok := ops.findDstRule(unix.AF_INET, 101, "10.0.30.0/24")
+	if !ok {
+		t.Fatalf("expected IPv4 per-prefix leak rule to 10.0.30.0/24 table 101, rules=%v", ops.rules[unix.AF_INET])
 	}
-	if !ops.hasTable(unix.AF_INET6, 101) {
-		t.Errorf("expected IPv6 leak rule for table 101, rules=%v", ops.rules[unix.AF_INET6])
+	if v4.Priority >= 32766 {
+		t.Errorf("IPv4 leak rule pref %d must be BEFORE main (32766) so it wins over a default route (#3876)", v4.Priority)
 	}
+	if v4.Priority < ribGroupLeakRulePriority || v4.Priority >= ribGroupLeakRulePriority+maxRibGroupLeakRules {
+		t.Errorf("IPv4 leak rule pref %d outside the #3876 window [%d,%d)", v4.Priority, ribGroupLeakRulePriority, ribGroupLeakRulePriority+maxRibGroupLeakRules)
+	}
+	v6, ok := ops.findDstRule(unix.AF_INET6, 101, "2001:db8:30::/64")
+	if !ok {
+		t.Fatalf("expected IPv6 per-prefix leak rule to 2001:db8:30::/64 table 101, rules=%v", ops.rules[unix.AF_INET6])
+	}
+	if v6.Priority >= 32766 {
+		t.Errorf("IPv6 leak rule pref %d must be BEFORE main (32766)", v6.Priority)
+	}
+
 	// tunnel-vr (self-only) must NOT produce a leak rule for table 100.
 	if ops.hasTable(unix.AF_INET, 100) {
 		t.Errorf("self-only should not leak table 100, rules=%v", ops.rules[unix.AF_INET])
@@ -175,7 +210,7 @@ func TestRibGroupRulesApply_Fake(t *testing.T) {
 	// Re-applying must clear the prior rules first (clear-then-add), so
 	// the rule count stays stable rather than doubling.
 	prevAdds := ops.adds
-	if err := rg.Apply(ribGroups, instances); err != nil {
+	if err := rg.Apply(ribGroups, instances, connected); err != nil {
 		t.Fatalf("Apply (second): %v", err)
 	}
 	if got := ops.count(unix.AF_INET); got != 1 {
@@ -186,6 +221,49 @@ func TestRibGroupRulesApply_Fake(t *testing.T) {
 	}
 	if ops.adds <= prevAdds {
 		t.Error("expected re-apply to re-add rules")
+	}
+}
+
+// TestRibGroupUpgradeCleanupRemovesLegacyBlanket is the #3876 upgrade-cleanup
+// guard. A pre-#3876 binary left an `ip rule from all lookup <sourceTable>
+// pref 33000` blanket rule in the kernel. On the first apply after upgrade,
+// clear() MUST remove that stale rule (its window is scanned) so the box is
+// not left with the broken blanket rule alongside the new per-prefix rules.
+//
+// RED-on-revert: dropping the [33000,33100) (old-blanket) window from clear()
+// leaves the seeded rule behind.
+func TestRibGroupUpgradeCleanupRemovesLegacyBlanket(t *testing.T) {
+	ops := newFakeRuleOps()
+	// Seed a stale pre-#3876 blanket rule (from all lookup 101 pref 33000).
+	seedRule(ops, unix.AF_INET, ribGroupRulePriority, 101)
+	seedRule(ops, unix.AF_INET6, ribGroupRulePriority, 101)
+	// And an even older legacy-window rule (pref 200).
+	seedRule(ops, unix.AF_INET, 200, 101)
+
+	rg := &ribGroupManager{ops: ops}
+	ribGroups := map[string]*config.RibGroup{
+		"dmz-leak": {Name: "dmz-leak", ImportRibs: []string{"inet.0"}},
+	}
+	instances := []*config.RoutingInstanceConfig{
+		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "dmz-leak"},
+	}
+	connected := map[string][]string{"dmz-vr": {"10.0.30.0/24"}}
+
+	if err := rg.Apply(ribGroups, instances, connected); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// The stale pref-33000 blanket rules and the pref-200 legacy rule must be gone.
+	if hasPriority(ops, unix.AF_INET, ribGroupRulePriority) || hasPriority(ops, unix.AF_INET6, ribGroupRulePriority) {
+		t.Errorf("upgrade cleanup must remove the stale pref-%d blanket rules, rules v4=%v v6=%v",
+			ribGroupRulePriority, ops.rules[unix.AF_INET], ops.rules[unix.AF_INET6])
+	}
+	if hasPriority(ops, unix.AF_INET, 200) {
+		t.Errorf("upgrade cleanup must remove the legacy pref-200 rule, rules=%v", ops.rules[unix.AF_INET])
+	}
+	// The new per-prefix rule must be installed in the #3876 window.
+	if _, ok := ops.findDstRule(unix.AF_INET, 101, "10.0.30.0/24"); !ok {
+		t.Errorf("expected the new per-prefix leak rule after upgrade, rules=%v", ops.rules[unix.AF_INET])
 	}
 }
 
@@ -216,8 +294,11 @@ func TestRibGroupRulesApply_UnknownRibNoLeak(t *testing.T) {
 	instances := []*config.RoutingInstanceConfig{
 		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "typo-leak"},
 	}
+	// Even WITH connected prefixes available, an all-unknown rib-group must
+	// leak nothing (it imports no main rib → leakV4/leakV6 stay false).
+	connected := map[string][]string{"dmz-vr": {"10.0.30.0/24", "2001:db8:30::/64"}}
 
-	if err := rg.Apply(ribGroups, instances); err != nil {
+	if err := rg.Apply(ribGroups, instances, connected); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
 
@@ -257,16 +338,24 @@ func TestRibGroupRulesApply_DefinedRibStillLeaks(t *testing.T) {
 	}
 	instances := []*config.RoutingInstanceConfig{
 		{Name: "tunnel-vr", TableID: 100},
-		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "dmz-leak"},
+		{Name: "dmz-vr", TableID: 101,
+			InterfaceRoutesRibGroup:   "dmz-leak",
+			InterfaceRoutesRibGroupV6: "dmz-leak"},
+	}
+	connected := map[string][]string{
+		"dmz-vr": {"10.0.30.0/24", "2001:db8:30::/64"},
 	}
 
-	if err := rg.Apply(ribGroups, instances); err != nil {
+	if err := rg.Apply(ribGroups, instances, connected); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if !ops.hasTable(unix.AF_INET, 101) {
+	// The rib-group imports main (inet.0), so the per-prefix leak fires even
+	// though it ALSO names a VRF→VRF target (tunnel-vr.inet.0) that Phase 1
+	// does not install.
+	if _, ok := ops.findDstRule(unix.AF_INET, 101, "10.0.30.0/24"); !ok {
 		t.Errorf("defined import-rib must still leak table 101 (IPv4), rules=%v", ops.rules[unix.AF_INET])
 	}
-	if !ops.hasTable(unix.AF_INET6, 101) {
+	if _, ok := ops.findDstRule(unix.AF_INET6, 101, "2001:db8:30::/64"); !ok {
 		t.Errorf("defined import-rib must still leak table 101 (IPv6), rules=%v", ops.rules[unix.AF_INET6])
 	}
 }
@@ -283,17 +372,23 @@ func TestRibGroupRulesApply_DefinedRibStillLeaks(t *testing.T) {
 // makes every subtest go RED (Apply returns nil).
 func TestRibGroupApplyAggregatesAddErrors(t *testing.T) {
 	ribGroups := map[string]*config.RibGroup{
-		"dmz-leak": {Name: "dmz-leak", ImportRibs: []string{"inet.0"}}, // main 254 != source
+		"dmz-leak": {Name: "dmz-leak", ImportRibs: []string{"inet.0"}}, // imports main
 	}
 	instances := []*config.RoutingInstanceConfig{
-		{Name: "dmz-vr", TableID: 101, InterfaceRoutesRibGroup: "dmz-leak"},
+		{Name: "dmz-vr", TableID: 101,
+			InterfaceRoutesRibGroup:   "dmz-leak",
+			InterfaceRoutesRibGroupV6: "dmz-leak"},
+	}
+	// One v4 + one v6 connected prefix → one v4 leak rule + one v6 leak rule.
+	connected := map[string][]string{
+		"dmz-vr": {"10.0.30.0/24", "2001:db8:30::/64"},
 	}
 
 	t.Run("v4-only", func(t *testing.T) {
 		ops := newFakeRuleOps()
 		ops.failAdd(unix.AF_INET, errors.New("netlink EPERM on v4"))
 		rg := &ribGroupManager{ops: ops}
-		if err := rg.Apply(ribGroups, instances); err == nil {
+		if err := rg.Apply(ribGroups, instances, connected); err == nil {
 			t.Fatal("Apply must return non-nil when the v4 leak rule fails (#3731)")
 		}
 		if ops.hasTable(unix.AF_INET, 101) {
@@ -308,7 +403,7 @@ func TestRibGroupApplyAggregatesAddErrors(t *testing.T) {
 		ops := newFakeRuleOps()
 		ops.failAdd(unix.AF_INET6, errors.New("netlink EPERM on v6"))
 		rg := &ribGroupManager{ops: ops}
-		if err := rg.Apply(ribGroups, instances); err == nil {
+		if err := rg.Apply(ribGroups, instances, connected); err == nil {
 			t.Fatal("Apply must return non-nil when the v6 leak rule fails (#3731)")
 		}
 		if !ops.hasTable(unix.AF_INET, 101) {
@@ -323,7 +418,7 @@ func TestRibGroupApplyAggregatesAddErrors(t *testing.T) {
 		ops := newFakeRuleOps()
 		ops.addErr = errors.New("netlink ENOBUFS")
 		rg := &ribGroupManager{ops: ops}
-		if err := rg.Apply(ribGroups, instances); err == nil {
+		if err := rg.Apply(ribGroups, instances, connected); err == nil {
 			t.Fatal("Apply must return non-nil when both leak rules fail (#3731)")
 		}
 		if ops.count(unix.AF_INET) != 0 || ops.count(unix.AF_INET6) != 0 {
@@ -503,79 +598,65 @@ func TestNextTableRulesPriorityCap(t *testing.T) {
 	})
 }
 
-// TestRibGroupRulesPriorityCap exercises the #1706 hard cap for rib-group
-// rules. Each leaking table consumes TWO priorities (v4+v6), so the
-// window of 100 priorities fits 50 tables. The 50th table must program at
-// slots 33098/33099 (the last in-range pair); the 51st must be rejected.
+// TestRibGroupRulesPriorityCap exercises the #3876 hard cap for the
+// per-prefix rib-group leak. One rule is programmed per connected prefix, and
+// the total is bounded by maxRibGroupLeakRules; prefixes beyond the window
+// must be dropped (with a degraded Apply error) and every programmed rule
+// must stay inside the window clear() scans so nothing leaks across applies.
 func TestRibGroupRulesPriorityCap(t *testing.T) {
-	mkConfig := func(n int) (map[string]*config.RibGroup, []*config.RoutingInstanceConfig) {
-		ribGroups := map[string]*config.RibGroup{}
-		instances := make([]*config.RoutingInstanceConfig, n)
-		for i := 0; i < n; i++ {
-			rgName := fmt.Sprintf("leak-%d", i)
-			// Import a different table than the source so needsLeak is true.
-			ribGroups[rgName] = &config.RibGroup{
-				Name:       rgName,
-				ImportRibs: []string{"inet.0"}, // main table 254 != source
-			}
-			instances[i] = &config.RoutingInstanceConfig{
-				Name:                    fmt.Sprintf("vr-%d", i),
-				TableID:                 1000 + i, // distinct source tables
-				InterfaceRoutesRibGroup: rgName,
-			}
+	// One instance leaking into main, with n distinct v4 connected prefixes.
+	mkConfig := func(n int) (map[string]*config.RibGroup, []*config.RoutingInstanceConfig, map[string][]string) {
+		ribGroups := map[string]*config.RibGroup{
+			"leak": {Name: "leak", ImportRibs: []string{"inet.0"}},
 		}
-		return ribGroups, instances
+		instances := []*config.RoutingInstanceConfig{
+			{Name: "leak-vr", TableID: 1000, InterfaceRoutesRibGroup: "leak"},
+		}
+		prefixes := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			prefixes = append(prefixes, fmt.Sprintf("10.%d.%d.0/24", i/256, i%256))
+		}
+		return ribGroups, instances, map[string][]string{"leak-vr": prefixes}
 	}
 
 	t.Run("at-limit", func(t *testing.T) {
 		ops := newFakeRuleOps()
 		rg := &ribGroupManager{ops: ops}
-		ribGroups, instances := mkConfig(50)
-		if err := rg.Apply(ribGroups, instances); err != nil {
+		ribGroups, instances, connected := mkConfig(maxRibGroupLeakRules)
+		if err := rg.Apply(ribGroups, instances, connected); err != nil {
 			t.Fatalf("Apply: %v", err)
 		}
-		total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
-		if total != 100 {
-			t.Fatalf("expected 50 tables * 2 = 100 rules at the limit, got %d", total)
+		if got := ops.count(unix.AF_INET); got != maxRibGroupLeakRules {
+			t.Fatalf("expected exactly %d rules at the limit, got %d", maxRibGroupLeakRules, got)
 		}
-		assertAllRulesInRange(t, ops, ribGroupRulePriority, ribGroupRulePriority+100)
-		// The 50th (last admitted) table must occupy the final in-range
-		// pair: IPv4 at 33098, IPv6 at 33099.
-		if !hasPriority(ops, unix.AF_INET, ribGroupRulePriority+98) {
-			t.Errorf("expected IPv4 rule at the last in-range slot %d", ribGroupRulePriority+98)
-		}
-		if !hasPriority(ops, unix.AF_INET6, ribGroupRulePriority+99) {
-			t.Errorf("expected IPv6 rule at the last in-range slot %d", ribGroupRulePriority+99)
-		}
+		assertAllRulesInRange(t, ops, ribGroupLeakRulePriority, ribGroupLeakRulePriority+maxRibGroupLeakRules)
 	})
 
 	t.Run("over-limit", func(t *testing.T) {
 		ops := newFakeRuleOps()
 		rg := &ribGroupManager{ops: ops}
-		ribGroups, instances := mkConfig(60)
-		if err := rg.Apply(ribGroups, instances); err != nil {
-			t.Fatalf("Apply: %v", err)
+		ribGroups, instances, connected := mkConfig(maxRibGroupLeakRules + 25)
+		// Over-limit must surface a degraded Apply error (not swallowed).
+		if err := rg.Apply(ribGroups, instances, connected); err == nil {
+			t.Fatal("over-limit Apply must return a degraded error naming the cap")
 		}
-		total := ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
-		if total != 100 {
-			t.Fatalf("expected cap to hold at 100 rules (50 tables), got %d", total)
+		if got := ops.count(unix.AF_INET); got != maxRibGroupLeakRules {
+			t.Fatalf("expected cap to hold at %d rules, got %d", maxRibGroupLeakRules, got)
 		}
-		assertAllRulesInRange(t, ops, ribGroupRulePriority, ribGroupRulePriority+100)
-		// The 51st table (would-be slots 33100/33101) must be absent.
-		if hasPriority(ops, unix.AF_INET, ribGroupRulePriority+100) ||
-			hasPriority(ops, unix.AF_INET6, ribGroupRulePriority+101) {
-			t.Errorf("51st table leaked beyond the cleared window (slot %d/%d present)",
-				ribGroupRulePriority+100, ribGroupRulePriority+101)
+		assertAllRulesInRange(t, ops, ribGroupLeakRulePriority, ribGroupLeakRulePriority+maxRibGroupLeakRules)
+		// The rule beyond the window (pref ribGroupLeakRulePriority+1000) must be absent.
+		if hasPriority(ops, unix.AF_INET, ribGroupLeakRulePriority+maxRibGroupLeakRules) {
+			t.Errorf("a rule leaked beyond the cleared window (slot %d present)",
+				ribGroupLeakRulePriority+maxRibGroupLeakRules)
 		}
 
 		// Re-apply must not leak: all programmed rules are inside the
-		// cleared window.
-		if err := rg.Apply(ribGroups, instances); err != nil {
-			t.Fatalf("Apply (second): %v", err)
+		// cleared window, so the count stays capped.
+		if err := rg.Apply(ribGroups, instances, connected); err == nil {
+			t.Fatal("re-apply over-limit must still surface the degraded error")
 		}
-		total = ops.count(unix.AF_INET) + ops.count(unix.AF_INET6)
-		if total != 100 {
-			t.Fatalf("re-apply leaked rib-group rules: expected 100, got %d", total)
+		if got := ops.count(unix.AF_INET); got != maxRibGroupLeakRules {
+			t.Fatalf("re-apply leaked rib-group rules: expected %d, got %d", maxRibGroupLeakRules, got)
 		}
 	})
 }
@@ -780,7 +861,7 @@ func TestRulesClearListErrorSurfaced(t *testing.T) {
 			run: func(ops *fakeRuleOps) error {
 				rg := &ribGroupManager{ops: ops}
 				// Empty rib-groups → early return after clear; no re-adds.
-				return rg.Apply(nil, nil)
+				return rg.Apply(nil, nil, nil)
 			},
 		},
 		{


### PR DESCRIPTION
Closes #3876.

## Problem

The rib-group `interface-routes` import installed a single blanket rule
per leaking source table:

    ip rule from all lookup <sourceTable> pref 33000

This was a **silent no-op in every real deployment**: priority 33000
sits AFTER the main table's rule (32766), so any main-table default route
matched first and the leak rule was never consulted. It was also
over-broad — `from all lookup <table>` leaked the WHOLE source table as a
catch-all fall-through, far wider than Junos, which leaks only the
interface/connected routes. The blanket rule was `Dst`-less, so the
userspace snapshot builder skipped it too — the leak was absent from
**both** FIBs.

## Fix (CONVERGED PLAN Option 2, Phase 1 — import into main)

Replace the blanket rule with one rule **per connected prefix** of the
source instance:

    ip rule to <connected-prefix> lookup <sourceTable> pref 30000

- **Before main:** band 30000-30999 sits BEFORE main (32766) and PBR
  (31000-31999), so a specific imported prefix wins over a main-table
  default route (`pkg/routing/rules.go` `ribGroupManager.Apply` +
  `ribGroupLeaksIntoMain`).
- **Both FIBs by construction:** the per-prefix rules carry a `Dst`, so
  the userspace snapshot builder's existing `rule.Dst != nil` +
  table→instance loop auto-captures them as `NextTable` leaks into
  `inet.0` — no change to the `Dst == nil` skip (a `from all` rule can't
  be a per-prefix leak).
- **Upgrade cleanup:** `clear()` now scans the new 30000-30999 window
  PLUS the legacy 33000-33099 blanket + 200-299 windows, so an in-place
  upgrade removes the stale broken blanket rule.
- **Shared prefix SSOT:** connected prefixes derived via new
  `config.RibGroupConnectedPrefixes` / `config.ConnectedNetworkPrefix`,
  reused by the userspace FIB connected-route builder so the leaked set
  matches the connected routes in the source table. Plumbed through
  `ApplyRibGroupRules` from `daemon_apply.go` step 3c.
- **Cap:** `maxRibGroupLeakRules = 1000` with a degraded-Apply error.
- **Fail-loud warns** (`validateRibGroupLeakWarnings`): DHCP-only /
  unaddressed source (no enumerable static prefix) and VRF→VRF import
  targets (Phase 2 deferral) now WARN at commit rather than no-op
  silently.

**Deferred:** VRF→VRF import install and route-copy (Option 1) — warned,
not implemented.

## Tests / validation

- `go build ./...`; `go test ./pkg/routing/... ./pkg/config/...
  ./pkg/dataplane/... ./pkg/daemon/...` green; gofmt + vet clean.
- RED-on-revert verified for all four legs: (a) moving the band to 33000
  (after main) fails the pref<32766 assertion; (b) Dst-bearing capture +
  Dst-less skip pinned in the userspace snapshot tests; (c) dropping the
  33000 window from `clear()` leaves the stale blanket rule; (d)
  neutering the warn drops the VRF→VRF / no-enumerable-prefix
  diagnostics.
- **Cluster forwarding smoke** (sustained iperf3 through a leaked path
  with a main default route present) is the ideal gate and was NOT run —
  flagged for operator validation. `test-failover` is not required (this
  touches routing/forwarding only, no session-sync/VRRP/HA path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
