### PR TITLE
event_stream: allocate seq atomically with channel enqueue (#3878)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28765,3 +28765,31 @@ top.
   pkg/frr/README.md (MINOR 1 metric-only-doesn't-float),
   pkg/config/delete_static_nexthop_3872_test.go (new, 5 tests),
   pkg/frr/static_empty_route_3872_test.go (new, 2 tests)
+
+## 2026-07-03 — #3878 fold: roll back the lossless-path seq UNDER the lock
+
+- **Timestamp**: 2026-07-03
+- **Action**: Hostile review of PR #3883 found a residual of the exact F-153
+  bug in the LOSSLESS path. `send_lossless_encoded` released the producer lock
+  at the end of its guard block and rolled the seq back in the OUTER match arms
+  — after the lock was dropped. Two concurrent lossless flushers on a Full
+  channel could then interleave: A alloc 6 / B alloc 7 / A rollback(6) CAS
+  expects-6-sees-7 FAILS / B rollback(7) CAS succeeds → next_seq left at 6 with
+  seq 6 STRANDED = a wire hole → spurious full owner-RG resync (the exact
+  symptom this PR targets). Reachable because flush_session_deltas →
+  push_delta_lossless runs per-worker (up to 6 concurrent on the mlx5 VF).
+  Fix: compute the try_send outcome AND perform the rollback INSIDE the guard
+  block (mirror send_sequenced), so allocations+rollbacks are strictly LIFO and
+  rollback_seq's CAS always targets the top of the stack; the lock is still
+  dropped before thread::sleep (no producer stall). Restores rollback_seq's
+  documented "called ONLY while producer_seq_lock is held" contract for both
+  callers.
+- **Test**: added `concurrent_lossless_full_drops_do_not_strand_seq_3878` — 4
+  threads call push_delta_lossless on a saturated (Full) channel, then give up;
+  asserts next_seq returns to the base (no stranded hole). RED on the pre-fold
+  code (non-LIFO rollback strands seqs, next_seq drifts above base), green with
+  the fix. The prior concurrent test used lossy push_delta on a never-Full
+  channel; the two single-threaded F-153 tests can't strand — none exercised
+  concurrent-lossless-on-Full.
+- **File(s)**: userspace-dp/src/event_stream/mod.rs (send_lossless_encoded
+  rollback-under-lock), userspace-dp/src/event_stream/tests.rs (new test)

--- a/_Log.md
+++ b/_Log.md
@@ -28568,3 +28568,47 @@ top.
   + partialFrameConn/recordingBufConn/closeCountingTimeoutConn mocks +
   parseOctetFrame collector parser), pkg/logging/README.md (partial-frame
   teardown #3874 bullet)
+
+## 2026-07-03 — #3878 event-stream seq allocate/enqueue atomicity (F-152 + F-153)
+
+- **Timestamp**: 2026-07-03
+- **Action**: Fixed the cross-worker event-stream sequence allocate/enqueue
+  race (F-152) and the try_send-Full seq burn (F-153). Seq allocation and the
+  channel `try_send` now happen together under a new
+  `EventStreamShared.producer_seq_lock`, so the seq embedded in each frame is
+  monotonic in wire (channel-FIFO) order across all producer threads —
+  eliminating the out-of-order frame that the Go reader (zero reorder
+  tolerance, `pkg/dataplane/userspace/eventstream.go`) mistook for a
+  session-sync gap and answered with a spurious full owner-RG resync +
+  disconnect (self-amplifying during recovery). On a full-channel drop the
+  allocated seq is rolled back via a compare-exchange on `next_seq` (safe under
+  the lock; CAS tolerates the rare I/O-thread FullResync interleave) instead of
+  being burned, so a saturation drop no longer opens a reader-visible hole that
+  trips the NEXT frame's gap check (F-153). Approach = Option 1 (producer-lock
+  atomicity) from the issue; NO wire-format change (the seq field/offset are
+  unchanged, only its allocation timing). Reader (Go) UNCHANGED — Option 3
+  (reader reorder-window) was deliberately skipped because it would mask future
+  producer regressions. The lossless retry path drops the lock before every
+  sleep (no producer stall under backpressure) and re-allocates + rolls back on
+  each Full so the eventual wire seq matches the successful enqueue position.
+  `send_frame_lossless`/`push_delta_lossless` now share one
+  `send_lossless_encoded` retry core; `encode_delta_frame` takes the seq as a
+  parameter instead of allocating it internally.
+- **RED-on-revert**: neutralizing the rollback CAS + the producer lock makes
+  all three new tests fail — `push_delta_full_channel_drop_does_not_burn_seq_3878`
+  and `dataplane_event_channel_full_does_not_burn_seq_3878` (F-153, deterministic:
+  next_seq burns) and `concurrent_push_delta_preserves_monotonic_wire_order_3878`
+  (F-152 stress: "wire seq went backwards: 184 after 192"). All green with the
+  fix. NOTE: did NOT run crate-wide `cargo fmt` — origin/master is not clean
+  under this env's rustfmt (1367 diff lines on pristine master), so fmt would
+  sweep 200+ unrelated files; edits were hand-formatted to match surrounding
+  style. FULL `cargo test --release` green; `go build ./...` + `go test
+  ./pkg/dataplane/... ./pkg/cluster/...` green (no Go change).
+- **File(s)**: userspace-dp/src/event_stream/mod.rs (producer_seq_lock field +
+  init, rollback_seq, send_sequenced, send_lossless_encoded, send_frame_lossless
+  wrapper, encode_delta_frame seq-param, push_delta/push_delta_lossless rewire),
+  userspace-dp/src/event_stream/producer.rs (try_emit_dataplane_frame routes
+  through send_sequenced), userspace-dp/src/event_stream/tests.rs (2 new tests),
+  userspace-dp/src/event_stream/producer_tests.rs (1 new test),
+  userspace-dp/src/event_stream/README.md (#3878 seq-atomicity gotcha + #2874
+  bullet update), docs/session-sync-design.md (seq/enqueue atomicity note)

--- a/docs/session-sync-design.md
+++ b/docs/session-sync-design.md
@@ -559,6 +559,15 @@ backlog (`write_buf`) and writes non-blocking; on `WouldBlock` it keeps the
 remainder for the next cycle. Daemon detects gaps via sequence numbers and can
 request a full reconciliation.
 
+**Seq/enqueue atomicity (#3878)**: because the daemon detects gaps via sequence
+numbers and has zero reorder tolerance, the seq allocation and the channel
+enqueue happen together under `producer_seq_lock` — the seq embedded in a frame
+is monotonic in wire (channel-FIFO) order across all producer threads. A
+full-channel drop rolls the allocated seq back rather than burning it, so a
+saturation drop does not open a hole that the reader would mistake for a lost
+session mutation and answer with a spurious full owner-RG resync (self-
+amplifying during recovery). See `event_stream/README.md` for the mechanism.
+
 The idle **keepalive** also rides the canonical write path (#2883): the
 connected loop enqueues the keepalive frame into `write_buf` rather than calling
 `write_all` directly. Before #2883 the keepalive used `write_all` on the

--- a/userspace-dp/src/event_stream/README.md
+++ b/userspace-dp/src/event_stream/README.md
@@ -242,14 +242,36 @@ cluster-scoped.
   (see `protocol.rs`). Use `push_delta_lossless()` only when
   correctness requires every frame and the producer can tolerate
   back-pressure.
+- **Seq allocation is atomic with the channel enqueue (#3878).** Every
+  producer path (`push_delta`, `push_delta_lossless`, and the RT_FLOW
+  `try_emit_dataplane_*` telemetry path) allocates its `next_seq` value and
+  calls `tx.try_send` while holding `EventStreamShared.producer_seq_lock`, so
+  the seq embedded in a frame is monotonic in wire (channel-FIFO) order. Before
+  #3878 the seq was allocated in `encode_delta_frame` and enqueued in a
+  separate step, so two workers could allocate N and N+1 but enqueue them
+  inverted — the Go reader (zero reorder tolerance) treats a seq inversion as a
+  session-sync gap and forces a spurious full owner-RG resync + disconnect,
+  which is self-amplifying during recovery (F-152). On a **full-channel drop**
+  the allocated seq is **rolled back** (a compare-exchange on `next_seq`, safe
+  under the lock) rather than burned, so a saturation drop never leaves a hole
+  that trips the reader's gap check on the NEXT frame (F-153). The lock covers
+  only the atomic allocate + non-blocking `try_send`; the lossless retry loop
+  drops it before every sleep so a backpressured export never stalls the other
+  producers, and re-allocates (rolling back the failed attempt) on each retry so
+  the eventual wire seq matches the successful enqueue position. The I/O
+  thread's own FullResync/resync allocations do NOT take this lock: they precede
+  a reader reset, so their seq holes are benign, and the rollback CAS tolerates
+  the rare interleave with them.
 - **HA session open/close deltas are correctness-critical and use the
   LOSSLESS path (#2874).** `flush_session_deltas` (`afxdp/session_delta.rs`)
   routes the type-2 session-sync open/close delta through
-  `push_delta_lossless`, NOT `push_delta`. The lossy `push_delta` burns a
-  sequence number in `encode_delta_frame` and then drops the frame on a full
-  channel, leaving a hole the Go consumer cumulatively ACKs past — which
-  trims the helper replay window over the missing open/close, so the standby
-  permanently misses a session until an unrelated full-sync runs. When the
+  `push_delta_lossless`, NOT `push_delta`. The lossy `push_delta` DROPS the
+  frame on a full channel (since #3878 it rolls the seq back rather than burning
+  it, so the drop no longer leaves a seq hole — but the delta CONTENT is still
+  lost), so the standby permanently misses that session open/close until an
+  unrelated full-sync runs. The lossless path instead waits briefly for
+  capacity and surfaces a give-up as an `Err`, which the worker turns into a
+  resync (below) rather than a silent miss. When the
   lossless push cannot enqueue (peer disconnected / queue timeout — a
   genuinely wedged consumer), `flush_session_deltas` returns `true` and the
   worker loop latches loss-of-sync via `SessionTable::set_delta_loss`, which

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -27,9 +27,9 @@ use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
 use std::io;
 use std::os::unix::net::UnixStream;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, SyncSender, TryRecvError};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
@@ -246,6 +246,17 @@ pub(crate) struct EventStreamStats {
 struct EventStreamShared {
     /// Workers fetch_add to get globally monotonic sequence numbers.
     next_seq: AtomicU64,
+    /// Serializes seq allocation with channel enqueue across all producer
+    /// threads (#3878). Held ONLY around `next_seq` allocation + the single
+    /// `tx.try_send`, so the wire (channel-FIFO) order equals seq order and two
+    /// workers cannot allocate N and N+1 but enqueue them inverted (F-152). The
+    /// critical section is non-blocking (an atomic + a byte-copy encode + a
+    /// non-blocking `try_send`); the lossless retry path releases it before any
+    /// sleep so a backpressured export never stalls the other producers. The
+    /// I/O thread's own FullResync/resync allocations do NOT take this lock —
+    /// they precede a reader reset, so their seq holes are benign; the rollback
+    /// CAS below guards the rare interleave with them.
+    producer_seq_lock: Mutex<()>,
     /// Updated by I/O thread from Ack frames.
     acked_seq: AtomicU64,
     /// Set by Pause, cleared by Resume.
@@ -324,6 +335,7 @@ impl EventStreamShared {
     ) -> Self {
         Self {
             next_seq: AtomicU64::new(0),
+            producer_seq_lock: Mutex::new(()),
             acked_seq: AtomicU64::new(0),
             paused: AtomicBool::new(false),
             session_evicted_while_paused: AtomicBool::new(false),
@@ -513,49 +525,146 @@ impl EventStreamWorkerHandle {
         }
     }
 
-    fn send_frame_lossless(&self, mut frame: EventFrame) -> Result<(), String> {
+    /// Roll back a sequence number allocated by `next_seq()` when the frame it
+    /// was allocated for could NOT be committed to the channel (#3878 F-153).
+    ///
+    /// Called ONLY while `producer_seq_lock` is held, so no other producer
+    /// thread can have allocated after us — `seq` is the highest
+    /// producer-allocated value and rolling it back frees it for the next
+    /// enqueue, keeping the wire seq contiguous. The compare-exchange guards
+    /// the rare race with the I/O thread's own FullResync allocation
+    /// (`replay_buffered` / drain-poison, which do not take this lock): if it
+    /// bumped `next_seq` past `seq`, the CAS fails and we leave the counter
+    /// alone — that seq is burned, but a FullResync is already in flight so the
+    /// reader resets and the hole is moot. The CAS can never create a duplicate
+    /// wire seq.
+    fn rollback_seq(&self, seq: u64) {
+        let _ = self.shared.next_seq.compare_exchange(
+            seq,
+            seq - 1,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
+    }
+
+    /// Allocate the next wire sequence number and enqueue `encode(seq)` to the
+    /// shared channel ATOMICALLY under `producer_seq_lock`, so seq order ==
+    /// channel (wire) order across every producer thread (#3878 F-152). On a
+    /// `Full` drop the seq is rolled back so a saturation drop never burns a
+    /// sequence number and trips the reader's gap check (#3878 F-153). A
+    /// `Disconnected` drop leaves the counter advanced: the stream tears down
+    /// and the reader reconnects from `lastRecvSeq = 0`, so the burn is benign
+    /// and rolling it back would only risk racing a fresh reconnect.
+    fn send_sequenced<F>(&self, encode: F) -> Result<u64, EventStreamSendError>
+    where
+        F: FnOnce(u64) -> EventFrame,
+    {
+        let _guard = self
+            .shared
+            .producer_seq_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let seq = self.next_seq();
+        let frame = encode(seq);
+        match self.try_send_frame(frame) {
+            Ok(()) => Ok(seq),
+            Err(EventStreamSendError::Full) => {
+                self.rollback_seq(seq);
+                Err(EventStreamSendError::Full)
+            }
+            Err(EventStreamSendError::Disconnected) => Err(EventStreamSendError::Disconnected),
+        }
+    }
+
+    /// Lossless retry core shared by `send_frame_lossless` (pre-built control
+    /// frames) and `push_delta_lossless` (session deltas). On EACH attempt the
+    /// `encode` closure runs and the frame is enqueued while
+    /// `producer_seq_lock` is held, so a delta's seq is allocated in the same
+    /// critical section as its enqueue (#3878) even across the retry loop and
+    /// concurrent lossy producers. The lock is dropped before any sleep so a
+    /// backpressured lossless export never stalls the other producers.
+    ///
+    /// `encode` returns `(frame, rollback_seq)`; `rollback_seq` is `Some(seq)`
+    /// for frames whose seq came from `next_seq()` (roll it back on a drop,
+    /// #3878 F-153) and `None` for control frames that carry a fixed, non-
+    /// allocated seq (e.g. `DrainComplete`).
+    fn send_lossless_encoded<F>(&self, mut encode: F) -> Result<(), String>
+    where
+        F: FnMut() -> (EventFrame, Option<u64>),
+    {
         if !self.shared.connected.load(Ordering::Acquire) {
             return Err("event stream not connected".to_string());
         }
         let deadline = Instant::now() + LOSSLESS_QUEUE_TIMEOUT;
         loop {
-            match self.tx.try_send(frame) {
+            // Raw `tx.try_send` (NOT `try_send_frame`): a `Full` here is a
+            // RETRY, not a drop, so it must not bump `frames_dropped` — the
+            // lossless caller decides whether an eventual give-up counts as a
+            // loss (#2880). Allocation and enqueue happen together under the
+            // producer lock so a delta's re-allocated seq matches its enqueue
+            // order (#3878).
+            let (result, rollback_seq, reported_seq) = {
+                let _guard = self
+                    .shared
+                    .producer_seq_lock
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let (frame, rollback_seq) = encode();
+                let reported_seq = frame.seq;
+                (self.tx.try_send(frame), rollback_seq, reported_seq)
+            };
+            match result {
                 Ok(()) => {
                     self.shared.frames_sent.fetch_add(1, Ordering::Relaxed);
                     return Ok(());
                 }
-                Err(mpsc::TrySendError::Full(returned)) => {
-                    frame = returned;
+                Err(mpsc::TrySendError::Full(_)) => {
+                    // Roll back the seq allocated for THIS attempt (#3878): the
+                    // next attempt re-allocates so the eventual wire seq matches
+                    // the successful enqueue position, and a give-up leaves no
+                    // burned seq. Control frames carry a fixed seq (None).
+                    if let Some(seq) = rollback_seq {
+                        self.rollback_seq(seq);
+                    }
                     if !self.shared.connected.load(Ordering::Acquire) {
                         return Err(format!(
-                            "event stream disconnected while queuing seq {}",
-                            frame.seq
+                            "event stream disconnected while queuing seq {reported_seq}"
                         ));
                     }
                     if Instant::now() >= deadline {
                         return Err(format!(
-                            "timed out queuing event stream frame seq {}",
-                            frame.seq
+                            "timed out queuing event stream frame seq {reported_seq}"
                         ));
                     }
                     thread::sleep(LOSSLESS_QUEUE_RETRY_DELAY);
                 }
-                Err(mpsc::TrySendError::Disconnected(returned)) => {
+                Err(mpsc::TrySendError::Disconnected(_)) => {
+                    if let Some(seq) = rollback_seq {
+                        self.rollback_seq(seq);
+                    }
                     return Err(format!(
-                        "event stream channel disconnected while queuing seq {}",
-                        returned.seq
+                        "event stream channel disconnected while queuing seq {reported_seq}"
                     ));
                 }
             }
         }
     }
 
+    /// Lossless send of a caller-encoded frame that carries its own seq (a
+    /// control frame such as `DrainComplete`). Retries on a full channel until
+    /// capacity frees, the deadline expires, or the peer disconnects. Test-only
+    /// after #3878 rerouted `push_delta_lossless` through the seq-allocating
+    /// `send_lossless_encoded` closure.
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn send_frame_lossless(&self, frame: EventFrame) -> Result<(), String> {
+        self.send_lossless_encoded(move || (frame.clone(), None))
+    }
+
     fn encode_delta_frame(
-        &self,
+        seq: u64,
         delta: &SessionDelta,
         zone_name_to_id: &FxHashMap<String, u16>,
     ) -> EventFrame {
-        let seq = self.next_seq();
         match delta.kind {
             SessionDeltaKind::Open => EventFrame::encode_session_open(
                 seq,
@@ -576,25 +685,35 @@ impl EventStreamWorkerHandle {
         }
     }
 
-    /// Encode and send a session delta as an event frame.
+    /// Encode and send a session delta as an event frame. The seq is allocated
+    /// atomically with the channel enqueue (#3878) so a concurrent producer
+    /// cannot invert wire order, and a full-channel drop rolls the seq back
+    /// rather than burning it into a reader-visible gap.
     pub(crate) fn push_delta(
         &self,
         delta: &SessionDelta,
         zone_name_to_id: &FxHashMap<String, u16>,
     ) {
-        let frame = self.encode_delta_frame(delta, zone_name_to_id);
-        self.try_send(frame);
+        let _ = self.send_sequenced(|seq| Self::encode_delta_frame(seq, delta, zone_name_to_id));
     }
 
     /// Lossless variant used for explicit bootstrap/replay exports. This path
-    /// may wait briefly for queue capacity, but it never silently drops.
+    /// may wait briefly for queue capacity, but it never silently drops. The
+    /// seq is (re)allocated under the producer lock on each retry (#3878), so
+    /// the delta's wire seq matches its enqueue order even under backpressure
+    /// and concurrent lossy producers.
     pub(crate) fn push_delta_lossless(
         &self,
         delta: &SessionDelta,
         zone_name_to_id: &FxHashMap<String, u16>,
     ) -> Result<(), String> {
-        let frame = self.encode_delta_frame(delta, zone_name_to_id);
-        self.send_frame_lossless(frame)
+        self.send_lossless_encoded(|| {
+            let seq = self.next_seq();
+            (
+                Self::encode_delta_frame(seq, delta, zone_name_to_id),
+                Some(seq),
+            )
+        })
     }
 
     /// #2460: emit a SESSION_CLOSE RT_FLOW frame (type 14) for a Close delta

--- a/userspace-dp/src/event_stream/mod.rs
+++ b/userspace-dp/src/event_stream/mod.rs
@@ -600,10 +600,17 @@ impl EventStreamWorkerHandle {
             // Raw `tx.try_send` (NOT `try_send_frame`): a `Full` here is a
             // RETRY, not a drop, so it must not bump `frames_dropped` — the
             // lossless caller decides whether an eventual give-up counts as a
-            // loss (#2880). Allocation and enqueue happen together under the
-            // producer lock so a delta's re-allocated seq matches its enqueue
-            // order (#3878).
-            let (result, rollback_seq, reported_seq) = {
+            // loss (#2880). Allocation, enqueue, AND the rollback-on-drop all
+            // happen together under the producer lock (#3878): the rollback
+            // MUST stay inside the guard so allocations+rollbacks are strictly
+            // LIFO and `rollback_seq`'s CAS always targets the top of the
+            // stack. Rolling back after the lock is released lets two
+            // concurrent flushers interleave alloc(N)/alloc(N+1)/rollback(N)-
+            // fails/rollback(N+1)-succeeds and STRAND seq N — the exact F-153
+            // hole this fix targets (flush_session_deltas runs push_delta_
+            // lossless per-worker, so >=2 concurrent flushers on a Full channel
+            // is the normal recovery-churn regime).
+            let outcome = {
                 let _guard = self
                     .shared
                     .producer_seq_lock
@@ -611,21 +618,32 @@ impl EventStreamWorkerHandle {
                     .unwrap_or_else(|poisoned| poisoned.into_inner());
                 let (frame, rollback_seq) = encode();
                 let reported_seq = frame.seq;
-                (self.tx.try_send(frame), rollback_seq, reported_seq)
+                match self.tx.try_send(frame) {
+                    Ok(()) => Ok(()),
+                    Err(mpsc::TrySendError::Full(_)) => {
+                        // The next attempt re-allocates, so this attempt's seq
+                        // must be freed for the next successful enqueue (and a
+                        // give-up must leave no burned seq). Control frames
+                        // carry a fixed seq (None).
+                        if let Some(seq) = rollback_seq {
+                            self.rollback_seq(seq);
+                        }
+                        Err((EventStreamSendError::Full, reported_seq))
+                    }
+                    Err(mpsc::TrySendError::Disconnected(_)) => {
+                        if let Some(seq) = rollback_seq {
+                            self.rollback_seq(seq);
+                        }
+                        Err((EventStreamSendError::Disconnected, reported_seq))
+                    }
+                }
             };
-            match result {
+            match outcome {
                 Ok(()) => {
                     self.shared.frames_sent.fetch_add(1, Ordering::Relaxed);
                     return Ok(());
                 }
-                Err(mpsc::TrySendError::Full(_)) => {
-                    // Roll back the seq allocated for THIS attempt (#3878): the
-                    // next attempt re-allocates so the eventual wire seq matches
-                    // the successful enqueue position, and a give-up leaves no
-                    // burned seq. Control frames carry a fixed seq (None).
-                    if let Some(seq) = rollback_seq {
-                        self.rollback_seq(seq);
-                    }
+                Err((EventStreamSendError::Full, reported_seq)) => {
                     if !self.shared.connected.load(Ordering::Acquire) {
                         return Err(format!(
                             "event stream disconnected while queuing seq {reported_seq}"
@@ -638,10 +656,7 @@ impl EventStreamWorkerHandle {
                     }
                     thread::sleep(LOSSLESS_QUEUE_RETRY_DELAY);
                 }
-                Err(mpsc::TrySendError::Disconnected(_)) => {
-                    if let Some(seq) = rollback_seq {
-                        self.rollback_seq(seq);
-                    }
+                Err((EventStreamSendError::Disconnected, reported_seq)) => {
                     return Err(format!(
                         "event stream channel disconnected while queuing seq {reported_seq}"
                     ));

--- a/userspace-dp/src/event_stream/producer.rs
+++ b/userspace-dp/src/event_stream/producer.rs
@@ -333,30 +333,27 @@ impl EventStreamWorkerHandle {
             };
         }
 
-        let seq = self.next_seq();
-        let frame = encode(seq);
-        match self.try_send_frame(frame) {
-            Ok(()) => {
+        // #3878: allocate the seq and enqueue the frame atomically under the
+        // producer lock so wire order == seq order across producers (F-152),
+        // and roll the seq back on a full-channel drop so a saturation drop
+        // never burns a seq into a reader-visible gap (F-153). The rate-limit
+        // and queue-budget gates above stay lock-free and still refuse before
+        // any seq is allocated.
+        match self.send_sequenced(encode) {
+            Ok(seq) => {
                 self.shared.dataplane_event_counters.record_sent(kind);
                 DataplaneEventEmitOutcome::Queued { seq }
             }
-            Err(EventStreamSendError::Full) => {
+            Err(err) => {
                 self.shared.dataplane_event_queue.release(kind);
+                let reason = match err {
+                    EventStreamSendError::Full => DataplaneEventDropReason::QueueFull,
+                    EventStreamSendError::Disconnected => DataplaneEventDropReason::Disconnected,
+                };
                 self.shared
                     .dataplane_event_counters
-                    .record_drop(kind, DataplaneEventDropReason::QueueFull);
-                DataplaneEventEmitOutcome::Dropped {
-                    reason: DataplaneEventDropReason::QueueFull,
-                }
-            }
-            Err(EventStreamSendError::Disconnected) => {
-                self.shared.dataplane_event_queue.release(kind);
-                self.shared
-                    .dataplane_event_counters
-                    .record_drop(kind, DataplaneEventDropReason::Disconnected);
-                DataplaneEventEmitOutcome::Dropped {
-                    reason: DataplaneEventDropReason::Disconnected,
-                }
+                    .record_drop(kind, reason);
+                DataplaneEventEmitOutcome::Dropped { reason }
             }
         }
     }

--- a/userspace-dp/src/event_stream/producer_tests.rs
+++ b/userspace-dp/src/event_stream/producer_tests.rs
@@ -242,6 +242,52 @@ fn dataplane_event_queue_full_counts_per_kind_drop() {
     assert_eq!(stats.filter_log.dropped, 1);
 }
 
+// #3878 F-153: a telemetry frame that clears the rate limiter AND the queue
+// budget but then hits a FULL shared channel must NOT burn a sequence number.
+// The seq is allocated atomically with the enqueue and rolled back on the
+// `Full` `try_send`, so a saturation drop never leaves a reader-visible gap.
+//
+// RED-on-revert: without the rollback, `next_seq` advances to 1 on the dropped
+// emit, and the next real frame lands on seq 2 with a hole at seq 1.
+#[test]
+fn dataplane_event_channel_full_does_not_burn_seq_3878() {
+    // capacity 2 -> telemetry budget ceil(2/2) = 1, so the budget alone admits
+    // one frame; pre-fill the shared channel with non-telemetry control frames
+    // (fixed seqs, `next_seq` untouched) so the budget still has room but the
+    // channel is full, forcing the `try_send` Full path.
+    let (handle, _rx, shared) = test_handle(
+        2,
+        DataplaneEventRateLimitConfig {
+            events_per_second: 0,
+            burst: 0,
+        },
+    );
+    assert!(handle.try_send(crate::event_stream::EventFrame::encode_drain_complete(100)));
+    assert!(handle.try_send(crate::event_stream::EventFrame::encode_drain_complete(101)));
+    assert_eq!(
+        shared.next_seq.load(Ordering::Relaxed),
+        0,
+        "control frames must not allocate sequence numbers"
+    );
+
+    let outcome =
+        handle.try_emit_dataplane_event_at(test_event(DataplaneEventKind::PolicyDeny, 7), 0);
+    assert_eq!(
+        outcome,
+        DataplaneEventEmitOutcome::Dropped {
+            reason: DataplaneEventDropReason::QueueFull
+        }
+    );
+    assert_eq!(
+        shared.next_seq.load(Ordering::Relaxed),
+        0,
+        "#3878 F-153: a full-channel telemetry drop must not burn a sequence number"
+    );
+
+    let stats = handle.dataplane_event_stats();
+    assert_eq!(stats.policy_deny.queue_full, 1);
+}
+
 #[test]
 fn dataplane_event_disconnected_counts_per_kind_drop() {
     let (handle, rx, shared) = test_handle(

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -1303,6 +1303,116 @@ fn test_lossless_send_fails_when_not_connected() {
     assert!(err.contains("not connected"));
 }
 
+// #3878 F-153: a full-channel drop of a lossy session delta must NOT burn a
+// sequence number. The producer allocates the seq atomically with the enqueue
+// and, on a `Full` `try_send`, rolls the seq back — so the next successfully
+// sent frame stays contiguous and the Go reader never sees a spurious gap that
+// would force a full owner-RG resync.
+//
+// RED-on-revert: without the rollback, the dropped frame's seq is burned;
+// `next_seq` advances to 2 after the drop and the next frame lands on seq 3,
+// leaving a hole at seq 2.
+#[test]
+fn push_delta_full_channel_drop_does_not_burn_seq_3878() {
+    let (tx, rx) = mpsc::sync_channel::<EventFrame>(1);
+    let shared = Arc::new(EventStreamShared::new());
+    let handle = EventStreamWorkerHandle {
+        tx,
+        shared: shared.clone(),
+    };
+    let zone_map = FxHashMap::default();
+    let delta = test_close_delta(crate::session::SessionDeltaKind::Open);
+
+    // Frame 1 fills the capacity-1 channel (seq 1).
+    handle.push_delta(&delta, &zone_map);
+    assert_eq!(shared.next_seq.load(Ordering::Relaxed), 1);
+
+    // Frame 2: the channel is full -> `try_send` returns Full. The seq must be
+    // rolled back, not burned.
+    handle.push_delta(&delta, &zone_map);
+    assert_eq!(
+        shared.next_seq.load(Ordering::Relaxed),
+        1,
+        "#3878 F-153: a full-channel drop must not burn a sequence number",
+    );
+
+    // Drain frame 1, then send frame 2 for real: it must be seq 2 (contiguous
+    // with seq 1), never seq 3 (a reader-visible gap -> spurious resync).
+    let f1 = rx.try_recv().expect("frame 1 queued");
+    assert_eq!(f1.seq, 1);
+    handle.push_delta(&delta, &zone_map);
+    let f2 = rx.try_recv().expect("frame 2 queued");
+    assert_eq!(
+        f2.seq, 2,
+        "seq after a full-channel drop must stay contiguous (no gap)"
+    );
+    assert!(rx.try_recv().is_err(), "no extra frame should be queued");
+}
+
+// #3878 F-152: seq allocation and channel enqueue are atomic under the producer
+// lock, so the seq embedded in each frame is strictly monotonic in wire
+// (channel-FIFO) order even when many workers push concurrently. Without the
+// lock two workers can allocate N and N+1 but enqueue them inverted, so a lower
+// seq lands after a higher one and the Go reader treats the inversion as a
+// session-sync gap -> spurious full owner-RG resync + disconnect.
+//
+// RED-on-revert: this is a concurrency stress test. With the non-atomic
+// allocate-then-enqueue restored, the wide window between `next_seq()` and
+// `try_send` (a full session-open encode) lets two of the eight workers invert
+// within the ~8000 frames, and the monotonicity assertion fails.
+#[test]
+fn concurrent_push_delta_preserves_monotonic_wire_order_3878() {
+    const THREADS: u64 = 8;
+    const PER_THREAD: u64 = 1000;
+    let total = (THREADS * PER_THREAD) as usize;
+
+    // Channel sized to hold every frame: the I/O thread is not draining in this
+    // unit test, so a smaller channel would exercise drops, not ordering.
+    let (tx, rx) = mpsc::sync_channel::<EventFrame>(total);
+    let shared = Arc::new(EventStreamShared::new());
+    let handle = EventStreamWorkerHandle { tx, shared };
+
+    let mut joins = Vec::new();
+    for _ in 0..THREADS {
+        let worker = handle.clone();
+        joins.push(std::thread::spawn(move || {
+            let zone_map = FxHashMap::default();
+            let delta = test_close_delta(crate::session::SessionDeltaKind::Open);
+            for _ in 0..PER_THREAD {
+                worker.push_delta(&delta, &zone_map);
+            }
+        }));
+    }
+    for join in joins {
+        join.join().expect("worker thread");
+    }
+
+    // Drain the channel in FIFO (wire) order; the embedded seqs must be strictly
+    // increasing and form a contiguous 1..=total run (no inversions, no burns).
+    let mut prev = 0u64;
+    let mut count = 0u64;
+    while let Ok(frame) = rx.try_recv() {
+        assert!(
+            frame.seq > prev,
+            "wire seq went backwards: {} after {} (non-atomic allocate+enqueue reordered a frame)",
+            frame.seq,
+            prev,
+        );
+        prev = frame.seq;
+        count += 1;
+    }
+    assert_eq!(
+        count,
+        THREADS * PER_THREAD,
+        "every delta must reach the channel"
+    );
+    assert_eq!(
+        prev,
+        THREADS * PER_THREAD,
+        "seqs must be a contiguous 1..=N run with no gaps or burns",
+    );
+}
+
 #[test]
 fn test_partial_read_accumulation() {
     // Simulate a partial Unix stream read: first 8 bytes, then the

--- a/userspace-dp/src/event_stream/tests.rs
+++ b/userspace-dp/src/event_stream/tests.rs
@@ -1359,11 +1359,15 @@ fn push_delta_full_channel_drop_does_not_burn_seq_3878() {
 // RED-on-revert: this is a concurrency stress test. With the non-atomic
 // allocate-then-enqueue restored, the wide window between `next_seq()` and
 // `try_send` (a full session-open encode) lets two of the eight workers invert
-// within the ~8000 frames, and the monotonicity assertion fails.
+// within the few thousand frames, and the monotonicity assertion fails.
 #[test]
 fn concurrent_push_delta_preserves_monotonic_wire_order_3878() {
+    // 8-way contention over the wide next_seq()->try_send window reorders very
+    // early on revert (observed at seq ~192); 500 per thread keeps a large
+    // margin while bounding the CPU burst so this does not starve co-scheduled
+    // timing-sensitive tests in a module-only test run.
     const THREADS: u64 = 8;
-    const PER_THREAD: u64 = 1000;
+    const PER_THREAD: u64 = 500;
     let total = (THREADS * PER_THREAD) as usize;
 
     // Channel sized to hold every frame: the I/O thread is not draining in this
@@ -1410,6 +1414,75 @@ fn concurrent_push_delta_preserves_monotonic_wire_order_3878() {
         prev,
         THREADS * PER_THREAD,
         "seqs must be a contiguous 1..=N run with no gaps or burns",
+    );
+}
+
+// #3878 F-153 (lossless path): concurrent lossless flushers that all hit a FULL
+// channel must NOT strand a sequence number. Each failed attempt's rollback
+// runs UNDER the producer lock, so allocations+rollbacks are strictly LIFO and
+// every drop returns `next_seq` to where it started. Before the follow-up fix
+// the rollback ran AFTER the lock was released, so two flushers could interleave
+// alloc(6)/alloc(7)/rollback(6)-CAS-fails/rollback(7)-CAS-succeeds and leave
+// `next_seq` at 6 with seq 6 stranded — a wire hole → spurious owner-RG resync
+// (reachable because `flush_session_deltas` → `push_delta_lossless` runs
+// per-worker, up to 6 concurrent flushers on the mlx5 VF).
+//
+// RED-on-revert: with the rollback moved back outside the guard, the non-LIFO
+// CAS failures strand seqs and `next_seq` ends well above the base.
+#[test]
+fn concurrent_lossless_full_drops_do_not_strand_seq_3878() {
+    const CAP: usize = 5;
+    const THREADS: usize = 3;
+
+    // rx is HELD (never dropped/drained) so every `try_send` returns Full, not
+    // Disconnected — the flushers stay in the retry loop.
+    let (tx, _rx) = mpsc::sync_channel::<EventFrame>(CAP);
+    let shared = Arc::new(EventStreamShared::new());
+    let handle = EventStreamWorkerHandle {
+        tx,
+        shared: shared.clone(),
+    };
+    let zone_map = FxHashMap::default();
+    let delta = test_close_delta(crate::session::SessionDeltaKind::Open);
+
+    // Fill the channel so every lossless attempt hits Full; base next_seq = CAP.
+    for _ in 0..CAP {
+        handle.push_delta(&delta, &zone_map);
+    }
+    assert_eq!(shared.next_seq.load(Ordering::Relaxed), CAP as u64);
+
+    // Mark connected so the flushers enter the retry loop rather than bailing at
+    // the initial connected check.
+    shared.connected.store(true, Ordering::Release);
+
+    let mut joins = Vec::new();
+    for _ in 0..THREADS {
+        let worker = handle.clone();
+        joins.push(std::thread::spawn(move || {
+            let zm = FxHashMap::default();
+            let d = test_close_delta(crate::session::SessionDeltaKind::Open);
+            // Retries on Full; gives up (Err) once `connected` is cleared below.
+            let _ = worker.push_delta_lossless(&d, &zm);
+        }));
+    }
+
+    // Let the flushers churn concurrently on the Full channel (this is where the
+    // non-LIFO rollback strands seqs on the buggy version), then make them give
+    // up quickly instead of waiting out the 5s lossless timeout. The flushers
+    // sleep LOSSLESS_QUEUE_RETRY_DELAY (50us) between attempts, so this window is
+    // low-CPU (mostly sleeping) yet still runs hundreds of interleaved attempts.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    shared.connected.store(false, Ordering::Release);
+    for join in joins {
+        join.join().expect("lossless flusher");
+    }
+
+    // Every lossless attempt was dropped and rolled back UNDER the lock, so the
+    // counter must be back at the base with no stranded hole.
+    assert_eq!(
+        shared.next_seq.load(Ordering::Relaxed),
+        CAP as u64,
+        "#3878: concurrent lossless Full-drops must not strand a sequence number",
     );
 }
 


### PR DESCRIPTION
Closes #3878.

## Problem (fable-review-161 F-152 + F-153)

The cross-worker event-stream sequence allocation was **not atomic** with the
channel enqueue. `encode_delta_frame` (and the RT_FLOW telemetry path)
allocated `next_seq` in one step and called `try_send` in a separate step, so
two workers could allocate N and N+1 but enqueue/flush them **inverted**. An
out-of-order seq reaches the wire, and the Go reader
(`pkg/dataplane/userspace/eventstream.go`) has **zero reorder tolerance**: it
treats a seq inversion on a session-sync frame as a hard gap and forces a
spurious full owner-RG resync + disconnect. During recovery — when reordering
is most likely — the resync churn causes more reordering, so the instability is
**self-amplifying** (F-152).

The `try_send` Full (channel-saturation) path additionally **burned a seq**
without rolling it back (F-153). The reader tracks a single monotonic
`prevSeq`, so a burned seq trips the NEXT session frame's gap check → the same
spurious resync.

## Fix (Option 1: producer-lock atomicity)

Allocate the seq and enqueue the frame **together** under a new
`EventStreamShared.producer_seq_lock`, so the seq embedded in a frame is
monotonic in wire (channel-FIFO) order across every producer thread. On a
full-channel drop the allocated seq is **rolled back** via a compare-exchange
on `next_seq` (safe while the lock is held; the CAS tolerates the rare
interleave with the I/O thread's own FullResync allocation, which is not
lock-held and precedes a reader reset). The lock covers only the atomic
allocate + non-blocking `try_send`; the lossless retry loop drops it before
every sleep so a backpressured export never stalls the other producers, and it
re-allocates (rolling back the failed attempt) on each retry so the eventual
wire seq matches the successful enqueue position — covering both the F-152 race
and the F-153 Full-drop residual.

**No wire-format change**: the seq field and its `[8:16]` header offset are
unchanged; only its allocation timing moves. The Go reader is intentionally
left untouched — a reader reorder-window (Option 3) would mask future producer
regressions. `send_frame_lossless` and `push_delta_lossless` now share one
`send_lossless_encoded` retry core; `encode_delta_frame` takes the seq as a
parameter instead of allocating it internally.

## Tests (RED-on-revert proven)

- `push_delta_full_channel_drop_does_not_burn_seq_3878` and
  `dataplane_event_channel_full_does_not_burn_seq_3878` deterministically pin
  F-153 (a Full drop must not advance `next_seq` / must keep the next frame
  contiguous).
- `concurrent_push_delta_preserves_monotonic_wire_order_3878` stresses F-152
  (8 workers × 1000 deltas; channel-FIFO seqs must be strictly increasing and
  contiguous).

All three go **RED** when the rollback CAS + producer lock are neutralized
(`wire seq went backwards: 184 after 192`) and **green** with the fix.

## Validation

- FULL `cargo test --release`: **3511 passed, 0 failed**.
- `go build ./...` green; `go test ./pkg/cluster/... ./pkg/dataplane/userspace/...` green (no Go change).
- Added code verified fmt-clean (crate-wide `cargo fmt` intentionally NOT run — origin/master already reports ~1367 rustfmt diff lines under this toolchain, so a blanket format would sweep 200+ unrelated files).

**test-failover WARRANTED** (HA session-sync recovery-churn path) — flagged for batch validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi