### PR TITLE
config: reject firewall-filter name reused across non-inet6 families (#3884 fail-open)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-03 — #3884: firewall-filter cross-family name collision folds into FiltersInet (discard→accept-all fail-open)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-review-161 F-030 (MEDIUM, security fail-open).
+    `compileFirewall` (`compiler_firewall.go`) selects `dest := fw.FiltersInet`
+    for EVERY family except `inet6` (inet, any, mpls, ccc, vpls, bridge, ...) and
+    writes `dest[name] = filter` unconditionally, so two same-name filters under
+    two different non-inet6 families silently collapse (last-write-wins) with no
+    commit error. A `family inet filter blockX { then discard }` replaced by a
+    same-name `family any filter blockX { then accept }` becomes accept-all on the
+    IPv4 path — a deny silently downgraded to an accept.
+  - **Fix**: Added `validateFirewallFilterFamilyCollisionsAST` (new AST pre-walk
+    in `compiler_firewall.go`, mirroring the #3339 application-collision gate)
+    that rejects at commit / commit-check a filter name defined under ≥ 2 distinct
+    non-inet6 families (naming the filter + families), and downgrades to a
+    `cfg.Warnings` entry on the tolerant load / peer-sync path
+    (`lenientFirewallFilterFamilyCollisions`, #1960 / #3261 no-brick). Chose
+    fail-closed REJECT over per-(family,name) namespacing because downstream
+    consumers reference filters by NAME within the inet (V4) / inet6 (V6) buckets
+    only — no family dimension exists to disambiguate, so the reuse is genuinely
+    ambiguous. inet6 has its own dest map (`FiltersInet6`) so the legitimate
+    inet/inet6 dual-stack same-name case is preserved (distinct maps, no collision).
+    Wired the gate into `compileConfig` (invoke after `validateApplicationNameCollisionsAST`;
+    warnings accumulated alongside `appCollisionWarnings`) with the new
+    `lenientFirewallFilterFamilyCollisions` opt set in both lenient constructors.
+  - **File(s)**: `pkg/config/compiler_firewall.go` (validator),
+    `pkg/config/compiler.go` (opt + invocation + warning accumulation),
+    `pkg/config/compiler_firewall_family_collision_3884_test.go` (new tests),
+    `docs/config-schema.md` (new gate section).
+  - **Validation**: `go test ./pkg/config/...` green; `go build ./...` clean;
+    gofmt + `go vet ./pkg/config/...` clean. RED-on-revert proven — neutralizing
+    the gate (forcing lenient) makes the strict Rejected tests fail (CompileConfig
+    returns nil, discard silently overwritten by accept). Reachable only via a
+    hierarchical config-file parse / peer-synced AST (the flat `set` grammar only
+    structures `family inet|inet6`), so tests use `parseHier` + a directly-built
+    AST — the actual reachable path.
+
 ## 2026-07-03 — #3876: rib-group interface-route import was a no-op (shadowed by default route) — per-prefix leak before main
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -633,6 +633,57 @@ and break the symmetry in the other direction. Pinned by
 `pkg/config/quotekey_roundtrip_3854_test.go` (`TestQuoteKeyLexerSymmetry3854`,
 `TestFormatParseRoundTrip3854`, `TestFormatParseIdempotent3854`).
 
+## Firewall-filter cross-family name collision fail-closed gate (#3884)
+
+Junos namespaces firewall filters **per family**, so `family inet filter blockX`
+and `family mpls filter blockX` are two distinct filters. xpf cannot: `compileFirewall`
+(`compiler_firewall.go`) selects the destination map with `dest := fw.FiltersInet`
+and only switches to `fw.FiltersInet6` when the family is literally `inet6`, so
+EVERY other family (`inet`, `any`, `mpls`, `ccc`, `vpls`, `bridge`, and any
+not-yet-modelled token — `SchemaValidate` does not reject an unknown family
+keyword) folds into the single `fw.FiltersInet` pool, then writes
+`dest[filter.Name] = filter` **unconditionally**. Two same-name filters authored
+under two different non-inet6 families therefore silently collapse — the later
+definition last-write-wins over the earlier with no commit error. If the `family
+inet` filter was a `discard`/deny and the colliding-family filter is accept-all,
+the effective IPv4 filter becomes accept-all: a deny silently downgraded to an
+accept (a security **fail-open**).
+
+Downstream consumers reference filters by **name** within the inet (V4) / inet6
+(V6) buckets only — an interface unit's `FilterInputV4` resolves against
+`fw.FiltersInet`, `FilterInputV6` against `fw.FiltersInet6`
+(`compiler_validate_warn.go`, `routing/rules.go`, `dataplane/userspace/filters.go`).
+There is no family dimension in the reference, so once two non-inet6 families
+share a name the map cannot disambiguate them and the reuse is genuinely
+ambiguous. `validateFirewallFilterFamilyCollisionsAST` (`compiler_firewall.go`)
+**rejects at commit / commit-check** a filter name defined under more than one
+distinct non-inet6 family, naming the filter and the colliding families. It is an
+AST pre-walk (mirroring `validateApplicationNameCollisionsAST`, #3339) because the
+colliding definitions are merged away by last-write-wins by the time
+`fw.FiltersInet` exists — only the raw AST still carries every family's
+definition — and it aggregates across every top-level `firewall {}` block
+(compileFirewall folds each into the same map, so a split-block collision is just
+as real).
+
+`inet6` has its own dest map (`fw.FiltersInet6`) and is the ONLY family that folds
+there, so a name shared between `family inet` and `family inet6` lands in two
+different maps and does **not** collide — the legitimate dual-stack case (one
+filter name for the V4 and V6 path) is preserved. Only a name under ≥ 2 distinct
+non-inet6 families is flagged. Because the schema-driven flat `set` grammar only
+structures `family inet` / `family inet6`, an unknown family (`any`, `mpls`, …)
+reaches a structured `filter` subtree — and thus the fold-overwrite — only via a
+hierarchical config-file parse or a directly-constructed / peer-synced AST; that
+is exactly the reachable path the gate closes.
+
+On the tolerant load / peer-sync path the error downgrades to a `cfg.Warnings`
+entry (`lenientFirewallFilterFamilyCollisions`, #1960 / #3261 no-brick), keeping
+the arbitrary-but-stable last-write-wins map so an already-persisted or
+peer-synced config an older binary silently accepted still BOOTS. Fail-on-revert:
+`pkg/config/compiler_firewall_family_collision_3884_test.go` (strict reject on
+`CompileConfig`, warn-not-brick on `CompileConfigLenient` with the surviving
+accept asserted, plus the inet/inet6 dual-stack and single-family no-false-reject
+cases).
+
 ## Repeated same-type sibling matches (NOT bracketed multi-value)
 
 The dual-AST contract above covers a single leaf carrying a bracketed list

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -407,6 +407,24 @@ type compileOpts struct {
 	// last-write-wins maps it always produced are unchanged on that path. Same
 	// doctrine as lenientApplicationSpecs / lenientApplicationSetMembers.
 	lenientApplicationNameCollisions bool
+
+	// lenientFirewallFilterFamilyCollisions (#3884, fable-review-161 F-030)
+	// downgrades the firewall-filter cross-family name-collision gate
+	// (validateFirewallFilterFamilyCollisionsAST) from a hard compile error to a
+	// cfg.Warnings entry. compileFirewall folds every filter family except inet6
+	// (inet, any, mpls, ccc, vpls, bridge, ...) into ONE name-keyed map
+	// (fw.FiltersInet) with an unconditional `dest[name] = filter` write, so a
+	// same-name filter authored under a second such family silently OVERWRITES
+	// the first — a `discard` filter can be replaced by a same-name accept-all
+	// (fail-open). Downstream consumers key filters by name within the inet (V4) /
+	// inet6 (V6) buckets only, with no family dimension to disambiguate, so the
+	// reuse is genuinely ambiguous. The strict commit / commit-check path hard-
+	// rejects it; the tolerant load / peer-sync paths downgrade to a warning so
+	// an already-persisted or peer-synced config an older binary silently
+	// accepted still BOOTS (#1960 no-brick), keeping the arbitrary-but-stable
+	// last-write-wins map compileFirewall always produced. Same doctrine as
+	// lenientApplicationNameCollisions.
+	lenientFirewallFilterFamilyCollisions bool
 	// lenientFilterProtocols (#2175 review) downgrades the firewall-filter
 	// `from protocol <token>` gate (validateFilterProtocolsStrict) from a
 	// hard compile error to a cfg.Warnings entry. The strict commit /
@@ -1362,6 +1380,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientRouteFilterMatchTypes:           true,
 		lenientApplicationSpecs:                true,
 		lenientApplicationNameCollisions:       true,
+		lenientFirewallFilterFamilyCollisions:  true,
 		lenientFilterProtocols:                 true,
 		lenientFilterCrossField:                true,
 		lenientFilterActions:                   true,
@@ -1540,6 +1559,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientRouteFilterMatchTypes:           true,
 		lenientApplicationSpecs:                true,
 		lenientApplicationNameCollisions:       true,
+		lenientFirewallFilterFamilyCollisions:  true,
 		lenientFilterProtocols:                 true,
 		lenientFilterCrossField:                true,
 		lenientFilterActions:                   true,
@@ -1802,6 +1822,23 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 
+	// #3884 (fable-review-161 F-030) firewall-filter cross-family name-collision
+	// gate. compileFirewall folds every filter family except inet6 into ONE
+	// name-keyed map (fw.FiltersInet) with an unconditional overwrite, so a
+	// same-name filter under a second non-inet6 family silently replaces the
+	// first — a discard filter can become a same-name accept-all (fail-open).
+	// Strict (commit / commit-check): the collision hard-rejects. Lenient (load /
+	// peer-sync): warn so an already-persisted or peer-synced config an older
+	// binary silently accepted still BOOTS (#1960 / #3261). Runs on the group-
+	// expanded, inactive-pruned AST because the colliding definitions are merged
+	// away by last-write-wins by the time fw.FiltersInet exists — only the raw
+	// AST still carries every family's definition.
+	fwFilterFamilyWarnings, err := validateFirewallFilterFamilyCollisionsAST(
+		tree.Children, opts.lenientFirewallFilterFamilyCollisions)
+	if err != nil {
+		return nil, err
+	}
+
 	// #3096: the #3079 interim NAT rule-set scope reject is LIFTED. A
 	// `security nat {source|destination|static}` rule-set whose `from`/`to`
 	// clause scopes traffic by `interface` or `routing-instance` is now
@@ -1990,6 +2027,7 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 	cfg.Warnings = append(cfg.Warnings, flowTraceSizeWarnings...)
 	cfg.Warnings = append(cfg.Warnings, unsupportedIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, appCollisionWarnings...)
+	cfg.Warnings = append(cfg.Warnings, fwFilterFamilyWarnings...)
 	cfg.Warnings = append(cfg.Warnings, bindIfaceWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyMatchWarnings...)
 	cfg.Warnings = append(cfg.Warnings, policyThenPermitWarnings...)

--- a/pkg/config/compiler_firewall.go
+++ b/pkg/config/compiler_firewall.go
@@ -227,6 +227,126 @@ func compileFirewall(node *Node, fw *FirewallConfig) error {
 	return nil
 }
 
+// validateFirewallFilterFamilyCollisionsAST walks every top-level `firewall`
+// node and rejects a firewall-filter NAME reused across two DIFFERENT non-inet6
+// families (#3884, fable-review-161 F-030).
+//
+// compileFirewall selects the destination map with `dest := fw.FiltersInet`
+// (compiler_firewall.go) and only switches to fw.FiltersInet6 when the family
+// is literally "inet6" — so EVERY other family (inet, any, mpls, ccc, vpls,
+// bridge, and any not-yet-modelled token, since SchemaValidate does not reject
+// an unknown family keyword) folds into the single fw.FiltersInet pool, then
+// writes `dest[filter.Name] = filter` unconditionally. A same-name filter
+// authored under a second such family therefore silently OVERWRITES the first
+// (last-write-wins). If `family inet filter blockX { ... then discard; }` is
+// followed by `family any filter blockX { ... then accept; }`, the effective
+// IPv4 filter becomes accept-all — a deny silently downgraded to an accept
+// (a security fail-open).
+//
+// Downstream consumers reference filters by NAME within the inet (V4) / inet6
+// (V6) buckets only — an interface unit's FilterInputV4 resolves against
+// fw.FiltersInet, FilterInputV6 against fw.FiltersInet6 (compiler_validate_warn.go,
+// routing/rules.go, dataplane/userspace/filters.go). There is no family
+// dimension in the reference, so once two non-inet6 families share a name the
+// map cannot disambiguate them — the reuse is genuinely ambiguous. Junos
+// namespaces firewall filters per family; xpf folds them, so it rejects the
+// reuse fail-closed instead of resolving it by arbitrary map-write order.
+//
+// inet6 has its own destination map (fw.FiltersInet6) and is the ONLY family
+// that folds there, so a name shared between family inet and family inet6 lands
+// in two DIFFERENT maps and does NOT collide — that legitimate dual-stack case
+// (the same filter name for the V4 and V6 path) is preserved. Only a name that
+// appears under >= 2 distinct non-inet6 families is flagged.
+//
+// Strict path (commit / commit-check, lenient=false): the first collision is a
+// hard compile error naming the offending filter and its families. Lenient path
+// (load / peer-sync, lenient=true): every collision is returned as a warning and
+// compilation continues with the existing last-write-wins behavior, so an
+// already-persisted or peer-synced config that an older binary silently accepted
+// still BOOTS (#1960 / #3261 fail-closed-on-load doctrine).
+//
+// The traversal mirrors compileFirewall's family/filter walk exactly (BOTH AST
+// shapes: hierarchical `family inet { filter ... }` and the set-command
+// `family { inet { filter ... } }`), and aggregates across every top-level
+// `firewall {}` block because compileFirewall compiles each into the same
+// fw.FiltersInet map — a collision split across two blocks is just as real.
+func validateFirewallFilterFamilyCollisionsAST(nodes []*Node, lenient bool) ([]string, error) {
+	// filterFamilies[name] = the ordered set of DISTINCT non-inet6 families that
+	// define a filter of this name (all folding into the shared FiltersInet pool).
+	filterFamilies := map[string][]string{}
+	// order preserves first-seen filter-name order for a deterministic error.
+	order := []string{}
+
+	record := func(name, fam string) {
+		for _, f := range filterFamilies[name] {
+			if f == fam {
+				return // same family already recorded — not a cross-family reuse
+			}
+		}
+		if len(filterFamilies[name]) == 0 {
+			order = append(order, name)
+		}
+		filterFamilies[name] = append(filterFamilies[name], fam)
+	}
+
+	for _, fwNode := range nodes {
+		if fwNode.Name() != "firewall" {
+			continue
+		}
+		for _, familyNode := range fwNode.FindChildren("family") {
+			var afNodes []*Node
+			var afName string
+			if len(familyNode.Keys) >= 2 {
+				// Hierarchical: family inet { ... }
+				afName = familyNode.Keys[1]
+				afNodes = []*Node{familyNode}
+			} else {
+				// Set-command shape: family { inet { ... } inet6 { ... } }
+				afNodes = append(afNodes, familyNode.Children...)
+			}
+			for _, afNode := range afNodes {
+				af := afName
+				if af == "" {
+					af = afNode.Keys[0]
+					if len(afNode.Keys) >= 2 {
+						af = afNode.Keys[1]
+					}
+				}
+				if af == "inet6" {
+					// Its own dest map (FiltersInet6) — cannot collide with the pool.
+					continue
+				}
+				for _, filterInst := range namedInstances(afNode.FindChildren("filter")) {
+					if filterInst.name == "" {
+						continue
+					}
+					record(filterInst.name, af)
+				}
+			}
+		}
+	}
+
+	var warnings []string
+	for _, name := range order {
+		fams := filterFamilies[name]
+		if len(fams) < 2 {
+			continue
+		}
+		msg := fmt.Sprintf(
+			"firewall filter %q is defined under multiple non-inet6 families "+
+				"(%s) — xpf folds every family except inet6 into one name-keyed "+
+				"filter map, so the later definition silently overwrites the "+
+				"earlier (a discard filter can become accept-all — fail-open); "+
+				"Junos namespaces filters per family, so rename one of them (#3884)",
+			name, strings.Join(fams, ", "))
+		if !lenient {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		warnings = append(warnings, msg)
+	}
+	return warnings, nil
+}
+
 // firewallMatchValues extracts every value carried by a `from` match-criterion
 // node, across BOTH parser AST shapes (#2545):
 //

--- a/pkg/config/compiler_firewall_family_collision_3884_test.go
+++ b/pkg/config/compiler_firewall_family_collision_3884_test.go
@@ -1,0 +1,244 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3884 (fable-review-161 F-030): compileFirewall folds every firewall-filter
+// family except inet6 into ONE name-keyed map (fw.FiltersInet) with an
+// unconditional `dest[name] = filter` write, so two same-name filters authored
+// under DIFFERENT non-inet6 families silently collapse — the later definition
+// overwrites the earlier with no commit error. If the IPv4 (`family inet`)
+// filter was a `discard`/deny and the colliding-family filter is accept-all,
+// the effective IPv4 filter becomes accept-all (a security fail-open). These
+// fixtures pin the strict reject at commit and the lenient warn on the tolerant
+// load / peer-sync path, and confirm the legitimate single-family and
+// inet/inet6 dual-stack cases are unaffected.
+//
+// Note on parse shape: a family the schema does not model (`any`, `mpls`, ...)
+// only reaches a structured `filter` subtree via a HIERARCHICAL config-file
+// parse or a directly-constructed / peer-synced AST — the schema-driven flat
+// `set` parser collapses `family any filter ...` into one unstructured leaf, so
+// it never mints a colliding filter. The reproduction therefore uses parseHier
+// (how a config file loads) and a directly-built AST (how a peer-synced tree
+// arrives), exactly the paths where the fold-overwrite fail-open is reachable.
+
+// Strict commit: a filter name reused across family inet (discard) and family
+// any (accept) is hard-rejected. On revert of the #3884 gate this goes RED —
+// the second definition silently overwrites the first (discard → accept-all)
+// and CompileConfig returns no error.
+func TestFirewallFilterCrossFamilyNameCollisionRejected(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family inet {
+        filter blockX {
+            term t1 {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+    family any {
+        filter blockX {
+            term t1 {
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of cross-family firewall filter name collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockX") ||
+		!strings.Contains(err.Error(), "#3884") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// The collision is just as real between two families that are BOTH non-inet /
+// non-inet6 (e.g. mpls and any) — anything except inet6 folds into the same
+// pool. Built as a direct AST (a peer-synced / load-merge tree can carry any
+// structured family node).
+func TestFirewallFilterCrossFamilyNameCollisionNonInetRejected(t *testing.T) {
+	tree := &ConfigTree{Children: []*Node{
+		{Keys: []string{"firewall"}, Children: []*Node{
+			{Keys: []string{"family", "mpls"}, Children: []*Node{
+				{Keys: []string{"filter", "blockY"}, Children: []*Node{
+					{Keys: []string{"term", "t1"}, Children: []*Node{
+						{Keys: []string{"then", "discard"}, IsLeaf: true},
+					}},
+				}},
+			}},
+			{Keys: []string{"family", "any"}, Children: []*Node{
+				{Keys: []string{"filter", "blockY"}, Children: []*Node{
+					{Keys: []string{"term", "t1"}, Children: []*Node{
+						{Keys: []string{"then", "accept"}, IsLeaf: true},
+					}},
+				}},
+			}},
+		}},
+	}}
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of mpls/any firewall filter name collision, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockY") ||
+		!strings.Contains(err.Error(), "#3884") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Cross-family collision split across two hierarchical `firewall {}` blocks. The
+// compiler compiles every top-level firewall node into the same fw.FiltersInet
+// map, so a walker that stopped at the first block would miss it.
+func TestFirewallFilterCrossFamilyCollisionSplitAcrossBlocks(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family inet {
+        filter blockZ {
+            term t1 {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+}
+firewall {
+    family any {
+        filter blockZ {
+            term t1 {
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+}
+`)
+
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("CompileConfig: expected rejection of cross-family collision split across firewall blocks, got nil")
+	}
+	if !strings.Contains(err.Error(), "blockZ") ||
+		!strings.Contains(err.Error(), "#3884") {
+		t.Fatalf("unexpected error text: %v", err)
+	}
+}
+
+// Lenient path (load / peer-sync): the collision must downgrade to a warning so
+// an already-persisted or peer-synced config an older binary silently accepted
+// still BOOTS. The last-write-wins map is preserved — and it is precisely the
+// fail-open: the `family inet` discard has been silently replaced by the
+// `family any` accept.
+func TestFirewallFilterCrossFamilyNameCollisionLenientWarns(t *testing.T) {
+	tree := parseHier(t, `
+firewall {
+    family inet {
+        filter blockX {
+            term t1 {
+                then {
+                    discard;
+                }
+            }
+        }
+    }
+    family any {
+        filter blockX {
+            term t1 {
+                then {
+                    accept;
+                }
+            }
+        }
+    }
+}
+`)
+
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("CompileConfigLenient: cross-family collision must downgrade to a warning, got error: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "blockX") && strings.Contains(w, "#3884") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a #3884 cross-family collision warning on the lenient path, got: %v", cfg.Warnings)
+	}
+	// The last-write-wins behavior is deliberately unchanged on the lenient path:
+	// the filter still lands in fw.FiltersInet under its single shared name, and
+	// it is the accept that survived — the exact fail-open the strict gate blocks.
+	f, ok := cfg.Firewall.FiltersInet["blockX"]
+	if !ok {
+		t.Fatal("lenient path: expected blockX to remain in FiltersInet (last-write-wins preserved)")
+	}
+	if len(f.Terms) != 1 || f.Terms[0].Action != "accept" {
+		t.Fatalf("lenient path: expected the fail-open accept to survive last-write-wins, got %+v", f.Terms)
+	}
+}
+
+// A filter name shared between family inet and family inet6 is NOT a collision:
+// inet6 has its own dest map (FiltersInet6), so the two coexist. This legitimate
+// dual-stack case (the same filter name for the V4 and V6 path) must commit
+// cleanly with no #3884 error/warning, and BOTH filters must survive.
+func TestFirewallFilterInetInet6SameNameCommits(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set firewall family inet filter dualX term t1 then discard",
+		"set firewall family inet6 filter dualX term t1 then accept",
+	})
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: inet/inet6 same-name filters must commit cleanly, got error: %v", err)
+	}
+	if _, ok := cfg.Firewall.FiltersInet["dualX"]; !ok {
+		t.Fatal("expected dualX in FiltersInet (V4)")
+	}
+	if _, ok := cfg.Firewall.FiltersInet6["dualX"]; !ok {
+		t.Fatal("expected dualX in FiltersInet6 (V6)")
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3884") {
+			t.Fatalf("unexpected #3884 warning on a valid inet/inet6 dual-stack config: %q", w)
+		}
+	}
+}
+
+// A normal single-family filter compiles unchanged — the gate must not
+// over-reject the common case.
+func TestFirewallFilterSingleFamilyCommits(t *testing.T) {
+	tree := buildTreeFromSet(t, []string{
+		"set firewall family inet filter allowSSH term t1 from destination-port 22",
+		"set firewall family inet filter allowSSH term t1 then accept",
+		"set firewall family inet filter dropAll term t2 then discard",
+	})
+
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig: single-family filters must commit cleanly, got error: %v", err)
+	}
+	if _, ok := cfg.Firewall.FiltersInet["allowSSH"]; !ok {
+		t.Fatal("expected allowSSH in FiltersInet")
+	}
+	if _, ok := cfg.Firewall.FiltersInet["dropAll"]; !ok {
+		t.Fatal("expected dropAll in FiltersInet")
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "#3884") {
+			t.Fatalf("unexpected #3884 warning on a valid single-family config: %q", w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes fable-review-161 F-030 (MEDIUM, security fail-open). `compileFirewall`
(`pkg/config/compiler_firewall.go`) selects the destination map with
`dest := fw.FiltersInet` and only switches to `fw.FiltersInet6` when the family
is literally `inet6`. Every other filter family (`inet`, `any`, `mpls`, `ccc`,
`vpls`, `bridge`, and any not-yet-modelled token — `SchemaValidate` does not
reject an unknown family keyword) folds into the single `fw.FiltersInet` pool,
then writes `dest[filter.Name] = filter` **unconditionally**. Two same-name
filters under two different non-inet6 families silently collapse (last-write-wins,
no commit error): a `family inet filter blockX { then discard }` replaced by a
same-name `family any filter blockX { then accept }` becomes **accept-all on the
IPv4 path** — a deny silently downgraded to an accept.

## Fix: reject fail-closed (not namespace)

Downstream consumers reference filters by **name** within the inet (V4) / inet6
(V6) buckets only — an interface unit's `FilterInputV4` → `fw.FiltersInet`,
`FilterInputV6` → `fw.FiltersInet6` (`compiler_validate_warn.go`,
`routing/rules.go`, `dataplane/userspace/filters.go`). There is **no family
dimension** in the reference, so once two non-inet6 families share a name the map
cannot disambiguate them — the reuse is genuinely ambiguous. Per-`(family,name)`
namespacing would require adding new maps and rewiring every consumer for families
xpf does not separately enforce; the sound, minimal fix is to reject the reuse
fail-closed (Junos namespaces filters per family; xpf folds them, so it errors
instead of resolving by arbitrary map-write order).

`validateFirewallFilterFamilyCollisionsAST` (new AST pre-walk in
`compiler_firewall.go`, mirroring the #3339 application-collision gate):

- Aggregates every top-level `firewall {}` block (compileFirewall folds each into
  the same map, so a split-block collision is just as real).
- Records the distinct non-inet6 families defining each filter name; rejects a
  name under ≥ 2 of them, naming the filter and the families.
- **inet6 is exempt** — its own dest map (`fw.FiltersInet6`) means a name shared
  between `family inet` and `family inet6` lands in two different maps and does
  not collide; the legitimate dual-stack same-name case is preserved.
- Runs on the raw AST (the colliding definitions are merged away by
  last-write-wins by the time `fw.FiltersInet` exists).
- **Strict** commit / commit-check hard-rejects; the tolerant **load / peer-sync**
  path downgrades to a `cfg.Warnings` entry
  (`lenientFirewallFilterFamilyCollisions`, #1960 / #3261 no-brick) so an
  already-persisted config an older binary silently accepted still boots.

## Reachability

The schema-driven flat `set` grammar only structures `family inet` / `inet6`, so
an unknown family reaches a structured `filter` subtree — and thus the
fold-overwrite — only via a hierarchical config-file parse or a
directly-constructed / peer-synced AST. Tests use `parseHier` + a directly-built
AST, the actual reachable path.

## Validation

- `go test ./pkg/config/...` green; `go build ./...` clean; gofmt + `go vet` clean.
- **RED-on-revert**: neutralizing the gate (forcing lenient) makes the strict
  Rejected tests fail — `CompileConfig` returns nil and the discard is silently
  overwritten by the accept.
- Tests (`pkg/config/compiler_firewall_family_collision_3884_test.go`): strict
  reject (inet/any and mpls/any, incl. split-block); lenient warn-not-brick with
  the surviving fail-open accept asserted; inet/inet6 dual-stack + single-family
  no-false-reject.
- Docs: new `docs/config-schema.md` gate section; `_Log.md` entry.

Closes #3884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
