### PR TITLE
config: gate NAT64 rule-set prefix to /96 at commit (#3886)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28759,3 +28759,30 @@ top.
   pkg/frr/README.md (MINOR 1 metric-only-doesn't-float),
   pkg/config/delete_static_nexthop_3872_test.go (new, 5 tests),
   pkg/frr/static_empty_route_3872_test.go (new, 2 tests)
+
+## 2026-07-03 — #3886 NAT64 rule-set `prefix` /96 commit gate
+- **Timestamp**: 2026-07-03
+- **Action**: Add commit-time strict/lenient validator for a NAT64 rule-set
+  `prefix`. A non-/96 or malformed prefix committed GREEN then made the Rust
+  `Nat64State::try_from_snapshots` /96-integrity check
+  (`userspace-dp/src/nat64.rs`) abort the ENTIRE `build_reconcile_forwarding`
+  without publishing → dataplane frozen at the last-good snapshot → every later
+  commit silently stopped reaching the dataplane. New `validateNAT64PrefixStrict`
+  (`compiler_nat.go`, wired after `validateNPTv6Strict` in `compileExpanded`)
+  mirrors the Rust check EXACTLY: split on `/`, the mask token must parse as
+  decimal `96` (only /96 supported), the address token must be IPv6 via the
+  textual `natAddrFamily` (colon == v6, matching Rust `Ipv6Addr::from_str` incl.
+  the `::ffff:x` mapped form). Strict (commit/commit-check): hard-reject.
+  Lenient (`CompileConfigLenient`/`CompileConfigForNodeLenient`, new
+  `lenientNAT64Prefix` flag): warn so an already-persisted / peer-synced bad
+  prefix still BOOTS (#1960 no-brick) — the helper's own try_from_snapshots
+  backstop keeps the previous live state. Empty/absent prefix is out of scope
+  (buildNAT64Snapshots skips it, never reaches the Rust check). RED-on-revert
+  proven (forcing lenient=true made all reject tests FAIL). go test
+  ./pkg/config/... green; go build ./... clean; gofmt + vet clean. Flagged the
+  Rust abort-whole-rebuild-vs-skip-bad-rule as a separate defense-in-depth
+  follow-up (larger userspace-dp change), not fixed here.
+- **File(s)**: pkg/config/compiler_nat.go (validateNAT64PrefixStrict),
+  pkg/config/compiler.go (lenientNAT64Prefix option + wiring + 2 lenient
+  blocks), pkg/config/compiler_nat64_prefix_test.go (new, 11 tests),
+  docs/config-schema.md (#3886 subsection)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3188,6 +3188,63 @@ match/prefix reject + parseable host/​block still-compile + lenient-warn). Lik
 `pool-utilization-alarm`, this is compiler-side only — not yet a typed
 `setSchema` leaf.
 
+### #3886 — NAT64 rule-set `prefix` /96 commit gate
+
+A NAT64 rule-set `prefix` (`security nat nat64 rule-set <r> prefix <p>`) is read
+verbatim into the wire snapshot (`compileNAT64` in `compiler_nat.go` →
+`NAT64RuleSnapshot.Prefix` via `buildNAT64Snapshots`) and parsed at dataplane
+apply by `Nat64State::try_from_snapshots` (`userspace-dp/src/nat64.rs`). That
+**/96-integrity check** requires an IPv6 `<address>/96`: it splits the string on
+`/`, the token after the first `/` MUST parse as a decimal `96` (only `/96` is
+supported by the translator), and the address token before the `/` MUST parse as
+an `Ipv6Addr`. Anything else — a non-`/96` length, a missing/garbage mask, or a
+non-IPv6 / malformed address — makes `try_from_snapshots` return a
+`SnapshotIntegrityError`, which propagates via `?` out of
+`build_reconcile_forwarding` and **aborts the ENTIRE forwarding rebuild WITHOUT
+publishing**. The dataplane is then frozen at the last-good snapshot: every later
+commit (new sessions, policy, NAT) silently stops reaching the dataplane. The
+`prefix` `setSchema` leaf (`schema_security.go`) carries no `keyValidator`
+(unlike the RA `nat-prefix`/`nat64prefix` leaves, whose `ValidatePREF64CIDR`
+accepts the broader RFC 8781 `{32,40,48,56,64,96}` set — WRONG for a NAT64
+translator that supports `/96` only), so before this gate a bad prefix committed
+GREEN and wedged the whole control→dataplane pipeline.
+
+`validateNAT64PrefixStrict` (`pkg/config/compiler_nat.go`, invoked from the
+typed-config phase of `compileExpanded` in `compiler.go`, right after
+`validateNPTv6Strict`) closes that gap and mirrors the Rust check EXACTLY (split
+on `/`, mask token must be `96`, address token must be IPv6 via the textual
+`natAddrFamily` — a colon means IPv6, matching Rust `Ipv6Addr::from_str` for the
+IPv4-mapped `::ffff:x` form), so anything that would abort the rebuild at runtime
+is rejected at commit — no commit-accept → runtime-abort gap.
+
+- **Scope / out-of-scope:** only a NON-EMPTY prefix is validated. An empty/absent
+  prefix is deliberately exempt — `buildNAT64Snapshots` skips an empty-prefix
+  rule, so it is never emitted on the wire and never reaches the Rust check, so
+  it cannot freeze the rebuild.
+- **Strict (`commit` / `commit check`):** a non-`/96` or malformed prefix is a
+  HARD commit error naming the rule-set and offending prefix.
+- **Lenient (`Store.Load` / HA peer-sync — `CompileConfigLenient` /
+  `CompileConfigForNodeLenient`, flag `lenientNAT64Prefix`):** the violation
+  downgrades to a `cfg.Warnings` entry so a node that committed a bad NAT64
+  prefix BEFORE this gate existed (or a peer-synced config) still BOOTS after
+  upgrade instead of failing closed (#1960 fail-closed-on-compile-failure). The
+  Rust helper's own `try_from_snapshots` backstop keeps the previous live
+  forwarding state, so a leniently-loaded bad prefix is inert — and the
+  operator's next strict commit rejects it loudly.
+
+> Defense-in-depth follow-up (not fixed here): even with the commit gate, a bad
+> NAT64 prefix arriving via HA peer-sync/lenient still makes the Rust
+> `try_from_snapshots` reject the WHOLE forwarding snapshot rather than skipping
+> just the bad NAT64 rule and publishing the rest. Scoping the Rust rejection to
+> the offending rule is a larger `userspace-dp` change tracked separately.
+
+Regression coverage: `pkg/config/compiler_nat64_prefix_test.go` (well-known
+`64:ff9b::/96` + `/96` NSP accept; non-`/96` lengths, missing mask, garbage
+mask, malformed IPv6 address, and IPv4 prefix reject with asserted message;
+lenient strict-reject → warn + valid-no-warning). Compiler-side only — not a
+typed `setSchema` leaf (a schema `keyValidator` has no lenient mode and would
+hard-reject on the load path too, re-introducing the #1960 boot-brick).
+
 ### #2217 — firewall / application undefined-reference validation
 
 Three firewall/application cross-references compiled cleanly with no operator

--- a/pkg/config/compiler.go
+++ b/pkg/config/compiler.go
@@ -599,6 +599,21 @@ type compileOpts struct {
 	// is inert. Commit stays strict so the operator's next edit fails loudly.
 	// Same doctrine as lenientNATHostMask.
 	lenientNPTv6 bool
+	// lenientNAT64Prefix (#3886) downgrades the NAT64 `prefix` /96 commit gate
+	// (validateNAT64PrefixStrict) from a hard compile error to a cfg.Warnings
+	// entry. The strict commit / commit-check path hard-rejects a NAT64
+	// rule-set prefix that is not an IPv6 `<address>/96` (a non-/96 length, a
+	// missing/garbage mask, or a non-IPv6 address). Before this gate such a
+	// prefix committed green, then the Rust Nat64State::try_from_snapshots
+	// /96-integrity check aborted the WHOLE forwarding rebuild without
+	// publishing — freezing the dataplane at the last-good snapshot so every
+	// later commit silently stopped taking effect. The tolerant load / peer-sync
+	// paths downgrade to a warning so an already-persisted or peer-synced config
+	// carrying a bad NAT64 prefix still BOOTS (#1960 no-brick) — the helper's own
+	// try_from_snapshots backstop keeps the previous live state, so a
+	// leniently-loaded bad prefix is inert. Commit stays strict so the operator's
+	// next edit fails loudly. Same doctrine as lenientNPTv6.
+	lenientNAT64Prefix bool
 	// lenientFirewallRefs (#2217) downgrades the firewall-filter term
 	// cross-reference gates — `then policer <name>` (Finding A,
 	// validateFirewallPolicerReferencesStrict) and `then routing-instance
@@ -1393,6 +1408,7 @@ func CompileConfigLenient(tree *ConfigTree) (*Config, error) {
 		lenientFilterRoutingInstanceConflict:   true,
 		lenientFilterDSCP:                      true,
 		lenientNPTv6:                           true,
+		lenientNAT64Prefix:                     true,
 		lenientFirewallRefs:                    true,
 		lenientFlowServerTemplateRef:           true,
 		lenientSamplingInstanceConflicts:       true,
@@ -1572,6 +1588,7 @@ func CompileConfigForNodeLenient(tree *ConfigTree, nodeID int) (*Config, error) 
 		lenientFilterRoutingInstanceConflict:   true,
 		lenientFilterDSCP:                      true,
 		lenientNPTv6:                           true,
+		lenientNAT64Prefix:                     true,
 		lenientFirewallRefs:                    true,
 		lenientFlowServerTemplateRef:           true,
 		lenientSamplingInstanceConflicts:       true,
@@ -3776,6 +3793,23 @@ func compileExpanded(tree *ConfigTree, opts compileOpts) (*Config, error) {
 		return nil, err
 	}
 	cfg.Warnings = append(cfg.Warnings, nptv6Warnings...)
+
+	// #3886: NAT64 prefix commit gate. A NAT64 rule-set `prefix` is read
+	// verbatim into the wire snapshot and parsed at dataplane apply by the Rust
+	// Nat64State::try_from_snapshots /96-integrity check. A non-/96 or malformed
+	// prefix committed green then makes that check ABORT the entire forwarding
+	// rebuild without publishing — freezing the dataplane at the last-good
+	// snapshot so every later commit silently stops reaching it. Strict (commit
+	// / commit-check): hard-reject anything that is not `<ipv6-address>/96`,
+	// matching the Rust check exactly so there is no commit-accept ->
+	// runtime-abort gap. Lenient (load / peer-sync): warn so a config committed
+	// before this gate existed still boots; the Rust helper independently keeps
+	// the previous live state, so the bad rule is inert.
+	nat64PrefixWarnings, err := validateNAT64PrefixStrict(cfg, opts.lenientNAT64Prefix)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Warnings = append(cfg.Warnings, nat64PrefixWarnings...)
 
 	// #1434 multi-peer WireGuard: per-tunnel commit gate. Strict (commit /
 	// commit-check): hard-reject a WG tunnel with a missing/invalid

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -686,6 +686,99 @@ func validateNPTv6Strict(cfg *Config, lenient bool) ([]string, error) {
 	return warnings, nil
 }
 
+// validateNAT64PrefixStrict is the #3886 strict-vs-lenient gate for a NAT64
+// rule-set's `prefix` (`security nat nat64 rule-set <r> prefix <p>`).
+//
+// The prefix is read verbatim into NAT64RuleSnapshot.Prefix
+// (compiler_nat.go:compileNAT64 -> buildNAT64Snapshots) and parsed at
+// dataplane apply by Nat64State::try_from_snapshots (userspace-dp/src/nat64.rs).
+// That /96-integrity check REQUIRES the prefix to be `<ipv6-address>/96`: it
+// splits on '/', the token after the first '/' MUST parse as a decimal /96
+// (only /96 is supported by the translator), and the address token before the
+// '/' MUST parse as an IPv6 address. Anything else (a non-/96 length, a missing
+// or garbage mask, a non-IPv6 / malformed address) makes try_from_snapshots
+// return a SnapshotIntegrityError, which propagates via `?` out of
+// build_reconcile_forwarding and ABORTS the whole forwarding rebuild WITHOUT
+// publishing a snapshot. The dataplane is then frozen at the last-good state:
+// every later commit (new sessions, policy, NAT) silently stops reaching the
+// dataplane with no operator feedback. Without this gate a single bad NAT64
+// prefix COMMITS GREEN and wedges the entire control->dataplane pipeline.
+//
+// This mirrors the Rust /96-integrity check EXACTLY so anything that would
+// abort the rebuild at runtime is rejected at commit — no commit-accept ->
+// runtime-abort gap. An empty/absent prefix is deliberately OUT OF SCOPE: the
+// Go builder (buildNAT64Snapshots) skips an empty-prefix rule, so it is never
+// emitted on the wire and never reaches the Rust check, so it cannot freeze the
+// rebuild.
+//
+// Strict (commit / commit-check): hard-reject a non-/96 or malformed prefix.
+// Lenient (load / peer-sync, #1960 / #1979 doctrine): return the message as a
+// warning so a config committed before this gate existed (or peer-synced) still
+// BOOTS — fail-closed-on-compile-failure would otherwise brick the daemon on
+// restart. The Rust helper's own try_from_snapshots backstop keeps the previous
+// live forwarding state on the leniently-loaded config, so the bad rule never
+// installs. Same doctrine as validateNPTv6Strict.
+func validateNAT64PrefixStrict(cfg *Config, lenient bool) ([]string, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	var warnings []string
+	emit := func(msg string) error {
+		if lenient {
+			warnings = append(warnings,
+				msg+" (this NAT64 rule is invalid; on a userspace-dataplane apply/preflight"+
+					" the helper's Nat64State::try_from_snapshots rejects the whole forwarding"+
+					" snapshot and the previous live state is kept, so this rule — and every"+
+					" later config change — will not reach the dataplane until it is corrected)")
+			return nil
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	for _, rs := range cfg.Security.NAT.NAT64 {
+		if rs == nil || rs.Prefix == "" {
+			continue
+		}
+		// Mirror Nat64State::try_from_snapshots (userspace-dp/src/nat64.rs)
+		// EXACTLY. Split on '/' (Rust `split('/')`); a trailing junk field
+		// after the mask is ignored by both sides, so we index [0] and [1] and
+		// disregard the rest rather than SplitN'ing the mask.
+		parts := strings.Split(rs.Prefix, "/")
+		// The token after the first '/' must parse as a decimal /96. A missing
+		// mask (no '/'), an empty mask, a non-numeric mask, or any length other
+		// than 96 is rejected — only /96 is supported by the translator.
+		mask96 := false
+		if len(parts) >= 2 {
+			if m, err := strconv.ParseUint(parts[1], 10, 8); err == nil && m == 96 {
+				mask96 = true
+			}
+		}
+		if !mask96 {
+			if err := emit(fmt.Sprintf(
+				"security nat nat64 rule-set %q prefix %q must be an IPv6 prefix of length /96 (RFC 6052: the well-known 64:ff9b::/96 or a /96 network-specific prefix); any other length or a missing/garbage mask is rejected by the dataplane, which aborts the entire forwarding rebuild",
+				rs.Name, rs.Prefix)); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		// The address token before the first '/' must parse as an IPv6 address.
+		// natAddrFamily keys the family on the un-parsed text (colon == v6) so
+		// an IPv4-mapped literal (::ffff:1.2.3.4) is classified V6, matching
+		// Rust's Ipv6Addr::from_str exactly (a dotted-quad or a non-IP token is
+		// NOT V6 and is rejected).
+		if natAddrFamily(parts[0]) != "v6" {
+			if err := emit(fmt.Sprintf(
+				"security nat nat64 rule-set %q prefix %q has an address part %q that is not a valid IPv6 address; the dataplane rejects it and aborts the entire forwarding rebuild",
+				rs.Name, rs.Prefix, parts[0])); err != nil {
+				return nil, err
+			}
+			continue
+		}
+	}
+
+	return warnings, nil
+}
+
 func compileNAT(node *Node, sec *SecurityConfig) error {
 	// Initialize SourcePools map
 	if sec.NAT.SourcePools == nil {

--- a/pkg/config/compiler_nat64_prefix_test.go
+++ b/pkg/config/compiler_nat64_prefix_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3886: commit-time validation for a NAT64 rule-set `prefix`.
+//
+// The prefix is read verbatim into the wire snapshot (compileNAT64 ->
+// buildNAT64Snapshots) and parsed at dataplane apply by the Rust
+// Nat64State::try_from_snapshots /96-integrity check (userspace-dp/src/nat64.rs).
+// That check REQUIRES an IPv6 `<address>/96`: it splits on '/', the token after
+// the first '/' must parse as a decimal 96 (only /96 is supported), and the
+// address token before the '/' must parse as an IPv6 address. Anything else
+// makes try_from_snapshots return a SnapshotIntegrityError, which aborts the
+// ENTIRE build_reconcile_forwarding without publishing — freezing the dataplane
+// at the last-good snapshot so every later commit silently stops reaching it.
+//
+// The commit gate rejects a non-/96 or malformed prefix at commit so the
+// operator gets an error instead of a silent dataplane freeze. RED-on-revert:
+// deleting validateNAT64PrefixStrict makes each reject-case below compile
+// cleanly (commit green, then dataplane-rebuild freeze) -> the reject tests go
+// RED.
+//
+// All tests use the production ParseSetCommand + SetPath path (buildTree),
+// never NewParser (the flat-set gotcha in CLAUDE.md).
+
+// nat64Set builds a minimal NAT64 rule-set with the given prefix.
+func nat64Set(prefix string) []string {
+	return []string{
+		"set security nat nat64 rule-set rs1 prefix " + prefix,
+	}
+}
+
+func TestNAT64PrefixWellKnownSlash96OK(t *testing.T) {
+	// RFC 6052 well-known prefix 64:ff9b::/96 — must compile on the strict path.
+	tree := buildTree(t, nat64Set("64:ff9b::/96"))
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("well-known 64:ff9b::/96 must compile, got: %v", err)
+	}
+}
+
+func TestNAT64PrefixNSPSlash96OK(t *testing.T) {
+	// A /96 network-specific prefix — must compile on the strict path.
+	for _, p := range []string{"2001:db8::/96", "2001:db8:1:2:3:4::/96"} {
+		tree := buildTree(t, nat64Set(p))
+		if _, err := CompileConfig(tree); err != nil {
+			t.Fatalf("/96 NSP %q must compile, got: %v", p, err)
+		}
+	}
+}
+
+func TestNAT64PrefixWithSourcePoolSlash96OK(t *testing.T) {
+	// A complete NAT64 rule-set (prefix + valid /32 source pool) must compile.
+	tree := buildTree(t, []string{
+		"set security nat source pool p64 address 100.64.0.7/32",
+		"set security nat nat64 rule-set rs1 prefix 64:ff9b::/96",
+		"set security nat nat64 rule-set rs1 source-pool p64",
+	})
+	if _, err := CompileConfig(tree); err != nil {
+		t.Fatalf("valid NAT64 rule-set must compile, got: %v", err)
+	}
+}
+
+func TestNAT64PrefixRejectsNonSlash96(t *testing.T) {
+	// A non-/96 length (the exact case in the issue) — reject at commit. The
+	// Rust /96-integrity check aborts the whole forwarding rebuild otherwise.
+	tree := buildTree(t, nat64Set("2001:db8::/64"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("NAT64 prefix /64 (non-/96) must be rejected at commit")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "rs1") ||
+		!strings.Contains(msg, "2001:db8::/64") ||
+		!strings.Contains(msg, "/96") {
+		t.Fatalf("error must name the rule-set + offending prefix + /96 requirement, got: %v", err)
+	}
+}
+
+func TestNAT64PrefixRejectsOtherLengths(t *testing.T) {
+	// Every non-96 mask length must be rejected (the translator supports /96
+	// only; any other length is silently dropped -> rebuild abort).
+	for _, p := range []string{"64:ff9b::/32", "64:ff9b::/48", "64:ff9b::/64", "64:ff9b::/128", "64:ff9b::/95"} {
+		tree := buildTree(t, nat64Set(p))
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatalf("NAT64 prefix %q (non-/96) must be rejected at commit", p)
+		}
+	}
+}
+
+func TestNAT64PrefixRejectsMissingMask(t *testing.T) {
+	// A bare address with no mask — Rust `parts.get(1)` is None -> reject.
+	tree := buildTree(t, nat64Set("64:ff9b::"))
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatal("NAT64 prefix with no /mask must be rejected at commit")
+	}
+}
+
+func TestNAT64PrefixRejectsGarbageMask(t *testing.T) {
+	// A non-numeric or empty mask — Rust `.parse::<u8>()` fails -> reject.
+	for _, p := range []string{"64:ff9b::/", "64:ff9b::/xx", "64:ff9b::/96x", "64:ff9b::/300"} {
+		tree := buildTree(t, nat64Set(p))
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatalf("NAT64 prefix %q (garbage mask) must be rejected at commit", p)
+		}
+	}
+}
+
+func TestNAT64PrefixRejectsMalformedAddress(t *testing.T) {
+	// The mask is /96 but the address part does not parse as IPv6 — Rust
+	// `parts[0].parse::<Ipv6Addr>()` fails -> reject. Covers a garbage token
+	// and an IPv4 dotted-quad (which Rust's Ipv6Addr::from_str rejects).
+	for _, p := range []string{"nonsense/96", "192.0.2.0/96", "64:ff9b:::/96", "g::1/96"} {
+		tree := buildTree(t, nat64Set(p))
+		if _, err := CompileConfig(tree); err == nil {
+			t.Fatalf("NAT64 prefix %q (malformed IPv6 address) must be rejected at commit", p)
+		}
+	}
+}
+
+func TestNAT64PrefixRejectsIPv4(t *testing.T) {
+	// An IPv4 CIDR — Rust rejects (not an Ipv6Addr, and /24 != 96) -> reject.
+	tree := buildTree(t, nat64Set("192.0.2.0/24"))
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("NAT64 IPv4 prefix must be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "rs1") {
+		t.Fatalf("error must name the rule-set, got: %v", err)
+	}
+}
+
+// Lenient path (#1960 / #1979 doctrine): a bad NAT64 prefix in an
+// already-persisted or peer-synced config must NOT hard-fail the compile
+// (that would brick the daemon on restart); it is downgraded to a warning.
+func TestNAT64PrefixLenientDowngradesToWarning(t *testing.T) {
+	for _, p := range []string{"2001:db8::/64", "64:ff9b::", "nonsense/96", "192.0.2.0/24"} {
+		tree := buildTree(t, nat64Set(p))
+		cfg, err := CompileConfigLenient(tree)
+		if err != nil {
+			t.Fatalf("lenient compile must NOT hard-fail on bad NAT64 prefix %q, got: %v", p, err)
+		}
+		found := false
+		for _, w := range cfg.Warnings {
+			if strings.Contains(w, "rs1") && strings.Contains(w, p) && strings.Contains(w, "nat64") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("lenient compile must emit a warning naming the bad NAT64 prefix %q, warnings: %v", p, cfg.Warnings)
+		}
+	}
+}
+
+// The valid well-known prefix must NOT warn on the lenient path either — the
+// gate must be silent on good input (no warning-noise regression).
+func TestNAT64PrefixLenientNoWarningOnValid(t *testing.T) {
+	tree := buildTree(t, nat64Set("64:ff9b::/96"))
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient compile of valid prefix must not fail, got: %v", err)
+	}
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "nat64") && strings.Contains(w, "prefix") {
+			t.Fatalf("valid NAT64 prefix must not warn, got: %q", w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #3886 (fable-review-161 F-032, MEDIUM availability — dataplane freeze).

A NAT64 rule-set `prefix` (`security nat nat64 rule-set <r> prefix <p>`) was read verbatim into the wire snapshot (`compileNAT64` → `buildNAT64Snapshots` → `NAT64RuleSnapshot.Prefix`) with **no** commit-time check that it is a valid IPv6 `/96`. The Rust helper then parses it at dataplane apply in `Nat64State::try_from_snapshots` (`userspace-dp/src/nat64.rs`), whose **/96-integrity check** rejects anything that is not `<ipv6-address>/96` by returning a `SnapshotIntegrityError`. That error propagates via `?` out of `build_reconcile_forwarding` and **aborts the entire forwarding rebuild without publishing** — freezing the dataplane at the last-good snapshot so **every later commit silently stops reaching the dataplane**. A single bad NAT64 prefix committed green and wedged the whole control→dataplane pipeline.

## Fix

`validateNAT64PrefixStrict` (`pkg/config/compiler_nat.go`), wired after `validateNPTv6Strict` in `compileExpanded`, mirrors the Rust check **exactly** so anything that would abort the rebuild at runtime is rejected at commit (no commit-accept → runtime-abort gap):

- split the prefix on `/`; the token after the first `/` must parse as decimal `96` (only `/96` is supported by the translator);
- the address token before the `/` must be IPv6, classified textually via `natAddrFamily` (a colon means v6 — matches Rust `Ipv6Addr::from_str`, including the IPv4-mapped `::ffff:x` form).

Strict/lenient split (same doctrine as `validateNPTv6Strict` / `validateNATHostMaskStrict`):

- **Strict** (`commit` / `commit check`): hard-reject a non-`/96` or malformed prefix, naming the rule-set and offending value.
- **Lenient** (`Store.Load` / HA peer-sync via `CompileConfigLenient` / `CompileConfigForNodeLenient`, new `lenientNAT64Prefix` flag): downgrade to a `cfg.Warnings` entry so a config committed before this gate existed still **boots** (#1960 fail-closed-on-compile-failure would otherwise brick the daemon on restart). The Rust helper's own `try_from_snapshots` backstop keeps the previous live state, so a leniently-loaded bad prefix is inert.

An **empty/absent** prefix is deliberately out of scope: `buildNAT64Snapshots` skips an empty-prefix rule, so it never reaches the Rust check and cannot freeze the rebuild.

Not a schema `keyValidator`: the RA `nat-prefix`/`nat64prefix` leaves' `ValidatePREF64CIDR` accepts the broader RFC 8781 `{32,40,48,56,64,96}` set (wrong for a `/96`-only NAT64 translator), and a schema validator has no lenient mode — it would hard-reject on the load path too, re-introducing the #1960 boot-brick.

## Exact Rust rule matched

`userspace-dp/src/nat64.rs` `Nat64State::try_from_snapshots`:
- `snap.prefix.split('/')`; `parts.get(1).and_then(|s| s.parse::<u8>().ok())` must be `Some(96)` (else `Nat64UnparseableRule`);
- `parts[0].parse::<Ipv6Addr>()` must succeed (else `Nat64UnparseableRule`).

## Testing

- New `pkg/config/compiler_nat64_prefix_test.go` (11 tests) via `ParseSetCommand` + `SetPath` + `CompileConfig`: well-known `64:ff9b::/96` and `/96` NSP **accept**; non-`/96` lengths, missing mask, garbage mask, malformed IPv6 address, and IPv4 prefix **reject** with asserted message; lenient strict-reject → warn + valid-no-warning.
- **RED-on-revert proven**: forcing the gate lenient made every reject test FAIL (`prefix 2001:db8::/64` and malformed prefixes committed green → dataplane-rebuild freeze).
- `go test ./pkg/config/...` green; `go build ./...` clean; `gofmt` + `go vet` clean.

## Follow-up (flagged, not fixed here)

Even with the commit gate, a bad NAT64 prefix arriving via HA peer-sync/lenient still makes the Rust `try_from_snapshots` reject the **whole** forwarding snapshot rather than skipping only the bad NAT64 rule and publishing the rest. Scoping the Rust rejection to the offending rule (defense-in-depth) is a larger `userspace-dp` change worth tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi