### PR TITLE
wg: add a `next` keypair slot so a responder rekey never blackholes egress (#3882)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,43 @@
+## 2026-07-03 — #3882: WireGuard responder rekey promoted an UNCONFIRMED session straight to `current` (no `next` slot) — 3-slot keypair lifecycle fix
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-019 (HIGH security, replayable egress DoS).
+    The userspace WG used a 2-slot keypair model (current/previous). When xpf
+    was the RESPONDER to a (re)key, `install_session` rotated the UNCONFIRMED
+    new session straight into `current`, demoting the confirmed keypair to
+    `previous`. Egress (`try_encap`) reads `current` only → NoSession → every
+    PEER-INITIATED rekey blackholed xpf→peer egress until the peer sent data
+    (replayable → persistent egress DoS).
+  - **Fix**: Added a third `next` keypair slot mirroring kernel WireGuard's
+    current/previous/next lifecycle. `Peer::install_new_session` (peer.rs) now
+    routes by role: Initiator → `current` (confirmed by the handshake response,
+    old current→previous, stale `next` evicted); Responder → `next`
+    (unconfirmed; `current`/`previous` untouched so egress never blackholes).
+    `try_decap` → `WgEngine::maybe_promote_next` (engine.rs) promotes
+    next→current (old current→previous) on the FIRST authenticated inbound data
+    record on the `next` keypair (WG confirm-on-first-inbound-data), via a
+    double-checked lock (cheap `next` read pre-check; `reconcile_lock` only on
+    the actual promotion). `Peer::promote_next` does the slot slide. `next` is
+    demux-registered, drained on peer-removal (`reconcile_peers`) and torn down
+    at REJECT_AFTER_TIME (`expire_sessions`). The initiator lifecycle and the
+    egress `is_confirmed()` defense-in-depth gate are unchanged; no wire change.
+  - **Validation**: FULL `cargo test --release` green
+    (CARGO_TARGET_DIR=/dev/shm/cargo-3882). RED-on-revert proven: reverting the
+    responder→`next` routing to the 2-slot rotate makes
+    `peer_initiated_rekey_does_not_blackhole_egress` panic on the egress
+    `.expect`. New tests: peer-initiated-rekey no-blackhole + promote +
+    previous-keypair grace; initiator-rekey immediate switch; rewrote
+    `encap_no_session_vs_unconfirmed_split` for the 3-slot reality (unconfirmed
+    keypair in `next` ⇒ no_session, gate kept as defense-in-depth). FLAG:
+    test-failover / WG-rekey-soak WARRANTED (batch-validate).
+  - **File(s)**: userspace-dp/src/afxdp/wg/peer.rs (next slot + install_new_session
+    + promote_next), userspace-dp/src/afxdp/wg/engine.rs (install_session_locked
+    role routing, maybe_promote_next, reconcile next-drain, test helpers),
+    userspace-dp/src/afxdp/wg/timers.rs (expire next slot),
+    userspace-dp/src/afxdp/wg/counters.rs (doc), userspace-dp/src/afxdp/wg/tests.rs
+    (established_pair promote + 2 new tests + rewrites),
+    docs/pr/wireguard-clean/plan.md (3-slot lifecycle bullet)
+
 ## 2026-07-03 — #3876: rib-group interface-route import was a no-op (shadowed by default route) — per-prefix leak before main
 
 - **Timestamp**: 2026-07-03

--- a/docs/pr/wireguard-clean/plan.md
+++ b/docs/pr/wireguard-clean/plan.md
@@ -168,7 +168,8 @@ message and at most one output message. Nothing to "drain".
   lives in a single `ArcSwap<PeerTable>` (`engine.rs:262`) so the
   hot path observes the three sub-fields as one atomic snapshot
   (`peer_arc` does an `ArcSwap::load` only — no lock). Per-peer
-  session state (`peer.current` / `peer.previous`) is
+  session state (`peer.current` / `peer.previous` / `peer.next`, the
+  3-slot keypair lifecycle — see below) is
   `RwLock<Option<Arc<WgSession>>>` and ingress demux
   (`sessions_by_local_index`) is `RwLock<FxHashMap<u32, Arc<WgSession>>>`,
   so encap takes one `RwLock::read` on `peer.current`
@@ -179,7 +180,27 @@ message and at most one output message. Nothing to "drain".
   earlier draft of this bullet claimed "never under a lock on the
   hot path"; that overstated the invariant — the lock-free property
   applies to the peer-table snapshot via `ArcSwap`, not to the
-  per-session current/previous slots or the inbound demux map.
+  per-session current/previous/next slots or the inbound demux map.
+- 3-slot keypair lifecycle (#3882, mirrors kernel WireGuard
+  `current`/`previous`/`next`): `peer.current` is the CONFIRMED
+  keypair egress encrypts with; `peer.previous` retains the prior
+  current so in-flight reverse traffic decrypts across a rotation;
+  `peer.next` holds a responder-role keypair that has NOT yet been
+  confirmed. When xpf is the RESPONDER to a (re)key,
+  `Peer::install_new_session` parks the new session in `next`, NOT
+  `current` — egress keeps using the confirmed `current`, so a
+  peer-initiated rekey never blackholes xpf→peer egress. The first
+  authenticated inbound data record on the `next` keypair
+  (`WgEngine::maybe_promote_next` in `try_decap`, double-checked
+  locking under `reconcile_lock`) promotes next→current (old
+  current→previous). Initiator-role installs (the handshake response
+  already confirmed them) go straight into `current` as before. All
+  three slots are demux-registered, drained on peer-removal
+  (`reconcile_peers`), and torn down at REJECT_AFTER_TIME
+  (`expire_sessions`). Before #3882 the 2-slot model rotated the
+  unconfirmed responder keypair straight into `current`, so every
+  peer-initiated rekey blackholed egress until the peer sent data — a
+  replayable egress DoS (fable-161 F-019).
 - Replay windows are per-session, tracked by a `ReplayState`
   (single counter + 64-bit sliding bitmap, RFC 6479) guarded by a
   `std::sync::Mutex` on the session. Encap is lock-free on the

--- a/userspace-dp/src/afxdp/wg/counters.rs
+++ b/userspace-dp/src/afxdp/wg/counters.rs
@@ -104,10 +104,16 @@ pub(crate) struct WgCounters {
     /// `EncapError::NoSession` from the no-current-session arm ONLY.
     pub(crate) encap_drops_no_session: AtomicU64,
     /// `EncapError::NoSession` from the `is_confirmed()` gate arm —
-    /// the responder key-confirmation window. Distinguishable so an
-    /// operator does not tcpdump a transient rekey blip (#1736 AGY
-    /// r2). Counter-only split: the returned error stays `NoSession`
-    /// and every caller contract is untouched.
+    /// egress was asked to encrypt on an UNCONFIRMED `current` session.
+    /// Distinguishable so an operator does not tcpdump a transient rekey
+    /// blip (#1736 AGY r2). Counter-only split: the returned error stays
+    /// `NoSession` and every caller contract is untouched. After the
+    /// #3882 3-slot keypair fix an unconfirmed responder keypair lives
+    /// in `next`, never `current`, so the natural responder-rekey path
+    /// no longer reaches this gate (it reports `encap_drops_no_session`
+    /// while the confirmed `current` keeps serving egress); the gate
+    /// remains as a defense-in-depth invariant that egress never uses an
+    /// unconfirmed session.
     pub(crate) encap_drops_unconfirmed: AtomicU64,
     pub(crate) encap_drops_rekey_required: AtomicU64,
     /// UnknownPeer | CryptoFailed | BufferTooSmall — all
@@ -134,7 +140,7 @@ pub(crate) struct WgCounters {
     /// (drop-only; never arms the rekey edge — Codex r1 M4).
     pub(crate) decap_drops_expired: AtomicU64,
     /// Sessions torn down by the control thread's `expire_sessions`
-    /// pass (current + previous slots).
+    /// pass (current + previous + next slots, #3882).
     pub(crate) sessions_expired: AtomicU64,
     /// Timer-driven handshake initiations by reason: `age` = the rekey
     /// edge (T1 send-age / T2 receive-horizon / send-side T3),

--- a/userspace-dp/src/afxdp/wg/engine.rs
+++ b/userspace-dp/src/afxdp/wg/engine.rs
@@ -622,7 +622,7 @@ impl WgEngine {
     ///   1. Build a fresh `PeerTable` off-line (no readers see partial
     ///      state).
     ///   2. Identify peers present in the old table but absent in the
-    ///      new one. Drain their `(current, previous)` session
+    ///      new one. Drain their `(current, previous, next)` session
     ///      `local_index` entries from `sessions_by_local_index`
     ///      before publishing the new table — otherwise an inbound
     ///      packet targeting a removed peer's session would decrypt
@@ -707,6 +707,11 @@ impl WgEngine {
             }
             if let Some(prev) = peer.previous.read().unwrap().as_ref() {
                 dropped_indices.push(prev.local_index);
+            }
+            // #3882: the pending `next` (unconfirmed responder) keypair
+            // is also demux-registered; drain it too or its entry leaks.
+            if let Some(next) = peer.next.read().unwrap().as_ref() {
+                dropped_indices.push(next.local_index);
             }
         }
         if !dropped_indices.is_empty() {
@@ -794,6 +799,36 @@ impl WgEngine {
             peer_index_by_pubkey: old.peer_index_by_pubkey.clone(),
             allowed_ips: old.allowed_ips.clone(),
         }));
+    }
+
+    /// Test-only: promote a peer's pending `next` keypair to `current`
+    /// exactly as the first authenticated inbound data record would
+    /// (drives `maybe_promote_next` → `promote_next` + demux cleanup),
+    /// WITHOUT running a real decap (no counter / tx / replay side
+    /// effects). Lets fixtures model a fully-established tunnel where the
+    /// responder session has been confirmed AND promoted. No-op if the
+    /// peer's `next` no longer holds `session` (#3882).
+    #[cfg(test)]
+    pub(crate) fn promote_next_for_test(&self, pubkey: &[u8; 32], session: &Arc<WgSession>) {
+        if let Some(peer) = self.peer_arc(pubkey) {
+            self.maybe_promote_next(&peer, session);
+        }
+    }
+
+    /// Test-only: force a session directly into a peer's `current` slot
+    /// (and register it for demux), bypassing the role-based install
+    /// routing. Used to exercise the egress `is_confirmed()`
+    /// defense-in-depth gate, which the #3882 3-slot model makes the
+    /// natural responder path no longer reach (an unconfirmed responder
+    /// keypair now parks in `next`, never `current`).
+    #[cfg(test)]
+    pub(crate) fn force_current_for_test(&self, pubkey: &[u8; 32], session: Arc<WgSession>) {
+        let peer = self.peer_arc(pubkey).expect("peer exists");
+        self.sessions_by_local_index
+            .write()
+            .unwrap()
+            .insert(session.local_index, session.clone());
+        *peer.current.write().unwrap() = Some(session);
     }
 
     /// Long-lived session/timer state for a peer (NOT its config).
@@ -884,22 +919,22 @@ impl WgEngine {
         // this trivially in expectation; a collision means the
         // caller must regenerate and retry).
         //
-        // After the demux insert, rotate_session() returns whichever
-        // session falls off the (current, previous) pair. That
-        // dropped session MUST then be removed from the demux map,
-        // and because the new session's local_index is now unique by
-        // construction, the remove cannot accidentally evict the
-        // entry we just inserted. The single-locked-region pattern
-        // keeps the (demux, current, previous) triple visible
-        // together to any subsequent decap.
+        // After the demux insert, install_new_session() routes the new
+        // session into `current` (initiator) or `next` (responder) per
+        // the 3-slot lifecycle and returns whichever session(s) fall out
+        // of the slots. Those evicted sessions MUST then be removed from
+        // the demux map, and because the new session's local_index is
+        // now unique by construction, the removes cannot accidentally
+        // evict the entry we just inserted. The single-locked-region
+        // pattern keeps the (demux, current, previous, next) tuple
+        // visible together to any subsequent decap.
         let new_local_index = session.local_index;
         let mut by_index = self.sessions_by_local_index.write().unwrap();
         if by_index.contains_key(&new_local_index) {
             return Err(InstallSessionError::LocalIndexCollision);
         }
         by_index.insert(new_local_index, session.clone());
-        let dropped_previous = peer.rotate_session(session);
-        if let Some(old) = dropped_previous {
+        for old in peer.install_new_session(session) {
             // `old.local_index != new_local_index` is guaranteed by
             // the uniqueness check above; the explicit assert keeps
             // the invariant visible if a future change ever relaxes
@@ -908,6 +943,37 @@ impl WgEngine {
             by_index.remove(&old.local_index);
         }
         Ok(())
+    }
+
+    /// #3882: promote a peer's pending `next` keypair to `current` when
+    /// the just-authenticated inbound `session` IS that pending keypair
+    /// (WG confirm-on-first-inbound-data). Called from `try_decap` after
+    /// a successful AEAD authenticate.
+    ///
+    /// Fast path: a cheap `next` RwLock read; if the record was on the
+    /// peer's `current`/`previous` (steady state) or the peer has no
+    /// pending `next`, return immediately with no `reconcile_lock`.
+    /// Slow path (once per responder rekey): take `reconcile_lock` to
+    /// serialize with install/reconcile/expiry, re-check `next` identity,
+    /// slide next→current (old current→previous), and drop the evicted
+    /// previous keypair from the demux map.
+    fn maybe_promote_next(&self, peer: &Peer, session: &Arc<WgSession>) {
+        // Pre-check WITHOUT the reconcile lock — the double-checked
+        // locking pattern (kernel `wg_noise_received_with_keypair`).
+        {
+            let next = peer.next.read().unwrap();
+            match next.as_ref() {
+                Some(n) if Arc::ptr_eq(n, session) => {}
+                _ => return,
+            }
+        }
+        let _guard = self.reconcile_lock.lock().unwrap();
+        if let Some(dropped_previous) = peer.promote_next(session) {
+            self.sessions_by_local_index
+                .write()
+                .unwrap()
+                .remove(&dropped_previous.local_index);
+        }
     }
 
     /// Hot-path encap.
@@ -1193,6 +1259,19 @@ impl WgEngine {
         // confirmation — the authentication is what the WG spec
         // ties confirmation to, not downstream policy gates.
         session.mark_confirmed();
+        // #3882 WG 3-slot keypair lifecycle: an authenticated inbound
+        // record on a peer's pending `next` (unconfirmed responder)
+        // keypair CONFIRMS it — promote next→current (old current→
+        // previous) so egress switches to the freshly-confirmed keypair.
+        // Done here (before the replay/LPM gates, same rationale as
+        // mark_confirmed) off ONE peer snapshot reused by the timer
+        // block below. The common steady-state record (on `current` or
+        // `previous`) returns from the fast pre-check with only a cheap
+        // RwLock read — no reconcile lock.
+        let peer = self.peer_arc(&session.peer_pubkey);
+        if let Some(peer) = peer.as_ref() {
+            self.maybe_promote_next(peer, &session);
+        }
         // Check the replay window AFTER successful decrypt — per
         // RFC 6479 / the WG paper, we mustn't update the window
         // for packets that fail authentication, or an attacker
@@ -1228,7 +1307,7 @@ impl WgEngine {
         // (arms T6) vs authenticated-recv (clears T7 only — a received
         // keepalive must not arm T6, no keepalive ping-pong).
         {
-            if let Some(peer) = self.peer_arc(&session.peer_pubkey) {
+            if let Some(peer) = peer.as_ref() {
                 if n == 0 {
                     peer.note_authenticated_recv(now_ns);
                 } else {

--- a/userspace-dp/src/afxdp/wg/peer.rs
+++ b/userspace-dp/src/afxdp/wg/peer.rs
@@ -3,8 +3,10 @@
 //! A peer holds:
 //!   - Its static public key (the identity used by the engine table).
 //!   - Optionally an endpoint (UDP `IP:port`) for outbound handshake.
-//!   - Active and previous transport sessions (current + prior, to
-//!     allow in-flight rekey handover).
+//!   - The 3-slot keypair lifecycle (#3882): `current` (confirmed,
+//!     egress), `previous` (prior current, in-flight rekey handover),
+//!     and `next` (unconfirmed responder keypair awaiting the peer's
+//!     first inbound data record). See the `Peer` struct doc.
 //!
 //! Reconciliation: the engine rebuilds the peer set from the config
 //! snapshot whenever a new snapshot lands. Existing peer state is
@@ -12,7 +14,7 @@
 //! AllowedIPs trie is rebuilt fresh because its index space is
 //! tied to the snapshot.
 
-use super::session::WgSession;
+use super::session::{SessionRole, WgSession};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -92,10 +94,34 @@ impl std::fmt::Debug for PeerConfig {
 
 /// A peer's long-lived, config-independent state: its identity, its
 /// transport sessions, and its timer bookkeeping. Reused across config
-/// commits (same pubkey → same `Arc<Peer>`) so the (current, previous)
-/// session pair and timer pacing survive a commit. The operator-facing
-/// config tuple lives in the per-snapshot `PeerConfig` (#2836), NOT
-/// here, so config changes are observed atomically with the table swap.
+/// commits (same pubkey → same `Arc<Peer>`) so the
+/// (current, previous, next) keypair slots and timer pacing survive a
+/// commit. The operator-facing config tuple lives in the per-snapshot
+/// `PeerConfig` (#2836), NOT here, so config changes are observed
+/// atomically with the table swap.
+///
+/// ## 3-slot keypair lifecycle (#3882)
+///
+/// The three session slots mirror the kernel WireGuard
+/// current/previous/next keypair model (`drivers/net/wireguard/noise.c`,
+/// `add_new_keypair` / `wg_noise_received_with_keypair`):
+///
+///   - **current** — the CONFIRMED keypair egress encrypts with. Only
+///     ever set to a confirmed session: an initiator-role session (the
+///     handshake response confirmed it) or a `next` session promoted
+///     after its first authenticated inbound data record.
+///   - **previous** — the prior current, retained across a rotation so
+///     in-flight reverse traffic on the old keypair still decrypts.
+///   - **next** — a responder-role keypair that has NOT yet been
+///     confirmed. When xpf is the RESPONDER to a (re)key, the new
+///     session lands here, NOT in `current`; egress keeps using the
+///     confirmed `current` until the initiator proves it completed the
+///     handshake by sending the first inbound data record on the new
+///     keypair, at which point `promote_next` slides next→current
+///     (old current→previous). Before #3882 the unconfirmed responder
+///     session was rotated straight into `current`, so every
+///     peer-initiated rekey blackholed xpf→peer egress until the peer
+///     sent data (a replayable egress DoS — the F-019 defect).
 pub(crate) struct Peer {
     pub(crate) pubkey: [u8; 32],
     /// #1888 S5 activity stamps + armed timers, all CLOCK_MONOTONIC ns
@@ -138,6 +164,14 @@ pub(crate) struct Peer {
     /// in-flight ciphertexts decrypt successfully. Same lock
     /// discipline as `current`.
     pub(crate) previous: RwLock<Option<Arc<WgSession>>>,
+    /// The pending (unconfirmed) responder keypair (#3882). Populated
+    /// when xpf responds to a peer-initiated (re)key; egress NEVER
+    /// reads this slot. Promoted to `current` by `promote_next` on the
+    /// first authenticated inbound data record. Same lock discipline as
+    /// `current`. Its session is registered in the engine demux map so
+    /// that first inbound record can be decrypted and trigger the
+    /// promotion.
+    pub(crate) next: RwLock<Option<Arc<WgSession>>>,
 }
 
 impl std::fmt::Debug for Peer {
@@ -148,6 +182,7 @@ impl std::fmt::Debug for Peer {
             .field("pubkey", &self.pubkey)
             .field("current", &self.current)
             .field("previous", &self.previous)
+            .field("next", &self.next)
             .finish()
     }
 }
@@ -163,6 +198,7 @@ impl Peer {
             t8_last_attempt_ns: AtomicU64::new(0),
             current: RwLock::new(None),
             previous: RwLock::new(None),
+            next: RwLock::new(None),
         }
     }
 
@@ -213,14 +249,68 @@ impl Peer {
         );
     }
 
-    /// Replace `current` with `new`, moving the old current to
-    /// `previous`. Called from the slow-path handshake-complete code.
-    pub(crate) fn rotate_session(&self, new: Arc<WgSession>) -> Option<Arc<WgSession>> {
-        let old_current = {
-            let mut cur = self.current.write().unwrap();
-            cur.replace(new)
+    /// Install a freshly-completed transport session per the WG 3-slot
+    /// keypair lifecycle (#3882, mirrors kernel `add_new_keypair`).
+    /// Returns every session EVICTED from a slot so the caller can drop
+    /// its demux entry.
+    ///
+    ///   - **Initiator role** — the handshake response already confirmed
+    ///     this keypair, so it becomes `current` immediately: demote the
+    ///     old current to `previous`, discard any pending (unconfirmed)
+    ///     `next` (superseded by this confirmed keypair), and evict the
+    ///     old previous.
+    ///   - **Responder role** — the keypair is UNCONFIRMED (the initiator
+    ///     has not proven it completed the handshake), so it is parked in
+    ///     `next`; `current` keeps serving egress. Any stale pending
+    ///     `next` is replaced (and evicted). `current`/`previous` are
+    ///     left untouched so a peer-initiated rekey never blackholes the
+    ///     xpf→peer direction.
+    ///
+    /// Each slot lock is taken and released independently (never nested),
+    /// matching the rest of the module's discipline; the caller holds the
+    /// engine `reconcile_lock` so no concurrent installer/promoter/expiry
+    /// can interleave.
+    pub(crate) fn install_new_session(&self, new: Arc<WgSession>) -> Vec<Arc<WgSession>> {
+        let mut evicted: Vec<Arc<WgSession>> = Vec::new();
+        if matches!(new.role, SessionRole::Initiator) {
+            // A pending unconfirmed responder keypair is superseded by
+            // this confirmed initiator keypair — drop it.
+            if let Some(old_next) = self.next.write().unwrap().take() {
+                evicted.push(old_next);
+            }
+            let old_current = self.current.write().unwrap().replace(new);
+            if let Some(old_prev) =
+                std::mem::replace(&mut *self.previous.write().unwrap(), old_current)
+            {
+                evicted.push(old_prev);
+            }
+        } else {
+            // Responder: unconfirmed. Park in `next`; egress keeps using
+            // the confirmed `current` until the first inbound data record
+            // promotes it.
+            if let Some(old_next) = self.next.write().unwrap().replace(new) {
+                evicted.push(old_next);
+            }
+        }
+        evicted
+    }
+
+    /// Promote the pending `next` keypair to `current` (moving the old
+    /// current to `previous`) IFF `next` is still `expected` (#3882 WG
+    /// confirm-on-first-inbound-data). Returns the session evicted from
+    /// `previous` (to drop from the demux map), or `None` if `next` no
+    /// longer holds `expected` (a concurrent install/promote raced, or
+    /// it was already promoted). Caller holds `reconcile_lock`.
+    pub(crate) fn promote_next(&self, expected: &Arc<WgSession>) -> Option<Arc<WgSession>> {
+        let promoted = {
+            let mut next = self.next.write().unwrap();
+            match next.as_ref() {
+                Some(n) if Arc::ptr_eq(n, expected) => {}
+                _ => return None,
+            }
+            next.take().expect("next is Some (matched above)")
         };
-        let mut prev = self.previous.write().unwrap();
-        std::mem::replace(&mut *prev, old_current)
+        let old_current = self.current.write().unwrap().replace(promoted);
+        std::mem::replace(&mut *self.previous.write().unwrap(), old_current)
     }
 }

--- a/userspace-dp/src/afxdp/wg/tests.rs
+++ b/userspace-dp/src/afxdp/wg/tests.rs
@@ -129,8 +129,17 @@ fn established_pair(
         .install_session(&resp_pub, init_session)
         .unwrap();
     resp_engine
-        .install_session(&init_pub, resp_session)
+        .install_session(&init_pub, resp_session.clone())
         .unwrap();
+    // #3882 3-slot lifecycle: a responder-role install parks the session
+    // in `next`, NOT `current`. Model a fully-established (bidirectional)
+    // tunnel by promoting it — the equivalent of the initiator's first
+    // inbound data record confirming the keypair — so responder-side
+    // encap works for the bulk of the round-trip tests. (The
+    // confirm-on-first-inbound-data path itself is exercised by
+    // `responder_session_blocks_encap_until_initiator_data_authenticated`
+    // and the peer-initiated-rekey tests, which do NOT use this helper.)
+    resp_engine.promote_next_for_test(&init_pub, &resp_session);
 
     (init_engine, resp_engine, init_pub, resp_pub)
 }
@@ -1753,6 +1762,184 @@ mod framed_handshake {
         assert_ne!(init_idx, resp_idx);
     }
 
+    /// #3882 RED-on-revert: a PEER-INITIATED rekey (xpf is the RESPONDER)
+    /// must NOT blackhole the xpf→peer egress direction. Under the 3-slot
+    /// keypair model the unconfirmed new responder keypair parks in
+    /// `next`; egress keeps using the confirmed `current` until the
+    /// peer's first inbound data record on the new keypair promotes it.
+    ///
+    /// On revert (responder keypair rotated straight into `current`, the
+    /// pre-#3882 2-slot behavior) the marked egress `try_encap` returns
+    /// `NoSession` and the `.expect(...)` below panics — the persistent,
+    /// replayable egress DoS the F-019 defect described.
+    #[test]
+    fn peer_initiated_rekey_does_not_blackhole_egress() {
+        let (xpf, peer, xpf_pub, peer_pub) = engine_pair();
+
+        // --- Phase 1: initial handshake, xpf as INITIATOR → a confirmed
+        //     `current` on xpf; xpf→peer egress works. ---
+        let mut m1 = [0u8; WG_MSG_INIT_LEN];
+        xpf.create_initiation(&peer_pub, &mut m1).unwrap();
+        let mut m2 = [0u8; WG_MSG_RESPONSE_LEN];
+        peer.consume_initiation_create_response(&m1, &mut m2)
+            .unwrap();
+        xpf.consume_response(&m2).unwrap();
+        let initial_current = xpf
+            .current_session_local_index(&peer_pub)
+            .expect("xpf holds a confirmed current after the initial handshake");
+
+        let inner = ipv4_packet(Ipv4Addr::new(10, 9, 9, 1), Ipv4Addr::new(10, 9, 9, 2));
+        let mut wire = [0u8; 2048];
+        let mut plain = [0u8; 2048];
+        // Baseline egress + delivery (peer confirms/promotes its own
+        // responder keypair on this first inbound record).
+        let e0 = xpf
+            .try_encap(&peer_pub, &inner, &mut wire)
+            .expect("baseline xpf→peer egress works");
+        peer.try_decap(&wire[..e0.len], &mut plain).unwrap();
+
+        // --- Phase 2: PEER-INITIATED rekey — peer is initiator, xpf is
+        //     responder; xpf builds a NEW (unconfirmed) responder keypair. ---
+        let mut rk1 = [0u8; WG_MSG_INIT_LEN];
+        peer.create_initiation(&xpf_pub, &mut rk1).unwrap();
+        let mut rk2 = [0u8; WG_MSG_RESPONSE_LEN];
+        xpf.consume_initiation_create_response(&rk1, &mut rk2)
+            .unwrap();
+
+        // RED-on-revert (the F-019 defect): xpf→peer egress must STILL
+        // work right after the peer-initiated rekey — it uses the
+        // confirmed `current`, NOT the unconfirmed new keypair. On revert
+        // (responder keypair rotated into `current`) this returns
+        // NoSession → the `.expect` panics → the persistent egress DoS.
+        // During the window the peer's `current` is also still the old
+        // keypair, so the record round-trips. Capture a peer→xpf record
+        // on the OLD keypair here too, to prove the previous-keypair
+        // decrypt grace after promotion below.
+        let e1 = xpf
+            .try_encap(&peer_pub, &inner, &mut wire)
+            .expect("peer-initiated rekey must NOT blackhole xpf→peer egress");
+        peer.try_decap(&wire[..e1.len], &mut plain)
+            .expect("peer decrypts on the still-current phase-1 keypair");
+
+        // The fix's mechanism: the unconfirmed rekey keypair parked in
+        // `next`; `current` was UNCHANGED (still the confirmed phase-1
+        // keypair) which is why the egress above did not blackhole.
+        {
+            let xp = xpf.peer_arc(&peer_pub).unwrap();
+            assert!(
+                xp.next.read().unwrap().is_some(),
+                "the unconfirmed responder rekey keypair must park in `next`"
+            );
+            assert_eq!(
+                xp.current.read().unwrap().as_ref().map(|s| s.local_index),
+                Some(initial_current),
+                "current must stay the confirmed phase-1 keypair — egress must not switch \
+                 to the unconfirmed one"
+            );
+        }
+        let mut wire_old = [0u8; 2048];
+        let e_old = peer
+            .try_encap(&xpf_pub, &inner, &mut wire_old)
+            .expect("peer egress on its (still current) old keypair");
+        let e_old_len = e_old.len;
+
+        // --- Phase 3: peer completes its side and sends the first data
+        //     record on the NEW keypair → xpf promotes next→current. ---
+        peer.consume_response(&rk2).unwrap();
+        let e_new = peer.try_encap(&xpf_pub, &inner, &mut wire).unwrap();
+        xpf.try_decap(&wire[..e_new.len], &mut plain)
+            .expect("xpf decrypts the first inbound data on the new keypair");
+
+        let promoted_current = xpf.current_session_local_index(&peer_pub).unwrap();
+        assert_ne!(
+            promoted_current, initial_current,
+            "first inbound data on `next` must promote it to `current`"
+        );
+        {
+            let xp = xpf.peer_arc(&peer_pub).unwrap();
+            assert!(
+                xp.next.read().unwrap().is_none(),
+                "`next` drained after promotion"
+            );
+            assert_eq!(
+                xp.previous.read().unwrap().as_ref().map(|s| s.local_index),
+                Some(initial_current),
+                "old current demoted to previous (in-flight reverse-traffic grace)"
+            );
+        }
+
+        // Previous-keypair grace: the peer→xpf record captured on the OLD
+        // keypair during the window still decrypts now that that keypair
+        // sits in `previous`.
+        xpf.try_decap(&wire_old[..e_old_len], &mut plain)
+            .expect("previous keypair must still decrypt in-flight reverse traffic");
+
+        // Egress still works, now on the promoted keypair.
+        let e2 = xpf
+            .try_encap(&peer_pub, &inner, &mut wire)
+            .expect("egress works on the promoted keypair");
+        peer.try_decap(&wire[..e2.len], &mut plain).unwrap();
+    }
+
+    /// #3882 guard: an xpf-INITIATED rekey is confirmed by the peer's
+    /// response, so its keypair goes straight to `current` (old
+    /// current→previous) and egress switches immediately — the initiator
+    /// lifecycle is UNCHANGED by the 3-slot responder fix, and `next`
+    /// stays empty.
+    #[test]
+    fn initiator_rekey_switches_current_immediately() {
+        let (xpf, peer, _xpf_pub, peer_pub) = engine_pair();
+
+        let mut m1 = [0u8; WG_MSG_INIT_LEN];
+        xpf.create_initiation(&peer_pub, &mut m1).unwrap();
+        let mut m2 = [0u8; WG_MSG_RESPONSE_LEN];
+        peer.consume_initiation_create_response(&m1, &mut m2)
+            .unwrap();
+        xpf.consume_response(&m2).unwrap();
+        let first = xpf.current_session_local_index(&peer_pub).unwrap();
+
+        // xpf initiates a REKEY. The peer builds a fresh responder
+        // keypair + msg2; xpf.consume_response installs the new INITIATOR
+        // keypair straight into `current`.
+        let mut rm1 = [0u8; WG_MSG_INIT_LEN];
+        xpf.create_initiation(&peer_pub, &mut rm1).unwrap();
+        let mut rm2 = [0u8; WG_MSG_RESPONSE_LEN];
+        peer.consume_initiation_create_response(&rm1, &mut rm2)
+            .unwrap();
+        xpf.consume_response(&rm2).unwrap();
+
+        let second = xpf.current_session_local_index(&peer_pub).unwrap();
+        assert_ne!(
+            second, first,
+            "initiator rekey switches `current` immediately"
+        );
+        {
+            let xp = xpf.peer_arc(&peer_pub).unwrap();
+            assert!(
+                xp.next.read().unwrap().is_none(),
+                "an initiator install must not populate `next`"
+            );
+            assert_eq!(
+                xp.previous.read().unwrap().as_ref().map(|s| s.local_index),
+                Some(first),
+                "old current demoted to previous"
+            );
+            assert!(
+                xp.current.read().unwrap().as_ref().unwrap().is_confirmed(),
+                "the initiator keypair is confirmed at install"
+            );
+        }
+        // Egress works immediately on the new keypair (no
+        // wait-for-inbound as the responder path requires).
+        let inner = ipv4_packet(Ipv4Addr::new(10, 9, 9, 1), Ipv4Addr::new(10, 9, 9, 2));
+        let mut wire = [0u8; 2048];
+        let mut plain = [0u8; 2048];
+        let e = xpf
+            .try_encap(&peer_pub, &inner, &mut wire)
+            .expect("egress on the rekeyed initiator keypair");
+        peer.try_decap(&wire[..e.len], &mut plain).unwrap();
+    }
+
     /// msg1's mac1 keys on the RESPONDER's pubkey; a responder configured
     /// with a different identity rejects it with Mac1Mismatch.
     #[test]
@@ -2651,14 +2838,19 @@ mod telemetry_counters {
         let _ = enc;
     }
 
-    /// The unconfirmed-vs-no-session split (AGY r2 #1736): the
-    /// responder key-confirmation gate bumps `encap_drops_unconfirmed`
-    /// (NOT no_session) while still returning `NoSession`; an engine
-    /// with a peer but no session at all bumps `encap_drops_no_session`.
+    /// The unconfirmed-vs-no-session split (AGY r2 #1736) under the
+    /// #3882 3-slot keypair model. A fresh responder handshake parks the
+    /// UNCONFIRMED keypair in `next`, leaving `current` empty, so egress
+    /// reports NO-SESSION (the confirmed `current` — here absent — is
+    /// what egress uses; the unconfirmed keypair never enters `current`).
+    /// The `is_confirmed()` gate survives as a defense-in-depth
+    /// invariant, verified here by forcing an unconfirmed session into
+    /// `current`. An engine with a peer but no session at all bumps
+    /// `encap_drops_no_session`.
     #[test]
     fn encap_no_session_vs_unconfirmed_split() {
-        // Unconfirmed: drive the framed handshake so the responder
-        // holds a real (unconfirmed) session, then encap from it.
+        // Drive the framed handshake so the responder holds a real
+        // (unconfirmed) session — which the 3-slot model parks in `next`.
         let (init, resp, init_pub, resp_pub) = framed_engine_pair();
         let mut msg1 = [0u8; crate::afxdp::wg::WG_MSG_INIT_LEN];
         init.create_initiation(&resp_pub, &mut msg1).unwrap();
@@ -2667,14 +2859,51 @@ mod telemetry_counters {
             .unwrap();
         let inner = ipv4_packet(Ipv4Addr::new(10, 2, 2, 1), Ipv4Addr::new(10, 2, 2, 2));
         let mut wire = [0u8; 2048];
+        // Egress with the keypair in `next` and `current` empty → the
+        // no-session arm (NOT the unconfirmed gate): the 3-slot fix keeps
+        // egress off the unconfirmed keypair without blackholing a
+        // confirmed one.
         let err = resp.try_encap(&init_pub, &inner, &mut wire).unwrap_err();
         assert_eq!(err, EncapError::NoSession, "wire error contract unchanged");
         let rc = resp.counters();
-        assert_eq!(rc.encap_drops_unconfirmed.load(Ordering::Relaxed), 1);
         assert_eq!(
             rc.encap_drops_no_session.load(Ordering::Relaxed),
+            1,
+            "3-slot model: the unconfirmed responder keypair sits in `next`, current is empty"
+        );
+        assert_eq!(
+            rc.encap_drops_unconfirmed.load(Ordering::Relaxed),
             0,
-            "the unconfirmed gate must NOT masquerade as no-session"
+            "an unconfirmed keypair in `next` must not reach the current-session confirmed gate"
+        );
+
+        // Defense-in-depth: the egress `is_confirmed()` gate still
+        // refuses if an UNCONFIRMED session ever occupies `current`.
+        // Force the unconfirmed responder session from `next` into
+        // `current` and confirm the gate — not the no-session arm —
+        // fires.
+        let unconfirmed = resp
+            .peer_arc(&init_pub)
+            .unwrap()
+            .next
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .clone();
+        assert!(!unconfirmed.is_confirmed());
+        resp.force_current_for_test(&init_pub, unconfirmed);
+        let err_gate = resp.try_encap(&init_pub, &inner, &mut wire).unwrap_err();
+        assert_eq!(err_gate, EncapError::NoSession, "wire error contract unchanged");
+        assert_eq!(
+            rc.encap_drops_unconfirmed.load(Ordering::Relaxed),
+            1,
+            "an unconfirmed session in `current` must bump the unconfirmed gate"
+        );
+        assert_eq!(
+            rc.encap_drops_no_session.load(Ordering::Relaxed),
+            1,
+            "the unconfirmed gate must NOT masquerade as no-session (no new no_session drop)"
         );
 
         // No session at all: fresh engine, configured peer, no handshake.
@@ -3347,8 +3576,17 @@ mod s5_timer_tests {
             assert_eq!(s.created_ns, 7_000 * SEC);
         }
         {
-            let cur = resp_peer.current.read().unwrap();
-            let s = cur.as_ref().unwrap();
+            // #3882: a fresh responder-role session parks in `next`
+            // (unconfirmed), NOT `current` — egress must not use it
+            // until the initiator's first inbound data record confirms
+            // and promotes it. `current` stays empty on this initial
+            // handshake (no prior confirmed keypair to keep serving).
+            assert!(
+                resp_peer.current.read().unwrap().is_none(),
+                "responder must not promote an unconfirmed keypair into current"
+            );
+            let next = resp_peer.next.read().unwrap();
+            let s = next.as_ref().unwrap();
             assert_eq!(s.role, SessionRole::Responder);
             assert_eq!(s.created_ns, 8_000 * SEC);
         }

--- a/userspace-dp/src/afxdp/wg/timers.rs
+++ b/userspace-dp/src/afxdp/wg/timers.rs
@@ -191,20 +191,23 @@ impl WgEngine {
         }
     }
 
-    /// Tear down current/previous sessions older than
+    /// Tear down current/previous/next sessions older than
     /// REJECT_AFTER_TIME. Holds `reconcile_lock` (serialized with
-    /// install/reconcile — a concurrent `consume_response` cannot
-    /// interleave) and removes the demux entries exactly like the
-    /// reconcile peer-removal drain, so no demux entry can orphan.
-    /// Returns the number of sessions dropped; each bumps
-    /// `sessions_expired`.
+    /// install/reconcile/promote — a concurrent `consume_response` or
+    /// `maybe_promote_next` cannot interleave) and removes the demux
+    /// entries exactly like the reconcile peer-removal drain, so no
+    /// demux entry can orphan. The `next` slot is included so an
+    /// unconfirmed responder keypair the peer never confirms (never
+    /// sends data on) is also torn down at REJECT_AFTER_TIME instead of
+    /// pinning a demux entry (#3882). Returns the number of sessions
+    /// dropped; each bumps `sessions_expired`.
     pub(crate) fn expire_sessions(&self, now_ns: u64) -> usize {
         let _guard = self.reconcile_lock.lock().unwrap();
         let table = self.load_table();
         let mut dropped_indices: Vec<u32> = Vec::new();
         for entry in table.peers.iter() {
             let peer = &entry.peer;
-            for slot in [&peer.current, &peer.previous] {
+            for slot in [&peer.current, &peer.previous, &peer.next] {
                 let mut guard = slot.write().unwrap();
                 if let Some(session) = guard.as_ref() {
                     if now_ns.saturating_sub(session.created_ns) >= REJECT_AFTER_TIME_NS {


### PR DESCRIPTION
## Summary

Closes #3882 (fable-161 F-019, HIGH security — replayable egress DoS).

The userspace WireGuard engine used a **2-slot** keypair model
(`current`/`previous`). When xpf was the **responder** to a (re)key,
`install_session` rotated the **unconfirmed** new transport session
straight into `current`, demoting the confirmed keypair to `previous`.
Egress (`try_encap`) reads `current` only, and an unconfirmed session
returns `NoSession` — so **every peer-initiated rekey blackholed
xpf→peer egress** until the peer sent its first data record. Replayable
→ persistent egress DoS.

## Fix — 3-slot keypair lifecycle (kernel WireGuard parity)

Adds a third `next` keypair slot mirroring kernel WG's
`current`/`previous`/`next` model (`add_new_keypair` /
`wg_noise_received_with_keypair`).

- **`Peer::install_new_session`** (`peer.rs`) routes by role:
  - **Initiator** → `current` immediately (confirmed by the handshake
    response); old current → previous; any stale unconfirmed `next`
    discarded.
  - **Responder** → `next` (unconfirmed); `current`/`previous` left
    untouched so egress keeps using the confirmed keypair.
- **`WgEngine::maybe_promote_next`** (`engine.rs`), called from
  `try_decap` after a successful AEAD authenticate, promotes
  next→current (old current→previous) on the **first authenticated
  inbound data record** on the `next` keypair (WG
  confirm-on-first-inbound-data). Double-checked locking: a cheap `next`
  read pre-check on the steady-state path; `reconcile_lock` taken only
  for the actual promotion. `Peer::promote_next` does the slide.
- `next` is demux-registered, drained on peer removal
  (`reconcile_peers`), and torn down at REJECT_AFTER_TIME
  (`expire_sessions`).

The initiator path is unchanged; the egress `is_confirmed()` gate is
kept as defense-in-depth. **No wire-format change.**

## Tests (RED on revert)

- `peer_initiated_rekey_does_not_blackhole_egress` — **RED on revert**:
  reverting the responder→`next` routing to the 2-slot rotate makes the
  post-rekey egress `try_encap` return `NoSession` → `.expect` panics.
  Also verifies next→current promotion on first inbound data and the
  previous-keypair decrypt grace.
- `initiator_rekey_switches_current_immediately` — guards the unchanged
  initiator lifecycle.
- `encap_no_session_vs_unconfirmed_split` rewritten for the 3-slot
  reality (unconfirmed keypair in `next` ⇒ `no_session`; confirmed-gate
  exercised via a forced-current test helper).

## Validation

- FULL `cargo test --release` green (3510 tests, 0 failed).
- `go build ./...` green.
- **WG rekey-soak / `test-failover` WARRANTED** — flagged for batch
  validation on the loss cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi