### PR TITLE
daemon: revoke stale super-user sudoers grants on downgrade/removal (#3889)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28856,3 +28856,32 @@ top.
   pkg/config/compiler.go (lenientNAT64Prefix option + wiring + 2 lenient
   blocks), pkg/config/compiler_nat64_prefix_test.go (new, 11 tests),
   docs/config-schema.md (#3886 subsection)
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3889 — reconcile + REVOKE super-user sudoers grants. The
+  daemon wrote a NOPASSWD `/etc/sudoers.d/xpf-<user>` for each super-user
+  login account but had NO removal branch, so a class DOWNGRADE
+  (super-user → operator/read-only) or a full user REMOVAL from config
+  left the passwordless-root grant dangling forever (fable-161 F-055,
+  MEDIUM security / stale privilege). Fix: moved the write out of the
+  per-user `applySystemLogin` loop into a new `reconcileSudoers(cfg)`
+  (`pkg/daemon/daemon_system.go`) called unconditionally from the apply
+  pipeline (`daemon_apply.go` step 11b) — it MUST run even when
+  `applySystemLogin` early-returns on no users (the "all users removed"
+  case). It mirrors the networkd/rsyslog stale-file reconcilers: build the
+  desired super-user set, WRITE `xpf-<user>` for each current super-user
+  (durable `fsatomic.WriteFileDurable` 0440, existing #1916 safety),
+  SWEEP `/etc/sudoers.d/xpf-*` and REMOVE any drop-in not in the desired
+  set. Only `xpf-` prefixed files are ever touched (operator-authored
+  files left alone); root is never granted. Added a `visudo -cf`
+  validation seam (`validateSudoersFile`, best-effort: root-only +
+  visudo-present) — a rejected drop-in is removed rather than left as a
+  lockout landmine (one malformed file breaks ALL sudo). RED-on-revert:
+  disabling the sweep made the downgrade/removal/all-removed assertions
+  FAIL (stale grant persists). go test ./pkg/daemon/ green; go build
+  ./... clean; gofmt + vet clean.
+- **File(s)**: pkg/daemon/daemon_system.go (reconcileSudoers +
+  writeSudoersGrant + sudoersDir/sudoersPrefix/validateSudoersFile;
+  removed inline write from applySystemLogin), pkg/daemon/daemon_apply.go
+  (step 11b reconcileSudoers call), pkg/daemon/daemon_sudoers_reconcile_3889_test.go
+  (new, 4 tests), docs/system-login.md (#3889 revocation section)

--- a/docs/system-login.md
+++ b/docs/system-login.md
@@ -110,11 +110,39 @@ provisioned, on the next commit xpf **locks** that account's password
 rather than orphaning a live credential. Re-adding the directive
 restores the password.
 
-This password reconciliation is **declarative**; SSH keys
-(`authorized_keys`) and sudo (`/etc/sudoers.d/xpf-<name>`) remain
-additive and are independent of the password — a live password is a
-higher-severity orphan than a stale key, so the two are treated
-asymmetrically by design.
+This password reconciliation is **declarative**. SSH keys
+(`authorized_keys`) remain additive and independent of the password — a
+live password is a higher-severity orphan than a stale key. The
+super-user sudo grant (`/etc/sudoers.d/xpf-<name>`) is **also
+declarative** and reconciled on every apply (see below): a class
+downgrade or user removal revokes it (#3889).
+
+## Super-user sudo grants are reconciled and revoked (#3889)
+
+A login user with `class super-user` is granted passwordless root via a
+NOPASSWD drop-in `/etc/sudoers.d/xpf-<name>`. That grant is reconciled
+against the **current** config on every commit by `reconcileSudoers`
+(`pkg/daemon/daemon_system.go`), mirroring the networkd/rsyslog
+stale-file reconcilers:
+
+1. Write `xpf-<name>` for each user that is a super-user **now**.
+2. Sweep `/etc/sudoers.d/xpf-*` and **REMOVE** any drop-in whose user is
+   no longer a super-user. This covers both a **class downgrade**
+   (`super-user` → `operator`/`read-only`) and a **user removal** from
+   the config — in either case the passwordless-root grant is revoked on
+   the next apply. Before #3889 the write had no removal branch, so a
+   demoted or deleted admin kept passwordless root forever.
+
+Only files with the `xpf-` prefix are written, kept, or removed; any
+operator-authored file in `/etc/sudoers.d` is left untouched. The
+reconcile runs **unconditionally** — even when `system login` has no
+users (the "all users removed" case), so stale grants are still swept.
+Writes are **DurableState** (`fsatomic.WriteFileDurable`, `0440`) and
+the generated file is validated with `visudo -cf` (best-effort, root
+only) before being trusted; a rejected drop-in is removed rather than
+left as a lockout landmine, because a single malformed file in
+`/etc/sudoers.d` breaks **all** sudo invocations. `root` is never
+granted an xpf-managed drop-in.
 
 ### Scope — only xpf-managed accounts
 
@@ -153,10 +181,11 @@ The password path is a `chpasswd` **process** invocation (which performs
 its own `lckpwdf`-protected shadow update), not a direct file write, so
 the #1916 fsatomic file-write wrapper does not apply to it.
 
-The sudoers drop-in and `authorized_keys` writes in the same apply
-function ARE direct file writes and were migrated to **DurableState** in
-#1916 (`fsatomic.WriteFileDurable`): a torn sudoers file is a
-management-access hazard, and SSH keys must survive a power cut. The
+The sudoers drop-in (now written by `reconcileSudoers`, #3889) and the
+`authorized_keys` write in `applySystemLogin` ARE direct file writes and
+were migrated to **DurableState** in #1916
+(`fsatomic.WriteFileDurable`): a torn sudoers file is a management-access
+hazard, and SSH keys must survive a power cut. The
 `authorized_keys` writes additionally use `fsatomic.WithOwner(uid, gid)`
 (owner resolved cgo-free via `lookupUIDGID`) so the file is installed
 already-correctly-owned — a plain durable write would replace the inode

--- a/pkg/daemon/daemon_apply.go
+++ b/pkg/daemon/daemon_apply.go
@@ -1344,6 +1344,13 @@ func (d *Daemon) applyConfigLocked(ctx context.Context, cfg *config.Config) erro
 	// 11. Apply system login users (create OS accounts, SSH keys)
 	d.applySystemLogin(cfg)
 
+	// 11b. Reconcile super-user sudo grants against the CURRENT config so a
+	// class downgrade or user removal REVOKES the stale NOPASSWD grant
+	// (#3889). Runs unconditionally — applySystemLogin returns early when
+	// there are no users, which is exactly the "all users removed" case
+	// that must still sweep stale grants.
+	d.reconcileSudoers(cfg)
+
 	// 12. Apply SSH service configuration (root-login)
 	d.applySSHConfig(cfg)
 

--- a/pkg/daemon/daemon_sudoers_reconcile_3889_test.go
+++ b/pkg/daemon/daemon_sudoers_reconcile_3889_test.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// withSudoersTestDir points reconcileSudoers at a throwaway directory and
+// stubs the visudo validator (unit tests run non-root; the fixed template
+// is always valid), restoring both on cleanup.
+func withSudoersTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	origDir := sudoersDir
+	origValidate := validateSudoersFile
+	sudoersDir = dir
+	validateSudoersFile = func(string) error { return nil }
+	t.Cleanup(func() {
+		sudoersDir = origDir
+		validateSudoersFile = origValidate
+	})
+	return dir
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0440); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+}
+
+func loginCfg(users ...*config.LoginUser) *config.Config {
+	cfg := &config.Config{}
+	cfg.System.Login = &config.LoginConfig{Users: users}
+	return cfg
+}
+
+// TestReconcileSudoersRevokesDowngradeAndRemoval is the #3889 RED-on-revert
+// test. It seeds an initial super-user grant set, then applies a config in
+// which one user is DOWNGRADED (super-user -> operator) and another is
+// REMOVED entirely, and a new super-user is added. After the reconcile:
+//   - the downgraded user's grant is REMOVED (RED on revert: without the
+//     revocation sweep the stale file persists and the demoted admin keeps
+//     passwordless root),
+//   - the removed user's grant is REMOVED,
+//   - the current super-user's grant is written with the correct content,
+//   - a non-xpf sudoers.d file is left completely untouched.
+func TestReconcileSudoersRevokesDowngradeAndRemoval(t *testing.T) {
+	dir := withSudoersTestDir(t)
+	d := &Daemon{}
+
+	// Initial state on disk: alice + carol were super-users (grants exist),
+	// plus an operator-authored drop-in that xpf must never touch.
+	alice := filepath.Join(dir, "xpf-alice")
+	carol := filepath.Join(dir, "xpf-carol")
+	custom := filepath.Join(dir, "90-operator-custom")
+	writeFile(t, alice, "alice ALL=(ALL) NOPASSWD: ALL\n")
+	writeFile(t, carol, "carol ALL=(ALL) NOPASSWD: ALL\n")
+	const customContent = "someuser ALL=(ALL) NOPASSWD: /bin/systemctl\n"
+	writeFile(t, custom, customContent)
+
+	// New config: alice downgraded to operator, carol removed entirely,
+	// bob added as a super-user.
+	cfg := loginCfg(
+		&config.LoginUser{Name: "alice", Class: "operator"},
+		&config.LoginUser{Name: "bob", Class: "super-user"},
+	)
+
+	d.reconcileSudoers(cfg)
+
+	// Downgraded user's grant revoked.
+	if _, err := os.Stat(alice); !os.IsNotExist(err) {
+		t.Errorf("downgraded user alice: sudoers grant still present (err=%v) — stale privilege not revoked", err)
+	}
+	// Removed user's grant revoked.
+	if _, err := os.Stat(carol); !os.IsNotExist(err) {
+		t.Errorf("removed user carol: sudoers grant still present (err=%v) — stale privilege not revoked", err)
+	}
+	// Current super-user's grant written with correct content.
+	bob := filepath.Join(dir, "xpf-bob")
+	got, err := os.ReadFile(bob)
+	if err != nil {
+		t.Fatalf("current super-user bob: grant not written: %v", err)
+	}
+	if want := "bob ALL=(ALL) NOPASSWD: ALL\n"; string(got) != want {
+		t.Errorf("bob grant = %q, want %q", got, want)
+	}
+	// Non-xpf operator file untouched.
+	if got, err := os.ReadFile(custom); err != nil || string(got) != customContent {
+		t.Errorf("operator-authored 90-operator-custom modified: content=%q err=%v", got, err)
+	}
+}
+
+// TestReconcileSudoersKeepsCurrentSuperUser proves an unchanged current
+// super-user's grant is (re)written/kept across an apply.
+func TestReconcileSudoersKeepsCurrentSuperUser(t *testing.T) {
+	dir := withSudoersTestDir(t)
+	d := &Daemon{}
+
+	cfg := loginCfg(&config.LoginUser{Name: "admin", Class: "super-user"})
+	d.reconcileSudoers(cfg)
+
+	admin := filepath.Join(dir, "xpf-admin")
+	if got, err := os.ReadFile(admin); err != nil {
+		t.Fatalf("first apply: admin grant not written: %v", err)
+	} else if want := "admin ALL=(ALL) NOPASSWD: ALL\n"; string(got) != want {
+		t.Fatalf("admin grant = %q, want %q", got, want)
+	}
+
+	// Idempotent second apply keeps it.
+	d.reconcileSudoers(cfg)
+	if _, err := os.Stat(admin); err != nil {
+		t.Errorf("second apply: admin grant removed unexpectedly: %v", err)
+	}
+}
+
+// TestReconcileSudoersAllUsersRemoved covers the config-with-no-login-users
+// case: every xpf-managed grant must still be revoked even though
+// applySystemLogin returns early (Login nil). Non-xpf files survive.
+func TestReconcileSudoersAllUsersRemoved(t *testing.T) {
+	dir := withSudoersTestDir(t)
+	d := &Daemon{}
+
+	stale := filepath.Join(dir, "xpf-ghost")
+	custom := filepath.Join(dir, "10-keep-me")
+	writeFile(t, stale, "ghost ALL=(ALL) NOPASSWD: ALL\n")
+	const keep = "root ALL=(ALL) ALL\n"
+	writeFile(t, custom, keep)
+
+	// Login entirely absent from the config.
+	cfg := &config.Config{}
+	d.reconcileSudoers(cfg)
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("xpf-ghost grant survived a no-users config (err=%v) — stale privilege not revoked", err)
+	}
+	if got, err := os.ReadFile(custom); err != nil || string(got) != keep {
+		t.Errorf("non-xpf 10-keep-me modified: content=%q err=%v", got, err)
+	}
+}
+
+// TestReconcileSudoersSkipsRoot proves a login user literally named root is
+// never granted an xpf-managed drop-in.
+func TestReconcileSudoersSkipsRoot(t *testing.T) {
+	dir := withSudoersTestDir(t)
+	d := &Daemon{}
+
+	cfg := loginCfg(&config.LoginUser{Name: "root", Class: "super-user"})
+	d.reconcileSudoers(cfg)
+
+	if _, err := os.Stat(filepath.Join(dir, "xpf-root")); !os.IsNotExist(err) {
+		t.Errorf("xpf-root grant written for a root login user (err=%v) — must be skipped", err)
+	}
+}

--- a/pkg/daemon/daemon_system.go
+++ b/pkg/daemon/daemon_system.go
@@ -774,21 +774,11 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 		// the exact xpf-provisioned account (UID-keyed marker).
 		d.reconcileUserPassword(user)
 
-		// Grant sudo for super-user class
-		if user.Class == "super-user" {
-			sudoFile := fmt.Sprintf("/etc/sudoers.d/xpf-%s", user.Name)
-			sudoLine := fmt.Sprintf("%s ALL=(ALL) NOPASSWD: ALL\n", user.Name)
-			current, _ := os.ReadFile(sudoFile)
-			if string(current) != sudoLine {
-				// DurableState: a torn or lost sudoers file is a
-				// management-access (sudo) hazard, so it must survive a
-				// power cut.
-				if err := fsatomic.WriteFileDurable(sudoFile, []byte(sudoLine), 0440); err != nil {
-					slog.Warn("failed to write sudoers file",
-						"user", user.Name, "err", err)
-				}
-			}
-		}
+		// Super-user sudo grants are reconciled separately by
+		// reconcileSudoers so that a class DOWNGRADE or full user removal
+		// REVOKES the stale NOPASSWD grant. reconcileSudoers must run even
+		// when this per-user loop is skipped (Login nil / no users), which
+		// is exactly the "user removed from config" case (#3889).
 
 		// Set SSH authorized keys
 		if len(user.SSHKeys) > 0 {
@@ -848,6 +838,119 @@ func (d *Daemon) applySystemLogin(cfg *config.Config) {
 			}
 		}
 	}
+}
+
+// sudoersDir is the directory that holds xpf-managed NOPASSWD sudo grants
+// for super-user login accounts. Overridable in tests so the reconcile can
+// run against a throwaway directory instead of the real /etc/sudoers.d.
+var sudoersDir = "/etc/sudoers.d"
+
+// sudoersPrefix namespaces every xpf-managed sudoers drop-in. Only files
+// with this prefix are ever written, kept, or removed by reconcileSudoers —
+// operator-authored files in the same directory are left untouched.
+const sudoersPrefix = "xpf-"
+
+// validateSudoersFile checks a generated sudoers drop-in with `visudo -cf`
+// so a malformed grant can never lock out sudo (a single broken drop-in
+// makes sudo refuse to run at all). It is a package var so tests can stub
+// it. The default is best-effort: it only validates when the process is
+// root (the daemon is; unit tests are not) and when visudo is installed —
+// otherwise it returns nil and the atomic durable write is relied on as
+// the write safety (the file content is a fixed, config-validated template).
+var validateSudoersFile = defaultValidateSudoersFile
+
+func defaultValidateSudoersFile(path string) error {
+	// visudo enforces root-ownership + 0440 on drop-ins, so the check is
+	// only meaningful when we actually run as root. Skip otherwise to keep
+	// non-root unit tests deterministic and hermetic.
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	if _, err := exec.LookPath("visudo"); err != nil {
+		return nil // best-effort: visudo not present
+	}
+	if out, err := runCommandTimeout("visudo", "-cf", path); err != nil {
+		return fmt.Errorf("visudo -cf %s: %w: %s", path, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// reconcileSudoers makes /etc/sudoers.d match the CURRENT config's
+// super-user set on every apply. It (a) writes a NOPASSWD grant
+// xpf-<user> for each current super-user login account and (b) REVOKES
+// any xpf-<user> drop-in whose user is no longer a super-user (class
+// DOWNGRADE) or no longer present in the config (user REMOVAL). Without
+// this sweep a demoted or deleted admin kept passwordless root sudo
+// forever (#3889) — the original write-only path had no revocation branch.
+//
+// It mirrors the networkd/rsyslog stale-file reconcilers: build the desired
+// set, sweep the managed namespace, remove what is not desired. Only
+// sudoersPrefix files are touched. It MUST be called on every apply,
+// independent of applySystemLogin's early return, so the "all users
+// removed" case still revokes stale grants.
+func (d *Daemon) reconcileSudoers(cfg *config.Config) {
+	// Desired: an xpf-<user> drop-in for each current super-user account.
+	desired := make(map[string]struct{})
+	if cfg.System.Login != nil {
+		for _, user := range cfg.System.Login.Users {
+			if user.Name == "" || user.Name == "root" {
+				continue // never grant/modify root via config
+			}
+			if user.Class != "super-user" {
+				continue
+			}
+			desired[sudoersPrefix+user.Name] = struct{}{}
+			if err := writeSudoersGrant(user.Name); err != nil {
+				slog.Warn("failed to write sudoers file",
+					"user", user.Name, "err", err)
+			}
+		}
+	}
+
+	// Revoke: remove any xpf-managed drop-in that is no longer desired.
+	entries, _ := os.ReadDir(sudoersDir)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, sudoersPrefix) {
+			continue // leave non-xpf sudoers.d files (and subdirs) alone
+		}
+		if _, keep := desired[name]; keep {
+			continue
+		}
+		path := filepath.Join(sudoersDir, name)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.Warn("failed to revoke stale sudoers grant",
+				"file", name, "err", err)
+		} else if err == nil {
+			slog.Info("revoked stale super-user sudo grant", "file", name)
+		}
+	}
+}
+
+// writeSudoersGrant writes (idempotently) the NOPASSWD grant for one
+// super-user. The write is durable because a torn or lost sudoers file is
+// a management-access (sudo) hazard that must survive a power cut. The
+// generated file is validated with visudo; if validation fails the file is
+// removed rather than left as a lockout landmine (a broken drop-in breaks
+// ALL sudo invocations).
+func writeSudoersGrant(user string) error {
+	path := filepath.Join(sudoersDir, sudoersPrefix+user)
+	line := fmt.Sprintf("%s ALL=(ALL) NOPASSWD: ALL\n", user)
+	if current, _ := os.ReadFile(path); string(current) == line {
+		return nil // idempotent: already correct
+	}
+	// DurableState: a torn or lost sudoers file is a management-access
+	// (sudo) hazard, so it must survive a power cut.
+	if err := fsatomic.WriteFileDurable(path, []byte(line), 0440); err != nil {
+		return err
+	}
+	if err := validateSudoersFile(path); err != nil {
+		// Fail closed toward availability of sudo itself: never leave an
+		// invalid drop-in that would break every sudo invocation.
+		os.Remove(path)
+		return fmt.Errorf("generated sudoers grant rejected: %w", err)
+	}
+	return nil
 }
 
 // reconcileUserPassword applies, leaves, or locks a login user's OS


### PR DESCRIPTION
Closes #3889

## Problem

A login user with `class super-user` is granted passwordless root via a
NOPASSWD drop-in `/etc/sudoers.d/xpf-<user>` (`pkg/daemon/daemon_system.go`,
formerly the per-user `applySystemLogin` loop). That write had **no
removal branch**: when the user was DOWNGRADED to a lower class
(operator/read-only) OR REMOVED from the config entirely, the grant was
never revoked. The stale drop-in persisted → a demoted or deleted admin
kept passwordless root. (fable-review-161 F-055, MEDIUM security / stale
privilege.)

## Fix

Move the write out of the per-user loop into a new `reconcileSudoers(cfg)`
that makes `/etc/sudoers.d` match the CURRENT config's super-user set on
every apply, mirroring the networkd/rsyslog stale-file reconcilers:

1. **Write** `xpf-<user>` for each account that is a super-user *now*
   (durable `fsatomic.WriteFileDurable` `0440` — existing #1916 safety).
2. **Revoke** — sweep `/etc/sudoers.d/xpf-*` and REMOVE any drop-in whose
   user is no longer a super-user (downgrade) or no longer in the config
   (removal).

`reconcileSudoers` is called **unconditionally** from the apply pipeline
(`daemon_apply.go` step 11b), not gated behind `applySystemLogin`'s early
return — the "all users removed" case (`Login` nil) is exactly when a
stale grant must still be swept. Only `xpf-` prefixed files are ever
touched (operator-authored files untouched); a login user named `root`
gets no grant.

**Safety:** a single malformed file in `/etc/sudoers.d` breaks *all* sudo,
so the generated grant is validated with `visudo -cf` via the
`validateSudoersFile` seam (best-effort: root-only + visudo-present, so
non-root unit tests stay hermetic) and a rejected file is removed rather
than left as a lockout landmine. `sudoersDir` / `validateSudoersFile` are
package vars so the reconcile runs against a throwaway dir in tests.

## RED-on-revert test

`daemon_sudoers_reconcile_3889_test.go`:
- downgraded super-user→operator → grant REMOVED
- removed user → grant REMOVED
- all-users-removed config → stale grants still swept
- current super-user → grant written/kept, idempotent re-apply
- non-xpf `/etc/sudoers.d` file untouched; `root` login user gets no grant

Disabling the revocation sweep makes the downgrade/removal/all-removed
assertions FAIL (proven: the stale-grant asserts go RED).

## Validation

- `go test ./pkg/daemon/` — green
- `go build ./...` — clean
- `gofmt -l` + `go vet ./pkg/daemon/` — clean
- Doc: `docs/system-login.md` updated (new revocation section; corrected the
  stale "sudo grants remain additive" claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
