### PR TITLE
applications: reject typo'd application-set member keyword at commit (#3890)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,48 @@
+## 2026-07-03 — #3890: typo'd application-set member keyword silently dropped (deny under-populated, fail-open)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-review-161 F-160 (MEDIUM, security fail-open). The
+    application-set member compiler (`compiler_applications.go`) switch over
+    member keywords had NO default arm, so a TYPO'd member keyword (e.g.
+    `applicaton foo` for `application foo`, or a mistyped `application-set`) was
+    SILENTLY DROPPED — it never reached strict validation, committed clean, and
+    the application-set was UNDER-POPULATED. If that set was used in a DENY
+    policy the deny matched FEWER applications than intended → traffic the
+    operator meant to block was permitted (fail-open under-match).
+  - **Fix**: Added a `default:` arm to the member switch that records the
+    offending keyword on the new `ApplicationSet.UnknownMembers` field (mirroring
+    the #3352 `UnknownTermLeaves` opaque-`term` pattern), plus an explicit
+    `case "description":` accept-and-ignore arm (Junos allows `description` on an
+    application-set — the documented way to author an otherwise-empty set; the
+    existing #3144/#3434 empty-set tests depend on it). Extended
+    `validateApplicationSyntaxStrict` (`compiler_validate_strict.go`) — the same
+    all-user-sets, referenced-or-not gate that already rejects an unknown leaf
+    inside an opaque `term` — to hard-reject the first application-set carrying an
+    UnknownMembers entry, naming the set + the bad keyword. Runs at commit /
+    commit-check; the tolerant load / peer-sync path downgrades to a
+    `cfg.Warnings` entry via the existing `lenientApplicationSpecs` flag (#1960
+    no-brick). Implicit application-sets synthesized for term-bearing applications
+    never carry UnknownMembers, so they are unaffected. Distinct from #2068 (a
+    dropped valid NESTED-set member) and #2217 Finding B
+    `validateApplicationSetMembersStrict` (a dangling member NAME; #3890 is a
+    typo'd member KEYWORD that never becomes a reference, and the syntax gate runs
+    earlier so it reports "unknown member statement" rather than a dangling ref).
+  - **Validation**: New `compiler_application_set_member_3890_test.go` (8 tests):
+    typo'd `application`/`application-set` keyword rejected (flat + hierarchical),
+    unreferenced set rejected, deny-policy end-to-end rejected, lenient warns,
+    valid `application`+nested-`application-set` set commits fully-populated +
+    expands, `description`-only set commits (not flagged). RED-on-revert proven —
+    removing the default arm makes the 6 reject/lenient tests FAIL while the
+    valid-members and description guards stay green. `go test ./pkg/config/...`
+    green; `go test ./pkg/appid/... ./pkg/policymatch/... ./pkg/dataplane/userspace/...`
+    green; `go build ./...` clean; gofmt + vet clean.
+  - **File(s)**: pkg/config/compiler_applications.go (default + description arms),
+    pkg/config/types_security.go (ApplicationSet.UnknownMembers field),
+    pkg/config/compiler_validate_strict.go (validateApplicationSyntaxStrict set
+    loop + doc), pkg/config/compiler_application_set_member_3890_test.go (new),
+    pkg/config/README.md (#3890 subsection), docs/config-schema.md (Finding B
+    sibling-gate note)
+
 ## 2026-07-03 — #3884: firewall-filter cross-family name collision folds into FiltersInet (discard→accept-all fail-open)
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3272,7 +3272,16 @@ strict-vs-lenient gates:
   multi-term user applications are skipped (their members are
   compiler-synthesized, not operator references). Pre-fix a policy matching the
   set silently failed to match the intended traffic (the unresolved member never
-  matches — an effective no-op term).
+  matches — an effective no-op term). **Sibling gate (#3890, fable-review-161
+  F-160):** Finding B checks a member's NAME resolves; a mistyped member KEYWORD
+  (`applicaton foo` instead of `application foo`, or a bad `application-set`) is a
+  distinct failure — the token never becomes a reference at all, it is silently
+  dropped and the set is UNDER-POPULATED (a fail-open under-match for a deny
+  policy referencing it). `compileApplications` records the bad keyword on
+  `ApplicationSet.UnknownMembers` and `validateApplicationSyntaxStrict` rejects it
+  (a `description` is accepted as metadata); it runs EARLIER than Finding B, so a
+  typo'd keyword is reported as "unknown member statement" rather than a dangling
+  reference. Same strict-reject / lenient-warn discipline (`lenientApplicationSpecs`).
 - **Finding C — `then routing-instance <name>` (FBF) →
   `validateFirewallRoutingInstanceReferencesStrict`.** A firewall-filter term
   whose filter-based-forwarding steer names a routing-instance not defined under

--- a/pkg/config/README.md
+++ b/pkg/config/README.md
@@ -925,6 +925,31 @@ so an already-persisted or older-peer-synced config still boots (#1960 no-brick
 doctrine). Distinct from #3339 (implicit-set vs explicit-set collision / duplicate
 term NAMES), #3352 (unknown leaves inside a term), and #3320 (malformed timeout).
 
+**Unknown application-set member keyword rejected (#3890 — fable-review-161
+F-160):** an `applications application-set <name>` member is `application
+<name>`, `application-set <name>` (nested), or `description <text>` (metadata).
+The schema declares `application-set` as an opaque `args:1` leaf (`children:
+nil`), so the `SchemaValidate` walk never reaches its members. Before this fix
+`compileApplications`' member switch had NO default arm, so a TYPO'd member
+keyword (e.g. `applicaton foo` for `application foo`, or a mistyped
+`application-set`) was SILENTLY DROPPED — the set was under-populated with no
+commit error. If that set was referenced by a DENY policy the deny then matched
+FEWER applications than the operator intended, permitting traffic meant to be
+blocked (a fail-OPEN under-match; for a permit policy it is the fail-closed
+inverse). `compileApplications` now records the offending keyword on
+`ApplicationSet.UnknownMembers` (a `description` is accepted-and-ignored, the
+documented way to author an otherwise-empty set), and
+`validateApplicationSyntaxStrict` (`compiler_validate_strict.go`) hard-rejects
+the first one at commit — the same all-user-sets, referenced-or-not scope and
+strict-reject / lenient-warn discipline as the #3352 opaque-`term` unknown-leaf
+gate it mirrors. The tolerant load/peer-sync path downgrades the reject to a
+warning (`lenientApplicationSpecs`) so an already-persisted or older-peer-synced
+config still boots (#1960 no-brick doctrine). Implicit application-sets
+synthesized for term-bearing applications never carry `UnknownMembers`, so they
+are unaffected. Distinct from #2068 (a dropped NESTED-set member — a valid
+keyword the old switch already handled) and the #3144/#3146/#3434 empty-set gate
+(a set that resolves by name but expands to zero members).
+
 **C struct alignment:** when mirroring C BPF structs in Go, match `sizeof`
 exactly with trailing `Pad [N]byte` fields. cilium/ebpf serializes map
 values in native endian, not big-endian, so use `binary.NativeEndian`

--- a/pkg/config/compiler_application_set_member_3890_test.go
+++ b/pkg/config/compiler_application_set_member_3890_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3890: an application-set member is either `application <name>` or
+// `application-set <name>`. The schema declares `application-set` as an opaque
+// args:1 leaf (children:nil), so the SchemaValidate walk never reaches its
+// members. Before this fix compileApplications' member switch had NO default
+// arm, so a TYPO'd member keyword (e.g. `applicaton foo` for `application foo`,
+// or a mistyped `application-set`) was SILENTLY DROPPED — the set was
+// under-populated, and if referenced by a DENY policy the deny matched FEWER
+// applications than intended (a fail-open under-match: traffic the operator
+// meant to block is permitted). validateApplicationSyntaxStrict now hard-rejects
+// a set carrying an unknown member keyword at commit; the tolerant load /
+// peer-sync path downgrades it to a warning (#1960 no-brick).
+//
+// Flat-set trees are built via flatTreeFromSets (ParseSetCommand + SetPath) —
+// the only correct way to exercise the flat-set AST shape.
+
+// Core fail-on-revert: a typo'd member keyword is rejected at commit. Revert the
+// default arm and the `applicaton junos-http` member is silently dropped, the
+// set compiles as empty, CompileConfig succeeds, and this assertion goes RED.
+func TestApplicationSetMember_TypoKeyword_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application-set web application junos-https",
+		"set applications application-set web applicaton junos-http",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to REJECT an application-set with a typo'd member keyword")
+	}
+	if !strings.Contains(err.Error(), "unknown member statement") ||
+		!strings.Contains(err.Error(), "applicaton") {
+		t.Fatalf("error should name the bad member keyword and the set, got: %v", err)
+	}
+}
+
+// A mistyped `application-set` (nested-set) keyword is caught the same way.
+func TestApplicationSetMember_TypoNestedSetKeyword_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application-set child application junos-http",
+		"set applications application-set parent application-sett child",
+	)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatalf("expected commit to REJECT a mistyped nested application-set keyword")
+	}
+	if !strings.Contains(err.Error(), "unknown member statement") ||
+		!strings.Contains(err.Error(), "application-sett") {
+		t.Fatalf("error should name the bad member keyword %q, got: %v", "application-sett", err)
+	}
+}
+
+// The under-population is the security hole even when the set is UNREFERENCED —
+// like #3352/#3353 this is a grammar error rejected at definition, not
+// reference-scoped. A set defined but wired into no policy must still reject.
+func TestApplicationSetMember_Typo_Unreferenced_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application-set lonely application junos-https",
+		"set applications application-set lonely bogus junos-http",
+	)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT an UNREFERENCED set with a bad member")
+	} else if !strings.Contains(err.Error(), "unknown member statement") {
+		t.Fatalf("error should explain the member rule, got: %v", err)
+	}
+}
+
+// The security-relevant end-to-end shape: a DENY policy references the set, and
+// a typo'd member under-populates it. The commit MUST fail — otherwise the deny
+// silently matches fewer apps (fail-open). Revert the gate and the config
+// commits with the set missing junos-http, so this assertion goes RED.
+func TestApplicationSetMember_Typo_DenyPolicy_Rejected(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set security zones security-zone trust",
+		"set security zones security-zone untrust",
+		"set applications application-set blocked application junos-https",
+		"set applications application-set blocked applicaton junos-http",
+		"set security policies from-zone trust to-zone untrust policy deny-bad match source-address any",
+		"set security policies from-zone trust to-zone untrust policy deny-bad match destination-address any",
+		"set security policies from-zone trust to-zone untrust policy deny-bad match application blocked",
+		"set security policies from-zone trust to-zone untrust policy deny-bad then deny",
+	)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT a deny policy whose set has a typo'd (dropped) member")
+	} else if !strings.Contains(err.Error(), "unknown member statement") {
+		t.Fatalf("error should name the unknown member, got: %v", err)
+	}
+}
+
+// Hierarchical (brace-block) shape: the compiler handles both AST shapes, so a
+// typo'd member authored as a brace block must reject too.
+func TestApplicationSetMember_Typo_Hierarchical_Rejected(t *testing.T) {
+	tree := hierTree(t, `
+applications {
+    application-set web {
+        application junos-https;
+        applicaton junos-http;
+    }
+}
+`)
+	if _, err := CompileConfig(tree); err == nil {
+		t.Fatalf("expected commit to REJECT a hierarchical set with a typo'd member")
+	} else if !strings.Contains(err.Error(), "unknown member statement") {
+		t.Fatalf("error should explain the member rule, got: %v", err)
+	}
+}
+
+// Guard against over-rejection: a valid set with both member kinds
+// (`application` and nested `application-set`) must commit cleanly AND be fully
+// populated. This pins that the default arm does not swallow a legitimate
+// member.
+func TestApplicationSetMember_ValidMembers_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application app1 protocol tcp destination-port 80",
+		"set applications application-set child application app1",
+		"set applications application-set parent application junos-https",
+		"set applications application-set parent application-set child",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("a valid set (application + nested application-set) must commit: %v", err)
+	}
+	parent := cfg.Applications.ApplicationSets["parent"]
+	if parent == nil {
+		t.Fatalf("application-set parent missing from compiled config")
+	}
+	// The set is FULLY populated: both the direct app and the nested-set ref.
+	if !contains(parent.Applications, "junos-https") {
+		t.Fatalf("parent must keep direct member junos-https; have %v", parent.Applications)
+	}
+	if !contains(parent.Applications, "child") {
+		t.Fatalf("parent must keep nested-set member child; have %v", parent.Applications)
+	}
+	if len(parent.UnknownMembers) != 0 {
+		t.Fatalf("a valid set must record no unknown members; got %v", parent.UnknownMembers)
+	}
+	// The nested child is expandable end-to-end.
+	expanded, err := ExpandApplicationSet("parent", &cfg.Applications)
+	if err != nil {
+		t.Fatalf("ExpandApplicationSet(parent): %v", err)
+	}
+	if !contains(expanded, "app1") {
+		t.Fatalf("expand(parent) = %v, missing app1 (reached via nested child)", expanded)
+	}
+}
+
+// Guard: `description` is a legitimate Junos application-set statement
+// (metadata), NOT an unknown member — an unreferenced set carrying only a
+// description must still commit cleanly and record no unknown members. This is
+// the documented way to author an otherwise-empty set (the #3144/#3434 empty-set
+// gate rejects it only when it is REFERENCED). Flip the compiler to treat
+// `description` as unknown and this goes RED.
+func TestApplicationSetMember_DescriptionOnly_Accepted(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application-set metaonly description \"documented set\"",
+	)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("a description-only application-set must commit (description is metadata): %v", err)
+	}
+	set := cfg.Applications.ApplicationSets["metaonly"]
+	if set == nil {
+		t.Fatalf("application-set metaonly missing from compiled config")
+	}
+	if len(set.UnknownMembers) != 0 {
+		t.Fatalf("`description` must not be flagged as an unknown member; got %v", set.UnknownMembers)
+	}
+	if len(set.Applications) != 0 {
+		t.Fatalf("`description` must not add a member; got %v", set.Applications)
+	}
+}
+
+// The tolerant load / peer-sync path (CompileConfigLenient) must NOT brick on a
+// set an older binary persisted with a bad member — it downgrades the reject to
+// a warning so the daemon still boots (#1960 no-brick). Revert the lenient
+// downgrade and this goes RED.
+func TestApplicationSetMember_Typo_Lenient_DowngradesToWarning(t *testing.T) {
+	tree := flatTreeFromSets(t,
+		"set applications application-set web application junos-https",
+		"set applications application-set web applicaton junos-http",
+	)
+	cfg, err := CompileConfigLenient(tree)
+	if err != nil {
+		t.Fatalf("lenient path must NOT fail on a bad member (no-brick): %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, "application syntax") && strings.Contains(w, "unknown member statement") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("lenient path must record a downgrade warning; warnings: %v", cfg.Warnings)
+	}
+}

--- a/pkg/config/compiler_applications.go
+++ b/pkg/config/compiler_applications.go
@@ -186,6 +186,28 @@ func compileApplications(node *Node, apps *ApplicationsConfig) error {
 				if v != "" {
 					as.Applications = append(as.Applications, v)
 				}
+			case "description":
+				// Junos allows a `description` statement on an application-set
+				// (metadata, not a member reference). Accept it without adding a
+				// member and without flagging it below — a `description` is the
+				// documented way to author an otherwise-empty set (the #3144/#3434
+				// empty-set gate then rejects it only when it is REFERENCED).
+			default:
+				// #3890: an unrecognized member statement inside the opaque
+				// application-set body. The schema declares `application-set` as
+				// an args:1 leaf (children:nil), so the SchemaValidate walk never
+				// reaches its members; without this default arm a typo'd member
+				// keyword (e.g. `applicaton foo` for `application foo`, or a
+				// mistyped `application-set`) was SILENTLY DROPPED — the set was
+				// under-populated, and if it was referenced by a DENY policy the
+				// deny matched FEWER applications than intended (a fail-open
+				// under-match). Mirroring UnknownTermLeaves (#3352), record the
+				// offending keyword so validateApplicationSyntaxStrict rejects the
+				// first one at commit (lenient-warn on the tolerant load / peer-sync
+				// path) instead of compiling an under-populated set.
+				if kw := member.Name(); kw != "" {
+					as.UnknownMembers = append(as.UnknownMembers, kw)
+				}
 			}
 		}
 

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -3727,8 +3727,9 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 
 // validateApplicationSyntaxStrict hard-rejects SYNTACTIC errors in a
 // user-defined application definition that the typed-schema walk cannot reach:
-// an unrecognized leaf inside an opaque inline `term { ... }` (#3352) and an
-// `alg` name xpf does not support (#3353).
+// an unrecognized leaf inside an opaque inline `term { ... }` (#3352), an
+// `alg` name xpf does not support (#3353), and an unrecognized member statement
+// inside an opaque `application-set { ... }` body (#3890).
 //
 // Unlike validateApplicationSpecsStrict — whose port / protocol / icmp / timeout
 // checks are SEMANTIC and deliberately scoped to REFERENCED applications (an
@@ -3753,7 +3754,7 @@ func validateApplicationSpecsStrict(cfg *Config) error {
 // tolerant load / peer-sync path so an already-persisted or older-peer-synced
 // config still BOOTS (#1960 no-brick).
 func validateApplicationSyntaxStrict(cfg *Config) error {
-	if cfg == nil || len(cfg.Applications.Applications) == 0 {
+	if cfg == nil {
 		return nil
 	}
 	names := make([]string, 0, len(cfg.Applications.Applications))
@@ -3805,6 +3806,39 @@ func validateApplicationSyntaxStrict(cfg *Config) error {
 					"deferred to the per-application ALG slice of #2008",
 				name, app.ALG)
 		}
+	}
+	// #3890: an unrecognized member statement inside an opaque application-set
+	// body. The schema declares `application-set` as an args:1 leaf
+	// (children:nil), so the SchemaValidate walk never reaches its members and a
+	// typo'd member keyword (e.g. `applicaton foo` for `application foo`, or a
+	// mistyped `application-set`) was silently dropped by compileApplications —
+	// the set was under-populated, and if referenced by a DENY policy the deny
+	// matched FEWER applications than intended (a fail-open under-match; traffic
+	// the operator meant to block is permitted). compileApplications records the
+	// offending keyword on ApplicationSet.UnknownMembers (mirroring
+	// UnknownTermLeaves); reject the first one so the silent under-population
+	// becomes an operator-visible commit error. Implicit application-sets
+	// synthesized for term-bearing applications never carry UnknownMembers, so
+	// they are unaffected. Iteration is sorted so the first-reported error is
+	// deterministic.
+	setNames := make([]string, 0, len(cfg.Applications.ApplicationSets))
+	for name := range cfg.Applications.ApplicationSets {
+		setNames = append(setNames, name)
+	}
+	sort.Strings(setNames)
+	for _, name := range setNames {
+		set := cfg.Applications.ApplicationSets[name]
+		if set == nil || len(set.UnknownMembers) == 0 {
+			continue
+		}
+		return fmt.Errorf(
+			"application-set %q: unknown member statement %q; an application-set "+
+				"member is `application <name>`, `application-set <name>`, or "+
+				"`description <text>` (an unrecognized keyword is silently dropped, "+
+				"leaving the set under-populated — a deny policy referencing it then "+
+				"matches fewer applications than intended, permitting traffic meant "+
+				"to be blocked)",
+			name, set.UnknownMembers[0])
 	}
 	return nil
 }

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -860,6 +860,20 @@ type ApplicationsConfig struct {
 type ApplicationSet struct {
 	Name         string
 	Applications []string // references to Application or ApplicationSet names
+	// UnknownMembers records the raw member keywords inside an application-set
+	// body that are NOT a recognized member statement (`application` or
+	// `application-set`). The schema declares `application-set` as an opaque
+	// args:1 leaf (children:nil), so the SchemaValidate walk never reaches its
+	// members; before #3890 compileApplications had no default arm on the
+	// member switch, so a typo'd member keyword (e.g. `applicaton foo` for
+	// `application foo`, or a mistyped `application-set`) was SILENTLY DROPPED —
+	// the set was under-populated, and if it was referenced by a DENY policy the
+	// deny matched FEWER applications than the operator intended (a fail-open
+	// under-match; traffic meant to be blocked is permitted). Mirroring
+	// UnknownTermLeaves, the offending keyword is recorded here and the deferred
+	// gate (validateApplicationSyntaxStrict) hard-rejects the first one on the
+	// strict commit path / warns on the tolerant load / peer-sync path (#3890).
+	UnknownMembers []string
 }
 
 // Application defines a network application by protocol and port.


### PR DESCRIPTION
## Summary

Fixes fable-review-161 **F-160** (MEDIUM, security fail-open).

The application-set member compiler (`pkg/config/compiler_applications.go`) switched over member keywords with **no default arm**, so a typo'd member keyword (e.g. `applicaton foo` for `application foo`, or a mistyped `application-set`) was **silently dropped**. It never reached strict validation, committed clean, and the application-set was left **under-populated**. If that set was referenced by a **DENY** policy the deny then matched **fewer** applications than intended, so traffic the operator meant to block was permitted — a **fail-open under-match** (the permit case is the fail-closed inverse).

## Fix

- **`compiler_applications.go`** — add a `default:` arm to the member switch that records the offending keyword on the new `ApplicationSet.UnknownMembers` field (mirroring the #3352 `UnknownTermLeaves` pattern for an unknown leaf inside an opaque `term`). Add an explicit `case "description":` accept-and-ignore arm — `description` is a legitimate Junos application-set statement (the documented way to author an otherwise-empty set; the #3144/#3434 empty-set tests depend on it).
- **`types_security.go`** — new `ApplicationSet.UnknownMembers []string` field.
- **`compiler_validate_strict.go`** — extend `validateApplicationSyntaxStrict` (the same all-user-sets, referenced-or-not gate that already rejects an unknown leaf inside an opaque `term`) to hard-reject the first application-set carrying an `UnknownMembers` entry, naming the set + the bad keyword. Strict at commit / commit-check; the tolerant load / peer-sync path downgrades to a `cfg.Warnings` entry via the existing `lenientApplicationSpecs` flag (#1960 no-brick).

The syntax gate runs **earlier** than the #2217 Finding B dangling-reference gate (`validateApplicationSetMembersStrict`), so a typo'd keyword — which never becomes a member reference at all — is reported as `unknown member statement` rather than a dangling reference. Distinct from #2068 (a dropped valid *nested-set* member). Implicit application-sets synthesized for term-bearing applications never carry `UnknownMembers`, so they are unaffected.

## Pattern mirrored

The #3352 opaque-`term` unknown-leaf gate (`UnknownTermLeaves` recorded in the compiler → hard-rejected in `validateApplicationSyntaxStrict`, lenient-warned on load). Same strict-reject / lenient-warn discipline.

## Tests — `compiler_application_set_member_3890_test.go` (8)

- typo'd `application` keyword rejected (flat-set)
- mistyped `application-set` nested keyword rejected
- unreferenced set with a bad member rejected (grammar error at definition)
- **deny-policy end-to-end** rejected (the security-relevant shape)
- hierarchical (brace-block) shape rejected
- valid `application` + nested `application-set` set commits **fully-populated** and expands
- `description`-only set commits without being flagged (guard against over-rejection)
- lenient path **warns, does not brick**

**RED-on-revert proven:** removing the `default:` arm makes the six reject/lenient tests FAIL while the valid-members and description guards stay green.

`go test ./pkg/config/...` green; `pkg/appid`, `pkg/policymatch`, `pkg/dataplane/userspace` green; `go build ./...` clean; gofmt + vet clean.

## Docs

`pkg/config/README.md` #3890 subsection; `docs/config-schema.md` Finding B sibling-gate note; `_Log.md` entry.

Closes #3890

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi