### PR TITLE
configstore: enforce clusterReadOnly on every mutating op, not just EnterConfigure (#3893)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -82,6 +82,46 @@
     pkg/config/README.md (#3890 subsection), docs/config-schema.md (Finding B
     sibling-gate note)
 
+## 2026-07-03 — #3893: clusterReadOnly enforced only at EnterConfigure* — an open session could Set/Commit on the HA secondary (config divergence)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-review-161 F-048 (MEDIUM, HA config integrity).
+    The `clusterReadOnly` guard (secondary nodes reject config mutations; the
+    RG0 primary is the sole config authority) was checked ONLY at
+    `EnterConfigure*` (`store_lock.go`). Once a config session was already open
+    (entered before the node became secondary, or via a path that did not
+    re-check), `Set`/`Delete`/`Commit`/`Load*`/`Rollback` only verified
+    `candidate != nil` — ZERO `clusterReadOnly` refs on the mutating path. So an
+    open session could `Set` + `Commit` on the read-only secondary and diverge
+    its active config from the primary (a local edit the primary never sees,
+    overwritten by the next config-sync → churn/divergence).
+  - **Fix**: Added `ErrClusterReadOnly` sentinel (`envelope.go`, "configuration
+    is read-only on the cluster secondary") and an `ensureWritableLocked()`
+    helper (`store_lock.go`, called under `s.mu`). Every user-session mutating
+    op now calls it: `Set`, `Delete`, `DeactivateFromInput`/`ActivateFromInput`,
+    `Copy`, `Rename`, `Insert`, `Annotate`, `LoadOverride`/`LoadMerge`/`LoadSet`
+    (`store_command.go`), `CommitWithDescription` (⇒ `Commit`), `CommitConfirmed`,
+    `Rollback` (`store_commit.go`) — plus the retained `EnterConfigure*` gate,
+    now routed through the same helper/sentinel. Distinguished the user path from
+    the internal-sync path: `SyncApply` (HA peer-sync ingress) and
+    `PromoteRollback` (commit-confirmed timeout revert) promote `active`/`compiled`
+    DIRECTLY and never route through the gated methods, so they are unaffected —
+    the secondary still APPLIES primary-authored config. Boot `bootstrapFromFile`
+    enters config mode first (governed by the same gate; no-op at boot when
+    `clusterReadOnly=false`, before any RG0 transition).
+  - **RED-on-revert**: neutering `ensureWritableLocked()` to `return nil` made
+    the open-session `Set`/`Commit` (and EnterConfigure) rejection assertions
+    FAIL — the edit commits and diverges the secondary. Restored → green.
+    New tests also assert the RG0 primary can `Set`+`Commit`, `SyncApply` applies
+    on a read-only secondary (internal bypass), and a promoted node can commit.
+  - **Validation**: go test ./pkg/configstore/... ./pkg/cluster/... green;
+    go build ./... clean; gofmt + go vet clean.
+  - **File(s)**: pkg/configstore/envelope.go (ErrClusterReadOnly),
+    pkg/configstore/store_lock.go (ensureWritableLocked + EnterConfigure* gates),
+    pkg/configstore/store_command.go + store_commit.go (mutating-op gates),
+    pkg/configstore/cluster_readonly_3893_test.go (new, 5 tests),
+    pkg/configstore/README.md (Cluster read-only gate #3893 section)
+
 ## 2026-07-03 — #3884: firewall-filter cross-family name collision folds into FiltersInet (discard→accept-all fail-open)
 
 - **Timestamp**: 2026-07-03

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -1000,7 +1000,8 @@ Configuration synchronization between chassis cluster nodes. Primary node pushes
 - **`clusterReadOnly bool`** field on `Store` struct
 - **`SetClusterReadOnly(ro bool)`** — toggles mode (called by daemon on cluster state change)
 - **`ClusterReadOnly() bool`** — getter for read-only state
-- **`EnterConfigureSession()`** / **`EnterConfigureExclusive()`** — both return `"configuration database is not writable (secondary node)"` when read-only
+- **`EnterConfigureSession()`** / **`EnterConfigureExclusive()`** — reject with the `ErrClusterReadOnly` sentinel (`"configuration is read-only on the cluster secondary"`, `errors.Is`-comparable) when read-only
+- **Every user-session mutating op enforces read-only too (#3893)** — `Set`/`Delete`/`Deactivate`/`Activate`/`Copy`/`Rename`/`Insert`/`Annotate`/`Load*`/`Commit`/`CommitConfirmed`/`Rollback` route through `ensureWritableLocked()` and return `ErrClusterReadOnly` on a secondary, so a session opened before the node went secondary can no longer Set+Commit and diverge the standby. The internal convergence paths (`SyncApply`, `PromoteRollback`) promote `active`/`compiled` directly and are deliberately **not** gated.
 - **`SyncApply(content string, chassisPreserve func(*ConfigTree)) (*Config, error)`** — bypasses read-only checks for applying config received from primary
   - Parses config text, calls optional `chassisPreserve` callback to patch tree before compilation
   - Pushes current active to history, promotes new tree, persists to DB

--- a/pkg/configstore/README.md
+++ b/pkg/configstore/README.md
@@ -161,6 +161,46 @@ config to the dataplane. A subsequent restart therefore re-classifies into
 bootstrap (the marker disambiguates never-committed from
 operator-committed-empty).
 
+### Cluster read-only gate (#3893)
+
+On an HA chassis cluster the RG0 primary is the sole config authority;
+the secondary is read-only and receives config only via `SyncApply`
+(peer sync from the primary). The daemon toggles the store's read-only
+mode on the RG0 primary↔secondary transition:
+`SetClusterReadOnly(true)` when this node becomes secondary,
+`SetClusterReadOnly(false)` when it is promoted to primary
+(`pkg/daemon/daemon_ha.go`).
+
+`clusterReadOnly` was originally checked ONLY at the `EnterConfigure*`
+gate. That left two holes: a config session **opened before** the node
+became secondary, and any mutating path that did not re-enter
+`EnterConfigure`. Once a session was open, `Set`/`Delete`/`Commit`/
+`Load*`/`Rollback` only verified `candidate != nil` — so an open session
+could `Set` + `Commit` on the read-only secondary and **diverge** its
+active config from the primary (a local edit the primary never sees,
+which the next config-sync overwrites — churn/divergence).
+
+The gate is now enforced on **every user-session mutating op** through
+`ensureWritableLocked()` (called under `s.mu`): `Set`, `Delete`,
+`DeactivateFromInput`/`ActivateFromInput`, `Copy`, `Rename`, `Insert`,
+`Annotate`, `LoadOverride`/`LoadMerge`/`LoadSet`, `CommitWithDescription`
+(and thus `Commit`), `CommitConfirmed`, and `Rollback`, in addition to
+the retained `EnterConfigure*` gate. A rejected op returns the
+`ErrClusterReadOnly` sentinel ("configuration is read-only on the
+cluster secondary"), which `errors.Is` distinguishes from the transient
+`ErrConfigLocked`.
+
+**Internal-sync bypass (load-bearing):** the secondary must still APPLY
+config authored by the primary. `SyncApply` (HA peer-sync ingress) and
+`PromoteRollback` (commit-confirmed timeout revert) promote the
+`active`/`compiled` state **directly** and never route through the gated
+`Set`/`Commit`/`Load`/`Rollback` methods, so they are unaffected by this
+gate — exactly the distinction between a user-driven mutation (blocked
+on a secondary) and an internal convergence apply (must proceed).
+Boot-time `bootstrapFromFile` enters config mode first, so it too is
+governed by the same gate (a no-op there because `clusterReadOnly` is
+`false` at boot, before any RG0 transition).
+
 ### Step-0 committed marker (#1922 Item 2)
 
 The config-DB compatibility envelope (#1917) carries a `committed=` header

--- a/pkg/configstore/cluster_readonly_3893_test.go
+++ b/pkg/configstore/cluster_readonly_3893_test.go
@@ -1,0 +1,154 @@
+package configstore
+
+import (
+	"errors"
+	"testing"
+)
+
+// #3893: clusterReadOnly was enforced ONLY at EnterConfigure*. Once a config
+// session was already open (entered before the node became a cluster
+// secondary, or via a path that did not re-check), Set/Delete/Commit/Load/
+// Rollback only verified candidate!=nil — so an open session could Set+Commit
+// on the read-only secondary and diverge its active config from the RG0
+// primary. These tests pin the store-level enforcement of the read-only gate
+// on every user-session mutating op. On revert of the fix, the "rejected"
+// assertions go RED (the edit commits and diverges the secondary).
+
+// TestClusterReadOnly_OpenSessionMutationsRejected reproduces the exact bug:
+// a session opened BEFORE the node became secondary must not be able to mutate
+// or commit once the node is read-only.
+func TestClusterReadOnly_OpenSessionMutationsRejected(t *testing.T) {
+	s := newTestStore(t)
+
+	// Session opened while the node is still the RG0 primary (writable).
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure (primary): %v", err)
+	}
+
+	// The node now fails over to secondary while the session is still open.
+	s.SetClusterReadOnly(true)
+
+	// Every candidate-mutating op must now be rejected with ErrClusterReadOnly.
+	if err := s.Set([]string{"system", "host-name", "evil"}); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Set on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.SetFromInput("system host-name evil"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("SetFromInput on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.Delete([]string{"system", "host-name"}); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Delete on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.DeleteFromInput("system host-name"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("DeleteFromInput on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.DeactivateFromInput("system host-name"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("DeactivateFromInput on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.ActivateFromInput("system host-name"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("ActivateFromInput on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.Copy([]string{"system"}, []string{"system2"}); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Copy on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.Rename([]string{"system"}, []string{"system2"}); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Rename on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.Insert([]string{"a"}, []string{"b"}, true); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Insert on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.Annotate([]string{"system"}, "note"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Annotate on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.LoadOverride("system { host-name evil; }"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("LoadOverride on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.LoadMerge("set system host-name evil"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("LoadMerge on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if _, err := s.LoadSet("set system host-name evil"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("LoadSet on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.Rollback(0); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Rollback on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+
+	// The commit paths — the divergence-causing step — must be rejected too.
+	if _, err := s.Commit(); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("Commit on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if _, err := s.CommitWithDescription("x"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("CommitWithDescription on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if _, err := s.CommitConfirmed(1); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("CommitConfirmed on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+}
+
+// TestClusterReadOnly_EnterConfigureRejected keeps pinning the original gate:
+// on a read-only secondary a fresh session cannot even be opened.
+func TestClusterReadOnly_EnterConfigureRejected(t *testing.T) {
+	s := newTestStore(t)
+	s.SetClusterReadOnly(true)
+	if err := s.EnterConfigure(); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("EnterConfigure on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+	if err := s.EnterConfigureExclusive("h"); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("EnterConfigureExclusive on read-only secondary: want ErrClusterReadOnly, got %v", err)
+	}
+}
+
+// TestClusterReadOnly_PrimaryCanCommit confirms the RG0 primary path is
+// untouched: a writable node can Set + Commit normally.
+func TestClusterReadOnly_PrimaryCanCommit(t *testing.T) {
+	s := newTestStore(t)
+	// Default is writable; be explicit for the transition contract.
+	s.SetClusterReadOnly(false)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure (primary): %v", err)
+	}
+	if err := s.SetFromInput("system host-name primary"); err != nil {
+		t.Fatalf("Set (primary): %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit (primary): %v", err)
+	}
+}
+
+// TestClusterReadOnly_SyncApplyBypassesGate confirms the internal HA-sync
+// ingress still applies config on a read-only secondary — the secondary
+// APPLIES config authored by the primary, which is exactly how it converges.
+func TestClusterReadOnly_SyncApplyBypassesGate(t *testing.T) {
+	s := newTestStore(t)
+	s.SetClusterReadOnly(true)
+
+	if _, err := s.SyncApply("system { host-name synced; }", nil); err != nil {
+		t.Fatalf("SyncApply on read-only secondary must succeed (internal sync), got %v", err)
+	}
+	if got := s.active.FormatSet(); got == "" {
+		t.Fatalf("SyncApply did not update active config on the secondary")
+	}
+}
+
+// TestClusterReadOnly_PromotedNodeCanCommit confirms the flag transition is
+// correct: a node promoted from secondary to RG0 primary can then commit.
+func TestClusterReadOnly_PromotedNodeCanCommit(t *testing.T) {
+	s := newTestStore(t)
+
+	// Secondary: config is blocked.
+	s.SetClusterReadOnly(true)
+	if err := s.EnterConfigure(); !errors.Is(err, ErrClusterReadOnly) {
+		t.Fatalf("EnterConfigure (secondary): want ErrClusterReadOnly, got %v", err)
+	}
+
+	// Promotion to RG0 primary.
+	s.SetClusterReadOnly(false)
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure (promoted primary): %v", err)
+	}
+	if err := s.SetFromInput("system host-name promoted"); err != nil {
+		t.Fatalf("Set (promoted primary): %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit (promoted primary): %v", err)
+	}
+}

--- a/pkg/configstore/envelope.go
+++ b/pkg/configstore/envelope.go
@@ -45,6 +45,20 @@ var ErrConfigCompile = errors.New("config DB present but does not compile")
 // preserved for operators that grep logs; only the error VALUE is new.
 var ErrConfigLocked = errors.New("configuration is locked by another user")
 
+// ErrClusterReadOnly tags a rejected config mutation on a cluster node that
+// is NOT the RG0 primary (a read-only secondary; config authority is the
+// primary). It is returned both at the EnterConfigure* gate AND on every
+// user-session mutating op (Set/Delete/Commit/Load/Rollback and the
+// interactive structural edits), so a config session that was opened BEFORE
+// the node became secondary — or reached via a path that did not re-check —
+// cannot Set+Commit and diverge the secondary's active config from the
+// primary (#3893). It is a PERMANENT condition (unlike the transient
+// ErrConfigLocked): the node stays read-only until it is promoted to RG0
+// primary. The internal HA-sync ingress (Store.SyncApply) and the
+// commit-confirmed timeout revert (Store.PromoteRollback) do NOT route
+// through the gated methods, so they deliberately bypass this gate.
+var ErrClusterReadOnly = errors.New("configuration is read-only on the cluster secondary")
+
 // Config-DB compatibility envelope (#1917 increment B, plan §6.4 / D1).
 //
 // The envelope is EMBEDDED in active.json as a single magic header LINE

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -12,6 +12,9 @@ func (s *Store) Set(path []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -37,6 +40,9 @@ func (s *Store) Delete(path []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -71,6 +77,9 @@ func (s *Store) DeleteFromInput(input string) error {
 func (s *Store) DeactivateFromInput(input string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -88,6 +97,9 @@ func (s *Store) DeactivateFromInput(input string) error {
 func (s *Store) ActivateFromInput(input string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -102,6 +114,9 @@ func (s *Store) ActivateFromInput(input string) error {
 func (s *Store) Copy(srcPath, dstPath []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -116,6 +131,9 @@ func (s *Store) Copy(srcPath, dstPath []string) error {
 func (s *Store) Rename(srcPath, dstPath []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -131,6 +149,9 @@ func (s *Store) Rename(srcPath, dstPath []string) error {
 func (s *Store) Insert(elementPath, refPath []string, before bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -152,6 +173,9 @@ func (s *Store) Annotate(path []string, comment string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -189,6 +213,9 @@ func (s *Store) LoadOverride(content string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -210,6 +237,9 @@ func (s *Store) LoadMerge(content string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
@@ -344,6 +374,9 @@ func applyEditLine(tree *config.ConfigTree, line string) error {
 func (s *Store) LoadSet(content string) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureWritableLocked(); err != nil {
+		return 0, err
+	}
 	if s.candidate == nil {
 		return 0, fmt.Errorf("not in configuration mode")
 	}

--- a/pkg/configstore/store_commit.go
+++ b/pkg/configstore/store_commit.go
@@ -64,6 +64,13 @@ func (s *Store) CommitWithDescription(description string) (*config.Config, error
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// #3893: reject a user-session commit on a read-only secondary. The
+	// internal HA-sync ingress (SyncApply) and the commit-confirmed timeout
+	// revert (PromoteRollback) promote the active config directly and never
+	// reach here, so they are unaffected by this gate.
+	if err := s.ensureWritableLocked(); err != nil {
+		return nil, err
+	}
 	if s.candidate == nil {
 		return nil, fmt.Errorf("not in configuration mode")
 	}
@@ -189,6 +196,11 @@ func (s *Store) CommitConfirmed(minutes int) (*config.Config, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// #3893: reject a user-session commit-confirmed on a read-only secondary
+	// (same gate as CommitWithDescription).
+	if err := s.ensureWritableLocked(); err != nil {
+		return nil, err
+	}
 	if s.candidate == nil {
 		return nil, fmt.Errorf("not in configuration mode")
 	}
@@ -455,6 +467,13 @@ func (s *Store) Rollback(n int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// #3893: `rollback N` mutates the candidate; reject it on a read-only
+	// secondary. This is the user-session verb, distinct from the internal
+	// commit-confirmed timeout revert PromoteRollback (which promotes the
+	// active config directly and is intentionally NOT gated).
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
+	}
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}

--- a/pkg/configstore/store_lock.go
+++ b/pkg/configstore/store_lock.go
@@ -6,6 +6,28 @@ import (
 	"time"
 )
 
+// ensureWritableLocked returns ErrClusterReadOnly when the store is in
+// cluster read-only mode (a non-RG0-primary / secondary node; config
+// authority is the primary). Callers MUST hold s.mu.
+//
+// #3893: the read-only flag was previously checked ONLY at the
+// EnterConfigure* gate. Once a config session was already open (entered
+// before the node became secondary, or via a path that did not re-check),
+// Set/Delete/Commit/Load/Rollback only verified candidate!=nil — so an open
+// session could Set+Commit on the read-only secondary and diverge its active
+// config from the primary (the local edit is one the primary never sees and
+// the next config-sync overwrites, causing churn). Every user-session
+// mutating op now calls this helper so the mutation is rejected regardless of
+// when the session was opened. The internal HA-sync ingress (SyncApply) and
+// the commit-confirmed timeout revert (PromoteRollback) do NOT go through the
+// gated methods, so they correctly bypass this gate.
+func (s *Store) ensureWritableLocked() error {
+	if s.clusterReadOnly {
+		return ErrClusterReadOnly
+	}
+	return nil
+}
+
 // EnterConfigure enters configuration mode by cloning the active config.
 // Returns an error if another session is already in config mode.
 func (s *Store) EnterConfigure() error {
@@ -17,8 +39,8 @@ func (s *Store) EnterConfigure() error {
 func (s *Store) EnterConfigureSession(sessionID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.clusterReadOnly {
-		return fmt.Errorf("configuration database is not writable (secondary node)")
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
 	}
 	if s.configDir {
 		// Allow re-entry by same session.
@@ -42,8 +64,8 @@ func (s *Store) EnterConfigureSession(sessionID string) error {
 func (s *Store) EnterConfigureExclusive(holder string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.clusterReadOnly {
-		return fmt.Errorf("configuration database is not writable (secondary node)")
+	if err := s.ensureWritableLocked(); err != nil {
+		return err
 	}
 	if s.configDir {
 		return fmt.Errorf("%w", ErrConfigLocked)


### PR DESCRIPTION
Closes #3893

## Problem

The `clusterReadOnly` guard — secondary cluster nodes reject config
mutations because the RG0 primary is the sole config authority — was
checked ONLY at the `EnterConfigure*` gate (`pkg/configstore/store_lock.go`).
Once a config session was already OPEN (entered before the node became
secondary, or reached via a path that did not re-check),
`Set`/`Delete`/`Commit`/`Load*`/`Rollback` only verified `candidate != nil`.
There were ZERO `clusterReadOnly` references on the mutating path.

So an already-open session could `Set` + `Commit` on the read-only
secondary → the secondary's active config **diverges** from the primary
(a local edit the primary never sees, which the next config-sync
overwrites → churn/divergence). Found by fable-review-161 F-048,
re-verified still-live on current origin/master.

## Fix

- Add `ErrClusterReadOnly` sentinel (`envelope.go`, message
  "configuration is read-only on the cluster secondary"), distinguished
  from the transient `ErrConfigLocked` via `errors.Is`.
- Add `ensureWritableLocked()` (`store_lock.go`, called under `s.mu`) and
  invoke it from **every user-session mutating op**: `Set`, `Delete`,
  `DeactivateFromInput`/`ActivateFromInput`, `Copy`, `Rename`, `Insert`,
  `Annotate`, `LoadOverride`/`LoadMerge`/`LoadSet`,
  `CommitWithDescription` (⇒ `Commit`), `CommitConfirmed`, `Rollback` —
  plus the retained `EnterConfigure*`/`EnterConfigureExclusive` gates,
  now routed through the same helper/sentinel.

### User-session vs internal-sync distinction (load-bearing)

The internal HA-sync ingress is deliberately NOT gated. `SyncApply`
(peer-sync from the primary) and `PromoteRollback` (commit-confirmed
timeout revert) promote `active`/`compiled` state **directly** and never
route through the gated `Set`/`Commit`/`Load`/`Rollback` methods, so the
secondary still APPLIES primary-authored config. That is exactly the
distinction between a user-driven mutation (blocked on a secondary) and
an internal convergence apply (must proceed). Boot-time
`bootstrapFromFile` enters config mode first, so it is governed by the
same gate — a no-op at boot when `clusterReadOnly` is `false`, before any
RG0 transition.

## Tests (RED-on-revert)

New `cluster_readonly_3893_test.go` (5 tests). Neutering
`ensureWritableLocked()` to `return nil` makes the open-session
`Set`/`Commit` (and `EnterConfigure`) rejection assertions FAIL — the
edit commits and diverges the secondary. Also asserts: the RG0 primary
can `Set`+`Commit`, `SyncApply` applies on a read-only secondary
(internal bypass), and a promoted node can commit.

## Validation

- `go test ./pkg/configstore/... ./pkg/cluster/...` — green
- `go build ./...` — clean
- `gofmt -l` + `go vet` — clean

Docs: added a "Cluster read-only gate (#3893)" section to
`pkg/configstore/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
