### PR TITLE
config: type IKE version/mode/nat-traversal leaves with ValidateEnum (#3896)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28969,3 +28969,30 @@ top.
   removed inline write from applySystemLogin), pkg/daemon/daemon_apply.go
   (step 11b reconcileSudoers call), pkg/daemon/daemon_sudoers_reconcile_3889_test.go
   (new, 4 tests), docs/system-login.md (#3889 revocation section)
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3896 — type IKE gateway `version`, IKE policy `mode`, and
+  gateway `nat-traversal` setSchema leaves with `ValidateEnum` so a typo
+  fails closed at commit instead of silently weakening negotiation
+  downstream. These three leaves were untyped free-form (`args:1`, no
+  validator) in BOTH the `ike` and `ipsec` stanza copies of the gateway
+  schema (fable-review-161 F-039). A typo committed CLEAN and was then
+  mis-mapped by the swanctl generator: `version v2-onyl` dropped the
+  v2-only pin (gateway silently accepts legacy IKEv1 — a downgrade);
+  `mode agressive` fell back to main mode; a typo'd `nat-traversal` value
+  silently took the auto-detect default. The accepted enum sets mirror
+  EXACTLY the generator-recognized values (verified against
+  `pkg/ipsec/policy.go` version/encap switch + `pkg/ipsec/ike.go`
+  aggressive check — a value the generator handles but the enum omitted
+  would be a false-reject regression): version ∈ {v1-only, v2-only},
+  mode ∈ {main, aggressive}, nat-traversal ∈ {enable, disable, force}.
+  ValidateEnum names the offending value in the reject error. RED-on-
+  revert proven: reverting the three leaves to untyped makes every typo
+  case return nil and go RED. go test ./pkg/config/ ./pkg/ipsec/ green
+  (existing ipsec render tests — version=2, aggressive=yes — unchanged,
+  proving valid values still render identically); go build ./... clean;
+  gofmt + vet clean.
+- **File(s)**: pkg/config/schema_security.go (mode/version/nat-traversal
+  ValidateEnum in ike.policy + ike.gateway + ipsec.gateway),
+  pkg/config/schema_ike_enum_3896_test.go (new, RED-on-revert gate),
+  docs/config-schema.md (#3896 enum-typing section)

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1192,6 +1192,27 @@ reserved for whole-dataplane selection where a rewrite shim
     UNTYPED: the swanctl renderer normalizes arbitrary algorithm spellings
     by string substitution, so an enum there would false-reject valid
     configs.
+  - **#3896 (IKE negotiation-mode / version / NAT-T enums):** the IKE
+    gateway `version`, IKE policy `mode`, and gateway `nat-traversal` leaves
+    were untyped free-form (`args:1`, no validator) in BOTH the `ike` and
+    `ipsec` stanza copies of the gateway schema, so a typo committed clean and
+    was then silently mis-mapped by the swanctl generator — a MEDIUM security
+    footgun (silent negotiation weakening):
+    - `version` — `ValidateEnum([v1-only, v2-only])`. `pkg/ipsec/policy.go`
+      emits `version = 2` for `v2-only` and `version = 1` for `v1-only`; any
+      OTHER spelling emits no `version` line, so a `v2-onyl` typo dropped the
+      v2-only pin and the gateway silently accepted legacy IKEv1 (a downgrade).
+    - `mode` — `ValidateEnum([main, aggressive])`. `pkg/ipsec/ike.go`
+      `resolveIKESettings` sets `aggressive = (Mode == "aggressive")`; every
+      other spelling (including a `agressive` typo) fell back to main mode.
+    - `nat-traversal` — `ValidateEnum([enable, disable, force])`. The
+      `pkg/ipsec/policy.go` switch maps `disable`→`encap = no`,
+      `force`→`forceencaps = yes`, and default (`enable`/empty)→auto-detect;
+      an unrecognized value silently took the auto-detect default.
+
+    The accepted sets are EXACTLY the generator-recognized values (a value the
+    generator handles but the enum omitted would be a false-reject regression).
+    A typo is now rejected at commit with an error naming the bad value.
   - **#2404 (responder-only / dynamic-IP peer):** the `security ike gateway
     <g> dynamic` node now declares a `hostname <fqdn>` child (it was a
     `children: nil` leaf in both the `ike` and `ipsec` stanza copies of the

--- a/pkg/config/schema_ike_enum_3896_test.go
+++ b/pkg/config/schema_ike_enum_3896_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// #3896 — IKE gateway `version`, IKE policy `mode`, and gateway
+// `nat-traversal` were untyped free-form leaves (args:1, no validator), so a
+// typo committed CLEAN and was then silently mis-mapped by the strongSwan
+// generator: `version v2-onyl` dropped the v2-only pin (the gateway then
+// accepts legacy IKEv1 — a downgrade); `mode agressive` fell back to main
+// mode; a typo'd `nat-traversal` value was ignored. The setSchema leaves are
+// now typed with ValidateEnum, matching EXACTLY the value sets the generator
+// recognizes:
+//
+//	version       ∈ {v1-only, v2-only}  (pkg/ipsec/policy.go — version = 1/2)
+//	mode          ∈ {main, aggressive}  (pkg/ipsec/ike.go — Mode=="aggressive")
+//	nat-traversal ∈ {enable, disable, force} (pkg/ipsec/policy.go — encap switch)
+//
+// FAIL-ON-REVERT: reverting the three leaves in schema_security.go back to
+// untyped (args:1 with no validator) makes every reject case below return nil
+// and go RED — a typo would commit clean and silently weaken negotiation.
+func TestIKEEnumSchemaGate_3896(t *testing.T) {
+	reject := func(set, badVal string) {
+		t.Helper()
+		tree := flatTreeFromSets(t, set)
+		err := SchemaValidate(tree, nil)
+		if err == nil {
+			t.Fatalf("%q: expected SchemaValidate to REJECT typo, got nil (silent mis-map)", set)
+		}
+		// The error must name the offending value so the operator can fix it.
+		if !strings.Contains(err.Error(), badVal) {
+			t.Fatalf("%q: reject error %q should name the bad value %q", set, err, badVal)
+		}
+	}
+	accept := func(set string) {
+		t.Helper()
+		tree := flatTreeFromSets(t, set)
+		if err := SchemaValidate(tree, nil); err != nil {
+			t.Fatalf("%q: expected SchemaValidate to ACCEPT valid value, got %v", set, err)
+		}
+	}
+
+	// --- Typos are rejected (fail-closed, error names the bad value) ---
+	reject("set security ike gateway G version v2-onyl", "v2-onyl")     // → would accept IKEv1
+	reject("set security ike gateway G version v3-only", "v3-only")     // unsupported version
+	reject("set security ike policy P mode agressive", "agressive")     // → would fall back to main
+	reject("set security ike policy P mode passive", "passive")         // unhandled mode
+	reject("set security ike gateway G nat-traversal enabel", "enabel") // → NAT-T not as intended
+	reject("set security ike gateway G nat-traversal on", "on")         // unhandled NAT-T value
+	// The `ipsec gateway` alias carries the same version/nat-traversal leaves.
+	reject("set security ipsec gateway G version v2-onyl", "v2-onyl")
+	reject("set security ipsec gateway G nat-traversal enabel", "enabel")
+
+	// --- Every value the generator handles must still commit (no false reject) ---
+	for _, v := range []string{"v1-only", "v2-only"} {
+		accept("set security ike gateway G version " + v)
+		accept("set security ipsec gateway G version " + v)
+	}
+	for _, m := range []string{"main", "aggressive"} {
+		accept("set security ike policy P mode " + m)
+	}
+	for _, n := range []string{"enable", "disable", "force"} {
+		accept("set security ike gateway G nat-traversal " + n)
+		accept("set security ipsec gateway G nat-traversal " + n)
+	}
+}

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -730,7 +730,16 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueExamples: []string{"3600", "28800"}, validator: ValidateIntegerMin(1), children: nil},
 		}},
 		"policy": {desc: "IKE policy name", args: 1, placeholder: "<policy-name>", children: map[string]*schemaNode{
-			"mode":           {desc: "IKE phase 1 mode (main|aggressive)", args: 1, placeholder: "<mode>", children: nil},
+			// #3896: type mode/version/nat-traversal so a typo fails closed at
+			// commit instead of silently downgrading. The accepted sets mirror
+			// exactly what the strongSwan generator (pkg/ipsec) recognizes:
+			// mode "aggressive" → aggressive=yes else main (ike.go
+			// resolveIKESettings); any unrecognized spelling silently fell back
+			// to main-mode before this gate.
+			"mode": {desc: "IKE phase 1 mode (main|aggressive)", args: 1, placeholder: "<mode>",
+				valueType: ValueEnumOf, valueDesc: "IKE phase 1 negotiation mode",
+				valueExamples: []string{"main", "aggressive"},
+				validator:     ValidateEnum([]string{"main", "aggressive"}), children: nil},
 			"proposals":      {desc: "IKE proposal reference", args: 1, placeholder: "<proposal-name>", children: nil},
 			"pre-shared-key": {desc: "Pre-shared key (ascii-text <key>)", children: nil},
 		}},
@@ -740,9 +749,15 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"ike-policy":         {desc: "IKE policy reference", args: 1, placeholder: "<policy-name>", children: nil},
 			"external-interface": {desc: "External interface for IKE (derives local address)", args: 1, placeholder: "<interface-name>", children: nil},
 			"local-certificate":  {desc: "Local certificate for IKE authentication", args: 1, placeholder: "<certificate-name>", children: nil},
-			"version":            {desc: "IKE version (v1-only|v2-only)", args: 1, placeholder: "<version>", children: nil},
-			"no-nat-traversal":   {desc: "Disable NAT traversal (UDP encapsulation)", children: nil},
-			"nat-traversal":      {desc: "NAT traversal (enable|disable|force)", args: 1, placeholder: "<mode>", children: nil},
+			"version": {desc: "IKE version (v1-only|v2-only)", args: 1, placeholder: "<version>",
+				valueType: ValueEnumOf, valueDesc: "IKE protocol version pin",
+				valueExamples: []string{"v1-only", "v2-only"},
+				validator:     ValidateEnum([]string{"v1-only", "v2-only"}), children: nil},
+			"no-nat-traversal": {desc: "Disable NAT traversal (UDP encapsulation)", children: nil},
+			"nat-traversal": {desc: "NAT traversal (enable|disable|force)", args: 1, placeholder: "<mode>",
+				valueType: ValueEnumOf, valueDesc: "NAT traversal (UDP encapsulation) mode",
+				valueExamples: []string{"enable", "disable", "force"},
+				validator:     ValidateEnum([]string{"enable", "disable", "force"}), children: nil},
 			"dead-peer-detection": {desc: "Dead peer detection", children: map[string]*schemaNode{
 				"always-send":       {desc: "Send DPD probes regardless of traffic", children: nil},
 				"optimized":         {desc: "Optimized DPD probing", children: nil},
@@ -796,9 +811,15 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 			"ike-policy":         {desc: "IKE policy reference", args: 1, placeholder: "<policy-name>", children: nil},
 			"external-interface": {desc: "External interface for IKE (derives local address)", args: 1, placeholder: "<interface-name>", children: nil},
 			"local-certificate":  {desc: "Local certificate for IKE authentication", args: 1, placeholder: "<certificate-name>", children: nil},
-			"version":            {desc: "IKE version (v1-only|v2-only)", args: 1, placeholder: "<version>", children: nil},
-			"no-nat-traversal":   {desc: "Disable NAT traversal (UDP encapsulation)", children: nil},
-			"nat-traversal":      {desc: "NAT traversal (enable|disable|force)", args: 1, placeholder: "<mode>", children: nil},
+			"version": {desc: "IKE version (v1-only|v2-only)", args: 1, placeholder: "<version>",
+				valueType: ValueEnumOf, valueDesc: "IKE protocol version pin",
+				valueExamples: []string{"v1-only", "v2-only"},
+				validator:     ValidateEnum([]string{"v1-only", "v2-only"}), children: nil},
+			"no-nat-traversal": {desc: "Disable NAT traversal (UDP encapsulation)", children: nil},
+			"nat-traversal": {desc: "NAT traversal (enable|disable|force)", args: 1, placeholder: "<mode>",
+				valueType: ValueEnumOf, valueDesc: "NAT traversal (UDP encapsulation) mode",
+				valueExamples: []string{"enable", "disable", "force"},
+				validator:     ValidateEnum([]string{"enable", "disable", "force"}), children: nil},
 			"dead-peer-detection": {desc: "Dead peer detection", children: map[string]*schemaNode{
 				"always-send":       {desc: "Send DPD probes regardless of traffic", children: nil},
 				"optimized":         {desc: "Optimized DPD probing", children: nil},


### PR DESCRIPTION
Closes #3896

## Problem (fable-review-161 F-039, MEDIUM security — silent negotiation weakening)

The IKE gateway `version`, IKE policy `mode`, and gateway `nat-traversal`
leaves were untyped free-form entries in `setSchema` (`args:1`,
`children:nil`, no validator) in **both** the `ike` and `ipsec` stanza
copies of the gateway schema (`pkg/config/schema_security.go`). A typo in
any of these **committed clean** and was then silently mis-mapped by the
strongSwan generator:

- `version v2-onyl` (typo of `v2-only`) → the v2-only pin was not
  recognized, so the gateway **silently accepted legacy IKEv1** (a
  downgrade — a v2-only policy meant to reject IKEv1 no longer did);
- `mode agressive` (typo of `aggressive`) → fell back to **main** mode;
- a typo'd `nat-traversal` value → NAT-T not enabled/disabled/forced as
  intended (silently took the auto-detect default).

## Fix

Type the three leaves with `ValidateEnum`. The accepted value sets mirror
**exactly** what the generator recognizes (a value the generator handles
but the enum omitted would be a false-reject regression):

| leaf | enum | generator site |
|------|------|----------------|
| `version` | `v1-only`, `v2-only` | `pkg/ipsec/policy.go` — `version = 2` / `version = 1`, else no version line |
| `mode` | `main`, `aggressive` | `pkg/ipsec/ike.go` `resolveIKESettings` — `aggressive = Mode == "aggressive"` |
| `nat-traversal` | `enable`, `disable`, `force` | `pkg/ipsec/policy.go` — `disable`→`encap = no`, `force`→`forceencaps = yes`, default→auto |

A typo is now **rejected at commit** (fail-closed) with an error naming
the bad value. The accepted values are unchanged — only invalid ones are
rejected.

## Validation

- **New test** `pkg/config/schema_ike_enum_3896_test.go` — a
  `SchemaValidate` gate (`ParseSetCommand` + `SetPath`) that rejects
  typo'd values (asserting the error names the bad value) and accepts
  every generator-recognized value across both the `ike.gateway` and
  `ipsec.gateway` paths and `ike.policy mode`.
- **RED-on-revert**: reverting the three leaves to untyped makes every
  typo case return `nil` and go RED (verified).
- `go test ./pkg/config/... ./pkg/ipsec/...` green — existing ipsec
  render tests (`version = 2`, `aggressive = yes`) unchanged, proving
  valid values still render identically.
- `go build ./...`, `gofmt`, `go vet` all clean.
- Doc: `docs/config-schema.md` #3896 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi