### PR TITLE
RA: bound lifetimes at commit + skip an un-marshalable option so one bad option can't blackhole IPv6 (#3895)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -28969,3 +28969,37 @@ top.
   removed inline write from applySystemLogin), pkg/daemon/daemon_apply.go
   (step 11b reconcileSudoers call), pkg/daemon/daemon_sudoers_reconcile_3889_test.go
   (new, 4 tests), docs/system-login.md (#3889 revocation section)
+
+## 2026-07-03
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3895 — bound the router-advertisement lifetimes at commit and
+  make the RA sender robust to an un-marshalable option, so an over-large
+  PREF64/router/prefix lifetime can no longer blackhole IPv6 on a segment.
+  Defect: the whole RA is built and sent in a single `conn.WriteTo`, which
+  marshals every option; a PREF64 scaled-lifetime > 8191 (RFC 8781 §4 13-bit
+  scaled-by-8, `8191*8 = 65528s`) makes `ndp.PREF64.marshal` FAIL and aborts
+  the ENTIRE advertisement — the segment silently stops receiving RAs and
+  hosts lose their default route / SLAAC when the current RAs expire. #2497
+  typed these lifetime leaves but left them UNBOUNDED (ValidateIntegerMin(0)).
+  Fix (a) commit gate (`pkg/config/schema_routing.go`): bound
+  `nat-prefix`/`nat64prefix lifetime` to [0, 65528] (RFC 8781), `default-lifetime`
+  to [1, 65535] (RFC 4861 §4.2 16-bit; a larger value silently wraps in
+  `uint16(lifetime)` — 65536 → 0 = "not a default router"), and prefix
+  `valid-/preferred-lifetime` to [0, 4294967295] (RFC 4861 §4.6.2 32-bit).
+  Fix (b) sender robustness (`pkg/ra/sender.go`): `buildRA` now calls
+  `pruneUnmarshalableOptions`, which probes each option through
+  `ndp.MarshalMessage` (the same encoder `conn.WriteTo` uses) and LOGS+DROPS
+  any that fail so the rest of the RA still goes out — defense-in-depth for a
+  config that predates the bound (loaded `active.json`). RED-on-revert:
+  reverting the PREF64 validator to min-only made
+  `TestSchema3895_PREF64Lifetime_RejectsOverlarge` FAIL (no commit error);
+  reverting the `buildRA` prune call made `TestBuildRA_3895_PruneOverlargePREF64`
+  FAIL with `ndp: pref64 scaled lifetime is too large` (RA marshal aborts).
+  Validation: `go test ./pkg/ra/... ./pkg/config/...` green; `go build ./...`
+  clean; gofmt + vet clean.
+- **File(s)**: pkg/config/schema_routing.go (raPREF64/Router/Prefix
+  MaxLifetimeSeconds consts + 5 leaf validators), pkg/ra/sender.go
+  (pruneUnmarshalableOptions + buildRA call), pkg/config/schema_validate_3895_test.go
+  (new, 6 tests), pkg/ra/sender_marshal_3895_test.go (new, 4 tests),
+  pkg/ra/README.md (#3895 gotcha)

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -225,6 +225,30 @@ var schemaPolicyOptions = &schemaNode{desc: "Policy options", children: map[stri
 	}},
 }}
 
+// Router-advertisement lifetime upper bounds (#3895). The RA sender
+// (pkg/ra/sender.go buildRA) builds and sends the whole Router Advertisement
+// in a single WriteTo, so an option whose lifetime overflows its on-wire field
+// makes the ndp marshal fail and aborts the ENTIRE RA — the segment then
+// silently stops receiving RAs and hosts lose their default route / SLAAC when
+// the current advertisements expire. #2497 typed these lifetimes as integers
+// but left them UNBOUNDED (ValidateIntegerMin(0)); bound them at commit so an
+// over-large value is rejected loudly instead of blackholing IPv6 at runtime.
+const (
+	// RFC 8781 §4: the PREF64 lifetime is a 13-bit value scaled by 8 seconds
+	// on the wire, so the maximum representable lifetime is 8191*8 = 65528s.
+	// A larger value makes ndp.PREF64.marshal return "scaled lifetime is too
+	// large" and aborts the whole RA (the #3895 blackhole).
+	raPREF64MaxLifetimeSeconds = 65528
+	// RFC 4861 §4.2: the RA header Router Lifetime is a 16-bit seconds field.
+	// A larger value silently wraps in ndp's uint16(lifetime) (65536 -> 0 =
+	// "not a default router"), so hosts drop their default route.
+	raRouterMaxLifetimeSeconds = 65535
+	// RFC 4861 §4.6.2: the Prefix Information valid/preferred lifetimes are
+	// 32-bit seconds fields (0xffffffff = infinity). A larger value silently
+	// truncates in ndp's uint32(lifetime); bound at the 32-bit maximum.
+	raPrefixMaxLifetimeSeconds = 4294967295
+)
+
 var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map[string]*schemaNode{
 	"ospf": {desc: "OSPF configuration", children: map[string]*schemaNode{
 		"router-id":           {desc: "Router ID", args: 1, placeholder: "<address>", children: nil},
@@ -405,9 +429,13 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 			"min-advertisement-interval": {desc: "Minimum time between unsolicited RAs (seconds)", args: 1, placeholder: "<seconds>",
 				valueType: ValueInteger, valueDesc: "min RA interval in seconds",
 				valueExamples: []string{"200", "600"}, validator: ValidateIntegerMin(1), children: nil},
+			// #3895: bound the router lifetime at the RFC 4861 §4.2 16-bit
+			// field maximum. A larger value silently wraps in the RA sender's
+			// ndp uint16(lifetime) (65536 -> 0 = "not a default router"), so
+			// hosts drop their default route.
 			"default-lifetime": {desc: "Router lifetime advertised to hosts (seconds)", args: 1, placeholder: "<seconds>",
-				valueType: ValueInteger, valueDesc: "router lifetime in seconds",
-				valueExamples: []string{"1800", "9000"}, validator: ValidateIntegerMin(1), children: nil},
+				valueType: ValueInteger, valueDesc: "router lifetime in seconds (RFC 4861 §4.2 16-bit)",
+				valueExamples: []string{"1800", "9000"}, validator: ValidateInteger(1, raRouterMaxLifetimeSeconds), children: nil},
 			// #2497: link-mtu is advertised verbatim via ndp.NewMTU. RFC 8200
 			// §5 sets the IPv6 minimum link MTU at 1280 bytes; a smaller value
 			// (1-1279) committed today reaches the wire and blackholes hosts
@@ -450,12 +478,15 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 					// `valid-lifetime abc`, which previously stayed at 0 and
 					// silently fell back to the default) while still accepting
 					// an explicit 0.
+					// #3895: bound at the RFC 4861 §4.6.2 32-bit PIO lifetime
+					// field maximum (0xffffffff = infinity). A larger value
+					// silently truncates in the RA sender's ndp uint32(lifetime).
 					"valid-lifetime": {desc: "Prefix valid lifetime in seconds (0 = SLAAC default)", args: 1, placeholder: "<seconds>",
-						valueType: ValueInteger, valueDesc: "prefix valid lifetime in seconds",
-						valueExamples: []string{"0", "86400", "2592000"}, validator: ValidateIntegerMin(0), children: nil},
+						valueType: ValueInteger, valueDesc: "prefix valid lifetime in seconds (RFC 4861 §4.6.2 32-bit)",
+						valueExamples: []string{"0", "86400", "2592000"}, validator: ValidateInteger(0, raPrefixMaxLifetimeSeconds), children: nil},
 					"preferred-lifetime": {desc: "Prefix preferred lifetime in seconds (0 = SLAAC default)", args: 1, placeholder: "<seconds>",
-						valueType: ValueInteger, valueDesc: "prefix preferred lifetime in seconds",
-						valueExamples: []string{"0", "604800", "86400"}, validator: ValidateIntegerMin(0), children: nil},
+						valueType: ValueInteger, valueDesc: "prefix preferred lifetime in seconds (RFC 4861 §4.6.2 32-bit)",
+						valueExamples: []string{"0", "604800", "86400"}, validator: ValidateInteger(0, raPrefixMaxLifetimeSeconds), children: nil},
 				}},
 			// #2497: nat-prefix/nat64prefix feed an ndp.PREF64 option whose
 			// 3-bit PLC wire field can only encode the RFC 8781 §4 length set
@@ -469,17 +500,23 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 				keyValueType: ValueCIDR, keyValueDesc: "NAT64 prefix (RFC 8781 length /32 /40 /48 /56 /64 /96)",
 				keyValueExamples: []string{"64:ff9b::/96"}, keyValidator: ValidatePREF64CIDR,
 				children: map[string]*schemaNode{
+					// #3895: bound at the RFC 8781 §4 13-bit scaled-by-8 field
+					// maximum (8191*8 = 65528s). A larger value makes
+					// ndp.PREF64.marshal fail, aborting the entire RA.
 					"lifetime": {desc: "Lifetime", args: 1, placeholder: "<seconds>",
-						valueType: ValueInteger, valueDesc: "PREF64 lifetime in seconds (0 = router lifetime)",
-						valueExamples: []string{"0", "1800"}, validator: ValidateIntegerMin(0), children: nil},
+						valueType: ValueInteger, valueDesc: "PREF64 lifetime in seconds (0 = router lifetime; RFC 8781 max 65528)",
+						valueExamples: []string{"0", "1800"}, validator: ValidateInteger(0, raPREF64MaxLifetimeSeconds), children: nil},
 				}},
 			"nat64prefix": {desc: "NAT64 prefix", args: 1, placeholder: "<prefix>",
 				keyValueType: ValueCIDR, keyValueDesc: "NAT64 prefix (RFC 8781 length /32 /40 /48 /56 /64 /96)",
 				keyValueExamples: []string{"64:ff9b::/96"}, keyValidator: ValidatePREF64CIDR,
 				children: map[string]*schemaNode{
+					// #3895: bound at the RFC 8781 §4 13-bit scaled-by-8 field
+					// maximum (8191*8 = 65528s). A larger value makes
+					// ndp.PREF64.marshal fail, aborting the entire RA.
 					"lifetime": {desc: "Lifetime", args: 1, placeholder: "<seconds>",
-						valueType: ValueInteger, valueDesc: "PREF64 lifetime in seconds (0 = router lifetime)",
-						valueExamples: []string{"0", "1800"}, validator: ValidateIntegerMin(0), children: nil},
+						valueType: ValueInteger, valueDesc: "PREF64 lifetime in seconds (0 = router lifetime; RFC 8781 max 65528)",
+						valueExamples: []string{"0", "1800"}, validator: ValidateInteger(0, raPREF64MaxLifetimeSeconds), children: nil},
 				}},
 		}},
 	}},

--- a/pkg/config/schema_validate_3895_test.go
+++ b/pkg/config/schema_validate_3895_test.go
@@ -1,0 +1,135 @@
+package config_test
+
+// Regression tests for #3895: the router-advertisement lifetime leaves were
+// typed by #2497 but left UNBOUNDED (ValidateIntegerMin(0) / min-only). An
+// over-large lifetime commits, then the RA sender (pkg/ra/sender.go buildRA)
+// hands it to an ndp option whose on-wire field cannot hold it:
+//   - PREF64 (nat-prefix/nat64prefix) lifetime is a 13-bit scaled-by-8 field
+//     (RFC 8781 §4, max 8191*8 = 65528s); an over-large value makes
+//     ndp.PREF64.marshal FAIL, which — the whole RA is one WriteTo — aborts
+//     the ENTIRE Router Advertisement and the segment stops getting RAs.
+//   - the RA-header router lifetime is a 16-bit field (RFC 4861 §4.2); a
+//     larger value silently wraps (65536 -> 0 = "not a default router").
+//   - the Prefix Information valid/preferred lifetimes are 32-bit fields
+//     (RFC 4861 §4.6.2); a larger value silently truncates.
+// Each RejectsBad case FAILS to error before the bound (goes RED on revert)
+// and errors after it; each AcceptsBoundary case guards against a false-reject
+// of the exact maximum.
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- PREF64 (nat-prefix / nat64prefix) lifetime: RFC 8781 max 65528s -----
+
+func TestSchema3895_PREF64Lifetime_RejectsOverlarge(t *testing.T) {
+	for _, leaf := range []string{"nat-prefix", "nat64prefix"} {
+		err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            `+leaf+` 64:ff9b::/96 {
+                lifetime 100000;
+            }
+        }
+    }
+}`)
+		if err == nil {
+			t.Fatalf("expected error for %s lifetime 100000 (> RFC 8781 max 65528), got nil", leaf)
+		}
+		if !strings.Contains(err.Error(), "lifetime") {
+			t.Fatalf("error should reference lifetime: %v", err)
+		}
+	}
+}
+
+func TestSchema3895_PREF64Lifetime_AcceptsMax(t *testing.T) {
+	for _, leaf := range []string{"nat-prefix", "nat64prefix"} {
+		// The exact RFC 8781 maximum (65528s) is representable and must pass;
+		// 0 (= use router lifetime) must also pass.
+		for _, life := range []string{"0", "1800", "65528"} {
+			if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            `+leaf+` 64:ff9b::/96 {
+                lifetime `+life+`;
+            }
+        }
+    }
+}`); err != nil {
+				t.Fatalf("unexpected error for %s lifetime %s: %v", leaf, life, err)
+			}
+		}
+	}
+}
+
+// --- router default-lifetime: RFC 4861 §4.2 16-bit max 65535s ------------
+
+func TestSchema3895_DefaultLifetime_RejectsOverlarge(t *testing.T) {
+	err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            default-lifetime 65536;
+        }
+    }
+}`)
+	if err == nil {
+		t.Fatal("expected error for default-lifetime 65536 (> uint16 max 65535), got nil")
+	}
+	if !strings.Contains(err.Error(), "default-lifetime") {
+		t.Fatalf("error should reference default-lifetime: %v", err)
+	}
+}
+
+func TestSchema3895_DefaultLifetime_AcceptsMax(t *testing.T) {
+	if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            default-lifetime 65535;
+        }
+    }
+}`); err != nil {
+		t.Fatalf("unexpected error for default-lifetime 65535: %v", err)
+	}
+}
+
+// --- prefix valid/preferred lifetimes: RFC 4861 §4.6.2 32-bit max --------
+
+func TestSchema3895_PrefixLifetimes_RejectOverlarge(t *testing.T) {
+	for _, leaf := range []string{"valid-lifetime", "preferred-lifetime"} {
+		err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            prefix 2001:db8::/64 {
+                `+leaf+` 4294967296;
+            }
+        }
+    }
+}`)
+		if err == nil {
+			t.Fatalf("expected error for prefix %s 4294967296 (> uint32 max), got nil", leaf)
+		}
+		if !strings.Contains(err.Error(), leaf) {
+			t.Fatalf("error should reference %s: %v", leaf, err)
+		}
+	}
+}
+
+func TestSchema3895_PrefixLifetimes_AcceptMax(t *testing.T) {
+	for _, leaf := range []string{"valid-lifetime", "preferred-lifetime"} {
+		// 4294967295 = 0xffffffff = RFC 4861 "infinity"; 0 = SLAAC default.
+		for _, life := range []string{"0", "4294967295"} {
+			if err := schemaCheck(t, `protocols {
+    router-advertisement {
+        interface ge-0-0-0 {
+            prefix 2001:db8::/64 {
+                `+leaf+` `+life+`;
+            }
+        }
+    }
+}`); err != nil {
+				t.Fatalf("unexpected error for prefix %s %s: %v", leaf, life, err)
+			}
+		}
+	}
+}

--- a/pkg/ra/README.md
+++ b/pkg/ra/README.md
@@ -231,6 +231,27 @@ best-effort).
   valid life paired with a large explicit preferred life) would otherwise
   silently lose SLAAC on every host. The clamp is never the reverse —
   extending validity would advertise a longer-lived prefix than configured.
+- **RA lifetimes are bounded so one bad option cannot blackhole the whole
+  segment (#3895).** The entire RA is built and sent in ONE `conn.WriteTo`,
+  which internally marshals every option, so a single option whose lifetime
+  overflows its on-wire field aborts the ENTIRE advertisement — the segment
+  then silently stops receiving RAs and hosts lose their default route / SLAAC
+  when the current RAs expire. Two guards, in depth:
+  - **Primary (commit-time gate, `pkg/config` `schema_routing.go`):** the
+    router-advertisement lifetime leaves are bounded to their wire fields —
+    `default-lifetime` ≤ 65535 (RFC 4861 §4.2 16-bit), `prefix
+    valid-/preferred-lifetime` ≤ 4294967295 (RFC 4861 §4.6.2 32-bit), and
+    `nat-prefix`/`nat64prefix lifetime` ≤ 65528 (RFC 8781 §4 13-bit
+    scaled-by-8, `8191*8`). An over-large value is rejected loudly at commit
+    (#2497 typed these leaves but left them unbounded).
+  - **Defense-in-depth (send-time, `buildRA` → `pruneUnmarshalableOptions`,
+    `sender.go`):** each option is probed through `ndp.MarshalMessage` (the
+    same encoder `conn.WriteTo` uses); any option that fails to marshal is
+    logged and DROPPED so the rest of the RA still goes out. This backstops a
+    config that predates the commit-time bound (e.g. a loaded `active.json`) —
+    a bad option degrades to "missing that one option" instead of a total RA
+    blackout. NDP options are independent on the wire, so per-option probing is
+    faithful to how the combined RA marshals.
 - IPv6 NODAD is set on the per-instance NDP socket so it doesn't fight
   the kernel's own duplicate-address detection on the link-local
   address.

--- a/pkg/ra/sender.go
+++ b/pkg/ra/sender.go
@@ -786,7 +786,48 @@ func (s *sender) buildRA() *ndp.RouterAdvertisement {
 		ra.Options = append(ra.Options, ndp.NewMTU(uint32(s.cfg.LinkMTU)))
 	}
 
+	// #3895 defense-in-depth: drop any option that fails to marshal so one bad
+	// option degrades to "missing that option" instead of aborting the whole
+	// RA. The commit-time schema bounds (pkg/config router-advertisement
+	// lifetimes) are the primary guard; this backstops any un-bounded field
+	// that could still overflow its on-wire encoding at send time.
+	ra.Options = pruneUnmarshalableOptions(s.cfg.Interface, ra.Options)
+
 	return ra
+}
+
+// pruneUnmarshalableOptions returns the subset of opts that marshal
+// successfully, logging and dropping any option whose ndp encoding fails.
+//
+// This is defense-in-depth for the RA send path (#3895). The whole Router
+// Advertisement is built and sent in a single WriteTo, which internally
+// marshals every option; a single option that fails to marshal — e.g. an
+// ndp.PREF64 whose scaled lifetime overflows the RFC 8781 13-bit field, or any
+// future option with an out-of-range field — would return an error from that
+// one WriteTo and abort the ENTIRE advertisement. The segment then silently
+// stops receiving RAs and hosts lose their default route / SLAAC config when
+// the current advertisements expire (an IPv6 blackhole). Skipping the bad
+// option keeps the rest of the RA on the wire.
+//
+// NDP options are independent on the wire — marshalOptions simply concatenates
+// each option's bytes with no cross-option state — so probing each option in
+// isolation is faithful to how the combined RA marshals. The probe reuses
+// ndp.MarshalMessage (the same encoder the real conn.WriteTo uses) on a
+// throwaway RA holding just that one option.
+func pruneUnmarshalableOptions(iface string, opts []ndp.Option) []ndp.Option {
+	kept := opts[:0] // filter in place; buildRA hands us a fresh slice
+	for _, opt := range opts {
+		probe := &ndp.RouterAdvertisement{Options: []ndp.Option{opt}}
+		if _, err := ndp.MarshalMessage(probe); err != nil {
+			slog.Warn("ra: dropping un-marshalable option from RA (rest of RA still sent)",
+				"interface", iface,
+				"option", fmt.Sprintf("%T", opt),
+				"err", err)
+			continue
+		}
+		kept = append(kept, opt)
+	}
+	return kept
 }
 
 // randomAdvInterval returns a random duration between MinRtrAdvInterval and

--- a/pkg/ra/sender_marshal_3895_test.go
+++ b/pkg/ra/sender_marshal_3895_test.go
@@ -1,0 +1,170 @@
+package ra
+
+// Regression tests for #3895: an over-large PREF64/router/prefix lifetime made
+// the ndp marshal of a single option fail, which — since the whole Router
+// Advertisement is built and sent in ONE conn.WriteTo — aborted the ENTIRE RA.
+// The segment then silently stopped receiving RAs and hosts lost their default
+// route / SLAAC config once the current advertisements expired (IPv6
+// blackhole). The commit-time schema bound (pkg/config) is the primary guard;
+// buildRA now also prunes any un-marshalable option so a bad option degrades to
+// "missing that one option" instead of a total RA blackout (defense-in-depth
+// for a config that predates the bound, e.g. a loaded active.json).
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/mdlayher/ndp"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// overlargePREF64Life is a PREF64 lifetime whose RFC 8781 §4 13-bit
+// scaled-by-8 wire field overflows: round(100000/8) = 12500 > 8191, so
+// ndp.PREF64.marshal returns "scaled lifetime is too large". The commit-time
+// schema bound rejects this value; it can still reach buildRA from a config
+// committed before that bound existed — exactly the defense-in-depth path.
+const overlargePREF64Life = 100000
+
+func newTestSender3895(cfg *config.RAInterfaceConfig) *sender {
+	return &sender{
+		cfg: cfg,
+		iface: &net.Interface{
+			Name:         cfg.Interface,
+			HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+		},
+	}
+}
+
+// An over-large PREF64 lifetime that reaches the sender must NOT abort the
+// whole RA. buildRA prunes the un-marshalable PREF64 so the rest of the RA
+// (SLLA + on-link prefix) still marshals and goes out on the wire.
+//
+// RED-on-revert: remove the buildRA prune call and the bad PREF64 stays in
+// ra.Options; ndp.MarshalMessage — the same encoder conn.WriteTo runs — then
+// fails, so the segment stops getting RAs (the #3895 blackhole).
+func TestBuildRA_3895_PruneOverlargePREF64(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface:       "trust0",
+		NAT64Prefix:     "64:ff9b::/96",
+		NAT64PrefixLife: overlargePREF64Life,
+		Prefixes: []*config.RAPrefix{
+			{Prefix: "2001:db8::/64", OnLink: true, Autonomous: true},
+		},
+	})
+
+	ra := s.buildRA()
+
+	// The whole RA must marshal — this is exactly what conn.WriteTo does.
+	if _, err := ndp.MarshalMessage(ra); err != nil {
+		t.Fatalf("RA must still marshal after pruning the bad PREF64; got %v", err)
+	}
+
+	// The bad PREF64 must be gone...
+	for _, opt := range ra.Options {
+		if _, ok := opt.(*ndp.PREF64); ok {
+			t.Fatal("over-large PREF64 option should have been pruned")
+		}
+	}
+
+	// ...while the rest of the RA survives (only the bad option is dropped).
+	var foundSLLA, foundPrefix bool
+	for _, opt := range ra.Options {
+		switch opt.(type) {
+		case *ndp.LinkLayerAddress:
+			foundSLLA = true
+		case *ndp.PrefixInformation:
+			foundPrefix = true
+		}
+	}
+	if !foundSLLA {
+		t.Error("source link-layer address dropped; only the bad option should be")
+	}
+	if !foundPrefix {
+		t.Error("prefix information dropped; only the bad option should be")
+	}
+}
+
+// A valid PREF64 lifetime must be kept and the RA must marshal with it (guards
+// against the prune over-reaching and dropping legitimate options).
+func TestBuildRA_3895_ValidPREF64Kept(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface:       "trust0",
+		NAT64Prefix:     "64:ff9b::/96",
+		NAT64PrefixLife: 1800,
+	})
+
+	ra := s.buildRA()
+	if _, err := ndp.MarshalMessage(ra); err != nil {
+		t.Fatalf("RA with a valid PREF64 must marshal; got %v", err)
+	}
+	var found bool
+	for _, opt := range ra.Options {
+		if _, ok := opt.(*ndp.PREF64); ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("valid PREF64 option was dropped")
+	}
+}
+
+// Boundary: exactly the RFC 8781 §4 maximum (65528s) still marshals and is kept.
+func TestBuildRA_3895_MaxPREF64Kept(t *testing.T) {
+	s := newTestSender3895(&config.RAInterfaceConfig{
+		Interface:       "trust0",
+		NAT64Prefix:     "64:ff9b::/96",
+		NAT64PrefixLife: 65528,
+	})
+
+	ra := s.buildRA()
+	if _, err := ndp.MarshalMessage(ra); err != nil {
+		t.Fatalf("RA with the max PREF64 lifetime (65528s) must marshal; got %v", err)
+	}
+	var found bool
+	for _, opt := range ra.Options {
+		if _, ok := opt.(*ndp.PREF64); ok {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("max-lifetime PREF64 option was dropped")
+	}
+}
+
+// Direct unit test of the per-option robustness helper: a mix of good options
+// plus one hand-crafted un-marshalable PREF64 -> only the bad one is dropped
+// and every survivor marshals cleanly.
+func TestPruneUnmarshalableOptions_3895(t *testing.T) {
+	good1 := &ndp.LinkLayerAddress{
+		Direction: ndp.Source,
+		Addr:      net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+	}
+	bad := &ndp.PREF64{
+		Lifetime: time.Duration(overlargePREF64Life) * time.Second,
+		Prefix:   netip.MustParsePrefix("64:ff9b::/96"),
+	}
+	good2 := ndp.NewMTU(1500)
+
+	// Sanity: the crafted bad option really does fail to marshal.
+	if _, err := ndp.MarshalMessage(&ndp.RouterAdvertisement{Options: []ndp.Option{bad}}); err == nil {
+		t.Fatal("test precondition: crafted PREF64 should fail to marshal")
+	}
+
+	kept := pruneUnmarshalableOptions("trust0", []ndp.Option{good1, bad, good2})
+
+	if len(kept) != 2 {
+		t.Fatalf("kept %d options, want 2 (bad PREF64 dropped)", len(kept))
+	}
+	for _, opt := range kept {
+		if _, ok := opt.(*ndp.PREF64); ok {
+			t.Fatal("bad PREF64 should not survive pruning")
+		}
+		probe := &ndp.RouterAdvertisement{Options: []ndp.Option{opt}}
+		if _, err := ndp.MarshalMessage(probe); err != nil {
+			t.Fatalf("surviving option %T must marshal; got %v", opt, err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #3895.

## Defect (MEDIUM availability — IPv6 segment blackhole)

The RA sender builds and sends the whole Router Advertisement in a single
`conn.WriteTo`, which internally marshals **every** option. A PREF64
scaled-lifetime greater than the RFC 8781 §4 13-bit field maximum
(`8191*8 = 65528s`) makes `ndp.PREF64.marshal` return
`ndp: pref64 scaled lifetime is too large`. Because the whole RA is one
`WriteTo`, that single marshal error aborts the **entire** advertisement —
the segment then silently stops receiving RAs and hosts lose their default
route / SLAAC when the current RAs expire. The schema had **no upper bound**
on the lifetime leaves (a distinct residual from #2497, which added
`ValidatePREF64CIDR` + `ValidateIntegerMin(0)` only).

## Fix — two guards, in depth

**(a) Commit gate — `pkg/config/schema_routing.go`.** Bound each RA lifetime
leaf to its on-wire field so an over-large value is rejected loudly at
commit instead of blackholing IPv6 at runtime:

| leaf | bound | field |
|------|-------|-------|
| `nat-prefix` / `nat64prefix lifetime` | `[0, 65528]` | RFC 8781 §4 13-bit scaled-by-8 (the marshal-abort field) |
| `default-lifetime` | `[1, 65535]` | RFC 4861 §4.2 16-bit (a larger value silently wraps in `uint16(lifetime)`: 65536 → 0 = "not a default router") |
| prefix `valid-`/`preferred-lifetime` | `[0, 4294967295]` | RFC 4861 §4.6.2 32-bit (0xffffffff = infinity; a larger value silently truncates) |

**(b) Sender robustness — `pkg/ra/sender.go`.** `buildRA` now calls
`pruneUnmarshalableOptions`, which probes each option through
`ndp.MarshalMessage` (the same encoder `conn.WriteTo` uses) and **logs +
drops** any option that fails to marshal so the rest of the RA still goes
out. Defense-in-depth for a config that predates the commit-time bound
(e.g. reloaded from `active.json`): a bad option degrades to "missing that
one option" instead of a total RA blackout. NDP options are independent on
the wire, so per-option probing is faithful to how the combined RA marshals.

## RED-on-revert proof

- **Commit gate:** reverting the PREF64 validators to `ValidateIntegerMin(0)`
  → `TestSchema3895_PREF64Lifetime_RejectsOverlarge` FAILS
  (`expected error for nat-prefix lifetime 100000 ... got nil`).
- **Sender:** removing the `buildRA` prune call →
  `TestBuildRA_3895_PruneOverlargePREF64` FAILS
  (`RA must still marshal after pruning the bad PREF64; got ndp: pref64
  scaled lifetime is too large`) — the exact runtime abort.

`AcceptsMax` / `ValidPREF64Kept` / `MaxPREF64Kept` cases guard the exact
wire maxima and legitimate values against a false-reject / over-prune.

## Validation

- `go test ./pkg/ra/... ./pkg/config/...` — green
- `go build ./...` — clean
- `gofmt` + `go vet ./pkg/ra/... ./pkg/config/...` — clean
- Doc: `pkg/ra/README.md` gains a #3895 gotcha covering both guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
