### PR TITLE
config: deep-copy per-unit tunnel inheritance (#3898)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29009,3 +29009,27 @@ top.
   removed inline write from applySystemLogin), pkg/daemon/daemon_apply.go
   (step 11b reconcileSudoers call), pkg/daemon/daemon_sudoers_reconcile_3889_test.go
   (new, 4 tests), docs/system-login.md (#3889 revocation section)
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3898 — deep-copy per-unit tunnel inheritance. The per-unit
+  tunnel inherit at compiler_interfaces.go did `*tc = *ifc.Tunnel`, a
+  SHALLOW struct copy that duplicated only the slice HEADERS (ptr+len+cap)
+  of the interface-level tunnel's reference fields. Sibling units then
+  aliased the same backing array; when each unit appended its own
+  address/peer into the shared spare capacity, the second-processed unit
+  overwrote the first's slot — unit A silently carried unit B's IP
+  (duplicate IP on two tunnel netdevs) or WgPeers. Fix: added
+  `TunnelConfig.cloneForUnit(linuxName)` which returns a deep copy —
+  independent backing arrays for Addresses, WgPeers, and each peer's
+  nested AllowedIPs (full audit of TunnelConfig reference-typed fields;
+  all other fields are value types). Call site now uses cloneForUnit
+  instead of the shallow copy. RED-on-revert: reverting the call-site line
+  to the shallow copy makes TestPerUnitTunnelAddressesIndependent and
+  TestPerUnitTunnelWgPeersIndependent FAIL (unit 1 carries unit 2's
+  address/peer + shared backing array). No docs change: per-unit tunnel
+  inheritance semantics are not a separately documented contract — this is
+  an internal correctness fix that makes each unit correctly own its own
+  config. go test ./pkg/config/... green; go build ./... clean; gofmt +
+  vet clean.
+- **File(s)**: pkg/config/types_routing.go (cloneForUnit method),
+  pkg/config/compiler_interfaces.go (call site), pkg/config/tunnel_perunit_deepcopy_test.go (new, 4 tests)

--- a/pkg/config/compiler_interfaces.go
+++ b/pkg/config/compiler_interfaces.go
@@ -231,10 +231,15 @@ func compileInterfaces(node *Node, ifaces *InterfacesConfig) error {
 					linuxName = linuxName + "u" + strconv.Itoa(unitNum)
 				}
 				tc := &TunnelConfig{Name: linuxName, Mode: defaultMode}
-				// Inherit from interface-level tunnel if present
+				// Inherit from interface-level tunnel if present. Deep-copy
+				// so each per-unit tunnel owns independent backing arrays for
+				// its slice fields (Addresses / WgPeers). A shallow
+				// `*tc = *ifc.Tunnel` copies only the slice headers, so
+				// sibling units would alias the parent's backing array and a
+				// per-unit override on one unit would contaminate the others
+				// (#3898 — duplicate IP on two tunnel netdevs).
 				if ifc.Tunnel != nil {
-					*tc = *ifc.Tunnel
-					tc.Name = linuxName
+					tc = ifc.Tunnel.cloneForUnit(linuxName)
 				}
 				for _, prop := range tunnelNode.Children {
 					switch prop.Name() {

--- a/pkg/config/tunnel_perunit_deepcopy_test.go
+++ b/pkg/config/tunnel_perunit_deepcopy_test.go
@@ -1,0 +1,294 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// buildTree (ParseSetCommand + SetPath, NOT NewParser) is defined in
+// compiler_equal_flow_worker_cap_test.go and reused here.
+
+func addrList(unitTunnel *TunnelConfig) []string {
+	if unitTunnel == nil {
+		return nil
+	}
+	return unitTunnel.Addresses
+}
+
+func hasStr(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPerUnitTunnelAddressesIndependent is the #3898 RED-on-revert gate for
+// the Addresses aliasing. Two per-unit tunnels on gr-0/0/0 each set their own
+// distinct address. Before the fix the per-unit inherit did a shallow
+// `*tc = *ifc.Tunnel`, which copied only the Addresses slice HEADER, so both
+// units aliased the interface-level tunnel's backing array. When each unit
+// then appended its own address into the shared spare capacity, the
+// second-processed unit overwrote the first-processed unit's slot, so unit 1
+// ended up carrying unit 2's address (a DUPLICATE IP on two tunnel netdevs).
+//
+// The three seed units (100/101/102) exist only to grow the interface-level
+// tunnel's Addresses slice to len 3 / cap 4 (one-at-a-time appends double the
+// capacity: 1 -> 2 -> 4), giving the shared backing array the spare slot the
+// aliasing bug writes into. With the deep-copy fix each unit owns an
+// independent backing array, so its own address is never clobbered.
+func TestPerUnitTunnelAddressesIndependent(t *testing.T) {
+	cmds := []string{
+		"set interfaces gr-0/0/0 tunnel source 192.0.2.1",
+		"set interfaces gr-0/0/0 tunnel destination 192.0.2.2",
+		// Seed units without a per-unit tunnel: their addresses accumulate
+		// onto the interface-level tunnel's Addresses slice, building spare
+		// capacity in the shared backing array.
+		"set interfaces gr-0/0/0 unit 100 family inet address 10.9.0.1/30",
+		"set interfaces gr-0/0/0 unit 101 family inet address 10.9.1.1/30",
+		"set interfaces gr-0/0/0 unit 102 family inet address 10.9.2.1/30",
+		// Two per-unit tunnels, each with its OWN distinct address.
+		"set interfaces gr-0/0/0 unit 1 tunnel key 1",
+		"set interfaces gr-0/0/0 unit 1 family inet address 10.0.1.1/30",
+		"set interfaces gr-0/0/0 unit 2 tunnel key 2",
+		"set interfaces gr-0/0/0 unit 2 family inet address 10.0.2.1/30",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["gr-0/0/0"]
+	if ifc == nil {
+		t.Fatal("gr-0/0/0 interface not found")
+	}
+	u1, u2 := ifc.Units[1], ifc.Units[2]
+	if u1 == nil || u1.Tunnel == nil {
+		t.Fatal("unit 1 per-unit tunnel is nil")
+	}
+	if u2 == nil || u2.Tunnel == nil {
+		t.Fatal("unit 2 per-unit tunnel is nil")
+	}
+
+	// Distinct devices (aliasing guard also protects Name, but Name is set
+	// explicitly by the compiler after the copy so it is never aliased).
+	if u1.Tunnel.Name == u2.Tunnel.Name {
+		t.Fatalf("units 1 and 2 share tunnel Name %q", u1.Tunnel.Name)
+	}
+
+	a1, a2 := addrList(u1.Tunnel), addrList(u2.Tunnel)
+
+	// Each unit must carry its OWN address...
+	if !hasStr(a1, "10.0.1.1/30") {
+		t.Errorf("unit 1 lost its own address 10.0.1.1/30: got %v", a1)
+	}
+	if !hasStr(a2, "10.0.2.1/30") {
+		t.Errorf("unit 2 lost its own address 10.0.2.1/30: got %v", a2)
+	}
+	// ...and must NOT carry its sibling's per-unit address. This is the
+	// contamination the aliasing bug produces (unit 1 ends up with unit 2's
+	// address in the shared slot).
+	if hasStr(a1, "10.0.2.1/30") {
+		t.Errorf("unit 1 was contaminated with unit 2's address 10.0.2.1/30: got %v", a1)
+	}
+	if hasStr(a2, "10.0.1.1/30") {
+		t.Errorf("unit 2 was contaminated with unit 1's address 10.0.1.1/30: got %v", a2)
+	}
+
+	// The two units must not share a backing array at all: mutating one must
+	// not be observable in the other. (Independent from the content check
+	// above; catches a partial fix that clones one field but keeps aliasing.)
+	if len(a1) > 0 && len(a2) > 0 && &a1[0] == &a2[0] {
+		t.Error("unit 1 and unit 2 tunnel Addresses share the same backing array")
+	}
+}
+
+// TestPerUnitTunnelWgPeersIndependent is the #3898 RED-on-revert gate for the
+// WgPeers aliasing. The interface-level tunnel is a WireGuard tunnel with three
+// peers (X/Y/Z) — enough to grow WgPeers to len 3 / cap 4 (one-at-a-time
+// appends double: 1 -> 2 -> 4) and leave a spare slot. Two per-unit tunnels each
+// add their OWN distinct peer. Before the fix both units aliased the
+// interface-level WgPeers backing array, so the second unit's peer overwrote
+// the first unit's peer in the shared spare slot: unit 1 silently carried unit
+// 2's peer instead of its own.
+func TestPerUnitTunnelWgPeersIndependent(t *testing.T) {
+	const (
+		priv  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+		peerX = "1111111111111111111111111111111111111111111111111111111111111111"
+		peerY = "2222222222222222222222222222222222222222222222222222222222222222"
+		peerZ = "3333333333333333333333333333333333333333333333333333333333333333"
+		peerA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		peerB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+	cmds := []string{
+		"set interfaces gr-0/0/0 tunnel mode wireguard",
+		"set interfaces gr-0/0/0 tunnel wireguard listen-port 51820",
+		"set interfaces gr-0/0/0 tunnel wireguard private-key " + priv,
+		"set interfaces gr-0/0/0 tunnel wireguard peer " + peerX + " allowed-ips 10.100.0.0/24",
+		"set interfaces gr-0/0/0 tunnel wireguard peer " + peerY + " allowed-ips 10.100.1.0/24",
+		"set interfaces gr-0/0/0 tunnel wireguard peer " + peerZ + " allowed-ips 10.100.2.0/24",
+		// Per-unit tunnels, each inheriting mode/listen-port/private-key/X/Y/Z
+		// and adding its OWN distinct peer.
+		"set interfaces gr-0/0/0 unit 1 tunnel wireguard peer " + peerA + " allowed-ips 10.200.1.0/24",
+		"set interfaces gr-0/0/0 unit 2 tunnel wireguard peer " + peerB + " allowed-ips 10.200.2.0/24",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["gr-0/0/0"]
+	if ifc == nil {
+		t.Fatal("gr-0/0/0 interface not found")
+	}
+	u1, u2 := ifc.Units[1], ifc.Units[2]
+	if u1 == nil || u1.Tunnel == nil || u2 == nil || u2.Tunnel == nil {
+		t.Fatal("per-unit wireguard tunnels not found")
+	}
+
+	pubkeys := func(tc *TunnelConfig) []string {
+		out := make([]string, 0, len(tc.WgPeers))
+		for _, p := range tc.WgPeers {
+			out = append(out, p.PublicKeyHex)
+		}
+		return out
+	}
+	p1, p2 := pubkeys(u1.Tunnel), pubkeys(u2.Tunnel)
+
+	if !hasStr(p1, peerA) {
+		t.Errorf("unit 1 lost its own peer %s: got %v", peerA, p1)
+	}
+	if hasStr(p1, peerB) {
+		t.Errorf("unit 1 was contaminated with unit 2's peer %s: got %v", peerB, p1)
+	}
+	if !hasStr(p2, peerB) {
+		t.Errorf("unit 2 lost its own peer %s: got %v", peerB, p2)
+	}
+	if hasStr(p2, peerA) {
+		t.Errorf("unit 2 was contaminated with unit 1's peer %s: got %v", peerA, p2)
+	}
+
+	// The inherited X/Y/Z peers must still be present on both units.
+	for _, u := range []struct {
+		name string
+		p    []string
+	}{{"unit1", p1}, {"unit2", p2}} {
+		for _, want := range []string{peerX, peerY, peerZ} {
+			if !hasStr(u.p, want) {
+				t.Errorf("%s lost inherited peer %s: got %v", u.name, want, u.p)
+			}
+		}
+	}
+
+	// Backing-array independence: the two units must not share WgPeers.
+	if len(u1.Tunnel.WgPeers) > 0 && len(u2.Tunnel.WgPeers) > 0 &&
+		&u1.Tunnel.WgPeers[0] == &u2.Tunnel.WgPeers[0] {
+		t.Error("unit 1 and unit 2 tunnel WgPeers share the same backing array")
+	}
+}
+
+// TestPerUnitTunnelSingleUnitAndNoOverrideStillInherit guards the non-aliasing
+// paths the #3898 fix must not regress: a single per-unit tunnel inherits the
+// interface-level source/destination correctly, and a unit WITHOUT its own
+// per-unit tunnel shares the interface-level tunnel (addresses collected onto
+// it) rather than getting a separate device.
+func TestPerUnitTunnelSingleUnitAndNoOverrideStillInherit(t *testing.T) {
+	cmds := []string{
+		"set interfaces gr-0/0/0 tunnel source 198.51.100.1",
+		"set interfaces gr-0/0/0 tunnel destination 198.51.100.2",
+		// unit 0: no per-unit tunnel -> shares the interface-level tunnel;
+		// its address is collected onto ifc.Tunnel.
+		"set interfaces gr-0/0/0 unit 0 family inet address 10.1.0.1/30",
+		// unit 5: per-unit tunnel that overrides only the key, inheriting
+		// source/destination from the interface-level tunnel.
+		"set interfaces gr-0/0/0 unit 5 tunnel key 42",
+		"set interfaces gr-0/0/0 unit 5 family inet address 10.5.0.1/30",
+	}
+	cfg, err := CompileConfig(buildTree(t, cmds))
+	if err != nil {
+		t.Fatalf("CompileConfig: %v", err)
+	}
+	ifc := cfg.Interfaces.Interfaces["gr-0/0/0"]
+	if ifc == nil || ifc.Tunnel == nil {
+		t.Fatal("gr-0/0/0 interface tunnel not found")
+	}
+
+	// No-override unit shares the interface-level tunnel; its address landed
+	// on ifc.Tunnel.Addresses.
+	if !hasStr(ifc.Tunnel.Addresses, "10.1.0.1/30") {
+		t.Errorf("interface-level tunnel missing no-override unit 0 address: got %v", ifc.Tunnel.Addresses)
+	}
+	if u0 := ifc.Units[0]; u0 != nil && u0.Tunnel != nil {
+		t.Errorf("unit 0 (no per-unit tunnel) unexpectedly got its own tunnel device %q", u0.Tunnel.Name)
+	}
+
+	// Single per-unit tunnel inherits source/destination and owns its device.
+	u5 := ifc.Units[5]
+	if u5 == nil || u5.Tunnel == nil {
+		t.Fatal("unit 5 per-unit tunnel is nil")
+	}
+	if u5.Tunnel.Source != "198.51.100.1" || u5.Tunnel.Destination != "198.51.100.2" {
+		t.Errorf("unit 5 did not inherit source/destination: src=%q dst=%q",
+			u5.Tunnel.Source, u5.Tunnel.Destination)
+	}
+	if u5.Tunnel.Key != 42 {
+		t.Errorf("unit 5 key override lost: got %d, want 42", u5.Tunnel.Key)
+	}
+	if !hasStr(u5.Tunnel.Addresses, "10.5.0.1/30") {
+		t.Errorf("unit 5 missing its own address 10.5.0.1/30: got %v", u5.Tunnel.Addresses)
+	}
+	if !strings.HasSuffix(u5.Tunnel.Name, "u5") {
+		t.Errorf("unit 5 per-unit tunnel Name %q should end in u5", u5.Tunnel.Name)
+	}
+}
+
+// TestTunnelConfigCloneForUnitDeepCopy exercises the cloneForUnit helper
+// directly, including the nested per-peer AllowedIPs slice that the compile
+// paths above do not mutate in place. Mutating the clone's slices (append into
+// spare capacity, in-place element overwrite) must leave the original
+// completely untouched.
+func TestTunnelConfigCloneForUnitDeepCopy(t *testing.T) {
+	orig := &TunnelConfig{
+		Name:        "gr-0-0-0",
+		Mode:        "wireguard",
+		Source:      "10.0.0.1",
+		Destination: "10.0.0.2",
+		// len 2 / cap 4 so an append lands in spare capacity (in-place write
+		// on a shared array would corrupt the original).
+		Addresses: append(make([]string, 0, 4), "10.1.0.1/30", "10.1.0.2/30"),
+		WgPeers: []WgPeerConfig{
+			{PublicKeyHex: "aa", AllowedIPs: append(make([]string, 0, 4), "10.2.0.0/24")},
+		},
+	}
+	clone := orig.cloneForUnit("gr-0-0-0u3")
+
+	if clone.Name != "gr-0-0-0u3" {
+		t.Errorf("clone Name = %q, want gr-0-0-0u3", clone.Name)
+	}
+	if orig.Name != "gr-0-0-0" {
+		t.Errorf("clone mutated original Name: %q", orig.Name)
+	}
+
+	// Mutate the clone's Addresses: append (into spare cap) + in-place set.
+	clone.Addresses = append(clone.Addresses, "10.9.9.9/30")
+	clone.Addresses[0] = "255.255.255.255/32"
+	if hasStr(orig.Addresses, "10.9.9.9/30") {
+		t.Errorf("clone Addresses append leaked into original: %v", orig.Addresses)
+	}
+	if orig.Addresses[0] != "10.1.0.1/30" {
+		t.Errorf("clone Addresses in-place write leaked into original: %v", orig.Addresses)
+	}
+
+	// Mutate the clone's WgPeers and the nested AllowedIPs.
+	clone.WgPeers = append(clone.WgPeers, WgPeerConfig{PublicKeyHex: "bb"})
+	clone.WgPeers[0].AllowedIPs = append(clone.WgPeers[0].AllowedIPs, "10.8.8.0/24")
+	clone.WgPeers[0].AllowedIPs[0] = "0.0.0.0/0"
+	if len(orig.WgPeers) != 1 {
+		t.Errorf("clone WgPeers append leaked into original: len=%d", len(orig.WgPeers))
+	}
+	if hasStr(orig.WgPeers[0].AllowedIPs, "10.8.8.0/24") {
+		t.Errorf("clone AllowedIPs append leaked into original: %v", orig.WgPeers[0].AllowedIPs)
+	}
+	if orig.WgPeers[0].AllowedIPs[0] != "10.2.0.0/24" {
+		t.Errorf("clone AllowedIPs in-place write leaked into original: %v", orig.WgPeers[0].AllowedIPs)
+	}
+}

--- a/pkg/config/types_routing.go
+++ b/pkg/config/types_routing.go
@@ -513,6 +513,39 @@ func (tc *TunnelConfig) String() string {
 		tc.WgListenPort, priv, strings.Join(peers, " "))
 }
 
+// cloneForUnit returns a deep copy of tc for a per-unit tunnel netdev,
+// with Name overridden to linuxName. Every reference-typed field is
+// given an INDEPENDENT backing array so a per-unit override on one unit
+// (e.g. appending its own Addresses or WgPeers) never mutates a slice
+// that a sibling unit inherited from the same interface-level tunnel
+// (#3898). A plain `*tc = *ifc.Tunnel` struct copy only copies the
+// slice headers (ptr+len+cap), so siblings would alias the parent's
+// backing array and cross-contaminate each other's IPs / peers.
+//
+// Deep-copied fields (audit of TunnelConfig for reference types):
+//   - Addresses      []string
+//   - WgPeers         []WgPeerConfig, and each peer's nested AllowedIPs []string
+//
+// All other fields are value types (strings, ints, uint32, uint16,
+// bool, Secret which is a string alias) and are safe to copy by value.
+func (tc *TunnelConfig) cloneForUnit(linuxName string) *TunnelConfig {
+	cp := *tc
+	cp.Name = linuxName
+	if tc.Addresses != nil {
+		cp.Addresses = append([]string(nil), tc.Addresses...)
+	}
+	if tc.WgPeers != nil {
+		cp.WgPeers = make([]WgPeerConfig, len(tc.WgPeers))
+		for i, p := range tc.WgPeers {
+			cp.WgPeers[i] = p
+			if p.AllowedIPs != nil {
+				cp.WgPeers[i].AllowedIPs = append([]string(nil), p.AllowedIPs...)
+			}
+		}
+	}
+	return &cp
+}
+
 // WgOuterFamilyV6 reports whether the tunnel's outer transport family is
 // IPv6 (#1434). A WG interface binds ONE kernel UDP socket, so it has a
 // single outer family. The family is derived from the peer(s) that


### PR DESCRIPTION
Closes #3898

## Problem

Per-unit tunnel inheritance in `compileInterfaces` inherited the
interface-level tunnel config onto each unit's own tunnel device with a
shallow struct copy:

```go
*tc = *ifc.Tunnel   // pkg/config/compiler_interfaces.go
tc.Name = linuxName
```

A struct copy of `TunnelConfig` duplicates only the **slice headers**
(ptr+len+cap) of its reference-typed fields, so every unit that inherits
from the parent tunnel shares the **same backing array** as the parent
(and, transitively, its siblings). When a unit then appended its own
address (`Addresses`) or peer (`WgPeers`) into shared spare capacity, the
write landed in the aliased array: the second-processed unit overwrote
the first-processed unit's slot, and the first unit's slice header —
still pointing at that array with an extended length — read the second
unit's value.

Result: a unit silently carried a sibling's IP (a **duplicate IP on two
tunnel netdevs**, one tunnel unusable) or a sibling's WireGuard peer.

Found by fable-review-161 F-031.

## Fix

Add `TunnelConfig.cloneForUnit(linuxName)` — a deep copy that gives each
per-unit tunnel independent backing arrays. Audit of `TunnelConfig`
reference-typed fields, all cloned:

- `Addresses []string`
- `WgPeers []WgPeerConfig`, and each peer's nested `AllowedIPs []string`

Every other field is a value type (strings, ints, `uint32`, `uint16`,
`bool`, `Secret` which is a string alias) and is safe to copy by value.
The call site now uses `cloneForUnit` instead of the shallow struct copy.

No documentation change: per-unit tunnel inheritance semantics are not a
separately documented contract; this is an internal correctness fix that
makes each unit correctly own its own config rather than aliasing its
siblings'.

## Tests (RED on revert)

Reverting the call-site line back to the shallow `*tc = *ifc.Tunnel`
makes both end-to-end tests FAIL:

- `TestPerUnitTunnelAddressesIndependent` — two per-unit tunnels each set
  a distinct address; seed units grow the parent `Addresses` slice to
  len 3 / cap 4 so the aliasing writes into the shared spare slot. On the
  shallow copy, unit 1 gets `[10.9.0.1/30 10.9.1.1/30 10.9.2.1/30
  10.0.2.1/30]` — unit 2's address `10.0.2.1/30` in unit 1's slot.
- `TestPerUnitTunnelWgPeersIndependent` — interface-level WireGuard
  tunnel with three peers (spare cap) plus two per-unit tunnels each
  adding a peer. On the shallow copy, unit 1 ends up with unit 2's peer.
- `TestPerUnitTunnelSingleUnitAndNoOverrideStillInherit` — guards the
  non-aliasing inheritance paths (no-override unit shares the
  interface-level tunnel; single per-unit tunnel inherits source/dest).
- `TestTunnelConfigCloneForUnitDeepCopy` — direct helper test covering
  the nested per-peer `AllowedIPs` independence.

`go test ./pkg/config/...` green; `go build ./...` clean; `gofmt` + `go
vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
