### PR TITLE
config: reject/scrub comment delimiters in annotations (#3900)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29069,3 +29069,39 @@ top.
   ValidateEnum in ike.policy + ike.gateway + ipsec.gateway),
   pkg/config/schema_ike_enum_3896_test.go (new, RED-on-revert gate),
   docs/config-schema.md (#3896 enum-typing section)
+
+## 2026-07-03 — #3900 annotation comment-delimiter injection
+
+- **Timestamp**: 2026-07-03
+- **Action**: Fix config annotation `*/`/`/*` comment-delimiter injection
+  (fable-review-161 F-035, MEDIUM config-integrity/injection). Node
+  annotations are emitted VERBATIM between `/* */` by ast_format.go, so an
+  annotation containing `*/` closes the comment early and the trailing
+  text is re-lexed as configuration on the next Format→Parse round-trip
+  (HA config sync — the primary formats, the secondary re-parses — and
+  rollback/archive reload). Empirically reproduced: annotation `note */
+  set system host-name pwned; /* end` on a leaf produced an injected
+  `set system host-name pwned` node in the reparsed tree. Annotations
+  enter the tree ONLY via `Store.Annotate` (the lexer discards comments
+  on parse), so allowing the primary to commit a malicious annotation is
+  the root. Fix mirrors the #1798 two-layer free-text defense: (1)
+  `Store.Annotate` rejects a delimiter up front via new public
+  `config.ValidateAnnotationText` (immediate operator feedback); (2) the
+  strict commit path `validateNodesControlChars` rejects it as a
+  backstop; (3) the lenient load/peer-sync path
+  `sanitizeNodesControlChars`/`SanitizeTreeControlChars` scrubs an
+  already-persisted delimiter in place (single-pass `sanitizeCommentDelim`
+  inserts a space between the two chars — also splits chained `*/*`,
+  `/*/`, `/**/`). Values are immune (emitted quoted; the lexer never
+  starts a comment inside a quoted string), so the guard is
+  annotation-only. RED-on-revert proven: reverting the strict-reject +
+  lenient-sanitize wiring makes the strict-reject test fail and the
+  Format→Parse round-trip re-inject. go test ./pkg/config/...
+  ./pkg/configstore/... green; go build ./... clean; gofmt + vet clean.
+- **File(s)**: pkg/config/freetext.go (hasCommentDelim,
+  sanitizeCommentDelim, ValidateAnnotationText; wired into
+  validateNodesControlChars + sanitizeNodesControlChars; package doc),
+  pkg/configstore/store_command.go (Store.Annotate early reject),
+  pkg/config/freetext_test.go (RED-on-revert injection + reject +
+  helper tests), pkg/configstore/store_test.go
+  (TestAnnotateRejectsCommentDelimiter), docs/phases.md (#3900 note)

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -670,7 +670,7 @@ Gap audit: `docs/archived/userspace-forwarding-and-failover-gap-audit.md` (PR #3
 ## Sprint 21 (`72e1020`)
 - **show security policies detail:** Expanded Junos-style policy view with resolved address book entries, application details, log flags, per-rule BPF hit counters; zone-pair filtering; global policies; gRPC policies-detail topic
 - **show firewall filter `<name>`:** Per-filter drill-down showing terms with match conditions (dscp, protocol, ports, tcp-flags, fragment), actions (accept/discard/reject/log/forwarding-class), BPF hit counts; DynamicFn completion for filter names
-- **Config annotate:** `annotate <path> "comment"` in configure mode; Annotation field on AST Node; /* comment */ output in FormatText(); Annotate() method in configstore; parser tests
+- **Config annotate:** `annotate <path> "comment"` in configure mode; Annotation field on AST Node; /* comment */ output in FormatText(); Annotate() method in configstore; parser tests. **#3900 injection hardening:** the annotation is emitted verbatim between `/* */`, so a `*/` (or `/*`) in the text would close the comment early and let the trailing text be re-lexed as configuration on the next Format→Parse round-trip (HA config sync, rollback/archive reload). `Store.Annotate` now rejects a comment delimiter up front (`config.ValidateAnnotationText`), the strict commit path (`validateNodesControlChars`) rejects it as a backstop, and the lenient load/peer-sync path (`sanitizeNodesControlChars`/`SanitizeTreeControlChars`) scrubs an already-persisted delimiter in place — mirroring the #1798 control-character two-layer defense (`pkg/config/freetext.go`).
 - Files: 8 files, 789 insertions — pkg/{cli,cmdtree,config,configstore,grpcapi}/, cmd/cli/
 
 ## Sprint 22 (`26cf1ad`)

--- a/pkg/config/freetext.go
+++ b/pkg/config/freetext.go
@@ -35,6 +35,21 @@ import (
 // The render-side belt (sanitizers in pkg/networkd, pkg/frr, pkg/ipsec
 // at each free-text file interpolation) is the third, independent
 // layer.
+//
+// #3900: a second, annotation-only injection class rides the same two
+// layers. Node annotations (the `annotate` command) are emitted VERBATIM
+// into `/* ... */` block comments by ast_format.go. An annotation
+// containing the sequence `*/` closes the comment early, so every token
+// after it is re-lexed as real configuration on the next Format→Parse
+// round-trip — HA config sync (the primary formats, the secondary
+// re-parses) and rollback/archive reload. `/*` is neutralized on the
+// same footing (a stray open would swallow following statements as an
+// unterminated comment). The strict commit path REJECTS a comment
+// delimiter in an annotation; the lenient load/peer-sync path scrubs it
+// in place (breaking the pair with a space). Config VALUES are immune —
+// they are emitted quoted (quoteKey), and the lexer never starts a
+// comment inside a quoted string — so the comment-delimiter guard is
+// applied to annotations only.
 
 // hasControlChars reports whether s contains any ASCII control
 // character: the full C0 set (0x00–0x1F, which includes \n, \r and \t)
@@ -66,6 +81,65 @@ func sanitizeControlChars(s string) string {
 	return string(b)
 }
 
+// ValidateAnnotationText returns a non-nil error if the annotation text
+// contains an ASCII control character or a `*/`/`/*` block-comment
+// delimiter (#3900). It is the single validation entry point for the
+// `annotate` command path (configstore.Store.Annotate), giving the
+// operator immediate feedback instead of deferring the rejection to
+// commit. The strict commit path (validateNodesControlChars) applies the
+// same rule as a backstop for annotations introduced by any other route.
+func ValidateAnnotationText(annotation string) error {
+	if hasControlChars(annotation) {
+		return fmt.Errorf("annotation %q contains control characters (newlines and other control characters are not allowed in annotations)", annotation)
+	}
+	if hasCommentDelim(annotation) {
+		return fmt.Errorf("annotation %q contains a comment delimiter (the sequences '*/' and '/*' are not allowed in annotations — they would close the comment and inject the remaining text as configuration on reload)", annotation)
+	}
+	return nil
+}
+
+// hasCommentDelim reports whether s contains a block-comment delimiter
+// (`*/` or `/*`). Annotations are emitted verbatim between `/* */`, so
+// either sequence lets annotation text escape the comment on the next
+// Format→Parse round-trip (#3900). Values never need this check — they
+// are emitted quoted and the lexer does not start comments inside a
+// quoted string — so the guard is used on annotations only.
+func hasCommentDelim(s string) bool {
+	for i := 0; i+1 < len(s); i++ {
+		if s[i] == '*' && s[i+1] == '/' {
+			return true
+		}
+		if s[i] == '/' && s[i+1] == '*' {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeCommentDelim breaks every block-comment delimiter (`*/`, `/*`)
+// in s by inserting a single space between the two characters, so the
+// text can no longer close or open a `/* */` comment. The single
+// left-to-right pass also splits chained delimiters such as `*/*` and
+// `/*/` (a delimiter created by a preceding split is re-examined on the
+// next byte), so the result is guaranteed free of both sequences.
+// Replacing rather than deleting keeps the annotation readable.
+func sanitizeCommentDelim(s string) string {
+	if !hasCommentDelim(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for i := 0; i < len(s); i++ {
+		b.WriteByte(s[i])
+		if i+1 < len(s) {
+			if (s[i] == '*' && s[i+1] == '/') || (s[i] == '/' && s[i+1] == '*') {
+				b.WriteByte(' ')
+			}
+		}
+	}
+	return b.String()
+}
+
 // joinNodePath builds a human-readable config path for error/warning
 // messages. Key values are sanitized for display so a path containing
 // the offending newline does not itself produce a multi-line message.
@@ -83,7 +157,9 @@ func joinNodePath(prefix string, keys []string) string {
 
 // validateNodesControlChars walks the (group-expanded) AST and returns
 // an error for the first value or annotation containing a control
-// character. Strict commit-path only — see the package comment above.
+// character, or the first annotation containing a `*/`/`/*` comment
+// delimiter (#3900). Strict commit-path only — see the package comment
+// above.
 func validateNodesControlChars(nodes []*Node, prefix string) error {
 	for _, n := range nodes {
 		nodePath := joinNodePath(prefix, n.Keys)
@@ -95,6 +171,9 @@ func validateNodesControlChars(nodes []*Node, prefix string) error {
 		if hasControlChars(n.Annotation) {
 			return fmt.Errorf("%s: annotation %q contains control characters (newlines and other control characters are not allowed in annotations)", nodePath, n.Annotation)
 		}
+		if hasCommentDelim(n.Annotation) {
+			return fmt.Errorf("%s: annotation %q contains a comment delimiter (the sequences '*/' and '/*' are not allowed in annotations — they would close the comment and inject the remaining text as configuration on reload)", nodePath, n.Annotation)
+		}
 		if err := validateNodesControlChars(n.Children, nodePath); err != nil {
 			return err
 		}
@@ -103,9 +182,10 @@ func validateNodesControlChars(nodes []*Node, prefix string) error {
 }
 
 // sanitizeNodesControlChars walks the AST replacing control characters
-// in values and annotations in place, returning one human-readable
-// config path per modified node. Lenient-path counterpart of
-// validateNodesControlChars.
+// in values and annotations in place — and breaking any `*/`/`/*`
+// comment delimiter in an annotation (#3900) — returning one
+// human-readable config path per modified node. Lenient-path
+// counterpart of validateNodesControlChars.
 func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
 	var warnings []string
 	for _, n := range nodes {
@@ -118,6 +198,10 @@ func sanitizeNodesControlChars(nodes []*Node, prefix string) []string {
 		}
 		if hasControlChars(n.Annotation) {
 			n.Annotation = sanitizeControlChars(n.Annotation)
+			changed = true
+		}
+		if hasCommentDelim(n.Annotation) {
+			n.Annotation = sanitizeCommentDelim(n.Annotation)
 			changed = true
 		}
 		nodePath := joinNodePath(prefix, n.Keys)

--- a/pkg/config/freetext_test.go
+++ b/pkg/config/freetext_test.go
@@ -106,6 +106,190 @@ func TestCompileConfigRejectsControlCharAnnotation(t *testing.T) {
 	}
 }
 
+// #3900: node annotations are emitted verbatim into `/* */` comments,
+// so an annotation containing `*/` closes the comment early and the
+// trailing text is re-lexed as configuration on the next Format→Parse
+// round-trip (HA config sync, rollback/archive reload). The strict
+// commit path must reject the delimiter; the lenient path must scrub it
+// so a Format→Parse round-trip cannot inject.
+
+const injectAnnotation = `note */ set system host-name pwned; /* end`
+
+// mtuTreeWithAnnotation builds a one-leaf tree and sets its annotation.
+func mtuTreeWithAnnotation(t *testing.T, annotation string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	path, err := ParseSetCommand("set interfaces ge-0-0-0 mtu 1500")
+	if err != nil {
+		t.Fatalf("ParseSetCommand: %v", err)
+	}
+	if err := tree.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	tree.Children[0].Annotation = annotation
+	return tree
+}
+
+// sameStructure compares two node slices by Keys, IsLeaf, and Children,
+// ignoring Annotation (which the lexer discards on parse) — so it detects
+// injected or dropped configuration nodes.
+func sameStructure(a, b []*Node) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].IsLeaf != b[i].IsLeaf || len(a[i].Keys) != len(b[i].Keys) {
+			return false
+		}
+		for j := range a[i].Keys {
+			if a[i].Keys[j] != b[i].Keys[j] {
+				return false
+			}
+		}
+		if !sameStructure(a[i].Children, b[i].Children) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCompileConfigRejectsCommentDelimAnnotation(t *testing.T) {
+	tree := mtuTreeWithAnnotation(t, injectAnnotation)
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("strict CompileConfig must reject an annotation containing a '*/' comment delimiter")
+	}
+	if !strings.Contains(err.Error(), "comment delimiter") {
+		t.Fatalf("error should mention the comment delimiter: %v", err)
+	}
+	if !strings.Contains(err.Error(), "annotation") {
+		t.Fatalf("error should mention the annotation: %v", err)
+	}
+	// The leading `/*` half of the pair must be rejected too.
+	openTree := mtuTreeWithAnnotation(t, "danger /* swallow the next stanza")
+	if _, err := CompileConfig(openTree); err == nil {
+		t.Fatal("strict CompileConfig must reject an annotation containing a '/*' comment delimiter")
+	}
+}
+
+// TestAnnotationCommentDelimInjection is the #3900 RED-on-revert proof:
+// without the fix, a malicious annotation round-trips through Format→Parse
+// into an INJECTED config node; with the fix, the lenient sanitize breaks
+// the delimiter so the round-trip is inert, and the strict compile rejects
+// the annotation outright.
+func TestAnnotationCommentDelimInjection(t *testing.T) {
+	// Baseline: the same tree WITHOUT any annotation, formatted and
+	// re-parsed, is the reference structure a safe round-trip must match.
+	clean := mtuTreeWithAnnotation(t, "")
+	clean.Children[0].Annotation = ""
+	refParsed, errs := NewParser(clean.Format()).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("baseline parse errors: %v", errs)
+	}
+
+	// Demonstrate the injection primitive is real: the malicious
+	// annotation, emitted verbatim, escapes the comment on re-parse. This
+	// is what a revert of the sanitize would leave live.
+	malicious := mtuTreeWithAnnotation(t, injectAnnotation)
+	injected, errs := NewParser(malicious.Format()).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("malicious parse errors: %v", errs)
+	}
+	if sameStructure(injected.Children, refParsed.Children) {
+		t.Fatal("expected the un-sanitized malicious annotation to INJECT nodes on Format→Parse (injection primitive precondition)")
+	}
+
+	// The lenient migration path (Store.Load / peer-sync) must scrub the
+	// delimiter in place so the SAME tree now round-trips inert.
+	warnings := SanitizeTreeControlChars(malicious)
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one sanitize warning, got %d: %v", len(warnings), warnings)
+	}
+	if hasCommentDelim(malicious.Children[0].Annotation) {
+		t.Fatalf("annotation still holds a comment delimiter after sanitize: %q", malicious.Children[0].Annotation)
+	}
+	sanitizedParsed, errs := NewParser(malicious.Format()).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("sanitized parse errors: %v", errs)
+	}
+	if !sameStructure(sanitizedParsed.Children, refParsed.Children) {
+		t.Fatalf("sanitized annotation still injected/altered config on Format→Parse: %v", sanitizedParsed.Children)
+	}
+
+	// And the strict commit path rejects the malicious annotation outright,
+	// so it can never be committed on the primary in the first place.
+	if _, err := CompileConfig(mtuTreeWithAnnotation(t, injectAnnotation)); err == nil {
+		t.Fatal("strict CompileConfig must reject the malicious annotation")
+	}
+}
+
+// TestNormalAnnotationRoundTrips confirms a benign annotation is inert:
+// it neither injects nor drops real configuration on Format→Parse and is
+// accepted by both the strict and lenient paths.
+func TestNormalAnnotationRoundTrips(t *testing.T) {
+	clean := mtuTreeWithAnnotation(t, "")
+	clean.Children[0].Annotation = ""
+	ref, errs := NewParser(clean.Format()).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("baseline parse errors: %v", errs)
+	}
+
+	normal := mtuTreeWithAnnotation(t, "primary firewall MTU note")
+	if _, err := CompileConfig(normal); err != nil {
+		t.Fatalf("strict CompileConfig must accept a normal annotation: %v", err)
+	}
+	if w := SanitizeTreeControlChars(normal); len(w) != 0 {
+		t.Fatalf("normal annotation must not be sanitized, got %v", w)
+	}
+	parsed, errs := NewParser(normal.Format()).Parse()
+	if len(errs) > 0 {
+		t.Fatalf("normal parse errors: %v", errs)
+	}
+	if !sameStructure(parsed.Children, ref.Children) {
+		t.Fatalf("normal annotation altered config structure on Format→Parse: %v", parsed.Children)
+	}
+}
+
+func TestSanitizeCommentDelim(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"clean note", "clean note"},
+		{"a */ b", "a * / b"},
+		{"a /* b", "a / * b"},
+		{"a */ b /* c", "a * / b / * c"},
+		{"*/*", "* / *"}, // chained: split must not leave a delimiter
+		{"/*/", "/ * /"},
+		{"/**/", "/ ** /"}, // /**/ -> /* and */ both broken, inner ** untouched
+	}
+	for _, c := range cases {
+		got := sanitizeCommentDelim(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeCommentDelim(%q) = %q, want %q", c.in, got, c.want)
+		}
+		if hasCommentDelim(got) {
+			t.Errorf("sanitizeCommentDelim(%q) = %q still contains a delimiter", c.in, got)
+		}
+	}
+}
+
+func TestValidateAnnotationText(t *testing.T) {
+	if err := ValidateAnnotationText("a normal note"); err != nil {
+		t.Errorf("normal annotation should validate: %v", err)
+	}
+	if err := ValidateAnnotationText("bad */ inject"); err == nil {
+		t.Error("annotation with '*/' must be rejected")
+	} else if !strings.Contains(err.Error(), "comment delimiter") {
+		t.Errorf("error should mention comment delimiter: %v", err)
+	}
+	if err := ValidateAnnotationText("open /* here"); err == nil {
+		t.Error("annotation with '/*' must be rejected")
+	}
+	if err := ValidateAnnotationText("line\nbreak"); err == nil {
+		t.Error("annotation with a control character must be rejected")
+	} else if !strings.Contains(err.Error(), "control characters") {
+		t.Errorf("error should mention control characters: %v", err)
+	}
+}
+
 func TestCompileConfigLenientSanitizesNewlineDescription(t *testing.T) {
 	tree := newlineDescTree(t)
 	cfg, err := CompileConfigLenient(tree)

--- a/pkg/configstore/store_command.go
+++ b/pkg/configstore/store_command.go
@@ -179,6 +179,15 @@ func (s *Store) Annotate(path []string, comment string) error {
 	if s.candidate == nil {
 		return fmt.Errorf("not in configuration mode")
 	}
+	// #3900: reject a comment delimiter (or control character) in the
+	// annotation up front. An annotation is emitted verbatim into a
+	// `/* */` comment, so a `*/` would close the comment early and let the
+	// trailing text be re-parsed as configuration on the next Format→Parse
+	// (HA config sync, rollback/archive reload). The strict commit path
+	// enforces the same rule; this is the immediate-feedback layer.
+	if err := config.ValidateAnnotationText(comment); err != nil {
+		return err
+	}
 
 	children := s.candidate.Children
 	var target *config.Node

--- a/pkg/configstore/store_test.go
+++ b/pkg/configstore/store_test.go
@@ -1359,6 +1359,42 @@ func TestAnnotate(t *testing.T) {
 	}
 }
 
+// TestAnnotateRejectsCommentDelimiter is the #3900 guard: an annotation
+// containing a `*/` (or `/*`) block-comment delimiter must be rejected up
+// front, because it would close the `/* */` comment early and inject the
+// trailing text as configuration on the next Format→Parse round-trip
+// (HA config sync, rollback/archive reload).
+func TestAnnotateRejectsCommentDelimiter(t *testing.T) {
+	s := newTestStore(t)
+	s.EnterConfigure()
+	if err := s.Set([]string{"system", "host-name", "fw1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The exact injection payload from the issue.
+	err := s.Annotate([]string{"system"}, "note */ set system host-name pwned; /* end")
+	if err == nil {
+		t.Fatal("Annotate must reject an annotation containing a '*/' comment delimiter")
+	}
+	if !strings.Contains(err.Error(), "comment delimiter") {
+		t.Errorf("error should mention comment delimiter: %v", err)
+	}
+	// The bare `/*` open half must be rejected too.
+	if err := s.Annotate([]string{"system"}, "danger /* swallow"); err == nil {
+		t.Fatal("Annotate must reject an annotation containing a '/*' comment delimiter")
+	}
+	// The rejected annotation must NOT have been applied, so the candidate
+	// stays injection-free through a format round-trip.
+	text := s.ShowCandidate()
+	if strings.Contains(text, "pwned") || strings.Contains(text, "set system host-name") {
+		t.Errorf("rejected annotation leaked into candidate:\n%s", text)
+	}
+	// A benign annotation still works.
+	if err := s.Annotate([]string{"system"}, "primary firewall"); err != nil {
+		t.Errorf("benign annotation must be accepted: %v", err)
+	}
+}
+
 func TestLoadSet(t *testing.T) {
 	s := newTestStore(t)
 	if err := s.EnterConfigure(); err != nil {


### PR DESCRIPTION
Closes #3900

## Problem

Config annotations (the Junos `annotate` command) are emitted VERBATIM
between `/* */` block-comment delimiters by `pkg/config/ast_format.go`.
There is no sanitization. An annotation containing `*/` closes the
comment early, so the trailing text is re-lexed as **real configuration**
on the next Format→Parse round-trip — HA config sync (the primary
formats, the secondary re-parses) and rollback/archive reload. A crafted
or accidental annotation injects config the operator never wrote, or
bricks the reload with a parse error. `/*` is neutralized on the same
footing.

Reproduced empirically: annotation `note */ set system host-name pwned; /* end`
on a leaf formats to `/* note */ set system host-name pwned; /* end */`,
which re-parses to an injected `set system host-name pwned` node.

## Root cause

Annotations enter the tree **only** via `Store.Annotate` (the lexer
discards comments on parse), so allowing the primary to commit a
malicious annotation is the root of the injection.

## Fix

Mirrors the #1798 free-text control-character two-layer defense
(`pkg/config/freetext.go`):

- **`Store.Annotate`** rejects a comment delimiter up front via the new
  public `config.ValidateAnnotationText` — immediate operator feedback;
  the annotate path is operator-only so it cannot brick boot.
- **Strict commit path** (`validateNodesControlChars`, via
  `CompileConfig` / commit-check) rejects a delimiter as a backstop for
  any other route.
- **Lenient load / peer-sync path** (`sanitizeNodesControlChars`,
  `SanitizeTreeControlChars`) scrubs an already-persisted delimiter in
  place so a config committed before this fix cannot inject on its next
  reload, and the primary's own tree is neutralized before it ever
  `Format()`s for HA sync. `sanitizeCommentDelim` is a single
  left-to-right pass that inserts a space between the two delimiter
  chars; it also splits chained delimiters (`*/*`, `/*/`, `/**/`).

Config **values** are immune (emitted quoted; the lexer never starts a
comment inside a quoted string), so the guard is annotation-only.

## Tests (RED-on-revert)

- `TestAnnotationCommentDelimInjection` — proves the malicious annotation
  injects on a raw Format→Parse, then that the lenient sanitize makes the
  same tree round-trip inert and the strict compile rejects it. Reverting
  either the strict-reject or the lenient-sanitize wiring turns this RED.
- `TestCompileConfigRejectsCommentDelimAnnotation`, `TestNormalAnnotationRoundTrips`,
  `TestSanitizeCommentDelim`, `TestValidateAnnotationText`,
  `TestAnnotateRejectsCommentDelimiter` (configstore).

`go test ./pkg/config/... ./pkg/configstore/...` green; `go build ./...`,
gofmt, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
