### PR TITLE
screen: run source-independent screens on the flowless path (#3902)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-03 — #3902: flowless screen path bypassed the source-independent screens (LAND, ip-source-route, ICMP/UDP flood) — fail-open on non-query ICMP + non-first fragments
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-085 (MEDIUM, screen/IDS fail-open). In
+    `stage_screen_check` the flowless branch (`flow == None` — a non-first IP
+    fragment #2344 or a non-query ICMP/ICMPv6 control message #3290) ran ONLY
+    the three L3 fragment screens restored by #3064 (ping-of-death, teardrop,
+    icmp-fragment). It did NOT run the SOURCE-INDEPENDENT screens — LAND
+    anti-spoof, ip-source-route, and the per-zone ICMP/UDP flood counters —
+    which need no transport flow. A crafted non-query ICMP or non-first
+    fragment therefore BYPASSED those screens (screen fail-open).
+  - **Fix**: Replaced `ScreenState::check_fragment_screens_l3` (&self, 3
+    fragment screens) with `ScreenState::check_flowless_screens` (&mut self)
+    that also runs LAND, ip-source-route, ICMP flood, and UDP flood, in the
+    same relative drop precedence as `check_packet_with_zone_id` (LAND →
+    ping-of-death → teardrop → icmp-fragment → source-route → icmp-flood →
+    udp-flood). Flow/session-dependent screens (TCP-flag, SYN-flood
+    per-source/dest sketches, scan/sweep, SYN-cookie) stay on the flow-present
+    path — no double-run on the flow path, flow path untouched. LAND compares
+    `src_ip == dst_ip`, so `poll_stages.rs` now derives the REAL L3 addresses
+    from the IP header (`flowless_l3_addrs`) instead of the pre-#3902
+    unspecified placeholder (which would have made every flowless packet look
+    like `src == dst`); when the frame is too short to hold them, LAND is
+    skipped (`addrs_known == false`) rather than false-dropped. No L4 port
+    read / session lookup is added, so the #2344 flowless fast path is NOT
+    reintroduced.
+  - **Validation**: 8 new `check_flowless_screens` unit tests (LAND on
+    flowless ICMP + non-first fragment, addrs-unknown skip, source-route,
+    ICMP flood, UDP flood, teardrop regression guard, clean-pass). RED-on-
+    revert proven: neutering the source-independent checks to the pre-#3902
+    behavior fails the 6 source-independent drop tests while the fragment +
+    clean tests stay green. FULL `cargo test --release` green; `go build
+    ./...` green.
+  - **File(s)**: userspace-dp/src/screen/mod.rs,
+    userspace-dp/src/afxdp/poll_stages.rs, userspace-dp/src/screen/tests.rs,
+    userspace-dp/src/afxdp/README.md
+
 ## 2026-07-03 — #3882: WireGuard responder rekey promoted an UNCONFIRMED session straight to `current` (no `next` slot) — 3-slot keypair lifecycle fix
 
 - **Timestamp**: 2026-07-03

--- a/userspace-dp/src/afxdp/README.md
+++ b/userspace-dp/src/afxdp/README.md
@@ -205,23 +205,34 @@ sync.
   (`meta.ingress_vlan_present != 0`), not `vlan_id > 0` — 802.1p
   priority-tagged frames carry a real 802.1Q tag with VID 0, so a
   VID-based test would mis-read the IP header at offset 14 (#2145).
-  - **#3064 — L3 fragment screens on the flowless path:**
-    `stage_screen_check` now resolves the ingress zone BEFORE branching on
-    `flow`, and on the flowless branch (`flow == None`) it runs ONLY the
-    L3-header fragment screens — ping-of-death, teardrop, icmp-fragment
-    (`ScreenState::check_fragment_screens_l3`) — against the zone profile.
-    A non-first IP fragment is deliberately flowless (`#2344`:
-    `parse_session_flow_from_bytes` returns `None` so the fragment payload
-    is never parsed as L4 ports); before #3064 it short-circuited to `Pass`,
-    leaving those per-fragment screens DEAD in the live pipeline so hostile
-    Teardrop / Ping-of-Death contributions transited unscreened. The
-    flowless branch extracts a header-only `ScreenPacketInfo` straight from
-    the IP header with a PLACEHOLDER L4 tuple (it never reads ports or does
-    a session lookup), so the #2344 flowless fast path is NOT reintroduced.
-    Flow/session-dependent screens (land, TCP-flag, icmp/udp/syn-flood
-    counters, scan/sweep, SYN-cookie) stay gated on the flow-present path
-    and are unchanged. A truncated/unparseable header fails CLOSED (drop),
-    matching the flow path (`#2146`).
+  - **#3064 + #3902 — source-independent screens on the flowless path:**
+    `stage_screen_check` resolves the ingress zone BEFORE branching on
+    `flow`, and on the flowless branch (`flow == None`) it runs the
+    SOURCE-INDEPENDENT screens via `ScreenState::check_flowless_screens`
+    against the zone profile: LAND anti-spoof, the three L3-header fragment
+    screens (ping-of-death, teardrop, icmp-fragment), ip-source-route, and
+    the per-zone ICMP/UDP flood counters. A non-first IP fragment (`#2344`)
+    and a non-query ICMP/ICMPv6 control message (`#3290`) are deliberately
+    flowless (`parse_session_flow_from_bytes` returns `None` so the payload
+    is never parsed as an L4 tuple). #3064 first restored the three fragment
+    screens here (before it, the flowless branch short-circuited to `Pass`,
+    leaving them DEAD so hostile Teardrop / Ping-of-Death contributions
+    transited unscreened). #3902 closes the remaining gap: the flowless
+    branch ran ONLY those three fragment screens, so LAND / ip-source-route /
+    ICMP flood / UDP flood — which need NO transport flow — were BYPASSED on
+    the flowless path (screen fail-open). The branch now derives the REAL L3
+    source/destination addresses from the IP header (`flowless_l3_addrs`) so
+    LAND (`src_ip == dst_ip`) evaluates correctly instead of on the pre-#3902
+    unspecified placeholder (which would have looked like `src == dst` on
+    every flowless packet); if the frame is too short to hold the addresses,
+    LAND is skipped (`addrs_known == false`) rather than false-dropped. The
+    branch still never reads L4 ports or does a session lookup, so the #2344
+    flowless fast path is NOT reintroduced. Flow/session-dependent screens
+    (TCP-flag bits, the SYN-flood per-source/per-destination sketches,
+    scan/sweep, SYN-cookie) require a flow / real TCP header and stay gated
+    on the flow-present `check_packet_with_zone_id` path — unchanged, with no
+    screen double-run on the flow path. A truncated/unparseable header fails
+    CLOSED (drop), matching the flow path (`#2146`).
   - **#3291 — zone policy / input filter / PBR on the flowless TRANSIT
     arm:** #3064 restored only the *screen* engine on the flowless path;
     zone security policy, the interface input filter, and firewall-filter

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -427,19 +427,18 @@ pub(super) fn stage_screen_check(
     } else {
         14
     };
-    // #3064: a non-first IP fragment has no transport flow —
-    // `parse_session_flow_from_bytes` returns `None` for it (#2344, so the
-    // fragment payload is never parsed as L4 ports). Such a fragment used to
-    // return `Pass` here, which made the PER-FRAGMENT L3-header screens
-    // (ping-of-death, teardrop, icmp-fragment) DEAD in the live pipeline —
-    // hostile Teardrop / Ping-of-Death fragment contributions transited
-    // unscreened. Run ONLY the L3-header fragment screens on the flowless
-    // path: extract a header-only `ScreenPacketInfo` straight from the IP
-    // header (placeholder L4 tuple — we never parse the fragment payload, so
-    // the #2344 flowless fast path is NOT reintroduced) and evaluate the
-    // three L3 fragment screens. Flow/session-dependent screens (land,
-    // TCP-flag, flood counters, scan/sweep, SYN-cookie) stay on the
-    // flow-present path below.
+    // #3064 + #3902: a non-first IP fragment (or a non-query ICMP/ICMPv6
+    // control message) has no transport flow — `parse_session_flow_from_bytes`
+    // returns `None` for it (#2344, so the payload is never parsed as L4
+    // ports). Such a packet used to `Pass` here, which made the per-fragment
+    // L3-header screens (ping-of-death, teardrop, icmp-fragment) DEAD (#3064)
+    // AND — until #3902 — bypassed the SOURCE-INDEPENDENT screens (LAND,
+    // ip-source-route, ICMP/UDP flood) that need no flow. The flowless branch
+    // below now runs ALL of those (see the detailed #3902 note in the branch).
+    // Only the genuinely FLOW/session-dependent screens (TCP-flag, SYN-flood
+    // sketches, scan/sweep, SYN-cookie) stay on the flow-present path below —
+    // they require a real TCP header / per-flow tuple. The #2344 flowless fast
+    // path is NOT reintroduced (no L4 parse / session lookup happens here).
     let Some(flow) = flow else {
         // #3902: the flowless path (a non-first IP fragment or a non-query
         // ICMP/ICMPv6 control message) must still run the SOURCE-INDEPENDENT

--- a/userspace-dp/src/afxdp/poll_stages.rs
+++ b/userspace-dp/src/afxdp/poll_stages.rs
@@ -297,6 +297,60 @@ pub(super) fn stage_classify_fabric_ingress(
     }
 }
 
+/// #3902: read the real L3 source/destination addresses from the IP header
+/// for the flowless screen path. A non-first IP fragment or a non-query
+/// ICMP/ICMPv6 control message carries a full IP header, so its addresses are
+/// present even though the packet has no transport flow. Returns
+/// `(src, dst, true)` when the captured frame holds the full base header, or
+/// `(unspecified, unspecified, false)` when it is too short — the caller then
+/// skips the address-dependent LAND screen rather than false-dropping on
+/// `unspecified == unspecified`. The IPv6 base header (and thus its addresses)
+/// is already guaranteed present by `extract_screen_info`'s fail-closed
+/// `l3_off + 40 <= frame.len()` gate; the IPv4 base header is a fixed 20 bytes.
+fn flowless_l3_addrs(frame: &[u8], addr_family: u8, l3_off: usize) -> (IpAddr, IpAddr, bool) {
+    if addr_family == libc::AF_INET6 as u8 {
+        if l3_off + 40 <= frame.len()
+            && let (Ok(src), Ok(dst)) = (
+                <[u8; 16]>::try_from(&frame[l3_off + 8..l3_off + 24]),
+                <[u8; 16]>::try_from(&frame[l3_off + 24..l3_off + 40]),
+            )
+        {
+            return (
+                IpAddr::V6(Ipv6Addr::from(src)),
+                IpAddr::V6(Ipv6Addr::from(dst)),
+                true,
+            );
+        }
+        return (
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            IpAddr::V6(Ipv6Addr::UNSPECIFIED),
+            false,
+        );
+    }
+    // IPv4 (and any other family falls back to an unspecified V4 tuple, matching
+    // the pre-#3902 placeholder default).
+    if addr_family == libc::AF_INET as u8 && l3_off + 20 <= frame.len() {
+        let src = IpAddr::V4(Ipv4Addr::new(
+            frame[l3_off + 12],
+            frame[l3_off + 13],
+            frame[l3_off + 14],
+            frame[l3_off + 15],
+        ));
+        let dst = IpAddr::V4(Ipv4Addr::new(
+            frame[l3_off + 16],
+            frame[l3_off + 17],
+            frame[l3_off + 18],
+            frame[l3_off + 19],
+        ));
+        return (src, dst, true);
+    }
+    (
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+        false,
+    )
+}
+
 /// Stage 10 — screen / IDS slow-path check.
 ///
 /// Only runs when screen profiles are configured (the `has_profiles`
@@ -387,31 +441,29 @@ pub(super) fn stage_screen_check(
     // TCP-flag, flood counters, scan/sweep, SYN-cookie) stay on the
     // flow-present path below.
     let Some(flow) = flow else {
-        // Placeholder L4 tuple: the L3 fragment screens (ping-of-death /
-        // teardrop / icmp-fragment) never read src/dst IP or ports — they
-        // operate purely on fragment offset / total/payload length /
-        // protocol. tcp_flags is 0 because a non-first fragment carries no
-        // L4 header. Unspecified addresses keep the drop-event log sane
-        // without re-deriving the L3 addresses (out of scope for #3064).
-        let (placeholder_src, placeholder_dst) = if meta.addr_family == libc::AF_INET6 as u8 {
-            (
-                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-                IpAddr::V6(Ipv6Addr::UNSPECIFIED),
-            )
-        } else {
-            (
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-            )
-        };
+        // #3902: the flowless path (a non-first IP fragment or a non-query
+        // ICMP/ICMPv6 control message) must still run the SOURCE-INDEPENDENT
+        // screens — LAND anti-spoof, ip-source-route, ICMP/UDP flood — which
+        // need no transport flow. Before #3902 only the three L3 fragment
+        // screens ran here, so those source-independent screens were BYPASSED
+        // on the flowless path (screen fail-open). LAND compares src_ip ==
+        // dst_ip, so derive the REAL L3 addresses from the IP header (a
+        // fragment / ICMP control message carries a full IP header) rather
+        // than the pre-#3902 unspecified placeholder, which would have made
+        // every flowless packet look like a LAND spoof. tcp_flags is 0
+        // because a non-first fragment carries no L4 header; the fragment
+        // screens never read ports, so no session lookup / L4 parse happens
+        // and the #2344 flowless fast path is NOT reintroduced.
+        let (screen_src, screen_dst, addrs_known) =
+            flowless_l3_addrs(packet_frame, meta.addr_family, l3_off);
         let screen_pkt = match extract_screen_info(
             packet_frame,
             meta.addr_family,
             meta.protocol,
             0,
             meta.pkt_len,
-            placeholder_src,
-            placeholder_dst,
+            screen_src,
+            screen_dst,
             0,
             0,
             l3_off,
@@ -435,7 +487,7 @@ pub(super) fn stage_screen_check(
                 return StageOutcome::RecycleAndContinue;
             }
         };
-        return match screen.check_fragment_screens_l3(zone_name, &screen_pkt) {
+        return match screen.check_flowless_screens(zone_name, &screen_pkt, addrs_known, now_secs) {
             ScreenVerdict::Drop(reason) => {
                 emit_screen_drop_event(
                     worker_ctx.event_stream,
@@ -448,9 +500,9 @@ pub(super) fn stage_screen_check(
                 counters.record_screen_drop(reason);
                 StageOutcome::RecycleAndContinue
             }
-            // The L3 fragment screens only ever return Pass or Drop — they
-            // never mint a SYN-cookie challenge/bypass (those are
-            // flow/TCP-only and stay on the flow-present path).
+            // The flowless source-independent screens only ever return Pass
+            // or Drop — they never mint a SYN-cookie challenge/bypass (those
+            // are flow/TCP-only and stay on the flow-present path).
             _ => StageOutcome::Continue(ScreenCheckOutcome::Pass),
         };
     };

--- a/userspace-dp/src/screen/mod.rs
+++ b/userspace-dp/src/screen/mod.rs
@@ -775,36 +775,57 @@ impl ScreenState {
         }
     }
 
-    /// #3064: run ONLY the L3-header-based fragment screens
-    /// (ping-of-death, teardrop, icmp-fragment) for a packet that has NO
-    /// transport flow — i.e. a non-first IP fragment that
-    /// `parse_session_flow_from_bytes` deliberately leaves flowless
-    /// (#2344, to avoid treating fragment payload as L4 ports).
+    /// #3064 + #3902: run the SOURCE-INDEPENDENT screens for a packet that
+    /// has NO transport flow — a non-first IP fragment or a non-query
+    /// ICMP/ICMPv6 control message that `parse_session_flow_from_bytes`
+    /// deliberately leaves flowless (#2344, to avoid treating fragment
+    /// payload as L4 ports; #3290, to avoid keying a session on a non-port
+    /// ICMP control word). Every screen evaluated here is genuinely
+    /// flow/session-INDEPENDENT — it reads only the L3 header (and per-zone
+    /// rate counters keyed on protocol), never a per-flow tuple:
     ///
-    /// `stateless.rs` documents these three checks as PER-FRAGMENT, but
-    /// the live pipeline previously short-circuited every flowless packet
-    /// to `Pass` in `stage_screen_check`, so they were DEAD for non-first
-    /// fragments — hostile Teardrop / Ping-of-Death contributions transited
-    /// unscreened. The three checks read purely the IP-header fields already
-    /// captured in `ScreenPacketInfo` (fragment offset, total/payload
-    /// length, protocol) and never touch L4 ports or any per-flow/zone
-    /// counter state, so they are safe to evaluate without a `SessionFlow`
-    /// and WITHOUT reintroducing the transport classification #2344
-    /// removed.
+    ///   - **LAND anti-spoof** (`src_ip == dst_ip`): reads only the L3
+    ///     addresses. The caller derives the REAL source/destination from
+    ///     the IP header and sets `addrs_known`; when it could not (frame too
+    ///     short to hold the addresses) LAND is skipped so a placeholder
+    ///     `src == dst == unspecified` is not mistaken for a spoofed frame.
+    ///   - **ping-of-death / teardrop / icmp-fragment** (#3064): the L3
+    ///     fragment screens — fragment offset, total/payload length,
+    ///     protocol only.
+    ///   - **ip-source-route** (IPv4 LSRR/SSRR, IPv6 RH0/RH1): read from the
+    ///     IP-header options / extension-header chain by `extract.rs`.
+    ///   - **ICMP flood / UDP flood**: per-zone rate counters keyed purely
+    ///     on protocol.
     ///
-    /// Flow/session-dependent screens (land, TCP-flag, the
-    /// icmp/udp/syn-flood rate counters, scan/sweep, SYN-cookie) are
-    /// intentionally NOT run here — they require a flow and stay gated on
-    /// the flow-present `check_packet_with_zone_id` path. The drop
-    /// precedence of these three checks matches that method exactly.
-    pub(crate) fn check_fragment_screens_l3(
-        &self,
+    /// Before #3902 the flowless branch ran ONLY the three fragment screens,
+    /// so a crafted non-first fragment / non-query ICMP BYPASSED LAND,
+    /// ip-source-route, and the ICMP/UDP flood counters (screen fail-open) —
+    /// an attack the operator explicitly enabled the screen to block
+    /// transited on the flowless path.
+    ///
+    /// Flow/session-dependent screens (TCP-flag bits, the SYN-flood
+    /// per-source/per-destination sketches, scan/sweep, SYN-cookie) require
+    /// a flow / real TCP header and stay gated on the flow-present
+    /// `check_packet_with_zone_id` path. The drop precedence of the screens
+    /// run here matches that method's relative order exactly (LAND →
+    /// ping-of-death → teardrop → icmp-fragment → source-route → icmp-flood
+    /// → udp-flood).
+    pub(crate) fn check_flowless_screens(
+        &mut self,
         zone: &str,
         pkt: &ScreenPacketInfo,
+        addrs_known: bool,
+        now_secs: u64,
     ) -> ScreenVerdict {
         let Some(profile) = self.profiles.get(zone) else {
             return ScreenVerdict::Pass;
         };
+        // --- Stateless, source-independent checks (side-effect-free) ---
+        // LAND is address-dependent: only evaluate it when the caller
+        // supplied the real L3 addresses (`addrs_known`).
+        if addrs_known && let Some(reason) = stateless::check_land(profile, pkt) {
+            return ScreenVerdict::Drop(reason);
+        }
         if let Some(reason) = stateless::check_ping_of_death(profile, pkt) {
             return ScreenVerdict::Drop(reason);
         }
@@ -814,6 +835,35 @@ impl ScreenState {
         if let Some(reason) = stateless::check_icmp_fragment(profile, pkt) {
             return ScreenVerdict::Drop(reason);
         }
+        if let Some(reason) = stateless::check_source_route(profile, pkt) {
+            return ScreenVerdict::Drop(reason);
+        }
+        // --- Rate-based flood checks (source-independent, per-zone) ---
+        // Copy the scalar thresholds out so the immutable `self.profiles`
+        // borrow is released before the `&mut self` per-zone counter maps
+        // (mirrors `check_packet_with_zone_id`).
+        let icmp_flood_threshold = profile.icmp_flood_threshold;
+        let udp_flood_threshold = profile.udp_flood_threshold;
+        // `profile` borrow ends here (NLL): no further reads of `self.profiles`.
+
+        // ICMP flood
+        if icmp_flood_threshold > 0
+            && (pkt.protocol == PROTO_ICMP || pkt.protocol == PROTO_ICMPV6)
+            && let Some(counter) = self.icmp_counters.get_mut(zone)
+            && counter.increment(now_secs, icmp_flood_threshold)
+        {
+            return ScreenVerdict::Drop("icmp-flood");
+        }
+
+        // UDP flood
+        if udp_flood_threshold > 0
+            && pkt.protocol == PROTO_UDP
+            && let Some(counter) = self.udp_counters.get_mut(zone)
+            && counter.increment(now_secs, udp_flood_threshold)
+        {
+            return ScreenVerdict::Drop("udp-flood");
+        }
+
         ScreenVerdict::Pass
     }
 

--- a/userspace-dp/src/screen/tests.rs
+++ b/userspace-dp/src/screen/tests.rs
@@ -4149,3 +4149,236 @@ fn empty_missing_set_passes_without_warn() {
     assert_eq!(state.check_packet("trust", &pkt, 1), ScreenVerdict::Pass);
     assert_eq!(state.missing_profile_warn_count(), 0);
 }
+
+// ================================================================
+// #3902: source-independent screens on the FLOWLESS path
+// ================================================================
+//
+// A non-first IP fragment and a non-query ICMP/ICMPv6 control message are
+// deliberately flowless (#2344 / #3290 — the dataplane never derives an L4
+// tuple for them). Before #3902 the flowless branch ran ONLY the three L3
+// fragment screens (ping-of-death / teardrop / icmp-fragment), so the
+// SOURCE-INDEPENDENT screens — LAND anti-spoof, ip-source-route, ICMP flood,
+// UDP flood — were BYPASSED for those packets (screen fail-open).
+// `check_flowless_screens` now runs them. Each drop test below goes RED if
+// the fix is reverted: the pre-#3902 `check_fragment_screens_l3` never
+// evaluated LAND / source-route / the flood counters.
+
+/// A flowless non-query ICMP/ICMPv6 packet (no fragment, no L4 flow).
+fn flowless_icmp_pkt(src: IpAddr, dst: IpAddr) -> ScreenPacketInfo {
+    let (proto, af) = match src {
+        IpAddr::V4(_) => (PROTO_ICMP, libc::AF_INET as u8),
+        IpAddr::V6(_) => (PROTO_ICMPV6, libc::AF_INET6 as u8),
+    };
+    ScreenPacketInfo {
+        addr_family: af,
+        protocol: proto,
+        tcp_flags: 0,
+        src_ip: src,
+        dst_ip: dst,
+        src_port: 0,
+        dst_port: 0,
+        tcp_seq: 0,
+        tcp_ack: 0,
+        tcp_mss: 0,
+        pkt_len: 84,
+        is_fragment: false,
+        is_first_fragment: false,
+        ip_ihl: 5,
+        ip_frag_off: 0,
+        ip_total_len: 84,
+        ip_payload_len: 0,
+        frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
+    }
+}
+
+/// A flowless non-first IPv4 fragment carrying `protocol` (no L4 flow). The
+/// fragment offset field is 185 (→ 1480 bytes, non-first) with MF=0 (tail
+/// fragment); the total length keeps the payload well above the teardrop
+/// threshold and the reassembled end below the ping-of-death ceiling so those
+/// two fragment screens do NOT fire — the source-independent screens under
+/// test are the only ones that can drop.
+fn flowless_nonfirst_fragment(src: IpAddr, dst: IpAddr, protocol: u8) -> ScreenPacketInfo {
+    ScreenPacketInfo {
+        addr_family: libc::AF_INET as u8,
+        protocol,
+        tcp_flags: 0,
+        src_ip: src,
+        dst_ip: dst,
+        src_port: 0,
+        dst_port: 0,
+        tcp_seq: 0,
+        tcp_ack: 0,
+        tcp_mss: 0,
+        pkt_len: 1400,
+        is_fragment: true,
+        is_first_fragment: false,
+        ip_ihl: 5,
+        ip_frag_off: 185, // offset field 185 (→ 1480 bytes), non-first, MF=0
+        ip_total_len: 1400,
+        ip_payload_len: 0,
+        frag_data_off: 0,
+        saw_ipv4_source_route: false,
+        saw_ipv6_routing_header: false,
+    }
+}
+
+#[test]
+fn land_flowless_non_query_icmp_drops() {
+    // RED-on-revert: a crafted non-query ICMP whose src_ip == dst_ip is
+    // flowless (#3290) but LAND is source-independent and MUST drop it.
+    let mut profile = ScreenProfile::default();
+    profile.land = true;
+    let mut state = make_state("trust", profile);
+    let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let pkt = flowless_icmp_pkt(ip, ip);
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Drop("land-attack")
+    );
+}
+
+#[test]
+fn land_flowless_non_first_fragment_drops() {
+    // RED-on-revert: a non-first fragment whose src_ip == dst_ip must trip
+    // LAND on the flowless path.
+    let mut profile = ScreenProfile::default();
+    profile.land = true;
+    let mut state = make_state("trust", profile);
+    let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 5, 5));
+    let pkt = flowless_nonfirst_fragment(ip, ip, PROTO_UDP);
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Drop("land-attack")
+    );
+}
+
+#[test]
+fn land_flowless_addrs_unknown_skips() {
+    // When the caller could not derive the real L3 addresses (frame too
+    // short → addrs_known=false) LAND must be SKIPPED rather than fired on
+    // the unspecified==unspecified placeholder. The same tuple WITH
+    // addrs_known=true proves the guard is what suppresses it.
+    let mut profile = ScreenProfile::default();
+    profile.land = true;
+    let mut state = make_state("trust", profile);
+    let unspec = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+    let pkt = flowless_icmp_pkt(unspec, unspec);
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, false, 1),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Drop("land-attack")
+    );
+}
+
+#[test]
+fn source_route_flowless_non_first_fragment_drops() {
+    // RED-on-revert: ip-source-route is source-independent and must drop a
+    // flowless non-first fragment carrying an LSRR/SSRR option.
+    let mut profile = ScreenProfile::default();
+    profile.source_route = true;
+    let mut state = make_state("trust", profile);
+    let mut pkt = flowless_nonfirst_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_UDP,
+    );
+    pkt.saw_ipv4_source_route = true; // extractor decoded LSRR/SSRR
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Drop("ip-source-route")
+    );
+}
+
+#[test]
+fn icmp_flood_flowless_drops() {
+    // RED-on-revert: the per-zone ICMP flood counter is source-independent
+    // and must count flowless non-query ICMP packets.
+    let mut profile = ScreenProfile::default();
+    profile.icmp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let pkt = flowless_icmp_pkt(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Drop("icmp-flood")
+    );
+}
+
+#[test]
+fn udp_flood_flowless_non_first_fragment_drops() {
+    // RED-on-revert: the per-zone UDP flood counter is source-independent
+    // and must count flowless non-first UDP fragments.
+    let mut profile = ScreenProfile::default();
+    profile.udp_flood_threshold = 2;
+    let mut state = make_state("trust", profile);
+    let pkt = flowless_nonfirst_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_UDP,
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Pass
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 100),
+        ScreenVerdict::Drop("udp-flood")
+    );
+}
+
+#[test]
+fn teardrop_still_screened_on_flowless_path() {
+    // #3064 regression guard: the L3 fragment screens still fire on the
+    // flowless path through check_flowless_screens.
+    let mut profile = ScreenProfile::default();
+    profile.teardrop = true;
+    let mut state = make_state("trust", profile);
+    let mut pkt = flowless_nonfirst_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_UDP,
+    );
+    pkt.ip_frag_off = 0x0001; // offset field 1 (non-first)
+    pkt.ip_total_len = 24; // 20-byte header + 4-byte payload (< 8) → teardrop
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Drop("teardrop")
+    );
+}
+
+#[test]
+fn flowless_clean_non_first_fragment_passes() {
+    // A benign flowless non-first fragment (no screen tripped) must PASS —
+    // the fix must not over-drop. Uses the full default profile (LAND,
+    // source-route, all fragment screens enabled) with distinct src/dst.
+    let mut state = make_state("trust", default_profile());
+    let pkt = flowless_nonfirst_fragment(
+        IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1)),
+        IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1)),
+        PROTO_UDP,
+    );
+    assert_eq!(
+        state.check_flowless_screens("trust", &pkt, true, 1),
+        ScreenVerdict::Pass
+    );
+}


### PR DESCRIPTION
## Summary

Closes #3902 (fable-review-161 F-085, MEDIUM screen/IDS fail-open).

In the userspace dataplane screen stage (`stage_screen_check`), the
**flowless** branch (`flow == None` — a non-first IP fragment #2344, or a
non-query ICMP/ICMPv6 control message #3290) ran ONLY the three L3
fragment screens restored by #3064 (ping-of-death, teardrop,
icmp-fragment). It did **not** run the SOURCE-INDEPENDENT screens — LAND
anti-spoof, ip-source-route, and the per-zone ICMP/UDP flood counters —
even though those need no transport flow (they read only the L3 header /
a per-zone protocol-keyed rate counter). A crafted non-query ICMP or
non-first fragment therefore **bypassed** those screens (screen
fail-open).

## Fix

- Replace `ScreenState::check_fragment_screens_l3` (`&self`, 3 fragment
  screens) with `ScreenState::check_flowless_screens` (`&mut self`) which
  additionally runs **LAND**, **ip-source-route**, **ICMP flood**, and
  **UDP flood**, in the same relative drop precedence as the flow-present
  `check_packet_with_zone_id` (LAND → ping-of-death → teardrop →
  icmp-fragment → source-route → icmp-flood → udp-flood).
- **Flow/session-dependent** screens (TCP-flag bits, SYN-flood
  per-source/per-destination sketches, scan/sweep, SYN-cookie) stay gated
  on the flow-present path. The flow path is untouched — **no screen is
  double-run** and drop precedence there is unchanged.
- LAND compares `src_ip == dst_ip`, so the flowless branch now derives
  the **real** L3 addresses from the IP header (`flowless_l3_addrs`)
  instead of the pre-#3902 unspecified placeholder (which would have made
  every flowless packet look like `src == dst`). When the captured frame
  is too short to hold the addresses, LAND is skipped
  (`addrs_known == false`) rather than false-dropped. No L4 port read or
  session lookup is added, so the #2344 flowless fast path is **not**
  reintroduced; a truncated/unparseable header still fails CLOSED (#2146).

### Screen flow-dependency reasoning

| Screen | Flowless placement | Why |
|--------|--------------------|-----|
| LAND (`src==dst`) | flowless (needs real L3 addrs) | source-independent anti-spoof; addresses read from IP header, guarded by `addrs_known` |
| ip-source-route | flowless | reads IPv4 LSRR/SSRR options / IPv6 RH0/RH1 from the L3 header |
| ICMP flood / UDP flood | flowless | per-zone rate counter keyed only on protocol |
| ping-of-death / teardrop / icmp-fragment | flowless (already, #3064) | L3 fragment-offset / length / protocol only |
| TCP-flag, SYN-flood, scan/sweep, SYN-cookie | flow path only | require a real L4/TCP header or a per-flow tuple |

## Validation

- 8 new `check_flowless_screens` unit tests. **RED-on-revert proven**:
  neutering the method back to the pre-#3902 behavior fails the 6
  source-independent drop tests (LAND / source-route / ICMP-flood /
  UDP-flood → Pass instead of Drop) while the teardrop regression guard
  and clean-pass test stay green.
- FULL `cargo test --release` green (3451 passed / 0 failed in the binary
  suite, integration suites 0 failed).
- `go build ./...` green.
- Module doc `userspace-dp/src/afxdp/README.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
