### PR TITLE
config: fix four bracket-list multi-value truncations (IKE/IPsec proposals, RIP export/redistribute, routing-instance interface) — #3904

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29156,3 +29156,11 @@ top.
   value via `firewallMatchValues` into the already-plural RIPConfig slices.
 - **File(s)**: pkg/config/schema_routing.go, pkg/config/compiler_protocols.go,
   pkg/config/compiler_rip_multivalue_3904_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-07-03
+- **Action**: F-163 — routing-instance `interface [ i1 i2 ]` no longer keeps only
+  the first port (VRF isolation break). Compiler reads every interface via
+  `firewallMatchValues` into RoutingInstanceConfig.Interfaces (opaque implicit
+  leaf, no schema change needed).
+- **File(s)**: pkg/config/compiler_routing.go,
+  pkg/config/compiler_routing_instance_interface_3904_test.go, docs/config-schema.md

--- a/_Log.md
+++ b/_Log.md
@@ -29128,3 +29128,23 @@ top.
   pkg/config/freetext_test.go (RED-on-revert injection + reject +
   helper tests), pkg/configstore/store_test.go
   (TestAnnotateRejectsCommentDelimiter), docs/phases.md (#3900 note)
+
+## 2026-07-03 — #3904 multi-value bracket-list truncation bundle (F-040/F-161/F-162/F-163)
+
+- **Timestamp**: 2026-07-03
+- **Action**: F-040/F-161 — IKE/IPsec `proposals [ p1 p2 ]` no longer truncates
+  to the first reference. Schema leaves marked `multi: true`; `IKEPolicy.Proposals`
+  and `IPsecPolicyDef.Proposals` widened `string` → `[]string`; compiler reads all
+  via `firewallMatchValues`; strongSwan generator emits every resolvable proposal
+  comma-joined; strict validators require every reference to resolve; show/CLI
+  join the list.
+- **File(s)**: pkg/config/types_security.go, pkg/config/schema_security.go,
+  pkg/config/compiler_ipsec.go, pkg/config/compiler_validate_strict.go,
+  pkg/ipsec/ike.go, pkg/cli/cli_show_security_ipsec.go,
+  pkg/grpcapi/server_show_security_text.go,
+  pkg/config/compiler_ipsec_proposals_multivalue_3904_test.go,
+  pkg/ipsec/ike_proposals_multivalue_3904_test.go,
+  pkg/config/parser_security_test.go, pkg/config/ike_policy_chain_ref_test.go,
+  pkg/config/ipsec_proposal_ref_test.go, pkg/ipsec/ipsec_test.go,
+  pkg/ipsec/swanctl_render_test.go, pkg/ipsec/ike_chain_failclosed_test.go,
+  docs/config-schema.md

--- a/_Log.md
+++ b/_Log.md
@@ -29148,3 +29148,11 @@ top.
   pkg/config/ipsec_proposal_ref_test.go, pkg/ipsec/ipsec_test.go,
   pkg/ipsec/swanctl_render_test.go, pkg/ipsec/ike_chain_failclosed_test.go,
   docs/config-schema.md
+
+- **Timestamp**: 2026-07-03
+- **Action**: F-162 — RIP `redistribute`/group `export`/`neighbor`/
+  `passive-interface` bracket lists no longer truncate to the first entry.
+  Declared RIP list-leaves marked `multi: true`; RIP compiler block reads every
+  value via `firewallMatchValues` into the already-plural RIPConfig slices.
+- **File(s)**: pkg/config/schema_routing.go, pkg/config/compiler_protocols.go,
+  pkg/config/compiler_rip_multivalue_3904_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -251,6 +251,30 @@ validation:
   directions — tail-drop and typo-bypass — across bracket / repeated-line /
   hierarchical shapes, plus the value-slot completion pin).
 
+**IKE/IPsec proposals, RIP export/redistribute, and routing-instance interface
+are multi-value (#3904).** Four more leaves of the #2419/#3431/#3703
+bracket-list-truncation class (fable-161 F-040/F-161/F-162/F-163), all fixed by
+routing the compiler read through `firewallMatchValues` (Keys[1:] + child nodes,
+both AST shapes):
+
+- **IKE/IPsec policy `proposals`** (`schema_security.go`) — both leaves are now
+  `args: 1, multi: true`. `IKEPolicy.Proposals` and `IPsecPolicyDef.Proposals`
+  changed from a scalar `string` to `[]string`, and `compileIKE` /`compileIPsec`
+  (`compiler_ipsec.go`) accumulate EVERY reference. The strongSwan generator
+  (`pkg/ipsec/ike.go` `resolveIKESettings` / `resolveESPSettings`) builds each
+  resolvable proposal and comma-joins them into the swanctl `proposals =` /
+  `esp_proposals =` list (strongSwan negotiates the first mutually acceptable
+  one); the auth method + lifetime come from the first resolvable proposal, and
+  the policy-level PFS group applies to every ESP proposal. Before #3904 the
+  scalar kept only the FIRST reference, so `proposals [ p1 p2 ]` silently offered
+  only `p1` — crypto negotiation NARROWED and a peer requiring `p2` could not
+  establish. The strict commit validators (`compiler_validate_strict.go`) now
+  require EVERY reference in the list to resolve (a dangling trailing reference
+  is a typo the commit-check rejects, mirroring the NAT H05 gate). Coverage:
+  `compiler_ipsec_proposals_multivalue_3904_test.go` (both AST shapes + dangling-
+  second rejection) and `pkg/ipsec/ike_proposals_multivalue_3904_test.go` (both
+  proposals comma-joined into the rendered swanctl config, PFS applied to all).
+
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 
 Beyond the per-leaf token allowlist above, host-inbound admission has a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -274,6 +274,18 @@ both AST shapes):
   `compiler_ipsec_proposals_multivalue_3904_test.go` (both AST shapes + dangling-
   second rejection) and `pkg/ipsec/ike_proposals_multivalue_3904_test.go` (both
   proposals comma-joined into the rendered swanctl config, PFS applied to all).
+- **RIP `redistribute` / group `export` / `neighbor` / `passive-interface`**
+  (`schema_routing.go` — the declared top-level leaves are now `multi: true`; the
+  `group` block stays an opaque `children: nil` container, so its `export` /
+  `neighbor` bracket list already collapses onto Keys[1:]). The RIP block in
+  `compileProtocols` (`compiler_protocols.go`) reads every value via
+  `firewallMatchValues` into the already-plural `RIPConfig.Redistribute` /
+  `Interfaces` / `Passive` slices. Before #3904 each read only `child.Keys[1]`, so
+  `redistribute [ static connected ]` or `export [ pa pb ]` kept ONE entry — a
+  RIP node silently advertised / redistributed less than configured. The existing
+  RIP export strict validator (`compiler_validate_strict.go`) already walks the
+  full slice, so a dangling non-first export name is rejected at commit. Coverage:
+  `compiler_rip_multivalue_3904_test.go` (both AST shapes).
 
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -286,6 +286,16 @@ both AST shapes):
   RIP export strict validator (`compiler_validate_strict.go`) already walks the
   full slice, so a dangling non-first export name is rejected at commit. Coverage:
   `compiler_rip_multivalue_3904_test.go` (both AST shapes).
+- **routing-instance `interface`** (`compiler_routing.go`) — the
+  `interface [ i1 i2 ]` list is compiled through `firewallMatchValues` into the
+  already-plural `RoutingInstanceConfig.Interfaces`. `interface` is an OPAQUE
+  implicit leaf under the `routing-instances` wildcard (not a declared schema
+  child — like `instance-type`), so the flat-set bracket already collapses onto
+  Keys[1:] and no schema change is required. Before #3904 the read was
+  `nodeVal(prop)` (Keys[1] only), so `interface [ ge-0/0/1 ge-0/0/2 ]` bound only
+  the first port to the VRF and the rest stayed in the DEFAULT table — a VRF
+  isolation break. Coverage: `compiler_routing_instance_interface_3904_test.go`
+  (both AST shapes + single-value back-compat).
 
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 

--- a/pkg/cli/cli_show_security_ipsec.go
+++ b/pkg/cli/cli_show_security_ipsec.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 func (c *CLI) showIPsec(args []string) error {
@@ -217,7 +218,7 @@ func (c *CLI) showIKE(args []string) error {
 			fmt.Printf("  IKE policy:         %s\n", gw.IKEPolicy)
 			if pol, ok := cfg.Security.IPsec.IKEPolicies[gw.IKEPolicy]; ok {
 				fmt.Printf("    Mode:     %s\n", pol.Mode)
-				fmt.Printf("    Proposal: %s\n", pol.Proposals)
+				fmt.Printf("    Proposal: %s\n", strings.Join(pol.Proposals, " "))
 			}
 		}
 		ver := gw.Version

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -74,7 +74,12 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 			case "mode":
 				pol.Mode = v
 			case "proposals":
-				pol.Proposals = v
+				// Multi-value leaf (#3904): `proposals [ p1 p2 ]` collapses
+				// onto Keys[1:] (hierarchical / clean flat-set) and/or child
+				// nodes (declared-leaf flat-set split). Read EVERY reference
+				// via firewallMatchValues; reading only Keys[1] (nodeVal)
+				// dropped all but the first, narrowing phase-1 negotiation.
+				pol.Proposals = append(pol.Proposals, firewallMatchValues(p)...)
 			case "pre-shared-key":
 				// "pre-shared-key ascii-text VALUE" or children
 				if len(p.Keys) >= 3 {
@@ -261,10 +266,11 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 	for _, inst := range namedInstances(node.FindChildren("policy")) {
 		pol := &IPsecPolicyDef{Name: inst.name}
 		for _, p := range inst.node.Children {
-			v := nodeVal(p)
 			switch p.Name() {
 			case "proposals":
-				pol.Proposals = v
+				// Multi-value leaf (#3904): read EVERY ESP proposal reference
+				// (Keys[1:] + child nodes) — mirror of the IKE policy loop.
+				pol.Proposals = append(pol.Proposals, firewallMatchValues(p)...)
 			case "perfect-forward-secrecy":
 				for _, c := range p.Children {
 					if c.Name() == "keys" {

--- a/pkg/config/compiler_ipsec_proposals_multivalue_3904_test.go
+++ b/pkg/config/compiler_ipsec_proposals_multivalue_3904_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #3904 (fable-161 F-040/F-161): an IKE/IPsec policy `proposals [ p1 p2 ]`
+// bracket list used to compile to a single scalar reference — the compiler
+// read only nodeVal(p) (the first token) and IKEPolicy.Proposals /
+// IPsecPolicyDef.Proposals were plain strings. The schema now marks the
+// leaves multi: true (so the flat-set path keeps every reference) and the
+// compiler accumulates EVERY value via firewallMatchValues into the []string
+// fields, in BOTH the flat-set and hierarchical AST shapes (#2419).
+//
+// fail-on-revert: restoring the scalar read leaves the slice with one element
+// (or fails to compile), so the two-element assertions below go RED.
+
+func multiProposalsFlat(t *testing.T) *Config {
+	t.Helper()
+	tree := buildTree(t, []string{
+		"set security ike proposal ike-a authentication-method pre-shared-keys",
+		"set security ike proposal ike-a encryption-algorithm aes-256-cbc",
+		"set security ike proposal ike-b authentication-method pre-shared-keys",
+		"set security ike proposal ike-b encryption-algorithm aes-128-cbc",
+		"set security ike policy ike-pol proposals [ ike-a ike-b ]",
+		"set security ipsec proposal esp-a protocol esp",
+		"set security ipsec proposal esp-a encryption-algorithm aes-256-cbc",
+		"set security ipsec proposal esp-b protocol esp",
+		"set security ipsec proposal esp-b encryption-algorithm aes-128-cbc",
+		"set security ipsec policy esp-pol proposals [ esp-a esp-b ]",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (flat multi-proposal): %v", err)
+	}
+	return cfg
+}
+
+func TestIKEIPsecProposalsMultiValueFlat(t *testing.T) {
+	cfg := multiProposalsFlat(t)
+	ikePol := cfg.Security.IPsec.IKEPolicies["ike-pol"]
+	if ikePol == nil {
+		t.Fatal("ike-policy ike-pol missing after compile")
+	}
+	if got, want := ikePol.Proposals, []string{"ike-a", "ike-b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("IKE policy Proposals = %v, want %v (bracket list truncated)", got, want)
+	}
+	espPol := cfg.Security.IPsec.Policies["esp-pol"]
+	if espPol == nil {
+		t.Fatal("ipsec-policy esp-pol missing after compile")
+	}
+	if got, want := espPol.Proposals, []string{"esp-a", "esp-b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("IPsec policy Proposals = %v, want %v (bracket list truncated)", got, want)
+	}
+}
+
+func TestIKEIPsecProposalsMultiValueHierarchical(t *testing.T) {
+	tree := mustParse(t, `security {
+    ike {
+        proposal ike-a {
+            authentication-method pre-shared-keys;
+            encryption-algorithm aes-256-cbc;
+        }
+        proposal ike-b {
+            authentication-method pre-shared-keys;
+            encryption-algorithm aes-128-cbc;
+        }
+        policy ike-pol {
+            proposals [ ike-a ike-b ];
+        }
+    }
+    ipsec {
+        proposal esp-a {
+            protocol esp;
+            encryption-algorithm aes-256-cbc;
+        }
+        proposal esp-b {
+            protocol esp;
+            encryption-algorithm aes-128-cbc;
+        }
+        policy esp-pol {
+            proposals [ esp-a esp-b ];
+        }
+    }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (hierarchical multi-proposal): %v", err)
+	}
+	if got, want := cfg.Security.IPsec.IKEPolicies["ike-pol"].Proposals, []string{"ike-a", "ike-b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("hierarchical IKE Proposals = %v, want %v", got, want)
+	}
+	if got, want := cfg.Security.IPsec.Policies["esp-pol"].Proposals, []string{"esp-a", "esp-b"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("hierarchical IPsec Proposals = %v, want %v", got, want)
+	}
+}
+
+// TestIPsecPolicyProposalsDanglingSecondRejected pins the strict-commit gate:
+// a bracket list whose SECOND reference dangles must be rejected at commit
+// (mirror the NAT bracket-list H05 precedent). Pre-#3904 the truncation hid
+// the second reference entirely, so a typo committed silently.
+func TestIPsecPolicyProposalsDanglingSecondRejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security ipsec proposal esp-a protocol esp",
+		"set security ipsec proposal esp-a encryption-algorithm aes-256-cbc",
+		"set security ipsec policy esp-pol proposals [ esp-a esp-typo ]",
+		"set security ike proposal ike-a authentication-method pre-shared-keys",
+		"set security ike policy ike-pol proposals ike-a",
+		"set security ike gateway gw1 address 172.16.0.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ipsec vpn tun1 ike gateway gw1",
+		"set security ipsec vpn tun1 ike ipsec-policy esp-pol",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("an ipsec policy proposals list with a dangling second reference must be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "esp-typo") {
+		t.Errorf("error should name the dangling reference esp-typo, got: %v", err)
+	}
+}
+
+// TestIKEPolicyProposalsDanglingSecondRejected is the phase-1 mirror: a
+// dangling SECOND ike-proposal reference must be rejected at commit.
+func TestIKEPolicyProposalsDanglingSecondRejected(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set security zones security-zone untrust",
+		"set security ike proposal ike-a authentication-method pre-shared-keys",
+		"set security ike policy ike-pol proposals [ ike-a ike-typo ]",
+		"set security ike gateway gw1 address 172.16.0.1",
+		"set security ike gateway gw1 ike-policy ike-pol",
+		"set security ipsec proposal esp-a protocol esp",
+		"set security ipsec proposal esp-a encryption-algorithm aes-256-cbc",
+		"set security ipsec policy esp-pol proposals esp-a",
+		"set security ipsec vpn tun1 ike gateway gw1",
+		"set security ipsec vpn tun1 ike ipsec-policy esp-pol",
+	})
+	_, err := CompileConfig(tree)
+	if err == nil {
+		t.Fatal("an ike policy proposals list with a dangling second reference must be rejected at commit")
+	}
+	if !strings.Contains(err.Error(), "ike-typo") {
+		t.Errorf("error should name the dangling reference ike-typo, got: %v", err)
+	}
+}

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -577,29 +577,26 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 			switch child.Name() {
 			case "group":
 				for _, gc := range child.Children {
+					// Multi-value leaves (#3904): a bracket list collapses onto
+					// Keys[1:] (opaque group) or child nodes; read EVERY value
+					// via firewallMatchValues. The pre-#3904 Keys[1]-only read
+					// truncated `export [ a b ]` / `neighbor [ i1 i2 ]` to the
+					// first entry.
 					switch gc.Name() {
 					case "neighbor":
-						if len(gc.Keys) >= 2 {
-							proto.RIP.Interfaces = append(proto.RIP.Interfaces, gc.Keys[1])
-						}
+						proto.RIP.Interfaces = append(proto.RIP.Interfaces, firewallMatchValues(gc)...)
 					case "export":
-						if len(gc.Keys) >= 2 {
-							proto.RIP.Redistribute = append(proto.RIP.Redistribute, gc.Keys[1])
-						}
+						proto.RIP.Redistribute = append(proto.RIP.Redistribute, firewallMatchValues(gc)...)
 					}
 				}
 			case "neighbor":
-				if len(child.Keys) >= 2 {
-					proto.RIP.Interfaces = append(proto.RIP.Interfaces, child.Keys[1])
-				}
+				// Multi-value leaf (#3904): read EVERY neighbor via
+				// firewallMatchValues (Keys[1:] + child nodes).
+				proto.RIP.Interfaces = append(proto.RIP.Interfaces, firewallMatchValues(child)...)
 			case "passive-interface":
-				if len(child.Keys) >= 2 {
-					proto.RIP.Passive = append(proto.RIP.Passive, child.Keys[1])
-				}
+				proto.RIP.Passive = append(proto.RIP.Passive, firewallMatchValues(child)...)
 			case "redistribute":
-				if len(child.Keys) >= 2 {
-					proto.RIP.Redistribute = append(proto.RIP.Redistribute, child.Keys[1])
-				}
+				proto.RIP.Redistribute = append(proto.RIP.Redistribute, firewallMatchValues(child)...)
 			case "authentication-key":
 				if v := nodeVal(child); v != "" {
 					proto.RIP.AuthKey = Secret(v)

--- a/pkg/config/compiler_rip_multivalue_3904_test.go
+++ b/pkg/config/compiler_rip_multivalue_3904_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #3904 (fable-161 F-162): RIP `redistribute [ a b ]`, group `export [ a b ]`,
+// and `neighbor [ i1 i2 ]` bracket lists used to truncate to the FIRST value —
+// the compiler read only child.Keys[1]. The schema now marks the declared RIP
+// list-leaves multi: true and the compiler accumulates EVERY value via
+// firewallMatchValues (Keys[1:] + child nodes), in both AST shapes (#2419).
+//
+// fail-on-revert: restoring the `child.Keys[1]`-only read leaves each slice
+// with one element, so the two-element assertions go RED.
+
+func TestRIPMultiValueFlat(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set policy-options policy-statement pa term t1 then accept",
+		"set policy-options policy-statement pb term t1 then accept",
+		"set protocols rip redistribute [ static connected ]",
+		"set protocols rip neighbor [ ge-0/0/1 ge-0/0/2 ]",
+		"set protocols rip passive-interface [ ge-0/0/3 ge-0/0/4 ]",
+		"set protocols rip group g1 export [ pa pb ]",
+		"set protocols rip group g1 neighbor [ ge-0/0/5 ge-0/0/6 ]",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (flat RIP multi-value): %v", err)
+	}
+	rip := cfg.Protocols.RIP
+	if rip == nil {
+		t.Fatal("RIP config missing after compile")
+	}
+	// redistribute [static connected] + group export [pa pb] both feed
+	// RIP.Redistribute.
+	if got, want := rip.Redistribute, []string{"static", "connected", "pa", "pb"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("RIP.Redistribute = %v, want %v (bracket list truncated)", got, want)
+	}
+	// neighbor [ge-0/0/1 ge-0/0/2] + group neighbor [ge-0/0/5 ge-0/0/6] both
+	// feed RIP.Interfaces.
+	if got, want := rip.Interfaces, []string{"ge-0/0/1", "ge-0/0/2", "ge-0/0/5", "ge-0/0/6"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("RIP.Interfaces = %v, want %v (bracket list truncated)", got, want)
+	}
+	if got, want := rip.Passive, []string{"ge-0/0/3", "ge-0/0/4"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("RIP.Passive = %v, want %v (bracket list truncated)", got, want)
+	}
+}
+
+func TestRIPMultiValueHierarchical(t *testing.T) {
+	tree := mustParse(t, `policy-options {
+    policy-statement pa {
+        term t1 {
+            then accept;
+        }
+    }
+    policy-statement pb {
+        term t1 {
+            then accept;
+        }
+    }
+}
+protocols {
+    rip {
+        redistribute [ static connected ];
+        neighbor [ ge-0/0/1 ge-0/0/2 ];
+        group g1 {
+            export [ pa pb ];
+        }
+    }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (hierarchical RIP multi-value): %v", err)
+	}
+	rip := cfg.Protocols.RIP
+	if rip == nil {
+		t.Fatal("RIP config missing after compile")
+	}
+	if got, want := rip.Redistribute, []string{"static", "connected", "pa", "pb"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("hierarchical RIP.Redistribute = %v, want %v", got, want)
+	}
+	if got, want := rip.Interfaces, []string{"ge-0/0/1", "ge-0/0/2"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("hierarchical RIP.Interfaces = %v, want %v", got, want)
+	}
+}

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -384,9 +384,14 @@ func compileRoutingInstances(node *Node, cfg *Config) error {
 			case "instance-type":
 				ri.InstanceType = nodeVal(prop)
 			case "interface":
-				if v := nodeVal(prop); v != "" {
-					ri.Interfaces = append(ri.Interfaces, v)
-				}
+				// Multi-value leaf (#3904): `interface [ i1 i2 ]` collapses
+				// onto Keys[1:] (this is an opaque implicit leaf) and/or child
+				// nodes in both AST shapes. Read EVERY interface via
+				// firewallMatchValues; the prior nodeVal(prop) read kept only
+				// the first, stranding the remaining ports OUTSIDE the routing-
+				// instance (they stayed in the default table — a VRF isolation
+				// break).
+				ri.Interfaces = append(ri.Interfaces, firewallMatchValues(prop)...)
 			case "routing-options":
 				var ro RoutingOptionsConfig
 				if err := compileRoutingOptions(prop, &ro); err != nil {

--- a/pkg/config/compiler_routing_instance_interface_3904_test.go
+++ b/pkg/config/compiler_routing_instance_interface_3904_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #3904 (fable-161 F-163): a routing-instance `interface [ i1 i2 ]` bracket
+// list kept only the FIRST interface — the compiler read nodeVal(prop)
+// (Keys[1]). The remaining ports stayed OUTSIDE the routing-instance (in the
+// default table), a VRF isolation break. The compiler now reads EVERY value
+// via firewallMatchValues (Keys[1:] + child nodes) into the already-plural
+// RoutingInstanceConfig.Interfaces slice, in both AST shapes (#2419). The
+// `interface` leaf is an opaque implicit leaf under the routing-instances
+// wildcard, so the flat-set bracket already collapses onto Keys[1:] — no
+// schema change is needed.
+//
+// fail-on-revert: restoring the nodeVal-only read leaves Interfaces with one
+// element, so the two-element assertions go RED.
+
+func riByName(t *testing.T, cfg *Config, name string) *RoutingInstanceConfig {
+	t.Helper()
+	for _, ri := range cfg.RoutingInstances {
+		if ri.Name == name {
+			return ri
+		}
+	}
+	t.Fatalf("routing-instance %q missing after compile", name)
+	return nil
+}
+
+func TestRoutingInstanceInterfaceMultiValueFlat(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances VR1 instance-type virtual-router",
+		"set routing-instances VR1 interface [ ge-0/0/1 ge-0/0/2 ge-0/0/3 ]",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (flat routing-instance interface): %v", err)
+	}
+	ri := riByName(t, cfg, "VR1")
+	if got, want := ri.Interfaces, []string{"ge-0/0/1", "ge-0/0/2", "ge-0/0/3"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("VR1.Interfaces = %v, want %v (bracket list truncated — VRF isolation break)", got, want)
+	}
+}
+
+func TestRoutingInstanceInterfaceMultiValueHierarchical(t *testing.T) {
+	tree := mustParse(t, `routing-instances {
+    VR1 {
+        instance-type virtual-router;
+        interface [ ge-0/0/1 ge-0/0/2 ge-0/0/3 ];
+    }
+}`)
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (hierarchical routing-instance interface): %v", err)
+	}
+	ri := riByName(t, cfg, "VR1")
+	if got, want := ri.Interfaces, []string{"ge-0/0/1", "ge-0/0/2", "ge-0/0/3"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("hierarchical VR1.Interfaces = %v, want %v", got, want)
+	}
+}
+
+// TestRoutingInstanceInterfaceSingleValue pins that the single-interface form
+// (and repeated single-interface lines) still works.
+func TestRoutingInstanceInterfaceSingleValue(t *testing.T) {
+	tree := buildTree(t, []string{
+		"set routing-instances VR1 instance-type virtual-router",
+		"set routing-instances VR1 interface ge-0/0/1",
+		"set routing-instances VR1 interface ge-0/0/2",
+	})
+	cfg, err := CompileConfig(tree)
+	if err != nil {
+		t.Fatalf("CompileConfig (single-value routing-instance interface): %v", err)
+	}
+	ri := riByName(t, cfg, "VR1")
+	if got, want := ri.Interfaces, []string{"ge-0/0/1", "ge-0/0/2"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("VR1.Interfaces = %v, want %v", got, want)
+	}
+}

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -210,30 +210,36 @@ func validateIPsecPolicyProposalReferencesStrict(cfg *Config) error {
 		if pol == nil {
 			continue
 		}
-		propRef := pol.Proposals
-		explicitRef := propRef != ""
+		// #3904: `proposals` is now a list — EVERY referenced proposal must
+		// resolve (mirror the NAT bracket-list strict gate: a dangling
+		// trailing reference is an operator typo the commit-check must catch,
+		// not silently ignore as the pre-#3904 truncation did).
+		propRefs := pol.Proposals
+		explicitRef := len(propRefs) > 0
 		if !explicitRef {
 			// Mirror resolveESPSettings' policy-name fallback: a policy
 			// with no `proposals` leaf resolves against a proposal named
 			// after the policy itself.
-			propRef = pol.Name
+			propRefs = []string{pol.Name}
 		}
-		if _, ok := proposals[propRef]; ok {
-			continue
+		for _, propRef := range propRefs {
+			if _, ok := proposals[propRef]; ok {
+				continue
+			}
+			if explicitRef {
+				return fmt.Errorf("ipsec policy %q references undefined ipsec proposal %q "+
+					"(the configured proposal set, including any perfect-forward-secrecy "+
+					"group, would be silently dropped to the strongSwan default)",
+					pol.Name, propRef)
+			}
+			// No explicit `proposals` leaf was given, so do not blame a
+			// phantom proposal named after the policy — describe the actual
+			// gap instead.
+			return fmt.Errorf("ipsec policy %q has no resolvable ipsec proposal "+
+				"(no `proposals` reference and no proposal named %q); the configured "+
+				"perfect-forward-secrecy group would be silently dropped — define a "+
+				"proposal or reference one", pol.Name, pol.Name)
 		}
-		if explicitRef {
-			return fmt.Errorf("ipsec policy %q references undefined ipsec proposal %q "+
-				"(the configured proposal set, including any perfect-forward-secrecy "+
-				"group, would be silently dropped to the strongSwan default)",
-				pol.Name, propRef)
-		}
-		// No explicit `proposals` leaf was given, so do not blame a
-		// phantom proposal named after the policy — describe the actual
-		// gap instead.
-		return fmt.Errorf("ipsec policy %q has no resolvable ipsec proposal "+
-			"(no `proposals` reference and no proposal named %q); the configured "+
-			"perfect-forward-secrecy group would be silently dropped — define a "+
-			"proposal or reference one", pol.Name, pol.Name)
 	}
 	return nil
 }
@@ -303,8 +309,21 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 	// name).
 	chainResolves := func(ikePolicyName string) bool {
 		if pol, ok := ikePolicies[ikePolicyName]; ok && pol != nil {
-			if _, ok := ikeProposals[pol.Proposals]; ok {
-				return true
+			// #3904: `proposals` is a list — the chain resolves only when
+			// EVERY referenced ike-proposal is defined. A partially-dangling
+			// list is an operator typo the commit-check must catch (the
+			// pre-#3904 scalar checked only the first reference).
+			if len(pol.Proposals) > 0 {
+				allResolve := true
+				for _, ref := range pol.Proposals {
+					if _, ok := ikeProposals[ref]; !ok {
+						allResolve = false
+						break
+					}
+				}
+				if allResolve {
+					return true
+				}
 			}
 		}
 		// Legacy fallback: a gateway's ike-policy value naming an IPsec
@@ -357,23 +376,33 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 				gw.Name, vpnName, gw.IKEPolicy)
 		}
 		pol := ikePolicies[gw.IKEPolicy]
-		if pol.Proposals == "" {
-			// The ike-policy exists but has no `proposals` leaf at all, so
-			// pol.Proposals is the empty string. Reporting an "undefined
-			// ike-proposal \"\"" misleads the operator into hunting for a
-			// proposal named "" — say plainly that the policy is missing its
-			// proposals configuration.
+		if len(pol.Proposals) == 0 {
+			// The ike-policy exists but has no `proposals` leaf at all.
+			// Reporting an "undefined ike-proposal \"\"" misleads the operator
+			// into hunting for a proposal named "" — say plainly that the
+			// policy is missing its proposals configuration.
 			return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
 				"has no proposals configured; phase-1 would silently negotiate "+
 				"with the strongSwan default proposal set instead of the "+
 				"configured crypto",
 				gw.IKEPolicy, gw.Name, vpnName)
 		}
+		// #3904: name the FIRST dangling reference in the list (chainResolves
+		// was false, so at least one reference does not resolve).
+		for _, ref := range pol.Proposals {
+			if _, ok := ikeProposals[ref]; !ok {
+				return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
+					"references undefined ike-proposal %q; phase-1 would silently "+
+					"negotiate with the strongSwan default proposal set instead of "+
+					"the configured crypto",
+					gw.IKEPolicy, gw.Name, vpnName, ref)
+			}
+		}
 		return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
-			"references undefined ike-proposal %q; phase-1 would silently "+
+			"references undefined ike-proposal(s) %q; phase-1 would silently "+
 			"negotiate with the strongSwan default proposal set instead of "+
 			"the configured crypto",
-			gw.IKEPolicy, gw.Name, vpnName, pol.Proposals)
+			gw.IKEPolicy, gw.Name, vpnName, strings.Join(pol.Proposals, " "))
 	}
 	return nil
 }

--- a/pkg/config/ike_policy_chain_ref_test.go
+++ b/pkg/config/ike_policy_chain_ref_test.go
@@ -123,7 +123,7 @@ func TestIKEPolicyResolvableChainAccepted(t *testing.T) {
 		t.Fatalf("CompileConfig rejected a fully resolvable IKE chain: %v", err)
 	}
 	pol := cfg.Security.IPsec.IKEPolicies["ike-pol"]
-	if pol == nil || pol.Proposals != "ike-aes256" {
+	if pol == nil || len(pol.Proposals) != 1 || pol.Proposals[0] != "ike-aes256" {
 		t.Fatalf("ike-policy ike-pol not compiled with proposals=ike-aes256: %+v", pol)
 	}
 	if _, ok := cfg.Security.IPsec.IKEProposals["ike-aes256"]; !ok {

--- a/pkg/config/ipsec_proposal_ref_test.go
+++ b/pkg/config/ipsec_proposal_ref_test.go
@@ -94,7 +94,7 @@ func TestIPsecPolicyResolvableProposalAccepted(t *testing.T) {
 	if pol.PFSGroup != 14 {
 		t.Errorf("PFSGroup = %d, want 14", pol.PFSGroup)
 	}
-	if pol.Proposals != "esp-p2" {
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "esp-p2" {
 		t.Errorf("Proposals = %q, want esp-p2", pol.Proposals)
 	}
 }

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1786,7 +1786,7 @@ func TestIKEAdvancedFeatures(t *testing.T) {
 	if ikePol.Mode != "main" {
 		t.Errorf("IKE policy mode = %q", ikePol.Mode)
 	}
-	if ikePol.Proposals != "ike-phase1" {
+	if len(ikePol.Proposals) != 1 || ikePol.Proposals[0] != "ike-phase1" {
 		t.Errorf("IKE policy proposals = %q", ikePol.Proposals)
 	}
 	if ikePol.PSK != "secret123" {
@@ -1831,7 +1831,7 @@ func TestIKEAdvancedFeatures(t *testing.T) {
 	if ipsecPol.PFSGroup != 14 {
 		t.Errorf("IPsec policy PFS group = %d, want 14", ipsecPol.PFSGroup)
 	}
-	if ipsecPol.Proposals != "esp-phase2" {
+	if len(ipsecPol.Proposals) != 1 || ipsecPol.Proposals[0] != "esp-phase2" {
 		t.Errorf("IPsec policy proposals = %q", ipsecPol.Proposals)
 	}
 	vpn := cfg.Security.IPsec.VPNs["site-a"]
@@ -2609,7 +2609,7 @@ func TestIKEProposalSetSyntax(t *testing.T) {
 	if pol.Mode != "main" {
 		t.Errorf("mode = %q, want main", pol.Mode)
 	}
-	if pol.Proposals != "ike-aes256" {
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "ike-aes256" {
 		t.Errorf("proposals = %q, want ike-aes256", pol.Proposals)
 	}
 	gw := cfg.Security.IPsec.Gateways["remote-gw"]
@@ -2660,7 +2660,7 @@ func TestIPsecProposalSetSyntax(t *testing.T) {
 	if pol == nil {
 		t.Fatal("missing IPsec policy ipsec-strong")
 	}
-	if pol.Proposals != "esp-aes256" {
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "esp-aes256" {
 		t.Errorf("proposals = %q, want esp-aes256", pol.Proposals)
 	}
 }

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -382,10 +382,16 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		}},
 	}},
 	"rip": {desc: "RIP configuration", children: map[string]*schemaNode{
-		"group":               {desc: "Group", args: 1, placeholder: "<group-name>", children: nil},
-		"neighbor":            {desc: "Neighbor", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
-		"passive-interface":   {desc: "Passive interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
-		"redistribute":        {desc: "Redistribute", args: 1, placeholder: "<protocol>", children: nil},
+		"group": {desc: "Group", args: 1, placeholder: "<group-name>", children: nil},
+		// multi (#3904): `neighbor`/`passive-interface`/`redistribute
+		// [ a b ]` bracket lists collapse onto the leaf's Keys[1:] instead
+		// of stranding every entry past the first as a child node. The
+		// compiler (compiler_protocols.go RIP block) reads every value via
+		// firewallMatchValues; the pre-#3904 Keys[1]-only read truncated to
+		// the first entry.
+		"neighbor":            {desc: "Neighbor", args: 1, multi: true, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
+		"passive-interface":   {desc: "Passive interface", args: 1, multi: true, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
+		"redistribute":        {desc: "Redistribute", args: 1, multi: true, placeholder: "<protocol>", children: nil},
 		"authentication-key":  {desc: "Authentication key", args: 1, placeholder: "<key>", children: nil},
 		"authentication-type": {desc: "Authentication type", args: 1, placeholder: "<type>", children: nil},
 	}},

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -740,7 +740,11 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueType: ValueEnumOf, valueDesc: "IKE phase 1 negotiation mode",
 				valueExamples: []string{"main", "aggressive"},
 				validator:     ValidateEnum([]string{"main", "aggressive"}), children: nil},
-			"proposals":      {desc: "IKE proposal reference", args: 1, placeholder: "<proposal-name>", children: nil},
+			// multi (#3904): `proposals [ p1 p2 ]` offers every listed IKE
+			// proposal for phase-1 negotiation. Without multi the flat-set
+			// path strands every reference past the first as a child node and
+			// the compiler dropped them (crypto-negotiation narrowing).
+			"proposals":      {desc: "IKE proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
 			"pre-shared-key": {desc: "Pre-shared key (ascii-text <key>)", children: nil},
 		}},
 		"gateway": {desc: "IKE gateway (VPN peer) name", args: 1, placeholder: "<gateway-name>", children: map[string]*schemaNode{
@@ -803,7 +807,9 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		}},
 		"policy": {desc: "IPsec policy name", args: 1, placeholder: "<policy-name>", children: map[string]*schemaNode{
 			"perfect-forward-secrecy": {desc: "Perfect forward secrecy (keys group<N>)", children: nil},
-			"proposals":               {desc: "IPsec proposal reference", args: 1, placeholder: "<proposal-name>", children: nil},
+			// multi (#3904): mirror of the IKE proposals leaf — offer every
+			// listed ESP proposal for phase-2 negotiation.
+			"proposals": {desc: "IPsec proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
 		}},
 		"gateway": {desc: "IKE gateway (VPN peer) name", args: 1, placeholder: "<gateway-name>", children: map[string]*schemaNode{
 			"address":            {desc: "Remote gateway address", args: 1, placeholder: "<address>", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -971,9 +971,14 @@ type IKEProposal struct {
 
 // IKEPolicy defines Phase 1 policy (mode, proposal reference, PSK).
 type IKEPolicy struct {
-	Name      string
-	Mode      string // "main" or "aggressive"
-	Proposals string // IKE proposal reference
+	Name string
+	Mode string // "main" or "aggressive"
+	// Proposals is the ordered list of IKE proposal references. Junos
+	// `proposals [ p1 p2 ]` offers every listed proposal for phase-1
+	// negotiation; reading only the first (the pre-#3904 scalar) narrowed
+	// crypto negotiation so a peer requiring the second proposal could not
+	// establish. Rendered comma-joined into the swanctl `proposals =` line.
+	Proposals []string
 	PSK       Secret // pre-shared key; redacted on JSON/YAML marshal (#2053)
 }
 
@@ -989,9 +994,13 @@ type IPsecProposal struct {
 
 // IPsecPolicyDef defines Phase 2 policy (PFS + proposal reference).
 type IPsecPolicyDef struct {
-	Name      string
-	PFSGroup  int    // PFS DH group number (0 = disabled)
-	Proposals string // IPsec proposal reference
+	Name     string
+	PFSGroup int // PFS DH group number (0 = disabled)
+	// Proposals is the ordered list of IPsec (ESP) proposal references.
+	// Junos `proposals [ p1 p2 ]` offers every listed proposal; the
+	// pre-#3904 scalar truncated to the first, narrowing negotiation.
+	// Rendered comma-joined into the swanctl `esp_proposals =` line.
+	Proposals []string
 }
 
 // IPsecGateway defines a remote IKE gateway.

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -940,7 +940,7 @@ func (s *Server) showIKE(cfg *config.Config, buf *strings.Builder) {
 				fmt.Fprintf(buf, "  IKE policy:         %s\n", gw.IKEPolicy)
 				if pol, ok := cfg.Security.IPsec.IKEPolicies[gw.IKEPolicy]; ok {
 					fmt.Fprintf(buf, "    Mode:     %s\n", pol.Mode)
-					fmt.Fprintf(buf, "    Proposal: %s\n", pol.Proposals)
+					fmt.Fprintf(buf, "    Proposal: %s\n", strings.Join(pol.Proposals, " "))
 				}
 			}
 			ver := gw.Version

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -54,12 +54,32 @@ func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authM
 
 	if ikePol, ok := cfg.IKEPolicies[gw.IKEPolicy]; ok {
 		aggressive = ikePol.Mode == "aggressive"
-		if ikeProp, ok := cfg.IKEProposals[ikePol.Proposals]; ok {
-			authMethod, err = authMethodToSwan(ikeProp.AuthMethod)
-			if err != nil {
-				return "", "", 0, false, err
+		// #3904: `proposals [ p1 p2 ]` offers every listed IKE proposal.
+		// Build each resolvable reference and comma-join into one swanctl
+		// `proposals =` list (strongSwan negotiates the first mutually
+		// acceptable one). The auth method and lifetime are connection-level,
+		// taken from the first resolvable proposal to preserve single-proposal
+		// behaviour exactly.
+		var built []string
+		var firstLifetime int
+		authResolved := false
+		for _, ref := range ikePol.Proposals {
+			ikeProp, ok := cfg.IKEProposals[ref]
+			if !ok {
+				continue
 			}
-			return authMethod, buildIKEProposalFromIKE(ikeProp), ikeProp.LifetimeSeconds, aggressive, nil
+			if !authResolved {
+				authMethod, err = authMethodToSwan(ikeProp.AuthMethod)
+				if err != nil {
+					return "", "", 0, false, err
+				}
+				firstLifetime = ikeProp.LifetimeSeconds
+				authResolved = true
+			}
+			built = append(built, buildIKEProposalFromIKE(ikeProp))
+		}
+		if len(built) > 0 {
+			return authMethod, strings.Join(built, ","), firstLifetime, aggressive, nil
 		}
 	}
 
@@ -83,12 +103,26 @@ func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, 
 	if vpn.IPsecPolicy != "" {
 		if ipsecPol, ok := cfg.Policies[vpn.IPsecPolicy]; ok {
 			pfsGroup = ipsecPol.PFSGroup
-			propRef := ipsecPol.Proposals
-			if propRef == "" {
-				propRef = vpn.IPsecPolicy
+			// #3904: `proposals [ p1 p2 ]` offers every listed ESP proposal.
+			// Build each resolvable reference (the policy-level PFS group
+			// applies to all) and comma-join. An empty list falls back to a
+			// proposal named after the policy, as before.
+			propRefs := ipsecPol.Proposals
+			if len(propRefs) == 0 {
+				propRefs = []string{vpn.IPsecPolicy}
 			}
-			if prop, ok := cfg.Proposals[propRef]; ok {
-				return buildESPProposal(prop, pfsGroup), prop.LifetimeSeconds
+			var built []string
+			var firstLifetime int
+			for _, propRef := range propRefs {
+				if prop, ok := cfg.Proposals[propRef]; ok {
+					if len(built) == 0 {
+						firstLifetime = prop.LifetimeSeconds
+					}
+					built = append(built, buildESPProposal(prop, pfsGroup))
+				}
+			}
+			if len(built) > 0 {
+				return strings.Join(built, ","), firstLifetime
 			}
 			// #2073: the IPsec policy resolves but its proposal reference
 			// does not. The commit-time strict validator
@@ -125,7 +159,7 @@ func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, 
 			if pfsGroup > 0 {
 				slog.Warn("ipsec policy references undefined proposal; "+
 					"preserving configured PFS group on fallback proposal",
-					"policy", vpn.IPsecPolicy, "proposal", propRef,
+					"policy", vpn.IPsecPolicy, "proposal", strings.Join(propRefs, ","),
 					"pfs_group", pfsGroup)
 				return fmt.Sprintf("aes256-sha256-%s", formatDHGroup(pfsGroup)), 0
 			}
@@ -192,8 +226,16 @@ func hasIKEChain(cfg *config.IPsecConfig, ikePolicyName string) bool {
 	if cfg.IKEProposals == nil {
 		return false
 	}
-	_, ok = cfg.IKEProposals[pol.Proposals]
-	return ok
+	// #3904: `proposals` is a list — the chain is available when ANY
+	// reference resolves (resolveIKESettings renders every resolvable
+	// reference; the legacy direct-proposal fallback is consulted only when
+	// none resolve).
+	for _, ref := range pol.Proposals {
+		if _, ok := cfg.IKEProposals[ref]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeEncAlg maps a Junos encryption-algorithm name to its swanctl

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -50,7 +50,7 @@ func TestResolveIKESettings_DanglingPolicyFailsClosed(t *testing.T) {
 func TestResolveIKESettings_DanglingProposalFailsClosed(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"ike-pol": {Name: "ike-pol", Proposals: "no-such-proposal"},
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"no-such-proposal"}},
 		},
 	}
 	gw := &config.IPsecGateway{Name: "gw1", Address: "192.0.2.1", IKEPolicy: "ike-pol"}
@@ -64,7 +64,7 @@ func TestResolveIKESettings_DanglingProposalFailsClosed(t *testing.T) {
 func TestResolveIKESettings_ResolvableChain(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"ike-pol": {Name: "ike-pol", Proposals: "ike-prop"},
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"ike-prop"}},
 		},
 		IKEProposals: map[string]*config.IKEProposal{
 			"ike-prop": {
@@ -97,7 +97,7 @@ func TestResolveIKESettings_ResolvableChain(t *testing.T) {
 func TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"good-pol": {Name: "good-pol", Proposals: "good-prop", PSK: "secret-good"},
+			"good-pol": {Name: "good-pol", Proposals: []string{"good-prop"}, PSK: "secret-good"},
 		},
 		IKEProposals: map[string]*config.IKEProposal{
 			"good-prop": {

--- a/pkg/ipsec/ike_proposals_multivalue_3904_test.go
+++ b/pkg/ipsec/ike_proposals_multivalue_3904_test.go
@@ -1,0 +1,107 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// #3904 (fable-161 F-040/F-161): a multi-proposal IKE/IPsec policy
+// (`proposals [ p1 p2 ]`) must offer EVERY listed proposal in the generated
+// swanctl config. Before #3904 IKEPolicy.Proposals / IPsecPolicyDef.Proposals
+// were scalar strings that captured only the first reference, so phase-1/2
+// negotiation silently narrowed — a peer requiring the second proposal could
+// not establish. resolveIKESettings / resolveESPSettings now build every
+// resolvable reference and comma-join them into the swanctl proposals list.
+//
+// fail-on-revert: restoring the scalar (single-proposal) render drops the
+// second proposal from both the `proposals =` (IKE) and `esp_proposals =`
+// (ESP) lines, so the "second proposal present" assertions go RED.
+
+// TestGenerateConfig_MultiIKEProposals asserts both IKE proposals in a
+// `proposals [ ike-a ike-b ]` policy reach the swanctl `proposals =` line,
+// comma-joined and in order.
+func TestGenerateConfig_MultiIKEProposals(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {Gateway: "gw1", IPsecPolicy: "esp-pol"},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw1": {Name: "gw1", Address: "172.16.0.1", IKEPolicy: "ike-pol"},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"ike-a", "ike-b"}},
+		},
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-a": {Name: "ike-a", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+			"ike-b": {Name: "ike-b", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-128-cbc", AuthAlg: "sha-256", DHGroup: 5},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"esp-pol": {Name: "esp-pol", Proposals: []string{"esp-a"}},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-a": {Name: "esp-a", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256", DHGroup: 14},
+		},
+	}
+	got := m.generateConfig(cfg)
+	want := "proposals = aes256-sha256-modp2048,aes128-sha256-modp1536"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected both IKE proposals comma-joined (%q), got:\n%s", want, got)
+	}
+	// The second proposal alone would be dropped by the pre-#3904 scalar read.
+	if !strings.Contains(got, "aes128-sha256-modp1536") {
+		t.Errorf("second IKE proposal missing from swanctl output (crypto narrowing):\n%s", got)
+	}
+}
+
+// TestGenerateConfig_MultiESPProposals asserts both ESP proposals in a
+// `proposals [ esp-a esp-b ]` IPsec policy reach the `esp_proposals =` line.
+func TestGenerateConfig_MultiESPProposals(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {Gateway: "172.16.0.1", IPsecPolicy: "esp-pol"},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"esp-pol": {Name: "esp-pol", Proposals: []string{"esp-a", "esp-b"}},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-a": {Name: "esp-a", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256", DHGroup: 14},
+			"esp-b": {Name: "esp-b", EncryptionAlg: "aes-128-cbc", AuthAlg: "hmac-sha-256", DHGroup: 5},
+		},
+	}
+	got := m.generateConfig(cfg)
+	want := "esp_proposals = aes256-sha256-modp2048,aes128-sha256-modp1536"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected both ESP proposals comma-joined (%q), got:\n%s", want, got)
+	}
+	if !strings.Contains(got, "aes128-sha256-modp1536") {
+		t.Errorf("second ESP proposal missing from swanctl output (crypto narrowing):\n%s", got)
+	}
+}
+
+// TestGenerateConfig_MultiESPProposalsPFS asserts the policy-level PFS group
+// is applied to EVERY proposal in the list (the DH suffix is the PFS group,
+// not each proposal's own dh-group).
+func TestGenerateConfig_MultiESPProposalsPFS(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		VPNs: map[string]*config.IPsecVPN{
+			"tun1": {Gateway: "172.16.0.1", IPsecPolicy: "esp-pol"},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"esp-pol": {Name: "esp-pol", PFSGroup: 19, Proposals: []string{"esp-a", "esp-b"}},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-a": {Name: "esp-a", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256"},
+			"esp-b": {Name: "esp-b", EncryptionAlg: "aes-128-cbc", AuthAlg: "hmac-sha-256"},
+		},
+	}
+	got := m.generateConfig(cfg)
+	want := "esp_proposals = aes256-sha256-ecp256,aes128-sha256-ecp256"
+	if !strings.Contains(got, want) {
+		t.Errorf("expected PFS group applied to both ESP proposals (%q), got:\n%s", want, got)
+	}
+}

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -207,7 +207,7 @@ func TestResolveESPSettings_DanglingProposalPreservesPFS(t *testing.T) {
 			"ipsec-pol": {
 				Name:      "ipsec-pol",
 				PFSGroup:  14,
-				Proposals: "does-not-exist",
+				Proposals: []string{"does-not-exist"},
 			},
 		},
 		// Proposals deliberately omits "does-not-exist" — dangling ref.
@@ -241,7 +241,7 @@ func TestResolveESPSettings_DanglingProposalNoPFSStaysDefault(t *testing.T) {
 			"ipsec-pol": {
 				Name:      "ipsec-pol",
 				PFSGroup:  0,
-				Proposals: "does-not-exist",
+				Proposals: []string{"does-not-exist"},
 			},
 		},
 	}
@@ -279,7 +279,7 @@ func TestGenerateConfig_DanglingProposalPreservesPFS(t *testing.T) {
 			},
 		},
 		Policies: map[string]*config.IPsecPolicyDef{
-			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 14, Proposals: "does-not-exist"},
+			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 14, Proposals: []string{"does-not-exist"}},
 		},
 	}
 	got := m.generateConfig(cfg)
@@ -481,7 +481,7 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 			"ike-pol": {
 				Name:      "ike-pol",
 				Mode:      "main",
-				Proposals: "ike-p1",
+				Proposals: []string{"ike-p1"},
 				PSK:       "secret123",
 			},
 		},
@@ -512,7 +512,7 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 			"ipsec-pol": {
 				Name:      "ipsec-pol",
 				PFSGroup:  14,
-				Proposals: "esp-p2",
+				Proposals: []string{"esp-p2"},
 			},
 		},
 		VPNs: map[string]*config.IPsecVPN{
@@ -561,7 +561,7 @@ func TestGenerateConfig_DynamicHostname(t *testing.T) {
 		// The ike-policy -> ike-proposal chain must resolve, else
 		// renderConfig fail-closed-skips the VPN (#2270).
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"pol1": {Name: "pol1", Proposals: "ike-p1"},
+			"pol1": {Name: "pol1", Proposals: []string{"ike-p1"}},
 		},
 		IKEProposals: map[string]*config.IKEProposal{
 			"ike-p1": {Name: "ike-p1", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
@@ -717,7 +717,7 @@ func TestGenerateConfig_AggressiveMode(t *testing.T) {
 			"aggr-pol": {
 				Name:      "aggr-pol",
 				Mode:      "aggressive",
-				Proposals: "ike-p1",
+				Proposals: []string{"ike-p1"},
 				PSK:       "secret",
 			},
 		},
@@ -755,7 +755,7 @@ func TestGenerateConfig_AggressiveMode_NotSet(t *testing.T) {
 			"main-pol": {
 				Name:      "main-pol",
 				Mode:      "main",
-				Proposals: "ike-p1",
+				Proposals: []string{"ike-p1"},
 				PSK:       "secret",
 			},
 		},
@@ -849,7 +849,7 @@ func TestGenerateConfig_IKELifetime(t *testing.T) {
 			},
 		},
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"pol1": {Name: "pol1", Proposals: "ike-p1", PSK: "secret"},
+			"pol1": {Name: "pol1", Proposals: []string{"ike-p1"}, PSK: "secret"},
 		},
 		Gateways: map[string]*config.IPsecGateway{
 			"gw": {Name: "gw", Address: "203.0.113.1", IKEPolicy: "pol1"},
@@ -879,7 +879,7 @@ func TestGenerateConfig_ESPLifetime(t *testing.T) {
 			},
 		},
 		Policies: map[string]*config.IPsecPolicyDef{
-			"ipsec-pol": {Name: "ipsec-pol", Proposals: "esp-p2"},
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"esp-p2"}},
 		},
 		VPNs: map[string]*config.IPsecVPN{
 			"tun": {Gateway: "203.0.113.1", IPsecPolicy: "ipsec-pol"},
@@ -944,7 +944,7 @@ func TestGenerateConfig_PubkeyAuth(t *testing.T) {
 			},
 		},
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"pol1": {Name: "pol1", Proposals: "ike-p1"},
+			"pol1": {Name: "pol1", Proposals: []string{"ike-p1"}},
 		},
 		Gateways: map[string]*config.IPsecGateway{
 			"gw": {

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -277,7 +277,7 @@ func TestProposalBuilders_ECPGroupAcrossAllSites(t *testing.T) {
 		// carries the configured PFS group onto a conservative proposal.
 		cfg := &config.IPsecConfig{
 			Policies: map[string]*config.IPsecPolicyDef{
-				"pol1": {Name: "pol1", PFSGroup: gc.group, Proposals: "missing-prop"},
+				"pol1": {Name: "pol1", PFSGroup: gc.group, Proposals: []string{"missing-prop"}},
 			},
 		}
 		vpn := &config.IPsecVPN{IPsecPolicy: "pol1"}


### PR DESCRIPTION
Closes #3904

Four sibling findings of the same #2419/#3431/#3703 bracket-list dual-AST
truncation class (fable-review-161 F-040/F-161/F-162/F-163). Each leaf
collapsed a Junos `[ a b ]` list to the FIRST value, silently narrowing the
compiled config. All four are fixed by the established mechanism: mark the
declared leaf `multi: true` (so the flat-set path keeps every reference on
`Keys[1:]` instead of stranding the rest as child nodes) and read every value
via `firewallMatchValues` (Keys[1:] + child nodes, both AST shapes). Committed
one finding per commit.

## F-040 / F-161 — IKE/IPsec `proposals [ p1 p2 ]` (crypto-negotiation narrowing)
- `schema_security.go`: both `proposals` leaves → `multi: true`.
- `types_security.go`: `IKEPolicy.Proposals` and `IPsecPolicyDef.Proposals`
  widened `string` → `[]string` (the compiled `Config` is never JSON round-
  tripped — persistence + peer sync use the AST tree — so this is wire-safe).
- `compiler_ipsec.go:77/267`: accumulate every reference via
  `firewallMatchValues`.
- `pkg/ipsec/ike.go` `resolveIKESettings` / `resolveESPSettings` / `hasIKEChain`:
  build each resolvable proposal and comma-join into the swanctl `proposals =`
  / `esp_proposals =` list; auth method + lifetime from the first resolvable
  proposal; policy PFS group applied to every ESP proposal.
- `compiler_validate_strict.go`: both strict validators now require EVERY
  reference to resolve (a dangling trailing reference is a commit error,
  mirroring the NAT H05 gate); tolerant load/peer-sync still downgrades to a
  warning.
- Show consumers (`pkg/cli`, `pkg/grpcapi`) join the list.

## F-162 — RIP `redistribute` / group `export` / `neighbor` / `passive-interface`
- `schema_routing.go`: declared top-level RIP list-leaves → `multi: true` (the
  `group` block stays an opaque container whose bracket list already collapses).
- `compiler_protocols.go` RIP block: every list read routed through
  `firewallMatchValues` into the already-plural `RIPConfig` slices. The existing
  RIP export strict validator already walks the full slice.

## F-163 — routing-instance `interface [ i1 i2 ]` (VRF isolation break)
- `compiler_routing.go`: read every interface via `firewallMatchValues` into
  `RoutingInstanceConfig.Interfaces`. `interface` is an opaque implicit leaf, so
  the flat-set bracket already collapses onto `Keys[1:]` — no schema change
  needed. Before the fix the remaining ports stayed in the DEFAULT table.

## Validation
- `go build ./...`, `go vet` (config/ipsec/grpcapi clean; two pre-existing
  warnings in untouched cli files), `gofmt` clean on all edited files.
- `go test ./pkg/config/... ./pkg/ipsec/... ./pkg/frr/...` — all green.
- RED-on-revert verified per finding: reverting each compiler read (and the
  strongSwan render loop) to the single-value form fails the new assertions;
  restoring passes.
- New coverage: `compiler_ipsec_proposals_multivalue_3904_test.go`,
  `pkg/ipsec/ike_proposals_multivalue_3904_test.go`,
  `compiler_rip_multivalue_3904_test.go`,
  `compiler_routing_instance_interface_3904_test.go` (both AST shapes; single-
  value + hierarchical-block forms still work; dangling-second-reference
  rejection for the proposals lists).
- Docs: `docs/config-schema.md` extended with the #3904 multi-value section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi