### PR TITLE
config: fix four bracket-list multi-value truncations (IKE/IPsec proposals, RIP export/redistribute, routing-instance interface) — #3904

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,25 @@
+## 2026-07-03 — #3904 (F-162): RIP `group export` / `redistribute [ a b ]` bracket-list truncated to the first — multi-value fix
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-162 (routing), the RIP arm of the #3904
+    bundle. `protocols rip group G export [ pol-a pol-b ]` and top-level
+    `protocols rip redistribute [ static direct ]` each kept only the first
+    value — dropped export policies / redistributed protocols.
+  - **Fix**: Both compiler readers (`compiler_protocols.go` RIP block)
+    accumulate every value into `RIPConfig.Redistribute` via
+    `firewallMatchValues` instead of `gc.Keys[1]` / `child.Keys[1]`. The
+    declared top-level `redistribute` leaf is now `multi: true`
+    (`schema_routing.go`); the RIP `group` node stays `children: nil`
+    (permissive for every group sub-leaf; the `export` bracket already
+    collapses onto the export leaf's Keys, so only the compiler read needed
+    fixing). The FRR renderer (`generateProtocols`) already loops
+    `rip.Redistribute` (one `redistribute <proto>` per entry), so no render
+    change was needed. RED-on-revert proven: reverting to the Keys[1] read
+    yields `[pol-a static]` (drops pol-b + direct). SchemaValidate accepts the
+    bracket configs. go test ./pkg/config/... ./pkg/frr/... green.
+  - **File(s)**: pkg/config/compiler_protocols.go, pkg/config/schema_routing.go,
+    pkg/config/multivalue_rip_3904_test.go (new), docs/config-schema.md
+
 ## 2026-07-03 — #3904 (F-040/F-161): IKE/IPsec policy `proposals [ p1 p2 ]` bracket-list truncated to the first proposal — multi-value fix
 
 - **Timestamp**: 2026-07-03

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,36 @@
+## 2026-07-03 — #3904 (F-040/F-161): IKE/IPsec policy `proposals [ p1 p2 ]` bracket-list truncated to the first proposal — multi-value fix
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-040/F-161 (crypto-negotiation narrowing), the
+    IKE/IPsec-proposals arm of the #3904 bundle (same #2419/#3872
+    bracket-list-truncation class). An `ike policy … proposals [ p1 p2 ]` /
+    `ipsec policy … proposals [ e1 e2 ]` list silently offered ONLY the first
+    proposal — a peer requiring the second could not establish.
+  - **Fix**: Made both `proposals` schema leaves `args: 1, multi: true`
+    (`schema_security.go`); widened `IKEPolicy.Proposals` and
+    `IPsecPolicyDef.Proposals` from scalar `string` to `[]string`
+    (`types_security.go`); compiler readers now accumulate EVERY reference via
+    `firewallMatchValues` (`compiler_ipsec.go`). The strongSwan generator
+    (`pkg/ipsec/ike.go` `resolveIKESettings`/`resolveESPSettings`/`hasIKEChain`)
+    renders every resolvable proposal comma-joined into the swanctl `proposals =`
+    / `esp_proposals =` line; strict validators
+    (`compiler_validate_strict.go`) resolve the chain if ANY listed proposal is
+    defined (mirroring the renderer's resolvable-subset behaviour). Display sites
+    (`pkg/cli`, `pkg/grpcapi`) and the `PrepareConfig` deep-copy (`pkg/ipsec/
+    policy.go`, slice clone) updated. RED-on-revert proven: simulating the old
+    Keys[1]/first-only read makes both the compile and end-to-end render tests
+    fail. go build ./... clean; go test ./pkg/config/... ./pkg/ipsec/... green.
+  - **File(s)**: pkg/config/types_security.go, pkg/config/schema_security.go,
+    pkg/config/compiler_ipsec.go, pkg/config/compiler_validate_strict.go,
+    pkg/ipsec/ike.go, pkg/ipsec/policy.go, pkg/cli/cli_show_security_ipsec.go,
+    pkg/grpcapi/server_show_security_text.go,
+    pkg/config/multivalue_proposals_3904_test.go (new),
+    pkg/ipsec/multivalue_proposals_3904_test.go (new),
+    pkg/config/parser_security_test.go, pkg/config/ike_policy_chain_ref_test.go,
+    pkg/config/ipsec_proposal_ref_test.go, pkg/ipsec/ipsec_test.go,
+    pkg/ipsec/ike_chain_failclosed_test.go, pkg/ipsec/swanctl_render_test.go,
+    docs/config-schema.md
+
 ## 2026-07-03 — #3882: WireGuard responder rekey promoted an UNCONFIRMED session straight to `current` (no `next` slot) — 3-slot keypair lifecycle fix
 
 - **Timestamp**: 2026-07-03

--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,22 @@
+## 2026-07-03 — #3904 (F-163): routing-instance `interface [ i1 i2 ]` kept only the first port (VRF isolation break) — multi-value fix
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-163 (VRF isolation break), the
+    routing-instance-interface arm of the #3904 bundle. `routing-instances VR
+    interface [ ge-0/0/1 ge-0/0/2 ]` placed ONLY ge-0/0/1 in the VRF; the
+    remaining ports stayed in the default table — an isolation break.
+  - **Fix**: The `interface` reader in `compileRoutingInstances`
+    (`compiler_routing.go`) accumulates every value via `firewallMatchValues`
+    instead of `nodeVal(prop)` (Keys[1]). No schema or type change was needed:
+    `interface` is an IMPLICIT leaf under the routing-instances wildcard (the
+    bracket already collapses onto its Keys) and `Interfaces` was already a
+    `[]string`. RED-on-revert proven: reverting to nodeVal yields
+    `[ge-0/0/1]`. SchemaValidate accepts the bracket config; the repeated-line
+    form still accumulates every port. go test ./pkg/config/... green.
+  - **File(s)**: pkg/config/compiler_routing.go,
+    pkg/config/multivalue_routing_instance_3904_test.go (new),
+    docs/config-schema.md
+
 ## 2026-07-03 — #3904 (F-162): RIP `group export` / `redistribute [ a b ]` bracket-list truncated to the first — multi-value fix
 
 - **Timestamp**: 2026-07-03

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -283,6 +283,17 @@ kept a scalar reader that dropped everything past the first bracketed value:
   direct ]` kept only the first — dropped redistributions. Coverage:
   `multivalue_rip_3904_test.go`.
 
+- **routing-instance `interface`** (`compiler_routing.go`
+  `compileRoutingInstances`) — reads every port into
+  `RoutingInstanceConfig.Interfaces` via `firewallMatchValues` instead of
+  `nodeVal(prop)`. No schema or type change: `interface` is an IMPLICIT leaf
+  under the `routing-instances` wildcard (deliberately not declared — see the
+  `schemaRoutingInstances` header comment), and the bracket already collapses
+  onto its Keys; `Interfaces` was already `[]string`. Before #3904 `interface
+  [ ge-0/0/1 ge-0/0/2 ]` kept only the first port — the rest stayed in the
+  DEFAULT table (a VRF isolation break). Coverage:
+  `multivalue_routing_instance_3904_test.go`.
+
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 
 Beyond the per-leaf token allowlist above, host-inbound admission has a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -251,6 +251,26 @@ validation:
   directions — tail-drop and typo-bypass — across bracket / repeated-line /
   hierarchical shapes, plus the value-slot completion pin).
 
+**IKE / IPsec `proposals`, RIP `export`/`redistribute`, and routing-instance
+`interface` are multi-value (#3904).** Four more sibling leaves of the #2419 /
+#3872 bracket-list-truncation class that the earlier sweeps never reached; each
+kept a scalar reader that dropped everything past the first bracketed value:
+
+- **security `ike policy … proposals` and `ipsec policy … proposals`**
+  (`schema_security.go`) — now `args: 1, multi: true, children: nil`. The typed
+  config fields `IKEPolicy.Proposals` and `IPsecPolicyDef.Proposals` widened from
+  a scalar `string` to `[]string`, and the compiler readers (`compiler_ipsec.go`)
+  accumulate EVERY reference via `firewallMatchValues`. The strongSwan generator
+  (`pkg/ipsec` `resolveIKESettings` / `resolveESPSettings`) renders every
+  resolvable proposal into the swanctl `proposals =` / `esp_proposals =` line,
+  comma-joined; the strict validators (`validateIKEPolicyChainReferencesStrict`,
+  `validateIPsecPolicyProposalReferencesStrict`) resolve the chain if ANY listed
+  proposal is defined (mirroring the renderer, which offers the resolvable
+  subset). Before #3904 `proposals [ p1 p2 ]` offered ONLY `p1` — a silent
+  crypto-negotiation narrowing (a peer requiring the second proposal could not
+  establish). Coverage: `multivalue_proposals_3904_test.go` in `pkg/config`
+  (compile) and `pkg/ipsec` (end-to-end render).
+
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 
 Beyond the per-leaf token allowlist above, host-inbound admission has a

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -271,6 +271,18 @@ kept a scalar reader that dropped everything past the first bracketed value:
   establish). Coverage: `multivalue_proposals_3904_test.go` in `pkg/config`
   (compile) and `pkg/ipsec` (end-to-end render).
 
+- **RIP `group … export` and top-level `redistribute`**
+  (`compiler_protocols.go`) — both accumulate every value into
+  `RIPConfig.Redistribute` via `firewallMatchValues` (the FRR renderer
+  `generateProtocols` already loops the slice, one `redistribute <proto>` per
+  entry). The declared top-level `redistribute` leaf is now `multi: true`
+  (`schema_routing.go`); the RIP `group` node keeps `children: nil` (permissive
+  for every group sub-leaf such as `metric-out`), and the `export` bracket
+  already collapses onto the export leaf's Keys, so the fix there is the
+  compiler read alone. Before #3904 `export [ a b ]` / `redistribute [ static
+  direct ]` kept only the first — dropped redistributions. Coverage:
+  `multivalue_rip_3904_test.go`.
+
 ## Duplicate host-local-address fail-closed gate (#3718, Option B)
 
 Beyond the per-leaf token allowlist above, host-inbound admission has a

--- a/pkg/cli/cli_show_security_ipsec.go
+++ b/pkg/cli/cli_show_security_ipsec.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 func (c *CLI) showIPsec(args []string) error {
@@ -217,7 +218,7 @@ func (c *CLI) showIKE(args []string) error {
 			fmt.Printf("  IKE policy:         %s\n", gw.IKEPolicy)
 			if pol, ok := cfg.Security.IPsec.IKEPolicies[gw.IKEPolicy]; ok {
 				fmt.Printf("    Mode:     %s\n", pol.Mode)
-				fmt.Printf("    Proposal: %s\n", pol.Proposals)
+				fmt.Printf("    Proposal: %s\n", strings.Join(pol.Proposals, ", "))
 			}
 		}
 		ver := gw.Version

--- a/pkg/config/compiler_ipsec.go
+++ b/pkg/config/compiler_ipsec.go
@@ -74,7 +74,13 @@ func compileIKE(node *Node, sec *SecurityConfig) error {
 			case "mode":
 				pol.Mode = v
 			case "proposals":
-				pol.Proposals = v
+				// multi-value leaf (#3904): `proposals [ p1 p2 ]` collapses
+				// onto Keys[1:] (multi schema) or strands the tail as child
+				// nodes (hierarchical/legacy). Read EVERY reference via the
+				// firewallMatchValues SSOT — the pre-#3904 nodeVal(p) read only
+				// Keys[1] and dropped every proposal past the first, narrowing
+				// phase-1 crypto negotiation.
+				pol.Proposals = append(pol.Proposals, firewallMatchValues(p)...)
 			case "pre-shared-key":
 				// "pre-shared-key ascii-text VALUE" or children
 				if len(p.Keys) >= 3 {
@@ -261,10 +267,13 @@ func compileIPsec(node *Node, sec *SecurityConfig) error {
 	for _, inst := range namedInstances(node.FindChildren("policy")) {
 		pol := &IPsecPolicyDef{Name: inst.name}
 		for _, p := range inst.node.Children {
-			v := nodeVal(p)
 			switch p.Name() {
 			case "proposals":
-				pol.Proposals = v
+				// multi-value leaf (#3904): read EVERY ESP proposal reference
+				// (Keys[1:] + child nodes) via firewallMatchValues; the
+				// pre-#3904 nodeVal(p) dropped all but the first, narrowing
+				// phase-2 negotiation.
+				pol.Proposals = append(pol.Proposals, firewallMatchValues(p)...)
 			case "perfect-forward-secrecy":
 				for _, c := range p.Children {
 					if c.Name() == "keys" {

--- a/pkg/config/compiler_protocols.go
+++ b/pkg/config/compiler_protocols.go
@@ -583,9 +583,12 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 							proto.RIP.Interfaces = append(proto.RIP.Interfaces, gc.Keys[1])
 						}
 					case "export":
-						if len(gc.Keys) >= 2 {
-							proto.RIP.Redistribute = append(proto.RIP.Redistribute, gc.Keys[1])
-						}
+						// multi-value leaf (#3904): `group G export [ a b ]`
+						// collapses every policy onto the leaf's Keys; read ALL
+						// via firewallMatchValues. Reading only Keys[1] dropped
+						// every export policy past the first (the RIP arm of the
+						// #2419 bracket-list-truncation class).
+						proto.RIP.Redistribute = append(proto.RIP.Redistribute, firewallMatchValues(gc)...)
 					}
 				}
 			case "neighbor":
@@ -597,9 +600,10 @@ func compileProtocols(node *Node, proto *ProtocolsConfig) error {
 					proto.RIP.Passive = append(proto.RIP.Passive, child.Keys[1])
 				}
 			case "redistribute":
-				if len(child.Keys) >= 2 {
-					proto.RIP.Redistribute = append(proto.RIP.Redistribute, child.Keys[1])
-				}
+				// multi-value leaf (#3904): `redistribute [ static direct ]`
+				// spreads across Keys[1:] + child nodes; accumulate every value
+				// via firewallMatchValues rather than only Keys[1].
+				proto.RIP.Redistribute = append(proto.RIP.Redistribute, firewallMatchValues(child)...)
 			case "authentication-key":
 				if v := nodeVal(child); v != "" {
 					proto.RIP.AuthKey = Secret(v)

--- a/pkg/config/compiler_routing.go
+++ b/pkg/config/compiler_routing.go
@@ -384,9 +384,14 @@ func compileRoutingInstances(node *Node, cfg *Config) error {
 			case "instance-type":
 				ri.InstanceType = nodeVal(prop)
 			case "interface":
-				if v := nodeVal(prop); v != "" {
-					ri.Interfaces = append(ri.Interfaces, v)
-				}
+				// multi-value leaf (#3904): `interface [ ge-0/0/1 ge-0/0/2 ]`
+				// collapses every port onto the leaf's Keys (and/or child
+				// nodes). Read EVERY value via the firewallMatchValues SSOT —
+				// the pre-#3904 nodeVal(prop) read only Keys[1], stranding the
+				// remaining ports OUTSIDE the routing-instance (in the default
+				// table): a VRF isolation break (the routing arm of the #2419
+				// bracket-list-truncation class).
+				ri.Interfaces = append(ri.Interfaces, firewallMatchValues(prop)...)
 			case "routing-options":
 				var ro RoutingOptionsConfig
 				if err := compileRoutingOptions(prop, &ro); err != nil {

--- a/pkg/config/compiler_validate_strict.go
+++ b/pkg/config/compiler_validate_strict.go
@@ -210,22 +210,33 @@ func validateIPsecPolicyProposalReferencesStrict(cfg *Config) error {
 		if pol == nil {
 			continue
 		}
-		propRef := pol.Proposals
-		explicitRef := propRef != ""
+		// #3904: `proposals` is a list. Mirror resolveESPSettings, which
+		// renders every RESOLVABLE reference — so the chain resolves if ANY
+		// listed proposal is defined; only an all-dangling (or empty) list
+		// drops the connection to the strongSwan default.
+		explicitRef := len(pol.Proposals) > 0
+		propRefs := pol.Proposals
 		if !explicitRef {
 			// Mirror resolveESPSettings' policy-name fallback: a policy
 			// with no `proposals` leaf resolves against a proposal named
 			// after the policy itself.
-			propRef = pol.Name
+			propRefs = []string{pol.Name}
 		}
-		if _, ok := proposals[propRef]; ok {
+		resolved := false
+		for _, ref := range propRefs {
+			if _, ok := proposals[ref]; ok {
+				resolved = true
+				break
+			}
+		}
+		if resolved {
 			continue
 		}
 		if explicitRef {
-			return fmt.Errorf("ipsec policy %q references undefined ipsec proposal %q "+
+			return fmt.Errorf("ipsec policy %q references undefined ipsec proposal(s) %q "+
 				"(the configured proposal set, including any perfect-forward-secrecy "+
 				"group, would be silently dropped to the strongSwan default)",
-				pol.Name, propRef)
+				pol.Name, strings.Join(propRefs, ", "))
 		}
 		// No explicit `proposals` leaf was given, so do not blame a
 		// phantom proposal named after the policy — describe the actual
@@ -303,8 +314,13 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 	// name).
 	chainResolves := func(ikePolicyName string) bool {
 		if pol, ok := ikePolicies[ikePolicyName]; ok && pol != nil {
-			if _, ok := ikeProposals[pol.Proposals]; ok {
-				return true
+			// #3904: `proposals` is a list; the chain resolves if ANY listed
+			// ike-proposal is defined (resolveIKESettings renders the
+			// resolvable subset).
+			for _, ref := range pol.Proposals {
+				if _, ok := ikeProposals[ref]; ok {
+					return true
+				}
 			}
 		}
 		// Legacy fallback: a gateway's ike-policy value naming an IPsec
@@ -357,12 +373,11 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 				gw.Name, vpnName, gw.IKEPolicy)
 		}
 		pol := ikePolicies[gw.IKEPolicy]
-		if pol.Proposals == "" {
-			// The ike-policy exists but has no `proposals` leaf at all, so
-			// pol.Proposals is the empty string. Reporting an "undefined
-			// ike-proposal \"\"" misleads the operator into hunting for a
-			// proposal named "" — say plainly that the policy is missing its
-			// proposals configuration.
+		if len(pol.Proposals) == 0 {
+			// The ike-policy exists but has no `proposals` leaf at all.
+			// Reporting an "undefined ike-proposal \"\"" misleads the operator
+			// into hunting for a proposal named "" — say plainly that the
+			// policy is missing its proposals configuration.
 			return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
 				"has no proposals configured; phase-1 would silently negotiate "+
 				"with the strongSwan default proposal set instead of the "+
@@ -370,10 +385,10 @@ func validateIKEPolicyChainReferencesStrict(cfg *Config) error {
 				gw.IKEPolicy, gw.Name, vpnName)
 		}
 		return fmt.Errorf("ike-policy %q (via gateway %q, ipsec vpn %q) "+
-			"references undefined ike-proposal %q; phase-1 would silently "+
+			"references undefined ike-proposal(s) %q; phase-1 would silently "+
 			"negotiate with the strongSwan default proposal set instead of "+
 			"the configured crypto",
-			gw.IKEPolicy, gw.Name, vpnName, pol.Proposals)
+			gw.IKEPolicy, gw.Name, vpnName, strings.Join(pol.Proposals, ", "))
 	}
 	return nil
 }

--- a/pkg/config/ike_policy_chain_ref_test.go
+++ b/pkg/config/ike_policy_chain_ref_test.go
@@ -123,7 +123,7 @@ func TestIKEPolicyResolvableChainAccepted(t *testing.T) {
 		t.Fatalf("CompileConfig rejected a fully resolvable IKE chain: %v", err)
 	}
 	pol := cfg.Security.IPsec.IKEPolicies["ike-pol"]
-	if pol == nil || pol.Proposals != "ike-aes256" {
+	if pol == nil || len(pol.Proposals) != 1 || pol.Proposals[0] != "ike-aes256" {
 		t.Fatalf("ike-policy ike-pol not compiled with proposals=ike-aes256: %+v", pol)
 	}
 	if _, ok := cfg.Security.IPsec.IKEProposals["ike-aes256"]; !ok {

--- a/pkg/config/ipsec_proposal_ref_test.go
+++ b/pkg/config/ipsec_proposal_ref_test.go
@@ -94,7 +94,7 @@ func TestIPsecPolicyResolvableProposalAccepted(t *testing.T) {
 	if pol.PFSGroup != 14 {
 		t.Errorf("PFSGroup = %d, want 14", pol.PFSGroup)
 	}
-	if pol.Proposals != "esp-p2" {
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "esp-p2" {
 		t.Errorf("Proposals = %q, want esp-p2", pol.Proposals)
 	}
 }

--- a/pkg/config/multivalue_proposals_3904_test.go
+++ b/pkg/config/multivalue_proposals_3904_test.go
@@ -1,0 +1,95 @@
+package config
+
+import "testing"
+
+// buildTree3904 compiles a slice of `set ...` commands into a ConfigTree via
+// the flat-set path (ParseSetCommand + SetPath), the ONLY faithful way to
+// exercise bracketed-list grouping (NewParser merges newlines).
+func buildTree3904(t *testing.T, lines []string) *ConfigTree {
+	t.Helper()
+	tree := &ConfigTree{}
+	for _, l := range lines {
+		path, err := ParseSetCommand(l)
+		if err != nil {
+			t.Fatalf("ParseSetCommand(%q): %v", l, err)
+		}
+		if err := tree.SetPath(path); err != nil {
+			t.Fatalf("SetPath(%q): %v", l, err)
+		}
+	}
+	return tree
+}
+
+// TestIKEIPsecProposalsMultiValue_3904 is the F-040/F-161 RED-on-revert guard:
+// an IKE / IPsec policy `proposals [ p1 p2 ]` bracketed list must compile to
+// BOTH references, not just the first. Before #3904 the schema leaf was not
+// `multi` and the compiler read only Keys[1], so the second proposal was
+// silently dropped and phase-1/phase-2 crypto negotiation narrowed.
+func TestIKEIPsecProposalsMultiValue_3904(t *testing.T) {
+	tree := buildTree3904(t, []string{
+		"set security ike proposal ike-p1 authentication-method pre-shared-keys",
+		"set security ike proposal ike-p2 authentication-method pre-shared-keys",
+		"set security ike policy POL proposals [ ike-p1 ike-p2 ]",
+		"set security ipsec proposal esp-p1 encryption-algorithm aes-256-cbc",
+		"set security ipsec proposal esp-p2 encryption-algorithm aes-128-cbc",
+		"set security ipsec policy IPOL proposals [ esp-p1 esp-p2 ]",
+	})
+	var sec SecurityConfig
+	if err := compileIKE(tree.FindChild("security").FindChild("ike"), &sec); err != nil {
+		t.Fatalf("compileIKE: %v", err)
+	}
+	if err := compileIPsec(tree.FindChild("security").FindChild("ipsec"), &sec); err != nil {
+		t.Fatalf("compileIPsec: %v", err)
+	}
+
+	ike := sec.IPsec.IKEPolicies["POL"]
+	if ike == nil {
+		t.Fatal("IKE policy POL not compiled")
+	}
+	if got, want := ike.Proposals, []string{"ike-p1", "ike-p2"}; !equalStrs3904(got, want) {
+		t.Errorf("IKE policy proposals = %v, want %v (bracket list truncated)", got, want)
+	}
+
+	esp := sec.IPsec.Policies["IPOL"]
+	if esp == nil {
+		t.Fatal("IPsec policy IPOL not compiled")
+	}
+	if got, want := esp.Proposals, []string{"esp-p1", "esp-p2"}; !equalStrs3904(got, want) {
+		t.Errorf("IPsec policy proposals = %v, want %v (bracket list truncated)", got, want)
+	}
+}
+
+// TestIKEIPsecProposalsSingleAndBlock_3904 confirms the single-value and
+// hierarchical-block forms still compile to exactly one reference each — the
+// multi leaf must not regress the common single-proposal case.
+func TestIKEIPsecProposalsSingleAndBlock_3904(t *testing.T) {
+	tree := buildTree3904(t, []string{
+		"set security ike policy P1 proposals ike-single",
+		"set security ipsec policy I1 proposals esp-single",
+	})
+	var sec SecurityConfig
+	if err := compileIKE(tree.FindChild("security").FindChild("ike"), &sec); err != nil {
+		t.Fatalf("compileIKE: %v", err)
+	}
+	if err := compileIPsec(tree.FindChild("security").FindChild("ipsec"), &sec); err != nil {
+		t.Fatalf("compileIPsec: %v", err)
+	}
+	if got, want := sec.IPsec.IKEPolicies["P1"].Proposals, []string{"ike-single"}; !equalStrs3904(got, want) {
+		t.Errorf("single IKE proposal = %v, want %v", got, want)
+	}
+	if got, want := sec.IPsec.Policies["I1"].Proposals, []string{"esp-single"}; !equalStrs3904(got, want) {
+		t.Errorf("single IPsec proposal = %v, want %v", got, want)
+	}
+}
+
+func equalStrs3904(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/config/multivalue_rip_3904_test.go
+++ b/pkg/config/multivalue_rip_3904_test.go
@@ -1,0 +1,49 @@
+package config
+
+import "testing"
+
+// TestRIPExportRedistributeMultiValue_3904 is the F-162 RED-on-revert guard:
+// a RIP `group G export [ a b ]` bracket list and a top-level
+// `redistribute [ static direct ]` bracket list must each compile to EVERY
+// value, not just the first. Before #3904 both compiler arms read only Keys[1]
+// (the RIP arm of the #2419 bracket-list-truncation class), so the second
+// export policy / redistribute protocol was silently dropped.
+func TestRIPExportRedistributeMultiValue_3904(t *testing.T) {
+	tree := buildTree3904(t, []string{
+		"set protocols rip group g export [ pol-a pol-b ]",
+		"set protocols rip redistribute [ static direct ]",
+	})
+	// The RIP config must also be commit-valid (schema-accepted).
+	var scfg Config
+	if err := SchemaValidate(tree, &scfg); err != nil {
+		t.Fatalf("SchemaValidate: %v", err)
+	}
+
+	var proto ProtocolsConfig
+	if err := compileProtocols(tree.FindChild("protocols"), &proto); err != nil {
+		t.Fatalf("compileProtocols: %v", err)
+	}
+	if proto.RIP == nil {
+		t.Fatal("RIP not compiled")
+	}
+	// group export → Redistribute, then top-level redistribute → Redistribute.
+	want := []string{"pol-a", "pol-b", "static", "direct"}
+	if !equalStrs3904(proto.RIP.Redistribute, want) {
+		t.Errorf("RIP.Redistribute = %v, want %v (bracket list truncated)", proto.RIP.Redistribute, want)
+	}
+}
+
+// TestRIPRedistributeSingle_3904 confirms the single-value form still compiles
+// to exactly one entry (the multi leaf must not regress it).
+func TestRIPRedistributeSingle_3904(t *testing.T) {
+	tree := buildTree3904(t, []string{
+		"set protocols rip redistribute static",
+	})
+	var proto ProtocolsConfig
+	if err := compileProtocols(tree.FindChild("protocols"), &proto); err != nil {
+		t.Fatalf("compileProtocols: %v", err)
+	}
+	if proto.RIP == nil || !equalStrs3904(proto.RIP.Redistribute, []string{"static"}) {
+		t.Errorf("single redistribute = %v, want [static]", proto.RIP.Redistribute)
+	}
+}

--- a/pkg/config/multivalue_routing_instance_3904_test.go
+++ b/pkg/config/multivalue_routing_instance_3904_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+// TestRoutingInstanceInterfaceMultiValue_3904 is the F-163 RED-on-revert guard:
+// a routing-instance `interface [ ge-0/0/1 ge-0/0/2 ]` bracket list must place
+// EVERY listed port in the routing-instance, not just the first. Before #3904
+// the compiler read `nodeVal(prop)` (Keys[1]) and dropped the rest, stranding
+// the remaining ports in the default table — a VRF isolation break (the routing
+// arm of the #2419 bracket-list-truncation class).
+func TestRoutingInstanceInterfaceMultiValue_3904(t *testing.T) {
+	tree := buildTree3904(t, []string{
+		"set routing-instances VR instance-type virtual-router",
+		"set routing-instances VR interface [ ge-0/0/1 ge-0/0/2 ]",
+	})
+	// The routing-instance config must also be commit-valid.
+	var scfg Config
+	if err := SchemaValidate(tree, &scfg); err != nil {
+		t.Fatalf("SchemaValidate: %v", err)
+	}
+
+	var cfg Config
+	if err := compileRoutingInstances(tree.FindChild("routing-instances"), &cfg); err != nil {
+		t.Fatalf("compileRoutingInstances: %v", err)
+	}
+	if len(cfg.RoutingInstances) != 1 {
+		t.Fatalf("routing-instances = %d, want 1", len(cfg.RoutingInstances))
+	}
+	ri := cfg.RoutingInstances[0]
+	if !equalStrs3904(ri.Interfaces, []string{"ge-0/0/1", "ge-0/0/2"}) {
+		t.Errorf("routing-instance %q interfaces = %v, want [ge-0/0/1 ge-0/0/2] (bracket list truncated → VRF isolation break)", ri.Name, ri.Interfaces)
+	}
+}
+
+// TestRoutingInstanceInterfaceSeparateLines_3904 confirms the repeated-line
+// form (one `interface` set per port) still accumulates every port, and a
+// single-value form keeps working.
+func TestRoutingInstanceInterfaceSeparateLines_3904(t *testing.T) {
+	tree := buildTree3904(t, []string{
+		"set routing-instances VR interface ge-0/0/1",
+		"set routing-instances VR interface ge-0/0/2",
+	})
+	var cfg Config
+	if err := compileRoutingInstances(tree.FindChild("routing-instances"), &cfg); err != nil {
+		t.Fatalf("compileRoutingInstances: %v", err)
+	}
+	if len(cfg.RoutingInstances) != 1 {
+		t.Fatalf("routing-instances = %d, want 1", len(cfg.RoutingInstances))
+	}
+	if !equalStrs3904(cfg.RoutingInstances[0].Interfaces, []string{"ge-0/0/1", "ge-0/0/2"}) {
+		t.Errorf("repeated-line interfaces = %v, want [ge-0/0/1 ge-0/0/2]", cfg.RoutingInstances[0].Interfaces)
+	}
+}

--- a/pkg/config/parser_security_test.go
+++ b/pkg/config/parser_security_test.go
@@ -1786,7 +1786,7 @@ func TestIKEAdvancedFeatures(t *testing.T) {
 	if ikePol.Mode != "main" {
 		t.Errorf("IKE policy mode = %q", ikePol.Mode)
 	}
-	if ikePol.Proposals != "ike-phase1" {
+	if len(ikePol.Proposals) != 1 || ikePol.Proposals[0] != "ike-phase1" {
 		t.Errorf("IKE policy proposals = %q", ikePol.Proposals)
 	}
 	if ikePol.PSK != "secret123" {
@@ -1831,7 +1831,7 @@ func TestIKEAdvancedFeatures(t *testing.T) {
 	if ipsecPol.PFSGroup != 14 {
 		t.Errorf("IPsec policy PFS group = %d, want 14", ipsecPol.PFSGroup)
 	}
-	if ipsecPol.Proposals != "esp-phase2" {
+	if len(ipsecPol.Proposals) != 1 || ipsecPol.Proposals[0] != "esp-phase2" {
 		t.Errorf("IPsec policy proposals = %q", ipsecPol.Proposals)
 	}
 	vpn := cfg.Security.IPsec.VPNs["site-a"]
@@ -2609,7 +2609,7 @@ func TestIKEProposalSetSyntax(t *testing.T) {
 	if pol.Mode != "main" {
 		t.Errorf("mode = %q, want main", pol.Mode)
 	}
-	if pol.Proposals != "ike-aes256" {
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "ike-aes256" {
 		t.Errorf("proposals = %q, want ike-aes256", pol.Proposals)
 	}
 	gw := cfg.Security.IPsec.Gateways["remote-gw"]
@@ -2660,7 +2660,7 @@ func TestIPsecProposalSetSyntax(t *testing.T) {
 	if pol == nil {
 		t.Fatal("missing IPsec policy ipsec-strong")
 	}
-	if pol.Proposals != "esp-aes256" {
+	if len(pol.Proposals) != 1 || pol.Proposals[0] != "esp-aes256" {
 		t.Errorf("proposals = %q, want esp-aes256", pol.Proposals)
 	}
 }

--- a/pkg/config/schema_routing.go
+++ b/pkg/config/schema_routing.go
@@ -382,10 +382,16 @@ var schemaProtocols = &schemaNode{desc: "Protocols configuration", children: map
 		}},
 	}},
 	"rip": {desc: "RIP configuration", children: map[string]*schemaNode{
-		"group":               {desc: "Group", args: 1, placeholder: "<group-name>", children: nil},
-		"neighbor":            {desc: "Neighbor", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
-		"passive-interface":   {desc: "Passive interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
-		"redistribute":        {desc: "Redistribute", args: 1, placeholder: "<protocol>", children: nil},
+		"group":             {desc: "Group", args: 1, placeholder: "<group-name>", children: nil},
+		"neighbor":          {desc: "Neighbor", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
+		"passive-interface": {desc: "Passive interface", args: 1, valueHint: ValueHintInterfaceName, placeholder: "<interface-name>", children: nil},
+		// multi (#3904): `redistribute [ static direct ]` lists several
+		// protocols; without multi the flat-set path stranded the tail as a
+		// child node and the scalar reader dropped all but the first. (RIP
+		// group `export [ a b ]` is handled on the compiler read side —
+		// `group` keeps children:nil, which stays permissive for every group
+		// sub-leaf, and the bracket already collapses onto the export leaf.)
+		"redistribute":        {desc: "Redistribute", args: 1, multi: true, placeholder: "<protocol>", children: nil},
 		"authentication-key":  {desc: "Authentication key", args: 1, placeholder: "<key>", children: nil},
 		"authentication-type": {desc: "Authentication type", args: 1, placeholder: "<type>", children: nil},
 	}},

--- a/pkg/config/schema_security.go
+++ b/pkg/config/schema_security.go
@@ -740,7 +740,11 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 				valueType: ValueEnumOf, valueDesc: "IKE phase 1 negotiation mode",
 				valueExamples: []string{"main", "aggressive"},
 				validator:     ValidateEnum([]string{"main", "aggressive"}), children: nil},
-			"proposals":      {desc: "IKE proposal reference", args: 1, placeholder: "<proposal-name>", children: nil},
+			// multi (#3904): `proposals [ p1 p2 ]` offers every listed IKE
+			// proposal for phase-1 negotiation. Without multi the flat-set
+			// path stranded every reference past the first as a child node and
+			// the scalar compiler dropped them — crypto-negotiation narrowing.
+			"proposals":      {desc: "IKE proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
 			"pre-shared-key": {desc: "Pre-shared key (ascii-text <key>)", children: nil},
 		}},
 		"gateway": {desc: "IKE gateway (VPN peer) name", args: 1, placeholder: "<gateway-name>", children: map[string]*schemaNode{
@@ -803,7 +807,9 @@ var schemaSecurity = &schemaNode{desc: "Security configuration", children: map[s
 		}},
 		"policy": {desc: "IPsec policy name", args: 1, placeholder: "<policy-name>", children: map[string]*schemaNode{
 			"perfect-forward-secrecy": {desc: "Perfect forward secrecy (keys group<N>)", children: nil},
-			"proposals":               {desc: "IPsec proposal reference", args: 1, placeholder: "<proposal-name>", children: nil},
+			// multi (#3904): mirror of the IKE proposals leaf — offer every
+			// listed ESP proposal for phase-2 negotiation.
+			"proposals": {desc: "IPsec proposal reference(s)", args: 1, multi: true, placeholder: "<proposal-name>", children: nil},
 		}},
 		"gateway": {desc: "IKE gateway (VPN peer) name", args: 1, placeholder: "<gateway-name>", children: map[string]*schemaNode{
 			"address":            {desc: "Remote gateway address", args: 1, placeholder: "<address>", children: nil},

--- a/pkg/config/types_security.go
+++ b/pkg/config/types_security.go
@@ -971,9 +971,15 @@ type IKEProposal struct {
 
 // IKEPolicy defines Phase 1 policy (mode, proposal reference, PSK).
 type IKEPolicy struct {
-	Name      string
-	Mode      string // "main" or "aggressive"
-	Proposals string // IKE proposal reference
+	Name string
+	Mode string // "main" or "aggressive"
+	// Proposals is the ordered list of IKE proposal references. Junos
+	// `proposals [ p1 p2 ]` offers every listed proposal for phase-1
+	// negotiation; the pre-#3904 scalar read only the first, narrowing
+	// crypto negotiation so a peer requiring the second proposal could not
+	// establish. Rendered comma-joined into the swanctl `proposals =` line
+	// (pkg/ipsec resolveIKESettings).
+	Proposals []string
 	PSK       Secret // pre-shared key; redacted on JSON/YAML marshal (#2053)
 }
 
@@ -989,9 +995,14 @@ type IPsecProposal struct {
 
 // IPsecPolicyDef defines Phase 2 policy (PFS + proposal reference).
 type IPsecPolicyDef struct {
-	Name      string
-	PFSGroup  int    // PFS DH group number (0 = disabled)
-	Proposals string // IPsec proposal reference
+	Name     string
+	PFSGroup int // PFS DH group number (0 = disabled)
+	// Proposals is the ordered list of IPsec (ESP) proposal references.
+	// Junos `proposals [ p1 p2 ]` offers every listed proposal for phase-2
+	// negotiation; the pre-#3904 scalar read only the first, narrowing
+	// negotiation. Rendered comma-joined into the swanctl `esp_proposals =`
+	// line (pkg/ipsec resolveESPSettings).
+	Proposals []string
 }
 
 // IPsecGateway defines a remote IKE gateway.

--- a/pkg/grpcapi/server_show_security_text.go
+++ b/pkg/grpcapi/server_show_security_text.go
@@ -940,7 +940,7 @@ func (s *Server) showIKE(cfg *config.Config, buf *strings.Builder) {
 				fmt.Fprintf(buf, "  IKE policy:         %s\n", gw.IKEPolicy)
 				if pol, ok := cfg.Security.IPsec.IKEPolicies[gw.IKEPolicy]; ok {
 					fmt.Fprintf(buf, "    Mode:     %s\n", pol.Mode)
-					fmt.Fprintf(buf, "    Proposal: %s\n", pol.Proposals)
+					fmt.Fprintf(buf, "    Proposal: %s\n", strings.Join(pol.Proposals, ", "))
 				}
 			}
 			ver := gw.Version

--- a/pkg/ipsec/ike.go
+++ b/pkg/ipsec/ike.go
@@ -54,12 +54,30 @@ func resolveIKESettings(cfg *config.IPsecConfig, gw *config.IPsecGateway) (authM
 
 	if ikePol, ok := cfg.IKEPolicies[gw.IKEPolicy]; ok {
 		aggressive = ikePol.Mode == "aggressive"
-		if ikeProp, ok := cfg.IKEProposals[ikePol.Proposals]; ok {
-			authMethod, err = authMethodToSwan(ikeProp.AuthMethod)
+		// #3904: an ike-policy may list several proposals
+		// (`proposals [ p1 p2 ]`); offer EVERY resolvable one in the swanctl
+		// `proposals =` line (comma-joined) rather than only the first. The
+		// auth method and lifetime are taken from the first resolvable
+		// proposal — strongSwan carries a single auth method per connection,
+		// and a policy's proposals share it in practice.
+		var parts []string
+		var first *config.IKEProposal
+		for _, ref := range ikePol.Proposals {
+			ikeProp, ok := cfg.IKEProposals[ref]
+			if !ok {
+				continue
+			}
+			if first == nil {
+				first = ikeProp
+			}
+			parts = append(parts, buildIKEProposalFromIKE(ikeProp))
+		}
+		if first != nil {
+			authMethod, err = authMethodToSwan(first.AuthMethod)
 			if err != nil {
 				return "", "", 0, false, err
 			}
-			return authMethod, buildIKEProposalFromIKE(ikeProp), ikeProp.LifetimeSeconds, aggressive, nil
+			return authMethod, strings.Join(parts, ","), first.LifetimeSeconds, aggressive, nil
 		}
 	}
 
@@ -83,12 +101,29 @@ func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, 
 	if vpn.IPsecPolicy != "" {
 		if ipsecPol, ok := cfg.Policies[vpn.IPsecPolicy]; ok {
 			pfsGroup = ipsecPol.PFSGroup
-			propRef := ipsecPol.Proposals
-			if propRef == "" {
-				propRef = vpn.IPsecPolicy
+			// #3904: an ipsec policy may list several ESP proposals
+			// (`proposals [ p1 p2 ]`); render EVERY resolvable one into the
+			// swanctl `esp_proposals =` line (comma-joined). A policy with no
+			// explicit `proposals` leaf resolves against a proposal named
+			// after the policy itself (the historical fallback).
+			propRefs := ipsecPol.Proposals
+			if len(propRefs) == 0 {
+				propRefs = []string{vpn.IPsecPolicy}
 			}
-			if prop, ok := cfg.Proposals[propRef]; ok {
-				return buildESPProposal(prop, pfsGroup), prop.LifetimeSeconds
+			var parts []string
+			var first *config.IPsecProposal
+			for _, ref := range propRefs {
+				prop, ok := cfg.Proposals[ref]
+				if !ok {
+					continue
+				}
+				if first == nil {
+					first = prop
+				}
+				parts = append(parts, buildESPProposal(prop, pfsGroup))
+			}
+			if first != nil {
+				return strings.Join(parts, ","), first.LifetimeSeconds
 			}
 			// #2073: the IPsec policy resolves but its proposal reference
 			// does not. The commit-time strict validator
@@ -123,9 +158,9 @@ func resolveESPSettings(cfg *config.IPsecConfig, vpn *config.IPsecVPN) (string, 
 			// so the #2392 ECP fix applies here too — group 19/20 no longer
 			// emits the strongSwan-invalid modp256/modp384 token.
 			if pfsGroup > 0 {
-				slog.Warn("ipsec policy references undefined proposal; "+
+				slog.Warn("ipsec policy references undefined proposal(s); "+
 					"preserving configured PFS group on fallback proposal",
-					"policy", vpn.IPsecPolicy, "proposal", propRef,
+					"policy", vpn.IPsecPolicy, "proposals", strings.Join(propRefs, ","),
 					"pfs_group", pfsGroup)
 				return fmt.Sprintf("aes256-sha256-%s", formatDHGroup(pfsGroup)), 0
 			}
@@ -192,8 +227,16 @@ func hasIKEChain(cfg *config.IPsecConfig, ikePolicyName string) bool {
 	if cfg.IKEProposals == nil {
 		return false
 	}
-	_, ok = cfg.IKEProposals[pol.Proposals]
-	return ok
+	// #3904: the chain resolves if ANY listed ike-proposal is defined —
+	// resolveIKESettings renders the resolvable subset, so a partially
+	// dangling list is still a real (non-empty) proposal, not a fall-through
+	// to strongSwan's default set.
+	for _, ref := range pol.Proposals {
+		if _, ok := cfg.IKEProposals[ref]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeEncAlg maps a Junos encryption-algorithm name to its swanctl

--- a/pkg/ipsec/ike_chain_failclosed_test.go
+++ b/pkg/ipsec/ike_chain_failclosed_test.go
@@ -50,7 +50,7 @@ func TestResolveIKESettings_DanglingPolicyFailsClosed(t *testing.T) {
 func TestResolveIKESettings_DanglingProposalFailsClosed(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"ike-pol": {Name: "ike-pol", Proposals: "no-such-proposal"},
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"no-such-proposal"}},
 		},
 	}
 	gw := &config.IPsecGateway{Name: "gw1", Address: "192.0.2.1", IKEPolicy: "ike-pol"}
@@ -64,7 +64,7 @@ func TestResolveIKESettings_DanglingProposalFailsClosed(t *testing.T) {
 func TestResolveIKESettings_ResolvableChain(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"ike-pol": {Name: "ike-pol", Proposals: "ike-prop"},
+			"ike-pol": {Name: "ike-pol", Proposals: []string{"ike-prop"}},
 		},
 		IKEProposals: map[string]*config.IKEProposal{
 			"ike-prop": {
@@ -97,7 +97,7 @@ func TestResolveIKESettings_ResolvableChain(t *testing.T) {
 func TestRenderConfig_BrokenChainSkipsVPN_HealthyTunnelSurvives(t *testing.T) {
 	cfg := &config.IPsecConfig{
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"good-pol": {Name: "good-pol", Proposals: "good-prop", PSK: "secret-good"},
+			"good-pol": {Name: "good-pol", Proposals: []string{"good-prop"}, PSK: "secret-good"},
 		},
 		IKEProposals: map[string]*config.IKEProposal{
 			"good-prop": {

--- a/pkg/ipsec/ipsec_test.go
+++ b/pkg/ipsec/ipsec_test.go
@@ -207,7 +207,7 @@ func TestResolveESPSettings_DanglingProposalPreservesPFS(t *testing.T) {
 			"ipsec-pol": {
 				Name:      "ipsec-pol",
 				PFSGroup:  14,
-				Proposals: "does-not-exist",
+				Proposals: []string{"does-not-exist"},
 			},
 		},
 		// Proposals deliberately omits "does-not-exist" — dangling ref.
@@ -241,7 +241,7 @@ func TestResolveESPSettings_DanglingProposalNoPFSStaysDefault(t *testing.T) {
 			"ipsec-pol": {
 				Name:      "ipsec-pol",
 				PFSGroup:  0,
-				Proposals: "does-not-exist",
+				Proposals: []string{"does-not-exist"},
 			},
 		},
 	}
@@ -279,7 +279,7 @@ func TestGenerateConfig_DanglingProposalPreservesPFS(t *testing.T) {
 			},
 		},
 		Policies: map[string]*config.IPsecPolicyDef{
-			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 14, Proposals: "does-not-exist"},
+			"ipsec-pol": {Name: "ipsec-pol", PFSGroup: 14, Proposals: []string{"does-not-exist"}},
 		},
 	}
 	got := m.generateConfig(cfg)
@@ -481,7 +481,7 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 			"ike-pol": {
 				Name:      "ike-pol",
 				Mode:      "main",
-				Proposals: "ike-p1",
+				Proposals: []string{"ike-p1"},
 				PSK:       "secret123",
 			},
 		},
@@ -512,7 +512,7 @@ func TestGenerateConfig_IKEChain(t *testing.T) {
 			"ipsec-pol": {
 				Name:      "ipsec-pol",
 				PFSGroup:  14,
-				Proposals: "esp-p2",
+				Proposals: []string{"esp-p2"},
 			},
 		},
 		VPNs: map[string]*config.IPsecVPN{
@@ -561,7 +561,7 @@ func TestGenerateConfig_DynamicHostname(t *testing.T) {
 		// The ike-policy -> ike-proposal chain must resolve, else
 		// renderConfig fail-closed-skips the VPN (#2270).
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"pol1": {Name: "pol1", Proposals: "ike-p1"},
+			"pol1": {Name: "pol1", Proposals: []string{"ike-p1"}},
 		},
 		IKEProposals: map[string]*config.IKEProposal{
 			"ike-p1": {Name: "ike-p1", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
@@ -717,7 +717,7 @@ func TestGenerateConfig_AggressiveMode(t *testing.T) {
 			"aggr-pol": {
 				Name:      "aggr-pol",
 				Mode:      "aggressive",
-				Proposals: "ike-p1",
+				Proposals: []string{"ike-p1"},
 				PSK:       "secret",
 			},
 		},
@@ -755,7 +755,7 @@ func TestGenerateConfig_AggressiveMode_NotSet(t *testing.T) {
 			"main-pol": {
 				Name:      "main-pol",
 				Mode:      "main",
-				Proposals: "ike-p1",
+				Proposals: []string{"ike-p1"},
 				PSK:       "secret",
 			},
 		},
@@ -849,7 +849,7 @@ func TestGenerateConfig_IKELifetime(t *testing.T) {
 			},
 		},
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"pol1": {Name: "pol1", Proposals: "ike-p1", PSK: "secret"},
+			"pol1": {Name: "pol1", Proposals: []string{"ike-p1"}, PSK: "secret"},
 		},
 		Gateways: map[string]*config.IPsecGateway{
 			"gw": {Name: "gw", Address: "203.0.113.1", IKEPolicy: "pol1"},
@@ -879,7 +879,7 @@ func TestGenerateConfig_ESPLifetime(t *testing.T) {
 			},
 		},
 		Policies: map[string]*config.IPsecPolicyDef{
-			"ipsec-pol": {Name: "ipsec-pol", Proposals: "esp-p2"},
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"esp-p2"}},
 		},
 		VPNs: map[string]*config.IPsecVPN{
 			"tun": {Gateway: "203.0.113.1", IPsecPolicy: "ipsec-pol"},
@@ -944,7 +944,7 @@ func TestGenerateConfig_PubkeyAuth(t *testing.T) {
 			},
 		},
 		IKEPolicies: map[string]*config.IKEPolicy{
-			"pol1": {Name: "pol1", Proposals: "ike-p1"},
+			"pol1": {Name: "pol1", Proposals: []string{"ike-p1"}},
 		},
 		Gateways: map[string]*config.IPsecGateway{
 			"gw": {

--- a/pkg/ipsec/multivalue_proposals_3904_test.go
+++ b/pkg/ipsec/multivalue_proposals_3904_test.go
@@ -1,0 +1,50 @@
+package ipsec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+)
+
+// TestGenerateConfig_MultiProposal_3904 is the F-040/F-161 render RED-on-revert
+// guard: an IKE / IPsec policy that lists two proposals must emit BOTH into the
+// swanctl `proposals =` / `esp_proposals =` line (comma-joined), never just the
+// first. Before #3904 IKEPolicy.Proposals / IPsecPolicyDef.Proposals were
+// scalar strings, so the second proposal was dropped and crypto negotiation
+// silently narrowed (a peer requiring the second proposal could not establish).
+func TestGenerateConfig_MultiProposal_3904(t *testing.T) {
+	m := &Manager{configDir: "/tmp", configPath: "/tmp/xpf.conf"}
+	cfg := &config.IPsecConfig{
+		IKEProposals: map[string]*config.IKEProposal{
+			"ike-p1": {Name: "ike-p1", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-256-cbc", AuthAlg: "sha-256", DHGroup: 14},
+			"ike-p2": {Name: "ike-p2", AuthMethod: "pre-shared-keys", EncryptionAlg: "aes-128-cbc", AuthAlg: "sha-256", DHGroup: 14},
+		},
+		IKEPolicies: map[string]*config.IKEPolicy{
+			"ike-pol": {Name: "ike-pol", Mode: "main", Proposals: []string{"ike-p1", "ike-p2"}, PSK: "secret"},
+		},
+		Gateways: map[string]*config.IPsecGateway{
+			"gw1": {Name: "gw1", Address: "203.0.113.1", LocalAddress: "198.51.100.1", IKEPolicy: "ike-pol", Version: "v2-only"},
+		},
+		Proposals: map[string]*config.IPsecProposal{
+			"esp-p1": {Name: "esp-p1", EncryptionAlg: "aes-256-cbc", AuthAlg: "hmac-sha-256-128", DHGroup: 14},
+			"esp-p2": {Name: "esp-p2", EncryptionAlg: "aes-128-cbc", AuthAlg: "hmac-sha-256-128", DHGroup: 14},
+		},
+		Policies: map[string]*config.IPsecPolicyDef{
+			"ipsec-pol": {Name: "ipsec-pol", Proposals: []string{"esp-p1", "esp-p2"}},
+		},
+		VPNs: map[string]*config.IPsecVPN{
+			"site-a": {Name: "site-a", Gateway: "gw1", IPsecPolicy: "ipsec-pol"},
+		},
+	}
+	got := m.generateConfig(cfg)
+
+	// Both IKE proposals, comma-joined, in the phase-1 proposals line.
+	if !strings.Contains(got, "proposals = aes256-sha256-modp2048,aes128-sha256-modp2048") {
+		t.Errorf("IKE proposals line missing the full comma-joined set; got:\n%s", got)
+	}
+	// Both ESP proposals, comma-joined, in the phase-2 esp_proposals line.
+	if !strings.Contains(got, "esp_proposals = aes256-sha256-modp2048,aes128-sha256-modp2048") {
+		t.Errorf("ESP esp_proposals line missing the full comma-joined set; got:\n%s", got)
+	}
+}

--- a/pkg/ipsec/policy.go
+++ b/pkg/ipsec/policy.go
@@ -479,6 +479,11 @@ func PrepareConfig(cfg *config.Config) *config.IPsecConfig {
 	}
 	for name, pol := range src.IKEPolicies {
 		cp := *pol
+		// #3904: Proposals is a slice; clone it so a runtime mutation of the
+		// returned deep copy never aliases the active config tree.
+		if pol.Proposals != nil {
+			cp.Proposals = append([]string(nil), pol.Proposals...)
+		}
 		out.IKEPolicies[name] = &cp
 	}
 	for name, gw := range src.Gateways {
@@ -495,6 +500,10 @@ func PrepareConfig(cfg *config.Config) *config.IPsecConfig {
 	}
 	for name, pol := range src.Policies {
 		cp := *pol
+		// #3904: clone the Proposals slice (see IKEPolicies above).
+		if pol.Proposals != nil {
+			cp.Proposals = append([]string(nil), pol.Proposals...)
+		}
 		out.Policies[name] = &cp
 	}
 	for name, vpn := range src.VPNs {

--- a/pkg/ipsec/swanctl_render_test.go
+++ b/pkg/ipsec/swanctl_render_test.go
@@ -277,7 +277,7 @@ func TestProposalBuilders_ECPGroupAcrossAllSites(t *testing.T) {
 		// carries the configured PFS group onto a conservative proposal.
 		cfg := &config.IPsecConfig{
 			Policies: map[string]*config.IPsecPolicyDef{
-				"pol1": {Name: "pol1", PFSGroup: gc.group, Proposals: "missing-prop"},
+				"pol1": {Name: "pol1", PFSGroup: gc.group, Proposals: []string{"missing-prop"}},
 			},
 		}
 		vpn := &config.IPsecVPN{IPsecPolicy: "pol1"}


### PR DESCRIPTION
Closes #3904

Four sibling findings of the #2419 / #3872 bracket-list-truncation class
(fable-review-161 F-040/F-161/F-162/F-163) that the earlier #2587 / #3703
sweeps never reached. Each leaf kept a scalar reader that dropped every
bracketed value past the first. Same mechanism as #2419: make the schema
leaf `multi: true` where declared and read ALL values (`Keys[1:]` +
child nodes) via the `firewallMatchValues` SSOT.

## F-040 / F-161 — IKE/IPsec `proposals [ p1 p2 ]` (crypto-negotiation narrowing)

`security ike policy … proposals` / `security ipsec policy … proposals`
offered only the first proposal — a peer requiring the second could not
establish.

- Schema: both `proposals` leaves → `args: 1, multi: true`
  (`schema_security.go`).
- Types: `IKEPolicy.Proposals` and `IPsecPolicyDef.Proposals` widened
  scalar `string` → `[]string` (`types_security.go`). Config is persisted
  as the Junos AST and recompiled on load, so there is no on-disk /
  HA-sync migration.
- Compiler reads accumulate every reference via `firewallMatchValues`
  (`compiler_ipsec.go`).
- strongSwan generator (`pkg/ipsec/ike.go`) renders every resolvable
  proposal comma-joined into the swanctl `proposals =` / `esp_proposals =`
  line; `hasIKEChain` + the strict validators resolve the chain if ANY
  listed proposal is defined (mirroring the renderer's resolvable-subset
  behaviour, preserving the #2270 / #2073 fail-closed contract).
- Display (`pkg/cli`, `pkg/grpcapi`) + `PrepareConfig` deep-copy (slice
  clone) updated.

## F-162 — RIP `group … export [ a b ]` / `redistribute [ static direct ]`

Both compiler arms accumulate into `RIPConfig.Redistribute` via
`firewallMatchValues` (`compiler_protocols.go`); the top-level
`redistribute` leaf becomes `multi: true` (`schema_routing.go`). The RIP
`group` node stays `children: nil` (permissive; the `export` bracket
already collapses onto its Keys). The FRR renderer already loops
`rip.Redistribute`, so no render change was needed.

## F-163 — routing-instance `interface [ i1 i2 ]` (VRF isolation break)

`compileRoutingInstances` reads every port via `firewallMatchValues`
(`compiler_routing.go`); the remaining ports previously stayed in the
DEFAULT table. No schema or type change — `interface` is an implicit leaf
under the routing-instances wildcard (bracket already collapses onto its
Keys) and `Interfaces` was already `[]string`.

## Validation

- RED-on-revert proven per finding (simulating the old first-only read
  makes the new tests fail): compile-level + end-to-end swanctl render for
  the proposals; compile-level for RIP and routing-instance.
- Single-value + hierarchical/repeated-line forms still compile to the
  right set; SchemaValidate accepts the bracket configs.
- New tests: `multivalue_proposals_3904_test.go` (pkg/config + pkg/ipsec),
  `multivalue_rip_3904_test.go`, `multivalue_routing_instance_3904_test.go`.
- `go build ./...` clean; `go test ./pkg/config/... ./pkg/ipsec/...
  ./pkg/frr/... ./pkg/cli/... ./pkg/grpcapi/...` green; gofmt + vet clean.
- `docs/config-schema.md` updated (new #3904 multi-value section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi