### PR TITLE
userspace-dp: keep SYN-cookie master key out of world-readable state.json (#3909)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29165,3 +29165,38 @@ top.
   pkg/config/freetext_test.go (RED-on-revert injection + reject +
   helper tests), pkg/configstore/store_test.go
   (TestAnnotateRejectsCommentDelimiter), docs/phases.md (#3900 note)
+
+## 2026-07-03
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3909 — keep the SYN-cookie master key out of the
+  world-readable state.json (secret exposure, MEDIUM). The helper persists
+  a JSON snapshot of `ServerState` to `state.json` via
+  `server::helpers::write_state`; that file is created with the process
+  umask (world-readable 0644). `ConfigSnapshot::syn_cookie_master_key` was
+  serialized into it in plaintext — a local unprivileged user could read
+  the master key, forge valid SYN cookies, and defeat SYN-flood source
+  validation. WG private keys / PSKs already avoid this via
+  `#[serde(skip_serializing)]`; mirror that exactly. FINDING: the key is
+  DETERMINISTIC, not random — the Go control plane derives it from the
+  cluster-synced root secret + cluster-id + screened zones
+  (`buildSYNCookieMasterKey`, pkg/dataplane/userspace/screens.go) and
+  re-delivers it on every config push via `apply_snapshot`.
+  `ServerState.snapshot` starts `None` on boot and is never restored from
+  `state.json`, so the control plane always re-supplies the key after a
+  restart — no Rust-side regeneration needed. A fresh random per-boot key
+  would BREAK HA (both chassis must derive the identical key for
+  cross-node cookie validation across failover), so skip-serialize +
+  control-plane re-delivery is the correct fix, not regenerate-on-boot.
+  Verified no OTHER secret leaks into the snapshot the same way — only
+  wg_local_privkey_hex, wg_preshared_key_hex (both already
+  skip_serializing), and this key. RED-on-revert: removing
+  `skip_serializing` makes `syn_cookie_master_key_is_skipped_in_state_snapshot`
+  go RED (field name + key bytes reappear in the serialized snapshot).
+  Full cargo test --release green; go build ./... clean.
+- **File(s)**: userspace-dp/src/protocol/snapshot.rs (skip_serializing +
+  doc), userspace-dp/src/protocol/tests.rs
+  (syn_cookie_master_key_is_skipped_in_state_snapshot RED-on-revert +
+  control-socket-delivery decode), userspace-dp/src/afxdp/forwarding_build/tests.rs
+  (syn_cookie_master_key_from_snapshot_reaches_forwarding_state),
+  docs/syn-cookie-flood-protection.md (on-disk state hygiene section)

--- a/docs/syn-cookie-flood-protection.md
+++ b/docs/syn-cookie-flood-protection.md
@@ -302,6 +302,33 @@ omits the key and fails closed instead of minting predictable cookies; config
 validation also warns and userspace capability admission refuses active
 SYN-cookie screen profiles until the secret exists.
 
+### On-disk state hygiene: the master key is never persisted (#3909)
+
+The SYN-cookie master key is the secret that makes minted cookies
+unforgeable — the source-validation check hashes a returning ACK against
+it. The helper persists a JSON snapshot of its `ServerState` to
+`state.json` (via `server::helpers::write_state`), and that file is
+created with the process umask (world-readable, mode 0644). The master
+key therefore carries `#[serde(skip_serializing)]` on
+`ConfigSnapshot::syn_cookie_master_key`, exactly like the WireGuard
+private key (`wg_local_privkey_hex`) and per-peer PSK
+(`wg_preshared_key_hex`), so it is NEVER written into that world-readable
+file. A local unprivileged user who could read the key would be able to
+forge valid SYN cookies and defeat source validation.
+
+No Rust-side regeneration is needed: the key is deterministic — the Go
+control plane derives it from the cluster-synced root secret + cluster-id
++ screened zones (`buildSYNCookieMasterKey`,
+`pkg/dataplane/userspace/screens.go`) and re-delivers it on every config
+push over the control socket (`apply_snapshot`). `ServerState.snapshot`
+starts `None` on boot and is never restored from `state.json`, so the
+control plane always supplies the key after a restart. A fresh random
+per-boot key would instead break HA: both chassis must derive the SAME
+key for cross-node cookie validation to survive failover. The
+skip-serialize omission is pinned by
+`syn_cookie_master_key_is_skipped_in_state_snapshot`
+(`userspace-dp/src/protocol/tests.rs`).
+
 Cookie replies are host-generated flood-control frames. They intentionally
 bypass output filters, CoS classification, DSCP rewrite, and mirroring, matching
 the legacy eBPF `XDP_TX` behavior instead of treating replies as forwarded

--- a/userspace-dp/src/afxdp/forwarding_build/tests.rs
+++ b/userspace-dp/src/afxdp/forwarding_build/tests.rs
@@ -69,6 +69,30 @@ fn parse_syn_cookie_master_key_rejects_malformed_keys() {
     }
 }
 
+// #3909: the SYN-cookie master key is `skip_serializing` (kept out of the
+// world-readable state.json), but it is STILL delivered on the control socket
+// via `apply_snapshot` and must reach the dataplane so source validation
+// functions. This asserts that a snapshot carrying the key (the control-plane
+// delivery path — i.e. the post-restart re-push) produces a live
+// `syn_cookie_master_key` in the forwarding state. A valid key present here is
+// what makes the SYN-cookie source-validation check work.
+#[test]
+fn syn_cookie_master_key_from_snapshot_reaches_forwarding_state() {
+    let snapshot = ConfigSnapshot {
+        syn_cookie_master_key: "00112233445566778899aabbccddeeff".into(),
+        ..Default::default()
+    };
+    let state = build_forwarding_state(&snapshot);
+    assert_eq!(
+        state.syn_cookie_master_key,
+        Some([
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+            0xee, 0xff,
+        ]),
+        "control-plane-delivered key must reach the dataplane for source validation"
+    );
+}
+
 #[test]
 fn forwarding_state_refresh_preserves_three_color_runtime_state() {
     let policy_counters = PolicyCounterStore::default();

--- a/userspace-dp/src/protocol/snapshot.rs
+++ b/userspace-dp/src/protocol/snapshot.rs
@@ -302,7 +302,31 @@ pub(crate) struct ConfigSnapshot {
     /// these zones; the verdict still stays Pass.
     #[serde(rename = "screen_missing_profile_zones", default)]
     pub screen_missing_profile_zones: Vec<ScreenMissingProfileRef>,
-    #[serde(rename = "syn_cookie_master_key", default)]
+    /// SYN-cookie master key, hex-encoded (32 chars for 16 bytes). This
+    /// is the secret that makes XDP-generated SYN-ACK cookies unforgeable
+    /// — the source-validation check hashes the incoming ACK against it.
+    ///
+    /// SECRET: this field is intentionally `skip_serializing`, exactly
+    /// like `wg_local_privkey_hex` / `wg_preshared_key_hex`. The helper
+    /// persists a JSON snapshot of `ServerState` to `state.json` via
+    /// `server::helpers::write_state`, and that file is created with the
+    /// process umask (world-readable 0644). A local unprivileged user who
+    /// could read the key would be able to forge valid SYN cookies and
+    /// defeat SYN-flood source validation (#3909). `skip_serializing`
+    /// keeps the key off disk while deserialization (control-socket
+    /// delivery via `apply_snapshot`) still populates it through the
+    /// `default` path.
+    ///
+    /// No Rust-side regeneration is needed or wanted: the key is
+    /// DETERMINISTIC — the Go control plane derives it from the root
+    /// secret + cluster-id + screened zones (`buildSYNCookieMasterKey`,
+    /// pkg/dataplane/userspace/screens.go) and re-delivers it on every
+    /// config push. `ServerState.snapshot` starts `None` on boot and is
+    /// never restored from `state.json`, so the control plane always
+    /// supplies the key. A fresh random per-boot key would instead break
+    /// HA: both chassis must derive the SAME key for cross-node SYN-cookie
+    /// validation to survive failover.
+    #[serde(rename = "syn_cookie_master_key", default, skip_serializing)]
     pub syn_cookie_master_key: String,
     #[serde(default)]
     pub filters: Vec<FirewallFilterSnapshot>,

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1401,7 +1401,14 @@ fn syn_cookie_master_key_is_skipped_in_state_snapshot() {
     // Control-socket delivery (apply_snapshot) still populates the key via the
     // `default` path, so a valid key is present after a restart re-push — SYN
     // cookie source validation keeps working.
-    let with_key = r#"{"syn_cookie_master_key":"00112233445566778899aabbccddeeff"}"#;
+    let with_key = r#"{
+        "version": 3,
+        "generation": 1,
+        "generated_at": "2024-01-01T00:00:00Z",
+        "summary": {"host_name":"h","dataplane_type":"userspace","interface_count":0,
+                    "zone_count":0,"policy_count":0,"scheduler_count":0,"ha_enabled":false},
+        "syn_cookie_master_key": "00112233445566778899aabbccddeeff"
+    }"#;
     let parsed: ConfigSnapshot = serde_json::from_str(with_key).expect("decode snapshot with key");
     assert_eq!(
         parsed.syn_cookie_master_key, "00112233445566778899aabbccddeeff",

--- a/userspace-dp/src/protocol/tests.rs
+++ b/userspace-dp/src/protocol/tests.rs
@@ -1372,6 +1372,43 @@ fn config_snapshot_decodes_without_app_catalog() {
         "snapshot without app_catalog must decode to an empty catalog (HA/upgrade compat)");
 }
 
+// #3909 (MEDIUM, secret exposure): the SYN-cookie master key is the secret
+// that makes XDP-generated SYN-ACK cookies unforgeable. It must be
+// `skip_serializing`, exactly like the WireGuard private key / PSK, so it never
+// lands in `state.json` (written world-readable 0644 by write_state). A local
+// unprivileged reader of that file could otherwise forge valid SYN cookies and
+// defeat SYN-flood source validation.
+//
+// FAIL-ON-REVERT: remove `skip_serializing` from
+// ConfigSnapshot::syn_cookie_master_key and this test goes RED — the field name
+// and the key bytes reappear in the serialized world-readable snapshot.
+#[test]
+fn syn_cookie_master_key_is_skipped_in_state_snapshot() {
+    let snap = ConfigSnapshot {
+        syn_cookie_master_key: "0badc0ffee0badc0ffee0badc0ffee42".into(),
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&snap).expect("serialize snapshot");
+    assert!(
+        !json.contains("syn_cookie_master_key"),
+        "syn_cookie_master_key field must be skip_serializing, got: {json}"
+    );
+    assert!(
+        !json.contains("0badc0ffee"),
+        "syn_cookie_master_key value must not appear in the world-readable snapshot"
+    );
+
+    // Control-socket delivery (apply_snapshot) still populates the key via the
+    // `default` path, so a valid key is present after a restart re-push — SYN
+    // cookie source validation keeps working.
+    let with_key = r#"{"syn_cookie_master_key":"00112233445566778899aabbccddeeff"}"#;
+    let parsed: ConfigSnapshot = serde_json::from_str(with_key).expect("decode snapshot with key");
+    assert_eq!(
+        parsed.syn_cookie_master_key, "00112233445566778899aabbccddeeff",
+        "control-plane delivery must still populate the key on deserialize"
+    );
+}
+
 // #2214 (HIGH, #1961-class): a NAT64 rule with no resolvable source pool makes
 // the Go builder emit `pool_addresses:null` (nil slice, no `,omitempty`). Plain
 // `#[serde(default)]` only fills an ABSENT key; an explicit null is still handed

--- a/userspace-dp/tests/fixtures/protocol_wire_v1.json
+++ b/userspace-dp/tests/fixtures/protocol_wire_v1.json
@@ -300,7 +300,6 @@
       "scheduler_count": 0,
       "zone_count": 0
     },
-    "syn_cookie_master_key": "",
     "three_color_policers": [],
     "tunnel_endpoints": [],
     "userspace": null,


### PR DESCRIPTION
Closes #3909

## Problem

The userspace-dp helper persists a JSON snapshot of its `ServerState` to
`state.json` via `server::helpers::write_state`. That file is created with the
process umask (world-readable, mode 0644). `ConfigSnapshot::syn_cookie_master_key`
was serialized into it in plaintext.

That key is the secret that makes XDP-generated SYN-ACK cookies unforgeable — the
source-validation check hashes a returning ACK against it. A local unprivileged
user who read `state.json` learned the master key, could forge valid SYN cookies,
and thereby defeat SYN-flood source validation (fable-review-161 F-087, MEDIUM).

The WireGuard private key (`wg_local_privkey_hex`) and per-peer PSK
(`wg_preshared_key_hex`) already avoid exactly this via `#[serde(skip_serializing)]`.

## Fix

Add `#[serde(skip_serializing)]` to `syn_cookie_master_key`
(`userspace-dp/src/protocol/snapshot.rs:329`), mirroring the WG keys, so it is
never written into the world-readable snapshot. Deserialization (control-socket
delivery via `apply_snapshot`) still populates it through the existing `default`
path.

### Why skip-serialize + control-plane re-delivery, not regenerate-on-boot

The key is **deterministic**, not random: the Go control plane derives it from the
cluster-synced root secret + cluster-id + screened zones (`buildSYNCookieMasterKey`,
`pkg/dataplane/userspace/screens.go`) and re-delivers it on every config push.
`ServerState.snapshot` starts `None` on boot and is **never** restored from
`state.json`, so the control plane always re-supplies the key after a restart — no
Rust-side regeneration is needed.

A fresh **random** per-boot key (the issue's fallback suggestion) would actively
break HA: both chassis must derive the **identical** key for cross-node SYN-cookie
validation to survive failover. So a stable key IS required, and it is already
provided by the deterministic control-plane derivation. Skip-serialize keeps it off
disk without any regeneration.

### Other secrets audited

The only crypto secrets in the snapshot are `wg_local_privkey_hex`,
`wg_preshared_key_hex` (both already `skip_serializing`), and this key. The other
`*_key` / `*_token` matches are GRE tunnel identifiers and counters, not secrets.
No further leak of this class found.

## Tests

- **`syn_cookie_master_key_is_skipped_in_state_snapshot`** (`protocol/tests.rs`) —
  RED-on-revert: dropping `skip_serializing` makes the field name and key bytes
  reappear in the serialized world-readable snapshot and this test fails (proven
  locally: serialization emits `"syn_cookie_master_key":"<bytes>"` under revert).
  Also asserts the control-socket decode path still populates the key so validation
  works after a restart.
- **`syn_cookie_master_key_from_snapshot_reaches_forwarding_state`**
  (`afxdp/forwarding_build/tests.rs`) — the control-plane-delivered key reaches the
  dataplane forwarding state, i.e. source validation still functions post-restore.
- `protocol_wire_v1.json` regenerated: the default specimen now omits the field
  (previously emitted as `""`), matching Go's `omitempty` wire behavior. Diff is
  exactly the one removed line.

Full `cargo test --release`: **3524 passed / 0 failed**. `go build ./...` clean.

Doc: `docs/syn-cookie-flood-protection.md` gains an "On-disk state hygiene"
subsection recording the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi