### PR TITLE
cluster-sync: record pendingBulkAckEpoch before writing BulkEnd (fix bulk-ack TOCTOU that blocks manual failover)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,39 @@
+## 2026-07-03 — #3912: cluster-sync bulk-ack TOCTOU — pendingBulkAckEpoch stored AFTER BulkEnd write → early ack latches a phantom pending epoch that blocks manual failover
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-025 (MEDIUM, HA — permanently blocks manual
+    failover). In `pkg/cluster/sync_bulk.go`, `BulkSync` (and the empty-marker
+    `sendBulkMarkers` path) stored `pendingBulkAckEpoch` AFTER writing the
+    `BulkEnd` marker to the wire. `BulkEnd` solicits the peer's `BulkAck`,
+    which is processed on the read goroutine (`handleMessage`,
+    `syncMsgBulkAck`) independently of the send goroutine. A peer that acked
+    faster than the send goroutine could record the pending epoch had its ack
+    processed against `pendingBulkAckEpoch == 0` — the ack handler's
+    `pending != 0` guard dropped it — and only then did the send goroutine
+    latch the epoch → a phantom pending epoch that no future ack ever clears →
+    the failover readiness gate waits on an outbound bulk ack that already
+    arrived → `request chassis cluster failover` blocked indefinitely.
+  - **Fix**: Record `pendingBulkAckEpoch`/`pendingBulkAckSince` BEFORE the
+    `BulkEnd` write (record-then-send, mirroring the #2170/#2198 gen-guard
+    discipline). An early ack can now only observe the pending epoch already
+    in place, so it clears it regardless of arrival timing. On a `BulkEnd`
+    write failure the epoch resets to 0 (handleDisconnect also clears), so a
+    failed send cannot leave the pending state falsely armed. Both the full
+    `BulkSync` path and the `sendBulkMarkers` empty-marker path corrected.
+  - **Test**: `TestBulkSyncPendingAckRecordedBeforeBulkEnd` — a mock conn
+    (`ackOnBulkEndConn`) synchronously feeds `BulkAck` back through
+    `handleMessage` the instant `BulkEnd` is written (the TOCTOU); asserts no
+    phantom pending epoch is latched. RED-on-revert verified (store-after-write
+    latches epoch 1 → failover would block). `TestBulkSyncPendingAckClearedByLaterAck`
+    confirms the normal (ack-after-store) barrier flow still clears.
+    Full `go test ./pkg/cluster/...` green (incl. -race on the bulk tests).
+  - **File(s)**: `pkg/cluster/sync_bulk.go`, `pkg/cluster/sync_test.go`,
+    `docs/session-sync-architecture.md`, `docs/sync-protocol.md`, `_Log.md`
+  - **Validation**: `go build ./...`, `gofmt`, `go vet ./pkg/cluster/...`,
+    `go test ./pkg/cluster/...`. test-failover WARRANTED (HA manual-failover
+    path) — batched with the other HA-Medium fixes under the
+    force-node0-primary gate.
+
 ## 2026-07-03 — #3902: flowless screen path bypassed the source-independent screens (LAND, ip-source-route, ICMP/UDP flood) — fail-open on non-query ICMP + non-first fragments
 
 - **Timestamp**: 2026-07-03

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -141,12 +141,30 @@ the new bulk is sent.
 4. skips reverse entries
 5. skips sessions not owned by this node for the ingress zone
 6. sends forward entries only
-7. sends `BulkEnd(epoch)`
-8. records `pendingBulkAckEpoch` and waits for peer acknowledgement
+7. records `pendingBulkAckEpoch` (**before** the `BulkEnd` write)
+8. sends `BulkEnd(epoch)` and then waits for peer acknowledgement
 
 The sender now treats outbound bulk acknowledgement as first-class state. A
 bulk transfer is not considered fully primed until the peer returns `BulkAck`
 for the current epoch.
+
+**Record-then-send ordering (#3912).** `pendingBulkAckEpoch` must be stored
+*before* the `BulkEnd` marker is written to the wire, not after. `BulkEnd` is
+what solicits the peer's `BulkAck`, and the ack is processed on the read
+goroutine (`handleMessage`, `syncMsgBulkAck`) independently of the send
+goroutine. If the pending epoch were recorded *after* the write, a peer that
+acked faster than the send goroutine could record the pending state would have
+its ack processed against `pendingBulkAckEpoch == 0` — the ack handler's
+`pending != 0` guard drops it — and the send goroutine would then latch a
+phantom pending epoch that no future ack ever clears. A latched phantom epoch
+permanently blocks manual failover, because the readiness gate waits on an
+outbound bulk ack that already arrived. Recording first (mirroring the
+#2170/#2198 gen-guard record-then-send discipline) guarantees an early ack can
+only ever observe the pending epoch already in place, so it clears it
+regardless of arrival timing. On a `BulkEnd` write failure the epoch is reset
+to 0 (and `handleDisconnect` also clears it), so a failed send cannot leave the
+pending state falsely armed. The same ordering applies to the empty-marker
+`sendBulkMarkers` path used after event-stream export.
 
 ### Receive Side
 

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -315,11 +315,19 @@ Triggered once when the `connectLoop` successfully dials the peer:
 ```
 connectLoop() establishes TCP connection
   → BulkSync()
-    → writeMsg(BulkStart, nil)           // signal start
+    → writeMsg(BulkStart, epoch)         // signal start
     → IterateSessions(all v4)            // send every v4 session as SessionV4
     → IterateSessionsV6(all v6)          // send every v6 session as SessionV6
-    → writeMsg(BulkEnd, nil)             // signal complete
+    → record pendingBulkAckEpoch=epoch   // record-then-send (#3912): BEFORE BulkEnd
+    → writeMsg(BulkEnd, epoch)           // solicit peer BulkAck(epoch)
 ```
+
+The pending-ack epoch is recorded **before** the `BulkEnd` write, not after.
+`BulkEnd` solicits the peer's `BulkAck`, which is processed on the read
+goroutine; recording after the write races a fast peer whose ack would then
+latch a phantom pending epoch that never clears and permanently blocks manual
+failover (#3912). See `docs/session-sync-architecture.md` "Record-then-send
+ordering".
 
 Both forward and reverse entries are sent during bulk sync. The receiver calls `SetSessionV4/V6` to install each session directly into the BPF map.
 

--- a/pkg/cluster/sync_bulk.go
+++ b/pkg/cluster/sync_bulk.go
@@ -61,16 +61,24 @@ func (s *SessionSync) sendBulkMarkers() error {
 		return err
 	}
 
+	// Record the pending bulk-ack epoch BEFORE writing the BulkEnd marker
+	// (record-then-send, #3912 — same TOCTOU as BulkSync). The BulkEnd
+	// marker is what solicits the peer's ack; recording the pending epoch
+	// first guarantees the read goroutine cannot process an early ack
+	// against a not-yet-set pending epoch and leave a phantom latched.
+	s.pendingBulkAckEpoch.Store(epoch)
+	s.pendingBulkAckSince.Store(time.Now().UnixNano())
+
 	s.writeMu.Lock()
 	err = writeMsg(conn, syncMsgBulkEnd, epochBuf[:])
 	s.writeMu.Unlock()
 	if err != nil {
+		s.pendingBulkAckEpoch.Store(0)
+		s.pendingBulkAckSince.Store(0)
 		s.handleDisconnect(conn)
 		return err
 	}
 
-	s.pendingBulkAckEpoch.Store(epoch)
-	s.pendingBulkAckSince.Store(time.Now().UnixNano())
 	s.stats.BulkSyncs.Add(1)
 	slog.Info("cluster sync: bulk markers sent", "epoch", epoch)
 	return nil
@@ -192,6 +200,20 @@ func (s *SessionSync) BulkSync() error {
 		"sessions", count,
 		"skipped", skipped)
 
+	// Record the pending bulk-ack epoch BEFORE writing the BulkEnd marker
+	// to the wire (record-then-send, mirroring the #2170/#2198 gen-guard
+	// discipline). The peer's ack is processed on the read goroutine
+	// (handleMessage, syncMsgBulkAck), which is independent of this send
+	// goroutine. If we stored the pending epoch AFTER the write, a fast
+	// peer could ack the BulkEnd and have the read goroutine process the
+	// ack (seeing pendingBulkAckEpoch==0, so it drops it) before this
+	// goroutine recorded the pending state. We would then latch a phantom
+	// pending epoch that no future ack ever clears — permanently blocking
+	// manual failover (#3912). Recording first guarantees the ack can only
+	// ever observe the pending epoch already in place.
+	s.pendingBulkAckEpoch.Store(epoch)
+	s.pendingBulkAckSince.Store(time.Now().UnixNano())
+
 	// Send bulk end marker with matching epoch.
 	slog.Info("cluster sync: bulk sync writing end marker", "epoch", epoch, "sessions", count, "skipped", skipped)
 	s.writeMu.Lock()
@@ -203,8 +225,6 @@ func (s *SessionSync) BulkSync() error {
 		s.handleDisconnect(conn)
 		return err
 	}
-	s.pendingBulkAckEpoch.Store(epoch)
-	s.pendingBulkAckSince.Store(time.Now().UnixNano())
 
 	s.stats.BulkSyncs.Add(1)
 	slog.Info("cluster sync: bulk sync complete", "sessions", count, "skipped", skipped, "epoch", epoch)

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -1629,6 +1629,102 @@ func TestBulkSyncSkipsReverseEntries(t *testing.T) {
 	}
 }
 
+// ackOnBulkEndConn simulates a peer that acks a BulkEnd the instant it lands
+// on the wire — the #3912 TOCTOU. When BulkSync writes the BulkEnd marker,
+// this conn synchronously feeds the matching BulkAck back through
+// handleMessage (the read-goroutine path), mimicking a peer that acks faster
+// than the send goroutine can record the pending epoch. If pendingBulkAckEpoch
+// is stored AFTER the write, the ack observes pending==0, drops it, and a
+// phantom pending epoch is latched that never clears.
+type ackOnBulkEndConn struct {
+	net.Conn
+	ss    *SessionSync
+	acked bool
+}
+
+func (c *ackOnBulkEndConn) SetDeadline(time.Time) error      { return nil }
+func (c *ackOnBulkEndConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *ackOnBulkEndConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *ackOnBulkEndConn) Write(b []byte) (int, error) {
+	if len(b) >= syncHeaderSize && string(b[0:4]) == "BPSY" && b[4] == syncMsgBulkEnd {
+		// Peer receives BulkEnd and immediately acks. The BulkEnd payload is
+		// the 8-byte epoch — reuse it directly as the BulkAck payload.
+		c.ss.handleMessage(c, syncMsgBulkAck, b[syncHeaderSize:])
+		c.acked = true
+	}
+	return len(b), nil
+}
+
+// TestBulkSyncPendingAckRecordedBeforeBulkEnd is the #3912 regression guard.
+// It drives a bulk sync whose peer acks the BulkEnd synchronously as it is
+// written. With record-then-send the pending epoch is already stored, so the
+// early ack clears it — no phantom latch. Reverting the fix (store after the
+// write) re-latches the phantom epoch and this test goes RED.
+func TestBulkSyncPendingAckRecordedBeforeBulkEnd(t *testing.T) {
+	dp := &mockSweepDP{
+		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{
+			{SrcIP: [4]byte{10, 0, 1, 1}, DstIP: [4]byte{10, 0, 2, 1}, Protocol: 6, SrcPort: 1000, DstPort: 80}: {
+				State: dataplane.SessStateEstablished, IsReverse: 0, IngressZone: 1,
+			},
+		},
+	}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.IsPrimaryFn = func() bool { return true }
+
+	conn := &ackOnBulkEndConn{ss: ss}
+	ss.mu.Lock()
+	ss.conn0 = conn
+	ss.mu.Unlock()
+
+	if err := ss.BulkSync(); err != nil {
+		t.Fatalf("BulkSync failed: %v", err)
+	}
+	if !conn.acked {
+		t.Fatal("test setup broken: BulkEnd was never written, no ack delivered")
+	}
+	// The immediate ack must have cleared the pending epoch. A latched phantom
+	// pending epoch here would permanently block manual failover (#3912).
+	if epoch, _, ok := ss.PendingBulkAck(); ok {
+		t.Fatalf("phantom pending bulk-ack epoch latched (%d) — manual failover would block (#3912 regression)", epoch)
+	}
+}
+
+// TestBulkSyncPendingAckClearedByLaterAck confirms the normal barrier flow is
+// intact: a pending epoch is armed by BulkSync and cleared by an ack that
+// arrives after the store (the common case, unaffected by the ordering fix).
+func TestBulkSyncPendingAckClearedByLaterAck(t *testing.T) {
+	dp := &mockSweepDP{
+		v4sessions: map[dataplane.SessionKey]dataplane.SessionValue{
+			{SrcIP: [4]byte{10, 0, 1, 1}, DstIP: [4]byte{10, 0, 2, 1}, Protocol: 6, SrcPort: 1000, DstPort: 80}: {
+				State: dataplane.SessStateEstablished, IsReverse: 0, IngressZone: 1,
+			},
+		},
+	}
+	ss := NewSessionSync(":0", "10.0.0.2:4785", dp)
+	ss.IsPrimaryFn = func() bool { return true }
+
+	cw := &countingWriter{}
+	ss.mu.Lock()
+	ss.conn0 = cw
+	ss.mu.Unlock()
+
+	if err := ss.BulkSync(); err != nil {
+		t.Fatalf("BulkSync failed: %v", err)
+	}
+	epoch, _, ok := ss.PendingBulkAck()
+	if !ok {
+		t.Fatal("expected a pending bulk-ack epoch after BulkSync with no ack yet")
+	}
+	// Peer acks the epoch afterward — this must clear the pending state.
+	var payload [8]byte
+	binary.LittleEndian.PutUint64(payload[:], epoch)
+	ss.handleMessage(cw, syncMsgBulkAck, payload[:])
+	if latched, _, stillOK := ss.PendingBulkAck(); stillOK {
+		t.Fatalf("pending bulk-ack epoch %d should be cleared after peer ack", latched)
+	}
+}
+
 func TestReconcileStaleSessions(t *testing.T) {
 	// Simulate: we're secondary for zone 2 (RG 2 owned by peer).
 	// We have 3 sessions in zone 2: sessionA, sessionB, sessionC.


### PR DESCRIPTION
Closes #3912

## Problem

In the bulk-sync barrier (`pkg/cluster/sync_bulk.go`), `BulkSync` and the
empty-marker `sendBulkMarkers` path stored `pendingBulkAckEpoch` **after**
writing the `BulkEnd` marker to the wire.

`BulkEnd` is what solicits the peer's `BulkAck`. The ack is processed on the
read goroutine (`handleMessage`, `syncMsgBulkAck`), which is independent of the
send goroutine. A peer that acked the `BulkEnd` faster than the send goroutine
could store the pending epoch had its ack processed against
`pendingBulkAckEpoch == 0` — the ack handler's `pending != 0 && epoch >= pending`
guard dropped it — and only *then* did the send goroutine latch the epoch:

```
send goroutine                 read goroutine (peer ack)
  writeMsg(BulkEnd, epoch) ───► peer receives BulkEnd
                                sends BulkAck(epoch)
                          ◄───  handleMessage(BulkAck): pending==0 → DROP
  store pendingBulkAckEpoch=epoch   (phantom latched, no future ack)
```

The result is a phantom pending-bulk-ack epoch that no future ack ever clears
(the only ack for that epoch already came and went). The failover readiness
gate then waits forever on an outbound bulk ack that already arrived →
`request chassis cluster failover` is refused / hangs indefinitely.

## Fix

Record `pendingBulkAckEpoch`/`pendingBulkAckSince` **before** writing the
`BulkEnd` marker — record-then-send, mirroring the #2170/#2198 gen-guard
ordering discipline. An early ack can now only ever observe the pending epoch
already in place, so it clears it correctly regardless of arrival timing:

- ack that arrives after the store → clears it (normal case, unchanged);
- ack that arrived "early" (synchronously as `BulkEnd` lands) → still observes
  the already-stored pending epoch and clears it → no phantom latch.

On a `BulkEnd` write failure the epoch is reset to 0 (and `handleDisconnect`
also clears it), so a failed send cannot leave the pending state falsely armed.
Both the full `BulkSync` path (cited defect site, line ~206) and the
`sendBulkMarkers` empty-marker path (used after event-stream export) had the
identical store-after-write ordering and are both corrected.

`pendingBulkAckEpoch` is an atomic; the store/load across the two goroutines is
already race-safe — the bug was purely the *ordering* of the store relative to
the wire write, which record-then-send fixes.

## Test / RED-on-revert

- `TestBulkSyncPendingAckRecordedBeforeBulkEnd` — a mock conn
  (`ackOnBulkEndConn`) synchronously feeds `BulkAck` back through
  `handleMessage` the instant `BulkEnd` is written (the TOCTOU); asserts no
  phantom pending epoch remains. **RED-on-revert verified**: restoring the old
  store-after-write ordering latches phantom epoch 1 and the test fails with
  "phantom pending bulk-ack epoch latched (1) — manual failover would block".
- `TestBulkSyncPendingAckClearedByLaterAck` — confirms the normal
  (ack-after-store) barrier flow still clears the pending epoch.
- `go test ./pkg/cluster/...` green (incl. `-race` on the bulk tests);
  `go build ./...`, `gofmt`, `go vet ./pkg/cluster/...` clean.

## Docs

`docs/session-sync-architecture.md` (send-side sequence + new "Record-then-send
ordering" note) and `docs/sync-protocol.md` (bulk-sync pseudo-sequence)
document the ordering invariant; `_Log.md` records the fix.

test-failover WARRANTED (HA manual-failover path) — batch-validate under the
force-node0-primary gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
