### PR TITLE
config/nat: accumulate all duplicate NAT sub-blocks in compileNAT (#3915)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29235,3 +29235,15 @@ top.
   leaf, no schema change needed).
 - **File(s)**: pkg/config/compiler_routing.go,
   pkg/config/compiler_routing_instance_interface_3904_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-07-03
+- **Action**: #3915 (F-158) — compileNAT accumulates ALL duplicate NAT
+  sub-blocks. Each source/destination/static/nat64/natv6v4/proxy-arp block
+  under a `nat {}` node was read FindChild-first, so a `load override`/`merge`
+  second block (e.g. a 2nd `source {}` with extra rule-sets) was SILENTLY
+  DROPPED -> SNAT/DNAT vanished, traffic egressed untranslated. Converted all
+  six sub-block reads to iterate via forEachChild; sub-block compilers already
+  append rule-sets + map-assign pools, so per-block invocation merges (Junos
+  semantics), single-block bit-identical. natv6v4 inits struct once + ORs flag.
+- **File(s)**: pkg/config/compiler_nat.go,
+  pkg/config/compiler_nat_dup_subblock_3915_test.go, docs/config-schema.md

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -1620,6 +1620,33 @@ reserved for whole-dataplane selection where a rewrite shim
   unsupported-modifier #3114 rejection incl. the lenient-warn surface, split
   required dimensions merged, single-block regression guard — built with
   `NewParser` for the `LoadOverride` shape).
+- **#3915 (the NAT-node analogue of #3842 — duplicate `source`/`destination`/
+  `static`/`nat64`/`natv6v4`/`proxy-arp` blocks UNDER ONE `nat {}` node):**
+  `compileNAT` (`compiler_nat.go`) read each of these six sub-blocks with
+  `node.FindChild(<name>)` (FIRST match only). `parseStatements` appends a
+  repeated hierarchical block as a sibling at EVERY level, so a
+  `LoadMerge`/`LoadOverride` that produced a SECOND `source {}` (or
+  `destination`/`static`/`nat64`/`proxy-arp`) block under one `nat {}` had that
+  block's rule-sets SILENTLY DROPPED — the SNAT/DNAT/static rule-set vanished
+  and traffic that should have been translated egressed UNtranslated (a NAT
+  bypass / connectivity break) with a clean commit. The fix iterates EVERY
+  same-named sub-block via the shared `forEachChild(node.Children, <name>, fn)`
+  primitive. Each sub-block compiler (`compileNATSource` / `compileNATDestination`
+  / `compileNATStatic` / `compileNAT64` and the inline proxy-arp loop) already
+  APPENDS its rule-sets (`sec.NAT.Source` / `Destination.RuleSets` / `Static` /
+  `NAT64` / `ProxyARP`) and map-assigns its pools, so invoking it once per
+  duplicate block MERGES the blocks exactly as Junos merges duplicate
+  hierarchical stanzas; with a single block the callback fires exactly once,
+  bit-identical to the prior `FindChild` read. `natv6v4` additionally
+  initializes its struct once and ORs the flag so a second block cannot reset an
+  already-observed `no-v6-frag-header`. This is the sub-block-level sibling of
+  #3444/#3562 (which fixed the `security`/`nat`/`destination` CONTAINER levels of
+  the DNAT-`to` strict gate) and of #3842 (the same defect at the policy
+  `match`/`then` level). Regression coverage:
+  `pkg/config/compiler_nat_dup_subblock_3915_test.go` (per-sub-block merge
+  RED-on-revert for source/destination/static/nat64/proxy-arp, pool merge,
+  single-block bit-identical guard — built with `NewParser` for the
+  `LoadOverride` dup-block shape, driving `compileNAT` directly).
 - **#3473 (duplicate security-policy names — strict commit gate):**
   `validateDuplicatePolicyNamesStrict` (`compiler_validate_strict.go`)
   hard-rejects two security policies that share a name within the same

--- a/pkg/config/compiler_nat.go
+++ b/pkg/config/compiler_nat.go
@@ -785,46 +785,75 @@ func compileNAT(node *Node, sec *SecurityConfig) error {
 		sec.NAT.SourcePools = make(map[string]*NATPool)
 	}
 
-	srcNode := node.FindChild("source")
-	if srcNode != nil {
+	// #3915: iterate EVERY source/destination/static/nat64/natv6v4/proxy-arp
+	// sub-block under this nat{} node, not just the FIRST. The Junos parser
+	// APPENDS a repeated hierarchical block as a sibling (parseStatements,
+	// parser.go) instead of merging it, so `load override`/`load merge` can
+	// produce a second `source {}` (or destination/static/nat64/proxy-arp)
+	// block carrying additional rule-sets. The prior FindChild-first read
+	// compiled only the first block and SILENTLY DROPPED the second block's
+	// rule-sets -> the SNAT/DNAT/static rule-set vanished and traffic that
+	// should have been translated egressed untranslated (a NAT bypass /
+	// connectivity break). Each sub-block compiler APPENDS its rule-sets
+	// (sec.NAT.Source / Destination.RuleSets / Static / NAT64 / ProxyARP) and
+	// map-assigns its pools, so invoking it once per duplicate block MERGES the
+	// blocks exactly as Junos merges duplicate hierarchical stanzas. With a
+	// single block the callback fires exactly once, bit-identical to the prior
+	// FindChild read. Mirrors the #3842 policy dup-block accumulate fix and the
+	// #3444/#3562 forEachChild dup-block-bypass class.
+	if err := forEachChild(node.Children, "source", func(srcNode *Node) error {
 		if err := compileNATSource(srcNode, sec); err != nil {
 			return fmt.Errorf("source: %w", err)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
-	dstNode := node.FindChild("destination")
-	if dstNode != nil {
+	if err := forEachChild(node.Children, "destination", func(dstNode *Node) error {
 		if err := compileNATDestination(dstNode, sec); err != nil {
 			return fmt.Errorf("destination: %w", err)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
-	staticNode := node.FindChild("static")
-	if staticNode != nil {
+	if err := forEachChild(node.Children, "static", func(staticNode *Node) error {
 		if err := compileNATStatic(staticNode, sec); err != nil {
 			return fmt.Errorf("static: %w", err)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
-	nat64Node := node.FindChild("nat64")
-	if nat64Node != nil {
+	if err := forEachChild(node.Children, "nat64", func(nat64Node *Node) error {
 		if err := compileNAT64(nat64Node, sec); err != nil {
 			return fmt.Errorf("nat64: %w", err)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
-	// natv6v4 { no-v6-frag-header; }
-	v6v4Node := node.FindChild("natv6v4")
-	if v6v4Node != nil {
-		sec.NAT.NATv6v4 = &NATv6v4Config{}
+	// natv6v4 { no-v6-frag-header; } — accumulate across duplicate blocks:
+	// initialize the struct once and OR the flag so a second natv6v4 block
+	// cannot silently reset an already-observed no-v6-frag-header.
+	if err := forEachChild(node.Children, "natv6v4", func(v6v4Node *Node) error {
+		if sec.NAT.NATv6v4 == nil {
+			sec.NAT.NATv6v4 = &NATv6v4Config{}
+		}
 		if v6v4Node.FindChild("no-v6-frag-header") != nil {
 			sec.NAT.NATv6v4.NoV6FragHeader = true
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	// proxy-arp { interface <name> { address <addr>; } }
-	proxyNode := node.FindChild("proxy-arp")
-	if proxyNode != nil {
+	if err := forEachChild(node.Children, "proxy-arp", func(proxyNode *Node) error {
 		for _, inst := range namedInstances(proxyNode.FindChildren("interface")) {
 			entry := &ProxyARPEntry{Interface: inst.name}
 			for _, prop := range inst.node.Children {
@@ -867,6 +896,9 @@ func compileNAT(node *Node, sec *SecurityConfig) error {
 			}
 			sec.NAT.ProxyARP = append(sec.NAT.ProxyARP, entry)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/config/compiler_nat_dup_subblock_3915_test.go
+++ b/pkg/config/compiler_nat_dup_subblock_3915_test.go
@@ -1,0 +1,402 @@
+package config
+
+import "testing"
+
+// #3915: compileNAT read each of the source / destination / static / nat64 /
+// natv6v4 / proxy-arp sub-blocks under a `nat {}` node with FindChild (first
+// match only). The Junos parser APPENDS a repeated hierarchical block as a
+// sibling (parseStatements) rather than merging it, so `load override` /
+// `load merge` can produce a second `source {}` (or destination/static/...)
+// block carrying additional rule-sets. FindChild-first compiled only the first
+// block and SILENTLY DROPPED the second block's rule-sets -> the SNAT/DNAT/
+// static rule-set vanished and traffic egressed untranslated. The fix iterates
+// EVERY same-named sub-block with forEachChild; each sub-block compiler already
+// APPENDS its rule-sets and map-assigns its pools, so the duplicate blocks
+// MERGE exactly as Junos merges duplicate hierarchical stanzas.
+//
+// These tests parse a real config (proving the parser emits the two sibling
+// sub-blocks), navigate to the single `nat` node, and call compileNAT directly
+// so they exercise the exact fix without CompileConfig's zone/policy
+// validation. Reverting compileNAT to FindChild-first drops the second block's
+// rule-set and every "both present" assertion goes RED.
+
+// natNodeFromText parses cfgText and returns the FIRST `security > nat` node.
+func natNodeFromText(t *testing.T, cfgText string) *Node {
+	t.Helper()
+	p := NewParser(cfgText)
+	tree, perrs := p.Parse()
+	if len(perrs) > 0 {
+		t.Fatalf("Parse: %v", perrs)
+	}
+	sec := tree.FindChild("security")
+	if sec == nil {
+		t.Fatalf("no security node parsed")
+	}
+	nat := sec.FindChild("nat")
+	if nat == nil {
+		t.Fatalf("no nat node parsed")
+	}
+	return nat
+}
+
+// countChildren returns how many direct children of nat have the given name.
+func countChildren(nat *Node, name string) int {
+	n := 0
+	for _, c := range nat.Children {
+		if c.Name() == name {
+			n++
+		}
+	}
+	return n
+}
+
+func hasSourceRuleSet(sec *SecurityConfig, name string) bool {
+	for _, rs := range sec.NAT.Source {
+		if rs.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDestRuleSet(sec *SecurityConfig, name string) bool {
+	if sec.NAT.Destination == nil {
+		return false
+	}
+	for _, rs := range sec.NAT.Destination.RuleSets {
+		if rs.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasStaticRuleSet(sec *SecurityConfig, name string) bool {
+	for _, rs := range sec.NAT.Static {
+		if rs.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCompileNATDuplicateSourceBlocksMerge is the primary RED-on-revert case:
+// two `source {}` blocks under one `nat {}`, the second adding rule-set RS2.
+// Both RS1 and RS2 must compile. FindChild-first drops RS2 -> RED (SNAT for the
+// second rule-set is missing and that traffic egresses untranslated).
+func TestCompileNATDuplicateSourceBlocksMerge(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS1 {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    then {
+                        source-nat interface;
+                    }
+                }
+            }
+        }
+        source {
+            rule-set RS2 {
+                from zone dmz;
+                to zone untrust;
+                rule R2 {
+                    then {
+                        source-nat interface;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	if got := countChildren(nat, "source"); got < 2 {
+		t.Fatalf("expected 2 `source` siblings under one nat (the bypass premise), got %d", got)
+	}
+
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	if !hasSourceRuleSet(sec, "RS1") {
+		t.Fatalf("first source block rule-set RS1 missing from compiled config")
+	}
+	if !hasSourceRuleSet(sec, "RS2") {
+		t.Fatalf("second source block rule-set RS2 SILENTLY DROPPED (#3915 dup-block bug); Source=%+v", sec.NAT.Source)
+	}
+	if len(sec.NAT.Source) != 2 {
+		t.Fatalf("expected exactly 2 source rule-sets after merge, got %d", len(sec.NAT.Source))
+	}
+}
+
+// TestCompileNATDuplicateDestinationBlocksMerge: two `destination {}` blocks,
+// the second adding pool P2 + rule-set RD2. Both DNAT rule-sets must compile.
+func TestCompileNATDuplicateDestinationBlocksMerge(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        destination {
+            pool P1 {
+                address 10.0.30.100;
+            }
+            rule-set RD1 {
+                from zone untrust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.1/32;
+                    }
+                    then {
+                        destination-nat pool P1;
+                    }
+                }
+            }
+        }
+        destination {
+            pool P2 {
+                address 10.0.30.200;
+            }
+            rule-set RD2 {
+                from zone untrust;
+                rule R2 {
+                    match {
+                        destination-address 198.51.100.2/32;
+                    }
+                    then {
+                        destination-nat pool P2;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	if got := countChildren(nat, "destination"); got < 2 {
+		t.Fatalf("expected 2 `destination` siblings under one nat, got %d", got)
+	}
+
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	if !hasDestRuleSet(sec, "RD1") {
+		t.Fatalf("first destination block rule-set RD1 missing")
+	}
+	if !hasDestRuleSet(sec, "RD2") {
+		t.Fatalf("second destination block rule-set RD2 SILENTLY DROPPED (#3915 dup-block bug)")
+	}
+	if sec.NAT.Destination == nil || len(sec.NAT.Destination.RuleSets) != 2 {
+		t.Fatalf("expected 2 destination rule-sets after merge, got %v", sec.NAT.Destination)
+	}
+	if _, ok := sec.NAT.Destination.Pools["P2"]; !ok {
+		t.Fatalf("second destination block pool P2 dropped")
+	}
+}
+
+// TestCompileNATDuplicateStaticBlocksMerge: two `static {}` blocks, the second
+// adding rule-set ST2. Both static rule-sets must compile.
+func TestCompileNATDuplicateStaticBlocksMerge(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        static {
+            rule-set ST1 {
+                from zone untrust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.10/32;
+                    }
+                    then {
+                        static-nat prefix 10.0.1.10/32;
+                    }
+                }
+            }
+        }
+        static {
+            rule-set ST2 {
+                from zone untrust;
+                rule R2 {
+                    match {
+                        destination-address 198.51.100.20/32;
+                    }
+                    then {
+                        static-nat prefix 10.0.1.20/32;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	if got := countChildren(nat, "static"); got < 2 {
+		t.Fatalf("expected 2 `static` siblings under one nat, got %d", got)
+	}
+
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	if !hasStaticRuleSet(sec, "ST1") {
+		t.Fatalf("first static block rule-set ST1 missing")
+	}
+	if !hasStaticRuleSet(sec, "ST2") {
+		t.Fatalf("second static block rule-set ST2 SILENTLY DROPPED (#3915 dup-block bug)")
+	}
+	if len(sec.NAT.Static) != 2 {
+		t.Fatalf("expected 2 static rule-sets after merge, got %d", len(sec.NAT.Static))
+	}
+}
+
+// TestCompileNATDuplicateNAT64BlocksMerge: two `nat64 {}` blocks, the second
+// adding rule-set N2.
+func TestCompileNATDuplicateNAT64BlocksMerge(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        nat64 {
+            rule-set N1 {
+                prefix 64:ff9b::/96;
+            }
+        }
+        nat64 {
+            rule-set N2 {
+                prefix 64:ff9b::/96;
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	if got := countChildren(nat, "nat64"); got < 2 {
+		t.Fatalf("expected 2 `nat64` siblings under one nat, got %d", got)
+	}
+
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	var names []string
+	for _, rs := range sec.NAT.NAT64 {
+		names = append(names, rs.Name)
+	}
+	has := func(n string) bool {
+		for _, s := range names {
+			if s == n {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("N1") || !has("N2") {
+		t.Fatalf("nat64 dup-block merge lost a rule-set; got %v (want N1 and N2)", names)
+	}
+}
+
+// TestCompileNATDuplicateProxyARPBlocksMerge: two `proxy-arp {}` blocks, the
+// second adding a second interface entry.
+func TestCompileNATDuplicateProxyARPBlocksMerge(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        proxy-arp {
+            interface ge-0/0/1.0 {
+                address 198.51.100.10/32;
+            }
+        }
+        proxy-arp {
+            interface ge-0/0/2.0 {
+                address 198.51.100.20/32;
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	if got := countChildren(nat, "proxy-arp"); got < 2 {
+		t.Fatalf("expected 2 `proxy-arp` siblings under one nat, got %d", got)
+	}
+
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	var ifaces []string
+	for _, e := range sec.NAT.ProxyARP {
+		ifaces = append(ifaces, e.Interface)
+	}
+	if len(ifaces) != 2 {
+		t.Fatalf("proxy-arp dup-block merge lost an entry; got %v (want 2 interfaces)", ifaces)
+	}
+}
+
+// TestCompileNATSingleBlockUnchanged pins bit-identical behaviour for the
+// common single-block case: exactly one source/destination/static block each
+// still yields exactly one rule-set, so the forEachChild conversion did not
+// regress the normal path.
+func TestCompileNATSingleBlockUnchanged(t *testing.T) {
+	cfgText := `
+security {
+    nat {
+        source {
+            rule-set RS1 {
+                from zone trust;
+                to zone untrust;
+                rule R1 {
+                    then {
+                        source-nat interface;
+                    }
+                }
+            }
+        }
+        destination {
+            pool P1 {
+                address 10.0.30.100;
+            }
+            rule-set RD1 {
+                from zone untrust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.1/32;
+                    }
+                    then {
+                        destination-nat pool P1;
+                    }
+                }
+            }
+        }
+        static {
+            rule-set ST1 {
+                from zone untrust;
+                rule R1 {
+                    match {
+                        destination-address 198.51.100.10/32;
+                    }
+                    then {
+                        static-nat prefix 10.0.1.10/32;
+                    }
+                }
+            }
+        }
+    }
+}
+`
+	nat := natNodeFromText(t, cfgText)
+	sec := &SecurityConfig{}
+	if err := compileNAT(nat, sec); err != nil {
+		t.Fatalf("compileNAT: %v", err)
+	}
+	if len(sec.NAT.Source) != 1 || !hasSourceRuleSet(sec, "RS1") {
+		t.Fatalf("single source block regressed: Source=%+v", sec.NAT.Source)
+	}
+	if sec.NAT.Destination == nil || len(sec.NAT.Destination.RuleSets) != 1 || !hasDestRuleSet(sec, "RD1") {
+		t.Fatalf("single destination block regressed: %+v", sec.NAT.Destination)
+	}
+	if len(sec.NAT.Static) != 1 || !hasStaticRuleSet(sec, "ST1") {
+		t.Fatalf("single static block regressed: Static=%+v", sec.NAT.Static)
+	}
+}


### PR DESCRIPTION
Closes #3915

## Problem

`compileNAT` (`pkg/config/compiler_nat.go`) read each of the
`source {}` / `destination {}` / `static {}` / `nat64 {}` / `natv6v4 {}` /
`proxy-arp {}` sub-blocks under a `nat {}` node with `node.FindChild(<name>)`
(FIRST match only). The Junos parser (`parseStatements`) APPENDS a repeated
hierarchical block as a sibling rather than merging it, so a
`load override` / `load merge` that produced a SECOND `source {}` (or
destination/static/nat64/proxy-arp) block carrying additional rule-sets had
that second block **silently dropped**. The lost rule-sets meant SNAT/DNAT/
static translations vanished and traffic that should have been translated
egressed **untranslated** — a NAT bypass / connectivity break, with a clean
commit and no operator feedback. `forEachChild` already existed in the file
but was unused here.

## Fix

Iterate EVERY same-named sub-block via the existing `forEachChild` helper
instead of `FindChild`-first. Each sub-block compiler already APPENDS its
rule-sets (`sec.NAT.Source` / `Destination.RuleSets` / `Static` / `NAT64` /
`ProxyARP`) and map-assigns its pools, so invoking it once per duplicate
block **merges** the blocks exactly as Junos merges duplicate hierarchical
stanzas. With a single block the callback fires exactly once, **bit-identical**
to the prior `FindChild` read. `natv6v4` additionally initializes its struct
once and ORs the flag so a second block cannot reset an already-observed
`no-v6-frag-header`.

Applied to all six node-level sub-block reads in `compileNAT`
(`compiler_nat.go:782`). Approach = **accumulate/merge** (matches Junos),
not reject — the sub-block compilers' existing append/map-assign semantics
make merge the natural, low-risk conversion.

This is the NAT-node sibling of the #3842 policy `match`/`then` dup-block
accumulate fix, and of the #3444/#3562 container-level `forEachChild`
dup-block-bypass class.

## Tests — RED on revert

New `pkg/config/compiler_nat_dup_subblock_3915_test.go` parses a real config
with two same-named NAT sub-blocks (proving the parser emits sibling dup
blocks in the load-override shape), navigates to the single `nat` node, and
drives `compileNAT` directly (hermetic — no zone/policy validation):

- `TestCompileNATDuplicateSourceBlocksMerge` — 2nd `source {}` adds RS2; both
  RS1 + RS2 compile. **RED on revert** (RS2 dropped).
- `TestCompileNATDuplicateDestinationBlocksMerge` — 2nd `destination {}` adds
  pool P2 + RD2; both rule-sets + both pools compile. **RED on revert.**
- `TestCompileNATDuplicateStaticBlocksMerge` — 2nd `static {}` adds ST2. **RED
  on revert.**
- `TestCompileNATDuplicateNAT64BlocksMerge` — 2nd `nat64 {}` adds N2. **RED on
  revert.**
- `TestCompileNATDuplicateProxyARPBlocksMerge` — 2nd `proxy-arp {}` adds a
  second interface entry.
- `TestCompileNATSingleBlockUnchanged` — single source+destination+static each
  still yields exactly one rule-set (bit-identical guard).

Verified RED-on-revert by simulating the FindChild-first revert: source /
destination / static / nat64 all FAIL with the second block dropped; the
single-block guard stays green.

## Validation

- `go test ./pkg/config/...` — green
- `go build ./...` — clean
- `go vet ./pkg/config/...` / `gofmt -l` — clean

Docs: `docs/config-schema.md` (#3915 entry as the NAT-node sibling of #3842),
`_Log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
