### PR TITLE
daemon: bring RETH member back UP after rename (#3920)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,42 @@
+## 2026-07-03 — #3920: RETH member left DOWN after rename — renameRethMember downs the member for the rename but never brings it UP, and programRethMAC early-returns (no UP) on MAC-match → RG demote/blackhole
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-057 (MEDIUM, HA — data-link-down
+    blackhole). `renameRethMember` (`pkg/daemon/daemon_reth.go`) brings a
+    RETH member DOWN to rename it (kernel requires the link be down to
+    rename) but never brought it back UP. It relied on the caller's next
+    step, `programRethMAC` (`daemon_apply.go:936`), for the UP — but
+    `programRethMAC` early-returns with no UP when the virtual MAC already
+    matches. That MAC-match no-op is the *common* path here:
+    `renameRethMember` finds the interface by matching that same virtual
+    MAC, so on a just-renamed member the MAC always already matches and
+    `programRethMAC` always no-ops → the member is left administratively
+    DOWN → interface track detects link-down → redundancy group demotes →
+    blackhole. Secondary facet: even the MAC-change fast path in
+    `programRethMAC` sets the MAC while the link is still DOWN (from the
+    rename), which succeeds without a cycle and returns without an UP.
+  - **Fix (option a)**: the function that downs the link owns bringing it
+    back up. `renameRethMember` now brings the member UP after a successful
+    rename (and best-effort UP on a failed rename, since it had already
+    downed the link). No flap: whenever a rename happens the MAC already
+    matches so `programRethMAC` no-ops, leaving the rename's UP as the final
+    state; even if `programRethMAC` did cycle, the member still ends UP.
+    Both functions now route netlink through a small `rethLinkOps` seam
+    (`rethLinkOpsFn`) so the admin link state is unit-testable without a
+    real netlink socket.
+  - **Test**: `pkg/daemon/daemon_reth_rename_up_test.go` —
+    `TestRenameRethMemberBringsLinkUpWhenMACMatches` (RED-on-revert:
+    removing the post-rename UP leaves the member DOWN → fails with the
+    blackhole message), `TestRenameRethMemberUpOnFailedRename`,
+    `TestProgramRethMACCyclePathEndsUp` (MAC-changing cycle still ends UP),
+    `TestProgramRethMACLiveChangeNoCycle`. RED-on-revert proven; all pass;
+    `go test ./pkg/daemon/` green; `go build ./...`, `go vet`, gofmt clean.
+    test-failover WARRANTED (HA RETH member link → RG demote) — batch with
+    the other HA-Medium fixes under the force-node0-primary gate.
+  - **File(s)**: `pkg/daemon/daemon_reth.go`,
+    `pkg/daemon/daemon_reth_rename_up_test.go`, `docs/reth-mac.md`,
+    `_Log.md`.
+
 ## 2026-07-03 — #3912: cluster-sync bulk-ack TOCTOU — pendingBulkAckEpoch stored AFTER BulkEnd write → early ack latches a phantom pending epoch that blocks manual failover
 
 - **Timestamp**: 2026-07-03

--- a/docs/reth-mac.md
+++ b/docs/reth-mac.md
@@ -40,6 +40,33 @@ Example for cluster_id=1:
 5. **GARP/NA** -- automatically use the kernel MAC (called at send time)
 6. **`bpf_fib_lookup`** -- automatically returns new MAC as `fib.smac`
 
+## Rename Owns the Link UP (#3920)
+
+A RETH member must be administratively DOWN to be renamed (kernel
+requirement). `renameRethMember` therefore downs the link, renames it,
+and then brings it back UP — the function that downs a link owns
+bringing it back up.
+
+It must NOT delegate the UP to the subsequent `programRethMAC`.
+`programRethMAC` early-returns (no UP) when the virtual MAC already
+matches, and that is precisely the situation after a rename:
+`renameRethMember` locates the interface by matching that same virtual
+MAC, so on a just-renamed member the MAC always already matches and
+`programRethMAC` always no-ops. (A second facet: even in the MAC-change
+path, `programRethMAC`'s fast path sets the MAC while the link is still
+DOWN, which succeeds without a cycle and returns without an UP.) If the
+UP were skipped, the RETH data link would be left DOWN → the interface
+track detects link-down → the redundancy group demotes → traffic
+blackhole.
+
+There is no flap: whenever a rename happens the MAC already matches so
+`programRethMAC` no-ops, leaving `renameRethMember`'s UP as the final
+state; and even in the defensive case where `programRethMAC` does cycle,
+the member still ends UP. Bringing the member UP before `programRethMAC`
+also restores that function's live-address-change detection, which
+requires an UP link to distinguish `IFF_LIVE_ADDR_CHANGE` drivers from
+those that need a cycle.
+
 ## Reboot Safety
 
 - Bootstrap `.link` files (from `setup.sh`) use the physical MAC for udev rename
@@ -55,7 +82,8 @@ Example for cluster_id=1:
 |------|----------|
 | `pkg/cluster/reth.go` | `RethMAC(clusterID, rgID)` -- returns deterministic MAC |
 | `pkg/cluster/reth.go` | `IsVirtualRethMAC(mac)` -- detects virtual RETH pattern |
-| `pkg/daemon/daemon.go` | `programRethMAC()` -- sets MAC via netlink (step 2.6 in applyConfig) |
+| `pkg/daemon/daemon_reth.go` | `renameRethMember()` -- renames a member found by virtual MAC (down → rename → **up**, #3920) |
+| `pkg/daemon/daemon_reth.go` | `programRethMAC()` -- sets MAC via netlink (step 2.6 in applyConfig) |
 | `pkg/dataplane/compiler.go` | Skips `.link` file when RETH member has virtual MAC |
 
 ## Impact

--- a/pkg/daemon/daemon_reth.go
+++ b/pkg/daemon/daemon_reth.go
@@ -136,11 +136,46 @@ func pciAddrToEnp(pciAddr string) string {
 	return fmt.Sprintf("enp%ds%d", bus, slot)
 }
 
+// rethLinkOps groups the netlink primitives that renameRethMember and
+// programRethMAC use. It exists as a seam so tests can inject a fake and
+// assert the RETH member's final admin link state (#3920). The zero value is
+// unusable; use rethLinkOpsFn, which is wired to the real netlink calls.
+type rethLinkOps struct {
+	interfaces      func() ([]net.Interface, error)
+	byName          func(string) (netlink.Link, error)
+	byIndex         func(int) (netlink.Link, error)
+	setDown         func(netlink.Link) error
+	setUp           func(netlink.Link) error
+	setName         func(netlink.Link, string) error
+	setHardwareAddr func(netlink.Link, net.HardwareAddr) error
+}
+
+// rethLinkOpsFn is the live wiring; tests save/restore and override it.
+var rethLinkOpsFn = rethLinkOps{
+	interfaces:      net.Interfaces,
+	byName:          netlink.LinkByName,
+	byIndex:         netlink.LinkByIndex,
+	setDown:         netlink.LinkSetDown,
+	setUp:           netlink.LinkSetUp,
+	setName:         netlink.LinkSetName,
+	setHardwareAddr: netlink.LinkSetHardwareAddr,
+}
+
 // renameRethMember finds an interface by its RETH virtual MAC and renames it
 // to the expected config name. Returns the old kernel name if renamed, or "".
-// The interface must be DOWN for the rename to succeed.
+//
+// The interface must be DOWN for the rename to succeed, so renameRethMember
+// brings it down for the rename and then back UP — the function that downs a
+// link owns bringing it back up. It does NOT rely on the caller's subsequent
+// programRethMAC for the UP: programRethMAC early-returns (no UP) when the
+// virtual MAC already matches, and that is exactly the case here — the
+// interface was found by matching that same virtual MAC, so programRethMAC
+// always no-ops on the just-renamed member. Without this UP the RETH data link
+// would be left administratively DOWN → the interface track detects link-down
+// → the redundancy group demotes → traffic blackhole (#3920).
 func renameRethMember(targetName string, expectedMAC net.HardwareAddr) string {
-	ifaces, err := net.Interfaces()
+	ops := rethLinkOpsFn
+	ifaces, err := ops.interfaces()
 	if err != nil {
 		return ""
 	}
@@ -148,16 +183,27 @@ func renameRethMember(targetName string, expectedMAC net.HardwareAddr) string {
 		if !bytes.Equal(iface.HardwareAddr, expectedMAC) || iface.Name == targetName {
 			continue
 		}
-		link, err := netlink.LinkByIndex(iface.Index)
+		link, err := ops.byIndex(iface.Index)
 		if err != nil {
 			return ""
 		}
 		// Ensure interface is DOWN for rename.
-		netlink.LinkSetDown(link)
-		if err := netlink.LinkSetName(link, targetName); err != nil {
+		ops.setDown(link)
+		if err := ops.setName(link, targetName); err != nil {
 			slog.Warn("failed to rename RETH member",
 				"from", iface.Name, "to", targetName, "err", err)
+			// We downed the link above; a failed rename must not strand
+			// the member DOWN. Best-effort restore admin UP.
+			ops.setUp(link)
 			return ""
+		}
+		// Bring the member back UP after the rename. renameRethMember downed
+		// it, so renameRethMember owns the UP — do not depend on
+		// programRethMAC, which no-ops (no UP) when the MAC already matches
+		// (#3920).
+		if err := ops.setUp(link); err != nil {
+			slog.Warn("failed to bring RETH member up after rename",
+				"iface", targetName, "err", err)
 		}
 		return iface.Name
 	}
@@ -168,7 +214,8 @@ func renameRethMember(targetName string, expectedMAC net.HardwareAddr) string {
 // Skips if the interface already has the correct MAC.
 // The interface must be brought DOWN to change its MAC, then back UP.
 func programRethMAC(ifName string, mac net.HardwareAddr) (linkCycled bool, err error) {
-	link, err := netlink.LinkByName(ifName)
+	ops := rethLinkOpsFn
+	link, err := ops.byName(ifName)
 	if err != nil {
 		return false, fmt.Errorf("interface %s: %w", ifName, err)
 	}
@@ -181,21 +228,21 @@ func programRethMAC(ifName string, mac net.HardwareAddr) (linkCycled bool, err e
 	// mlx5 zero-copy AF_XDP sockets break on link cycle — the driver
 	// doesn't reinitialize XSK WQEs after link UP. If the driver
 	// supports IFF_LIVE_ADDR_CHANGE, this succeeds without any cycle.
-	if err := netlink.LinkSetHardwareAddr(link, mac); err == nil {
+	if err := ops.setHardwareAddr(link, mac); err == nil {
 		slog.Info("RETH MAC set without link cycle", "iface", ifName)
 		return false, nil
 	}
 	// Fallback: bring link down, set MAC, bring back up.
 	slog.Info("RETH MAC requires link cycle (driver does not support live change)",
 		"iface", ifName)
-	if err := netlink.LinkSetDown(link); err != nil {
+	if err := ops.setDown(link); err != nil {
 		return false, fmt.Errorf("link down %s: %w", ifName, err)
 	}
-	if err := netlink.LinkSetHardwareAddr(link, mac); err != nil {
-		netlink.LinkSetUp(link) // best-effort restore
+	if err := ops.setHardwareAddr(link, mac); err != nil {
+		ops.setUp(link) // best-effort restore
 		return false, fmt.Errorf("set mac %s: %w", ifName, err)
 	}
-	if err := netlink.LinkSetUp(link); err != nil {
+	if err := ops.setUp(link); err != nil {
 		return true, fmt.Errorf("link up %s: %w", ifName, err)
 	}
 	return true, nil

--- a/pkg/daemon/daemon_reth_rename_up_test.go
+++ b/pkg/daemon/daemon_reth_rename_up_test.go
@@ -1,0 +1,226 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+// fakeRethLink is a minimal netlink.Link for exercising renameRethMember /
+// programRethMAC through the rethLinkOps seam.
+type fakeRethLink struct {
+	attrs netlink.LinkAttrs
+}
+
+func (f *fakeRethLink) Attrs() *netlink.LinkAttrs { return &f.attrs }
+func (f *fakeRethLink) Type() string              { return "fakeReth" }
+
+// installFakeRethLinkOps wires rethLinkOpsFn to a fake that tracks admin
+// link state on link and records the ordered sequence of operations. It
+// restores the real ops on test cleanup. adminUp starts true (operational);
+// setDown clears it, setUp sets it. macChangeNeedsCycle, when true, makes
+// setHardwareAddr fail while the link is UP (modelling a driver without
+// IFF_LIVE_ADDR_CHANGE) so programRethMAC takes its DOWN→set→UP fallback.
+func installFakeRethLinkOps(t *testing.T, link *fakeRethLink, adminUp *bool, ops *[]string, macChangeNeedsCycle bool) {
+	t.Helper()
+	orig := rethLinkOpsFn
+	t.Cleanup(func() { rethLinkOpsFn = orig })
+	rethLinkOpsFn = rethLinkOps{
+		interfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{
+				Index:        link.attrs.Index,
+				Name:         link.attrs.Name,
+				HardwareAddr: link.attrs.HardwareAddr,
+			}}, nil
+		},
+		byName: func(name string) (netlink.Link, error) {
+			if name != link.attrs.Name {
+				return nil, errors.New("no such link")
+			}
+			return link, nil
+		},
+		byIndex: func(idx int) (netlink.Link, error) {
+			if idx != link.attrs.Index {
+				return nil, errors.New("no such link")
+			}
+			return link, nil
+		},
+		setDown: func(l netlink.Link) error {
+			*adminUp = false
+			*ops = append(*ops, "down")
+			return nil
+		},
+		setUp: func(l netlink.Link) error {
+			*adminUp = true
+			*ops = append(*ops, "up")
+			return nil
+		},
+		setName: func(l netlink.Link, name string) error {
+			l.Attrs().Name = name
+			*ops = append(*ops, "name:"+name)
+			return nil
+		},
+		setHardwareAddr: func(l netlink.Link, mac net.HardwareAddr) error {
+			if macChangeNeedsCycle && *adminUp {
+				return errors.New("EBUSY: driver lacks IFF_LIVE_ADDR_CHANGE")
+			}
+			l.Attrs().HardwareAddr = mac
+			*ops = append(*ops, "mac")
+			return nil
+		},
+	}
+}
+
+// TestRenameRethMemberBringsLinkUpWhenMACMatches is the #3920 RED-on-revert
+// guard. It models the post-restart scenario: a RETH member still carrying
+// its virtual MAC but under the kernel name enp8s0, needing a rename to
+// ge-0-0-1. Because the MAC already equals the virtual MAC, the caller's
+// subsequent programRethMAC would early-return with no UP — so renameRethMember
+// MUST bring the link back up itself. Reverting the post-rename UP leaves
+// adminUp false here → RG demote/blackhole in production.
+func TestRenameRethMemberBringsLinkUpWhenMACMatches(t *testing.T) {
+	mac, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 7, Name: "enp8s0", HardwareAddr: mac}}
+	adminUp := true // operational before the rename
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, false)
+
+	old := renameRethMember("ge-0-0-1", mac)
+	if old != "enp8s0" {
+		t.Fatalf("renameRethMember returned old name %q, want enp8s0", old)
+	}
+	if link.attrs.Name != "ge-0-0-1" {
+		t.Fatalf("link not renamed: %q", link.attrs.Name)
+	}
+	if !adminUp {
+		t.Fatal("RETH member left DOWN after rename — RG would demote/blackhole (#3920)")
+	}
+	// Ordering invariant: the link is downed for the rename, then renamed,
+	// then brought back up. No flap beyond the single required cycle.
+	want := []string{"down", "name:ge-0-0-1", "up"}
+	if !reflect.DeepEqual(ops, want) {
+		t.Fatalf("op order = %v, want %v", ops, want)
+	}
+
+	// programRethMAC on the just-renamed member no-ops (MAC already matches)
+	// and must NOT disturb the UP state that renameRethMember established.
+	cycled, err := programRethMAC("ge-0-0-1", mac)
+	if err != nil {
+		t.Fatalf("programRethMAC: %v", err)
+	}
+	if cycled {
+		t.Fatal("programRethMAC should not report a cycle on a MAC-match no-op")
+	}
+	if !adminUp {
+		t.Fatal("member DOWN after rename+programRethMAC no-op path (#3920)")
+	}
+}
+
+// TestRenameRethMemberUpOnFailedRename verifies that a rename failure does not
+// strand the member DOWN: renameRethMember downed the link, so it must
+// best-effort restore UP even when LinkSetName fails.
+func TestRenameRethMemberUpOnFailedRename(t *testing.T) {
+	mac, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 7, Name: "enp8s0", HardwareAddr: mac}}
+	adminUp := true
+	var ops []string
+	orig := rethLinkOpsFn
+	t.Cleanup(func() { rethLinkOpsFn = orig })
+	rethLinkOpsFn = rethLinkOps{
+		interfaces: func() ([]net.Interface, error) {
+			return []net.Interface{{Index: 7, Name: "enp8s0", HardwareAddr: mac}}, nil
+		},
+		byIndex: func(idx int) (netlink.Link, error) { return link, nil },
+		setDown: func(l netlink.Link) error { adminUp = false; ops = append(ops, "down"); return nil },
+		setUp:   func(l netlink.Link) error { adminUp = true; ops = append(ops, "up"); return nil },
+		setName: func(l netlink.Link, name string) error {
+			ops = append(ops, "name-fail")
+			return errors.New("EEXIST: name in use")
+		},
+	}
+
+	if old := renameRethMember("ge-0-0-1", mac); old != "" {
+		t.Fatalf("expected empty old name on failed rename, got %q", old)
+	}
+	if !adminUp {
+		t.Fatal("member left DOWN after a failed rename — must be restored UP (#3920)")
+	}
+	want := []string{"down", "name-fail", "up"}
+	if !reflect.DeepEqual(ops, want) {
+		t.Fatalf("op order = %v, want %v", ops, want)
+	}
+}
+
+// TestProgramRethMACCyclePathEndsUp covers the other production path: a member
+// already under its correct name but carrying a stale/physical MAC, on a
+// driver that cannot change the MAC live. programRethMAC must down→set→up and
+// leave the member UP with linkCycled=true. This is the "a MAC-changing update
+// still ends UP" half of #3920.
+func TestProgramRethMACCyclePathEndsUp(t *testing.T) {
+	virt, err := net.ParseMAC("02:bf:72:01:01:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	phys, err := net.ParseMAC("52:54:00:aa:bb:cc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 9, Name: "ge-0-0-2", HardwareAddr: phys}}
+	adminUp := true
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, true /* needs cycle */)
+
+	cycled, err := programRethMAC("ge-0-0-2", virt)
+	if err != nil {
+		t.Fatalf("programRethMAC: %v", err)
+	}
+	if !cycled {
+		t.Fatal("expected linkCycled=true for a driver without live MAC change")
+	}
+	if !adminUp {
+		t.Fatal("member left DOWN after MAC-change cycle (#3920)")
+	}
+	if !reflect.DeepEqual(link.attrs.HardwareAddr, net.HardwareAddr(virt)) {
+		t.Fatalf("MAC not programmed: %v", link.attrs.HardwareAddr)
+	}
+	// The live-change attempt fails (link UP), then down→set→up.
+	want := []string{"down", "mac", "up"}
+	if !reflect.DeepEqual(ops, want) {
+		t.Fatalf("op order = %v, want %v", ops, want)
+	}
+}
+
+// TestProgramRethMACLiveChangeNoCycle confirms the fast path: a driver that
+// supports IFF_LIVE_ADDR_CHANGE sets the MAC without a link cycle and reports
+// linkCycled=false, leaving the member UP.
+func TestProgramRethMACLiveChangeNoCycle(t *testing.T) {
+	virt, _ := net.ParseMAC("02:bf:72:01:01:00")
+	phys, _ := net.ParseMAC("52:54:00:aa:bb:cc")
+	link := &fakeRethLink{attrs: netlink.LinkAttrs{Index: 9, Name: "ge-0-0-2", HardwareAddr: phys}}
+	adminUp := true
+	var ops []string
+	installFakeRethLinkOps(t, link, &adminUp, &ops, false /* live change ok */)
+
+	cycled, err := programRethMAC("ge-0-0-2", virt)
+	if err != nil {
+		t.Fatalf("programRethMAC: %v", err)
+	}
+	if cycled {
+		t.Fatal("expected no cycle on a live-address-change driver")
+	}
+	if !adminUp {
+		t.Fatal("member unexpectedly DOWN")
+	}
+	if want := []string{"mac"}; !reflect.DeepEqual(ops, want) {
+		t.Fatalf("op order = %v, want %v", ops, want)
+	}
+}


### PR DESCRIPTION
Closes #3920

## Problem

`renameRethMember` (`pkg/daemon/daemon_reth.go`) brings a RETH member
interface DOWN to perform the rename (the kernel requires the link be
down to rename it) but never brought it back UP. It relied on the
caller's next step, `programRethMAC` (`daemon_apply.go:936`), for the UP
— but `programRethMAC` early-returns with **no UP** when the virtual MAC
already matches.

That MAC-match no-op is not an edge case: it is the **common** path here.
`renameRethMember` finds the interface by matching that same virtual MAC,
so on a just-renamed member the MAC always already matches and
`programRethMAC` always no-ops → the member is left administratively DOWN
→ the interface track detects link-down → the redundancy group demotes →
traffic blackhole.

A second facet makes it doubly broken: even in the MAC-change path,
`programRethMAC`'s fast path sets the MAC while the link is still DOWN
(from the rename), which succeeds without a cycle and returns without an
UP — so a stale-MAC member would also be stranded DOWN.

## Fix (option a from the issue)

The function that downs the link owns bringing it back up.
`renameRethMember` now brings the member UP after a successful rename
(and best-effort UP on a *failed* rename, since it had already downed the
link). It no longer depends on `programRethMAC` for the UP.

No down/up flap: whenever a rename happens the MAC already matches so
`programRethMAC` no-ops, leaving `renameRethMember`'s UP as the final
state; and even if `programRethMAC` did cycle, the member still ends UP.
Bringing the member UP before `programRethMAC` also **restores** that
function's live-address-change detection, which needs an UP link to
distinguish `IFF_LIVE_ADDR_CHANGE` drivers from those needing a cycle.

`renameRethMember` and `programRethMAC` now route their netlink
primitives through a small `rethLinkOps` seam (`rethLinkOpsFn`) so the
admin link state can be asserted in a unit test without a real netlink
socket.

## Tests (`pkg/daemon/daemon_reth_rename_up_test.go`)

- **`TestRenameRethMemberBringsLinkUpWhenMACMatches`** — RED-on-revert
  guard. Models the post-restart case; asserts ordered ops
  (down → name → up) and final UP. Removing the post-rename UP makes it
  fail with `RETH member left DOWN after rename — RG would demote/blackhole`.
- **`TestRenameRethMemberUpOnFailedRename`** — a rename failure still
  restores UP.
- **`TestProgramRethMACCyclePathEndsUp`** — correct name, stale MAC,
  no-live-change driver → down → set → up, `linkCycled=true`, member UP.
- **`TestProgramRethMACLiveChangeNoCycle`** — `IFF_LIVE_ADDR_CHANGE` fast
  path, no cycle, member UP.

RED-on-revert proven locally. `go test ./pkg/daemon/` green;
`go build ./...`, `go vet ./pkg/daemon/`, `gofmt` clean. Doc updated
(`docs/reth-mac.md`: new "Rename Owns the Link UP (#3920)" section +
implementation-table fix).

**test-failover WARRANTED** (HA RETH member link → RG demote) — to be
batch-validated with the other HA-Medium fixes under the
force-node0-primary gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi