### PR TITLE
daemon/ha: fence the CURRENT redundancy-group set on a peer fence (#3917)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,49 @@
+## 2026-07-03 — #3917: HA peer-fence iterated the STARTUP config snapshot → day-2 redundancy-groups never fenced → split-brain dual-active
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-165 (MEDIUM, HA — split-brain dual-active).
+    In `pkg/daemon/daemon_ha_sync.go`, `startClusterComms` wired
+    `d.sessionSync.OnFenceReceived` as a closure over the `cfg` snapshot it
+    captured at startup. On a peer fence the callback iterated
+    `cfg.Chassis.Cluster.RedundancyGroups` from that snapshot. `startClusterComms`
+    is only restarted on a **transport-field** change (`clusterTransportKey`
+    — control/fabric interfaces + peer addresses), so a redundancy-group added
+    by a day-2 commit is absent from the snapshot. Such a day-2 RG was therefore
+    NEVER fenced on a peer fence → it stayed active on this node while the peer
+    also became active for it → split-brain dual-active (the exact failure the
+    fence exists to prevent).
+  - **Fix**: Extracted the fence handler into `d.fenceAllRedundancyGroups(ctx)`
+    plus a shared live-config reader `d.currentRedundancyGroups()` that reads
+    `d.store.ActiveConfig()` (the CURRENT compiled config, RLock-guarded) —
+    mirroring how `pushConfigToPeer` and other HA reconcilers read live config.
+    Every RG in the current config, including day-2 additions, is now fenced.
+    Nil-safe: `d.dp == nil` (config-only mode) skips deactivation with the same
+    diagnostic; `d.store == nil` / no-cluster config returns an empty slice.
+  - **Audit / second stale-snapshot fix**: the per-RG watchdog-heartbeat
+    goroutine in the same function iterated the same startup `cc.RedundancyGroups`
+    every 500ms → a day-2 RG got no watchdog write → its watchdog stayed stale →
+    the dataplane refused to forward for it. Fixed to re-read
+    `d.currentRedundancyGroups()` each tick and gated on `d.dp != nil` alone
+    (dropped the startup RG-count precondition so a cluster that boots with zero
+    RGs still picks up its first day-2 RG). Transport/feature-flag fields
+    (heartbeat/sync/fabric endpoints, IPsecSASync, DHCPLeaseSync) legitimately
+    rely on the #87 transport-restart and are out of the RG-membership class.
+  - **Test**: `pkg/daemon/daemon_ha_fence_3917_test.go` —
+    `TestFenceAllRedundancyGroups_ReadsCurrentConfig` commits a day-2 RG2 after
+    building the startup config and asserts the fence deactivates {0,1,2} (RED
+    on revert: a simulated stale snapshot fences only {0,1});
+    `_StartupRGsFenced` (base case preserved), `_ConfigOnlyModeSafe`
+    (`d.dp == nil` no panic), `_NoClusterSafe` (nil store + non-cluster config),
+    and `TestCurrentRedundancyGroups` (2 → 3 after day-2 commit). RED-on-revert
+    verified by injecting a snapshot-truncation bug: day-2 test failed with
+    `fenced RGs = [0 1], want [0 1 2]`.
+  - **File(s)**: pkg/daemon/daemon_ha_sync.go,
+    pkg/daemon/daemon_ha_fence_3917_test.go, docs/ha-failover-status.md, _Log.md
+  - **Validation**: `go test ./pkg/daemon/... ./pkg/cluster/...` green;
+    `go build ./...`; gofmt clean; `go vet ./pkg/daemon/...` clean.
+    test-failover WARRANTED (HA fence/split-brain) — batched with the other
+    HA-Medium fixes under the force-node0-primary gate.
+
 ## 2026-07-03 — #3912: cluster-sync bulk-ack TOCTOU — pendingBulkAckEpoch stored AFTER BulkEnd write → early ack latches a phantom pending epoch that blocks manual failover
 
 - **Timestamp**: 2026-07-03

--- a/docs/ha-failover-status.md
+++ b/docs/ha-failover-status.md
@@ -220,6 +220,32 @@ most ~0.33/s per RG (≈6x reduction), while the kernel-level liveness (the map
 write) stays at the full 500ms cadence. Failover/failback timing is unchanged
 because state changes bypass the throttle entirely.
 
+**Live-config read every tick (#3917):** the heartbeat loop re-reads the
+CURRENT redundancy-group set (`d.currentRedundancyGroups()` →
+`d.store.ActiveConfig()`) on each tick rather than the `cc.RedundancyGroups`
+snapshot captured when `startClusterComms` first ran. `startClusterComms` is
+only restarted on a **transport-field** change (`clusterTransportKey`), so a
+redundancy-group added by a day-2 commit would otherwise never receive a
+watchdog write — its watchdog would stay stale and the dataplane would refuse
+to forward for it. The loop is now gated on `d.dp != nil` alone (no startup
+RG-count precondition) so it also picks up the first RG added to a cluster that
+booted with none.
+
+### Peer fence reads the live config (#3917)
+
+On a heartbeat timeout the surviving node sends a **fence** over the sync
+channel; on receipt `OnFenceReceived` (`pkg/daemon/daemon_ha_sync.go`) must
+deactivate `rg_active` for EVERY redundancy-group so the peer can own them
+without a dual-active split-brain. The handler
+(`d.fenceAllRedundancyGroups`) reads the CURRENT active config via
+`d.currentRedundancyGroups()`, NOT the startup `cfg` closure. Before #3917 the
+callback iterated the snapshot captured at `startClusterComms` time; because
+comms are only restarted on a transport change, a day-2 redundancy-group was
+absent from that snapshot and was **never fenced** — leaving it active on this
+node while the peer also became active for it (split-brain dual-active, the
+exact failure the fence exists to prevent). The handler is nil-safe in
+config-only mode (`d.dp == nil`) and when the config has no cluster stanza.
+
 ## What Was Eliminated
 
 These mechanisms existed before the simplification work and have been

--- a/pkg/daemon/daemon_ha_fence_3917_test.go
+++ b/pkg/daemon/daemon_ha_fence_3917_test.go
@@ -1,0 +1,221 @@
+package daemon
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/configstore"
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// fenceRecorderHA records the SetRGActive / SetHAWatchdog calls the fence
+// path makes so a test can assert exactly which redundancy-groups were
+// deactivated on a peer fence.
+type fenceRecorderHA struct {
+	mu          sync.Mutex
+	deactivated []int // RG IDs passed to SetRGActive(ctx, id, false)
+	activated   []int // RG IDs passed to SetRGActive(ctx, id, true) — none on fence
+}
+
+func (h *fenceRecorderHA) SetRGActive(_ context.Context, rgID int, active bool) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if active {
+		h.activated = append(h.activated, rgID)
+	} else {
+		h.deactivated = append(h.deactivated, rgID)
+	}
+	return nil
+}
+
+func (h *fenceRecorderHA) SetHAWatchdog(_ context.Context, _ int, _ uint64) error {
+	return nil
+}
+
+func (h *fenceRecorderHA) SetFabricForwarding(_ context.Context, _ dataplane.FabricID, _ dataplane.FabricFwdInfo) error {
+	return nil
+}
+
+func (h *fenceRecorderHA) SyncFabricState(_ context.Context) error { return nil }
+
+func (h *fenceRecorderHA) sortedDeactivated() []int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := append([]int(nil), h.deactivated...)
+	sort.Ints(out)
+	return out
+}
+
+// fenceRecorderDP is a RuntimeDataPlane whose only live surface is HA().
+// The nil embed panics if any other method is called, which keeps the fake
+// honest: the fence path must touch nothing but HA().SetRGActive.
+type fenceRecorderDP struct {
+	dataplane.RuntimeDataPlane
+	ha *fenceRecorderHA
+}
+
+func (d *fenceRecorderDP) HA() dataplane.HAController { return d.ha }
+
+// fenceTestStore builds a committed configstore.Store from flat-set lines.
+func fenceTestStore(t *testing.T, setCmds string) *configstore.Store {
+	t.Helper()
+	s, err := configstore.New(filepath.Join(t.TempDir(), "xpf.conf"))
+	if err != nil {
+		t.Fatalf("configstore.New: %v", err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure: %v", err)
+	}
+	if _, err := s.LoadSet(setCmds); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	s.ExitConfigureSession("")
+	return s
+}
+
+// commitDay2 re-enters configure and applies additional set lines, promoting
+// them to the active config — the day-2 commit that a fence must observe.
+func commitDay2(t *testing.T, s *configstore.Store, setCmds string) {
+	t.Helper()
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatalf("EnterConfigure (day-2): %v", err)
+	}
+	if _, err := s.LoadSet(setCmds); err != nil {
+		t.Fatalf("LoadSet (day-2): %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit (day-2): %v", err)
+	}
+	s.ExitConfigureSession("")
+}
+
+const fenceStartupClusterSet = "" +
+	"set chassis cluster cluster-id 1\n" +
+	"set chassis cluster node 0\n" +
+	"set chassis cluster reth-count 2\n" +
+	"set chassis cluster redundancy-group 0 node 0 priority 200\n" +
+	"set chassis cluster redundancy-group 0 node 1 priority 100\n" +
+	"set chassis cluster redundancy-group 1 node 0 priority 200\n" +
+	"set chassis cluster redundancy-group 1 node 1 priority 100\n"
+
+// TestFenceAllRedundancyGroups_ReadsCurrentConfig is the #3917 regression
+// guard. A redundancy-group added by a day-2 commit (after startClusterComms
+// captured its `cfg` closure) MUST be fenced on a peer fence — otherwise the
+// day-2 RG stays active on this node while the peer also becomes active for
+// it, i.e. split-brain dual-active. The pre-fix closure iterated the startup
+// snapshot (RG0, RG1 only), so RG2 went unfenced; this test goes RED on that
+// revert.
+func TestFenceAllRedundancyGroups_ReadsCurrentConfig(t *testing.T) {
+	s := fenceTestStore(t, fenceStartupClusterSet)
+
+	// Snapshot the startup RG set the buggy closure would have captured.
+	startup := s.ActiveConfig()
+	if startup == nil || startup.Chassis.Cluster == nil {
+		t.Fatal("startup config missing cluster")
+	}
+	if got := len(startup.Chassis.Cluster.RedundancyGroups); got != 2 {
+		t.Fatalf("startup RG count = %d, want 2 (RG0, RG1)", got)
+	}
+
+	// Day-2 commit: add redundancy-group 2. Comms are NOT restarted for a
+	// non-transport change, so a startup-snapshot closure would never see it.
+	commitDay2(t, s, fenceStartupClusterSet+
+		"set chassis cluster redundancy-group 2 node 0 priority 200\n"+
+		"set chassis cluster redundancy-group 2 node 1 priority 100\n")
+
+	rec := &fenceRecorderHA{}
+	d := &Daemon{store: s, dp: &fenceRecorderDP{ha: rec}}
+
+	d.fenceAllRedundancyGroups(context.Background())
+
+	if got, want := rec.sortedDeactivated(), []int{0, 1, 2}; !equalInts(got, want) {
+		t.Fatalf("fenced RGs = %v, want %v (day-2 RG2 must be fenced)", got, want)
+	}
+	if len(rec.activated) != 0 {
+		t.Fatalf("fence must never activate any RG, got %v", rec.activated)
+	}
+}
+
+// TestFenceAllRedundancyGroups_StartupRGsFenced confirms the fix does not
+// regress the base case: RGs present at startup are still fenced.
+func TestFenceAllRedundancyGroups_StartupRGsFenced(t *testing.T) {
+	s := fenceTestStore(t, fenceStartupClusterSet)
+	rec := &fenceRecorderHA{}
+	d := &Daemon{store: s, dp: &fenceRecorderDP{ha: rec}}
+
+	d.fenceAllRedundancyGroups(context.Background())
+
+	if got, want := rec.sortedDeactivated(), []int{0, 1}; !equalInts(got, want) {
+		t.Fatalf("fenced RGs = %v, want %v", got, want)
+	}
+}
+
+// TestFenceAllRedundancyGroups_ConfigOnlyModeSafe: with a nil dataplane
+// (config-only mode) a fence must not panic and must make no HA calls.
+func TestFenceAllRedundancyGroups_ConfigOnlyModeSafe(t *testing.T) {
+	s := fenceTestStore(t, fenceStartupClusterSet)
+	d := &Daemon{store: s, dp: nil}
+	// Must not panic.
+	d.fenceAllRedundancyGroups(context.Background())
+}
+
+// TestFenceAllRedundancyGroups_NoClusterSafe: a non-cluster (or nil) config
+// yields no RGs and no HA calls, without panicking.
+func TestFenceAllRedundancyGroups_NoClusterSafe(t *testing.T) {
+	// nil store.
+	rec := &fenceRecorderHA{}
+	d := &Daemon{store: nil, dp: &fenceRecorderDP{ha: rec}}
+	d.fenceAllRedundancyGroups(context.Background())
+	if len(rec.deactivated) != 0 {
+		t.Fatalf("nil store must fence nothing, got %v", rec.deactivated)
+	}
+
+	// Committed config with no chassis cluster stanza.
+	s := fenceTestStore(t, "set interfaces ge-0/0/3 unit 0 family inet address 10.0.30.1/24\n")
+	rec2 := &fenceRecorderHA{}
+	d2 := &Daemon{store: s, dp: &fenceRecorderDP{ha: rec2}}
+	d2.fenceAllRedundancyGroups(context.Background())
+	if len(rec2.deactivated) != 0 {
+		t.Fatalf("non-cluster config must fence nothing, got %v", rec2.deactivated)
+	}
+}
+
+// TestCurrentRedundancyGroups covers the shared live-config reader directly.
+func TestCurrentRedundancyGroups(t *testing.T) {
+	// nil store → nil.
+	d := &Daemon{}
+	if rgs := d.currentRedundancyGroups(); rgs != nil {
+		t.Fatalf("nil store: got %v, want nil", rgs)
+	}
+
+	s := fenceTestStore(t, fenceStartupClusterSet)
+	d.store = s
+	if got := len(d.currentRedundancyGroups()); got != 2 {
+		t.Fatalf("current RG count = %d, want 2", got)
+	}
+
+	commitDay2(t, s, fenceStartupClusterSet+
+		"set chassis cluster redundancy-group 2 node 0 priority 200\n"+
+		"set chassis cluster redundancy-group 2 node 1 priority 100\n")
+	if got := len(d.currentRedundancyGroups()); got != 3 {
+		t.Fatalf("post day-2 RG count = %d, want 3", got)
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/daemon/daemon_ha_sync.go
+++ b/pkg/daemon/daemon_ha_sync.go
@@ -408,7 +408,14 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 	// Start BPF watchdog heartbeat: write monotonic timestamp to ha_watchdog
 	// map every 500ms for each configured RG. If the daemon is SIGKILL'd,
 	// the timestamp goes stale and BPF stops forwarding within 2s.
-	if d.dp != nil && len(cc.RedundancyGroups) > 0 {
+	//
+	// #3917: gate on d.dp only (not the startup RG count) and re-read the
+	// CURRENT redundancy-group set each tick. Comms are only restarted on a
+	// transport-field change, so binding cc.RedundancyGroups here would
+	// starve a day-2 RG (added by a later commit) of watchdog heartbeats ->
+	// its watchdog goes stale -> the dataplane stops forwarding for it.
+	// This mirrors the live-config read the fence path now uses.
+	if d.dp != nil {
 		go func() {
 			ticker := time.NewTicker(500 * time.Millisecond)
 			defer ticker.Stop()
@@ -417,10 +424,14 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 				case <-commsCtx.Done():
 					return
 				case <-ticker.C:
+					rgs := d.currentRedundancyGroups()
+					if len(rgs) == 0 {
+						continue
+					}
 					var ts unix.Timespec
 					_ = unix.ClockGettime(unix.CLOCK_MONOTONIC, &ts)
 					now := uint64(ts.Sec)
-					for _, rg := range cc.RedundancyGroups {
+					for _, rg := range rgs {
 						if err := d.dp.HA().SetHAWatchdog(commsCtx, rg.ID, now); err != nil {
 							slog.Warn("ha watchdog write failed", "rg", rg.ID, "err", err)
 						}
@@ -702,32 +713,17 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			d.cluster.SetPeerFenceFunc(d.sessionSync.SendFence)
 			d.sessionSync.OnFenceReceived = func() {
 				slog.Warn("cluster: fence received from peer")
-				// Guard d.dp: the daemon can run in config-only mode
-				// (d.dp == nil) when the runtime dataplane factory rejects
-				// the configured backend — for example, a stale
-				// "system dataplane-type dpdk" config triggers
-				// dataplane.ErrDPDKBackendRetired and daemon_run.go falls
-				// back to nil dp. Without this guard a peer fence would
-				// panic on a nil pointer dereference. The same applies to
-				// any future Start() failure that leaves d.dp == nil.
-				if d.dp == nil {
-					slog.Warn("cluster: fence received but dataplane is nil; skipping RG deactivation",
-						"mode", "config-only",
-						"action", "skip_rg_deactivation",
-						"remediation", "set system dataplane-type userspace and restart xpfd",
-					)
-					return
-				}
-				if cfg.Chassis.Cluster != nil {
-					slog.Warn("cluster: fence: disabling all RGs",
-						"rg_count", len(cfg.Chassis.Cluster.RedundancyGroups))
-					for _, rg := range cfg.Chassis.Cluster.RedundancyGroups {
-						if err := d.dp.HA().SetRGActive(commsCtx, rg.ID, false); err != nil {
-							slog.Warn("cluster: fence: failed to disable rg_active",
-								"rg", rg.ID, "err", err)
-						}
-					}
-				}
+				// #3917: fence the CURRENT redundancy-group set, not the
+				// `cfg` snapshot captured in this closure at
+				// startClusterComms time. Comms are only restarted on a
+				// transport-field change (clusterTransportKey), so a
+				// redundancy-group added by a day-2 commit is absent from
+				// the startup snapshot. Fencing off the snapshot would
+				// leave that RG active on this node while the peer also
+				// becomes active for it -> split-brain dual-active. The
+				// dp==nil (config-only) and nil-cluster guards live in
+				// fenceAllRedundancyGroups.
+				d.fenceAllRedundancyGroups(commsCtx)
 			}
 
 			d.sessionSync.SetVRFDevice(vrfDevice)
@@ -840,6 +836,59 @@ func (d *Daemon) startClusterComms(ctx context.Context) {
 			// Monitor fabric link/neighbor state via netlink (#124).
 			go d.monitorFabricState(commsCtx)
 		}()
+	}
+}
+
+// currentRedundancyGroups returns the redundancy-groups from the CURRENT
+// active configuration (d.store.ActiveConfig()) rather than a snapshot
+// captured earlier. #3917: long-lived HA goroutines wired in
+// startClusterComms (peer-fence handling, watchdog heartbeat) must read
+// live config at every event/tick. startClusterComms is only restarted on a
+// transport-field change (clusterTransportKey), so a redundancy-group added
+// by a day-2 commit never reaches a closure that captured the startup `cfg`.
+// Returns nil when there is no store, no compiled config, or the config is
+// not in cluster mode — every caller must tolerate an empty slice.
+func (d *Daemon) currentRedundancyGroups() []*config.RedundancyGroup {
+	if d.store == nil {
+		return nil
+	}
+	cfg := d.store.ActiveConfig()
+	if cfg == nil || cfg.Chassis.Cluster == nil {
+		return nil
+	}
+	return cfg.Chassis.Cluster.RedundancyGroups
+}
+
+// fenceAllRedundancyGroups disables rg_active for every redundancy-group in
+// the CURRENT active config. It is the peer-fence handler: when a fence
+// message arrives the local node must relinquish ALL redundancy-groups so
+// the peer can own them without a dual-active split-brain. #3917: reading
+// the live config here (via currentRedundancyGroups) ensures day-2 RGs are
+// fenced too. Safe when the dataplane is nil (config-only mode) or the
+// config has no cluster/RGs.
+func (d *Daemon) fenceAllRedundancyGroups(ctx context.Context) {
+	// Guard d.dp: the daemon can run in config-only mode (d.dp == nil)
+	// when the runtime dataplane factory rejects the configured backend —
+	// for example, a stale "system dataplane-type dpdk" config triggers
+	// dataplane.ErrDPDKBackendRetired and daemon_run.go falls back to nil
+	// dp. Without this guard a peer fence would panic on a nil pointer
+	// dereference. The same applies to any future Start() failure that
+	// leaves d.dp == nil.
+	if d.dp == nil {
+		slog.Warn("cluster: fence received but dataplane is nil; skipping RG deactivation",
+			"mode", "config-only",
+			"action", "skip_rg_deactivation",
+			"remediation", "set system dataplane-type userspace and restart xpfd",
+		)
+		return
+	}
+	rgs := d.currentRedundancyGroups()
+	slog.Warn("cluster: fence: disabling all RGs", "rg_count", len(rgs))
+	for _, rg := range rgs {
+		if err := d.dp.HA().SetRGActive(ctx, rg.ID, false); err != nil {
+			slog.Warn("cluster: fence: failed to disable rg_active",
+				"rg", rg.ID, "err", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes fable-161 F-165 (MEDIUM, HA — split-brain dual-active).

`OnFenceReceived` was wired in `startClusterComms` as a **closure over the
`cfg` config snapshot captured at startup**, and iterated
`cfg.Chassis.Cluster.RedundancyGroups` from that snapshot on a fence.
`startClusterComms` is only restarted on a **transport-field** change
(`clusterTransportKey`: control/fabric interfaces + peer addresses), so a
redundancy-group added by a **day-2 commit** is absent from the snapshot.
Such a day-2 RG was therefore **never fenced** on a peer fence → it stayed
active on this node while the peer also became active for it → **split-brain
dual-active**, the exact failure the fence mechanism exists to prevent.

## Fix

- Extract the fence handler into `d.fenceAllRedundancyGroups(ctx)` + a shared
  live-config reader `d.currentRedundancyGroups()` that reads
  `d.store.ActiveConfig()` (current compiled config, RLock-guarded) — mirroring
  how `pushConfigToPeer` and other HA reconcilers read live config. Every RG in
  the current config, including day-2 additions, is now fenced.
- Nil-safe: `d.dp == nil` (config-only mode) skips deactivation with the same
  diagnostic; `d.store == nil` / a non-cluster config yields an empty slice.

## Second stale-snapshot instance found in the audit (fixed)

The per-RG **watchdog-heartbeat** goroutine in the same function iterated the
same startup `cc.RedundancyGroups` every 500ms → a day-2 RG got no watchdog
write → its watchdog went stale → the dataplane refused to forward for it. It
now re-reads `d.currentRedundancyGroups()` each tick and is gated on
`d.dp != nil` alone (dropped the startup RG-count precondition), so a cluster
that boots with zero RGs still picks up its first day-2 RG.

Transport/feature-flag fields (heartbeat/sync/fabric endpoints, `IPsecSASync`,
`DHCPLeaseSync`) legitimately rely on the #87 transport-restart and are outside
the RG-membership stale-snapshot class.

## Tests (`pkg/daemon/daemon_ha_fence_3917_test.go`)

- `TestFenceAllRedundancyGroups_ReadsCurrentConfig` — commits a day-2 RG2 after
  the startup config, asserts the fence deactivates `{0,1,2}`. **RED on revert:**
  injecting a snapshot-truncation bug made the day-2 test fail with
  `fenced RGs = [0 1], want [0 1 2]`.
- `_StartupRGsFenced` (base case preserved), `_ConfigOnlyModeSafe`
  (`d.dp == nil` no panic), `_NoClusterSafe` (nil store + non-cluster config),
  `TestCurrentRedundancyGroups` (2 → 3 across a day-2 commit).

## Validation

- `go test ./pkg/daemon/... ./pkg/cluster/...` green (also under `-race`)
- `go build ./...`; `gofmt` clean; `go vet ./pkg/daemon/...` clean
- Docs updated: `docs/ha-failover-status.md` (peer-fence + watchdog live-config read)
- **test-failover WARRANTED** (HA fence/split-brain) — batch with the other
  HA-Medium fixes under the force-node0-primary gate.

Closes #3917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi