### PR TITLE
daemon: fix direct-mode GARP gateway probe on /25+ subnets (#3922)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29365,3 +29365,35 @@ top.
   semantics), single-block bit-identical. natv6v4 inits struct once + ORs flag.
 - **File(s)**: pkg/config/compiler_nat.go,
   pkg/config/compiler_nat_dup_subblock_3915_test.go, docs/config-schema.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #3922 — direct-mode (private-rg-election / no-reth-vrrp)
+    post-failover GARP blackhole on /25+ subnets. `directSendGARPs`
+    (`pkg/daemon/daemon_ha_vip.go`) computed the supplementary gateway ARP
+    probe target by forcing the network address's last octet to `.1`, a
+    pre-#2377 assumption that the gateway is `<subnet>.1`. On any /25-or-longer
+    prefix, or a subnet whose network does not end in `.0`, the forced `.1`
+    falls OUTSIDE the subnet (e.g. VIP 10.0.61.18/28 → 10.0.61.1, outside
+    .16-.31) → the directed probe hit a foreign address and the real gateway's
+    ARP cache was never re-bound to the new master's MAC → post-failover
+    blackhole until the stale entry aged out. #2377 fixed the identical
+    forced-.1 in `vrrp.sendGARP` but MISSED this direct-mode site. Fix: exported
+    the #2377 network-free helper `gatewayProbeTarget` → `vrrp.GatewayProbeTarget`
+    as the single source of truth (network address + 1, respects the prefix,
+    returns ok=false to SKIP the directed probe on /31 (RFC 3021) and /32) and
+    routed `directSendGARPs` through it, replacing the forced-.1 block. Added a
+    `directARPProbeFn` seam (mirrors `vrrp.arpProbeFn`) so the probe target is
+    unit-testable without AF_PACKET I/O. RED-on-revert table test in
+    `pkg/daemon/direct_garp_probe_target_test.go` exercises the full
+    directSendGARPs path: /24-.1 unchanged (green on both), /25 + /28 assert the
+    in-subnet network+1 target (RED against forced-.1 — out of subnet), /32 host
+    route + /30-VIP-is-first-host assert NO directed probe (RED against
+    forced-.1 — fires an out-of-range probe). Verified: 4/5 cases RED on a
+    reverted forced-.1, /24 stays green. `go test ./pkg/daemon/... ./pkg/vrrp/...`
+    green; `go build ./...`, gofmt, vet clean. test-failover WARRANTED (HA
+    post-failover GARP) — batched with the other HA-Medium fixes under the
+    force-node0-primary gate.
+  - **File(s)**: pkg/daemon/daemon_ha_vip.go,
+    pkg/daemon/direct_garp_probe_target_test.go, pkg/vrrp/instance.go,
+    pkg/vrrp/instance_garp_probe_target_test.go, pkg/vrrp/README.md,
+    pkg/daemon/README.md

--- a/pkg/daemon/README.md
+++ b/pkg/daemon/README.md
@@ -47,6 +47,25 @@ Detected by the presence of `/etc/xpf/node-id` (contents `0` or `1`).
 Absent → standalone. Cluster mode triggers the bondless-RETH naming
 convention (`fxp0`, `em0`, `ge-{0,7}-0-X`).
 
+### Direct-mode VIP failover (private-rg-election / no-reth-vrrp)
+
+When `no-reth-vrrp` or `private-rg-election` is configured, the daemon owns
+VIP add/remove and the post-failover GARP directly (there are no VRRP
+instances). `directSendGARPs` (`daemon_ha_vip.go`) sends a broadcast GARP
+burst per VIP plus a supplementary **directed** ARP probe to the subnet
+gateway so a router that ignores broadcast gratuitous ARP still re-binds the
+VIP to the new master's MAC. The probe target is derived by the single source
+of truth `vrrp.GatewayProbeTarget(ipNet)` — the subnet's first usable host
+(network address + 1), respecting the actual prefix length, returning
+`ok=false` (skip the directed probe) on /31 (RFC 3021) and /32 where no
+in-subnet gateway host exists. Before #3922 this site forced the last octet
+to `.1`, which lands OUTSIDE the subnet on /25+ or a non-.0 network (e.g. VIP
+`10.0.61.18/28` → `10.0.61.1`, outside `.16-.31`) → the directed probe hit a
+foreign address and the real gateway's ARP cache was never updated → post-
+failover blackhole until the stale entry aged out. #2377 fixed the identical
+forced-.1 in `vrrp.sendGARP` but missed this direct-mode site; #3922 routes
+both through the shared `vrrp.GatewayProbeTarget` helper.
+
 ## Interface management
 
 `enumerateAndRenameInterfaces()` runs at startup (in `linksetup.go`),

--- a/pkg/daemon/daemon_ha_vip.go
+++ b/pkg/daemon/daemon_ha_vip.go
@@ -492,6 +492,13 @@ var (
 	directNABurstFn   = cluster.SendGratuitousIPv6BurstGated
 )
 
+// directARPProbeFn is the supplementary gateway ARP-probe sender used by
+// directSendGARPs. It is a package var so tests can capture the sender/target
+// that directSendGARPs passes — proving the probe carries the VIP as the ARP
+// sender (#2152) and targets the in-subnet first host (network+1, #3922) —
+// without performing real AF_PACKET I/O. Mirrors vrrp.arpProbeFn.
+var directARPProbeFn = cluster.SendARPProbe
+
 // directBurstStillValid returns a cluster.BurstStillValid predicate for the
 // direct-mode GARP/NA follow-up loops (#2898). seq is the directAnnounceSeq
 // captured at burst start. The predicate reports true only while this RG still
@@ -557,19 +564,27 @@ func (d *Daemon) directSendGARPs(rgID int) {
 				if err := directGARPBurstFn(ifName, ip, garpCount, stillValid); err != nil {
 					slog.Warn("directSendGARPs: GARP failed", "iface", ifName, "ip", ip, "err", err)
 				}
-				// Send ARP probe to gateway (.1) to update upstream ARP caches.
+				// Send a directed ARP probe to the subnet's first usable host
+				// (network address + 1, the most common gateway) so a router
+				// that ignores broadcast gratuitous ARP still re-binds the VIP
+				// to our MAC. The target derivation is the single source of
+				// truth vrrp.GatewayProbeTarget: it respects the actual prefix
+				// length and returns ok=false on /31 (RFC 3021) and /32 where
+				// no in-subnet gateway host exists. Pre-#3922 this site forced
+				// the network address's last octet to .1, which lands OUTSIDE
+				// the subnet on /25+ or a non-.0 network (e.g. 10.0.61.18/28 →
+				// 10.0.61.1, outside .16-.31) → the probe went to a foreign
+				// address and the real gateway's ARP cache was never updated →
+				// post-failover blackhole. #2377 fixed the analogous forced-.1
+				// in vrrp.sendGARP but missed this direct-mode site.
 				_, ipNet, _ := net.ParseCIDR(cidr)
 				if ipNet != nil {
-					gw := make(net.IP, len(ipNet.IP))
-					copy(gw, ipNet.IP)
-					gw[len(gw)-1] = 1
-					// Skip when the VIP is itself the subnet .1 — otherwise we
-					// would probe ourselves. Mirrors the guard in
-					// vrrp.sendGARP (Codex/AGY #2152 review).
-					if !gw.Equal(ip.To4()) {
-						// Use the VIP as the ARP sender so the gateway re-binds
-						// VIP -> our MAC, not the primary IP -> MAC (#2152).
-						if err := cluster.SendARPProbe(ifName, ip.To4(), gw); err != nil {
+					if gw, ok := vrrp.GatewayProbeTarget(ipNet); ok && !gw.Equal(ip.To4()) {
+						// Skip when network+1 is the VIP itself — otherwise we
+						// would probe ourselves. Use the VIP as the ARP sender
+						// so the gateway re-binds VIP -> our MAC, not the
+						// primary IP -> MAC (#2152).
+						if err := directARPProbeFn(ifName, ip.To4(), gw); err != nil {
 							slog.Warn("directSendGARPs: ARP probe failed", "iface", ifName, "gw", gw, "err", err)
 						}
 					}

--- a/pkg/daemon/direct_garp_probe_target_test.go
+++ b/pkg/daemon/direct_garp_probe_target_test.go
@@ -1,0 +1,153 @@
+package daemon
+
+import (
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/cluster"
+	"github.com/psaab/xpf/pkg/configstore"
+)
+
+// #3922: the direct-mode (private-rg-election / no-reth-vrrp) supplementary
+// gateway ARP probe in directSendGARPs must compute its target as the subnet's
+// first usable host (network address + 1, via vrrp.GatewayProbeTarget), NOT by
+// forcing the network address's last octet to .1. On /25-or-longer subnets, or
+// a subnet whose network does not end in .0, the legacy forced-.1 computation
+// landed OUTSIDE the subnet — the probe went to a foreign address and the real
+// gateway's ARP cache was never re-bound to the new master's MAC → post-
+// failover blackhole. #2377 fixed the analogous forced-.1 in vrrp.sendGARP but
+// missed this direct-mode site.
+//
+// These tests exercise the full directSendGARPs path through the directARPProbeFn
+// seam. They are fail-on-revert: the /25 and /28 cases assert the target is the
+// in-subnet network+1, which the pre-#3922 forced-.1 code computed OUTSIDE the
+// subnet (RED); the /32 and VIP-is-first-host cases assert NO directed probe
+// fires, which the forced-.1 code violated by synthesizing an out-of-range .1
+// target (RED). The /24-.1 case is unchanged (network .0 + 1 = .1) and stays
+// green on both the fix and the revert.
+
+// probeCapture records the sender/target of every directARPProbeFn call.
+type probeCapture struct {
+	mu      sync.Mutex
+	calls   int
+	senders []net.IP
+	targets []net.IP
+}
+
+func installProbeSeam(t *testing.T, cap *probeCapture) {
+	t.Helper()
+	prev := directARPProbeFn
+	directARPProbeFn = func(_ string, sender, target net.IP) error {
+		cap.mu.Lock()
+		cap.calls++
+		cap.senders = append(cap.senders, append(net.IP(nil), sender...))
+		cap.targets = append(cap.targets, append(net.IP(nil), target...))
+		cap.mu.Unlock()
+		return nil
+	}
+	t.Cleanup(func() { directARPProbeFn = prev })
+}
+
+// directProbeTestDaemon builds a cluster-mode Daemon that owns RG 1 with a
+// single IPv4 VIP at the given CIDR on reth0, so directSendGARPs exercises the
+// supplementary gateway-probe path for that prefix.
+func directProbeTestDaemon(t *testing.T, vipCIDR string) *Daemon {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := configstore.New(filepath.Join(dir, "xpf.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.EnterConfigure(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.LoadSet(
+		"set chassis cluster cluster-id 1\n" +
+			"set interfaces reth0 redundant-ether-options redundancy-group 1\n" +
+			"set interfaces reth0 unit 0 family inet address " + vipCIDR + "\n",
+	); err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, err := s.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return &Daemon{
+		store:             s,
+		rgStates:          make(map[int]*rgStateMachine),
+		directVIPOwned:    map[int]bool{1: true},
+		directAnnounceSeq: map[int]uint64{1: 1},
+	}
+}
+
+func TestDirectSendGARPs_ProbeTargetRespectsPrefix(t *testing.T) {
+	cases := []struct {
+		name      string
+		vipCIDR   string
+		wantProbe bool
+		wantGW    string
+	}{
+		// /24, gateway .1 — unchanged: network .0 + 1 = .1. Green on both the
+		// fix and the pre-#3922 forced-.1 revert.
+		{"slash24_gw_dot1", "10.0.5.10/24", true, "10.0.5.1"},
+		// /25 with a non-.0 network — the #3922 regression: network
+		// 192.168.1.128 + 1 = .129, INSIDE .128-.255. Forced-.1 computes
+		// 192.168.1.1, OUTSIDE the subnet → RED on revert.
+		{"slash25_nonzero_network", "192.168.1.130/25", true, "192.168.1.129"},
+		// /28: network 10.0.61.16 + 1 = .17, INSIDE .16-.31. Forced-.1
+		// computes 10.0.61.1, OUTSIDE → RED on revert.
+		{"slash28", "10.0.61.18/28", true, "10.0.61.17"},
+		// /32 host route — no in-subnet gateway host; the probe is skipped.
+		// Forced-.1 would synthesize 10.1.2.1 and fire → RED on revert.
+		{"slash32_hostroute_skips", "10.1.2.3/32", false, ""},
+		// /30 where the VIP is itself the first usable host (10.0.0.4 + 1 =
+		// 10.0.0.5 == VIP) — the equals-VIP guard skips the self-probe.
+		// Forced-.1 computes 10.0.0.1 (!= VIP) and fires → RED on revert.
+		{"slash30_vip_is_first_host_skips", "10.0.0.5/30", false, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := directProbeTestDaemon(t, tc.vipCIDR)
+
+			var cap probeCapture
+			installProbeSeam(t, &cap)
+			noop := func(string, net.IP, int, cluster.BurstStillValid) error { return nil }
+			installBurstSeams(t, noop, noop)
+
+			d.directSendGARPs(1)
+
+			if !tc.wantProbe {
+				if cap.calls != 0 {
+					t.Fatalf("%s: expected NO directed ARP probe, got %d (targets %v) — "+
+						"forced-.1 fired an out-of-subnet probe (#3922 regression)",
+						tc.vipCIDR, cap.calls, cap.targets)
+				}
+				return
+			}
+
+			if cap.calls != 1 {
+				t.Fatalf("%s: expected exactly 1 directed ARP probe, got %d", tc.vipCIDR, cap.calls)
+			}
+			gw := cap.targets[0]
+			if gw.String() != tc.wantGW {
+				t.Errorf("%s: probe target = %s, want %s (network+1)", tc.vipCIDR, gw, tc.wantGW)
+			}
+			_, ipNet, err := net.ParseCIDR(tc.vipCIDR)
+			if err != nil {
+				t.Fatalf("ParseCIDR(%q): %v", tc.vipCIDR, err)
+			}
+			if !ipNet.Contains(gw) {
+				t.Errorf("%s: probe target %s is OUTSIDE the subnet %s — #3922 forced-.1 regression",
+					tc.vipCIDR, gw, ipNet)
+			}
+			// The ARP sender must be the VIP (#2152), so the gateway re-binds
+			// VIP -> our MAC rather than the interface primary -> MAC.
+			vipIP, _, _ := net.ParseCIDR(tc.vipCIDR)
+			if !cap.senders[0].Equal(vipIP.To4()) {
+				t.Errorf("%s: probe sender = %s, want VIP %s (#2152)", tc.vipCIDR, cap.senders[0], vipIP)
+			}
+		})
+	}
+}

--- a/pkg/vrrp/README.md
+++ b/pkg/vrrp/README.md
@@ -124,12 +124,16 @@ This is the package that drives chassis-cluster failover.
   so a router that ignores broadcast gratuitous ARP still re-binds the VIP.
   This is belt-and-suspenders: the broadcast GARP burst always fires; the
   directed probe is supplementary. The target comes from the network-free
-  helper `gatewayProbeTarget`, which computes network+1 from the masked CIDR
+  helper `GatewayProbeTarget`, which computes network+1 from the masked CIDR
   (`net.ParseCIDR`) — it returns `ok=false` to SKIP the directed probe on
   /31 (RFC 3021) and /32, where no in-subnet gateway host exists. Pre-#2377
   the target was the network address with its last octet forced to .1, which
   fell OUTSIDE the subnet for /25-or-longer prefixes whose network does not
   end in .0 (e.g. VIP 10.0.61.18/28 → 10.0.61.1, outside .16-.31).
+  `GatewayProbeTarget` is exported so the daemon's direct-mode
+  (private-rg-election / no-reth-vrrp) GARP path (`directSendGARPs` in
+  `pkg/daemon`) reuses the identical derivation — that site had the same
+  forced-.1 bug and was missed by #2377 (fixed in #3922).
 - Burst follow-up abdication gate (#2867): the cluster burst helpers send the
   first GARP/NA frame synchronously, then fan the remaining `count-1` frames
   out over a detached goroutine spanning `(count-1)*50 ms`. `sendGARP` captures

--- a/pkg/vrrp/instance.go
+++ b/pkg/vrrp/instance.go
@@ -1888,7 +1888,7 @@ func (vi *vrrpInstance) garpSendAllowed(force bool, nowNanos int64) bool {
 // sender (#2152) without performing real AF_PACKET I/O.
 var arpProbeFn = cluster.SendARPProbe
 
-// gatewayProbeTarget computes the supplementary gateway-probe target for an
+// GatewayProbeTarget computes the supplementary gateway-probe target for an
 // IPv4 VIP subnet: the first usable host address (network address + 1), which
 // is the most common gateway address. The second return value reports whether
 // a sensible target exists; when it is false the caller MUST skip the
@@ -1910,7 +1910,12 @@ var arpProbeFn = cluster.SendARPProbe
 // OUTSIDE the subnet (.16-.31) and the probe went to a foreign address.
 // Computing network+1 from the masked CIDR keeps the target inside the subnet
 // for every prefix length.
-func gatewayProbeTarget(ipNet *net.IPNet) (net.IP, bool) {
+//
+// Exported as the single source of truth for the gateway-probe target so the
+// daemon's direct-mode (private-rg-election / no-reth-vrrp) GARP path in
+// pkg/daemon reuses the identical derivation instead of re-deriving the
+// forced-.1 target that #2377 removed here (#3922).
+func GatewayProbeTarget(ipNet *net.IPNet) (net.IP, bool) {
 	ip4 := ipNet.IP.To4()
 	if ip4 == nil {
 		return nil, false
@@ -1935,7 +1940,7 @@ func gatewayProbeTarget(ipNet *net.IPNet) (net.IP, bool) {
 // Uses burst mode: one immediate pair then background follow-ups at 50ms intervals.
 // After each IPv4 GARP burst, also sends a standard ARP probe to the subnet's
 // first usable host (network address + 1), the most common gateway address
-// (see gatewayProbeTarget; skipped on /31 and /32). Some routers ignore
+// (see GatewayProbeTarget; skipped on /31 and /32). Some routers ignore
 // gratuitous ARP but always update their ARP cache when they receive a
 // standard ARP Request with the VIP as the source address.
 //
@@ -1977,10 +1982,10 @@ func (vi *vrrpInstance) sendGARP(force bool) {
 			// Probe the first usable host (network address + 1) of the
 			// VIP subnet — this is the most common gateway address. The
 			// ARP Request's source IP/MAC forces the gateway to update its
-			// ARP cache for our VIP. gatewayProbeTarget returns ok=false on
+			// ARP cache for our VIP. GatewayProbeTarget returns ok=false on
 			// /31 and /32, where no in-subnet gateway host exists; the
 			// broadcast GARP burst above still fires (#2377).
-			gwIP, ok := gatewayProbeTarget(ipNet)
+			gwIP, ok := GatewayProbeTarget(ipNet)
 			if ok && !gwIP.Equal(ip.To4()) {
 				// Send the probe with the VIP as the ARP sender so the
 				// gateway re-binds VIP -> our (new) MAC, not the primary

--- a/pkg/vrrp/instance_garp_probe_target_test.go
+++ b/pkg/vrrp/instance_garp_probe_target_test.go
@@ -11,7 +11,7 @@ import (
 // .0, the legacy gwIP[3] = 1 computation landed OUTSIDE the subnet, sending the
 // directed probe to a foreign address.
 //
-// These tests pin gatewayProbeTarget directly. They are fail-on-revert: the
+// These tests pin GatewayProbeTarget directly. They are fail-on-revert: the
 // /28 case (VIP 10.0.61.18/28, network 10.0.61.16) wants 10.0.61.17; the
 // pre-#2377 code computed 10.0.61.1, which is OUTSIDE the .16-.31 subnet — so
 // asserting the target is in-subnet fails against master.
@@ -53,18 +53,18 @@ func TestGatewayProbeTargetInSubnet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.cidr, func(t *testing.T) {
 			ipNet := mustCIDR(t, tc.cidr)
-			gw, ok := gatewayProbeTarget(ipNet)
+			gw, ok := GatewayProbeTarget(ipNet)
 			if ok != tc.wantOK {
-				t.Fatalf("gatewayProbeTarget(%s) ok = %v, want %v", tc.cidr, ok, tc.wantOK)
+				t.Fatalf("GatewayProbeTarget(%s) ok = %v, want %v", tc.cidr, ok, tc.wantOK)
 			}
 			if !ok {
 				return
 			}
 			if gw.String() != tc.wantGW {
-				t.Errorf("gatewayProbeTarget(%s) = %s, want %s", tc.cidr, gw, tc.wantGW)
+				t.Errorf("GatewayProbeTarget(%s) = %s, want %s", tc.cidr, gw, tc.wantGW)
 			}
 			if tc.inSubnet && !ipNet.Contains(gw) {
-				t.Errorf("gatewayProbeTarget(%s) = %s is OUTSIDE the subnet %s — #2377 regression",
+				t.Errorf("GatewayProbeTarget(%s) = %s is OUTSIDE the subnet %s — #2377 regression",
 					tc.cidr, gw, ipNet)
 			}
 		})


### PR DESCRIPTION
## Summary

Closes #3922.

The direct-mode (private-rg-election / no-reth-vrrp) post-failover GARP path `directSendGARPs` (`pkg/daemon/daemon_ha_vip.go`) computed its supplementary directed gateway ARP-probe target by forcing the VIP network address's last octet to `.1` — a pre-#2377 assumption that the gateway is `<subnet>.1`. On any /25-or-longer prefix, or a subnet whose network does not end in `.0`, the forced `.1` falls **outside** the subnet (VIP `10.0.61.18/28` → `10.0.61.1`, outside `.16-.31`). The directed probe then hit a foreign address, so a router that ignores broadcast gratuitous ARP never re-bound the VIP to the new master's MAC → **post-failover blackhole** until the stale ARP entry aged out.

#2377 fixed the identical forced-`.1` in `vrrp.sendGARP` but missed this direct-mode site (direct mode has no VRRP instances; the daemon owns the GARP directly).

## Fix

- Export the #2377 network-free helper `gatewayProbeTarget` → **`vrrp.GatewayProbeTarget`** as the single source of truth for the gateway-probe target (network address + 1, respects the actual prefix length, returns `ok=false` to SKIP the directed probe on /31 (RFC 3021) and /32 where no in-subnet gateway host exists).
- Route `directSendGARPs` through it, replacing the forced-`.1` block. The broadcast GARP burst still fires on every subnet regardless — this hardens the supplementary directed probe, not the primary mechanism. The equals-VIP self-probe guard is preserved.
- Add a `directARPProbeFn` seam (mirrors `vrrp.arpProbeFn`) so the probe target is unit-testable without AF_PACKET I/O.

**Real-gateway-derivation fix:** `pkg/daemon/daemon_ha_vip.go` — `directSendGARPs` now calls `vrrp.GatewayProbeTarget(ipNet)` instead of forcing `gw[len(gw)-1] = 1`. Mirrors the #2377 source: `pkg/vrrp/instance.go` `GatewayProbeTarget` (formerly `gatewayProbeTarget`, commit `17255f1d3`).

## RED-on-revert proof

New fail-on-revert table test `pkg/daemon/direct_garp_probe_target_test.go` drives the full `directSendGARPs` path through the seam. Against a reverted forced-`.1` computation:

- `slash24_gw_dot1` (10.0.5.10/24) — **PASS** on both (network .0 + 1 = .1, unchanged)
- `slash25_nonzero_network` (192.168.1.130/25) — **FAIL** on revert (forced .1 = 192.168.1.1, outside .128-.255)
- `slash28` (10.0.61.18/28) — **FAIL** on revert (forced .1 = 10.0.61.1, outside .16-.31)
- `slash32_hostroute_skips` (10.1.2.3/32) — **FAIL** on revert (forced .1 synthesizes 10.1.2.1 and fires; fix skips)
- `slash30_vip_is_first_host_skips` (10.0.0.5/30) — **FAIL** on revert (forced .1 = 10.0.0.1 fires; fix skips via equals-VIP guard)

4/5 cases go RED on the reverted forced-`.1`; the /24 case stays green as designed.

## Validation

- `go test ./pkg/daemon/... ./pkg/vrrp/...` green
- `go build ./...`, `gofmt`, `go vet` clean
- Docs updated: `pkg/vrrp/README.md` (helper now exported + daemon consumer note), `pkg/daemon/README.md` (new "Direct-mode VIP failover" section), `_Log.md`

**test-failover WARRANTED** (HA post-failover GARP) — to be batch-validated with the other HA-Medium fixes under the force-node0-primary gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
