### PR TITLE
flowcache: read neighbor_mac_epoch before resolve, not at stamp (#3918)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,49 @@
+## 2026-07-03 — #3918: flow-cache neighbor_mac_epoch stamped AFTER neighbor resolve → resolve→stamp TOCTOU re-opens the #3048 stale-MAC blackhole on VRRP gateway failover
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-089 (MEDIUM, HA — stale-MAC blackhole on
+    failover). `poll_descriptor/mod.rs` stamped the flow-cache entry's
+    `neighbor_mac_epoch` by reading the LIVE
+    `dynamic_neighbors.mac_change_epoch()` at insert time — AFTER the neighbor
+    MAC backing the decision was resolved. A VRRP gateway failover (a kernel
+    ARP/NDP update replacing the gateway MAC) landing between the resolve
+    (which read the OLD MAC) and the stamp captured the NEW epoch onto the
+    cached OLD `dst_mac`: the entry's epoch then EQUALS the live epoch, so
+    `neighbor_mac_epoch_stale` returns false and the stale MAC is served on
+    every fast-path hit → blackhole until the entry ages out (re-opening the
+    #3048 class the epoch mechanism was added to prevent).
+  - **Fix**: Read-before-resolve. Capture the epoch into
+    `neighbor_mac_epoch_at_resolve` at the top of per-descriptor processing
+    (before `resolve_flow_session_decision` / session-miss
+    `finalize_new_flow_ha_resolution` consult the neighbor table) and thread it
+    into `FlowCacheEntry::from_forward_decision` as a `neighbor_mac_epoch`
+    VALUE parameter. The constructor has no `dynamic_neighbors` handle, so it
+    structurally cannot re-read the live epoch — the only source is the
+    caller's pre-resolve snapshot. The separate post-construction stamp is
+    removed. A subsequent MAC-change bump now makes the stamped (older) epoch
+    != current on the next hit → evict + re-resolve to the new MAC. Relaxed
+    load suffices (snapshot + stamp on one worker thread, program-ordered
+    before the resolve; the neighbor shard Mutex synchronizes the MAC bytes;
+    the epoch is a monotonic invalidation signal). Mirrors #2170/#3912
+    record-before-use.
+  - **Test**: `flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover`
+    (flow_cache_tests.rs) models the interleaved failover with real primitives
+    (ShardedNeighborMap genuine `mac_change_epoch` bump + real
+    `from_forward_decision` + `neighbor_mac_epoch_stale`): stamps a pre-resolve
+    snapshot, asserts the entry is stale after failover, and asserts a
+    POST-resolve read looks fresh (the blackhole). RED-on-revert VERIFIED:
+    reverting the constructor to ignore the pre-resolve param fails the
+    blackhole assertion. `flow_cache_normal_resolve_caches_and_serves_neighbor_mac`
+    is the no-interleave companion (no spurious eviction). FULL
+    `cargo test --release` green (3456 lib + 71 others, 0 failed).
+    `go build ./...` green.
+  - **File(s)**: `userspace-dp/src/afxdp/flow_cache.rs`,
+    `userspace-dp/src/afxdp/poll_descriptor/mod.rs`,
+    `userspace-dp/src/afxdp/flow_cache_tests.rs`,
+    `docs/flow-cache-simplification.md`, `_Log.md`
+  - **Validation flag**: test-failover WARRANTED (HA VRRP gateway failover →
+    stale-MAC scenario) — parent batch-validates on the loss userspace cluster.
+
 ## 2026-07-03 — #3912: cluster-sync bulk-ack TOCTOU — pendingBulkAckEpoch stored AFTER BulkEnd write → early ack latches a phantom pending epoch that blocks manual failover
 
 - **Timestamp**: 2026-07-03

--- a/docs/flow-cache-simplification.md
+++ b/docs/flow-cache-simplification.md
@@ -445,15 +445,34 @@ neighbor write paths are covered:
   sighting and same-MAC re-learn add a single Relaxed read per key and no
   bump, matching the per-key semantics.
 
-`FlowCacheEntry` carries a `neighbor_mac_epoch` stamped at insert
-(`poll_descriptor/mod.rs`, the single insert site, reading the live
-`dynamic_neighbors.mac_change_epoch()`). The worker fast path
+`FlowCacheEntry` carries a `neighbor_mac_epoch`. The worker fast path
 (`poll_descriptor/flow_cache_hit.rs`) re-reads the epoch on every hit; a
 mismatch (`FlowCacheEntry::neighbor_mac_epoch_stale`) evicts the slot and
 falls through to the slow path, which re-resolves the current MAC. This is
 the same lazy epoch-compare pattern as `rg_epochs` — chosen over an explicit
 cross-worker `FlushFlowCaches` so invalidation is lock-free and self-healing
 on the next packet.
+
+**Read-before-resolve (#3918).** The stamped epoch is SNAPSHOTTED BEFORE the
+next-hop MAC is resolved, not re-read at insert time. `poll_descriptor/mod.rs`
+captures `dynamic_neighbors.mac_change_epoch()` into
+`neighbor_mac_epoch_at_resolve` at the top of per-descriptor processing —
+before `resolve_flow_session_decision` / the session-miss
+`finalize_new_flow_ha_resolution` consult the neighbor table — and threads
+that value into `FlowCacheEntry::from_forward_decision` (a `neighbor_mac_epoch`
+value parameter; the constructor has no `dynamic_neighbors` handle, so it
+cannot re-read the live epoch). Re-reading the epoch AT insert time (after the
+resolve) was a TOCTOU that re-opened the #3048 blackhole: a VRRP gateway
+failover landing between the resolve (which read the OLD MAC) and the stamp
+would capture the NEW epoch onto the cached OLD `dst_mac` — a fresh-looking
+stale entry that survives every hit until it ages out. Reading first
+guarantees the stamped epoch is `<=` the epoch observed at resolve time, so
+the MAC-change bump makes the entry stale on its next hit and it re-resolves
+to the new MAC. A Relaxed load suffices: the snapshot and the stamp run on the
+one worker thread (program order sequences the snapshot before the resolve),
+and the neighbor shard `Mutex` — not this counter — synchronizes the MAC
+bytes; the epoch is a monotonic invalidation signal needing only eventual
+cross-thread visibility. Mirrors the #2170/#3912 record-before-use discipline.
 
 **Scope / tradeoff (documented per #3048):** the flow cache is keyed by the
 flow 5-tuple, not by next-hop, so next-hop-scoped invalidation is not
@@ -480,7 +499,15 @@ re-learn no-bump, change bumps — fail-on-revert for `learn_pair_if_changed`
 (flow_cache_tests.rs) is the end-to-end fail-on-revert: a descriptor stamped
 at the live epoch survives a same-MAC refresh and is evicted on a MAC change.
 Neutralizing either `mac_change_epoch.fetch_add` turns the change/eviction
-assertions RED.
+assertions RED. `flow_cache_stamps_pre_resolve_epoch_survives_interleaved_
+gateway_failover` (flow_cache_tests.rs) is the #3918 read-before-resolve
+fail-on-revert: it snapshots the epoch, interleaves a gateway-MAC failover
+(bumping the live epoch), stamps a real `from_forward_decision` entry with the
+PRE-resolve snapshot, and asserts the entry is stale on its next hit — and
+that a POST-resolve read (the pre-#3918 bug) would look fresh (the blackhole).
+Reverting the fix so the constructor ignores the caller's pre-resolve epoch
+turns it RED. `flow_cache_normal_resolve_caches_and_serves_neighbor_mac` is
+the companion no-interleave case: a normal resolve must not spuriously evict.
 
 ## FIB-generation bump gating (#3767)
 

--- a/userspace-dp/src/afxdp/flow_cache.rs
+++ b/userspace-dp/src/afxdp/flow_cache.rs
@@ -337,6 +337,15 @@ impl FlowCacheEntry {
         ha_state: &BTreeMap<i32, HAGroupRuntime>,
         apply_nat_on_fabric: bool,
         rg_epochs: &[AtomicU32; MAX_RG_EPOCHS],
+        // #3918: the caller's PRE-RESOLVE snapshot of
+        // `ShardedNeighborMap::mac_change_epoch()` — read BEFORE the neighbor
+        // MAC backing `decision.resolution` was resolved. Passed as a value so
+        // this constructor cannot re-read the live epoch (it has no
+        // `dynamic_neighbors` handle): the only source is the caller's
+        // pre-resolve capture. Stamping this instead of a post-resolve read
+        // closes the resolve→stamp TOCTOU that re-opened the #3048 stale-MAC
+        // blackhole on a VRRP gateway MAC failover.
+        neighbor_mac_epoch: u32,
     ) -> Option<Self> {
         if !Self::should_cache(meta, decision) {
             return None;
@@ -528,12 +537,17 @@ impl FlowCacheEntry {
             // #1219: 0 = "never touched"; first lookup hit will stamp
             // it with the current epoch.
             last_used_epoch: 0,
-            // #3048: the neighbor-MAC-change epoch is captured by the
-            // caller at insert time (it owns the `dynamic_neighbors`
-            // handle), immediately before `FlowCache::insert`. Seeded to 0
-            // here; the live value is read from
-            // `ShardedNeighborMap::mac_change_epoch()` at the insert site.
-            neighbor_mac_epoch: 0,
+            // #3048/#3918: the neighbor-MAC-change epoch is captured by the
+            // caller BEFORE it resolves the neighbor MAC for `decision`
+            // (the caller owns the `dynamic_neighbors` handle) and passed in
+            // as `neighbor_mac_epoch`. Reading it pre-resolve — instead of
+            // re-reading `mac_change_epoch()` after the resolve at stamp time
+            // — closes the resolve→stamp TOCTOU: a MAC change landing between
+            // the resolve and here advances the live epoch past this stamped
+            // (older) value, so the entry is treated stale on its next
+            // fast-path hit (`neighbor_mac_epoch_stale`) and re-resolved to
+            // the current MAC instead of blackholing on the pre-failover MAC.
+            neighbor_mac_epoch,
         })
     }
 }

--- a/userspace-dp/src/afxdp/flow_cache_tests.rs
+++ b/userspace-dp/src/afxdp/flow_cache_tests.rs
@@ -626,6 +626,8 @@ fn from_forward_decision_round_trip() {
         )]),
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
     let entry = entry.expect("should produce a cache entry for ForwardCandidate");
 
@@ -820,6 +822,8 @@ fn from_forward_decision_skips_cache_for_dscp_matched_output_filter() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
 
     assert!(
@@ -873,6 +877,8 @@ fn from_forward_decision_skips_cache_for_dscp_matched_input_filter() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
 
     assert!(
@@ -926,6 +932,8 @@ fn from_forward_decision_skips_cache_for_per_packet_l4_input_filter() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
 
     assert!(
@@ -975,6 +983,8 @@ fn from_forward_decision_skips_cache_for_per_packet_l4_output_filter() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
 
     assert!(
@@ -1071,6 +1081,8 @@ fn dscp_input_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
 
     assert!(
@@ -1135,6 +1147,8 @@ fn dscp_output_gate_blocks_flow_cache_insertion_via_runbook_pattern() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
 
     assert!(
@@ -1259,6 +1273,8 @@ fn try_build_entry(
         ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     )
 }
 
@@ -1303,6 +1319,8 @@ fn from_forward_decision_preserves_input_filter_log_for_cached_hits() {
         &ha_state,
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     )
     .expect("cacheable entry");
 
@@ -1488,6 +1506,8 @@ fn from_forward_decision_returns_none_for_non_cacheable() {
         &BTreeMap::new(),
         false,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     );
     assert!(entry.is_none(), "NoRoute should not produce a cache entry");
 }
@@ -1564,6 +1584,8 @@ fn fabric_redirect_cache_entry_uses_flow_owner_rg_for_epoch_invalidation() {
         )]),
         true,
         &rg_epochs,
+        // #3918: pre-resolve neighbor_mac_epoch snapshot (0 = none).
+        0,
     )
     .expect("fabric redirect entry");
 
@@ -2656,5 +2678,158 @@ fn cached_descriptor_evicted_only_on_neighbor_mac_change() {
     assert!(
         entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
         "neighbor MAC change must evict the cached stale dst_mac (#3048)"
+    );
+}
+
+// ── #3918: resolve→stamp TOCTOU (re-opens the #3048 stale-MAC blackhole) ──
+// poll_descriptor resolves the next-hop neighbor MAC, then builds + stamps a
+// flow-cache entry with the neighbor mac_change_epoch. The stamp MUST use the
+// epoch SNAPSHOTTED BEFORE the resolve — not a fresh read at stamp time. If a
+// VRRP gateway failover REPLACES the gateway MAC in the window between the
+// resolve (which read the OLD MAC) and the stamp, a post-resolve read captures
+// the NEW epoch and stamps it onto the cached OLD dst_mac: the entry's epoch
+// then EQUALS the live epoch, so `neighbor_mac_epoch_stale` returns false, the
+// stale dst_mac is served on every fast-path hit, and traffic blackholes to
+// the dead gateway until the entry ages out.
+//
+// The fix threads the pre-resolve snapshot into `from_forward_decision`
+// (`neighbor_mac_epoch` value param) so the constructor cannot re-read the live
+// epoch. This test models the interleaved failover with the real primitives
+// (ShardedNeighborMap.insert_if_changed's genuine mac_change_epoch bump +
+// FlowCacheEntry.neighbor_mac_epoch_stale) and asserts the pre-resolve stamp is
+// correctly treated stale. RED-ON-REVERT: reverting the fix (dropping the param
+// + re-reading mac_change_epoch() at stamp time, i.e. AFTER the failover bump
+// modeled here) makes the stamped epoch equal the live epoch -> not stale ->
+// the blackhole; the explicit post-resolve-read contrast below encodes exactly
+// that failing state.
+#[test]
+fn flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover() {
+    use crate::afxdp::sharded_neighbor::ShardedNeighborMap;
+    use crate::afxdp::types::NeighborEntry;
+
+    let neighbors = ShardedNeighborMap::new();
+    let nh = (6i32, IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1)));
+    // Gateway resolved with its pre-failover MAC (first insert — no bump).
+    neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
+
+    // poll_descriptor snapshots the epoch BEFORE resolving the neighbor MAC.
+    let epoch_at_resolve = neighbors.mac_change_epoch();
+
+    // ── Interleaved VRRP gateway failover ──
+    // A kernel ARP/NDP update REPLACES the gateway MAC AFTER the resolve read
+    // the old MAC but BEFORE the flow-cache entry is stamped. This advances the
+    // live epoch past the pre-resolve snapshot.
+    neighbors.insert_if_changed(nh, NeighborEntry { mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x99] });
+    assert_ne!(
+        epoch_at_resolve,
+        neighbors.mac_change_epoch(),
+        "the interleaved failover must advance the live epoch past the \
+         pre-resolve snapshot (otherwise the test proves nothing)"
+    );
+
+    // Build + stamp the flow-cache entry exactly as poll_descriptor does after
+    // the resolve: `from_forward_decision` stamps the PRE-RESOLVE snapshot
+    // (`neighbor_mac_epoch` param), NOT a fresh post-resolve read.
+    let (flow, meta, validation, decision, forwarding, ha_state) = make_v4_round_trip_inputs();
+    let rg_epochs = default_rg_epochs();
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(3),
+        Some(7),
+        None,
+        crate::filter::CachedFilterCounters::default(),
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+        epoch_at_resolve, // #3918: pre-resolve snapshot, not a post-resolve read
+    )
+    .expect("v4 round-trip decision is cacheable");
+
+    // On the NEXT fast-path hit the entry's stamped (pre-failover) epoch != the
+    // current live epoch -> treated STALE -> evicted + re-resolved to the new
+    // MAC. This is the fix.
+    assert!(
+        entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
+        "an entry stamped with the pre-resolve epoch must be stale after an \
+         interleaved gateway-MAC failover so the stale dst_mac is re-resolved (#3918)"
+    );
+
+    // Contrast: the pre-#3918 behavior read the epoch AFTER the resolve (i.e.
+    // after the failover bump modeled above). That post-resolve value EQUALS
+    // the current live epoch, so the stale entry looks FRESH and is never
+    // evicted — the blackhole. Encoding it here makes the revert's failure mode
+    // explicit and guards against a regression that re-reads at stamp time.
+    let post_resolve_read = neighbors.mac_change_epoch();
+    let buggy_entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(3),
+        Some(7),
+        None,
+        crate::filter::CachedFilterCounters::default(),
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+        post_resolve_read,
+    )
+    .expect("v4 round-trip decision is cacheable");
+    assert!(
+        !buggy_entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
+        "a POST-resolve stamp (the pre-#3918 bug) looks fresh after failover — \
+         this is the stale-MAC blackhole the fix closes (#3918)"
+    );
+}
+
+// #3918 companion: the normal (no-interleave) resolve must still cache and
+// serve. A pre-resolve epoch snapshot taken with no intervening MAC change
+// equals the live epoch on the next hit, so the entry is NOT evicted — the fix
+// must not spuriously flush steady-state flows.
+#[test]
+fn flow_cache_normal_resolve_caches_and_serves_neighbor_mac() {
+    use crate::afxdp::sharded_neighbor::ShardedNeighborMap;
+    use crate::afxdp::types::NeighborEntry;
+
+    let neighbors = ShardedNeighborMap::new();
+    let nh = (6i32, IpAddr::V4(Ipv4Addr::new(172, 16, 50, 1)));
+    neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
+
+    // Snapshot pre-resolve; NO failover interleaves.
+    let epoch_at_resolve = neighbors.mac_change_epoch();
+
+    let (flow, meta, validation, decision, forwarding, ha_state) = make_v4_round_trip_inputs();
+    let rg_epochs = default_rg_epochs();
+    let entry = FlowCacheEntry::from_forward_decision(
+        &flow,
+        meta,
+        validation,
+        decision,
+        1,
+        Some(3),
+        Some(7),
+        None,
+        crate::filter::CachedFilterCounters::default(),
+        &forwarding,
+        &ha_state,
+        false,
+        &rg_epochs,
+        epoch_at_resolve,
+    )
+    .expect("v4 round-trip decision is cacheable");
+
+    // A same-MAC refresh does not advance the epoch, so the entry stays fresh.
+    neighbors.insert_if_changed(nh, NeighborEntry { mac: [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01] });
+    assert!(
+        !entry.neighbor_mac_epoch_stale(neighbors.mac_change_epoch()),
+        "a normal resolve with no interleaved MAC change must serve the cached \
+         entry, not spuriously evict it (#3918)"
     );
 }

--- a/userspace-dp/src/afxdp/poll_descriptor/mod.rs
+++ b/userspace-dp/src/afxdp/poll_descriptor/mod.rs
@@ -763,6 +763,31 @@ pub(super) fn poll_binding_process_descriptor(
                 let mut pre_routing_dnat_counter: Option<
                     std::sync::Arc<crate::nat::NatRuleCounter>,
                 > = None;
+                // #3918: snapshot the neighbor-MAC-change epoch BEFORE the
+                // neighbor MAC that backs this packet's forwarding decision is
+                // resolved. `resolve_flow_session_decision` (session-hit
+                // resolve) and the session-miss `finalize_new_flow_ha_
+                // resolution` below both consult `dynamic_neighbors`; the
+                // flow-cache entry built further down is stamped with THIS
+                // pre-resolve value (passed into `from_forward_decision`).
+                // Reading the epoch here — not after the resolve at stamp
+                // time — closes a TOCTOU that re-opened the #3048 stale-MAC
+                // blackhole: a kernel ARP/NDP update (a VRRP gateway failover
+                // changing the gateway MAC) landing between the resolve and the
+                // stamp would, on a post-resolve read, stamp the NEW epoch onto
+                // the cached OLD dst_mac — a fresh-looking stale entry that
+                // survives every fast-path hit until it ages out (blackhole).
+                // Reading first guarantees the stamped epoch <= the epoch
+                // observed at resolve time, so a subsequent MAC-change bump
+                // makes the entry stale on its next hit -> evicted -> re-
+                // resolved to the new MAC. Mirrors the #2170/#3912 record-
+                // before-use discipline. A Relaxed load suffices: this
+                // snapshot and the stamp run on this one worker thread (program
+                // order sequences the snapshot before the resolve), and the
+                // neighbor shard Mutex — not this counter — synchronizes the
+                // MAC bytes; the epoch is a monotonic invalidation signal that
+                // only needs eventual cross-thread visibility.
+                let neighbor_mac_epoch_at_resolve = worker_ctx.dynamic_neighbors.mac_change_epoch();
                 let mut decision = if let Some(flow) = flow.as_ref() {
                     if let Some(resolved) = resolve_flow_session_decision(
                         sessions,
@@ -3836,15 +3861,21 @@ pub(super) fn poll_binding_process_descriptor(
                                 worker_ctx.ha_state,
                                 apply_nat_on_fabric,
                                 &worker_ctx.rg_epochs,
+                                // #3048/#3918: stamp the neighbor-MAC-change
+                                // epoch SNAPSHOTTED BEFORE the resolve above
+                                // (`neighbor_mac_epoch_at_resolve`), not a
+                                // fresh post-resolve read. A later kernel
+                                // ARP/NDP MAC change for this descriptor's
+                                // next-hop advances the live epoch past this
+                                // stamp, evicting the cached stale dst_mac on
+                                // its next fast-path hit
+                                // (`neighbor_mac_epoch_stale`) — and a MAC
+                                // change racing the resolve is caught too,
+                                // because the pre-resolve snapshot cannot
+                                // already reflect it (closes the TOCTOU).
+                                neighbor_mac_epoch_at_resolve,
                             )
                         {
-                            // #3048: stamp the live neighbor-MAC-change
-                            // epoch so a later kernel ARP/NDP MAC change
-                            // for this descriptor's next-hop evicts the
-                            // cached stale dst_mac on the next fast-path
-                            // hit (see neighbor_mac_epoch_stale).
-                            entry.neighbor_mac_epoch =
-                                worker_ctx.dynamic_neighbors.mac_change_epoch();
                             // #3073: stamp the admitting rule's hit-counter handle
                             // onto the cached entry (the seed constructor leaves
                             // it 0). The flow-cache hit path


### PR DESCRIPTION
## Summary

Fixes a resolve->stamp TOCTOU in the flow-cache neighbor-MAC-change
invalidation that re-opens the #3048 stale-MAC blackhole on a VRRP
gateway failover (fable-review-161 F-089, MEDIUM HA).

`poll_descriptor` stamped each cached forwarding descriptor's
`neighbor_mac_epoch` by re-reading the LIVE
`dynamic_neighbors.mac_change_epoch()` at insert time — AFTER the
next-hop MAC backing the decision was resolved. If a neighbor-table
update (a gateway MAC failover) lands between the resolve (which read the
OLD MAC) and the stamp, the entry caches the OLD MAC but records the NEW
epoch. Its stamped epoch then equals the live epoch, so
`neighbor_mac_epoch_stale` returns false, the entry looks fresh, and
every fast-path hit is sent to the dead gateway MAC until the entry ages
out — a blackhole.

## Fix — read-before-resolve

- Snapshot `mac_change_epoch()` into `neighbor_mac_epoch_at_resolve` at
  the top of per-descriptor processing, BEFORE
  `resolve_flow_session_decision` / the session-miss
  `finalize_new_flow_ha_resolution` consult the neighbor table.
- Thread that value into `FlowCacheEntry::from_forward_decision` as a
  `neighbor_mac_epoch` VALUE parameter and stamp it inside the
  constructor; the separate post-construction stamp is removed. The
  constructor holds no `dynamic_neighbors` handle, so it structurally
  cannot re-read the live epoch — the only source is the caller's
  pre-resolve capture.
- A MAC change during/after the resolve now advances the live epoch past
  the stamped (older) value → the entry is stale on its next hit →
  re-resolved to the current MAC.

Memory ordering: a Relaxed load suffices. Snapshot and stamp run on the
one worker thread (program order sequences the snapshot before the
resolve); the neighbor shard `Mutex` — not this counter — synchronizes
the MAC bytes; the epoch is a monotonic invalidation signal needing only
eventual cross-thread visibility. Mirrors the #2170/#3912
record-before-use discipline.

## Tests

- `flow_cache_stamps_pre_resolve_epoch_survives_interleaved_gateway_failover`
  models the interleaved failover with real primitives (genuine
  `ShardedNeighborMap` epoch bump + real `from_forward_decision` +
  `neighbor_mac_epoch_stale`): stamps a pre-resolve snapshot, asserts the
  entry is stale after failover, and asserts a POST-resolve read looks
  fresh (the blackhole). **RED-on-revert verified**: reverting the
  constructor to ignore the pre-resolve param fails the blackhole
  assertion.
- `flow_cache_normal_resolve_caches_and_serves_neighbor_mac` — the
  no-interleave companion (no spurious eviction).

## Validation

- FULL `cargo test --release` green (3456 lib + 71 across other suites, 0
  failed).
- `go build ./...` green.
- **test-failover WARRANTED** (HA VRRP gateway failover -> stale-MAC
  scenario) — to be batch-validated on the loss userspace cluster.

Closes #3918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
