### PR TITLE
userspace maps-sync: don't prune VRRP VIP keys on a partial AddrList (#3924)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,40 @@
+## 2026-07-03 — #3924: userspace local-address sync pruned VRRP VIP keys on a transient netlink AddrList failure → VIP/SSH/BGP/IKE blackhole
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-183 (MEDIUM, HA/robustness — VIP blackhole).
+    `syncLocalAddressMapsLocked` (`pkg/dataplane/userspace/maps_sync.go`) builds
+    the desired `userspace_local_v4`/`userspace_local_v6` key set partly from
+    `netlink.AddrList(nil, family)` to recover kernel-owned VRRP VIPs that are
+    absent from the config snapshot, then prunes every map key not in the
+    desired set. On a TRANSIENT `AddrList` error (or an interrupted / `ENOBUFS`
+    partial dump) the old code `continue`d silently, leaving the desired set
+    INCOMPLETE, and still ran the prune — removing the live VRRP VIP keys and
+    blackholing packets destined to the firewall's own VIP/SSH/BGP/IKE
+    endpoints, with the error swallowed.
+  - **Fix**: `buildDesiredLocalAddressSets` is now a `*Manager` method that
+    reports `enumComplete` (true only when every `AddrList` family dump
+    succeeded) and enumerates through a `m.addrListForLocalSync` seam
+    (test hook `addrListForLocalSyncHook` on the Manager). `syncLocalAddressMapsLocked`
+    still performs the adds (adding only widens the local set — always safe)
+    but SKIPS the stale-key prune and logs a `slog.Warn` when the enumeration
+    is incomplete; the next reconcile with a complete enumeration prunes any
+    genuinely stale keys. Only `userspace_local_v4`/`v6` enumerate the kernel —
+    the interface-NAT and config-derived sets are snapshot-only, unaffected.
+  - **Files**: `pkg/dataplane/userspace/maps_sync.go`,
+    `pkg/dataplane/userspace/manager.go`,
+    `pkg/dataplane/userspace/maps_sync_addrlist_prune_3924_test.go` (RED-on-revert
+    unit tests), `docs/userspace-xdp-pass-bootstrap-and-ipv6.md` (§3 hardening
+    note).
+  - **Validation**: `go build ./...`, `gofmt`, `go vet` clean.
+    `TestSyncLocalAddressMapsSkipsPruneOnAddrListError` (VIP keys preserved +
+    warning on injected `AddrList` error; adds still land) and
+    `TestSyncLocalAddressMapsPrunesStaleOnCompleteEnum` (stale keys still pruned
+    on complete enum) pass under sudo (ebpf maps need memlock); RED-on-revert
+    proven — simulating the pre-fix always-prune makes the VIP-preserved test
+    fail with "VRRP VIP v4 key pruned". Neighboring sudo-only failures
+    (ingress_ifaces / XDP-program tests) reproduce identically on clean
+    origin/master (kernel 7.0.13 env), unrelated to this change.
+
 ## 2026-07-03 — #3917: HA peer-fence iterated the STARTUP config snapshot → day-2 redundancy-groups never fenced → split-brain dual-active
 
 - **Timestamp**: 2026-07-03

--- a/docs/userspace-xdp-pass-bootstrap-and-ipv6.md
+++ b/docs/userspace-xdp-pass-bootstrap-and-ipv6.md
@@ -58,7 +58,27 @@ The XDP shim checks `USERSPACE_LOCAL_V6` to determine if a packet's destination 
 - NDP NAs for the VIP were not recognized as local
 - Any IPv6 traffic destined to the firewall's own WAN VIPs was misclassified
 
-**Fix:** `syncLocalAddressMapsLocked()` in `manager.go` now enumerates ALL kernel addresses via `netlink.AddrList(nil, family)`, including dynamically added VIPs. This runs periodically in the status update loop.
+**Fix:** `syncLocalAddressMapsLocked()` in `maps_sync.go` now enumerates ALL kernel addresses via `netlink.AddrList(nil, family)`, including dynamically added VIPs. This runs periodically in the status update loop.
+
+**Hardening — no prune on incomplete enumeration (#3924):** the reconcile
+adds the desired local keys and then prunes any map key not in the desired
+set. Because the desired set is built partly from `netlink.AddrList`, a
+transient netlink failure (or an interrupted / `ENOBUFS` partial dump)
+produced an INCOMPLETE desired set that was still treated as authoritative —
+so the prune removed the VRRP VIP keys (and any other kernel-owned local
+address) from `userspace_local_v4`/`userspace_local_v6`, blackholing
+VIP/SSH/BGP/IKE traffic destined to the firewall's own endpoints, and the
+`AddrList` error was swallowed silently. `buildDesiredLocalAddressSets` now
+reports whether the enumeration was COMPLETE (all `AddrList` family dumps
+succeeded). On an incomplete enumeration the reconcile still performs the
+adds (adding a key only ever widens the local set — always safe) but SKIPS
+the stale-key prune for that cycle and logs a warning; the next reconcile
+with a complete enumeration removes any genuinely stale keys. Pruning is
+therefore only ever performed against a known-complete desired set. This is
+the same fail-safe-reconcile posture used elsewhere: never act destructively
+on incomplete input. `userspace_local_v4`/`v6` are the only maps affected —
+the interface-NAT and config-derived local sets are snapshot-only and do not
+enumerate the kernel.
 
 ### 4. Kernel Never Learns ARP/NDP from XSK-Captured Packets
 

--- a/pkg/dataplane/userspace/manager.go
+++ b/pkg/dataplane/userspace/manager.go
@@ -257,6 +257,11 @@ type Manager struct {
 
 	lookupUserspaceCtrlForFailClosedHook userspaceCtrlLookupHook
 
+	// addrListForLocalSyncHook, when non-nil, replaces netlink.AddrList in
+	// buildDesiredLocalAddressSets so tests can inject a transient
+	// enumeration failure (#3924). Production leaves it nil.
+	addrListForLocalSyncHook addrListHook
+
 	mode               DataplaneMode // current active runtime mode
 	configuredMode     DataplaneMode // user-configured desired mode (from config)
 	lastHASyncTime     time.Time     // throttle HA watchdog sync to avoid control socket contention

--- a/pkg/dataplane/userspace/maps_sync.go
+++ b/pkg/dataplane/userspace/maps_sync.go
@@ -896,7 +896,7 @@ func (m *Manager) syncLocalAddressMapsLocked(snapshot *ConfigSnapshot) error {
 		return errors.New("userspace_local_v6 map not loaded")
 	}
 
-	desiredV4, desiredV6 := buildDesiredLocalAddressSets(snapshot)
+	desiredV4, desiredV6, enumComplete := m.buildDesiredLocalAddressSets(snapshot)
 	for key := range desiredV4 {
 		if err := localV4Map.Update(key, uint8(1), ebpf.UpdateAny); err != nil {
 			return fmt.Errorf("update userspace_local_v4 %08x: %w", key, err)
@@ -906,6 +906,23 @@ func (m *Manager) syncLocalAddressMapsLocked(snapshot *ConfigSnapshot) error {
 		if err := localV6Map.Update(key, uint8(1), ebpf.UpdateAny); err != nil {
 			return fmt.Errorf("update userspace_local_v6 %+v: %w", key, err)
 		}
+	}
+
+	// A transient netlink AddrList failure (or an interrupted/ENOBUFS
+	// partial dump) yields a NON-AUTHORITATIVE desired set that may be
+	// missing kernel-owned VIP addresses (VRRP VIPs, secondary locals).
+	// Pruning against that partial set would delete live VRRP VIP / local
+	// keys from userspace_local_v4/v6 and blackhole packets destined to
+	// the VIP / SSH / BGP / IKE local endpoints (#3924). Treat the
+	// incomplete enumeration as non-authoritative: the adds above already
+	// landed (adding is always safe — it only ever widens the local set),
+	// but SKIP the stale-key prune this cycle and warn. The next reconcile
+	// with a complete enumeration removes any genuinely stale keys.
+	if !enumComplete {
+		slog.Warn("userspace local-address sync: netlink AddrList enumeration incomplete; " +
+			"skipping stale-key prune to avoid removing VRRP VIP/local keys from " +
+			"userspace_local_v4/v6 (will reconcile on the next complete enumeration)")
+		return nil
 	}
 
 	var (
@@ -952,9 +969,30 @@ func (m *Manager) syncLocalAddressMapsLocked(snapshot *ConfigSnapshot) error {
 	return nil
 }
 
-func buildDesiredLocalAddressSets(snapshot *ConfigSnapshot) (map[uint32]struct{}, map[userspaceLocalV6Key]struct{}) {
-	desiredV4 := make(map[uint32]struct{})
-	desiredV6 := make(map[userspaceLocalV6Key]struct{})
+// addrListHook mirrors netlink.AddrList so tests can inject a transient
+// enumeration failure through the Manager (#3924).
+type addrListHook func(link netlink.Link, family int) ([]netlink.Addr, error)
+
+// addrListForLocalSync enumerates addresses for the local-address map
+// reconcile, dispatching to the test hook when one is installed and to
+// netlink.AddrList otherwise.
+func (m *Manager) addrListForLocalSync(link netlink.Link, family int) ([]netlink.Addr, error) {
+	if m.addrListForLocalSyncHook != nil {
+		return m.addrListForLocalSyncHook(link, family)
+	}
+	return netlink.AddrList(link, family)
+}
+
+// buildDesiredLocalAddressSets returns the desired userspace_local_v4/v6
+// key sets and reports whether the kernel-address enumeration was
+// COMPLETE. enumComplete is false when any netlink AddrList family dump
+// failed — in that case the returned sets are non-authoritative (they may
+// be missing kernel-owned VIP addresses), so the caller MUST NOT prune
+// existing map keys against them (#3924). Config-derived entries are
+// always present regardless of enumeration outcome.
+func (m *Manager) buildDesiredLocalAddressSets(snapshot *ConfigSnapshot) (desiredV4 map[uint32]struct{}, desiredV6 map[userspaceLocalV6Key]struct{}, enumComplete bool) {
+	desiredV4 = make(map[uint32]struct{})
+	desiredV6 = make(map[userspaceLocalV6Key]struct{})
 	for _, entry := range buildLocalAddressEntries(snapshot) {
 		if entry.v4 {
 			desiredV4[entry.v4Key] = struct{}{}
@@ -966,9 +1004,16 @@ func buildDesiredLocalAddressSets(snapshot *ConfigSnapshot) (map[uint32]struct{}
 	// config snapshot. Without this, the XDP shim doesn't recognize VIP
 	// destinations as local and redirects them to XSK instead of the kernel.
 	// Use AddrList(nil, ...) to enumerate ALL addresses on the system.
+	//
+	// A failed family dump means the enumeration is INCOMPLETE: record it
+	// via enumComplete so the caller skips the destructive prune. We still
+	// accumulate whatever the surviving family dump returned (adding is
+	// safe — only pruning against a partial set is dangerous).
+	enumComplete = true
 	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
-		addrs, err := netlink.AddrList(nil, family)
+		addrs, err := m.addrListForLocalSync(nil, family)
 		if err != nil {
+			enumComplete = false
 			continue
 		}
 		for _, addr := range addrs {
@@ -986,7 +1031,7 @@ func buildDesiredLocalAddressSets(snapshot *ConfigSnapshot) (map[uint32]struct{}
 			}
 		}
 	}
-	return desiredV4, desiredV6
+	return desiredV4, desiredV6, enumComplete
 }
 
 func (m *Manager) syncInterfaceNATAddressMapsLocked(snapshot *ConfigSnapshot) error {

--- a/pkg/dataplane/userspace/maps_sync_addrlist_prune_3924_test.go
+++ b/pkg/dataplane/userspace/maps_sync_addrlist_prune_3924_test.go
@@ -1,0 +1,199 @@
+package userspace
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/vishvananda/netlink"
+)
+
+// newLocalAddressMaps builds real in-memory userspace_local_v4/v6 HASH
+// maps sized for the reconcile and injects them into the shim so the test
+// can seed keys and Lookup them afterwards.
+func newLocalAddressMaps(t *testing.T, m *Manager) (v4, v6 *ebpf.Map) {
+	t.Helper()
+	var err error
+	v4, err = ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    4,
+		ValueSize:  1,
+		MaxEntries: 64,
+	})
+	if err != nil {
+		t.Fatalf("new userspace_local_v4 map: %v", err)
+	}
+	t.Cleanup(func() { v4.Close() })
+	v6, err = ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    uint32(unsafe.Sizeof(userspaceLocalV6Key{})),
+		ValueSize:  1,
+		MaxEntries: 64,
+	})
+	if err != nil {
+		t.Fatalf("new userspace_local_v6 map: %v", err)
+	}
+	t.Cleanup(func() { v6.Close() })
+	injectShimMap(t, m.bpfShim, "userspace_local_v4", v4)
+	injectShimMap(t, m.bpfShim, "userspace_local_v6", v6)
+	return v4, v6
+}
+
+func v4Key(t *testing.T, s string) uint32 {
+	t.Helper()
+	ip := net.ParseIP(s).To4()
+	if ip == nil {
+		t.Fatalf("bad v4 addr %q", s)
+	}
+	return binary.BigEndian.Uint32(ip)
+}
+
+func v6Key(t *testing.T, s string) userspaceLocalV6Key {
+	t.Helper()
+	ip := net.ParseIP(s).To16()
+	if ip == nil {
+		t.Fatalf("bad v6 addr %q", s)
+	}
+	var k userspaceLocalV6Key
+	copy(k.Addr[:], ip)
+	return k
+}
+
+// TestSyncLocalAddressMapsSkipsPruneOnAddrListError is the #3924 RED-on-revert
+// guard. A transient netlink AddrList failure yields an INCOMPLETE desired
+// set that is missing kernel-owned VRRP VIP addresses. The reconcile MUST
+// treat the incomplete enumeration as non-authoritative: it keeps the
+// existing VIP/local keys (does NOT prune them), still adds any newly
+// config-desired key, and emits an operator-visible warning. Reverting the
+// fix re-prunes the VIP keys against the partial set -> VIP/SSH/BGP/IKE
+// blackhole -> this test goes RED.
+func TestSyncLocalAddressMapsSkipsPruneOnAddrListError(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+
+	m := New()
+	localV4Map, localV6Map := newLocalAddressMaps(t, m)
+
+	// Kernel-owned VRRP VIPs that are NOT in the config snapshot. These are
+	// exactly the keys buildDesiredLocalAddressSets recovers via AddrList —
+	// on a transient AddrList error they are absent from the desired set.
+	vipV4 := v4Key(t, "10.0.61.1")   // reth1.0 VIP
+	vipV6 := v6Key(t, "2001:db8::1") // reth VIP v6
+	if err := localV4Map.Update(vipV4, uint8(1), ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed VIP v4: %v", err)
+	}
+	if err := localV6Map.Update(vipV6, uint8(1), ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed VIP v6: %v", err)
+	}
+
+	// Inject a transient AddrList failure for BOTH families.
+	injectErr := errors.New("transient netlink AddrList ENOBUFS")
+	m.addrListForLocalSyncHook = func(_ netlink.Link, _ int) ([]netlink.Addr, error) {
+		return nil, injectErr
+	}
+
+	// Snapshot carries one config-derived local address that is NOT yet in
+	// the map — the reconcile must still add it (adds are safe on partial
+	// data).
+	newLocal := v4Key(t, "198.51.100.1")
+	if err := m.syncLocalAddressMapsLocked(&ConfigSnapshot{
+		Interfaces: []InterfaceSnapshot{{
+			Name: "reth1.0",
+			Addresses: []InterfaceAddressSnapshot{{
+				Family:  "inet",
+				Address: "198.51.100.1/24",
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("syncLocalAddressMapsLocked returned %v, want nil (transient enum error is non-fatal)", err)
+	}
+
+	var got uint8
+	// The kernel VIP keys MUST survive — this is the blackhole guard.
+	if err := localV4Map.Lookup(vipV4, &got); err != nil {
+		t.Fatalf("VRRP VIP v4 key pruned on incomplete enumeration (#3924 blackhole): %v", err)
+	}
+	if err := localV6Map.Lookup(vipV6, &got); err != nil {
+		t.Fatalf("VRRP VIP v6 key pruned on incomplete enumeration (#3924 blackhole): %v", err)
+	}
+	// The config-derived add must still land.
+	if err := localV4Map.Lookup(newLocal, &got); err != nil {
+		t.Fatalf("config-derived local add dropped on incomplete enumeration: %v", err)
+	}
+	// The operator-visible warning must fire (error not silently swallowed).
+	if out := buf.String(); !strings.Contains(out, "enumeration incomplete") {
+		t.Fatalf("missing incomplete-enumeration warning, got: %q", out)
+	}
+}
+
+// TestSyncLocalAddressMapsPrunesStaleOnCompleteEnum proves the fix does not
+// break the normal reconcile: when AddrList succeeds (enumeration COMPLETE),
+// keys that are neither config-desired nor present in the kernel dump are
+// pruned as before.
+func TestSyncLocalAddressMapsPrunesStaleOnCompleteEnum(t *testing.T) {
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("RemoveMemlock: %v", err)
+	}
+	m := New()
+	localV4Map, localV6Map := newLocalAddressMaps(t, m)
+
+	staleV4 := v4Key(t, "192.0.2.99")
+	staleV6 := v6Key(t, "2001:db8::dead")
+	if err := localV4Map.Update(staleV4, uint8(1), ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed stale v4: %v", err)
+	}
+	if err := localV6Map.Update(staleV6, uint8(1), ebpf.UpdateAny); err != nil {
+		t.Fatalf("seed stale v6: %v", err)
+	}
+
+	// AddrList succeeds but returns a kernel VIP that the reconcile should
+	// preserve (present in the desired set), and NOT the stale keys.
+	kernelVIP := net.ParseIP("10.0.61.1")
+	m.addrListForLocalSyncHook = func(_ netlink.Link, family int) ([]netlink.Addr, error) {
+		if family == netlink.FAMILY_V4 {
+			return []netlink.Addr{{IPNet: &net.IPNet{IP: kernelVIP, Mask: net.CIDRMask(24, 32)}}}, nil
+		}
+		return nil, nil // empty but successful v6 dump
+	}
+
+	newLocal := v4Key(t, "198.51.100.1")
+	if err := m.syncLocalAddressMapsLocked(&ConfigSnapshot{
+		Interfaces: []InterfaceSnapshot{{
+			Name: "reth1.0",
+			Addresses: []InterfaceAddressSnapshot{{
+				Family:  "inet",
+				Address: "198.51.100.1/24",
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("syncLocalAddressMapsLocked: %v", err)
+	}
+
+	var got uint8
+	// Stale keys removed on complete enumeration.
+	if err := localV4Map.Lookup(staleV4, &got); !errors.Is(err, ebpf.ErrKeyNotExist) {
+		t.Fatalf("stale v4 key not pruned on complete enumeration: err=%v", err)
+	}
+	if err := localV6Map.Lookup(staleV6, &got); !errors.Is(err, ebpf.ErrKeyNotExist) {
+		t.Fatalf("stale v6 key not pruned on complete enumeration: err=%v", err)
+	}
+	// Config add + kernel VIP preserved.
+	if err := localV4Map.Lookup(newLocal, &got); err != nil {
+		t.Fatalf("config-derived local add missing: %v", err)
+	}
+	if err := localV4Map.Lookup(v4Key(t, "10.0.61.1"), &got); err != nil {
+		t.Fatalf("kernel VIP pruned despite being enumerated: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #3924

## Problem

The userspace local-address reconcile (`syncLocalAddressMapsLocked` in
`pkg/dataplane/userspace/maps_sync.go`) builds the desired
`userspace_local_v4`/`userspace_local_v6` key set — the map the XDP shim
consults to decide whether a packet's destination is a local address (→
host path) or transit (→ redirect to XSK). Part of the desired set comes
from `netlink.AddrList(nil, family)`, which recovers kernel-owned VRRP
VIP addresses that are added dynamically after election and are absent
from the config snapshot. After the adds, the reconcile prunes every map
key not in the desired set.

`buildDesiredLocalAddressSets` swallowed an `AddrList` error with a bare
`continue`, leaving the desired set **incomplete**, and the reconcile
still pruned against that partial set. A transient netlink failure — or
an interrupted / `ENOBUFS` partial dump under memory pressure — therefore
removed the live VRRP VIP keys (and any other kernel-owned local address)
from `userspace_local_v4/v6`. Packets destined to the firewall's own
VIP / SSH / BGP / IKE endpoints stopped being classified as local and
were **blackholed**, and the error produced no log.

## Fix

Treat an incomplete enumeration as **non-authoritative**:

- `buildDesiredLocalAddressSets` is now a `*Manager` method that reports
  `enumComplete` (true only when every `AddrList` family dump succeeded)
  and enumerates through an `m.addrListForLocalSync` seam
  (`addrListForLocalSyncHook` on the Manager for tests).
- `syncLocalAddressMapsLocked` still performs the **adds** (adding a key
  only ever widens the local set — always safe) but **skips the stale-key
  prune** and logs a warning when the enumeration is incomplete. The next
  reconcile with a complete enumeration removes any genuinely stale keys,
  so pruning is only ever done against a known-complete desired set.
- Only `userspace_local_v4`/`v6` enumerate the kernel; the interface-NAT
  and config-derived local sets are snapshot-only and unaffected.

A transient netlink read failure is deliberately **not** propagated as a
returned error: a `syncLocalAddressMapsLocked` error fail-closes the
whole dataplane (disables `userspace_ctrl`), so turning a transient
`AddrList` hiccup into a hard error would over-gate and drop **all**
forwarding — worse than the VIP-only blackhole it replaces. The warning
makes the event operator-visible without the destructive side effect.

## Tests / RED-on-revert

`maps_sync_addrlist_prune_3924_test.go`:

- `TestSyncLocalAddressMapsSkipsPruneOnAddrListError` — injects an
  `AddrList` error, asserts the seeded VRRP VIP v4/v6 keys are preserved,
  the config-derived add still lands, and the warning fires. **RED on
  revert**: simulating the pre-fix always-prune makes this fail with
  "VRRP VIP v4 key pruned on incomplete enumeration".
- `TestSyncLocalAddressMapsPrunesStaleOnCompleteEnum` — a successful
  complete enumeration still prunes stale keys (no regression to the
  normal reconcile).

`go build ./...`, `gofmt`, `go vet ./pkg/dataplane/userspace/` clean.
ebpf-map tests need memlock so they run under sudo locally; both new
tests pass and RED-on-revert is proven. Neighboring sudo-only failures
(ingress_ifaces / XDP-program-load tests) reproduce identically on clean
`origin/master` (kernel 7.0.13 env) — unrelated to this change.

test-failover / VIP-reachability smoke is warranted (HA VIP steering) and
is batched with the other HA-Medium fixes by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
