### PR TITLE
cluster-sync: flush the delete journal while connected (#3926)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29442,3 +29442,37 @@ top.
     pkg/daemon/direct_garp_probe_target_test.go, pkg/vrrp/instance.go,
     pkg/vrrp/instance_garp_probe_target_test.go, pkg/vrrp/README.md,
     pkg/daemon/README.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #3926 — flush the session-delete journal while CONNECTED. A
+    session DELETE generated while the sync link is UP but `sendCh` is full
+    (backpressure) is journaled by `QueueDeleteV4`/`V6`, but the journal was
+    flushed ONLY on a full disconnect/reconnect (`handleNewConnection` →
+    `flushDeleteJournal`). The periodic sweep replayed INSTALLS but never the
+    journaled deletes, so a delete journaled while the link stayed up was never
+    delivered until an unrelated disconnect — the standby retained the dead
+    session and made a wrong forwarding decision on failover. Fix (chose the
+    sweep-replay option, mirroring the existing install-replay — it reuses the
+    tested #2121 `flushDeleteJournal`/`rejournalTail` requeue path with no
+    hot-path mutex, no O(N^2) take-all churn, and bounded ≤1s convergence since
+    delete backpressure sets `syncBackfillNeeded` which holds the sweep at the
+    1s active cadence): `syncSweep` now calls `flushDeleteJournal` every tick
+    while connected, before the `s.sessions == nil` early-return (the flush is
+    independent of the kernel session iteration). `flushDeleteJournal` is a
+    no-op on an empty journal, re-sends each entry at most once (take-all under
+    the journal lock, `DeletesSent` counted on success), preserves the encoded
+    #2170/#2221 delete generation (no re-stamp — a stale journaled delete that
+    replays after a same-key replacement was re-synced is still refused by the
+    peer's delete guard), and re-journals any un-sent tail if `sendCh` is still
+    full (retried next tick). RED-on-revert unit test
+    `TestDeleteJournalConnectedFlushViaSweep`: connected + full `sendCh` →
+    delete journaled with a fresh gen > install gen, `DeletesSent==0`; drain
+    `sendCh` WITHOUT a disconnect; `syncSweep()` flushes the delete (journal
+    empty, `DeletesSent==1`, wire gen preserved); a second sweep does not
+    double-send. Verified RED on a reverted flush line (delete stuck in journal,
+    1 remain). `go test ./pkg/cluster/...` green, `-race` on the journal tests
+    green, `go build ./...`, gofmt, vet clean. test-failover WARRANTED (HA
+    session-sync convergence) — batch with the other HA-Medium fixes under the
+    force-node0-primary gate.
+  - **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync_test.go,
+    docs/session-sync-architecture.md, _Log.md

--- a/docs/session-sync-architecture.md
+++ b/docs/session-sync-architecture.md
@@ -268,10 +268,28 @@ way the kernel conntrack path exports incremental session creation.
 ### Delete Journal
 
 Delete messages are queued immediately from conntrack GC callbacks. If the peer
-is disconnected, deletes are journaled in a bounded ring.
+is disconnected — **or the peer is connected but `sendCh` is momentarily full
+(backpressure)** — the delete is journaled in a bounded ring by
+`QueueDeleteV4`/`V6` instead of being sent inline.
 
-The journal is replayed when the next first-post-disconnect connection comes up,
-before `OnPeerConnected` and before the fresh bulk starts.
+The journal is replayed on two triggers:
+
+1. **Reconnect flush** — the next first-post-disconnect connection comes up,
+   before `OnPeerConnected` and before the fresh bulk starts
+   (`handleNewConnection` → `flushDeleteJournal`).
+2. **Connected sweep flush (#3926)** — the periodic sweep (`syncSweep`) calls
+   `flushDeleteJournal` on every tick while connected, mirroring the
+   install-replay it already performs. This converges a delete that was
+   journaled during a connected-but-backpressured moment **without requiring a
+   disconnect**. Before #3926 the journal was flushed only on trigger (1), so a
+   delete journaled while the link stayed up was never delivered until an
+   unrelated disconnect — the standby kept the dead session and made the wrong
+   forwarding decision on failover. The delete backpressure sets
+   `syncBackfillNeeded`, which holds the sweep at the 1s active cadence, so
+   convergence is bounded by one active sweep interval. The re-sent delete
+   carries the same encoded #2170/#2221 generation drawn when it was first
+   journaled, so a stale journaled delete that replays after a same-key
+   replacement was re-synced is still refused by the peer's delete guard.
 
 Replay goes through the ordered send channel (`queueMessage`), so a delete that
 is delivered stays ordered behind any session frames already queued in `sendCh`

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -685,6 +685,25 @@ func (s *SessionSync) syncSweep() int {
 	if !s.stats.Connected.Load() {
 		return 0
 	}
+	// #3926: converge journaled deletes while CONNECTED. A delete generated
+	// during a connected-but-backpressured moment (sendCh full) is journaled by
+	// QueueDeleteV4/V6 but was previously flushed ONLY on a full
+	// disconnect/reconnect (handleNewConnection) — the install-replay below
+	// never carried it, so a journaled-while-connected delete never reached the
+	// standby until an unrelated disconnect, leaving the standby with a dead
+	// session (wrong forwarding on failover). Mirror the install-replay here:
+	// flush the delete journal every sweep tick while connected so the standby
+	// converges to the primary's DELETED set without requiring a disconnect.
+	// flushDeleteJournal is a no-op when the journal is empty, re-sends each
+	// entry at most once (take-all under the journal lock, DeletesSent counted
+	// on success), preserves the encoded #2170/#2221 delete generation, and
+	// re-journals any un-sent tail if sendCh is still full (retried next tick,
+	// #2121). The delete backpressure that journaled the entry set
+	// syncBackfillNeeded, which holds the sweep at the 1s active cadence, so
+	// convergence is bounded by one active sweep interval. This flush is
+	// independent of the kernel session iteration below and runs even when
+	// s.sessions is nil.
+	s.flushDeleteJournal()
 	if s.sessions == nil {
 		return 0
 	}

--- a/pkg/cluster/sync_test.go
+++ b/pkg/cluster/sync_test.go
@@ -2368,6 +2368,102 @@ func TestDeleteJournalReconnectConvergence(t *testing.T) {
 	}
 }
 
+func TestDeleteJournalConnectedFlushViaSweep(t *testing.T) {
+	// #3926: a delete generated while CONNECTED but with a FULL sendCh is
+	// journaled by QueueDeleteV4 (connected backpressure). Before the fix the
+	// journal was flushed ONLY on a full disconnect/reconnect, so a
+	// journaled-while-connected delete never reached the standby until an
+	// unrelated disconnect — the standby kept the dead session (wrong forwarding
+	// on failover). The periodic sweep must flush the journal while connected so
+	// the standby converges to the primary's DELETED set without a disconnect.
+	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)
+	ss.IsPrimaryFn = func() bool { return true }
+	ss.stats.Connected.Store(true)
+
+	key := dataplane.SessionKey{SrcIP: [4]byte{10, 0, 1, 1}, Protocol: 6, SrcPort: 1000, DstPort: 80}
+
+	// Install once so the matching delete draws a real (non-zero,
+	// strictly-greater) generation (#2170/#2221). Drain the install frame.
+	ss.QueueSessionV4(key, dataplane.SessionValue{State: 1})
+	ss.genSentMu.Lock()
+	installGen := ss.genSentV4[key]
+	ss.genSentMu.Unlock()
+	if installGen == 0 {
+		t.Fatal("expected a non-zero install generation to be stamped")
+	}
+	select {
+	case <-ss.sendCh: // drain the install frame
+	default:
+		t.Fatal("expected the install frame on sendCh")
+	}
+
+	// Fill sendCh to capacity so the delete cannot be sent inline and is
+	// journaled (connected-but-backpressured).
+	for len(ss.sendCh) < cap(ss.sendCh) {
+		ss.sendCh <- []byte{0}
+	}
+	ss.QueueDeleteV4(key)
+
+	// The delete must be journaled (not sent) and carry a fresh gen > installGen.
+	ss.deleteJournalMu.Lock()
+	if len(ss.deleteJournal) != 1 {
+		ss.deleteJournalMu.Unlock()
+		t.Fatalf("expected 1 journaled delete, got %d", len(ss.deleteJournal))
+	}
+	wantGen := binary.LittleEndian.Uint64(ss.deleteJournal[0][syncHeaderSize+16 : syncHeaderSize+24])
+	ss.deleteJournalMu.Unlock()
+	if wantGen == 0 || wantGen <= installGen {
+		t.Fatalf("delete gen %d must be non-zero and strictly greater than install gen %d", wantGen, installGen)
+	}
+	if got := ss.stats.DeletesSent.Load(); got != 0 {
+		t.Fatalf("delete should be journaled, not sent, while sendCh is full; DeletesSent=%d", got)
+	}
+
+	// Drain sendCh entirely (capacity returns) WITHOUT a disconnect.
+	for len(ss.sendCh) > 0 {
+		<-ss.sendCh
+	}
+
+	// A connected sweep tick must flush the journaled delete (the #3926 fix). On
+	// revert, syncSweep never touches the delete journal → this assertion goes
+	// RED (the delete is stuck in the journal until a disconnect).
+	ss.syncSweep()
+
+	ss.deleteJournalMu.Lock()
+	remaining := len(ss.deleteJournal)
+	ss.deleteJournalMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("journaled delete not flushed by connected sweep, %d remain (bug #3926)", remaining)
+	}
+	if got := ss.stats.DeletesSent.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 delete flushed, DeletesSent=%d", got)
+	}
+
+	// The flushed message must be the delete carrying the exact same generation
+	// (encoded gen preserved across the connected flush — no re-stamp).
+	select {
+	case msg := <-ss.sendCh:
+		if msg[4] != syncMsgDeleteV4 {
+			t.Fatalf("flushed message type = %d, want delete %d", msg[4], syncMsgDeleteV4)
+		}
+		gotGen := binary.LittleEndian.Uint64(msg[syncHeaderSize+16 : syncHeaderSize+24])
+		if gotGen != wantGen {
+			t.Fatalf("flushed delete gen = %d, want %d (gen must be preserved)", gotGen, wantGen)
+		}
+	default:
+		t.Fatal("expected the flushed delete on sendCh")
+	}
+
+	// No double-send: a second connected sweep must not re-emit the delete.
+	ss.syncSweep()
+	if got := ss.stats.DeletesSent.Load(); got != 1 {
+		t.Fatalf("delete double-sent by second sweep, DeletesSent=%d", got)
+	}
+	if len(ss.sendCh) != 0 {
+		t.Fatalf("second sweep re-queued a delete; sendCh len=%d", len(ss.sendCh))
+	}
+}
+
 func TestSessionQueueDoesNotJournal(t *testing.T) {
 	// Session updates (not deletes) should NOT be journaled — they get replayed by sweep.
 	ss := NewSessionSync(":0", "10.0.0.2:4785", nil)


### PR DESCRIPTION
Closes #3926

## Problem

A session DELETE generated while the sync fabric is **CONNECTED** but `sendCh` is momentarily full (backpressure) is journaled by `QueueDeleteV4`/`V6` rather than sent inline. Before this change the delete journal was flushed **only** on a full disconnect/reconnect (`handleNewConnection` → `flushDeleteJournal`). The periodic sweep replayed session **INSTALLS** but never the journaled deletes, so a delete journaled during a connected-but-backpressured moment was never delivered to the standby until an unrelated disconnect.

Result: the standby **retained a dead session** (one the primary had already torn down) and made a wrong forwarding decision on failover — a torn-down flow's reverse traffic would be forwarded, or a stale NAT binding would persist.

## Fix

Mirror the install-replay: `syncSweep` now calls `flushDeleteJournal` on every tick **while connected**, before the `s.sessions == nil` early return (the flush only pushes bytes to `sendCh` and is independent of the kernel session iteration). The standby converges to the primary's DELETED set without requiring a disconnect.

`pkg/cluster/sync_conn.go` — one call added in `syncSweep`.

**Why sweep-replay over an event-driven `sendLoop` flush:** it reuses the tested #2121 `flushDeleteJournal`/`rejournalTail` requeue contract exactly — no hot-path mutex on every sent message, no O(N²) take-all churn when `sendCh` drains one slot at a time. Delete backpressure sets `syncBackfillNeeded`, which holds the sweep at the 1s active cadence, so a journaled delete is flushed within one active sweep interval.

## Correctness properties preserved

- **No double-send** — `flushDeleteJournal` takes the whole journal under the journal lock (nil'ing it) and counts `DeletesSent` only on a successful enqueue; a concurrent sweep/reconnect flush sees an empty journal.
- **Gen-correct (#2170/#2221)** — the re-sent delete carries the same encoded generation drawn by `takeDeleteGenV4` when it was first journaled (no re-stamp), so a stale journaled delete that replays after a same-key replacement session was re-synced is still refused by the peer's delete guard.
- **Drop-on-full accounting (#2121)** — an un-sent tail is re-journaled and retried next tick; genuine loss only at the journal cap, counted in `DeletesDropped`.

## Test (RED-on-revert)

`TestDeleteJournalConnectedFlushViaSweep`: connected with a full `sendCh` → delete journaled with a fresh gen greater than the install gen and `DeletesSent==0`; `sendCh` drained **WITHOUT** a disconnect; a connected `syncSweep()` flushes the delete (journal empty, `DeletesSent==1`, wire generation preserved); a second sweep does not double-send. Verified RED with the flush line reverted (delete stuck in journal, 1 remaining).

- `go test ./pkg/cluster/...` green; `-race` on the journal tests green
- `go build ./...`, `gofmt`, `go vet` clean

## Validation note

`test-failover` is **warranted** (HA session-sync convergence) — to be batched with the other HA-Medium fixes under the force-node0-primary gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi