### PR TITLE
daemon: single stable flow-trace callback, swap the writer in place (Closes #3932)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -29558,3 +29558,38 @@ top.
     force-node0-primary gate.
   - **File(s)**: pkg/cluster/sync_conn.go, pkg/cluster/sync_test.go,
     docs/session-sync-architecture.md, _Log.md
+
+- **Timestamp**: 2026-07-03
+  - **Action**: #3932 — flow-traceoptions leaked one EventReader callback per
+    commit. `updateFlowTrace`/`applyFlowTrace` (pkg/daemon/daemon_flow.go)
+    closed the old `TraceWriter` but still called
+    `EventReader.AddCallback(tw.HandleEvent)` every commit touching
+    `security flow traceoptions`, without removing the previous callback. After
+    N such commits the reader held N registered trace callbacks: each event was
+    dispatched to all N, and the stale (already-closed) writers still ran
+    `HandleEvent` and bumped `DroppedWrites` — an unbounded per-event cost plus
+    a leaked-writer drop storm on a long-lived daemon. Fix (issue option b, the
+    #2075/#3742 flowexport pattern): register a SINGLE stable indirection
+    callback `Daemon.flowTraceCallback` exactly once (guarded by `traceCBOnce`)
+    that reads the live writer lock-free from a new
+    `atomic.Pointer[logging.TraceWriter]` (`traceWriterPtr`, replacing the plain
+    `traceWriter` field); each reconcile only SWAPS the underlying writer and
+    closes the one it replaced (`reconcileFlowTrace`), guarded by `traceReconMu`
+    so exactly one writer is closed per swap while the event-path callback stays
+    lock-free. Disabling traceoptions swaps in nil (callback stays, no-op); a
+    NewTraceWriter build failure keeps the current writer running rather than
+    dropping tracing. Added exported test hook
+    `logging.SetTraceLogDirForTest` (trace.go) so the cross-package daemon test
+    can drive `NewTraceWriter` against a temp dir. RED-on-revert unit test
+    `TestFlowTraceSingleCallbackAcrossReconciles`: after 3 reconciles the reader
+    has exactly 1 callback (RED=2/3 on revert) + 1 live writer, the 2 superseded
+    writers are closed and receive ZERO dispatched events (their `DroppedWrites`
+    do not move — RED bumps them on revert), a single SESSION_CLOSE writes
+    exactly one trace line, and disabling clears the writer while the single
+    callback remains. Verified RED by simulating the per-commit AddCallback
+    (callbacks=2, want 1). `go test -race ./pkg/daemon/... ./pkg/logging/...`
+    green, `go build ./...`, gofmt, vet clean. Doc: pkg/logging/README.md
+    flow-trace single-callback bullet.
+  - **File(s)**: pkg/daemon/daemon.go, pkg/daemon/daemon_flow.go,
+    pkg/daemon/daemon_flowtrace_3932_test.go, pkg/logging/trace.go,
+    pkg/logging/README.md, _Log.md

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -288,15 +288,25 @@ type Daemon struct {
 	syncReadyTimer              *time.Timer
 	syncReadyTimeout            time.Duration
 	slogHandler                 *logging.SyslogSlogHandler
-	traceWriter                 *logging.TraceWriter
-	eventBuf                    *logging.EventBuffer
-	eventReader                 *logging.EventReader
-	eventEngine                 *eventengine.Engine
-	aggregator                  *logging.SessionAggregator
-	aggCancel                   context.CancelFunc
-	vrrpMgr                     *vrrp.Manager
-	gc                          *conntrack.GC
-	startTime                   time.Time // daemon start time; used to suppress stale config sync
+	// #3932: the flow-traceoptions writer is published through an atomic
+	// pointer read lock-free by a SINGLE stable EventReader callback that
+	// traceCBOnce registers exactly once. Each commit that changes
+	// traceoptions SWAPS the underlying writer (closing the old one) instead
+	// of registering a new callback, so a long-lived daemon that re-commits
+	// traceoptions repeatedly leaves exactly one callback and one live
+	// TraceWriter regardless of commit count. traceReconMu serializes the
+	// build+swap on the commit path; the callback reads the pointer lock-free.
+	traceWriterPtr atomic.Pointer[logging.TraceWriter]
+	traceCBOnce    sync.Once
+	traceReconMu   sync.Mutex
+	eventBuf       *logging.EventBuffer
+	eventReader    *logging.EventReader
+	eventEngine    *eventengine.Engine
+	aggregator     *logging.SessionAggregator
+	aggCancel      context.CancelFunc
+	vrrpMgr        *vrrp.Manager
+	gc             *conntrack.GC
+	startTime      time.Time // daemon start time; used to suppress stale config sync
 
 	// #846: applySem (capacity 1) serializes applyConfig + the
 	// commit→apply pair across all entry points (HTTP/gRPC commits,

--- a/pkg/daemon/daemon_flow.go
+++ b/pkg/daemon/daemon_flow.go
@@ -333,49 +333,89 @@ func scpArchiveTransfer(ctx context.Context, srcPath, dest string) error {
 	return nil
 }
 
-// applyFlowTrace sets up the initial flow trace writer from config.
-func (d *Daemon) applyFlowTrace(cfg *config.Config, er *logging.EventReader) {
-	if cfg.Security.Flow.Traceoptions == nil || cfg.Security.Flow.Traceoptions.File == "" {
+// flowTraceCallback is the single, stable flow-traceoptions handler
+// registered on the EventReader exactly ONCE (traceCBOnce). It reads the live
+// TraceWriter lock-free from the atomic pointer, so a config commit can swap
+// the writer — or clear it to nil on disable — without ever registering a
+// second callback. This is the #3932 fix: the previous applyFlowTrace /
+// updateFlowTrace called er.AddCallback on every commit touching traceoptions,
+// so a long-lived daemon leaked one callback (and one TraceWriter) per commit,
+// and every event was then dispatched to all N — a growing per-event cost plus
+// a stale-writer drop storm. A nil pointer (traceoptions disabled) makes this a
+// no-op.
+func (d *Daemon) flowTraceCallback(rec logging.EventRecord, raw []byte) {
+	tw := d.traceWriterPtr.Load()
+	if tw == nil {
 		return
 	}
-
-	tw, err := logging.NewTraceWriter(cfg.Security.Flow.Traceoptions)
-	if err != nil {
-		slog.Warn("failed to create trace writer", "err", err)
-		return
-	}
-	d.traceWriter = tw
-	er.AddCallback(tw.HandleEvent)
-	slog.Info("flow traceoptions enabled",
-		"file", cfg.Security.Flow.Traceoptions.File,
-		"filters", len(cfg.Security.Flow.Traceoptions.PacketFilters))
+	tw.HandleEvent(rec, raw)
 }
 
-// updateFlowTrace updates the trace writer when config changes.
+// applyFlowTrace sets up the initial flow trace writer from config at boot.
+func (d *Daemon) applyFlowTrace(cfg *config.Config, er *logging.EventReader) {
+	d.reconcileFlowTrace(cfg, er)
+}
+
+// updateFlowTrace reconciles the trace writer when config changes.
 func (d *Daemon) updateFlowTrace(cfg *config.Config) {
-	if d.traceWriter != nil {
-		d.traceWriter.Close()
-		d.traceWriter = nil
-	}
+	d.reconcileFlowTrace(cfg, d.eventReader)
+}
 
-	if d.eventReader == nil {
+// reconcileFlowTrace installs the flow trace writer described by cfg as the
+// SINGLE live writer. The stable indirection callback (flowTraceCallback) is
+// registered on er exactly once — the first time a writer is installed — and
+// every later call only SWAPS the underlying writer, closing the one it
+// replaced. So N commits touching traceoptions leave exactly one registered
+// callback and one live TraceWriter (#3932). Closing the old writer on swap
+// releases its file handle so it can no longer rotate the trace file (no
+// double-rotation, no drop storm from a stale closed writer). Disabling
+// traceoptions clears the writer to nil; the stable callback stays but becomes
+// a no-op. er may be nil (no event reader yet) — then this is a no-op.
+func (d *Daemon) reconcileFlowTrace(cfg *config.Config, er *logging.EventReader) {
+	if er == nil {
 		return
 	}
 
-	if cfg.Security.Flow.Traceoptions == nil || cfg.Security.Flow.Traceoptions.File == "" {
-		return
+	to := cfg.Security.Flow.Traceoptions
+	enabled := to != nil && to.File != ""
+
+	var tw *logging.TraceWriter
+	if enabled {
+		w, err := logging.NewTraceWriter(to)
+		if err != nil {
+			// Keep the current writer running rather than dropping tracing on a
+			// bad reconcile (mirrors the flowexport #3742 keep-old-on-build-
+			// failure posture). Nothing is swapped, so no callback/writer leak.
+			slog.Warn("failed to create trace writer", "err", err)
+			return
+		}
+		tw = w
+		// Register the single stable callback exactly once, the first time a
+		// writer exists. A boot with traceoptions disabled registers nothing;
+		// the first enable arms it.
+		d.traceCBOnce.Do(func() {
+			er.AddCallback(d.flowTraceCallback)
+		})
 	}
 
-	tw, err := logging.NewTraceWriter(cfg.Security.Flow.Traceoptions)
-	if err != nil {
-		slog.Warn("failed to create trace writer", "err", err)
-		return
+	// Swap the live writer (possibly nil) and close the one it replaced. The
+	// callback reads the pointer lock-free; traceReconMu only serializes
+	// concurrent reconciles so exactly one writer is closed per swap.
+	d.traceReconMu.Lock()
+	old := d.traceWriterPtr.Swap(tw)
+	if old != nil {
+		old.Close()
 	}
-	d.traceWriter = tw
-	d.eventReader.AddCallback(tw.HandleEvent)
-	slog.Info("flow traceoptions updated",
-		"file", cfg.Security.Flow.Traceoptions.File,
-		"filters", len(cfg.Security.Flow.Traceoptions.PacketFilters))
+	d.traceReconMu.Unlock()
+
+	switch {
+	case enabled:
+		slog.Info("flow traceoptions active",
+			"file", to.File,
+			"filters", len(to.PacketFilters))
+	case old != nil:
+		slog.Info("flow traceoptions disabled")
+	}
 }
 
 // monitorLinkState subscribes to netlink link updates and sends SNMP traps

--- a/pkg/daemon/daemon_flowtrace_3932_test.go
+++ b/pkg/daemon/daemon_flowtrace_3932_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/psaab/xpf/pkg/config"
+	"github.com/psaab/xpf/pkg/logging"
+)
+
+// traceOptsCfg builds a config that enables flow traceoptions to the given
+// basename with the `session` flag so SESSION_CLOSE events are traced.
+func traceOptsCfg(file string) *config.Config {
+	cfg := &config.Config{}
+	cfg.Security.Flow.Traceoptions = &config.FlowTraceoptions{
+		File:  file,
+		Flags: []string{"session"},
+	}
+	return cfg
+}
+
+// TestFlowTraceSingleCallbackAcrossReconciles pins #3932: repeated
+// traceoptions reconciles must leave EXACTLY ONE registered EventReader
+// callback and ONE live TraceWriter, swapping the underlying writer in place
+// rather than registering a new callback on every commit.
+//
+// RED-on-revert: the old applyFlowTrace/updateFlowTrace called er.AddCallback
+// on every commit, so after 3 reconciles the reader held 3 callbacks (not 1)
+// and every event was dispatched to all of them — including the stale, closed
+// writers (each bumping DroppedWrites). Both the CallbackCount == 1 assertions
+// and the stale-writer DroppedWrites-unchanged assertions flip on revert.
+func TestFlowTraceSingleCallbackAcrossReconciles(t *testing.T) {
+	dir := t.TempDir()
+	restore := logging.SetTraceLogDirForTest(dir)
+	defer restore()
+
+	d := &Daemon{
+		daemonCtx:   context.Background(),
+		eventReader: logging.NewEventReader(nil, nil),
+	}
+
+	// Boot enable.
+	d.applyFlowTrace(traceOptsCfg("trace.log"), d.eventReader)
+	w1 := d.traceWriterPtr.Load()
+	if w1 == nil {
+		t.Fatal("applyFlowTrace must install a live trace writer")
+	}
+	if n := d.eventReader.CallbackCount(); n != 1 {
+		t.Fatalf("after enable: callbacks=%d, want 1", n)
+	}
+
+	// Two more reconciles, distinct files so writer identity is observable.
+	d.updateFlowTrace(traceOptsCfg("trace2.log"))
+	w2 := d.traceWriterPtr.Load()
+	if n := d.eventReader.CallbackCount(); n != 1 {
+		t.Fatalf("after 2nd reconcile: callbacks=%d, want 1 (callback leaked on revert)", n)
+	}
+	if w2 == w1 {
+		t.Fatal("2nd reconcile must swap in a new writer")
+	}
+
+	d.updateFlowTrace(traceOptsCfg("trace3.log"))
+	w3 := d.traceWriterPtr.Load()
+	if n := d.eventReader.CallbackCount(); n != 1 {
+		t.Fatalf("after 3rd reconcile: callbacks=%d, want 1 (callback leaked on revert)", n)
+	}
+	if w3 == nil || w3 == w2 {
+		t.Fatal("3rd reconcile must swap in a new writer")
+	}
+
+	// The two superseded writers must have been closed on swap; capture their
+	// drop counters so we can prove the dispatch below never touches them.
+	before1, before2 := w1.DroppedWrites(), w2.DroppedWrites()
+
+	// Dispatch ONE SESSION_CLOSE through the reader. Exactly the single stable
+	// callback fires, so only the CURRENT writer (w3) sees the event.
+	payload := buildSessionCloseRawEventV4(
+		6, // TCP
+		[4]byte{10, 0, 1, 102}, [4]byte{172, 16, 80, 200},
+		12345, 443,
+		[4]byte{0, 0, 0, 0}, 0,
+		2, 3, // trust -> untrust
+	)
+	if !d.eventReader.ProcessRawEvent(payload) {
+		t.Fatal("ProcessRawEvent rejected a valid SESSION_CLOSE payload")
+	}
+
+	// On the fix the stale writers are unregistered, so the dispatch never
+	// reaches them: their DroppedWrites counters do not move. On revert each
+	// stale-but-closed writer's leaked callback fires and bumps DroppedWrites.
+	if got := w1.DroppedWrites(); got != before1 {
+		t.Fatalf("stale writer w1 received a dispatched event (DroppedWrites %d->%d): callback leaked", before1, got)
+	}
+	if got := w2.DroppedWrites(); got != before2 {
+		t.Fatalf("stale writer w2 received a dispatched event (DroppedWrites %d->%d): callback leaked", before2, got)
+	}
+
+	// The single live writer wrote the event exactly once (dispatch-once).
+	data, err := os.ReadFile(filepath.Join(dir, "trace3.log"))
+	if err != nil {
+		t.Fatalf("read current trace file: %v", err)
+	}
+	if got := bytes.Count(data, []byte("\n")); got != 1 {
+		t.Fatalf("current trace file has %d lines, want 1 (dispatch-once)", got)
+	}
+
+	// Disabling traceoptions clears the live writer and closes it; the stable
+	// callback stays but becomes a no-op.
+	d.updateFlowTrace(&config.Config{})
+	if d.traceWriterPtr.Load() != nil {
+		t.Fatal("disabling traceoptions must clear the live writer")
+	}
+	if n := d.eventReader.CallbackCount(); n != 1 {
+		t.Fatalf("after disable: callbacks=%d, want 1 (single stable callback stays)", n)
+	}
+	// A dispatch after disable must not panic and must write nothing.
+	if !d.eventReader.ProcessRawEvent(payload) {
+		t.Fatal("ProcessRawEvent rejected a valid SESSION_CLOSE after disable")
+	}
+}

--- a/pkg/logging/README.md
+++ b/pkg/logging/README.md
@@ -328,6 +328,24 @@ client never reconnects once the receiver returns.
   `TestLocalLogWriter_NilFileDropObservable`,
   `TestLocalLogWriter_TightensExistingMode`,
   `TestLocalLogWriter_HardenedOpen`.
+- **Flow-trace uses ONE stable EventReader callback, writer swapped in place
+  (#3932).** The daemon registers a single indirection callback
+  (`Daemon.flowTraceCallback`, `pkg/daemon/daemon_flow.go`) on the
+  `EventReader` exactly once — guarded by `traceCBOnce` — and every config
+  commit that changes `security flow traceoptions` only SWAPS the underlying
+  `TraceWriter` behind an `atomic.Pointer`, closing the writer it replaced
+  (`reconcileFlowTrace`). Before #3932, `applyFlowTrace`/`updateFlowTrace`
+  called `EventReader.AddCallback` on every such commit without removing the
+  previous one, so a long-lived daemon accumulated N callbacks: each event was
+  dispatched to all N, and the stale (already-closed) writers still received
+  every event, bumping their `DroppedWrites` — a growing per-event cost plus a
+  leaked-writer drop storm. The callback reads the live writer lock-free;
+  `traceReconMu` serializes the build+swap on the commit path so exactly one
+  writer is closed per swap. Disabling traceoptions clears the pointer to nil
+  (the stable callback stays but becomes a no-op); a build failure keeps the
+  current writer running (the flowexport #3742 keep-old-on-failure posture).
+  `EventReader.CallbackCount()` is the leak witness. Pin:
+  `TestFlowTraceSingleCallbackAcrossReconciles` (`pkg/daemon`).
 - **Event time is DECISION time, not receive time (#2465/#2470/#2511).**
   The on-wire RT_FLOW frame carries an absolute Unix-nanosecond timestamp
   in its first 8 bytes (LE u64), stamped by the userspace-dp producer at

--- a/pkg/logging/trace.go
+++ b/pkg/logging/trace.go
@@ -29,6 +29,16 @@ var errFileUnavailable = errors.New("audit log file unavailable (failed rotation
 // file always lives directly under this directory.
 var traceLogDir = "/var/log"
 
+// SetTraceLogDirForTest redirects the flow-trace output directory to dir and
+// returns a function that restores the previous value. It exists only so tests
+// in OTHER packages (the daemon #3932 single-callback reconcile test) can drive
+// NewTraceWriter against a writable temp dir; production never calls it.
+func SetTraceLogDirForTest(dir string) (restore func()) {
+	old := traceLogDir
+	traceLogDir = dir
+	return func() { traceLogDir = old }
+}
+
 // sanitizeTraceFileName validates an operator-supplied flow-trace filename.
 // The trace file always lives directly under traceLogDir, so only a bare
 // basename is accepted: path separators, "." / "..", and absolute paths are


### PR DESCRIPTION
## Summary

Closes #3932.

`updateFlowTrace` / `applyFlowTrace` (`pkg/daemon/daemon_flow.go`) closed the old `TraceWriter` on every commit touching `security flow traceoptions` but still called `EventReader.AddCallback(tw.HandleEvent)` **without removing the previous callback**. After N such commits the reader held N registered trace callbacks: each incoming event was dispatched to all N, and the stale (already-closed) writers still ran `HandleEvent` and bumped their `DroppedWrites`. A long-lived daemon that re-commits traceoptions accumulated callbacks unboundedly — a growing per-event cost plus a leaked-writer drop storm.

## Fix (issue option b — the #2075/#3742 flowexport pattern)

- Register a **single stable indirection callback** `flowTraceCallback` exactly once, guarded by `traceCBOnce`, that reads the live writer **lock-free** from a new `atomic.Pointer[logging.TraceWriter]` (`traceWriterPtr`, replacing the plain `traceWriter` field).
- Each reconcile now only **swaps** the underlying writer and closes the one it replaced (`reconcileFlowTrace`), guarded by `traceReconMu` so exactly one writer is closed per swap while the event-path callback stays lock-free.
- So **N commits leave exactly one registered callback and one live TraceWriter** regardless of commit count. Closing the old writer on swap releases its file handle (no double-rotation, no stale-writer drop storm).
- Disabling traceoptions swaps in `nil` (the callback stays but becomes a no-op); a `NewTraceWriter` build failure keeps the current writer running rather than dropping tracing.
- Added exported test hook `logging.SetTraceLogDirForTest` so the cross-package daemon test can drive `NewTraceWriter` against a temp dir.

**Key file:line:** `pkg/daemon/daemon_flow.go` `flowTraceCallback` (single callback) + `reconcileFlowTrace` (writer swap under `traceReconMu`); struct fields `pkg/daemon/daemon.go` (`traceWriterPtr` / `traceCBOnce` / `traceReconMu`).

## Test — RED on revert

`TestFlowTraceSingleCallbackAcrossReconciles` (`pkg/daemon`): after 3 reconciles the `EventReader` holds **exactly 1 callback** (RED = 2/3 on revert) and 1 live writer; the 2 superseded writers are closed and receive **zero** dispatched events (their `DroppedWrites` do not move — the revert bumps them); a single `SESSION_CLOSE` writes exactly one trace line; disabling clears the writer while the single stable callback remains. Confirmed RED by simulating the per-commit `AddCallback` (`callbacks=2, want 1`).

## Validation

- `go test -race ./pkg/daemon/... ./pkg/logging/...` — green
- `go build ./...`, `gofmt`, `go vet` — clean
- Doc: `pkg/logging/README.md` flow-trace single-callback bullet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi