### PR TITLE
cluster: order config sync with a monotonic generation (Closes #3931)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,56 @@
+## 2026-07-03 — #3931: cluster config-sync applied via unordered goroutines with no sequence number → a rapid commit pair could leave the standby on the OLDER config (no alarm)
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-156 (MEDIUM, HA config divergence). Config
+    sync applied the received config via a racing `go OnConfigReceived(...)`
+    goroutine per message (`sync_conn.go`, `syncMsgConfig` handler) with NO
+    sequence number / generation on the config-sync wire. A rapid commit pair
+    (C1 then C2) spawned two goroutines that could race: if the C1-apply ran
+    after the C2-apply, the standby ended on the OLDER C1 while the primary was
+    on C2 → the nodes DIVERGED with no alarm; on failover the standby served
+    the stale C1. Unlike the session-install path (#2170 gen-guard), config
+    sync had no ordering guard.
+  - **Fix**: (1) Wire — the config-sync payload now carries a monotonic config
+    generation as a trailing 16-byte framing
+    `[config text][configGenMagic (8)][gen u64 LE (8)]` (`encodeConfigPayload`/
+    `decodeConfigPayload`, `sync_protocol.go`). The magic (`\x00\xffxpfCG\x00`)
+    is non-printable so it cannot collide with Junos config text; a payload
+    without it is a legacy sender's raw text and decodes with gen=0 (applied
+    unconditionally). The sender (`QueueConfig`) stamps a strictly-monotonic
+    gen from `configGenCounter` (seeded from CLOCK_MONOTONIC nanos, same
+    cross-boot reasoning as the session `genCounter`). (2) Ordering + serialize
+    — the handler no longer spawns a racing goroutine; it enqueues
+    `{gen, text}` onto a bounded single-consumer queue (`configApplyCh`) drained
+    by `configApplyLoop` (started in `Start`). The receiveLoop is
+    single-threaded per connection, so this preserves receive order; the
+    non-blocking enqueue never stalls session sync / heartbeats behind a slow
+    apply. `admitConfigGen` applies a config only if its gen is strictly newer
+    than `lastAppliedConfigGen` (or gen=0 legacy); an out-of-order older config
+    is dropped with an alarm and counted in `ConfigsStaleIgnored`. The standby
+    always converges to the newest config. `resetRecvGen` (BulkStart) also
+    zeroes `lastAppliedConfigGen` so a rebooted primary's lower-seeded counter
+    is accepted, not refused as stale (#2198 F2 reasoning applied to config).
+    Deliberately NO `SessionSyncWireVersion` bump — the framing is additive and
+    self-detecting (the #2239 lesson); the only degraded direction is a new
+    sender → legacy receiver in the brief ISSU window, which fails SAFE (old
+    node's parser rejects the framing bytes → keeps its current config).
+  - **Test**: `pkg/cluster/sync_config_gen_test.go` — wire round-trip +
+    legacy/short/empty decode, `admitConfigGen` monotonic + legacy-unconditional
+    + reset, and the end-to-end RED-on-revert
+    `TestConfigSyncOrderedApplyDropsReorderedOlder` (delivers C2 then C1 →
+    standby ends on C2, drops stale C1, `ConfigsStaleIgnored=1`). RED-on-revert
+    VERIFIED: neutralizing `admitConfigGen` to always-accept makes the standby
+    end on the older C1 (`applied=[C2 C1]`) → test fails. `go test -race
+    ./pkg/cluster/...` and `go test ./pkg/daemon/...` green; `go build ./...`,
+    `go vet ./pkg/cluster/...`, gofmt clean.
+  - **File(s)**: `pkg/cluster/sync.go`, `pkg/cluster/sync_conn.go`,
+    `pkg/cluster/sync_protocol.go`, `pkg/cluster/status.go`,
+    `pkg/cluster/sync_config_gen_test.go`, `docs/sync-protocol.md`,
+    `docs/feature-coverage.md`, `_Log.md`
+  - **Validation flag**: test-failover WARRANTED (HA config convergence) —
+    parent batch-validates on the loss userspace cluster with the
+    force-node0-primary gate.
+
 ## 2026-07-03 — #3918: flow-cache neighbor_mac_epoch stamped AFTER neighbor resolve → resolve→stamp TOCTOU re-opens the #3048 stale-MAC blackhole on VRRP gateway failover
 
 - **Timestamp**: 2026-07-03

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -119,7 +119,9 @@ the userspace dataplane admission boundary is in
 - **Session sync**: incremental 1s sweep + ring buffer + GC delete
   callbacks, TCP on fabric link.
 - **Config sync**: primary → secondary with `${node}` variable expansion,
-  reverse-sync on reconnect.
+  reverse-sync on reconnect. Each push carries a monotonic config generation
+  and applies through a single-consumer ordered queue, so a rapid commit pair
+  cannot leave the standby on the older config (#3931).
 - **IPsec SA sync**: shared IKE/ESP state across cluster nodes.
 - **Dual fabric links**: independent fab0/fab1 for redundancy (no
   bonding).

--- a/docs/sync-protocol.md
+++ b/docs/sync-protocol.md
@@ -41,7 +41,7 @@ All multi-byte integers in the wire format are **little-endian**, matching the n
 | 5    | BulkStart        | Primary→Secondary | 0                   | Marks start of bulk transfer |
 | 6    | BulkEnd          | Primary→Secondary | 0                   | Marks end of bulk transfer |
 | 7    | Heartbeat        | Bidirectional     | 0                   | Keepalive (sent on 30s idle) |
-| 8    | Config           | Primary→Secondary | Variable (UTF-8)    | Full config text |
+| 8    | Config           | Primary→Secondary | Variable (UTF-8) + 16B gen framing | Full config text + monotonic config generation (#3931) |
 | 9    | IPsecSA          | Primary→Secondary | Variable (UTF-8)    | Newline-separated connection names |
 
 ## Session V4 Payload Layout (120 bytes)
@@ -300,7 +300,56 @@ V6}` (drives the real sender enqueue + receiver apply in wire order),
 
 ## Config Payload (Variable)
 
-Raw UTF-8 text of the full Junos-format configuration. Sent as-is after `commitConfig()` on the primary. The secondary's `OnConfigReceived` callback invokes `load override` + commit to apply it.
+UTF-8 text of the full Junos-format configuration followed by a trailing
+16-byte generation framing (#3931):
+
+```
+[config text bytes ...][configGenMagic (8 bytes)][gen (uint64 LE, 8 bytes)]
+```
+
+`configGenMagic` = `00 ff 78 70 66 43 47 00` (`\x00\xffxpfCG\x00`), chosen from
+non-printable bytes so it cannot collide with real Junos config text. The
+sender (`QueueConfig`) stamps a strictly-monotonic `gen` drawn from a
+process-wide counter seeded from `CLOCK_MONOTONIC` nanos (same cross-boot
+reasoning as the session install `genCounter`).
+
+**Ordering guard (#3931).** Config sync historically applied via a racing
+`go OnConfigReceived` goroutine per message with no sequence number, so a rapid
+commit pair (C1 then C2) could apply out of order and leave the standby on the
+older C1 with no alarm. The receiver now:
+
+1. Decodes `(configText, gen)` with `decodeConfigPayload`. A payload without the
+   trailing magic is a **legacy sender's** raw config text and decodes with
+   `gen=0` (applied unconditionally — the pre-#3931 behavior).
+2. Enqueues `{gen, configText}` onto a bounded, single-consumer ordered apply
+   queue (`configApplyLoop`) — the `receiveLoop` is single-threaded per
+   connection, so this preserves receive order. The non-blocking enqueue never
+   stalls session sync / heartbeats behind a slow config apply.
+3. Applies a config only when `admitConfigGen` accepts its generation
+   (strictly newer than the last-applied high-water mark, or `gen=0`). An
+   out-of-order older config is **dropped with an alarm** and counted in
+   `ConfigsStaleIgnored`. The standby therefore always converges to the newest
+   config the primary sent.
+
+The last-applied high-water mark is reset to 0 on a peer bulk re-prime
+(`resetRecvGen`, fired on `BulkStart`) so a **rebooted primary** — whose
+monotonic counter restarts lower — is accepted instead of refused as stale
+(the #2198 F2 inverse-of-stale-RETAIN reasoning applied to config). The next
+config after a reconnect is always the peer's *current* config
+(`pushConfigToPeer` sends `ShowActive`), so the newest content still wins.
+
+**Wire compatibility.** #3931 deliberately does NOT bump
+`SessionSyncWireVersion`: the framing is additive and self-detecting via the
+magic, and that gate governs whether SESSIONS sync at all across a mixed-base
+pair — bumping it would break session sync for the whole mixed-version ISSU
+window (the #2239 lesson). The one asymmetric direction is a NEW sender's
+framed payload reaching a LEGACY receiver in the brief ISSU window: the old
+node treats the 16 trailing bytes as config text, its Junos parser rejects it,
+and the config-sync apply fails — the old node retains its current config
+(fail-safe, no crash, no divergence worse than today).
+
+The secondary's `OnConfigReceived` callback invokes `load override` + commit to
+apply the accepted config.
 
 ## IPsec SA Payload (Variable)
 
@@ -409,7 +458,7 @@ This is **additive** to the periodic sweep — it provides sub-millisecond sync 
 | DeleteV4/V6 | Lookup → delete reverse → delete dnat_table (SNAT) → delete forward |
 | BulkStart/End | Log markers; BulkEnd triggers `OnBulkSyncReceived` (releases VRRP sync hold) |
 | Heartbeat | No-op (resets read deadline) |
-| Config | `OnConfigReceived` callback (runs in goroutine) |
+| Config | Decode `(text, gen)` → enqueue on the single-consumer ordered apply queue (`configApplyLoop`); `admitConfigGen` drops out-of-order older gens, then `OnConfigReceived` applies (#3931) |
 | IPsecSA | Store names, call `OnIPsecSAReceived` |
 
 ### Session Reconstruction on Receiver
@@ -463,6 +512,7 @@ All counters are `atomic.Uint64` / `atomic.Bool`, lock-free:
 | DeletesReceived | Delete messages received |
 | BulkSyncs | Completed bulk sync operations |
 | ConfigsSent/Received | Config sync messages |
+| ConfigsStaleIgnored | Config messages dropped by the #3931 ordering guard (incoming generation not strictly newer than last-applied) |
 | IPsecSASent/Received | IPsec SA list messages |
 | Errors | Send failures, channel overflows, bad magic |
 | Connected | Peer TCP connection active |

--- a/pkg/cluster/status.go
+++ b/pkg/cluster/status.go
@@ -328,6 +328,9 @@ func (m *Manager) FormatInformation() string {
 		}
 		fmt.Fprintf(&b, "  Configs sent:     %d\n", syncStats.ConfigsSent)
 		fmt.Fprintf(&b, "  Configs received: %d\n", syncStats.ConfigsReceived)
+		if syncStats.ConfigsStaleIgnored > 0 {
+			fmt.Fprintf(&b, "  Configs stale-dropped: %d\n", syncStats.ConfigsStaleIgnored)
+		}
 	} else {
 		fmt.Fprintln(&b, "  Not configured")
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -100,8 +100,15 @@ type SyncStats struct {
 	BulkSyncs         atomic.Uint64
 	ConfigsSent       atomic.Uint64
 	ConfigsReceived   atomic.Uint64
-	IPsecSASent       atomic.Uint64
-	IPsecSAReceived   atomic.Uint64
+	// ConfigsStaleIgnored counts config-sync messages dropped by the #3931
+	// config-generation ordering guard: an incoming config whose monotonic
+	// generation was NOT strictly newer than the last-applied one (an
+	// out-of-order / reordered older config). A nonzero value means the
+	// guard prevented a rapid-commit reorder (C1 applied after C2) from
+	// leaving the standby on the older config.
+	ConfigsStaleIgnored atomic.Uint64
+	IPsecSASent         atomic.Uint64
+	IPsecSAReceived     atomic.Uint64
 	// #2239 HA DHCP-server lease sync counters. Sent/Received count
 	// full-set lease push MESSAGES (one per family per push); Seeded counts
 	// leases written into a freshly-started Kea on takeover; errors fold
@@ -154,6 +161,7 @@ type SyncStatsSnapshot struct {
 	BulkSyncs            uint64
 	ConfigsSent          uint64
 	ConfigsReceived      uint64
+	ConfigsStaleIgnored  uint64
 	IPsecSASent          uint64
 	IPsecSAReceived      uint64
 	DHCPLeasesSent       uint64
@@ -348,6 +356,36 @@ type SessionSync struct {
 	recvGenMu  sync.Mutex
 	recvGenV4  map[dataplane.SessionKey]uint64
 	recvGenV6  map[dataplane.SessionKeyV6]uint64
+
+	// #3931 config-sync ordering guard.
+	//
+	// Sender side: configGenCounter is a process-wide strictly-monotonic
+	// config generation, seeded at construction from CLOCK_MONOTONIC nanos
+	// (the same cross-boot reasoning as the session genCounter above). Every
+	// QueueConfig draws configGenCounter.Add(1) and STAMPS it on the wire
+	// (encodeConfigPayload), so a rapid commit pair carries strictly
+	// increasing generations.
+	//
+	// Receiver side: the config-sync handler no longer spawns a racing
+	// goroutine per message (the pre-#3931 `go OnConfigReceived` hazard). It
+	// enqueues (gen, text) onto configApplyCh, and a single ordered consumer
+	// (configApplyLoop) drains it in receive order, applying a config only
+	// when its generation is strictly newer than lastAppliedConfigGen
+	// (admitConfigGen). An out-of-order older config is dropped with an alarm
+	// (ConfigsStaleIgnored). lastAppliedConfigGen is reset to 0 on a peer
+	// bulk re-prime (resetRecvGen) so a rebooted primary — whose monotonic
+	// counter restarts lower — is accepted instead of refused as stale (the
+	// #2198 F2 inverse-of-stale-RETAIN reasoning, applied to config).
+	configGenCounter     atomic.Uint64
+	lastAppliedConfigGen atomic.Uint64
+	configApplyCh        chan configApplyItem
+}
+
+// configApplyItem is one config-sync payload queued for ordered apply by the
+// single-consumer configApplyLoop (#3931).
+type configApplyItem struct {
+	gen  uint64
+	text string
 }
 type failoverAck struct {
 	status uint8
@@ -504,6 +542,16 @@ func (s *SessionSync) initGenState() {
 	s.genSentV6 = make(map[dataplane.SessionKeyV6]uint64)
 	s.recvGenV4 = make(map[dataplane.SessionKey]uint64)
 	s.recvGenV6 = make(map[dataplane.SessionKeyV6]uint64)
+	// #3931: seed the config generation from the same monotonic base so the
+	// sender's config-gen never regresses below a value the peer may hold
+	// across this node's restarts within a boot, and create the ordered
+	// config-apply queue drained by configApplyLoop. Buffered generously —
+	// commits are seconds apart and apply is sub-second, so the queue never
+	// fills in practice; overflow drops with an alarm and re-converges on the
+	// next commit/reconnect re-push (see the syncMsgConfig handler).
+	s.configGenCounter.Store(seed)
+	s.lastAppliedConfigGen.Store(0)
+	s.configApplyCh = make(chan configApplyItem, 64)
 }
 
 // NewDualSessionSync creates a session sync manager with dual-fabric transport.
@@ -592,7 +640,7 @@ func (s *SessionSync) Stats() SyncStatsSnapshot {
 		activeFabric = -1
 	}
 	s.mu.Unlock()
-	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
+	return SyncStatsSnapshot{SessionsSent: s.stats.SessionsSent.Load(), SessionsReceived: s.stats.SessionsReceived.Load(), SessionsInstalled: s.stats.SessionsInstalled.Load(), DeletesSent: s.stats.DeletesSent.Load(), DeletesReceived: s.stats.DeletesReceived.Load(), BulkSyncs: s.stats.BulkSyncs.Load(), ConfigsSent: s.stats.ConfigsSent.Load(), ConfigsReceived: s.stats.ConfigsReceived.Load(), ConfigsStaleIgnored: s.stats.ConfigsStaleIgnored.Load(), IPsecSASent: s.stats.IPsecSASent.Load(), IPsecSAReceived: s.stats.IPsecSAReceived.Load(), DHCPLeasesSent: s.stats.DHCPLeasesSent.Load(), DHCPLeasesReceived: s.stats.DHCPLeasesReceived.Load(), DHCPLeasesSeeded: s.stats.DHCPLeasesSeeded.Load(), FencesSent: s.stats.FencesSent.Load(), FencesReceived: s.stats.FencesReceived.Load(), Errors: s.stats.Errors.Load(), DeletesDropped: s.stats.DeletesDropped.Load(), DeletesStaleIgnored: s.stats.DeletesStaleIgnored.Load(), InstallsStaleIgnored: s.stats.InstallsStaleIgnored.Load(), GenMapOverflow: s.stats.GenMapOverflow.Load(), Connected: s.stats.Connected.Load(), ActiveFabric: activeFabric, BulkSyncStartTime: s.stats.BulkSyncStartTime.Load(), BulkSyncEndTime: s.stats.BulkSyncEndTime.Load(), BulkSyncSessions: s.stats.BulkSyncSessions.Load(), LastConfigSyncTime: s.stats.LastConfigSyncTime.Load(), LastConfigSyncSize: s.stats.LastConfigSyncSize.Load(), LastFenceSeq: s.stats.LastFenceSeq.Load(), LastFenceAckAt: s.stats.LastFenceAckAt.Load()}
 }
 
 // IsConnected reports whether a peer sync connection is currently established.

--- a/pkg/cluster/sync_config_gen_test.go
+++ b/pkg/cluster/sync_config_gen_test.go
@@ -1,0 +1,269 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// #3931 — HA config-sync generation ordering guard tests.
+//
+// These exercise the config-sync wire codec (encodeConfigPayload /
+// decodeConfigPayload), the receiver-side ordering guard (admitConfigGen), and
+// the single-consumer ordered apply loop (configApplyLoop). Every test is
+// written so it FAILS against the pre-#3931 behavior, where a config was
+// applied via a racing `go OnConfigReceived` with NO generation on the wire:
+// a rapid commit pair (C1 then C2) could apply out of order and leave the
+// standby on the older C1.
+
+// --- wire codec round-trip -------------------------------------------------
+
+func TestConfigPayloadRoundTrip(t *testing.T) {
+	const text = "set system host-name node0\nset interfaces ge-0/0/0 unit 0 family inet address 10.0.1.1/24\n"
+	payload := encodeConfigPayload(text, 42)
+	gotText, gotGen := decodeConfigPayload(payload)
+	if gotText != text {
+		t.Fatalf("config text round-trip mismatch:\n got %q\nwant %q", gotText, text)
+	}
+	if gotGen != 42 {
+		t.Fatalf("config gen round-trip mismatch: got %d want 42", gotGen)
+	}
+}
+
+// A legacy sender emits the raw config text with no trailing framing; the new
+// receiver must decode it with gen==0 (applied unconditionally).
+func TestConfigPayloadLegacyNoMagic(t *testing.T) {
+	const text = "set system host-name legacy\n"
+	gotText, gotGen := decodeConfigPayload([]byte(text))
+	if gotText != text {
+		t.Fatalf("legacy config text mismatch: got %q want %q", gotText, text)
+	}
+	if gotGen != 0 {
+		t.Fatalf("legacy config gen must be 0, got %d", gotGen)
+	}
+}
+
+// Config text that happens to be short must not be misread as framed.
+func TestConfigPayloadShortNotFramed(t *testing.T) {
+	const text = "short"
+	gotText, gotGen := decodeConfigPayload([]byte(text))
+	if gotText != text || gotGen != 0 {
+		t.Fatalf("short payload mis-decoded: got %q/%d", gotText, gotGen)
+	}
+}
+
+// An empty config text still frames and decodes with its generation.
+func TestConfigPayloadEmptyText(t *testing.T) {
+	payload := encodeConfigPayload("", 7)
+	gotText, gotGen := decodeConfigPayload(payload)
+	if gotText != "" || gotGen != 7 {
+		t.Fatalf("empty-text framing mis-decoded: got %q/%d", gotText, gotGen)
+	}
+}
+
+// --- ordering guard --------------------------------------------------------
+
+func TestAdmitConfigGenMonotonic(t *testing.T) {
+	s := &SessionSync{}
+	// First real config admits and sets the high-water mark.
+	if !s.admitConfigGen(5) {
+		t.Fatal("gen 5 should admit (first config)")
+	}
+	// A strictly-newer config admits.
+	if !s.admitConfigGen(6) {
+		t.Fatal("gen 6 should admit (newer than 5)")
+	}
+	// An older config (the reordered C1) is refused.
+	if s.admitConfigGen(5) {
+		t.Fatal("gen 5 must be refused after gen 6 applied (stale)")
+	}
+	// The same generation is refused (not strictly newer).
+	if s.admitConfigGen(6) {
+		t.Fatal("gen 6 must be refused after gen 6 applied (not strictly newer)")
+	}
+	if got := s.lastAppliedConfigGen.Load(); got != 6 {
+		t.Fatalf("last-applied gen should be 6, got %d", got)
+	}
+}
+
+// gen==0 (legacy sender) is always applied and does NOT advance the
+// high-water mark, so a subsequent real generation still orders correctly.
+func TestAdmitConfigGenLegacyUnconditional(t *testing.T) {
+	s := &SessionSync{}
+	if !s.admitConfigGen(0) {
+		t.Fatal("legacy gen 0 must always admit")
+	}
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("gen 0 must not advance high-water mark, got %d", got)
+	}
+	if !s.admitConfigGen(3) {
+		t.Fatal("real gen 3 should admit after a legacy gen 0")
+	}
+	if !s.admitConfigGen(0) {
+		t.Fatal("legacy gen 0 must still admit after a real gen")
+	}
+	if got := s.lastAppliedConfigGen.Load(); got != 3 {
+		t.Fatalf("high-water mark should remain 3, got %d", got)
+	}
+}
+
+// After a peer bulk re-prime (resetRecvGen), the high-water mark resets so a
+// rebooted primary — whose monotonic counter restarts LOWER — is accepted
+// instead of refused as stale (#2198 F2 reasoning applied to config).
+func TestResetRecvGenResetsConfigGen(t *testing.T) {
+	s := &SessionSync{}
+	s.recvGenV4 = nil
+	s.recvGenV6 = nil
+	if !s.admitConfigGen(100) {
+		t.Fatal("gen 100 should admit")
+	}
+	s.resetRecvGen()
+	if got := s.lastAppliedConfigGen.Load(); got != 0 {
+		t.Fatalf("resetRecvGen must zero the config gen, got %d", got)
+	}
+	// A lower generation (rebooted peer) now applies.
+	if !s.admitConfigGen(3) {
+		t.Fatal("gen 3 should admit after reset (rebooted peer)")
+	}
+}
+
+// --- end-to-end ordered apply (RED-on-revert) ------------------------------
+
+// configRecorder captures the sequence of applied config texts under a mutex
+// so the ordered-apply consumer can be observed deterministically.
+type configRecorder struct {
+	mu      sync.Mutex
+	applied []string
+}
+
+func (r *configRecorder) record(text string) {
+	r.mu.Lock()
+	r.applied = append(r.applied, text)
+	r.mu.Unlock()
+}
+
+func (r *configRecorder) last() (string, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.applied) == 0 {
+		return "", 0
+	}
+	return r.applied[len(r.applied)-1], len(r.applied)
+}
+
+// drainConfigApply waits for the ordered consumer to drain configApplyCh and
+// finish the in-flight apply, so the recorder can be observed deterministically.
+func drainConfigApply(t *testing.T, s *SessionSync) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(s.configApplyCh) == 0 {
+			// Give the consumer a beat to finish the in-flight item.
+			time.Sleep(5 * time.Millisecond)
+			if len(s.configApplyCh) == 0 {
+				return
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestConfigSyncOrderedApplyDropsReorderedOlder is the #3931 RED-on-revert
+// test. It delivers C2 (newer) BEFORE C1 (older) — the reordered-apply case —
+// and asserts the standby ends on C2 and drops the stale C1. Under the
+// pre-#3931 racing/no-gen behavior both would apply and the final state could
+// be C1 (diverged), so this fails on revert.
+func TestConfigSyncOrderedApplyDropsReorderedOlder(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	rec := &configRecorder{}
+	s.OnConfigReceived = rec.record
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	// Reordered delivery: C2 (gen 2) enqueued before C1 (gen 1).
+	s.configApplyCh <- configApplyItem{gen: 2, text: "config-C2"}
+	s.configApplyCh <- configApplyItem{gen: 1, text: "config-C1"}
+
+	drainConfigApply(t, s)
+
+	last, count := rec.last()
+	if last != "config-C2" {
+		t.Fatalf("standby must end on the newest config C2, ended on %q (applied=%v)", last, rec.applied)
+	}
+	if count != 1 {
+		t.Fatalf("only C2 should have applied; got %d applies: %v", count, rec.applied)
+	}
+	if got := s.stats.ConfigsStaleIgnored.Load(); got != 1 {
+		t.Fatalf("stale C1 must be counted as dropped, ConfigsStaleIgnored=%d", got)
+	}
+	if got := s.lastAppliedConfigGen.Load(); got != 2 {
+		t.Fatalf("last-applied gen should be 2 (C2), got %d", got)
+	}
+}
+
+// In-order delivery applies both configs and the standby ends on the newest.
+func TestConfigSyncOrderedApplyInOrder(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	rec := &configRecorder{}
+	s.OnConfigReceived = rec.record
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	s.configApplyCh <- configApplyItem{gen: 1, text: "config-C1"}
+	s.configApplyCh <- configApplyItem{gen: 2, text: "config-C2"}
+
+	drainConfigApply(t, s)
+
+	last, count := rec.last()
+	if last != "config-C2" {
+		t.Fatalf("standby must end on C2, ended on %q", last)
+	}
+	if count != 2 {
+		t.Fatalf("both configs should apply in order, got %d: %v", count, rec.applied)
+	}
+	if got := s.stats.ConfigsStaleIgnored.Load(); got != 0 {
+		t.Fatalf("no config should be dropped in-order, ConfigsStaleIgnored=%d", got)
+	}
+}
+
+// A single config push applies normally (regression guard on the common path).
+func TestConfigSyncSinglePushApplies(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	rec := &configRecorder{}
+	s.OnConfigReceived = rec.record
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.configApplyLoop(ctx)
+
+	s.configApplyCh <- configApplyItem{gen: 9, text: "config-only"}
+	drainConfigApply(t, s)
+
+	last, count := rec.last()
+	if last != "config-only" || count != 1 {
+		t.Fatalf("single push should apply once, got %q count=%d", last, count)
+	}
+}
+
+// The QueueConfig sender + decodeConfigPayload receiver agree on the wire
+// generation, and the drawn generations are strictly monotonic per push.
+func TestNextConfigGenMonotonic(t *testing.T) {
+	s := NewSessionSync("127.0.0.1:0", "127.0.0.1:0", nil)
+	g1 := s.nextConfigGen()
+	g2 := s.nextConfigGen()
+	g3 := s.nextConfigGen()
+	if !(g1 < g2 && g2 < g3) {
+		t.Fatalf("config generations must be strictly monotonic, got %d,%d,%d", g1, g2, g3)
+	}
+	// A payload stamped with a drawn generation decodes back to the same value.
+	payload := encodeConfigPayload("set system host-name x", g2)
+	_, gen := decodeConfigPayload(payload)
+	if gen != g2 {
+		t.Fatalf("decoded gen %d != stamped gen %d", gen, g2)
+	}
+}

--- a/pkg/cluster/sync_conn.go
+++ b/pkg/cluster/sync_conn.go
@@ -289,6 +289,16 @@ func (s *SessionSync) resetRecvGen() {
 	s.recvGenV4 = make(map[dataplane.SessionKey]uint64)
 	s.recvGenV6 = make(map[dataplane.SessionKeyV6]uint64)
 	s.recvGenMu.Unlock()
+	// #3931: also reset the last-applied config generation. A reconnecting
+	// peer may have REBOOTED, restarting its monotonic configGenCounter at a
+	// value LOWER than the generation we stored from its previous boot.
+	// Without this reset the config guard (admitConfigGen) would refuse the
+	// reconnect config re-push as stale (last > incoming) — the same
+	// stale-RETAIN inverse the session reset closes (#2198 F2). Resetting to
+	// 0 makes the next config apply unconditionally; it is always the peer's
+	// CURRENT config (pushConfigToPeer sends ShowActive), so the newest
+	// content still wins.
+	s.lastAppliedConfigGen.Store(0)
 }
 
 // Non-atomicity note (#2198 F3): the apply sequence — guard check
@@ -573,6 +583,14 @@ func (s *SessionSync) Start(ctx context.Context) error {
 	go func() {
 		defer s.wg.Done()
 		s.sendLoop(ctx)
+	}()
+	// #3931: single ordered consumer for config-sync apply. Started once here
+	// so it lives for the whole sync lifetime; it drains configApplyCh in
+	// receive order and enforces the monotonic config-generation guard.
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.configApplyLoop(ctx)
 	}()
 	return nil
 }
@@ -974,13 +992,25 @@ func (s *SessionSync) rejournalTail(tail [][]byte) {
 	s.deleteJournal = merged
 }
 
-// QueueConfig sends the full config text to the peer for configuration synchronization.
+// nextConfigGen draws the next strictly-monotonic config generation stamped
+// on an outgoing config-sync message (#3931). The counter is seeded from
+// CLOCK_MONOTONIC nanos at construction so it never regresses below a value
+// the peer may already hold across this node's restarts within a boot.
+func (s *SessionSync) nextConfigGen() uint64 {
+	return s.configGenCounter.Add(1)
+}
+
+// QueueConfig sends the full config text to the peer for configuration
+// synchronization. The payload carries a monotonic config generation (#3931)
+// so the receiver can order a rapid commit pair and refuse a reordered older
+// config.
 func (s *SessionSync) QueueConfig(configText string) {
 	conn := s.getActiveConn()
 	if conn == nil {
 		return
 	}
-	payload := []byte(configText)
+	gen := s.nextConfigGen()
+	payload := encodeConfigPayload(configText, gen)
 	s.writeMu.Lock()
 	err := writeMsg(conn, syncMsgConfig, payload)
 	s.writeMu.Unlock()
@@ -991,7 +1021,50 @@ func (s *SessionSync) QueueConfig(configText string) {
 		return
 	}
 	s.stats.ConfigsSent.Add(1)
-	slog.Info("cluster sync: config sent to peer", "size", len(payload))
+	slog.Info("cluster sync: config sent to peer", "size", len(configText), "gen", gen)
+}
+
+// admitConfigGen implements the #3931 receiver-side config ordering guard. It
+// returns true if a config with generation gen should be applied — strictly
+// newer than the last-applied one, or gen==0 (a legacy sender / unknown, which
+// is applied unconditionally without advancing the high-water mark) — and
+// false if it is an out-of-order older config that must be dropped. On admit
+// of a non-zero gen it advances lastAppliedConfigGen. It is called ONLY from
+// the single-consumer configApplyLoop, so the load/store pair needs no CAS.
+func (s *SessionSync) admitConfigGen(gen uint64) bool {
+	last := s.lastAppliedConfigGen.Load()
+	if gen != 0 && last != 0 && gen <= last {
+		return false
+	}
+	if gen != 0 && gen > last {
+		s.lastAppliedConfigGen.Store(gen)
+	}
+	return true
+}
+
+// configApplyLoop is the single ordered consumer of config-sync messages
+// (#3931). It drains configApplyCh in receive order and applies a config only
+// when admitConfigGen accepts its generation, so a reordered older config from
+// a rapid commit pair (C1 after C2) is dropped and the standby always
+// converges to the newest config. Replaces the pre-#3931 racing
+// `go OnConfigReceived` per message.
+func (s *SessionSync) configApplyLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case item := <-s.configApplyCh:
+			if !s.admitConfigGen(item.gen) {
+				s.stats.ConfigsStaleIgnored.Add(1)
+				slog.Warn("cluster sync: dropping out-of-order config sync (stale generation) — standby retains newer config",
+					"incoming_gen", item.gen, "last_applied_gen", s.lastAppliedConfigGen.Load(), "size", len(item.text))
+				continue
+			}
+			if s.OnConfigReceived != nil {
+				s.OnConfigReceived(item.text)
+			}
+		}
+	}
 }
 
 // SendLivenessKeepalive writes a sync-level heartbeat to the active peer
@@ -1348,11 +1421,26 @@ func (s *SessionSync) handleMessage(conn net.Conn, msgType uint8, payload []byte
 	case syncMsgConfig:
 		s.stats.ConfigsReceived.Add(1)
 		s.stats.LastConfigSyncTime.Store(time.Now().UnixNano())
-		s.stats.LastConfigSyncSize.Store(uint64(len(payload)))
-		if s.OnConfigReceived != nil {
-			configText := string(payload)
-			slog.Info("cluster sync: config received from peer", "size", len(payload))
-			go s.OnConfigReceived(configText)
+		configText, gen := decodeConfigPayload(payload)
+		s.stats.LastConfigSyncSize.Store(uint64(len(configText)))
+		slog.Info("cluster sync: config received from peer", "size", len(configText), "gen", gen)
+		// #3931: enqueue onto the single-consumer ordered apply queue instead
+		// of spawning a racing `go OnConfigReceived`. The receiveLoop is
+		// single-threaded per connection, so this preserves receive order;
+		// configApplyLoop then applies only strictly-newer generations. The
+		// enqueue is non-blocking so a slow apply never stalls session sync /
+		// heartbeats on this connection.
+		if s.configApplyCh != nil {
+			select {
+			case s.configApplyCh <- configApplyItem{gen: gen, text: configText}:
+			default:
+				// Ordered apply queue full — practically impossible (commits
+				// are seconds apart, apply is sub-second). Drop with an alarm;
+				// the next commit / reconnect re-push (fresh higher gen)
+				// re-converges the standby.
+				s.stats.Errors.Add(1)
+				slog.Error("cluster sync: config apply queue full, dropping config (will re-converge on next push)", "gen", gen, "size", len(configText))
+			}
 		}
 	case syncMsgIPsecSA:
 		s.stats.IPsecSAReceived.Add(1)

--- a/pkg/cluster/sync_protocol.go
+++ b/pkg/cluster/sync_protocol.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"bytes"
 	"encoding/binary"
 	"net"
 	"strings"
@@ -570,6 +571,53 @@ func decodeIPsecSAPayload(payload []byte) []string {
 		}
 	}
 	return names
+}
+
+// --- #3931 config-sync generation wire codec ------------------------------
+//
+// The config-sync payload historically was the raw UTF-8 config text with no
+// framing. #3931 appends a monotonic config generation so the receiver can
+// order a rapid commit pair (C1 then C2) and refuse a reordered older config.
+// Because the config text is arbitrary bytes (no fixed layout to length-gate a
+// leading field against), the generation is carried as a TRAILING framing:
+//
+//	[config text bytes][configGenMagic (8)][gen (uint64 LE, 8)]
+//
+// A NEW receiver (decodeConfigPayload) detects the magic at the tail and peels
+// off the trailing 16 bytes; a payload without the magic is a LEGACY sender's
+// raw config text and decodes with gen=0 (applied unconditionally, preserving
+// the pre-#3931 behavior). The magic bytes are deliberately non-printable so
+// they cannot collide with real Junos config text. NOTE the one asymmetric
+// direction: a NEW sender's framed payload reaching a LEGACY receiver (only
+// possible in the brief mixed-version ISSU window) is treated by that old
+// receiver as config text with 16 trailing binary bytes, which its Junos
+// parser rejects — the config-sync apply fails and the old node retains its
+// current config (fail-safe, no crash, no divergence worse than today). This
+// is why #3931 does NOT bump SessionSyncWireVersion: that gate governs whether
+// SESSIONS sync at all across a mixed pair, and bumping it would break session
+// sync for the whole mixed-base window (the #2239 lesson). Config-gen is
+// additive and self-detecting via the magic.
+var configGenMagic = [8]byte{0x00, 0xff, 'x', 'p', 'f', 'C', 'G', 0x00}
+
+// encodeConfigPayload builds a config-sync payload carrying the config text
+// and a trailing generation (see the codec note above).
+func encodeConfigPayload(configText string, gen uint64) []byte {
+	buf := make([]byte, 0, len(configText)+16)
+	buf = append(buf, configText...)
+	buf = append(buf, configGenMagic[:]...)
+	buf = binary.LittleEndian.AppendUint64(buf, gen)
+	return buf
+}
+
+// decodeConfigPayload splits a config-sync payload into its config text and
+// generation. A payload without the trailing configGenMagic is a legacy
+// sender's raw config text and yields gen=0.
+func decodeConfigPayload(payload []byte) (configText string, gen uint64) {
+	if len(payload) >= 16 && bytes.Equal(payload[len(payload)-16:len(payload)-8], configGenMagic[:]) {
+		gen = binary.LittleEndian.Uint64(payload[len(payload)-8:])
+		return string(payload[:len(payload)-16]), gen
+	}
+	return string(payload), 0
 }
 
 // --- #2239 HA DHCP-server lease sync wire codec ---------------------------


### PR DESCRIPTION
## Problem

Config sync applied the received config via a racing `go
OnConfigReceived(...)` goroutine per message (the `syncMsgConfig`
handler in `pkg/cluster/sync_conn.go`) with **no sequence number** on
the config-sync wire. A rapid commit pair (C1 then C2) spawned two
goroutines that could race: if the C1-apply ran **after** the C2-apply,
the standby ended on the OLDER C1 while the primary was on C2 → the
nodes diverged with **no alarm**, and on failover the standby served the
stale C1. Unlike the #2170 session-install path, config sync had no
ordering guard. (fable-161 F-156, re-verified STILL-LIVE on current
origin/master.)

## Fix

Add a monotonic config generation to the config-sync wire and serialize
the apply — mirroring the #2170 session-install gen-guard discipline.

- **Wire** (`sync_protocol.go`): the payload carries a trailing 16-byte
  framing `[config text][configGenMagic (8)][gen u64 LE (8)]`
  (`encodeConfigPayload` / `decodeConfigPayload`). The magic
  (`\x00\xffxpfCG\x00`) is non-printable so it cannot collide with Junos
  config text; a payload without it is a legacy sender's raw text and
  decodes with `gen=0` (applied unconditionally, preserving today's
  behavior). `QueueConfig` stamps a strictly-monotonic gen from
  `configGenCounter`, seeded from `CLOCK_MONOTONIC` nanos.

- **Ordering + serialize** (`sync_conn.go`): the handler no longer spawns
  a racing goroutine. It enqueues `{gen, text}` onto a bounded
  single-consumer queue (`configApplyCh`) drained by `configApplyLoop`
  (started in `Start`). The `receiveLoop` is single-threaded per
  connection, so this preserves receive order; the non-blocking enqueue
  never stalls session sync / heartbeats behind a slow apply.
  `admitConfigGen` applies a config only if its gen is strictly newer
  than `lastAppliedConfigGen` (or `gen=0` legacy); an out-of-order older
  config is dropped with an alarm and counted in `ConfigsStaleIgnored`.
  The standby always converges to the newest config.

- `resetRecvGen` (fired on `BulkStart`) also zeroes
  `lastAppliedConfigGen` so a **rebooted primary** — whose monotonic
  counter restarts lower — is accepted, not refused as stale (#2198 F2
  reasoning applied to config). The reconnect re-push always sends the
  peer's current config, so the newest content still wins.

**No `SessionSyncWireVersion` bump** — the framing is additive and
self-detecting via the magic; that gate governs whether SESSIONS sync at
all across a mixed-base pair, and bumping it would break session sync for
the whole ISSU window (the #2239 lesson). The one asymmetric direction (a
new sender's framed payload reaching a legacy receiver in the brief ISSU
window) fails **safe**: the old node's Junos parser rejects the trailing
bytes and it retains its current config.

## Tests (`pkg/cluster/sync_config_gen_test.go`)

- Wire round-trip + legacy/short/empty decode.
- `admitConfigGen` monotonic ordering, legacy-unconditional `gen=0`, and
  the `resetRecvGen` high-water reset (rebooted-peer acceptance).
- **RED-on-revert** `TestConfigSyncOrderedApplyDropsReorderedOlder`:
  delivers C2 (newer) before C1 (older) through the real
  `configApplyLoop` → standby ends on C2, drops the stale C1,
  `ConfigsStaleIgnored=1`. Neutralizing `admitConfigGen` to always-accept
  makes the standby end on the older C1 (`applied=[C2 C1]`) → test fails.
- In-order-applies-both and single-push regression companions.

`go test -race ./pkg/cluster/...` and `go test ./pkg/daemon/...` green;
`go build ./...`, `go vet ./pkg/cluster/...`, gofmt clean.

**test-failover WARRANTED** (HA config convergence) — batch-validate on
the loss userspace cluster with the force-node0-primary gate.

Closes #3931

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oARShYtiJJ2H4UB4nXGqi
