### PR TITLE
Source session-count stats from the live userspace table (#3929)

### DIFF
--- a/_Log.md
+++ b/_Log.md
@@ -1,3 +1,46 @@
+## 2026-07-03 — #3929: session-count stats (SessionCount + xpf_sessions_active/established) permanently 0 on the userspace dataplane
+
+- **Timestamp**: 2026-07-03
+  - **Action**: Fixed fable-161 F-051 (MEDIUM, observability). `SessionCount`
+    (gRPC `GetStatus`, REST `/status`) and the Prometheus
+    `xpf_sessions_active`/`xpf_sessions_established` gauges were sourced from
+    `gc.Stats().TotalEntries`/`EstablishedSessions`. On the userspace dataplane
+    (the only live forwarding path since #1476) the BPF GC sweep is skipped
+    (#333), so `gc.Stats()` session counts are permanently 0 — active-session
+    metrics/dashboards/alerts read a constant 0 regardless of real load, and a
+    session-leak/exhaustion condition is invisible. Fix: re-source all three
+    outputs from the LIVE dataplane session table (the same mirrored conntrack
+    maps `show security flow session` reads). `collectSessionGauges`
+    (`pkg/api/metrics_sessions.go`) now derives `active` (forward entries,
+    `IsReverse==0`) and `established` (forward entries with
+    `State==SessStateEstablished`) inside the SAME `IterateSessions`/
+    `IterateSessionsV6` scan that already backs the type breakdown — one scan,
+    no new periodic scan (the #333 GC-skip optimization stands), and all session
+    gauges share the one fail-loud `xpf_sessions_breakdown_scrape_ok` gate
+    (#2469 extended to active/established). `GetStatus`
+    (`pkg/grpcapi/server_show_status.go`) and `/status`
+    (`pkg/api/health.go`) read `dp.SessionCount()` (forward-only live total)
+    guarded by `dp != nil && IsLoaded()`. `SessionCount()` added to the
+    `apiRuntimeDataPlane` interface (pkg/api) and its daemon mirror
+    `apiDataPlane` (`pkg/daemon/runtime_probes.go`). The Rust mirror writes
+    `state=ESTABLISHED` for all live rows (`publish_conntrack.rs`), so on a real
+    node established≈active today; the Go derivation is correct and general and
+    was unit-tested with a mock snapshot carrying a DISTINCT established subset.
+    RED-on-revert (verified by temporarily reverting each site): Prometheus
+    snapshot with 4 forward (3 established, +1 reverse ignored) → active=4,
+    established=3, ipv4=3/ipv6=1/snat=1/dnat=1 (revert → 0/0); REST `/status`
+    `session_count`=4 (revert → 0); gRPC `GetStatus` SessionCount=7 for
+    v4=5+v6=2 (revert → 0). `go test ./pkg/api/... ./pkg/grpcapi/...
+    ./pkg/conntrack/... ./pkg/dataplane/... ./pkg/daemon/...` green;
+    `go build ./...`, gofmt, vet clean. Cluster smoke (metric non-zero under
+    iperf) WARRANTED but not required for merge — pure read-path stats change,
+    no forwarding/HA/session-sync code touched.
+  - **File(s)**: pkg/api/metrics_sessions.go, pkg/api/api.go, pkg/api/health.go,
+    pkg/grpcapi/server_show_status.go, pkg/daemon/runtime_probes.go,
+    pkg/api/README.md, pkg/api/metrics_sessions_userspace_3929_test.go,
+    pkg/api/metrics_descriptor_coverage_test.go,
+    pkg/grpcapi/server_show_status_3929_test.go
+
 ## 2026-07-03 — #3924: userspace local-address sync pruned VRRP VIP keys on a transient netlink AddrList failure → VIP/SSH/BGP/IKE blackhole
 
 - **Timestamp**: 2026-07-03

--- a/pkg/api/README.md
+++ b/pkg/api/README.md
@@ -251,13 +251,28 @@ under the daemon's errgroup. Nothing else imports this package.
   on that error instead of an HTTP 200 with a partial/zero body. The
   Prometheus session-breakdown collector emits
   `xpf_sessions_breakdown_scrape_ok` (1 = full scan, 0 = truncated) and
-  OMITS the `xpf_sessions_{ipv4,ipv6,snat,dnat}` gauges when the scan
-  failed, so an alert fires rather than a graph silently dropping to
-  zero. The gRPC `GetSessions` (legacy + cursor) and `GetSessionSummary`
-  return `codes.Internal` on the same error. The contract is pinned by
-  `sessions_iterator_error_test.go` in this package and in `pkg/grpcapi`
-  / `pkg/cli` (CLI top-talkers fails the command; NAT summaries print a
-  stderr warning).
+  OMITS the `xpf_sessions_{active,established,ipv4,ipv6,snat,dnat}` gauges
+  when the scan failed, so an alert fires rather than a graph silently
+  dropping to zero. The gRPC `GetSessions` (legacy + cursor) and
+  `GetSessionSummary` return `codes.Internal` on the same error. The
+  contract is pinned by `sessions_iterator_error_test.go` in this package
+  and in `pkg/grpcapi` / `pkg/cli` (CLI top-talkers fails the command; NAT
+  summaries print a stderr warning).
+- Session-count metrics come from the LIVE dataplane session table, not
+  the BPF GC sweep stats (#3929). `collectSessionGauges`
+  (`metrics_sessions.go`) derives `xpf_sessions_active` (forward entries)
+  and `xpf_sessions_established` (forward entries in the ESTABLISHED
+  state) from the SAME `IterateSessions`/`IterateSessionsV6` scan that
+  backs the type breakdown, so all session gauges share one scan (no new
+  periodic scan; the #333 GC-skip optimization stands) and one
+  fail-loud `scrape_ok` gate. The REST `/status` and gRPC `GetStatus`
+  `SessionCount` read `dp.SessionCount()` (forward-only live total).
+  Before #3929 all three read `gc.Stats().TotalEntries` /
+  `EstablishedSessions`, which are permanently 0 on the userspace
+  dataplane (the only live forwarding path) because the BPF GC sweep is
+  skipped (#333) — so active-session metrics/dashboards read a constant 0
+  regardless of real load. `xpf_gc_sweep_duration_seconds` still reflects
+  the (skipped, 0) BPF sweep and is orthogonal.
 - Dataplane counter read failures get a uniform observability-integrity
   treatment (#3345 global; #3408 per-zone / per-policy / screen-flood /
   filter): a failed counter read is no longer swallowed to `0`, because a

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,6 +24,11 @@ type apiRuntimeDataPlane interface {
 	// direction's volume.
 	GetSessionV4(dataplane.SessionKey) (dataplane.SessionValue, error)
 	GetSessionV6(dataplane.SessionKeyV6) (dataplane.SessionValueV6, error)
+	// SessionCount returns the live forward-only session count (v4, v6) read
+	// from the dataplane session table — the same source `show security flow
+	// session` uses. The /status handler reports it as SessionCount (#3929):
+	// GC sweep stats are permanently 0 on the userspace dataplane (#333).
+	SessionCount() (v4, v6 int)
 	ClearAllSessions() (int, int, error)
 
 	ReadGlobalCounter(uint32) (uint64, error)

--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -80,9 +80,14 @@ func (s *Server) statusHandler(w http.ResponseWriter, _ *http.Request) {
 	if cfg := s.store.ActiveConfig(); cfg != nil {
 		resp.ZoneCount = len(cfg.Security.Zones)
 	}
-	if s.gc != nil {
-		stats := s.gc.Stats()
-		resp.SessionCount = stats.TotalEntries
+	// #3929: report the live session count from the dataplane session table,
+	// NOT the BPF GC sweep stats. On the userspace dataplane (the only live
+	// forwarding path) the BPF GC sweep is skipped (#333), so
+	// gc.Stats().TotalEntries is permanently 0 — this reported 0 sessions on
+	// every real deployment.
+	if s.dp != nil && s.dp.IsLoaded() {
+		v4, v6 := s.dp.SessionCount()
+		resp.SessionCount = v4 + v6
 	}
 	writeOK(w, resp)
 }

--- a/pkg/api/metrics_descriptor_coverage_test.go
+++ b/pkg/api/metrics_descriptor_coverage_test.go
@@ -56,6 +56,20 @@ type descriptorCoverageDP struct {
 
 func (d *descriptorCoverageDP) IsLoaded() bool { return true }
 
+// #3929: collectSessionGauges now derives xpf_sessions_active/established/
+// breakdown from the session table iteration, omitting them on iterator error
+// (the #2469 fail-loud contract). dataplane.New() answers IterateSessions with
+// a map-missing error, which would drop the session-gauge family out of
+// coverage — override both iterators to succeed (enumerate nothing) so the
+// xpf_sessions_active sentinel stays exercised.
+func (d *descriptorCoverageDP) IterateSessions(func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	return nil
+}
+
+func (d *descriptorCoverageDP) IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	return nil
+}
+
 func (d *descriptorCoverageDP) Status() (dpuserspace.ProcessStatus, error) {
 	return d.status, nil
 }

--- a/pkg/api/metrics_sessions.go
+++ b/pkg/api/metrics_sessions.go
@@ -7,46 +7,57 @@ import (
 )
 
 func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiRuntimeDataPlane) {
-	if c.srv.gc == nil {
-		return
+	// xpf_gc_sweep_duration_seconds reflects the last BPF GC sweep timing.
+	// On the userspace dataplane (the only live forwarding path) the BPF GC
+	// sweep is skipped (#333), so this is 0 — expected, and orthogonal to the
+	// session counts derived below.
+	if c.srv.gc != nil {
+		ch <- prometheus.MustNewConstMetric(c.gcSweepDuration, prometheus.GaugeValue,
+			c.srv.gc.Stats().LastSweepDuration.Seconds())
 	}
-	stats := c.srv.gc.Stats()
-	ch <- prometheus.MustNewConstMetric(c.sessionsActive, prometheus.GaugeValue,
-		float64(stats.TotalEntries))
-	ch <- prometheus.MustNewConstMetric(c.sessionsEstablished, prometheus.GaugeValue,
-		float64(stats.EstablishedSessions))
-	ch <- prometheus.MustNewConstMetric(c.gcSweepDuration, prometheus.GaugeValue,
-		stats.LastSweepDuration.Seconds())
 
-	// Session breakdowns by type. A backend iterator error (e.g. a
-	// helper restart mid-scrape) truncates the scan and would otherwise
-	// publish low/zero gauges as a healthy result, so Prometheus reads a
-	// wrong-but-confident picture (#2469). Instead, track the iteration
-	// outcome, EXPOSE it as xpf_sessions_breakdown_scrape_ok, and OMIT
-	// the breakdown gauges on failure so an alert on staleness/scrape_ok
-	// fires rather than a graph silently dropping to zero.
-	var ipv4, ipv6, snat, dnat int
+	// #3929: derive the active/established/breakdown session gauges from the
+	// LIVE dataplane session table — the same source `show security flow
+	// session` reads. Previously xpf_sessions_active/xpf_sessions_established
+	// were sourced from GC sweep stats (gc.Stats().TotalEntries /
+	// EstablishedSessions), which are permanently 0 on the userspace dataplane
+	// because the BPF GC sweep is skipped (#333). Counting inside the single
+	// iteration that already backs the type breakdown keeps the scrape cost
+	// unchanged (no new periodic scan; the #333 optimization stands).
+	//
+	// active   = forward session entries (IsReverse == 0) — the live count.
+	// established = forward entries whose State is ESTABLISHED (a distinct
+	//              session state). Half-open / opening sessions are counted in
+	//              active but not established.
+	//
+	// A backend iterator error (e.g. a helper restart mid-scrape) truncates the
+	// scan; publishing the partial counts would report a wrong-but-confident
+	// picture (#2469), so on error we EXPOSE xpf_sessions_breakdown_scrape_ok=0
+	// and OMIT every session gauge, letting an alert on scrape_ok fire rather
+	// than a graph silently dropping toward zero.
+	var active, established, ipv4, ipv6, snat, dnat int
+	countForward := func(state uint8, flags uint8, ipCounter *int) {
+		active++
+		*ipCounter++
+		if state == dataplane.SessStateEstablished {
+			established++
+		}
+		if flags&dataplane.SessFlagSNAT != 0 {
+			snat++
+		}
+		if flags&dataplane.SessFlagDNAT != 0 {
+			dnat++
+		}
+	}
 	errV4 := dp.IterateSessions(func(_ dataplane.SessionKey, val dataplane.SessionValue) bool {
 		if val.IsReverse == 0 {
-			ipv4++
-			if val.Flags&dataplane.SessFlagSNAT != 0 {
-				snat++
-			}
-			if val.Flags&dataplane.SessFlagDNAT != 0 {
-				dnat++
-			}
+			countForward(val.State, val.Flags, &ipv4)
 		}
 		return true
 	})
 	errV6 := dp.IterateSessionsV6(func(_ dataplane.SessionKeyV6, val dataplane.SessionValueV6) bool {
 		if val.IsReverse == 0 {
-			ipv6++
-			if val.Flags&dataplane.SessFlagSNAT != 0 {
-				snat++
-			}
-			if val.Flags&dataplane.SessFlagDNAT != 0 {
-				dnat++
-			}
+			countForward(val.State, val.Flags, &ipv6)
 		}
 		return true
 	})
@@ -55,6 +66,8 @@ func (c *xpfCollector) collectSessionGauges(ch chan<- prometheus.Metric, dp apiR
 		return
 	}
 	ch <- prometheus.MustNewConstMetric(c.sessionScrapeOK, prometheus.GaugeValue, 1)
+	ch <- prometheus.MustNewConstMetric(c.sessionsActive, prometheus.GaugeValue, float64(active))
+	ch <- prometheus.MustNewConstMetric(c.sessionsEstablished, prometheus.GaugeValue, float64(established))
 	ch <- prometheus.MustNewConstMetric(c.sessionsIPv4, prometheus.GaugeValue, float64(ipv4))
 	ch <- prometheus.MustNewConstMetric(c.sessionsIPv6, prometheus.GaugeValue, float64(ipv6))
 	ch <- prometheus.MustNewConstMetric(c.sessionsSNAT, prometheus.GaugeValue, float64(snat))

--- a/pkg/api/metrics_sessions_userspace_3929_test.go
+++ b/pkg/api/metrics_sessions_userspace_3929_test.go
@@ -1,0 +1,182 @@
+package api
+
+import (
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/psaab/xpf/pkg/dataplane"
+)
+
+// userspaceSessionsDP models the userspace dataplane's live session table.
+// It embeds *dataplane.Manager for the methods the tests do not exercise and
+// yields a fixed set of forward + reverse session entries from the iterators
+// (the same surface `show security flow session` reads). SessionCount returns
+// the forward-only totals, matching the real Manager semantics.
+type userspaceSessionsDP struct {
+	*dataplane.Manager
+	v4 []dataplane.SessionValue
+	v6 []dataplane.SessionValueV6
+}
+
+func (d *userspaceSessionsDP) IsLoaded() bool { return true }
+
+func (d *userspaceSessionsDP) IterateSessions(fn func(dataplane.SessionKey, dataplane.SessionValue) bool) error {
+	for _, v := range d.v4 {
+		if !fn(dataplane.SessionKey{}, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *userspaceSessionsDP) IterateSessionsV6(fn func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error {
+	for _, v := range d.v6 {
+		if !fn(dataplane.SessionKeyV6{}, v) {
+			break
+		}
+	}
+	return nil
+}
+
+func (d *userspaceSessionsDP) SessionCount() (int, int) {
+	v4, v6 := 0, 0
+	for _, v := range d.v4 {
+		if v.IsReverse == 0 {
+			v4++
+		}
+	}
+	for _, v := range d.v6 {
+		if v.IsReverse == 0 {
+			v6++
+		}
+	}
+	return v4, v6
+}
+
+// newUserspaceSessionsDP builds a snapshot with:
+//   - 3 forward v4 sessions (2 ESTABLISHED, 1 OPENING), one SNAT-flagged
+//   - 1 reverse v4 entry (must NOT be counted)
+//   - 1 forward v6 session (ESTABLISHED, DNAT-flagged)
+//
+// => active (forward total) = 4, established = 3, ipv4 = 3, ipv6 = 1,
+// snat = 1, dnat = 1.
+func newUserspaceSessionsDP() *userspaceSessionsDP {
+	const opening = 1 // any non-ESTABLISHED session state
+	return &userspaceSessionsDP{
+		Manager: dataplane.New(),
+		v4: []dataplane.SessionValue{
+			{IsReverse: 0, State: dataplane.SessStateEstablished, Flags: dataplane.SessFlagSNAT},
+			{IsReverse: 0, State: dataplane.SessStateEstablished},
+			{IsReverse: 0, State: opening},
+			{IsReverse: 1, State: dataplane.SessStateEstablished}, // reverse — ignored
+		},
+		v6: []dataplane.SessionValueV6{
+			{IsReverse: 0, State: dataplane.SessStateEstablished, Flags: dataplane.SessFlagDNAT},
+		},
+	}
+}
+
+func gatherGaugesByName(t *testing.T, c *xpfCollector, dp apiRuntimeDataPlane) map[string]float64 {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 32)
+	c.collectSessionGauges(ch, dp)
+	close(ch)
+	out := map[string]float64{}
+	names := []string{
+		"xpf_sessions_active", "xpf_sessions_established",
+		"xpf_sessions_ipv4", "xpf_sessions_ipv6",
+		"xpf_sessions_snat", "xpf_sessions_dnat",
+		"xpf_sessions_breakdown_scrape_ok",
+	}
+	for m := range ch {
+		desc := m.Desc().String()
+		for _, n := range names {
+			// Desc().String() renders as `fqName: "<name>"`; anchor the match
+			// so xpf_sessions_ipv4 does not also match a superset name.
+			if strings.Contains(desc, `"`+n+`"`) {
+				out[n] = gaugeValue(t, m)
+			}
+		}
+	}
+	return out
+}
+
+// TestPrometheusSessionGaugesFromUserspaceTable is the #3929 RED-on-revert
+// guard for the Prometheus session gauges. It derives active/established/
+// breakdown from a userspace session snapshot (the live dataplane session
+// table). Reverting collectSessionGauges to source xpf_sessions_active /
+// xpf_sessions_established from gc.Stats() (permanently 0 on the userspace
+// dataplane, which skips the BPF GC sweep per #333) drops active from 4 -> 0
+// and established from 3 -> 0, flipping both assertions red.
+func TestPrometheusSessionGaugesFromUserspaceTable(t *testing.T) {
+	c := newSessionGaugeCollector() // gc present, never swept => Stats() all-zero
+	dp := newUserspaceSessionsDP()
+
+	g := gatherGaugesByName(t, c, dp)
+
+	checks := []struct {
+		name string
+		want float64
+	}{
+		{"xpf_sessions_breakdown_scrape_ok", 1},
+		{"xpf_sessions_active", 4},
+		{"xpf_sessions_established", 3},
+		{"xpf_sessions_ipv4", 3},
+		{"xpf_sessions_ipv6", 1},
+		{"xpf_sessions_snat", 1},
+		{"xpf_sessions_dnat", 1},
+	}
+	for _, chk := range checks {
+		got, ok := g[chk.name]
+		if !ok {
+			t.Fatalf("%s not emitted; want %v", chk.name, chk.want)
+		}
+		if got != chk.want {
+			t.Errorf("%s = %v, want %v", chk.name, got, chk.want)
+		}
+	}
+}
+
+// TestPrometheusSessionGaugesEmptyTable proves the count tracks the snapshot:
+// zero sessions => zero active/established (and scrape_ok=1, not omitted).
+func TestPrometheusSessionGaugesEmptyTable(t *testing.T) {
+	c := newSessionGaugeCollector()
+	dp := &userspaceSessionsDP{Manager: dataplane.New()}
+
+	g := gatherGaugesByName(t, c, dp)
+
+	if g["xpf_sessions_breakdown_scrape_ok"] != 1 {
+		t.Fatalf("scrape_ok = %v, want 1 on empty healthy scan", g["xpf_sessions_breakdown_scrape_ok"])
+	}
+	if g["xpf_sessions_active"] != 0 || g["xpf_sessions_established"] != 0 {
+		t.Errorf("active/established = %v/%v, want 0/0 on empty table",
+			g["xpf_sessions_active"], g["xpf_sessions_established"])
+	}
+}
+
+// TestRESTStatusSessionCountFromUserspaceTable is the #3929 RED-on-revert
+// guard for the REST /status SessionCount. It must reflect the live dataplane
+// session count (forward-only = 4), NOT gc.Stats().TotalEntries (0 on the
+// userspace dataplane). Reverting health.go to `resp.SessionCount =
+// stats.TotalEntries` reports 0 and flips this assertion red.
+func TestRESTStatusSessionCountFromUserspaceTable(t *testing.T) {
+	s := &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    newUserspaceSessionsDP(),
+	}
+
+	rr := httptest.NewRecorder()
+	s.statusHandler(rr, httptest.NewRequest("GET", "/api/v1/status", nil))
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	// StatusResponse serializes SessionCount as "session_count":4.
+	if !strings.Contains(body, `"session_count":4`) {
+		t.Fatalf(`REST /status body missing "session_count":4 (live userspace count); got: %s`, body)
+	}
+}

--- a/pkg/daemon/runtime_probes.go
+++ b/pkg/daemon/runtime_probes.go
@@ -60,6 +60,9 @@ type apiDataPlane interface {
 	IterateSessionsV6(func(dataplane.SessionKeyV6, dataplane.SessionValueV6) bool) error
 	GetSessionV4(dataplane.SessionKey) (dataplane.SessionValue, error)
 	GetSessionV6(dataplane.SessionKeyV6) (dataplane.SessionValueV6, error)
+	// SessionCount feeds the REST /status SessionCount from the live session
+	// table (#3929); mirrors the pkg/api apiRuntimeDataPlane addition.
+	SessionCount() (v4, v6 int)
 	ClearAllSessions() (int, int, error)
 
 	ReadGlobalCounter(uint32) (uint64, error)

--- a/pkg/grpcapi/server_show_status.go
+++ b/pkg/grpcapi/server_show_status.go
@@ -25,9 +25,15 @@ func (s *Server) GetStatus(_ context.Context, _ *pb.GetStatusRequest) (*pb.GetSt
 	if cfg := s.store.ActiveConfig(); cfg != nil {
 		resp.ZoneCount = int32(len(cfg.Security.Zones))
 	}
-	if s.gc != nil {
-		stats := s.gc.Stats()
-		resp.SessionCount = int32(stats.TotalEntries)
+	// #3929: read the live session count from the dataplane session table (the
+	// same source `show security flow session` uses), NOT the BPF GC sweep
+	// stats. On the userspace dataplane (the only live forwarding path) the BPF
+	// GC sweep is skipped (#333), so gc.Stats().TotalEntries is permanently 0 —
+	// this reported 0 sessions on every real deployment. SessionCount counts
+	// forward entries only, so it is the live session total.
+	if s.dp != nil && s.dp.IsLoaded() {
+		v4, v6 := s.dp.SessionCount()
+		resp.SessionCount = int32(v4 + v6)
 	}
 	if s.cluster != nil {
 		rg0 := s.cluster.GroupState(0)

--- a/pkg/grpcapi/server_show_status_3929_test.go
+++ b/pkg/grpcapi/server_show_status_3929_test.go
@@ -1,0 +1,64 @@
+package grpcapi
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/psaab/xpf/pkg/conntrack"
+	"github.com/psaab/xpf/pkg/dataplane"
+	pb "github.com/psaab/xpf/pkg/grpcapi/xpfv1"
+)
+
+// statusSessionsDP is a grpcRuntime whose SessionCount reports the live
+// (forward-only) dataplane session totals. It embeds *dataplane.Manager for
+// the methods GetStatus does not touch and overrides IsLoaded/SessionCount.
+type statusSessionsDP struct {
+	*dataplane.Manager
+	v4 int
+	v6 int
+}
+
+func (d *statusSessionsDP) IsLoaded() bool           { return true }
+func (d *statusSessionsDP) SessionCount() (int, int) { return d.v4, d.v6 }
+
+// TestGetStatusSessionCountFromUserspaceTable is the #3929 RED-on-revert guard
+// for the gRPC GetStatus SessionCount. It must report the live dataplane
+// session count (forward-only v4+v6 = 7), NOT gc.Stats().TotalEntries, which is
+// permanently 0 on the userspace dataplane (the BPF GC sweep is skipped, #333).
+// Reverting server_show_status.go to `resp.SessionCount = stats.TotalEntries`
+// reports 0 and flips this assertion red.
+func TestGetStatusSessionCountFromUserspaceTable(t *testing.T) {
+	s := &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		dp:    &statusSessionsDP{Manager: dataplane.New(), v4: 5, v6: 2},
+		// A GC that has never swept — models the userspace runtime, where
+		// gc.Stats() is all-zero. The reverted code would read 0 from here.
+		gc: conntrack.NewGC(nil, time.Minute),
+	}
+
+	resp, err := s.GetStatus(context.Background(), &pb.GetStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if resp.SessionCount != 7 {
+		t.Fatalf("SessionCount = %d, want 7 (live userspace forward count v4=5 + v6=2)", resp.SessionCount)
+	}
+}
+
+// TestGetStatusSessionCountNoDataplane guards the nil/unloaded dataplane path:
+// no dp => SessionCount 0, no panic.
+func TestGetStatusSessionCountNoDataplane(t *testing.T) {
+	s := &Server{
+		store: newConfigStore(t, filepath.Join(t.TempDir(), "xpf.conf")),
+		gc:    conntrack.NewGC(nil, time.Minute),
+	}
+	resp, err := s.GetStatus(context.Background(), &pb.GetStatusRequest{})
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+	if resp.SessionCount != 0 {
+		t.Fatalf("SessionCount = %d, want 0 with no dataplane", resp.SessionCount)
+	}
+}


### PR DESCRIPTION
## Problem

`SessionCount` (gRPC `GetStatus`, REST `/status`) and the Prometheus
`xpf_sessions_active` / `xpf_sessions_established` gauges were sourced from
`gc.Stats().TotalEntries` / `EstablishedSessions`. On the Rust AF_XDP userspace
dataplane — the only live forwarding path since #1476 — the BPF GC sweep is
skipped (#333, `GC.SkipSweep`), so those GC stats never update and stay at their
zero value. Every real deployment therefore reported **0** active sessions on
`show security flow session summary` / `/status` and published constant-0
`xpf_sessions_active` / `xpf_sessions_established`, blinding capacity dashboards
and session-leak/exhaustion alerts regardless of the actual live session count.

## Fix

Re-source all three outputs from the LIVE dataplane session table — the same
mirrored conntrack maps `show security flow session` reads:

- **`collectSessionGauges`** (`pkg/api/metrics_sessions.go`) derives `active`
  (forward entries, `IsReverse==0`) and `established` (forward entries with
  `State==SessStateEstablished`) inside the **same** `IterateSessions` /
  `IterateSessionsV6` scan that already backs the type breakdown — one scan, no
  new periodic scan (the #333 GC-skip optimization stands). All session gauges
  now share the one fail-loud `xpf_sessions_breakdown_scrape_ok` gate (#2469
  extended to active/established): a truncated scan omits every session gauge
  rather than publishing a wrong-but-confident zero. `xpf_gc_sweep_duration_seconds`
  still reflects the (skipped, 0) BPF sweep and is orthogonal.
- **`GetStatus`** (`pkg/grpcapi/server_show_status.go`) and the **REST `/status`**
  handler (`pkg/api/health.go`) read `dp.SessionCount()` (forward-only live total)
  guarded by `dp != nil && IsLoaded()`.

`SessionCount()` is added to the pkg/api `apiRuntimeDataPlane` interface and its
daemon mirror `apiDataPlane` (`pkg/daemon/runtime_probes.go`); `grpcRuntime`
already declared it.

The Rust mirror publishes `state=ESTABLISHED` for all live rows
(`publish_conntrack.rs`), so on a real node established currently tracks active;
the Go derivation is correct and general and is unit-tested with a mock snapshot
carrying a **distinct** established subset.

## RED-on-revert (verified by temporarily restoring each `gc.Stats()` source)

- Prometheus snapshot: 4 forward (3 established, +1 reverse ignored) →
  active=4, established=3, ipv4=3/ipv6=1/snat=1/dnat=1 — revert drops active/
  established to 0/0. Empty table → 0.
- REST `/status` `session_count`=4 — revert → 0.
- gRPC `GetStatus` SessionCount=7 for v4=5+v6=2 — revert → 0.

## Validation

`go test ./pkg/api/... ./pkg/grpcapi/... ./pkg/conntrack/... ./pkg/daemon/...`
green; `go build ./...`, gofmt, vet clean. Pure read-path stats change — no
forwarding / HA / session-sync code touched. A cluster smoke asserting the
metric is non-zero under iperf is warranted but not required for merge.

Closes #3929

🤖 Generated with [Claude Code](https://claude.com/claude-code)